### PR TITLE
Add LFU policy for CPU KV offloading

### DIFF
--- a/tests/v1/kv_connector/unit/test_config.py
+++ b/tests/v1/kv_connector/unit/test_config.py
@@ -5,9 +5,16 @@
 
 import pytest
 
-from vllm.config import CacheConfig, KVTransferConfig, ParallelConfig, VllmConfig
+from vllm.config import (
+    CacheConfig,
+    DeviceConfig,
+    KVTransferConfig,
+    ParallelConfig,
+    VllmConfig,
+)
 
 pytestmark = pytest.mark.cpu_test
+pytestmark = [pytest.mark.cpu_test, pytest.mark.skip_global_cleanup]
 
 
 @pytest.mark.parametrize(
@@ -37,6 +44,7 @@ def test_kv_connector(
             kv_offloading_backend=kv_offloading_backend,
             kv_offloading_size=kv_offloading_size,
         ),
+        device_config=DeviceConfig("cpu"),
         kv_transfer_config=kv_transfer_config,
         parallel_config=ParallelConfig(
             tensor_parallel_size=tp, pipeline_parallel_size=pp
@@ -72,6 +80,7 @@ def test_kv_offloading_size_only_uses_native_default():
             kv_offloading_size=4.0,
             # kv_offloading_backend not set, should default to "native"
         ),
+        device_config=DeviceConfig("cpu"),
     )
 
     kv_transfer_config = vllm_config.kv_transfer_config
@@ -79,3 +88,25 @@ def test_kv_offloading_size_only_uses_native_default():
     assert kv_transfer_config.kv_connector == "OffloadingConnector"
     assert kv_transfer_config.kv_role == "kv_both"
     assert kv_connector_extra_config["cpu_bytes_to_use"] == 4.0 * (1 << 30)
+
+
+def test_kv_offloading_preserves_eviction_policy_extra_config():
+    """Test that native KV offloading preserves the configured eviction policy."""
+    vllm_config = VllmConfig(
+        cache_config=CacheConfig(
+            kv_offloading_size=4.0,
+            kv_offloading_backend="native",
+        ),
+        device_config=DeviceConfig("cpu"),
+        kv_transfer_config=KVTransferConfig(
+            kv_connector_extra_config={"eviction_policy": "lfu"}
+        ),
+    )
+
+    kv_transfer_config = vllm_config.kv_transfer_config
+    assert kv_transfer_config is not None
+    kv_connector_extra_config = kv_transfer_config.kv_connector_extra_config
+    assert kv_transfer_config.kv_connector == "OffloadingConnector"
+    assert kv_transfer_config.kv_role == "kv_both"
+    assert kv_connector_extra_config["cpu_bytes_to_use"] == 4.0 * (1 << 30)
+    assert kv_connector_extra_config["eviction_policy"] == "lfu"

--- a/tests/v1/kv_offload/test_cpu_manager.py
+++ b/tests/v1/kv_offload/test_cpu_manager.py
@@ -15,8 +15,11 @@ from vllm.v1.kv_offload.abstract import (
 )
 from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
 from vllm.v1.kv_offload.cpu.policies.arc import ARCCachePolicy
+from vllm.v1.kv_offload.cpu.policies.lfu import LFUCachePolicy
 from vllm.v1.kv_offload.mediums import CPULoadStoreSpec
 from vllm.v1.kv_offload.reuse_manager import FilterReusedOffloadingManager
+
+pytestmark = pytest.mark.skip_global_cleanup
 
 
 @dataclass
@@ -82,7 +85,7 @@ def verify_events(
     assert tuple(stores) == to_key_sets(expected_stores)
 
 
-@pytest.mark.parametrize("eviction_policy", ["lru", "arc"])
+@pytest.mark.parametrize("eviction_policy", ["lru", "lfu", "arc"])
 def test_already_stored_block_not_evicted_during_prepare_store(eviction_policy):
     """
     Regression test: a block that is already stored must not be evicted
@@ -541,6 +544,126 @@ class TestARCPolicy:
         # verify events
         events = list(cpu_manager.take_events())
         assert len(events) > 0  # should have store and eviction events
+
+
+class TestLFUPolicy:
+    """Unit tests for CPUOffloadingManager with LFU eviction policy."""
+
+    def _make_manager(
+        self, num_blocks: int = 4, enable_events: bool = True
+    ) -> tuple[CPUOffloadingManager, LFUCachePolicy]:
+        manager = CPUOffloadingManager(
+            block_size=256,
+            num_blocks=num_blocks,
+            cache_policy="lfu",
+            enable_events=enable_events,
+        )
+        policy = manager._policy
+        assert isinstance(policy, LFUCachePolicy)
+        return manager, policy
+
+    def test_eviction_prefers_low_frequency_blocks(self):
+        manager, policy = self._make_manager(enable_events=False)
+
+        manager.prepare_store(to_keys([1, 2, 3, 4]))
+        manager.complete_store(to_keys([1, 2, 3, 4]))
+
+        manager.touch(to_keys([1, 1, 2]))
+
+        output = manager.prepare_store(to_keys([5]))
+        verify_store_output(
+            output,
+            ExpectedPrepareStoreOutput(
+                keys_to_store=[5],
+                store_block_ids=[2],
+                evicted_keys=[3],
+            ),
+        )
+
+        assert policy.freqs[to_keys([1])[0]] == 3
+        assert policy.freqs[to_keys([2])[0]] == 2
+        assert to_keys([3])[0] not in policy.freqs
+        assert policy.freqs[to_keys([4])[0]] == 1
+
+    def test_touch_breaks_frequency_ties_by_recency(self):
+        manager, _ = self._make_manager(enable_events=False)
+
+        manager.prepare_store(to_keys([1, 2, 3, 4]))
+        manager.complete_store(to_keys([1, 2, 3, 4]))
+
+        manager.touch(to_keys([1, 2, 3, 4]))
+        manager.touch(to_keys([2, 3, 4]))
+
+        output = manager.prepare_store(to_keys([5]))
+        verify_store_output(
+            output,
+            ExpectedPrepareStoreOutput(
+                keys_to_store=[5],
+                store_block_ids=[0],
+                evicted_keys=[1],
+            ),
+        )
+
+    def test_loaded_blocks_are_not_evicted(self):
+        manager, _ = self._make_manager(enable_events=False)
+
+        manager.prepare_store(to_keys([1, 2, 3, 4]))
+        manager.complete_store(to_keys([1, 2, 3, 4]))
+
+        manager.touch(to_keys([1, 2, 3]))
+        load_spec = manager.prepare_load(to_keys([4]))
+        verify_load_output(load_spec, [3])
+
+        verify_store_output(
+            manager.prepare_store(to_keys([5])),
+            ExpectedPrepareStoreOutput(
+                keys_to_store=[5],
+                store_block_ids=[2],
+                evicted_keys=[3],
+            ),
+        )
+        manager.complete_load(to_keys([4]))
+
+
+def _run_policy_eval(policy: str, num_blocks: int) -> int:
+    manager = CPUOffloadingManager(
+        block_size=256,
+        num_blocks=num_blocks,
+        cache_policy=policy,  # type: ignore[arg-type]
+        enable_events=False,
+    )
+
+    manager.prepare_store(to_keys(list(range(1, num_blocks + 1))))
+    manager.complete_store(to_keys(list(range(1, num_blocks + 1))))
+
+    hot_key = to_keys([1])
+    manager.touch(hot_key * 3)
+
+    # Refresh the cold keys after the hot-key training so the hot key becomes
+    # the LRU candidate despite having the highest frequency.
+    manager.touch(to_keys([2, 3, 4]))
+
+    # Insert unique cold keys to force eviction pressure without refreshing
+    # recency on the hot key. LRU should evict the hot key, LFU should not.
+    for cold_key in [5]:
+        output = manager.prepare_store(to_keys([cold_key]))
+        assert output is not None
+        manager.complete_store(to_keys([cold_key]))
+
+    return manager.lookup(hot_key)
+
+
+def test_lfu_eval_reduces_hot_key_eviction_against_lru():
+    """
+    Synthetic evaluation:
+    after building frequency on one hot key, unique cold keys create pressure.
+    LFU should retain the hot key where pure LRU evicts it.
+    """
+    lru_hits = _run_policy_eval("lru", num_blocks=4)
+    lfu_hits = _run_policy_eval("lfu", num_blocks=4)
+
+    assert lru_hits == 0
+    assert lfu_hits == 1
 
 
 def test_filter_reused_manager():

--- a/vllm/v1/kv_offload/cpu/manager.py
+++ b/vllm/v1/kv_offload/cpu/manager.py
@@ -12,18 +12,21 @@ from vllm.v1.kv_offload.abstract import (
 )
 from vllm.v1.kv_offload.cpu.policies.abstract import BlockStatus, CachePolicy
 from vllm.v1.kv_offload.cpu.policies.arc import ARCCachePolicy
+from vllm.v1.kv_offload.cpu.policies.lfu import LFUCachePolicy
 from vllm.v1.kv_offload.cpu.policies.lru import LRUCachePolicy
 from vllm.v1.kv_offload.mediums import CPULoadStoreSpec
 
 _CACHE_POLICIES: dict[str, type[CachePolicy]] = {
     "lru": LRUCachePolicy,
     "arc": ARCCachePolicy,
+    "lfu": LFUCachePolicy,
 }
+SUPPORTED_CACHE_POLICIES = tuple(_CACHE_POLICIES)
 
 
 class CPUOffloadingManager(OffloadingManager):
     """
-    An OffloadingManager with a pluggable CachePolicy (LRU or ARC).
+    An OffloadingManager with a pluggable CachePolicy (LRU, LFU, or ARC).
 
     The manager owns all shared logic: ref-counting, event emission,
     block pool management, and the prepare_store/complete_store skeletons.
@@ -35,7 +38,7 @@ class CPUOffloadingManager(OffloadingManager):
         self,
         block_size: int,
         num_blocks: int,
-        cache_policy: Literal["lru", "arc"] = "lru",
+        cache_policy: Literal["lru", "lfu", "arc"] = "lru",
         enable_events: bool = False,
     ):
         self.block_size: int = block_size

--- a/vllm/v1/kv_offload/cpu/policies/lfu.py
+++ b/vllm/v1/kv_offload/cpu/policies/lfu.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections import OrderedDict
+from collections.abc import Iterable
+
+from vllm.v1.kv_offload.abstract import OffloadKey
+from vllm.v1.kv_offload.cpu.policies.abstract import BlockStatus, CachePolicy
+
+
+class LFUCachePolicy(CachePolicy):
+    """LFU cache policy with recency tie-breaking within each frequency."""
+
+    def __init__(self, cache_capacity: int):
+        self.cache_capacity = cache_capacity
+        self.blocks: dict[OffloadKey, BlockStatus] = {}
+        self.freqs: dict[OffloadKey, int] = {}
+        self.freq_buckets: dict[int, OrderedDict[OffloadKey, None]] = {}
+        self.min_freq = 0
+        self.max_freq = 0
+
+    def get(self, key: OffloadKey) -> BlockStatus | None:
+        return self.blocks.get(key)
+
+    def insert(self, key: OffloadKey, block: BlockStatus) -> None:
+        self.blocks[key] = block
+        self.freqs[key] = 1
+        self.freq_buckets.setdefault(1, OrderedDict())[key] = None
+        self.min_freq = 1
+        self.max_freq = max(self.max_freq, 1)
+
+    def remove(self, key: OffloadKey) -> None:
+        self._remove(key, update_min_freq=True)
+
+    def _remove(self, key: OffloadKey, update_min_freq: bool) -> None:
+        freq = self.freqs.pop(key)
+        del self.blocks[key]
+        bucket = self.freq_buckets[freq]
+        del bucket[key]
+        if not bucket:
+            del self.freq_buckets[freq]
+            if update_min_freq and self.min_freq == freq:
+                self._update_min_freq()
+            if self.max_freq == freq:
+                self._update_max_freq()
+
+    def touch(self, keys: Iterable[OffloadKey]) -> None:
+        for key in reversed(list(keys)):
+            if key not in self.blocks:
+                continue
+
+            old_freq = self.freqs[key]
+            new_freq = old_freq + 1
+
+            old_bucket = self.freq_buckets[old_freq]
+            del old_bucket[key]
+            if not old_bucket:
+                del self.freq_buckets[old_freq]
+                if self.min_freq == old_freq:
+                    self.min_freq = new_freq
+
+            self.freqs[key] = new_freq
+            self.freq_buckets.setdefault(new_freq, OrderedDict())[key] = None
+            self.max_freq = max(self.max_freq, new_freq)
+
+    def evict(
+        self, n: int, protected: set[OffloadKey]
+    ) -> list[tuple[OffloadKey, BlockStatus]] | None:
+        if n == 0:
+            return []
+
+        candidates: list[tuple[OffloadKey, BlockStatus]] = []
+        already_selected: set[OffloadKey] = set()
+
+        freq = self.min_freq
+        while freq <= self.max_freq and len(candidates) < n:
+            bucket = self.freq_buckets.get(freq)
+            if bucket is None:
+                freq += 1
+                continue
+
+            for key in bucket:
+                block = self.blocks[key]
+                if (
+                    block.ref_cnt == 0
+                    and key not in protected
+                    and key not in already_selected
+                ):
+                    candidates.append((key, block))
+                    already_selected.add(key)
+                    if len(candidates) == n:
+                        break
+            freq += 1
+
+        if len(candidates) < n:
+            return None
+
+        for key, _ in candidates:
+            self._remove(key, update_min_freq=False)
+
+        self._update_min_freq()
+        self._update_max_freq()
+
+        return candidates
+
+    def _update_min_freq(self) -> None:
+        self.min_freq = min(self.freq_buckets, default=0)
+
+    def _update_max_freq(self) -> None:
+        self.max_freq = max(self.freq_buckets, default=0)

--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -7,6 +7,7 @@ from vllm.platforms import current_platform
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.kv_offload.abstract import LoadStoreSpec, OffloadingManager
 from vllm.v1.kv_offload.cpu.manager import CPUOffloadingManager
+from vllm.v1.kv_offload.cpu.manager import SUPPORTED_CACHE_POLICIES
 from vllm.v1.kv_offload.mediums import CPULoadStoreSpec, GPULoadStoreSpec
 from vllm.v1.kv_offload.reuse_manager import FilterReusedOffloadingManager
 from vllm.v1.kv_offload.spec import CanonicalKVCaches, OffloadingSpec
@@ -52,6 +53,11 @@ class CPUOffloadingSpec(OffloadingSpec):
         self._handlers: CpuGpuOffloadingHandlers | None = None
 
         self.eviction_policy: str = self.extra_config.get("eviction_policy", "lru")
+        if self.eviction_policy not in SUPPORTED_CACHE_POLICIES:
+            raise ValueError(
+                f"Unsupported KV offloading eviction_policy: {self.eviction_policy!r}. "
+                f"Supported policies: {SUPPORTED_CACHE_POLICIES}"
+            )
 
     def get_manager(self) -> OffloadingManager:
         if not self._manager:


### PR DESCRIPTION


## Purpose

- Wire LFU into the existing cache policy interface and validate `eviction_policy` values in CPU offloading config.
- Add unit/config tests. 
- Default remains `lru`.

## Test Plan

Test Commands:

- `PYTHONPATH=$PWD python -m pytest tests/v1/kv_offload/test_cpu_manager.py -q`
- `PYTHONPATH=$PWD python -m pytest tests/v1/kv_connector/unit/test_config.py -q`

## Test Result

- `tests/v1/kv_offload/test_cpu_manager.py`: 18 passed
- `tests/v1/kv_connector/unit/test_config.py`: 7 passed

## Duplicate-work checks

- Checked existing issues and PRs.
- No open PR found that adds LFU to CPU KV offloading.
- This PR limited in scope to LFU policy wiring, validation, and tests.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

