### PR TITLE
[Feature] Add `auto` option to `--max-num-batched-tokens`

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -525,6 +525,36 @@ def test_human_readable_model_len():
             parser.parse_args(["--max-model-len", invalid])
 
 
+def test_human_readable_batched_tokens():
+    """Test that --max-num-batched-tokens accepts 'auto' and human-readable
+    integers, mirroring --max-model-len behavior."""
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser(exit_on_error=False))
+
+    # Default is None
+    args = parser.parse_args([])
+    assert args.max_num_batched_tokens is None
+
+    # Plain integer
+    args = parser.parse_args(["--max-num-batched-tokens", "2048"])
+    assert args.max_num_batched_tokens == 2048
+
+    # Human-readable suffixes
+    args = parser.parse_args(["--max-num-batched-tokens", "8k"])
+    assert args.max_num_batched_tokens == 8_000
+    args = parser.parse_args(["--max-num-batched-tokens", "8K"])
+    assert args.max_num_batched_tokens == 8 * 1024
+
+    # Special value -1 for auto
+    args = parser.parse_args(["--max-num-batched-tokens", "-1"])
+    assert args.max_num_batched_tokens == -1
+
+    # 'auto' is an alias for -1
+    args = parser.parse_args(["--max-num-batched-tokens", "auto"])
+    assert args.max_num_batched_tokens == -1
+    args = parser.parse_args(["--max-num-batched-tokens", "AUTO"])
+    assert args.max_num_batched_tokens == -1
+
+
 def test_ir_op_priority():
     from vllm.config.kernel import IrOpPriorityConfig, KernelConfig
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -318,10 +318,10 @@ def _compute_kwargs(cls: ConfigType) -> dict[str, dict[str, Any]]:
         elif contains_type(type_hints, set):
             kwargs[name].update(collection_to_kwargs(type_hints, set))
         elif contains_type(type_hints, int):
-            if name == "max_model_len":
+            if name == "max_model_len" or name == "max_num_batched_tokens":
                 kwargs[name]["type"] = human_readable_int_or_auto
                 kwargs[name]["help"] += f"\n\n{human_readable_int_or_auto.__doc__}"
-            elif name in ("max_num_batched_tokens", "kv_cache_memory_bytes"):
+            elif name == "kv_cache_memory_bytes":
                 kwargs[name]["type"] = human_readable_int
                 kwargs[name]["help"] += f"\n\n{human_readable_int.__doc__}"
             else:
@@ -2230,6 +2230,10 @@ class EngineArgs:
             default_max_num_batched_tokens,
             default_max_num_seqs,
         ) = self.get_batch_defaults(world_size)
+
+        # Treat -1 (auto) the same as None (unset) for auto-detection.
+        if self.max_num_batched_tokens is not None and self.max_num_batched_tokens < 0:
+            self.max_num_batched_tokens = None
 
         orig_max_num_batched_tokens = self.max_num_batched_tokens
         orig_max_num_seqs = self.max_num_seqs


### PR DESCRIPTION
## Purpose
Allow users to pass `--max-num-batched-tokens auto` (or `-1`) to trigger the existing auto-detection logic, mirroring the behavior of `--max-model-len auto`.

Closes #38507

## Test Plan

```bash
pytest tests/engine/test_arg_utils.py -v
```

## Test Result

<details>
<summary>Test Result </summary>

```bash
================================================================================================================================================== test session starts ===================================================================================================================================================
platform darwin -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0 -- /Users/injaeryou/Personal/vllm/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/injaeryou/Personal/vllm
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 54 items

tests/engine/test_arg_utils.py::test_parse_type[int-42-42] PASSED                                                                                                                                                                                                                                                  [  1%]
tests/engine/test_arg_utils.py::test_parse_type[float-3.14-3.14] PASSED                                                                                                                                                                                                                                            [  3%]
tests/engine/test_arg_utils.py::test_parse_type[str-Hello World!-Hello World!] PASSED                                                                                                                                                                                                                              [  5%]
tests/engine/test_arg_utils.py::test_parse_type[loads-{"foo":1,"bar":2}-expected3] PASSED                                                                                                                                                                                                                          [  7%]
tests/engine/test_arg_utils.py::test_optional_type PASSED                                                                                                                                                                                                                                                          [  9%]
tests/engine/test_arg_utils.py::test_is_type[int-int-True] PASSED                                                                                                                                                                                                                                                  [ 11%]
tests/engine/test_arg_utils.py::test_is_type[int-float-False] PASSED                                                                                                                                                                                                                                               [ 12%]
tests/engine/test_arg_utils.py::test_is_type[list-list-True] PASSED                                                                                                                                                                                                                                                [ 14%]
tests/engine/test_arg_utils.py::test_is_type[list-tuple-False] PASSED                                                                                                                                                                                                                                              [ 16%]
tests/engine/test_arg_utils.py::test_is_type[Literal-Literal-True] PASSED                                                                                                                                                                                                                                          [ 18%]
tests/engine/test_arg_utils.py::test_contains_type[type_hints0-int-True] PASSED                                                                                                                                                                                                                                    [ 20%]
tests/engine/test_arg_utils.py::test_contains_type[type_hints1-int-True] PASSED                                                                                                                                                                                                                                    [ 22%]
tests/engine/test_arg_utils.py::test_contains_type[type_hints2-int-True] PASSED                                                                                                                                                                                                                                    [ 24%]
tests/engine/test_arg_utils.py::test_contains_type[type_hints3-int-True] PASSED                                                                                                                                                                                                                                    [ 25%]
tests/engine/test_arg_utils.py::test_contains_type[type_hints4-float-False] PASSED                                                                                                                                                                                                                                 [ 27%]
tests/engine/test_arg_utils.py::test_contains_type[type_hints5-float-False] PASSED                                                                                                                                                                                                                                 [ 29%]
tests/engine/test_arg_utils.py::test_contains_type[type_hints6-Literal-True] PASSED                                                                                                                                                                                                                                [ 31%]
tests/engine/test_arg_utils.py::test_get_type[type_hints0-int-int] PASSED                                                                                                                                                                                                                                          [ 33%]
tests/engine/test_arg_utils.py::test_get_type[type_hints1-str-None] PASSED                                                                                                                                                                                                                                         [ 35%]
tests/engine/test_arg_utils.py::test_get_type[type_hints2-Literal-Literal] PASSED                                                                                                                                                                                                                                  [ 37%]
tests/engine/test_arg_utils.py::test_literal_to_kwargs[type_hints0-expected0] PASSED                                                                                                                                                                                                                               [ 38%]
tests/engine/test_arg_utils.py::test_literal_to_kwargs[type_hints1-expected1] PASSED                                                                                                                                                                                                                               [ 40%]
tests/engine/test_arg_utils.py::test_literal_to_kwargs[type_hints2-Exception] PASSED                                                                                                                                                                                                                               [ 42%]
tests/engine/test_arg_utils.py::test_is_not_builtin[int-False] PASSED                                                                                                                                                                                                                                              [ 44%]
tests/engine/test_arg_utils.py::test_is_not_builtin[DummyConfig-True] PASSED                                                                                                                                                                                                                                       [ 46%]
tests/engine/test_arg_utils.py::test_get_type_hints[Annotated] PASSED                                                                                                                                                                                                                                              [ 48%]
tests/engine/test_arg_utils.py::test_get_type_hints[or_None] PASSED                                                                                                                                                                                                                                                [ 50%]
tests/engine/test_arg_utils.py::test_get_type_hints[Annotated_or_None] PASSED                                                                                                                                                                                                                                      [ 51%]
tests/engine/test_arg_utils.py::test_get_type_hints[or_None_Annotated] PASSED                                                                                                                                                                                                                                      [ 53%]
tests/engine/test_arg_utils.py::test_get_kwargs PASSED                                                                                                                                                                                                                                                             [ 55%]
tests/engine/test_arg_utils.py::test_media_io_kwargs_parser[None-expected0] PASSED                                                                                                                                                                                                                                 [ 57%]
tests/engine/test_arg_utils.py::test_media_io_kwargs_parser[{"video": {"num_frames": 123} }-expected1] PASSED                                                                                                                                                                                                      [ 59%]
tests/engine/test_arg_utils.py::test_media_io_kwargs_parser[{"video": {"num_frames": 123, "fps": 1.0, "foo": "bar"}, "image": {"foo": "bar"} }-expected2] PASSED                                                                                                                                                   [ 61%]
tests/engine/test_arg_utils.py::test_optimization_level[args0-1] PASSED                                                                                                                                                                                                                                            [ 62%]
tests/engine/test_arg_utils.py::test_optimization_level[args1-2] PASSED                                                                                                                                                                                                                                            [ 64%]
tests/engine/test_arg_utils.py::test_optimization_level[args2-3] PASSED                                                                                                                                                                                                                                            [ 66%]
tests/engine/test_arg_utils.py::test_optimization_level[args3-0] PASSED                                                                                                                                                                                                                                            [ 68%]
tests/engine/test_arg_utils.py::test_optimization_level[args4-1] PASSED                                                                                                                                                                                                                                            [ 70%]
tests/engine/test_arg_utils.py::test_optimization_level[args5-2] PASSED                                                                                                                                                                                                                                            [ 72%]
tests/engine/test_arg_utils.py::test_optimization_level[args6-3] PASSED                                                                                                                                                                                                                                            [ 74%]
tests/engine/test_arg_utils.py::test_mode_parser[args0-0] PASSED                                                                                                                                                                                                                                                   [ 75%]
tests/engine/test_arg_utils.py::test_mode_parser[args1-1] PASSED                                                                                                                                                                                                                                                   [ 77%]
tests/engine/test_arg_utils.py::test_mode_parser[args2-2] PASSED                                                                                                                                                                                                                                                   [ 79%]
tests/engine/test_arg_utils.py::test_mode_parser[args3-3] PASSED                                                                                                                                                                                                                                                   [ 81%]
tests/engine/test_arg_utils.py::test_compilation_config PASSED                                                                                                                                                                                                                                                     [ 83%]
tests/engine/test_arg_utils.py::test_attention_config PASSED                                                                                                                                                                                                                                                       [ 85%]
tests/engine/test_arg_utils.py::test_prefix_cache_default PASSED                                                                                                                                                                                                                                                   [ 87%]
tests/engine/test_arg_utils.py::test_composite_arg_parser[None-None-mm-processor-kwargs] PASSED                                                                                                                                                                                                                    [ 88%]
tests/engine/test_arg_utils.py::test_composite_arg_parser[{}-expected1-mm-processor-kwargs] PASSED                                                                                                                                                                                                                 [ 90%]
tests/engine/test_arg_utils.py::test_composite_arg_parser[{"num_crops": 4}-expected2-mm-processor-kwargs] PASSED                                                                                                                                                                                                   [ 92%]
tests/engine/test_arg_utils.py::test_composite_arg_parser[{"foo": {"bar": "baz"}}-expected3-mm-processor-kwargs] PASSED                                                                                                                                                                                            [ 94%]
tests/engine/test_arg_utils.py::test_human_readable_model_len PASSED                                                                                                                                                                                                                                               [ 96%]
tests/engine/test_arg_utils.py::test_human_readable_batched_tokens PASSED                                                                                                                                                                                                                                          [ 98%]
tests/engine/test_arg_utils.py::test_ir_op_priority PASSED                                                                                                                                                                                                                                                         [100%]

==================================================================================================================================================== warnings summary ====================================================================================================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

tests/engine/test_arg_utils.py: 14 warnings
  /Users/injaeryou/Personal/vllm/.venv/lib/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================================================================ 54 passed, 16 warnings in 10.75s ============================================================================================================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```
</details>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>