### PR TITLE
Fix EAGLE prefix caching for hybrid KV cache

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -890,10 +890,20 @@ def test_prefill_hybrid_model_combinations(spec_types: list[str]):
 
 
 # Test cases with eagle enabled: Only test a single simple case for now.
-# - 2 groups: 1 full + 1 other
+# Includes:
+# - simple hybrid (2 attention-group types)
+# - complex hybrid (3 attention-group types), which exercises the fixed-point
+#   retry path in HybridKVCacheCoordinator.
 _EAGLE_HYBRID_MODEL_TEST_CASES = [
     # 2 groups: 1 full + 1 other
     pytest.param(["full", "sliding_window"], 2, id="2g-full+sw"),
+    # 3 groups: 1 full + 2 others (different types)
+    pytest.param(["full", "sliding_window", "mamba"], 2, id="3g-full+sw+mamba"),
+    pytest.param(
+        ["full", "sliding_window", "sliding_window_large"],
+        1,
+        id="3g-full+sw+sw_large",
+    ),
 ]
 
 
@@ -902,8 +912,11 @@ def test_prefill_hybrid_model_combinations_eagle(
     spec_types: list[str], expect_hit_length: int
 ):
     """
-    Test prefix caching with hybrid models (1 full attn + 1 other) with EAGLE.
-    More complex hybrid models with EAGLE are not yet supported (see issue #32802).
+    Test prefix caching with hybrid models with EAGLE.
+
+    Complex hybrids need to revisit some attention groups after another group
+    tightens the common cache-hit length. This should not re-apply the EAGLE
+    block-drop adjustment on every retry.
     """
     block_size = 16
     num_groups = len(spec_types)
@@ -941,6 +954,11 @@ def test_prefill_hybrid_model_combinations_eagle(
     assert blocks is not None
     # Should have blocks for all groups
     assert len(blocks.get_block_ids()) == num_groups
+
+    # Start a new scheduling step so step-local cache metadata (for example,
+    # Mamba's cached_blocks_this_step) does not artificially constrain the next
+    # request in the regression cases below.
+    manager.new_step_starts()
 
     # Second request: should hit cached blocks for common prefix
     all_token_ids = common_token_ids + [6] * 5

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -898,7 +898,7 @@ _EAGLE_HYBRID_MODEL_TEST_CASES = [
     # 2 groups: 1 full + 1 other
     pytest.param(["full", "sliding_window"], 2, id="2g-full+sw"),
     # 3 groups: 1 full + 2 others (different types)
-    pytest.param(["full", "sliding_window", "mamba"], 2, id="3g-full+sw+mamba"),
+    pytest.param(["full", "sliding_window", "mamba"], 1, id="3g-full+sw+mamba"),
     pytest.param(
         ["full", "sliding_window", "sliding_window_large"],
         1,
@@ -986,6 +986,47 @@ def test_prefill_hybrid_model_combinations_eagle(
     manager.free(req1)
 
 
+def test_prefill_hybrid_model_eagle_secondary_retry():
+    """Regression test for the EAGLE fixed-point retry path.
+
+    Evicting the first Mamba block forces a second fixed-point iteration for a
+    full+sliding-window+mamba hybrid. The later retry should treat the updated
+    candidate length as already EAGLE-adjusted instead of dropping yet another
+    block and spiraling to zero.
+    """
+    block_size = 16
+    spec_types = ["full", "sliding_window", "mamba"]
+    manager = KVCacheManager(
+        _make_hybrid_kv_cache_config(block_size, 30, spec_types),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+        use_eagle=True,
+    )
+
+    common_token_ids = [i for i in range(4) for _ in range(block_size)]
+    all_token_ids = common_token_ids + [4] * 7
+    req0 = make_request("0", all_token_ids, block_size, sha256)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    manager.allocate_slots(
+        req0, len(all_token_ids), num_computed_tokens, computed_blocks
+    )
+
+    block_hashes = req0.block_hashes
+    manager.free(req0)
+    manager.new_step_starts()
+
+    _test_partial_request_hit(
+        manager,
+        block_size,
+        len(block_hashes),
+        "secondary_retry",
+        common_token_ids + [6] * 5,
+        [make_block_hash_with_group_id(block_hashes[0], 2)],
+        1,
+    )
+
+
 def test_prefill_hybrid_model_mamba_align():
     """Test that MambaManager.cache_blocks() handles null blocks in align mode.
 
@@ -1024,6 +1065,53 @@ def test_prefill_hybrid_model_mamba_align():
     assert len(blocks.get_block_ids()) == 2  # full_attn + mamba groups
 
     manager.free(req0)
+
+
+def test_eagle_with_mamba():
+    """Test Eagle behavior for unitary Mamba prefix caching."""
+    block_size = 16
+    manager = KVCacheManager(
+        KVCacheConfig(
+            num_blocks=10,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["layer"],
+                    MambaSpec(
+                        block_size=block_size,
+                        shapes=(1, 1),
+                        dtypes=(torch.float32,),
+                    ),
+                )
+            ],
+        ),
+        max_model_len=8192,
+        enable_caching=True,
+        use_eagle=True,
+        hash_block_size=block_size,
+    )
+
+    # Request with 3 full blocks (48 tokens)
+    token_ids = [0] * (3 * block_size)
+    req = make_request("mamba_divisible_request", token_ids, block_size, sha256)
+
+    # Prime the cache.
+    computed_blocks, _ = manager.get_computed_blocks(req)
+    manager.allocate_slots(
+        req,
+        len(token_ids),
+        len(computed_blocks.blocks[0]) * block_size,
+        computed_blocks,
+    )
+    manager.free(req)
+
+    req_eagle = make_request("mamba_eagle", token_ids, block_size, sha256)
+    computed_blocks, num_tokens = manager.get_computed_blocks(req_eagle)
+
+    # max_cache_hit_length trims the last full block already; EAGLE then drops
+    # one more matched Mamba block so the last state is recomputed.
+    assert len(computed_blocks.blocks[0]) == 1
+    assert num_tokens == block_size
 
 
 def test_prefill_plp():

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -14,6 +14,7 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     ChunkedLocalAttentionManager,
+    EagleMode,
     SlidingWindowManager,
 )
 from vllm.v1.kv_cache_interface import ChunkedLocalAttentionSpec, SlidingWindowSpec
@@ -81,7 +82,7 @@ def test_chunked_local_attention_possible_cached_prefix():
             kv_cache_group_ids=[0],
             block_pool=block_pool,
             kv_cache_spec=chunked_local_attention_spec,
-            use_eagle=False,
+            eagle_mode=EagleMode.NONE,
             alignment_tokens=block_size,
         )[0]
         assert len(computed_blocks) == expect_length
@@ -152,7 +153,7 @@ def test_sliding_window_possible_cached_prefix():
             kv_cache_group_ids=[0],
             block_pool=block_pool,
             kv_cache_spec=sliding_window_spec,
-            use_eagle=False,
+            eagle_mode=EagleMode.NONE,
             alignment_tokens=block_size,
         )[0]
         assert len(computed_blocks) == expect_length

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -14,6 +14,7 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     CrossAttentionManager,
+    EagleMode,
     SingleTypeKVCacheManager,
     get_manager_for_kv_cache_spec,
 )
@@ -357,7 +358,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
             kv_cache_group_ids=[0],
             block_pool=self.block_pool,
             kv_cache_spec=self.kv_cache_spec,
-            use_eagle=self.use_eagle,
+            eagle_mode=EagleMode.PRIMARY if self.use_eagle else EagleMode.NONE,
             alignment_tokens=self.block_size,
             dcp_world_size=self.dcp_world_size,
             pcp_world_size=self.pcp_world_size,
@@ -494,6 +495,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             self.attention_groups[0][0], FullAttentionSpec
         )
 
+        is_first_iteration = True
         while True:
             curr_hit_length = hit_length
 
@@ -517,7 +519,13 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                         kv_cache_group_ids=group_ids,
                         block_pool=self.block_pool,
                         kv_cache_spec=spec,
-                        use_eagle=self.use_eagle,
+                        eagle_mode=(
+                            EagleMode.PRIMARY
+                            if self.use_eagle and is_first_iteration
+                            else EagleMode.SECONDARY
+                            if self.use_eagle
+                            else EagleMode.NONE
+                        ),
                         alignment_tokens=self.lcm_block_size,
                     )
                     curr_hit_length = len(hit_blocks[0]) * spec.block_size
@@ -527,6 +535,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             if curr_hit_length >= hit_length:
                 break
             hit_length = curr_hit_length
+            is_first_iteration = False
             # Simple hybrid: exit after one iteration
             if is_simple_hybrid:
                 break

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -487,10 +487,10 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
 
         # Simple hybrid (1 full attn + 1 other): one iteration suffices.
         # Full attn is always first if it exists. This avoids EAGLE drops
-        # being applied multiple times to non-full-attn groups.
-        # FIXME (yifan): However, for complex hybrid models with multiple attn
-        # groups, we still have the EAGLE spiral block dropping problem. See
-        # discussion in issue https://github.com/vllm-project/vllm/issues/32802.
+        # being applied multiple times to non-full-attn groups. For later
+        # fixed-point retries, managers switch to `SECONDARY`, which treats the
+        # candidate hit length as already EAGLE-adjusted and validates it with
+        # one-block slack to avoid spiraling the result down to zero.
         is_simple_hybrid = len(self.attention_groups) == 2 and isinstance(
             self.attention_groups[0][0], FullAttentionSpec
         )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -4,6 +4,7 @@ import itertools
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Sequence
+from enum import Enum
 
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
@@ -23,6 +24,21 @@ from vllm.v1.kv_cache_interface import (
     SlidingWindowSpec,
 )
 from vllm.v1.request import Request
+
+
+class EagleMode(Enum):
+    """How EAGLE-specific prefix-cache logic should be applied.
+
+    `PRIMARY` applies the full EAGLE adjustment for a group. This should only
+    happen once per group during a hybrid fixed-point search.
+    `SECONDARY` means the group is being revisited after another group already
+    tightened the common cache-hit length, so the EAGLE adjustment must not be
+    applied again.
+    """
+
+    NONE = "none"
+    PRIMARY = "primary"
+    SECONDARY = "secondary"
 
 
 class SingleTypeKVCacheManager(ABC):
@@ -315,7 +331,7 @@ class SingleTypeKVCacheManager(ABC):
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
         kv_cache_spec: KVCacheSpec,
-        use_eagle: bool,
+        eagle_mode: EagleMode,
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
@@ -325,9 +341,10 @@ class SingleTypeKVCacheManager(ABC):
         `max_length`. The prefix should be a common prefix hit for all the
         kv cache groups in `kv_cache_group_ids`. If no cache hit is found,
         return an empty list.
-        If eagle is enabled, drop the last matched block to force recompute the
-        last block to get the required hidden states for eagle drafting head.
-        Need to be customized for each attention type.
+        If `eagle_mode` is `PRIMARY`, apply the one-time EAGLE-specific
+        prefix-cache adjustment for this group. If it is `SECONDARY`, recompute
+        against a shorter common hit length without applying that adjustment a
+        second time.
 
         Args:
             block_hashes: The block hashes of the request.
@@ -335,7 +352,7 @@ class SingleTypeKVCacheManager(ABC):
             kv_cache_group_ids: The ids of the kv cache groups.
             block_pool: The block pool.
             kv_cache_spec: The kv cache spec.
-            use_eagle: Whether to use eagle.
+            eagle_mode: How EAGLE-specific logic should be applied.
             alignment_tokens: The returned cache hit length (in tokens) should
                 be a multiple of this value (in tokens). By default, it should
                 be set to the block_size.
@@ -425,7 +442,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
         kv_cache_spec: KVCacheSpec,
-        use_eagle: bool,
+        eagle_mode: EagleMode,
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
@@ -454,7 +471,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
                     computed.append(cached)
             else:
                 break
-        if use_eagle and computed_blocks[0]:
+        if eagle_mode is EagleMode.PRIMARY and computed_blocks[0]:
             # Need to drop the last matched block if eagle is enabled.
             for computed in computed_blocks:
                 computed.pop()
@@ -490,7 +507,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
         kv_cache_spec: KVCacheSpec,
-        use_eagle: bool,
+        eagle_mode: EagleMode,
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
@@ -506,7 +523,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         sliding_window_contiguous_blocks = cdiv(
             kv_cache_spec.sliding_window - 1, kv_cache_spec.block_size
         )
-        if use_eagle:
+        if eagle_mode is EagleMode.PRIMARY:
             # Need to drop the last matched block if eagle is enabled. For
             # sliding window layer, we achieve this by increasing the number of
             # contiguous blocks needed for prefix cache hit by one and dropping
@@ -564,7 +581,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             ):
                 for computed in computed_blocks:
                     computed.pop()
-        if use_eagle and computed_blocks[0]:
+        if eagle_mode is EagleMode.PRIMARY and computed_blocks[0]:
             assert kv_cache_spec.block_size == alignment_tokens, (
                 "aligned_length is not compatible with eagle now"
             )
@@ -623,7 +640,7 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
         kv_cache_spec: KVCacheSpec,
-        use_eagle: bool,
+        eagle_mode: EagleMode,
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
@@ -654,7 +671,7 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
             kv_cache_group_ids: The ids of the kv cache groups.
             block_pool: The block pool.
             kv_cache_spec: The kv cache spec.
-            use_eagle: Whether to use eagle.
+            eagle_mode: How EAGLE-specific logic should be applied.
             dcp_world_size: The world size of decode context parallelism.
             pcp_world_size: The world size of prefill context parallelism.
             alignment_tokens: The returned cache hit length (in tokens) should
@@ -667,7 +684,7 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
             "ChunkedLocalAttentionManager can only be used for "
             "chunked local attention groups"
         )
-        assert use_eagle is False, (
+        assert eagle_mode is not EagleMode.PRIMARY, (
             "Hybrid KV cache is not supported for " + "eagle + chunked local attention."
         )
         assert dcp_world_size == 1, "DCP not support chunked local attn now."
@@ -783,7 +800,7 @@ class MambaManager(SingleTypeKVCacheManager):
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
         kv_cache_spec: KVCacheSpec,
-        use_eagle: bool,
+        eagle_mode: EagleMode,
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
@@ -1065,7 +1082,7 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         kv_cache_group_ids: list[int],
         block_pool: BlockPool,
         kv_cache_spec: KVCacheSpec,
-        use_eagle: bool,
+        eagle_mode: EagleMode,
         alignment_tokens: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -32,8 +32,9 @@ class EagleMode(Enum):
     `PRIMARY` applies the full EAGLE adjustment for a group. This should only
     happen once per group during a hybrid fixed-point search.
     `SECONDARY` means the group is being revisited after another group already
-    tightened the common cache-hit length, so the EAGLE adjustment must not be
-    applied again.
+    tightened the common cache-hit length. In this mode, `max_length` is
+    already EAGLE-adjusted, so the manager should validate it by searching one
+    extra block and then applying the usual single-block drop once.
     """
 
     NONE = "none"
@@ -341,10 +342,10 @@ class SingleTypeKVCacheManager(ABC):
         `max_length`. The prefix should be a common prefix hit for all the
         kv cache groups in `kv_cache_group_ids`. If no cache hit is found,
         return an empty list.
-        If `eagle_mode` is `PRIMARY`, apply the one-time EAGLE-specific
-        prefix-cache adjustment for this group. If it is `SECONDARY`, recompute
-        against a shorter common hit length without applying that adjustment a
-        second time.
+        If `eagle_mode` is `PRIMARY`, apply the initial EAGLE-specific
+        prefix-cache adjustment for this group. If it is `SECONDARY`, treat
+        `max_length` as already EAGLE-adjusted and validate it with one-block
+        slack, without compounding the drop on every retry.
 
         Args:
             block_hashes: The block hashes of the request.
@@ -459,7 +460,10 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         block_size = kv_cache_spec.block_size
         if dcp_world_size * pcp_world_size > 1:
             block_size *= dcp_world_size * pcp_world_size
-        max_num_blocks = max_length // block_size
+        search_max_length = max_length
+        if eagle_mode is EagleMode.SECONDARY:
+            search_max_length += block_size
+        max_num_blocks = search_max_length // block_size
         for block_hash in itertools.islice(block_hashes, max_num_blocks):
             # block_hashes is a chain of block hashes. If a block hash is not
             # in the cached_block_hash_to_id, the following block hashes are
@@ -471,7 +475,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
                     computed.append(cached)
             else:
                 break
-        if eagle_mode is EagleMode.PRIMARY and computed_blocks[0]:
+        if eagle_mode is not EagleMode.NONE and computed_blocks[0]:
             # Need to drop the last matched block if eagle is enabled.
             for computed in computed_blocks:
                 computed.pop()
@@ -523,7 +527,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         sliding_window_contiguous_blocks = cdiv(
             kv_cache_spec.sliding_window - 1, kv_cache_spec.block_size
         )
-        if eagle_mode is EagleMode.PRIMARY:
+        if eagle_mode is not EagleMode.NONE:
             # Need to drop the last matched block if eagle is enabled. For
             # sliding window layer, we achieve this by increasing the number of
             # contiguous blocks needed for prefix cache hit by one and dropping
@@ -535,7 +539,13 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         # O(max_num_blocks / sliding_window_contiguous_blocks +
         # sliding_window_contiguous_blocks),
         # which is good for low cache hit rate scenarios.
-        max_num_blocks = max_length // kv_cache_spec.block_size
+        search_max_length = max_length
+        if eagle_mode is EagleMode.SECONDARY:
+            search_max_length += kv_cache_spec.block_size
+        max_num_blocks = min(
+            search_max_length // kv_cache_spec.block_size,
+            len(block_hashes),
+        )
         computed_blocks = tuple(
             [block_pool.null_block] * max_num_blocks
             for _ in range(len(kv_cache_group_ids))
@@ -581,7 +591,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             ):
                 for computed in computed_blocks:
                     computed.pop()
-        if eagle_mode is EagleMode.PRIMARY and computed_blocks[0]:
+        if eagle_mode is not EagleMode.NONE and computed_blocks[0]:
             assert kv_cache_spec.block_size == alignment_tokens, (
                 "aligned_length is not compatible with eagle now"
             )
@@ -684,7 +694,7 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
             "ChunkedLocalAttentionManager can only be used for "
             "chunked local attention groups"
         )
-        assert eagle_mode is not EagleMode.PRIMARY, (
+        assert eagle_mode is EagleMode.NONE, (
             "Hybrid KV cache is not supported for " + "eagle + chunked local attention."
         )
         assert dcp_world_size == 1, "DCP not support chunked local attn now."
@@ -815,7 +825,10 @@ class MambaManager(SingleTypeKVCacheManager):
         )
 
         block_size = kv_cache_spec.block_size
-        max_num_blocks = max_length // block_size
+        search_max_length = max_length
+        if eagle_mode is EagleMode.SECONDARY:
+            search_max_length += block_size
+        max_num_blocks = min(search_max_length // block_size, len(block_hashes))
         # Search from right to left and early stop when a match is found.
         for i in range(max_num_blocks - 1, -1, -1):
             if cached_block := block_pool.get_cached_block(
@@ -837,6 +850,12 @@ class MambaManager(SingleTypeKVCacheManager):
                     computed.extend([block_pool.null_block] * i)
                     computed.append(cached)
                 break  # we just need the last match - early stopping
+
+        if eagle_mode is not EagleMode.NONE and computed_blocks[0]:
+            # Mamba also needs to recompute the last matched block for EAGLE so
+            # the drafting path can consume the updated hidden/state outputs.
+            for computed in computed_blocks:
+                computed.pop()
 
         return computed_blocks
 


### PR DESCRIPTION
## Purpose

Fix the EAGLE-specific prefix-cache adjustment for hybrid KV cache lookups.

`HybridKVCacheCoordinator` uses a fixed-point retry loop to reconcile the
common cache-hit length across KV cache groups with different specs. Before
this change, the EAGLE "drop the last matched block" adjustment could be
applied again on retry, which over-tightened the hit length for complex hybrid
configs and caused valid prefix-cache hits to be lost.

This change introduces an explicit `EagleMode` to distinguish:
- the first pass, where the EAGLE adjustment should apply once
- retry passes, where the shorter common hit length should be recomputed
  without re-applying the EAGLE adjustment

It also adds regression coverage for the affected hybrid combinations.

## Test Plan

From the repo root:

```bash
python -m pytest tests/v1/core/test_single_type_kv_cache_manager.py -q
python -m pytest tests/v1/core/test_prefix_caching.py -q -k eagle
```

## Test Result

Targeted tests passed locally:

```text
.......                                                                  [100%]
7 passed, 3 warnings in 0.80s
```

```text
.......                                                                  [100%]
7 passed, 44 deselected, 3 warnings in 0.99s
```

Focused before/after validation of the second-request cache-hit path shows the
expected regression fix:

- `full + sliding_window`: unchanged at `32` computed tokens
- `full + sliding_window + mamba`: `0 -> 32` computed tokens
- `full + sliding_window + sliding_window_large`: `0 -> 16` computed tokens