### PR TITLE
[Bugfix] Make completions response construction use normalized per-prompt max_tokens

### DIFF
--- a/tests/entrypoints/openai/completion/test_completion.py
+++ b/tests/entrypoints/openai/completion/test_completion.py
@@ -607,6 +607,86 @@ async def test_echo_logprob_completion(
     "model_name",
     [MODEL_NAME],
 )
+async def test_completion_without_max_tokens_uses_normalized_budget(
+    client: openai.AsyncOpenAI, model_name: str
+):
+    completion = await client.completions.create(
+        model=model_name,
+        prompt="Hello, my name is",
+        temperature=0.0,
+        echo=True,
+        extra_body={"return_token_ids": True},
+    )
+
+    choice = completion.choices[0]
+
+    assert choice.prompt_token_ids is not None
+    assert choice.token_ids is not None
+    assert completion.usage.prompt_tokens == len(choice.prompt_token_ids)
+    assert completion.usage.completion_tokens == len(choice.token_ids)
+    assert completion.usage.total_tokens == (
+        completion.usage.prompt_tokens + completion.usage.completion_tokens
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model_name",
+    [MODEL_NAME],
+)
+async def test_completion_stream_without_max_tokens_uses_normalized_budget(
+    client: openai.AsyncOpenAI, model_name: str
+):
+    stream = await client.completions.create(
+        model=model_name,
+        prompt="Hello, my name is",
+        temperature=0.0,
+        echo=True,
+        stream=True,
+        stream_options={
+            "include_usage": True,
+            "continuous_usage_stats": True,
+        },
+        extra_body={"return_token_ids": True},
+    )
+
+    choice_chunks = []
+    final_usage_chunk = None
+
+    async for chunk in stream:
+        assert chunk.usage is not None
+        assert chunk.usage.total_tokens == (
+            chunk.usage.prompt_tokens + chunk.usage.completion_tokens
+        )
+
+        if chunk.choices:
+            choice_chunks.append(chunk)
+        else:
+            final_usage_chunk = chunk
+
+    assert choice_chunks
+    assert final_usage_chunk is not None
+    assert final_usage_chunk.choices == []
+    assert final_usage_chunk.usage is not None
+    assert final_usage_chunk.usage.total_tokens == (
+        final_usage_chunk.usage.prompt_tokens
+        + final_usage_chunk.usage.completion_tokens
+    )
+
+    first_choice = choice_chunks[0].choices[0]
+    assert first_choice.prompt_token_ids is not None
+    assert first_choice.token_ids is not None
+
+    for chunk in choice_chunks[1:]:
+        choice = chunk.choices[0]
+        assert choice.prompt_token_ids is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model_name",
+    [MODEL_NAME],
+)
 async def test_zero_budget_echo_completion_hides_helper_token(
     client: openai.AsyncOpenAI, model_name: str
 ):

--- a/tests/entrypoints/openai/completion/test_completion.py
+++ b/tests/entrypoints/openai/completion/test_completion.py
@@ -613,6 +613,7 @@ async def test_completion_without_max_tokens_uses_normalized_budget(
     completion = await client.completions.create(
         model=model_name,
         prompt="Hello, my name is",
+        max_tokens=None,
         temperature=0.0,
         echo=True,
         extra_body={"return_token_ids": True},
@@ -640,6 +641,7 @@ async def test_completion_stream_without_max_tokens_uses_normalized_budget(
     stream = await client.completions.create(
         model=model_name,
         prompt="Hello, my name is",
+        max_tokens=None,
         temperature=0.0,
         echo=True,
         stream=True,

--- a/tests/entrypoints/openai/completion/test_completion.py
+++ b/tests/entrypoints/openai/completion/test_completion.py
@@ -607,6 +607,107 @@ async def test_echo_logprob_completion(
     "model_name",
     [MODEL_NAME],
 )
+async def test_zero_budget_echo_completion_hides_helper_token(
+    client: openai.AsyncOpenAI, model_name: str
+):
+    prompt = "Hello, my name is"
+    tokenizer = get_tokenizer(tokenizer_name=MODEL_NAME)
+
+    completion = await client.completions.create(
+        model=model_name,
+        prompt=prompt,
+        max_tokens=0,
+        temperature=0.0,
+        echo=True,
+        logprobs=1,
+        extra_body={"return_token_ids": True},
+    )
+
+    choice = completion.choices[0]
+
+    # With return_token_ids=True, the echoed prompt is surfaced via
+    # prompt_token_ids rather than duplicated in the text field.
+    assert choice.text == ""
+    assert choice.prompt_token_ids is not None
+    assert prompt in tokenizer.decode(choice.prompt_token_ids)
+    assert choice.token_ids == []
+    assert choice.logprobs is not None
+    assert len(choice.logprobs.tokens) == len(choice.prompt_token_ids)
+    assert completion.usage.prompt_tokens == len(choice.prompt_token_ids)
+    assert completion.usage.completion_tokens == 0
+    assert completion.usage.total_tokens == completion.usage.prompt_tokens
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model_name",
+    [MODEL_NAME],
+)
+async def test_zero_budget_echo_stream_hides_helper_token(
+    client: openai.AsyncOpenAI, model_name: str
+):
+    prompt = "Hello, my name is"
+    tokenizer = get_tokenizer(tokenizer_name=MODEL_NAME)
+
+    stream = await client.completions.create(
+        model=model_name,
+        prompt=prompt,
+        max_tokens=0,
+        temperature=0.0,
+        echo=True,
+        logprobs=1,
+        stream=True,
+        stream_options={
+            "include_usage": True,
+            "continuous_usage_stats": True,
+        },
+        extra_body={"return_token_ids": True},
+    )
+
+    choice_chunks = []
+    final_usage_chunk = None
+
+    async for chunk in stream:
+        assert chunk.usage is not None
+        assert chunk.usage.completion_tokens == 0
+        assert chunk.usage.total_tokens == chunk.usage.prompt_tokens
+
+        if chunk.choices:
+            choice_chunks.append(chunk)
+        else:
+            final_usage_chunk = chunk
+
+    assert choice_chunks
+    assert final_usage_chunk is not None
+    assert final_usage_chunk.choices == []
+    assert final_usage_chunk.usage is not None
+    assert final_usage_chunk.usage.completion_tokens == 0
+
+    first_choice = choice_chunks[0].choices[0]
+    # With return_token_ids=True, the echoed prompt is surfaced via
+    # prompt_token_ids rather than duplicated in the text field.
+    assert first_choice.prompt_token_ids is not None
+    assert prompt in tokenizer.decode(first_choice.prompt_token_ids)
+    assert first_choice.text == ""
+    assert first_choice.token_ids == []
+    assert first_choice.logprobs is not None
+    assert len(first_choice.logprobs.tokens) == len(first_choice.prompt_token_ids)
+
+    for chunk in choice_chunks[1:]:
+        choice = chunk.choices[0]
+        assert choice.prompt_token_ids is None
+        assert choice.text == ""
+        assert choice.token_ids == []
+        assert choice.logprobs is None
+
+    assert choice_chunks[-1].choices[0].finish_reason == "length"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "model_name",
+    [MODEL_NAME],
+)
 async def test_invalid_json_schema(client: openai.AsyncOpenAI, model_name: str) -> None:
     invalid_json_schema = {
         "$defs": {

--- a/tests/entrypoints/openai/completion/test_completion_error.py
+++ b/tests/entrypoints/openai/completion/test_completion_error.py
@@ -1,19 +1,25 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
 from dataclasses import dataclass, field
 from typing import Any
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from vllm.config.multimodal import MultiModalConfig
 from vllm.entrypoints.openai.completion.protocol import CompletionRequest
 from vllm.entrypoints.openai.completion.serving import OpenAIServingCompletion
-from vllm.entrypoints.openai.engine.protocol import GenerationError
+from vllm.entrypoints.openai.engine.protocol import (
+    GenerationError,
+    RequestResponseMetadata,
+    StreamOptions,
+)
 from vllm.entrypoints.openai.models.protocol import BaseModelPath
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.serve.render.serving import OpenAIServingRender
+from vllm.logprobs import Logprob
 from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.renderers.hf import HfRenderer
 from vllm.tokenizers.registry import cached_tokenizer_from_config
@@ -96,6 +102,119 @@ def _build_renderer(model_config: MockModelConfig):
     return HfRenderer(
         MockVllmConfig(model_config, parallel_config=MockParallelConfig()),
         cached_tokenizer_from_config(model_config),
+    )
+
+
+def _build_mock_engine() -> MagicMock:
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+    return mock_engine
+
+
+def _build_request_output(
+    *,
+    prompt: str = "Test prompt",
+    prompt_token_ids: list[int] | None = None,
+    text: str = "Hello",
+    token_ids: list[int] | None = None,
+    logprobs: list[dict[int, Logprob] | None] | None = None,
+    finish_reason: str | None = "length",
+    finished: bool = True,
+) -> RequestOutput:
+    return RequestOutput(
+        request_id="test-id",
+        prompt=prompt,
+        prompt_token_ids=[1, 2, 3] if prompt_token_ids is None else prompt_token_ids,
+        prompt_logprobs=None,
+        outputs=[
+            CompletionOutput(
+                index=0,
+                text=text,
+                token_ids=[100] if token_ids is None else token_ids,
+                cumulative_logprob=None,
+                logprobs=logprobs,
+                finish_reason=finish_reason,
+            )
+        ],
+        finished=finished,
+        metrics=None,
+        lora_request=None,
+        encoder_prompt=None,
+        encoder_prompt_token_ids=None,
+    )
+
+
+def _build_engine_input(
+    *,
+    prompt: str = "Test prompt",
+    prompt_token_ids: list[int] | None = None,
+) -> dict[str, str | list[int]]:
+    return {
+        "prompt": prompt,
+        "prompt_token_ids": [1, 2, 3] if prompt_token_ids is None else prompt_token_ids,
+    }
+
+
+def _build_output_logprobs(
+    token_id: int,
+    decoded_token: str,
+    *,
+    logprob: float = -0.5,
+) -> list[dict[int, Logprob] | None]:
+    return [
+        {
+            token_id: Logprob(
+                logprob=logprob,
+                rank=1,
+                decoded_token=decoded_token,
+            )
+        }
+    ]
+
+
+async def _stream_results(results: list[tuple[int, RequestOutput]]):
+    for result in results:
+        yield result
+
+
+async def _collect_stream_payloads(
+    serving_completion: OpenAIServingCompletion,
+    request: CompletionRequest,
+    results: list[tuple[int, RequestOutput]],
+    *,
+    max_tokens_per_prompt: list[int],
+):
+    response = serving_completion.completion_stream_generator(
+        request=request,
+        engine_inputs=[_build_engine_input()],
+        result_generator=_stream_results(results),
+        request_id="test-id",
+        created_time=0,
+        model_name=MODEL_NAME,
+        num_prompts=1,
+        max_tokens_per_prompt=max_tokens_per_prompt,
+        tokenizer=serving_completion.renderer.tokenizer,
+        request_metadata=RequestResponseMetadata(request_id="test-id"),
+    )
+
+    chunks = []
+    async for chunk in response:
+        chunks.append(chunk)
+
+    payloads = [
+        json.loads(chunk.removeprefix("data: ").removesuffix("\n\n"))
+        for chunk in chunks
+        if chunk.startswith("data: {")
+    ]
+    return (
+        chunks,
+        payloads,
+        [payload for payload in payloads if payload.get("choices")],
+        [payload for payload in payloads if payload.get("usage")],
     )
 
 
@@ -227,6 +346,392 @@ async def test_completion_error_stream():
         f"Expected error message in chunks: {chunks}"
     )
     assert chunks[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("echo", "max_tokens_per_prompt", "expected_text"),
+    [
+        (False, [16], "Hello"),
+        (True, [16], "Test promptHello"),
+        (True, [0], "Test prompt"),
+    ],
+)
+async def test_request_output_to_completion_response_uses_normalized_max_tokens(
+    echo: bool,
+    max_tokens_per_prompt: list[int],
+    expected_text: str,
+):
+    mock_engine = _build_mock_engine()
+    serving_completion = _build_serving_completion(mock_engine)
+    request = CompletionRequest(
+        model=MODEL_NAME,
+        prompt="Test prompt",
+        max_tokens=None,
+        stream=False,
+        echo=echo,
+    )
+    request_output = _build_request_output()
+
+    response = serving_completion.request_output_to_completion_response(
+        [request_output],
+        request,
+        request_id="test-id",
+        created_time=0,
+        model_name=MODEL_NAME,
+        max_tokens_per_prompt=max_tokens_per_prompt,
+        tokenizer=serving_completion.renderer.tokenizer,
+        request_metadata=RequestResponseMetadata(request_id="test-id"),
+    )
+
+    assert response.choices[0].text == expected_text
+
+
+@pytest.mark.asyncio
+async def test_request_output_to_completion_response_uses_per_prompt_max_tokens():
+    mock_engine = _build_mock_engine()
+    serving_completion = _build_serving_completion(mock_engine)
+    request = CompletionRequest(
+        model=MODEL_NAME,
+        prompt=["First prompt", "Second prompt"],
+        max_tokens=None,
+        stream=False,
+        echo=True,
+    )
+
+    response = serving_completion.request_output_to_completion_response(
+        [
+            _build_request_output(
+                prompt="First prompt",
+                prompt_token_ids=[1, 2],
+                text="Alpha",
+                token_ids=[101],
+            ),
+            _build_request_output(
+                prompt="Second prompt",
+                prompt_token_ids=[3, 4],
+                text="Beta",
+                token_ids=[202],
+            ),
+        ],
+        request,
+        request_id="test-id",
+        created_time=0,
+        model_name=MODEL_NAME,
+        max_tokens_per_prompt=[0, 16],
+        tokenizer=serving_completion.renderer.tokenizer,
+        request_metadata=RequestResponseMetadata(request_id="test-id"),
+    )
+
+    assert [choice.text for choice in response.choices] == [
+        "First prompt",
+        "Second promptBeta",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_request_output_to_completion_response_allows_empty_logprobs():
+    mock_engine = _build_mock_engine()
+    serving_completion = _build_serving_completion(mock_engine)
+    request = CompletionRequest(
+        model=MODEL_NAME,
+        prompt="Test prompt",
+        max_tokens=None,
+        stream=False,
+        echo=False,
+        logprobs=1,
+    )
+
+    response = serving_completion.request_output_to_completion_response(
+        [
+            _build_request_output(
+                text="",
+                token_ids=[],
+                logprobs=None,
+                finish_reason="length",
+            )
+        ],
+        request,
+        request_id="test-id",
+        created_time=0,
+        model_name=MODEL_NAME,
+        max_tokens_per_prompt=[0],
+        tokenizer=serving_completion.renderer.tokenizer,
+        request_metadata=RequestResponseMetadata(request_id="test-id"),
+    )
+
+    assert response.choices[0].text == ""
+    assert response.choices[0].logprobs is None
+    assert response.usage.completion_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_request_output_to_completion_response_allows_empty_echo_logprobs():
+    mock_engine = _build_mock_engine()
+    serving_completion = _build_serving_completion(mock_engine)
+    request = CompletionRequest(
+        model=MODEL_NAME,
+        prompt="Test prompt",
+        max_tokens=None,
+        stream=False,
+        echo=True,
+        logprobs=1,
+    )
+    request_output = _build_request_output(
+        text="",
+        token_ids=[],
+        logprobs=None,
+        finish_reason="length",
+    )
+    request_output.prompt_logprobs = [None, None, None]
+
+    response = serving_completion.request_output_to_completion_response(
+        [request_output],
+        request,
+        request_id="test-id",
+        created_time=0,
+        model_name=MODEL_NAME,
+        max_tokens_per_prompt=[16],
+        tokenizer=serving_completion.renderer.tokenizer,
+        request_metadata=RequestResponseMetadata(request_id="test-id"),
+    )
+
+    assert response.choices[0].text == "Test prompt"
+    assert response.choices[0].logprobs is not None
+    assert response.choices[0].token_ids is None
+    assert response.usage.completion_tokens == 0
+
+
+@pytest.mark.asyncio
+async def test_completion_stream_generator_uses_normalized_max_tokens():
+    mock_engine = _build_mock_engine()
+    serving_completion = _build_serving_completion(mock_engine)
+    request = CompletionRequest(
+        model=MODEL_NAME,
+        prompt="Test prompt",
+        max_tokens=None,
+        stream=True,
+        echo=True,
+    )
+
+    chunks, payloads, _, _ = await _collect_stream_payloads(
+        serving_completion,
+        request,
+        [(0, _build_request_output())],
+        max_tokens_per_prompt=[16],
+    )
+    payload = next(payload for payload in payloads if payload.get("choices"))
+
+    assert payload["choices"][0]["text"] == "Test promptHello"
+    assert all("error" not in payload for payload in payloads)
+    assert chunks[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_stream_generator_hides_prompt_token_ids_without_return_token_ids():
+    mock_engine = _build_mock_engine()
+    serving_completion = _build_serving_completion(mock_engine)
+    request = CompletionRequest(
+        model=MODEL_NAME,
+        prompt="Test prompt",
+        max_tokens=None,
+        stream=True,
+        echo=True,
+        return_token_ids=False,
+    )
+
+    chunks, payloads, choice_payloads, _ = await _collect_stream_payloads(
+        serving_completion,
+        request,
+        [(0, _build_request_output())],
+        max_tokens_per_prompt=[16],
+    )
+
+    assert all("error" not in payload for payload in payloads)
+    assert choice_payloads[0]["choices"][0]["text"] == "Test promptHello"
+    assert choice_payloads[0]["choices"][0]["prompt_token_ids"] is None
+    assert choice_payloads[0]["choices"][0]["token_ids"] is None
+    assert chunks[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_completion_stream_generator_allows_empty_prefill_logprobs():
+    mock_engine = _build_mock_engine()
+    serving_completion = _build_serving_completion(mock_engine)
+    request = CompletionRequest(
+        model=MODEL_NAME,
+        prompt="Test prompt",
+        max_tokens=16,
+        stream=True,
+        logprobs=1,
+        return_token_ids=True,
+    )
+
+    chunks, payloads, choice_payloads, _ = await _collect_stream_payloads(
+        serving_completion,
+        request,
+        [
+            (
+                0,
+                _build_request_output(
+                    text="",
+                    token_ids=[],
+                    logprobs=None,
+                    finish_reason=None,
+                    finished=False,
+                ),
+            ),
+            (
+                0,
+                _build_request_output(
+                    text="Hello",
+                    token_ids=[100],
+                    logprobs=_build_output_logprobs(100, "Hello"),
+                ),
+            ),
+        ],
+        max_tokens_per_prompt=[16],
+    )
+
+    assert all("error" not in payload for payload in payloads)
+    assert choice_payloads[0]["choices"][0]["prompt_token_ids"] == [1, 2, 3]
+    assert choice_payloads[0]["choices"][0]["token_ids"] == []
+    assert choice_payloads[0]["choices"][0]["logprobs"] is None
+    assert choice_payloads[1]["choices"][0]["token_ids"] == [100]
+    assert choice_payloads[1]["choices"][0]["logprobs"] is not None
+    assert chunks[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_zero_budget_stream_hides_prompt_token_ids():
+    mock_engine = _build_mock_engine()
+    serving_completion = _build_serving_completion(mock_engine)
+    request = CompletionRequest(
+        model=MODEL_NAME,
+        prompt="Test prompt",
+        max_tokens=None,
+        stream=True,
+        echo=True,
+        return_token_ids=False,
+    )
+
+    chunks, payloads, choice_payloads, _ = await _collect_stream_payloads(
+        serving_completion,
+        request,
+        [
+            (
+                0,
+                _build_request_output(
+                    text="H",
+                    token_ids=[999],
+                    finish_reason="length",
+                ),
+            ),
+        ],
+        max_tokens_per_prompt=[0],
+    )
+
+    assert all("error" not in payload for payload in payloads)
+    assert choice_payloads[0]["choices"][0]["text"] == "Test prompt"
+    assert choice_payloads[0]["choices"][0]["prompt_token_ids"] is None
+    assert choice_payloads[0]["choices"][0]["token_ids"] is None
+    assert chunks[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "results",
+    [
+        [
+            (
+                0,
+                _build_request_output(
+                    text="H",
+                    token_ids=[999],
+                    finish_reason="length",
+                ),
+            ),
+        ],
+        [
+            (
+                0,
+                _build_request_output(
+                    text="",
+                    token_ids=[],
+                    finish_reason=None,
+                    finished=False,
+                ),
+            ),
+            (
+                0,
+                _build_request_output(
+                    text="H",
+                    token_ids=[999],
+                    finish_reason="length",
+                ),
+            ),
+        ],
+    ],
+)
+async def test_stream_generator_suppresses_helper_token(
+    results: list[tuple[int, RequestOutput]],
+):
+    mock_engine = _build_mock_engine()
+    serving_completion = _build_serving_completion(mock_engine)
+    request = CompletionRequest(
+        model=MODEL_NAME,
+        prompt="Test prompt",
+        max_tokens=None,
+        stream=True,
+        echo=True,
+        return_token_ids=True,
+        stream_options=StreamOptions(
+            include_usage=True,
+            continuous_usage_stats=True,
+        ),
+    )
+
+    chunks, payloads, choice_payloads, usage_payloads = await _collect_stream_payloads(
+        serving_completion,
+        request,
+        results,
+        max_tokens_per_prompt=[0],
+    )
+
+    assert all("error" not in payload for payload in payloads)
+    assert choice_payloads[0]["choices"][0]["prompt_token_ids"] == [1, 2, 3]
+    assert all(payload["choices"][0]["text"] == "" for payload in choice_payloads)
+    assert choice_payloads[0]["choices"][0]["token_ids"] == []
+    assert choice_payloads[-1]["choices"][0]["finish_reason"] == "length"
+    assert all(payload["usage"]["completion_tokens"] == 0 for payload in usage_payloads)
+    assert chunks[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_create_completion_threads_normalized_max_tokens():
+    mock_engine = _build_mock_engine()
+    serving_completion = _build_serving_completion(mock_engine)
+    serving_completion.render_completion_request = AsyncMock(
+        return_value=[_build_engine_input()]
+    )
+    request_output = _build_request_output()
+
+    async def mock_generate(*args, **kwargs):
+        yield request_output
+
+    mock_engine.generate = MagicMock(side_effect=mock_generate)
+
+    request = CompletionRequest(
+        model=MODEL_NAME,
+        prompt="Test prompt",
+        max_tokens=None,
+        stream=False,
+    )
+
+    response = await serving_completion.create_completion(request)
+
+    assert response.choices[0].text == "Hello"
+    assert mock_engine.generate.call_args.args[1].max_tokens > 0
 
 
 def test_json_schema_response_format_missing_schema():

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -255,7 +255,7 @@ class CompletionRequest(OpenAIBaseModel):
         if prompt_logprobs is None and self.echo:
             prompt_logprobs = self.logprobs
 
-        echo_without_generation = self.echo and self.max_tokens == 0
+        echo_without_generation = self.echo and max_tokens == 0
 
         response_format = self.response_format
         if response_format is not None:

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -144,6 +144,7 @@ class OpenAIServingCompletion(OpenAIServing):
         # Schedule the request and get the result generator.
         max_model_len = self.model_config.max_model_len
         generators: list[AsyncGenerator[RequestOutput, None]] = []
+        max_tokens_per_prompt: list[int] = []
         for i, engine_input in enumerate(engine_inputs):
             max_tokens = get_max_tokens(
                 max_model_len,
@@ -152,6 +153,7 @@ class OpenAIServingCompletion(OpenAIServing):
                 self.default_sampling_params,
                 self.override_max_tokens,
             )
+            max_tokens_per_prompt.append(max_tokens)
 
             sampling_params: SamplingParams | BeamSearchParams
             if request.use_beam_search:
@@ -217,6 +219,7 @@ class OpenAIServingCompletion(OpenAIServing):
                 created_time,
                 model_name,
                 num_prompts=num_prompts,
+                max_tokens_per_prompt=max_tokens_per_prompt,
                 tokenizer=tokenizer,
                 request_metadata=request_metadata,
             )
@@ -244,6 +247,7 @@ class OpenAIServingCompletion(OpenAIServing):
                 request_id,
                 created_time,
                 model_name,
+                max_tokens_per_prompt,
                 tokenizer,
                 request_metadata,
             )
@@ -272,9 +276,11 @@ class OpenAIServingCompletion(OpenAIServing):
         created_time: int,
         model_name: str,
         num_prompts: int,
+        max_tokens_per_prompt: list[int],
         tokenizer: TokenizerLike | None,
         request_metadata: RequestResponseMetadata,
     ) -> AsyncGenerator[str, None]:
+        assert len(max_tokens_per_prompt) == num_prompts
         num_choices = 1 if request.n is None else request.n
         previous_text_lens = [0] * num_choices * num_prompts
         previous_num_tokens = [0] * num_choices * num_prompts
@@ -311,40 +317,65 @@ class OpenAIServingCompletion(OpenAIServing):
 
                 for output in res.outputs:
                     i = output.index + prompt_idx * num_choices
+                    prompt_max_tokens = max_tokens_per_prompt[prompt_idx]
+                    echo_without_generation = request.echo and prompt_max_tokens == 0
+                    visible_token_ids = as_list(output.token_ids)
+                    num_visible_tokens = len(visible_token_ids)
+                    visible_text_len = len(output.text)
 
                     # Useful when request.return_token_ids is True
                     # Returning prompt token IDs shares the same logic
                     # with the echo implementation.
                     prompt_token_ids_to_return: list[int] | None = None
 
-                    assert request.max_tokens is not None
-                    if request.echo and not has_echoed[i]:
+                    if echo_without_generation:
                         assert prompt_token_ids is not None
                         if request.return_token_ids:
                             prompt_text = ""
                         assert prompt_text is not None
-                        if request.max_tokens == 0:
+                        if not has_echoed[i]:
                             # only return the prompt
                             delta_text = prompt_text
                             delta_token_ids = prompt_token_ids
                             out_logprobs = prompt_logprobs
                         else:
-                            # echo the prompt and first token
-                            delta_text = prompt_text + output.text
-                            delta_token_ids = [
-                                *prompt_token_ids,
-                                *output.token_ids,
-                            ]
-                            out_logprobs = [
-                                *(prompt_logprobs or []),
-                                *(output.logprobs or []),
-                            ]
-                        prompt_token_ids_to_return = prompt_token_ids
+                            # The engine may emit a helper token internally,
+                            # but it must not become visible to clients.
+                            delta_text = ""
+                            delta_token_ids = []
+                            out_logprobs = [] if request.logprobs is not None else None
+                        visible_token_ids = []
+                        num_visible_tokens = 0
+                        visible_text_len = 0
+                        prompt_token_ids_to_return = (
+                            prompt_token_ids
+                            if request.return_token_ids and not has_echoed[i]
+                            else None
+                        )
+                        has_echoed[i] = True
+                    elif request.echo and not has_echoed[i]:
+                        assert prompt_token_ids is not None
+                        if request.return_token_ids:
+                            prompt_text = ""
+                        assert prompt_text is not None
+                        # echo the prompt and first token
+                        delta_text = prompt_text + output.text
+                        delta_token_ids = [
+                            *prompt_token_ids,
+                            *visible_token_ids,
+                        ]
+                        out_logprobs = [
+                            *(prompt_logprobs or []),
+                            *(output.logprobs or []),
+                        ]
+                        prompt_token_ids_to_return = (
+                            prompt_token_ids if request.return_token_ids else None
+                        )
                         has_echoed[i] = True
                     else:
                         # return just the delta
                         delta_text = output.text
-                        delta_token_ids = output.token_ids
+                        delta_token_ids = visible_token_ids
                         out_logprobs = output.logprobs
 
                         # has_echoed[i] is reused here to indicate whether
@@ -353,15 +384,21 @@ class OpenAIServingCompletion(OpenAIServing):
                             prompt_token_ids_to_return = prompt_token_ids
                             has_echoed[i] = True
 
-                        if (
-                            not delta_text
-                            and not delta_token_ids
-                            and not previous_num_tokens[i]
-                        ):
-                            # Chunked prefill case, don't return empty chunks
-                            continue
+                    finish_reason = output.finish_reason
+                    stop_reason = output.stop_reason
 
-                    if request.logprobs is not None:
+                    if (
+                        not delta_text
+                        and not delta_token_ids
+                        and prompt_token_ids_to_return is None
+                        and finish_reason is None
+                        and stop_reason is None
+                    ):
+                        # Chunked prefill / suppressed helper-token case,
+                        # don't return empty intermediate chunks.
+                        continue
+
+                    if request.logprobs is not None and len(delta_token_ids) > 0:
                         assert out_logprobs is not None, "Did not output logprobs"
                         logprobs = self._create_completion_logprobs(
                             token_ids=delta_token_ids,
@@ -372,12 +409,12 @@ class OpenAIServingCompletion(OpenAIServing):
                             return_as_token_id=request.return_tokens_as_token_ids,
                         )
                     else:
+                        # Prompt-token-id-only chunks do not have completion
+                        # token logprobs to surface.
                         logprobs = None
 
-                    previous_text_lens[i] += len(output.text)
-                    previous_num_tokens[i] += len(output.token_ids)
-                    finish_reason = output.finish_reason
-                    stop_reason = output.stop_reason
+                    previous_text_lens[i] += visible_text_len
+                    previous_num_tokens[i] += num_visible_tokens
 
                     self._raise_if_error(finish_reason, request_id)
 
@@ -394,7 +431,7 @@ class OpenAIServingCompletion(OpenAIServing):
                                 stop_reason=stop_reason,
                                 prompt_token_ids=prompt_token_ids_to_return,
                                 token_ids=(
-                                    as_list(output.token_ids)
+                                    visible_token_ids
                                     if request.return_token_ids
                                     else None
                                 ),
@@ -457,15 +494,17 @@ class OpenAIServingCompletion(OpenAIServing):
         request_id: str,
         created_time: int,
         model_name: str,
+        max_tokens_per_prompt: list[int],
         tokenizer: TokenizerLike | None,
         request_metadata: RequestResponseMetadata,
     ) -> CompletionResponse:
+        assert len(max_tokens_per_prompt) == len(final_res_batch)
         choices: list[CompletionResponseChoice] = []
         num_prompt_tokens = 0
         num_generated_tokens = 0
         kv_transfer_params = None
         last_final_res = None
-        for final_res in final_res_batch:
+        for prompt_idx, final_res in enumerate(final_res_batch):
             last_final_res = final_res
             prompt_token_ids = final_res.prompt_token_ids
             assert prompt_token_ids is not None
@@ -477,21 +516,27 @@ class OpenAIServingCompletion(OpenAIServing):
 
             for output in final_res.outputs:
                 self._raise_if_error(output.finish_reason, request_id)
+                visible_token_ids = as_list(output.token_ids)
+                num_visible_tokens = len(visible_token_ids)
 
-                assert request.max_tokens is not None
                 if request.echo:
                     if request.return_token_ids:
                         prompt_text = ""
                     assert prompt_text is not None
-                    if request.max_tokens == 0:
+                    if max_tokens_per_prompt[prompt_idx] == 0:
                         token_ids = prompt_token_ids
                         out_logprobs = prompt_logprobs
                         output_text = prompt_text
+                        visible_token_ids = []
+                        num_visible_tokens = 0
                     else:
-                        token_ids = [*prompt_token_ids, *output.token_ids]
+                        token_ids = [*prompt_token_ids, *visible_token_ids]
 
                         if request.logprobs is None:
                             out_logprobs = None
+                        elif num_visible_tokens == 0:
+                            assert prompt_logprobs is not None
+                            out_logprobs = prompt_logprobs
                         else:
                             assert prompt_logprobs is not None
                             assert output.logprobs is not None
@@ -502,11 +547,11 @@ class OpenAIServingCompletion(OpenAIServing):
 
                         output_text = prompt_text + output.text
                 else:
-                    token_ids = output.token_ids
+                    token_ids = visible_token_ids
                     out_logprobs = output.logprobs
                     output_text = output.text
 
-                if request.logprobs is not None:
+                if request.logprobs is not None and len(token_ids) > 0:
                     assert out_logprobs is not None, "Did not output logprobs"
                     logprobs = self._create_completion_logprobs(
                         token_ids=token_ids,
@@ -516,6 +561,8 @@ class OpenAIServingCompletion(OpenAIServing):
                         return_as_token_id=request.return_tokens_as_token_ids,
                     )
                 else:
+                    # Empty visible completions do not have completion token
+                    # logprobs to surface.
                     logprobs = None
 
                 choice_data = CompletionResponseChoice(
@@ -528,13 +575,11 @@ class OpenAIServingCompletion(OpenAIServing):
                     prompt_token_ids=(
                         prompt_token_ids if request.return_token_ids else None
                     ),
-                    token_ids=(
-                        as_list(output.token_ids) if request.return_token_ids else None
-                    ),
+                    token_ids=(visible_token_ids if request.return_token_ids else None),
                 )
                 choices.append(choice_data)
 
-                num_generated_tokens += len(output.token_ids)
+                num_generated_tokens += num_visible_tokens
 
             num_prompt_tokens += len(prompt_token_ids)
 


### PR DESCRIPTION
## Purpose
Addressed a bug in the completions path where response construction used the request-level `max_tokens` value instead of the per-prompt normalized `max_tokens` already computed by `create_completion()`.

This bug caused requests such as `max_tokens=None` to fail during response construction even though sampling had already been configured with a valid per-prompt limit. 

The same response path also handled  `echo=True` request incorrectly when the computed per-prompt `max_tokens` was `0`.  In this case, `CompletionRequest.to_sampling_params()` passed `SamplingParams.max_tokens = 1` to the engine, which caused an internally generated token to leak into the user-visible output, appear in returned `token_ids` or be counted in the `completion_tokens`. 

Related edge cases in the same path could also still mishandle empty first streaming chunks, emit `prompt_token_ids` when `return_token_ids` was unset, or try to construct completion logprobs when there were no visible completion tokens.

## Test Plan
Ran the following 2 tests:

### 1. `test_completion_error.py`

`pytest tests/entrypoints/openai/completion/test_completion_error.py -q` 

with regression tests to verify normalized `max_token` handling in the completions serving path, including the related edge cases. 

### 2.` test_completion.py`

`pytest tests/entrypoints/openai/completion/test_completion.py -k 'without_max_tokens or zero_budget_echo' -q`

with E2E tests to verify `max_tokens` = `None`  handling and `echo=True` handling when the computed per-prompt `max_tokens` is `0`, in both non-streaming and streaming modes.

## Test Result

`test_completion_error.py`: 18 passed, 2 warnings

`test_completion.py:` 4 passed, 19 deselected, 16 warnings