### PR TITLE
[LoRA] Fix PEFTHelper.vllm_max_position_embeddings default from False to None

### DIFF
--- a/vllm/lora/peft_helper.py
+++ b/vllm/lora/peft_helper.py
@@ -37,7 +37,7 @@ class PEFTHelper:
     use_dora: bool = field(default=False)
     # Extra vllm field, start with 'vllm_' to avoid conflict
     vllm_lora_scaling_factor: float = field(default=1.0)
-    vllm_max_position_embeddings: int | None = field(default=False)
+    vllm_max_position_embeddings: int | None = field(default=None)
 
     def _validate_features(self) -> list[str]:
         """


### PR DESCRIPTION
## Summary

`PEFTHelper.vllm_max_position_embeddings` is typed `int | None` but defaults to `False`. Since `bool` is a subclass of `int` in Python, `False` silently passes `isinstance(x, int)` checks. However, any code using `is None` to detect the "not set" sentinel will fail — `False is not None` evaluates to `True`, treating the unset default as if it were an explicitly provided value of `0`.

**Fix:** Change `field(default=False)` to `field(default=None)` to match the declared type annotation.

**Note:** The primary production path (`from_local_dir`) always injects this key before calling `from_dict`, so this is currently latent. The fix ensures the `from_dict` public API honors its type contract.

This PR was created with AI assistance (Claude). No duplicate PRs exist — searched `vllm_max_position_embeddings` and `peft_helper` in open PRs.

## Test plan

- [ ] Existing `tests/lora/test_peft_helper.py` passes (tests `from_local_dir` which always sets the field)
- [ ] `PEFTHelper.from_dict({...})` without the key now defaults to `None`, not `False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)