### PR TITLE
fix: add ernie4_5_moe_vl to _AUTO_CONFIG_KWARGS_OVERRIDES (has_no_defaults_at_init)

### DIFF
--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -130,6 +130,7 @@ _AUTO_CONFIG_KWARGS_OVERRIDES: dict[str, dict[str, Any]] = {
     "internvl_chat": {"has_no_defaults_at_init": True},
     "Llama_Nemotron_Nano_VL": {"attn_implementation": "eager"},
     "NVLM_D": {"has_no_defaults_at_init": True},
+    "ernie4_5_moe_vl": {"has_no_defaults_at_init": True},
 }
 
 


### PR DESCRIPTION
## Summary

Fixes initialization of `Ernie4_5_VLMoeForConditionalGeneration` with Transformers v5.

The ERNIE-4.5-VL MoE model uses `trust_remote_code=True` with a custom config class whose `__init__` unconditionally accesses `kwargs["num_hidden_layers"]`. When `to_diff_dict()` tries to compute a diff by instantiating `self.__class__()` with no args, it raises:

```
KeyError: 'num_hidden_layers'
```

This is the same pattern already handled for `internvl_chat` and `NVLM_D`. The fix is a one-line addition to `_AUTO_CONFIG_KWARGS_OVERRIDES`:

```python
"ernie4_5_moe_vl": {"has_no_defaults_at_init": True},
```

Setting `has_no_defaults_at_init=True` causes `to_diff_dict` to skip the default instantiation and return an empty dict instead, which is correct behavior for configs that require args at init.

## Companion PR

A companion fix to `huggingface/transformers` (huggingface/transformers#45275) resolves three additional issues with this model family:
- `model_type` mismatch (`ernie4_5_moe_vl` vs `ernie4_5_vl_moe` registration)
- `rope_theta` validation not firing when consumed by custom `__init__`
- `moe_num_experts` type too narrow (`int` vs `list[int]`)

Both PRs together make `test_can_initialize_large_subset[Ernie4_5_VLMoeForConditionalGeneration]` pass.

## Testing

```python
from transformers import AutoConfig
cfg = AutoConfig.from_pretrained(
    "baidu/ERNIE-4.5-VL-28B-A3B-PT",
    trust_remote_code=True,
    has_no_defaults_at_init=True,  # what this PR enables
)
# Before: KeyError: 'num_hidden_layers'
# After:  SUCCESS: Ernie4_5_VLMoEConfig
```