### PR TITLE
Fix CLI help keyword state leaking between parse calls

### DIFF
--- a/tests/utils_/test_argparse_utils.py
+++ b/tests/utils_/test_argparse_utils.py
@@ -81,6 +81,22 @@ def test_with_bool_flag(parser):
     assert args.enable_feature is True
 
 
+def test_help_keyword_does_not_leak_between_parse_calls():
+    parser = FlexibleArgumentParser(prog="test")
+    parser.add_argument("--foo-bar", help="foo help")
+    parser.add_argument("--baz-qux", help="baz help")
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--help=foo"])
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--help"])
+
+    help_text = parser.format_help()
+    assert "--foo-bar" in help_text
+    assert "--baz-qux" in help_text
+
+
 def test_invalid_choice(parser):
     with pytest.raises(SystemExit):
         parser.parse_args(["--image_input_type", "invalid_choice"])

--- a/vllm/utils/argparse_utils.py
+++ b/vllm/utils/argparse_utils.py
@@ -57,14 +57,13 @@ class FlexibleArgumentParser(ArgumentParser):
         '   --json-arg \'{"key4": ["value3", "value4", "value5"]}\'\n'
         "   --json-arg.key4+ value3 --json-arg.key4+='value4,value5'\n\n"
     )
-    _search_keyword: str | None = None
-
     def __init__(self, *args, **kwargs):
         # Set the default "formatter_class" to SortedHelpFormatter
         if "formatter_class" not in kwargs:
             kwargs["formatter_class"] = SortedHelpFormatter
         # Pop kwarg "add_json_tip" to control whether to add the JSON tip
         self.add_json_tip = kwargs.pop("add_json_tip", True)
+        self._search_keyword: str | None = None
         super().__init__(*args, **kwargs)
 
     if sys.version_info < (3, 13):
@@ -182,6 +181,8 @@ class FlexibleArgumentParser(ArgumentParser):
         if args is None:
             args = sys.argv[1:]
 
+        self._search_keyword = None
+
         if args and args[0] == "serve":
             # Check for --model in command line arguments first
             try:
@@ -243,7 +244,7 @@ class FlexibleArgumentParser(ArgumentParser):
         processed_args = list[str]()
         for i, arg in enumerate(args):
             if arg.startswith("--help="):
-                FlexibleArgumentParser._search_keyword = arg.split("=", 1)[-1].lower()
+                self._search_keyword = arg.split("=", 1)[-1].lower()
                 processed_args.append("--help")
             elif arg.startswith("--"):
                 if "=" in arg:


### PR DESCRIPTION
Signed-off-by: Walter <lnvitesace@gmail.com>




## Purpose

 Fix a state leak in `FlexibleArgumentParser` where `--help=<keyword>` can affect later plain `--help` / `format_help()` calls on the same
  parser instance.

  This PR moves `_search_keyword` to instance state and resets it at the start of each `parse_args()` call. It also adds a regression test
  covering repeated parse calls.

  Why this is not duplicate work:
  - I checked for existing open work on this area and did not find an open PR or issue covering this fix.
  - Commands checked:
    - `gh pr list --repo vllm-project/vllm --state open --search "argparse_utils help keyword"`
    - `gh issue list --repo vllm-project/vllm --search "argparse_utils help keyword"`
 
## Test Plan

Reviewed the code change manually and added a regression test:
  - `tests/utils_/test_argparse_utils.py::test_help_keyword_does_not_leak_between_parse_calls`

  Attempted to run:
  - `uv run --python 3.12 python -m pytest tests/utils_/test_argparse_utils.py -k help_keyword -q`

## Test Result

  - Added a regression test for the leak between parse calls.
  - Local test execution was blocked by environment-specific dependency resolution on macOS/aarch64 in this setup, rather than by the change
  itself.
  - No documentation update is needed.
  - No release note update is needed because this is a small internal bug fix.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [x] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

