### PR TITLE
[CI][NIXL] Fix PD CI breakage: pin nixl-cu{12,13} versions

### DIFF
--- a/requirements/kv_connectors.txt
+++ b/requirements/kv_connectors.txt
@@ -1,3 +1,5 @@
 lmcache >= 0.3.9
 nixl[cu13] >= 0.7.1, < 0.10.0 # Required for disaggregated prefill
+nixl-cu12 >= 0.7.1, < 0.10.0
+nixl-cu13 >= 0.7.1, < 0.10.0
 mooncake-transfer-engine >= 0.3.8


### PR DESCRIPTION
`nixl-cu12==1.0.1` dropped on PyPI today (19:38 UTC) and ships `nixl_ep` compiled against `libcudart.so.12` — crashes on CUDA 13 CI runners. Our `< 0.10.0` constraint only pins the meta-package, not the backends:

```
[2026-04-14T21:21:43Z]  + nixl==0.9.0
[2026-04-14T21:21:43Z]  + nixl-cu12==1.0.1
[2026-04-14T21:21:43Z]  + nixl-cu13==1.0.1
```

- Passing: https://buildkite.com/vllm/ci/builds/61159 (`nixl-cu12==1.0.0`, no `nixl_ep`)
- Failing: https://buildkite.com/vllm/ci/builds/61308 (`nixl-cu12==1.0.1`, `nixl_ep` import crashes)

Temp fix: pin `nixl-cu12` and `nixl-cu13` to `< 0.10.0`. @NickLucche is working on the proper version bump in #39797 (tracking #39521).