### PR TITLE
feat: add logit_scale to PoolerConfig for affine score calibration

### DIFF
--- a/docs/models/pooling_models/classify.md
+++ b/docs/models/pooling_models/classify.md
@@ -267,9 +267,34 @@ You can modify the `problem_type` via problem_type in the Hugging Face config. T
 
 Implement alignment with transformers [ForSequenceClassificationLoss](https://github.com/huggingface/transformers/blob/57bb6db6ee4cfaccc45b8d474dfad5a17811ca60/src/transformers/loss/loss_utils.py#L92).
 
-### Logit bias
+### Affine Score Calibration
 
-You can modify the `logit_bias` (aka `sigmoid_normalize`) through the logit_bias parameter in `vllm.config.PoolerConfig`.
+Affine Score Calibration, also known as [Platt Scaling](https://en.wikipedia.org/wiki/Platt_scaling) (Platt, 1999), is the most widely used method for calibrating classifier outputs into well-calibrated probabilities.
+
+The calibration follows the transformation:
+
+`activation(logit_scale * (logit - logit_bias))`
+
+| Parameter | Default | Description |
+| --------- | ------- | ----------- |
+| `logit_bias` | `None` | Bias subtracted from logits before activation |
+| `logit_scale` | `None` | Scale factor applied to logits after bias subtraction |
+
+Note: `logit_bias` is **subtracted** from the logits (not added), consistent with the `sigmoid_normalize` convention where `sigmoid(x - bias)` centers the sigmoid around the bias value.
+
+The computation order is as follows:
+
+```python
+logits -= logit_bias    # subtract bias (center scores)
+logits *= logit_scale   # scale logits
+logits = activation(logits)  # e.g. sigmoid
+```
+
+Example configuration:
+
+```bash
+--pooler-config '{"use_activation": true, "logit_bias": 4.5, "logit_scale": 1.0}'
+```
 
 ## Removed Features
 

--- a/vllm/config/pooler.py
+++ b/vllm/config/pooler.py
@@ -83,6 +83,13 @@ class PoolerConfig:
     If provided, apply classification logit biases. Defaults to None.
     """
 
+    logit_scale: float | None = None
+    """
+    If provided, scale the classification logits by this factor before
+    activation. Combined with logit_bias, enables affine score calibration:
+    activation(logit_scale * (score - logit_bias)). Defaults to None.
+    """
+
     ## for reward models
     step_tag_id: int | None = None
     """

--- a/vllm/model_executor/layers/pooler/seqwise/heads.py
+++ b/vllm/model_executor/layers/pooler/seqwise/heads.py
@@ -104,6 +104,7 @@ class ClassifierPoolerHead(SequencePoolerHead):
         self,
         classifier: ClassifierFn | None = None,
         logit_bias: float | None = None,
+        logit_scale: float | None = None,
         head_dtype: torch.dtype | str | None = None,
         activation: ActivationFn | None = None,
     ) -> None:
@@ -111,6 +112,7 @@ class ClassifierPoolerHead(SequencePoolerHead):
 
         self.classifier = classifier
         self.logit_bias = logit_bias
+        self.logit_scale = logit_scale
         self.head_dtype = head_dtype
         self.activation = activation
 
@@ -140,6 +142,8 @@ class ClassifierPoolerHead(SequencePoolerHead):
         # logits shape: [batchsize, num_labels]
         if self.logit_bias is not None:
             logits -= self.logit_bias
+        if self.logit_scale is not None:
+            logits *= self.logit_scale
 
         if self.activation is not None:
             flags = [p.use_activation for p in pooling_params]

--- a/vllm/model_executor/layers/pooler/seqwise/poolers.py
+++ b/vllm/model_executor/layers/pooler/seqwise/poolers.py
@@ -119,6 +119,7 @@ def pooler_for_classify(
         head_dtype=model_config.head_dtype,
         classifier=classifier,
         logit_bias=model_config.pooler_config.logit_bias,
+        logit_scale=model_config.pooler_config.logit_scale,
         activation=resolve_classifier_act_fn(
             model_config, static_num_labels=True, act_fn=act_fn
         ),

--- a/vllm/model_executor/layers/pooler/tokwise/heads.py
+++ b/vllm/model_executor/layers/pooler/tokwise/heads.py
@@ -93,6 +93,7 @@ class TokenClassifierPoolerHead(TokenPoolerHead):
         self,
         classifier: ClassifierFn | None = None,
         logit_bias: float | None = None,
+        logit_scale: float | None = None,
         head_dtype: torch.dtype | str | None = None,
         activation: ActivationFn | None = None,
     ) -> None:
@@ -100,6 +101,7 @@ class TokenClassifierPoolerHead(TokenPoolerHead):
 
         self.classifier = classifier
         self.logit_bias = logit_bias
+        self.logit_scale = logit_scale
         self.head_dtype = head_dtype
         self.activation = activation
 
@@ -127,6 +129,8 @@ class TokenClassifierPoolerHead(TokenPoolerHead):
 
         if self.logit_bias is not None:
             logits -= self.logit_bias
+        if self.logit_scale is not None:
+            logits *= self.logit_scale
 
         if self.activation is not None and pooling_param.use_activation:
             logits = self.activation(logits)

--- a/vllm/model_executor/layers/pooler/tokwise/poolers.py
+++ b/vllm/model_executor/layers/pooler/tokwise/poolers.py
@@ -127,6 +127,7 @@ def pooler_for_token_classify(
         head_dtype=model_config.head_dtype,
         classifier=classifier,
         logit_bias=model_config.pooler_config.logit_bias,
+        logit_scale=model_config.pooler_config.logit_scale,
         activation=resolve_classifier_act_fn(
             model_config, static_num_labels=False, act_fn=act_fn
         ),


### PR DESCRIPTION
## Purpose

Add `logit_scale` to `PoolerConfig` alongside existing `logit_bias`, enabling affine score calibration ([Platt scaling](https://en.wikipedia.org/wiki/Platt_scaling)) in the pooler: `activation(scale * (logit - bias))`.

This allows reranker and classification models to produce calibrated probability scores via `--pooler-config` without custom model code or client-side postprocessing.

RFC: #39434

## Changes

- `vllm/config/pooler.py` — add `logit_scale: float | None = None` field
- `vllm/model_executor/layers/pooler/seqwise/heads.py` — apply scale in `ClassifierPoolerHead.forward()`
- `vllm/model_executor/layers/pooler/seqwise/poolers.py` — pass scale from config
- `vllm/model_executor/layers/pooler/tokwise/heads.py` — apply scale in `TokenClassifierPoolerHead.forward_chunk()`
- `vllm/model_executor/layers/pooler/tokwise/poolers.py` — pass scale from config

**5 files changed, 17 lines added. Zero behavior change for existing models (default is `None`).**

## How it works

```python
# In ClassifierPoolerHead.forward() / TokenClassifierPoolerHead.forward_chunk():
if self.logit_bias is not None:
    logits -= self.logit_bias      # existing
if self.logit_scale is not None:
    logits *= self.logit_scale     # new
if self.activation is not None:
    logits = self.activation(logits)  # existing
```

## Usage

```bash
# No calibration (current behavior, unchanged)
--pooler-config '{"use_activation": true}'

# Bias only (current behavior, unchanged)
--pooler-config '{"use_activation": true, "logit_bias": 0.3}'

# Full Platt scaling (new)
--pooler-config '{"use_activation": true, "logit_bias": 0.3, "logit_scale": 5.0}'

# Temperature scaling (new, special case)
--pooler-config '{"use_activation": true, "logit_scale": 2.0}'
```

## Use cases

1. **Cross-encoder rerankers** — Map raw logits to calibrated `[0,1]` probabilities without retraining
2. **Temperature scaling** — Calibrate overconfident classifiers (`logit_scale = 1/T`)
3. **Score normalization across model versions** — Normalize different model versions to a consistent score range
4. **Domain adaptation** — Calibrate a model for a new domain by fitting two parameters on a small validation set

## Test plan

- [x] Ruff format + check passes
- [x] mypy 3.10 passes
- [x] Tested with cross-encoder reranker model (score calibration produces correct calibrated scores)

```bash
# Test with any cross-encoder
python -m vllm.entrypoints.openai.api_server \
    --model cross-encoder/ms-marco-MiniLM-L-6-v2 \
    --runner pooling \
    --pooler-config '{"use_activation": true, "logit_bias": 0.0, "logit_scale": 1.0}'
```

**Not a duplicate:** No existing PR adds `logit_scale`. This completes the affine calibration pair started by the existing `logit_bias` field.

AI-assisted work: AI assistance was used for implementation. All code reviewed and tested by human submitter.

Cc: @noooop @DarkLight1337