### PR TITLE
[ROCm] Fallback SwigluOAI activation when _C op is absent

### DIFF
--- a/tests/kernels/core/test_activation.py
+++ b/tests/kernels/core/test_activation.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import random
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 import torch
@@ -234,3 +236,123 @@ def test_activation(
 
     out = torch.empty_like(x)
     opcheck(fn, (out, x))
+
+
+@pytest.mark.parametrize("num_tokens", [7, 83])
+@pytest.mark.parametrize("d", [512])
+@pytest.mark.parametrize("dtype", [torch.float, torch.bfloat16])
+@torch.inference_mode()
+def test_swigluoai_and_mul_rocm_no_c_ext(
+    num_tokens: int,
+    d: int,
+    dtype: torch.dtype,
+) -> None:
+    """Regression test for ROCm/cuda-alike builds without the custom op."""
+    x = torch.randn(num_tokens, 2 * d, dtype=dtype)
+    empty_c = SimpleNamespace()
+    fake_compilation_config = SimpleNamespace(
+        custom_ops=["all"],
+        enabled_custom_ops=set(),
+        disabled_custom_ops=set(),
+    )
+
+    with (
+        patch(
+            "vllm.model_executor.layers.activation.current_platform.is_cuda_alike",
+            return_value=True,
+        ),
+        patch(
+            "vllm.model_executor.layers.activation.current_platform.is_rocm",
+            return_value=True,
+        ),
+        patch(
+            "vllm.model_executor.layers.activation.current_platform.is_xpu",
+            return_value=False,
+        ),
+        patch(
+            "vllm.model_executor.custom_op.current_platform.is_rocm",
+            return_value=True,
+        ),
+        patch(
+            "vllm.model_executor.custom_op.current_platform.is_xpu",
+            return_value=False,
+        ),
+        patch(
+            "vllm.model_executor.custom_op.get_cached_compilation_config",
+            return_value=fake_compilation_config,
+        ),
+        patch("vllm.model_executor.layers.activation.torch.ops._C", empty_c),
+    ):
+        layer = SwigluOAIAndMul()
+        out = layer(x)
+        ref_out = layer.forward_native(x)
+
+    torch.testing.assert_close(
+        out, ref_out, atol=get_default_atol(out), rtol=get_default_rtol(out)
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [7, 83])
+@pytest.mark.parametrize("d", [512])
+@pytest.mark.parametrize("dtype", [torch.float, torch.bfloat16])
+@torch.inference_mode()
+def test_swigluoai_and_mul_xpu_uses_custom_op(
+    num_tokens: int,
+    d: int,
+    dtype: torch.dtype,
+) -> None:
+    """Regression test for XPU dispatch when the custom op is present."""
+    x = torch.randn(num_tokens, 2 * d, dtype=dtype)
+    fake_compilation_config = SimpleNamespace(
+        custom_ops=["all"],
+        enabled_custom_ops=set(),
+        disabled_custom_ops=set(),
+    )
+    fake_calls = {"count": 0}
+
+    def fake_swigluoai_and_mul(
+        out: torch.Tensor,
+        inp: torch.Tensor,
+        alpha: float,
+        limit: float,
+    ) -> None:
+        fake_calls["count"] += 1
+        gate, up = inp[..., ::2], inp[..., 1::2]
+        gate = gate.clamp(min=None, max=limit)
+        up = up.clamp(min=-limit, max=limit)
+        glu = gate * torch.sigmoid(gate * alpha)
+        out.copy_((up + 1) * glu)
+
+    fake_c = SimpleNamespace(swigluoai_and_mul=fake_swigluoai_and_mul)
+
+    with (
+        patch(
+            "vllm.model_executor.layers.activation.current_platform.is_cuda_alike",
+            return_value=False,
+        ),
+        patch(
+            "vllm.model_executor.layers.activation.current_platform.is_xpu",
+            return_value=True,
+        ),
+        patch(
+            "vllm.model_executor.custom_op.current_platform.is_rocm",
+            return_value=False,
+        ),
+        patch(
+            "vllm.model_executor.custom_op.current_platform.is_xpu",
+            return_value=True,
+        ),
+        patch(
+            "vllm.model_executor.custom_op.get_cached_compilation_config",
+            return_value=fake_compilation_config,
+        ),
+        patch("vllm.model_executor.layers.activation.torch.ops._C", fake_c),
+    ):
+        layer = SwigluOAIAndMul()
+        out = layer(x)
+        ref_out = layer.forward_native(x)
+
+    assert fake_calls["count"] == 1
+    torch.testing.assert_close(
+        out, ref_out, atol=get_default_atol(out), rtol=get_default_rtol(out)
+    )

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -446,6 +446,11 @@ class SwigluOAIAndMul(CustomOp):
         super().__init__()
         self.alpha = alpha
         self.limit = limit
+        if current_platform.is_cuda_alike() or current_platform.is_xpu():
+            if hasattr(torch.ops._C, "swigluoai_and_mul"):
+                self.op = torch.ops._C.swigluoai_and_mul
+            else:
+                self._forward_method = self.forward_native
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
         """PyTorch-native implementation equivalent to forward()."""
@@ -461,8 +466,11 @@ class SwigluOAIAndMul(CustomOp):
         d = x.shape[-1] // 2
         output_shape = x.shape[:-1] + (d,)
         out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
-        torch.ops._C.swigluoai_and_mul(out, x, self.alpha, self.limit)
+        self.op(out, x, self.alpha, self.limit)
         return out
+
+    def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:
+        return self.forward_cuda(x)
 
     def extra_repr(self) -> str:
         return f"alpha={repr(self.alpha)}, limit={repr(self.limit)}"


### PR DESCRIPTION
## Summary
- add the same missing-`_C` fallback pattern to `SwigluOAIAndMul`
- switch `forward_cuda()` to use `self.op` so the class can cleanly fall back to `forward_native`
- add a focused regression test for ROCm/cuda-alike builds where `_C.swigluoai_and_mul` is absent

## Why this is not duplicating an existing PR
- I checked the live PR/issue surface for `swigluoai_and_mul` fallback work and did not find an open or merged PR covering this activation.
- This is a narrow follow-up to #39729, which applies the missing-`_C` fallback pattern to neighboring activations but does not touch `SwigluOAIAndMul`.

## Tests run
- `uv run --no-project --python 3.12 --with torch python -` with a stub loader around the real `custom_op.py` and `activation.py`
  - before the fix: reproduced `AttributeError: 'types.SimpleNamespace' object has no attribute 'swigluoai_and_mul'`
  - after the fix: `PASS`
- `uv run --no-project --python 3.12 python -`
  - `py_compile` succeeded for:
    - `vllm/model_executor/layers/activation.py`
    - `tests/kernels/core/test_activation.py`

## AI assistance
This PR was prepared with AI assistance.