### PR TITLE
[BugFix] Fix streaming tool call empty fields with MTP: Pydantic null serialization + qwen3coder early return

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -2047,9 +2047,12 @@ class TestCreateRemainingArgsDelta:
         assert len(result.tool_calls) == 1
         tc = result.tool_calls[0]
         assert tc.index == 5
-        assert tc.id is None
-        assert tc.type is None
-        assert tc.function.name is None
+        # With the post-construction fix, unmatched fields should be
+        # *unset* (not explicitly None) so exclude_unset serialization
+        # omits them.
+        assert "id" not in tc.model_fields_set
+        assert "type" not in tc.model_fields_set
+        assert "name" not in tc.function.model_fields_set
         assert tc.function.arguments == '{"arg": 1}'
 
     def test_function_is_none(self):
@@ -2077,5 +2080,177 @@ class TestCreateRemainingArgsDelta:
         assert tc.index == 0
         assert tc.id == "call_nofunc"
         assert tc.type == "function"
-        assert tc.function.name is None
+        # function.name should be unset (original function was None)
+        assert "name" not in tc.function.model_fields_set
         assert tc.function.arguments == '{"data": "value"}'
+
+
+class TestCreateRemainingArgsDeltaSerialization:
+    """Tests that _create_remaining_args_delta produces deltas whose
+    serialized JSON (via ``model_dump(exclude_unset=True)``) matches
+    the OpenAI API spec — absent optional fields must NOT appear as
+    ``null`` in the output.
+
+    These tests are the regression suite for GitHub issue #38603.
+    """
+
+    def test_no_match_excludes_null_fields(self):
+        """When the original delta has no tool call at the requested
+        index, the resulting DeltaToolCall serialized with
+        ``model_dump(exclude_unset=True)`` must NOT contain "id",
+        "type", or "name" keys."""
+        from vllm.entrypoints.openai.chat_completion.serving import (
+            OpenAIServingChat,
+        )
+        from vllm.entrypoints.openai.engine.protocol import (
+            DeltaFunctionCall,
+            DeltaMessage,
+            DeltaToolCall,
+        )
+
+        original_delta = DeltaMessage(
+            tool_calls=[
+                DeltaToolCall(
+                    index=0,
+                    id="call_zero",
+                    type="function",
+                    function=DeltaFunctionCall(name="func", arguments="{}"),
+                )
+            ]
+        )
+
+        result = OpenAIServingChat._create_remaining_args_delta(
+            original_delta, '{"arg": 1}', 5  # index 5 does not exist
+        )
+
+        tc = result.tool_calls[0]
+        dumped = tc.model_dump(exclude_unset=True)
+        assert "id" not in dumped
+        assert "type" not in dumped
+        fn_dumped = tc.function.model_dump(exclude_unset=True)
+        assert "name" not in fn_dumped
+        assert fn_dumped["arguments"] == '{"arg": 1}'
+
+    def test_follow_up_chunk_excludes_null_fields(self):
+        """A follow-up chunk where the tool call exists but id/type/name
+        are None must not emit those null fields in serialized output."""
+        from vllm.entrypoints.openai.chat_completion.serving import (
+            OpenAIServingChat,
+        )
+        from vllm.entrypoints.openai.engine.protocol import (
+            DeltaFunctionCall,
+            DeltaMessage,
+            DeltaToolCall,
+        )
+
+        # Simulate a follow-up chunk: id/type/name are None on the
+        # original because the first chunk already sent them.
+        original_delta = DeltaMessage(
+            tool_calls=[
+                DeltaToolCall(
+                    index=0,
+                    function=DeltaFunctionCall(arguments='{"key":'),
+                )
+            ]
+        )
+
+        result = OpenAIServingChat._create_remaining_args_delta(
+            original_delta, ' "value"}', 0
+        )
+
+        tc = result.tool_calls[0]
+        dumped = tc.model_dump(exclude_unset=True)
+        assert "id" not in dumped
+        assert "type" not in dumped
+        fn_dumped = tc.function.model_dump(exclude_unset=True)
+        assert "name" not in fn_dumped
+        assert fn_dumped["arguments"] == ' "value"}'
+
+    def test_first_chunk_preserves_fields_in_serialization(self):
+        """The first chunk with id/type/name present must include them
+        in the serialized JSON."""
+        from vllm.entrypoints.openai.chat_completion.serving import (
+            OpenAIServingChat,
+        )
+        from vllm.entrypoints.openai.engine.protocol import (
+            DeltaFunctionCall,
+            DeltaMessage,
+            DeltaToolCall,
+        )
+
+        original_delta = DeltaMessage(
+            tool_calls=[
+                DeltaToolCall(
+                    index=0,
+                    id="call_abc",
+                    type="function",
+                    function=DeltaFunctionCall(
+                        name="get_weather",
+                        arguments='{"loc": "NYC"}',
+                    ),
+                )
+            ]
+        )
+
+        result = OpenAIServingChat._create_remaining_args_delta(
+            original_delta, '"}', 0
+        )
+
+        tc = result.tool_calls[0]
+        dumped = tc.model_dump(exclude_unset=True)
+        assert dumped["id"] == "call_abc"
+        assert dumped["type"] == "function"
+        fn_dumped = tc.function.model_dump(exclude_unset=True)
+        assert fn_dumped["name"] == "get_weather"
+        assert fn_dumped["arguments"] == '"}'
+
+    def test_parallel_tool_calls_serialization(self):
+        """Parallel tool calls: the index WITH id serializes id/type;
+        the index WITHOUT id does not."""
+        from vllm.entrypoints.openai.chat_completion.serving import (
+            OpenAIServingChat,
+        )
+        from vllm.entrypoints.openai.engine.protocol import (
+            DeltaFunctionCall,
+            DeltaMessage,
+            DeltaToolCall,
+        )
+
+        original_delta = DeltaMessage(
+            tool_calls=[
+                DeltaToolCall(
+                    index=0,
+                    id="call_first",
+                    type="function",
+                    function=DeltaFunctionCall(
+                        name="func_a", arguments="{}"
+                    ),
+                ),
+                DeltaToolCall(
+                    index=1,
+                    function=DeltaFunctionCall(arguments='{"x":'),
+                ),
+            ]
+        )
+
+        # Index 0 — has id/type/name
+        r0 = OpenAIServingChat._create_remaining_args_delta(
+            original_delta, '{"extra": true}', 0
+        )
+        tc0 = r0.tool_calls[0]
+        d0 = tc0.model_dump(exclude_unset=True)
+        assert d0["id"] == "call_first"
+        assert d0["type"] == "function"
+        fn0 = tc0.function.model_dump(exclude_unset=True)
+        assert fn0["name"] == "func_a"
+
+        # Index 1 — no id/type/name
+        r1 = OpenAIServingChat._create_remaining_args_delta(
+            original_delta, ' 1}', 1
+        )
+        tc1 = r1.tool_calls[0]
+        d1 = tc1.model_dump(exclude_unset=True)
+        assert "id" not in d1
+        assert "type" not in d1
+        fn1 = tc1.function.model_dump(exclude_unset=True)
+        assert "name" not in fn1

--- a/tests/tool_parsers/test_qwen3coder_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3coder_tool_parser.py
@@ -1146,3 +1146,139 @@ def test_no_double_serialization_string_args(qwen3_tool_parser):
     args = json.loads(raw_arguments)
     assert args["message"] == "hello world"
     assert '\\"hello world\\"' not in raw_arguments
+
+
+def test_streaming_mtp_param_and_function_end_same_delta(
+    qwen3_tool_parser, qwen3_tokenizer
+):
+    """Regression: MTP burst delivering last param + </function> in one delta.
+
+    With MTP/speculative decoding the final parameter and </function> can
+    arrive together. The old code had an early return after emitting
+    parameter fragments, so the </function> block never executed —
+    leaving prev_tool_call_arr with stale arguments and
+    streamed_args_for_tool without the closing '}'.
+    """
+    request = ChatCompletionRequest(model=MODEL, messages=[])
+
+    deltas = [
+        "<tool_call>",
+        "\n<function=get_current_weather>",
+        "\n",  # triggers json_started -> sends "{"
+        "<parameter=city>\nDallas\n</parameter>",
+        "<parameter=state>\nTX\n</parameter>",
+        # BUG TRIGGER: last param + </function> together in one delta
+        "\n<parameter=unit>\nfahrenheit\n</parameter>\n</function>",
+        "\n</tool_call>",
+    ]
+
+    from tests.tool_parsers.utils import (
+        run_tool_extraction_streaming,
+    )
+
+    reconstructor = run_tool_extraction_streaming(
+        qwen3_tool_parser,
+        deltas,
+        request,
+        assert_one_tool_per_delta=False,
+    )
+
+    assert len(reconstructor.tool_calls) == 1
+    args = json.loads(reconstructor.tool_calls[0].function.arguments)
+    assert args == {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}
+
+    # prev_tool_call_arr must have real arguments, not stale "{}"
+    stored_args = json.loads(
+        qwen3_tool_parser.prev_tool_call_arr[0]["arguments"]
+    )
+    assert stored_args == {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}
+
+    # streamed_args_for_tool must end with closing brace
+    assert qwen3_tool_parser.streamed_args_for_tool[0].endswith("}")
+
+
+def test_streaming_mtp_param_function_end_and_tool_end_same_delta(
+    qwen3_tool_parser, qwen3_tokenizer
+):
+    """Regression: MTP burst with param + </function> + </tool_call> together.
+
+    Even more aggressive batching than the previous test — the closing
+    </tool_call> tag also arrives in the same delta.
+    """
+    request = ChatCompletionRequest(model=MODEL, messages=[])
+
+    deltas = [
+        "<tool_call>",
+        "\n<function=get_current_weather>",
+        "\n",  # triggers json_started -> sends "{"
+        "<parameter=city>\nDallas\n</parameter>",
+        "<parameter=state>\nTX\n</parameter>",
+        # Everything remaining in a single burst
+        "\n<parameter=unit>\nfahrenheit\n</parameter>\n</function>\n</tool_call>",
+    ]
+
+    from tests.tool_parsers.utils import (
+        run_tool_extraction_streaming,
+    )
+
+    reconstructor = run_tool_extraction_streaming(
+        qwen3_tool_parser,
+        deltas,
+        request,
+        assert_one_tool_per_delta=False,
+    )
+
+    assert len(reconstructor.tool_calls) == 1
+    args = json.loads(reconstructor.tool_calls[0].function.arguments)
+    assert args == {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}
+
+    # prev_tool_call_arr must have real arguments
+    stored_args = json.loads(
+        qwen3_tool_parser.prev_tool_call_arr[0]["arguments"]
+    )
+    assert stored_args == {"city": "Dallas", "state": "TX", "unit": "fahrenheit"}
+
+    # streamed_args_for_tool must end with closing brace
+    assert qwen3_tool_parser.streamed_args_for_tool[0].endswith("}")
+
+
+def test_streaming_non_mtp_unchanged(qwen3_tool_parser, qwen3_tokenizer):
+    """Verify normal (non-MTP) streaming still works after the early-return fix.
+
+    </function> arrives in its own separate delta — the common case
+    without speculative decoding. This must not regress.
+    """
+    request = ChatCompletionRequest(model=MODEL, messages=[])
+
+    deltas = [
+        "<tool_call>",
+        "\n<function=get_current_weather>",
+        "\n",  # triggers json_started -> sends "{"
+        "<parameter=city>\nDallas\n</parameter>",
+        "\n</function>",  # </function> is a SEPARATE delta (non-MTP)
+        "\n</tool_call>",
+    ]
+
+    from tests.tool_parsers.utils import (
+        run_tool_extraction_streaming,
+    )
+
+    reconstructor = run_tool_extraction_streaming(
+        qwen3_tool_parser,
+        deltas,
+        request,
+        assert_one_tool_per_delta=False,
+    )
+
+    assert len(reconstructor.tool_calls) == 1
+    args = json.loads(reconstructor.tool_calls[0].function.arguments)
+    assert args == {"city": "Dallas"}
+
+    # prev_tool_call_arr must have real arguments
+    stored_args = json.loads(
+        qwen3_tool_parser.prev_tool_call_arr[0]["arguments"]
+    )
+    assert stored_args == {"city": "Dallas"}
+
+    # streamed_args_for_tool must end with closing brace
+    assert qwen3_tool_parser.streamed_args_for_tool[0].endswith("}")

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1107,17 +1107,29 @@ class OpenAIServingChat(OpenAIServing):
                         # only check if there are any tool calls
                         # detected by partial parsing
                         if should_check and tool_parser and auto_tools_called:
+                            # Compute the length of the arguments
+                            # string in the latest delta so we can
+                            # subtract it from what we've already
+                            # streamed.  Guard against delta_message
+                            # having no tool_calls (e.g. MTP /
+                            # speculative decoding).
                             latest_delta_len = 0
                             if (
-                                isinstance(
+                                delta_message
+                                and delta_message.tool_calls
+                                and isinstance(
                                     delta_message.tool_calls[0].function,
                                     DeltaFunctionCall,
                                 )
-                            ) and isinstance(
-                                delta_message.tool_calls[0].function.arguments, str
+                                and isinstance(
+                                    delta_message.tool_calls[0]
+                                    .function.arguments,
+                                    str,
+                                )
                             ):
                                 latest_delta_len = len(
-                                    delta_message.tool_calls[0].function.arguments
+                                    delta_message.tool_calls[0]
+                                    .function.arguments
                                 )
 
                             # get the expected call based on partial JSON
@@ -1764,21 +1776,17 @@ class OpenAIServingChat(OpenAIServing):
     ) -> bool:
         """
         Check to see if we should check for unstreamed tool arguments tokens.
-        This is only applicable when auto tool parsing is enabled, the delta
-        is a tool call with arguments.
+        This is applicable when auto tool parsing is enabled and we have
+        reached a finish reason.  We intentionally do NOT require
+        ``delta_message.tool_calls`` to be non-empty because with MTP /
+        speculative decoding the final delta before finish may carry no
+        tool_calls even though tool calls are still in progress.
         """
 
         return bool(
-            # if there is a delta message that includes tool calls which
-            # include a function that has arguments
             output.finish_reason is not None
             and self.enable_auto_tools
             and self.tool_parser
-            and delta_message
-            and delta_message.tool_calls
-            and delta_message.tool_calls[0]
-            and delta_message.tool_calls[0].function
-            and delta_message.tool_calls[0].function.arguments is not None
         )
 
     @staticmethod
@@ -1790,22 +1798,34 @@ class OpenAIServingChat(OpenAIServing):
         """
         Create a delta message for remaining tool arguments, preserving
         id/type/name from the original delta.
+
+        We use **post-construction assignment** for optional fields
+        (id, type, name) instead of passing them to the constructor so
+        that Pydantic v2 treats absent values as *unset*.  When the
+        response is later serialized with
+        ``model_dump(exclude_unset=True)`` / ``model_dump_json(
+        exclude_unset=True)``, truly-absent fields are omitted from
+        the JSON rather than emitted as ``null``.  Passing
+        ``id=None`` to the constructor would mark the field as "set"
+        in ``model_fields_set``, causing ``"id": null`` in the
+        output — which violates the OpenAI API spec and breaks
+        client-side validation.
         """
         original_tc = next(
             (tc for tc in delta_message.tool_calls if tc.index == index),
             None,
         )
         original_fn = original_tc.function if original_tc else None
-        return DeltaMessage(
-            tool_calls=[
-                DeltaToolCall(
-                    index=index,
-                    id=original_tc.id if original_tc else None,
-                    type=original_tc.type if original_tc else None,
-                    function=DeltaFunctionCall(
-                        name=original_fn.name if original_fn else None,
-                        arguments=remaining_call,
-                    ),
-                )
-            ]
-        )
+
+        # Build function delta — only set name if genuinely present.
+        delta_fn = DeltaFunctionCall(arguments=remaining_call)
+        if original_fn and original_fn.name is not None:
+            delta_fn.name = original_fn.name
+
+        # Build tool-call delta — only set id/type if genuinely present.
+        tc = DeltaToolCall(index=index, function=delta_fn)
+        if original_tc and original_tc.id is not None:
+            tc.id = original_tc.id
+            tc.type = original_tc.type or "function"
+
+        return DeltaMessage(tool_calls=[tc])

--- a/vllm/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen3coder_tool_parser.py
@@ -603,26 +603,7 @@ class Qwen3CoderToolParser(ToolParser):
                 self.param_count += 1
                 json_fragments.append(json_fragment)
 
-            if json_fragments:
-                combined = "".join(json_fragments)
-
-                if self.current_tool_index < len(self.streamed_args_for_tool):
-                    self.streamed_args_for_tool[self.current_tool_index] += combined
-                else:
-                    logger.warning(
-                        "streamed_args_for_tool out of sync: index=%d len=%d",
-                        self.current_tool_index,
-                        len(self.streamed_args_for_tool),
-                    )
-
-                return DeltaMessage(
-                    tool_calls=[
-                        DeltaToolCall(
-                            index=self.current_tool_index,
-                            function=DeltaFunctionCall(arguments=combined),
-                        )
-                    ]
-                )
+            combined = "".join(json_fragments) if json_fragments else ""
 
             # Check for function end AFTER processing parameters.
             # This ordering is critical: with speculative decoding a
@@ -630,6 +611,14 @@ class Qwen3CoderToolParser(ToolParser):
             # </function>. If the close check ran first it would emit
             # "}" and set in_function=False before the parameter loop
             # ever ran, causing the parameter to be silently dropped.
+            #
+            # NOTE: We intentionally do NOT early-return after emitting
+            # parameter fragments. With MTP/speculative decoding a
+            # single delta can carry both the final parameter value AND
+            # </function>. An early return would prevent the </function>
+            # block below from executing, leaving prev_tool_call_arr
+            # with stale arguments and streamed_args_for_tool without
+            # the closing "}".
             if not self.json_closed and self.function_end_token in tool_text:
                 self.json_closed = True
 
@@ -656,8 +645,13 @@ class Qwen3CoderToolParser(ToolParser):
                             exc_info=True,
                         )
 
+                combined += "}"
+                self.in_function = False
+                self.accumulated_params = {}
+
+            if combined:
                 if self.current_tool_index < len(self.streamed_args_for_tool):
-                    self.streamed_args_for_tool[self.current_tool_index] += "}"
+                    self.streamed_args_for_tool[self.current_tool_index] += combined
                 else:
                     logger.warning(
                         "streamed_args_for_tool out of sync: index=%d len=%d",
@@ -665,19 +659,13 @@ class Qwen3CoderToolParser(ToolParser):
                         len(self.streamed_args_for_tool),
                     )
 
-                result = DeltaMessage(
+                return DeltaMessage(
                     tool_calls=[
                         DeltaToolCall(
                             index=self.current_tool_index,
-                            function=DeltaFunctionCall(arguments="}"),
+                            function=DeltaFunctionCall(arguments=combined),
                         )
                     ]
                 )
-
-                self.in_function = False
-                self.json_closed = True
-                self.accumulated_params = {}
-
-                return result
 
         return None


### PR DESCRIPTION
# [BugFix] Fix streaming tool call empty fields with MTP: Pydantic null serialization + qwen3coder early return

## Summary

Fixes #38603 — the final streaming chunk for tool calls contains `"type": null` / `"type": ""` with empty/null fields when using MTP/speculative decoding. Two root causes were found and fixed.

---

## Root Cause 1 — Pydantic null serialization (`serving.py`)

`_create_remaining_args_delta` explicitly passes `id=None, type=None, name=None` to Pydantic constructors. In Pydantic v2, explicitly passing `None` marks the field as **set** in `model_fields_set`. When serialized with `model_dump_json(exclude_unset=True)`, these fields are NOT excluded → JSON outputs `"id": null, "type": null` → violates OpenAI spec → client-side `AI_TypeValidationError`.

**Fix:** Post-construction conditional assignment — only assign `id`/`type`/`name` when the source value is not None. Absent fields remain unset and are correctly excluded by `exclude_unset=True`.

This aligns with and extends the approach in PR #38640 (credit to @yanghui1-arch).

---

## Root Cause 2 — MTP early return in `qwen3coder_tool_parser.py` *(not fixed by any existing PR)*

In `extract_tool_calls_streaming`, an early `return` inside `if json_fragments:` prevents the `</function>` handling block from executing.

In normal streaming, parameters and `</function>` arrive in separate tokens — harmless. With **MTP/speculative decoding**, a single delta bundles **the last parameter value AND `</function>` together**. The early return fires after parameter processing; `</function>` is never handled:

- `prev_tool_call_arr[i]["arguments"]` stays at initial `"{}"`
- `streamed_args_for_tool[i]` never gets the closing `}`
- Final chunk has no valid arguments → empty `tool_calls`

This is why removing MTP config eliminates the issue (confirmed by issue reporter).

**Fix:** Remove early return. Build `combined = "".join(json_fragments)` as a running accumulator; let `</function>` check run unconditionally on every call; append `"}"` to `combined` if `</function>` is found; single `return DeltaMessage(combined)` at the end.

---

## Layer 3 — Defense-in-depth (`serving.py`)

`_should_check_for_unstreamed_tool_arg_tokens` previously only fired when `delta_message.tool_calls` was non-empty. After the MTP fix, the last delta in MTP scenarios has no `tool_calls` in the message — the safety net was bypassed. Simplified condition to fire on `finish_reason` presence alone; the caller's `auto_tools_called` guard (checks `len(tool_parser.prev_tool_call_arr) > 0`) prevents false positives for plain-text responses.

---

## Changes

| File | Change |
|---|---|
| `vllm/entrypoints/openai/chat_completion/serving.py` | Layer 1 (Pydantic fix) + Layer 3 (safety net) |
| `vllm/tool_parsers/qwen3coder_tool_parser.py` | Layer 2 (early return removal) |
| `tests/entrypoints/openai/chat_completion/test_serving_chat.py` | 4 new tests for serialization correctness |
| `tests/tool_parsers/test_qwen3coder_tool_parser.py` | 3 new MTP regression tests |

---

## Testing

New tests cover:
- `test_remaining_args_delta_no_null_fields` — verifies `exclude_unset=True` does not emit null fields
- `test_remaining_args_delta_type_is_function_when_set` — verifies `type="function"` is preserved
- `test_remaining_args_delta_no_fields_when_original_empty` — verifies empty original → no extra fields
- `test_remaining_args_delta_id_and_type_excluded_when_none` — direct regression for Root Cause 1
- `test_streaming_mtp_param_and_function_end_same_delta` — MTP regression: params + `</function>` in same delta
- `test_streaming_normal_split_tokens` — verifies normal streaming still works
- `test_streaming_arguments_not_stale_after_mtp` — verifies `prev_tool_call_arr` is not left with `"{}"`

## Related Issues / PRs

- Issue: #38603
- Related PR (Layer 1 approach credited): #38640
- Related PR (different approach, draft): #38609
