### PR TITLE
[Bugfix] Fix Gemma 4 pipeline parallelism crash — IntermediateTensors .get() and None values

### DIFF
--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -1208,8 +1208,8 @@ class Gemma4Model(nn.Module, EagleModelMixin):
         else:
             assert intermediate_tensors is not None
             hidden_states = intermediate_tensors["hidden_states"]
-            residual = intermediate_tensors["residual"]
-            per_layer_inputs = intermediate_tensors.get("per_layer_inputs")
+            residual = intermediate_tensors.tensors.get("residual")
+            per_layer_inputs = intermediate_tensors.tensors.get("per_layer_inputs")
 
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
         for layer_idx, layer in enumerate(
@@ -1234,13 +1234,12 @@ class Gemma4Model(nn.Module, EagleModelMixin):
                 aux_hidden_states, layer_idx + 1, hidden_states, residual
             )
         if not get_pp_group().is_last_rank:
-            return IntermediateTensors(
-                {
-                    "hidden_states": hidden_states,
-                    "residual": residual,
-                    "per_layer_inputs": per_layer_inputs,
-                }
-            )
+            tensors = {"hidden_states": hidden_states}
+            if residual is not None:
+                tensors["residual"] = residual
+            if per_layer_inputs is not None:
+                tensors["per_layer_inputs"] = per_layer_inputs
+            return IntermediateTensors(tensors)
         # Gemma4 incorporates residual into hidden_states directly
         # Apply norm without residual fusion when possible.
         if residual is None:


### PR DESCRIPTION
## Purpose

Fix two bugs in `gemma4.py` that crash **all** Gemma 4 models with `--pipeline-parallel-size > 1`:

1. **`IntermediateTensors` has no `.get()` method** — `gemma4.py:1212` calls `intermediate_tensors.get("per_layer_inputs")`, but `IntermediateTensors` only exposes `__getitem__`, `__setitem__`, `items`, etc. Crashes during profiling with `AttributeError`.

2. **`None` values in `IntermediateTensors`** — `Gemma4DecoderLayer.forward()` always returns `residual=None` (by design, Gemma 4 absorbs residual within each layer). This means **every Gemma 4 model** hits this bug in PP mode. Additionally, models without PLE (31B, 26B-A4B, where `hidden_size_per_layer_input=0`) also have `per_layer_inputs=None`. These `None` values get packed into `IntermediateTensors` and sent to the next PP rank, where `sync_and_slice_intermediate_tensors()` tries `v[:copy_len]` on `None` → `TypeError`.

**Affected models:**

| Model | Bug 1 (.get) | Bug 2 (residual=None) | Bug 2 (per_layer_inputs=None) |
|-------|:---:|:---:|:---:|
| gemma-4-E2B-it | ✅ | ✅ | — (has PLE) |
| gemma-4-E4B-it | ✅ | ✅ | — (has PLE) |
| gemma-4-31B-it | ✅ | ✅ | ✅ |
| gemma-4-26B-A4B-it | ✅ | ✅ | ✅ |

**Fix:** Read side uses `.tensors.get()` for safe access. Write side filters out `None` values before constructing `IntermediateTensors`. Only `gemma4.py` is changed. Other models (Llama, Gemma3, etc.) always return real tensors for residual, so they are unaffected.

## Test Plan

```bash
vllm serve google/gemma-4-E4B-it \
  --distributed-executor-backend ray \
  --pipeline-parallel-size 2 \
  --max-model-len 8192 \
  --gpu-memory-utilization 0.90 \
  --limit-mm-per-prompt '{"image":0,"audio":0}' \
  --trust-remote-code \
  --enforce-eager \
  --served-model-name gemma4-e4b

# Then:
curl http://localhost:8000/v1/chat/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"gemma4-e4b","messages":[{"role":"user","content":"Hello! What model are you?"}],"max_tokens":32}'
```

Requires 2 GPUs on separate nodes (1 GPU per node) with Ray cluster.

## Test Result

Tested with `google/gemma-4-E4B-it`, PP=2, Ray backend, 2× NVIDIA L4 24GB.

| Patch | Profiling | Inference |
|-------|:---------:|:---------:|
| Unpatched | ❌ `AttributeError: 'IntermediateTensors' object has no attribute 'get'` | not reached |
| Fix1 only (.get) | ✅ | ❌ `TypeError: 'NoneType' object is not subscriptable` |
| Full fix | ✅ | ✅ |

Successful response:
```json
{
    "model": "gemma4-e4b",
    "choices": [{
        "message": {"content": "I am Gemma 4, a Large Language Model developed by Google DeepMind."},
        "finish_reason": "stop"
    }],
    "usage": {"prompt_tokens": 21, "completion_tokens": 17}
}
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update.
</details>