### PR TITLE
[Realtime][Video] Add streaming video input for real-time video understanding

### DIFF
--- a/examples/online_serving/openai_realtime_camera_client.py
+++ b/examples/online_serving/openai_realtime_camera_client.py
@@ -1,0 +1,1008 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Demo client for the vLLM Realtime Video WebSocket API using live camera.
+
+Reads frames from the camera, samples every Nth frame (--frame-interval),
+and sends to the server. When the client-side frame queue is full, old
+frames are discarded and newer frames are kept (drop-oldest policy).
+
+Before running, start vLLM with a vision model that supports video, e.g.:
+
+    vllm serve Qwen2.5-VL-7B-Instruct --enforce-eager
+
+Requirements:
+- websockets
+- Pillow
+- opencv-python
+- gradio (for --gradio UI)
+
+Usage:
+  # Default camera (device 0), every frame
+  python openai_realtime_camera_client.py
+
+  # Set output resolution (exact size, may stretch image)
+  python openai_realtime_camera_client.py --output-resolution 640x480
+
+  # Set max size (keep aspect ratio)
+  python openai_realtime_camera_client.py --max-size 640
+
+  # Keep aspect ratio when resizing to exact resolution
+  python openai_realtime_camera_client.py --output-resolution 640x480 --keep-aspect-ratio
+
+  # Gradio UI: set all parameters in the interface, send new prompts anytime
+  python openai_realtime_camera_client.py --gradio
+
+  # Gradio with CLI defaults (override in UI)
+  python openai_realtime_camera_client.py --gradio --port 8000 --camera-id 0
+
+Press Ctrl+C to stop.
+"""
+
+import argparse
+import asyncio
+import base64
+import collections
+import io
+import json
+import os
+import queue
+import sys
+import threading
+
+import websockets
+
+try:
+    import gradio as gr
+except ImportError:
+    gr = None
+
+try:
+    from PIL import Image
+except ImportError:
+    Image = None
+
+try:
+    import cv2
+
+    # cv2.setLogLevel exists in OpenCV 4.8+; Gradio may call it
+    if not hasattr(cv2, "setLogLevel"):
+        cv2.setLogLevel = lambda _: None  # no-op for older OpenCV
+except ImportError:
+    cv2 = None
+
+# Shared state
+frame_queue: collections.deque | None = None
+is_capturing = False
+is_stopping = False
+dropped_count = 0
+latest_display_frame = None  # RGB numpy array for Gradio
+response_text = ""  # Model output for Gradio
+
+# For Gradio: prompts to send (session.update) when user sends new prompt
+_prompt_queue: queue.Queue | None = None
+# For Gradio: trigger events to send (generation.trigger) for asking questions
+_trigger_queue: queue.Queue | None = None
+
+# Shared resize configuration (for runtime modification)
+_resize_config = {
+    "output_resolution": None,
+    "max_size": None,
+    "keep_aspect_ratio": False,
+}
+
+
+def _append_response(s: str) -> None:
+    """Append to response_text for Gradio display."""
+    global response_text
+    response_text += s
+
+
+def _parse_resolution(resolution_str: str) -> tuple[int, int] | None:
+    """Parse resolution string 'WxH' into (width, height). Returns None if invalid."""
+    if not resolution_str:
+        return None
+    try:
+        parts = resolution_str.lower().replace(" ", "").split("x")
+        if len(parts) == 2:
+            width = int(parts[0])
+            height = int(parts[1])
+            if width > 0 and height > 0:
+                return width, height
+    except (ValueError, AttributeError):
+        pass
+    return None
+
+
+def frame_to_base64_jpeg(
+    bgr,
+    quality: int = 85,
+    output_resolution: str | None = None,
+    max_size: int | None = None,
+    keep_aspect_ratio: bool = False,
+) -> str:
+    """Convert BGR frame to base64-encoded JPEG with optional resize."""
+    if Image is None:
+        raise RuntimeError("PIL is required. Install with: pip install Pillow")
+
+    original_height, original_width = bgr.shape[:2]
+
+    # Determine output dimensions
+    output_width, output_height = None, None
+
+    if max_size:
+        # Use max_size with aspect ratio preservation
+        if original_width > max_size or original_height > max_size:
+            ratio = min(max_size / original_width, max_size / original_height)
+            output_width = int(original_width * ratio)
+            output_height = int(original_height * ratio)
+    elif output_resolution:
+        parsed_res = _parse_resolution(output_resolution)
+        if parsed_res:
+            if keep_aspect_ratio:
+                # Fit image within the target resolution while maintaining aspect ratio
+                target_width, target_height = parsed_res
+                target_ratio = target_width / target_height
+                original_ratio = original_width / original_height
+
+                if original_ratio > target_ratio:
+                    # Image is wider, fit width
+                    output_width = target_width
+                    output_height = int(target_width / original_ratio)
+                else:
+                    # Image is taller, fit height
+                    output_height = target_height
+                    output_width = int(target_height * original_ratio)
+            else:
+                # Exact resize (may stretch)
+                output_width, output_height = parsed_res
+
+    # Resize if needed
+    if output_width and output_height:
+        bgr = cv2.resize(bgr, (output_width, output_height), interpolation=cv2.INTER_LINEAR)
+
+    rgb = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+    img = Image.fromarray(rgb)
+    buf = io.BytesIO()
+    img.save(buf, format="JPEG", quality=quality)
+    return base64.b64encode(buf.getvalue()).decode("utf-8")
+
+
+def camera_capture_loop(
+    camera_id: int,
+    frame_interval: int,
+    queue: "collections.deque[str]",
+    quality: int,
+    update_display_frame: bool = False,
+    output_resolution: str | None = None,
+    max_size: int | None = None,
+    keep_aspect_ratio: bool = False,
+) -> None:
+    """Capture frames from camera, sample, and append to queue. Drops oldest when full."""
+    global dropped_count, latest_display_frame
+    if cv2 is None:
+        raise RuntimeError(
+            "opencv-python is required. Install with: pip install opencv-python"
+        )
+    # On Windows, CAP_DSHOW often works better for webcams
+    if sys.platform == "win32":
+        cap = cv2.VideoCapture(camera_id, cv2.CAP_DSHOW)
+    else:
+        cap = cv2.VideoCapture(camera_id)
+    if not cap.isOpened():
+        raise RuntimeError(f"Cannot open camera {camera_id}")
+
+    # Get camera original resolution
+    orig_width = int(cap.get(cv2.CAP_PROP_FRAME_WIDTH))
+    orig_height = int(cap.get(cv2.CAP_PROP_FRAME_HEIGHT))
+
+    # Determine effective resolution
+    effective_res = f"{orig_width}x{orig_height}"
+    if max_size:
+        effective_res = f"max={max_size} (from {orig_width}x{orig_height})"
+    elif output_resolution:
+        if keep_aspect_ratio:
+            effective_res = f"fit in {output_resolution} (from {orig_width}x{orig_height})"
+        else:
+            effective_res = f"{output_resolution} (from {orig_width}x{orig_height})"
+
+    if update_display_frame:
+        _append_response(f"[Camera] Original: {orig_width}x{orig_height}, Output: {effective_res}\n")
+    else:
+        print(f"Camera: {orig_width}x{orig_height} -> Output: {effective_res}", flush=True)
+
+    frame_idx = 0
+    try:
+        while is_capturing:
+            ret, bgr = cap.read()
+            if not ret:
+                break
+            if update_display_frame:
+                latest_display_frame = cv2.cvtColor(bgr, cv2.COLOR_BGR2RGB)
+            if frame_idx % frame_interval == 0:
+                # Use shared config for runtime updates
+                out_res = output_resolution or _resize_config.get("output_resolution")
+                max_sz = max_size or _resize_config.get("max_size")
+                keep_ar = _resize_config.get("keep_aspect_ratio", False) or keep_aspect_ratio
+
+                b64 = frame_to_base64_jpeg(
+                    bgr,
+                    quality=quality,
+                    output_resolution=out_res,
+                    max_size=max_sz,
+                    keep_aspect_ratio=keep_ar,
+                )
+                # deque(maxlen=N): when full, append() automatically drops leftmost (oldest)
+                if len(queue) >= queue.maxlen:
+                    dropped_count += 1
+                queue.append(b64)
+            frame_idx += 1
+    finally:
+        cap.release()
+
+
+async def run_realtime_camera(
+    host: str,
+    port: int,
+    model: str,
+    prompt: str | None,
+    camera_id: int,
+    frame_interval: int,
+    batch_size: int,
+    queue_size: int,
+    quality: int,
+    prompt_queue: queue.Queue | None = None,
+    trigger_queue: queue.Queue | None = None,
+    update_display_frame: bool = False,
+    output_resolution: str | None = None,
+    max_size: int | None = None,
+    keep_aspect_ratio: bool = False,
+):
+    """Stream camera frames to realtime video WebSocket.
+
+    Client runs in silent mode by default (frames sent but no output).
+    Use 'generation.trigger' to ask questions and get responses.
+
+    Parameters:
+        batch_size: Upper limit on frames per commit. Actual frames sent is
+            min(batch_size, available_server_capacity, frames_in_queue).
+            Server capacity is controlled by its max_queue_size (typically 3-4).
+    """
+    global frame_queue, is_capturing
+
+    frame_queue = collections.deque(maxlen=queue_size)
+    is_capturing = True
+
+    # Set shared config for runtime updates
+    _resize_config["output_resolution"] = output_resolution
+    _resize_config["max_size"] = max_size
+    _resize_config["keep_aspect_ratio"] = keep_aspect_ratio
+
+    uri = f"ws://{host}:{port}/v1/realtime_video"
+    capture_thread = threading.Thread(
+        target=camera_capture_loop,
+        args=(
+            camera_id,
+            frame_interval,
+            frame_queue,
+            quality,
+            update_display_frame,
+            output_resolution,
+            max_size,
+            keep_aspect_ratio,
+        ),
+        daemon=True,
+    )
+    capture_thread.start()
+
+    print(
+        f"Camera {camera_id}: frame_interval={frame_interval}, "
+        f"batch_size={batch_size}, queue_size={queue_size} (drop oldest when full)"
+    )
+    print("Mode: Silent by default. Use 'Trigger' button to ask questions.")
+    print("Press Ctrl+C to stop.\n")
+
+    try:
+        try:
+            async with websockets.connect(uri, open_timeout=10) as ws:
+                msg = json.loads(await ws.recv())
+                if msg.get("type") == "error":
+                    print(f"Error: {msg.get('error', msg)}")
+                    return
+                if msg.get("type") != "session.created":
+                    print(f"Unexpected: {msg}")
+                    return
+                initial_water = msg.get("input_video_buffer") or {}
+                print(f"Session created: {msg.get('id', '')}")
+
+                payload = {"type": "session.update", "model": model}
+                if prompt:
+                    payload["prompt"] = prompt
+                await ws.send(json.dumps(payload))
+
+                # Background task: handle session.update and generation.trigger from UI
+                prompt_task: asyncio.Task | None = None
+                if prompt_queue is not None:
+
+                    async def prompt_sender() -> None:
+                        while is_capturing:
+                            try:
+                                # Check if stopping signal received
+                                global is_stopping
+                                if is_stopping:
+                                    # Send final commit to signal server we're done
+                                    await ws.send(
+                                        json.dumps({"type": "input_video_buffer.commit", "final": True})
+                                    )
+                                    if update_display_frame:
+                                        _append_response(f"\n[Stopping] Sent final commit to server\n")
+                                    else:
+                                        print(f"\n[Stopping] Sent final commit to server", flush=True)
+                                    break
+
+                                # Check for session.update (silent mode prompt change)
+                                try:
+                                    new_prompt = prompt_queue.get_nowait()
+                                    await ws.send(
+                                        json.dumps({
+                                            "type": "session.update",
+                                            "model": model,
+                                            "prompt": new_prompt or "",
+                                        })
+                                    )
+                                    if update_display_frame:
+                                        _append_response(f"\n[Prompt updated] {new_prompt}\n")
+                                    else:
+                                        print(f"\n[Prompt updated] {new_prompt}", flush=True)
+                                except queue.Empty:
+                                    pass
+
+                                # Check for generation.trigger (trigger question)
+                                if trigger_queue is not None:
+                                    try:
+                                        trigger_data = trigger_queue.get_nowait()
+                                        trigger_payload = {"type": "generation.trigger"}
+                                        if trigger_data.get("prompt"):
+                                            trigger_payload["prompt"] = trigger_data["prompt"]
+                                        if trigger_data.get("max_tokens"):
+                                            trigger_payload["max_tokens"] = trigger_data["max_tokens"]
+                                        await ws.send(json.dumps(trigger_payload))
+                                        if update_display_frame:
+                                            _append_response(f"\n[Trigger] {trigger_data.get('prompt', '')}\n")
+                                        else:
+                                            print(f"\n[Trigger] {trigger_data.get('prompt', '')}", flush=True)
+                                    except queue.Empty:
+                                        pass
+
+                            except Exception as e:
+                                if update_display_frame:
+                                    _append_response(f"\n[Sender error] {e}\n")
+                                else:
+                                    print(f"\n[Sender error] {e}", flush=True)
+                            await asyncio.sleep(0.05)
+
+                    prompt_task = asyncio.create_task(prompt_sender())
+
+                queue_depth = 0
+                max_queue_size = initial_water.get("max_queue_size", 3)
+                received_done_count = 0
+                err: str | None = None
+                waiting_for_response = False  # Track if we're waiting for a trigger response
+
+                try:
+                    while err is None and is_capturing:
+                        # Calculate how many frames we can actually send
+                        available_server_capacity = max_queue_size - queue_depth
+                        frames_in_queue = len(frame_queue)
+                        frames_to_send = min(batch_size, available_server_capacity, frames_in_queue)
+
+                        # Collect frames from queue (only what we plan to send)
+                        batch: list[str] = []
+                        for _ in range(frames_to_send):
+                            try:
+                                batch.append(frame_queue.popleft())
+                            except IndexError:
+                                break
+
+                        # Send when we have frames (>=2 for model compatibility) and server has capacity
+                        # Note: Qwen2-VL/Qwen3-VL require at least 2 frames per batch
+                        should_send = (
+                            len(batch) >= 2
+                            and queue_depth < max_queue_size
+                        )
+
+                        if should_send:
+                            for b64 in batch:
+                                await ws.send(
+                                    json.dumps(
+                                        {
+                                            "type": "input_video_buffer.append",
+                                            "video": b64,
+                                            "format": "image/jpeg",
+                                        }
+                                    )
+                                )
+                            # For live camera, we never send final=True until we stop
+                            await ws.send(
+                                json.dumps({"type": "input_video_buffer.commit", "final": False})
+                            )
+                            queue_depth += 1
+                            continue  # Sent successfully, try to send more
+
+                        # If we collected frames but couldn't send, put them back
+                        if batch:
+                            for b64 in reversed(batch):
+                                frame_queue.appendleft(b64)
+
+                        # When queue is empty and not waiting for response, sleep briefly
+                        if len(frame_queue) == 0 and not waiting_for_response:
+                            await asyncio.sleep(0.01)
+                            continue
+
+                        # Receive message
+                        if prompt_queue is not None:
+                            try:
+                                msg_bytes = await asyncio.wait_for(ws.recv(), timeout=1)
+                            except asyncio.TimeoutError:
+                                continue
+                        else:
+                            # Always use timeout to allow graceful stopping in non-Gradio mode too
+                            try:
+                                msg_bytes = await asyncio.wait_for(ws.recv(), timeout=1)
+                            except asyncio.TimeoutError:
+                                continue
+                        response = json.loads(msg_bytes)
+                        t = response.get("type")
+                        if t == "completion.delta":
+                            waiting_for_response = True
+                            delta = response.get("delta", "")
+                            if update_display_frame:
+                                _append_response(delta)
+                            else:
+                                print(delta, end="", flush=True)
+                        elif t == "completion.done":
+                            waiting_for_response = False
+                            text = response.get("text", "")
+                            only_show_non_empty = True  # Only show non-empty responses (triggered)
+                            if text or not only_show_non_empty:
+                                if update_display_frame:
+                                    _append_response(f"\n\n[Response] {text}")
+                                    if response.get("usage"):
+                                        _append_response(f"\nUsage: {response['usage']}")
+                                else:
+                                    print(f"\n\n[Response] {text}")
+                                    if response.get("usage"):
+                                        print(f"Usage: {response['usage']}")
+                            received_done_count += 1
+                            buf = response.get("input_video_buffer")
+                            if buf is not None:
+                                queue_depth = buf.get("queue_depth", queue_depth)
+                                max_queue_size = buf.get("max_queue_size", max_queue_size)
+                        elif t == "input_video_buffer.water_level":
+                            queue_depth = response.get("queue_depth", queue_depth)
+                            max_queue_size = response.get("max_queue_size", max_queue_size)
+                        elif t == "session.stop":
+                            is_stopping = True
+                            is_capturing = False
+                            if update_display_frame:
+                                _append_response("\n[Session stopped by server]\n")
+                            else:
+                                print("\n[Session stopped by server]", flush=True)
+                            break
+                        elif t == "error":
+                            err = response.get("error", response.get("message", str(response)))
+                            err_str = f"\nError: {err}"
+                            if response.get("code"):
+                                err_str += f"\nCode: {response['code']}"
+                            if update_display_frame:
+                                _append_response(err_str)
+                            else:
+                                print(err_str, flush=True)
+                        else:
+                            print(f"[Received type={t!r}] {response}", flush=True)
+
+                    # If we exited loop normally (not due to error), send final commit to server
+                    if is_stopping:
+                        try:
+                            await ws.send(
+                                json.dumps({"type": "input_video_buffer.commit", "final": True})
+                            )
+                            if update_display_frame:
+                                _append_response("\n[Stopped] Sent final commit to server\n")
+                            else:
+                                print("\n[Stopped] Sent final commit to server", flush=True)
+                        except Exception as e:
+                            # WebSocket may already be closed, that's ok
+                            pass
+                finally:
+                    if prompt_task is not None and not prompt_task.done():
+                        prompt_task.cancel()
+                        try:
+                            await prompt_task
+                        except asyncio.CancelledError:
+                            pass
+
+                    # Close WebSocket connection gracefully
+                    try:
+                        await ws.close()
+                    except Exception:
+                        pass
+        except Exception as conn_err:
+            err_msg = f"Connection error: {conn_err}\nIs the vLLM server running at {uri}?"
+            if update_display_frame:
+                _append_response(err_msg)
+            else:
+                print(err_msg)
+            # Keep camera running for preview so user can see it works
+            while is_capturing:
+                await asyncio.sleep(0.2)
+    except asyncio.CancelledError:
+        pass
+    finally:
+        is_capturing = False
+        if dropped_count > 0:
+            print(f"\nDropped {dropped_count} frame(s) (queue was full).", flush=True)
+
+
+def websocket_handler(
+    host: str,
+    port: int,
+    model: str,
+    prompt: str | None,
+    camera_id: int,
+    frame_interval: int,
+    batch_size: int,
+    queue_size: int,
+    quality: int,
+    trigger_queue: queue.Queue | None = None,
+    output_resolution: str | None = None,
+    max_size: int | None = None,
+    keep_aspect_ratio: bool = False,
+) -> None:
+    """Run WebSocket + camera in event loop (for Gradio background thread)."""
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    try:
+        loop.run_until_complete(
+            run_realtime_camera(
+                host,
+                port,
+                model,
+                prompt,
+                camera_id,
+                frame_interval,
+                batch_size,
+                queue_size,
+                quality,
+                prompt_queue=_prompt_queue,
+                trigger_queue=trigger_queue,
+                update_display_frame=True,
+                output_resolution=output_resolution,
+                max_size=max_size,
+                keep_aspect_ratio=keep_aspect_ratio,
+            )
+        )
+    except Exception as e:
+        print(f"WebSocket error: {e}")
+
+
+def send_prompt(prompt: str) -> tuple:
+    """Gradio callback: enqueue new prompt for session.update."""
+    global _prompt_queue
+    if _prompt_queue is not None and prompt and prompt.strip():
+        _prompt_queue.put(prompt.strip())
+    return gr.update(value="")  # Clear the input
+
+
+def send_trigger(prompt: str) -> tuple:
+    """Gradio callback: enqueue trigger for generation."""
+    global _trigger_queue
+    if _trigger_queue is not None and prompt and prompt.strip():
+        _trigger_queue.put({"prompt": prompt.strip(), "max_tokens": 512})
+    return gr.update(value="")  # Clear the input
+
+
+def update_resolution_settings(
+    resolution: str, max_size: int, keep_aspect_ratio: bool
+) -> tuple:
+    """Runtime update resolution settings."""
+    global _resize_config
+    _resize_config["output_resolution"] = resolution if resolution else None
+    _resize_config["max_size"] = max_size if max_size > 0 else None
+    _resize_config["keep_aspect_ratio"] = keep_aspect_ratio
+
+    msg = f"[Resolution updated] "
+    if max_size > 0:
+        msg += f"max_size={max_size}, keep_aspect={keep_aspect_ratio}"
+    elif resolution:
+        msg += f"{resolution}, keep_aspect={keep_aspect_ratio}"
+    else:
+        msg += "using camera original resolution"
+    _append_response(f"\n{msg}\n")
+
+    return gr.update(), gr.update(), gr.update()
+
+
+def start_camera_service(
+    host: str,
+    port: int,
+    model: str,
+    prompt: str,
+    camera_id: int,
+    frame_interval: int,
+    batch_size: int,
+    queue_size: int,
+    quality: int,
+    output_resolution: str | None = None,
+    max_size: int = 0,
+    keep_aspect_ratio: bool = False,
+) -> tuple:
+    """Start the camera + WebSocket service (Gradio Start button)."""
+    global response_text, _trigger_queue, is_capturing, is_stopping
+    response_text = ""
+    _trigger_queue = queue.Queue()
+    is_capturing = True
+    is_stopping = False
+    thread = threading.Thread(
+        target=websocket_handler,
+        args=(
+            host or "localhost",
+            int(port) if port else 8000,
+            model or "Qwen2.5-VL-7B-Instruct",
+            prompt.strip() if prompt else None,
+            int(camera_id) if camera_id is not None else 0,
+            int(frame_interval) if frame_interval else 1,
+            int(batch_size) if batch_size else 16,
+            int(queue_size) if queue_size else 64,
+            int(quality) if quality else 85,
+            _trigger_queue,
+            output_resolution.strip() if output_resolution else None,
+            max_size if max_size > 0 else None,
+            keep_aspect_ratio,
+        ),
+        daemon=True,
+    )
+    thread.start()
+    return gr.update(interactive=False), gr.update(interactive=True)
+
+
+def stop_camera_service() -> tuple:
+    """Stop the camera + WebSocket service (Gradio Stop button)."""
+    global is_capturing, is_stopping
+    is_capturing = False
+    is_stopping = True  # Signal graceful shutdown to send final commit
+    _append_response("\n[Stop] Stopping camera service...\n")
+    return gr.update(interactive=True), gr.update(interactive=False)
+
+
+def get_latest_display() -> tuple:
+    """Return latest frame and response text for Gradio periodic update."""
+    global latest_display_frame, response_text
+    img = latest_display_frame
+    return img, response_text
+
+
+def create_gradio_demo(
+    host: str = "localhost",
+    port: int = 8000,
+    model: str = "Qwen2.5-VL-7B-Instruct",
+    prompt: str | None = None,
+    camera_id: int = 0,
+    frame_interval: int = 1,
+    batch_size: int = 16,
+    queue_size: int = 64,
+    quality: int = 85,
+    output_resolution: str | None = None,
+    max_size: int = 0,
+    keep_aspect_ratio: bool = False,
+) -> "gr.Blocks":
+    """Create Gradio interface with parameter inputs and prompt send."""
+    # Inline JS: stick to bottom unless user scrolls up; when at bottom, keep auto-scrolling
+    scroll_js = """
+    <script>
+    (function(){
+      var userScrolledUp = false;
+      function isAtBottom(ta){
+        return ta.scrollHeight - ta.scrollTop - ta.clientHeight < 10;
+      }
+      function run(){
+        var el = document.getElementById("model-response-output");
+        if(!el) return;
+        var ta = el.tagName==="TEXTAREA" ? el : el.querySelector("textarea");
+        if(!ta) return;
+        if(!userScrolledUp || isAtBottom(ta)) ta.scrollTop = ta.scrollHeight;
+      }
+      function onScroll(){
+        var el = document.getElementById("model-response-output");
+        if(!el) return;
+        var ta = el.tagName==="TEXTAREA" ? el : el.querySelector("textarea");
+        if(!ta) return;
+        userScrolledUp = !isAtBottom(ta);
+      }
+      function start(){
+        var el = document.getElementById("model-response-output");
+        if(!el){ setTimeout(start, 200); return; }
+        var ta = el.tagName==="TEXTAREA" ? el : el.querySelector("textarea");
+        if(ta) ta.addEventListener("scroll", onScroll, {passive:true});
+        setInterval(run, 100);
+      }
+      if(document.readyState==="loading")
+        document.addEventListener("DOMContentLoaded", start);
+      else
+        setTimeout(start, 500);
+    })();
+    </script>
+    """
+    with gr.Blocks(title="Real-time Camera Vision", head=scroll_js) as demo:
+        gr.Markdown("# Real-time Camera Vision")
+        gr.Markdown(
+            "Set parameters below (or use defaults from command line), click **Start**. "
+            "Camera runs in **silent mode** by default. Use **Trigger** button to ask questions and get responses."
+        )
+        with gr.Row():
+            with gr.Column(scale=1):
+                host_in = gr.Textbox(label="Host", value=host or "localhost")
+                port_in = gr.Number(label="Port", value=port or 8000, precision=0)
+                model_in = gr.Textbox(
+                    label="Model",
+                    value=model or "Qwen2.5-VL-7B-Instruct",
+                )
+                prompt_in = gr.Textbox(
+                    label="Initial Prompt (optional)",
+                    value=prompt or "",
+                    placeholder="Describe what you see.",
+                    lines=2,
+                )
+                camera_id_in = gr.Number(
+                    label="Camera ID",
+                    value=camera_id,
+                    precision=0,
+                )
+                frame_interval_in = gr.Number(
+                    label="Frame Interval",
+                    value=frame_interval,
+                    precision=0,
+                )
+                batch_size_in = gr.Number(
+                    label="Batch Size",
+                    value=batch_size,
+                    precision=0,
+                )
+                queue_size_in = gr.Number(
+                    label="Queue Size",
+                    value=queue_size,
+                    precision=0,
+                )
+                quality_in = gr.Number(
+                    label="Quality (1-100)",
+                    value=quality,
+                    precision=0,
+                )
+                # Resolution settings
+                gr.Markdown("### Resolution Settings")
+                resolution_in = gr.Textbox(
+                    label="Output Resolution (e.g., 640x480, 1280x720)",
+                    value=output_resolution or "",
+                    placeholder="e.g., 640x480, 1280x720. Leave empty for original.",
+                )
+                max_size_in = gr.Number(
+                    label="Max Size (0=disabled, keep aspect ratio)",
+                    value=max_size,
+                    precision=0,
+                    minimum=0,
+                )
+                keep_aspect_in = gr.Checkbox(
+                    label="Keep Aspect Ratio",
+                    value=keep_aspect_ratio,
+                )
+                update_res_btn = gr.Button("Update Resolution", variant="secondary", size="sm")
+                with gr.Row():
+                    start_btn = gr.Button("Start", variant="primary")
+                    stop_btn = gr.Button("Stop", variant="stop", interactive=False)
+            with gr.Column(scale=1):
+                image_out = gr.Image(label="Camera", height=400)
+                text_out = gr.Textbox(
+                    label="Model Response",
+                    lines=12,
+                    max_lines=25,
+                    elem_id="model-response-output",
+                )
+                gr.Markdown("### Trigger Question (Ask & Get Response)")
+                with gr.Row():
+                    trigger_in = gr.Textbox(
+                        label="Question",
+                        placeholder="Type and click Trigger to ask the model",
+                        scale=4,
+                    )
+                    trigger_btn = gr.Button("Trigger", variant="primary", scale=1)
+                gr.Markdown("### Update Silent Mode Prompt (No output)")
+                with gr.Row():
+                    new_prompt_in = gr.Textbox(
+                        label="New Silent Prompt",
+                        placeholder="Type and click Send to update prompt",
+                        scale=4,
+                    )
+                    send_btn = gr.Button("Send", scale=1)
+
+        start_btn.click(
+            start_camera_service,
+            inputs=[
+                host_in,
+                port_in,
+                model_in,
+                prompt_in,
+                camera_id_in,
+                frame_interval_in,
+                batch_size_in,
+                queue_size_in,
+                quality_in,
+                resolution_in,
+                max_size_in,
+                keep_aspect_in,
+            ],
+            outputs=[start_btn, stop_btn],
+        )
+        stop_btn.click(
+            stop_camera_service,
+            outputs=[start_btn, stop_btn],
+        )
+        # Runtime resolution update
+        update_res_btn.click(
+            update_resolution_settings,
+            inputs=[resolution_in, max_size_in, keep_aspect_in],
+            outputs=[resolution_in, max_size_in, keep_aspect_in],
+        )
+        trigger_btn.click(
+            send_trigger,
+            inputs=[trigger_in],
+            outputs=[trigger_in],
+        )
+        send_btn.click(
+            send_prompt,
+            inputs=[new_prompt_in],
+            outputs=[new_prompt_in],
+        )
+        # Gradio 6+: use Timer instead of demo.load(every=...)
+        timer = gr.Timer(value=0.1)  # Refresh every 100ms
+        timer.tick(
+            get_latest_display,
+            outputs=[image_out, text_out],
+        )
+
+    return demo
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Realtime Video WebSocket client for vLLM (live camera)"
+    )
+    parser.add_argument("--model", type=str, default="Qwen2.5-VL-7B-Instruct")
+    parser.add_argument("--prompt", type=str, default=None)
+    parser.add_argument(
+        "--camera-id",
+        type=int,
+        default=0,
+        help="Camera device index. Default: 0.",
+    )
+    parser.add_argument(
+        "--frame-interval",
+        type=int,
+        default=1,
+        help="Send every Nth frame (1=every frame, 10=every 10th frame). Default: 1.",
+    )
+    parser.add_argument("--host", type=str, default="localhost")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=16,
+        help=(
+            "Frames per batch; one commit per batch. "
+            "Send rhythm is controlled by server water level (backpressure)."
+        ),
+    )
+    parser.add_argument(
+        "--queue-size",
+        type=int,
+        default=64,
+        help=(
+            "Max frames in client queue. When full, oldest frames are "
+            "dropped to make room for newer ones. Default: 64."
+        ),
+    )
+    parser.add_argument(
+        "--quality",
+        type=int,
+        default=85,
+        help="JPEG encoding quality (1-100). Default: 85.",
+    )
+    parser.add_argument(
+        "--output-resolution",
+        type=str,
+        default=None,
+        help=(
+            "Output image resolution (exact size), format WIDTHxHEIGHT "
+            "(e.g., 640x480, 1280x720). May stretch image. Default: use "
+            "camera original resolution."
+        ),
+    )
+    parser.add_argument(
+        "--max-size",
+        type=int,
+        default=0,
+        help=(
+            "Maximum dimension for resize (0=disabled). Keeps aspect ratio. "
+            "Larger of width/height will be scaled to this value. Default: 0."
+        ),
+    )
+    parser.add_argument(
+        "--keep-aspect-ratio",
+        action="store_true",
+        help=(
+            "When using --output-resolution, fit image within target "
+            "resolution while maintaining aspect ratio."
+        ),
+    )
+    parser.add_argument(
+        "--gradio",
+        action="store_true",
+        help="Launch Gradio UI (image + text side by side).",
+    )
+    parser.add_argument(
+        "--share",
+        action="store_true",
+        help="Create public Gradio link (use with --gradio).",
+    )
+    args = parser.parse_args()
+
+    if args.frame_interval < 1:
+        parser.error("--frame-interval must be >= 1")
+
+    if args.gradio:
+        if gr is None:
+            raise RuntimeError(
+                "gradio is required for --gradio. "
+                "Install with: pip install gradio"
+            )
+        global _prompt_queue
+        _prompt_queue = queue.Queue()
+        demo = create_gradio_demo(
+            host=args.host,
+            port=args.port,
+            model=args.model,
+            prompt=args.prompt,
+            camera_id=args.camera_id,
+            frame_interval=args.frame_interval,
+            batch_size=args.batch_size,
+            queue_size=args.queue_size,
+            quality=args.quality,
+            output_resolution=args.output_resolution,
+            max_size=args.max_size,
+            keep_aspect_ratio=args.keep_aspect_ratio,
+        )
+        demo.launch(share=args.share)
+        return
+
+    try:
+        asyncio.run(
+            run_realtime_camera(
+                args.host,
+                args.port,
+                args.model,
+                args.prompt,
+                args.camera_id,
+                args.frame_interval,
+                args.batch_size,
+                args.queue_size,
+                args.quality,
+                output_resolution=args.output_resolution,
+                max_size=args.max_size if args.max_size > 0 else None,
+                keep_aspect_ratio=args.keep_aspect_ratio,
+            )
+        )
+    except KeyboardInterrupt:
+        print("\nStopped by user.", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/online_serving/openai_realtime_camera_client.py
+++ b/examples/online_serving/openai_realtime_camera_client.py
@@ -9,7 +9,7 @@ frames are discarded and newer frames are kept (drop-oldest policy).
 
 Before running, start vLLM with a vision model that supports video, e.g.:
 
-    vllm serve Qwen2.5-VL-7B-Instruct --enforce-eager
+    vllm serve Qwen3-VL-8B-Instruct --enforce-eager
 
 Requirements:
 - websockets

--- a/examples/online_serving/openai_realtime_camera_client.py
+++ b/examples/online_serving/openai_realtime_camera_client.py
@@ -21,6 +21,15 @@ Usage:
   # Default camera (device 0), every frame
   python openai_realtime_camera_client.py
 
+  # Every 10th frame (e.g. ~3 fps for 30fps camera)
+  python openai_realtime_camera_client.py --frame-interval 10
+
+  # Custom prompt and camera
+  python openai_realtime_camera_client.py --prompt "Describe what you see." --camera-id 0
+
+  # Limit queue size (drop old when full)
+  python openai_realtime_camera_client.py --queue-size 32 --frame-interval 5
+
   # Set output resolution (exact size, may stretch image)
   python openai_realtime_camera_client.py --output-resolution 640x480
 
@@ -71,6 +80,8 @@ try:
 except ImportError:
     cv2 = None
 
+os.environ["NO_PROXY"] = "127.0.0.1,localhost"
+os.environ["no_proxy"] = "127.0.0.1,localhost"
 # Shared state
 frame_queue: collections.deque | None = None
 is_capturing = False
@@ -251,6 +262,7 @@ async def run_realtime_camera(
     batch_size: int,
     queue_size: int,
     quality: int,
+    target_fps: float = 5.0,
     prompt_queue: queue.Queue | None = None,
     trigger_queue: queue.Queue | None = None,
     update_display_frame: bool = False,
@@ -264,9 +276,8 @@ async def run_realtime_camera(
     Use 'generation.trigger' to ask questions and get responses.
 
     Parameters:
-        batch_size: Upper limit on frames per commit. Actual frames sent is
-            min(batch_size, available_server_capacity, frames_in_queue).
-            Server capacity is controlled by its max_queue_size (typically 3-4).
+        batch_size: Frames per commit.
+        target_fps: Delay between batches = 1/target_fps seconds (default=5.0).
     """
     global frame_queue, is_capturing
 
@@ -297,7 +308,8 @@ async def run_realtime_camera(
 
     print(
         f"Camera {camera_id}: frame_interval={frame_interval}, "
-        f"batch_size={batch_size}, queue_size={queue_size} (drop oldest when full)"
+        f"batch_size={batch_size}, queue_size={queue_size} (drop oldest when full), "
+        f"target_fps={target_fps}"
     )
     print("Mode: Silent by default. Use 'Trigger' button to ask questions.")
     print("Press Ctrl+C to stop.\n")
@@ -383,20 +395,16 @@ async def run_realtime_camera(
 
                     prompt_task = asyncio.create_task(prompt_sender())
 
-                queue_depth = 0
-                max_queue_size = initial_water.get("max_queue_size", 3)
-                received_done_count = 0
+                batch_id = 0
+                frame_interval_sec = 1.0 / target_fps
                 err: str | None = None
-                waiting_for_response = False  # Track if we're waiting for a trigger response
 
                 try:
                     while err is None and is_capturing:
-                        # Calculate how many frames we can actually send
-                        available_server_capacity = max_queue_size - queue_depth
-                        frames_in_queue = len(frame_queue)
-                        frames_to_send = min(batch_size, available_server_capacity, frames_in_queue)
+                        # Get frames to send (simple: just take what's available up to batch_size)
+                        frames_to_send = min(batch_size, len(frame_queue))
 
-                        # Collect frames from queue (only what we plan to send)
+                        # Collect frames from queue
                         batch: list[str] = []
                         for _ in range(frames_to_send):
                             try:
@@ -404,14 +412,8 @@ async def run_realtime_camera(
                             except IndexError:
                                 break
 
-                        # Send when we have frames (>=2 for model compatibility) and server has capacity
-                        # Note: Qwen2-VL/Qwen3-VL require at least 2 frames per batch
-                        should_send = (
-                            len(batch) >= 2
-                            and queue_depth < max_queue_size
-                        )
-
-                        if should_send:
+                        # Send frames if we have any
+                        if batch:
                             for b64 in batch:
                                 await ws.send(
                                     json.dumps(
@@ -422,84 +424,58 @@ async def run_realtime_camera(
                                         }
                                     )
                                 )
-                            # For live camera, we never send final=True until we stop
+                            # Commit this batch
                             await ws.send(
                                 json.dumps({"type": "input_video_buffer.commit", "final": False})
                             )
-                            queue_depth += 1
-                            continue  # Sent successfully, try to send more
+                            batch_id += 1
 
-                        # If we collected frames but couldn't send, put them back
-                        if batch:
-                            for b64 in reversed(batch):
-                                frame_queue.appendleft(b64)
+                        # Collect any available responses with timeout
+                        try:
+                            while True:
+                                async with asyncio.timeout(1):
+                                    msg_bytes = await ws.recv()
+                                    response = json.loads(msg_bytes)
+                                    t = response.get("type")
+                                    if t == "completion.delta":
+                                        delta = response.get("delta", "")
+                                        if update_display_frame:
+                                            _append_response(delta)
+                                        else:
+                                            print(delta, end="", flush=True)
+                                    elif t == "completion.done":
+                                        text = response.get("text", "")
+                                        if text:
+                                            if update_display_frame:
+                                                _append_response(f"\n\n[Response] {text}")
+                                                if response.get("usage"):
+                                                    _append_response(f"\nUsage: {response['usage']}")
+                                            else:
+                                                print(f"\n\n[Response] {text}")
+                                                if response.get("usage"):
+                                                    print(f"Usage: {response['usage']}")
+                                    elif t == "session.stop":
+                                        is_stopping = True
+                                        is_capturing = False
+                                        if update_display_frame:
+                                            _append_response("\n[Session stopped by server]\n")
+                                        else:
+                                            print("\n[Session stopped by server]", flush=True)
+                                        break
+                                    elif t == "error":
+                                        err = response.get("error", response.get("message", str(response)))
+                                        err_str = f"\nError: {err}"
+                                        if response.get("code"):
+                                            err_str += f"\nCode: {response['code']}"
+                                        if update_display_frame:
+                                            _append_response(err_str)
+                                        else:
+                                            print(err_str, flush=True)
+                        except asyncio.TimeoutError:
+                            pass
 
-                        # When queue is empty and not waiting for response, sleep briefly
-                        if len(frame_queue) == 0 and not waiting_for_response:
-                            await asyncio.sleep(0.01)
-                            continue
-
-                        # Receive message
-                        if prompt_queue is not None:
-                            try:
-                                msg_bytes = await asyncio.wait_for(ws.recv(), timeout=1)
-                            except asyncio.TimeoutError:
-                                continue
-                        else:
-                            # Always use timeout to allow graceful stopping in non-Gradio mode too
-                            try:
-                                msg_bytes = await asyncio.wait_for(ws.recv(), timeout=1)
-                            except asyncio.TimeoutError:
-                                continue
-                        response = json.loads(msg_bytes)
-                        t = response.get("type")
-                        if t == "completion.delta":
-                            waiting_for_response = True
-                            delta = response.get("delta", "")
-                            if update_display_frame:
-                                _append_response(delta)
-                            else:
-                                print(delta, end="", flush=True)
-                        elif t == "completion.done":
-                            waiting_for_response = False
-                            text = response.get("text", "")
-                            only_show_non_empty = True  # Only show non-empty responses (triggered)
-                            if text or not only_show_non_empty:
-                                if update_display_frame:
-                                    _append_response(f"\n\n[Response] {text}")
-                                    if response.get("usage"):
-                                        _append_response(f"\nUsage: {response['usage']}")
-                                else:
-                                    print(f"\n\n[Response] {text}")
-                                    if response.get("usage"):
-                                        print(f"Usage: {response['usage']}")
-                            received_done_count += 1
-                            buf = response.get("input_video_buffer")
-                            if buf is not None:
-                                queue_depth = buf.get("queue_depth", queue_depth)
-                                max_queue_size = buf.get("max_queue_size", max_queue_size)
-                        elif t == "input_video_buffer.water_level":
-                            queue_depth = response.get("queue_depth", queue_depth)
-                            max_queue_size = response.get("max_queue_size", max_queue_size)
-                        elif t == "session.stop":
-                            is_stopping = True
-                            is_capturing = False
-                            if update_display_frame:
-                                _append_response("\n[Session stopped by server]\n")
-                            else:
-                                print("\n[Session stopped by server]", flush=True)
-                            break
-                        elif t == "error":
-                            err = response.get("error", response.get("message", str(response)))
-                            err_str = f"\nError: {err}"
-                            if response.get("code"):
-                                err_str += f"\nCode: {response['code']}"
-                            if update_display_frame:
-                                _append_response(err_str)
-                            else:
-                                print(err_str, flush=True)
-                        else:
-                            print(f"[Received type={t!r}] {response}", flush=True)
+                        # Fixed interval timing control
+                        await asyncio.sleep(frame_interval_sec)
 
                     # If we exited loop normally (not due to error), send final commit to server
                     if is_stopping:
@@ -554,6 +530,7 @@ def websocket_handler(
     batch_size: int,
     queue_size: int,
     quality: int,
+    target_fps: float,
     trigger_queue: queue.Queue | None = None,
     output_resolution: str | None = None,
     max_size: int | None = None,
@@ -574,6 +551,7 @@ def websocket_handler(
                 batch_size,
                 queue_size,
                 quality,
+                target_fps=target_fps,
                 prompt_queue=_prompt_queue,
                 trigger_queue=trigger_queue,
                 update_display_frame=True,
@@ -633,6 +611,7 @@ def start_camera_service(
     batch_size: int,
     queue_size: int,
     quality: int,
+    target_fps: float,
     output_resolution: str | None = None,
     max_size: int = 0,
     keep_aspect_ratio: bool = False,
@@ -655,6 +634,7 @@ def start_camera_service(
             int(batch_size) if batch_size else 16,
             int(queue_size) if queue_size else 64,
             int(quality) if quality else 85,
+            float(target_fps) if target_fps else 5.0,
             _trigger_queue,
             output_resolution.strip() if output_resolution else None,
             max_size if max_size > 0 else None,
@@ -692,6 +672,7 @@ def create_gradio_demo(
     batch_size: int = 16,
     queue_size: int = 64,
     quality: int = 85,
+    target_fps: float = 5.0,
     output_resolution: str | None = None,
     max_size: int = 0,
     keep_aspect_ratio: bool = False,
@@ -778,6 +759,11 @@ def create_gradio_demo(
                     value=quality,
                     precision=0,
                 )
+                target_fps_in = gr.Number(
+                    label="Target FPS",
+                    value=target_fps,
+                    precision=1,
+                )
                 # Resolution settings
                 gr.Markdown("### Resolution Settings")
                 resolution_in = gr.Textbox(
@@ -836,6 +822,7 @@ def create_gradio_demo(
                 batch_size_in,
                 queue_size_in,
                 quality_in,
+                target_fps_in,
                 resolution_in,
                 max_size_in,
                 keep_aspect_in,
@@ -896,19 +883,13 @@ def main():
         "--batch-size",
         type=int,
         default=16,
-        help=(
-            "Frames per batch; one commit per batch. "
-            "Send rhythm is controlled by server water level (backpressure)."
-        ),
+        help="Frames per batch; one commit per batch. Default: 16.",
     )
     parser.add_argument(
         "--queue-size",
         type=int,
         default=64,
-        help=(
-            "Max frames in client queue. When full, oldest frames are "
-            "dropped to make room for newer ones. Default: 64."
-        ),
+        help="Max frames in client queue. When full, oldest frames are dropped to make room for newer ones. Default: 64.",
     )
     parser.add_argument(
         "--quality",
@@ -917,31 +898,27 @@ def main():
         help="JPEG encoding quality (1-100). Default: 85.",
     )
     parser.add_argument(
+        "--target-fps",
+        type=float,
+        default=5.0,
+        help="Target frames per second for sending batches. Default: 5.0.",
+    )
+    parser.add_argument(
         "--output-resolution",
         type=str,
         default=None,
-        help=(
-            "Output image resolution (exact size), format WIDTHxHEIGHT "
-            "(e.g., 640x480, 1280x720). May stretch image. Default: use "
-            "camera original resolution."
-        ),
+        help="Output image resolution (exact size), format WIDTHxHEIGHT (e.g., 640x480, 1280x720). May stretch image. Default: use camera original resolution.",
     )
     parser.add_argument(
         "--max-size",
         type=int,
         default=0,
-        help=(
-            "Maximum dimension for resize (0=disabled). Keeps aspect ratio. "
-            "Larger of width/height will be scaled to this value. Default: 0."
-        ),
+        help="Maximum dimension for resize (0=disabled). Keeps aspect ratio. Larger of width/height will be scaled to this value. Default: 0.",
     )
     parser.add_argument(
         "--keep-aspect-ratio",
         action="store_true",
-        help=(
-            "When using --output-resolution, fit image within target "
-            "resolution while maintaining aspect ratio."
-        ),
+        help="When using --output-resolution, fit image within target resolution while maintaining aspect ratio.",
     )
     parser.add_argument(
         "--gradio",
@@ -960,10 +937,7 @@ def main():
 
     if args.gradio:
         if gr is None:
-            raise RuntimeError(
-                "gradio is required for --gradio. "
-                "Install with: pip install gradio"
-            )
+            raise RuntimeError("gradio is required for --gradio. Install with: pip install gradio")
         global _prompt_queue
         _prompt_queue = queue.Queue()
         demo = create_gradio_demo(
@@ -976,6 +950,7 @@ def main():
             batch_size=args.batch_size,
             queue_size=args.queue_size,
             quality=args.quality,
+            target_fps=args.target_fps,
             output_resolution=args.output_resolution,
             max_size=args.max_size,
             keep_aspect_ratio=args.keep_aspect_ratio,
@@ -995,6 +970,7 @@ def main():
                 args.batch_size,
                 args.queue_size,
                 args.quality,
+                target_fps=args.target_fps,
                 output_resolution=args.output_resolution,
                 max_size=args.max_size if args.max_size > 0 else None,
                 keep_aspect_ratio=args.keep_aspect_ratio,

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -240,6 +240,13 @@ def build_app(
         )
 
         register_realtime_api_router(app)
+    
+    if "realtime_video" in supported_tasks:
+        from vllm.entrypoints.openai.video_realtime.api_router import (
+            attach_router as register_video_realtime_api_router,
+        )
+
+        register_video_realtime_api_router(app)
 
     if any(task in POOLING_TASKS for task in supported_tasks):
         from vllm.entrypoints.pooling import register_pooling_api_routers
@@ -283,7 +290,7 @@ def build_app(
     # Add scaling middleware to check for scaling state
     app.add_middleware(ScalingMiddleware)
 
-    if "realtime" in supported_tasks:
+    if "realtime" in supported_tasks or "realtime_video" in supported_tasks:
         # Add WebSocket metrics middleware
         from vllm.entrypoints.openai.realtime.metrics import (
             WebSocketMetricsMiddleware,
@@ -414,6 +421,14 @@ async def init_app_state(
         from vllm.entrypoints.openai.realtime.api_router import init_realtime_state
 
         init_realtime_state(engine_client, state, args, request_logger, supported_tasks)
+
+    if "realtime_video" in supported_tasks:
+        from vllm.entrypoints.openai.video_realtime.api_router import (
+            init_realtime_video_state,
+        )
+
+        init_realtime_video_state(engine_client, state, args, 
+                                  request_logger, supported_tasks)
 
     if any(task in POOLING_TASKS for task in supported_tasks):
         from vllm.entrypoints.pooling import init_pooling_state

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -273,6 +273,8 @@ class FrontendArgs(BaseFrontendArgs):
     h11_max_header_count: int = H11_MAX_HEADER_COUNT_DEFAULT
     """Maximum number of HTTP headers allowed in a request for h11 parser.
     Helps mitigate header abuse. Default: 256."""
+    ws_ping_interval: float | None = 60.0
+    ws_ping_timeout: float | None = 60.0
     enable_offline_docs: bool = False
     """
     Enable offline FastAPI documentation for air-gapped environments.

--- a/vllm/entrypoints/openai/video_realtime/__init__.py
+++ b/vllm/entrypoints/openai/video_realtime/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/vllm/entrypoints/openai/video_realtime/api_router.py
+++ b/vllm/entrypoints/openai/video_realtime/api_router.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""API router and state init for streaming video realtime (WebSocket)."""
+
+from typing import TYPE_CHECKING
+
+from fastapi import APIRouter, FastAPI, WebSocket
+
+from vllm.entrypoints.openai.video_realtime.connection import (
+    RealtimeVideoConnection,
+)
+from vllm.entrypoints.openai.video_realtime.serving import (
+    OpenAIServingRealtimeVideo,
+)
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+if TYPE_CHECKING:
+    from argparse import Namespace
+
+    from starlette.datastructures import State
+
+    from vllm.engine.protocol import EngineClient
+    from vllm.entrypoints.logger import RequestLogger
+    from vllm.tasks import SupportedTask
+else:
+    RequestLogger = object
+
+router = APIRouter()
+
+
+@router.websocket("/v1/realtime_video")
+async def realtime_video_endpoint(websocket: WebSocket):
+    """WebSocket endpoint for realtime video understanding.
+
+    Protocol:
+      1. Client connects to ws://host/v1/realtime_video
+      2. Server sends session.created (includes initial water level:
+         queue_depth, max_queue_size so client can throttle sends)
+      3. Client sends session.update with model (and optional prompt)
+      4. Client obtains water level (from session.created, completion.done, or
+         input_video_buffer.water_level); sends next batch only when
+         queue_depth < max_queue_size (backpressure)
+      5. Client sends one batch: input_video_buffer.append with base64-encoded
+         frames (e.g. JPEG), then input_video_buffer.commit to process buffer
+      6. Server sends completion.delta then completion.done (with updated
+         water level in input_video_buffer)
+      7. Repeat from step 4; use input_video_buffer.commit with final=True
+         when done
+
+    Text-only or text-then-video: send session.update with prompt, then
+    input_video_buffer.commit with no frames in buffer for text-only; or
+    append frames then commit for text + video. Empty commit = one text-only turn.
+    """
+    app = websocket.app
+    serving = getattr(app.state, "openai_serving_realtime_video", None)
+    if serving is None:
+        await websocket.accept()
+        await websocket.send_text(
+            '{"type":"error","error":"Realtime video not enabled","code":"not_available"}'
+        )
+        await websocket.close()
+        return
+    connection = RealtimeVideoConnection(websocket, serving)
+    await connection.handle_connection()
+
+
+def attach_router(app: FastAPI):
+    """Attach the realtime_video router to the FastAPI app."""
+    app.include_router(router)
+    logger.info("Realtime video API router attached")
+
+
+def init_realtime_video_state(
+    engine_client: "EngineClient",
+    state: "State",
+    args: "Namespace",
+    request_logger: RequestLogger | None,
+    supported_tasks: tuple["SupportedTask", ...],
+):
+    """Initialize openai_serving_realtime_video when generate task is supported."""
+    state.openai_serving_realtime_video = (
+        OpenAIServingRealtimeVideo(
+            engine_client,
+            state.openai_serving_models,
+            request_logger=request_logger,
+            log_error_stack=args.log_error_stack,
+        )
+        if "realtime_video" in supported_tasks
+        else None
+    )

--- a/vllm/entrypoints/openai/video_realtime/api_router.py
+++ b/vllm/entrypoints/openai/video_realtime/api_router.py
@@ -86,7 +86,6 @@ def init_realtime_video_state(
             engine_client,
             state.openai_serving_models,
             request_logger=request_logger,
-            log_error_stack=args.log_error_stack,
         )
         if "realtime_video" in supported_tasks
         else None

--- a/vllm/entrypoints/openai/video_realtime/connection.py
+++ b/vllm/entrypoints/openai/video_realtime/connection.py
@@ -1,0 +1,350 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""WebSocket connection handler for streaming video input."""
+
+import asyncio
+import base64
+import io
+import json
+from http import HTTPStatus
+from uuid import uuid4
+
+from fastapi import WebSocket
+from starlette.websockets import WebSocketDisconnect
+
+try:
+    from uvicorn.protocols.utils import ClientDisconnected
+except ImportError:
+
+    class ClientDisconnected(Exception):  # type: ignore[no-redef]
+        """Placeholder when uvicorn not available."""
+        pass
+
+import contextlib
+
+from vllm.entrypoints.openai.engine.protocol import ErrorResponse, UsageInfo
+from vllm.entrypoints.openai.video_realtime.protocol import (
+    CompletionDelta,
+    CompletionDone,
+    ErrorEvent,
+    GenerationTrigger,
+    InputVideoBufferAppend,
+    InputVideoBufferCommit,
+    SessionCreated,
+)
+from vllm.entrypoints.openai.video_realtime.serving import (
+    OpenAIServingRealtimeVideo,
+)
+from vllm.exceptions import VLLMValidationError
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+DEFAULT_VIDEO_PROMPT = ""
+
+DEFAULT_MAX_FRAMES_PER_COMMIT = 64
+
+DEFAULT_VIDEO_BATCH_QUEUE_MAXSIZE = 4
+
+
+
+def _decode_video_frame(payload_b64: str, fmt: str | None):
+    """Decode base64 to a single frame (PIL Image) for multi_modal_data."""
+    raw = base64.b64decode(payload_b64)
+    if not raw:
+        raise VLLMValidationError("Empty video frame data.")
+    try:
+        from PIL import Image
+    except ImportError as err:
+        raise VLLMValidationError(
+            "PIL is required for streaming video. Install with: pip install Pillow"
+        ) from err
+    stream = io.BytesIO(raw)
+    img = Image.open(stream).convert("RGB")
+    return img
+
+
+class RealtimeVideoConnection:
+    """Manages WebSocket lifecycle for realtime video understanding.
+
+    - Session: session.update (model, optional prompt)
+    - Append: input_video_buffer.append (base64 frame, one per message)
+    - Commit: input_video_buffer.commit (process buffer as one batch, optional final)
+      - With frames: process video + prompt. With no frames: text-only turn (prompt only).
+      - So "text-only" or "text first then streaming video" are supported.
+    - Trigger: generation.trigger (set prompt to use for next generation)
+    - Server sends: completion.delta, completion.done, error
+    """
+
+    def __init__(
+        self,
+        websocket: WebSocket,
+        serving: OpenAIServingRealtimeVideo,
+        *,
+        max_frames_per_commit: int = DEFAULT_MAX_FRAMES_PER_COMMIT,
+        video_batch_queue_maxsize: int = DEFAULT_VIDEO_BATCH_QUEUE_MAXSIZE,
+    ):
+        self.websocket = websocket
+        self.connection_id = f"ws-video-{uuid4()}"
+        self.serving = serving
+        self._frame_buffer: list = []
+        self._video_batch_queue: asyncio.Queue[list | None] = asyncio.Queue(
+            maxsize=video_batch_queue_maxsize + 1
+        )
+        self._frame_idx_queue: asyncio.Queue[list | None] = asyncio.Queue(
+            maxsize=video_batch_queue_maxsize + 1
+        )
+        self.last_frame_idx = 0
+        self._video_batch_queue_maxsize = video_batch_queue_maxsize
+        self.generation_task: asyncio.Task | None = None
+        self._is_connected = False
+        self._is_input_finished = False
+        self._is_model_validated = False
+        self._prompt_text = DEFAULT_VIDEO_PROMPT
+        self._max_frames_per_commit = max_frames_per_commit
+        self._prompt_consume_next = False
+        self._is_trigger_generating = False
+
+    async def handle_connection(self):
+        """Main connection loop."""
+        await self.websocket.accept()
+        logger.debug("WebSocket (video) connection accepted: %s", self.connection_id)
+        self._is_connected = True
+        await self._send(SessionCreated())
+
+        try:
+            while True:
+                message = await self.websocket.receive_text()
+                try:
+                    event = json.loads(message)
+                    await self._handle_event(event)
+                except json.JSONDecodeError:
+                    await self._send_error("Invalid JSON", "invalid_json")
+                except Exception as e:
+                    logger.exception("Error handling event: %s", e)
+                    await self._send_error(str(e), "processing_error")
+        except WebSocketDisconnect:
+            logger.debug("WebSocket disconnected: %s", self.connection_id)
+            self._is_connected = False
+        except Exception as e:
+            logger.exception("Unexpected error in connection: %s", e)
+        finally:
+            await self._cleanup()
+
+    def _check_model(self, model: str | None) -> ErrorResponse | None:
+        if self.serving._is_model_supported(model):
+            return None
+        return self.serving.create_error_response(
+            message=f"The model `{model}` does not exist.",
+            err_type="NotFoundError",
+            status_code=HTTPStatus.NOT_FOUND,
+            param="model",
+        )
+
+    async def _handle_event(self, event: dict):
+        """Route events to handlers."""
+        event_type = event.get("type")
+        if event_type == "session.update":
+            logger.debug("Session updated: %s", event)
+            self._check_model(event.get("model"))
+            self._is_model_validated = True
+            if "prompt" in event and event["prompt"]:
+                self._prompt_text = event["prompt"]
+        elif event_type == "input_video_buffer.append":
+            append_evt = InputVideoBufferAppend(**event)
+            try:
+                frame = _decode_video_frame(append_evt.video, append_evt.format)
+                self._frame_buffer.append(frame)
+                if len(self._frame_buffer) > self._max_frames_per_commit:
+                    raise VLLMValidationError(
+                        f"Too many frames in buffer, max {self._max_frames_per_commit}"
+                        "Send input_video_buffer.commit first."
+                    )
+            except Exception as e:
+                logger.error("Failed to decode video frame: %s", e)
+                await self._send_error("Invalid video data", "invalid_video")
+        elif event_type == "input_video_buffer.commit":
+            if not self._is_model_validated:
+                await self._send_error(
+                    "Model not validated. Send session.update with model first.",
+                    "model_not_validated",
+                )
+                return
+            commit_evt = InputVideoBufferCommit(**event)
+            # Enqueue one batch: current buffer as list of frames, 
+            # or empty list for text-only turn.
+            # Use await put() so we block when queue is full (backpressure to client).
+            if self._frame_buffer:
+                await self._video_batch_queue.put(list(self._frame_buffer))
+                frame_count = len(self._frame_buffer)
+                frame_indices = list(
+                    range(self.last_frame_idx, self.last_frame_idx + frame_count)
+                )
+                await self._frame_idx_queue.put(frame_indices)
+                self.last_frame_idx += len(self._frame_buffer)
+                self._frame_buffer = []
+            else:
+                await self._video_batch_queue.put([])
+                await self._frame_idx_queue.put([])
+            if commit_evt.final:
+                self._is_input_finished = True
+                await self._video_batch_queue.put(None)
+                await self._frame_idx_queue.put(None)
+            if self.generation_task is None or self.generation_task.done():
+                await self._start_generation()
+        elif event_type == "generation.trigger":
+            # Trigger event: set prompt and mark as trigger generation
+            trigger_evt = GenerationTrigger(**event)
+            if trigger_evt.prompt is not None:
+                self._prompt_text = trigger_evt.prompt
+                self._prompt_consume_next = True
+            logger.debug("Generation trigger set")
+
+        else:
+            await self._send_error(f"Unknown event type: {event_type}", "unknown_event")
+
+    async def _start_generation(self):
+        """Start the generation loop: one engine.generate() per batch for real-time low latency."""  # noqa: E501
+        if self.generation_task is not None and not self.generation_task.done():
+            logger.warning("Generation already in progress, ignoring commit")
+            return
+
+        self.generation_task = asyncio.create_task(self._run_generation_loop())
+
+    async def _run_generation_loop(self):
+        """One generate per batch: 
+        stream_video_realtime yields one StreamingInput per batch;
+        we run one engine.generate() per yield for real-time understanding."""
+
+        full_text = ""
+        total_prompt_tokens = 0
+        total_output_tokens = 0
+        total_tokens = 0
+        try:
+            from vllm.sampling_params import RequestOutputKind, SamplingParams
+            while True:
+                full_text = ""
+                total_prompt_tokens = 0
+                total_output_tokens = 0
+                total_tokens = 0
+                request_id = f"rt-video-{self.connection_id}-{uuid4()}"
+                stream_gen = self.serving.stream_video_realtime(
+                    self._video_batch_queue,
+                    self._frame_idx_queue,
+                    prompt_getter=lambda: self._get_prompt_with_consume(),
+                )
+
+                max_tokens = 512
+
+                sampling_params = SamplingParams.from_optional(
+                    temperature=0.0,
+                    max_tokens=max_tokens,
+                    output_kind=RequestOutputKind.DELTA,
+                    skip_clone=True,
+                )
+                result_gen = self.serving.engine_client.generate(
+                    prompt=stream_gen,
+                    sampling_params=sampling_params,
+                    request_id=request_id,
+                )
+                max_model_len = self.serving.engine_client.model_config.max_model_len
+                async for output in result_gen:
+                    if output.outputs and len(output.outputs) > 0:
+                        if output.prompt_token_ids:
+                            num_prompt_tokens = len(output.prompt_token_ids)
+                        else:
+                            num_prompt_tokens = 0
+                        total_prompt_tokens += num_prompt_tokens
+                        logger.info('input prompt token: %d', num_prompt_tokens) 
+                        delta = output.outputs[0].text
+                        full_text += delta
+                        await self._send(CompletionDelta(delta=delta))
+                        num_output_tokens = len(output.outputs[0].token_ids)
+                        logger.info('output tokens: %d', num_output_tokens)
+                        total_output_tokens += num_output_tokens
+                        total_tokens = total_prompt_tokens + total_output_tokens
+                        if total_tokens > max_model_len//2:
+                            logger.info('starting truncation from connection side')
+                            break  
+
+                    if not self._is_connected:
+                        break
+                if not self._is_connected:
+                    break
+            
+            usage = UsageInfo(
+                prompt_tokens=total_prompt_tokens,
+                completion_tokens=total_output_tokens,
+                total_tokens=total_tokens
+            )
+
+            await self._send(
+                CompletionDone(
+                    text=full_text,
+                    usage=usage
+                )
+            )
+
+        except asyncio.CancelledError:
+            self._is_trigger_generating = False
+            pass
+        except (WebSocketDisconnect, ClientDisconnected):
+            self._is_trigger_generating = False
+            logger.debug(
+                "Video generation stopped: client disconnected (%s)",
+                self.connection_id,
+            )
+        except Exception as e:
+            self._is_trigger_generating = False
+            logger.exception("Error in video generation: %s", e)
+            with contextlib.suppress(WebSocketDisconnect, ClientDisconnected):
+                await self._send_error(str(e), "processing_error")
+
+    def _get_prompt_with_consume(self) -> str:
+        if self._prompt_consume_next:
+            self._prompt_consume_next = False
+            prompt = self._prompt_text
+            self._prompt_text = ""
+            self._is_trigger_generating = True
+            return prompt
+        return ""
+
+    async def _send(self, event):
+        """Send event to client. Sets _is_connected=False on disconnect."""
+        try:
+            await self.websocket.send_text(event.model_dump_json())
+        except (WebSocketDisconnect, ClientDisconnected) as e:
+            self._is_connected = False
+            logger.debug(
+                "WebSocket closed while sending (connection_id=%s): %s",
+                self.connection_id,
+                e,
+            )
+            raise
+
+    async def _send_error(self, message: str, code: str | None = None):
+        """Send error event to client."""
+        await self.websocket.send_text(
+            ErrorEvent(error=message, code=code).model_dump_json()
+        )
+
+    async def _cleanup(self):
+        """Cleanup resources. Awaits generation_task after cancel so shutdown doesn't hang."""
+        if self.generation_task and not self.generation_task.done():
+            self.generation_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, asyncio.TimeoutError):
+                await asyncio.wait_for(self.generation_task, timeout=10.0)
+        # Drain queue so we have room for None; then signal consumer to exit.
+        while not self._video_batch_queue.empty():
+            try:
+                self._video_batch_queue.get_nowait()
+                self._frame_idx_queue.get_nowait()
+            except asyncio.QueueEmpty:
+                break
+        try:
+            self._video_batch_queue.put_nowait(None)
+            self._frame_idx_queue.put_nowait(None)
+        except asyncio.QueueFull:
+            pass
+        logger.debug("Connection cleanup complete: %s", self.connection_id)

--- a/vllm/entrypoints/openai/video_realtime/connection.py
+++ b/vllm/entrypoints/openai/video_realtime/connection.py
@@ -111,8 +111,9 @@ class RealtimeVideoConnection:
         await self.websocket.accept()
         logger.debug("WebSocket (video) connection accepted: %s", self.connection_id)
         self._is_connected = True
-        await self._send(SessionCreated())
-
+        await self._send(
+            SessionCreated()
+        )
         try:
             while True:
                 message = await self.websocket.receive_text()
@@ -172,16 +173,11 @@ class RealtimeVideoConnection:
                 )
                 return
             commit_evt = InputVideoBufferCommit(**event)
-            # Enqueue one batch: current buffer as list of frames, 
-            # or empty list for text-only turn.
-            # Use await put() so we block when queue is full (backpressure to client).
             if self._frame_buffer:
                 await self._video_batch_queue.put(list(self._frame_buffer))
-                frame_count = len(self._frame_buffer)
-                frame_indices = list(
-                    range(self.last_frame_idx, self.last_frame_idx + frame_count)
+                await self._frame_idx_queue.put(
+                    list(range(self.last_frame_idx,self.last_frame_idx+len(self._frame_buffer)))
                 )
-                await self._frame_idx_queue.put(frame_indices)
                 self.last_frame_idx += len(self._frame_buffer)
                 self._frame_buffer = []
             else:
@@ -213,21 +209,14 @@ class RealtimeVideoConnection:
         self.generation_task = asyncio.create_task(self._run_generation_loop())
 
     async def _run_generation_loop(self):
-        """One generate per batch: 
-        stream_video_realtime yields one StreamingInput per batch;
-        we run one engine.generate() per yield for real-time understanding."""
-
         full_text = ""
-        total_prompt_tokens = 0
-        total_output_tokens = 0
-        total_tokens = 0
+        prompt_token_ids_len = 0
+        completion_tokens_len = 0
         try:
             from vllm.sampling_params import RequestOutputKind, SamplingParams
+            # main loop
             while True:
-                full_text = ""
-                total_prompt_tokens = 0
-                total_output_tokens = 0
-                total_tokens = 0
+                completion_tokens_len = 0
                 request_id = f"rt-video-{self.connection_id}-{uuid4()}"
                 stream_gen = self.serving.stream_video_realtime(
                     self._video_batch_queue,
@@ -236,7 +225,7 @@ class RealtimeVideoConnection:
                 )
 
                 max_tokens = 512
-
+                
                 sampling_params = SamplingParams.from_optional(
                     temperature=0.0,
                     max_tokens=max_tokens,
@@ -248,25 +237,20 @@ class RealtimeVideoConnection:
                     sampling_params=sampling_params,
                     request_id=request_id,
                 )
-                max_model_len = self.serving.engine_client.model_config.max_model_len
+
                 async for output in result_gen:
                     if output.outputs and len(output.outputs) > 0:
                         if output.prompt_token_ids:
-                            num_prompt_tokens = len(output.prompt_token_ids)
-                        else:
-                            num_prompt_tokens = 0
-                        total_prompt_tokens += num_prompt_tokens
-                        logger.info('input prompt token: %d', num_prompt_tokens) 
+                            prompt_token_ids_len = len(output.prompt_token_ids)
                         delta = output.outputs[0].text
                         full_text += delta
                         await self._send(CompletionDelta(delta=delta))
-                        num_output_tokens = len(output.outputs[0].token_ids)
-                        logger.info('output tokens: %d', num_output_tokens)
-                        total_output_tokens += num_output_tokens
-                        total_tokens = total_prompt_tokens + total_output_tokens
-                        if total_tokens > max_model_len//2:
-                            logger.info('starting truncation from connection side')
-                            break  
+                        output_tokens_len = len(output.outputs[0].token_ids)
+                        completion_tokens_len += output_tokens_len
+                        total_tokens = prompt_token_ids_len+completion_tokens_len
+                        if total_tokens > self.serving.engine_client.model_config.max_model_len//2:
+                            print('starting truncation')
+                            break # this serves as the actual session change
 
                     if not self._is_connected:
                         break
@@ -274,8 +258,6 @@ class RealtimeVideoConnection:
                     break
             
             usage = UsageInfo(
-                prompt_tokens=total_prompt_tokens,
-                completion_tokens=total_output_tokens,
                 total_tokens=total_tokens
             )
 

--- a/vllm/entrypoints/openai/video_realtime/protocol.py
+++ b/vllm/entrypoints/openai/video_realtime/protocol.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import time
+from typing import Literal
+
+from pydantic import Field
+
+from vllm.entrypoints.openai.engine.protocol import (
+    OpenAIBaseModel,
+    UsageInfo,
+)
+from vllm.utils import random_uuid
+
+# Client -> Server Events
+
+class InputVideoBufferAppend(OpenAIBaseModel):
+    """Append one video frame to buffer (video is sent frame-by-frame)"""
+
+    type: Literal["input_video_buffer.append"] = "input_video_buffer.append"
+    video: str  # base64-encoded frame (e.g., JPEG/PNG)
+    format: str | None = None  # Optional format hint (e.g., "jpeg", "png")
+
+class InputVideoBufferCommit(OpenAIBaseModel):
+    """Process accumulated video buffer"""
+
+    type: Literal["input_video_buffer.commit"] = "input_video_buffer.commit"
+    final: bool = False
+
+class GenerationTrigger(OpenAIBaseModel):
+    """Trigger generation based with custom prompt"""
+
+    type: Literal["generation.trigger"] = "generation.trigger"
+    prompt: str | None = None  # Custom prompt to trigger generation
+
+class InputVideoBufferWaterlevel(OpenAIBaseModel):
+    """Server buffer water level so client can wait for capacity before sending."""
+
+    queue_depth: int = 0
+    """Number of batches in the server queue. 
+    Client should send when queue_depth < max_queue_size."""
+    max_queue_size: int = 1
+
+    buffer_frames: int = 0
+
+class SessionUpdate(OpenAIBaseModel):
+    """Configure session parameters"""
+
+    type: Literal["session.update"] = "session.update"
+    model: str | None = None
+
+
+class SessionCreated(OpenAIBaseModel):
+    """Connection established notification"""
+
+    type: Literal["session.created"] = "session.created"
+    id: str = Field(default_factory=lambda: f"sess-{random_uuid()}")
+    created: int = Field(default_factory=lambda: int(time.time()))
+    input_video_buffer: InputVideoBufferWaterlevel | None = None
+
+
+class CompletionDelta(OpenAIBaseModel):
+    """Incremental completion text"""
+
+    type: Literal["completion.delta"] = "completion.delta"
+    delta: str
+
+
+class CompletionDone(OpenAIBaseModel):
+    """Final completion with usage stats"""
+
+    type: Literal["completion.done"] = "completion.done"
+    text: str  # Complete completion
+    usage: UsageInfo | None = None
+
+
+class ErrorEvent(OpenAIBaseModel):
+    """Error notification"""
+
+    type: Literal["error"] = "error"
+    error: str
+    code: str | None = None

--- a/vllm/entrypoints/openai/video_realtime/serving.py
+++ b/vllm/entrypoints/openai/video_realtime/serving.py
@@ -8,11 +8,11 @@ from collections.abc import AsyncGenerator, Callable
 
 import numpy as np
 
-from vllm.engine.protocol import EngineClient
+from vllm.engine.protocol import EngineClient, StreamingInput
 from vllm.entrypoints.logger import RequestLogger
 from vllm.entrypoints.openai.engine.serving import OpenAIServing
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
-from vllm.inputs.data import StreamingInput, TextPrompt
+from vllm.inputs import TextPrompt
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
@@ -51,13 +51,11 @@ class OpenAIServingRealtimeVideo(OpenAIServing):
         models: OpenAIServingModels,
         *,
         request_logger: RequestLogger | None,
-        log_error_stack: bool = False,
     ):
         super().__init__(
             engine_client=engine_client,
             models=models,
             request_logger=request_logger,
-            log_error_stack=log_error_stack,
         )
         self.task_type = "realtime_video"
         logger.info(

--- a/vllm/entrypoints/openai/video_realtime/serving.py
+++ b/vllm/entrypoints/openai/video_realtime/serving.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+"""Serving layer for streaming video input via WebSocket."""
+
 import asyncio
 from collections.abc import AsyncGenerator, Callable
 
@@ -15,21 +17,31 @@ from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
+# Default text prompt when client does not send one (video-only input).
+# we utilize it as the default summarize text
+DEFAULT_VIDEO_PROMPT = ""
 
+# Qwen2-VL/Qwen3-VL require at least 2 frames; different models have different frame
+# requirements. Pad by repeating frames when insufficient, to satisfy model constraints.
 MIN_VIDEO_FRAMES = 2
 
-VIDEO_PLACEHOLDER = "<|vision_start|><|video_pad|><vision_end|>"
+# Video placeholder required by the model so prompt replacement can inject video.
+# Used by Qwen2-VL/Qwen3-VL; other models may use different placeholders (set
+# prompt via session.update including the correct placeholder if needed).
+VIDEO_PLACEHOLDER = "<|vision_start|><|video_pad|><|vision_end|>"
 
+# Qwen-style chat wrapper so the model generates a full assistant reply instead of
+# stopping after one token (EOS). Without this, raw prompt has no "assistant" turn
+# and the model may emit EOS immediately.
 QWEN_CHAT_USER_PREFIX = "<|im_start|>user\n"
 QWEN_CHAT_USER_SUFFIX = "<|im_end|>\n"
 QWEN_CHAT_ASSISTANT_PREFIX = "<|im_start|>assistant\n"
 
 
-
 class OpenAIServingRealtimeVideo(OpenAIServing):
-    """Realtime video service via WebSocket streaming.
+    """Realtime video understanding via WebSocket streaming.
 
-    Provides streaming video frames into StreamingInput objects with
+    Transforms streamed video frames into StreamingInput objects with
     multi_modal_data for engine.generate().
     """
 
@@ -47,33 +59,34 @@ class OpenAIServingRealtimeVideo(OpenAIServing):
             request_logger=request_logger,
             log_error_stack=log_error_stack,
         )
-
         self.task_type = "realtime_video"
-    
-        logger.info("OpenAIServingRealtimeVideo initialized for task: %s", self.task_type)
-
-
+        logger.info(
+            "OpenAIServingRealtimeVideo initialized for task: %s", self.task_type
+        )
 
     async def stream_video_realtime(
-            self,
-            video_batch_queue: asyncio.Queue[list | None],
-            _frame_idx_queue: asyncio.Queue[list | None],
-            prompt_getter: Callable[[], str] | None = None,
+        self,
+        video_batch_queue: asyncio.Queue[list | None],
+        frame_idx_queue: asyncio.Queue[list | None],
+        prompt_text: str = DEFAULT_VIDEO_PROMPT,
+        prompt_getter: Callable[[], str] | None = None,
     ) -> AsyncGenerator[StreamingInput, None]:
-        
+        """Turn queued video batches into StreamingInput for engine.generate().
+        """
+        # Use a mutable object (list) to track first batch state
+
         def _get_prompt() -> str:
-            return prompt_getter() if prompt_getter else ""
+            user_prompt = prompt_getter() if prompt_getter else prompt_text
+            return user_prompt if prompt_getter else ""
 
         while True:
             batch = await video_batch_queue.get()
+            frame_idx = await frame_idx_queue.get()
             if batch is None:
-                # Signal for end of stream
                 break
-            frame_idx = await _frame_idx_queue.get()
             current_prompt = _get_prompt()
             if not batch:
-                yield StreamingInput(
-                    prompt=TextPrompt(prompt=current_prompt))
+                yield StreamingInput(prompt=TextPrompt(prompt=current_prompt))
                 continue
             num_frames = len(batch)
             frames_array = np.stack([np.array(img) for img in batch])
@@ -83,12 +96,12 @@ class OpenAIServingRealtimeVideo(OpenAIServing):
                 num_frames = MIN_VIDEO_FRAMES
             height, width = frames_array.shape[1], frames_array.shape[2]
             fps = 1.0
-            meta_data = {
+            metadata = {
                 "total_num_frames": num_frames,
-                "fps": fps,
+                "fps": fps, # this also needs to be sent in
                 "duration": num_frames / fps,
-                "video_backend": "realtime_video",
-                "frame_indices": frame_idx, 
+                "video_backend": "realtime_stream",
+                "frames_indices": frame_idx,
                 "do_sample_frames": True,
                 "width": width,
                 "height": height,
@@ -98,12 +111,13 @@ class OpenAIServingRealtimeVideo(OpenAIServing):
             else:
                 user_content = current_prompt
             effective_prompt = (
-                QWEN_CHAT_USER_PREFIX + user_content + QWEN_CHAT_USER_SUFFIX +
-                QWEN_CHAT_ASSISTANT_PREFIX
+                QWEN_CHAT_USER_PREFIX
+                + user_content
+                + QWEN_CHAT_USER_SUFFIX
+                + QWEN_CHAT_ASSISTANT_PREFIX
             )
             has_text = current_prompt != ""
             prompt = TextPrompt(prompt=effective_prompt, 
-                                multi_modal_data={"video": (frames_array, meta_data)},
+                                multi_modal_data={"video": (frames_array, metadata)},
                                 has_text=has_text)
             yield StreamingInput(prompt=prompt)
-            

--- a/vllm/entrypoints/openai/video_realtime/serving.py
+++ b/vllm/entrypoints/openai/video_realtime/serving.py
@@ -73,7 +73,6 @@ class OpenAIServingRealtimeVideo(OpenAIServing):
     ) -> AsyncGenerator[StreamingInput, None]:
         """Turn queued video batches into StreamingInput for engine.generate().
         """
-        # Use a mutable object (list) to track first batch state
 
         def _get_prompt() -> str:
             user_prompt = prompt_getter() if prompt_getter else prompt_text

--- a/vllm/entrypoints/openai/video_realtime/serving.py
+++ b/vllm/entrypoints/openai/video_realtime/serving.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import asyncio
+from collections.abc import AsyncGenerator, Callable
+
+import numpy as np
+
+from vllm.engine.protocol import EngineClient
+from vllm.entrypoints.logger import RequestLogger
+from vllm.entrypoints.openai.engine.serving import OpenAIServing
+from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.inputs.data import StreamingInput, TextPrompt
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+MIN_VIDEO_FRAMES = 2
+
+VIDEO_PLACEHOLDER = "<|vision_start|><|video_pad|><vision_end|>"
+
+QWEN_CHAT_USER_PREFIX = "<|im_start|>user\n"
+QWEN_CHAT_USER_SUFFIX = "<|im_end|>\n"
+QWEN_CHAT_ASSISTANT_PREFIX = "<|im_start|>assistant\n"
+
+
+
+class OpenAIServingRealtimeVideo(OpenAIServing):
+    """Realtime video service via WebSocket streaming.
+
+    Provides streaming video frames into StreamingInput objects with
+    multi_modal_data for engine.generate().
+    """
+
+    def __init__(
+        self,
+        engine_client: EngineClient,
+        models: OpenAIServingModels,
+        *,
+        request_logger: RequestLogger | None,
+        log_error_stack: bool = False,
+    ):
+        super().__init__(
+            engine_client=engine_client,
+            models=models,
+            request_logger=request_logger,
+            log_error_stack=log_error_stack,
+        )
+
+        self.task_type = "realtime_video"
+    
+        logger.info("OpenAIServingRealtimeVideo initialized for task: %s", self.task_type)
+
+
+
+    async def stream_video_realtime(
+            self,
+            video_batch_queue: asyncio.Queue[list | None],
+            _frame_idx_queue: asyncio.Queue[list | None],
+            prompt_getter: Callable[[], str] | None = None,
+    ) -> AsyncGenerator[StreamingInput, None]:
+        
+        def _get_prompt() -> str:
+            return prompt_getter() if prompt_getter else ""
+
+        while True:
+            batch = await video_batch_queue.get()
+            if batch is None:
+                # Signal for end of stream
+                break
+            frame_idx = await _frame_idx_queue.get()
+            current_prompt = _get_prompt()
+            if not batch:
+                yield StreamingInput(
+                    prompt=TextPrompt(prompt=current_prompt))
+                continue
+            num_frames = len(batch)
+            frames_array = np.stack([np.array(img) for img in batch])
+            if num_frames < MIN_VIDEO_FRAMES:
+                repeat = (MIN_VIDEO_FRAMES + num_frames - 1) // num_frames
+                frames_array = np.tile(frames_array, (repeat, 1, 1, 1))[:MIN_VIDEO_FRAMES]
+                num_frames = MIN_VIDEO_FRAMES
+            height, width = frames_array.shape[1], frames_array.shape[2]
+            fps = 1.0
+            meta_data = {
+                "total_num_frames": num_frames,
+                "fps": fps,
+                "duration": num_frames / fps,
+                "video_backend": "realtime_video",
+                "frame_indices": frame_idx, 
+                "do_sample_frames": True,
+                "width": width,
+                "height": height,
+            }
+            if VIDEO_PLACEHOLDER not in current_prompt:
+                user_content = current_prompt + " " + VIDEO_PLACEHOLDER
+            else:
+                user_content = current_prompt
+            effective_prompt = (
+                QWEN_CHAT_USER_PREFIX + user_content + QWEN_CHAT_USER_SUFFIX +
+                QWEN_CHAT_ASSISTANT_PREFIX
+            )
+            has_text = current_prompt != ""
+            prompt = TextPrompt(prompt=effective_prompt, 
+                                multi_modal_data={"video": (frames_array, meta_data)},
+                                has_text=has_text)
+            yield StreamingInput(prompt=prompt)
+            

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -1068,6 +1068,10 @@ def supports_realtime(
 ) -> TypeIs[type[SupportsRealtime]] | TypeIs[SupportsRealtime]:
     return getattr(model, "supports_realtime", False)
 
+def supports_realtime_video(
+    model: type[object] | object,
+) -> bool:
+    return getattr(model, "supports_realtime_video", False)
 
 @runtime_checkable
 class SupportsTranscription(Protocol):

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1588,6 +1588,7 @@ class Qwen3VLForConditionalGeneration(
     SupportsEagle3,
     SupportsMultiModalPruning,
 ):
+    supports_realtime_video = True
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",

--- a/vllm/v1/core/sched/async_scheduler.py
+++ b/vllm/v1/core/sched/async_scheduler.py
@@ -49,9 +49,18 @@ class AsyncScheduler(Scheduler):
         )
 
         # Update the number of output placeholders.
-        request.num_output_placeholders -= len(new_token_ids)
-        assert request.num_output_placeholders >= 0
-
+        # request.num_output_placeholders -= len(new_token_ids)
+        # assert request.num_output_placeholders >= 0
+        excess = request.num_output_placeholders - len(new_token_ids)
+        if excess < 0:
+            logger.warning(
+                "num_output_placeholders underflow for request %s "
+                "(placeholder=%d, new_tokens=%d). Clamping to 0.",
+                request.request_id,
+                request.num_output_placeholders,
+                len(new_token_ids),
+            )
+        request.num_output_placeholders = max(0, excess)
         # Cache the new tokens. Preempted requests should be skipped.
         if status_before_update == RequestStatus.RUNNING:
             self.kv_cache_manager.cache_blocks(

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1036,6 +1036,7 @@ class Scheduler(SchedulerInterface):
         session.update_block_hashes()
         session.num_prompt_tokens = len(session.prompt_token_ids)
         session.arrival_time = update.arrival_time
+        session.max_tokens = update.max_tokens
         session.sampling_params = update.sampling_params
         if session.status == RequestStatus.WAITING_FOR_STREAMING_REQ:
             self.num_waiting_for_streaming_input -= 1

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -463,8 +463,8 @@ class AsyncLLM(EngineClient):
                         self._validate_streaming_input_sampling_params(sp)
                     else:
                         sp = sampling_params
-                    sp_temp = deepcopy(sp)
-                    if input_chunk.prompt['has_text']:
+                    sp_temp = sp.clone()
+                    if input_chunk.prompt.get("has_text", True):
                         sp_temp.max_tokens = sp.max_tokens
                     else:
                         sp_temp.max_tokens = 1

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -6,7 +6,7 @@ import socket
 import time
 import warnings
 from collections.abc import AsyncGenerator, Iterable, Mapping
-from copy import copy
+from copy import copy, deepcopy
 from typing import Any
 
 import torch
@@ -463,6 +463,11 @@ class AsyncLLM(EngineClient):
                         self._validate_streaming_input_sampling_params(sp)
                     else:
                         sp = sampling_params
+                    sp_temp = deepcopy(sp)
+                    if input_chunk.prompt['has_text']:
+                        sp_temp.max_tokens = sp.max_tokens
+                    else:
+                        sp_temp.max_tokens = 1
                     # TODO(nick): Avoid re-validating reused sampling parameters
                     req = self.input_processor.process_inputs(
                         request_id=internal_req_id,

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -464,9 +464,9 @@ class AsyncLLM(EngineClient):
                     else:
                         sp = sampling_params
                     sp_temp = sp.clone()
-                    if input_chunk.prompt.get("has_text", True):
+                    if input_chunk.prompt.get("has_text") is True:
                         sp_temp.max_tokens = sp.max_tokens
-                    else:
+                    elif input_chunk.prompt.get("has_text") is False:
                         sp_temp.max_tokens = 1
                     # TODO(nick): Avoid re-validating reused sampling parameters
                     req = self.input_processor.process_inputs(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -75,6 +75,7 @@ from vllm.model_executor.models.interfaces import (
     supports_mrope,
     supports_multimodal_pruning,
     supports_realtime,
+    supports_realtime_video,
     supports_transcription,
     supports_xdrope,
 )
@@ -3034,6 +3035,9 @@ class GPUModelRunner(
 
         if supports_realtime(model):
             supported_tasks.append("realtime")
+
+        if supports_realtime_video(model):
+            supported_tasks.append("realtime_video")
 
         return supported_tasks
 


### PR DESCRIPTION
Implements Phase 1 of [RFC: Streaming Video Input for Real-Time Video Understanding #38141](https://github.com/vllm-project/vllm/issues/38141).

Fix the issue where AsyncScheduler crashes due to an AssertionError caused by num_output_placeholders underflow during real-time streaming, following the modification approach in [#35755](https://github.com/vllm-project/vllm/issues/35755).

### Summary

This PR extends vLLM's realtime streaming infrastructure to accept **live video frames** as input, enabling a camera-first interaction model: the model continuously ingests video in the background, accumulates scene understanding, and only generates a response when the user asks a question.

The design reuses vLLM's existing `StreamingInput` pipeline (chunked prefill, encoder caching, prefix caching, resumable requests) and adds video-specific orchestration for **trigger-based Q&A** and **unbounded streaming sessions**.

Although this PR uses Qwen3-VL as the reference implementation, the feature has no model-specific dependencies beyond standard vision-language capabilities. Enabling realtime video for other VLMs only requires adding `supports_realtime_video = True` to the corresponding model class.

### Highlights

**Trigger-based Q&A** — The core interaction model. Video frames flow in continuously via `input_video_buffer.append/commit`, but the model runs silently (minimal token output, only extending the KV cache). When the user sends a `generation.trigger` event with a question, the system flags the next chunk to carry a prompt, and the engine switches from encode-only mode to full text generation.

**Unbounded streaming sessions** — A single WebSocket connection can run indefinitely. The connection handler splits the video stream into a sequence of `engine.generate()` calls, each handling one batch. When the cumulative token count approaches the model's context limit (`max_model_len // 2`), the session resets by breaking out of the inner generation loop and starting a new `engine.generate()` call with fresh token accounting. This lays the groundwork for future historical context management features.

**Robust long-running sessions** — The `num_output_placeholders` underflow bug (#35755) that previously crashed the entire `EngineCore` process during streaming is fixed by replacing the hard `assert` with a clamped value and warning. This is critical for video streaming: the interaction between prefill-chunk transitions and encoder completion timing makes the underflow inevitable in long sessions.

### Architecture

```
Camera / Video Stream
    │  (base64 JPEG frames via WebSocket)
    ▼
RealtimeVideoConnection
    │  append/commit → frame buffer → asyncio.Queue (backpressure)
    │  generation.trigger → inject prompt into next chunk
    ▼
OpenAIServingRealtimeVideo
    │  stream_video_realtime() → AsyncGenerator[StreamingInput]
    │  frames → PIL → numpy → TextPrompt + multi_modal_data
    │  has_text flag → controls per-chunk generation mode
    ▼
AsyncLLM (engine)
    │  deepcopy(sp): video-only → max_tokens=1, with-prompt → full max_tokens
    │  StreamingUpdate → scheduler session continuation
    │  token counting → session reset at context boundary → unbounded streaming
    ▼
Scheduler
    │  session.max_tokens from StreamingUpdate
    │  num_output_placeholders clamped (no crash)
    ▼
Qwen3-VL  →  completion.delta / completion.done  →  WebSocket  →  Client
```

### Files Changed

| File | What it enables |
|---|---|
| `vllm/entrypoints/openai/video_realtime/` (new) | WebSocket endpoint, protocol, connection lifecycle, video-to-prompt pipeline |
| `vllm/v1/engine/async_llm.py` | Per-chunk `has_text` → trigger-based Q&A and efficient video-only processing |
| `vllm/v1/core/sched/scheduler.py` | `session.max_tokens = update.max_tokens` → dynamic generation length per streaming chunk |
| `vllm/v1/core/sched/async_scheduler.py` | Clamp `num_output_placeholders` → no crash during long streaming sessions (fixes #35755) |
| `vllm/model_executor/models/interfaces.py` | `supports_realtime_video()` → opt-in interface for future models |
| `vllm/model_executor/models/qwen3_vl.py` | `supports_realtime_video = True` → first model to opt in |
| `vllm/entrypoints/openai/api_server.py` | Wire up `/v1/realtime_video` router and state |
| `vllm/entrypoints/openai/cli_args.py` | WebSocket keepalive args |
| `examples/online_serving/realtime_camera_client.py` | Demo client: live camera + Gradio UI + trigger Q&A |

### Quick Start

```bash
# Start server
vllm serve Qwen3-VL-7B-Instruct --enforce-eager

# Gradio UI (camera + trigger-based Q&A)
python examples/online_serving/realtime_camera_client.py --gradio --host x.x.x.x
```

### Test Plan

- [ ] End-to-end: webcam → WebSocket → Qwen3-VL → text response
- [ ] Trigger-based Q&A: stream frames silently, then trigger a question and verify response
- [ ] Long-running session: verify session resets cleanly at context boundary without crash
