### PR TITLE
[Core] Populate token_ids in offloading BlockStored events

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -363,6 +363,11 @@ def test_abort_loading_requests(request_runner, async_scheduling: bool):
 
 
 def test_take_events_populates_token_ids():
+    """
+    It emits one stored event for two known blocks, then verifies that the
+    resulting BlockStored event contains the concatenated token_ids from both
+    stored block mappings.
+    """
     (
         scheduler,
         manager,
@@ -393,6 +398,11 @@ def test_take_events_populates_token_ids():
 
 
 def test_take_events_resolves_parent_block_hash_for_non_first_block():
+    """
+    It emits a stored event for the second block only, then verifies that
+    the emitted BlockStored event keeps only that block's token_ids and
+    resolves parent_block_hash to the first block.
+    """
     (
         scheduler,
         manager,
@@ -422,6 +432,11 @@ def test_take_events_resolves_parent_block_hash_for_non_first_block():
 
 
 def test_take_events_cleans_mapping_after_consumption():
+    """
+    It emits a stored event for the first block only, then verifies that
+    the first block was removed from scheduler._stored_block_tokens and the
+    second block mapping stayed intact.
+    """
     (
         scheduler,
         manager,
@@ -450,6 +465,11 @@ def test_take_events_cleans_mapping_after_consumption():
 
 
 def test_block_removed_events_clean_up_token_mapping():
+    """
+    It emits a removed event for the first block only, then verifies that
+    the scheduler returns BlockRemoved and deletes only that block's token
+    mapping while keeping the second mapping intact.
+    """
     (
         scheduler,
         manager,

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Iterable
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -9,10 +11,52 @@ from tests.v1.kv_connector.unit.offloading_connector.utils import (
     to_keys,
 )
 from tests.v1.kv_connector.unit.utils import EOS_TOKEN_ID
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
+    OffloadingConnectorScheduler,
+)
 from vllm.distributed.kv_events import BlockRemoved, BlockStored
 from vllm.v1.core.kv_cache_utils import BlockHash
 from vllm.v1.kv_offload.abstract import OffloadingEvent
 from vllm.v1.request import RequestStatus
+
+
+def _create_scheduler_with_stored_block_tokens():
+    manager = MagicMock()
+    spec = SimpleNamespace(
+        gpu_block_size=[4],
+        block_size_factor=3,
+        get_manager=lambda: manager,
+        vllm_config=SimpleNamespace(
+            cache_config=SimpleNamespace(enable_prefix_caching=False)
+        ),
+    )
+    scheduler = OffloadingConnectorScheduler(spec)
+
+    first_hash = BlockHash(b"block-1")
+    second_hash = BlockHash(b"block-2")
+    first_token_ids = list(range(12))
+    second_token_ids = list(range(12, 24))
+
+    scheduler._stored_block_tokens = {
+        first_hash: (first_token_ids, None),
+        second_hash: (second_token_ids, first_hash),
+    }
+
+    return (
+        scheduler,
+        manager,
+        first_hash,
+        second_hash,
+        first_token_ids,
+        second_token_ids,
+    )
+
+
+def _take_events(*events: OffloadingEvent):
+    def take_events() -> Iterable[OffloadingEvent]:
+        yield from events
+
+    return take_events
 
 
 @pytest.mark.parametrize("async_scheduling", [True, False])
@@ -316,3 +360,123 @@ def test_abort_loading_requests(request_runner, async_scheduling: bool):
 
     # assert request is deleted
     assert req_id not in runner.scheduler.requests
+
+
+def test_take_events_populates_token_ids():
+    (
+        scheduler,
+        manager,
+        first_hash,
+        second_hash,
+        first_token_ids,
+        second_token_ids,
+    ) = _create_scheduler_with_stored_block_tokens()
+
+    manager.take_events.side_effect = _take_events(
+        OffloadingEvent(
+            block_hashes=[first_hash, second_hash],
+            block_size=scheduler.offloaded_block_size,
+            medium="CPU",
+            removed=False,
+        )
+    )
+
+    events = list(scheduler.take_events())
+    assert len(events) == 1
+
+    event = events[0]
+    assert isinstance(event, BlockStored)
+    assert event.block_hashes == [first_hash, second_hash]
+    assert event.token_ids == first_token_ids + second_token_ids
+    assert event.block_size == scheduler.offloaded_block_size
+    assert event.medium == "CPU"
+
+
+def test_take_events_resolves_parent_block_hash_for_non_first_block():
+    (
+        scheduler,
+        manager,
+        first_hash,
+        second_hash,
+        _first_token_ids,
+        second_token_ids,
+    ) = _create_scheduler_with_stored_block_tokens()
+
+    manager.take_events.side_effect = _take_events(
+        OffloadingEvent(
+            block_hashes=[second_hash],
+            block_size=scheduler.offloaded_block_size,
+            medium="CPU",
+            removed=False,
+        )
+    )
+
+    events = list(scheduler.take_events())
+    assert len(events) == 1
+
+    event = events[0]
+    assert isinstance(event, BlockStored)
+    assert event.block_hashes == [second_hash]
+    assert event.token_ids == second_token_ids
+    assert event.parent_block_hash == first_hash
+
+
+def test_take_events_cleans_mapping_after_consumption():
+    (
+        scheduler,
+        manager,
+        first_hash,
+        second_hash,
+        _first_token_ids,
+        second_token_ids,
+    ) = _create_scheduler_with_stored_block_tokens()
+
+    manager.take_events.side_effect = _take_events(
+        OffloadingEvent(
+            block_hashes=[first_hash],
+            block_size=scheduler.offloaded_block_size,
+            medium="CPU",
+            removed=False,
+        )
+    )
+
+    events = list(scheduler.take_events())
+    assert len(events) == 1
+
+    assert first_hash not in scheduler._stored_block_tokens
+    assert scheduler._stored_block_tokens == {
+        second_hash: (second_token_ids, first_hash)
+    }
+
+
+def test_block_removed_events_clean_up_token_mapping():
+    (
+        scheduler,
+        manager,
+        first_hash,
+        second_hash,
+        _first_token_ids,
+        second_token_ids,
+    ) = _create_scheduler_with_stored_block_tokens()
+
+    manager.take_events.side_effect = _take_events(
+        OffloadingEvent(
+            block_hashes=[first_hash],
+            block_size=scheduler.offloaded_block_size,
+            medium="CPU",
+            removed=True,
+        )
+    )
+
+    events = list(scheduler.take_events())
+    assert len(events) == 1
+
+    event = events[0]
+    assert isinstance(event, BlockRemoved)
+    assert event.block_hashes == [first_hash]
+    assert event.medium == "CPU"
+
+    assert first_hash not in scheduler._stored_block_tokens
+    assert scheduler._stored_block_tokens == {
+        second_hash: (second_token_ids, first_hash)
+    }

--- a/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
@@ -11,10 +11,10 @@ from tests.v1.kv_connector.unit.offloading_connector.utils import (
     to_keys,
 )
 from tests.v1.kv_connector.unit.utils import EOS_TOKEN_ID
+from vllm.distributed.kv_events import BlockRemoved, BlockStored
 from vllm.distributed.kv_transfer.kv_connector.v1.offloading.scheduler import (
     OffloadingConnectorScheduler,
 )
-from vllm.distributed.kv_events import BlockRemoved, BlockStored
 from vllm.v1.core.kv_cache_utils import BlockHash
 from vllm.v1.kv_offload.abstract import OffloadingEvent
 from vllm.v1.request import RequestStatus

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -131,9 +131,7 @@ class OffloadingConnectorScheduler:
 
         # token data for enriching offloading events
         # offload_key → (token_ids, parent_block_hash)
-        self._stored_block_tokens: dict[
-            OffloadKey, tuple[list[int], bytes | None]
-        ] = {}
+        self._stored_block_tokens: dict[OffloadKey, tuple[list[int], bytes | None]] = {}
 
     def get_num_new_matched_tokens(
         self, request: Request, num_computed_tokens: int
@@ -345,24 +343,14 @@ class OffloadingConnectorScheduler:
             for idx, key in enumerate(new_offload_keys):
                 if key in keys_to_store:
                     offloaded_idx = start_block_idx + idx
-                    token_start = (
-                        offloaded_idx * group_config.offloaded_block_size
-                    )
-                    token_end = (
-                        token_start + group_config.offloaded_block_size
-                    )
-                    token_ids = list(
-                        req.all_token_ids[token_start:token_end]
-                    )
+                    token_start = offloaded_idx * group_config.offloaded_block_size
+                    token_end = token_start + group_config.offloaded_block_size
+                    token_ids = list(req.all_token_ids[token_start:token_end])
 
                     parent_block_hash = None
                     if offloaded_idx > 0:
-                        parent_key = group_state.offload_keys[
-                            offloaded_idx - 1
-                        ]
-                        parent_block_hash = get_offload_block_hash(
-                            parent_key
-                        )
+                        parent_key = group_state.offload_keys[offloaded_idx - 1]
+                        parent_block_hash = get_offload_block_hash(parent_key)
 
                     self._stored_block_tokens[key] = (
                         token_ids,
@@ -449,13 +437,9 @@ class OffloadingConnectorScheduler:
             A list of KV cache events.
         """
         for event in self.manager.take_events():
-            block_hashes = [
-                get_offload_block_hash(key) for key in event.keys
-            ]
+            block_hashes = [get_offload_block_hash(key) for key in event.keys]
             if event.removed:
-                yield BlockRemoved(
-                    block_hashes=block_hashes, medium=event.medium
-                )
+                yield BlockRemoved(block_hashes=block_hashes, medium=event.medium)
                 # Clean token mapping for removed blocks
                 for key in event.keys:
                     self._stored_block_tokens.pop(key, None)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -129,6 +129,12 @@ class OffloadingConnectorScheduler:
         self._reqs_being_stored = defaultdict[ReqId, set[OffloadKey]](set)
         self._reqs_being_loaded = defaultdict[ReqId, set[OffloadKey]](set)
 
+        # token data for enriching offloading events
+        # offload_key → (token_ids, parent_block_hash)
+        self._stored_block_tokens: dict[
+            OffloadKey, tuple[list[int], bytes | None]
+        ] = {}
+
     def get_num_new_matched_tokens(
         self, request: Request, num_computed_tokens: int
     ) -> tuple[int | None, bool]:
@@ -335,6 +341,34 @@ class OffloadingConnectorScheduler:
             reqs_to_store[req_id] = (src_spec, dst_spec)
             self._reqs_being_stored[req_id] |= keys_to_store
 
+            # Record token mapping for event enrichment
+            for idx, key in enumerate(new_offload_keys):
+                if key in keys_to_store:
+                    offloaded_idx = start_block_idx + idx
+                    token_start = (
+                        offloaded_idx * group_config.offloaded_block_size
+                    )
+                    token_end = (
+                        token_start + group_config.offloaded_block_size
+                    )
+                    token_ids = list(
+                        req.all_token_ids[token_start:token_end]
+                    )
+
+                    parent_block_hash = None
+                    if offloaded_idx > 0:
+                        parent_key = group_state.offload_keys[
+                            offloaded_idx - 1
+                        ]
+                        parent_block_hash = get_offload_block_hash(
+                            parent_key
+                        )
+
+                    self._stored_block_tokens[key] = (
+                        token_ids,
+                        parent_block_hash,
+                    )
+
             logger.debug(
                 "Request %s offloading %s blocks starting from block #%d",
                 req_id,
@@ -415,14 +449,37 @@ class OffloadingConnectorScheduler:
             A list of KV cache events.
         """
         for event in self.manager.take_events():
-            block_hashes = [get_offload_block_hash(key) for key in event.keys]
+            block_hashes = [
+                get_offload_block_hash(key) for key in event.keys
+            ]
             if event.removed:
-                yield BlockRemoved(block_hashes=block_hashes, medium=event.medium)
+                yield BlockRemoved(
+                    block_hashes=block_hashes, medium=event.medium
+                )
+                # Clean token mapping for removed blocks
+                for key in event.keys:
+                    self._stored_block_tokens.pop(key, None)
             else:
+                # Aggregate token_ids and resolve parent hash.
+                # parent_block_hash is the parent of the first block in
+                # the batch — it may legitimately be None (start of
+                # sequence).
+                all_token_ids: list[int] = []
+                parent_block_hash: bytes | None = None
+                parent_hash_resolved = False
+                for key in event.keys:
+                    entry = self._stored_block_tokens.pop(key, None)
+                    if entry is not None:
+                        tokens, p_hash = entry
+                        all_token_ids.extend(tokens)
+                        if not parent_hash_resolved:
+                            parent_block_hash = p_hash
+                            parent_hash_resolved = True
+
                 yield BlockStored(
                     block_hashes=block_hashes,
-                    parent_block_hash=None,
-                    token_ids=[],
+                    parent_block_hash=parent_block_hash,
+                    token_ids=all_token_ids,
                     lora_id=None,
                     block_size=event.block_size,
                     medium=event.medium,


### PR DESCRIPTION
## Purpose

Offloading `BlockStored` events emitted via `OffloadingConnectorScheduler.take_events()` currently have empty `token_ids` and `parent_block_hash=None`. This PR populates these fields by recording the token mapping at store preparation time and enriching the events during conversion.

External KV cache indexers (e.g. [llm-d-kv-cache](https://github.com/llm-d/llm-d-kv-cache)) consume `BlockStored` events via ZMQ to track which blocks are available on which storage tiers. For GPU/CPU events emitted by `BlockPool.cache_full_blocks`, token IDs are included because they're available at the call site. But for offloading events, the `OffloadingEvent` dataclass doesn't carry token data, so the conversion in `take_events()` emits `token_ids=[]`.

This matters for storage-tier offloading (like shared filesystem backends) where the consumer needs to re-hash tokens at the storage block size to compute storage-resolution cache keys. Without token IDs, the events are incomplete.

## Test Plan

- [x] Existing offloading tests pass (no behavior change for backends that don't emit events).
- [x] New test: `OffloadingEvent` -> `BlockStored` conversion includes correct `token_ids`
- [x] New test: `parent_block_hash` is correctly resolved for non-first blocks
- [x] New test: mapping is cleaned up after events are consumed
- [x] New test: `BlockRemoved` events clean up the token mapping

## Test Result

Passed.

```bash
[7:47:32] ● albertomba13 ➜ ~/workspace/vllm$ git:(feat/populate-offloading-event-token-ids) .venv/bin/python -m pytest tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py -v
=========================================================================================================================================================== test session starts ============================================================================================================================================================
platform darwin -- Python 3.12.4, pytest-9.0.3, pluggy-1.6.0 -- /Users/aperdomo/workspace/vllm/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/aperdomo/workspace/vllm
configfile: pyproject.toml
plugins: asyncio-1.3.0, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 12 items                                                                                                                                                                                                                                                                                                                         

tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py::test_offloading_connector[True] PASSED                                                                                                                                                                                                                            [  8%]
tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py::test_offloading_connector[False] PASSED                                                                                                                                                                                                                           [ 16%]
tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py::test_request_preemption[True] PASSED                                                                                                                                                                                                                              [ 25%]
tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py::test_request_preemption[False] PASSED                                                                                                                                                                                                                             [ 33%]
tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py::test_concurrent_lookups_of_the_same_prefix[True] PASSED                                                                                                                                                                                                           [ 41%]
tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py::test_concurrent_lookups_of_the_same_prefix[False] PASSED                                                                                                                                                                                                          [ 50%]
tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py::test_abort_loading_requests[True] PASSED                                                                                                                                                                                                                          [ 58%]
tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py::test_abort_loading_requests[False] PASSED                                                                                                                                                                                                                         [ 66%]
tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py::test_take_events_populates_token_ids PASSED                                                                                                                                                                                                                       [ 75%]
tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py::test_take_events_resolves_parent_block_hash_for_non_first_block PASSED                                                                                                                                                                                            [ 83%]
tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py::test_take_events_cleans_mapping_after_consumption PASSED                                                                                                                                                                                                          [ 91%]
tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py::test_block_removed_events_clean_up_token_mapping PASSED                                                                                                                                                                                                           [100%]

============================================================================================================================================================= warnings summary =============================================================================================================================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: 14 warnings
  /Users/aperdomo/workspace/redhat/vllm/.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
===================================================================================================================================================== 12 passed, 16 warnings in 8.35s ======================================================================================================================================================
```

*This PR (tests) was developed with AI assistance (Codex). All changes have been reviewed and tested by the submitter.*

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
