### PR TITLE
fix: respect `VLLM_CONFIGURE_LOGGING` in V1 subprocesses

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1038,6 +1038,11 @@ class EngineCoreProc(EngineCore):
     def run_engine_core(*args, dp_rank: int = 0, local_dp_rank: int = 0, **kwargs):
         """Launch EngineCore busy loop in background process."""
 
+        # Re-evaluate logging configuration for this subprocess,
+        # respecting VLLM_CONFIGURE_LOGGING env var.
+        from vllm.logger import _configure_vllm_root_logger
+        _configure_vllm_root_logger()
+
         # Ensure we can serialize transformer config after spawning
         maybe_register_config_serialize_by_value()
 

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -796,6 +796,11 @@ class WorkerProc:
         """Worker initialization and execution loops.
         This runs a background process"""
 
+        # Re-evaluate logging configuration for this subprocess,
+        # respecting VLLM_CONFIGURE_LOGGING env var.
+        from vllm.logger import _configure_vllm_root_logger
+        _configure_vllm_root_logger()
+
         # Signal handler used for graceful termination.
         # SystemExit exception is only raised once to allow this and worker
         # processes to terminate without error


### PR DESCRIPTION
Fixes #18549

## Root Cause

In the V1 architecture, inference runs in dedicated subprocesses (`EngineCoreProc` and `WorkerProc`) that are spawned via `multiprocessing`. The `_configure_vllm_root_logger()` function is called at module import time in `vllm/logger.py`. However, when a new subprocess is spawned, Python re-imports all modules in the child process. Depending on import ordering and how environment variables are propagated, the module-level logger configuration call may execute before the entry-point code has a chance to read and apply settings such as `VLLM_CONFIGURE_LOGGING=0`. The result is that log-handler configuration set by the parent is not respected inside subprocesses.

## Fix

Added an explicit `_configure_vllm_root_logger()` call at the very top of both subprocess entry points:

- `WorkerProc.worker_main()` in `vllm/v1/executor/multiproc_executor.py`
- `EngineCoreProc.run_engine_core()` in `vllm/v1/engine/core.py`

This ensures the logging configuration is re-evaluated from environment variables before any logging occurs in the child process, matching the behaviour of V0 and making `VLLM_CONFIGURE_LOGGING=0` (and related env vars) reliably effective across all processes.

## Test Plan

1. Start a vLLM server with `VLLM_CONFIGURE_LOGGING=0`:
   ```bash
   VLLM_CONFIGURE_LOGGING=0 vllm serve <model>
   ```
2. Confirm that vLLM does not install its custom log handlers in either the engine process or the worker processes — log output should use the default Python logging format (or be suppressed if no handlers are configured by the caller), rather than vLLM's custom formatter.
3. Verify that without the env var set, behaviour is unchanged (vLLM's custom log handlers are active in all processes).

## Notes

- No new public API surface is introduced; this is a pure bug fix.
- The change is limited to the two V1 subprocess entry points and does not affect V0 or single-process mode.
- Checked for duplicate PRs: none found addressing this specific issue.
- AI assistance (Claude) was used to help draft and review this change; all code was reviewed and tested by the submitting author.