### PR TITLE
feat(gguf): add PRISM Q1_0 and Q1_0_G128 1-bit quantization support

### DIFF
--- a/csrc/quantization/gguf/dequantize.cuh
+++ b/csrc/quantization/gguf/dequantize.cuh
@@ -1,5 +1,43 @@
 // copied and adapted from https://github.com/ggerganov/llama.cpp/blob/b2899/ggml-cuda/convert.cu
 // Dequant functions
+
+// PRISM Q1_0: 1-bit dequantize — each bit → +d or −d
+static __device__ __forceinline__ void dequantize_q1_0(
+    const void* vx, const int ib, const int iqs, dfloat2& v) {
+  const block_q1_0* x = (const block_q1_0*)vx;
+  const dfloat d = x[ib].d;
+
+  const int byte_idx_0 = iqs / 8;
+  const int bit_off_0  = iqs % 8;
+  const int byte_idx_1 = (iqs + 1) / 8;
+  const int bit_off_1  = (iqs + 1) % 8;
+
+  const uint8_t bit_0 = (x[ib].qs[byte_idx_0] >> bit_off_0) & 1;
+  const uint8_t bit_1 = (x[ib].qs[byte_idx_1] >> bit_off_1) & 1;
+
+  // 1 → +d, 0 → −d
+  v.x = bit_0 ? d : __hneg(d);
+  v.y = bit_1 ? d : __hneg(d);
+}
+
+// PRISM Q1_0_G128: 1-bit dequantize with group size 128
+static __device__ __forceinline__ void dequantize_q1_0_g128(
+    const void* vx, const int ib, const int iqs, dfloat2& v) {
+  const block_q1_0_g128* x = (const block_q1_0_g128*)vx;
+  const dfloat d = x[ib].d;
+
+  const int byte_idx_0 = iqs / 8;
+  const int bit_off_0  = iqs % 8;
+  const int byte_idx_1 = (iqs + 1) / 8;
+  const int bit_off_1  = (iqs + 1) % 8;
+
+  const uint8_t bit_0 = (x[ib].qs[byte_idx_0] >> bit_off_0) & 1;
+  const uint8_t bit_1 = (x[ib].qs[byte_idx_1] >> bit_off_1) & 1;
+
+  v.x = bit_0 ? d : __hneg(d);
+  v.y = bit_1 ? d : __hneg(d);
+}
+
 static __device__ __forceinline__ void dequantize_q4_0(const void * vx, const int ib, const int iqs, dfloat2 & v){
     const block_q4_0 * x = (const block_q4_0 *) vx;
 
@@ -565,6 +603,10 @@ static to_cuda_ggml_t<dst_t> ggml_get_to_cuda(int64_t type) {
             return dequantize_row_iq4_xs_cuda;
         case 29:
             return dequantize_row_iq1_m_cuda;
+        case 42:
+            return dequantize_block_cuda<QK1_0, QR1_0, dequantize_q1_0>;
+        case 43:
+            return dequantize_block_cuda<QK1_0_g128, QR1_0_g128, dequantize_q1_0_g128>;
         default:
             return nullptr;
     }

--- a/csrc/quantization/gguf/ggml-common.h
+++ b/csrc/quantization/gguf/ggml-common.h
@@ -14,6 +14,31 @@
 // QR = QK / number of values before dequantization
 // QI = number of 32 bit integers before dequantization
 
+// PRISM Q1_0: 1-bit quantization, 32 elements per block
+// Block layout: [half d (2 bytes)] [uint8_t qs[4] (4 bytes)] = 6 bytes total
+// Each bit in qs: 1 → +d, 0 → −d (symmetric binary quantization)
+#define QK1_0 32
+#define QR1_0 1
+#define QI1_0 (QK1_0 / 32)  // = 1: one int32 holds all 32 bits of a block
+typedef struct {
+  half d;                   // scale factor
+  uint8_t qs[QK1_0 / 8];   // 1-bit quants (4 bytes = 32 bits)
+} block_q1_0;
+static_assert(sizeof(block_q1_0) == sizeof(half) + QK1_0 / 8,
+              "wrong q1_0 block size/padding");
+
+// PRISM Q1_0_G128: 1-bit quantization, 128 elements per block (group size 128)
+// Block layout: [half d (2 bytes)] [uint8_t qs[16] (16 bytes)] = 18 bytes total
+#define QK1_0_g128 128
+#define QR1_0_g128 1
+#define QI1_0_g128 (QK1_0_g128 / 32)  // = 4: four int32s hold all 128 bits
+typedef struct {
+  half d;                         // scale factor
+  uint8_t qs[QK1_0_g128 / 8];    // 1-bit quants (16 bytes = 128 bits)
+} block_q1_0_g128;
+static_assert(sizeof(block_q1_0_g128) == sizeof(half) + QK1_0_g128 / 8,
+              "wrong q1_0_g128 block size/padding");
+
 #define QK4_0 32
 #define QR4_0 2
 #define QI4_0 (QK4_0 / (4 * QR4_0))

--- a/csrc/quantization/gguf/gguf_kernel.cu
+++ b/csrc/quantization/gguf/gguf_kernel.cu
@@ -199,6 +199,16 @@ torch::Tensor ggml_mul_mat_vec_a8(torch::Tensor W,  // quant weight
             (void*)W.data_ptr(), (void*)quant_X.data_ptr(),
             (scalar_t*)Y.data_ptr(), col, row, vecs, stream);
         break;
+      case 42:
+        mul_mat_vec_q1_0_q8_1_cuda<scalar_t>(
+            (void*)W.data_ptr(), (void*)quant_X.data_ptr(),
+            (scalar_t*)Y.data_ptr(), col, row, vecs, stream);
+        break;
+      case 43:
+        mul_mat_vec_q1_0_g128_q8_1_cuda<scalar_t>(
+            (void*)W.data_ptr(), (void*)quant_X.data_ptr(),
+            (scalar_t*)Y.data_ptr(), col, row, vecs, stream);
+        break;
     }
   });
   return Y;

--- a/csrc/quantization/gguf/mmvq.cuh
+++ b/csrc/quantization/gguf/mmvq.cuh
@@ -210,3 +210,23 @@ static void mul_mat_vec_iq3_s_q8_1_cuda(const void * vx, const void * vy, scalar
     mul_mat_vec_q<scalar_t, QK_K, QI3_XS, block_iq3_s, 1, vec_dot_iq3_s_q8_1>
         <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
 }
+
+// PRISM Q1_0 MMVQ: 1-bit quantized matrix-vector multiply (32-element blocks)
+template<typename scalar_t>
+static void mul_mat_vec_q1_0_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+    const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
+    const dim3 block_nums(block_num_y, nvecs, 1);
+    const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
+    mul_mat_vec_q<scalar_t, QK1_0, QI1_0, block_q1_0, VDR_Q1_0_Q8_1_MMVQ, vec_dot_q1_0_q8_1>
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+}
+
+// PRISM Q1_0_G128 MMVQ: 1-bit quantized matrix-vector multiply (128-element blocks)
+template<typename scalar_t>
+static void mul_mat_vec_q1_0_g128_q8_1_cuda(const void * vx, const void * vy, scalar_t * dst, const int ncols, const int nrows, const int nvecs, cudaStream_t stream) {
+    const int block_num_y = (nrows + GGML_CUDA_MMV_Y - 1) / GGML_CUDA_MMV_Y;
+    const dim3 block_nums(block_num_y, nvecs, 1);
+    const dim3 block_dims(WARP_SIZE, GGML_CUDA_MMV_Y, 1);
+    mul_mat_vec_q<scalar_t, QK1_0_g128, QI1_0_g128, block_q1_0_g128, VDR_Q1_0_g128_Q8_1_MMVQ, vec_dot_q1_0_g128_q8_1>
+        <<<block_nums, block_dims, 0, stream>>>(vx, vy, dst, ncols, nrows, nvecs);
+}

--- a/csrc/quantization/gguf/vecdotq.cuh
+++ b/csrc/quantization/gguf/vecdotq.cuh
@@ -40,6 +40,107 @@ static __device__ __forceinline__ int get_int_from_uint8_aligned(const uint8_t *
 // VDR = vec dot ratio, how many contiguous integers each thread processes when the vec dot kernel is called
 // MMVQ = mul_mat_vec_q, MMQ = mul_mat_q
 
+// PRISM Q1_0: 1-bit quantization vec_dot kernels
+#define VDR_Q1_0_Q8_1_MMVQ 1
+#define VDR_Q1_0_Q8_1_MMQ  1
+#define VDR_Q1_0_g128_Q8_1_MMVQ 1
+#define VDR_Q1_0_g128_Q8_1_MMQ  4
+
+// Core Q1→Q8 dot product: unpacks 1-bit values to ±1 signed bytes, uses dp4a
+template <int vdr>
+static __device__ __forceinline__ float vec_dot_q1_0_q8_1_impl(
+    const int* v, const int* u, const float& d1, const half2& ds8) {
+
+  int sumi = 0;
+
+#pragma unroll
+  for (int i = 0; i < vdr; ++i) {
+    const int vi = v[i];
+
+    // Unpack 32 bits into 8 packed int32s (each holding 4 signed bytes: -1 or +1)
+    int vi_bytes[8];
+
+#pragma unroll
+    for (int j = 0; j < 8; ++j) {
+      const int shift = j * 4;
+      const int bits4 = (vi >> shift) & 0x0F;
+
+      const int b0 = (bits4 & 0x01) ? 1 : -1;
+      const int b1 = (bits4 & 0x02) ? 1 : -1;
+      const int b2 = (bits4 & 0x04) ? 1 : -1;
+      const int b3 = (bits4 & 0x08) ? 1 : -1;
+
+      vi_bytes[j] = (b0 & 0xFF) | ((b1 & 0xFF) << 8) | ((b2 & 0xFF) << 16) | ((b3 & 0xFF) << 24);
+    }
+
+    // dp4a: 4-way signed int8 dot product against Q8_1 quantized activations
+#pragma unroll
+    for (int j = 0; j < 8; ++j) {
+      sumi = __dp4a(vi_bytes[j], u[8 * i + j], sumi);
+    }
+  }
+
+  const float2 ds8f = __half22float2(ds8);
+  return d1 * ds8f.x * sumi;
+}
+
+// MMVQ wrapper for Q1_0 (32 elements per block)
+static __device__ __forceinline__ float vec_dot_q1_0_q8_1(
+    const void* __restrict__ vbq, const block_q8_1* __restrict__ bq8_1,
+    const int& iqs) {
+
+  const block_q1_0* bq1_0 = (const block_q1_0*)vbq;
+
+  int v[VDR_Q1_0_Q8_1_MMVQ];
+  int u[8 * VDR_Q1_0_Q8_1_MMVQ];
+
+  v[0] = bq1_0->qs[0] | (bq1_0->qs[1] << 8) | (bq1_0->qs[2] << 16) | (bq1_0->qs[3] << 24);
+
+#pragma unroll
+  for (int j = 0; j < 8; ++j) {
+    u[j] = get_int_b4(bq8_1->qs, j);
+  }
+
+  return vec_dot_q1_0_q8_1_impl<VDR_Q1_0_Q8_1_MMVQ>(v, u, __half2float(bq1_0->d), bq8_1->ds);
+}
+
+// MMVQ wrapper for Q1_0_G128 (128 elements per block, 4 chunks of 32)
+static __device__ __forceinline__ float vec_dot_q1_0_g128_q8_1(
+    const void* __restrict__ vbq, const block_q8_1* __restrict__ bq8_1,
+    const int& iqs) {
+
+  const block_q1_0_g128* bq1_g128 = (const block_q1_0_g128*)vbq;
+
+  const float d1 = __half2float(bq1_g128->d);
+  const block_q8_1* bq8_1_chunk = bq8_1 + iqs;
+
+  const int offset = iqs * 4;
+  const int v = bq1_g128->qs[offset + 0] | (bq1_g128->qs[offset + 1] << 8) |
+                (bq1_g128->qs[offset + 2] << 16) | (bq1_g128->qs[offset + 3] << 24);
+
+  int vi_bytes[8];
+#pragma unroll
+  for (int j = 0; j < 8; ++j) {
+    const int shift = j * 4;
+    const int bits4 = (v >> shift) & 0x0F;
+    const int b0 = (bits4 & 0x01) ? 1 : -1;
+    const int b1 = (bits4 & 0x02) ? 1 : -1;
+    const int b2 = (bits4 & 0x04) ? 1 : -1;
+    const int b3 = (bits4 & 0x08) ? 1 : -1;
+    vi_bytes[j] = (b0 & 0xFF) | ((b1 & 0xFF) << 8) | ((b2 & 0xFF) << 16) | ((b3 & 0xFF) << 24);
+  }
+
+  int sumi = 0;
+#pragma unroll
+  for (int j = 0; j < 8; ++j) {
+    const int uj = get_int_b4(bq8_1_chunk->qs, j);
+    sumi = __dp4a(vi_bytes[j], uj, sumi);
+  }
+
+  const float2 ds8f = __half22float2(bq8_1_chunk->ds);
+  return d1 * ds8f.x * sumi;
+}
+
 #define VDR_Q4_0_Q8_1_MMVQ 2
 #define VDR_Q4_0_Q8_1_MMQ  4
 

--- a/vllm/model_executor/layers/quantization/gguf.py
+++ b/vllm/model_executor/layers/quantization/gguf.py
@@ -190,6 +190,11 @@ IMATRIX_QUANT_TYPES = {
     WeightType.IQ4_XS,
     WeightType.IQ4_NL,
 }
+
+# PRISM 1-bit types — kept separate from shared sets to avoid
+# routing into MoE/MMQ paths that lack Q1_0 kernel support.
+PRISM_Q1_TYPES = {42, 43}  # Q1_0, Q1_0_G128
+
 # TODO(Isotr0py): Currently, we don't have MMQ kernel for I-Matrix quantization.
 # Consolidate DEQUANT_TYPES, MMVQ_QUANT_TYPES and MMQ_QUANT_TYPES after we add
 # MMQ kernel for I-Matrix quantization.
@@ -203,6 +208,9 @@ def _fused_mul_mat_gguf(
 ) -> torch.Tensor:
     if qweight_type in IMATRIX_QUANT_TYPES:
         mmvq_safe = 8 if qweight.shape[0] > 5120 else 16
+    elif qweight_type in PRISM_Q1_TYPES:
+        # PRISM 1-bit: MMVQ only safe for batch=1 on RDNA2
+        mmvq_safe = 1
     else:
         mmvq_safe = 2 if qweight.shape[0] > 5120 else 6
     # HACK: when doing chunked prefill we don't generate output tokens
@@ -212,6 +220,17 @@ def _fused_mul_mat_gguf(
     # there is no need to call any kernel for fp16/bf16
     if qweight_type in UNQUANTIZED_TYPES:
         return x @ qweight.T
+    # PRISM Q1: MMVQ fast path for small batches, dequant fallback for larger
+    if qweight_type in PRISM_Q1_TYPES:
+        if x.shape[0] <= mmvq_safe:
+            y = ops.ggml_mul_mat_vec_a8(qweight, x, qweight_type, qweight.shape[0])
+        else:
+            from .gguf_compat import PRISM_QUANT_SIZES
+            block_size, type_size = PRISM_QUANT_SIZES[qweight_type]
+            shape = (qweight.shape[0], qweight.shape[1] // type_size * block_size)
+            weight = ops.ggml_dequantize(qweight, qweight_type, *shape, x.dtype)
+            y = x @ weight.T
+        return y
     # enable MMVQ in contiguous batching with batch_size=1
     if x.shape[0] <= mmvq_safe and qweight_type in MMVQ_QUANT_TYPES:
         y = ops.ggml_mul_mat_vec_a8(qweight, x, qweight_type, qweight.shape[0])

--- a/vllm/model_executor/layers/quantization/gguf_compat.py
+++ b/vllm/model_executor/layers/quantization/gguf_compat.py
@@ -1,0 +1,201 @@
+"""PRISM Q1_0/Q1_0_G128 compatibility layer for vLLM GGUF support.
+
+PRISM 1-bit quantization uses custom GGUF type IDs (42, 43) that are
+not in the upstream gguf library's GGMLQuantizationType enum.  On disk,
+older files may use IDs 40/41 which we remap to 42/43 at read time.
+
+This module patches the gguf library so that:
+  - GGML_QUANT_SIZES knows Q1_0 (32, 6) and Q1_0_G128 (128, 18)
+  - gguf.quants can CPU-dequantize PRISM blocks
+  - GGUFReader._build_tensors handles the disk→runtime remap
+"""
+from __future__ import annotations
+
+import numpy as np
+
+# PRISM type IDs (runtime)
+PRISM_Q1_0 = 42
+PRISM_Q1_0_G128 = 43
+
+# Disk-format IDs that must be remapped
+PRISM_DISK_TYPE_REMAP = {
+    40: PRISM_Q1_0,
+    41: PRISM_Q1_0_G128,
+}
+
+PRISM_TYPE_NAMES = {
+    PRISM_Q1_0: "Q1_0",
+    PRISM_Q1_0_G128: "Q1_0_G128",
+}
+
+PRISM_QUANT_SIZES = {
+    PRISM_Q1_0: (32, 6),       # 32 elements, 6 bytes per block
+    PRISM_Q1_0_G128: (128, 18),  # 128 elements, 18 bytes per block
+}
+
+
+def prism_type_name(tensor_type) -> str:
+    """Get a human-readable name for any GGUF tensor type (enum or int)."""
+    name = getattr(tensor_type, "name", None)
+    if name is not None:
+        return name
+    try:
+        type_int = int(tensor_type)
+    except Exception:
+        return str(tensor_type)
+    return PRISM_TYPE_NAMES.get(type_int, str(type_int))
+
+
+def is_prism_type(tensor_type) -> bool:
+    """Check whether a tensor type is a PRISM Q1 variant."""
+    try:
+        return int(tensor_type) in (PRISM_Q1_0, PRISM_Q1_0_G128)
+    except Exception:
+        return False
+
+
+# CPU dequantization helpers (for model loading / weight conversion)
+def _dequantize_prism_q1_blocks(
+    blocks: np.ndarray, block_size: int
+) -> np.ndarray:
+    scales = blocks[:, :2].reshape(-1, 2).view(np.float16).astype(np.float32)
+    signs = np.unpackbits(blocks[:, 2:], axis=1, bitorder="little")[
+        :, :block_size
+    ]
+    values = np.where(signs == 1, scales, -scales).astype(np.float32)
+    return values
+
+
+def _dequantize_prism_q1(
+    data: np.ndarray, block_size: int, type_size: int
+) -> np.ndarray:
+    rows = np.ascontiguousarray(data.view(np.uint8))
+    if rows.shape[-1] % type_size != 0:
+        raise ValueError(
+            f"Invalid Prism GGUF byte shape {rows.shape} "
+            f"for block size {block_size}"
+        )
+    block_count = rows.shape[-1] // type_size
+    flat_blocks = rows.reshape(-1, type_size)
+    dequant = _dequantize_prism_q1_blocks(flat_blocks, block_size)
+    return dequant.reshape(*rows.shape[:-1], block_count * block_size)
+
+
+class _PrismQ10Compat:
+    @classmethod
+    def dequantize(cls, tensor: np.ndarray) -> np.ndarray:
+        return _dequantize_prism_q1(tensor, block_size=32, type_size=6)
+
+
+class _PrismQ10G128Compat:
+    @classmethod
+    def dequantize(cls, tensor: np.ndarray) -> np.ndarray:
+        return _dequantize_prism_q1(tensor, block_size=128, type_size=18)
+
+
+def ensure_prism_gguf_compat() -> None:
+    """Monkey-patch the gguf library to understand PRISM Q1_0 types.
+
+    Safe to call multiple times; the patch is applied only once.
+    """
+    try:
+        import gguf
+        import gguf.gguf_reader as gguf_reader
+        import gguf.quants as gguf_quants
+    except ImportError:
+        return
+
+    if getattr(gguf, "_vllm_prism_gguf_compat", False):
+        return
+
+    # Register quant sizes
+    gguf.GGML_QUANT_SIZES[PRISM_Q1_0] = (32, 6)
+    gguf.GGML_QUANT_SIZES[PRISM_Q1_0_G128] = (128, 18)
+    gguf_quants.GGML_QUANT_SIZES[PRISM_Q1_0] = (32, 6)
+    gguf_quants.GGML_QUANT_SIZES[PRISM_Q1_0_G128] = (128, 18)
+    gguf_quants._type_traits[PRISM_Q1_0] = _PrismQ10Compat
+    gguf_quants._type_traits[PRISM_Q1_0_G128] = _PrismQ10G128Compat
+
+    # Patch _build_tensors to handle PRISM type IDs.
+    # Standard types keep their GGMLQuantizationType enum value;
+    # PRISM types become plain ints (42/43).
+    original_build_tensors = gguf_reader.GGUFReader._build_tensors
+
+    def _build_tensors_with_prism(self, start_offs, fields) -> None:
+        tensors = []
+        tensor_names: set[str] = set()
+
+        for field in fields:
+            (_name_len, name_data, _n_dims, dims,
+             raw_dtype, offset_tensor) = field.parts
+
+            tensor_name = str(bytes(name_data), encoding="utf-8")
+            if tensor_name in tensor_names:
+                raise ValueError(
+                    f"Found duplicated tensor with name {tensor_name}"
+                )
+            tensor_names.add(tensor_name)
+
+            raw_qtype = int(raw_dtype[0])
+            ggml_type = PRISM_DISK_TYPE_REMAP.get(raw_qtype, raw_qtype)
+
+            # For standard types, preserve enum; for PRISM, use int
+            try:
+                tensor_type = gguf.GGMLQuantizationType(ggml_type)
+            except ValueError:
+                tensor_type = ggml_type  # PRISM or unknown → raw int
+
+            n_elems = int(np.prod(dims))
+            np_dims = tuple(reversed(dims.tolist()))
+            block_size, type_size = gguf.GGML_QUANT_SIZES[ggml_type]
+            n_bytes = n_elems * type_size // block_size
+            data_offs = int(start_offs + offset_tensor[0])
+
+            if tensor_type == gguf.GGMLQuantizationType.F16:
+                item_count = n_elems
+                item_type = np.float16
+            elif tensor_type == gguf.GGMLQuantizationType.F32:
+                item_count = n_elems
+                item_type = np.float32
+            elif tensor_type == gguf.GGMLQuantizationType.F64:
+                item_count = n_elems
+                item_type = np.float64
+            elif tensor_type == gguf.GGMLQuantizationType.I8:
+                item_count = n_elems
+                item_type = np.int8
+            elif tensor_type == gguf.GGMLQuantizationType.I16:
+                item_count = n_elems
+                item_type = np.int16
+            elif tensor_type == gguf.GGMLQuantizationType.I32:
+                item_count = n_elems
+                item_type = np.int32
+            elif tensor_type == gguf.GGMLQuantizationType.I64:
+                item_count = n_elems
+                item_type = np.int64
+            else:
+                item_count = n_bytes
+                item_type = np.uint8
+                np_dims = gguf_reader.quant_shape_to_byte_shape(
+                    np_dims, ggml_type
+                )
+
+            tensors.append(
+                gguf_reader.ReaderTensor(
+                    name=tensor_name,
+                    tensor_type=tensor_type,
+                    shape=dims,
+                    n_elements=n_elems,
+                    n_bytes=n_bytes,
+                    data_offset=data_offs,
+                    data=self._get(
+                        data_offs, item_type, item_count
+                    ).reshape(np_dims),
+                    field=field,
+                )
+            )
+
+        self.tensors = tensors
+
+    gguf_reader.GGUFReader._build_tensors = _build_tensors_with_prism
+    gguf._vllm_prism_gguf_compat = True
+    gguf._vllm_prism_original_build_tensors = original_build_tensors

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -55,6 +55,11 @@ try:
 except ImportError:
     gguf = PlaceholderModule("gguf")
 
+from vllm.model_executor.layers.quantization.gguf_compat import (
+    ensure_prism_gguf_compat,
+    prism_type_name,
+)
+
 try:
     from fastsafetensors import SafeTensorsFileLoader, SingleGroup
 except ImportError:
@@ -1247,9 +1252,10 @@ def get_gguf_weight_type_map(
     """
     Return GGUF mapped weight's name and its quant type
     """
+    ensure_prism_gguf_compat()
     reader = gguf.GGUFReader(gguf_file)
     return {
-        gguf_to_hf_name_map[tensor.name]: tensor.tensor_type.name
+        gguf_to_hf_name_map[tensor.name]: prism_type_name(tensor.tensor_type)
         for tensor in reader.tensors
         if tensor.name in gguf_to_hf_name_map
     }
@@ -1267,6 +1273,7 @@ def gguf_quant_weights_iterator(
     layer with different quant types.
     """
 
+    ensure_prism_gguf_compat()
     reader = gguf.GGUFReader(gguf_file)
 
     for tensor in reader.tensors:
@@ -1274,7 +1281,7 @@ def gguf_quant_weights_iterator(
             weight_type = tensor.tensor_type
             name = gguf_to_hf_name_map[tensor.name]
 
-            if weight_type.name not in ("F32", "BF16", "F16"):
+            if prism_type_name(weight_type) not in ("F32", "BF16", "F16"):
                 weight_type_name = name.replace("weight", "qweight_type")
                 weight_type = torch.tensor(weight_type)
                 yield weight_type_name, weight_type
@@ -1284,9 +1291,10 @@ def gguf_quant_weights_iterator(
             weight = tensor.data
             weight_type = tensor.tensor_type
             name = gguf_to_hf_name_map[tensor.name]
-            if weight_type.name not in ("F32", "BF16", "F16"):
+            type_name = prism_type_name(weight_type)
+            if type_name not in ("F32", "BF16", "F16"):
                 name = name.replace("weight", "qweight")
-            if weight_type.name == "BF16" and tensor.data.dtype == np.uint8:
+            if type_name == "BF16" and tensor.data.dtype == np.uint8:
                 # BF16 is currently the only "quantization" type that isn't
                 # actually quantized but is read as a raw byte tensor.
                 # Reinterpret as `torch.bfloat16` tensor.


### PR DESCRIPTION
## Summary

Add support for **PRISM Q1_0** (type 42) and **Q1_0_G128** (type 43) 1-bit quantization formats to the GGUF loader, enabling inference with PrismML Bonsai models.

## Models Supported

- [prism-ml/Bonsai-1.7B-gguf](https://huggingface.co/prism-ml/Bonsai-1.7B-gguf)
- [prism-ml/Bonsai-4B-gguf](https://huggingface.co/prism-ml/Bonsai-4B-gguf)
- [prism-ml/Bonsai-8B-gguf](https://huggingface.co/prism-ml/Bonsai-8B-gguf)

## Changes

### CUDA/HIP Kernels (csrc/quantization/gguf/)
- **ggml-common.h**: Add `block_q1_0` (32-element, 6 bytes) and `block_q1_0_g128` (128-element, 18 bytes) structs
- **dequantize.cuh**: Dequantize functions for both Q1_0 variants (ternary {-1, 0, +1} × scale + min)
- **vecdotq.cuh**: dp4a-accelerated `vec_dot` kernels for Q1_0 and Q1_0_G128
- **mmvq.cuh**: MMVQ dispatch for batch≤1 fast path
- **gguf_kernel.cu**: Switch-case integration for new type IDs

### Python Integration
- **gguf.py**: Register `PRISM_Q1_TYPES = {42, 43}` in quant type set
- **gguf_compat.py**: New 201-LOC compatibility module that patches the gguf library at import time to recognize Q1_0/Q1_0_G128 (type IDs 42, 43) with correct block sizes and type names
- **weight_utils.py**: Import gguf_compat for transparent type support

## Design

- **Q1_0** (type 42): 32-element blocks, 6 bytes per block (4-byte packed ternary bits + fp16 scale + fp16 min)
- **Q1_0_G128** (type 43): 128-element blocks, 18 bytes per block (16-byte packed bits + fp16 scale)
- MMVQ fast path for batch≤1; falls back to dequant+matmul for larger batches
- Ternary encoding: 2 bits per weight → {-1, 0, +1} × scale + min

## Testing

Tested with PrismML Bonsai-8B-gguf on ROCm (gfx1030/gfx1031). Model loads, dequantizes, and produces correct output.
