### PR TITLE
fix(tool-parser): stop converting "none" strings to Python None in minimax_m2 parser

### DIFF
--- a/vllm/tool_parsers/minimax_m2_tool_parser.py
+++ b/vllm/tool_parsers/minimax_m2_tool_parser.py
@@ -160,10 +160,6 @@ class MinimaxM2ToolParser(ToolParser):
         Returns:
             The converted value
         """
-        # Check if the VALUE itself indicates null (not just if null is allowed)
-        if value.lower() in ("null", "none", "nil"):
-            return None
-
         # Normalize types
         normalized_types = [t.lower() for t in param_types]
 


### PR DESCRIPTION
The `_infer_type` method in `minimax_m2_tool_parser.py` converts string values "null", "none", "nil" to Python `None`. This breaks legitimate use cases where "none" is a valid enum value (e.g., a user selecting "none" from a list of options).

Removed the null-inference block so string values pass through unchanged and are handled by the existing type-coercion logic instead.

Fixes #39567