### PR TITLE
Guard GraphCaptureOutput override for torch compatibility

### DIFF
--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -504,31 +504,37 @@ if not is_torch_equal_or_newer("2.12.0"):
     import builtins as _builtins
     import pickle
 
-    from torch._dynamo.convert_frame import GraphCaptureOutput
+    try:
+        from torch._dynamo.convert_frame import GraphCaptureOutput
+    except ImportError:
+        GraphCaptureOutput = None  # type: ignore[assignment]
 
-    _original_get_runtime_env = GraphCaptureOutput.get_runtime_env
+    if GraphCaptureOutput is not None and hasattr(
+        GraphCaptureOutput, "get_runtime_env"
+    ):
+        _original_get_runtime_env = GraphCaptureOutput.get_runtime_env
 
-    def _safe_builtins_dict(builtins_dict: dict) -> dict:
-        """Filter a builtins dict to only picklable entries for serialization."""
-        result = {}
-        for k, v in builtins_dict.items():
-            try:
-                pickle.dumps(v)
-                result[k] = v
-            except Exception:
-                pass
-        return result
+        def _safe_builtins_dict(builtins_dict: dict) -> dict:
+            """Filter a builtins dict to only picklable entries for serialization."""
+            result = {}
+            for k, v in builtins_dict.items():
+                try:
+                    pickle.dumps(v)
+                    result[k] = v
+                except Exception:
+                    pass
+            return result
 
-    def _patched_get_runtime_env(self):  # type: ignore[no-untyped-def]
-        runtime_env = _original_get_runtime_env(self)
-        for ref in runtime_env.external_refs:
-            if ref not in runtime_env.used_globals:
-                if ref.startswith("__builtins_dict__") and ref in self.f_globals:
-                    runtime_env.used_globals[ref] = _safe_builtins_dict(
-                        self.f_globals[ref]
-                    )
-                elif hasattr(_builtins, ref):
-                    runtime_env.used_globals[ref] = getattr(_builtins, ref)
-        return runtime_env
+        def _patched_get_runtime_env(self):  # type: ignore[no-untyped-def]
+            runtime_env = _original_get_runtime_env(self)
+            for ref in runtime_env.external_refs:
+                if ref not in runtime_env.used_globals:
+                    if ref.startswith("__builtins_dict__") and ref in self.f_globals:
+                        runtime_env.used_globals[ref] = _safe_builtins_dict(
+                            self.f_globals[ref]
+                        )
+                    elif hasattr(_builtins, ref):
+                        runtime_env.used_globals[ref] = getattr(_builtins, ref)
+            return runtime_env
 
-    GraphCaptureOutput.get_runtime_env = _patched_get_runtime_env
+        GraphCaptureOutput.get_runtime_env = _patched_get_runtime_env


### PR DESCRIPTION
## Purpose

Guard the `GraphCaptureOutput.get_runtime_env` override in
`vllm/env_override.py` for torch compatibility.

The current code assumes that
`torch._dynamo.convert_frame.GraphCaptureOutput` is always importable and
exposes `get_runtime_env`. On newer torch layouts, that assumption no longer
holds, which can make `import vllm` fail at module import time.

This change keeps the existing override when the symbol is available, and
skips it otherwise. That preserves the current workaround where supported while
avoiding an import-time failure on newer torch versions.

## Test Plan

```bash
python -c "import vllm; print('import ok')"
```
Validated locally on `torch==2.9.1+cu128`.

## Test Result

Before:
```text
ImportError: cannot import name 'GraphCaptureOutput' from 'torch._dynamo.convert_frame'
```

After:
```text
import ok
```