### PR TITLE
[Bugfix] Fix model loader compare pattern for safetensors to enable subdir loading

### DIFF
--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -169,11 +169,11 @@ class DefaultModelLoader(BaseModelLoader):
         for pattern in allow_patterns:
             hf_weights_files += glob.glob(os.path.join(hf_folder, pattern))
             if len(hf_weights_files) > 0:
-                if pattern == "*.safetensors":
+                if pattern.endswith(".safetensors"):
                     use_safetensors = True
                 break
 
-        if use_safetensors:
+        if use_safetensors and allow_patterns_overrides is None:
             # For models like Mistral-7B-Instruct-v0.3
             # there are both sharded safetensors files and a consolidated
             # safetensors file. Using both breaks.


### PR DESCRIPTION



## Purpose

Resolves #39699 

This PR fixed the exact pattern comparison of `pattern == "*.safetensors"` and updated the condition for the branch of `filter_duplicate_safetensors_files`.

Without updating the branch condition, subdirectory model with a different model index file of the root still failed to load. When a caller explicitly sets `allow_patterns_overrides`, skipping the filter should be reasonable: the caller has fully specified which files to load, so deduplicating against an unrelated root-level index is inapplicable. 

Please correct me if I understand wrong or there exist any usage that sets `allow_patterns_overrides `while also relying on `filter_duplicate_safetensors_files`

## Test Plan

I got a script for dev testing
```python
from vllm.config import LoadConfig
from vllm.model_executor.model_loader.default_loader import DefaultModelLoader 

loader = DefaultModelLoader(LoadConfig(load_format="auto"))

source = DefaultModelLoader.Source(
	"inclusionAI/Ming-flash-omni-2.0",
    revision=None,
	prefix="",
	allow_patterns_overrides=["talker/model*.safetensors"],
)


hf_folder, weight_files, use_safetensors = loader._prepare_weights(
	"inclusionAI/Ming-flash-omni-2.0",
    subfolder=None,
    revision=None,
    fall_back_to_pt=False,
	allow_patterns_overrides=["talker/model*.safetensors"],
)
# weight file does exist
print(f" >>> weight_files: {weight_files}")
# use_safetensors is returned as False
print(f" >>> use_safetensors: {use_safetensors}")


# Crashes happened
for name, tensor in loader._get_weights_iterator(source):
	print(name, tensor.shape)

```



## Test Result

On main branch the script failed for the error of the issue linked:

```bash
INFO 04-13 12:20:17 [weight_utils.py:615] Time spent downloading weights for inclusionAI/Ming-flash-omni-2.0: 46.467259 seconds
 >>> weight_files: ['/root/.cache/huggingface/hub/models--inclusionAI--Ming-flash-omni-2.0/snapshots/6a2e1dec07066d20f62a743ac7c34284e4a3932d/talker/model.safetensors']
 >>> use_safetensors: False
Loading pt checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
Loading pt checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]

...
  File "/repos/vllm-project/vllm/.venv/lib/python3.12/site-packages/torch/_weights_only_unpickler.py", line 590, in load
    return Unpickler(file, encoding=encoding).load()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/repos/vllm-project/vllm/.venv/lib/python3.12/site-packages/torch/_weights_only_unpickler.py", line 544, in load
    self.append(self.memo[idx])
                ~~~~~~~~~^^^^^
KeyError: 231
```

With changes made on this branch, the script successfully loaded subdirectory scoped model weights:

```bash
 >>> weight_files: ['/root/.cache/huggingface/hub/models--inclusionAI--Ming-flash-omni-2.0/snapshots/6a2e1dec07066d20f62a743ac7c34284e4a3932d/talker/model.safetensors']
 >>> use_safetensors: True
INFO 04-13 12:46:22 [weight_utils.py:904] Filesystem type for checkpoints: OVERLAY. Checkpoint size: 1.30 GiB. Available RAM: 1819.53 GiB.
INFO 04-13 12:46:22 [weight_utils.py:927] Auto-prefetch is disabled because the filesystem (OVERLAY) is not a recognized network FS (NFS/Lustre). If you want to force prefetching, start vLLM with --safetensors-load-strategy=prefetch.
Loading safetensors checkpoint shards:   0% Completed | 0/1 [00:00<?, ?it/s]
aggregator.blocks.0.attn.to_k.bias torch.Size([1024])
aggregator.blocks.0.attn.to_k.weight torch.Size([1024, 1024])
aggregator.blocks.0.attn.to_out.0.bias torch.Size([1024])
aggregator.blocks.0.attn.to_out.0.weight torch.Size([1024, 1024])
aggregator.blocks.0.attn.to_q.bias torch.Size([1024])
...
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

