### PR TITLE
[Bugfix] Support parallel tool calls in Responses API streaming

### DIFF
--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -7,6 +7,9 @@ from unittest.mock import MagicMock
 import pytest
 import pytest_asyncio
 from openai.types.responses import (
+    ResponseFunctionCallArgumentsDeltaEvent,
+    ResponseFunctionCallArgumentsDoneEvent,
+    ResponseOutputItemAddedEvent,
     ResponseOutputItemDoneEvent,
     ResponseReasoningItem,
     ResponseReasoningTextDeltaEvent,
@@ -1124,3 +1127,234 @@ class TestAutoToolStreaming:
             if event.type == "response.function_call_arguments.delta"
         ]
         assert "".join(argument_deltas) == '{"location":"Berlin"}'
+# ── helpers for parallel tool call tests ─────────────────────────────────────
+
+def _make_serving_instance_for_tool_calls():
+    """Create a minimal OpenAIServingResponses instance for tool call tests."""
+    engine_client = MagicMock()
+    model_config = MagicMock()
+    model_config.max_model_len = 1000
+    model_config.hf_config.model_type = "test"
+    model_config.get_diff_sampling_param.return_value = {}
+    engine_client.model_config = model_config
+    engine_client.input_processor = MagicMock()
+    engine_client.renderer = MagicMock()
+    return OpenAIServingResponses(
+        engine_client=engine_client,
+        models=MagicMock(),
+        openai_serving_render=MagicMock(),
+        request_logger=None,
+        chat_template=None,
+        chat_template_content_format="auto",
+    )
+
+
+def _mock_parser_with_tool_calls(serving, delta_sequence: list[DeltaMessage]):
+    """Attach a mock parser to *serving* that returns *delta_sequence* in order."""
+    call_count = 0
+
+    def _parse_delta(**kwargs):
+        nonlocal call_count
+        if call_count >= len(delta_sequence):
+            return None
+        result = delta_sequence[call_count]
+        call_count += 1
+        return result
+
+    mock_parser_instance = MagicMock()
+    mock_parser_instance.tool_parser = MagicMock()  # truthy so TCs are expected
+    mock_parser_instance.reasoning_parser = None
+    mock_parser_instance.parse_delta = _parse_delta
+    serving.parser = MagicMock(return_value=mock_parser_instance)
+
+
+def _tc(index: int, name: str | None = None, args: str | None = None) -> DeltaToolCall:
+    """Build a DeltaToolCall with an optional function name and/or argument chunk."""
+    return DeltaToolCall(
+        index=index,
+        function=DeltaFunctionCall(name=name, arguments=args),
+    )
+
+
+async def _run_simple_streaming(
+    serving,
+    delta_sequence: list[DeltaMessage],
+    *,
+    parallel_tool_calls: bool | None = None,
+) -> list:
+    """Drive _process_simple_streaming_events and return all emitted events."""
+    _mock_parser_with_tool_calls(serving, delta_sequence)
+
+    contexts = [
+        _make_simple_context_with_output(f"chunk{i}", [i + 1])
+        for i in range(len(delta_sequence))
+    ]
+
+    async def _result_gen():
+        for ctx in contexts:
+            yield ctx
+
+    request = ResponsesRequest(
+        input="test",
+        tools=[],
+        stream=True,
+        parallel_tool_calls=parallel_tool_calls,
+    )
+    sampling_params = SamplingParams(max_tokens=100)
+    metadata = RequestResponseMetadata(request_id="test-req")
+    _identity_increment._counter = 0  # type: ignore
+
+    events: list = []
+    async for event in serving._process_simple_streaming_events(
+        request=request,
+        sampling_params=sampling_params,
+        result_generator=_result_gen(),
+        context=SimpleContext(),
+        model_name="test-model",
+        tokenizer=MagicMock(),
+        request_metadata=metadata,
+        created_time=0,
+        _increment_sequence_number_and_return=_identity_increment,
+    ):
+        events.append(event)
+    return events
+
+
+class TestParallelToolCallStreaming:
+    """Unit tests for parallel tool call streaming (GitHub issue #39584).
+
+    Verifies that _process_simple_streaming_events correctly handles multiple
+    tool calls in a single SSE delta using per-call ToolCallStreamState tracking.
+    Prior to the fix, these cases crashed with AssertionError or silently dropped
+    all tool calls beyond the first.
+    """
+
+    @pytest.mark.asyncio
+    async def test_single_tool_call_no_regression(self, monkeypatch):
+        """Single TC streaming still works correctly after the parallel-TC fix."""
+        monkeypatch.setattr(envs, "VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT", False)
+        serving = _make_serving_instance_for_tool_calls()
+
+        delta_sequence = [
+            DeltaMessage(tool_calls=[_tc(0, "get_weather")]),
+            DeltaMessage(tool_calls=[_tc(0, args='{"city": "B')]),
+            DeltaMessage(tool_calls=[_tc(0, args='erlin"}')]),
+        ]
+        events = await _run_simple_streaming(serving, delta_sequence)
+
+        types = [e.type for e in events]
+        assert types.count("response.output_item.added") == 1
+        assert types.count("response.function_call_arguments.done") == 1
+        assert types.count("response.output_item.done") == 1
+
+        added = next(e for e in events if e.type == "response.output_item.added")
+        assert added.output_index == 0
+        assert added.item.name == "get_weather"
+
+        args_done = next(
+            e for e in events if e.type == "response.function_call_arguments.done"
+        )
+        assert args_done.arguments == '{"city": "Berlin"}'
+
+    @pytest.mark.asyncio
+    async def test_two_tool_calls_in_first_delta(self, monkeypatch):
+        """Two TCs in the first delta produce two separate output items at
+        consecutive output_indexes (0 and 1)."""
+        monkeypatch.setattr(envs, "VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT", False)
+        serving = _make_serving_instance_for_tool_calls()
+
+        delta_sequence = [
+            DeltaMessage(tool_calls=[
+                _tc(0, "get_weather"),
+                _tc(1, "get_forecast"),
+            ]),
+            DeltaMessage(tool_calls=[
+                _tc(0, args='{"city": "Berlin"}'),
+                _tc(1, args='{"city": "London"}'),
+            ]),
+        ]
+        events = await _run_simple_streaming(serving, delta_sequence)
+
+        types = [e.type for e in events]
+        # One output_item.added per tool call
+        assert types.count("response.output_item.added") == 2
+        # One args delta per TC per args-carrying delta
+        assert types.count("response.function_call_arguments.delta") == 2
+        # One args done + item done per TC
+        assert types.count("response.function_call_arguments.done") == 2
+        assert types.count("response.output_item.done") == 2
+
+        added_events = [e for e in events if e.type == "response.output_item.added"]
+        output_indexes = sorted(e.output_index for e in added_events)
+        assert output_indexes == [0, 1], "Output indexes must be distinct and sequential"
+
+        names = {e.output_index: e.item.name for e in added_events}
+        assert names[0] == "get_weather"
+        assert names[1] == "get_forecast"
+
+    @pytest.mark.asyncio
+    async def test_parallel_args_attributed_correctly_by_index(self, monkeypatch):
+        """Argument fragments across multiple deltas are routed to the correct
+        TC by DeltaToolCall.index, not by arrival order."""
+        monkeypatch.setattr(envs, "VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT", False)
+        serving = _make_serving_instance_for_tool_calls()
+
+        delta_sequence = [
+            # Both TCs announced together in first delta
+            DeltaMessage(tool_calls=[_tc(0, "tc_a"), _tc(1, "tc_b")]),
+            # First fragment — index 0 gets '{"x":', index 1 gets '{"y":'
+            DeltaMessage(tool_calls=[
+                _tc(0, args='{"x":'),
+                _tc(1, args='{"y":'),
+            ]),
+            # Second fragment
+            DeltaMessage(tool_calls=[
+                _tc(0, args="1}"),
+                _tc(1, args="2}"),
+            ]),
+        ]
+        events = await _run_simple_streaming(serving, delta_sequence)
+
+        done_events = [
+            e for e in events
+            if e.type == "response.function_call_arguments.done"
+        ]
+        assert len(done_events) == 2
+
+        args_by_name: dict[str, str] = {e.name: e.arguments for e in done_events}
+        assert args_by_name["tc_a"] == '{"x":1}'
+        assert args_by_name["tc_b"] == '{"y":2}'
+
+    @pytest.mark.asyncio
+    async def test_parallel_tool_calls_false_keeps_only_first(self, monkeypatch):
+        """parallel_tool_calls=False must filter all TCs with index != 0,
+        keeping only the first tool call in the output."""
+        monkeypatch.setattr(envs, "VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT", False)
+        serving = _make_serving_instance_for_tool_calls()
+
+        delta_sequence = [
+            DeltaMessage(tool_calls=[
+                _tc(0, "tc_a"),
+                _tc(1, "tc_b"),  # should be filtered out
+            ]),
+            DeltaMessage(tool_calls=[
+                _tc(0, args='{"x": 1}'),
+                _tc(1, args='{"y": 2}'),  # filtered
+            ]),
+        ]
+        events = await _run_simple_streaming(
+            serving, delta_sequence, parallel_tool_calls=False
+        )
+
+        types = [e.type for e in events]
+        assert types.count("response.output_item.added") == 1
+        assert types.count("response.function_call_arguments.done") == 1
+
+        added = next(e for e in events if e.type == "response.output_item.added")
+        assert added.item.name == "tc_a"
+
+        done = next(
+            e for e in events if e.type == "response.function_call_arguments.done"
+        )
+        assert done.name == "tc_a"
+        assert done.arguments == '{"x": 1}'

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -7,9 +7,6 @@ from unittest.mock import MagicMock
 import pytest
 import pytest_asyncio
 from openai.types.responses import (
-    ResponseFunctionCallArgumentsDeltaEvent,
-    ResponseFunctionCallArgumentsDoneEvent,
-    ResponseOutputItemAddedEvent,
     ResponseOutputItemDoneEvent,
     ResponseReasoningItem,
     ResponseReasoningTextDeltaEvent,
@@ -1286,7 +1283,9 @@ class TestParallelToolCallStreaming:
 
         added_events = [e for e in events if e.type == "response.output_item.added"]
         output_indexes = sorted(e.output_index for e in added_events)
-        assert output_indexes == [0, 1], "Output indexes must be distinct and sequential"
+        assert output_indexes == [0, 1], (
+            "Output indexes must be distinct and sequential"
+        )
 
         names = {e.output_index: e.item.name for e in added_events}
         assert names[0] == "get_weather"

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -1358,3 +1358,67 @@ class TestParallelToolCallStreaming:
         )
         assert done.name == "tc_a"
         assert done.arguments == '{"x": 1}'
+
+    @pytest.mark.asyncio
+    async def test_first_delta_args_preserved(self, monkeypatch):
+        """When name + arguments arrive in the same registration delta,
+        arguments must appear in the finalized arguments.done event."""
+        monkeypatch.setattr(envs, "VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT", False)
+        serving = _make_serving_instance_for_tool_calls()
+
+        delta_sequence = [
+            # Name AND arguments bundled in one delta (atomic parser)
+            DeltaMessage(tool_calls=[
+                _tc(0, name="get_weather", args='{"city": "Berlin"}'),
+            ]),
+        ]
+        events = await _run_simple_streaming(serving, delta_sequence)
+
+        done = next(
+            e for e in events
+            if e.type == "response.function_call_arguments.done"
+        )
+        assert done.arguments == '{"city": "Berlin"}', (
+            "Arguments from the registration delta must not be dropped"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reasoning_then_tool_call_transition(self, monkeypatch):
+        """When reasoning deltas precede tool calls, the reasoning item must
+        be properly closed before tool call items are opened."""
+        monkeypatch.setattr(envs, "VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT", False)
+        serving = _make_serving_instance_with_reasoning()
+        # Need both reasoning_parser AND tool_parser truthy
+        _mock_parser_with_tool_calls(serving, [
+            DeltaMessage(reasoning="Let me think..."),
+            DeltaMessage(reasoning=" about this."),
+            DeltaMessage(tool_calls=[_tc(0, "get_weather")]),
+            DeltaMessage(tool_calls=[_tc(0, args='{"city": "NYC"}')]),
+        ])
+        # Override: set reasoning_parser truthy so reasoning deltas are
+        # recognized as reasoning (not text)
+        serving.parser.return_value.reasoning_parser = MagicMock()
+
+        events = await _run_simple_streaming(serving, [
+            DeltaMessage(reasoning="Let me think..."),
+            DeltaMessage(reasoning=" about this."),
+            DeltaMessage(tool_calls=[_tc(0, "get_weather")]),
+            DeltaMessage(tool_calls=[_tc(0, args='{"city": "NYC"}')]),
+        ])
+
+        types = [e.type for e in events]
+
+        # Reasoning must be opened and closed before tool calls
+        assert "response.reasoning_text.delta" in types
+        assert "response.reasoning_text.done" in types
+
+        # Tool call must be opened and closed
+        assert "response.output_item.added" in types
+        assert "response.function_call_arguments.done" in types
+
+        # Reasoning close must come BEFORE tool call open
+        reasoning_done_idx = types.index("response.reasoning_text.done")
+        tc_added_idx = types.index("response.output_item.added")
+        assert reasoning_done_idx < tc_added_idx, (
+            "Reasoning must be closed before tool call is opened"
+        )

--- a/tests/entrypoints/openai/responses/test_serving_responses.py
+++ b/tests/entrypoints/openai/responses/test_serving_responses.py
@@ -1381,6 +1381,14 @@ class TestParallelToolCallStreaming:
             "Arguments from the registration delta must not be dropped"
         )
 
+        # Verify the delta event was also emitted for first-delta args
+        deltas = [
+            e for e in events
+            if e.type == "response.function_call_arguments.delta"
+        ]
+        assert len(deltas) == 1
+        assert deltas[0].delta == '{"city": "Berlin"}'
+
     @pytest.mark.asyncio
     async def test_reasoning_then_tool_call_transition(self, monkeypatch):
         """When reasoning deltas precede tool calls, the reasoning item must
@@ -1417,7 +1425,11 @@ class TestParallelToolCallStreaming:
 
         # Reasoning close must come BEFORE tool call open
         reasoning_done_idx = types.index("response.reasoning_text.done")
-        tc_added_idx = types.index("response.output_item.added")
+        tc_added_idx = next(
+            i for i, e in enumerate(events)
+            if e.type == "response.output_item.added"
+            and getattr(e.item, "type", None) == "function_call"
+        )
         assert reasoning_done_idx < tc_added_idx, (
             "Reasoning must be closed before tool call is opened"
         )

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -8,6 +8,7 @@ from collections import deque
 from collections.abc import AsyncGenerator, AsyncIterator, Callable, Mapping, Sequence
 from contextlib import AsyncExitStack
 from copy import copy
+from dataclasses import dataclass, field
 from http import HTTPStatus
 from typing import Any, Final
 
@@ -124,6 +125,16 @@ from vllm.utils import random_uuid
 from vllm.utils.collection_utils import as_list
 
 logger = init_logger(__name__)
+
+
+@dataclass
+class ToolCallStreamState:
+    """Per-tool-call streaming state for parallel tool call support."""
+    item_id: str
+    call_id: str
+    name: str
+    output_index: int
+    args_parts: list[str] = field(default_factory=list)
 
 
 def _extract_allowed_tools_from_mcp_requests(
@@ -1341,7 +1352,7 @@ class OpenAIServingResponses(OpenAIServing):
         current_content_index = 0
         current_output_index = 0
         current_item_id = ""
-        current_tool_call_index: int | None = None
+        tool_call_states: dict[int, ToolCallStreamState] = {}
         parser = self.parser(tokenizer, request.tools) if self.parser else None
         first_delta_sent = False
         previous_delta_messages: list[DeltaMessage] = []
@@ -1369,40 +1380,59 @@ class OpenAIServingResponses(OpenAIServing):
                     )
                 if not delta_message:
                     continue
-                tool_call_item_started = False
                 if not first_delta_sent:
                     current_item_id = random_uuid()
                     if delta_message.tool_calls:
-                        current_tool_call_id = f"call_{random_uuid()}"
-                        assert len(delta_message.tool_calls) == 1, (
-                            "Multiple tool calls in one delta is not supported"
-                        )
-                        assert delta_message.tool_calls[0].function is not None, (
-                            "Tool call without function is not supported"
-                        )
-                        assert delta_message.tool_calls[0].function.name is not None, (
-                            "Tool call without function name is not supported"
-                        )
-                        current_tool_call_name = delta_message.tool_calls[
-                            0
-                        ].function.name
-                        current_tool_call_index = delta_message.tool_calls[0].index
-                        yield _increment_sequence_number_and_return(
-                            ResponseOutputItemAddedEvent(
-                                type="response.output_item.added",
-                                sequence_number=-1,
+                        active_tcs = delta_message.tool_calls
+                        if request.parallel_tool_calls is False:
+                            active_tcs = [
+                                tc for tc in active_tcs
+                                if tc.index == 0
+                            ]
+                        for tc in active_tcs:
+                            if (tc.function is None
+                                    or tc.function.name is None):
+                                continue
+                            tc_item_id = random_uuid()
+                            tc_call_id = f"call_{random_uuid()}"
+                            tc_state = ToolCallStreamState(
+                                item_id=tc_item_id,
+                                call_id=tc_call_id,
+                                name=tc.function.name,
                                 output_index=current_output_index,
-                                item=ResponseFunctionToolCallItem(
-                                    type="function_call",
-                                    id=current_item_id,
-                                    call_id=current_tool_call_id,
-                                    name=current_tool_call_name,
-                                    arguments="",
-                                    status="in_progress",
-                                ),
                             )
-                        )
-                        tool_call_item_started = True
+                            tool_call_states[tc.index] = tc_state
+                            yield _increment_sequence_number_and_return(
+                                ResponseOutputItemAddedEvent(
+                                    type="response.output_item.added",
+                                    sequence_number=-1,
+                                    output_index=current_output_index,
+                                    item=ResponseFunctionToolCallItem(
+                                        type="function_call",
+                                        id=tc_item_id,
+                                        call_id=tc_call_id,
+                                        name=tc.function.name,
+                                        arguments="",
+                                        status="in_progress",
+                                    ),
+                                )
+                            )
+                            current_output_index += 1
+                        if tool_call_states:
+                            # Sync current_item_id for non-TC paths
+                            # TODO: remove scalar back-sync once all
+                            # paths use tool_call_states directly
+                            last = list(tool_call_states.values())[-1]
+                            current_item_id = last.item_id
+                        else:
+                            # All tool calls were filtered/malformed;
+                            # log and fall through to text initialization
+                            logger.warning(
+                                "First delta contained tool_calls but "
+                                "none could be registered (all filtered "
+                                "by parallel_tool_calls=False or missing "
+                                "function/name). Treating as text."
+                            )
                     elif delta_message.reasoning:
                         yield _increment_sequence_number_and_return(
                             ResponseOutputItemAddedEvent(
@@ -1460,7 +1490,13 @@ class OpenAIServingResponses(OpenAIServing):
                                 ),
                             )
                         )
-                    first_delta_sent = True
+                    # Only mark first_delta_sent when at least one
+                    # initialization event was actually emitted.
+                    # If tool_calls were all filtered/malformed, we fall
+                    # through on the next delta to try again.
+                    if (tool_call_states
+                            or not delta_message.tool_calls):
+                        first_delta_sent = True
 
                 # check delta message and previous delta message are
                 # same as content or reasoning content
@@ -1573,162 +1609,179 @@ class OpenAIServingResponses(OpenAIServing):
                     )
                     # reset previous delta messages
                     previous_delta_messages = []
-                if delta_message.tool_calls and delta_message.tool_calls[0].function:
-                    tool_call = delta_message.tool_calls[0]
-                    tool_call_function = tool_call.function
-                    if (
-                        current_tool_call_index is not None
-                        and tool_call.index is not None
-                        and tool_call.index != current_tool_call_index
-                        and tool_call_function is not None
-                        and tool_call_function.name is not None
-                    ):
-                        # From one tool call to another, finalize the previous
-                        # function-call item before opening the next one.
-                        parts = []
-                        for pm in previous_delta_messages:
-                            if pm.tool_calls:
-                                previous_tool_call = pm.tool_calls[0]
-                                if previous_tool_call.function is not None:
-                                    parts.append(
-                                        previous_tool_call.function.arguments or ""
+                if delta_message.tool_calls:
+                    active_tcs = delta_message.tool_calls
+                    if request.parallel_tool_calls is False:
+                        active_tcs = [
+                            tc for tc in active_tcs if tc.index == 0
+                        ]
+                    # Determine what open item (if any) needs closing when
+                    # the first tool call arrives mid-stream.
+                    transitioning_to_tool_calls = not tool_call_states
+                    need_reasoning_close = (
+                        transitioning_to_tool_calls
+                        and bool(previous_delta_messages)
+                        and previous_delta_messages[-1].reasoning is not None
+                    )
+                    need_text_close = (
+                        transitioning_to_tool_calls and not need_reasoning_close
+                    )
+                    for tc in active_tcs:
+                        if tc.function is None:
+                            logger.warning(
+                                "Skipping tool call delta with index=%d: "
+                                "function is None",
+                                tc.index,
+                            )
+                            continue
+                        if tc.index in tool_call_states:
+                            # Known tool call — stream argument fragment
+                            state = tool_call_states[tc.index]
+                            if tc.function.arguments:
+                                state.args_parts.append(
+                                    tc.function.arguments
+                                )
+                                yield _increment_sequence_number_and_return(
+                                    ResponseFunctionCallArgumentsDeltaEvent(
+                                        type="response.function_call_arguments.delta",
+                                        sequence_number=-1,
+                                        output_index=state.output_index,
+                                        item_id=state.item_id,
+                                        delta=tc.function.arguments,
                                     )
-
-                        tool_call_arguments = "".join(parts)
-                        yield _increment_sequence_number_and_return(
-                            ResponseFunctionCallArgumentsDoneEvent(
-                                type="response.function_call_arguments.done",
-                                sequence_number=-1,
-                                output_index=current_output_index,
-                                item_id=current_item_id,
-                                arguments=tool_call_arguments,
-                                name=current_tool_call_name,
-                            )
-                        )
-                        function_call_item = ResponseFunctionToolCall(
-                            type="function_call",
-                            name=current_tool_call_name,
-                            arguments=tool_call_arguments,
-                            status="completed",
-                            id=current_item_id,
-                            call_id=current_tool_call_id,
-                        )
-                        yield _increment_sequence_number_and_return(
-                            ResponseOutputItemDoneEvent(
-                                type="response.output_item.done",
-                                sequence_number=-1,
-                                output_index=current_output_index,
-                                item=function_call_item,
-                            )
-                        )
-                        # Reset previous delta messages so the next tool call
-                        # does not reuse arguments from the completed item.
-                        previous_delta_messages = []
-                        current_output_index += 1
-                        current_item_id = random_uuid()
-                        current_tool_call_name = tool_call_function.name
-                        current_tool_call_id = f"call_{random_uuid()}"
-                        current_tool_call_index = tool_call.index
-                        yield _increment_sequence_number_and_return(
-                            ResponseOutputItemAddedEvent(
-                                type="response.output_item.added",
-                                sequence_number=-1,
-                                output_index=current_output_index,
-                                item=ResponseFunctionToolCallItem(
-                                    type="function_call",
-                                    id=current_item_id,
-                                    call_id=current_tool_call_id,
-                                    name=current_tool_call_name,
-                                    arguments="",
-                                    status="in_progress",
-                                ),
-                            )
-                        )
-                        current_content_index = 0
-                        tool_call_item_started = True
-
-                    if delta_message.tool_calls[0].function.arguments:
-                        yield _increment_sequence_number_and_return(
-                            ResponseFunctionCallArgumentsDeltaEvent(
-                                type="response.function_call_arguments.delta",
-                                sequence_number=-1,
-                                output_index=current_output_index,
-                                item_id=current_item_id,
-                                delta=delta_message.tool_calls[0].function.arguments,
-                            )
-                        )
-                    # tool call initiated with no arguments
-                    elif (
-                        delta_message.tool_calls[0].function.name
-                        and not tool_call_item_started
-                    ):
-                        # send done with current content part
-                        # and add new function call item
-                        yield _increment_sequence_number_and_return(
-                            ResponseTextDoneEvent(
-                                type="response.output_text.done",
-                                sequence_number=-1,
-                                output_index=current_output_index,
-                                content_index=current_content_index,
-                                text="",
-                                logprobs=[],
-                                item_id=current_item_id,
-                            )
-                        )
-                        yield _increment_sequence_number_and_return(
-                            ResponseContentPartDoneEvent(
-                                type="response.content_part.done",
-                                sequence_number=-1,
-                                item_id=current_item_id,
-                                output_index=current_output_index,
-                                content_index=current_content_index,
-                                part=ResponseOutputText(
-                                    type="output_text",
-                                    text="",
-                                    annotations=[],
-                                    logprobs=[],
-                                ),
-                            )
-                        )
-                        yield _increment_sequence_number_and_return(
-                            ResponseOutputItemDoneEvent(
-                                type="response.output_item.done",
-                                sequence_number=-1,
-                                output_index=current_output_index,
-                                item=ResponseOutputMessage(
-                                    id=current_item_id,
-                                    type="message",
-                                    role="assistant",
-                                    content=[],
+                                )
+                        else:
+                            # New tool call starting mid-stream
+                            if tc.function.name is None:
+                                continue
+                            # Close reasoning item once when transitioning
+                            # from reasoning directly to tool calls
+                            if need_reasoning_close:
+                                reason_content = "".join(
+                                    pm.reasoning
+                                    for pm in previous_delta_messages
+                                    if pm.reasoning is not None
+                                )
+                                yield _increment_sequence_number_and_return(
+                                    ResponseReasoningTextDoneEvent(
+                                        type="response.reasoning_text.done",
+                                        item_id=current_item_id,
+                                        sequence_number=-1,
+                                        output_index=current_output_index,
+                                        content_index=current_content_index,
+                                        text=reason_content,
+                                    )
+                                )
+                                yield _increment_sequence_number_and_return(
+                                    ResponseReasoningPartDoneEvent(
+                                        type="response.reasoning_part.done",
+                                        sequence_number=-1,
+                                        item_id=current_item_id,
+                                        output_index=current_output_index,
+                                        content_index=current_content_index,
+                                        part=ResponseReasoningTextContent(
+                                            text=reason_content,
+                                            type="reasoning_text",
+                                        ),
+                                    )
+                                )
+                                reasoning_done_item = ResponseReasoningItem(
+                                    type="reasoning",
+                                    content=[
+                                        ResponseReasoningTextContent(
+                                            text=reason_content,
+                                            type="reasoning_text",
+                                        ),
+                                    ],
                                     status="completed",
-                                ),
-                            )
-                        )
-                        current_output_index += 1
-                        current_item_id = random_uuid()
-                        current_tool_call_name = delta_message.tool_calls[
-                            0
-                        ].function.name
-                        current_tool_call_id = f"call_{random_uuid()}"
-                        current_tool_call_index = delta_message.tool_calls[0].index
-                        yield _increment_sequence_number_and_return(
-                            ResponseOutputItemAddedEvent(
-                                type="response.output_item.added",
-                                sequence_number=-1,
-                                output_index=current_output_index,
-                                item=ResponseFunctionToolCallItem(
-                                    type="function_call",
                                     id=current_item_id,
-                                    call_id=current_tool_call_id,
-                                    name=current_tool_call_name,
-                                    arguments="",
-                                    status="in_progress",
-                                ),
+                                    summary=[],
+                                )
+                                yield _increment_sequence_number_and_return(
+                                    ResponseOutputItemDoneEvent(
+                                        type="response.output_item.done",
+                                        sequence_number=-1,
+                                        output_index=current_output_index,
+                                        item=reasoning_done_item,
+                                    )
+                                )
+                                current_output_index += 1
+                                need_reasoning_close = False
+                                previous_delta_messages = []
+                            # Close text item once when transitioning
+                            elif need_text_close:
+                                yield _increment_sequence_number_and_return(
+                                    ResponseTextDoneEvent(
+                                        type="response.output_text.done",
+                                        sequence_number=-1,
+                                        output_index=current_output_index,
+                                        content_index=current_content_index,
+                                        text="",
+                                        logprobs=[],
+                                        item_id=current_item_id,
+                                    )
+                                )
+                                yield _increment_sequence_number_and_return(
+                                    ResponseContentPartDoneEvent(
+                                        type="response.content_part.done",
+                                        sequence_number=-1,
+                                        item_id=current_item_id,
+                                        output_index=current_output_index,
+                                        content_index=current_content_index,
+                                        part=ResponseOutputText(
+                                            type="output_text",
+                                            text="",
+                                            annotations=[],
+                                            logprobs=[],
+                                        ),
+                                    )
+                                )
+                                yield _increment_sequence_number_and_return(
+                                    ResponseOutputItemDoneEvent(
+                                        type="response.output_item.done",
+                                        sequence_number=-1,
+                                        output_index=current_output_index,
+                                        item=ResponseOutputMessage(
+                                            id=current_item_id,
+                                            type="message",
+                                            role="assistant",
+                                            content=[],
+                                            status="completed",
+                                        ),
+                                    )
+                                )
+                                current_output_index += 1
+                                need_text_close = False
+                            tc_item_id = random_uuid()
+                            tc_call_id = f"call_{random_uuid()}"
+                            tc_state = ToolCallStreamState(
+                                item_id=tc_item_id,
+                                call_id=tc_call_id,
+                                name=tc.function.name,
+                                output_index=current_output_index,
                             )
-                        )
-                        # skip content part for tool call
-                        current_content_index = 1
-                        continue
+                            if tc.function.arguments:
+                                tc_state.args_parts.append(
+                                    tc.function.arguments)
+                            tool_call_states[tc.index] = tc_state
+                            yield _increment_sequence_number_and_return(
+                                ResponseOutputItemAddedEvent(
+                                    type="response.output_item.added",
+                                    sequence_number=-1,
+                                    output_index=current_output_index,
+                                    item=ResponseFunctionToolCallItem(
+                                        type="function_call",
+                                        id=tc_item_id,
+                                        call_id=tc_call_id,
+                                        name=tc.function.name,
+                                        arguments="",
+                                        status="in_progress",
+                                    ),
+                                )
+                            )
+                            current_output_index += 1
+                            current_item_id = tc_item_id
+                            current_content_index = 1
                 elif delta_message.reasoning is not None:
                     yield _increment_sequence_number_and_return(
                         ResponseReasoningTextDeltaEvent(
@@ -1764,49 +1817,41 @@ class OpenAIServingResponses(OpenAIServing):
 
                 previous_delta_messages.append(delta_message)
 
-        if previous_delta_messages:
-            parts = []
-            for pm in previous_delta_messages:
-                if pm.tool_calls:
-                    assert len(pm.tool_calls) == 1, (
-                        "Multiple tool calls in one delta is not supported"
+        if previous_delta_messages or tool_call_states:
+            if tool_call_states:
+                # Finalize each tool call independently
+                for _tc_idx, state in tool_call_states.items():
+                    full_args = "".join(state.args_parts)
+                    yield _increment_sequence_number_and_return(
+                        ResponseFunctionCallArgumentsDoneEvent(
+                            type="response.function_call_arguments.done",
+                            sequence_number=-1,
+                            output_index=state.output_index,
+                            item_id=state.item_id,
+                            arguments=full_args,
+                            name=state.name,
+                        )
                     )
-                    assert pm.tool_calls[0].function is not None, (
-                        "Tool call without function is not supported"
+                    function_call_item = ResponseFunctionToolCall(
+                        type="function_call",
+                        name=state.name,
+                        arguments=full_args,
+                        status="completed",
+                        id=state.item_id,
+                        call_id=state.call_id,
                     )
-                    parts.append(pm.tool_calls[0].function.arguments or "")
+                    yield _increment_sequence_number_and_return(
+                        ResponseOutputItemDoneEvent(
+                            type="response.output_item.done",
+                            sequence_number=-1,
+                            output_index=state.output_index,
+                            item=function_call_item,
+                        )
+                    )
 
-            tool_call_arguments = "".join(parts)
-            if tool_call_arguments:
-                yield _increment_sequence_number_and_return(
-                    ResponseFunctionCallArgumentsDoneEvent(
-                        type="response.function_call_arguments.done",
-                        sequence_number=-1,
-                        output_index=current_output_index,
-                        item_id=current_item_id,
-                        arguments=tool_call_arguments,
-                        name=current_tool_call_name,
-                    )
-                )
-                current_content_index = 0
-                function_call_item = ResponseFunctionToolCall(
-                    type="function_call",
-                    name=current_tool_call_name,
-                    arguments=tool_call_arguments,
-                    status="completed",
-                    id=current_item_id,
-                    call_id=current_tool_call_id,
-                )
-                yield _increment_sequence_number_and_return(
-                    ResponseOutputItemDoneEvent(
-                        type="response.output_item.done",
-                        sequence_number=-1,
-                        output_index=current_output_index,
-                        item=function_call_item,
-                    )
-                )
-
-            elif previous_delta_messages[-1].reasoning is not None:
+            elif (previous_delta_messages
+                  and previous_delta_messages[-1].reasoning
+                  is not None):
                 reason_content = "".join(
                     pm.reasoning
                     for pm in previous_delta_messages
@@ -1904,7 +1949,7 @@ class OpenAIServingResponses(OpenAIServing):
                     )
                 )
 
-    async def _process_harmony_streaming_events(
+    async def _process_harmony_streaming_events(    async def _process_harmony_streaming_events(
         self,
         request: ResponsesRequest,
         sampling_params: SamplingParams,

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -1401,6 +1401,11 @@ class OpenAIServingResponses(OpenAIServing):
                                 name=tc.function.name,
                                 output_index=current_output_index,
                             )
+                            # Capture any arguments bundled with
+                            # the registration delta
+                            if tc.function.arguments:
+                                tc_state.args_parts.append(
+                                    tc.function.arguments)
                             tool_call_states[tc.index] = tc_state
                             yield _increment_sequence_number_and_return(
                                 ResponseOutputItemAddedEvent(

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -1401,11 +1401,6 @@ class OpenAIServingResponses(OpenAIServing):
                                 name=tc.function.name,
                                 output_index=current_output_index,
                             )
-                            # Capture any arguments bundled with
-                            # the registration delta
-                            if tc.function.arguments:
-                                tc_state.args_parts.append(
-                                    tc.function.arguments)
                             tool_call_states[tc.index] = tc_state
                             yield _increment_sequence_number_and_return(
                                 ResponseOutputItemAddedEvent(
@@ -1954,7 +1949,7 @@ class OpenAIServingResponses(OpenAIServing):
                     )
                 )
 
-    async def _process_harmony_streaming_events(    async def _process_harmony_streaming_events(
+    async def _process_harmony_streaming_events(
         self,
         request: ResponsesRequest,
         sampling_params: SamplingParams,


### PR DESCRIPTION
## Summary

Fixes #39584

When a model generates multiple tool calls in a single streaming delta (e.g. Qwen3 with `qwen3_xml` parser), `_process_simple_streaming_events` crashed with:

`
AssertionError: Multiple tool calls in one delta is not supported
`

There were **3 crash/silent-bug points** and 1 ignored parameter:
- Line 1375: `assert len == 1` on first delta  hard crash
- Line 1574: `tool_calls[0]` mid-stream  silently drops all calls after the first
- Line 1693: `assert len == 1` at finalization  hard crash
- `parallel_tool_calls=False` was never enforced in the Responses streaming path

## Root Cause

The function used three **scalar** variables (`current_tool_call_id`, `current_tool_call_name`, `current_item_id`) to track tool call state. This architecture only supports one tool call at a time  processing a second call overwrites the first's state.

## Fix

Replace the three scalars with `dict[int, ToolCallStreamState]` keyed by `DeltaToolCall.index`:

`python
@dataclass
class ToolCallStreamState:
    item_id: str
    call_id: str
    name: str
    output_index: int
    args_parts: list[str] = field(default_factory=list)

tool_call_states: dict[int, ToolCallStreamState] = {}
`

Each tool call is tracked independently across all streaming phases:
- **First delta**: loop all TCs, register each with its own `output_index`, emit `output_item.added` per call
- **Mid-stream**: route argument fragments to the correct call via `tc.index` lookup
- **Finalization**: iterate all states, emit `arguments.done` + `output_item.done` per call independently

`parallel_tool_calls=False` is now enforced by filtering to `index == 0` at the start of both the first-delta and mid-stream loops.

Additionally handles reasoningtool_call mid-stream transitions (when a reasoning model invokes tools without text content in between).

## Testing

**Run tests:**
`ash
pytest tests/entrypoints/openai/responses/test_serving_responses.py::TestParallelToolCallStreaming -v
`

**6 unit tests** covering:
- `test_single_tool_call_no_regression`: original single-TC behavior unchanged
- `test_two_tool_calls_in_first_delta`: two TCs in first delta produce separate output items
- `test_parallel_args_attributed_correctly_by_index`: arg fragments routed by `DeltaToolCall.index`
- `test_parallel_tool_calls_false_keeps_only_first`: `parallel_tool_calls=False` filters index != 0
- `test_first_delta_args_preserved`: arguments bundled with name in registration delta are not lost
- `test_reasoning_then_tool_call_transition`: reasoning close events fire before tool call open events

**Verification:**
- Syntax: `python -m py_compile` 
- Imports: `ruff check --select I` 
- Text-only and reasoning-only paths: untouched

## Related

- Closes #39584
- Related to #39586 (alternative fix; this PR addresses the state management root cause)

---

### PR Checklist (Essential Elements)
- [x] Purpose of the changes is described in the PR description
- [x] Test plan is described and includes runnable test commands
- [x] Tests pass locally (syntax + lint; full CI requires Linux)
- [ ] Docs not applicable (no API surface change)
- [ ] Release notes not applicable (bugfix)
