### PR TITLE
[Bugfix]: Fix MinimaxM2ToolParser missing tools parameter

### DIFF
--- a/vllm/parser/minimax_m2_parser.py
+++ b/vllm/parser/minimax_m2_parser.py
@@ -13,6 +13,9 @@ from vllm.logger import init_logger
 from vllm.parser.abstract_parser import DelegatingParser
 from vllm.reasoning.minimax_m2_reasoning_parser import MiniMaxM2ReasoningParser
 from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers.abstract_tool_parser import (
+    Tool,
+)
 from vllm.tool_parsers.minimax_m2_tool_parser import MinimaxM2ToolParser
 
 logger = init_logger(__name__)
@@ -40,12 +43,12 @@ class MiniMaxM2Parser(DelegatingParser):
     reasoning_parser_cls = MiniMaxM2ReasoningParser
     tool_parser_cls = MinimaxM2ToolParser
 
-    def __init__(self, tokenizer: TokenizerLike):
+    def __init__(self, tokenizer: TokenizerLike, tools: list[Tool] | None = None):
         super().__init__(tokenizer)
 
         # Initialize the underlying parsers
         self._reasoning_parser = MiniMaxM2ReasoningParser(tokenizer)
-        self._tool_parser = MinimaxM2ToolParser(tokenizer)
+        self._tool_parser = MinimaxM2ToolParser(tokenizer, tools)
 
         logger.debug(
             "vLLM Successfully initialized parser %s!", self.__class__.__name__


### PR DESCRIPTION


## Purpose
[Bugfix]: Fix MinimaxM2ToolParser missing tools parameter
## Test Plan
before
```
(APIServer pid=3566526)     |     async for event_data in processor(
(APIServer pid=3566526)     |   File "/mnt/data4/jxy/vllm/vllm/entrypoints/openai/responses/serving.py", line 1344, in _process_simple_streaming_events
(APIServer pid=3566526)     |     parser = self.parser(tokenizer, request.tools) if self.parser else None
(APIServer pid=3566526)     |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=3566526)     | TypeError: MiniMaxM2Parser.__init__() takes 2 positional arguments but 3 were given

```
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

