### PR TITLE
Bugfix: `use_existing_torch.py`: Glob recursive subdirs in requirements (fixes #39024)

### DIFF
--- a/use_existing_torch.py
+++ b/use_existing_torch.py
@@ -30,8 +30,8 @@ def main(argv):
     args = parser.parse_args(argv)
 
     for file in (
-        *glob.glob("requirements/*.txt"),
-        *glob.glob("requirements/*.in"),
+        *glob.glob("requirements/**/*.txt", recursive=True),
+        *glob.glob("requirements/**/*.in", recursive=True),
         "pyproject.toml",
     ):
         with open(file) as f:


### PR DESCRIPTION
#39024 added nesting to the requirements folder. `use_existing_torch.py` expected all requirements files to be flat. This pr adds recursion to the glob so `use_existing_torch` can work properly again. 

Repro:

1. Run the script on current `main`: `python use_existing_torch.py`. 
2. Observe: only top-level `requirements/*.txt` / `*.in` are modified. Nested files (e.g. `requirements/build/*`, `requirements/test/*`) are untouched.
3. Apply recursive glob change:
   ```diff
   - glob("requirements/*.txt")
   - glob("requirements/*.in")
   + glob("requirements/**/*.txt", recursive=True)
   + glob("requirements/**/*.in", recursive=True)
   ```
4. Observe:
   - Torch dependencies are removed across all requirement files:
     - `requirements/build/*`
     - `requirements/test/*`
     - `cuda`, `rocm`, `xpu` variants
   - Behavior is now consistent with pre-restructure layout.