### PR TITLE
[ROCm][CI] Fix condition for `test_per_token_group_quant_fp8_packed`

### DIFF
--- a/tests/kernels/quantization/test_per_token_group_quant.py
+++ b/tests/kernels/quantization/test_per_token_group_quant.py
@@ -81,7 +81,9 @@ def test_per_token_group_quant_fp8(
     ],
 )
 @pytest.mark.parametrize("poisoned_scales", [False, True])
-@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA not available")
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="DeepGEMM not available on this platform"
+)
 def test_per_token_group_quant_fp8_packed(
     num_tokens, hidden_dim, group_size, poisoned_scales
 ):

--- a/tests/kernels/quantization/test_per_token_group_quant.py
+++ b/tests/kernels/quantization/test_per_token_group_quant.py
@@ -6,6 +6,7 @@ import pytest
 import torch
 
 from vllm.model_executor.layers.quantization.utils import fp8_utils, int8_utils
+from vllm.platforms import current_platform
 
 
 @pytest.mark.parametrize(
@@ -80,7 +81,7 @@ def test_per_token_group_quant_fp8(
     ],
 )
 @pytest.mark.parametrize("poisoned_scales", [False, True])
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA not available")
+@pytest.mark.skipif(not current_platform.is_cuda(), reason="CUDA not available")
 def test_per_token_group_quant_fp8_packed(
     num_tokens, hidden_dim, group_size, poisoned_scales
 ):


### PR DESCRIPTION

Kernels Quantization Test is failing on main since the `test_per_token_group_quant_fp8_packed` test was added in https://github.com/vllm-project/vllm/pull/39547, which tests a feature that is unavailable on ROCm. This PR updates the pytest.skip condition so that this test is skipped on non-CUDA platforms.
