### PR TITLE
[Bugfix] Fix FP8 cast order in `_compute_prefill_context` for chunked prefill

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -2534,13 +2534,18 @@ class MLACommonImpl(MLAAttentionImpl[M], Generic[M]):
                 -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim
             )
 
-            # To Do: Use epilogue of kv_b_proj to generate fp8 kv_nope.
-            if use_fp8_prefill:
-                kv_nope = kv_nope.to(prefill_metadata.q_data_type)
-                k_pe = k_pe.to(prefill_metadata.q_data_type)
             k_nope, v = kv_nope.split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
 
+            # Ensure k_pe matches k_nope dtype before concat;
+            # flashinfer_concat_mla_k only supports BF16/FP16.
+            if use_fp8_prefill and k_pe.dtype != k_nope.dtype:
+                k_pe = k_pe.to(k_nope.dtype)
             k = self._concat_k_nope_k_pe(k_nope, k_pe)
+
+            # Cast to FP8 after concat (aligned with forward_mha's order)
+            if use_fp8_prefill:
+                k = k.to(prefill_metadata.q_data_type)
+                v = v.to(prefill_metadata.q_data_type)
 
             attn_output, attn_softmax_lse = self._run_prefill_context_chunk(
                 prefill=prefill_metadata,


### PR DESCRIPTION
## Summary

Optimize in `_compute_prefill_context` where FP8 quantization of K/V tensors happens **before** `_concat_k_nope_k_pe`, causing `flashinfer_concat_mla_k` to crash since it only supports BF16/FP16 inputs. This makes FP8 prefill (`use_prefill_query_quantization: true`) completely broken for any workload that requires chunked prefill (i.e., 128K long-context sequences).

## Root Cause

In `_compute_prefill_context` (the chunked prefill path), the original code casts `kv_nope` and `k_pe` to FP8 **before** the concat operation:

```python
# Bug: FP8 cast before concat
if use_fp8_prefill:
    kv_nope = kv_nope.to(prefill_metadata.q_data_type)   # bf16 to fp8
    k_pe = k_pe.to(prefill_metadata.q_data_type)         # already fp[8
k_nope, v = kv_nope.split(...)
k = self._concat_k_nope_k_pe(k_nope, k_pe)               # fp8 inputs will lead to crash
```

However, `flashinfer_concat_mla_k` uses `DISPATCH_DLPACK_DTYPE_TO_CTYPE_FP16`, which only dispatches BF16/FP16, and also [requires all three tensors to share the same dtype](https://github.com/flashinfer-ai/flashinfer/blob/bf9b1dac855005ffaa57b48ae54cba30642bf213/csrc/concat_mla.cu#L74-L75).

pass FP8 tensors causes the vLLM server to crash, making FP8 chunked prefill can not use normally.


## Fix

- Remove the FP8 cast before concat
- Ensure `k_pe` (FP8 from workspace) matches `k_nope` (BF16 from `kv_b_proj`) dtype before concat
- Cast `k` and `v` to FP8 **after** concat, aligning with `forward_mha`

## Impact

- **Before**: Any workload using `enable-chunked-prefill` + `use_prefill_query_quantization` (FP8 prefill) crashes. This includes all long-context sequences (e.g., ISL >= 4K) that require chunking.
- **After**: fp8 chunked prefill works correct.
- **No regression**: for short seq that do not trigger chunked prefill are unaffected (they go through `forward_mha` which was already correct). the bf16 path in `_compute_prefill_context` is also unchanged.

## Benchmark Results

end-to-end A/B comparison on GB200 (DeepSeek-R1-0528-FP4, DP=4, chunked prefill, ISL=**128K**, 16 requests):

| Metric | BF16 (baseline) | FP8 (this fix) | |
|---|---|---|---|
| Median TTFT | 42.1 s | 30.4 s | **-27.7%** |
| Mean TTFT | 41.5 s | 33.3 s | **-19.9%** |
| Token throughput | 11,924 tok/s | 13,684 tok/s | **+14.8%** |
| Successful requests | 16/16 | 16/16 | |

## Test Plan

- [x] Existing `test_mla_backends.py` tests pass
- [x] end-to-end benchmark: ISL=128K FP8 prefill, 16/16 requests succeed
- [x] verified FP8 prefill gives expected speedup over BF16 at long context scenrios
