### PR TITLE
[Bugfix] Reserve distributed init socket to avoid port conflicts

### DIFF
--- a/tests/distributed/test_parallel_state.py
+++ b/tests/distributed/test_parallel_state.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import socket
+import sys
+from types import ModuleType, SimpleNamespace
+
+from vllm.distributed import parallel_state
+from vllm.utils.network_utils import get_distributed_init_method
+
+
+def test_init_distributed_environment_uses_reserved_listen_socket(
+    monkeypatch,
+):
+    init_process_group_calls: list[dict] = []
+    store_calls: list[dict] = []
+    store = object()
+
+    config_stub = ModuleType("vllm.config")
+    config_stub.get_current_vllm_config_or_none = lambda: None
+    monkeypatch.setitem(sys.modules, "vllm.config", config_stub)
+    monkeypatch.setattr(parallel_state, "_WORLD", None)
+    monkeypatch.setattr(
+        parallel_state.torch.distributed, "is_initialized", lambda: False
+    )
+    monkeypatch.setattr(
+        parallel_state.torch.distributed,
+        "is_backend_available",
+        lambda backend: True,
+    )
+    monkeypatch.setattr(
+        parallel_state.torch.distributed,
+        "init_process_group",
+        lambda **kwargs: init_process_group_calls.append(kwargs),
+    )
+    monkeypatch.setattr(
+        parallel_state.torch.distributed,
+        "get_world_size",
+        lambda: 1,
+    )
+    monkeypatch.setattr(
+        parallel_state,
+        "init_world_group",
+        lambda ranks, local_rank, backend: SimpleNamespace(cpu_group=object()),
+    )
+    monkeypatch.setattr(parallel_state, "_node_count", lambda group: 1)
+
+    def fake_create_tcp_store(host: str, port: int, **kwargs):
+        store_calls.append(
+            {
+                "host": host,
+                "port": port,
+                **kwargs,
+            }
+        )
+        return store
+
+    monkeypatch.setattr(parallel_state, "create_tcp_store", fake_create_tcp_store)
+
+    listen_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listen_socket.bind(("127.0.0.1", 0))
+    listen_socket.listen()
+    _, port = listen_socket.getsockname()
+    distributed_init_method = get_distributed_init_method("127.0.0.1", port)
+
+    parallel_state.init_distributed_environment(
+        world_size=1,
+        rank=0,
+        distributed_init_method=distributed_init_method,
+        local_rank=0,
+        backend="gloo",
+        distributed_listen_socket=listen_socket,
+    )
+
+    assert store_calls == [
+        {
+            "host": "127.0.0.1",
+            "port": port,
+            "listen_socket": listen_socket,
+            "world_size": 1,
+            "is_master": True,
+        }
+    ]
+    assert init_process_group_calls == [
+        {
+            "backend": "gloo",
+            "store": store,
+            "world_size": 1,
+            "rank": 0,
+            "timeout": None,
+        }
+    ]
+
+
+def test_init_distributed_environment_closes_unused_reserved_socket(monkeypatch):
+    config_stub = ModuleType("vllm.config")
+    config_stub.get_current_vllm_config_or_none = lambda: None
+    monkeypatch.setitem(sys.modules, "vllm.config", config_stub)
+    monkeypatch.setattr(parallel_state.torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        parallel_state,
+        "_WORLD",
+        SimpleNamespace(world_size=1),
+    )
+    monkeypatch.setattr(parallel_state.torch.distributed, "get_world_size", lambda: 1)
+
+    listen_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listen_socket.bind(("127.0.0.1", 0))
+    listen_socket.listen()
+    _, port = listen_socket.getsockname()
+
+    parallel_state.init_distributed_environment(
+        world_size=1,
+        rank=0,
+        distributed_init_method=get_distributed_init_method("127.0.0.1", port),
+        local_rank=0,
+        backend="gloo",
+        distributed_listen_socket=listen_socket,
+    )
+
+    assert listen_socket.fileno() == -1

--- a/tests/distributed/test_parallel_state.py
+++ b/tests/distributed/test_parallel_state.py
@@ -96,7 +96,9 @@ def test_init_distributed_environment_closes_unused_reserved_socket(monkeypatch)
     config_stub = ModuleType("vllm.config")
     config_stub.get_current_vllm_config_or_none = lambda: None
     monkeypatch.setitem(sys.modules, "vllm.config", config_stub)
-    monkeypatch.setattr(parallel_state.torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(
+        parallel_state.torch.distributed, "is_initialized", lambda: True
+    )
     monkeypatch.setattr(
         parallel_state,
         "_WORLD",

--- a/tests/distributed/test_parallel_state.py
+++ b/tests/distributed/test_parallel_state.py
@@ -121,3 +121,78 @@ def test_init_distributed_environment_closes_unused_reserved_socket(monkeypatch)
     )
 
     assert listen_socket.fileno() == -1
+
+
+def test_init_distributed_environment_uses_tcp_store_for_nonzero_ranks(monkeypatch):
+    init_process_group_calls: list[dict] = []
+    store_calls: list[dict] = []
+    store = object()
+
+    config_stub = ModuleType("vllm.config")
+    config_stub.get_current_vllm_config_or_none = lambda: None
+    monkeypatch.setitem(sys.modules, "vllm.config", config_stub)
+    monkeypatch.setattr(parallel_state, "_WORLD", None)
+    monkeypatch.setattr(
+        parallel_state.torch.distributed, "is_initialized", lambda: False
+    )
+    monkeypatch.setattr(
+        parallel_state.torch.distributed,
+        "is_backend_available",
+        lambda backend: True,
+    )
+    monkeypatch.setattr(
+        parallel_state.torch.distributed,
+        "init_process_group",
+        lambda **kwargs: init_process_group_calls.append(kwargs),
+    )
+    monkeypatch.setattr(
+        parallel_state.torch.distributed,
+        "get_world_size",
+        lambda: 2,
+    )
+    monkeypatch.setattr(
+        parallel_state,
+        "init_world_group",
+        lambda ranks, local_rank, backend: SimpleNamespace(cpu_group=object()),
+    )
+    monkeypatch.setattr(parallel_state, "_node_count", lambda group: 1)
+
+    def fake_create_tcp_store(host: str, port: int, **kwargs):
+        store_calls.append(
+            {
+                "host": host,
+                "port": port,
+                **kwargs,
+            }
+        )
+        return store
+
+    monkeypatch.setattr(parallel_state, "create_tcp_store", fake_create_tcp_store)
+
+    distributed_init_method = get_distributed_init_method("127.0.0.1", 23456)
+
+    parallel_state.init_distributed_environment(
+        world_size=2,
+        rank=1,
+        distributed_init_method=distributed_init_method,
+        local_rank=1,
+        backend="gloo",
+    )
+
+    assert store_calls == [
+        {
+            "host": "127.0.0.1",
+            "port": 23456,
+            "world_size": 2,
+            "is_master": False,
+        }
+    ]
+    assert init_process_group_calls == [
+        {
+            "backend": "gloo",
+            "store": store,
+            "world_size": 2,
+            "rank": 1,
+            "timeout": None,
+        }
+    ]

--- a/tests/v1/executor/test_multiproc_executor_unit.py
+++ b/tests/v1/executor/test_multiproc_executor_unit.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Unit tests for helper logic in the multiprocess executor."""
+
+import socket
+
+from vllm.utils.network_utils import create_distributed_init_endpoint
+
+
+def test_create_distributed_init_endpoint_without_reserved_socket(monkeypatch):
+    monkeypatch.setattr(
+        "vllm.utils.network_utils.get_open_port",
+        lambda: 23456,
+    )
+
+    endpoint = create_distributed_init_endpoint(
+        "127.0.0.1",
+        reserve_listen_socket=False,
+    )
+
+    assert endpoint.init_method == "tcp://127.0.0.1:23456"
+    assert endpoint.listen_socket is None
+
+
+def test_create_distributed_init_endpoint_with_reserved_socket():
+    endpoint = create_distributed_init_endpoint(
+        "127.0.0.1",
+        reserve_listen_socket=True,
+    )
+
+    try:
+        assert endpoint.listen_socket is not None
+        assert endpoint.listen_socket.family == socket.AF_INET
+        _, port = endpoint.listen_socket.getsockname()
+        assert endpoint.init_method == f"tcp://127.0.0.1:{port}"
+    finally:
+        if endpoint.listen_socket is not None:
+            endpoint.listen_socket.close()

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1362,24 +1362,23 @@ def _init_process_group_with_optional_listen_socket(
         "rank": rank,
         "timeout": timeout,
     }
-    if distributed_listen_socket is None:
+    if dist_init_host_port is None:
         torch.distributed.init_process_group(
             init_method=distributed_init_method,
             **process_group_kwargs,
         )
         return dist_init_host_port
 
-    assert dist_init_host_port is not None, (
-        "distributed_listen_socket requires a tcp:// init method"
-    )
     host, port = dist_init_host_port
     store_kwargs: dict[str, Any] = {
-        "listen_socket": distributed_listen_socket,
         "world_size": world_size,
-        "is_master": True,
+        "is_master": rank == 0,
     }
     if timeout is not None:
         store_kwargs["timeout"] = timeout
+    if distributed_listen_socket is not None:
+        assert rank == 0, "Only rank 0 may own the distributed listen socket"
+        store_kwargs["listen_socket"] = distributed_listen_socket
     store = create_tcp_store(host, port, **store_kwargs)
     torch.distributed.init_process_group(
         store=store,

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -26,6 +26,8 @@ If you only need to use the distributed environment without model/pipeline
 import contextlib
 import gc
 import pickle
+import socket
+import traceback
 import weakref
 from collections import namedtuple
 from collections.abc import Callable
@@ -35,6 +37,7 @@ from datetime import timedelta
 from multiprocessing import shared_memory
 from typing import TYPE_CHECKING, Any, Protocol
 from unittest.mock import patch
+from urllib.parse import urlparse
 
 import torch
 import torch.distributed
@@ -48,11 +51,15 @@ from vllm.distributed.device_communicators.base_device_communicator import (
 )
 from vllm.distributed.utils import (
     StatelessProcessGroup,
+    create_tcp_store,
     get_cached_tcp_store_client,
 )
 from vllm.logger import init_logger
 from vllm.utils.import_utils import resolve_obj_by_qualname
-from vllm.utils.network_utils import get_distributed_init_method
+from vllm.utils.network_utils import (
+    find_process_using_port,
+    get_distributed_init_method,
+)
 from vllm.utils.system_utils import suppress_stdout
 from vllm.utils.torch_utils import (
     direct_register_custom_op,
@@ -1310,6 +1317,77 @@ def set_custom_all_reduce(enable: bool):
     _ENABLE_CUSTOM_ALL_REDUCE = enable
 
 
+def _get_dist_init_host_port(
+    distributed_init_method: str,
+) -> tuple[str, int] | None:
+    parsed = urlparse(distributed_init_method)
+    if parsed.scheme != "tcp" or parsed.hostname is None or parsed.port is None:
+        return None
+    return parsed.hostname, parsed.port
+
+
+def _format_port_conflict_details(port: int) -> str:
+    process = find_process_using_port(port)
+    if process is None:
+        return (
+            "port owner unavailable (unsupported on this platform or process "
+            "already exited)"
+        )
+
+    try:
+        process_name = process.name()
+    except Exception:
+        process_name = "<unknown>"
+
+    try:
+        cmdline = " ".join(process.cmdline())
+    except Exception:
+        cmdline = "<unavailable>"
+
+    return f"pid={process.pid} name={process_name} cmdline={cmdline}"
+
+
+def _init_process_group_with_optional_listen_socket(
+    backend: str,
+    world_size: int,
+    rank: int,
+    timeout: timedelta | None,
+    distributed_init_method: str,
+    distributed_listen_socket: socket.socket | None,
+) -> tuple[str, int] | None:
+    dist_init_host_port = _get_dist_init_host_port(distributed_init_method)
+    process_group_kwargs: dict[str, Any] = {
+        "backend": backend,
+        "world_size": world_size,
+        "rank": rank,
+        "timeout": timeout,
+    }
+    if distributed_listen_socket is None:
+        torch.distributed.init_process_group(
+            init_method=distributed_init_method,
+            **process_group_kwargs,
+        )
+        return dist_init_host_port
+
+    assert dist_init_host_port is not None, (
+        "distributed_listen_socket requires a tcp:// init method"
+    )
+    host, port = dist_init_host_port
+    store_kwargs: dict[str, Any] = {
+        "listen_socket": distributed_listen_socket,
+        "world_size": world_size,
+        "is_master": True,
+    }
+    if timeout is not None:
+        store_kwargs["timeout"] = timeout
+    store = create_tcp_store(host, port, **store_kwargs)
+    torch.distributed.init_process_group(
+        store=store,
+        **process_group_kwargs,
+    )
+    return dist_init_host_port
+
+
 def _init_elastic_ep_world(
     config, local_rank: int, backend: str, rank: int, world_size: int
 ) -> None:
@@ -1352,6 +1430,7 @@ def init_distributed_environment(
     local_rank: int = -1,
     backend: str = "nccl",
     timeout: timedelta | None = None,
+    distributed_listen_socket: socket.socket | None = None,
 ):
     logger.debug(
         "world_size=%d rank=%d local_rank=%d distributed_init_method=%s backend=%s",
@@ -1419,13 +1498,28 @@ def init_distributed_environment(
             )
             backend = "gloo"
         # this backend is used for WORLD
-        torch.distributed.init_process_group(
-            backend=backend,
-            init_method=distributed_init_method,
-            world_size=world_size,
-            rank=rank,
-            timeout=timeout,
-        )
+        dist_init_host_port = None
+        try:
+            dist_init_host_port = _init_process_group_with_optional_listen_socket(
+                backend=backend,
+                world_size=world_size,
+                rank=rank,
+                timeout=timeout,
+                distributed_init_method=distributed_init_method,
+                distributed_listen_socket=distributed_listen_socket,
+            )
+        except Exception:
+            exc_msg = traceback.format_exc()
+            if dist_init_host_port is not None and (
+                "EADDRINUSE" in exc_msg or "Address already in use" in exc_msg
+            ):
+                _, port = dist_init_host_port
+                logger.error(
+                    "Distributed init port conflict detected for %s; %s",
+                    distributed_init_method,
+                    _format_port_conflict_details(port),
+                )
+            raise
         if enable_elastic_ep:
             tp_pp_cpu_group = torch.distributed.new_group(
                 backend="gloo", timeout=timeout
@@ -1437,6 +1531,9 @@ def init_distributed_environment(
                 raise RuntimeError(
                     "Elastic EP is not yet supported with multi-node TP/PP"
                 )
+
+    elif distributed_listen_socket is not None:
+        distributed_listen_socket.close()
 
     # set the local rank
     # local_rank is not available in torch ProcessGroup,

--- a/vllm/utils/network_utils.py
+++ b/vllm/utils/network_utils.py
@@ -10,6 +10,7 @@ from collections.abc import (
     Iterator,
     Sequence,
 )
+from dataclasses import dataclass
 from typing import Any
 from uuid import uuid4
 
@@ -22,6 +23,12 @@ import vllm.envs as envs
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+
+@dataclass
+class DistributedInitEndpoint:
+    init_method: str
+    listen_socket: socket.socket | None = None
 
 
 def close_sockets(sockets: Sequence[zmq.Socket | zmq.asyncio.Socket]):
@@ -129,6 +136,29 @@ def join_host_port(host: str, port: int) -> str:
 
 def get_distributed_init_method(ip: str, port: int) -> str:
     return get_tcp_uri(ip, port)
+
+
+def create_distributed_init_endpoint(
+    host: str,
+    *,
+    reserve_listen_socket: bool,
+) -> DistributedInitEndpoint:
+    if not reserve_listen_socket:
+        return DistributedInitEndpoint(
+            init_method=get_distributed_init_method(host, get_open_port())
+        )
+
+    socket_family = socket.AF_INET6 if ":" in host else socket.AF_INET
+    listen_socket = socket.socket(socket_family, socket.SOCK_STREAM)
+    listen_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listen_socket.bind((host, 0))
+    listen_socket.listen()
+    return DistributedInitEndpoint(
+        init_method=get_distributed_init_method(
+            host, listen_socket.getsockname()[1]
+        ),
+        listen_socket=listen_socket,
+    )
 
 
 def get_tcp_uri(ip: str, port: int) -> str:

--- a/vllm/utils/network_utils.py
+++ b/vllm/utils/network_utils.py
@@ -154,9 +154,7 @@ def create_distributed_init_endpoint(
     listen_socket.bind((host, 0))
     listen_socket.listen()
     return DistributedInitEndpoint(
-        init_method=get_distributed_init_method(
-            host, listen_socket.getsockname()[1]
-        ),
+        init_method=get_distributed_init_method(host, listen_socket.getsockname()[1]),
         listen_socket=listen_socket,
     )
 

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -5,6 +5,7 @@ import os
 import pickle
 import queue
 import signal
+import socket
 import threading
 import time
 import traceback
@@ -46,10 +47,9 @@ from vllm.platforms import current_platform
 from vllm.tracing import instrument, maybe_init_worker_tracer
 from vllm.utils import numa_utils
 from vllm.utils.network_utils import (
-    get_distributed_init_method,
+    create_distributed_init_endpoint,
     get_ip,
     get_loopback_ip,
-    get_open_port,
 )
 from vllm.utils.system_utils import (
     _maybe_force_spawn,
@@ -123,9 +123,8 @@ class MultiprocExecutor(Executor):
         set_multiprocessing_worker_envs()
 
         # use the loopback address get_loopback_ip() for communication.
-        distributed_init_method = get_distributed_init_method(
-            get_loopback_ip(), get_open_port()
-        )
+        distributed_host = get_loopback_ip()
+        distributed_listen_socket: socket.socket | None = None
         self.rpc_broadcast_mq: MessageQueue | None = None
         scheduler_output_handle: Handle | None = None
         # Initialize worker and set up message queues for SchedulerOutputs
@@ -162,6 +161,12 @@ class MultiprocExecutor(Executor):
             global_start_rank = (
                 self.local_world_size * self.parallel_config.node_rank_within_dp
             )
+            distributed_endpoint = create_distributed_init_endpoint(
+                distributed_host,
+                reserve_listen_socket=(global_start_rank == 0),
+            )
+            distributed_init_method = distributed_endpoint.init_method
+            distributed_listen_socket = distributed_endpoint.listen_socket
             # When using fork, keep track of socket file descriptors that are
             # inherited by the worker, so that we can close them in subsequent
             # workers
@@ -181,6 +186,9 @@ class MultiprocExecutor(Executor):
                         local_rank=local_rank,
                         rank=global_rank,
                         distributed_init_method=distributed_init_method,
+                        distributed_listen_socket=(
+                            distributed_listen_socket if global_rank == 0 else None
+                        ),
                         input_shm_handle=scheduler_output_handle,
                         shared_worker_lock=shared_worker_lock,
                         is_driver_worker=is_driver_worker,
@@ -192,12 +200,20 @@ class MultiprocExecutor(Executor):
                         local_rank=local_rank,
                         rank=global_rank,
                         distributed_init_method=distributed_init_method,
+                        distributed_listen_socket=(
+                            distributed_listen_socket if global_rank == 0 else None
+                        ),
                         input_shm_handle=scheduler_output_handle,
                         shared_worker_lock=shared_worker_lock,
                         is_driver_worker=is_driver_worker,
                         inherited_fds=inherited_fds,
                     )
                 unready_workers.append(unready_worker_handle)
+                if global_rank == 0 and distributed_listen_socket is not None:
+                    # Drop the parent's copy immediately so later forked workers
+                    # do not inherit the reserved rendezvous socket.
+                    distributed_listen_socket.close()
+                    distributed_listen_socket = None
                 if inherited_fds is not None:
                     inherited_fds.append(unready_worker_handle.death_writer.fileno())
                     inherited_fds.append(unready_worker_handle.ready_pipe.fileno())
@@ -243,6 +259,8 @@ class MultiprocExecutor(Executor):
 
             success = True
         finally:
+            if distributed_listen_socket is not None:
+                distributed_listen_socket.close()
             if not success:
                 # Clean up the worker procs if there was a failure.
                 # Close death_writers first to signal workers to exit
@@ -591,6 +609,7 @@ class WorkerProc:
         local_rank: int,
         rank: int,
         distributed_init_method: str,
+        distributed_listen_socket: socket.socket | None,
         input_shm_handle: Handle,
         shared_worker_lock: LockType,
         is_driver_worker: bool,
@@ -610,6 +629,7 @@ class WorkerProc:
             "shared_worker_lock": shared_worker_lock,
         }
         wrapper.init_worker(all_kwargs)
+        wrapper.worker.distributed_listen_socket = distributed_listen_socket
         self.worker = wrapper
 
         self.setup_proc_title_and_log_prefix(
@@ -655,6 +675,7 @@ class WorkerProc:
         local_rank: int,
         rank: int,
         distributed_init_method: str,
+        distributed_listen_socket: socket.socket | None,
         input_shm_handle,  # Receive SchedulerOutput
         shared_worker_lock: LockType,
         is_driver_worker: bool,
@@ -673,6 +694,7 @@ class WorkerProc:
             "local_rank": local_rank,
             "rank": rank,
             "distributed_init_method": distributed_init_method,
+            "distributed_listen_socket": distributed_listen_socket,
             "input_shm_handle": input_shm_handle,
             "ready_pipe": ready_writer,
             "death_pipe": death_reader,

--- a/vllm/v1/worker/cpu_worker.py
+++ b/vllm/v1/worker/cpu_worker.py
@@ -84,6 +84,7 @@ class CPUWorker(Worker):
             self.distributed_init_method,
             self.local_rank,
             current_platform.dist_backend,
+            self.distributed_listen_socket,
         )
         # Set random seed.
         set_random_seed(self.model_config.seed)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -4,6 +4,7 @@
 
 import gc
 import os
+import socket
 from collections.abc import Callable
 from contextlib import AbstractContextManager, nullcontext
 from datetime import timedelta
@@ -266,6 +267,7 @@ class Worker(WorkerBase):
                 self.distributed_init_method,
                 self.local_rank,
                 current_platform.dist_backend,
+                self.distributed_listen_socket,
             )
 
             if self.use_v2_model_runner:
@@ -1020,6 +1022,7 @@ def init_worker_distributed_environment(
     distributed_init_method: str | None = None,
     local_rank: int = -1,
     backend: str = "nccl",
+    distributed_listen_socket: socket.socket | None = None,
 ) -> None:
     """Initialize the distributed environment."""
     attention_config = vllm_config.attention_config
@@ -1043,6 +1046,7 @@ def init_worker_distributed_environment(
         local_rank,
         backend,
         timeout,
+        distributed_listen_socket=distributed_listen_socket,
     )
 
     ensure_model_parallel_initialized(

--- a/vllm/v1/worker/worker_base.py
+++ b/vllm/v1/worker/worker_base.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import socket
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -76,6 +77,7 @@ class WorkerBase:
         self.local_rank = local_rank
         self.rank = rank
         self.distributed_init_method = distributed_init_method
+        self.distributed_listen_socket: socket.socket | None = None
         self.is_driver_worker = is_driver_worker
 
         # Device and model state

--- a/vllm/v1/worker/xpu_worker.py
+++ b/vllm/v1/worker/xpu_worker.py
@@ -83,6 +83,7 @@ class XPUWorker(Worker):
             self.distributed_init_method,
             self.local_rank,
             current_platform.dist_backend,
+            self.distributed_listen_socket,
         )
 
         # global all_reduce needed for overall oneccl warm up


### PR DESCRIPTION
Reserve the multiprocess distributed rendezvous socket in the parent process and pass it to rank 0 so workers do not race for a reused port. Add focused tests for reserved endpoint creation and process-group initialization.





## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

