### PR TITLE
fix: add LoRA prefix mapping for text-only adapters in Qwen3.5-VL

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1609,6 +1609,7 @@ class Qwen3VLForConditionalGeneration(
             "model.visual.": "visual.",
             "lm_head.": "language_model.lm_head.",
             "model.language_model.": "language_model.model.",
+            "model.": "language_model.model.",
         }
     )
 


### PR DESCRIPTION
## Summary

When a LoRA adapter is trained on a Qwen3.5 model using `AutoModelForCausalLM` (standard PEFT practice for text-only fine-tuning), vLLM's dynamic LoRA loading silently fails — all adapter weights are loaded into memory but **zero modules are activated**. The model runs on pure base weights with no error or warning at default log levels.

This also applies to `Qwen3VLForConditionalGeneration` models.

**Note:** `--language-model-only` does NOT work around this bug — it still loads `Qwen3_5ForConditionalGeneration` with the same `language_model.model.layers.*` prefix, same broken mapper.

## Root Cause

Prefix mismatch between LoRA adapter weight keys and vLLM's internal module paths:

- **Training side**: `AutoModelForCausalLM.from_pretrained("Qwen/Qwen3.5-4B")` loads `Qwen3_5ForCausalLM`, producing adapter keys like `base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight`
- **vLLM side**: loads `Qwen3_5ForConditionalGeneration` (inherits from `Qwen3VLForConditionalGeneration`), so internal module paths are `language_model.model.layers.0.self_attn.q_proj`

After `parse_fine_tuned_lora_name` strips the `base_model.model.` prefix, the LoRA module name becomes `model.layers.0.self_attn.q_proj`. The `hf_to_vllm_mapper` only has:

```python
hf_to_vllm_mapper = WeightsMapper(
    orig_to_new_prefix={
        "model.visual.": "visual.",
        "lm_head.": "language_model.lm_head.",
        "model.language_model.": "language_model.model.",
    }
)
```

`model.layers.*` does NOT match `model.language_model.*`, so the mapper passes it through unchanged. All lookups in `_create_merged_loras_inplace` fail silently.

## End-to-End Reproduction

Tested on Qwen3.5-4B with vLLM v0.19.0:

```python
# 1. Create LoRA adapter (standard PEFT workflow)
from transformers import AutoModelForCausalLM, AutoTokenizer
from peft import LoraConfig, get_peft_model
import torch

model = AutoModelForCausalLM.from_pretrained("Qwen/Qwen3.5-4B", dtype=torch.bfloat16, device_map="cpu")
peft_model = get_peft_model(model, LoraConfig(r=8, lora_alpha=16, target_modules=["q_proj", "v_proj"], task_type="CAUSAL_LM"))
# Perturb lora_B so output would differ from base if LoRA is active
for name, param in peft_model.named_parameters():
    if "lora_B" in name:
        param.data = torch.randn_like(param.data) * 0.1
peft_model.save_pretrained("./test_lora")
AutoTokenizer.from_pretrained("Qwen/Qwen3.5-4B").save_pretrained("./test_lora")
```

```python
# 2. Test with vLLM (must be in if __name__ == '__main__' for spawn)
from vllm import LLM, SamplingParams
from vllm.lora.request import LoRARequest

llm = LLM(model="Qwen/Qwen3.5-4B", enable_lora=True, max_lora_rank=8,
           max_model_len=256, dtype="bfloat16", enforce_eager=True)
params = SamplingParams(temperature=0, max_tokens=30)

base = llm.generate(["The meaning of life is"], params)[0].outputs[0].text
lora = llm.generate(["The meaning of life is"], params,
                     lora_request=LoRARequest("test", 1, "./test_lora"))[0].outputs[0].text
print(f"Identical: {base == lora}")  # True — LoRA is silently ignored
```

### Results

| Config | Base output | LoRA output | Identical? |
|--------|-----------|------------|-----------|
| Unpatched | "...puzzled philosophers..." | "...puzzled philosophers..." | **True (BUG)** |
| Unpatched + `--language-model-only` | "...puzzled philosophers..." | "...puzzled philosophers..." | **True (BUG)** |
| **Patched** | "...puzzled philosophers..." | "...pondered by philosophers..." | **False (FIX)** |

## Fix

Add `"model.": "language_model.model."` to `hf_to_vllm_mapper` in `Qwen3VLForConditionalGeneration`. Existing more-specific rules (`model.visual.`, `model.language_model.`) take priority due to prefix-first matching, so no regression.

This pattern is already used in vLLM's own test suite for Baichuan LoRA weight mapping (`tests/lora/test_lora_checkpoints.py:108-111`).

```python
hf_to_vllm_mapper = WeightsMapper(
    orig_to_new_prefix={
        "model.visual.": "visual.",
        "lm_head.": "language_model.lm_head.",
        "model.language_model.": "language_model.model.",
        "model.": "language_model.model.",  # handle text-only LoRA adapters
    }
)
```

## Related issues

- #38085 — LoRA module validation warning (fixed, different issue)
- #36395 / #36603 — TP tensor mismatch (different root cause)