### PR TITLE
Revert "[BugFix] Fix OOB read in CUTLASS grouped GEMM with epilogue" (#38571)

### DIFF
--- a/csrc/cutlass_extensions/epilogue/broadcast_load_epilogue_array_c3x.hpp
+++ b/csrc/cutlass_extensions/epilogue/broadcast_load_epilogue_array_c3x.hpp
@@ -389,28 +389,20 @@ struct Sm90ColOrScalarBroadcastArray {
 
     CUTLASS_DEVICE void
     begin() {
+      cute::Tensor pred = make_tensor<bool>(shape(tCgCol));
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < size(pred); ++i) {
+        pred(i) = get<0>(tCcCol(i)) < m;
+      }
+
       if (!params.col_broadcast) {
         fill(tCrCol, *(params.ptr_col_array[group]));
         return;
       }
 
-      // tCgCol has layout (CPY,CPY_M,CPY_N,EPI_M,EPI_N) where CPY_N and
-      // EPI_N are stride-0 for the column broadcast. Slice those modes at
-      // index 0 to avoid redundant copies AND ensure pred/data consistency
-      static_assert(decltype(stride<2>(tCgCol))::value == 0, "Expected stride-0 CPY_N for col broadcast");
-      static_assert(decltype(stride<4>(tCgCol))::value == 0, "Expected stride-0 EPI_N for col broadcast");
-
-      auto tCgCol_s = tCgCol(_,_,0,_,0);      // (CPY,CPY_M,EPI_M)
-      auto tCrCol_s = tCrCol(_,_,0,_,0);      // (CPY,CPY_M,EPI_M)
-      auto tCcCol_s = tCcCol(_,_,0,_,0);      // (CPY,CPY_M,EPI_M)
-
-      cute::Tensor pred = make_tensor<bool>(shape(tCgCol_s));
-      CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < size(pred); ++i) {
-        pred(i) = get<0>(tCcCol_s(i)) < m;
-      }
-
-      copy_if(pred, tCgCol_s, tCrCol_s);
+      // Filter so we don't issue redundant copies over stride-0 modes
+      // (only works if 0-strides are in same location, which is by construction)
+      copy_if(pred, filter(tCgCol), filter(tCrCol));
     }
 
     template <typename ElementAccumulator, int FragmentSize>

--- a/csrc/cutlass_extensions/epilogue/broadcast_load_epilogue_c3x.hpp
+++ b/csrc/cutlass_extensions/epilogue/broadcast_load_epilogue_c3x.hpp
@@ -382,28 +382,20 @@ struct Sm90ColOrScalarBroadcast {
 
     CUTLASS_DEVICE void
     begin() {
+      cute::Tensor pred = make_tensor<bool>(shape(tCgCol));
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < size(pred); ++i) {
+        pred(i) = get<0>(tCcCol(i)) < m;
+      }
+
       if (!params.col_broadcast) {
         fill(tCrCol, *(params.ptr_col));
         return;
       }
 
-      // tCgCol has layout (CPY,CPY_M,CPY_N,EPI_M,EPI_N) where CPY_N and
-      // EPI_N are stride-0 for the column broadcast. Slice those modes at
-      // index 0 to avoid redundant copies AND ensure pred/data consistency
-      static_assert(decltype(stride<2>(tCgCol))::value == 0, "Expected stride-0 CPY_N for col broadcast");
-      static_assert(decltype(stride<4>(tCgCol))::value == 0, "Expected stride-0 EPI_N for col broadcast");
-
-      auto tCgCol_s = tCgCol(_,_,0,_,0);      // (CPY,CPY_M,EPI_M)
-      auto tCrCol_s = tCrCol(_,_,0,_,0);      // (CPY,CPY_M,EPI_M)
-      auto tCcCol_s = tCcCol(_,_,0,_,0);      // (CPY,CPY_M,EPI_M)
-
-      cute::Tensor pred = make_tensor<bool>(shape(tCgCol_s));
-      CUTLASS_PRAGMA_UNROLL
-      for (int i = 0; i < size(pred); ++i) {
-        pred(i) = get<0>(tCcCol_s(i)) < m;
-      }
-
-      copy_if(pred, tCgCol_s, tCrCol_s);
+      // Filter so we don't issue redundant copies over stride-0 modes
+      // (only works if 0-strides are in same location, which is by construction)
+      copy_if(pred, filter(tCgCol), filter(tCrCol));
     }
 
     template <typename ElementAccumulator, int FragmentSize>


### PR DESCRIPTION
## Revert of PR #38571

This reverts https://github.com/vllm-project/vllm/pull/38571 (merge commit f83de7196f0d589a1a5d71dd20e2d5867c361dd4).

### Reason
Nightly CI build [#60760](https://buildkite.com/vllm/ci/builds/60760) detected 1 new failure linked to this PR:
- **Kernels (B200)** — `test_cutedsl_moe.py::test_flashinfer_cutedsl_moe_masked` crashed with GPU coredump (Fatal Python error: Aborted, exit status 134) on B200

The PR modified CUTLASS extension epilogue headers (`broadcast_load_epilogue_array_c3x.hpp` and `broadcast_load_epilogue_c3x.hpp`), and the failing test exercises CUTLASS grouped GEMM on B200 GPUs.

---
*Auto-generated by CI failure analyzer*