### PR TITLE
[Bugfix] Inaccurate prefix cache metrics

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1493,6 +1493,53 @@ def test_kv_connector_unable_to_allocate(use_ec_connector, ec_role):
     assert len(scheduler.waiting) == 0
 
 
+def test_prefix_cache_stats_not_double_counted_on_alloc_fail():
+    block_size = 16
+    num_tokens = block_size * 6 + 1
+    scheduler = create_scheduler(
+        enable_prefix_caching=True,
+        num_blocks=8,
+        block_size=block_size,
+        max_num_seqs=2,
+        max_num_batched_tokens=4096,
+        skip_tokenizer_init=True,
+    )
+
+    requests = create_requests(
+        num_requests=2,
+        num_tokens=num_tokens,
+        max_tokens=2,
+        block_size=block_size,
+        same_prompt=True,
+    )
+    for request in requests:
+        scheduler.add_request(request)
+
+    output = scheduler.schedule()
+    assert output.num_scheduled_tokens == {requests[0].request_id: num_tokens}
+    stats = scheduler.update_from_output(output, make_output(scheduler))[0]
+    assert stats.scheduler_stats is not None
+    local_stats = stats.scheduler_stats.prefix_cache_stats
+    assert local_stats.queries == num_tokens
+    assert local_stats.hits == 0
+
+    output = scheduler.schedule()
+    assert output.num_scheduled_tokens == {requests[0].request_id: 1}
+    stats = scheduler.update_from_output(output, make_output(scheduler))[0]
+    assert stats.scheduler_stats is not None
+    local_stats = stats.scheduler_stats.prefix_cache_stats
+    assert local_stats.queries == 0
+    assert local_stats.hits == 0
+
+    output = scheduler.schedule()
+    assert output.num_scheduled_tokens == {requests[1].request_id: 1}
+    stats = scheduler.update_from_output(output, make_output(scheduler))[0]
+    assert stats.scheduler_stats is not None
+    local_stats = stats.scheduler_stats.prefix_cache_stats
+    assert local_stats.queries == num_tokens
+    assert local_stats.hits == block_size * 6
+
+
 @pytest.mark.parametrize("is_async", [False, True])
 @pytest.mark.parametrize(
     "use_ec_connector, ec_role", [(False, None), (True, "ec_consumer")]

--- a/tests/v1/engine/test_llm_engine.py
+++ b/tests/v1/engine/test_llm_engine.py
@@ -2,12 +2,17 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import random
 from typing import TYPE_CHECKING
+from unittest.mock import Mock
 
 import pytest
 
 from vllm import LLM
 from vllm.sampling_params import SamplingParams, StructuredOutputsParams
+from vllm.v1.engine import EngineCoreOutputs
+from vllm.v1.engine.llm_engine import LLMEngine
+from vllm.v1.engine.output_processor import OutputProcessorOutput
 from vllm.v1.metrics.reader import Counter, Gauge, Histogram, Metric, Vector
+from vllm.v1.metrics.stats import SchedulerStats
 
 if TYPE_CHECKING:
     from tests.conftest import VllmRunner
@@ -147,6 +152,44 @@ def test_parallel_sampling(vllm_model, example_prompts) -> None:
                 f"{len(completion_counts)} unique completions; expected"
                 f" {n}. Repeats: {repeats}"
             )
+
+
+def test_records_scheduler_stats_with_empty_outputs():
+    llm_engine = object.__new__(LLMEngine)
+    llm_engine.should_execute_dummy_batch = False
+    llm_engine.log_stats = True
+    llm_engine.engine_core = Mock()
+    llm_engine.output_processor = Mock()
+    llm_engine.logger_manager = Mock()
+    llm_engine.renderer = Mock()
+    llm_engine.do_log_stats_with_interval = Mock()
+
+    scheduler_stats = SchedulerStats()
+    llm_engine.engine_core.get_output.return_value = EngineCoreOutputs(
+        outputs=[],
+        scheduler_stats=scheduler_stats,
+    )
+    llm_engine.output_processor.process_outputs.return_value = OutputProcessorOutput(
+        request_outputs=[], reqs_to_abort=[]
+    )
+    llm_engine.renderer.stat_mm_cache.return_value = None
+
+    outputs = llm_engine.step()
+
+    assert outputs == []
+    llm_engine.output_processor.update_scheduler_stats.assert_called_once_with(
+        scheduler_stats
+    )
+    llm_engine.engine_core.abort_requests.assert_called_once_with([])
+    llm_engine.logger_manager.record.assert_called_once()
+    assert llm_engine.logger_manager.record.call_args.kwargs["scheduler_stats"] is (
+        scheduler_stats
+    )
+    assert (
+        llm_engine.logger_manager.record.call_args.kwargs["iteration_stats"] is not None
+    )
+    assert llm_engine.logger_manager.record.call_args.kwargs["mm_cache_stats"] is None
+    llm_engine.do_log_stats_with_interval.assert_called_once()
 
 
 def test_engine_metrics(vllm_runner, example_prompts):

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -205,14 +205,6 @@ class KVCacheManager:
             )
         )
 
-        if self.log_stats:
-            assert self.prefix_cache_stats is not None
-            self.prefix_cache_stats.record(
-                num_tokens=request.num_tokens,
-                num_hits=num_new_computed_tokens,
-                preempted=request.num_preemptions > 0,
-            )
-
         return self.create_kv_cache_blocks(computed_blocks), num_new_computed_tokens
 
     def can_fit_full_sequence(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -763,6 +763,14 @@ class Scheduler(SchedulerInterface):
                         self.encoder_cache_manager.free(request)
                     break
 
+                if self.kv_cache_manager.log_stats:
+                    assert self.kv_cache_manager.prefix_cache_stats is not None
+                    self.kv_cache_manager.prefix_cache_stats.record(
+                        num_tokens=request.num_tokens,
+                        num_hits=num_new_local_computed_tokens,
+                        preempted=request.num_preemptions > 0,
+                    )
+
                 # KVTransfer: the connector uses this info to determine
                 # if a load is needed. Note that
                 # This information is used to determine if a load is

--- a/vllm/v1/engine/llm_engine.py
+++ b/vllm/v1/engine/llm_engine.py
@@ -311,11 +311,7 @@ class LLMEngine:
 
         # 4) Record stats
         with record_function_or_nullcontext("llm_engine step: record_stats"):
-            if (
-                self.logger_manager is not None
-                and outputs.scheduler_stats is not None
-                and len(outputs.outputs) > 0
-            ):
+            if self.logger_manager is not None and outputs.scheduler_stats is not None:
                 self.logger_manager.record(
                     scheduler_stats=outputs.scheduler_stats,
                     iteration_stats=iteration_stats,


### PR DESCRIPTION
## Purpose

Fixes two metric issues:
* "[Bugfix] Metric not updated when output is emtpy":
    * Problem: Offline engine metrics were not updated when a step produces no request outputs. Regression from aa181c923bf83b6f8c4ce5613492a6b410c0c535.
    * Solution: Update metrics even when outputs are empty.
* "[Bugfix] Double-counted prefix cache stats on alloc fail":
    * Problem: When allocate_slots fails (e.g., due to insufficient free blocks), the request stays in the waiting queue with num_computed_tokens == 0. On the next scheduling step, get_computed_blocks is called again, and the prefix cache stats (queries, hits) are recorded a second time. This inflates the reported hit rate.
    * Solution: Move stats recording from get_computed_blocks to the scheduler, after allocation succeeds. This matches the pattern already used for connector_prefix_cache_stats, which records after allocation.

## Examples

### [Bugfix] Metric not updated when output is emtpy

```python
from vllm import LLM, SamplingParams
from vllm.v1.metrics.reader import Counter, Metric

# Four prompts share the same 1600-token prefix and differ only in the last
# 10 tokens, so later requests should see large prefix-cache hits.
prefix = list(range(1600))
prompts = [prefix + list(range(i * 10, (i + 1) * 10)) for i in range(4)]


def get_counter_value(metrics: list[Metric], name: str) -> int:
    return sum(
        metric.value
        for metric in metrics
        if isinstance(metric, Counter) and metric.name == name
    )


def main():
    # max_num_batched_tokens=128 forces the prompt to be processed across many
    # scheduler steps. Some of those steps produce no output tokens, which is
    # the path where the metric update regression showed up.
    llm = LLM(
        model="Qwen/Qwen3-0.6B",
        max_num_seqs=2,
        block_size=256,
        max_num_batched_tokens=128,
        enable_prefix_caching=True,
        enforce_eager=True,
        disable_log_stats=False,
    )

    llm.generate(prompts, SamplingParams(temperature=0.0))

    metrics = llm.get_metrics()
    prefix_queries = get_counter_value(metrics, "vllm:prefix_cache_queries")
    prefix_hits = get_counter_value(metrics, "vllm:prefix_cache_hits")
    print(f"{prefix_queries=}, {prefix_hits=}")
    # before fix:
    # prefix_queries=3220, prefix_hits=3072
    # after fix:
    # prefix_queries=6440, prefix_hits=4608


if __name__ == "__main__":
    main()
```

### [Bugfix] Double-counted prefix cache stats on alloc fail

```python
from vllm import LLM, SamplingParams
from vllm.v1.metrics.reader import Counter, Metric

prompt = list(range(97))
prompts = [prompt.copy(), prompt.copy()]


def get_counter_value(metrics: list[Metric], name: str) -> int:
    return sum(
        metric.value
        for metric in metrics
        if isinstance(metric, Counter) and metric.name == name
    )


def main():
    # With block_size=16, a 97-token prompt has a 96-token full-block prefix hit.
    # Forcing 8 GPU blocks leaves 7 usable blocks, which is enough for one
    # request but not enough for both while the first request is still running.
    llm = LLM(
        model="Qwen/Qwen3-0.6B",
        max_num_seqs=2,
        block_size=16,
        num_gpu_blocks_override=8,
        enable_prefix_caching=True,
        enforce_eager=True,
        disable_log_stats=False,
    )

    # max_tokens=2 keeps the first request alive long enough for the second
    # request to retry after an allocation failure.
    llm.generate(prompts, SamplingParams(temperature=0.0, max_tokens=2))

    metrics = llm.get_metrics()
    prefix_queries = get_counter_value(metrics, "vllm:prefix_cache_queries")
    prefix_hits = get_counter_value(metrics, "vllm:prefix_cache_hits")
    print(f"{prefix_queries=}, {prefix_hits=}")
    # before fix:
    # prefix_queries=388, prefix_hits=288
    # after fix:
    # prefix_queries=194, prefix_hits=96


if __name__ == "__main__":
    main()
```

## Testing

Added unit tests for both fixes:
- `tests/v1/engine/test_llm_engine.py::test_records_scheduler_stats_with_empty_outputs`
- `tests/v1/core/test_scheduler.py::test_prefix_cache_stats_not_double_counted_on_alloc_fail`

## AI assistance
Used Codex to generate the unit tests out of th example scripts.

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>


