### PR TITLE
Optimize unnecessary all reduce in MiniMaxText01RMSNormTP for MinimaxM2

### DIFF
--- a/vllm/model_executor/layers/mamba/linear_attn.py
+++ b/vllm/model_executor/layers/mamba/linear_attn.py
@@ -84,13 +84,35 @@ class MiniMaxText01RMSNormTP(CustomOp):
         k_norm: "MiniMaxText01RMSNormTP",
         q: torch.Tensor,
         k: torch.Tensor,
+        skip_all_reduce: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        """
+        Apply RMSNorm to Q and K tensors.
+
+        Args:
+            q_norm: RMSNorm layer for query.
+            k_norm: RMSNorm layer for key.
+            q: Query tensor of shape [..., num_heads * head_dim].
+            k: Key tensor of shape [..., num_kv_heads * head_dim].
+            skip_all_reduce: If True, skip all-reduce during variance computation.
+                Set to True when Q/K are sharded by head dimension (not TP),
+                since each rank's head partition already has complete variance.
+                Set to False when Q/K are replicated across TP ranks and
+                variance needs to be synchronized.
+
+        Returns:
+            Normalized Q and K tensors.
+        """
         orig_dtype = q.dtype
         q = q.to(torch.float32)
         k = k.to(torch.float32)
         q_var = q.pow(2).mean(dim=-1, keepdim=True)
         k_var = k.pow(2).mean(dim=-1, keepdim=True)
-        if q_norm.tp_world > 1:
+        # All-reduce is only needed when Q/K are replicated across TP ranks.
+        # When Q/K are sharded by head dimension, each rank computes variance
+        # on its own head partition, which is already complete and doesn't
+        # require cross-rank synchronization.
+        if not skip_all_reduce and q_norm.tp_world > 1:
             qk_var = torch.cat([q_var, k_var], dim=-1)
             qk_var = tensor_model_parallel_all_reduce(qk_var) / q_norm.tp_world
             q_var, k_var = qk_var.chunk(2, dim=-1)

--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -234,7 +234,11 @@ class MiniMaxM2Attention(nn.Module):
         qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         q, k = MiniMaxText01RMSNormTP.forward_qk(
-            self.q_norm, self.k_norm, q.contiguous(), k.contiguous()
+            self.q_norm,
+            self.k_norm,
+            q.contiguous(),
+            k.contiguous(),
+            skip_all_reduce=True,
         )
         q, k = self.rotary_emb(positions, q, k)
         attn_output = self.attn(q, k, v)


### PR DESCRIPTION
## Purpose

Optimize `MiniMaxText01RMSNormTP.forward_qk` by skipping unnecessary tensor parallel all-reduce operation when Q/K tensors are sharded by head dimension.

In the MiniMaxM2 model's attention layer, Q and K tensors are partitioned along the head dimension via `QKVParallelLinear`. When computing RMSNorm variance (`q.pow(2).mean(dim=-1)`), each rank already has the complete variance for its own head partition—no cross-rank synchronization is needed.

However, the original implementation always performed `tensor_model_parallel_all_reduce` when `tp_world > 1`, which introduced unnecessary communication overhead.

>  Why all-reduce is unnecessary for head-dimension sharding:
> 
> In MiniMaxM2's attention layer, QKV tensors are partitioned along the head dimension through QKVParallelLinear. When computing RMSNorm variance via q.pow(2).mean(dim=-1), since the variance is computed along the last dimension (head_dim), each rank already obtains complete variance results for its own head partition. No cross-rank synchronization via all-reduce is required.

## Test Result

A800, Minimax-M2.5-AWQ, TP=4+EP , prompt 1 token, generation 1000 tokens

before

  | max_concurrency=1 | max_concurrency=4 | max_concurrency=16
-- | -- | -- | --
output_throughput | 98.88  | 327.29 | 952.38 
mean_ttft | 49.39 | 60.79 | 1992.45
median_ttft | 38.97 | 62.16 | 143.83
p99_ttft | 87.55 | 76.78 | 8968.62
mean_itl | 10.09 | 12.18 | 16.83
median_itl | 10.07 | 12.15 | 16.58
p99_itl | 18.00 | 20.36 | 27.68

after 

  | max_concurrency=1 | max_concurrency=4 | max_concurrency=16
-- | -- | -- | --
output_throughput | 108.67 | 335.75 | 988.26
mean_ttft | 38.42 | 57.74 | 133.40
median_ttft | 36.98 | 56.08 | 135.13
p99_ttft | 41.54 | 81.23 | 181.09
mean_itl | 9.17 | 11.87 | 16.19
median_itl | 9.16 | 11.86 | 16.19
p99_itl | 17.42 | 17.59 | 24.27

Evaluations were run on Minimax-M2.5-AWQ

- [ ] The evaluation results will be attached later.