### PR TITLE
fix(reasoning): apply reasoning_effort parameter in nemotron_v3 parser

### DIFF
--- a/vllm/reasoning/nemotron_v3_reasoning_parser.py
+++ b/vllm/reasoning/nemotron_v3_reasoning_parser.py
@@ -14,6 +14,24 @@ class NemotronV3ReasoningParser(DeepSeekR1ReasoningParser):
     Reasoning parser for Nemotron V3 models.
     """
 
+    def adjust_request(
+        self, request: ChatCompletionRequest | ResponsesRequest
+    ) -> ChatCompletionRequest | ResponsesRequest:
+        # Translate the OpenAI-standard reasoning_effort field into the
+        # Nemotron chat template's native kwargs (low_effort, enable_thinking)
+        # so the template can actually adjust generation behavior.
+        reasoning_effort = getattr(request, "reasoning_effort", None)
+        if reasoning_effort is not None:
+            chat_kwargs = request.chat_template_kwargs
+            if chat_kwargs is None:
+                chat_kwargs = {}
+                request.chat_template_kwargs = chat_kwargs
+            if reasoning_effort == "low" and "low_effort" not in chat_kwargs:
+                chat_kwargs["low_effort"] = True
+            if reasoning_effort == "none" and "enable_thinking" not in chat_kwargs:
+                chat_kwargs["enable_thinking"] = False
+        return request
+
     def extract_reasoning(
         self, model_output: str, request: ChatCompletionRequest | ResponsesRequest
     ) -> tuple[str | None, str | None]:


### PR DESCRIPTION
## Problem

The `nemotron_v3` reasoning parser silently ignores the OpenAI-standard `reasoning_effort` field in chat completion requests. The Nemotron chat template reads `low_effort` and `enable_thinking` kwargs to control generation behavior, but nothing translated `reasoning_effort` into those native parameters.

Sending `reasoning_effort: "low"` produces identical output to no flag at all (full chain-of-thought, ~370 tokens). Sending `reasoning_effort: "none"` hides the reasoning from the response but still generates it (~315 tokens), giving the false impression that reasoning was skipped.

## Fix

Add `adjust_request` to `NemotronV3ReasoningParser` that maps:
- `reasoning_effort="low"` → `chat_template_kwargs["low_effort"] = True`
- `reasoning_effort="none"` → `chat_template_kwargs["enable_thinking"] = False`

Existing user-provided `chat_template_kwargs` are preserved (not overwritten when already set).

## Verification

Logic verified with unit tests covering all `reasoning_effort` values (`"low"`, `"none"`, `"medium"`, `"high"`, `None`), kwargs preservation, and merge behavior.

Fixes #39581