### PR TITLE
Log warning for scheduled token mismatch

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3226,9 +3226,15 @@ class GPUModelRunner(
                 is_multimodal=is_mm_embed,
             )
 
+            
+            if num_scheduled_tokens != inputs_embeds_scheduled.shape[0]:
+                logger.warning(f"Mismatch detected: {num_scheduled_tokens} vs {inputs_embeds_scheduled.shape[0]}")
+                
+                num_scheduled_tokens = inputs_embeds_scheduled.shape[0]
+
             # TODO(woosuk): Avoid the copy. Optimize.
             self.inputs_embeds.gpu[:num_scheduled_tokens].copy_(inputs_embeds_scheduled)
-
+            
             input_ids, inputs_embeds = self._prepare_mm_inputs(num_input_tokens)
             model_kwargs = {
                 **self._init_model_kwargs(),

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3226,9 +3226,15 @@ class GPUModelRunner(
                 is_multimodal=is_mm_embed,
             )
 
+            num_real_tokens = inputs_embeds_scheduled.shape[0]
             
-            if num_scheduled_tokens != inputs_embeds_scheduled.shape[0]:
-                logger.warning(f"Mismatch detected: {num_scheduled_tokens} vs {inputs_embeds_scheduled.shape[0]}")
+            if num_scheduled_tokens != num_real_tokens:
+                if self.max_num_tokens < num_real_tokens:
+                    raise RuntimeError(
+                        f"The embedding size {num_real_tokens} exceeds"
+                        f"the max amount of tokens {self.max_num_tokens}."
+                        
+                logger.warning(f"Mismatch detected: {num_scheduled_tokens} vs {num_real_tokens}")
                 
                 num_scheduled_tokens = inputs_embeds_scheduled.shape[0]
 


### PR DESCRIPTION
Added a warning for token mismatch in scheduled inputs.




## Purpose
To fix the issue of:
- #39174 
## Test Plan
Because I'm running on a MacBook, which doesn't have a GPU nor CUDA, I can't run the test normally. Instead I'm running manually. I created a test file in the root of the folder, wrote some code that manually tests the issue, and then ran it.

The test command to run the code was `python3 manual_test_copy.py` because the file is named `manual_test_copy.py` and I'm using Python 3.
## Test Result
The test has ran successfully.

Before:
```
RuntimeError: The size of tensor a (40) must match the size of tensor b (39) at non-singleton dimension 0
```

After:
```
before: scheduled=40, actual=39
fixing mismatch: 40 -> 39
copy succeeded

before: scheduled=39, actual=39
copy succeeded

before: scheduled=12, actual=10
fixing mismatch: 12 -> 10
copy succeeded
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

