### PR TITLE
[KVConnector][LMCache] Propagate cache_salt through MP connector for per-user cache isolation

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -215,6 +215,8 @@ class LMCacheMPRequestTracker:
     # Main state
     state: LMCacheMPRequestState = LMCacheMPRequestState.PREFETCHING
 
+    cache_salt: str = ""
+
     def __init__(self, request: "Request"):
         self.request_id = request.request_id
         self.cache_salt: str = request.cache_salt or ""

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -217,6 +217,7 @@ class LMCacheMPRequestTracker:
 
     def __init__(self, request: "Request"):
         self.request_id = request.request_id
+        self.cache_salt: str = request.cache_salt or ""
         self.all_token_ids = request.all_token_ids
         self.block_hashes = ConstantList(request.block_hashes)
         self.allocated_block_ids = []
@@ -289,6 +290,7 @@ class LMCacheMPRequestMetadata:
     request_id: str
     direction: Literal["STORE", "RETRIEVE"]
     op: LoadStoreOp
+    cache_salt: str = ""
 
     @staticmethod
     def GetStoreMetadata(
@@ -355,6 +357,7 @@ class LMCacheMPRequestMetadata:
                 request_id=tracker.request_id,
                 direction="STORE",
                 op=op,
+                cache_salt=tracker.cache_salt,
             )
 
             # Update the request tracker
@@ -421,6 +424,7 @@ class LMCacheMPRequestMetadata:
                 request_id=tracker.request_id,
                 direction="RETRIEVE",
                 op=op,
+                cache_salt=tracker.cache_salt,
             )
             return ret
 
@@ -569,12 +573,14 @@ class LMCacheMPConnector(KVConnectorBase_V1):
 
         request_ids = []
         ops = []
+        cache_salts = []
 
         for meta in metadata.requests:
             if meta.direction != "RETRIEVE":
                 continue
             request_ids.append(meta.request_id)
             ops.append(meta.op)
+            cache_salts.append(meta.cache_salt)
 
         if len(request_ids) == 0:
             return
@@ -583,7 +589,9 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             event = torch.cuda.Event(interprocess=True)
             event.record()
 
-        self.worker_adapter.batched_submit_retrieve_requests(request_ids, ops, event)
+        self.worker_adapter.batched_submit_retrieve_requests(
+            request_ids, ops, event, cache_salts=cache_salts
+        )
 
     def wait_for_layer_load(self, layer_name: str) -> None:
         """
@@ -640,11 +648,13 @@ class LMCacheMPConnector(KVConnectorBase_V1):
 
         request_ids = []
         ops = []
+        cache_salts = []
         for meta in metadata.requests:
             if meta.direction != "STORE":
                 continue
             request_ids.append(meta.request_id)
             ops.append(meta.op)
+            cache_salts.append(meta.cache_salt)
 
         if len(request_ids) == 0:
             return
@@ -653,7 +663,9 @@ class LMCacheMPConnector(KVConnectorBase_V1):
             event = torch.cuda.Event(interprocess=True)
             event.record()
 
-        self.worker_adapter.batched_submit_store_requests(request_ids, ops, event)
+        self.worker_adapter.batched_submit_store_requests(
+            request_ids, ops, event, cache_salts=cache_salts
+        )
 
     def get_finished(
         self, finished_req_ids: set[str]
@@ -755,6 +767,7 @@ class LMCacheMPConnector(KVConnectorBase_V1):
         self.scheduler_adapter.maybe_submit_lookup_request(
             request.request_id,
             token_ids=list(request.all_token_ids),
+            cache_salt=tracker.cache_salt,
         )
 
         ret = self.scheduler_adapter.check_lookup_result(request.request_id)


### PR DESCRIPTION
## Summary

Propagate `request.cache_salt` through the LMCache MP connector to enable per-user cache isolation. This is the vLLM-side counterpart to LMCache/LMCache#3029.

## Changes

- `LMCacheMPRequestTracker.__init__`: store `request.cache_salt or ""`
- `LMCacheMPRequestMetadata`: add `cache_salt: str = ""` field
- `GetStoreMetadata` / `GetRetrieveMetadata`: copy `cache_salt` from tracker
- `get_num_new_matched_tokens`: pass `cache_salt` to `scheduler_adapter.maybe_submit_lookup_request()`
- `start_load_kv`: collect `cache_salts`, pass to `worker_adapter.batched_submit_retrieve_requests()`
- `wait_for_save`: collect `cache_salts`, pass to `worker_adapter.batched_submit_store_requests()`

## Context

`cache_salt` is already a per-request field in vLLM's OpenAI API (used for prefix cache isolation). This PR threads it through the LMCache MP connector so that LMCache can use it for per-user storage quotas.

With `cache_salt=""` (default when not set by API caller), behavior is identical to today. The LMCache adapter methods already accept `cache_salt=""` defaults (LMCache/LMCache#3029).

## Test plan

- [x] All pre-commit hooks pass
- [x] No behavioral change when `cache_salt` is not set (defaults to `""`)
- [ ] Integration test with LMCache per-user quota (follow-up)