### PR TITLE
[Bugfix] Specify enable_kv_cache_events to prevent falsely disabling HMA in VllmConfig

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1229,7 +1229,10 @@ class VllmConfig:
         if not current_platform.support_hybrid_kv_cache():
             # Hybrid KV cache manager is not supported on non-GPU platforms.
             need_disable_hybrid_kv_cache_manager = True
-        if self.kv_events_config is not None:
+        if (
+            self.kv_events_config is not None
+            and self.kv_events_config.enable_kv_cache_events
+        ):
             # Hybrid KV cache manager is not compatible with KV events.
             need_disable_hybrid_kv_cache_manager = True
         if (


### PR DESCRIPTION



## Purpose

Fixed a logic flaw in the `__post_init__` method of the `VllmConfig` class, which forces the `True` value for the `need_disable_hybrid_kv_cache_manager` variable even when KV cache events are disabled.

The issue occurs when trying to launch VLLM with Dynamo (tested on version v1.0.1) and loading a hybrid model such as `Qwen/Qwen3-Next-80B-A3B-Instruct` with the `--no-disable-hybrid-kv-cache-manager` flag

### Changes

Fixed conditional logic which requires the hybrid KV cache manager to be disabled when KV cache events are enabled.

## Test Plan

Pass

## Test Result

Pass

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

