### PR TITLE
fix(tool_parsers): fix Gemma4 STRING_DELIM leaking into array string …

### DIFF
--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -676,3 +676,20 @@ class TestStreamingExtraction:
         }
 
         assert args_text.count("replace_all") == 1
+
+
+def test_parse_gemma4_args_pdf_array():
+    """Regression test: STRING_DELIM must not leak into output values."""
+    raw = 'pdfs:[<|"|>/home/h/.openclaw/pdfs/a.pdf<|"|>,<|"|>/home/h/.openclaw/pdfs/b.pdf<|"|>],prompt:<|"|>analyse these 2 pdfs.<|"|>'
+
+    result = _parse_gemma4_args(raw)
+
+    assert result["pdfs"] == [
+        "/home/h/.openclaw/pdfs/a.pdf",
+        "/home/h/.openclaw/pdfs/b.pdf",
+    ]
+    assert result["prompt"] == "analyse these 2 pdfs."
+
+    output_json = json.dumps(result)
+    assert '<|"' not in output_json
+    assert '"|>' not in output_json

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -135,8 +135,8 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
             break
 
         # String value: <|"|>...<|"|>
-        if args_str[i:].startswith(STRING_DELIM):
-            i += len(STRING_DELIM)
+        if args_str[i:].lstrip().startswith(STRING_DELIM):
+            i = args_str.find(STRING_DELIM, i) + len(STRING_DELIM)
             val_start = i
             end_pos = args_str.find(STRING_DELIM, i)
             if end_pos == -1:
@@ -200,7 +200,12 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
                 # Value may be incomplete (e.g. partial boolean) —
                 # withhold to avoid type instability during streaming.
                 break
-            result[key] = _parse_gemma4_value(args_str[val_start:i])
+            bare_val = args_str[val_start:i].strip()
+            if bare_val.startswith(STRING_DELIM):
+                bare_val = bare_val[len(STRING_DELIM):]
+            if bare_val.endswith(STRING_DELIM):
+                bare_val = bare_val[:-len(STRING_DELIM)]
+            result[key] = _parse_gemma4_value(bare_val)
 
     return result
 
@@ -218,8 +223,8 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
             break
 
         # String element
-        if arr_str[i:].startswith(STRING_DELIM):
-            i += len(STRING_DELIM)
+        if arr_str[i:].lstrip().startswith(STRING_DELIM):
+            i = arr_str.find(STRING_DELIM, i) + len(STRING_DELIM)
             end_pos = arr_str.find(STRING_DELIM, i)
             if end_pos == -1:
                 items.append(arr_str[i:])
@@ -254,6 +259,11 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
             sub_start = i + 1
             i += 1
             while i < n and depth > 0:
+                if arr_str[i:].startswith(STRING_DELIM):
+                    i += len(STRING_DELIM)
+                    nd = arr_str.find(STRING_DELIM, i)
+                    i = nd + len(STRING_DELIM) if nd != -1 else n
+                    continue
                 if arr_str[i] == "[":
                     depth += 1
                 elif arr_str[i] == "]":
@@ -271,7 +281,12 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
                 i += 1
             if partial and i >= n:
                 break
-            items.append(_parse_gemma4_value(arr_str[val_start:i]))
+            bare_val = arr_str[val_start:i].strip()
+            if bare_val.startswith(STRING_DELIM):
+                bare_val = bare_val[len(STRING_DELIM):]
+            if bare_val.endswith(STRING_DELIM):
+                bare_val = bare_val[:-len(STRING_DELIM)]
+            items.append(_parse_gemma4_value(bare_val))
 
     return items
 


### PR DESCRIPTION
## Purpose

Fix `STRING_DELIM` (`<|"|>`) leaking into JSON output when parsing array string values in `_parse_gemma4_args` and `_parse_gemma4_array` in the Gemma4 tool call parser.

Fixes #39468

When a tool call contains an array of string values (e.g. file paths), the output JSON contained raw `<|"` delimiter fragments instead of clean string values:

**Before:**
```json
{
    "pdfs": ["<|"|"/home/h/a.pdf<|"|>", "<|"|"/home/h/b.pdf<|"|>"],
    "prompt": "analyse these 2 pdfs."
}
```

**After:**
```json
{
    "pdfs": ["/home/h/a.pdf", "/home/h/b.pdf"],
    "prompt": "analyse these 2 pdfs."
}
```

## Test Plan

```bash
python -m pytest tests/tool_parsers/test_gemma4_tool_parser.py -v
```

## Test Result

Added regression test `test_parse_gemma4_args_pdf_array` that reproduces the exact bug. All 46 tests pass: