### PR TITLE
[ROCm] INT8 WMMA fast path for QK dot-product in unified attention 2D (INT8_PER_TOKEN_HEAD)

### DIFF
--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -1172,24 +1172,9 @@ def unified_attention(
         is_prefill=False,
     )
 
-    # Route both the QK and PV dots through AMD WMMA/MFMA int8 when the
-    # KV cache is int8 per-token-head on ROCm.
-    #
-    # Why this is a win on AMD:
-    #   * RDNA3 (gfx1100) WMMA int8 runs at ~2x the throughput of bf16
-    #     (v_wmma_i32_16x16x16_iu8 vs v_wmma_f32_16x16x16_bf16).
-    #   * CDNA2/CDNA3 (MI2xx/MI3xx) MFMA int8 is also markedly faster
-    #     than the bf16 variant.
-    #   * Keeping K and V in their native int8 layout drops the
-    #     HEAD_SIZE x TILE int8->bf16 casts the original path ran on
-    #     every tile — a cost that scales as O(seqlen^2) during prefill.
-    #   * Q is quantized to int8 once per Q-block outside the tile loop
-    #     (amortized across all tiles); P is quantized per tile but the
-    #     BLOCK_M x TILE cost is small vs the BLOCK_M x TILE x HEAD_SIZE
-    #     int8 WMMA it enables.
-    #
-    # Gated off for NVIDIA: not benchmarked there, keep the existing
-    # bf16 path. Gated off for fp8 modes: int8 WMMA cannot consume fp8.
+    # Route the QK dot through AMD int8 WMMA (~2x bf16 throughput on
+    # RDNA3/CDNA) when the KV cache is int8 per-token-head on ROCm.
+    # Also drops the per-tile int8->bf16 cast on K.
     use_rocm_int8_wmma_qk = (
         kv_quant_mode == KVQuantMode.INT8_PER_TOKEN_HEAD and current_platform.is_rocm()
     )

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -165,6 +165,10 @@ def kernel_unified_attention_2d(
     USE_FP8: tl.constexpr,  # bool
     # KV cache quantization: 0=none, 1=fp8, 2=per-token-head
     KV_QUANT_MODE: tl.constexpr = 0,
+    # Use int8 WMMA for the QK dot (requires KV_QUANT_MODE==2 and int8 cache)
+    QK_INT8_WMMA: tl.constexpr = False,
+    # Use int8 WMMA for the PV dot (requires KV_QUANT_MODE==2 and int8 cache)
+    PV_INT8_WMMA: tl.constexpr = False,
     FP8_MIN: tl.constexpr = float8_info.min,
     FP8_MAX: tl.constexpr = float8_info.max,
     # Per-token-head scale caches (KV_QUANT_MODE >= 2)
@@ -220,6 +224,14 @@ def kernel_unified_attention_2d(
         mask=dim_mask[None, :] & query_mask_0[:, None] & query_mask_1[:, None],
         other=0.0,
     )
+
+    # Per-row symmetric int8 quantization of Q, reused across all tiles.
+    # Enables int8 WMMA for the QK dot when the K cache is also int8.
+    if QK_INT8_WMMA:
+        Q_f32 = Q.to(tl.float32)
+        q_absmax = tl.max(tl.abs(Q_f32), axis=1)
+        q_scale = tl.maximum(q_absmax * (1.0 / 127.0), 1e-6)
+        Q_q = tl.clamp(Q_f32 * (1.0 / q_scale)[:, None], -128.0, 127.0).to(tl.int8)
 
     block_table_offset = seq_idx * block_table_stride
 
@@ -328,21 +340,35 @@ def kernel_unified_attention_2d(
             mask=dim_mask[:, None] & tile_mask[None, :],
             other=0.0,
         )
-        K, k_token_head_scales = _prepare_kv_tile(
-            K_load,
-            Q,
-            k_scale,
-            k_scale_cache_ptr,
-            physical_block_idx,
-            seq_offset,
-            kv_head_idx,
-            stride_ks_blk,
-            stride_ks_slot,
-            stride_ks_head,
-            tile_mask,
-            BLOCK_SIZE,
-            KV_QUANT_MODE,
-        )
+        if QK_INT8_WMMA:
+            # Keep K in int8; pair with the int8-quantized Q for a WMMA int8
+            # dot. Load the per-token-head k_scale separately and apply it
+            # post-dot fused with softmax_scale and q_scale.
+            K = K_load
+            scale_idx = (
+                physical_block_idx * stride_ks_blk
+                + (seq_offset % BLOCK_SIZE) * stride_ks_slot
+                + kv_head_idx * stride_ks_head
+            )
+            k_token_head_scales = tl.load(
+                k_scale_cache_ptr + scale_idx, mask=tile_mask, other=1.0
+            )
+        else:
+            K, k_token_head_scales = _prepare_kv_tile(
+                K_load,
+                Q,
+                k_scale,
+                k_scale_cache_ptr,
+                physical_block_idx,
+                seq_offset,
+                kv_head_idx,
+                stride_ks_blk,
+                stride_ks_slot,
+                stride_ks_head,
+                tile_mask,
+                BLOCK_SIZE,
+                KV_QUANT_MODE,
+            )
 
         # V : (TILE_SIZE, HEAD_SIZE)
         V_load = tl.load(
@@ -350,21 +376,34 @@ def kernel_unified_attention_2d(
             mask=dim_mask[None, :] & tile_mask[:, None],
             other=0.0,
         )
-        V, v_token_head_scales = _prepare_kv_tile(
-            V_load,
-            Q,
-            v_scale,
-            v_scale_cache_ptr,
-            physical_block_idx,
-            seq_offset,
-            kv_head_idx,
-            stride_vs_blk,
-            stride_vs_slot,
-            stride_vs_head,
-            tile_mask,
-            BLOCK_SIZE,
-            KV_QUANT_MODE,
-        )
+        if PV_INT8_WMMA:
+            # Keep V in int8; pair with an int8-quantized P (computed per
+            # tile after softmax) for a WMMA int8 PV dot.
+            V = V_load
+            scale_idx_v = (
+                physical_block_idx * stride_vs_blk
+                + (seq_offset % BLOCK_SIZE) * stride_vs_slot
+                + kv_head_idx * stride_vs_head
+            )
+            v_token_head_scales = tl.load(
+                v_scale_cache_ptr + scale_idx_v, mask=tile_mask, other=1.0
+            )
+        else:
+            V, v_token_head_scales = _prepare_kv_tile(
+                V_load,
+                Q,
+                v_scale,
+                v_scale_cache_ptr,
+                physical_block_idx,
+                seq_offset,
+                kv_head_idx,
+                stride_vs_blk,
+                stride_vs_slot,
+                stride_vs_head,
+                tile_mask,
+                BLOCK_SIZE,
+                KV_QUANT_MODE,
+            )
 
         # Compute attention mask: causal by default (key <= query)
         query_abs_pos = context_len + query_pos[:, None]
@@ -402,9 +441,15 @@ def kernel_unified_attention_2d(
         # S : (BLOCK_M, TILE_SIZE)
         S = tl.zeros(shape=(BLOCK_M, TILE_SIZE), dtype=tl.float32)
 
-        # Per-token-head quant: fuse softmax_scale with per-head k_scale
-        # to avoid a separate BLOCK_M × TILE_SIZE multiply on S.
-        if KV_QUANT_MODE >= 2:
+        if QK_INT8_WMMA:
+            # int8 WMMA QK: fused scale = softmax_scale * q_scale * k_scale.
+            qk_i32 = tl.dot(Q_q, K, out_dtype=tl.int32)
+            S += qk_i32.to(tl.float32) * (
+                scale * q_scale[:, None] * k_token_head_scales[None, :]
+            )
+        elif KV_QUANT_MODE >= 2:
+            # Per-token-head quant: fuse softmax_scale with per-head k_scale
+            # to avoid a separate BLOCK_M × TILE_SIZE multiply on S.
             S += tl.dot(Q, K) * (scale * k_token_head_scales[None, :])
         else:
             S += scale * tl.dot(Q, K)
@@ -466,13 +511,26 @@ def kernel_unified_attention_2d(
 
         if SLIDING_WINDOW:
             qpos_lo = q_block_local_idx * BLOCK_Q
-            V = tl.where(
-                (context_len + qpos_lo - seq_offset[:, None]) < SLIDING_WINDOW, V, 0.0
-            )
+            sw_mask = (context_len + qpos_lo - seq_offset[:, None]) < SLIDING_WINDOW
+            if PV_INT8_WMMA:
+                V = tl.where(sw_mask, V, tl.zeros_like(V))
+            else:
+                V = tl.where(sw_mask, V, 0.0)
 
         # acc : (BLOCK_M, HEAD_SIZE_PADDED)
-        # Per-token-head quant: apply v_scale to P instead of V.
-        if KV_QUANT_MODE >= 2:
+        if PV_INT8_WMMA:
+            # int8 WMMA PV: fuse v_scales into P (fp32), quantize per row to
+            # int8, dot against int8 V, then rescale by per-row p_scale.
+            P_v_f32 = P * v_token_head_scales[None, :]
+            p_absmax = tl.max(P_v_f32, axis=1)  # P_v_f32 >= 0
+            p_scale = tl.maximum(p_absmax * (1.0 / 127.0), 1e-6)
+            P_v_q = tl.clamp(
+                P_v_f32 * (1.0 / p_scale)[:, None], 0.0, 127.0
+            ).to(tl.int8)
+            pv_i32 = tl.dot(P_v_q, V, out_dtype=tl.int32)
+            acc += pv_i32.to(tl.float32) * p_scale[:, None]
+        elif KV_QUANT_MODE >= 2:
+            # Per-token-head quant (bf16 path): apply v_scale to P not V.
             P_v = (P * v_token_head_scales[None, :]).to(V.dtype)
             acc += tl.dot(P_v, V)
         else:
@@ -1106,6 +1164,29 @@ def unified_attention(
         is_prefill=False,
     )
 
+    # Route both the QK and PV dots through AMD WMMA/MFMA int8 when the
+    # KV cache is int8 per-token-head on ROCm.
+    #
+    # Why this is a win on AMD:
+    #   * RDNA3 (gfx1100) WMMA int8 runs at ~2x the throughput of bf16
+    #     (v_wmma_i32_16x16x16_iu8 vs v_wmma_f32_16x16x16_bf16).
+    #   * CDNA2/CDNA3 (MI2xx/MI3xx) MFMA int8 is also markedly faster
+    #     than the bf16 variant.
+    #   * Keeping K and V in their native int8 layout drops the
+    #     HEAD_SIZE x TILE int8->bf16 casts the original path ran on
+    #     every tile — a cost that scales as O(seqlen^2) during prefill.
+    #   * Q is quantized to int8 once per Q-block outside the tile loop
+    #     (amortized across all tiles); P is quantized per tile but the
+    #     BLOCK_M x TILE cost is small vs the BLOCK_M x TILE x HEAD_SIZE
+    #     int8 WMMA it enables.
+    #
+    # Gated off for NVIDIA: not benchmarked there, keep the existing
+    # bf16 path. Gated off for fp8 modes: int8 WMMA cannot consume fp8.
+    use_rocm_int8_wmma_qk = (
+        kv_quant_mode == KVQuantMode.INT8_PER_TOKEN_HEAD
+        and current_platform.is_rocm()
+    )
+
     # Launch the 2D kernel if
     # 1. No intermediate tiled softmax buffers for the 3D kernel have been allocated, or
     # 2. The batch includes at least one prefill request, or
@@ -1176,6 +1257,11 @@ def unified_attention(
             BLOCK_M=BLOCK_M,
             USE_FP8=output_scale is not None,
             KV_QUANT_MODE=kv_quant_mode,
+            QK_INT8_WMMA=use_rocm_int8_wmma_qk,
+            # PV int8 WMMA disabled: measured regression on gfx1100 —
+            # per-tile P quantization overhead + likely WMMA emission
+            # issues for the PV shape outweigh the dot speedup.
+            PV_INT8_WMMA=False,
             k_scale_cache_ptr=k_scale_cache,
             v_scale_cache_ptr=v_scale_cache,
             stride_ks_blk=k_scale_cache.stride(0) if k_scale_cache is not None else 0,

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -335,15 +335,15 @@ def kernel_unified_attention_2d(
         )
 
         # K : (HEAD_SIZE, TILE_SIZE)
-        K_load = tl.load(
-            key_cache_ptr + k_offset,
-            mask=dim_mask[:, None] & tile_mask[None, :],
-            other=0.0,
-        )
         if QK_INT8_WMMA:
             # Keep K in int8; pair with the int8-quantized Q for a WMMA int8
-            # dot. Load the per-token-head k_scale separately and apply it
-            # post-dot fused with softmax_scale and q_scale.
+            # dot. Use an integer `other` to avoid implicit promotion of the
+            # int8 load to float, which would break the int8 tl.dot.
+            K_load = tl.load(
+                key_cache_ptr + k_offset,
+                mask=dim_mask[:, None] & tile_mask[None, :],
+                other=0,
+            )
             K = K_load
             scale_idx = (
                 physical_block_idx * stride_ks_blk
@@ -354,6 +354,11 @@ def kernel_unified_attention_2d(
                 k_scale_cache_ptr + scale_idx, mask=tile_mask, other=1.0
             )
         else:
+            K_load = tl.load(
+                key_cache_ptr + k_offset,
+                mask=dim_mask[:, None] & tile_mask[None, :],
+                other=0.0,
+            )
             K, k_token_head_scales = _prepare_kv_tile(
                 K_load,
                 Q,
@@ -371,14 +376,14 @@ def kernel_unified_attention_2d(
             )
 
         # V : (TILE_SIZE, HEAD_SIZE)
-        V_load = tl.load(
-            value_cache_ptr + v_offset,
-            mask=dim_mask[None, :] & tile_mask[:, None],
-            other=0.0,
-        )
         if PV_INT8_WMMA:
-            # Keep V in int8; pair with an int8-quantized P (computed per
-            # tile after softmax) for a WMMA int8 PV dot.
+            # Keep V in int8; see K path above — `other` must stay integer
+            # to avoid unintended type promotion of the int8 load.
+            V_load = tl.load(
+                value_cache_ptr + v_offset,
+                mask=dim_mask[None, :] & tile_mask[:, None],
+                other=0,
+            )
             V = V_load
             scale_idx_v = (
                 physical_block_idx * stride_vs_blk
@@ -389,6 +394,11 @@ def kernel_unified_attention_2d(
                 v_scale_cache_ptr + scale_idx_v, mask=tile_mask, other=1.0
             )
         else:
+            V_load = tl.load(
+                value_cache_ptr + v_offset,
+                mask=dim_mask[None, :] & tile_mask[:, None],
+                other=0.0,
+            )
             V, v_token_head_scales = _prepare_kv_tile(
                 V_load,
                 Q,

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -524,9 +524,7 @@ def kernel_unified_attention_2d(
             P_v_f32 = P * v_token_head_scales[None, :]
             p_absmax = tl.max(P_v_f32, axis=1)  # P_v_f32 >= 0
             p_scale = tl.maximum(p_absmax * (1.0 / 127.0), 1e-6)
-            P_v_q = tl.clamp(
-                P_v_f32 * (1.0 / p_scale)[:, None], 0.0, 127.0
-            ).to(tl.int8)
+            P_v_q = tl.clamp(P_v_f32 * (1.0 / p_scale)[:, None], 0.0, 127.0).to(tl.int8)
             pv_i32 = tl.dot(P_v_q, V, out_dtype=tl.int32)
             acc += pv_i32.to(tl.float32) * p_scale[:, None]
         elif KV_QUANT_MODE >= 2:
@@ -1183,8 +1181,7 @@ def unified_attention(
     # Gated off for NVIDIA: not benchmarked there, keep the existing
     # bf16 path. Gated off for fp8 modes: int8 WMMA cannot consume fp8.
     use_rocm_int8_wmma_qk = (
-        kv_quant_mode == KVQuantMode.INT8_PER_TOKEN_HEAD
-        and current_platform.is_rocm()
+        kv_quant_mode == KVQuantMode.INT8_PER_TOKEN_HEAD and current_platform.is_rocm()
     )
 
     # Launch the 2D kernel if


### PR DESCRIPTION
<h2>ONLY FOR TEST</h2>
<h2>Summary</h2>
<p>Adds a ROCm fast path to <code>kernel_unified_attention_2d</code> for the <code>INT8_PER_TOKEN_HEAD</code> KV cache mode that lowers the QK dot-product to native AMD integer matrix instructions across all supported ROCm architectures, instead of the existing bf16 path. Triton maps <code>tl.dot(int8, int8, out_dtype=tl.int32)</code> to the appropriate instruction per family: <code>v_wmma_i32_16x16x16_iu8</code> on RDNA3/4 and <code>v_mfma_i32_*i8</code> on CDNA2/3.</p>
<h2>Motivation</h2>
<p>When the KV cache is quantized with <code>KVQuantMode.INT8_PER_TOKEN_HEAD</code>, the current kernel dequantizes K to bf16 inside the tile loop before calling <code>tl.dot</code>. On all ROCm targets this means:</p>
<ol>
<li>A per-tile int8→bf16 conversion for K.</li>
<li>A bf16 matrix multiply instruction.</li>
</ol>
<p>Both are avoidable. Every AMD GPU family supported by ROCm has native int8 matrix instructions that deliver significantly higher throughput than the bf16 path, and Q can be quantized once per Q block outside the tile loop rather than dequantizing K on every tile.</p>
<h2>Hardware coverage</h2>
<p>Triton abstracts the underlying instruction, so the same <code>tl.dot(Q_int8, K_int8, out_dtype=tl.int32)</code> call lowers correctly on all ROCm targets:</p>

Architecture | GFX targets | Instruction | Notes
-- | -- | -- | --
RDNA3 | gfx1100–gfx1153 | v_wmma_i32_16x16x16_iu8 | Benchmarked (RX 7900 XTX)
RDNA4 | gfx1200, gfx1201 | v_wmma_i32_16x16x16_iu8 (_gfx12 variant) | ~4× int8 throughput vs RDNA3
CDNA2 | gfx90a (MI200/MI210/MI250X) | v_mfma_i32_16x16x16i8 | Triton dispatches automatically
CDNA3 | gfx940/941/942 (MI300A/X, MI325X) | v_mfma_i32_16x16x16i8 | Triton dispatches automatically


<p>Decode latency is unaffected, as expected — the optimization targets the prefill QK path.</p></body></html>