### PR TITLE
[SM120][MLA] Fix FlashInfer MLA DCP/MTP decode path

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -367,6 +367,9 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 "KV cache format, please set `--attention-backend FLASHMLA_SPARSE`"
             )
 
+        # The C++ cache ops only accept "auto" or fp8 variants.
+        if kv_cache_dtype in ("bfloat16", "float16"):
+            kv_cache_dtype = "auto"
         # Initialize KV cache quantization attributes
         self.kv_cache_dtype = kv_cache_dtype
         self.calculate_kv_scales = calculate_kv_scales
@@ -543,6 +546,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         output_scale: torch.Tensor | None = None,
         output_block_scale: torch.Tensor | None = None,
     ) -> torch.Tensor:
+        assert output is not None, "Output tensor must be provided."
         use_quant = output_scale is not None or output_block_scale is not None
         if use_quant:
             # The fusion pass has allocated output with quantized dtype
@@ -2704,7 +2708,12 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
         if has_context:
             assert prefill_metadata.chunked_context is not None
             suffix_output, suffix_lse = output_prefill
-            if self.dcp_world_size > 1:
+            use_dcp_prefill = (
+                self.dcp_world_size > 1
+                and prefill_metadata.chunked_context.
+                padded_local_chunk_seq_lens is not None
+            )
+            if use_dcp_prefill:
                 context_output, context_lse = (
                     self._context_parallel_compute_prefill_context(
                         q,

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -5,9 +5,12 @@ from dataclasses import dataclass
 import torch
 
 from vllm.config import CacheConfig
+from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.model_executor.layers.quantization import QuantizationConfig
+
+logger = init_logger(__name__)
 
 
 @dataclass
@@ -107,6 +110,14 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
             use_sparse=self.is_sparse,
             indexer=self.indexer,
         )
+
+        if self.is_sparse and not self.mla_attn.attn_backend.is_sparse():
+            logger.warning_once(
+                "Sparse MLA requested but backend %s is not sparse. "
+                "Falling back to dense attention (all KV attended).",
+                self.mla_attn.attn_backend.get_name(),
+            )
+            self.is_sparse = False
 
         self.prefix = prefix
 

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -206,42 +206,28 @@ def sparse_attn_indexer(
         num_rows = logits.shape[0]
         topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
 
-        if current_platform.is_cuda():
-            workspace_manager = current_workspace_manager()
-            (topk_workspace,) = workspace_manager.get_simultaneous(
-                ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
-            )
-            torch.ops._C.persistent_topk(
+        if current_platform.is_xpu():
+            ops.top_k_per_row_decode(
                 logits,
-                decode_metadata.seq_lens,
+                next_n,
+                seq_lens,
                 topk_indices,
-                topk_workspace,
+                num_rows,
+                logits.stride(0),
+                logits.stride(1),
                 topk_tokens,
-                attn_metadata.max_seq_len,
             )
         else:
-            if current_platform.is_xpu():
-                ops.top_k_per_row_decode(
-                    logits,
-                    next_n,
-                    seq_lens,
-                    topk_indices,
-                    num_rows,
-                    logits.stride(0),
-                    logits.stride(1),
-                    topk_tokens,
-                )
-            else:
-                torch.ops._C.top_k_per_row_decode(
-                    logits,
-                    next_n,
-                    seq_lens,
-                    topk_indices,
-                    num_rows,
-                    logits.stride(0),
-                    logits.stride(1),
-                    topk_tokens,
-                )
+            torch.ops._C.top_k_per_row_decode(
+                logits,
+                next_n,
+                seq_lens,
+                topk_indices,
+                num_rows,
+                logits.stride(0),
+                logits.stride(1),
+                topk_tokens,
+            )
 
         if decode_metadata.requires_padding:
             # if padded, we need to unpack
@@ -318,8 +304,10 @@ class SparseAttnIndexer(CustomOp):
         self.max_total_seq_len = max_total_seq_len
         self.topk_indices_buffer = topk_indices_buffer
         if current_platform.is_cuda() and not has_deep_gemm():
-            raise RuntimeError(
-                "Sparse Attention Indexer CUDA op requires DeepGEMM to be installed."
+            import logging
+            logging.getLogger("vllm").warning(
+                "DeepGEMM not available for Sparse Attention Indexer. "
+                "Sparse attention will be disabled (dense MLA fallback)."
             )
 
     def forward_native(

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -84,7 +84,7 @@ def _get_backend_priorities(
 ) -> list[AttentionBackendEnum]:
     """Get backend priorities with lazy import to avoid circular dependency."""
     if use_mla:
-        if device_capability.major == 10:
+        if device_capability.major >= 10:
             # Sparse MLA backend priorities
             # See https://github.com/vllm-project/vllm/issues/35807 for
             # benchmark results
@@ -298,10 +298,23 @@ class CudaPlatformBase(Platform):
             except ImportError:
                 invalid_reasons = ["ImportError"]
             if invalid_reasons:
-                raise ValueError(
-                    f"Selected backend {selected_backend} is not valid for "
-                    f"this configuration. Reason: {invalid_reasons}"
-                )
+                if (invalid_reasons == ["sparse not supported"]
+                        and attn_selector_config.use_sparse):
+                    logger.warning_once(
+                        "Selected backend %s does not support sparse. "
+                        "Falling back to dense MLA.",
+                        selected_backend,
+                    )
+                    fallback = attn_selector_config._replace(use_sparse=False)
+                    invalid_reasons = backend_class.validate_configuration(
+                        device_capability=device_capability,
+                        **fallback._asdict(),
+                    )
+                if invalid_reasons:
+                    raise ValueError(
+                        f"Selected backend {selected_backend} is not valid for "
+                        f"this configuration. Reason: {invalid_reasons}"
+                    )
             else:
                 logger.info("Using %s backend.", selected_backend)
                 return selected_backend.get_path()
@@ -327,10 +340,25 @@ class CudaPlatformBase(Platform):
             f"{config_str}. Reasons: {reasons_str}."
         )
         if len(valid_backends_priorities) == 0:
-            raise ValueError(
-                f"No valid attention backend found for {cls.device_name} "
-                f"with {config_str}. Reasons: {reasons_str}."
-            )
+            if attn_selector_config.use_sparse:
+                logger.warning_once(
+                    "No sparse MLA backend available on this device "
+                    "(compute capability %s). Falling back to dense MLA.",
+                    device_capability.as_version_str(),
+                )
+                fallback_config = attn_selector_config._replace(
+                    use_sparse=False)
+                valid_backends_priorities, fb_reasons = cls.get_valid_backends(
+                    device_capability=device_capability,
+                    attn_selector_config=fallback_config,
+                    num_heads=num_heads,
+                )
+                all_invalid_reasons.update(fb_reasons)
+            if len(valid_backends_priorities) == 0:
+                raise ValueError(
+                    f"No valid attention backend found for {cls.device_name} "
+                    f"with {config_str}. Reasons: {reasons_str}."
+                )
 
         # We have found some valid backends. Select the one with the
         # highest priority.

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -895,12 +895,15 @@ class MLAAttentionImpl(AttentionImplBase[T], Generic[T]):
             return
         from vllm import _custom_ops as ops
 
+        effective_dtype = kv_cache_dtype
+        if kv_cache_dtype in ("bfloat16", "float16"):
+            effective_dtype = "auto"
         ops.concat_and_cache_mla(
             kv_c_normed,
             k_pe.squeeze(1),
             kv_cache,
             slot_mapping.flatten(),
-            kv_cache_dtype=kv_cache_dtype,
+            kv_cache_dtype=effective_dtype,
             scale=k_scale,
         )
 
@@ -970,12 +973,15 @@ class SparseMLAAttentionImpl(AttentionImplBase[T], Generic[T]):
             return
         from vllm import _custom_ops as ops
 
+        effective_dtype = kv_cache_dtype
+        if kv_cache_dtype in ("bfloat16", "float16"):
+            effective_dtype = "auto"
         ops.concat_and_cache_mla(
             kv_c_normed,
             k_pe.squeeze(1),
             kv_cache,
             slot_mapping.flatten(),
-            kv_cache_dtype=kv_cache_dtype,
+            kv_cache_dtype=effective_dtype,
             scale=k_scale,
         )
 

--- a/vllm/v1/attention/backends/mla/flashinfer_mla.py
+++ b/vllm/v1/attention/backends/mla/flashinfer_mla.py
@@ -1,53 +1,169 @@
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# FlashInfer MLA backend - plan() in builder, run() in forward (SGLang pattern)
+# CG support: UNIFORM_BATCH — per-batch-size wrappers with use_cuda_graph=True
+# ensure plan() copies into fixed-address buffers for safe CUDA graph replay.
 
-from typing import ClassVar
+from dataclasses import dataclass
+from typing import ClassVar, Optional
 
 import torch
-from flashinfer.decode import trtllm_batch_decode_with_kv_cache_mla
+from flashinfer import BatchMLAPagedAttentionWrapper
 
+from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.mla_attention import (
     MLACommonBackend,
+    MLACommonDecodeMetadata,
     MLACommonImpl,
     MLACommonMetadata,
     MLACommonMetadataBuilder,
     QueryLenSupport,
+    get_mla_dims,
 )
 from vllm.platforms.interface import DeviceCapability
-from vllm.utils.torch_utils import is_quantized_kv_cache
 from vllm.v1.attention.backend import (
     AttentionCGSupport,
     AttentionLayer,
     AttentionType,
     MultipleOf,
 )
-from vllm.v1.attention.backends.utils import KVCacheLayoutType
+from vllm.v1.kv_cache_interface import AttentionSpec
 
 logger = init_logger(__name__)
 
 FLASHINFER_MLA_WORKSPACE_BUFFER_SIZE = 128 * 1024 * 1024
 
 
-class FlashInferMLAMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
-    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+_shared_workspaces: dict[torch.device, torch.Tensor] = {}
+
+
+def _get_shared_workspace(device: torch.device) -> torch.Tensor:
+    workspace = _shared_workspaces.get(device)
+    if workspace is None:
+        workspace = torch.zeros(
+            FLASHINFER_MLA_WORKSPACE_BUFFER_SIZE,
+            dtype=torch.uint8,
+            device=device,
+        )
+        _shared_workspaces[device] = workspace
+    return workspace
+
+
+def _create_wrapper(workspace, device, batch_size, max_pages_per_req, tpr=1):
+    """Create a BatchMLAPagedAttentionWrapper with use_cuda_graph=True
+    and pre-allocated buffers sized for exactly batch_size requests."""
+    num_tokens = batch_size * tpr
+    qo_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    kv_indptr = torch.zeros(batch_size + 1, dtype=torch.int32, device=device)
+    kv_indices = torch.zeros(batch_size * max_pages_per_req, dtype=torch.int32, device=device)
+    kv_len_arr = torch.zeros(batch_size, dtype=torch.int32, device=device)
+    return BatchMLAPagedAttentionWrapper(
+        workspace,
+        use_cuda_graph=True,
+        qo_indptr=qo_indptr,
+        kv_indptr=kv_indptr,
+        kv_indices=kv_indices,
+        kv_len_arr=kv_len_arr,
+        backend="auto",
+    )
+
+
+@dataclass
+class FlashInferMLADecodeMetadata(MLACommonDecodeMetadata):
+    wrapper: Optional[BatchMLAPagedAttentionWrapper] = None
+
+
+class FlashInferMLAMetadataBuilder(MLACommonMetadataBuilder["FlashInferMLAMetadata"]):
+    _cudagraph_support: ClassVar[AttentionCGSupport] = (
+        AttentionCGSupport.UNIFORM_BATCH
+    )
     query_len_support: ClassVar[QueryLenSupport] = QueryLenSupport.UNIFORM
+
+    def __init__(self, kv_cache_spec, layer_names, vllm_config, device, **kwargs):
+        max_model_len = vllm_config.model_config.max_model_len
+        block_size = kv_cache_spec.block_size
+        self._max_pages_per_req = (max_model_len + block_size - 1) // block_size
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device, supports_dcp_with_varlen=True,
+                         metadata_cls=FlashInferMLAMetadata, **kwargs)
+
+        mla_dims = get_mla_dims(self.model_config)
+        self._kv_lora_rank = mla_dims.kv_lora_rank
+        self._qk_nope_head_dim = mla_dims.qk_nope_head_dim
+        self._qk_rope_head_dim = mla_dims.qk_rope_head_dim
+        self._page_size = kv_cache_spec.block_size
+        self._device = device
+        self._shared_workspace = _get_shared_workspace(device)
+
+        # Per-batch-size wrappers: created lazily on first use.
+        # Key = (num_reqs, tokens_per_req), value = wrapper.
+        # Wrappers share one scratch workspace per worker process.
+        self._wrappers: dict[tuple[int, int], BatchMLAPagedAttentionWrapper] = {}
+
+    def _get_wrapper(self, num_reqs, tpr=1):
+        """Get or create a wrapper for the given batch size."""
+        key = (num_reqs, tpr)
+        if key not in self._wrappers:
+            logger.info("Creating FlashInfer MLA wrapper for batch=%d tpr=%d",
+                        num_reqs, tpr)
+            self._wrappers[key] = _create_wrapper(
+                self._shared_workspace,
+                self._device,
+                num_reqs,
+                self._max_pages_per_req,
+                tpr,
+            )
+        return self._wrappers[key]
+
+    def _build_decode(self, block_table_tensor, seq_lens_device,
+                      max_seq_len, query_start_loc_cpu, query_start_loc_device,
+                      num_decode_tokens, dcp_tot_seq_lens_device=None):
+        num_reqs = seq_lens_device.shape[0]
+        page_size = self._page_size
+        dev = seq_lens_device.device
+
+        num_pages_per_req = (seq_lens_device + page_size - 1) // page_size
+        kv_indptr = torch.zeros(num_reqs + 1, dtype=torch.int32, device=dev)
+        torch.cumsum(num_pages_per_req, dim=0, out=kv_indptr[1:])
+        max_blk = block_table_tensor.shape[1]
+        blk_idx = torch.arange(max_blk, device=dev)
+        mask = blk_idx.unsqueeze(0) < num_pages_per_req.unsqueeze(1)
+        kv_indices = block_table_tensor[mask].to(torch.int32)
+
+        tpr = num_decode_tokens // num_reqs if num_reqs > 0 else 1
+        qo_indptr = torch.arange(0, num_reqs * tpr + 1, tpr,
+                                 dtype=torch.int32, device=dev)
+
+        wrapper = self._get_wrapper(num_reqs, tpr)
+        wrapper.plan(
+            qo_indptr, kv_indptr, kv_indices,
+            seq_lens_device.to(torch.int32),
+            num_heads=self.num_heads * self.dcp_world_size,
+            head_dim_ckv=self._kv_lora_rank,
+            head_dim_kpe=self._qk_rope_head_dim,
+            page_size=page_size, causal=False,
+            sm_scale=1.0 / (self._qk_nope_head_dim + self._qk_rope_head_dim) ** 0.5,
+            q_data_type=self.model_config.dtype,
+            kv_data_type=self.model_config.dtype)
+
+        return FlashInferMLADecodeMetadata(
+            block_table=block_table_tensor, seq_lens=seq_lens_device,
+            dcp_tot_seq_lens=dcp_tot_seq_lens_device, wrapper=wrapper)
+
+
+@dataclass
+class FlashInferMLAMetadata(MLACommonMetadata[FlashInferMLADecodeMetadata]):
+    pass
 
 
 class FlashInferMLABackend(MLACommonBackend):
     supported_dtypes: ClassVar[list[torch.dtype]] = [torch.float16, torch.bfloat16]
     supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = [
-        "auto",
-        "float16",
-        "bfloat16",
-        "fp8",
-        "fp8_e4m3",
-    ]
+        "auto", "bfloat16", "fp8", "fp8_e4m3"]
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
-        return [32, 64]
+        return [MultipleOf(1)]
 
     @staticmethod
     def get_name() -> str:
@@ -63,147 +179,56 @@ class FlashInferMLABackend(MLACommonBackend):
 
     @classmethod
     def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
-        return capability.major == 10
+        return capability.major >= 10
 
     @classmethod
-    def supports_combination(
-        cls,
-        head_size: int,
-        dtype: torch.dtype,
-        kv_cache_dtype: CacheDType | None,
-        block_size: int | None,
-        use_mla: bool,
-        has_sink: bool,
-        use_sparse: bool,
-        device_capability: DeviceCapability,
-    ) -> str | None:
-        # FlashInfer MLA kernel requires qk_nope_head_dim in [64, 128, 192]
-        from vllm.config import get_current_vllm_config
-
-        vllm_config = get_current_vllm_config()
-        if vllm_config.model_config is not None:
-            hf_text_config = vllm_config.model_config.hf_text_config
-            qk_nope_head_dim = getattr(hf_text_config, "qk_nope_head_dim", 1)
-            if qk_nope_head_dim not in [64, 128, 192]:
-                return (
-                    "FlashInfer MLA kernel requires qk_nope_head_dim "
-                    f"in [64, 128, 192], but got {qk_nope_head_dim}"
-                )
+    def supports_combination(cls, head_size, dtype, kv_cache_dtype, block_size,
+                             use_mla, has_sink, use_sparse,
+                             device_capability) -> str | None:
         return None
 
-    @classmethod
-    def get_required_kv_cache_layout(cls) -> "KVCacheLayoutType | None":
-        return "HND"
 
+class FlashInferMLAImpl(MLACommonImpl[FlashInferMLAMetadata]):
+    can_return_lse_for_decode: bool = True
 
-g_fi_workspace = torch.zeros(
-    FLASHINFER_MLA_WORKSPACE_BUFFER_SIZE,
-    dtype=torch.uint8,
-    device="cuda",
-)
-
-
-class FlashInferMLAImpl(MLACommonImpl[MLACommonMetadata]):
-    def __init__(
-        self,
-        num_heads: int,
-        head_size: int,
-        scale: float,
-        num_kv_heads: int,
-        alibi_slopes: list[float] | None,
-        sliding_window: int | None,
-        kv_cache_dtype: str,
-        logits_soft_cap: float | None,
-        attn_type: str,
-        kv_sharing_target_layer_name: str | None,
-        # MLA Specific Arguments
-        **mla_args,
-    ) -> None:
-        super().__init__(
-            num_heads,
-            head_size,
-            scale,
-            num_kv_heads,
-            alibi_slopes,
-            sliding_window,
-            kv_cache_dtype,
-            logits_soft_cap,
-            attn_type,
-            kv_sharing_target_layer_name,
-            **mla_args,
-        )
-
-        unsupported_features = [alibi_slopes, sliding_window, logits_soft_cap]
-        if any(unsupported_features):
+    def __init__(self, num_heads, head_size, scale, num_kv_heads,
+                 alibi_slopes, sliding_window, kv_cache_dtype,
+                 logits_soft_cap, attn_type, kv_sharing_target_layer_name,
+                 **mla_args):
+        super().__init__(num_heads, head_size, scale, num_kv_heads,
+                         alibi_slopes, sliding_window, kv_cache_dtype,
+                         logits_soft_cap, attn_type, kv_sharing_target_layer_name,
+                         **mla_args)
+        if any([alibi_slopes, sliding_window, logits_soft_cap]):
             raise NotImplementedError(
-                "FlashInferMLAImpl does not support one of the following: "
-                "alibi_slopes, sliding_window, logits_soft_cap"
-            )
-
+                "FlashInferMLAImpl does not support "
+                "alibi/sliding_window/logits_soft_cap")
         if attn_type != AttentionType.DECODER:
-            raise NotImplementedError(
-                "Encoder self-attention and "
-                "encoder/decoder cross-attention "
-                "are not implemented for "
-                "FlashInferMLAImpl"
-            )
+            raise NotImplementedError("Only decoder attention supported")
 
-        self._workspace_buffer = g_fi_workspace
-        self.bmm1_scale: float | None = None
-        self.bmm2_scale: float | None = None
-
-    def forward_mqa(
-        self,
-        q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
-        kv_c_and_k_pe_cache: torch.Tensor,
-        attn_metadata: MLACommonMetadata,
-        layer: AttentionLayer,
-    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+    def forward_mqa(self, q, kv_c_and_k_pe_cache, attn_metadata, layer):
         assert kv_c_and_k_pe_cache.numel() > 0
         assert attn_metadata.decode is not None
+        assert attn_metadata.decode.wrapper is not None
 
         if isinstance(q, tuple):
             q_nope, q_pe = q
-            q = torch.cat([q_nope, q_pe], dim=-1)
-
-        # trtllm API requires extra dimension q_len_per_request for MTP
-        if attn_metadata.num_decode_tokens % attn_metadata.num_decodes != 0:
-            logger.warning_once(
-                """FlashInferMLAImpl got a query of uneven length.
-                This usually indicates an issue in batch reordering
-                or incorrect setup in dummy_run."""
-            )
-            q = q.unsqueeze(1)
         else:
-            q = q.view(attn_metadata.num_decodes, -1, q.shape[-2], q.shape[-1])
+            q_nope = q[:, :, :self.kv_lora_rank]
+            q_pe = q[:, :, self.kv_lora_rank:]
 
-        if self.bmm1_scale is None:
-            self.bmm1_scale = self.scale
-            if is_quantized_kv_cache(self.kv_cache_dtype):
-                self.bmm1_scale *= layer._q_scale_float * layer._k_scale_float
+        # Split KV cache: (blocks, block_size, 576) -> ckv(512) + kpe(64)
+        # No .contiguous() — SGLang also passes strided slices, flashinfer handles it
+        ckv_cache = kv_c_and_k_pe_cache[:, :, :self.kv_lora_rank].unsqueeze(2)
+        kpe_cache = kv_c_and_k_pe_cache[:, :, self.kv_lora_rank:].unsqueeze(2)
 
-        if self.bmm2_scale is None:
-            self.bmm2_scale = 1.0
-            if is_quantized_kv_cache(self.kv_cache_dtype):
-                self.bmm2_scale *= layer._k_scale_float
+        wrapper = attn_metadata.decode.wrapper
+        o, lse = wrapper.run(
+            q_nope.contiguous(), q_pe.contiguous(),
+            ckv_cache, kpe_cache, return_lse=True, return_lse_base_on_e=True)
 
-        o = trtllm_batch_decode_with_kv_cache_mla(
-            query=q,
-            kv_cache=kv_c_and_k_pe_cache.unsqueeze(1),
-            workspace_buffer=self._workspace_buffer,
-            qk_nope_head_dim=self.qk_nope_head_dim,
-            kv_lora_rank=self.kv_lora_rank,
-            qk_rope_head_dim=self.qk_rope_head_dim,
-            block_tables=attn_metadata.decode.block_table,
-            seq_lens=attn_metadata.decode.seq_lens,
-            max_seq_len=attn_metadata.max_seq_len,
-            bmm1_scale=self.bmm1_scale,
-            bmm2_scale=self.bmm2_scale,
-        )
+        v_scale = layer._v_scale_float
+        if v_scale != 1.0:
+            o = o * v_scale
 
-        # Flatten the output for consistent shape
-        o = o.view(-1, o.shape[-2], o.shape[-1])
-
-        # TODO: Return LSE pending support from Flashinfer API:
-        # https://github.com/flashinfer-ai/flashinfer/pull/1566
-        return o, None
+        return o.contiguous(), lse


### PR DESCRIPTION
Tracked in #37113.

This PR fixes the FlashInfer MLA decode/runtime path used when GLM-5.1 runs with DCP and MTP enabled.

## Problem

During MTP, the target model validates multiple candidate tokens for the same request. Under DCP, those validation tokens do not map to a simple contiguous local KV suffix on each rank. Treating that multi-token validation as a normal single-request multi-token decode can build incorrect FlashInfer MLA metadata.

That shows up as unstable or corrupted generation after some decoding, especially with DCP enabled.

## What This PR Changes

- Makes the FlashInfer MLA decode metadata path DCP-aware for MTP target validation.
- Handles DCP multi-token target validation as per-token decode entries with DCP-local sequence lengths.
- Keeps FlashInfer MLA in a CUDA graph mode that is valid for this DCP + speculative-decode path.
- Keeps MLA indexer/fallback coordination aligned with the FlashInfer MLA runtime path.

## Scope

- FlashInfer MLA decode/runtime handling only.
- Includes the DCP + MTP target-validation path.
- No model-side GLM loading changes.
- No distributed/custom-allreduce changes.
- No SM120 B12X backend-selection changes.
- No draft attention metadata reuse from #39632.

## Update 2026-04-19

- Fixed FlashInfer MLA wrapper workspace reuse for per-`(num_reqs, tokens_per_req)` variants.
- Wrappers remain per shape for CUDA-graph-safe metadata buffers, but they now reuse one scratch workspace per worker process instead of allocating a new 128 MiB workspace for each wrapper key.
- This addresses the runtime OOM pattern triggered by repeated wrapper creation under GLM-5.1 MTP workloads.
