### PR TITLE
PD disagg: skip decode-side re-tokenization in PD serving with vllm-router + NixlConnector

### DIFF
--- a/tests/entrypoints/openai/test_skip_decode_tokenization.py
+++ b/tests/entrypoints/openai/test_skip_decode_tokenization.py
@@ -1,0 +1,511 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for skipping decode-side tokenization in PD disaggregated serving.
+
+When the router forwards pre-tokenized prompt_token_ids from the prefill
+response, the decode side should skip chat template rendering and
+tokenization (render_chat_async) and use the token IDs directly.
+"""
+
+from contextlib import suppress
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.config import MultiModalConfig
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.entrypoints.openai.models.serving import (
+    BaseModelPath,
+    OpenAIServingModels,
+)
+from vllm.entrypoints.serve.render.serving import OpenAIServingRender
+from vllm.renderers.hf import HfRenderer
+from vllm.tokenizers.registry import tokenizer_args_from_config
+from vllm.v1.engine.async_llm import AsyncLLM
+
+MODEL_NAME = "openai-community/gpt2"
+BASE_MODEL_PATHS = [BaseModelPath(name=MODEL_NAME, model_path=MODEL_NAME)]
+# GPT-2's default chat template
+CHAT_TEMPLATE = (
+    "{% for message in messages %}"
+    "{{ message['role'] }}: {{ message['content'] }}\n"
+    "{% endfor %}"
+    "{% if add_generation_prompt %}assistant: {% endif %}"
+)
+
+
+@dataclass
+class MockHFConfig:
+    model_type: str = "any"
+
+
+@dataclass
+class MockModelConfig:
+    task = "generate"
+    runner_type = "generate"
+    model = MODEL_NAME
+    tokenizer = MODEL_NAME
+    trust_remote_code = False
+    tokenizer_mode = "auto"
+    max_model_len = 100
+    tokenizer_revision = None
+    multimodal_config = MultiModalConfig()
+    hf_config = MockHFConfig()
+    hf_text_config = MockHFConfig()
+    logits_processors: list[str] | None = None
+    diff_sampling_param: dict | None = None
+    allowed_local_media_path: str = ""
+    allowed_media_domains: list[str] | None = None
+    encoder_config = None
+    generation_config: str = "auto"
+    override_generation_config: dict[str, Any] = field(default_factory=dict)
+    media_io_kwargs: dict[str, dict[str, Any]] = field(default_factory=dict)
+    skip_tokenizer_init: bool = False
+    is_encoder_decoder: bool = False
+    is_multimodal_model: bool = False
+
+    def get_diff_sampling_param(self):
+        return self.diff_sampling_param or {}
+
+
+@dataclass
+class MockParallelConfig:
+    _api_process_rank: int = 0
+
+
+@dataclass
+class MockVllmConfig:
+    model_config: MockModelConfig
+    parallel_config: MockParallelConfig
+
+
+def _build_renderer(model_config: MockModelConfig):
+    _, tokenizer_name, _, kwargs = tokenizer_args_from_config(model_config)
+    return HfRenderer.from_config(
+        MockVllmConfig(model_config, parallel_config=MockParallelConfig()),
+        tokenizer_kwargs={**kwargs, "tokenizer_name": tokenizer_name},
+    )
+
+
+def _build_serving_render(
+    engine,
+    model_registry,
+) -> OpenAIServingRender:
+    return OpenAIServingRender(
+        model_config=engine.model_config,
+        renderer=engine.renderer,
+        io_processor=engine.io_processor,
+        model_registry=model_registry,
+        request_logger=None,
+        chat_template=CHAT_TEMPLATE,
+        chat_template_content_format="auto",
+    )
+
+
+def _build_serving_chat(engine) -> OpenAIServingChat:
+    models = OpenAIServingModels(
+        engine_client=engine,
+        base_model_paths=BASE_MODEL_PATHS,
+    )
+    openai_serving_render = _build_serving_render(engine, models.registry)
+    return OpenAIServingChat(
+        engine,
+        models,
+        response_role="assistant",
+        openai_serving_render=openai_serving_render,
+        chat_template=CHAT_TEMPLATE,
+        chat_template_content_format="auto",
+        request_logger=None,
+    )
+
+
+def _build_mock_engine():
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+    return mock_engine
+
+
+class TestPromptTokenIdsRequestField:
+    """Tests for the prompt_token_ids field on ChatCompletionRequest."""
+
+    def test_request_without_prompt_token_ids(self):
+        request = ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "test-model",
+            }
+        )
+        assert request.prompt_token_ids is None
+
+    def test_request_with_prompt_token_ids(self):
+        token_ids = [100, 200, 300, 400, 500]
+        request = ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "test-model",
+                "prompt_token_ids": token_ids,
+            }
+        )
+        assert request.prompt_token_ids == token_ids
+
+    def test_request_with_prompt_token_ids_and_kv_transfer_params(self):
+        """Typical decode-side request from router."""
+        token_ids = list(range(16000))
+        request = ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "test-model",
+                "prompt_token_ids": token_ids,
+                "kv_transfer_params": {
+                    "do_remote_prefill": True,
+                    "do_remote_decode": False,
+                    "remote_block_ids": [[1, 2, 3]],
+                    "remote_engine_id": "engine-1",
+                },
+            }
+        )
+        assert request.prompt_token_ids == token_ids
+        assert request.kv_transfer_params["do_remote_prefill"] is True
+        assert len(request.prompt_token_ids) == 16000
+
+    def test_request_with_empty_prompt_token_ids(self):
+        request = ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "test-model",
+                "prompt_token_ids": [],
+            }
+        )
+        assert request.prompt_token_ids == []
+
+
+class TestSkipRenderCondition:
+    """Tests for the skip_render condition logic."""
+
+    def _should_skip_render(self, request: ChatCompletionRequest) -> bool:
+        """Reproduce the skip_render condition from serving.py."""
+        return bool(
+            request.kv_transfer_params
+            and request.kv_transfer_params.get("do_remote_prefill")
+            and request.prompt_token_ids
+        )
+
+    def test_skip_render_decode_with_token_ids(self):
+        """Decode side with prompt_token_ids -> should skip."""
+        request = ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "test-model",
+                "prompt_token_ids": [1, 2, 3],
+                "kv_transfer_params": {"do_remote_prefill": True},
+            }
+        )
+        assert self._should_skip_render(request) is True
+
+    def test_no_skip_render_without_kv_params(self):
+        """Normal request without PD -> should not skip."""
+        request = ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "test-model",
+            }
+        )
+        assert self._should_skip_render(request) is False
+
+    def test_no_skip_render_prefill_side(self):
+        """Prefill side (do_remote_decode) -> should not skip."""
+        request = ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "test-model",
+                "kv_transfer_params": {"do_remote_decode": True},
+            }
+        )
+        assert self._should_skip_render(request) is False
+
+    def test_no_skip_render_without_token_ids(self):
+        """Decode side but no prompt_token_ids (old router) -> should not skip."""
+        request = ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "test-model",
+                "kv_transfer_params": {"do_remote_prefill": True},
+            }
+        )
+        assert self._should_skip_render(request) is False
+
+    def test_no_skip_render_empty_token_ids(self):
+        """Decode side with empty prompt_token_ids -> should not skip."""
+        request = ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "test-model",
+                "prompt_token_ids": [],
+                "kv_transfer_params": {"do_remote_prefill": True},
+            }
+        )
+        assert self._should_skip_render(request) is False
+
+    def test_skip_render_with_echo(self):
+        """Decode side with echo=True -> still skip (conversation preserved)."""
+        request = ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "test-model",
+                "prompt_token_ids": [1, 2, 3],
+                "kv_transfer_params": {"do_remote_prefill": True},
+                "echo": True,
+            }
+        )
+        assert self._should_skip_render(request) is True
+
+
+class TestPrefillResponseIncludesTokenIds:
+    """Tests for the prefill response prompt_token_ids inclusion logic."""
+
+    def _should_include_prompt_token_ids(
+        self,
+        return_token_ids: bool,
+        kv_transfer_params: dict | None,
+    ) -> bool:
+        """Reproduce the condition from serving.py response construction."""
+        return bool(
+            return_token_ids
+            or (kv_transfer_params and kv_transfer_params.get("do_remote_prefill"))
+        )
+
+    def test_include_when_return_token_ids(self):
+        assert self._should_include_prompt_token_ids(True, None) is True
+
+    def test_include_when_do_remote_prefill(self):
+        """Prefill response for PD -> should include for router to forward."""
+        assert (
+            self._should_include_prompt_token_ids(False, {"do_remote_prefill": True})
+            is True
+        )
+
+    def test_exclude_when_no_flags(self):
+        assert self._should_include_prompt_token_ids(False, None) is False
+
+    def test_exclude_when_do_remote_decode(self):
+        assert (
+            self._should_include_prompt_token_ids(False, {"do_remote_decode": True})
+            is False
+        )
+
+
+class TestSkipTokenizationE2E:
+    """End-to-end tests: normal path vs skip-tokenization path produce
+    equivalent engine prompts (same token IDs, conversation, cache_salt)."""
+
+    @pytest.mark.asyncio
+    async def test_same_token_ids_single_turn(self):
+        """Single-turn: skip path with prefill token IDs matches normal."""
+        engine = _build_mock_engine()
+        serving_chat = _build_serving_chat(engine)
+
+        messages = [{"role": "user", "content": "what is 1+1?"}]
+
+        # --- Normal path (no skip) ---
+        normal_req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=messages,
+        )
+        normal_result = await serving_chat.render_chat_request(normal_req)
+        assert isinstance(normal_result, tuple)
+        normal_conv, normal_prompts = normal_result
+        normal_token_ids = normal_prompts[0]["prompt_token_ids"]
+
+        # --- Skip path (with prompt_token_ids) ---
+        skip_result = await serving_chat.render_chat_request(
+            normal_req,
+            prompt_token_ids=normal_token_ids,
+        )
+        assert isinstance(skip_result, tuple)
+        skip_conv, skip_prompts = skip_result
+
+        # Token IDs must be identical.
+        assert skip_prompts[0]["prompt_token_ids"] == normal_token_ids
+
+        # Conversation messages should have the same roles and content.
+        assert len(skip_conv) == len(normal_conv)
+        for skip_msg, normal_msg in zip(skip_conv, normal_conv):
+            assert skip_msg["role"] == normal_msg["role"]
+            assert skip_msg["content"] == normal_msg["content"]
+
+    @pytest.mark.asyncio
+    async def test_same_token_ids_multi_turn(self):
+        """Multi-turn conversation: token IDs match between paths."""
+        engine = _build_mock_engine()
+        serving_chat = _build_serving_chat(engine)
+
+        messages = [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi! How can I help you?"},
+            {"role": "user", "content": "What is the weather today?"},
+        ]
+
+        # Normal path
+        normal_req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=messages,
+        )
+        normal_result = await serving_chat.render_chat_request(normal_req)
+        assert isinstance(normal_result, tuple)
+        normal_conv, normal_prompts = normal_result
+        normal_token_ids = normal_prompts[0]["prompt_token_ids"]
+
+        # Skip path
+        skip_result = await serving_chat.render_chat_request(
+            normal_req,
+            prompt_token_ids=normal_token_ids,
+        )
+        assert isinstance(skip_result, tuple)
+        skip_conv, skip_prompts = skip_result
+
+        assert skip_prompts[0]["prompt_token_ids"] == normal_token_ids
+        assert len(skip_conv) == len(normal_conv)
+
+    @pytest.mark.asyncio
+    async def test_cache_salt_preserved_in_skip_path(self):
+        """cache_salt should be propagated even when tokenization is skipped."""
+        engine = _build_mock_engine()
+        serving_chat = _build_serving_chat(engine)
+
+        messages = [{"role": "user", "content": "test"}]
+
+        # Get token IDs from normal path
+        normal_req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=messages,
+        )
+        normal_result = await serving_chat.render_chat_request(normal_req)
+        assert isinstance(normal_result, tuple)
+        normal_token_ids = normal_result[1][0]["prompt_token_ids"]
+
+        # Skip path with cache_salt
+        req_with_salt = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=messages,
+            cache_salt="my-salt",
+        )
+        skip_result = await serving_chat.render_chat_request(
+            req_with_salt,
+            prompt_token_ids=normal_token_ids,
+        )
+        assert isinstance(skip_result, tuple)
+        _, skip_prompts = skip_result
+        assert skip_prompts[0]["cache_salt"] == "my-salt"
+
+    @pytest.mark.asyncio
+    async def test_normal_path_no_cache_salt(self):
+        """Verify cache_salt is absent when not set (both paths)."""
+        engine = _build_mock_engine()
+        serving_chat = _build_serving_chat(engine)
+
+        messages = [{"role": "user", "content": "test"}]
+        req = ChatCompletionRequest(model=MODEL_NAME, messages=messages)
+
+        normal_result = await serving_chat.render_chat_request(req)
+        assert isinstance(normal_result, tuple)
+        normal_token_ids = normal_result[1][0]["prompt_token_ids"]
+        assert "cache_salt" not in normal_result[1][0]
+
+        skip_result = await serving_chat.render_chat_request(
+            req,
+            prompt_token_ids=normal_token_ids,
+        )
+        assert isinstance(skip_result, tuple)
+        assert "cache_salt" not in skip_result[1][0]
+
+    @pytest.mark.asyncio
+    async def test_create_chat_completion_uses_skip_path(self):
+        """Full create_chat_completion with PD skip condition passes
+        prompt_token_ids through render_chat_request."""
+        engine = _build_mock_engine()
+        serving_chat = _build_serving_chat(engine)
+
+        # Capture what render_chat_request receives
+        orig_render = serving_chat.render_chat_request
+        captured_kwargs: list[dict] = []
+
+        async def tracking_render(request, prompt_token_ids=None):
+            captured_kwargs.append({"prompt_token_ids": prompt_token_ids})
+            return await orig_render(request, prompt_token_ids=prompt_token_ids)
+
+        serving_chat.render_chat_request = tracking_render
+
+        # Normal request -- prompt_token_ids should be None
+        normal_req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+        with suppress(Exception):
+            await serving_chat.create_chat_completion(normal_req)
+
+        assert captured_kwargs[-1]["prompt_token_ids"] is None
+
+        # PD decode request -- prompt_token_ids should be passed through
+        pd_req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "Hello"}],
+            prompt_token_ids=[1, 2, 3, 4, 5],
+            kv_transfer_params={"do_remote_prefill": True},
+        )
+        with suppress(Exception):
+            await serving_chat.create_chat_completion(pd_req)
+
+        assert captured_kwargs[-1]["prompt_token_ids"] == [1, 2, 3, 4, 5]
+
+    @pytest.mark.asyncio
+    async def test_model_validation_runs_in_skip_path(self):
+        """_check_model and engine health checks still run when skipping."""
+        engine = _build_mock_engine()
+        serving_chat = _build_serving_chat(engine)
+
+        # Request with invalid model name
+        req = ChatCompletionRequest(
+            model="nonexistent-model",
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+
+        # Normal path -- should return ErrorResponse
+        from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+
+        normal_result = await serving_chat.render_chat_request(req)
+        assert isinstance(normal_result, ErrorResponse)
+
+        # Skip path -- should ALSO return ErrorResponse (not bypass validation)
+        skip_result = await serving_chat.render_chat_request(
+            req,
+            prompt_token_ids=[1, 2, 3],
+        )
+        assert isinstance(skip_result, ErrorResponse)
+
+    @pytest.mark.asyncio
+    async def test_engine_health_check_in_skip_path(self):
+        """Engine dead error is raised even when skip path is used."""
+        engine = _build_mock_engine()
+        engine.errored = True
+        engine.dead_error = RuntimeError("Engine is dead")
+
+        serving_chat = _build_serving_chat(engine)
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "Hello"}],
+        )
+
+        with pytest.raises(RuntimeError, match="Engine is dead"):
+            await serving_chat.render_chat_request(
+                req,
+                prompt_token_ids=[1, 2, 3],
+            )

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -337,6 +337,13 @@ class ChatCompletionRequest(OpenAIBaseModel):
         description="KVTransfer parameters used for disaggregated serving.",
     )
 
+    prompt_token_ids: list[int] | None = Field(
+        default=None,
+        description="Pre-tokenized prompt token IDs from prefill stage. "
+        "When provided with kv_transfer_params.do_remote_prefill, "
+        "skips chat template rendering and tokenization on decode side.",
+    )
+
     vllm_xargs: dict[str, str | int | float | list[str | int | float]] | None = Field(
         default=None,
         description=(

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -183,12 +183,17 @@ class OpenAIServingChat(OpenAIServing):
     async def render_chat_request(
         self,
         request: ChatCompletionRequest,
+        prompt_token_ids: list[int] | None = None,
     ) -> tuple[list[ConversationMessage], list[EngineInput]] | ErrorResponse:
         """
         Validate the model and preprocess a chat completion request.
 
         Delegates preprocessing logic to OpenAIServingRender, adding the
         engine-aware checks (LoRA model validation, engine health).
+
+        Args:
+            prompt_token_ids: Pre-tokenized prompt token IDs from PD prefill.
+                When provided, skips chat template rendering and tokenization.
 
         Returns:
             A tuple of (conversation, engine_inputs) on success,
@@ -205,7 +210,9 @@ class OpenAIServingChat(OpenAIServing):
         if self.engine_client.errored:
             raise self.engine_client.dead_error
 
-        return await self.openai_serving_render.render_chat(request)
+        return await self.openai_serving_render.render_chat(
+            request, prompt_token_ids=prompt_token_ids
+        )
 
     async def create_chat_completion(
         self,
@@ -219,6 +226,19 @@ class OpenAIServingChat(OpenAIServing):
         for the API specification. This API mimics the OpenAI
         Chat Completion API.
         """
+        # PD disagg fast path: when the decode side receives pre-tokenized
+        # prompt_token_ids from the prefill response (forwarded by the router),
+        # skip chat template rendering and tokenization.
+        prompt_token_ids = (
+            request.prompt_token_ids
+            if (
+                request.kv_transfer_params
+                and request.kv_transfer_params.get("do_remote_prefill")
+                and request.prompt_token_ids
+            )
+            else None
+        )
+
         # Streaming response
         tokenizer = self.renderer.tokenizer
         assert tokenizer is not None
@@ -232,7 +252,10 @@ class OpenAIServingChat(OpenAIServing):
                 tokenizer,
                 chat_template_kwargs=chat_template_kwargs,  # type: ignore[call-arg]
             )
-        result = await self.render_chat_request(request)
+
+        result = await self.render_chat_request(
+            request, prompt_token_ids=prompt_token_ids
+        )
         if isinstance(result, ErrorResponse):
             return result
 
@@ -1529,7 +1552,13 @@ class OpenAIServingChat(OpenAIServing):
             usage=usage,
             prompt_logprobs=clamp_prompt_logprobs(final_res.prompt_logprobs),
             prompt_token_ids=(
-                final_res.prompt_token_ids if request.return_token_ids else None
+                final_res.prompt_token_ids
+                if request.return_token_ids
+                or (
+                    final_res.kv_transfer_params
+                    and final_res.kv_transfer_params.get("do_remote_prefill")
+                )
+                else None
             ),
             kv_transfer_params=final_res.kv_transfer_params,
         )

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -182,6 +182,7 @@ class OpenAIServingRender:
     async def render_chat(
         self,
         request: ChatCompletionRequest,
+        prompt_token_ids: list[int] | None = None,
     ) -> tuple[list[ConversationMessage], list[EngineInput]] | ErrorResponse:
         """Core preprocessing logic for chat requests (no model/engine check).
 
@@ -251,6 +252,7 @@ class OpenAIServingRender:
                 tool_dicts=tool_dicts,
                 tool_parser=tool_parser,
                 reasoning_parser=self.reasoning_parser,
+                prompt_token_ids=prompt_token_ids,
             )
         else:
             # For GPT-OSS.
@@ -510,6 +512,7 @@ class OpenAIServingRender:
         tool_dicts: list[dict[str, Any]] | None = None,
         tool_parser: type[ToolParser] | None = None,
         reasoning_parser: type[ReasoningParser] | None = None,
+        prompt_token_ids: list[int] | None = None,
         *,
         skip_mm_cache: bool = False,
     ) -> tuple[list[ConversationMessage], list[EngineInput]]:
@@ -543,6 +546,7 @@ class OpenAIServingRender:
                 for k in ("mm_processor_kwargs", "cache_salt")
                 if (v := getattr(request, k, None)) is not None
             },
+            prompt_token_ids=prompt_token_ids,
             skip_mm_cache=skip_mm_cache,
         )
 

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -977,6 +977,13 @@ class BaseRenderer(ABC, Generic[_T]):
         if prompt_token_ids is not None:
             # PD disagg fast path: skip chat template rendering and
             # tokenization when pre-tokenized IDs are provided.
+            # This is text-only; multimodal requests must go through
+            # the normal path to attach multi_modal_data/uuids.
+            if len(conversations) != 1:
+                raise ValueError(
+                    "prompt_token_ids fast path only supports a single "
+                    f"conversation, got {len(conversations)}"
+                )
             out_conversations: list[list[ConversationMessage]] = [
                 [dict(msg) for msg in conv]  # type: ignore[arg-type]
                 for conv in conversations

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -979,13 +979,17 @@ class BaseRenderer(ABC, Generic[_T]):
             # tokenization when pre-tokenized IDs are provided.
             # This is text-only; multimodal requests must go through
             # the normal path to attach multi_modal_data/uuids.
+            logger.debug(
+                "Skipping tokenization using %d pre-tokenized IDs",
+                len(prompt_token_ids),
+            )
             if len(conversations) != 1:
                 raise ValueError(
                     "prompt_token_ids fast path only supports a single "
                     f"conversation, got {len(conversations)}"
                 )
             out_conversations: list[list[ConversationMessage]] = [
-                [dict(msg) for msg in conv]  # type: ignore[arg-type]
+                [dict(msg) for msg in conv]  # type: ignore[misc]
                 for conv in conversations
             ]
             tok_prompts: list[TokPrompt] = [

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -969,25 +969,37 @@ class BaseRenderer(ABC, Generic[_T]):
         tok_params: TokenizeParams | None = None,
         *,
         prompt_extras: dict[str, Any] | None = None,
+        prompt_token_ids: list[int] | None = None,
         skip_mm_cache: bool = False,
     ):
         arrival_time = time.time()
 
-        if tok_params is None:
-            tok_params = self.default_chat_tok_params
+        if prompt_token_ids is not None:
+            # PD disagg fast path: skip chat template rendering and
+            # tokenization when pre-tokenized IDs are provided.
+            out_conversations: list[list[ConversationMessage]] = [
+                [dict(msg) for msg in conv]  # type: ignore[arg-type]
+                for conv in conversations
+            ]
+            tok_prompts: list[TokPrompt] = [
+                TokensPrompt(prompt_token_ids=prompt_token_ids),
+            ]
+        else:
+            if tok_params is None:
+                tok_params = self.default_chat_tok_params
 
-        rendered = [
-            self.render_messages_async(conversation, chat_params)
-            for conversation in conversations
-        ]
+            rendered = [
+                self.render_messages_async(conversation, chat_params)
+                for conversation in conversations
+            ]
 
-        out_conversations = list[list["ConversationMessage"]]()
-        dict_prompts = list[DictPrompt]()
-        for conv, prompt in await asyncio.gather(*rendered):
-            out_conversations.append(conv)
-            dict_prompts.append(prompt)
+            out_conversations = list[list["ConversationMessage"]]()
+            dict_prompts = list[DictPrompt]()
+            for conv, prompt in await asyncio.gather(*rendered):
+                out_conversations.append(conv)
+                dict_prompts.append(prompt)
 
-        tok_prompts = await self.tokenize_prompts_async(dict_prompts, tok_params)
+            tok_prompts = await self.tokenize_prompts_async(dict_prompts, tok_params)
 
         self._apply_prompt_extras(tok_prompts, prompt_extras)
 


### PR DESCRIPTION
## Summary

In PD disaggregated serving with NixlConnector, the decode side redundantly re-tokenizes the prompt (chat template rendering + tokenization) that was already processed on the prefill side. Since the two stages are sequential, this duplicate work adds directly to end-to-end latency.

This PR adds a fast path: when the router forwards pre-tokenized `prompt_token_ids` from the prefill response alongside `kv_transfer_params.do_remote_prefill`, the decode side skips `render_messages_async` and `tokenize_prompts_async` entirely, constructing a `TokensPrompt` directly from the provided IDs.

**Changes:**
- `protocol.py`: Add `prompt_token_ids` field to `ChatCompletionRequest`
- `serving.py`: Detect PD decode requests and pass `prompt_token_ids` through the rendering pipeline; include `prompt_token_ids` in prefill responses when `kv_transfer_params.do_remote_prefill` is set
- `render/serving.py`: Thread `prompt_token_ids` through `render_chat` and `preprocess_chat`
- `renderers/base.py`: Skip chat template rendering and tokenization in `render_chat_async` when `prompt_token_ids` is provided

**Safety:** The skip condition (`kv_transfer_params.do_remote_prefill AND prompt_token_ids`) is backward-compatible — non-PD requests and older routers that don't send `prompt_token_ids` are completely unaffected.

**Scope:** This optimization only benefits the NixlConnector (sequential prefill→decode) path. In P2P NCCL mode, both requests are sent concurrently so decode tokenization is hidden behind prefill compute.

The corresponding router-side change that forwards token IDs is in vllm-project/router#144.

## Test plan

- [x] Unit tests for `prompt_token_ids` field parsing on `ChatCompletionRequest`
- [x] Unit tests for skip condition logic (all combinations of kv_transfer_params / prompt_token_ids / empty)
- [x] Unit tests for prefill response `prompt_token_ids` inclusion logic
- [x] E2E tests verifying skip path produces identical token IDs as normal path (single-turn, multi-turn)
- [x] Tests for `cache_salt` preservation in skip path
- [x] Tests that model validation and engine health checks still run in skip path
- [x] Pre-commit hooks pass (ruff, mypy, typos)
- [x] E2E integration test with vLLM PD disagg setup (NixlConnector)

### E2E test with Llama3 8B 1P1D on 2*GB200s with vllm-router + NixlConnector
### Baseline 
```
GSM8K 0.8260

======================================================================
  BENCHMARK RESULTS  [default]
======================================================================
 Prompt tokens |  TTFT mean     median        p90      stdev |  Total mean
------------------------------------------------------------------------------------------
           500 |      75.5ms      79.6ms      91.3ms      13.9ms |       75.6ms
          2000 |      73.9ms      71.2ms      88.8ms      13.5ms |       74.0ms
          8000 |      93.8ms      95.5ms     109.2ms      11.3ms |       93.9ms
         32000 |     167.9ms     167.1ms     200.2ms      21.3ms |      168.1ms
         64000 |     265.4ms     269.2ms     281.9ms      13.7ms |      265.6ms
        100000 |     410.7ms     375.4ms     568.5ms      90.5ms |      410.8ms
======================================================================
```
### With Optimization
```
GSM8K  0.8180
======================================================================
  BENCHMARK RESULTS  [default]
======================================================================
 Prompt tokens |  TTFT mean     median        p90      stdev |  Total mean
------------------------------------------------------------------------------------------
           500 |      66.4ms      58.5ms      85.1ms      15.3ms |       66.6ms
          2000 |      69.0ms      75.0ms      81.3ms      12.2ms |       69.1ms
          8000 |      80.8ms      75.1ms     101.3ms      14.9ms |       81.0ms
         32000 |     134.9ms     137.7ms     150.7ms      12.8ms |      135.1ms
         64000 |     193.1ms     194.4ms     206.4ms      11.3ms |      193.3ms
        100000 |     298.5ms     299.0ms     309.2ms       8.1ms |      298.6ms
======================================================================
```


AI assistance was used (Claude).

🤖 Generated with [Claude Code](https://claude.com/claude-code)