### PR TITLE
[Model] Fix Gemma 4 token repetition by dynamic BOS injection for PT models

### DIFF
--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -167,10 +167,15 @@ class Gemma4ProcessingInfo(BaseProcessingInfo):
 
         Setting ``add_special_tokens=False`` here prevents the duplicate and
         ensures both ``llm.generate()`` and the chat/completions API behave
-        correctly.
+        correctly for IT models. For PT models (without chat template), we
+        keep the default (True) to ensure BOS is added for raw prompts.
         """
+        tokenizer = self.ctx.get_tokenizer()
+        has_chat_template = getattr(tokenizer, "chat_template", None) is not None
+
         params = super().get_default_tok_params()
-        params = params.with_kwargs(add_special_tokens=False)
+        if has_chat_template:
+            params = params.with_kwargs(add_special_tokens=False)
         return params
 
     def get_hf_processor(self, **kwargs: object) -> Gemma4Processor:


### PR DESCRIPTION
## Purpose

This PR fixes the token repetition issue (e.g., "is is is is...") observed in Gemma 4 Pre-Trained (PT) models when running in completion mode (without a chat template).

The issue was caused by `Gemma4ProcessingInfo.get_default_tok_params` explicitly overriding `add_special_tokens=False` to prevent double-BOS sequences in Instruction-Tuned (IT) models (where the chat template already includes a literal `<bos>`). However, this caused PT models loaded without a chat template to lack the required `<bos>` token at position 0, leading to generation degradation.

This fix dynamically checks for the presence of a `chat_template` on the tokenizer:
- **For IT models**: Keeps `add_special_tokens=False` to avoid double-BOS artifacts.
- **For PT models**: Allows the default `add_special_tokens=True` to ensure the `<bos>` token is injected for raw prompts.
Fixes https://github.com/vllm-project/vllm/issues/39827

It doesn't affect other models nor Gemma4 IT models - It is targeted for Gemma4 PT models checkpoints only.

## Test Plan & Results

The test is really straightforward. Running the following test code:

```
import os
from vllm import LLM, SamplingParams
VLLM_MODEL_ID = 'google/gemma-4-26B-A4B'
llm = LLM(
  VLLM_MODEL_ID,
  max_model_len=16,
  tensor_parallel_size=1,
  gpu_memory_utilization=0.65,
  async_scheduling=False,
  enforce_eager=True,
)
sampling_params = SamplingParams(temperature=0.0, max_tokens=10)
# Hardcoded Gemma 4 prompt template string
prompt = 'Paris is'
print('\n' + '='*80)
print('Generation test after weight transfer:')
print(llm.generate(prompt, sampling_params=sampling_params))
```

Without the fix the response has a loop as below:

```
Rendering prompts: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 22.40it/s]
Processed prompts: 100%|████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  7.77it/s, est. speed input: 15.59 toks/s, output: 77.91 toks/s]
[RequestOutput(request_id=0, prompt='Paris is', prompt_token_ids=[50429, 563], encoder_prompt=None, encoder_prompt_token_ids=None, prompt_logprobs=None, outputs=[CompletionOutput(index=0, text=' is is is is is is is is is is', token_ids=[563, 563, 563, 563, 563, 563, 563, 563, 563, 563], routed_experts=None, cumulative_logprob=None, logprobs=None, finish_reason=length, stop_reason=None)], finished=True, metrics=None, lora_request=None, num_cached_tokens=0)]
(EngineCore pid=892199) INFO 04-14 21:00:27 [core.py:1210] Shutdown initiated (timeout=0)
(EngineCore pid=892199) INFO 04-14 21:00:27 [core.py:1233] Shutdown complete
```

with the fix the response is the correct one, without tokens looping:

```
Rendering prompts: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00, 22.47it/s]
Processed prompts: 100%|█████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  1.11it/s, est. speed input: 3.33 toks/s, output: 11.12 toks/s]
[RequestOutput(request_id=0, prompt='Paris is', prompt_token_ids=[2, 50429, 563], encoder_prompt=None, encoder_prompt_token_ids=None, prompt_logprobs=None, outputs=[CompletionOutput(index=0, text=' a city of romance, and there’s no', token_ids=[496, 3207, 529, 30875, 236764, 532, 993, 236858, 236751, 951], routed_experts=None, cumulative_logprob=None, logprobs=None, finish_reason=length, stop_reason=None)], finished=True, metrics=None, lora_request=None, num_cached_tokens=0)]
(EngineCore pid=970951) INFO 04-14 23:22:39 [core.py:1234] Shutdown initiated (timeout=0)
(EngineCore pid=970951) INFO 04-14 23:22:39 [core.py:1257] Shutdown complete
```