### PR TITLE
[Perf] Support Allreduce + Norm + Per-token Group Fp8 Quant Fusion

### DIFF
--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -264,7 +264,7 @@ class TestAllReduceRMSNormGroupQuantFP8PackedModel(torch.nn.Module):
         (TestAllReduceRMSNormStaticQuantFP8Model, True),
         (TestAllReduceRMSNormStaticQuantFP8Model, False),
         (TestAllReduceFusedAddRMSNormStaticQuantFP4Model, False),
-        (TestAllReduceRMSNormGroupQuantFP8PackedModel, False),
+        (TestAllReduceRMSNormGroupQuantFP8PackedModel, True),
     ],
 )
 @pytest.mark.parametrize("batch_size", [8])
@@ -305,6 +305,7 @@ def test_all_reduce_fusion_pass_replace(
 
         if not is_deep_gemm_supported():
             pytest.skip("Skip as per-token-group packed FP8 quant requires DeepGEMM")
+
         gs = TestAllReduceRMSNormGroupQuantFP8PackedModel.GROUP_SIZE
         if hidden_size % gs != 0:
             pytest.skip(f"hidden_size={hidden_size} not divisible by group_size={gs}")
@@ -366,14 +367,12 @@ def all_reduce_fusion_pass_on_test_model(
         custom_ops.append("+rms_norm")
     if enable_quant_fp8_custom_op:
         custom_ops.append("+quant_fp8")
-    # Group quant model needs QuantFP8 custom op enabled to use CUDA path,
-    # and the DeepGemm oracle initialized for the packed quant path.
-    if test_model_cls == TestAllReduceRMSNormGroupQuantFP8PackedModel:
-        if "+quant_fp8" not in custom_ops:
-            custom_ops.append("+quant_fp8")
-        from vllm.utils.deep_gemm import DeepGemmQuantScaleFMT
 
-        DeepGemmQuantScaleFMT.init_oracle_cache()
+    if test_model_cls == TestAllReduceRMSNormGroupQuantFP8PackedModel:
+        from vllm.utils.deep_gemm import is_deep_gemm_e8m0_used
+
+        if not is_deep_gemm_e8m0_used():
+            pytest.skip("Skip as DeepGEMM E8M0 is not supported on this system")
 
     vllm_config = VllmConfig(
         compilation_config=CompilationConfig(
@@ -415,36 +414,9 @@ def all_reduce_fusion_pass_on_test_model(
         results_fused = compiled_model(hidden_states)
         torch.testing.assert_close(results_unfused, results_fused, atol=1e-2, rtol=1e-2)
 
-        if test_model_cls == TestAllReduceRMSNormGroupQuantFP8PackedModel:
-            if not enable_rms_norm_custom_op:
-                # Native RMSNorm ops → patterns can't match the rmsnorm node
-                pass
-            elif flashinfer_allreduce_backend == "mnnvl":
-                # mnnvl doesn't support quant fusion; only non-quant
-                # AR+RMSNorm patterns fire (2 of 4 allreduce points
-                # have quant after them → those won't match the quant
-                # pattern on mnnvl, but the non-quant pattern still
-                # matches all 4 allreduce+rmsnorm points).
-                assert all_reduce_fusion_pass.matched_count >= 2, (
-                    f"Expected at least 2 allreduce fusions on mnnvl, got "
-                    f"{all_reduce_fusion_pass.matched_count}"
-                )
-            else:
-                # trtllm backend + custom RMSNorm enabled: all 4 allreduce
-                # patterns should match (2 with quant, 2 without).
-                assert all_reduce_fusion_pass.matched_count == 4, (
-                    f"Expected 4 allreduce fusions (2 with group quant), "
-                    f"got {all_reduce_fusion_pass.matched_count}"
-                )
-                # Verify the group quant op was actually fused
-                backend.check_before_ops(
-                    model.ops_in_model_before(), fully_replaced=False
-                )
-                backend.check_after_ops(model.ops_in_model_after())
-        else:
-            assert all_reduce_fusion_pass.matched_count == 4, (
-                f"{all_reduce_fusion_pass.matched_count=}"
-            )
-            backend.check_before_ops(model.ops_in_model_before(), fully_replaced=False)
-            backend.check_after_ops(model.ops_in_model_after())
+        assert all_reduce_fusion_pass.matched_count == 4, (
+            f"{all_reduce_fusion_pass.matched_count=}"
+        )
+        backend.check_before_ops(model.ops_in_model_before(), fully_replaced=False)
+        backend.check_after_ops(model.ops_in_model_after())
         del all_reduce_fusion_pass

--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -502,7 +502,7 @@ def _run_fused_allreduce_norm_group_quant_test(
     from vllm.utils.deep_gemm import is_deep_gemm_e8m0_used
 
     device = torch.device(f"cuda:{local_rank}")
-    torch.accelerator.set_device(device)
+    torch.accelerator.set_device_index(device)
     dist.init_process_group(
         backend="nccl",
         init_method="tcp://localhost:12399",

--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -439,28 +439,42 @@ def all_reduce_fusion_pass_on_test_model(
         del all_reduce_fusion_pass
 
 
+_GROUP_QUANT_FP8_PACKED_CASES = [
+    # (num_tokens, hidden_dim, group_size)
+    (4, 7168, 128),
+    (1, 7168, 128),
+    (3, 7168, 128),
+    (4, 640, 128),
+    (4, 768, 128),
+    (4, 384, 128),
+    (1, 384, 128),
+    (3, 640, 128),
+    (64, 7168, 128),
+    (128, 14336, 128),
+    (127, 7168, 128),
+    (253, 640, 128),
+    (1, 256, 128),
+    (4, 7168, 64),
+    (1, 7168, 64),
+    (4, 640, 64),
+    (3, 768, 64),
+    (3, 640, 64),
+    (4, 768, 8),
+    (4, 768, 16),
+    (4, 768, 12),
+    (3, 768, 6),
+    (4, 768, 4),
+    (4, 768, 48),
+    (4, 960, 48),
+    (3, 768, 24),
+    (512, 768, 48),
+    (4, 7168, 512),
+    (4, 4096, 256),
+    (3, 4096, 512),
+]
+
+
 @multi_gpu_test(num_gpus=2)
-@pytest.mark.parametrize(
-    "num_tokens,hidden_dim,group_size",
-    [
-        (4, 7168, 128),
-        (1, 7168, 128),
-        (3, 7168, 128),
-        (4, 640, 128),
-        (4, 768, 128),
-        (4, 384, 128),
-        (1, 384, 128),
-        (3, 640, 128),
-        (64, 7168, 128),
-        (128, 14336, 128),
-        (127, 7168, 128),
-        (253, 640, 128),
-        (4, 7168, 64),
-        (1, 7168, 64),
-        (4, 640, 64),
-        (3, 768, 64),
-    ],
-)
 @pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["cuda"], reason="Only test on CUDA")
 @pytest.mark.skipif(
     not find_spec("flashinfer")
@@ -468,31 +482,30 @@ def all_reduce_fusion_pass_on_test_model(
     or not has_module_attribute("flashinfer.comm", "create_allreduce_fusion_workspace"),
     reason="flashinfer allreduce_fusion not available",
 )
-def test_fused_allreduce_norm_group_quant_fp8_packed(
-    num_tokens, hidden_dim, group_size
-):
+def test_fused_allreduce_norm_group_quant_fp8_packed():
     """Test the flashinfer fused allreduce+RMSNorm+group-quant kernel by
     extracting norm_out from the fused kernel and comparing the fused
     quant_out / scale_out against per_token_group_quant_fp8_packed_for_deepgemm
-    applied to that same norm_out."""
+    applied to that same norm_out.
+
+    All shape combos run inside a single process group spawn to avoid
+    per-case process startup + NCCL init overhead."""
     from vllm.utils.deep_gemm import is_deep_gemm_supported
 
     if not is_deep_gemm_supported():
         pytest.skip("DeepGEMM not supported on this platform")
 
     torch.multiprocessing.spawn(
-        _run_fused_allreduce_norm_group_quant_test,
-        args=(2, num_tokens, hidden_dim, group_size),
+        _run_fused_allreduce_norm_group_quant_batch,
+        args=(2, _GROUP_QUANT_FP8_PACKED_CASES),
         nprocs=2,
     )
 
 
-def _run_fused_allreduce_norm_group_quant_test(
+def _run_fused_allreduce_norm_group_quant_batch(
     local_rank: int,
     world_size: int,
-    num_tokens: int,
-    hidden_dim: int,
-    group_size: int,
+    cases: list,
 ):
     import flashinfer.comm as flashinfer_comm
     import torch.distributed as dist
@@ -516,89 +529,107 @@ def _run_fused_allreduce_norm_group_quant_test(
             return  # skip silently in subprocess
 
         dtype = torch.bfloat16
+        max_tokens = max(c[0] for c in cases)
+        max_hidden = max(c[1] for c in cases)
         workspace = flashinfer_comm.create_allreduce_fusion_workspace(
             backend="trtllm",
             world_size=world_size,
             rank=local_rank,
-            max_token_num=num_tokens,
-            hidden_dim=hidden_dim,
+            max_token_num=max_tokens,
+            hidden_dim=max_hidden,
             dtype=dtype,
             comm_backend=TorchDistBackend(),
         )
 
-        groups_per_row = hidden_dim // group_size
-        k_num_packed = (groups_per_row + 3) // 4
-        tma_aligned_mn = ((num_tokens + 3) // 4) * 4
+        for num_tokens, hidden_dim, group_size in cases:
+            # Recreate workspace if current one is too small
+            if not workspace.is_buffer_size_sufficient(
+                world_size, num_tokens, hidden_dim, dtype
+            ):
+                workspace.destroy()
+                workspace = flashinfer_comm.create_allreduce_fusion_workspace(
+                    backend="trtllm",
+                    world_size=world_size,
+                    rank=local_rank,
+                    max_token_num=num_tokens,
+                    hidden_dim=hidden_dim,
+                    dtype=dtype,
+                    comm_backend=TorchDistBackend(),
+                )
 
-        torch.manual_seed(42 + local_rank)
-        allreduce_in = (
-            torch.randn(num_tokens, hidden_dim, dtype=dtype, device=device) * 8
-        )
-        residual_in = (
-            torch.randn(num_tokens, hidden_dim, dtype=dtype, device=device) * 8
-        )
-        rms_gamma = torch.randn(hidden_dim, dtype=dtype, device=device)
+            groups_per_row = hidden_dim // group_size
+            k_num_packed = (groups_per_row + 3) // 4
+            tma_aligned_mn = ((num_tokens + 3) // 4) * 4
 
-        # Use kARResidualRMSNormOutPerTokenGroupFP8PackedQuant so that
-        # norm_out is written to a separate buffer we can feed to the
-        # standalone quant kernel for comparison.
-        residual_out = torch.empty_like(allreduce_in)
-        norm_out = torch.empty_like(allreduce_in)
-        quant_out = torch.empty(
-            num_tokens,
-            hidden_dim,
-            dtype=torch.float8_e4m3fn,
-            device=device,
-        )
-        scale_out = torch.empty_strided(
-            (num_tokens, k_num_packed),
-            (1, tma_aligned_mn),
-            dtype=torch.int32,
-            device=device,
-        )
+            torch.manual_seed(42 + local_rank)
+            allreduce_in = (
+                torch.randn(num_tokens, hidden_dim, dtype=dtype, device=device) * 8
+            )
+            residual_in = (
+                torch.randn(num_tokens, hidden_dim, dtype=dtype, device=device) * 8
+            )
+            rms_gamma = torch.randn(hidden_dim, dtype=dtype, device=device)
 
-        flashinfer_comm.allreduce_fusion(
-            input=allreduce_in,
-            workspace=workspace,
-            pattern=(
-                flashinfer_comm.AllReduceFusionPattern.kARResidualRMSNormOutPerTokenGroupFP8PackedQuant
-            ),
-            residual_in=residual_in,
-            residual_out=residual_out,
-            norm_out=norm_out,
-            quant_out=quant_out,
-            scale_out=scale_out,
-            rms_gamma=rms_gamma,
-            rms_eps=1e-5,
-            block_quant_group_size=group_size,
-            fp32_acc=True,
-            use_oneshot=True,
-        )
-        torch.accelerator.synchronize()
+            residual_out = torch.empty_like(allreduce_in)
+            norm_out = torch.empty_like(allreduce_in)
+            quant_out = torch.empty(
+                num_tokens,
+                hidden_dim,
+                dtype=torch.float8_e4m3fn,
+                device=device,
+            )
+            scale_out = torch.empty_strided(
+                (num_tokens, k_num_packed),
+                (1, tma_aligned_mn),
+                dtype=torch.int32,
+                device=device,
+            )
 
-        # Reference: apply standalone packed quant to the fused norm_out.
-        ref_q, ref_s = fp8_utils.per_token_group_quant_fp8_packed_for_deepgemm(
-            norm_out,
-            group_size=group_size,
-            use_ue8m0=True,
-        )
+            flashinfer_comm.allreduce_fusion(
+                input=allreduce_in,
+                workspace=workspace,
+                pattern=(
+                    flashinfer_comm.AllReduceFusionPattern.kARResidualRMSNormOutPerTokenGroupFP8PackedQuant
+                ),
+                residual_in=residual_in,
+                residual_out=residual_out,
+                norm_out=norm_out,
+                quant_out=quant_out,
+                scale_out=scale_out,
+                rms_gamma=rms_gamma,
+                rms_eps=1e-5,
+                block_quant_group_size=group_size,
+                fp32_acc=True,
+                use_oneshot=True,
+            )
+            torch.accelerator.synchronize()
 
-        # Quantized activations must match exactly.
-        assert torch.equal(quant_out, ref_q), (
-            f"quant_out mismatch: "
-            f"{(quant_out != ref_q).sum().item()}/{ref_q.numel()} differ"
-        )
+            # Reference: apply standalone packed quant to the fused norm_out.
+            ref_q, ref_s = fp8_utils.per_token_group_quant_fp8_packed_for_deepgemm(
+                norm_out,
+                group_size=group_size,
+                use_ue8m0=True,
+            )
 
-        # Packed scales must match exactly.
-        num_scale_elems = num_tokens + (k_num_packed - 1) * tma_aligned_mn
-        fused_s = torch.as_strided(scale_out, (num_scale_elems,), (1,))
-        ref_s_flat = torch.as_strided(ref_s, (num_scale_elems,), (1,))
-        assert torch.equal(fused_s, ref_s_flat), (
-            f"scale_out mismatch: "
-            f"{(fused_s != ref_s_flat).sum().item()}/{num_scale_elems} differ"
-        )
+            # Quantized activations must match exactly.
+            assert torch.equal(quant_out, ref_q), (
+                f"[tokens={num_tokens}, hidden={hidden_dim}, gs={group_size}] "
+                f"quant_out mismatch: "
+                f"{(quant_out != ref_q).sum().item()}/{ref_q.numel()} differ"
+            )
+
+            # Packed scales must match exactly.
+            num_scale_elems = num_tokens + (k_num_packed - 1) * tma_aligned_mn
+            fused_s = torch.as_strided(scale_out, (num_scale_elems,), (1,))
+            ref_s_flat = torch.as_strided(ref_s, (num_scale_elems,), (1,))
+            assert torch.equal(fused_s, ref_s_flat), (
+                f"[tokens={num_tokens}, hidden={hidden_dim}, gs={group_size}] "
+                f"scale_out mismatch: "
+                f"{(fused_s != ref_s_flat).sum().item()}/{num_scale_elems} differ"
+            )
+
+            dist.barrier(group=group)
 
     finally:
-        dist.barrier(group=group)
         workspace.destroy()
         dist.destroy_process_group(group=group)

--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -190,6 +190,72 @@ class TestAllReduceFusedAddRMSNormStaticQuantFP4Model(torch.nn.Module):
         ]
 
 
+class TestAllReduceRMSNormGroupQuantFP8PackedModel(torch.nn.Module):
+    """AR + RMSNorm + per_token_group_quant_fp8_packed_for_deepgemm fusion test.
+
+    Uses QuantFP8 (the CustomOp) like real models do, so the compiled graph
+    matches the e2e trace structure where the fusion pattern is known to work.
+    """
+
+    GROUP_SIZE = 128
+
+    def __init__(
+        self,
+        hidden_size=128,
+        token_num=16,
+        eps=1e-5,
+        dtype: torch.dtype = torch.bfloat16,
+    ):
+        super().__init__()
+        from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
+        from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
+
+        self.hidden_size = hidden_size
+        self.eps = eps
+        self.norm = [RMSNorm(hidden_size, eps) for _ in range(4)]
+        self.w = [torch.rand(hidden_size, hidden_size) for _ in range(3)]
+        self.quant = QuantFP8(
+            static=False,
+            group_shape=GroupShape(1, self.GROUP_SIZE),
+            use_ue8m0=True,
+        )
+
+    def forward(self, x):
+        z = torch.relu(x)
+        x = resid = tensor_model_parallel_all_reduce(z)
+        y = self.norm[0](x)
+
+        z2 = torch.mm(y, self.w[0])
+        x2 = tensor_model_parallel_all_reduce(z2)
+        y2, resid = self.norm[1](x2, resid)
+
+        # Apply group quant after norm via QuantFP8 CustomOp
+        y2_q, y2_s = self.quant(y2)
+        z3 = torch.mm(y2_q.to(x.dtype), self.w[1])
+
+        x3 = tensor_model_parallel_all_reduce(z3)
+        y3, resid = self.norm[2](x3, resid)
+
+        y3_q, y3_s = self.quant(y3)
+        z4 = torch.mm(y3_q.to(x.dtype), self.w[2])
+
+        x4 = tensor_model_parallel_all_reduce(z4)
+        y4, resid = self.norm[3](x4, resid)
+        return y4
+
+    def ops_in_model_before(self):
+        return [
+            torch.ops.vllm.all_reduce.default,
+            torch.ops._C.per_token_group_fp8_quant_packed.default,
+        ]
+
+    def ops_in_model_after(self):
+        return [
+            torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm.default,
+            torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm_group_quant.default,
+        ]
+
+
 @multi_gpu_test(num_gpus=2)
 @pytest.mark.parametrize(
     "test_model, enable_quant_fp8_custom_op",
@@ -198,12 +264,13 @@ class TestAllReduceFusedAddRMSNormStaticQuantFP4Model(torch.nn.Module):
         (TestAllReduceRMSNormStaticQuantFP8Model, True),
         (TestAllReduceRMSNormStaticQuantFP8Model, False),
         (TestAllReduceFusedAddRMSNormStaticQuantFP4Model, False),
+        (TestAllReduceRMSNormGroupQuantFP8PackedModel, False),
     ],
 )
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("seq_len", [8])
-@pytest.mark.parametrize("hidden_size", [64])
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("hidden_size", [128])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("enable_rms_norm_custom_op", [True, False])
 @pytest.mark.parametrize("flashinfer_allreduce_backend", ["trtllm", "mnnvl"])
 @pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["cuda"], reason="Only test on CUDA")
@@ -233,6 +300,14 @@ def test_all_reduce_fusion_pass_replace(
             "Skip as nvfp4 is only supported on "
             "devices with compute capability 10.0 (Blackwell)"
         )
+    if test_model == TestAllReduceRMSNormGroupQuantFP8PackedModel:
+        from vllm.utils.deep_gemm import is_deep_gemm_supported
+
+        if not is_deep_gemm_supported():
+            pytest.skip("Skip as per-token-group packed FP8 quant requires DeepGEMM")
+        gs = TestAllReduceRMSNormGroupQuantFP8PackedModel.GROUP_SIZE
+        if hidden_size % gs != 0:
+            pytest.skip(f"hidden_size={hidden_size} not divisible by group_size={gs}")
 
     def run_torch_spawn(fn, nprocs):
         torch.multiprocessing.spawn(
@@ -291,6 +366,14 @@ def all_reduce_fusion_pass_on_test_model(
         custom_ops.append("+rms_norm")
     if enable_quant_fp8_custom_op:
         custom_ops.append("+quant_fp8")
+    # Group quant model needs QuantFP8 custom op enabled to use CUDA path,
+    # and the DeepGemm oracle initialized for the packed quant path.
+    if test_model_cls == TestAllReduceRMSNormGroupQuantFP8PackedModel:
+        if "+quant_fp8" not in custom_ops:
+            custom_ops.append("+quant_fp8")
+        from vllm.utils.deep_gemm import DeepGemmQuantScaleFMT
+
+        DeepGemmQuantScaleFMT.init_oracle_cache()
 
     vllm_config = VllmConfig(
         compilation_config=CompilationConfig(
@@ -332,9 +415,36 @@ def all_reduce_fusion_pass_on_test_model(
         results_fused = compiled_model(hidden_states)
         torch.testing.assert_close(results_unfused, results_fused, atol=1e-2, rtol=1e-2)
 
-        assert all_reduce_fusion_pass.matched_count == 4, (
-            f"{all_reduce_fusion_pass.matched_count=}"
-        )
-        backend.check_before_ops(model.ops_in_model_before(), fully_replaced=False)
-        backend.check_after_ops(model.ops_in_model_after())
+        if test_model_cls == TestAllReduceRMSNormGroupQuantFP8PackedModel:
+            if not enable_rms_norm_custom_op:
+                # Native RMSNorm ops → patterns can't match the rmsnorm node
+                pass
+            elif flashinfer_allreduce_backend == "mnnvl":
+                # mnnvl doesn't support quant fusion; only non-quant
+                # AR+RMSNorm patterns fire (2 of 4 allreduce points
+                # have quant after them → those won't match the quant
+                # pattern on mnnvl, but the non-quant pattern still
+                # matches all 4 allreduce+rmsnorm points).
+                assert all_reduce_fusion_pass.matched_count >= 2, (
+                    f"Expected at least 2 allreduce fusions on mnnvl, got "
+                    f"{all_reduce_fusion_pass.matched_count}"
+                )
+            else:
+                # trtllm backend + custom RMSNorm enabled: all 4 allreduce
+                # patterns should match (2 with quant, 2 without).
+                assert all_reduce_fusion_pass.matched_count == 4, (
+                    f"Expected 4 allreduce fusions (2 with group quant), "
+                    f"got {all_reduce_fusion_pass.matched_count}"
+                )
+                # Verify the group quant op was actually fused
+                backend.check_before_ops(
+                    model.ops_in_model_before(), fully_replaced=False
+                )
+                backend.check_after_ops(model.ops_in_model_after())
+        else:
+            assert all_reduce_fusion_pass.matched_count == 4, (
+                f"{all_reduce_fusion_pass.matched_count=}"
+            )
+            backend.check_before_ops(model.ops_in_model_before(), fully_replaced=False)
+            backend.check_after_ops(model.ops_in_model_after())
         del all_reduce_fusion_pass

--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -437,3 +437,168 @@ def all_reduce_fusion_pass_on_test_model(
         backend.check_before_ops(model.ops_in_model_before(), fully_replaced=False)
         backend.check_after_ops(model.ops_in_model_after())
         del all_reduce_fusion_pass
+
+
+@multi_gpu_test(num_gpus=2)
+@pytest.mark.parametrize(
+    "num_tokens,hidden_dim,group_size",
+    [
+        (4, 7168, 128),
+        (1, 7168, 128),
+        (3, 7168, 128),
+        (4, 640, 128),
+        (4, 768, 128),
+        (4, 384, 128),
+        (1, 384, 128),
+        (3, 640, 128),
+        (64, 7168, 128),
+        (128, 14336, 128),
+        (127, 7168, 128),
+        (253, 640, 128),
+        (4, 7168, 64),
+        (1, 7168, 64),
+        (4, 640, 64),
+        (3, 768, 64),
+    ],
+)
+@pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["cuda"], reason="Only test on CUDA")
+@pytest.mark.skipif(
+    not find_spec("flashinfer")
+    or not has_module_attribute("flashinfer.comm", "allreduce_fusion")
+    or not has_module_attribute("flashinfer.comm", "create_allreduce_fusion_workspace"),
+    reason="flashinfer allreduce_fusion not available",
+)
+def test_fused_allreduce_norm_group_quant_fp8_packed(
+    num_tokens, hidden_dim, group_size
+):
+    """Test the flashinfer fused allreduce+RMSNorm+group-quant kernel by
+    extracting norm_out from the fused kernel and comparing the fused
+    quant_out / scale_out against per_token_group_quant_fp8_packed_for_deepgemm
+    applied to that same norm_out."""
+    from vllm.utils.deep_gemm import is_deep_gemm_supported
+
+    if not is_deep_gemm_supported():
+        pytest.skip("DeepGEMM not supported on this platform")
+
+    torch.multiprocessing.spawn(
+        _run_fused_allreduce_norm_group_quant_test,
+        args=(2, num_tokens, hidden_dim, group_size),
+        nprocs=2,
+    )
+
+
+def _run_fused_allreduce_norm_group_quant_test(
+    local_rank: int,
+    world_size: int,
+    num_tokens: int,
+    hidden_dim: int,
+    group_size: int,
+):
+    import flashinfer.comm as flashinfer_comm
+    import torch.distributed as dist
+    from flashinfer.comm.mnnvl import TorchDistBackend
+
+    from vllm.model_executor.layers.quantization.utils import fp8_utils
+    from vllm.utils.deep_gemm import is_deep_gemm_e8m0_used
+
+    device = torch.device(f"cuda:{local_rank}")
+    torch.accelerator.set_device(device)
+    dist.init_process_group(
+        backend="nccl",
+        init_method="tcp://localhost:12399",
+        rank=local_rank,
+        world_size=world_size,
+    )
+    group = dist.group.WORLD
+
+    try:
+        if not is_deep_gemm_e8m0_used():
+            return  # skip silently in subprocess
+
+        dtype = torch.bfloat16
+        workspace = flashinfer_comm.create_allreduce_fusion_workspace(
+            backend="trtllm",
+            world_size=world_size,
+            rank=local_rank,
+            max_token_num=num_tokens,
+            hidden_dim=hidden_dim,
+            dtype=dtype,
+            comm_backend=TorchDistBackend(),
+        )
+
+        groups_per_row = hidden_dim // group_size
+        k_num_packed = (groups_per_row + 3) // 4
+        tma_aligned_mn = ((num_tokens + 3) // 4) * 4
+
+        torch.manual_seed(42 + local_rank)
+        allreduce_in = (
+            torch.randn(num_tokens, hidden_dim, dtype=dtype, device=device) * 8
+        )
+        residual_in = (
+            torch.randn(num_tokens, hidden_dim, dtype=dtype, device=device) * 8
+        )
+        rms_gamma = torch.randn(hidden_dim, dtype=dtype, device=device)
+
+        # Use kARResidualRMSNormOutPerTokenGroupFP8PackedQuant so that
+        # norm_out is written to a separate buffer we can feed to the
+        # standalone quant kernel for comparison.
+        residual_out = torch.empty_like(allreduce_in)
+        norm_out = torch.empty_like(allreduce_in)
+        quant_out = torch.empty(
+            num_tokens,
+            hidden_dim,
+            dtype=torch.float8_e4m3fn,
+            device=device,
+        )
+        scale_out = torch.empty_strided(
+            (num_tokens, k_num_packed),
+            (1, tma_aligned_mn),
+            dtype=torch.int32,
+            device=device,
+        )
+
+        flashinfer_comm.allreduce_fusion(
+            input=allreduce_in,
+            workspace=workspace,
+            pattern=(
+                flashinfer_comm.AllReduceFusionPattern.kARResidualRMSNormOutPerTokenGroupFP8PackedQuant
+            ),
+            residual_in=residual_in,
+            residual_out=residual_out,
+            norm_out=norm_out,
+            quant_out=quant_out,
+            scale_out=scale_out,
+            rms_gamma=rms_gamma,
+            rms_eps=1e-5,
+            block_quant_group_size=group_size,
+            fp32_acc=True,
+            use_oneshot=True,
+        )
+        torch.accelerator.synchronize()
+
+        # Reference: apply standalone packed quant to the fused norm_out.
+        ref_q, ref_s = fp8_utils.per_token_group_quant_fp8_packed_for_deepgemm(
+            norm_out,
+            group_size=group_size,
+            use_ue8m0=True,
+        )
+
+        # Quantized activations must match exactly.
+        assert torch.equal(quant_out, ref_q), (
+            f"quant_out mismatch: "
+            f"{(quant_out != ref_q).sum().item()}/{ref_q.numel()} differ"
+        )
+
+        # Packed scales must match exactly.
+        num_scale_elems = num_tokens + (k_num_packed - 1) * tma_aligned_mn
+        fused_s = torch.as_strided(scale_out, (num_scale_elems,), (1,))
+        ref_s_flat = torch.as_strided(ref_s, (num_scale_elems,), (1,))
+        assert torch.equal(fused_s, ref_s_flat), (
+            f"scale_out mismatch: "
+            f"{(fused_s != ref_s_flat).sum().item()}/{num_scale_elems} differ"
+        )
+
+    finally:
+        dist.barrier(group=group)
+        workspace.destroy()
+        dist.destroy_process_group(group=group)

--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -229,7 +229,11 @@ class TestAllReduceRMSNormGroupQuantFP8PackedModel(torch.nn.Module):
         x2 = tensor_model_parallel_all_reduce(z2)
         y2, resid = self.norm[1](x2, resid)
 
-        # Apply group quant after norm via QuantFP8 CustomOp
+        # Apply group quant after norm via QuantFP8 CustomOp.
+        # Both y*_q and y*_s must be used to prevent dead-code elimination
+        # of the scale output, which the fusion pattern needs to match.
+        # We return the scales as extra outputs (mirroring real models where
+        # they feed into DeepGEMM).
         y2_q, y2_s = self.quant(y2)
         z3 = torch.mm(y2_q.to(x.dtype), self.w[1])
 
@@ -241,7 +245,7 @@ class TestAllReduceRMSNormGroupQuantFP8PackedModel(torch.nn.Module):
 
         x4 = tensor_model_parallel_all_reduce(z4)
         y4, resid = self.norm[3](x4, resid)
-        return y4
+        return y4, y2_s, y3_s
 
     def ops_in_model_before(self):
         return [
@@ -270,7 +274,7 @@ class TestAllReduceRMSNormGroupQuantFP8PackedModel(torch.nn.Module):
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("seq_len", [8])
 @pytest.mark.parametrize("hidden_size", [128])
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("enable_rms_norm_custom_op", [True, False])
 @pytest.mark.parametrize("flashinfer_allreduce_backend", ["trtllm", "mnnvl"])
 @pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["cuda"], reason="Only test on CUDA")
@@ -305,6 +309,9 @@ def test_all_reduce_fusion_pass_replace(
 
         if not is_deep_gemm_supported():
             pytest.skip("Skip as per-token-group packed FP8 quant requires DeepGEMM")
+
+        if flashinfer_allreduce_backend == "mnnvl":
+            pytest.skip("MNNVL backend does not support group quant fusion pattern")
 
         gs = TestAllReduceRMSNormGroupQuantFP8PackedModel.GROUP_SIZE
         if hidden_size % gs != 0:
@@ -412,7 +419,17 @@ def all_reduce_fusion_pass_on_test_model(
 
         results_unfused = model(hidden_states)
         results_fused = compiled_model(hidden_states)
-        torch.testing.assert_close(results_unfused, results_fused, atol=1e-2, rtol=1e-2)
+        # Models may return extra outputs (e.g. quant scales) to prevent DCE;
+        # compare only the primary output.
+        out_unfused = (
+            results_unfused[0]
+            if isinstance(results_unfused, tuple)
+            else results_unfused
+        )
+        out_fused = (
+            results_fused[0] if isinstance(results_fused, tuple) else results_fused
+        )
+        torch.testing.assert_close(out_unfused, out_fused, atol=1e-2, rtol=1e-2)
 
         assert all_reduce_fusion_pass.matched_count == 4, (
             f"{all_reduce_fusion_pass.matched_count=}"

--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -204,6 +204,72 @@ class TestAllReduceFusedAddRMSNormStaticQuantFP4Model(torch.nn.Module):
         ]
 
 
+class TestAllReduceRMSNormGroupQuantFP8PackedModel(torch.nn.Module):
+    """AR + RMSNorm + per_token_group_quant_fp8_packed_for_deepgemm fusion test.
+
+    Uses QuantFP8 (the CustomOp) like real models do, so the compiled graph
+    matches the e2e trace structure where the fusion pattern is known to work.
+    """
+
+    GROUP_SIZE = 128
+
+    def __init__(
+        self,
+        hidden_size=128,
+        token_num=16,
+        eps=1e-5,
+        dtype: torch.dtype = torch.bfloat16,
+    ):
+        super().__init__()
+        from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
+        from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
+
+        self.hidden_size = hidden_size
+        self.eps = eps
+        self.norm = [RMSNorm(hidden_size, eps) for _ in range(4)]
+        self.w = [torch.rand(hidden_size, hidden_size) for _ in range(3)]
+        self.quant = QuantFP8(
+            static=False,
+            group_shape=GroupShape(1, self.GROUP_SIZE),
+            use_ue8m0=True,
+        )
+
+    def forward(self, x):
+        z = torch.relu(x)
+        x = resid = tensor_model_parallel_all_reduce(z)
+        y = self.norm[0](x)
+
+        z2 = torch.mm(y, self.w[0])
+        x2 = tensor_model_parallel_all_reduce(z2)
+        y2, resid = self.norm[1](x2, resid)
+
+        # Apply group quant after norm via QuantFP8 CustomOp
+        y2_q, y2_s = self.quant(y2)
+        z3 = torch.mm(y2_q.to(x.dtype), self.w[1])
+
+        x3 = tensor_model_parallel_all_reduce(z3)
+        y3, resid = self.norm[2](x3, resid)
+
+        y3_q, y3_s = self.quant(y3)
+        z4 = torch.mm(y3_q.to(x.dtype), self.w[2])
+
+        x4 = tensor_model_parallel_all_reduce(z4)
+        y4, resid = self.norm[3](x4, resid)
+        return y4
+
+    def ops_in_model_before(self):
+        return [
+            torch.ops.vllm.all_reduce.default,
+            torch.ops._C.per_token_group_fp8_quant_packed.default,
+        ]
+
+    def ops_in_model_after(self):
+        return [
+            torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm.default,
+            torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm_group_quant.default,
+        ]
+
+
 @multi_gpu_test(num_gpus=2)
 @pytest.mark.parametrize(
     "test_model, enable_quant_fp8_custom_op, use_aiter",
@@ -236,12 +302,21 @@ class TestAllReduceFusedAddRMSNormStaticQuantFP4Model(torch.nn.Module):
                 reason="Not supported on ROCm platform",
             ),
         ),
+        pytest.param(
+            TestAllReduceRMSNormGroupQuantFP8PackedModel,
+            False,
+            False,
+            marks=pytest.mark.skipif(
+                current_platform.is_rocm(),
+                reason="Not supported on ROCm platform",
+            ),
+        ),
     ],
 )
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("seq_len", [8])
-@pytest.mark.parametrize("hidden_size", [64])
-@pytest.mark.parametrize("dtype", [torch.bfloat16])
+@pytest.mark.parametrize("hidden_size", [128])
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("enable_rms_norm_custom_op", [True, False])
 @pytest.mark.parametrize("flashinfer_allreduce_backend", ["trtllm", "mnnvl"])
 @pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["cuda"], reason="Only test on CUDA")
@@ -287,6 +362,14 @@ def test_all_reduce_fusion_pass_replace(
             "Skip as nvfp4 is only supported on "
             "devices with compute capability 10.0 (Blackwell)"
         )
+    if test_model == TestAllReduceRMSNormGroupQuantFP8PackedModel:
+        from vllm.utils.deep_gemm import is_deep_gemm_supported
+
+        if not is_deep_gemm_supported():
+            pytest.skip("Skip as per-token-group packed FP8 quant requires DeepGEMM")
+        gs = TestAllReduceRMSNormGroupQuantFP8PackedModel.GROUP_SIZE
+        if hidden_size % gs != 0:
+            pytest.skip(f"hidden_size={hidden_size} not divisible by group_size={gs}")
 
     def run_torch_spawn(fn, nprocs):
         torch.multiprocessing.spawn(
@@ -349,6 +432,14 @@ def all_reduce_fusion_pass_on_test_model(
         custom_ops.append("+rms_norm")
     if enable_quant_fp8_custom_op:
         custom_ops.append("+quant_fp8")
+    # Group quant model needs QuantFP8 custom op enabled to use CUDA path,
+    # and the DeepGemm oracle initialized for the packed quant path.
+    if test_model_cls == TestAllReduceRMSNormGroupQuantFP8PackedModel:
+        if "+quant_fp8" not in custom_ops:
+            custom_ops.append("+quant_fp8")
+        from vllm.utils.deep_gemm import DeepGemmQuantScaleFMT
+
+        DeepGemmQuantScaleFMT.init_oracle_cache()
 
     vllm_config = VllmConfig(
         compilation_config=CompilationConfig(
@@ -399,9 +490,36 @@ def all_reduce_fusion_pass_on_test_model(
         results_fused = compiled_model(hidden_states)
         torch.testing.assert_close(results_unfused, results_fused, atol=1e-2, rtol=1e-2)
 
-        assert all_reduce_fusion_pass.matched_count == 4, (
-            f"{all_reduce_fusion_pass.matched_count=}"
-        )
-        backend.check_before_ops(model.ops_in_model_before(), fully_replaced=False)
-        backend.check_after_ops(model.ops_in_model_after())
+        if test_model_cls == TestAllReduceRMSNormGroupQuantFP8PackedModel:
+            if not enable_rms_norm_custom_op:
+                # Native RMSNorm ops → patterns can't match the rmsnorm node
+                pass
+            elif flashinfer_allreduce_backend == "mnnvl":
+                # mnnvl doesn't support quant fusion; only non-quant
+                # AR+RMSNorm patterns fire (2 of 4 allreduce points
+                # have quant after them → those won't match the quant
+                # pattern on mnnvl, but the non-quant pattern still
+                # matches all 4 allreduce+rmsnorm points).
+                assert all_reduce_fusion_pass.matched_count >= 2, (
+                    f"Expected at least 2 allreduce fusions on mnnvl, got "
+                    f"{all_reduce_fusion_pass.matched_count}"
+                )
+            else:
+                # trtllm backend + custom RMSNorm enabled: all 4 allreduce
+                # patterns should match (2 with quant, 2 without).
+                assert all_reduce_fusion_pass.matched_count == 4, (
+                    f"Expected 4 allreduce fusions (2 with group quant), "
+                    f"got {all_reduce_fusion_pass.matched_count}"
+                )
+                # Verify the group quant op was actually fused
+                backend.check_before_ops(
+                    model.ops_in_model_before(), fully_replaced=False
+                )
+                backend.check_after_ops(model.ops_in_model_after())
+        else:
+            assert all_reduce_fusion_pass.matched_count == 4, (
+                f"{all_reduce_fusion_pass.matched_count=}"
+            )
+            backend.check_before_ops(model.ops_in_model_before(), fully_replaced=False)
+            backend.check_after_ops(model.ops_in_model_after())
         del all_reduce_fusion_pass

--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -514,28 +514,42 @@ def all_reduce_fusion_pass_on_test_model(
         del all_reduce_fusion_pass
 
 
+_GROUP_QUANT_FP8_PACKED_CASES = [
+    # (num_tokens, hidden_dim, group_size)
+    (4, 7168, 128),
+    (1, 7168, 128),
+    (3, 7168, 128),
+    (4, 640, 128),
+    (4, 768, 128),
+    (4, 384, 128),
+    (1, 384, 128),
+    (3, 640, 128),
+    (64, 7168, 128),
+    (128, 14336, 128),
+    (127, 7168, 128),
+    (253, 640, 128),
+    (1, 256, 128),
+    (4, 7168, 64),
+    (1, 7168, 64),
+    (4, 640, 64),
+    (3, 768, 64),
+    (3, 640, 64),
+    (4, 768, 8),
+    (4, 768, 16),
+    (4, 768, 12),
+    (3, 768, 6),
+    (4, 768, 4),
+    (4, 768, 48),
+    (4, 960, 48),
+    (3, 768, 24),
+    (512, 768, 48),
+    (4, 7168, 512),
+    (4, 4096, 256),
+    (3, 4096, 512),
+]
+
+
 @multi_gpu_test(num_gpus=2)
-@pytest.mark.parametrize(
-    "num_tokens,hidden_dim,group_size",
-    [
-        (4, 7168, 128),
-        (1, 7168, 128),
-        (3, 7168, 128),
-        (4, 640, 128),
-        (4, 768, 128),
-        (4, 384, 128),
-        (1, 384, 128),
-        (3, 640, 128),
-        (64, 7168, 128),
-        (128, 14336, 128),
-        (127, 7168, 128),
-        (253, 640, 128),
-        (4, 7168, 64),
-        (1, 7168, 64),
-        (4, 640, 64),
-        (3, 768, 64),
-    ],
-)
 @pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["cuda"], reason="Only test on CUDA")
 @pytest.mark.skipif(
     not find_spec("flashinfer")
@@ -543,31 +557,30 @@ def all_reduce_fusion_pass_on_test_model(
     or not has_module_attribute("flashinfer.comm", "create_allreduce_fusion_workspace"),
     reason="flashinfer allreduce_fusion not available",
 )
-def test_fused_allreduce_norm_group_quant_fp8_packed(
-    num_tokens, hidden_dim, group_size
-):
+def test_fused_allreduce_norm_group_quant_fp8_packed():
     """Test the flashinfer fused allreduce+RMSNorm+group-quant kernel by
     extracting norm_out from the fused kernel and comparing the fused
     quant_out / scale_out against per_token_group_quant_fp8_packed_for_deepgemm
-    applied to that same norm_out."""
+    applied to that same norm_out.
+
+    All shape combos run inside a single process group spawn to avoid
+    per-case process startup + NCCL init overhead."""
     from vllm.utils.deep_gemm import is_deep_gemm_supported
 
     if not is_deep_gemm_supported():
         pytest.skip("DeepGEMM not supported on this platform")
 
     torch.multiprocessing.spawn(
-        _run_fused_allreduce_norm_group_quant_test,
-        args=(2, num_tokens, hidden_dim, group_size),
+        _run_fused_allreduce_norm_group_quant_batch,
+        args=(2, _GROUP_QUANT_FP8_PACKED_CASES),
         nprocs=2,
     )
 
 
-def _run_fused_allreduce_norm_group_quant_test(
+def _run_fused_allreduce_norm_group_quant_batch(
     local_rank: int,
     world_size: int,
-    num_tokens: int,
-    hidden_dim: int,
-    group_size: int,
+    cases: list,
 ):
     import flashinfer.comm as flashinfer_comm
     import torch.distributed as dist
@@ -591,89 +604,107 @@ def _run_fused_allreduce_norm_group_quant_test(
             return  # skip silently in subprocess
 
         dtype = torch.bfloat16
+        max_tokens = max(c[0] for c in cases)
+        max_hidden = max(c[1] for c in cases)
         workspace = flashinfer_comm.create_allreduce_fusion_workspace(
             backend="trtllm",
             world_size=world_size,
             rank=local_rank,
-            max_token_num=num_tokens,
-            hidden_dim=hidden_dim,
+            max_token_num=max_tokens,
+            hidden_dim=max_hidden,
             dtype=dtype,
             comm_backend=TorchDistBackend(),
         )
 
-        groups_per_row = hidden_dim // group_size
-        k_num_packed = (groups_per_row + 3) // 4
-        tma_aligned_mn = ((num_tokens + 3) // 4) * 4
+        for num_tokens, hidden_dim, group_size in cases:
+            # Recreate workspace if current one is too small
+            if not workspace.is_buffer_size_sufficient(
+                world_size, num_tokens, hidden_dim, dtype
+            ):
+                workspace.destroy()
+                workspace = flashinfer_comm.create_allreduce_fusion_workspace(
+                    backend="trtllm",
+                    world_size=world_size,
+                    rank=local_rank,
+                    max_token_num=num_tokens,
+                    hidden_dim=hidden_dim,
+                    dtype=dtype,
+                    comm_backend=TorchDistBackend(),
+                )
 
-        torch.manual_seed(42 + local_rank)
-        allreduce_in = (
-            torch.randn(num_tokens, hidden_dim, dtype=dtype, device=device) * 8
-        )
-        residual_in = (
-            torch.randn(num_tokens, hidden_dim, dtype=dtype, device=device) * 8
-        )
-        rms_gamma = torch.randn(hidden_dim, dtype=dtype, device=device)
+            groups_per_row = hidden_dim // group_size
+            k_num_packed = (groups_per_row + 3) // 4
+            tma_aligned_mn = ((num_tokens + 3) // 4) * 4
 
-        # Use kARResidualRMSNormOutPerTokenGroupFP8PackedQuant so that
-        # norm_out is written to a separate buffer we can feed to the
-        # standalone quant kernel for comparison.
-        residual_out = torch.empty_like(allreduce_in)
-        norm_out = torch.empty_like(allreduce_in)
-        quant_out = torch.empty(
-            num_tokens,
-            hidden_dim,
-            dtype=torch.float8_e4m3fn,
-            device=device,
-        )
-        scale_out = torch.empty_strided(
-            (num_tokens, k_num_packed),
-            (1, tma_aligned_mn),
-            dtype=torch.int32,
-            device=device,
-        )
+            torch.manual_seed(42 + local_rank)
+            allreduce_in = (
+                torch.randn(num_tokens, hidden_dim, dtype=dtype, device=device) * 8
+            )
+            residual_in = (
+                torch.randn(num_tokens, hidden_dim, dtype=dtype, device=device) * 8
+            )
+            rms_gamma = torch.randn(hidden_dim, dtype=dtype, device=device)
 
-        flashinfer_comm.allreduce_fusion(
-            input=allreduce_in,
-            workspace=workspace,
-            pattern=(
-                flashinfer_comm.AllReduceFusionPattern.kARResidualRMSNormOutPerTokenGroupFP8PackedQuant
-            ),
-            residual_in=residual_in,
-            residual_out=residual_out,
-            norm_out=norm_out,
-            quant_out=quant_out,
-            scale_out=scale_out,
-            rms_gamma=rms_gamma,
-            rms_eps=1e-5,
-            block_quant_group_size=group_size,
-            fp32_acc=True,
-            use_oneshot=True,
-        )
-        torch.accelerator.synchronize()
+            residual_out = torch.empty_like(allreduce_in)
+            norm_out = torch.empty_like(allreduce_in)
+            quant_out = torch.empty(
+                num_tokens,
+                hidden_dim,
+                dtype=torch.float8_e4m3fn,
+                device=device,
+            )
+            scale_out = torch.empty_strided(
+                (num_tokens, k_num_packed),
+                (1, tma_aligned_mn),
+                dtype=torch.int32,
+                device=device,
+            )
 
-        # Reference: apply standalone packed quant to the fused norm_out.
-        ref_q, ref_s = fp8_utils.per_token_group_quant_fp8_packed_for_deepgemm(
-            norm_out,
-            group_size=group_size,
-            use_ue8m0=True,
-        )
+            flashinfer_comm.allreduce_fusion(
+                input=allreduce_in,
+                workspace=workspace,
+                pattern=(
+                    flashinfer_comm.AllReduceFusionPattern.kARResidualRMSNormOutPerTokenGroupFP8PackedQuant
+                ),
+                residual_in=residual_in,
+                residual_out=residual_out,
+                norm_out=norm_out,
+                quant_out=quant_out,
+                scale_out=scale_out,
+                rms_gamma=rms_gamma,
+                rms_eps=1e-5,
+                block_quant_group_size=group_size,
+                fp32_acc=True,
+                use_oneshot=True,
+            )
+            torch.accelerator.synchronize()
 
-        # Quantized activations must match exactly.
-        assert torch.equal(quant_out, ref_q), (
-            f"quant_out mismatch: "
-            f"{(quant_out != ref_q).sum().item()}/{ref_q.numel()} differ"
-        )
+            # Reference: apply standalone packed quant to the fused norm_out.
+            ref_q, ref_s = fp8_utils.per_token_group_quant_fp8_packed_for_deepgemm(
+                norm_out,
+                group_size=group_size,
+                use_ue8m0=True,
+            )
 
-        # Packed scales must match exactly.
-        num_scale_elems = num_tokens + (k_num_packed - 1) * tma_aligned_mn
-        fused_s = torch.as_strided(scale_out, (num_scale_elems,), (1,))
-        ref_s_flat = torch.as_strided(ref_s, (num_scale_elems,), (1,))
-        assert torch.equal(fused_s, ref_s_flat), (
-            f"scale_out mismatch: "
-            f"{(fused_s != ref_s_flat).sum().item()}/{num_scale_elems} differ"
-        )
+            # Quantized activations must match exactly.
+            assert torch.equal(quant_out, ref_q), (
+                f"[tokens={num_tokens}, hidden={hidden_dim}, gs={group_size}] "
+                f"quant_out mismatch: "
+                f"{(quant_out != ref_q).sum().item()}/{ref_q.numel()} differ"
+            )
+
+            # Packed scales must match exactly.
+            num_scale_elems = num_tokens + (k_num_packed - 1) * tma_aligned_mn
+            fused_s = torch.as_strided(scale_out, (num_scale_elems,), (1,))
+            ref_s_flat = torch.as_strided(ref_s, (num_scale_elems,), (1,))
+            assert torch.equal(fused_s, ref_s_flat), (
+                f"[tokens={num_tokens}, hidden={hidden_dim}, gs={group_size}] "
+                f"scale_out mismatch: "
+                f"{(fused_s != ref_s_flat).sum().item()}/{num_scale_elems} differ"
+            )
+
+            dist.barrier(group=group)
 
     finally:
-        dist.barrier(group=group)
         workspace.destroy()
         dist.destroy_process_group(group=group)

--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -494,8 +494,7 @@ def all_reduce_fusion_pass_on_test_model(
 
         results_unfused = model(hidden_states)
         results_fused = compiled_model(hidden_states)
-        # Models may return extra outputs (e.g. quant scales) to prevent DCE;
-        # compare only the primary output.
+
         out_unfused = (
             results_unfused[0]
             if isinstance(results_unfused, tuple)
@@ -516,36 +515,35 @@ def all_reduce_fusion_pass_on_test_model(
 
 _GROUP_QUANT_FP8_PACKED_CASES = [
     # (num_tokens, hidden_dim, group_size)
-    (4, 7168, 128),
-    (1, 7168, 128),
-    (3, 7168, 128),
-    (4, 640, 128),
-    (4, 768, 128),
-    (4, 384, 128),
-    (1, 384, 128),
-    (3, 640, 128),
-    (64, 7168, 128),
-    (128, 14336, 128),
-    (127, 7168, 128),
-    (253, 640, 128),
-    (1, 256, 128),
-    (4, 7168, 64),
-    (1, 7168, 64),
-    (4, 640, 64),
-    (3, 768, 64),
-    (3, 640, 64),
-    (4, 768, 8),
-    (4, 768, 16),
-    (4, 768, 12),
-    (3, 768, 6),
-    (4, 768, 4),
-    (4, 768, 48),
-    (4, 960, 48),
-    (3, 768, 24),
-    (512, 768, 48),
-    (4, 7168, 512),
-    (4, 4096, 256),
-    (3, 4096, 512),
+    #
+    # Layout-driving quantities for each case:
+    #   tma_aligned_mn = round_up(num_tokens, 4)
+    #   groups_per_row = hidden_dim // group_size
+    #   k_num_packed   = round_up(groups_per_row, 4) // 4
+    # Cases are grouped by which boundary they exercise.
+    #
+    # groups_per_row % 4 == 0 (no packing padding).
+    (4, 7168, 128),  # 56 groups, 14 packed; tokens % 4 == 0
+    (1, 7168, 128),  # single token, large hidden
+    (3, 7168, 128),  # tokens % 4 == 3
+    (64, 7168, 128),  # moderate batch
+    (128, 14336, 128),  # 112 groups, 28 packed; large batch and hidden
+    (127, 7168, 128),  # tokens % 4 == 3 at scale
+    # groups_per_row % 4 != 0: packed-scale row needs zero padding.
+    (4, 640, 128),  # 5 groups → 2 packed (groups % 4 == 1)
+    (4, 768, 128),  # 6 groups → 2 packed (groups % 4 == 2)
+    (4, 384, 128),  # 3 groups → 1 packed (groups % 4 == 3)
+    (1, 384, 128),  # 3 groups, single token
+    (3, 640, 128),  # 5 groups, 3 tokens
+    (1, 256, 128),  # 2 groups, single token
+    (253, 640, 128),  # 5 groups, tokens % 4 == 1 at scale
+    # num_tokens % 4 == 2: tma_aligned_mn stride boundary not covered above.
+    (2, 7168, 128),
+    (6, 768, 128),
+    (254, 640, 128),
+    # hidden_dim == group_size: single group per row (groups_per_row == 1).
+    (4, 128, 128),
+    (1, 128, 128),
 ]
 
 
@@ -561,10 +559,7 @@ def test_fused_allreduce_norm_group_quant_fp8_packed():
     """Test the flashinfer fused allreduce+RMSNorm+group-quant kernel by
     extracting norm_out from the fused kernel and comparing the fused
     quant_out / scale_out against per_token_group_quant_fp8_packed_for_deepgemm
-    applied to that same norm_out.
-
-    All shape combos run inside a single process group spawn to avoid
-    per-case process startup + NCCL init overhead."""
+    applied to that same norm_out."""
     from vllm.utils.deep_gemm import is_deep_gemm_supported
 
     if not is_deep_gemm_supported():

--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -243,7 +243,11 @@ class TestAllReduceRMSNormGroupQuantFP8PackedModel(torch.nn.Module):
         x2 = tensor_model_parallel_all_reduce(z2)
         y2, resid = self.norm[1](x2, resid)
 
-        # Apply group quant after norm via QuantFP8 CustomOp
+        # Apply group quant after norm via QuantFP8 CustomOp.
+        # Both y*_q and y*_s must be used to prevent dead-code elimination
+        # of the scale output, which the fusion pattern needs to match.
+        # We return the scales as extra outputs (mirroring real models where
+        # they feed into DeepGEMM).
         y2_q, y2_s = self.quant(y2)
         z3 = torch.mm(y2_q.to(x.dtype), self.w[1])
 
@@ -255,7 +259,7 @@ class TestAllReduceRMSNormGroupQuantFP8PackedModel(torch.nn.Module):
 
         x4 = tensor_model_parallel_all_reduce(z4)
         y4, resid = self.norm[3](x4, resid)
-        return y4
+        return y4, y2_s, y3_s
 
     def ops_in_model_before(self):
         return [
@@ -316,7 +320,7 @@ class TestAllReduceRMSNormGroupQuantFP8PackedModel(torch.nn.Module):
 @pytest.mark.parametrize("batch_size", [8])
 @pytest.mark.parametrize("seq_len", [8])
 @pytest.mark.parametrize("hidden_size", [128])
-@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("dtype", [torch.bfloat16])
 @pytest.mark.parametrize("enable_rms_norm_custom_op", [True, False])
 @pytest.mark.parametrize("flashinfer_allreduce_backend", ["trtllm", "mnnvl"])
 @pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["cuda"], reason="Only test on CUDA")
@@ -367,6 +371,9 @@ def test_all_reduce_fusion_pass_replace(
 
         if not is_deep_gemm_supported():
             pytest.skip("Skip as per-token-group packed FP8 quant requires DeepGEMM")
+
+        if flashinfer_allreduce_backend == "mnnvl":
+            pytest.skip("MNNVL backend does not support group quant fusion pattern")
 
         gs = TestAllReduceRMSNormGroupQuantFP8PackedModel.GROUP_SIZE
         if hidden_size % gs != 0:
@@ -487,7 +494,17 @@ def all_reduce_fusion_pass_on_test_model(
 
         results_unfused = model(hidden_states)
         results_fused = compiled_model(hidden_states)
-        torch.testing.assert_close(results_unfused, results_fused, atol=1e-2, rtol=1e-2)
+        # Models may return extra outputs (e.g. quant scales) to prevent DCE;
+        # compare only the primary output.
+        out_unfused = (
+            results_unfused[0]
+            if isinstance(results_unfused, tuple)
+            else results_unfused
+        )
+        out_fused = (
+            results_fused[0] if isinstance(results_fused, tuple) else results_fused
+        )
+        torch.testing.assert_close(out_unfused, out_fused, atol=1e-2, rtol=1e-2)
 
         assert all_reduce_fusion_pass.matched_count == 4, (
             f"{all_reduce_fusion_pass.matched_count=}"

--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -577,7 +577,7 @@ def _run_fused_allreduce_norm_group_quant_test(
     from vllm.utils.deep_gemm import is_deep_gemm_e8m0_used
 
     device = torch.device(f"cuda:{local_rank}")
-    torch.accelerator.set_device(device)
+    torch.accelerator.set_device_index(device)
     dist.init_process_group(
         backend="nccl",
         init_method="tcp://localhost:12399",

--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -304,7 +304,7 @@ class TestAllReduceRMSNormGroupQuantFP8PackedModel(torch.nn.Module):
         ),
         pytest.param(
             TestAllReduceRMSNormGroupQuantFP8PackedModel,
-            False,
+            True,
             False,
             marks=pytest.mark.skipif(
                 current_platform.is_rocm(),
@@ -367,6 +367,7 @@ def test_all_reduce_fusion_pass_replace(
 
         if not is_deep_gemm_supported():
             pytest.skip("Skip as per-token-group packed FP8 quant requires DeepGEMM")
+
         gs = TestAllReduceRMSNormGroupQuantFP8PackedModel.GROUP_SIZE
         if hidden_size % gs != 0:
             pytest.skip(f"hidden_size={hidden_size} not divisible by group_size={gs}")
@@ -432,14 +433,12 @@ def all_reduce_fusion_pass_on_test_model(
         custom_ops.append("+rms_norm")
     if enable_quant_fp8_custom_op:
         custom_ops.append("+quant_fp8")
-    # Group quant model needs QuantFP8 custom op enabled to use CUDA path,
-    # and the DeepGemm oracle initialized for the packed quant path.
-    if test_model_cls == TestAllReduceRMSNormGroupQuantFP8PackedModel:
-        if "+quant_fp8" not in custom_ops:
-            custom_ops.append("+quant_fp8")
-        from vllm.utils.deep_gemm import DeepGemmQuantScaleFMT
 
-        DeepGemmQuantScaleFMT.init_oracle_cache()
+    if test_model_cls == TestAllReduceRMSNormGroupQuantFP8PackedModel:
+        from vllm.utils.deep_gemm import is_deep_gemm_e8m0_used
+
+        if not is_deep_gemm_e8m0_used():
+            pytest.skip("Skip as DeepGEMM E8M0 is not supported on this system")
 
     vllm_config = VllmConfig(
         compilation_config=CompilationConfig(
@@ -490,36 +489,9 @@ def all_reduce_fusion_pass_on_test_model(
         results_fused = compiled_model(hidden_states)
         torch.testing.assert_close(results_unfused, results_fused, atol=1e-2, rtol=1e-2)
 
-        if test_model_cls == TestAllReduceRMSNormGroupQuantFP8PackedModel:
-            if not enable_rms_norm_custom_op:
-                # Native RMSNorm ops → patterns can't match the rmsnorm node
-                pass
-            elif flashinfer_allreduce_backend == "mnnvl":
-                # mnnvl doesn't support quant fusion; only non-quant
-                # AR+RMSNorm patterns fire (2 of 4 allreduce points
-                # have quant after them → those won't match the quant
-                # pattern on mnnvl, but the non-quant pattern still
-                # matches all 4 allreduce+rmsnorm points).
-                assert all_reduce_fusion_pass.matched_count >= 2, (
-                    f"Expected at least 2 allreduce fusions on mnnvl, got "
-                    f"{all_reduce_fusion_pass.matched_count}"
-                )
-            else:
-                # trtllm backend + custom RMSNorm enabled: all 4 allreduce
-                # patterns should match (2 with quant, 2 without).
-                assert all_reduce_fusion_pass.matched_count == 4, (
-                    f"Expected 4 allreduce fusions (2 with group quant), "
-                    f"got {all_reduce_fusion_pass.matched_count}"
-                )
-                # Verify the group quant op was actually fused
-                backend.check_before_ops(
-                    model.ops_in_model_before(), fully_replaced=False
-                )
-                backend.check_after_ops(model.ops_in_model_after())
-        else:
-            assert all_reduce_fusion_pass.matched_count == 4, (
-                f"{all_reduce_fusion_pass.matched_count=}"
-            )
-            backend.check_before_ops(model.ops_in_model_before(), fully_replaced=False)
-            backend.check_after_ops(model.ops_in_model_after())
+        assert all_reduce_fusion_pass.matched_count == 4, (
+            f"{all_reduce_fusion_pass.matched_count=}"
+        )
+        backend.check_before_ops(model.ops_in_model_before(), fully_replaced=False)
+        backend.check_after_ops(model.ops_in_model_after())
         del all_reduce_fusion_pass

--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -512,3 +512,168 @@ def all_reduce_fusion_pass_on_test_model(
         backend.check_before_ops(model.ops_in_model_before(), fully_replaced=False)
         backend.check_after_ops(model.ops_in_model_after())
         del all_reduce_fusion_pass
+
+
+@multi_gpu_test(num_gpus=2)
+@pytest.mark.parametrize(
+    "num_tokens,hidden_dim,group_size",
+    [
+        (4, 7168, 128),
+        (1, 7168, 128),
+        (3, 7168, 128),
+        (4, 640, 128),
+        (4, 768, 128),
+        (4, 384, 128),
+        (1, 384, 128),
+        (3, 640, 128),
+        (64, 7168, 128),
+        (128, 14336, 128),
+        (127, 7168, 128),
+        (253, 640, 128),
+        (4, 7168, 64),
+        (1, 7168, 64),
+        (4, 640, 64),
+        (3, 768, 64),
+    ],
+)
+@pytest.mark.skipif(envs.VLLM_TARGET_DEVICE not in ["cuda"], reason="Only test on CUDA")
+@pytest.mark.skipif(
+    not find_spec("flashinfer")
+    or not has_module_attribute("flashinfer.comm", "allreduce_fusion")
+    or not has_module_attribute("flashinfer.comm", "create_allreduce_fusion_workspace"),
+    reason="flashinfer allreduce_fusion not available",
+)
+def test_fused_allreduce_norm_group_quant_fp8_packed(
+    num_tokens, hidden_dim, group_size
+):
+    """Test the flashinfer fused allreduce+RMSNorm+group-quant kernel by
+    extracting norm_out from the fused kernel and comparing the fused
+    quant_out / scale_out against per_token_group_quant_fp8_packed_for_deepgemm
+    applied to that same norm_out."""
+    from vllm.utils.deep_gemm import is_deep_gemm_supported
+
+    if not is_deep_gemm_supported():
+        pytest.skip("DeepGEMM not supported on this platform")
+
+    torch.multiprocessing.spawn(
+        _run_fused_allreduce_norm_group_quant_test,
+        args=(2, num_tokens, hidden_dim, group_size),
+        nprocs=2,
+    )
+
+
+def _run_fused_allreduce_norm_group_quant_test(
+    local_rank: int,
+    world_size: int,
+    num_tokens: int,
+    hidden_dim: int,
+    group_size: int,
+):
+    import flashinfer.comm as flashinfer_comm
+    import torch.distributed as dist
+    from flashinfer.comm.mnnvl import TorchDistBackend
+
+    from vllm.model_executor.layers.quantization.utils import fp8_utils
+    from vllm.utils.deep_gemm import is_deep_gemm_e8m0_used
+
+    device = torch.device(f"cuda:{local_rank}")
+    torch.accelerator.set_device(device)
+    dist.init_process_group(
+        backend="nccl",
+        init_method="tcp://localhost:12399",
+        rank=local_rank,
+        world_size=world_size,
+    )
+    group = dist.group.WORLD
+
+    try:
+        if not is_deep_gemm_e8m0_used():
+            return  # skip silently in subprocess
+
+        dtype = torch.bfloat16
+        workspace = flashinfer_comm.create_allreduce_fusion_workspace(
+            backend="trtllm",
+            world_size=world_size,
+            rank=local_rank,
+            max_token_num=num_tokens,
+            hidden_dim=hidden_dim,
+            dtype=dtype,
+            comm_backend=TorchDistBackend(),
+        )
+
+        groups_per_row = hidden_dim // group_size
+        k_num_packed = (groups_per_row + 3) // 4
+        tma_aligned_mn = ((num_tokens + 3) // 4) * 4
+
+        torch.manual_seed(42 + local_rank)
+        allreduce_in = (
+            torch.randn(num_tokens, hidden_dim, dtype=dtype, device=device) * 8
+        )
+        residual_in = (
+            torch.randn(num_tokens, hidden_dim, dtype=dtype, device=device) * 8
+        )
+        rms_gamma = torch.randn(hidden_dim, dtype=dtype, device=device)
+
+        # Use kARResidualRMSNormOutPerTokenGroupFP8PackedQuant so that
+        # norm_out is written to a separate buffer we can feed to the
+        # standalone quant kernel for comparison.
+        residual_out = torch.empty_like(allreduce_in)
+        norm_out = torch.empty_like(allreduce_in)
+        quant_out = torch.empty(
+            num_tokens,
+            hidden_dim,
+            dtype=torch.float8_e4m3fn,
+            device=device,
+        )
+        scale_out = torch.empty_strided(
+            (num_tokens, k_num_packed),
+            (1, tma_aligned_mn),
+            dtype=torch.int32,
+            device=device,
+        )
+
+        flashinfer_comm.allreduce_fusion(
+            input=allreduce_in,
+            workspace=workspace,
+            pattern=(
+                flashinfer_comm.AllReduceFusionPattern.kARResidualRMSNormOutPerTokenGroupFP8PackedQuant
+            ),
+            residual_in=residual_in,
+            residual_out=residual_out,
+            norm_out=norm_out,
+            quant_out=quant_out,
+            scale_out=scale_out,
+            rms_gamma=rms_gamma,
+            rms_eps=1e-5,
+            block_quant_group_size=group_size,
+            fp32_acc=True,
+            use_oneshot=True,
+        )
+        torch.accelerator.synchronize()
+
+        # Reference: apply standalone packed quant to the fused norm_out.
+        ref_q, ref_s = fp8_utils.per_token_group_quant_fp8_packed_for_deepgemm(
+            norm_out,
+            group_size=group_size,
+            use_ue8m0=True,
+        )
+
+        # Quantized activations must match exactly.
+        assert torch.equal(quant_out, ref_q), (
+            f"quant_out mismatch: "
+            f"{(quant_out != ref_q).sum().item()}/{ref_q.numel()} differ"
+        )
+
+        # Packed scales must match exactly.
+        num_scale_elems = num_tokens + (k_num_packed - 1) * tma_aligned_mn
+        fused_s = torch.as_strided(scale_out, (num_scale_elems,), (1,))
+        ref_s_flat = torch.as_strided(ref_s, (num_scale_elems,), (1,))
+        assert torch.equal(fused_s, ref_s_flat), (
+            f"scale_out mismatch: "
+            f"{(fused_s != ref_s_flat).sum().item()}/{num_scale_elems} differ"
+        )
+
+    finally:
+        dist.barrier(group=group)
+        workspace.destroy()
+        dist.destroy_process_group(group=group)

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -249,7 +249,7 @@ if flashinfer_comm is not None:
         launch_with_pdl: bool,
         fp32_acc: bool,
         max_token_num: int,
-        group_size: int,
+        block_quant_group_size: int,
         quant_out: torch.Tensor | None = None,
         scale_out: torch.Tensor | None = None,
     ) -> None:
@@ -287,7 +287,7 @@ if flashinfer_comm is not None:
         flashinfer_comm.allreduce_fusion(
             input=allreduce_in,
             workspace=workspace,
-            pattern=ar_fusion_patterns.kARResidualRMSNormGroupFP8Quant,
+            pattern=ar_fusion_patterns.kARResidualRMSNormPerTokenGroupFP8PackedQuant,
             launch_with_pdl=launch_with_pdl,
             output=None,
             residual_out=residual,
@@ -299,7 +299,7 @@ if flashinfer_comm is not None:
             rms_eps=rms_eps,
             use_oneshot=use_oneshot,
             fp32_acc=fp32_acc,
-            group_size=group_size,
+            block_quant_group_size=block_quant_group_size,
         )
 
     def call_trtllm_fused_allreduce_norm_group_quant_fake(
@@ -311,7 +311,7 @@ if flashinfer_comm is not None:
         launch_with_pdl: bool,
         fp32_acc: bool,
         max_token_num: int,
-        group_size: int,
+        block_quant_group_size: int,
         quant_out: torch.Tensor | None = None,
         scale_out: torch.Tensor | None = None,
     ) -> None:
@@ -329,8 +329,7 @@ if flashinfer_comm is not None:
         fake_impl=call_trtllm_fused_allreduce_norm_group_quant_fake,
     )
     flashinfer_trtllm_fused_allreduce_norm_group_quant = (
-        torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm_group_quant
-        .default
+        torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm_group_quant.default
     )
 
 
@@ -846,7 +845,7 @@ class AllReduceFusedRMSNormGroupQuantFP8PackedPattern(BasePattern):
     with UE8M0 packed scales (for DeepGEMM).
     Applies to the first Transformer block where there is no residual.
 
-    Uses flashinfer kARResidualRMSNormGroupFP8Quant (single kernel).
+    Uses flashinfer kARResidualRMSNormPerTokenGroupFP8PackedQuant (single kernel).
     """
 
     def __init__(
@@ -869,12 +868,8 @@ class AllReduceFusedRMSNormGroupQuantFP8PackedPattern(BasePattern):
     def get_inputs(self) -> list[torch.Tensor]:
         input_t = self.empty(5, 16)
         weight = self.empty(16)
-        output_q = torch.empty(
-            (5, 16), device=self.device, dtype=self.quant_dtype
-        )
-        output_s_packed = torch.empty(
-            (5, 1), device=self.device, dtype=torch.int32
-        )
+        output_q = torch.empty((5, 16), device=self.device, dtype=self.quant_dtype)
+        output_s_packed = torch.empty((5, 1), device=self.device, dtype=torch.int32)
         return [input_t, weight, output_q, output_s_packed]
 
     def register(self, pm_pass: PatternMatcherPass) -> None:
@@ -913,7 +908,7 @@ class AllReduceFusedRMSNormGroupQuantFP8PackedPattern(BasePattern):
                 residual=residual,
                 rms_gamma=weight,
                 rms_eps=self.epsilon,
-                group_size=self.group_size,
+                block_quant_group_size=self.group_size,
                 quant_out=output_q,
                 scale_out=output_s_packed,
                 **self.allreduce_params.get_trtllm_fused_allreduce_kwargs(),
@@ -937,7 +932,7 @@ class AllReduceFusedAddRMSNormGroupQuantFP8PackedPattern(BasePattern):
     with UE8M0 packed scales (for DeepGEMM).
     Applies to o_proj + rmsnorm after attn and mlp + rmsnorm before attn.
 
-    Uses flashinfer kARResidualRMSNormGroupFP8Quant (single kernel).
+    Uses flashinfer kARResidualRMSNormPerTokenGroupFP8PackedQuant (single kernel).
     """
 
     def __init__(
@@ -960,15 +955,14 @@ class AllReduceFusedAddRMSNormGroupQuantFP8PackedPattern(BasePattern):
 
     def get_inputs(self) -> list[torch.Tensor]:
         input_t, residual, weight = self.rmsnorm_matcher.inputs()
-        output_q = torch.empty(
-            (5, 16), device=self.device, dtype=self.quant_dtype
-        )
-        output_s_packed = torch.empty(
-            (5, 1), device=self.device, dtype=torch.int32
-        )
+        output_q = torch.empty((5, 16), device=self.device, dtype=self.quant_dtype)
+        output_s_packed = torch.empty((5, 1), device=self.device, dtype=torch.int32)
         return [
-            residual, input_t.to(self.dtype), weight,
-            output_q, output_s_packed,
+            residual,
+            input_t.to(self.dtype),
+            weight,
+            output_q,
+            output_s_packed,
         ]
 
     def register(self, pm_pass: PatternMatcherPass) -> None:
@@ -980,9 +974,7 @@ class AllReduceFusedAddRMSNormGroupQuantFP8PackedPattern(BasePattern):
             output_s_packed: torch.Tensor,
         ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
             allreduce_output = tensor_model_parallel_all_reduce(input)
-            rms, residual = self.rmsnorm_matcher(
-                allreduce_output, weight, residual
-            )
+            rms, residual = self.rmsnorm_matcher(allreduce_output, weight, residual)
             quant_out = auto_functionalized(
                 PACKED_GROUP_QUANT_OP,
                 input=rms,
@@ -1009,7 +1001,7 @@ class AllReduceFusedAddRMSNormGroupQuantFP8PackedPattern(BasePattern):
                 residual=residual,
                 rms_gamma=weight,
                 rms_eps=self.epsilon,
-                group_size=self.group_size,
+                block_quant_group_size=self.group_size,
                 quant_out=output_q,
                 scale_out=output_s_packed,
                 **self.allreduce_params.get_trtllm_fused_allreduce_kwargs(),

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -54,6 +54,12 @@ if find_spec("flashinfer"):
 if hasattr(torch.ops._C, "scaled_fp4_quant"):
     STATIC_FP4_QUANT_OP = torch.ops._C.scaled_fp4_quant.out
 
+PACKED_GROUP_QUANT_OP = getattr(
+    getattr(torch.ops._C, "per_token_group_fp8_quant_packed", None),
+    "default",
+    None,
+)
+
 # Max size of the input tensor per world size per device capability
 # to use flashinfer fused allreduce
 FI_ALLREDUCE_FUSION_MAX_SIZE_MB: dict[int, dict[int, float]] = {
@@ -230,6 +236,101 @@ if flashinfer_comm is not None:
     )
     flashinfer_trtllm_fused_allreduce_norm = (
         torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm.default
+    )
+
+    # Separate op for group FP8 quant fusion (AR + RMSNorm + group quant).
+    # Kept separate from the existing op to avoid changing its schema.
+    def call_trtllm_fused_allreduce_norm_group_quant(
+        allreduce_in: torch.Tensor,
+        residual: torch.Tensor,
+        rms_gamma: torch.Tensor,
+        rms_eps: float,
+        world_size: int,
+        launch_with_pdl: bool,
+        fp32_acc: bool,
+        max_token_num: int,
+        group_size: int,
+        quant_out: torch.Tensor | None = None,
+        scale_out: torch.Tensor | None = None,
+    ) -> None:
+        num_tokens, hidden_size = allreduce_in.shape
+        element_size = allreduce_in.element_size()
+        current_tensor_size = num_tokens * hidden_size * element_size
+        max_tensor_size = max_token_num * hidden_size * element_size
+        assert current_tensor_size <= max_tensor_size, (
+            f"Current tensor size {current_tensor_size} is larger than "
+            f"max token num {max_token_num} * hidden size {hidden_size} * "
+            f"element size {element_size}"
+        )
+        curr_device = current_platform.get_device_capability()
+        device_capability = curr_device.to_int() if curr_device is not None else None
+        max_one_shot_size = _FI_ALLREDUCE_ONE_SHOT_MAX_SIZES_MB.get(
+            device_capability,  # type: ignore[arg-type, unused-ignore]
+            {},
+        ).get(world_size, None)
+        use_oneshot = (
+            max_one_shot_size is None or current_tensor_size <= max_one_shot_size * MiB
+        )
+        # Group quant uses the non-quant workspace (no per-tensor scale input)
+        workspace = get_fi_ar_workspace(
+            world_size=world_size,
+            rank=get_tensor_model_parallel_rank(),
+            max_token_num=max_token_num,
+            hidden_dim=hidden_size,
+            dtype=allreduce_in.dtype,
+            group=get_tp_group().device_group,
+        )
+        assert workspace is not None
+        assert flashinfer_comm is not None
+        # norm_out=None: RMSNorm result overwrites allreduce_in,
+        # residual gets residual_out
+        flashinfer_comm.allreduce_fusion(
+            input=allreduce_in,
+            workspace=workspace,
+            pattern=ar_fusion_patterns.kARResidualRMSNormGroupFP8Quant,
+            launch_with_pdl=launch_with_pdl,
+            output=None,
+            residual_out=residual,
+            norm_out=allreduce_in,
+            quant_out=quant_out,
+            scale_out=scale_out,
+            residual_in=residual,
+            rms_gamma=rms_gamma,
+            rms_eps=rms_eps,
+            use_oneshot=use_oneshot,
+            fp32_acc=fp32_acc,
+            group_size=group_size,
+        )
+
+    def call_trtllm_fused_allreduce_norm_group_quant_fake(
+        allreduce_in: torch.Tensor,
+        residual: torch.Tensor,
+        rms_gamma: torch.Tensor,
+        rms_eps: float,
+        world_size: int,
+        launch_with_pdl: bool,
+        fp32_acc: bool,
+        max_token_num: int,
+        group_size: int,
+        quant_out: torch.Tensor | None = None,
+        scale_out: torch.Tensor | None = None,
+    ) -> None:
+        pass
+
+    direct_register_custom_op(
+        op_name="flashinfer_trtllm_fused_allreduce_norm_group_quant",
+        op_func=call_trtllm_fused_allreduce_norm_group_quant,
+        mutates_args=[
+            "allreduce_in",
+            "residual",
+            "quant_out",
+            "scale_out",
+        ],
+        fake_impl=call_trtllm_fused_allreduce_norm_group_quant_fake,
+    )
+    flashinfer_trtllm_fused_allreduce_norm_group_quant = (
+        torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm_group_quant
+        .default
     )
 
 
@@ -739,6 +840,188 @@ class AllReduceFusedAddRMSNormStaticQuantNVFP4Pattern(BasePattern):
         )
 
 
+class AllReduceFusedRMSNormGroupQuantFP8PackedPattern(BasePattern):
+    """
+    Fuses allreduce + rms_norm (without residual) + per-token-group FP8 quant
+    with UE8M0 packed scales (for DeepGEMM).
+    Applies to the first Transformer block where there is no residual.
+
+    Uses flashinfer kARResidualRMSNormGroupFP8Quant (single kernel).
+    """
+
+    def __init__(
+        self,
+        epsilon: float,
+        group_size: int,
+        dtype: torch.dtype,
+        device: str | None,
+        allreduce_params: FlashInferFusedAllReduceParams,
+    ) -> None:
+        super().__init__(dtype, device)
+        self.epsilon = epsilon
+        self.group_size = group_size
+        self.allreduce_params = allreduce_params
+        self.quant_dtype = torch.float8_e4m3fn
+        finfo = torch.finfo(self.quant_dtype)
+        self.fp8_min = float(finfo.min)
+        self.fp8_max = float(finfo.max)
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        input_t = self.empty(5, 16)
+        weight = self.empty(16)
+        output_q = torch.empty(
+            (5, 16), device=self.device, dtype=self.quant_dtype
+        )
+        output_s_packed = torch.empty(
+            (5, 1), device=self.device, dtype=torch.int32
+        )
+        return [input_t, weight, output_q, output_s_packed]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            output_q: torch.Tensor,
+            output_s_packed: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            all_reduce = tensor_model_parallel_all_reduce(input)
+            rms = vllm.ir.ops.rms_norm(all_reduce, weight, self.epsilon)
+            quant_out = auto_functionalized(
+                PACKED_GROUP_QUANT_OP,
+                input=rms,
+                output_q=output_q,
+                output_s_packed=output_s_packed,
+                group_size=self.group_size,
+                eps=1e-10,
+                fp8_min=self.fp8_min,
+                fp8_max=self.fp8_max,
+            )
+            # quant_out[1] = output_q, quant_out[2] = output_s_packed
+            return quant_out[1], quant_out[2], all_reduce
+
+        def replacement(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            output_q: torch.Tensor,
+            output_s_packed: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            residual = torch.zeros_like(input)
+            assert flashinfer_comm is not None
+            allreduce = auto_functionalized(
+                flashinfer_trtllm_fused_allreduce_norm_group_quant,
+                allreduce_in=input,
+                residual=residual,
+                rms_gamma=weight,
+                rms_eps=self.epsilon,
+                group_size=self.group_size,
+                quant_out=output_q,
+                scale_out=output_s_packed,
+                **self.allreduce_params.get_trtllm_fused_allreduce_kwargs(),
+            )
+            # quant_out, scale_out, allreduce_in (holds allreduce output)
+            return allreduce[3], allreduce[4], allreduce[1]
+
+        pm.register_replacement(
+            pattern,
+            replacement,
+            self.get_inputs(),
+            pm.fwd_only,
+            pm_pass,
+            extra_check=_rms_input_weight_dtype_match,
+        )
+
+
+class AllReduceFusedAddRMSNormGroupQuantFP8PackedPattern(BasePattern):
+    """
+    Fuses allreduce + fused_add_rms_norm + per-token-group FP8 quant
+    with UE8M0 packed scales (for DeepGEMM).
+    Applies to o_proj + rmsnorm after attn and mlp + rmsnorm before attn.
+
+    Uses flashinfer kARResidualRMSNormGroupFP8Quant (single kernel).
+    """
+
+    def __init__(
+        self,
+        epsilon: float,
+        group_size: int,
+        dtype: torch.dtype,
+        device: str | None,
+        allreduce_params: FlashInferFusedAllReduceParams,
+    ) -> None:
+        super().__init__(dtype, device)
+        self.epsilon = epsilon
+        self.group_size = group_size
+        self.allreduce_params = allreduce_params
+        self.quant_dtype = torch.float8_e4m3fn
+        finfo = torch.finfo(self.quant_dtype)
+        self.fp8_min = float(finfo.min)
+        self.fp8_max = float(finfo.max)
+        self.rmsnorm_matcher = MatcherFusedAddRMSNorm(epsilon)
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        input_t, residual, weight = self.rmsnorm_matcher.inputs()
+        output_q = torch.empty(
+            (5, 16), device=self.device, dtype=self.quant_dtype
+        )
+        output_s_packed = torch.empty(
+            (5, 1), device=self.device, dtype=torch.int32
+        )
+        return [
+            residual, input_t.to(self.dtype), weight,
+            output_q, output_s_packed,
+        ]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            residual: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            output_q: torch.Tensor,
+            output_s_packed: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            allreduce_output = tensor_model_parallel_all_reduce(input)
+            rms, residual = self.rmsnorm_matcher(
+                allreduce_output, weight, residual
+            )
+            quant_out = auto_functionalized(
+                PACKED_GROUP_QUANT_OP,
+                input=rms,
+                output_q=output_q,
+                output_s_packed=output_s_packed,
+                group_size=self.group_size,
+                eps=1e-10,
+                fp8_min=self.fp8_min,
+                fp8_max=self.fp8_max,
+            )
+            return quant_out[1], residual, quant_out[2]
+
+        def replacement(
+            residual: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            output_q: torch.Tensor,
+            output_s_packed: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            assert flashinfer_comm is not None
+            allreduce = auto_functionalized(
+                flashinfer_trtllm_fused_allreduce_norm_group_quant,
+                allreduce_in=input,
+                residual=residual,
+                rms_gamma=weight,
+                rms_eps=self.epsilon,
+                group_size=self.group_size,
+                quant_out=output_q,
+                scale_out=output_s_packed,
+                **self.allreduce_params.get_trtllm_fused_allreduce_kwargs(),
+            )
+            # quant_out, residual_out, scale_out
+            return allreduce[3], allreduce[2], allreduce[4]
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
 class AllReduceFusionPass(VllmPatternMatcherPass):
     def __init__(self, config: VllmConfig) -> None:
         super().__init__(config)
@@ -846,6 +1129,24 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
                     ).register(self.patterns)
                     AllReduceFusedAddRMSNormStaticQuantNVFP4Pattern(
                         epsilon,
+                        self.model_dtype,
+                        self.device,
+                        self.allreduce_params,
+                    ).register(self.patterns)
+            # Per-token-group FP8 packed quant patterns (DeepGEMM).
+            # Registered before non-quant patterns so the longer match wins.
+            if current_platform.is_cuda() and PACKED_GROUP_QUANT_OP is not None:
+                for group_size in [128, 64]:
+                    AllReduceFusedRMSNormGroupQuantFP8PackedPattern(
+                        epsilon,
+                        group_size,
+                        self.model_dtype,
+                        self.device,
+                        self.allreduce_params,
+                    ).register(self.patterns)
+                    AllReduceFusedAddRMSNormGroupQuantFP8PackedPattern(
+                        epsilon,
+                        group_size,
                         self.model_dtype,
                         self.device,
                         self.allreduce_params,

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -60,6 +60,11 @@ PACKED_GROUP_QUANT_OP = getattr(
     None,
 )
 
+# Supported group sizes for per-token-group FP8 packed quant fusion.
+# Must be power-of-2 multiples of VEC_SIZE (8 for bf16/fp16) for the
+# warp-shuffle group reduction to stay within group boundaries.
+SUPPORTED_PACKED_GROUP_QUANT_SIZES = (64, 128)
+
 # Max size of the input tensor per world size per device capability
 # to use flashinfer fused allreduce
 FI_ALLREDUCE_FUSION_MAX_SIZE_MB: dict[int, dict[int, float]] = {
@@ -1128,7 +1133,7 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
             # Per-token-group FP8 packed quant patterns (DeepGEMM).
             # Registered before non-quant patterns so the longer match wins.
             if current_platform.is_cuda() and PACKED_GROUP_QUANT_OP is not None:
-                for group_size in [128, 64]:
+                for group_size in SUPPORTED_PACKED_GROUP_QUANT_SIZES:
                     AllReduceFusedRMSNormGroupQuantFP8PackedPattern(
                         epsilon,
                         group_size,

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -65,16 +65,9 @@ if find_spec("flashinfer"):
 if hasattr(torch.ops._C, "scaled_fp4_quant"):
     STATIC_FP4_QUANT_OP = torch.ops._C.scaled_fp4_quant.out
 
-PACKED_GROUP_QUANT_OP = getattr(
-    getattr(torch.ops._C, "per_token_group_fp8_quant_packed", None),
-    "default",
-    None,
-)
-
-# Supported group sizes for per-token-group FP8 packed quant fusion.
-# Must be power-of-2 multiples of VEC_SIZE (8 for bf16/fp16) for the
-# warp-shuffle group reduction to stay within group boundaries.
-SUPPORTED_PACKED_GROUP_QUANT_SIZES = (64, 128)
+# Registered per-token-group FP8 packed quant group sizes
+# All sizes are supported.
+SUPPORTED_PACKED_GROUP_QUANT_SIZES = [128]
 
 # Max size of the input tensor per world size per device capability
 # to use flashinfer fused allreduce
@@ -255,8 +248,6 @@ if flashinfer_comm is not None:
         torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm.default
     )
 
-    # Separate op for group FP8 quant fusion (AR + RMSNorm + group quant).
-    # Kept separate from the existing op to avoid changing its schema.
     def call_trtllm_fused_allreduce_norm_group_quant(
         allreduce_in: torch.Tensor,
         residual: torch.Tensor,
@@ -299,8 +290,7 @@ if flashinfer_comm is not None:
         )
         assert workspace is not None
         assert flashinfer_comm is not None
-        # norm_out=None: RMSNorm result overwrites allreduce_in,
-        # residual gets residual_out
+
         flashinfer_comm.allreduce_fusion(
             input=allreduce_in,
             workspace=workspace,
@@ -906,7 +896,7 @@ class AllReduceFusedRMSNormGroupQuantFP8PackedPattern(BasePattern):
             all_reduce = tensor_model_parallel_all_reduce(input)
             rms = vllm.ir.ops.rms_norm(all_reduce, weight, self.epsilon)
             quant_out = auto_functionalized(
-                PACKED_GROUP_QUANT_OP,
+                torch.ops._C.per_token_group_fp8_quant_packed.default,
                 input=rms,
                 output_q=output_q,
                 output_s_packed=output_s_packed,
@@ -937,8 +927,9 @@ class AllReduceFusedRMSNormGroupQuantFP8PackedPattern(BasePattern):
                 scale_out=output_s_packed,
                 **self.allreduce_params.get_trtllm_fused_allreduce_kwargs(),
             )
-            # quant_out, scale_out, allreduce_in (holds allreduce output)
-            return allreduce[3], allreduce[4], allreduce[1]
+            # quant_out, scale_out, residual_out (holds allreduce result
+            # since residual_in is zeros)
+            return allreduce[3], allreduce[4], allreduce[2]
 
         pm.register_replacement(
             pattern,
@@ -975,12 +966,14 @@ class AllReduceFusedAddRMSNormGroupQuantFP8PackedPattern(BasePattern):
         finfo = torch.finfo(self.quant_dtype)
         self.fp8_min = float(finfo.min)
         self.fp8_max = float(finfo.max)
-        self.rmsnorm_matcher = MatcherFusedAddRMSNorm(epsilon)
 
     def get_inputs(self) -> list[torch.Tensor]:
-        input_t, residual, weight = self.rmsnorm_matcher.inputs()
+        input_t = self.empty(5, 16)
+        residual = self.empty(5, 16)
+        weight = self.empty(16)
         output_q = torch.empty((5, 16), device=self.device, dtype=self.quant_dtype)
         output_s_packed = torch.empty((5, 1), device=self.device, dtype=torch.int32)
+        # input goes through allreduce first, always 16-bit
         return [
             residual,
             input_t.to(self.dtype),
@@ -998,9 +991,11 @@ class AllReduceFusedAddRMSNormGroupQuantFP8PackedPattern(BasePattern):
             output_s_packed: torch.Tensor,
         ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
             allreduce_output = tensor_model_parallel_all_reduce(input)
-            rms, residual = self.rmsnorm_matcher(allreduce_output, weight, residual)
+            rms, residual = vllm.ir.ops.fused_add_rms_norm(
+                allreduce_output, residual, weight, self.epsilon
+            )
             quant_out = auto_functionalized(
-                PACKED_GROUP_QUANT_OP,
+                torch.ops._C.per_token_group_fp8_quant_packed.default,
                 input=rms,
                 output_q=output_q,
                 output_s_packed=output_s_packed,
@@ -1149,9 +1144,7 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
                         self.device,
                         self.allreduce_params,
                     ).register(self.patterns)
-            # Per-token-group FP8 packed quant patterns (DeepGEMM).
-            # Registered before non-quant patterns so the longer match wins.
-            if current_platform.is_cuda() and PACKED_GROUP_QUANT_OP is not None:
+                # Per-token group FP8 packed quant patterns (DeepGEMM).
                 for group_size in SUPPORTED_PACKED_GROUP_QUANT_SIZES:
                     AllReduceFusedRMSNormGroupQuantFP8PackedPattern(
                         epsilon,
@@ -1167,6 +1160,7 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
                         self.device,
                         self.allreduce_params,
                     ).register(self.patterns)
+                    torch._inductor.pattern_matcher._seen_patterns.clear()
             AllReduceRMSNormPattern(
                 epsilon,
                 self.model_dtype,

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -261,7 +261,7 @@ if flashinfer_comm is not None:
         launch_with_pdl: bool,
         fp32_acc: bool,
         max_token_num: int,
-        group_size: int,
+        block_quant_group_size: int,
         quant_out: torch.Tensor | None = None,
         scale_out: torch.Tensor | None = None,
     ) -> None:
@@ -299,7 +299,7 @@ if flashinfer_comm is not None:
         flashinfer_comm.allreduce_fusion(
             input=allreduce_in,
             workspace=workspace,
-            pattern=ar_fusion_patterns.kARResidualRMSNormGroupFP8Quant,
+            pattern=ar_fusion_patterns.kARResidualRMSNormPerTokenGroupFP8PackedQuant,
             launch_with_pdl=launch_with_pdl,
             output=None,
             residual_out=residual,
@@ -311,7 +311,7 @@ if flashinfer_comm is not None:
             rms_eps=rms_eps,
             use_oneshot=use_oneshot,
             fp32_acc=fp32_acc,
-            group_size=group_size,
+            block_quant_group_size=block_quant_group_size,
         )
 
     def call_trtllm_fused_allreduce_norm_group_quant_fake(
@@ -323,7 +323,7 @@ if flashinfer_comm is not None:
         launch_with_pdl: bool,
         fp32_acc: bool,
         max_token_num: int,
-        group_size: int,
+        block_quant_group_size: int,
         quant_out: torch.Tensor | None = None,
         scale_out: torch.Tensor | None = None,
     ) -> None:
@@ -341,8 +341,7 @@ if flashinfer_comm is not None:
         fake_impl=call_trtllm_fused_allreduce_norm_group_quant_fake,
     )
     flashinfer_trtllm_fused_allreduce_norm_group_quant = (
-        torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm_group_quant
-        .default
+        torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm_group_quant.default
     )
 
 
@@ -865,7 +864,7 @@ class AllReduceFusedRMSNormGroupQuantFP8PackedPattern(BasePattern):
     with UE8M0 packed scales (for DeepGEMM).
     Applies to the first Transformer block where there is no residual.
 
-    Uses flashinfer kARResidualRMSNormGroupFP8Quant (single kernel).
+    Uses flashinfer kARResidualRMSNormPerTokenGroupFP8PackedQuant (single kernel).
     """
 
     def __init__(
@@ -888,12 +887,8 @@ class AllReduceFusedRMSNormGroupQuantFP8PackedPattern(BasePattern):
     def get_inputs(self) -> list[torch.Tensor]:
         input_t = self.empty(5, 16)
         weight = self.empty(16)
-        output_q = torch.empty(
-            (5, 16), device=self.device, dtype=self.quant_dtype
-        )
-        output_s_packed = torch.empty(
-            (5, 1), device=self.device, dtype=torch.int32
-        )
+        output_q = torch.empty((5, 16), device=self.device, dtype=self.quant_dtype)
+        output_s_packed = torch.empty((5, 1), device=self.device, dtype=torch.int32)
         return [input_t, weight, output_q, output_s_packed]
 
     def register(self, pm_pass: PatternMatcherPass) -> None:
@@ -932,7 +927,7 @@ class AllReduceFusedRMSNormGroupQuantFP8PackedPattern(BasePattern):
                 residual=residual,
                 rms_gamma=weight,
                 rms_eps=self.epsilon,
-                group_size=self.group_size,
+                block_quant_group_size=self.group_size,
                 quant_out=output_q,
                 scale_out=output_s_packed,
                 **self.allreduce_params.get_trtllm_fused_allreduce_kwargs(),
@@ -956,7 +951,7 @@ class AllReduceFusedAddRMSNormGroupQuantFP8PackedPattern(BasePattern):
     with UE8M0 packed scales (for DeepGEMM).
     Applies to o_proj + rmsnorm after attn and mlp + rmsnorm before attn.
 
-    Uses flashinfer kARResidualRMSNormGroupFP8Quant (single kernel).
+    Uses flashinfer kARResidualRMSNormPerTokenGroupFP8PackedQuant (single kernel).
     """
 
     def __init__(
@@ -979,15 +974,14 @@ class AllReduceFusedAddRMSNormGroupQuantFP8PackedPattern(BasePattern):
 
     def get_inputs(self) -> list[torch.Tensor]:
         input_t, residual, weight = self.rmsnorm_matcher.inputs()
-        output_q = torch.empty(
-            (5, 16), device=self.device, dtype=self.quant_dtype
-        )
-        output_s_packed = torch.empty(
-            (5, 1), device=self.device, dtype=torch.int32
-        )
+        output_q = torch.empty((5, 16), device=self.device, dtype=self.quant_dtype)
+        output_s_packed = torch.empty((5, 1), device=self.device, dtype=torch.int32)
         return [
-            residual, input_t.to(self.dtype), weight,
-            output_q, output_s_packed,
+            residual,
+            input_t.to(self.dtype),
+            weight,
+            output_q,
+            output_s_packed,
         ]
 
     def register(self, pm_pass: PatternMatcherPass) -> None:
@@ -999,9 +993,7 @@ class AllReduceFusedAddRMSNormGroupQuantFP8PackedPattern(BasePattern):
             output_s_packed: torch.Tensor,
         ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
             allreduce_output = tensor_model_parallel_all_reduce(input)
-            rms, residual = self.rmsnorm_matcher(
-                allreduce_output, weight, residual
-            )
+            rms, residual = self.rmsnorm_matcher(allreduce_output, weight, residual)
             quant_out = auto_functionalized(
                 PACKED_GROUP_QUANT_OP,
                 input=rms,
@@ -1028,7 +1020,7 @@ class AllReduceFusedAddRMSNormGroupQuantFP8PackedPattern(BasePattern):
                 residual=residual,
                 rms_gamma=weight,
                 rms_eps=self.epsilon,
-                group_size=self.group_size,
+                block_quant_group_size=self.group_size,
                 quant_out=output_q,
                 scale_out=output_s_packed,
                 **self.allreduce_params.get_trtllm_fused_allreduce_kwargs(),

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -65,6 +65,12 @@ if find_spec("flashinfer"):
 if hasattr(torch.ops._C, "scaled_fp4_quant"):
     STATIC_FP4_QUANT_OP = torch.ops._C.scaled_fp4_quant.out
 
+PACKED_GROUP_QUANT_OP = getattr(
+    getattr(torch.ops._C, "per_token_group_fp8_quant_packed", None),
+    "default",
+    None,
+)
+
 # Max size of the input tensor per world size per device capability
 # to use flashinfer fused allreduce
 FI_ALLREDUCE_FUSION_MAX_SIZE_MB: dict[int, dict[int, float]] = {
@@ -242,6 +248,101 @@ if flashinfer_comm is not None:
     )
     flashinfer_trtllm_fused_allreduce_norm = (
         torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm.default
+    )
+
+    # Separate op for group FP8 quant fusion (AR + RMSNorm + group quant).
+    # Kept separate from the existing op to avoid changing its schema.
+    def call_trtllm_fused_allreduce_norm_group_quant(
+        allreduce_in: torch.Tensor,
+        residual: torch.Tensor,
+        rms_gamma: torch.Tensor,
+        rms_eps: float,
+        world_size: int,
+        launch_with_pdl: bool,
+        fp32_acc: bool,
+        max_token_num: int,
+        group_size: int,
+        quant_out: torch.Tensor | None = None,
+        scale_out: torch.Tensor | None = None,
+    ) -> None:
+        num_tokens, hidden_size = allreduce_in.shape
+        element_size = allreduce_in.element_size()
+        current_tensor_size = num_tokens * hidden_size * element_size
+        max_tensor_size = max_token_num * hidden_size * element_size
+        assert current_tensor_size <= max_tensor_size, (
+            f"Current tensor size {current_tensor_size} is larger than "
+            f"max token num {max_token_num} * hidden size {hidden_size} * "
+            f"element size {element_size}"
+        )
+        curr_device = current_platform.get_device_capability()
+        device_capability = curr_device.to_int() if curr_device is not None else None
+        max_one_shot_size = _FI_ALLREDUCE_ONE_SHOT_MAX_SIZES_MB.get(
+            device_capability,  # type: ignore[arg-type, unused-ignore]
+            {},
+        ).get(world_size, None)
+        use_oneshot = (
+            max_one_shot_size is None or current_tensor_size <= max_one_shot_size * MiB
+        )
+        # Group quant uses the non-quant workspace (no per-tensor scale input)
+        workspace = get_fi_ar_workspace(
+            world_size=world_size,
+            rank=get_tensor_model_parallel_rank(),
+            max_token_num=max_token_num,
+            hidden_dim=hidden_size,
+            dtype=allreduce_in.dtype,
+            group=get_tp_group().device_group,
+        )
+        assert workspace is not None
+        assert flashinfer_comm is not None
+        # norm_out=None: RMSNorm result overwrites allreduce_in,
+        # residual gets residual_out
+        flashinfer_comm.allreduce_fusion(
+            input=allreduce_in,
+            workspace=workspace,
+            pattern=ar_fusion_patterns.kARResidualRMSNormGroupFP8Quant,
+            launch_with_pdl=launch_with_pdl,
+            output=None,
+            residual_out=residual,
+            norm_out=allreduce_in,
+            quant_out=quant_out,
+            scale_out=scale_out,
+            residual_in=residual,
+            rms_gamma=rms_gamma,
+            rms_eps=rms_eps,
+            use_oneshot=use_oneshot,
+            fp32_acc=fp32_acc,
+            group_size=group_size,
+        )
+
+    def call_trtllm_fused_allreduce_norm_group_quant_fake(
+        allreduce_in: torch.Tensor,
+        residual: torch.Tensor,
+        rms_gamma: torch.Tensor,
+        rms_eps: float,
+        world_size: int,
+        launch_with_pdl: bool,
+        fp32_acc: bool,
+        max_token_num: int,
+        group_size: int,
+        quant_out: torch.Tensor | None = None,
+        scale_out: torch.Tensor | None = None,
+    ) -> None:
+        pass
+
+    direct_register_custom_op(
+        op_name="flashinfer_trtllm_fused_allreduce_norm_group_quant",
+        op_func=call_trtllm_fused_allreduce_norm_group_quant,
+        mutates_args=[
+            "allreduce_in",
+            "residual",
+            "quant_out",
+            "scale_out",
+        ],
+        fake_impl=call_trtllm_fused_allreduce_norm_group_quant_fake,
+    )
+    flashinfer_trtllm_fused_allreduce_norm_group_quant = (
+        torch.ops.vllm.flashinfer_trtllm_fused_allreduce_norm_group_quant
+        .default
     )
 
 
@@ -758,6 +859,188 @@ class AllReduceFusedAddRMSNormStaticQuantNVFP4Pattern(BasePattern):
         )
 
 
+class AllReduceFusedRMSNormGroupQuantFP8PackedPattern(BasePattern):
+    """
+    Fuses allreduce + rms_norm (without residual) + per-token-group FP8 quant
+    with UE8M0 packed scales (for DeepGEMM).
+    Applies to the first Transformer block where there is no residual.
+
+    Uses flashinfer kARResidualRMSNormGroupFP8Quant (single kernel).
+    """
+
+    def __init__(
+        self,
+        epsilon: float,
+        group_size: int,
+        dtype: torch.dtype,
+        device: str | None,
+        allreduce_params: FlashInferFusedAllReduceParams,
+    ) -> None:
+        super().__init__(dtype, device)
+        self.epsilon = epsilon
+        self.group_size = group_size
+        self.allreduce_params = allreduce_params
+        self.quant_dtype = torch.float8_e4m3fn
+        finfo = torch.finfo(self.quant_dtype)
+        self.fp8_min = float(finfo.min)
+        self.fp8_max = float(finfo.max)
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        input_t = self.empty(5, 16)
+        weight = self.empty(16)
+        output_q = torch.empty(
+            (5, 16), device=self.device, dtype=self.quant_dtype
+        )
+        output_s_packed = torch.empty(
+            (5, 1), device=self.device, dtype=torch.int32
+        )
+        return [input_t, weight, output_q, output_s_packed]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            output_q: torch.Tensor,
+            output_s_packed: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            all_reduce = tensor_model_parallel_all_reduce(input)
+            rms = vllm.ir.ops.rms_norm(all_reduce, weight, self.epsilon)
+            quant_out = auto_functionalized(
+                PACKED_GROUP_QUANT_OP,
+                input=rms,
+                output_q=output_q,
+                output_s_packed=output_s_packed,
+                group_size=self.group_size,
+                eps=1e-10,
+                fp8_min=self.fp8_min,
+                fp8_max=self.fp8_max,
+            )
+            # quant_out[1] = output_q, quant_out[2] = output_s_packed
+            return quant_out[1], quant_out[2], all_reduce
+
+        def replacement(
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            output_q: torch.Tensor,
+            output_s_packed: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            residual = torch.zeros_like(input)
+            assert flashinfer_comm is not None
+            allreduce = auto_functionalized(
+                flashinfer_trtllm_fused_allreduce_norm_group_quant,
+                allreduce_in=input,
+                residual=residual,
+                rms_gamma=weight,
+                rms_eps=self.epsilon,
+                group_size=self.group_size,
+                quant_out=output_q,
+                scale_out=output_s_packed,
+                **self.allreduce_params.get_trtllm_fused_allreduce_kwargs(),
+            )
+            # quant_out, scale_out, allreduce_in (holds allreduce output)
+            return allreduce[3], allreduce[4], allreduce[1]
+
+        pm.register_replacement(
+            pattern,
+            replacement,
+            self.get_inputs(),
+            pm.fwd_only,
+            pm_pass,
+            extra_check=_rms_input_weight_dtype_match,
+        )
+
+
+class AllReduceFusedAddRMSNormGroupQuantFP8PackedPattern(BasePattern):
+    """
+    Fuses allreduce + fused_add_rms_norm + per-token-group FP8 quant
+    with UE8M0 packed scales (for DeepGEMM).
+    Applies to o_proj + rmsnorm after attn and mlp + rmsnorm before attn.
+
+    Uses flashinfer kARResidualRMSNormGroupFP8Quant (single kernel).
+    """
+
+    def __init__(
+        self,
+        epsilon: float,
+        group_size: int,
+        dtype: torch.dtype,
+        device: str | None,
+        allreduce_params: FlashInferFusedAllReduceParams,
+    ) -> None:
+        super().__init__(dtype, device)
+        self.epsilon = epsilon
+        self.group_size = group_size
+        self.allreduce_params = allreduce_params
+        self.quant_dtype = torch.float8_e4m3fn
+        finfo = torch.finfo(self.quant_dtype)
+        self.fp8_min = float(finfo.min)
+        self.fp8_max = float(finfo.max)
+        self.rmsnorm_matcher = MatcherFusedAddRMSNorm(epsilon)
+
+    def get_inputs(self) -> list[torch.Tensor]:
+        input_t, residual, weight = self.rmsnorm_matcher.inputs()
+        output_q = torch.empty(
+            (5, 16), device=self.device, dtype=self.quant_dtype
+        )
+        output_s_packed = torch.empty(
+            (5, 1), device=self.device, dtype=torch.int32
+        )
+        return [
+            residual, input_t.to(self.dtype), weight,
+            output_q, output_s_packed,
+        ]
+
+    def register(self, pm_pass: PatternMatcherPass) -> None:
+        def pattern(
+            residual: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            output_q: torch.Tensor,
+            output_s_packed: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            allreduce_output = tensor_model_parallel_all_reduce(input)
+            rms, residual = self.rmsnorm_matcher(
+                allreduce_output, weight, residual
+            )
+            quant_out = auto_functionalized(
+                PACKED_GROUP_QUANT_OP,
+                input=rms,
+                output_q=output_q,
+                output_s_packed=output_s_packed,
+                group_size=self.group_size,
+                eps=1e-10,
+                fp8_min=self.fp8_min,
+                fp8_max=self.fp8_max,
+            )
+            return quant_out[1], residual, quant_out[2]
+
+        def replacement(
+            residual: torch.Tensor,
+            input: torch.Tensor,
+            weight: torch.Tensor,
+            output_q: torch.Tensor,
+            output_s_packed: torch.Tensor,
+        ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+            assert flashinfer_comm is not None
+            allreduce = auto_functionalized(
+                flashinfer_trtllm_fused_allreduce_norm_group_quant,
+                allreduce_in=input,
+                residual=residual,
+                rms_gamma=weight,
+                rms_eps=self.epsilon,
+                group_size=self.group_size,
+                quant_out=output_q,
+                scale_out=output_s_packed,
+                **self.allreduce_params.get_trtllm_fused_allreduce_kwargs(),
+            )
+            # quant_out, residual_out, scale_out
+            return allreduce[3], allreduce[2], allreduce[4]
+
+        pm.register_replacement(
+            pattern, replacement, self.get_inputs(), pm.fwd_only, pm_pass
+        )
+
+
 class AllReduceFusionPass(VllmPatternMatcherPass):
     def __init__(self, config: VllmConfig) -> None:
         super().__init__(config)
@@ -865,6 +1148,24 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
                     ).register(self.patterns)
                     AllReduceFusedAddRMSNormStaticQuantNVFP4Pattern(
                         epsilon,
+                        self.model_dtype,
+                        self.device,
+                        self.allreduce_params,
+                    ).register(self.patterns)
+            # Per-token-group FP8 packed quant patterns (DeepGEMM).
+            # Registered before non-quant patterns so the longer match wins.
+            if current_platform.is_cuda() and PACKED_GROUP_QUANT_OP is not None:
+                for group_size in [128, 64]:
+                    AllReduceFusedRMSNormGroupQuantFP8PackedPattern(
+                        epsilon,
+                        group_size,
+                        self.model_dtype,
+                        self.device,
+                        self.allreduce_params,
+                    ).register(self.patterns)
+                    AllReduceFusedAddRMSNormGroupQuantFP8PackedPattern(
+                        epsilon,
+                        group_size,
                         self.model_dtype,
                         self.device,
                         self.allreduce_params,

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -69,6 +69,9 @@ if hasattr(torch.ops._C, "scaled_fp4_quant"):
 # All sizes are supported.
 SUPPORTED_PACKED_GROUP_QUANT_SIZES = [128]
 
+# Max num tokens for applying the AR+RMSNorm+packed FP8 group quant
+FI_ALLREDUCE_GROUP_QUANT_FUSION_MAX_TOKEN_NUM = 256
+
 # Max size of the input tensor per world size per device capability
 # to use flashinfer fused allreduce
 FI_ALLREDUCE_FUSION_MAX_SIZE_MB: dict[int, dict[int, float]] = {
@@ -290,6 +293,36 @@ if flashinfer_comm is not None:
         )
         assert workspace is not None
         assert flashinfer_comm is not None
+
+        if num_tokens > FI_ALLREDUCE_GROUP_QUANT_FUSION_MAX_TOKEN_NUM:
+            # use separate group quant kernel instead of fused
+            assert quant_out is not None
+            assert scale_out is not None
+            flashinfer_comm.allreduce_fusion(
+                input=allreduce_in,
+                workspace=workspace,
+                pattern=ar_fusion_patterns.kARResidualRMSNorm,
+                launch_with_pdl=launch_with_pdl,
+                output=None,
+                residual_out=residual,
+                norm_out=allreduce_in,
+                residual_in=residual,
+                rms_gamma=rms_gamma,
+                rms_eps=rms_eps,
+                use_oneshot=use_oneshot,
+                fp32_acc=fp32_acc,
+            )
+            finfo = torch.finfo(torch.float8_e4m3fn)
+            torch.ops._C.per_token_group_fp8_quant_packed(
+                allreduce_in,
+                quant_out,
+                scale_out,
+                block_quant_group_size,
+                1e-10,
+                float(finfo.min),
+                float(finfo.max),
+            )
+            return
 
         flashinfer_comm.allreduce_fusion(
             input=allreduce_in,

--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -71,6 +71,11 @@ PACKED_GROUP_QUANT_OP = getattr(
     None,
 )
 
+# Supported group sizes for per-token-group FP8 packed quant fusion.
+# Must be power-of-2 multiples of VEC_SIZE (8 for bf16/fp16) for the
+# warp-shuffle group reduction to stay within group boundaries.
+SUPPORTED_PACKED_GROUP_QUANT_SIZES = (64, 128)
+
 # Max size of the input tensor per world size per device capability
 # to use flashinfer fused allreduce
 FI_ALLREDUCE_FUSION_MAX_SIZE_MB: dict[int, dict[int, float]] = {
@@ -1147,7 +1152,7 @@ class AllReduceFusionPass(VllmPatternMatcherPass):
             # Per-token-group FP8 packed quant patterns (DeepGEMM).
             # Registered before non-quant patterns so the longer match wins.
             if current_platform.is_cuda() and PACKED_GROUP_QUANT_OP is not None:
-                for group_size in [128, 64]:
+                for group_size in SUPPORTED_PACKED_GROUP_QUANT_SIZES:
                     AllReduceFusedRMSNormGroupQuantFP8PackedPattern(
                         epsilon,
                         group_size,


### PR DESCRIPTION
## Purpose
This PR adds support for allreduce + Norm + Per-token Group Fp8 Quant Fusion, which quantizes activation for DeepGemm gemm (`per_token_group_quant_fp8_packed_for_deepgemm`). The fusion is only enabled for num_tokens <= 256.

<img width="1021" height="240" alt="Screenshot 2026-04-13 at 9 44 49 PM" src="https://github.com/user-attachments/assets/496d831f-7131-4cff-8ae2-0e91e259db33" />

With fusion:
<img width="790" height="144" alt="Screenshot 2026-04-13 at 9 45 56 PM" src="https://github.com/user-attachments/assets/d4f0149b-e87d-460c-81f8-74c0d6ffea1c" />

## Test Plan
`tests/compile/passes/distributed/test_fusion_all_reduce.py`: fusion compile tests and kernel tests.

From testing, the values of `quant_out` and `norm_out` from the fused kernel match exactly as applying `per_token_group_quant_fp8_packed_for_deepgemm` on the `norm_out` of the fused kernel.

## Test Result
AR+norm+quant Microbenchmark:
```
  tokens  oneshot  fused mean ms   unfused mean ms         speedup
------------------------------------------------------------------
       1     True         0.0102           0.0105           1.022
       2     True         0.0096           0.0107           1.105
       4     True         0.0097           0.0109           1.128
       8     True         0.0121           0.0134           1.104
      16     True         0.0121           0.0135           1.115
      32     True         0.0121           0.0135           1.114
      64     True         0.0123           0.0136           1.111
     128     True         0.0125           0.0141           1.128
     256     True         0.0152           0.0157           1.038
     512     True         0.0191           0.0192           1.005
    1024     True         0.0293           0.0287           0.978
    2048     True         0.0537           0.0511           0.952
    4096     True         0.1107           0.1026           0.927
    8192    False         0.2453           0.2202           0.898
```

```
vllm serve MiniMaxAI/MiniMax-M2.5 --port 8888 --tensor-parallel-size=4 --gpu-memory-utilization 0.90 --max-model-len 2304 --block-size=32 --kv-cache-dtype fp8 --max-cudagraph-capture-size 2048 --max-num-batched-tokens 2048 --stream-interval 20 --no-enable-prefix-caching --trust-remote-code
```

1K1K single-user latency: **159.45 -> 161.29 tok/s**
```
vllm bench serve \
  --backend vllm \
  --endpoint /v1/completions \
  --port 8888 \
  --num-prompts 10 \
  --dataset-name random \
  --input-len 1024 \
  --output-len 1024 \
  --max-concurrency 1 \
  --trust-remote-code \
  --num-warmups 2
```

E2E eval:
```
vllm serve MiniMaxAI/MiniMax-M2.5 --trust-remote-code --tensor-parallel-size 2

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9303|±  |0.0070|
|     |       |strict-match    |     5|exact_match|↑  |0.9249|±  |0.0073|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

