### PR TITLE
[Misc] Update deprecation warning for --model flag

### DIFF
--- a/vllm/utils/argparse_utils.py
+++ b/vllm/utils/argparse_utils.py
@@ -192,7 +192,7 @@ class FlexibleArgumentParser(ArgumentParser):
                     "With `vllm serve`, you should provide the model as a "
                     "positional argument or in a config file instead of via "
                     "the `--model` option. "
-                    "The `--model` option will be removed in v0.13."
+                    "The `--model` option will be removed in a future version."
                 )
 
                 if args[model_idx] == "--model":


### PR DESCRIPTION
## Purpose
Fixes #39506

### Problem 
The deprecation warning for the `--model` flag in `vllm serve` currently references removal in v0.13.
Since vLLM is now at v0.19, this warning is outdated and misleading.

### Solution 
Update the warning message to refer to "a future version" instead of a specific outdated version, so it remains accurate for current and future users.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

