### PR TITLE
[Bugfix]: Expose added_tokens_decoder to mistral tokenizer wrapper

### DIFF
--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -324,6 +324,15 @@ class MistralTokenizer(TokenizerLike):
 
     # the following attributes are set to fit vLLM's design and are used
     # by the structured output backends.
+    class TokenInfo:
+        def __init__(self, is_special):
+            self.special = is_special
+
+    @property
+    def added_tokens_decoder(self):
+        """Expose added_tokens_decoder for compatibility."""
+        return {tid: self.TokenInfo(True) for tid in self._special_token_ids}
+
     @property
     def all_special_tokens(self) -> list[str]:
         return self._special_tokens


### PR DESCRIPTION
## Purpose
Observed the following error while running vllm bench serve
```
AttributeError: 'MistralTokenizer' object has no attribute 'added_tokens_decoder'
```
<details>
vllm bench serve --model mistralai/Ministral-3-14B-Instruct-2512-BF16 --dataset-name random-mm --max-concurrency 32 --random-output-len 128 --num-prompts 10 --random-input-len 30000 --backend openai-chat --endpoint /v1/chat/completions

Traceback (most recent call last):
  File "/home/tedchang/vllm/.venv/bin/vllm", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/tedchang/vllm/vllm/entrypoints/cli/main.py", line 75, in main
    args.dispatch_function(args)
  File "/home/tedchang/vllm/vllm/entrypoints/cli/benchmark/serve.py", line 21, in cmd
    main(args)
  File "/home/tedchang/vllm/vllm/benchmarks/serve.py", line 1632, in main
    return asyncio.run(main_async(args))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tedchang/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/home/tedchang/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tedchang/.local/share/uv/python/cpython-3.12.12-linux-x86_64-gnu/lib/python3.12/asyncio/base_events.py", line 691, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/tedchang/vllm/vllm/benchmarks/serve.py", line 1743, in main_async
    input_requests = get_samples(args, tokenizer)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tedchang/vllm/vllm/benchmarks/datasets.py", line 2085, in get_samples
    input_requests = dataset_mapping[args.dataset_name]()
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/tedchang/vllm/vllm/benchmarks/datasets.py", line 2034, in <lambda>
    ).sample(
      ^^^^^^^
  File "/home/tedchang/vllm/vllm/benchmarks/datasets.py", line 1215, in sample
    for tok_id, token in tokenizer.added_tokens_decoder.items()
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'MistralTokenizer' object has no attribute 'added_tokens_decoder'
</details>

How to verify:
Re-run the command
```
vllm bench serve --model mistralai/Ministral-3-14B-Instruct-2512-BF16 --dataset-name random-mm --max-concurrency 32 
```
The error should disappear and result similar to:
```
============ Serving Benchmark Result ============
Successful requests:                     10        
Failed requests:                         0         
Maximum request concurrency:             32        
Benchmark duration (s):                  82.98     
Total input tokens:                      299990    
Total generated tokens:                  1280      
Request throughput (req/s):              0.12      
Output token throughput (tok/s):         15.43     
Peak output token throughput (tok/s):    32.00     
Peak concurrent requests:                10.00     
Total token throughput (tok/s):          3630.78   
---------------Time to First Token----------------
Mean TTFT (ms):                          30561.39  
Median TTFT (ms):                        33302.06  
P99 TTFT (ms):                           69575.28  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          202.95    
Median TPOT (ms):                        221.65    
P99 TPOT (ms):                           256.50    
---------------Inter-token Latency----------------
Mean ITL (ms):                           201.36    
Median ITL (ms):                         129.72    
P99 ITL (ms):                            5368.30   
==================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc]

