### PR TITLE
Defensively use torch.zeros for batched MoE to avoid NaNs in case an expert isn't assigned any tokens

### DIFF
--- a/tests/kernels/moe/test_batched_moe_scale_init.py
+++ b/tests/kernels/moe/test_batched_moe_scale_init.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Regression test for uninitialized expert activation scales in batched MoE.
+
+In vllm/model_executor/layers/fused_moe/fused_batched_moe.py, the
+BatchedPrepareAndFinalize.prepare() method allocates expert activation
+scale tensors.  When an expert receives 0 tokens (common in DP+EP),
+its scale rows must be safely initialized (zeros), not garbage/NaN.
+
+The bug: torch.empty() was used, leaving NaN in 0-token expert scales.
+The fix: torch.zeros() ensures safe initialization.
+
+These tests call the actual BatchedPrepareAndFinalize.prepare() method
+with inputs crafted so some experts receive 0 tokens, then check the
+returned scale tensor for NaN.
+"""
+
+import torch
+
+from vllm.platforms import current_platform
+
+DEVICE = torch.device(current_platform.device_type)
+
+
+class TestBatchedMoEScaleInit:
+    """Regression test for uninitialized expert activation scales.
+
+    When an expert receives 0 tokens, its scale tensor must be zero-filled,
+    not NaN from torch.empty().  NaN scales propagate through downstream
+    GEMM operations and corrupt model outputs.
+    """
+
+    @staticmethod
+    def _nan_empty(*args, **kwargs):
+        """Drop-in replacement for torch.empty that fills with NaN.
+        This simulates the worst case of recycled GPU memory containing
+        NaN values, making the test deterministic."""
+        t = torch._nan_empty_original(*args, **kwargs)
+        if t.is_floating_point():
+            t.fill_(float('nan'))
+        return t
+
+    def test_prepare_zero_token_experts_no_nan(self):
+        """Call BatchedPrepareAndFinalize.prepare() with topk_ids that
+        route NO tokens to some experts.  The returned b_a1_scale must
+        not contain NaN for those experts.
+
+        Fails without fix: torch.empty() leaves NaN/garbage in scale
+        rows for experts that receive 0 tokens."""
+        from unittest.mock import patch
+
+        from vllm.model_executor.layers.fused_moe.config import (
+            FusedMoEQuantConfig,
+        )
+        from vllm.model_executor.layers.fused_moe.fused_batched_moe import (
+            BatchedPrepareAndFinalize,
+        )
+
+        num_local_experts = 8
+        num_tokens = 16
+        hidden_dim = 128
+        topk = 2
+        max_num_tokens = 64
+
+        prep = BatchedPrepareAndFinalize(
+            max_num_tokens=max_num_tokens,
+            num_local_experts=num_local_experts,
+            num_dispatchers=1,
+            rank=0,
+        )
+
+        # Create inputs that route tokens to only experts 0 and 1
+        # Experts 2-7 get 0 tokens
+        a1 = torch.randn(
+            num_tokens, hidden_dim, dtype=torch.float16, device=DEVICE,
+        )
+        topk_weights = torch.ones(
+            num_tokens, topk, dtype=torch.float16, device=DEVICE,
+        )
+        # All tokens go to experts 0 and 1 only
+        topk_ids = torch.zeros(
+            num_tokens, topk, dtype=torch.int64, device=DEVICE,
+        )
+        topk_ids[:, 0] = 0  # first choice: expert 0
+        topk_ids[:, 1] = 1  # second choice: expert 1
+
+        quant_config = FusedMoEQuantConfig.make(
+            quant_dtype=torch.float8_e4m3fn,
+            per_act_token_quant=True,
+        )
+
+        # Patch torch.empty to deterministically return NaN-filled tensors.
+        # This simulates the worst case for recycled GPU memory.
+        torch._nan_empty_original = torch.empty
+        try:
+            with patch.object(torch, 'empty', self._nan_empty):
+                b_a1, b_a1_scale, expert_tokens_meta, _, _ = prep.prepare(
+                    a1=a1,
+                    topk_weights=topk_weights,
+                    topk_ids=topk_ids,
+                    num_experts=num_local_experts,
+                    expert_map=None,
+                    apply_router_weight_on_input=False,
+                    quant_config=quant_config,
+                )
+        finally:
+            del torch._nan_empty_original
+
+        torch.cuda.synchronize()
+
+        assert b_a1_scale is not None, (
+            "Scale tensor should exist for quantized config"
+        )
+
+        # Check experts that received 0 tokens (experts 2-7)
+        for expert_id in range(2, num_local_experts):
+            expert_scale = b_a1_scale[expert_id].cpu()
+            has_nan = torch.isnan(expert_scale).any().item()
+            assert not has_nan, (
+                f"Expert {expert_id} received 0 tokens but has NaN in "
+                f"scale tensor. This will corrupt MoE output when the "
+                f"scale is used in downstream GEMM operations."
+            )
+
+    def test_prepare_block_quant_zero_token_experts(self):
+        """Same test but with block quantization (block_shape=[128, 128])
+        instead of per-token quantization."""
+        from unittest.mock import patch
+
+        from vllm.model_executor.layers.fused_moe.config import (
+            FusedMoEQuantConfig,
+        )
+        from vllm.model_executor.layers.fused_moe.fused_batched_moe import (
+            BatchedPrepareAndFinalize,
+        )
+
+        num_local_experts = 4
+        num_tokens = 8
+        hidden_dim = 256
+        topk = 1
+        max_num_tokens = 32
+
+        prep = BatchedPrepareAndFinalize(
+            max_num_tokens=max_num_tokens,
+            num_local_experts=num_local_experts,
+            num_dispatchers=1,
+            rank=0,
+        )
+
+        a1 = torch.randn(
+            num_tokens, hidden_dim, dtype=torch.float16, device=DEVICE,
+        )
+        topk_weights = torch.ones(
+            num_tokens, topk, dtype=torch.float16, device=DEVICE,
+        )
+        # All tokens go to expert 0 only; experts 1-3 get nothing
+        topk_ids = torch.zeros(
+            num_tokens, topk, dtype=torch.int64, device=DEVICE,
+        )
+
+        quant_config = FusedMoEQuantConfig.make(
+            quant_dtype=torch.float8_e4m3fn,
+            block_shape=[128, 128],
+        )
+
+        # Patch torch.empty to deterministically return NaN
+        torch._nan_empty_original = torch.empty
+        try:
+            with patch.object(torch, 'empty', self._nan_empty):
+                b_a1, b_a1_scale, expert_tokens_meta, _, _ = prep.prepare(
+                    a1=a1,
+                    topk_weights=topk_weights,
+                    topk_ids=topk_ids,
+                    num_experts=num_local_experts,
+                    expert_map=None,
+                    apply_router_weight_on_input=False,
+                    quant_config=quant_config,
+                )
+        finally:
+            del torch._nan_empty_original
+
+        torch.cuda.synchronize()
+
+        assert b_a1_scale is not None
+        for expert_id in range(1, num_local_experts):
+            expert_scale = b_a1_scale[expert_id].cpu()
+            has_nan = torch.isnan(expert_scale).any().item()
+            assert not has_nan, (
+                f"Expert {expert_id} (0 tokens, block quant) has NaN "
+                f"in scale tensor."
+            )
+
+    def test_expert_scale_nan_propagation(self):
+        """Demonstrate that NaN in scale tensors propagates through
+        matrix multiplication — the mechanism by which uninitialized
+        scales corrupt model outputs and eventually the KV cache."""
+        num_experts = 4
+        max_tokens = 32
+        hidden_dim = 64
+
+        activations = torch.randn(
+            num_experts, max_tokens, hidden_dim,
+            dtype=torch.float32, device=DEVICE,
+        )
+        weights = torch.randn(
+            num_experts, hidden_dim, hidden_dim,
+            dtype=torch.float32, device=DEVICE,
+        )
+
+        # Buggy: scales contain NaN for expert 2 (0 tokens)
+        scales_buggy = torch.ones(
+            num_experts, max_tokens, 1,
+            dtype=torch.float32, device=DEVICE,
+        )
+        scales_buggy[2] = float('nan')
+
+        # Fixed: scales are zero for expert 2
+        scales_fixed = torch.ones(
+            num_experts, max_tokens, 1,
+            dtype=torch.float32, device=DEVICE,
+        )
+        scales_fixed[2] = 0.0
+
+        output_buggy = torch.bmm(activations * scales_buggy, weights)
+        output_fixed = torch.bmm(activations * scales_fixed, weights)
+
+        torch.cuda.synchronize()
+
+        assert torch.isnan(output_buggy[2]).all(), (
+            "NaN scale propagates to ALL output values for that expert"
+        )
+        assert not torch.isnan(output_fixed).any(), (
+            "Zero scale prevents NaN propagation"
+        )

--- a/tests/kernels/moe/test_batched_moe_scale_init.py
+++ b/tests/kernels/moe/test_batched_moe_scale_init.py
@@ -5,58 +5,88 @@ Regression test for uninitialized expert activation scales in batched MoE.
 
 In vllm/model_executor/layers/fused_moe/fused_batched_moe.py, the
 BatchedPrepareAndFinalize.prepare() method allocates expert activation
-scale tensors.  When an expert receives 0 tokens (common in DP+EP),
-its scale rows must be safely initialized (zeros), not garbage/NaN.
+scale tensors.  When an expert receives 0 tokens, its scale rows must
+be safely initialized (zeros), not garbage/NaN.
 
 The bug: torch.empty() was used, leaving NaN in 0-token expert scales.
 The fix: torch.zeros() ensures safe initialization.
 
-These tests call the actual BatchedPrepareAndFinalize.prepare() method
-with inputs crafted so some experts receive 0 tokens, then check the
-returned scale tensor for NaN.
+These tests verify:
+1. The prepare() method doesn't leave NaN in scale tensors (unit test)
+2. End-to-end MoE kernels (Triton, DeepGEMM, NVFP4) produce NaN-free
+   output when some experts receive 0 tokens
 """
 
+from unittest.mock import patch
+
+import pytest
 import torch
 
+from tests.kernels.moe.utils import make_dummy_moe_config, make_test_weights
+from vllm.config import ParallelConfig, VllmConfig, set_current_vllm_config  # noqa: E501
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEQuantConfig,
+    fp8_w8a8_moe_quant_config,
+    nvfp4_moe_quant_config,
+)
+from vllm.model_executor.layers.fused_moe.fused_batched_moe import (
+    BatchedPrepareAndFinalize,
+    BatchedTritonExperts,
+)
+from vllm.model_executor.layers.fused_moe.modular_kernel import (
+    FusedMoEKernel,
+    MoEActivation,
+)
 from vllm.platforms import current_platform
 
 DEVICE = torch.device(current_platform.device_type)
 
+BLOCK_SHAPE = [128, 128]
+
+
+def _nan_empty(*args, **kwargs):
+    """Drop-in replacement for torch.empty that fills with NaN.
+    Simulates worst-case recycled GPU memory."""
+    t = torch._nan_empty_original(*args, **kwargs)
+    if t.is_floating_point():
+        t.fill_(float('nan'))
+    return t
+
+
+def _patch_empty():
+    """Context manager that patches torch.empty to return NaN-filled tensors."""
+    torch._nan_empty_original = torch.empty
+    return patch.object(torch, 'empty', _nan_empty)
+
+
+def _make_routing_with_empty_experts(
+    num_tokens: int,
+    num_experts: int,
+    topk: int,
+    active_experts: list[int],
+    dtype: torch.dtype = torch.bfloat16,
+):
+    """Create topk_weights/topk_ids that route all tokens to active_experts
+    only, leaving the rest with 0 tokens."""
+    topk_ids = torch.zeros(num_tokens, topk, dtype=torch.int32, device=DEVICE)
+    for k_idx in range(topk):
+        expert = active_experts[k_idx % len(active_experts)]
+        topk_ids[:, k_idx] = expert
+    topk_weights = torch.ones(num_tokens, topk, dtype=dtype, device=DEVICE)
+    topk_weights /= topk  # normalize
+    return topk_weights, topk_ids
+
+
+# ============================================================================
+# 1. Unit tests: prepare() scale initialization
+# ============================================================================
+
 
 class TestBatchedMoEScaleInit:
-    """Regression test for uninitialized expert activation scales.
-
-    When an expert receives 0 tokens, its scale tensor must be zero-filled,
-    not NaN from torch.empty().  NaN scales propagate through downstream
-    GEMM operations and corrupt model outputs.
-    """
-
-    @staticmethod
-    def _nan_empty(*args, **kwargs):
-        """Drop-in replacement for torch.empty that fills with NaN.
-        This simulates the worst case of recycled GPU memory containing
-        NaN values, making the test deterministic."""
-        t = torch._nan_empty_original(*args, **kwargs)
-        if t.is_floating_point():
-            t.fill_(float('nan'))
-        return t
+    """Verify that prepare() zero-fills scale tensors for 0-token experts."""
 
     def test_prepare_zero_token_experts_no_nan(self):
-        """Call BatchedPrepareAndFinalize.prepare() with topk_ids that
-        route NO tokens to some experts.  The returned b_a1_scale must
-        not contain NaN for those experts.
-
-        Fails without fix: torch.empty() leaves NaN/garbage in scale
-        rows for experts that receive 0 tokens."""
-        from unittest.mock import patch
-
-        from vllm.model_executor.layers.fused_moe.config import (
-            FusedMoEQuantConfig,
-        )
-        from vllm.model_executor.layers.fused_moe.fused_batched_moe import (
-            BatchedPrepareAndFinalize,
-        )
-
+        """Per-token quant: 0-token experts must have zero scales, not NaN."""
         num_local_experts = 8
         num_tokens = 16
         hidden_dim = 128
@@ -70,31 +100,21 @@ class TestBatchedMoEScaleInit:
             rank=0,
         )
 
-        # Create inputs that route tokens to only experts 0 and 1
-        # Experts 2-7 get 0 tokens
-        a1 = torch.randn(
-            num_tokens, hidden_dim, dtype=torch.float16, device=DEVICE,
+        a1 = torch.randn(num_tokens, hidden_dim,
+                          dtype=torch.float16, device=DEVICE)
+        topk_weights, topk_ids = _make_routing_with_empty_experts(
+            num_tokens, num_local_experts, topk, active_experts=[0, 1],
+            dtype=torch.float16,
         )
-        topk_weights = torch.ones(
-            num_tokens, topk, dtype=torch.float16, device=DEVICE,
-        )
-        # All tokens go to experts 0 and 1 only
-        topk_ids = torch.zeros(
-            num_tokens, topk, dtype=torch.int64, device=DEVICE,
-        )
-        topk_ids[:, 0] = 0  # first choice: expert 0
-        topk_ids[:, 1] = 1  # second choice: expert 1
 
         quant_config = FusedMoEQuantConfig.make(
             quant_dtype=torch.float8_e4m3fn,
             per_act_token_quant=True,
         )
 
-        # Patch torch.empty to deterministically return NaN-filled tensors.
-        # This simulates the worst case for recycled GPU memory.
         torch._nan_empty_original = torch.empty
         try:
-            with patch.object(torch, 'empty', self._nan_empty):
+            with _patch_empty():
                 b_a1, b_a1_scale, expert_tokens_meta, _, _ = prep.prepare(
                     a1=a1,
                     topk_weights=topk_weights,
@@ -108,33 +128,17 @@ class TestBatchedMoEScaleInit:
             del torch._nan_empty_original
 
         torch.cuda.synchronize()
+        assert b_a1_scale is not None
 
-        assert b_a1_scale is not None, (
-            "Scale tensor should exist for quantized config"
-        )
-
-        # Check experts that received 0 tokens (experts 2-7)
         for expert_id in range(2, num_local_experts):
             expert_scale = b_a1_scale[expert_id].cpu()
-            has_nan = torch.isnan(expert_scale).any().item()
-            assert not has_nan, (
+            assert not torch.isnan(expert_scale).any(), (
                 f"Expert {expert_id} received 0 tokens but has NaN in "
-                f"scale tensor. This will corrupt MoE output when the "
-                f"scale is used in downstream GEMM operations."
+                f"scale tensor."
             )
 
     def test_prepare_block_quant_zero_token_experts(self):
-        """Same test but with block quantization (block_shape=[128, 128])
-        instead of per-token quantization."""
-        from unittest.mock import patch
-
-        from vllm.model_executor.layers.fused_moe.config import (
-            FusedMoEQuantConfig,
-        )
-        from vllm.model_executor.layers.fused_moe.fused_batched_moe import (
-            BatchedPrepareAndFinalize,
-        )
-
+        """Block quant: 0-token experts must have zero scales, not NaN."""
         num_local_experts = 4
         num_tokens = 8
         hidden_dim = 256
@@ -148,26 +152,21 @@ class TestBatchedMoEScaleInit:
             rank=0,
         )
 
-        a1 = torch.randn(
-            num_tokens, hidden_dim, dtype=torch.float16, device=DEVICE,
-        )
-        topk_weights = torch.ones(
-            num_tokens, topk, dtype=torch.float16, device=DEVICE,
-        )
-        # All tokens go to expert 0 only; experts 1-3 get nothing
-        topk_ids = torch.zeros(
-            num_tokens, topk, dtype=torch.int64, device=DEVICE,
+        a1 = torch.randn(num_tokens, hidden_dim,
+                          dtype=torch.float16, device=DEVICE)
+        topk_weights, topk_ids = _make_routing_with_empty_experts(
+            num_tokens, num_local_experts, topk, active_experts=[0],
+            dtype=torch.float16,
         )
 
         quant_config = FusedMoEQuantConfig.make(
             quant_dtype=torch.float8_e4m3fn,
-            block_shape=[128, 128],
+            block_shape=BLOCK_SHAPE,
         )
 
-        # Patch torch.empty to deterministically return NaN
         torch._nan_empty_original = torch.empty
         try:
-            with patch.object(torch, 'empty', self._nan_empty):
+            with _patch_empty():
                 b_a1, b_a1_scale, expert_tokens_meta, _, _ = prep.prepare(
                     a1=a1,
                     topk_weights=topk_weights,
@@ -181,55 +180,309 @@ class TestBatchedMoEScaleInit:
             del torch._nan_empty_original
 
         torch.cuda.synchronize()
-
         assert b_a1_scale is not None
+
         for expert_id in range(1, num_local_experts):
             expert_scale = b_a1_scale[expert_id].cpu()
-            has_nan = torch.isnan(expert_scale).any().item()
-            assert not has_nan, (
+            assert not torch.isnan(expert_scale).any(), (
                 f"Expert {expert_id} (0 tokens, block quant) has NaN "
                 f"in scale tensor."
             )
 
-    def test_expert_scale_nan_propagation(self):
-        """Demonstrate that NaN in scale tensors propagates through
-        matrix multiplication — the mechanism by which uninitialized
-        scales corrupt model outputs and eventually the KV cache."""
-        num_experts = 4
-        max_tokens = 32
-        hidden_dim = 64
 
-        activations = torch.randn(
-            num_experts, max_tokens, hidden_dim,
-            dtype=torch.float32, device=DEVICE,
-        )
-        weights = torch.randn(
-            num_experts, hidden_dim, hidden_dim,
-            dtype=torch.float32, device=DEVICE,
+# ============================================================================
+# 2. End-to-end: full kernel with 0-token experts produces NaN-free output
+# ============================================================================
+
+
+def _make_block_quant_fp8_weights(e, n, k):
+    """Create FP8 block-quantized weights for e experts."""
+    from tests.kernels.moe.test_deepgemm import make_block_quant_fp8_weights
+    return make_block_quant_fp8_weights(e, n, k, BLOCK_SHAPE)
+
+
+class TestBatchedMoEEndToEnd:
+    """End-to-end tests: run full MoE kernel with 0-token experts and
+    verify the final output is NaN-free."""
+
+    def test_batched_triton_zero_token_experts(self, workspace_init):
+        """BatchedTritonExperts with FP8 block quant: 0-token experts
+        must not inject NaN into output."""
+        E, N, K = 8, 512, 256
+        num_tokens = 32
+        topk = 2
+
+        w1, w2, w1_s, w2_s = _make_block_quant_fp8_weights(E, N, K)
+
+        a = torch.randn(num_tokens, K, device=DEVICE,
+                         dtype=torch.bfloat16) / 10
+        fp8_info = torch.finfo(torch.float8_e4m3fn)
+        a.clamp_(fp8_info.min, fp8_info.max)
+
+        # Route all tokens to experts 0 and 1 only
+        topk_weights, topk_ids = _make_routing_with_empty_experts(
+            num_tokens, E, topk, active_experts=[0, 1])
+
+        max_num_tokens = 64
+        quant_config = fp8_w8a8_moe_quant_config(
+            w1_scale=w1_s, w2_scale=w2_s,
+            per_act_token_quant=False, block_shape=BLOCK_SHAPE,
         )
 
-        # Buggy: scales contain NaN for expert 2 (0 tokens)
-        scales_buggy = torch.ones(
-            num_experts, max_tokens, 1,
-            dtype=torch.float32, device=DEVICE,
+        kernel = FusedMoEKernel(
+            BatchedPrepareAndFinalize(
+                max_num_tokens=max_num_tokens,
+                num_local_experts=E,
+                num_dispatchers=1, rank=0,
+            ),
+            BatchedTritonExperts(
+                max_num_tokens=max_num_tokens,
+                num_dispatchers=1,
+                quant_config=quant_config,
+                moe_config=make_dummy_moe_config(),
+            ),
+            inplace=False,
         )
-        scales_buggy[2] = float('nan')
 
-        # Fixed: scales are zero for expert 2
-        scales_fixed = torch.ones(
-            num_experts, max_tokens, 1,
-            dtype=torch.float32, device=DEVICE,
-        )
-        scales_fixed[2] = 0.0
-
-        output_buggy = torch.bmm(activations * scales_buggy, weights)
-        output_fixed = torch.bmm(activations * scales_fixed, weights)
+        with set_current_vllm_config(VllmConfig()):
+            output = kernel.apply(
+                hidden_states=a, w1=w1, w2=w2,
+                topk_weights=topk_weights, topk_ids=topk_ids,
+                global_num_experts=E,
+                activation=MoEActivation.SILU,
+                apply_router_weight_on_input=False,
+                expert_map=None,
+            )
 
         torch.cuda.synchronize()
-
-        assert torch.isnan(output_buggy[2]).all(), (
-            "NaN scale propagates to ALL output values for that expert"
+        assert not torch.isnan(output).any(), (
+            "BatchedTritonExperts output contains NaN with 0-token experts"
         )
-        assert not torch.isnan(output_fixed).any(), (
-            "Zero scale prevents NaN propagation"
+        assert not torch.isinf(output).any(), (
+            "BatchedTritonExperts output contains Inf with 0-token experts"
+        )
+
+    @pytest.mark.skipif(
+        not current_platform.has_device_capability(89),
+        reason="Requires sm89+ for FP8",
+    )
+    def test_batched_triton_per_token_quant_zero_token_experts(
+        self, workspace_init,
+    ):
+        """BatchedTritonExperts with per-token FP8 quant: 0-token experts
+        must not inject NaN into output."""
+        E, N, K = 8, 512, 256
+        num_tokens = 32
+        topk = 2
+
+        # Per-token quant needs per-channel weight scales [E, 1, 1]
+        fp8_info = torch.finfo(torch.float8_e4m3fn)
+        w1_bf16 = torch.randn(E, 2 * N, K, device=DEVICE,
+                               dtype=torch.bfloat16) / 10
+        w2_bf16 = torch.randn(E, K, N, device=DEVICE,
+                               dtype=torch.bfloat16) / 10
+        w1_bf16.clamp_(fp8_info.min, fp8_info.max)
+        w2_bf16.clamp_(fp8_info.min, fp8_info.max)
+
+        w1 = w1_bf16.to(torch.float8_e4m3fn)
+        w2 = w2_bf16.to(torch.float8_e4m3fn)
+        w1_s = torch.ones(E, dtype=torch.float32, device=DEVICE)
+        w2_s = torch.ones(E, dtype=torch.float32, device=DEVICE)
+
+        a = torch.randn(num_tokens, K, device=DEVICE,
+                         dtype=torch.bfloat16) / 10
+
+        topk_weights, topk_ids = _make_routing_with_empty_experts(
+            num_tokens, E, topk, active_experts=[0, 1])
+
+        max_num_tokens = 64
+        quant_config = fp8_w8a8_moe_quant_config(
+            w1_scale=w1_s, w2_scale=w2_s,
+            per_act_token_quant=True, block_shape=None,
+        )
+
+        kernel = FusedMoEKernel(
+            BatchedPrepareAndFinalize(
+                max_num_tokens=max_num_tokens,
+                num_local_experts=E,
+                num_dispatchers=1, rank=0,
+            ),
+            BatchedTritonExperts(
+                max_num_tokens=max_num_tokens,
+                num_dispatchers=1,
+                quant_config=quant_config,
+                moe_config=make_dummy_moe_config(),
+            ),
+            inplace=False,
+        )
+
+        with set_current_vllm_config(VllmConfig()):
+            output = kernel.apply(
+                hidden_states=a, w1=w1, w2=w2,
+                topk_weights=topk_weights, topk_ids=topk_ids,
+                global_num_experts=E,
+                activation=MoEActivation.SILU,
+                apply_router_weight_on_input=False,
+                expert_map=None,
+            )
+
+        torch.cuda.synchronize()
+        assert not torch.isnan(output).any(), (
+            "BatchedTritonExperts (per-token quant) output contains NaN"
+        )
+
+    @pytest.mark.skipif(
+        not current_platform.has_device_capability(89),
+        reason="Requires sm89+ for DeepGEMM FP8",
+    )
+    def test_batched_deepgemm_zero_token_experts(
+        self, monkeypatch, workspace_init,
+    ):
+        """BatchedDeepGemmExperts with FP8 block quant: 0-token experts
+        must not inject NaN into output."""
+        from vllm.utils.deep_gemm import is_deep_gemm_supported
+
+        if not is_deep_gemm_supported():
+            pytest.skip("Requires deep_gemm kernels")
+
+        from vllm.model_executor.layers.fused_moe.experts.batched_deep_gemm_moe import (
+            BatchedDeepGemmExperts,
+        )
+
+        monkeypatch.setenv("VLLM_USE_DEEP_GEMM", "1")
+
+        E, N, K = 8, 512, 256
+        num_tokens = 32
+        topk = 2
+
+        w1, w2, w1_s, w2_s = _make_block_quant_fp8_weights(E, N, K)
+
+        a = torch.randn(num_tokens, K, device=DEVICE,
+                         dtype=torch.bfloat16) / 10
+        fp8_info = torch.finfo(torch.float8_e4m3fn)
+        a.clamp_(fp8_info.min, fp8_info.max)
+
+        topk_weights, topk_ids = _make_routing_with_empty_experts(
+            num_tokens, E, topk, active_experts=[0, 1])
+
+        max_num_tokens = 64
+        quant_config = fp8_w8a8_moe_quant_config(
+            w1_scale=w1_s, w2_scale=w2_s,
+            per_act_token_quant=False, block_shape=BLOCK_SHAPE,
+        )
+
+        kernel = FusedMoEKernel(
+            BatchedPrepareAndFinalize(
+                max_num_tokens=max_num_tokens,
+                num_local_experts=E,
+                num_dispatchers=1, rank=0,
+            ),
+            BatchedDeepGemmExperts(
+                max_num_tokens=max_num_tokens,
+                num_dispatchers=1,
+                quant_config=quant_config,
+                moe_config=make_dummy_moe_config(),
+            ),
+            inplace=False,
+        )
+
+        with set_current_vllm_config(VllmConfig()):
+            output = kernel.apply(
+                hidden_states=a, w1=w1, w2=w2,
+                topk_weights=topk_weights, topk_ids=topk_ids,
+                global_num_experts=E,
+                activation=MoEActivation.SILU,
+                apply_router_weight_on_input=False,
+                expert_map=None,
+            )
+
+        torch.cuda.synchronize()
+        assert not torch.isnan(output).any(), (
+            "BatchedDeepGemmExperts output contains NaN with 0-token experts"
+        )
+        assert not torch.isinf(output).any(), (
+            "BatchedDeepGemmExperts output contains Inf with 0-token experts"
+        )
+
+    @pytest.mark.skipif(
+        not current_platform.has_device_capability(100),
+        reason="NVFP4 requires sm100+",
+    )
+    def test_cutlass_fp4_zero_token_experts(self, workspace_init):
+        """CutlassExpertsFp4 (NVFP4): 0-token experts must not inject
+        NaN into output."""
+        from vllm.model_executor.layers.fused_moe.cutlass_moe import (
+            CutlassExpertsFp4,
+        )
+        from vllm.model_executor.layers.fused_moe.all2all_utils import (
+            maybe_make_prepare_finalize,
+        )
+
+        E, N, K = 8, 1024, 1024
+        num_tokens = 32
+        topk = 2
+
+        (_, w1_q, w1_blockscale, w1_gs), (_, w2_q, w2_blockscale, w2_gs) = (
+            make_test_weights(
+                E, N, K,
+                in_dtype=torch.bfloat16,
+                quant_dtype="nvfp4",
+            )
+        )
+
+        a = torch.randn(num_tokens, K, device=DEVICE,
+                         dtype=torch.bfloat16) / 10
+
+        topk_weights, topk_ids = _make_routing_with_empty_experts(
+            num_tokens, E, topk, active_experts=[0, 1])
+
+        a1_gs = torch.ones((E,), device=DEVICE, dtype=torch.float32)
+        a2_gs = torch.ones((E,), device=DEVICE, dtype=torch.float32)
+
+        quant_config = nvfp4_moe_quant_config(
+            g1_alphas=(1 / w1_gs),
+            g2_alphas=(1 / w2_gs),
+            a1_gscale=a1_gs,
+            a2_gscale=a2_gs,
+            w1_scale=w1_blockscale,
+            w2_scale=w2_blockscale,
+        )
+        moe_config = make_dummy_moe_config()
+
+        kernel = FusedMoEKernel(
+            maybe_make_prepare_finalize(
+                moe=moe_config,
+                quant_config=quant_config,
+                allow_new_interface=True,
+                use_monolithic=False,
+            ),
+            CutlassExpertsFp4(
+                moe_config=moe_config,
+                quant_config=quant_config,
+            ),
+            inplace=False,
+        )
+
+        with set_current_vllm_config(
+            VllmConfig(
+                parallel_config=ParallelConfig(pipeline_parallel_size=1)
+            )
+        ):
+            output = kernel.apply(
+                hidden_states=a, w1=w1_q, w2=w2_q,
+                topk_weights=topk_weights, topk_ids=topk_ids,
+                global_num_experts=E,
+                activation=MoEActivation.SILU,
+                apply_router_weight_on_input=False,
+                expert_map=None,
+            )
+
+        torch.cuda.synchronize()
+        assert not torch.isnan(output).any(), (
+            "CutlassExpertsFp4 (NVFP4) output contains NaN with "
+            "0-token experts"
+        )
+        assert not torch.isinf(output).any(), (
+            "CutlassExpertsFp4 (NVFP4) output contains Inf with "
+            "0-token experts"
         )

--- a/vllm/model_executor/layers/fused_moe/fused_batched_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_batched_moe.py
@@ -576,7 +576,7 @@ class BatchedPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
                 num_local_experts, self.max_num_tokens, hidden_dim
             )
 
-            b_a1_scale = torch.empty(scale_shape, dtype=torch.float32, device=a1.device)
+            b_a1_scale = torch.zeros(scale_shape, dtype=torch.float32, device=a1.device)
         else:
             assert quant_config.a1_scale is None
             b_a1_scale = None
@@ -836,7 +836,7 @@ def batched_moe_kernel_quantize_input(
     elif qtype is None:
         return A, normalize_batched_scales_shape(A_scale, E)
     else:
-        A_q = torch.empty_like(A, dtype=qtype)
+        A_q = torch.zeros_like(A, dtype=qtype)
 
         if per_act_token_quant:
             assert block_shape is None


### PR DESCRIPTION
In the batched MoE codepath, used in the case of the DeepEP low latency all2all backend, if an expert isn't assigned any tokens, the scales and tokens can remain uninitialized. This is a defensive fix, as this invalid data shouldn't be read, however NaNs could potentially leak into real data.

Leaving this as a draft for now, until we figure out if the NaNs can leak into valid tokens.