### PR TITLE
[Bugfix] Fix _has_module to verify native deps via trial import

### DIFF
--- a/tests/utils_/test_import_utils.py
+++ b/tests/utils_/test_import_utils.py
@@ -1,8 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from unittest.mock import MagicMock, patch
+
 import pytest
 
-from vllm.utils.import_utils import PlaceholderModule
+from vllm.utils.import_utils import PlaceholderModule, _has_module
 
 
 def _raises_module_not_found():
@@ -44,3 +46,64 @@ def test_placeholder_module_error_handling():
     with _raises_module_not_found():
         # Test conflict with internal __module attribute
         _ = placeholder_attr.module
+
+
+class TestHasModule:
+    """Tests for _has_module with trial import verification."""
+
+    def setup_method(self):
+        # Clear the @cache between tests so each test gets a fresh call
+        _has_module.cache_clear()
+
+    def test_returns_true_for_importable_stdlib_module(self):
+        assert _has_module("json") is True
+
+    def test_returns_false_for_nonexistent_module(self):
+        assert _has_module("nonexistent_module_xyz_12345") is False
+
+    def test_returns_false_when_find_spec_succeeds_but_import_fails(self):
+        """Simulate a native extension whose shared library is missing.
+
+        ``find_spec`` finds the package on disk, but the actual import
+        raises ``ImportError`` (e.g. missing ``libcudart.so``).
+        """
+        fake_spec = MagicMock()
+
+        with (
+            patch(
+                "vllm.utils.import_utils.importlib.util.find_spec",
+                return_value=fake_spec,
+            ),
+            patch(
+                "vllm.utils.import_utils.importlib.import_module",
+                side_effect=ImportError(
+                    "libcudart.so.12: cannot open shared object file"
+                ),
+            ),
+        ):
+            assert _has_module("fake_native_ext") is False
+
+    def test_returns_false_on_os_error_during_import(self):
+        """Some shared-library failures surface as ``OSError``."""
+        fake_spec = MagicMock()
+
+        with (
+            patch(
+                "vllm.utils.import_utils.importlib.util.find_spec",
+                return_value=fake_spec,
+            ),
+            patch(
+                "vllm.utils.import_utils.importlib.import_module",
+                side_effect=OSError("cannot load library"),
+            ),
+        ):
+            assert _has_module("fake_native_ext_os") is False
+
+    def test_result_is_cached(self):
+        """Verify the @cache decorator prevents repeated imports."""
+        _has_module("json")  # prime the cache
+
+        with patch("vllm.utils.import_utils.importlib.util.find_spec") as mock_spec:
+            result = _has_module("json")  # should hit cache
+            mock_spec.assert_not_called()
+            assert result is True

--- a/vllm/utils/import_utils.py
+++ b/vllm/utils/import_utils.py
@@ -394,12 +394,21 @@ class LazyLoader(ModuleType):
 # Optional dependency detection utilities
 @cache
 def _has_module(module_name: str) -> bool:
-    """Return True if *module_name* can be found in the current environment.
+    """Return True if *module_name* can be imported in the current environment.
 
-    The result is cached so that subsequent queries for the same module incur
-    no additional overhead.
+    Uses ``importlib.util.find_spec`` as a fast pre-check, then performs a
+    trial import to verify that native dependencies (shared libraries, etc.)
+    are also satisfied.  The result is cached so that subsequent queries for
+    the same module incur no additional overhead.
     """
-    return importlib.util.find_spec(module_name) is not None
+    if importlib.util.find_spec(module_name) is None:
+        return False
+    try:
+        importlib.import_module(module_name)
+        return True
+    except (ImportError, OSError) as exc:
+        logger.debug("Module %s was found but failed to import: %s", module_name, exc)
+        return False
 
 
 def has_deep_ep() -> bool:


### PR DESCRIPTION
## Summary

- `_has_module` previously used `importlib.util.find_spec()` which only checks whether a module spec exists on disk, but does not verify that the module can actually be imported
- For native-extension packages whose shared libraries are missing (e.g. `nixl_ep` installed without `libcudart.so.12`), `find_spec` returns a valid spec but the real import crashes with `ImportError`
- This caused `has_nixl_ep()` (and potentially other `has_*` guards) to return `True` when the module was not actually usable, leading to import-time crashes like:
  ```
  ImportError: libcudart.so.12: cannot open shared object file: No such file or directory
  ```
- The fix adds a trial `importlib.import_module()` after the `find_spec` pre-check, catching `ImportError`/`OSError` and returning `False` when native dependencies are unsatisfied. The `@cache` decorator ensures this only runs once per module name.

## Not a duplicate

No existing open PRs address this issue. Searched for `_has_module`, `find_spec`, and `has_module ImportError`.

## Test plan

## AI disclosure

This PR was authored with AI assistance (Claude). The human submitter has reviewed all changed lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)