### PR TITLE
[Metrics] Add num_requests_prefilling/decoding Prometheus gauges

### DIFF
--- a/tests/entrypoints/serve/instrumentator/test_metrics.py
+++ b/tests/entrypoints/serve/instrumentator/test_metrics.py
@@ -182,6 +182,8 @@ async def test_metrics_counts(
 EXPECTED_METRICS_V1 = [
     "vllm:num_requests_running",
     "vllm:num_requests_waiting",
+    "vllm:num_requests_prefilling",
+    "vllm:num_requests_decoding",
     "vllm:kv_cache_usage_perc",
     "vllm:prefix_cache_queries",
     "vllm:prefix_cache_hits",

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1957,9 +1957,14 @@ class Scheduler(SchedulerInterface):
         connector_stats_payload = (
             kv_connector_stats.data if kv_connector_stats else None
         )
+        num_prefilling_reqs = sum(
+            1 for req in self.running if req.num_computed_tokens < req.num_prompt_tokens
+        )
         return SchedulerStats(
             num_running_reqs=len(self.running),
             num_waiting_reqs=len(self.waiting) + len(self.skipped_waiting),
+            num_prefilling_reqs=num_prefilling_reqs,
+            num_decoding_reqs=len(self.running) - num_prefilling_reqs,
             kv_cache_usage=self.kv_cache_manager.usage,
             encoder_cache_usage=self._get_encoder_cache_usage(),
             prefix_cache_stats=prefix_cache_stats,

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -328,6 +328,12 @@ class AggregatedLoggingStatLogger(LoggingStatLogger, AggregateStatLoggerBase):
             self.last_scheduler_stats.num_running_reqs += (
                 last_scheduler_stats.num_running_reqs
             )
+            self.last_scheduler_stats.num_prefilling_reqs += (
+                last_scheduler_stats.num_prefilling_reqs
+            )
+            self.last_scheduler_stats.num_decoding_reqs += (
+                last_scheduler_stats.num_decoding_reqs
+            )
             self.last_scheduler_stats.kv_cache_usage += (
                 last_scheduler_stats.kv_cache_usage
             )
@@ -451,6 +457,26 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         )
         self.gauge_scheduler_waiting = create_metric_per_engine(
             gauge_scheduler_waiting, per_engine_labelvalues
+        )
+
+        gauge_scheduler_prefilling = self._gauge_cls(
+            name="vllm:num_requests_prefilling",
+            documentation="Number of requests currently in prefill phase.",
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_scheduler_prefilling = create_metric_per_engine(
+            gauge_scheduler_prefilling, per_engine_labelvalues
+        )
+
+        gauge_scheduler_decoding = self._gauge_cls(
+            name="vllm:num_requests_decoding",
+            documentation="Number of requests currently in decode phase.",
+            multiprocess_mode="mostrecent",
+            labelnames=labelnames,
+        )
+        self.gauge_scheduler_decoding = create_metric_per_engine(
+            gauge_scheduler_decoding, per_engine_labelvalues
         )
 
         gauge_engine_sleep_state = self._gauge_cls(
@@ -1042,6 +1068,12 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             )
             self.gauge_scheduler_waiting[engine_idx].set(
                 scheduler_stats.num_waiting_reqs
+            )
+            self.gauge_scheduler_prefilling[engine_idx].set(
+                scheduler_stats.num_prefilling_reqs
+            )
+            self.gauge_scheduler_decoding[engine_idx].set(
+                scheduler_stats.num_decoding_reqs
             )
             self.gauge_kv_cache_usage[engine_idx].set(scheduler_stats.kv_cache_usage)
 

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -173,6 +173,8 @@ class SchedulerStats:
 
     num_running_reqs: int = 0
     num_waiting_reqs: int = 0
+    num_prefilling_reqs: int = 0
+    num_decoding_reqs: int = 0
 
     # These are used for internal DP load-balancing.
     step_counter: int = 0


### PR DESCRIPTION
## Purpose

Expose prefill vs decode request count breakdown as Prometheus gauges.

The scheduler already classifies requests as prefill vs decode internally (`request.num_computed_tokens < request.num_prompt_tokens`), but this was never surfaced to the `/metrics` endpoint. Operators currently only see `num_requests_running` (total) and `num_requests_waiting`, making it impossible to distinguish prefill-heavy vs decode-heavy load from metrics alone.

New gauges:
- `vllm:num_requests_prefilling` — requests currently in prefill phase
- `vllm:num_requests_decoding` — requests currently in decode phase

**Files changed:**

| File | Change |
|------|--------|
| `vllm/v1/metrics/stats.py` | Add `num_prefilling_reqs` / `num_decoding_reqs` fields to `SchedulerStats` |
| [vllm/v1/core/sched/scheduler.py](cci:7://file:///Users/yqu161/workplace/vllm/vllm/v1/core/sched/scheduler.py:0:0-0:0) | Compute prefill/decode counts in [make_stats()](cci:1://file:///Users/yqu161/workplace/vllm/vllm/v1/core/sched/scheduler.py:1935:4-1976:9) |
| `vllm/v1/metrics/loggers.py` | Register Prometheus gauges + DP aggregation |
| `tests/entrypoints/serve/instrumentator/test_metrics.py` | Add new gauges to `EXPECTED_METRICS_V1` |

Invariant: `prefilling + decoding == running` (both derived from the same `self.running` set in a single scheduler call).

**Use cases:**
- Correlate TPOT spikes with prefill bursts (the most common cause of TPOT spikes produces zero preemptions, so `num_preemptions_total` alone is insufficient)
- Tune `--max-num-batched-tokens` and `--max-num-partial-prefills` based onobserved prefill/decode concurrency
- Enable P/D-aware routing and autoscaling in external gateways

## Test Plan

```bash
python -m pytest tests/entrypoints/serve/instrumentator/test_metrics.py -v
```

## Test Result
* Existing test_metrics.py updated to expect the new gauge names in EXPECTED_METRICS_V1.
* Tests require GPU — relying on CI to validate. The change is minimal (41 LOC) and purely additive (new gauge registration + stats field plumbing), with no modifications to existing logic.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

