### PR TITLE
[Bugfix] FlexAttention: reject block_size < 16

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -172,7 +172,7 @@ Priority is **1 = highest** (tried first).
 | `FLASH_ATTN` | FA3* | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %16 | Any | ✅ | ❌ | ✅ | All | 9.x |
 | `FLASH_ATTN` | FA4* | fp16, bf16 | `auto`, `float16`, `bfloat16` | %16 | Any | ❌ | ❌ | ✅ | All | ≥10.0 |
 | `FLASH_ATTN_DIFFKV` | | fp16, bf16 | `auto` | Any | Any | ❌ | ❌ | ✅ | Decoder | Any |
-| `FLEX_ATTENTION` | | fp16, bf16, fp32 | `auto`, `float16`, `bfloat16` | Any | Any | ❌ | ✅ | ❌ | Decoder, Encoder Only | Any |
+| `FLEX_ATTENTION` | | fp16, bf16, fp32 | `auto`, `float16`, `bfloat16` | %16 | Any | ❌ | ✅ | ❌ | Decoder, Encoder Only | Any |
 | `ROCM_AITER_FA` | | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | 16, 32 | 64, 128, 256 | ❌ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_AITER_UNIFIED_ATTN` | | fp16, bf16 | `auto` | %16 | Any | ✅ | ✅ | ❌ | All | N/A |
 | `ROCM_ATTN` | | fp16, bf16, fp32 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %16 | 32, 64, 80, 96, 128, 160, 192, 224, 256 | ❌ | ✅ | ❌ | Decoder, Encoder, Encoder Only | N/A |

--- a/tests/kernels/attention/test_attention_selector.py
+++ b/tests/kernels/attention/test_attention_selector.py
@@ -427,3 +427,17 @@ def test_per_head_quant_scales_backend_selection(
                     use_per_head_quant_scales=True,
                 )
             assert backend_name in str(exc_info.value)
+
+
+def test_flex_attention_rejects_small_block_sizes():
+    """FlexAttention's Triton kernel requires block tiles >= 16. Block sizes
+    below that used to slip through backend selection and crash during Triton
+    codegen (issue #39340); ensure they are now rejected up front, matching
+    the other Triton-based backends."""
+    from vllm.v1.attention.backends.flex_attention import FlexAttentionBackend
+
+    assert not FlexAttentionBackend.supports_block_size(1)
+    assert not FlexAttentionBackend.supports_block_size(8)
+    assert FlexAttentionBackend.supports_block_size(16)
+    assert FlexAttentionBackend.supports_block_size(32)
+    assert FlexAttentionBackend.supports_block_size(64)

--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -35,6 +35,7 @@ from vllm.v1.attention.backend import (
     AttentionMetadataBuilder,
     AttentionType,
     CommonAttentionMetadata,
+    MultipleOf,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec
 
@@ -85,6 +86,14 @@ class FlexAttentionBackend(AttentionBackend):
     ]
 
     forward_includes_kv_cache_update: bool = False
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        # The FlexAttention Triton kernel requires BLOCK tiles of at least
+        # 16. Smaller block sizes silently reach torch.compile and crash
+        # during Triton codegen, so reject them at backend selection time
+        # (matching FlashAttention / TritonAttention / FlashInfer behavior).
+        return [MultipleOf(16)]
 
     @staticmethod
     def get_name() -> str:
@@ -1140,13 +1149,13 @@ def get_kernel_options(
         kernel_options["BLOCK_N"] = 16
         kernel_options["IS_DIVISIBLE"] = False
         return kernel_options
+    block_lower_bound = 16
     if use_direct_build:
-        kernel_options["BLOCK_M"] = block_m
-        kernel_options["BLOCK_N"] = block_n
+        kernel_options["BLOCK_M"] = max(block_m, block_lower_bound)
+        kernel_options["BLOCK_N"] = max(block_n, block_lower_bound)
         return kernel_options
     else:
         preferred_block = 32 if query.dtype == torch.float32 else 64
-        block_lower_bound = 16
 
         block_m_candidate = ensure_divisible(preferred_block, block_m)
         block_n_candidate = ensure_divisible(preferred_block, block_n)


### PR DESCRIPTION
## Summary

`block_size=8` with FlexAttention currently blows up inside Triton
codegen on the first forward pass. `FlexAttentionBackend` was missing a
`get_supported_kernel_block_sizes` override and inherited the base
`[MultipleOf(1)]` default, so anything smaller than the kernel's real
minimum (16) slipped past backend selection and only failed deep inside
`torch.compile`.

The minimum `block_lower_bound = 16` is already hard-coded inside
`get_kernel_options`, but only in the non-direct-build branch — the
direct-build path (torch >= 2.9) skipped it. So the 16 minimum was
effectively only half-applied.

Two small changes for the same root cause:

- Override `get_supported_kernel_block_sizes` on `FlexAttentionBackend`
  to return `[MultipleOf(16)]`, so unsupported block sizes are rejected
  up front with the usual "block_size not supported" error, matching
  what FA / Triton / FlashInfer already do.
- Lift `block_lower_bound = 16` out of the non-direct-build branch of
  `get_kernel_options` and apply `max(..., 16)` in the direct-build
  branch as well, so `BLOCK_M` / `BLOCK_N` can't drop below 16 even if
  a smaller tile is routed through.

The attention-backend doc table was regenerated by the pre-commit hook
(`Any` -> `%16` for `FLEX_ATTENTION`).

Fixes #39340

## Duplicate check

- `gh issue view 39340 --comments` — no one has claimed this issue, no
  in-progress work.
- `gh pr list --state open --search "39340 in:body"` — no open PR
  references this issue.
- `gh pr list --state open --search "FlexAttention block_size"` — no
  overlapping PR.

## Test Plan

- [x] `.venv/bin/python -m pytest tests/kernels/attention/test_attention_selector.py -v`
      → 17 passed, 10 skipped (GPU-gated), 0 failed. Includes the new
      `test_flex_attention_rejects_small_block_sizes` unit test which
      asserts `FlexAttentionBackend.supports_block_size` returns False
      for 1 and 8, and True for 16/32/64. No GPU required.
- [x] `pre-commit run --files ...` all hooks green (ruff, mypy, SPDX,
      attention-backend-docs, etc).

### Test code

```python
def test_flex_attention_rejects_small_block_sizes():
    from vllm.v1.attention.backends.flex_attention import FlexAttentionBackend

    assert not FlexAttentionBackend.supports_block_size(1)
    assert not FlexAttentionBackend.supports_block_size(8)
    assert FlexAttentionBackend.supports_block_size(16)
    assert FlexAttentionBackend.supports_block_size(32)
    assert FlexAttentionBackend.supports_block_size(64)
```