### PR TITLE
[WIP][Bugfix] Add LIBRARY_PATH to Dockerfile for Triton JIT compilation on GKE

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -546,6 +546,10 @@ RUN --mount=type=bind,from=build,src=/tmp/ep_kernels_workspace/dist,target=/vllm
 # consistently from the host (see https://github.com/vllm-project/vllm/issues/18859).
 # Until then, add /usr/local/nvidia/lib64 before the image cuda path to allow override.
 ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
+# LIBRARY_PATH is needed for compile-time linking (e.g. Triton JIT compilation with
+# GCC). Without it, GCC's linker cannot find libcuda.so.1 on platforms like GKE where
+# NVIDIA drivers are mounted at /usr/local/nvidia/lib64 at runtime.
+ENV LIBRARY_PATH=/usr/local/nvidia/lib64:${LIBRARY_PATH:-}
 
 # Copy examples and benchmarks at the end to minimize cache invalidation
 COPY examples examples

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -547,9 +547,10 @@ RUN --mount=type=bind,from=build,src=/tmp/ep_kernels_workspace/dist,target=/vllm
 # Until then, add /usr/local/nvidia/lib64 before the image cuda path to allow override.
 ENV LD_LIBRARY_PATH=/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}
 # LIBRARY_PATH is needed for compile-time linking (e.g. Triton JIT compilation with
-# GCC). Without it, GCC's linker cannot find libcuda.so.1 on platforms like GKE where
-# NVIDIA drivers are mounted at /usr/local/nvidia/lib64 at runtime.
-ENV LIBRARY_PATH=/usr/local/nvidia/lib64:${LIBRARY_PATH:-}
+# GCC). We make it consistent with LD_LIBRARY_PATH so that any JIT-compiled code can
+# find CUDA libraries at link time. /usr/local/nvidia/lib64 is where container providers
+# (GKE, etc.) mount host NVIDIA drivers at runtime.
+ENV LIBRARY_PATH=/usr/local/nvidia/lib64:/usr/local/cuda/lib64:${LIBRARY_PATH:-}
 
 # Copy examples and benchmarks at the end to minimize cache invalidation
 COPY examples examples


### PR DESCRIPTION
## Purpose

Fix Triton JIT compilation failure (`cannot find -l:libcuda.so.1`) when running vLLM v0.17.1+ on GKE (Google Kubernetes Engine).

On GKE, the NVIDIA device plugin mounts driver libraries at `/usr/local/nvidia/lib64/` at runtime. The Dockerfile already sets `LD_LIBRARY_PATH` to include this path (for runtime dynamic linking), but `LIBRARY_PATH` is not set.

When Triton does JIT compilation, it invokes GCC to compile and link `cuda_utils.c` with `-l:libcuda.so.1`. GCC's linker uses `-L` flags and `LIBRARY_PATH` to find libraries at link time — it does **not** consult `LD_LIBRARY_PATH`. Triton's `libcuda_dirs()` function attempts to locate the library via `ldconfig -p`, which may return stale paths from the container image build time, causing the linker to fail.

This PR adds `ENV LIBRARY_PATH=/usr/local/nvidia/lib64:${LIBRARY_PATH:-}` alongside the existing `LD_LIBRARY_PATH` setting so GCC can find `libcuda.so.1` during Triton JIT compilation.

Reported in: https://github.com/llm-d/llm-d/issues/1063

## Test Plan

- Build a vLLM container image with this change
- Deploy on GKE with NVIDIA device plugin
- Verify that Triton JIT compilation succeeds without the `cannot find -l:libcuda.so.1` error

## Test Result

The workaround (`export LIBRARY_PATH=/usr/local/nvidia/lib64:$LIBRARY_PATH`) has been verified by multiple users in the upstream issue to resolve the problem.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>