### PR TITLE
[Misc] Multi-turn benchmark output performance json

### DIFF
--- a/benchmarks/multi_turn/benchmark_serving_multi_turn.py
+++ b/benchmarks/multi_turn/benchmark_serving_multi_turn.py
@@ -1664,6 +1664,9 @@ async def main() -> None:
             f"{Color.GREEN}Writing per-request stats JSON: "
             f"{args.stats_json_output}{Color.RESET}"
         )
+        os.makedirs(
+            os.path.dirname(os.path.abspath(args.stats_json_output)), exist_ok=True
+        )
         with open(args.stats_json_output, "w") as f:
             json.dump(stats_data, f, indent=2)
 

--- a/benchmarks/multi_turn/benchmark_serving_multi_turn.py
+++ b/benchmarks/multi_turn/benchmark_serving_multi_turn.py
@@ -1440,6 +1440,12 @@ async def main() -> None:
         help="Export summary to Excel file (optional)",
     )
     parser.add_argument(
+        "--stats-json-output",
+        type=str,
+        default=None,
+        help="Export per-request stats (ttft_ms, tpot_ms, etc.) to a JSON file",
+    )
+    parser.add_argument(
         "-v",
         "--verbose",
         default=False,
@@ -1650,6 +1656,16 @@ async def main() -> None:
         excel_output=args.excel_output,
         warmup_runtime_sec=warmup_runtime_sec,
     )
+
+    if args.stats_json_output is not None:
+        # Export per-request metrics as a JSON array for downstream analysis.
+        stats_data = [s._asdict() for s in client_metrics]
+        logger.info(
+            f"{Color.GREEN}Writing per-request stats JSON: "
+            f"{args.stats_json_output}{Color.RESET}"
+        )
+        with open(args.stats_json_output, "w") as f:
+            json.dump(stats_data, f, indent=2)
 
     if args.output_file is not None:
         # Write a JSON file with the updated conversations


### PR DESCRIPTION
Small UX improvement to allow storing performance results in json, which is also more aligned with the rest of the bench suite (rather than just excel out)