### PR TITLE
[Lora][Gemma4]: gemma4 fix lora online serving

### DIFF
--- a/tests/lora/test_model_manager_aliasing.py
+++ b/tests/lora/test_model_manager_aliasing.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import tempfile
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from torch import nn
+
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.config.lora import LoRAConfig
+from vllm.distributed import (
+    cleanup_dist_env_and_memory,
+    init_distributed_environment,
+    initialize_model_parallel,
+)
+from vllm.lora.lora_model import LoRAModel
+from vllm.lora.lora_weights import LoRALayerWeights
+from vllm.lora.model_manager import LoRAModelManager
+from vllm.model_executor.layers.linear import ColumnParallelLinear
+from vllm.model_executor.models.interfaces import SupportsLoRA
+from vllm.platforms import current_platform
+
+CANONICAL_PATH = "layers.0.proj"
+ALIASED_PATH = "self_decoder.decoder_layers.0.proj"
+
+
+class DecoderAliasWrapper(nn.Module):
+    def __init__(self, decoder_layers: nn.ModuleList):
+        super().__init__()
+        self.decoder_layers = decoder_layers
+
+
+class ToyGemma4DecoderLayer(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.proj = ColumnParallelLinear(16, 8)
+
+
+class ToyGemma4AliasedLoRAModel(nn.Module, SupportsLoRA):
+    """Minimal Gemma4-style aliasing setup.
+
+    The same decoder child module is reachable through both:
+    - layers.0.proj
+    - self_decoder.decoder_layers.0.proj
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.layers = nn.ModuleList([ToyGemma4DecoderLayer()])
+        self.self_decoder = DecoderAliasWrapper(self.layers[:1])
+        self.config = MagicMock()
+        self.embedding_modules = {}
+        self.unpadded_vocab_size = 128
+
+
+@pytest.fixture()
+def should_do_global_cleanup_after_test() -> bool:
+    return False
+
+
+@pytest.fixture()
+def dist_init_local():
+    temp_file = tempfile.mkstemp()[1]
+
+    backend = "nccl"
+    if current_platform.is_cpu() or current_platform.is_tpu():
+        backend = "gloo"
+
+    with set_current_vllm_config(VllmConfig()):
+        init_distributed_environment(
+            world_size=1,
+            rank=0,
+            distributed_init_method=f"file://{temp_file}",
+            local_rank=0,
+            backend=backend,
+        )
+        initialize_model_parallel(1, 1)
+        yield
+
+    cleanup_dist_env_and_memory(shutdown_ray=False)
+
+
+def _make_lora_config() -> LoRAConfig:
+    return LoRAConfig(
+        max_lora_rank=8,
+        max_cpu_loras=2,
+        max_loras=1,
+        lora_dtype=torch.float32,
+    )
+
+
+def _make_nonzero_lora(module_name: str, module: ColumnParallelLinear) -> LoRAModel:
+    lora_a = torch.ones((8, module.base_layer.weight.shape[1]))
+    lora_b = torch.ones((module.base_layer.weight.shape[0], 8))
+
+    assert lora_a.abs().sum().item() > 0
+    assert lora_b.abs().sum().item() > 0
+
+    return LoRAModel(
+        1,
+        8,
+        {module_name: LoRALayerWeights(module_name, 8, 16, lora_a, lora_b)},
+    )
+
+
+def _stacked_lora_sums(module: ColumnParallelLinear) -> tuple[float, float]:
+    return (
+        module.lora_a_stacked[0].abs().sum().item(),
+        module.lora_b_stacked[0].abs().sum().item(),
+    )
+
+
+def _make_manager() -> LoRAModelManager:
+    return LoRAModelManager(
+        ToyGemma4AliasedLoRAModel(),
+        max_num_seqs=1,
+        max_num_batched_tokens=8,
+        vocab_size=128,
+        lora_config=_make_lora_config(),
+        device="cpu",
+    )
+
+
+def test_toy_model_exposes_aliased_linear_paths(dist_init_local):
+    model = ToyGemma4AliasedLoRAModel()
+
+    aliased_paths = {
+        name
+        for name, _ in model.named_modules(remove_duplicate=False)
+        if name in {CANONICAL_PATH, ALIASED_PATH}
+    }
+
+    assert aliased_paths == {CANONICAL_PATH, ALIASED_PATH}
+    assert model.layers[0] is model.self_decoder.decoder_layers[0]
+    assert model.layers[0].proj is model.self_decoder.decoder_layers[0].proj
+
+
+def test_lora_manager_keeps_aliased_modules(dist_init_local):
+    manager = _make_manager()
+
+    assert set(manager.modules) == {CANONICAL_PATH, ALIASED_PATH}
+    assert manager.model.layers[0].proj is manager.modules[CANONICAL_PATH]
+    assert (
+        manager.model.self_decoder.decoder_layers[0].proj
+        is manager.modules[ALIASED_PATH]
+    )
+    assert manager.modules[CANONICAL_PATH] is manager.modules[ALIASED_PATH]
+
+
+def test_activation_prefers_weighted_duplicate_lora_wrapper(dist_init_local):
+    manager = _make_manager()
+
+    assert set(manager.modules) == {CANONICAL_PATH, ALIASED_PATH}
+    assert manager.modules[CANONICAL_PATH] is manager.modules[ALIASED_PATH]
+
+    shared_module = manager.modules[CANONICAL_PATH]
+    manager.add_adapter(_make_nonzero_lora(CANONICAL_PATH, shared_module))
+    manager.modules = {
+        ALIASED_PATH: manager.modules[ALIASED_PATH],
+        CANONICAL_PATH: manager.modules[CANONICAL_PATH],
+    }
+
+    events: list[str] = []
+    set_lora = shared_module.set_lora
+    reset_lora = shared_module.reset_lora
+
+    def wrapped_set_lora(*args, **kwargs):
+        events.append("set")
+        return set_lora(*args, **kwargs)
+
+    def wrapped_reset_lora(*args, **kwargs):
+        events.append("reset")
+        return reset_lora(*args, **kwargs)
+
+    shared_module.set_lora = MagicMock(side_effect=wrapped_set_lora)
+    shared_module.reset_lora = MagicMock(side_effect=wrapped_reset_lora)
+
+    manager.activate_adapter(1)
+
+    assert shared_module.set_lora.call_count == 1
+    assert shared_module.reset_lora.call_count == 1
+    assert events == ["set", "reset"]
+    assert _stacked_lora_sums(shared_module) != (0.0, 0.0)

--- a/vllm/lora/model_manager.py
+++ b/vllm/lora/model_manager.py
@@ -286,9 +286,20 @@ class LoRAModelManager:
             "Activating LoRA. int id: %d, slot index: %d", lora_model.id, index
         )
         self.lora_index_to_id[index] = lora_model.id
+        chosen_modules: dict[
+            int, tuple[str, BaseLayerWithLoRA, LoRALayerWeights | None]
+        ] = {}
         for module_name, module in self.modules.items():
+            module_key = id(module)
             module_lora = self._get_lora_layer_weights(lora_model, module_name)
-            if not module_lora:
+
+            if module_key not in chosen_modules:
+                chosen_modules[module_key] = (module_name, module, module_lora)
+            elif module_lora is not None and chosen_modules[module_key][2] is None:
+                chosen_modules[module_key] = (module_name, module, module_lora)
+
+        for module_name, module, module_lora in chosen_modules.values():
+            if module_lora is None:
                 module.reset_lora(index)
                 logger.debug(
                     "No LoRA weights found for module %s, skipping.", module_name


### PR DESCRIPTION
<!-- markdownlint-disable -->
Fixes: #39815 


  ## Purpose

  This PR fixes Gemma4 LoRA online serving when aliased module paths point to the
  same physical module.

  Gemma4’s fast-prefill / YOCO split added `self_decoder` and `cross_decoder`
  wrappers. Those wrappers reference existing decoder layers, so the same module
  can show up under multiple paths:

  ```text
  model.layers.0...
  model.self_decoder.decoder_layers.0...
  ```

  Before this PR, LoRA activation could load weights through one path and then
  reset the same wrapper through the alias path:

  ```text
  set_lora(...)   for model.layers.0...
  reset_lora(...) for model.self_decoder.decoder_layers.0...
  ```

  Since both names point to the same live wrapper, the reset could wipe out the
  weights that were just loaded. This made the adapter behave like the base model.

  ## Fix

  Keep `remove_duplicate=False` during module discovery so all valid LoRA paths
  stay registered:

  ```python
  self.model.named_modules(remove_duplicate=False)
  ```

  Then dedupe only during activation by physical module identity. This keeps the
  module names LoRA needs for adapter matching, while making sure `set_lora()` /
  `reset_lora()` only run once per actual wrapper.

  This matters for Gemma4ForConditionalGeneration because adapter paths can map to
  prefixed vLLM paths like:

  ```text
  language_model.model.layers...
  language_model.lm_head...
  ```

  Deduping during `_create_lora_modules()` can drop names that are still valid for
  LoRA, so the dedupe needs to happen at activation time instead.

  ## Test Plan

  ```bash
  .venv/bin/python -m pytest tests/lora/test_model_manager_aliasing.py -q
  ```

  ## Test Result

  ```text
  PASSED
  ```

  The regression test checks that:

- the toy model exposes both canonical and aliased module paths
- both paths resolve to the same physical LoRA wrapper
- activation keeps nonzero LoRA weights loaded instead of zeroing them through the alias path

Also worth noting that this bug was surfaced after aliasing was introduced in the gemma4 implementation in this PR: #38879 
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
