### PR TITLE
Fix: Propagate child process startup errors to the frontend

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -977,10 +977,11 @@ class EngineCoreProc(EngineCore):
             bind=False,
         ) as handshake_socket:
             # Register engine with front-end.
-            addresses = self.startup_handshake(
-                handshake_socket, local_client, headless, parallel_config_to_update
-            )
             try:
+                addresses = self.startup_handshake(
+                    handshake_socket, local_client, headless,
+                    parallel_config_to_update
+                )
                 yield addresses
             except Exception as e:
                 # Send failure notification to frontend (best-effort).

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -980,7 +980,22 @@ class EngineCoreProc(EngineCore):
             addresses = self.startup_handshake(
                 handshake_socket, local_client, headless, parallel_config_to_update
             )
-            yield addresses
+            try:
+                yield addresses
+            except Exception as e:
+                # Send failure notification to frontend (best-effort).
+                try:
+                    handshake_socket.send(
+                        msgspec.msgpack.encode({
+                            "status": "FAILED",
+                            "local": local_client,
+                            "headless": headless,
+                            "error_msg": str(e),
+                        })
+                    )
+                except Exception:
+                    pass
+                raise
 
             # Send ready message.
             ready_msg = {

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1145,8 +1145,8 @@ def wait_for_engine_startup(
                     *start_pending,
                 )
             continue
-        if len(events) > 1 or events[0][0] != handshake_socket:
-            # One of the local core processes exited.
+        if not any(sock == handshake_socket for sock, _ in events):
+            # No handshake message; a process or coordinator exited.
             finished = proc_manager.finished_procs() if proc_manager else {}
             if coord_process is not None and coord_process.exitcode is not None:
                 finished[coord_process.name] = coord_process.exitcode
@@ -1231,6 +1231,15 @@ def wait_for_engine_startup(
 
             start_pending[0 if local else 1] -= 1
             engine.state = CoreEngineState.READY
+        elif status == "FAILED" and engine.state == CoreEngineState.CONNECTED:
+            finished = proc_manager.finished_procs() if proc_manager else {}
+            raise RuntimeError(
+                "Engine core initialization failed. "
+                "See root cause above. "
+                f"Failed core proc(s): {finished}. "
+                f"Error from engine {eng_index}: "
+                f"{msg.get('error_msg', 'unknown')}"
+            )
         else:
             raise RuntimeError(
                 f"Unexpected {status} message for "

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1231,7 +1231,7 @@ def wait_for_engine_startup(
 
             start_pending[0 if local else 1] -= 1
             engine.state = CoreEngineState.READY
-        elif status == "FAILED" and engine.state == CoreEngineState.CONNECTED:
+        elif status == "FAILED":
             finished = proc_manager.finished_procs() if proc_manager else {}
             raise RuntimeError(
                 "Engine core initialization failed. "

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -549,6 +549,7 @@ class WorkerProc:
     """Wrapper that runs one Worker in a separate process."""
 
     READY_STR = "READY"
+    FAILED_INIT_STR = "FAILED_INIT"
     rpc_broadcast_mq: MessageQueue | None
     worker_response_mq: MessageQueue | None
 
@@ -744,7 +745,15 @@ class WorkerProc:
                     # Wait until the WorkerProc is ready.
                     unready_proc_handle = pipes.pop(pipe)
                     response: dict[str, Any] = pipe.recv()
-                    if response["status"] != "READY":
+                    status = response["status"]
+                    if status == WorkerProc.FAILED_INIT_STR:
+                        raise Exception(
+                            "WorkerProc initialization failed due to "
+                            "an exception in a background process: "
+                            f"{response['error_msg']}. "
+                            "See stack trace for root cause."
+                        )
+                    if status != WorkerProc.READY_STR:
                         raise e
 
                     idx = unready_proc_handle.rank % len(ready_proc_handles)
@@ -869,13 +878,20 @@ class WorkerProc:
 
             worker.worker_busy_loop()
 
-        except Exception:
+        except Exception as e:
             # NOTE: if an Exception arises in busy_loop, we send
             # a FAILURE message over the MQ RPC to notify the Executor,
             # which triggers system shutdown.
             # TODO(rob): handle case where the MQ itself breaks.
 
             if ready_writer is not None:
+                try:
+                    ready_writer.send({
+                        "status": WorkerProc.FAILED_INIT_STR,
+                        "error_msg": str(e),
+                    })
+                except Exception:
+                    pass
                 logger.exception("WorkerProc failed to start.")
             elif shutdown_requested.is_set():
                 logger.info("WorkerProc shutting down.")


### PR DESCRIPTION
Fix: Propagate child process startup errors to the frontend

## Purpose

When a child process (WorkerProc or EngineCore) fails during initialization, the frontend currently receives opaque error messages like `"Failed core proc(s): {}"` or `"See stack trace for root cause"` with no indication of the actual error. The root cause is only visible in the child process's stderr, which may not be easily accessible.

This PR propagates startup errors from child processes back to the frontend through existing IPC channels (pipes and zmq sockets), so the user sees the actual error message.

This is a replacement for #25722, which was auto-closed due to inactivity. Compared to that PR, this one:

- **Covers `startup_handshake()` errors**: #25722 only caught errors *after* the handshake completed. This PR wraps both `startup_handshake()` and the subsequent yield in the try/except, so connection-level failures during the handshake itself are also propagated.
- **Simpler, less invasive approach in `core.py`**: #25722 changed the `_perform_handshake` context manager's yield type to leak the zmq socket outward. This PR instead adds the try/except directly around the existing yield in `_run_engine_core`, keeping the context manager's API unchanged.
- **Best-effort error notifications**: Both the zmq send (in `core.py`) and the pipe send (in `multiproc_executor.py`) are wrapped in try/except so that failures in the notification itself don't mask the original error. #25722 did not guard these sends.
- **Simpler polling fix in `utils.py`**: #25722 split the poller into two separate pollers with independent timeouts, which introduced bugs flagged by reviewers (potential `NameError`, `IndexError`, and hangs). This PR uses a single-line fix (`any(sock == handshake_socket for sock, _ in events)`) to correctly prioritize handshake messages when both a message and a process sentinel fire simultaneously.
- **No unnecessary file changes**: #25722 modified `vllm/v1/executor/abstract.py` to add an unused logger import. This PR only touches the 3 files that need changes.

**Changes across 3 files:**

1. **`vllm/v1/executor/multiproc_executor.py`** -- WorkerProc now sends a `FAILED_INIT` message with the error string via the `ready_writer` pipe when initialization fails. The parent's `wait_for_ready()` checks for this status and includes the error in the raised exception.

2. **`vllm/v1/engine/core.py`** -- EngineCoreProc now sends a `FAILED` message with the error string via the zmq handshake socket when initialization (including `startup_handshake()` itself) fails. The send is best-effort so zmq failures don't mask the original error.

3. **`vllm/v1/engine/utils.py`** -- `wait_for_engine_startup()` gains two fixes:
   - **Sentinel detection**: when both a handshake message and a process sentinel fire simultaneously, the handshake message is now read first instead of immediately raising. This ensures FAILED messages (with error details) aren't skipped.
   - **FAILED status handler**: when an engine sends a FAILED message, the error_msg is included in the RuntimeError so the user sees the actual root cause.

## Test Plan

- Manual testing: introduce deliberate initialization failures (e.g., invalid model path, GPU OOM) and verify the frontend error message now contains the actual root cause instead of the opaque fallback.
- Existing test suite: `pytest tests/v1/engine/ -v` to verify no regressions in the startup handshake flow.

## Test Result

Startup errors from child processes now surface in the frontend error message, replacing opaque messages like `"Failed core proc(s): {}"` with the actual exception text from the failing process.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

