### PR TITLE
[XPU] Fix all_reduce precision under torch.compile using functional collective

### DIFF
--- a/vllm/distributed/device_communicators/xpu_communicator.py
+++ b/vllm/distributed/device_communicators/xpu_communicator.py
@@ -4,6 +4,7 @@
 
 import torch
 import torch.distributed as dist
+import torch.distributed._functional_collectives as funcol
 from torch.distributed import ProcessGroup
 
 from vllm.logger import init_logger
@@ -48,8 +49,16 @@ class XpuCommunicator(DeviceCommunicatorBase):
                 logger.info("Using AgRs manager on XPU device.")
 
     def all_reduce(self, input_) -> torch.Tensor:
-        dist.all_reduce(input_, group=self.device_group)
-        return input_
+        if torch.compiler.is_compiling():
+            # Use functional all_reduce so torch.compile can correctly track the
+            # output as a new tensor rather than an in-place mutation of `input_`.
+            # In-place dist.all_reduce (even on a clone) causes precision issues
+            # under torch.compile due to incorrect aliasing / mutation analysis.
+            output = funcol.all_reduce(input_, reduceOp="sum", group=self.device_group)
+            return funcol.wait_tensor(output)
+        else:
+            dist.all_reduce(input_, group=self.device_group)
+            return input_
 
     def reduce_scatter(self, input_: torch.Tensor, dim: int = -1):
         world_size = self.world_size


### PR DESCRIPTION





## Purpose
 **Problem**

  When running vLLM with torch.compile enabled on XPU, XpuCommunicator.all_reduce produces incorrect numerical results.

  The root cause is that dist.all_reduce is an in-place operation. Under torch.compile, the compiler performs aliasing and mutation analysis over the traced graph leading to silent precision errors.

  **Fix**

  use  out_place version of all_reduce : **torch.distributed._functional_collectives.all_reduce** 

   
## Test Plan

## Test Result

**latency**:

command:  vllm bench latency --model=meta-llama/Llama-3.1-8B -tp 2 
**Median latency**
|Configuration               |     Main        |  PR                 |
|---------------------  |--------|--------|
|  default                        |     2.6956s  |   2.6755s       |
|  --enforce-eager        |     2.6439s  |   2.6457s       |



**lm_eval:**
 **command**:  
- **compile**: bash run-lm-eval-gsm-vllm-baseline.sh -m meta-llama/Llama-3.1-8B,dtype=bfloat16 -b 20 -l 250 -f 5 -t 2
-  **eager**: bash run-lm-eval-gsm-vllm-baseline.sh -m meta-llama/Llama-3.1-8B,dtype=bfloat16,enforce_eager=True -b 20 -l 250 -f 5 -t 2

**Main** :
**compile**: 

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.0 |±  |0.0|
|     |       |strict-match    |     5|exact_match|↑  | 0.0|±  |0.0|

**eager**: 
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.52|±  |0.0317|
|     |       |strict-match    |     5|exact_match|↑  | 0.52|±  |0.0317|

**PR**:
**compile**: 
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  | 0.52|±  |0.0317|
|     |       |strict-match    |     5|exact_match|↑  | 0.52|±  |0.0317|

**eager**: 
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.512|±  |0.0317|
|     |       |strict-match    |     5|exact_match|↑  |0.512|±  |0.0317|

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

