### PR TITLE
[Bugfix] check hasattr "silu_and_mul_per_block_quant"

### DIFF
--- a/vllm/compilation/passes/fusion/act_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/act_quant_fusion.py
@@ -45,7 +45,9 @@ silu_and_mul_nvfp4_quant_supported = current_platform.is_cuda() and hasattr(
 if silu_and_mul_nvfp4_quant_supported:
     FUSED_OPS[kNvfp4Dynamic] = torch.ops._C.silu_and_mul_nvfp4_quant.default  # noqa: E501
 
-if current_platform.is_cuda_alike():
+if current_platform.is_cuda_alike() and hasattr(
+    torch.ops._C, "silu_and_mul_per_block_quant"
+):
     FUSED_OPS[kFp8Dynamic128Sym] = torch.ops._C.silu_and_mul_per_block_quant.default
     FUSED_OPS[kFp8Dynamic64Sym] = torch.ops._C.silu_and_mul_per_block_quant.default
 


### PR DESCRIPTION



## Purpose
When serving the `PaddlePaddle/PaddleOCR-VL-1.5` model using the `main` branch (around commit b569620f720d0c07bcb90bcc29dacaf0ce318d85) via the vLLM CLI Command `python -m vllm.entrypoints.cli.main serve PaddlePaddle/PaddleOCR-VL-1.5 --trust-remote-code --gpu-memory-utilization 0.7`, 
the `EngineCore` fails to initialize with the following error:
`AttributeError: '_OpNamespace' '_C' object has no attribute 'silu_and_mul_per_block_quant'.`

The error occurs during model loading, specifically when importing `vllm.compilation.passes.fusion.act_quant_fusion`. The code attempts to access `torch.ops._C.silu_and_mul_per_block_quant.default`, but this op is not available in the current PyTorch environment.

```text
(EngineCore pid=4736) ERROR 04-15 10:43:31 [core.py:1132] EngineCore failed to start.
...
(EngineCore pid=4736)   File "/home/yeguorong/code/vllm/vllm/compilation/passes/fusion/act_quant_fusion.py", line 49, in <module>
(EngineCore pid=4736)     FUSED_OPS[kFp8Dynamic128Sym] = torch.ops._C.silu_and_mul_per_block_quant.default
(EngineCore pid=4736)                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=4736) AttributeError: '_OpNamespace' '_C' object has no attribute 'silu_and_mul_per_block_quant'. Did you mean: 'rms_norm_per_block_quant'?
```


## Test Plan
python -m vllm.entrypoints.cli.main serve PaddlePaddle/PaddleOCR-VL-1.5 --trust-remote-code --gpu-memory-utilization 0.7

## Test Result
The model should load successfully and start the API server.