### PR TITLE
fix(run_batch): handle ORJSONResponse when orjson is installed

### DIFF
--- a/vllm/entrypoints/openai/run_batch.py
+++ b/vllm/entrypoints/openai/run_batch.py
@@ -22,7 +22,7 @@ from prometheus_client import start_http_server
 from pydantic import Field, TypeAdapter, field_validator, model_validator
 from pydantic_core.core_schema import ValidationInfo
 from starlette.datastructures import State
-from starlette.responses import JSONResponse
+from starlette.responses import JSONResponse, StreamingResponse
 from tqdm import tqdm
 from urllib3.util import parse_url
 
@@ -542,7 +542,10 @@ async def run_request(
     except Exception as e:
         response = create_error_response(e)
 
-    if isinstance(response, JSONResponse):
+    # Handle both JSONResponse and ORJSONResponse (used when orjson is installed).
+    # ORJSONResponse inherits from Response directly, not from JSONResponse, so
+    # we check for any non-streaming response that carries a JSON body.
+    if not isinstance(response, StreamingResponse) and hasattr(response, "body"):
         with contextlib.suppress(pydantic.ValidationError):
             response = TypeAdapter(AllResponse | ErrorResponse).validate_python(
                 json.loads(response.body)


### PR DESCRIPTION
## Summary

`vllm run-batch` fails with `"Request must not be sent in stream mode"` for embedding requests (`/v1/embeddings`) when `orjson` is installed, even though the requests have no `stream` flag set.

### Root Cause

`vllm/entrypoints/pooling/utils.py` returns `ORJSONResponse` instead of `JSONResponse` when `orjson` is available:

```python
def get_json_response_cls() -> type[JSONResponse]:
    if importlib.util.find_spec("orjson") is not None:
        from fastapi.responses import ORJSONResponse
        return ORJSONResponse  # <-- not a subclass of JSONResponse
    return JSONResponse
```

`ORJSONResponse` inherits directly from `Response`, **not** from `JSONResponse`. So the check in `run_request()`:

```python
if isinstance(response, JSONResponse):   # False for ORJSONResponse
```

silently fails, the response is never parsed back to an `EmbeddingResponse`, and the function falls into the `else` branch:

```python
else:
    make_error_request_output(request, error_msg="Request must not be sent in stream mode")
```

### Fix

Replace the `isinstance(response, JSONResponse)` check with a check that covers any non-streaming response that carries a JSON body — i.e., both `JSONResponse` and `ORJSONResponse`:

```python
if not isinstance(response, StreamingResponse) and hasattr(response, "body"):
```

### How to reproduce

```bash
pip install orjson vllm
echo '{"custom_id":"r1","method":"POST","url":"/v1/embeddings","body":{"model":"<embed-model>","input":"hello"}}' > batch.jsonl
python -m vllm.entrypoints.openai.run_batch -i batch.jsonl -o out.jsonl --model <embed-model>
# Output: {"error": {"message": "Request must not be sent in stream mode", ...}}
```

Removing `orjson` makes the same command succeed.