### PR TITLE
[Core] Fix EAGLE assertion in SlidingWindowManager for hybrid models

### DIFF
--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -558,16 +558,15 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             # `num_contiguous_blocks < sliding_window_contiguous_blocks`.
             for computed in computed_blocks:
                 del computed[num_contiguous_blocks:]
-            while (
-                block_size != alignment_tokens  # Faster for common case.
-                and len(computed_blocks[0]) * block_size % alignment_tokens != 0
-            ):
-                for computed in computed_blocks:
-                    computed.pop()
         if use_eagle and computed_blocks[0]:
-            assert kv_cache_spec.block_size == alignment_tokens, (
-                "aligned_length is not compatible with eagle now"
-            )
+            # Need to drop the last matched block if eagle is enabled.
+            for computed in computed_blocks:
+                computed.pop()
+        while (
+            block_size != alignment_tokens  # Faster for common case.
+            and computed_blocks[0]
+            and len(computed_blocks[0]) * block_size % alignment_tokens != 0
+        ):
             for computed in computed_blocks:
                 computed.pop()
         return computed_blocks


### PR DESCRIPTION
## Purpose

Fixes the following crash when running EAGLE speculative decoding on hybrid attention models (e.g. Exaone4_5) with prefix caching enabled (reported by @188zzoon):

```
Traceback (most recent call last):
  File "<string>", line 15, in <module>
  File "vllm/v1/core/single_type_kv_cache_manager.py", line 568, in find_longest_cache_hit
    assert kv_cache_spec.block_size == alignment_tokens, (
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: aligned_length is not compatible with eagle now
```

`SlidingWindowManager.find_longest_cache_hit()` asserted `block_size == alignment_tokens` when EAGLE was enabled. This was added as a placeholder in #29143 for hybrid allocator support with different block sizes.

In hybrid models with both full attention and sliding window layers, `HybridKVCacheCoordinator` sets `alignment_tokens = lcm(block_sizes)`, which can differ from the sliding window layer's individual `block_size`. When prefix caching finds cached blocks with EAGLE enabled, the assertion fires and crashes the EngineCore.

The existing test (`test_eagle_with_sliding_window`) only covers single KV cache group (unitary coordinator), where `alignment_tokens == block_size` always holds, so the assertion was never triggered.

Fix by following the same pattern as `FullAttentionManager`: perform the EAGLE pop before alignment adjustment instead of asserting incompatibility.

## Test Plan

Existing tests:
```bash
python -m pytest tests/v1/core/test_single_type_kv_cache_manager.py -v
python -m pytest tests/v1/core/test_prefix_caching.py -v
```

Reproduction (block_size=4, alignment_tokens=8, simulating hybrid model):
```python
import torch
from vllm.v1.core.block_pool import BlockPool
from vllm.v1.core.kv_cache_utils import BlockHash, make_block_hash_with_group_id
from vllm.v1.core.single_type_kv_cache_manager import SlidingWindowManager
from vllm.v1.kv_cache_interface import SlidingWindowSpec

spec = SlidingWindowSpec(block_size=4, num_kv_heads=1, head_size=64,
                         dtype=torch.float32, sliding_window=16)
pool = BlockPool(num_gpu_blocks=100, enable_caching=True, hash_block_size=4)
hashes = [BlockHash(f'b{i}'.encode()) for i in range(8)]
for i, h in enumerate(hashes):
    pool.cached_block_hash_to_block.insert(
        make_block_hash_with_group_id(h, 0), pool.blocks[i+10])
result = SlidingWindowManager.find_longest_cache_hit(
    block_hashes=hashes, max_length=32, kv_cache_group_ids=[0],
    block_pool=pool, kv_cache_spec=spec,
    use_eagle=True, alignment_tokens=8)
print('OK - no assertion, blocks:', len(result[0]))
```

## Test Result

**Before:**
```
Traceback (most recent call last):
  File "<string>", line 15, in <module>
  File "vllm/v1/core/single_type_kv_cache_manager.py", line 568, in find_longest_cache_hit
    assert kv_cache_spec.block_size == alignment_tokens, (
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AssertionError: aligned_length is not compatible with eagle now
```

**After:**
```
OK - no assertion, blocks: 6

# tests/v1/core/test_single_type_kv_cache_manager.py: 7 passed
# tests/v1/core/test_prefix_caching.py: 49 passed (including test_eagle_with_sliding_window)
```

---

- [x] The purpose of the PR
- [x] The test plan
- [x] The test results
- [ ] N/A - Documentation update
- [ ] N/A - Release notes update
