### PR TITLE
[Model Runner V2] Fix flex attention kv blocks calculation issue

### DIFF
--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -750,11 +750,11 @@ class FlexAttentionMetadataBuilder(AttentionMetadataBuilder[FlexAttentionMetadat
         self.max_model_len = self.model_config.max_model_len
         max_num_seqs = vllm_config.scheduler_config.max_num_seqs
         max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
-        self.max_num_q_block = (
-            self.max_model_len + self.q_block_size - 1
-        ) // self.q_block_size
+        self.max_num_query_groups = cdiv(max_num_batched_tokens, self.q_block_size)
+        max_num_pages_per_seq = cdiv(self.max_model_len, self.block_size)
+        self.max_num_kv_indices = self.q_block_size * max_num_pages_per_seq
         self.persistent_kv_num_blocks = torch.empty(
-            self.max_num_q_block, dtype=torch.int32, device=device
+            self.max_num_query_groups, dtype=torch.int32, device=device
         )
         self.persistent_offset_tensor = torch.empty(
             max_num_seqs, dtype=torch.int32, device=device
@@ -828,12 +828,9 @@ class FlexAttentionMetadataBuilder(AttentionMetadataBuilder[FlexAttentionMetadat
             )
 
         if self.persistent_kv_indices is None:
-            max_num_kv_block = (
-                self.max_model_len + self.kv_block_size - 1
-            ) // self.kv_block_size
             self.persistent_kv_indices = torch.empty(
-                self.max_model_len,
-                max_num_kv_block,
+                self.max_num_query_groups,
+                self.max_num_kv_indices,
                 dtype=torch.int32,
                 device=self.device,
             )


### PR DESCRIPTION
## Purpose

`VLLM_USE_V2_MODEL_RUNNER=1 pytest -s tests/v1/e2e/general/test_async_scheduling.py`

```bash
(EngineCore pid=2359877) Process EngineCore:
(EngineCore pid=2359877) Traceback (most recent call last):
(EngineCore pid=2359877)   File "/usr/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
(EngineCore pid=2359877)     self.run()
(EngineCore pid=2359877)   File "/usr/lib/python3.12/multiprocessing/process.py", line 108, in run
(EngineCore pid=2359877)     self._target(*self._args, **self._kwargs)
(EngineCore pid=2359877)   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 1115, in run_engine_core
(EngineCore pid=2359877)     raise e
(EngineCore pid=2359877)   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 1085, in run_engine_core
(EngineCore pid=2359877)     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
(EngineCore pid=2359877)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2359877)   File "/home/yewentao256/vllm-source/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=2359877)     return func(*args, **kwargs)
(EngineCore pid=2359877)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2359877)   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 849, in __init__
(EngineCore pid=2359877)     super().__init__(
(EngineCore pid=2359877)   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 125, in __init__
(EngineCore pid=2359877)     kv_cache_config = self._initialize_kv_caches(vllm_config)
(EngineCore pid=2359877)                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2359877)   File "/home/yewentao256/vllm-source/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=2359877)     return func(*args, **kwargs)
(EngineCore pid=2359877)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2359877)   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 281, in _initialize_kv_caches
(EngineCore pid=2359877)     self.model_executor.initialize_from_config(kv_cache_configs)
(EngineCore pid=2359877)   File "/home/yewentao256/vllm-source/vllm/v1/executor/abstract.py", line 124, in initialize_from_config
(EngineCore pid=2359877)     compilation_times: list[float] = self.collective_rpc("compile_or_warm_up_model")
(EngineCore pid=2359877)                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2359877)   File "/home/yewentao256/vllm-source/vllm/v1/executor/multiproc_executor.py", line 412, in collective_rpc
(EngineCore pid=2359877)     return future if non_block else future.result()
(EngineCore pid=2359877)                                     ^^^^^^^^^^^^^^^
(EngineCore pid=2359877)   File "/home/yewentao256/vllm-source/vllm/v1/executor/multiproc_executor.py", line 89, in result
(EngineCore pid=2359877)     return super().result()
(EngineCore pid=2359877)            ^^^^^^^^^^^^^^^^
(EngineCore pid=2359877)   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 449, in result
(EngineCore pid=2359877)     return self.__get_result()
(EngineCore pid=2359877)            ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2359877)   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
(EngineCore pid=2359877)     raise self._exception
(EngineCore pid=2359877)   File "/home/yewentao256/vllm-source/vllm/v1/executor/multiproc_executor.py", line 93, in _wait_for_response
(EngineCore pid=2359877)     response = self.aggregate(self.get_response())
(EngineCore pid=2359877)                               ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2359877)   File "/home/yewentao256/vllm-source/vllm/v1/executor/multiproc_executor.py", line 399, in get_response
(EngineCore pid=2359877)     raise RuntimeError(
(EngineCore pid=2359877) RuntimeError: Worker failed with error 'Fail to re-stride a persistent tensor of shape torch.Size([4096, 256]) for a tensor of shape torch.Size([1024, 4096])', please check the stack trace above for the root cause
```

This is a bug since we should consider batch tokens `max_num_batched_tokens` instead of `max_model_len` (only one request)

## Test

Rerun unit test and pass now