### PR TITLE
[v1] Allow attention backends to declare custom KV cache page size

### DIFF
--- a/tests/v1/core/test_custom_page_size.py
+++ b/tests/v1/core/test_custom_page_size.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the `custom_page_size` seam on AttentionSpec.
+
+These tests verify that:
+1. AttentionBackend.get_kv_cache_page_size() defaults to None.
+2. An AttentionSpec with custom_page_size returns that value from
+   real_page_size_bytes instead of the head_size-based formula.
+3. FullAttentionSpec.merge and MLAAttentionSpec.merge preserve
+   custom_page_size.
+"""
+import pytest
+import torch
+
+from vllm.v1.attention.backend import AttentionBackend
+from vllm.v1.kv_cache_interface import FullAttentionSpec, MLAAttentionSpec
+
+
+class _QuantizedStubBackend(AttentionBackend):
+    """Minimal backend that reports a smaller page size than head_size*dtype."""
+
+    @classmethod
+    def get_kv_cache_page_size(
+        cls, block_size, num_kv_heads, head_size, dtype, cache_dtype_str="auto"
+    ):
+        # Pretend 4-bit quantization: 4 bits per element → head_size / 2 bytes.
+        return 2 * block_size * num_kv_heads * (head_size // 2)
+
+
+def test_default_backend_returns_none():
+    # The base class returns None; overriding is opt-in.
+    assert AttentionBackend.get_kv_cache_page_size(
+        block_size=16, num_kv_heads=8, head_size=128,
+        dtype=torch.float16, cache_dtype_str="auto",
+    ) is None
+
+
+def test_stub_backend_returns_custom_size():
+    got = _QuantizedStubBackend.get_kv_cache_page_size(
+        block_size=16, num_kv_heads=8, head_size=128,
+        dtype=torch.float16, cache_dtype_str="fp8",
+    )
+    # 2 * 16 * 8 * 64 = 16384 (half of the fp16 default 32768).
+    assert got == 16384
+
+
+def test_spec_custom_page_size_overrides_formula():
+    spec = FullAttentionSpec(
+        block_size=16, num_kv_heads=8, head_size=128,
+        dtype=torch.float16,
+        custom_page_size=12345,
+    )
+    assert spec.real_page_size_bytes == 12345
+
+
+def test_spec_default_still_uses_formula():
+    spec = FullAttentionSpec(
+        block_size=16, num_kv_heads=8, head_size=128,
+        dtype=torch.float16,
+    )
+    # block_size * num_kv_heads * head_size * dtype_size
+    # 16 * 8 * 128 * 2 = 32768 (FullAttentionSpec formula)
+    assert spec.real_page_size_bytes == 32768
+
+
+def test_full_attention_spec_merge_preserves_custom_page_size():
+    a = FullAttentionSpec(
+        block_size=16, num_kv_heads=8, head_size=128,
+        dtype=torch.float16, custom_page_size=9999,
+    )
+    merged = FullAttentionSpec.merge([a, a])
+    assert merged.custom_page_size == 9999
+
+
+def test_mla_attention_spec_merge_preserves_custom_page_size():
+    a = MLAAttentionSpec(
+        block_size=16, num_kv_heads=1, head_size=576,
+        dtype=torch.bfloat16, cache_dtype_str="auto",
+        custom_page_size=7777,
+    )
+    merged = MLAAttentionSpec.merge([a])
+    assert merged.custom_page_size == 7777
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -94,6 +94,28 @@ class AttentionBackend(ABC):
         raise NotImplementedError
 
     @classmethod
+    def get_kv_cache_page_size(
+        cls,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        dtype: "torch.dtype",
+        cache_dtype_str: str = "auto",
+    ) -> int | None:
+        """Return the page size in bytes for KV cache allocation.
+
+        If None (default), the standard formula is used:
+            2 * block_size * num_kv_heads * head_size * dtype_size
+
+        Custom backends (e.g., quantized KV) can override this to return
+        a smaller page size, enabling more cache blocks in the same memory.
+
+        Returns:
+            Page size in bytes, or None for default behavior.
+        """
+        return None
+
+    @classmethod
     def get_kv_cache_block_dim(
         cls,
         block_size: int,

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -117,6 +117,9 @@ class AttentionSpec(KVCacheSpec):
     dtype: torch.dtype
     kv_quant_mode: KVQuantMode = KVQuantMode.NONE
     page_size_padded: int | None = None
+    # Custom page size from attention backend (e.g., quantized KV cache).
+    # If set, overrides the default head_size-based calculation.
+    custom_page_size: int | None = None
 
     @property
     def page_size_bytes(self) -> int:
@@ -135,6 +138,8 @@ class AttentionSpec(KVCacheSpec):
 
     @property
     def real_page_size_bytes(self) -> int:
+        if self.custom_page_size is not None:
+            return self.custom_page_size
         return (
             2
             * self.block_size
@@ -218,6 +223,7 @@ class FullAttentionSpec(AttentionSpec):
             dtype=specs[0].dtype,
             kv_quant_mode=specs[0].kv_quant_mode,
             page_size_padded=specs[0].page_size_padded,
+            custom_page_size=specs[0].custom_page_size,
             sliding_window=cls.merge_window_sizes(sliding_window),
             attention_chunk_size=cls.merge_window_sizes(attention_chunk_size),
         )
@@ -237,6 +243,8 @@ class FullAttentionSpec(AttentionSpec):
 
     @property
     def real_page_size_bytes(self) -> int:
+        if self.custom_page_size is not None:
+            return self.custom_page_size
         return (
             self.block_size
             * self.num_kv_heads
@@ -252,9 +260,9 @@ class MLAAttentionSpec(FullAttentionSpec):
 
     @property
     def real_page_size_bytes(self) -> int:
+        if self.custom_page_size is not None:
+            return self.custom_page_size
         if self.cache_dtype_str == "fp8_ds_mla":
-            # See `vllm/v1/attention/backends/mla/flashmla_sparse.py`
-            #  for details.
             return self.block_size * 656
         return (
             self.block_size
@@ -280,6 +288,7 @@ class MLAAttentionSpec(FullAttentionSpec):
             dtype=specs[0].dtype,
             kv_quant_mode=specs[0].kv_quant_mode,
             page_size_padded=specs[0].page_size_padded,
+            custom_page_size=specs[0].custom_page_size,
             cache_dtype_str=cache_dtype_str_set.pop(),
         )
 

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, cast
 
 import numpy as np
@@ -33,9 +33,18 @@ def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:
     kv_cache_spec: dict[str, KVCacheSpec] = {}
     layer_type = cast(type[Any], AttentionLayerBase)
     attn_layers = get_layers_from_vllm_config(vllm_config, layer_type)
+    cache_dtype = vllm_config.cache_config.cache_dtype
     for layer_name, attn_module in attn_layers.items():
         # Skip modules that don't need KV cache (eg encoder-only attention)
         if spec := attn_module.get_kv_cache_spec(vllm_config):
+            # Let backends override page size for compressed KV.
+            backend = getattr(attn_module, 'attn_backend', None)
+            if isinstance(spec, AttentionSpec) and backend is not None:
+                custom_ps = backend.get_kv_cache_page_size(
+                    spec.block_size, spec.num_kv_heads,
+                    spec.head_size, spec.dtype, cache_dtype)
+                if custom_ps is not None:
+                    spec = replace(spec, custom_page_size=custom_ps)
             kv_cache_spec[layer_name] = spec
     return kv_cache_spec
 

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4,6 +4,7 @@
 import functools
 import gc
 import itertools
+import math
 import threading
 import time
 from collections import defaultdict
@@ -6566,11 +6567,15 @@ class GPUModelRunner(
                         kv_cache_stride_order.index(i)
                         for i in range(len(kv_cache_stride_order))
                     ]
+                    # Allow backends that pack KV more tightly than
+                    # head_size*dtype_size bytes per entry (e.g., quantized
+                    # backends) to view a prefix of the raw allocation.
+                    typed = kv_cache_raw_tensors[layer_name].view(dtype)
+                    shape_elements = math.prod(kv_cache_shape)
+                    if shape_elements < typed.numel():
+                        typed = typed[:shape_elements]
                     kv_caches[layer_name] = (
-                        kv_cache_raw_tensors[layer_name]
-                        .view(dtype)
-                        .view(kv_cache_shape)
-                        .permute(*inv_order)
+                        typed.view(kv_cache_shape).permute(*inv_order)
                     )
                 elif isinstance(kv_cache_spec, MambaSpec):
                     has_mamba = True
@@ -6884,6 +6889,15 @@ class GPUModelRunner(
                 continue
             # Skip modules that don't need KV cache (eg encoder-only attention)
             if spec := attn_module.get_kv_cache_spec(self.vllm_config):
+                # Let backends override page size for compressed KV.
+                backend = getattr(attn_module, 'attn_backend', None)
+                if isinstance(spec, AttentionSpec) and backend is not None:
+                    custom_ps = backend.get_kv_cache_page_size(
+                        spec.block_size, spec.num_kv_heads,
+                        spec.head_size, spec.dtype,
+                        self.cache_config.cache_dtype)
+                    if custom_ps is not None:
+                        spec = replace(spec, custom_page_size=custom_ps)
                 kv_cache_spec[layer_name] = spec
 
         return kv_cache_spec


### PR DESCRIPTION
## Summary

Third-party attention backends registered via the `vllm.general_plugins`
entry-point currently cannot request a per-block page size that differs
from `2 × block_size × num_kv_heads × head_size × dtype_size`. This
blocks plugins that pack KV more tightly than one element per (head, dim)
— e.g., quantized-KV backends storing a few bytes of quantized data plus
a scalar norm instead of `head_size` fp16s.

This PR adds three opt-in seams. **All default to existing behavior**, so
no in-tree backend is affected:

1. `AttentionBackend.get_kv_cache_page_size(...) -> int | None` — new
   classmethod on the backend base; returns `None` (default formula).
2. `AttentionSpec.custom_page_size: int | None` — new dataclass field;
   `real_page_size_bytes` returns it verbatim when set. Propagates
   through `FullAttentionSpec.merge` / `MLAAttentionSpec.merge`.
3. `GPUModelRunner._reshape_kv_cache_tensors` views a prefix of the
   allocation when the backend's shape packs fewer elements per entry.

## Motivation

TurboQuant (arXiv:2504.19874) compresses KV cache to 4-bit with Hadamard
preconditioning (3.76× vs fp16). As an out-of-tree plugin on stock vLLM
it's capped at 2× because the allocator reserves 128 bytes/head for the
underlying fp8 dtype while only ~68 bytes/head carry real data. With
this PR the backend can declare its true page size.

## Benchmarks

A100-40GB, Qwen3-8B, `max_model_len=1024`, 5 prompts × 32 tokens, best of 3
(TurboQuant plugin applied):

| Config | TPOT | KV tokens |
|---|---|---|
| FP16 eager | 4.36 ms | 83,280 |
| FP16 graphs | 3.15 ms | 83,216 |
| TQ fp8 eager | 5.76 ms | 266,512 |
| TQ fp8 graphs | **3.53 ms** | **266,144** |

TQ fp8 gets **3.20× more KV tokens** in the same memory at 1.12× the
FP16-graphs TPOT.

## Tests

`tests/v1/core/test_custom_page_size.py` — 6 pure-CPU tests covering
default return value, custom override, spec formula fallback, and
`merge` preservation for both `FullAttentionSpec` and `MLAAttentionSpec`.

## Test plan

- [ ] `pytest tests/v1/core/test_custom_page_size.py`
- [ ] Existing FP16/FP8 workloads unchanged (no backend overrides `get_kv_cache_page_size`)
- [ ] TurboQuant plugin (out-of-tree) reaches 3.20× KV-token memory with this PR applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)