### PR TITLE
[Model] Add block-local attention and YaRN for local layers to Gemma3

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -472,6 +472,7 @@ th {
 | `Qwen3MoeForCausalLM` | Qwen3MoE | `Qwen/Qwen3-30B-A3B`, etc. | ✅︎ | ✅︎ |
 | `Qwen3NextForCausalLM` | Qwen3NextMoE | `Qwen/Qwen3-Next-80B-A3B-Instruct`, etc. | ✅︎ | ✅︎ |
 | `RWForCausalLM` | Falcon RW | `tiiuae/falcon-40b`, etc. | | ✅︎ |
+| `Rnj1ForCausalLM` | Rnj1 | `EssentialAI/rnj-1-instruct`, etc. | | |
 | `SarvamMoEForCausalLM` | Sarvam 2 | `sarvamai/sarvam2-30b-a3b`, etc. | ✅︎ | ✅︎ |
 | `SarvamMLAForCausalLM` | Sarvam 2 | `sarvamai/sarvam2-105b-a9b`, etc. | | ✅︎ |
 | `SeedOssForCausalLM` | SeedOss | `ByteDance-Seed/Seed-OSS-36B-Instruct`, etc. | ✅︎ | ✅︎ |

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -518,6 +518,10 @@ _TEXT_GENERATION_EXAMPLE_MODELS = {
         extras={"tiny-random": "tiny-random/qwen3-next-moe"},
         min_transformers_version="4.56.3",
     ),
+    "Rnj1ForCausalLM": _HfExamplesInfo(
+        "EssentialAI/rnj-1-instruct",
+        is_available_online=False,
+    ),
     "RWForCausalLM": _HfExamplesInfo("tiiuae/falcon-40b"),
     "SarvamMoEForCausalLM": _HfExamplesInfo(
         "sarvamai/sarvam-30b",

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -334,6 +334,12 @@ class Attention(nn.Module, AttentionLayerBase):
             )
             cache_config.enable_prefix_caching = False
 
+        if extra_impl_args.get("block_local_lookback", -1) > -1:
+            assert self.attn_backend.get_name() == "TRITON_ATTN", (
+                f"Block-local attention requires the Triton backend, "
+                f"but got {self.attn_backend.get_name()}."
+            )
+
         impl_cls = self.attn_backend.get_impl_cls()
         self.impl = impl_cls(
             num_heads,

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -334,9 +334,9 @@ class Attention(nn.Module, AttentionLayerBase):
             )
             cache_config.enable_prefix_caching = False
 
-        if extra_impl_args.get("block_local_lookback", -1) > -1:
+        if extra_impl_args.get("chunk_lookback", -1) > -1:
             assert self.attn_backend.get_name() == "TRITON_ATTN", (
-                f"Block-local attention requires the Triton backend, "
+                f"Chunked attention with lookback requires the Triton backend, "
                 f"but got {self.attn_backend.get_name()}."
             )
 

--- a/vllm/model_executor/models/gemma3.py
+++ b/vllm/model_executor/models/gemma3.py
@@ -168,11 +168,6 @@ class Gemma3Attention(nn.Module):
         sliding_window = config.sliding_window if is_local else None
 
         # Initialize the rotary embedding.
-        rope_local_type = getattr(
-            config,
-            "rope_local_type",
-            config.rope_parameters.get("rope_type", None),
-        )
         if layer_type in config.rope_parameters:
             # Transformers v5 rope config.
             rope_parameters = config.rope_parameters[layer_type]
@@ -181,15 +176,10 @@ class Gemma3Attention(nn.Module):
             # Global attention. Use the values in config.json.
             rope_parameters = config.rope_parameters
             # Local attention. Override the values in config.json.
-            if self.is_sliding or self.is_chunked:
-                if rope_local_type not in ("yarn",):
-                    # Default: use a simple rope with local base freq.
-                    # When rope_local_type == "yarn", keep the global
-                    # rope_parameters (which contain YaRN scaling).
-                    rope_parameters = dict(
-                        rope_type="default",
-                        rope_theta=config.rope_local_base_freq,
-                    )
+            if self.is_sliding:
+                rope_parameters = dict(
+                    rope_type="default", rope_theta=config.rope_local_base_freq
+                )
 
         self.rotary_emb = get_rope(
             self.head_dim,

--- a/vllm/model_executor/models/gemma3.py
+++ b/vllm/model_executor/models/gemma3.py
@@ -162,9 +162,17 @@ class Gemma3Attention(nn.Module):
         layer_idx = extract_layer_index(prefix)
         layer_type = config.layer_types[layer_idx]
         self.is_sliding = layer_type == "sliding_attention"
-        sliding_window = config.sliding_window if self.is_sliding else None
+        self.is_block_local = layer_type == "linear_attention"
+        self.block_local_lookback = 1 if self.is_block_local else -1
+        is_local = self.is_sliding or self.is_block_local
+        sliding_window = config.sliding_window if is_local else None
 
         # Initialize the rotary embedding.
+        rope_local_type = getattr(
+            config,
+            "rope_local_type",
+            config.rope_parameters.get("rope_type", None),
+        )
         if layer_type in config.rope_parameters:
             # Transformers v5 rope config.
             rope_parameters = config.rope_parameters[layer_type]
@@ -173,10 +181,15 @@ class Gemma3Attention(nn.Module):
             # Global attention. Use the values in config.json.
             rope_parameters = config.rope_parameters
             # Local attention. Override the values in config.json.
-            if self.is_sliding:
-                rope_parameters = dict(
-                    rope_type="default", rope_theta=config.rope_local_base_freq
-                )
+            if self.is_sliding or self.is_block_local:
+                if rope_local_type not in ("yarn",):
+                    # Default: use a simple rope with local base freq.
+                    # When rope_local_type == "yarn", keep the global
+                    # rope_parameters (which contain YaRN scaling).
+                    rope_parameters = dict(
+                        rope_type="default",
+                        rope_theta=config.rope_local_base_freq,
+                    )
 
         self.rotary_emb = get_rope(
             self.head_dim,
@@ -206,6 +219,7 @@ class Gemma3Attention(nn.Module):
             attn_type=attn_type,
             logits_soft_cap=attn_logits_soft_cap,
             per_layer_sliding_window=sliding_window,
+            block_local_lookback=self.block_local_lookback,
             prefix=f"{prefix}.attn",
         )
 

--- a/vllm/model_executor/models/gemma3.py
+++ b/vllm/model_executor/models/gemma3.py
@@ -162,9 +162,9 @@ class Gemma3Attention(nn.Module):
         layer_idx = extract_layer_index(prefix)
         layer_type = config.layer_types[layer_idx]
         self.is_sliding = layer_type == "sliding_attention"
-        self.is_block_local = layer_type == "linear_attention"
-        self.block_local_lookback = 1 if self.is_block_local else -1
-        is_local = self.is_sliding or self.is_block_local
+        self.is_chunked = layer_type == "chunked_attention"
+        self.chunk_lookback = 1 if self.is_chunked else -1
+        is_local = self.is_sliding or self.is_chunked
         sliding_window = config.sliding_window if is_local else None
 
         # Initialize the rotary embedding.
@@ -181,7 +181,7 @@ class Gemma3Attention(nn.Module):
             # Global attention. Use the values in config.json.
             rope_parameters = config.rope_parameters
             # Local attention. Override the values in config.json.
-            if self.is_sliding or self.is_block_local:
+            if self.is_sliding or self.is_chunked:
                 if rope_local_type not in ("yarn",):
                     # Default: use a simple rope with local base freq.
                     # When rope_local_type == "yarn", keep the global
@@ -219,7 +219,7 @@ class Gemma3Attention(nn.Module):
             attn_type=attn_type,
             logits_soft_cap=attn_logits_soft_cap,
             per_layer_sliding_window=sliding_window,
-            block_local_lookback=self.block_local_lookback,
+            chunk_lookback=self.chunk_lookback,
             prefix=f"{prefix}.attn",
         )
 

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -110,6 +110,7 @@ _TEXT_GENERATION_MODELS = {
     "GemmaForCausalLM": ("gemma", "GemmaForCausalLM"),
     "Gemma2ForCausalLM": ("gemma2", "Gemma2ForCausalLM"),
     "Gemma3ForCausalLM": ("gemma3", "Gemma3ForCausalLM"),
+    "Rnj1ForCausalLM": ("rnj1", "Rnj1ForCausalLM"),
     "Gemma3nForCausalLM": ("gemma3n", "Gemma3nForCausalLM"),
     "Gemma4ForCausalLM": ("gemma4", "Gemma4ForCausalLM"),
     "Qwen3NextForCausalLM": ("qwen3_next", "Qwen3NextForCausalLM"),

--- a/vllm/model_executor/models/rnj1.py
+++ b/vllm/model_executor/models/rnj1.py
@@ -1,20 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-# Copyright 2025 The vLLM team.
-# Copyright 2025 Google Inc. HuggingFace Inc. team. All rights reserved.
 #
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
+# RNJ-1 model: Gemma3-based architecture with chunked (block-local) attention.
+# Chunked attention restricts local layers to attend within aligned blocks,
+# with lookback to one previous block.
 from collections.abc import Iterable
 from itertools import islice
 
@@ -27,10 +16,7 @@ from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import GeluAndMul
-from vllm.model_executor.layers.attention import (
-    Attention,
-    EncoderOnlyAttention,
-)
+from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.layernorm import GemmaRMSNorm
 from vllm.model_executor.layers.linear import (
     MergedColumnParallelLinear,
@@ -64,7 +50,7 @@ from .utils import (
 logger = init_logger(__name__)
 
 
-class Gemma3MLP(nn.Module):
+class Rnj1MLP(nn.Module):
     def __init__(
         self,
         hidden_size: int,
@@ -90,7 +76,7 @@ class Gemma3MLP(nn.Module):
         )
         if hidden_activation != "gelu_pytorch_tanh":
             raise ValueError(
-                "Gemma3 uses `gelu_pytorch_tanh` as the hidden activation "
+                "RNJ-1 uses `gelu_pytorch_tanh` as the hidden activation "
                 "function. Please set `hidden_act` and `hidden_activation` to "
                 "`gelu_pytorch_tanh`."
             )
@@ -103,7 +89,7 @@ class Gemma3MLP(nn.Module):
         return x
 
 
-class Gemma3Attention(nn.Module):
+class Rnj1Attention(nn.Module):
     def __init__(
         self,
         config: Gemma3TextConfig,
@@ -126,12 +112,8 @@ class Gemma3Attention(nn.Module):
         self.num_heads = self.total_num_heads // tp_size
         self.total_num_kv_heads = num_kv_heads
         if self.total_num_kv_heads >= tp_size:
-            # Number of KV heads is greater than TP size, so we partition
-            # the KV heads across multiple tensor parallel GPUs.
             assert self.total_num_kv_heads % tp_size == 0
         else:
-            # Number of KV heads is less than TP size, so we replicate
-            # the KV heads across multiple tensor parallel GPUs.
             assert tp_size % self.total_num_kv_heads == 0
         self.num_kv_heads = max(1, self.total_num_kv_heads // tp_size)
         self.head_dim = head_dim
@@ -161,22 +143,16 @@ class Gemma3Attention(nn.Module):
 
         layer_idx = extract_layer_index(prefix)
         layer_type = config.layer_types[layer_idx]
-        self.is_sliding = layer_type == "sliding_attention"
-        sliding_window = config.sliding_window if self.is_sliding else None
+        self.is_chunked = layer_type == "chunked_attention"
+        self.chunk_lookback = 1 if self.is_chunked else -1
+        sliding_window = config.sliding_window if self.is_chunked else None
 
         # Initialize the rotary embedding.
+        # Expects v5-style rope_parameters keyed by layer type.
         if layer_type in config.rope_parameters:
-            # Transformers v5 rope config.
             rope_parameters = config.rope_parameters[layer_type]
         else:
-            # Transformers v4 rope config.
-            # Global attention. Use the values in config.json.
             rope_parameters = config.rope_parameters
-            # Local attention. Override the values in config.json.
-            if self.is_sliding:
-                rope_parameters = dict(
-                    rope_type="default", rope_theta=config.rope_local_base_freq
-                )
 
         self.rotary_emb = get_rope(
             self.head_dim,
@@ -185,27 +161,17 @@ class Gemma3Attention(nn.Module):
             is_neox_style=True,
         )
 
-        if getattr(config, "is_causal", True):
-            attn_type = AttentionType.DECODER
-        else:
-            attn_type = AttentionType.ENCODER_ONLY
-
-        attn_cls = (
-            EncoderOnlyAttention
-            if attn_type == AttentionType.ENCODER_ONLY
-            else Attention
-        )
-
-        self.attn = attn_cls(
+        self.attn = Attention(
             self.num_heads,
             self.head_dim,
             self.scaling,
             num_kv_heads=self.num_kv_heads,
             cache_config=cache_config,
             quant_config=quant_config,
-            attn_type=attn_type,
+            attn_type=AttentionType.DECODER,
             logits_soft_cap=attn_logits_soft_cap,
             per_layer_sliding_window=sliding_window,
+            chunk_lookback=self.chunk_lookback,
             prefix=f"{prefix}.attn",
         )
 
@@ -231,7 +197,7 @@ class Gemma3Attention(nn.Module):
         return output
 
 
-class Gemma3DecoderLayer(nn.Module):
+class Rnj1DecoderLayer(nn.Module):
     def __init__(
         self,
         config: Gemma3TextConfig,
@@ -241,7 +207,7 @@ class Gemma3DecoderLayer(nn.Module):
     ) -> None:
         super().__init__()
         self.hidden_size = config.hidden_size
-        self.self_attn = Gemma3Attention(
+        self.self_attn = Rnj1Attention(
             config=config,
             hidden_size=self.hidden_size,
             num_heads=config.num_attention_heads,
@@ -254,7 +220,7 @@ class Gemma3DecoderLayer(nn.Module):
             prefix=f"{prefix}.self_attn",
         )
         self.hidden_size = config.hidden_size
-        self.mlp = Gemma3MLP(
+        self.mlp = Rnj1MLP(
             hidden_size=self.hidden_size,
             intermediate_size=config.intermediate_size,
             hidden_activation=config.hidden_activation,
@@ -300,7 +266,7 @@ class Gemma3DecoderLayer(nn.Module):
 
 
 @support_torch_compile
-class Gemma3Model(nn.Module):
+class Rnj1Model(nn.Module):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
         super().__init__()
         config = vllm_config.model_config.hf_config
@@ -317,17 +283,13 @@ class Gemma3Model(nn.Module):
         )
         self.start_layer, self.end_layer, self.layers = make_layers(
             config.num_hidden_layers,
-            lambda prefix: Gemma3DecoderLayer(
+            lambda prefix: Rnj1DecoderLayer(
                 config, cache_config, quant_config, prefix=prefix
             ),
             prefix=f"{prefix}.layers",
         )
         self.norm = GemmaRMSNorm(config.hidden_size, eps=config.rms_norm_eps)
 
-        # Normalize the embedding by sqrt(hidden_size)
-        # The normalizer's data type should be downcasted to the model's
-        # data type such as bfloat16, not float32.
-        # See https://github.com/huggingface/transformers/pull/29402
         normalizer = self.config.hidden_size**0.5
         self.register_buffer("normalizer", torch.tensor(normalizer), persistent=False)
         self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
@@ -335,8 +297,6 @@ class Gemma3Model(nn.Module):
         )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        # NOTE(woosuk): Only apply the normalizer to the output of
-        # vocab embedding. Don't apply it to the vision embedding.
         return self.embed_tokens(input_ids) * self.normalizer
 
     def forward(
@@ -383,8 +343,6 @@ class Gemma3Model(nn.Module):
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         for name, loaded_weight in weights:
-            # Revert +1 during llama.cpp conversion
-            # see: https://github.com/ggml-org/llama.cpp/blob/be7c3034108473beda214fd1d7c98fd6a7a3bdf5/convert_hf_to_gguf.py#L3397-L3400
             if (
                 self.quant_config
                 and self.quant_config.get_name() == "gguf"
@@ -395,7 +353,6 @@ class Gemma3Model(nn.Module):
             if self.quant_config is not None and (
                 scale_name := self.quant_config.get_cache_scale(name)
             ):
-                # Loading kv cache scales for compressed-tensors quantization
                 param = params_dict[scale_name]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 loaded_weight = loaded_weight[0]
@@ -403,12 +360,9 @@ class Gemma3Model(nn.Module):
                 loaded_params.add(scale_name)
                 continue
 
-            # Check if this is a scale parameter that needs remapping first
             if name.endswith((".k_scale", ".v_scale", ".q_scale", ".prob_scale")):
-                # Try to remap the scale name first
                 remapped_name = maybe_remap_kv_scale_name(name, params_dict)
                 if remapped_name is not None and remapped_name in params_dict:
-                    # Successfully remapped, use the remapped name
                     param = params_dict[remapped_name]
                     weight_loader = getattr(
                         param, "weight_loader", default_weight_loader
@@ -416,13 +370,11 @@ class Gemma3Model(nn.Module):
                     weight_loader(param, loaded_weight)
                     loaded_params.add(remapped_name)
                     continue
-                # If remapping failed, continue with normal processing
 
             for param_name, shard_name, shard_id in stacked_params_mapping:
                 if shard_name not in name:
                     continue
                 name = name.replace(shard_name, param_name)
-                # Skip loading extra bias for GPTQ models.
                 if name.endswith(".bias") and name not in params_dict:
                     continue
                 if is_pp_missing_parameter(name, self):
@@ -432,10 +384,8 @@ class Gemma3Model(nn.Module):
                 weight_loader(param, loaded_weight, shard_id)
                 break
             else:
-                # Skip loading extra bias for GPTQ models.
                 if name.endswith(".bias") and name not in params_dict:
                     continue
-                # Remapping the name of FP8 kv-scale.
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:
                     continue
@@ -449,7 +399,7 @@ class Gemma3Model(nn.Module):
         return loaded_params
 
 
-class Gemma3ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
+class Rnj1ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",
@@ -469,7 +419,7 @@ class Gemma3ForCausalLM(nn.Module, SupportsLoRA, SupportsPP):
         super().__init__()
         self.config = config
         self.quant_config = quant_config
-        self.model = Gemma3Model(
+        self.model = Rnj1Model(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
 

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -458,7 +458,7 @@ class TritonAttentionImpl(AttentionImpl):
         kv_sharing_target_layer_name: int | None = None,
         sinks: torch.Tensor | None = None,
         use_alibi_sqrt: bool = False,
-        block_local_lookback: int = -1,
+        chunk_lookback: int = -1,
     ) -> None:
         self.num_heads = num_heads
         self.head_size = head_size
@@ -493,7 +493,7 @@ class TritonAttentionImpl(AttentionImpl):
                 f"num_heads: {num_heads}."
             )
         self.use_alibi_sqrt = use_alibi_sqrt
-        self.block_local_lookback = block_local_lookback
+        self.chunk_lookback = chunk_lookback
         self.supports_quant_query_input = current_platform.is_cuda()
 
         self._kv_quant_mode = get_kv_quant_mode(kv_cache_dtype)
@@ -633,7 +633,7 @@ class TritonAttentionImpl(AttentionImpl):
             kv_quant_mode=self._kv_quant_mode,
             k_scale_cache=k_scale_cache,
             v_scale_cache=v_scale_cache,
-            block_local_lookback=self.block_local_lookback,
+            chunk_lookback=self.chunk_lookback,
         )
 
         return output

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -458,6 +458,7 @@ class TritonAttentionImpl(AttentionImpl):
         kv_sharing_target_layer_name: int | None = None,
         sinks: torch.Tensor | None = None,
         use_alibi_sqrt: bool = False,
+        block_local_lookback: int = -1,
     ) -> None:
         self.num_heads = num_heads
         self.head_size = head_size
@@ -492,6 +493,7 @@ class TritonAttentionImpl(AttentionImpl):
                 f"num_heads: {num_heads}."
             )
         self.use_alibi_sqrt = use_alibi_sqrt
+        self.block_local_lookback = block_local_lookback
         self.supports_quant_query_input = current_platform.is_cuda()
 
         self._kv_quant_mode = get_kv_quant_mode(kv_cache_dtype)
@@ -631,6 +633,7 @@ class TritonAttentionImpl(AttentionImpl):
             kv_quant_mode=self._kv_quant_mode,
             k_scale_cache=k_scale_cache,
             v_scale_cache=v_scale_cache,
+            block_local_lookback=self.block_local_lookback,
         )
 
         return output

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -1136,6 +1136,7 @@ def unified_attention(
     block_local_block_size = -1
     if sliding_window_val > 0 and block_local_lookback > -1:
         block_local_block_size = sliding_window_val // (block_local_lookback + 1)
+        assert block_local_block_size > 0, "sliding_window must be > block_local_lookback+1"
     elif sliding_window_val <= 0:
         block_local_lookback = -1
 

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -177,8 +177,8 @@ def kernel_unified_attention_2d(
     stride_vs_blk=0,
     stride_vs_slot=0,
     stride_vs_head=0,
-    BLOCK_LOCAL_LOOKBACK: tl.constexpr = -1,
-    BLOCK_LOCAL_BLOCK_SIZE: tl.constexpr = -1,
+    CHUNK_LOOKBACK: tl.constexpr = -1,
+    CHUNK_SIZE: tl.constexpr = -1,
 ):
     q_block_global_idx = tl.program_id(0)
     kv_head_idx = tl.program_id(1)
@@ -296,10 +296,10 @@ def kernel_unified_attention_2d(
         # The union of allowed key positions for this Q-block is:
         # [context_len + qpos_lo - SLIDING_WINDOW + 1, context_len + qpos_hi]
         q_abs = context_len + qpos_lo
-        if BLOCK_LOCAL_LOOKBACK > -1:
+        if CHUNK_LOOKBACK > -1:
             first_allowed_key = (
-                (q_abs // BLOCK_LOCAL_BLOCK_SIZE) - BLOCK_LOCAL_LOOKBACK
-            ) * BLOCK_LOCAL_BLOCK_SIZE
+                (q_abs // CHUNK_SIZE) - CHUNK_LOOKBACK
+            ) * CHUNK_SIZE
         else:
             first_allowed_key = q_abs - SLIDING_WINDOW + 1
         last_allowed_key = context_len + qpos_hi
@@ -378,17 +378,17 @@ def kernel_unified_attention_2d(
         query_abs_pos = context_len + query_pos[:, None]
         seq_mask = seq_offset[None, :] <= query_abs_pos
 
-        # Apply sliding window / block-local to base mask BEFORE
-        # mm_prefix OR.
+        # Apply sliding window / chunked attention to base mask
+        # BEFORE mm_prefix OR.
         # Order must match FlexAttention:
         #   (causal AND sliding_window) OR mm_prefix
-        if BLOCK_LOCAL_LOOKBACK > -1:
+        if CHUNK_LOOKBACK > -1:
             seq_mask = seq_mask & (
                 (
-                    (context_len + query_pos[:, None]) // BLOCK_LOCAL_BLOCK_SIZE
-                    - (seq_offset[None, :] // BLOCK_LOCAL_BLOCK_SIZE)
+                    (context_len + query_pos[:, None]) // CHUNK_SIZE
+                    - (seq_offset[None, :] // CHUNK_SIZE)
                 )
-                <= BLOCK_LOCAL_LOOKBACK
+                <= CHUNK_LOOKBACK
             )
         elif SLIDING_WINDOW > 0:
             seq_mask = seq_mask & ((query_abs_pos - seq_offset) < SLIDING_WINDOW)
@@ -577,8 +577,8 @@ def kernel_unified_attention_3d(
     stride_vs_blk=0,
     stride_vs_slot=0,
     stride_vs_head=0,
-    BLOCK_LOCAL_LOOKBACK: tl.constexpr = -1,
-    BLOCK_LOCAL_BLOCK_SIZE: tl.constexpr = -1,
+    CHUNK_LOOKBACK: tl.constexpr = -1,
+    CHUNK_SIZE: tl.constexpr = -1,
 ):
     q_block_global_idx = tl.program_id(0)
     kv_head_idx = tl.program_id(1)
@@ -702,10 +702,10 @@ def kernel_unified_attention_3d(
         # The union of allowed key positions for this Q-block is:
         # [context_len + qpos_lo - SLIDING_WINDOW + 1, context_len + qpos_hi]
         q_abs = context_len + qpos_lo
-        if BLOCK_LOCAL_LOOKBACK > -1:
+        if CHUNK_LOOKBACK > -1:
             first_allowed_key = (
-                (q_abs // BLOCK_LOCAL_BLOCK_SIZE) - BLOCK_LOCAL_LOOKBACK
-            ) * BLOCK_LOCAL_BLOCK_SIZE
+                (q_abs // CHUNK_SIZE) - CHUNK_LOOKBACK
+            ) * CHUNK_SIZE
         else:
             first_allowed_key = q_abs - SLIDING_WINDOW + 1
         last_allowed_key = context_len + qpos_hi
@@ -787,17 +787,17 @@ def kernel_unified_attention_3d(
         query_abs_pos = context_len + query_pos[:, None]
         seq_mask = seq_offset[None, :] <= query_abs_pos
 
-        # Apply sliding window / block-local to base mask BEFORE
-        # mm_prefix OR.
+        # Apply sliding window / chunked attention to base mask
+        # BEFORE mm_prefix OR.
         # Order must match FlexAttention:
         #   (causal AND sliding_window) OR mm_prefix
-        if BLOCK_LOCAL_LOOKBACK > -1:
+        if CHUNK_LOOKBACK > -1:
             seq_mask = seq_mask & (
                 (
-                    (context_len + query_pos[:, None]) // BLOCK_LOCAL_BLOCK_SIZE
-                    - (seq_offset[None, :] // BLOCK_LOCAL_BLOCK_SIZE)
+                    (context_len + query_pos[:, None]) // CHUNK_SIZE
+                    - (seq_offset[None, :] // CHUNK_SIZE)
                 )
-                <= BLOCK_LOCAL_LOOKBACK
+                <= CHUNK_LOOKBACK
             )
         elif SLIDING_WINDOW > 0:
             seq_mask = seq_mask & ((query_abs_pos - seq_offset) < SLIDING_WINDOW)
@@ -1082,8 +1082,8 @@ def unified_attention(
     kv_quant_mode: KVQuantMode = KVQuantMode.NONE,
     k_scale_cache=None,  # [num_blocks, block_size, num_kv_heads] float32
     v_scale_cache=None,  # [num_blocks, block_size, num_kv_heads] float32
-    # Block-local attention: restrict attention to aligned blocks.
-    block_local_lookback=-1,
+    # Chunked attention: restrict attention to aligned blocks with lookback.
+    chunk_lookback=-1,
 ):
     assert causal, "Only causal attention is supported"
     assert q_descale is None, "Q scales not supported"
@@ -1132,13 +1132,13 @@ def unified_attention(
     # Note: tile size must be at least 32 for fp8 (element_size == 1).
     sliding_window_val = 1 + window_size[0] if window_size[0] >= 0 else 0
 
-    # Compute block-local block size from sliding window if needed.
-    block_local_block_size = -1
-    if sliding_window_val > 0 and block_local_lookback > -1:
-        block_local_block_size = sliding_window_val // (block_local_lookback + 1)
-        assert block_local_block_size > 0, "sliding_window must be > block_local_lookback+1"
+    # Compute chunked block size from sliding window if needed.
+    chunk_size = -1
+    if sliding_window_val > 0 and chunk_lookback > -1:
+        chunk_size = sliding_window_val // (chunk_lookback + 1)
+        assert chunk_size > 0, "sliding_window must be > chunk_lookback+1"
     elif sliding_window_val <= 0:
-        block_local_lookback = -1
+        chunk_lookback = -1
 
     TILE_SIZE_PREFILL = _get_tile_size(
         head_size,
@@ -1231,8 +1231,8 @@ def unified_attention(
             stride_vs_blk=v_scale_cache.stride(0) if v_scale_cache is not None else 0,
             stride_vs_slot=v_scale_cache.stride(1) if v_scale_cache is not None else 0,
             stride_vs_head=v_scale_cache.stride(2) if v_scale_cache is not None else 0,
-            BLOCK_LOCAL_LOOKBACK=block_local_lookback,
-            BLOCK_LOCAL_BLOCK_SIZE=block_local_block_size,
+            CHUNK_LOOKBACK=chunk_lookback,
+            CHUNK_SIZE=chunk_size,
         )
     else:
         kernel_unified_attention_3d[
@@ -1294,8 +1294,8 @@ def unified_attention(
             stride_vs_blk=v_scale_cache.stride(0) if v_scale_cache is not None else 0,
             stride_vs_slot=v_scale_cache.stride(1) if v_scale_cache is not None else 0,
             stride_vs_head=v_scale_cache.stride(2) if v_scale_cache is not None else 0,
-            BLOCK_LOCAL_LOOKBACK=block_local_lookback,
-            BLOCK_LOCAL_BLOCK_SIZE=block_local_block_size,
+            CHUNK_LOOKBACK=chunk_lookback,
+            CHUNK_SIZE=chunk_size,
         )
         reduce_segments[(q.shape[0], num_query_heads)](
             output_ptr=out,

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -297,9 +297,7 @@ def kernel_unified_attention_2d(
         # [context_len + qpos_lo - SLIDING_WINDOW + 1, context_len + qpos_hi]
         q_abs = context_len + qpos_lo
         if CHUNK_LOOKBACK > -1:
-            first_allowed_key = (
-                (q_abs // CHUNK_SIZE) - CHUNK_LOOKBACK
-            ) * CHUNK_SIZE
+            first_allowed_key = ((q_abs // CHUNK_SIZE) - CHUNK_LOOKBACK) * CHUNK_SIZE
         else:
             first_allowed_key = q_abs - SLIDING_WINDOW + 1
         last_allowed_key = context_len + qpos_hi
@@ -703,9 +701,7 @@ def kernel_unified_attention_3d(
         # [context_len + qpos_lo - SLIDING_WINDOW + 1, context_len + qpos_hi]
         q_abs = context_len + qpos_lo
         if CHUNK_LOOKBACK > -1:
-            first_allowed_key = (
-                (q_abs // CHUNK_SIZE) - CHUNK_LOOKBACK
-            ) * CHUNK_SIZE
+            first_allowed_key = ((q_abs // CHUNK_SIZE) - CHUNK_LOOKBACK) * CHUNK_SIZE
         else:
             first_allowed_key = q_abs - SLIDING_WINDOW + 1
         last_allowed_key = context_len + qpos_hi

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -295,13 +295,13 @@ def kernel_unified_attention_2d(
         # where q_abs = context_len + q
         # The union of allowed key positions for this Q-block is:
         # [context_len + qpos_lo - SLIDING_WINDOW + 1, context_len + qpos_hi]
+        q_abs = context_len + qpos_lo
         if BLOCK_LOCAL_LOOKBACK > -1:
-            q_abs = context_len + qpos_lo
             first_allowed_key = (
                 (q_abs // BLOCK_LOCAL_BLOCK_SIZE) - BLOCK_LOCAL_LOOKBACK
             ) * BLOCK_LOCAL_BLOCK_SIZE
         else:
-            first_allowed_key = context_len + qpos_lo - SLIDING_WINDOW + 1
+            first_allowed_key = q_abs - SLIDING_WINDOW + 1
         last_allowed_key = context_len + qpos_hi
         # Convert to tile indices and clamp
         tile_start = tl.maximum(0, first_allowed_key // TILE_SIZE)
@@ -701,13 +701,13 @@ def kernel_unified_attention_3d(
         # where q_abs = context_len + q
         # The union of allowed key positions for this Q-block is:
         # [context_len + qpos_lo - SLIDING_WINDOW + 1, context_len + qpos_hi]
+        q_abs = context_len + qpos_lo
         if BLOCK_LOCAL_LOOKBACK > -1:
-            q_abs = context_len + qpos_lo
             first_allowed_key = (
                 (q_abs // BLOCK_LOCAL_BLOCK_SIZE) - BLOCK_LOCAL_LOOKBACK
             ) * BLOCK_LOCAL_BLOCK_SIZE
         else:
-            first_allowed_key = context_len + qpos_lo - SLIDING_WINDOW + 1
+            first_allowed_key = q_abs - SLIDING_WINDOW + 1
         last_allowed_key = context_len + qpos_hi
         # Convert to tile indices and clamp
         tile_start = tl.maximum(0, first_allowed_key // TILE_SIZE)

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -177,6 +177,8 @@ def kernel_unified_attention_2d(
     stride_vs_blk=0,
     stride_vs_slot=0,
     stride_vs_head=0,
+    BLOCK_LOCAL_LOOKBACK: tl.constexpr = -1,
+    BLOCK_LOCAL_BLOCK_SIZE: tl.constexpr = -1,
 ):
     q_block_global_idx = tl.program_id(0)
     kv_head_idx = tl.program_id(1)
@@ -293,7 +295,13 @@ def kernel_unified_attention_2d(
         # where q_abs = context_len + q
         # The union of allowed key positions for this Q-block is:
         # [context_len + qpos_lo - SLIDING_WINDOW + 1, context_len + qpos_hi]
-        first_allowed_key = context_len + qpos_lo - SLIDING_WINDOW + 1
+        if BLOCK_LOCAL_LOOKBACK > -1:
+            q_abs = context_len + qpos_lo
+            first_allowed_key = (
+                (q_abs // BLOCK_LOCAL_BLOCK_SIZE) - BLOCK_LOCAL_LOOKBACK
+            ) * BLOCK_LOCAL_BLOCK_SIZE
+        else:
+            first_allowed_key = context_len + qpos_lo - SLIDING_WINDOW + 1
         last_allowed_key = context_len + qpos_hi
         # Convert to tile indices and clamp
         tile_start = tl.maximum(0, first_allowed_key // TILE_SIZE)
@@ -370,9 +378,19 @@ def kernel_unified_attention_2d(
         query_abs_pos = context_len + query_pos[:, None]
         seq_mask = seq_offset[None, :] <= query_abs_pos
 
-        # Apply sliding window to base mask BEFORE mm_prefix OR.
-        # Order must match FlexAttention: (causal AND sliding_window) OR mm_prefix
-        if SLIDING_WINDOW > 0:
+        # Apply sliding window / block-local to base mask BEFORE
+        # mm_prefix OR.
+        # Order must match FlexAttention:
+        #   (causal AND sliding_window) OR mm_prefix
+        if BLOCK_LOCAL_LOOKBACK > -1:
+            seq_mask = seq_mask & (
+                (
+                    (context_len + query_pos[:, None]) // BLOCK_LOCAL_BLOCK_SIZE
+                    - (seq_offset[None, :] // BLOCK_LOCAL_BLOCK_SIZE)
+                )
+                <= BLOCK_LOCAL_LOOKBACK
+            )
+        elif SLIDING_WINDOW > 0:
             seq_mask = seq_mask & ((query_abs_pos - seq_offset) < SLIDING_WINDOW)
 
         # PrefixLM: extend mask with bidirectional ranges for multimodal tokens.
@@ -559,6 +577,8 @@ def kernel_unified_attention_3d(
     stride_vs_blk=0,
     stride_vs_slot=0,
     stride_vs_head=0,
+    BLOCK_LOCAL_LOOKBACK: tl.constexpr = -1,
+    BLOCK_LOCAL_BLOCK_SIZE: tl.constexpr = -1,
 ):
     q_block_global_idx = tl.program_id(0)
     kv_head_idx = tl.program_id(1)
@@ -681,7 +701,13 @@ def kernel_unified_attention_3d(
         # where q_abs = context_len + q
         # The union of allowed key positions for this Q-block is:
         # [context_len + qpos_lo - SLIDING_WINDOW + 1, context_len + qpos_hi]
-        first_allowed_key = context_len + qpos_lo - SLIDING_WINDOW + 1
+        if BLOCK_LOCAL_LOOKBACK > -1:
+            q_abs = context_len + qpos_lo
+            first_allowed_key = (
+                (q_abs // BLOCK_LOCAL_BLOCK_SIZE) - BLOCK_LOCAL_LOOKBACK
+            ) * BLOCK_LOCAL_BLOCK_SIZE
+        else:
+            first_allowed_key = context_len + qpos_lo - SLIDING_WINDOW + 1
         last_allowed_key = context_len + qpos_hi
         # Convert to tile indices and clamp
         tile_start = tl.maximum(0, first_allowed_key // TILE_SIZE)
@@ -761,9 +787,19 @@ def kernel_unified_attention_3d(
         query_abs_pos = context_len + query_pos[:, None]
         seq_mask = seq_offset[None, :] <= query_abs_pos
 
-        # Apply sliding window to base mask BEFORE mm_prefix OR.
-        # Order must match FlexAttention: (causal AND sliding_window) OR mm_prefix
-        if SLIDING_WINDOW > 0:
+        # Apply sliding window / block-local to base mask BEFORE
+        # mm_prefix OR.
+        # Order must match FlexAttention:
+        #   (causal AND sliding_window) OR mm_prefix
+        if BLOCK_LOCAL_LOOKBACK > -1:
+            seq_mask = seq_mask & (
+                (
+                    (context_len + query_pos[:, None]) // BLOCK_LOCAL_BLOCK_SIZE
+                    - (seq_offset[None, :] // BLOCK_LOCAL_BLOCK_SIZE)
+                )
+                <= BLOCK_LOCAL_LOOKBACK
+            )
+        elif SLIDING_WINDOW > 0:
             seq_mask = seq_mask & ((query_abs_pos - seq_offset) < SLIDING_WINDOW)
 
         # PrefixLM: extend mask with bidirectional ranges for multimodal tokens.
@@ -1046,6 +1082,8 @@ def unified_attention(
     kv_quant_mode: KVQuantMode = KVQuantMode.NONE,
     k_scale_cache=None,  # [num_blocks, block_size, num_kv_heads] float32
     v_scale_cache=None,  # [num_blocks, block_size, num_kv_heads] float32
+    # Block-local attention: restrict attention to aligned blocks.
+    block_local_lookback=-1,
 ):
     assert causal, "Only causal attention is supported"
     assert q_descale is None, "Q scales not supported"
@@ -1093,6 +1131,14 @@ def unified_attention(
     # Tile sizes for prefill and decode. Gemma3 models use optimized values.
     # Note: tile size must be at least 32 for fp8 (element_size == 1).
     sliding_window_val = 1 + window_size[0] if window_size[0] >= 0 else 0
+
+    # Compute block-local block size from sliding window if needed.
+    block_local_block_size = -1
+    if sliding_window_val > 0 and block_local_lookback > -1:
+        block_local_block_size = sliding_window_val // (block_local_lookback + 1)
+    elif sliding_window_val <= 0:
+        block_local_lookback = -1
+
     TILE_SIZE_PREFILL = _get_tile_size(
         head_size,
         sliding_window_val,
@@ -1184,6 +1230,8 @@ def unified_attention(
             stride_vs_blk=v_scale_cache.stride(0) if v_scale_cache is not None else 0,
             stride_vs_slot=v_scale_cache.stride(1) if v_scale_cache is not None else 0,
             stride_vs_head=v_scale_cache.stride(2) if v_scale_cache is not None else 0,
+            BLOCK_LOCAL_LOOKBACK=block_local_lookback,
+            BLOCK_LOCAL_BLOCK_SIZE=block_local_block_size,
         )
     else:
         kernel_unified_attention_3d[
@@ -1245,6 +1293,8 @@ def unified_attention(
             stride_vs_blk=v_scale_cache.stride(0) if v_scale_cache is not None else 0,
             stride_vs_slot=v_scale_cache.stride(1) if v_scale_cache is not None else 0,
             stride_vs_head=v_scale_cache.stride(2) if v_scale_cache is not None else 0,
+            BLOCK_LOCAL_LOOKBACK=block_local_lookback,
+            BLOCK_LOCAL_BLOCK_SIZE=block_local_block_size,
         )
         reduce_segments[(q.shape[0], num_query_heads)](
             output_ptr=out,


### PR DESCRIPTION
## Purpose

This adds support for an upcoming model from Essential AI in the Rnj-1 series.

Rnj-1 used a similar enough architecture to Gemma3 that no code changes were needed (see config [here](https://huggingface.co/EssentialAI/rnj-1-instruct/blob/main/config.json)). This upcoming model also has a similar architecture, but it requires two changes, which we've implemented as options on the Gemma3 model file:

- Gemma3 uses YaRN for global layers and RoPE for local layers; our model uses YaRN for all layers.  This adds support for a `local_rope_type` parameter that can be set to `"yarn"`.
- Gemma3 uses sliding window attention in local layers; our model uses block-local attention.  This adds support for block-local attention in the unified triton kernel and threads a config through the Gemma3 model to allow it to be used.

Block-local attention is similar to sliding window but has a different masking pattern.  Each query token can attend to keys in the current block or N previous blocks.  It has two configuration parameters: the size of these blocks, and the number of lookback blocks (usually 1, in addition to the current block).  For example, if the block size is 512 tokens and the number of lookback blocks is 1, then the max receptive field is 1024 tokens, since the last token in a block can attend to the current block and previous one.

The implementation in this PR is intended to be minimally disruptive but fully functional.  Open to feedback on how to best integrate these changes.  One way it's perhaps too minimal is that we re-use the name `"linear_attention"` for the `layer_types` entry for block-local attention because it needs to be in the `ALLOWED_LAYER_TYPES` [list](https://github.com/huggingface/transformers/blob/e40b0c0195569becf0cafa63c21df33defa710f7/src/transformers/configuration_utils.py#L62) in Transformers.

## Test Plan

I ran RULER at 32k sequence length on gemma3-4b-it and a checkpoint of our unreleased model using the following docker images: (1) v0.19.0, (2) the changes in this PR, and (3) our internal fork of VLLM that we have used extensively during development of the model.  Since we've used our internal fork extensively, my main concern was that extracting these changes could introduce a bug.

Expectation: gemma3-4b-it should receive identical results on all three images, and our model should receive good results on images (2) and (3) but not on (1).

## Test Result

Gemma3-4b-it received nearly identical results on all three images, with all top-line results within 0.2%.  Each sub-task was also very similar.  So no regression on Gemma3.

Our model received significantly worse results on the v0.19.0 image on several subtasks, especially CWE where it was 17% worse.  The top-line result was closer, because many of the subtasks are saturated at 32k.

This matches expectations.

## AI Usage

The original implementation was written by humans, but AI assistance was used to extract and rebase the changes to a recent commit.