### PR TITLE
add warning when FP8 KV cache misses prefill query quantization

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1443,6 +1443,19 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
                 scope="local",
             )
             return model_dtype
+        elif (
+            is_quantized_kv_cache(vllm_config.cache_config.cache_dtype)
+            and backend_supports_prefill_query_quantization()
+        ):
+            logger.warning_once(
+                "FP8 KV cache is enabled but prefill queries are not "
+                "quantized to FP8. For long-context workloads (ISL >= 4K), "
+                "enabling FP8 prefill attention can significant optimize "
+                "prefill latency. To enable, add: "
+                '--attention-config \'{"use_prefill_query_quantization"'
+                ": true}'",
+                scope="local",
+            )
 
         return model_dtype
 

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -1450,7 +1450,7 @@ class MLACommonMetadataBuilder(AttentionMetadataBuilder[M]):
             logger.warning_once(
                 "FP8 KV cache is enabled but prefill queries are not "
                 "quantized to FP8. For long-context workloads (ISL >= 4K), "
-                "enabling FP8 prefill attention can significant optimize "
+                "enabling FP8 prefill attention can significantly optimize "
                 "prefill latency. To enable, add: "
                 '--attention-config \'{"use_prefill_query_quantization"'
                 ": true}'",


### PR DESCRIPTION
## Purpose

add a startup warning log when FP8 KV cache is enabled (`--kv-cache-dtype fp8`) but `use_prefill_query_quantization` is not set, so users are aware of the FP8 prefill attention option.

Resolves #39751 

**Background**: Per PR #31195 by @pavanimajety, FP8 prefill query quantization was intentionally gated behind `use_prefill_query_quantization=true` because it regresses short-sequence performance (~20% at ISL=1024). However, for long-context workloads (ISL >= 4K), the FP8 FMHA kernel is significantly faster (up to 1.4x at 128K). Currently, users with `--kv-cache-dtype fp8` silently get BF16 prefill attention with no indication that a faster path exists.

This PR adds a `warning_once` log in `determine_prefill_query_data_type()` for the case where FP8 KV cache is active and the backend supports FP8 prefill, but the user has not enabled it. The warning includes the exact `--attention-config` flag.

no default behavior is changed.

## Test Plan

1. Start vLLM with FP8 KV cache but **without** the flag:
```bash
vllm serve <model> --kv-cache-dtype fp8
```
Verify the warning appears in startup logs:
```
WARNING: FP8 KV cache is enabled but prefill queries are not quantized to FP8. 
For long-context workloads (ISL >= 4K), enabling FP8 prefill attention can 
significantly improve prefill latency. To enable, add: 
--attention-config '{"use_prefill_query_quantization": true}'
```

2. Start with the flag **enabled** — verify **no** warning, and the existing info log appears instead:
```bash
vllm serve <model> --kv-cache-dtype fp8 \
  --attention-config '{"use_prefill_query_quantization": true}'
```
Expected: `INFO: FP8 prefill attention enabled: query data type is FP8`

3. Start **without** FP8 KV cache — verify **no** warning:
```bash
vllm serve <model>
```

## Test Result

Profiling results on GB300 (DeepSeek-R1-FP4, DP=4, ISL=128K) showing the speedup users miss without this flag:

| Kernel Variant | Avg Latency |
|---|---|
| `fmhaSm103aKernel_QkvBfloat16` (default) | 287 ms |
| `fmhaSm103aKernel_QkvE4m3` (with flag) | 225 ms |
| **Speedup** | **1.28x** |

### Short-Seq Benchmark

To verify whether the cast overhead has improved since the original analysis (Dec 2025), we ran end-to-end benchmarks on GB300 with the following setup:

- **Model**: DeepSeek-R1-0528-FP4
- **Parallelism**: DP=4 (matching Pavani's PR #31195 config, but we used `max-model-len=34816` to also test ISL=4096)
- **KV cache**: `fp8`
- **Platform**: GB300

| ISL | BF16 Throughput (tok/s) | FP8 Throughput (tok/s) | FP8 / BF16 | Mean TTFT (BF16) | Mean TTFT (FP8) |
|---|---|---|---|---|---|
| 1024 | 15,803 | 12,562 | **79.5%** | 24.8 s | 38.2 s |
| 4096 | 80,861 | 83,799 | **103.6%** | 5.25 s | 5.16 s |

**Findings**:
- ISL=1024: FP8 prefill still regresses **~20%** in throughput, confirming the current default is correct.
- ISL=4096: Crossover point — FP8 is ~3.6% faster.
