### PR TITLE
[Hardware][AMD][Bugfix] Defer ROCm GCN arch fallback to avoid forced spawn

### DIFF
--- a/tests/test_platform_rocm.py
+++ b/tests/test_platform_rocm.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import importlib
+import sys
+import types
+
+
+def test_rocm_gcn_arch_fallback_is_lazy(monkeypatch):
+    import torch
+    import vllm.platforms.rocm as rocm
+
+    fallback_calls = 0
+
+    def fake_get_device_properties(device):
+        nonlocal fallback_calls
+        fallback_calls += 1
+        return types.SimpleNamespace(gcnArchName="gfx950")
+
+    fake_amdsmi = types.ModuleType("amdsmi")
+    fake_amdsmi.AmdSmiException = RuntimeError
+    fake_amdsmi.amdsmi_get_gpu_asic_info = lambda handle: {}
+    fake_amdsmi.amdsmi_get_gpu_device_uuid = lambda handle: "fake-uuid"
+    fake_amdsmi.amdsmi_get_processor_handles = lambda: []
+    fake_amdsmi.amdsmi_init = lambda: None
+    fake_amdsmi.amdsmi_shut_down = lambda: None
+    fake_amdsmi.amdsmi_topo_get_link_type = (
+        lambda handle, peer: {"hops": 1, "type": 2}
+    )
+
+    with monkeypatch.context() as m:
+        m.setitem(sys.modules, "amdsmi", fake_amdsmi)
+        m.setattr(torch.cuda, "get_device_properties", fake_get_device_properties)
+
+        rocm = importlib.reload(rocm)
+        assert fallback_calls == 0
+
+        assert rocm.on_gfx950()
+        assert fallback_calls == 1
+
+        rocm._get_gcn_arch.cache_clear()
+        assert rocm.RocmPlatform.supports_fp8()
+        assert fallback_calls == 2
+
+    importlib.reload(rocm)

--- a/tests/utils_/test_system_utils.py
+++ b/tests/utils_/test_system_utils.py
@@ -1,9 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import importlib
 import os
+import sys
 import tempfile
+import types
 from pathlib import Path
+
+import torch
 
 from vllm.utils.system_utils import _maybe_force_spawn, unique_filepath
 
@@ -25,3 +30,45 @@ def test_numa_bind_forces_spawn(monkeypatch):
     monkeypatch.setattr("sys.argv", ["vllm", "serve", "--numa-bind"])
     _maybe_force_spawn()
     assert os.environ["VLLM_WORKER_MULTIPROC_METHOD"] == "spawn"
+
+
+def test_importing_rocm_platform_does_not_force_spawn(monkeypatch):
+    import vllm.platforms.rocm as rocm
+
+    fallback_calls = 0
+
+    def fake_get_device_properties(device):
+        nonlocal fallback_calls
+        fallback_calls += 1
+        return types.SimpleNamespace(gcnArchName="gfx950")
+
+    fake_amdsmi = types.ModuleType("amdsmi")
+    fake_amdsmi.AmdSmiException = RuntimeError
+    fake_amdsmi.amdsmi_get_gpu_asic_info = lambda handle: {}
+    fake_amdsmi.amdsmi_get_gpu_device_uuid = lambda handle: "fake-uuid"
+    fake_amdsmi.amdsmi_get_processor_handles = lambda: []
+    fake_amdsmi.amdsmi_init = lambda: None
+    fake_amdsmi.amdsmi_shut_down = lambda: None
+    fake_amdsmi.amdsmi_topo_get_link_type = (
+        lambda handle, peer: {"hops": 1, "type": 2}
+    )
+
+    with monkeypatch.context() as m:
+        m.delenv("VLLM_WORKER_MULTIPROC_METHOD", raising=False)
+        m.setattr("sys.argv", ["pytest"])
+        m.setitem(sys.modules, "amdsmi", fake_amdsmi)
+        m.setattr(torch.cuda, "_is_compiled", lambda: True)
+        m.setattr(torch.cuda, "is_initialized", lambda: False)
+        m.setattr(torch.cuda, "get_device_properties", fake_get_device_properties)
+        m.setattr("vllm.utils.system_utils.is_in_ray_actor", lambda: False)
+        m.setattr("vllm.utils.system_utils.in_wsl", lambda: False)
+        m.setattr("vllm.utils.system_utils.xpu_is_initialized", lambda: False)
+
+        rocm = importlib.reload(rocm)
+        assert fallback_calls == 0
+
+        _maybe_force_spawn()
+        assert "VLLM_WORKER_MULTIPROC_METHOD" not in os.environ
+        assert fallback_calls == 0
+
+    importlib.reload(rocm)

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -181,6 +181,7 @@ def _get_gcn_arch() -> str:
     return torch.cuda.get_device_properties("cuda").gcnArchName
 
 
+@cache
 def _gcn_arch_contains(*gfx_names: str) -> bool:
     gcn_arch = _get_gcn_arch()
     return any(gfx_name in gcn_arch for gfx_name in gfx_names)

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -160,10 +160,13 @@ def _query_gcn_arch_from_amdsmi() -> str:
     raise RuntimeError("amdsmi did not return valid GCN arch")
 
 
+@cache
 def _get_gcn_arch() -> str:
     """
     Get GCN arch via amdsmi (no CUDA init), fallback to torch.cuda.
-    Called once at module level; result stored in _GCN_ARCH.
+
+    The result is cached lazily so importing vLLM does not initialize HIP
+    before multiprocessing has selected the worker start method.
     """
     try:
         return _query_gcn_arch_from_amdsmi()
@@ -178,18 +181,9 @@ def _get_gcn_arch() -> str:
     return torch.cuda.get_device_properties("cuda").gcnArchName
 
 
-# Resolve once at module load. Uses amdsmi (no CUDA init) so Ray workers
-# can still set CUDA_VISIBLE_DEVICES after import.
-# These are plain Python bools — fully torch.compile/Dynamo safe.
-_GCN_ARCH = _get_gcn_arch()
-
-_ON_GFX1X = any(arch in _GCN_ARCH for arch in ["gfx11", "gfx12"])
-_ON_GFX12X = any(arch in _GCN_ARCH for arch in ["gfx12"])
-_ON_MI3XX = any(arch in _GCN_ARCH for arch in ["gfx942", "gfx950"])
-_ON_GFX9 = any(arch in _GCN_ARCH for arch in ["gfx90a", "gfx942", "gfx950"])
-_ON_GFX90A = "gfx90a" in _GCN_ARCH
-_ON_GFX942 = "gfx942" in _GCN_ARCH
-_ON_GFX950 = "gfx950" in _GCN_ARCH
+def _gcn_arch_contains(*gfx_names: str) -> bool:
+    gcn_arch = _get_gcn_arch()
+    return any(gfx_name in gcn_arch for gfx_name in gfx_names)
 
 
 def _capability_from_gcn_arch(gcn_arch: str) -> tuple[int, int] | None:
@@ -264,31 +258,31 @@ def _capability_from_gcn_arch(gcn_arch: str) -> tuple[int, int] | None:
 
 
 def on_gfx1x() -> bool:
-    return _ON_GFX1X
+    return _gcn_arch_contains("gfx11", "gfx12")
 
 
 def on_gfx12x() -> bool:
-    return _ON_GFX12X
+    return _gcn_arch_contains("gfx12")
 
 
 def on_mi3xx() -> bool:
-    return _ON_MI3XX
+    return _gcn_arch_contains("gfx942", "gfx950")
 
 
 def on_gfx9() -> bool:
-    return _ON_GFX9
+    return _gcn_arch_contains("gfx90a", "gfx942", "gfx950")
 
 
 def on_gfx90a() -> bool:
-    return _ON_GFX90A
+    return _gcn_arch_contains("gfx90a")
 
 
 def on_gfx942() -> bool:
-    return _ON_GFX942
+    return _gcn_arch_contains("gfx942")
 
 
 def on_gfx950() -> bool:
-    return _ON_GFX950
+    return _gcn_arch_contains("gfx950")
 
 
 @cache
@@ -305,7 +299,7 @@ def use_rocm_custom_paged_attention(
 ) -> bool:
     # custom paged attn always supported on V0. On V1, requires sliding window
     # disabled due to observed numerical discrepancy.
-    if _ON_GFX9:
+    if on_gfx9():
         return (
             (sliding_window == 0 or sliding_window == (-1, -1))
             and (qtype == torch.half or qtype == torch.bfloat16)
@@ -318,7 +312,7 @@ def use_rocm_custom_paged_attention(
 
     else:
         return (
-            _ON_GFX1X
+            on_gfx1x()
             and (sliding_window == 0 or sliding_window == (-1, -1))
             and (qtype == torch.half or qtype == torch.bfloat16)
             and head_size == 128
@@ -617,14 +611,15 @@ class RocmPlatform(Platform):
     @classmethod
     @lru_cache(maxsize=8)
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
-        cap = _capability_from_gcn_arch(_GCN_ARCH)
+        gcn_arch = _get_gcn_arch()
+        cap = _capability_from_gcn_arch(gcn_arch)
         if cap is not None:
             return DeviceCapability(major=cap[0], minor=cap[1])
 
         logger.warning_once(
             "Could not derive device capability from GCN arch '%s', "
             "falling back to torch.cuda (this will initialize CUDA).",
-            _GCN_ARCH,
+            gcn_arch,
         )
         major, minor = torch.cuda.get_device_capability(device_id)
         return DeviceCapability(major=major, minor=minor)
@@ -794,16 +789,16 @@ class RocmPlatform(Platform):
 
     @classmethod
     def supports_mx(cls) -> bool:
-        return any(gfx in _GCN_ARCH for gfx in ["gfx95"])
+        return _gcn_arch_contains("gfx95")
 
     @classmethod
     def supports_fp8(cls) -> bool:
-        return any(gfx in _GCN_ARCH for gfx in ["gfx94", "gfx95", "gfx12"])
+        return _gcn_arch_contains("gfx94", "gfx95", "gfx12")
 
     @classmethod
     def is_fp8_fnuz(cls) -> bool:
         # only device 0 is checked, this assumes MI300 platforms are homogeneous
-        return "gfx94" in _GCN_ARCH
+        return _gcn_arch_contains("gfx94")
 
     @classmethod
     def fp8_dtype(cls) -> torch.dtype:
@@ -815,7 +810,7 @@ class RocmPlatform(Platform):
     @classmethod
     def use_custom_allreduce(cls) -> bool:
         # We only enable custom allreduce for MI300 series
-        return any(gfx in _GCN_ARCH for gfx in ["gfx94", "gfx95"])
+        return _gcn_arch_contains("gfx94", "gfx95")
 
     @classmethod
     def opaque_attention_op(cls) -> bool:
@@ -823,7 +818,7 @@ class RocmPlatform(Platform):
 
     @classmethod
     def is_navi(cls) -> bool:
-        return "gfx1" in _GCN_ARCH
+        return _gcn_arch_contains("gfx1")
 
     @classmethod
     def get_static_graph_wrapper_cls(cls) -> str:


### PR DESCRIPTION
## Summary

This PR addresses one likely root cause behind the ROCm `gpt-oss` LoRA TP failure tracked under #34994.

Previously, `vllm.platforms.rocm` resolved GCN arch at module import time and could fall back to `torch.cuda.get_device_properties(...)` when `amdsmi` was unavailable or returned no arch. That fallback initializes HIP/CUDA early, which can cause vLLM to force `VLLM_WORKER_MULTIPROC_METHOD=spawn` before worker startup.

This change makes ROCm GCN arch detection lazy and cached instead of import-time, and updates ROCm capability helpers to read through that lazy path.

It also adds regression coverage for:
- deferred ROCm torch fallback on import
- `_maybe_force_spawn()` not switching to `spawn` just from importing the ROCm platform module

## Why this is not duplicate work

I checked:
- issue comments on #34994
- open PRs referencing `34994`
- open PRs for `test_gptoss_tp.py` / `gptoss_tp` / ROCm LoRA GPT-OSS

I did not find an open PR specifically addressing the ROCm early-HIP-init / forced-spawn path for `tests/lora/test_gptoss_tp.py`.

## Tests run

```bash
.venv/bin/python -m py_compile vllm/platforms/rocm.py tests/test_platform_rocm.py tests/utils_/test_system_utils.py
.venv/bin/python -m pytest tests/test_platform_rocm.py -q --noconftest
.venv/bin/python -m pytest tests/utils_/test_system_utils.py -q --noconftest
```

Results:
- `tests/test_platform_rocm.py`: passed
- `tests/utils_/test_system_utils.py`: passed

## AI assistance

This PR was prepared with AI assistance. I reviewed the changes and test results before submission.

## Follow-up expectation

This PR intentionally does not remove the Buildkite `VLLM_WORKER_MULTIPROC_METHOD=spawn` override yet. The next step depends on ROCm CI results for the LoRA TP job:
- if CI passes, a follow-up can narrow or remove the override
- if CI still fails, the remaining issue is likely in the fused MoE LoRA Triton runtime path rather than import-time HIP initialization