### PR TITLE
[Bugfix][Gemma4] Fix quantized MoE weight loading and KV cache spec merge

### DIFF
--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -168,6 +168,7 @@ class Gemma4Router(nn.Module):
             config.num_experts,
             bias=False,
             out_dtype=torch.float32,
+            quant_config=quant_config,
             prefix=f"{prefix}.proj",
         )
 
@@ -1342,13 +1343,14 @@ class Gemma4Model(nn.Module, EagleModelMixin):
                     expert_id,
                     shard_id,
                 ) in expert_params_mapping:
-                    # Match both:
-                    #  - Bare weights: "experts.0.down_proj" (from 3D explosion)
-                    #  - With suffix: "experts.0.down_proj.weight_scale" (2D quantized)
-                    # weight_name has trailing dot, so check with and without it
+                    # Match weight names in three forms:
+                    #  1. Dot suffix: "experts.0.down_proj.weight_scale"
+                    #  2. Bare weight: "experts.0.down_proj" (from 3D explosion)
+                    #  3. Underscore suffix: "experts.0.down_proj_packed"
+                    #     (from compressed-tensors / AWQ quantization)
                     weight_name_base = weight_name.rstrip(".")
                     if weight_name in name:
-                        # Has suffix (e.g., .weight_scale)
+                        # Has dot suffix (e.g., .weight_scale)
                         moe_name = name.replace(weight_name, param_name)
                     elif name.endswith(weight_name_base):
                         # Bare weight (no suffix)
@@ -1356,7 +1358,19 @@ class Gemma4Model(nn.Module, EagleModelMixin):
                             weight_name_base, param_name.rstrip("_") + "_weight"
                         )
                     else:
-                        continue
+                        # Check for underscore suffix (e.g., _packed, _scale)
+                        m_us = re.match(
+                            re.escape(weight_name_base) + r"_(\w+)$",
+                            name[name.find("experts."):] if "experts." in name else "",
+                        )
+                        if m_us:
+                            us_suffix = "_" + m_us.group(1)
+                            moe_name = name.replace(
+                                weight_name_base + us_suffix,
+                                param_name + "weight" + us_suffix,
+                            )
+                        else:
+                            continue
                     if moe_name not in params_dict:
                         continue
                     if is_pp_missing_parameter(moe_name, self):
@@ -1566,22 +1580,35 @@ class Gemma4ForCausalLM(
                 #
                 # No transpose needed: checkpoint orientation already
                 # matches FusedMoE's expected layout.
-                if "moe.gate_up_proj" in name and weight.dim() == 3:
+                #
+                # Handle both unquantized weights (gate_up_proj,
+                # down_proj) and quantized weights with suffixes
+                # (gate_up_proj_packed, gate_up_proj_scale,
+                # down_proj_packed, down_proj_scale) from
+                # compressed-tensors / AWQ quantization.
+                m_gup = re.match(r"(.*)moe\.gate_up_proj(_.*)?$", name)
+                if m_gup and weight.dim() == 3:
+                    suffix = m_gup.group(2) or ""
                     num_experts = weight.size(0)
                     intermediate_size = weight.size(1) // 2
                     for expert_id in range(num_experts):
                         gate_weight = weight[expert_id, :intermediate_size, :]
                         up_weight = weight[expert_id, intermediate_size:, :]
-                        base = name.replace("moe.", f"moe.experts.{expert_id}.")
-                        yield base.replace("gate_up_proj", "gate_proj"), gate_weight
-                        yield base.replace("gate_up_proj", "up_proj"), up_weight
+                        prefix = name[:m_gup.end(1)]
+                        yield (f"{prefix}moe.experts.{expert_id}"
+                               f".gate_proj{suffix}"), gate_weight
+                        yield (f"{prefix}moe.experts.{expert_id}"
+                               f".up_proj{suffix}"), up_weight
                     continue
 
-                if "moe.down_proj" in name and weight.dim() == 3:
+                m_dp = re.match(r"(.*)moe\.down_proj(_.*)?$", name)
+                if m_dp and weight.dim() == 3:
+                    suffix = m_dp.group(2) or ""
                     num_experts = weight.size(0)
                     for expert_id in range(num_experts):
-                        expert_name = name.replace("moe.", f"moe.experts.{expert_id}.")
-                        yield expert_name, weight[expert_id]
+                        prefix = name[:m_dp.end(1)]
+                        yield (f"{prefix}moe.experts.{expert_id}"
+                               f".down_proj{suffix}"), weight[expert_id]
                     continue
 
                 # k_eq_v layers: checkpoint has k_proj but no v_proj.

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -117,6 +117,7 @@ class AttentionSpec(KVCacheSpec):
     dtype: torch.dtype
     kv_quant_mode: KVQuantMode = KVQuantMode.NONE
     page_size_padded: int | None = None
+    cache_dtype_str: str | None = None
 
     @property
     def page_size_bytes(self) -> int:
@@ -251,8 +252,7 @@ class FullAttentionSpec(AttentionSpec):
 
 @dataclass(frozen=True, kw_only=True)
 class MLAAttentionSpec(FullAttentionSpec):
-    # TODO(Lucas/Chen): less hacky way to do this
-    cache_dtype_str: str | None = None
+    # cache_dtype_str is inherited from AttentionSpec
 
     @property
     def real_page_size_bytes(self) -> int:

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -218,6 +218,7 @@ class FullAttentionSpec(AttentionSpec):
             dtype=specs[0].dtype,
             kv_quant_mode=specs[0].kv_quant_mode,
             page_size_padded=specs[0].page_size_padded,
+            cache_dtype_str=specs[0].cache_dtype_str,
             sliding_window=cls.merge_window_sizes(sliding_window),
             attention_chunk_size=cls.merge_window_sizes(attention_chunk_size),
         )
@@ -225,7 +226,10 @@ class FullAttentionSpec(AttentionSpec):
             for f in fields(AttentionSpec):
                 assert getattr(spec, f.name) == getattr(merged_spec, f.name), (
                     "All attention layers in the same KV cache group must have "
-                    "the same attention spec."
+                    "the same attention spec. "
+                    f"Field '{f.name}': "
+                    f"{getattr(spec, f.name)!r} != "
+                    f"{getattr(merged_spec, f.name)!r}"
                 )
         assert (merged_spec.sliding_window is not None) + (
             merged_spec.attention_chunk_size is not None
@@ -413,6 +417,7 @@ class SinkFullAttentionSpec(FullAttentionSpec):
             dtype=specs[0].dtype,
             kv_quant_mode=specs[0].kv_quant_mode,
             page_size_padded=specs[0].page_size_padded,
+            cache_dtype_str=specs[0].cache_dtype_str,
             sliding_window=cls.merge_window_sizes(sliding_window),
             attention_chunk_size=cls.merge_window_sizes(attention_chunk_size),
         )
@@ -420,7 +425,10 @@ class SinkFullAttentionSpec(FullAttentionSpec):
             for f in fields(AttentionSpec):
                 assert getattr(spec, f.name) == getattr(merged_spec, f.name), (
                     "All attention layers in the same KV cache group must have "
-                    "the same attention spec."
+                    "the same attention spec. "
+                    f"Field '{f.name}': "
+                    f"{getattr(spec, f.name)!r} != "
+                    f"{getattr(merged_spec, f.name)!r}"
                 )
         assert (merged_spec.sliding_window is not None) + (
             merged_spec.attention_chunk_size is not None


### PR DESCRIPTION
## Summary

Fixes three issues that prevent serving quantized Gemma 4 MoE checkpoints (compressed-tensors / AWQ format) with vLLM:

- **3D expert weight explosion drops quantization suffixes**: `_weight_iterator` only matched exact projection names (`gate_up_proj`, `down_proj`). Quantized checkpoints use suffixed names like `gate_up_proj_packed` and `down_proj_scale`, which were silently dropped during the 3D→2D per-expert explosion, causing `KeyError` at load time.

- **Expert params mapping ignores underscore suffixes**: The mapping loop handled dot-separated suffixes (`.weight_scale`) and bare names, but not the underscore suffixes (`_packed`, `_scale`) from compressed-tensors quantization. Added a third matching branch that detects and remaps these.

- **`FullAttentionSpec.merge()` drops `cache_dtype_str`**: The merged spec was constructed without forwarding `cache_dtype_str` from the source specs. The subsequent field-equality assertion then compared `None` against `'auto'` and crashed. Fixed in both `FullAttentionSpec.merge()` and `SinkFullAttentionSpec.merge()`. Also improved the assertion message to show which field mismatches.

- **`GateLinear` missing `quant_config`**: `Gemma4Router.proj` was not passing `quant_config` to `GateLinear`, causing crashes when router weights are quantized (e.g. in AutoRound / compressed-tensors checkpoints).

### Relationship to #39406

PR #39406 makes the fallthrough path more robust by skipping unrecognized keys instead of crashing. This PR is complementary — it fixes the root cause so that quantized weight names are correctly generated and mapped in the first place, rather than falling through to the error path.

### Relationship to #39460

PR #39460 fixes GPTQ-Marlin specific issues (ceiling division for scales, quantized gate weights, GELU activation). This PR fixes the upstream weight name mapping that affects all compressed-tensors quantized Gemma 4 MoE checkpoints.

## Test plan

- [x] Verified no duplicate PR exists for these specific fixes
- [x] Loaded `cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit` (compressed-tensors W4A16) on a single RTX 3090 (24 GB VRAM)
- [x] Model loads all 4 safetensor shards without errors (Marlin WNA16 MoE backend)
- [x] Server starts and serves requests via OpenAI-compatible API
- [x] Verified correct text generation output
- [ ] Regression test: unquantized `google/gemma-4-26B-A4B-it` loading still works (needs 80 GB GPU)

AI assistance was used during development (Claude). All changes were reviewed and tested by the submitter.