### PR TITLE
[Kernel] Batch invariant NVFP4 Triton MoE backend

### DIFF
--- a/tests/kernels/quantization/test_batch_invariant_fp4_moe.py
+++ b/tests/kernels/quantization/test_batch_invariant_fp4_moe.py
@@ -33,16 +33,9 @@ from vllm.triton_utils import tl
 from vllm.triton_utils.allocation import set_triton_allocator
 from vllm.utils.torch_utils import set_random_seed
 
-HAS_SM90 = current_platform.has_device_capability(90)
-HAS_SM100 = current_platform.has_device_capability(100)
-REQUIRES_SM100 = pytest.mark.skipif(
-    not HAS_SM100,
-    reason="Some batch-invariant NVFP4 MoE coverage requires Blackwell (sm100+).",
-)
-
-if not HAS_SM90:
+if not current_platform.has_device_capability(100):
     pytest.skip(
-        reason="Batch-invariant FP4 MoE requires Hopper or newer (sm90+).",
+        reason="Batch-invariant FP4 MoE requires Blackwell or newer (sm100+).",
         allow_module_level=True,
     )
 
@@ -271,7 +264,6 @@ def _run_batch_invariant_nvfp4(
     return output
 
 
-@REQUIRES_SM100
 @pytest.mark.parametrize(
     "topk,apply_router_weight_on_input",
     BATCH_INVARIANT_CASES,
@@ -346,7 +338,6 @@ def test_batch_invariant_nvfp4_moe_matches_cutlass(
         torch.testing.assert_close(fallback_out, cutlass_out, atol=1e-1, rtol=1e-1)
 
 
-@REQUIRES_SM100
 @pytest.mark.parametrize(
     "topk,apply_router_weight_on_input",
     BATCH_INVARIANT_CASES,
@@ -425,7 +416,6 @@ def test_batch_invariant_nvfp4_moe_batch_size_invariance(
     assert torch.equal(out_single[0], out_batch[0])
 
 
-@REQUIRES_SM100
 @torch.inference_mode()
 def test_batch_invariant_nvfp4_moe_all_invalid_routes_return_zero() -> None:
     set_random_seed(31)
@@ -463,7 +453,6 @@ def test_batch_invariant_nvfp4_moe_all_invalid_routes_return_zero() -> None:
     torch.testing.assert_close(out, torch.zeros_like(out), atol=0.0, rtol=0.0)
 
 
-@REQUIRES_SM100
 @torch.inference_mode()
 def test_grouped_matmul_nvfp4_packed_matches_cutlass_reference() -> None:
     set_random_seed(17)

--- a/tests/kernels/quantization/test_batch_invariant_fp4_moe.py
+++ b/tests/kernels/quantization/test_batch_invariant_fp4_moe.py
@@ -56,6 +56,12 @@ DTYPE = torch.bfloat16
 DEVICE = "cuda:0"
 FLOAT8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
 FLOAT4_E2M1_MAX = 6.0
+BATCH_INVARIANT_CASES = [
+    (1, False),
+    (2, False),
+    (4, False),
+    (1, True),
+]
 
 
 @pytest.fixture(autouse=True)
@@ -112,6 +118,52 @@ def _global_scale(x: torch.Tensor) -> torch.Tensor:
     return (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / x.abs().max()).to(torch.float32)
 
 
+def _make_nvfp4_weights_and_scales(
+    *,
+    e: int,
+    n: int,
+    k: int,
+    scale_source: torch.Tensor,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    (_, w1_q, w1_blockscale, w1_gs), (_, w2_q, w2_blockscale, w2_gs) = (
+        make_test_weights(
+            e,
+            n,
+            k,
+            in_dtype=DTYPE,
+            quant_dtype="nvfp4",
+            block_shape=None,
+            per_out_ch_quant=False,
+        )
+    )
+    assert w1_blockscale is not None and w2_blockscale is not None
+    assert w1_gs is not None and w2_gs is not None
+
+    a1_gscale = _global_scale(scale_source).expand(e).contiguous()
+    a2_gscale = _global_scale(scale_source).expand(e).contiguous()
+    g1_alphas = ((1.0 / w1_gs) / a1_gscale).to(torch.float32)
+    g2_alphas = ((1.0 / w2_gs) / a2_gscale).to(torch.float32)
+    return (
+        w1_q,
+        w1_blockscale,
+        w2_q,
+        w2_blockscale,
+        a1_gscale,
+        a2_gscale,
+        g1_alphas,
+        g2_alphas,
+    )
+
+
 def _make_nvfp4_moe_tensors(
     *,
     m: int,
@@ -133,33 +185,27 @@ def _make_nvfp4_moe_tensors(
     torch.Tensor,
 ]:
     hidden_states = torch.randn((m, k), device=DEVICE, dtype=DTYPE) / 10
-    (_, w1_q, w1_blockscale, w1_gs), (_, w2_q, w2_blockscale, w2_gs) = (
-        make_test_weights(
-            e,
-            n,
-            k,
-            in_dtype=DTYPE,
-            quant_dtype="nvfp4",
-            block_shape=None,
-            per_out_ch_quant=False,
-        )
+    (
+        w1_q,
+        w1_blockscale,
+        w2_q,
+        w2_blockscale,
+        a1_gscale,
+        a2_gscale,
+        g1_alphas,
+        g2_alphas,
+    ) = _make_nvfp4_weights_and_scales(
+        e=e,
+        n=n,
+        k=k,
+        scale_source=hidden_states,
     )
-    assert w1_blockscale is not None and w2_blockscale is not None
-    assert w1_gs is not None and w2_gs is not None
 
     score = torch.randn((m, e), device=DEVICE, dtype=DTYPE)
     topk_weights, topk_ids, _ = fused_topk(
         hidden_states, score, topk, renormalize=False
     )
 
-    # Use realistic (non-trivial) per-expert activation global scales so that
-    # the alpha fusion in process_weights_after_loading is actually exercised.
-    # Trivial gscale=1.0 would mask missing fusion since multiplying by 1 is
-    # identity.
-    a1_gscale = _global_scale(hidden_states).expand(e).contiguous()
-    a2_gscale = _global_scale(hidden_states).expand(e).contiguous()
-    g1_alphas = ((1.0 / w1_gs) / a1_gscale).to(torch.float32)
-    g2_alphas = ((1.0 / w2_gs) / a2_gscale).to(torch.float32)
     return (
         hidden_states,
         topk_weights,
@@ -175,15 +221,60 @@ def _make_nvfp4_moe_tensors(
     )
 
 
+def _run_batch_invariant_nvfp4(
+    *,
+    hidden_states: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+    w1_q: torch.Tensor,
+    w1_blockscale: torch.Tensor,
+    w2_q: torch.Tensor,
+    w2_blockscale: torch.Tensor,
+    a1_gscale: torch.Tensor,
+    a2_gscale: torch.Tensor,
+    g1_alphas: torch.Tensor,
+    g2_alphas: torch.Tensor,
+    activation: MoEActivation = MoEActivation.SILU,
+    apply_router_weight_on_input: bool = False,
+    expert_map: torch.Tensor | None = None,
+) -> torch.Tensor:
+    workspace13, workspace2 = _batch_invariant_fp4_workspaces(
+        m=hidden_states.shape[0],
+        topk=topk_ids.shape[1],
+        w1_row_dim=w1_q.shape[1],
+        hidden_dim=hidden_states.shape[1],
+        activation=activation,
+        device=hidden_states.device,
+        dtype=hidden_states.dtype,
+    )
+    output = torch.empty_like(hidden_states)
+    fused_moe_batch_invariant_nvfp4(
+        hidden_states=hidden_states,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        w13_weight=w1_q,
+        w13_weight_scale=w1_blockscale,
+        w2_weight=w2_q,
+        w2_weight_scale=w2_blockscale,
+        a1_gscale=a1_gscale,
+        g1_alphas=g1_alphas,
+        a2_gscale=a2_gscale,
+        g2_alphas=g2_alphas,
+        activation=activation,
+        workspace13=workspace13,
+        workspace2=workspace2,
+        output=output,
+        workspace=_make_nvfp4_workspace(w1_q.shape[0]),
+        apply_router_weight_on_input=apply_router_weight_on_input,
+        expert_map=expert_map,
+    )
+    return output
+
+
 @REQUIRES_SM100
 @pytest.mark.parametrize(
     "topk,apply_router_weight_on_input",
-    [
-        (1, False),
-        (2, False),
-        (4, False),
-        (1, True),
-    ],
+    BATCH_INVARIANT_CASES,
 )
 @torch.inference_mode()
 def test_batch_invariant_nvfp4_moe_matches_cutlass(
@@ -208,16 +299,6 @@ def test_batch_invariant_nvfp4_moe_matches_cutlass(
             g1_alphas,
             g2_alphas,
         ) = _make_nvfp4_moe_tensors(m=32, n=128, k=128, e=8, topk=topk)
-
-        w13, w2 = _batch_invariant_fp4_workspaces(
-            m=32,
-            topk=topk,
-            w1_row_dim=w1_q.shape[1],
-            hidden_dim=128,
-            activation=MoEActivation.SILU,
-            device=DEVICE,
-            dtype=DTYPE,
-        )
 
         quant_config = nvfp4_moe_quant_config(
             g1_alphas=g1_alphas,
@@ -248,24 +329,18 @@ def test_batch_invariant_nvfp4_moe_matches_cutlass(
             apply_router_weight_on_input=apply_router_weight_on_input,
         )
 
-        fallback_out = torch.empty_like(hidden_states)
-        fused_moe_batch_invariant_nvfp4(
+        fallback_out = _run_batch_invariant_nvfp4(
             hidden_states=hidden_states,
-            topk_ids=topk_ids,
             topk_weights=topk_weights,
-            w13_weight=w1_q,
-            w13_weight_scale=w1_blockscale,
-            w2_weight=w2_q,
-            w2_weight_scale=w2_blockscale,
+            topk_ids=topk_ids,
+            w1_q=w1_q,
+            w1_blockscale=w1_blockscale,
+            w2_q=w2_q,
+            w2_blockscale=w2_blockscale,
             a1_gscale=a1_gscale,
-            g1_alphas=g1_alphas,
             a2_gscale=a2_gscale,
+            g1_alphas=g1_alphas,
             g2_alphas=g2_alphas,
-            activation=MoEActivation.SILU,
-            workspace13=w13,
-            workspace2=w2,
-            output=fallback_out,
-            workspace=_make_nvfp4_workspace(8),
             apply_router_weight_on_input=apply_router_weight_on_input,
         )
         torch.testing.assert_close(fallback_out, cutlass_out, atol=1e-1, rtol=1e-1)
@@ -274,12 +349,7 @@ def test_batch_invariant_nvfp4_moe_matches_cutlass(
 @REQUIRES_SM100
 @pytest.mark.parametrize(
     "topk,apply_router_weight_on_input",
-    [
-        (1, False),
-        (2, False),
-        (4, False),
-        (1, True),
-    ],
+    BATCH_INVARIANT_CASES,
 )
 @torch.inference_mode()
 def test_batch_invariant_nvfp4_moe_batch_size_invariance(
@@ -293,24 +363,21 @@ def test_batch_invariant_nvfp4_moe_batch_size_invariance(
         [x_single, torch.randn((7, k), device=DEVICE, dtype=DTYPE) / 10], dim=0
     )
 
-    (_, w1_q, w1_blockscale, w1_gs), (_, w2_q, w2_blockscale, w2_gs) = (
-        make_test_weights(
-            e,
-            n,
-            k,
-            in_dtype=DTYPE,
-            quant_dtype="nvfp4",
-            block_shape=None,
-            per_out_ch_quant=False,
-        )
+    (
+        w1_q,
+        w1_blockscale,
+        w2_q,
+        w2_blockscale,
+        a1_gscale,
+        a2_gscale,
+        g1_alphas,
+        g2_alphas,
+    ) = _make_nvfp4_weights_and_scales(
+        e=e,
+        n=n,
+        k=k,
+        scale_source=x_batch,
     )
-    assert w1_blockscale is not None and w2_blockscale is not None
-    assert w1_gs is not None and w2_gs is not None
-
-    a1_gscale = _global_scale(x_batch).expand(e).contiguous()
-    a2_gscale = _global_scale(x_batch).expand(e).contiguous()
-    g1_alphas = ((1.0 / w1_gs) / a1_gscale).to(torch.float32)
-    g2_alphas = ((1.0 / w2_gs) / a2_gscale).to(torch.float32)
 
     topk_ids_single = torch.randint(0, e, (1, topk), device=DEVICE, dtype=torch.int32)
     topk_ids_batch = torch.cat(
@@ -327,265 +394,35 @@ def test_batch_invariant_nvfp4_moe_batch_size_invariance(
     topk_weights_batch /= topk_weights_batch.sum(dim=-1, keepdim=True)
     topk_weights_batch[0] = topk_weights_single[0]
 
-    w13_1, w2_1 = _batch_invariant_fp4_workspaces(
-        m=1,
-        topk=topk,
-        w1_row_dim=w1_q.shape[1],
-        hidden_dim=k,
-        activation=MoEActivation.SILU,
-        device=DEVICE,
-        dtype=DTYPE,
-    )
-    w13_8, w2_8 = _batch_invariant_fp4_workspaces(
-        m=8,
-        topk=topk,
-        w1_row_dim=w1_q.shape[1],
-        hidden_dim=k,
-        activation=MoEActivation.SILU,
-        device=DEVICE,
-        dtype=DTYPE,
-    )
-
-    out_single = torch.empty_like(x_single)
-    fused_moe_batch_invariant_nvfp4(
+    out_single = _run_batch_invariant_nvfp4(
         hidden_states=x_single,
-        topk_ids=topk_ids_single,
         topk_weights=topk_weights_single,
-        w13_weight=w1_q,
-        w13_weight_scale=w1_blockscale,
-        w2_weight=w2_q,
-        w2_weight_scale=w2_blockscale,
+        topk_ids=topk_ids_single,
+        w1_q=w1_q,
+        w1_blockscale=w1_blockscale,
+        w2_q=w2_q,
+        w2_blockscale=w2_blockscale,
         a1_gscale=a1_gscale,
-        g1_alphas=g1_alphas,
         a2_gscale=a2_gscale,
+        g1_alphas=g1_alphas,
         g2_alphas=g2_alphas,
-        activation=MoEActivation.SILU,
-        workspace13=w13_1,
-        workspace2=w2_1,
-        output=out_single,
-        workspace=_make_nvfp4_workspace(e),
         apply_router_weight_on_input=apply_router_weight_on_input,
     )
-    out_batch = torch.empty_like(x_batch)
-    fused_moe_batch_invariant_nvfp4(
+    out_batch = _run_batch_invariant_nvfp4(
         hidden_states=x_batch,
-        topk_ids=topk_ids_batch,
         topk_weights=topk_weights_batch,
-        w13_weight=w1_q,
-        w13_weight_scale=w1_blockscale,
-        w2_weight=w2_q,
-        w2_weight_scale=w2_blockscale,
+        topk_ids=topk_ids_batch,
+        w1_q=w1_q,
+        w1_blockscale=w1_blockscale,
+        w2_q=w2_q,
+        w2_blockscale=w2_blockscale,
         a1_gscale=a1_gscale,
-        g1_alphas=g1_alphas,
         a2_gscale=a2_gscale,
+        g1_alphas=g1_alphas,
         g2_alphas=g2_alphas,
-        activation=MoEActivation.SILU,
-        workspace13=w13_8,
-        workspace2=w2_8,
-        output=out_batch,
-        workspace=_make_nvfp4_workspace(e),
         apply_router_weight_on_input=apply_router_weight_on_input,
     )
     assert torch.equal(out_single[0], out_batch[0])
-
-
-# NVFP4 MoE does not support expert parallelism yet; this test fails until it does.
-@pytest.mark.skip(
-    reason="NVFP4 MoE expert parallelism not supported; test fails until then.",
-)
-@REQUIRES_SM100
-@torch.inference_mode()
-def test_batch_invariant_nvfp4_moe_ignores_invalid_sentinel_routes() -> None:
-    set_random_seed(23)
-    m, e, n, k = 32, 8, 128, 128
-    (
-        hidden_states,
-        _,
-        _,
-        w1_q,
-        w1_blockscale,
-        w2_q,
-        w2_blockscale,
-        a1_gscale,
-        a2_gscale,
-        g1_alphas,
-        g2_alphas,
-    ) = _make_nvfp4_moe_tensors(m=m, n=n, k=k, e=e, topk=1)
-
-    valid_topk_ids = torch.randint(0, e, (m, 1), device=DEVICE, dtype=torch.int32)
-    valid_topk_weights = torch.rand((m, 1), device=DEVICE, dtype=torch.float32)
-    invalid_topk_ids = torch.full((m, 1), -1, device=DEVICE, dtype=torch.int32)
-    invalid_topk_weights = torch.rand((m, 1), device=DEVICE, dtype=torch.float32)
-
-    topk_ids_with_invalid = torch.cat([valid_topk_ids, invalid_topk_ids], dim=1)
-    topk_weights_with_invalid = torch.cat(
-        [valid_topk_weights, invalid_topk_weights], dim=1
-    )
-
-    w13, w2 = _batch_invariant_fp4_workspaces(
-        m=m,
-        topk=2,
-        w1_row_dim=w1_q.shape[1],
-        hidden_dim=k,
-        activation=MoEActivation.SILU,
-        device=DEVICE,
-        dtype=DTYPE,
-    )
-
-    out_with_invalid = torch.empty_like(hidden_states)
-    fused_moe_batch_invariant_nvfp4(
-        hidden_states=hidden_states,
-        topk_ids=topk_ids_with_invalid,
-        topk_weights=topk_weights_with_invalid,
-        w13_weight=w1_q,
-        w13_weight_scale=w1_blockscale,
-        w2_weight=w2_q,
-        w2_weight_scale=w2_blockscale,
-        a1_gscale=a1_gscale,
-        g1_alphas=g1_alphas,
-        a2_gscale=a2_gscale,
-        g2_alphas=g2_alphas,
-        activation=MoEActivation.SILU,
-        workspace13=w13,
-        workspace2=w2,
-        output=out_with_invalid,
-        workspace=_make_nvfp4_workspace(e),
-    )
-    out_valid_only = torch.empty_like(hidden_states)
-    fused_moe_batch_invariant_nvfp4(
-        hidden_states=hidden_states,
-        topk_ids=valid_topk_ids,
-        topk_weights=valid_topk_weights,
-        w13_weight=w1_q,
-        w13_weight_scale=w1_blockscale,
-        w2_weight=w2_q,
-        w2_weight_scale=w2_blockscale,
-        a1_gscale=a1_gscale,
-        g1_alphas=g1_alphas,
-        a2_gscale=a2_gscale,
-        g2_alphas=g2_alphas,
-        activation=MoEActivation.SILU,
-        workspace13=w13,
-        workspace2=w2,
-        output=out_valid_only,
-        workspace=_make_nvfp4_workspace(e),
-    )
-
-    torch.testing.assert_close(out_with_invalid, out_valid_only, atol=1e-1, rtol=1e-1)
-
-
-# NVFP4 MoE does not support expert parallelism yet; this test fails until it does.
-@pytest.mark.skip(
-    reason="NVFP4 MoE expert parallelism not supported; test fails until then.",
-)
-@REQUIRES_SM100
-@torch.inference_mode()
-def test_batch_invariant_nvfp4_moe_expert_map_invalidation_matches_local_routes() -> (
-    None
-):
-    set_random_seed(29)
-    m, e_local, n, k = 32, 4, 128, 128
-    (
-        hidden_states,
-        _,
-        _,
-        w1_q,
-        w1_blockscale,
-        w2_q,
-        w2_blockscale,
-        a1_gscale,
-        a2_gscale,
-        g1_alphas,
-        g2_alphas,
-    ) = _make_nvfp4_moe_tensors(m=m, n=n, k=k, e=e_local, topk=1)
-
-    global_num_experts = 8
-    expert_map = torch.full((global_num_experts,), -1, dtype=torch.int32, device=DEVICE)
-    mapped_global_ids = torch.tensor([1, 3, 5, 7], dtype=torch.int64, device=DEVICE)
-    expert_map[mapped_global_ids] = torch.arange(
-        e_local, dtype=torch.int32, device=DEVICE
-    )
-
-    valid_global_ids = mapped_global_ids[
-        torch.randint(0, mapped_global_ids.numel(), (m, 1), device=DEVICE)
-    ]
-    invalid_global_candidates = torch.tensor(
-        [0, 2, 4, 6], dtype=torch.int64, device=DEVICE
-    )
-    invalid_global_ids = invalid_global_candidates[
-        torch.randint(0, invalid_global_candidates.numel(), (m, 1), device=DEVICE)
-    ]
-    topk_ids_global = torch.cat([valid_global_ids, invalid_global_ids], dim=1).to(
-        torch.int32
-    )
-    topk_weights_global = torch.rand((m, 2), device=DEVICE, dtype=torch.float32)
-
-    w13_g, w2_g = _batch_invariant_fp4_workspaces(
-        m=m,
-        topk=2,
-        w1_row_dim=w1_q.shape[1],
-        hidden_dim=k,
-        activation=MoEActivation.SILU,
-        device=DEVICE,
-        dtype=DTYPE,
-    )
-    w13_l, w2_l = _batch_invariant_fp4_workspaces(
-        m=m,
-        topk=1,
-        w1_row_dim=w1_q.shape[1],
-        hidden_dim=k,
-        activation=MoEActivation.SILU,
-        device=DEVICE,
-        dtype=DTYPE,
-    )
-
-    out_with_expert_map = torch.empty_like(hidden_states)
-    fused_moe_batch_invariant_nvfp4(
-        hidden_states=hidden_states,
-        topk_ids=topk_ids_global,
-        topk_weights=topk_weights_global,
-        w13_weight=w1_q,
-        w13_weight_scale=w1_blockscale,
-        w2_weight=w2_q,
-        w2_weight_scale=w2_blockscale,
-        a1_gscale=a1_gscale,
-        g1_alphas=g1_alphas,
-        a2_gscale=a2_gscale,
-        g2_alphas=g2_alphas,
-        activation=MoEActivation.SILU,
-        workspace13=w13_g,
-        workspace2=w2_g,
-        output=out_with_expert_map,
-        workspace=_make_nvfp4_workspace(e_local),
-        expert_map=expert_map,
-    )
-
-    topk_ids_local = expert_map[topk_ids_global[:, :1]].to(torch.int32)
-    assert torch.all(topk_ids_local >= 0)
-    out_local_only = torch.empty_like(hidden_states)
-    fused_moe_batch_invariant_nvfp4(
-        hidden_states=hidden_states,
-        topk_ids=topk_ids_local,
-        topk_weights=topk_weights_global[:, :1].contiguous(),
-        w13_weight=w1_q,
-        w13_weight_scale=w1_blockscale,
-        w2_weight=w2_q,
-        w2_weight_scale=w2_blockscale,
-        a1_gscale=a1_gscale,
-        g1_alphas=g1_alphas,
-        a2_gscale=a2_gscale,
-        g2_alphas=g2_alphas,
-        activation=MoEActivation.SILU,
-        workspace13=w13_l,
-        workspace2=w2_l,
-        output=out_local_only,
-        workspace=_make_nvfp4_workspace(e_local),
-        expert_map=None,
-    )
-
-    torch.testing.assert_close(
-        out_with_expert_map, out_local_only, atol=1e-1, rtol=1e-1
-    )
 
 
 @REQUIRES_SM100
@@ -609,33 +446,18 @@ def test_batch_invariant_nvfp4_moe_all_invalid_routes_return_zero() -> None:
 
     topk_ids = torch.full((m, 2), -1, dtype=torch.int32, device=DEVICE)
     topk_weights = torch.rand((m, 2), dtype=torch.float32, device=DEVICE)
-    w13_z, w2_z = _batch_invariant_fp4_workspaces(
-        m=m,
-        topk=2,
-        w1_row_dim=w1_q.shape[1],
-        hidden_dim=k,
-        activation=MoEActivation.SILU,
-        device=DEVICE,
-        dtype=DTYPE,
-    )
-    out = torch.empty_like(hidden_states)
-    fused_moe_batch_invariant_nvfp4(
+    out = _run_batch_invariant_nvfp4(
         hidden_states=hidden_states,
-        topk_ids=topk_ids,
         topk_weights=topk_weights,
-        w13_weight=w1_q,
-        w13_weight_scale=w1_blockscale,
-        w2_weight=w2_q,
-        w2_weight_scale=w2_blockscale,
+        topk_ids=topk_ids,
+        w1_q=w1_q,
+        w1_blockscale=w1_blockscale,
+        w2_q=w2_q,
+        w2_blockscale=w2_blockscale,
         a1_gscale=a1_gscale,
-        g1_alphas=g1_alphas,
         a2_gscale=a2_gscale,
+        g1_alphas=g1_alphas,
         g2_alphas=g2_alphas,
-        activation=MoEActivation.SILU,
-        workspace13=w13_z,
-        workspace2=w2_z,
-        output=out,
-        workspace=_make_nvfp4_workspace(e),
     )
 
     torch.testing.assert_close(out, torch.zeros_like(out), atol=0.0, rtol=0.0)

--- a/tests/kernels/quantization/test_batch_invariant_fp4_moe.py
+++ b/tests/kernels/quantization/test_batch_invariant_fp4_moe.py
@@ -513,6 +513,9 @@ def test_grouped_matmul_nvfp4_packed_matches_cutlass_reference() -> None:
         row_offset += rows
         scale_row_offset += a_scale.shape[0]
 
+    expert_offsets.append(row_offset)
+    a_scale_offsets.append(scale_row_offset)
+
     packed_a_fp4_t = torch.cat(packed_a_fp4, dim=0)
     packed_a_scale_t = torch.cat(packed_a_scale, dim=0)
     packed_b_fp4_t = torch.stack(packed_b_fp4, dim=0)

--- a/tests/kernels/quantization/test_batch_invariant_fp4_moe.py
+++ b/tests/kernels/quantization/test_batch_invariant_fp4_moe.py
@@ -1,0 +1,704 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from tests.kernels.moe.utils import make_dummy_moe_config, make_test_weights
+from vllm._custom_ops import cutlass_scaled_fp4_mm, scaled_fp4_quant
+from vllm.config import ParallelConfig, VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.fused_moe import fused_topk
+from vllm.model_executor.layers.fused_moe.activation import (
+    MoEActivation,
+)
+from vllm.model_executor.layers.fused_moe.batch_invariant_fp4_moe import (
+    _grouped_matmul_nvfp4_packed,
+    fused_moe_batch_invariant_nvfp4,
+)
+from vllm.model_executor.layers.fused_moe.config import nvfp4_moe_quant_config
+from vllm.model_executor.layers.fused_moe.cutlass_moe import CutlassExpertsFp4
+from vllm.model_executor.layers.fused_moe.prepare_finalize import (
+    MoEPrepareAndFinalizeNoDPEPModular,
+)
+from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
+    pad_nvfp4_activation_for_cutlass,
+    pad_nvfp4_weight_for_cutlass,
+    slice_nvfp4_output,
+    swizzle_blockscale,
+)
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl
+from vllm.triton_utils.allocation import set_triton_allocator
+from vllm.utils.torch_utils import set_random_seed
+
+HAS_SM90 = current_platform.has_device_capability(90)
+HAS_SM100 = current_platform.has_device_capability(100)
+REQUIRES_SM100 = pytest.mark.skipif(
+    not HAS_SM100,
+    reason="Some batch-invariant NVFP4 MoE coverage requires Blackwell (sm100+).",
+)
+
+if not HAS_SM90:
+    pytest.skip(
+        reason="Batch-invariant FP4 MoE requires Hopper or newer (sm90+).",
+        allow_module_level=True,
+    )
+
+if not hasattr(tl, "dot_scaled"):
+    pytest.skip(
+        reason="Installed Triton build does not expose tl.dot_scaled.",
+        allow_module_level=True,
+    )
+
+DTYPE = torch.bfloat16
+DEVICE = "cuda:0"
+FLOAT8_E4M3_MAX = torch.finfo(torch.float8_e4m3fn).max
+FLOAT4_E2M1_MAX = 6.0
+
+
+@pytest.fixture(autouse=True)
+def _triton_allocator_for_tma_kernels():
+    """tl.make_tensor_descriptor in grouped NVFP4 GEMM needs triton.set_allocator."""
+    set_triton_allocator(torch.device(DEVICE))
+    yield
+
+
+def _batch_invariant_fp4_workspaces(
+    m: int,
+    topk: int,
+    w1_row_dim: int,
+    hidden_dim: int,
+    activation: MoEActivation,
+    device: torch.device | str,
+    dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Scratch buffers matching ``BatchInvariantNvfp4Experts.workspace_shapes``."""
+    act_out_dim = mk.FusedMoEExpertsModular.adjust_N_for_activation(
+        w1_row_dim, activation
+    )
+    m_total = m * topk
+    workspace13 = torch.empty(
+        (m_total, max(w1_row_dim, hidden_dim)), device=device, dtype=dtype
+    )
+    workspace2 = torch.empty(
+        (m_total, max(act_out_dim, hidden_dim)), device=device, dtype=dtype
+    )
+    return workspace13, workspace2
+
+
+def _global_scale(x: torch.Tensor) -> torch.Tensor:
+    return (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / x.abs().max()).to(torch.float32)
+
+
+def _make_nvfp4_moe_tensors(
+    *,
+    m: int,
+    n: int,
+    k: int,
+    e: int,
+    topk: int,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+]:
+    hidden_states = torch.randn((m, k), device=DEVICE, dtype=DTYPE) / 10
+    (_, w1_q, w1_blockscale, w1_gs), (_, w2_q, w2_blockscale, w2_gs) = (
+        make_test_weights(
+            e,
+            n,
+            k,
+            in_dtype=DTYPE,
+            quant_dtype="nvfp4",
+            block_shape=None,
+            per_out_ch_quant=False,
+        )
+    )
+    assert w1_blockscale is not None and w2_blockscale is not None
+    assert w1_gs is not None and w2_gs is not None
+
+    score = torch.randn((m, e), device=DEVICE, dtype=DTYPE)
+    topk_weights, topk_ids, _ = fused_topk(
+        hidden_states, score, topk, renormalize=False
+    )
+
+    # Use realistic (non-trivial) per-expert activation global scales so that
+    # the alpha fusion in process_weights_after_loading is actually exercised.
+    # Trivial gscale=1.0 would mask missing fusion since multiplying by 1 is
+    # identity.
+    a1_gscale = _global_scale(hidden_states).expand(e).contiguous()
+    a2_gscale = _global_scale(hidden_states).expand(e).contiguous()
+    g1_alphas = ((1.0 / w1_gs) / a1_gscale).to(torch.float32)
+    g2_alphas = ((1.0 / w2_gs) / a2_gscale).to(torch.float32)
+    return (
+        hidden_states,
+        topk_weights,
+        topk_ids,
+        w1_q,
+        w1_blockscale,
+        w2_q,
+        w2_blockscale,
+        a1_gscale,
+        a2_gscale,
+        g1_alphas,
+        g2_alphas,
+    )
+
+
+@REQUIRES_SM100
+@pytest.mark.parametrize(
+    "topk,apply_router_weight_on_input",
+    [
+        (1, False),
+        (2, False),
+        (4, False),
+        (1, True),
+    ],
+)
+@torch.inference_mode()
+def test_batch_invariant_nvfp4_moe_matches_cutlass(
+    workspace_init,
+    topk: int,
+    apply_router_weight_on_input: bool,
+) -> None:
+    set_random_seed(11)
+    with set_current_vllm_config(
+        VllmConfig(parallel_config=ParallelConfig(pipeline_parallel_size=1))
+    ):
+        (
+            hidden_states,
+            topk_weights,
+            topk_ids,
+            w1_q,
+            w1_blockscale,
+            w2_q,
+            w2_blockscale,
+            a1_gscale,
+            a2_gscale,
+            g1_alphas,
+            g2_alphas,
+        ) = _make_nvfp4_moe_tensors(m=32, n=128, k=128, e=8, topk=topk)
+
+        w13, w2 = _batch_invariant_fp4_workspaces(
+            m=32,
+            topk=topk,
+            w1_row_dim=w1_q.shape[1],
+            hidden_dim=128,
+            activation=MoEActivation.SILU,
+            device=DEVICE,
+            dtype=DTYPE,
+        )
+
+        quant_config = nvfp4_moe_quant_config(
+            g1_alphas=g1_alphas,
+            g2_alphas=g2_alphas,
+            a1_gscale=a1_gscale,
+            a2_gscale=a2_gscale,
+            w1_scale=w1_blockscale,
+            w2_scale=w2_blockscale,
+        )
+        kernel = mk.FusedMoEKernel(
+            MoEPrepareAndFinalizeNoDPEPModular(),
+            CutlassExpertsFp4(
+                moe_config=make_dummy_moe_config(),
+                quant_config=quant_config,
+            ),
+            inplace=False,
+        )
+
+        cutlass_out = kernel.apply(
+            hidden_states=hidden_states,
+            w1=w1_q,
+            w2=w2_q,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation=MoEActivation.SILU,
+            global_num_experts=8,
+            expert_map=None,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+        )
+
+        fallback_out = torch.empty_like(hidden_states)
+        fused_moe_batch_invariant_nvfp4(
+            hidden_states=hidden_states,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            w13_weight=w1_q,
+            w13_weight_scale=w1_blockscale,
+            w2_weight=w2_q,
+            w2_weight_scale=w2_blockscale,
+            a1_gscale=a1_gscale,
+            g1_alphas=g1_alphas,
+            a2_gscale=a2_gscale,
+            g2_alphas=g2_alphas,
+            activation=MoEActivation.SILU,
+            workspace13=w13,
+            workspace2=w2,
+            output=fallback_out,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+        )
+        torch.testing.assert_close(fallback_out, cutlass_out, atol=1e-1, rtol=1e-1)
+
+
+@REQUIRES_SM100
+@pytest.mark.parametrize(
+    "topk,apply_router_weight_on_input",
+    [
+        (1, False),
+        (2, False),
+        (4, False),
+        (1, True),
+    ],
+)
+@torch.inference_mode()
+def test_batch_invariant_nvfp4_moe_batch_size_invariance(
+    topk: int,
+    apply_router_weight_on_input: bool,
+) -> None:
+    set_random_seed(13)
+    e, n, k = 8, 128, 128
+    x_single = torch.randn((1, k), device=DEVICE, dtype=DTYPE) / 10
+    x_batch = torch.cat(
+        [x_single, torch.randn((7, k), device=DEVICE, dtype=DTYPE) / 10], dim=0
+    )
+
+    (_, w1_q, w1_blockscale, w1_gs), (_, w2_q, w2_blockscale, w2_gs) = (
+        make_test_weights(
+            e,
+            n,
+            k,
+            in_dtype=DTYPE,
+            quant_dtype="nvfp4",
+            block_shape=None,
+            per_out_ch_quant=False,
+        )
+    )
+    assert w1_blockscale is not None and w2_blockscale is not None
+    assert w1_gs is not None and w2_gs is not None
+
+    a1_gscale = _global_scale(x_batch).expand(e).contiguous()
+    a2_gscale = _global_scale(x_batch).expand(e).contiguous()
+    g1_alphas = ((1.0 / w1_gs) / a1_gscale).to(torch.float32)
+    g2_alphas = ((1.0 / w2_gs) / a2_gscale).to(torch.float32)
+
+    topk_ids_single = torch.randint(0, e, (1, topk), device=DEVICE, dtype=torch.int32)
+    topk_ids_batch = torch.cat(
+        [
+            topk_ids_single,
+            torch.randint(0, e, (7, topk), device=DEVICE, dtype=torch.int32),
+        ],
+        dim=0,
+    )
+
+    topk_weights_single = torch.rand((1, topk), device=DEVICE, dtype=torch.float32)
+    topk_weights_single /= topk_weights_single.sum(dim=-1, keepdim=True)
+    topk_weights_batch = torch.rand((8, topk), device=DEVICE, dtype=torch.float32)
+    topk_weights_batch /= topk_weights_batch.sum(dim=-1, keepdim=True)
+    topk_weights_batch[0] = topk_weights_single[0]
+
+    w13_1, w2_1 = _batch_invariant_fp4_workspaces(
+        m=1,
+        topk=topk,
+        w1_row_dim=w1_q.shape[1],
+        hidden_dim=k,
+        activation=MoEActivation.SILU,
+        device=DEVICE,
+        dtype=DTYPE,
+    )
+    w13_8, w2_8 = _batch_invariant_fp4_workspaces(
+        m=8,
+        topk=topk,
+        w1_row_dim=w1_q.shape[1],
+        hidden_dim=k,
+        activation=MoEActivation.SILU,
+        device=DEVICE,
+        dtype=DTYPE,
+    )
+
+    out_single = torch.empty_like(x_single)
+    fused_moe_batch_invariant_nvfp4(
+        hidden_states=x_single,
+        topk_ids=topk_ids_single,
+        topk_weights=topk_weights_single,
+        w13_weight=w1_q,
+        w13_weight_scale=w1_blockscale,
+        w2_weight=w2_q,
+        w2_weight_scale=w2_blockscale,
+        a1_gscale=a1_gscale,
+        g1_alphas=g1_alphas,
+        a2_gscale=a2_gscale,
+        g2_alphas=g2_alphas,
+        activation=MoEActivation.SILU,
+        workspace13=w13_1,
+        workspace2=w2_1,
+        output=out_single,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+    )
+    out_batch = torch.empty_like(x_batch)
+    fused_moe_batch_invariant_nvfp4(
+        hidden_states=x_batch,
+        topk_ids=topk_ids_batch,
+        topk_weights=topk_weights_batch,
+        w13_weight=w1_q,
+        w13_weight_scale=w1_blockscale,
+        w2_weight=w2_q,
+        w2_weight_scale=w2_blockscale,
+        a1_gscale=a1_gscale,
+        g1_alphas=g1_alphas,
+        a2_gscale=a2_gscale,
+        g2_alphas=g2_alphas,
+        activation=MoEActivation.SILU,
+        workspace13=w13_8,
+        workspace2=w2_8,
+        output=out_batch,
+        apply_router_weight_on_input=apply_router_weight_on_input,
+    )
+    assert torch.equal(out_single[0], out_batch[0])
+
+
+# NVFP4 MoE does not support expert parallelism yet; this test fails until it does.
+@pytest.mark.skip(
+    reason="NVFP4 MoE expert parallelism not supported; test fails until then.",
+)
+@REQUIRES_SM100
+@torch.inference_mode()
+def test_batch_invariant_nvfp4_moe_ignores_invalid_sentinel_routes() -> None:
+    set_random_seed(23)
+    m, e, n, k = 32, 8, 128, 128
+    (
+        hidden_states,
+        _,
+        _,
+        w1_q,
+        w1_blockscale,
+        w2_q,
+        w2_blockscale,
+        a1_gscale,
+        a2_gscale,
+        g1_alphas,
+        g2_alphas,
+    ) = _make_nvfp4_moe_tensors(m=m, n=n, k=k, e=e, topk=1)
+
+    valid_topk_ids = torch.randint(0, e, (m, 1), device=DEVICE, dtype=torch.int32)
+    valid_topk_weights = torch.rand((m, 1), device=DEVICE, dtype=torch.float32)
+    invalid_topk_ids = torch.full((m, 1), -1, device=DEVICE, dtype=torch.int32)
+    invalid_topk_weights = torch.rand((m, 1), device=DEVICE, dtype=torch.float32)
+
+    topk_ids_with_invalid = torch.cat([valid_topk_ids, invalid_topk_ids], dim=1)
+    topk_weights_with_invalid = torch.cat(
+        [valid_topk_weights, invalid_topk_weights], dim=1
+    )
+
+    w13, w2 = _batch_invariant_fp4_workspaces(
+        m=m,
+        topk=2,
+        w1_row_dim=w1_q.shape[1],
+        hidden_dim=k,
+        activation=MoEActivation.SILU,
+        device=DEVICE,
+        dtype=DTYPE,
+    )
+
+    out_with_invalid = torch.empty_like(hidden_states)
+    fused_moe_batch_invariant_nvfp4(
+        hidden_states=hidden_states,
+        topk_ids=topk_ids_with_invalid,
+        topk_weights=topk_weights_with_invalid,
+        w13_weight=w1_q,
+        w13_weight_scale=w1_blockscale,
+        w2_weight=w2_q,
+        w2_weight_scale=w2_blockscale,
+        a1_gscale=a1_gscale,
+        g1_alphas=g1_alphas,
+        a2_gscale=a2_gscale,
+        g2_alphas=g2_alphas,
+        activation=MoEActivation.SILU,
+        workspace13=w13,
+        workspace2=w2,
+        output=out_with_invalid,
+    )
+    out_valid_only = torch.empty_like(hidden_states)
+    fused_moe_batch_invariant_nvfp4(
+        hidden_states=hidden_states,
+        topk_ids=valid_topk_ids,
+        topk_weights=valid_topk_weights,
+        w13_weight=w1_q,
+        w13_weight_scale=w1_blockscale,
+        w2_weight=w2_q,
+        w2_weight_scale=w2_blockscale,
+        a1_gscale=a1_gscale,
+        g1_alphas=g1_alphas,
+        a2_gscale=a2_gscale,
+        g2_alphas=g2_alphas,
+        activation=MoEActivation.SILU,
+        workspace13=w13,
+        workspace2=w2,
+        output=out_valid_only,
+    )
+
+    torch.testing.assert_close(out_with_invalid, out_valid_only, atol=1e-1, rtol=1e-1)
+
+
+# NVFP4 MoE does not support expert parallelism yet; this test fails until it does.
+@pytest.mark.skip(
+    reason="NVFP4 MoE expert parallelism not supported; test fails until then.",
+)
+@REQUIRES_SM100
+@torch.inference_mode()
+def test_batch_invariant_nvfp4_moe_expert_map_invalidation_matches_local_routes() -> (
+    None
+):
+    set_random_seed(29)
+    m, e_local, n, k = 32, 4, 128, 128
+    (
+        hidden_states,
+        _,
+        _,
+        w1_q,
+        w1_blockscale,
+        w2_q,
+        w2_blockscale,
+        a1_gscale,
+        a2_gscale,
+        g1_alphas,
+        g2_alphas,
+    ) = _make_nvfp4_moe_tensors(m=m, n=n, k=k, e=e_local, topk=1)
+
+    global_num_experts = 8
+    expert_map = torch.full((global_num_experts,), -1, dtype=torch.int32, device=DEVICE)
+    mapped_global_ids = torch.tensor([1, 3, 5, 7], dtype=torch.int64, device=DEVICE)
+    expert_map[mapped_global_ids] = torch.arange(
+        e_local, dtype=torch.int32, device=DEVICE
+    )
+
+    valid_global_ids = mapped_global_ids[
+        torch.randint(0, mapped_global_ids.numel(), (m, 1), device=DEVICE)
+    ]
+    invalid_global_candidates = torch.tensor(
+        [0, 2, 4, 6], dtype=torch.int64, device=DEVICE
+    )
+    invalid_global_ids = invalid_global_candidates[
+        torch.randint(0, invalid_global_candidates.numel(), (m, 1), device=DEVICE)
+    ]
+    topk_ids_global = torch.cat([valid_global_ids, invalid_global_ids], dim=1).to(
+        torch.int32
+    )
+    topk_weights_global = torch.rand((m, 2), device=DEVICE, dtype=torch.float32)
+
+    w13_g, w2_g = _batch_invariant_fp4_workspaces(
+        m=m,
+        topk=2,
+        w1_row_dim=w1_q.shape[1],
+        hidden_dim=k,
+        activation=MoEActivation.SILU,
+        device=DEVICE,
+        dtype=DTYPE,
+    )
+    w13_l, w2_l = _batch_invariant_fp4_workspaces(
+        m=m,
+        topk=1,
+        w1_row_dim=w1_q.shape[1],
+        hidden_dim=k,
+        activation=MoEActivation.SILU,
+        device=DEVICE,
+        dtype=DTYPE,
+    )
+
+    out_with_expert_map = torch.empty_like(hidden_states)
+    fused_moe_batch_invariant_nvfp4(
+        hidden_states=hidden_states,
+        topk_ids=topk_ids_global,
+        topk_weights=topk_weights_global,
+        w13_weight=w1_q,
+        w13_weight_scale=w1_blockscale,
+        w2_weight=w2_q,
+        w2_weight_scale=w2_blockscale,
+        a1_gscale=a1_gscale,
+        g1_alphas=g1_alphas,
+        a2_gscale=a2_gscale,
+        g2_alphas=g2_alphas,
+        activation=MoEActivation.SILU,
+        workspace13=w13_g,
+        workspace2=w2_g,
+        output=out_with_expert_map,
+        expert_map=expert_map,
+    )
+
+    topk_ids_local = expert_map[topk_ids_global[:, :1]].to(torch.int32)
+    assert torch.all(topk_ids_local >= 0)
+    out_local_only = torch.empty_like(hidden_states)
+    fused_moe_batch_invariant_nvfp4(
+        hidden_states=hidden_states,
+        topk_ids=topk_ids_local,
+        topk_weights=topk_weights_global[:, :1].contiguous(),
+        w13_weight=w1_q,
+        w13_weight_scale=w1_blockscale,
+        w2_weight=w2_q,
+        w2_weight_scale=w2_blockscale,
+        a1_gscale=a1_gscale,
+        g1_alphas=g1_alphas,
+        a2_gscale=a2_gscale,
+        g2_alphas=g2_alphas,
+        activation=MoEActivation.SILU,
+        workspace13=w13_l,
+        workspace2=w2_l,
+        output=out_local_only,
+        expert_map=None,
+    )
+
+    torch.testing.assert_close(
+        out_with_expert_map, out_local_only, atol=1e-1, rtol=1e-1
+    )
+
+
+@REQUIRES_SM100
+@torch.inference_mode()
+def test_batch_invariant_nvfp4_moe_all_invalid_routes_return_zero() -> None:
+    set_random_seed(31)
+    m, e, n, k = 16, 8, 128, 128
+    (
+        hidden_states,
+        _,
+        _,
+        w1_q,
+        w1_blockscale,
+        w2_q,
+        w2_blockscale,
+        a1_gscale,
+        a2_gscale,
+        g1_alphas,
+        g2_alphas,
+    ) = _make_nvfp4_moe_tensors(m=m, n=n, k=k, e=e, topk=1)
+
+    topk_ids = torch.full((m, 2), -1, dtype=torch.int32, device=DEVICE)
+    topk_weights = torch.rand((m, 2), dtype=torch.float32, device=DEVICE)
+    w13_z, w2_z = _batch_invariant_fp4_workspaces(
+        m=m,
+        topk=2,
+        w1_row_dim=w1_q.shape[1],
+        hidden_dim=k,
+        activation=MoEActivation.SILU,
+        device=DEVICE,
+        dtype=DTYPE,
+    )
+    out = torch.empty_like(hidden_states)
+    fused_moe_batch_invariant_nvfp4(
+        hidden_states=hidden_states,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        w13_weight=w1_q,
+        w13_weight_scale=w1_blockscale,
+        w2_weight=w2_q,
+        w2_weight_scale=w2_blockscale,
+        a1_gscale=a1_gscale,
+        g1_alphas=g1_alphas,
+        a2_gscale=a2_gscale,
+        g2_alphas=g2_alphas,
+        activation=MoEActivation.SILU,
+        workspace13=w13_z,
+        workspace2=w2_z,
+        output=out,
+    )
+
+    torch.testing.assert_close(out, torch.zeros_like(out), atol=0.0, rtol=0.0)
+
+
+@REQUIRES_SM100
+@torch.inference_mode()
+def test_grouped_matmul_nvfp4_packed_matches_cutlass_reference() -> None:
+    set_random_seed(17)
+
+    # Non-uniform M across experts exercises offset/problem-size dispatch.
+    per_expert_rows = [17, 131, 64, 5]
+    E = len(per_expert_rows)
+    N = 128
+    K = 256
+
+    xs = [
+        torch.randn((rows, K), dtype=DTYPE, device=DEVICE) for rows in per_expert_rows
+    ]
+    ws = [torch.randn((N, K), dtype=DTYPE, device=DEVICE) for _ in range(E)]
+
+    input_gs = [_global_scale(x) for x in xs]
+    weight_gs = [_global_scale(w) for w in ws]
+    alphas = [
+        (1.0 / (ig * wg)).to(torch.float32) for ig, wg in zip(input_gs, weight_gs)
+    ]
+
+    packed_a_fp4 = []
+    packed_a_scale = []
+    packed_b_fp4 = []
+    packed_b_scale = []
+    ref_outputs = []
+    expert_offsets = []
+    a_scale_offsets = []
+
+    row_offset = 0
+    scale_row_offset = 0
+    for expert_id, rows in enumerate(per_expert_rows):
+        a_fp4, a_scale = scaled_fp4_quant(
+            xs[expert_id], input_gs[expert_id], is_sf_swizzled_layout=True
+        )
+        b_fp4, b_scale_raw = scaled_fp4_quant(ws[expert_id], weight_gs[expert_id])
+        b_scale = swizzle_blockscale(b_scale_raw)
+        b_fp4, weights_padding_cols = pad_nvfp4_weight_for_cutlass(b_fp4)
+        a_fp4 = pad_nvfp4_activation_for_cutlass(a_fp4, weights_padding_cols)
+
+        # Reference: one CUTLASS launch per expert.
+        ref = cutlass_scaled_fp4_mm(
+            a_fp4,
+            b_fp4,
+            a_scale,
+            b_scale,
+            alphas[expert_id],
+            DTYPE,
+        )
+        ref_outputs.append(slice_nvfp4_output(ref, N))
+
+        packed_a_fp4.append(a_fp4)
+        packed_a_scale.append(a_scale)
+        packed_b_fp4.append(b_fp4)
+        packed_b_scale.append(b_scale)
+        expert_offsets.append(row_offset)
+        a_scale_offsets.append(scale_row_offset)
+        row_offset += rows
+        scale_row_offset += a_scale.shape[0]
+
+    packed_a_fp4_t = torch.cat(packed_a_fp4, dim=0)
+    packed_a_scale_t = torch.cat(packed_a_scale, dim=0)
+    packed_b_fp4_t = torch.stack(packed_b_fp4, dim=0)
+    packed_b_scale_t = torch.stack(packed_b_scale, dim=0)
+    alpha_t = torch.stack(alphas)
+    expert_offsets_t = torch.tensor(expert_offsets, dtype=torch.int32, device=DEVICE)
+    a_scale_offsets_t = torch.tensor(a_scale_offsets, dtype=torch.int32, device=DEVICE)
+    problem_sizes_t = torch.tensor(
+        [[rows, N, K] for rows in per_expert_rows],
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+
+    packed_out = torch.empty((row_offset, N), device=DEVICE, dtype=DTYPE)
+    _grouped_matmul_nvfp4_packed(
+        a_fp4=packed_a_fp4_t,
+        b_fp4=packed_b_fp4_t,
+        a_scale=packed_a_scale_t,
+        b_scale=packed_b_scale_t,
+        alpha=alpha_t,
+        expert_offsets=expert_offsets_t,
+        a_scale_offsets=a_scale_offsets_t,
+        problem_sizes=problem_sizes_t,
+        output=packed_out,
+    )
+    if packed_out.shape[1] != N:
+        packed_out = packed_out[:, :N].contiguous()
+
+    ref_cat = torch.cat(ref_outputs, dim=0)
+    torch.testing.assert_close(packed_out, ref_cat, atol=1e-1, rtol=1e-1)

--- a/tests/kernels/quantization/test_batch_invariant_fp4_moe.py
+++ b/tests/kernels/quantization/test_batch_invariant_fp4_moe.py
@@ -12,7 +12,9 @@ from vllm.model_executor.layers.fused_moe.activation import (
     MoEActivation,
 )
 from vllm.model_executor.layers.fused_moe.batch_invariant_fp4_moe import (
+    NvFP4MoEWorkspace,
     _grouped_matmul_nvfp4_packed,
+    _map_extra_rows,
     fused_moe_batch_invariant_nvfp4,
 )
 from vllm.model_executor.layers.fused_moe.config import nvfp4_moe_quant_config
@@ -77,13 +79,33 @@ def _batch_invariant_fp4_workspaces(
         w1_row_dim, activation
     )
     m_total = m * topk
-    workspace13 = torch.empty(
-        (m_total, max(w1_row_dim, hidden_dim)), device=device, dtype=dtype
-    )
+    cols13 = max(w1_row_dim, hidden_dim)
+    extra = _map_extra_rows(m_total, cols13)
+    workspace13 = torch.empty((m_total + extra, cols13), device=device, dtype=dtype)
     workspace2 = torch.empty(
         (m_total, max(act_out_dim, hidden_dim)), device=device, dtype=dtype
     )
     return workspace13, workspace2
+
+
+def _make_nvfp4_workspace(
+    num_experts: int,
+    device: torch.device | str = DEVICE,
+) -> NvFP4MoEWorkspace:
+    """Create an ``NvFP4MoEWorkspace`` for test helpers."""
+    return NvFP4MoEWorkspace(
+        expert_offsets=torch.empty(num_experts + 1, dtype=torch.int32, device=device),
+        blockscale_offsets=torch.empty(
+            num_experts + 1, dtype=torch.int32, device=device
+        ),
+        problem_sizes1=torch.empty(num_experts, 3, dtype=torch.int32, device=device),
+        problem_sizes2=torch.empty(num_experts, 3, dtype=torch.int32, device=device),
+        tiles_per_expert=torch.empty(num_experts, dtype=torch.int32, device=device),
+        expert_tile_start=torch.zeros(
+            num_experts + 1, dtype=torch.int32, device=device
+        ),
+        dummy_bias=torch.empty(0, device=device, dtype=torch.float32),
+    )
 
 
 def _global_scale(x: torch.Tensor) -> torch.Tensor:
@@ -243,6 +265,7 @@ def test_batch_invariant_nvfp4_moe_matches_cutlass(
             workspace13=w13,
             workspace2=w2,
             output=fallback_out,
+            workspace=_make_nvfp4_workspace(8),
             apply_router_weight_on_input=apply_router_weight_on_input,
         )
         torch.testing.assert_close(fallback_out, cutlass_out, atol=1e-1, rtol=1e-1)
@@ -340,6 +363,7 @@ def test_batch_invariant_nvfp4_moe_batch_size_invariance(
         workspace13=w13_1,
         workspace2=w2_1,
         output=out_single,
+        workspace=_make_nvfp4_workspace(e),
         apply_router_weight_on_input=apply_router_weight_on_input,
     )
     out_batch = torch.empty_like(x_batch)
@@ -359,6 +383,7 @@ def test_batch_invariant_nvfp4_moe_batch_size_invariance(
         workspace13=w13_8,
         workspace2=w2_8,
         output=out_batch,
+        workspace=_make_nvfp4_workspace(e),
         apply_router_weight_on_input=apply_router_weight_on_input,
     )
     assert torch.equal(out_single[0], out_batch[0])
@@ -424,6 +449,7 @@ def test_batch_invariant_nvfp4_moe_ignores_invalid_sentinel_routes() -> None:
         workspace13=w13,
         workspace2=w2,
         output=out_with_invalid,
+        workspace=_make_nvfp4_workspace(e),
     )
     out_valid_only = torch.empty_like(hidden_states)
     fused_moe_batch_invariant_nvfp4(
@@ -442,6 +468,7 @@ def test_batch_invariant_nvfp4_moe_ignores_invalid_sentinel_routes() -> None:
         workspace13=w13,
         workspace2=w2,
         output=out_valid_only,
+        workspace=_make_nvfp4_workspace(e),
     )
 
     torch.testing.assert_close(out_with_invalid, out_valid_only, atol=1e-1, rtol=1e-1)
@@ -529,6 +556,7 @@ def test_batch_invariant_nvfp4_moe_expert_map_invalidation_matches_local_routes(
         workspace13=w13_g,
         workspace2=w2_g,
         output=out_with_expert_map,
+        workspace=_make_nvfp4_workspace(e_local),
         expert_map=expert_map,
     )
 
@@ -551,6 +579,7 @@ def test_batch_invariant_nvfp4_moe_expert_map_invalidation_matches_local_routes(
         workspace13=w13_l,
         workspace2=w2_l,
         output=out_local_only,
+        workspace=_make_nvfp4_workspace(e_local),
         expert_map=None,
     )
 
@@ -606,6 +635,7 @@ def test_batch_invariant_nvfp4_moe_all_invalid_routes_return_zero() -> None:
         workspace13=w13_z,
         workspace2=w2_z,
         output=out,
+        workspace=_make_nvfp4_workspace(e),
     )
 
     torch.testing.assert_close(out, torch.zeros_like(out), atol=0.0, rtol=0.0)
@@ -696,6 +726,9 @@ def test_grouped_matmul_nvfp4_packed_matches_cutlass_reference() -> None:
         a_scale_offsets=a_scale_offsets_t,
         problem_sizes=problem_sizes_t,
         output=packed_out,
+        tiles_per_expert=torch.empty(E, dtype=torch.int32, device=DEVICE),
+        expert_tile_start=torch.zeros(E + 1, dtype=torch.int32, device=DEVICE),
+        dummy_bias=torch.empty(0, device=DEVICE, dtype=torch.float32),
     )
     if packed_out.shape[1] != N:
         packed_out = packed_out[:, :N].contiguous()

--- a/vllm/model_executor/layers/fused_moe/batch_invariant_fp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/batch_invariant_fp4_moe.py
@@ -138,8 +138,10 @@ def _validate_fused_moe_batch_invariant_nvfp4_inputs(
     assert w13_weight_scale.is_contiguous(), "w13_weight_scale must be contiguous"
     assert w2_weight.is_contiguous(), "w2_weight must be contiguous"
     assert w2_weight_scale.is_contiguous(), "w2_weight_scale must be contiguous"
-    if expert_map is not None:
-        assert expert_map.is_contiguous(), "expert_map must be contiguous"
+    assert expert_map is None, (
+        "Batch-invariant NVFP4 MoE does not support expert_map. "
+        "This kernel requires local expert IDs and ep_size == 1."
+    )
 
     for name, tensor in (
         ("a1_gscale", a1_gscale),
@@ -160,19 +162,6 @@ def _validate_fused_moe_batch_invariant_nvfp4_inputs(
             f"NVFP4 MoE tensor '{name}' must have {num_experts} elements, "
             f"got {tensor.numel()}."
         )
-
-
-def _nvfp4_moe_map_experts(
-    topk_ids: torch.Tensor, expert_map: torch.Tensor
-) -> torch.Tensor:
-    flat_ids = topk_ids.reshape(-1).to(torch.long)
-    if expert_map.numel() == 0:
-        return torch.full(topk_ids.shape, -1, dtype=torch.int32, device=topk_ids.device)
-    valid = (flat_ids >= 0) & (flat_ids < expert_map.numel())
-    clamped = flat_ids.clamp(min=0, max=max(0, expert_map.numel() - 1))
-    remapped = expert_map.to(torch.long).index_select(0, clamped)
-    mapped = torch.where(valid, remapped, -1)
-    return mapped.reshape(topk_ids.shape).to(dtype=torch.int32)
 
 
 # ---------------------------------------------------------------------------
@@ -708,8 +697,6 @@ def fused_moe_batch_invariant_nvfp4(
         return output
 
     routed_topk_ids = topk_ids
-    if expert_map is not None:
-        routed_topk_ids = _nvfp4_moe_map_experts(topk_ids, expert_map)
     # Out-of-range IDs are treated as invalid routes.
     valid_routes = (routed_topk_ids >= 0) & (routed_topk_ids < num_experts)
     routed_topk_ids = torch.where(valid_routes, routed_topk_ids, -1)

--- a/vllm/model_executor/layers/fused_moe/batch_invariant_fp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/batch_invariant_fp4_moe.py
@@ -182,7 +182,7 @@ def _nvfp4_moe_map_experts(
     valid = (flat_ids >= 0) & (flat_ids < expert_map.numel())
     clamped = flat_ids.clamp(min=0, max=max(0, expert_map.numel() - 1))
     remapped = expert_map.to(torch.long).index_select(0, clamped)
-    mapped = torch.where(valid, remapped, torch.full_like(remapped, -1))
+    mapped = torch.where(valid, remapped, -1)
     return mapped.reshape(topk_ids.shape).to(dtype=torch.int32)
 
 
@@ -752,9 +752,7 @@ def fused_moe_batch_invariant_nvfp4(
         routed_topk_ids = _nvfp4_moe_map_experts(topk_ids, expert_map)
     # Out-of-range IDs are treated as invalid routes.
     valid_routes = (routed_topk_ids >= 0) & (routed_topk_ids < num_experts)
-    routed_topk_ids = torch.where(
-        valid_routes, routed_topk_ids, torch.full_like(routed_topk_ids, -1)
-    )
+    routed_topk_ids = torch.where(valid_routes, routed_topk_ids, -1)
     routed_topk_weights = topk_weights
 
     if apply_router_weight_on_input:

--- a/vllm/model_executor/layers/fused_moe/batch_invariant_fp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/batch_invariant_fp4_moe.py
@@ -2,9 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Batch-invariant NVFP4 fused MoE expert implementations."""
 
-from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from enum import Enum
 
 import torch
 import torch.nn.functional as F
@@ -77,25 +75,6 @@ class NvFP4MoEWorkspace:
     dummy_bias: torch.Tensor  # [0] float32
 
 
-class _GroupedGemmAMode(Enum):
-    NVFP4_PACKED = 0
-    BF16 = 1
-    MXFP8 = 2
-
-
-# Plain integer constants for use inside Triton kernels, which cannot resolve
-# Python Enum attribute access at compile time.
-_A_NVFP4_PACKED = tl.constexpr(int(_GroupedGemmAMode.NVFP4_PACKED.value))
-_A_BF16 = tl.constexpr(int(_GroupedGemmAMode.BF16.value))
-_A_MXFP8 = tl.constexpr(int(_GroupedGemmAMode.MXFP8.value))
-
-_A_DOT_TYPE: dict[_GroupedGemmAMode, str] = {
-    _GroupedGemmAMode.NVFP4_PACKED: "e2m1",
-    _GroupedGemmAMode.BF16: "bf16",
-    _GroupedGemmAMode.MXFP8: "e4m3",
-}
-
-
 @triton.jit
 def _unswizzle_scale(
     scale_raw,
@@ -118,7 +97,7 @@ def _unswizzle_scale(
     )
 
 
-def _validate_fp4_moe_shared_user_tensors(
+def _validate_fused_moe_batch_invariant_nvfp4_inputs(
     *,
     hidden_states: torch.Tensor,
     topk_ids: torch.Tensor,
@@ -127,12 +106,16 @@ def _validate_fp4_moe_shared_user_tensors(
     w13_weight_scale: torch.Tensor,
     w2_weight: torch.Tensor,
     w2_weight_scale: torch.Tensor,
+    a1_gscale: torch.Tensor | None,
+    g1_alphas: torch.Tensor | None,
+    a2_gscale: torch.Tensor | None,
+    g2_alphas: torch.Tensor | None,
     output: torch.Tensor,
     workspace13: torch.Tensor,
     workspace2: torch.Tensor,
     expert_map: torch.Tensor | None,
+    num_experts: int,
 ) -> None:
-    """Layouts shared by batch-invariant FP4 fused MoE entry points."""
     assert hidden_states.is_contiguous(), "hidden_states must be contiguous"
     assert hidden_states.dtype in (torch.float16, torch.bfloat16), (
         f"hidden_states must be float16 or bfloat16, got {hidden_states.dtype}"
@@ -154,40 +137,6 @@ def _validate_fp4_moe_shared_user_tensors(
     assert w2_weight_scale.is_contiguous(), "w2_weight_scale must be contiguous"
     if expert_map is not None:
         assert expert_map.is_contiguous(), "expert_map must be contiguous"
-
-
-def _validate_fused_moe_batch_invariant_nvfp4_inputs(
-    *,
-    hidden_states: torch.Tensor,
-    topk_ids: torch.Tensor,
-    topk_weights: torch.Tensor,
-    w13_weight: torch.Tensor,
-    w13_weight_scale: torch.Tensor,
-    w2_weight: torch.Tensor,
-    w2_weight_scale: torch.Tensor,
-    a1_gscale: torch.Tensor | None,
-    g1_alphas: torch.Tensor | None,
-    a2_gscale: torch.Tensor | None,
-    g2_alphas: torch.Tensor | None,
-    output: torch.Tensor,
-    workspace13: torch.Tensor,
-    workspace2: torch.Tensor,
-    expert_map: torch.Tensor | None,
-    num_experts: int,
-) -> None:
-    _validate_fp4_moe_shared_user_tensors(
-        hidden_states=hidden_states,
-        topk_ids=topk_ids,
-        topk_weights=topk_weights,
-        w13_weight=w13_weight,
-        w13_weight_scale=w13_weight_scale,
-        w2_weight=w2_weight,
-        w2_weight_scale=w2_weight_scale,
-        output=output,
-        workspace13=workspace13,
-        workspace2=workspace2,
-        expert_map=expert_map,
-    )
 
     for name, tensor in (
         ("a1_gscale", a1_gscale),
@@ -301,23 +250,17 @@ def _grouped_matmul_fp4_packed_persistent_kernel(
     NUM_SMS: tl.constexpr,
     A_LARGE: tl.constexpr,
     B_LARGE: tl.constexpr,
-    A_MODE: tl.constexpr,
-    A_DOT_TYPE: tl.constexpr,
     B_SCALE_GROUP: tl.constexpr,
     HAS_ALPHA: tl.constexpr,
     HAS_BIAS: tl.constexpr,
 ):
-    """Persistent packed grouped FP4 expert weights with selectable A-side precision.
+    """Persistent packed grouped NVFP4 GEMM with FP4 activations and weights.
 
+    Both A and B are packed FP4 with per-block float8_e4m3fn scales.
     Launches ``NUM_SMS`` programs that loop over a global tile index space
     built from a prefix-sum of per-expert tile counts.  Each iteration maps
     a global tile id to ``(expert_id, local_tile_id)`` via binary search,
-    then executes the same GEMM tile logic as the non-persistent kernel.
-
-    ``A_MODE`` selects the A-side contract:
-    - NVFP4 packed FP4 + block scales
-    - BF16/FP16 dense activations without A scales
-    - MXFP8 dense FP8 activations with block scales
+    then executes the GEMM tile.
 
     B and B-scale tensors are pre-flattened by the wrapper:
     ``b_fp4`` from ``[E, N, K_packed]`` to ``[E*N, K_packed]``, and
@@ -345,22 +288,13 @@ def _grouped_matmul_fp4_packed_persistent_kernel(
     num_pid_in_group = GROUP_SIZE_M * num_pid_n
 
     # Global descriptors created once before the loop.
-    if A_MODE == _A_NVFP4_PACKED:
-        a_desc = tl.make_tensor_descriptor(
-            a_ptr,
-            shape=[M_total, k_bytes_total],
-            strides=[stride_am, stride_ak],
-            block_shape=[BLOCK_SIZE_M, K_BYTES],
-            padding_option="zero",
-        )
-    else:
-        a_desc = tl.make_tensor_descriptor(
-            a_ptr,
-            shape=[M_total, K_total],
-            strides=[stride_am, stride_ak],
-            block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_K],
-            padding_option="zero",
-        )
+    a_desc = tl.make_tensor_descriptor(
+        a_ptr,
+        shape=[M_total, k_bytes_total],
+        strides=[stride_am, stride_ak],
+        block_shape=[BLOCK_SIZE_M, K_BYTES],
+        padding_option="zero",
+    )
     # B flattened to [E*N, K_packed] by the wrapper.
     b_desc = tl.make_tensor_descriptor(
         b_ptr,
@@ -369,29 +303,28 @@ def _grouped_matmul_fp4_packed_persistent_kernel(
         block_shape=[BLOCK_SIZE_N, K_BYTES],
         padding_option="zero",
     )
-    if A_MODE != _A_BF16:
-        a_scale_desc = tl.make_tensor_descriptor(
-            a_scale_ptr,
-            shape=[
-                1,
-                tl.cdiv(a_scale_rows_total, 128),
-                a_scale_cols_total // 4,
-                2,
-                256,
-            ],
-            strides=[
-                tl.cdiv(a_scale_rows_total, 128)
-                * (a_scale_cols_total // 4)
-                * 512
-                * stride_ask,
-                (a_scale_cols_total // 4) * 512 * stride_ask,
-                512 * stride_ask,
-                256 * stride_ask,
-                stride_ask,
-            ],
-            block_shape=[1, SCALE_M_TILES, SCALE_K_TILES, 2, 256],
-            padding_option="zero",
-        )
+    a_scale_desc = tl.make_tensor_descriptor(
+        a_scale_ptr,
+        shape=[
+            1,
+            tl.cdiv(a_scale_rows_total, 128),
+            a_scale_cols_total // 4,
+            2,
+            256,
+        ],
+        strides=[
+            tl.cdiv(a_scale_rows_total, 128)
+            * (a_scale_cols_total // 4)
+            * 512
+            * stride_ask,
+            (a_scale_cols_total // 4) * 512 * stride_ask,
+            512 * stride_ask,
+            256 * stride_ask,
+            stride_ask,
+        ],
+        block_shape=[1, SCALE_M_TILES, SCALE_K_TILES, 2, 256],
+        padding_option="zero",
+    )
     # B-scale flattened to [E*N_pad, K_s] by the wrapper.
     b_scale_n_tiles = tl.cdiv(num_experts * b_scale_n_per_expert, 128)
     b_scale_desc = tl.make_tensor_descriptor(
@@ -423,11 +356,9 @@ def _grouped_matmul_fp4_packed_persistent_kernel(
         )
 
         expert_row_offset = tl.load(expert_offsets_ptr + expert_id).to(tl.int32)
-        if A_MODE != _A_BF16:
-            expert_scale_offset = tl.load(a_scale_offsets_ptr + expert_id).to(tl.int32)
+        expert_scale_offset = tl.load(a_scale_offsets_ptr + expert_id).to(tl.int32)
         expert_row_offset = _maybe_widen(expert_row_offset, A_LARGE)
-        if A_MODE != _A_BF16:
-            expert_scale_offset = _maybe_widen(expert_scale_offset, A_LARGE)
+        expert_scale_offset = _maybe_widen(expert_scale_offset, A_LARGE)
 
         if HAS_ALPHA:
             alpha = tl.load(alpha_ptr + expert_id).to(tl.float32)
@@ -454,14 +385,8 @@ def _grouped_matmul_fp4_packed_persistent_kernel(
             a_m_start = _maybe_widen(expert_row_offset + start_m, A_LARGE)
             b_n_start = _maybe_widen(b_row_offset + start_n, B_LARGE)
 
-            if A_MODE == _A_NVFP4_PACKED:
-                a = a_desc.load([a_m_start, k_start_bytes])
-                a = tl.where(m_mask[:, None] & k_byte_mask[None, :], a, 0)
-            else:
-                k_start_elems = _maybe_widen(ki * BLOCK_SIZE_K, A_LARGE)
-                a = a_desc.load([a_m_start, k_start_elems])
-                k_elem_mask = (ki * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)) < K_total
-                a = tl.where(m_mask[:, None] & k_elem_mask[None, :], a, 0)
+            a = a_desc.load([a_m_start, k_start_bytes])
+            a = tl.where(m_mask[:, None] & k_byte_mask[None, :], a, 0)
             b_raw = b_desc.load([b_n_start, k_start_bytes])
             b = tl.where(n_mask[:, None] & k_byte_mask[None, :], b_raw, 0).T
 
@@ -475,23 +400,18 @@ def _grouped_matmul_fp4_packed_persistent_kernel(
                 TILE_SCALE_COLS=SCALE_K_TILE,
             )
 
-            if A_MODE == _A_NVFP4_PACKED or A_MODE == _A_MXFP8:  # noqa: SIM109
-                scale_tile_m = _maybe_widen(
-                    (expert_scale_offset + start_m) // 128, A_LARGE
-                )
-                a_scale_raw = a_scale_desc.load([0, scale_tile_m, scale_tile_k, 0, 0])
-                a_scale = _unswizzle_scale(
-                    a_scale_raw.reshape(BLOCK_SIZE_M, SCALE_K_TILE),
-                    TILE_ROWS=BLOCK_SIZE_M,
-                    TILE_SCALE_COLS=SCALE_K_TILE,
-                )
-            else:
-                a_scale = None
+            scale_tile_m = _maybe_widen((expert_scale_offset + start_m) // 128, A_LARGE)
+            a_scale_raw = a_scale_desc.load([0, scale_tile_m, scale_tile_k, 0, 0])
+            a_scale = _unswizzle_scale(
+                a_scale_raw.reshape(BLOCK_SIZE_M, SCALE_K_TILE),
+                TILE_ROWS=BLOCK_SIZE_M,
+                TILE_SCALE_COLS=SCALE_K_TILE,
+            )
 
             accumulator = tl.dot_scaled(
                 a,
                 a_scale,
-                A_DOT_TYPE,
+                "e2m1",
                 b,
                 b_scale,
                 "e2m1",
@@ -690,8 +610,6 @@ def _grouped_matmul_nvfp4_packed(
         NUM_SMS=NUM_SMS,
         A_LARGE=A_LARGE,
         B_LARGE=B_LARGE,
-        A_MODE=_GroupedGemmAMode.NVFP4_PACKED.value,
-        A_DOT_TYPE=_A_DOT_TYPE[_GroupedGemmAMode.NVFP4_PACKED],
         B_SCALE_GROUP=16,
         HAS_ALPHA=True,
         HAS_BIAS=False,
@@ -948,8 +866,8 @@ def fused_moe_batch_invariant_nvfp4(
 # ---------------------------------------------------------------------------
 
 
-class _BatchInvariantFP4ExpertsBase(mk.FusedMoEExpertsModular, ABC):
-    """Shared batch-invariant FP4 MoE expert logic."""
+class BatchInvariantNvfp4Experts(mk.FusedMoEExpertsModular):
+    """Batch-invariant NVFP4 (W4A4) MoE experts."""
 
     def __init__(
         self,
@@ -958,6 +876,21 @@ class _BatchInvariantFP4ExpertsBase(mk.FusedMoEExpertsModular, ABC):
     ):
         super().__init__(moe_config, quant_config)
         self._num_local_experts = moe_config.num_local_experts
+        self._cached_scale_vecs: (
+            tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor] | None
+        ) = None
+
+        E = moe_config.num_local_experts
+        device = moe_config.device
+        self._workspace = NvFP4MoEWorkspace(
+            expert_offsets=torch.empty(E + 1, dtype=torch.int32, device=device),
+            blockscale_offsets=torch.empty(E + 1, dtype=torch.int32, device=device),
+            problem_sizes1=torch.empty(E, 3, dtype=torch.int32, device=device),
+            problem_sizes2=torch.empty(E, 3, dtype=torch.int32, device=device),
+            tiles_per_expert=torch.empty(E, dtype=torch.int32, device=device),
+            expert_tile_start=torch.zeros(E + 1, dtype=torch.int32, device=device),
+            dummy_bias=torch.empty(0, device=device, dtype=torch.float32),
+        )
 
     @property
     def expects_unquantized_inputs(self) -> bool:
@@ -977,6 +910,13 @@ class _BatchInvariantFP4ExpertsBase(mk.FusedMoEExpertsModular, ABC):
         return True
 
     @staticmethod
+    def _supports_quant_scheme(
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> bool:
+        return (weight_key, activation_key) == (kNvfp4Static, kNvfp4Dynamic)
+
+    @staticmethod
     def _supports_parallel_config(
         moe_parallel_config: FusedMoEParallelConfig,
     ) -> bool:
@@ -990,66 +930,6 @@ class _BatchInvariantFP4ExpertsBase(mk.FusedMoEExpertsModular, ABC):
     def activation_format() -> mk.FusedMoEActivationFormat:
         return mk.FusedMoEActivationFormat.Standard
 
-    def supports_chunking(self) -> bool:
-        return True
-
-    def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
-        return TopKWeightAndReduceNoOP()
-
-    def workspace_shapes(
-        self,
-        M: int,
-        N: int,
-        K: int,
-        topk: int,
-        global_num_experts: int,
-        local_num_experts: int,
-        expert_tokens_meta: mk.ExpertTokensMetadata | None,
-        activation: MoEActivation,
-    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
-        act_out_dim = self.adjust_N_for_activation(N, activation)
-        m_total = M * topk
-        cols13 = max(N, K)
-        extra = _map_extra_rows(m_total, cols13)
-        workspace13 = (m_total + extra, cols13)
-        workspace2 = (m_total, max(act_out_dim, K))
-        output_shape = (M, K)
-        return (workspace13, workspace2, output_shape)
-
-    @abstractmethod
-    def apply(
-        self,
-        output: torch.Tensor,
-        hidden_states: torch.Tensor,
-        w1: torch.Tensor,
-        w2: torch.Tensor,
-        topk_weights: torch.Tensor,
-        topk_ids: torch.Tensor,
-        activation: MoEActivation,
-        global_num_experts: int,
-        expert_map: torch.Tensor | None,
-        a1q_scale: torch.Tensor | None,
-        a2_scale: torch.Tensor | None,
-        workspace13: torch.Tensor,
-        workspace2: torch.Tensor,
-        expert_tokens_meta: mk.ExpertTokensMetadata | None,
-        apply_router_weight_on_input: bool | None,
-    ) -> None: ...
-
-    def moe_sum(self, input: torch.Tensor, output: torch.Tensor) -> None:
-        raise NotImplementedError("LoRA is not supported for batch-invariant FP4 MoE")
-
-
-class BatchInvariantNvfp4Experts(_BatchInvariantFP4ExpertsBase):
-    """Batch-invariant NVFP4 (W4A4) MoE experts."""
-
-    @staticmethod
-    def _supports_quant_scheme(
-        weight_key: QuantKey | None,
-        activation_key: QuantKey | None,
-    ) -> bool:
-        return (weight_key, activation_key) == (kNvfp4Static, kNvfp4Dynamic)
-
     @staticmethod
     def is_supported_config(
         cls,
@@ -1058,8 +938,6 @@ class BatchInvariantNvfp4Experts(_BatchInvariantFP4ExpertsBase):
         activation_key: QuantKey | None,
         activation_format: mk.FusedMoEActivationFormat,
     ) -> tuple[bool, str | None]:
-        # Use it when batch invariance is requested (env)
-        # or the user pinned moe_backend explicitly.
         if (
             not envs.VLLM_BATCH_INVARIANT
             and moe_config.moe_backend != "batch_invariant"
@@ -1089,30 +967,34 @@ class BatchInvariantNvfp4Experts(_BatchInvariantFP4ExpertsBase):
             cls, moe_config, weight_key, activation_key, activation_format
         )
 
+    def supports_chunking(self) -> bool:
+        return True
+
     def supports_expert_map(self) -> bool:
         return False
 
-    def __init__(
-        self,
-        moe_config: mk.FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
-    ):
-        super().__init__(moe_config, quant_config)
-        self._cached_scale_vecs: (
-            tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor] | None
-        ) = None
+    def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
+        return TopKWeightAndReduceNoOP()
 
-        E = moe_config.num_local_experts
-        device = moe_config.device
-        self._workspace = NvFP4MoEWorkspace(
-            expert_offsets=torch.empty(E + 1, dtype=torch.int32, device=device),
-            blockscale_offsets=torch.empty(E + 1, dtype=torch.int32, device=device),
-            problem_sizes1=torch.empty(E, 3, dtype=torch.int32, device=device),
-            problem_sizes2=torch.empty(E, 3, dtype=torch.int32, device=device),
-            tiles_per_expert=torch.empty(E, dtype=torch.int32, device=device),
-            expert_tile_start=torch.zeros(E + 1, dtype=torch.int32, device=device),
-            dummy_bias=torch.empty(0, device=device, dtype=torch.float32),
-        )
+    def workspace_shapes(
+        self,
+        M: int,
+        N: int,
+        K: int,
+        topk: int,
+        global_num_experts: int,
+        local_num_experts: int,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        activation: MoEActivation,
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        act_out_dim = self.adjust_N_for_activation(N, activation)
+        m_total = M * topk
+        cols13 = max(N, K)
+        extra = _map_extra_rows(m_total, cols13)
+        workspace13 = (m_total + extra, cols13)
+        workspace2 = (m_total, max(act_out_dim, K))
+        output_shape = (M, K)
+        return (workspace13, workspace2, output_shape)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         # Fuse activation scales into w_scale_2 in-place so that
@@ -1175,3 +1057,6 @@ class BatchInvariantNvfp4Experts(_BatchInvariantFP4ExpertsBase):
             apply_router_weight_on_input=bool(apply_router_weight_on_input),
             expert_map=expert_map,
         )
+
+    def moe_sum(self, input: torch.Tensor, output: torch.Tensor) -> None:
+        raise NotImplementedError("LoRA is not supported for batch-invariant FP4 MoE")

--- a/vllm/model_executor/layers/fused_moe/batch_invariant_fp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/batch_invariant_fp4_moe.py
@@ -426,26 +426,6 @@ def _grouped_matmul_fp4_packed_persistent_kernel(
         tl.store(c_ptrs, c, mask=m_mask[:, None] & n_mask[None, :])
 
 
-def _canonicalize_grouped_offsets(
-    offsets: torch.Tensor,
-    *,
-    num_experts: int,
-    name: str,
-) -> torch.Tensor:
-    if offsets.ndim != 1:
-        raise RuntimeError(f"{name} must be 1-D, got shape {tuple(offsets.shape)}.")
-    if offsets.numel() == num_experts + 1:
-        offsets = offsets[:-1]
-    if offsets.numel() != num_experts:
-        raise RuntimeError(
-            f"{name} must have {num_experts} or {num_experts + 1} entries, "
-            f"got {offsets.numel()}."
-        )
-    if offsets.dtype not in (torch.int32, torch.int64):
-        offsets = offsets.to(dtype=torch.int32)
-    return offsets
-
-
 def _grouped_matmul_nvfp4_packed(
     a_fp4: torch.Tensor,
     b_fp4: torch.Tensor,
@@ -475,25 +455,18 @@ def _grouped_matmul_nvfp4_packed(
             scales.
         b_scale: [E, N_pad, K_s] float8_e4m3fn swizzled weight block scales.
         alpha: [E] float32 per-expert alpha.
-        expert_offsets: [E] or [E+1] start row offsets in ``a_fp4``/output.
+        expert_offsets: [E+1] int32 prefix-sum row offsets in ``a_fp4``/output.
         problem_sizes: [E, 3] int tensor containing per-expert (M, N, K).
-        a_scale_offsets: Optional [E] or [E+1] start row offsets in ``a_scale``.
-            If not provided, ``expert_offsets`` are reused.
+        a_scale_offsets: Optional [E+1] int32 prefix-sum row offsets in
+            ``a_scale``. If not provided, ``expert_offsets`` are reused.
         output: Pre-allocated [>= M_total, >= N_max] tensor for the GEMM output.
 
     Returns:
         [M_total, N_max] tensor with grouped expert GEMM outputs.
     """
-    assert a_fp4.ndim == 2 and b_fp4.ndim == 3, (
-        "Expected packed a_fp4=[M_total, K_packed] and b_fp4=[E, N, K_packed]."
-    )
     assert a_fp4.dtype == torch.uint8 and b_fp4.dtype == torch.uint8
-    assert a_scale.ndim == 2 and b_scale.ndim == 3
     assert a_scale.dtype == torch.float8_e4m3fn and b_scale.dtype == torch.float8_e4m3fn
     assert alpha.dtype == torch.float32
-    assert problem_sizes.ndim == 2 and problem_sizes.shape[1] == 3, (
-        f"Expected problem_sizes shape [E, 3], got {tuple(problem_sizes.shape)}."
-    )
 
     E = b_fp4.shape[0]
     if E == 0:
@@ -501,22 +474,11 @@ def _grouped_matmul_nvfp4_packed(
         N_out = b_fp4.shape[1]
         return output.flatten()[: M_logical * N_out].view(M_logical, N_out)
 
-    assert problem_sizes.shape[0] == E, (
-        f"Expected problem_sizes.shape[0] == num_experts ({E}), "
-        f"got {problem_sizes.shape[0]}."
-    )
-    assert b_fp4.shape[2] == a_fp4.shape[1], "Packed K dimensions must match."
-    assert alpha.numel() == E, f"alpha must have {E} elements, got {alpha.numel()}."
-
     if a_scale_offsets is None:
         a_scale_offsets = expert_offsets
 
-    expert_offsets = _canonicalize_grouped_offsets(
-        expert_offsets, num_experts=E, name="expert_offsets"
-    )
-    a_scale_offsets = _canonicalize_grouped_offsets(
-        a_scale_offsets, num_experts=E, name="a_scale_offsets"
-    )
+    expert_offsets = expert_offsets[:-1]
+    a_scale_offsets = a_scale_offsets[:-1]
 
     BLOCK_SIZE_M = 128
     BLOCK_SIZE_N = 128

--- a/vllm/model_executor/layers/fused_moe/batch_invariant_fp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/batch_invariant_fp4_moe.py
@@ -5,7 +5,6 @@
 from dataclasses import dataclass
 
 import torch
-import torch.nn.functional as F
 
 import vllm._custom_ops as ops
 import vllm.envs as envs
@@ -27,6 +26,10 @@ from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
 from vllm.model_executor.layers.fused_moe.utils import _resize_cache
+from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
+    pad_nvfp4_activation_for_cutlass,
+    slice_nvfp4_output,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kNvfp4Dynamic,
@@ -780,25 +783,24 @@ def fused_moe_batch_invariant_nvfp4(
         blockscale_offsets,
         top_k,
     )
-    if w1_padding_cols > 0:
-        a1_fp4 = F.pad(a1_fp4, (0, w1_padding_cols))
-
-    gemm1_out = _grouped_matmul_nvfp4_packed(
-        a_fp4=a1_fp4,
-        b_fp4=w13_weight,
-        a_scale=a1_scale,
-        b_scale=w13_weight_scale,
-        alpha=g1_alphas,
-        expert_offsets=expert_offsets,
-        a_scale_offsets=blockscale_offsets,
-        problem_sizes=problem_sizes1,
-        output=workspace13,
-        tiles_per_expert=workspace.tiles_per_expert,
-        expert_tile_start=workspace.expert_tile_start,
-        dummy_bias=workspace.dummy_bias,
+    a1_fp4 = pad_nvfp4_activation_for_cutlass(a1_fp4, w1_padding_cols)
+    gemm1_out = slice_nvfp4_output(
+        _grouped_matmul_nvfp4_packed(
+            a_fp4=a1_fp4,
+            b_fp4=w13_weight,
+            a_scale=a1_scale,
+            b_scale=w13_weight_scale,
+            alpha=g1_alphas,
+            expert_offsets=expert_offsets,
+            a_scale_offsets=blockscale_offsets,
+            problem_sizes=problem_sizes1,
+            output=workspace13,
+            tiles_per_expert=workspace.tiles_per_expert,
+            expert_tile_start=workspace.expert_tile_start,
+            dummy_bias=workspace.dummy_bias,
+        ),
+        w1_output_size,
     )
-    if gemm1_out.shape[-1] != w1_output_size:
-        gemm1_out = gemm1_out[:, :w1_output_size].contiguous()
 
     if activation_kind == MoEActivation.SILU:
         int_fp4, int_scale = ops.silu_and_mul_scaled_fp4_experts_quant(
@@ -822,25 +824,24 @@ def fused_moe_batch_invariant_nvfp4(
             blockscale_offsets,
             top_k,
         )
-    if w2_padding_cols > 0:
-        int_fp4 = F.pad(int_fp4, (0, w2_padding_cols))
-
-    gemm2_out = _grouped_matmul_nvfp4_packed(
-        a_fp4=int_fp4,
-        b_fp4=w2_weight,
-        a_scale=int_scale,
-        b_scale=w2_weight_scale,
-        alpha=g2_alphas,
-        expert_offsets=expert_offsets,
-        a_scale_offsets=blockscale_offsets,
-        problem_sizes=problem_sizes2,
-        output=workspace2,
-        tiles_per_expert=workspace.tiles_per_expert,
-        expert_tile_start=workspace.expert_tile_start,
-        dummy_bias=workspace.dummy_bias,
+    int_fp4 = pad_nvfp4_activation_for_cutlass(int_fp4, w2_padding_cols)
+    gemm2_out = slice_nvfp4_output(
+        _grouped_matmul_nvfp4_packed(
+            a_fp4=int_fp4,
+            b_fp4=w2_weight,
+            a_scale=int_scale,
+            b_scale=w2_weight_scale,
+            alpha=g2_alphas,
+            expert_offsets=expert_offsets,
+            a_scale_offsets=blockscale_offsets,
+            problem_sizes=problem_sizes2,
+            output=workspace2,
+            tiles_per_expert=workspace.tiles_per_expert,
+            expert_tile_start=workspace.expert_tile_start,
+            dummy_bias=workspace.dummy_bias,
+        ),
+        w2_output_size,
     )
-    if gemm2_out.shape[-1] != w2_output_size:
-        gemm2_out = gemm2_out[:, :w2_output_size].contiguous()
 
     epilogue_topk_weights = (
         torch.ones_like(routed_topk_weights)

--- a/vllm/model_executor/layers/fused_moe/batch_invariant_fp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/batch_invariant_fp4_moe.py
@@ -1,0 +1,1116 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Batch-invariant NVFP4 fused MoE expert implementations."""
+
+from abc import ABC, abstractmethod
+from enum import Enum
+
+import torch
+import torch.nn.functional as F
+
+import vllm._custom_ops as ops
+import vllm.envs as envs
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.logger import init_logger
+from vllm.model_executor.layers.batch_invariant import _compute_pid
+from vllm.model_executor.layers.fused_moe.activation import (
+    MoEActivation,
+    apply_moe_activation,
+)
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEParallelConfig,
+    FusedMoEQuantConfig,
+)
+from vllm.model_executor.layers.fused_moe.moe_permute_unpermute import (
+    moe_unpermute,
+)
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceNoOP,
+)
+from vllm.model_executor.layers.fused_moe.utils import _resize_cache
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
+    kNvfp4Dynamic,
+    kNvfp4Static,
+)
+from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.platform_utils import num_compute_units
+
+logger = init_logger(__name__)
+
+
+class _GroupedGemmAMode(Enum):
+    NVFP4_PACKED = 0
+    BF16 = 1
+    MXFP8 = 2
+
+
+# Plain integer constants for use inside Triton kernels, which cannot resolve
+# Python Enum attribute access at compile time.
+_A_NVFP4_PACKED = tl.constexpr(int(_GroupedGemmAMode.NVFP4_PACKED.value))
+_A_BF16 = tl.constexpr(int(_GroupedGemmAMode.BF16.value))
+_A_MXFP8 = tl.constexpr(int(_GroupedGemmAMode.MXFP8.value))
+
+_A_DOT_TYPE: dict[_GroupedGemmAMode, str] = {
+    _GroupedGemmAMode.NVFP4_PACKED: "e2m1",
+    _GroupedGemmAMode.BF16: "bf16",
+    _GroupedGemmAMode.MXFP8: "e4m3",
+}
+
+
+@triton.jit
+def _unswizzle_scale(
+    scale_raw,
+    TILE_ROWS: tl.constexpr,
+    TILE_SCALE_COLS: tl.constexpr,
+):
+    """Un-swizzle NVFP4 block scales from hardware-interleaved 128x4 layout
+    to standard 2D row-major layout expected by tl.dot_scaled.
+
+    The swizzled layout stores a (M, K_s) scale tensor as:
+        (M//128, K_s//4, 32, 4, 4)
+    The standard layout is:
+        (M//128, 4, 32, K_s//4, 4)
+    The inverse permutation (0, 3, 2, 1, 4) recovers the standard layout.
+    """
+    return (
+        scale_raw.reshape(TILE_ROWS // 128, TILE_SCALE_COLS // 4, 32, 4, 4)
+        .trans(0, 3, 2, 1, 4)
+        .reshape(TILE_ROWS, TILE_SCALE_COLS)
+    )
+
+
+def _validate_fp4_moe_shared_user_tensors(
+    *,
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    w13_weight: torch.Tensor,
+    w13_weight_scale: torch.Tensor,
+    w2_weight: torch.Tensor,
+    w2_weight_scale: torch.Tensor,
+    output: torch.Tensor,
+    workspace13: torch.Tensor,
+    workspace2: torch.Tensor,
+    expert_map: torch.Tensor | None,
+) -> None:
+    """Layouts shared by batch-invariant FP4 fused MoE entry points."""
+    assert hidden_states.is_contiguous(), "hidden_states must be contiguous"
+    assert hidden_states.dtype in (torch.float16, torch.bfloat16), (
+        f"hidden_states must be float16 or bfloat16, got {hidden_states.dtype}"
+    )
+    assert topk_ids.is_contiguous(), "topk_ids must be contiguous"
+    assert topk_ids.dtype == torch.int32, (
+        f"topk_ids must be int32, got {topk_ids.dtype}"
+    )
+    assert topk_weights.is_contiguous(), "topk_weights must be contiguous"
+    assert topk_weights.dtype == torch.float32, (
+        f"topk_weights must be float32, got {topk_weights.dtype}"
+    )
+    assert output.is_contiguous(), "output must be contiguous"
+    assert workspace13.is_contiguous(), "workspace13 must be contiguous"
+    assert workspace2.is_contiguous(), "workspace2 must be contiguous"
+    assert w13_weight.is_contiguous(), "w13_weight must be contiguous"
+    assert w13_weight_scale.is_contiguous(), "w13_weight_scale must be contiguous"
+    assert w2_weight.is_contiguous(), "w2_weight must be contiguous"
+    assert w2_weight_scale.is_contiguous(), "w2_weight_scale must be contiguous"
+    if expert_map is not None:
+        assert expert_map.is_contiguous(), "expert_map must be contiguous"
+
+
+def _validate_fused_moe_batch_invariant_nvfp4_inputs(
+    *,
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    w13_weight: torch.Tensor,
+    w13_weight_scale: torch.Tensor,
+    w2_weight: torch.Tensor,
+    w2_weight_scale: torch.Tensor,
+    a1_gscale: torch.Tensor | None,
+    g1_alphas: torch.Tensor | None,
+    a2_gscale: torch.Tensor | None,
+    g2_alphas: torch.Tensor | None,
+    output: torch.Tensor,
+    workspace13: torch.Tensor,
+    workspace2: torch.Tensor,
+    expert_map: torch.Tensor | None,
+    num_experts: int,
+) -> None:
+    _validate_fp4_moe_shared_user_tensors(
+        hidden_states=hidden_states,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        w13_weight=w13_weight,
+        w13_weight_scale=w13_weight_scale,
+        w2_weight=w2_weight,
+        w2_weight_scale=w2_weight_scale,
+        output=output,
+        workspace13=workspace13,
+        workspace2=workspace2,
+        expert_map=expert_map,
+    )
+
+    for name, tensor in (
+        ("a1_gscale", a1_gscale),
+        ("a2_gscale", a2_gscale),
+        ("g1_alphas", g1_alphas),
+        ("g2_alphas", g2_alphas),
+    ):
+        if tensor is None:
+            raise RuntimeError(f"Missing required NVFP4 MoE tensor: {name}")
+        assert tensor.ndim == 1, (
+            f"NVFP4 MoE tensor '{name}' must be 1-D, got shape {tuple(tensor.shape)}."
+        )
+        assert tensor.dtype == torch.float32, (
+            f"NVFP4 MoE tensor '{name}' must be float32, got {tensor.dtype}."
+        )
+        assert tensor.is_contiguous(), f"NVFP4 MoE tensor '{name}' must be contiguous."
+        assert tensor.numel() == num_experts, (
+            f"NVFP4 MoE tensor '{name}' must have {num_experts} elements, "
+            f"got {tensor.numel()}."
+        )
+
+
+def _nvfp4_moe_map_experts(
+    topk_ids: torch.Tensor, expert_map: torch.Tensor
+) -> torch.Tensor:
+    flat_ids = topk_ids.reshape(-1).to(torch.long)
+    if expert_map.numel() == 0:
+        return torch.full(topk_ids.shape, -1, dtype=torch.int32, device=topk_ids.device)
+    valid = (flat_ids >= 0) & (flat_ids < expert_map.numel())
+    clamped = flat_ids.clamp(min=0, max=max(0, expert_map.numel() - 1))
+    remapped = expert_map.to(torch.long).index_select(0, clamped)
+    mapped = torch.where(valid, remapped, torch.full_like(remapped, -1))
+    return mapped.reshape(topk_ids.shape).to(dtype=torch.int32)
+
+
+# ---------------------------------------------------------------------------
+# Packed grouped NVFP4 GEMM kernel and wrapper
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _find_expert_bin_search(
+    expert_tile_start_ptr,
+    global_tile_id,
+    num_experts,
+):
+    """Binary search to find which expert owns ``global_tile_id``.
+
+    ``expert_tile_start_ptr`` points to an ``[E+1]`` prefix-sum array where
+    ``expert_tile_start[e]`` is the first global tile belonging to expert
+    ``e``.  Returns the expert index ``e`` such that
+    ``expert_tile_start[e] <= global_tile_id < expert_tile_start[e+1]``.
+    """
+    lo: tl.int32 = 0
+    hi: tl.int32 = num_experts
+    while lo < hi:
+        mid = (lo + hi) // 2
+        val = tl.load(expert_tile_start_ptr + mid + 1).to(tl.int32)
+        if val <= global_tile_id:
+            lo = mid + 1
+        else:
+            hi = mid
+    return lo
+
+
+@triton.jit
+def _maybe_widen(val, LARGE: tl.constexpr):
+    """Promote *val* to int64 when LARGE (tensor exceeds int32 indexing)."""
+    if LARGE:
+        return val.to(tl.int64)
+    return val
+
+
+@triton.jit
+def _grouped_matmul_fp4_packed_persistent_kernel(
+    a_ptr,
+    a_scale_ptr,
+    b_ptr,
+    b_scale_ptr,
+    c_ptr,
+    alpha_ptr,
+    bias_ptr,
+    expert_offsets_ptr,
+    a_scale_offsets_ptr,
+    problem_sizes_ptr,
+    expert_tile_start_ptr,
+    num_experts,
+    M_total,
+    N_total,
+    K_total,
+    a_scale_rows_total,
+    stride_ps0,
+    stride_ps1,
+    stride_am,
+    stride_ak,
+    stride_asm,
+    stride_ask,
+    stride_bm,
+    stride_bk,
+    stride_bsk,
+    stride_cm,
+    stride_cn,
+    stride_bias_e,
+    a_scale_cols_total,
+    b_scale_cols_total,
+    b_scale_n_per_expert,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    A_LARGE: tl.constexpr,
+    B_LARGE: tl.constexpr,
+    A_MODE: tl.constexpr,
+    A_DOT_TYPE: tl.constexpr,
+    B_SCALE_GROUP: tl.constexpr,
+    HAS_ALPHA: tl.constexpr,
+    HAS_BIAS: tl.constexpr,
+):
+    """Persistent packed grouped FP4 expert weights with selectable A-side precision.
+
+    Launches ``NUM_SMS`` programs that loop over a global tile index space
+    built from a prefix-sum of per-expert tile counts.  Each iteration maps
+    a global tile id to ``(expert_id, local_tile_id)`` via binary search,
+    then executes the same GEMM tile logic as the non-persistent kernel.
+
+    ``A_MODE`` selects the A-side contract:
+    - NVFP4 packed FP4 + block scales
+    - BF16/FP16 dense activations without A scales
+    - MXFP8 dense FP8 activations with block scales
+
+    B and B-scale tensors are pre-flattened by the wrapper:
+    ``b_fp4`` from ``[E, N, K_packed]`` to ``[E*N, K_packed]``, and
+    ``b_scale`` from ``[E, N_pad, K_s]`` to ``[E*N_pad, K_s]``.
+    ``b_scale_n_per_expert`` = N_pad (may differ from N_total).
+
+    When ``HAS_BIAS=True``, a per-expert bias vector ``[E, N]`` is added
+    to the float32 accumulator after the optional alpha multiply and before
+    the output cast/store.
+    """
+    start_pid = tl.program_id(axis=0)
+    total_tiles = tl.load(expert_tile_start_ptr + num_experts).to(tl.int32)
+
+    K_BYTES: tl.constexpr = BLOCK_SIZE_K // 2
+    SCALE_K_TILE: tl.constexpr = BLOCK_SIZE_K // B_SCALE_GROUP
+    SCALE_K_TILES: tl.constexpr = SCALE_K_TILE // 4
+    SCALE_M_TILES: tl.constexpr = BLOCK_SIZE_M // 128
+    SCALE_N_TILES: tl.constexpr = BLOCK_SIZE_N // 128
+
+    k_bytes_total = K_total // 2
+
+    # N and K are uniform across experts; hoist derived values before the loop.
+    k_tiles = tl.cdiv(K_total, BLOCK_SIZE_K)
+    num_pid_n = tl.cdiv(N_total, BLOCK_SIZE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+
+    # Global descriptors created once before the loop.
+    if A_MODE == _A_NVFP4_PACKED:
+        a_desc = tl.make_tensor_descriptor(
+            a_ptr,
+            shape=[M_total, k_bytes_total],
+            strides=[stride_am, stride_ak],
+            block_shape=[BLOCK_SIZE_M, K_BYTES],
+            padding_option="zero",
+        )
+    else:
+        a_desc = tl.make_tensor_descriptor(
+            a_ptr,
+            shape=[M_total, K_total],
+            strides=[stride_am, stride_ak],
+            block_shape=[BLOCK_SIZE_M, BLOCK_SIZE_K],
+            padding_option="zero",
+        )
+    # B flattened to [E*N, K_packed] by the wrapper.
+    b_desc = tl.make_tensor_descriptor(
+        b_ptr,
+        shape=[num_experts * N_total, k_bytes_total],
+        strides=[stride_bm, stride_bk],
+        block_shape=[BLOCK_SIZE_N, K_BYTES],
+        padding_option="zero",
+    )
+    if A_MODE != _A_BF16:
+        a_scale_desc = tl.make_tensor_descriptor(
+            a_scale_ptr,
+            shape=[
+                1,
+                tl.cdiv(a_scale_rows_total, 128),
+                a_scale_cols_total // 4,
+                2,
+                256,
+            ],
+            strides=[
+                tl.cdiv(a_scale_rows_total, 128)
+                * (a_scale_cols_total // 4)
+                * 512
+                * stride_ask,
+                (a_scale_cols_total // 4) * 512 * stride_ask,
+                512 * stride_ask,
+                256 * stride_ask,
+                stride_ask,
+            ],
+            block_shape=[1, SCALE_M_TILES, SCALE_K_TILES, 2, 256],
+            padding_option="zero",
+        )
+    # B-scale flattened to [E*N_pad, K_s] by the wrapper.
+    b_scale_n_tiles = tl.cdiv(num_experts * b_scale_n_per_expert, 128)
+    b_scale_desc = tl.make_tensor_descriptor(
+        b_scale_ptr,
+        shape=[1, b_scale_n_tiles, b_scale_cols_total // 4, 2, 256],
+        strides=[
+            b_scale_n_tiles * (b_scale_cols_total // 4) * 512 * stride_bsk,
+            (b_scale_cols_total // 4) * 512 * stride_bsk,
+            512 * stride_bsk,
+            256 * stride_bsk,
+            stride_bsk,
+        ],
+        block_shape=[1, SCALE_N_TILES, SCALE_K_TILES, 2, 256],
+        padding_option="zero",
+    )
+
+    for global_tid in tl.range(start_pid, total_tiles, NUM_SMS, flatten=True):
+        expert_id = _find_expert_bin_search(
+            expert_tile_start_ptr, global_tid, num_experts
+        )
+        local_tile_start = tl.load(expert_tile_start_ptr + expert_id).to(tl.int32)
+        local_tile_id = global_tid - local_tile_start
+
+        M = tl.load(problem_sizes_ptr + expert_id * stride_ps0).to(tl.int32)
+        num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+
+        pid_m, pid_n = _compute_pid(
+            local_tile_id, num_pid_in_group, num_pid_m, GROUP_SIZE_M, 0
+        )
+
+        expert_row_offset = tl.load(expert_offsets_ptr + expert_id).to(tl.int32)
+        if A_MODE != _A_BF16:
+            expert_scale_offset = tl.load(a_scale_offsets_ptr + expert_id).to(tl.int32)
+        expert_row_offset = _maybe_widen(expert_row_offset, A_LARGE)
+        if A_MODE != _A_BF16:
+            expert_scale_offset = _maybe_widen(expert_scale_offset, A_LARGE)
+
+        if HAS_ALPHA:
+            alpha = tl.load(alpha_ptr + expert_id).to(tl.float32)
+        start_m = pid_m * BLOCK_SIZE_M
+        start_n = pid_n * BLOCK_SIZE_N
+        offs_m = start_m + tl.arange(0, BLOCK_SIZE_M)
+        offs_n = start_n + tl.arange(0, BLOCK_SIZE_N)
+        m_mask = offs_m < M
+        n_mask = offs_n < N_total
+
+        # B offset into the flattened [E*N, K_packed] view.
+        b_row_offset = expert_id * N_total
+        # B-scale offset into the flattened [E*N_pad, K_s] view.
+        bs_row_offset = expert_id * b_scale_n_per_expert
+        b_row_offset = _maybe_widen(b_row_offset, B_LARGE)
+        bs_row_offset = _maybe_widen(bs_row_offset, B_LARGE)
+
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            k_start_bytes = _maybe_widen(ki * K_BYTES, A_LARGE or B_LARGE)
+
+            k_byte_mask = (ki * K_BYTES + tl.arange(0, K_BYTES)) < k_bytes_total
+
+            a_m_start = _maybe_widen(expert_row_offset + start_m, A_LARGE)
+            b_n_start = _maybe_widen(b_row_offset + start_n, B_LARGE)
+
+            if A_MODE == _A_NVFP4_PACKED:
+                a = a_desc.load([a_m_start, k_start_bytes])
+                a = tl.where(m_mask[:, None] & k_byte_mask[None, :], a, 0)
+            else:
+                k_start_elems = _maybe_widen(ki * BLOCK_SIZE_K, A_LARGE)
+                a = a_desc.load([a_m_start, k_start_elems])
+                k_elem_mask = (ki * BLOCK_SIZE_K + tl.arange(0, BLOCK_SIZE_K)) < K_total
+                a = tl.where(m_mask[:, None] & k_elem_mask[None, :], a, 0)
+            b_raw = b_desc.load([b_n_start, k_start_bytes])
+            b = tl.where(n_mask[:, None] & k_byte_mask[None, :], b_raw, 0).T
+
+            scale_tile_k = _maybe_widen(ki * SCALE_K_TILES, A_LARGE or B_LARGE)
+            scale_tile_n = _maybe_widen((bs_row_offset + start_n) // 128, B_LARGE)
+
+            b_scale_raw = b_scale_desc.load([0, scale_tile_n, scale_tile_k, 0, 0])
+            b_scale = _unswizzle_scale(
+                b_scale_raw.reshape(BLOCK_SIZE_N, SCALE_K_TILE),
+                TILE_ROWS=BLOCK_SIZE_N,
+                TILE_SCALE_COLS=SCALE_K_TILE,
+            )
+
+            if A_MODE == _A_NVFP4_PACKED or A_MODE == _A_MXFP8:  # noqa: SIM109
+                scale_tile_m = _maybe_widen(
+                    (expert_scale_offset + start_m) // 128, A_LARGE
+                )
+                a_scale_raw = a_scale_desc.load([0, scale_tile_m, scale_tile_k, 0, 0])
+                a_scale = _unswizzle_scale(
+                    a_scale_raw.reshape(BLOCK_SIZE_M, SCALE_K_TILE),
+                    TILE_ROWS=BLOCK_SIZE_M,
+                    TILE_SCALE_COLS=SCALE_K_TILE,
+                )
+            else:
+                a_scale = None
+
+            accumulator = tl.dot_scaled(
+                a,
+                a_scale,
+                A_DOT_TYPE,
+                b,
+                b_scale,
+                "e2m1",
+                accumulator,
+            )
+
+        if HAS_ALPHA:
+            accumulator *= alpha
+        if HAS_BIAS:
+            bias_ptrs = bias_ptr + expert_id * stride_bias_e + offs_n
+            bias_vals = tl.load(bias_ptrs, mask=n_mask, other=0.0).to(tl.float32)
+            accumulator += bias_vals[None, :]
+        c = accumulator.to(c_ptr.dtype.element_ty)
+        c_expert_ptr = c_ptr + expert_row_offset * stride_cm
+        offs_m_c = _maybe_widen(offs_m, A_LARGE)
+        offs_n_c = _maybe_widen(offs_n, B_LARGE)
+        c_ptrs = (
+            c_expert_ptr + offs_m_c[:, None] * stride_cm + offs_n_c[None, :] * stride_cn
+        )
+        tl.store(c_ptrs, c, mask=m_mask[:, None] & n_mask[None, :])
+
+
+def _canonicalize_grouped_offsets(
+    offsets: torch.Tensor,
+    *,
+    num_experts: int,
+    name: str,
+) -> torch.Tensor:
+    if offsets.ndim != 1:
+        raise RuntimeError(f"{name} must be 1-D, got shape {tuple(offsets.shape)}.")
+    if offsets.numel() == num_experts + 1:
+        offsets = offsets[:-1]
+    if offsets.numel() != num_experts:
+        raise RuntimeError(
+            f"{name} must have {num_experts} or {num_experts + 1} entries, "
+            f"got {offsets.numel()}."
+        )
+    if offsets.dtype not in (torch.int32, torch.int64):
+        offsets = offsets.to(dtype=torch.int32)
+    return offsets
+
+
+def _grouped_matmul_nvfp4_packed(
+    a_fp4: torch.Tensor,
+    b_fp4: torch.Tensor,
+    a_scale: torch.Tensor,
+    b_scale: torch.Tensor,
+    alpha: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    problem_sizes: torch.Tensor,
+    *,
+    output: torch.Tensor,
+    a_scale_offsets: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Packed grouped NVFP4 GEMM with expert-local problem metadata.
+
+    TMA descriptors use ``padding_option="zero"`` so boundary tiles that
+    overshoot ``M_total`` are zero-filled by hardware -- no guard rows or
+    ``F.pad`` copies are needed.
+
+    Args:
+        a_fp4: [M_total, K_packed] uint8 packed FP4 activations in
+            expert-packed row order.
+        b_fp4: [E, N_max, K_packed] uint8 packed FP4 expert weights.
+        a_scale: [S_total, K_s] float8_e4m3fn swizzled activation block
+            scales.
+        b_scale: [E, N_pad, K_s] float8_e4m3fn swizzled weight block scales.
+        alpha: [E] float32 per-expert alpha.
+        expert_offsets: [E] or [E+1] start row offsets in ``a_fp4``/output.
+        problem_sizes: [E, 3] int tensor containing per-expert (M, N, K).
+        a_scale_offsets: Optional [E] or [E+1] start row offsets in ``a_scale``.
+            If not provided, ``expert_offsets`` are reused.
+        output: Pre-allocated [>= M_total, >= N_max] tensor for the GEMM output.
+
+    Returns:
+        [M_total, N_max] tensor with grouped expert GEMM outputs.
+    """
+    assert a_fp4.ndim == 2 and b_fp4.ndim == 3, (
+        "Expected packed a_fp4=[M_total, K_packed] and b_fp4=[E, N, K_packed]."
+    )
+    assert a_fp4.dtype == torch.uint8 and b_fp4.dtype == torch.uint8
+    assert a_scale.ndim == 2 and b_scale.ndim == 3
+    assert a_scale.dtype == torch.float8_e4m3fn and b_scale.dtype == torch.float8_e4m3fn
+    assert alpha.dtype == torch.float32
+    assert problem_sizes.ndim == 2 and problem_sizes.shape[1] == 3, (
+        f"Expected problem_sizes shape [E, 3], got {tuple(problem_sizes.shape)}."
+    )
+
+    E = b_fp4.shape[0]
+    if E == 0:
+        M_logical = a_fp4.shape[0]
+        N_out = b_fp4.shape[1]
+        return output.flatten()[: M_logical * N_out].view(M_logical, N_out)
+
+    assert problem_sizes.shape[0] == E, (
+        f"Expected problem_sizes.shape[0] == num_experts ({E}), "
+        f"got {problem_sizes.shape[0]}."
+    )
+    assert b_fp4.shape[2] == a_fp4.shape[1], "Packed K dimensions must match."
+    assert alpha.numel() == E, f"alpha must have {E} elements, got {alpha.numel()}."
+
+    if a_scale_offsets is None:
+        a_scale_offsets = expert_offsets
+
+    expert_offsets = _canonicalize_grouped_offsets(
+        expert_offsets, num_experts=E, name="expert_offsets"
+    )
+    a_scale_offsets = _canonicalize_grouped_offsets(
+        a_scale_offsets, num_experts=E, name="a_scale_offsets"
+    )
+
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 128
+    BLOCK_SIZE_K = 256
+
+    M_logical = a_fp4.shape[0]
+
+    # Upper-bound tile count from static tensor shapes.  The persistent
+    # kernel grid is min(NUM_SMS, worst_case_tiles), both derived from
+    # fixed shapes / device properties, so the grid is constant across
+    # calls and safe for CUDA graph capture.
+    max_tiles_m = triton.cdiv(M_logical, BLOCK_SIZE_M)
+    max_tiles_n = triton.cdiv(b_fp4.shape[1], BLOCK_SIZE_N)
+    max_tiles_per_expert = max_tiles_m * max_tiles_n
+
+    N_out = b_fp4.shape[1]
+    c_work = output.flatten()[: M_logical * N_out].view(M_logical, N_out)
+
+    if max_tiles_per_expert == 0:
+        return c_work
+
+    NUM_SMS = num_compute_units(a_fp4.device.index)
+    worst_case_tiles = E * max_tiles_per_expert
+    A_LARGE = max(a_fp4.numel(), a_scale.numel(), c_work.numel()) > 2**31
+    B_LARGE = max(b_fp4.numel(), b_scale.numel()) > 2**31
+
+    # Pre-compute tile-to-expert mapping (all device-side, no host sync).
+    # N and K are uniform across experts; only M varies.
+    M_per_expert = problem_sizes[:, 0].to(torch.int32)
+    tiles_per_expert = (
+        torch.div(
+            M_per_expert + BLOCK_SIZE_M - 1,
+            BLOCK_SIZE_M,
+            rounding_mode="floor",
+        )
+        * max_tiles_n
+        * (M_per_expert > 0).to(torch.int32)
+    )
+    expert_tile_start = torch.zeros(E + 1, dtype=torch.int32, device=a_fp4.device)
+    expert_tile_start[1:] = torch.cumsum(tiles_per_expert, dim=0)
+
+    # Flatten B [E, N, K] -> [E*N, K] and B-scale [E, Np, Ks] -> [E*Np, Ks]
+    # for a single global TMA descriptor.
+    b_fp4_flat = b_fp4.reshape(-1, b_fp4.shape[2])
+    b_scale_flat = b_scale.reshape(-1, b_scale.shape[2])
+
+    grid = (min(NUM_SMS, worst_case_tiles),)
+    dummy_bias = torch.empty(0, device=a_fp4.device, dtype=torch.float32)
+    _grouped_matmul_fp4_packed_persistent_kernel[grid](
+        a_fp4,
+        a_scale,
+        b_fp4_flat,
+        b_scale_flat,
+        c_work,
+        alpha,
+        dummy_bias,
+        expert_offsets,
+        a_scale_offsets,
+        problem_sizes,
+        expert_tile_start,
+        E,
+        a_fp4.shape[0],
+        b_fp4.shape[1],
+        a_fp4.shape[1] * 2,
+        a_scale.shape[0],
+        problem_sizes.stride(0),
+        problem_sizes.stride(1),
+        a_fp4.stride(0),
+        a_fp4.stride(1),
+        a_scale.stride(0),
+        a_scale.stride(1),
+        b_fp4_flat.stride(0),
+        b_fp4_flat.stride(1),
+        b_scale_flat.stride(1),
+        c_work.stride(0),
+        c_work.stride(1),
+        0,  # stride_bias_e (unused)
+        a_scale.shape[1],
+        b_scale.shape[2],
+        b_scale.shape[1],
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        GROUP_SIZE_M=8,
+        NUM_SMS=NUM_SMS,
+        A_LARGE=A_LARGE,
+        B_LARGE=B_LARGE,
+        A_MODE=_GroupedGemmAMode.NVFP4_PACKED.value,
+        A_DOT_TYPE=_A_DOT_TYPE[_GroupedGemmAMode.NVFP4_PACKED],
+        B_SCALE_GROUP=16,
+        HAS_ALPHA=True,
+        HAS_BIAS=False,
+        num_stages=2,
+        num_warps=8,
+    )
+    return c_work
+
+
+# ---------------------------------------------------------------------------
+# Standalone deterministic NVFP4 MoE implementation
+# ---------------------------------------------------------------------------
+
+
+def fused_moe_batch_invariant_nvfp4(
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+    w13_weight: torch.Tensor,
+    w13_weight_scale: torch.Tensor,
+    w2_weight: torch.Tensor,
+    w2_weight_scale: torch.Tensor,
+    a1_gscale: torch.Tensor | None,
+    g1_alphas: torch.Tensor | None,
+    a2_gscale: torch.Tensor | None,
+    g2_alphas: torch.Tensor | None,
+    activation: MoEActivation,
+    *,
+    workspace13: torch.Tensor,
+    workspace2: torch.Tensor,
+    output: torch.Tensor,
+    apply_router_weight_on_input: bool = False,
+    expert_map: torch.Tensor | None = None,
+    quant_backend: str = "cutlass",
+) -> torch.Tensor:
+    """
+    Deterministic NVFP4 MoE using packed routing metadata and grouped GEMMs.
+
+    The input ``[M, K]`` is expanded and permuted into expert-major packed
+    order ``[M * topk, K]`` via ``shuffle_rows`` with CUTLASS metadata
+    (``a_map``/``c_map``).  Both GEMMs then run in packed 2D form using
+    per-expert offsets/problem sizes.  The epilogue uses ``moe_unpermute``
+    to gather, apply router weights and reduce back to ``[M, K]`` while
+    safely skipping invalid routes.  The final reduction writes into
+    ``output``.
+
+    ``workspace13`` and ``workspace2`` must match
+    ``BatchInvariantNvfp4Experts.workspace_shapes`` (large enough for GEMM1 /
+    GEMM2 staging and activations).
+    """
+
+    assert hidden_states.ndim == 2, (
+        f"Expected 2D hidden_states for NVFP4 MoE fallback, got {hidden_states.shape}."
+    )
+    assert topk_ids.shape == topk_weights.shape, (
+        "NVFP4 MoE fallback expects topk_ids and topk_weights to have identical shapes."
+    )
+    assert topk_ids.ndim == 2, (
+        f"Expected 2D top-k routing tensors, got shape {topk_ids.shape}."
+    )
+    assert not apply_router_weight_on_input or topk_ids.shape[1] == 1, (
+        "apply_router_weight_on_input=True is only supported for top_k == 1."
+    )
+    assert quant_backend == "cutlass", (
+        "Packed batch-invariant NVFP4 MoE requires quant_backend='cutlass'."
+    )
+    activation_kind = activation
+
+    num_tokens, hidden_dim = hidden_states.shape
+    num_experts = w13_weight.shape[0]
+    top_k = topk_ids.shape[1]
+    _validate_fused_moe_batch_invariant_nvfp4_inputs(
+        hidden_states=hidden_states,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        w13_weight=w13_weight,
+        w13_weight_scale=w13_weight_scale,
+        w2_weight=w2_weight,
+        w2_weight_scale=w2_weight_scale,
+        a1_gscale=a1_gscale,
+        g1_alphas=g1_alphas,
+        a2_gscale=a2_gscale,
+        g2_alphas=g2_alphas,
+        output=output,
+        workspace13=workspace13,
+        workspace2=workspace2,
+        expert_map=expert_map,
+        num_experts=num_experts,
+    )
+    M_total = num_tokens * top_k
+    if M_total == 0:
+        return output
+
+    routed_topk_ids = topk_ids
+    if expert_map is not None:
+        routed_topk_ids = _nvfp4_moe_map_experts(topk_ids, expert_map)
+    # Out-of-range IDs are treated as invalid routes.
+    valid_routes = (routed_topk_ids >= 0) & (routed_topk_ids < num_experts)
+    routed_topk_ids = torch.where(
+        valid_routes, routed_topk_ids, torch.full_like(routed_topk_ids, -1)
+    )
+    routed_topk_weights = topk_weights
+
+    if apply_router_weight_on_input:
+        packed_hidden_states = hidden_states * routed_topk_weights.view(-1, 1).to(
+            hidden_states.dtype
+        )
+    else:
+        packed_hidden_states = hidden_states
+
+    device = hidden_states.device
+    w1_output_size = w13_weight.shape[1]
+    activation_out_dim = (
+        w1_output_size // 2 if activation_kind.is_gated else w1_output_size
+    )
+    w2_output_size = hidden_dim
+    w1_padding_cols = max(0, w13_weight.shape[-1] - hidden_dim // 2)
+    w2_padding_cols = max(0, w2_weight.shape[-1] - activation_out_dim // 2)
+    min_w13_cols = max(w13_weight.shape[1], hidden_dim)
+    if workspace13.shape[0] < M_total or workspace13.shape[1] < min_w13_cols:
+        raise RuntimeError(
+            "workspace13 is too small for GEMM1 staging. "
+            f"Need at least ({M_total}, {min_w13_cols}), "
+            f"got {tuple(workspace13.shape)}."
+        )
+    required_workspace2_cols = max(activation_out_dim, w2_output_size)
+    if workspace2.shape[0] < M_total or workspace2.shape[1] < required_workspace2_cols:
+        raise RuntimeError(
+            "workspace2 is too small for activation/GEMM2 staging. "
+            f"Need at least ({M_total}, {required_workspace2_cols}), "
+            f"got {tuple(workspace2.shape)}."
+        )
+    # Per-expert metadata/permutations for packed grouped-GEMM.
+    expert_offsets = torch.empty((num_experts + 1), dtype=torch.int32, device=device)
+    blockscale_offsets = torch.empty(
+        (num_experts + 1), dtype=torch.int32, device=device
+    )
+    problem_sizes1 = torch.empty((num_experts, 3), dtype=torch.int32, device=device)
+    problem_sizes2 = torch.empty((num_experts, 3), dtype=torch.int32, device=device)
+    a_map = torch.zeros((M_total,), dtype=torch.int32, device=device)
+    c_map = torch.empty((M_total,), dtype=torch.int32, device=device)
+    ops.get_cutlass_moe_mm_data(
+        routed_topk_ids,
+        expert_offsets,
+        problem_sizes1,
+        problem_sizes2,
+        a_map,
+        c_map,
+        num_experts,
+        activation_out_dim,
+        hidden_dim,
+        blockscale_offsets,
+    )
+
+    # get_cutlass_moe_mm_data() assumes gated MLP (`w13` width == 2 * n).
+    # For *_no_mul activations, overwrite the logical problem shapes.
+    if not activation_kind.is_gated:
+        problem_sizes1[:, 1].fill_(w1_output_size)
+        problem_sizes2[:, 2].fill_(activation_out_dim)
+
+    packed_hidden_states = ops.shuffle_rows(packed_hidden_states, a_map)
+
+    a1_fp4, a1_scale = ops.scaled_fp4_experts_quant(
+        packed_hidden_states,
+        a1_gscale,
+        expert_offsets,
+        blockscale_offsets,
+        top_k,
+    )
+    if w1_padding_cols > 0:
+        a1_fp4 = F.pad(a1_fp4, (0, w1_padding_cols))
+
+    gemm1_out = _grouped_matmul_nvfp4_packed(
+        a_fp4=a1_fp4,
+        b_fp4=w13_weight,
+        a_scale=a1_scale,
+        b_scale=w13_weight_scale,
+        alpha=g1_alphas,
+        expert_offsets=expert_offsets,
+        a_scale_offsets=blockscale_offsets,
+        problem_sizes=problem_sizes1,
+        output=workspace13,
+    )
+    if gemm1_out.shape[-1] != w1_output_size:
+        gemm1_out = gemm1_out[:, :w1_output_size].contiguous()
+
+    if activation_kind == MoEActivation.SILU:
+        int_fp4, int_scale = ops.silu_and_mul_scaled_fp4_experts_quant(
+            gemm1_out,
+            a2_gscale,
+            expert_offsets,
+            blockscale_offsets,
+            top_k,
+        )
+    else:
+        act_out = _resize_cache(workspace2, (M_total, activation_out_dim))
+        apply_moe_activation(
+            activation=activation_kind,
+            output=act_out,
+            input=gemm1_out,
+        )
+        int_fp4, int_scale = ops.scaled_fp4_experts_quant(
+            act_out,
+            a2_gscale,
+            expert_offsets,
+            blockscale_offsets,
+            top_k,
+        )
+    if w2_padding_cols > 0:
+        int_fp4 = F.pad(int_fp4, (0, w2_padding_cols))
+
+    gemm2_out = _grouped_matmul_nvfp4_packed(
+        a_fp4=int_fp4,
+        b_fp4=w2_weight,
+        a_scale=int_scale,
+        b_scale=w2_weight_scale,
+        alpha=g2_alphas,
+        expert_offsets=expert_offsets,
+        a_scale_offsets=blockscale_offsets,
+        problem_sizes=problem_sizes2,
+        output=workspace2,
+    )
+    if gemm2_out.shape[-1] != w2_output_size:
+        gemm2_out = gemm2_out[:, :w2_output_size].contiguous()
+
+    epilogue_topk_weights = (
+        torch.ones_like(routed_topk_weights)
+        if apply_router_weight_on_input
+        else routed_topk_weights
+    )
+    inv_permuted_idx = c_map.view(num_tokens, top_k)
+    # moe_unpermute reads from gemm2_out and writes to reduced. Source/destination
+    # must never alias (particularly in non-chunked mode where workspaces are reused).
+    reduced = output
+    moe_unpermute(
+        out=reduced,
+        permuted_hidden_states=gemm2_out,
+        topk_weights=epilogue_topk_weights,
+        inv_permuted_idx=inv_permuted_idx,
+        expert_first_token_offset=expert_offsets.to(torch.int64),
+    )
+    return reduced
+
+
+# ---------------------------------------------------------------------------
+# Modular-kernel wrapper class
+# ---------------------------------------------------------------------------
+
+
+class _BatchInvariantFP4ExpertsBase(mk.FusedMoEExpertsModular, ABC):
+    """Shared batch-invariant FP4 MoE expert logic."""
+
+    def __init__(
+        self,
+        moe_config: mk.FusedMoEConfig,
+        quant_config: FusedMoEQuantConfig,
+    ):
+        super().__init__(moe_config, quant_config)
+        self._num_local_experts = moe_config.num_local_experts
+
+    @property
+    def expects_unquantized_inputs(self) -> bool:
+        return True
+
+    @staticmethod
+    def _supports_current_device() -> bool:
+        p = current_platform
+        return p.is_cuda() and p.has_device_capability(90)
+
+    @staticmethod
+    def _supports_no_act_and_mul() -> bool:
+        return True
+
+    @staticmethod
+    def _supports_activation(activation: MoEActivation) -> bool:
+        return True
+
+    @staticmethod
+    def _supports_parallel_config(
+        moe_parallel_config: FusedMoEParallelConfig,
+    ) -> bool:
+        return True
+
+    @staticmethod
+    def _supports_batch_invariance() -> bool:
+        return True
+
+    @staticmethod
+    def activation_format() -> mk.FusedMoEActivationFormat:
+        return mk.FusedMoEActivationFormat.Standard
+
+    def supports_chunking(self) -> bool:
+        return True
+
+    def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
+        return TopKWeightAndReduceNoOP()
+
+    def workspace_shapes(
+        self,
+        M: int,
+        N: int,
+        K: int,
+        topk: int,
+        global_num_experts: int,
+        local_num_experts: int,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        activation: MoEActivation,
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        act_out_dim = self.adjust_N_for_activation(N, activation)
+        workspace13 = (M * topk, max(N, K))
+        workspace2 = (M * topk, max(act_out_dim, K))
+        output_shape = (M, K)
+        return (workspace13, workspace2, output_shape)
+
+    @abstractmethod
+    def apply(
+        self,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        a2_scale: torch.Tensor | None,
+        workspace13: torch.Tensor,
+        workspace2: torch.Tensor,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        apply_router_weight_on_input: bool | None,
+    ) -> None: ...
+
+    def moe_sum(self, input: torch.Tensor, output: torch.Tensor) -> None:
+        raise NotImplementedError("LoRA is not supported for batch-invariant FP4 MoE")
+
+
+class BatchInvariantNvfp4Experts(_BatchInvariantFP4ExpertsBase):
+    """Batch-invariant NVFP4 (W4A4) MoE experts."""
+
+    @staticmethod
+    def _supports_quant_scheme(
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> bool:
+        return (weight_key, activation_key) == (kNvfp4Static, kNvfp4Dynamic)
+
+    @staticmethod
+    def is_supported_config(
+        cls,
+        moe_config: mk.FusedMoEConfig,
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+        activation_format: mk.FusedMoEActivationFormat,
+    ) -> tuple[bool, str | None]:
+        # Use it when batch invariance is requested (env)
+        # or the user pinned moe_backend explicitly.
+        if (
+            not envs.VLLM_BATCH_INVARIANT
+            and moe_config.moe_backend != "batch_invariant"
+        ):
+            return (
+                False,
+                "NvFP4 batch-invariant MoE is not available unless explicitly enabled "
+                "using VLLM_BATCH_INVARIANT=1 or moe_backend='batch_invariant'",
+            )
+        # NVFP4 + EP: expert_map maps non-local experts to -1. MoE shuffle keeps a
+        # fixed (M * topk, K) buffer so CUDA graphs see stable tensor shapes; valid
+        # packed rows are only expert_offsets[-1]. Padding rows must not be quantized
+        # incorrectly (see nvfp4_experts_quant.cu). Combining EP, expert_map, graphs,
+        # and libtorch NVFP4 expert quant is unsupported—require ep_size == 1.
+        if (weight_key, activation_key) == (
+            kNvfp4Static,
+            kNvfp4Dynamic,
+        ) and moe_config.moe_parallel_config.ep_size > 1:
+            return (
+                False,
+                "kernel does not support expert parallel for NVFP4 batch-invariant "
+                "MoE (expert_map / -1 routes, fixed (M*topk,K) activations for CUDA "
+                "graphs vs expert_offsets[-1] packed rows; libtorch "
+                "scaled_fp4_experts_quant). Use ep_size==1.",
+            )
+        return mk.FusedMoEExperts.is_supported_config(
+            cls, moe_config, weight_key, activation_key, activation_format
+        )
+
+    def supports_expert_map(self) -> bool:
+        return False
+
+    def __init__(
+        self,
+        moe_config: mk.FusedMoEConfig,
+        quant_config: FusedMoEQuantConfig,
+    ):
+        super().__init__(moe_config, quant_config)
+        self._cached_scale_vecs: (
+            tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor] | None
+        ) = None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        # Fuse activation scales into w_scale_2 in-place so that
+        # g1/g2_alphas (which reference the same tensor) stay in sync
+        # when EPLB rearranges the parameter.
+        layer.w13_weight_scale_2.data.mul_(layer.w13_input_scale)
+        layer.w2_weight_scale_2.data.mul_(layer.w2_input_scale)
+
+    def _get_nvfp4_scale_vecs(
+        self,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        if self._cached_scale_vecs is not None:
+            return self._cached_scale_vecs
+        self._cached_scale_vecs = (
+            self.a1_gscale,
+            self.a2_gscale,
+            self.g1_alphas,
+            self.g2_alphas,
+        )
+        return self._cached_scale_vecs
+
+    def apply(
+        self,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        a2_scale: torch.Tensor | None,
+        workspace13: torch.Tensor,
+        workspace2: torch.Tensor,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        apply_router_weight_on_input: bool | None,
+    ) -> None:
+        a1_gscale_vec, a2_gscale_vec, g1_alpha_vec, g2_alpha_vec = (
+            self._get_nvfp4_scale_vecs()
+        )
+        fused_moe_batch_invariant_nvfp4(
+            hidden_states=hidden_states,
+            topk_ids=topk_ids,
+            topk_weights=topk_weights,
+            w13_weight=w1,
+            w13_weight_scale=self.w1_scale,
+            w2_weight=w2,
+            w2_weight_scale=self.w2_scale,
+            a1_gscale=a1_gscale_vec,
+            g1_alphas=g1_alpha_vec,
+            a2_gscale=a2_gscale_vec,
+            g2_alphas=g2_alpha_vec,
+            activation=activation,
+            workspace13=workspace13,
+            workspace2=workspace2,
+            output=output,
+            apply_router_weight_on_input=bool(apply_router_weight_on_input),
+            expert_map=expert_map,
+        )

--- a/vllm/model_executor/layers/fused_moe/batch_invariant_fp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/batch_invariant_fp4_moe.py
@@ -3,6 +3,7 @@
 """Batch-invariant NVFP4 fused MoE expert implementations."""
 
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from enum import Enum
 
 import torch
@@ -38,6 +39,42 @@ from vllm.triton_utils import tl, triton
 from vllm.utils.platform_utils import num_compute_units
 
 logger = init_logger(__name__)
+
+
+def _map_extra_rows(m_total: int, cols: int) -> int:
+    """Extra workspace13 rows needed to embed ``a_map`` and ``c_map``.
+
+    Both maps are ``[M_total]`` int32 tensors.  We pack them into the
+    trailing rows of the bfloat16 workspace13 buffer so they are managed
+    by the workspace-manager and sized correctly for CUDA-graph capture.
+    """
+    bytes_needed = 2 * m_total * 4  # 2 maps × M_total × sizeof(int32)
+    row_bytes = cols * 2  # cols × sizeof(bfloat16)
+    return (bytes_needed + row_bytes - 1) // row_bytes
+
+
+@dataclass
+class NvFP4MoEWorkspace:
+    """Pre-allocated scratch buffers for batch-invariant NVFP4 MoE.
+
+    Expert-count-dependent tensors are allocated once in
+    ``BatchInvariantNvfp4Experts.__init__`` and reused across forward calls
+    to avoid hot-path allocations and stay compatible with CUDA graph
+    capture.
+
+    The M-dependent ``a_map`` / ``c_map`` buffers are carved out of the
+    extra rows appended to ``workspace13`` by ``workspace_shapes`` (see
+    ``_map_extra_rows``), so they inherit the workspace-manager's
+    pre-allocation and CUDA-graph-safe lifetime.
+    """
+
+    expert_offsets: torch.Tensor  # [E+1] int32
+    blockscale_offsets: torch.Tensor  # [E+1] int32
+    problem_sizes1: torch.Tensor  # [E, 3] int32
+    problem_sizes2: torch.Tensor  # [E, 3] int32
+    tiles_per_expert: torch.Tensor  # [E] int32
+    expert_tile_start: torch.Tensor  # [E+1] int32
+    dummy_bias: torch.Tensor  # [0] float32
 
 
 class _GroupedGemmAMode(Enum):
@@ -507,6 +544,9 @@ def _grouped_matmul_nvfp4_packed(
     problem_sizes: torch.Tensor,
     *,
     output: torch.Tensor,
+    tiles_per_expert: torch.Tensor,
+    expert_tile_start: torch.Tensor,
+    dummy_bias: torch.Tensor,
     a_scale_offsets: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Packed grouped NVFP4 GEMM with expert-local problem metadata.
@@ -593,18 +633,17 @@ def _grouped_matmul_nvfp4_packed(
 
     # Pre-compute tile-to-expert mapping (all device-side, no host sync).
     # N and K are uniform across experts; only M varies.
+    # Reuse pre-allocated tiles_per_expert and expert_tile_start buffers.
     M_per_expert = problem_sizes[:, 0].to(torch.int32)
-    tiles_per_expert = (
-        torch.div(
-            M_per_expert + BLOCK_SIZE_M - 1,
-            BLOCK_SIZE_M,
-            rounding_mode="floor",
-        )
-        * max_tiles_n
-        * (M_per_expert > 0).to(torch.int32)
+    torch.div(
+        M_per_expert + BLOCK_SIZE_M - 1,
+        BLOCK_SIZE_M,
+        rounding_mode="floor",
+        out=tiles_per_expert,
     )
-    expert_tile_start = torch.zeros(E + 1, dtype=torch.int32, device=a_fp4.device)
-    expert_tile_start[1:] = torch.cumsum(tiles_per_expert, dim=0)
+    tiles_per_expert.mul_(max_tiles_n)
+    tiles_per_expert.mul_((M_per_expert > 0).to(torch.int32))
+    torch.cumsum(tiles_per_expert, dim=0, out=expert_tile_start[1:])
 
     # Flatten B [E, N, K] -> [E*N, K] and B-scale [E, Np, Ks] -> [E*Np, Ks]
     # for a single global TMA descriptor.
@@ -612,7 +651,6 @@ def _grouped_matmul_nvfp4_packed(
     b_scale_flat = b_scale.reshape(-1, b_scale.shape[2])
 
     grid = (min(NUM_SMS, worst_case_tiles),)
-    dummy_bias = torch.empty(0, device=a_fp4.device, dtype=torch.float32)
     _grouped_matmul_fp4_packed_persistent_kernel[grid](
         a_fp4,
         a_scale,
@@ -685,6 +723,7 @@ def fused_moe_batch_invariant_nvfp4(
     workspace13: torch.Tensor,
     workspace2: torch.Tensor,
     output: torch.Tensor,
+    workspace: NvFP4MoEWorkspace,
     apply_router_weight_on_input: bool = False,
     expert_map: torch.Tensor | None = None,
     quant_backend: str = "cutlass",
@@ -762,7 +801,6 @@ def fused_moe_batch_invariant_nvfp4(
     else:
         packed_hidden_states = hidden_states
 
-    device = hidden_states.device
     w1_output_size = w13_weight.shape[1]
     activation_out_dim = (
         w1_output_size // 2 if activation_kind.is_gated else w1_output_size
@@ -784,15 +822,18 @@ def fused_moe_batch_invariant_nvfp4(
             f"Need at least ({M_total}, {required_workspace2_cols}), "
             f"got {tuple(workspace2.shape)}."
         )
-    # Per-expert metadata/permutations for packed grouped-GEMM.
-    expert_offsets = torch.empty((num_experts + 1), dtype=torch.int32, device=device)
-    blockscale_offsets = torch.empty(
-        (num_experts + 1), dtype=torch.int32, device=device
-    )
-    problem_sizes1 = torch.empty((num_experts, 3), dtype=torch.int32, device=device)
-    problem_sizes2 = torch.empty((num_experts, 3), dtype=torch.int32, device=device)
-    a_map = torch.zeros((M_total,), dtype=torch.int32, device=device)
-    c_map = torch.empty((M_total,), dtype=torch.int32, device=device)
+    # Reuse pre-allocated workspace buffers for routing/GEMM dispatch.
+    expert_offsets = workspace.expert_offsets
+    blockscale_offsets = workspace.blockscale_offsets
+    problem_sizes1 = workspace.problem_sizes1
+    problem_sizes2 = workspace.problem_sizes2
+    # a_map and c_map are carved from the extra rows that workspace_shapes
+    # appended to workspace13.  This keeps them inside the workspace-manager's
+    # pre-allocation so they are CUDA-graph safe.
+    map_i32 = workspace13[M_total:].flatten().view(torch.int32)[: 2 * M_total]
+    a_map = map_i32[:M_total]
+    c_map = map_i32[M_total:]
+    a_map.zero_()
     ops.get_cutlass_moe_mm_data(
         routed_topk_ids,
         expert_offsets,
@@ -834,6 +875,9 @@ def fused_moe_batch_invariant_nvfp4(
         a_scale_offsets=blockscale_offsets,
         problem_sizes=problem_sizes1,
         output=workspace13,
+        tiles_per_expert=workspace.tiles_per_expert,
+        expert_tile_start=workspace.expert_tile_start,
+        dummy_bias=workspace.dummy_bias,
     )
     if gemm1_out.shape[-1] != w1_output_size:
         gemm1_out = gemm1_out[:, :w1_output_size].contiguous()
@@ -873,6 +917,9 @@ def fused_moe_batch_invariant_nvfp4(
         a_scale_offsets=blockscale_offsets,
         problem_sizes=problem_sizes2,
         output=workspace2,
+        tiles_per_expert=workspace.tiles_per_expert,
+        expert_tile_start=workspace.expert_tile_start,
+        dummy_bias=workspace.dummy_bias,
     )
     if gemm2_out.shape[-1] != w2_output_size:
         gemm2_out = gemm2_out[:, :w2_output_size].contiguous()
@@ -961,8 +1008,11 @@ class _BatchInvariantFP4ExpertsBase(mk.FusedMoEExpertsModular, ABC):
         activation: MoEActivation,
     ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
         act_out_dim = self.adjust_N_for_activation(N, activation)
-        workspace13 = (M * topk, max(N, K))
-        workspace2 = (M * topk, max(act_out_dim, K))
+        m_total = M * topk
+        cols13 = max(N, K)
+        extra = _map_extra_rows(m_total, cols13)
+        workspace13 = (m_total + extra, cols13)
+        workspace2 = (m_total, max(act_out_dim, K))
         output_shape = (M, K)
         return (workspace13, workspace2, output_shape)
 
@@ -1052,6 +1102,18 @@ class BatchInvariantNvfp4Experts(_BatchInvariantFP4ExpertsBase):
             tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor] | None
         ) = None
 
+        E = moe_config.num_local_experts
+        device = moe_config.device
+        self._workspace = NvFP4MoEWorkspace(
+            expert_offsets=torch.empty(E + 1, dtype=torch.int32, device=device),
+            blockscale_offsets=torch.empty(E + 1, dtype=torch.int32, device=device),
+            problem_sizes1=torch.empty(E, 3, dtype=torch.int32, device=device),
+            problem_sizes2=torch.empty(E, 3, dtype=torch.int32, device=device),
+            tiles_per_expert=torch.empty(E, dtype=torch.int32, device=device),
+            expert_tile_start=torch.zeros(E + 1, dtype=torch.int32, device=device),
+            dummy_bias=torch.empty(0, device=device, dtype=torch.float32),
+        )
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         # Fuse activation scales into w_scale_2 in-place so that
         # g1/g2_alphas (which reference the same tensor) stay in sync
@@ -1109,6 +1171,7 @@ class BatchInvariantNvfp4Experts(_BatchInvariantFP4ExpertsBase):
             workspace13=workspace13,
             workspace2=workspace2,
             output=output,
+            workspace=self._workspace,
             apply_router_weight_on_input=bool(apply_router_weight_on_input),
             expert_map=expert_map,
         )

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -45,6 +45,7 @@ class NvFp4MoeBackend(Enum):
     FLASHINFER_CUTEDSL_BATCHED = "FLASHINFER_CUTEDSL_BATCHED"
     VLLM_CUTLASS = "VLLM_CUTLASS"
     MARLIN = "MARLIN"
+    TRITON_BATCH_INVARIANT = "TRITON_BATCH_INVARIANT"
 
 
 FLASHINFER_NVFP4_MOE_BACKENDS = [
@@ -118,6 +119,13 @@ def backend_to_kernel_cls(
         )
 
         return [MarlinExperts]
+
+    elif backend == NvFp4MoeBackend.TRITON_BATCH_INVARIANT:
+        from vllm.model_executor.layers.fused_moe.batch_invariant_fp4_moe import (
+            BatchInvariantNvfp4Experts,
+        )
+
+        return [BatchInvariantNvfp4Experts]
     else:
         raise ValueError(f"Unknown NvFP4 MoE backend: {backend.value}")
 
@@ -130,6 +138,7 @@ def map_nvfp4_backend(runner_backend: MoEBackend) -> NvFp4MoeBackend:
         "flashinfer_cutlass": NvFp4MoeBackend.FLASHINFER_CUTLASS,
         "flashinfer_cutedsl": NvFp4MoeBackend.FLASHINFER_CUTEDSL,
         "marlin": NvFp4MoeBackend.MARLIN,
+        "batch_invariant": NvFp4MoeBackend.TRITON_BATCH_INVARIANT,
     }
     if backend := mapping.get(runner_backend):
         return backend
@@ -157,6 +166,7 @@ def select_nvfp4_moe_backend(
         NvFp4MoeBackend.FLASHINFER_CUTLASS,
         NvFp4MoeBackend.VLLM_CUTLASS,
         NvFp4MoeBackend.MARLIN,
+        NvFp4MoeBackend.TRITON_BATCH_INVARIANT,
     ]
 
     # NOTE(rob): this is kind of a hack. We need to peak into
@@ -329,6 +339,7 @@ def convert_to_nvfp4_moe_kernel_format(
     elif (
         nvfp4_backend in FLASHINFER_NVFP4_MOE_BACKENDS
         or nvfp4_backend == NvFp4MoeBackend.VLLM_CUTLASS
+        or nvfp4_backend == NvFp4MoeBackend.TRITON_BATCH_INVARIANT
     ):
         (
             w13,

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -316,6 +316,7 @@ def prepare_nvfp4_moe_layer_for_fi_or_cutlass(
         NvFp4MoeBackend.FLASHINFER_CUTLASS,
         NvFp4MoeBackend.FLASHINFER_TRTLLM,
         NvFp4MoeBackend.FLASHINFER_CUTEDSL_BATCHED,
+        NvFp4MoeBackend.TRITON_BATCH_INVARIANT,
     ]
 
     # Reorder [w1, w3] to [w3, w1] for FI NVFP4 MoE kernels.


### PR DESCRIPTION
## Purpose

This PR adds a batch invariant NVFP4 MoE backend, using a custom Triton NVFP4 grouped GEMM kernel.

Performance is not terrible (baseline is VLLM_CUTLASS ~~and batch invariant is using the emulated nvfp4 linear layers~~, hw: RTX 6000d):
```
$ VLLM_BENCH_GPU_MEMORY_UTILIZATION="0.9" VLLM_BENCH_BACKEND="TRITON_ATTN" VLLM_BENCH_MODEL="nvidia/Qwen3-30B-A3B-NVFP4" python3 benchmarks/benchmark_batch_invariance.py

...
================================================================================
COMPARISON: Batch Invariance vs Baseline
================================================================================

Initialization Time:
  Baseline:         53.98s
  Batch Invariant:  44.32s
  Overhead:         -17.90%

Average Trial Time:
  Baseline:         2.64s
  Batch Invariant:  3.18s
  Overhead:         +20.34%

Throughput (tokens/s):
  Baseline:         4989.89
  Batch Invariant:  4146.38
  Change:           -16.90%

Prompts/s:
  Baseline:         38.98
  Batch Invariant:  32.39
```

## Test Plan
The kernel comes with a test suite (`pytest tests/kernels/quantization/test_batch_invariant_fp4_moe.py`),
also passes the batch invariance tests (`VLLM_TEST_MODEL="nvidia/Qwen3-30B-A3B-NVFP4" pytest tests/v1/determinism/test_batch_invariance.py -k "bs1_vs_bsN[TRITON_ATTN]"`)

## Test Result


