### PR TITLE
[V1] Async parallel startup for EngineCore processes in DP/TP scenarios

### DIFF
--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import asyncio
+import concurrent.futures
 import contextlib
 import os
 import threading
@@ -11,7 +13,7 @@ from enum import Enum, auto
 from multiprocessing import Process, connection
 from multiprocessing.process import BaseProcess
 from multiprocessing.queues import Queue
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 from unittest.mock import patch
 
 import msgspec
@@ -35,6 +37,11 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 STARTUP_POLL_PERIOD_MS = 10000
+
+# Threshold for switching to async parallel startup of EngineCore processes.
+# When local_engine_count > this value, all processes are started concurrently
+# via asyncio.gather() to reduce total startup time from O(N) to O(1).
+_ASYNC_STARTUP_ENGINE_THRESHOLD = 1
 
 
 class CoreEngineState(Enum):
@@ -80,6 +87,29 @@ class EngineHandshakeMetadata:
     parallel_config: dict[str, int | str | list[int]]
 
 
+def _enginecore_bootstrap(
+    *,
+    evar: str,
+    value: str,
+    target_fn: Callable[..., Any],
+    target_kwargs: dict[str, Any],
+) -> None:
+    """Bootstrap function for EngineCore subprocesses that need env control.
+
+    Sets the device control environment variable (e.g. CUDA_VISIBLE_DEVICES)
+    before invoking the real engine entry point. This avoids the race
+    condition that arises when the parent process temporarily patches the
+    environment variable and then forks, because the patch is applied
+    inside the child instead.
+
+    Only used when need_env_control is True (non-CUDA platforms or Ray
+    launcher). CUDA platforms without Ray use torch.cuda.set_device()
+    inside the worker and never call this function.
+    """
+    os.environ[evar] = value
+    target_fn(**target_kwargs)
+
+
 class CoreEngineProcManager:
     """
     Utility class to handle creation, readiness, and shutdown
@@ -112,9 +142,21 @@ class CoreEngineProcManager:
         if client_handshake_address:
             common_kwargs["client_handshake_address"] = client_handshake_address
 
-        is_dp = vllm_config.parallel_config.data_parallel_size > 1
-
         from vllm.v1.engine.core import EngineCoreProc
+
+        # Determine whether we need to control the device visibility env var
+        # inside the child process rather than in the parent.
+        # For CUDA platforms without Ray we rely on torch.cuda.set_device()
+        # inside the worker, so no env-var patching is needed.
+        data_parallel = vllm_config.parallel_config.data_parallel_size > 1
+        need_env_control = data_parallel and (
+            not current_platform.is_cuda_alike()
+            or vllm_config.parallel_config.use_ray
+        )
+        if need_env_control:
+            evar = current_platform.device_control_env_var
+            world_size = vllm_config.parallel_config.world_size
+            local_world_size = vllm_config.parallel_config.local_world_size
 
         self.processes: list[BaseProcess] = []
         local_dp_ranks = []
@@ -126,10 +168,28 @@ class CoreEngineProcManager:
             local_dp_ranks.append(local_index)
             self.processes.append(
                 context.Process(
-                    target=EngineCoreProc.run_engine_core,
-                    name=f"EngineCore_DP{global_index}" if is_dp else "EngineCore",
-                    kwargs=common_kwargs
-                    | {"dp_rank": global_index, "local_dp_rank": local_index},
+                    target=(_enginecore_bootstrap if need_env_control
+                            else EngineCoreProc.run_engine_core),
+                    name=(f"EngineCore_DP{global_index}" if data_parallel
+                          else "EngineCore"),
+                    kwargs=(
+                        {
+                            "evar": evar,
+                            "value": get_device_indices(
+                                evar, local_index, world_size, local_world_size
+                            ),
+                            "target_fn": EngineCoreProc.run_engine_core,
+                            "target_kwargs": common_kwargs | {
+                                "dp_rank": global_index,
+                                "local_dp_rank": local_index,
+                            },
+                        }
+                        if need_env_control
+                        else common_kwargs | {
+                            "dp_rank": global_index,
+                            "local_dp_rank": local_index,
+                        }
+                    ),
                 )
             )
 
@@ -137,43 +197,93 @@ class CoreEngineProcManager:
         self.manager_stopped = threading.Event()
         self.failed_proc_name: str | None = None
 
-        try:
-            for proc, local_dp_rank in zip(self.processes, local_dp_ranks):
-                # Adjust device control in DP for non-CUDA platforms
-                # as well as external and ray launchers
-                # For CUDA platforms, we use torch.accelerator.set_device_index()()
-                device_control_context: contextlib.AbstractContextManager[None] = (
-                    contextlib.nullcontext()
+        # Start all processes concurrently to avoid O(N) sequential startup
+        # latency. Serial path is taken only for single-engine deployments.
+        use_async_startup = local_engine_count > _ASYNC_STARTUP_ENGINE_THRESHOLD
+        if use_async_startup:
+            logger.info(
+                "Using async parallel startup for %d EngineCore processes.",
+                local_engine_count,
+            )
+            try:
+                self._run_async_startup(vllm_config, local_dp_ranks)
+                logger.info(
+                    "All %d EngineCore processes started successfully.",
+                    local_engine_count,
                 )
-                if is_dp and (
-                    not current_platform.is_cuda_alike()
-                    or vllm_config.parallel_config.use_ray
-                ):
-                    device_control_context = set_device_control_env_var(
-                        vllm_config, local_dp_rank
-                    )
-
-                with (
-                    device_control_context,
-                    numa_utils.configure_subprocess(
-                        # EngineCore itself does not have a TP/PP-local rank.
-                        # When DP is enabled, set_device_control_env_var()
-                        # narrows visible devices to this DP shard first, so
-                        # local_rank=0 means "the first local GPU in this
-                        # shard". The actual TP/PP worker processes spawned by
-                        # the executor are bound separately with their own
-                        # local_rank values.
+            finally:
+                if self.finished_procs():
+                    self.shutdown()
+        else:
+            # Serial startup path (small DP or single-engine).
+            # For non-CUDA / Ray cases the env var is now set inside the child
+            # via _enginecore_bootstrap, so no parent-side patching is needed.
+            try:
+                for proc, local_dp_rank in zip(self.processes, local_dp_ranks):
+                    with numa_utils.configure_subprocess(
                         vllm_config,
                         local_rank=0,
                         dp_local_rank=local_dp_rank,
                         process_kind="EngineCore",
-                    ),
+                    ):
+                        proc.start()
+            finally:
+                if self.finished_procs():
+                    self.shutdown()
+
+    def _run_async_startup(
+        self,
+        vllm_config: VllmConfig,
+        local_dp_ranks: list[int],
+    ) -> None:
+        """Run _start_processes_async() in an event loop.
+
+        Handles the case where we are already inside a running event loop
+        (e.g. called from AsyncLLM) by offloading to a dedicated thread
+        with its own loop, avoiding nested asyncio.run() calls.
+        """
+        try:
+            asyncio.get_running_loop()
+            # Already inside an event loop - spin up a fresh loop in a
+            # background thread to avoid nesting asyncio.run() calls.
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(
+                    asyncio.run,
+                    self._start_processes_async(vllm_config, local_dp_ranks),
+                )
+                future.result()
+        except RuntimeError:
+            # No running loop - safe to call asyncio.run() directly.
+            asyncio.run(self._start_processes_async(vllm_config, local_dp_ranks))
+
+    async def _start_processes_async(
+        self,
+        vllm_config: VllmConfig,
+        local_dp_ranks: list[int],
+    ) -> None:
+        """Start all EngineCore processes concurrently.
+
+        Each proc.start() is offloaded to the thread pool via
+        asyncio.to_thread so that NUMA binding context managers can be
+        applied per-process without blocking the event loop.
+        """
+
+        async def _start_one(proc: BaseProcess, local_dp_rank: int) -> None:
+            def _start_with_numa() -> None:
+                with numa_utils.configure_subprocess(
+                    vllm_config,
+                    local_rank=0,
+                    dp_local_rank=local_dp_rank,
+                    process_kind="EngineCore",
                 ):
                     proc.start()
-        finally:
-            # Kill other procs if not all are running.
-            if self.finished_procs():
-                self.shutdown()
+
+            await asyncio.to_thread(_start_with_numa)
+
+        await asyncio.gather(
+            *(_start_one(proc, rank)
+              for proc, rank in zip(self.processes, local_dp_ranks))
+        )
 
     def shutdown(self, timeout: float | None = None) -> None:
         """Shutdown engine core processes with configurable timeout."""

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import asyncio
 import multiprocessing
 import os
 import pickle
@@ -11,7 +12,7 @@ import traceback
 import weakref
 from collections import deque
 from collections.abc import Callable, Sequence
-from concurrent.futures import Future, InvalidStateError
+from concurrent.futures import Future, InvalidStateError, ThreadPoolExecutor
 from contextlib import suppress
 from dataclasses import dataclass
 from enum import Enum, auto
@@ -165,42 +166,70 @@ class MultiprocExecutor(Executor):
             # When using fork, keep track of socket file descriptors that are
             # inherited by the worker, so that we can close them in subsequent
             # workers
-            inherited_fds: list[int] | None = (
-                [] if context.get_start_method() == "fork" else None
-            )
+            is_fork = context.get_start_method() == "fork"
+            inherited_fds: list[int] | None = [] if is_fork else None
 
-            for local_rank in range(self.local_world_size):
-                global_rank = global_start_rank + local_rank
-                is_driver_worker = self._is_driver_worker(global_rank)
-                if current_platform.is_cpu():
-                    om = current_platform.get_omp_manager()
-                    logger.info("Configured OMP PLACES %s", str(om.omp_places))
-                    unready_worker_handle = om.run(
-                        WorkerProc.make_worker_process,
-                        vllm_config=self.vllm_config,
-                        local_rank=local_rank,
-                        rank=global_rank,
-                        distributed_init_method=distributed_init_method,
-                        input_shm_handle=scheduler_output_handle,
-                        shared_worker_lock=shared_worker_lock,
-                        is_driver_worker=is_driver_worker,
-                        inherited_fds=inherited_fds,
-                    )
-                else:
-                    unready_worker_handle = WorkerProc.make_worker_process(
-                        vllm_config=self.vllm_config,
-                        local_rank=local_rank,
-                        rank=global_rank,
-                        distributed_init_method=distributed_init_method,
-                        input_shm_handle=scheduler_output_handle,
-                        shared_worker_lock=shared_worker_lock,
-                        is_driver_worker=is_driver_worker,
-                        inherited_fds=inherited_fds,
-                    )
-                unready_workers.append(unready_worker_handle)
-                if inherited_fds is not None:
-                    inherited_fds.append(unready_worker_handle.death_writer.fileno())
-                    inherited_fds.append(unready_worker_handle.ready_pipe.fileno())
+            # Use async parallel startup for spawn mode with multiple workers.
+            # Fork mode requires sequential fd tracking, so it must use serial.
+            # CPU platform uses om.run() which is not compatible with async startup.
+            use_async_startup = (
+                not is_fork
+                and not current_platform.is_cpu()
+                and self.local_world_size > 1
+            )
+            if use_async_startup:
+                logger.info(
+                    "Using async parallel startup for %d worker processes.",
+                    self.local_world_size,
+                )
+                unready_workers = self._run_async_workers_startup(
+                    global_start_rank,
+                    distributed_init_method,
+                    scheduler_output_handle,
+                    shared_worker_lock,
+                )
+                logger.info(
+                    "All %d worker processes started successfully.",
+                    self.local_world_size,
+                )
+            else:
+                # Serial startup path (fork mode, CPU platform, or small world_size).
+                for local_rank in range(self.local_world_size):
+                    global_rank = global_start_rank + local_rank
+                    is_driver_worker = self._is_driver_worker(global_rank)
+                    if current_platform.is_cpu():
+                        om = current_platform.get_omp_manager()
+                        logger.info("Configured OMP PLACES %s", str(om.omp_places))
+                        unready_worker_handle = om.run(
+                            WorkerProc.make_worker_process,
+                            vllm_config=self.vllm_config,
+                            local_rank=local_rank,
+                            rank=global_rank,
+                            distributed_init_method=distributed_init_method,
+                            input_shm_handle=scheduler_output_handle,
+                            shared_worker_lock=shared_worker_lock,
+                            is_driver_worker=is_driver_worker,
+                            inherited_fds=inherited_fds,
+                        )
+                    else:
+                        unready_worker_handle = WorkerProc.make_worker_process(
+                            vllm_config=self.vllm_config,
+                            local_rank=local_rank,
+                            rank=global_rank,
+                            distributed_init_method=distributed_init_method,
+                            input_shm_handle=scheduler_output_handle,
+                            shared_worker_lock=shared_worker_lock,
+                            is_driver_worker=is_driver_worker,
+                            inherited_fds=inherited_fds,
+                        )
+                    unready_workers.append(unready_worker_handle)
+                    if inherited_fds is not None:
+                        inherited_fds.append(
+                            unready_worker_handle.death_writer.fileno()
+                        )
+                        inherited_fds.append(
+                            unready_worker_handle.ready_pipe.fileno()
+                        )
 
             # Workers must be created before wait_for_ready to avoid
             # deadlock, since worker.init_device() does a device sync.
@@ -272,6 +301,83 @@ class MultiprocExecutor(Executor):
 
     def _is_driver_worker(self, rank: int) -> bool:
         return rank % self.parallel_config.tensor_parallel_size == 0
+
+    def _run_async_workers_startup(
+        self,
+        global_start_rank: int,
+        distributed_init_method: str,
+        scheduler_output_handle,
+        shared_worker_lock,
+    ) -> list["UnreadyWorkerProcHandle"]:
+        """Run _start_workers_async() in an event loop.
+
+        Handles the case where we are already inside a running event loop
+        by offloading to a dedicated thread with its own loop.
+        """
+        try:
+            asyncio.get_running_loop()
+            # Already inside an event loop — spin up a fresh loop in a
+            # background thread to avoid nesting asyncio.run() calls.
+            with ThreadPoolExecutor(max_workers=1) as pool:
+                future = pool.submit(
+                    asyncio.run,
+                    self._start_workers_async(
+                        global_start_rank,
+                        distributed_init_method,
+                        scheduler_output_handle,
+                        shared_worker_lock,
+                    ),
+                )
+                return future.result()
+        except RuntimeError:
+            # No running loop — safe to call asyncio.run() directly.
+            return asyncio.run(
+                self._start_workers_async(
+                    global_start_rank,
+                    distributed_init_method,
+                    scheduler_output_handle,
+                    shared_worker_lock,
+                )
+            )
+
+    async def _start_workers_async(
+        self,
+        global_start_rank: int,
+        distributed_init_method: str,
+        scheduler_output_handle,
+        shared_worker_lock,
+    ) -> list["UnreadyWorkerProcHandle"]:
+        """Start all worker processes concurrently.
+
+        Each WorkerProc.make_worker_process() call is offloaded to a
+        thread-pool thread via asyncio.to_thread(), allowing all workers
+        to be spawned in parallel rather than sequentially.
+
+        Note: This method is only used when inherited_fds is None
+        (i.e., spawn mode), since fork mode requires sequential fd tracking.
+        """
+
+        async def _start_one(
+            local_rank: int, global_rank: int
+        ) -> "UnreadyWorkerProcHandle":
+            is_driver_worker = self._is_driver_worker(global_rank)
+            return await asyncio.to_thread(
+                WorkerProc.make_worker_process,
+                vllm_config=self.vllm_config,
+                local_rank=local_rank,
+                rank=global_rank,
+                distributed_init_method=distributed_init_method,
+                input_shm_handle=scheduler_output_handle,
+                shared_worker_lock=shared_worker_lock,
+                is_driver_worker=is_driver_worker,
+                inherited_fds=None,  # spawn mode only
+            )
+
+        tasks = [
+            _start_one(local_rank, global_start_rank + local_rank)
+            for local_rank in range(self.local_world_size)
+        ]
+        return list(await asyncio.gather(*tasks))
 
     def start_worker_monitor(self, inline=False) -> None:
         workers = self.workers


### PR DESCRIPTION
## Summary
Reduces subprocess startup latency in Data Parallel (DP) and Tensor Parallel (TP) deployments from O(N) sequential to O(1) parallel by starting all processes concurrently via `asyncio.gather` + `asyncio.to_thread`.

**Two independent optimizations:**

1. **EngineCore parallel startup** (`vllm/v1/engine/utils.py`) — DP dimension: all EngineCore processes on a node start concurrently instead of one-by-one. Triggered when `local_engine_count > 1`.
2. **Worker parallel startup** (`vllm/v1/executor/multiproc_executor.py`) — TP dimension: all Worker processes within each EngineCore start concurrently. Triggered when `local_world_size > 1`, spawn mode, and non-CPU platform.

**Also fixes a correctness bug:** replaces parent-side `patch.dict(os.environ)` with a child-side bootstrap shim (`_enginecore_bootstrap`) to eliminate the race condition when setting device visibility env vars under concurrent forks on non-CUDA platforms (Ascend NPU, ROCm) and Ray-launched deployments.

Related  #RFC:39678

## Changes
#### `vllm/v1/engine/utils.py`

| Change | Description |
|---|---|
| Add `_ASYNC_STARTUP_ENGINE_THRESHOLD = 1` | Threshold constant. Async startup is used when `local_engine_count > _ASYNC_STARTUP_ENGINE_THRESHOLD` (i.e., DP ≥ 2). |
| Add `_enginecore_bootstrap()` | Child-side bootstrap shim that sets the device visibility env var (e.g. `CUDA_VISIBLE_DEVICES`, `ASCEND_RT_VISIBLE_DEVICES`) inside the subprocess before invoking the real engine entry point. Eliminates the parent-side `patch.dict` race condition. Only used when `need_env_control` is True (non-CUDA platforms or Ray). |
| Refactor `CoreEngineProcManager.__init__` | (1) Extract `need_env_control` logic before process creation loop. (2) Use `_enginecore_bootstrap` as subprocess target when env control is needed, avoiding parent-side env patching entirely. (3) Dispatch to async or serial startup path based on `local_engine_count`. |
| Add `_run_async_startup()` | Event loop wrapper. Detects whether we are already inside a running event loop (e.g. `AsyncLLM`) and offloads to a background thread if so, avoiding nested `asyncio.run()`. |
| Add `_start_processes_async()` | Core async method. Starts all EngineCore processes concurrently via `asyncio.gather`. Each `proc.start()` is wrapped in a `_start_with_numa` closure (to keep the NUMA binding context manager on the same thread) and offloaded via `asyncio.to_thread`. |

#### `vllm/v1/executor/multiproc_executor.py`

| Change | Description |
|---|---|
| Refactor `_init_executor` | Add `is_fork` variable and `use_async_startup` branch: when spawn mode + non-CPU + `local_world_size > 1`, delegate to `_run_async_workers_startup()`. Serial path (fork mode, CPU, single worker) is preserved unchanged, including `inherited_fds` incremental tracking. |
| Add `_run_async_workers_startup()` | Event loop wrapper (same pattern as EngineCore side). |
| Add `_start_workers_async()` | Core async method. Starts all Worker processes concurrently via `asyncio.gather`. Each `WorkerProc.make_worker_process()` call is offloaded via `asyncio.to_thread` with `inherited_fds=None` (spawn mode does not need fd tracking). |

---