### PR TITLE
[Bugfix] - Enforce enable_chunked_prefill=False even if long_prefill_token_threshold is set > 0

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -406,7 +406,10 @@ class Scheduler(SchedulerInterface):
                 + request.num_output_placeholders
                 - request.num_computed_tokens
             )
-            if 0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens:
+            if (
+                0 < self.scheduler_config.long_prefill_token_threshold < num_new_tokens
+                and self.scheduler_config.enable_chunked_prefill
+            ):
                 num_new_tokens = self.scheduler_config.long_prefill_token_threshold
             num_new_tokens = min(num_new_tokens, token_budget)
 
@@ -663,9 +666,6 @@ class Scheduler(SchedulerInterface):
                     # `request.num_prompt_tokens` to consider the resumed
                     # requests, which have output tokens.
                     num_new_tokens = request.num_tokens - num_computed_tokens
-                    threshold = self.scheduler_config.long_prefill_token_threshold
-                    if 0 < threshold < num_new_tokens:
-                        num_new_tokens = threshold
 
                     # chunked prefill has to be enabled explicitly to allow
                     # pooling requests to be chunked
@@ -676,6 +676,10 @@ class Scheduler(SchedulerInterface):
                         # If chunked_prefill is disabled,
                         # we can stop the scheduling here.
                         break
+                    elif self.scheduler_config.enable_chunked_prefill:
+                        threshold = self.scheduler_config.long_prefill_token_threshold
+                        if 0 < threshold < num_new_tokens:
+                            num_new_tokens = threshold
 
                     num_new_tokens = min(num_new_tokens, token_budget)
                     assert num_new_tokens > 0


### PR DESCRIPTION


## Purpose
Current scheduler code applies the long_prefill_token_threshold to num_new_tokens before checking if enable_chunked_prefill is enabled. Though long_prefill_token_threshold should ideally not be set to be > 0 if enable_chunked_prefill is False, this adds an explicit guard to enforce that enable_chunked_prefill flag takes precedence.

## Test Plan
Run
```
.venv/bin/python -m pytest tests/v1/core/test_scheduler.py -v
.venv/bin/python -m pytest tests/v1/core/test_async_scheduler.py -v
.venv/bin/python -m pytest tests/v1/core/test_scheduler_e2e.py -v
.venv/bin/python -m pytest tests/v1/core/test_priority_scheduler_random.py -v
```

## Test Result
All tests described above pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

