### PR TITLE
[Bugfix] FlashInfer MXINT4 MoE crashes, missing do_finalize

### DIFF
--- a/tests/kernels/moe/test_marlin_vs_trtllm_mxint4.py
+++ b/tests/kernels/moe/test_marlin_vs_trtllm_mxint4.py
@@ -269,3 +269,78 @@ def test_marlin_vs_trtllm_mxint4_moe_kimik2(monkeypatch, m, n, k, e, topk, group
     # Note: Different quantization schemes (UINT4b8 vs signed MXINT4) cause
     # some differences
     torch.testing.assert_close(marlin_output, trtllm_output, atol=0.3, rtol=6.0)
+
+
+@pytest.mark.skipif(not TRTLLM_GEN_AVAILABLE, reason="Skip for non SM100")
+@pytest.mark.parametrize("m", [1, 33])
+@pytest.mark.parametrize("n", [1024])
+@pytest.mark.parametrize("k", [512])
+@pytest.mark.parametrize("e", [64])
+@pytest.mark.parametrize("topk", [4])
+@torch.inference_mode()
+def test_flashinfer_trtllm_mxint4_moe_wrapper(m, n, k, e, topk):
+    """Test the flashinfer_trtllm_mxint4_moe wrapper against BF16 reference."""
+    pytest.importorskip("flashinfer")
+    from flashinfer import RoutingMethodType
+
+    from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
+        grouped_topk,
+    )
+    from vllm.model_executor.layers.quantization.utils.flashinfer_mxint4_moe import (
+        flashinfer_trtllm_mxint4_moe,
+    )
+
+    torch.cuda.manual_seed(0)
+    dtype = torch.bfloat16
+
+    a = torch.randn((m, k), device="cuda", dtype=dtype) * 0.5
+    router_logits = torch.randn((m, e), device="cuda", dtype=torch.float32)
+    w1_bf16 = torch.randn((e, 2 * n, k), device="cuda", dtype=dtype) * 0.1
+    w2_bf16 = torch.randn((e, k, n), device="cuda", dtype=dtype) * 0.1
+
+    w1_int4, w1_scales = mxint4_quantize_moe_weights(w1_bf16)
+    w2_int4, w2_scales = mxint4_quantize_moe_weights(w2_bf16)
+
+    prepared = prepare_static_weights_for_trtllm_mxint4_moe(
+        gemm1_weights=w1_int4,
+        gemm1_scales=w1_scales,
+        gemm2_weights=w2_int4,
+        gemm2_scales=w2_scales,
+    )
+
+    out = flashinfer_trtllm_mxint4_moe(
+        x=a,
+        router_logits=router_logits,
+        w13_weight_packed=prepared["gemm1_weights"],
+        w13_weight_scale=prepared["gemm1_scales"],
+        w2_weight_packed=prepared["gemm2_weights"],
+        w2_weight_scale=prepared["gemm2_scales"],
+        global_num_experts=e,
+        top_k=topk,
+        intermediate_size_per_partition=n,
+        local_num_experts=e,
+        ep_rank=0,
+        routing_method_type=RoutingMethodType.TopK,
+    )
+
+    assert out.shape == (m, k)
+    assert out.dtype == dtype
+
+    # BF16 reference using same routing
+    topk_weights, topk_ids = grouped_topk(
+        hidden_states=a,
+        gating_output=router_logits,
+        topk=topk,
+        renormalize=False,
+    )
+    bf16_output = torch.zeros((m, k), device="cuda", dtype=dtype)
+    for token_idx in range(m):
+        for expert_rank in range(topk):
+            eid = topk_ids[token_idx, expert_rank].item()
+            w = topk_weights[token_idx, expert_rank].item()
+            up_gate = a[token_idx] @ w1_bf16[eid].T
+            gate, up = up_gate.chunk(2, dim=0)
+            expert_out = (torch.nn.functional.silu(gate) * up) @ w2_bf16[eid].T
+            bf16_output[token_idx] += w * expert_out
+
+    torch.testing.assert_close(out, bf16_output, atol=0.3, rtol=1.0)

--- a/tests/kernels/moe/test_marlin_vs_trtllm_mxint4.py
+++ b/tests/kernels/moe/test_marlin_vs_trtllm_mxint4.py
@@ -273,19 +273,18 @@ def test_marlin_vs_trtllm_mxint4_moe_kimik2(monkeypatch, m, n, k, e, topk, group
 
 @pytest.mark.skipif(not TRTLLM_GEN_AVAILABLE, reason="Skip for non SM100")
 @pytest.mark.parametrize("m", [1, 33])
-@pytest.mark.parametrize("n", [1024])
+@pytest.mark.parametrize("n", [7168])
 @pytest.mark.parametrize("k", [512])
-@pytest.mark.parametrize("e", [64])
-@pytest.mark.parametrize("topk", [4])
+@pytest.mark.parametrize("e", [384])
+@pytest.mark.parametrize("topk", [8])
 @torch.inference_mode()
 def test_flashinfer_trtllm_mxint4_moe_wrapper(m, n, k, e, topk):
-    """Test the flashinfer_trtllm_mxint4_moe wrapper against BF16 reference."""
+    """Test that the flashinfer_trtllm_mxint4_moe wrapper matches the raw
+    trtllm_mxint4_block_scale_moe kernel call."""
     pytest.importorskip("flashinfer")
     from flashinfer import RoutingMethodType
+    from flashinfer.fused_moe import trtllm_mxint4_block_scale_moe
 
-    from vllm.model_executor.layers.fused_moe.router.grouped_topk_router import (
-        grouped_topk,
-    )
     from vllm.model_executor.layers.quantization.utils.flashinfer_mxint4_moe import (
         flashinfer_trtllm_mxint4_moe,
     )
@@ -294,9 +293,13 @@ def test_flashinfer_trtllm_mxint4_moe_wrapper(m, n, k, e, topk):
     dtype = torch.bfloat16
 
     a = torch.randn((m, k), device="cuda", dtype=dtype) * 0.5
-    router_logits = torch.randn((m, e), device="cuda", dtype=torch.float32)
-    w1_bf16 = torch.randn((e, 2 * n, k), device="cuda", dtype=dtype) * 0.1
-    w2_bf16 = torch.randn((e, k, n), device="cuda", dtype=dtype) * 0.1
+    router_logits = torch.randn((m, e), device="cuda", dtype=torch.float32) * 1.5
+    routing_bias = torch.randn(e, device="cuda", dtype=torch.float32) * 0.8
+
+    std_w1 = (2.0 / (k + 2 * n)) ** 0.5
+    std_w2 = (2.0 / (n + k)) ** 0.5
+    w1_bf16 = torch.randn((e, 2 * n, k), device="cuda", dtype=dtype) * std_w1
+    w2_bf16 = torch.randn((e, k, n), device="cuda", dtype=dtype) * std_w2
 
     w1_int4, w1_scales = mxint4_quantize_moe_weights(w1_bf16)
     w2_int4, w2_scales = mxint4_quantize_moe_weights(w2_bf16)
@@ -308,7 +311,37 @@ def test_flashinfer_trtllm_mxint4_moe_wrapper(m, n, k, e, topk):
         gemm2_scales=w2_scales,
     )
 
-    out = flashinfer_trtllm_mxint4_moe(
+    # Raw kernel call (reference)
+    raw_out = trtllm_mxint4_block_scale_moe(
+        routing_logits=router_logits.to(torch.float32),
+        routing_bias=routing_bias.to(torch.bfloat16),
+        hidden_states=a,
+        gemm1_weights=prepared["gemm1_weights"].data,
+        gemm1_weights_scale=prepared["gemm1_scales"].data,
+        gemm1_alpha=None,
+        gemm1_beta=None,
+        gemm1_clamp_limit=None,
+        gemm2_weights=prepared["gemm2_weights"].data,
+        gemm2_weights_scale=prepared["gemm2_scales"].data,
+        num_experts=e,
+        top_k=topk,
+        n_group=1,
+        topk_group=1,
+        intermediate_size=n,
+        local_expert_offset=0,
+        local_num_experts=e,
+        routed_scaling_factor=None,
+        routing_method_type=RoutingMethodType.DeepSeekV3,
+        enable_pdl=None,
+        output=None,
+        tune_max_num_tokens=8192,
+    )
+    if not isinstance(raw_out, torch.Tensor):
+        raw_out = raw_out[0]
+    raw_out = raw_out.to(dtype)
+
+    # Wrapper call
+    wrapper_out = flashinfer_trtllm_mxint4_moe(
         x=a,
         router_logits=router_logits,
         w13_weight_packed=prepared["gemm1_weights"],
@@ -320,27 +353,12 @@ def test_flashinfer_trtllm_mxint4_moe_wrapper(m, n, k, e, topk):
         intermediate_size_per_partition=n,
         local_num_experts=e,
         ep_rank=0,
-        routing_method_type=RoutingMethodType.TopK,
+        num_expert_group=1,
+        topk_group=1,
+        e_score_correction_bias=routing_bias,
+        routing_method_type=RoutingMethodType.DeepSeekV3,
     )
 
-    assert out.shape == (m, k)
-    assert out.dtype == dtype
-
-    # BF16 reference using same routing
-    topk_weights, topk_ids = grouped_topk(
-        hidden_states=a,
-        gating_output=router_logits,
-        topk=topk,
-        renormalize=False,
-    )
-    bf16_output = torch.zeros((m, k), device="cuda", dtype=dtype)
-    for token_idx in range(m):
-        for expert_rank in range(topk):
-            eid = topk_ids[token_idx, expert_rank].item()
-            w = topk_weights[token_idx, expert_rank].item()
-            up_gate = a[token_idx] @ w1_bf16[eid].T
-            gate, up = up_gate.chunk(2, dim=0)
-            expert_out = (torch.nn.functional.silu(gate) * up) @ w2_bf16[eid].T
-            bf16_output[token_idx] += w * expert_out
-
-    torch.testing.assert_close(out, bf16_output, atol=0.3, rtol=1.0)
+    assert wrapper_out.shape == (m, k)
+    assert wrapper_out.dtype == dtype
+    torch.testing.assert_close(wrapper_out, raw_out, atol=0.0, rtol=0.0)

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_mxint4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_mxint4_moe.py
@@ -263,7 +263,7 @@ def flashinfer_trtllm_mxint4_moe(
         output=None,
         tune_max_num_tokens=8192,
     )
-    if not isinstance(out, torch.Tensor):
+    if isinstance(out, (tuple, list)):
         out = out[0]
     out = out.to(x.dtype)
 

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_mxint4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_mxint4_moe.py
@@ -259,8 +259,12 @@ def flashinfer_trtllm_mxint4_moe(
         routed_scaling_factor=None,
         routing_method_type=routing_method_type,
         enable_pdl=None,
+        do_finalize=True,
         output=None,
         tune_max_num_tokens=8192,
-    ).to(x.dtype)
+    )
+    if not isinstance(out, torch.Tensor):
+        out = out[0]
+    out = out.to(x.dtype)
 
     return out


### PR DESCRIPTION
## Purpose

In FlashInfer 0.6.4 the interface to the fused MoE backends changed. MXINT4 did not get updated. This means that `VLLM_USE_FLASHINFER_MOE_INT4` has been unusable in vLLM since v0.15.1. 

FIX https://github.com/vllm-project/vllm/issues/39245

## Test Plan

Launches fine with the flag enabled. GSM8k pass, 1k1k runs ~4% faster with this flag enabled

## Test Result

<details><summary>Details</summary>
<p>

### vLLM 0.19.0 with `VLLM_USE_FLASHINFER_MOE_INT4=0`:

```
Running GSM8K evaluation: 1319 questions, 5-shot
Evaluating: 100%|...| 1319/1319 [02:23<00:00,  9.18it/s]

Results:
Accuracy: 0.936
Invalid responses: 0.001
Total latency: 143.735 s
Questions per second: 9.177
Total output tokens: 130628
Output tokens per second: 908.814

============ Serving Benchmark Result ============
Successful requests:                     10        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  85.87     
Total input tokens:                      9704      
Total generated tokens:                  11079     
Request throughput (req/s):              0.12      
Output token throughput (tok/s):         129.02    
Peak output token throughput (tok/s):    131.00    
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          242.03    
---------------Time to First Token----------------
Mean TTFT (ms):                          120.90    
Median TTFT (ms):                        120.83    
P99 TTFT (ms):                           130.67    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          7.65      
Median TPOT (ms):                        7.65      
P99 TPOT (ms):                           7.66      
---------------Inter-token Latency----------------
Mean ITL (ms):                           7.65      
Median ITL (ms):                         7.65      
P99 ITL (ms):                            8.11      
==================================================

============ Serving Benchmark Result ============
Successful requests:                     320       
Failed requests:                         0         
Maximum request concurrency:             32        
Benchmark duration (s):                  218.74    
Total input tokens:                      330012    
Total generated tokens:                  330878    
Request throughput (req/s):              1.46      
Output token throughput (tok/s):         1512.62   
Peak output token throughput (tok/s):    2112.00   
Peak concurrent requests:                37.00     
Total token throughput (tok/s):          3021.29   
---------------Time to First Token----------------
Mean TTFT (ms):                          242.22    
Median TTFT (ms):                        152.04    
P99 TTFT (ms):                           1527.05   
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          20.28     
Median TPOT (ms):                        20.56     
P99 TPOT (ms):                           21.35     
---------------Inter-token Latency----------------
Mean ITL (ms):                           20.28     
Median ITL (ms):                         17.69     
P99 ITL (ms):                            117.64    
==================================================
```

### vLLM 0.19.0 with `VLLM_USE_FLASHINFER_MOE_INT4=1`:

```
Evaluating: 100%|...| 1319/1319 [02:26<00:00,  8.98it/s]

Results:
Accuracy: 0.939
Invalid responses: 0.000
Total latency: 146.937 s
Questions per second: 8.977
Total output tokens: 130571
Output tokens per second: 888.617

============ Serving Benchmark Result ============
Successful requests:                     10        
Failed requests:                         0         
Maximum request concurrency:             1         
Benchmark duration (s):                  82.66     
Total input tokens:                      9704      
Total generated tokens:                  11079     
Request throughput (req/s):              0.12      
Output token throughput (tok/s):         134.03    
Peak output token throughput (tok/s):    137.00    
Peak concurrent requests:                2.00      
Total token throughput (tok/s):          251.43    
---------------Time to First Token----------------
Mean TTFT (ms):                          127.76    
Median TTFT (ms):                        127.03    
P99 TTFT (ms):                           132.25    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          7.35      
Median TPOT (ms):                        7.35      
P99 TPOT (ms):                           7.36      
---------------Inter-token Latency----------------
Mean ITL (ms):                           7.35      
Median ITL (ms):                         7.35      
P99 ITL (ms):                            7.82      
==================================================

============ Serving Benchmark Result ============
Successful requests:                     320       
Failed requests:                         0         
Maximum request concurrency:             32        
Benchmark duration (s):                  210.17    
Total input tokens:                      330012    
Total generated tokens:                  330878    
Request throughput (req/s):              1.52      
Output token throughput (tok/s):         1574.30   
Peak output token throughput (tok/s):    2176.00   
Peak concurrent requests:                37.00     
Total token throughput (tok/s):          3144.48   
---------------Time to First Token----------------
Mean TTFT (ms):                          211.33    
Median TTFT (ms):                        159.28    
P99 TTFT (ms):                           889.39    
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          19.52     
Median TPOT (ms):                        19.84     
P99 TPOT (ms):                           20.70     
---------------Inter-token Latency----------------
Mean ITL (ms):                           19.53     
Median ITL (ms):                         16.70     
P99 ITL (ms):                            127.00    
==================================================
```

</p>
</details> 
