### PR TITLE
fix(reasoning): translate reasoning_effort in nemotron_v3 parser

### DIFF
--- a/tests/reasoning/test_nemotron_v3_reasoning_parser.py
+++ b/tests/reasoning/test_nemotron_v3_reasoning_parser.py
@@ -170,3 +170,109 @@ def test_nemotron_v3_with_thinking_keeps_truncated_reasoning(
 
     assert reasoning == "This is truncated reasoning"
     assert content is None
+
+
+# ---------------------------------------------------------------------------
+# adjust_request tests — reasoning_effort translation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "effort,expected_kwargs",
+    [
+        pytest.param("low", {"low_effort": True}, id="low_sets_low_effort"),
+        pytest.param(
+            "none", {"enable_thinking": False}, id="none_sets_enable_thinking_false"
+        ),
+        pytest.param("medium", {}, id="medium_is_noop"),
+        pytest.param("high", {}, id="high_is_noop"),
+    ],
+)
+def test_adjust_request_reasoning_effort(
+    tokenizer: FakeNemotronTokenizer,
+    effort: str,
+    expected_kwargs: dict,
+):
+    parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+    parser = parser_cls(tokenizer)
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[],
+        reasoning_effort=effort,
+    )
+
+    result = parser.adjust_request(request)
+
+    for key, value in expected_kwargs.items():
+        assert result.chat_template_kwargs.get(key) == value
+
+
+def test_adjust_request_none_effort_is_noop(tokenizer: FakeNemotronTokenizer):
+    """reasoning_effort=None should leave chat_template_kwargs untouched."""
+    parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+    parser = parser_cls(tokenizer)
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[],
+        reasoning_effort=None,
+        chat_template_kwargs={"custom_key": "custom_value"},
+    )
+
+    result = parser.adjust_request(request)
+
+    assert result.chat_template_kwargs == {"custom_key": "custom_value"}
+
+
+def test_adjust_request_does_not_overwrite_existing_kwargs(
+    tokenizer: FakeNemotronTokenizer,
+):
+    """User-provided chat_template_kwargs must not be overwritten."""
+    parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+    parser = parser_cls(tokenizer)
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[],
+        reasoning_effort="low",
+        chat_template_kwargs={"low_effort": False},  # user explicitly set False
+    )
+
+    result = parser.adjust_request(request)
+
+    assert result.chat_template_kwargs["low_effort"] is False
+
+
+def test_adjust_request_initialises_none_chat_template_kwargs(
+    tokenizer: FakeNemotronTokenizer,
+):
+    """When chat_template_kwargs is None, it should be created as a new dict."""
+    parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+    parser = parser_cls(tokenizer)
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[],
+        reasoning_effort="low",
+        chat_template_kwargs=None,
+    )
+
+    result = parser.adjust_request(request)
+
+    assert result.chat_template_kwargs is not None
+    assert result.chat_template_kwargs["low_effort"] is True
+
+
+def test_adjust_request_none_effort_does_not_overwrite_enable_thinking_true(
+    tokenizer: FakeNemotronTokenizer,
+):
+    """reasoning_effort='none' must not override an explicit enable_thinking=True."""
+    parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+    parser = parser_cls(tokenizer)
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[],
+        reasoning_effort="none",
+        chat_template_kwargs={"enable_thinking": True},  # user explicitly wants thinking
+    )
+
+    result = parser.adjust_request(request)
+
+    assert result.chat_template_kwargs["enable_thinking"] is True

--- a/vllm/reasoning/nemotron_v3_reasoning_parser.py
+++ b/vllm/reasoning/nemotron_v3_reasoning_parser.py
@@ -14,6 +14,31 @@ class NemotronV3ReasoningParser(DeepSeekR1ReasoningParser):
     Reasoning parser for Nemotron V3 models.
     """
 
+    def adjust_request(
+        self, request: ChatCompletionRequest | ResponsesRequest
+    ) -> ChatCompletionRequest | ResponsesRequest:
+        # Translate OpenAI-standard reasoning_effort into the Nemotron chat
+        # template's native kwargs so the template actually adjusts generation.
+        # The Nemotron jinja template reads `low_effort` and `enable_thinking`;
+        # it does not read `reasoning_effort` directly.
+        reasoning_effort = getattr(request, "reasoning_effort", None)
+        if reasoning_effort is not None:
+            chat_kwargs = getattr(request, "chat_template_kwargs", None)
+            if chat_kwargs is None and hasattr(request, "chat_template_kwargs"):
+                chat_kwargs = {}
+                request.chat_template_kwargs = chat_kwargs
+            if chat_kwargs is not None:
+                if reasoning_effort == "low" and "low_effort" not in chat_kwargs:
+                    chat_kwargs["low_effort"] = True
+                elif (
+                    reasoning_effort == "none"
+                    and "enable_thinking" not in chat_kwargs
+                ):
+                    chat_kwargs["enable_thinking"] = False
+                # "medium" and "high" map to default full-thinking behavior;
+                # the template has no finer-grained knob for those levels.
+        return request
+
     def extract_reasoning(
         self, model_output: str, request: ChatCompletionRequest | ResponsesRequest
     ) -> tuple[str | None, str | None]:


### PR DESCRIPTION
## Problem

\NemotronV3ReasoningParser\ silently ignores the OpenAI-standard \easoning_effort\ field. The Nemotron chat template reads \low_effort\ and \nable_thinking\ kwargs  not \easoning_effort\  so nothing was bridging the two.

- \easoning_effort='low'\  full thinking (same as no flag)
- \easoning_effort='none'\  model still generates full CoT, response just hides it (\easoning: null\), giving a false impression that thinking was skipped

Fixes #39581.

## Fix

Add \djust_request\ to \NemotronV3ReasoningParser\ that maps:

| \easoning_effort\ | Effect |
|---|---|
| \'low'\  | \chat_template_kwargs['low_effort'] = True\ |
| \'none'\ | \chat_template_kwargs['enable_thinking'] = False\ |
| \'medium'\ / \'high'\ / \None\ | no-op (full thinking is the default) |

Key details:
- Uses \getattr\ for safe access on \ResponsesRequest\ (which lacks \chat_template_kwargs\)
- Uses \lif\  the two branches are mutually exclusive
- Never overwrites existing user-provided kwargs

## Tests

Added 6 unit tests covering:
- All effort values (\low\, \
one\, \medium\, \high\)
- \None\ effort is a no-op
- User-provided kwargs are not overwritten (e.g. \low_effort=False\ stays \False\)
- \None\ chat_template_kwargs is initialised correctly
- \easoning_effort='none'\ + preexisting \nable_thinking=True\  thinking stays on