### PR TITLE
[Bugfix] Fix tensor shape mismatch in sparse attention with speculative decoding

### DIFF
--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -250,7 +250,7 @@ def sparse_attn_indexer(
                 topk_indices.reshape(batch_size, -1, topk_indices.shape[-1]),
                 decode_lens,
             )
-            topk_indices_buffer[:topk_indices.shape[0], : topk_indices.shape[-1]] = (
+            topk_indices_buffer[: topk_indices.shape[0], : topk_indices.shape[-1]] = (
                 topk_indices
             )
 

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -213,7 +213,7 @@ def sparse_attn_indexer(
             )
             torch.ops._C.persistent_topk(
                 logits,
-                decode_metadata.seq_lens,
+                seq_lens,
                 topk_indices,
                 topk_workspace,
                 topk_tokens,
@@ -250,7 +250,7 @@ def sparse_attn_indexer(
                 topk_indices.reshape(batch_size, -1, topk_indices.shape[-1]),
                 decode_lens,
             )
-            topk_indices_buffer[:num_decode_tokens, : topk_indices.shape[-1]] = (
+            topk_indices_buffer[:topk_indices.shape[0], : topk_indices.shape[-1]] = (
                 topk_indices
             )
 


### PR DESCRIPTION



## Purpose

Fixes two tensor shape mismatches in sparse_indexer.py that cause RuntimeError when running DeepSeek-V3.2-NVFP4 with MTP and padded decode batches.

A previous refactor here correctly sliced `decode_metadata.seq_lens` to `batch_size` for `fp8_paged_mqa_logits`, but missed two downstream consumers that still used the unsliced tensor or the raw `num_decode_tokens` count:

**Fix 1: persistent_topk receiving wrong seq_lens**

persistent_topk was called with the full `decode_metadata.seq_lens` while logits and topk_indices were sized based on `batch_size * next_n.` The kernel used the unsliced seq_lens to determine output rows, producing a result with fewer rows than topk_indices expected.

 **Fix 2: topk_indices_buffer write-back after unpack_seq_triton**

After unpacking padded topk results, the code assigned back into `topk_indices_buffer[:num_decode_tokens]`. But num_decode_tokens is the total token count before packing, while unpack_seq_triton returns `sum(decode_lens)` rows — which is smaller when `requires_padding=True` (i.e. when short chunked prefills fall below the decode threshold). The write-back now uses `topk_indices.shape[0]` to match the actual unpacked size.

When does this trigger?

The bug surfaces specifically when all three conditions are met:
  - Speculative decoding is active (MTP/EAGLE), so next_n > 1
  - `requires_padding=True` — happens when a chunked prefill shorter than the decode threshold gets mixed into the decode batch
  - The padded batch size differs from the raw decode token count

Without speculative decoding (next_n=1) or without padding, the sizes happen to align and the bug is latent.

Error seen:
```
RuntimeError: The expanded size of the tensor (104) must match the existing size (98) at non-singleton dimension 0. Target sizes: [104, 2048]. Tensor sizes: [98, 2048] at sparse_indexer.py:168
```

## Test Plan
- Verified on B300 with DeepSeek-V3.2 (MTP next_n=2, next_n=4) using gsm8k eval for correctness

## Test Result

Without MTP
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9500|±  | 0.006|
|     |       |strict-match    |     5|exact_match|↑  |0.9492|±  | 0.006|
```


MTP=1
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9560|±  |0.0056|
|     |       |strict-match    |     5|exact_match|↑  |0.9553|±  |0.0057|
```

MTP=3
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9583|±  |0.0055|
|     |       |strict-match    |     5|exact_match|↑  |0.9575|±  |0.0056|
```d



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

