### PR TITLE
[XPU] revert torch-xpu to 2.10

### DIFF
--- a/requirements/test/xpu.txt
+++ b/requirements/test/xpu.txt
@@ -90,7 +90,7 @@ docker==7.1.0
     # via gpt-oss
 docopt==0.6.2
     # via num2words
-dpcpp-cpp-rt==2025.3.2
+dpcpp-cpp-rt==2025.3.1
     # via
     #   onemkl-sycl-blas
     #   onemkl-sycl-dft
@@ -171,27 +171,27 @@ idna==3.11
     #   yarl
 imageio==2.37.3
     # via scikit-image
-impi-rt==2021.17.2
+impi-rt==2021.17.0
     # via
     #   oneccl
     #   torch
 iniconfig==2.3.0
     # via pytest
-intel-cmplr-lib-rt==2025.3.2
+intel-cmplr-lib-rt==2025.3.1
     # via
     #   intel-sycl-rt
     #   torch
-intel-cmplr-lib-ur==2025.3.2
+intel-cmplr-lib-ur==2025.3.1
     # via
     #   intel-openmp
     #   intel-sycl-rt
     #   torch
-intel-cmplr-lic-rt==2025.3.2
+intel-cmplr-lic-rt==2025.3.1
     # via
     #   intel-opencl-rt
     #   intel-sycl-rt
     #   torch
-intel-opencl-rt==2025.3.2
+intel-opencl-rt==2025.3.1
     # via
     #   dpcpp-cpp-rt
     #   onemkl-sycl-blas
@@ -200,14 +200,14 @@ intel-opencl-rt==2025.3.2
     #   onemkl-sycl-rng
     #   onemkl-sycl-sparse
     #   torch
-intel-openmp==2025.3.2
+intel-openmp==2025.3.1
     # via
     #   dpcpp-cpp-rt
     #   mkl
     #   torch
-intel-pti==0.16.0
+intel-pti==0.15.0
     # via torch
-intel-sycl-rt==2025.3.2
+intel-sycl-rt==2025.3.1
     # via
     #   dpcpp-cpp-rt
     #   oneccl
@@ -269,7 +269,7 @@ mistral-common==1.11.0
     # via
     #   -c requirements/common.txt
     #   -r requirements/test/xpu.in
-mkl==2025.3.1
+mkl==2025.3.0
     # via
     #   onemkl-sycl-blas
     #   onemkl-sycl-dft
@@ -334,28 +334,28 @@ numpy==2.2.6
     #   tifffile
     #   torchvision
     #   transformers
-oneccl==2021.17.2
+oneccl==2021.17.1
     # via
     #   oneccl-devel
     #   torch
-oneccl-devel==2021.17.2
+oneccl-devel==2021.17.1
     # via torch
-onemkl-license==2025.3.1
+onemkl-license==2025.3.0
     # via
     #   mkl
     #   torch
-onemkl-sycl-blas==2025.3.1
+onemkl-sycl-blas==2025.3.0
     # via
     #   onemkl-sycl-lapack
     #   onemkl-sycl-sparse
     #   torch
-onemkl-sycl-dft==2025.3.1
+onemkl-sycl-dft==2025.3.0
     # via torch
-onemkl-sycl-lapack==2025.3.1
+onemkl-sycl-lapack==2025.3.0
     # via torch
-onemkl-sycl-rng==2025.3.1
+onemkl-sycl-rng==2025.3.0
     # via torch
-onemkl-sycl-sparse==2025.3.1
+onemkl-sycl-sparse==2025.3.0
     # via torch
 openai-harmony==0.0.8
     # via
@@ -606,7 +606,7 @@ tabledata==1.3.4
     # via pytablewriter
 tabulate==0.10.0
     # via sacrebleu
-tbb==2022.3.1
+tbb==2022.3.0
     # via
     #   intel-opencl-rt
     #   mkl
@@ -643,7 +643,7 @@ tokenizers==0.22.2
     # via
     #   -c requirements/common.txt
     #   transformers
-torch==2.11.0+xpu
+torch==2.10.0+xpu
     # via
     #   -c requirements/xpu.txt
     #   accelerate
@@ -651,7 +651,7 @@ torch==2.11.0+xpu
     #   sentence-transformers
     #   timm
     #   torchvision
-torchvision==0.26.0+xpu
+torchvision==0.25.0+xpu
     # via timm
 tqdm==4.67.3
     # via
@@ -669,7 +669,7 @@ transformers==4.57.6
     # via
     #   -c requirements/common.txt
     #   sentence-transformers
-triton-xpu==3.7.0
+triton-xpu==3.6.0
     # via torch
 typepy==1.3.4
     # via
@@ -704,7 +704,7 @@ typing-inspection==0.4.2
     # via
     #   fastapi
     #   pydantic
-umf==1.0.3
+umf==1.0.2
     # via
     #   intel-cmplr-lib-ur
     #   torch

--- a/requirements/xpu.txt
+++ b/requirements/xpu.txt
@@ -11,7 +11,7 @@ jinja2>=3.1.6
 datasets # for benchmark scripts
 numba == 0.61.2 # Required for N-gram speculative decoding
 --extra-index-url=https://download.pytorch.org/whl/xpu
-torch==2.11.0+xpu
+torch==2.10.0+xpu
 torchaudio
 torchvision
 


### PR DESCRIPTION



## Purpose
oneccl dependecy of xpu stack is not ready yet. so revert back to 2.10 to not break functionality and CI. 

## Test Plan
CI 
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

