### PR TITLE
[MTP][Runtime] Reuse draft attention metadata across draft steps

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1372,6 +1372,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
     # - VARLEN: Supports variable-length queries (spec decode with mixed lengths)
     # If set to UNIFORM or VARLEN, this will increase `reorder_batch_threshold` when
     # speculative decoding is enabled.
+    supports_update_for_drafting: ClassVar[bool] = True
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.SINGLE_ONLY
 
     # The threshold for reordering the batch into decode and prefill requests.
@@ -1685,6 +1686,82 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
 
         return self.build(0, m)
 
+    def build_for_drafting(
+        self,
+        common_attn_metadata: CommonAttentionMetadata,
+        draft_index: int,
+    ) -> M:
+        """Build attention metadata for draft model without DCP fields.
+
+        Draft models (MTP layer) have their own local KV cache and don't
+        participate in decode context parallelism. Temporarily disable DCP
+        to prevent incompatible tensor shapes in draft attention kernels.
+        """
+        if self.dcp_world_size > 1:
+            saved = self.dcp_world_size
+            self.dcp_world_size = 1
+            try:
+                return self.build(0, common_attn_metadata, fast_build=True)
+            finally:
+                self.dcp_world_size = saved
+        return self.build(0, common_attn_metadata, fast_build=True)
+
+    def update_for_drafting(
+        self,
+        attn_metadata: M,
+        common_attn_metadata: CommonAttentionMetadata,
+        draft_index: int,
+    ) -> M:
+        num_reqs = common_attn_metadata.num_reqs
+        num_tokens = common_attn_metadata.num_actual_tokens
+        max_seq_len = common_attn_metadata.max_seq_len
+        query_start_loc = common_attn_metadata.query_start_loc
+        seq_lens = common_attn_metadata.seq_lens
+        dcp_local_seq_lens = common_attn_metadata.dcp_local_seq_lens
+
+        num_decodes, num_prefills, num_decode_tokens, _ = (
+            split_decodes_and_prefills(
+                common_attn_metadata,
+                decode_threshold=self.reorder_batch_threshold,
+                require_uniform=(self.query_len_support != QueryLenSupport.VARLEN),
+            )
+        )
+
+        if num_prefills > 0:
+            return self.build_for_drafting(common_attn_metadata, draft_index)
+
+        dcp_tot_seq_lens_device = None
+        if self.dcp_world_size > 1:
+            dcp_tot_seq_lens_device = seq_lens[:num_decodes]
+            seq_lens = dcp_local_seq_lens
+
+            num_partitions = self.dcp_world_size * self.cp_kv_cache_interleave_size
+            max_seq_len = (
+                (max_seq_len + num_partitions - 1) // num_partitions
+            ) * self.cp_kv_cache_interleave_size
+
+        attn_metadata.num_reqs = num_reqs
+        attn_metadata.max_query_len = common_attn_metadata.max_query_len
+        attn_metadata.max_seq_len = max_seq_len
+        attn_metadata.num_actual_tokens = num_tokens
+        attn_metadata.query_start_loc = query_start_loc
+        attn_metadata.seq_lens = seq_lens
+        attn_metadata.slot_mapping = common_attn_metadata.slot_mapping
+        attn_metadata.num_decodes = num_decodes
+        attn_metadata.num_decode_tokens = num_decode_tokens
+        attn_metadata.num_prefills = num_prefills
+        attn_metadata.num_prefill_tokens = 0
+        attn_metadata.prefill = None
+
+        decode = attn_metadata.decode
+        if decode is None:
+            return self.build_for_drafting(common_attn_metadata, draft_index)
+
+        decode.block_table = common_attn_metadata.block_table_tensor[:num_decodes, ...]
+        decode.seq_lens = seq_lens
+        decode.dcp_tot_seq_lens = dcp_tot_seq_lens_device
+
+        return attn_metadata
     def build(
         self,
         common_prefix_len: int,

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -257,6 +257,7 @@ def get_max_prefill_buffer_size(vllm_config: VllmConfig):
 
 
 class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
+    supports_update_for_drafting = True
     reorder_batch_threshold: int = 1
     natively_supported_next_n: list[int] = [1, 2]
     # TODO (matt): integrate kernel with next_n = 4 support
@@ -584,5 +585,62 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             prefill=prefill_metadata,
             decode=decode_metadata,
         )
+
+        return attn_metadata
+
+    def update_for_drafting(
+        self,
+        attn_metadata: DeepseekV32IndexerMetadata,
+        common_attn_metadata: CommonAttentionMetadata,
+        draft_index: int,
+    ) -> DeepseekV32IndexerMetadata:
+        num_reqs = common_attn_metadata.num_reqs
+        num_tokens = common_attn_metadata.num_actual_tokens
+        num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
+            split_decodes_and_prefills(
+                common_attn_metadata,
+                decode_threshold=self.reorder_batch_threshold,
+            )
+        )
+
+        if num_prefills > 0 or num_decode_tokens != num_decodes:
+            return self.build_for_drafting(common_attn_metadata, draft_index)
+
+        max_seq_len = common_attn_metadata.max_seq_len
+        seq_lens = common_attn_metadata.seq_lens[:num_decodes]
+
+        attn_metadata.seq_lens = common_attn_metadata.seq_lens
+        attn_metadata.num_reqs = num_reqs
+        attn_metadata.max_query_len = common_attn_metadata.max_query_len
+        attn_metadata.max_seq_len = max_seq_len
+        attn_metadata.num_actual_tokens = num_tokens
+        attn_metadata.query_start_loc = common_attn_metadata.query_start_loc
+        attn_metadata.slot_mapping = common_attn_metadata.slot_mapping
+        attn_metadata.num_decodes = num_decodes
+        attn_metadata.num_decode_tokens = num_decode_tokens
+        attn_metadata.num_prefills = num_prefills
+        attn_metadata.num_prefill_tokens = num_prefill_tokens
+        attn_metadata.prefill = None
+
+        decode = attn_metadata.decode
+        if decode is None:
+            return self.build_for_drafting(common_attn_metadata, draft_index)
+
+        decode.block_table = common_attn_metadata.block_table_tensor[:num_decodes, ...]
+        decode.seq_lens = seq_lens
+        self.decode_lens_buffer[:num_decode_tokens] = 1
+        decode.decode_lens = self.decode_lens_buffer[:num_decode_tokens]
+        decode.requires_padding = False
+        decode.use_large_context_topk = (
+            num_decodes <= 128 and max_seq_len > 8192
+        )
+        decode.offsets = None
+
+        if current_platform.is_cuda() and has_deep_gemm():
+            decode.schedule_metadata = get_paged_mqa_logits_metadata(
+                seq_lens,
+                self.kv_cache_spec.block_size,
+                self.num_sms,
+            )
 
         return attn_metadata

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -57,6 +57,10 @@ from vllm.v1.worker.utils import AttentionGroup
 logger = init_logger(__name__)
 
 
+def _reuse_mtp_draft_attn_metadata() -> bool:
+    return True
+
+
 class SpecDecodeBaseProposer:
     def __init__(
         self,
@@ -401,6 +405,48 @@ class SpecDecodeBaseProposer:
             return self.model.get_top_tokens(hidden_states)
         return self.model.compute_logits(hidden_states).argmax(dim=-1)
 
+    def _should_reuse_draft_attn_metadata(
+        self, per_layer_attn_metadata: dict[str, object]
+    ) -> bool:
+        if not _reuse_mtp_draft_attn_metadata():
+            return False
+        if self.method != "mtp":
+            return False
+        if self.num_speculative_tokens <= 1 or self.parallel_drafting:
+            return False
+        if not per_layer_attn_metadata:
+            return False
+        return all(
+            getattr(attn_group.get_metadata_builder(),
+                    "supports_update_for_drafting", False)
+            for attn_group in self.draft_attn_groups
+        )
+
+    def _update_reused_draft_attn_metadata(
+        self,
+        per_layer_attn_metadata: dict[str, object],
+        common_attn_metadata: CommonAttentionMetadata,
+        draft_index: int,
+    ) -> None:
+        updated_ids: set[int] = set()
+        for attn_group in self.draft_attn_groups:
+            if not attn_group.layer_names:
+                continue
+            layer_name = attn_group.layer_names[0]
+            attn_metadata = per_layer_attn_metadata[layer_name]
+            metadata_id = id(attn_metadata)
+            if metadata_id in updated_ids:
+                continue
+            builder = attn_group.get_metadata_builder()
+            attn_metadata = builder.update_for_drafting(
+                attn_metadata,
+                common_attn_metadata,
+                draft_index,
+            )
+            for group_layer_name in attn_group.layer_names:
+                per_layer_attn_metadata[group_layer_name] = attn_metadata
+            updated_ids.add(metadata_id)
+
     def propose(
         self,
         # [num_tokens]
@@ -451,6 +497,10 @@ class SpecDecodeBaseProposer:
         per_group_attn_metadata, per_layer_attn_metadata = (
             self.build_per_group_and_layer_attn_metadata(common_attn_metadata)
         )
+        can_reuse_draft_attn_metadata = self._should_reuse_draft_attn_metadata(
+            per_layer_attn_metadata
+        )
+        reuse_draft_attn_metadata_ready = False
 
         cudagraph_runtime_mode, num_input_tokens, num_tokens_across_dp = (
             self._determine_batch_execution_and_padding(num_tokens)
@@ -594,10 +644,21 @@ class SpecDecodeBaseProposer:
             if common_attn_metadata._num_computed_tokens_cpu is not None:
                 common_attn_metadata._num_computed_tokens_cpu += 1
 
-            # Rebuild attention metadata
-            _, per_layer_attn_metadata = self.build_per_group_and_layer_attn_metadata(
-                common_attn_metadata, draft_index=token_index + 1
-            )
+            if can_reuse_draft_attn_metadata and reuse_draft_attn_metadata_ready:
+                self._update_reused_draft_attn_metadata(
+                    per_layer_attn_metadata,
+                    common_attn_metadata,
+                    token_index + 1,
+                )
+            else:
+                _, per_layer_attn_metadata = (
+                    self.build_per_group_and_layer_attn_metadata(
+                        common_attn_metadata,
+                        draft_index=token_index + 1,
+                    )
+                )
+                if can_reuse_draft_attn_metadata:
+                    reuse_draft_attn_metadata_ready = True
 
             # copy inputs to buffer for cudagraph
             self.input_ids[:batch_size] = input_ids


### PR DESCRIPTION
Tracked in #37113.

This PR reduces speculative decode overhead by reusing draft attention metadata across MTP draft steps.

## Problem

The MTP draft loop rebuilds attention metadata repeatedly while advancing through successive draft steps. That work is redundant for the draft path and becomes more visible when running GLM-5.1 with DCP and MTP enabled.

## What This PR Changes

- Reuses draft attention metadata across successive MTP draft steps.
- Keeps the reuse path scoped to speculative draft execution.
- Adds the DCP-aware plumbing needed by the draft path so reuse does not cross request/rank boundaries incorrectly.
- Keeps target-model validation separate from the draft metadata reuse path.

## Scope

- MTP speculative runtime only.
- No model-side GLM loading changes.
- No distributed/custom-allreduce changes.
- No SM120 B12X backend-selection changes.
- No FlashInfer MLA target-validation fix; that is tracked separately in #39635.