### PR TITLE
[Bugfix] Disable FlashInfer CUTLASS MoE on SM121 (DGX Spark)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer_cutlass_moe.py
@@ -130,7 +130,14 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
                 p.is_device_capability(90)
                 or p.is_device_capability_family(100)
                 or p.is_device_capability_family(110)
-                or p.is_device_capability_family(120)
+                or p.is_device_capability(120)
+                # NOTE: SM121 (DGX Spark) is excluded because the bf16
+                # unquantized CUTLASS MoE GEMM in flashinfer <= 0.6.7 has no
+                # Relu2 template instantiation and throws "Invalid activation
+                # type" on Nemotron-H. Fixed upstream by
+                # https://github.com/flashinfer-ai/flashinfer/pull/2926
+                # (merged 2026-04-01, not yet in a stable release); lift this
+                # restriction once flashinfer >= 0.6.8 is the minimum.
             )
             and has_flashinfer_cutlass_fused_moe()
         )


### PR DESCRIPTION
The bf16 unquantized CUTLASS MoE GEMM in flashinfer <= 0.6.7 has no `Relu2` template instantiation and throws `Invalid activation type` at `moe_gemm_template_dispatch.h:1042` when running Nemotron-H (MTP drafter) on SM121. Narrow the SM120 family gate to exact SM120 so the oracle falls back to Triton on SM121.

Fixed upstream by https://github.com/flashinfer-ai/flashinfer/pull/2926 (merged 2026-04-01, not in a stable release yet). The guard can be removed once flashinfer >= 0.6.8 is the minimum.

## Test plan

Before (SM121, `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` with `-sc.method mtp`): EngineCore crashes in profile_run with `RuntimeError: Invalid activation type.` from `flashinfer_cutlass_fused_moe`.

After: drafter's unquantized MoE falls back to Triton and the server starts.

AI assistance (Claude Code) was used to diagnose and draft this change.