### PR TITLE
[Bugfix] Fix uninterpolated {e} in Mistral tool parser log message

### DIFF
--- a/vllm/tool_parsers/mistral_tool_parser.py
+++ b/vllm/tool_parsers/mistral_tool_parser.py
@@ -323,7 +323,7 @@ class MistralToolParser(ToolParser):
                     )[0]
                     tool_calls = json.loads(raw_tool_call)
                 except (IndexError, json.JSONDecodeError):
-                    logger.exception("Error in extracting tool call from response: {e}")
+                    logger.exception("Error in extracting tool call from response.")
                     # If raw decoding and decoding post regex rule fails, then just
                     # return content.
                     return ExtractedToolCallInformation(


### PR DESCRIPTION
## Purpose

Fix a string formatting bug in the Mistral tool parser where the error
log message contains a literal `{e}` instead of the actual exception.

**Location:** `vllm/tool_parsers/mistral_tool_parser.py:326`

**Before (buggy):**
```python
except (IndexError, json.JSONDecodeError):
    logger.exception("Error in extracting tool call from response: {e}")
```

Two issues:
1. The string is not an f-string, so `{e}` prints literally
2. The except clause doesn't bind the exception with `as e`

**After:**
```python
except (IndexError, json.JSONDecodeError):
    logger.exception("Error in extracting tool call from response.")
```

`logger.exception` already includes the full traceback, so the explicit
`{e}` reference is unnecessary.

## Test Plan

```bash
grep -n '{e}' vllm/tool_parsers/mistral_tool_parser.py
# Should return no matches after the fix
```

## Test Result

Before: `326: logger.exception("Error in extracting tool call from response: {e}")`
After: No matches — the literal `{e}` is gone.

## (Optional) AI Disclosure

This fix was identified and implemented with AI assistance (Claude).
The change was reviewed manually for correctness.