### PR TITLE
fix: make ColQwen3 work with transformers >=5.0.0

### DIFF
--- a/vllm/model_executor/models/colqwen3.py
+++ b/vllm/model_executor/models/colqwen3.py
@@ -271,8 +271,14 @@ class ColQwen3Model(Qwen3VLForConditionalGeneration, SupportsLateInteraction):
                     name = "model." + name
                 model_weights.append((name, weight))
 
-        loader = AutoWeightsLoader(self)
+        loader = AutoWeightsLoader(self, ignore_unexpected_prefixes=["lm_head."])
         loaded = loader.load_weights(model_weights, mapper=self.hf_to_vllm_mapper)
+
+        # ColQwen3 is a pooling model and does not need lm_head.
+        # Some checkpoints (e.g. TomoroAI) omit it entirely.
+        # Mark it as loaded so the weight validator doesn't complain.
+        if "language_model.lm_head.weight" not in loaded:
+            loaded.add("language_model.lm_head.weight")
 
         if proj_weights:
             model_dtype = next(self.language_model.parameters()).dtype


### PR DESCRIPTION


## Purpose

- ColQwen3 inherits `lm_head` from `Qwen3VLForConditionalGeneration` but never uses it (pooling model)
- TomoroAI/tomoro-colqwen3-embed-4b checkpoint doesn't include `lm_head` weights
- Transformers 5.0 made `PretrainedConfig` a dataclass, which crashes TomoroAI's custom config due to a mutable default. This causes fallback to a config with `tie_word_embeddings=False`, creating `lm_head` as a separate parameter instead of tying it to `embed_tokens`
- The strict weight validator then fails because `language_model.lm_head.weight` is not in the checkpoint
- Fix: mark `lm_head` as loaded when missing, since ColQwen3 doesn't use it for pooling

## Test plan
- [x] `pytest tests/models/multimodal/pooling/test_colqwen3.py -v` — all 18 tests pass (including all 6 TomoroAI tests that were failing)

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

