### PR TITLE
[CI/Build[ Don't auto-rebase PRs with CI failures

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -18,7 +18,7 @@ pull_request_rules:
 - name: comment-pre-commit-failure
   description: Comment on PR when pre-commit check fails
   conditions:
-    - status-failure=pre-commit
+    - check-failure=pre-commit
     - -closed
     - -draft
   actions:
@@ -51,7 +51,7 @@ pull_request_rules:
 - name: comment-dco-failure
   description: Comment on PR when DCO check fails
   conditions:
-    - status-failure=dco
+    - check-failure=dco
     - -closed
     - -draft
   actions:
@@ -384,6 +384,7 @@ pull_request_rules:
     - label=ready
     - "#approved-reviews-by >= 1"
     - "#commits-behind >= 50"
+    - "#check-failure = 0"
     - -closed
     - -draft
     - -conflict


### PR DESCRIPTION



## Purpose

I see mergify going through quite a lot of PRs. Searching on GitHub, we currently have 124 open PRs that are both approved and ready - updating them every day would add way too much CI pressure considering that we only merge 30-40 PRs per day.

The original purpose of auto-rebase is to avoid merging stale PRs into main. While it's nice for auto-rebase to update PRs to incorporate fixes to broken/flaky CI on main, I don't think it's worth the cost under the current settings. We also don't want to keep updating PRs if the author does not fix relevant CI failures after we add `ready` label. So, let's just focus on the original purpose for now.

Also, according to https://docs.mergify.com/configuration/conditions/, the condition name should be `check-failure`, not `status-failure`.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

