### PR TITLE
[CI][Metrics] Fix local_cache_hit assertion after prompt tokens metrics updates

### DIFF
--- a/tests/v1/kv_connector/nixl_integration/test_multi_connector_edge_cases.py
+++ b/tests/v1/kv_connector/nixl_integration/test_multi_connector_edge_cases.py
@@ -341,8 +341,8 @@ def test_full_decode_gpu_cache_hit_metrics():
     print(f"FULL CACHE HIT: {P} tokens, cached={cached}, nixl={expected_nixl}")
     print(f"  metrics delta: {d}, nixl_bytes_delta={n1 - n0}")
     assert len(proxy_text) > 0, "proxy returned empty response"
-    assert d["local_cache_hit"] == cached, (
-        f"expected local_cache_hit={cached}, got {d['local_cache_hit']}"
+    assert d["local_cache_hit"] == cached - 1, (
+        f"expected local_cache_hit={cached - 1}, got {d['local_cache_hit']}"
     )
     assert d["external_kv_transfer"] == expected_nixl, (
         f"expected external_kv_transfer={expected_nixl}, "
@@ -383,8 +383,8 @@ def test_partial_decode_gpu_cache_hit_metrics():
         f"expected external_kv_transfer={expected_nixl}, "
         f"got {d['external_kv_transfer']}"
     )
-    assert d["local_cache_hit"] == cached, (
-        f"expected local_cache_hit={cached}, got {d['local_cache_hit']}"
+    assert d["local_cache_hit"] == cached - 1, (
+        f"expected local_cache_hit={cached - 1}, got {d['local_cache_hit']}"
     )
     assert d["local_compute"] == 1, (
         f"expected local_compute=1 (recomputed last token), got {d['local_compute']}"


### PR DESCRIPTION
## Purpose
PR #38709 removed the `recomputed` token from `PromptTokenStats.update_from_output()`. When all prompt tokens are cached (local + NIXL), the scheduler reduces `num_cached_tokens` by 1, which is now absorbed by `local_cache_hit` in the metric accounting. This temporarily updates the MultiConnector edge case test assertions to match the new metric semantics. 

## Test Plan
CI runs. 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

