### PR TITLE
[BugFix][Attention] Fix NaN in Triton merge_attn_states when both LSEs are -inf

### DIFF
--- a/tests/kernels/attention/test_merge_attn_states.py
+++ b/tests/kernels/attention/test_merge_attn_states.py
@@ -390,3 +390,72 @@ def test_merge_attn_states(
         len(NUM_BATCH_TOKENS) * len(HEAD_SIZES) * len(NUM_QUERY_HEADS) * len(DTYPES)
     ):
         generate_markdown_table()
+
+
+@pytest.mark.parametrize("num_tokens", [32, 128, 512])
+@pytest.mark.parametrize("num_query_heads", [8, 32])
+@pytest.mark.parametrize("head_size", [64, 128])
+@pytest.mark.parametrize("input_dtype", [torch.float32, torch.bfloat16])
+@torch.inference_mode()
+def test_merge_attn_states_both_lse_neg_inf(
+    num_tokens: int,
+    num_query_heads: int,
+    head_size: int,
+    input_dtype: torch.dtype,
+):
+    """Regression test for NaN when both prefix_lse and suffix_lse are -inf.
+
+    This happens during chunked prefill when a request has zero context
+    tokens — both sides produce no valid attention scores, so both LSEs
+    are -inf.  The kernel must produce finite (zero) output, not NaN.
+    """
+    device = "cuda"
+
+    prefix_output = torch.randn(
+        (num_tokens, num_query_heads, head_size),
+        dtype=input_dtype, device=device,
+    )
+    suffix_output = torch.randn(
+        (num_tokens, num_query_heads, head_size),
+        dtype=input_dtype, device=device,
+    )
+    output = torch.zeros_like(prefix_output)
+
+    prefix_lse = torch.randn(
+        num_query_heads, num_tokens, dtype=torch.float32, device=device,
+    )
+    suffix_lse = torch.randn(
+        num_query_heads, num_tokens, dtype=torch.float32, device=device,
+    )
+
+    # --- Inject edge cases ---
+    # ~25% of (head, token) positions: both LSEs = -inf  (the NaN trigger)
+    both_neg_inf_mask = torch.rand(num_query_heads, num_tokens) < 0.25
+    prefix_lse[both_neg_inf_mask] = float("-inf")
+    suffix_lse[both_neg_inf_mask] = float("-inf")
+
+    # ~10% of remaining positions: both LSEs = +inf  (FA2 empty-sequence style)
+    fa2_mask = (torch.rand(num_query_heads, num_tokens) < 0.10) & ~both_neg_inf_mask
+    prefix_lse[fa2_mask] = float("inf")
+    suffix_lse[fa2_mask] = float("inf")
+
+    merge_attn_states_triton(
+        output, prefix_output, prefix_lse, suffix_output, suffix_lse,
+    )
+
+    # 1) No NaN anywhere in the output.
+    nan_count = torch.isnan(output).sum().item()
+    assert nan_count == 0, (
+        f"Found {nan_count} NaN elements in output"
+    )
+
+    # 2) Positions where both LSEs were -inf must produce zero output
+    #    (no attention scores to merge → zero weight on both sides).
+    #    both_neg_inf_mask is [num_heads, num_tokens], output is
+    #    [num_tokens, num_heads, head_size].
+    both_inf_idx = both_neg_inf_mask.T.unsqueeze(-1).expand_as(output)
+    zero_region = output[both_inf_idx]
+    assert torch.all(zero_region == 0), (
+        f"Expected zero output for both-neg-inf positions, "
+        f"got max abs = {zero_region.abs().max().item()}"
+    )

--- a/vllm/v1/attention/ops/triton_merge_attn_states.py
+++ b/vllm/v1/attention/ops/triton_merge_attn_states.py
@@ -133,12 +133,12 @@ def merge_attn_states_kernel(
     # IEEE 754: -inf - (-inf) = NaN, which then propagates through
     # exp and division.  The CUDA merge_attn_states kernel handles
     # this via an early-return branch on isinf(max_lse).  Here we use
-    # a branchless safe-softmax approach instead: clamping max_lse to
-    # a finite floor turns the subtraction into -inf (not NaN), so
-    # exp() yields exactly 0.  The epsilon in the denominator then
+    # a branchless safe-softmax approach instead: replacing -inf with
+    # a finite floor so the subtraction yields -inf (not NaN), and
+    # exp() gives exactly 0.  The epsilon in the denominator then
     # prevents the resulting 0/0, producing zero output (correct,
     # since there are no attention scores to merge).
-    max_lse = tl.maximum(max_lse, -1e30)
+    max_lse = tl.where(max_lse == float("-inf"), -1e30, max_lse)
 
     p_lse = p_lse - max_lse
     s_lse = s_lse - max_lse

--- a/vllm/v1/attention/ops/triton_merge_attn_states.py
+++ b/vllm/v1/attention/ops/triton_merge_attn_states.py
@@ -132,12 +132,11 @@ def merge_attn_states_kernel(
     # request with zero context length), both LSEs are -inf.
     # IEEE 754: -inf - (-inf) = NaN, which then propagates through
     # exp and division.  The CUDA merge_attn_states kernel handles
-    # this via an early-return branch on isinf(max_lse).  Here we use
-    # a branchless safe-softmax approach instead: replacing -inf with
-    # a finite floor so the subtraction yields -inf (not NaN), and
-    # exp() gives exactly 0.  The epsilon in the denominator then
-    # prevents the resulting 0/0, producing zero output (correct,
-    # since there are no attention scores to merge).
+    # this via an early-return branch on isinf(max_lse).  Here we
+    # replace -inf with a finite floor so the subtraction yields -inf
+    # (not NaN) and exp() gives exactly 0.  The epsilon in the
+    # denominator then prevents the resulting 0/0, producing zero
+    # output (correct, since there are no attention scores to merge).
     max_lse = tl.where(max_lse == float("-inf"), -1e30, max_lse)
 
     p_lse = p_lse - max_lse

--- a/vllm/v1/attention/ops/triton_merge_attn_states.py
+++ b/vllm/v1/attention/ops/triton_merge_attn_states.py
@@ -127,12 +127,25 @@ def merge_attn_states_kernel(
     s_lse = float("-inf") if s_lse == float("inf") else s_lse
 
     max_lse = tl.maximum(p_lse, s_lse)
+
+    # When both prefix and suffix have no tokens (e.g. chunked prefill
+    # request with zero context length), both LSEs are -inf.
+    # IEEE 754: -inf - (-inf) = NaN, which then propagates through
+    # exp and division.  The CUDA merge_attn_states kernel handles
+    # this via an early-return branch on isinf(max_lse).  Here we use
+    # a branchless safe-softmax approach instead: clamping max_lse to
+    # a finite floor turns the subtraction into -inf (not NaN), so
+    # exp() yields exactly 0.  The epsilon in the denominator then
+    # prevents the resulting 0/0, producing zero output (correct,
+    # since there are no attention scores to merge).
+    max_lse = tl.maximum(max_lse, -1e30)
+
     p_lse = p_lse - max_lse
     s_lse = s_lse - max_lse
     # Will reuse precomputed Exp values for scale factor computation.
     p_se = tl.exp(p_lse)
     s_se = tl.exp(s_lse)
-    out_se = p_se + s_se
+    out_se = p_se + s_se + 1e-10
 
     if OUTPUT_LSE:
         out_lse = tl.log(out_se) + max_lse


### PR DESCRIPTION
## Purpose
Fix NaN output in the Triton merge_attn_states kernel when both prefix_lse and suffix_lse are -inf.
When both prefix and suffix have no tokens (e.g. chunked prefill with zero context length), both LSEs are -inf. Per IEEE 754, -inf - (-inf) = NaN, which propagates through exp and division into the final output.
This applies a branchless fix in the Triton kernel:
Clamp max_lse to a finite floor (-1e30) so the subtraction yields -inf instead of NaN, and exp() gives exactly 0.
Add epsilon (1e-10) to the denominator to prevent 0/0.
The CUDA merge_attn_states kernel already handles this via an early-return branch on isinf(max_lse). This brings the Triton kernel to parity using an arithmetic-only approach.

## Test Plan
Add test_merge_attn_states_both_lse_neg_inf regression test that injects ~25% both-LSE-negative-inf positions and ~10% both-LSE-positive-inf (FA2-style) positions, then asserts:
No NaN anywhere in the output.
Both-neg-inf positions produce exactly zero output.
`pytest tests/kernels/attention/test_merge_attn_states.py::test_merge_attn_states_both_lse_neg_inf -v`

## Test Result
Without fix — 24/24 FAILED (NaN counts from 5,440 to 680,960 per test case):
```
FAILED ...[input_dtype0-64-8-32] - AssertionError: Found 6016 NaN elements in output
FAILED ...[input_dtype0-128-32-512] - AssertionError: Found 680960 NaN elements in output
...
======================== 24 failed in 4.58s =========================
```

With fix — 24/24 PASSED:
```
======================== 24 passed in 6.93s =========================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

