### PR TITLE
[compile] Nest inductor cache under AOT compile dir

### DIFF
--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -511,8 +511,10 @@ def _support_torch_compile(
             self.compilation_config.local_cache_dir = cache_dir
             inductor_cache = os.path.join(cache_dir, "inductor_cache")
             os.makedirs(inductor_cache, exist_ok=True)
-            # Unconditional override: torch's cache_dir() may have already set
-            # this to the /tmp default during import, making setdefault a no-op.
+            # Process-wide: post-load execution, CUDA-graph capture, and later
+            # autotune/recompile all need to write under {hash}/inductor_cache/.
+            # Unconditional because torch's cache_dir() may have pre-filled the
+            # /tmp default during import, making setdefault a no-op.
             os.environ["TORCHINDUCTOR_CACHE_DIR"] = inductor_cache
 
             rank = self.vllm_config.parallel_config.rank

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -507,6 +507,14 @@ def _support_torch_compile(
                 hash_key,
             )
 
+            # Hash-level dir; shared across ranks on the same node.
+            self.compilation_config.local_cache_dir = cache_dir
+            inductor_cache = os.path.join(cache_dir, "inductor_cache")
+            os.makedirs(inductor_cache, exist_ok=True)
+            # Unconditional override: torch's cache_dir() may have already set
+            # this to the /tmp default during import, making setdefault a no-op.
+            os.environ["TORCHINDUCTOR_CACHE_DIR"] = inductor_cache
+
             rank = self.vllm_config.parallel_config.rank
             dp_rank = self.vllm_config.parallel_config.data_parallel_index
             cache_dir = os.path.join(cache_dir, f"rank_{rank}_{dp_rank}")


### PR DESCRIPTION


## Purpose

  With `VLLM_USE_AOT_COMPILE`, the mega-artifact is saved under `~/.cache/vllm/torch_compile_cache/torch_aot_compile/{hash}/rank_{r}_{dp}/model`, but on load Triton and Inductor unpack their on-disk state (fx_graph / aotautograd / triton cubins / generated `.py`) to                                                                                                                         
  `/tmp/torchinductor_$USER/` by default. Unless that directory is shipped as part of the deployment, every fresh environment pays the first-run unpack  cost, and `/tmp` is wiped on reboot so the cost repeats.                                                                                                                              
                                                                                                                                                                                        
  This PR sets `TORCHINDUCTOR_CACHE_DIR` to `{hash}/inductor_cache/` in the AOT  branch of `_support_torch_compile.__call__`, above the per-rank subdir . `TRITON_CACHE_DIR` is left  unset since PyTorch nests Triton under `{TORCHINDUCTOR_CACHE_DIR}/triton/{device}` by default.                                                                                                                                                                           
                                                                                                                                                                                        
  One run now produces a self-contained cache tree; shipping `{hash}/` alone is enough to skip the unpack step on fresh deployments:   
  torch_aot_compile/{hash}/                                                                                                                                                             
  ├── inductor_cache/      
  │   ├── fxgraph/, aotautograd/, {xx}/*.py                                                                                                                                             
  │   └── triton/{device}/   # cubins, ptx, ttir, launcher .so                                                                                                                          
  └── rank_{r}_{dp}/model                        

## Test Plan
after a run inspect `~/.cache/vllm/torch_compile_cache/torch_aot_compile/` and `/tmp/torchinductor_$USER/`.
## Test Result
  - 1st run: `{hash}/inductor_cache/` fully populated (fxgraph, aotautograd generated `.py`, `triton/0/` with `.cubin`/ etc);                                                                                                          
    `{hash}/rank_0_0/model` written; `/tmp/torchinductor_$USER/` empty.       
  - 2nd run: loads from cache, no recompile.  
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

