### PR TITLE
[Feature]: Support routed_experts export in disaggregated Prefill/Decode serving

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -92,6 +92,14 @@ class ChatCompletionResponseChoice(OpenAIBaseModel):
     # not part of the OpenAI spec but is useful for tracing the tokens
     # in agent scenarios
     token_ids: list[int] | None = None
+    routed_experts: list[list[list[int]]] | None = Field(
+        default=None,
+        description=(
+            "The routed expert indices for each generated token, with shape "
+            "[seq_len, num_layers, topk]. Only present when the server is "
+            "started with --enable-return-routed-experts."
+        ),
+    )
 
 
 class ChatCompletionResponse(OpenAIBaseModel):

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1368,6 +1368,11 @@ class OpenAIServingChat(OpenAIServing):
                     token_ids=(
                         as_list(output.token_ids) if request.return_token_ids else None
                     ),
+                    routed_experts=(
+                        output.routed_experts.tolist()
+                        if output.routed_experts is not None
+                        else None
+                    ),
                 )
                 choices.append(choice_data)
                 continue
@@ -1566,6 +1571,11 @@ class OpenAIServingChat(OpenAIServing):
                 stop_reason=output.stop_reason,
                 token_ids=(
                     as_list(output.token_ids) if request.return_token_ids else None
+                ),
+                routed_experts=(
+                    output.routed_experts.tolist()
+                    if output.routed_experts is not None
+                    else None
                 ),
             )
             choice_data = maybe_filter_parallel_tool_calls(choice_data, request)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1435,6 +1435,22 @@ class Scheduler(SchedulerInterface):
                 if finished:
                     kv_transfer_params = self._free_request(request)
 
+                    # For PD disaggregated serving, merge prefill and decode
+                    # routed_experts so the final output contains the complete trace.
+                    # The prefill experts come from request.kv_transfer_params,
+                    # and decode experts from routed_experts captured above.
+                    if routed_experts is not None and request.kv_transfer_params:
+                        prefill_experts_list = request.kv_transfer_params.get(
+                            "routed_experts"
+                        )
+                        if prefill_experts_list is not None:
+                            prefill_experts = np.array(prefill_experts_list)
+                            # In-place merge: copy prefill experts into decode array
+                            routed_experts[: prefill_experts.shape[0]] = prefill_experts
+                        elif kv_transfer_params is not None:
+                            kv_transfer_params["routed_experts"] = (
+                                routed_experts.tolist()
+                            )
                 if status_before_stop == RequestStatus.RUNNING:
                     stopped_running_reqs.add(request)
                 else:


### PR DESCRIPTION
## Purpose

FIX #38523

## Test Plan
```
# Proxy
python tests/v1/kv_connector/nixl_integration/toy_proxy_server.py --prefiller-hosts 172.16.1.247 --decoder-hosts 172.16.1.247 --decoder-ports 8002 --prefiller-ports 8001 --port 800

# Decode
vllm serve /mnt/data3/models/Qwen/Qwen3.5-35B-A3B --enable-auto-tool-choice --tool-call-parser qwen3_coder  --served-model-name my-model  --enable_return_routed_experts --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_load_failure_policy":"fail"}' --port 8002 --no-disable-hybrid-kv-cache-manager


# Prefill
vllm serve /mnt/data3/models/Qwen/Qwen3.5-35B-A3B --enable-auto-tool-choice --tool-call-parser qwen3_coder  --served-model-name my-model  --enable_return_routed_experts --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both","kv_load_failure_policy":"fail"}' --port 8001 --no-disable-hybrid-kv-cache-manager
```
## Test Result

```
openai_api_key = "EMPTY"
openai_api_base = "http://localhost:8003/v1"   # Proxy port

client = OpenAI(
    api_key=openai_api_key,
    base_url=openai_api_base,
)
messages = [{"role": "user", "content": "9.11 and 9.8, which is lower?"}]
response = client.chat.completions.create(
    model="my-model",
    messages=messages,
    stream=stream,
    n=1,
    max_tokens=5
)

for choice in response.choices:
    print("---")
    print(len(choice.routed_experts))

---
28

```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
