### PR TITLE
Fix engine_id collision + MoRIIO robustness for multi-node disagg DP

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -254,9 +254,10 @@ class MoRIIOConfig:
         kv_transfer_config = vllm_config.kv_transfer_config
         extra_config = kv_transfer_config.kv_connector_extra_config
         tp_rank = get_tensor_model_parallel_rank()
-        dp_rank = vllm_config.parallel_config.data_parallel_rank
+        dp_rank = (vllm_config.parallel_config.data_parallel_rank
+                   % vllm_config.parallel_config.data_parallel_size_local)
         base_notify_port = int(extra_config["notify_port"])
-        dp_size = vllm_config.parallel_config.data_parallel_size
+        dp_size = vllm_config.parallel_config.data_parallel_size_local
         tp_size = get_tensor_model_parallel_world_size()
         port_offset = get_port_offset(dp_rank, tp_rank)
         backend = str(extra_config.get("backend", "rdma")).lower()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -247,15 +247,17 @@ class MoRIIOConfig:
 
         # TODO : merge notify_port and handshake_port to simplify port management
         #        supports non-contiguous ports
-        assert vllm_config.kv_transfer_config is not None, (
-            "kv_transfer_config must be set for MoRIIOConnector"
-        )
+        assert (
+            vllm_config.kv_transfer_config is not None
+        ), "kv_transfer_config must be set for MoRIIOConnector"
         _warn_deprecated_env_vars()
         kv_transfer_config = vllm_config.kv_transfer_config
         extra_config = kv_transfer_config.kv_connector_extra_config
         tp_rank = get_tensor_model_parallel_rank()
-        dp_rank = (vllm_config.parallel_config.data_parallel_rank
-                   % vllm_config.parallel_config.data_parallel_size_local)
+        dp_rank = (
+            vllm_config.parallel_config.data_parallel_rank
+            % vllm_config.parallel_config.data_parallel_size_local
+        )
         base_notify_port = int(extra_config["notify_port"])
         dp_size = vllm_config.parallel_config.data_parallel_size_local
         tp_size = get_tensor_model_parallel_world_size()

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import logging
 import math
+import os
 import queue
 import threading
 import time
@@ -266,13 +267,19 @@ class MoRIIOConnectorScheduler:
             "notify_port"
         ]
         self.tp_size = self.vllm_config.parallel_config.tensor_parallel_size
-        self.dp_rank = self.vllm_config.parallel_config.data_parallel_rank
+        self.dp_rank = (self.vllm_config.parallel_config.data_parallel_rank
+                        % self.vllm_config.parallel_config
+                        .data_parallel_size_local)
+        self._is_kv_master = (
+            self.vllm_config.parallel_config.data_parallel_rank
+            < self.vllm_config.parallel_config.data_parallel_size_local)
         self.is_producer = self.kv_transfer_config.kv_role == "kv_producer"
         # Requests that need to start recv/send.
         # New requests are added by update_state_after_alloc in
         # the scheduler. Used to make metadata passed to Worker.
         self._reqs_need_recv: dict[ReqId, tuple[Request, list[int]]] = {}
         self._reqs_need_save: dict[ReqId, tuple[Request, list[int]]] = {}
+        self._req_kv_params: dict[ReqId, dict] = {}
 
         # For chunked prefill, we perform layer-wise access within the final chunk.
         # TODO: Perform transfer at end chunk.
@@ -393,6 +400,7 @@ class MoRIIOConnectorScheduler:
         if params.get("do_remote_decode"):
             local_block_ids = blocks.get_block_ids()[0]
             self._reqs_need_save[request.request_id] = (request, local_block_ids)
+            self._req_kv_params[request.request_id] = dict(params)
 
         if params is not None and params.get("do_remote_prefill"):
             if self.mode == MoRIIOMode.READ:
@@ -416,6 +424,9 @@ class MoRIIOConnectorScheduler:
                             request,
                             local_block_ids,
                         )
+                        self._req_kv_params[request.request_id] = dict(
+                            params
+                        )
                     else:
                         logger.warning(
                             "Got invalid KVTransferParams: %s. This "
@@ -431,23 +442,28 @@ class MoRIIOConnectorScheduler:
 
                 remote_dp_rank = request.kv_transfer_params.get("remote_dp_rank", 0)
 
-                peer_zmq = get_peer_zmq_from_request_id(
-                    request.request_id, is_producer=False
-                )
-                remote_host, _, remote_notify_port = parse_moriio_zmq_address(peer_zmq)
-
-                for tp_index in range(self.tp_size):
-                    target_port = remote_notify_port + get_port_offset(
-                        remote_dp_rank, tp_index
+                if self._is_kv_master:
+                    peer_zmq = get_peer_zmq_from_request_id(
+                        request.request_id, is_producer=True
+                    )
+                    remote_host, _, remote_notify_port = (
+                        parse_moriio_zmq_address(peer_zmq)
                     )
 
-                    self.send_notify_block(
-                        req_id=request.request_id,
-                        transfer_id=request.kv_transfer_params["transfer_id"],
-                        block_notify_list=blocks.get_block_ids()[0],
-                        host=remote_host,
-                        port=target_port,
-                    )
+                    for tp_index in range(self.tp_size):
+                        target_port = remote_notify_port + get_port_offset(
+                            remote_dp_rank, tp_index
+                        )
+
+                        self.send_notify_block(
+                            req_id=request.request_id,
+                            transfer_id=request.kv_transfer_params[
+                                "transfer_id"
+                            ],
+                            block_notify_list=blocks.get_block_ids()[0],
+                            host=remote_host,
+                            port=target_port,
+                        )
 
             # Only trigger 1 KV transfer per request.
 
@@ -507,25 +523,32 @@ class MoRIIOConnectorScheduler:
                             * self.block_size
                             >= req.num_prompt_tokens
                         ):
+                            kv_params = self._req_kv_params.pop(
+                                req_id, req.kv_transfer_params or {}
+                            )
                             meta.add_new_req(
                                 request_id=req_id,
                                 local_block_ids=self._reqs_need_pending_save[req_id][1],
-                                kv_transfer_params=req.kv_transfer_params or {},
+                                kv_transfer_params=kv_params,
                                 write_mode=True,
                             )
                             del self._reqs_need_pending_save[req_id]
 
         # Loop through scheduled reqs and convert to ReqMeta.
         for req_id, (req, block_ids) in self._reqs_need_recv.items():
-            assert req.kv_transfer_params is not None
+            kv_params = self._req_kv_params.get(
+                req_id, req.kv_transfer_params or {}
+            )
             meta.add_new_req(
                 request_id=req_id,
                 local_block_ids=block_ids,
-                kv_transfer_params=req.kv_transfer_params,
+                kv_transfer_params=kv_params,
             )
 
         for req_id, (req, block_ids) in self._reqs_need_save.items():
-            assert req.kv_transfer_params is not None
+            kv_params = self._req_kv_params.get(
+                req_id, req.kv_transfer_params or {}
+            )
             if req.num_prompt_tokens > len(block_ids) * self.block_size:
                 # not last chunk prefill
                 self._reqs_need_pending_save[req_id] = (req, block_ids)
@@ -533,13 +556,18 @@ class MoRIIOConnectorScheduler:
             meta.add_new_req(
                 request_id=req_id,
                 local_block_ids=block_ids,
-                kv_transfer_params=req.kv_transfer_params,
+                kv_transfer_params=kv_params,
                 write_mode=True,
             )
         # Clear the list once workers start the transfers
 
         meta.reqs_to_send = self._reqs_need_send
 
+        for req_id in self._reqs_need_recv:
+            self._req_kv_params.pop(req_id, None)
+        for req_id in self._reqs_need_save:
+            if req_id not in self._reqs_need_pending_save:
+                self._req_kv_params.pop(req_id, None)
         self._reqs_need_recv.clear()
         self._reqs_need_save.clear()
         self._reqs_need_send = {}
@@ -839,6 +867,9 @@ class MoRIIOConnectorWorker:
         self._recving_transfers: defaultdict[ReqId, list] = defaultdict(list)
         # Values are (remote_host, remote_notify_port, transfer_id).
         self._recving_transfers_callback_addr: dict[ReqId, tuple[str, str, str]] = {}
+        # Track when each transfer started (keyed by transfer_id) for
+        # deferred-write timeout tracking.
+        self._recving_transfers_start: dict[str, float] = {}
 
         # Track the expiration time of requests that are waiting to be sent.
         self._reqs_to_send: dict[ReqId, float] = {}
@@ -1242,7 +1273,14 @@ class MoRIIOConnectorWorker:
             self.slot_size_bytes = (
                 kv_elem_size * n_kv_heads * head_dim
             )  # 1 token 1 layer size , slot size
-        assert block_size == self.block_size
+        if block_size != self.block_size:
+            logger.info(
+                "KV cache block_size=%d differs from config block_size=%d; "
+                "using actual tensor shape (attention backend override).",
+                block_size,
+                self.block_size,
+            )
+            self.block_size = block_size
         # TODO(tms): self.block_len needs to be per-layer for sliding window,
         # hybrid attn, etc
         # block size in bytes
@@ -1382,6 +1420,8 @@ class MoRIIOConnectorWorker:
 
     def _pop_done_transfers(self) -> set[str]:
         done_req_ids: set[str] = set()
+        _xfer_timeout = int(
+            os.environ.get("VLLM_MORIIO_TRANSFER_TIMEOUT_S", "120"))
         with self.moriio_wrapper.lock:
             to_remove = []
             for req_id, status_list in self._recving_transfers.items():
@@ -1411,10 +1451,21 @@ class MoRIIOConnectorWorker:
                     to_remove.append(req_id)
                     # Do NOT add to done_req_ids: decode KV cache is incomplete.
                     # The request will expire via the normal request timeout.
+                elif req_id in self._recving_transfers_start:
+                    # PR #39276: timeout tracking — abort still-in-flight
+                    # transfers that exceeded the deadline, so we don't hang
+                    # forever waiting on a lost RDMA completion.
+                    _age = (time.monotonic()
+                            - self._recving_transfers_start[req_id])
+                    if _age > _xfer_timeout:
+                        logger.error(
+                            "RDMA read TIMED OUT for req %s after %.1fs",
+                            req_id, _age)
+                        to_remove.append(req_id)
             for req_id in to_remove:
                 del self._recving_transfers[req_id]
                 del self._recving_transfers_callback_addr[req_id]
-
+                self._recving_transfers_start.pop(req_id, None)
             return done_req_ids
 
     def save_kv_layer(
@@ -1737,6 +1788,8 @@ class MoRIIOConnectorWorker:
             )
             with self.moriio_wrapper.lock:
                 self._recving_transfers[request_id].append(transfer_status)
+                self._recving_transfers_start.setdefault(
+                    request_id, time.monotonic())
                 self._recving_transfers_callback_addr[request_id] = (
                     remote_host,
                     str(remote_notify_port + self.tp_rank),

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -98,9 +98,9 @@ class MoRIIOConnector(KVConnectorBase_V1):
         kv_cache_config: "KVCacheConfig",
     ):
         super().__init__(vllm_config, role, kv_cache_config)
-        assert vllm_config.kv_transfer_config is not None, (
-            "kv_transfer_config must be set for MoRIIOConnector"
-        )
+        assert (
+            vllm_config.kv_transfer_config is not None
+        ), "kv_transfer_config must be set for MoRIIOConnector"
 
         self.kv_transfer_config = vllm_config.kv_transfer_config
         self._set_port_defaults(vllm_config)
@@ -130,9 +130,9 @@ class MoRIIOConnector(KVConnectorBase_V1):
     ############################################################
 
     def _set_port_defaults(self, vllm_config: VllmConfig):
-        assert vllm_config.kv_transfer_config is not None, (
-            "kv_transfer_config must be set for MoRIIOConnector"
-        )
+        assert (
+            vllm_config.kv_transfer_config is not None
+        ), "kv_transfer_config must be set for MoRIIOConnector"
         kv_transfer_config = vllm_config.kv_transfer_config
         extra_config = kv_transfer_config.kv_connector_extra_config
 
@@ -210,13 +210,13 @@ class MoRIIOConnector(KVConnectorBase_V1):
         # Only producer/prefill saves KV Cache
         if get_role() == ROLE.CONSUMER:
             return
-        assert self.connector_worker is not None, (
-            "save_kv_layer called on scheduler role"
-        )
+        assert (
+            self.connector_worker is not None
+        ), "save_kv_layer called on scheduler role"
 
-        assert isinstance(self._connector_metadata, MoRIIOConnectorMetadata), (
-            "Connector metadata not initialized yet"
-        )
+        assert isinstance(
+            self._connector_metadata, MoRIIOConnectorMetadata
+        ), "Connector metadata not initialized yet"
         self.connector_worker.save_kv_layer(
             self._connector_metadata, layer_name, kv_layer, attn_metadata, **kwargs
         )
@@ -250,9 +250,9 @@ class MoRIIOConnectorScheduler:
     def __init__(self, vllm_config: VllmConfig, engine_id: str):
         self.vllm_config = vllm_config
 
-        assert vllm_config.kv_transfer_config is not None, (
-            "kv_transfer_config must be set for MoRIIOConnector"
-        )
+        assert (
+            vllm_config.kv_transfer_config is not None
+        ), "kv_transfer_config must be set for MoRIIOConnector"
         self.kv_transfer_config = vllm_config.kv_transfer_config
         self.block_size = vllm_config.cache_config.block_size
         self.engine_id: EngineId = engine_id
@@ -267,12 +267,14 @@ class MoRIIOConnectorScheduler:
             "notify_port"
         ]
         self.tp_size = self.vllm_config.parallel_config.tensor_parallel_size
-        self.dp_rank = (self.vllm_config.parallel_config.data_parallel_rank
-                        % self.vllm_config.parallel_config
-                        .data_parallel_size_local)
+        self.dp_rank = (
+            self.vllm_config.parallel_config.data_parallel_rank
+            % self.vllm_config.parallel_config.data_parallel_size_local
+        )
         self._is_kv_master = (
             self.vllm_config.parallel_config.data_parallel_rank
-            < self.vllm_config.parallel_config.data_parallel_size_local)
+            < self.vllm_config.parallel_config.data_parallel_size_local
+        )
         self.is_producer = self.kv_transfer_config.kv_role == "kv_producer"
         # Requests that need to start recv/send.
         # New requests are added by update_state_after_alloc in
@@ -424,9 +426,7 @@ class MoRIIOConnectorScheduler:
                             request,
                             local_block_ids,
                         )
-                        self._req_kv_params[request.request_id] = dict(
-                            params
-                        )
+                        self._req_kv_params[request.request_id] = dict(params)
                     else:
                         logger.warning(
                             "Got invalid KVTransferParams: %s. This "
@@ -436,18 +436,18 @@ class MoRIIOConnectorScheduler:
 
             else:
                 # WRITE mode, decode side: notify P that blocks are ready
-                assert request.kv_transfer_params is not None, (
-                    "kv_transfer_params should not be None"
-                )
+                assert (
+                    request.kv_transfer_params is not None
+                ), "kv_transfer_params should not be None"
 
                 remote_dp_rank = request.kv_transfer_params.get("remote_dp_rank", 0)
 
                 if self._is_kv_master:
                     peer_zmq = get_peer_zmq_from_request_id(
-                        request.request_id, is_producer=True
+                        request.request_id, is_producer=False
                     )
-                    remote_host, _, remote_notify_port = (
-                        parse_moriio_zmq_address(peer_zmq)
+                    remote_host, _, remote_notify_port = parse_moriio_zmq_address(
+                        peer_zmq
                     )
 
                     for tp_index in range(self.tp_size):
@@ -457,9 +457,7 @@ class MoRIIOConnectorScheduler:
 
                         self.send_notify_block(
                             req_id=request.request_id,
-                            transfer_id=request.kv_transfer_params[
-                                "transfer_id"
-                            ],
+                            transfer_id=request.kv_transfer_params["transfer_id"],
                             block_notify_list=blocks.get_block_ids()[0],
                             host=remote_host,
                             port=target_port,
@@ -484,12 +482,12 @@ class MoRIIOConnectorScheduler:
                 for new_req in scheduler_output.scheduled_new_reqs:
                     red_id = new_req.req_id
                     local_block_ids = list(new_req.block_ids)[0]
-                    assert new_req.sampling_params is not None, (
-                        f"sampling_params is None for req {new_req.req_id}"
-                    )
-                    assert hasattr(new_req.sampling_params, "extra_args"), (
-                        f"sampling_params missing extra_args for req {new_req.req_id}"
-                    )
+                    assert (
+                        new_req.sampling_params is not None
+                    ), f"sampling_params is None for req {new_req.req_id}"
+                    assert hasattr(
+                        new_req.sampling_params, "extra_args"
+                    ), f"sampling_params missing extra_args for req {new_req.req_id}"
                     kv_transfer_params = (
                         new_req.sampling_params.extra_args.get("kv_transfer_params", {})
                         if new_req.sampling_params.extra_args
@@ -536,9 +534,7 @@ class MoRIIOConnectorScheduler:
 
         # Loop through scheduled reqs and convert to ReqMeta.
         for req_id, (req, block_ids) in self._reqs_need_recv.items():
-            kv_params = self._req_kv_params.get(
-                req_id, req.kv_transfer_params or {}
-            )
+            kv_params = self._req_kv_params.get(req_id, req.kv_transfer_params or {})
             meta.add_new_req(
                 request_id=req_id,
                 local_block_ids=block_ids,
@@ -546,9 +542,7 @@ class MoRIIOConnectorScheduler:
             )
 
         for req_id, (req, block_ids) in self._reqs_need_save.items():
-            kv_params = self._req_kv_params.get(
-                req_id, req.kv_transfer_params or {}
-            )
+            kv_params = self._req_kv_params.get(req_id, req.kv_transfer_params or {})
             if req.num_prompt_tokens > len(block_ids) * self.block_size:
                 # not last chunk prefill
                 self._reqs_need_pending_save[req_id] = (req, block_ids)
@@ -728,9 +722,9 @@ class MoRIIOConnectorWorker:
 
         # Config.
         self.vllm_config = vllm_config
-        assert vllm_config.kv_transfer_config is not None, (
-            "kv_transfer_config must be set for MoRIIOConnector"
-        )
+        assert (
+            vllm_config.kv_transfer_config is not None
+        ), "kv_transfer_config must be set for MoRIIOConnector"
         self.kv_transfer_config = vllm_config.kv_transfer_config
         self.is_producer = self.kv_transfer_config.is_kv_producer
 
@@ -1420,8 +1414,7 @@ class MoRIIOConnectorWorker:
 
     def _pop_done_transfers(self) -> set[str]:
         done_req_ids: set[str] = set()
-        _xfer_timeout = int(
-            os.environ.get("VLLM_MORIIO_TRANSFER_TIMEOUT_S", "120"))
+        _xfer_timeout = int(os.environ.get("VLLM_MORIIO_TRANSFER_TIMEOUT_S", "120"))
         with self.moriio_wrapper.lock:
             to_remove = []
             for req_id, status_list in self._recving_transfers.items():
@@ -1455,12 +1448,11 @@ class MoRIIOConnectorWorker:
                     # PR #39276: timeout tracking — abort still-in-flight
                     # transfers that exceeded the deadline, so we don't hang
                     # forever waiting on a lost RDMA completion.
-                    _age = (time.monotonic()
-                            - self._recving_transfers_start[req_id])
+                    _age = time.monotonic() - self._recving_transfers_start[req_id]
                     if _age > _xfer_timeout:
                         logger.error(
-                            "RDMA read TIMED OUT for req %s after %.1fs",
-                            req_id, _age)
+                            "RDMA read TIMED OUT for req %s after %.1fs", req_id, _age
+                        )
                         to_remove.append(req_id)
             for req_id in to_remove:
                 del self._recving_transfers[req_id]
@@ -1788,8 +1780,7 @@ class MoRIIOConnectorWorker:
             )
             with self.moriio_wrapper.lock:
                 self._recving_transfers[request_id].append(transfer_status)
-                self._recving_transfers_start.setdefault(
-                    request_id, time.monotonic())
+                self._recving_transfers_start.setdefault(request_id, time.monotonic())
                 self._recving_transfers_callback_addr[request_id] = (
                     remote_host,
                     str(remote_notify_port + self.tp_rank),

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
 import threading
 import time
 from typing import TYPE_CHECKING, Any
@@ -156,7 +157,6 @@ class MoRIIOWriter:
         defer_timeout = self._defer_timeout
         now = time.perf_counter()
         still_deferred: list[WriteTask] = []
-
         for task in self._deferred_tasks:
             if now - task.enqueue_time > defer_timeout:
                 logger.error(
@@ -657,18 +657,33 @@ class MoRIIOWrapper:
         req_list = req_ids if isinstance(req_ids, list) else [req_ids]
 
         sock = self.paths[path]
-        try:
-            for req_id in req_list:
-                if not isinstance(req_id, str):
-                    logger.warning(
-                        "Invalid req_id type: %s, expected str", type(req_id)
-                    )
-                    continue
-                sock.send(req_id.encode("utf-8"))
-        except Exception as e:
-            logger.error("Failed to send notification to %s: %s", path, e)
-            self.paths.pop(path, None)
-            raise
+        _MAX_RETRIES = 3
+        for req_id in req_list:
+            if not isinstance(req_id, str):
+                logger.warning(
+                    "Invalid req_id type: %s, expected str", type(req_id))
+                continue
+            for _attempt in range(_MAX_RETRIES):
+                try:
+                    sock.send(req_id.encode("utf-8"), zmq.NOBLOCK)
+                    break
+                except zmq.Again:
+                    if _attempt < _MAX_RETRIES - 1:
+                        time.sleep(0.01 * (_attempt + 1))
+                        logger.warning(
+                            "ZMQ send retry %d for req %s to %s",
+                            _attempt + 1, req_id, path)
+                    else:
+                        logger.error(
+                            "ZMQ send FAILED after %d retries "
+                            "for req %s to %s",
+                            _MAX_RETRIES, req_id, path)
+                except Exception as e:
+                    logger.error(
+                        "Failed to send notification to %s: %s",
+                        path, e)
+                    self.paths.pop(path, None)
+                    raise
 
     def pop_finished_req_ids(self):
         # producer invocation: get the set of completed requests at the decode

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
@@ -406,9 +406,9 @@ class MoRIIOWrapper:
         self.paths: dict[str, zmq.Socket] = {}
 
     def set_moriio_engine(self, moriio_engine):
-        assert moriio_engine is not None, (
-            "You Cannot pass None engine to MoRIIOWrapper!"
-        )
+        assert (
+            moriio_engine is not None
+        ), "You Cannot pass None engine to MoRIIOWrapper!"
         self.moriio_engine = moriio_engine
 
     def set_backend_type(
@@ -464,9 +464,9 @@ class MoRIIOWrapper:
             self.local_memory_metadata = self.moriio_engine.register_torch_tensor(
                 tensor
             )
-            assert self.local_memory_metadata is not None, (
-                "register_torch_tensor returned None"
-            )
+            assert (
+                self.local_memory_metadata is not None
+            ), "register_torch_tensor returned None"
             local_memory_metadata_packed = self.local_memory_metadata.pack()
         except Exception as e:
             raise MoRIIOError(f"Failed to register local memory: {e}") from e
@@ -624,9 +624,9 @@ class MoRIIOWrapper:
         transfer_id = data["transfer_id"]
         block_notify_list = data.get("block_notify_list", [])
         decode_dp_rank = data.get("decode_rank", 0)
-        assert len(block_notify_list) > 0, (
-            "block_notify_list cannot be empty in remote allocate message"
-        )
+        assert (
+            len(block_notify_list) > 0
+        ), "block_notify_list cannot be empty in remote allocate message"
 
         with self.lock:
             self.done_remote_allocate_req_dict[transfer_id] = RemoteAllocInfo(
@@ -660,8 +660,7 @@ class MoRIIOWrapper:
         _MAX_RETRIES = 3
         for req_id in req_list:
             if not isinstance(req_id, str):
-                logger.warning(
-                    "Invalid req_id type: %s, expected str", type(req_id))
+                logger.warning("Invalid req_id type: %s, expected str", type(req_id))
                 continue
             for _attempt in range(_MAX_RETRIES):
                 try:
@@ -672,16 +671,19 @@ class MoRIIOWrapper:
                         time.sleep(0.01 * (_attempt + 1))
                         logger.warning(
                             "ZMQ send retry %d for req %s to %s",
-                            _attempt + 1, req_id, path)
+                            _attempt + 1,
+                            req_id,
+                            path,
+                        )
                     else:
                         logger.error(
-                            "ZMQ send FAILED after %d retries "
-                            "for req %s to %s",
-                            _MAX_RETRIES, req_id, path)
+                            "ZMQ send FAILED after %d retries " "for req %s to %s",
+                            _MAX_RETRIES,
+                            req_id,
+                            path,
+                        )
                 except Exception as e:
-                    logger.error(
-                        "Failed to send notification to %s: %s",
-                        path, e)
+                    logger.error("Failed to send notification to %s: %s", path, e)
                     self.paths.pop(path, None)
                     raise
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1135,10 +1135,11 @@ class EngineCoreProc(EngineCore):
                 numa_utils.log_current_affinity_state(process_title)
 
             if data_parallel and vllm_config.kv_transfer_config is not None:
-                # modify the engine_id and append the local_dp_rank to it to ensure
-                # that the kv_transfer_config is unique for each DP rank.
+                # Use the global dp_rank (not local_dp_rank) to ensure
+                # engine_ids are globally unique across all nodes in
+                # multi-node data parallel deployments.
                 vllm_config.kv_transfer_config.engine_id = (
-                    f"{vllm_config.kv_transfer_config.engine_id}_dp{local_dp_rank}"
+                    f"{vllm_config.kv_transfer_config.engine_id}_dp{dp_rank}"
                 )
                 logger.debug(
                     "Setting kv_transfer_config.engine_id to %s",

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1685,9 +1685,9 @@ class DPEngineCoreProc(EngineCoreProc):
         client_handshake_address: str | None = None,
         tensor_queue: Queue | None = None,
     ):
-        assert vllm_config.model_config.is_moe, (
-            "DPEngineCoreProc should only be used for MoE models"
-        )
+        assert (
+            vllm_config.model_config.is_moe
+        ), "DPEngineCoreProc should only be used for MoE models"
 
         # Counts forward-passes of the model so that we can synchronize
         # finished with DP peers every N steps.

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -86,7 +86,7 @@ from vllm.version import __version__ as VLLM_VERSION
 
 logger = init_logger(__name__)
 
-HANDSHAKE_TIMEOUT_MINS = 5
+HANDSHAKE_TIMEOUT_MINS = int(os.environ.get("VLLM_HANDSHAKE_TIMEOUT_MINS", "5"))
 
 _R = TypeVar("_R")  # Return type for collective_rpc
 

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -430,6 +430,14 @@ class CoreEngineActorManager:
             dp_vllm_config.parallel_config.placement_group = pg
             local_client = index < local_engine_count
 
+            if dp_size > 1 and dp_vllm_config.kv_transfer_config is not None:
+                # Use the global index (not local_index) to ensure
+                # engine_ids are globally unique across all nodes in
+                # multi-node data parallel deployments.
+                dp_vllm_config.kv_transfer_config.engine_id = (
+                    f"{dp_vllm_config.kv_transfer_config.engine_id}_dp{index}"
+                )
+
             # Ray XPU known issue: dpctl initializes the GPU runtime early, so
             # setting device env vars in Ray actor's initialization method
             # will not affect device selection. See:

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -401,12 +401,12 @@ class CoreEngineActorManager:
             self._coord_store = store
 
         if placement_groups is not None:
-            assert local_dp_ranks is not None, (
-                "local_dp_ranks must be provided if placement_groups is provided"
-            )
-            assert len(placement_groups) == len(local_dp_ranks), (
-                "placement_groups and local_dp_ranks must have the same length"
-            )
+            assert (
+                local_dp_ranks is not None
+            ), "local_dp_ranks must be provided if placement_groups is provided"
+            assert len(placement_groups) == len(
+                local_dp_ranks
+            ), "placement_groups and local_dp_ranks must have the same length"
             logger.info("Using provided placement groups")
             # TODO(rui): validate passed-in placement groups
             self.created_placement_groups = []
@@ -415,9 +415,9 @@ class CoreEngineActorManager:
                 CoreEngineActorManager.create_dp_placement_groups(vllm_config)
             )
             self.created_placement_groups = placement_groups
-        assert len(placement_groups) == dp_size, (
-            "Number of placement groups must match data parallel size"
-        )
+        assert (
+            len(placement_groups) == dp_size
+        ), "Number of placement groups must match data parallel size"
 
         self.placement_group_is_local = []
         refs = []
@@ -511,9 +511,9 @@ class CoreEngineActorManager:
             available_resources.values(), key=lambda x: dp_master_ip_key not in x
         )
         assert len(nodes) > 0, "No nodes with resources found in Ray cluster."
-        assert dp_master_ip_key in nodes[0], (
-            f"The DP master node (ip: {dp_master_ip}) is missing or dead"
-        )
+        assert (
+            dp_master_ip_key in nodes[0]
+        ), f"The DP master node (ip: {dp_master_ip}) is missing or dead"
         device_str = current_platform.ray_device_key
         n_node_devices: list[int] = [
             int(node_resources[device_str])
@@ -557,9 +557,9 @@ class CoreEngineActorManager:
 
             # if we need multiple nodes per dp group, we require for now that
             # available nodes are homogeneous
-            assert set(n_node_devices) == {max_device_per_node}, (
-                f"Nodes are not homogeneous, {nodes}"
-            )
+            assert set(n_node_devices) == {
+                max_device_per_node
+            }, f"Nodes are not homogeneous, {nodes}"
             assert world_size % max_device_per_node == 0, (
                 f"For multi-node data parallel groups, world_size ({world_size}) must "
                 f"be a multiple of number of devices per node ({max_device_per_node})."
@@ -587,9 +587,9 @@ class CoreEngineActorManager:
                 and key.startswith("node:")
                 and "_group_" not in key
             ]
-            assert len(node_ip_keys) == 1, (
-                f"Zero or multiple node IP keys found in node resources: {node_ip_keys}"
-            )
+            assert (
+                len(node_ip_keys) == 1
+            ), f"Zero or multiple node IP keys found in node resources: {node_ip_keys}"
             node_ip_key = node_ip_keys[0]
             node_ip = node_ip_key.split(":")[1]
 
@@ -675,9 +675,9 @@ class CoreEngineActorManager:
                 "Available resources: "
                 f"{available_resources}"
             )
-        assert len(placement_groups) == dp_size, (
-            f"Created {len(placement_groups)} DP placement groups, expected {dp_size}"
-        )
+        assert (
+            len(placement_groups) == dp_size
+        ), f"Created {len(placement_groups)} DP placement groups, expected {dp_size}"
         assert len(local_dp_ranks) == dp_size, (
             f"local_dp_ranks length {len(local_dp_ranks)} does not match "
             f"expected {dp_size}"
@@ -710,9 +710,9 @@ class CoreEngineActorManager:
         nodes = list_nodes()
         nodes = sorted(nodes, key=lambda node: node.node_ip != dp_master_ip)
         assert nodes[0].node_ip == dp_master_ip, "The first node must be the head node"
-        assert len(nodes) == 1 or nodes[1].node_ip != dp_master_ip, (
-            "There can only be one head node"
-        )
+        assert (
+            len(nodes) == 1 or nodes[1].node_ip != dp_master_ip
+        ), "There can only be one head node"
 
         available_resources = available_resources_per_node()
         total_resources = total_resources_per_node()


### PR DESCRIPTION
## Summary

### 1. Engine_id collision fix (`core.py`, `utils.py`)

Use global `dp_rank` instead of `local_dp_rank` when generating the engine_id suffix for KV transfer in data-parallel deployments. In multi-node DP with `--headless` child nodes, using `local_dp_rank` causes master and child nodes to produce identical engine_ids, routing all data to whichever engine registered first.

### 2. MoRIIOConnector fixes (`moriio_connector.py`, `moriio_common.py`)

**Fix A -- Cache `kv_transfer_params` across scheduler steps:** Snapshot into `_req_kv_params` dict at allocation time; use cached copy in `build_connector_meta`. Handles chunked prefill correctly: params are retained for requests moved to `_reqs_need_pending_save` and only cleaned up when the final chunk is processed.

**Fix B -- Handle attention backend `block_size` overrides:** FlashMLA silently overrides `block_size` to 64 for MLA models. Trust the actual tensor shape instead of asserting against the CLI config value.

**Fix C -- Default values for MORI-IO-specific ports:** `remote_handshake_port` and `remote_notify_port` now use `.get()` with `MoRIIOConstants` defaults, preventing `KeyError` from external coordinators (e.g., NIXL sidecar in LLM-D).

**Fix D -- Multi-node DP sizing and ranking:** Use `data_parallel_size_local` and local `dp_rank` (`global % local_size`) so port offsets stay in 0..N range per node. Applied to both `MoRIIOConfig.from_vllm_config` and `MoRIIOConnectorScheduler`.

**Fix E -- Prevent child nodes from sending block notifications:** Added `_is_kv_master` flag to guard `send_notify_block` calls.

### 3. MoRIIO robustness fixes (`moriio_engine.py`, `moriio_connector.py`)

**Fix F -- Timeout-guarded transfer completion:** Replace blocking `status.Wait()` with a polling loop bounded by `VLLM_MORIIO_TRANSFER_TIMEOUT_S` (default 120s).

**Fix G -- Failure detection in `_pop_done_transfers`:** Check `Failed()` status and implement age-based timeout for pending RDMA reads.

**Fix H -- Deferred task timeout:** Expire write tasks stuck waiting for remote block allocation after `VLLM_MORIIO_DEFERRED_TIMEOUT_S` (default 300s).

**Fix I -- ZMQ notification retry:** Non-blocking send with 3 retries and exponential backoff for transient ZMQ failures.

## Environment Variables

| Variable | Default | Description |
|----------|---------|-------------|
| `VLLM_MORIIO_TRANSFER_TIMEOUT_S` | 120 | Max seconds to wait for a single RDMA transfer |
| `VLLM_MORIIO_DEFERRED_TIMEOUT_S` | 300 | Max seconds a deferred write task waits for remote block allocation |

## Files Changed

| File | Lines | Change |
|------|-------|--------|
| `core.py` | +4/-3 | engine_id: local_dp_rank -> dp_rank |
| `utils.py` | +4/-3 | engine_id: local_index -> index |
| `moriio_common.py` | +11/-4 | Fix C (default ports), Fix D (local dp_size/dp_rank) |
| `moriio_connector.py` | +71/-17 | Fix A-E + Fix G (failure detection + timeout) |
| `moriio_engine.py` | +60/-21 | Fix F (transfer timeout), Fix H (deferred timeout), Fix I (ZMQ retry) |

Signed-off-by: Rav Gupta <ravi.gupta@amd.com>