### PR TITLE
[Bugfix] Skip malformed parameters in qwen3coder tool parser

### DIFF
--- a/tests/tool_parsers/test_qwen3coder_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3coder_tool_parser.py
@@ -1013,6 +1013,30 @@ def test_malformed_xml_no_gt_delimiter(qwen3_tool_parser):
     assert all(tc is not None for tc in result.tool_calls)
 
 
+def test_malformed_parameter_no_gt_delimiter(qwen3_tool_parser):
+    """Regression: malformed <parameter=...> without '>' must not crash and
+    valid parameters in the same call should still be parsed."""
+    # The first parameter is malformed (truncated, no '>' separator).
+    # The second parameter is well-formed.
+    model_output = (
+        "<tool_call>\n"
+        "<function=get_current_weather>\n"
+        "<parameter=truncated_param_no_gt"
+        "<parameter=city>Dallas</parameter>\n"
+        "</function>\n"
+        "</tool_call>"
+    )
+
+    request = ChatCompletionRequest(model=MODEL, messages=[])
+    result = qwen3_tool_parser.extract_tool_calls(model_output, request=request)
+    assert result.tools_called
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].function.name == "get_current_weather"
+    args = json.loads(result.tool_calls[0].function.arguments)
+    # Malformed parameter is skipped, valid one is preserved
+    assert args == {"city": "Dallas"}
+
+
 def test_none_tool_calls_filtered(qwen3_tool_parser):
     """Regression: None tool calls filtered from output (PR #36774)."""
     model_output = (

--- a/vllm/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen3coder_tool_parser.py
@@ -233,7 +233,18 @@ class Qwen3CoderToolParser(ToolParser):
         parameters = function_call_str[end_index + 1 :]
         param_dict = {}
         for match_text in self.tool_call_parameter_regex.findall(parameters):
-            idx = match_text.index(">")
+            idx = match_text.find(">")
+            # Skip malformed parameters missing the name>value separator
+            # (e.g. truncated output) so other valid parameters can still
+            # be parsed.
+            if idx == -1:
+                logger.warning(
+                    "Skipping malformed parameter without '>' separator "
+                    "in tool call for function '%s': %r",
+                    function_name,
+                    match_text,
+                )
+                continue
             param_name = match_text[:idx]
             param_value = str(match_text[idx + 1 :])
             # Remove prefix and trailing \n


### PR DESCRIPTION
## Summary

- Replace `str.index(">")` with `str.find(">")` in `Qwen3CoderToolParser._parse_xml_function_call` and skip parameters that lack the `name>value` separator
- Match the safe-handling pattern already used for the function name a few lines above
- Add a regression test

Fixes #39771

## Motivation

When the model emits a malformed `<parameter=...>` (truncation, dropped `>`, etc.), `match_text.index(">")` raises `ValueError: substring not found`. The error is swallowed by the broad `except Exception` in `extract_tool_calls`, but the catch discards the **entire** response's tool calls — including any well-formed parameters / other tool calls in the same output — and falls back to plain text content. Skipping the malformed parameter individually preserves the rest of the response.

The function name path on the preceding lines already does exactly this:
```python
end_index = function_call_str.find(">")
if end_index == -1:
    return None
```
The parameter loop should be consistent.

## Test plan

- [x] New regression test `test_malformed_parameter_no_gt_delimiter` verifies that a malformed parameter is skipped while a well-formed one in the same call is parsed correctly
- [x] Existing parser tests (`tests/tool_parsers/test_qwen3coder_tool_parser.py`) still pass — including the previous related regression `test_malformed_xml_no_gt_delimiter`