### PR TITLE
fix(ci): pin setup-uv action to immutable commit SHA

### DIFF
--- a/.github/workflows/macos-smoke-test.yml
+++ b/.github/workflows/macos-smoke-test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.1
 
-      - uses: astral-sh/setup-uv@v7
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7
         with:
           enable-cache: true
           cache-dependency-glob: |


### PR DESCRIPTION
Pins astral-sh/setup-uv in .github/workflows/macos-smoke-test.yml from mutable tag @v7 to the corresponding immutable commit SHA.

- before: astral-sh/setup-uv@v7
- after: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 (v7)

This hardens CI against tag-retargeting supply-chain risk while keeping behavior unchanged.

Fixes #39199