### PR TITLE
[Build][Attention] Degrade cleanly without flash-attn extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,10 @@ set_gencode_flags_for_srcs(
   CUDA_ARCHS "${CUDA_ARCHS}")
 
 if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
-  message(STATUS "Enabling cumem allocator extension.")
+  if(DEFINED ENV{VLLM_SKIP_CUMEM_ALLOCATOR} AND NOT "$ENV{VLLM_SKIP_CUMEM_ALLOCATOR}" STREQUAL "")
+    message(STATUS "Skipping cumem allocator extension due to VLLM_SKIP_CUMEM_ALLOCATOR.")
+  else()
+    message(STATUS "Enabling cumem allocator extension.")
   if(VLLM_GPU_LANG STREQUAL "CUDA")
     # link against cuda driver library
     list(APPEND CUMEM_LIBS CUDA::cuda_driver)
@@ -273,6 +276,7 @@ if(VLLM_GPU_LANG STREQUAL "CUDA" OR VLLM_GPU_LANG STREQUAL "HIP")
     LIBRARIES ${CUMEM_LIBS}
     USE_SABI 3.8
     WITH_SOABI)
+  endif()
 endif()
 
 #
@@ -1229,5 +1233,9 @@ if (VLLM_GPU_LANG STREQUAL "CUDA")
     include(cmake/external_projects/qutlass.cmake)
 
     # vllm-flash-attn should be last as it overwrites some CMake functions
+  if(DEFINED ENV{VLLM_SKIP_FLASH_ATTN} AND NOT "$ENV{VLLM_SKIP_FLASH_ATTN}" STREQUAL "")
+    message(STATUS "Skipping vllm-flash-attn due to VLLM_SKIP_FLASH_ATTN.")
+  else()
     include(cmake/external_projects/vllm_flash_attn.cmake)
+  endif()
 endif ()

--- a/setup.py
+++ b/setup.py
@@ -976,7 +976,8 @@ ext_modules = []
 
 if _is_cuda() or _is_hip():
     ext_modules.append(CMakeExtension(name="vllm._moe_C"))
-    ext_modules.append(CMakeExtension(name="vllm.cumem_allocator"))
+    if not os.getenv("VLLM_SKIP_CUMEM_ALLOCATOR"):
+        ext_modules.append(CMakeExtension(name="vllm.cumem_allocator"))
     # Optional since this doesn't get built (produce an .so file). This is just
     # copying the relevant .py files from the source repository.
     ext_modules.append(CMakeExtension(name="vllm.triton_kernels", optional=True))
@@ -985,17 +986,18 @@ if _is_hip():
     ext_modules.append(CMakeExtension(name="vllm._rocm_C"))
 
 if _is_cuda():
-    ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa2_C"))
-    if envs.VLLM_USE_PRECOMPILED or (
-        CUDA_HOME and get_nvcc_cuda_version() >= Version("12.3")
-    ):
-        # FA3 requires CUDA 12.3 or later
-        ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa3_C"))
-    # FA4 CuteDSL - Python-only component for FA4's cute DSL support
-    # Optional since this doesn't produce a .so file, just copies Python files
-    ext_modules.append(
-        CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa4_cutedsl_C", optional=True)
-    )
+    if not os.getenv("VLLM_SKIP_FLASH_ATTN"):
+        ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa2_C"))
+        if envs.VLLM_USE_PRECOMPILED or (
+            CUDA_HOME and get_nvcc_cuda_version() >= Version("12.3")
+        ):
+            # FA3 requires CUDA 12.3 or later
+            ext_modules.append(CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa3_C"))
+        # FA4 CuteDSL - Python-only component for FA4's cute DSL support
+        # Optional since this doesn't produce a .so file, just copies Python files
+        ext_modules.append(
+            CMakeExtension(name="vllm.vllm_flash_attn._vllm_fa4_cutedsl_C", optional=True)
+        )
     if envs.VLLM_USE_PRECOMPILED or (
         CUDA_HOME and get_nvcc_cuda_version() >= Version("12.9")
     ):

--- a/vllm/model_executor/layers/rotary_embedding/common.py
+++ b/vllm/model_executor/layers/rotary_embedding/common.py
@@ -229,7 +229,10 @@ class ApplyRotaryEmb(CustomOp):
         cos: torch.Tensor,
         sin: torch.Tensor,
     ) -> torch.Tensor:
-        from vllm.vllm_flash_attn.layers.rotary import apply_rotary_emb
+        try:
+            from vllm.vllm_flash_attn.layers.rotary import apply_rotary_emb
+        except ImportError:
+            return self.forward_native(x, cos, sin)
 
         x, cos, sin, origin_shape, origin_dtype = self._pre_process(x, cos, sin)
 

--- a/vllm/v1/attention/backends/fa_utils.py
+++ b/vllm/v1/attention/backends/fa_utils.py
@@ -9,6 +9,9 @@ from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
 
+# Track whether CUDA flash-attn extensions are available.
+_CUDA_FLASH_ATTN_AVAILABLE = False
+
 # Track whether upstream flash-attn is available on ROCm.
 # Set during module initialization and never modified afterwards.
 # This module-level flag avoids repeated import attempts and ensures
@@ -17,10 +20,24 @@ _ROCM_FLASH_ATTN_AVAILABLE = False
 
 if current_platform.is_cuda():
     from vllm._custom_ops import reshape_and_cache_flash
-    from vllm.vllm_flash_attn import (  # type: ignore[attr-defined]
-        flash_attn_varlen_func,
-        get_scheduler_metadata,
-    )
+
+    try:
+        from vllm.vllm_flash_attn import (  # type: ignore[attr-defined]
+            flash_attn_varlen_func,
+            get_scheduler_metadata,
+        )
+
+        _CUDA_FLASH_ATTN_AVAILABLE = True
+    except ImportError:
+
+        def flash_attn_varlen_func(*args: Any, **kwargs: Any) -> Any:  # type: ignore[no-redef,misc]
+            raise ImportError(
+                "CUDA flash attention extensions are unavailable. "
+                "Build _vllm_fa2_C/_vllm_fa3_C or choose a backend that does not require flash-attn."
+            )
+
+        def get_scheduler_metadata(*args: Any, **kwargs: Any) -> None:  # type: ignore[no-redef,misc]
+            return None
 
 elif current_platform.is_xpu():
     from vllm import _custom_ops as ops
@@ -224,8 +241,10 @@ def is_flash_attn_varlen_func_available() -> bool:
     Returns:
         bool: True if a working flash_attn_varlen_func implementation is available.
     """
-    if current_platform.is_cuda() or current_platform.is_xpu():
-        # CUDA and XPU always have flash_attn_varlen_func available
+    if current_platform.is_cuda():
+        return _CUDA_FLASH_ATTN_AVAILABLE
+
+    if current_platform.is_xpu():
         return True
 
     if current_platform.is_rocm():

--- a/vllm/v1/attention/backends/mla/flashattn_mla.py
+++ b/vllm/v1/attention/backends/mla/flashattn_mla.py
@@ -32,10 +32,21 @@ from vllm.v1.attention.backends.fa_utils import (
     get_flash_attn_version,
 )
 from vllm.v1.kv_cache_interface import AttentionSpec
-from vllm.vllm_flash_attn import (  # type: ignore[attr-defined]
-    flash_attn_varlen_func,
-    get_scheduler_metadata,
-)
+try:
+    from vllm.vllm_flash_attn import (  # type: ignore[attr-defined]
+        flash_attn_varlen_func,
+        get_scheduler_metadata,
+    )
+except ImportError:
+
+    def flash_attn_varlen_func(*args, **kwargs):  # type: ignore[no-redef]
+        raise ImportError(
+            "CUDA flash attention extensions are unavailable. "
+            "FLASH_ATTN_MLA cannot be used without _vllm_fa2_C/_vllm_fa3_C."
+        )
+
+    def get_scheduler_metadata(*args, **kwargs):  # type: ignore[no-redef]
+        return None
 
 logger = init_logger(__name__)
 


### PR DESCRIPTION
## Summary
This PR makes flash-attn-dependent CUDA paths fail closed when the flash-attn extensions are unavailable and adds env-controlled build skips for those optional extensions.

## Overlap
This partially overlaps with #38060, which covers the `ApplyRotaryEmb` import guard.
This branch is broader: it also updates flash-attn backend availability detection, MLA import behavior, and optional extension build wiring in both CMake and `setup.py`.

## Validation
- `git diff --check`
- `/usr/bin/python3 -m py_compile setup.py vllm/model_executor/layers/rotary_embedding/common.py vllm/v1/attention/backends/fa_utils.py vllm/v1/attention/backends/mla/flashattn_mla.py`

## AI Use
This PR was prepared with AI assistance. The submitting human reviewed the changes and is responsible for the final submission.