### PR TITLE
[BugFix] Dense + multinode + DP > 1 port conflicts

### DIFF
--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -905,3 +905,19 @@ class ParallelConfig:
             )
 
         return self
+
+    def rescope_for_independent_dp(self):
+        """
+        For non-MoE models with data parallelism, each DP rank is
+        independent. This method re-scopes the parallel config to
+        reflect the world of a single DP rank.
+        """
+        # The order of operations is important here to correctly capture
+        # the values before they are affected by other config changes.
+        nnodes = self.nnodes_within_dp
+        node_rank = self.node_rank_within_dp
+        self.data_parallel_size = 1
+        self.data_parallel_size_local = 1
+        self.data_parallel_rank = 0
+        self.nnodes = nnodes
+        self.node_rank = node_rank

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1079,13 +1079,7 @@ class EngineCoreProc(EngineCore):
                 # Non-MoE DP ranks are completely independent, so treat like DP=1.
                 # Note that parallel_config.data_parallel_index will still reflect
                 # the original DP rank.
-                nnodes = parallel_config.nnodes_within_dp
-                node_rank = parallel_config.node_rank_within_dp
-                parallel_config.data_parallel_size = 1
-                parallel_config.data_parallel_size_local = 1
-                parallel_config.data_parallel_rank = 0
-                parallel_config.nnodes = nnodes
-                parallel_config.node_rank = node_rank
+                parallel_config.rescope_for_independent_dp()
                 engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
 
             assert engine_core is not None
@@ -2030,14 +2024,7 @@ class EngineCoreActor(EngineCoreActorMixin, EngineCoreProc):
         dp_rank: int = 0,
         local_dp_rank: int = 0,
     ):
-        nnodes = vllm_config.parallel_config.nnodes_within_dp
-        node_rank = vllm_config.parallel_config.node_rank_within_dp
-        vllm_config.parallel_config.data_parallel_size = 1
-        vllm_config.parallel_config.data_parallel_size_local = 1
-        vllm_config.parallel_config.data_parallel_rank = 0
-        vllm_config.parallel_config.nnodes = nnodes
-        vllm_config.parallel_config.node_rank = node_rank
-
+        vllm_config.parallel_config.rescope_for_independent_dp()
         EngineCoreActorMixin.__init__(
             self, vllm_config, addresses, dp_rank, local_dp_rank
         )

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1079,9 +1079,13 @@ class EngineCoreProc(EngineCore):
                 # Non-MoE DP ranks are completely independent, so treat like DP=1.
                 # Note that parallel_config.data_parallel_index will still reflect
                 # the original DP rank.
+                nnodes = parallel_config.nnodes_within_dp
+                node_rank = parallel_config.node_rank_within_dp
                 parallel_config.data_parallel_size = 1
                 parallel_config.data_parallel_size_local = 1
                 parallel_config.data_parallel_rank = 0
+                parallel_config.nnodes = nnodes
+                parallel_config.node_rank = node_rank
                 engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
 
             assert engine_core is not None
@@ -2026,9 +2030,13 @@ class EngineCoreActor(EngineCoreActorMixin, EngineCoreProc):
         dp_rank: int = 0,
         local_dp_rank: int = 0,
     ):
+        nnodes = vllm_config.parallel_config.nnodes_within_dp
+        node_rank = vllm_config.parallel_config.node_rank_within_dp
         vllm_config.parallel_config.data_parallel_size = 1
         vllm_config.parallel_config.data_parallel_size_local = 1
         vllm_config.parallel_config.data_parallel_rank = 0
+        vllm_config.parallel_config.nnodes = nnodes
+        vllm_config.parallel_config.node_rank = node_rank
 
         EngineCoreActorMixin.__init__(
             self, vllm_config, addresses, dp_rank, local_dp_rank


### PR DESCRIPTION
## Purpose

Broken by #30739. Currently we have the following situation

| DP | nnodes_within_dp | nnodes | working |
| -- | -- | -- | -- |
| 1 | 1 | 1 | ✅ |
| 1 | >1 | >1 | ✅ |
| 1 | 1 | >1 | ✅ |
| >1 | 1 | 1 | ✅ |
| >1 | >1 | >1 | :x: |
| >1 | 1 | >1 | :x: |

This minimal PR fixes the last row (e.g. `-dp 4 -tp 4`). To fix the second last row (e.g. `-dp 4 -tp 16`) we would need a bigger refactor, because we can no longer rely on `localhost` to do it's distributed initialization. We would need some mechanism to discover the IP of the leader rank within each DP group. Leaving the fix to the future as it's a lot more involved and unclear if this combination is even heavily used. (Seems to be broken unnoticed for ~3 months). 

The symptom of the issue with the last row is

```
DistNetworkError: The server socket has failed to listen on any local network address. port: 29501,
useIpv6: false, code: -98, name: EADDRINUSE, message: address already in us
```

This is because without the current patch, `parallel_state.nnodes` is still set to > 1, so in `init_distributed_environment` it tries to create the `distributed_init_method` based on `parallel_config.master_addr` and `parallel_config.master_port`, which means multiple dp ranks would try to use `master_addr:master_port` for init, which leads to port conflicts. With this patch, it will fallback to `localhost:get_open_port()` which solves the issue for the nnodes_with_dp = 1 case (but wouldn't work for nnodes_with_dp > 1).

This is discussed in the context of `distributed_executor_backend = "mp"` (default), I'm not sure what is supposed to happen for other distributed_executor_backend modes.

## Test Plan

Manually tested.

## Test Result

It works.