### PR TITLE
[KV Offload] Implement `shutdown()` in `OffloadingConnector` and related classes

### DIFF
--- a/tests/v1/kv_offload/test_worker.py
+++ b/tests/v1/kv_offload/test_worker.py
@@ -69,6 +69,9 @@ class OffloadingHandler1To2(OffloadingHandler):
             if spec:
                 assert spec.finished
 
+    def shutdown(self) -> None:
+        pass
+
 
 class OffloadingHandler2To1(OffloadingHandler):
     def __init__(self):
@@ -95,6 +98,9 @@ class OffloadingHandler2To1(OffloadingHandler):
             spec = self.transfers.get(job_id)
             if spec:
                 assert spec.finished
+
+    def shutdown(self) -> None:
+        pass
 
 
 def test_offloading_worker():

--- a/tests/v1/kv_offload/test_worker.py
+++ b/tests/v1/kv_offload/test_worker.py
@@ -69,9 +69,6 @@ class OffloadingHandler1To2(OffloadingHandler):
             if spec:
                 assert spec.finished
 
-    def shutdown(self) -> None:
-        pass
-
 
 class OffloadingHandler2To1(OffloadingHandler):
     def __init__(self):
@@ -98,9 +95,6 @@ class OffloadingHandler2To1(OffloadingHandler):
             spec = self.transfers.get(job_id)
             if spec:
                 assert spec.finished
-
-    def shutdown(self) -> None:
-        pass
 
 
 def test_offloading_worker():

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -428,3 +428,6 @@ class OffloadingConnectorScheduler:
                     medium=event.medium,
                     lora_name=None,
                 )
+
+    def shutdown(self) -> None:
+        self.manager.shutdown()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
@@ -399,4 +399,8 @@ class OffloadingConnectorWorker:
         # Drop deferred store jobs: CPU cache is non-persistent,
         # so submitting stores on shutdown is pointless.
         self._unsubmitted_store_jobs.clear()
+        self._jobs.clear()
+        self._load_job.clear()
+        self._store_jobs.clear()
+        self._finished_reqs_waiting_for_store.clear()
         self.worker.shutdown()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
@@ -394,3 +394,9 @@ class OffloadingConnectorWorker:
         kv_connector_stats = self.kv_connector_stats
         self.kv_connector_stats = OffloadingConnectorStats()
         return kv_connector_stats
+
+    def shutdown(self) -> None:
+        # Drop deferred store jobs: CPU cache is non-persistent,
+        # so submitting stores on shutdown is pointless.
+        self._unsubmitted_store_jobs.clear()
+        self.worker.shutdown()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
@@ -396,8 +396,8 @@ class OffloadingConnectorWorker:
         return kv_connector_stats
 
     def shutdown(self) -> None:
-        # Drop deferred store jobs: CPU cache is non-persistent,
-        # so submitting stores on shutdown is pointless.
+        # Drop deferred store jobs: there is no point in submitting
+        # them during shutdown.
         self._unsubmitted_store_jobs.clear()
         self._jobs.clear()
         self._load_job.clear()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -64,6 +64,12 @@ class OffloadingConnector(KVConnectorBase_V1):
         elif role == KVConnectorRole.WORKER:
             self.connector_worker = OffloadingConnectorWorker(spec)
 
+    def shutdown(self) -> None:
+        if self.connector_worker is not None:
+            self.connector_worker.shutdown()
+        if self.connector_scheduler is not None:
+            self.connector_scheduler.shutdown()
+
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         assert self.connector_worker is not None
         self.connector_worker.register_kv_caches(kv_caches)

--- a/vllm/v1/kv_offload/abstract.py
+++ b/vllm/v1/kv_offload/abstract.py
@@ -178,3 +178,7 @@ class OffloadingManager(ABC):
             New OffloadingEvents collected since the last call.
         """
         return ()
+
+    def shutdown(self) -> None:
+        """Shutdown the manager and release any resources."""
+        return

--- a/vllm/v1/kv_offload/worker/cpu_gpu.py
+++ b/vllm/v1/kv_offload/worker/cpu_gpu.py
@@ -274,6 +274,12 @@ class SingleDirectionOffloadingHandler(OffloadingHandler):
             if event is not None:
                 event.synchronize()
 
+    def shutdown(self) -> None:
+        self._transfers.clear()
+        self._transfer_events.clear()
+        self._stream_pool.clear()
+        self._event_pool.clear()
+
 
 class CpuGpuOffloadingHandlers:
     def __init__(

--- a/vllm/v1/kv_offload/worker/cpu_gpu.py
+++ b/vllm/v1/kv_offload/worker/cpu_gpu.py
@@ -275,7 +275,9 @@ class SingleDirectionOffloadingHandler(OffloadingHandler):
                 event.synchronize()
 
     def shutdown(self) -> None:
-        self._transfers.clear()
+        while self._transfers:
+            transfer = self._transfers.popleft()
+            transfer.end_event.synchronize()
         self._transfer_events.clear()
         self._stream_pool.clear()
         self._event_pool.clear()

--- a/vllm/v1/kv_offload/worker/worker.py
+++ b/vllm/v1/kv_offload/worker/worker.py
@@ -69,6 +69,10 @@ class OffloadingHandler(ABC):
             job_ids: The set of job IDs to wait for.
         """
 
+    @abstractmethod
+    def shutdown(self) -> None:
+        """Shutdown the handler and release any resources."""
+
 
 class OffloadingWorker:
     """
@@ -166,3 +170,7 @@ class OffloadingWorker:
         """
         for handler in self.handlers:
             handler.wait(job_ids)
+
+    def shutdown(self) -> None:
+        for handler in self.handlers:
+            handler.shutdown()

--- a/vllm/v1/kv_offload/worker/worker.py
+++ b/vllm/v1/kv_offload/worker/worker.py
@@ -71,6 +71,7 @@ class OffloadingHandler(ABC):
 
     def shutdown(self) -> None:  # noqa: B027 -- optional no-op default
         """Shutdown the handler and release any resources."""
+        pass
 
 
 class OffloadingWorker:

--- a/vllm/v1/kv_offload/worker/worker.py
+++ b/vllm/v1/kv_offload/worker/worker.py
@@ -69,8 +69,7 @@ class OffloadingHandler(ABC):
             job_ids: The set of job IDs to wait for.
         """
 
-    @abstractmethod
-    def shutdown(self) -> None:
+    def shutdown(self) -> None:  # noqa: B027 -- optional no-op default
         """Shutdown the handler and release any resources."""
 
 

--- a/vllm/v1/kv_offload/worker/worker.py
+++ b/vllm/v1/kv_offload/worker/worker.py
@@ -69,9 +69,9 @@ class OffloadingHandler(ABC):
             job_ids: The set of job IDs to wait for.
         """
 
-    def shutdown(self) -> None:  # noqa: B027 -- optional no-op default
+    def shutdown(self) -> None:
         """Shutdown the handler and release any resources."""
-        pass
+        return
 
 
 class OffloadingWorker:


### PR DESCRIPTION


## Purpose

Add `shutdown()` to the offloading connector stack so resources are released cleanly when the engine shuts down.


Changes:
- `OffloadingConnector.shutdown()` — delegates to worker and scheduler sides
- `OffloadingConnectorWorker.shutdown()` — drops deferred store jobs (CPU cache  is non-persistent, so submitting them on shutdown is pointless) and shuts down the worker
- `OffloadingConnectorScheduler.shutdown()` — delegates to `manager.shutdown()`
- `OffloadingManager.shutdown()` — default no-op added to the abstract base
- `OffloadingWorker.shutdown()` — delegates to all registered handlers
- `OffloadingHandler.shutdown()` — abstract method added to the base class
- `SingleDirectionOffloadingHandler.shutdown()` — clears Python-side stream, event, and transfer state

## Test Plan

```bash
python -m pytest tests/v1/kv_offload/ -v
```

## Test Result

All existing tests pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

