### PR TITLE
[Bugfix] Fix Gemma4 audio batch shape mismatch for concurrent requests

### DIFF
--- a/tests/utils_/test_tensor_schema.py
+++ b/tests/utils_/test_tensor_schema.py
@@ -4,6 +4,10 @@
 import pytest
 import torch
 
+from vllm.model_executor.models.gemma4_mm import (
+    Gemma4AudioInputs,
+    Gemma4ForConditionalGeneration,
+)
 from vllm.model_executor.models.glm4_1v import Glm4vImageEmbeddingInputs
 from vllm.model_executor.models.granite_speech import GraniteSpeechAudioInputs
 from vllm.model_executor.models.hyperclovax_vision import HCXVisionVideoPixelInputs
@@ -201,3 +205,67 @@ def test_invalid_tensor_schema_with_static_last_dim():
             image_embeds=image_embeds,
             image_grid_thw=image_grid_thw,
         )
+
+
+# ---------------------------------------------------------------------------
+# Gemma4 audio batching regression tests
+# ---------------------------------------------------------------------------
+
+
+def test_gemma4_audio_inputs_uniform_batch():
+    """Gemma4AudioInputs accepts a stacked tensor when all s-dims match."""
+    Gemma4AudioInputs(
+        input_features_padded=torch.zeros(2, 215, 128),
+        input_features_mask=torch.ones(2, 215, dtype=torch.bool),
+    )
+
+
+def test_gemma4_audio_inputs_variable_length_raises():
+    """Gemma4AudioInputs rejects a list with inconsistent s-dims directly.
+
+    This documents the raw TensorSchema behaviour — the shape mismatch error
+    that _parse_and_validate_audio_input must prevent by pre-padding.
+    """
+    with pytest.raises(ValueError, match="contains inconsistent shapes"):
+        Gemma4AudioInputs(
+            input_features_padded=[
+                torch.zeros(215, 128),
+                torch.zeros(189, 128),
+            ],
+            input_features_mask=[
+                torch.ones(215, dtype=torch.bool),
+                torch.ones(189, dtype=torch.bool),
+            ],
+        )
+
+
+def test_gemma4_parse_and_validate_audio_pads_variable_lengths():
+    """_parse_and_validate_audio_input pads to the batch-level max s-dim.
+
+    Regression test for concurrent requests carrying audio clips of different
+    durations. Without the fix the method crashes with a TensorSchema shape
+    mismatch; with it the shorter clip is zero-padded and the mask extended
+    with False so the audio tower ignores the extra frames.
+    """
+    # Simulate what MultiModalBatchedField._reduce_data produces when two
+    # requests have audio of different lengths: a plain Python list of 2-D
+    # tensors (one per audio clip) with mismatched first dimensions.
+    feats = [torch.zeros(215, 128), torch.zeros(189, 128)]
+    masks = [torch.ones(215, dtype=torch.bool), torch.ones(189, dtype=torch.bool)]
+
+    # _parse_and_validate_audio_input only reads kwargs — it never touches
+    # any other model state — so object.__new__ is sufficient here.
+    model = object.__new__(Gemma4ForConditionalGeneration)
+    result = model._parse_and_validate_audio_input(
+        input_features_padded=feats,
+        input_features_mask=masks,
+    )
+
+    assert result is not None
+    assert result["input_features_padded"].shape == (2, 215, 128)
+    assert result["input_features_mask"].shape == (2, 215)
+    # The padded frames of the shorter clip must be masked out.
+    assert result["input_features_mask"][1, 189:].sum() == 0
+    # The real frames of both clips must remain unmasked.
+    assert result["input_features_mask"][0, :215].all()
+    assert result["input_features_mask"][1, :189].all()

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -969,6 +969,19 @@ class Gemma4ForConditionalGeneration(nn.Module, SupportsMultiModal, SupportsPP):
         input_features_mask = kwargs.pop("input_features_mask", None)
         if input_features_mask is None:
             return None
+
+        # When requests with different audio durations are batched together,
+        # each audio item may have a different sequence length in the s-dim
+        # (the HF processor pads per-request to that request's max audio
+        # length, not to a global fixed length).  Re-pad everything to the
+        # batch-level maximum before stacking so the audio tower can run in
+        # batched mode and the TensorSchema validation passes.
+        if isinstance(input_features_padded, (list, tuple)):
+            input_features_padded = torch.nn.utils.rnn.pad_sequence(
+                input_features_padded, batch_first=True)
+            input_features_mask = torch.nn.utils.rnn.pad_sequence(
+                input_features_mask, batch_first=True, padding_value=False)
+
         return Gemma4AudioInputs(
             input_features_padded=input_features_padded,
             input_features_mask=input_features_mask,


### PR DESCRIPTION
When vLLM schedules multiple requests carrying audio clips of different durations in the same batch, the HF processor pads each request's input_features to that request's own max length (not a global fixed length). MultiModalBatchedField._reduce_data then returns a plain Python list of 2-D tensors with mismatched s-dims, which fails TensorSchema validation inside Gemma4AudioInputs:

  ValueError: input_features_padded contains inconsistent shapes:
    torch.Size([215, 128]) (index 0) vs torch.Size([189, 128]) (index 2)

Fix: re-pad all items to the batch-level maximum s-dim in _parse_and_validate_audio_input before stacking into a single [bn, max_s, f] tensor. The mask is extended with 0 (False) for the new padding frames; the audio tower already uses the mask to ignore padding positions, and enc[mask] strips them before injection into the LM.




## Purpose

Fix a crash that occurs when vLLM batches concurrent requests whose audio clips have different durations.

The HF Gemma4 processor pads `input_features` per-request to that request's own max audio length rather than a global fixed length. When `MultiModalBatchedField._reduce_data` collects these across requests, shapes differ in the `s` (MEL frame) dimension and it falls back to a plain Python list instead of stacking. `TensorSchema.validate()` then raises:

ValueError: input_features_padded contains inconsistent shapes:
torch.Size([215, 128]) (index 0) vs torch.Size([189, 128]) (index 2)

The fix re-pads all items to the batch-level maximum `s` before stacking in `_parse_and_validate_audio_input`, producing a uniform `[bn, max_s, f]` tensor. The mask is extended with `0` (False) for the added frames. The audio tower already uses the mask for attention and `enc[mask]` strips padding embeddings before LM injection, so the model never processes the synthetic frames.

This is not a duplicate of #38305, which targets `Gemma3nAudioInputs` and uses a `dynamic_dims` annotation. That approach only silences the schema validation — the subsequent `.squeeze(1)` call in `_process_audio_input` would still crash on a Python list. This PR applies the correct end-to-end fix for Gemma4.

Discovered during bot-to-bot audio conversations where requests with varying clip lengths were batched concurrently.

Fixes: intermittent `ValueError: input_features_padded contains inconsistent shapes` on Gemma4 audio inference.
Related: #38297, #38305 (Gemma3n variant)

## Test Plan

Unit tests (no GPU required):
python -m pytest tests/utils_/test_tensor_schema.py -v -k "gemma4"

Three new tests are added to `tests/utils_/test_tensor_schema.py`:
- `test_gemma4_audio_inputs_uniform_batch`: baseline: uniform shapes still accepted
- `test_gemma4_audio_inputs_variable_length_raises`: documents that the raw schema rejects unpadded variable-length lists
- `test_gemma4_parse_and_validate_audio_pads_variable_lengths`: regression test that directly calls `_parse_and_validate_audio_input` with mismatched s-dims and asserts correct padding and masking

## Test Result
**Before fix** — 
=== test_gemma4_audio_inputs_uniform_batch ===
PASSED

`test_gemma4_parse_and_validate_audio_pads_variable_lengths` fails with:
```
ValueError: input_features_padded contains inconsistent shapes:
torch.Size([215, 128]) (index 0) vs torch.Size([189, 128]) (index 1)
```

**After fix:**
=== test_gemma4_audio_inputs_uniform_batch ===
PASSED

=== test_gemma4_audio_inputs_variable_length_raises ===
PASSED (raised ValueError as expected): input_features_padded contains inconsistent shapes: torch.Size([215, 128]) (index 0) vs torch.Size([189, 128]) (index 1)

=== test_gemma4_parse_and_validate_audio_pads_variable_lengths ===
PASSED

Change is additionally verified by simulating 150 multi-turn audio conversations with clips of varying lengths and concurrency of 4 — zero failures, compared to intermittent crashes before the fix.

Co-authored-by: Claude
Signed-off-by: raghav.mehndiratta
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

