### PR TITLE
fix(test): recompute Jina ColBERT rotary inv_freq cleared by transformers v5 weight loader

### DIFF
--- a/tests/models/language/pooling/test_colbert.py
+++ b/tests/models/language/pooling/test_colbert.py
@@ -109,6 +109,14 @@ def _load_hf_model(model_name: str, hf_spec: dict, device: torch.device):
         **extra,
     ).to(device)
     model.eval()
+
+    # Transformers 5.0 weight materialization can clear non-persistent
+    # buffers (e.g. rotary inv_freq) that were registered with
+    # persistent=False.  Re-compute them so the model produces valid output.
+    for mod in model.modules():
+        if hasattr(mod, "_compute_inv_freq") and hasattr(mod, "inv_freq"):
+            mod.inv_freq = mod._compute_inv_freq(device=device)
+
     return model
 
 


### PR DESCRIPTION
## Purpose

## Summary
- Transformers 5.0 introduced a new weight materialization system that clears non-persistent buffers (`persistent=False`) during `from_pretrained`
- The Jina ColBERT model's `RotaryEmbedding` registers `inv_freq` as a non-persistent buffer, so it gets wiped to uninitialized memory after weight loading
- This caused NaN outputs in the `test_colbert_hf_comparison[jina]` HF reference model, failing the embedding comparison
- Fix: recompute `inv_freq` for all rotary embedding modules after loading the HF model in `_load_hf_model`

Fix: https://github.com/vllm-project/vllm/issues/38737


## Test plan
- [x] `pytest tests/models/language/pooling/test_colbert.py::test_colbert_hf_comparison[jina]` passes

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

