### PR TITLE
[ROCm] Remove unused TOKEN_NUM from MLA sparse ragged kernel

### DIFF
--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -42,7 +42,6 @@ def fetch_id_to_ragged_kernel(
     out_tensor_ptr,  # [max_num_seq * topk]
     in_tensor_ptr_stride,
     TOPK: tl.constexpr,
-    TOKEN_NUM: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
     seq_id = tl.program_id(0)
@@ -73,7 +72,7 @@ def fetch_id_to_ragged_triton(
         num_block_per_row,
     )
     fetch_id_to_ragged_kernel[grid](
-        in_tensor, cumsum, out_tensor, in_tensor.stride(0), topk, num_tokens, block_size
+        in_tensor, cumsum, out_tensor, in_tensor.stride(0), topk, block_size
     )
 
 


### PR DESCRIPTION
`fetch_id_to_ragged_kernel` declares `TOKEN_NUM: tl.constexpr` and receives `num_tokens` from the wrapper, but it's never used in the kernel body. Token bounds are computed from `cumsum_ptr` loads instead (lines 51-52).

Since it's a `tl.constexpr`, different `num_tokens` values cause Triton to JIT-compile separate kernel specializations for no benefit.

Same pattern as the `IS_FNUZ` fix in #39123.

No duplicate PRs found. AI assistance was used for code search; all changes reviewed by human submitter.