### PR TITLE
[Model] Add GGUF support for Qwen 3.5 dense and MoE models

### DIFF
--- a/tests/models/multimodal/generation/test_multimodal_gguf.py
+++ b/tests/models/multimodal/generation/test_multimodal_gguf.py
@@ -18,6 +18,7 @@ from vllm.multimodal.image import rescale_image_size
 from vllm.utils.torch_utils import set_default_torch_num_threads
 
 from ....conftest import IMAGE_ASSETS, HfRunner, VllmRunner
+from ....utils import large_gpu_mark
 from ...utils import check_logprobs_close
 
 
@@ -83,7 +84,50 @@ GEMMA3_CONFIG_PAN_AND_SCAN = GGUFMMTestConfig(
     mm_processor_kwargs={"do_pan_and_scan": True},
 )
 
-MODELS_TO_TEST = [GEMMA3_CONFIG, GEMMA3_CONFIG_PAN_AND_SCAN]
+# Qwen3.5 multimodal GGUF — natively multimodal (shared arch for text + vision)
+_QWEN35_PROMPTS = IMAGE_ASSETS.prompts(
+    {
+        "stop_sign": (
+            "<|im_start|>user\n"
+            "<|vision_start|><|image_pad|><|vision_end|>"
+            "What's the content in the center of the image?"
+            "<|im_end|>\n<|im_start|>assistant\n"
+        ),
+        "cherry_blossom": (
+            "<|im_start|>user\n"
+            "<|vision_start|><|image_pad|><|vision_end|>"
+            "What is the season?"
+            "<|im_end|>\n<|im_start|>assistant\n"
+        ),
+    }
+)
+
+_QWEN35_IMAGE_NAMES = ["stop_sign", "cherry_blossom"]
+
+QWEN35_CONFIG = GGUFMMTestConfig(
+    original_model="Qwen/Qwen3.5-0.8B",
+    gguf_repo="unsloth/Qwen3.5-0.8B-GGUF",
+    gguf_backbone="Qwen3.5-0.8B-Q4_K_M.gguf",
+    gguf_mmproj="mmproj-BF16.gguf",
+    prompt=_QWEN35_PROMPTS,
+    image_names=_QWEN35_IMAGE_NAMES,
+    max_model_len=4096,
+)
+
+# Qwen3.5-MoE multimodal GGUF (large weights + HF baseline; skip on small GPUs)
+QWEN35_MOE_CONFIG = GGUFMMTestConfig(
+    original_model="Qwen/Qwen3.5-35B-A3B",
+    gguf_repo="unsloth/Qwen3.5-35B-A3B-GGUF",
+    gguf_backbone="Qwen3.5-35B-A3B-Q4_K_M.gguf",
+    gguf_mmproj="mmproj-BF16.gguf",
+    prompt=_QWEN35_PROMPTS,
+    image_names=_QWEN35_IMAGE_NAMES,
+    max_model_len=4096,
+    marks=[large_gpu_mark(min_gb=24)],
+)
+
+GEMMA3_MODELS_TO_TEST = [GEMMA3_CONFIG, GEMMA3_CONFIG_PAN_AND_SCAN]
+QWEN35_MODELS_TO_TEST = [QWEN35_CONFIG, QWEN35_MOE_CONFIG]
 
 
 def run_multimodal_gguf_test(
@@ -161,13 +205,40 @@ def run_multimodal_gguf_test(
     "model",
     [
         pytest.param(test_config, marks=test_config.marks)
-        for test_config in MODELS_TO_TEST
+        for test_config in GEMMA3_MODELS_TO_TEST
     ],
 )
 @pytest.mark.parametrize("dtype", ["bfloat16"])
 @pytest.mark.parametrize("max_tokens", [32])
 @pytest.mark.parametrize("num_logprobs", [10])
 def test_gemma3_mm_gguf(
+    hf_runner: type[HfRunner],
+    vllm_runner: type[VllmRunner],
+    model: GGUFMMTestConfig,
+    dtype: str,
+    max_tokens: int,
+    num_logprobs: int,
+) -> None:
+    run_multimodal_gguf_test(
+        hf_runner, vllm_runner, model, dtype, max_tokens, num_logprobs
+    )
+
+
+@pytest.mark.skipif(
+    not is_quant_method_supported("gguf"),
+    reason="gguf is not supported on this GPU type.",
+)
+@pytest.mark.parametrize(
+    "model",
+    [
+        pytest.param(test_config, marks=test_config.marks)
+        for test_config in QWEN35_MODELS_TO_TEST
+    ],
+)
+@pytest.mark.parametrize("dtype", ["bfloat16"])
+@pytest.mark.parametrize("max_tokens", [32])
+@pytest.mark.parametrize("num_logprobs", [10])
+def test_qwen35_mm_gguf(
     hf_runner: type[HfRunner],
     vllm_runner: type[VllmRunner],
     model: GGUFMMTestConfig,

--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -696,13 +696,13 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         # initialize GGUF param after we know the quantize type
         is_gguf_weight = getattr(param, "is_gguf_weight", False)
         is_gguf_weight_type = getattr(param, "is_gguf_weight_type", False)
-        if isinstance(loaded_shard_id, tuple) and (
-            is_gguf_weight or is_gguf_weight_type
-        ):
-            raise NotImplementedError(
-                "Shard id with multiple indices is not supported for GGUF."
-            )
         if is_gguf_weight_type:
+            if isinstance(loaded_shard_id, tuple):
+                # Fused weight type covers multiple shards
+                for idx in loaded_shard_id:
+                    param.data[idx].copy_(loaded_weight)
+                    param.shard_weight_type[idx] = loaded_weight.item()
+                return
             if loaded_shard_id is not None:
                 param.data[loaded_shard_id].copy_(loaded_weight)
                 param.shard_weight_type[loaded_shard_id] = loaded_weight.item()
@@ -714,6 +714,26 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
 
         if is_gguf_weight:
             output_dim = getattr(param, "output_dim", None)
+            if isinstance(loaded_shard_id, tuple):
+                # Fused weight covers multiple shards - split and load each
+                output_sizes = self.output_sizes[
+                    loaded_shard_id[0] : loaded_shard_id[-1] + 1
+                ]
+                current_offset = 0
+                for i, idx in enumerate(loaded_shard_id):
+                    shard_weight = loaded_weight.narrow(
+                        output_dim, current_offset, output_sizes[i]
+                    )
+                    shard_size = shard_weight.size(output_dim) // self.tp_size
+                    start_idx = self.tp_rank * shard_size
+                    narrowed = shard_weight.narrow(
+                        output_dim, start_idx, shard_size
+                    )
+                    param.shard_id.append(idx)
+                    param.shard_id_map[idx] = len(param.data_container)
+                    param.data_container.append(narrowed)
+                    current_offset += output_sizes[i]
+                return
             shard_size = loaded_weight.size(output_dim) // self.tp_size
             start_idx = self.tp_rank * shard_size
 

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -171,6 +171,90 @@ class GGUFModelLoader(BaseModelLoader):
                         r"\.mlp\.experts\.[0-9]+\.(gate|up|down)_proj\.weight"
                     )
                 )
+        if model_type in ("qwen3_5", "qwen3_5_text"):
+            model_type = "qwen35"
+            # dt_bias may not exist in GGUF (can be folded into dt_proj)
+            sideload_params.append(
+                re.compile(
+                    r"model\.(language_model\.)?layers\.\d+"
+                    r"\.linear_attn\.dt_bias"
+                )
+            )
+            if is_multimodal:
+                # Manual GGUF→HF mappings for Qwen3.5 merger (mmproj)
+                # gguf-py MMPROJ map doesn't have linear_fc1/fc2 patterns
+                gguf_to_hf_name_map["mm.0.weight"] = (
+                    "model.visual.merger.linear_fc1.weight"
+                )
+                gguf_to_hf_name_map["mm.0.bias"] = (
+                    "model.visual.merger.linear_fc1.bias"
+                )
+                gguf_to_hf_name_map["mm.2.weight"] = (
+                    "model.visual.merger.linear_fc2.weight"
+                )
+                gguf_to_hf_name_map["mm.2.bias"] = (
+                    "model.visual.merger.linear_fc2.bias"
+                )
+                gguf_to_hf_name_map["mm.input_norm.weight"] = (
+                    "model.visual.merger.norm.weight"
+                )
+                gguf_to_hf_name_map["mm.input_norm.bias"] = (
+                    "model.visual.merger.norm.bias"
+                )
+        if model_type in ("qwen3_5_moe", "qwen3_5_moe_text"):
+            model_type = "qwen35moe"
+            # dt_bias may not exist in GGUF (can be folded into dt_proj)
+            sideload_params.append(
+                re.compile(
+                    r"model\.(language_model\.)?layers\.\d+"
+                    r"\.linear_attn\.dt_bias"
+                )
+            )
+            if is_multimodal:
+                # Same merger mappings for MoE variant
+                gguf_to_hf_name_map["mm.0.weight"] = (
+                    "model.visual.merger.linear_fc1.weight"
+                )
+                gguf_to_hf_name_map["mm.0.bias"] = (
+                    "model.visual.merger.linear_fc1.bias"
+                )
+                gguf_to_hf_name_map["mm.2.weight"] = (
+                    "model.visual.merger.linear_fc2.weight"
+                )
+                gguf_to_hf_name_map["mm.2.bias"] = (
+                    "model.visual.merger.linear_fc2.bias"
+                )
+                gguf_to_hf_name_map["mm.input_norm.weight"] = (
+                    "model.visual.merger.norm.weight"
+                )
+                gguf_to_hf_name_map["mm.input_norm.bias"] = (
+                    "model.visual.merger.norm.bias"
+                )
+            # GGUF layer map assumes merged expert weights
+            num_layers = text_config.num_hidden_layers
+            # Multimodal uses model.language_model.layers prefix
+            layer_prefix = (
+                "model.language_model.layers"
+                if is_multimodal
+                else "model.layers"
+            )
+            layer_prefix_re = layer_prefix.replace(".", "\\.")
+            for idx in range(num_layers):
+                gguf_to_hf_name_map[f"blk.{idx}.ffn_down_exps.weight"] = (
+                    f"{layer_prefix}.{idx}.mlp.experts.0.down_proj.weight"
+                )
+                gguf_to_hf_name_map[f"blk.{idx}.ffn_gate_exps.weight"] = (
+                    f"{layer_prefix}.{idx}.mlp.experts.0.gate_proj.weight"
+                )
+                gguf_to_hf_name_map[f"blk.{idx}.ffn_up_exps.weight"] = (
+                    f"{layer_prefix}.{idx}.mlp.experts.0.up_proj.weight"
+                )
+                sideload_params.append(
+                    re.compile(
+                        f"{layer_prefix_re}\\.{idx}"
+                        r"\.mlp\.experts\.[0-9]+\.(gate|up|down)_proj\.weight"
+                    )
+                )
         if model_type == "minimax_m2":
             model_type = "minimax-m2"
             # GGUF layer map assumes merged expert weights
@@ -207,7 +291,12 @@ class GGUFModelLoader(BaseModelLoader):
 
         if is_multimodal:
             mm_proj_arch = gguf.MODEL_ARCH.MMPROJ
-            vision_num_layers = config.vision_config.num_hidden_layers
+            # Some vision configs use 'depth' instead of 'num_hidden_layers'
+            # (e.g. Qwen3_5VisionConfig)
+            vision_num_layers = getattr(
+                config.vision_config, "num_hidden_layers",
+                getattr(config.vision_config, "depth", 0),
+            )
             vision_name_map = gguf.get_tensor_name_map(mm_proj_arch, vision_num_layers)
         else:
             vision_name_map = None
@@ -271,6 +360,10 @@ class GGUFModelLoader(BaseModelLoader):
             # gguf-py expects it.
             if hf_name.startswith("language_model."):
                 hf_name = hf_name[15:]  # Remove 'language_model.'
+            elif hf_name.startswith("model.language_model."):
+                # Qwen3.5-style: model.language_model.X → model.X
+                # gguf-py text tensor map expects model.layers.* format
+                hf_name = "model." + hf_name[21:]
 
             # Parse parameter name and suffix
             if hf_name.endswith((".weight", ".bias")):
@@ -287,6 +380,10 @@ class GGUFModelLoader(BaseModelLoader):
             # Priority 1: Search vision/projector parameters for multimodal models
             if vision_name_map is not None:
                 gguf_name = vision_name_map.get_name(base_name)
+                # Try without 'model.' prefix for vision params
+                # (Qwen3.5 HF uses model.visual.* but gguf-py expects visual.*)
+                if gguf_name is None and base_name.startswith("model."):
+                    gguf_name = vision_name_map.get_name(base_name[6:])
 
             # Priority 2: Search text backbone parameters
             if gguf_name is None:
@@ -358,41 +455,156 @@ class GGUFModelLoader(BaseModelLoader):
     ) -> Generator[tuple[str, torch.Tensor], None, None]:
         """
         Iterate over GGUF model weights, loading from both main model file and
-        mmproj.gguf for multimodal Gemma3 models.
+        mmproj.gguf for multimodal models.
 
-        For Gemma3 multimodal GGUF models:
-        - Main file (gemma-3-*.gguf): Language model weights (model.*)
+        For multimodal GGUF models:
+        - Main file (*.gguf): Language model weights (blk.*)
         - mmproj file (mmproj*.gguf): Vision tower + projector weights (v.*, mm.*)
 
         Yields:
             Tuples of (parameter_name, tensor) for all model weights
         """
         hf_config = model_config.hf_config
-        is_multimodal = hasattr(hf_config, "vision_config")
-
+        is_multimodal = (
+            hasattr(hf_config, "vision_config")
+            and hf_config.vision_config is not None
+        )
+        mmproj_file = (
+            detect_gguf_multimodal(model_name_or_path)
+            if is_multimodal
+            else None
+        )
         if is_multimodal:
-            # Load mm_proj (mm_encoder + projector) for multimodal weights
-            mmproj_file = detect_gguf_multimodal(model_name_or_path)
             assert mmproj_file is not None, (
-                "Could not find mm_proj file for multimodal GGUF model"
+                "Could not find mm_proj file for multimodal GGUF model. "
+                "Please ensure mmproj.gguf is in the same directory or "
+                "available in the HF repo."
             )
-            yield from gguf_quant_weights_iterator(mmproj_file, gguf_to_hf_name_map)
+            # Qwen3.5 uses 3D conv (temporal_patch_size>1) for patch_embed
+            # but GGUF mmproj stores it as 4D (2D conv). Expand to 5D.
+            temporal_patch_size = getattr(
+                hf_config.vision_config, "temporal_patch_size", 1
+            )
+            needs_patch_embed_expansion = temporal_patch_size > 1
+            if needs_patch_embed_expansion:
+                for name, weight in gguf_quant_weights_iterator(
+                    mmproj_file, gguf_to_hf_name_map
+                ):
+                    if (
+                        "patch_embed.proj.weight" in name
+                        and weight.dim() == 4
+                    ):
+                        weight = (
+                            weight.unsqueeze(2)
+                            .repeat(1, 1, temporal_patch_size, 1, 1)
+                            / temporal_patch_size
+                        )
+                    yield name, weight
+            else:
+                yield from gguf_quant_weights_iterator(
+                    mmproj_file, gguf_to_hf_name_map
+                )
 
         gguf_files = self._get_all_gguf_files(model_name_or_path)
         if len(gguf_files) > 1:
-            yield from gguf_quant_weights_iterator_multi(
+            main_iter = gguf_quant_weights_iterator_multi(
                 gguf_files, gguf_to_hf_name_map
             )
         else:
-            yield from gguf_quant_weights_iterator(
+            main_iter = gguf_quant_weights_iterator(
                 model_name_or_path, gguf_to_hf_name_map
             )
+
+        # Qwen3.5-specific GGUF weight transformations
+        model_type = hf_config.model_type
+        is_qwen35 = model_type in ("qwen3_5", "qwen3_5_moe")
+        if is_qwen35:
+            # Modules forced unquantized: GGUF may have them quantized
+            # but model uses plain params. Skip their qweight/qweight_type.
+            skip_quant_prefixes = ("lm_head.", "embed_tokens.")
+            for name, weight in main_iter:
+                # Skip GGUF quant params for forced-unquantized modules
+                if any(p in name for p in skip_quant_prefixes) and (
+                    "qweight" in name
+                ):
+                    continue
+                # GDN: GGUF stores conv1d as 2D [d, k] but model
+                # expects 3D [d, 1, k] (depthwise Conv1d).
+                if "conv1d.weight" in name and weight.dim() == 2:
+                    weight = weight.unsqueeze(1)
+                # GGUF flattens small linear layers (e.g. shared expert
+                # gate [1, hidden] → [hidden]). Restore the output dim.
+                if (
+                    name.endswith(".weight")
+                    and weight.dim() == 1
+                    and "norm" not in name
+                ):
+                    weight = weight.unsqueeze(0)
+                yield name, weight
+        else:
+            yield from main_iter
+
+    def _ensure_mmproj(
+        self, model_config: ModelConfig, local_model_path: str
+    ) -> None:
+        """Download mmproj file for multimodal GGUF models if not present.
+
+        When using HF repos, the mmproj file may need to be downloaded
+        separately so it ends up in the same cache directory as the main
+        GGUF file.
+        """
+        hf_config = model_config.hf_config
+        is_multimodal = (
+            hasattr(hf_config, "vision_config")
+            and hf_config.vision_config is not None
+        )
+        if not is_multimodal:
+            return
+
+        # Already available locally
+        if detect_gguf_multimodal(local_model_path) is not None:
+            return
+
+        # Try to download from the same HF repo
+        model_name = model_config.model
+        repo_id = None
+        if "/" in model_name and model_name.endswith(".gguf"):
+            repo_id = model_name.rsplit("/", 1)[0]
+        elif "/" in model_name and ":" in model_name:
+            repo_id = model_name.rsplit(":", 1)[0]
+
+        if repo_id is None:
+            return
+
+        try:
+            from vllm.transformers_utils.repo_utils import list_filtered_repo_files
+
+            repo_files = list_filtered_repo_files(
+                repo_id,
+                allow_patterns=["*mmproj*.gguf"],
+                revision=model_config.revision,
+            )
+            for mmproj_file in repo_files:
+                logger.info(
+                    "Auto-downloading mmproj file: %s from %s",
+                    mmproj_file,
+                    repo_id,
+                )
+                hf_hub_download(
+                    repo_id=repo_id,
+                    filename=mmproj_file,
+                    revision=model_config.revision,
+                )
+                return
+        except Exception as e:
+            logger.warning("Failed to auto-download mmproj: %s", e)
 
     def download_model(self, model_config: ModelConfig) -> None:
         self._prepare_weights(model_config)
 
     def load_weights(self, model: nn.Module, model_config: ModelConfig) -> None:
         local_model_path = self._prepare_weights(model_config)
+        self._ensure_mmproj(model_config, local_model_path)
         gguf_weights_map = self._get_gguf_weights_map(model_config)
         model.load_weights(
             self._get_weights_iterator(model_config, local_model_path, gguf_weights_map)
@@ -403,6 +615,7 @@ class GGUFModelLoader(BaseModelLoader):
     ) -> nn.Module:
         device_config = vllm_config.device_config
         local_model_path = self._prepare_weights(model_config)
+        self._ensure_mmproj(model_config, local_model_path)
         gguf_weights_map = self._get_gguf_weights_map(model_config)
         # we can only know if tie word embeddings after mapping weights
         gguf_files = self._get_all_gguf_files(local_model_path)
@@ -421,6 +634,14 @@ class GGUFModelLoader(BaseModelLoader):
             for name, weight_type in weight_type_map.items()
             if weight_type in ("F32", "F16", "BF16") and name.endswith(".weight")
         ]
+        # Qwen3.5 multimodal: lm_head and embed_tokens use
+        # ParallelLMHead/VocabParallelEmbedding which don't support
+        # GGUF quantized params when routed through AutoWeightsLoader.
+        model_type = model_config.hf_config.model_type
+        if model_type in ("qwen3_5", "qwen3_5_moe"):
+            for name in ("lm_head", "embed_tokens"):
+                if name not in unquant_names:
+                    unquant_names.append(name)
         logger.debug("GGUF unquantized modules: %s", unquant_names)
         if TYPE_CHECKING:
             vllm_config.quant_config = cast(GGUFConfig, vllm_config.quant_config)

--- a/vllm/transformers_utils/gguf_utils.py
+++ b/vllm/transformers_utils/gguf_utils.py
@@ -13,6 +13,8 @@ from gguf.quants import GGMLQuantizationType
 from transformers import Gemma3Config, PretrainedConfig, SiglipVisionConfig
 
 from vllm.logger import init_logger
+from vllm.transformers_utils.configs.qwen3_5 import Qwen3_5Config
+from vllm.transformers_utils.configs.qwen3_5_moe import Qwen3_5MoeConfig
 
 from .repo_utils import list_filtered_repo_files
 
@@ -291,6 +293,29 @@ def maybe_patch_hf_config_from_gguf(
                 architectures=["Gemma3ForConditionalGeneration"],
             )
             hf_config = new_hf_config
+
+        # Qwen3.5: upgrade text-only config to multimodal when mmproj found
+        if hf_config.model_type in ("qwen3_5", "qwen3_5_text"):
+            hf_config = Qwen3_5Config(
+                text_config=hf_config.to_dict(),
+                architectures=["Qwen3_5ForConditionalGeneration"],
+            )
+        elif hf_config.model_type in ("qwen3_5_moe", "qwen3_5_moe_text"):
+            hf_config = Qwen3_5MoeConfig(
+                text_config=hf_config.to_dict(),
+                architectures=["Qwen3_5MoeForConditionalGeneration"],
+            )
+
+    # Qwen3.5 is multimodal — ensure ConditionalGeneration architecture
+    _QWEN35_CONDITIONAL_ARCH = {
+        "qwen3_5": "Qwen3_5ForConditionalGeneration",
+        "qwen3_5_moe": "Qwen3_5MoeForConditionalGeneration",
+    }
+    conditional_arch = _QWEN35_CONDITIONAL_ARCH.get(hf_config.model_type)
+    if conditional_arch is not None:
+        archs = getattr(hf_config, "architectures", []) or []
+        if not any("ConditionalGeneration" in a for a in archs):
+            hf_config.architectures = [conditional_arch]
 
     return hf_config
 


### PR DESCRIPTION
## Purpose
Add GGUF support for Qwen 3.5 dense and MoE models

Fixes: #39198, #36456, #38122

## Test Plan
```bash
# Qwen 3.5 Dense
vllm serve unsloth/Qwen3.5-0.8B-GGUF:UD-IQ2_XXS --tokenizer Qwen/Qwen3.5-0.8B --hf-config-path Qwen/Qwen3.5-0.8B
```
```bash
# Qwen 3.5 MoE
vllm serve unsloth/Qwen3.5-35B-A3B-GGUF:UD-IQ2_XXS --tokenizer Qwen/Qwen3.5-35B-A3B-GGUF
```

## Test Result

### Qwen3.5 Dense

<details>
<summary>before</summary>

```bash
vllm serve unsloth/Qwen3.5-0.8B-GGUF:UD-IQ2_XXS --tokenizer Qwen/Qwen3.5-0.8B --hf-config-path Qwen/Qwen3.5-0.8B
(APIServer pid=2639330) INFO 04-11 18:49:05 [utils.py:299]
(APIServer pid=2639330) INFO 04-11 18:49:05 [utils.py:299]        █     █     █▄   ▄█
(APIServer pid=2639330) INFO 04-11 18:49:05 [utils.py:299]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.19.1rc1.dev122+g83aea2147
(APIServer pid=2639330) INFO 04-11 18:49:05 [utils.py:299]   █▄█▀ █     █     █     █  model   unsloth/Qwen3.5-0.8B-GGUF:UD-IQ2_XXS
(APIServer pid=2639330) INFO 04-11 18:49:05 [utils.py:299]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀
(APIServer pid=2639330) INFO 04-11 18:49:05 [utils.py:299]
(APIServer pid=2639330) INFO 04-11 18:49:05 [utils.py:233] non-default args: {'model_tag': 'unsloth/Qwen3.5-0.8B-GGUF:UD-IQ2_XXS', 'model': 'unsloth/Qwen3.5-0.8B-GGUF:UD-IQ2_XXS', 'tokenizer': 'Qwen/Qwen3.5-0.8B', 'hf_config_path': 'Qwen/Qwen3.5-0.8B'}
(APIServer pid=2639330) WARNING 04-11 18:49:05 [gguf_utils.py:60] Non-standard GGUF quant type 'UD-IQ2_XXS' detected.
(APIServer pid=2639330) INFO 04-11 18:49:07 [model.py:554] Resolved architecture: Qwen3_5ForConditionalGeneration
(APIServer pid=2639330) INFO 04-11 18:49:07 [model.py:1684] Using max model len 262144
(APIServer pid=2639330) INFO 04-11 18:49:07 [vllm.py:799] Asynchronous scheduling is enabled.
(APIServer pid=2639330) INFO 04-11 18:49:07 [kernel.py:199] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'])
(EngineCore pid=2639990) INFO 04-11 18:49:23 [core.py:107] Initializing a V1 LLM engine (v0.19.1rc1.dev122+g83aea2147) with config: model='unsloth/Qwen3.5-0.8B-GGUF:UD-IQ2_XXS', speculative_config=None, tokenizer='Qwen/Qwen3.5-0.8B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=262144, download_dir=None, load_format=gguf, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=gguf, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=unsloth/Qwen3.5-0.8B-GGUF:UD-IQ2_XXS, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_images_per_batch': 0, 'compile_sizes': [], 'compile_ranges_endpoints': [2048], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'size_asserts': False, 'alignment_asserts': False, 'scalar_asserts': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native']), enable_flashinfer_autotune=True, moe_backend='auto')
(EngineCore pid=2639990) INFO 04-11 18:49:25 [parallel_state.py:1400] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.16.1.10:59959 backend=nccl
(EngineCore pid=2639990) INFO 04-11 18:49:25 [parallel_state.py:1713] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
(EngineCore pid=2639990) WARNING 04-11 18:49:25 [gguf_utils.py:60] Non-standard GGUF quant type 'UD-IQ2_XXS' detected.
(EngineCore pid=2639990) INFO 04-11 18:49:34 [gpu_model_runner.py:4735] Starting to load model unsloth/Qwen3.5-0.8B-GGUF:UD-IQ2_XXS...
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112] EngineCore failed to start.
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112] Traceback (most recent call last):
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]   File "/home/name/.test/.gpu/vllm/vllm/v1/engine/core.py", line 1086, in run_engine_core
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]   File "/home/name/.test/.gpu/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]     return func(*args, **kwargs)
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]   File "/home/name/.test/.gpu/vllm/vllm/v1/engine/core.py", line 850, in __init__
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]     super().__init__(
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]   File "/home/name/.test/.gpu/vllm/vllm/v1/engine/core.py", line 116, in __init__
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]     self.model_executor = executor_class(vllm_config)
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]   File "/home/name/.test/.gpu/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]     return func(*args, **kwargs)
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]   File "/home/name/.test/.gpu/vllm/vllm/v1/executor/abstract.py", line 109, in __init__
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]     self._init_executor()
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]   File "/home/name/.test/.gpu/vllm/vllm/v1/executor/uniproc_executor.py", line 52, in _init_executor
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]     self.driver_worker.load_model()
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]   File "/home/name/.test/.gpu/vllm/vllm/v1/worker/gpu_worker.py", line 323, in load_model
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]     self.model_runner.load_model(load_dummy_weights=load_dummy_weights)
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]   File "/home/name/.test/.gpu/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]     return func(*args, **kwargs)
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]   File "/home/name/.test/.gpu/vllm/vllm/v1/worker/gpu_model_runner.py", line 4751, in load_model
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]     self.model = model_loader.load_model(
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]                  ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]   File "/home/name/.test/.gpu/vllm/vllm/model_executor/model_loader/gguf_loader.py", line 406, in load_model
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]     gguf_weights_map = self._get_gguf_weights_map(model_config)
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]   File "/home/name/.test/.gpu/vllm/vllm/model_executor/model_loader/gguf_loader.py", line 204, in _get_gguf_weights_map
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112]     raise RuntimeError(f"Unknown gguf model_type: {model_type}")
(EngineCore pid=2639990) ERROR 04-11 18:49:35 [core.py:1112] RuntimeError: Unknown gguf model_type: qwen3_5
(EngineCore pid=2639990) Process EngineCore:
(EngineCore pid=2639990) Traceback (most recent call last):
(EngineCore pid=2639990)   File "/home/name/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/multiprocessing/process.py", line 314, in _bootstrap
(EngineCore pid=2639990)     self.run()
(EngineCore pid=2639990)   File "/home/name/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/multiprocessing/process.py", line 108, in run
(EngineCore pid=2639990)     self._target(*self._args, **self._kwargs)
(EngineCore pid=2639990)   File "/home/name/.test/.gpu/vllm/vllm/v1/engine/core.py", line 1116, in run_engine_core
(EngineCore pid=2639990)     raise e
(EngineCore pid=2639990)   File "/home/name/.test/.gpu/vllm/vllm/v1/engine/core.py", line 1086, in run_engine_core
(EngineCore pid=2639990)     engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
(EngineCore pid=2639990)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2639990)   File "/home/name/.test/.gpu/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=2639990)     return func(*args, **kwargs)
(EngineCore pid=2639990)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2639990)   File "/home/name/.test/.gpu/vllm/vllm/v1/engine/core.py", line 850, in __init__
(EngineCore pid=2639990)     super().__init__(
(EngineCore pid=2639990)   File "/home/name/.test/.gpu/vllm/vllm/v1/engine/core.py", line 116, in __init__
(EngineCore pid=2639990)     self.model_executor = executor_class(vllm_config)
(EngineCore pid=2639990)                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2639990)   File "/home/name/.test/.gpu/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=2639990)     return func(*args, **kwargs)
(EngineCore pid=2639990)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2639990)   File "/home/name/.test/.gpu/vllm/vllm/v1/executor/abstract.py", line 109, in __init__
(EngineCore pid=2639990)     self._init_executor()
(EngineCore pid=2639990)   File "/home/name/.test/.gpu/vllm/vllm/v1/executor/uniproc_executor.py", line 52, in _init_executor
(EngineCore pid=2639990)     self.driver_worker.load_model()
(EngineCore pid=2639990)   File "/home/name/.test/.gpu/vllm/vllm/v1/worker/gpu_worker.py", line 323, in load_model
(EngineCore pid=2639990)     self.model_runner.load_model(load_dummy_weights=load_dummy_weights)
(EngineCore pid=2639990)   File "/home/name/.test/.gpu/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(EngineCore pid=2639990)     return func(*args, **kwargs)
(EngineCore pid=2639990)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2639990)   File "/home/name/.test/.gpu/vllm/vllm/v1/worker/gpu_model_runner.py", line 4751, in load_model
(EngineCore pid=2639990)     self.model = model_loader.load_model(
(EngineCore pid=2639990)                  ^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2639990)   File "/home/name/.test/.gpu/vllm/vllm/model_executor/model_loader/gguf_loader.py", line 406, in load_model
(EngineCore pid=2639990)     gguf_weights_map = self._get_gguf_weights_map(model_config)
(EngineCore pid=2639990)                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2639990)   File "/home/name/.test/.gpu/vllm/vllm/model_executor/model_loader/gguf_loader.py", line 204, in _get_gguf_weights_map
(EngineCore pid=2639990)     raise RuntimeError(f"Unknown gguf model_type: {model_type}")
(EngineCore pid=2639990) RuntimeError: Unknown gguf model_type: qwen3_5
[rank0]:[W411 18:49:36.785516042 ProcessGroupNCCL.cpp:1575] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
(APIServer pid=2639330) Traceback (most recent call last):
(APIServer pid=2639330)   File "/home/name/.test/.gpu/vllm/.venv/bin/vllm", line 10, in <module>
(APIServer pid=2639330)     sys.exit(main())
(APIServer pid=2639330)              ^^^^^^
(APIServer pid=2639330)   File "/home/name/.test/.gpu/vllm/vllm/entrypoints/cli/main.py", line 75, in main
(APIServer pid=2639330)     args.dispatch_function(args)
(APIServer pid=2639330)   File "/home/name/.test/.gpu/vllm/vllm/entrypoints/cli/serve.py", line 122, in cmd
(APIServer pid=2639330)     uvloop.run(run_server(args))
(APIServer pid=2639330)   File "/home/name/.test/.gpu/vllm/.venv/lib/python3.12/site-packages/uvloop/__init__.py", line 96, in run
(APIServer pid=2639330)     return __asyncio.run(
(APIServer pid=2639330)            ^^^^^^^^^^^^^^
(APIServer pid=2639330)   File "/home/name/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/asyncio/runners.py", line 195, in run
(APIServer pid=2639330)     return runner.run(main)
(APIServer pid=2639330)            ^^^^^^^^^^^^^^^^
(APIServer pid=2639330)   File "/home/name/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/asyncio/runners.py", line 118, in run
(APIServer pid=2639330)     return self._loop.run_until_complete(task)
(APIServer pid=2639330)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2639330)   File "uvloop/loop.pyx", line 1518, in uvloop.loop.Loop.run_until_complete
(APIServer pid=2639330)   File "/home/name/.test/.gpu/vllm/.venv/lib/python3.12/site-packages/uvloop/__init__.py", line 48, in wrapper
(APIServer pid=2639330)     return await main
(APIServer pid=2639330)            ^^^^^^^^^^
(APIServer pid=2639330)   File "/home/name/.test/.gpu/vllm/vllm/entrypoints/openai/api_server.py", line 686, in run_server
(APIServer pid=2639330)     await run_server_worker(listen_address, sock, args, **uvicorn_kwargs)
(APIServer pid=2639330)   File "/home/name/.test/.gpu/vllm/vllm/entrypoints/openai/api_server.py", line 700, in run_server_worker
(APIServer pid=2639330)     async with build_async_engine_client(
(APIServer pid=2639330)                ^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2639330)   File "/home/name/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/contextlib.py", line 210, in __aenter__
(APIServer pid=2639330)     return await anext(self.gen)
(APIServer pid=2639330)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2639330)   File "/home/name/.test/.gpu/vllm/vllm/entrypoints/openai/api_server.py", line 100, in build_async_engine_client
(APIServer pid=2639330)     async with build_async_engine_client_from_engine_args(
(APIServer pid=2639330)                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2639330)   File "/home/name/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/contextlib.py", line 210, in __aenter__
(APIServer pid=2639330)     return await anext(self.gen)
(APIServer pid=2639330)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2639330)   File "/home/name/.test/.gpu/vllm/vllm/entrypoints/openai/api_server.py", line 136, in build_async_engine_client_from_engine_args
(APIServer pid=2639330)     async_llm = AsyncLLM.from_vllm_config(
(APIServer pid=2639330)                 ^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2639330)   File "/home/name/.test/.gpu/vllm/vllm/v1/engine/async_llm.py", line 225, in from_vllm_config
(APIServer pid=2639330)     return cls(
(APIServer pid=2639330)            ^^^^
(APIServer pid=2639330)   File "/home/name/.test/.gpu/vllm/vllm/v1/engine/async_llm.py", line 154, in __init__
(APIServer pid=2639330)     self.engine_core = EngineCoreClient.make_async_mp_client(
(APIServer pid=2639330)                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2639330)   File "/home/name/.test/.gpu/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(APIServer pid=2639330)     return func(*args, **kwargs)
(APIServer pid=2639330)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2639330)   File "/home/name/.test/.gpu/vllm/vllm/v1/engine/core_client.py", line 130, in make_async_mp_client
(APIServer pid=2639330)     return AsyncMPClient(*client_args)
(APIServer pid=2639330)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2639330)   File "/home/name/.test/.gpu/vllm/vllm/tracing/otel.py", line 178, in sync_wrapper
(APIServer pid=2639330)     return func(*args, **kwargs)
(APIServer pid=2639330)            ^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2639330)   File "/home/name/.test/.gpu/vllm/vllm/v1/engine/core_client.py", line 890, in __init__
(APIServer pid=2639330)     super().__init__(
(APIServer pid=2639330)   File "/home/name/.test/.gpu/vllm/vllm/v1/engine/core_client.py", line 551, in __init__
(APIServer pid=2639330)     with launch_core_engines(
(APIServer pid=2639330)          ^^^^^^^^^^^^^^^^^^^^
(APIServer pid=2639330)   File "/home/name/.local/share/uv/python/cpython-3.12.13-linux-x86_64-gnu/lib/python3.12/contextlib.py", line 144, in __exit__
(APIServer pid=2639330)     next(self.gen)
(APIServer pid=2639330)   File "/home/name/.test/.gpu/vllm/vllm/v1/engine/utils.py", line 1094, in launch_core_engines
(APIServer pid=2639330)     wait_for_engine_startup(
(APIServer pid=2639330)   File "/home/name/.test/.gpu/vllm/vllm/v1/engine/utils.py", line 1153, in wait_for_engine_startup
(APIServer pid=2639330)     raise RuntimeError(
(APIServer pid=2639330) RuntimeError: Engine core initialization failed. See root cause above. Failed core proc(s): {}
```
</details>

<details>
<summary>after</summary>

```bash
vllm serve unsloth/Qwen3.5-0.8B-GGUF:UD-IQ2_XXS --tokenizer Qwen/Qwen3.5-0.8B --hf-config-path Qwen/Qwen3.5-0.8B
(APIServer pid=1622311) INFO 04-13 22:08:32 [utils.py:299] 
(APIServer pid=1622311) INFO 04-13 22:08:32 [utils.py:299]        █     █     █▄   ▄█
(APIServer pid=1622311) INFO 04-13 22:08:32 [utils.py:299]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.19.1rc1.dev164+g55d037e2e.d20260410
(APIServer pid=1622311) INFO 04-13 22:08:32 [utils.py:299]   █▄█▀ █     █     █     █  model   unsloth/Qwen3.5-0.8B-GGUF:UD-IQ2_XXS
(APIServer pid=1622311) INFO 04-13 22:08:32 [utils.py:299]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀
(APIServer pid=1622311) INFO 04-13 22:08:32 [utils.py:299] 
(APIServer pid=1622311) INFO 04-13 22:08:32 [utils.py:233] non-default args: {'model_tag': 'unsloth/Qwen3.5-0.8B-GGUF:UD-IQ2_XXS', 'model': 'unsloth/Qwen3.5-0.8B-GGUF:UD-IQ2_XXS', 'tokenizer': 'Qwen/Qwen3.5-0.8B', 'hf_config_path': 'Qwen/Qwen3.5-0.8B'}
(APIServer pid=1622311) WARNING 04-13 22:08:32 [gguf_utils.py:62] Non-standard GGUF quant type 'UD-IQ2_XXS' detected.
(APIServer pid=1622311) INFO 04-13 22:08:34 [model.py:554] Resolved architecture: Qwen3_5ForConditionalGeneration
(APIServer pid=1622311) INFO 04-13 22:08:34 [model.py:1684] Using max model len 262144
(APIServer pid=1622311) INFO 04-13 22:08:34 [vllm.py:809] Asynchronous scheduling is enabled.
(APIServer pid=1622311) INFO 04-13 22:08:34 [kernel.py:199] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'])
(APIServer pid=1622311) `Qwen2VLImageProcessorFast` is deprecated. The `Fast` suffix for image processors has been removed; use `Qwen2VLImageProcessor` instead.
(APIServer pid=1622311) The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
(EngineCore pid=1623438) INFO 04-13 22:08:55 [core.py:107] Initializing a V1 LLM engine (v0.19.1rc1.dev164+g55d037e2e.d20260410) with config: model='unsloth/Qwen3.5-0.8B-GGUF:UD-IQ2_XXS', speculative_config=None, tokenizer='Qwen/Qwen3.5-0.8B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=262144, download_dir=None, load_format=gguf, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=gguf, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=unsloth/Qwen3.5-0.8B-GGUF:UD-IQ2_XXS, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_images_per_batch': 0, 'compile_sizes': [], 'compile_ranges_endpoints': [2048], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'size_asserts': False, 'alignment_asserts': False, 'scalar_asserts': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native']), enable_flashinfer_autotune=True, moe_backend='auto')
(EngineCore pid=1623438) `Qwen2VLImageProcessorFast` is deprecated. The `Fast` suffix for image processors has been removed; use `Qwen2VLImageProcessor` instead.
(EngineCore pid=1623438) INFO 04-13 22:08:58 [parallel_state.py:1400] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.16.1.10:39833 backend=nccl
(EngineCore pid=1623438) INFO 04-13 22:08:58 [parallel_state.py:1713] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank N/A, EPLB rank N/A
(EngineCore pid=1623438) WARNING 04-13 22:08:58 [gguf_utils.py:62] Non-standard GGUF quant type 'UD-IQ2_XXS' detected.
(EngineCore pid=1623438) The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
(EngineCore pid=1623438) INFO 04-13 22:09:11 [gpu_model_runner.py:4750] Starting to load model unsloth/Qwen3.5-0.8B-GGUF:UD-IQ2_XXS...
(EngineCore pid=1623438) The fast path is not available because one of the required library is not installed. Falling back to torch implementation. To install follow https://github.com/fla-org/flash-linear-attention#installation and https://github.com/Dao-AILab/causal-conv1d
(EngineCore pid=1623438) INFO 04-13 22:09:24 [gguf_loader.py:443] Loading extra mm_proj weights from /home/name/.cache/huggingface/hub/models--unsloth--Qwen3.5-0.8B-GGUF/snapshots/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/mmproj-BF16.gguf...
(EngineCore pid=1623438) INFO 04-13 22:09:24 [cuda.py:422] Using backend AttentionBackendEnum.FLASH_ATTN for vit attention
(EngineCore pid=1623438) INFO 04-13 22:09:24 [mm_encoder_attention.py:230] Using AttentionBackendEnum.FLASH_ATTN for MMEncoderAttention.
(EngineCore pid=1623438) INFO 04-13 22:09:24 [gdn_linear_attn.py:155] Using Triton/FLA GDN prefill kernel
(EngineCore pid=1623438) INFO 04-13 22:09:25 [cuda.py:366] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(EngineCore pid=1623438) INFO 04-13 22:09:25 [flash_attn.py:637] Using FlashAttention version 2
(EngineCore pid=1623438) <frozen importlib._bootstrap_external>:1301: FutureWarning: The cuda.cudart module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.runtime module instead.
(EngineCore pid=1623438) <frozen importlib._bootstrap_external>:1301: FutureWarning: The cuda.nvrtc module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.nvrtc module instead.
(EngineCore pid=1623438) INFO 04-13 22:09:32 [gpu_model_runner.py:4835] Model loading took 0.95 GiB memory and 20.688811 seconds
(EngineCore pid=1623438) INFO 04-13 22:09:32 [interface.py:606] Setting attention block size to 544 tokens to ensure that attention page size is >= mamba page size.
(EngineCore pid=1623438) INFO 04-13 22:09:32 [interface.py:630] Padding mamba page size by 2.64% to ensure that mamba page size and attention page size are exactly equal.
(EngineCore pid=1623438) INFO 04-13 22:09:32 [gpu_model_runner.py:5784] Encoder cache will be initialized with a budget of 16384 tokens, and profiled with 1 image items of the maximum feature size.
(EngineCore pid=1623438) INFO 04-13 22:09:33 [backends.py:1070] Using cache directory: /home/name/.cache/vllm/torch_compile_cache/3ff83d0cde/rank_0_0/backbone for vLLM's torch.compile
(EngineCore pid=1623438) INFO 04-13 22:09:33 [backends.py:1130] Dynamo bytecode transform time: 0.60 s
(EngineCore pid=1623438) INFO 04-13 22:09:34 [backends.py:286] Directly load the compiled graph(s) for compile range (1, 2048) from the cache, took 0.904 s
(EngineCore pid=1623438) INFO 04-13 22:09:34 [decorators.py:305] Directly load AOT compilation from path /home/name/.cache/vllm/torch_compile_cache/torch_aot_compile/910686eaa28fa02dabfb763dc29f80d7cc4efce33d0e6008f20f0e94258b227f/rank_0_0/model
(EngineCore pid=1623438) INFO 04-13 22:09:34 [monitor.py:48] torch.compile took 1.61 s in total
(EngineCore pid=1623438) INFO 04-13 22:09:35 [monitor.py:76] Initial profiling/warmup run took 0.11 s
(EngineCore pid=1623438) INFO 04-13 22:09:35 [kv_cache_utils.py:829] Overriding num_gpu_blocks=0 with num_gpu_blocks_override=512
(EngineCore pid=1623438) INFO 04-13 22:09:35 [gpu_model_runner.py:5914] Profiling CUDA graph memory: PIECEWISE=51 (largest=512), FULL=35 (largest=256)
(EngineCore pid=1623438) INFO 04-13 22:09:36 [gpu_model_runner.py:5993] Estimated CUDA graph memory: 0.73 GiB total
(EngineCore pid=1623438) INFO 04-13 22:09:36 [gpu_worker.py:436] Available KV cache memory: 18.76 GiB
(EngineCore pid=1623438) INFO 04-13 22:09:36 [gpu_worker.py:470] In v0.19, CUDA graph memory profiling will be enabled by default (VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1), which more accurately accounts for CUDA graph memory during KV cache allocation. To try it now, set VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1 and increase --gpu-memory-utilization from 0.9000 to 0.9312 to maintain the same effective KV cache size.
(EngineCore pid=1623438) INFO 04-13 22:09:36 [kv_cache_utils.py:1319] GPU KV cache size: 409,632 tokens
(EngineCore pid=1623438) INFO 04-13 22:09:36 [kv_cache_utils.py:1324] Maximum concurrency for 262,144 tokens per request: 6.21x
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|███████████████████████| 51/51 [00:01<00:00, 47.86it/s]
Capturing CUDA graphs (decode, FULL): 100%|██████████████████████████████████████████| 35/35 [00:00<00:00, 49.09it/s]
(EngineCore pid=1623438) INFO 04-13 22:09:38 [gpu_model_runner.py:6084] Graph capturing finished in 2 secs, took 0.72 GiB
(EngineCore pid=1623438) INFO 04-13 22:09:38 [gpu_worker.py:597] CUDA graph pool memory: 0.72 GiB (actual), 0.73 GiB (estimated), difference: 0.01 GiB (1.3%).
(EngineCore pid=1623438) INFO 04-13 22:09:38 [core.py:285] init engine (profile, create kv cache, warmup model) took 6.29 seconds
(EngineCore pid=1623438) INFO 04-13 22:09:38 [vllm.py:809] Asynchronous scheduling is enabled.
(EngineCore pid=1623438) INFO 04-13 22:09:38 [kernel.py:199] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'])
(APIServer pid=1622311) INFO 04-13 22:09:38 [api_server.py:600] Supported tasks: ['generate']
(APIServer pid=1622311) INFO 04-13 22:09:47 [hf.py:314] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(APIServer pid=1622311) INFO 04-13 22:09:56 [base.py:245] Multi-modal warmup completed in 8.255s
(APIServer pid=1622311) INFO 04-13 22:09:57 [api_server.py:604] Starting vLLM server on http://0.0.0.0:8000
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:37] Available routes are:
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /openapi.json, Methods: HEAD, GET
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /docs, Methods: HEAD, GET
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: HEAD, GET
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /redoc, Methods: HEAD, GET
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /tokenize, Methods: POST
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /detokenize, Methods: POST
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /v1/chat/completions/batch, Methods: POST
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /v1/messages/count_tokens, Methods: POST
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /v1/chat/completions/render, Methods: POST
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /v1/completions/render, Methods: POST
(APIServer pid=1622311) INFO 04-13 22:09:57 [launcher.py:46] Route: /generative_scoring, Methods: POST
(APIServer pid=1622311) INFO:     Started server process [1622311]
(APIServer pid=1622311) INFO:     Waiting for application startup.
(APIServer pid=1622311) INFO:     Application startup complete.
(APIServer pid=1622311) INFO:     127.0.0.1:40480 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```
</details>

### Qwen3.5 MoE

<details>
<summary>after</summary>

```bash
vllm serve unsloth/Qwen3.5-35B-A3B-GGUF:UD-IQ2_XXS --tokenizer Qwen/Qwen3.5-35B-A3B
(APIServer pid=1258756) INFO 04-13 19:49:54 [utils.py:299]
(APIServer pid=1258756) INFO 04-13 19:49:54 [utils.py:299]        █     █     █▄   ▄█
(APIServer pid=1258756) INFO 04-13 19:49:54 [utils.py:299]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.19.1rc1.dev164+g55d037e2e.d20260410
(APIServer pid=1258756) INFO 04-13 19:49:54 [utils.py:299]   █▄█▀ █     █     █     █  model   unsloth/Qwen3.5-35B-A3B-GGUF:UD-IQ2_XXS
(APIServer pid=1258756) INFO 04-13 19:49:54 [utils.py:299]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀
(APIServer pid=1258756) INFO 04-13 19:49:54 [utils.py:299]
(APIServer pid=1258756) INFO 04-13 19:49:54 [utils.py:233] non-default args: {'model_tag': 'unsloth/Qwen3.5-35B-A3B-GGUF:UD-IQ2_XXS', 'model': 'unsloth/Qwen3.5-35B-A3B-GGUF:UD-IQ2_XXS', 'tokenizer': 'Qwen/Qwen3.5-35B-A3B'}
(APIServer pid=1258756) WARNING 04-13 19:49:54 [gguf_utils.py:62] Non-standard GGUF quant type 'UD-IQ2_XXS' detected.
(APIServer pid=1258756) INFO 04-13 19:49:56 [gguf_utils.py:334] Forced Qwen3.5 multimodal architecture: Qwen3_5MoeForConditionalGeneration
(APIServer pid=1258756) INFO 04-13 19:49:56 [model.py:554] Resolved architecture: Qwen3_5MoeForConditionalGeneration
(APIServer pid=1258756) INFO 04-13 19:49:56 [model.py:1684] Using max model len 262144
(APIServer pid=1258756) INFO 04-13 19:49:56 [vllm.py:809] Asynchronous scheduling is enabled.
(APIServer pid=1258756) INFO 04-13 19:49:56 [kernel.py:199] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'])
(APIServer pid=1258756) `Qwen2VLImageProcessorFast` is deprecated. The `Fast` suffix for image processors has been removed; use `Qwen2VLImageProcessor` instead.
(APIServer pid=1258756) The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
(EngineCore pid=1259857) INFO 04-13 19:50:17 [core.py:107] Initializing a V1 LLM engine (v0.19.1rc1.dev164+g55d037e2e.d20260410) with config: model='unsloth/Qwen3.5-35B-A3B-GGUF:UD-IQ2_XXS', speculative_config=None, tokenizer='Qwen/Qwen3.5-35B-A3B', skip_tokenizer_init=False, tokenizer_mode=auto, revision=None, tokenizer_revision=None, trust_remote_code=False, dtype=torch.bfloat16, max_seq_len=262144, download_dir=None, load_format=gguf, tensor_parallel_size=1, pipeline_parallel_size=1, data_parallel_size=1, decode_context_parallel_size=1, dcp_comm_backend=ag_rs, disable_custom_all_reduce=False, quantization=gguf, quantization_config=None, enforce_eager=False, enable_return_routed_experts=False, kv_cache_dtype=auto, device_config=cuda, structured_outputs_config=StructuredOutputsConfig(backend='auto', disable_any_whitespace=False, disable_additional_properties=False, reasoning_parser='', reasoning_parser_plugin='', enable_in_reasoning=False), observability_config=ObservabilityConfig(show_hidden_metrics_for_version=None, otlp_traces_endpoint=None, collect_detailed_traces=None, kv_cache_metrics=False, kv_cache_metrics_sample=0.01, cudagraph_metrics=False, enable_layerwise_nvtx_tracing=False, enable_mfu_metrics=False, enable_mm_processor_stats=False, enable_logging_iteration_details=False), seed=0, served_model_name=unsloth/Qwen3.5-35B-A3B-GGUF:UD-IQ2_XXS, enable_prefix_caching=False, enable_chunked_prefill=True, pooler_config=None, compilation_config={'mode': <CompilationMode.VLLM_COMPILE: 3>, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', 'backend': 'inductor', 'custom_ops': ['none'], 'ir_enable_torch_wrap': True, 'splitting_ops': ['vllm::unified_attention_with_output', 'vllm::unified_mla_attention_with_output', 'vllm::mamba_mixer2', 'vllm::mamba_mixer', 'vllm::short_conv', 'vllm::linear_attention', 'vllm::plamo2_mamba_mixer', 'vllm::gdn_attention_core', 'vllm::olmo_hybrid_gdn_full_forward', 'vllm::kda_attention', 'vllm::sparse_attn_indexer', 'vllm::rocm_aiter_sparse_attn_indexer', 'vllm::unified_kv_cache_update', 'vllm::unified_mla_kv_cache_update'], 'compile_mm_encoder': False, 'cudagraph_mm_encoder': False, 'encoder_cudagraph_token_budgets': [], 'encoder_cudagraph_max_images_per_batch': 0, 'compile_sizes': [], 'compile_ranges_endpoints': [2048], 'inductor_compile_config': {'enable_auto_functionalized_v2': False, 'size_asserts': False, 'alignment_asserts': False, 'scalar_asserts': False, 'combo_kernels': True, 'benchmark_combo_kernel': True}, 'inductor_passes': {}, 'cudagraph_mode': <CUDAGraphMode.FULL_AND_PIECEWISE: (2, 1)>, 'cudagraph_num_of_warmups': 1, 'cudagraph_capture_sizes': [1, 2, 4, 8, 16, 24, 32, 40, 48, 56, 64, 72, 80, 88, 96, 104, 112, 120, 128, 136, 144, 152, 160, 168, 176, 184, 192, 200, 208, 216, 224, 232, 240, 248, 256, 272, 288, 304, 320, 336, 352, 368, 384, 400, 416, 432, 448, 464, 480, 496, 512], 'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': False, 'pass_config': {'fuse_norm_quant': False, 'fuse_act_quant': False, 'fuse_attn_quant': False, 'enable_sp': False, 'fuse_gemm_comms': False, 'fuse_allreduce_rms': False}, 'max_cudagraph_capture_size': 512, 'dynamic_shapes_config': {'type': <DynamicShapesType.BACKED: 'backed'>, 'evaluate_guards': False, 'assume_32_bit_indexing': False}, 'local_cache_dir': None, 'fast_moe_cold_start': False, 'static_all_moe_layers': []}, kernel_config=KernelConfig(ir_op_priority=IrOpPriorityConfig(rms_norm=['native']), enable_flashinfer_autotune=True, moe_backend='auto')
(EngineCore pid=1259857) `Qwen2VLImageProcessorFast` is deprecated. The `Fast` suffix for image processors has been removed; use `Qwen2VLImageProcessor` instead.
(EngineCore pid=1259857) INFO 04-13 19:50:19 [parallel_state.py:1400] world_size=1 rank=0 local_rank=0 distributed_init_method=tcp://172.16.1.10:51161 backend=nccl
(EngineCore pid=1259857) INFO 04-13 19:50:20 [parallel_state.py:1713] rank 0 in world size 1 is assigned as DP rank 0, PP rank 0, PCP rank 0, TP rank 0, EP rank 0, EPLB rank N/A
(EngineCore pid=1259857) WARNING 04-13 19:50:20 [gguf_utils.py:62] Non-standard GGUF quant type 'UD-IQ2_XXS' detected.
(EngineCore pid=1259857) The `use_fast` parameter is deprecated and will be removed in a future version. Use `backend="torchvision"` instead of `use_fast=True`, or `backend="pil"` instead of `use_fast=False`.
(EngineCore pid=1259857) INFO 04-13 19:50:32 [gpu_model_runner.py:4750] Starting to load model unsloth/Qwen3.5-35B-A3B-GGUF:UD-IQ2_XXS...
(EngineCore pid=1259857) The fast path is not available because one of the required library is not installed. Falling back to torch implementation. To install follow https://github.com/fla-org/flash-linear-attention#installation and https://github.com/Dao-AILab/causal-conv1d
(EngineCore pid=1259857) INFO 04-13 19:50:47 [gguf_loader.py:456] Loading extra mm_proj weights from /home/name/.cache/huggingface/hub/models--unsloth--Qwen3.5-35B-A3B-GGUF/snapshots/bc014a17be43adabd7066b7a86075ff935c6a4e2/mmproj-BF16.gguf...
(EngineCore pid=1259857) INFO 04-13 19:50:47 [cuda.py:422] Using backend AttentionBackendEnum.FLASH_ATTN for vit attention
(EngineCore pid=1259857) INFO 04-13 19:50:47 [mm_encoder_attention.py:230] Using AttentionBackendEnum.FLASH_ATTN for MMEncoderAttention.
(EngineCore pid=1259857) INFO 04-13 19:50:47 [gdn_linear_attn.py:155] Using Triton/FLA GDN prefill kernel
(EngineCore pid=1259857) INFO 04-13 19:50:47 [cuda.py:366] Using FLASH_ATTN attention backend out of potential backends: ['FLASH_ATTN', 'FLASHINFER', 'TRITON_ATTN', 'FLEX_ATTENTION'].
(EngineCore pid=1259857) INFO 04-13 19:50:47 [flash_attn.py:637] Using FlashAttention version 2
(EngineCore pid=1259857) <frozen importlib._bootstrap_external>:1301: FutureWarning: The cuda.cudart module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.runtime module instead.
(EngineCore pid=1259857) <frozen importlib._bootstrap_external>:1301: FutureWarning: The cuda.nvrtc module is deprecated and will be removed in a future release, please switch to use the cuda.bindings.nvrtc module instead.
(EngineCore pid=1259857) INFO 04-13 19:50:57 [gpu_model_runner.py:4835] Model loading took 12.21 GiB memory and 23.596208 seconds
(EngineCore pid=1259857) INFO 04-13 19:50:57 [interface.py:606] Setting attention block size to 1056 tokens to ensure that attention page size is >= mamba page size.
(EngineCore pid=1259857) INFO 04-13 19:50:57 [interface.py:630] Padding mamba page size by 0.76% to ensure that mamba page size and attention page size are exactly equal.
(EngineCore pid=1259857) INFO 04-13 19:50:57 [gpu_model_runner.py:5784] Encoder cache will be initialized with a budget of 16384 tokens, and profiled with 1 image items of the maximum feature size.
(EngineCore pid=1259857) INFO 04-13 19:51:01 [backends.py:1070] Using cache directory: /home/name/.cache/vllm/torch_compile_cache/2e45e00b32/rank_0_0/backbone for vLLM's torch.compile
(EngineCore pid=1259857) INFO 04-13 19:51:01 [backends.py:1130] Dynamo bytecode transform time: 3.86 s
(EngineCore pid=1259857) INFO 04-13 19:51:03 [backends.py:373] Cache the graph of compile range (1, 2048) for later use
(EngineCore pid=1259857) INFO 04-13 19:51:15 [backends.py:391] Compiling a graph for compile range (1, 2048) takes 13.76 s
(EngineCore pid=1259857) INFO 04-13 19:51:18 [decorators.py:655] saved AOT compiled function to /home/name/.cache/vllm/torch_compile_cache/torch_aot_compile/703a7fd7463c0d2c8352e4b42e821c7d228ba254269fa8c7310bbeda6ae7ffa0/rank_0_0/model
(EngineCore pid=1259857) INFO 04-13 19:51:18 [monitor.py:48] torch.compile took 20.01 s in total
(EngineCore pid=1259857) INFO 04-13 19:51:20 [monitor.py:76] Initial profiling/warmup run took 2.18 s
(EngineCore pid=1259857) INFO 04-13 19:51:20 [kv_cache_utils.py:829] Overriding num_gpu_blocks=0 with num_gpu_blocks_override=512
(EngineCore pid=1259857) INFO 04-13 19:51:20 [gpu_model_runner.py:5914] Profiling CUDA graph memory: PIECEWISE=51 (largest=512), FULL=35 (largest=256)
(EngineCore pid=1259857) INFO 04-13 19:51:23 [gpu_model_runner.py:5993] Estimated CUDA graph memory: 1.62 GiB total
(EngineCore pid=1259857) INFO 04-13 19:51:24 [gpu_worker.py:436] Available KV cache memory: 6.9 GiB
(EngineCore pid=1259857) INFO 04-13 19:51:24 [gpu_worker.py:470] In v0.19, CUDA graph memory profiling will be enabled by default (VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1), which more accurately accounts for CUDA graph memory during KV cache allocation. To try it now, set VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1 and increase --gpu-memory-utilization from 0.9000 to 0.9690 to maintain the same effective KV cache size.
(EngineCore pid=1259857) INFO 04-13 19:51:24 [kv_cache_utils.py:1319] GPU KV cache size: 89,760 tokens
(EngineCore pid=1259857) INFO 04-13 19:51:24 [kv_cache_utils.py:1324] Maximum concurrency for 262,144 tokens per request: 1.36x
Capturing CUDA graphs (mixed prefill-decode, PIECEWISE): 100%|████████████████████████████████████████| 51/51 [00:10<00:00,  4.86it/s]
Capturing CUDA graphs (decode, FULL): 100%|███████████████████████████████████████████████████████████| 35/35 [00:04<00:00,  7.02it/s]
(EngineCore pid=1259857) INFO 04-13 19:51:40 [gpu_model_runner.py:6084] Graph capturing finished in 16 secs, took 1.71 GiB
(EngineCore pid=1259857) INFO 04-13 19:51:40 [gpu_worker.py:597] CUDA graph pool memory: 1.71 GiB (actual), 1.62 GiB (estimated), difference: 0.08 GiB (4.8%).
(EngineCore pid=1259857) INFO 04-13 19:51:40 [core.py:285] init engine (profile, create kv cache, warmup model) took 43.22 seconds
(EngineCore pid=1259857) INFO 04-13 19:51:40 [vllm.py:809] Asynchronous scheduling is enabled.
(EngineCore pid=1259857) INFO 04-13 19:51:40 [kernel.py:199] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'])
(APIServer pid=1258756) INFO 04-13 19:51:40 [api_server.py:600] Supported tasks: ['generate']
(APIServer pid=1258756) INFO 04-13 19:51:47 [hf.py:314] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(APIServer pid=1258756) INFO 04-13 19:51:55 [base.py:245] Multi-modal warmup completed in 8.099s
(APIServer pid=1258756) INFO 04-13 19:51:55 [api_server.py:604] Starting vLLM server on http://0.0.0.0:8000/
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:37] Available routes are:
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /openapi.json, Methods: GET, HEAD
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /docs, Methods: GET, HEAD
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: GET, HEAD
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /redoc, Methods: GET, HEAD
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /tokenize, Methods: POST
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /detokenize, Methods: POST
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /v1/chat/completions/batch, Methods: POST
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /v1/messages/count_tokens, Methods: POST
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /v1/chat/completions/render, Methods: POST
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /v1/completions/render, Methods: POST
(APIServer pid=1258756) INFO 04-13 19:51:55 [launcher.py:46] Route: /generative_scoring, Methods: POST
(APIServer pid=1258756) INFO:     Started server process [1258756]
(APIServer pid=1258756) INFO:     Waiting for application startup.
(APIServer pid=1258756) INFO:     Application startup complete.
(APIServer pid=1258756) INFO:     127.0.0.1:33702 - "POST /v1/chat/completions HTTP/1.1" 200 OK
```
</details>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

