### PR TITLE
[Bugfix] Reject non-nvfp4 dtypes when using the flashinfer_nvlink_one_sided all2all backend

### DIFF
--- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
+++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
@@ -225,6 +225,14 @@ def maybe_make_prepare_finalize(
 
     elif moe.use_fi_nvl_one_sided_kernels:
         assert quant_config is not None
+        if quant_config.quant_dtype != "nvfp4":
+            raise ValueError(
+                "The 'flashinfer_nvlink_one_sided' all2all backend only "
+                "supports nvfp4 activation quantization, but got "
+                f"quant_dtype={quant_config.quant_dtype!r}. Use a different "
+                "all2all backend (e.g. 'flashinfer_nvlink_two_sided' or "
+                "'allgather_reducescatter') for non-nvfp4 models."
+            )
         max_num_tokens = (
             get_current_vllm_config().scheduler_config.max_num_batched_tokens
         )


### PR DESCRIPTION
The flashinfer_nvlink_one_sided all2all backend hardcodes its workspace sizing for nvfp4 payloads (4-bit activations + fp8 block scales). 

See the hardcoding to datatype here:
https://github.com/vllm-project/vllm/blob/4d042ed85f3b8fe8c73b6a4a365e65cf1811823e/vllm/distributed/device_communicators/all2all.py#L720-L725

When used with bf16 or other dtypes, the undersized workspace causes silent data corruption and gibberish output. Add an explicit dtype check at backend selection time so unsupported configurations fail loudly with an actionable error message.
