### PR TITLE
[KV Connector] Ignore specdec models layer on decode node for transfer

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -147,7 +147,7 @@ def _filter_draft_kv_cache_groups(
             idx is not None and idx >= target_num_layers for idx in layer_indices
         ):
             draft_group_indices.add(i)
-            logger.info(
+            logger.debug(
                 "Filtering draft KV cache group %d (%d layers) from NIXL "
                 "transfer config",
                 i,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py
@@ -12,11 +12,12 @@ import uuid
 from collections import defaultdict
 from collections.abc import Iterator
 from concurrent.futures import Future, ThreadPoolExecutor
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Any, cast
 
 import msgspec
 import numpy as np
+import regex as re
 import torch
 import zmq
 
@@ -103,6 +104,64 @@ NIXL_CONNECTOR_VERSION: int = 2
 GET_META_MSG = b"get_meta_msg"
 
 logger = init_logger(__name__)
+
+# Pattern to extract layer index from attention layer names like
+# "model.layers.61.self_attn" or "model.layers.0.self_attn"
+_LAYER_IDX_RE = re.compile(r"\.layers\.(\d+)\.")
+
+
+def _extract_layer_idx(layer_name: str) -> int | None:
+    """Extract the numeric layer index from a layer name, or None."""
+    m = _LAYER_IDX_RE.search(layer_name)
+    return int(m.group(1)) if m else None
+
+
+def _filter_draft_kv_cache_groups(
+    kv_cache_config: "KVCacheConfig",
+    vllm_config: VllmConfig,
+) -> tuple["KVCacheConfig", set[int]]:
+    """Remove draft model KV cache groups and return filtered config + excluded
+    group indices.
+
+    Draft layers are appended after target model layers, so their layer indices
+    are >= target_num_layers. They are validated to be in the same KV cache
+    group by eagle.py:validate_same_kv_cache_group.
+
+    Returns:
+        (filtered_config, draft_group_indices) where draft_group_indices is the
+        set of original group indices that were removed.
+    """
+    spec_config = vllm_config.speculative_config
+    if spec_config is None:
+        return kv_cache_config, set()
+
+    target_num_layers = vllm_config.model_config.get_num_layers(
+        vllm_config.parallel_config
+    )
+
+    draft_group_indices: set[int] = set()
+    filtered_groups = []
+    for i, group in enumerate(kv_cache_config.kv_cache_groups):
+        layer_indices = [_extract_layer_idx(n) for n in group.layer_names]
+        if layer_indices and all(
+            idx is not None and idx >= target_num_layers for idx in layer_indices
+        ):
+            draft_group_indices.add(i)
+            logger.info(
+                "Filtering draft KV cache group %d (%d layers) from NIXL "
+                "transfer config",
+                i,
+                len(group.layer_names),
+            )
+        else:
+            filtered_groups.append(group)
+
+    if not draft_group_indices:
+        return kv_cache_config, set()
+
+    filtered = replace(kv_cache_config, kv_cache_groups=filtered_groups)
+    return filtered, draft_group_indices
+
 
 # Lazy import nixl_wrapper to avoid loading nixl_bindings if nixl is not used
 try:
@@ -364,15 +423,28 @@ class NixlConnector(KVConnectorBase_V1, SupportsHMA):
         self.kv_cache_config = kv_cache_config
         self.engine_id: EngineId = vllm_config.kv_transfer_config.engine_id
         self.kv_transfer_config = vllm_config.kv_transfer_config
+
+        # Filter out draft model KV cache groups so NIXL only sees target
+        # model layers. This prevents P/D group count mismatches when
+        # speculative decoding adds draft attention layers on the D side.
+        transfer_kv_cache_config, self._draft_group_indices = (
+            _filter_draft_kv_cache_groups(kv_cache_config, vllm_config)
+        )
+
         if role == KVConnectorRole.SCHEDULER:
             self.connector_scheduler: NixlConnectorScheduler | None = (
-                NixlConnectorScheduler(vllm_config, self.engine_id, kv_cache_config)
+                NixlConnectorScheduler(
+                    vllm_config,
+                    self.engine_id,
+                    transfer_kv_cache_config,
+                    draft_group_indices=self._draft_group_indices,
+                )
             )
             self.connector_worker: NixlConnectorWorker | None = None
         elif role == KVConnectorRole.WORKER:
             self.connector_scheduler = None
             self.connector_worker = NixlConnectorWorker(
-                vllm_config, self.engine_id, kv_cache_config
+                vllm_config, self.engine_id, transfer_kv_cache_config
             )
 
     ############################################################
@@ -438,6 +510,13 @@ class NixlConnector(KVConnectorBase_V1, SupportsHMA):
         block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict[str, Any] | None]:
         assert self.connector_scheduler is not None
+        # Filter out draft group block_ids before the scheduler sees them.
+        if self._draft_group_indices:
+            block_ids = tuple(
+                bids
+                for i, bids in enumerate(block_ids)
+                if i not in self._draft_group_indices
+            )
         return self.connector_scheduler.request_finished(request, block_ids)
 
     def set_xfer_handshake_metadata(
@@ -555,9 +634,14 @@ class NixlConnectorScheduler:
     """Implementation of Scheduler side methods"""
 
     def __init__(
-        self, vllm_config: VllmConfig, engine_id: str, kv_cache_config: "KVCacheConfig"
+        self,
+        vllm_config: VllmConfig,
+        engine_id: str,
+        kv_cache_config: "KVCacheConfig",
+        draft_group_indices: set[int] | None = None,
     ):
         self.vllm_config = vllm_config
+        self._draft_group_indices: set[int] = draft_group_indices or set()
         self.block_size = vllm_config.cache_config.block_size
         self.engine_id: EngineId = engine_id
         self.kv_cache_config = kv_cache_config
@@ -620,6 +704,16 @@ class NixlConnectorScheduler:
             cdiv(n_tokens, block_size) + 1 if n_tokens else 0
             for n_tokens, block_size in sw_sizes_tokens
         ]
+
+    def _filter_draft_block_ids(self, block_ids: BlockIds) -> BlockIds:
+        """Remove block ID entries for draft model KV cache groups."""
+        if not self._draft_group_indices or not block_ids:
+            return block_ids
+        return tuple(
+            bids
+            for i, bids in enumerate(block_ids)
+            if i not in self._draft_group_indices
+        )
 
     def shutdown(self):
         self._stop_event.set()
@@ -842,6 +936,11 @@ class NixlConnectorScheduler:
                         blocks.get_unhashed_block_ids_all_groups()
                         if num_external_tokens > 0
                         else ()
+                    )
+                    # Filter out draft groups before SW clipping and
+                    # transfer so P/D group counts match.
+                    unhashed_local_block_ids = self._filter_draft_block_ids(
+                        unhashed_local_block_ids
                     )
                     local_block_ids = self.get_sw_clipped_blocks(
                         unhashed_local_block_ids

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -314,6 +314,18 @@ class SpecDecodeBaseProposer:
                 "does not support M-RoPE yet"
             )
 
+    def get_transfer_excluded_layer_names(self) -> set[str]:
+        """Layer names whose KV caches should NOT be transferred via NIXL."""
+        return set(getattr(self, "_draft_attn_layer_names", set()))
+
+    def get_cp_compatibility_excluded_layer_names(self) -> set[str]:
+        """Layer names to skip during DCP/PCP compatibility checks."""
+        return self.get_transfer_excluded_layer_names()
+
+    def get_cudagraph_excluded_layer_names(self) -> set[str]:
+        """Layer names to exclude from cudagraph backend selection."""
+        return self.get_cp_compatibility_excluded_layer_names()
+
     def _init_parallel_drafting_params(self):
         # For parallel drafting, we need the token ID to use for masked slots
         # And for EAGLE + parallel drafting, we need the hidden state tensor to use

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -11,14 +11,19 @@ else:
     AttentionLayerBase = object
 
 
-def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
+def check_attention_cp_compatibility(
+    vllm_config: VllmConfig,
+    excluded_layers: set[str] | None = None,
+) -> None:
     pcp_size = vllm_config.parallel_config.prefill_context_parallel_size
     dcp_size = vllm_config.parallel_config.decode_context_parallel_size
     interleave_size = vllm_config.parallel_config.cp_kv_cache_interleave_size
     if pcp_size * dcp_size > 1:
         layer_type = cast(type[Any], AttentionLayerBase)
         layers = get_layers_from_vllm_config(vllm_config, layer_type)
-        for layer in layers.values():
+        for layer_name, layer in layers.items():
+            if excluded_layers and layer_name in excluded_layers:
+                continue
             layer_impl = getattr(layer, "impl", None)
             if layer_impl is None:
                 continue

--- a/vllm/v1/worker/gpu/kv_connector.py
+++ b/vllm/v1/worker/gpu/kv_connector.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import copy
+import logging
 from typing import TYPE_CHECKING
 
 import torch
@@ -22,6 +23,8 @@ from vllm.v1.outputs import (
     KVConnectorOutput,
     ModelRunnerOutput,
 )
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
@@ -47,10 +50,29 @@ class KVConnector:
 
 class ActiveKVConnector(KVConnector):
     def __init__(
-        self, vllm_config: VllmConfig, kv_caches_dict: dict[str, torch.Tensor]
+        self,
+        vllm_config: VllmConfig,
+        kv_caches_dict: dict[str, torch.Tensor],
+        excluded_layer_names: set[str] | None = None,
     ):
         self.vllm_config = vllm_config
         self.kv_connector = get_kv_transfer_group()
+
+        # Filter out draft model KV caches (e.g., EAGLE draft attention
+        # layers) before registering with the connector. This prevents
+        # P/D mismatches when speculative decoding adds extra layers on
+        # the decode side.
+        if excluded_layer_names:
+            found = sorted(excluded_layer_names & kv_caches_dict.keys())
+            if found:
+                logger.info(
+                    "Excluding draft KV caches from transfer: %s",
+                    found,
+                )
+            kv_caches_dict = {
+                k: v for k, v in kv_caches_dict.items() if k not in excluded_layer_names
+            }
+
         # Register kv caches with KV Connector if applicable.
         # TODO: support cross_layers_kv_cache
         # (see https://github.com/vllm-project/vllm/pull/27743)
@@ -123,10 +145,11 @@ NO_OP_KV_CONNECTOR = KVConnector()
 
 
 def get_kv_connector(
-    vllm_config: VllmConfig, kv_caches_dict: dict[str, torch.Tensor]
+    vllm_config: VllmConfig,
+    kv_caches_dict: dict[str, torch.Tensor],
+    excluded_layer_names: set[str] | None = None,
 ) -> KVConnector:
     if not has_kv_transfer_group():
-        # No-op connector.
         return NO_OP_KV_CONNECTOR
 
-    return ActiveKVConnector(vllm_config, kv_caches_dict)
+    return ActiveKVConnector(vllm_config, kv_caches_dict, excluded_layer_names)

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -333,6 +333,13 @@ class GPUModelRunner(LoRAModelRunnerMixin):
     def get_kv_cache_spec(self):
         return get_kv_cache_spec(self.vllm_config)
 
+    def _get_speculator_excluded_layer_names(self, method_name: str) -> set[str]:
+        """Get excluded layer names from the speculator, if present."""
+        if self.speculator is None:
+            return set()
+        fn = getattr(self.speculator, method_name, None)
+        return set(fn()) if callable(fn) else set()
+
     def initialize_kv_cache(self, kv_cache_config: KVCacheConfig) -> None:
         kv_cache_config = deepcopy(kv_cache_config)
         self.kv_cache_config = kv_cache_config
@@ -364,7 +371,10 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         self.attn_backends, self.attn_groups = init_attn_backend(
             self.kv_cache_config, self.vllm_config, self.device
         )
-        check_attention_cp_compatibility(self.vllm_config)
+        draft_excluded = self._get_speculator_excluded_layer_names(
+            "get_cp_compatibility_excluded_layer_names"
+        )
+        check_attention_cp_compatibility(self.vllm_config, draft_excluded or None)
         if self.speculator is not None:
             # HACK(woosuk)
             self.speculator.set_attn(
@@ -382,7 +392,12 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.device,
             self.cache_config.cache_dtype,
         )
-        self.kv_connector = get_kv_connector(self.vllm_config, kv_caches_dict)
+        transfer_excluded = self._get_speculator_excluded_layer_names(
+            "get_transfer_excluded_layer_names"
+        )
+        self.kv_connector = get_kv_connector(
+            self.vllm_config, kv_caches_dict, transfer_excluded or None
+        )
 
     @torch.inference_mode()
     @step_eplb_after(is_dummy=True)

--- a/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
@@ -125,6 +125,18 @@ class EagleSpeculator:
             target_attn_layer_names
         )
 
+    def get_transfer_excluded_layer_names(self) -> set[str]:
+        """Layer names whose KV caches should not be transferred."""
+        return set(getattr(self, "draft_attn_layer_names", set()))
+
+    def get_cp_compatibility_excluded_layer_names(self) -> set[str]:
+        """Layer names to skip during DCP/PCP compatibility checks."""
+        return self.get_transfer_excluded_layer_names()
+
+    def get_cudagraph_excluded_layer_names(self) -> set[str]:
+        """Layer names to exclude from cudagraph backend selection."""
+        return self.get_cp_compatibility_excluded_layer_names()
+
     def set_attn(
         self,
         model_state: ModelState,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6225,7 +6225,11 @@ class GPUModelRunner(
         )
 
         # Check if attention backend supports PCP&DCP and related features.
-        check_attention_cp_compatibility(self.vllm_config)
+        # Exclude draft model layers that may use incompatible backends.
+        draft_excluded = self._get_drafter_excluded_layer_names(
+            "get_cp_compatibility_excluded_layer_names"
+        )
+        check_attention_cp_compatibility(self.vllm_config, draft_excluded or None)
 
         for i, attn_backend_map in enumerate(attention_backend_maps):
             self.attn_groups.append(create_attn_groups(attn_backend_map, i))
@@ -6801,6 +6805,29 @@ class GPUModelRunner(
                 else:
                     break
 
+    def _get_drafter_excluded_layer_names(self, method_name: str) -> set[str]:
+        """Get excluded layer names from the drafter via the named method."""
+        drafter = getattr(self, "drafter", None)
+        if drafter is None:
+            return set()
+        fn = getattr(drafter, method_name, None)
+        return set(fn()) if callable(fn) else set()
+
+    def _get_kv_caches_for_transfer(
+        self, kv_caches: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        """Filter out draft model KV caches before NIXL registration."""
+        excluded = self._get_drafter_excluded_layer_names(
+            "get_transfer_excluded_layer_names"
+        )
+        if not excluded:
+            return kv_caches
+        filtered = {k: v for k, v in kv_caches.items() if k not in excluded}
+        found = sorted(excluded & kv_caches.keys())
+        if found:
+            logger.info("Excluding drafter KV caches from transfer: %s", found)
+        return filtered
+
     def initialize_kv_cache(
         self,
         kv_cache_config: KVCacheConfig,
@@ -6854,7 +6881,9 @@ class GPUModelRunner(
                     self.cross_layers_kv_cache, self.cross_layers_attn_backend
                 )
             else:
-                kv_transfer_group.register_kv_caches(kv_caches)
+                kv_transfer_group.register_kv_caches(
+                    self._get_kv_caches_for_transfer(kv_caches)
+                )
             kv_transfer_group.set_host_xfer_buffer_ops(copy_kv_blocks)
 
     def _get_attention_kv_cache_gid(self) -> int:


### PR DESCRIPTION
This PR addresses a case where we run spec-dec models in DI mode, where KV Transfer mis-shape would happen due to the fact decode will include speculative models, whereas prefill might not run such speculators.

I've only tested with NIXL connector, but open to add support for connectors if this is fit. Additionally, not entirely sure wrt MRV2 API so I've extensively test with MRV2 yet.

Signed-off-by: Aaron Pham <contact@aarnphm.xyz>
