### PR TITLE
[WIP] Enable `torch.cond` for dynamic block-scaled MM kernels

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/BlockScaledMMLinearKernel.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/BlockScaledMMLinearKernel.py
@@ -207,3 +207,38 @@ class Fp8BlockScaledDynamicMMLinearKernel(Fp8BlockScaledMMLinearKernel, ABC):
         if not can_implement_base:
             return False, f"base cannot implement due to {reason_1}"
         return False, f"fallback cannot implement due to {reason_2}"
+
+    @abstractmethod
+    def predicate(
+        self,
+        A: torch.Tensor,
+        B: torch.Tensor,
+        As: torch.Tensor,
+        Bs: torch.Tensor,
+    ) -> bool:
+        """Return a scalar boolean Tensor selecting the branch for torch.cond.
+
+        Returns True to dispatch to base, False to dispatch to fallback.
+        Must return a scalar boolean Tensor (not a Python bool) for
+        torch.compile compatibility.
+        """
+        raise NotImplementedError
+
+    def apply_block_scaled_mm(
+        self,
+        A: torch.Tensor,
+        B: torch.Tensor,
+        As: torch.Tensor,
+        Bs: torch.Tensor,
+    ) -> torch.Tensor:
+        # torch.cond registers both branches in the computation graph so
+        # torch.compile can capture dynamic dispatch without breaking tracing.
+        # All operands must be concrete Tensors — non-tensor state is accessed
+        # via self.config or captured by the branch method closures.
+
+        return torch.cond(
+            self.predicate(A, B, As, Bs),
+            self.base.apply_block_scaled_mm,
+            self.fallback.apply_block_scaled_mm,
+            [A, B, As, Bs],
+        )

--- a/vllm/model_executor/kernels/linear/scaled_mm/BlockScaledMMLinearKernel.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/BlockScaledMMLinearKernel.py
@@ -20,6 +20,9 @@ from ..base import (
 )
 from .ScaledMMLinearKernel import FP8ScaledMMLinearLayerConfig
 
+# This enables torch.cond to be cached.
+torch.ops.higher_order.cond._cacheable = True
+
 
 @dataclass
 class FP8BlockParams(FP8Params):

--- a/vllm/model_executor/kernels/linear/scaled_mm/BlockScaledMMLinearKernel.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/BlockScaledMMLinearKernel.py
@@ -219,12 +219,6 @@ class Fp8BlockScaledDynamicMMLinearKernel(Fp8BlockScaledMMLinearKernel, ABC):
         As: torch.Tensor,
         Bs: torch.Tensor,
     ) -> bool:
-        """Return a scalar boolean Tensor selecting the branch for torch.cond.
-
-        Returns True to dispatch to base, False to dispatch to fallback.
-        Must return a scalar boolean Tensor (not a Python bool) for
-        torch.compile compatibility.
-        """
         raise NotImplementedError
 
     def apply_block_scaled_mm(

--- a/vllm/model_executor/kernels/linear/scaled_mm/deep_gemm.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/deep_gemm.py
@@ -39,7 +39,10 @@ class DeepGemmFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             static=False,
             group_shape=act_scale_descriptor.group_shape,
             use_ue8m0=self.use_deep_gemm_e8m0,
-            tma_aligned_scales=envs.VLLM_USE_DEEP_GEMM_TMA_ALIGNED_SCALES,
+            tma_aligned_scales=(
+                envs.VLLM_USE_DEEP_GEMM_TMA_ALIGNED_SCALES
+                and not envs.VLLM_BATCH_INVARIANT
+            ),
             column_major_scales=True,
         )
 

--- a/vllm/model_executor/kernels/linear/scaled_mm/flashinfer.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/flashinfer.py
@@ -7,9 +7,6 @@ from typing import ClassVar
 import torch
 
 import vllm.envs as envs
-from vllm.model_executor.layers.quantization.utils.fp8_utils import (
-    per_token_group_quant_fp8,
-)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
 )
@@ -27,7 +24,7 @@ from .BlockScaledMMLinearKernel import (
     Fp8BlockScaledDynamicMMLinearKernel,
     Fp8BlockScaledMMLinearKernel,
 )
-from .deep_gemm import DeepGemmFp8BlockScaledMMKernel, fp8_gemm_nt
+from .deep_gemm import DeepGemmFp8BlockScaledMMKernel
 from .ScaledMMLinearKernel import (
     FP8ScaledMMLinearKernel,
     FP8ScaledMMLinearLayerConfig,
@@ -164,6 +161,13 @@ class FlashInferFp8DeepGEMMDynamicBlockScaledKernel(
     )
     apply_input_quant: ClassVar[bool] = False
 
+    @classmethod
+    def is_supported(cls, compute_capability=None):
+        if envs.VLLM_BATCH_INVARIANT:
+            return False, "Use deepgemm for batch invariant setting"
+
+        return super().is_supported(compute_capability)
+
     def __init__(self, config: FP8ScaledMMLinearLayerConfig):
         super().__init__(config)
         self.base: FlashInferFp8BlockScaledMMKernel
@@ -174,6 +178,29 @@ class FlashInferFp8DeepGEMMDynamicBlockScaledKernel(
         # parameter tensor layout so processing once is sufficient.
         self.fallback.process_weights_after_loading(layer)
 
+    def predicate(
+        self,
+        A: torch.Tensor,
+        B: torch.Tensor,
+        As: torch.Tensor,
+        Bs: torch.Tensor,
+    ) -> bool:
+        return A.shape[0] < 32
+
+    def _deepgemm_apply_mm(
+        self,
+        A: torch.Tensor,
+        B: torch.Tensor,
+        As: torch.Tensor,
+        Bs: torch.Tensor,
+    ) -> torch.Tensor:
+        # A is BF16 (apply_input_quant=False).  Quantise here before calling
+        # DeepGEMM, which requires FP8 input.
+        # Both input_scale and input_scale_ub are None for dynamic block-scaled
+        # quantisation (static quantisation is rejected by can_implement).
+        A_fp8, As_fp8 = self.fallback.quant_fp8(A, None, None, use_triton=False)
+        return self.fallback.apply_block_scaled_mm(A_fp8, B, As_fp8, Bs)
+
     def apply_block_scaled_mm(
         self,
         A: torch.Tensor,
@@ -181,11 +208,13 @@ class FlashInferFp8DeepGEMMDynamicBlockScaledKernel(
         As: torch.Tensor,
         Bs: torch.Tensor,
     ) -> torch.Tensor:
-        group_size = self.weight_group_shape.col
-        use_deep_gemm_e8m0 = self.fallback.use_deep_gemm_e8m0
-
-        return torch.ops.vllm.dynamic_flashinfer_deepgemm_blockscale_gemm(
-            A, B, Bs, group_size, use_deep_gemm_e8m0
+        # FlashInfer branch receives BF16 A directly.
+        # DeepGEMM branch quantises BF16→FP8 inside _deepgemm_apply_mm.
+        return torch.cond(
+            self.predicate(A, B, As, Bs),
+            self.base.apply_block_scaled_mm,
+            self._deepgemm_apply_mm,
+            [A, B, As, Bs],
         )
 
 
@@ -219,113 +248,4 @@ direct_register_custom_op(
     "flashinfer_fp8_blockscale_gemm",
     _flashinfer_fp8_blockscale_gemm_impl,
     fake_impl=_flashinfer_fp8_blockscale_gemm_fake,
-)
-
-
-def _dynamic_flashinfer_deepgemm_blockscale_gemm_impl(
-    input: torch.Tensor,
-    weight: torch.Tensor,
-    weight_scale: torch.Tensor,
-    group_size: int,
-    use_deep_gemm_e8m0: bool,
-) -> torch.Tensor:
-    """
-    Conditional FlashInfer FP8 blockscale GEMM with batch-size-dependent selection.
-
-    This function switches between two optimized kernels based on the input batch size:
-    - For small batches (M < 32): Uses FlashInfer's DeepGEMM swapAB optimization.
-    - For larger batches (M >= 32): Uses the official DeepGEMM kernel.
-
-    The conditional logic must use torch.cond() instead of a simple if-else statement
-    to maintain compatibility with torch.compile graph compilation.
-
-    This batch-size-dependent selection is essential for maintaining model accuracy.
-    Benchmarks on GSM8K show a significant accuracy gap (88% vs 95%) for DeepSeek-V3.1
-    when using FlashInfer's DeepGEMM on M>=32. The M < 32 strategy fixes the accuracy
-    drop.
-
-    Args:
-        input: Input tensor of shape (batch_size, input_dim) in FP8 format
-        weight: Weight tensor of shape (output_dim, input_dim) in FP8 format
-        weight_scale: Scale factors for weight quantization (per-group)
-        group_size: Quantization group size for the weight tensor
-        use_deep_gemm_e8m0: Whether to use the E8M0 format in DeepGEMM quantization
-
-    Returns:
-        Output tensor of shape (batch_size, output_dim) in bfloat16 format
-    """
-
-    def run_flashinfer_deepgemm_swapAB(
-        input: torch.Tensor,
-        weight: torch.Tensor,
-        weight_scale: torch.Tensor,
-    ) -> torch.Tensor:
-        return flashinfer_fp8_blockscale_gemm(
-            input=input,
-            weight=weight,
-            weight_scale=weight_scale,
-            out_dtype=torch.bfloat16,
-        )
-
-    def run_deepgemm(
-        input: torch.Tensor,
-        weight: torch.Tensor,
-        weight_scale: torch.Tensor,
-    ) -> torch.Tensor:
-        q_input, input_scale = per_token_group_quant_fp8(
-            input,
-            group_size=group_size,
-            column_major_scales=True,
-            use_ue8m0=use_deep_gemm_e8m0,
-        )
-        output = torch.empty(
-            (q_input.shape[0], weight.shape[0]),
-            dtype=torch.bfloat16,
-            device=q_input.device,
-        )
-        fp8_gemm_nt(
-            (q_input, input_scale),
-            (weight, weight_scale),
-            output,
-            is_deep_gemm_e8m0_used=use_deep_gemm_e8m0,
-        )
-        return output
-
-    if envs.VLLM_BATCH_INVARIANT:
-        return run_deepgemm(input, weight, weight_scale)
-
-    condition = input.shape[0] < 32
-
-    # PyTorch's torch.compile cannot handle input-dependent control flow in standard
-    # Python conditionals. torch.cond() explicitly registers both code paths in the
-    # computation graph, allowing torch.compile to capture both branches.
-    # without torch.cond, the M < 32 condition won't be able to be captured by torch
-    # compile
-    return torch.cond(
-        condition,
-        run_flashinfer_deepgemm_swapAB,
-        run_deepgemm,
-        (input, weight, weight_scale),
-    )
-
-
-def _dynamic_flashinfer_deepgemm_blockscale_gemm_fake(
-    input: torch.Tensor,
-    weight: torch.Tensor,
-    weight_scale: torch.Tensor,
-    group_size: int,
-    use_deep_gemm_e8m0: bool,
-) -> torch.Tensor:
-    """
-    Required fake/meta implementation for torch.compile graph tracing.
-    """
-    return torch.empty(
-        input.shape[0], weight.shape[0], dtype=torch.bfloat16, device=input.device
-    )
-
-
-direct_register_custom_op(
-    "dynamic_flashinfer_deepgemm_blockscale_gemm",
-    _dynamic_flashinfer_deepgemm_blockscale_gemm_impl,
-    fake_impl=_dynamic_flashinfer_deepgemm_blockscale_gemm_fake,
 )


### PR DESCRIPTION



## Purpose

Refactors `FlashInferFp8DeepGEMMDynamicBlockScaledKernel` to use `torch.cond` for batch-size-dependent kernel dispatch, lifting the logic previously in `_dynamic_flashinfer_deepgemm_blockscale_gemm_impl` into the kernel class hierarchy.

## Issues with `torch.cond`:
1. AOTAutogradCache 
  ```
raise BypassAOTAutogradCache(
  torch._functorch._aot_autograd.autograd_cache.BypassAOTAutogradCache: Unsupported call_function target cond.
   Function module: torch.ops.higher_order,
  Function name: cond
```

 fix : The monkeypatch `torch.ops.higher_order.cond._cacheable = True`  fixes that error

3. fx-graph during dummy run skipping the cond node.
fix: this PR https://github.com/vllm-project/vllm/pull/38958 fixes the issue.

4. Finally after the fx-graph is compiled then the true_fn and false_fn path should be serialized for caching.
After checking the tlparse result, the submodules were compiled successfully but there is a cache miss. Speculation: the cache miss originates from `orig(*args, **kwargs)`  in the patched `autograd_cache_key`.  it seems the torch.cond predicate `(Sym(s72 < 32), a SymBool`) is not pickleable, causing `pickler.get_hash(details)`  to raise.

```
EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/aot_autograd.py", line 1093, in aot_module_simplified
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]     compiled_fn = AOTAutogradCache.try_load(
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/autograd_cache.py", line 721, in try_load
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]     raise e
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/autograd_cache.py", line 633, in try_load
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]     cache_key, debug_lines = autograd_cache_key(
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]                              ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]   File "/app/rfc/2nd/vllm/vllm/compilation/backends.py", line 326, in autograd_cache_key
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]     result = orig(*args, **kwargs)
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]              ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]   File "/usr/local/lib/python3.12/dist-packages/torch/_functorch/_aot_autograd/autograd_cache.py", line 496, in autograd_cache_key
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]     key = "a" + pickler.get_hash(details)
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]                 ^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/codecache.py", line 640, in get_hash
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]     serialized_data = self.dumps(obj)
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]                       ^^^^^^^^^^^^^^^
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]   File "/usr/local/lib/python3.12/dist-packages/torch/_inductor/codecache.py", line 625, in dumps
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108]     self.dump(obj)
(EngineCore pid=63310) ERROR 04-04 03:52:41 [core.py:1108] RuntimeError: <pybind11_builtins.pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1 object at 0x7f39e8116030> is not pickleable.
```
## Summery of changes 

- Introduces `predicate()` + `apply_block_scaled_mm()` on `Fp8BlockScaledDynamicMMLinearKernel` as a shared `torch.cond`-based dispatch contract — subclasses implement only `predicate()`
- `FlashInferFp8DeepGEMMDynamicBlockScaledKernel` now expresses the same `M < 32 / M ≥ 32` branching (FlashInfer vs. DeepGEMM) that was previously inside `_dynamic_flashinfer_deepgemm_blockscale_gemm_impl`, but as a proper class method rather than a standalone custom op
- Removes the `dynamic_flashinfer_deepgemm_blockscale_gemm` custom op and its fake impl, which are no longer needed
- `VLLM_BATCH_INVARIANT` disables `FlashInferFp8DeepGEMMDynamicBlockScaledKernel` via `is_supported` and disables TMA-aligned scales in DeepGEMM, preserving the batch-invariant behavior from the original impl


## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

