### PR TITLE
Revert "[PluggableLayer][3/N] Apply PluggableLayer to llm_head and vocab embedding layer" (#33465)

### DIFF
--- a/vllm/model_executor/layers/logits_processor.py
+++ b/vllm/model_executor/layers/logits_processor.py
@@ -9,14 +9,14 @@ from vllm.distributed import (
     tensor_model_parallel_all_gather,
     tensor_model_parallel_gather,
 )
-from vllm.model_executor.custom_op import PluggableLayer
+from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.vocab_parallel_embedding import VocabParallelEmbedding
 from vllm.platforms import current_platform
 
 
 # --8<-- [start:logits_processor]
-@PluggableLayer.register("logits_processor")
-class LogitsProcessor(PluggableLayer):
+@CustomOp.register("logits_processor")
+class LogitsProcessor(CustomOp):
     """Process logits and apply logits processors from sampling metadata.
 
     This layer does the following:

--- a/vllm/model_executor/layers/vocab_parallel_embedding.py
+++ b/vllm/model_executor/layers/vocab_parallel_embedding.py
@@ -14,7 +14,7 @@ from vllm.distributed import (
     get_tensor_model_parallel_world_size,
     tensor_model_parallel_all_reduce,
 )
-from vllm.model_executor.custom_op import PluggableLayer
+from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
     QuantizeMethodBase,
@@ -182,8 +182,8 @@ def get_masked_input_and_mask(
 
 
 # --8<-- [start:vocab_parallel_embedding]
-@PluggableLayer.register("vocab_parallel_embedding")
-class VocabParallelEmbedding(PluggableLayer):
+@CustomOp.register("vocab_parallel_embedding")
+class VocabParallelEmbedding(CustomOp):
     """Embedding parallelized in the vocabulary dimension.
 
     Adapted from torch.nn.Embedding, note that we pad the vocabulary size to
@@ -461,7 +461,7 @@ class VocabParallelEmbedding(PluggableLayer):
         param[: loaded_weight.shape[0]].data.copy_(loaded_weight)
         param[loaded_weight.shape[0] :].data.fill_(0)
 
-    def forward(self, input_):
+    def forward_native(self, input_):
         if self.tp_size > 1:
             # Build the mask.
             masked_input, input_mask = get_masked_input_and_mask(
@@ -483,6 +483,9 @@ class VocabParallelEmbedding(PluggableLayer):
         output = tensor_model_parallel_all_reduce(output_parallel)
         return output
 
+    def forward_cuda(self, input_):
+        return self.forward_native(input_)
+
     def extra_repr(self) -> str:
         s = f"num_embeddings={self.num_embeddings_per_partition}"
         s += f", embedding_dim={self.embedding_dim}"
@@ -493,7 +496,7 @@ class VocabParallelEmbedding(PluggableLayer):
 
 
 # --8<-- [start:parallel_lm_head]
-@PluggableLayer.register("parallel_lm_head")
+@CustomOp.register("parallel_lm_head")
 class ParallelLMHead(VocabParallelEmbedding):
     """Parallelized LM head.
 


### PR DESCRIPTION
## Revert of https://github.com/vllm-project/vllm/pull/33465

**Reason:** This PR is suspected of causing 1 new CI failure in [build #60867](https://buildkite.com/vllm/ci/builds/60867):
- **CPU-Language Generation and Pooling Model Tests** — embedding cosine similarity dropped to 0.7961 (required >= 0.99) for `ssmits/Qwen2-7B-Instruct-embed-base`

The original PR modified `vocab_parallel_embedding.py` and `logits_processor.py`, which are core to how embeddings are computed. The drastic drop in cosine similarity suggests a fundamental change in embedding output.

---
*Auto-generated by CI failure analyzer*