### PR TITLE
[Bugfix] Narrow fp8_e5m2 kv-cache gate to only reject actual fp8 checkpoints

### DIFF
--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -87,6 +87,22 @@ def should_load_quant_weights(quant_method: QuantizeMethodBase | None) -> bool:
     )
 
 
+def _is_fp8_kv_cache_method(quant_method: QuantizeMethodBase) -> bool:
+    """Returns whether the KV cache quant method is from an fp8 checkpoint.
+
+    This distinguishes fp8-specific KV cache methods (Fp8KVCacheMethod,
+    ModelOptFp8KVCacheMethod) from other BaseKVCacheMethod subclasses like
+    CompressedTensorsKVCacheMethod or QuarkKVCacheMethod, which may be used
+    with non-fp8 checkpoints (e.g., INT4, INT8).
+    """
+    from vllm.model_executor.layers.quantization.fp8 import Fp8KVCacheMethod
+    from vllm.model_executor.layers.quantization.modelopt import (
+        ModelOptFp8KVCacheMethod,
+    )
+
+    return isinstance(quant_method, (Fp8KVCacheMethod, ModelOptFp8KVCacheMethod))
+
+
 def set_default_quant_scales(layer: nn.Module, register_buffer: bool = False) -> None:
     """Sets default quantization scales for the layer."""
     if register_buffer:
@@ -160,8 +176,12 @@ def _init_kv_cache_quant(
         assert isinstance(quant_method, BaseKVCacheMethod)
         # TODO (mgoin): kv cache dtype should be specified in the FP8
         # checkpoint config and become the "auto" behavior
-        if layer.kv_cache_dtype == "fp8_e5m2":
-            raise ValueError("fp8_e5m2 kv-cache is not supported with fp8 checkpoints.")
+        if layer.kv_cache_dtype == "fp8_e5m2" and _is_fp8_kv_cache_method(
+            quant_method
+        ):
+            raise ValueError(
+                "fp8_e5m2 kv-cache is not supported with fp8 checkpoints."
+            )
         # If quantization is enabled, we make "k_scale" and "v_scale"
         # parameters so that it can be loaded from the model checkpoint.
         # The k/v_scale will then be converted back to native float32


### PR DESCRIPTION
## Summary

Fixes #39137

The `fp8_e5m2` kv-cache dtype check in `_init_kv_cache_quant` incorrectly rejects **all** quantized checkpoints when combined with `--kv-cache-dtype fp8_e5m2`, even though the error message says "fp8 checkpoints." The root cause is that `should_load_quant_weights(quant_method)` returns `True` for any `BaseKVCacheMethod` subclass, including `CompressedTensorsKVCacheMethod` and `QuarkKVCacheMethod`, which may be used with non-fp8 checkpoints (e.g., INT4, INT8, AWQ, GPTQ).

This PR narrows the gate to only fire when the quant method is specifically `Fp8KVCacheMethod` or `ModelOptFp8KVCacheMethod` — the actual fp8-checkpoint KV cache methods where `fp8_e5m2` is incompatible due to conflicting scales.

### Changes

- Added `_is_fp8_kv_cache_method()` helper that checks if the quant method is an fp8-specific KV cache method
- Updated the `fp8_e5m2` guard in `_init_kv_cache_quant` to use this helper, so non-fp8 quantized checkpoints (INT4, INT8, etc.) can use `--kv-cache-dtype fp8_e5m2` without being incorrectly rejected

### Before (broken)
```
vllm serve cyankiwi/gemma-4-31B-it-AWQ-4bit --kv-cache-dtype fp8_e5m2 ...
# ValueError: fp8_e5m2 kv-cache is not supported with fp8 checkpoints.
# (but this is an INT4 checkpoint, not fp8!)
```

### After (fixed)
The error only fires for actual fp8 checkpoints (`Fp8Config`, `ModelOpt` fp8). Non-fp8 quantized checkpoints proceed to load KV cache scales normally (defaulting to 1.0 when no scales are present in the checkpoint).

## Test plan

- Verified Python syntax compiles without errors
- The fix is a strict narrowing of an existing gate condition — fp8 checkpoints still get the same error, while non-fp8 checkpoints are no longer incorrectly blocked
- AI assistance was used (Claude). The change was reviewed line-by-line.
- No existing PR addresses this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)