### PR TITLE
[v1] Expose num_prompt_tokens in CommonAttentionMetadata

### DIFF
--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -388,6 +388,12 @@ class CommonAttentionMetadata:
     (num_computed_tokens < num_prompt_tokens). Used by some backends to
     distinguish actual decodes from short extends."""
 
+    num_prompt_tokens: torch.Tensor | None = None
+    """(batch_size,) int tensor: original prompt length for each request.
+    Needed by dual-cache RoPE implementations (e.g. LongRoPE SplitByLength)
+    to select the correct cache per-sequence under chunked prefill, where
+    positions.max() of a chunk does not reflect the full prompt length."""
+
     # WARNING: Deprecated fields. Will be removed in a future release (v0.15.0)
     _seq_lens_cpu: torch.Tensor | None = None
     _num_computed_tokens_cpu: torch.Tensor | None = None
@@ -470,6 +476,7 @@ class CommonAttentionMetadata:
             dcp_local_seq_lens=maybe_slice_reqs(self.dcp_local_seq_lens),
             dcp_local_seq_lens_cpu=maybe_slice_reqs(self.dcp_local_seq_lens_cpu),
             is_prefilling=maybe_slice_reqs(self.is_prefilling),
+            num_prompt_tokens=maybe_slice_reqs(self.num_prompt_tokens),
         )
 
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2192,6 +2192,7 @@ class GPUModelRunner(
             slot_mapping=slot_mapping_gid_0,
             causal=True,
             is_prefilling=is_prefilling,
+            num_prompt_tokens=num_prompt_tokens_cpu,
         )
 
         if self.dcp_world_size > 1:


### PR DESCRIPTION
## Summary

Add `num_prompt_tokens` (per-request original prompt length) to `CommonAttentionMetadata` so that model layers can access it during the forward pass via `get_forward_context()`.

## Motivation

Dual-cache RoPE implementations like LongRoPE's `SplitByLength` need to select SHORT vs LONG cache based on each request's **total prompt length**, not the current chunk's `positions.max()`. Under chunked prefill (`max_num_batched_tokens < prompt_length`), a long sequence is split into multiple chunks. Early chunks have `positions.max() < len0` (the SHORT/LONG threshold), causing them to incorrectly use the SHORT cache, while later chunks use the LONG cache. This produces mismatched RoPE embeddings in the KV cache and destroys model output quality for long contexts.

The existing `Phi3LongRoPEScaledRotaryEmbedding` avoids this by making an init-time decision based on `max_model_len`, but this forces all requests to use the same cache regardless of their actual prompt length. With `num_prompt_tokens` available in the forward context, RoPE implementations can make per-sequence decisions — matching the behavior of TRT-LLM's per-sequence `original_prompt_length` selection in its attention kernels.

## Changes

- **`vllm/v1/attention/backend.py`**: Add optional `num_prompt_tokens: torch.Tensor | None` field to `CommonAttentionMetadata`, with handling in `unpadded()`.
- **`vllm/v1/worker/gpu_model_runner.py`**: Pass the already-computed `num_prompt_tokens_cpu` tensor when constructing `CommonAttentionMetadata`.

The data already exists in `InputBatch.num_prompt_tokens` (set once at `add_request` time). This change simply threads it through to where model code can read it.

## Impact

- No behavioral change for existing models — the field defaults to `None` and is only read by models that opt in.
- Enables correct per-sequence LongRoPE cache selection under chunked prefill without monkey-patching.