### PR TITLE
[BugFix] Fix MoRIIOConnector for multi-node disaggregated P/D inference

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_common.py
@@ -207,9 +207,10 @@ class MoRIIOConfig:
         kv_transfer_config = vllm_config.kv_transfer_config
         extra_config = kv_transfer_config.kv_connector_extra_config
         tp_rank = get_tensor_model_parallel_rank()
-        dp_rank = vllm_config.parallel_config.data_parallel_rank
+        dp_rank = (vllm_config.parallel_config.data_parallel_rank
+                   % vllm_config.parallel_config.data_parallel_size_local)
         base_notify_port = int(extra_config["notify_port"])
-        dp_size = vllm_config.parallel_config.data_parallel_size
+        dp_size = vllm_config.parallel_config.data_parallel_size_local
         tp_size = get_tensor_model_parallel_world_size()
         port_offset = get_port_offset(dp_rank, tp_rank)
 
@@ -293,8 +294,14 @@ class MoRIIOConnectorMetadata(KVConnectorMetadata):
             remote_engine_id=kv_transfer_params["remote_engine_id"],
             remote_host=kv_transfer_params["remote_host"],
             remote_port=kv_transfer_params["remote_port"],
-            remote_handshake_port=kv_transfer_params["remote_handshake_port"],
-            remote_notify_port=kv_transfer_params["remote_notify_port"],
+            remote_handshake_port=kv_transfer_params.get(
+                "remote_handshake_port",
+                int(MoRIIOConstants.DEFAULT_HANDSHAKE_PORT),
+            ),
+            remote_notify_port=kv_transfer_params.get(
+                "remote_notify_port",
+                int(MoRIIOConstants.DEFAULT_NOTIFY_PORT),
+            ),
             tp_size=kv_transfer_params.get("tp_size", 1),
             remote_dp_size=kv_transfer_params.get("remote_dp_size", 1),
         )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_connector.py
@@ -259,13 +259,19 @@ class MoRIIOConnectorScheduler:
             "notify_port"
         ]
         self.tp_size = self.vllm_config.parallel_config.tensor_parallel_size
-        self.dp_rank = self.vllm_config.parallel_config.data_parallel_rank
+        self.dp_rank = (self.vllm_config.parallel_config.data_parallel_rank
+                        % self.vllm_config.parallel_config
+                        .data_parallel_size_local)
+        self._is_kv_master = (
+            self.vllm_config.parallel_config.data_parallel_rank
+            < self.vllm_config.parallel_config.data_parallel_size_local)
         self.is_producer = self.kv_transfer_config.kv_role == "kv_producer"
         # Requests that need to start recv/send.
         # New requests are added by update_state_after_alloc in
         # the scheduler. Used to make metadata passed to Worker.
         self._reqs_need_recv: dict[ReqId, tuple[Request, list[int]]] = {}
         self._reqs_need_save: dict[ReqId, tuple[Request, list[int]]] = {}
+        self._req_kv_params: dict[ReqId, dict] = {}
 
         # For chunked prefill, we perform layer-wise access within the final chunk.
         # TODO: Perform transfer at end chunk.
@@ -375,6 +381,7 @@ class MoRIIOConnectorScheduler:
         if params.get("do_remote_decode"):
             local_block_ids = blocks.get_block_ids()[0]
             self._reqs_need_save[request.request_id] = (request, local_block_ids)
+            self._req_kv_params[request.request_id] = dict(params)
 
         if params is not None and params.get("do_remote_prefill"):
             if self.mode == MoRIIOMode.READ:
@@ -399,6 +406,9 @@ class MoRIIOConnectorScheduler:
                             request,
                             local_block_ids,
                         )
+                        self._req_kv_params[request.request_id] = dict(
+                            params
+                        )
                     else:
                         logger.warning(
                             "Got invalid KVTransferParams: %s. This "
@@ -413,18 +423,20 @@ class MoRIIOConnectorScheduler:
 
                 remote_dp_rank = request.kv_transfer_params.get("remote_dp_rank", 0)
 
-                for tp_index in range(self.tp_size):
-                    target_port = request.kv_transfer_params[
-                        "remote_notify_port"
-                    ] + get_port_offset(remote_dp_rank, tp_index)
+                if self._is_kv_master:
+                    for tp_index in range(self.tp_size):
+                        target_port = request.kv_transfer_params[
+                            "remote_notify_port"
+                        ] + get_port_offset(remote_dp_rank, tp_index)
 
-                    self.send_notify_block(
-                        req_id=request.request_id,
-                        transfer_id=request.kv_transfer_params["transfer_id"],
-                        block_notify_list=blocks.get_block_ids()[0],
-                        host=params.get("remote_host"),
-                        port=target_port,
-                    )
+                        self.send_notify_block(
+                            req_id=request.request_id,
+                            transfer_id=request.kv_transfer_params[
+                                "transfer_id"],
+                            block_notify_list=blocks.get_block_ids()[0],
+                            host=params.get("remote_host"),
+                            port=target_port,
+                        )
 
             # Only trigger 1 KV transfer per request.
 
@@ -484,25 +496,32 @@ class MoRIIOConnectorScheduler:
                             * self.block_size
                             >= req.num_prompt_tokens
                         ):
+                            kv_params = self._req_kv_params.pop(
+                                req_id, req.kv_transfer_params or {}
+                            )
                             meta.add_new_req(
                                 request_id=req_id,
                                 local_block_ids=self._reqs_need_pending_save[req_id][1],
-                                kv_transfer_params=req.kv_transfer_params or {},
+                                kv_transfer_params=kv_params,
                                 write_mode=True,
                             )
                             del self._reqs_need_pending_save[req_id]
 
         # Loop through scheduled reqs and convert to ReqMeta.
         for req_id, (req, block_ids) in self._reqs_need_recv.items():
-            assert req.kv_transfer_params is not None
+            kv_params = self._req_kv_params.get(
+                req_id, req.kv_transfer_params or {}
+            )
             meta.add_new_req(
                 request_id=req_id,
                 local_block_ids=block_ids,
-                kv_transfer_params=req.kv_transfer_params,
+                kv_transfer_params=kv_params,
             )
 
         for req_id, (req, block_ids) in self._reqs_need_save.items():
-            assert req.kv_transfer_params is not None
+            kv_params = self._req_kv_params.get(
+                req_id, req.kv_transfer_params or {}
+            )
             if req.num_prompt_tokens > len(block_ids) * self.block_size:
                 # not last chunk prefill
                 self._reqs_need_pending_save[req_id] = (req, block_ids)
@@ -510,13 +529,18 @@ class MoRIIOConnectorScheduler:
             meta.add_new_req(
                 request_id=req_id,
                 local_block_ids=block_ids,
-                kv_transfer_params=req.kv_transfer_params,
+                kv_transfer_params=kv_params,
                 write_mode=True,
             )
         # Clear the list once workers start the transfers
 
         meta.reqs_to_send = self._reqs_need_send
 
+        for req_id in self._reqs_need_recv:
+            self._req_kv_params.pop(req_id, None)
+        for req_id in self._reqs_need_save:
+            if req_id not in self._reqs_need_pending_save:
+                self._req_kv_params.pop(req_id, None)
         self._reqs_need_recv.clear()
         self._reqs_need_save.clear()
         self._reqs_need_send = {}
@@ -1128,7 +1152,14 @@ class MoRIIOConnectorWorker:
             self.slot_size_bytes = (
                 kv_elem_size * n_kv_heads * head_dim
             )  # 1 token 1 layer size , slot size
-        assert block_size == self.block_size
+        if block_size != self.block_size:
+            logger.info(
+                "KV cache block_size=%d differs from config block_size=%d; "
+                "using actual tensor shape (attention backend override).",
+                block_size,
+                self.block_size,
+            )
+            self.block_size = block_size
         # TODO(tms): self.block_len needs to be per-layer for sliding window,
         # hybrid attn, etc
         # block size in bytes


### PR DESCRIPTION
## Summary

Five targeted fixes to `MoRIIOConnector` that resolve crashes and enable multi-node data-parallel disaggregated inference (xP/yD). All changes are scoped to the MORI-IO code path only -- zero impact on NIXL, shared-storage, or SGLang connectors.

### Fix 1: Cache `kv_transfer_params` across scheduler steps

The `Request` object's `kv_transfer_params` can be mutated or cleared between the `update_state_after_alloc` and `build_connector_meta` scheduler steps. By the time `build_connector_meta` runs, fields like `remote_block_ids` and `remote_engine_id` may be gone, causing `KeyError` on every decode request.

**Fix**: Snapshot `kv_transfer_params` into a `_req_kv_params` dict at allocation time and use the cached copy when building connector metadata. Cleanup is performed after both recv and save loops to avoid memory leaks.

### Fix 2: Handle attention backend `block_size` overrides

For MLA models (e.g., DeepSeek-V3), the FlashMLA attention backend silently overrides `block_size` to 64 regardless of the `--block-size` CLI flag. The existing `assert block_size == self.block_size` compared the actual KV cache tensor shape against the CLI config value, causing an `AssertionError` during `register_kv_caches`.

**Fix**: Trust the actual tensor shape as ground truth. If it differs from the config, log an informational message and update `self.block_size` to match.

### Fix 3: Default values for MORI-IO-specific `kv_transfer_params` fields

`remote_handshake_port` and `remote_notify_port` used direct dict access with no fallback. External coordinators (e.g., the NIXL sidecar in LLM-D) that don't inject these MORI-IO-specific fields would cause `KeyError`.

**Fix**: Use `.get()` with `MoRIIOConstants.DEFAULT_HANDSHAKE_PORT` / `DEFAULT_NOTIFY_PORT` defaults.

### Fix 4: Multi-node DP sizing and ranking

In multi-node DP (e.g. 2P/2D with 8 GPUs per node), `MoRIIOConfig` used global `dp_size` and `dp_rank` which caused port offsets to exceed the reachable range on the registered IP. For example, NODE2 with global dp_rank=8-15 would compute ports unreachable via NODE1's registered IP.

**Fix**: Use `data_parallel_size_local` and local dp_rank (`global % local_size`) so port offsets stay in 0..7 range per node. Applied to both `MoRIIOConfig.from_vllm_config` and `MoRIIOConnectorScheduler`.

### Fix 5: Prevent child/headless nodes from sending block notifications

In multi-node DP, child nodes participate in EP all-to-all via DP sync but must not perform KV transfers -- only master nodes (global `dp_rank < data_parallel_size_local`) have handshaked sessions and registered endpoints.

**Fix**: Added `_is_kv_master` flag to guard `send_notify_block` calls, preventing child nodes from sending spurious notifications that would never be received.

## Files Changed

| File | Change |
|------|--------|
| `moriio_connector.py` | +43/-17: Fix 1 (kv_params cache), Fix 2 (block_size), Fix 4 (local dp_rank), Fix 5 (_is_kv_master) |
| `moriio_common.py` | +11/-4: Fix 3 (default ports), Fix 4 (local dp_size/dp_rank) |

Signed-off-by: Rav Gupta <ravi.gupta@amd.com>