### PR TITLE
[SM120][B12X] Add b12x NVFP4 MoE and dense backends

### DIFF
--- a/tests/quantization/test_sm12x_b12x_backends.py
+++ b/tests/quantization/test_sm12x_b12x_backends.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+import vllm.model_executor.kernels.linear.nvfp4.b12x as linear_b12x_module
+import vllm.model_executor.layers.fused_moe.experts.b12x_nvfp4_moe as moe_b12x_module
+from vllm.model_executor.kernels.linear import _NVFP4_BACKEND_TO_KERNEL
+from vllm.model_executor.kernels.linear.nvfp4.base import NvFp4LinearLayerConfig
+from vllm.model_executor.kernels.linear.nvfp4.b12x import B12xNvFp4LinearKernel
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.experts.b12x_nvfp4_moe import (
+    B12xExperts,
+    _get_b12x_workspace_pool,
+)
+from vllm.model_executor.layers.fused_moe.oracle.nvfp4 import (
+    NvFp4MoeBackend,
+    backend_to_kernel_cls,
+    map_nvfp4_backend,
+)
+
+
+def test_b12x_nvfp4_linear_backend_registered() -> None:
+    assert _NVFP4_BACKEND_TO_KERNEL["b12x"] is B12xNvFp4LinearKernel
+
+
+def test_b12x_moe_backend_maps_to_b12x() -> None:
+    assert map_nvfp4_backend("b12x") is NvFp4MoeBackend.B12X
+    assert backend_to_kernel_cls(NvFp4MoeBackend.B12X) == [B12xExperts]
+
+
+def test_b12x_experts_workspace_contract() -> None:
+    experts = object.__new__(B12xExperts)
+    assert experts.workspace_shapes(
+        M=64,
+        N=256,
+        K=512,
+        topk=8,
+        global_num_experts=16,
+        local_num_experts=16,
+        expert_tokens_meta=None,
+        activation=MoEActivation.SILU,
+    ) == ((0,), (0,), (64, 512))
+
+
+def test_b12x_linear_backend_imports_required_submodules(monkeypatch) -> None:
+    imported_modules: list[str] = []
+    grouped_scale_view = object()
+    swizzle_block_scale = object()
+    dense_gemm = object()
+
+    def fake_import_module(module_name: str):
+        imported_modules.append(module_name)
+        if module_name == "b12x.cute.fp4":
+            return SimpleNamespace(
+                as_grouped_scale_view=grouped_scale_view,
+                swizzle_block_scale=swizzle_block_scale,
+            )
+        if module_name == "b12x.gemm.dense":
+            return SimpleNamespace(dense_gemm=dense_gemm)
+        raise ImportError(module_name)
+
+    monkeypatch.setattr(linear_b12x_module.importlib, "import_module", fake_import_module)
+    monkeypatch.setattr(linear_b12x_module.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(
+        linear_b12x_module.current_platform,
+        "is_device_capability_family",
+        lambda capability: capability == 120,
+    )
+
+    kernel = B12xNvFp4LinearKernel(NvFp4LinearLayerConfig())
+
+    assert kernel._as_grouped_scale_view is grouped_scale_view
+    assert kernel._swizzle_block_scale is swizzle_block_scale
+    assert kernel._dense_gemm is dense_gemm
+    assert "b12x.cute.fp4" in imported_modules
+    assert "b12x.gemm.dense" in imported_modules
+
+
+def test_b12x_workspace_pool_imports_tp_moe_submodule(monkeypatch) -> None:
+    imported_modules: list[str] = []
+    workspace_pool = object()
+
+    def fake_import_module(module_name: str):
+        imported_modules.append(module_name)
+        if module_name == "b12x.integration.tp_moe":
+            return SimpleNamespace(
+                allocate_tp_moe_workspace_pool=lambda: workspace_pool
+            )
+        raise ImportError(module_name)
+
+    monkeypatch.setattr(moe_b12x_module.importlib, "import_module", fake_import_module)
+    monkeypatch.setattr(moe_b12x_module.torch.cuda, "current_device", lambda: 0)
+    monkeypatch.setattr(moe_b12x_module, "_B12X_MOE_WORKSPACE_POOLS", {})
+
+    assert _get_b12x_workspace_pool(torch.device("cuda")) is workspace_pool
+    assert _get_b12x_workspace_pool(torch.device("cuda")) is workspace_pool
+    assert imported_modules == ["b12x.integration.tp_moe"]
+
+
+def test_b12x_experts_pass_reciprocal_input_scales(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+    workspace_pool = object()
+
+    def fake_b12x_moe_fp4(
+        *args,
+        workspace,
+        output=None,
+        input_scales_are_reciprocal=False,
+        input_scales_static=False,
+        **kwargs,
+    ):
+        del args, kwargs
+        captured["workspace"] = workspace
+        captured["output"] = output
+        captured["input_scales_are_reciprocal"] = input_scales_are_reciprocal
+        captured["input_scales_static"] = input_scales_static
+
+    experts = object.__new__(B12xExperts)
+    experts.quant_config = SimpleNamespace(
+        a1_gscale=torch.ones(1, dtype=torch.float32),
+        a2_gscale=torch.ones(1, dtype=torch.float32),
+        g1_alphas=torch.ones(1, dtype=torch.float32),
+        g2_alphas=torch.ones(1, dtype=torch.float32),
+        w1_scale=torch.ones(1, dtype=torch.float32),
+        w2_scale=torch.ones(1, dtype=torch.float32),
+    )
+    experts._b12x_moe_fp4 = fake_b12x_moe_fp4
+    monkeypatch.setattr(
+        moe_b12x_module,
+        "_get_b12x_workspace_pool",
+        lambda _device: workspace_pool,
+    )
+
+    hidden_states = torch.randn(2, 8)
+    output = torch.empty_like(hidden_states)
+    topk_weights = torch.ones(2, 1, dtype=torch.float32)
+    topk_ids = torch.zeros(2, 1, dtype=torch.int32)
+
+    experts.apply(
+        output=output,
+        hidden_states=hidden_states,
+        w1=torch.empty(1, dtype=torch.uint8),
+        w2=torch.empty(1, dtype=torch.uint8),
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=MoEActivation.SILU,
+        global_num_experts=1,
+        expert_map=None,
+        a1q_scale=None,
+        a2_scale=None,
+        workspace13=torch.empty(0),
+        workspace2=torch.empty(0),
+        expert_tokens_meta=None,
+        apply_router_weight_on_input=False,
+    )
+
+    assert captured == {
+        "workspace": workspace_pool,
+        "output": output,
+        "input_scales_are_reciprocal": True,
+        "input_scales_static": True,
+    }
+
+
+def test_b12x_experts_fuse_input_scales_into_alphas_once() -> None:
+    experts = object.__new__(B12xExperts)
+    experts.quant_config = SimpleNamespace()
+
+    layer = SimpleNamespace(
+        w13_weight_scale_2=torch.nn.Parameter(torch.tensor([2.0, 3.0])),
+        w2_weight_scale_2=torch.nn.Parameter(torch.tensor([5.0, 7.0])),
+        w13_input_scale=torch.nn.Parameter(torch.tensor([11.0, 13.0])),
+        w2_input_scale=torch.nn.Parameter(torch.tensor([17.0, 19.0])),
+    )
+
+    experts.process_weights_after_loading(layer)
+    experts.process_weights_after_loading(layer)
+
+    torch.testing.assert_close(
+        layer.w13_weight_scale_2,
+        torch.tensor([22.0, 39.0]),
+    )
+    torch.testing.assert_close(
+        layer.w2_weight_scale_2,
+        torch.tensor([85.0, 133.0]),
+    )

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -107,6 +107,7 @@ class IrOpPriorityConfig:
 
 MoEBackend = Literal[
     "auto",
+    "b12x",
     "triton",
     "deep_gemm",
     "cutlass",
@@ -135,6 +136,7 @@ class KernelConfig:
     """Backend for MoE expert computation kernels. Available options:
 
     - "auto": Automatically select the best backend based on model and hardware
+    - "b12x": Use the external b12x SM12x Blackwell fused MoE backend
     - "triton": Use Triton-based fused MoE kernels
     - "deep_gemm": Use DeepGEMM kernels (FP8 block-quantized only)
     - "cutlass": Use vLLM CUTLASS kernels

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1467,6 +1467,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # - "flashinfer-cudnn": use flashinfer cudnn GEMM backend
     # - "flashinfer-trtllm": use flashinfer trtllm GEMM backend
     # - "flashinfer-cutlass": use flashinfer cutlass GEMM backend
+    # - "b12x": use the external b12x SM12x GEMM backend
     # - "marlin": use marlin GEMM backend (for GPUs without native FP4 support)
     # - "emulation":
     #     use BF16/FP16 GEMM, dequantizing weights and running QDQ on activations.
@@ -1480,6 +1481,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
             "flashinfer-cudnn",
             "flashinfer-trtllm",
             "flashinfer-cutlass",
+            "b12x",
             "cutlass",
             "marlin",
             "emulation",

--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -72,6 +72,7 @@ from vllm.model_executor.kernels.linear.mxfp8.marlin import (
     MarlinMxfp8LinearKernel,
 )
 from vllm.model_executor.kernels.linear.nvfp4 import (
+    B12xNvFp4LinearKernel,
     NvFp4LinearKernel,
     NvFp4LinearLayerConfig,
 )
@@ -247,6 +248,7 @@ _POSSIBLE_MXFP8_KERNELS: dict[PlatformEnum, list[type[Mxfp8LinearKernel]]] = {
 
 _POSSIBLE_NVFP4_KERNELS: dict[PlatformEnum, list[type[NvFp4LinearKernel]]] = {
     PlatformEnum.CUDA: [
+        B12xNvFp4LinearKernel,
         FlashInferCutlassNvFp4LinearKernel,
         CutlassNvFp4LinearKernel,
         MarlinNvFp4LinearKernel,
@@ -578,6 +580,7 @@ def init_wfp8_a16_linear_kernel(
 
 # Maps VLLM_NVFP4_GEMM_BACKEND env var values to kernel classes.
 _NVFP4_BACKEND_TO_KERNEL: dict[str, type[NvFp4LinearKernel]] = {
+    "b12x": B12xNvFp4LinearKernel,
     "flashinfer-cutlass": FlashInferCutlassNvFp4LinearKernel,
     "cutlass": CutlassNvFp4LinearKernel,
     "marlin": MarlinNvFp4LinearKernel,
@@ -744,6 +747,7 @@ __all__ = [
     "MarlinMxfp8LinearKernel",
     "EmulationMxfp8LinearKernel",
     "CutlassNvFp4LinearKernel",
+    "B12xNvFp4LinearKernel",
     "EmulationNvFp4LinearKernel",
     "FbgemmNvFp4LinearKernel",
     "FlashInferCutlassNvFp4LinearKernel",

--- a/vllm/model_executor/kernels/linear/nvfp4/__init__.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/__init__.py
@@ -5,8 +5,12 @@ from vllm.model_executor.kernels.linear.nvfp4.base import (
     NvFp4LinearKernel,
     NvFp4LinearLayerConfig,
 )
+from vllm.model_executor.kernels.linear.nvfp4.b12x import (
+    B12xNvFp4LinearKernel,
+)
 
 __all__ = [
+    "B12xNvFp4LinearKernel",
     "NvFp4LinearKernel",
     "NvFp4LinearLayerConfig",
 ]

--- a/vllm/model_executor/kernels/linear/nvfp4/b12x.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/b12x.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import importlib
+
+import torch
+
+from vllm._custom_ops import scaled_fp4_quant
+from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
+    pad_nvfp4_activation_for_cutlass,
+    pad_nvfp4_weight_for_cutlass,
+    slice_nvfp4_output,
+)
+from vllm.model_executor.kernels.linear.nvfp4.base import (
+    NvFp4LinearKernel,
+    NvFp4LinearLayerConfig,
+)
+from vllm.platforms import current_platform
+
+
+def _import_b12x_cute_fp4():
+    try:
+        return importlib.import_module("b12x.cute.fp4")
+    except ImportError:
+        return None
+
+
+def _import_b12x_gemm_dense():
+    try:
+        return importlib.import_module("b12x.gemm.dense")
+    except ImportError:
+        return None
+
+
+class B12xNvFp4LinearKernel(NvFp4LinearKernel):
+    """NVFP4 GEMM via the optional external b12x SM12x backend."""
+
+    @classmethod
+    def is_supported(
+        cls, compute_capability: int | None = None
+    ) -> tuple[bool, str | None]:
+        del compute_capability
+        if not current_platform.is_cuda():
+            return False, "b12x NVFP4 kernels are only available on CUDA"
+        if not current_platform.is_device_capability_family(120):
+            return False, "b12x NVFP4 kernels require a Blackwell 12x device"
+        if _import_b12x_cute_fp4() is None:
+            return False, "b12x.cute.fp4 is not importable"
+        if _import_b12x_gemm_dense() is None:
+            return False, "b12x.gemm.dense is not importable"
+        return True, None
+
+    @classmethod
+    def can_implement(cls, config: NvFp4LinearLayerConfig) -> tuple[bool, str | None]:
+        del config
+        return True, None
+
+    def __init__(self, config: NvFp4LinearLayerConfig) -> None:
+        super().__init__(config)
+        b12x_cute_fp4 = _import_b12x_cute_fp4()
+        b12x_gemm_dense = _import_b12x_gemm_dense()
+        if b12x_cute_fp4 is None or b12x_gemm_dense is None:
+            raise ImportError("b12x is not installed or importable")
+        self._as_grouped_scale_view = b12x_cute_fp4.as_grouped_scale_view
+        self._swizzle_block_scale = b12x_cute_fp4.swizzle_block_scale
+        self._dense_gemm = b12x_gemm_dense.dense_gemm
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        layer.weight_scale = torch.nn.Parameter(
+            self._swizzle_block_scale(layer.weight_scale.data), requires_grad=False
+        )
+        padded_weight, weights_padding_cols = pad_nvfp4_weight_for_cutlass(
+            layer.weight.data
+        )
+        layer.weight = torch.nn.Parameter(padded_weight, requires_grad=False)
+        layer.weights_padding_cols = weights_padding_cols
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        output_size = layer.output_size_per_partition
+        output_dtype = x.dtype
+        output_shape = [*x.shape[:-1], output_size]
+        x_2d = x.reshape(-1, x.shape[-1]).contiguous()
+        m = x_2d.shape[0]
+        x_packed, x_scale_swizzled = scaled_fp4_quant(
+            x_2d,
+            layer.input_global_scale_inv,
+            is_sf_swizzled_layout=True,
+            backend="cutlass",
+        )
+        x_packed = pad_nvfp4_activation_for_cutlass(
+            x_packed, getattr(layer, "weights_padding_cols", 0)
+        )
+        k = x_packed.shape[1] * 2
+        x_scale = self._as_grouped_scale_view(
+            x_scale_swizzled.view(torch.uint8).unsqueeze(0),
+            m,
+            k,
+        )
+        weight_scale = self._as_grouped_scale_view(
+            layer.weight_scale.view(torch.uint8).unsqueeze(0),
+            layer.weight.shape[0],
+            k,
+        )
+
+        out = torch.empty(
+            (m, layer.weight.shape[0], 1),
+            device=x.device,
+            dtype=output_dtype,
+        )
+        self._dense_gemm(
+            (x_packed.unsqueeze(-1), x_scale),
+            (layer.weight.unsqueeze(-1), weight_scale),
+            out=out,
+            alpha=layer.alpha.view(1),
+            ab_dtype="float4_e2m1fn",
+            sf_dtype="float8_e4m3fn",
+            c_dtype=str(output_dtype).split(".")[-1],
+            sf_vec_size=16,
+        )
+        out = slice_nvfp4_output(out[:, :, 0], output_size)
+        if bias is not None:
+            out = out + bias
+        return out.view(*output_shape)

--- a/vllm/model_executor/layers/fused_moe/experts/b12x_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/b12x_nvfp4_moe.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import importlib
+from typing import Any
+
+import torch
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEParallelConfig,
+    FusedMoEQuantConfig,
+)
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceNoOP,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
+    kNvfp4Dynamic,
+    kNvfp4Static,
+)
+from vllm.platforms import current_platform
+
+
+def _import_b12x_tp_moe():
+    try:
+        return importlib.import_module("b12x.integration.tp_moe")
+    except ImportError:
+        return None
+
+
+_B12X_MOE_WORKSPACE_POOLS: dict[int, Any] = {}
+
+
+def _get_b12x_workspace_pool(device: torch.device) -> Any:
+    """Return a lazily created per-device workspace pool for the B12X MoE kernel."""
+    device_idx = device.index if device.index is not None else torch.cuda.current_device()
+    pool = _B12X_MOE_WORKSPACE_POOLS.get(device_idx)
+    if pool is None:
+        tp_moe = _import_b12x_tp_moe()
+        if tp_moe is None:
+            raise ImportError("b12x is not installed or importable")
+        pool = tp_moe.allocate_tp_moe_workspace_pool()
+        _B12X_MOE_WORKSPACE_POOLS[device_idx] = pool
+    return pool
+
+
+class B12xExperts(mk.FusedMoEExpertsModular):
+    """NVFP4 fused MoE via the optional external b12x SM12x backend."""
+
+    def __init__(
+        self,
+        moe_config: mk.FusedMoEConfig,
+        quant_config: FusedMoEQuantConfig,
+    ):
+        super().__init__(moe_config, quant_config)
+        tp_moe = _import_b12x_tp_moe()
+        if tp_moe is None:
+            raise ImportError("b12x is not installed or importable")
+        self._b12x_moe_fp4 = tp_moe.b12x_moe_fp4
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if getattr(layer, "_b12x_input_scales_fused", False):
+            return
+        layer.w13_weight_scale_2.data.mul_(layer.w13_input_scale)
+        layer.w2_weight_scale_2.data.mul_(layer.w2_input_scale)
+        layer._b12x_input_scales_fused = True
+
+    @property
+    def expects_unquantized_inputs(self) -> bool:
+        return True
+
+    @property
+    def writes_final_output_directly(self) -> bool:
+        return True
+
+    @staticmethod
+    def _supports_current_device() -> bool:
+        return (
+            current_platform.is_cuda()
+            and current_platform.is_device_capability_family(120)
+            and _import_b12x_tp_moe() is not None
+        )
+
+    @staticmethod
+    def _supports_no_act_and_mul() -> bool:
+        return False
+
+    @staticmethod
+    def _supports_quant_scheme(
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> bool:
+        return (weight_key, activation_key) == (kNvfp4Static, kNvfp4Dynamic)
+
+    @staticmethod
+    def _supports_activation(activation: MoEActivation) -> bool:
+        return activation in [MoEActivation.SILU, MoEActivation.SWIGLUOAI]
+
+    @staticmethod
+    def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
+        del moe_parallel_config
+        return True
+
+    @staticmethod
+    def activation_format() -> mk.FusedMoEActivationFormat:
+        return mk.FusedMoEActivationFormat.Standard
+
+    def supports_expert_map(self) -> bool:
+        return False
+
+    def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
+        return TopKWeightAndReduceNoOP()
+
+    def workspace_shapes(
+        self,
+        M: int,
+        N: int,
+        K: int,
+        topk: int,
+        global_num_experts: int,
+        local_num_experts: int,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        activation: MoEActivation,
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        del N, topk, global_num_experts, local_num_experts, expert_tokens_meta, activation
+        return ((0,), (0,), (M, K))
+
+    def apply(
+        self,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        a2_scale: torch.Tensor | None,
+        workspace13: torch.Tensor,
+        workspace2: torch.Tensor,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        apply_router_weight_on_input: bool | None,
+    ) -> None:
+        del global_num_experts, a2_scale, workspace13, workspace2, expert_tokens_meta
+        assert expert_map is None, "B12xExperts does not support expert_map"
+        assert activation.is_gated, "B12xExperts only supports gated activations"
+        assert not apply_router_weight_on_input, (
+            "B12xExperts requires router weights to be applied inside the kernel"
+        )
+        assert a1q_scale is None, "B12xExperts expects unquantized inputs"
+        assert self.a1_gscale is not None
+        assert self.a2_gscale is not None
+        assert self.g1_alphas is not None
+        assert self.g2_alphas is not None
+        assert self.w1_scale is not None
+        assert self.w2_scale is not None
+
+        self._b12x_moe_fp4(
+            hidden_states,
+            self.a1_gscale,
+            w1,
+            self.w1_scale,
+            self.g1_alphas,
+            self.a2_gscale,
+            w2,
+            self.w2_scale,
+            self.g2_alphas,
+            topk_weights,
+            topk_ids,
+            workspace=_get_b12x_workspace_pool(hidden_states.device),
+            output=output,
+            input_scales_are_reciprocal=True,
+            input_scales_static=True,
+        )

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -748,6 +748,18 @@ class FusedMoEExperts(ABC):
         """
         return False
 
+    @property
+    def writes_final_output_directly(self) -> bool:
+        """
+        Whether apply() writes the fully reduced final output directly into the
+        provided output tensor.
+
+        Backends that return True may bypass framework-managed temporary
+        workspace allocation when they also manage their own internal
+        workspaces.
+        """
+        return False
+
 
 class FusedMoEExpertsModular(FusedMoEExperts):
     """
@@ -1026,6 +1038,17 @@ class FusedMoEKernelModularImpl:
             and moe_parallel_config.dp_size > 1
             and moe_parallel_config.use_ep
         )
+        self._empty_tensor_cache: dict[tuple[torch.device, torch.dtype], torch.Tensor] = {}
+
+    def _get_empty_tensor(
+        self, device: torch.device, dtype: torch.dtype
+    ) -> torch.Tensor:
+        key = (device, dtype)
+        empty = self._empty_tensor_cache.get(key)
+        if empty is None:
+            empty = torch.empty((0,), device=device, dtype=dtype)
+            self._empty_tensor_cache[key] = empty
+        return empty
 
     def _allocate_buffers(
         self,
@@ -1191,6 +1214,7 @@ class FusedMoEKernelModularImpl:
 
     def _fused_experts(
         self,
+        output: torch.Tensor,
         in_dtype: torch.dtype,
         a1q: torch.Tensor,
         a1q_scale: torch.Tensor | None,
@@ -1218,19 +1242,24 @@ class FusedMoEKernelModularImpl:
         if M_full == 0:
             return torch.empty_like(a1q, dtype=in_dtype)
 
-        workspace13, workspace2, fused_out = self._allocate_buffers(
-            in_dtype,
-            a1q.device,
-            M_full,
-            M_full,
-            N,
-            K,
-            top_k,
-            global_num_experts,
-            local_num_experts,
-            expert_tokens_meta,
-            activation,
-        )
+        if self.fused_experts.writes_final_output_directly:
+            workspace13 = self._get_empty_tensor(a1q.device, in_dtype)
+            workspace2 = workspace13
+            fused_out = output
+        else:
+            workspace13, workspace2, fused_out = self._allocate_buffers(
+                in_dtype,
+                a1q.device,
+                M_full,
+                M_full,
+                N,
+                K,
+                top_k,
+                global_num_experts,
+                local_num_experts,
+                expert_tokens_meta,
+                activation,
+            )
 
         self.fused_experts.apply(
             output=fused_out,
@@ -1379,6 +1408,7 @@ class FusedMoEKernelModularImpl:
         )
 
         fused_out = self._fused_experts(
+            output=output,
             in_dtype=hidden_states.dtype,
             a1q=a1q,
             a1q_scale=a1q_scale,

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -39,6 +39,7 @@ logger = init_logger(__name__)
 
 
 class NvFp4MoeBackend(Enum):
+    B12X = "B12X"
     FLASHINFER_TRTLLM = "FLASHINFER_TRTLLM"
     FLASHINFER_CUTLASS = "FLASHINFER_CUTLASS"
     FLASHINFER_CUTEDSL = "FLASHINFER_CUTEDSL"
@@ -105,6 +106,13 @@ def backend_to_kernel_cls(
 
         return [FlashInferCuteDSLBatchedExperts]
 
+    elif backend == NvFp4MoeBackend.B12X:
+        from vllm.model_executor.layers.fused_moe.experts.b12x_nvfp4_moe import (
+            B12xExperts,
+        )
+
+        return [B12xExperts]
+
     elif backend == NvFp4MoeBackend.VLLM_CUTLASS:
         from vllm.model_executor.layers.fused_moe.cutlass_moe import (
             CutlassExpertsFp4,
@@ -125,6 +133,7 @@ def backend_to_kernel_cls(
 def map_nvfp4_backend(runner_backend: MoEBackend) -> NvFp4MoeBackend:
     """Map user's MoEBackend to NvFp4MoeBackend."""
     mapping = {
+        "b12x": NvFp4MoeBackend.B12X,
         "cutlass": NvFp4MoeBackend.VLLM_CUTLASS,
         "flashinfer_trtllm": NvFp4MoeBackend.FLASHINFER_TRTLLM,
         "flashinfer_cutlass": NvFp4MoeBackend.FLASHINFER_CUTLASS,
@@ -151,6 +160,7 @@ def select_nvfp4_moe_backend(
 
     # NOTE: the kernels are selected in the following order.
     AVAILABLE_BACKENDS = [
+        NvFp4MoeBackend.B12X,
         NvFp4MoeBackend.FLASHINFER_TRTLLM,
         NvFp4MoeBackend.FLASHINFER_CUTEDSL,
         NvFp4MoeBackend.FLASHINFER_CUTEDSL_BATCHED,
@@ -327,7 +337,8 @@ def convert_to_nvfp4_moe_kernel_format(
             a2_scale=a2_scale,
         )
     elif (
-        nvfp4_backend in FLASHINFER_NVFP4_MOE_BACKENDS
+        nvfp4_backend == NvFp4MoeBackend.B12X
+        or nvfp4_backend in FLASHINFER_NVFP4_MOE_BACKENDS
         or nvfp4_backend == NvFp4MoeBackend.VLLM_CUTLASS
     ):
         (

--- a/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
+++ b/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
@@ -61,6 +61,8 @@ class TopKWeightAndReduceNoOP(mk.TopKWeightAndReduce):
         # Weight application and reduction operations are already done.
         if output is None:
             return fused_expert_output
+        if output is fused_expert_output:
+            return output
 
         # MoEPrepareAndFinalizeNoDPEPModular needs the output to be in the `output`
         # tensor.

--- a/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
+++ b/vllm/model_executor/layers/quantization/utils/flashinfer_fp4_moe.py
@@ -312,6 +312,7 @@ def prepare_nvfp4_moe_layer_for_fi_or_cutlass(
     )
 
     assert backend in [
+        NvFp4MoeBackend.B12X,
         NvFp4MoeBackend.VLLM_CUTLASS,
         NvFp4MoeBackend.FLASHINFER_CUTLASS,
         NvFp4MoeBackend.FLASHINFER_TRTLLM,
@@ -325,6 +326,7 @@ def prepare_nvfp4_moe_layer_for_fi_or_cutlass(
         and is_act_and_mul
         and backend
         in [
+            NvFp4MoeBackend.B12X,
             NvFp4MoeBackend.FLASHINFER_CUTLASS,
             NvFp4MoeBackend.FLASHINFER_TRTLLM,
         ]


### PR DESCRIPTION
Tracked in #37113.

`b12x` is an external SM120-oriented kernel library for NVFP4 dense FP4 GEMM and MoE. On supported SM120 deployments, it provides optimized kernels for the FP4 paths used by NVFP4 models.

This PR makes `b12x` selectable from vLLM's SM120 NVFP4 backend-selection paths.

## What This PR Changes

- Adds `b12x` as an NVFP4 dense FP4 linear backend on SM120.
- Adds `b12x` as an NVFP4 MoE backend on SM120.
- Wires backend selection, kernel registration, and NVFP4 weight-preparation support for those paths.
- Adds focused unit tests for backend registration and import/workspace behavior.

## Runtime Dependency

- The runtime environment must provide an external `b12x` Python package.
- The dependency remains optional at import/selection time; if `b12x` is not importable, the backend is not selected.
- Packaging/install policy for `b12x` should follow maintainer guidance, since it is an external CUDA/CUTLASS-side library.

## Important Scope Boundary

- This PR is only for the target-model NVFP4 B12X path.
- It does not add `b12x` support for unquantized MoE.
- For GLM-5.1 MTP, the draft model is unquantized/BF16, so the draft MoE backend must remain an unquantized backend such as `flashinfer_cutlass`.
- Automatic speculative-config fallback for incompatible draft backends should be handled separately from this backend integration.

## How We Run GLM-5.1

```bash
export VLLM_ENABLE_PCIE_ALLREDUCE=1
unset VLLM_NVFP4_GEMM_BACKEND

python3 -m vllm.entrypoints.openai.api_server \
  --model lukealonso/GLM-5.1-NVFP4 \
  --served-model-name abtest \
  --trust-remote-code \
  --tensor-parallel-size 8 \
  --decode-context-parallel-size 4 \
  --gpu-memory-utilization 0.82 \
  --max-num-seqs 64 \
  --kv-cache-dtype bfloat16 \
  --enable-prefix-caching \
  --enable-chunked-prefill \
  --reasoning-parser glm45 \
  --moe-backend b12x \
  --speculative-config '{"method":"mtp","num_speculative_tokens":3,"rejection_sample_method":"probabilistic","moe_backend":"flashinfer_cutlass"}' \
  --host 0.0.0.0 \
  --port 5248
```

## How We Run MiniMax-M2.7-NVFP4

```bash
python3 -m vllm.entrypoints.openai.api_server \
  --model /data/models/MiniMax-M2.7-NVFP4 \
  --served-model-name MiniMax-M2.7-NVFP4 \
  --trust-remote-code \
  --tensor-parallel-size 2 \
  --kv-cache-dtype auto \
  --gpu-memory-utilization 0.95 \
  --enable-auto-tool-choice \
  --disable-custom-all-reduce \
  --tool-call-parser minimax_m2 \
  --reasoning-parser minimax_m2_append_think \
  --max-num-seqs 32 \
  --moe-backend b12x \
  --host 0.0.0.0 \
  --port 8000
```