### PR TITLE
fix: allow HMA with KV events when explicitly enabled

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1223,8 +1223,14 @@ class VllmConfig:
         if not current_platform.support_hybrid_kv_cache():
             # Hybrid KV cache manager is not supported on non-GPU platforms.
             need_disable_hybrid_kv_cache_manager = True
-        if self.kv_events_config is not None:
-            # Hybrid KV cache manager is not compatible with KV events.
+        if (
+            self.kv_events_config is not None
+            and self.scheduler_config.disable_hybrid_kv_cache_manager is not False
+        ):
+            # Hybrid KV cache manager is not compatible with KV events
+            # by default. When explicitly enabled via
+            # --no-disable-hybrid-kv-cache-manager (e.g. for hybrid models
+            # using NixlConnector which implements SupportsHMA), allow it.
             need_disable_hybrid_kv_cache_manager = True
         if (
             self.model_config is not None


### PR DESCRIPTION
## Summary

Allow the Hybrid Memory Allocator (HMA) to work alongside KV events when explicitly enabled via `--no-disable-hybrid-kv-cache-manager`. This unblocks disaggregated serving for hybrid models (Mamba + attention) like NVIDIA Nemotron-H.

**The problem:** HMA is unconditionally disabled when `kv_events_config` is set (line 1226-1228 of `vllm/config/vllm.py`), even when the user explicitly passes `--no-disable-hybrid-kv-cache-manager`. This blocks disaggregated serving for hybrid models despite `NixlConnector` already implementing `SupportsHMA` with full Mamba support (`_has_mamba` detection, `MAMBA2_ATTN` backend handling).

**The fix:** Only auto-disable HMA for KV events when the user hasn't explicitly opted in. When `--no-disable-hybrid-kv-cache-manager` is passed (`disable_hybrid_kv_cache_manager=False`), respect it.

## Changes

- `vllm/config/vllm.py`: Add check for explicit user opt-in before disabling HMA due to KV events config (+8 lines, -2 lines)

## Test Plan

Tested with:
- [x] NVIDIA Nemotron-3-Super-120B-A12B-NVFP4 (hybrid Mamba + attention, NVFP4 quantization)
- [x] Disaggregated prefill/decode via NixlConnector with CUDA-aware UCX
- [x] 200/200 requests successful in production benchmark at concurrency=[1, 32, 128, 512]

## Context

NixlConnector already:
- Subclasses `SupportsHMA` (kv_connector/v1/base.py)
- Detects Mamba layers via `_has_mamba` (nixl_connector.py:576)
- Handles `MAMBA2_ATTN` attention backend (nixl_connector.py:1216)
- Initializes NIXL scheduler for hybrid models (nixl_connector.py:581)

The config guard at line 1226 was added conservatively but creates a conflict: disaggregated mode auto-enables KV events, which then blocks HMA, making hybrid disagg impossible even though the connector supports it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)