### PR TITLE
[Frontend] Improve parse_type error message for JSON dict CLI args

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import json
-from argparse import ArgumentError
+from argparse import ArgumentError, ArgumentTypeError
 from contextlib import AbstractContextManager, nullcontext
 from typing import Annotated, Literal
 
@@ -37,6 +37,31 @@ from vllm.utils.argparse_utils import FlexibleArgumentParser
 def test_parse_type(type, value, expected):
     parse_type_func = parse_type(type)
     assert parse_type_func(value) == expected
+
+
+def test_parse_type_json_error_hint():
+    # Regression test for https://github.com/vllm-project/vllm/issues/39687:
+    # passing the old `key=val,key=val` syntax (removed in #20969) to a
+    # JSON-typed CLI argument produced a useless error that printed the
+    # `json.loads` function object's repr instead of a JSON hint.
+    parse_json = parse_type(json.loads)
+    with pytest.raises(ArgumentTypeError) as exc_info:
+        parse_json("image=4,audio=1")
+    msg = str(exc_info.value)
+    assert "image=4,audio=1" in msg
+    assert "JSON" in msg
+    assert '{"image"' in msg
+    assert "<function" not in msg
+
+
+def test_parse_type_generic_error_message():
+    parse_int = parse_type(int)
+    with pytest.raises(ArgumentTypeError) as exc_info:
+        parse_int("not-a-number")
+    msg = str(exc_info.value)
+    assert "not-a-number" in msg
+    assert "int" in msg
+    assert "<class" not in msg
 
 
 def test_optional_type():

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -137,8 +137,17 @@ def parse_type(return_type: Callable[[str], T]) -> Callable[[str], T]:
         try:
             return return_type(val)
         except ValueError as e:
+            if return_type is json.loads:
+                raise argparse.ArgumentTypeError(
+                    f"Value {val!r} is not valid JSON ({e}). "
+                    "Expected a JSON string, "
+                    'e.g. \'{"image": 4, "audio": 1}\'.'
+                ) from e
+            type_name = getattr(
+                return_type, "__qualname__", getattr(return_type, "__name__", None)
+            ) or repr(return_type)
             raise argparse.ArgumentTypeError(
-                f"Value {val} cannot be converted to {return_type}."
+                f"Value {val!r} cannot be parsed as {type_name}: {e}"
             ) from e
 
     return _parse_type


### PR DESCRIPTION
## Summary

Fixes #39687.

When a dict-typed CLI argument such as `--limit-mm-per-prompt` receives an invalid value (e.g. the legacy `key=val,key=val` form that was removed in #20969), `parse_type` in `vllm/engine/arg_utils.py` formats the error by interpolating `json.loads` directly into an f-string, producing:

```
vllm serve: error: argument --limit-mm-per-prompt: Value image=4,audio=1 cannot be converted to <function loads at 0x7a37a144c5e0>.
```

This is unreadable and gives no hint about the expected JSON syntax.

This PR reworks the `ValueError` branch in `parse_type`:

- Special-case `json.loads` so the message explicitly mentions JSON, includes the underlying parse error, and shows a concrete example:
  ```
  Value 'image=4,audio=1' is not valid JSON (Expecting value: line 1 column 1 (char 0)). Expected a JSON string, e.g. '{\"image\": 4, \"audio\": 1}'.
  ```
- For other callables, use `__qualname__` / `__name__` instead of `repr()` so users see a type name rather than a `<function ...>` or `<class ...>` object address.

Pure error-message change — no behavioural difference for valid input.

## Duplicate check

- \`gh issue view 39687\` — no comments, no assignee.
- \`gh pr list --search \"39687 in:body\"\` — no existing PR.
- \`gh pr list --search \"parse_type error message\"\` — no overlapping PR.

## Test Plan

- [x] \`.venv/bin/python -m pytest tests/engine/test_arg_utils.py -q\` — 56 passed (includes the two new regression tests below).
- [x] \`.venv/bin/python -m pytest tests/engine/test_arg_utils.py::test_parse_type tests/engine/test_arg_utils.py::test_parse_type_json_error_hint tests/engine/test_arg_utils.py::test_parse_type_generic_error_message -v\` — 6 passed.
- [x] \`pre-commit run --files vllm/engine/arg_utils.py tests/engine/test_arg_utils.py\` — all hooks passed (ruff check, ruff format, typos, mypy, SPDX, etc.).

New tests added in \`tests/engine/test_arg_utils.py\`:

- \`test_parse_type_json_error_hint\` — regression for #39687; asserts the error message contains the offending value, mentions JSON, shows a \`{\"image\"\` example, and does not contain \`<function\`.
- \`test_parse_type_generic_error_message\` — asserts non-JSON callables produce a readable type name and do not leak \`<class ...>\` repr.