### PR TITLE
[CPU] Skip K conversion in MLA decode on AVX512_BF16

### DIFF
--- a/csrc/cpu/mla_decode.cpp
+++ b/csrc/cpu/mla_decode.cpp
@@ -190,17 +190,19 @@ void mla_decode_block(
     const int nbytes = BLOCK_SIZE * HEAD_DIM * sizeof(float);
     kv_cache_f32 = static_cast<float*>(std::aligned_alloc(64, nbytes));
 
+    // With AVX512_BF16, K stays in native BF16 — only convert V section.
+    // Without AVX512_BF16, K also needs FP32 — convert the full block.
+    constexpr int CONVERT_DIM =
+        std::is_same<qk_load_vec_type, qk_vec_type>::value ? V_HEAD_DIM
+                                                           : HEAD_DIM;
     for (int block_offset = 0; block_offset < num_tokens; ++block_offset)
-      for (int i = 0; i < HEAD_DIM; i += V_NUM_ELEM) {
+      for (int i = 0; i < CONVERT_DIM; i += V_NUM_ELEM) {
         v_load_vec_type kv_load_vec(kv_cache + block_offset * HEAD_DIM + i);
         f32_vec_type kv_vec_f32(kv_load_vec);
         kv_vec_f32.save(kv_cache_f32 + block_offset * HEAD_DIM + i);
       }
 
     if constexpr (std::is_same<qk_load_vec_type, qk_vec_type>::value) {
-      // for AVX512_BF16, Q @ K.T uses BF16 for K (no conversion)
-      // NOTE: in this case, we only need to convert the V section to FP32.
-      // But for simplicity, we will convert the whole KV block to FP32.
       k_vecs = reinterpret_cast<const qk_vec_type*>(kv_cache);
     } else {
       k_vecs = reinterpret_cast<const qk_vec_type*>(kv_cache_f32);


### PR DESCRIPTION
## Summary

- On AVX512_BF16 hardware, the Q @ K.T computation uses native BF16 dot product (`_mm512_dpbf16_ps`), so K does not need FP32 conversion
- Only convert the V section (`V_HEAD_DIM=512` elements per row) instead of the full block (`HEAD_DIM=576`), reducing conversion memory traffic by ~11% per block
- Uses a compile-time `constexpr CONVERT_DIM` that resolves to `V_HEAD_DIM` on AVX512_BF16 or `HEAD_DIM` otherwise — zero overhead on non-AVX512_BF16 hardware
- Addresses the existing comment in the code: `// NOTE: in this case, we only need to convert the V section to FP32. But for simplicity, we will convert the whole KV block to FP32.`

## Test plan

- [x] All 6 existing MLA decode CPU tests pass (`test_mla_decode_cpu`): float32, float16, bfloat16 × fixed/variable length
- [x] `pytest tests/kernels/attention/test_mla_decode_cpu.py -v` — 6/6 passed
- [ ] Needs CI validation on AVX512_BF16 hardware (Sapphire Rapids / Cooper Lake) to exercise the optimized path — local machine (i7-11850H) lacks AVX512_BF16

```
tests/kernels/attention/test_mla_decode_cpu.py::test_mla_decode_cpu[False-dtype0-16-512-576-16-256-4] PASSED
tests/kernels/attention/test_mla_decode_cpu.py::test_mla_decode_cpu[False-dtype1-16-512-576-16-256-4] PASSED
tests/kernels/attention/test_mla_decode_cpu.py::test_mla_decode_cpu[False-dtype2-16-512-576-16-256-4] PASSED
tests/kernels/attention/test_mla_decode_cpu.py::test_mla_decode_cpu[True-dtype0-16-512-576-16-256-4] PASSED
tests/kernels/attention/test_mla_decode_cpu.py::test_mla_decode_cpu[True-dtype1-16-512-576-16-256-4] PASSED
tests/kernels/attention/test_mla_decode_cpu.py::test_mla_decode_cpu[True-dtype2-16-512-576-16-256-4] PASSED
```

Co-Assisted-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)