### PR TITLE
Increase robustness for triton moe kernel benchmark to ignore/continue w/ Triton known issue

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -4,6 +4,7 @@
 import argparse
 import gc
 import json
+import logging
 import os
 import time
 from contextlib import nullcontext
@@ -35,6 +36,8 @@ from vllm.transformers_utils.config import get_config
 from vllm.triton_utils import triton
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.utils.torch_utils import set_random_seed
+
+logger = logging.getLogger(__name__)
 
 FP8_DTYPE = current_platform.fp8_dtype()
 

--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -630,7 +630,9 @@ class BenchmarkWorker:
             # Ray restricts each worker to one GPU; use local index 0
             torch.accelerator.device_index(0) if need_device_guard else nullcontext()
         ):
-            for idx, config in enumerate(tqdm(search_space)):
+            for idx, config in enumerate(
+                tqdm(search_space, desc=f"batch_size={num_tokens}", unit="cfg")
+            ):
                 try:
                     kernel_time = benchmark_config(
                         config,
@@ -649,7 +651,20 @@ class BenchmarkWorker:
                     )
                 except triton.runtime.autotuner.OutOfResources:
                     # Some configurations may be invalid and fail to compile.
+                    logger.debug(
+                        "OutOfResources exception for config %s, skip this config.",
+                        config,
+                    )
                     continue
+                except RuntimeError as e:
+                    if "PassManager::run failed" in str(e):
+                        logger.debug(
+                            "RuntimeError for config %s, skip this config. Error is: %s",
+                            config,
+                            e,
+                        )
+                        continue
+                    raise
 
                 if kernel_time < best_time:
                     best_time = kernel_time

--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -662,10 +662,11 @@ class BenchmarkWorker:
                 except RuntimeError as e:
                     if "PassManager::run failed" in str(e):
                         logger.debug(
-                            "RuntimeError for config %s, skip this config. Error is: %s",
-                            config,
-                            e,
-                        )
+                        "RuntimeError for config %s, skip this config. "
+                        "Error is: %s",
+                        config,
+                        e,
+                    )
                         continue
                     raise
 

--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -662,11 +662,11 @@ class BenchmarkWorker:
                 except RuntimeError as e:
                     if "PassManager::run failed" in str(e):
                         logger.debug(
-                        "RuntimeError for config %s, skip this config. "
-                        "Error is: %s",
-                        config,
-                        e,
-                    )
+                            "RuntimeError for config %s, skip this config. "
+                            "Error is: %s",
+                            config,
+                            e,
+                        )
                         continue
                     raise
 


### PR DESCRIPTION


## Purpose

when running `python3 benchmarks/kernels/benchmark_moe.py --model  XXX  --tp-size 8  --tune `, not only the expected OutOfResource exception, but also lots of `PassManager::run failed` **raised** from Triton, and **break/stop** the whole benchmark process.

This `PassManager::run failed` error is not from vLLM, but Triton compiling MLIR Pass pipeline crash.
it's due to some known Triton  issue like https://github.com/triton-lang/triton/issues/9928 and/or https://github.com/triton-lang/triton/issues/9809 , introduced from 3.3.0 and impacted from 3.3.0-3.6.0, expected to be fixed in >= 3.6.1 (hope so ??...)



Error keywords: 

`TritonGPURemoveLayoutConversions`, reporting `SSA dominance violation： operand #0 does not dominate this use `

Reason: 

by Triton PR  `Cleanup IR after backward remat in RemoveLayoutConversions` (#5659)  , introduces a illegal IR SSA dominance violation, when Pipeline failed while executing [`TritonGPURemoveLayoutConversions` on 'builtin.module' operation]


My Test Env:

```
Driver Version: 575.57.08      
CUDA Version: 12.9
triton: 3.6.0
vLLM 0.17.0 (image) and 0.19.0 (image)
```

Error details:
```

 /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/fused_moe.py:574:24: error: operand #0 does not dominate this use
     c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
                        ^              
 /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/fused_moe.py:508:28: note: operand defined here (op in a child region)
             mask=token_mask[:, None] & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
                            ^          
 module {                              
   tt.func public @fused_moe_kernel(%arg0: !t............................. {
     %c63_i32 = arith.constant 63 : i32
 ..............................................
     tt.return                         
   }                                   
 }                                     
                                       
 {-#                                   
   external_resources: {               
     mlir_reproducer: {                
       pipeline: "builtin.module(convert-triton-to-tritongpu{enable-source-remat=false num-ctas=1 num-warps=4 target=cuda:120 threads-per-warp=32}, tritongpu-coalesce, tritongpu-F32DotTC{emu-tf32=true}, triton-nvidia-gpu-plan-cta, tritongpu-remove-layout-conversions, tritongpu-optimize-thread-locality, tritongpu-accelerate-matmul, tritongpu-remove-layout-conversions, tritongpu-optimize-dot-operands{hoist-layout-conversion=true}, triton-nvidia-optimize-descriptor-encoding, triton-loop-aware-cse, tritongpu-fuse-nested-loops, canonicalize{  max-iterations=10 max-num-rewrites=-1 region-simplify=normal test-convergence=false top-down=true}, triton-licm, tritongpu-optimize-accumulator-init, tritongpu-hoist-tmem-alloc{hoist-out-of-if=false}, tritongpu-promote-lhs-to-tmem, tritongpu-assign-latencies{num-stages=2}, tritongpu-schedule-loops, tritongpu-automatic-warp-specialization{num-stages=2}, tritongpu-pipeline{dump-intermediate-steps=false num-stages=2}, tritongpu-optimize-partition-warps, tritongpu-combine-tensor-select-and-if, tritongpu-hoist-tmem-alloc{hoist-out-of-if=true}, triton-nvidia-gpu-remove-tmem-tokens, canonicalize{  max-iterations=10 max-num-rewrites=-1 region-simplify=normal test-convergence=false top-down=true}, triton-loop-aware-cse, tritongpu-prefetch, tritongpu-optimize-dot-operands{hoist-layout-conversion=true}, tritongpu-coalesce-async-copy, triton-nvidia-optimize-tmem-layouts, triton-nvidia-tma-lowering, tritongpu-remove-layout-conversions, triton-nvidia-interleave-tmem, tritongpu-reduce-data-duplication, tritongpu-reorder-instructions, triton-loop-aware-cse, symbol-dce, triton-nvidia-gpu-fence-insertion{compute-capability=120}, triton-nvidia-mma-lowering, sccp, cse, canonicalize{  max-iterations=10 max-num-rewrites=-1 region-simplify=normal test-convergence=false top-down=true})",
       disable_threading: true,        
       verify_each: true               
     }                                 
   }                                   
 #-}                                   
 /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/fused_moe.py:315:0: error: Failures have been detected while processing an MLIR pass pipeline
 /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/fused_moe.py:315:0: note: Pipeline failed while executing [`TritonGPURemoveLayoutConversions` on 'builtin.module' operation]: reproducer generated at `std::errs, please share the reproducer above with Triton project.`

ERROR 04-07 07:43:39 [benchmark_moe.py:652] RuntimeError for config {'BLOCK_SIZE_M': 256, 'BLOCK_SIZE_N': 64, 'BLOCK_SIZE_K': 64, 'GROUP_SIZE_M': 1, 'num_warps': 4, 'num_stages': 2},  RuntimeError: PassManager::run failed

```






-----------
By the way , adding more clear tqdm with `batch_size` prefix , otherwise, dozes of tqdm progress bar shows up and mess together ...
```
(pid=12533) batch_size=1: 100%|██████████| 1.92k/1.92k [59:32<00:00, 1.86s/cfg]/s]
(pid=12533) batch_size=3072:  99%|█████████▉| 1.90k/1.92k [04:09<00:02, 7.62cfg/s]
(pid=12533) batch_size=64:  99%|█████████▉| 1.91k/1.92k [05:22<00:02, 5.90cfg/s]s]
(pid=12534) batch_size=2048: 100%|█████████▉| 1.92k/1.92k [04:09<00:00, 7.68cfg/s]
(pid=12534) batch_size=48: 100%|██████████| 1.92k/1.92k [59:32<00:00, 1.86s/cfg]
(pid=12536) batch_size=2: 100%|██████████| 1.92k/1.92k [59:32<00:00, 1.86s/cfg]
(pid=12536) batch_size=4096:  99%|█████████▉| 1.91k/1.92k [04:07<00:01, 7.71cfg/s]
(pid=12536) batch_size=96: 100%|██████████| 1.92k/1.92k [05:39<00:00, 5.65cfg/s]
(pid=12539) batch_size=128: 100%|██████████| 1.92k/1.92k [05:39<00:00, 5.66cfg/s]
(pid=12539) batch_size=4: 100%|██████████| 1.92k/1.92k [59:32<00:00, 1.86s/cfg]
(pid=12540) batch_size=1536:  99%|█████████▉| 1.91k/1.92k [04:10<00:01, 7.61cfg/s]
(pid=12540) batch_size=32: 100%|██████████| 1.92k/1.92k [59:31<00:00, 1.86s/cfg]
(pid=12542) batch_size=16: 100%|██████████| 1.92k/1.92k [59:32<00:00, 1.86s/cfg]s]
(pid=12542) batch_size=512:  93%|█████████▎| 1.79k/1.92k [04:09<00:18, 7.18cfg/s]
(pid=12543) batch_size=1024:  99%|█████████▉| 1.91k/1.92k [04:07<00:01, 7.70cfg/s]
(pid=12543) batch_size=24: 100%|██████████| 1.92k/1.92k [59:31<00:00, 1.86s/cfg]
(pid=12548) batch_size=256: 100%|█████████▉| 1.92k/1.92k [04:11<00:00, 7.63cfg/s]]
(pid=12548) batch_size=8: 100%|██████████| 1.92k/1.92k [59:32<00:00, 1.86s/cfg]/s]
```








## Test Plan


same configuration and version, the  `PassManager::run failed` captured and ignored. 

```
export VLLM_MOE_TUNE_CACHE_CLEAR_INTERVAL=0;
export FOLDER=/mnt/nfs/peter/moe_configs_5090-qwen3-vl30b-a3b-tp8;
mkdir -p $FOLDER;
python3 benchmarks/kernels/benchmark_moe.py --model  /mnt/nfs/model/Qwen/Qwen3-VL-30B-A3B-Instruct/  --tp-size 8  --tune  --save-dir  $FOLDER   2>&1 | tee $FOLDER/benchmark.log
```


## Test Result


```
grep "OutOfResource" benchmark.log | wc -l
630
grep "PassManager::run" benchmark.log | wc -l         <------------- captured
334
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
