### PR TITLE
[fix][MOE] Fix MOE experts `intermediate_size` dimension not being narrowed before weight loading

### DIFF
--- a/tests/kernels/moe/test_moe_weight_loading_padded.py
+++ b/tests/kernels/moe/test_moe_weight_loading_padded.py
@@ -257,6 +257,41 @@ class TestWeightLoadingWithPaddedHiddenSize:
 
         assert torch.equal(expert_data_full, loaded_weight)
 
+    def test_narrow_shard_dim(self):
+        """Simulate loading w2 when both hidden_size and intermediate_size
+        are padded.
+        """
+        padded_hidden = 3072
+        original_hidden = 2688
+        padded_intermediate = 1024
+        original_intermediate = 896
+
+        expert_data_full = torch.zeros(padded_hidden, padded_intermediate)
+        loaded_weight = torch.randn(original_hidden, original_intermediate)
+
+        shard_dim = 1
+        hidden_dim = FusedMoE._get_hidden_dim(shard_dim=shard_dim, ndim=2)
+        expert_data = FusedMoE._narrow_expert_data_for_padding(
+            expert_data_full,
+            loaded_weight,
+            hidden_dim=hidden_dim,
+            shard_dim=shard_dim,
+        )
+        expert_data.copy_(loaded_weight)
+
+        assert torch.equal(
+            expert_data_full[:original_hidden, :original_intermediate],
+            loaded_weight,
+        )
+        assert torch.equal(
+            expert_data_full[original_hidden:, :],
+            torch.zeros(padded_hidden - original_hidden, padded_intermediate),
+        )
+        assert torch.equal(
+            expert_data_full[:original_hidden, original_intermediate:],
+            torch.zeros(original_hidden, padded_intermediate - original_intermediate),
+        )
+
     def test_bnb_shape_mismatch_raises(self):
         """BnB + padded hidden_size should raise via weight_loader."""
         from unittest.mock import MagicMock

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -842,7 +842,10 @@ class FusedMoE(CustomOp):
         if shard_id == "w2":
             hidden_dim = self._get_hidden_dim(shard_dim, expert_data.ndim)
             expert_data = self._narrow_expert_data_for_padding(
-                expert_data, loaded_weight, hidden_dim=hidden_dim
+                expert_data,
+                loaded_weight,
+                hidden_dim=hidden_dim,
+                shard_dim=shard_dim,
             )
             expert_data.copy_(loaded_weight)
         elif shard_id in ("w1", "w3"):
@@ -882,29 +885,33 @@ class FusedMoE(CustomOp):
         expert_data: torch.Tensor,
         loaded_weight: torch.Tensor,
         hidden_dim: int,
+        shard_dim: int = -1,
     ) -> torch.Tensor:
-        """Narrow expert_data hidden dim to match loaded_weight for padded
-        hidden_size.
+        """Narrow expert_data to match loaded_weight for padded dimensions.
 
         When backends (e.g., DeepEP) round up hidden_size, weight parameters
         are larger than checkpoint weights. Narrow the padded hidden dimension
-        before copying.
+        before copying. Similarly, when padding occurs on the shard
+        (intermediate) dimension (e.g., last TP shard), narrow that dimension
+        as well.
 
         Args:
             expert_data: The (possibly padded) parameter tensor to narrow.
             loaded_weight: The checkpoint weight tensor with original size.
             hidden_dim: The dimension index corresponding to hidden_size.
                 Must be non-negative.
+            shard_dim: The dimension index corresponding to the shard
+                (intermediate) dimension. If negative, shard-dim narrowing
+                is skipped.
         """
-        if (
-            loaded_weight.ndim > 0
-            and 0 <= hidden_dim < expert_data.ndim
-            and hidden_dim < loaded_weight.ndim
-            and expert_data.shape[hidden_dim] > loaded_weight.shape[hidden_dim]
-        ):
-            expert_data = expert_data.narrow(
-                hidden_dim, 0, loaded_weight.shape[hidden_dim]
-            )
+        if loaded_weight.ndim > 0:
+            for dim in (hidden_dim, shard_dim):
+                if (
+                    0 <= dim < expert_data.ndim
+                    and dim < loaded_weight.ndim
+                    and expert_data.shape[dim] > loaded_weight.shape[dim]
+                ):
+                    expert_data = expert_data.narrow(dim, 0, loaded_weight.shape[dim])
         return expert_data
 
     def _load_w13(
@@ -946,7 +953,10 @@ class FusedMoE(CustomOp):
             expert_data = expert_data.narrow(shard_dim, shard_size, shard_size)
         hidden_dim = self._get_hidden_dim(shard_dim, expert_data.ndim)
         expert_data = self._narrow_expert_data_for_padding(
-            expert_data, loaded_weight, hidden_dim=hidden_dim
+            expert_data,
+            loaded_weight,
+            hidden_dim=hidden_dim,
+            shard_dim=shard_dim,
         )
         expert_data.copy_(loaded_weight)
 
@@ -979,7 +989,10 @@ class FusedMoE(CustomOp):
         # w2, down_proj: Load into only logical weight of w2.
         hidden_dim = self._get_hidden_dim(shard_dim, expert_data.ndim)
         expert_data = self._narrow_expert_data_for_padding(
-            expert_data, loaded_weight, hidden_dim=hidden_dim
+            expert_data,
+            loaded_weight,
+            hidden_dim=hidden_dim,
+            shard_dim=shard_dim,
         )
         expert_data.copy_(loaded_weight)
 

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -885,14 +885,14 @@ class FusedMoE(CustomOp):
         expert_data: torch.Tensor,
         loaded_weight: torch.Tensor,
         hidden_dim: int,
-        shard_dim: int = -1,
+        shard_dim: int | None = None,
     ) -> torch.Tensor:
         """Narrow expert_data to match loaded_weight for padded dimensions.
 
         When backends (e.g., DeepEP) round up hidden_size, weight parameters
         are larger than checkpoint weights. Narrow the padded hidden dimension
         before copying. Similarly, when padding occurs on the shard
-        (intermediate) dimension (e.g., last TP shard), narrow that dimension
+        (intermediate) dimension (e.g. for MXFP4 GEMM), narrow that dimension
         as well.
 
         Args:
@@ -901,11 +901,11 @@ class FusedMoE(CustomOp):
             hidden_dim: The dimension index corresponding to hidden_size.
                 Must be non-negative.
             shard_dim: The dimension index corresponding to the shard
-                (intermediate) dimension. If negative, shard-dim narrowing
-                is skipped.
+                (intermediate) dimension. Defaults to `None`.
         """
+        dims = (hidden_dim,) if shard_dim is None else (hidden_dim, shard_dim)
         if loaded_weight.ndim > 0:
-            for dim in (hidden_dim, shard_dim):
+            for dim in dims:
                 if (
                     0 <= dim < expert_data.ndim
                     and dim < loaded_weight.ndim


### PR DESCRIPTION
## Purpose

The PR https://github.com/vllm-project/vllm/pull/37010 modified `_load_per_channel_weight_scale`, `_load_w13`, `_load_w2` logic to use a method `_narrow_expert_data_for_padding` to narrow the instantiated padded `nn.Parameter` before copying weights into there.

The introduced method handles the hidden size dimension only, whereas the previous logic correctly narrowed both the hidden size + intermediate size dimensions, that may both be padded:

https://github.com/vllm-project/vllm/blob/1b19bd758936496751432eccabf8adb7b5d8936a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py#L376-L400

The old logic correctly handled this:

```python
        # Handle padding: if loaded_weight is smaller than expert_data (can happen
        # on last TP shard with padding), copy to top-left corner
        if expert_data.shape != loaded_weight.shape:
            expert_data = expert_data[
                : loaded_weight.shape[0], : loaded_weight.shape[1]
            ]
```

This PR adds narrowing on the intermediate size dimension, as it used to be before https://github.com/vllm-project/vllm/pull/37010 was merged.

## Test Plan

```bash
CUDA_VISIBLE_DEVICES=7 pytest tests/quantization/test_quark.py -s -vvvvv -k "test_ocp_mx_wikitext_correctness"
```

on `main`:

```
(EngineCore pid=7164)   File "/felmarty/repos/vllm/vllm/model_executor/models/qwen2_moe.py", line 495, in load_weights
(EngineCore pid=7164)     weight_loader(
(EngineCore pid=7164)   File "/felmarty/repos/vllm/vllm/model_executor/layers/fused_moe/layer.py", line 1338, in weight_loader
(EngineCore pid=7164)     self._load_model_weight_or_group_weight_scale(
(EngineCore pid=7164)   File "/felmarty/repos/vllm/vllm/model_executor/layers/fused_moe/layer.py", line 817, in _load_model_weight_or_group_weight_scale
(EngineCore pid=7164)     self._load_w2(
(EngineCore pid=7164)   File "/felmarty/repos/vllm/vllm/model_executor/layers/fused_moe/layer.py", line 991, in _load_w2
(EngineCore pid=7164)     expert_data.copy_(loaded_weight)
(EngineCore pid=7164) RuntimeError: The size of tensor a (768) must match the size of tensor b (704) at non-singleton dimension 1
```

on this PR: passes.