### PR TITLE
[Bugfix][Docs] Fix ReadTheDocs build crash from mocked torch decorator

### DIFF
--- a/docs/mkdocs/hooks/generate_argparse.py
+++ b/docs/mkdocs/hooks/generate_argparse.py
@@ -59,7 +59,7 @@ class PydanticMagicMock(MagicMock):
     """`MagicMock` that's able to generate pydantic-core schemas."""
 
     def __init__(self, *args, **kwargs):
-        name = kwargs.get("name", None)
+        name = kwargs.get("name")
         super().__init__(*args, **kwargs)
         self.__spec__ = ModuleSpec(name, None)
 

--- a/docs/mkdocs/hooks/generate_argparse.py
+++ b/docs/mkdocs/hooks/generate_argparse.py
@@ -59,7 +59,7 @@ class PydanticMagicMock(MagicMock):
     """`MagicMock` that's able to generate pydantic-core schemas."""
 
     def __init__(self, *args, **kwargs):
-        name = kwargs.pop("name", None)
+        name = kwargs.get("name", None)
         super().__init__(*args, **kwargs)
         self.__spec__ = ModuleSpec(name, None)
 
@@ -85,7 +85,8 @@ def auto_mock(module_name: str, attr: str, max_mocks: int = 100):
             logger.info("Mocking %s for argparse doc generation", e.name)
             sys.modules[e.name] = PydanticMagicMock(name=e.name)
         except Exception:
-            logger.exception("Failed to import %s.%s: %s", module_name, attr)
+            logger.exception("Failed to import %s.%s", module_name, attr)
+            raise
 
     raise ImportError(
         f"Failed to import {module_name}.{attr} after mocking {max_mocks} imports"


### PR DESCRIPTION
## Summary

- Fix `PydanticMagicMock` dropping the `name` kwarg before passing to `MagicMock.__init__`, which left `_mock_name` as `None` and caused `TypeError: unsupported operand type(s) for +: 'NoneType' and 'str'` when `@torch.compiler.assume_constant_result` (added in 2111997) was used as a decorator during import on ReadTheDocs
- Fix logging format string in `auto_mock` (3 `%s` placeholders but only 2 args) and re-raise non-`ModuleNotFoundError` exceptions instead of silently retrying 100 times

## Root cause

`PydanticMagicMock.__init__` used `kwargs.pop("name")` to extract the name for `ModuleSpec`, but this prevented `MagicMock.__init__` from receiving it. Without `name`, `MagicMock` sets `_mock_name = None`. When the mock is used as a decorator (`@torch.compiler.assume_constant_result`), the internal call tracking does `_new_parent._mock_name + '.'` → `None + '.'` → `TypeError`.

## Fix

Change `kwargs.pop("name", None)` to `kwargs.get("name", None)` so `name` is passed to both `MagicMock` (for `_mock_name`) and `ModuleSpec` (for `__spec__`).

## Test plan

- [ ] ReadTheDocs build succeeds on this PR (check the RTD status check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude