### PR TITLE
[Core] Label torch trace logging overhead with dynamo_timed

### DIFF
--- a/vllm/compilation/piecewise_backend.py
+++ b/vllm/compilation/piecewise_backend.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import torch._functorch.config
 import torch.fx as fx
+from torch._dynamo.utils import dynamo_timed
 from torch._inductor.runtime.triton_heuristics import CachingAutotuner
 from torch._logging._internal import trace_structured
 
@@ -275,6 +276,7 @@ class PiecewiseBackend:
 
             range_entry.compiled = True
 
+    @dynamo_timed("vllm_log_compile_start_torch_trace_only")
     def _log_compile_start(self, compile_range: Range):
         """Log compilation event for TORCH_TRACE/tlparse."""
         is_cudagraph_size = (


### PR DESCRIPTION
## Purpose
Add dynamo_timed instrumentation to PiecewiseBackend._log_compile_start
so its cost is visible in torch compile traces. This helps identify
whether TORCH_TRACE/tlparse logging is a significant overhead during
compilation.

## Test Plan
- The decorator is observational only — no behavioral change.

## Test Result
- The decorator is observational only — no behavioral change.