### PR TITLE
[Core] Pass donate_graph_module=True to standalone_compile

### DIFF
--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -295,6 +295,9 @@ class InductorStandaloneAdaptor(CompilerInterface):
             },
         }
 
+        if is_torch_equal_or_newer("2.13.0.dev"):
+            compile_kwargs["donate_graph_module"] = True  # type: ignore[assignment]
+
         use_aot: bool = supports_aot and envs.VLLM_USE_MEGA_AOT_ARTIFACT
         # only add 'aot' parameter if both supported and enabled...
         # this will set bundled_autograd_cache


### PR DESCRIPTION
## Purpose
Pass donate_graph_module=True to standalone_compile for PyTorch >= 2.13dev.
This allows standalone_compile to take ownership of the graph module,
avoiding unnecessary copies.

## Test Plan
Compile benchmark: 1 repeat, Llama-3-70B, TP=4, cold compile.

## Test Result
No regression:
- Current: 29.1s (n=1)
- Parent:  29.4s (n=1)

Expected improvement is ~0.1s which is hard to measure with the
end-to-end benchmark. Confirmed the copy elimination with tlparse.

Authored with Claude.