### PR TITLE
[Attention] Validate DIFFKV via backend selection

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -384,6 +384,29 @@ def test_attention_config():
     assert engine_args.attention_config.disable_flashinfer_prefill is False
     assert engine_args.attention_config.disable_flashinfer_q_quantization is False
 
+
+def test_attention_backend_diffkv_shorthand_flows_into_vllm_config():
+    from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+
+    args = parser.parse_args(
+        [
+            "--model",
+            "facebook/opt-125m",
+            "--attention-backend",
+            "FLASH_ATTN_DIFFKV",
+        ]
+    )
+    assert args is not None
+
+    engine_args = EngineArgs.from_cli_args(args)
+    vllm_config = engine_args.create_engine_config()
+    assert (
+        vllm_config.attention_config.backend
+        == AttentionBackendEnum.FLASH_ATTN_DIFFKV
+    )
+
     # test --attention-backend flows into VllmConfig.attention_config
     args = parser.parse_args(
         [

--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -326,6 +326,31 @@ def test_invalid_backend():
         AttentionConfig(backend=AttentionBackendEnum["INVALID"])
 
 
+def test_diffkv_backend_string_parses():
+    attention_config = AttentionConfig(backend="FLASH_ATTN_DIFFKV")
+    assert attention_config.backend == AttentionBackendEnum.FLASH_ATTN_DIFFKV
+
+
+def test_diffkv_backend_cannot_be_selected_globally():
+    if CudaPlatform is None:
+        pytest.skip("CudaPlatform not available")
+
+    attention_config = AttentionConfig(
+        backend=AttentionBackendEnum.FLASH_ATTN_DIFFKV
+    )
+    cache_config = CacheConfig(block_size=16)
+    vllm_config = VllmConfig(
+        attention_config=attention_config, cache_config=cache_config
+    )
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch("vllm.platforms.current_platform", CudaPlatform()),
+        pytest.raises(ValueError, match="cannot be selected as a global"),
+    ):
+        get_attn_backend(16, torch.float16, None)
+
+
 @pytest.mark.parametrize("auto_value", ["auto", "AUTO", "Auto"])
 def test_auto_backend_string(auto_value: str):
     """Test that 'auto' string value triggers automatic backend selection."""

--- a/vllm/v1/attention/backends/flash_attn_diffkv.py
+++ b/vllm/v1/attention/backends/flash_attn_diffkv.py
@@ -31,6 +31,24 @@ class FlashAttentionDiffKVBackend(FlashAttentionBackend):
     head_size_v: int = 128
 
     @classmethod
+    def supports_combination(
+        cls,
+        head_size: int,
+        dtype: torch.dtype,
+        kv_cache_dtype: str | None,
+        block_size: int | None,
+        use_mla: bool,
+        has_sink: bool,
+        use_sparse: bool,
+        device_capability,
+    ) -> str | None:
+        return (
+            "FLASH_ATTN_DIFFKV is only supported when selected explicitly by "
+            "model implementations; it cannot be selected as a global "
+            "attention backend."
+        )
+
+    @classmethod
     def set_head_size_v(cls, head_size_v: int) -> None:
         cls.head_size_v = head_size_v
 

--- a/vllm/v1/attention/backends/flash_attn_diffkv.py
+++ b/vllm/v1/attention/backends/flash_attn_diffkv.py
@@ -35,12 +35,12 @@ class FlashAttentionDiffKVBackend(FlashAttentionBackend):
         cls,
         head_size: int,
         dtype: torch.dtype,
-        kv_cache_dtype: str | None,
+        kv_cache_dtype: "CacheDType | None",
         block_size: int | None,
         use_mla: bool,
         has_sink: bool,
         use_sparse: bool,
-        device_capability,
+        device_capability: "DeviceCapability",
     ) -> str | None:
         return (
             "FLASH_ATTN_DIFFKV is only supported when selected explicitly by "


### PR DESCRIPTION

Fixes #39339.
## Purpose
Reject `attention_backend="FLASH_ATTN_DIFFKV"` through normal backend validation instead of letting initialization continue until it crashes.

## Test Plan
```bash
.venv-py312-tests/bin/python -m pytest -s -v tests/engine/test_arg_utils.py tests/kernels/attention/test_attention_selector.py
```
## Test Result

73 passed, 10 skipped

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>