### PR TITLE
[Bugfix][Kernel][ROCm] Fix triton_w4a16 scales mismatch when BLOCK_K > group_size

### DIFF
--- a/vllm/model_executor/kernels/linear/mixed_precision/triton_w4a16.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/triton_w4a16.py
@@ -235,6 +235,14 @@ def triton_w4a16_gemm(
         else:
             BLOCK_M, BLOCK_N, BLOCK_K = 128, 128, 32
 
+    # The kernel loads scales/zeros for a single group per BLOCK_K tile
+    # (one g_idx per iteration). If BLOCK_K > group_size, rows at the tail
+    # of the tile dequantize with the wrong group's scales, silently
+    # corrupting the output. Clamp BLOCK_K to group_size to keep one
+    # scale group per tile.
+    if group_size < BLOCK_K:
+        BLOCK_K = group_size
+
     grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
 
     triton_w4a16_gemm_kernel[grid](

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -180,7 +180,8 @@ def preprocess_mamba(
     for i, req_id in enumerate(input_batch.req_ids):
         req_state = requests[req_id]
         prev_state_idx = mamba_state_idx.get(req_id)
-        if prev_state_idx is None:
+        is_new_or_resumed = prev_state_idx is None
+        if is_new_or_resumed:
             # new / resumed request, no previous state
             # if num_computed_tokens is 0, prev_state_idx will be -1
             prev_state_idx = (req_state.num_computed_tokens - 1) // block_size
@@ -203,6 +204,28 @@ def preprocess_mamba(
         # And use block 1 to save the running state.
         curr_state_idx = num_blocks - 1 - num_speculative_blocks
         mamba_state_idx[req_id] = curr_state_idx
+
+        if is_new_or_resumed and req_state.num_computed_tokens > 0:
+            # Prefix cache hit: verify the source block has valid state.
+            mamba_gid = mamba_group_ids[0]
+            src_phys = req_state.block_ids[mamba_gid][prev_state_idx]
+            layer_name = kv_cache_config.kv_cache_groups[
+                mamba_gid].layer_names[0]
+            ssm_cache = forward_context[layer_name].kv_cache[-1]
+            src_state = ssm_cache[src_phys]
+            if src_state.count_nonzero() == 0:
+                import logging
+                logging.getLogger(__name__).warning(
+                    "MAMBA STATE BUG: req %s prefix cache hit "
+                    "(%d computed tokens) but ssm_state at "
+                    "block[%d] (phys=%d) is ALL ZEROS. "
+                    "The cached mamba state was lost.",
+                    req_id,
+                    req_state.num_computed_tokens,
+                    prev_state_idx,
+                    src_phys,
+                )
+
         if prev_state_idx != -1 and prev_state_idx != curr_state_idx:
             collect_mamba_copy_meta(
                 copy_bufs,

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -180,8 +180,7 @@ def preprocess_mamba(
     for i, req_id in enumerate(input_batch.req_ids):
         req_state = requests[req_id]
         prev_state_idx = mamba_state_idx.get(req_id)
-        is_new_or_resumed = prev_state_idx is None
-        if is_new_or_resumed:
+        if prev_state_idx is None:
             # new / resumed request, no previous state
             # if num_computed_tokens is 0, prev_state_idx will be -1
             prev_state_idx = (req_state.num_computed_tokens - 1) // block_size
@@ -204,28 +203,6 @@ def preprocess_mamba(
         # And use block 1 to save the running state.
         curr_state_idx = num_blocks - 1 - num_speculative_blocks
         mamba_state_idx[req_id] = curr_state_idx
-
-        if is_new_or_resumed and req_state.num_computed_tokens > 0:
-            # Prefix cache hit: verify the source block has valid state.
-            mamba_gid = mamba_group_ids[0]
-            src_phys = req_state.block_ids[mamba_gid][prev_state_idx]
-            layer_name = kv_cache_config.kv_cache_groups[
-                mamba_gid].layer_names[0]
-            ssm_cache = forward_context[layer_name].kv_cache[-1]
-            src_state = ssm_cache[src_phys]
-            if src_state.count_nonzero() == 0:
-                import logging
-                logging.getLogger(__name__).warning(
-                    "MAMBA STATE BUG: req %s prefix cache hit "
-                    "(%d computed tokens) but ssm_state at "
-                    "block[%d] (phys=%d) is ALL ZEROS. "
-                    "The cached mamba state was lost.",
-                    req_id,
-                    req_state.num_computed_tokens,
-                    prev_state_idx,
-                    src_phys,
-                )
-
         if prev_state_idx != -1 and prev_state_idx != curr_state_idx:
             collect_mamba_copy_meta(
                 copy_bufs,


### PR DESCRIPTION
The Triton W4A16 GEMM kernel (triton_w4a16_gemm_kernel) loads quantization
scales and zero points from a single group index per BLOCK_K tile, but the
kernel launcher does not enforce BLOCK_K <= group_size. When BLOCK_K
exceeds group_size, a single tile spans multiple scale groups, but only the
first group's scales are applied to all rows in the tile. This silently
corrupts the dequantized weights in the tail rows.

In real-world use cases, this was reflected in agent tool calls within contexts exceeding 10K tokens. Typically, the model would start calling tools in a loop with the same arguments or perform the same task multiple times.

In other instances, it would leave the task unfinished, or—in the case of coding agents—start deleting relevant code or hallucinating the instructions.

Following the fix, the model now functions correctly and consistently with its capacity; in this case: Qwen3.5-35B-A3B-GPTQ-W4A16-G32.

I should clarify that I previously assumed this behavior was inherent to the model because, while working with ROCm RDNA3, I was forced to use Group Size with float16 dtype for the ExLlamaLinearKernel, which only worked passably.

Now, with the kernel introduced in PR #37352 (https://github.com/vllm-project/vllm/pull/37352), I can execute in bfloat16. I initially noticed the model was failing even more than with the ExLlamaLinearKernel, but after reviewing the code, I found the error in my specific use case.

After correcting it, I can run Qwen3.5-35B-A3B-GPTQ-W4A16-G32 much more efficiently. Beyond the performance gain, the model now hardly ever makes mistakes and works with much greater precision.

Thanks to @jatseng-ai and @tjtanaa for the kernel!