### PR TITLE
add prot available check when create server before

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -500,15 +500,14 @@ def _check_port_available(addr: tuple[str, int]) -> None:
 
     Raises RuntimeError if the port is occupied, so the server fails fast.
     """
-    family = socket.AF_INET
-    if is_valid_ipv6_address(addr[0]):
-        family = socket.AF_INET6
-    host = addr[0] if addr[0] else "0.0.0.0"
+    family = socket.AF_INET6 if is_valid_ipv6_address(addr[0]) else socket.AF_INET
+    host = addr[0] if addr[0] else ("::1" if family == socket.AF_INET6 else "127.0.0.1")
     with socket.socket(family, type=socket.SOCK_STREAM) as s:
-        s.settimeout(1)
+        s.settimeout(0.1)
         if s.connect_ex((host, addr[1])) == 0:
             raise RuntimeError(
-                f"Port {addr[1]} on {host} is already in use by another process. "
+                f"Port {addr[1]} on {addr[0] or 'all interfaces'} is already in use by"
+                "another process. "
                 "Please stop the conflicting service or use a different port (--port)."
             )
 

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -498,8 +498,7 @@ async def init_render_app_state(
 def _check_port_available(addr: tuple[str, int]) -> None:
     """Check if the given port is already in use by another process.
 
-    Raises RuntimeError if the port is occupied, so the server fails fast
-    instead of silently sharing the port due to SO_REUSEPORT in upstream vllm.
+    Raises RuntimeError if the port is occupied, so the server fails fast.
     """
     family = socket.AF_INET
     if is_valid_ipv6_address(addr[0]):

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -495,7 +495,27 @@ async def init_render_app_state(
     state.server_load_metrics = 0
 
 
+def _check_port_available(addr: tuple[str, int]) -> None:
+    """Check if the given port is already in use by another process.
+
+    Raises RuntimeError if the port is occupied, so the server fails fast
+    instead of silently sharing the port due to SO_REUSEPORT in upstream vllm.
+    """
+    family = socket.AF_INET
+    if is_valid_ipv6_address(addr[0]):
+        family = socket.AF_INET6
+    host = addr[0] if addr[0] else "0.0.0.0"
+    with socket.socket(family, type=socket.SOCK_STREAM) as s:
+        s.settimeout(1)
+        if s.connect_ex((host, addr[1])) == 0:
+            raise RuntimeError(
+                f"Port {addr[1]} on {host} is already in use by another process. "
+                "Please stop the conflicting service or use a different port (--port)."
+            )
+
+
 def create_server_socket(addr: tuple[str, int]) -> socket.socket:
+    _check_port_available(addr=addr)
     family = socket.AF_INET
     if is_valid_ipv6_address(addr[0]):
         family = socket.AF_INET6


### PR DESCRIPTION



## Purpose

Fixs: https://github.com/vllm-project/vllm/issues/39762

## Test Plan

When can first step, start a vllm instance, can set `--api-server-count=4`, after, agent start a new vllm instance, when not set `--port` we can look a RuntimeError.

```
(APIServer pid=69077) RuntimeError: Port 8000 on 0.0.0.0 is already in use by another process. Please stop the conflicting service or use a different port (--port).
```

1. first step, start first a vllm instance
```
$ vllm serve /home/jovyan/qwen3-8b/ --api-server-count 4
```
start after, we can look this api server have four process.
<img width="1312" height="256" alt="image" src="https://github.com/user-attachments/assets/e54a65e9-26f1-4364-a9d1-a7e0e6b68614" />


2. second step, start second vllm instance
```
$ vllm serve /home/jovyan/qwen3-8b/ --api-server-count 4
```
wen can't start success, can get RuntimeError, `Port 8000 on 0.0.0.0 is already in use by another process. Please stop the conflicting service or use a different port (--port)`

## Test Result

This resolves situations where the port is already occupied by another process prior to startup.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

