### PR TITLE
[LoRA] Warn when adapter has zero effective modules after loading

### DIFF
--- a/vllm/lora/worker_manager.py
+++ b/vllm/lora/worker_manager.py
@@ -170,6 +170,43 @@ class WorkerLoRAManager:
                         ", ".join(sorted(target_modules)),
                     )
 
+            # Check that at least some LoRA modules will actually match
+            # the model's module paths. The suffix-based checks above
+            # validate module *names* (e.g., "down_proj"), but the actual
+            # weight application in _create_merged_loras_inplace uses
+            # full path matching. A mismatch can happen when the adapter
+            # was trained on a different model class than what vLLM
+            # serves (e.g., AutoModelForCausalLM vs a multimodal wrapper
+            # like ForConditionalGeneration that nests the language model
+            # under a prefix like "language_model.").
+            model_module_names = set(self._adapter_manager.modules.keys())
+            possible_model_names = model_module_names.copy()
+            if self._adapter_manager.is_pooling_model:
+                possible_model_names.update(
+                    n.removeprefix("model.") for n in model_module_names
+                )
+            effective_modules = [
+                name for name in lora.loras if name in possible_model_names
+            ]
+            if len(effective_modules) == 0 and len(lora.loras) > 0:
+                logger.warning(
+                    "LoRA adapter '%s' (path: '%s') has %d module(s) but "
+                    "NONE match the model's module paths. The adapter "
+                    "will have NO effect on inference. This commonly "
+                    "happens when the adapter was trained on a base "
+                    "model class (e.g., AutoModelForCausalLM) but vLLM "
+                    "serves a multimodal wrapper (e.g., "
+                    "ForConditionalGeneration) that nests the language "
+                    "model under a different prefix. "
+                    "Adapter modules: %s. "
+                    "Model modules (sample): %s.",
+                    lora_request.lora_name,
+                    lora_request.lora_path,
+                    len(lora.loras),
+                    sorted(lora.loras.keys())[:3],
+                    sorted(model_module_names)[:5],
+                )
+
         except FileNotFoundError as e:
             # FileNotFoundError should be raised if both
             # - No adapter found to download from huggingface (or in


### PR DESCRIPTION
## Purpose                                                

When a LoRA adapter is loaded whose weight keys pass the suffix-based validation (e.g., `down_proj` is a valid module name) but fail to match any actual model module by full path, vLLM silently accepts the adapter — returns 200 OK, appears  
in `/v1/models` — while it has **zero effect on inference**.  

This happens when the adapter was trained on a base language model class (e.g., `AutoModelForCausalLM` with module path `model.layers.X.mlp.down_proj`) but vLLM serves a multimodal wrapper (e.g., `Qwen3_5ForConditionalGeneration`) that nests
 the language model under `language_model.`, making the actual path `language_model.model.layers.X.mlp.down_proj`. The `hf_to_vllm_mapper` doesn't cover this CausalLM-to-ConditionalGeneration key mismatch.

The existing suffix check (`is_supported_lora_module`) passes because `down_proj` is valid. But `_create_merged_loras_inplace` silently skips the weights because the full path doesn't match — no warning, no error.                            

This PR adds a check in `WorkerLoRAManager._load_adapter()`: after loading, if the adapter has N LoRA modules but 0 match the model's actual module paths, emit a clear WARNING with both the adapter's module names and the model's module      
names.                                                    

## Test Plan                                              

Reproduce with Qwen3.5-27B served via vLLM with `--enable-lora`:                                                                                                                                                                                 

1. Train a LoRA adapter on `AutoModelForCausalLM` using peft, save with `model.save_pretrained()`                                                                                                                                                
2. Register via `POST /v1/load_lora_adapter` → 200 OK (no warning in current code)
3. Query with adapter name at `temperature=0, logprobs=True` → logprobs identical to base model                                                                                                                                                  

After this PR, step 2 emits:                                                                                                                                                                                                                     
WARNING: LoRA adapter 'my_adapter' (path: '/tmp/adapter') has 64 module(s) but NONE match                                                                                                                                                        
the model's module paths. The adapter will have NO effect on inference. ...                                                                                                                                                                      
Adapter modules: ['model.layers.0.mlp.down_proj', ...].                    
Model modules (sample): ['language_model.model.layers.0.mlp.down_proj', ...].                                                                                                                                                                    

## Test Result                                                                                                                                                                                                                                   

**Before this PR**: Adapter loaded silently, logprobs unchanged (delta = 0.000000). No indication of failure. Took a full day of debugging with deterministic logprobs comparison to diagnose.                                                   
                                                            
**After this PR**: Clear WARNING at load time showing the module path mismatch. Users can immediately see the prefix discrepancy and fix their adapter export.                                                                                   
                                                            
The check is pure logging — no behavioral change for correctly-matched adapters.