### PR TITLE
Fix RoPE init for Ernie4.5 on Transformers v5

### DIFF
--- a/PR_BODY.md
+++ b/PR_BODY.md
@@ -1,0 +1,49 @@
+Title: compat: Fix Ernie4.5 RoPE initialization under Transformers v5
+
+What
+
+This PR makes two targeted fixes in `vllm/transformers_utils/config.py` to ensure models like `Ernie4_5_VLMoeForConditionalGeneration` initialize correctly when running against Transformers v5:
+
+- Remove the Transformers v5 auto-validator for RoPE (`validate_rope`) from `PretrainedConfig.__class_validators__` at module load time.
+- After calling `config.standardize_rope_params()` in `patch_rope_parameters()`, propagate a real `config.rope_theta` into `config.rope_parameters['rope_theta']` when the dict contains `None`.
+
+Why
+
+Transformers v5 triggers RoPE validation during `PretrainedConfig.__init__()`. Some remote configs (e.g., Ernie-4.5) set `rope_theta` only after `super().__init__()`, causing the auto-validation to see a missing/None `rope_theta` and throw a KeyError. vLLM already performs proper RoPE patching and validation in `patch_rope_parameters()`; deferring/removing the premature auto-check removes false failures while preserving validation coverage.
+
+How
+
+- `_disable_rope_auto_validation()` removes `validate_rope` from the class validators for Transformers >= 5 at module import.
+- `patch_rope_parameters()` now fills `rope_parameters['rope_theta']` from `config.rope_theta` when necessary before calling `config.validate_rope()`.
+
+Testing Done
+
+- Verified `transformers` v5.5.0 installed in `.venv` and that `get_config('baidu/ERNIE-4.5-VL-28B-A3B-PT', trust_remote_code=True, ..)` loads without KeyError; `rope_theta` is present and set to the expected default (500000).
+- Verified `AutoConfig.from_pretrained()` (tokenizer codepath) also succeeds.
+- Ran `pre-commit` hooks; `ruff` auto-format applied and all hooks passed.
+
+Notes / Caveats
+
+- The module-level suppression mutates Transformers' `__class_validators__` to remove `validate_rope`. This is intentionally narrow (only removes the RoPE auto-validator) and vLLM still calls `validate_rope()` explicitly after patching, preserving validation coverage.
+- On macOS, running the full test suite locally can show unrelated fork/Objective-C initialization errors (SIGSEGV). Recommend running full regression on Linux CI.
+
+How to verify locally
+
+```bash
+# Ensure venv activated and transformers v5 installed
+.venv/bin/python -c "import transformers; print(transformers.__version__)"
+# Quick config load test
+.venv/bin/python -c "from vllm.transformers_utils.config import get_config; c=get_config('baidu/ERNIE-4.5-VL-28B-A3B-PT', trust_remote_code=True); print(getattr(c.get_text_config(),'rope_theta', None), c.get_text_config().rope_parameters.get('rope_theta'))"
+# Run the targeted pytest (macOS: set fork safety env)
+export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+.venv/bin/python -m pytest 'tests/models/test_initialization.py::test_can_initialize_large_subset[Ernie4_5_VLMoeForConditionalGeneration]' -q
+```
+
+Suggested reviewers / labels
+
+- Reviewers: @maintainer-rope, @transformers-compat
+- Labels: compat, bug, tests
+
+If preferred, we can instead take a smaller-scope approach (context-managed suppression) but that proved fragile because multiple codepaths call `AutoConfig.from_pretrained()` (tokenizer path, etc.).
+
+Co-authored-by: GitHub Copilot <>

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -154,6 +154,34 @@ def _mistral_patch_hf_hub_constants() -> Iterator[None]:
         constants.SAFETENSORS_INDEX_FILE = hf_safetensors_index_file
 
 
+def _disable_rope_auto_validation() -> None:
+    """Remove ``validate_rope`` from the Transformers v5 class validators.
+
+    In Transformers v5, ``validate_rope`` is automatically invoked during
+    ``PretrainedConfig.__init__()`` via the ``__class_validators__``
+    machinery from ``huggingface_hub``.  Some upstream model configs (e.g.
+    Ernie-4.5) set ``rope_theta`` *after* ``super().__init__()``, which
+    causes the auto-validator to raise a ``KeyError`` before the value is
+    available.
+
+    vLLM calls ``validate_rope()`` **explicitly** in
+    :func:`patch_rope_parameters` after all RoPE fields have been properly
+    propagated, so the auto-validation during ``__init__`` is redundant.
+    Removing it here prevents false-positive failures without losing any
+    validation coverage.
+    """
+    if Version(version("transformers")) < Version("5.0.0"):
+        return
+    validators: list = getattr(PretrainedConfig, "__class_validators__", None) or []
+    for i in range(len(validators) - 1, -1, -1):
+        if getattr(validators[i], "__name__", None) == "validate_rope":
+            validators.pop(i)
+
+
+# One-time suppression at module load.
+_disable_rope_auto_validation()
+
+
 class HFConfigParser(ConfigParserBase):
     def parse(
         self,
@@ -413,6 +441,16 @@ def patch_rope_parameters(config: PretrainedConfig) -> None:
             config.partial_rotary_factor = partial_rotary_factor
         # Standardize and validate RoPE parameters
         config.standardize_rope_params()
+        # Some model configs (e.g. Ernie4.5) set rope_theta after
+        # super().__init__(), so the rope_scaling property setter creates
+        # rope_parameters with rope_theta=None before the real value is
+        # assigned.  standardize_rope_params() uses setdefault() which
+        # won't overwrite the stale None.  Propagate the real value here.
+        rp = getattr(config, "rope_parameters", None)
+        if rp is not None and rp.get("rope_theta") is None:
+            _theta = getattr(config, "rope_theta", None)
+            if _theta is not None:
+                rp["rope_theta"] = _theta
         config.validate_rope()
 
     # No RoPE parameters to patch

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -172,10 +172,21 @@ def _disable_rope_auto_validation() -> None:
     """
     if Version(version("transformers")) < Version("5.0.0"):
         return
-    validators: list = getattr(PretrainedConfig, "__class_validators__", None) or []
-    for i in range(len(validators) - 1, -1, -1):
-        if getattr(validators[i], "__name__", None) == "validate_rope":
-            validators.pop(i)
+    validators = getattr(PretrainedConfig, "__class_validators__", None)
+    if not validators:
+        return
+    # ``__class_validators__`` may be a plain list of callables (current
+    # huggingface_hub) **or** a dict mapping field names to lists of
+    # validators (pydantic-style).  Handle both layouts defensively.
+    groups: list[list] = (
+        list(validators.values()) if isinstance(validators, dict) else [validators]
+    )
+    for group in groups:
+        if not isinstance(group, list):
+            continue
+        for i in range(len(group) - 1, -1, -1):
+            if getattr(group[i], "__name__", None) == "validate_rope":
+                group.pop(i)
 
 
 # One-time suppression at module load.


### PR DESCRIPTION
<!-- markdownlint-disable -->

Title: compat: Fix Ernie4.5 RoPE initialization under Transformers v5
Fixes https://github.com/vllm-project/vllm/issues/38735

## Summary
- Remove automatic Transformers v5 `validate_rope` auto-validator during config construction.
- Propagate `rope_theta` into `config.rope_parameters` after `standardize_rope_params()` so configs that set `rope_theta` after `super().__init__()` pass validation.
- Fixes initialization failure for `Ernie4_5_VLMoeForConditionalGeneration` under Transformers v5 (see issue #38735, parent task #38379).

## Purpose
Transformers v5 runs RoPE validation during `PretrainedConfig.__init__()` via `__class_validators__`. Some upstream model configs (e.g. Ernie-4.5) assign `rope_theta` only after `super().__init__()`, which caused a `KeyError: Missing required keys in \`rope_parameters\` ... {'rope_theta'}` during model initialization. vLLM already performs RoPE patching and validation in `patch_rope_parameters()`; this PR prevents the premature auto-validation and guarantees `rope_theta` is present when validation runs.

## Changes
- config.py
  - Add `_disable_rope_auto_validation()` to remove the v5 RoPE auto-validator from `PretrainedConfig.__class_validators__` (applies only for Transformers >= 5).
  - In `patch_rope_parameters()`, after `config.standardize_rope_params()` propagate `config.rope_theta` into `config.rope_parameters['rope_theta']` when needed, before `config.validate_rope()`.

## Test Plan
Run the focused checks locally, then run CI full tests (recommended on Linux):

1. Quick version check
```bash
.venv/bin/python -c "import transformers; print(transformers.__version__)"
# Expect: transformers >= 5.0.0 (tested with 5.5.0)
```

2. Quick config load (verifies `rope_theta` propagation)
```bash
.venv/bin/python -c "from vllm.transformers_utils.config import get_config; c=get_config('baidu/ERNIE-4.5-VL-28B-A3B-PT', trust_remote_code=True); tc=c.get_text_config(); print(getattr(tc,'rope_theta',None), tc.rope_parameters.get('rope_theta'))"
# Expect output: 500000 500000  (or other configured value present in both places)
```

3. Targeted unit test (macOS: avoid fork issues)
```bash
export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
.venv/bin/python -m pytest 'tests/models/test_initialization.py::test_can_initialize_large_subset[Ernie4_5_VLMoeForConditionalGeneration]' -q
```

4. Full test suite (run on CI / Linux recommended)
```bash
.venv/bin/python -m pytest tests -q
```

## Test Results (local)
- `get_config(...)` now loads successfully and prints:
```
rope_theta attr: 500000
rope_parameters[rope_theta]: 500000
```
- `AutoConfig.from_pretrained(...)` (tokenizer path) also succeeds.
- `pre-commit` hooks passed after `ruff` formatting.

> Note: On macOS running the full test suite locally sometimes produces unrelated fork / Objective‑C initialization issues (SIGSEGV). These are platform-specific; please run full regression on Linux CI.

## Risk & Rollout
- Risk: We mutate Transformers’ `__class_validators__` to remove only the `validate_rope` validator. This intentionally defers automatic validation to vLLM's explicit validation in `patch_rope_parameters()`. Validation coverage is preserved and the change is narrowly scoped (only affects RoPE auto-validator for Transformers >= 5).
- Rollout: Safe to merge. Recommend running full tests on CI (Ubuntu) before merging to main.

## Documentation & Release Notes
- No public API change; no docs required for users. If you maintain a release-notes doc, add a short entry:
  `Fix: Ensure Ernie4.5 initializes under Transformers v5 by deferring RoPE auto-validation and propagating rope_theta (issue #38735).`

## Checklist (please confirm)
- [x] The purpose of the PR is documented (links to issues: #38735, parent #38379).
- [x] Test plan provided (commands for targeted and full tests).
- [x] Test results recorded for the critical verification steps.
- [ ] (Optional) Documentation updates — none required for user-facing docs in this change.
- [x] `pre-commit` / linters passed locally.

---

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
