### PR TITLE
[Attention] Add Triton fallback for encoder attention on SM100+ 

### DIFF
--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -748,7 +748,7 @@ def test_sliding_window_encoder_backend_correctness(
         "medium_encoder_prefill",
     ],
 )
-@pytest.mark.parametrize("model", ["google/embeddinggemma-300m"])
+@pytest.mark.parametrize("model", ["facebook/opt-125m"])
 @pytest.mark.parametrize("tensor_parallel_size", [1, 2])
 def test_flash_attn_encoder_triton_fallback(
     batch_spec_name: str, model: str, tensor_parallel_size: int
@@ -760,37 +760,34 @@ def test_flash_attn_encoder_triton_fallback(
 
     from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
 
-    batch_spec = BATCH_SPECS[batch_spec_name]
-    model_config = ModelConfig(model=model, max_model_len=max(batch_spec.seq_lens))
-    sliding_window = model_config.get_sliding_window()
-
-    def bidi_sliding_window_mask_mod(
+    def encoder_mask_mod(
         b: torch.Tensor,
         h: torch.Tensor,
         q_idx: torch.Tensor,
         kv_idx: torch.Tensor,
         *,
         context_len: int,
-        sliding_window: int,
     ):
-        return torch.abs(q_idx + context_len - kv_idx) < sliding_window
+        return torch.ones_like(q_idx, dtype=torch.bool)
 
-    sliding_window_mask_mod_fn = partial(
-        bidi_sliding_window_mask_mod, sliding_window=sliding_window
-    )
+    batch_spec = BATCH_SPECS[batch_spec_name]
 
     # Force the Triton fallback path by redirecting the encoder attention
-    # method to the Triton implementation.
+    # method to the Triton implementation.  The wrapper drops the `layer`
+    # arg that the caller passes but the Triton path doesn't need.
+    def _triton_encoder_attn(self, q, k, v, o, meta, layer):
+        return self._forward_encoder_attention_triton(q, k, v, o, meta)
+
     with unittest.mock.patch.object(
         FlashAttentionImpl,
         "_forward_encoder_attention",
-        FlashAttentionImpl._forward_encoder_attention_triton,
+        _triton_encoder_attn,
     ):
         _test_backend_correctness(
             batch_spec,
             model,
             [AttentionBackendEnum.FLASH_ATTN],
-            sliding_window_mask_mod_fn,
+            encoder_mask_mod,
             attn_type=AttentionType.ENCODER_ONLY,
             tensor_parallel_size=tensor_parallel_size,
         )

--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -749,17 +749,16 @@ def test_sliding_window_encoder_backend_correctness(
     ],
 )
 @pytest.mark.parametrize("model", ["google/embeddinggemma-300m"])
-def test_flash_attn_encoder_triton_fallback(batch_spec_name: str, model: str):
-    """Test that the Triton fallback for encoder attention in the
-    FlashAttention backend produces correct results.
-
-    On Blackwell (SM 10.0+), FA2 lacks SM100 cubins so
-    ``FlashAttentionImpl._forward_encoder_attention`` must fall back to
-    the Triton-based ``context_attention_fwd`` kernel. This test forces
-    the fallback path via ``_use_triton_for_encoder_attn = True`` and
-    verifies numerical correctness against an SDPA reference.
-    """
+@pytest.mark.parametrize("tensor_parallel_size", [1, 2])
+def test_flash_attn_encoder_triton_fallback(
+    batch_spec_name: str, model: str, tensor_parallel_size: int
+):
+    """Test that the Triton fallback for encoder attention produces correct
+    results. On SM100+ (Blackwell), FA2 lacks cubins so encoder attention
+    falls back to the Triton-based context_attention_fwd kernel."""
     import unittest.mock
+
+    from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
 
     batch_spec = BATCH_SPECS[batch_spec_name]
     model_config = ModelConfig(model=model, max_model_len=max(batch_spec.seq_lens))
@@ -780,22 +779,18 @@ def test_flash_attn_encoder_triton_fallback(batch_spec_name: str, model: str):
         bidi_sliding_window_mask_mod, sliding_window=sliding_window
     )
 
-    # Force the Triton fallback path in FlashAttentionImpl by patching
-    # ``_use_triton_for_encoder_attn`` on the class so every instance
-    # created during the test run uses the Triton kernel.
-    from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
-
-    orig_init = FlashAttentionImpl.__init__
-
-    def patched_init(self, *args, **kwargs):
-        orig_init(self, *args, **kwargs)
-        self._use_triton_for_encoder_attn = True
-
-    with unittest.mock.patch.object(FlashAttentionImpl, "__init__", patched_init):
+    # Force the Triton fallback path by redirecting the encoder attention
+    # method to the Triton implementation.
+    with unittest.mock.patch.object(
+        FlashAttentionImpl,
+        "_forward_encoder_attention",
+        FlashAttentionImpl._forward_encoder_attention_triton,
+    ):
         _test_backend_correctness(
             batch_spec,
             model,
             [AttentionBackendEnum.FLASH_ATTN],
             sliding_window_mask_mod_fn,
             attn_type=AttentionType.ENCODER_ONLY,
+            tensor_parallel_size=tensor_parallel_size,
         )

--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -739,3 +739,63 @@ def test_sliding_window_encoder_backend_correctness(
         attn_type=AttentionType.ENCODER_ONLY,
         tensor_parallel_size=tensor_parallel_size,
     )
+
+
+@pytest.mark.parametrize(
+    "batch_spec_name",
+    [
+        "small_encoder_prefill",
+        "medium_encoder_prefill",
+    ],
+)
+@pytest.mark.parametrize("model", ["google/embeddinggemma-300m"])
+def test_flash_attn_encoder_triton_fallback(batch_spec_name: str, model: str):
+    """Test that the Triton fallback for encoder attention in the
+    FlashAttention backend produces correct results.
+
+    On Blackwell (SM 10.0+), FA2 lacks SM100 cubins so
+    ``FlashAttentionImpl._forward_encoder_attention`` must fall back to
+    the Triton-based ``context_attention_fwd`` kernel. This test forces
+    the fallback path via ``_use_triton_for_encoder_attn = True`` and
+    verifies numerical correctness against an SDPA reference.
+    """
+    import unittest.mock
+
+    batch_spec = BATCH_SPECS[batch_spec_name]
+    model_config = ModelConfig(model=model, max_model_len=max(batch_spec.seq_lens))
+    sliding_window = model_config.get_sliding_window()
+
+    def bidi_sliding_window_mask_mod(
+        b: torch.Tensor,
+        h: torch.Tensor,
+        q_idx: torch.Tensor,
+        kv_idx: torch.Tensor,
+        *,
+        context_len: int,
+        sliding_window: int,
+    ):
+        return torch.abs(q_idx + context_len - kv_idx) < sliding_window
+
+    sliding_window_mask_mod_fn = partial(
+        bidi_sliding_window_mask_mod, sliding_window=sliding_window
+    )
+
+    # Force the Triton fallback path in FlashAttentionImpl by patching
+    # ``_use_triton_for_encoder_attn`` on the class so every instance
+    # created during the test run uses the Triton kernel.
+    from vllm.v1.attention.backends.flash_attn import FlashAttentionImpl
+
+    orig_init = FlashAttentionImpl.__init__
+
+    def patched_init(self, *args, **kwargs):
+        orig_init(self, *args, **kwargs)
+        self._use_triton_for_encoder_attn = True
+
+    with unittest.mock.patch.object(FlashAttentionImpl, "__init__", patched_init):
+        _test_backend_correctness(
+            batch_spec,
+            model,
+            [AttentionBackendEnum.FLASH_ATTN],
+            sliding_window_mask_mod_fn,
+            attn_type=AttentionType.ENCODER_ONLY,
+        )

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -626,6 +626,18 @@ class FlashAttentionImpl(AttentionImpl):
         # Cache the batch invariant result for use in forward passes
         self.batch_invariant_enabled = envs.VLLM_BATCH_INVARIANT
 
+        # FA2 only ships cubins up to ~SM89; it lacks SM100+ cubins and has
+        # no PTX fallback, so it will crash at runtime on Blackwell (B200).
+        # When the encoder-attention path would use FA2 on SM >= 10.0 we
+        # fall back to the Triton-based ``context_attention_fwd`` kernel,
+        # which is device-agnostic (same approach the ROCm backend uses).
+        device_capability = current_platform.get_device_capability()
+        self._use_triton_for_encoder_attn = (
+            self.vllm_flash_attn_version == 2
+            and device_capability is not None
+            and device_capability.major >= 10
+        )
+
         if is_quantized_kv_cache(self.kv_cache_dtype) and not flash_attn_supports_fp8():
             raise NotImplementedError(
                 "FlashAttention does not support fp8 kv-cache on this device."
@@ -971,15 +983,22 @@ class FlashAttentionImpl(AttentionImpl):
             attn_metadata: Encoder attention metadata
             layer: The attention layer
         """
-        assert self.vllm_flash_attn_version is not None, (
-            "FlashAttention version not detected."
-        )
-
         # For encoder attention, process FP8 quantization if needed
         if is_quantized_kv_cache(self.kv_cache_dtype):
             raise NotImplementedError(
                 "quantization is not supported for encoder attention"
             )
+
+        # FA2 lacks SM100+ cubins, so fall back to the device-agnostic
+        # Triton kernel on Blackwell and newer architectures.
+        if self._use_triton_for_encoder_attn:
+            return self._forward_encoder_attention_triton(
+                query, key, value, output, attn_metadata
+            )
+
+        assert self.vllm_flash_attn_version is not None, (
+            "FlashAttention version not detected."
+        )
 
         # Use encoder-specific metadata for sequence information
         cu_seqlens_q = attn_metadata.query_start_loc
@@ -1017,6 +1036,39 @@ class FlashAttentionImpl(AttentionImpl):
             num_splits=1 if self.batch_invariant_enabled else 0,
         )
 
+        return output
+
+    def _forward_encoder_attention_triton(
+        self,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        output: torch.Tensor,
+        attn_metadata: FlashAttentionMetadata,
+    ) -> torch.Tensor:
+        """Triton fallback for encoder attention on devices where FA2 is
+        unsupported (e.g. Blackwell / SM100+).
+
+        Uses the same ``context_attention_fwd`` kernel that the Triton and
+        ROCm attention backends use for their encoder-attention paths.
+        """
+        from vllm.v1.attention.ops.triton_prefill_attention import (
+            context_attention_fwd,
+        )
+
+        context_attention_fwd(
+            q=query,
+            k=key,
+            v=value,
+            o=output,
+            b_start_loc=attn_metadata.query_start_loc,
+            b_seq_len=attn_metadata.seq_lens,
+            max_input_len=attn_metadata.max_query_len,
+            is_causal=False,  # Encoder attention is bidirectional
+            softmax_scale=self.scale,
+            sliding_window_q=self.sliding_window[0],
+            sliding_window_k=self.sliding_window[1],
+        )
         return output
 
 


### PR DESCRIPTION
## Purpose
Fixes https://github.com/vllm-project/vllm/issues/39210
## Test Plan
1. Created a test case to repro the issue
2. Tested without the patch and we run into the failure
3. Tested with the patch and it solves

If there is a better fix, or we can ship the FA2/3/4 kernel for SM100 that'll be much better than this silent fallback to Triton
