### PR TITLE
[Bugfix] Skip gpu_memory_utilization validation when kv_cache_memory_bytes is set

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -280,11 +280,16 @@ class Worker(WorkerBase):
 
             # take current memory snapshot
             self.init_snapshot = init_snapshot = MemorySnapshot(device=self.device)
-            self.requested_memory = request_memory(init_snapshot, self.cache_config)
+            # Skip gpu_memory_utilization validation when kv_cache_memory_bytes
+            # is explicitly set — the user controls the KV cache size directly
+            # and gpu_memory_utilization should be ignored per CacheConfig docs.
+            if self.cache_config.kv_cache_memory_bytes is None:
+                self.requested_memory = request_memory(init_snapshot, self.cache_config)
+                logger.debug(
+                    "worker requested memory: %sGiB",
+                    format_gib(self.requested_memory),
+                )
             logger.debug("worker init memory snapshot: %r", self.init_snapshot)
-            logger.debug(
-                "worker requested memory: %sGiB", format_gib(self.requested_memory)
-            )
         else:
             raise RuntimeError(f"Not support device type: {self.device_config.device}")
 


### PR DESCRIPTION
## Summary

- When `kv_cache_memory_bytes` is explicitly set, `gpu_memory_utilization` should be ignored (as [documented in CacheConfig](https://github.com/vllm-project/vllm/blob/main/vllm/config/cache.py#L150)). However, `request_memory()` was unconditionally called during `init_device()`, validating free memory against `gpu_memory_utilization` **before** `determine_available_memory()` could honor the `kv_cache_memory_bytes` early-return path.
- This caused spurious `ValueError` on shared GPUs or when free memory fluctuated between runs — exactly the scenario `kv_cache_memory_bytes` (introduced in #21489) was designed to handle.
- Fix: gate the `request_memory()` call on `kv_cache_memory_bytes is None`. This is safe because `self.requested_memory` is only referenced in code paths already guarded by the same condition.

## Reproduction

1. Run vLLM on a GPU, get the suggested `--kv-cache-memory-bytes=X` from logs
2. Start another process that consumes some GPU memory (so free < `total * gpu_memory_utilization`)
3. Run vLLM again with `--kv-cache-memory-bytes=X` — hits `ValueError` from `request_memory()` even though the KV cache + model weights would fit

## Test plan

- [x] Pre-commit hooks pass (`ruff check`, `ruff format`, `mypy`)
- [ ] Existing tests pass (no test changes needed — this is a validation-only code path)
- [ ] Manual verification: set `--kv-cache-memory-bytes` with reduced free GPU memory, confirm no ValueError

AI assistance was used (Claude). This is not duplicating any existing PR — verified via `gh pr list --search`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)