### PR TITLE
[ROCm][Perf] Expose AITER MoE sorting dispatch policy via env var

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -144,6 +144,7 @@ def _rocm_aiter_fused_moe_impl(
     intermediate_pad: int = 0,
     bias1: torch.Tensor | None = None,
     bias2: torch.Tensor | None = None,
+    moe_sorting_dispatch_policy: int = 0,
 ) -> torch.Tensor:
     from aiter import ActivationType, QuantType
     from aiter.fused_moe import fused_moe
@@ -171,6 +172,7 @@ def _rocm_aiter_fused_moe_impl(
         intermediate_pad=intermediate_pad,
         bias1=bias1,
         bias2=bias2,
+        moe_sorting_dispatch_policy=moe_sorting_dispatch_policy,
     )
 
 
@@ -194,6 +196,7 @@ def _rocm_aiter_fused_moe_fake(
     intermediate_pad: int = 0,
     bias1: torch.Tensor | None = None,
     bias2: torch.Tensor | None = None,
+    moe_sorting_dispatch_policy: int = 0,
 ) -> torch.Tensor:
     if output_dtype is not None:
         return torch.empty_like(hidden_states, dtype=output_dtype)
@@ -1282,6 +1285,18 @@ class rocm_aiter_ops:
         - Triton ops: triton_rotary_embed, triton_fp8_bmm, triton_gemm_a8w8_blockscale
     """
 
+    _MOE_DISPATCH_POLICY: int | None = None
+
+    @classmethod
+    @if_aiter_supported
+    def get_moe_dispatch_policy(cls) -> int:
+        """Cached MoE sorting dispatch policy."""
+        if cls._MOE_DISPATCH_POLICY is None:
+            import vllm.envs as envs
+
+            cls._MOE_DISPATCH_POLICY = envs.VLLM_ROCM_AITER_MOE_DISPATCH_POLICY
+        return cls._MOE_DISPATCH_POLICY
+
     # Check if the env variable is set
     _AITER_ENABLED = envs.VLLM_ROCM_USE_AITER
     _LINEAR_ENABLED = envs.VLLM_ROCM_USE_AITER_LINEAR
@@ -1890,6 +1905,7 @@ class rocm_aiter_ops:
         intermediate_pad: int = 0,
         bias1: torch.Tensor | None = None,
         bias2: torch.Tensor | None = None,
+        moe_sorting_dispatch_policy: int = 0,
     ) -> torch.Tensor:
         return torch.ops.vllm.rocm_aiter_fused_moe(
             hidden_states,
@@ -1911,6 +1927,7 @@ class rocm_aiter_ops:
             intermediate_pad,
             bias1,
             bias2,
+            moe_sorting_dispatch_policy,
         )
 
     @staticmethod

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -116,6 +116,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_PAGED_ATTN: bool = False
     VLLM_ROCM_USE_AITER_LINEAR: bool = True
     VLLM_ROCM_USE_AITER_MOE: bool = True
+    VLLM_ROCM_AITER_MOE_DISPATCH_POLICY: int = 0
     VLLM_ROCM_USE_AITER_RMSNORM: bool = True
     VLLM_ROCM_USE_AITER_MLA: bool = True
     VLLM_ROCM_USE_AITER_MHA: bool = True
@@ -1102,6 +1103,17 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # By default is enabled.
     "VLLM_ROCM_USE_AITER_MOE": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_MOE", "True").lower() in ("true", "1")
+    ),
+    # MoE sorting dispatch policy for AITER fused MoE kernels.
+    #   0 = auto (default): single-pass for small batches, multi-pass
+    #       for large batches
+    #   1 = always single-pass: one kernel launch, no workspace,
+    #       may be preferred for low-concurrency decode workloads
+    #   2 = always multi-pass: can be faster for MoE-heavy models
+    #       (e.g., +2-5% on Qwen3-Next, +1.5% on DeepSeek-V3 at TP4,
+    #       see PR #39177 for benchmarks)
+    "VLLM_ROCM_AITER_MOE_DISPATCH_POLICY": lambda: int(
+        os.getenv("VLLM_ROCM_AITER_MOE_DISPATCH_POLICY", "0")
     ),
     # use aiter rms norm op if aiter ops are enabled.
     "VLLM_ROCM_USE_AITER_RMSNORM": lambda: (

--- a/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/rocm_aiter_moe.py
@@ -246,6 +246,7 @@ def rocm_aiter_fused_experts(
     a1q_scale: torch.Tensor | None = None,
     num_local_tokens: torch.Tensor | None = None,
     output_dtype: torch.dtype | None = None,
+    moe_sorting_dispatch_policy: int = 0,
 ) -> torch.Tensor:
     """ROCm AITER fused MoE expert computation."""
     if quant_config is None:
@@ -361,6 +362,7 @@ def rocm_aiter_fused_experts(
             intermediate_pad=intermediate_pad // 64 * 64 * 2,
             bias1=quant_config.w1_bias if quant_config.use_mxfp4_w4a16 else None,
             bias2=quant_config.w2_bias if quant_config.use_mxfp4_w4a16 else None,
+            moe_sorting_dispatch_policy=moe_sorting_dispatch_policy,
         )
 
 
@@ -504,6 +506,7 @@ class AiterExperts(mk.FusedMoEExpertsModular):
             a1q_scale=a1q_scale,
             num_local_tokens=num_local_tokens,
             output_dtype=output.dtype,
+            moe_sorting_dispatch_policy=rocm_aiter_ops.get_moe_dispatch_policy(),
         )
         # avoid redundant copy when output is a view of the result
         if (


### PR DESCRIPTION
Thread `moe_sorting_dispatch_policy` through the vLLM → AITER fused MoE call chain, controlled by `VLLM_ROCM_AITER_MOE_DISPATCH_POLICY` env var (default: `0`, matching current behavior).

Setting `VLLM_ROCM_AITER_MOE_DISPATCH_POLICY=2` enables an alternative dispatch policy. The best value (1 or 2) is model/workload-dependent.

Requires the companion AITER fix ([ROCm/aiter#2639](https://github.com/ROCm/aiter/pull/2639), fixes [ROCm/aiter#2576](https://github.com/ROCm/aiter/issues/2576)) that corrects the `moe_sorting_dispatch_policy` type annotation from `bool` to `int`, without which values >1 are silently cast to 1.

## Purpose

Expose AITER's `moe_sorting_dispatch_policy` parameter to vLLM users via environment variable. Currently there is no way to set this parameter from vLLM, leaving performance on the table for ROCm users.

3 files changed, 16 lines added:
- `vllm/envs.py`: New `VLLM_ROCM_AITER_MOE_DISPATCH_POLICY: int = 0`
- `vllm/_aiter_ops.py`: Add `moe_sorting_dispatch_policy` to impl/fake/static method signatures and pass through to `torch.ops.vllm.rocm_aiter_fused_moe`
- `vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py`: Add parameter to `rocm_aiter_fused_experts()`, read env var in `AiterExperts.apply()`

## Test Plan

Tested on Qwen3-Next-80B-A3B-Instruct-FP8 (MI355X, TP1):

```bash
# Baseline (default, no behavior change)
VLLM_ROCM_AITER_MOE_DISPATCH_POLICY=0 vllm serve ...

# Alternative dispatch
VLLM_ROCM_AITER_MOE_DISPATCH_POLICY=2 vllm serve ...
```

- Accuracy: `lm_eval --tasks gsm8k` (5-shot)
- Throughput: `vllm bench serve --dataset-name random --random-input-len 1024 --random-output-len 1024 --max-concurrency 16 --num-prompts 64`

## Test Result

| Metric | dp=0 (baseline) | dp=2 |
|--------|-----------------|------|
| gsm8k flex_extract | 0.8560 | 0.8628 |
| gsm8k strict_match | 0.8143 | 0.8196 |
| Output throughput (tok/s) | 1527.83 | 1551.84 (+1.6%) |
| Mean TPOT (ms) | 10.12 | 10.06 (-0.6%) |

No accuracy regression. Default value 0 preserves existing behavior.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

