### PR TITLE
[ROCm] Fix AttributeError in GELU activations when C extension ops are absent on cuda_alike platforms

### DIFF
--- a/tests/kernels/core/test_activation.py
+++ b/tests/kernels/core/test_activation.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import random
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -114,6 +116,67 @@ def test_act_and_mul(
         opcheck(fn, (out, x, layer.alpha, layer.limit))
     elif activation != "swiglustep_and_mul":
         opcheck(fn, (out, x))
+
+
+@pytest.mark.parametrize(
+    "activation,approximate",
+    [
+        ("gelu_and_mul", "none"),
+        ("gelu_and_mul", "tanh"),
+        ("new_gelu", None),
+        ("fast_gelu", None),
+        ("quick_gelu", None),
+    ],
+)
+@pytest.mark.parametrize("num_tokens", [7, 83])
+@pytest.mark.parametrize("d", [512])
+@pytest.mark.parametrize("dtype", [torch.float, torch.bfloat16])
+@torch.inference_mode()
+def test_activation_cuda_alike_no_c_ext(
+    default_vllm_config,
+    activation: str,
+    approximate,
+    num_tokens: int,
+    d: int,
+    dtype: torch.dtype,
+) -> None:
+    """Regression test: activations must not crash on cuda_alike platforms
+    (e.g. ROCm) when the vLLM C++ extension was built without GPU support
+    and the _C ops are absent."""
+    # Simulate a cuda_alike platform whose _C extension has no custom ops.
+    empty_C = SimpleNamespace()  # no attributes → hasattr(...) is always False
+
+    with (
+        patch(
+            "vllm.model_executor.layers.activation.current_platform.is_cuda_alike",
+            return_value=True,
+        ),
+        patch(
+            "vllm.model_executor.layers.activation.current_platform.is_rocm",
+            return_value=False,
+        ),
+        patch(
+            "vllm.model_executor.layers.activation.current_platform.is_xpu",
+            return_value=False,
+        ),
+        patch("vllm.model_executor.layers.activation.torch.ops._C", empty_C),
+    ):
+        if activation == "gelu_and_mul":
+            x = torch.randn(num_tokens, 2 * d, dtype=dtype)
+            layer = GeluAndMul(approximate=approximate)
+        elif activation == "new_gelu":
+            x = torch.randn(num_tokens, d, dtype=dtype)
+            layer = NewGELU()
+        elif activation == "fast_gelu":
+            x = torch.randn(num_tokens, d, dtype=dtype)
+            layer = FastGELU()
+        elif activation == "quick_gelu":
+            x = torch.randn(num_tokens, d, dtype=dtype)
+            layer = QuickGELU()
+
+    out = layer(x)
+    ref_out = layer.forward_native(x)
+    torch.testing.assert_close(out, ref_out, atol=0.0, rtol=0.0)
 
 
 @pytest.mark.parametrize(

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -94,7 +94,10 @@ class FatreluAndMul(CustomOp):
         super().__init__()
         self.threshold = threshold
         if current_platform.is_cuda_alike():
-            self.op = torch.ops._C.fatrelu_and_mul
+            if hasattr(torch.ops._C, "fatrelu_and_mul"):
+                self.op = torch.ops._C.fatrelu_and_mul
+            else:
+                self._forward_method = self.forward_native
         elif current_platform.is_cpu():
             self._forward_method = self.forward_native
 
@@ -130,7 +133,10 @@ class SiluAndMul(CustomOp):
     def __init__(self, *, compile_native: bool = True):
         super().__init__(compile_native=compile_native)
         if current_platform.is_cuda_alike() or current_platform.is_xpu():
-            self.op = torch.ops._C.silu_and_mul
+            if hasattr(torch.ops._C, "silu_and_mul"):
+                self.op = torch.ops._C.silu_and_mul
+            else:
+                self._forward_method = self.forward_native
         elif current_platform.is_cpu():
             self._forward_method = self.forward_native
 
@@ -168,7 +174,10 @@ class MulAndSilu(CustomOp):
     def __init__(self):
         super().__init__()
         if current_platform.is_cuda_alike() or current_platform.is_xpu():
-            self.op = torch.ops._C.mul_and_silu
+            if hasattr(torch.ops._C, "mul_and_silu"):
+                self.op = torch.ops._C.mul_and_silu
+            else:
+                self._forward_method = self.forward_native
         elif current_platform.is_cpu():
             self._forward_method = self.forward_native
 
@@ -271,10 +280,11 @@ class GeluAndMul(CustomOp):
             or current_platform.is_cpu()
             or current_platform.is_xpu()
         ):
-            if approximate == "none":
-                self.op = torch.ops._C.gelu_and_mul
-            elif approximate == "tanh":
-                self.op = torch.ops._C.gelu_tanh_and_mul
+            op_name = "gelu_and_mul" if approximate == "none" else "gelu_tanh_and_mul"
+            if hasattr(torch.ops._C, op_name):
+                self.op = getattr(torch.ops._C, op_name)
+            else:
+                self._forward_method = self.forward_native
         if current_platform.is_rocm() and approximate == "tanh":
             logger.warning_once(
                 "[ROCm] PyTorch's native GELU with tanh approximation is unstable "
@@ -387,7 +397,10 @@ class NewGELU(CustomOp):
             or current_platform.is_cpu()
             or current_platform.is_xpu()
         ):
-            self.op = torch.ops._C.gelu_new
+            if hasattr(torch.ops._C, "gelu_new"):
+                self.op = torch.ops._C.gelu_new
+            else:
+                self._forward_method = self.forward_native
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
         """PyTorch-native implementation equivalent to forward()."""
@@ -415,7 +428,10 @@ class FastGELU(CustomOp):
             or current_platform.is_cpu()
             or current_platform.is_xpu()
         ):
-            self.op = torch.ops._C.gelu_fast
+            if hasattr(torch.ops._C, "gelu_fast"):
+                self.op = torch.ops._C.gelu_fast
+            else:
+                self._forward_method = self.forward_native
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
         """PyTorch-native implementation equivalent to forward()."""
@@ -443,7 +459,10 @@ class QuickGELU(CustomOp):
             or current_platform.is_cpu()
             or current_platform.is_xpu()
         ):
-            self.op = torch.ops._C.gelu_quick
+            if hasattr(torch.ops._C, "gelu_quick"):
+                self.op = torch.ops._C.gelu_quick
+            else:
+                self._forward_method = self.forward_native
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
         """PyTorch-native implementation equivalent to forward()."""


### PR DESCRIPTION
On AMD ROCm platforms like MI300A in APU mode, `is_cuda_alike()` returns `True` but the vLLM C extension may not have the GPU ops registered (e.g. when built without ROCm support), causing an `AttributeError` at model load time in `GeluAndMul`, `NewGELU`, `FastGELU`, and `QuickGELU`. This PR adds `hasattr` guards so these activations fall back to their pure-Python `forward_native` implementations when the `_C` ops are missing. A regression test is included that simulates this exact scenario by mocking `is_cuda_alike=True` with an empty `torch.ops._C` namespace.