### PR TITLE
[Scheduler] Cap SWA admission budget at sliding_window + chunk_size

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1831,6 +1831,59 @@ def test_reset_prefix_cache():
     assert all([blk.block_hash is None for blk in manager.block_pool.blocks])
 
 
+def test_hybrid_swa_cap_does_not_crash_allocator():
+    block_size = 16
+    sliding_window = 64
+    num_tokens = 200
+    request_id = "r"
+
+    manager = KVCacheManager(
+        kv_cache_config=KVCacheConfig(
+            num_blocks=26,  # 25 usable blocks + 1 null block.
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["full"],
+                    FullAttentionSpec(
+                        block_size=block_size,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float32,
+                    ),
+                ),
+                KVCacheGroupSpec(
+                    ["swa"],
+                    SlidingWindowSpec(
+                        block_size=block_size,
+                        num_kv_heads=1,
+                        head_size=1,
+                        dtype=torch.float32,
+                        sliding_window=sliding_window,
+                    ),
+                ),
+            ],
+        ),
+        max_model_len=4096,
+        hash_block_size=block_size,
+        max_num_batched_tokens=32,
+        enable_caching=True,
+    )
+
+    req = make_request(request_id, [1] * num_tokens, block_size, sha256)
+    full_required_blocks = (num_tokens + block_size - 1) // block_size
+    allocated = manager.block_pool.get_new_blocks(
+        manager.block_pool.num_gpu_blocks - 1)
+    full_mgr, swa_mgr = manager.coordinator.single_type_managers
+
+    full_mgr.req_to_blocks[request_id] = allocated[:full_required_blocks]
+    swa_mgr.req_to_blocks[request_id] = allocated[
+        full_required_blocks:full_required_blocks + (full_required_blocks - 1)
+    ]
+
+    assert manager.block_pool.get_num_free_blocks() == 0
+    assert manager.allocate_slots(req, num_new_tokens=num_tokens) is None
+
+
 def test_prefix_cache_stats_disabled():
     """Test that prefix_cache_stats is None when log_stats is False."""
     block_size = 16

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -1871,13 +1871,12 @@ def test_hybrid_swa_cap_does_not_crash_allocator():
 
     req = make_request(request_id, [1] * num_tokens, block_size, sha256)
     full_required_blocks = (num_tokens + block_size - 1) // block_size
-    allocated = manager.block_pool.get_new_blocks(
-        manager.block_pool.num_gpu_blocks - 1)
+    allocated = manager.block_pool.get_new_blocks(manager.block_pool.num_gpu_blocks - 1)
     full_mgr, swa_mgr = manager.coordinator.single_type_managers
 
     full_mgr.req_to_blocks[request_id] = allocated[:full_required_blocks]
     swa_mgr.req_to_blocks[request_id] = allocated[
-        full_required_blocks:full_required_blocks + (full_required_blocks - 1)
+        full_required_blocks : full_required_blocks + (full_required_blocks - 1)
     ]
 
     assert manager.block_pool.get_num_free_blocks() == 0

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -15,6 +15,7 @@ from vllm.v1.core.kv_cache_utils import (
 from vllm.v1.core.single_type_kv_cache_manager import (
     CrossAttentionManager,
     SingleTypeKVCacheManager,
+    SlidingWindowManager,
     get_manager_for_kv_cache_spec,
 )
 from vllm.v1.kv_cache_interface import (
@@ -40,10 +41,12 @@ class KVCacheCoordinator(ABC):
         dcp_world_size: int,
         pcp_world_size: int,
         hash_block_size: int,
+        max_num_batched_tokens: int = 0,
         metrics_collector: KVCacheMetricsCollector | None = None,
     ):
         self.kv_cache_config = kv_cache_config
         self.max_model_len = max_model_len
+        self.max_num_batched_tokens = max_num_batched_tokens
         self.enable_caching = enable_caching
 
         self.block_pool = BlockPool(
@@ -105,9 +108,19 @@ class KVCacheCoordinator(ABC):
                     request_id, num_encoder_tokens, [], 0, num_encoder_tokens
                 )
             else:
+                # Cap num_tokens for SWA: a sliding window layer never
+                # holds more than sliding_window blocks at steady state.
+                # OOW blocks are freed between chunks by
+                # remove_skipped_blocks(), so the admission check only
+                # needs to budget for the window, not the full sequence.
+                effective_num_tokens = num_tokens
+                if isinstance(manager, SlidingWindowManager):
+                    effective_num_tokens = min(
+                        num_tokens, manager.sliding_window + self.max_num_batched_tokens
+                    )
                 num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
                     request_id,
-                    num_tokens,
+                    effective_num_tokens,
                     new_computed_blocks[i],
                     total_computed_tokens,
                     num_tokens_main_model,
@@ -270,6 +283,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
         dcp_world_size: int,
         pcp_world_size: int,
         hash_block_size: int,
+        max_num_batched_tokens: int = 0,
         metrics_collector: KVCacheMetricsCollector | None = None,
     ):
         super().__init__(
@@ -281,6 +295,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
             dcp_world_size=dcp_world_size,
             pcp_world_size=pcp_world_size,
             hash_block_size=hash_block_size,
+            max_num_batched_tokens=max_num_batched_tokens,
             metrics_collector=metrics_collector,
         )
         self.num_single_type_manager = len(self.single_type_managers)
@@ -316,6 +331,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
         dcp_world_size: int,
         pcp_world_size: int,
         hash_block_size: int,
+        max_num_batched_tokens: int = 0,
         metrics_collector: KVCacheMetricsCollector | None = None,
     ):
         super().__init__(
@@ -327,6 +343,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
             dcp_world_size=dcp_world_size,
             pcp_world_size=pcp_world_size,
             hash_block_size=hash_block_size,
+            max_num_batched_tokens=max_num_batched_tokens,
             metrics_collector=metrics_collector,
         )
         self.kv_cache_spec = self.kv_cache_config.kv_cache_groups[0].kv_cache_spec
@@ -381,6 +398,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         dcp_world_size: int,
         pcp_world_size: int,
         hash_block_size: int,
+        max_num_batched_tokens: int = 0,
         metrics_collector: KVCacheMetricsCollector | None = None,
     ):
         super().__init__(
@@ -392,6 +410,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
             dcp_world_size=dcp_world_size,
             pcp_world_size=pcp_world_size,
             hash_block_size=hash_block_size,
+            max_num_batched_tokens=max_num_batched_tokens,
             metrics_collector=metrics_collector,
         )
         # hash_block_size: the block size used to compute block hashes.
@@ -547,6 +566,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
 def get_kv_cache_coordinator(
     kv_cache_config: KVCacheConfig,
     max_model_len: int,
+    max_num_batched_tokens: int,
     use_eagle: bool,
     enable_caching: bool,
     enable_kv_cache_events: bool,
@@ -564,6 +584,7 @@ def get_kv_cache_coordinator(
             dcp_world_size=dcp_world_size,
             pcp_world_size=pcp_world_size,
             hash_block_size=hash_block_size,
+            max_num_batched_tokens=max_num_batched_tokens,
             metrics_collector=metrics_collector,
         )
     if len(kv_cache_config.kv_cache_groups) == 1:
@@ -576,6 +597,7 @@ def get_kv_cache_coordinator(
             dcp_world_size=dcp_world_size,
             pcp_world_size=pcp_world_size,
             hash_block_size=hash_block_size,
+            max_num_batched_tokens=max_num_batched_tokens,
             metrics_collector=metrics_collector,
         )
     return HybridKVCacheCoordinator(
@@ -587,5 +609,6 @@ def get_kv_cache_coordinator(
         dcp_world_size=dcp_world_size,
         pcp_world_size=pcp_world_size,
         hash_block_size=hash_block_size,
+        max_num_batched_tokens=max_num_batched_tokens,
         metrics_collector=metrics_collector,
     )

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -71,7 +71,7 @@ class KVCacheCoordinator(ABC):
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
 
-    def get_num_blocks_to_allocate(
+    def get_num_blocks_needed_for_admission(
         self,
         request_id: str,
         num_tokens: int,
@@ -81,7 +81,12 @@ class KVCacheCoordinator(ABC):
         num_tokens_main_model: int,
     ) -> int:
         """
-        Get the number of blocks needed to be allocated for the request.
+        Get the number of blocks needed for admission.
+
+        This is an admission estimate, not the exact allocator demand. For SWA
+        groups, cap the token count at sliding_window + one prefill chunk.
+        OOW blocks are freed between chunks by remove_skipped_blocks(), so the
+        scheduler does not need to budget the full sequence length here.
 
         Args:
             request_id: The request ID.
@@ -108,19 +113,39 @@ class KVCacheCoordinator(ABC):
                     request_id, num_encoder_tokens, [], 0, num_encoder_tokens
                 )
             else:
-                # Cap num_tokens for SWA: a sliding window layer never
-                # holds more than sliding_window blocks at steady state.
-                # OOW blocks are freed between chunks by
-                # remove_skipped_blocks(), so the admission check only
-                # needs to budget for the window, not the full sequence.
-                effective_num_tokens = num_tokens
-                if isinstance(manager, SlidingWindowManager):
-                    effective_num_tokens = min(
-                        num_tokens, manager.sliding_window + self.max_num_batched_tokens
-                    )
+                effective_num_tokens = self._get_admission_num_tokens(
+                    manager, num_tokens)
                 num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
                     request_id,
                     effective_num_tokens,
+                    new_computed_blocks[i],
+                    total_computed_tokens,
+                    num_tokens_main_model,
+                )
+        return num_blocks_to_allocate
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: tuple[Sequence[KVCacheBlock], ...],
+        num_encoder_tokens: int,
+        total_computed_tokens: int,
+        num_tokens_main_model: int,
+    ) -> int:
+        """
+        Get the exact number of blocks needed to allocate for the request.
+        """
+        num_blocks_to_allocate = 0
+        for i, manager in enumerate(self.single_type_managers):
+            if isinstance(manager, CrossAttentionManager):
+                num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
+                    request_id, num_encoder_tokens, [], 0, num_encoder_tokens
+                )
+            else:
+                num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
+                    request_id,
+                    num_tokens,
                     new_computed_blocks[i],
                     total_computed_tokens,
                     num_tokens_main_model,
@@ -187,6 +212,17 @@ class KVCacheCoordinator(ABC):
             )
             for manager in self.single_type_managers
         )
+
+    def _get_admission_num_tokens(
+        self,
+        manager: SingleTypeKVCacheManager,
+        num_tokens: int,
+    ) -> int:
+        # SWA layers never need more than their window plus one prefill chunk.
+        if isinstance(manager, SlidingWindowManager):
+            return min(num_tokens,
+                       manager.sliding_window + self.max_num_batched_tokens)
+        return num_tokens
 
     def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
         """

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -114,7 +114,8 @@ class KVCacheCoordinator(ABC):
                 )
             else:
                 effective_num_tokens = self._get_admission_num_tokens(
-                    manager, num_tokens)
+                    manager, num_tokens
+                )
                 num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
                     request_id,
                     effective_num_tokens,
@@ -220,8 +221,7 @@ class KVCacheCoordinator(ABC):
     ) -> int:
         # SWA layers never need more than their window plus one prefill chunk.
         if isinstance(manager, SlidingWindowManager):
-            return min(num_tokens,
-                       manager.sliding_window + self.max_num_batched_tokens)
+            return min(num_tokens, manager.sliding_window + self.max_num_batched_tokens)
         return num_tokens
 
     def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -377,7 +377,7 @@ class KVCacheManager:
             request.request_id, total_computed_tokens
         )
 
-        num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
+        block_allocation_kwargs = dict(
             request_id=request.request_id,
             num_tokens=num_tokens_need_slot,
             new_computed_blocks=new_computed_block_list,
@@ -387,8 +387,22 @@ class KVCacheManager:
             num_tokens_main_model=num_tokens_main_model,
         )
 
-        if num_blocks_to_allocate > self.block_pool.get_num_free_blocks():
+        num_blocks_to_allocate = (
+            self.coordinator.get_num_blocks_needed_for_admission(
+                **block_allocation_kwargs))
+
+        num_free_blocks = self.block_pool.get_num_free_blocks()
+        if num_blocks_to_allocate > num_free_blocks:
             # Cannot allocate new blocks
+            return None
+
+        # The SWA-capped admission estimate can be lower than the actual
+        # allocator demand when a request already owns some blocks. Re-check
+        # with the uncapped token count so we fail cleanly instead of throwing
+        # out of BlockPool.get_new_blocks().
+        actual_num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
+            **block_allocation_kwargs)
+        if actual_num_blocks_to_allocate > num_free_blocks:
             return None
 
         if (

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -109,6 +109,7 @@ class KVCacheManager:
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
         hash_block_size: int,
+        max_num_batched_tokens: int = 0,
         enable_caching: bool = True,
         use_eagle: bool = False,
         log_stats: bool = False,
@@ -118,6 +119,7 @@ class KVCacheManager:
         metrics_collector: KVCacheMetricsCollector | None = None,
     ) -> None:
         self.max_model_len = max_model_len
+        self.max_num_batched_tokens = max_num_batched_tokens
 
         self.enable_caching = enable_caching
         self.use_eagle = use_eagle
@@ -131,6 +133,7 @@ class KVCacheManager:
         self.coordinator = get_kv_cache_coordinator(
             kv_cache_config=kv_cache_config,
             max_model_len=self.max_model_len,
+            max_num_batched_tokens=self.max_num_batched_tokens,
             use_eagle=self.use_eagle,
             enable_caching=self.enable_caching,
             enable_kv_cache_events=enable_kv_cache_events,

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -246,7 +246,7 @@ class KVCacheManager:
         )
         full_num_tokens = min(request.num_tokens, self.max_model_len)
 
-        num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
+        num_blocks_to_allocate = self.coordinator.get_num_blocks_needed_for_admission(
             request_id=request.request_id,
             num_tokens=full_num_tokens,
             new_computed_blocks=new_computed_block_list,
@@ -377,19 +377,16 @@ class KVCacheManager:
             request.request_id, total_computed_tokens
         )
 
-        block_allocation_kwargs = dict(
+        total_comp = num_local_computed_tokens + num_external_computed_tokens
+
+        num_blocks_to_allocate = self.coordinator.get_num_blocks_needed_for_admission(
             request_id=request.request_id,
             num_tokens=num_tokens_need_slot,
             new_computed_blocks=new_computed_block_list,
             num_encoder_tokens=num_encoder_tokens,
-            total_computed_tokens=num_local_computed_tokens
-            + num_external_computed_tokens,
+            total_computed_tokens=total_comp,
             num_tokens_main_model=num_tokens_main_model,
         )
-
-        num_blocks_to_allocate = (
-            self.coordinator.get_num_blocks_needed_for_admission(
-                **block_allocation_kwargs))
 
         num_free_blocks = self.block_pool.get_num_free_blocks()
         if num_blocks_to_allocate > num_free_blocks:
@@ -401,7 +398,13 @@ class KVCacheManager:
         # with the uncapped token count so we fail cleanly instead of throwing
         # out of BlockPool.get_new_blocks().
         actual_num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
-            **block_allocation_kwargs)
+            request_id=request.request_id,
+            num_tokens=num_tokens_need_slot,
+            new_computed_blocks=new_computed_block_list,
+            num_encoder_tokens=num_encoder_tokens,
+            total_computed_tokens=total_comp,
+            num_tokens_main_model=num_tokens_main_model,
+        )
         if actual_num_blocks_to_allocate > num_free_blocks:
             return None
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -225,6 +225,7 @@ class Scheduler(SchedulerInterface):
         self.kv_cache_manager = KVCacheManager(
             kv_cache_config=kv_cache_config,
             max_model_len=self.max_model_len,
+            max_num_batched_tokens=self.scheduler_config.max_num_batched_tokens,
             enable_caching=self.cache_config.enable_prefix_caching,
             use_eagle=self.use_eagle,
             log_stats=self.log_stats,

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -110,6 +110,9 @@ class SimpleCPUOffloadScheduler:
         self.cpu_coordinator: KVCacheCoordinator = get_kv_cache_coordinator(
             kv_cache_config=self.cpu_kv_cache_config,
             max_model_len=vllm_config.model_config.max_model_len,
+            max_num_batched_tokens=(
+                vllm_config.scheduler_config.max_num_batched_tokens
+            ),
             use_eagle=False,
             enable_caching=True,
             enable_kv_cache_events=self.enable_kv_cache_events,


### PR DESCRIPTION
## Purpose

The scheduler over-budgets Sliding Window Attention (SWA) layers during admission by passing the full sequence length to `get_num_blocks_to_allocate` for **every** layer group, even though SWA layers only ever need a window-sized footprint at steady state plus one prefill chunk of overhead. On hybrid SWA + full-attention models such as Gemma 4, this over-reservation throttles concurrent request admission.

On **Gemma 4 31B** (50 SWA layers, `sliding_window=1024`, `max_num_batched_tokens=8192`), each SWA group budgets `ceil(full_num_tokens / block_size)` blocks at admission. For a 16K-token request the budget is 1001 blocks instead of the **576** that the window-plus-one-chunk actually needs. On H200 TP=1 with a ~29.5K-block pool, this over-budget causes 4-way serialization of 8 concurrent 65K-token sessions (running caps at 4 while half the pool sits idle).

## Test Plan

- [x] **Unit test** (new): `tests/v1/core/test_prefix_caching.py::test_hybrid_swa_cap_does_not_crash_allocator` — hybrid full+SWA pool drained to 0 free blocks; `allocate_slots` must return `None`, not throw.
- [x] **Full `tests/v1/core/test_prefix_caching.py`** — no regressions.
- [x] **Admission-budget microcheck** — SWA group budget before/after the cap.
- [x] **Accuracy: GSM8K 5-shot via `lm_eval`** against the served endpoint; `num_concurrent=32`, `batch_size=32`, `max_length=4096`, `tokenized_requests=False`.
- [x] **SCBench Code.RepoQA (BF16 ckpt, H200 TP=4)** — 88 examples × 5 multi-turn, conc=4, greedy; compare per-turn and overall Pass@1 (threshold=0.8).
- [x] **Concurrency repro (H200 TP=1, 8 concurrent 65K-token requests)** — `vllm bench serve` shows higher concurrent request (**2.25x** peak OTPS).

---

## Test Result

### 1. Admission budget (Gemma 4 31B, `sliding_window=1024`, `max_num_batched_tokens=8192`, `block_size=16`)

| | BEFORE | AFTER | Δ |
|---|---:|---:|---:|
| SWA admission budget for a 16K-token per-step admission | 1,001 blocks | 576 blocks | −42.5% |


** 2. Higher concurrency **

H200 TP1 Gemma-4-31B-it, ISL=65k, OSL=64

```bash
vllm serve /trt_llm_ci/data/llm-models/gemma/gemma-4-31B-it \
    --tensor-parallel-size 1 \
    --max-num-seqs 8 \
    --max-num-batched-tokens 8192 \
    --max-model-len 131072 \
    --gpu-memory-utilization 0.95 \
    --attention-backend FLASH_ATTN \
    --enable-prefix-caching \
    --async-scheduling \
    --compilation-config '{"compile_sizes":[1,2,4,8],"cudagraph_capture_sizes":[1,2,4,8]}' \
    --host 0.0.0.0 --port 8000
```


```bash
vllm bench serve \
    --backend openai \
    --host localhost --port 8000 \
    --model /trt_llm_ci/data/llm-models/gemma/gemma-4-31B-it \
    --endpoint /v1/completions \
    --dataset-name random \
    --random-input-len 65000 \
    --random-output-len 64 \
    --num-prompts 8 \
    --max-concurrency 8 \
    --request-rate inf \
    --ignore-eos
```

Before

```
============ Serving Benchmark Result ============
Successful requests:                     8         
Failed requests:                         0         
Maximum request concurrency:             8         
Benchmark duration (s):                  125.47    
Total input tokens:                      520000    
Total generated tokens:                  512       
Request throughput (req/s):              0.06      
Output token throughput (tok/s):         4.08      
Peak output token throughput (tok/s):    103.00    
Peak concurrent requests:                8.00      
Total token throughput (tok/s):          4148.34   
---------------Time to First Token----------------
Mean TTFT (ms):                          54668.16  
Median TTFT (ms):                        54649.04  
P99 TTFT (ms):                           92683.91  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          514.69    
Median TPOT (ms):                        508.30    
P99 TPOT (ms):                           535.27    
---------------Inter-token Latency----------------
Mean ITL (ms):                           522.99    
Median ITL (ms):                         23.94     
P99 ITL (ms):                            1795.89   
==================================================
```

After - finishes the benchmark 30s faster due to higher concurrency, more decode step are batched. 
**2.25x** peak OTPS (232 / 103)
Higher ITL also showed that it got batched to 8 requests.

```
============ Serving Benchmark Result ============
Successful requests:                     8         
Failed requests:                         0         
Maximum request concurrency:             8         
Benchmark duration (s):                  93.54     
Total input tokens:                      520000    
Total generated tokens:                  512       
Request throughput (req/s):              0.09      
Output token throughput (tok/s):         5.47      
Peak output token throughput (tok/s):    232.00    
Peak concurrent requests:                8.00      
Total token throughput (tok/s):          5564.75   
---------------Time to First Token----------------
Mean TTFT (ms):                          53673.62  
Median TTFT (ms):                        53656.52  
P99 TTFT (ms):                           91250.95  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          622.58    
Median TPOT (ms):                        623.42    
P99 TPOT (ms):                           1209.73   
---------------Inter-token Latency----------------
Mean ITL (ms):                           622.58    
Median ITL (ms):                         29.93     
P99 ITL (ms):                            1824.92   
==================================================
```

### 3. Accuracy — GSM8K 5-shot (Gemma-4-31B-IT, H200, `lm_eval` `num_concurrent=32`)

| Filter | BEFORE (upstream `d622e27d2`) | **AFTER (this PR)** |
|---|---:|---:|
| `flexible-extract` | 0.7180 ± 0.0124 | **0.7142 ± 0.0124** |
| `strict-match`     | 0.7119 ± 0.0125 | **0.7058 ± 0.0126** |

Deltas are within stderr. The patch does not regress accuracy (as expected — the cap changes only *admission* decisions; once admitted, generation math is identical).

### 4. SCBench Code.RepoQA — Gemma-4-31B-IT BF16, H200 TP=4, conc=4

Serve config: `FLASH_ATTN`, `max_num_seqs=16`, `max_num_batched_tokens=8192`, `max_model_len=131072`, `gpu_memory_utilization=0.95`, prefix caching + async scheduling. 88 examples × 5 multi-turn, temperature=0, greedy.

Per-turn Pass@1 (threshold=0.8):

| Turn | BEFORE (upstream `d622e27d2`) | **AFTER (this PR)** |
|---|---:|---:|
| 0 | 79.5% | 79.5% |
| 1 | 78.4% | 78.4% |
| 2 | 76.1% | 77.3% |
| 3 | 65.9% | 65.9% |
| 4 | 79.5% | 79.5% |
| **Overall** | **75.9%** | **76.1%** |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

