### PR TITLE
Fix native offload CPU block sizing

### DIFF
--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -24,15 +24,6 @@ class CPUOffloadingSpec(OffloadingSpec):
                 "cpu_bytes_to_use must be specified in kv_connector_extra_config"
             )
 
-        # Calculate the number of bytes for one offloaded block across the
-        # whole tensor-parallel group.
-        #
-        # `kv_cache_group.kv_cache_spec.page_size_bytes` is already the page
-        # size of the whole KV cache group. In particular, for
-        # `UniformTypeKVCacheSpecs`, it is the sum of all per-layer page sizes
-        # in that group. Multiplying by `len(kv_cache_tensors)` again would
-        # over-count the KV bytes per block and dramatically under-size the CPU
-        # offload pool.
         assert kv_cache_config is not None
         page_sizes = {
             kv_cache_group.kv_cache_spec.page_size_bytes

--- a/vllm/v1/kv_offload/cpu/spec.py
+++ b/vllm/v1/kv_offload/cpu/spec.py
@@ -24,7 +24,15 @@ class CPUOffloadingSpec(OffloadingSpec):
                 "cpu_bytes_to_use must be specified in kv_connector_extra_config"
             )
 
-        # calculate kv_bytes_per_offloaded_block
+        # Calculate the number of bytes for one offloaded block across the
+        # whole tensor-parallel group.
+        #
+        # `kv_cache_group.kv_cache_spec.page_size_bytes` is already the page
+        # size of the whole KV cache group. In particular, for
+        # `UniformTypeKVCacheSpecs`, it is the sum of all per-layer page sizes
+        # in that group. Multiplying by `len(kv_cache_tensors)` again would
+        # over-count the KV bytes per block and dramatically under-size the CPU
+        # offload pool.
         assert kv_cache_config is not None
         page_sizes = {
             kv_cache_group.kv_cache_spec.page_size_bytes
@@ -33,9 +41,7 @@ class CPUOffloadingSpec(OffloadingSpec):
         assert len(page_sizes) == 1
         page_size_bytes = page_sizes.pop()
         kv_bytes_per_block = (
-            page_size_bytes
-            * len(kv_cache_config.kv_cache_tensors)
-            * vllm_config.parallel_config.world_size
+            page_size_bytes * vllm_config.parallel_config.world_size
         )
 
         kv_bytes_per_offloaded_block = kv_bytes_per_block * self.block_size_factor


### PR DESCRIPTION
## Summary
- Fix native CPU offload block sizing by avoiding double-counting KV tensors
- Keep the tensor-parallel world size factor so `cpu_bytes_to_use` remains a TP-group budget
- Remove stale comment

## Root Cause
`kv_cache_group.kv_cache_spec.page_size_bytes` already accounts for the aggregate page size across all KV cache tensors in the group. Multiplying by `len(kv_cache_config.kv_cache_tensors)` again under-sizes the native CPU offload pool, which later causes out-of-bounds CPU block mappings during store.

## Test Plan
- [x] Reproduced the native failure before the fix
- [x] Verified the corrected capacity calculation for the Kimi TP=4 case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>