### PR TITLE
[Config] Introduce RuntimeDefault fields for runtime initialized config values with correct static types

### DIFF
--- a/docs/mkdocs/hooks/generate_argparse.py
+++ b/docs/mkdocs/hooks/generate_argparse.py
@@ -145,6 +145,7 @@ bench_sweep_serve_workload = auto_mock(
 bench_throughput = auto_mock("vllm.benchmarks", "throughput")
 AsyncEngineArgs = auto_mock("vllm.engine.arg_utils", "AsyncEngineArgs")
 EngineArgs = auto_mock("vllm.engine.arg_utils", "EngineArgs")
+is_runtime_default = auto_mock("vllm.config.utils", "is_runtime_default")
 ChatCommand = auto_mock("vllm.entrypoints.cli.openai", "ChatCommand")
 CompleteCommand = auto_mock("vllm.entrypoints.cli.openai", "CompleteCommand")
 RenderSubcommand = auto_mock("vllm.entrypoints.cli.launch", "RenderSubcommand")
@@ -202,8 +203,13 @@ class MarkdownFormatter(HelpFormatter):
                 help_dd = ":" + textwrap.indent(action.help, "    ")[1:]
                 self._markdown_output.append(f"{help_dd}\n\n")
 
-            # None usually means the default is determined at runtime
-            if (default := action.default) != SUPPRESS and default is not None:
+            # None or an unresolved RuntimeDefault() sentinel means the
+            # default is determined at runtime
+            if (
+                (default := action.default) != SUPPRESS
+                and default is not None
+                and not is_runtime_default(default)
+            ):
                 # Make empty string defaults visible
                 if default == "":
                     default = '""'

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -10,6 +10,7 @@ import pytest
 from pydantic import Field
 
 from vllm.config import AttentionConfig, CompilationConfig, ModelConfig, config
+from vllm.config.utils import is_runtime_default
 from vllm.engine.arg_utils import (
     EngineArgs,
     _expand_json_human_readable_numbers,
@@ -511,7 +512,7 @@ def test_human_readable_model_len():
     parser = EngineArgs.add_cli_args(FlexibleArgumentParser(exit_on_error=False))
 
     args = parser.parse_args([])
-    assert args.max_model_len is None
+    assert is_runtime_default(args.max_model_len)
 
     args = parser.parse_args(["--max-model-len", "1024"])
     assert args.max_model_len == 1024
@@ -597,6 +598,32 @@ def test_human_readable_other_args():
     assert args.max_num_batched_tokens == 2_000
     args = parser.parse_args(["--max-num-batched-tokens", "4K"])
     assert args.max_num_batched_tokens == 2**10 * 4
+
+
+def test_spec_decode_shorthand_flags_default_to_none():
+    # --spec-method and --spec-tokens must default to None. It is not
+    # SpeculativeConfig's RuntimeDefault sentinel because
+    # create_speculative_config() builds a SpeculativeConfig on every
+    # default startup (no speculative decoding requested).
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args([])
+    assert args.spec_method is None
+    assert args.spec_tokens is None
+
+    engine_args = EngineArgs.from_cli_args(args)
+    assert engine_args.create_speculative_config(None, None) is None  # type: ignore[arg-type]
+
+
+def test_served_model_name_accepts_multiple_names():
+    # ModelConfig.served_model_name must stay `str | list[str] | None` (not
+    # RuntimeDefault) since its argparse shape (nargs="+") is derived from
+    # that annotation.
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(["--served-model-name", "a", "b"])
+    assert args.served_model_name == ["a", "b"]
+
+    args = parser.parse_args([])
+    assert args.served_model_name is None
 
 
 def test_numa_bind_args():

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -1,13 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from collections.abc import Callable
 from dataclasses import field
-from typing import Any, ClassVar, Literal
+from typing import ClassVar, Literal
 
 from pydantic import Field, field_validator, model_validator
 
-from vllm.config.utils import config
+from vllm.config.utils import (
+    RuntimeDefault,
+    config,
+    is_runtime_default,
+    runtime_default_validator,
+)
 from vllm.logger import init_logger
 from vllm.utils.torch_utils import (
     is_quantized_kv_cache,
@@ -46,9 +50,10 @@ class CacheConfig:
 
     DEFAULT_BLOCK_SIZE: ClassVar[int] = 16
 
-    block_size: int = Field(default=None, gt=0)  # type: ignore[assignment]
-    """Size of a contiguous cache block in number of tokens.
-    Accepts None (meaning "use default"). After construction, always int."""
+    block_size: int = RuntimeDefault(gt=0)
+    """Size of a contiguous cache block in number of tokens. Resolved to a
+    platform specific default at runtime if left unset. After construction,
+    always int."""
     user_specified_block_size: bool = field(default=False, init=False)
     """Whether block_size was explicitly provided. Derived automatically."""
     user_specified_mamba_block_size: bool = field(default=False, init=False)
@@ -237,12 +242,7 @@ class CacheConfig:
     _block_size_resolved: bool = field(default=False, init=False)
     """Guard against pydantic re-running _apply_block_size_default."""
 
-    @field_validator("block_size", mode="wrap")
-    @classmethod
-    def _skip_none_validation(cls, value: Any, handler: Callable) -> Any:
-        if value is None:
-            return value
-        return handler(value)
+    _accept_unresolved_block_size = runtime_default_validator("block_size")
 
     @model_validator(mode="after")
     def _apply_block_size_default(self) -> "CacheConfig":
@@ -251,7 +251,7 @@ class CacheConfig:
         if self._block_size_resolved:
             return self
         self._block_size_resolved = True
-        if self.block_size is None:
+        if is_runtime_default(self.block_size):
             self.block_size = self.DEFAULT_BLOCK_SIZE
         else:
             self.user_specified_block_size = True

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -14,7 +14,6 @@ import vllm.envs as envs
 from vllm.compilation.passes.inductor_pass import CallableInductorPass, InductorPass
 from vllm.config.utils import (
     Deferred,
-    DeferredFieldsMixin,
     Range,
     config,
     get_hash_factors,
@@ -106,7 +105,7 @@ class CUDAGraphMode(enum.Enum):
 
 
 @config
-class PassConfig(DeferredFieldsMixin):
+class PassConfig:
     """Configuration for custom Inductor passes.
 
     This is separate from general `CompilationConfig` so that inductor passes

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -160,9 +160,6 @@ class PassConfig:
     eliminate_noops: bool = Field(default=True)
     """Eliminate no-op ops."""
 
-    enable_qk_norm_rope_fusion: bool = False
-    """Enable fused Q/K RMSNorm + RoPE pass."""
-
     rope_kvcache_fusion_max_token_num: int = 256
     """The threshold for ROCm AITER RoPE+KVCache fusion e.g. for small batch decode.
     Larger batch sizes e.g. during prefill will use the unfused kernels.

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -6,13 +6,15 @@ from collections import Counter
 from collections.abc import Callable
 from dataclasses import field, fields
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal
 
 from pydantic import Field, TypeAdapter, field_validator
 
 import vllm.envs as envs
 from vllm.compilation.passes.inductor_pass import CallableInductorPass, InductorPass
 from vllm.config.utils import (
+    Deferred,
+    DeferredFieldsMixin,
     Range,
     config,
     get_hash_factors,
@@ -104,7 +106,7 @@ class CUDAGraphMode(enum.Enum):
 
 
 @config
-class PassConfig:
+class PassConfig(DeferredFieldsMixin):
     """Configuration for custom Inductor passes.
 
     This is separate from general `CompilationConfig` so that inductor passes
@@ -117,22 +119,32 @@ class PassConfig:
     improper state.
     """
 
-    # New flags
-    fuse_norm_quant: bool = None  # type: ignore[assignment]
+    # Deferred annotation for fields initialized during VllmConfig post_init
+
+    # Fields below use Deferred(False) as a last-resort fallback that fires
+    # only when neither the user nor the optimization-level table
+    # (OPTIMIZATION_LEVEL_TO_CONFIG in vllm.py) has supplied a value.
+    # In practice, most of these fields are covered by the optimization-level
+    # table, so Deferred(False) rarely triggers for them.  The exceptions are
+    # fuse_attn_quant (absent from optimization levels 0 and 1) and
+    # fuse_minimax_qk_norm (absent from all optimizati
+    # on levels), where Deferred(False) provides the only default.
+
+    fuse_norm_quant: Annotated[bool | None, Deferred(False)] = None
     """Fuse the custom RMSNorm + quant ops."""
-    fuse_act_quant: bool = None  # type: ignore[assignment]
+    fuse_act_quant: Annotated[bool | None, Deferred(False)] = None
     """Fuse the custom SiluMul + quant ops."""
-    fuse_attn_quant: bool = None  # type: ignore[assignment]
+    fuse_attn_quant: Annotated[bool | None, Deferred(False)] = None
     """Fuse the custom Attention and MLAAttention + quant ops."""
     eliminate_noops: bool = Field(default=True)
     """Eliminate no-op ops."""
-    enable_sp: bool = None  # type: ignore[assignment]
+    enable_sp: Annotated[bool | None, Deferred(False)] = None
     """Enable sequence parallelism. Requires TP>1. Automatically disabled
     if the model's hidden_size is too small for SP to be beneficial
     (threshold is device-capability dependent)."""
-    fuse_gemm_comms: bool = None  # type: ignore[assignment]
+    fuse_gemm_comms: Annotated[bool | None, Deferred(False)] = None
     """Enable async TP."""
-    fuse_allreduce_rms: bool = None  # type: ignore[assignment]
+    fuse_allreduce_rms: Annotated[bool | None, Deferred(False)] = None
     """Enable flashinfer allreduce fusion."""
     enable_qk_norm_rope_fusion: bool = None  # type: ignore[assignment]
     """Enable fused Q/K RMSNorm + RoPE pass."""
@@ -140,17 +152,20 @@ class PassConfig:
     """Enable fused MLA KV cache update with RoPE."""
 
     # ROCm/AITER specific fusions
-    fuse_act_padding: bool = None  # type: ignore[assignment]
+    fuse_act_padding: Annotated[bool | None, Deferred(False)] = None
     """Fuse the custom RMSNorm + padding ops."""
-    fuse_mla_dual_rms_norm: bool = None  # type: ignore[assignment]
+    fuse_mla_dual_rms_norm: Annotated[bool | None, Deferred(False)] = None
     """Fuse paired q/kv RMS norms in MLA attention."""
-    fuse_rope_kvcache: bool = None  # type: ignore[assignment]
+    fuse_rope_kvcache: Annotated[bool | None, Deferred(False)] = None
     """Fuse the QK rope + KV cache ops."""
     fuse_qk_norm_rope_kvcache: bool = Field(default=None)  # type: ignore[assignment]
     """Fuse QK RMSNorm + RoPE + KV cache update into a single AITER HIP
     kernel. Supersedes both enable_qk_norm_rope_fusion and fuse_rope_kvcache
     for layers that support it. Auto-enabled at O1+ on ROCm for models
     with QK-norm (e.g. Qwen3-MoE)."""
+
+    enable_qk_norm_rope_fusion: bool = False
+    """Enable fused Q/K RMSNorm + RoPE pass."""
 
     rope_kvcache_fusion_max_token_num: int = 256
     """The threshold for ROCm AITER RoPE+KVCache fusion e.g. for small batch decode.
@@ -223,28 +238,6 @@ class PassConfig:
         """
 
         return hash_factors(get_hash_factors(self, set()))
-
-    @field_validator(
-        "fuse_norm_quant",
-        "fuse_act_quant",
-        "fuse_attn_quant",
-        "enable_sp",
-        "fuse_gemm_comms",
-        "fuse_allreduce_rms",
-        "fuse_act_padding",
-        "fuse_mla_dual_rms_norm",
-        "fuse_rope_kvcache",
-        "fuse_qk_norm_rope_kvcache",
-        "enable_qk_norm_rope_fusion",
-        "fuse_rope_kvcache_cat_mla",
-        mode="wrap",
-    )
-    @classmethod
-    def _skip_none_validation(cls, value: Any, handler: Callable) -> Any:
-        """Skip validation if the value is `None` when initialisation is delayed."""
-        if value is None:
-            return value
-        return handler(value)
 
     def __post_init__(self) -> None:
         # Handle deprecation and defaults

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -13,8 +13,8 @@ from pydantic import Field, TypeAdapter, field_validator
 import vllm.envs as envs
 from vllm.compilation.passes.inductor_pass import CallableInductorPass, InductorPass
 from vllm.config.utils import (
-    Deferred,
     Range,
+    RuntimeDefault,
     config,
     get_hash_factors,
     hash_factors,
@@ -120,24 +120,24 @@ class PassConfig:
 
     # Fields initialized during VllmConfig.__post_init__.
     #
-    # Deferred() fields have no fallback: they must be set by the user or by
+    # RuntimeDefault() fields have no fallback: they must be set by the user or by
     # the optimization-level table (OPTIMIZATION_LEVEL_TO_CONFIG in vllm.py).
-    # Deferred(False) is reserved for fields absent from the optimization-level
+    # RuntimeDefault(False) is reserved for fields absent from the optimization-level
     # tables.
 
-    fuse_norm_quant: bool = Deferred()
+    fuse_norm_quant: bool = RuntimeDefault()
     """Fuse the custom RMSNorm + quant ops."""
-    fuse_act_quant: bool = Deferred()
+    fuse_act_quant: bool = RuntimeDefault()
     """Fuse the custom SiluMul + quant ops."""
-    fuse_attn_quant: bool = Deferred()
+    fuse_attn_quant: bool = RuntimeDefault()
     """Fuse the custom Attention and MLAAttention + quant ops."""
-    enable_sp: bool = Deferred()
+    enable_sp: bool = RuntimeDefault()
     """Enable sequence parallelism. Requires TP>1. Automatically disabled
     if the model's hidden_size is too small for SP to be beneficial
     (threshold is device-capability dependent)."""
-    fuse_gemm_comms: bool = Deferred()
+    fuse_gemm_comms: bool = RuntimeDefault()
     """Enable async TP."""
-    fuse_allreduce_rms: bool = Deferred()
+    fuse_allreduce_rms: bool = RuntimeDefault()
     """Enable flashinfer allreduce fusion."""
     enable_qk_norm_rope_fusion: bool = None  # type: ignore[assignment]
     """Enable fused Q/K RMSNorm + RoPE pass."""
@@ -145,11 +145,11 @@ class PassConfig:
     """Enable fused MLA KV cache update with RoPE."""
 
     # ROCm/AITER specific fusions
-    fuse_act_padding: bool = Deferred()
+    fuse_act_padding: bool = RuntimeDefault()
     """Fuse the custom RMSNorm + padding ops."""
-    fuse_mla_dual_rms_norm: bool = Deferred()
+    fuse_mla_dual_rms_norm: bool = RuntimeDefault()
     """Fuse paired q/kv RMS norms in MLA attention."""
-    fuse_rope_kvcache: bool = Deferred()
+    fuse_rope_kvcache: bool = RuntimeDefault()
     """Fuse the QK rope + KV cache ops."""
     fuse_qk_norm_rope_kvcache: bool = Field(default=None)  # type: ignore[assignment]
     """Fuse QK RMSNorm + RoPE + KV cache update into a single AITER HIP

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -123,7 +123,7 @@ class PassConfig:
     # Deferred() fields have no fallback: they must be set by the user or by
     # the optimization-level table (OPTIMIZATION_LEVEL_TO_CONFIG in vllm.py).
     # Deferred(False) is reserved for fields absent from the optimization-level
-    # tables; currently only fuse_minimax_qk_norm falls into that category.
+    # tables.
 
     fuse_norm_quant: bool = Deferred()
     """Fuse the custom RMSNorm + quant ops."""
@@ -131,8 +131,6 @@ class PassConfig:
     """Fuse the custom SiluMul + quant ops."""
     fuse_attn_quant: bool = Deferred()
     """Fuse the custom Attention and MLAAttention + quant ops."""
-    eliminate_noops: bool = Field(default=True)
-    """Eliminate no-op ops."""
     enable_sp: bool = Deferred()
     """Enable sequence parallelism. Requires TP>1. Automatically disabled
     if the model's hidden_size is too small for SP to be beneficial
@@ -158,6 +156,9 @@ class PassConfig:
     kernel. Supersedes both enable_qk_norm_rope_fusion and fuse_rope_kvcache
     for layers that support it. Auto-enabled at O1+ on ROCm for models
     with QK-norm (e.g. Qwen3-MoE)."""
+
+    eliminate_noops: bool = Field(default=True)
+    """Eliminate no-op ops."""
 
     enable_qk_norm_rope_fusion: bool = False
     """Enable fused Q/K RMSNorm + RoPE pass."""

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -692,7 +692,7 @@ class CompilationConfig:
     local_cache_dir: str = field(default=None, init=False)  # type: ignore
     """local cache dir for each rank"""
 
-    fast_moe_cold_start: bool | None = None
+    fast_moe_cold_start: bool = RuntimeDefault()
     """Optimization for fast MOE cold start.
 
     This is a bit of a hack that assumes that:

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -433,7 +433,7 @@ class CompilationConfig:
     """
 
     # Top-level Compilation control
-    mode: CompilationMode = None  # type: ignore[assignment]
+    mode: CompilationMode = RuntimeDefault()
     """The compilation approach used for torch.compile-based compilation of the
     model.
 
@@ -495,7 +495,7 @@ class CompilationConfig:
     backend="inductor".
     Inductor generates (fused) Triton kernels for disabled custom ops."""
 
-    ir_enable_torch_wrap: bool = None  # type: ignore[assignment]
+    ir_enable_torch_wrap: bool = RuntimeDefault()
     """If True, enable vllm_ir torch custom op wrapping during the forward pass.
     When False, torch custom op wrapping is disabled, allowing Dynamo to trace the
     selected implementation directly or avoiding torch custom op overhead in eager mode.
@@ -593,7 +593,7 @@ class CompilationConfig:
     constructor, e.g. `CompilationConfig(inductor_passes={"a": func})`."""
 
     # CudaGraph compilation
-    cudagraph_mode: CUDAGraphMode = None  # type: ignore[assignment]
+    cudagraph_mode: CUDAGraphMode = RuntimeDefault()
     """
     The mode of the cudagraph:
 
@@ -634,7 +634,7 @@ class CompilationConfig:
     It means the first several runs will be treated as warmup runs.
     Only after that, the execution will be recorded, and the recorded
     cudagraph will be used for subsequent runs."""
-    cudagraph_capture_sizes: list[int] = None  # type: ignore[assignment]
+    cudagraph_capture_sizes: list[int] = RuntimeDefault()
     """Sizes to capture cudagraph.
     - None (default): capture sizes are inferred from vllm config.
     - list[int]: capture sizes are specified as given."""
@@ -655,7 +655,7 @@ class CompilationConfig:
     When `enable_lora` is False, this option has no effect.
     """
 
-    use_inductor_graph_partition: bool = None  # type: ignore[assignment]
+    use_inductor_graph_partition: bool = RuntimeDefault()
     """Use inductor graph partition to split the graph at cudagraph_unsafe ops.
     This partition happens at inductor codegen time after all passes and fusions
     are finished. It generates a single `call` function which wraps
@@ -678,7 +678,7 @@ class CompilationConfig:
     pass_config: PassConfig = field(default_factory=PassConfig)
     """Custom inductor passes, see PassConfig for more details"""
 
-    max_cudagraph_capture_size: int = None  # type: ignore[assignment]
+    max_cudagraph_capture_size: int = RuntimeDefault()
     """The maximum cudagraph capture size.
 
     If cudagraph_capture_sizes is specified, this will be set to the largest
@@ -876,22 +876,6 @@ class CompilationConfig:
                 f"got: {value}"
             )
         return value
-
-    @field_validator(
-        "level",
-        "mode",
-        "cudagraph_mode",
-        "max_cudagraph_capture_size",
-        "use_inductor_graph_partition",
-        "ir_enable_torch_wrap",
-        mode="wrap",
-    )
-    @classmethod
-    def _skip_none_validation(cls, value: Any, handler: Callable) -> Any:
-        """Skip validation if the value is `None` when initialisation is delayed."""
-        if value is None:
-            return value
-        return handler(value)
 
     def __post_init__(self) -> None:
         count_none = self.custom_ops.count("none")

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -6,7 +6,7 @@ from collections import Counter
 from collections.abc import Callable
 from dataclasses import field, fields
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 from pydantic import Field, TypeAdapter, field_validator
 
@@ -119,32 +119,30 @@ class PassConfig(DeferredFieldsMixin):
     improper state.
     """
 
-    # Deferred annotation for fields initialized during VllmConfig post_init
+    # Fields initialized during VllmConfig.__post_init__.
+    #
+    # Deferred(False) is a last-resort fallback that fires only when neither
+    # the user nor the optimization-level table (OPTIMIZATION_LEVEL_TO_CONFIG
+    # in vllm.py) has supplied a value.  Most fields are covered by the table;
+    # the exceptions are fuse_attn_quant (absent from levels 0 and 1) and
+    # fuse_minimax_qk_norm (absent from all levels), where Deferred(False) is
+    # the sole default.
 
-    # Fields below use Deferred(False) as a last-resort fallback that fires
-    # only when neither the user nor the optimization-level table
-    # (OPTIMIZATION_LEVEL_TO_CONFIG in vllm.py) has supplied a value.
-    # In practice, most of these fields are covered by the optimization-level
-    # table, so Deferred(False) rarely triggers for them.  The exceptions are
-    # fuse_attn_quant (absent from optimization levels 0 and 1) and
-    # fuse_minimax_qk_norm (absent from all optimizati
-    # on levels), where Deferred(False) provides the only default.
-
-    fuse_norm_quant: Annotated[bool | None, Deferred(False)] = None
+    fuse_norm_quant: bool = Deferred(False)
     """Fuse the custom RMSNorm + quant ops."""
-    fuse_act_quant: Annotated[bool | None, Deferred(False)] = None
+    fuse_act_quant: bool = Deferred(False)
     """Fuse the custom SiluMul + quant ops."""
-    fuse_attn_quant: Annotated[bool | None, Deferred(False)] = None
+    fuse_attn_quant: bool = Deferred(False)
     """Fuse the custom Attention and MLAAttention + quant ops."""
     eliminate_noops: bool = Field(default=True)
     """Eliminate no-op ops."""
-    enable_sp: Annotated[bool | None, Deferred(False)] = None
+    enable_sp: bool = Deferred(False)
     """Enable sequence parallelism. Requires TP>1. Automatically disabled
     if the model's hidden_size is too small for SP to be beneficial
     (threshold is device-capability dependent)."""
-    fuse_gemm_comms: Annotated[bool | None, Deferred(False)] = None
+    fuse_gemm_comms: bool = Deferred(False)
     """Enable async TP."""
-    fuse_allreduce_rms: Annotated[bool | None, Deferred(False)] = None
+    fuse_allreduce_rms: bool = Deferred(False)
     """Enable flashinfer allreduce fusion."""
     enable_qk_norm_rope_fusion: bool = None  # type: ignore[assignment]
     """Enable fused Q/K RMSNorm + RoPE pass."""
@@ -152,11 +150,11 @@ class PassConfig(DeferredFieldsMixin):
     """Enable fused MLA KV cache update with RoPE."""
 
     # ROCm/AITER specific fusions
-    fuse_act_padding: Annotated[bool | None, Deferred(False)] = None
+    fuse_act_padding: bool = Deferred(False)
     """Fuse the custom RMSNorm + padding ops."""
-    fuse_mla_dual_rms_norm: Annotated[bool | None, Deferred(False)] = None
+    fuse_mla_dual_rms_norm: bool = Deferred(False)
     """Fuse paired q/kv RMS norms in MLA attention."""
-    fuse_rope_kvcache: Annotated[bool | None, Deferred(False)] = None
+    fuse_rope_kvcache: bool = Deferred(False)
     """Fuse the QK rope + KV cache ops."""
     fuse_qk_norm_rope_kvcache: bool = Field(default=None)  # type: ignore[assignment]
     """Fuse QK RMSNorm + RoPE + KV cache update into a single AITER HIP

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -132,10 +132,12 @@ class PassConfig:
     """Enable async TP."""
     fuse_allreduce_rms: bool = RuntimeDefault()
     """Enable flashinfer allreduce fusion."""
-    enable_qk_norm_rope_fusion: bool = None  # type: ignore[assignment]
+    enable_qk_norm_rope_fusion: bool = RuntimeDefault()
     """Enable fused Q/K RMSNorm + RoPE pass."""
-    fuse_rope_kvcache_cat_mla: bool = None  # type: ignore[assignment]
+    fuse_rope_kvcache_cat_mla: bool = RuntimeDefault()
     """Enable fused MLA KV cache update with RoPE."""
+    eliminate_noops: bool = Field(default=True)
+    """Eliminate no-op ops."""
 
     # ROCm/AITER specific fusions
     fuse_act_padding: bool = RuntimeDefault()
@@ -149,9 +151,6 @@ class PassConfig:
     kernel. Supersedes both enable_qk_norm_rope_fusion and fuse_rope_kvcache
     for layers that support it. Auto-enabled at O1+ on ROCm for models
     with QK-norm (e.g. Qwen3-MoE)."""
-
-    eliminate_noops: bool = Field(default=True)
-    """Eliminate no-op ops."""
 
     rope_kvcache_fusion_max_token_num: int = 256
     """The threshold for ROCm AITER RoPE+KVCache fusion e.g. for small batch decode.

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -118,13 +118,6 @@ class PassConfig:
     improper state.
     """
 
-    # Fields initialized during VllmConfig.__post_init__.
-    #
-    # RuntimeDefault() fields have no fallback: they must be set by the user or by
-    # the optimization-level table (OPTIMIZATION_LEVEL_TO_CONFIG in vllm.py).
-    # RuntimeDefault(False) is reserved for fields absent from the optimization-level
-    # tables.
-
     fuse_norm_quant: bool = RuntimeDefault()
     """Fuse the custom RMSNorm + quant ops."""
     fuse_act_quant: bool = RuntimeDefault()

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -121,28 +121,26 @@ class PassConfig(DeferredFieldsMixin):
 
     # Fields initialized during VllmConfig.__post_init__.
     #
-    # Deferred(False) is a last-resort fallback that fires only when neither
-    # the user nor the optimization-level table (OPTIMIZATION_LEVEL_TO_CONFIG
-    # in vllm.py) has supplied a value.  Most fields are covered by the table;
-    # the exceptions are fuse_attn_quant (absent from levels 0 and 1) and
-    # fuse_minimax_qk_norm (absent from all levels), where Deferred(False) is
-    # the sole default.
+    # Deferred() fields have no fallback: they must be set by the user or by
+    # the optimization-level table (OPTIMIZATION_LEVEL_TO_CONFIG in vllm.py).
+    # Deferred(False) is reserved for fields absent from the optimization-level
+    # tables; currently only fuse_minimax_qk_norm falls into that category.
 
-    fuse_norm_quant: bool = Deferred(False)
+    fuse_norm_quant: bool = Deferred()
     """Fuse the custom RMSNorm + quant ops."""
-    fuse_act_quant: bool = Deferred(False)
+    fuse_act_quant: bool = Deferred()
     """Fuse the custom SiluMul + quant ops."""
-    fuse_attn_quant: bool = Deferred(False)
+    fuse_attn_quant: bool = Deferred()
     """Fuse the custom Attention and MLAAttention + quant ops."""
     eliminate_noops: bool = Field(default=True)
     """Eliminate no-op ops."""
-    enable_sp: bool = Deferred(False)
+    enable_sp: bool = Deferred()
     """Enable sequence parallelism. Requires TP>1. Automatically disabled
     if the model's hidden_size is too small for SP to be beneficial
     (threshold is device-capability dependent)."""
-    fuse_gemm_comms: bool = Deferred(False)
+    fuse_gemm_comms: bool = Deferred()
     """Enable async TP."""
-    fuse_allreduce_rms: bool = Deferred(False)
+    fuse_allreduce_rms: bool = Deferred()
     """Enable flashinfer allreduce fusion."""
     enable_qk_norm_rope_fusion: bool = None  # type: ignore[assignment]
     """Enable fused Q/K RMSNorm + RoPE pass."""
@@ -150,11 +148,11 @@ class PassConfig(DeferredFieldsMixin):
     """Enable fused MLA KV cache update with RoPE."""
 
     # ROCm/AITER specific fusions
-    fuse_act_padding: bool = Deferred(False)
+    fuse_act_padding: bool = Deferred()
     """Fuse the custom RMSNorm + padding ops."""
-    fuse_mla_dual_rms_norm: bool = Deferred(False)
+    fuse_mla_dual_rms_norm: bool = Deferred()
     """Fuse paired q/kv RMS norms in MLA attention."""
-    fuse_rope_kvcache: bool = Deferred(False)
+    fuse_rope_kvcache: bool = Deferred()
     """Fuse the QK rope + KV cache ops."""
     fuse_qk_norm_rope_kvcache: bool = Field(default=None)  # type: ignore[assignment]
     """Fuse QK RMSNorm + RoPE + KV cache update into a single AITER HIP

--- a/vllm/config/ec_transfer.py
+++ b/vllm/config/ec_transfer.py
@@ -5,7 +5,12 @@ import uuid
 from dataclasses import field
 from typing import Any, Literal, get_args
 
-from vllm.config.utils import config
+from vllm.config.utils import (
+    RuntimeDefault,
+    config,
+    is_runtime_default,
+    runtime_default_validator,
+)
 
 ECProducer = Literal["ec_producer", "ec_both"]
 ECConsumer = Literal["ec_consumer", "ec_both"]
@@ -20,7 +25,7 @@ class ECTransferConfig:
     """The EC connector for vLLM to transmit EC caches between vLLM instances.
     """
 
-    engine_id: str | None = None
+    engine_id: str = RuntimeDefault()
     """The engine id for EC transfers."""
 
     ec_buffer_device: str | None = "cuda"
@@ -57,6 +62,8 @@ class ECTransferConfig:
     """The Python module path to dynamically load the EC connector from.
     Only supported in V1."""
 
+    _accept_unresolved_engine_id = runtime_default_validator("engine_id")
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,
@@ -76,7 +83,7 @@ class ECTransferConfig:
         return hash_str
 
     def __post_init__(self) -> None:
-        if self.engine_id is None:
+        if is_runtime_default(self.engine_id):
             self.engine_id = str(uuid.uuid4())
 
         if self.ec_role is not None and self.ec_role not in get_args(ECRole):

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -1,13 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import contextlib
-from collections.abc import Callable
 from dataclasses import asdict, fields
 from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import Field, field_validator
 
-from vllm.config.utils import config, get_hash_factors, hash_factors
+from vllm.config.utils import (
+    RuntimeDefault,
+    config,
+    get_hash_factors,
+    hash_factors,
+    skip_none_validator,
+)
 from vllm.logger import init_logger
 
 if TYPE_CHECKING:
@@ -172,7 +177,7 @@ class KernelConfig:
     Platform defaults appended automatically during VllmConfig.__post_init__.
     """
 
-    enable_flashinfer_autotune: bool = None  # type: ignore[assignment]
+    enable_flashinfer_autotune: bool = RuntimeDefault()
     """If True, run FlashInfer autotuning during kernel warmup."""
 
     # TODO(roberto): Remove after registered CuTeDSL warmups are migrated
@@ -264,18 +269,9 @@ class KernelConfig:
         factors["ir_op_priority"] = self.ir_op_priority.compute_hash()
         return hash_factors(factors)
 
-    @field_validator(
-        "enable_flashinfer_autotune",
-        "enable_cutedsl_warmup",
-        "enable_jit_warmup",
-        mode="wrap",
+    _skip_none_warmup_flags = skip_none_validator(
+        "enable_cutedsl_warmup", "enable_jit_warmup"
     )
-    @classmethod
-    def _skip_none_validation(cls, value: Any, handler: Callable) -> Any:
-        """Skip validation if the value is `None` when initialization is delayed."""
-        if value is None:
-            return value
-        return handler(value)
 
     def set_platform_defaults(self, vllm_config: "VllmConfig") -> None:
         """Set platform-specific defaults for the kernel config."""

--- a/vllm/config/kv_events.py
+++ b/vllm/config/kv_events.py
@@ -4,7 +4,7 @@
 
 from typing import Literal
 
-from vllm.config.utils import config
+from vllm.config.utils import RuntimeDefault, config, is_runtime_default
 
 
 @config
@@ -16,7 +16,7 @@ class KVEventsConfig:
     Events can be published externally by zmq using the event publisher config.
     """
 
-    publisher: Literal["null", "zmq"] = None  # type: ignore[assignment]
+    publisher: Literal["null", "zmq"] = RuntimeDefault()
     """The publisher to use for publishing kv events. Can be "null", "zmq".
     """
 
@@ -48,5 +48,5 @@ class KVEventsConfig:
     """
 
     def __post_init__(self):
-        if self.publisher is None:
+        if is_runtime_default(self.publisher):
             self.publisher = "zmq" if self.enable_kv_cache_events else "null"

--- a/vllm/config/kv_transfer.py
+++ b/vllm/config/kv_transfer.py
@@ -5,7 +5,12 @@ import uuid
 from dataclasses import field
 from typing import Any, Literal, get_args
 
-from vllm.config.utils import config
+from vllm.config.utils import (
+    RuntimeDefault,
+    config,
+    is_runtime_default,
+    runtime_default_validator,
+)
 from vllm.utils.hashing import safe_hash
 
 KVProducer = Literal["kv_producer", "kv_both"]
@@ -27,7 +32,7 @@ class KVTransferConfig:
     """The KV connector for vLLM to transmit KV caches between vLLM instances.
     """
 
-    engine_id: str | None = None
+    engine_id: str = RuntimeDefault()
     """The engine id for KV transfers."""
 
     kv_buffer_device: str = field(default_factory=kv_buffer_device_default_factory)
@@ -71,6 +76,8 @@ class KVTransferConfig:
     'recompute': reschedule the request to recompute failed blocks
     'fail': immediately fail the request with an error finish reason (default)"""
 
+    _accept_unresolved_engine_id = runtime_default_validator("engine_id")
+
     def compute_hash(self) -> str:
         """
         WARNING: Whenever a new field is added to this config,
@@ -90,7 +97,7 @@ class KVTransferConfig:
         return hash_str
 
     def __post_init__(self) -> None:
-        if self.engine_id is None:
+        if is_runtime_default(self.engine_id):
             self.engine_id = str(uuid.uuid4())
 
         if self.kv_role is not None and self.kv_role not in get_args(KVRole):

--- a/vllm/config/lora.py
+++ b/vllm/config/lora.py
@@ -9,7 +9,12 @@ from pydantic import ConfigDict, Field, model_validator
 from typing_extensions import Self
 
 from vllm import envs
-from vllm.config.utils import config
+from vllm.config.utils import (
+    RuntimeDefault,
+    config,
+    is_runtime_default,
+    runtime_default_validator,
+)
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.hashing import safe_hash
@@ -41,7 +46,7 @@ class LoRAConfig:
     parallelism. Enabling this will use the fully sharded layers. At high
     sequence length, max rank or tensor parallel size, this is likely faster.
     """
-    max_cpu_loras: int | None = None
+    max_cpu_loras: int = RuntimeDefault()
     """Maximum number of LoRAs to store in CPU memory. Must be >= than
     `max_loras`."""
     lora_dtype: torch.dtype | LoRADType = "auto"
@@ -113,9 +118,11 @@ class LoRAConfig:
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str
 
+    _accept_unresolved_max_cpu_loras = runtime_default_validator("max_cpu_loras")
+
     @model_validator(mode="after")
     def _validate_lora_config(self) -> Self:
-        if self.max_cpu_loras is None:
+        if is_runtime_default(self.max_cpu_loras):
             self.max_cpu_loras = self.max_loras
         elif self.max_cpu_loras < self.max_loras:
             raise ValueError(

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -23,7 +23,13 @@ from vllm.config.multimodal import (
 from vllm.config.pooler import POOLER_CONFIG_LOG_FIELDS, PoolerConfig
 from vllm.config.quantization import QuantizationConfigArgs
 from vllm.config.scheduler import RunnerType
-from vllm.config.utils import config, getattr_iter
+from vllm.config.utils import (
+    RuntimeDefault,
+    config,
+    getattr_iter,
+    is_runtime_default,
+    runtime_default_validator,
+)
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.tasks import PoolingTask, ScoreType, SupportedTask
@@ -124,7 +130,7 @@ class ModelConfig:
     """Convert the model using adapters defined in
     [vllm.model_executor.models.adapters][]. The most common use case is to
     adapt a text generation model to be used for pooling tasks."""
-    tokenizer: str = None  # type: ignore[assignment]
+    tokenizer: str = RuntimeDefault()
     """Name or path of the Hugging Face tokenizer to use. If unspecified, model
     name or path will be used."""
     tokenizer_mode: TokenizerMode | str = "auto"
@@ -187,7 +193,7 @@ class ModelConfig:
     """The specific revision to use for the tokenizer on the Hugging Face Hub.
     It can be a branch name, a tag name, or a commit id. If unspecified, will
     use the default version."""
-    max_model_len: int = Field(default=None, ge=-1)  # type: ignore[assignment]
+    max_model_len: int = RuntimeDefault(ge=-1)
     """Model context length (prompt and output). If unspecified, will be
     automatically derived from the model config.
 
@@ -509,7 +515,7 @@ class ModelConfig:
         )
         self.model = maybe_model_redirect(self.model)
         # The tokenizer is consistent with the model by default.
-        if self.tokenizer is None:
+        if is_runtime_default(self.tokenizer):
             self.tokenizer = self.model
         if self.tokenizer_revision is None:
             self.tokenizer_revision = self.revision
@@ -772,13 +778,7 @@ class ModelConfig:
         convertor = convertor_cls(self.hf_config, self.hf_text_config)
         return convertor.convert()
 
-    @field_validator("tokenizer", "max_model_len", mode="wrap")
-    @classmethod
-    def _skip_none_validation(cls, value: Any, handler: Callable) -> Any:
-        """Skip validation if the value is `None` when initialisation is delayed."""
-        if value is None:
-            return value
-        return handler(value)
+    _accept_unresolved = runtime_default_validator("tokenizer", "max_model_len")
 
     @field_validator("tokenizer_mode", mode="after")
     def _lowercase_tokenizer_mode(cls, tokenizer_mode: str) -> str:
@@ -1763,6 +1763,12 @@ class ModelConfig:
         return self.get_hidden_size()
 
     def get_and_verify_max_len(self, max_model_len: int):
+        # An unresolved RuntimeDefault() sentinel means "unset". This is the same as
+        # the `None` that `_get_and_verify_max_len` already knows how to
+        # handle.
+        resolved_max_model_len: int | None = (
+            None if is_runtime_default(max_model_len) else max_model_len
+        )
         # Consider max_model_len in tokenizer_config only when
         # pooling models use absolute position_embedding.
         tokenizer_config = None
@@ -1779,7 +1785,7 @@ class ModelConfig:
             hf_config=self.hf_text_config,
             model_arch_config=self.model_arch_config,
             tokenizer_config=tokenizer_config,
-            max_model_len=max_model_len,
+            max_model_len=resolved_max_model_len,
             disable_sliding_window=self.disable_sliding_window,
             sliding_window=self.get_sliding_window(),
             spec_target_max_model_len=self.spec_target_max_model_len,

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -3,7 +3,6 @@
 
 import os
 import socket
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Literal, overload
 
 import regex as re
@@ -13,7 +12,7 @@ from torch.distributed import ProcessGroup, ReduceOp, Store
 from typing_extensions import Self
 
 import vllm.envs as envs
-from vllm.config.utils import config
+from vllm.config.utils import RuntimeDefault, config, runtime_default_validator
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.network_utils import get_open_ports_list
@@ -222,8 +221,8 @@ class ParallelConfig:
     threshold, microbatching will be used. Otherwise, the request will be
     processed in a single batch."""
 
-    disable_nccl_for_dp_synchronization: bool | None = None
-    """Forces the dp synchronization logic in vllm/v1/worker/dp_utils.py 
+    disable_nccl_for_dp_synchronization: bool = RuntimeDefault()
+    """Forces the dp synchronization logic in vllm/v1/worker/dp_utils.py
     to use Gloo instead of NCCL for its all reduce.
 
     Defaults to True when async scheduling is enabled, False otherwise.
@@ -393,11 +392,9 @@ class ParallelConfig:
         should only be set by API server scale-out.
     """
 
-    @field_validator("disable_nccl_for_dp_synchronization", mode="wrap")
-    @classmethod
-    def _skip_none_validation(cls, value: Any, handler: Callable) -> Any:
-        """Skip validation if the value is `None` when initialisation is delayed."""
-        return None if value is None else handler(value)
+    _accept_unresolved_disable_nccl_for_dp_synchronization = runtime_default_validator(
+        "disable_nccl_for_dp_synchronization"
+    )
 
     @field_validator("numa_bind_nodes")
     @classmethod

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -1,14 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from collections.abc import Callable
 from dataclasses import InitVar
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, cast
 
-from pydantic import Field, field_validator
+from pydantic import Field
 from typing_extensions import Self
 
-from vllm.config.utils import config
+from vllm.config.utils import (
+    RuntimeDefault,
+    config,
+    runtime_default_validator,
+    skip_none_validator,
+)
 from vllm.logger import init_logger
 from vllm.utils.hashing import safe_hash
 from vllm.utils.import_utils import resolve_obj_by_qualname
@@ -119,7 +123,7 @@ class SchedulerConfig:
     the default scheduler. Can be a class directly or the path to a class of
     form "mod.custom_class"."""
 
-    disable_hybrid_kv_cache_manager: bool | None = None
+    disable_hybrid_kv_cache_manager: bool = RuntimeDefault()
     """If set to True, KV cache manager will allocate the same size of KV cache
     for all attention layers even if there are multiple type of attention layers
     like full attention and sliding window attention.
@@ -145,7 +149,7 @@ class SchedulerConfig:
     once every N engine steps, aligned across DP ranks, to better balance
     per-step forward-pass times."""
 
-    async_scheduling: bool | None = None
+    async_scheduling: bool = RuntimeDefault()
     """If set to False, disable async scheduling. Async scheduling helps to
     avoid gaps in GPU utilization, leading to better latency and throughput.
     """
@@ -218,11 +222,10 @@ class SchedulerConfig:
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str
 
-    @field_validator("scheduler_cls", "async_scheduling", mode="wrap")
-    @classmethod
-    def _skip_none_validation(cls, value: Any, handler: Callable) -> Any:
-        """Skip validation if the value is `None` when initialisation is delayed."""
-        return None if value is None else handler(value)
+    _skip_none_scheduler_cls = skip_none_validator("scheduler_cls")
+    _accept_unresolved = runtime_default_validator(
+        "async_scheduling", "disable_hybrid_kv_cache_manager"
+    )
 
     def __post_init__(self, max_model_len: int, is_encoder_decoder: bool) -> None:
         if is_encoder_decoder:

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -14,7 +14,7 @@ from vllm.config.cache import CacheDType
 from vllm.config.kernel import MoEBackend
 from vllm.config.model import HfOverrides, ModelConfig
 from vllm.config.parallel import ParallelConfig
-from vllm.config.utils import config
+from vllm.config.utils import RuntimeDefault, config, is_runtime_default
 from vllm.logger import init_logger
 from vllm.transformers_utils.config import get_hf_text_config
 from vllm.utils.hashing import safe_hash
@@ -85,13 +85,13 @@ class SpeculativeConfig:
     enforce_eager: bool | None = None
     """Override the default enforce_eager from model_config"""
     # General speculative decoding control
-    num_speculative_tokens: int = Field(default=None, gt=0)  # type: ignore[assignment]
+    num_speculative_tokens: int = RuntimeDefault(gt=0)
     """The number of speculative tokens, if provided. It will default to the
     number in the draft model config if present, otherwise, it is required."""
     model: str | None = None
     """The name of the draft model, eagle head, or additional weights, if
     provided."""
-    method: SpeculativeMethod | None = None
+    method: SpeculativeMethod = RuntimeDefault()
     """The name of the speculative method to use. If users provide and set the
     `model` param, the speculative method type will be detected automatically
     if possible, if `model` param is not provided, the method name must be
@@ -673,11 +673,11 @@ class SpeculativeConfig:
         # default.
 
         # infer method from user args
-        if self.method is None and SpeculativeConfig._is_custom_proposer_path(
-            self.model
-        ):
+        if is_runtime_default(
+            self.method
+        ) and SpeculativeConfig._is_custom_proposer_path(self.model):
             self.method = "custom_class"
-        elif self.method is None:
+        elif is_runtime_default(self.method):
             if self.model in ("ngram", "[ngram]"):
                 self.method = "ngram"
             else:
@@ -689,7 +689,7 @@ class SpeculativeConfig:
             )
             self.method = "mtp"
 
-        if self.model is None and self.num_speculative_tokens is not None:
+        if self.model is None and not is_runtime_default(self.num_speculative_tokens):
             if self.method == "mtp":
                 if self.target_model_config is None:
                     raise ValueError("target_model_config must be present for mtp")
@@ -963,7 +963,7 @@ class SpeculativeConfig:
                 if self.method in ("dflash", "dspark"):
                     self.parallel_drafting = True
 
-                if self.num_speculative_tokens is not None and hasattr(
+                if not is_runtime_default(self.num_speculative_tokens) and hasattr(
                     self.draft_model_config.hf_config, "num_lookahead_tokens"
                 ):
                     self.draft_model_config.hf_config.num_lookahead_tokens = (
@@ -974,7 +974,7 @@ class SpeculativeConfig:
                     self.draft_model_config.hf_config, "n_predict", None
                 )
                 if n_predict is not None:
-                    if self.num_speculative_tokens is None:
+                    if is_runtime_default(self.num_speculative_tokens):
                         # Default to max value defined in draft model config.
                         self.num_speculative_tokens = n_predict
                     elif (
@@ -987,7 +987,7 @@ class SpeculativeConfig:
                             f" must be divisible by {n_predict=}"
                         )
 
-                if self.num_speculative_tokens is None:
+                if is_runtime_default(self.num_speculative_tokens):
                     raise ValueError(
                         "A speculative model was provided, but "
                         "`num_speculative_tokens` was not provided"
@@ -1055,7 +1055,7 @@ class SpeculativeConfig:
                 "Arctic Inference is required for suffix decoding. "
                 "Install via `pip install arctic-inference==0.1.1`."
             )
-        if self.num_speculative_tokens is None:
+        if is_runtime_default(self.num_speculative_tokens):
             # Suffix decoding decides the actual number of speculative tokens
             # dynamically and treats num_speculative_tokens as a maximum limit.
             self.num_speculative_tokens = self.suffix_decoding_max_tree_depth
@@ -1221,7 +1221,7 @@ class SpeculativeConfig:
                 "speculative_config. Please pass 'draft_tensor_parallel_size' instead."
             )
 
-        if self.num_speculative_tokens is None:
+        if is_runtime_default(self.num_speculative_tokens):
             raise ValueError(
                 "num_speculative_tokens must be provided with "
                 "speculative model unless the draft model config contains an "

--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -78,7 +78,9 @@ def config(
         merged_config.update(config)
 
     def decorator(cls: type[ConfigT]) -> type[ConfigT]:
-        return dataclass(cls, config=merged_config, **kwargs)  # type: ignore[return-value]
+        processed = dataclass(cls, config=merged_config, **kwargs)  # type: ignore[return-value]
+        _inject_deferred_methods(processed)
+        return processed  # type: ignore[return-value]
 
     # Called with arguments: @config(config=...)
     if cls is None:
@@ -507,19 +509,38 @@ def set_from_deprecated_env_if_set(
 # Deferred field initialization
 #
 # Fields whose values cannot be determined at dataclass construction time
-# (they depend on being resolved at runtime in VllmConfig.__post_init__)
-# are declared as:
+# are declared using one of three forms:
+#
+#     field_name: bool = Deferred()
+#         # No fallback — must be set by the caller (e.g. optimization-level
+#         # table).  Validation raises if still unset after __post_init__.
 #
 #     field_name: bool = Deferred(False)
-#     field_name: bool = Deferred(lambda cfg: cfg.parallel_config.tp > 1)
+#         # Static fallback — resolved to False if not set by the caller.
 #
-# Deferred(factory) sets the field's pydantic default to a _DeferredValue
-# instance that carries the factory.  The sentinel is falsy so that
-# __post_init__ guards like ``if self.fuse_norm_quant:`` do not fire before
-# initialization.  VllmConfig calls initialize_deferred_fields() to replace
-# every _DeferredValue with its resolved value, and
-# validate_deferred_fields_initialized() (auto-discovered at the end of
-# VllmConfig.__post_init__) asserts that no sentinels remain.
+#     field_name: bool = Deferred(lambda cfg: cfg.parallel_config.tp > 1)
+#         # Computed fallback — factory is called with the VllmConfig instance
+#         # if the field has not been set by the caller.
+#
+# Mechanism:
+#   Deferred(...) returns a pydantic Field whose default is a _DeferredValue
+#   sentinel (validate_default=False skips type coercion of the sentinel).
+#   _DeferredValue is falsy, so __post_init__ guards that read deferred fields
+#   before initialization behave as if the value were falsy/None.
+#
+#   The @config decorator calls _inject_deferred_methods() after pydantic
+#   processes each class.  If the class declares any Deferred() field, two
+#   methods are attached directly to the class:
+#     • initialize_deferred_fields(vllm_config)  — replaces every
+#       _DeferredValue still present with its resolved value (static or
+#       factory-computed).  Fields already set by the caller are left alone.
+#     • validate_deferred_fields_initialized()   — raises ValueError listing
+#       any field that still holds a _DeferredValue sentinel.
+#
+#   VllmConfig.__post_init__ calls these methods on itself and on every
+#   sub-config attribute that satisfies the HasDeferredFields protocol
+#   (detected via isinstance checks).  validate_deferred_fields_initialized()
+#   is always called last to assert no sentinels remain.
 # ---------------------------------------------------------------------------
 
 
@@ -585,7 +606,7 @@ def Deferred(factory: "Callable[[Any], Any] | Any" = MISSING) -> Any:
     Example::
 
         @config
-        class MyConfig(DeferredFieldsMixin):
+        class MyConfig:
             required_flag: bool = Deferred()  # must be set by table/user
             fallback_flag: bool = Deferred(False)  # falls back to False
             tp_flag: bool = Deferred(lambda cfg: cfg.parallel_config.tp > 1)
@@ -596,53 +617,73 @@ def Deferred(factory: "Callable[[Any], Any] | Any" = MISSING) -> Any:
     )
 
 
-class DeferredFieldsMixin:
-    """Mixin for config classes that contain Deferred fields.
+@runtime_checkable
+class HasDeferredFields(Protocol):
+    """Structural interface satisfied by any ``@config`` class that declares at
+    least one ``Deferred()`` field.
 
-    Provides initialize_deferred_fields() and validate_deferred_fields_initialized().
-    VllmConfig.__post_init__ is responsible for calling both at the appropriate
-    points (see vllm/config/vllm.py).
-
-    Usage::
-
-        @config
-        class PassConfig(DeferredFieldsMixin):
-            fuse_norm_quant: bool = Deferred(False)
+    The ``@config`` decorator injects ``initialize_deferred_fields`` and
+    ``validate_deferred_fields_initialized`` automatically — no inheritance is
+    required.  ``VllmConfig.__post_init__`` uses ``isinstance(v, HasDeferredFields)``
+    to discover sub-configs that need initialization.
     """
 
-    def initialize_deferred_fields(self, vllm_config: Any) -> None:
-        """Replace every field still holding a _DeferredValue with its value.
+    def initialize_deferred_fields(self, vllm_config: Any) -> None: ...
+    def validate_deferred_fields_initialized(self) -> None: ...
 
-        Fields explicitly set by the caller (e.g. the optimization-level table)
-        are left unchanged; only sentinel-valued fields are touched.
 
-        Uses ``dataclasses.fields()`` for discovery so that the mechanism works
-        regardless of which pydantic internals (``__pydantic_fields__``,
-        ``FieldInfo.metadata``) are available.
+def _impl_initialize_deferred_fields(self: Any, vllm_config: Any) -> None:
+    """Injected as ``initialize_deferred_fields`` by the ``@config`` decorator.
 
-        Args:
-            vllm_config: The VllmConfig instance passed to factory callables.
-        """
-        for dc_field in fields(self):  # type: ignore[arg-type]
-            current = getattr(self, dc_field.name)
-            if isinstance(current, _DeferredValue) and current.factory is not MISSING:
-                factory = current.factory
-                value = factory(vllm_config) if callable(factory) else factory
-                setattr(self, dc_field.name, value)
+    Replaces every field still holding a ``_DeferredValue`` with its resolved
+    value.  Fields explicitly set by the caller (e.g. the optimization-level
+    table) are left unchanged; only sentinel-valued fields are touched.
+    """
+    for dc_field in fields(self):  # type: ignore[arg-type]
+        current = getattr(self, dc_field.name)
+        if isinstance(current, _DeferredValue) and current.factory is not MISSING:
+            factory = current.factory
+            value = factory(vllm_config) if callable(factory) else factory
+            setattr(self, dc_field.name, value)
 
-    def validate_deferred_fields_initialized(self) -> None:
-        """Assert that no field still holds a _DeferredValue.
 
-        Called automatically by VllmConfig.__post_init__ via auto-discovery.
-        Raises ValueError listing every offending field name.
-        """
-        uninitialized = [
-            dc_field.name
-            for dc_field in fields(self)  # type: ignore[arg-type]
-            if isinstance(getattr(self, dc_field.name), _DeferredValue)
-        ]
-        if uninitialized:
-            raise ValueError(
-                f"{type(self).__name__}: deferred fields were never initialized: "
-                f"{uninitialized}. This is a bug in VllmConfig initialization."
-            )
+def _impl_validate_deferred_fields_initialized(self: Any) -> None:
+    """Injected as ``validate_deferred_fields_initialized`` by ``@config``.
+
+    Asserts that no field still holds a ``_DeferredValue``.  Called
+    automatically by ``VllmConfig.__post_init__`` via auto-discovery.
+    Raises ``ValueError`` listing every offending field name.
+    """
+    uninitialized = [
+        dc_field.name
+        for dc_field in fields(self)  # type: ignore[arg-type]
+        if isinstance(getattr(self, dc_field.name), _DeferredValue)
+    ]
+    if uninitialized:
+        raise ValueError(
+            f"{type(self).__name__}: deferred fields were never initialized: "
+            f"{uninitialized}. This is a bug in VllmConfig initialization."
+        )
+
+
+def _inject_deferred_methods(cls: type) -> None:
+    """Attach deferred-field methods to *cls* if it declares any ``Deferred()`` fields.
+
+    Called by the ``@config`` decorator after pydantic has finished processing
+    the class.  Uses ``dataclasses.fields()`` + ``PydanticFieldInfo.default``
+    for detection so that it works regardless of pydantic-internal changes.
+    """
+    if not is_dataclass(cls):
+        return
+    has_deferred = any(
+        isinstance(f.default, PydanticFieldInfo)
+        and isinstance(f.default.default, _DeferredValue)
+        for f in fields(cls)  # type: ignore[arg-type]
+    )
+    if has_deferred:
+        cls.initialize_deferred_fields = (  # type: ignore[attr-defined]
+            _impl_initialize_deferred_fields
+        )
+        cls.validate_deferred_fields_initialized = (  # type: ignore[attr-defined]
+            _impl_validate_deferred_fields_initialized
+        )

--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -13,7 +13,17 @@ import textwrap
 from collections.abc import Callable, Mapping, Sequence, Set
 from dataclasses import MISSING, field, fields, is_dataclass
 from itertools import pairwise
-from typing import TYPE_CHECKING, Any, Protocol, TypeVar, cast, overload
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    Protocol,
+    TypeVar,
+    cast,
+    get_args,
+    get_origin,
+    overload,
+)
 
 import torch
 from pydantic import ConfigDict
@@ -485,3 +495,136 @@ def set_from_deprecated_env_if_set(
         elif to_int:
             field_value = int(env_value)
         setattr(config, field_name, field_value)
+
+
+# Deferred field initialization support
+# This pattern is used for configuration fields that cannot be determined statically
+# but are always set during VllmConfig initialization.
+
+
+class _DeferredMarker:
+    """Marker for deferred initialization.
+
+    This class is used as metadata in Annotated types to mark fields
+    that will be initialized later during VllmConfig post-initialization.
+
+    Example:
+        field_name: Annotated[bool, Deferred(enable_norm_fusion)] = None
+
+    Attributes:
+        factory: Either a static value or a callable that takes VllmConfig
+                 and returns the field value.
+    """
+
+    def __init__(self, factory: Callable[[Any], Any] | Any):
+        self.factory = factory
+
+    def __repr__(self) -> str:
+        factory_name = getattr(self.factory, "__name__", repr(self.factory))
+        return f"Deferred({factory_name})"
+
+
+def Deferred(factory: Callable[[Any], Any] | Any) -> Any:
+    """Mark a field for deferred initialization.
+
+    Use this in Annotated type hints to indicate that a field's value
+    will be determined during VllmConfig initialization rather than at
+    config class instantiation.
+
+    Args:
+        factory: Either:
+            - A static value (e.g., False, True, 0)
+            - A callable that takes VllmConfig and returns the value
+              (e.g., enable_norm_fusion, lambda cfg: cfg.parallel_config.tp > 1)
+
+    Returns:
+        _DeferredMarker instance for use in Annotated type hints
+
+    Example:
+        @config
+        class MyConfig(DeferredFieldsMixin):
+            # Static default
+            simple_field: Annotated[bool, Deferred(False)] = None
+
+            # Dynamic default based on VllmConfig
+            complex_field: Annotated[bool, Deferred(enable_norm_fusion)] = None
+    """
+    return _DeferredMarker(factory)
+
+
+def get_deferred_factory(field_type: Any) -> _DeferredMarker | None:
+    """Extract _DeferredMarker from an Annotated type.
+
+    Args:
+        field_type: The type annotation to inspect
+
+    Returns:
+        _DeferredMarker if found, None otherwise
+    """
+    if get_origin(field_type) is Annotated:
+        for metadata in get_args(field_type)[1:]:
+            if isinstance(metadata, _DeferredMarker):
+                return metadata
+    return None
+
+
+class DeferredFieldsMixin:
+    """Mixin to handle deferred field initialization.
+
+    Add this mixin to any config class that has fields marked with
+    Annotated[T, Deferred(factory)]. The mixin provides methods to
+    initialize and validate deferred fields.
+
+    Example:
+        @config
+        class PassConfig(DeferredFieldsMixin):
+            fuse_norm_quant: Annotated[bool, Deferred(enable_norm_fusion)] = None
+
+            def __post_init__(self) -> None:
+                # Existing validation logic
+                pass
+
+    The VllmConfig.__post_init__() method should call:
+        config.initialize_deferred_fields(self)
+        config.validate_deferred_fields_initialized()
+    """
+
+    def initialize_deferred_fields(self, vllm_config: Any) -> None:
+        """Initialize all deferred fields in this config.
+
+        This method should be called from VllmConfig.__post_init__() after
+        the config object is created but before it's used.
+
+        Args:
+            vllm_config: The VllmConfig instance to use for initialization
+        """
+        for field_info in fields(self):  # type: ignore[arg-type]
+            marker = get_deferred_factory(field_info.type)
+            if marker is not None:
+                current_value = getattr(self, field_info.name)
+                # Only initialize if not already set by user
+                if current_value is None:
+                    factory = marker.factory
+                    value = factory(vllm_config) if callable(factory) else factory
+                    setattr(self, field_info.name, value)
+
+    def validate_deferred_fields_initialized(self) -> None:
+        """Validate that all deferred fields have been initialized.
+
+        This should be called after initialize_deferred_fields() to ensure
+        all deferred fields were properly set.
+
+        Raises:
+            ValueError: If any deferred fields are still None
+        """
+        uninitialized = []
+        for field_info in fields(self):  # type: ignore[arg-type]
+            marker = get_deferred_factory(field_info.type)
+            if marker is not None and getattr(self, field_info.name) is None:
+                uninitialized.append(field_info.name)
+
+        if uninitialized:
+            raise ValueError(
+                f"{self.__class__.__name__}: Deferred fields not initialized: "
+                f"{uninitialized}. This is a bug in VllmConfig initialization."
+            )

--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -524,9 +524,9 @@ def set_from_deprecated_env_if_set(
 
 
 class _DeferredValue:
-    """Per-field sentinel that doubles as a factory carrier.
+    """Per-field sentinel that doubles as an optional factory carrier.
 
-    Each ``Deferred(factory)`` call produces one ``_DeferredValue`` instance
+    Each ``Deferred(...)`` call produces one ``_DeferredValue`` instance
     that becomes the pydantic default for that field.  Embedding the factory
     in the default value means:
 
@@ -536,36 +536,58 @@ class _DeferredValue:
     * ``__bool__`` returns ``False`` so guards in ``__post_init__`` that read
       deferred fields before initialization treat them as falsy, matching the
       behaviour of the old ``None`` sentinel.
+    * When no factory is provided (``MISSING``), the field has no fallback and
+      must be set by the user or the optimization-level table; validation will
+      fail if it remains unset.
     """
 
-    def __init__(self, factory: "Callable[[Any], Any] | Any") -> None:
+    def __init__(self, factory: "Callable[[Any], Any] | Any" = MISSING) -> None:
         self.factory = factory
 
     def __bool__(self) -> bool:
         return False
 
+    def __copy__(self) -> "_DeferredValue":
+        return self
+
+    def __deepcopy__(self, memo: dict) -> "_DeferredValue":
+        # _DeferredValue is a sentinel whose identity matters.  Pydantic
+        # deepcopies mutable defaults when creating each model instance;
+        # returning self preserves factory identity so that ``is MISSING``
+        # checks and __repr__ work correctly on every instance.
+        return self
+
     def __repr__(self) -> str:
+        if self.factory is MISSING:
+            return "<Deferred()>"
         factory_name = getattr(self.factory, "__name__", repr(self.factory))
         return f"<Deferred({factory_name})>"
 
 
-def Deferred(factory: "Callable[[Any], Any] | Any") -> Any:
+def Deferred(factory: "Callable[[Any], Any] | Any" = MISSING) -> Any:
     """Declare a config field whose value is resolved in VllmConfig.__post_init__.
 
-    Returns a pydantic Field whose default is a ``_DeferredValue`` instance
-    carrying the factory.  The declared annotation is the true runtime type —
-    no ``| None`` needed.  ``validate_default=False`` tells pydantic to skip
-    coercion of the sentinel through the field's type validator.
+    Returns a pydantic Field whose default is a ``_DeferredValue`` instance.
+    The declared annotation is the true runtime type — no ``| None`` needed.
+    ``validate_default=False`` tells pydantic to skip coercion of the sentinel
+    through the field's type validator.
+
+    When called with no argument, the field has no fallback: it must be set by
+    the user or the optimization-level table, or validation will raise.  Pass a
+    factory only when a last-resort fallback is genuinely needed (e.g. for
+    fields absent from the optimization-level tables).
 
     Args:
-        factory: Either a static fallback value (e.g. False) or a callable
+        factory: Optional static fallback value (e.g. ``False``) or a callable
                  that accepts a VllmConfig instance and returns the value.
+                 Omit to require the field to be set externally.
 
     Example::
 
         @config
         class MyConfig(DeferredFieldsMixin):
-            simple_flag: bool = Deferred(False)
+            required_flag: bool = Deferred()  # must be set by table/user
+            fallback_flag: bool = Deferred(False)  # falls back to False
             tp_flag: bool = Deferred(lambda cfg: cfg.parallel_config.tp > 1)
     """
     return PydanticField(  # type: ignore[call-overload]
@@ -603,7 +625,7 @@ class DeferredFieldsMixin:
         """
         for dc_field in fields(self):  # type: ignore[arg-type]
             current = getattr(self, dc_field.name)
-            if isinstance(current, _DeferredValue):
+            if isinstance(current, _DeferredValue) and current.factory is not MISSING:
                 factory = current.factory
                 value = factory(vllm_config) if callable(factory) else factory
                 setattr(self, dc_field.name, value)

--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -23,7 +23,7 @@ from typing import (
 )
 
 import torch
-from pydantic import ConfigDict
+from pydantic import ConfigDict, field_validator
 from pydantic.dataclasses import dataclass
 from pydantic.fields import Field as PydanticField
 from pydantic.fields import FieldInfo as PydanticFieldInfo
@@ -267,7 +267,7 @@ def normalize_value(x):
 
     # RuntimeDefault sentinel: a field was never initialized before compute_hash()
     # was called.  This is always a bug — surface it clearly.
-    if isinstance(x, _RuntimeDefaultValue):
+    if is_runtime_default(x):
         raise TypeError(
             f"normalize_value: encountered uninitialized runtime default field "
             f"({x!r}).  This field must be resolved (e.g. by VllmConfig."
@@ -532,7 +532,19 @@ class _RuntimeDefaultValue:
         return "<RuntimeDefault()>"
 
 
-def RuntimeDefault() -> Any:
+# Shared sentinel instance. `__copy__`/`__deepcopy__` already return `self`,
+# so reusing one instance everywhere (the `RuntimeDefault()` default and
+# every validator that re-mints an "unresolved" value) keeps identity stable
+# and avoids pointless allocation.
+RUNTIME_DEFAULT = _RuntimeDefaultValue()
+
+
+def is_runtime_default(value: Any) -> bool:
+    """True if a `RuntimeDefault()` field has not been resolved yet."""
+    return isinstance(value, _RuntimeDefaultValue)
+
+
+def RuntimeDefault(**kwargs: Any) -> Any:
     """Declare a config field whose value must be resolved before the end of
     VllmConfig.__post_init__.
 
@@ -540,6 +552,10 @@ def RuntimeDefault() -> Any:
     instance. The declared annotation is the true runtime type, no ``| None``
     needed. `validate_default=False` tells pydantic to skip coercion of the
     sentinel through the field's type validator.
+
+    Extra `kwargs` (e.g. `gt=0`) are forwarded to the underlying
+    `pydantic.Field`, and still apply to any real value assigned to the
+    field; only the sentinel default itself is exempt from them.
 
     The ``@config`` decorator attaches `validate_runtime_default_fields_initialized()`
     to any class declaring a `RuntimeDefault()` field. `VllmConfig.__post_init__`
@@ -554,9 +570,37 @@ def RuntimeDefault() -> Any:
             required_flag: bool = RuntimeDefault()  # set before __post_init__ ends
     """
     return PydanticField(  # type: ignore[call-overload]
-        default=_RuntimeDefaultValue(),
+        default=RUNTIME_DEFAULT,
         validate_default=False,
+        **kwargs,
     )
+
+
+def runtime_default_validator(*fields: str) -> Any:
+    """Field validator that treats `None` and an already unresolved sentinel as
+    "not set yet" and therefore bypassing the field's type/constraint checks.
+    Needed when a `RuntimeDefault()` field can be passed explicitly (e.g. forwarded
+    from an `EngineArgs` default) rather than omitted."""
+
+    def _accept_unresolved(cls, value: Any, handler: Callable) -> Any:
+        if value is None or isinstance(value, _RuntimeDefaultValue):
+            return RUNTIME_DEFAULT
+        return handler(value)
+
+    return field_validator(*fields, mode="wrap")(classmethod(_accept_unresolved))
+
+
+def skip_none_validator(*fields: str) -> Any:
+    """Field validator that passes `None` through unchanged, bypassing the
+    field's type/constraint checks. For fields whose "unset" contract is
+    `None` itself, not the `RuntimeDefault()` sentinel."""
+
+    def _skip_none(cls, value: Any, handler: Callable) -> Any:
+        if value is None:
+            return value
+        return handler(value)
+
+    return field_validator(*fields, mode="wrap")(classmethod(_skip_none))
 
 
 @runtime_checkable
@@ -583,7 +627,7 @@ def _impl_validate_runtime_default_fields_initialized(self: Any) -> None:
     uninitialized = [
         dc_field.name
         for dc_field in fields(self)  # type: ignore[arg-type]
-        if isinstance(getattr(self, dc_field.name), _RuntimeDefaultValue)
+        if is_runtime_default(getattr(self, dc_field.name))
     ]
     if uninitialized:
         raise ValueError(
@@ -622,7 +666,7 @@ def _inject_runtime_default_methods(cls: type) -> None:
         return
     has_runtime_default = any(
         isinstance(f.default, PydanticFieldInfo)
-        and isinstance(f.default.default, _RuntimeDefaultValue)
+        and is_runtime_default(f.default.default)
         for f in fields(cls)  # type: ignore[arg-type]
     )
     if has_runtime_default:

--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -79,7 +79,7 @@ def config(
 
     def decorator(cls: type[ConfigT]) -> type[ConfigT]:
         processed = dataclass(cls, config=merged_config, **kwargs)  # type: ignore[return-value]
-        _inject_deferred_methods(processed)
+        _inject_runtime_default_methods(processed)
         return processed  # type: ignore[return-value]
 
     # Called with arguments: @config(config=...)
@@ -265,12 +265,12 @@ def normalize_value(x):
     if x is None or isinstance(x, (bool, int, float, str)):
         return x
 
-    # Deferred sentinel: a field was never initialized before compute_hash()
+    # RuntimeDefault sentinel: a field was never initialized before compute_hash()
     # was called.  This is always a bug — surface it clearly.
-    if isinstance(x, _DeferredValue):
+    if isinstance(x, _RuntimeDefaultValue):
         raise TypeError(
-            f"normalize_value: encountered uninitialized deferred field "
-            f"({x!r}).  Call initialize_deferred_fields() on the containing "
+            f"normalize_value: encountered uninitialized runtime default field "
+            f"({x!r}).  Call initialize_runtime_default_fields() on the containing "
             "config before computing hashes."
         )
 
@@ -506,56 +506,56 @@ def set_from_deprecated_env_if_set(
 
 
 # ---------------------------------------------------------------------------
-# Deferred field initialization
+# RuntimeDefault field initialization
 #
 # Fields whose values cannot be determined at dataclass construction time
 # are declared using one of three forms:
 #
-#     field_name: bool = Deferred()
+#     field_name: bool = RuntimeDefault()
 #         # No fallback — must be set by the caller (e.g. optimization-level
 #         # table).  Validation raises if still unset after __post_init__.
 #
-#     field_name: bool = Deferred(False)
+#     field_name: bool = RuntimeDefault(False)
 #         # Static fallback — resolved to False if not set by the caller.
 #
-#     field_name: bool = Deferred(lambda cfg: cfg.parallel_config.tp > 1)
+#     field_name: bool = RuntimeDefault(lambda cfg: cfg.parallel_config.tp > 1)
 #         # Computed fallback — factory is called with the VllmConfig instance
 #         # if the field has not been set by the caller.
 #
 # Mechanism:
-#   Deferred(...) returns a pydantic Field whose default is a _DeferredValue
+#   RuntimeDefault(...) returns a pydantic Field whose default is a _RuntimeDefaultValue
 #   sentinel (validate_default=False skips type coercion of the sentinel).
-#   _DeferredValue is falsy, so __post_init__ guards that read deferred fields
-#   before initialization behave as if the value were falsy/None.
+#   _RuntimeDefaultValue is falsy, so __post_init__ guards that read runtime default
+#   fields before initialization behave as if the value were falsy/None.
 #
-#   The @config decorator calls _inject_deferred_methods() after pydantic
-#   processes each class.  If the class declares any Deferred() field, two
+#   The @config decorator calls _inject_runtime_default_methods() after pydantic
+#   processes each class.  If the class declares any RuntimeDefault() field, two
 #   methods are attached directly to the class:
-#     • initialize_deferred_fields(vllm_config)  — replaces every
-#       _DeferredValue still present with its resolved value (static or
+#     • initialize_runtime_default_fields(vllm_config)  — replaces every
+#       _RuntimeDefaultValue still present with its resolved value (static or
 #       factory-computed).  Fields already set by the caller are left alone.
-#     • validate_deferred_fields_initialized()   — raises ValueError listing
-#       any field that still holds a _DeferredValue sentinel.
+#     • validate_runtime_default_fields_initialized()   — raises ValueError listing
+#       any field that still holds a _RuntimeDefaultValue sentinel.
 #
 #   VllmConfig.__post_init__ calls these methods on itself and on every
-#   sub-config attribute that satisfies the HasDeferredFields protocol
-#   (detected via isinstance checks).  validate_deferred_fields_initialized()
+#   sub-config attribute that satisfies the HasRuntimeDefaultFields protocol
+#   (detected via isinstance checks).  validate_runtime_default_fields_initialized()
 #   is always called last to assert no sentinels remain.
 # ---------------------------------------------------------------------------
 
 
-class _DeferredValue:
+class _RuntimeDefaultValue:
     """Per-field sentinel that doubles as an optional factory carrier.
 
-    Each ``Deferred(...)`` call produces one ``_DeferredValue`` instance
+    Each ``RuntimeDefault(...)`` call produces one ``_RuntimeDefaultValue`` instance
     that becomes the pydantic default for that field.  Embedding the factory
     in the default value means:
 
-    * Detection uses only ``isinstance(value, _DeferredValue)`` on the live
+    * Detection uses only ``isinstance(value, _RuntimeDefaultValue)`` on the live
       field value — no dependency on ``FieldInfo.metadata`` or pydantic
       internals.
     * ``__bool__`` returns ``False`` so guards in ``__post_init__`` that read
-      deferred fields before initialization treat them as falsy, matching the
+      runtime default fields before initialization treat them as falsy, matching the
       behaviour of the old ``None`` sentinel.
     * When no factory is provided (``MISSING``), the field has no fallback and
       must be set by the user or the optimization-level table; validation will
@@ -568,11 +568,11 @@ class _DeferredValue:
     def __bool__(self) -> bool:
         return False
 
-    def __copy__(self) -> "_DeferredValue":
+    def __copy__(self) -> "_RuntimeDefaultValue":
         return self
 
-    def __deepcopy__(self, memo: dict) -> "_DeferredValue":
-        # _DeferredValue is a sentinel whose identity matters.  Pydantic
+    def __deepcopy__(self, memo: dict) -> "_RuntimeDefaultValue":
+        # _RuntimeDefaultValue is a sentinel whose identity matters.  Pydantic
         # deepcopies mutable defaults when creating each model instance;
         # returning self preserves factory identity so that ``is MISSING``
         # checks and __repr__ work correctly on every instance.
@@ -580,15 +580,15 @@ class _DeferredValue:
 
     def __repr__(self) -> str:
         if self.factory is MISSING:
-            return "<Deferred()>"
+            return "<RuntimeDefault()>"
         factory_name = getattr(self.factory, "__name__", repr(self.factory))
-        return f"<Deferred({factory_name})>"
+        return f"<RuntimeDefault({factory_name})>"
 
 
-def Deferred(factory: "Callable[[Any], Any] | Any" = MISSING) -> Any:
+def RuntimeDefault(factory: "Callable[[Any], Any] | Any" = MISSING) -> Any:
     """Declare a config field whose value is resolved in VllmConfig.__post_init__.
 
-    Returns a pydantic Field whose default is a ``_DeferredValue`` instance.
+    Returns a pydantic Field whose default is a ``_RuntimeDefaultValue`` instance.
     The declared annotation is the true runtime type — no ``| None`` needed.
     ``validate_default=False`` tells pydantic to skip coercion of the sentinel
     through the field's type validator.
@@ -607,91 +607,95 @@ def Deferred(factory: "Callable[[Any], Any] | Any" = MISSING) -> Any:
 
         @config
         class MyConfig:
-            required_flag: bool = Deferred()  # must be set by table/user
-            fallback_flag: bool = Deferred(False)  # falls back to False
-            tp_flag: bool = Deferred(lambda cfg: cfg.parallel_config.tp > 1)
+            required_flag: bool = RuntimeDefault()  # must be set by table/user
+            fallback_flag: bool = RuntimeDefault(False)  # falls back to False
+            tp_flag: bool = RuntimeDefault(lambda cfg: cfg.parallel_config.tp > 1)
     """
     return PydanticField(  # type: ignore[call-overload]
-        default=_DeferredValue(factory),
+        default=_RuntimeDefaultValue(factory),
         validate_default=False,
     )
 
 
 @runtime_checkable
-class HasDeferredFields(Protocol):
+class HasRuntimeDefaultFields(Protocol):
     """Structural interface satisfied by any ``@config`` class that declares at
-    least one ``Deferred()`` field.
+    least one ``RuntimeDefault()`` field.
 
-    The ``@config`` decorator injects ``initialize_deferred_fields`` and
-    ``validate_deferred_fields_initialized`` automatically — no inheritance is
-    required.  ``VllmConfig.__post_init__`` uses ``isinstance(v, HasDeferredFields)``
-    to discover sub-configs that need initialization.
+    The ``@config`` decorator injects ``initialize_runtime_default_fields`` and
+    ``validate_runtime_default_fields_initialized`` automatically — no inheritance is
+    required.  ``VllmConfig.__post_init__`` uses
+    ``isinstance(v, HasRuntimeDefaultFields)`` to discover sub-configs that need
+    initialization.
     """
 
-    def initialize_deferred_fields(self, vllm_config: Any) -> None: ...
-    def validate_deferred_fields_initialized(self) -> None: ...
+    def initialize_runtime_default_fields(self, vllm_config: Any) -> None: ...
+    def validate_runtime_default_fields_initialized(self) -> None: ...
 
 
-def _impl_initialize_deferred_fields(self: Any, vllm_config: Any) -> None:
-    """Injected as ``initialize_deferred_fields`` by the ``@config`` decorator.
+def _impl_initialize_runtime_default_fields(self: Any, vllm_config: Any) -> None:
+    """Injected as ``initialize_runtime_default_fields`` by the ``@config`` decorator.
 
-    Replaces every field still holding a ``_DeferredValue`` with its resolved
+    Replaces every field still holding a ``_RuntimeDefaultValue`` with its resolved
     value.  Fields explicitly set by the caller (e.g. the optimization-level
     table) are left unchanged; only sentinel-valued fields are touched.
     """
     for dc_field in fields(self):  # type: ignore[arg-type]
         current = getattr(self, dc_field.name)
-        if isinstance(current, _DeferredValue) and current.factory is not MISSING:
+        if isinstance(current, _RuntimeDefaultValue) and current.factory is not MISSING:
             factory = current.factory
             value = factory(vllm_config) if callable(factory) else factory
             setattr(self, dc_field.name, value)
 
 
-def _impl_validate_deferred_fields_initialized(self: Any) -> None:
-    """Injected as ``validate_deferred_fields_initialized`` by ``@config``.
+def _impl_validate_runtime_default_fields_initialized(self: Any) -> None:
+    """Injected as ``validate_runtime_default_fields_initialized`` by ``@config``.
 
-    Asserts that no field still holds a ``_DeferredValue``.  Called
+    Asserts that no field still holds a ``RuntimeDefaultValue``.  Called
     automatically by ``VllmConfig.__post_init__`` via auto-discovery.
     Raises ``ValueError`` listing every offending field name.
     """
     uninitialized = [
         dc_field.name
         for dc_field in fields(self)  # type: ignore[arg-type]
-        if isinstance(getattr(self, dc_field.name), _DeferredValue)
+        if isinstance(getattr(self, dc_field.name), _RuntimeDefaultValue)
     ]
     if uninitialized:
         raise ValueError(
-            f"{type(self).__name__}: deferred fields were never initialized: "
+            f"{type(self).__name__}: runtime default fields were never initialized: "
             f"{uninitialized}. This is a bug in VllmConfig initialization."
         )
 
 
-def _walk_deferred(obj: Any) -> Generator[Any, None, None]:
+def _walk_runtime_default(obj: Any) -> Generator[Any, None, None]:
     """Depth-first generator over *obj* and all nested dataclass children."""
     yield obj
     if is_dataclass(obj):
         for f in fields(obj):  # type: ignore[arg-type]
             child = getattr(obj, f.name)
             if child is not None and child is not obj and is_dataclass(child):
-                yield from _walk_deferred(child)
+                yield from _walk_runtime_default(child)
 
 
-def initialize_deferred_fields_recursive(obj: Any, vllm_config: Any) -> None:
-    """Initialize deferred fields in *obj* and all nested ``@config`` dataclasses."""
-    for node in _walk_deferred(obj):
-        if isinstance(node, HasDeferredFields):
-            node.initialize_deferred_fields(vllm_config)
+def initialize_runtime_default_fields_recursive(obj: Any, vllm_config: Any) -> None:
+    """Initialize runtime default fields in *obj* and all nested ``@config``
+    dataclasses."""
+    for node in _walk_runtime_default(obj):
+        if isinstance(node, HasRuntimeDefaultFields):
+            node.initialize_runtime_default_fields(vllm_config)
 
 
-def validate_deferred_fields_recursive(obj: Any) -> None:
-    """Validate deferred fields in *obj* and all nested ``@config`` dataclasses."""
-    for node in _walk_deferred(obj):
-        if isinstance(node, HasDeferredFields):
-            node.validate_deferred_fields_initialized()
+def validate_runtime_default_fields_recursive(obj: Any) -> None:
+    """Validate runtime default fields in *obj* and all nested ``@config``
+    dataclasses."""
+    for node in _walk_runtime_default(obj):
+        if isinstance(node, HasRuntimeDefaultFields):
+            node.validate_runtime_default_fields_initialized()
 
 
-def _inject_deferred_methods(cls: type) -> None:
-    """Attach deferred-field methods to *cls* if it declares any ``Deferred()`` fields.
+def _inject_runtime_default_methods(cls: type) -> None:
+    """Attach runtime default field methods to *cls* if it declares any
+    ``RuntimeDefault()`` fields.
 
     Called by the ``@config`` decorator after pydantic has finished processing
     the class.  Uses ``dataclasses.fields()`` + ``PydanticFieldInfo.default``
@@ -699,15 +703,15 @@ def _inject_deferred_methods(cls: type) -> None:
     """
     if not is_dataclass(cls):
         return
-    has_deferred = any(
+    has_runtime_default = any(
         isinstance(f.default, PydanticFieldInfo)
-        and isinstance(f.default.default, _DeferredValue)
+        and isinstance(f.default.default, _RuntimeDefaultValue)
         for f in fields(cls)  # type: ignore[arg-type]
     )
-    if has_deferred:
-        cls.initialize_deferred_fields = (  # type: ignore[attr-defined]
-            _impl_initialize_deferred_fields
+    if has_runtime_default:
+        cls.initialize_runtime_default_fields = (  # type: ignore[attr-defined]
+            _impl_initialize_runtime_default_fields
         )
-        cls.validate_deferred_fields_initialized = (  # type: ignore[attr-defined]
-            _impl_validate_deferred_fields_initialized
+        cls.validate_runtime_default_fields_initialized = (  # type: ignore[attr-defined]
+            _impl_validate_runtime_default_fields_initialized
         )

--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -10,7 +10,7 @@ import json
 import os
 import pathlib
 import textwrap
-from collections.abc import Callable, Mapping, Sequence, Set
+from collections.abc import Callable, Generator, Mapping, Sequence, Set
 from dataclasses import MISSING, field, fields, is_dataclass
 from itertools import pairwise
 from typing import (
@@ -664,6 +664,30 @@ def _impl_validate_deferred_fields_initialized(self: Any) -> None:
             f"{type(self).__name__}: deferred fields were never initialized: "
             f"{uninitialized}. This is a bug in VllmConfig initialization."
         )
+
+
+def _walk_deferred(obj: Any) -> Generator[Any, None, None]:
+    """Depth-first generator over *obj* and all nested dataclass children."""
+    yield obj
+    if is_dataclass(obj):
+        for f in fields(obj):  # type: ignore[arg-type]
+            child = getattr(obj, f.name)
+            if child is not None and child is not obj and is_dataclass(child):
+                yield from _walk_deferred(child)
+
+
+def initialize_deferred_fields_recursive(obj: Any, vllm_config: Any) -> None:
+    """Initialize deferred fields in *obj* and all nested ``@config`` dataclasses."""
+    for node in _walk_deferred(obj):
+        if isinstance(node, HasDeferredFields):
+            node.initialize_deferred_fields(vllm_config)
+
+
+def validate_deferred_fields_recursive(obj: Any) -> None:
+    """Validate deferred fields in *obj* and all nested ``@config`` dataclasses."""
+    for node in _walk_deferred(obj):
+        if isinstance(node, HasDeferredFields):
+            node.validate_deferred_fields_initialized()
 
 
 def _inject_deferred_methods(cls: type) -> None:

--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -15,13 +15,10 @@ from dataclasses import MISSING, field, fields, is_dataclass
 from itertools import pairwise
 from typing import (
     TYPE_CHECKING,
-    Annotated,
     Any,
     Protocol,
     TypeVar,
     cast,
-    get_args,
-    get_origin,
     overload,
 )
 
@@ -29,7 +26,7 @@ import torch
 from pydantic import ConfigDict
 from pydantic.dataclasses import dataclass
 from pydantic.fields import Field as PydanticField
-from pydantic.fields import FieldInfo
+from pydantic.fields import FieldInfo as PydanticFieldInfo
 from typing_extensions import dataclass_transform, runtime_checkable
 
 import vllm.envs as envs
@@ -106,7 +103,7 @@ def get_field(cls: ConfigType, name: str) -> Any:
     init = named_field.init
 
     # Handle pydantic.Field
-    if isinstance(default, FieldInfo):
+    if isinstance(default, PydanticFieldInfo):
         if default.init is not None:
             init = default.init
         if default.default_factory is not None:
@@ -265,6 +262,15 @@ def normalize_value(x):
     # Fast path
     if x is None or isinstance(x, (bool, int, float, str)):
         return x
+
+    # Deferred sentinel: a field was never initialized before compute_hash()
+    # was called.  This is always a bug — surface it clearly.
+    if isinstance(x, _DeferredValue):
+        raise TypeError(
+            f"normalize_value: encountered uninitialized deferred field "
+            f"({x!r}).  Call initialize_deferred_fields() on the containing "
+            "config before computing hashes."
+        )
 
     # Enums: tag with FQN to avoid primitive collisions.
     # Ex: Enum(1) vs int(1) -> ("module.QualName", value).
@@ -497,134 +503,124 @@ def set_from_deprecated_env_if_set(
         setattr(config, field_name, field_value)
 
 
-# Deferred field initialization support
-# This pattern is used for configuration fields that cannot be determined statically
-# but are always set during VllmConfig initialization.
+# ---------------------------------------------------------------------------
+# Deferred field initialization
+#
+# Fields whose values cannot be determined at dataclass construction time
+# (they depend on being resolved at runtime in VllmConfig.__post_init__)
+# are declared as:
+#
+#     field_name: bool = Deferred(False)
+#     field_name: bool = Deferred(lambda cfg: cfg.parallel_config.tp > 1)
+#
+# Deferred(factory) sets the field's pydantic default to a _DeferredValue
+# instance that carries the factory.  The sentinel is falsy so that
+# __post_init__ guards like ``if self.fuse_norm_quant:`` do not fire before
+# initialization.  VllmConfig calls initialize_deferred_fields() to replace
+# every _DeferredValue with its resolved value, and
+# validate_deferred_fields_initialized() (auto-discovered at the end of
+# VllmConfig.__post_init__) asserts that no sentinels remain.
+# ---------------------------------------------------------------------------
 
 
-class _DeferredMarker:
-    """Marker for deferred initialization.
+class _DeferredValue:
+    """Per-field sentinel that doubles as a factory carrier.
 
-    This class is used as metadata in Annotated types to mark fields
-    that will be initialized later during VllmConfig post-initialization.
+    Each ``Deferred(factory)`` call produces one ``_DeferredValue`` instance
+    that becomes the pydantic default for that field.  Embedding the factory
+    in the default value means:
 
-    Example:
-        field_name: Annotated[bool, Deferred(enable_norm_fusion)] = None
-
-    Attributes:
-        factory: Either a static value or a callable that takes VllmConfig
-                 and returns the field value.
+    * Detection uses only ``isinstance(value, _DeferredValue)`` on the live
+      field value — no dependency on ``FieldInfo.metadata`` or pydantic
+      internals.
+    * ``__bool__`` returns ``False`` so guards in ``__post_init__`` that read
+      deferred fields before initialization treat them as falsy, matching the
+      behaviour of the old ``None`` sentinel.
     """
 
-    def __init__(self, factory: Callable[[Any], Any] | Any):
+    def __init__(self, factory: "Callable[[Any], Any] | Any") -> None:
         self.factory = factory
+
+    def __bool__(self) -> bool:
+        return False
 
     def __repr__(self) -> str:
         factory_name = getattr(self.factory, "__name__", repr(self.factory))
-        return f"Deferred({factory_name})"
+        return f"<Deferred({factory_name})>"
 
 
-def Deferred(factory: Callable[[Any], Any] | Any) -> Any:
-    """Mark a field for deferred initialization.
+def Deferred(factory: "Callable[[Any], Any] | Any") -> Any:
+    """Declare a config field whose value is resolved in VllmConfig.__post_init__.
 
-    Use this in Annotated type hints to indicate that a field's value
-    will be determined during VllmConfig initialization rather than at
-    config class instantiation.
+    Returns a pydantic Field whose default is a ``_DeferredValue`` instance
+    carrying the factory.  The declared annotation is the true runtime type —
+    no ``| None`` needed.  ``validate_default=False`` tells pydantic to skip
+    coercion of the sentinel through the field's type validator.
 
     Args:
-        factory: Either:
-            - A static value (e.g., False, True, 0)
-            - A callable that takes VllmConfig and returns the value
-              (e.g., enable_norm_fusion, lambda cfg: cfg.parallel_config.tp > 1)
+        factory: Either a static fallback value (e.g. False) or a callable
+                 that accepts a VllmConfig instance and returns the value.
 
-    Returns:
-        _DeferredMarker instance for use in Annotated type hints
+    Example::
 
-    Example:
         @config
         class MyConfig(DeferredFieldsMixin):
-            # Static default
-            simple_field: Annotated[bool, Deferred(False)] = None
-
-            # Dynamic default based on VllmConfig
-            complex_field: Annotated[bool, Deferred(enable_norm_fusion)] = None
+            simple_flag: bool = Deferred(False)
+            tp_flag: bool = Deferred(lambda cfg: cfg.parallel_config.tp > 1)
     """
-    return _DeferredMarker(factory)
-
-
-def get_deferred_factory(field_type: Any) -> _DeferredMarker | None:
-    """Extract _DeferredMarker from an Annotated type.
-
-    Args:
-        field_type: The type annotation to inspect
-
-    Returns:
-        _DeferredMarker if found, None otherwise
-    """
-    if get_origin(field_type) is Annotated:
-        for metadata in get_args(field_type)[1:]:
-            if isinstance(metadata, _DeferredMarker):
-                return metadata
-    return None
+    return PydanticField(  # type: ignore[call-overload]
+        default=_DeferredValue(factory),
+        validate_default=False,
+    )
 
 
 class DeferredFieldsMixin:
-    """Mixin to handle deferred field initialization.
+    """Mixin for config classes that contain Deferred fields.
 
-    Add this mixin to any config class that has fields marked with
-    Annotated[T, Deferred(factory)]. The mixin provides methods to
-    initialize and validate deferred fields.
+    Provides initialize_deferred_fields() and validate_deferred_fields_initialized().
+    VllmConfig.__post_init__ is responsible for calling both at the appropriate
+    points (see vllm/config/vllm.py).
 
-    Example:
+    Usage::
+
         @config
         class PassConfig(DeferredFieldsMixin):
-            fuse_norm_quant: Annotated[bool, Deferred(enable_norm_fusion)] = None
-
-            def __post_init__(self) -> None:
-                # Existing validation logic
-                pass
-
-    The VllmConfig.__post_init__() method should call:
-        config.initialize_deferred_fields(self)
-        config.validate_deferred_fields_initialized()
+            fuse_norm_quant: bool = Deferred(False)
     """
 
     def initialize_deferred_fields(self, vllm_config: Any) -> None:
-        """Initialize all deferred fields in this config.
+        """Replace every field still holding a _DeferredValue with its value.
 
-        This method should be called from VllmConfig.__post_init__() after
-        the config object is created but before it's used.
+        Fields explicitly set by the caller (e.g. the optimization-level table)
+        are left unchanged; only sentinel-valued fields are touched.
+
+        Uses ``dataclasses.fields()`` for discovery so that the mechanism works
+        regardless of which pydantic internals (``__pydantic_fields__``,
+        ``FieldInfo.metadata``) are available.
 
         Args:
-            vllm_config: The VllmConfig instance to use for initialization
+            vllm_config: The VllmConfig instance passed to factory callables.
         """
-        for field_info in fields(self):  # type: ignore[arg-type]
-            marker = get_deferred_factory(field_info.type)
-            if marker is not None:
-                current_value = getattr(self, field_info.name)
-                # Only initialize if not already set by user
-                if current_value is None:
-                    factory = marker.factory
-                    value = factory(vllm_config) if callable(factory) else factory
-                    setattr(self, field_info.name, value)
+        for dc_field in fields(self):  # type: ignore[arg-type]
+            current = getattr(self, dc_field.name)
+            if isinstance(current, _DeferredValue):
+                factory = current.factory
+                value = factory(vllm_config) if callable(factory) else factory
+                setattr(self, dc_field.name, value)
 
     def validate_deferred_fields_initialized(self) -> None:
-        """Validate that all deferred fields have been initialized.
+        """Assert that no field still holds a _DeferredValue.
 
-        This should be called after initialize_deferred_fields() to ensure
-        all deferred fields were properly set.
-
-        Raises:
-            ValueError: If any deferred fields are still None
+        Called automatically by VllmConfig.__post_init__ via auto-discovery.
+        Raises ValueError listing every offending field name.
         """
-        uninitialized = []
-        for field_info in fields(self):  # type: ignore[arg-type]
-            marker = get_deferred_factory(field_info.type)
-            if marker is not None and getattr(self, field_info.name) is None:
-                uninitialized.append(field_info.name)
-
+        uninitialized = [
+            dc_field.name
+            for dc_field in fields(self)  # type: ignore[arg-type]
+            if isinstance(getattr(self, dc_field.name), _DeferredValue)
+        ]
         if uninitialized:
             raise ValueError(
-                f"{self.__class__.__name__}: Deferred fields not initialized: "
+                f"{type(self).__name__}: deferred fields were never initialized: "
                 f"{uninitialized}. This is a bug in VllmConfig initialization."
             )

--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -270,8 +270,8 @@ def normalize_value(x):
     if isinstance(x, _RuntimeDefaultValue):
         raise TypeError(
             f"normalize_value: encountered uninitialized runtime default field "
-            f"({x!r}).  Call initialize_runtime_default_fields() on the containing "
-            "config before computing hashes."
+            f"({x!r}).  This field must be resolved (e.g. by VllmConfig."
+            "__post_init__) before computing hashes."
         )
 
     # Enums: tag with FQN to avoid primitive collisions.
@@ -505,65 +505,16 @@ def set_from_deprecated_env_if_set(
         setattr(config, field_name, field_value)
 
 
-# ---------------------------------------------------------------------------
-# RuntimeDefault field initialization
-#
-# Fields whose values cannot be determined at dataclass construction time
-# are declared using one of three forms:
-#
-#     field_name: bool = RuntimeDefault()
-#         # No fallback — must be set by the caller (e.g. optimization-level
-#         # table).  Validation raises if still unset after __post_init__.
-#
-#     field_name: bool = RuntimeDefault(False)
-#         # Static fallback — resolved to False if not set by the caller.
-#
-#     field_name: bool = RuntimeDefault(lambda cfg: cfg.parallel_config.tp > 1)
-#         # Computed fallback — factory is called with the VllmConfig instance
-#         # if the field has not been set by the caller.
-#
-# Mechanism:
-#   RuntimeDefault(...) returns a pydantic Field whose default is a _RuntimeDefaultValue
-#   sentinel (validate_default=False skips type coercion of the sentinel).
-#   _RuntimeDefaultValue is falsy, so __post_init__ guards that read runtime default
-#   fields before initialization behave as if the value were falsy/None.
-#
-#   The @config decorator calls _inject_runtime_default_methods() after pydantic
-#   processes each class.  If the class declares any RuntimeDefault() field, two
-#   methods are attached directly to the class:
-#     • initialize_runtime_default_fields(vllm_config)  — replaces every
-#       _RuntimeDefaultValue still present with its resolved value (static or
-#       factory-computed).  Fields already set by the caller are left alone.
-#     • validate_runtime_default_fields_initialized()   — raises ValueError listing
-#       any field that still holds a _RuntimeDefaultValue sentinel.
-#
-#   VllmConfig.__post_init__ calls these methods on itself and on every
-#   sub-config attribute that satisfies the HasRuntimeDefaultFields protocol
-#   (detected via isinstance checks).  validate_runtime_default_fields_initialized()
-#   is always called last to assert no sentinels remain.
-# ---------------------------------------------------------------------------
-
-
 class _RuntimeDefaultValue:
-    """Per-field sentinel that doubles as an optional factory carrier.
+    """Sentinel produced by `RuntimeDefault()`.
 
-    Each ``RuntimeDefault(...)`` call produces one ``_RuntimeDefaultValue`` instance
-    that becomes the pydantic default for that field.  Embedding the factory
-    in the default value means:
-
-    * Detection uses only ``isinstance(value, _RuntimeDefaultValue)`` on the live
-      field value — no dependency on ``FieldInfo.metadata`` or pydantic
+    * Detection uses only `isinstance(value, _RuntimeDefaultValue)` on the live
+      field value. No dependency on `FieldInfo.metadata` or pydantic
       internals.
-    * ``__bool__`` returns ``False`` so guards in ``__post_init__`` that read
-      runtime default fields before initialization treat them as falsy, matching the
-      behaviour of the old ``None`` sentinel.
-    * When no factory is provided (``MISSING``), the field has no fallback and
-      must be set by the user or the optimization-level table; validation will
-      fail if it remains unset.
+    * `__bool__` returns `False` so guards in `__post_init__` that read
+      the field before it has been resolved treat it as falsy, matching the
+      behaviour of the old `None` sentinel.
     """
-
-    def __init__(self, factory: "Callable[[Any], Any] | Any" = MISSING) -> None:
-        self.factory = factory
 
     def __bool__(self) -> bool:
         return False
@@ -572,88 +523,62 @@ class _RuntimeDefaultValue:
         return self
 
     def __deepcopy__(self, memo: dict) -> "_RuntimeDefaultValue":
-        # _RuntimeDefaultValue is a sentinel whose identity matters.  Pydantic
-        # deepcopies mutable defaults when creating each model instance;
-        # returning self preserves factory identity so that ``is MISSING``
-        # checks and __repr__ work correctly on every instance.
+        # Pydantic deepcopies mutable defaults when creating each model
+        # instance, returning self keeps the sentinel identity stable so
+        # isinstance checks behave the same on every instance.
         return self
 
     def __repr__(self) -> str:
-        if self.factory is MISSING:
-            return "<RuntimeDefault()>"
-        factory_name = getattr(self.factory, "__name__", repr(self.factory))
-        return f"<RuntimeDefault({factory_name})>"
+        return "<RuntimeDefault()>"
 
 
-def RuntimeDefault(factory: "Callable[[Any], Any] | Any" = MISSING) -> Any:
-    """Declare a config field whose value is resolved in VllmConfig.__post_init__.
+def RuntimeDefault() -> Any:
+    """Declare a config field whose value must be resolved before the end of
+    VllmConfig.__post_init__.
 
-    Returns a pydantic Field whose default is a ``_RuntimeDefaultValue`` instance.
-    The declared annotation is the true runtime type — no ``| None`` needed.
-    ``validate_default=False`` tells pydantic to skip coercion of the sentinel
-    through the field's type validator.
+    Returns a pydantic Field whose default is a `_RuntimeDefaultValue`
+    instance. The declared annotation is the true runtime type, no ``| None``
+    needed. `validate_default=False` tells pydantic to skip coercion of the
+    sentinel through the field's type validator.
 
-    When called with no argument, the field has no fallback: it must be set by
-    the user or the optimization-level table, or validation will raise.  Pass a
-    factory only when a last-resort fallback is genuinely needed (e.g. for
-    fields absent from the optimization-level tables).
-
-    Args:
-        factory: Optional static fallback value (e.g. ``False``) or a callable
-                 that accepts a VllmConfig instance and returns the value.
-                 Omit to require the field to be set externally.
+    The ``@config`` decorator attaches `validate_runtime_default_fields_initialized()`
+    to any class declaring a `RuntimeDefault()` field. `VllmConfig.__post_init__`
+    calls it recursively on every nested sub-config, raising ``ValueError``
+    for any field that still holds the sentinel. It must be set somehow
+    before then.
 
     Example::
 
         @config
         class MyConfig:
-            required_flag: bool = RuntimeDefault()  # must be set by table/user
-            fallback_flag: bool = RuntimeDefault(False)  # falls back to False
-            tp_flag: bool = RuntimeDefault(lambda cfg: cfg.parallel_config.tp > 1)
+            required_flag: bool = RuntimeDefault()  # set before __post_init__ ends
     """
     return PydanticField(  # type: ignore[call-overload]
-        default=_RuntimeDefaultValue(factory),
+        default=_RuntimeDefaultValue(),
         validate_default=False,
     )
 
 
 @runtime_checkable
 class HasRuntimeDefaultFields(Protocol):
-    """Structural interface satisfied by any ``@config`` class that declares at
-    least one ``RuntimeDefault()`` field.
+    """Structural interface satisfied by any `@config` class that declares at
+    least one `RuntimeDefault()` field.
 
-    The ``@config`` decorator injects ``initialize_runtime_default_fields`` and
-    ``validate_runtime_default_fields_initialized`` automatically — no inheritance is
-    required.  ``VllmConfig.__post_init__`` uses
-    ``isinstance(v, HasRuntimeDefaultFields)`` to discover sub-configs that need
-    initialization.
+    The `@config` decorator injects `validate_runtime_default_fields_initialized`
+    automatically. No inheritance is required.  `VllmConfig.__post_init__` uses
+    `isinstance(v, HasRuntimeDefaultFields)` to discover sub-configs that need
+    validation.
     """
 
-    def initialize_runtime_default_fields(self, vllm_config: Any) -> None: ...
     def validate_runtime_default_fields_initialized(self) -> None: ...
 
 
-def _impl_initialize_runtime_default_fields(self: Any, vllm_config: Any) -> None:
-    """Injected as ``initialize_runtime_default_fields`` by the ``@config`` decorator.
-
-    Replaces every field still holding a ``_RuntimeDefaultValue`` with its resolved
-    value.  Fields explicitly set by the caller (e.g. the optimization-level
-    table) are left unchanged; only sentinel-valued fields are touched.
-    """
-    for dc_field in fields(self):  # type: ignore[arg-type]
-        current = getattr(self, dc_field.name)
-        if isinstance(current, _RuntimeDefaultValue) and current.factory is not MISSING:
-            factory = current.factory
-            value = factory(vllm_config) if callable(factory) else factory
-            setattr(self, dc_field.name, value)
-
-
 def _impl_validate_runtime_default_fields_initialized(self: Any) -> None:
-    """Injected as ``validate_runtime_default_fields_initialized`` by ``@config``.
+    """Injected as `validate_runtime_default_fields_initialized` by `@config`.
 
-    Asserts that no field still holds a ``RuntimeDefaultValue``.  Called
-    automatically by ``VllmConfig.__post_init__`` via auto-discovery.
-    Raises ``ValueError`` listing every offending field name.
+    Asserts that no field still holds a `RuntimeDefaultValue`.  Called
+    automatically by `VllmConfig.__post_init__` via auto-discovery.
+    Raises `ValueError` listing every offending field name.
     """
     uninitialized = [
         dc_field.name
@@ -677,16 +602,8 @@ def _walk_runtime_default(obj: Any) -> Generator[Any, None, None]:
                 yield from _walk_runtime_default(child)
 
 
-def initialize_runtime_default_fields_recursive(obj: Any, vllm_config: Any) -> None:
-    """Initialize runtime default fields in *obj* and all nested ``@config``
-    dataclasses."""
-    for node in _walk_runtime_default(obj):
-        if isinstance(node, HasRuntimeDefaultFields):
-            node.initialize_runtime_default_fields(vllm_config)
-
-
 def validate_runtime_default_fields_recursive(obj: Any) -> None:
-    """Validate runtime default fields in *obj* and all nested ``@config``
+    """Validate runtime default fields in *obj* and all nested `@config`
     dataclasses."""
     for node in _walk_runtime_default(obj):
         if isinstance(node, HasRuntimeDefaultFields):
@@ -694,12 +611,12 @@ def validate_runtime_default_fields_recursive(obj: Any) -> None:
 
 
 def _inject_runtime_default_methods(cls: type) -> None:
-    """Attach runtime default field methods to *cls* if it declares any
-    ``RuntimeDefault()`` fields.
+    """Attach the runtime default field validation method to *cls* if it
+    declares any `RuntimeDefault()` fields.
 
-    Called by the ``@config`` decorator after pydantic has finished processing
-    the class.  Uses ``dataclasses.fields()`` + ``PydanticFieldInfo.default``
-    for detection so that it works regardless of pydantic-internal changes.
+    Called by the `@config` decorator after pydantic has finished processing
+    the class.  Uses `dataclasses.fields()` + `PydanticFieldInfo.default`
+    for detection so that it works regardless of pydantic internal changes.
     """
     if not is_dataclass(cls):
         return
@@ -709,9 +626,6 @@ def _inject_runtime_default_methods(cls: type) -> None:
         for f in fields(cls)  # type: ignore[arg-type]
     )
     if has_runtime_default:
-        cls.initialize_runtime_default_fields = (  # type: ignore[attr-defined]
-            _impl_initialize_runtime_default_fields
-        )
         cls.validate_runtime_default_fields_initialized = (  # type: ignore[attr-defined]
             _impl_validate_runtime_default_fields_initialized
         )

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -264,7 +264,6 @@ OPTIMIZATION_LEVEL_02 = {
             "fuse_attn_quant": IS_QUANTIZED,
             "enable_sp": IS_DENSE,
             "fuse_gemm_comms": IS_DENSE,
-            "fuse_minimax_qk_norm": True,
             "fuse_act_padding": enable_norm_pad_fusion,
             "fuse_mla_dual_rms_norm": enable_mla_dual_rms_norm_fusion,
             "fuse_rope_kvcache": enable_rope_kvcache_fusion,

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -264,6 +264,7 @@ OPTIMIZATION_LEVEL_02 = {
             "fuse_attn_quant": IS_QUANTIZED,
             "enable_sp": IS_DENSE,
             "fuse_gemm_comms": IS_DENSE,
+            "fuse_minimax_qk_norm": True,
             "fuse_act_padding": enable_norm_pad_fusion,
             "fuse_mla_dual_rms_norm": enable_mla_dual_rms_norm_fusion,
             "fuse_rope_kvcache": enable_rope_kvcache_fusion,

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -50,8 +50,8 @@ from .speculative import EagleModelTypes, NgramGPUTypes, SpeculativeConfig
 from .structured_outputs import StructuredOutputsConfig
 from .utils import (
     SupportsHash,
-    _RuntimeDefaultValue,
     config,
+    is_runtime_default,
     replace,
     validate_runtime_default_fields_recursive,
 )
@@ -788,11 +788,11 @@ class VllmConfig:
         """
         current = getattr(config_obj, key)
         # Apply the default when the field is unset (None) or still holds its
-        # RuntimeDefault sentinel (a _RuntimeDefaultValue produced by
-        # RuntimeDefault(factory)).
-        # Without the _RuntimeDefaultValue check, optimization-level defaults would
-        # never be applied to runtime default fields because their sentinel is not None.
-        if current is None or isinstance(current, _RuntimeDefaultValue):
+        # RuntimeDefault sentinel (produced by RuntimeDefault()).
+        # Without the is_runtime_default() check, optimization level defaults
+        # would never be applied to runtime default fields because their
+        # sentinel is not None.
+        if current is None or is_runtime_default(current):
             # Some config values are known before initialization and are
             # hard coded.
             # Other values depend on the user given configuration, so they are
@@ -1068,7 +1068,7 @@ class VllmConfig:
                 raise ValueError(
                     f"`{executor_backend}` does not support async scheduling yet."
                 )
-        elif self.scheduler_config.async_scheduling is None:
+        elif is_runtime_default(self.scheduler_config.async_scheduling):
             # Enable async scheduling unless there is an incompatible option.
             if (
                 self.model_config is not None
@@ -1123,7 +1123,7 @@ class VllmConfig:
             "enabled" if self.scheduler_config.async_scheduling else "disabled",
         )
 
-        if self.parallel_config.disable_nccl_for_dp_synchronization is None:
+        if is_runtime_default(self.parallel_config.disable_nccl_for_dp_synchronization):
             if self.scheduler_config.async_scheduling:
                 if self.parallel_config.data_parallel_size > 1 and (
                     self.model_config is None or self.model_config.is_moe
@@ -1219,7 +1219,7 @@ class VllmConfig:
             self.compilation_config.mode = CompilationMode.NONE
 
         if self.compilation_config.backend == "eager" or (
-            not isinstance(self.compilation_config.mode, _RuntimeDefaultValue)
+            not is_runtime_default(self.compilation_config.mode)
             and self.compilation_config.mode is not None
             and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
         ):
@@ -1248,8 +1248,8 @@ class VllmConfig:
 
         current_platform.apply_config_platform_defaults(self)
 
-        if self.compilation_config.mode is None or isinstance(
-            self.compilation_config.mode, _RuntimeDefaultValue
+        if self.compilation_config.mode is None or is_runtime_default(
+            self.compilation_config.mode
         ):
             if self.optimization_level > OptimizationLevel.O0:
                 self.compilation_config.mode = CompilationMode.VLLM_COMPILE
@@ -1257,8 +1257,8 @@ class VllmConfig:
                 self.compilation_config.mode = CompilationMode.NONE
 
         # By default, enable torch wrapping only when using custom Inductor lowering
-        if self.compilation_config.ir_enable_torch_wrap is None or isinstance(
-            self.compilation_config.ir_enable_torch_wrap, _RuntimeDefaultValue
+        if self.compilation_config.ir_enable_torch_wrap is None or is_runtime_default(
+            self.compilation_config.ir_enable_torch_wrap
         ):
             self.compilation_config.ir_enable_torch_wrap = (
                 self.compilation_config.mode == CompilationMode.VLLM_COMPILE
@@ -1282,7 +1282,7 @@ class VllmConfig:
         default_config = OPTIMIZATION_LEVEL_TO_CONFIG[self.optimization_level]
         self._apply_optimization_level_defaults(default_config)
 
-        if self.kernel_config.enable_flashinfer_autotune is None:
+        if is_runtime_default(self.kernel_config.enable_flashinfer_autotune):
             raise ValueError(
                 "KernelConfig.enable_flashinfer_autotune must be set after applying "
                 "optimization level defaults."
@@ -1342,7 +1342,7 @@ class VllmConfig:
             # On torch >= 2.11 the hoisted OpaqueObject approach supersedes
             # fast_moe_cold_start, so force it off.
             self.compilation_config.fast_moe_cold_start = False
-        elif self.compilation_config.fast_moe_cold_start is None:
+        elif is_runtime_default(self.compilation_config.fast_moe_cold_start):
             # resolve default behavior: try to be as safe as possible
             # this config is unsafe if any spec decoding draft model has a MOE.
             # We'll conservatively turn it off if we see spec decoding.
@@ -1617,7 +1617,7 @@ class VllmConfig:
                 # local attention.
                 need_disable_hybrid_kv_cache_manager = True
 
-        if self.scheduler_config.disable_hybrid_kv_cache_manager is None:
+        if is_runtime_default(self.scheduler_config.disable_hybrid_kv_cache_manager):
             # Auto-disable HMA only when the connector config does not support it.
             if self.kv_transfer_config is not None:
                 from vllm.distributed.kv_transfer.kv_connector.factory import (
@@ -1652,7 +1652,7 @@ class VllmConfig:
                 " automatically."
             )
 
-        if self.scheduler_config.disable_hybrid_kv_cache_manager is None:
+        if is_runtime_default(self.scheduler_config.disable_hybrid_kv_cache_manager):
             # Default to enable HMA if not explicitly disabled by user or logic above.
             self.scheduler_config.disable_hybrid_kv_cache_manager = False
 
@@ -1818,8 +1818,8 @@ class VllmConfig:
             max_cudagraph_capture_size = (
                 self.compilation_config.max_cudagraph_capture_size
             )
-            if max_cudagraph_capture_size is None or isinstance(
-                max_cudagraph_capture_size, _RuntimeDefaultValue
+            if max_cudagraph_capture_size is None or is_runtime_default(
+                max_cudagraph_capture_size
             ):
                 decode_query_len = 1 + self.num_speculative_tokens
                 max_cudagraph_capture_size = min(

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -48,7 +48,14 @@ from .reasoning import ReasoningConfig
 from .scheduler import SchedulerConfig
 from .speculative import EagleModelTypes, NgramGPUTypes, SpeculativeConfig
 from .structured_outputs import StructuredOutputsConfig
-from .utils import HasDeferredFields, SupportsHash, _DeferredValue, config, replace
+from .utils import (
+    SupportsHash,
+    _DeferredValue,
+    config,
+    initialize_deferred_fields_recursive,
+    replace,
+    validate_deferred_fields_recursive,
+)
 from .weight_transfer import WeightTransferConfig
 
 if TYPE_CHECKING:
@@ -1270,12 +1277,13 @@ class VllmConfig:
         default_config = OPTIMIZATION_LEVEL_TO_CONFIG[self.optimization_level]
         self._apply_optimization_level_defaults(default_config)
 
-        # Initialize deferred fields in PassConfig (must run after the
-        # optimization-level table is applied so the table's explicit values
+        # Initialize deferred fields in all nested sub-configs (must run after
+        # the optimization-level table is applied so the table's explicit values
         # take priority over the Deferred fallbacks).
-        pass_config = self.compilation_config.pass_config
-        if isinstance(pass_config, HasDeferredFields):
-            pass_config.initialize_deferred_fields(self)
+        for _f in fields(self):  # type: ignore[arg-type]
+            _v = getattr(self, _f.name)
+            if _v is not None:
+                initialize_deferred_fields_recursive(_v, self)
 
         if self.kernel_config.enable_flashinfer_autotune is None:
             raise ValueError(
@@ -1677,13 +1685,13 @@ class VllmConfig:
         self.compilation_config.pass_config.log_enabled_passes()
 
         # Validate that every sub-config with Deferred() fields had them all
-        # initialized before __post_init__ completed.  Auto-discovery via the
-        # HasDeferredFields Protocol means new @config classes with Deferred()
-        # fields are covered automatically without touching this loop.
+        # initialized before __post_init__ completed.  The recursive walk means
+        # new @config classes with Deferred() fields nested at any depth are
+        # covered automatically without touching this code.
         for _f in fields(self):  # type: ignore[arg-type]
             _value = getattr(self, _f.name)
-            if isinstance(_value, HasDeferredFields):
-                _value.validate_deferred_fields_initialized()
+            if _value is not None:
+                validate_deferred_fields_recursive(_value)
 
     def update_sizes_for_sequence_parallelism(self, possible_sizes: list) -> list:
         # remove the sizes that not multiple of tp_size when

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -10,7 +10,7 @@ import threading
 import time
 from collections.abc import Iterable
 from contextlib import contextmanager
-from dataclasses import is_dataclass
+from dataclasses import fields, is_dataclass
 from datetime import datetime
 from enum import IntEnum
 from functools import lru_cache
@@ -48,7 +48,7 @@ from .reasoning import ReasoningConfig
 from .scheduler import SchedulerConfig
 from .speculative import EagleModelTypes, NgramGPUTypes, SpeculativeConfig
 from .structured_outputs import StructuredOutputsConfig
-from .utils import DeferredFieldsMixin, SupportsHash, config, replace
+from .utils import DeferredFieldsMixin, SupportsHash, _DeferredValue, config, replace
 from .weight_transfer import WeightTransferConfig
 
 if TYPE_CHECKING:
@@ -780,7 +780,12 @@ class VllmConfig:
             key: Attribute name.
             value: Default value (static or callable).
         """
-        if getattr(config_obj, key) is None:
+        current = getattr(config_obj, key)
+        # Apply the default when the field is unset (None) or still holds its
+        # Deferred sentinel (a _DeferredValue produced by Deferred(factory)).
+        # Without the _DeferredValue check, optimization-level defaults would
+        # never be applied to deferred fields because their sentinel is not None.
+        if current is None or isinstance(current, _DeferredValue):
             # Some config values are known before initialization and are
             # hard coded.
             # Other values depend on the user given configuration, so they are
@@ -1265,10 +1270,10 @@ class VllmConfig:
         default_config = OPTIMIZATION_LEVEL_TO_CONFIG[self.optimization_level]
         self._apply_optimization_level_defaults(default_config)
 
-        # Initialize deferred fields in PassConfig
-        if isinstance(self.compilation_config.pass_config, DeferredFieldsMixin):
-            self.compilation_config.pass_config.initialize_deferred_fields(self)
-            self.compilation_config.pass_config.validate_deferred_fields_initialized()
+        # Initialize deferred fields in PassConfig (must run after the
+        # optimization-level table is applied so the table's explicit values
+        # take priority over the Deferred fallbacks).
+        self.compilation_config.pass_config.initialize_deferred_fields(self)
 
         if self.kernel_config.enable_flashinfer_autotune is None:
             raise ValueError(
@@ -1668,6 +1673,15 @@ class VllmConfig:
         self._verify_kv_transfer_compat()
         # Log the custom passes that are enabled
         self.compilation_config.pass_config.log_enabled_passes()
+
+        # Validate that every DeferredFieldsMixin sub-config had all its
+        # deferred fields initialized before __post_init__ completed.
+        # Auto-discovery means new DeferredFieldsMixin sub-configs are covered
+        # automatically without touching this loop.
+        for _f in fields(self):  # type: ignore[arg-type]
+            _value = getattr(self, _f.name)
+            if isinstance(_value, DeferredFieldsMixin):
+                _value.validate_deferred_fields_initialized()
 
     def update_sizes_for_sequence_parallelism(self, possible_sizes: list) -> list:
         # remove the sizes that not multiple of tp_size when

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -48,7 +48,7 @@ from .reasoning import ReasoningConfig
 from .scheduler import SchedulerConfig
 from .speculative import EagleModelTypes, NgramGPUTypes, SpeculativeConfig
 from .structured_outputs import StructuredOutputsConfig
-from .utils import SupportsHash, config, replace
+from .utils import DeferredFieldsMixin, SupportsHash, config, replace
 from .weight_transfer import WeightTransferConfig
 
 if TYPE_CHECKING:
@@ -1264,6 +1264,12 @@ class VllmConfig:
 
         default_config = OPTIMIZATION_LEVEL_TO_CONFIG[self.optimization_level]
         self._apply_optimization_level_defaults(default_config)
+
+        # Initialize deferred fields in PassConfig
+        if isinstance(self.compilation_config.pass_config, DeferredFieldsMixin):
+            self.compilation_config.pass_config.initialize_deferred_fields(self)
+            self.compilation_config.pass_config.validate_deferred_fields_initialized()
+
         if self.kernel_config.enable_flashinfer_autotune is None:
             raise ValueError(
                 "KernelConfig.enable_flashinfer_autotune must be set after applying "

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -48,7 +48,7 @@ from .reasoning import ReasoningConfig
 from .scheduler import SchedulerConfig
 from .speculative import EagleModelTypes, NgramGPUTypes, SpeculativeConfig
 from .structured_outputs import StructuredOutputsConfig
-from .utils import DeferredFieldsMixin, SupportsHash, _DeferredValue, config, replace
+from .utils import HasDeferredFields, SupportsHash, _DeferredValue, config, replace
 from .weight_transfer import WeightTransferConfig
 
 if TYPE_CHECKING:
@@ -1273,7 +1273,9 @@ class VllmConfig:
         # Initialize deferred fields in PassConfig (must run after the
         # optimization-level table is applied so the table's explicit values
         # take priority over the Deferred fallbacks).
-        self.compilation_config.pass_config.initialize_deferred_fields(self)
+        pass_config = self.compilation_config.pass_config
+        if isinstance(pass_config, HasDeferredFields):
+            pass_config.initialize_deferred_fields(self)
 
         if self.kernel_config.enable_flashinfer_autotune is None:
             raise ValueError(
@@ -1674,13 +1676,13 @@ class VllmConfig:
         # Log the custom passes that are enabled
         self.compilation_config.pass_config.log_enabled_passes()
 
-        # Validate that every DeferredFieldsMixin sub-config had all its
-        # deferred fields initialized before __post_init__ completed.
-        # Auto-discovery means new DeferredFieldsMixin sub-configs are covered
-        # automatically without touching this loop.
+        # Validate that every sub-config with Deferred() fields had them all
+        # initialized before __post_init__ completed.  Auto-discovery via the
+        # HasDeferredFields Protocol means new @config classes with Deferred()
+        # fields are covered automatically without touching this loop.
         for _f in fields(self):  # type: ignore[arg-type]
             _value = getattr(self, _f.name)
-            if isinstance(_value, DeferredFieldsMixin):
+            if isinstance(_value, HasDeferredFields):
                 _value.validate_deferred_fields_initialized()
 
     def update_sizes_for_sequence_parallelism(self, possible_sizes: list) -> list:

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1221,7 +1221,8 @@ class VllmConfig:
             self.compilation_config.mode = CompilationMode.NONE
 
         if self.compilation_config.backend == "eager" or (
-            self.compilation_config.mode is not None
+            not isinstance(self.compilation_config.mode, _RuntimeDefaultValue)
+            and self.compilation_config.mode is not None
             and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
         ):
             logger.warning(
@@ -1249,14 +1250,18 @@ class VllmConfig:
 
         current_platform.apply_config_platform_defaults(self)
 
-        if self.compilation_config.mode is None:
+        if self.compilation_config.mode is None or isinstance(
+            self.compilation_config.mode, _RuntimeDefaultValue
+        ):
             if self.optimization_level > OptimizationLevel.O0:
                 self.compilation_config.mode = CompilationMode.VLLM_COMPILE
             else:
                 self.compilation_config.mode = CompilationMode.NONE
 
         # By default, enable torch wrapping only when using custom Inductor lowering
-        if self.compilation_config.ir_enable_torch_wrap is None:
+        if self.compilation_config.ir_enable_torch_wrap is None or isinstance(
+            self.compilation_config.ir_enable_torch_wrap, _RuntimeDefaultValue
+        ):
             self.compilation_config.ir_enable_torch_wrap = (
                 self.compilation_config.mode == CompilationMode.VLLM_COMPILE
                 and self.compilation_config.backend == "inductor"
@@ -1424,6 +1429,8 @@ class VllmConfig:
 
         else:
             self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+            self.compilation_config.max_cudagraph_capture_size = 0
+            self.compilation_config.cudagraph_capture_sizes = []
 
         if self.cache_config.kv_sharing_fast_prefill:
             if (
@@ -1821,7 +1828,9 @@ class VllmConfig:
             max_cudagraph_capture_size = (
                 self.compilation_config.max_cudagraph_capture_size
             )
-            if max_cudagraph_capture_size is None:
+            if max_cudagraph_capture_size is None or isinstance(
+                max_cudagraph_capture_size, _RuntimeDefaultValue
+            ):
                 decode_query_len = 1 + self.num_speculative_tokens
                 max_cudagraph_capture_size = min(
                     self.scheduler_config.max_num_seqs * decode_query_len * 2, 512
@@ -1835,7 +1844,7 @@ class VllmConfig:
             )
 
             # determine the cudagraph_capture_sizes
-            if self.compilation_config.cudagraph_capture_sizes is not None:
+            if isinstance(self.compilation_config.cudagraph_capture_sizes, list):
                 assert len(self.compilation_config.cudagraph_capture_sizes) > 0, (
                     "cudagraph_capture_sizes should contain at least one element "
                     "when using cuda graph."
@@ -1890,12 +1899,12 @@ class VllmConfig:
                 cudagraph_capture_sizes[-1] if cudagraph_capture_sizes else 0
             )
             if (
-                self.compilation_config.max_cudagraph_capture_size is not None
+                isinstance(self.compilation_config.max_cudagraph_capture_size, int)
                 and self.compilation_config.max_cudagraph_capture_size != valid_max_size
             ):
                 # raise error only when both two flags are user-specified
                 # and they are inconsistent with each other
-                if self.compilation_config.cudagraph_capture_sizes is not None:
+                if isinstance(self.compilation_config.cudagraph_capture_sizes, list):
                     raise ValueError(
                         "customized max_cudagraph_capture_size"
                         f"(={self.compilation_config.max_cudagraph_capture_size}) "
@@ -1910,9 +1919,11 @@ class VllmConfig:
             # always set the final max_cudagraph_capture_size
             self.compilation_config.max_cudagraph_capture_size = valid_max_size
 
-            if self.compilation_config.cudagraph_capture_sizes is not None and len(
-                cudagraph_capture_sizes
-            ) < len(self.compilation_config.cudagraph_capture_sizes):
+            if isinstance(
+                self.compilation_config.cudagraph_capture_sizes, list
+            ) and len(cudagraph_capture_sizes) < len(
+                self.compilation_config.cudagraph_capture_sizes
+            ):
                 # If users have specified capture sizes, we only need to
                 # compare the lens before and after modification since the modified
                 # list is only the subset of the original list.

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -50,11 +50,11 @@ from .speculative import EagleModelTypes, NgramGPUTypes, SpeculativeConfig
 from .structured_outputs import StructuredOutputsConfig
 from .utils import (
     SupportsHash,
-    _DeferredValue,
+    _RuntimeDefaultValue,
     config,
-    initialize_deferred_fields_recursive,
+    initialize_runtime_default_fields_recursive,
     replace,
-    validate_deferred_fields_recursive,
+    validate_runtime_default_fields_recursive,
 )
 from .weight_transfer import WeightTransferConfig
 
@@ -790,10 +790,11 @@ class VllmConfig:
         """
         current = getattr(config_obj, key)
         # Apply the default when the field is unset (None) or still holds its
-        # Deferred sentinel (a _DeferredValue produced by Deferred(factory)).
-        # Without the _DeferredValue check, optimization-level defaults would
-        # never be applied to deferred fields because their sentinel is not None.
-        if current is None or isinstance(current, _DeferredValue):
+        # RuntimeDefault sentinel (a _RuntimeDefaultValue produced by
+        # RuntimeDefault(factory)).
+        # Without the _RuntimeDefaultValue check, optimization-level defaults would
+        # never be applied to runtime default fields because their sentinel is not None.
+        if current is None or isinstance(current, _RuntimeDefaultValue):
             # Some config values are known before initialization and are
             # hard coded.
             # Other values depend on the user given configuration, so they are
@@ -1278,13 +1279,13 @@ class VllmConfig:
         default_config = OPTIMIZATION_LEVEL_TO_CONFIG[self.optimization_level]
         self._apply_optimization_level_defaults(default_config)
 
-        # Initialize deferred fields in all nested sub-configs (must run after
+        # Initialize runtime default fields in all nested sub-configs (must run after
         # the optimization-level table is applied so the table's explicit values
-        # take priority over the Deferred fallbacks).
+        # take priority over the RuntimeDefault fallbacks).
         for _f in fields(self):  # type: ignore[arg-type]
             _v = getattr(self, _f.name)
             if _v is not None:
-                initialize_deferred_fields_recursive(_v, self)
+                initialize_runtime_default_fields_recursive(_v, self)
 
         if self.kernel_config.enable_flashinfer_autotune is None:
             raise ValueError(
@@ -1685,14 +1686,14 @@ class VllmConfig:
         # Log the custom passes that are enabled
         self.compilation_config.pass_config.log_enabled_passes()
 
-        # Validate that every sub-config with Deferred() fields had them all
+        # Validate that every sub-config with RuntimeDefault() fields had them all
         # initialized before __post_init__ completed.  The recursive walk means
-        # new @config classes with Deferred() fields nested at any depth are
+        # new @config classes with RuntimeDefault() fields nested at any depth are
         # covered automatically without touching this code.
         for _f in fields(self):  # type: ignore[arg-type]
             _value = getattr(self, _f.name)
             if _value is not None:
-                validate_deferred_fields_recursive(_value)
+                validate_runtime_default_fields_recursive(_value)
 
     def update_sizes_for_sequence_parallelism(self, possible_sizes: list) -> list:
         # remove the sizes that not multiple of tp_size when

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -52,7 +52,6 @@ from .utils import (
     SupportsHash,
     _RuntimeDefaultValue,
     config,
-    initialize_runtime_default_fields_recursive,
     replace,
     validate_runtime_default_fields_recursive,
 )
@@ -1282,14 +1281,6 @@ class VllmConfig:
 
         default_config = OPTIMIZATION_LEVEL_TO_CONFIG[self.optimization_level]
         self._apply_optimization_level_defaults(default_config)
-
-        # Initialize runtime default fields in all nested sub-configs (must run after
-        # the optimization-level table is applied so the table's explicit values
-        # take priority over the RuntimeDefault fallbacks).
-        for _f in fields(self):  # type: ignore[arg-type]
-            _v = getattr(self, _f.name)
-            if _v is not None:
-                initialize_runtime_default_fields_recursive(_v, self)
 
         if self.kernel_config.enable_flashinfer_autotune is None:
             raise ValueError(

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -2324,15 +2324,15 @@ class EngineArgs:
 
         # Compilation config overrides
         compilation_config = copy.deepcopy(self.compilation_config)
-        if self.cudagraph_capture_sizes is not None:
-            if compilation_config.cudagraph_capture_sizes is not None:
+        if isinstance(self.cudagraph_capture_sizes, list):
+            if isinstance(compilation_config.cudagraph_capture_sizes, list):
                 raise ValueError(
                     "cudagraph_capture_sizes and compilation_config."
                     "cudagraph_capture_sizes are mutually exclusive"
                 )
             compilation_config.cudagraph_capture_sizes = self.cudagraph_capture_sizes
-        if self.max_cudagraph_capture_size is not None:
-            if compilation_config.max_cudagraph_capture_size is not None:
+        if isinstance(self.max_cudagraph_capture_size, int):
+            if isinstance(compilation_config.max_cudagraph_capture_size, int):
                 raise ValueError(
                     "max_cudagraph_capture_size and compilation_config."
                     "max_cudagraph_capture_size are mutually exclusive"

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -95,7 +95,7 @@ from vllm.config.parallel import (
     ExpertPlacementStrategy,
 )
 from vllm.config.scheduler import SchedulerPolicy
-from vllm.config.utils import get_field
+from vllm.config.utils import get_field, is_runtime_default
 from vllm.config.vllm import OptimizationLevel, PerformanceMode
 from vllm.logger import init_logger, suppress_logging
 from vllm.platforms import CpuArchEnum, current_platform
@@ -496,7 +496,7 @@ class EngineArgs:
     ubatch_size: int = ParallelConfig.ubatch_size
     dbo_decode_token_threshold: int = ParallelConfig.dbo_decode_token_threshold
     dbo_prefill_token_threshold: int = ParallelConfig.dbo_prefill_token_threshold
-    disable_nccl_for_dp_synchronization: bool | None = (
+    disable_nccl_for_dp_synchronization: bool = (
         ParallelConfig.disable_nccl_for_dp_synchronization
     )
     eplb_config: EPLBConfig = get_field(ParallelConfig, "eplb_config")
@@ -615,7 +615,7 @@ class EngineArgs:
 
     watermark: float = SchedulerConfig.watermark
 
-    disable_hybrid_kv_cache_manager: bool | None = (
+    disable_hybrid_kv_cache_manager: bool = (
         SchedulerConfig.disable_hybrid_kv_cache_manager
     )
 
@@ -712,7 +712,7 @@ class EngineArgs:
     )
     """Custom logitproc types"""
 
-    async_scheduling: bool | None = SchedulerConfig.async_scheduling
+    async_scheduling: bool = SchedulerConfig.async_scheduling
 
     stream_interval: int = SchedulerConfig.stream_interval
 
@@ -780,7 +780,7 @@ class EngineArgs:
                         model_id,
                         self.model,
                     )
-            if self.tokenizer is not None and not is_cloud_storage(self.tokenizer):
+            if isinstance(self.tokenizer, str) and not is_cloud_storage(self.tokenizer):
                 tokenizer_id = self.tokenizer
                 self.tokenizer = get_model_path(self.tokenizer, self.tokenizer_revision)
                 if tokenizer_id is not self.tokenizer:
@@ -1316,6 +1316,10 @@ class EngineArgs:
 
         # LoRA related configs
         lora_kwargs = get_kwargs(LoRAConfig)
+        # max_cpu_loras' annotation is now non Optional (RuntimeDefault), so
+        # _compute_kwargs no longer wraps its type in optional_type. Restore
+        # the `--max-cpu-loras None`/`""` -> None CLI behaviour explicitly.
+        lora_kwargs["max_cpu_loras"]["type"] = optional_type(int)
         lora_group = parser.add_argument_group(
             title="LoRAConfig",
             description=LoRAConfig.__doc__,
@@ -1530,6 +1534,10 @@ class EngineArgs:
             "--speculative-config", "-sc", **vllm_kwargs["speculative_config"]
         )
         speculative_kwargs = get_kwargs(SpeculativeConfig)
+        # --spec-method and --spec-tokens are independent shorthands. Their
+        # "unset" value is None, not SpeculativeConfig's RuntimeDefault sentinel.
+        for key in ("method", "num_speculative_tokens"):
+            speculative_kwargs[key]["default"] = None
         vllm_group.add_argument("--spec-method", **speculative_kwargs["method"])
         vllm_group.add_argument("--spec-model", **speculative_kwargs["model"])
         vllm_group.add_argument(
@@ -1742,7 +1750,7 @@ class EngineArgs:
             ("--spec-model", "model", self.spec_model),
             ("--spec-tokens", "num_speculative_tokens", self.spec_tokens),
         ):
-            if value is None:
+            if value is None or is_runtime_default(value):
                 continue
             if self.speculative_config is None:
                 self.speculative_config = {}
@@ -2196,6 +2204,11 @@ class EngineArgs:
                 "non multimodal model"
             )
 
+        max_cpu_loras = (
+            self.max_cpu_loras
+            if self.max_cpu_loras and self.max_cpu_loras > 0
+            else None
+        )
         lora_config = (
             LoRAConfig(
                 max_lora_rank=self.max_lora_rank,
@@ -2208,9 +2221,7 @@ class EngineArgs:
                 specialize_active_lora=self.specialize_active_lora,
                 enable_mixed_moe_lora_format=self.enable_mixed_moe_lora_format,
                 enable_moe_shared_loras=self.enable_moe_shared_loras,
-                max_cpu_loras=self.max_cpu_loras
-                if self.max_cpu_loras and self.max_cpu_loras > 0
-                else None,
+                max_cpu_loras=max_cpu_loras,  # type: ignore[arg-type]
             )
             if self.enable_lora
             else None
@@ -2278,8 +2289,8 @@ class EngineArgs:
 
         # Kernel config overrides
         kernel_config = copy.deepcopy(self.kernel_config)
-        if self.enable_flashinfer_autotune is not None:
-            if kernel_config.enable_flashinfer_autotune is not None:
+        if isinstance(self.enable_flashinfer_autotune, bool):
+            if isinstance(kernel_config.enable_flashinfer_autotune, bool):
                 raise ValueError(
                     "enable_flashinfer_autotune and "
                     "kernel_config.enable_flashinfer_autotune "

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -374,10 +374,7 @@ async def init_app_state(
         )
         supported_tasks = _FALLBACK_SUPPORTED_TASKS
 
-    if args.served_model_name is not None:
-        served_model_names = args.served_model_name
-    else:
-        served_model_names = [args.model]
+    served_model_names = args.served_model_name or [args.model]
 
     if args.enable_log_requests:
         request_logger = RequestLogger(max_log_len=args.max_log_len)


### PR DESCRIPTION
 ## Purpose

Introduces a `RuntimeDefault` field mechanism to cleanly express fields that are initialized during runtime rather than at config class instantiation. Previously, config classes like `PassConfig` with fields like `fuse_norm_quant` and `enable_sp` were typed as `bool` but initialized to `None`, requiring `# type: ignore[assignment]` comments and a blanket `_skip_none_validation` field validator to suppress Pydantic errors. This approach was fragile and confused static type checkers.

The new pattern uses `field_name: bool = RuntimeDefault()`, the declared annotation is the true runtime type with no `| None` needed. `RuntimeDefault()` returns a pydantic Field whose default is the shared `RUNTIME_DEFAULT` sentinel (`validate_default=False` skips type coercion of the sentinel). The sentinel is `falsy`, so guards in `__post_init__` that read runtime default fields before initialization behave as if the value were `falsy`, matching the behaviour of the old `None` sentinel. Any extra kwargs are forwarded to `pydantic.Field` and still constrain real values, e.g. `block_size: int = RuntimeDefault(gt=0)` and `max_model_len: int = RuntimeDefault(ge=-1)`.

  There is deliberately no fallback/factory form. Resolution stays where it already lived in the owning class's `__post_init__`/`model_validator` or in `VllmConfig.__post_init__`, so this PR does not move any defaulting logic around. What changes is that the sentinel can no longer escape unnoticed.

  The `@config` decorator automatically detects classes with `RuntimeDefault()` fields and injects `validate_runtime_default_fields_initialized()` directly onto the class, no inheritance required. It raises `ValueError` listing any field that still holds the sentinel. A `HasRuntimeDefaultFields` `runtime_checkable` Protocol lets `validate_runtime_default_fields_recursive` walk the full `VllmConfig` dataclass tree (via `_walk_runtime_default`) so every nested sub config is covered without manual wiring. `normalize_value()` raises on the sentinel too, so an unresolved field cannot silently poison a config hash.

Supporting helpers in `vllm/config/utils.py`:
- `is_runtime_default(value)`: public predicate, so call sites do not reach for the private `_RuntimeDefaultValue` class
- `runtime_default_validator(*fields)`: `mode="wrap"` validator factory for fields that may be passed explicitly as `None` or as an already unresolved sentinel
- `skip_none_validator(*fields)`: replaces the old per file `_skip_none_validation` copies for fields where `None` genuinely stays `None` (`scheduler_cls`, the kernel warmup flags)

Fields where `None` is a real permanent value ("auto-detect", "inherit from the target model", "not applicable") are deliberately left alone.

**Notes:**

- `validate_default=False` only exempts *omitted* fields. Several converted fields are top level CLI flags whose `EngineArgs` default is a copy of the config class attribute and which are forwarded into the config constructor as an explicit kwarg where the sentinel does hit validation. Those fields get `runtime_default_validator(...)`.
- A raw `argparse.Namespace` bypasses pydantic entirely, so `is None` identity checks on `args.<field>` / `self.<field>` see the raw sentinel. Truthy checks are safe (the sentinel is falsy) but identity checks are not. Fixed in `EngineArgs`' offline-tokenizer branch and `api_server.py`'s served model name handling.
- `RuntimeDefault()` also changes what `_compute_kwargs()` reads to build the CLI: the argparse default becomes the sentinel and the annotation drives `type`/`nargs`/`action`. Consequences handled here: the `--spec-method`/`--spec-tokens` shorthands pin their argparse default back to `None` so a bare `vllm serve` no longer builds a `SpeculativeConfig`, `--max-cpu-loras` keeps its `optional_type(int)` wrapper explicitly and `generate_argparse.py` skips the sentinel so generated docs do not render `Default: <RuntimeDefault()>`.
- `served_model_name` was evaluated and intentionally **not** converted: its accepted input (`str | list[str]`) is wider than its resolved type (`str`), and narrowing the annotation would break --served-model-name a b c`.

## Test Plan

```bash
$ pytest tests/engine/test_arg_utils.py -v
$ pytest tests/test_config.py tests/config -v
```

## Test Result

All tests pass.
