### PR TITLE
[ROCm] Remove false ENCODER_DECODER support from unified attention

### DIFF
--- a/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
+++ b/vllm/v1/attention/backends/rocm_aiter_unified_attn.py
@@ -87,12 +87,14 @@ class RocmAiterUnifiedAttentionBackend(RocmAttentionBackend):
 
     @classmethod
     def supports_attn_type(cls, attn_type: str) -> bool:
-        """RocmAiterUnifiedAttention supports all attention types."""
+        """ENCODER_DECODER is not supported because forward() hardcodes
+        causal=True, which is incorrect for cross-attention layers where
+        decoder queries should attend to all encoder positions.
+        """
         return attn_type in (
             AttentionType.DECODER,
             AttentionType.ENCODER,
             AttentionType.ENCODER_ONLY,
-            AttentionType.ENCODER_DECODER,
         )
 
 


### PR DESCRIPTION
`RocmAiterUnifiedAttentionBackend.supports_attn_type()` claims to support `ENCODER_DECODER`, but `forward()` hardcodes `causal=True` (line 238). For cross-attention layers, decoder queries should attend to all encoder positions bidirectionally — using causal masking would mask out valid encoder tokens.

The base class `RocmAttentionBackend` already explicitly excludes `ENCODER_DECODER` with a detailed explanation (lines 216-221). The unified attention subclass added it back without implementing proper causality handling.

This removes `ENCODER_DECODER` from the supported types, consistent with the base class and with `AiterFlashAttentionBackend` (which also correctly excludes it).

No duplicate PRs found. AI assistance was used for code search; all changes reviewed by human submitter.