### PR TITLE
Add tokens-per-expert threshold for DeepGemm vs Triton MoE dispatch

### DIFF
--- a/vllm/model_executor/layers/fused_moe/triton_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/triton_deep_gemm_moe.py
@@ -86,11 +86,12 @@ class TritonOrDeepGemmExperts(FallbackExperts):
             # full BLOCK_M tile. Below this threshold, DeepGemm's persistent
             # kernel wastes compute on padding and Triton is faster.
             M = hidden_states.size(0)
-            E = w1.size(0)
+            E = self.moe_config.num_experts
             top_k = self.moe_config.experts_per_token
             block_m = get_mk_alignment_for_contiguous_layout()[0]
-            tokens_per_expert = M * top_k / E
-            if tokens_per_expert < block_m:
+            # Fallback to Triton only if scales are not packed (Blackwell E8M0)
+            if (M * top_k < block_m * E and 
+                DeepGemmQuantScaleFMT.from_oracle() != DeepGemmQuantScaleFMT.UE8M0):
                 return self.fallback_experts
             return self.experts
         else:

--- a/vllm/model_executor/layers/fused_moe/triton_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/triton_deep_gemm_moe.py
@@ -17,6 +17,7 @@ from vllm.model_executor.layers.fused_moe.experts.deep_gemm_moe import (
 from vllm.model_executor.layers.fused_moe.fallback import FallbackExperts
 from vllm.model_executor.layers.fused_moe.fused_moe import TritonExperts
 from vllm.utils.deep_gemm import (
+    DeepGemmQuantScaleFMT,
     get_mk_alignment_for_contiguous_layout,
     is_deep_gemm_e8m0_used,
 )

--- a/vllm/model_executor/layers/fused_moe/triton_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/triton_deep_gemm_moe.py
@@ -17,6 +17,7 @@ from vllm.model_executor.layers.fused_moe.experts.deep_gemm_moe import (
 from vllm.model_executor.layers.fused_moe.fallback import FallbackExperts
 from vllm.model_executor.layers.fused_moe.fused_moe import TritonExperts
 from vllm.utils.deep_gemm import (
+    get_mk_alignment_for_contiguous_layout,
     is_deep_gemm_e8m0_used,
 )
 
@@ -81,6 +82,16 @@ class TritonOrDeepGemmExperts(FallbackExperts):
         w2: torch.Tensor,
     ) -> mk.FusedMoEExpertsModular:
         if is_deep_gemm_e8m0_used() or _valid_deep_gemm(hidden_states, w1, w2):
+            # Check that each expert gets enough tokens to fill at least one
+            # full BLOCK_M tile. Below this threshold, DeepGemm's persistent
+            # kernel wastes compute on padding and Triton is faster.
+            M = hidden_states.size(0)
+            E = w1.size(0)
+            top_k = self.moe_config.experts_per_token
+            block_m = get_mk_alignment_for_contiguous_layout()[0]
+            tokens_per_expert = M * top_k / E
+            if tokens_per_expert < block_m:
+                return self.fallback_experts
             return self.experts
         else:
             return self.fallback_experts


### PR DESCRIPTION
### Summary

DeepGemm's persistent kernel pads each expert's token batch to `BLOCK_M` (128). When experts receive fewer tokens than this — which happens at decode batch sizes — the padding wastes up to 94% of compute. This PR adds a runtime check in `TritonOrDeepGemmExperts._select_experts_impl` that falls back to Triton when `tokens_per_expert = M * top_k / E < BLOCK_M`.

For Qwen3.5-35B-A3B-FP8 (E=256, top_k=8), the threshold is M >= 4096:
- **Prefill** (M >> 4096): uses DeepGemm (faster for large GEMMs)
- **Decode** (M = 256): uses Triton (avoids DeepGemm padding waste)

**Requires `VLLM_USE_DEEP_GEMM=1`** — DeepGemm is not packaged with vLLM by default and must be installed separately (`pip install deep-gemm`). The FP8 MoE oracle on Hopper currently prefers Triton unless DeepGemm is explicitly enabled. With this flag set, our threshold ensures DeepGemm is used for prefill (where it excels) and Triton for decode (where DeepGemm wastes compute on padding).

### Change

Single file: `vllm/model_executor/layers/fused_moe/triton_deep_gemm_moe.py`
- Import `get_mk_alignment_for_contiguous_layout` to get `BLOCK_M`
- Before returning `self.experts` (DeepGemm), check if `tokens_per_expert < block_m` and fall back to `self.fallback_experts` (Triton) if so

### Benchmark results

**Hardware:** 1x NVIDIA H100 NVL (96GB), CUDA 13.0, Driver 580.95.05
**Model:** Qwen/Qwen3.5-35B-A3B-FP8 (E=256 experts, top_k=8, FP8 quantized)
**vLLM:** nightly (commit b55d830ec, 2026-04-08)
**Baseline:** vLLM defaults (Triton MoE, no `VLLM_USE_DEEP_GEMM`)
**With patch:** `VLLM_USE_DEEP_GEMM=1` + this PR

#### `vllm bench latency` (offline, deterministic, BS=256, input_len=4096)

| Output tokens | Default (s) | + DG Threshold (s) | Speedup |
|:---:|:---:|:---:|:---:|
| 10 (prefill-heavy) | 20.44 | 17.00 | **1.20x (−16.8%)** |
| 256 (decode-heavy) | 32.25 | 28.86 | **1.12x (−10.5%)** |

#### `vllm bench serve` (server mode, 256 prompts, request_rate=inf, input_len=4096)

**Prefill-heavy (output_len=10):**

| Metric | Default | + DG Threshold | Delta |
|---|---:|---:|---:|
| Benchmark duration (s) | 22.68 | 19.77 | −12.8% |
| Request throughput (req/s) | 11.29 | 12.95 | +14.7% |
| Total token throughput (tok/s) | 46,347 | 53,166 | +14.7% |
| Mean TTFT (ms) | 11,516 | 10,042 | −12.8% |
| Mean TPOT (ms) | 167.71 | 146.15 | −12.9% |
| Mean ITL (ms) | 167.71 | 146.15 | −12.9% |

**Decode-heavy (output_len=256):**

| Metric | Default | + DG Threshold | Delta |
|---|---:|---:|---:|
| Benchmark duration (s) | 38.01 | 34.97 | −8.0% |
| Request throughput (req/s) | 6.74 | 7.32 | +8.6% |
| Output token throughput (tok/s) | 1,724 | 1,874 | +8.7% |
| Total token throughput (tok/s) | 29,313 | 31,861 | +8.7% |
| Mean TTFT (ms) | 13,431 | 11,915 | −11.3% |
| Mean TPOT (ms) | 89.85 | 83.94 | −6.6% |
| Mean ITL (ms) | 89.85 | 83.94 | −6.6% |

### Threshold derivation

DeepGemm's persistent kernel operates on tiles of size `BLOCK_M` (128 on H100, queried at runtime via `get_mk_alignment_for_contiguous_layout()`). Each expert receives, on average:

```
tokens_per_expert = M * top_k / E
```

where `M` is the total number of tokens in the batch, `top_k` is the number of experts each token is routed to, and `E` is the total number of experts.

When `tokens_per_expert < BLOCK_M`, DeepGemm pads each expert's batch up to 128. The wasted compute fraction is:

```
waste = 1 - tokens_per_expert / BLOCK_M
```

For **Qwen3.5-35B-A3B-FP8** (E=256, top_k=8, BLOCK_M=128):

| Phase | M | tokens_per_expert | Waste | Winner |
|-------|---|-------------------|-------|--------|
| Decode (BS=256) | 256 | 256 × 8 / 256 = **8** | 93.8% | Triton |
| Chunked prefill | 16,384 | 16384 × 8 / 256 = **512** | 0% | DeepGemm |

The crossover point where DeepGemm breaks even is `M * top_k / E >= BLOCK_M`, i.e.:

```
M >= BLOCK_M * E / top_k = 128 * 256 / 8 = 4096
```

Below M=4096 the kernel falls back to Triton. Above it, DeepGemm's persistent kernel is used. The threshold is computed at runtime from the model's actual `E`, `top_k`, and the hardware's `BLOCK_M`, so it generalizes across MoE architectures.

### Why this matters in practice

With chunked prefill (default in vLLM, `max_num_batched_tokens=16384`), vLLM interleaves prefill chunks and decode batches in the same forward pass. The decode batches consistently hit the small-M regime where DeepGemm wastes compute on padding. Since decode steps dominate wall-clock time in generation-heavy workloads, the cumulative overhead is significant.

The prefill chunks have large M (up to 16384), so DeepGemm's persistent kernel continues to be used where it provides its advantage over Triton.

AI assistance was used in developing and benchmarking this change. The change was largely automatically discovered using the nCompass Performance Optimization Agent.