### PR TITLE
[Core] Use standalone autograd_cache_key for compilation dedup optimization

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -39,6 +39,8 @@ from .compiler_interface import (
     InductorAdaptor,
     InductorStandaloneAdaptor,
     is_compile_cache_enabled,
+    set_functorch_config,
+    set_inductor_config,
 )
 from .counter import compilation_counter
 from .partition_rules import (
@@ -255,6 +257,119 @@ class CompilerManager:
         )
         return compiled_graph
 
+    def _compile_legacy(
+        self,
+        graph: fx.GraphModule,
+        example_inputs: list[Any],
+        additional_inductor_config: dict[str, Any],
+        compile_range: Range,
+        key: str | None,
+    ) -> tuple[Any, Any, str | None]:
+        """Compile while capturing the cache key via monkey-patching.
+
+        Used on torch < 2.12 where ``standalone_compile.autograd_cache_key``
+        is not available.  Returns ``(compiled_graph, handle, cache_key)``.
+        """
+        from unittest.mock import patch
+
+        logger.debug("_compile_legacy: entering for range=%s", compile_range)
+        cache_key = None
+        orig = torch._functorch._aot_autograd.autograd_cache.autograd_cache_key
+
+        def patched_autograd_cache_key(*args, **kwargs):
+            result = orig(*args, **kwargs)
+            if result is None:
+                return None
+            nonlocal cache_key
+            cache_key = result[0]
+            if cache_key in self.loaded_artifacts:
+                raise _StopCompiling()
+            return result
+
+        with (
+            torch._functorch.config.patch(
+                autograd_cache_normalize_inputs=True,
+            ),
+            patch(
+                "torch._functorch._aot_autograd.autograd_cache.autograd_cache_key",
+                patched_autograd_cache_key,
+            ),
+        ):
+            try:
+                compiled_graph, handle = self.compiler.compile(
+                    graph,
+                    example_inputs,
+                    additional_inductor_config,
+                    compile_range,
+                    key,
+                )
+            except _StopCompiling:
+                assert cache_key is not None
+                logger.debug("_compile_legacy: dedup hit, cache_key=%s", cache_key)
+                return self.loaded_artifacts[cache_key], None, cache_key
+
+        logger.debug("_compile_legacy: compiled, cache_key=%s", cache_key)
+        return compiled_graph, handle, cache_key
+
+    def _compute_cache_key(
+        self,
+        graph: fx.GraphModule,
+        example_inputs: list[Any],
+        inductor_config: dict[str, Any],
+        compile_range: Range,
+    ) -> str:
+        """Compute the autograd cache key for dedup without compiling.
+
+        Uses the public ``standalone_compile.autograd_cache_key`` API under
+        the same config patches that the actual compilation would apply.
+
+        Requires torch >= 2.12.
+        """
+        from torch._inductor.standalone_compile import (
+            autograd_cache_key as _autograd_cache_key,
+        )
+
+        dynamic_shapes = InductorStandaloneAdaptor.resolve_dynamic_shapes(
+            compile_range,
+        )
+        aot = InductorStandaloneAdaptor.use_aot()
+        with (
+            torch._inductor.config.patch(inductor_config),
+            torch._functorch.config.patch(
+                autograd_cache_normalize_inputs=True,
+            ),
+        ):
+            key, _ = _autograd_cache_key(
+                graph,
+                example_inputs,
+                dynamic_shapes,
+                aot=aot,
+            )
+        logger.debug("_compute_cache_key (standalone API): %s", key)
+        return key
+
+    def _assert_cache_key_equivalence(
+        self,
+        graph: fx.GraphModule,
+        example_inputs: list[Any],
+        additional_inductor_config: dict[str, Any],
+        compile_range: Range,
+        legacy_key: str,
+    ) -> None:
+        """Assert that the standalone cache key API produces the same key
+        as the legacy monkey-patch path."""
+        standalone_key = self._compute_cache_key(
+            graph,
+            example_inputs,
+            additional_inductor_config,
+            compile_range,
+        )
+        assert legacy_key == standalone_key, (
+            "Cache key mismatch between standalone API and "
+            f"legacy path: {standalone_key!r} != {legacy_key!r}"
+        )
+        logger.debug("Cache key equivalence verified: %s", legacy_key)
+
     @instrument(span_name="Compile graph")
     def compile(
         self,
@@ -302,49 +417,37 @@ class CompilerManager:
             maybe_key += f"{compile_range.start}_{compile_range.end}"
             maybe_key += f"_subgraph_{graph_index}"
         with self.compile_context(compile_range):
-            # There is a compilation time optimization here.
-            #
-            # If the (input metadata, graph, compiler config) are the same, then
-            # we want to avoid compiling the same artifact again. If we didn't
-            # do this optimization, the backend compilation (InductorAdaptor or
-            # InductorStandaloneAdaptor)
-            # is able to cache hit and produce an artifact faster if it was
-            # already created, but it is still a duplicate artifact that
-            # requires unnecessary things e.g. disk IO.
-            #
-            # The optimization is: If the backend compilation cache hits,
-            # then do an early return from the backend compilation and look up
-            # which of the previous in-memory artifacts we created to reuse.
-            #
-            # We implemented this by monkey-patching torch (torch does not
-            # easily expose the cache_key function), but in the future torch
-            # should expose the cache_key function that we can just call
-            # directly before invoking backend compilation.
+            set_inductor_config(additional_inductor_config, compile_range)
+            set_functorch_config()
+
             cache_key = None
-            orig = torch._functorch._aot_autograd.autograd_cache.autograd_cache_key
 
-            def autograd_cache_key(*args, **kwargs):
-                result = orig(*args, **kwargs)
-                if result is None:
-                    return None
-                nonlocal cache_key
-                cache_key = result[0]
-                if cache_key in self.loaded_artifacts:
-                    raise StopCompiling()
-                return result
+            has_standalone_key_api = is_torch_equal_or_newer("2.12.0.dev")
+            use_standalone_key = (
+                has_standalone_key_api and not envs.VLLM_DEBUG_COMPILE_CACHE_KEY
+            )
 
-            from unittest.mock import patch
+            if use_standalone_key:
+                # Dedup optimization (Inductor only): compute the cache
+                # key up-front via the autograd_cache_key API and
+                # reuse a previously compiled artifact if available.
+                is_inductor = isinstance(
+                    self.compiler,
+                    (InductorAdaptor, InductorStandaloneAdaptor),
+                )
+                if is_inductor:
+                    cache_key = self._compute_cache_key(
+                        graph,
+                        example_inputs,
+                        additional_inductor_config,
+                        compile_range,
+                    )
+                    if cache_key in self.loaded_artifacts:
+                        return self.loaded_artifacts[cache_key]
 
-            with (
-                # Graphs that are isometric (different node names but same
-                # structure) should be treated as the same.
-                torch._functorch.config.patch(autograd_cache_normalize_inputs=True),
-                patch(
-                    "torch._functorch._aot_autograd.autograd_cache.autograd_cache_key",
-                    autograd_cache_key,
-                ),
-            ):
-                try:
+                with torch._functorch.config.patch(
+                    autograd_cache_normalize_inputs=True,
+                ):
                     compiled_graph, handle = self.compiler.compile(
                         graph,
                         example_inputs,
@@ -352,9 +455,30 @@ class CompilerManager:
                         compile_range,
                         maybe_key,
                     )
-                except StopCompiling:
-                    assert cache_key is not None
-                    return self.loaded_artifacts[cache_key]
+            else:
+                # torch < 2.12 or debug mode: capture key via
+                # monkey-patching during compilation.
+                compiled_graph, handle, cache_key = self._compile_legacy(
+                    graph,
+                    example_inputs,
+                    additional_inductor_config,
+                    compile_range,
+                    maybe_key,
+                )
+
+                if (
+                    envs.VLLM_DEBUG_COMPILE_CACHE_KEY
+                    and has_standalone_key_api
+                    and cache_key is not None
+                ):
+                    self._assert_cache_key_equivalence(
+                        graph,
+                        example_inputs,
+                        additional_inductor_config,
+                        compile_range,
+                        cache_key,
+                    )
+
             if cache_key is not None and compiled_graph is not None:
                 self.loaded_artifacts[cache_key] = compiled_graph
 
@@ -398,7 +522,10 @@ class CompilerManager:
         return compiled_graph
 
 
-class StopCompiling(BaseException):
+class _StopCompiling(BaseException):
+    """Raised by the legacy monkey-patched ``autograd_cache_key`` to
+    short-circuit compilation when an in-memory artifact already exists."""
+
     pass
 
 

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -421,6 +421,7 @@ class CompilerManager:
             set_functorch_config()
 
             cache_key = None
+            handle = None
 
             has_standalone_key_api = is_torch_equal_or_newer("2.12.0.dev")
             use_standalone_key = (
@@ -443,18 +444,19 @@ class CompilerManager:
                         compile_range,
                     )
                     if cache_key in self.loaded_artifacts:
-                        return self.loaded_artifacts[cache_key]
+                        compiled_graph = self.loaded_artifacts[cache_key]
 
-                with torch._functorch.config.patch(
-                    autograd_cache_normalize_inputs=True,
-                ):
-                    compiled_graph, handle = self.compiler.compile(
-                        graph,
-                        example_inputs,
-                        additional_inductor_config,
-                        compile_range,
-                        maybe_key,
-                    )
+                if compiled_graph is None:
+                    with torch._functorch.config.patch(
+                        autograd_cache_normalize_inputs=True,
+                    ):
+                        compiled_graph, handle = self.compiler.compile(
+                            graph,
+                            example_inputs,
+                            additional_inductor_config,
+                            compile_range,
+                            maybe_key,
+                        )
             else:
                 # torch < 2.12 or debug mode: capture key via
                 # monkey-patching during compilation.

--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -296,6 +296,27 @@ class InductorStandaloneAdaptor(CompilerInterface):
     ) -> None:
         self.cache_dir = cache_dir
 
+    @staticmethod
+    def resolve_dynamic_shapes(compile_range: Range):
+        if compile_range.is_single_size():
+            return "from_example_inputs"
+        else:
+            return "from_graph"
+
+    @staticmethod
+    def use_aot() -> bool:
+        supports_aot = is_torch_equal_or_newer("2.10.0")
+
+        if not supports_aot and envs.VLLM_USE_MEGA_AOT_ARTIFACT:
+            logger.error(
+                "CRITICAL: VLLM_USE_MEGA_AOT_ARTIFACT "
+                "is enabled but PyTorch version does not support 'aot' "
+                "parameter in standalone_compile. This requires PyTorch "
+                "2.10.0+. Falling back to non-AOT mode."
+            )
+
+        return supports_aot and envs.VLLM_USE_MEGA_AOT_ARTIFACT
+
     def compile(
         self,
         graph: fx.GraphModule,
@@ -311,22 +332,10 @@ class InductorStandaloneAdaptor(CompilerInterface):
         set_inductor_config(current_config, compile_range)
         set_functorch_config()
 
-        if compile_range.is_single_size():
-            dynamic_shapes = "from_example_inputs"
-        else:
-            dynamic_shapes = "from_graph"
+        dynamic_shapes = self.resolve_dynamic_shapes(compile_range)
+        use_aot = self.use_aot()
 
         from torch._inductor import standalone_compile
-
-        supports_aot = is_torch_equal_or_newer("2.10.0")
-
-        if not supports_aot and envs.VLLM_USE_MEGA_AOT_ARTIFACT:
-            logger.error(
-                "CRITICAL: VLLM_USE_MEGA_AOT_ARTIFACT "
-                "is enabled but PyTorch version does not support 'aot' "
-                "parameter in standalone_compile. This requires PyTorch "
-                "2.10.0+. Falling back to non-AOT mode."
-            )
 
         compile_kwargs = {
             "dynamic_shapes": dynamic_shapes,
@@ -335,7 +344,6 @@ class InductorStandaloneAdaptor(CompilerInterface):
             },
         }
 
-        use_aot: bool = supports_aot and envs.VLLM_USE_MEGA_AOT_ARTIFACT
         # only add 'aot' parameter if both supported and enabled...
         # this will set bundled_autograd_cache
         # https://github.com/pytorch/pytorch/blob/9bbc5b2905c260adf41bc866a732f9c121a2828a/torch/_inductor/standalone_compile.py#L359 # noqa

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -245,6 +245,7 @@ if TYPE_CHECKING:
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
     VLLM_USE_V2_MODEL_RUNNER: bool = False
     VLLM_LOG_MODEL_INSPECTION: bool = False
+    VLLM_DEBUG_COMPILE_CACHE_KEY: bool = False
     VLLM_DEBUG_MFU_METRICS: bool = False
     VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY: bool = False
     VLLM_WEIGHT_OFFLOADING_DISABLE_UVA: bool = False
@@ -1625,6 +1626,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Debug workspace allocations.
     # logging of workspace resize operations.
     "VLLM_DEBUG_WORKSPACE": lambda: bool(int(os.getenv("VLLM_DEBUG_WORKSPACE", "0"))),
+    # Cross-check the new standalone autograd_cache_key API against the
+    # legacy monkey-patching path before fully migrating to the new API.
+    # Only effective on torch >= 2.12.
+    "VLLM_DEBUG_COMPILE_CACHE_KEY": lambda: bool(
+        int(os.getenv("VLLM_DEBUG_COMPILE_CACHE_KEY", "0"))
+    ),
     # Disables parallel execution of shared_experts via separate cuda stream
     "VLLM_DISABLE_SHARED_EXPERTS_STREAM": lambda: bool(
         int(os.getenv("VLLM_DISABLE_SHARED_EXPERTS_STREAM", "0"))
@@ -1824,6 +1831,7 @@ def compile_factors() -> dict[str, object]:
         "VLLM_LOGGING_COLOR",
         "VLLM_LOG_STATS_INTERVAL",
         "VLLM_DEBUG_LOG_API_SERVER_RESPONSE",
+        "VLLM_DEBUG_COMPILE_CACHE_KEY",
         "VLLM_TUNED_CONFIG_FOLDER",
         "VLLM_ENGINE_ITERATION_TIMEOUT_S",
         "VLLM_HTTP_TIMEOUT_KEEP_ALIVE",


### PR DESCRIPTION
## Purpose

Use the new torch.compile standalone_compile.autograd_cache_key API
(torch >= 2.12) to compute cache keys up front, avoiding the legacy
monkey-patching of autograd_cache.autograd_cache_key during compilation.
This enables deduplication without compiling duplicate subgraphs.

A new VLLM_DEBUG_COMPILE_CACHE_KEY env var cross-checks the standalone
API against the legacy path. This uses a dedicated env var rather than
a log-level guard because the check changes the compilation codepath
(forces legacy compile + extra key computation), not just verbosity.
This follows the established VLLM_DEBUG_* convention (VLLM_DEBUG_WORKSPACE,
VLLM_DEBUG_MFU_METRICS, etc.).

## Test Plan

- Run meta-llama/Meta-Llama-3-70B-Instruct with TP=4. We expect no
  functional changes.
- Unit tests: tests/compile/ (test_config, test_wrapper, test_compile_ranges,
  passes/test_pass_manager, passes/test_noop_elimination).
- E2E test matrix: 2x2 matrix of (standalone vs legacy path) ×
  (VLLM_DEBUG_COMPILE_CACHE_KEY=0 vs =1). Legacy path simulated by
  setting has_standalone_key_api=False locally.

## Test Result

Cold-compile benchmark (Llama 3 70B, TP=4):
  No dedup (109b4a0):                mean 35.6s ± 0.8s, median 35.7s
  Dedup via monkey-patch (baseline):  mean 34.2s ± 0.8s, median 34.3s
  Dedup via standalone API (108414a): mean 34.7s ± 0.9s, median 34.8s

The standalone API is ~0.9s (2.5%) faster than no dedup, and within
noise of the monkey-patch baseline it replaces.