### PR TITLE
[Bugfix] add SupportsMultiModal to Exaone4_5_MTP

### DIFF
--- a/vllm/model_executor/models/exaone4_5_mtp.py
+++ b/vllm/model_executor/models/exaone4_5_mtp.py
@@ -23,8 +23,14 @@ from vllm.model_executor.models.exaone_moe_mtp import (
     ExaoneMoeMultiTokenPredictor,
 )
 
+from .interfaces import (
+    MultiModalEmbeddings,
+    SupportsMultiModal,
+    _require_is_multimodal,
+)
 from .utils import (
     AutoWeightsLoader,
+    _merge_multimodal_embeddings,
     maybe_prefix,
 )
 
@@ -85,9 +91,12 @@ class Exaone4_5MultiTokenPredictor(ExaoneMoeMultiTokenPredictor):
             config.hidden_size, eps=config.rms_norm_eps
         )
 
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embed_tokens(input_ids)
+
 
 @support_torch_compile
-class Exaone4_5_MTP(ExaoneMoeMTP):
+class Exaone4_5_MTP(ExaoneMoeMTP, SupportsMultiModal):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         config = vllm_config.model_config.hf_config
         self.vllm_config = vllm_config
@@ -110,6 +119,32 @@ class Exaone4_5_MTP(ExaoneMoeMTP):
         self.logits_processor = LogitsProcessor(
             self.unpadded_vocab_size, config.vocab_size
         )
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        multimodal_embeddings: MultiModalEmbeddings | None = None,
+        *,
+        is_multimodal: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        inputs_embeds = self._embed_text_input_ids(
+            input_ids,
+            self.model.embed_input_ids,
+            is_multimodal=is_multimodal,
+        )
+
+        if multimodal_embeddings is None or len(multimodal_embeddings) == 0:
+            return inputs_embeds
+
+        is_multimodal = _require_is_multimodal(is_multimodal)
+
+        inputs_embeds = _merge_multimodal_embeddings(
+            inputs_embeds=inputs_embeds,
+            multimodal_embeddings=multimodal_embeddings,
+            is_multimodal=is_multimodal,
+        )
+
+        return inputs_embeds
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         shared_weight_names = ["embed_tokens", "lm_head"]


### PR DESCRIPTION
## Purpose

`Exaone4_5_MTP` is missing the `SupportsMultiModal` interface, causing MTP speculative decoding to break for the Exaone4.5 VL model.

In `eagle.py:1310-1318`, the spec decode code calls `self.model.embed_input_ids(...)` on the draft model. Since `Exaone4_5_MTP` lacks this method, it raises `AttributeError` and falls back to text-only mode (`supports_mm_inputs = False`). Raw `input_ids` with OOV multimodal tokens (image/video pads) are then passed directly to `embed_tokens`, resulting in `IndexError: index out of range in self`.

This PR adds `SupportsMultiModal` inheritance and `embed_input_ids` to `Exaone4_5_MTP`, following the same pattern as `Qwen3_5MTP`.

## Test Plan

```bash
python -c "
from vllm.model_executor.models.exaone4_5_mtp import Exaone4_5_MTP
from vllm.model_executor.models import supports_multimodal
print('supports_multimodal:', supports_multimodal(Exaone4_5_MTP))
print('has embed_input_ids:', hasattr(Exaone4_5_MTP, 'embed_input_ids'))
"
```

## Test Result
Before:
```
supports_multimodal: False
has embed_input_ids: False
```
After:
```
supports_multimodal: True
has embed_input_ids: True
```
Pre-commit hooks all pass (`ruff-check`, `ruff-format`, `mypy`, `typos`, etc.)

- [x] The purpose of the PR
- [x] The test plan
- [x] The test results
- [ ] N/A - Documentation update
- [ ] N/A - Release notes update

