### PR TITLE
[CI] Add Qwen3-VL multimodal serving benchmark

### DIFF
--- a/.buildkite/performance-benchmarks/performance-benchmarks-descriptions.md
+++ b/.buildkite/performance-benchmarks/performance-benchmarks-descriptions.md
@@ -33,6 +33,7 @@
 - CPU Models: llama-3.1 8B.
 - Evaluation metrics: throughput, TTFT (time to the first token, with mean, median and p99), ITL (inter-token latency, with mean, median and p99).
 - For CPU, we added random dataset tests to benchmark fixed input/output length with 100 prompts.
+- We also added a multi-modal serving test for Qwen3-VL 8B Instruct on GPU using the `random-mm` dataset with deterministic 1-image synthetic requests.
 
 {serving_tests_markdown_table}
 

--- a/.buildkite/performance-benchmarks/tests/serving-tests.json
+++ b/.buildkite/performance-benchmarks/tests/serving-tests.json
@@ -73,5 +73,25 @@
             "temperature": 0,
             "num_prompts": 200 
         }
+    },
+    {
+        "test_name": "serving_qwen3vl8b_tp1_random_mm",
+        "qps_list": [1, 4, 16, "inf"],
+        "server_parameters": {
+            "model": "Qwen/Qwen3-VL-8B-Instruct",
+            "tensor_parallel_size": 1,
+            "disable_log_stats": "",
+            "load_format": "dummy",
+            "limit_mm_per_prompt.image": 1
+        },
+        "client_parameters": {
+            "model": "Qwen/Qwen3-VL-8B-Instruct",
+            "backend": "openai-chat",
+            "dataset_name": "random-mm",
+            "temperature": 0,
+            "num_prompts": 200,
+            "random_mm_base_items_per_request": 1,
+            "random_mm_num_mm_items_range_ratio": 0
+        }
     }
 ]


### PR DESCRIPTION
## Purpose

Add a Qwen3-VL multimodal serving benchmark to the CI performance benchmark suite.

This uses `openai-chat` with the `random-mm` dataset and deterministic 1-image synthetic requests. It addresses the benchmark coverage part of #16353. Peak memory tracking is not included in this PR.

  ## Test Plan

Verified locally by:
  - validating that `serving-tests.json` parses successfully
  - confirming the new benchmark entry is present
  - checking the generated server and client CLI args
  - attempting a dry-run of the benchmark runner

The dry-run could not proceed because the local environment does not have GPU access.

## Test Result

Local static verification passed.

  - JSON validation succeeded
  - new benchmark entry was found in `serving-tests.json`
  - generated server args matched the expected CLI shape
  - generated client args matched the expected CLI shape
  - local dry-run stopped with `Need at least 1 GPU to run benchmarking.`

## Documentation update:
  - updated `.buildkite/performance-benchmarks/performance-benchmarks-descriptions.md`

## Release notes:
  - not updated, since this is a CI benchmark configuration change rather than a user-facing feature