### PR TITLE
[Bugfix] Add 501 response to STT OpenAPI schema

### DIFF
--- a/vllm/entrypoints/openai/speech_to_text/api_router.py
+++ b/vllm/entrypoints/openai/speech_to_text/api_router.py
@@ -56,6 +56,7 @@ def translation(request: Request) -> OpenAIServingTranslation:
         HTTPStatus.BAD_REQUEST.value: {"model": ErrorResponse},
         HTTPStatus.UNPROCESSABLE_ENTITY.value: {"model": ErrorResponse},
         HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
+        HTTPStatus.NOT_IMPLEMENTED.value: {"model": ErrorResponse},
     },
 )
 @with_cancellation
@@ -89,6 +90,7 @@ async def create_transcriptions(
         HTTPStatus.BAD_REQUEST.value: {"model": ErrorResponse},
         HTTPStatus.UNPROCESSABLE_ENTITY.value: {"model": ErrorResponse},
         HTTPStatus.INTERNAL_SERVER_ERROR.value: {"model": ErrorResponse},
+        HTTPStatus.NOT_IMPLEMENTED.value: {"model": ErrorResponse},
     },
 )
 @with_cancellation


### PR DESCRIPTION
## Summary

Fixes #38004.

The Speech-to-Text (STT) endpoint returns `501 Not Implemented` when the feature is not available, but this response code was not documented in the OpenAPI schema. This caused API clients and documentation consumers to be unaware of the possible 501 response.

**Changes:**
- Added `501` response to the OpenAPI schema decorators for the STT endpoint

This is a schema-only change — no functional behavior is modified.

## Duplicate PR Check

Searched open PRs for issue `38004` — no existing PRs found addressing this issue.

## Test Plan

- [x] `pre-commit run --all-files` passes (ruff, mypy, etc.)
- [x] No functional behavior change — schema documentation only

## Notes

AI assistance (Claude) was used in preparing this fix. All changed lines were reviewed by the submitter.