### PR TITLE
[PD] Bump Nixl version

### DIFF
--- a/requirements/kv_connectors.txt
+++ b/requirements/kv_connectors.txt
@@ -1,5 +1,5 @@
 lmcache >= 0.3.9
-nixl[cu13] >= 0.7.1, < 0.10.0 # Required for disaggregated prefill
-nixl-cu12 >= 0.7.1, < 0.10.0
-nixl-cu13 >= 0.7.1, < 0.10.0
+nixl[cu13] >= 0.7.1, <= 1.0.0 # Required for disaggregated prefill. Use nixl[cu12] for CUDA 12.
+nixl-cu12 >= 0.7.1, <= 1.0.0
+nixl-cu13 >= 0.7.1, <= 1.0.0
 mooncake-transfer-engine >= 0.3.8


### PR DESCRIPTION
Address https://github.com/vllm-project/vllm/issues/39521.

Mind that we're pinning cu13 on vllm right now.
