### PR TITLE
[Superseded] Broad GLM-5 MLA/MTP runtime recovery draft

### DIFF
--- a/vllm/distributed/device_communicators/custom_all_reduce.py
+++ b/vllm/distributed/device_communicators/custom_all_reduce.py
@@ -150,12 +150,18 @@ class CustomAllreduce:
         assert current_platform.is_cuda_alike()
         fully_connected = current_platform.is_fully_connected(physical_device_ids)
         if world_size > 2 and not fully_connected:
-            logger.warning(
-                "Custom allreduce is disabled because it's not supported on"
-                " more than two PCIe-only GPUs. To silence this warning, "
-                "specify disable_custom_all_reduce=True explicitly."
+            import os
+            if os.environ.get("VLLM_ENABLE_PCIE_ALLREDUCE", "0") != "1":
+                logger.warning(
+                    "Custom allreduce is disabled for >2 PCIe-only GPUs. "
+                    "Set VLLM_ENABLE_PCIE_ALLREDUCE=1 to enable P2P custom "
+                    "allreduce on PCIe topology (requires P2P-capable driver, "
+                    "see PR #39040 for details)."
+                )
+                return
+            logger.info(
+                "PCIe custom allreduce enabled via VLLM_ENABLE_PCIE_ALLREDUCE=1"
             )
-            return
         # test P2P capability, this checks software/cudaruntime support
         # this is expensive to compute at the first time
         # then we cache the result
@@ -238,11 +244,7 @@ class CustomAllreduce:
             return False
         if not is_weak_contiguous(inp):
             return False
-        # for 4 or more non NVLink-capable GPUs, custom allreduce provides
-        # little performance improvement over NCCL.
-        if self.world_size == 2 or self.fully_connected:
-            return inp_size < self.max_size
-        return False
+        return inp_size < self.max_size
 
     def all_reduce(
         self, inp: torch.Tensor, *, out: torch.Tensor = None, registered: bool = False

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1372,6 +1372,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
     # - VARLEN: Supports variable-length queries (spec decode with mixed lengths)
     # If set to UNIFORM or VARLEN, this will increase `reorder_batch_threshold` when
     # speculative decoding is enabled.
+    supports_update_for_drafting: ClassVar[bool] = True
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.SINGLE_ONLY
 
     # The threshold for reordering the batch into decode and prefill requests.
@@ -1685,6 +1686,82 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
 
         return self.build(0, m)
 
+    def build_for_drafting(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        draft_index: int,
+    ) -> M:
+        """Build attention metadata for draft model without DCP fields.
+
+        Draft models (MTP layer) have their own local KV cache and don't
+        participate in decode context parallelism. Temporarily disable DCP
+        to prevent incompatible tensor shapes in draft attention kernels.
+        """
+        if self.dcp_world_size > 1:
+            saved = self.dcp_world_size
+            self.dcp_world_size = 1
+            try:
+                return self.build(0, common_attn_metadata, fast_build=True)
+            finally:
+                self.dcp_world_size = saved
+        return self.build(0, common_attn_metadata, fast_build=True)
+
+    def update_for_drafting(
+        self,
+        attn_metadata: M,
+        common_attn_metadata: CommonAttentionMetadata,
+        draft_index: int,
+    ) -> M:
+        num_reqs = common_attn_metadata.num_reqs
+        num_tokens = common_attn_metadata.num_actual_tokens
+        max_seq_len = common_attn_metadata.max_seq_len
+        query_start_loc = common_attn_metadata.query_start_loc
+        seq_lens = common_attn_metadata.seq_lens
+        dcp_local_seq_lens = common_attn_metadata.dcp_local_seq_lens
+
+        num_decodes, num_prefills, num_decode_tokens, _ = (
+            split_decodes_and_prefills(
+                common_attn_metadata,
+                decode_threshold=self.reorder_batch_threshold,
+                require_uniform=(self.query_len_support != QueryLenSupport.VARLEN),
+            )
+        )
+
+        if num_prefills > 0:
+            return self.build_for_drafting(common_attn_metadata, draft_index)
+
+        dcp_tot_seq_lens_device = None
+        if self.dcp_world_size > 1:
+            dcp_tot_seq_lens_device = seq_lens[:num_decodes]
+            seq_lens = dcp_local_seq_lens
+
+            num_partitions = self.dcp_world_size * self.cp_kv_cache_interleave_size
+            max_seq_len = (
+                (max_seq_len + num_partitions - 1) // num_partitions
+            ) * self.cp_kv_cache_interleave_size
+
+        attn_metadata.num_reqs = num_reqs
+        attn_metadata.max_query_len = common_attn_metadata.max_query_len
+        attn_metadata.max_seq_len = max_seq_len
+        attn_metadata.num_actual_tokens = num_tokens
+        attn_metadata.query_start_loc = query_start_loc
+        attn_metadata.seq_lens = seq_lens
+        attn_metadata.slot_mapping = common_attn_metadata.slot_mapping
+        attn_metadata.num_decodes = num_decodes
+        attn_metadata.num_decode_tokens = num_decode_tokens
+        attn_metadata.num_prefills = num_prefills
+        attn_metadata.num_prefill_tokens = 0
+        attn_metadata.prefill = None
+
+        decode = attn_metadata.decode
+        if decode is None:
+            return self.build_for_drafting(common_attn_metadata, draft_index)
+
+        decode.block_table = common_attn_metadata.block_table_tensor[:num_decodes, ...]
+        decode.seq_lens = seq_lens
+        decode.dcp_tot_seq_lens = dcp_tot_seq_lens_device
+
+        return attn_metadata
     def build(
         self,
         common_prefix_len: int,

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -367,6 +367,9 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 "KV cache format, please set `--attention-backend FLASHMLA_SPARSE`"
             )
 
+        # The C++ cache ops only accept "auto" or fp8 variants.
+        if kv_cache_dtype in ("bfloat16", "float16"):
+            kv_cache_dtype = "auto"
         # Initialize KV cache quantization attributes
         self.kv_cache_dtype = kv_cache_dtype
         self.calculate_kv_scales = calculate_kv_scales
@@ -543,6 +546,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         output_scale: torch.Tensor | None = None,
         output_block_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        assert output is not None, "Output tensor must be provided."
         use_quant = output_scale is not None or output_block_scale is not None
         if use_quant:
             # The fusion pass has allocated output with quantized dtype
@@ -1762,6 +1766,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
         decode.dcp_tot_seq_lens = dcp_tot_seq_lens_device
 
         return attn_metadata
+
     def build(
         self,
         common_prefix_len: int,
@@ -2781,7 +2786,12 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
         if has_context:
             assert prefill_metadata.chunked_context is not None
             suffix_output, suffix_lse = output_prefill
-            if self.dcp_world_size > 1:
+            use_dcp_prefill = (
+                self.dcp_world_size > 1
+                and prefill_metadata.chunked_context.
+                padded_local_chunk_seq_lens is not None
+            )
+            if use_dcp_prefill:
                 context_output, context_lse = (
                     self._context_parallel_compute_prefill_context(
                         q,

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -5,9 +5,12 @@ from dataclasses import dataclass
 import torch
 
 from vllm.config import CacheConfig
+from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.model_executor.layers.quantization import QuantizationConfig
+
+logger = init_logger(__name__)
 
 
 @dataclass
@@ -107,6 +110,14 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
             use_sparse=self.is_sparse,
             indexer=self.indexer,
         )
+
+        if self.is_sparse and not self.mla_attn.attn_backend.is_sparse():
+            logger.warning_once(
+                "Sparse MLA requested but backend %s is not sparse. "
+                "Falling back to dense attention (all KV attended).",
+                self.mla_attn.attn_backend.get_name(),
+            )
+            self.is_sparse = False
 
         self.prefix = prefix
 

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -318,8 +318,10 @@ class SparseAttnIndexer(CustomOp):
         self.max_total_seq_len = max_total_seq_len
         self.topk_indices_buffer = topk_indices_buffer
         if current_platform.is_cuda() and not has_deep_gemm():
-            raise RuntimeError(
-                "Sparse Attention Indexer CUDA op requires DeepGEMM to be installed."
+            import logging
+            logging.getLogger("vllm").warning(
+                "DeepGEMM not available for Sparse Attention Indexer. "
+                "Sparse attention will be disabled (dense MLA fallback)."
             )
 
     def forward_native(

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -84,7 +84,7 @@ def _get_backend_priorities(
 ) -> list[AttentionBackendEnum]:
     """Get backend priorities with lazy import to avoid circular dependency."""
     if use_mla:
-        if device_capability.major == 10:
+        if device_capability.major >= 10:
             # Sparse MLA backend priorities
             # See https://github.com/vllm-project/vllm/issues/35807 for
             # benchmark results
@@ -298,10 +298,23 @@ class CudaPlatformBase(Platform):
             except ImportError:
                 invalid_reasons = ["ImportError"]
             if invalid_reasons:
-                raise ValueError(
-                    f"Selected backend {selected_backend} is not valid for "
-                    f"this configuration. Reason: {invalid_reasons}"
-                )
+                if (invalid_reasons == ["sparse not supported"]
+                        and attn_selector_config.use_sparse):
+                    logger.warning_once(
+                        "Selected backend %s does not support sparse. "
+                        "Falling back to dense MLA.",
+                        selected_backend,
+                    )
+                    fallback = attn_selector_config._replace(use_sparse=False)
+                    invalid_reasons = backend_class.validate_configuration(
+                        device_capability=device_capability,
+                        **fallback._asdict(),
+                    )
+                if invalid_reasons:
+                    raise ValueError(
+                        f"Selected backend {selected_backend} is not valid for "
+                        f"this configuration. Reason: {invalid_reasons}"
+                    )
             else:
                 logger.info("Using %s backend.", selected_backend)
                 return selected_backend.get_path()
@@ -327,10 +340,25 @@ class CudaPlatformBase(Platform):
             f"{config_str}. Reasons: {reasons_str}."
         )
         if len(valid_backends_priorities) == 0:
-            raise ValueError(
-                f"No valid attention backend found for {cls.device_name} "
-                f"with {config_str}. Reasons: {reasons_str}."
-            )
+            if attn_selector_config.use_sparse:
+                logger.warning_once(
+                    "No sparse MLA backend available on this device "
+                    "(compute capability %s). Falling back to dense MLA.",
+                    device_capability.as_version_str(),
+                )
+                fallback_config = attn_selector_config._replace(
+                    use_sparse=False)
+                valid_backends_priorities, fb_reasons = cls.get_valid_backends(
+                    device_capability=device_capability,
+                    attn_selector_config=fallback_config,
+                    num_heads=num_heads,
+                )
+                all_invalid_reasons.update(fb_reasons)
+            if len(valid_backends_priorities) == 0:
+                raise ValueError(
+                    f"No valid attention backend found for {cls.device_name} "
+                    f"with {config_str}. Reasons: {reasons_str}."
+                )
 
         # We have found some valid backends. Select the one with the
         # highest priority.

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -895,12 +895,15 @@ class MLAAttentionImpl(AttentionImplBase[T], Generic[T]):
             return
         from vllm import _custom_ops as ops
 
+        effective_dtype = kv_cache_dtype
+        if kv_cache_dtype in ("bfloat16", "float16"):
+            effective_dtype = "auto"
         ops.concat_and_cache_mla(
             kv_c_normed,
             k_pe.squeeze(1),
             kv_cache,
             slot_mapping.flatten(),
-            kv_cache_dtype=kv_cache_dtype,
+            kv_cache_dtype=effective_dtype,
             scale=k_scale,
         )
 
@@ -970,12 +973,15 @@ class SparseMLAAttentionImpl(AttentionImplBase[T], Generic[T]):
             return
         from vllm import _custom_ops as ops
 
+        effective_dtype = kv_cache_dtype
+        if kv_cache_dtype in ("bfloat16", "float16"):
+            effective_dtype = "auto"
         ops.concat_and_cache_mla(
             kv_c_normed,
             k_pe.squeeze(1),
             kv_cache,
             slot_mapping.flatten(),
-            kv_cache_dtype=kv_cache_dtype,
+            kv_cache_dtype=effective_dtype,
             scale=k_scale,
         )
 

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -257,6 +257,7 @@ def get_max_prefill_buffer_size(vllm_config: VllmConfig):
 
 
 class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
+    supports_update_for_drafting = True
     reorder_batch_threshold: int = 1
     natively_supported_next_n: list[int] = [1, 2]
     # TODO (matt): integrate kernel with next_n = 4 support
@@ -584,5 +585,62 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             prefill=prefill_metadata,
             decode=decode_metadata,
         )
+
+        return attn_metadata
+
+    def update_for_drafting(
+        self,
+        attn_metadata: DeepseekV32IndexerMetadata,
+        common_attn_metadata: CommonAttentionMetadata,
+        draft_index: int,
+    ) -> DeepseekV32IndexerMetadata:
+        num_reqs = common_attn_metadata.num_reqs
+        num_tokens = common_attn_metadata.num_actual_tokens
+        num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
+            split_decodes_and_prefills(
+                common_attn_metadata,
+                decode_threshold=self.reorder_batch_threshold,
+            )
+        )
+
+        if num_prefills > 0 or num_decode_tokens != num_decodes:
+            return self.build_for_drafting(common_attn_metadata, draft_index)
+
+        max_seq_len = common_attn_metadata.max_seq_len
+        seq_lens = common_attn_metadata.seq_lens[:num_decodes]
+
+        attn_metadata.seq_lens = common_attn_metadata.seq_lens
+        attn_metadata.num_reqs = num_reqs
+        attn_metadata.max_query_len = common_attn_metadata.max_query_len
+        attn_metadata.max_seq_len = max_seq_len
+        attn_metadata.num_actual_tokens = num_tokens
+        attn_metadata.query_start_loc = common_attn_metadata.query_start_loc
+        attn_metadata.slot_mapping = common_attn_metadata.slot_mapping
+        attn_metadata.num_decodes = num_decodes
+        attn_metadata.num_decode_tokens = num_decode_tokens
+        attn_metadata.num_prefills = num_prefills
+        attn_metadata.num_prefill_tokens = num_prefill_tokens
+        attn_metadata.prefill = None
+
+        decode = attn_metadata.decode
+        if decode is None:
+            return self.build_for_drafting(common_attn_metadata, draft_index)
+
+        decode.block_table = common_attn_metadata.block_table_tensor[:num_decodes, ...]
+        decode.seq_lens = seq_lens
+        self.decode_lens_buffer[:num_decode_tokens] = 1
+        decode.decode_lens = self.decode_lens_buffer[:num_decode_tokens]
+        decode.requires_padding = False
+        decode.use_large_context_topk = (
+            num_decodes <= 128 and max_seq_len > 8192
+        )
+        decode.offsets = None
+
+        if current_platform.is_cuda() and has_deep_gemm():
+            decode.schedule_metadata = get_paged_mqa_logits_metadata(
+                seq_lens,
+                self.kv_cache_spec.block_size,
+                self.num_sms,
+            )
 
         return attn_metadata

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -57,6 +57,10 @@ from vllm.v1.worker.utils import AttentionGroup
 logger = init_logger(__name__)
 
 
+def _reuse_mtp_draft_attn_metadata() -> bool:
+    return True
+
+
 class SpecDecodeBaseProposer:
     def __init__(
         self,
@@ -401,6 +405,48 @@ class SpecDecodeBaseProposer:
             return self.model.get_top_tokens(hidden_states)
         return self.model.compute_logits(hidden_states).argmax(dim=-1)
 
+    def _should_reuse_draft_attn_metadata(
+        self, per_layer_attn_metadata: dict[str, object]
+    ) -> bool:
+        if not _reuse_mtp_draft_attn_metadata():
+            return False
+        if self.method != "mtp":
+            return False
+        if self.num_speculative_tokens <= 1 or self.parallel_drafting:
+            return False
+        if not per_layer_attn_metadata:
+            return False
+        return all(
+            getattr(attn_group.get_metadata_builder(),
+                    "supports_update_for_drafting", False)
+            for attn_group in self.draft_attn_groups
+        )
+
+    def _update_reused_draft_attn_metadata(
+        self,
+        per_layer_attn_metadata: dict[str, object],
+        common_attn_metadata: CommonAttentionMetadata,
+        draft_index: int,
+    ) -> None:
+        updated_ids: set[int] = set()
+        for attn_group in self.draft_attn_groups:
+            if not attn_group.layer_names:
+                continue
+            layer_name = attn_group.layer_names[0]
+            attn_metadata = per_layer_attn_metadata[layer_name]
+            metadata_id = id(attn_metadata)
+            if metadata_id in updated_ids:
+                continue
+            builder = attn_group.get_metadata_builder()
+            attn_metadata = builder.update_for_drafting(
+                attn_metadata,
+                common_attn_metadata,
+                draft_index,
+            )
+            for group_layer_name in attn_group.layer_names:
+                per_layer_attn_metadata[group_layer_name] = attn_metadata
+            updated_ids.add(metadata_id)
+
     def propose(
         self,
         # [num_tokens]
@@ -451,6 +497,10 @@ class SpecDecodeBaseProposer:
         per_group_attn_metadata, per_layer_attn_metadata = (
             self.build_per_group_and_layer_attn_metadata(common_attn_metadata)
         )
+        can_reuse_draft_attn_metadata = self._should_reuse_draft_attn_metadata(
+            per_layer_attn_metadata
+        )
+        reuse_draft_attn_metadata_ready = False
 
         cudagraph_runtime_mode, num_input_tokens, num_tokens_across_dp = (
             self._determine_batch_execution_and_padding(num_tokens)
@@ -594,10 +644,21 @@ class SpecDecodeBaseProposer:
             if common_attn_metadata._num_computed_tokens_cpu is not None:
                 common_attn_metadata._num_computed_tokens_cpu += 1
 
-            # Rebuild attention metadata
-            _, per_layer_attn_metadata = self.build_per_group_and_layer_attn_metadata(
-                common_attn_metadata, draft_index=token_index + 1
-            )
+            if can_reuse_draft_attn_metadata and reuse_draft_attn_metadata_ready:
+                self._update_reused_draft_attn_metadata(
+                    per_layer_attn_metadata,
+                    common_attn_metadata,
+                    token_index + 1,
+                )
+            else:
+                _, per_layer_attn_metadata = (
+                    self.build_per_group_and_layer_attn_metadata(
+                        common_attn_metadata,
+                        draft_index=token_index + 1,
+                    )
+                )
+                if can_reuse_draft_attn_metadata:
+                    reuse_draft_attn_metadata_ready = True
 
             # copy inputs to buffer for cudagraph
             self.input_ids[:batch_size] = input_ids


### PR DESCRIPTION
Superseded by #39632, #39633, #39634, and #39635, and tracked in #37113.

This draft was split into smaller PRs with clear ownership and narrower review scope.