### PR TITLE
fix: check for missing weights in all models (quantized and non-quant…

### DIFF
--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -386,12 +386,21 @@ class DefaultModelLoader(BaseModelLoader):
             self.counter_after_loading_weights - self.counter_before_loading_weights,
             scope="local",
         )
-        # We only enable strict check for non-quantized models
-        # that have loaded weights tracking currently.
-        if model_config.quantization is None and loaded_weights is not None:
+
+        # Non-quantized models: raise error if weights not loaded.
+        # Quantized models: still perform check but only log warning.
+        if loaded_weights is not None:
             weights_not_loaded = weights_to_load - loaded_weights
             if weights_not_loaded:
-                raise ValueError(
-                    "Following weights were not initialized from "
-                    f"checkpoint: {weights_not_loaded}"
-                )
+                if model_config.quantization is not None:
+                    logger.warning(
+                        "Following weights were not initialized from "
+                        "checkpoint (quantized model): %s",
+                        weights_not_loaded
+                    )
+                else:
+                    raise ValueError(
+                        "Following weights were not initialized from "
+                        f"checkpoint: {weights_not_loaded}"
+                    )
+                    

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -680,6 +680,14 @@ def filter_duplicate_safetensors_files(
     weight_files_in_index = set()
     for weight_name in weight_map:
         weight_files_in_index.add(os.path.join(hf_folder, weight_map[weight_name]))
+    # Check if files referenced in model.safetensors.index.json actually exist.
+    # Raise error if any file is missing.
+    hf_weights_files_set = set(hf_weights_files)
+    missing_files = weight_files_in_index - hf_weights_files_set
+    if missing_files:
+        raise FileNotFoundError(
+            f"Weight files referenced in index but missing: {missing_files}"
+        )
     # Filter out any fields that are not found in the index file.
     hf_weights_files = [f for f in hf_weights_files if f in weight_files_in_index]
     return hf_weights_files


### PR DESCRIPTION
## Problem Description

### Purpose

1. Fix the weight file missing detection vulnerability in `filter_duplicate_safetensors_files()`
   - Add disk file existence validation before intersection check
   - Detect weight files referenced in index.json but actually missing
   - Raise FileNotFoundError directly
   - Cover all model scenarios with index files

2. Fix the issue of no notification for quantized model weight integrity
   - Modify weight integrity check logic
   - Remove skip condition for quantized models
   - Output warning log for quantized model weight missing
   - Keep original error logic for non-quantized models

3. Unify detection capability for all scenarios
   - All models (quantized / non-quantized) can detect missing weight files
   - Non-quantized models: weight incomplete directly raises error and interrupts service
   - Quantized models: weight incomplete outputs warning, waiting for official solution

### Problem

For non-quantized models, with/without safetensors.index.json, when weight files are missing, `filter_duplicate_safetensors_files()` cannot detect it, but `load_weights()` can detect weight incompleteness and raise error, interrupting service startup.

For quantized models, with/without safetensors.index.json, when weight files are missing, `filter_duplicate_safetensors_files()` cannot detect it, and `load_weights()` does not check quantized models, so it cannot detect weight incompleteness. Service starts successfully, but inference has precision issues due to missing files.

### Test Plan and Results

| Scenario | Detection Result |
|----------|------------------|
| 1. Quantized + with index | ❌ Cannot detect weight incompleteness, ❌ Cannot detect file missing |
| 2. Non-quantized + with index | ✅ Detects weight incompleteness, ❌ Cannot detect file missing |
| 3. Quantized + without index | ❌ Cannot detect weight incompleteness, ❌ Cannot detect file missing |
| 4. Non-quantized + without index | ✅ Detects weight incompleteness, ❌ Cannot detect file missing |

## Fix Solution

### Fix 1: `filter_duplicate_safetensors_files()`

Add disk weight file missing detection before intersection check to solve file missing problem:

```python
hf_weights_files_set = set(hf_weights_files)
missing_files = weight_files_in_index - hf_weights_files_set
if missing_files:
    raise FileNotFoundError(
        f"Weight files referenced in index but missing: {missing_files}"
    )
```

### Fix 2: `load_weights()`

For quantized models that don't check weight integrity, modify the judgment logic to output a warning for quantized model detection, expecting an official solution:

```python
if loaded_weights is not None:
    weights_not_loaded = weights_to_load - loaded_weights
    if weights_not_loaded:
        if model_config.quantization is not None:
            logger.warning(
                "Following weights were not initialized from "
                "checkpoint (quantized model): %s",
                weights_not_loaded
            )
        else:
            raise ValueError(
                "Following weights were not initialized from "
                f"checkpoint: {weights_not_loaded}"
            )
```

## Test Results After Fix

| Scenario | Detection Result |
|----------|------------------|
| 1. Quantized + with index | Weight incompleteness only warns, ✅ Detects file missing |
| 2. Non-quantized + with index | ✅ Detects weight incompleteness, ✅ Detects file missing |
| 3. Quantized + without index | Weight incompleteness only warns, ✅ Detects file missing |
| 4. Non-quantized + without index | ✅ Detects weight incompleteness, ✅ Detects file missing |

## Modified Files

- `vllm/model_executor/model_loader/default_loader.py`
- `vllm/model_executor/model_loader/weight_utils.py`