### PR TITLE
[Model Runner V2] Disable piecewise cudagraph mode fallback for eagle draft decodes

### DIFF
--- a/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
@@ -129,9 +129,7 @@ class EagleSpeculator:
         self.decode_cudagraph_manager = EagleCudaGraphManager(
             self.vllm_config,
             self.device,
-            # Only use FULL graph mode, if available, because draft decodes
-            # only consist of a single token.
-            cudagraph_mode.decode_mode(),
+            cudagraph_mode,
             decode_query_len=1,
         )
         # Share a single pool between prefill and decode since they never

--- a/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
@@ -629,6 +629,11 @@ def _prepare_eagle_inputs_kernel(
             block = i + tl.arange(0, BLOCK_SIZE)
             mask = block < max_num_reqs
             tl.store(eagle_seq_lens_ptr + block, 0, mask=mask)
+        # Pad last_token_indices for CUDA graphs.
+        for i in range(num_reqs, max_num_reqs, BLOCK_SIZE):
+            block = i + tl.arange(0, BLOCK_SIZE)
+            mask = block < max_num_reqs
+            tl.store(last_token_indices_ptr + block, 0, mask=mask)
 
 
 def prepare_eagle_inputs(

--- a/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
@@ -115,7 +115,17 @@ class EagleSpeculator:
             cudagraph_mode,
             self.num_speculative_steps + 1,
         )
-        # Initialize cudagraph manager for draft generation (draft positions > 0).
+
+        # PIECEWISE cudagraphs are not supported for eagle draft decodes.
+        # PIECEWISE pads num_tokens to the next capture size without padding
+        # num_reqs, which can cause attention backends to read past the
+        # valid per-request metadata (e.g. FlashInfer's kv_indptr buffer).
+        if cudagraph_mode.decode_mode() == CUDAGraphMode.FULL:
+            cudagraph_mode = CUDAGraphMode.FULL_DECODE_ONLY
+        else:
+            cudagraph_mode = CUDAGraphMode.NONE
+
+        # Initialize cudagraph manager for draft decodes (draft positions > 0).
         self.decode_cudagraph_manager = EagleCudaGraphManager(
             self.vllm_config,
             self.device,
@@ -366,11 +376,8 @@ class EagleSpeculator:
 
         # Capture the decode draft generation loop (model forward +
         # compute_logits + gumbel_sample + update_eagle_inputs, for
-        # each step).
-        # For FULL graphs, the entire multi-step loop is recorded as
-        # one graph. For PIECEWISE, only the model's compiled regions
-        # are captured, and the rest (compute_logits, gumbel_sample,
-        # update_eagle_inputs) runs eagerly.
+        # each step). For FULL graphs, the entire multi-step loop is
+        # recorded as one graph.
         assert self.decode_cudagraph_manager is not None
         self.decode_cudagraph_manager.capture(
             self.generate_draft,


### PR DESCRIPTION
# Purpose
There were two issues present with speculator's cudagraph implementation:
1. `last_token_indices` was not being padded before prefill, allowing stale values to remain in the buffer from previous runs and cause OOB errors during a gather op.
2. The eagle draft decodes are currently able to run in PIECEWISE mode. This is problematic for at least one attention backend (FlashInfer), where during PIECEWISE decode with single-token batches it expects num_tokens == num_reqs. However, during PIECEWISE the num_tokens are padded up to the capture size, thus causing a mismatch and stale values to be read from the paged KV indices buffer. https://github.com/vllm-project/vllm/blob/1696c864b90afb9cec925312d0cf12c396517007/vllm/v1/attention/backends/flashinfer.py#L1149-L1185

Claude's elaboration on 2:
```
The paged_kv_indptr is a CSR-format array indexed by requests, not tokens. Its length is always num_requests + 1. This is an internal implementation detail of the FlashInfer backend — callers interacting through CommonAttentionMetadata shouldn't need to know about it.
The bug is actually inside FlashInferMetadataBuilder.build() itself. Look at the decode pathway:

        ## DECODE PATHWAY
        if num_decodes > 0:
            // ...
            else:
                // ...
                num_input_tokens = num_decode_tokens   # <-- THIS IS WRONG
                decode_wrapper = self._get_decode_wrapper(
                    num_input_tokens, use_cudagraph
                )
                fast_plan_decode(
                    decode_wrapper,
                    indptr_cpu=self.paged_kv_indptr.cpu[: num_input_tokens + 1],
                    // ...
                    last_page_len_cpu=self.paged_kv_last_page_len.cpu[
                        :num_input_tokens
                    ],
                    // ...
                )
num_input_tokens is used to slice paged_kv_indptr and paged_kv_last_page_len, which are both per-request buffers. But num_input_tokens is set to num_decode_tokens — the token count. These two are coincidentally equal when every decode request has exactly 1 token and there's no padding, which is why this bug was latent.
The fix belongs here, inside build():
num_input_tokens = num_decodes  # not num_decode_tokens
This is correct because:
_compute_flashinfer_kv_metadata fills indptr for num_reqs entries (which includes the num_decodes decode requests)

The indptr slice for the decode wrapper should be [:num_decodes + 1], not [:num_decode_tokens + 1]
paged_kv_last_page_len is also per-request, so [:num_decodes] is the right slice
_get_decode_wrapper(batch_size, ...) semantically wants the batch size (number of requests), not number of tokens
The caller shouldn't have to maintain the invariant that num_tokens == num_reqs for decode batches. CommonAttentionMetadata legitimately allows num_actual_tokens > num_reqs for token padding — the backend should handle that correctly internally.
```

In this PR, i fix both of the above issues. (1) was fixed by simply padding `last_token_indices` with zeros in `_prepare_eagle_inputs_kernel`. (2) is addressed by enforcing FULL_DECODE_ONLY mode for the draft decodes, which was the behavior before #37588.

# Testing
## Before
Observed a crash while serving on B300:
**Server Command**
```
SAFETENSORS_FAST_GPU=1 VLLM_FLASHINFER_MOE_BACKEND=latency VLLM_SERVER_DEV_MODE=1 VLLM_USE_V2_MODEL_RUNNER=1 vllm serve lukealonso/MiniMax-M2.5-NVFP4 -tp 4 --enable-prefix-caching --trust-remote-code --max-num-seqs 64 --kv-cache-dtype fp8 --async-scheduling --compilation-config '{"mode":3,"pass_config":{"fuse_norm_quant":true,"fuse_act_quant":true,"fuse_gemm_comms":true}}' --speculative-config '{"method": "eagle3", "model": "thoughtworks/MiniMax-M2.5-Eagle3", "num_speculative_tokens": 3}'
```
**Benchmark Command**
```
      vllm-bench
      --backend openai-chat
      --base-url http://127.0.0.1:8000
      --model {model}
      --dataset-name speed-bench
      --speed-bench-config throughput_16k
      --speed-bench-max-input-len 10240
      --speed-bench-category low_entropy
      --num-warmups 50
      --num-prompts 1000
      --output-len 1536
      --sweep-max-concurrency 1,2,4,8,16,32,64
      --sweep-num-prompts-factor 10
      --reset-prefix-cache
      --save-result
```
**Error**
```
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]                    ^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]   File "/home/gdelfin/vllm/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]     return func(*args, **kwargs)
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]   File "/home/gdelfin/vllm/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py", line 536, in propose
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]     attn_metadata_updated = self._build_draft_attn_metadata(
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]   File "/home/gdelfin/vllm/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py", line 325, in _build_draft_attn_metadata
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]     attn_metadata = build_attn_metadata(
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]                     ^^^^^^^^^^^^^^^^^^^^
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]   File "/home/gdelfin/vllm/vllm/v1/worker/gpu/attn_utils.py", line 263, in build_attn_metadata
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]     metadata = attn_metadata_builder.build(
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]   File "/home/gdelfin/vllm/vllm/v1/attention/backends/flashinfer.py", line 1164, in build
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]     fast_plan_decode(
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]   File "/home/gdelfin/vllm/vllm/v1/attention/backends/flashinfer.py", line 1722, in fast_plan_decode
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]     self.plan(
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]   File "/home/gdelfin/vllm/.venv/lib/python3.12/site-packages/flashinfer/decode.py", line 1099, in plan
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]     self._plan_info = self._cached_module.plan(
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]                       ^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971]   File "python/tvm_ffi/cython/function.pxi", line 929, in tvm_ffi.core.Function.__call__
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971] RuntimeError: Error in function 'PrefillSplitQOKVIndptr' at /home/gdelfin/vllm/.venv/lib/python3.12/site-packages/flashinfer/data/include/flashinfer/attention/scheduler.cuh:522: kv_indptr[4]4 - kv_indptr[3]1684 should be non-negative
(Worker_TP2 pid=2617149) ERROR 04-14 05:19:40 [multiproc_executor.py:971] 
```

## After
No more error, can serve requests to completion.