### PR TITLE
[Core] Immediately evict thinking token blocks from prefix cache

### DIFF
--- a/tests/v1/core/test_thinking_token_cache.py
+++ b/tests/v1/core/test_thinking_token_cache.py
@@ -102,37 +102,58 @@ class TestReasoningTokenCount:
         return req
 
     def test_simple_thinking_block(self):
-        """Count tokens in <think>...</think>."""
+        """Count tokens in <think>...</think> and return first index."""
         # <think>=50, </think>=51, normal tokens are anything else
         req = self._make_request([50, 100, 101, 102, 51, 200, 201])
-        req.update_reasoning_token_count(start_token_id=50, end_token_id=51)
+        first_idx = req.update_reasoning_token_count(
+            start_token_id=50, end_token_id=51)
         # <think>(50) + 100 + 101 + 102 + </think>(51) = 5 tokens
         assert req.num_reasoning_tokens == 5
+        assert first_idx == 0
 
     def test_no_thinking_tokens(self):
-        """No thinking markers -> 0 reasoning tokens."""
+        """No thinking markers -> 0 reasoning tokens, None index."""
         req = self._make_request([200, 201, 202])
-        req.update_reasoning_token_count(start_token_id=50, end_token_id=51)
+        first_idx = req.update_reasoning_token_count(
+            start_token_id=50, end_token_id=51)
         assert req.num_reasoning_tokens == 0
+        assert first_idx is None
 
     def test_all_thinking(self):
         """Entire output is thinking."""
         req = self._make_request([50, 100, 101, 51])
-        req.update_reasoning_token_count(start_token_id=50, end_token_id=51)
+        first_idx = req.update_reasoning_token_count(
+            start_token_id=50, end_token_id=51)
         assert req.num_reasoning_tokens == 4
+        assert first_idx == 0
 
     def test_nested_thinking(self):
         """Nested thinking blocks should be handled by depth counter."""
         req = self._make_request([50, 100, 50, 101, 51, 102, 51, 200])
-        req.update_reasoning_token_count(start_token_id=50, end_token_id=51)
+        first_idx = req.update_reasoning_token_count(
+            start_token_id=50, end_token_id=51)
         # All of [50, 100, 50, 101, 51, 102, 51] = 7 tokens are thinking
         assert req.num_reasoning_tokens == 7
+        assert first_idx == 0
 
     def test_empty_output(self):
-        """Empty output -> 0 reasoning tokens."""
+        """Empty output -> 0 reasoning tokens, None index."""
         req = self._make_request([])
-        req.update_reasoning_token_count(start_token_id=50, end_token_id=51)
+        first_idx = req.update_reasoning_token_count(
+            start_token_id=50, end_token_id=51)
         assert req.num_reasoning_tokens == 0
+        assert first_idx is None
+
+    def test_thinking_starts_mid_output(self):
+        """Thinking tokens starting after some answer tokens."""
+        # Output: [200, 201, <think>, 100, 101, </think>]
+        req = self._make_request([200, 201, 50, 100, 101, 51])
+        first_idx = req.update_reasoning_token_count(
+            start_token_id=50, end_token_id=51)
+        # 4 reasoning tokens: <think>(50), 100, 101, </think>(51)
+        assert req.num_reasoning_tokens == 4
+        # First reasoning token is at output index 2
+        assert first_idx == 2
 
     def test_unmatched_end_token(self):
         """End token without start should be ignored."""

--- a/tests/v1/core/test_thinking_token_cache.py
+++ b/tests/v1/core/test_thinking_token_cache.py
@@ -155,11 +155,40 @@ class TestReasoningTokenCount:
         # First reasoning token is at output index 2
         assert first_idx == 2
 
-    def test_unmatched_end_token(self):
-        """End token without start should be ignored."""
-        req = self._make_request([51, 200, 201])
-        req.update_reasoning_token_count(start_token_id=50, end_token_id=51)
-        assert req.num_reasoning_tokens == 0
+    def test_end_token_without_start_implicit_reasoning(self):
+        """</think> without <think> in output means the model was already
+        in thinking mode (e.g. Qwen3 places <think> in the chat template,
+        MiniMax M2 never generates <think>).  All tokens up to </think>
+        should be counted as reasoning, starting from output position 0."""
+        # Output: [100, 101, 102, </think>, 200, 201]
+        req = self._make_request([100, 101, 102, 51, 200, 201])
+        first_idx = req.update_reasoning_token_count(
+            start_token_id=50, end_token_id=51)
+        # Tokens 0..3 inclusive (100, 101, 102, </think>) = 4 reasoning
+        assert req.num_reasoning_tokens == 4
+        assert first_idx == 0
+
+    def test_end_token_only_all_thinking(self):
+        """Entire output is thinking, closed by </think> at the end."""
+        req = self._make_request([100, 101, 102, 51])
+        first_idx = req.update_reasoning_token_count(
+            start_token_id=50, end_token_id=51)
+        assert req.num_reasoning_tokens == 4
+        assert first_idx == 0
+
+    def test_orphan_end_token_after_matched_block(self):
+        """An orphan </think> after a properly matched block should not
+        change the count (only the first unmatched </think> triggers
+        implicit reasoning)."""
+        # Output: [<think>, 100, </think>, 200, </think>]
+        req = self._make_request([50, 100, 51, 200, 51])
+        first_idx = req.update_reasoning_token_count(
+            start_token_id=50, end_token_id=51)
+        # Matched block: <think>(50) + 100 + </think>(51) = 3 tokens
+        # The trailing orphan </think> does not trigger implicit mode
+        # because <think> was already found in the output.
+        assert req.num_reasoning_tokens == 3
+        assert first_idx == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/core/test_thinking_token_cache.py
+++ b/tests/v1/core/test_thinking_token_cache.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for thinking token prefix cache eviction.
+
+When serving reasoning models with --reasoning-parser, thinking tokens
+(<think>...</think>) should be immediately evicted from the prefix cache
+on request completion since they are unreachable in multi-turn prompts.
+
+See: https://github.com/vllm-project/vllm/issues/39321
+"""
+
+import pytest
+
+from vllm.v1.core.kv_cache_utils import (
+    FreeKVCacheBlockQueue,
+    KVCacheBlock,
+)
+from vllm.v1.request import Request
+
+
+# ---------------------------------------------------------------------------
+# FreeKVCacheBlockQueue.prepend_n tests
+# ---------------------------------------------------------------------------
+
+
+class TestPrependN:
+    """Test that prepend_n inserts blocks at the head of the free queue."""
+
+    def test_prepend_n_basic(self):
+        """Prepended blocks should be popped first by popleft."""
+        blocks = [KVCacheBlock(block_id=i) for i in range(5)]
+        queue = FreeKVCacheBlockQueue(blocks)
+
+        # Pop all original blocks
+        original = [queue.popleft() for _ in range(5)]
+        assert [b.block_id for b in original] == [0, 1, 2, 3, 4]
+
+        # Now append some blocks to the tail (normal path)
+        tail_blocks = [KVCacheBlock(block_id=10), KVCacheBlock(block_id=11)]
+        queue.append_n(tail_blocks)
+
+        # Prepend some blocks to the head
+        head_blocks = [KVCacheBlock(block_id=20), KVCacheBlock(block_id=21)]
+        queue.prepend_n(head_blocks)
+
+        assert queue.num_free_blocks == 4
+
+        # Head blocks should come out first
+        popped = [queue.popleft() for _ in range(4)]
+        assert [b.block_id for b in popped] == [20, 21, 10, 11]
+
+    def test_prepend_n_empty_list(self):
+        """Prepending empty list should be a no-op."""
+        blocks = [KVCacheBlock(block_id=i) for i in range(3)]
+        queue = FreeKVCacheBlockQueue(blocks)
+        queue.prepend_n([])
+        assert queue.num_free_blocks == 3
+        # First block should still be block 0
+        assert queue.popleft().block_id == 0
+
+    def test_prepend_n_to_empty_queue(self):
+        """Prepending to an empty queue should work."""
+        queue = FreeKVCacheBlockQueue([])
+        assert queue.num_free_blocks == 0
+
+        new_blocks = [KVCacheBlock(block_id=5), KVCacheBlock(block_id=6)]
+        queue.prepend_n(new_blocks)
+        assert queue.num_free_blocks == 2
+        assert queue.popleft().block_id == 5
+        assert queue.popleft().block_id == 6
+
+    def test_prepend_then_append_ordering(self):
+        """Verify ordering: prepended < existing < appended."""
+        queue = FreeKVCacheBlockQueue([KVCacheBlock(block_id=1)])
+
+        queue.prepend_n([KVCacheBlock(block_id=0)])
+        queue.append_n([KVCacheBlock(block_id=2)])
+
+        popped = [queue.popleft() for _ in range(3)]
+        assert [b.block_id for b in popped] == [0, 1, 2]
+
+
+# ---------------------------------------------------------------------------
+# Request.update_reasoning_token_count tests
+# ---------------------------------------------------------------------------
+
+
+class TestReasoningTokenCount:
+    """Test reasoning token counting on the Request object."""
+
+    def _make_request(self, output_token_ids: list[int]) -> Request:
+        """Create a minimal Request with the given output tokens."""
+        from vllm.sampling_params import SamplingParams
+
+        req = Request(
+            request_id="test",
+            prompt_token_ids=[1, 2, 3],
+            sampling_params=SamplingParams(max_tokens=100),
+            pooling_params=None,
+        )
+        req.append_output_token_ids(output_token_ids)
+        return req
+
+    def test_simple_thinking_block(self):
+        """Count tokens in <think>...</think>."""
+        # <think>=50, </think>=51, normal tokens are anything else
+        req = self._make_request([50, 100, 101, 102, 51, 200, 201])
+        req.update_reasoning_token_count(start_token_id=50, end_token_id=51)
+        # <think>(50) + 100 + 101 + 102 + </think>(51) = 5 tokens
+        assert req.num_reasoning_tokens == 5
+
+    def test_no_thinking_tokens(self):
+        """No thinking markers -> 0 reasoning tokens."""
+        req = self._make_request([200, 201, 202])
+        req.update_reasoning_token_count(start_token_id=50, end_token_id=51)
+        assert req.num_reasoning_tokens == 0
+
+    def test_all_thinking(self):
+        """Entire output is thinking."""
+        req = self._make_request([50, 100, 101, 51])
+        req.update_reasoning_token_count(start_token_id=50, end_token_id=51)
+        assert req.num_reasoning_tokens == 4
+
+    def test_nested_thinking(self):
+        """Nested thinking blocks should be handled by depth counter."""
+        req = self._make_request([50, 100, 50, 101, 51, 102, 51, 200])
+        req.update_reasoning_token_count(start_token_id=50, end_token_id=51)
+        # All of [50, 100, 50, 101, 51, 102, 51] = 7 tokens are thinking
+        assert req.num_reasoning_tokens == 7
+
+    def test_empty_output(self):
+        """Empty output -> 0 reasoning tokens."""
+        req = self._make_request([])
+        req.update_reasoning_token_count(start_token_id=50, end_token_id=51)
+        assert req.num_reasoning_tokens == 0
+
+    def test_unmatched_end_token(self):
+        """End token without start should be ignored."""
+        req = self._make_request([51, 200, 201])
+        req.update_reasoning_token_count(start_token_id=50, end_token_id=51)
+        assert req.num_reasoning_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# Integration: thinking blocks evicted before normal blocks
+# ---------------------------------------------------------------------------
+
+
+class TestThinkingBlockEviction:
+    """Test that thinking blocks are evicted before normal cached blocks."""
+
+    def _make_block(self, block_id: int, ref_cnt: int = 1,
+                    block_hash: int | None = None) -> KVCacheBlock:
+        block = KVCacheBlock(block_id=block_id)
+        block.ref_cnt = ref_cnt
+        if block_hash is not None:
+            from vllm.v1.core.kv_cache_utils import make_block_hash_with_group_id
+            block.block_hash = make_block_hash_with_group_id(
+                (block_hash, ()), 0
+            )
+        return block
+
+    def test_free_blocks_immediate_evict_prepends_to_head(self):
+        """Blocks freed via immediate_evict should appear before
+        blocks freed via normal free_blocks."""
+        from vllm.v1.core.block_pool import BlockPool
+
+        num_blocks = 20
+        pool = BlockPool(
+            num_gpu_blocks=num_blocks,
+            enable_caching=True,
+            hash_block_size=16,
+            enable_kv_cache_events=False,
+        )
+
+        # Allocate some blocks
+        normal_blocks = pool.get_new_blocks(2)
+        thinking_blocks = pool.get_new_blocks(2)
+
+        # Give them hashes so they're "cached"
+        for i, blk in enumerate(normal_blocks):
+            blk.block_hash = (i, (), 0)
+            pool.cached_block_hash_to_block.insert((i, (), 0), blk)
+        for i, blk in enumerate(thinking_blocks):
+            h = (100 + i, (), 0)
+            blk.block_hash = h
+            pool.cached_block_hash_to_block.insert(h, blk)
+
+        # Free normal blocks (go to tail)
+        pool.free_blocks(normal_blocks)
+        # Free thinking blocks with immediate evict (go to head)
+        pool.free_blocks_immediate_evict(thinking_blocks)
+
+        # Now allocate 2 blocks - should get the thinking blocks first
+        # (they were prepended to head)
+        new_blocks = pool.get_new_blocks(2)
+        new_ids = {b.block_id for b in new_blocks}
+        thinking_ids = {b.block_id for b in thinking_blocks}
+        assert new_ids == thinking_ids
+
+    def test_immediate_evict_removes_hash(self):
+        """Blocks freed via immediate_evict should have their hash removed."""
+        from vllm.v1.core.block_pool import BlockPool
+
+        pool = BlockPool(
+            num_gpu_blocks=10,
+            enable_caching=True,
+            hash_block_size=16,
+            enable_kv_cache_events=False,
+        )
+
+        blocks = pool.get_new_blocks(1)
+        blk = blocks[0]
+        block_hash = (42, (), 0)
+        blk.block_hash = block_hash
+        pool.cached_block_hash_to_block.insert(block_hash, blk)
+
+        pool.free_blocks_immediate_evict(blocks)
+
+        # Hash should be removed
+        assert blk.block_hash is None
+        # Block should be in the free queue
+        assert pool.free_block_queue.num_free_blocks > 0

--- a/vllm/config/reasoning.py
+++ b/vllm/config/reasoning.py
@@ -26,6 +26,13 @@ class ReasoningConfig:
     reasoning_end_str: str = ""
     """String that indicates the end of reasoning content."""
 
+    cache_reasoning_tokens: bool = False
+    """Whether to keep thinking tokens in the prefix cache after request
+    completion. When False (default), thinking token blocks are immediately
+    evicted since most clients strip thinking from subsequent turns, making
+    them unreachable dead weight. Set to True if your client includes
+    thinking tokens in follow-up prompts."""
+
     _reasoning_start_token_ids: list[int] | None = field(
         default=None, init=False, repr=False
     )

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -421,6 +421,31 @@ class BlockPool:
             [block for block in blocks_list if block.ref_cnt == 0 and not block.is_null]
         )
 
+    def free_blocks_immediate_evict(
+        self, ordered_blocks: Iterable[KVCacheBlock]
+    ) -> None:
+        """Free blocks and immediately evict them from the prefix cache.
+
+        Unlike ``free_blocks`` which appends freed blocks to the *tail* of the
+        free queue (keeping them cached for potential prefix reuse), this method
+        removes block hashes and prepends freed blocks to the *head* so they
+        are the first to be reallocated.
+
+        Use this for blocks whose cached KV entries will never be matched by
+        future requests (e.g. thinking token blocks that clients strip from
+        subsequent turns).
+        """
+        blocks_list = list(ordered_blocks)
+        evictable: list[KVCacheBlock] = []
+        for block in blocks_list:
+            # Remove the block hash so it can't be prefix-matched.
+            self._maybe_evict_cached_block(block)
+            block.ref_cnt -= 1
+            if block.ref_cnt == 0 and not block.is_null:
+                evictable.append(block)
+        # Prepend to head: these blocks will be reused first.
+        self.free_block_queue.prepend_n(evictable)
+
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.
 

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -188,15 +188,17 @@ class KVCacheCoordinator(ABC):
         for manager in self.single_type_managers:
             manager.cache_blocks(request, num_computed_tokens)
 
-    def free(self, request_id: str) -> None:
+    def free(self, request_id: str, num_thinking_blocks: int = 0) -> None:
         """
         Free the blocks for the request.
 
         Args:
             request_id: The request ID.
+            num_thinking_blocks: Number of trailing blocks to immediately
+                evict from prefix cache (thinking token blocks).
         """
         for manager in self.single_type_managers:
-            manager.free(request_id)
+            manager.free(request_id, num_thinking_blocks=num_thinking_blocks)
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> list[int]:
         """

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -426,15 +426,22 @@ class KVCacheManager:
 
         return self.create_kv_cache_blocks(new_blocks)
 
-    def free(self, request: Request) -> None:
+    def free(
+        self, request: Request, num_thinking_blocks: int = 0
+    ) -> None:
         """Free the blocks allocated for the request.
         We free the blocks in reverse order so that the tail blocks are evicted
         first when caching is enabled.
 
         Args:
             request: The request to free the blocks.
+            num_thinking_blocks: Number of trailing blocks to immediately
+                evict from prefix cache (thinking token blocks).
         """
-        self.coordinator.free(request.request_id)
+        self.coordinator.free(
+            request.request_id,
+            num_thinking_blocks=num_thinking_blocks,
+        )
 
     def remove_skipped_blocks(
         self, request_id: str, total_computed_tokens: int

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -345,6 +345,37 @@ class FreeKVCacheBlockQueue:
 
         self.num_free_blocks += len(blocks)
 
+    def prepend_n(self, blocks: list[KVCacheBlock]) -> None:
+        """Put a list of blocks at the front of the free list so they are
+        the first to be reused by ``popleft``/``popleft_n``.
+
+        This is used for blocks that should be evicted as soon as possible
+        (e.g. thinking token blocks that will never be prefix-matched).
+
+        Args:
+            blocks: The blocks to prepend.
+        """
+        if len(blocks) == 0:
+            return
+
+        first_real = self.fake_free_list_head.next_free_block
+        assert first_real is not None, (
+            "next_free_block of fake_free_list_head should always exist"
+        )
+
+        # Build the chain: fake_head -> blocks[0] -> ... -> blocks[-1]
+        prev = self.fake_free_list_head
+        for block in blocks:
+            prev.next_free_block = block
+            block.prev_free_block = prev
+            prev = block
+
+        # Connect the last prepended block to the original first block
+        prev.next_free_block = first_real
+        first_real.prev_free_block = prev
+
+        self.num_free_blocks += len(blocks)
+
     def get_all_free_blocks(self) -> list[KVCacheBlock]:
         """Get all free blocks in the free list. Mainly used for testing.
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1839,8 +1839,46 @@ class Scheduler(SchedulerInterface):
 
     def _free_blocks(self, request: Request):
         assert request.is_finished()
-        self.kv_cache_manager.free(request)
+        num_thinking_blocks = self._get_num_thinking_blocks(request)
+        self.kv_cache_manager.free(
+            request, num_thinking_blocks=num_thinking_blocks
+        )
         del self.requests[request.request_id]
+
+    def _get_num_thinking_blocks(self, request: Request) -> int:
+        """Compute how many trailing blocks contain thinking/answer tokens
+        that should be immediately evicted from the prefix cache.
+
+        Returns 0 when reasoning is disabled, caching of reasoning tokens
+        is opted-in, or the output contains no thinking tokens.
+        """
+        reasoning_config = self.vllm_config.reasoning_config
+        if (
+            reasoning_config is None
+            or not reasoning_config.enabled
+            or reasoning_config.cache_reasoning_tokens
+        ):
+            return 0
+
+        start_ids = reasoning_config.reasoning_start_token_ids
+        end_ids = reasoning_config.reasoning_end_token_ids
+        if not start_ids or not end_ids:
+            return 0
+
+        # Count reasoning tokens in the output using the start/end markers.
+        request.update_reasoning_token_count(start_ids[0], end_ids[0])
+        if request.num_reasoning_tokens == 0:
+            return 0
+
+        # All output tokens (thinking + answer) occupy blocks after the
+        # prompt prefix.  Answer tokens after thinking have mismatched
+        # RoPE positions and cannot be reused either, so we evict all
+        # post-prompt blocks.
+        num_prompt_blocks = request.num_prompt_tokens // self.block_size
+        num_total_blocks = (
+            (request.num_tokens + self.block_size - 1) // self.block_size
+        )
+        return max(0, num_total_blocks - num_prompt_blocks)
 
     @property
     def pause_state(self) -> PauseState:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1865,20 +1865,26 @@ class Scheduler(SchedulerInterface):
         if not start_ids or not end_ids:
             return 0
 
-        # Count reasoning tokens in the output using the start/end markers.
-        request.update_reasoning_token_count(start_ids[0], end_ids[0])
-        if request.num_reasoning_tokens == 0:
+        # Count reasoning tokens and find the first occurrence.
+        first_reasoning_idx = request.update_reasoning_token_count(
+            start_ids[0], end_ids[0]
+        )
+        if request.num_reasoning_tokens == 0 or first_reasoning_idx is None:
             return 0
 
-        # All output tokens (thinking + answer) occupy blocks after the
-        # prompt prefix.  Answer tokens after thinking have mismatched
-        # RoPE positions and cannot be reused either, so we evict all
-        # post-prompt blocks.
-        num_prompt_blocks = request.num_prompt_tokens // self.block_size
+        # Evict blocks starting from the one containing the first
+        # reasoning token.  Output tokens before <think> have correct
+        # RoPE positions and are reusable in multi-turn.  Tokens at or
+        # after reasoning have mismatched positions if reasoning is
+        # stripped in subsequent turns.
+        first_evict_block_idx = (
+            (request.num_prompt_tokens + first_reasoning_idx)
+            // self.block_size
+        )
         num_total_blocks = (
             (request.num_tokens + self.block_size - 1) // self.block_size
         )
-        return max(0, num_total_blocks - num_prompt_blocks)
+        return max(0, num_total_blocks - first_evict_block_idx)
 
     @property
     def pause_state(self) -> PauseState:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1851,6 +1851,21 @@ class Scheduler(SchedulerInterface):
 
         Returns 0 when reasoning is disabled, caching of reasoning tokens
         is opted-in, or the output contains no thinking tokens.
+
+        Known limitations:
+        - Speculative decoding: ``allocate_slots()`` may allocate
+          lookahead blocks beyond ``request.num_tokens``.  The block
+          count here is based on finalized tokens only, so the
+          prompt/thinking split in ``free()`` could be off by a few
+          blocks when speculative decoding is active.
+        - Hybrid KV cache groups: this method computes a single
+          ``num_thinking_blocks`` using ``self.block_size``, but hybrid
+          cache groups may have different effective block sizes.  Passing
+          the same count to every group may over-evict for groups with
+          larger blocks.
+        - Multi-token delimiters: only ``start_ids[0]`` and
+          ``end_ids[0]`` are used.  Models with multi-token reasoning
+          delimiters are not yet supported.
         """
         reasoning_config = self.vllm_config.reasoning_config
         if (

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -273,21 +273,44 @@ class SingleTypeKVCacheManager(ABC):
 
         self.num_cached_block[request.request_id] = num_full_blocks
 
-    def free(self, request_id: str) -> None:
+    def free(
+        self, request_id: str, num_thinking_blocks: int = 0
+    ) -> None:
         """
         Free the blocks for the request.
 
         Args:
             request_id: The request ID.
+            num_thinking_blocks: Number of trailing blocks that contain
+                thinking/answer tokens and should be immediately evicted
+                from the prefix cache (prepended to the head of the free
+                queue).  When 0, all blocks follow the normal eviction
+                path.
         """
         # Default to [] in case a request is freed (aborted) before alloc.
         req_blocks = self.req_to_blocks.pop(request_id, [])
 
-        # Free blocks in reverse order so that the tail blocks are
-        # freed first.
-        ordered_blocks = reversed(req_blocks)
+        if num_thinking_blocks > 0 and len(req_blocks) > 0:
+            # Split into prompt blocks (keep cached, normal LRU) and
+            # thinking+answer blocks (evict immediately).
+            # Due to RoPE position mismatch, answer tokens after thinking
+            # are also unreusable, so everything after prompt blocks gets
+            # evicted.
+            num_prompt_blocks = max(0, len(req_blocks) - num_thinking_blocks)
+            prompt_blocks = req_blocks[:num_prompt_blocks]
+            thinking_blocks = req_blocks[num_prompt_blocks:]
 
-        self.block_pool.free_blocks(ordered_blocks)
+            # Normal path for prompt blocks (reversed = tail first)
+            self.block_pool.free_blocks(reversed(prompt_blocks))
+            # Immediate evict for thinking+answer blocks (head of queue)
+            self.block_pool.free_blocks_immediate_evict(
+                reversed(thinking_blocks)
+            )
+        else:
+            # Normal path: free in reverse order so that the tail blocks
+            # are freed first.
+            self.block_pool.free_blocks(reversed(req_blocks))
+
         self.num_cached_block.pop(request_id, None)
 
     @abstractmethod
@@ -1008,11 +1031,13 @@ class MambaManager(SingleTypeKVCacheManager):
                 self._allocated_block_reqs.add(request_id)
                 return req_blocks[prev_block_len:]
 
-    def free(self, request_id: str) -> None:
+    def free(
+        self, request_id: str, num_thinking_blocks: int = 0
+    ) -> None:
         if self.mamba_cache_mode == "align":
             self._allocated_block_reqs.discard(request_id)
             self.last_state_block_idx.pop(request_id, None)
-        super().free(request_id)
+        super().free(request_id, num_thinking_blocks=num_thinking_blocks)
 
     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
         """

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -173,6 +173,11 @@ class Request:
         # None entry in the queue means finished.
         self.streaming_queue: deque[StreamingUpdate | None] | None = None
 
+        # Number of reasoning/thinking tokens in the output. Set by
+        # update_reasoning_token_count() at request completion. Used to
+        # determine which blocks to immediately evict from the prefix cache.
+        self.num_reasoning_tokens: int = 0
+
     @classmethod
     def from_engine_core_request(
         cls,
@@ -281,6 +286,30 @@ class Request:
         prefill_stats = self.prefill_stats
         self.prefill_stats = None
         return prefill_stats
+
+    def update_reasoning_token_count(
+        self,
+        start_token_id: int,
+        end_token_id: int,
+    ) -> None:
+        """Count all tokens within thinking markers (e.g. <think>...</think>)
+        in the output, including the markers themselves.
+
+        Uses a depth counter so nested spans are handled safely. Only
+        single-token start/end markers are supported for now.
+        """
+        count = 0
+        depth = 0
+        for tid in self._output_token_ids:
+            if tid == start_token_id:
+                depth += 1
+                count += 1
+            elif tid == end_token_id and depth > 0:
+                depth -= 1
+                count += 1
+            elif depth > 0:
+                count += 1
+        self.num_reasoning_tokens = count
 
     def __lt__(self, other: "Request") -> bool:
         """

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -300,21 +300,41 @@ class Request:
 
         Uses a depth counter so nested spans are handled safely. Only
         single-token start/end markers are supported for now.
+
+        Some models (Qwen3, MiniMax M2) place ``<think>`` in the prompt
+        template or omit it entirely — the model only generates
+        ``</think>`` to end reasoning.  When ``</think>`` is found in the
+        output without a preceding ``<think>``, all tokens from the start
+        of the output up to ``</think>`` are treated as reasoning (i.e.
+        the model was already in thinking mode from the prompt).
         """
         count = 0
         depth = 0
         first_idx: int | None = None
+        has_end_without_start = False
         for i, tid in enumerate(self._output_token_ids):
             if tid == start_token_id:
                 if first_idx is None:
                     first_idx = i
                 depth += 1
                 count += 1
-            elif tid == end_token_id and depth > 0:
-                depth -= 1
-                count += 1
+            elif tid == end_token_id:
+                if depth > 0:
+                    depth -= 1
+                    count += 1
+                elif first_idx is None:
+                    # </think> found without any preceding <think> in
+                    # the output.  The model was already in thinking
+                    # mode (start marker is in the prompt or implicit).
+                    # Retroactively count all tokens from position 0.
+                    has_end_without_start = True
+                    count = i + 1  # tokens 0..i inclusive
             elif depth > 0:
                 count += 1
+
+        if has_end_without_start and first_idx is None:
+            first_idx = 0
+
         self.num_reasoning_tokens = count
         return first_idx
 

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -291,17 +291,23 @@ class Request:
         self,
         start_token_id: int,
         end_token_id: int,
-    ) -> None:
+    ) -> int | None:
         """Count all tokens within thinking markers (e.g. <think>...</think>)
         in the output, including the markers themselves.
+
+        Returns the index of the first reasoning token in the output, or
+        ``None`` if no reasoning tokens are found.
 
         Uses a depth counter so nested spans are handled safely. Only
         single-token start/end markers are supported for now.
         """
         count = 0
         depth = 0
-        for tid in self._output_token_ids:
+        first_idx: int | None = None
+        for i, tid in enumerate(self._output_token_ids):
             if tid == start_token_id:
+                if first_idx is None:
+                    first_idx = i
                 depth += 1
                 count += 1
             elif tid == end_token_id and depth > 0:
@@ -310,6 +316,7 @@ class Request:
             elif depth > 0:
                 count += 1
         self.num_reasoning_tokens = count
+        return first_idx
 
     def __lt__(self, other: "Request") -> bool:
         """


### PR DESCRIPTION
## Summary

When serving reasoning models (DeepSeek-R1, QwQ, etc.) with `--reasoning-parser`, all output tokens — including `<think>...</think>` tokens — are cached in the prefix cache. Since most clients strip thinking tokens from subsequent turns (per [DeepSeek API docs](https://api-docs.deepseek.com/guides/thinking_mode)), these cached entries create dead branches that:

1. **Waste GPU memory**: ~1.3–1.6 GB per dead branch (5000 thinking tokens × 256–320 KB/token)
2. **Block prefix matching**: answer tokens stranded behind thinking branches are unreachable, forcing recomputation every turn
3. **Compete with useful entries in LRU eviction** — thinking blocks are `append_n`'d to the tail of the free queue (most recently used), so they're the *last* to be evicted despite being unreachable

With 50 concurrent conversations, dead branches consume 65–80 GB.

A benchmark on the equivalent SGLang fix (sgl-project/sglang#22617) measured with QwQ-32B on 2× B300 GPUs:

| Metric | Baseline | With fix | Delta |
|--------|----------|----------|-------|
| Overall cache hit rate | 11.1% | 17.1% | **+6.0%** |
| TTFT p50 | 9.98s | 8.96s | **−1.02s** |

## Approach

On request completion, if reasoning tokens are detected:

- **Prompt blocks** → normal eviction path (tail of free queue, hash retained for prefix matching)
- **Thinking + answer blocks** → immediately evicted: hash removed from `cached_block_hash_to_block`, block prepended to **head** of free queue (first to be reused)

Answer tokens after thinking are also evicted because their RoPE positional encodings are mismatched — computed at positions `[input_len + thinking_len, ...]` but would appear at `[input_len, ...]` in the next turn without thinking.

Adds `cache_reasoning_tokens` config flag (default `False`) so users who include thinking tokens in subsequent prompts (e.g., MiniMax models that append thinking to visible content) can opt in to caching them.

## Changes

| File | Change |
|------|--------|
| `vllm/config/reasoning.py` | Add `cache_reasoning_tokens: bool = False` |
| `vllm/v1/request.py` | Add `num_reasoning_tokens` + depth-based counting method |
| `vllm/v1/core/kv_cache_utils.py` | Add `FreeKVCacheBlockQueue.prepend_n()` (head insertion) |
| `vllm/v1/core/block_pool.py` | Add `BlockPool.free_blocks_immediate_evict()` |
| `vllm/v1/core/single_type_kv_cache_manager.py` | Split `free()` into prompt vs thinking block paths |
| `vllm/v1/core/kv_cache_coordinator.py` | Pass through `num_thinking_blocks` |
| `vllm/v1/core/kv_cache_manager.py` | Pass through `num_thinking_blocks` |
| `vllm/v1/core/sched/scheduler.py` | Add `_get_num_thinking_blocks()` orchestration |

## Test plan

- [x] Unit tests for `prepend_n()` (basic, empty list, empty queue, ordering)
- [x] Unit tests for reasoning token counting (simple, nested, edge cases)
- [x] Integration tests for `free_blocks_immediate_evict()` (head ordering, hash removal)
- [x] Existing `test_prefix_caching.py` passes (56/56, no regressions)
- [x] Existing `test_kv_cache_utils.py` passes (no regressions)
- [ ] E2E multi-turn test with reasoning model (needs GPU CI)

## Related work

- Fixes https://github.com/vllm-project/vllm/issues/39321
- **SGLang landed the parallel fix on 2026-04-21**: [sgl-project/sglang#23315](https://github.com/sgl-project/sglang/pull/23315), closing the mirror issue [sgl-project/sglang#22373](https://github.com/sgl-project/sglang/issues/22373) and superseding community PRs #22617 and #22950. Same direction as this PR: opt-in flag (`--strip-thinking-cache`), strip both thinking and answer tokens at cache commit, same RoPE-position-shift rationale for why answer tokens can't be safely reused either.
- SGLang's implementation is ~70 lines because they only insert into the radix tree at request-finish, so a single `_cache_commit_len()` helper covers every cache variant. vLLM caches eagerly during generation (`cache_blocks()` fires every scheduler step), so this PR hooks at the free path instead — different shape for the same fix.

AI assistance was used (Claude). All changes reviewed and tested by human submitter.
