### PR TITLE
[RL] Synchronize pause return in DPEP

### DIFF
--- a/tests/v1/distributed/test_async_llm_dp.py
+++ b/tests/v1/distributed/test_async_llm_dp.py
@@ -365,10 +365,13 @@ async def test_dp_pause_keep_race_staggered_engines():
         async def staggered_pause_keep(method: str, *args) -> Any:
             if method != "pause_scheduler" or not args or args[0] != "keep":
                 return await original_call_utility(method, *args)
-            # Send pause(keep) to engine 0 first
-            await client._call_utility_async(
-                method, *args, engine=client.core_engines[0]
+            # Send pause(keep) to engine 0 — don't await, because with
+            # coordinated pause the response is deferred until ALL
+            # engines have acknowledged.
+            eng0_task = asyncio.create_task(
+                client._call_utility_async(method, *args, engine=client.core_engines[0])
             )
+            await asyncio.sleep(0.5)
             # In the middle: send two requests (race window)
             sp = SamplingParams(max_tokens=5, ignore_eos=True)
 
@@ -384,11 +387,12 @@ async def test_dp_pause_keep_race_staggered_engines():
             t2 = asyncio.create_task(consume_gen("race-2"))
             mid_pause_tasks.extend([t1, t2])
             await asyncio.sleep(3)
-            # Then send pause(keep) to engine 1
-            result = await client._call_utility_async(
-                method, *args, engine=client.core_engines[1]
+            # Then send pause(keep) to engine 1 — both engines will
+            # resolve together once the coordinator broadcasts ALL_PAUSED.
+            eng1_task = asyncio.create_task(
+                client._call_utility_async(method, *args, engine=client.core_engines[1])
             )
-            return result
+            await asyncio.gather(eng0_task, eng1_task)
 
         client.call_utility_async = staggered_pause_keep
 

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -209,6 +209,10 @@ class EngineCoreOutputs(
     # "old" wave, so the next wave needs to be started in other engines.
     start_wave: int | None = None
 
+    # Sent by an engine to the coordinator after its scheduler has
+    # finished pausing, so the coordinator can barrier-sync all engines.
+    pause_ack: bool = False
+
     def __post_init__(self):
         if self.timestamp == 0.0:
             self.timestamp = time.monotonic()
@@ -228,6 +232,9 @@ class EngineCoreRequestType(enum.Enum):
     EXECUTOR_FAILED = b"\x04"
     # Sentinel to wake up input_queue.get() during shutdown.
     WAKEUP = b"\x05"
+    # Broadcast from coordinator to engines when all DP ranks have
+    # acknowledged a scheduler pause.
+    ALL_PAUSED = b"\x06"
 
 
 class ReconfigureDistributedRequest(msgspec.Struct):

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -450,13 +450,14 @@ class DPCoordinatorProc:
                     # ALL_PAUSED once every engine has acknowledged.
                     if outputs.pause_ack:
                         self.pause_acks.add(eng_index)
+                        active_indices = set(range(len(self.engines)))
                         logger.debug(
                             "Pause ack from engine %d (%d/%d).",
                             eng_index,
                             len(self.pause_acks),
                             len(self.engines),
                         )
-                        if len(self.pause_acks) >= len(self.engines):
+                        if active_indices <= self.pause_acks:
                             logger.debug("All engines paused, broadcasting ALL_PAUSED.")
                             self._send_all_paused(publish_back)
                             self.pause_acks.clear()

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -163,6 +163,10 @@ class DPCoordinatorProc:
         self.stats_update_interval_ms = min_stats_update_interval_ms
         self.enable_wave_coordination = enable_wave_coordination
 
+        # Tracks which engines have acknowledged a scheduler pause.
+        # When all engines have acked, we broadcast ALL_PAUSED.
+        self.pause_acks: set[int] = set()
+
     @staticmethod
     def run_coordinator(
         engine_count: int,
@@ -442,6 +446,21 @@ class DPCoordinatorProc:
                             wave_state_changed = True
                             self._send_start_wave(publish_back, wave, eng_index)
 
+                    # Pause barrier: collect acks from engines, broadcast
+                    # ALL_PAUSED once every engine has acknowledged.
+                    if outputs.pause_ack:
+                        self.pause_acks.add(eng_index)
+                        logger.debug(
+                            "Pause ack from engine %d (%d/%d).",
+                            eng_index,
+                            len(self.pause_acks),
+                            len(self.engines),
+                        )
+                        if len(self.pause_acks) >= len(self.engines):
+                            logger.debug("All engines paused, broadcasting ALL_PAUSED.")
+                            self._send_all_paused(publish_back)
+                            self.pause_acks.clear()
+
                 if wave_state_changed:
                     message = (None, current_wave, engines_running)
                     publish_front.send(msgspec.msgpack.encode(message))
@@ -457,6 +476,14 @@ class DPCoordinatorProc:
         """
         wave_encoded = msgspec.msgpack.encode((wave, exclude_engine_index))
         socket.send_multipart((EngineCoreRequestType.START_DP_WAVE.value, wave_encoded))
+
+    @staticmethod
+    def _send_all_paused(socket: zmq.Socket):
+        """Broadcast ALL_PAUSED to all engines once every engine has
+        acknowledged a scheduler pause."""
+        socket.send_multipart(
+            (EngineCoreRequestType.ALL_PAUSED.value, msgspec.msgpack.encode(None))
+        )
 
     def _get_engine_counts(self, do_copy=False) -> list[list[int]]:
         """Return list of [waiting, running] count lists for each engine."""

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1674,6 +1674,12 @@ class DPEngineCoreProc(EngineCoreProc):
         if not self.has_coordinator:
             return super().pause_scheduler(mode=mode, clear_cache=clear_cache)
 
+        # If a barrier is already in flight, the pause is already in
+        # progress — return the existing future so all callers resolve
+        # together when ALL_PAUSED arrives.
+        if self._pause_barrier_future is not None:
+            return self._pause_barrier_future
+
         # With a coordinator we barrier-sync the pause: each engine sends
         # a PAUSE_ACK after its local pause completes, and the coordinator
         # broadcasts ALL_PAUSED once every engine has acknowledged. The
@@ -1693,12 +1699,12 @@ class DPEngineCoreProc(EngineCoreProc):
         self.scheduler.set_pause_state(pause_state)
 
         barrier_future: Future[Any] = Future()
+        self._pause_barrier_future = barrier_future
 
         def _on_idle(engine: "DPEngineCoreProc") -> None:
             if clear_cache:
                 engine._reset_caches()
             engine.output_queue.put_nowait((-1, EngineCoreOutputs(pause_ack=True)))
-            engine._pause_barrier_future = barrier_future
 
         if not self.has_work():
             _on_idle(self)

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1604,6 +1604,9 @@ class DPEngineCoreProc(EngineCoreProc):
 
         self.eep_scaling_state: ElasticEPScalingState | None = None
 
+        # Future that is pending until the coordinator broadcasts ALL_PAUSED.
+        self._pause_barrier_future: Future[Any] | None = None
+
         # Initialize the engine.
         dp_rank = vllm_config.parallel_config.data_parallel_rank
         super().__init__(
@@ -1665,6 +1668,45 @@ class DPEngineCoreProc(EngineCoreProc):
                 (-1, EngineCoreOutputs(start_wave=self.current_wave))
             )
 
+    def pause_scheduler(
+        self, mode: PauseMode = "abort", clear_cache: bool = True
+    ) -> Future | None:
+        if not self.has_coordinator:
+            return super().pause_scheduler(mode=mode, clear_cache=clear_cache)
+
+        # With a coordinator we barrier-sync the pause: each engine sends
+        # a PAUSE_ACK after its local pause completes, and the coordinator
+        # broadcasts ALL_PAUSED once every engine has acknowledged. The
+        # returned Future is resolved only when ALL_PAUSED is received,
+        # so the /pause HTTP response is deferred until all DP ranks are
+        # paused.
+        if mode not in ("keep", "abort", "wait"):
+            raise ValueError(f"Invalid pause mode: {mode}")
+
+        if mode == "abort":
+            aborted_reqs = self.scheduler.finish_requests(
+                None, RequestStatus.FINISHED_ABORTED
+            )
+            self._send_abort_outputs(aborted_reqs)
+
+        pause_state = PauseState.PAUSED_ALL if mode == "keep" else PauseState.PAUSED_NEW
+        self.scheduler.set_pause_state(pause_state)
+
+        barrier_future: Future[Any] = Future()
+
+        def _on_idle(engine: "DPEngineCoreProc") -> None:
+            if clear_cache:
+                engine._reset_caches()
+            engine.output_queue.put_nowait((-1, EngineCoreOutputs(pause_ack=True)))
+            engine._pause_barrier_future = barrier_future
+
+        if not self.has_work():
+            _on_idle(self)
+        else:
+            self._idle_state_callbacks.append(_on_idle)
+
+        return barrier_future
+
     def _handle_client_request(
         self, request_type: EngineCoreRequestType, request: Any
     ) -> None:
@@ -1677,6 +1719,12 @@ class DPEngineCoreProc(EngineCoreProc):
                 if not self.engines_running:
                     logger.debug("EngineCore starting idle loop for wave %d.", new_wave)
                     self.engines_running = True
+        elif request_type == EngineCoreRequestType.ALL_PAUSED:
+            future = getattr(self, "_pause_barrier_future", None)
+            if future is not None:
+                logger.debug("ALL_PAUSED received, completing pause barrier.")
+                future.set_result(None)
+                self._pause_barrier_future = None
         else:
             super()._handle_client_request(request_type, request)
 


### PR DESCRIPTION



## Purpose

Currently, for DPEP with external load balancer, you have to call pause on all dp ranks, and then await all pauses before submitting any other collectives (weight sync, etc). This PR handles this synchronization, so if one pause returns, then we have the guarantee that all engines cores are paused and ready for collectives/weight sync.

When one engine core is finished pausing, it submits a pause message to the dp coordinator. Upon receiving pause receipts from all engine cores, it broadcasts a pause acknowledgement message to all engine cores that allows the pause function to return. 


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

