### PR TITLE
Add int4 per-token-head KV cache

### DIFF
--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -427,3 +427,40 @@ def test_per_head_quant_scales_backend_selection(
                     use_per_head_quant_scales=True,
                 )
             assert backend_name in str(exc_info.value)
+
+
+@pytest.mark.skipif(
+    current_platform.is_rocm(),
+    reason="This selector regression test targets CUDA FlashAttention gating.",
+)
+def test_flash_attn_rejects_int4_kv_cache():
+    _cached_get_attn_backend.cache_clear()
+
+    attention_config = AttentionConfig(
+        backend=AttentionBackendEnum.FLASH_ATTN,
+        flash_attn_version=3,
+    )
+    cache_config = CacheConfig(block_size=64)
+    vllm_config = VllmConfig(
+        attention_config=attention_config, cache_config=cache_config
+    )
+
+    if CudaPlatform is None:
+        pytest.skip("CudaPlatform not available")
+    with (
+        set_current_vllm_config(vllm_config),
+        patch("vllm.platforms.current_platform", CudaPlatform()),
+    ):
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA is required for FlashAttention selection tests")
+        capability = torch.cuda.get_device_capability()
+        if capability[0] != 9:
+            pytest.skip("FA3 selector path requires Hopper (SM 9.x) GPUs")
+
+        with pytest.raises(ValueError) as exc_info:
+            get_attn_backend(
+                head_size=128,
+                dtype=torch.float16,
+                kv_cache_dtype="int4_per_token_head",
+            )
+        assert "FLASH_ATTN" in str(exc_info.value)

--- a/tests/quantization/test_per_token_kv_cache.py
+++ b/tests/quantization/test_per_token_kv_cache.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Tests for per-token-head KV cache quantization (INT8 and FP8).
+"""Tests for per-token-head KV cache quantization (INT8, INT4 and FP8).
 
 Covers:
 - Per-token-head Triton reshape-and-cache kernel
@@ -17,13 +17,24 @@ from unittest.mock import MagicMock
 
 import pytest
 import torch
+from compressed_tensors.transform import deterministic_hadamard_matrix
 
+from vllm import _custom_ops as ops
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     get_fp8_min_max,
 )
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import set_random_seed
-from vllm.v1.kv_cache_interface import KVQuantMode, is_quantized_kv_cache
+from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
+    INT4_CODEBOOK_LEVELS,
+    INT4_MAGNITUDE_LEVELS,
+)
+from vllm.v1.kv_cache_interface import (
+    INT4_CHANNELS_PER_SCALE,
+    KVQuantMode,
+    get_int4_num_scale_groups,
+    is_quantized_kv_cache,
+)
 
 # Skip entire module if no CUDA/ROCm GPU available
 pytestmark = [
@@ -54,12 +65,13 @@ FP8_MIN, FP8_MAX = get_fp8_min_max()
 class QuantConfig:
     """Quantization parameters for a given cache dtype."""
 
-    cache_dtype: torch.dtype  # torch.int8 or FP8_DTYPE
-    kv_cache_dtype_str: str  # "int8_per_token_head" or "fp8_per_token_head"
+    cache_dtype: torch.dtype
+    kv_cache_dtype_str: str
     quant_max: float
     quant_min: float
     kv_quant_mode: KVQuantMode
-    # INT8 Triton stores truncate; FP8 hardware casts round.
+    scale_dtype: torch.dtype
+    # INT8 Triton stores truncate; FP8 casts round; INT4 uses codebook lookup.
     uses_trunc: bool
 
 
@@ -69,7 +81,17 @@ INT8_CONFIG = QuantConfig(
     quant_max=127.0,
     quant_min=-128.0,
     kv_quant_mode=KVQuantMode.INT8_PER_TOKEN_HEAD,
+    scale_dtype=torch.float32,
     uses_trunc=True,
+)
+INT4_CONFIG = QuantConfig(
+    cache_dtype=torch.uint8,
+    kv_cache_dtype_str="int4_per_token_head",
+    quant_max=1.0,
+    quant_min=0.0,
+    kv_quant_mode=KVQuantMode.INT4_PER_TOKEN_HEAD,
+    scale_dtype=torch.float16,
+    uses_trunc=False,
 )
 FP8_CONFIG = QuantConfig(
     cache_dtype=FP8_DTYPE,
@@ -77,36 +99,144 @@ FP8_CONFIG = QuantConfig(
     quant_max=FP8_MAX,
     quant_min=FP8_MIN,
     kv_quant_mode=KVQuantMode.FP8_PER_TOKEN_HEAD,
+    scale_dtype=torch.float32,
     uses_trunc=False,
 )
 
-QUANT_CONFIGS = [INT8_CONFIG, FP8_CONFIG]
+QUANT_CONFIGS = [INT8_CONFIG, INT4_CONFIG, FP8_CONFIG]
 
 
-@pytest.fixture(params=QUANT_CONFIGS, ids=["int8", "fp8"])
+@pytest.fixture(params=QUANT_CONFIGS, ids=["int8", "int4", "fp8"])
 def qcfg(request) -> QuantConfig:
-    return request.param
+    cfg = request.param
+    if (
+        cfg.kv_quant_mode == KVQuantMode.FP8_PER_TOKEN_HEAD
+        and not current_platform.supports_fp8()
+    ):
+        pytest.skip("FP8 per-token-head tests require FP8-capable hardware.")
+    return cfg
 
 
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+INT4_MAGNITUDE_LEVELS_T = torch.tensor(INT4_MAGNITUDE_LEVELS, dtype=torch.float32)
+INT4_CODEBOOK_LEVELS_T = torch.tensor(INT4_CODEBOOK_LEVELS, dtype=torch.float32)
+
+
+def _packed_head_size(head_size: int, cfg: QuantConfig) -> int:
+    if cfg.kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD:
+        return (head_size + 1) // 2
+    return head_size
+
+
+def _allocate_cache_tensors(
+    num_blocks: int,
+    block_size: int,
+    num_heads: int,
+    head_size: int,
+    cfg: QuantConfig,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    cache_head_size = _packed_head_size(head_size, cfg)
+    key_cache = torch.zeros(
+        num_blocks, block_size, num_heads, cache_head_size, dtype=cfg.cache_dtype
+    )
+    value_cache = torch.zeros_like(key_cache)
+    scale_shape = (
+        (num_blocks, block_size, num_heads, get_int4_num_scale_groups(head_size))
+        if cfg.kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD
+        else (num_blocks, block_size, num_heads)
+    )
+    k_scale_cache = torch.ones(scale_shape, dtype=cfg.scale_dtype)
+    v_scale_cache = torch.ones_like(k_scale_cache)
+    return key_cache, value_cache, k_scale_cache, v_scale_cache
+
+
 def _quantize_per_token_head_ref(
-    data: torch.Tensor,  # [num_tokens, num_heads, head_size]
+    data: torch.Tensor,
     cfg: QuantConfig,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Reference per-token-head quantization (one scale per token per head).
 
-    Returns (quantized, scales) where scales is [num_tokens, num_heads].
+    Supports arbitrary leading dimensions with the last dimension treated as
+    the head dimension.
     """
-    absmax = data.float().abs().amax(dim=2)  # [num_tokens, num_heads]
-    scales = (absmax / cfg.quant_max).clamp(min=1e-6)
-    scaled = data.float() * (1.0 / scales[:, :, None])
+    absmax = data.float().abs().amax(dim=-1)
+    if cfg.kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD:
+        num_scale_groups = get_int4_num_scale_groups(data.shape[-1])
+        scales = torch.empty(
+            *data.shape[:-1],
+            num_scale_groups,
+            device=data.device,
+            dtype=cfg.scale_dtype,
+        )
+        normalized = torch.empty_like(data, dtype=torch.float32)
+        for group_idx in range(num_scale_groups):
+            start = group_idx * INT4_CHANNELS_PER_SCALE
+            end = min(start + INT4_CHANNELS_PER_SCALE, data.shape[-1])
+            group = data[..., start:end].float()
+            group_scale = group.abs().amax(dim=-1).clamp(min=1e-6)
+            scales[..., group_idx] = group_scale.to(cfg.scale_dtype)
+            normalized[..., start:end] = group / group_scale.unsqueeze(-1)
+        level_dist = torch.abs(
+            normalized.abs().unsqueeze(-1) - INT4_MAGNITUDE_LEVELS_T.to(data.device)
+        )
+        mag_idx = level_dist.argmin(dim=-1).to(torch.uint8)
+        signed_idx = mag_idx | ((normalized < 0).to(torch.uint8) << 3)
+        packed = torch.zeros(
+            *data.shape[:-1],
+            (data.shape[-1] + 1) // 2,
+            dtype=torch.uint8,
+            device=data.device,
+        )
+        packed.copy_(signed_idx[..., ::2])
+        packed[..., : signed_idx[..., 1::2].shape[-1]] |= signed_idx[..., 1::2] << 4
+        return packed, scales
+
+    scales = (absmax / cfg.quant_max).clamp(min=1e-6).to(cfg.scale_dtype)
+    scaled = data.float() * (1.0 / scales.unsqueeze(-1).float())
     if cfg.uses_trunc:
         q = scaled.round().clamp(cfg.quant_min, cfg.quant_max).to(cfg.cache_dtype)
     else:
         q = scaled.clamp(cfg.quant_min, cfg.quant_max).to(cfg.cache_dtype)
     return q, scales
+
+
+def _dequantize_per_token_head_ref(
+    q: torch.Tensor,
+    scales: torch.Tensor,
+    cfg: QuantConfig,
+    head_size: int,
+) -> torch.Tensor:
+    if cfg.kv_quant_mode != KVQuantMode.INT4_PER_TOKEN_HEAD:
+        return q.float() * scales.unsqueeze(-1).float()
+
+    lo = (q & 0x0F).to(torch.int32)
+    hi = ((q >> 4) & 0x0F).to(torch.int32)
+    packed = torch.stack((lo, hi), dim=-1).reshape(*q.shape[:-1], -1)[..., :head_size]
+    levels = INT4_CODEBOOK_LEVELS_T.to(q.device)[packed]
+    group_idx = (
+        torch.arange(head_size, device=q.device) // INT4_CHANNELS_PER_SCALE
+    ).view(*([1] * (levels.dim() - 1)), head_size)
+    group_scales = torch.take_along_dim(
+        scales.float(), group_idx.expand(*levels.shape[:-1], head_size), dim=-1
+    )
+    return levels * group_scales
+
+
+def _dequantize_symmetric_linear_int4_ref(data: torch.Tensor) -> torch.Tensor:
+    absmax = data.float().abs().amax(dim=-1, keepdim=True).clamp(min=1e-6)
+    scale = absmax / 7.0
+    q = torch.round(data.float() / scale).clamp(-7, 7)
+    return q * scale
+
+
+def _apply_hadamard_ref(data: torch.Tensor) -> torch.Tensor:
+    head_size = data.shape[-1]
+    hadamard = deterministic_hadamard_matrix(
+        head_size, dtype=torch.float64, device=data.device
+    ) / head_size**0.5
+    return (data.to(torch.float64) @ hadamard.T).to(torch.float32)
 
 
 # ===========================================================================
@@ -120,6 +250,9 @@ class TestIsQuantizedKvCache:
 
     def test_int8_per_token_head(self):
         assert is_quantized_kv_cache("int8_per_token_head")
+
+    def test_int4_per_token_head(self):
+        assert is_quantized_kv_cache("int4_per_token_head")
 
     def test_fp8_per_token_head(self):
         assert is_quantized_kv_cache("fp8_per_token_head")
@@ -142,6 +275,13 @@ class TestIsQuantizedKvCache:
 
         assert get_kv_quant_mode("fp8_per_token_head") == KVQuantMode.FP8_PER_TOKEN_HEAD
 
+    def test_kv_quant_mode_int4(self):
+        from vllm.v1.kv_cache_interface import get_kv_quant_mode
+
+        assert (
+            get_kv_quant_mode("int4_per_token_head") == KVQuantMode.INT4_PER_TOKEN_HEAD
+        )
+
 
 # ===========================================================================
 # 2. Triton per-token-head kernel (reshape-and-cache)
@@ -160,8 +300,9 @@ def test_reshape_and_cache_per_token_head(
     block_size: int,
     seed: int,
 ):
-    """Test triton_reshape_and_cache_flash_per_token_head_quant kernel."""
+    """Test per-token-head reshape-and-cache kernels."""
     from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
+        triton_reshape_and_cache_flash_int4_per_token_head,
         triton_reshape_and_cache_flash_per_token_head_quant,
     )
 
@@ -173,33 +314,45 @@ def test_reshape_and_cache_per_token_head(
     key = torch.randn(num_tokens, num_heads, head_size, dtype=torch.bfloat16)
     value = torch.randn(num_tokens, num_heads, head_size, dtype=torch.bfloat16)
 
-    key_cache = torch.zeros(
-        num_blocks, block_size, num_heads, head_size, dtype=qcfg.cache_dtype
+    key_cache, value_cache, k_scale_cache, v_scale_cache = _allocate_cache_tensors(
+        num_blocks, block_size, num_heads, head_size, qcfg
     )
-    value_cache = torch.zeros(
-        num_blocks, block_size, num_heads, head_size, dtype=qcfg.cache_dtype
-    )
-    k_scale_cache = torch.ones(num_blocks, block_size, num_heads, dtype=torch.float32)
-    v_scale_cache = torch.ones(num_blocks, block_size, num_heads, dtype=torch.float32)
 
     num_slots = block_size * num_blocks
     slot_mapping = torch.tensor(
         random.sample(range(num_slots), num_tokens), dtype=torch.long
     )
 
-    triton_reshape_and_cache_flash_per_token_head_quant(
-        key,
-        value,
-        key_cache,
-        value_cache,
-        k_scale_cache,
-        v_scale_cache,
-        slot_mapping,
-    )
+    if qcfg.kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD:
+        triton_reshape_and_cache_flash_int4_per_token_head(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            k_scale_cache,
+            v_scale_cache,
+            slot_mapping,
+        )
+    else:
+        triton_reshape_and_cache_flash_per_token_head_quant(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            k_scale_cache,
+            v_scale_cache,
+            slot_mapping,
+        )
 
     # Reference
     ref_k_quant, ref_k_scales = _quantize_per_token_head_ref(key, qcfg)
     ref_v_quant, ref_v_scales = _quantize_per_token_head_ref(value, qcfg)
+    ref_k_deq = _dequantize_per_token_head_ref(
+        ref_k_quant, ref_k_scales, qcfg, head_size
+    )
+    ref_v_deq = _dequantize_per_token_head_ref(
+        ref_v_quant, ref_v_scales, qcfg, head_size
+    )
 
     # Compare dequantized values rather than raw quantized values.
     # Triton and PyTorch reductions can differ at FP8 rounding boundaries
@@ -209,30 +362,34 @@ def test_reshape_and_cache_per_token_head(
         blk = slot // block_size
         off = slot % block_size
 
-        actual_k_scale = k_scale_cache[blk, off]  # [num_heads]
-        k_deq = key_cache[blk, off].float() * actual_k_scale[:, None]
-        k_ref_deq = key[i].float()
+        actual_k_scale = k_scale_cache[blk, off]
+        k_deq = _dequantize_per_token_head_ref(
+            key_cache[blk, off][None], actual_k_scale[None], qcfg, head_size
+        )[0]
+        k_ref_deq = ref_k_deq[i].float()
         torch.testing.assert_close(
             k_deq,
             k_ref_deq,
-            atol=0.1,
-            rtol=0.1,
+            atol=0.12 if qcfg.kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD else 0.1,
+            rtol=0.12 if qcfg.kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD else 0.1,
         )
-        actual_v_scale = v_scale_cache[blk, off]  # [num_heads]
-        v_deq = value_cache[blk, off].float() * actual_v_scale[:, None]
-        v_ref_deq = value[i].float()
+        actual_v_scale = v_scale_cache[blk, off]
+        v_deq = _dequantize_per_token_head_ref(
+            value_cache[blk, off][None], actual_v_scale[None], qcfg, head_size
+        )[0]
+        v_ref_deq = ref_v_deq[i].float()
         torch.testing.assert_close(
             v_deq,
             v_ref_deq,
-            atol=0.1,
-            rtol=0.1,
+            atol=0.12 if qcfg.kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD else 0.1,
+            rtol=0.12 if qcfg.kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD else 0.1,
         )
         # Per-head scales: [num_heads]
         torch.testing.assert_close(
-            k_scale_cache[blk, off], ref_k_scales[i], atol=1e-4, rtol=1e-3
+            k_scale_cache[blk, off].float(), ref_k_scales[i].float(), atol=1e-4, rtol=1e-3
         )
         torch.testing.assert_close(
-            v_scale_cache[blk, off], ref_v_scales[i], atol=1e-4, rtol=1e-3
+            v_scale_cache[blk, off].float(), ref_v_scales[i].float(), atol=1e-4, rtol=1e-3
         )
 
 
@@ -257,6 +414,7 @@ def test_per_token_head_round_trip_accuracy(
     FP8: hardware cast (clamp then cast).
     """
     from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
+        triton_reshape_and_cache_flash_int4_per_token_head,
         triton_reshape_and_cache_flash_per_token_head_quant,
     )
 
@@ -268,26 +426,32 @@ def test_per_token_head_round_trip_accuracy(
     key = torch.randn(num_tokens, num_heads, head_size, dtype=torch.bfloat16) * 0.5
     value = torch.randn(num_tokens, num_heads, head_size, dtype=torch.bfloat16) * 0.5
 
-    key_cache = torch.zeros(
-        num_blocks, block_size, num_heads, head_size, dtype=qcfg.cache_dtype
+    key_cache, value_cache, k_scale_cache, v_scale_cache = _allocate_cache_tensors(
+        num_blocks, block_size, num_heads, head_size, qcfg
     )
-    value_cache = torch.zeros(
-        num_blocks, block_size, num_heads, head_size, dtype=qcfg.cache_dtype
-    )
-    k_scale_cache = torch.ones(num_blocks, block_size, num_heads, dtype=torch.float32)
-    v_scale_cache = torch.ones(num_blocks, block_size, num_heads, dtype=torch.float32)
 
     slot_mapping = torch.arange(num_tokens, dtype=torch.long)
 
-    triton_reshape_and_cache_flash_per_token_head_quant(
-        key,
-        value,
-        key_cache,
-        value_cache,
-        k_scale_cache,
-        v_scale_cache,
-        slot_mapping,
-    )
+    if qcfg.kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD:
+        triton_reshape_and_cache_flash_int4_per_token_head(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            k_scale_cache,
+            v_scale_cache,
+            slot_mapping,
+        )
+    else:
+        triton_reshape_and_cache_flash_per_token_head_quant(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            k_scale_cache,
+            v_scale_cache,
+            slot_mapping,
+        )
 
     for i in range(num_tokens):
         blk = i // block_size
@@ -300,17 +464,276 @@ def test_per_token_head_round_trip_accuracy(
             for h in range(num_heads):
                 orig = data[i, h].float()  # [head_size]
 
-                actual_q = cache[blk, off, h]
-                actual_sc = sc[blk, off, h]
-                actual_deq = actual_q.float() * actual_sc
+                actual_q = cache[blk, off, h][None, None]
+                actual_sc = sc[blk, off, h][None, None]
+                actual_deq = _dequantize_per_token_head_ref(
+                    actual_q, actual_sc, qcfg, head_size
+                )[0, 0]
 
                 # Round-trip: dequantized should be close to original
                 torch.testing.assert_close(
                     actual_deq,
                     orig,
-                    atol=0.1,
-                    rtol=0.1,
+                    atol=0.12 if qcfg.kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD else 0.1,
+                    rtol=0.12 if qcfg.kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD else 0.1,
                 )
+
+
+@pytest.mark.parametrize("head_size", [64, 128])
+@torch.inference_mode()
+def test_int4_gaussian_codebook_beats_linear_int4_mse(head_size: int):
+    torch.set_default_device("cuda")
+    set_random_seed(123)
+
+    key = torch.randn(256, 8, head_size, dtype=torch.bfloat16)
+    value = torch.randn(256, 8, head_size, dtype=torch.bfloat16)
+
+    for label, data in [("key", key), ("value", value)]:
+        quantized, scales = _quantize_per_token_head_ref(data, INT4_CONFIG)
+        gaussian_deq = _dequantize_per_token_head_ref(
+            quantized, scales, INT4_CONFIG, head_size
+        )
+        linear_deq = _dequantize_symmetric_linear_int4_ref(data)
+
+        gaussian_mse = (data.float() - gaussian_deq.float()).square().mean()
+        linear_mse = (data.float() - linear_deq.float()).square().mean()
+
+        assert gaussian_mse < linear_mse, (
+            f"{label} Gaussian-friendly int4 should beat symmetric linear int4 "
+            f"for normal inputs, got {gaussian_mse.item():.6f} >= "
+            f"{linear_mse.item():.6f}"
+        )
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="Hadamard-backed int4 path is currently CUDA-only.",
+)
+@torch.inference_mode()
+def test_int4_hadamard_helper_preserves_fp16_signal_out_of_place():
+    from vllm.v1.attention.backends.triton_attn import TritonAttentionImpl
+
+    torch.set_default_device("cuda")
+    set_random_seed(777)
+
+    impl = TritonAttentionImpl(
+        num_heads=4,
+        head_size=128,
+        scale=128**-0.5,
+        num_kv_heads=4,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="int4_per_token_head",
+    )
+
+    x = torch.randn(8, 4, 128, dtype=torch.float16)
+    x_before = x.clone()
+    y = impl._maybe_hadamard_transform(x, inplace=False)
+
+    assert y.dtype == x.dtype
+    assert torch.count_nonzero(y).item() > 0
+    torch.testing.assert_close(x, x_before)
+
+    x_norm = x.float().norm(dim=-1)
+    y_norm = y.float().norm(dim=-1)
+    torch.testing.assert_close(y_norm, x_norm, atol=1e-1, rtol=1e-1)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="Hadamard-backed int4 path is currently CUDA-only.",
+)
+@torch.inference_mode()
+def test_int4_hadamard_helper_reuses_workspace_out_of_place(workspace_init):
+    from vllm.v1.attention.backends.triton_attn import TritonAttentionImpl
+    from vllm.v1.worker.workspace import current_workspace_manager
+
+    torch.set_default_device("cuda")
+    set_random_seed(778)
+
+    impl = TritonAttentionImpl(
+        num_heads=4,
+        head_size=128,
+        scale=128**-0.5,
+        num_kv_heads=4,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="int4_per_token_head",
+    )
+
+    x = torch.randn(8, 4, 128, dtype=torch.float16)
+    y = impl._maybe_hadamard_transform(x, inplace=False)
+
+    workspace = current_workspace_manager()._current_workspaces[0]
+    assert workspace is not None
+    assert y.untyped_storage().data_ptr() == workspace.untyped_storage().data_ptr()
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="Hadamard-backed int4 path is currently CUDA-only.",
+)
+@torch.inference_mode()
+def test_int4_encoder_attention_skips_hadamard_query_transform():
+    from vllm.v1.attention.backend import AttentionType
+    from vllm.v1.attention.backends.triton_attn import TritonAttentionImpl
+
+    torch.set_default_device("cuda")
+
+    impl = TritonAttentionImpl(
+        num_heads=4,
+        head_size=128,
+        scale=128**-0.5,
+        num_kv_heads=4,
+        alibi_slopes=None,
+        sliding_window=None,
+        kv_cache_dtype="int4_per_token_head",
+        attn_type=AttentionType.ENCODER_ONLY,
+    )
+    impl._maybe_hadamard_transform = MagicMock(side_effect=AssertionError("unexpected"))
+
+    attn_metadata = MagicMock(use_cascade=False, num_actual_tokens=2)
+    query = torch.randn(2, 4, 128, dtype=torch.float16)
+    key = torch.randn(2, 4, 128, dtype=torch.float16)
+    value = torch.randn(2, 4, 128, dtype=torch.float16)
+    kv_cache = torch.empty(0, dtype=torch.uint8)
+    output = torch.empty_like(query)
+
+    with pytest.raises(NotImplementedError, match="quantized KV cache"):
+        impl.forward(
+            layer=MagicMock(),
+            query=query,
+            key=key,
+            value=value,
+            kv_cache=kv_cache,
+            attn_metadata=attn_metadata,
+            output=output,
+        )
+
+    impl._maybe_hadamard_transform.assert_not_called()
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="Hadamard-backed int4 path is currently CUDA-only.",
+)
+@pytest.mark.parametrize("head_size", [64, 128])
+@torch.inference_mode()
+def test_int4_hadamard_round_trip_preserves_attention_semantics(head_size: int):
+    from vllm.utils.math_utils import next_power_of_2
+    from vllm.v1.attention.ops.triton_unified_attention import unified_attention
+
+    torch.set_default_device("cuda")
+    set_random_seed(321)
+
+    num_seqs = 2
+    query_lens = [1, 1]
+    kv_lens = [64, 96]
+    num_query_heads = 4
+    num_kv_heads = 4
+    block_size = 16
+    num_blocks = 512
+    scale = head_size**-0.5
+
+    query = torch.randn(sum(query_lens), num_query_heads, head_size, dtype=torch.bfloat16)
+    key_cache = torch.randn(
+        num_blocks, block_size, num_kv_heads, head_size, dtype=torch.bfloat16
+    )
+    value_cache = torch.randn_like(key_cache)
+
+    query_h = ops.hadacore_transform(
+        query.reshape(-1, head_size).contiguous(), inplace=False
+    ).view_as(query)
+    key_cache_h = ops.hadacore_transform(
+        key_cache.reshape(-1, head_size).contiguous(), inplace=False
+    ).view_as(key_cache)
+    key_cache_q, k_scale_cache = _quantize_per_token_head_ref(key_cache_h, INT4_CONFIG)
+    value_cache_q, v_scale_cache = _quantize_per_token_head_ref(value_cache, INT4_CONFIG)
+
+    cu_query_lens = torch.tensor([0] + query_lens, dtype=torch.int32).cumsum(
+        dim=0, dtype=torch.int32
+    )
+    kv_lens_t = torch.tensor(kv_lens, dtype=torch.int32)
+    max_num_blocks_per_seq = (max(kv_lens) + block_size - 1) // block_size
+    block_tables = torch.randint(
+        0, num_blocks, (num_seqs, max_num_blocks_per_seq), dtype=torch.int32
+    )
+
+    head_size_padded = next_power_of_2(head_size)
+    seq_threshold_3D = 0
+    num_par_softmax_segments = 16
+    softmax_segm_output = torch.empty(
+        (seq_threshold_3D, num_query_heads, num_par_softmax_segments, head_size_padded),
+        dtype=torch.float32,
+    )
+    softmax_segm_max = torch.empty(
+        (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+        dtype=torch.float32,
+    )
+    softmax_segm_expsum = torch.empty(
+        (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+        dtype=torch.float32,
+    )
+
+    output_h = torch.empty_like(query)
+    unified_attention(
+        q=query_h,
+        k=key_cache_q,
+        v=value_cache_q,
+        out=output_h,
+        cu_seqlens_q=cu_query_lens,
+        seqused_k=kv_lens_t,
+        max_seqlen_q=max(query_lens),
+        max_seqlen_k=max(kv_lens),
+        softmax_scale=scale,
+        causal=True,
+        window_size=(-1, -1),
+        block_table=block_tables,
+        softcap=0,
+        q_descale=None,
+        k_descale=None,
+        v_descale=None,
+        seq_threshold_3D=seq_threshold_3D,
+        num_par_softmax_segments=num_par_softmax_segments,
+        softmax_segm_output=softmax_segm_output,
+        softmax_segm_max=softmax_segm_max,
+        softmax_segm_expsum=softmax_segm_expsum,
+        kv_quant_mode=INT4_CONFIG.kv_quant_mode,
+        k_scale_cache=k_scale_cache,
+        v_scale_cache=v_scale_cache,
+    )
+    key_cache_h_deq = _dequantize_per_token_head_ref(
+        key_cache_q, k_scale_cache, INT4_CONFIG, head_size
+    ).to(torch.bfloat16)
+    value_cache_h_deq = _dequantize_per_token_head_ref(
+        value_cache_q, v_scale_cache, INT4_CONFIG, head_size
+    ).to(torch.bfloat16)
+
+    output_ref = torch.empty_like(query)
+    unified_attention(
+        q=query_h,
+        k=key_cache_h_deq,
+        v=value_cache_h_deq,
+        out=output_ref,
+        cu_seqlens_q=cu_query_lens,
+        seqused_k=kv_lens_t,
+        max_seqlen_q=max(query_lens),
+        max_seqlen_k=max(kv_lens),
+        softmax_scale=scale,
+        causal=True,
+        window_size=(-1, -1),
+        block_table=block_tables,
+        softcap=0,
+        q_descale=None,
+        k_descale=None,
+        v_descale=None,
+        seq_threshold_3D=seq_threshold_3D,
+        num_par_softmax_segments=num_par_softmax_segments,
+        softmax_segm_output=softmax_segm_output,
+        softmax_segm_max=softmax_segm_max,
+        softmax_segm_expsum=softmax_segm_expsum,
+    )
+    torch.testing.assert_close(output_h, output_ref, atol=1e-1, rtol=1e-1)
 
 
 # ===========================================================================
@@ -320,6 +743,7 @@ def test_per_token_head_round_trip_accuracy(
 def test_per_token_head_negative_slot_skipped(qcfg: QuantConfig):
     """Tokens with slot_mapping=-1 should leave the cache unchanged."""
     from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
+        triton_reshape_and_cache_flash_int4_per_token_head,
         triton_reshape_and_cache_flash_per_token_head_quant,
     )
 
@@ -333,29 +757,35 @@ def test_per_token_head_negative_slot_skipped(qcfg: QuantConfig):
     key = torch.randn(num_tokens, num_heads, head_size, dtype=torch.bfloat16)
     value = torch.randn(num_tokens, num_heads, head_size, dtype=torch.bfloat16)
 
-    key_cache = torch.zeros(
-        num_blocks, block_size, num_heads, head_size, dtype=qcfg.cache_dtype
+    key_cache, value_cache, k_scale_cache, v_scale_cache = _allocate_cache_tensors(
+        num_blocks, block_size, num_heads, head_size, qcfg
     )
-    value_cache = torch.zeros(
-        num_blocks, block_size, num_heads, head_size, dtype=qcfg.cache_dtype
-    )
-    k_scale_cache = torch.ones(num_blocks, block_size, num_heads, dtype=torch.float32)
-    v_scale_cache = torch.ones(num_blocks, block_size, num_heads, dtype=torch.float32)
 
     slot_mapping = torch.tensor([0, -1, 1, -1], dtype=torch.long)
 
     key_cache_before = key_cache.clone()
     val_cache_before = value_cache.clone()
 
-    triton_reshape_and_cache_flash_per_token_head_quant(
-        key,
-        value,
-        key_cache,
-        value_cache,
-        k_scale_cache,
-        v_scale_cache,
-        slot_mapping,
-    )
+    if qcfg.kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD:
+        triton_reshape_and_cache_flash_int4_per_token_head(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            k_scale_cache,
+            v_scale_cache,
+            slot_mapping,
+        )
+    else:
+        triton_reshape_and_cache_flash_per_token_head_quant(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            k_scale_cache,
+            v_scale_cache,
+            slot_mapping,
+        )
 
     # Slots 0 and 1 should have been written (tokens 0 and 2)
     assert not torch.equal(key_cache[0, 0], key_cache_before[0, 0])
@@ -372,7 +802,8 @@ def test_per_token_head_negative_slot_skipped(qcfg: QuantConfig):
 # 5. process_weights_after_loading -- per-token-head early return
 # ===========================================================================
 @pytest.mark.parametrize(
-    "kv_cache_dtype", ["int8_per_token_head", "fp8_per_token_head"]
+    "kv_cache_dtype",
+    ["int8_per_token_head", "int4_per_token_head", "fp8_per_token_head"],
 )
 def test_process_weights_sets_placeholder_scales(kv_cache_dtype: str):
     """Per-token-head should set _k_scale=1.0, _v_scale=1.0
@@ -406,7 +837,7 @@ def test_process_weights_sets_placeholder_scales(kv_cache_dtype: str):
 
 
 # ===========================================================================
-# 6. Triton unified_attention -- per-token-head scale cache (INT8 and FP8)
+# 6. Triton unified_attention -- per-token-head scale cache
 # ===========================================================================
 @pytest.mark.parametrize(
     "seq_lens",
@@ -451,32 +882,14 @@ def test_triton_unified_attention_per_token_head_scale(
     )
     value_cache_bf16 = torch.randn_like(key_cache_bf16)
 
-    # Per-token-head quantization: one scale per (block, slot, head)
-    k_absmax = key_cache_bf16.float().abs().amax(dim=-1)  # [..., num_kv_heads]
-    v_absmax = value_cache_bf16.float().abs().amax(dim=-1)
-    k_scale_cache = (k_absmax / qcfg.quant_max).clamp(min=1e-6).to(torch.float32)
-    v_scale_cache = (v_absmax / qcfg.quant_max).clamp(min=1e-6).to(torch.float32)
-
-    scaled_k = key_cache_bf16.float() / k_scale_cache[:, :, :, None]
-    scaled_v = value_cache_bf16.float() / v_scale_cache[:, :, :, None]
-    if qcfg.uses_trunc:
-        key_cache_q = (
-            scaled_k.round().clamp(qcfg.quant_min, qcfg.quant_max).to(qcfg.cache_dtype)
-        )
-        value_cache_q = (
-            scaled_v.round().clamp(qcfg.quant_min, qcfg.quant_max).to(qcfg.cache_dtype)
-        )
-    else:
-        key_cache_q = scaled_k.clamp(qcfg.quant_min, qcfg.quant_max).to(
-            qcfg.cache_dtype
-        )
-        value_cache_q = scaled_v.clamp(qcfg.quant_min, qcfg.quant_max).to(
-            qcfg.cache_dtype
-        )
-
-    # Dequantized reference
-    key_cache_deq = key_cache_q.float() * k_scale_cache[:, :, :, None]
-    value_cache_deq = value_cache_q.float() * v_scale_cache[:, :, :, None]
+    key_cache_q, k_scale_cache = _quantize_per_token_head_ref(key_cache_bf16, qcfg)
+    value_cache_q, v_scale_cache = _quantize_per_token_head_ref(value_cache_bf16, qcfg)
+    key_cache_deq = _dequantize_per_token_head_ref(
+        key_cache_q, k_scale_cache, qcfg, head_size
+    )
+    value_cache_deq = _dequantize_per_token_head_ref(
+        value_cache_q, v_scale_cache, qcfg, head_size
+    )
 
     cu_query_lens = torch.tensor([0] + query_lens, dtype=torch.int32).cumsum(
         dim=0, dtype=torch.int32
@@ -557,4 +970,6 @@ def test_triton_unified_attention_per_token_head_scale(
         softmax_segm_expsum=softmax_segm_expsum,
     )
 
-    torch.testing.assert_close(output_q, output_ref, atol=5e-2, rtol=5e-2)
+    atol = 1e-1 if qcfg.kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD else 5e-2
+    rtol = 1e-1 if qcfg.kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD else 5e-2
+    torch.testing.assert_close(output_q, output_ref, atol=atol, rtol=rtol)

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -43,6 +43,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheSpec,
     KVCacheTensor,
+    KVQuantMode,
     MambaSpec,
     MLAAttentionSpec,
     SlidingWindowSpec,
@@ -2137,3 +2138,60 @@ def test_unify_hybrid_kv_cache_specs():
 
     with pytest.raises(ValueError):
         kv_cache_utils.unify_hybrid_kv_cache_specs(kv_cache_spec)
+
+
+def test_unify_kv_cache_spec_page_size_pads_non_divisible_attention_spec():
+    smaller_spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=8,
+        head_size=64,
+        dtype=torch.float16,
+        kv_quant_mode=KVQuantMode.INT4_PER_TOKEN_HEAD,
+    )
+    larger_spec = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=8,
+        head_size=96,
+        dtype=torch.float16,
+        kv_quant_mode=KVQuantMode.INT4_PER_TOKEN_HEAD,
+        sliding_window=1024,
+    )
+    assert larger_spec.page_size_bytes > smaller_spec.page_size_bytes
+    assert larger_spec.page_size_bytes % smaller_spec.page_size_bytes != 0
+
+    kv_cache_spec = {
+        "full": smaller_spec,
+        "sliding": larger_spec,
+    }
+
+    unified = kv_cache_utils.unify_kv_cache_spec_page_size(kv_cache_spec)
+
+    assert unified["sliding"] == larger_spec
+    assert unified["full"].block_size == smaller_spec.block_size
+    assert unified["full"].page_size_padded == larger_spec.page_size_bytes
+    assert unified["full"].page_size_bytes == unified["sliding"].page_size_bytes
+    assert unified["full"].real_page_size_bytes == smaller_spec.real_page_size_bytes
+
+
+def test_unify_kv_cache_spec_page_size_rejects_non_attention_padding():
+    attention_spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=8,
+        head_size=96,
+        dtype=torch.float16,
+        kv_quant_mode=KVQuantMode.INT4_PER_TOKEN_HEAD,
+    )
+    mamba_spec = new_mamba_spec(
+        block_size=16,
+        shapes=((33,),),
+        dtypes=(torch.float16,),
+    )
+    assert attention_spec.page_size_bytes % mamba_spec.page_size_bytes != 0
+
+    with pytest.raises(NotImplementedError):
+        kv_cache_utils.unify_kv_cache_spec_page_size(
+            {
+                "attention": attention_spec,
+                "mamba": mamba_spec,
+            }
+        )

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -25,6 +25,7 @@ CacheDType = Literal[
     "fp8_inc",
     "fp8_ds_mla",
     "int8_per_token_head",
+    "int4_per_token_head",
     "fp8_per_token_head",
 ]
 MambaDType = Literal["auto", "float32", "float16"]

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -39,6 +39,7 @@ STR_DTYPE_TO_TORCH_DTYPE = {
     "fp8_e5m2": torch.uint8,
     "int8": torch.int8,
     "int8_per_token_head": torch.int8,
+    "int4_per_token_head": torch.uint8,
     "fp8_per_token_head": torch.uint8,
     "fp8_inc": torch.float8_e4m3fn,
     "fp8_ds_mla": torch.uint8,

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -183,7 +183,7 @@ class FlashAttentionBackend(AttentionBackend):
     def supports_kv_cache_dtype(cls, kv_cache_dtype: CacheDType | None) -> bool:
         if kv_cache_dtype is None:
             return True
-        if is_quantized_kv_cache(kv_cache_dtype):
+        if kv_cache_dtype in ("fp8", "fp8_e4m3", "fp8_e5m2"):
             return flash_attn_supports_fp8()
         return kv_cache_dtype in ["auto", "float16", "bfloat16"]
 

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -7,6 +7,7 @@ from typing import ClassVar
 
 import torch
 
+from vllm import _custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import CUDAGraphMode, VllmConfig
 from vllm.config.cache import CacheDType
@@ -33,13 +34,21 @@ from vllm.v1.attention.backends.utils import get_kv_cache_layout
 from vllm.v1.attention.ops.triton_prefill_attention import context_attention_fwd
 from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
     triton_reshape_and_cache_flash,
+    triton_reshape_and_cache_flash_int4_per_token_head,
     triton_reshape_and_cache_flash_per_token_head_quant,
 )
 from vllm.v1.attention.ops.triton_unified_attention import unified_attention
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
+    KVQuantMode,
     get_kv_quant_mode,
+    get_per_token_head_scale_count,
+    get_per_token_head_scale_dtype,
     kv_cache_uses_per_token_head_scales,
+)
+from vllm.v1.worker.workspace import (
+    current_workspace_manager,
+    is_workspace_manager_initialized,
 )
 
 logger = init_logger(__name__)
@@ -277,6 +286,7 @@ class TritonAttentionBackend(AttentionBackend):
         "fp8_e4m3",
         "fp8_e5m2",
         "int8_per_token_head",
+        "int4_per_token_head",
         "fp8_per_token_head",
     ]
 
@@ -310,6 +320,23 @@ class TritonAttentionBackend(AttentionBackend):
     ) -> tuple[int, ...]:
         if block_size % 16 != 0:
             raise ValueError("Block size must be a multiple of 16.")
+        kv_quant_mode = get_kv_quant_mode(cache_dtype_str)
+        if kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD:
+            from vllm.utils.math_utils import cdiv
+            from vllm.utils.torch_utils import get_dtype_size
+
+            packed_head_size = cdiv(head_size, 2)
+            scale_pad = (
+                get_per_token_head_scale_count(head_size, kv_quant_mode)
+                * get_dtype_size(torch.float16)
+            )
+            return (
+                num_blocks,
+                2,
+                block_size,
+                num_kv_heads,
+                packed_head_size + scale_pad,
+            )
         if kv_cache_uses_per_token_head_scales(cache_dtype_str):
             # Pad head_size by sizeof(float32)/sizeof(cache_dtype) so
             # the per-head scale fits inline.  The backend extracts
@@ -388,16 +415,20 @@ class TritonAttentionImpl(AttentionImpl):
     # Per-token-head quant: scale views carved from inline head padding.
     _k_scale_cache: torch.Tensor | None = None
     _v_scale_cache: torch.Tensor | None = None
+    _k_data_cache: torch.Tensor | None = None
+    _v_data_cache: torch.Tensor | None = None
 
     def _ensure_scale_caches(self, kv_cache: torch.Tensor) -> None:
         """Extract per-head scale views from the padded head dimension.
 
         The KV cache shape is ``(num_blocks, 2, block_size, nkv, hs+pad)``
-        where ``pad = sizeof(float32) / sizeof(cache_dtype)``.  The last
-        ``pad`` elements of each head hold one float32 scale.  We create
-        strided float32 views over those bytes.
+        where ``pad = sizeof(scale_dtype) / sizeof(cache_dtype)``. The last
+        ``pad`` elements of each head hold one scale value. We create
+        strided typed views over those bytes.
 
-        Scale shape: ``(num_blocks, block_size, num_kv_heads)``
+        Scale shape:
+          - int4: ``(num_blocks, block_size, num_kv_heads, num_scale_groups)``
+          - others: ``(num_blocks, block_size, num_kv_heads)``
         """
         if self._k_scale_cache is not None:
             return
@@ -405,41 +436,67 @@ class TritonAttentionImpl(AttentionImpl):
 
         num_blocks, _, block_size, nkv, padded_hs = kv_cache.shape
         dtype_sz = kv_cache.element_size()
-        scale_pad = get_dtype_size(torch.float32) // dtype_sz  # e.g. 4
+        scale_dtype = get_per_token_head_scale_dtype(self._kv_quant_mode)
+        assert scale_dtype is not None
+        scale_dtype_sz = get_dtype_size(scale_dtype)
+        scale_count = get_per_token_head_scale_count(self.head_size, self._kv_quant_mode)
+        scale_pad = scale_count * scale_dtype_sz // dtype_sz
         hs = padded_hs - scale_pad
 
         raw = kv_cache.untyped_storage()
-        base_f32 = torch.tensor([], dtype=torch.float32, device=kv_cache.device).set_(
+        scale_storage = torch.tensor([], dtype=scale_dtype, device=kv_cache.device).set_(
             raw
         )
 
-        # In the raw bytes, each (block, kv_half, slot, head) occupies
-        # padded_hs * dtype_sz bytes.  The scale float32 sits at byte
-        # offset hs * dtype_sz within that region.
-        kv_half_bytes = block_size * nkv * padded_hs * dtype_sz
-        full_block_f32 = 2 * kv_half_bytes // 4  # stride between blocks
-        slot_f32 = nkv * padded_hs * dtype_sz // 4  # stride between slots
-        head_f32 = padded_hs * dtype_sz // 4  # stride between heads
-        scale_off_f32 = hs * dtype_sz // 4  # offset to scale within head
-
-        # K scales: kv_half=0
-        self._k_scale_cache = torch.as_strided(
-            base_f32,
-            size=(num_blocks, block_size, nkv),
-            stride=(full_block_f32, slot_f32, head_f32),
-            storage_offset=scale_off_f32,
+        # Derive scale strides from the logical KV tensor strides so padded
+        # bytes between pages remain invisible to callers while scale views
+        # still land on the correct inline tail.
+        block_stride, kv_half_stride, slot_stride, head_stride, hs_stride = (
+            kv_cache.stride()
         )
-        self._k_scale_cache.fill_(1.0)
+        full_block_scale = block_stride * dtype_sz // scale_dtype_sz
+        v_base_scale = kv_half_stride * dtype_sz // scale_dtype_sz
+        slot_scale = slot_stride * dtype_sz // scale_dtype_sz
+        head_scale = head_stride * dtype_sz // scale_dtype_sz
+        scale_off = hs * hs_stride * dtype_sz // scale_dtype_sz
 
-        # V scales: kv_half=1, offset by kv_half_bytes
-        v_base_f32 = kv_half_bytes // 4
-        self._v_scale_cache = torch.as_strided(
-            base_f32,
-            size=(num_blocks, block_size, nkv),
-            stride=(full_block_f32, slot_f32, head_f32),
-            storage_offset=v_base_f32 + scale_off_f32,
-        )
-        self._v_scale_cache.fill_(1.0)
+        if self._kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD:
+            scale_size = (num_blocks, block_size, nkv, scale_count)
+            scale_stride = (full_block_scale, slot_scale, head_scale, 1)
+            self._k_scale_cache = torch.as_strided(
+                scale_storage,
+                size=scale_size,
+                stride=scale_stride,
+                storage_offset=scale_off,
+            )
+            self._v_scale_cache = torch.as_strided(
+                scale_storage,
+                size=scale_size,
+                stride=scale_stride,
+                storage_offset=v_base_scale + scale_off,
+            )
+            self._k_scale_cache.fill_(1.0)
+            self._v_scale_cache.fill_(1.0)
+            self._k_data_cache = kv_cache[:, 0, :, :, :hs]
+            self._v_data_cache = kv_cache[:, 1, :, :, :hs]
+        else:
+            # K scales: kv_half=0
+            self._k_scale_cache = torch.as_strided(
+                scale_storage,
+                size=(num_blocks, block_size, nkv),
+                stride=(full_block_scale, slot_scale, head_scale),
+                storage_offset=scale_off,
+            )
+            self._k_scale_cache.fill_(1.0)
+
+            # V scales: kv_half=1, offset by kv_half_bytes
+            self._v_scale_cache = torch.as_strided(
+                scale_storage,
+                size=(num_blocks, block_size, nkv),
+                stride=(full_block_scale, slot_scale, head_scale),
+                storage_offset=v_base_scale + scale_off,
+            )
+            self._v_scale_cache.fill_(1.0)
 
     def fused_output_quant_supported(self, quant_key: QuantKey):
         return quant_key == kFp8StaticTensorSym
@@ -497,6 +554,47 @@ class TritonAttentionImpl(AttentionImpl):
         self._kv_quant_mode = get_kv_quant_mode(kv_cache_dtype)
         self._is_per_token_head_quant = self._kv_quant_mode.is_per_token_head
 
+    def _maybe_hadamard_transform(
+        self, x: torch.Tensor, *, inplace: bool
+    ) -> torch.Tensor:
+        if (
+            self._kv_quant_mode != KVQuantMode.INT4_PER_TOKEN_HEAD
+            or not current_platform.is_cuda()
+            or x.numel() == 0
+            or self.head_size <= 0
+            or self.head_size > (1 << 15)
+            or (self.head_size & (self.head_size - 1)) != 0
+        ):
+            return x
+        flat = x.reshape(-1, self.head_size)
+        if inplace:
+            if flat.is_contiguous():
+                ops.hadacore_transform(flat, inplace=True)
+                return x
+            work = flat.contiguous()
+            ops.hadacore_transform(work, inplace=True)
+            x.copy_(work.view_as(x))
+            return x
+
+        # The out-of-place hadacore fp16 path is unreliable on this runtime.
+        # Reuse the per-ubatch workspace when available so CUDA graph capture
+        # does not record an extra allocation node for every int4 query/key
+        # transform. Fallback to clone only when no workspace manager exists
+        # (e.g. focused unit tests) or a locked workspace is undersized.
+        work = None
+        if is_workspace_manager_initialized():
+            workspace_manager = current_workspace_manager()
+            try:
+                (work,) = workspace_manager.get_simultaneous((flat.shape, flat.dtype))
+            except AssertionError:
+                if not workspace_manager.is_locked():
+                    raise
+        if work is None:
+            work = torch.empty_like(flat, memory_format=torch.contiguous_format)
+        work.copy_(flat)
+        ops.hadacore_transform(work, inplace=True)
+        return work.view_as(x)
+
     def forward(
         self,
         layer: torch.nn.Module,
@@ -526,7 +624,6 @@ class TritonAttentionImpl(AttentionImpl):
                 "fused block_scale output quantization is not yet supported"
                 " for TritonAttentionImpl"
             )
-
         if attn_metadata is None:
             # Profiling run.
             return output.fill_(0)
@@ -543,7 +640,6 @@ class TritonAttentionImpl(AttentionImpl):
         # performance to make sure it does not introduce any overhead.
 
         num_actual_tokens = attn_metadata.num_actual_tokens
-
         # Handle encoder attention differently - no KV cache needed
         if self.attn_type in (AttentionType.ENCODER_ONLY, AttentionType.ENCODER):
             # For encoder attention,
@@ -556,12 +652,26 @@ class TritonAttentionImpl(AttentionImpl):
                 attn_metadata,
                 layer,
             )
+        query_for_attn = query[:num_actual_tokens]
+        if self._kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD:
+            query_for_attn = self._maybe_hadamard_transform(
+                query_for_attn, inplace=False
+            )
 
         # Per-token-head quantized KV cache: use separate scale caches.
         if self._is_per_token_head_quant:
             self._ensure_scale_caches(kv_cache)
-            key_cache, value_cache = kv_cache.unbind(1)
-            if key_cache.dtype == torch.uint8:
+            if self._kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD:
+                assert self._k_data_cache is not None
+                assert self._v_data_cache is not None
+                key_cache = self._k_data_cache
+                value_cache = self._v_data_cache
+            else:
+                key_cache, value_cache = kv_cache.unbind(1)
+            if (
+                key_cache.dtype == torch.uint8
+                and self._kv_quant_mode != KVQuantMode.INT4_PER_TOKEN_HEAD
+            ):
                 key_cache = key_cache.view(self.fp8_dtype)
                 value_cache = value_cache.view(self.fp8_dtype)
             k_descale = None
@@ -602,7 +712,7 @@ class TritonAttentionImpl(AttentionImpl):
         mm_prefix_range_tensor = attn_metadata.mm_prefix_range_tensor
 
         unified_attention(
-            q=query[:num_actual_tokens],
+            q=query_for_attn,
             k=key_cache,
             v=value_cache,
             out=output[:num_actual_tokens],
@@ -696,6 +806,20 @@ class TritonAttentionImpl(AttentionImpl):
         # Reshape the input keys and values and store them in the cache.
         if self._is_per_token_head_quant:
             self._ensure_scale_caches(kv_cache)
+            if self._kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD:
+                assert self._k_data_cache is not None
+                assert self._v_data_cache is not None
+                key_to_cache = self._maybe_hadamard_transform(key, inplace=False)
+                triton_reshape_and_cache_flash_int4_per_token_head(
+                    key_to_cache,
+                    value,
+                    self._k_data_cache,
+                    self._v_data_cache,
+                    self._k_scale_cache,
+                    self._v_scale_cache,
+                    slot_mapping,
+                )
+                return
             key_cache, value_cache = kv_cache.unbind(1)
             if key_cache.dtype == torch.uint8:
                 key_cache = key_cache.view(self.fp8_dtype)

--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -10,8 +10,47 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.torch_utils import is_quantized_kv_cache
+from vllm.v1.kv_cache_interface import (
+    INT4_CHANNELS_PER_SCALE,
+    get_int4_num_scale_groups,
+)
 
 FP8_MIN, FP8_MAX = get_fp8_min_max()
+
+# Gaussian-friendly symmetric int4 codebook normalized to [-1, 1].
+# Indices 0-7 are non-negative and 8-15 are the mirrored signed entries.
+INT4_CODEBOOK_LEVELS = (
+    0.0,
+    0.049726,
+    0.150815,
+    0.257223,
+    0.374146,
+    0.510790,
+    0.688876,
+    1.0,
+    -0.0,
+    -0.049726,
+    -0.150815,
+    -0.257223,
+    -0.374146,
+    -0.510790,
+    -0.688876,
+    -1.0,
+)
+INT4_MAGNITUDE_LEVELS = INT4_CODEBOOK_LEVELS[:8]
+INT4_LEVEL_BOUNDARIES = tuple(
+    0.5 * (INT4_MAGNITUDE_LEVELS[i] + INT4_MAGNITUDE_LEVELS[i + 1])
+    for i in range(len(INT4_MAGNITUDE_LEVELS) - 1)
+)
+(
+    INT4_LEVEL_BOUNDARY_0,
+    INT4_LEVEL_BOUNDARY_1,
+    INT4_LEVEL_BOUNDARY_2,
+    INT4_LEVEL_BOUNDARY_3,
+    INT4_LEVEL_BOUNDARY_4,
+    INT4_LEVEL_BOUNDARY_5,
+    INT4_LEVEL_BOUNDARY_6,
+) = INT4_LEVEL_BOUNDARIES
 
 
 @triton.jit
@@ -243,6 +282,189 @@ _PER_TOKEN_HEAD_QUANT_PARAMS: dict[torch.dtype, tuple[float, float]] = {
     FP8_DTYPE: (FP8_MAX, FP8_MIN),
 }
 
+@triton.jit
+def _int4_gaussian_mag_idx(
+    x_abs,
+    B0: tl.constexpr,
+    B1: tl.constexpr,
+    B2: tl.constexpr,
+    B3: tl.constexpr,
+    B4: tl.constexpr,
+    B5: tl.constexpr,
+    B6: tl.constexpr,
+):
+    idx = (x_abs > B0).to(tl.int32)
+    idx += (x_abs > B1).to(tl.int32)
+    idx += (x_abs > B2).to(tl.int32)
+    idx += (x_abs > B3).to(tl.int32)
+    idx += (x_abs > B4).to(tl.int32)
+    idx += (x_abs > B5).to(tl.int32)
+    idx += (x_abs > B6).to(tl.int32)
+    return idx
+
+
+@triton.jit
+def _reshape_cache_per_token_head_int4(
+    key_ptr,  # [num_tokens, num_kv_heads, head_size]
+    value_ptr,  # [num_tokens, num_kv_heads, head_size_v]
+    key_cache_ptr,  # [num_blocks, block_size, num_kv_heads, packed_head_size]
+    value_cache_ptr,  # [num_blocks, block_size, num_kv_heads, packed_head_size_v]
+    k_scale_cache_ptr,  # [num_blocks, block_size, num_kv_heads, num_dim_groups]
+    v_scale_cache_ptr,  # [num_blocks, block_size, num_kv_heads, num_dim_groups]
+    slot_mapping_ptr,  # [num_tokens]
+    stride_key_tok: tl.int64,
+    stride_key_head: tl.int64,
+    stride_val_tok: tl.int64,
+    stride_val_head: tl.int64,
+    stride_kc_blk: tl.int64,
+    stride_kc_slot: tl.int64,
+    stride_kc_head: tl.int64,
+    stride_vc_blk: tl.int64,
+    stride_vc_slot: tl.int64,
+    stride_vc_head: tl.int64,
+    stride_ks_blk: tl.int64,
+    stride_ks_slot: tl.int64,
+    stride_ks_head: tl.int64,
+    stride_ks_group: tl.int64,
+    stride_vs_blk: tl.int64,
+    stride_vs_slot: tl.int64,
+    stride_vs_head: tl.int64,
+    stride_vs_group: tl.int64,
+    block_size: tl.constexpr,
+    head_size: tl.constexpr,
+    head_size_v: tl.constexpr,
+    PACKED_HEAD_SIZE_PADDED: tl.constexpr,
+    NUM_DIM_GROUPS: tl.constexpr,
+    CHANNELS_PER_SCALE: tl.constexpr,
+    INT4_B0: tl.constexpr,
+    INT4_B1: tl.constexpr,
+    INT4_B2: tl.constexpr,
+    INT4_B3: tl.constexpr,
+    INT4_B4: tl.constexpr,
+    INT4_B5: tl.constexpr,
+    INT4_B6: tl.constexpr,
+):
+    tok = tl.program_id(0)
+    head = tl.program_id(1)
+
+    slot = tl.load(slot_mapping_ptr + tok).to(tl.int64)
+    if slot < 0:
+        return
+
+    blk = slot // block_size
+    slot_in_blk = slot % block_size
+
+    pair_offs = tl.arange(0, PACKED_HEAD_SIZE_PADDED)
+    dim0 = pair_offs * 2
+    dim1 = dim0 + 1
+    pairs_per_scale = CHANNELS_PER_SCALE // 2
+
+    k0_mask = dim0 < head_size
+    k1_mask = dim1 < head_size
+    k0 = tl.load(
+        key_ptr + tok * stride_key_tok + head * stride_key_head + dim0,
+        mask=k0_mask,
+        other=0.0,
+    ).to(tl.float32)
+    k1 = tl.load(
+        key_ptr + tok * stride_key_tok + head * stride_key_head + dim1,
+        mask=k1_mask,
+        other=0.0,
+    ).to(tl.float32)
+    k_pair_mask = pair_offs < ((head_size + 1) // 2)
+    k_pair_abs = tl.maximum(tl.abs(k0), tl.abs(k1))
+    k_scale = tl.full([PACKED_HEAD_SIZE_PADDED], 1.0, dtype=tl.float32)
+    for group_idx in tl.static_range(NUM_DIM_GROUPS):
+        group_mask = (
+            (pair_offs >= group_idx * pairs_per_scale)
+            & (pair_offs < (group_idx + 1) * pairs_per_scale)
+            & k_pair_mask
+        )
+        group_absmax = tl.max(tl.where(group_mask, k_pair_abs, 0.0))
+        group_scale = tl.maximum(group_absmax, 1e-6)
+        tl.store(
+            k_scale_cache_ptr
+            + blk * stride_ks_blk
+            + slot_in_blk * stride_ks_slot
+            + head * stride_ks_head
+            + group_idx * stride_ks_group,
+            group_scale.to(tl.float16),
+        )
+        k_scale = tl.where(group_mask, group_scale, k_scale)
+    k_norm0 = tl.where(k0_mask, k0 * (1.0 / k_scale), 0.0)
+    k_norm1 = tl.where(k1_mask, k1 * (1.0 / k_scale), 0.0)
+    k_abs0 = tl.abs(k_norm0)
+    k_abs1 = tl.abs(k_norm1)
+    k_idx0 = _int4_gaussian_mag_idx(
+        k_abs0, INT4_B0, INT4_B1, INT4_B2, INT4_B3, INT4_B4, INT4_B5, INT4_B6
+    ) + 8 * (k_norm0 < 0).to(tl.int32)
+    k_idx1 = _int4_gaussian_mag_idx(
+        k_abs1, INT4_B0, INT4_B1, INT4_B2, INT4_B3, INT4_B4, INT4_B5, INT4_B6
+    ) + 8 * (k_norm1 < 0).to(tl.int32)
+    k_packed = (k_idx0 | (k_idx1 << 4)).to(tl.uint8)
+    tl.store(
+        key_cache_ptr
+        + blk * stride_kc_blk
+        + slot_in_blk * stride_kc_slot
+        + head * stride_kc_head
+        + pair_offs,
+        k_packed,
+        mask=k_pair_mask,
+    )
+
+    v0_mask = dim0 < head_size_v
+    v1_mask = dim1 < head_size_v
+    v0 = tl.load(
+        value_ptr + tok * stride_val_tok + head * stride_val_head + dim0,
+        mask=v0_mask,
+        other=0.0,
+    ).to(tl.float32)
+    v1 = tl.load(
+        value_ptr + tok * stride_val_tok + head * stride_val_head + dim1,
+        mask=v1_mask,
+        other=0.0,
+    ).to(tl.float32)
+    v_pair_mask = pair_offs < ((head_size_v + 1) // 2)
+    v_pair_abs = tl.maximum(tl.abs(v0), tl.abs(v1))
+    v_scale = tl.full([PACKED_HEAD_SIZE_PADDED], 1.0, dtype=tl.float32)
+    for group_idx in tl.static_range(NUM_DIM_GROUPS):
+        group_mask = (
+            (pair_offs >= group_idx * pairs_per_scale)
+            & (pair_offs < (group_idx + 1) * pairs_per_scale)
+            & v_pair_mask
+        )
+        group_absmax = tl.max(tl.where(group_mask, v_pair_abs, 0.0))
+        group_scale = tl.maximum(group_absmax, 1e-6)
+        tl.store(
+            v_scale_cache_ptr
+            + blk * stride_vs_blk
+            + slot_in_blk * stride_vs_slot
+            + head * stride_vs_head
+            + group_idx * stride_vs_group,
+            group_scale.to(tl.float16),
+        )
+        v_scale = tl.where(group_mask, group_scale, v_scale)
+    v_norm0 = tl.where(v0_mask, v0 * (1.0 / v_scale), 0.0)
+    v_norm1 = tl.where(v1_mask, v1 * (1.0 / v_scale), 0.0)
+    v_abs0 = tl.abs(v_norm0)
+    v_abs1 = tl.abs(v_norm1)
+    v_idx0 = _int4_gaussian_mag_idx(
+        v_abs0, INT4_B0, INT4_B1, INT4_B2, INT4_B3, INT4_B4, INT4_B5, INT4_B6
+    ) + 8 * (v_norm0 < 0).to(tl.int32)
+    v_idx1 = _int4_gaussian_mag_idx(
+        v_abs1, INT4_B0, INT4_B1, INT4_B2, INT4_B3, INT4_B4, INT4_B5, INT4_B6
+    ) + 8 * (v_norm1 < 0).to(tl.int32)
+    v_packed = (v_idx0 | (v_idx1 << 4)).to(tl.uint8)
+    tl.store(
+        value_cache_ptr
+        + blk * stride_vc_blk
+        + slot_in_blk * stride_vc_slot
+        + head * stride_vc_head
+        + pair_offs,
+        v_packed,
+        mask=v_pair_mask,
+    )
+
 
 def triton_reshape_and_cache_flash_per_token_head_quant(
     key: torch.Tensor,  # [num_tokens, num_kv_heads, head_size]
@@ -312,6 +534,72 @@ def triton_reshape_and_cache_flash_per_token_head_quant(
         HEAD_SIZE_PADDED=head_size_padded,
         QUANT_MAX=quant_max,
         QUANT_MIN=quant_min,
+        num_warps=num_warps,
+    )
+
+
+def triton_reshape_and_cache_flash_int4_per_token_head(
+    key: torch.Tensor,  # [num_tokens, num_kv_heads, head_size]
+    value: torch.Tensor,  # [num_tokens, num_kv_heads, head_size_v]
+    key_cache: torch.Tensor,  # [num_blocks, block_size, num_kv_heads, packed_head_size]
+    value_cache: torch.Tensor,  # [num_blocks, block_size, num_kv_heads, packed_head_size_v]
+    k_scale_cache: torch.Tensor,  # [num_blocks, block_size, num_kv_heads, num_dim_groups]
+    v_scale_cache: torch.Tensor,  # [num_blocks, block_size, num_kv_heads, num_dim_groups]
+    slot_mapping: torch.Tensor,  # [num_tokens]
+):
+    """Quantize key/value to packed int4 with Gaussian-friendly levels."""
+    num_tokens, num_kv_heads, head_size = key.shape
+    head_size_v = value.shape[2]
+    packed_head_size_padded = triton.next_power_of_2(
+        max((head_size + 1) // 2, (head_size_v + 1) // 2)
+    )
+    block_size = key_cache.shape[1]
+    num_dim_groups = k_scale_cache.shape[-1]
+
+    if current_platform.is_rocm() or current_platform.is_xpu():
+        num_warps = 4
+    else:
+        num_warps = min(8, max(1, packed_head_size_padded // 16))
+
+    _reshape_cache_per_token_head_int4[(num_tokens, num_kv_heads)](
+        key_ptr=key,
+        value_ptr=value,
+        key_cache_ptr=key_cache,
+        value_cache_ptr=value_cache,
+        k_scale_cache_ptr=k_scale_cache,
+        v_scale_cache_ptr=v_scale_cache,
+        slot_mapping_ptr=slot_mapping,
+        stride_key_tok=key.stride(0),
+        stride_key_head=key.stride(1),
+        stride_val_tok=value.stride(0),
+        stride_val_head=value.stride(1),
+        stride_kc_blk=key_cache.stride(0),
+        stride_kc_slot=key_cache.stride(1),
+        stride_kc_head=key_cache.stride(2),
+        stride_vc_blk=value_cache.stride(0),
+        stride_vc_slot=value_cache.stride(1),
+        stride_vc_head=value_cache.stride(2),
+        stride_ks_blk=k_scale_cache.stride(0),
+        stride_ks_slot=k_scale_cache.stride(1),
+        stride_ks_head=k_scale_cache.stride(2),
+        stride_ks_group=k_scale_cache.stride(3),
+        stride_vs_blk=v_scale_cache.stride(0),
+        stride_vs_slot=v_scale_cache.stride(1),
+        stride_vs_head=v_scale_cache.stride(2),
+        stride_vs_group=v_scale_cache.stride(3),
+        block_size=block_size,
+        head_size=head_size,
+        head_size_v=head_size_v,
+        PACKED_HEAD_SIZE_PADDED=packed_head_size_padded,
+        NUM_DIM_GROUPS=num_dim_groups,
+        CHANNELS_PER_SCALE=INT4_CHANNELS_PER_SCALE,
+        INT4_B0=INT4_LEVEL_BOUNDARY_0,
+        INT4_B1=INT4_LEVEL_BOUNDARY_1,
+        INT4_B2=INT4_LEVEL_BOUNDARY_2,
+        INT4_B3=INT4_LEVEL_BOUNDARY_3,
+        INT4_B4=INT4_LEVEL_BOUNDARY_4,
+        INT4_B5=INT4_LEVEL_BOUNDARY_5,
+        INT4_B6=INT4_LEVEL_BOUNDARY_6,
         num_warps=num_warps,
     )
 

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -13,11 +13,30 @@ import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
-from vllm.v1.kv_cache_interface import KVQuantMode
+from vllm.v1.attention.ops.triton_reshape_and_cache_flash import INT4_CODEBOOK_LEVELS
+from vllm.v1.kv_cache_interface import INT4_CHANNELS_PER_SCALE, KVQuantMode
 
 logger = init_logger(__name__)
 is_batch_invariant = envs.VLLM_BATCH_INVARIANT
 float8_info = torch.finfo(current_platform.fp8_dtype())
+(
+    INT4_CODEBOOK_0,
+    INT4_CODEBOOK_1,
+    INT4_CODEBOOK_2,
+    INT4_CODEBOOK_3,
+    INT4_CODEBOOK_4,
+    INT4_CODEBOOK_5,
+    INT4_CODEBOOK_6,
+    INT4_CODEBOOK_7,
+    INT4_CODEBOOK_8,
+    INT4_CODEBOOK_9,
+    INT4_CODEBOOK_10,
+    INT4_CODEBOOK_11,
+    INT4_CODEBOOK_12,
+    INT4_CODEBOOK_13,
+    INT4_CODEBOOK_14,
+    INT4_CODEBOOK_15,
+) = INT4_CODEBOOK_LEVELS
 
 
 @triton.jit
@@ -34,6 +53,42 @@ def apply_softcap(S, x):
 
 
 @triton.jit
+def _int4_codebook_value(
+    idx,
+    C1: tl.constexpr,
+    C2: tl.constexpr,
+    C3: tl.constexpr,
+    C4: tl.constexpr,
+    C5: tl.constexpr,
+    C6: tl.constexpr,
+    C7: tl.constexpr,
+    C9: tl.constexpr,
+    C10: tl.constexpr,
+    C11: tl.constexpr,
+    C12: tl.constexpr,
+    C13: tl.constexpr,
+    C14: tl.constexpr,
+    C15: tl.constexpr,
+):
+    value = idx.to(tl.float32) * 0.0
+    value = tl.where(idx == 1, C1, value)
+    value = tl.where(idx == 2, C2, value)
+    value = tl.where(idx == 3, C3, value)
+    value = tl.where(idx == 4, C4, value)
+    value = tl.where(idx == 5, C5, value)
+    value = tl.where(idx == 6, C6, value)
+    value = tl.where(idx == 7, C7, value)
+    value = tl.where(idx == 9, C9, value)
+    value = tl.where(idx == 10, C10, value)
+    value = tl.where(idx == 11, C11, value)
+    value = tl.where(idx == 12, C12, value)
+    value = tl.where(idx == 13, C13, value)
+    value = tl.where(idx == 14, C14, value)
+    value = tl.where(idx == 15, C15, value)
+    return value
+
+
+@triton.jit
 def _prepare_kv_tile(
     data,
     Q,
@@ -45,9 +100,27 @@ def _prepare_kv_tile(
     stride_s_blk,
     stride_s_slot,
     stride_s_head,
+    stride_s_group,
+    offs_d,
     tile_mask,
+    IS_VALUE: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     KV_QUANT_MODE: tl.constexpr,
+    CHANNELS_PER_SCALE: tl.constexpr,
+    INT4_C1: tl.constexpr,
+    INT4_C2: tl.constexpr,
+    INT4_C3: tl.constexpr,
+    INT4_C4: tl.constexpr,
+    INT4_C5: tl.constexpr,
+    INT4_C6: tl.constexpr,
+    INT4_C7: tl.constexpr,
+    INT4_C9: tl.constexpr,
+    INT4_C10: tl.constexpr,
+    INT4_C11: tl.constexpr,
+    INT4_C12: tl.constexpr,
+    INT4_C13: tl.constexpr,
+    INT4_C14: tl.constexpr,
+    INT4_C15: tl.constexpr,
 ):
     """Prepare a loaded KV tile for attention computation.
 
@@ -57,7 +130,8 @@ def _prepare_kv_tile(
     - ``KV_QUANT_MODE == 0``: cast only (no-op for bf16/fp16).
     - ``KV_QUANT_MODE == 1`` (FP8 per-tensor): dequantize inline
       using the tensor-wide scale.
-    - ``KV_QUANT_MODE >= 2`` (per-token-head int8/fp8): cast to Q's
+    - ``KV_QUANT_MODE >= 2`` (per-token-head int8/fp8/int4): cast or
+      decode to Q's
       dtype and return per-head scales separately — the caller applies
       them after the dot product for better numerical efficiency.
 
@@ -66,7 +140,8 @@ def _prepare_kv_tile(
     the same constexpr so the compiler eliminates dead code.
     """
     # KV_QUANT_MODE values: 0=none, 1=fp8 per-tensor,
-    #                       2=int8 per-token-head, 3=fp8 per-token-head
+    #                       2=int8 per-token-head, 3=fp8 per-token-head,
+    #                       4=int4 per-token-head
 
     # Placeholder scales (float32) — never read when KV_QUANT_MODE < 2.
     unused_scales = tile_mask.to(tl.float32)
@@ -75,6 +150,49 @@ def _prepare_kv_tile(
         if Q.dtype.is_fp8():
             return data.to(Q.dtype), unused_scales
         return (data.to(tl.float32) * tl.load(tensor_scale)).to(Q.dtype), unused_scales
+    if KV_QUANT_MODE == 4:  # per-token-head int4
+        dim_groups = offs_d // CHANNELS_PER_SCALE
+        if IS_VALUE:
+            scale_idx = (
+                physical_block_idx[:, None] * stride_s_blk
+                + (seq_offset % BLOCK_SIZE)[:, None] * stride_s_slot
+                + kv_head_idx * stride_s_head
+                + dim_groups[None, :] * stride_s_group
+            )
+            scale_mask = tile_mask[:, None]
+        else:
+            scale_idx = (
+                physical_block_idx[None, :] * stride_s_blk
+                + (seq_offset % BLOCK_SIZE)[None, :] * stride_s_slot
+                + kv_head_idx * stride_s_head
+                + dim_groups[:, None] * stride_s_group
+            )
+            scale_mask = tile_mask[None, :]
+        token_dim_scales = tl.load(scale_cache_ptr + scale_idx, mask=scale_mask, other=1.0)
+        if IS_VALUE:
+            shift = ((offs_d % 2) * 4).to(tl.int32)[None, :]
+        else:
+            shift = ((offs_d % 2) * 4).to(tl.int32)[:, None]
+        idx = (data.to(tl.int32) >> shift) & 0xF
+        decoded = _int4_codebook_value(
+            idx,
+            INT4_C1,
+            INT4_C2,
+            INT4_C3,
+            INT4_C4,
+            INT4_C5,
+            INT4_C6,
+            INT4_C7,
+            INT4_C9,
+            INT4_C10,
+            INT4_C11,
+            INT4_C12,
+            INT4_C13,
+            INT4_C14,
+            INT4_C15,
+        )
+        scaled = decoded * token_dim_scales.to(tl.float32)
+        return scaled.to(Q.dtype), unused_scales
     if KV_QUANT_MODE >= 2:  # per-token-head (int8 or fp8)
         scale_idx = (
             physical_block_idx * stride_s_blk
@@ -84,7 +202,7 @@ def _prepare_kv_tile(
         token_head_scales = tl.load(
             scale_cache_ptr + scale_idx, mask=tile_mask, other=1.0
         )
-        return data.to(Q.dtype), token_head_scales
+        return data.to(Q.dtype), token_head_scales.to(tl.float32)
     # .to(Q.dtype) is a no-op when data is already Q's type (bf16/fp16),
     # but required so Triton sees consistent return types across branches.
     return data.to(Q.dtype), unused_scales
@@ -174,9 +292,26 @@ def kernel_unified_attention_2d(
     stride_ks_blk=0,
     stride_ks_slot=0,
     stride_ks_head=0,
+    stride_ks_group=0,
     stride_vs_blk=0,
     stride_vs_slot=0,
     stride_vs_head=0,
+    stride_vs_group=0,
+    CHANNELS_PER_SCALE: tl.constexpr = INT4_CHANNELS_PER_SCALE,
+    INT4_C1: tl.constexpr = 0.0,
+    INT4_C2: tl.constexpr = 0.0,
+    INT4_C3: tl.constexpr = 0.0,
+    INT4_C4: tl.constexpr = 0.0,
+    INT4_C5: tl.constexpr = 0.0,
+    INT4_C6: tl.constexpr = 0.0,
+    INT4_C7: tl.constexpr = 0.0,
+    INT4_C9: tl.constexpr = 0.0,
+    INT4_C10: tl.constexpr = 0.0,
+    INT4_C11: tl.constexpr = 0.0,
+    INT4_C12: tl.constexpr = 0.0,
+    INT4_C13: tl.constexpr = 0.0,
+    INT4_C14: tl.constexpr = 0.0,
+    INT4_C15: tl.constexpr = 0.0,
 ):
     q_block_global_idx = tl.program_id(0)
     kv_head_idx = tl.program_id(1)
@@ -308,17 +443,22 @@ def kernel_unified_attention_2d(
             block_tables_ptr + block_table_offset + seq_offset // BLOCK_SIZE
         ).to(tl.int64)
 
+        if KV_QUANT_MODE == 4:
+            cache_offs_d = offs_d // 2
+        else:
+            cache_offs_d = offs_d
+
         v_offset = (
             physical_block_idx[:, None] * stride_v_cache_0
             + kv_head_idx * stride_v_cache_2
-            + offs_d[None, :] * stride_v_cache_3
+            + cache_offs_d[None, :] * stride_v_cache_3
             + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
         )
 
         k_offset = (
             physical_block_idx[None, :] * stride_k_cache_0
             + kv_head_idx * stride_k_cache_2
-            + offs_d[:, None] * stride_k_cache_3
+            + cache_offs_d[:, None] * stride_k_cache_3
             + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
         )
 
@@ -339,9 +479,27 @@ def kernel_unified_attention_2d(
             stride_ks_blk,
             stride_ks_slot,
             stride_ks_head,
+            stride_ks_group,
+            offs_d,
             tile_mask,
+            False,
             BLOCK_SIZE,
             KV_QUANT_MODE,
+            CHANNELS_PER_SCALE,
+            INT4_C1,
+            INT4_C2,
+            INT4_C3,
+            INT4_C4,
+            INT4_C5,
+            INT4_C6,
+            INT4_C7,
+            INT4_C9,
+            INT4_C10,
+            INT4_C11,
+            INT4_C12,
+            INT4_C13,
+            INT4_C14,
+            INT4_C15,
         )
 
         # V : (TILE_SIZE, HEAD_SIZE)
@@ -361,9 +519,27 @@ def kernel_unified_attention_2d(
             stride_vs_blk,
             stride_vs_slot,
             stride_vs_head,
+            stride_vs_group,
+            offs_d,
             tile_mask,
+            True,
             BLOCK_SIZE,
             KV_QUANT_MODE,
+            CHANNELS_PER_SCALE,
+            INT4_C1,
+            INT4_C2,
+            INT4_C3,
+            INT4_C4,
+            INT4_C5,
+            INT4_C6,
+            INT4_C7,
+            INT4_C9,
+            INT4_C10,
+            INT4_C11,
+            INT4_C12,
+            INT4_C13,
+            INT4_C14,
+            INT4_C15,
         )
 
         # Compute attention mask: causal by default (key <= query)
@@ -404,7 +580,9 @@ def kernel_unified_attention_2d(
 
         # Per-token-head quant: fuse softmax_scale with per-head k_scale
         # to avoid a separate BLOCK_M × TILE_SIZE multiply on S.
-        if KV_QUANT_MODE >= 2:
+        if KV_QUANT_MODE == 4:
+            S += scale * tl.dot(Q, K)
+        elif KV_QUANT_MODE >= 2:
             S += tl.dot(Q, K) * (scale * k_token_head_scales[None, :])
         else:
             S += scale * tl.dot(Q, K)
@@ -472,7 +650,9 @@ def kernel_unified_attention_2d(
 
         # acc : (BLOCK_M, HEAD_SIZE_PADDED)
         # Per-token-head quant: apply v_scale to P instead of V.
-        if KV_QUANT_MODE >= 2:
+        if KV_QUANT_MODE == 4:
+            acc += tl.dot(P.to(V.dtype), V)
+        elif KV_QUANT_MODE >= 2:
             P_v = (P * v_token_head_scales[None, :]).to(V.dtype)
             acc += tl.dot(P_v, V)
         else:
@@ -556,9 +736,26 @@ def kernel_unified_attention_3d(
     stride_ks_blk=0,
     stride_ks_slot=0,
     stride_ks_head=0,
+    stride_ks_group=0,
     stride_vs_blk=0,
     stride_vs_slot=0,
     stride_vs_head=0,
+    stride_vs_group=0,
+    CHANNELS_PER_SCALE: tl.constexpr = INT4_CHANNELS_PER_SCALE,
+    INT4_C1: tl.constexpr = 0.0,
+    INT4_C2: tl.constexpr = 0.0,
+    INT4_C3: tl.constexpr = 0.0,
+    INT4_C4: tl.constexpr = 0.0,
+    INT4_C5: tl.constexpr = 0.0,
+    INT4_C6: tl.constexpr = 0.0,
+    INT4_C7: tl.constexpr = 0.0,
+    INT4_C9: tl.constexpr = 0.0,
+    INT4_C10: tl.constexpr = 0.0,
+    INT4_C11: tl.constexpr = 0.0,
+    INT4_C12: tl.constexpr = 0.0,
+    INT4_C13: tl.constexpr = 0.0,
+    INT4_C14: tl.constexpr = 0.0,
+    INT4_C15: tl.constexpr = 0.0,
 ):
     q_block_global_idx = tl.program_id(0)
     kv_head_idx = tl.program_id(1)
@@ -699,17 +896,22 @@ def kernel_unified_attention_3d(
             block_tables_ptr + block_table_offset + seq_offset // BLOCK_SIZE
         ).to(tl.int64)
 
+        if KV_QUANT_MODE == 4:
+            cache_offs_d = offs_d // 2
+        else:
+            cache_offs_d = offs_d
+
         v_offset = (
             physical_block_idx[:, None] * stride_v_cache_0
             + kv_head_idx * stride_v_cache_2
-            + offs_d[None, :] * stride_v_cache_3
+            + cache_offs_d[None, :] * stride_v_cache_3
             + (seq_offset % BLOCK_SIZE)[:, None] * stride_v_cache_1
         )
 
         k_offset = (
             physical_block_idx[None, :] * stride_k_cache_0
             + kv_head_idx * stride_k_cache_2
-            + offs_d[:, None] * stride_k_cache_3
+            + cache_offs_d[:, None] * stride_k_cache_3
             + (seq_offset % BLOCK_SIZE)[None, :] * stride_k_cache_1
         )
 
@@ -730,9 +932,27 @@ def kernel_unified_attention_3d(
             stride_ks_blk,
             stride_ks_slot,
             stride_ks_head,
+            stride_ks_group,
+            offs_d,
             tile_mask,
+            False,
             BLOCK_SIZE,
             KV_QUANT_MODE,
+            CHANNELS_PER_SCALE,
+            INT4_C1,
+            INT4_C2,
+            INT4_C3,
+            INT4_C4,
+            INT4_C5,
+            INT4_C6,
+            INT4_C7,
+            INT4_C9,
+            INT4_C10,
+            INT4_C11,
+            INT4_C12,
+            INT4_C13,
+            INT4_C14,
+            INT4_C15,
         )
 
         # V : (TILE_SIZE, HEAD_SIZE)
@@ -752,9 +972,27 @@ def kernel_unified_attention_3d(
             stride_vs_blk,
             stride_vs_slot,
             stride_vs_head,
+            stride_vs_group,
+            offs_d,
             tile_mask,
+            True,
             BLOCK_SIZE,
             KV_QUANT_MODE,
+            CHANNELS_PER_SCALE,
+            INT4_C1,
+            INT4_C2,
+            INT4_C3,
+            INT4_C4,
+            INT4_C5,
+            INT4_C6,
+            INT4_C7,
+            INT4_C9,
+            INT4_C10,
+            INT4_C11,
+            INT4_C12,
+            INT4_C13,
+            INT4_C14,
+            INT4_C15,
         )
 
         # Compute attention mask: causal by default (key <= query)
@@ -795,7 +1033,9 @@ def kernel_unified_attention_3d(
 
         # Per-token-head quant: fuse softmax_scale with per-head k_scale
         # to avoid a separate BLOCK_M × TILE_SIZE multiply on S.
-        if KV_QUANT_MODE >= 2:
+        if KV_QUANT_MODE == 4:
+            S += scale * tl.dot(Q, K)
+        elif KV_QUANT_MODE >= 2:
             S += tl.dot(Q, K) * (scale * k_token_head_scales[None, :])
         else:
             S += scale * tl.dot(Q, K)
@@ -863,7 +1103,9 @@ def kernel_unified_attention_3d(
 
         # acc : (BLOCK_M, HEAD_SIZE_PADDED)
         # Per-token-head quant: apply v_scale to P instead of V.
-        if KV_QUANT_MODE >= 2:
+        if KV_QUANT_MODE == 4:
+            acc += tl.dot(P.to(V.dtype), V)
+        elif KV_QUANT_MODE >= 2:
             P_v = (P * v_token_head_scales[None, :]).to(V.dtype)
             acc += tl.dot(P_v, V)
         else:
@@ -1044,8 +1286,8 @@ def unified_attention(
     use_alibi_sqrt=False,
     # KV cache quantization mode and per-token-head scale caches.
     kv_quant_mode: KVQuantMode = KVQuantMode.NONE,
-    k_scale_cache=None,  # [num_blocks, block_size, num_kv_heads] float32
-    v_scale_cache=None,  # [num_blocks, block_size, num_kv_heads] float32
+    k_scale_cache=None,  # int4: [num_blocks, block_size, num_kv_heads, num_groups]
+    v_scale_cache=None,  # int4: [num_blocks, block_size, num_kv_heads, num_groups]
 ):
     assert causal, "Only causal attention is supported"
     assert q_descale is None, "Q scales not supported"
@@ -1181,9 +1423,26 @@ def unified_attention(
             stride_ks_blk=k_scale_cache.stride(0) if k_scale_cache is not None else 0,
             stride_ks_slot=k_scale_cache.stride(1) if k_scale_cache is not None else 0,
             stride_ks_head=k_scale_cache.stride(2) if k_scale_cache is not None else 0,
+            stride_ks_group=k_scale_cache.stride(3) if k_scale_cache is not None and k_scale_cache.ndim == 4 else 0,
             stride_vs_blk=v_scale_cache.stride(0) if v_scale_cache is not None else 0,
             stride_vs_slot=v_scale_cache.stride(1) if v_scale_cache is not None else 0,
             stride_vs_head=v_scale_cache.stride(2) if v_scale_cache is not None else 0,
+            stride_vs_group=v_scale_cache.stride(3) if v_scale_cache is not None and v_scale_cache.ndim == 4 else 0,
+            CHANNELS_PER_SCALE=INT4_CHANNELS_PER_SCALE,
+            INT4_C1=INT4_CODEBOOK_1,
+            INT4_C2=INT4_CODEBOOK_2,
+            INT4_C3=INT4_CODEBOOK_3,
+            INT4_C4=INT4_CODEBOOK_4,
+            INT4_C5=INT4_CODEBOOK_5,
+            INT4_C6=INT4_CODEBOOK_6,
+            INT4_C7=INT4_CODEBOOK_7,
+            INT4_C9=INT4_CODEBOOK_9,
+            INT4_C10=INT4_CODEBOOK_10,
+            INT4_C11=INT4_CODEBOOK_11,
+            INT4_C12=INT4_CODEBOOK_12,
+            INT4_C13=INT4_CODEBOOK_13,
+            INT4_C14=INT4_CODEBOOK_14,
+            INT4_C15=INT4_CODEBOOK_15,
         )
     else:
         kernel_unified_attention_3d[
@@ -1242,9 +1501,26 @@ def unified_attention(
             stride_ks_blk=k_scale_cache.stride(0) if k_scale_cache is not None else 0,
             stride_ks_slot=k_scale_cache.stride(1) if k_scale_cache is not None else 0,
             stride_ks_head=k_scale_cache.stride(2) if k_scale_cache is not None else 0,
+            stride_ks_group=k_scale_cache.stride(3) if k_scale_cache is not None and k_scale_cache.ndim == 4 else 0,
             stride_vs_blk=v_scale_cache.stride(0) if v_scale_cache is not None else 0,
             stride_vs_slot=v_scale_cache.stride(1) if v_scale_cache is not None else 0,
             stride_vs_head=v_scale_cache.stride(2) if v_scale_cache is not None else 0,
+            stride_vs_group=v_scale_cache.stride(3) if v_scale_cache is not None and v_scale_cache.ndim == 4 else 0,
+            CHANNELS_PER_SCALE=INT4_CHANNELS_PER_SCALE,
+            INT4_C1=INT4_CODEBOOK_1,
+            INT4_C2=INT4_CODEBOOK_2,
+            INT4_C3=INT4_CODEBOOK_3,
+            INT4_C4=INT4_CODEBOOK_4,
+            INT4_C5=INT4_CODEBOOK_5,
+            INT4_C6=INT4_CODEBOOK_6,
+            INT4_C7=INT4_CODEBOOK_7,
+            INT4_C9=INT4_CODEBOOK_9,
+            INT4_C10=INT4_CODEBOOK_10,
+            INT4_C11=INT4_CODEBOOK_11,
+            INT4_C12=INT4_CODEBOOK_12,
+            INT4_C13=INT4_CODEBOOK_13,
+            INT4_C14=INT4_CODEBOOK_14,
+            INT4_C15=INT4_CODEBOOK_15,
         )
         reduce_segments[(q.shape[0], num_query_heads)](
             output_ptr=out,

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -18,6 +18,7 @@ from vllm.utils.hashing import sha256_cbor, xxhash_cbor
 from vllm.utils.math_utils import cdiv
 from vllm.utils.mem_utils import format_gib
 from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
     KVCacheConfig,
@@ -939,6 +940,14 @@ def unify_kv_cache_spec_page_size(
         else:
             layer_page_size = layer_spec.page_size_bytes
             if max_page_size % layer_page_size != 0:
+                if isinstance(layer_spec, AttentionSpec):
+                    new_spec = replace(
+                        layer_spec,
+                        page_size_padded=max_page_size,
+                    )
+                    assert new_spec.page_size_bytes == max_page_size
+                    new_kv_cache_spec[layer_name] = new_spec
+                    continue
                 raise NotImplementedError(
                     "The page size of the layer is not divisible by the "
                     "maximum page size. Cannot unify by adjusting block_size."

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -38,6 +38,7 @@ class KVQuantMode(IntEnum):
     FP8_PER_TENSOR = 1  # per-tensor scales (current fp8 path)
     INT8_PER_TOKEN_HEAD = 2  # per-token-head dynamic scales for int8
     FP8_PER_TOKEN_HEAD = 3  # per-token-head dynamic scales for fp8
+    INT4_PER_TOKEN_HEAD = 4  # per-token-head dynamic scales for packed int4
 
     @property
     def is_per_token_head(self) -> bool:
@@ -51,6 +52,8 @@ def get_kv_quant_mode(kv_cache_dtype: str) -> KVQuantMode:
         return KVQuantMode.INT8_PER_TOKEN_HEAD
     if kv_cache_dtype == "fp8_per_token_head":
         return KVQuantMode.FP8_PER_TOKEN_HEAD
+    if kv_cache_dtype == "int4_per_token_head":
+        return KVQuantMode.INT4_PER_TOKEN_HEAD
     if kv_cache_dtype.startswith("fp8"):
         return KVQuantMode.FP8_PER_TENSOR
     return KVQuantMode.NONE
@@ -63,6 +66,39 @@ def is_quantized_kv_cache(kv_cache_dtype: str) -> bool:
 def kv_cache_uses_per_token_head_scales(kv_cache_dtype: str) -> bool:
     """Return True if *kv_cache_dtype* needs per-token-head scales."""
     return get_kv_quant_mode(kv_cache_dtype).is_per_token_head
+
+
+def get_per_token_head_scale_dtype(kv_quant_mode: KVQuantMode) -> torch.dtype | None:
+    if kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD:
+        return torch.float16
+    if kv_quant_mode.is_per_token_head:
+        return torch.float32
+    return None
+
+
+INT4_CHANNELS_PER_SCALE = 32
+
+
+def get_int4_num_scale_groups(head_size: int) -> int:
+    return cdiv(head_size, INT4_CHANNELS_PER_SCALE)
+
+
+def get_per_token_head_scale_count(
+    head_size: int, kv_quant_mode: KVQuantMode
+) -> int:
+    if kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD:
+        return get_int4_num_scale_groups(head_size)
+    if kv_quant_mode.is_per_token_head:
+        return 1
+    return 0
+
+
+def get_kv_cache_head_size_bytes(
+    head_size: int, dtype: torch.dtype, kv_quant_mode: KVQuantMode
+) -> int:
+    if kv_quant_mode == KVQuantMode.INT4_PER_TOKEN_HEAD:
+        return cdiv(head_size, 2)
+    return head_size * get_dtype_size(dtype)
 
 
 @dataclass(frozen=True)
@@ -121,12 +157,20 @@ class AttentionSpec(KVCacheSpec):
     @property
     def page_size_bytes(self) -> int:
         real_page_size = self.real_page_size_bytes
-        # Per-token-head scales are stored in separate tensors managed
-        # by the attention backend, but the memory is carved from the
-        # raw KV cache allocation so it must be budgeted here.
-        if self.kv_quant_mode.is_per_token_head:
+        scale_dtype = get_per_token_head_scale_dtype(self.kv_quant_mode)
+        # Per-token-head scales are stored in separate typed views managed
+        # by the attention backend, but the memory is carved from the raw KV
+        # cache allocation so it must be budgeted here.
+        if scale_dtype is not None:
+            scale_count = get_per_token_head_scale_count(
+                self.head_size, self.kv_quant_mode
+            )
             real_page_size += (
-                2 * self.block_size * self.num_kv_heads * get_dtype_size(torch.float32)
+                2
+                * self.block_size
+                * self.num_kv_heads
+                * scale_count
+                * get_dtype_size(scale_dtype)
             )
         if self.page_size_padded is not None:
             assert self.page_size_padded >= real_page_size
@@ -139,8 +183,9 @@ class AttentionSpec(KVCacheSpec):
             2
             * self.block_size
             * self.num_kv_heads
-            * self.head_size
-            * get_dtype_size(self.dtype)
+            * get_kv_cache_head_size_bytes(
+                self.head_size, self.dtype, self.kv_quant_mode
+            )
         )
 
 
@@ -240,8 +285,14 @@ class FullAttentionSpec(AttentionSpec):
         return (
             self.block_size
             * self.num_kv_heads
-            * (self.head_size + self.head_size_v)
-            * get_dtype_size(self.dtype)
+            * (
+                get_kv_cache_head_size_bytes(
+                    self.head_size, self.dtype, self.kv_quant_mode
+                )
+                + get_kv_cache_head_size_bytes(
+                    self.head_size_v, self.dtype, self.kv_quant_mode
+                )
+            )
         )
 
 
@@ -259,8 +310,9 @@ class MLAAttentionSpec(FullAttentionSpec):
         return (
             self.block_size
             * self.num_kv_heads
-            * self.head_size
-            * get_dtype_size(self.dtype)
+            * get_kv_cache_head_size_bytes(
+                self.head_size, self.dtype, self.kv_quant_mode
+            )
         )
 
     @classmethod

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Sequence
 from dataclasses import dataclass
+from math import prod
 from typing import Any, cast
 
 import numpy as np
@@ -183,7 +184,20 @@ def _reshape_kv_cache(
 
             dtype = kv_cache_spec.dtype
             raw_tensor = raw_tensor.view(dtype)
-            raw_tensor = raw_tensor.view(kv_cache_shape)
+            logical_numel = prod(kv_cache_shape)
+            if raw_tensor.numel() == logical_numel:
+                raw_tensor = raw_tensor.view(kv_cache_shape)
+            else:
+                assert kv_cache_spec.page_size_padded is not None
+                elems_per_page = kv_cache_spec.page_size_bytes // raw_tensor.element_size()
+                logical_elems_per_page = logical_numel // num_blocks
+                assert logical_elems_per_page <= elems_per_page
+                contiguous_strides = torch.empty(kv_cache_shape).stride()
+                raw_tensor = torch.as_strided(
+                    raw_tensor,
+                    size=kv_cache_shape,
+                    stride=(elems_per_page, *contiguous_strides[1:]),
+                )
             kv_caches[layer_name] = raw_tensor.permute(*inv_order)
     return kv_caches
 


### PR DESCRIPTION
## Summary
- add a generic `int4_per_token_head` KV cache path with fp16 runtime scales
- add the Triton write/read/dequant plumbing for the int4 packed layout and grouped dim scales
- keep backend selection and hybrid KV cache handling aligned with the new int4 cache layout

## Validation
- `pytest tests/quantization/test_per_token_kv_cache.py -k 'hadamard or int4' -v`
- `pytest tests/kernels/attention/test_attention_selector.py -k 'per_head_quant_scales_backend_selection or flash_attn_rejects_int4_kv_cache' -v`
- `pytest tests/v1/core/test_kv_cache_utils.py -k 'unify_kv_cache_spec_page_size or get_max_concurrency_for_kv_cache_config' -v`
- non-eager serving smoke on Gemma4 26B with `--kv-cache-dtype int4_per_token_head`, `--gpu-memory-utilization 0.90`, `--compilation-config '{"cudagraph_mode":"PIECEWISE"}'`, including text, multilingual, long-context, MM, and multi-image consistency checks
- non-eager serving smoke on Gemma4 31B TP=2 with `--kv-cache-dtype int4_per_token_head`, `--gpu-memory-utilization 0.90`, `--compilation-config '{"cudagraph_mode":"PIECEWISE"}'`, including text and MM checks

## Notes
- this PR is intentionally separate from `#39460`
- runtime validation on this machine used `0.90` GPU memory utilization as the stable baseline for large Gemma4 models
