### PR TITLE
feat: Add LoRA support for Gemma 4 models

### DIFF
--- a/tests/lora/test_lora_checkpoints.py
+++ b/tests/lora/test_lora_checkpoints.py
@@ -5,7 +5,10 @@ import pytest
 
 from vllm.lora.lora_model import LoRAModel
 from vllm.lora.peft_helper import PEFTHelper
+from vllm.lora.utils import parse_fine_tuned_lora_name
 from vllm.model_executor.models.baichuan import BaiChuanBaseForCausalLM
+from vllm.model_executor.models.gemma4 import Gemma4ForCausalLM
+from vllm.model_executor.models.gemma4_mm import Gemma4ForConditionalGeneration
 from vllm.model_executor.models.utils import WeightsMapper
 
 lora_lst = ["baichuan7B", "baichuan7B-zero", "baichuan7B-zero-regex", "chatglm3-6b"]
@@ -128,3 +131,121 @@ def test_lora_weights_mapping(baichuan_lora_files):
     for name in lora_model.loras:
         assert name.startswith(hf_to_vllm_mapper.orig_to_new_prefix["model."])
         assert ".baichuan_layers." in name
+
+# ---------------------------------------------------------------------------
+# Gemma4ForCausalLM LoRA weight mapping tests
+# ---------------------------------------------------------------------------
+
+
+def test_gemma4_lora_weights_mapping():
+    """Test that LoRA adapter names from the conditional wrapper are
+    correctly remapped to the text-only model namespace via the
+    ``hf_to_vllm_mapper`` on ``Gemma4ForCausalLM``."""
+    mapper = Gemma4ForCausalLM.hf_to_vllm_mapper
+    name = (
+        "base_model.model.model.language_model.layers.9"
+        ".mlp.down_proj.lora_A.weight"
+    )
+    assert parse_fine_tuned_lora_name(name, mapper) == (
+        "model.layers.9.mlp.down_proj",
+        True,
+    )
+
+
+def test_gemma4_attention_lora_weights_mapping():
+    """Test that attention projection LoRA names are mapped correctly."""
+    mapper = Gemma4ForCausalLM.hf_to_vllm_mapper
+    for proj in ("q_proj", "k_proj", "v_proj", "o_proj"):
+        name = (
+            f"base_model.model.model.language_model.layers.3"
+            f".self_attn.{proj}.lora_A.weight"
+        )
+        expected_module = f"model.layers.3.self_attn.{proj}"
+        result = parse_fine_tuned_lora_name(name, mapper)
+        assert result == (expected_module, True), (
+            f"Unexpected mapping for {proj}: {result}"
+        )
+
+
+def test_gemma4_gate_up_proj_lora_weights_mapping():
+    """Test that gate_up_proj LoRA names are mapped correctly."""
+    mapper = Gemma4ForCausalLM.hf_to_vllm_mapper
+    name = (
+        "base_model.model.model.language_model.layers.5"
+        ".mlp.gate_up_proj.lora_B.weight"
+    )
+    assert parse_fine_tuned_lora_name(name, mapper) == (
+        "model.layers.5.mlp.gate_up_proj",
+        False,
+    )
+
+
+def test_gemma4_moe_lora_weights_mapping():
+    """Test that MoE expert adapter names are remapped: the checkpoint
+    uses ``moe.experts.gate_up_proj`` while the text-only model uses
+    ``moe.gate_up_proj``."""
+    mapper = Gemma4ForCausalLM.hf_to_vllm_mapper
+    name = (
+        "base_model.model.model.language_model.layers.9.moe.experts."
+        "gate_up_proj.lora_B.weight"
+    )
+    assert parse_fine_tuned_lora_name(name, mapper) == (
+        "model.layers.9.moe.gate_up_proj",
+        False,
+    )
+
+
+def test_gemma4_moe_down_proj_lora_weights_mapping():
+    """Test that MoE down_proj expert adapter names are remapped."""
+    mapper = Gemma4ForCausalLM.hf_to_vllm_mapper
+    name = (
+        "base_model.model.model.language_model.layers.12.moe.experts."
+        "down_proj.lora_A.weight"
+    )
+    assert parse_fine_tuned_lora_name(name, mapper) == (
+        "model.layers.12.moe.down_proj",
+        True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gemma4ForConditionalGeneration LoRA support tests
+# ---------------------------------------------------------------------------
+
+
+def test_gemma4_conditional_supports_lora():
+    """Verify that the multimodal wrapper exposes LoRA support."""
+    assert hasattr(Gemma4ForConditionalGeneration, "supports_lora")
+    assert Gemma4ForConditionalGeneration.supports_lora is True
+
+
+def test_gemma4_conditional_packed_modules():
+    """Verify packed_modules_mapping on the multimodal model."""
+    mapping = Gemma4ForConditionalGeneration.packed_modules_mapping
+    assert "qkv_proj" in mapping
+    assert set(mapping["qkv_proj"]) == {"q_proj", "k_proj", "v_proj"}
+    assert "gate_up_proj" in mapping
+    assert set(mapping["gate_up_proj"]) == {"gate_proj", "up_proj"}
+
+
+def test_gemma4_conditional_hf_to_vllm_mapper():
+    """Verify that the multimodal model exposes a weights mapper."""
+    mapper = Gemma4ForConditionalGeneration.hf_to_vllm_mapper
+    assert isinstance(mapper, WeightsMapper)
+    # Should map language_model prefix
+    assert "model.language_model." in mapper.orig_to_new_prefix
+
+
+def test_gemma4_causal_lm_supports_lora():
+    """Verify that the text-only model exposes LoRA support."""
+    assert hasattr(Gemma4ForCausalLM, "supports_lora")
+    assert Gemma4ForCausalLM.supports_lora is True
+
+
+def test_gemma4_causal_packed_modules():
+    """Verify packed_modules_mapping on the text-only model."""
+    mapping = Gemma4ForCausalLM.packed_modules_mapping
+    assert "qkv_proj" in mapping
+    assert set(mapping["qkv_proj"]) == {"q_proj", "k_proj", "v_proj"}
+    assert "gate_up_proj" in mapping
+    assert set(mapping["gate_up_proj"]) == {"gate_proj", "up_proj"}

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -69,6 +69,7 @@ from .interfaces import (
 )
 from .utils import (
     AutoWeightsLoader,
+    WeightsMapper,
     extract_layer_index,
     is_pp_missing_parameter,
     make_layers,
@@ -1411,6 +1412,23 @@ class Gemma4ForCausalLM(
             "up_proj",
         ],
     }
+
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            # Gemma4ForConditionalGeneration loads the text stack from
+            # ``model.language_model.*``.  We reuse that same checkpoint
+            # and adapter naming for the text-only Gemma4ForCausalLM path,
+            # so LoRA keys from the conditional wrapper map onto ``model.*``.
+            "model.language_model.": "model.",
+        },
+        orig_to_new_substr={
+            # Gemma4ForConditionalGeneration names MoE adapter targets
+            # under ``...moe.experts.*``, while the text-only model
+            # exposes them under ``...moe.*``.
+            ".moe.experts.gate_up_proj": ".moe.gate_up_proj",
+            ".moe.experts.down_proj": ".moe.down_proj",
+        },
+    )
 
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         config = _get_text_config(vllm_config.model_config.hf_config)

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -67,6 +67,7 @@ from vllm.utils.tensor_schema import TensorSchema, TensorShape
 from .interfaces import (
     MultiModalEmbeddings,
     SupportsEagle3,
+    SupportsLoRA,
     SupportsMultiModal,
     SupportsPP,
 )
@@ -854,6 +855,7 @@ class Gemma4ForConditionalGeneration(
     nn.Module,
     SupportsMultiModal,
     SupportsPP,
+    SupportsLoRA,
     SupportsEagle3,
 ):
     packed_modules_mapping = {


### PR DESCRIPTION
## Summary

Enable LoRA adapters for Gemma 4 model classes:

- **`Gemma4ForCausalLM`** (text-only): Add `hf_to_vllm_mapper` with `WeightsMapper` to correctly remap LoRA adapter weight names — strips `model.language_model.` prefix and normalizes MoE expert paths (`.moe.experts.gate_up_proj` → `.moe.gate_up_proj`, `.moe.experts.down_proj` → `.moe.down_proj`)
- **`Gemma4ForConditionalGeneration`** (multimodal): Add `SupportsLoRA` mixin so the multimodal wrapper is recognized by the LoRA subsystem. The existing `packed_modules_mapping` and `hf_to_vllm_mapper` are already defined — only the interface declaration was missing.

### Files changed

| File | Change |
|------|--------|
| `vllm/model_executor/models/gemma4.py` | Add `WeightsMapper` import + `hf_to_vllm_mapper` class attribute |
| `vllm/model_executor/models/gemma4_mm.py` | Add `SupportsLoRA` to imports and class MRO |
| `tests/lora/test_lora_checkpoints.py` | Add 10 test functions covering weight mapping (attention, MLP, MoE) and LoRA support flags |

### LoRA target modules supported

- `q_proj`, `k_proj`, `v_proj` (packed as `qkv_proj`)
- `o_proj`
- `gate_proj`, `up_proj` (packed as `gate_up_proj`)
- `down_proj`
- MoE expert projections (`gate_up_proj`, `down_proj`)

Fixes #39246

## Test plan

- [x] Unit tests for LoRA weight name mapping via `parse_fine_tuned_lora_name`
- [x] Tests for attention projections (`q_proj`, `k_proj`, `v_proj`, `o_proj`)
- [x] Tests for MLP projections (`gate_up_proj`, `down_proj`)
- [x] Tests for MoE expert projection remapping
- [x] Tests for `supports_lora` flag on both model classes
- [x] Tests for `packed_modules_mapping` correctness
- [x] Tests for `hf_to_vllm_mapper` existence on multimodal model

🤖 Generated with [Claude Code](https://claude.com/claude-code)