### PR TITLE
fix(lmcache): correct store for cached requests and num_scheduled_tokens in lmcache_mp_connector.py

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -304,10 +304,20 @@ class LMCacheMPRequestMetadata:
         # NOTE: the invariant here is that `num_stored_blocks` should
         # always be a multiple of `blocks_in_chunk`
         # TODO: This should be checked everytime we update the num_stored_blocks
+        #
+        # Why computed_blocks includes num_lmcache_hit_blocks:
+        #
+        # Include lmcache-hit blocks so that the upper bound
+        # matches num_stored_blocks (which already covers
+        # them). Hit blocks are NOT re-stored.
+        computed_blocks = (
+            tracker.num_scheduled_tokens // vllm_block_size
+            + tracker.num_lmcache_hit_blocks
+        )
         min_available_blocks = min(
             len(tracker.block_hashes),
             len(tracker.allocated_block_ids),
-            tracker.num_scheduled_tokens // vllm_block_size,
+            computed_blocks,
         )
         num_staging_blocks = min_available_blocks - tracker.num_stored_blocks
         num_chunks = num_staging_blocks // blocks_in_chunk
@@ -1010,8 +1020,9 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             if request_id not in cached_reqs.resumed_req_ids:
                 request_tracker.append_block_ids(new_block_ids)
 
-            # Update new scheduled tokens
-            num_new_tokens = cached_reqs.num_computed_tokens[idx]
+            # Use the incremental num_scheduled_tokens to
+            # stay consistent with _process_new_requests.
+            num_new_tokens = scheduler_output.num_scheduled_tokens[request_id]
             request_tracker.increase_num_scheduled_tokens(num_new_tokens)
 
             r_meta = LMCacheMPRequestMetadata.GetStoreMetadata(


### PR DESCRIPTION



## Purpose

Fix two bugs in lmcache_mp_connector.py related to incorrect KV store behavior for cached requests:

1. Fix num_scheduled_tokens source for cached requests: In _process_cached_requests, the num_new_tokens was incorrectly using cached_reqs.num_computed_tokens[idx] instead of scheduler_output.num_scheduled_tokens[request_id]. This caused inconsistency with _process_new_requests which uses the incremental num_scheduled_tokens.
2. Fix min_available_blocks upper bound calculation: The computed_blocks now correctly includes num_lmcache_hit_blocks so that the upper bound matches num_stored_blocks (which already covers hit blocks). Previously, hit blocks were excluded from the calculation, causing the upper bound to be too low and potentially skipping blocks that should be staged for storage.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

