### PR TITLE
[Bugfix] Inconsistent tool-calling behavior between Chat Completions …

### DIFF
--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -877,3 +877,97 @@ class TestStreamingReasoningToContentTransition:
         ]
         assert len(item_done_events) == 1
         assert isinstance(item_done_events[0].item, ResponseReasoningItem)
+
+
+# Minimal function tool dict, mirrors GET_WEATHER_SCHEMA used in other tests.
+_FUNCTION_TOOL = {
+    "type": "function",
+    "name": "get_weather",
+    "description": "Get the current weather.",
+    "parameters": {
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+        "required": ["location"],
+        "additionalProperties": False,
+    },
+    "strict": True,
+}
+
+
+class TestToolChoiceValidation:
+    """Test that _validate_create_responses_input rejects tool_choice settings
+    that require a tool parser when none is configured, mirroring the 400
+    behaviour of the Chat Completions endpoint."""
+
+    @pytest.fixture
+    def serving_no_tool_parser(self):
+        """OpenAIServingResponses with no tool parser and no harmony model."""
+        engine_client = MagicMock()
+        model_config = MagicMock()
+        model_config.max_model_len = 4096
+        model_config.hf_config.model_type = "llama"  # non-harmony
+        model_config.get_diff_sampling_param.return_value = {}
+        engine_client.model_config = model_config
+        engine_client.input_processor = MagicMock()
+        engine_client.io_processor = MagicMock()
+        engine_client.renderer = MagicMock()
+
+        return OpenAIServingResponses(
+            engine_client=engine_client,
+            models=MagicMock(),
+            openai_serving_render=MagicMock(),
+            request_logger=None,
+            chat_template=None,
+            chat_template_content_format="auto",
+            # No tool_parser, no enable_auto_tools → tool parsing unavailable.
+            enable_auto_tools=False,
+            tool_parser=None,
+        )
+
+    def test_auto_tool_choice_without_tool_parser_returns_error(
+        self, serving_no_tool_parser
+    ):
+        """tool_choice='auto' with tools but no --tool-call-parser → 400."""
+        request = ResponsesRequest(
+            input="What's the weather?",
+            tools=[_FUNCTION_TOOL],
+            tool_choice="auto",
+        )
+        error = serving_no_tool_parser._validate_create_responses_input(request)
+        assert error is not None
+        assert "auto" in error.error.message
+        assert "--tool-call-parser" in error.error.message
+
+    def test_required_tool_choice_without_tool_parser_returns_error(
+        self, serving_no_tool_parser
+    ):
+        """tool_choice='required' with tools but no --tool-call-parser → 400."""
+        request = ResponsesRequest(
+            input="What's the weather?",
+            tools=[_FUNCTION_TOOL],
+            tool_choice="required",
+        )
+        error = serving_no_tool_parser._validate_create_responses_input(request)
+        assert error is not None
+        assert "required" in error.error.message
+        assert "--tool-call-parser" in error.error.message
+
+    def test_none_tool_choice_skips_validation(self, serving_no_tool_parser):
+        """tool_choice='none' should never require a tool parser."""
+        request = ResponsesRequest(
+            input="Hello",
+            tools=[_FUNCTION_TOOL],
+            tool_choice="none",
+        )
+        error = serving_no_tool_parser._validate_create_responses_input(request)
+        assert error is None
+
+    def test_empty_tools_skips_validation(self, serving_no_tool_parser):
+        """No tools provided → validation should be skipped entirely."""
+        request = ResponsesRequest(
+            input="Hello",
+            tools=[],
+            tool_choice="auto",
+        )
+        error = serving_no_tool_parser._validate_create_responses_input(request)
+        assert error is None

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -122,6 +122,7 @@ from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers import ToolParser
 from vllm.utils import random_uuid
 from vllm.utils.collection_utils import as_list
+from vllm.utils.mistral import is_mistral_tokenizer
 
 logger = init_logger(__name__)
 
@@ -321,6 +322,37 @@ class OpenAIServingResponses(OpenAIServing):
                 status_code=HTTPStatus.BAD_REQUEST,
                 param="previous_response_id",
             )
+        # Validate tool_choice when tool parsing is required but unavailable
+        if request.tools and request.tool_choice != "none":
+            tool_parser_cls = self.parser.tool_parser_cls if self.parser else None
+            tokenizer = self.renderer.get_tokenizer()
+            tool_parsing_unavailable = (
+                tool_parser_cls is None
+                and not is_mistral_tokenizer(tokenizer)
+                and not self.use_harmony
+            )
+            if tool_parsing_unavailable:
+                if request.tool_choice == "auto" and not self.enable_auto_tools:
+                    return self.create_error_response(
+                        err_type="invalid_request_error",
+                        message=(
+                            '"auto" tool choice requires '
+                            "--enable-auto-tool-choice and "
+                            "--tool-call-parser to be set"
+                        ),
+                        status_code=HTTPStatus.BAD_REQUEST,
+                        param="tool_choice",
+                    )
+                elif request.tool_choice != "auto":
+                    return self.create_error_response(
+                        err_type="invalid_request_error",
+                        message=(
+                            f'tool_choice="{request.tool_choice}" requires '
+                            "--tool-call-parser to be set"
+                        ),
+                        status_code=HTTPStatus.BAD_REQUEST,
+                        param="tool_choice",
+                    )
         return None
 
     async def create_responses(


### PR DESCRIPTION
…and Responses API when tool parsing params is not set

## Purpose
Resolves #39221.
- Change the Responses API to throw errors following the established pattern in the Chat Completions API, which was given in vllm/entrypoints/serve/render/serving.py.
- Add unit tests to ensure that 400 errors are thrown when the tool call parameters are incorrect.
- Not sure if it's worth extracting the common logic for tool-call parsing and putting it in a shared util so we don't forget to update both in the future. Leaving it alone for now since there are only two call sites.

## Test Plan
```
pytest -s -v tests/entrypoints/openai/responses/test_serving_responses.py
```

## Test Result
This fix was developed with AI assistance (Claude). I have reviewed every changed line and personally ran the test commands above.

```
================================= test session starts ==================================
platform darwin -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0 -- /Users/tzhou/Documents/GitHub/vllm/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/tzhou/Documents/GitHub/vllm
configfile: pyproject.toml
plugins: asyncio-1.3.0, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 20 items                                                                     

tests/entrypoints/openai/responses/test_serving_responses.py::test_extract_tool_types PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::TestInitializeToolSessions::test_initialize_tool_sessions PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::TestInitializeToolSessions::test_validate_create_responses_input PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::TestValidateGeneratorInput::test_validate_generator_input PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::test_reasoning_tokens_counted_for_text_reasoning_model PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::TestExtractAllowedToolsFromMcpRequests::test_extract_allowed_tools_basic_formats PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::TestExtractAllowedToolsFromMcpRequests::test_extract_allowed_tools_star_normalization PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::TestExtractAllowedToolsFromMcpRequests::test_extract_allowed_tools_filters_non_mcp PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::TestHarmonyPreambleStreaming::test_preamble_delta_emits_text_events PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::TestHarmonyPreambleStreaming::test_preamble_delta_second_token_no_added PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::TestHarmonyPreambleStreaming::test_commentary_with_function_recipient_not_preamble PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::TestHarmonyPreambleStreaming::test_preamble_done_emits_text_done_events PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::TestHarmonyPreambleStreaming::test_commentary_with_recipient_no_preamble_done PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::TestStreamingReasoningToContentTransition::test_mixed_delta_reasoning_and_content_emits_reasoning_delta PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::TestStreamingReasoningToContentTransition::test_transition_without_mixed_delta_no_extra_reasoning_event PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::TestStreamingReasoningToContentTransition::test_reasoning_only_stream_no_content PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::TestToolChoiceValidation::test_auto_tool_choice_without_tool_parser_returns_error PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::TestToolChoiceValidation::test_required_tool_choice_without_tool_parser_returns_error PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::TestToolChoiceValidation::test_none_tool_choice_skips_validation PASSED
tests/entrypoints/openai/responses/test_serving_responses.py::TestToolChoiceValidation::test_empty_tools_skips_validation PASSED

=================================== warnings summary ===================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

.venv/lib/python3.12/site-packages/torch/jit/_script.py:362: 14 warnings
  /Users/tzhou/Documents/GitHub/vllm/.venv/lib/python3.12/site-packages/torch/jit/_script.py:362: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== 20 passed, 16 warnings in 2.74s ============================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

