### PR TITLE
[Perf] Downgrade mxfp4 triton_kernels to 3.5

### DIFF
--- a/cmake/external_projects/triton_kernels.cmake
+++ b/cmake/external_projects/triton_kernels.cmake
@@ -1,6 +1,6 @@
 # Install OpenAI triton_kernels from https://github.com/triton-lang/triton/tree/main/python/triton_kernels
 
-set(DEFAULT_TRITON_KERNELS_TAG "v3.6.0")
+set(DEFAULT_TRITON_KERNELS_TAG "v3.5.1")
 
 # Set TRITON_KERNELS_SRC_DIR for use with local development with vLLM. We expect TRITON_KERNELS_SRC_DIR to
 # be directly set to the triton_kernels python directory.

--- a/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
@@ -15,7 +15,6 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEQuantConfig,
     RoutingMethodType,
 )
-from vllm.model_executor.layers.fused_moe.lora_experts_mixin import LoRAExpertsMixin
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
@@ -28,193 +27,14 @@ from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.import_utils import has_triton_kernels
 
-from ..utils import swiglu_limit_func
-
 logger = init_logger(__name__)
-
-
-def _patch_make_bitmatrix_metadata() -> None:
-    """Monkey-patch make_bitmatrix_metadata to support non-power-of-2 top_k.
-
-    triton's tl.arange requires a power-of-2 range.  The original kernel
-    computes BLOCK_SIZE = BLOCK_PER_TOK * TOKS_PER_ROW (= 32 * top_k).  For
-    DeepSeek-V4 with top_k=6 this gives 192, which is not a power of 2 and
-    causes a compile error at the first forward pass.
-
-    Fix: define a drop-in replacement kernel that accepts an extra constexpr
-    BLOCK_SIZE_PADDED (next power of 2 >= BLOCK_SIZE) and uses it for the
-    tl.arange call while keeping the actual BLOCK_SIZE as the stride between
-    thread-blocks so that all flat indices into NonzeroIndx stay correct.
-    Elements beyond BLOCK_SIZE are masked out (col_indx = 0xffff) and ignored.
-
-    This function is called once at module load time and patches the function
-    inside the triton_kernels tensor module so that SparseMatrix.__post_init__
-    picks up the fixed version transparently.
-    """
-    import torch
-    import triton
-    import triton.language as tl
-
-    try:
-        from vllm.third_party.triton_kernels.tensor_details import (
-            bitmatrix as _bm,
-        )
-        from vllm.third_party.triton_kernels.tensor_details.bitmatrix import (
-            BitmatrixMetadata,
-            _keyed_add,
-            cdiv,
-        )
-        from vllm.third_party.triton_kernels.tensor_details.bitmatrix_details.sum_bitmatrix_rows import (  # noqa: E501
-            sum_bitmatrix_rows,
-        )
-    except ImportError:
-        return
-
-    @triton.jit
-    def _stage2_pow2(
-        ColSortedIndx,
-        RowSortedIndx,
-        NonzeroIndx,
-        n_tokens,
-        ColPartialSum,
-        stride_pm,
-        stride_pn,
-        ColOffs,
-        TOKS_PER_ROW: tl.constexpr,
-        BLOCK_PER_TOK: tl.constexpr,
-        BLOCK_SIZE_PADDED: tl.constexpr,
-    ):
-        # Actual number of elements per block (may not be a power of 2).
-        BLOCK_SIZE: tl.constexpr = BLOCK_PER_TOK * TOKS_PER_ROW
-        tl.static_assert(BLOCK_SIZE_PADDED <= 32768)
-        if isinstance(n_tokens, tl.tensor) and n_tokens.dtype.is_ptr():
-            n_tokens = tl.load(n_tokens)
-        nonzero_indx_size = n_tokens * TOKS_PER_ROW
-        pid_m = tl.program_id(0)
-        # Use BLOCK_SIZE_PADDED (a power of 2) for tl.arange, but stride by
-        # the actual BLOCK_SIZE so flat positions in NonzeroIndx are correct.
-        # Elements with offs_local >= BLOCK_SIZE have offs_global beyond the
-        # valid range, get col_indx = 0xffff, and are filtered by the mask
-        # below without producing any output.
-        offs_local = tl.arange(0, BLOCK_SIZE_PADDED)
-        offs_global = pid_m * BLOCK_SIZE + offs_local
-        mask = offs_global < nonzero_indx_size
-        col_indx = tl.load(NonzeroIndx + offs_global, mask=mask, other=-1).to(tl.uint32)
-        kv_pairs = ((col_indx << 16) | offs_local).to(tl.uint32)
-        kv_pairs = tl.sort(kv_pairs, 0)
-        col_indx = kv_pairs >> 16
-        offs_global = pid_m * BLOCK_SIZE + (kv_pairs & 0xFFFF)
-        mask = col_indx != 0xFFFF
-        x = kv_pairs & 0xFFFF0000 | 0x00000001
-        cols_and_inclusive_run_lengths = tl.associative_scan(x, 0, _keyed_add)
-        exclusive_run_lengths = (cols_and_inclusive_run_lengths - 1) & 0xFFFF
-        row_sorted_indx = tl.load(
-            ColPartialSum + pid_m * stride_pm + col_indx * stride_pn, mask=mask
-        )
-        row_sorted_indx += tl.load(ColOffs + col_indx, mask=mask)
-        row_sorted_indx += exclusive_run_lengths
-        tl.store(RowSortedIndx + offs_global, row_sorted_indx, mask=mask)
-        tl.store(ColSortedIndx + row_sorted_indx, offs_global, mask=mask)
-
-    def _make_bitmatrix_metadata_pow2_safe(nonzero_indx, bitmatrix):
-        assert nonzero_indx.ndim == 2
-        PARTIAL_BLOCK_M = 32
-        col_sum, col_partial_sum = sum_bitmatrix_rows(
-            bitmatrix, partials_block_size=PARTIAL_BLOCK_M
-        )
-        device = bitmatrix.device
-        n_indx = nonzero_indx.numel()
-        n_cols = bitmatrix.shape[1]
-        col_offs = torch.empty(n_cols, dtype=torch.int32, device=device)
-        combined_indx = torch.empty(n_indx * 2, dtype=torch.int32, device=device)
-        col_sorted_indx = combined_indx[:n_indx]
-        row_sorted_indx = combined_indx[n_indx:]
-        MEMSET_BLOCK = 1024
-        memset_grid = (cdiv(n_indx * 2, MEMSET_BLOCK) + n_cols + 1,)
-        _bm._bitmatrix_metadata_compute_stage1[memset_grid](
-            combined_indx,
-            n_indx * 2,
-            -1,
-            MEMSET_BLOCK,
-            col_sum,
-            col_offs,
-            col_sum.shape[0],
-            col_partial_sum,
-            col_partial_sum.shape[0],
-            col_partial_sum.stride(0),
-            col_partial_sum.stride(1),
-            BLOCK_M=512,
-            BLOCK_N=512,
-        )
-        toks_per_row = nonzero_indx.shape[-1]
-        block_size = PARTIAL_BLOCK_M * toks_per_row
-        # Next power of 2 >= block_size (required by tl.arange).
-        block_size_padded = 1 << (max(block_size, 1) - 1).bit_length()
-        compute_grid = (cdiv(bitmatrix.shape_max[0], PARTIAL_BLOCK_M),)
-        _stage2_pow2[compute_grid](
-            col_sorted_indx,
-            row_sorted_indx,
-            nonzero_indx,
-            bitmatrix.shape[0],
-            col_partial_sum,
-            col_partial_sum.stride(0),
-            col_partial_sum.stride(1),
-            col_offs,
-            TOKS_PER_ROW=toks_per_row,
-            BLOCK_PER_TOK=PARTIAL_BLOCK_M,
-            BLOCK_SIZE_PADDED=block_size_padded,
-        )
-        return BitmatrixMetadata(
-            col_sum=col_sum,
-            col_sorted_indx=col_sorted_indx,
-            row_sorted_indx=row_sorted_indx,
-        )
-
-    # The most reliable patch point: SparseMatrix.__post_init__ looks up
-    # make_bitmatrix_metadata via its own __globals__ dict (the tensor.py
-    # module dict).  Patching through __globals__ works regardless of how
-    # sys.modules maps "triton_kernels.tensor" vs
-    # "vllm.third_party.triton_kernels.tensor".
-    from triton_kernels.tensor import SparseMatrix as _SparseMatrix
-
-    _SparseMatrix.__post_init__.__globals__["make_bitmatrix_metadata"] = (
-        _make_bitmatrix_metadata_pow2_safe
-    )
-    # Also patch the bitmatrix module itself in case it is imported directly.
-    _bm.make_bitmatrix_metadata = _make_bitmatrix_metadata_pow2_safe
-
-
-use_legacy_triton_kernels = False
 
 if has_triton_kernels():
     try:
         import triton_kernels.swiglu
-        from triton_kernels.matmul_ogs import (
-            FnSpecs,
-            FusedActivation,
-            GatherIndx,
-            RoutingData,
-            ScatterIndx,
-            matmul_ogs,
-        )
-        from triton_kernels.tensor import (
-            BIT,
-            Bitmatrix,
-        )
-
-        try:
-            from triton_kernels.tensor import (
-                SparseMatrix,
-                make_ragged_tensor_metadata,
-            )
-        except ImportError:
-            if current_platform.is_rocm():
-                logger.warning_once("Using legacy triton_kernels on ROCm")
-                use_legacy_triton_kernels = True
-            else:
-                raise
-        if not use_legacy_triton_kernels:
-            _patch_make_bitmatrix_metadata()
+        from triton_kernels.matmul_ogs import FnSpecs, FusedActivation, matmul_ogs
+        from triton_kernels.routing import RoutingData, routing, routing_from_bitmatrix
+        from triton_kernels.tensor import Bitmatrix
     except (AttributeError, ImportError) as e:
         logger.error(
             "Failed to import Triton kernels. Please make sure your triton "
@@ -315,22 +135,17 @@ def triton_kernel_moe_forward(
             unpadded_K_w2=unpadded_K_w2,
         )
 
-    from triton_kernels.topk import topk as topk_fn
-
     sm_first = not renormalize
-    logits = gating_output
-    if sm_first:
-        logits = torch.softmax(logits, dim=-1)
-    topk_result = topk_fn(logits, topk, apply_softmax=not sm_first)
-    # topk may return a tuple (vals, indx, bitmatrix) or a
-    # SparseMatrix depending on the triton_kernels version.
-    if isinstance(topk_result, tuple):
-        topk_weights, topk_ids_raw, _ = topk_result
-    else:
-        topk_weights = topk_result.vals
-        topk_ids_raw = topk_result.indx
-
     if expert_map is not None:
+        from triton_kernels.topk import topk as topk_fn
+
+        logits = gating_output
+        if sm_first:
+            logits = torch.softmax(logits, dim=-1)
+        topk_weights, topk_ids_raw, _ = topk_fn(
+            logits, topk, apply_softmax=not sm_first
+        )
+
         # topk_ids_raw contains global expert IDs - remap to local.
         topk_ids = expert_map[topk_ids_raw.to(torch.long)]
         local_num_experts = w1.shape[0]
@@ -341,9 +156,8 @@ def triton_kernel_moe_forward(
         effective_expert_map = None
         effective_global_num_experts = local_num_experts
     else:
-        topk_ids = topk_ids_raw.to(torch.long)
-        routing_data, gather_idx, scatter_idx = make_routing_data(
-            topk_ids, topk_weights, gating_output.shape[-1]
+        routing_data, gather_idx, scatter_idx = routing(
+            gating_output, topk, sm_first=sm_first
         )
         effective_expert_map = expert_map
         effective_global_num_experts = global_num_experts
@@ -426,22 +240,10 @@ def triton_kernel_fused_experts(
     )
     output_tensor = _resize_cache(output_tensor, (batch_dim, M, K))
 
-    act = (
-        FusedActivation(
-            FnSpecs(
-                "swiglu",
-                triton_kernels.swiglu.swiglu_fn,
-                ("alpha", "limit"),
-                reduction_n=2,
-            ),
-            (swiglu_alpha, swiglu_limit),
-        )
-        if not use_legacy_triton_kernels
-        else FusedActivation(
-            FnSpecs("swiglu", triton_kernels.swiglu.swiglu_fn, ("alpha", "limit")),
-            (swiglu_alpha, swiglu_limit),
-            2,
-        )
+    act = FusedActivation(
+        FnSpecs("swiglu", triton_kernels.swiglu.swiglu_fn, ("alpha", "limit")),
+        (swiglu_alpha, swiglu_limit),
+        2,
     )
     gammas = routing_data.gate_scal if routing_data else None
 
@@ -595,47 +397,18 @@ def make_routing_data(
 
     bitmatrix_shape = [n_rows, bm_cols * 32]
     bitmatrix_shape_max = [n_rows, None]
-    bitmatrix = (
-        Bitmatrix(
-            bitmatrix, dtype=BIT, shape=bitmatrix_shape, shape_max=bitmatrix_shape_max
-        )
-        if not use_legacy_triton_kernels
-        else Bitmatrix(
-            bitmatrix,
-            shape=bitmatrix_shape,
-            shape_max=bitmatrix_shape_max,
-            scratchpad=None,
-        )
+    bitmatrix = Bitmatrix(
+        bitmatrix,
+        shape=bitmatrix_shape,
+        shape_max=bitmatrix_shape_max,
+        scratchpad=None,
     )
 
     # matmul_ogs expects invalid topk_weights to be -1s
     topk_weights = torch.where(topk_ids == -1, -1.0, topk_weights)
-
-    if use_legacy_triton_kernels:
-        from triton_kernels.routing import routing_from_bitmatrix
-
-        return routing_from_bitmatrix(
-            bitmatrix, topk_weights, topk_ids, num_local_experts, num_topk
-        )
-
-    sparse_logits = SparseMatrix(indx=topk_ids, vals=topk_weights, mask=bitmatrix)
-    dispatch_indx = sparse_logits.mask_metadata.row_sorted_indx
-    combine_indx = sparse_logits.mask_metadata.col_sorted_indx
-    ragged_batch_metadata = make_ragged_tensor_metadata(
-        sparse_logits.mask_metadata.col_sum,
-        dispatch_indx.shape[0],
+    return routing_from_bitmatrix(
+        bitmatrix, topk_weights, topk_ids, num_local_experts, num_topk
     )
-    gate_scal = sparse_logits.vals.flatten()[combine_indx]
-    routing_data = RoutingData(
-        gate_scal,
-        ragged_batch_metadata.block_sizes,
-        num_local_experts,
-        num_topk,
-        ragged_batch_metadata,
-    )
-    gather_indx = GatherIndx(combine_indx, dispatch_indx)
-    scatter_indx = ScatterIndx(dispatch_indx, combine_indx)
-    return routing_data, gather_indx, scatter_indx
 
 
 class BaseOAITritonExperts(mk.FusedMoEExpertsModular):
@@ -653,8 +426,6 @@ class BaseOAITritonExperts(mk.FusedMoEExpertsModular):
             return False
         # (9,0) <= cap < (11,0) covers CUDA SM90 (Hopper), SM100+ (Blackwell)
         # and ROCm gfx942/gfx950 (which map to 9.4/9.5).
-        if not has_triton_kernels():
-            return False
         return (9, 0) <= (cap.major, cap.minor) < (11, 0)
 
     @staticmethod
@@ -812,7 +583,7 @@ class OAITritonExperts(BaseOAITritonExperts):
         )
 
 
-class UnfusedOAITritonExperts(LoRAExpertsMixin, BaseOAITritonExperts):
+class UnfusedOAITritonExperts(BaseOAITritonExperts):
     """
     A Triton based MoE expert class that operates on expert standard
     format and explicitly keeps the activation and reduction (moe_sum) steps
@@ -856,37 +627,6 @@ class UnfusedOAITritonExperts(LoRAExpertsMixin, BaseOAITritonExperts):
     def moe_sum(self, input: torch.Tensor, output: torch.Tensor):
         ops.moe_sum(input, output)
 
-    def activation(
-        self,
-        activation: MoEActivation,
-        output: torch.Tensor,
-        input: torch.Tensor,
-    ) -> None:
-        quant_config = self.quant_config or FUSED_MOE_UNQUANTIZED_CONFIG
-        if activation == MoEActivation.SWIGLUOAI:
-            alpha = (
-                quant_config.gemm1_alpha
-                if quant_config.gemm1_alpha is not None
-                else 1.702
-            )
-            limit = (
-                quant_config.gemm1_clamp_limit
-                if quant_config.gemm1_clamp_limit is not None
-                else 7.0
-            )
-            torch.ops._C.swigluoai_and_mul(output, input, alpha, limit)
-        elif (
-            activation == MoEActivation.SILU
-            and quant_config.gemm1_clamp_limit is not None
-        ):
-            swiglu_limit_func(
-                output,
-                input,
-                quant_config.gemm1_clamp_limit,
-            )
-        else:
-            super().activation(activation, output, input)
-
     def apply(
         self,
         output: torch.Tensor,
@@ -910,7 +650,6 @@ class UnfusedOAITritonExperts(LoRAExpertsMixin, BaseOAITritonExperts):
         if quant_config is None:
             quant_config = FUSED_MOE_UNQUANTIZED_CONFIG
 
-        global_topk_ids = topk_ids
         if expert_map is not None:
             topk_ids = expert_map[topk_ids]
 
@@ -965,45 +704,15 @@ class UnfusedOAITritonExperts(LoRAExpertsMixin, BaseOAITritonExperts):
             y=intermediate_cache1,
         )
 
-        # w13 LoRA: gather the activation input from expert-sorted
-        # intermediate_cache1, then add the LoRA delta in-place on that copy
-        # before passing it to activation — exactly mirroring the old
-        # decorator approach which modified the gathered tensor in-place.
-        act_input = intermediate_cache1.view(-1, N)[gather_indx.dst_indx]
-
-        sorted_token_ids_lora = None
-        expert_ids_lora = None
-        num_tokens_post_padded_lora = None
-        token_lora_mapping = None
-        lora_context = self._lora_context
-        if lora_context is not None:
-            (
-                sorted_token_ids_lora,
-                expert_ids_lora,
-                num_tokens_post_padded_lora,
-                token_lora_mapping,
-            ) = self.apply_w13_lora(
-                lora_context,
-                y=act_input,
-                x=hidden_states,
-                topk_ids=global_topk_ids,
-                topk_weights=topk_weights,
-                expert_map=expert_map,
-                w1=w1,
-                w2=w2,
-                num_tokens=M,
-                top_k_num=topk,
-            )
-
         self.activation(
             activation,
             intermediate_cache2,
-            act_input,
+            intermediate_cache1.view(-1, N)[gather_indx.dst_indx],
         )
 
-        # matmul_ogs grouped reduction fuses sum across multiple experts:
+        # matmul_ogs grouped reduction fuse sum across multiple experts:
         # y[dst_indx // n_expts_act, :] += x
-        # Set n_expts_act to 1 to unfuse the sum so we can do it manually via moe_sum.
+        # Need to set n_expts_act to 1 to unfuse moe_sum
         routing_data.n_expts_act = 1
 
         matmul_ogs(
@@ -1016,24 +725,6 @@ class UnfusedOAITritonExperts(LoRAExpertsMixin, BaseOAITritonExperts):
             gammas=None if apply_router_weight_on_input else gammas,
             y=intermediate_cache3,
         )
-
-        # w2 LoRA: after matmul_ogs with scatter_indx, intermediate_cache3 is
-        # in token-topk order, matching the (M, topk, K) layout add_lora_w2 expects.
-        if lora_context is not None:
-            self.apply_w2_lora(
-                lora_context,
-                y=intermediate_cache3.view(-1, topk, K),
-                x=intermediate_cache2,
-                topk_weights=topk_weights,
-                sorted_token_ids_lora=sorted_token_ids_lora,
-                expert_ids_lora=expert_ids_lora,
-                num_tokens_post_padded_lora=num_tokens_post_padded_lora,
-                token_lora_mapping=token_lora_mapping,
-                num_tokens=M,
-                w1=w1,
-                w2=w2,
-                top_k_num=topk,
-            )
 
         self.moe_sum(intermediate_cache3.view(-1, topk, K), output)
 
@@ -1067,8 +758,6 @@ class OAITritonMxfp4ExpertsMonolithic(mk.FusedMoEExpertsMonolithic):
             return False
         # (9,0) <= cap < (11,0) covers CUDA SM90 (Hopper), SM100+ (Blackwell)
         # and ROCm gfx942/gfx950 (which map to 9.4/9.5).
-        if not has_triton_kernels():
-            return False
         return (9, 0) <= (cap.major, cap.minor) < (11, 0)
 
     @staticmethod


### PR DESCRIPTION



## Purpose

triton_kernels was upgraded to 3.6.0 in #30525. This caused more than 30% performance regression at batch size 1, because triton_kernels 3.6.0 has much worse performance than 3.5. So this PR downgrade triton_kernels back to 3.5.1.

## Test Plan

```
pytest -s -v tests/kernels/moe/test_gpt_oss_triton_kernels.py
```

## Benchmarking

Benchmarked on H200.

```
vllm serve /opt/dlami/nvme/models/gpt-oss-20b \
  --tensor-parallel-size 1 \
  --max-num-seqs 16 \
  --no-enable-prefix-caching
```

Main:

concurrency=1

```
============ Serving Benchmark Result ============
Successful requests:                     60        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  75.04     
Total input tokens:                      15599     
Total generated tokens:                  18000     
Request throughput (req/s):              0.80      
Output token throughput (tok/s):         239.87    
Peak output token throughput (tok/s):    243.00    
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          447.75    
---------------Time to First Token----------------
Mean TTFT (ms):                          17.94     
Median TTFT (ms):                        17.85     
P99 TTFT (ms):                           28.54     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          4.12      
Median TPOT (ms):                        4.12      
P99 TPOT (ms):                           4.13      
---------------Inter-token Latency----------------
Mean ITL (ms):                           4.12      
Median ITL (ms):                         4.12      
P99 ITL (ms):                            4.44      
==================================================
```

concurrency=16

```
============ Serving Benchmark Result ============
Successful requests:                     960       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  137.76    
Total input tokens:                      217301    
Total generated tokens:                  288000    
Request throughput (req/s):              6.97      
Output token throughput (tok/s):         2090.54   
Peak output token throughput (tok/s):    2448.00   
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          3667.89   
---------------Time to First Token----------------
Mean TTFT (ms):                          123.38    
Median TTFT (ms):                        74.02     
P99 TTFT (ms):                           742.44    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          7.26      
Median TPOT (ms):                        7.09      
P99 TPOT (ms):                           9.45      
---------------Inter-token Latency----------------
Mean ITL (ms):                           7.26      
Median ITL (ms):                         6.97      
P99 ITL (ms):                            9.70      
==================================================
```

PR:

concurrency=1

```
============ Serving Benchmark Result ============
Successful requests:                     60        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  55.57     
Total input tokens:                      15599     
Total generated tokens:                  18000     
Request throughput (req/s):              1.08      
Output token throughput (tok/s):         323.91    
Peak output token throughput (tok/s):    327.00    
Peak concurrent requests:                3.00      
Total token throughput (tok/s):          604.61    
---------------Time to First Token----------------
Mean TTFT (ms):                          17.90     
Median TTFT (ms):                        17.82     
P99 TTFT (ms):                           28.78     
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          3.04      
Median TPOT (ms):                        3.04      
P99 TPOT (ms):                           3.05      
---------------Inter-token Latency----------------
Mean ITL (ms):                           3.04      
Median ITL (ms):                         3.04      
P99 ITL (ms):                            3.41      
==================================================
```

concurrency=16

```
============ Serving Benchmark Result ============
Successful requests:                     960       
Failed requests:                         0         
Maximum request concurrency:             16        
Benchmark duration (s):                  118.07    
Total input tokens:                      217301    
Total generated tokens:                  288000    
Request throughput (req/s):              8.13      
Output token throughput (tok/s):         2439.18   
Peak output token throughput (tok/s):    2944.00   
Peak concurrent requests:                32.00     
Total token throughput (tok/s):          4279.59   
---------------Time to First Token----------------
Mean TTFT (ms):                          132.54    
Median TTFT (ms):                        39.41     
P99 TTFT (ms):                           653.21    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          6.14      
Median TPOT (ms):                        5.92      
P99 TPOT (ms):                           7.95      
---------------Inter-token Latency----------------
Mean ITL (ms):                           6.14      
Median ITL (ms):                         5.78      
P99 ITL (ms):                            10.37     
==================================================
```

## Accuracy Testing

```
OPENAI_API_KEY=EMPTY python3 -m gpt_oss.evals --model /opt/dlami/nvme/models/gpt-oss-20b --eval gpqa --n-threads 200 --reasoning-effort low
```

Main:

```
{'chars': np.float64(60.72348484848485), 'chars:std': np.float64(222.8212538462918), 'score': np.float64(0.5669191919191919), 'score:std': np.float64(0.4955015860245882)}
Writing results to /tmp/gpqa___opt__dlami__nvme__models__gpt-oss-20b-low_temp1.0_20260406_235002.json
Writing all results to /tmp/gpqa___opt__dlami__nvme__models__gpt-oss-20b-low_temp1.0_20260406_235002_allresults.json
[{'eval_name': 'gpqa', 'model_name': '__opt__dlami__nvme__models__gpt-oss-20b-low_temp1.0_20260406_235002', 'metric': 0.5669191919191919}]
```

PR:

```
{'chars': np.float64(66.51010101010101), 'chars:std': np.float64(239.0948997994119), 'score': np.float64(0.571969696969697), 'score:std': np.float64(0.49479325249854617)}
Writing results to /tmp/gpqa___opt__dlami__nvme__models__gpt-oss-20b-low_temp1.0_20260407_202524.json
Writing all results to /tmp/gpqa___opt__dlami__nvme__models__gpt-oss-20b-low_temp1.0_20260407_202524_allresults.json
[{'eval_name': 'gpqa', 'model_name': '__opt__dlami__nvme__models__gpt-oss-20b-low_temp1.0_20260407_202524', 'metric': 0.571969696969697}]
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

