### PR TITLE
[Perf] Fuse Zero Initializer for FP8 DeepGemm Block Quant Kernel

### DIFF
--- a/csrc/libtorch_stable/quantization/w8a8/fp8/per_token_group_quant.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/fp8/per_token_group_quant.cu
@@ -261,12 +261,18 @@ __global__ void per_token_group_quant_8bit_packed_kernel(
   const bool is_valid = (mn_idx < mn) && (sf_k_idx < groups_per_row);
 
   // Padding groups: write a zero byte and exit.
+  // Skip writes beyond the storage, which has
+  // mn + (padded_groups_per_row / 4 - 1) * tma_aligned_mn int32s.
   if (!is_valid) {
     if (lane_id == 0) {
       const int sf_k_pack_idx = sf_k_idx / 4;
       const int pos = sf_k_idx % 4;
       const int out_idx = sf_k_pack_idx * tma_aligned_mn + mn_idx;
-      reinterpret_cast<uint8_t*>(output_s_packed)[out_idx * 4 + pos] = 0;
+      const int num_scale_elems =
+          mn + (padded_groups_per_row / 4 - 1) * tma_aligned_mn;
+      if (out_idx < num_scale_elems) {
+        reinterpret_cast<uint8_t*>(output_s_packed)[out_idx * 4 + pos] = 0;
+      }
     }
     return;
   }

--- a/csrc/libtorch_stable/quantization/w8a8/fp8/per_token_group_quant.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/fp8/per_token_group_quant.cu
@@ -260,13 +260,14 @@ __global__ void per_token_group_quant_8bit_packed_kernel(
   const int mn_idx = static_cast<int>(global_group_id / padded_groups_per_row);
 
   // Padding groups: write a zero byte and exit.
-  // Skip writes beyond the storage (num_scale_elems int32s).
   if (!((mn_idx < mn) && (sf_k_idx < groups_per_row))) {
     if (lane_id == 0) {
       // each uint32 in output_s_packed stores 4 packed scales
       const int sf_k_pack_idx = sf_k_idx / 4;
       const int pos = sf_k_idx % 4;
       const int out_idx = sf_k_pack_idx * tma_aligned_mn + mn_idx;
+
+      // skip writes beyond the storage size
       if (out_idx < num_scale_elems) {
         reinterpret_cast<uint8_t*>(output_s_packed)[out_idx * 4 + pos] = 0;
       }
@@ -290,14 +291,15 @@ __global__ void per_token_group_quant_8bit_packed_kernel(
       ComputeGroupScale<T, true>(group_input, smem_group, group_size, lane_id,
                                  threads_per_group, eps, max_8bit);
 
-  // reinterpret the UE8M0 scale y_s as IEEE bits, extract the 8-bit
-  // exponent, and write it to the correct byte position in output_s_packed.
+  // pack 4 scales into a uint32
   if (lane_id == 0) {
     // each uint32 in output_s_packed stores 4 packed scales
     const int sf_k_pack_idx = sf_k_idx / 4;
     const int pos = sf_k_idx % 4;
     const int out_idx = sf_k_pack_idx * tma_aligned_mn + mn_idx;
 
+    // reinterpret the UE8M0 scale y_s as IEEE bits, extract the 8-bit
+    // exponent, and write it to the correct byte position in output_s_packed.
     const unsigned int bits = __float_as_uint(y_s);
     const uint8_t exponent = static_cast<uint8_t>((bits >> 23u) & 0xffu);
     reinterpret_cast<uint8_t*>(output_s_packed)[out_idx * 4 + pos] = exponent;

--- a/csrc/libtorch_stable/quantization/w8a8/fp8/per_token_group_quant.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/fp8/per_token_group_quant.cu
@@ -262,7 +262,7 @@ __global__ void per_token_group_quant_8bit_packed_kernel(
   // whether it is a valid group (not padding)
   const bool is_valid_group = (mn_idx < mn) && (sf_k_idx < groups_per_row);
 
-  // Only valid groups read input and compute scales via shared memory.
+  // shared memory to cache each group's data to avoid double DRAM reads.
   extern __shared__ __align__(16) char smem_raw[];
   T* smem = reinterpret_cast<T*>(smem_raw);
   T* smem_group = smem + local_group_id * group_size;
@@ -277,7 +277,7 @@ __global__ void per_token_group_quant_8bit_packed_kernel(
                                      lane_id, threads_per_group, eps, max_8bit);
   }
 
-  // write scale byte: exponent for valid groups, zero for padding.
+  // pack 4 scales into a uint32 exponent
   if (lane_id == 0) {
     // each uint32 in output_s_packed stores 4 packed scales
     const int sf_k_pack_idx = sf_k_idx / 4;
@@ -291,7 +291,7 @@ __global__ void per_token_group_quant_8bit_packed_kernel(
       const uint8_t exponent = static_cast<uint8_t>((bits >> 23u) & 0xffu);
       reinterpret_cast<uint8_t*>(output_s_packed)[out_idx * 4 + pos] = exponent;
     } else if (out_idx < num_scale_elems) {
-      // skip writes beyond the storage size
+      // write zero for padding groups if within bounds of output_s_packed
       reinterpret_cast<uint8_t*>(output_s_packed)[out_idx * 4 + pos] = 0;
     }
   }
@@ -356,7 +356,7 @@ void per_token_group_quant_8bit_packed(const torch::stable::Tensor& input,
   // output_s_packed is written (padding bytes get zeroed by the kernel).
   const int64_t padded_groups_per_row = k_num_packed_sfk * 4;
   const int64_t num_groups_padded = tma_aligned_mn * padded_groups_per_row;
-  // Number of uint32 elements in output_s_packed.
+  // Number of elements in output_s_packed.
   const int64_t num_scale_elems = mn + (k_num_packed_sfk - 1) * tma_aligned_mn;
 
   const int groups_per_block = GetGroupsPerBlock(num_groups_padded);

--- a/csrc/libtorch_stable/quantization/w8a8/fp8/per_token_group_quant.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/fp8/per_token_group_quant.cu
@@ -240,20 +240,40 @@ template <typename T, typename DST_DTYPE>
 __global__ void per_token_group_quant_8bit_packed_kernel(
     const T* __restrict__ input, void* __restrict__ output_q,
     unsigned int* __restrict__ output_s_packed, const int group_size,
-    const int num_groups, const int groups_per_block, const int groups_per_row,
-    const int mn, const int tma_aligned_mn, const float eps,
-    const float min_8bit, const float max_8bit) {
+    const int num_groups_padded, const int groups_per_block,
+    const int padded_groups_per_row, const int groups_per_row, const int mn,
+    const int tma_aligned_mn, const float eps, const float min_8bit,
+    const float max_8bit) {
   const int threads_per_group = 16;
   const int64_t local_group_id = threadIdx.x / threads_per_group;
   const int lane_id = threadIdx.x % threads_per_group;
 
   const int64_t block_group_id = blockIdx.x * groups_per_block;
   const int64_t global_group_id = block_group_id + local_group_id;
-  if (global_group_id >= num_groups) {
+  if (global_group_id >= num_groups_padded) {
     return;
   }
 
-  const int64_t block_group_offset = global_group_id * group_size;
+  // Map flat padded group id to 2D position in the padded grid.
+  const int sf_k_idx =
+      static_cast<int>(global_group_id % padded_groups_per_row);
+  const int mn_idx = static_cast<int>(global_group_id / padded_groups_per_row);
+  const bool is_valid = (mn_idx < mn) && (sf_k_idx < groups_per_row);
+
+  // Padding groups: write a zero byte and exit.
+  if (!is_valid) {
+    if (lane_id == 0) {
+      const int sf_k_pack_idx = sf_k_idx / 4;
+      const int pos = sf_k_idx % 4;
+      const int out_idx = sf_k_pack_idx * tma_aligned_mn + mn_idx;
+      reinterpret_cast<uint8_t*>(output_s_packed)[out_idx * 4 + pos] = 0;
+    }
+    return;
+  }
+
+  const int64_t block_group_offset =
+      static_cast<int64_t>(mn_idx) * groups_per_row * group_size +
+      sf_k_idx * group_size;
 
   const T* group_input = input + block_group_offset;
   DST_DTYPE* group_output =
@@ -267,27 +287,15 @@ __global__ void per_token_group_quant_8bit_packed_kernel(
       ComputeGroupScale<T, true>(group_input, smem_group, group_size, lane_id,
                                  threads_per_group, eps, max_8bit);
 
-  // pack 4 scales into a uint32
+  // Write the 8-bit UE8M0 exponent directly to the correct byte position.
   if (lane_id == 0) {
-    // map flat group id to 2D indices (mn_idx, sf_k_idx)
-    const int sf_k_idx = static_cast<int>(global_group_id % groups_per_row);
-    const int mn_idx = static_cast<int>(global_group_id / groups_per_row);
+    const int sf_k_pack_idx = sf_k_idx / 4;
+    const int pos = sf_k_idx % 4;
+    const int out_idx = sf_k_pack_idx * tma_aligned_mn + mn_idx;
 
-    if (mn_idx < mn) {
-      // each uint32 in output_s_packed stores 4 packed scales
-      const int sf_k_pack_idx = sf_k_idx / 4;
-      const int pos = sf_k_idx % 4;
-
-      // reinterpret the UE8M0 scale y_s as IEEE bits, extract the 8-bit
-      // exponent, and place it into the correct byte of the 32-bit word.
-      const unsigned int bits = __float_as_uint(y_s);
-      const unsigned int exponent = (bits >> 23u) & 0xffu;
-      const unsigned int contrib = exponent << (pos * 8u);
-
-      const int out_idx = sf_k_pack_idx * tma_aligned_mn + mn_idx;
-      // atomically OR 8-bit exponent into the packed scales buffer
-      atomicOr(output_s_packed + out_idx, contrib);
-    }
+    const unsigned int bits = __float_as_uint(y_s);
+    const uint8_t exponent = static_cast<uint8_t>((bits >> 23u) & 0xffu);
+    reinterpret_cast<uint8_t*>(output_s_packed)[out_idx * 4 + pos] = exponent;
   }
 
   __syncthreads();
@@ -310,7 +318,6 @@ void per_token_group_quant_8bit_packed(const torch::stable::Tensor& input,
 
   const int64_t mn = input.numel() / k;
   const int64_t groups_per_row = k / group_size;
-  const int64_t num_groups = mn * groups_per_row;
 
   STD_TORCH_CHECK(output_s_packed.dim() == 2,
                   "output_s_packed must be 2D, got dim=", output_s_packed.dim(),
@@ -335,31 +342,33 @@ void per_token_group_quant_8bit_packed(const torch::stable::Tensor& input,
 
   constexpr int THREADS_PER_GROUP = 16;
 
-  const int groups_per_block = GetGroupsPerBlock(num_groups);
+  // Expand the grid to cover MN and K padding so every byte in
+  // output_s_packed is written (padding bytes get zeroed by the kernel).
+  // This eliminates the need for a separate zero-init pass.
+  const int64_t padded_groups_per_row = k_num_packed_sfk * 4;
+  const int64_t num_groups_padded = tma_aligned_mn * padded_groups_per_row;
+
+  const int groups_per_block = GetGroupsPerBlock(num_groups_padded);
 
   auto dst_type = output_q.scalar_type();
-  const int num_blocks = num_groups / groups_per_block;
+  const int num_blocks = num_groups_padded / groups_per_block;
   const int num_threads = groups_per_block * THREADS_PER_GROUP;
 
-  // zero-initialize packed scales, since we use atomicOr to accumulate
-  // exponents from different groups.
-  torch::stable::zero_(output_s_packed);
-
-#define LAUNCH_PACKED_KERNEL(T, DST_DTYPE)                                \
-  do {                                                                    \
-    dim3 grid(num_blocks);                                                \
-    dim3 block(num_threads);                                              \
-    size_t smem_bytes =                                                   \
-        static_cast<size_t>(groups_per_block) * group_size * sizeof(T);   \
-    per_token_group_quant_8bit_packed_kernel<T, DST_DTYPE>                \
-        <<<grid, block, smem_bytes, stream>>>(                            \
-            static_cast<const T*>(input.data_ptr()), output_q.data_ptr(), \
-            reinterpret_cast<unsigned int*>(output_s_packed.data_ptr()),  \
-            static_cast<int>(group_size), static_cast<int>(num_groups),   \
-            groups_per_block, static_cast<int>(groups_per_row),           \
-            static_cast<int>(mn), static_cast<int>(tma_aligned_mn),       \
-            static_cast<float>(eps), static_cast<float>(min_8bit),        \
-            static_cast<float>(max_8bit));                                \
+#define LAUNCH_PACKED_KERNEL(T, DST_DTYPE)                                     \
+  do {                                                                         \
+    dim3 grid(num_blocks);                                                     \
+    dim3 block(num_threads);                                                   \
+    size_t smem_bytes =                                                        \
+        static_cast<size_t>(groups_per_block) * group_size * sizeof(T);        \
+    per_token_group_quant_8bit_packed_kernel<T, DST_DTYPE>                     \
+        <<<grid, block, smem_bytes, stream>>>(                                 \
+            static_cast<const T*>(input.data_ptr()), output_q.data_ptr(),      \
+            reinterpret_cast<unsigned int*>(output_s_packed.data_ptr()),       \
+            static_cast<int>(group_size), static_cast<int>(num_groups_padded), \
+            groups_per_block, static_cast<int>(padded_groups_per_row),         \
+            static_cast<int>(groups_per_row), static_cast<int>(mn),            \
+            static_cast<int>(tma_aligned_mn), static_cast<float>(eps),         \
+            static_cast<float>(min_8bit), static_cast<float>(max_8bit));       \
   } while (0)
 
   VLLM_STABLE_DISPATCH_FLOATING_TYPES(

--- a/csrc/libtorch_stable/quantization/w8a8/fp8/per_token_group_quant.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/fp8/per_token_group_quant.cu
@@ -259,56 +259,53 @@ __global__ void per_token_group_quant_8bit_packed_kernel(
       static_cast<int>(global_group_id % padded_groups_per_row);
   const int mn_idx = static_cast<int>(global_group_id / padded_groups_per_row);
 
-  // Padding groups: write a zero byte and exit.
-  if (!((mn_idx < mn) && (sf_k_idx < groups_per_row))) {
-    if (lane_id == 0) {
-      // each uint32 in output_s_packed stores 4 packed scales
-      const int sf_k_pack_idx = sf_k_idx / 4;
-      const int pos = sf_k_idx % 4;
-      const int out_idx = sf_k_pack_idx * tma_aligned_mn + mn_idx;
+  // whether it is a valid group (not padding)
+  const bool is_valid_group = (mn_idx < mn) && (sf_k_idx < groups_per_row);
 
-      // skip writes beyond the storage size
-      if (out_idx < num_scale_elems) {
-        reinterpret_cast<uint8_t*>(output_s_packed)[out_idx * 4 + pos] = 0;
-      }
-    }
-    return;
-  }
-
-  const int64_t block_group_offset =
-      static_cast<int64_t>(mn_idx) * groups_per_row * group_size +
-      sf_k_idx * group_size;
-
-  const T* group_input = input + block_group_offset;
-  DST_DTYPE* group_output =
-      static_cast<DST_DTYPE*>(output_q) + block_group_offset;
-
-  // shared memory to cache each group's data to avoid double DRAM reads.
+  // Only valid groups read input and compute scales via shared memory.
   extern __shared__ __align__(16) char smem_raw[];
   T* smem = reinterpret_cast<T*>(smem_raw);
   T* smem_group = smem + local_group_id * group_size;
-  const float y_s =
-      ComputeGroupScale<T, true>(group_input, smem_group, group_size, lane_id,
-                                 threads_per_group, eps, max_8bit);
 
-  // pack 4 scales into a uint32
+  // compute scale for valid groups
+  float y_s = 0.f;
+  if (is_valid_group) {
+    const T* group_input =
+        input + static_cast<int64_t>(mn_idx) * groups_per_row * group_size +
+        sf_k_idx * group_size;
+    y_s = ComputeGroupScale<T, true>(group_input, smem_group, group_size,
+                                     lane_id, threads_per_group, eps, max_8bit);
+  }
+
+  // write scale byte: exponent for valid groups, zero for padding.
   if (lane_id == 0) {
     // each uint32 in output_s_packed stores 4 packed scales
     const int sf_k_pack_idx = sf_k_idx / 4;
     const int pos = sf_k_idx % 4;
     const int out_idx = sf_k_pack_idx * tma_aligned_mn + mn_idx;
 
-    // reinterpret the UE8M0 scale y_s as IEEE bits, extract the 8-bit
-    // exponent, and write it to the correct byte position in output_s_packed.
-    const unsigned int bits = __float_as_uint(y_s);
-    const uint8_t exponent = static_cast<uint8_t>((bits >> 23u) & 0xffu);
-    reinterpret_cast<uint8_t*>(output_s_packed)[out_idx * 4 + pos] = exponent;
+    if (is_valid_group) {
+      // reinterpret the UE8M0 scale y_s as IEEE bits, extract the 8-bit
+      // exponent, and place it into the correct byte of the 32-bit word.
+      const unsigned int bits = __float_as_uint(y_s);
+      const uint8_t exponent = static_cast<uint8_t>((bits >> 23u) & 0xffu);
+      reinterpret_cast<uint8_t*>(output_s_packed)[out_idx * 4 + pos] = exponent;
+    } else if (out_idx < num_scale_elems) {
+      // skip writes beyond the storage size
+      reinterpret_cast<uint8_t*>(output_s_packed)[out_idx * 4 + pos] = 0;
+    }
   }
 
   __syncthreads();
 
-  QuantizeGroup<T, DST_DTYPE>(smem_group, group_output, group_size, lane_id,
-                              threads_per_group, y_s, min_8bit, max_8bit);
+  if (is_valid_group) {
+    DST_DTYPE* group_output =
+        static_cast<DST_DTYPE*>(output_q) +
+        static_cast<int64_t>(mn_idx) * groups_per_row * group_size +
+        sf_k_idx * group_size;
+    QuantizeGroup<T, DST_DTYPE>(smem_group, group_output, group_size, lane_id,
+                                threads_per_group, y_s, min_8bit, max_8bit);
+  }
 }
 
 void per_token_group_quant_8bit_packed(const torch::stable::Tensor& input,

--- a/csrc/libtorch_stable/quantization/w8a8/fp8/per_token_group_quant.cu
+++ b/csrc/libtorch_stable/quantization/w8a8/fp8/per_token_group_quant.cu
@@ -242,8 +242,8 @@ __global__ void per_token_group_quant_8bit_packed_kernel(
     unsigned int* __restrict__ output_s_packed, const int group_size,
     const int num_groups_padded, const int groups_per_block,
     const int padded_groups_per_row, const int groups_per_row, const int mn,
-    const int tma_aligned_mn, const float eps, const float min_8bit,
-    const float max_8bit) {
+    const int tma_aligned_mn, const int num_scale_elems, const float eps,
+    const float min_8bit, const float max_8bit) {
   const int threads_per_group = 16;
   const int64_t local_group_id = threadIdx.x / threads_per_group;
   const int lane_id = threadIdx.x % threads_per_group;
@@ -254,22 +254,19 @@ __global__ void per_token_group_quant_8bit_packed_kernel(
     return;
   }
 
-  // Map flat padded group id to 2D position in the padded grid.
+  // map flat group id to 2D indices (mn_idx, sf_k_idx)
   const int sf_k_idx =
       static_cast<int>(global_group_id % padded_groups_per_row);
   const int mn_idx = static_cast<int>(global_group_id / padded_groups_per_row);
-  const bool is_valid = (mn_idx < mn) && (sf_k_idx < groups_per_row);
 
   // Padding groups: write a zero byte and exit.
-  // Skip writes beyond the storage, which has
-  // mn + (padded_groups_per_row / 4 - 1) * tma_aligned_mn int32s.
-  if (!is_valid) {
+  // Skip writes beyond the storage (num_scale_elems int32s).
+  if (!((mn_idx < mn) && (sf_k_idx < groups_per_row))) {
     if (lane_id == 0) {
+      // each uint32 in output_s_packed stores 4 packed scales
       const int sf_k_pack_idx = sf_k_idx / 4;
       const int pos = sf_k_idx % 4;
       const int out_idx = sf_k_pack_idx * tma_aligned_mn + mn_idx;
-      const int num_scale_elems =
-          mn + (padded_groups_per_row / 4 - 1) * tma_aligned_mn;
       if (out_idx < num_scale_elems) {
         reinterpret_cast<uint8_t*>(output_s_packed)[out_idx * 4 + pos] = 0;
       }
@@ -293,8 +290,10 @@ __global__ void per_token_group_quant_8bit_packed_kernel(
       ComputeGroupScale<T, true>(group_input, smem_group, group_size, lane_id,
                                  threads_per_group, eps, max_8bit);
 
-  // Write the 8-bit UE8M0 exponent directly to the correct byte position.
+  // reinterpret the UE8M0 scale y_s as IEEE bits, extract the 8-bit
+  // exponent, and write it to the correct byte position in output_s_packed.
   if (lane_id == 0) {
+    // each uint32 in output_s_packed stores 4 packed scales
     const int sf_k_pack_idx = sf_k_idx / 4;
     const int pos = sf_k_idx % 4;
     const int out_idx = sf_k_pack_idx * tma_aligned_mn + mn_idx;
@@ -343,6 +342,12 @@ void per_token_group_quant_8bit_packed(const torch::stable::Tensor& input,
                   "output_s_packed shape must be [", mn, ", ", k_num_packed_sfk,
                   "], but got [", output_s_packed.size(0), ", ",
                   output_s_packed.size(1), "].");
+  // Verify column-major TMA-aligned layout
+  STD_TORCH_CHECK(output_s_packed.stride(0) == 1 &&
+                      output_s_packed.stride(1) == tma_aligned_mn,
+                  "output_s_packed must have strides [1, ", tma_aligned_mn,
+                  "], but got [", output_s_packed.stride(0), ", ",
+                  output_s_packed.stride(1), "].");
 
   cudaStream_t stream = get_current_cuda_stream();
 
@@ -350,9 +355,10 @@ void per_token_group_quant_8bit_packed(const torch::stable::Tensor& input,
 
   // Expand the grid to cover MN and K padding so every byte in
   // output_s_packed is written (padding bytes get zeroed by the kernel).
-  // This eliminates the need for a separate zero-init pass.
   const int64_t padded_groups_per_row = k_num_packed_sfk * 4;
   const int64_t num_groups_padded = tma_aligned_mn * padded_groups_per_row;
+  // Number of uint32 elements in output_s_packed.
+  const int64_t num_scale_elems = mn + (k_num_packed_sfk - 1) * tma_aligned_mn;
 
   const int groups_per_block = GetGroupsPerBlock(num_groups_padded);
 
@@ -373,7 +379,8 @@ void per_token_group_quant_8bit_packed(const torch::stable::Tensor& input,
             static_cast<int>(group_size), static_cast<int>(num_groups_padded), \
             groups_per_block, static_cast<int>(padded_groups_per_row),         \
             static_cast<int>(groups_per_row), static_cast<int>(mn),            \
-            static_cast<int>(tma_aligned_mn), static_cast<float>(eps),         \
+            static_cast<int>(tma_aligned_mn),                                  \
+            static_cast<int>(num_scale_elems), static_cast<float>(eps),        \
             static_cast<float>(min_8bit), static_cast<float>(max_8bit));       \
   } while (0)
 

--- a/tests/kernels/quantization/test_per_token_group_quant.py
+++ b/tests/kernels/quantization/test_per_token_group_quant.py
@@ -61,12 +61,17 @@ def test_per_token_group_quant_fp8(
         (4, 640),
         # K padding only: groups_per_row=6 (6%4=2)
         (4, 768),
+        # Single packed column, no padding: k_num_packed=1, mn%4=0
+        (4, 384),
         # Both MN and K padding
         (1, 384),
         (3, 640),
-        # Larger shapes
+        # Larger shapes with no padding
         (64, 7168),
         (128, 14336),
+        # Larger shapes with padding
+        (127, 7168),
+        (253, 640),
     ],
 )
 @pytest.mark.parametrize("group_size", [128])
@@ -97,69 +102,31 @@ def test_per_token_group_quant_fp8_packed(num_tokens, hidden_dim, group_size):
     # Quantized values must match.
     assert torch.equal(out_q, ref_q), "Quantized output mismatch"
 
-    # Verify packed scales against reference float scales.
-    # ref_s is row-major float32 with shape [mn, groups_per_row].
-    # out_s_packed is int32 with 4 UE8M0 exponent bytes per word.
+    # Verify packed scales (valid exponents + padding zeros)
     mn = num_tokens
     groups_per_row = hidden_dim // group_size
     k_num_packed = (groups_per_row + 3) // 4
     tma_aligned_mn = ((mn + 3) // 4) * 4
+    num_scale_elems = mn + (k_num_packed - 1) * tma_aligned_mn
 
-    # Extract reference exponents from float scales.
-    # UE8M0 scale = 2^(exponent - 127), so the IEEE exponent byte encodes it.
+    # Extract reference exponents from the Triton float32 scales.
     ref_s_flat = ref_s.reshape(mn, groups_per_row)
     ref_exponents = (ref_s_flat.view(torch.int32) >> 23) & 0xFF
 
-    # Read packed buffer as raw bytes.
-    packed_bytes = out_s_packed.view(torch.int32).cpu()
-    # The physical layout is column-major: stride (1, tma_aligned_mn).
-    # packed_bytes has shape [mn, k_num_packed].
+    expected = torch.zeros(num_scale_elems, dtype=torch.int32)
     for row in range(mn):
         for g in range(groups_per_row):
             pack_col = g // 4
             pos = g % 4
-            word = packed_bytes[row, pack_col].item()
-            byte_val = (word >> (pos * 8)) & 0xFF
-            expected = ref_exponents[row, g].item()
-            assert byte_val == expected, (
-                f"Scale mismatch at row={row}, group={g}: "
-                f"packed={byte_val}, expected={expected}"
-            )
+            idx = pack_col * tma_aligned_mn + row
+            expected[idx] |= int(ref_exponents[row, g].item()) << (pos * 8)
 
-    # Verify padding bytes are zero.
-    # out_s_packed has shape [mn, k_num_packed] with strides (1, tma_aligned_mn).
-    # The storage has mn + (k_num_packed - 1) * tma_aligned_mn int32s,
-    # which does NOT include the last column's MN padding (those bytes are
-    # beyond the allocation and never read by DeepGEMM).
-    storage_size = mn + (k_num_packed - 1) * tma_aligned_mn
-    raw_flat = torch.as_strided(out_s_packed, (storage_size,), (1,)).cpu()
-
-    # Helper to read a physical int32 at column c, row r.
-    def read_word(c, r):
-        idx = c * tma_aligned_mn + r
-        assert idx < storage_size
-        return raw_flat[idx].item()
-
-    # Check MN padding rows (mn..tma_aligned_mn-1) in each column,
-    # but skip the last column where these positions are beyond the storage.
-    for c in range(k_num_packed - 1):
-        for r in range(mn, tma_aligned_mn):
-            assert read_word(c, r) == 0, (
-                f"MN padding not zero at col={c}, row={r}: 0x{read_word(c, r):08x}"
-            )
-
-    # Check K padding bytes within valid MN rows
-    padded_groups_per_row = k_num_packed * 4
-    if padded_groups_per_row > groups_per_row:
-        for r in range(mn):
-            for g in range(groups_per_row, padded_groups_per_row):
-                pack_col = g // 4
-                pos = g % 4
-                word = read_word(pack_col, r)
-                byte_val = (word >> (pos * 8)) & 0xFF
-                assert byte_val == 0, (
-                    f"K padding not zero at row={r}, group={g}: {byte_val}"
-                )
+    actual = torch.as_strided(out_s_packed, (num_scale_elems,), (1,)).cpu()
+    assert torch.equal(actual, expected), (
+        f"Packed scale storage mismatch.\n"
+        f"First diff at index "
+        f"{(actual != expected).nonzero(as_tuple=True)[0][0].item()}"
+    )
 
 
 @pytest.mark.parametrize("shape", [(32, 128), (64, 256), (16, 512)])

--- a/tests/kernels/quantization/test_per_token_group_quant.py
+++ b/tests/kernels/quantization/test_per_token_group_quant.py
@@ -49,36 +49,41 @@ def test_per_token_group_quant_fp8(
 
 
 @pytest.mark.parametrize(
-    "num_tokens,hidden_dim",
+    "num_tokens,hidden_dim,group_size",
     [
         # No padding: mn=4 (mult of 4), groups_per_row=56 (mult of 4)
-        (4, 7168),
+        (4, 7168, 128),
         # MN padding only: mn=1, tma_aligned_mn=4
-        (1, 7168),
+        (1, 7168, 128),
         # MN padding only: mn=3, tma_aligned_mn=4
-        (3, 7168),
+        (3, 7168, 128),
         # K padding only: groups_per_row=5 (5%4=1)
-        (4, 640),
+        (4, 640, 128),
         # K padding only: groups_per_row=6 (6%4=2)
-        (4, 768),
+        (4, 768, 128),
         # Single packed column, no padding: k_num_packed=1, mn%4=0
-        (4, 384),
+        (4, 384, 128),
         # Both MN and K padding
-        (1, 384),
-        (3, 640),
+        (1, 384, 128),
+        (3, 640, 128),
         # Larger shapes with no padding
-        (64, 7168),
-        (128, 14336),
+        (64, 7168, 128),
+        (128, 14336, 128),
         # Larger shapes with padding
-        (127, 7168),
-        (253, 640),
+        (127, 7168, 128),
+        (253, 640, 128),
+        # Non-power-of-2 group size
+        (4, 768, 96),  # 768/96=8 groups, no padding
+        (3, 768, 96),  # 768/96=8 groups, MN padding
+        (4, 480, 96),  # 480/96=5 groups, K padding
+        (1, 480, 96),  # both MN and K padding
     ],
 )
-@pytest.mark.parametrize("group_size", [128])
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
 def test_per_token_group_quant_fp8_packed(num_tokens, hidden_dim, group_size):
     """Test the packed DeepGEMM quantization kernel against the Triton
     reference (row-major, UE8M0 scales)."""
+
     device = "cuda"
     torch.manual_seed(42)
 

--- a/tests/kernels/quantization/test_per_token_group_quant.py
+++ b/tests/kernels/quantization/test_per_token_group_quant.py
@@ -118,7 +118,7 @@ def test_per_token_group_quant_fp8_packed(num_tokens, hidden_dim, group_size):
     ref_s_flat = ref_s.reshape(mn, groups_per_row)
     ref_exponents = (ref_s_flat.view(torch.int32) >> 23) & 0xFF
 
-    expected = torch.zeros(num_scale_elems, dtype=torch.int32)
+    expected = torch.zeros(num_scale_elems, dtype=torch.int32, device="cpu")
     for row in range(mn):
         for g in range(groups_per_row):
             pack_col = g // 4

--- a/tests/kernels/quantization/test_per_token_group_quant.py
+++ b/tests/kernels/quantization/test_per_token_group_quant.py
@@ -127,23 +127,25 @@ def test_per_token_group_quant_fp8_packed(num_tokens, hidden_dim, group_size):
             )
 
     # Verify padding bytes are zero.
-    # MN padding: rows mn..tma_aligned_mn-1 in each column.
-    raw = out_s_packed.cpu().contiguous()
-    # Physical buffer is k_num_packed * tma_aligned_mn int32s.
-    # Stride is (1, tma_aligned_mn) so column c starts at int32 offset
-    # c * tma_aligned_mn.
-    raw_int32 = torch.zeros(k_num_packed, tma_aligned_mn, dtype=torch.int32)
-    for c in range(k_num_packed):
-        for r in range(tma_aligned_mn):
-            # physical offset = c * tma_aligned_mn + r
-            raw_int32[c, r] = raw.view(-1)[c * tma_aligned_mn + r]
+    # out_s_packed has shape [mn, k_num_packed] with strides (1, tma_aligned_mn).
+    # The storage has mn + (k_num_packed - 1) * tma_aligned_mn int32s,
+    # which does NOT include the last column's MN padding (those bytes are
+    # beyond the allocation and never read by DeepGEMM).
+    storage_size = mn + (k_num_packed - 1) * tma_aligned_mn
+    raw_flat = torch.as_strided(out_s_packed, (storage_size,), (1,)).cpu()
 
-    # Check MN padding rows
-    for c in range(k_num_packed):
+    # Helper to read a physical int32 at column c, row r.
+    def read_word(c, r):
+        idx = c * tma_aligned_mn + r
+        assert idx < storage_size
+        return raw_flat[idx].item()
+
+    # Check MN padding rows (mn..tma_aligned_mn-1) in each column,
+    # but skip the last column where these positions are beyond the storage.
+    for c in range(k_num_packed - 1):
         for r in range(mn, tma_aligned_mn):
-            assert raw_int32[c, r].item() == 0, (
-                f"MN padding not zero at col={c}, row={r}: "
-                f"0x{raw_int32[c, r].item():08x}"
+            assert read_word(c, r) == 0, (
+                f"MN padding not zero at col={c}, row={r}: 0x{read_word(c, r):08x}"
             )
 
     # Check K padding bytes within valid MN rows
@@ -153,7 +155,7 @@ def test_per_token_group_quant_fp8_packed(num_tokens, hidden_dim, group_size):
             for g in range(groups_per_row, padded_groups_per_row):
                 pack_col = g // 4
                 pos = g % 4
-                word = raw_int32[pack_col, r].item()
+                word = read_word(pack_col, r)
                 byte_val = (word >> (pos * 8)) & 0xFF
                 assert byte_val == 0, (
                     f"K padding not zero at row={r}, group={g}: {byte_val}"

--- a/tests/kernels/quantization/test_per_token_group_quant.py
+++ b/tests/kernels/quantization/test_per_token_group_quant.py
@@ -79,8 +79,11 @@ def test_per_token_group_quant_fp8(
         (1, 480, 96),  # both MN and K padding
     ],
 )
+@pytest.mark.parametrize("poisoned_scales", [False, True])
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
-def test_per_token_group_quant_fp8_packed(num_tokens, hidden_dim, group_size):
+def test_per_token_group_quant_fp8_packed(
+    num_tokens, hidden_dim, group_size, poisoned_scales
+):
     """Test the packed DeepGEMM quantization kernel against the Triton
     reference (row-major, UE8M0 scales)."""
 
@@ -89,12 +92,40 @@ def test_per_token_group_quant_fp8_packed(num_tokens, hidden_dim, group_size):
 
     x = torch.randn((num_tokens, hidden_dim), device=device, dtype=torch.bfloat16) * 8
 
-    # Packed CUDA kernel under test
-    out_q, out_s_packed = fp8_utils.per_token_group_quant_fp8_packed_for_deepgemm(
-        x,
-        group_size=group_size,
-        use_ue8m0=True,
-    )
+    mn = num_tokens
+    groups_per_row = hidden_dim // group_size
+    k_num_packed = (groups_per_row + 3) // 4
+    tma_aligned_mn = ((mn + 3) // 4) * 4
+    num_scale_elems = mn + (k_num_packed - 1) * tma_aligned_mn
+
+    if poisoned_scales:
+        # Call the kernel with poisoned scale buffer to
+        # ensure padded indices are correctly zeroed.
+        fp8_dtype = torch.float8_e4m3fn
+        finfo = torch.finfo(fp8_dtype)
+        out_q = torch.empty_like(x, dtype=fp8_dtype)
+        out_s_packed = torch.empty_strided(
+            (mn, k_num_packed),
+            (1, tma_aligned_mn),
+            device=device,
+            dtype=torch.int32,
+        )
+        torch.as_strided(out_s_packed, (num_scale_elems,), (1,)).fill_(0x7F7F7F7F)
+        torch.ops._C.per_token_group_fp8_quant_packed(
+            x,
+            out_q,
+            out_s_packed,
+            group_size,
+            1e-10,
+            finfo.min,
+            finfo.max,
+        )
+    else:
+        out_q, out_s_packed = fp8_utils.per_token_group_quant_fp8_packed_for_deepgemm(
+            x,
+            group_size=group_size,
+            use_ue8m0=True,
+        )
 
     # Triton reference (row-major float32 scales, UE8M0)
     with patch("vllm.platforms.current_platform.is_cuda", return_value=False):
@@ -107,14 +138,7 @@ def test_per_token_group_quant_fp8_packed(num_tokens, hidden_dim, group_size):
     # Quantized values must match.
     assert torch.equal(out_q, ref_q), "Quantized output mismatch"
 
-    # Verify packed scales (valid exponents + padding zeros)
-    mn = num_tokens
-    groups_per_row = hidden_dim // group_size
-    k_num_packed = (groups_per_row + 3) // 4
-    tma_aligned_mn = ((mn + 3) // 4) * 4
-    num_scale_elems = mn + (k_num_packed - 1) * tma_aligned_mn
-
-    # Extract reference exponents from the Triton float32 scales.
+    # Verify packed scales (valid exponents + padding zeros).
     ref_s_flat = ref_s.reshape(mn, groups_per_row)
     ref_exponents = (ref_s_flat.view(torch.int32) >> 23) & 0xFF
 

--- a/tests/kernels/quantization/test_per_token_group_quant.py
+++ b/tests/kernels/quantization/test_per_token_group_quant.py
@@ -48,6 +48,118 @@ def test_per_token_group_quant_fp8(
     assert torch.allclose(scale, ref_s, atol=0.01, rtol=0.01)
 
 
+@pytest.mark.parametrize(
+    "num_tokens,hidden_dim",
+    [
+        # No padding: mn=4 (mult of 4), groups_per_row=56 (mult of 4)
+        (4, 7168),
+        # MN padding only: mn=1, tma_aligned_mn=4
+        (1, 7168),
+        # MN padding only: mn=3, tma_aligned_mn=4
+        (3, 7168),
+        # K padding only: groups_per_row=5 (5%4=1)
+        (4, 640),
+        # K padding only: groups_per_row=6 (6%4=2)
+        (4, 768),
+        # Both MN and K padding
+        (1, 384),
+        (3, 640),
+        # Larger shapes
+        (64, 7168),
+        (128, 14336),
+    ],
+)
+@pytest.mark.parametrize("group_size", [128])
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+def test_per_token_group_quant_fp8_packed(num_tokens, hidden_dim, group_size):
+    """Test the packed DeepGEMM quantization kernel against the Triton
+    reference (row-major, UE8M0 scales)."""
+    device = "cuda"
+    torch.manual_seed(42)
+
+    x = torch.randn((num_tokens, hidden_dim), device=device, dtype=torch.bfloat16) * 8
+
+    # Packed CUDA kernel under test
+    out_q, out_s_packed = fp8_utils.per_token_group_quant_fp8_packed_for_deepgemm(
+        x,
+        group_size=group_size,
+        use_ue8m0=True,
+    )
+
+    # Triton reference (row-major float32 scales, UE8M0)
+    with patch("vllm.platforms.current_platform.is_cuda", return_value=False):
+        ref_q, ref_s = fp8_utils.per_token_group_quant_fp8(
+            x,
+            group_size,
+            use_ue8m0=True,
+        )
+
+    # Quantized values must match.
+    assert torch.equal(out_q, ref_q), "Quantized output mismatch"
+
+    # Verify packed scales against reference float scales.
+    # ref_s is row-major float32 with shape [mn, groups_per_row].
+    # out_s_packed is int32 with 4 UE8M0 exponent bytes per word.
+    mn = num_tokens
+    groups_per_row = hidden_dim // group_size
+    k_num_packed = (groups_per_row + 3) // 4
+    tma_aligned_mn = ((mn + 3) // 4) * 4
+
+    # Extract reference exponents from float scales.
+    # UE8M0 scale = 2^(exponent - 127), so the IEEE exponent byte encodes it.
+    ref_s_flat = ref_s.reshape(mn, groups_per_row)
+    ref_exponents = (ref_s_flat.view(torch.int32) >> 23) & 0xFF
+
+    # Read packed buffer as raw bytes.
+    packed_bytes = out_s_packed.view(torch.int32).cpu()
+    # The physical layout is column-major: stride (1, tma_aligned_mn).
+    # packed_bytes has shape [mn, k_num_packed].
+    for row in range(mn):
+        for g in range(groups_per_row):
+            pack_col = g // 4
+            pos = g % 4
+            word = packed_bytes[row, pack_col].item()
+            byte_val = (word >> (pos * 8)) & 0xFF
+            expected = ref_exponents[row, g].item()
+            assert byte_val == expected, (
+                f"Scale mismatch at row={row}, group={g}: "
+                f"packed={byte_val}, expected={expected}"
+            )
+
+    # Verify padding bytes are zero.
+    # MN padding: rows mn..tma_aligned_mn-1 in each column.
+    raw = out_s_packed.cpu().contiguous()
+    # Physical buffer is k_num_packed * tma_aligned_mn int32s.
+    # Stride is (1, tma_aligned_mn) so column c starts at int32 offset
+    # c * tma_aligned_mn.
+    raw_int32 = torch.zeros(k_num_packed, tma_aligned_mn, dtype=torch.int32)
+    for c in range(k_num_packed):
+        for r in range(tma_aligned_mn):
+            # physical offset = c * tma_aligned_mn + r
+            raw_int32[c, r] = raw.view(-1)[c * tma_aligned_mn + r]
+
+    # Check MN padding rows
+    for c in range(k_num_packed):
+        for r in range(mn, tma_aligned_mn):
+            assert raw_int32[c, r].item() == 0, (
+                f"MN padding not zero at col={c}, row={r}: "
+                f"0x{raw_int32[c, r].item():08x}"
+            )
+
+    # Check K padding bytes within valid MN rows
+    padded_groups_per_row = k_num_packed * 4
+    if padded_groups_per_row > groups_per_row:
+        for r in range(mn):
+            for g in range(groups_per_row, padded_groups_per_row):
+                pack_col = g // 4
+                pos = g % 4
+                word = raw_int32[pack_col, r].item()
+                byte_val = (word >> (pos * 8)) & 0xFF
+                assert byte_val == 0, (
+                    f"K padding not zero at row={r}, group={g}: {byte_val}"
+                )
+
+
 @pytest.mark.parametrize("shape", [(32, 128), (64, 256), (16, 512)])
 @pytest.mark.parametrize("group_size", [64, 128])
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")


### PR DESCRIPTION
## Purpose
Currently, `per_token_group_quant_fp8_packed_for_deepgemm` requires calling `torch::stable::zero_(output_s_packed)` to initialize the scale buffer before the quant kernel.
<img width="699" height="258" alt="Screenshot 2026-04-10 at 6 12 58 PM" src="https://github.com/user-attachments/assets/7b6102da-2d1c-470a-b336-d84f40666bb1" />

This PR removes the zero initializer for the quant kernel by writing zero to the padded indices of the scale buffer within the quant kernel:
<img width="638" height="184" alt="Screenshot 2026-04-10 at 6 15 05 PM" src="https://github.com/user-attachments/assets/415c76a7-f50f-4530-b352-b1f89baec56b" />

For Minimax M2.5 Fp8 concurrency 128 1K/1K, this saves 2 * 1.2 us out of 240 us layer time (**~1% E2E speedup**) in decoding.

## Test Plan
- Added `per_token_group_quant_fp8_packed_for_deepgemm` kernel tests in `tests/kernels/quantization/test_per_token_group_quant.py`
- E2E model accuracy eval with minimax 2.5.

## Test Result
```
vllm serve MiniMaxAI/MiniMax-M2.5 --trust-remote-code --tensor-parallel-size 2

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9295|±  |0.0071|
|     |       |strict-match    |     5|exact_match|↑  |0.9265|±  |0.0072|

VLLM_USE_DEEP_GEMM=1 vllm serve MiniMaxAI/MiniMax-M2.5 --trust-remote-code --tensor-parallel-size 2 

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9325|±  |0.0069|
|     |       |strict-match    |     5|exact_match|↑  |0.9265|±  |0.0072|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

