### PR TITLE
[Core] Change max_model_len in EngineCoreReadyResponse to be non-None

### DIFF
--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -72,9 +72,9 @@ class EngineCoreReadyResponse:
     values (e.g. max_model_len after KV cache auto-fitting).
     """
 
+    max_model_len: int
     num_gpu_blocks: int
     dp_stats_address: str | None
-    max_model_len: int | None = None
 
 
 class EngineCoreRequest(

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -671,11 +671,9 @@ class MPClient(EngineCoreClient):
             return
         vllm_config = self.vllm_config
         response = msgspec.msgpack.decode(payload, type=EngineCoreReadyResponse)
-        if response.max_model_len is not None:
-            vllm_config.model_config.max_model_len = min(
-                vllm_config.model_config.max_model_len,
-                response.max_model_len,
-            )
+        vllm_config.model_config.max_model_len = min(
+            vllm_config.model_config.max_model_len, response.max_model_len
+        )
 
         # Setup KV cache config with initialization state from
         # engine core process. Sum values from all engines in DP case.


### PR DESCRIPTION
Tiny follow-on from https://github.com/vllm-project/vllm/pull/39364 and https://github.com/vllm-project/vllm/pull/39102. This field is never None, clearer if the type reflects that.