### PR TITLE
[vLLM IR] Support vLLM IR on XPU Platform and fix precision issue under torch.compile

### DIFF
--- a/vllm/distributed/device_communicators/xpu_communicator.py
+++ b/vllm/distributed/device_communicators/xpu_communicator.py
@@ -48,8 +48,13 @@ class XpuCommunicator(DeviceCommunicatorBase):
                 logger.info("Using AgRs manager on XPU device.")
 
     def all_reduce(self, input_) -> torch.Tensor:
-        dist.all_reduce(input_, group=self.device_group)
-        return input_
+        if torch.compiler.is_compiling():
+            output = input_.clone()
+            dist.all_reduce(output, group=self.device_group)
+            return output
+        else:
+            dist.all_reduce(input_, group=self.device_group)
+            return input_
 
     def reduce_scatter(self, input_: torch.Tensor, dim: int = -1):
         world_size = self.world_size

--- a/vllm/ir/ops/layernorm.py
+++ b/vllm/ir/ops/layernorm.py
@@ -17,5 +17,5 @@ def rms_norm(
     variance = x_var.pow(2).mean(dim=-1, keepdim=True)
     x = x * torch.rsqrt(variance + epsilon)
     if weight is not None:
-        x = x.to(weight.dtype) * weight
+        x = x * weight
     return x.to(orig_dtype)

--- a/vllm/model_executor/layers/layernorm.py
+++ b/vllm/model_executor/layers/layernorm.py
@@ -226,9 +226,9 @@ class RMSNorm(CustomOp):
         variance = x_var.pow(2).mean(dim=-1, keepdim=True)
 
         x = x * torch.rsqrt(variance + variance_epsilon)
-        x = x.to(orig_dtype)
         if weight is not None:
             x = x * weight
+        x = x.to(orig_dtype)
         if residual is None:
             return x
         else:

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -207,6 +207,41 @@ class XPUPlatform(Platform):
                     "falling back to PIECEWISE graph mode on XPU platform."
                 )
 
+        # Disable fusion passes not yet supported on XPU.
+        pass_config = compilation_config.pass_config
+        if pass_config.enable_sp:
+            logger.warning(
+                "Sequence parallelism is not yet supported on XPU and will be disabled."
+            )
+            pass_config.enable_sp = False
+        if pass_config.fuse_gemm_comms:
+            logger.warning("Async TP is not yet supported on XPU and will be disabled.")
+            pass_config.fuse_gemm_comms = False
+        if pass_config.fuse_allreduce_rms:
+            logger.warning(
+                "AllReduce + RMSNorm fusion is not yet supported on XPU and will "
+                "be disabled."
+            )
+            pass_config.fuse_allreduce_rms = False
+        if pass_config.fuse_norm_quant:
+            logger.warning(
+                "RMSNorm + quant fusion is not yet supported on XPU and will "
+                "be disabled."
+            )
+            pass_config.fuse_norm_quant = False
+        if pass_config.fuse_act_quant:
+            logger.warning(
+                "Activation + quant fusion is not yet supported on XPU and will "
+                "be disabled."
+            )
+            pass_config.fuse_act_quant = False
+        if pass_config.fuse_attn_quant:
+            logger.warning(
+                "Attention + quant fusion is not yet supported on XPU and will "
+                "be disabled."
+            )
+            pass_config.fuse_attn_quant = False
+
         # check and update parallel config
         parallel_config = vllm_config.parallel_config
         # Only override worker_cls if it's still the default "auto"
@@ -325,8 +360,9 @@ class XPUPlatform(Platform):
         cc = vllm_config.compilation_config
         using_inductor = cc.backend == "inductor" and cc.mode != CompilationMode.NONE
         default = ["native"] if using_inductor else ["xpu_kernels", "native"]
-
-        return IrOpPriorityConfig.with_default(default)
+        return IrOpPriorityConfig.with_default(
+            default, rms_norm=["xpu_kernels", "native"]
+        )
 
     @classmethod
     def device_count(cls) -> int:


### PR DESCRIPTION
## Purpose
Enable vLLM IR compilation  on XPU platform and fix precision issues in compile mode.

## Fix
**Fix 1**: XPU all_reduce returns all-zeros in compile mode
  dist.all_reduce is an in-place operation. When traced by inductor, the original input tensor may be optimized away since the compiler
  does not see a new tensor being produced, causing the output to be all-zeros.

  **Fix**: Clone the input tensor before calling dist.all_reduce when torch.compiler.is_compiling(), so inductor properly tracks the output
  tensor in the FX graph. The eager path remains unchanged (no unnecessary copy).

**Fix 2**: Native rms_norm — remove unnecessary intermediate dtype truncation

  When inductor inlines and compiles these operations on XPU's Triton backend, codegen_upcast_to_fp32=True converts the intermediate bf16 cast into a no-op (to_dtype(bf16) → to(tl.float32)), causing the truncation to be silently eliminated. This makes the compiled result differ from the eager result by up to 6.25e-02 (amplified by large weight values: 8 × eps_bf16 ≈ 0.0625).

**Fix**: Delay the dtype cast to after the weight multiply, keeping fp32 precision throughout

**Fix 3**: Disable unsupported XPU fusion passes

## Test Plan

Llama-3.1-8B latency configuration:
Command: vllm bench latency --model=meta-llama/Llama-3.1-8B -tp 2 


**Median latency**

| Configuration       | main   | PR     |
|---------------------|--------|--------|
| --enforce-eager     | 2.6439s | 2.6459s |
| default             | 2.6956s | 2.6889 | 

**lm_eval:**

Main: 

1. torch.compile mode

bash run-lm-eval-gsm-vllm-baseline.sh -m meta-llama/Llama-3.1-8B,dtype=bfloat16 -b 20 -l 250 -f 5 -t 2 
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0|±  |0|
|     |       |strict-match    |     5|exact_match|↑  | 0|±  |0|

2. eager mode:
bash run-lm-eval-gsm-vllm-baseline.sh -m meta-llama/Llama-3.1-8B,dtype=bfloat16,enforce_eager=True  -b 20 -l 250 -f 5 -t 2 

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.52|±  |0.0317|
|     |       |strict-match    |     5|exact_match|↑  | 0.52|±  |0.0317|

PR:

1. torch.compile mode
a. set rms_norm provider = xpu_kernels
bash run-lm-eval-gsm-vllm-baseline.sh -m meta-llama/Llama-3.1-8B,dtype=bfloat16 -b 20 -l 250 -f 5 -t 2 

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.52|±  |0.0317|
|     |       |strict-match    |     5|exact_match|↑  | 0.52|±  |0.0317|

b. set rms_norm provider = native
bash run-lm-eval-gsm-vllm-baseline.sh -m meta-llama/Llama-3.1-8B,dtype=bfloat16 -b 20 -l 250 -f 5 -t 2 

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.508|±  |0.0317|
|     |       |strict-match    |     5|exact_match|↑  | 0.508|±  |0.0317|

2. eager mode:
bash run-lm-eval-gsm-vllm-baseline.sh -m meta-llama/Llama-3.1-8B,dtype=bfloat16,enforce_eager=True  -b 20 -l 250 -f 5 -t 2 

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.52|±  |0.0317|
|     |       |strict-match    |     5|exact_match|↑  | 0.52|±  |0.0317|


## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

