### PR TITLE
[Bugfix] Fix glm4_moe_tool_parser._is_string_type for /v1/responses FunctionTool format

### DIFF
--- a/tests/tool_parsers/test_glm4_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm4_moe_tool_parser.py
@@ -5,6 +5,7 @@ import json
 from unittest.mock import Mock
 
 import pytest
+from openai.types.responses import FunctionTool
 
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
@@ -12,6 +13,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     FunctionDefinition,
 )
 from vllm.entrypoints.openai.engine.protocol import FunctionCall, ToolCall
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.tokenizers import get_tokenizer
 from vllm.tool_parsers.glm4_moe_tool_parser import (
     Glm4MoeModelToolParser,
@@ -1363,3 +1365,105 @@ def test_stream_interval_content_between_tool_calls(
     args1 = json.loads("".join(tools_found[1]["args_fragments"]))
     assert args0 == {"city": "Beijing"}
     assert args1 == {"city": "Shanghai"}
+
+def test_extract_tool_calls_with_responses_format_tools(glm4_moe_tokenizer):
+    """Test extract tool call with Responses API FunctionTool input.
+
+    The parser's _is_string_type reads self.tools (set at construction),
+    so we must pass FunctionTool via the constructor — not request.tools —
+    to actually exercise _extract_tool_info with FunctionTool objects.
+    """
+    responses_tools = [
+        FunctionTool(
+            type="function",
+            name="get_weather",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                },
+            },
+        )
+    ]
+
+    # Key: parser constructed with FunctionTool so self.tools has FunctionTool
+    parser = Glm4MoeModelToolParser(glm4_moe_tokenizer, tools=responses_tools)
+
+    request = Mock(spec=ResponsesRequest)
+    request.tools = responses_tools
+
+    model_output = """<tool_call>get_weather
+<arg_key>city</arg_key>
+<arg_value>Beijing</arg_value>
+</tool_call>"""
+
+    extracted_tool_calls = parser.extract_tool_calls(
+        model_output, request=request
+    )
+
+    assert extracted_tool_calls.tools_called
+    assert len(extracted_tool_calls.tool_calls) == 1
+    assert extracted_tool_calls.tool_calls[0].function.name == "get_weather"
+
+    args = json.loads(extracted_tool_calls.tool_calls[0].function.arguments)
+
+    assert args["city"] == "Beijing"
+    assert isinstance(args["city"], str)
+
+
+def test_extract_tool_calls_with_responses_format_tools_streaming(
+    glm4_moe_tokenizer,
+):
+    """Test streaming extract tool call with Responses API FunctionTool input.
+
+    Same as the non-streaming variant: parser must be constructed with
+    FunctionTool so self.tools contains FunctionTool objects, otherwise
+    _is_string_type never calls _extract_tool_info on FunctionTool.
+    """
+    responses_tools = [
+        FunctionTool(
+            type="function",
+            name="get_weather",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "city": {"type": "string"},
+                },
+            },
+        )
+    ]
+
+    # Key: parser constructed with FunctionTool so self.tools has FunctionTool
+    parser = Glm4MoeModelToolParser(glm4_moe_tokenizer, tools=responses_tools)
+    _reset_streaming_state(parser)
+
+    request = Mock(spec=ResponsesRequest)
+    request.tools = responses_tools
+
+    chunks = [
+        "<tool_call>",
+        "get_weather\n",
+        "<arg_key>city</arg_key>",
+        "<arg_value>",
+        "Bei",
+        "jing",
+        "</arg_value>",
+        "</tool_call>",
+    ]
+
+    for chunk in chunks:
+        parser.extract_tool_calls_streaming(
+            previous_text="",
+            current_text="",
+            delta_text=chunk,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=request,
+        )
+
+    assert len(parser.streamed_args_for_tool) == 1
+    args = json.loads(parser.streamed_args_for_tool[0])
+
+    assert args["city"] == "Beijing"
+    assert isinstance(args["city"], str)

--- a/tests/tool_parsers/test_glm4_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm4_moe_tool_parser.py
@@ -13,7 +13,6 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     FunctionDefinition,
 )
 from vllm.entrypoints.openai.engine.protocol import FunctionCall, ToolCall
-from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.tokenizers import get_tokenizer
 from vllm.tool_parsers.glm4_moe_tool_parser import (
     Glm4MoeModelToolParser,
@@ -1367,14 +1366,12 @@ def test_stream_interval_content_between_tool_calls(
     assert args1 == {"city": "Shanghai"}
 
 
-def test_extract_tool_calls_with_responses_format_tools(glm4_moe_tokenizer):
-    """Test extract tool call with Responses API FunctionTool input.
+# ── FunctionTool (Responses API) tests ──────────────────────────────
 
-    The parser's _is_string_type reads self.tools (set at construction),
-    so we must pass FunctionTool via the constructor — not request.tools —
-    to actually exercise _extract_tool_info with FunctionTool objects.
-    """
-    responses_tools = [
+
+@pytest.fixture
+def function_tools():
+    return [
         FunctionTool(
             type="function",
             name="get_weather",
@@ -1382,87 +1379,107 @@ def test_extract_tool_calls_with_responses_format_tools(glm4_moe_tokenizer):
                 "type": "object",
                 "properties": {
                     "city": {"type": "string"},
+                    "unit": {"type": "string"},
                 },
             },
-        )
+        ),
+        FunctionTool(
+            type="function",
+            name="calculate",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "operation": {"type": "string"},
+                    "a": {"type": "number"},
+                    "b": {"type": "number"},
+                },
+            },
+        ),
     ]
 
-    # Key: parser constructed with FunctionTool so self.tools has FunctionTool
-    parser = Glm4MoeModelToolParser(glm4_moe_tokenizer, tools=responses_tools)
 
-    request = Mock(spec=ResponsesRequest)
-    request.tools = responses_tools
+@pytest.fixture
+def glm4_moe_parser_function_tools(glm4_moe_tokenizer, function_tools):
+    return Glm4MoeModelToolParser(glm4_moe_tokenizer, tools=function_tools)
 
+
+@pytest.fixture
+def mock_request_function_tools(function_tools) -> ChatCompletionRequest:
+    request = Mock(spec=ChatCompletionRequest)
+    request.tools = function_tools
+    return request
+
+
+def test_extract_tool_calls_with_function_tool(
+    glm4_moe_parser_function_tools, mock_request_function_tools
+):
     model_output = """<tool_call>get_weather
 <arg_key>city</arg_key>
-<arg_value>Beijing</arg_value>
+<arg_value>Dallas</arg_value>
+<arg_key>unit</arg_key>
+<arg_value>fahrenheit</arg_value>
 </tool_call>"""
 
-    extracted_tool_calls = parser.extract_tool_calls(model_output, request=request)
+    extracted = glm4_moe_parser_function_tools.extract_tool_calls(
+        model_output, request=mock_request_function_tools
+    )
+    assert extracted.tools_called
+    assert len(extracted.tool_calls) == 1
+    assert extracted.tool_calls[0].function.name == "get_weather"
+    args = json.loads(extracted.tool_calls[0].function.arguments)
+    assert args["city"] == "Dallas"
+    assert args["unit"] == "fahrenheit"
 
-    assert extracted_tool_calls.tools_called
-    assert len(extracted_tool_calls.tool_calls) == 1
-    assert extracted_tool_calls.tool_calls[0].function.name == "get_weather"
 
-    args = json.loads(extracted_tool_calls.tool_calls[0].function.arguments)
-
-    assert args["city"] == "Beijing"
-    assert isinstance(args["city"], str)
-
-
-def test_extract_tool_calls_with_responses_format_tools_streaming(
-    glm4_moe_tokenizer,
+def test_extract_tool_calls_with_function_tool_mixed_types(
+    glm4_moe_parser_function_tools, mock_request_function_tools
 ):
-    """Test streaming extract tool call with Responses API FunctionTool input.
+    model_output = """<tool_call>calculate
+<arg_key>operation</arg_key>
+<arg_value>add</arg_value>
+<arg_key>a</arg_key>
+<arg_value>42</arg_value>
+<arg_key>b</arg_key>
+<arg_value>3.14</arg_value>
+</tool_call>"""
 
-    Same as the non-streaming variant: parser must be constructed with
-    FunctionTool so self.tools contains FunctionTool objects, otherwise
-    _is_string_type never calls _extract_tool_info on FunctionTool.
-    """
-    responses_tools = [
-        FunctionTool(
-            type="function",
-            name="get_weather",
-            parameters={
-                "type": "object",
-                "properties": {
-                    "city": {"type": "string"},
-                },
-            },
-        )
-    ]
+    extracted = glm4_moe_parser_function_tools.extract_tool_calls(
+        model_output, request=mock_request_function_tools
+    )
+    assert extracted.tools_called
+    args = json.loads(extracted.tool_calls[0].function.arguments)
+    assert args["operation"] == "add"
+    assert isinstance(args["a"], (int, float))
+    assert isinstance(args["b"], float)
 
-    # Key: parser constructed with FunctionTool so self.tools has FunctionTool
-    parser = Glm4MoeModelToolParser(glm4_moe_tokenizer, tools=responses_tools)
-    _reset_streaming_state(parser)
 
-    request = Mock(spec=ResponsesRequest)
-    request.tools = responses_tools
+def test_streaming_with_function_tool(
+    glm4_moe_parser_function_tools, mock_request_function_tools
+):
+    _reset_streaming_state(glm4_moe_parser_function_tools)
 
     chunks = [
-        "<tool_call>",
-        "get_weather\n",
+        "<tool_call>get_weather\n",
         "<arg_key>city</arg_key>",
-        "<arg_value>",
-        "Bei",
+        "<arg_value>Bei",
         "jing",
         "</arg_value>",
         "</tool_call>",
     ]
 
+    current_text = ""
     for chunk in chunks:
-        parser.extract_tool_calls_streaming(
+        current_text += chunk
+        glm4_moe_parser_function_tools.extract_tool_calls_streaming(
             previous_text="",
-            current_text="",
+            current_text=current_text,
             delta_text=chunk,
             previous_token_ids=[],
             current_token_ids=[],
             delta_token_ids=[],
-            request=request,
+            request=mock_request_function_tools,
         )
 
-    assert len(parser.streamed_args_for_tool) == 1
-    args = json.loads(parser.streamed_args_for_tool[0])
-
+    assert len(glm4_moe_parser_function_tools.prev_tool_call_arr) == 1
+    args = json.loads(glm4_moe_parser_function_tools.prev_tool_call_arr[0]["arguments"])
     assert args["city"] == "Beijing"
-    assert isinstance(args["city"], str)

--- a/tests/tool_parsers/test_glm4_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm4_moe_tool_parser.py
@@ -1366,6 +1366,7 @@ def test_stream_interval_content_between_tool_calls(
     assert args0 == {"city": "Beijing"}
     assert args1 == {"city": "Shanghai"}
 
+
 def test_extract_tool_calls_with_responses_format_tools(glm4_moe_tokenizer):
     """Test extract tool call with Responses API FunctionTool input.
 

--- a/tests/tool_parsers/test_glm4_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm4_moe_tool_parser.py
@@ -1397,9 +1397,7 @@ def test_extract_tool_calls_with_responses_format_tools(glm4_moe_tokenizer):
 <arg_value>Beijing</arg_value>
 </tool_call>"""
 
-    extracted_tool_calls = parser.extract_tool_calls(
-        model_output, request=request
-    )
+    extracted_tool_calls = parser.extract_tool_calls(model_output, request=request)
 
     assert extracted_tool_calls.tools_called
     assert len(extracted_tool_calls.tool_calls) == 1

--- a/vllm/tool_parsers/glm4_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm4_moe_tool_parser.py
@@ -38,7 +38,11 @@ from vllm.tool_parsers.abstract_tool_parser import (
     Tool,
     ToolParser,
 )
-from vllm.tool_parsers.utils import _extract_tool_info, partial_tag_overlap
+from vllm.tool_parsers.utils import (
+    extract_types_from_schema,
+    find_tool_properties,
+    partial_tag_overlap,
+)
 
 logger = init_logger(__name__)
 
@@ -123,26 +127,13 @@ class Glm4MoeModelToolParser(ToolParser):
             return ""
         return json.dumps(s, ensure_ascii=False)[1:-1]
 
-    @staticmethod
-    def _is_string_type(
-        tool_name: str,
-        arg_name: str,
-        tools: list[Tool] | None,
-    ) -> bool:
-        if tools is None:
+    def _is_string_type(self, tool_name: str, arg_name: str) -> bool:
+        tool_properties = find_tool_properties(self.tools, tool_name)
+        param_schema = tool_properties.get(arg_name)
+        if param_schema is None:
             return False
-        for tool in tools:
-            name, parameters = _extract_tool_info(tool)
-            if name != tool_name:
-                continue
-            if parameters is None:
-                return False
-            arg_type = (
-                parameters.get("properties", {}).get(arg_name, {}).get("type", None)
-            )
-            return arg_type == "string"
-        logger.debug("No tool named '%s'.", tool_name)
-        return False
+        param_types = extract_types_from_schema(param_schema)
+        return set(param_types) - {"null"} == {"string"}
 
     @staticmethod
     def _tools_enabled(request: ChatCompletionRequest) -> bool:
@@ -209,7 +200,7 @@ class Glm4MoeModelToolParser(ToolParser):
                 arg_dct: dict[str, Any] = {}
                 for key, value in pairs:
                     arg_key = key.strip()
-                    if self._is_string_type(tc_name, arg_key, self.tools):
+                    if self._is_string_type(tc_name, arg_key):
                         arg_val = value
                     else:
                         arg_val = self._deserialize(value.strip())
@@ -351,7 +342,7 @@ class Glm4MoeModelToolParser(ToolParser):
         for key, value in pairs:
             key = key.strip()
             key_json = json.dumps(key, ensure_ascii=False)
-            if self._is_string_type(tool_name, key, self.tools):
+            if self._is_string_type(tool_name, key):
                 # Don't strip string values — whitespace is significant
                 # and must match the partial-value path for diffing.
                 val_json = json.dumps(value, ensure_ascii=False)
@@ -391,7 +382,7 @@ class Glm4MoeModelToolParser(ToolParser):
                     # Tool call finished but </arg_value> is missing
                     # (malformed output). Treat partial as complete value
                     # so the diff naturally closes any open quotes.
-                    if self._is_string_type(tool_name, partial_key, self.tools):
+                    if self._is_string_type(tool_name, partial_key):
                         val_json = json.dumps(partial_content, ensure_ascii=False)
                     else:
                         val_json = json.dumps(
@@ -399,7 +390,7 @@ class Glm4MoeModelToolParser(ToolParser):
                             ensure_ascii=False,
                         )
                     parts.append(f"{key_json}: {val_json}")
-                elif self._is_string_type(tool_name, partial_key, self.tools):
+                elif self._is_string_type(tool_name, partial_key):
                     escaped = self._json_escape_string_content(partial_content)
                     # Open quote but no close — more content may arrive
                     parts.append(f'{key_json}: "{escaped}')

--- a/vllm/tool_parsers/glm4_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm4_moe_tool_parser.py
@@ -38,7 +38,7 @@ from vllm.tool_parsers.abstract_tool_parser import (
     Tool,
     ToolParser,
 )
-from vllm.tool_parsers.utils import partial_tag_overlap
+from vllm.tool_parsers.utils import _extract_tool_info, partial_tag_overlap
 
 logger = init_logger(__name__)
 
@@ -132,12 +132,13 @@ class Glm4MoeModelToolParser(ToolParser):
         if tools is None:
             return False
         for tool in tools:
-            if tool.function.name != tool_name:
+            name, parameters = _extract_tool_info(tool)
+            if name != tool_name:
                 continue
-            if tool.function.parameters is None:
+            if parameters is None:
                 return False
             arg_type = (
-                tool.function.parameters.get("properties", {})
+                parameters.get("properties", {})
                 .get(arg_name, {})
                 .get("type", None)
             )

--- a/vllm/tool_parsers/glm4_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm4_moe_tool_parser.py
@@ -138,9 +138,7 @@ class Glm4MoeModelToolParser(ToolParser):
             if parameters is None:
                 return False
             arg_type = (
-                parameters.get("properties", {})
-                .get(arg_name, {})
-                .get("type", None)
+                parameters.get("properties", {}).get(arg_name, {}).get("type", None)
             )
             return arg_type == "string"
         logger.debug("No tool named '%s'.", tool_name)


### PR DESCRIPTION
Co-authored-by: Mathias Rasmussen <mra@ordbogen.com>

## Summary

Fix `AttributeError: 'FunctionTool' object has no attribute 'function'` in `Glm4MoeModelToolParser._is_string_type` when using the `/v1/responses` endpoint.

Fixes #39574

## Root Cause

`_is_string_type` directly accessed `tool.function.name` / `tool.function.parameters`, assuming the `/v1/chat/completions` tool shape. When called via `/v1/responses`, tools arrive as `FunctionTool` (flat structure: `tool.name` / `tool.parameters`), causing `AttributeError`.

Both streaming (`extract_tool_calls_streaming`) and non-streaming (`extract_tool_calls`) paths are affected.

## Fix

Replace direct attribute access with `_extract_tool_info(tool)` from `vllm/tool_parsers/utils.py`, which already handles both `ChatCompletionToolsParam` and `FunctionTool` via `isinstance`. This is the established pattern used throughout the codebase.

## Tests

Added two tests in `tests/tool_parsers/test_glm4_moe_tool_parser.py`:
- `test_extract_tool_calls_with_responses_format_tools`: non-streaming path with `FunctionTool`
- `test_extract_tool_calls_with_responses_format_tools_streaming`: streaming path with `FunctionTool`

Both tests create the parser with `FunctionTool` in the constructor (so `self.tools` contains `FunctionTool`), ensuring the fix is exercised.

## Note

PR #38544 addresses the same issue using `hasattr`-style duck-typing. This PR instead reuses the existing `_extract_tool_info` utility for DRY consistency with the codebase.
