### PR TITLE
[ROCm] Fix broken logger.warning and typos in quick_all_reduce

### DIFF
--- a/vllm/distributed/device_communicators/quick_all_reduce.py
+++ b/vllm/distributed/device_communicators/quick_all_reduce.py
@@ -162,16 +162,16 @@ class QuickAllReduce:
 
     def init_quick_all_reduce(self):
         # On RocM, bfloat16 kernels are slower than fp16
-        # due to slower match operations
+        # due to slower math operations
         # If environment variable is set to 1, we convert input to fp16
         self.use_fp16_kernels = envs.VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16
         regime_str = envs.VLLM_ROCM_QUICK_REDUCE_QUANTIZATION
         if regime_str not in QuickReduceRegime.__members__:
             logger.warning(
-                "Custom quick allreduce:",
-                f"Invalid quantization level: {regime_str}. "
-                "Supported levels: "
-                f"{list(QuickReduceRegime.__members__.keys())}",
+                "Custom quick allreduce: Invalid quantization level: %s. "
+                "Supported levels: %s",
+                regime_str,
+                list(QuickReduceRegime.__members__.keys()),
             )
             return
 
@@ -193,7 +193,7 @@ class QuickAllReduce:
             if dtype not in [torch.float16, torch.bfloat16]:
                 logger.debug(
                     "Custom quick allreduce disabled: only supports "
-                    "float16 and float16, but get %s.",
+                    "float16 and bfloat16, but get %s.",
                     dtype,
                 )
                 return


### PR DESCRIPTION
Three bugs in `init_quick_all_reduce`:

**1. `logger.warning` TypeError (runtime crash)**

When an invalid `VLLM_ROCM_QUICK_REDUCE_QUANTIZATION` value is set, the warning call passes the message as two separate positional args instead of using format specifiers:

```python
# Before (crashes with TypeError):
logger.warning("Custom quick allreduce:", f"Invalid quantization level: {regime_str}...")

# After:
logger.warning("Custom quick allreduce: Invalid quantization level: %s...", regime_str, ...)
```

**2. Comment typo:** "match operations" → "math operations"

**3. Log message typo:** "float16 and float16" → "float16 and bfloat16"

No duplicate PRs found. AI assistance was used for code search; all changes reviewed by human submitter.