### PR TITLE
fix(quark): propagate trust_remote_code into quant config reload

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -528,7 +528,10 @@ class VllmConfig:
                     f"method {model_config.quantization}. Supported dtypes: "
                     f"{supported_dtypes}"
                 )
-            quant_config.maybe_update_config(model_config.model)
+            quant_config.maybe_update_config(
+                model_config.model,
+                trust_remote_code=model_config.trust_remote_code,
+            )
             return quant_config
         return None
 

--- a/vllm/model_executor/layers/quantization/quark/quark.py
+++ b/vllm/model_executor/layers/quantization/quark/quark.py
@@ -63,10 +63,15 @@ class QuarkConfig(QuantizationConfig):
         self.pack_method = pack_method
         self.dynamic_mxfp4_quant = False
 
-    def maybe_update_config(self, model_name: str, revision: str | None = None):
+    def maybe_update_config(
+        self,
+        model_name: str,
+        revision: str | None = None,
+        trust_remote_code: bool = False,
+    ):
         self.hf_config = get_config(
             model=model_name,
-            trust_remote_code=False,  # or get from model_config if available
+            trust_remote_code=trust_remote_code,
             revision=revision,
             config_format="auto",
         )


### PR DESCRIPTION
Quark quantization re-reads HF config via maybe_update_config(), but previously hardcoded trust_remote_code=False.\n\nThis caused models with custom code (e.g. MiniMax-M2.1-MXFP4) to fail during VllmConfig initialization even when --trust-remote-code was provided on the CLI.\n\nChanges:\n- pass model_config.trust_remote_code from VllmConfig._get_quantization_config()\n- add trust_remote_code parameter to QuarkConfig.maybe_update_config()\n- forward that value to get_config() instead of hardcoding False\n\nResult: trust_remote_code now flows consistently through the Quark path, so custom-code models load correctly when explicitly trusted.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

