### PR TITLE
[ROCm] Eliminate MoE output copy via final_output aliasing and router buffer reuse

### DIFF
--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -1204,6 +1204,7 @@ class FusedMoEKernelModularImpl:
         expert_map: torch.Tensor | None,
         apply_router_weight_on_input: bool,
         expert_tokens_meta: ExpertTokensMetadata | None,
+        final_output: torch.Tensor | None = None,
     ) -> torch.Tensor:
         _, M_full, N, K, top_k = self.fused_experts.moe_problem_size(
             a1q, w1, w2, topk_ids
@@ -1231,6 +1232,13 @@ class FusedMoEKernelModularImpl:
             expert_tokens_meta,
             activation,
         )
+
+        if (
+            final_output is not None
+            and final_output.shape == fused_out.shape
+            and final_output.dtype == fused_out.dtype
+        ):
+            fused_out = final_output
 
         self.fused_experts.apply(
             output=fused_out,
@@ -1392,6 +1400,7 @@ class FusedMoEKernelModularImpl:
             expert_map=expert_map,
             apply_router_weight_on_input=apply_router_weight_on_input,
             expert_tokens_meta=expert_tokens_meta,
+            final_output=output if not self.inplace else None,
         )
 
         return self._finalize(

--- a/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/fused_topk_router.py
@@ -78,15 +78,33 @@ def fused_topk(
 
     M, _ = hidden_states.size()
 
-    topk_weights = torch.empty(
-        M, topk, dtype=torch.float32, device=hidden_states.device
+    from vllm.model_executor.layers.fused_moe.rocm_aiter_fused_moe import (
+        aiter_topK_meta_data,
     )
-    topk_ids = torch.empty(
-        M,
-        topk,
-        dtype=torch.int32 if indices_type is None else indices_type,
-        device=hidden_states.device,
-    )
+
+    if (
+        rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
+        and aiter_topK_meta_data is not None
+    ):
+        total_topk_weights, total_topk_ids = aiter_topK_meta_data
+        total_topk_weights_slice = total_topk_weights[:M]
+        total_topk_ids_slice = total_topk_ids[:M]
+        topk_weights, _ = total_topk_weights_slice.split(
+            [topk, total_topk_weights_slice.shape[1] - topk], dim=1
+        )
+        topk_ids, _ = total_topk_ids_slice.split(
+            [topk, total_topk_ids_slice.shape[1] - topk], dim=1
+        )
+    else:
+        topk_weights = torch.empty(
+            M, topk, dtype=torch.float32, device=hidden_states.device
+        )
+        topk_ids = torch.empty(
+            M,
+            topk,
+            dtype=torch.int32 if indices_type is None else indices_type,
+            device=hidden_states.device,
+        )
     token_expert_indices = torch.empty(
         M, topk, dtype=torch.int32, device=hidden_states.device
     )
@@ -95,22 +113,26 @@ def fused_topk(
         topk_func = dispatch_topk_softmax_func(
             use_rocm_aiter=rocm_aiter_ops.is_fused_moe_enabled()
         )
-        topk_weights, topk_ids = topk_func(
+        topk_func(
             topk_weights, topk_ids, token_expert_indices, gating_output, renormalize
         )
-
-        return topk_weights, topk_ids, token_expert_indices
     elif scoring_func == "sigmoid":
         topk_func = dispatch_topk_sigmoid_func(
             use_rocm_aiter=rocm_aiter_ops.is_fused_moe_enabled()
         )
-        topk_weights, topk_ids = topk_func(
+        topk_func(
             topk_weights, topk_ids, token_expert_indices, gating_output, renormalize
         )
-
-        return topk_weights, topk_ids, token_expert_indices
     else:
         raise ValueError(f"Unsupported scoring function: {scoring_func}")
+
+    if (
+        rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
+        and aiter_topK_meta_data is not None
+    ):
+        return total_topk_weights_slice, total_topk_ids_slice, token_expert_indices
+
+    return topk_weights, topk_ids, token_expert_indices
 
 
 class FusedTopKRouter(BaseRouter):


### PR DESCRIPTION
## Summary
- Allow `_fused_experts` to write directly into the caller's output tensor (`final_output` aliasing) when shapes/dtypes match, skipping the copy in `_finalize`
- When AITER fused shared experts are enabled, reuse the pre-allocated topK metadata buffers for router outputs instead of allocating new tensors each forward pass

## Test plan
- [ ] Verify MoE models produce correct output with and without AITER shared expert fusion
- [ ] Benchmark to confirm reduced memory allocation overhead
- [ ] Verify non-ROCm paths are unaffected (conditions gate on AITER enablement)

Made with [Cursor](https://cursor.com)