### PR TITLE
[BugFix] Fix Gemma4 parser delimiter over-consumption bug

### DIFF
--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -676,3 +676,638 @@ class TestStreamingExtraction:
         }
 
         assert args_text.count("replace_all") == 1
+
+    def test_streaming_incomplete_string_then_next_key(self, parser, mock_request):
+        """Test incomplete string with delimiter + next key in same chunk."""
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            'oldText:<|"|>code with }] chars',  # No closing delimiter yet
+            '<|"|>,path:<|"|>file.txt<|"|>}',  # Delimiter + next key together
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        # Verify valid JSON
+        parsed_args = json.loads(args_text)
+
+        # Verify both keys exist as separate keys
+        assert "oldText" in parsed_args, "oldText key should exist"
+        assert "path" in parsed_args, "path key should exist as separate field"
+
+        # Verify no key bleeding into string values
+        assert ",path:" not in parsed_args["oldText"], (
+            f"'path' key incorrectly merged into oldText. Full args: {args_text!r}"
+        )
+        assert "<|" not in parsed_args["oldText"], (
+            f"Delimiter fragment in oldText. Full args: {args_text!r}"
+        )
+
+        # Verify expected values
+        assert parsed_args["oldText"] == "code with }] chars"
+        assert parsed_args["path"] == "file.txt"
+
+    def test_streaming_complete_string_comma_in_next_chunk(self, parser, mock_request):
+        """Test complete string value when comma separator arrives in separate chunk."""
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            'oldText:<|"|>function() { return []; }<|"|>',  # Complete string
+            ',path:<|"|>code.js<|"|>}',  # Comma + next key in separate chunk
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        # Verify valid JSON
+        parsed_args = json.loads(args_text)
+
+        # Verify both keys exist
+        assert "oldText" in parsed_args
+        assert "path" in parsed_args
+
+        # Verify no key bleeding
+        assert ",path:" not in parsed_args["oldText"], (
+            f"'path' key incorrectly merged into oldText. Full args: {args_text!r}"
+        )
+
+        # Verify expected values
+        assert parsed_args["oldText"] == "function() { return []; }"
+        assert parsed_args["path"] == "code.js"
+
+    def test_streaming_multiple_incomplete_strings(self, parser, mock_request):
+        """Test multiple string values incomplete at different chunk boundaries."""
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            'oldText:<|"|>some long text value',  # Incomplete string
+            '<|"|>,newText:<|"|>replacement',  # First closes, second incomplete
+            '<|"|>,path:<|"|>src/app.py<|"|>}',  # Second closes, third complete
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        # Verify valid JSON
+        parsed_args = json.loads(args_text)
+
+        # Verify all three keys exist
+        assert "oldText" in parsed_args
+        assert "newText" in parsed_args
+        assert "path" in parsed_args
+
+        # Verify no key bleeding
+        assert ",newText:" not in parsed_args["oldText"], (
+            f"'newText' key incorrectly merged into oldText. Full args: {args_text!r}"
+        )
+        assert ",path:" not in parsed_args["newText"], (
+            f"'path' key incorrectly merged into newText. Full args: {args_text!r}"
+        )
+
+        # Verify expected values
+        assert parsed_args["oldText"] == "some long text value"
+        assert parsed_args["newText"] == "replacement"
+        assert parsed_args["path"] == "src/app.py"
+
+    def test_streaming_string_ending_with_withholding_chars(self, parser, mock_request):
+        """Test incomplete string ending with structural characters like }."""
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            'oldText:<|"|>function() { return []; }',  # Incomplete, ends with }
+            '<|"|>,path:<|"|>code.js<|"|>}',  # Closes oldText, adds path
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        # Verify valid JSON
+        parsed_args = json.loads(args_text)
+
+        # Verify both keys exist
+        assert "oldText" in parsed_args
+        assert "path" in parsed_args
+
+        # Verify no key bleeding
+        assert ",path:" not in parsed_args["oldText"], (
+            f"'path' key incorrectly merged into oldText. Full args: {args_text!r}"
+        )
+
+        # Verify expected values
+        assert parsed_args["oldText"] == "function() { return []; }"
+        assert parsed_args["path"] == "code.js"
+
+    def test_streaming_realistic_code_with_multiple_keys(self, parser, mock_request):
+        """Test code containing }] with multiple incomplete strings."""
+        chunks = [
+            "<|tool_call>",
+            "call:ReplaceText{",
+            # oldText incomplete - Go code ending with }
+            'oldText:<|"|>// qgaSplit function\n'
+            "func qgaSplit(data []byte) {\n"
+            "  return 0, nil, nil\n"
+            "}",
+            # oldText closes, newText incomplete
+            '<|"|>,newText:<|"|>// QGAReader implementation\ntype QGAReader struct {}',
+            # newText closes, path complete
+            '<|"|>,path:<|"|>qga.go<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        # Verify valid JSON
+        parsed_args = json.loads(args_text)
+
+        # Verify all three keys exist
+        assert "oldText" in parsed_args
+        assert "newText" in parsed_args
+        assert "path" in parsed_args
+
+        # Verify no key bleeding
+        assert ",newText:" not in parsed_args["oldText"], (
+            f"'newText' key incorrectly merged into oldText. Full args: {args_text!r}"
+        )
+        assert ",path:" not in parsed_args["oldText"], (
+            f"'path' key incorrectly merged into oldText. Full args: {args_text!r}"
+        )
+        assert ",path:" not in parsed_args["newText"], (
+            f"'path' key incorrectly merged into newText. Full args: {args_text!r}"
+        )
+
+        # Verify oldText contains expected Go code
+        assert "func qgaSplit" in parsed_args["oldText"]
+        assert parsed_args["oldText"].endswith("}")
+
+        # Verify newText contains expected Go code
+        assert "QGAReader" in parsed_args["newText"]
+        assert "struct" in parsed_args["newText"]
+
+        # Verify path is correct
+        assert parsed_args["path"] == "qga.go"
+
+    def test_streaming_string_value_ending_with_closing_brace(
+        self, parser, mock_request
+    ):
+        """Test string value ending with } is preserved (e.g., 'return {}')."""
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            # Value ends with }, complete in this chunk
+            'oldText:<|"|>return {}<|"|>',
+            # Next key arrives in separate chunk
+            ',path:<|"|>test.js<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        # Verify valid JSON
+        parsed_args = json.loads(args_text)
+
+        # Verify closing brace is preserved in string value
+        assert parsed_args["oldText"] == "return {}", (
+            f"Closing brace incorrectly stripped from string value. "
+            f"Expected 'return {{}}', got {parsed_args['oldText']!r}. "
+            f"Full args: {args_text!r}"
+        )
+
+        # Verify path exists as separate key
+        assert "path" in parsed_args
+        assert parsed_args["path"] == "test.js"
+
+    def test_streaming_string_value_ending_with_closing_bracket(
+        self, parser, mock_request
+    ):
+        """Test string value ending with ] is preserved (e.g., 'data = []')."""
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            'oldText:<|"|>data = []<|"|>',  # Complete string ending with ]
+            ',path:<|"|>test.py<|"|>}',  # Next key in separate chunk
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        # Verify valid JSON
+        parsed_args = json.loads(args_text)
+
+        # Verify closing bracket is preserved in string value
+        assert parsed_args["oldText"] == "data = []", (
+            f"Closing bracket incorrectly stripped from string value. "
+            f"Expected 'data = []', got {parsed_args['oldText']!r}. "
+            f"Full args: {args_text!r}"
+        )
+
+        assert "path" in parsed_args
+        assert parsed_args["path"] == "test.py"
+
+    def test_streaming_string_ending_with_multiple_structural_chars(
+        self, parser, mock_request
+    ):
+        """Test string ending with multiple structural characters like }]."""
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            # Value ends with }] - both in withholding list
+            'oldText:<|"|>func() { return [1, 2, 3]; }<|"|>',
+            ',path:<|"|>code.go<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        # Verify valid JSON
+        parsed_args = json.loads(args_text)
+
+        # Verify structural characters preserved in string value
+        expected = "func() { return [1, 2, 3]; }"
+        assert parsed_args["oldText"] == expected, (
+            f"Structural characters incorrectly stripped from string value. "
+            f"Expected {expected!r}, got {parsed_args['oldText']!r}. "
+            f"Full args: {args_text!r}"
+        )
+
+        assert "path" in parsed_args
+        assert parsed_args["path"] == "code.go"
+
+    def test_streaming_value_with_comma_then_key_no_space(self, parser, mock_request):
+        """Test string value ending with comma followed immediately by next key."""
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            'oldText:<|"|>item1,item2,item3',  # Incomplete, ends with comma
+            '<|"|>,path:<|"|>file.txt<|"|>}',  # Closes, then new key starts with comma
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        parsed_args = json.loads(args_text)
+
+        # The comma in "item3," is PART of oldText, but ",path:" is a new key
+        assert parsed_args["oldText"] == "item1,item2,item3"
+        assert ",path:" not in parsed_args["oldText"]
+        assert "path" in parsed_args
+        assert parsed_args["path"] == "file.txt"
+
+    def test_streaming_chunk_ends_mid_key_name(self, parser, mock_request):
+        """Test chunk boundary splitting a key name."""
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            'oldText:<|"|>code<|"|>,pa',  # Chunk ends mid-key "pa"
+            'th:<|"|>file.txt<|"|>}',  # Key name completes
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        parsed_args = json.loads(args_text)
+
+        assert parsed_args["oldText"] == "code"
+        assert ",pa" not in parsed_args["oldText"]
+        assert "path" in parsed_args
+        assert parsed_args["path"] == "file.txt"
+
+    def test_streaming_value_contains_key_like_pattern(self, parser, mock_request):
+        """Test string value containing text that looks like a key (e.g., ',path:')."""
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            # String value itself contains ",path:" pattern
+            'oldText:<|"|>Set ,path: option in config',
+            '<|"|>,actualPath:<|"|>config.yaml<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        parsed_args = json.loads(args_text)
+
+        # The ",path:" inside the string value should be preserved
+        assert parsed_args["oldText"] == "Set ,path: option in config"
+        assert "actualPath" in parsed_args
+        assert parsed_args["actualPath"] == "config.yaml"
+
+    def test_streaming_very_long_value_with_structural_chars(
+        self, parser, mock_request
+    ):
+        """Test very long string value with many structural characters."""
+        # Create a long code snippet with many }, ], etc.
+        code = """function test() {
+    const data = [1, 2, 3];
+    const obj = {key: "value"};
+    return {data, obj};
+}"""
+
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            f'oldText:<|"|>{code}',  # Long string, incomplete
+            '<|"|>,path:<|"|>test.js<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        parsed_args = json.loads(args_text)
+
+        assert parsed_args["oldText"] == code
+        assert ",path:" not in parsed_args["oldText"]
+        assert "path" in parsed_args
+        assert parsed_args["path"] == "test.js"
+
+    def test_streaming_empty_string_then_next_key(self, parser, mock_request):
+        """Test empty string value followed by another key."""
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            'oldText:<|"|><|"|>,',  # Empty string + comma
+            'path:<|"|>file.txt<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        parsed_args = json.loads(args_text)
+
+        assert parsed_args["oldText"] == ""
+        assert "path" in parsed_args
+        assert parsed_args["path"] == "file.txt"
+
+    def test_streaming_number_value_then_string_key(self, parser, mock_request):
+        """Test numeric value followed by string key."""
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            'lineNumber:42,oldText:<|"|>code',  # Number then string
+            '<|"|>,path:<|"|>file.txt<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        parsed_args = json.loads(args_text)
+
+        assert parsed_args["lineNumber"] == 42
+        assert parsed_args["oldText"] == "code"
+        assert "path" in parsed_args
+        assert parsed_args["path"] == "file.txt"
+
+    def test_streaming_string_value_ending_with_exact_bug_pattern(
+        self, parser, mock_request
+    ):
+        """Test string value ending with pattern that looks like next key.
+
+        Adversarial: The string value literally ends with text that looks
+        exactly like '},path:"' which might confuse the parser.
+        """
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            # String value ends with literal text "},path:"
+            'oldText:<|"|>The config uses },path:',
+            '<|"|>,actualPath:<|"|>test.js<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        parsed_args = json.loads(args_text)
+
+        # The literal "},path:" should be in the string value
+        assert parsed_args["oldText"] == "The config uses },path:"
+        assert "actualPath" in parsed_args
+        assert parsed_args["actualPath"] == "test.js"
+
+    def test_streaming_withholding_with_identical_suffix_pattern(
+        self, parser, mock_request
+    ):
+        """Test when withheld suffix characters match start of next chunk."""
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            'oldText:<|"|>code }]',  # Ends with }] (will be withheld)
+            '<|"|>,}],path:<|"|>file.txt<|"|>}',  # Next chunk also starts with }]
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        parsed_args = json.loads(args_text)
+
+        # Should NOT duplicate the }]
+        assert parsed_args["oldText"] == "code }]"
+        assert "}],path" in parsed_args  # This is a separate key
+        assert parsed_args["}],path"] == "file.txt"
+
+    def test_streaming_json_chars_at_every_boundary(self, parser, mock_request):
+        """Test JSON structural characters at every possible chunk boundary."""
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            'a:<|"|>}',  # Value is just '}'
+            '<|"|>,b:<|"|>]',  # Value is just ']'
+            '<|"|>,c:<|"|>",',  # Value is just '",'
+            '<|"|>,d:<|"|>ok<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        parsed_args = json.loads(args_text)
+
+        assert parsed_args["a"] == "}"
+        assert parsed_args["b"] == "]"
+        assert parsed_args["c"] == '",'
+        assert parsed_args["d"] == "ok"
+
+    def test_streaming_missing_string_delimiter_causes_overconsumption(
+        self, parser, mock_request
+    ):
+        """Test parser handles malformed input missing closing delimiter."""
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            # MALFORMED: Missing closing delimiter after "code with }]"
+            'oldText:<|"|>code with }],path:<|"|>file.txt<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        parsed_args = json.loads(args_text)
+
+        # Verify parser correctly handles malformed input
+        assert "oldText" in parsed_args, "oldText key should exist"
+
+        # Verify no overconsumption
+        assert ",path:" not in parsed_args["oldText"], (
+            f"Parser incorrectly consumed ',path:' into oldText. "
+            f"Got: {parsed_args['oldText']!r}, full JSON: {args_text!r}"
+        )
+
+        # Verify correct parsing despite missing delimiter
+        assert parsed_args["oldText"] == "code with }]"
+        assert "path" in parsed_args
+        assert parsed_args["path"] == "file.txt"
+
+    def test_streaming_value_with_comma_no_colon(self, parser, mock_request):
+        """Test well-formed string value containing comma without colon."""
+        chunks = [
+            "<|tool_call>",
+            "call:GetData{",
+            'location:<|"|>Paris, France<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+        parsed_args = json.loads(args_text)
+
+        assert parsed_args["location"] == "Paris, France", (
+            "Should preserve comma in well-formed value"
+        )
+
+    def test_streaming_value_ending_with_comma_colon(self, parser, mock_request):
+        """Test well-formed value ending with ',identifier:' pattern is preserved."""
+        chunks = [
+            "<|tool_call>",
+            "call:ProcessData{",
+            'pattern:<|"|>foo,bar:<|"|>,next:<|"|>value<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+        parsed_args = json.loads(args_text)
+
+        assert parsed_args["pattern"] == "foo,bar:", (
+            "Should preserve ',bar:' pattern in well-formed value"
+        )
+        assert parsed_args["next"] == "value", (
+            "Should correctly parse next key after value with ',identifier:' pattern"
+        )
+
+    def test_streaming_malformed_with_comma_colon_pattern(self, parser, mock_request):
+        """Test malformed input with ',identifier:' pattern and missing delimiter."""
+        chunks = [
+            "<|tool_call>",
+            "call:Replace{",
+            'old:<|"|>foo,bar:<|"|>replacement<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+        parsed_args = json.loads(args_text)
+
+        assert parsed_args["old"] == "foo", (
+            "Should stop at comma when delimiter not followed by structural char"
+        )
+        assert parsed_args["bar"] == "replacement", (
+            "Should correctly parse 'bar' as the next key"
+        )
+
+    def test_streaming_search_replace_realistic(self, parser, mock_request):
+        """Test realistic search/replace args with commas and colons."""
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            'oldText:<|"|>const config = {a: 1, b: 2}<|"|>,',
+            'newText:<|"|>const config = {a: 1, b: 2, c: 3}<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+        parsed_args = json.loads(args_text)
+
+        assert parsed_args["oldText"] == "const config = {a: 1, b: 2}", (
+            "Should preserve code with commas and colons in well-formed value"
+        )
+        assert parsed_args["newText"] == "const config = {a: 1, b: 2, c: 3}", (
+            "Should correctly parse second argument"
+        )
+
+    def test_streaming_extra_delimiter_in_value(self, parser, mock_request):
+        """Test string value containing unescaped delimiter."""
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            # String contains literal <|"|> that should be escaped but isn't
+            'oldText:<|"|>use <|"|> as delimiter<|"|>,path:<|"|>file.txt<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        parsed_args = json.loads(args_text)
+
+        # Verify unescaped delimiter doesn't cause key bleeding
+        if "oldText" in parsed_args and ",path:" in parsed_args["oldText"]:
+            pytest.fail(
+                f"Unescaped delimiter caused ',path:' to bleed into oldText. "
+                f"oldText value: {parsed_args['oldText']!r}"
+            )
+
+    def test_streaming_partial_mode_string_never_closes(self, parser, mock_request):
+        """Test incomplete string that grows across many chunks without closing."""
+        chunks = [
+            "<|tool_call>",
+            "call:Edit{",
+            'oldText:<|"|>line1',  # Incomplete
+            " line2",  # Still incomplete
+            " line3",  # Still incomplete
+            ",path",  # STILL incomplete - "," is part of the string!
+            ':<|"|>',  # Wait, now we have :<|"|> but no closing for oldText
+            'file.txt<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        try:
+            parsed_args = json.loads(args_text)
+
+            # The ,path: sequence appeared while oldText was incomplete
+            # Did the parser incorrectly treat it as a new key?
+            if "oldText" in parsed_args:
+                # oldText should be "line1 line2 line3,path"
+                # But if the parser got confused, it might be "line1 line2 line3"
+                expected_value = "line1 line2 line3,path"
+                if (
+                    parsed_args["oldText"] != expected_value
+                    and ",path" not in parsed_args["oldText"]
+                ):
+                    pytest.fail(
+                        f"Parser lost ',path' from oldText value. "
+                        f"Expected: {expected_value!r}, "
+                        f"Got: {parsed_args['oldText']!r}"
+                    )
+
+        except json.JSONDecodeError as e:
+            pytest.fail(f"JSON parse failed: {e}. Raw output: {args_text!r}")

--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -127,6 +127,21 @@ class TestParseGemma4Args:
         result = _parse_gemma4_args('name:<|"|>test<|"|>,flag:', partial=True)
         assert result == {"name": "test"}
 
+    def test_delimiter_with_trailing_whitespace(self):
+        """Test delimiter followed by whitespace before structural character."""
+        result = _parse_gemma4_args('key:<|"|>value<|"|> ,next:<|"|>data<|"|>')
+        assert result == {"key": "value", "next": "data"}
+
+    def test_hyphenated_argument_key(self):
+        """Test argument keys with hyphens (e.g., file-name)."""
+        result = _parse_gemma4_args('file-name:<|"|>test.txt<|"|>,user-id:123')
+        assert result == {"file-name": "test.txt", "user-id": 123}
+
+    def test_dotted_argument_key(self):
+        """Test argument keys with dots (e.g., module.path)."""
+        result = _parse_gemma4_args('config.path:<|"|>/etc/config<|"|>,api.version:2')
+        assert result == {"config.path": "/etc/config", "api.version": 2}
+
 
 class TestParseGemma4Array:
     def test_string_array(self):
@@ -140,6 +155,33 @@ class TestParseGemma4Array:
     def test_bare_values(self):
         result = _parse_gemma4_array("42,true,3.14")
         assert result == [42, True, 3.14]
+
+    def test_array_string_elements(self):
+        """Test array parsing with string elements."""
+        result = _parse_gemma4_array('<|"|>first<|"|>,<|"|>second<|"|>')
+        assert result == ["first", "second"]
+
+        result = _parse_gemma4_array('<|"|>first<|"|>,<|"|>second')
+        assert result == ["first", "second"]
+
+    def test_array_nested_object_with_malformed_string(self):
+        """Test nested object in array with malformed string delimiter."""
+        result = _parse_gemma4_array('{a:<|"|>value,b:<|"|>other<|"|>}')
+        assert len(result) == 1
+        assert isinstance(result[0], dict)
+        assert result[0]["a"] == "value"
+        assert result[0]["b"] == "other"
+
+    def test_array_nested_array_with_string(self):
+        """Test nested array with string elements."""
+        result = _parse_gemma4_array('[<|"|>inner1<|"|>,<|"|>inner2<|"|>]')
+        assert len(result) == 1
+        assert result[0] == ["inner1", "inner2"]
+
+    def test_array_string_with_structural_chars(self):
+        """Test array string containing structural characters."""
+        result = _parse_gemma4_array('<|"|>text[with]brackets<|"|>,<|"|>more<|"|>')
+        assert result == ["text[with]brackets", "more"]
 
 
 # ---------------------------------------------------------------------------

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -47,6 +47,13 @@ logger = init_logger(__name__)
 TOOL_CALL_START = "<|tool_call>"
 TOOL_CALL_END = "<tool_call|>"
 STRING_DELIM = '<|"|>'
+STRING_DELIM_LEN = len(STRING_DELIM)
+
+# Structural characters that follow closing string delimiters in well-formed input
+STRUCTURAL_CHARS = (",", "}", "]")
+
+# Pre-compiled regex for malformed input detection
+TOOL_CALL_KEY_PATTERN = re.compile(r",\s*([a-zA-Z_]\w*):\s*$")
 
 
 # ---------------------------------------------------------------------------
@@ -76,6 +83,75 @@ def _parse_gemma4_value(value_str: str) -> object:
 
     # Bare string (no <|"|> delimiters — shouldn't happen but be safe)
     return value_str
+
+
+def _find_string_value_end(args_str: str, value_start: int) -> tuple[int, bool]:
+    """Find the end position of a string value, handling missing delimiters.
+
+    Uses a two-stage check to distinguish between:
+    1. Closing delimiter (well-formed): followed by `,`, `}`, or `]`
+    2. Opening delimiter (malformed): delimiter belongs to next key
+
+    Args:
+        args_str: The full argument string being parsed
+        value_start: Position where the string value starts (after opening delimiter)
+
+    Returns:
+        Tuple of (end_position, is_closing_delimiter) where:
+        - end_position: Position where the string value ends
+        - is_closing_delimiter: True if end_position points to a valid closing
+          delimiter, False if it points to a comma (malformed input), or -1 if
+          no delimiter found (unterminated string)
+
+    Examples:
+        Well-formed:
+        >>> _find_string_value_end('text<|"|>,next:', 0)
+        (4, True)  # Delimiter at position 4, followed by ',' -> closing delimiter
+
+        Well-formed with comma-colon pattern in value:
+        >>> _find_string_value_end('foo,bar:<|"|>,x:', 0)
+        (8, True)  # Delimiter at position 8, followed by ',' -> closing delimiter
+
+        Malformed (missing closing delimiter):
+        >>> _find_string_value_end('foo,bar:<|"|>value', 0)
+        (3, False)  # Stops at comma position 3 (malformed - missing closing delim)
+    """
+    # Find next delimiter
+    next_delim = args_str.find(STRING_DELIM, value_start)
+
+    if next_delim == -1:
+        # No delimiter found - unterminated string
+        return (-1, False)
+
+    # Stage 1: Check if delimiter is followed by structural character
+    # In valid Gemma4, closing delimiters are ALWAYS followed by ',', '}', or ']'
+    after_delim_pos = next_delim + STRING_DELIM_LEN
+    if after_delim_pos < len(args_str):
+        char_after = args_str[after_delim_pos]
+        if char_after in STRUCTURAL_CHARS:
+            # This is a valid closing delimiter
+            return (next_delim, True)
+    else:
+        # Delimiter is at end of string - likely a closing delimiter
+        return (next_delim, True)
+
+    # Stage 2: Delimiter not followed by structural character - might be malformed
+    # Check if substring before delimiter contains ',identifier:' pattern
+    # Use in-place search to avoid creating temporary substring
+    last_comma = args_str.rfind(",", value_start, next_delim)
+
+    if last_comma != -1:
+        # Check if pattern ',identifier:' appears after the comma
+        after_comma = args_str[last_comma:next_delim]
+        match = TOOL_CALL_KEY_PATTERN.match(after_comma)
+
+        if match:
+            # Found ',key:' pattern - this delimiter likely opens next key's value
+            # Stop at the comma to avoid over-consumption
+            return (last_comma, False)
+
+    # No evidence of malformed input - use the delimiter
+    return (next_delim, True)
 
 
 def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
@@ -136,15 +212,20 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
 
         # String value: <|"|>...<|"|>
         if args_str[i:].startswith(STRING_DELIM):
-            i += len(STRING_DELIM)
+            i += STRING_DELIM_LEN
             val_start = i
-            end_pos = args_str.find(STRING_DELIM, i)
+
+            end_pos, is_closing_delim = _find_string_value_end(args_str, val_start)
+
             if end_pos == -1:
                 # Unterminated string — take rest
                 result[key] = args_str[val_start:]
                 break
+
             result[key] = args_str[val_start:end_pos]
-            i = end_pos + len(STRING_DELIM)
+
+            # Advance position based on what we found
+            i = end_pos + STRING_DELIM_LEN if is_closing_delim else end_pos
 
         # Nested object: {...}
         elif args_str[i] == "{":
@@ -154,9 +235,15 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
             while i < n and depth > 0:
                 if args_str[i:].startswith(STRING_DELIM):
                     # Skip over string contents to avoid counting { inside strings
-                    i += len(STRING_DELIM)
-                    next_delim = args_str.find(STRING_DELIM, i)
-                    i = n if next_delim == -1 else next_delim + len(STRING_DELIM)
+                    i += STRING_DELIM_LEN
+                    end_pos, is_closing_delim = _find_string_value_end(args_str, i)
+                    if end_pos == -1:
+                        i = n
+                    elif is_closing_delim:
+                        i = end_pos + STRING_DELIM_LEN
+                    else:
+                        # Stopped at comma (malformed) - advance with bounds check
+                        i = min(end_pos + 1, n)
                     continue
                 if args_str[i] == "{":
                     depth += 1
@@ -177,9 +264,15 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
             i += 1
             while i < n and depth > 0:
                 if args_str[i:].startswith(STRING_DELIM):
-                    i += len(STRING_DELIM)
-                    next_delim = args_str.find(STRING_DELIM, i)
-                    i = n if next_delim == -1 else next_delim + len(STRING_DELIM)
+                    i += STRING_DELIM_LEN
+                    end_pos, is_closing_delim = _find_string_value_end(args_str, i)
+                    if end_pos == -1:
+                        i = n
+                    elif is_closing_delim:
+                        i = end_pos + STRING_DELIM_LEN
+                    else:
+                        # Stopped at comma (malformed) - advance with bounds check
+                        i = min(end_pos + 1, n)
                     continue
                 if args_str[i] == "[":
                     depth += 1

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -39,7 +39,7 @@ from vllm.entrypoints.openai.responses.protocol import (
 from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import Tool, ToolParser
-from vllm.tool_parsers.utils import find_common_prefix
+from vllm.tool_parsers.utils import consume_space, find_common_prefix
 
 logger = init_logger(__name__)
 
@@ -53,7 +53,8 @@ STRING_DELIM_LEN = len(STRING_DELIM)
 STRUCTURAL_CHARS = (",", "}", "]")
 
 # Pre-compiled regex for malformed input detection
-TOOL_CALL_KEY_PATTERN = re.compile(r",\s*([a-zA-Z_]\w*):\s*$")
+# Supports standard identifiers, hyphens, and dots (e.g., "file-name", "module.path")
+TOOL_CALL_KEY_PATTERN = re.compile(r",\s*([a-zA-Z_][\w.\-]*):\s*$")
 
 
 # ---------------------------------------------------------------------------
@@ -85,6 +86,18 @@ def _parse_gemma4_value(value_str: str) -> object:
     return value_str
 
 
+def _skip_string_in_nested_structure(text: str, i: int, n: int) -> int:
+    """Skip over a string delimiter and its contents in nested structures."""
+    i += STRING_DELIM_LEN
+    end_pos, is_closing_delim = _find_string_value_end(text, i)
+    if end_pos == -1:
+        return n
+    elif is_closing_delim:
+        return end_pos + STRING_DELIM_LEN
+    else:
+        return min(end_pos + 1, n)
+
+
 def _find_string_value_end(args_str: str, value_start: int) -> tuple[int, bool]:
     """Find the end position of a string value, handling missing delimiters.
 
@@ -98,10 +111,11 @@ def _find_string_value_end(args_str: str, value_start: int) -> tuple[int, bool]:
 
     Returns:
         Tuple of (end_position, is_closing_delimiter) where:
-        - end_position: Position where the string value ends
+        - end_position: Position where the string value ends (or -1 if
+          no delimiter found for unterminated strings)
         - is_closing_delimiter: True if end_position points to a valid closing
-          delimiter, False if it points to a comma (malformed input), or -1 if
-          no delimiter found (unterminated string)
+          delimiter, False if it points to a comma (malformed input) or if
+          no delimiter found (end_position will be -1 for unterminated strings)
 
     Examples:
         Well-formed:
@@ -123,12 +137,13 @@ def _find_string_value_end(args_str: str, value_start: int) -> tuple[int, bool]:
         # No delimiter found - unterminated string
         return (-1, False)
 
-    # Stage 1: Check if delimiter is followed by structural character
-    # In valid Gemma4, closing delimiters are ALWAYS followed by ',', '}', or ']'
+    # Check if delimiter is followed by structural character (with optional whitespace)
     after_delim_pos = next_delim + STRING_DELIM_LEN
+    if after_delim_pos < len(args_str) and args_str[after_delim_pos].isspace():
+        after_delim_pos = consume_space(after_delim_pos, args_str)
+
     if after_delim_pos < len(args_str):
-        char_after = args_str[after_delim_pos]
-        if char_after in STRUCTURAL_CHARS:
+        if args_str[after_delim_pos] in STRUCTURAL_CHARS:
             # This is a valid closing delimiter
             return (next_delim, True)
     else:
@@ -234,16 +249,7 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
             i += 1
             while i < n and depth > 0:
                 if args_str[i:].startswith(STRING_DELIM):
-                    # Skip over string contents to avoid counting { inside strings
-                    i += STRING_DELIM_LEN
-                    end_pos, is_closing_delim = _find_string_value_end(args_str, i)
-                    if end_pos == -1:
-                        i = n
-                    elif is_closing_delim:
-                        i = end_pos + STRING_DELIM_LEN
-                    else:
-                        # Stopped at comma (malformed) - advance with bounds check
-                        i = min(end_pos + 1, n)
+                    i = _skip_string_in_nested_structure(args_str, i, n)
                     continue
                 if args_str[i] == "{":
                     depth += 1
@@ -264,15 +270,7 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
             i += 1
             while i < n and depth > 0:
                 if args_str[i:].startswith(STRING_DELIM):
-                    i += STRING_DELIM_LEN
-                    end_pos, is_closing_delim = _find_string_value_end(args_str, i)
-                    if end_pos == -1:
-                        i = n
-                    elif is_closing_delim:
-                        i = end_pos + STRING_DELIM_LEN
-                    else:
-                        # Stopped at comma (malformed) - advance with bounds check
-                        i = min(end_pos + 1, n)
+                    i = _skip_string_in_nested_structure(args_str, i, n)
                     continue
                 if args_str[i] == "[":
                     depth += 1
@@ -312,13 +310,20 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
 
         # String element
         if arr_str[i:].startswith(STRING_DELIM):
-            i += len(STRING_DELIM)
-            end_pos = arr_str.find(STRING_DELIM, i)
+            i += STRING_DELIM_LEN
+            val_start = i
+
+            end_pos, is_closing_delim = _find_string_value_end(arr_str, val_start)
+
             if end_pos == -1:
-                items.append(arr_str[i:])
+                # Unterminated string — take rest
+                items.append(arr_str[val_start:])
                 break
-            items.append(arr_str[i:end_pos])
-            i = end_pos + len(STRING_DELIM)
+
+            items.append(arr_str[val_start:end_pos])
+
+            # Advance position based on what we found
+            i = end_pos + STRING_DELIM_LEN if is_closing_delim else end_pos
 
         # Nested object
         elif arr_str[i] == "{":
@@ -327,9 +332,7 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
             i += 1
             while i < n and depth > 0:
                 if arr_str[i:].startswith(STRING_DELIM):
-                    i += len(STRING_DELIM)
-                    nd = arr_str.find(STRING_DELIM, i)
-                    i = nd + len(STRING_DELIM) if nd != -1 else n
+                    i = _skip_string_in_nested_structure(arr_str, i, n)
                     continue
                 if arr_str[i] == "{":
                     depth += 1
@@ -347,6 +350,9 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
             sub_start = i + 1
             i += 1
             while i < n and depth > 0:
+                if arr_str[i:].startswith(STRING_DELIM):
+                    i = _skip_string_in_nested_structure(arr_str, i, n)
+                    continue
                 if arr_str[i] == "[":
                     depth += 1
                 elif arr_str[i] == "]":

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -112,10 +112,10 @@ def _find_string_value_end(args_str: str, value_start: int) -> tuple[int, bool]:
     Returns:
         Tuple of (end_position, is_closing_delimiter) where:
         - end_position: Position where the string value ends (or -1 if
-          no delimiter found for unterminated strings)
+        no delimiter found for unterminated strings)
         - is_closing_delimiter: True if end_position points to a valid closing
-          delimiter, False if it points to a comma (malformed input) or if
-          no delimiter found (end_position will be -1 for unterminated strings)
+        delimiter, False if it points to a comma (malformed input) or if
+        no delimiter found (end_position will be -1 for unterminated strings)
 
     Examples:
         Well-formed:


### PR DESCRIPTION
## Purpose

When the model generates malformed Gemma4 format missing a closing string delimiter, the parser would incorrectly consume the opening delimiter of the next key, causing argument values to bleed into subsequent key names.

Example:
  Input:  oldText:<|"|>code with }],path:<|"|>file.txt<|"|>
                                  ^ missing closing delimiter
  Before: {"oldText": "code with }],path:"}  # Wrong - consumed next key
  After:  {"oldText": "code with }]", "path": "file.txt"}  # Correct

**Root Cause:**
The parser used naive string.find() to locate the next delimiter, assuming any delimiter found was a valid closing delimiter. This failed when:
1. The model omitted a closing delimiter (malformed output)
2. The next key's opening delimiter appeared before any other delimiter
3. Result: parser consumed everything between delimiters, including the next key name

**Fix:**
Implemented two-stage delimiter disambiguation in _find_string_value_end():

Stage 1: Check if delimiter is followed by structural characters
  - In valid Gemma4, closing delimiters are ALWAYS followed by ',', '}', ']'
  - If yes → valid closing delimiter, use it
  - If no → proceed to Stage 2

Stage 2: Check for malformed input pattern
  - Look for ',identifier:' pattern before the delimiter
  - If found → delimiter belongs to next key, stop at comma
  - Otherwise → use the delimiter

This prevents false positives for legitimate values like "foo,bar:" while correctly detecting and recovering from malformed input.

**Changes:**
- Added _find_string_value_end() helper with pattern-based detection
- Pre-compiled TOOL_CALL_KEY_PATTERN regex for performance
- Updated all string parsing paths (values, nested objects, arrays)

**Regression Prevention:**
Added test cases covering:
- Incomplete strings with delimiters + next key in same chunk
- Complete strings with comma separator in next chunk
- Multiple incomplete strings at different boundaries
- Strings ending with structural characters (}, ], }])
- Realistic code snippets with complex nesting
- Adversarial cases (values containing key-like patterns)
- Malformed input with missing delimiters
- Edge cases (empty strings, numeric values, long values)

## Test Plan

```
pytest tests/tool_parsers/test_gemma4_tool_parser.py
```

## Test Result

```
76 passed, 2 warnings in 5.02s
```
