### PR TITLE
[Doc] Add pip equivalent for CUDA-specific wheel installation

### DIFF
--- a/docs/getting_started/installation/gpu.cuda.inc.md
+++ b/docs/getting_started/installation/gpu.cuda.inc.md
@@ -46,6 +46,15 @@ export CPU_ARCH=$(uname -m) # x86_64 or aarch64
 uv pip install https://github.com/vllm-project/vllm/releases/download/v${VLLM_VERSION}/vllm-${VLLM_VERSION}+cu${CUDA_VERSION}-cp38-abi3-manylinux_2_35_${CPU_ARCH}.whl --extra-index-url https://download.pytorch.org/whl/cu${CUDA_VERSION}
 ```
 
+??? console "pip"
+    ```bash
+    # Install vLLM with a specific CUDA version (e.g., 13.0).
+    export VLLM_VERSION=$(curl -s https://api.github.com/repos/vllm-project/vllm/releases/latest | jq -r .tag_name | sed 's/^v//')
+    export CUDA_VERSION=130 # or other
+    export CPU_ARCH=$(uname -m) # x86_64 or aarch64
+    pip install https://github.com/vllm-project/vllm/releases/download/v${VLLM_VERSION}/vllm-${VLLM_VERSION}+cu${CUDA_VERSION}-cp38-abi3-manylinux_2_35_${CPU_ARCH}.whl --extra-index-url https://download.pytorch.org/whl/cu${CUDA_VERSION}
+    ```
+
 #### Install the latest code
 
 LLM inference is a fast-evolving field, and the latest code may contain bug fixes, performance improvements, and new features that are not released yet. To allow users to try the latest code without waiting for the next release, vLLM provides wheels for every commit since `v0.5.3` on <https://wheels.vllm.ai/nightly>. There are multiple indices that could be used:


### PR DESCRIPTION
## Summary

The "specific CUDA version" install section (`gpu.cuda.inc.md`) only showed a `uv pip install` command with no `pip` alternative. The default install section above it already has a `??? console "pip"` collapsible block  this PR adds the same for the CUDA-specific section, for consistency.

## Root cause context

Issue #39462 reports that the [vllm.ai quickstart widget](https://vllm.ai/) generates `pip install ... --index-strategy unsafe-best-match` for non-default CUDA versions, but `--index-strategy` is a `uv`-only flag. The actual bug is in the website's JavaScript (the Stable + non-default CUDA path appends this flag unconditionally to both `uv` and `pip` commands). The vllm docs are technically correct, but were missing a `pip` equivalent for this specific section.

## Changes

- Added `??? console "pip"` collapsible block for the CUDA-specific wheel install section, matching the existing pattern used in the default install section above

## Testing

Documentation-only change. No code changes.

Relates to #39462