### PR TITLE
fix nemotron vl ls1, ls2 parameters

### DIFF
--- a/vllm/model_executor/models/nano_nemotron_vl.py
+++ b/vllm/model_executor/models/nano_nemotron_vl.py
@@ -1537,11 +1537,7 @@ class NemotronH_Nano_VL_V2(
         # but dummy weight initialization overwrites them with ~0 random values.
         # Without this fix, vision encoder output is scaled by ~1e-3 instead of 1.0.
         if len(vision_weights) > 0:
-            init_factor = getattr(
-                getattr(self.config, "vision_config", None),
-                "initializer_factor",
-                1.0,
-            )
+            init_factor = getattr(self.config.vision_config, "initializer_factor", 1.0)
             for name, param in self.vision_model.named_parameters():
                 if name.endswith(".ls1") or name.endswith(".ls2"):
                     param.data.fill_(init_factor)

--- a/vllm/model_executor/models/nano_nemotron_vl.py
+++ b/vllm/model_executor/models/nano_nemotron_vl.py
@@ -1532,6 +1532,20 @@ class NemotronH_Nano_VL_V2(
         if self.sound_encoder is not None and len(sound_weights) > 0:
             self.sound_encoder.load_weights(sound_weights)
 
+        # Fix: Reinitialize layer-scale (ls1/ls2) parameters in vision encoder.
+        # These are not stored in HF checkpoints (default value is all-ones),
+        # but dummy weight initialization overwrites them with ~0 random values.
+        # Without this fix, vision encoder output is scaled by ~1e-3 instead of 1.0.
+        if len(vision_weights) > 0:
+            init_factor = getattr(
+                getattr(self.config, "vision_config", None),
+                "initializer_factor",
+                1.0,
+            )
+            for name, param in self.vision_model.named_parameters():
+                if name.endswith(".ls1") or name.endswith(".ls2"):
+                    param.data.fill_(init_factor)
+
     def get_vit_model_from_radio_config(self, hf_config):
         hf_config_vision = hf_config.vision_config
         model_name = hf_config_vision.args.get("model")

--- a/vllm/model_executor/models/radio.py
+++ b/vllm/model_executor/models/radio.py
@@ -777,7 +777,9 @@ class RadioModel(nn.Module):
                 if len(parts) >= 4:
                     layer_idx = parts[2]
                     suffix = ".".join(parts[3:])
-                    # Skip layer-scale entries that vLLM doesn't use
+                    # Skip layer-scale entries — they are not in HF checkpoints
+                    # and are reinitialized to their correct default values
+                    # in NemotronH_Nano_VL_V2.load_weights after weight transfer.
                     if suffix in {"ls1", "ls2"} or suffix.startswith(("ls1.", "ls2.")):
                         continue
                     vllm_key = f"model.encoder.layers.{layer_idx}.{suffix}"


### PR DESCRIPTION
In RL training, we first initialize the weights with dummy values and later transfer the actual weights.

However, .ls1 and .ls2 weights are missing from HF checkpoints. So they will not be transfered anymore after the dummy values initial. Their default initialization value of 1 would be overwritten by the dummy values. Therefore, we need to restore them.


@collinmccarthy Would you mind helping checking it please? 



Note: For RL training, this is a general issue for any model with parameters that (a) have non-trivial default init values and (b) are not stored in HF checkpoints. 

**Why ls1/ls2 are absent from HF checkpoints**: The original RADIO model was likely trained with timm, where layer scale values may have remained at their initial value or were not used at all. When converting to HF format, parameters whose values are identical to the model's `__init__` defaults are often omitted to reduce checkpoint size — `from_pretrained` will simply keep the `__init__` values for any missing keys. This is a perfectly valid optimization under the standard HF loading flow, but it creates a hidden dependency: any non-standard loading path (such as `load_format=dummy` + weight transfer) that does not preserve `__init__` defaults will silently break these parameters.

