### PR TITLE
[SimpleCPUOffloadConnector]: Add KV event support

### DIFF
--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -1215,61 +1215,6 @@ def test_store_completion_emits_cpu_block_stored_event() -> None:
     assert len(stored[0].block_hashes) == num_blocks
 
 
-def test_eager_multi_request_emits_per_request_block_stored() -> None:
-    """Eager mode with two requests in one step emits separate BlockStored
-    events per request, not one merged event."""
-    fix = make_scheduler_with_events(num_cpu_blocks=16, num_gpu_blocks=32)
-    sched = fix.scheduler
-
-    # Create two requests with different block counts
-    req_a = make_request(num_blocks=2)
-    req_b = make_request(num_blocks=3)
-
-    kv_a = _alloc_and_register(fix, req_a, 2)
-    kv_b = _alloc_and_register(fix, req_b, 3)
-    ids_a = kv_a.get_block_ids()
-    ids_b = kv_b.get_block_ids()
-
-    sched.update_state_after_alloc(req_a, kv_a, num_external_tokens=0)
-    sched.update_state_after_alloc(req_b, kv_b, num_external_tokens=0)
-
-    # Schedule both requests in one step — eager mode merges them
-    so = make_scheduler_output(
-        {
-            req_a.request_id: 2 * BLOCK_SIZE,
-            req_b.request_id: 3 * BLOCK_SIZE,
-        },
-        new_reqs={
-            req_a.request_id: ids_a,
-            req_b.request_id: ids_b,
-        },
-    )
-    meta = sched.build_connector_meta(so)
-    assert meta.store_event != INVALID_JOB_ID
-
-    # Complete the (merged) store
-    simulate_store_completion(sched, meta.store_event)
-
-    events = list(sched.take_events())
-    stored = [e for e in events if isinstance(e, BlockStored)]
-
-    # Should get two separate events, one per request
-    assert len(stored) == 2, (
-        f"Expected 2 per-request BlockStored events, got {len(stored)}"
-    )
-
-    # One event should have 2 block hashes (req_a), the other 3 (req_b)
-    hash_counts = sorted(len(e.block_hashes) for e in stored)
-    assert hash_counts == [2, 3], (
-        f"Expected block hash counts [2, 3], got {hash_counts}"
-    )
-
-    # All events should have medium='CPU'
-    for event in stored:
-        assert event.medium == "CPU"
-        assert event.block_size == BLOCK_SIZE
-
-
 def test_cpu_eviction_emits_block_removed_with_cpu_medium() -> None:
     """Evicting CPU blocks emits BlockRemoved with medium='CPU'."""
     # 3 CPU blocks total — fill with 2 then store 3 more to force eviction

--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -17,6 +17,8 @@ from vllm.config import (
     SchedulerConfig,
     VllmConfig,
 )
+from vllm.config.kv_events import KVEventsConfig
+from vllm.distributed.kv_events import BlockRemoved, BlockStored
 from vllm.utils.hashing import sha256
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
@@ -39,7 +41,10 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
 from vllm.v1.simple_kv_offload.manager import SimpleCPUOffloadScheduler
-from vllm.v1.simple_kv_offload.metadata import SimpleCPUOffloadWorkerMetadata
+from vllm.v1.simple_kv_offload.metadata import (
+    INVALID_JOB_ID,
+    SimpleCPUOffloadWorkerMetadata,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -1135,3 +1140,122 @@ def test_partial_gpu_prefix_plus_cpu_load() -> None:
         assert bid in ext_block_ids, (
             f"Load GPU block {bid} should be an ext_comp block, not a comp or new block"
         )
+
+
+def make_scheduler_with_events(
+    num_cpu_blocks: int = 8,
+    num_gpu_blocks: int = 16,
+    num_groups: int = 1,
+    lazy: bool = False,
+) -> SchedulerFixture:
+    """Build a SimpleCPUOffloadScheduler with KV cache events enabled."""
+    kv_cache_config = _make_kv_cache_config(num_gpu_blocks, num_groups)
+    vllm_config = _make_vllm_config()
+    vllm_config.kv_events_config = KVEventsConfig(
+        enable_kv_cache_events=True,
+        publisher="null",
+    )
+    cpu_capacity_bytes = _BYTES_PER_BLOCK * num_cpu_blocks * num_groups
+
+    sched = SimpleCPUOffloadScheduler(
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        cpu_capacity_bytes=cpu_capacity_bytes,
+        lazy_offload=lazy,
+    )
+
+    gpu_block_pool = BlockPool(
+        num_gpu_blocks=num_gpu_blocks,
+        enable_caching=True,
+        hash_block_size=BLOCK_SIZE,
+    )
+    sched.bind_gpu_block_pool(gpu_block_pool)
+
+    return SchedulerFixture(
+        scheduler=sched,
+        gpu_block_pool=gpu_block_pool,
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        num_groups=num_groups,
+    )
+
+
+def test_cpu_block_pool_medium_is_cpu() -> None:
+    """CPU block pool should have medium='CPU'."""
+    fix = make_scheduler_with_events()
+    assert fix.scheduler.cpu_block_pool.medium == "CPU"
+
+
+def test_store_completion_emits_cpu_block_stored_event() -> None:
+    """Completing a store emits BlockStored with medium='CPU'."""
+    fix = make_scheduler_with_events(num_cpu_blocks=8, num_gpu_blocks=16)
+    sched = fix.scheduler
+
+    num_blocks = 2
+    req = make_request(num_blocks=num_blocks)
+    kv_blocks = _alloc_and_register(fix, req, num_blocks)
+    block_ids = kv_blocks.get_block_ids()
+
+    sched.update_state_after_alloc(req, kv_blocks, num_external_tokens=0)
+    so = make_scheduler_output(
+        {req.request_id: num_blocks * BLOCK_SIZE},
+        new_reqs={req.request_id: block_ids},
+    )
+    meta = sched.build_connector_meta(so)
+
+    # Complete the store
+    assert meta.store_event != INVALID_JOB_ID
+    simulate_store_completion(sched, meta.store_event)
+
+    events = list(sched.take_events())
+    stored = [e for e in events if isinstance(e, BlockStored)]
+    assert len(stored) == 1
+    assert stored[0].medium == "CPU"
+    assert stored[0].block_size == BLOCK_SIZE
+    assert len(stored[0].block_hashes) == num_blocks
+
+
+def test_cpu_eviction_emits_block_removed_with_cpu_medium() -> None:
+    """Evicting CPU blocks emits BlockRemoved with medium='CPU'."""
+    # 3 CPU blocks total — fill with 2 then store 3 more to force eviction
+    fix = make_scheduler_with_events(
+        num_cpu_blocks=3,
+        num_gpu_blocks=16,
+        lazy=False,
+    )
+    sched = fix.scheduler
+
+    # Store req0 (2 blocks) to fill most of CPU
+    req0 = make_request(num_blocks=2)
+    kv0 = _alloc_and_register(fix, req0, 2)
+    ids0 = kv0.get_block_ids()
+    sched.update_state_after_alloc(req0, kv0, num_external_tokens=0)
+    so0 = make_scheduler_output(
+        {req0.request_id: 2 * BLOCK_SIZE},
+        new_reqs={req0.request_id: ids0},
+    )
+    meta0 = sched.build_connector_meta(so0)
+    assert meta0.store_event != INVALID_JOB_ID
+    simulate_store_completion(sched, meta0.store_event)
+
+    # Drain the initial BlockStored events
+    list(sched.take_events())
+
+    # Store req1 (3 blocks) — CPU only has 1 free slot, must evict
+    req1 = make_request(num_blocks=3)
+    kv1 = _alloc_and_register(fix, req1, 3)
+    ids1 = kv1.get_block_ids()
+    sched.update_state_after_alloc(req1, kv1, num_external_tokens=0)
+    so1 = make_scheduler_output(
+        {req1.request_id: 3 * BLOCK_SIZE},
+        new_reqs={req1.request_id: ids1},
+    )
+    meta1 = sched.build_connector_meta(so1)
+    assert meta1.store_event != INVALID_JOB_ID
+    simulate_store_completion(sched, meta1.store_event)
+
+    events = list(sched.take_events())
+    removed = [e for e in events if isinstance(e, BlockRemoved)]
+    assert len(removed) > 0, "Expected CPU eviction events"
+    for event in removed:
+        assert event.medium == "CPU"

--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -1215,6 +1215,61 @@ def test_store_completion_emits_cpu_block_stored_event() -> None:
     assert len(stored[0].block_hashes) == num_blocks
 
 
+def test_eager_multi_request_emits_per_request_block_stored() -> None:
+    """Eager mode with two requests in one step emits separate BlockStored
+    events per request, not one merged event."""
+    fix = make_scheduler_with_events(num_cpu_blocks=16, num_gpu_blocks=32)
+    sched = fix.scheduler
+
+    # Create two requests with different block counts
+    req_a = make_request(num_blocks=2)
+    req_b = make_request(num_blocks=3)
+
+    kv_a = _alloc_and_register(fix, req_a, 2)
+    kv_b = _alloc_and_register(fix, req_b, 3)
+    ids_a = kv_a.get_block_ids()
+    ids_b = kv_b.get_block_ids()
+
+    sched.update_state_after_alloc(req_a, kv_a, num_external_tokens=0)
+    sched.update_state_after_alloc(req_b, kv_b, num_external_tokens=0)
+
+    # Schedule both requests in one step — eager mode merges them
+    so = make_scheduler_output(
+        {
+            req_a.request_id: 2 * BLOCK_SIZE,
+            req_b.request_id: 3 * BLOCK_SIZE,
+        },
+        new_reqs={
+            req_a.request_id: ids_a,
+            req_b.request_id: ids_b,
+        },
+    )
+    meta = sched.build_connector_meta(so)
+    assert meta.store_event != INVALID_JOB_ID
+
+    # Complete the (merged) store
+    simulate_store_completion(sched, meta.store_event)
+
+    events = list(sched.take_events())
+    stored = [e for e in events if isinstance(e, BlockStored)]
+
+    # Should get two separate events, one per request
+    assert len(stored) == 2, (
+        f"Expected 2 per-request BlockStored events, got {len(stored)}"
+    )
+
+    # One event should have 2 block hashes (req_a), the other 3 (req_b)
+    hash_counts = sorted(len(e.block_hashes) for e in stored)
+    assert hash_counts == [2, 3], (
+        f"Expected block hash counts [2, 3], got {hash_counts}"
+    )
+
+    # All events should have medium='CPU'
+    for event in stored:
+        assert event.medium == "CPU"
+        assert event.block_size == BLOCK_SIZE
+
+
 def test_cpu_eviction_emits_block_removed_with_cpu_medium() -> None:
     """Evicting CPU blocks emits BlockRemoved with medium='CPU'."""
     # 3 CPU blocks total — fill with 2 then store 3 more to force eviction

--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -1839,6 +1839,61 @@ def test_store_completion_emits_cpu_block_stored_event() -> None:
     assert len(stored[0].block_hashes) == num_blocks
 
 
+def test_eager_multi_request_emits_per_request_block_stored() -> None:
+    """Eager mode with two requests in one step emits separate BlockStored
+    events per request, not one merged event."""
+    fix = make_scheduler_with_events(num_cpu_blocks=16, num_gpu_blocks=32)
+    sched = fix.scheduler
+
+    # Create two requests with different block counts
+    req_a = make_request(num_blocks=2)
+    req_b = make_request(num_blocks=3)
+
+    kv_a = _alloc_and_register(fix, req_a, 2)
+    kv_b = _alloc_and_register(fix, req_b, 3)
+    ids_a = kv_a.get_block_ids()
+    ids_b = kv_b.get_block_ids()
+
+    sched.update_state_after_alloc(req_a, kv_a, num_external_tokens=0)
+    sched.update_state_after_alloc(req_b, kv_b, num_external_tokens=0)
+
+    # Schedule both requests in one step — eager mode merges them
+    so = make_scheduler_output(
+        {
+            req_a.request_id: 2 * BLOCK_SIZE,
+            req_b.request_id: 3 * BLOCK_SIZE,
+        },
+        new_reqs={
+            req_a.request_id: ids_a,
+            req_b.request_id: ids_b,
+        },
+    )
+    meta = sched.build_connector_meta(so)
+    assert meta.store_event != INVALID_JOB_ID
+
+    # Complete the (merged) store
+    simulate_store_completion(sched, meta.store_event)
+
+    events = list(sched.take_events())
+    stored = [e for e in events if isinstance(e, BlockStored)]
+
+    # Should get two separate events, one per request
+    assert len(stored) == 2, (
+        f"Expected 2 per-request BlockStored events, got {len(stored)}"
+    )
+
+    # One event should have 2 block hashes (req_a), the other 3 (req_b)
+    hash_counts = sorted(len(e.block_hashes) for e in stored)
+    assert hash_counts == [2, 3], (
+        f"Expected block hash counts [2, 3], got {hash_counts}"
+    )
+
+    # All events should have medium='CPU'
+    for event in stored:
+        assert event.medium == "CPU"
+        assert event.block_size == BLOCK_SIZE
+
+
 def test_cpu_eviction_emits_block_removed_with_cpu_medium() -> None:
     """Evicting CPU blocks emits BlockRemoved with medium='CPU'."""
     # 3 CPU blocks total: fill with 2, then store 3 more to force eviction.

--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -1839,61 +1839,6 @@ def test_store_completion_emits_cpu_block_stored_event() -> None:
     assert len(stored[0].block_hashes) == num_blocks
 
 
-def test_eager_multi_request_emits_per_request_block_stored() -> None:
-    """Eager mode with two requests in one step emits separate BlockStored
-    events per request, not one merged event."""
-    fix = make_scheduler_with_events(num_cpu_blocks=16, num_gpu_blocks=32)
-    sched = fix.scheduler
-
-    # Create two requests with different block counts
-    req_a = make_request(num_blocks=2)
-    req_b = make_request(num_blocks=3)
-
-    kv_a = _alloc_and_register(fix, req_a, 2)
-    kv_b = _alloc_and_register(fix, req_b, 3)
-    ids_a = kv_a.get_block_ids()
-    ids_b = kv_b.get_block_ids()
-
-    sched.update_state_after_alloc(req_a, kv_a, num_external_tokens=0)
-    sched.update_state_after_alloc(req_b, kv_b, num_external_tokens=0)
-
-    # Schedule both requests in one step — eager mode merges them
-    so = make_scheduler_output(
-        {
-            req_a.request_id: 2 * BLOCK_SIZE,
-            req_b.request_id: 3 * BLOCK_SIZE,
-        },
-        new_reqs={
-            req_a.request_id: ids_a,
-            req_b.request_id: ids_b,
-        },
-    )
-    meta = sched.build_connector_meta(so)
-    assert meta.store_event != INVALID_JOB_ID
-
-    # Complete the (merged) store
-    simulate_store_completion(sched, meta.store_event)
-
-    events = list(sched.take_events())
-    stored = [e for e in events if isinstance(e, BlockStored)]
-
-    # Should get two separate events, one per request
-    assert len(stored) == 2, (
-        f"Expected 2 per-request BlockStored events, got {len(stored)}"
-    )
-
-    # One event should have 2 block hashes (req_a), the other 3 (req_b)
-    hash_counts = sorted(len(e.block_hashes) for e in stored)
-    assert hash_counts == [2, 3], (
-        f"Expected block hash counts [2, 3], got {hash_counts}"
-    )
-
-    # All events should have medium='CPU'
-    for event in stored:
-        assert event.medium == "CPU"
-        assert event.block_size == BLOCK_SIZE
-
-
 def test_cpu_eviction_emits_block_removed_with_cpu_medium() -> None:
     """Evicting CPU blocks emits BlockRemoved with medium='CPU'."""
     # 3 CPU blocks total: fill with 2, then store 3 more to force eviction.

--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -18,6 +18,8 @@ from vllm.config import (
     SchedulerConfig,
     VllmConfig,
 )
+from vllm.config.kv_events import KVEventsConfig
+from vllm.distributed.kv_events import BlockRemoved, BlockStored
 from vllm.utils.hashing import sha256
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_manager import KVCacheBlocks
@@ -43,7 +45,10 @@ from vllm.v1.kv_cache_interface import (
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
 from vllm.v1.simple_kv_offload.manager import SimpleCPUOffloadScheduler
-from vllm.v1.simple_kv_offload.metadata import SimpleCPUOffloadWorkerMetadata
+from vllm.v1.simple_kv_offload.metadata import (
+    INVALID_JOB_ID,
+    SimpleCPUOffloadWorkerMetadata,
+)
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -1758,3 +1763,121 @@ def test_cp_lazy_target_blocks_scaling(cp_world_size: int) -> None:
             f"cp_world_size={cp_world_size}: target_cp={target_cp} should be "
             f"less than target_base={target_base}"
         )
+
+
+def make_scheduler_with_events(
+    num_cpu_blocks: int = 8,
+    num_gpu_blocks: int = 16,
+    num_groups: int = 1,
+    lazy: bool = False,
+) -> SchedulerFixture:
+    """Build a SimpleCPUOffloadScheduler with KV cache events enabled."""
+    kv_cache_config = _make_kv_cache_config(num_gpu_blocks, num_groups)
+    vllm_config = _make_vllm_config()
+    vllm_config.kv_events_config = KVEventsConfig(
+        enable_kv_cache_events=True,
+        publisher="null",
+    )
+    cpu_capacity_bytes = _BYTES_PER_BLOCK * num_cpu_blocks * num_groups
+
+    sched = SimpleCPUOffloadScheduler(
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        cpu_capacity_bytes=cpu_capacity_bytes,
+        scheduler_block_size=BLOCK_SIZE,
+        hash_block_size=BLOCK_SIZE,
+        lazy_offload=lazy,
+    )
+
+    gpu_block_pool = BlockPool(
+        num_gpu_blocks=num_gpu_blocks,
+        enable_caching=True,
+        hash_block_size=BLOCK_SIZE,
+    )
+    sched.bind_gpu_block_pool(gpu_block_pool)
+
+    return SchedulerFixture(
+        scheduler=sched,
+        gpu_block_pool=gpu_block_pool,
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        num_groups=num_groups,
+    )
+
+
+def test_cpu_block_pool_medium_is_cpu() -> None:
+    """CPU block pool should have medium='CPU'."""
+    fix = make_scheduler_with_events()
+    assert fix.scheduler.cpu_block_pool.medium == "CPU"
+
+
+def test_store_completion_emits_cpu_block_stored_event() -> None:
+    """Completing a store emits BlockStored with medium='CPU'."""
+    fix = make_scheduler_with_events(num_cpu_blocks=8, num_gpu_blocks=16)
+    sched = fix.scheduler
+
+    num_blocks = 2
+    req = make_request(num_blocks=num_blocks)
+    kv_blocks = _alloc_and_register(fix, req, num_blocks)
+    block_ids = kv_blocks.get_block_ids()
+
+    sched.update_state_after_alloc(req, kv_blocks, num_external_tokens=0)
+    so = make_scheduler_output(
+        {req.request_id: num_blocks * BLOCK_SIZE},
+        new_reqs={req.request_id: block_ids},
+    )
+    meta = sched.build_connector_meta(so)
+
+    assert meta.store_event != INVALID_JOB_ID
+    simulate_store_completion(sched, meta.store_event)
+
+    events = list(sched.take_events())
+    stored = [e for e in events if isinstance(e, BlockStored)]
+    assert len(stored) == 1
+    assert stored[0].medium == "CPU"
+    assert stored[0].block_size == BLOCK_SIZE
+    assert len(stored[0].block_hashes) == num_blocks
+
+
+def test_cpu_eviction_emits_block_removed_with_cpu_medium() -> None:
+    """Evicting CPU blocks emits BlockRemoved with medium='CPU'."""
+    # 3 CPU blocks total: fill with 2, then store 3 more to force eviction.
+    fix = make_scheduler_with_events(
+        num_cpu_blocks=3,
+        num_gpu_blocks=16,
+        lazy=False,
+    )
+    sched = fix.scheduler
+
+    req0 = make_request(num_blocks=2)
+    kv0 = _alloc_and_register(fix, req0, 2)
+    ids0 = kv0.get_block_ids()
+    sched.update_state_after_alloc(req0, kv0, num_external_tokens=0)
+    so0 = make_scheduler_output(
+        {req0.request_id: 2 * BLOCK_SIZE},
+        new_reqs={req0.request_id: ids0},
+    )
+    meta0 = sched.build_connector_meta(so0)
+    assert meta0.store_event != INVALID_JOB_ID
+    simulate_store_completion(sched, meta0.store_event)
+
+    # Drain the initial BlockStored events.
+    list(sched.take_events())
+
+    req1 = make_request(num_blocks=3)
+    kv1 = _alloc_and_register(fix, req1, 3)
+    ids1 = kv1.get_block_ids()
+    sched.update_state_after_alloc(req1, kv1, num_external_tokens=0)
+    so1 = make_scheduler_output(
+        {req1.request_id: 3 * BLOCK_SIZE},
+        new_reqs={req1.request_id: ids1},
+    )
+    meta1 = sched.build_connector_meta(so1)
+    assert meta1.store_event != INVALID_JOB_ID
+    simulate_store_completion(sched, meta1.store_event)
+
+    events = list(sched.take_events())
+    removed = [e for e in events if isinstance(e, BlockRemoved)]
+    assert len(removed) > 0, "Expected CPU eviction events"
+    for event in removed:
+        assert event.medium == "CPU"

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -153,6 +153,7 @@ class BlockPool:
         hash_block_size: int,
         enable_kv_cache_events: bool = False,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        medium: str = MEDIUM_GPU,
     ):
         assert isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0
         self.num_gpu_blocks = num_gpu_blocks
@@ -179,6 +180,8 @@ class BlockPool:
         self.enable_kv_cache_events = enable_kv_cache_events
         self.kv_event_queue: list[KVCacheEvent] = []
 
+        # NOTE: This is only used for SimpleCPUOffloadConnector's BlockPool
+        self.medium = medium
         self.metrics_collector = metrics_collector
 
     def get_cached_block(
@@ -310,7 +313,7 @@ class BlockPool:
                     lora_id=request.lora_request.adapter_id
                     if request.lora_request
                     else None,
-                    medium=MEDIUM_GPU,
+                    medium=self.medium,
                     lora_name=request.lora_request.name
                     if request.lora_request
                     else None,
@@ -382,7 +385,7 @@ class BlockPool:
             self.kv_event_queue.append(
                 BlockRemoved(
                     block_hashes=[maybe_convert_block_hash(get_block_hash(block_hash))],
-                    medium=MEDIUM_GPU,
+                    medium=self.medium,
                     group_idx=get_group_id(block_hash),
                 )
             )

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -153,6 +153,7 @@ class BlockPool:
         hash_block_size: int,
         enable_kv_cache_events: bool = False,
         metrics_collector: KVCacheMetricsCollector | None = None,
+        medium: str = MEDIUM_GPU,
     ):
         assert isinstance(num_gpu_blocks, int) and num_gpu_blocks > 0
         self.num_gpu_blocks = num_gpu_blocks
@@ -179,6 +180,8 @@ class BlockPool:
         self.enable_kv_cache_events = enable_kv_cache_events
         self.kv_event_queue: list[KVCacheEvent] = []
 
+        # NOTE: This is only used for SimpleCPUOffloadConnector's BlockPool
+        self.medium = medium
         self.metrics_collector = metrics_collector
 
     def get_cached_block(
@@ -321,7 +324,7 @@ class BlockPool:
                     lora_id=request.lora_request.adapter_id
                     if request.lora_request
                     else None,
-                    medium=MEDIUM_GPU,
+                    medium=self.medium,
                     lora_name=request.lora_request.name
                     if request.lora_request
                     else None,
@@ -393,7 +396,7 @@ class BlockPool:
             self.kv_event_queue.append(
                 BlockRemoved(
                     block_hashes=[maybe_convert_block_hash(get_block_hash(block_hash))],
-                    medium=MEDIUM_GPU,
+                    medium=self.medium,
                     group_idx=get_group_id(block_hash),
                 )
             )

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from vllm.config import VllmConfig
-from vllm.distributed.kv_events import KVCacheEvent
+from vllm.distributed.kv_events import BlockStored, KVCacheEvent
 from vllm.distributed.kv_transfer.kv_connector.utils import yield_req_data
 from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
@@ -17,6 +17,7 @@ from vllm.v1.core.kv_cache_coordinator import (
     KVCacheCoordinator,
     get_kv_cache_coordinator,
 )
+from vllm.v1.core.kv_cache_utils import get_block_hash, maybe_convert_block_hash
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -103,7 +104,7 @@ class SimpleCPUOffloadScheduler:
             "lazy" if lazy_offload else "eager",
         )
 
-        # TODO (yifan): maybe need to enable kv_cache_events and metrics_collector here.
+        # TODO (yifan): maybe need to enable metrics_collector here.
         dcp_world_size = vllm_config.parallel_config.decode_context_parallel_size
         pcp_world_size = vllm_config.parallel_config.prefill_context_parallel_size
         assert dcp_world_size == 1 and pcp_world_size == 1
@@ -118,6 +119,7 @@ class SimpleCPUOffloadScheduler:
             hash_block_size=self.block_size,
         )
         self.cpu_block_pool: BlockPool = self.cpu_coordinator.block_pool
+        self.cpu_block_pool.medium = "CPU"
 
         # GPU block pool reference - bound after scheduler builds kv_cache_manager
         self._gpu_block_pool: BlockPool | None = None
@@ -639,6 +641,25 @@ class SimpleCPUOffloadScheduler:
             bhash = cpu_block.block_hash
             assert bhash is not None
             self.cpu_block_pool.cached_block_hash_to_block.insert(bhash, cpu_block)
+
+        if self.enable_kv_cache_events:
+            block_hashes = [
+                maybe_convert_block_hash(get_block_hash(b.block_hash))
+                for b in cpu_blocks
+                if b.block_hash is not None
+            ]
+            if block_hashes:
+                self.cpu_block_pool.kv_event_queue.append(
+                    BlockStored(
+                        block_hashes=block_hashes,
+                        parent_block_hash=None,
+                        token_ids=[],
+                        block_size=self.block_size,
+                        medium=self.cpu_block_pool.medium,
+                        lora_id=None,
+                        lora_name=None,
+                    )
+                )
 
         # Free CPU and GPU blocks' ref counts to turn them into prefix cache
         self.cpu_block_pool.free_blocks(cpu_blocks)

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -145,6 +145,9 @@ class SimpleCPUOffloadScheduler:
         # Eager mode only
         self._reqs_to_store: dict[str, StoreRequestState] = {}
         self._store_event_to_reqs: dict[int, list[str]] = {}
+        # Eager mode only: per-request CPU block IDs for correct event emission.
+        # Maps store_event_idx → {req_id → [cpu_block_ids]}.
+        self._store_event_to_req_cpu_blocks: dict[int, dict[str, list[int]]] = {}
 
         # Event counters
         self._load_event_counter: int = 0
@@ -320,7 +323,9 @@ class SimpleCPUOffloadScheduler:
     ) -> SimpleCPUOffloadMetadata:
         # --- Stores ---
         store_event = -1
-        store_gpu, store_cpu, store_req_ids = self.prepare_store_specs(scheduler_output)
+        store_gpu, store_cpu, store_req_ids, req_cpu_blocks = self.prepare_store_specs(
+            scheduler_output
+        )
         if store_gpu:
             store_event = self._store_event_counter
             self._store_event_counter += 1
@@ -329,6 +334,8 @@ class SimpleCPUOffloadScheduler:
             )
             if store_req_ids:  # For eager mode only, track req->blocks mapping
                 self._store_event_to_reqs[store_event] = store_req_ids
+                if req_cpu_blocks:
+                    self._store_event_to_req_cpu_blocks[store_event] = req_cpu_blocks
                 for req_id in store_req_ids:
                     store_state = self._reqs_to_store.get(req_id)
                     if store_state is not None:
@@ -367,10 +374,10 @@ class SimpleCPUOffloadScheduler:
 
     def prepare_store_specs(
         self, scheduler_output: SchedulerOutput
-    ) -> tuple[list[int], list[int], list[str]]:
-        """Prepare store specs for the store event."""
+    ) -> tuple[list[int], list[int], list[str], dict[str, list[int]]]:
         if self._lazy_mode:
-            return self._prepare_lazy_store_specs()
+            gpu, cpu, reqs = self._prepare_lazy_store_specs()
+            return gpu, cpu, reqs, {}
         else:
             return self._prepare_eager_store_specs(scheduler_output)
 
@@ -444,7 +451,7 @@ class SimpleCPUOffloadScheduler:
 
     def _prepare_eager_store_specs(
         self, scheduler_output: SchedulerOutput
-    ) -> tuple[list[int], list[int], list[str]]:
+    ) -> tuple[list[int], list[int], list[str], dict[str, list[int]]]:
         """Identify newly computed blocks to offload from scheduler requests.
 
         Only considers blocks whose KV data has been **confirmed computed** by
@@ -453,16 +460,17 @@ class SimpleCPUOffloadScheduler:
         that block may be missed. (TODO: flush on finish.)
 
         Returns:
-            (gpu_block_ids, cpu_block_ids, req_ids) for the store event.
+            (gpu_block_ids, cpu_block_ids, req_ids, req_cpu_blocks) for the store event.
         """
 
         merged_gpu_block_ids: list[int] = []
         merged_cpu_block_ids: list[int] = []
         req_ids: list[str] = []
+        req_cpu_blocks: dict[str, list[int]] = {}
 
         gpu_block_pool = self._gpu_block_pool
         if gpu_block_pool is None:
-            return [], [], []
+            return [], [], [], {}
         cpu_block_pool = self.cpu_block_pool
         num_free = cpu_block_pool.get_num_free_blocks()
         kv_cache_groups = self.cpu_kv_cache_config.kv_cache_groups
@@ -560,6 +568,7 @@ class SimpleCPUOffloadScheduler:
                 req_ids.append(req_id)
                 merged_gpu_block_ids.extend(gpu_block_ids)
                 merged_cpu_block_ids.extend(cpu_block_ids)
+                req_cpu_blocks[req_id] = cpu_block_ids
                 gpu_blocks_this_step.update(gpu_block_ids)
 
                 # Touch GPU blocks to prevent freeing during async copy
@@ -578,7 +587,7 @@ class SimpleCPUOffloadScheduler:
             for g in range(num_groups):
                 state.num_stored_blocks[g] += advanced_per_group[g]
 
-        return merged_gpu_block_ids, merged_cpu_block_ids, req_ids
+        return merged_gpu_block_ids, merged_cpu_block_ids, req_ids, req_cpu_blocks
 
     def update_connector_output(self, connector_output: KVConnectorOutput) -> None:
         """Handle async transfer completions from worker.
@@ -607,7 +616,10 @@ class SimpleCPUOffloadScheduler:
     def _process_store_event(self, event_idx: int) -> None:
         """Process a fully-completed store event."""
         transfer = self._store_event_to_blocks.pop(event_idx)
-        self._process_store_completion(transfer.gpu_block_ids, transfer.cpu_block_ids)
+        req_cpu_blocks = self._store_event_to_req_cpu_blocks.pop(event_idx, None)
+        self._process_store_completion(
+            transfer.gpu_block_ids, transfer.cpu_block_ids, req_cpu_blocks
+        )
         logger.debug(
             "Store event %d completed: cached %d blocks to CPU",
             event_idx,
@@ -625,7 +637,10 @@ class SimpleCPUOffloadScheduler:
                     self._cleanup_store_request(req_id)
 
     def _process_store_completion(
-        self, gpu_block_ids: list[int], cpu_block_ids: list[int]
+        self,
+        gpu_block_ids: list[int],
+        cpu_block_ids: list[int],
+        req_cpu_blocks: dict[str, list[int]] | None = None,
     ) -> None:
         """Cache CPU blocks per-group and release GPU refs.
 
@@ -643,6 +658,42 @@ class SimpleCPUOffloadScheduler:
             self.cpu_block_pool.cached_block_hash_to_block.insert(bhash, cpu_block)
 
         if self.enable_kv_cache_events:
+            self._emit_store_events(cpu_blocks, req_cpu_blocks)
+
+        # Free CPU and GPU blocks' ref counts to turn them into prefix cache
+        self.cpu_block_pool.free_blocks(cpu_blocks)
+        assert self._gpu_block_pool is not None
+        self._gpu_block_pool.free_blocks(
+            self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids
+        )
+
+    def _emit_store_events(
+        self,
+        cpu_blocks: list["KVCacheBlock"],
+        req_cpu_blocks: dict[str, list[int]] | None,
+    ) -> None:
+        if req_cpu_blocks:
+            for _req_id, per_req_cpu_ids in req_cpu_blocks.items():
+                block_hashes = [
+                    maybe_convert_block_hash(
+                        get_block_hash(self.cpu_block_pool.blocks[bid].block_hash)
+                    )
+                    for bid in per_req_cpu_ids
+                    if self.cpu_block_pool.blocks[bid].block_hash is not None
+                ]
+                if block_hashes:
+                    self.cpu_block_pool.kv_event_queue.append(
+                        BlockStored(
+                            block_hashes=block_hashes,
+                            parent_block_hash=None,
+                            token_ids=[],
+                            block_size=self.block_size,
+                            medium=self.cpu_block_pool.medium,
+                            lora_id=None,
+                            lora_name=None,
+                        )
+                    )
+        else:
             block_hashes = [
                 maybe_convert_block_hash(get_block_hash(b.block_hash))
                 for b in cpu_blocks
@@ -660,13 +711,6 @@ class SimpleCPUOffloadScheduler:
                         lora_name=None,
                     )
                 )
-
-        # Free CPU and GPU blocks' ref counts to turn them into prefix cache
-        self.cpu_block_pool.free_blocks(cpu_blocks)
-        assert self._gpu_block_pool is not None
-        self._gpu_block_pool.free_blocks(
-            self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids
-        )
 
     def has_pending_stores(self) -> bool:
         """Return True if there are in-flight store transfers."""

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -145,9 +145,6 @@ class SimpleCPUOffloadScheduler:
         # Eager mode only
         self._reqs_to_store: dict[str, StoreRequestState] = {}
         self._store_event_to_reqs: dict[int, list[str]] = {}
-        # Eager mode only: per-request CPU block IDs for correct event emission.
-        # Maps store_event_idx → {req_id → [cpu_block_ids]}.
-        self._store_event_to_req_cpu_blocks: dict[int, dict[str, list[int]]] = {}
 
         # Event counters
         self._load_event_counter: int = 0
@@ -323,9 +320,7 @@ class SimpleCPUOffloadScheduler:
     ) -> SimpleCPUOffloadMetadata:
         # --- Stores ---
         store_event = -1
-        store_gpu, store_cpu, store_req_ids, req_cpu_blocks = self.prepare_store_specs(
-            scheduler_output
-        )
+        store_gpu, store_cpu, store_req_ids = self.prepare_store_specs(scheduler_output)
         if store_gpu:
             store_event = self._store_event_counter
             self._store_event_counter += 1
@@ -334,8 +329,6 @@ class SimpleCPUOffloadScheduler:
             )
             if store_req_ids:  # For eager mode only, track req->blocks mapping
                 self._store_event_to_reqs[store_event] = store_req_ids
-                if req_cpu_blocks:
-                    self._store_event_to_req_cpu_blocks[store_event] = req_cpu_blocks
                 for req_id in store_req_ids:
                     store_state = self._reqs_to_store.get(req_id)
                     if store_state is not None:
@@ -374,10 +367,10 @@ class SimpleCPUOffloadScheduler:
 
     def prepare_store_specs(
         self, scheduler_output: SchedulerOutput
-    ) -> tuple[list[int], list[int], list[str], dict[str, list[int]]]:
+    ) -> tuple[list[int], list[int], list[str]]:
+        """Prepare store specs for the store event."""
         if self._lazy_mode:
-            gpu, cpu, reqs = self._prepare_lazy_store_specs()
-            return gpu, cpu, reqs, {}
+            return self._prepare_lazy_store_specs()
         else:
             return self._prepare_eager_store_specs(scheduler_output)
 
@@ -451,7 +444,7 @@ class SimpleCPUOffloadScheduler:
 
     def _prepare_eager_store_specs(
         self, scheduler_output: SchedulerOutput
-    ) -> tuple[list[int], list[int], list[str], dict[str, list[int]]]:
+    ) -> tuple[list[int], list[int], list[str]]:
         """Identify newly computed blocks to offload from scheduler requests.
 
         Only considers blocks whose KV data has been **confirmed computed** by
@@ -460,17 +453,16 @@ class SimpleCPUOffloadScheduler:
         that block may be missed. (TODO: flush on finish.)
 
         Returns:
-            (gpu_block_ids, cpu_block_ids, req_ids, req_cpu_blocks) for the store event.
+            (gpu_block_ids, cpu_block_ids, req_ids) for the store event.
         """
 
         merged_gpu_block_ids: list[int] = []
         merged_cpu_block_ids: list[int] = []
         req_ids: list[str] = []
-        req_cpu_blocks: dict[str, list[int]] = {}
 
         gpu_block_pool = self._gpu_block_pool
         if gpu_block_pool is None:
-            return [], [], [], {}
+            return [], [], []
         cpu_block_pool = self.cpu_block_pool
         num_free = cpu_block_pool.get_num_free_blocks()
         kv_cache_groups = self.cpu_kv_cache_config.kv_cache_groups
@@ -568,7 +560,6 @@ class SimpleCPUOffloadScheduler:
                 req_ids.append(req_id)
                 merged_gpu_block_ids.extend(gpu_block_ids)
                 merged_cpu_block_ids.extend(cpu_block_ids)
-                req_cpu_blocks[req_id] = cpu_block_ids
                 gpu_blocks_this_step.update(gpu_block_ids)
 
                 # Touch GPU blocks to prevent freeing during async copy
@@ -587,7 +578,7 @@ class SimpleCPUOffloadScheduler:
             for g in range(num_groups):
                 state.num_stored_blocks[g] += advanced_per_group[g]
 
-        return merged_gpu_block_ids, merged_cpu_block_ids, req_ids, req_cpu_blocks
+        return merged_gpu_block_ids, merged_cpu_block_ids, req_ids
 
     def update_connector_output(self, connector_output: KVConnectorOutput) -> None:
         """Handle async transfer completions from worker.
@@ -616,10 +607,7 @@ class SimpleCPUOffloadScheduler:
     def _process_store_event(self, event_idx: int) -> None:
         """Process a fully-completed store event."""
         transfer = self._store_event_to_blocks.pop(event_idx)
-        req_cpu_blocks = self._store_event_to_req_cpu_blocks.pop(event_idx, None)
-        self._process_store_completion(
-            transfer.gpu_block_ids, transfer.cpu_block_ids, req_cpu_blocks
-        )
+        self._process_store_completion(transfer.gpu_block_ids, transfer.cpu_block_ids)
         logger.debug(
             "Store event %d completed: cached %d blocks to CPU",
             event_idx,
@@ -637,10 +625,7 @@ class SimpleCPUOffloadScheduler:
                     self._cleanup_store_request(req_id)
 
     def _process_store_completion(
-        self,
-        gpu_block_ids: list[int],
-        cpu_block_ids: list[int],
-        req_cpu_blocks: dict[str, list[int]] | None = None,
+        self, gpu_block_ids: list[int], cpu_block_ids: list[int]
     ) -> None:
         """Cache CPU blocks per-group and release GPU refs.
 
@@ -658,42 +643,6 @@ class SimpleCPUOffloadScheduler:
             self.cpu_block_pool.cached_block_hash_to_block.insert(bhash, cpu_block)
 
         if self.enable_kv_cache_events:
-            self._emit_store_events(cpu_blocks, req_cpu_blocks)
-
-        # Free CPU and GPU blocks' ref counts to turn them into prefix cache
-        self.cpu_block_pool.free_blocks(cpu_blocks)
-        assert self._gpu_block_pool is not None
-        self._gpu_block_pool.free_blocks(
-            self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids
-        )
-
-    def _emit_store_events(
-        self,
-        cpu_blocks: list["KVCacheBlock"],
-        req_cpu_blocks: dict[str, list[int]] | None,
-    ) -> None:
-        if req_cpu_blocks:
-            for _req_id, per_req_cpu_ids in req_cpu_blocks.items():
-                block_hashes = [
-                    maybe_convert_block_hash(
-                        get_block_hash(self.cpu_block_pool.blocks[bid].block_hash)
-                    )
-                    for bid in per_req_cpu_ids
-                    if self.cpu_block_pool.blocks[bid].block_hash is not None
-                ]
-                if block_hashes:
-                    self.cpu_block_pool.kv_event_queue.append(
-                        BlockStored(
-                            block_hashes=block_hashes,
-                            parent_block_hash=None,
-                            token_ids=[],
-                            block_size=self.block_size,
-                            medium=self.cpu_block_pool.medium,
-                            lora_id=None,
-                            lora_name=None,
-                        )
-                    )
-        else:
             block_hashes = [
                 maybe_convert_block_hash(get_block_hash(b.block_hash))
                 for b in cpu_blocks
@@ -711,6 +660,13 @@ class SimpleCPUOffloadScheduler:
                         lora_name=None,
                     )
                 )
+
+        # Free CPU and GPU blocks' ref counts to turn them into prefix cache
+        self.cpu_block_pool.free_blocks(cpu_blocks)
+        assert self._gpu_block_pool is not None
+        self._gpu_block_pool.free_blocks(
+            self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids
+        )
 
     def has_pending_stores(self) -> bool:
         """Return True if there are in-flight store transfers."""

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -168,6 +168,9 @@ class SimpleCPUOffloadScheduler:
         self._store_event_to_reqs: dict[int, list[str]] = {}
         self._in_flight_store_gpu_blocks: set[int] = set()
         self._abandoned_reqs_to_load: dict[str, LoadRequestState] = {}
+        # Eager mode only: per-request CPU block IDs for correct event emission.
+        # Maps store_event_idx to {req_id: [cpu_block_ids]}.
+        self._store_event_to_req_cpu_blocks: dict[int, dict[str, list[int]]] = {}
 
         # Event counters
         self._load_event_counter: int = 0
@@ -408,7 +411,9 @@ class SimpleCPUOffloadScheduler:
     ) -> SimpleCPUOffloadMetadata:
         # --- Stores ---
         store_event = -1
-        store_gpu, store_cpu, store_req_ids = self.prepare_store_specs(scheduler_output)
+        store_gpu, store_cpu, store_req_ids, req_cpu_blocks = self.prepare_store_specs(
+            scheduler_output
+        )
         if store_gpu:
             store_event = self._store_event_counter
             self._store_event_counter += 1
@@ -417,6 +422,8 @@ class SimpleCPUOffloadScheduler:
             )
             if store_req_ids:  # For eager mode only, track req->blocks mapping
                 self._store_event_to_reqs[store_event] = store_req_ids
+                if req_cpu_blocks:
+                    self._store_event_to_req_cpu_blocks[store_event] = req_cpu_blocks
                 for req_id in store_req_ids:
                     store_state = self._reqs_to_store.get(req_id)
                     if store_state is not None:
@@ -458,10 +465,10 @@ class SimpleCPUOffloadScheduler:
 
     def prepare_store_specs(
         self, scheduler_output: SchedulerOutput
-    ) -> tuple[list[int], list[int], list[str]]:
-        """Prepare store specs for the store event."""
+    ) -> tuple[list[int], list[int], list[str], dict[str, list[int]]]:
         if self._lazy_mode:
-            return self._prepare_lazy_store_specs()
+            gpu, cpu, reqs = self._prepare_lazy_store_specs()
+            return gpu, cpu, reqs, {}
         else:
             return self._prepare_eager_store_specs(scheduler_output)
 
@@ -535,7 +542,7 @@ class SimpleCPUOffloadScheduler:
 
     def _prepare_eager_store_specs(
         self, scheduler_output: SchedulerOutput
-    ) -> tuple[list[int], list[int], list[str]]:
+    ) -> tuple[list[int], list[int], list[str], dict[str, list[int]]]:
         """Identify newly computed blocks to offload from scheduler requests.
 
         Only considers blocks whose KV data has been **confirmed computed** by
@@ -544,16 +551,17 @@ class SimpleCPUOffloadScheduler:
         that block may be missed. (TODO: flush on finish.)
 
         Returns:
-            (gpu_block_ids, cpu_block_ids, req_ids) for the store event.
+            (gpu_block_ids, cpu_block_ids, req_ids, req_cpu_blocks) for the store event.
         """
 
         merged_gpu_block_ids: list[int] = []
         merged_cpu_block_ids: list[int] = []
         req_ids: list[str] = []
+        req_cpu_blocks: dict[str, list[int]] = {}
 
         gpu_block_pool = self._gpu_block_pool
         if gpu_block_pool is None:
-            return [], [], []
+            return [], [], [], {}
         cpu_block_pool = self.cpu_block_pool
         num_free = cpu_block_pool.get_num_free_blocks()
         kv_cache_groups = self.cpu_kv_cache_config.kv_cache_groups
@@ -656,6 +664,7 @@ class SimpleCPUOffloadScheduler:
                 merged_gpu_block_ids.extend(gpu_block_ids)
                 merged_cpu_block_ids.extend(cpu_block_ids)
                 in_flight.update(gpu_block_ids)
+                req_cpu_blocks[req_id] = cpu_block_ids
 
                 # Touch GPU blocks to prevent freeing during async copy
                 gpu_block_pool.touch(
@@ -673,7 +682,7 @@ class SimpleCPUOffloadScheduler:
             for g in range(num_groups):
                 state.num_stored_blocks[g] += advanced_per_group[g]
 
-        return merged_gpu_block_ids, merged_cpu_block_ids, req_ids
+        return merged_gpu_block_ids, merged_cpu_block_ids, req_ids, req_cpu_blocks
 
     def update_connector_output(self, connector_output: KVConnectorOutput) -> None:
         """Handle async transfer completions from worker.
@@ -704,6 +713,7 @@ class SimpleCPUOffloadScheduler:
         transfer = self._store_event_to_blocks.pop(event_idx, None)
         if transfer is None:
             transfer = self._abandoned_store_event_to_blocks.pop(event_idx, None)
+            self._store_event_to_req_cpu_blocks.pop(event_idx, None)
             if transfer is None:
                 return  # guard stale events from before a reset() call
             self._release_transfer_refs(transfer)
@@ -712,7 +722,10 @@ class SimpleCPUOffloadScheduler:
         if not self._lazy_mode:
             self._in_flight_store_gpu_blocks.difference_update(transfer.gpu_block_ids)
 
-        self._process_store_completion(transfer.gpu_block_ids, transfer.cpu_block_ids)
+        req_cpu_blocks = self._store_event_to_req_cpu_blocks.pop(event_idx, None)
+        self._process_store_completion(
+            transfer.gpu_block_ids, transfer.cpu_block_ids, req_cpu_blocks
+        )
         logger.debug(
             "Store event %d completed: cached %d blocks to CPU",
             event_idx,
@@ -730,7 +743,10 @@ class SimpleCPUOffloadScheduler:
                     self._cleanup_store_request(req_id)
 
     def _process_store_completion(
-        self, gpu_block_ids: list[int], cpu_block_ids: list[int]
+        self,
+        gpu_block_ids: list[int],
+        cpu_block_ids: list[int],
+        req_cpu_blocks: dict[str, list[int]] | None = None,
     ) -> None:
         """Cache CPU blocks per-group and release GPU refs.
 
@@ -748,6 +764,42 @@ class SimpleCPUOffloadScheduler:
             self.cpu_block_pool.cached_block_hash_to_block.insert(bhash, cpu_block)
 
         if self.enable_kv_cache_events:
+            self._emit_store_events(cpu_blocks, req_cpu_blocks)
+
+        # Free CPU and GPU blocks' ref counts to turn them into prefix cache
+        self.cpu_block_pool.free_blocks(cpu_blocks)
+        assert self._gpu_block_pool is not None
+        self._gpu_block_pool.free_blocks(
+            self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids
+        )
+
+    def _emit_store_events(
+        self,
+        cpu_blocks: list["KVCacheBlock"],
+        req_cpu_blocks: dict[str, list[int]] | None,
+    ) -> None:
+        if req_cpu_blocks:
+            for _req_id, per_req_cpu_ids in req_cpu_blocks.items():
+                block_hashes = [
+                    maybe_convert_block_hash(
+                        get_block_hash(self.cpu_block_pool.blocks[bid].block_hash)
+                    )
+                    for bid in per_req_cpu_ids
+                    if self.cpu_block_pool.blocks[bid].block_hash is not None
+                ]
+                if block_hashes:
+                    self.cpu_block_pool.kv_event_queue.append(
+                        BlockStored(
+                            block_hashes=block_hashes,
+                            parent_block_hash=None,
+                            token_ids=[],
+                            block_size=self.block_size,
+                            medium=self.cpu_block_pool.medium,
+                            lora_id=None,
+                            lora_name=None,
+                        )
+                    )
+        else:
             block_hashes = [
                 maybe_convert_block_hash(get_block_hash(b.block_hash))
                 for b in cpu_blocks

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from vllm.config import VllmConfig
-from vllm.distributed.kv_events import KVCacheEvent
+from vllm.distributed.kv_events import BlockStored, KVCacheEvent
 from vllm.distributed.kv_transfer.kv_connector.utils import yield_req_data
 from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
@@ -17,6 +17,7 @@ from vllm.v1.core.kv_cache_coordinator import (
     KVCacheCoordinator,
     get_kv_cache_coordinator,
 )
+from vllm.v1.core.kv_cache_utils import get_block_hash, maybe_convert_block_hash
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
@@ -131,6 +132,7 @@ class SimpleCPUOffloadScheduler:
             hash_block_size=self.hash_block_size,
         )
         self.cpu_block_pool: BlockPool = self.cpu_coordinator.block_pool
+        self.cpu_block_pool.medium = "CPU"
 
         # GPU block pool reference - bound after scheduler builds kv_cache_manager
         self._gpu_block_pool: BlockPool | None = None
@@ -744,6 +746,25 @@ class SimpleCPUOffloadScheduler:
             bhash = cpu_block.block_hash
             assert bhash is not None
             self.cpu_block_pool.cached_block_hash_to_block.insert(bhash, cpu_block)
+
+        if self.enable_kv_cache_events:
+            block_hashes = [
+                maybe_convert_block_hash(get_block_hash(b.block_hash))
+                for b in cpu_blocks
+                if b.block_hash is not None
+            ]
+            if block_hashes:
+                self.cpu_block_pool.kv_event_queue.append(
+                    BlockStored(
+                        block_hashes=block_hashes,
+                        parent_block_hash=None,
+                        token_ids=[],
+                        block_size=self.block_size,
+                        medium=self.cpu_block_pool.medium,
+                        lora_id=None,
+                        lora_name=None,
+                    )
+                )
 
         # Free CPU and GPU blocks' ref counts to turn them into prefix cache
         self.cpu_block_pool.free_blocks(cpu_blocks)

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -168,9 +168,6 @@ class SimpleCPUOffloadScheduler:
         self._store_event_to_reqs: dict[int, list[str]] = {}
         self._in_flight_store_gpu_blocks: set[int] = set()
         self._abandoned_reqs_to_load: dict[str, LoadRequestState] = {}
-        # Eager mode only: per-request CPU block IDs for correct event emission.
-        # Maps store_event_idx to {req_id: [cpu_block_ids]}.
-        self._store_event_to_req_cpu_blocks: dict[int, dict[str, list[int]]] = {}
 
         # Event counters
         self._load_event_counter: int = 0
@@ -411,9 +408,7 @@ class SimpleCPUOffloadScheduler:
     ) -> SimpleCPUOffloadMetadata:
         # --- Stores ---
         store_event = -1
-        store_gpu, store_cpu, store_req_ids, req_cpu_blocks = self.prepare_store_specs(
-            scheduler_output
-        )
+        store_gpu, store_cpu, store_req_ids = self.prepare_store_specs(scheduler_output)
         if store_gpu:
             store_event = self._store_event_counter
             self._store_event_counter += 1
@@ -422,8 +417,6 @@ class SimpleCPUOffloadScheduler:
             )
             if store_req_ids:  # For eager mode only, track req->blocks mapping
                 self._store_event_to_reqs[store_event] = store_req_ids
-                if req_cpu_blocks:
-                    self._store_event_to_req_cpu_blocks[store_event] = req_cpu_blocks
                 for req_id in store_req_ids:
                     store_state = self._reqs_to_store.get(req_id)
                     if store_state is not None:
@@ -465,10 +458,10 @@ class SimpleCPUOffloadScheduler:
 
     def prepare_store_specs(
         self, scheduler_output: SchedulerOutput
-    ) -> tuple[list[int], list[int], list[str], dict[str, list[int]]]:
+    ) -> tuple[list[int], list[int], list[str]]:
+        """Prepare store specs for the store event."""
         if self._lazy_mode:
-            gpu, cpu, reqs = self._prepare_lazy_store_specs()
-            return gpu, cpu, reqs, {}
+            return self._prepare_lazy_store_specs()
         else:
             return self._prepare_eager_store_specs(scheduler_output)
 
@@ -542,7 +535,7 @@ class SimpleCPUOffloadScheduler:
 
     def _prepare_eager_store_specs(
         self, scheduler_output: SchedulerOutput
-    ) -> tuple[list[int], list[int], list[str], dict[str, list[int]]]:
+    ) -> tuple[list[int], list[int], list[str]]:
         """Identify newly computed blocks to offload from scheduler requests.
 
         Only considers blocks whose KV data has been **confirmed computed** by
@@ -551,17 +544,16 @@ class SimpleCPUOffloadScheduler:
         that block may be missed. (TODO: flush on finish.)
 
         Returns:
-            (gpu_block_ids, cpu_block_ids, req_ids, req_cpu_blocks) for the store event.
+            (gpu_block_ids, cpu_block_ids, req_ids) for the store event.
         """
 
         merged_gpu_block_ids: list[int] = []
         merged_cpu_block_ids: list[int] = []
         req_ids: list[str] = []
-        req_cpu_blocks: dict[str, list[int]] = {}
 
         gpu_block_pool = self._gpu_block_pool
         if gpu_block_pool is None:
-            return [], [], [], {}
+            return [], [], []
         cpu_block_pool = self.cpu_block_pool
         num_free = cpu_block_pool.get_num_free_blocks()
         kv_cache_groups = self.cpu_kv_cache_config.kv_cache_groups
@@ -664,7 +656,6 @@ class SimpleCPUOffloadScheduler:
                 merged_gpu_block_ids.extend(gpu_block_ids)
                 merged_cpu_block_ids.extend(cpu_block_ids)
                 in_flight.update(gpu_block_ids)
-                req_cpu_blocks[req_id] = cpu_block_ids
 
                 # Touch GPU blocks to prevent freeing during async copy
                 gpu_block_pool.touch(
@@ -682,7 +673,7 @@ class SimpleCPUOffloadScheduler:
             for g in range(num_groups):
                 state.num_stored_blocks[g] += advanced_per_group[g]
 
-        return merged_gpu_block_ids, merged_cpu_block_ids, req_ids, req_cpu_blocks
+        return merged_gpu_block_ids, merged_cpu_block_ids, req_ids
 
     def update_connector_output(self, connector_output: KVConnectorOutput) -> None:
         """Handle async transfer completions from worker.
@@ -713,7 +704,6 @@ class SimpleCPUOffloadScheduler:
         transfer = self._store_event_to_blocks.pop(event_idx, None)
         if transfer is None:
             transfer = self._abandoned_store_event_to_blocks.pop(event_idx, None)
-            self._store_event_to_req_cpu_blocks.pop(event_idx, None)
             if transfer is None:
                 return  # guard stale events from before a reset() call
             self._release_transfer_refs(transfer)
@@ -722,10 +712,7 @@ class SimpleCPUOffloadScheduler:
         if not self._lazy_mode:
             self._in_flight_store_gpu_blocks.difference_update(transfer.gpu_block_ids)
 
-        req_cpu_blocks = self._store_event_to_req_cpu_blocks.pop(event_idx, None)
-        self._process_store_completion(
-            transfer.gpu_block_ids, transfer.cpu_block_ids, req_cpu_blocks
-        )
+        self._process_store_completion(transfer.gpu_block_ids, transfer.cpu_block_ids)
         logger.debug(
             "Store event %d completed: cached %d blocks to CPU",
             event_idx,
@@ -743,10 +730,7 @@ class SimpleCPUOffloadScheduler:
                     self._cleanup_store_request(req_id)
 
     def _process_store_completion(
-        self,
-        gpu_block_ids: list[int],
-        cpu_block_ids: list[int],
-        req_cpu_blocks: dict[str, list[int]] | None = None,
+        self, gpu_block_ids: list[int], cpu_block_ids: list[int]
     ) -> None:
         """Cache CPU blocks per-group and release GPU refs.
 
@@ -764,42 +748,6 @@ class SimpleCPUOffloadScheduler:
             self.cpu_block_pool.cached_block_hash_to_block.insert(bhash, cpu_block)
 
         if self.enable_kv_cache_events:
-            self._emit_store_events(cpu_blocks, req_cpu_blocks)
-
-        # Free CPU and GPU blocks' ref counts to turn them into prefix cache
-        self.cpu_block_pool.free_blocks(cpu_blocks)
-        assert self._gpu_block_pool is not None
-        self._gpu_block_pool.free_blocks(
-            self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids
-        )
-
-    def _emit_store_events(
-        self,
-        cpu_blocks: list["KVCacheBlock"],
-        req_cpu_blocks: dict[str, list[int]] | None,
-    ) -> None:
-        if req_cpu_blocks:
-            for _req_id, per_req_cpu_ids in req_cpu_blocks.items():
-                block_hashes = [
-                    maybe_convert_block_hash(
-                        get_block_hash(self.cpu_block_pool.blocks[bid].block_hash)
-                    )
-                    for bid in per_req_cpu_ids
-                    if self.cpu_block_pool.blocks[bid].block_hash is not None
-                ]
-                if block_hashes:
-                    self.cpu_block_pool.kv_event_queue.append(
-                        BlockStored(
-                            block_hashes=block_hashes,
-                            parent_block_hash=None,
-                            token_ids=[],
-                            block_size=self.block_size,
-                            medium=self.cpu_block_pool.medium,
-                            lora_id=None,
-                            lora_name=None,
-                        )
-                    )
-        else:
             block_hashes = [
                 maybe_convert_block_hash(get_block_hash(b.block_hash))
                 for b in cpu_blocks


### PR DESCRIPTION
## Purpose
BlockPool reports events with `medium=GPU`. These changes make it so that you can specify the medium where GPU is default when initializing BlockPool.

Per request event emission for eager mode is added. 

