### PR TITLE
[BugFix] fix tests/kernels/moe/test_moe_layer.py

### DIFF
--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner_base.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner_base.py
@@ -40,7 +40,7 @@ from vllm.utils.torch_utils import (
 
 def get_layer_from_name(layer_name: str) -> torch.nn.Module:
     forward_context: ForwardContext = get_forward_context()
-    if layer_name == "from_forward_context":
+    if not HAS_OPAQUE_TYPE and layer_name == "from_forward_context":
         all_moe_layers = forward_context.all_moe_layers
         assert all_moe_layers is not None
         moe_layer_index = forward_context.moe_layer_index


### PR DESCRIPTION
https://github.com/vllm-project/vllm/pull/39286 broke this test. That PR made it so that with PyTorch 2.11, vLLM stops using "from_forward_context" as a sentinel layer name value.

tests/kernels/moe/test_moe_layer.py was using "from_forward_context" as the literal layer name (instead of as the sentinel layer name). The bug is that if a layer happens to be named `from_forward_context` after #39286, we'd still treat it as the sentinel value. Instead, we should treat it just like any other layer name.

Test Plan:
- ran tests/kernels/moe/test_moe_layer.py locally
