### PR TITLE
[Core] Cache PostGradPassManager.uuid by compile_range

### DIFF
--- a/vllm/compilation/passes/pass_manager.py
+++ b/vllm/compilation/passes/pass_manager.py
@@ -94,6 +94,7 @@ class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
 
     def __init__(self) -> None:
         self.passes: list[InductorPass] = []
+        self._uuid_cache: dict[str, str] = {}
 
     @with_pattern_match_debug
     def __call__(self, graph: fx.Graph) -> None:
@@ -131,6 +132,7 @@ class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
 
     def configure(self, config: VllmConfig) -> None:
         self.pass_config = config.compilation_config.pass_config
+        self._uuid_cache.clear()
 
         # Set the current vllm config to allow tracing CustomOp instances
         with set_current_vllm_config(config, check_compile=False):
@@ -190,6 +192,7 @@ class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
     def add(self, pass_: InductorPass) -> None:
         assert isinstance(pass_, InductorPass)
         self.passes.append(pass_)
+        self._uuid_cache.clear()
 
     def uuid(self) -> str:
         """
@@ -197,6 +200,10 @@ class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
         affects compilation caching. Its uuid depends on the UUIDs of all
         dependent passes and the pass config. See InductorPass for more info.
         """
+        key = str(get_pass_context().compile_range)
+        if key in self._uuid_cache:
+            return self._uuid_cache[key]
+
         passes = []
 
         state: dict[str, Any] = {"pass_config": self.pass_config.compute_hash()}
@@ -211,6 +218,8 @@ class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
 
         # Include the compile range in the uuid to ensure that inductor
         # recompiles the graph for the new dynamic compile range.
-        state["compile_range"] = str(get_pass_context().compile_range)
+        state["compile_range"] = key
         state["passes"] = passes
-        return InductorPass.hash_dict(state)
+        result = InductorPass.hash_dict(state)
+        self._uuid_cache[key] = result
+        return result


### PR DESCRIPTION
## Purpose
PostGradPassManager.uuid() is called repeatedly during compilation —
once per compile range per subgraph. It iterates all passes calling
.uuid() on each (which triggers hash_source / inspect.getsource),
computes pass_config.compute_hash(), and hashes builtin passes. The
only part that varies between calls is compile_range; everything else
is fixed after configure().

Add a _uuid_cache dict keyed by compile_range string. On cache hit,
skip the entire pass iteration and hashing. The cache is cleared in
configure() and add() — the only methods that mutate pass state.

## Test Plan
- tests/compile/passes/test_pass_manager.py
- E2E: meta-llama/Meta-Llama-3-70B-Instruct, TP=4, cold compile

## Test Result
- 4/4 tests passed in test_pass_manager.py
- uuid() per-call: 0.001-0.002ms (baseline 0.039-0.050ms, ~25x speedup)
- With ~1288 calls per compilation: saves ~50ms total
- Cold compile time: 29.9s ± 1.0s (baseline 29.2s ± 0.5s) — no
  meaningful E2E difference (expected: cold compile sees each range
  only once, so the cache never hits; benefit is on warm path)