### PR TITLE
[Spec Decode] Add attention_backend override option for draft model

### DIFF
--- a/tests/v1/spec_decode/test_draft_attention_backend.py
+++ b/tests/v1/spec_decode/test_draft_attention_backend.py
@@ -64,6 +64,7 @@ def _make_vllm_config(
 # SpeculativeConfig.attention_backend field validation
 # ---------------------------------------------------------------------------
 
+
 class TestAttentionBackendValidator:
     """Test the field_validator on SpeculativeConfig.attention_backend."""
 
@@ -87,7 +88,8 @@ class TestAttentionBackendValidator:
 
     def test_enum_passthrough(self):
         result = SpeculativeConfig._validate_attention_backend(
-            AttentionBackendEnum.FLASH_ATTN)
+            AttentionBackendEnum.FLASH_ATTN
+        )
         assert result == AttentionBackendEnum.FLASH_ATTN
 
     def test_invalid_backend_raises(self):
@@ -99,6 +101,7 @@ class TestAttentionBackendValidator:
 # SpeculativeConfig.draft_attention_backend property
 # ---------------------------------------------------------------------------
 
+
 class TestDraftAttentionBackendProperty:
     """Test that the draft_attention_backend property resolves correctly."""
 
@@ -106,7 +109,8 @@ class TestDraftAttentionBackendProperty:
         self, attention_backend: str | None = None
     ) -> SpeculativeConfig:
         model_config = ModelConfig(
-            model=model_dir, runner="generate", max_model_len=100)
+            model=model_dir, runner="generate", max_model_len=100
+        )
         return SpeculativeConfig(
             target_model_config=model_config,
             target_parallel_config=ParallelConfig(),
@@ -133,6 +137,7 @@ class TestDraftAttentionBackendProperty:
 # _create_draft_vllm_config attention backend override
 # ---------------------------------------------------------------------------
 
+
 class TestCreateDraftVllmConfig:
     """Test that _create_draft_vllm_config respects attention_backend."""
 
@@ -148,8 +153,7 @@ class TestCreateDraftVllmConfig:
             target_attention_backend=target_backend,
             draft_attention_backend=draft_backend_setting,
         )
-        proposer = EagleProposer(
-            vllm_config=vllm_config, device=DEVICE_TYPE)
+        proposer = EagleProposer(vllm_config=vllm_config, device=DEVICE_TYPE)
         draft_config = proposer._create_draft_vllm_config()
         return draft_config.attention_config.backend
 
@@ -193,9 +197,9 @@ class TestCreateDraftVllmConfig:
             target_attention_backend=AttentionBackendEnum.FLASHINFER_MLA,
             draft_attention_backend="auto",
         )
-        proposer = EagleProposer(
-            vllm_config=vllm_config, device=DEVICE_TYPE)
+        proposer = EagleProposer(vllm_config=vllm_config, device=DEVICE_TYPE)
         proposer._create_draft_vllm_config()
         # Target config should still have the original backend.
-        assert (vllm_config.attention_config.backend
-                == AttentionBackendEnum.FLASHINFER_MLA)
+        assert (
+            vllm_config.attention_config.backend == AttentionBackendEnum.FLASHINFER_MLA
+        )

--- a/tests/v1/spec_decode/test_draft_attention_backend.py
+++ b/tests/v1/spec_decode/test_draft_attention_backend.py
@@ -1,0 +1,201 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for speculative_config.attention_backend and its effect on
+draft model attention backend selection."""
+
+import pytest
+
+from vllm.config import (
+    AttentionConfig,
+    CacheConfig,
+    DeviceConfig,
+    ModelConfig,
+    ParallelConfig,
+    SchedulerConfig,
+    SpeculativeConfig,
+    VllmConfig,
+)
+from vllm.config.load import LoadConfig
+from vllm.platforms import current_platform
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+model_dir = "meta-llama/Llama-3.1-8B-Instruct"
+eagle_dir = "yuhuili/EAGLE-LLaMA3.1-Instruct-8B"
+
+DEVICE_TYPE = current_platform.device_type
+
+
+def _make_vllm_config(
+    target_attention_backend: AttentionBackendEnum | None = None,
+    draft_attention_backend: str | AttentionBackendEnum | None = None,
+) -> VllmConfig:
+    """Create a VllmConfig with the given target and draft attention backends."""
+    model_config = ModelConfig(
+        model=model_dir,
+        runner="generate",
+        max_model_len=100,
+    )
+
+    speculative_config = SpeculativeConfig(
+        target_model_config=model_config,
+        target_parallel_config=ParallelConfig(),
+        model=eagle_dir,
+        method="eagle",
+        num_speculative_tokens=3,
+        attention_backend=draft_attention_backend,
+    )
+
+    return VllmConfig(
+        model_config=model_config,
+        cache_config=CacheConfig(block_size=16),
+        speculative_config=speculative_config,
+        device_config=DeviceConfig(device=DEVICE_TYPE),
+        parallel_config=ParallelConfig(),
+        load_config=LoadConfig(),
+        scheduler_config=SchedulerConfig(
+            max_model_len=model_config.max_model_len,
+            is_encoder_decoder=model_config.is_encoder_decoder,
+        ),
+        attention_config=AttentionConfig(backend=target_attention_backend),
+    )
+
+
+# ---------------------------------------------------------------------------
+# SpeculativeConfig.attention_backend field validation
+# ---------------------------------------------------------------------------
+
+class TestAttentionBackendValidator:
+    """Test the field_validator on SpeculativeConfig.attention_backend."""
+
+    def test_none_returns_none(self):
+        assert SpeculativeConfig._validate_attention_backend(None) is None
+
+    def test_auto_returns_sentinel(self):
+        assert SpeculativeConfig._validate_attention_backend("auto") == "auto"
+
+    def test_auto_case_insensitive(self):
+        assert SpeculativeConfig._validate_attention_backend("AUTO") == "auto"
+        assert SpeculativeConfig._validate_attention_backend("Auto") == "auto"
+
+    def test_specific_backend_string(self):
+        result = SpeculativeConfig._validate_attention_backend("FLASH_ATTN")
+        assert result == AttentionBackendEnum.FLASH_ATTN
+
+    def test_specific_backend_case_insensitive(self):
+        result = SpeculativeConfig._validate_attention_backend("flash_attn")
+        assert result == AttentionBackendEnum.FLASH_ATTN
+
+    def test_enum_passthrough(self):
+        result = SpeculativeConfig._validate_attention_backend(
+            AttentionBackendEnum.FLASH_ATTN)
+        assert result == AttentionBackendEnum.FLASH_ATTN
+
+    def test_invalid_backend_raises(self):
+        with pytest.raises(ValueError):
+            SpeculativeConfig._validate_attention_backend("NOT_A_BACKEND")
+
+
+# ---------------------------------------------------------------------------
+# SpeculativeConfig.draft_attention_backend property
+# ---------------------------------------------------------------------------
+
+class TestDraftAttentionBackendProperty:
+    """Test that the draft_attention_backend property resolves correctly."""
+
+    def _make_spec_config(
+        self, attention_backend: str | None = None
+    ) -> SpeculativeConfig:
+        model_config = ModelConfig(
+            model=model_dir, runner="generate", max_model_len=100)
+        return SpeculativeConfig(
+            target_model_config=model_config,
+            target_parallel_config=ParallelConfig(),
+            model=eagle_dir,
+            method="eagle",
+            num_speculative_tokens=3,
+            attention_backend=attention_backend,
+        )
+
+    def test_none_resolves_to_none(self):
+        cfg = self._make_spec_config(attention_backend=None)
+        assert cfg.draft_attention_backend is None
+
+    def test_auto_resolves_to_none(self):
+        cfg = self._make_spec_config(attention_backend="auto")
+        assert cfg.draft_attention_backend is None
+
+    def test_explicit_backend_passes_through(self):
+        cfg = self._make_spec_config(attention_backend="FLASH_ATTN")
+        assert cfg.draft_attention_backend == AttentionBackendEnum.FLASH_ATTN
+
+
+# ---------------------------------------------------------------------------
+# _create_draft_vllm_config attention backend override
+# ---------------------------------------------------------------------------
+
+class TestCreateDraftVllmConfig:
+    """Test that _create_draft_vllm_config respects attention_backend."""
+
+    def _get_draft_attention_backend(
+        self,
+        target_backend: AttentionBackendEnum | None,
+        draft_backend_setting: str | AttentionBackendEnum | None,
+    ) -> AttentionBackendEnum | None:
+        """Helper: create proposer and return the draft config's backend."""
+        from vllm.v1.spec_decode.eagle import EagleProposer
+
+        vllm_config = _make_vllm_config(
+            target_attention_backend=target_backend,
+            draft_attention_backend=draft_backend_setting,
+        )
+        proposer = EagleProposer(
+            vllm_config=vllm_config, device=DEVICE_TYPE)
+        draft_config = proposer._create_draft_vllm_config()
+        return draft_config.attention_config.backend
+
+    def test_default_inherits_target_backend(self):
+        """Default (None) should inherit the target model's backend."""
+        backend = self._get_draft_attention_backend(
+            target_backend=AttentionBackendEnum.FLASH_ATTN,
+            draft_backend_setting=None,
+        )
+        assert backend == AttentionBackendEnum.FLASH_ATTN
+
+    def test_default_inherits_none_target(self):
+        """Default (None) with no target backend should stay None."""
+        backend = self._get_draft_attention_backend(
+            target_backend=None,
+            draft_backend_setting=None,
+        )
+        assert backend is None
+
+    def test_auto_overrides_to_none(self):
+        """'auto' should reset backend to None (auto-select)."""
+        backend = self._get_draft_attention_backend(
+            target_backend=AttentionBackendEnum.FLASHINFER_MLA,
+            draft_backend_setting="auto",
+        )
+        assert backend is None
+
+    def test_specific_backend_override(self):
+        """Explicit backend should override the target's backend."""
+        backend = self._get_draft_attention_backend(
+            target_backend=AttentionBackendEnum.FLASHINFER_MLA,
+            draft_backend_setting="FLASH_ATTN",
+        )
+        assert backend == AttentionBackendEnum.FLASH_ATTN
+
+    def test_target_config_unchanged(self):
+        """The original vllm_config should not be mutated."""
+        from vllm.v1.spec_decode.eagle import EagleProposer
+
+        vllm_config = _make_vllm_config(
+            target_attention_backend=AttentionBackendEnum.FLASHINFER_MLA,
+            draft_attention_backend="auto",
+        )
+        proposer = EagleProposer(
+            vllm_config=vllm_config, device=DEVICE_TYPE)
+        proposer._create_draft_vllm_config()
+        # Target config should still have the original backend.
+        assert (vllm_config.attention_config.backend
+                == AttentionBackendEnum.FLASHINFER_MLA)

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -5,7 +5,7 @@ import ast
 import copy
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
-from pydantic import Field, SkipValidation, model_validator
+from pydantic import Field, SkipValidation, field_validator, model_validator
 from typing_extensions import Self
 
 from vllm.config import LoadConfig
@@ -17,6 +17,7 @@ from vllm.logger import init_logger
 from vllm.transformers_utils.config import get_hf_text_config
 from vllm.utils.hashing import safe_hash
 from vllm.utils.import_utils import LazyLoader, has_arctic_inference
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 if TYPE_CHECKING:
     from transformers import PretrainedConfig
@@ -98,6 +99,15 @@ class SpeculativeConfig:
     """Quantization method that was used to quantize the draft model weights.
     If `None`, we assume the model weights are not quantized. Note that it only
     takes effect when using the draft model-based speculative method."""
+    attention_backend: AttentionBackendEnum | str | None = None
+    """Attention backend to use for the draft model. When ``None`` (the
+    default), the draft model inherits the target model's
+    ``--attention_config.backend`` setting. Set to ``"auto"`` to let vLLM
+    auto-select a compatible backend for the draft model, which is useful
+    when the draft model has a different attention architecture from the
+    target (e.g. a standard-attention Eagle3 drafter paired with an MLA
+    target model). Can also be set to a specific backend name (e.g.
+    ``"FLASH_ATTN"``)."""
     moe_backend: MoEBackend | None = None
     """MoE backend to use for the draft model. When `None`, the draft model
     inherits the target model's `--moe-backend` setting. Useful when the
@@ -784,6 +794,27 @@ class SpeculativeConfig:
         )
 
         return draft_parallel_config
+
+    @field_validator("attention_backend", mode="before")
+    @classmethod
+    def _validate_attention_backend(cls, value: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, str):
+            # "auto" is kept as a string sentinel meaning auto-select.
+            if value.lower() == "auto":
+                return "auto"
+            return AttentionBackendEnum[value.upper()]
+        return value
+
+    @property
+    def draft_attention_backend(self) -> AttentionBackendEnum | None:
+        """Resolve ``attention_backend`` to a value consumable by
+        ``AttentionConfig.backend``.  ``"auto"`` and ``None`` both map to
+        ``None`` (auto-select); an explicit enum value passes through."""
+        if self.attention_backend is None or self.attention_backend == "auto":
+            return None
+        return self.attention_backend  # type: ignore[return-value]
 
     @model_validator(mode="after")
     def _verify_args(self) -> Self:

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1259,15 +1259,29 @@ class SpecDecodeBaseProposer:
         Subclasses may override to apply additional config changes.
         """
         spec_cfg = self.speculative_config
+        draft_config = self.vllm_config
+
+        # Override attention backend for the draft model when explicitly set.
+        # Default (None) inherits from the target; "auto" auto-selects.
+        if spec_cfg.attention_backend is not None:
+            draft_config = replace(
+                draft_config,
+                attention_config=replace(
+                    draft_config.attention_config,
+                    backend=spec_cfg.draft_attention_backend,
+                ),
+            )
+
         if spec_cfg.moe_backend is not None:
-            return replace(
-                self.vllm_config,
+            draft_config = replace(
+                draft_config,
                 kernel_config=replace(
-                    self.vllm_config.kernel_config,
+                    draft_config.kernel_config,
                     moe_backend=spec_cfg.moe_backend,
                 ),
             )
-        return self.vllm_config
+
+        return draft_config
 
     def _get_model(self) -> nn.Module:
         """

--- a/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
@@ -14,8 +14,8 @@ def load_eagle_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mod
     assert speculative_config is not None
     draft_model_config = speculative_config.draft_model_config
 
-    # Override attention backend for the draft model when explicitly set.
-    # Default (None) inherits from the target; "auto" auto-selects.
+    # Override attention and MoE backends for the draft model when explicitly
+    # set. Default (None) inherits from the target; "auto" auto-selects.
     draft_vllm_config = vllm_config
     if speculative_config.attention_backend is not None:
         draft_vllm_config = replace(
@@ -23,6 +23,15 @@ def load_eagle_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Mod
             attention_config=replace(
                 draft_vllm_config.attention_config,
                 backend=speculative_config.draft_attention_backend,
+            ),
+        )
+
+    if speculative_config.moe_backend is not None:
+        draft_vllm_config = replace(
+            draft_vllm_config,
+            kernel_config=replace(
+                draft_vllm_config.kernel_config,
+                moe_backend=speculative_config.moe_backend,
             ),
         )
 

--- a/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/utils.py
@@ -8,13 +8,27 @@ from vllm.model_executor.model_loader import get_model
 
 def load_eagle_model(target_model: nn.Module, vllm_config: VllmConfig) -> nn.Module:
     from vllm.compilation.backends import set_model_tag
+    from vllm.config.utils import replace
 
     speculative_config = vllm_config.speculative_config
     assert speculative_config is not None
     draft_model_config = speculative_config.draft_model_config
+
+    # Override attention backend for the draft model when explicitly set.
+    # Default (None) inherits from the target; "auto" auto-selects.
+    draft_vllm_config = vllm_config
+    if speculative_config.attention_backend is not None:
+        draft_vllm_config = replace(
+            draft_vllm_config,
+            attention_config=replace(
+                draft_vllm_config.attention_config,
+                backend=speculative_config.draft_attention_backend,
+            ),
+        )
+
     with set_model_tag("eagle_head"):
         eagle_model = get_model(
-            vllm_config=vllm_config, model_config=draft_model_config
+            vllm_config=draft_vllm_config, model_config=draft_model_config
         )
 
     # Share target embeddings when the draft checkpoint does not include


### PR DESCRIPTION
## Summary

Eagle3 uses standard Llama attention (non-MLA) for its draft model. When paired with an MLA target model, the inherited attention backend (e.g. `FLASHINFER_MLA`) is incompatible and causes crashes.

- Adds `speculative_config.attention_backend` to allow overriding the draft model's attention backend independently from the target
- `None` (default): inherits target backend (existing behavior)
- `"auto"`: draft model auto-selects a compatible backend
- Specific name (e.g. `"FLASH_ATTN"`): uses that backend directly
- Override applied in both `_create_draft_vllm_config()` (proposer) and `load_eagle_model()` (worker)

**Example usage:**
```bash
vllm serve deepseek-ai/DeepSeek-V3 \
  --speculative-model eagle3-draft \
  --speculative-config '{"attention_backend": "auto"}'
```

## Test plan
- [x] Unit tests for `attention_backend` field validation (`TestAttentionBackendValidator`)
- [x] Unit tests for `draft_attention_backend` property resolution (`TestDraftAttentionBackendProperty`)
- [x] Unit tests for `_create_draft_vllm_config` attention override (`TestCreateDraftVllmConfig`)
- [x] Manual: Eagle3 + MLA target model with `attention_backend: auto`

### Before
```
vllm serve nvidia/Kimi-K2.5-NVFP4 \
    --attention_config.backend FLASHINFER_MLA \
    --speculative-config '{"model": "lightseekorg/kimi-k2.5-eagle3", "method": "eagle3", "num_speculative_tokens": 3}' 

(Worker_TP0 pid=1765929) INFO 04-13 23:19:00 [gpu_model_runner.py:4774] Loading drafter model...
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879] WorkerProc failed to start.
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879] Traceback (most recent call last):
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/v1/executor/multiproc_executor.py", line 846, in worker_main
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     worker = WorkerProc(*args, **kwargs)
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     return func(*args, **kwargs)
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/v1/executor/multiproc_executor.py", line 628, in __init__
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     self.worker.load_model()
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/v1/worker/gpu_worker.py", line 323, in load_model
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     self.model_runner.load_model(load_dummy_weights=load_dummy_weights)
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     return func(*args, **kwargs)
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/v1/worker/gpu_model_runner.py", line 4775, in load_model
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     self.drafter.load_model(self.model)
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/v1/spec_decode/eagle.py", line 1310, in load_model
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     self.model = self._get_model()
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]                  ^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/v1/spec_decode/eagle.py", line 1295, in _get_model
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     model = get_model(
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]             ^^^^^^^^^^
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/model_executor/model_loader/__init__.py", line 138, in get_model
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     return loader.load_model(
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]            ^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     return func(*args, **kwargs)
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/model_executor/model_loader/base_loader.py", line 55, in load_model
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     model = initialize_model(
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]             ^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     return func(*args, **kwargs)
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/model_executor/model_loader/utils.py", line 57, in initialize_model
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     model = model_class(vllm_config=vllm_config, prefix=prefix)
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/model_executor/models/llama_eagle3.py", line 289, in __init__
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     self.model = LlamaModel(
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]                  ^^^^^^^^^^^
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/compilation/decorators.py", line 379, in __init__
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     old_init(self, *args, **kwargs)
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/model_executor/models/llama_eagle3.py", line 165, in __init__
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     LlamaDecoderLayer(
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/model_executor/models/llama_eagle3.py", line 46, in __init__
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     super().__init__(vllm_config, prefix=prefix, config=config)
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/model_executor/models/llama.py", line 288, in __init__
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     self.self_attn = attn_layer_type(
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]                      ^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/model_executor/models/llama.py", line 211, in __init__
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     self.attn = attn_cls(
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]                 ^^^^^^^^^
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/model_executor/layers/attention/attention.py", line 297, in __init__
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     self.attn_backend = get_attn_backend(
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]                         ^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/v1/attention/selector.py", line 100, in get_attn_backend
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     return _cached_get_attn_backend(
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]            ^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/v1/attention/selector.py", line 115, in _cached_get_attn_backend
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     attention_cls = current_platform.get_attn_backend_cls(
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]   File "/home/zixi/repos/vllm-main/vllm/vllm/platforms/cuda.py", line 301, in get_attn_backend_cls
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879]     raise ValueError(
(Worker_TP0 pid=1765929) ERROR 04-13 23:19:00 [multiproc_executor.py:879] ValueError: Selected backend AttentionBackendEnum.FLASHINFER_MLA is not valid for this configuration. Reason: ['head_size not supported', 'non-MLA not supported']
NCCL version 2.28.9+cuda13.0
```
### After
```
vllm serve nvidia/Kimi-K2.5-NVFP4 \
    --attention_config.backend FLASHINFER_MLA \
    --speculative-config '{"model": "lightseekorg/kimi-k2.5-eagle3", "method": "eagle3", "num_speculative_tokens": 3, "attention_backend": "FLASHINFER"}' 

(Worker_TP0 pid=1784710) INFO 04-13 23:54:17 [gpu_model_runner.py:4774] Loading drafter model...
(Worker_TP0 pid=1784710) INFO 04-13 23:54:17 [kernel.py:199] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'])
(Worker_TP0 pid=1784710) INFO 04-13 23:54:17 [cuda.py:306] Using AttentionBackendEnum.FLASHINFER backend.
(Worker_TP0 pid=1784710) INFO 04-13 23:54:17 [selector.py:132] Using HND KV cache layout for FLASHINFER backend.
(Worker_TP1 pid=1784711) INFO 04-13 23:54:17 [kernel.py:199] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'])
(Worker_TP1 pid=1784711) INFO 04-13 23:54:17 [cuda.py:306] Using AttentionBackendEnum.FLASHINFER backend.
(Worker_TP1 pid=1784711) INFO 04-13 23:54:17 [selector.py:132] Using HND KV cache layout for FLASHINFER backend.
(Worker_TP0 pid=1784710) INFO 04-13 23:54:17 [weight_utils.py:904] Filesystem type for checkpoints: LUSTRE. Checkpoint size: 5.92 GiB. Available RAM: 765.21 GiB.
(Worker_TP0 pid=1784710) INFO 04-13 23:54:17 [weight_utils.py:874] Prefetching checkpoint files into page cache started (in background)
(Worker_TP0 pid=1784710) 
Loading safetensors checkpoint shards:   0% Completed | 0/2 [00:00<?, ?it/s]
(Worker_TP0 pid=1784710) 
Loading safetensors checkpoint shards: 100% Completed | 2/2 [00:00<00:00, 89.64it/s]

```
## Duplicate-work check
No existing open PRs address draft model attention backend override.

## AI disclosure
AI assistance (Claude) was used. All changes reviewed by human submitter.

Signed-off-by: zixi-qi <zixi@inferact.ai>