### PR TITLE
[Bugfix] Fix V1 dummy run writing NaN to KV cache null block

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5367,6 +5367,12 @@ class GPUModelRunner(
             ubatch_slices=ubatch_slices_padded,
         )
 
+        # Dummy runs have no real slot assignments — fill with -1 so
+        # concat_and_cache kernels skip the KV write.
+        if slot_mappings_by_group is not None:
+            for sm in slot_mappings_by_group.values():
+                sm.fill_(-1)
+
         # _dummy_run shares pinned CPU buffers (seq_lens, query_start_loc,
         # etc.) with execute_model.  It must participate in the same event
         # protocol so that back-to-back dummy/real steps don't overwrite

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5361,7 +5361,7 @@ class GPUModelRunner(
         attn_metadata: PerLayerAttnMetadata | None = None
 
         slot_mappings_by_group, slot_mappings = self._get_slot_mappings(
-            num_tokens_padded=num_tokens,
+            num_tokens_padded=num_tokens_padded,
             num_reqs_padded=num_reqs_padded,
             num_tokens_unpadded=num_tokens_unpadded,
             ubatch_slices=ubatch_slices_padded,


### PR DESCRIPTION
## Summary

- V1's `_dummy_run` (used by idle DP ranks in DP+EP) calls `_get_slot_mappings`, which reads from a persistent `slot_mapping` buffer initialized with `torch.zeros`. The real-token region `[0:num_tokens_unpadded]` retains value **0**, mapping to block 0 offset 0 — the **null block**. The `concat_and_cache_mla` kernel sees `slot_idx=0 >= 0` and writes garbage hidden states (often NaN) into the null block.
- This corrupts block 0, which is referenced by all unused block table entries. Downstream attention reads from block 0 for padding positions, propagating NaN through the model.
- Fix: fill all slot mappings with `-1` (PAD_SLOT_ID) after `_get_slot_mappings` returns in `_dummy_run`, so `concat_and_cache` kernels skip the KV write entirely. This matches V2's `get_dummy_slot_mappings` behavior which already does `self.slot_mappings.fill_(PAD_SLOT_ID)`.

## Root cause

Introduced by #25954 (Jan 24, 2026) which refactored slot mappings into a standalone `_get_slot_mappings()` called unconditionally in `_dummy_run` and passed via `set_forward_context(slot_mapping=...)`. Before that PR, slot mappings were only set up inside `_build_attention_metadata` (conditional on FULL cudagraph mode), so dummy runs on idle DP ranks wouldn't always trigger KV cache writes.

## Impact

Affects all V1 deployments using DP with EP (e.g., DeepSeek R1/V3 with `data_parallel_size > 1` and `expert_parallel_size > 1`). Quantization-agnostic — FP8, NVFP4, and BF16 are all affected. Observed as accuracy regression (97% → 55%) on DeepSeek R1 NVFP4.

## Test plan

- [x] Verified via KV cache NaN instrumentation on a live DeepSeek R1 NVFP4 deployment: `slot_mapping=[0]` confirmed before fix, `slot_mapping=[-1]` after fix, NaN in block 0 eliminated
- [ ] `pytest tests/v1/worker/test_gpu_model_runner.py -v` (no dummy run slot mapping tests exist yet)
- [ ] lm_eval accuracy check on DeepSeek R1 with DP+EP

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.6 <noreply@anthropic.com>