### PR TITLE
[Model] Add IsHybrid support to Qwen3_5MoeForCausalLM

### DIFF
--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -550,7 +550,17 @@ class Qwen3_5ForCausalLM(Qwen3_5ForCausalLMBase):
     pass
 
 
-class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLMBase, QwenNextMixtureOfExperts):
+class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLMBase, QwenNextMixtureOfExperts,
+                            IsHybrid):
+    """Qwen3.5 MoE text-only model (e.g. Qwen3.5-35B-A3B).
+
+    This model uses hybrid attention (DeltaNet + full attention) just like
+    the dense Qwen3.5 variants. The ``IsHybrid`` mixin is required so that
+    ``_align_hybrid_block_size`` runs during config validation, which sets
+    ``mamba_block_size`` and aligns KV-cache page sizes between attention
+    and DeltaNet layers.
+    """
+
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__(vllm_config=vllm_config, prefix=prefix)
 
@@ -559,6 +569,45 @@ class Qwen3_5MoeForCausalLM(Qwen3_5ForCausalLMBase, QwenNextMixtureOfExperts):
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         return self.model.get_expert_mapping()
+
+    @classmethod
+    def get_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: "VllmConfig",
+    ) -> tuple[torch.dtype, torch.dtype]:
+        return MambaStateDtypeCalculator.gated_delta_net_state_dtype(
+            vllm_config.model_config.dtype,
+            vllm_config.cache_config.mamba_cache_dtype,
+            vllm_config.cache_config.mamba_ssm_cache_dtype,
+        )
+
+    @classmethod
+    def get_mamba_state_shape_from_config(
+        cls, vllm_config: "VllmConfig"
+    ) -> tuple[tuple[int, int], tuple[int, int]]:
+        parallel_config = vllm_config.parallel_config
+        hf_config = vllm_config.model_config.hf_text_config
+        tp_size = parallel_config.tensor_parallel_size
+        num_spec = (
+            vllm_config.speculative_config.num_speculative_tokens
+            if vllm_config.speculative_config
+            else 0
+        )
+        return MambaStateShapeCalculator.gated_delta_net_state_shape(
+            tp_size,
+            hf_config.linear_num_key_heads,
+            hf_config.linear_num_value_heads,
+            hf_config.linear_key_head_dim,
+            hf_config.linear_value_head_dim,
+            hf_config.linear_conv_kernel_dim,
+            num_spec,
+        )
+
+    @classmethod
+    def get_mamba_state_copy_func(
+        cls,
+    ) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
+        return MambaStateCopyFuncCalculator.gated_delta_net_state_copy_func()
 
 
 ########################################################


### PR DESCRIPTION
## Summary

`Qwen3_5MoeForCausalLM` (text-only MoE variant used by Qwen3.5-35B-A3B) shares the same hybrid DeltaNet + full attention architecture as the dense Qwen3.5 models, but was missing the `IsHybrid` mixin. This causes the V1 engine to crash during KV cache initialization.

**Root cause:** Without `IsHybrid`, `_align_hybrid_block_size` never runs during config validation, leaving `mamba_block_size` as `None`. This triggers `TypeError` crashes in multiple V1 code paths that call `min(block_size)` or perform arithmetic on `block_size`.

**Fix:** Add `IsHybrid` to `Qwen3_5MoeForCausalLM` base classes, along with the three required mamba state methods (`get_mamba_state_dtype_from_config`, `get_mamba_state_shape_from_config`, `get_mamba_state_copy_func`). The implementations mirror `Qwen3_5ForConditionalGeneration` (VLM wrapper) since both share the same DeltaNet architecture.

## Test Plan

- [x] Tested on NVIDIA DGX Spark (GB10, SM121) with merged Qwen3.5-35B-A3B at BF16
- [x] V1 engine initializes successfully with auto-computed `block_size=544`
- [x] FlashAttention v2 + FlashInfer CUTLASS MoE backend selected correctly
- [x] Inference produces coherent output at ~30 tok/s decode throughput
- [x] KV cache: 539K tokens, 41 GiB available, 360x max concurrency at 4096 ctx

## Error without this fix

```
TypeError: '<' not supported between instances of 'NoneType' and 'NoneType'
  File ".../vllm/v1/core/kv_cache_utils.py", line 1298, in _report_kv_cache_config
    min_block_size = min([group.kv_cache_spec.block_size for group in ...])

TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
  File ".../vllm/v1/worker/gpu_model_runner.py", line 6493, in may_reinitialize_input_batch
    max_model_len, block_size * get_total_cp_world_size()
```

Related: #36236

🤖 Generated with [Claude Code](https://claude.com/claude-code)