### PR TITLE
[Bugfix] Fix DP port conflict during distributed initialization

### DIFF
--- a/tests/utils_/test_network_utils.py
+++ b/tests/utils_/test_network_utils.py
@@ -12,6 +12,7 @@ from vllm.utils.network_utils import (
     join_host_port,
     make_zmq_path,
     make_zmq_socket,
+    normalize_last_endpoint,
     split_host_port,
     split_zmq_path,
 )
@@ -144,3 +145,67 @@ def test_split_host_port():
 def test_join_host_port():
     assert join_host_port("127.0.0.1", 5555) == "127.0.0.1:5555"
     assert join_host_port("::1", 5555) == "[::1]:5555"
+
+
+def test_split_zmq_path_port_zero():
+    """Port 0 is a valid wildcard port for late binding."""
+    scheme, host, port = split_zmq_path("tcp://127.0.0.1:0")
+    assert scheme == "tcp"
+    assert host == "127.0.0.1"
+    assert port == "0"
+
+
+def test_zmq_late_binding_assigns_real_port():
+    """Binding to port 0 should assign a concrete non-zero port."""
+    ctx = zmq.Context()
+    try:
+        sock = ctx.socket(zmq.PULL)
+        sock.bind("tcp://127.0.0.1:0")
+        endpoint = sock.last_endpoint.decode("utf-8")
+        _, _, port_str = split_zmq_path(endpoint)
+        port = int(port_str)
+        assert port > 0
+        assert port <= 65535
+    finally:
+        sock.close()
+        ctx.term()
+
+
+def test_zmq_late_binding_ipv6_port_parsing():
+    """IPv6 late-bound endpoint should parse with the correct port."""
+    try:
+        s = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        s.close()
+    except OSError:
+        pytest.skip("IPv6 not supported on this system")
+
+    ctx = zmq.Context()
+    try:
+        sock = ctx.socket(zmq.PULL)
+        sock.setsockopt(zmq.IPV6, 1)
+        sock.bind("tcp://[::1]:0")
+        endpoint = sock.last_endpoint.decode("utf-8")
+        _, _, port_str = split_zmq_path(endpoint)
+        port = int(port_str)
+        assert port > 0
+    finally:
+        sock.close()
+        ctx.term()
+
+
+def test_get_tcp_uri_preserves_port_zero():
+    """TCP URI builder must preserve port=0 for late binding."""
+    addr = get_tcp_uri("127.0.0.1", 0)
+    assert addr == "tcp://127.0.0.1:0"
+
+
+def test_normalize_last_endpoint_preserves_original_host():
+    """Wildcard binds should keep the caller-visible host after binding."""
+
+    class DummySocket:
+        last_endpoint = b"tcp://0.0.0.0:45678"
+
+    assert (
+        normalize_last_endpoint(DummySocket(), "tcp://127.0.0.1:0")
+        == "tcp://127.0.0.1:45678"
+    )

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -32,10 +32,10 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.network_utils import (
     get_ip,
-    get_open_port,
     get_open_zmq_inproc_path,
     get_open_zmq_ipc_path,
     is_valid_ipv6_address,
+    split_zmq_path,
 )
 
 if TYPE_CHECKING:
@@ -413,13 +413,16 @@ class MessageQueue:
                 connect_ip = get_ip()
             self.remote_socket = context.socket(XPUB)
             self.remote_socket.setsockopt(XPUB_VERBOSE, True)
-            remote_subscribe_port = get_open_port()
             if is_valid_ipv6_address(connect_ip):
                 self.remote_socket.setsockopt(IPV6, 1)
                 remote_addr_ipv6 = True
                 connect_ip = f"[{connect_ip}]"
-            socket_addr = f"tcp://{connect_ip}:{remote_subscribe_port}"
-            self.remote_socket.bind(socket_addr)
+            # Bind to port 0 — OS assigns an available port atomically.
+            # This eliminates the TOCTOU race between port discovery and use.
+            self.remote_socket.bind(f"tcp://{connect_ip}:0")
+            actual_endpoint = self.remote_socket.last_endpoint.decode("utf-8")
+            _, _, _port_str = split_zmq_path(actual_endpoint)
+            remote_subscribe_port = int(_port_str)
             remote_subscribe_addr = f"tcp://{connect_ip}:{remote_subscribe_port}"
         else:
             remote_subscribe_addr = None

--- a/vllm/utils/network_utils.py
+++ b/vllm/utils/network_utils.py
@@ -10,7 +10,7 @@ from collections.abc import (
     Iterator,
     Sequence,
 )
-from typing import Any
+from typing import Any, Literal, overload
 from uuid import uuid4
 
 import psutil
@@ -182,7 +182,7 @@ def get_open_ports_list(count: int = 5) -> list[int]:
         return list(ports_set)
     else:
         while len(ports_set) < count:
-            ports_set.add(get_open_port())
+            ports_set.add(_get_open_port())
 
     return list(ports_set)
 
@@ -280,7 +280,95 @@ def make_zmq_path(scheme: str, host: str, port: int | None = None) -> str:
     return f"{scheme}://{host}:{port}"
 
 
+def is_wildcard_addr(path: str) -> bool:
+    """Return True if path is a TCP address with wildcard port (port 0).
+
+    Wildcard port addresses use port 0 to tell the OS to assign an available
+    port atomically on bind — eliminating the TOCTOU race condition where a
+    port is discovered free but stolen before it can be bound.
+
+    Args:
+        path: ZMQ address string, e.g. "tcp://192.168.1.5:0"
+
+    Returns:
+        True only for TCP addresses with port exactly 0.
+
+    Examples:
+        >>> is_wildcard_addr("tcp://127.0.0.1:0")
+        True
+        >>> is_wildcard_addr("tcp://[::1]:0")
+        True
+        >>> is_wildcard_addr("tcp://127.0.0.1:8080")
+        False
+        >>> is_wildcard_addr("ipc:///tmp/sock")
+        False
+    """
+    if not path.startswith("tcp://"):
+        return False
+    try:
+        _, _, port_str = split_zmq_path(path)
+        return port_str == "0"
+    except ValueError:
+        return False
+
+
+def normalize_last_endpoint(
+    sock: zmq.Socket | zmq.asyncio.Socket,  # type: ignore[name-defined]
+    original_path: str,
+) -> str:
+    """Return the actual bound address after a ZMQ wildcard bind.
+
+    After binding to a wildcard address (port 0), the OS assigns a real port.
+    last_endpoint may return 0.0.0.0 as the host instead of the specific IP
+    we intended. This function corrects that by preserving the original host
+    while taking the OS-assigned port.
+
+    Correctly handles both IPv4 and IPv6 addresses using split_zmq_path,
+    avoiding the bug in PR #30520 which used split(":")[-1] and broke on
+    IPv6 addresses like tcp://[::1]:59251.
+
+    Args:
+        sock: The bound ZMQ socket.
+        original_path: The wildcard address used for binding (e.g. "tcp://host:0").
+
+    Returns:
+        The actual address with OS-assigned port (e.g. "tcp://host:59251").
+    """
+    actual_endpoint = sock.last_endpoint.decode("utf-8")
+    _, _, port_str = split_zmq_path(actual_endpoint)
+    orig_scheme, orig_host, _ = split_zmq_path(original_path)
+    return make_zmq_path(orig_scheme, orig_host, int(port_str))
+
+
 # Adapted from: https://github.com/sgl-project/sglang/blob/v0.4.1/python/sglang/srt/utils.py#L783 # noqa: E501
+@overload
+def make_zmq_socket(
+    ctx: zmq.asyncio.Context | zmq.Context,  # type: ignore[name-defined]
+    path: str,
+    socket_type: Any,
+    bind: bool | None = ...,
+    identity: bytes | None = ...,
+    linger: int | None = ...,
+    router_handover: bool = ...,
+    *,
+    return_address: Literal[True],
+) -> tuple[zmq.Socket | zmq.asyncio.Socket, str]: ...  # type: ignore[name-defined]
+
+
+@overload
+def make_zmq_socket(
+    ctx: zmq.asyncio.Context | zmq.Context,  # type: ignore[name-defined]
+    path: str,
+    socket_type: Any,
+    bind: bool | None = ...,
+    identity: bytes | None = ...,
+    linger: int | None = ...,
+    router_handover: bool = ...,
+    *,
+    return_address: Literal[False] = ...,
+) -> zmq.Socket | zmq.asyncio.Socket: ...  # type: ignore[name-defined]
+
+
 def make_zmq_socket(
     ctx: zmq.asyncio.Context | zmq.Context,  # type: ignore[name-defined]
     path: str,
@@ -289,8 +377,33 @@ def make_zmq_socket(
     identity: bytes | None = None,
     linger: int | None = None,
     router_handover: bool = False,
-) -> zmq.Socket | zmq.asyncio.Socket:  # type: ignore[name-defined]
-    """Make a ZMQ socket with the proper bind/connect semantics."""
+    *,
+    return_address: bool = False,
+) -> zmq.Socket | zmq.asyncio.Socket | tuple[zmq.Socket | zmq.asyncio.Socket, str]:  # type: ignore[name-defined]
+    """Make a ZMQ socket with the proper bind/connect semantics.
+
+    Supports late binding for wildcard TCP addresses (port 0). When binding
+    to a wildcard address, the OS assigns an available port atomically,
+    eliminating TOCTOU race conditions (issue #28498).
+
+    Args:
+        ctx: ZMQ context (sync or async).
+        path: Socket address. Use port 0 for late binding, e.g. "tcp://host:0".
+        socket_type: ZMQ socket type (e.g. zmq.ROUTER, zmq.PULL).
+        bind: Whether to bind (True) or connect (False). If None, inferred
+            from socket_type.
+        identity: Optional ZMQ socket identity bytes.
+        linger: Optional linger value for socket close behaviour.
+        router_handover: If True, enables ROUTER_HANDOVER option.
+        return_address: If True, return (socket, actual_address) tuple.
+            For wildcard addresses, actual_address contains the OS-assigned
+            port. For non-wildcard addresses, actual_address equals path.
+            Default False preserves backward compatibility.
+
+    Returns:
+        Socket if return_address=False (default, backward compatible).
+        (socket, actual_address) tuple if return_address=True.
+    """
 
     mem = psutil.virtual_memory()
     socket = ctx.socket(socket_type)
@@ -336,6 +449,13 @@ def make_zmq_socket(
 
     if bind:
         socket.bind(path)
+        if return_address:
+            actual_address = (
+                normalize_last_endpoint(socket, path)
+                if is_wildcard_addr(path)
+                else path
+            )
+            return socket, actual_address
     else:
         socket.connect(path)
 

--- a/vllm/utils/network_utils.py
+++ b/vllm/utils/network_utils.py
@@ -335,6 +335,9 @@ def normalize_last_endpoint(
         The actual address with OS-assigned port (e.g. "tcp://host:59251").
     """
     actual_endpoint = sock.last_endpoint.decode("utf-8")
+    # Guard against non-TCP paths (IPC, inproc) — no port to parse.
+    if not actual_endpoint.startswith("tcp://"):
+        return actual_endpoint
     _, _, port_str = split_zmq_path(actual_endpoint)
     orig_scheme, orig_host, _ = split_zmq_path(original_path)
     return make_zmq_path(orig_scheme, orig_host, int(port_str))

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -11,7 +11,11 @@ import zmq
 
 from vllm.config import ParallelConfig
 from vllm.logger import init_logger
-from vllm.utils.network_utils import get_tcp_uri, make_zmq_socket
+from vllm.utils.network_utils import (
+    get_tcp_uri,
+    make_zmq_socket,
+    normalize_last_endpoint,
+)
 from vllm.utils.system_utils import get_mp_context, set_process_title
 from vllm.v1.engine import EngineCoreOutputs, EngineCoreRequestType
 from vllm.v1.serial_utils import MsgpackDecoder
@@ -234,9 +238,11 @@ class DPCoordinatorProc:
                 try:
                     zmq_addr_pipe.send(
                         (
-                            publish_front.getsockopt(zmq.LAST_ENDPOINT).decode(),
-                            output_back.getsockopt(zmq.LAST_ENDPOINT).decode(),
-                            publish_back.getsockopt(zmq.LAST_ENDPOINT).decode(),
+                            normalize_last_endpoint(
+                                publish_front, front_publish_address
+                            ),
+                            normalize_last_endpoint(output_back, back_output_address),
+                            normalize_last_endpoint(publish_back, back_publish_address),
                         )
                     )
                 finally:

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -521,15 +521,20 @@ class MPClient(EngineCoreClient):
             else:
                 # Engines are managed by this client.
                 addresses = get_engine_zmq_addresses(vllm_config)
-                self.input_socket = self.resources.input_socket = make_zmq_socket(
+                self.input_socket, addresses.inputs[0] = make_zmq_socket(
                     self.ctx,
                     addresses.inputs[0],
                     zmq.ROUTER,
                     bind=True,
                     router_handover=enable_input_socket_handover,
+                    return_address=True,
                 )
-                self.resources.output_socket = make_zmq_socket(
-                    self.ctx, addresses.outputs[0], zmq.PULL
+                self.resources.input_socket = self.input_socket
+                self.resources.output_socket, addresses.outputs[0] = make_zmq_socket(
+                    self.ctx,
+                    addresses.outputs[0],
+                    zmq.PULL,
+                    return_address=True,
                 )
 
                 with launch_core_engines(

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -23,7 +23,10 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.ray.ray_env import get_env_vars_to_copy
 from vllm.utils import numa_utils
-from vllm.utils.network_utils import get_open_zmq_ipc_path, zmq_socket_ctx
+from vllm.utils.network_utils import (
+    get_open_zmq_ipc_path,
+    make_zmq_socket,
+)
 from vllm.utils.system_utils import get_mp_context
 from vllm.v1.engine.coordinator import DPCoordinator
 from vllm.v1.executor import Executor
@@ -1068,39 +1071,55 @@ def launch_core_engines(
         local_handshake_address = handshake_address
         client_handshake_address = None
 
-    with zmq_socket_ctx(
-        local_handshake_address, zmq.ROUTER, bind=True
-    ) as handshake_socket:
-        # Start local engines.
-        if local_engine_count:
-            local_engine_manager = CoreEngineProcManager(
-                vllm_config=vllm_config,
-                executor_class=executor_class,
-                log_stats=log_stats,
-                handshake_address=handshake_address,
-                client_handshake_address=client_handshake_address,
-                local_client=True,
-                local_engine_count=local_engine_count,
-                start_index=dp_rank,
-                local_start_index=local_start_index or 0,
-                tensor_queue=tensor_queue,
-            )
-        else:
-            local_engine_manager = None
-
-        yield local_engine_manager, coordinator, addresses, tensor_queue
-
-        # Now wait for engines to start.
-        wait_for_engine_startup(
-            handshake_socket,
-            addresses,
-            engines_to_handshake,
-            parallel_config,
-            dp_size > 1 and vllm_config.model_config.is_moe,
-            vllm_config.cache_config,
-            local_engine_manager,
-            coordinator.proc if coordinator else None,
+    handshake_ctx = zmq.Context()  # type: ignore[attr-defined]
+    try:
+        handshake_socket, bound_handshake_address = cast(
+            tuple[zmq.Socket, str],
+            make_zmq_socket(
+                handshake_ctx,
+                local_handshake_address,
+                zmq.ROUTER,
+                bind=True,
+                return_address=True,
+            ),
         )
+        if client_handshake_address is None:
+            handshake_address = bound_handshake_address
+        try:
+            # Start local engines.
+            if local_engine_count:
+                local_engine_manager = CoreEngineProcManager(
+                    vllm_config=vllm_config,
+                    executor_class=executor_class,
+                    log_stats=log_stats,
+                    handshake_address=handshake_address,
+                    client_handshake_address=client_handshake_address,
+                    local_client=True,
+                    local_engine_count=local_engine_count,
+                    start_index=dp_rank,
+                    local_start_index=local_start_index or 0,
+                    tensor_queue=tensor_queue,
+                )
+            else:
+                local_engine_manager = None
+
+            yield local_engine_manager, coordinator, addresses, tensor_queue
+
+            # Now wait for engines to start.
+            wait_for_engine_startup(
+                handshake_socket,
+                addresses,
+                engines_to_handshake,
+                parallel_config,
+                dp_size > 1 and vllm_config.model_config.is_moe,
+                vllm_config.cache_config,
+                local_engine_manager,
+                coordinator.proc if coordinator else None,
+            )
+        finally:
+            handshake_socket.close(linger=0)
+    finally:
+        handshake_ctx.destroy(linger=0)
 
 
 def wait_for_engine_startup(

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -28,7 +28,7 @@ from torch.autograd.profiler import record_function
 import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.usage.usage_lib import UsageContext, is_usage_stats_enabled, usage_message
-from vllm.utils.network_utils import get_open_port, get_open_zmq_ipc_path, get_tcp_uri
+from vllm.utils.network_utils import get_open_zmq_ipc_path, get_tcp_uri
 from vllm.utils.system_utils import decorate_logs, kill_process_tree, set_process_title
 from vllm.v1.core.sched.output import SchedulerOutput
 
@@ -152,11 +152,7 @@ def get_engine_client_zmq_addr(local_only: bool, host: str, port: int = 0) -> st
     Otherwise, the provided host and port will be used to construct a TCP
     address (port == 0 means assign an available port)."""
 
-    return (
-        get_open_zmq_ipc_path()
-        if local_only
-        else (get_tcp_uri(host, port or get_open_port()))
-    )
+    return get_open_zmq_ipc_path() if local_only else (get_tcp_uri(host, port))
 
 
 class APIServerProcessManager:


### PR DESCRIPTION
[Bugfix] Fix DP port conflict race condition with late binding 
Fixes #28498

**Problem**
Port allocation race condition in data parallel (DP) mode causes `zmq.error.ZMQError: Address already in use` on multi-node setups. The issue occurs when:
1. vLLM discovers a free port via `get_open_port()`
2. Time passes (engine startup can take ~5 minutes)
3. Another process (e.g., Ray) binds to that port before vLLM can
4. vLLM's ZMQ socket bind fails

This is a classic TOCTOU (Time-Of-Check-Time-Of-Use) race condition between port discovery and actual socket binding.

**Solution**
Replace the "discover port first, bind later" pattern with late binding using wildcard port `0`:
- Bind ZMQ sockets to `tcp://host:0` immediately
- OS assigns an available port atomically at bind time
- Retrieve actual bound port from `socket.last_endpoint`
- Eliminates the race window entirely

**Changes**
1. **vllm/v1/utils.py**: Remove eager port allocation in `get_engine_client_zmq_addr()` - let port=0 pass through to late binding
2. **vllm/utils/network_utils.py**: 
   - Add `is_wildcard_addr()` to detect `tcp://host:0` addresses
   - Add `normalize_last_endpoint()` to preserve caller-visible host while using OS-assigned port
   - Extend `make_zmq_socket()` with `return_address=True` parameter to return actual bound address
3. **vllm/v1/engine/core_client.py**: Update managed engine socket creation to capture actual addresses after bind
4. **vllm/v1/engine/utils.py**: Update handshake socket creation to use late binding and resolve address before engine startup
5. **vllm/v1/engine/coordinator.py**: Use `normalize_last_endpoint()` when sending resolved addresses through pipes
6. **vllm/distributed/device_communicators/shm_broadcast.py**: Replace `get_open_port()` with direct port 0 binding for XPUB socket
7. **tests/utils_/test_network_utils.py**: Add comprehensive tests for wildcard binding, IPv6 parsing, and address normalization

**Testing**
- All 20 existing network_utils tests pass
- New tests verify:
  - Port 0 parsing for IPv4 and IPv6
  - Actual port assignment on bind
  - Host preservation in `normalize_last_endpoint()`
  - TCP URI builder preserves port 0

**Backward Compatibility**
Fully backward compatible. The `return_address=True` parameter default is False, preserving existing behavior for callers that don't need it.

