### PR TITLE
[MRv2]fix: model accuracy regression caused by reusing the stale last_sampled_tokens and draft_tokens

### DIFF
--- a/vllm/v1/worker/gpu/states.py
+++ b/vllm/v1/worker/gpu/states.py
@@ -102,6 +102,18 @@ class RequestState:
         self.num_computed_prefill_tokens[req_idx] = num_computed_tokens
         self.num_computed_tokens.stage_write_elem(req_idx, num_computed_tokens)
 
+        if num_computed_tokens > 0 and num_computed_tokens <= prefill_len:
+            # For PD disagg or resumed requests: set last_sampled to the last
+            # computed token so the first decode step gets the right input_id.
+            # For fresh prefill requests (num_computed_tokens == 0) the tensor
+            # is not read by combine_sampled_and_draft_tokens so we skip the
+            # write. Use a slice assignment rather than scalar indexing so the
+            # write is dispatched through fill_ without a host/device sync.
+            self.last_sampled_tokens[req_idx : req_idx + 1] = all_token_ids[
+                num_computed_tokens - 1
+            ]
+        self.draft_tokens[req_idx].zero_()
+
     def apply_staged_writes(self) -> None:
         self.prompt_len.copy_to_uva()
         self.prefill_len.copy_to_uva()


### PR DESCRIPTION
## Summary
- Fix ~13% GSM8K accuracy regression in PD disaggregation caused by stale `last_sampled_tokens` and `draft_tokens` leaking between requests when V2 model runner reuses request state slots
- In `add_request()`, initialize `last_sampled_tokens` to the last computed token and zero out `draft_tokens`

## Root Cause
In PD disagg, the decode side receives requests with `num_computed_tokens == prefill_len` (fully prefilled). The first iteration is a decode step — no prefill step runs to initialize `last_sampled_tokens` via `postprocess()`. The `combine_sampled_and_draft_tokens` kernel reads the stale value from a previous request that occupied the same slot.

**Bug location:** `vllm/v1/worker/gpu/states.py:add_request()`

## Test plan
- [x] GSM8K score restored: V2+fix = 0.94 (V1 baseline = 0.93, V2 before fix = 0.82)
- [x] Verified with full GSM8K eval at concurrency=32 on Crusoe GB200 NVL72

This PR was AI-assisted (Claude Code).