### PR TITLE
Fix FullAttentionSpec.max_memory_usage_bytes() to respect sliding_window

### DIFF
--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -169,6 +169,10 @@ class FullAttentionSpec(AttentionSpec):
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         max_model_len = vllm_config.model_config.max_model_len
+        # Respect sliding window: layers converted from SlidingWindowSpec
+        # only need sliding_window tokens, not the full context length.
+        if self.sliding_window is not None:
+            max_model_len = min(self.sliding_window, max_model_len)
         dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size
         pcp_world_size = vllm_config.parallel_config.prefill_context_parallel_size
         # Note(hc): each dcp rank only need save


### PR DESCRIPTION
## Summary

- `FullAttentionSpec.max_memory_usage_bytes()` ignores the `sliding_window` field, causing converted SlidingWindowSpec layers to claim `max_model_len` tokens of memory instead of `sliding_window` tokens
- This vastly overestimates KV cache memory for hybrid models (e.g. Gemma 4) when `disable_hybrid_kv_cache_manager=True`

## Root Cause

`unify_hybrid_kv_cache_specs()` converts `SlidingWindowSpec` → `FullAttentionSpec` preserving `sliding_window` (line 1199 of `kv_cache_utils.py`), but `FullAttentionSpec.max_memory_usage_bytes()` never reads it.

## Fix

Two lines added to `vllm/v1/kv_cache_interface.py`:
```python
if self.sliding_window is not None:
    max_model_len = min(self.sliding_window, max_model_len)
```

## Impact

Gemma 4 31B on RTX 5090 (32GB): max context increases from **64K → 93K** (+45%).
Gemma 4 26B-A4B MoE: enables **128K context** on a single GPU.

## Test plan

- [ ] Verify hybrid model (Gemma 4) loads at higher max_model_len with `disable_hybrid_kv_cache_manager=True`
- [ ] Verify non-hybrid models are unaffected (`sliding_window=None` → no change)
- [ ] Verify sliding window compute is still correct (only allocation changes, not attention)