### PR TITLE
[Bugfix]: Fix assertion in MambaManager.allocate_slots()

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1023,6 +1023,57 @@ def test_prefill_hybrid_model_mamba_align():
     manager.free(req0)
 
 
+def test_hybrid_model_mamba_align_with_dynamic_draft_tokens():
+    """Regression test for https://github.com/vllm-project/vllm/issues/39271.
+
+    With suffix decoding enabled, the number of proposed draft token may
+    change dynamically each round, causing the MambaManager to crash during
+    allocate_slots() as it originally assumes the `num_blocks` to increase.
+    """
+    block_size = 16
+    num_blocks = 30
+
+    kv_cache_config = _make_hybrid_kv_cache_config(
+        block_size, num_blocks, ["full", "mamba_align"]
+    )
+    manager = KVCacheManager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    # the default hash function is sha256
+    hash_fn = sha256
+
+    all_token_ids = [i for i in range(3) for _ in range(block_size)] + [3] * 7
+    req0 = make_request("0", all_token_ids, block_size, hash_fn)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    blocks = manager.allocate_slots(
+        req0, len(all_token_ids), num_computed_tokens, computed_blocks
+    )
+    assert blocks is not None
+
+    # prefill forward finished
+    req0.append_output_token_ids([1])
+    req0.num_computed_tokens = len(all_token_ids)
+
+    # Round1: propose 16 draft tokens, accept only one
+    req0.spec_token_ids = [4] * 16
+    blocks = manager.allocate_slots(req0, num_new_tokens=16, num_new_computed_tokens=0)
+    assert blocks is not None
+    req0.append_output_token_ids([4])
+    req0.num_computed_tokens += 1
+
+    # Round2: propose only one token, allocate should not crash
+    req0.spec_token_ids = [5] * 1
+    blocks = manager.allocate_slots(req0, num_new_tokens=1, num_new_computed_tokens=0)
+    assert blocks is not None and all(len(group) == 0 for group in blocks.blocks)
+
+    manager.free(req0)
+
+
 def test_prefill_plp():
     """Test prefill with APC and some prompt logprobs (plp) requests.
 

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1041,6 +1041,7 @@ def test_hybrid_model_mamba_align_with_dynamic_draft_tokens():
         max_model_len=8192,
         enable_caching=True,
         hash_block_size=block_size,
+        scheduler_block_size=block_size,
     )
 
     # the default hash function is sha256

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1148,10 +1148,6 @@ class MambaManager(SingleTypeKVCacheManager):
             if num_required_blocks <= len(req_blocks):
                 return []
             else:
-                assert num_required_blocks > len(req_blocks), (
-                    "num_required_blocks "
-                    f"{num_required_blocks} < len(req_blocks) {len(req_blocks)}"
-                )
                 prev_block_len = len(req_blocks)
                 blocks_allocated = request_id in self._allocated_block_reqs
                 # Record the last state block

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1143,7 +1143,9 @@ class MambaManager(SingleTypeKVCacheManager):
             num_required_blocks = (
                 cdiv(num_tokens, self.block_size) + self.num_speculative_blocks
             )
-            if num_required_blocks == len(req_blocks):
+            # `num_required_blocks` might be less than `len(req_blocks)` if blocks are
+            # over-allocated at last round.
+            if num_required_blocks <= len(req_blocks):
                 return []
             else:
                 assert num_required_blocks > len(req_blocks), (


### PR DESCRIPTION
## Summary

  Fixes #39271. With suffix-decoding (or any speculative-decoding method that proposes a dynamic number of draft tokens per round), `MambaManager.allocate_new_blocks()` in `align` mode could hit: ` AssertionError: num_required_blocks N < len(req_blocks) M`

## Root cause

  `scheduler.py` computes `num_new_tokens` based on the number of proposed draft tokens at current round. With suffix decoding, the draft count varies at each round, the `num_new_tokens` might be less than previous round, causing the assertion in ``MambaManager`` to crash during its ``num_blocks`` check. 

## Reproduction

  Reproduced on current `main` with `Qwen/Qwen3.5-4B` (same hybrid Mamba+Attention architecture as the issue reporter's `Qwen3.5-35B-A3B`, fits on a single 32 GB GPU):

  ```python
  from vllm import LLM, SamplingParams

  llm = LLM(
      model="Qwen/Qwen3.5-4B",
      enable_prefix_caching=True,        # auto-sets mamba_cache_mode="align"
      enforce_eager=True,
      max_model_len=8192,
      speculative_config={"method": "suffix", "num_speculative_tokens": 16},
  )
  prompts = [...] * 160     # ~160 long-form requests
  llm.generate(prompts, SamplingParams(temperature=0.0, max_tokens=2048))
```

  The bug is probabilistic — it requires the round-over-round drop in num_tokens_main_model to cross a block_size boundary. Around 160 requests with long generations is enough to hit it on Qwen3.5-4B.

  Trace: added necessary debug print before ``MambaManager`` allocate_new_slots function, pick the latest two trace records before crashing: the ``num_draft_proposed`` decreased from 12 to 1, causing the ``num_tokens_main_model`` decreased from 2370 to 2360. 
```
(EngineCore pid=136841) [allocate_new_slots] request(d894): num_computed_tokens=2357, num_new_computed_tokens=0, total_computed_tokens=2357, num_tokens_with_spec=2370, num_tokens=2358, num_draft_proposed=12, num_tokens_main_model=2370, num_new_tokens=13
(EngineCore pid=136841) [allocate_new_blocks] request(d894): num_tokens=2370, num_speculative_blocks=16, num_required_blocks=21, block_size=592, req_blocks=20
(EngineCore pid=136841) [allocate_new_slots] request(d894): num_computed_tokens=2358, num_new_computed_tokens=0, total_computed_tokens=2358, num_tokens_with_spec=2360, num_tokens=2359, num_draft_proposed=1, num_tokens_main_model=2360, num_new_tokens=2
(EngineCore pid=136841) [allocate_new_blocks] request(d894): num_tokens=2360, num_speculative_blocks=16, num_required_blocks=20, block_size=592, req_blocks=21
```

  ## Fix

  Relax the equality check from ``==`` to ``<=`` so the over-allocated case becomes a no-op (return []). This matches:
  - The parent class ``SingleTypeKVCacheManager.allocate_new_blocks()``, which already returns [] when ``num_new_blocks <= 0``

  The over-allocated blocks are retained and can be reused for next round of block allocation

 ## Test plan

  - Added regression test test_hybrid_model_mamba_align_with_dynamic_draft_tokens in tests/v1/core/test_prefix_caching.py. The test simulates prefill -> high-spec round -> low-spec round
  - pre-commit run --files <changed files> passes all hooks.

## AI assistance

  AI assistance was used during exploration, debugging, and drafting of the regression test. I have read, understood, and can defend every line of the change.