### PR TITLE
[Core] Cache InductorPass.hash_source with functools.cache

### DIFF
--- a/vllm/compilation/passes/inductor_pass.py
+++ b/vllm/compilation/passes/inductor_pass.py
@@ -51,6 +51,15 @@ def pass_context(compile_range: Range) -> Generator[None, None, None]:
         _pass_context = prev_context
 
 
+@functools.cache
+def _hash_source_cached(*srcs: str | type | types.FunctionType) -> str:
+    hasher = hashlib.sha256()
+    for src in srcs:
+        src_str = src if isinstance(src, str) else inspect.getsource(src)
+        hasher.update(src_str.encode("utf-8"))
+    return hasher.hexdigest()
+
+
 class InductorPass(CustomGraphPass):  # type: ignore[misc]
     """
     A custom graph pass that uses a hash of its source as the UUID.
@@ -72,19 +81,16 @@ class InductorPass(CustomGraphPass):  # type: ignore[misc]
         Utility method to hash the sources of functions or objects.
         :param srcs: strings or objects to add to the hash.
         Objects and functions have their source inspected.
+        Results are cached by resolved types to avoid repeated
+        inspect.getsource() calls.
         :return:
         """
-        hasher = hashlib.sha256()
-        for src in srcs:
-            if isinstance(src, str):
-                src_str = src
-            elif isinstance(src, (types.FunctionType, type)):
-                src_str = inspect.getsource(src)
-            else:
-                # object instance
-                src_str = inspect.getsource(src.__class__)
-            hasher.update(src_str.encode("utf-8"))
-        return hasher.hexdigest()
+        # Resolve instances to their class for a hashable cache key.
+        cache_key = tuple(
+            src if isinstance(src, (str, type, types.FunctionType)) else src.__class__
+            for src in srcs
+        )
+        return _hash_source_cached(*cache_key)
 
     @staticmethod
     def hash_dict(dict_: dict[Any, Any]) -> str:


### PR DESCRIPTION
## Purpose
InductorPass.hash_source() calls inspect.getsource() on every pass
class each time it's invoked, which is expensive. Since source code
doesn't change at runtime, extract the hashing into a module-level
_hash_source_cached() helper decorated with functools.cache. Object
instances are resolved to their __class__ for a hashable cache key,
eliminating repeated inspect.getsource() calls across all pass uuid()
computations.

## Test Plan
- tests/compile/passes/test_pass_manager.py (covers pass uuid computation)
- E2E: meta-llama/Meta-Llama-3-70B-Instruct, TP=4, cold compile

## Test Result
- 4/4 tests passed in test_pass_manager.py
- E2E test passed (cold compile 29.5s, correct output)
- Cold compile time: 29.70s ± 0.50s (baseline 34.10s ± 0.30s, 1.15x speedup)
- Cache lookup time: 11.30ms ± 0.30ms (baseline 32.50ms ± 1.05ms, 2.88x speedup)