### PR TITLE
[ROCm][MLA] validate AITER head counts during selection

### DIFF
--- a/tests/v1/attention/test_rocm_aiter_mla_head_selection.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_head_selection.py
@@ -4,7 +4,7 @@
 import importlib
 import sys
 import types
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 import pytest
 import torch
@@ -90,7 +90,7 @@ class FakeTritonMLABackend(_FakeMLABackend):
 
 
 def _install_fake_amdsmi(monkeypatch: pytest.MonkeyPatch) -> None:
-    fake_amdsmi = types.ModuleType("amdsmi")
+    fake_amdsmi: Any = types.ModuleType("amdsmi")
 
     class AmdSmiException(Exception):
         pass
@@ -108,7 +108,7 @@ def _install_fake_amdsmi(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def _install_fake_aiter_ops(monkeypatch: pytest.MonkeyPatch) -> None:
-    fake_aiter_ops = types.ModuleType("vllm._aiter_ops")
+    fake_aiter_ops: Any = types.ModuleType("vllm._aiter_ops")
 
     class FakeRocmAiterOps:
         @staticmethod

--- a/tests/v1/attention/test_rocm_aiter_mla_head_selection.py
+++ b/tests/v1/attention/test_rocm_aiter_mla_head_selection.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import importlib
+import sys
+import types
+from typing import NamedTuple
+
+import pytest
+import torch
+
+from vllm.v1.attention.backend import AttentionBackend
+from vllm.v1.attention.backends.registry import (
+    AttentionBackendEnum,
+    register_backend,
+)
+
+
+class AttentionSelectorConfig(NamedTuple):
+    head_size: int
+    dtype: torch.dtype
+    kv_cache_dtype: str | None
+    block_size: int | None
+    use_mla: bool = False
+    has_sink: bool = False
+    use_sparse: bool = False
+    use_mm_prefix: bool = False
+    use_per_head_quant_scales: bool = False
+    attn_type: str = "decoder"
+    use_non_causal: bool = False
+
+
+class _FakeMLABackend(AttentionBackend):
+    @staticmethod
+    def get_name() -> str:
+        return "FAKE_MLA"
+
+    @staticmethod
+    def get_impl_cls():
+        return object
+
+    @staticmethod
+    def get_builder_cls():
+        return object
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        return (num_blocks, block_size, num_kv_heads, head_size)
+
+    @classmethod
+    def is_mla(cls) -> bool:
+        return True
+
+
+class FakeRocmAiterMLABackend(_FakeMLABackend):
+    @staticmethod
+    def get_name() -> str:
+        return "FAKE_ROCM_AITER_MLA"
+
+    @classmethod
+    def supports_num_heads(cls, num_heads: int | None) -> str | None:
+        if num_heads is None:
+            return None
+
+        valid_heads = num_heads in (4, 8) or (
+            num_heads % 16 == 0 and 16 <= num_heads <= 128
+        )
+        if valid_heads:
+            return None
+
+        return "num_heads not supported"
+
+
+class FakeRocmAiterTritonMLABackend(FakeRocmAiterMLABackend):
+    @staticmethod
+    def get_name() -> str:
+        return "FAKE_ROCM_AITER_TRITON_MLA"
+
+
+class FakeTritonMLABackend(_FakeMLABackend):
+    @staticmethod
+    def get_name() -> str:
+        return "FAKE_TRITON_MLA"
+
+
+def _install_fake_amdsmi(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_amdsmi = types.ModuleType("amdsmi")
+
+    class AmdSmiException(Exception):
+        pass
+
+    fake_amdsmi.AmdSmiException = AmdSmiException
+    fake_amdsmi.amdsmi_init = lambda: None
+    fake_amdsmi.amdsmi_shut_down = lambda: None
+    fake_amdsmi.amdsmi_get_processor_handles = lambda: ["gpu0"]
+    fake_amdsmi.amdsmi_get_gpu_asic_info = lambda handle: {
+        "target_graphics_version": "gfx942"
+    }
+    fake_amdsmi.amdsmi_get_gpu_device_uuid = lambda handle: "uuid"
+    fake_amdsmi.amdsmi_topo_get_link_type = lambda src, dst: {"hops": 1, "type": 2}
+    monkeypatch.setitem(sys.modules, "amdsmi", fake_amdsmi)
+
+
+def _install_fake_aiter_ops(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_aiter_ops = types.ModuleType("vllm._aiter_ops")
+
+    class FakeRocmAiterOps:
+        @staticmethod
+        def is_mla_enabled() -> bool:
+            return True
+
+        @staticmethod
+        def is_mha_enabled() -> bool:
+            return False
+
+        @staticmethod
+        def is_unified_attention_enabled() -> bool:
+            return False
+
+    fake_aiter_ops.rocm_aiter_ops = FakeRocmAiterOps()
+    fake_aiter_ops.is_aiter_found_and_supported = lambda *args, **kwargs: True
+    monkeypatch.setitem(sys.modules, "vllm._aiter_ops", fake_aiter_ops)
+
+
+def _override_backends() -> None:
+    register_backend(
+        AttentionBackendEnum.ROCM_AITER_MLA,
+        f"{__name__}.FakeRocmAiterMLABackend",
+    )
+    register_backend(
+        AttentionBackendEnum.ROCM_AITER_TRITON_MLA,
+        f"{__name__}.FakeRocmAiterTritonMLABackend",
+    )
+    register_backend(
+        AttentionBackendEnum.TRITON_MLA,
+        f"{__name__}.FakeTritonMLABackend",
+    )
+
+
+def _clear_backend_overrides() -> None:
+    AttentionBackendEnum.ROCM_AITER_MLA.clear_override()
+    AttentionBackendEnum.ROCM_AITER_TRITON_MLA.clear_override()
+    AttentionBackendEnum.TRITON_MLA.clear_override()
+
+
+def _load_rocm_platform(monkeypatch: pytest.MonkeyPatch):
+    _install_fake_amdsmi(monkeypatch)
+    _install_fake_aiter_ops(monkeypatch)
+    _override_backends()
+
+    for module_name in ("vllm.platforms.rocm",):
+        sys.modules.pop(module_name, None)
+
+    return importlib.import_module("vllm.platforms.rocm")
+
+
+@pytest.fixture(autouse=True)
+def _cleanup_backend_overrides():
+    yield
+    _clear_backend_overrides()
+
+
+def _make_selector_config() -> AttentionSelectorConfig:
+    return AttentionSelectorConfig(
+        head_size=128,
+        dtype=torch.float16,
+        kv_cache_dtype="auto",
+        block_size=16,
+        use_mla=True,
+        has_sink=False,
+        use_sparse=False,
+    )
+
+
+def test_auto_selection_falls_back_for_unsupported_dense_aiter_heads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rocm = _load_rocm_platform(monkeypatch)
+
+    backend_path = rocm.RocmPlatform.get_attn_backend_cls(
+        selected_backend=None,
+        attn_selector_config=_make_selector_config(),
+        num_heads=24,
+    )
+
+    assert backend_path == AttentionBackendEnum.TRITON_MLA.get_path()
+
+
+def test_auto_selection_keeps_supported_dense_aiter_heads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rocm = _load_rocm_platform(monkeypatch)
+
+    backend_path = rocm.RocmPlatform.get_attn_backend_cls(
+        selected_backend=None,
+        attn_selector_config=_make_selector_config(),
+        num_heads=32,
+    )
+
+    assert backend_path == AttentionBackendEnum.ROCM_AITER_MLA.get_path()
+
+
+@pytest.mark.parametrize(
+    "backend",
+    [
+        AttentionBackendEnum.ROCM_AITER_MLA,
+        AttentionBackendEnum.ROCM_AITER_TRITON_MLA,
+    ],
+)
+def test_explicit_dense_aiter_selection_rejects_unsupported_heads(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: AttentionBackendEnum,
+) -> None:
+    rocm = _load_rocm_platform(monkeypatch)
+
+    with pytest.raises(ValueError, match="num_heads not supported"):
+        rocm.RocmPlatform.get_attn_backend_cls(
+            selected_backend=backend,
+            attn_selector_config=_make_selector_config(),
+            num_heads=24,
+        )

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -379,6 +379,7 @@ class CudaPlatformBase(Platform):
                 backend_class = _get_attn_backend_class(backend)
                 invalid_reasons_i = backend_class.validate_configuration(
                     device_capability=device_capability,
+                    num_heads=num_heads,
                     **attn_selector_config._asdict(),
                 )
             except ImportError:
@@ -408,6 +409,7 @@ class CudaPlatformBase(Platform):
                 backend_class = _get_attn_backend_class(selected_backend)
                 invalid_reasons = backend_class.validate_configuration(
                     device_capability=device_capability,
+                    num_heads=num_heads,
                     **attn_selector_config._asdict(),
                 )
             except ImportError:

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -400,6 +400,7 @@ class CudaPlatformBase(Platform):
                 backend_class = _get_attn_backend_class(backend)
                 invalid_reasons_i = backend_class.validate_configuration(
                     device_capability=device_capability,
+                    num_heads=num_heads,
                     **attn_selector_config._asdict(),
                 )
             except (ImportError, OSError) as e:
@@ -452,6 +453,7 @@ class CudaPlatformBase(Platform):
                 backend_class = _get_attn_backend_class(selected_backend)
                 invalid_reasons = backend_class.validate_configuration(
                     device_capability=device_capability,
+                    num_heads=num_heads,
                     **attn_selector_config._asdict(),
                 )
             except (ImportError, OSError) as e:

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -530,6 +530,7 @@ class RocmPlatform(Platform):
                 backend_class = backend.get_class()
                 invalid_reasons_i = backend_class.validate_configuration(
                     device_capability=device_capability,
+                    num_heads=num_heads,
                     **attn_selector_config._asdict(),
                 )
             except ImportError:
@@ -557,6 +558,7 @@ class RocmPlatform(Platform):
                 backend_class = selected_backend.get_class()
                 invalid_reasons = backend_class.validate_configuration(
                     device_capability=device_capability,
+                    num_heads=num_heads,
                     **attn_selector_config._asdict(),
                 )
             except ImportError:

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -603,6 +603,7 @@ class RocmPlatform(Platform):
                 backend_class = backend.get_class()
                 invalid_reasons_i = backend_class.validate_configuration(
                     device_capability=device_capability,
+                    num_heads=num_heads,
                     **attn_selector_config._asdict(),
                 )
             except ImportError:
@@ -630,6 +631,7 @@ class RocmPlatform(Platform):
                 backend_class = selected_backend.get_class()
                 sel_invalid_reasons = backend_class.validate_configuration(
                     device_capability=device_capability,
+                    num_heads=num_heads,
                     **attn_selector_config._asdict(),
                 )
             except ImportError:

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -317,6 +317,10 @@ class AttentionBackend(ABC):
         return None
 
     @classmethod
+    def supports_num_heads(cls, num_heads: int | None) -> str | None:
+        return None
+
+    @classmethod
     def validate_configuration(
         cls,
         head_size: int,
@@ -335,6 +339,7 @@ class AttentionBackend(ABC):
         use_batch_invariant: bool = False,
         use_kv_connector: bool = False,
         use_pcp: bool = False,
+        num_heads: int | None = None,
     ) -> list[str]:
         invalid_reasons = []
         if not cls.supports_head_size(head_size):
@@ -390,6 +395,9 @@ class AttentionBackend(ABC):
         )
         if combination_reason is not None:
             invalid_reasons.append(combination_reason)
+        num_heads_reason = cls.supports_num_heads(num_heads)
+        if num_heads_reason is not None:
+            invalid_reasons.append(num_heads_reason)
         return invalid_reasons
 
     @classmethod

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -267,6 +267,10 @@ class AttentionBackend(ABC):
         return None
 
     @classmethod
+    def supports_num_heads(cls, num_heads: int | None) -> str | None:
+        return None
+
+    @classmethod
     def validate_configuration(
         cls,
         head_size: int,
@@ -287,6 +291,7 @@ class AttentionBackend(ABC):
         use_pcp: bool = False,
         use_adaptive_verification: bool = False,
         use_dcp: bool = False,
+        num_heads: int | None = None,
     ) -> list[str]:
         invalid_reasons = []
         if not cls.supports_head_size(head_size):
@@ -354,6 +359,9 @@ class AttentionBackend(ABC):
         )
         if combination_reason is not None:
             invalid_reasons.append(combination_reason)
+        num_heads_reason = cls.supports_num_heads(num_heads)
+        if num_heads_reason is not None:
+            invalid_reasons.append(num_heads_reason)
         return invalid_reasons
 
     @classmethod

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -86,6 +86,22 @@ class AiterMLABackend(MLACommonBackend):
     def get_builder_cls() -> type["AiterMLAMetadataBuilder"]:
         return AiterMLAMetadataBuilder
 
+    @classmethod
+    def supports_num_heads(cls, num_heads: int | None) -> str | None:
+        if num_heads is None:
+            return None
+
+        valid_heads = num_heads in (4, 8) or (
+            num_heads % 16 == 0 and 16 <= num_heads <= 128
+        )
+        if valid_heads:
+            return None
+
+        return (
+            "num_heads not supported; ROCm AITER MLA supports 4, 8, "
+            "or multiples of 16 in [16, 128]"
+        )
+
 
 @dataclass
 class AiterMLADecodeMetadata(MLACommonDecodeMetadata):

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -259,6 +259,22 @@ class AiterMLABackend(MLACommonBackend):
     def get_builder_cls() -> type["AiterMLAMetadataBuilder"]:
         return AiterMLAMetadataBuilder
 
+    @classmethod
+    def supports_num_heads(cls, num_heads: int | None) -> str | None:
+        if num_heads is None:
+            return None
+
+        valid_heads = num_heads in (4, 8) or (
+            num_heads % 16 == 0 and 16 <= num_heads <= 128
+        )
+        if valid_heads:
+            return None
+
+        return (
+            "num_heads not supported; ROCm AITER MLA supports 4, 8, "
+            "or multiples of 16 in [16, 128]"
+        )
+
 
 @dataclass
 class AiterMLADCPVerifyMetadata:


### PR DESCRIPTION
## Summary
- reject unsupported dense ROCm AITER MLA head counts during backend selection instead of waiting for backend construction to assert
- keep supported counts like `32` on the AITER path; the remaining bad case on current `main` is unsupported dense counts such as `24`
- add a selector-focused regression that exercises fallback and explicit backend validation without depending on the full ROCm kernel stack

## Why this is not duplicating an existing PR
- I re-ran the duplicate checks for `#38972` and related ROCm MLA keywords before opening this.
- The closest open PR is `#36855`, but that one fixes the sparse MLA `num_heads < 16` path by repeating heads at runtime.
- This PR is about dense ROCm AITER MLA backend selection rejecting unsupported head counts up front so selection can fall back cleanly.

## Testing
- `uv run --no-project --with pytest --with torch --with numpy --with packaging --with pyyaml --with regex --with pydantic --with typing_extensions --with filelock --with cachetools --with blake3 --with msgspec --with msgpack --with cloudpickle --with psutil --with requests --with tqdm --with cbor2 --with pyzmq --with huggingface_hub --with transformers python -m pytest tests/v1/attention/test_rocm_aiter_mla_head_selection.py -q --noconftest`
- `uv run --no-project python -m py_compile vllm/v1/attention/backend.py vllm/platforms/rocm.py vllm/platforms/cuda.py vllm/v1/attention/backends/mla/rocm_aiter_mla.py tests/v1/attention/test_rocm_aiter_mla_head_selection.py`
- `git diff --check`

## AI assistance
- I used AI assistance for drafting and local implementation, and I reviewed the final diff and test results before opening this PR.

Refs #38972.
