### PR TITLE
[Bugfix][ROCm]: Allow `gpt_oss_mxfp4` quantization method on rocm

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -412,6 +412,7 @@ class RocmPlatform(Platform):
         "gguf",
         "quark",
         "mxfp4",
+        "gpt_oss_mxfp4",
         "torchao",
         "bitsandbytes",
         "modelopt_fp4",


### PR DESCRIPTION
## Purpose
#39604 added the `gpt_oss_mxfp4` quantization method, but did not add it to the list of `supported_quantization` methods that `rocm.py` maintains. Running `vllm serve --model openai/gpt-oss-120b` thus gives me the following error:

```
VLLM_ROCM_USE_AITER=1 vllm bench latency --model openai/gpt-oss-120b --batch-size 32 --input-len 16 --output-len 16 --num-iters-warmup 1
 --num-iters 3 --attention-backend ROCM_AITER_UNIFIED_ATTN
WARNING 04-14 00:24:08 [gpt_oss_triton_kernels_moe.py:58] Using legacy triton_kernels on ROCm
INFO 04-14 00:24:09 [utils.py:233] non-default args: {'enable_prefix_caching': False, 'enable_lora': None, 'reasoning_parser_plugin': '', 'attention_backend': 'ROCM_AITER_UNIFIED_ATTN', 'model': 'openai/gpt-oss-120b'}
INFO 04-14 00:24:26 [model.py:554] Resolved architecture: GptOssForCausalLM
Parse safetensors files: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 15/15 [00:02<00:00,  5.54it/s]
INFO 04-14 00:24:29 [model.py:1685] Using max model len 131072
[aiter] start build [module_aiter_enum] under /usr/local/lib/python3.12/dist-packages/aiter/jit/build/module_aiter_enum
[aiter] finish build [module_aiter_enum], cost 25.4s 
[aiter] import [module_aiter_enum] under /usr/local/lib/python3.12/dist-packages/aiter/jit/module_aiter_enum.so
Traceback (most recent call last):
  File "/usr/local/bin/vllm", line 33, in <module>
    sys.exit(load_entry_point('vllm', 'console_scripts', 'vllm')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ropotdar/Desktop/vllm/vllm/entrypoints/cli/main.py", line 75, in main
    args.dispatch_function(args)
  File "/home/ropotdar/Desktop/vllm/vllm/entrypoints/cli/benchmark/latency.py", line 21, in cmd
    main(args)
  File "/home/ropotdar/Desktop/vllm/vllm/benchmarks/latency.py", line 87, in main
    llm = LLM.from_engine_args(engine_args)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ropotdar/Desktop/vllm/vllm/entrypoints/llm.py", line 413, in from_engine_args
    return cls(**vars(engine_args))
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ropotdar/Desktop/vllm/vllm/entrypoints/llm.py", line 381, in __init__
    self.llm_engine = LLMEngine.from_engine_args(
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ropotdar/Desktop/vllm/vllm/v1/engine/llm_engine.py", line 163, in from_engine_args
    vllm_config = engine_args.create_engine_config(usage_context)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ropotdar/Desktop/vllm/vllm/engine/arg_utils.py", line 1584, in create_engine_config
    model_config = self.create_model_config()
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ropotdar/Desktop/vllm/vllm/engine/arg_utils.py", line 1432, in create_model_config
    return ModelConfig(
           ^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/dist-packages/pydantic/_internal/_dataclasses.py", line 121, in __init__
    s.__pydantic_validator__.validate_python(ArgsKwargs(args, kwargs), self_instance=s)
pydantic_core._pydantic_core.ValidationError: 1 validation error for ModelConfig
  Value error, gpt_oss_mxfp4 quantization is currently not supported in rocm. [type=value_error, input_value=ArgsKwargs((), {'model': ...nderer_num_workers': 1}), input_type=ArgsKwargs]
    For further information visit https://errors.pydantic.dev/2.13/v/value_error
```

This PR fixes the error. As an aside, ROCm seems to be the only platform that maintains such a list-do we know if we still want it here? I think it makes more sense for the quantization method itself to specify the supported platform(s), rather than this list at the platform level.

cc @gshtras @tjtanaa @mgoin @zyongye

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

