### PR TITLE
[Perf] Skip decode for generative scoring with max_tokens=0

### DIFF
--- a/tests/entrypoints/openai/generative_scoring/test_generative_scoring.py
+++ b/tests/entrypoints/openai/generative_scoring/test_generative_scoring.py
@@ -105,7 +105,7 @@ def _create_mock_request_output(logprobs_dict: dict[int, float]) -> RequestOutpu
     completion_output = CompletionOutput(
         index=0,
         text="",
-        token_ids=[100],
+        token_ids=[],
         cumulative_logprob=-1.0,
         logprobs=[logprobs_with_objs],
         finish_reason="length",
@@ -160,7 +160,7 @@ class TestProtocolModels:
                 GenerativeScoringItemResult(index=0, score=0.7),
                 GenerativeScoringItemResult(index=1, score=0.4),
             ],
-            usage={"prompt_tokens": 10, "total_tokens": 12, "completion_tokens": 2},
+            usage={"prompt_tokens": 10, "total_tokens": 10, "completion_tokens": 0},
         )
         assert response.object == "list"
         assert response.model == "test-model"

--- a/tests/entrypoints/openai/generative_scoring/test_generative_scoring_e2e.py
+++ b/tests/entrypoints/openai/generative_scoring/test_generative_scoring_e2e.py
@@ -62,7 +62,7 @@ class TestGenerativeScoringAPI:
         # Verify usage tracking
         usage = data["usage"]
         assert usage["prompt_tokens"] > 0
-        assert usage["completion_tokens"] > 0
+        assert usage["completion_tokens"] == 0
         assert (
             usage["total_tokens"] == usage["prompt_tokens"] + usage["completion_tokens"]
         )

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -255,8 +255,6 @@ class CompletionRequest(OpenAIBaseModel):
         if prompt_logprobs is None and self.echo:
             prompt_logprobs = self.logprobs
 
-        echo_without_generation = self.echo and self.max_tokens == 0
-
         response_format = self.response_format
         if response_format is not None:
             structured_outputs_kwargs = dict[str, Any]()
@@ -307,7 +305,7 @@ class CompletionRequest(OpenAIBaseModel):
             stop_token_ids=self.stop_token_ids,
             logprobs=self.logprobs,
             ignore_eos=self.ignore_eos,
-            max_tokens=max_tokens if not echo_without_generation else 1,
+            max_tokens=max_tokens,
             min_tokens=self.min_tokens,
             prompt_logprobs=prompt_logprobs,
             skip_special_tokens=self.skip_special_tokens,

--- a/vllm/entrypoints/openai/generative_scoring/serving.py
+++ b/vllm/entrypoints/openai/generative_scoring/serving.py
@@ -241,15 +241,14 @@ class OpenAIServingGenerativeScoring(OpenAIServing):
             logger.exception("Error building prompts")
             return self.create_error_response(e)
 
-        # Create sampling params for scoring
-        # We use max_tokens=1 with logprob_token_ids to efficiently get
-        # logprobs for only the specified label tokens (not full vocab)
-        # Note: temperature/top_k/top_p don't affect logprobs - they only
-        # affect the sampling distribution. Logprobs are computed from raw
-        # logits via log_softmax before any sampling transformations.
+        # Create sampling params for scoring (prefill-only).
+        # max_tokens=0 runs only the prefill forward pass and returns
+        # logprobs for the next-token position without generating tokens.
+        # Using logprob_token_ids without logprobs avoids the expensive
+        # full-vocab log_softmax and top-k gather in the sampler — only
+        # a fused Triton kernel for the specific label tokens runs.
         sampling_params = SamplingParams(
-            max_tokens=1,
-            logprobs=len(request.label_token_ids),
+            max_tokens=0,
             logprob_token_ids=request.label_token_ids,
             n=1,
         )
@@ -426,8 +425,9 @@ class OpenAIServingGenerativeScoring(OpenAIServing):
             else:
                 prompt_token_ids = query_token_ids + item_token_ids
 
-            # Truncate to max_model_len - 1 to leave room for 1 output token
-            max_prompt_len = max_model_len - 1
+            # No output tokens are generated (prefill-only), so the full
+            # context window is available for the prompt.
+            max_prompt_len = max_model_len
             if len(prompt_token_ids) > max_prompt_len:
                 prompt_token_ids = prompt_token_ids[:max_prompt_len]
 

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -482,9 +482,9 @@ class SamplingParams(
             )
         if not 0.0 <= self.min_p <= 1.0:
             raise ValueError(f"min_p must be in [0, 1], got {self.min_p}.")
-        if self.max_tokens is not None and self.max_tokens < 1:
+        if self.max_tokens is not None and self.max_tokens < 0:
             raise VLLMValidationError(
-                f"max_tokens must be at least 1, got {self.max_tokens}.",
+                f"max_tokens must be at least 0, got {self.max_tokens}.",
                 parameter="max_tokens",
                 value=self.max_tokens,
             )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1405,6 +1405,14 @@ class Scheduler(SchedulerInterface):
                 # Pooling stops as soon as there is output.
                 request.status = RequestStatus.FINISHED_STOPPED
                 stopped = True
+            elif (
+                request.max_tokens == 0
+                and not request.is_prefill_chunk
+                and request.sampling_params is not None
+            ):
+                # Prefill-only: finish without generating any tokens.
+                request.status = RequestStatus.FINISHED_LENGTH_CAPPED
+                stopped = True
 
             if new_token_ids and self.structured_output_manager.should_advance(request):
                 struct_output_request = request.structured_output_request
@@ -1443,10 +1451,20 @@ class Scheduler(SchedulerInterface):
             # Extract sample logprobs if needed.
             if (
                 request.sampling_params is not None
-                and request.sampling_params.logprobs is not None
+                and (
+                    request.sampling_params.logprobs is not None
+                    or request.sampling_params.logprob_token_ids is not None
+                )
                 and logprobs
             ):
-                new_logprobs = logprobs.slice_request(req_index, len(new_token_ids))
+                # For max_tokens=0, tokens were discarded by the model
+                # runner but logprobs were still computed (1 position).
+                num_logprob_positions = (
+                    len(new_token_ids)
+                    if new_token_ids
+                    else (1 if request.max_tokens == 0 else 0)
+                )
+                new_logprobs = logprobs.slice_request(req_index, num_logprob_positions)
 
             if num_nans_in_logits is not None and req_id in num_nans_in_logits:
                 request.num_nans_in_logits = num_nans_in_logits[req_id]

--- a/vllm/v1/engine/logprobs.py
+++ b/vllm/v1/engine/logprobs.py
@@ -48,6 +48,10 @@ class LogprobsProcessor:
         sampling_params = request.sampling_params
         assert sampling_params is not None
         num_logprobs = sampling_params.logprobs
+        # When logprob_token_ids is set without logprobs, enable logprobs
+        # processing using the count of specific token IDs.
+        if num_logprobs is None and sampling_params.logprob_token_ids is not None:
+            num_logprobs = len(sampling_params.logprob_token_ids)
         num_prompt_logprobs = sampling_params.prompt_logprobs
         return cls(
             tokenizer=tokenizer,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1918,10 +1918,21 @@ class GPUModelRunner(
         num_tokens_np = np.array(num_tokens, dtype=np.int32)
 
         # Record which requests should not be sampled,
-        # so that we could clear the sampled tokens before returning
-        self.discard_request_mask.np[:num_reqs] = (
+        # so that we could clear the sampled tokens before returning.
+        # Also discard tokens for max_tokens=0 (prefill-only) requests
+        # that just finished prefill, so no token is cached.
+        still_prefilling = (
             self.optimistic_seq_lens_cpu[:num_reqs].numpy() < num_tokens_np
         )
+        max_tokens_zero = np.array(
+            [
+                self.requests[r].sampling_params is not None
+                and self.requests[r].sampling_params.max_tokens == 0
+                for r in self.input_batch.req_ids
+            ],
+            dtype=bool,
+        )
+        self.discard_request_mask.np[:num_reqs] = still_prefilling | max_tokens_zero
         self.discard_request_mask.copy_to_gpu(num_reqs)
 
         # Sync num_accepted_tokens from CPU (set by


### PR DESCRIPTION
## Purpose

Optimize the `/generative_scoring` endpoint by eliminating the unnecessary decode forward pass. The endpoint only needs next-token logprobs for scoring, but was forced to use `max_tokens=1` because vLLM rejected `max_tokens=0`. This change:

- **Allows `max_tokens=0`** in `SamplingParams` for prefill-only requests that return logprobs without generating tokens
- **Uses `logprob_token_ids` instead of `logprobs`** to skip the expensive full-vocab `log_softmax` (248K vocab for Qwen) and top-k gather — a fused Triton kernel computes logprobs for only the specified label tokens
- **Removes the `echo_without_generation` workaround** in the completion protocol now that the engine natively supports `max_tokens=0`

### How it works

In vLLM v1, the first decode token comes from the same forward pass as prefill. For scoring, we only need the next-token-prediction logprobs from that prefill pass. With `max_tokens=0`:

1. Forward pass runs normally, sampler produces logprobs for the next-token position
2. `discard_request_mask` clears the sampled token (never cached in KV)
3. Scheduler detects `max_tokens=0` + prefill complete → marks `FINISHED_LENGTH_CAPPED`
4. Logprobs are extracted (1 position) and returned with `completion_tokens=0`


## Test Plan

```bash
pytest tests/entrypoints/openai/generative_scoring/test_generative_scoring.py -v
pre-commit run --files vllm/sampling_params.py vllm/v1/core/sched/scheduler.py \
  vllm/entrypoints/openai/completion/protocol.py \
  vllm/entrypoints/openai/generative_scoring/serving.py \
  vllm/v1/engine/logprobs.py vllm/v1/worker/gpu_model_runner.py
```

Additional manual verification:
- `SamplingParams(max_tokens=0)` accepted, `SamplingParams(max_tokens=-1)` rejected
- `max_tokens=0, echo=True, logprobs=1` returns prompt logprobs, no generated text
- Generative scoring endpoint returns correct scores with `completion_tokens=0`

## Test Result

### Correctness

Scores are **exact match** (10 decimal places) between baseline (`max_tokens=1`) and optimized (`max_tokens=0`):

| Query | Baseline | Optimized | Match |
|-------|----------|-----------|-------|
| Q0 | `[0.3629, 0.3074, 0.2509]` | `[0.3629, 0.3074, 0.2509]` | EXACT |
| Q1 | `[0.5312, 0.5851, 0.1919, 0.1603]` | `[0.5312, 0.5851, 0.1919, 0.1603]` | EXACT |
| Q2 | `[0.5234, 0.1385, 0.6151]` | `[0.5234, 0.1385, 0.6151]` | EXACT |

Determinism: 5/5 identical runs for both baseline and optimized.

### Latency at 120 QPS (saturation), H100

**Setup**: Qwen3.5-0.8B (248K vocab), H100 GPU, prefix caching disabled, 10 items/request, 30s duration, Poisson arrivals, seed=42.

| Metric | Baseline | Optimized | Change |
|--------|----------|-----------|--------|
| **Mean** | 86.72 ms | 75.62 ms | **-12.8%** |
| **Median** | 85.22 ms | 73.50 ms | **-13.7%** |
| **P90** | 108.49 ms | 93.16 ms | **-14.1%** |
| **P95** | 114.10 ms | 100.87 ms | **-11.6%** |
| **P99** | 124.94 ms | 109.90 ms | **-12.0%** |

Improvement scales with QPS (negligible at low QPS where forward pass dominates, 11-14% at saturation):

| QPS | Baseline Mean | Optimized Mean | Change |
|-----|--------------|----------------|--------|
| 60 | 55.43 ms | 54.22 ms | -2.2% |
| 80 | 62.36 ms | 61.45 ms | -1.5% |
| 100 | 69.23 ms | 66.93 ms | -3.3% |
| 110 | 80.30 ms | 71.39 ms | **-11.1%** |
| 120 | 86.72 ms | 75.62 ms | **-12.8%** |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update
- [ ] (Optional) Release notes update
</details>

> AI assistance was used (Claude). All changes reviewed and benchmarked by human submitter.
> No existing PR addresses this optimization — verified via `gh pr list --search`.
