### PR TITLE
[Pooling] Disable async scheduling by default for pooling models

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -764,6 +764,16 @@ class VllmConfig:
         elif self.scheduler_config.async_scheduling is None:
             # Enable async scheduling unless there is an incompatible option.
             if (
+                self.model_config is not None
+                and self.model_config.runner_type == "pooling"
+            ):
+                # The current implementation of asynchronous scheduling negatively
+                # impacts performance of pooling models, so we disable by default.
+                logger.debug(
+                    "Disabling asynchronous scheduling by default for pooling model."
+                )
+                self.scheduler_config.async_scheduling = False
+            elif (
                 self.speculative_config is not None
                 and self.speculative_config.method not in get_args(EagleModelTypes)
                 and self.speculative_config.method not in get_args(NgramGPUTypes)


### PR DESCRIPTION
Asynchronous scheduling mostly benefits decode performance and as currently implemented can have a negative impact on TTFT. This means overall performance of pooling models is better without it enabled, so we'll disable it by default for now for these.