### PR TITLE
Set a timeout on api client HTTP calls

### DIFF
--- a/examples/online_serving/api_client.py
+++ b/examples/online_serving/api_client.py
@@ -35,7 +35,7 @@ def post_http_request(
         "max_tokens": 16,
         "stream": stream,
     }
-    response = requests.post(api_url, headers=headers, json=pload, stream=stream)
+    response = requests.post(api_url, headers=headers, json=pload, stream=stream, timeout=10.0)
     return response
 
 

--- a/examples/online_serving/disaggregated_serving/disagg_proxy_demo.py
+++ b/examples/online_serving/disaggregated_serving/disagg_proxy_demo.py
@@ -392,7 +392,7 @@ class ProxyServer:
         model_suffix = model.split("/")[-1]
         for instance in instances:
             try:
-                response = requests.get(f"http://{instance}/v1/models")
+                response = requests.get(f"http://{instance}/v1/models", timeout=10.0)
                 if response.status_code == 200:
                     model_cur = response.json()["data"][0]["id"]
                     model_cur_suffix = model_cur.split("/")[-1]

--- a/examples/online_serving/gradio_webserver.py
+++ b/examples/online_serving/gradio_webserver.py
@@ -33,7 +33,7 @@ def http_bot(prompt):
         "stream": True,
         "max_tokens": 128,
     }
-    response = requests.post(args.model_url, headers=headers, json=pload, stream=True)
+    response = requests.post(args.model_url, headers=headers, json=pload, stream=True, timeout=10.0)
 
     for chunk in response.iter_lines(
         chunk_size=8192, decode_unicode=False, delimiter=b"\n"

--- a/examples/online_serving/openai_chat_completion_client_for_multimodal.py
+++ b/examples/online_serving/openai_chat_completion_client_for_multimodal.py
@@ -45,7 +45,7 @@ headers = {"User-Agent": "vLLM Example Client"}
 def encode_base64_content_from_url(content_url: str) -> str:
     """Encode a content retrieved from a remote url to base64 format."""
 
-    with requests.get(content_url, headers=headers) as response:
+    with requests.get(content_url, headers=headers, timeout=10.0) as response:
         response.raise_for_status()
         result = base64.b64encode(response.content).decode("utf-8")
 

--- a/examples/online_serving/opentelemetry/dummy_client.py
+++ b/examples/online_serving/opentelemetry/dummy_client.py
@@ -31,4 +31,4 @@ with tracer.start_as_current_span("client-span", kind=SpanKind.CLIENT) as span:
         "temperature": 0.0,
         # "stream": True,
     }
-    response = requests.post(url, headers=headers, json=payload)
+    response = requests.post(url, headers=headers, json=payload, timeout=10.0)

--- a/examples/online_serving/token_generation_client.py
+++ b/examples/online_serving/token_generation_client.py
@@ -35,7 +35,7 @@ def main(client):
         "sampling_params": {"max_tokens": 24, "temperature": 0.2, "detokenize": False},
         "stream": False,
     }
-    resp = client.post(GEN_ENDPOINT, json=payload)
+    resp = client.post(GEN_ENDPOINT, json=payload, timeout=10.0)
     resp.raise_for_status()
     data = resp.json()
     print(data)

--- a/examples/pooling/classify/classification_online.py
+++ b/examples/pooling/classify/classification_online.py
@@ -27,7 +27,7 @@ def main(args):
     classify_url = base_url + "/classify"
     tokenize_url = base_url + "/tokenize"
 
-    response = requests.get(models_url, headers=headers)
+    response = requests.get(models_url, headers=headers, timeout=10.0)
     model = response.json()["data"][0]["id"]
 
     # /classify can accept str as input
@@ -42,7 +42,7 @@ def main(args):
         "model": model,
         "input": prompts,
     }
-    response = requests.post(classify_url, headers=headers, json=payload)
+    response = requests.post(classify_url, headers=headers, json=payload, timeout=10.0)
     pprint.pprint(response.json())
 
     # /classify can accept token ids as input
@@ -51,6 +51,7 @@ def main(args):
         response = requests.post(
             tokenize_url,
             json={"model": model, "prompt": prompt},
+            timeout=10.0,
         )
         token_ids.append(response.json()["tokens"])
 
@@ -58,7 +59,7 @@ def main(args):
         "model": model,
         "input": token_ids,
     }
-    response = requests.post(classify_url, headers=headers, json=payload)
+    response = requests.post(classify_url, headers=headers, json=payload, timeout=10.0)
     pprint.pprint(response.json())
 
 

--- a/examples/pooling/classify/vision_classification_online.py
+++ b/examples/pooling/classify/vision_classification_online.py
@@ -36,7 +36,7 @@ def main(args):
     models_url = base_url + "/v1/models"
     classify_url = base_url + "/classify"
 
-    response = requests.get(models_url)
+    response = requests.get(models_url, timeout=10.0)
     model_name = response.json()["data"][0]["id"]
 
     print("Text classification output:")
@@ -53,6 +53,7 @@ def main(args):
     response = requests.post(
         classify_url,
         json={"model": model_name, "messages": messages},
+        timeout=10.0,
     )
     pprint.pprint(response.json())
 
@@ -69,6 +70,7 @@ def main(args):
     response = requests.post(
         classify_url,
         json={"model": model_name, "messages": messages},
+        timeout=10.0,
     )
     pprint.pprint(response.json())
 
@@ -85,6 +87,7 @@ def main(args):
     response = requests.post(
         classify_url,
         json={"model": model_name, "messages": messages},
+        timeout=10.0,
     )
     pprint.pprint(response.json())
 
@@ -101,6 +104,7 @@ def main(args):
     response = requests.post(
         classify_url,
         json={"model": model_name, "messages": messages},
+        timeout=10.0,
     )
     pprint.pprint(response.json())
 

--- a/examples/pooling/embed/embedding_requests_base64_online.py
+++ b/examples/pooling/embed/embedding_requests_base64_online.py
@@ -17,7 +17,7 @@ from vllm.utils.serial_utils import EMBED_DTYPES, ENDIANNESS, binary2tensor
 
 def post_http_request(prompt: dict, api_url: str) -> requests.Response:
     headers = {"User-Agent": "Test Client"}
-    response = requests.post(api_url, headers=headers, json=prompt)
+    response = requests.post(api_url, headers=headers, json=prompt, timeout=10.0)
     return response
 
 
@@ -33,7 +33,7 @@ def main(args):
     models_url = base_url + "/v1/models"
     embeddings_url = base_url + "/v1/embeddings"
 
-    response = requests.get(models_url)
+    response = requests.get(models_url, timeout=10.0)
     model = response.json()["data"][0]["id"]
 
     input_texts = [

--- a/examples/pooling/embed/embedding_requests_bytes_online.py
+++ b/examples/pooling/embed/embedding_requests_bytes_online.py
@@ -22,7 +22,7 @@ from vllm.utils.serial_utils import EMBED_DTYPES, ENDIANNESS
 
 def post_http_request(prompt: dict, api_url: str) -> requests.Response:
     headers = {"User-Agent": "Test Client"}
-    response = requests.post(api_url, headers=headers, json=prompt)
+    response = requests.post(api_url, headers=headers, json=prompt, timeout=10.0)
     return response
 
 
@@ -39,7 +39,7 @@ def main(args):
     models_url = base_url + "/v1/models"
     embeddings_url = base_url + "/v1/embeddings"
 
-    response = requests.get(models_url)
+    response = requests.get(models_url, timeout=10.0)
     model = response.json()["data"][0]["id"]
 
     embedding_size = 0

--- a/examples/pooling/plugin/prithvi_geospatial_mae_online.py
+++ b/examples/pooling/plugin/prithvi_geospatial_mae_online.py
@@ -35,7 +35,7 @@ def main():
         "model": "ibm-nasa-geospatial/Prithvi-EO-2.0-300M-TL-Sen1Floods11",
     }
 
-    ret = requests.post(server_endpoint, json=request_payload_url)
+    ret = requests.post(server_endpoint, json=request_payload_url, timeout=10.0)
 
     print(f"response.status_code: {ret.status_code}")
     print(f"response.reason:{ret.reason}")

--- a/examples/pooling/pooling/pooling_online.py
+++ b/examples/pooling/pooling/pooling_online.py
@@ -17,7 +17,7 @@ import requests
 
 def post_http_request(prompt: dict, api_url: str) -> requests.Response:
     headers = {"User-Agent": "Test Client"}
-    response = requests.post(api_url, headers=headers, json=prompt)
+    response = requests.post(api_url, headers=headers, json=prompt, timeout=10.0)
     return response
 
 
@@ -34,7 +34,7 @@ def main(args):
     models_url = base_url + "/v1/models"
     pooing_url = base_url + "/pooling"
 
-    response = requests.get(models_url)
+    response = requests.get(models_url, timeout=10.0)
     model = response.json()["data"][0]["id"]
 
     # Input like Completions API

--- a/examples/pooling/score/colbert_rerank_online.py
+++ b/examples/pooling/score/colbert_rerank_online.py
@@ -54,7 +54,7 @@ def rerank_example():
         "documents": documents,
     }
 
-    response = requests.post(f"{BASE_URL}/rerank", headers=headers, json=data)
+    response = requests.post(f"{BASE_URL}/rerank", headers=headers, json=data, timeout=10.0)
     result = response.json()
     print(json.dumps(result, indent=2))
 
@@ -78,7 +78,7 @@ def score_example():
         ],
     }
 
-    response = requests.post(f"{BASE_URL}/score", headers=headers, json=data)
+    response = requests.post(f"{BASE_URL}/score", headers=headers, json=data, timeout=10.0)
     result = response.json()
     print(json.dumps(result, indent=2))
 


### PR DESCRIPTION
This fell out while I was looking at examples/online_serving/api_client.py. Set a timeout on api client HTTP calls. Network calls without a timeout can hang a worker indefinitely. I kept the patch small and re-ran syntax checks after applying it.