### PR TITLE
[Bugfix] utf-8 decoding errors in benchmark endpoint client

### DIFF
--- a/vllm/benchmarks/lib/endpoint_request_func.py
+++ b/vllm/benchmarks/lib/endpoint_request_func.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """The request function for API endpoints."""
 
+import codecs
 import io
 import json
 import os
@@ -25,11 +26,12 @@ class StreamedResponseHandler:
 
     def __init__(self):
         self.buffer = ""
+        self._decoder = codecs.getincrementaldecoder("utf-8")()
 
     def add_chunk(self, chunk_bytes: bytes) -> list[str]:
         """Add a chunk of bytes to the buffer and return any complete
         messages."""
-        chunk_str = chunk_bytes.decode("utf-8")
+        chunk_str = self._decoder.decode(chunk_bytes)
         self.buffer += chunk_str
 
         messages = []


### PR DESCRIPTION
Use codecs.IncrementalDecoder to handle multi-byte UTF-8 characters  (e.g. Chinese text) split across streaming chunk boundaries, fixing  UnicodeDecodeError in StreamedResponseHandler.add_chunk()

Signed-off-by: yuhui06 <173983476@qq.com>

