### PR TITLE
[Bugfix] Fix extract_hidden_states crash with quantized KV cache dtype

### DIFF
--- a/vllm/model_executor/models/extract_hidden_states.py
+++ b/vllm/model_executor/models/extract_hidden_states.py
@@ -9,6 +9,7 @@ extract_hidden_states speculative decoding method.
 """
 
 from collections.abc import Iterable
+from dataclasses import replace
 from typing import ClassVar
 
 import torch
@@ -351,6 +352,12 @@ class ExtractHiddenStatesModel(nn.Module):
         )
 
         cache_config = vllm_config.cache_config
+
+        # Hidden states dtype should be independent of KV cache dtype.
+        if cache_config is not None and is_quantized_kv_cache(
+            cache_config.cache_dtype
+        ):
+            cache_config = replace(cache_config, cache_dtype="auto")
 
         # Create a single cache-only attention layer
         # Note: We set num_heads <- self.num_hidden_states


### PR DESCRIPTION
## Purpose

When `kv_cache_dtype` is set to a quantized type (e.g. `fp8_e4m3`), `ExtractHiddenStatesModel` passes the global `cache_config` directly to `CacheOnlyAttentionLayer`, which only supports `auto`/`bfloat16`/`float16` and crashes with an AssertionError.

`CacheOnlyAttentionLayer` stores intermediate hidden states for the `extract_hidden_states` speculative decoding method — it does not store actual KV projections, so quantized cache dtypes are not applicable.

This fix creates a shallow copy of `cache_config` with `cache_dtype` reset to `"auto"` (resolves to the model's native dtype) before passing it to the hidden-states cache layer, while leaving the target model's KV cache quantization unchanged.

## Test Plan
Tested locally


## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

