### PR TITLE
fix online fp8 for MiniCPM models

### DIFF
--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -1452,11 +1452,9 @@ class MiniCPMV2_6(MiniCPMVBaseModel, SupportsLoRA):
                 quant_config=quant_config,
                 prefix=prefix,
             )
-        target_device = current_platform.device_type
-        target_dtype = torch.get_default_dtype()
-        if any(p.is_meta for p in resampler.parameters()):
-            return resampler.to_empty(device=target_device).to(dtype=target_dtype)
-        return resampler.to(device=target_device, dtype=target_dtype)
+        return resampler.to(
+            device=current_platform.device_type, dtype=torch.get_default_dtype()
+        )
 
     def get_vision_hidden_states(self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
         pixel_values = data["pixel_values"]
@@ -1649,11 +1647,9 @@ class MiniCPMV4_5(MiniCPMVBaseModel, SupportsLoRA):
                 quant_config=quant_config,
                 prefix=prefix,
             )
-        target_device = current_platform.device_type
-        target_dtype = torch.get_default_dtype()
-        if any(p.is_meta for p in resampler.parameters()):
-            return resampler.to_empty(device=target_device).to(dtype=target_dtype)
-        return resampler.to(device=target_device, dtype=target_dtype)
+        return resampler.to(
+            device=current_platform.device_type, dtype=torch.get_default_dtype()
+        )
 
     def get_vision_hidden_states(self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
         pixel_values = data["pixel_values"]

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -1050,8 +1050,16 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
                 quant_config=quant_config,
                 prefix=maybe_prefix(prefix, "resampler"),
             )
+            self._resampler_moved = False
 
         self.make_empty_intermediate_tensors = self.llm.make_empty_intermediate_tensors
+
+    def _ensure_resampler_device(self) -> None:
+        if self._resampler_moved:
+            return
+        # Only move device, DO NOT touch dtype (fp8 quant needs its own dtype)
+        self.resampler.to(current_platform.device_type)
+        self._resampler_moved = True
 
     def _parse_and_validate_vision_input(
         self,
@@ -1171,7 +1179,9 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self)
-        return loader.load_weights(weights)
+        loaded = loader.load_weights(weights)
+        self._ensure_resampler_device()
+        return loaded
 
     def get_mm_mapping(self) -> MultiModelKeys:
         """
@@ -1276,9 +1286,7 @@ class MiniCPMV2_0(MiniCPMVBaseModel):
                 prefix=prefix,
             )
 
-        return resampler.to(
-            device=current_platform.device_type, dtype=torch.get_default_dtype()
-        )
+        return resampler.to(dtype=torch.get_default_dtype())
 
     def get_vision_hidden_states(self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
         pixel_values = data["pixel_values"]
@@ -1359,9 +1367,7 @@ class MiniCPMV2_5(MiniCPMVBaseModel, SupportsLoRA):
                 prefix=prefix,
             )
 
-        return resampler.to(
-            device=current_platform.device_type, dtype=torch.get_default_dtype()
-        )
+        return resampler.to(dtype=torch.get_default_dtype())
 
     def get_vision_hidden_states(self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
         pixel_values = data["pixel_values"]
@@ -1452,9 +1458,8 @@ class MiniCPMV2_6(MiniCPMVBaseModel, SupportsLoRA):
                 quant_config=quant_config,
                 prefix=prefix,
             )
-        return resampler.to(
-            device=current_platform.device_type, dtype=torch.get_default_dtype()
-        )
+
+        return resampler.to(dtype=torch.get_default_dtype())
 
     def get_vision_hidden_states(self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
         pixel_values = data["pixel_values"]
@@ -1489,7 +1494,9 @@ class MiniCPMV2_6(MiniCPMVBaseModel, SupportsLoRA):
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self, skip_prefixes=["apm.", "audio", "tts"])
-        return loader.load_weights(weights)
+        loaded = loader.load_weights(weights)
+        self._ensure_resampler_device()
+        return loaded
 
 
 class MiniCPMV4_0(MiniCPMVBaseModel, SupportsLoRA):
@@ -1549,10 +1556,7 @@ class MiniCPMV4_0(MiniCPMVBaseModel, SupportsLoRA):
                 quant_config=quant_config,
                 prefix=prefix,
             )
-
-        return resampler.to(
-            device=current_platform.device_type, dtype=torch.get_default_dtype()
-        )
+        return resampler.to(dtype=torch.get_default_dtype())
 
     def get_vision_hidden_states(self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
         pixel_values = data["pixel_values"]
@@ -1587,7 +1591,9 @@ class MiniCPMV4_0(MiniCPMVBaseModel, SupportsLoRA):
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self, skip_prefixes=["apm.", "audio", "tts"])
-        return loader.load_weights(weights)
+        loaded = loader.load_weights(weights)
+        self._ensure_resampler_device()
+        return loaded
 
 
 class MiniCPMV4_5(MiniCPMVBaseModel, SupportsLoRA):
@@ -1647,9 +1653,8 @@ class MiniCPMV4_5(MiniCPMVBaseModel, SupportsLoRA):
                 quant_config=quant_config,
                 prefix=prefix,
             )
-        return resampler.to(
-            device=current_platform.device_type, dtype=torch.get_default_dtype()
-        )
+
+        return resampler.to(dtype=torch.get_default_dtype())
 
     def get_vision_hidden_states(self, data: MiniCPMVImagePixelInputs) -> torch.Tensor:
         pixel_values = data["pixel_values"]
@@ -1688,7 +1693,9 @@ class MiniCPMV4_5(MiniCPMVBaseModel, SupportsLoRA):
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self, skip_prefixes=["apm.", "audio", "tts"])
-        return loader.load_weights(weights)
+        loaded = loader.load_weights(weights)
+        self._ensure_resampler_device()
+        return loaded
 
 
 _SUPPORT_VERSION = {


### PR DESCRIPTION



## Purpose
PR #36751 fixed meta tensor issue for minicpm models but only partially, so still met below error when running `MiniCPM-V-4`. This PR uses a different method to do the fix and cover whole family.
```

(EngineCore pid=6692) ERROR 04-15 02:31:16 [core.py:1110]   File "/workspace/vllm-attn/vllm/model_executor/models/minicpmv.py", line 1555, in init_resampler
(EngineCore pid=6692) ERROR 04-15 02:31:16 [core.py:1110]     return resampler.to(
(EngineCore pid=6692) ERROR 04-15 02:31:16 [core.py:1110]            ^^^^^^^^^^^^^
(EngineCore pid=6692) ERROR 04-15 02:31:16 [core.py:1110]   File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1384, in to
(EngineCore pid=6692) ERROR 04-15 02:31:16 [core.py:1110]     return self._apply(convert)
(EngineCore pid=6692) ERROR 04-15 02:31:16 [core.py:1110]            ^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=6692) ERROR 04-15 02:31:16 [core.py:1110]   File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 934, in _apply
(EngineCore pid=6692) ERROR 04-15 02:31:16 [core.py:1110]     module._apply(fn)
(EngineCore pid=6692) ERROR 04-15 02:31:16 [core.py:1110]   File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 965, in _apply
(EngineCore pid=6692) ERROR 04-15 02:31:16 [core.py:1110]     param_applied = fn(param)
(EngineCore pid=6692) ERROR 04-15 02:31:16 [core.py:1110]                     ^^^^^^^^^
(EngineCore pid=6692) ERROR 04-15 02:31:16 [core.py:1110]   File "/opt/venv/lib/python3.12/site-packages/torch/nn/modules/module.py", line 1377, in convert
(EngineCore pid=6692) ERROR 04-15 02:31:16 [core.py:1110]     raise NotImplementedError(
(EngineCore pid=6692) ERROR 04-15 02:31:16 [core.py:1110] NotImplementedError: Cannot copy out of meta tensor; no data! Please use torch.nn.Module.to_empty() instead of torch.nn.Module.to() when moving module from meta to a different device.
(EngineCore pid=6692) Process EngineCore:

```
## Test Plan
```
VLLM_WORKER_MULTIPROC_METHOD=spawn python3 examples/basic/offline_inference/generate.py --model openbmb/MiniCPM-V-4 --enforce-eager --quantization fp8 --dtype=float16 --max-model-len 4096 --trust-remote-code
```
## Test Result
```
Processed prompts: 100%|█████████████| 4/4 [00:01<00:00,  2.49it/s, est. speed input: 16.19 toks/s, output: 39.84 toks/s]
--------------------------------------------------
Prompt: 'Hello, my name is'
Generated text: ' Nirav, and I am here to do something about climate change, not'
--------------------------------------------------
Prompt: 'The president of the United States is'
Generated text: ' a non-civil servant. “U.S. President: civil servant'
--------------------------------------------------
Prompt: 'The capital of France is'
Generated text: " Paris, but that's primarily for the struggle of history. Radio center,"
--------------------------------------------------
Prompt: 'The future of AI is'
Generated text: ' bright, and Collins Aerospace is leading the way. With its latest advance'

```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

