### PR TITLE
[CI/Build] Fix use_existing_torch.py to recursively match requirements subdirectories

### DIFF
--- a/use_existing_torch.py
+++ b/use_existing_torch.py
@@ -30,8 +30,8 @@ def main(argv):
     args = parser.parse_args(argv)
 
     for file in (
-        *glob.glob("requirements/*.txt"),
-        *glob.glob("requirements/*.in"),
+        *glob.glob("requirements/**/*.txt", recursive=True),
+        *glob.glob("requirements/**/*.in", recursive=True),
         "pyproject.toml",
     ):
         with open(file) as f:


### PR DESCRIPTION
### What does this PR do?
The `requirements` directory was recently restructured to include subdirectories like `build/` and `test/`. The previous glob patterns in `use_existing_torch.py` (`requirements/*.txt` and `requirements/*.in`) failed to match files inside these subdirectories. 

This PR updates the glob patterns to use `**/*.txt` and `**/*.in` with `recursive=True` to ensure all requirements files (including those in nested directories) are properly processed when using the script to strip torch dependencies.

### CheckList
- [x] This PR is not a duplicate of an existing PR.
- [x] I have read the [Contributing Guidelines](https://docs.vllm.ai/en/latest/developer/contributing.html).
- [x] The title of the PR starts with an appropriate prefix (e.g. `[Bugfix]`, `[CI/Build]`).

