### PR TITLE
Use physical device id for get_device_uuid

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -655,8 +655,9 @@ class RocmPlatform(Platform):
     @classmethod
     @with_amdsmi_context
     def get_device_uuid(cls, device_id: int = 0) -> str:
+        physical_device_id = cls.device_id_to_physical_device_id(device_id)
         try:
-            device = amdsmi_get_processor_handles()[device_id]
+            device = amdsmi_get_processor_handles()[physical_device_id]
         except AmdSmiException as error:
             logger.error("amdsmi device query failed ", exc_info=error)
             return ""


### PR DESCRIPTION
This PR updates the get_device_uuid to translate the device_id parameter to a physical gpu id before retrieving the gpu handle.

`get_device_uuid` is used in the Verl application PPO and Fully Async uses cases which executes the code below when the vllm backend is being used:

def get_device_uuid(device_id: int) -> str:
    from vllm.platforms import current_platform
 
    # Convert torch.npu.current_device to its corresponding ASCEND_RT_VISIBLE_DEVICES.
    if is_npu_available:
        if os.getenv("ASCEND_RT_VISIBLE_DEVICES") is not None:
            npu_visible_devices = os.environ["ASCEND_RT_VISIBLE_DEVICES"].split(",")
            assert device_id < len(npu_visible_devices), f"device_id {device_id} must less than {npu_visible_devices}"
            return "NPU-" + npu_visible_devices[device_id]
        else:
            return f"NPU-{device_id}"
    else:
        return current_platform.get_device_uuid(device_id)