### PR TITLE
[Core] Add Ring Attention Primitives for Context Parallelism

### DIFF
--- a/tests/distributed/test_ring_attn.py
+++ b/tests/distributed/test_ring_attn.py
@@ -66,8 +66,7 @@ def _make_varlen_inputs(
     head_dim: int,
     dtype: torch.dtype,
     device: torch.device,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor,
-           torch.Tensor, int]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int]:
     total = sum(seq_lens)
     q = torch.randn(total, num_q_heads, head_dim, dtype=dtype, device=device)
     k = torch.randn(total, num_kv_heads, head_dim, dtype=dtype, device=device)
@@ -75,17 +74,20 @@ def _make_varlen_inputs(
 
     cu = torch.zeros(len(seq_lens) + 1, dtype=torch.int32, device=device)
     cu[1:] = torch.cumsum(
-        torch.tensor(seq_lens, dtype=torch.int32, device=device), dim=0)
+        torch.tensor(seq_lens, dtype=torch.int32, device=device), dim=0
+    )
 
     return q, k, v, cu, max(seq_lens)
 
 
 def _shard_varlen(
-    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
     seq_lens: list[int],
-    rank: int, world_size: int,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor,
-           torch.Tensor, int]:
+    rank: int,
+    world_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int]:
     """Shard packed tensors: each rank gets a contiguous chunk per request."""
     q_chunks, k_chunks, v_chunks = [], [], []
     local_lens = []
@@ -94,9 +96,9 @@ def _shard_varlen(
     for sl in seq_lens:
         chunk_size = sl // world_size
         start = offset + rank * chunk_size
-        q_chunks.append(q[start:start + chunk_size])
-        k_chunks.append(k[start:start + chunk_size])
-        v_chunks.append(v[start:start + chunk_size])
+        q_chunks.append(q[start : start + chunk_size])
+        k_chunks.append(k[start : start + chunk_size])
+        v_chunks.append(v[start : start + chunk_size])
         local_lens.append(chunk_size)
         offset += sl
 
@@ -104,10 +106,10 @@ def _shard_varlen(
     k_local = torch.cat(k_chunks, dim=0).contiguous()
     v_local = torch.cat(v_chunks, dim=0).contiguous()
 
-    cu_local = torch.zeros(len(local_lens) + 1, dtype=torch.int32,
-                           device=q.device)
+    cu_local = torch.zeros(len(local_lens) + 1, dtype=torch.int32, device=q.device)
     cu_local[1:] = torch.cumsum(
-        torch.tensor(local_lens, dtype=torch.int32, device=q.device), dim=0)
+        torch.tensor(local_lens, dtype=torch.int32, device=q.device), dim=0
+    )
 
     return q_local, k_local, v_local, cu_local, max(local_lens)
 
@@ -134,41 +136,57 @@ def _run_one_config(
 
     torch.manual_seed(42)
     q, k, v, cu, max_sl = _make_varlen_inputs(
-        seq_lens, num_q_heads, num_kv_heads, head_dim, dtype, device)
+        seq_lens, num_q_heads, num_kv_heads, head_dim, dtype, device
+    )
 
     ref, _, _ = reference_varlen(
-        q, k, v,
-        cu_seqlens_q=cu, cu_seqlens_k=cu,
-        max_seqlen_q=max_sl, max_seqlen_k=max_sl,
-        causal=causal, return_attn_probs=True)
+        q,
+        k,
+        v,
+        cu_seqlens_q=cu,
+        cu_seqlens_k=cu,
+        max_seqlen_q=max_sl,
+        max_seqlen_k=max_sl,
+        causal=causal,
+        return_attn_probs=True,
+    )
 
-    q_l, k_l, v_l, cu_l, max_l = _shard_varlen(
-        q, k, v, seq_lens, rank, world_size)
+    q_l, k_l, v_l, cu_l, max_l = _shard_varlen(q, k, v, seq_lens, rank, world_size)
 
     ring = ring_flash_attn_varlen_func(
-        q_l, k_l, v_l,
-        cu_seqlens_q=cu_l, cu_seqlens_k=cu_l,
-        max_seqlen_q=max_l, max_seqlen_k=max_l,
-        cp_group=dist.group.WORLD, causal=causal)
+        q_l,
+        k_l,
+        v_l,
+        cu_seqlens_q=cu_l,
+        cu_seqlens_k=cu_l,
+        max_seqlen_q=max_l,
+        max_seqlen_k=max_l,
+        cp_group=dist.group.WORLD,
+        causal=causal,
+    )
 
     ref_chunks = []
     offset = 0
     for sl in seq_lens:
         chunk_size = sl // world_size
         start = offset + rank * chunk_size
-        ref_chunks.append(ref[start:start + chunk_size])
+        ref_chunks.append(ref[start : start + chunk_size])
         offset += sl
     ref_local = torch.cat(ref_chunks, dim=0)
 
     torch.testing.assert_close(
-        ring.float(), ref_local.float(),
-        atol=ATOL, rtol=RTOL,
-        msg=f"Ring Attention mismatch on rank {rank}")
+        ring.float(),
+        ref_local.float(),
+        atol=ATOL,
+        rtol=RTOL,
+        msg=f"Ring Attention mismatch on rank {rank}",
+    )
 
 
 # =====================================================================
 # Standalone torchrun mode
 # =====================================================================
+
 
 def _run_standalone():
     dist.init_process_group(backend="nccl")
@@ -188,8 +206,8 @@ def _run_standalone():
             continue
         try:
             _run_one_config(
-                seq_lens, Hq, Hkv, D, causal, dtype,
-                rank, world_size, device)
+                seq_lens, Hq, Hkv, D, causal, dtype, rank, world_size, device
+            )
             if rank == 0:
                 print(f"  [PASS] {label}")
         except AssertionError as e:
@@ -230,8 +248,7 @@ else:
         monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
         device = torch.device(f"cuda:{rank}")
         torch.accelerator.set_device_index(device)
-        init_test_distributed_environment(
-            tp_size, pp_size, rank, distributed_init_port)
+        init_test_distributed_environment(tp_size, pp_size, rank, distributed_init_port)
 
         seq_lens = [int(x) for x in os.environ["TEST_SEQ_LENS"].split(",")]
         Hq = int(os.environ["TEST_HQ"])
@@ -240,15 +257,13 @@ else:
         causal = os.environ["TEST_CAUSAL"] == "1"
         dtype = getattr(torch, os.environ["TEST_DTYPE"])
 
-        _run_one_config(seq_lens, Hq, Hkv, D, causal, dtype,
-                        rank, tp_size, device)
+        _run_one_config(seq_lens, Hq, Hkv, D, causal, dtype, rank, tp_size, device)
 
     CP_SIZES = [2, 4]
 
     @pytest.mark.distributed
     @pytest.mark.parametrize("cp_size", CP_SIZES)
-    @pytest.mark.parametrize(
-        "seq_lens,Hq,Hkv,D,causal,dtype,label", VARLEN_CONFIGS)
+    @pytest.mark.parametrize("seq_lens,Hq,Hkv,D,causal,dtype,label", VARLEN_CONFIGS)
     def test_ring_attn_varlen(
         monkeypatch: pytest.MonkeyPatch,
         cp_size: int,
@@ -268,8 +283,7 @@ else:
         monkeypatch.setenv("TEST_HKV", str(Hkv))
         monkeypatch.setenv("TEST_D", str(D))
         monkeypatch.setenv("TEST_CAUSAL", "1" if causal else "0")
-        monkeypatch.setenv("TEST_DTYPE",
-                           str(dtype).split(".")[-1])
+        monkeypatch.setenv("TEST_DTYPE", str(dtype).split(".")[-1])
 
         multi_process_parallel(
             monkeypatch,

--- a/tests/distributed/test_ring_attn.py
+++ b/tests/distributed/test_ring_attn.py
@@ -1,0 +1,279 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Tests for Ring Attention correctness.
+
+Verifies that :func:`ring_flash_attn_varlen_func` produces the same
+output as standard single-GPU ``flash_attn_varlen_func`` across:
+  - Bidirectional and causal attention
+  - GQA (num_kv_heads < num_q_heads)
+  - Multiple dtypes (bf16, fp16)
+  - Multi-request packed batches with different lengths
+  - CP sizes 2 and 4
+
+Two run modes:
+  1. pytest (uses ray for multi-GPU, compatible with vLLM CI):
+       pytest tests/distributed/test_ring_attn.py -v
+  2. torchrun (standalone, no ray/pytest):
+       torchrun --nproc_per_node=2 tests/distributed/test_ring_attn.py
+       torchrun --nproc_per_node=4 tests/distributed/test_ring_attn.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import torch
+import torch.distributed as dist
+
+ATOL = 5e-3
+RTOL = 5e-3
+
+# Test configurations: (seq_lens, Hq, Hkv, D, causal, dtype, label)
+VARLEN_CONFIGS = [
+    # MHA bidirectional
+    ([512], 16, 16, 64, False, torch.bfloat16, "single_bidir_MHA"),
+    ([256, 256], 16, 16, 64, False, torch.bfloat16, "multi_eq_bidir"),
+    ([128, 384, 512], 16, 16, 64, False, torch.bfloat16, "multi_diff_bidir"),
+    # MHA causal
+    ([512], 16, 16, 64, True, torch.bfloat16, "single_causal_MHA"),
+    ([256, 256], 16, 16, 64, True, torch.bfloat16, "multi_eq_causal"),
+    ([128, 384, 512], 16, 16, 64, True, torch.bfloat16, "multi_diff_causal"),
+    # GQA
+    ([512], 32, 8, 128, False, torch.bfloat16, "single_bidir_GQA"),
+    ([512], 32, 8, 128, True, torch.bfloat16, "single_causal_GQA"),
+    ([128, 384], 32, 8, 128, False, torch.bfloat16, "multi_bidir_GQA"),
+    ([128, 384], 32, 8, 128, True, torch.bfloat16, "multi_causal_GQA"),
+    # fp16
+    ([256, 256], 16, 16, 64, False, torch.float16, "multi_bidir_fp16"),
+    ([512], 32, 8, 128, False, torch.float16, "single_GQA_fp16"),
+    # Longer sequences (closer to AR prefill)
+    ([2048], 32, 8, 128, True, torch.bfloat16, "long_causal_GQA"),
+    ([512, 1024], 32, 8, 128, True, torch.bfloat16, "multi_long_causal_GQA"),
+]
+
+
+# =====================================================================
+# Helpers
+# =====================================================================
+
+
+def _make_varlen_inputs(
+    seq_lens: list[int],
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    dtype: torch.dtype,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor,
+           torch.Tensor, int]:
+    total = sum(seq_lens)
+    q = torch.randn(total, num_q_heads, head_dim, dtype=dtype, device=device)
+    k = torch.randn(total, num_kv_heads, head_dim, dtype=dtype, device=device)
+    v = torch.randn(total, num_kv_heads, head_dim, dtype=dtype, device=device)
+
+    cu = torch.zeros(len(seq_lens) + 1, dtype=torch.int32, device=device)
+    cu[1:] = torch.cumsum(
+        torch.tensor(seq_lens, dtype=torch.int32, device=device), dim=0)
+
+    return q, k, v, cu, max(seq_lens)
+
+
+def _shard_varlen(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor,
+    seq_lens: list[int],
+    rank: int, world_size: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor,
+           torch.Tensor, int]:
+    """Shard packed tensors: each rank gets a contiguous chunk per request."""
+    q_chunks, k_chunks, v_chunks = [], [], []
+    local_lens = []
+
+    offset = 0
+    for sl in seq_lens:
+        chunk_size = sl // world_size
+        start = offset + rank * chunk_size
+        q_chunks.append(q[start:start + chunk_size])
+        k_chunks.append(k[start:start + chunk_size])
+        v_chunks.append(v[start:start + chunk_size])
+        local_lens.append(chunk_size)
+        offset += sl
+
+    q_local = torch.cat(q_chunks, dim=0).contiguous()
+    k_local = torch.cat(k_chunks, dim=0).contiguous()
+    v_local = torch.cat(v_chunks, dim=0).contiguous()
+
+    cu_local = torch.zeros(len(local_lens) + 1, dtype=torch.int32,
+                           device=q.device)
+    cu_local[1:] = torch.cumsum(
+        torch.tensor(local_lens, dtype=torch.int32, device=q.device), dim=0)
+
+    return q_local, k_local, v_local, cu_local, max(local_lens)
+
+
+def _run_one_config(
+    seq_lens: list[int],
+    num_q_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    causal: bool,
+    dtype: torch.dtype,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+) -> None:
+    """Run one test config and assert correctness."""
+    from vllm.v1.attention.backends.fa_utils import (
+        flash_attn_varlen_func as reference_varlen,
+    )
+    from vllm.v1.attention.ops.ring_attn import ring_flash_attn_varlen_func
+
+    if any(sl % world_size != 0 for sl in seq_lens):
+        return  # skip non-divisible configs
+
+    torch.manual_seed(42)
+    q, k, v, cu, max_sl = _make_varlen_inputs(
+        seq_lens, num_q_heads, num_kv_heads, head_dim, dtype, device)
+
+    ref, _, _ = reference_varlen(
+        q, k, v,
+        cu_seqlens_q=cu, cu_seqlens_k=cu,
+        max_seqlen_q=max_sl, max_seqlen_k=max_sl,
+        causal=causal, return_attn_probs=True)
+
+    q_l, k_l, v_l, cu_l, max_l = _shard_varlen(
+        q, k, v, seq_lens, rank, world_size)
+
+    ring = ring_flash_attn_varlen_func(
+        q_l, k_l, v_l,
+        cu_seqlens_q=cu_l, cu_seqlens_k=cu_l,
+        max_seqlen_q=max_l, max_seqlen_k=max_l,
+        cp_group=dist.group.WORLD, causal=causal)
+
+    ref_chunks = []
+    offset = 0
+    for sl in seq_lens:
+        chunk_size = sl // world_size
+        start = offset + rank * chunk_size
+        ref_chunks.append(ref[start:start + chunk_size])
+        offset += sl
+    ref_local = torch.cat(ref_chunks, dim=0)
+
+    torch.testing.assert_close(
+        ring.float(), ref_local.float(),
+        atol=ATOL, rtol=RTOL,
+        msg=f"Ring Attention mismatch on rank {rank}")
+
+
+# =====================================================================
+# Standalone torchrun mode
+# =====================================================================
+
+def _run_standalone():
+    dist.init_process_group(backend="nccl")
+    rank = dist.get_rank()
+    world_size = dist.get_world_size()
+    device = torch.device(f"cuda:{rank}")
+    torch.cuda.set_device(device)
+
+    if rank == 0:
+        print(f"\n=== Ring Attention varlen tests (CP={world_size}) ===")
+
+    all_pass = True
+    for seq_lens, Hq, Hkv, D, causal, dtype, label in VARLEN_CONFIGS:
+        if any(sl % world_size != 0 for sl in seq_lens):
+            if rank == 0:
+                print(f"  [SKIP] {label}")
+            continue
+        try:
+            _run_one_config(
+                seq_lens, Hq, Hkv, D, causal, dtype,
+                rank, world_size, device)
+            if rank == 0:
+                print(f"  [PASS] {label}")
+        except AssertionError as e:
+            all_pass = False
+            if rank == 0:
+                print(f"  [FAIL] {label}: {e}")
+
+    dist.destroy_process_group()
+
+    if rank == 0:
+        print(f"\n{'All tests passed!' if all_pass else 'SOME TESTS FAILED!'}")
+    sys.exit(0 if all_pass else 1)
+
+
+# =====================================================================
+# pytest + ray mode (for vLLM CI)
+# =====================================================================
+
+if __name__ == "__main__":
+    _run_standalone()
+else:
+    import pytest
+    import ray
+
+    from tests.utils import (
+        init_test_distributed_environment,
+        multi_process_parallel,
+    )
+
+    @ray.remote(num_gpus=1, max_calls=1)
+    def _ring_attn_worker(
+        monkeypatch: pytest.MonkeyPatch,
+        tp_size: int,
+        pp_size: int,
+        rank: int,
+        distributed_init_port: str,
+    ) -> None:
+        monkeypatch.delenv("CUDA_VISIBLE_DEVICES", raising=False)
+        device = torch.device(f"cuda:{rank}")
+        torch.accelerator.set_device_index(device)
+        init_test_distributed_environment(
+            tp_size, pp_size, rank, distributed_init_port)
+
+        seq_lens = [int(x) for x in os.environ["TEST_SEQ_LENS"].split(",")]
+        Hq = int(os.environ["TEST_HQ"])
+        Hkv = int(os.environ["TEST_HKV"])
+        D = int(os.environ["TEST_D"])
+        causal = os.environ["TEST_CAUSAL"] == "1"
+        dtype = getattr(torch, os.environ["TEST_DTYPE"])
+
+        _run_one_config(seq_lens, Hq, Hkv, D, causal, dtype,
+                        rank, tp_size, device)
+
+    CP_SIZES = [2, 4]
+
+    @pytest.mark.distributed
+    @pytest.mark.parametrize("cp_size", CP_SIZES)
+    @pytest.mark.parametrize(
+        "seq_lens,Hq,Hkv,D,causal,dtype,label", VARLEN_CONFIGS)
+    def test_ring_attn_varlen(
+        monkeypatch: pytest.MonkeyPatch,
+        cp_size: int,
+        seq_lens: list[int],
+        Hq: int,
+        Hkv: int,
+        D: int,
+        causal: bool,
+        dtype: torch.dtype,
+        label: str,
+    ):
+        if any(sl % cp_size != 0 for sl in seq_lens):
+            pytest.skip(f"seq_lens not divisible by cp_size={cp_size}")
+
+        monkeypatch.setenv("TEST_SEQ_LENS", ",".join(str(s) for s in seq_lens))
+        monkeypatch.setenv("TEST_HQ", str(Hq))
+        monkeypatch.setenv("TEST_HKV", str(Hkv))
+        monkeypatch.setenv("TEST_D", str(D))
+        monkeypatch.setenv("TEST_CAUSAL", "1" if causal else "0")
+        monkeypatch.setenv("TEST_DTYPE",
+                           str(dtype).split(".")[-1])
+
+        multi_process_parallel(
+            monkeypatch,
+            tp_size=cp_size,
+            pp_size=1,
+            test_target=_ring_attn_worker,
+        )

--- a/vllm/distributed/ring_comm.py
+++ b/vllm/distributed/ring_comm.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Ring communication primitives for Context Parallelism.
+
+Provides asynchronous P2P send/recv in a ring topology with explicit
+CUDA stream management for reliable communication-computation overlap.
+
+The design follows NVIDIA TransformerEngine's context_parallel.py:
+- A dedicated ``cp_stream`` handles all P2P transfers
+- Events synchronize between the compute stream and the comm stream
+- K and V are packed into a single contiguous buffer per P2P round
+
+Adapted from vllm-omni (diffusion/distributed/comm.py) and
+TransformerEngine (attention/dot_product_attention/context_parallel.py).
+"""
+
+import torch
+import torch.distributed as dist
+
+
+class RingComm:
+    """Asynchronous ring P2P communicator with explicit stream overlap.
+
+    Each rank sends to ``(rank + 1) % world_size`` and receives from
+    ``(rank - 1) % world_size``.  All P2P transfers run on a dedicated
+    CUDA stream (``cp_stream``) so they can overlap with attention
+    kernels running on the default compute stream.
+
+    Args:
+        process_group: The torch distributed process group for the CP
+            ranks.
+        cp_stream: Optional dedicated CUDA stream for P2P communication.
+            If *None*, a new stream is created on the current device.
+
+    Usage::
+
+        comm = RingComm(cp_group, cp_stream)
+
+        for step in range(comm.world_size):
+            if step + 1 < comm.world_size:
+                next_kv = comm.send_recv(current_kv)
+                comm.commit()       # launch P2P on cp_stream
+
+            # ... run attention on the default (compute) stream ...
+
+            if step + 1 < comm.world_size:
+                comm.wait()         # sync cp_stream → compute stream
+                current_kv = next_kv
+    """
+
+    def __init__(
+        self,
+        process_group: dist.ProcessGroup,
+        cp_stream: torch.cuda.Stream | None = None,
+    ):
+        self._process_group = process_group
+        self._ops: list[dist.P2POp] = []
+        self._reqs: list[dist.Work] | None = None
+
+        self.rank = dist.get_rank(self._process_group)
+        self.world_size = dist.get_world_size(self._process_group)
+
+        local_send = (self.rank + 1) % self.world_size
+        local_recv = (self.rank - 1) % self.world_size
+        self.send_rank = dist.get_global_rank(self._process_group, local_send)
+        self.recv_rank = dist.get_global_rank(self._process_group, local_recv)
+
+        if cp_stream is None:
+            cp_stream = torch.cuda.Stream()
+        self._cp_stream = cp_stream
+
+        self._comm_event = torch.cuda.Event()
+        self._compute_event = torch.cuda.Event()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def send_recv(
+        self,
+        to_send: torch.Tensor,
+        recv_tensor: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Queue an async send/recv pair.
+
+        Multiple ``send_recv`` calls can be queued (e.g. K and V)
+        before a single ``commit``.
+
+        Args:
+            to_send: Tensor to send.  Made contiguous if needed.
+            recv_tensor: Optional pre-allocated receive buffer.
+
+        Returns:
+            The receive buffer (contents valid only after ``wait``).
+        """
+        if not to_send.is_contiguous():
+            to_send = to_send.contiguous()
+
+        if recv_tensor is None:
+            res = torch.empty_like(to_send,
+                                   memory_format=torch.contiguous_format)
+        else:
+            res = recv_tensor
+            if not res.is_contiguous():
+                res = res.contiguous()
+
+        # TE pattern: alternate send/recv order by rank parity
+        # to avoid potential deadlocks on some NCCL/RCCL versions
+        if self.rank % 2 == 0:
+            self._ops.append(
+                dist.P2POp(dist.isend, to_send, self.send_rank,
+                           group=self._process_group))
+            self._ops.append(
+                dist.P2POp(dist.irecv, res, self.recv_rank,
+                           group=self._process_group))
+        else:
+            self._ops.append(
+                dist.P2POp(dist.irecv, res, self.recv_rank,
+                           group=self._process_group))
+            self._ops.append(
+                dist.P2POp(dist.isend, to_send, self.send_rank,
+                           group=self._process_group))
+        return res
+
+    def commit(self) -> None:
+        """Launch all queued P2P operations on the dedicated cp_stream.
+
+        Records an event on the compute stream so cp_stream can wait
+        for any preceding compute to finish before sending data, then
+        dispatches the batched P2P ops on cp_stream.
+        """
+        if self._reqs is not None:
+            raise RuntimeError(
+                "commit() called while previous operations are still pending. "
+                "Call wait() before committing new operations.")
+
+        # compute stream records: "my tensors are ready to send"
+        self._compute_event.record(torch.cuda.current_stream())
+        # cp_stream waits for compute to finish writing the send buffers
+        self._cp_stream.wait_event(self._compute_event)
+
+        with torch.cuda.stream(self._cp_stream):
+            self._reqs = dist.batch_isend_irecv(self._ops)
+
+    def wait(self) -> None:
+        """Block until all committed P2P operations complete.
+
+        Waits for P2P ops on cp_stream, then synchronises cp_stream
+        back into the compute stream so subsequent compute can safely
+        read the received tensors.
+        """
+        if self._reqs is None:
+            raise RuntimeError(
+                "wait() called before commit(). "
+                "Queue operations with send_recv(), then call commit().")
+
+        # Wait for all P2P ops to finish on cp_stream
+        with torch.cuda.stream(self._cp_stream):
+            for req in self._reqs:
+                req.wait()
+
+        # cp_stream records: "recv buffers are filled"
+        self._comm_event.record(self._cp_stream)
+        # compute stream waits until recv data is ready
+        torch.cuda.current_stream().wait_event(self._comm_event)
+
+        self._reqs = None
+        self._ops = []

--- a/vllm/distributed/ring_comm.py
+++ b/vllm/distributed/ring_comm.py
@@ -40,12 +40,12 @@ class RingComm:
         for step in range(comm.world_size):
             if step + 1 < comm.world_size:
                 next_kv = comm.send_recv(current_kv)
-                comm.commit()       # launch P2P on cp_stream
+                comm.commit()  # launch P2P on cp_stream
 
             # ... run attention on the default (compute) stream ...
 
             if step + 1 < comm.world_size:
-                comm.wait()         # sync cp_stream → compute stream
+                comm.wait()  # sync cp_stream → compute stream
                 current_kv = next_kv
     """
 
@@ -98,8 +98,7 @@ class RingComm:
             to_send = to_send.contiguous()
 
         if recv_tensor is None:
-            res = torch.empty_like(to_send,
-                                   memory_format=torch.contiguous_format)
+            res = torch.empty_like(to_send, memory_format=torch.contiguous_format)
         else:
             res = recv_tensor
             if not res.is_contiguous():
@@ -109,18 +108,22 @@ class RingComm:
         # to avoid potential deadlocks on some NCCL/RCCL versions
         if self.rank % 2 == 0:
             self._ops.append(
-                dist.P2POp(dist.isend, to_send, self.send_rank,
-                           group=self._process_group))
+                dist.P2POp(
+                    dist.isend, to_send, self.send_rank, group=self._process_group
+                )
+            )
             self._ops.append(
-                dist.P2POp(dist.irecv, res, self.recv_rank,
-                           group=self._process_group))
+                dist.P2POp(dist.irecv, res, self.recv_rank, group=self._process_group)
+            )
         else:
             self._ops.append(
-                dist.P2POp(dist.irecv, res, self.recv_rank,
-                           group=self._process_group))
+                dist.P2POp(dist.irecv, res, self.recv_rank, group=self._process_group)
+            )
             self._ops.append(
-                dist.P2POp(dist.isend, to_send, self.send_rank,
-                           group=self._process_group))
+                dist.P2POp(
+                    dist.isend, to_send, self.send_rank, group=self._process_group
+                )
+            )
         return res
 
     def commit(self) -> None:
@@ -133,7 +136,8 @@ class RingComm:
         if self._reqs is not None:
             raise RuntimeError(
                 "commit() called while previous operations are still pending. "
-                "Call wait() before committing new operations.")
+                "Call wait() before committing new operations."
+            )
 
         # compute stream records: "my tensors are ready to send"
         self._compute_event.record(torch.cuda.current_stream())
@@ -153,7 +157,8 @@ class RingComm:
         if self._reqs is None:
             raise RuntimeError(
                 "wait() called before commit(). "
-                "Queue operations with send_recv(), then call commit().")
+                "Queue operations with send_recv(), then call commit()."
+            )
 
         # Wait for all P2P ops to finish on cp_stream
         with torch.cuda.stream(self._cp_stream):

--- a/vllm/v1/attention/ops/ring_attn.py
+++ b/vllm/v1/attention/ops/ring_attn.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Ring Attention for Context Parallelism.
+
+Implements Ring Attention where Q stays local while K/V circulate through
+a ring of CP ranks.  Each step computes a partial attention block and
+incrementally merges the result using online softmax correction.
+
+This module is a **communication framework**, not a new attention kernel.
+It calls the platform's existing flash-attention varlen implementation
+(resolved at import time by ``fa_utils``) inside a ring-topology P2P loop.
+
+Performance optimizations:
+  - K and V are packed into a single contiguous buffer for P2P transfer,
+    halving the number of P2P operations per step.
+  - Double buffering: two pre-allocated receive buffers are alternated
+    across steps, eliminating per-step memory allocation.
+  - The CUDA stream for P2P communication is created once and cached
+    (``hipStreamCreate`` costs ~2ms on ROCm; caching avoids this per-call).
+  - The ``RingComm``'s dedicated CUDA stream enables overlap between
+    P2P communication and attention computation.
+
+Known limitations:
+  - Sequence sharding assumes contiguous partitioning (rank i gets the
+    i-th chunk).  Stripe/zigzag partitioning is not supported.
+  - Not compatible with ``torch.compile`` due to ``dist.batch_isend_irecv``,
+    Python-level ring loop, and explicit CUDA stream management.
+  - Does not manage KV cache; callers are responsible for reading/writing
+    paged KV cache before/after calling these functions.
+
+References:
+    - vllm-omni diffusion/attention/backends/ring_flash_attn.py
+    - Fang et al., long-context-attention (yunchang)
+    - Liu et al., "Ring Attention with Blockwise Transformers" (2023)
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+from vllm.distributed.ring_comm import RingComm
+from vllm.v1.attention.backends.fa_utils import (
+    flash_attn_varlen_func,
+)
+
+
+# ---------------------------------------------------------------------------
+# Cached CUDA stream for P2P communication.
+# hipStreamCreate costs ~2ms on ROCm; caching avoids this on every call.
+# TODO: When integrated into a PCP attention backend, create the stream
+# at model init time and pass it in via cp_stream instead of using this
+# module-level cache.  The module-level cache is bound to the device
+# that is current at first call; this is safe in vLLM where each worker
+# process owns a single device.
+# ---------------------------------------------------------------------------
+_cp_stream: torch.cuda.Stream | None = None
+
+
+def _get_cp_stream() -> torch.cuda.Stream:
+    global _cp_stream
+    if _cp_stream is None:
+        _cp_stream = torch.cuda.Stream()
+    return _cp_stream
+
+
+# ---------------------------------------------------------------------------
+# Online softmax merge for varlen packed layout [N, H, D]
+# ---------------------------------------------------------------------------
+
+
+def _update_out_and_lse(
+    out: torch.Tensor,
+    lse: torch.Tensor,
+    block_out: torch.Tensor,
+    block_lse: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Merge a new attention block into the running output.
+
+    Uses the numerically stable online softmax correction:
+
+        out = out - sigmoid(block_lse - lse) * (out - block_out)
+        lse = lse - logsigmoid(lse - block_lse)
+
+    All computation is done in float32 for numerical stability.
+
+    Args:
+        out: Running output ``[N, H, D]`` (float32).
+        lse: Running log-sum-exp ``[N, H, 1]`` (float32).
+        block_out: New block output ``[N, H, D]``.
+        block_lse: New block LSE ``[H, N]`` (float32,
+            raw flash_attn_varlen_func output layout).
+    """
+    block_out = block_out.to(torch.float32)
+    block_lse = block_lse.transpose(0, 1).unsqueeze(-1)  # [H,N] -> [N,H,1]
+
+    out = out - F.sigmoid(block_lse - lse) * (out - block_out)
+    lse = lse - F.logsigmoid(lse - block_lse)
+    return out, lse
+
+
+def _init_out_and_lse(
+    block_out: torch.Tensor,
+    block_lse: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Initialize running output and LSE from the first block.
+
+    Args:
+        block_out: ``[N, H, D]``.
+        block_lse: ``[H, N]`` (float32).
+
+    Returns:
+        (out, lse) -- out ``[N, H, D]`` fp32, lse ``[N, H, 1]`` fp32.
+    """
+    out = block_out.to(torch.float32)
+    lse = block_lse.transpose(0, 1).unsqueeze(-1)
+    return out, lse
+
+
+# ---------------------------------------------------------------------------
+# Ring Flash Attention -- varlen packed interface
+# ---------------------------------------------------------------------------
+
+
+def ring_flash_attn_varlen_func(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    cu_seqlens_q: torch.Tensor,
+    cu_seqlens_k: torch.Tensor,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    cp_group: dist.ProcessGroup,
+    cp_stream: torch.cuda.Stream | None = None,
+    softmax_scale: float | None = None,
+    causal: bool = False,
+) -> torch.Tensor:
+    """Ring Attention for packed variable-length sequences.
+
+    Q stays local while K/V circulate through a ring of CP ranks.
+    Each rank holds a contiguous chunk of every request's tokens;
+    ``cu_seqlens_q`` and ``cu_seqlens_k`` describe the **local**
+    (post-sharding) packed layout.
+
+    Supports GQA (K/V may have fewer heads than Q) -- the underlying
+    flash-attention kernel handles KV head repeat internally.
+
+    Note:
+        Each request's sequence length must be evenly divisible by
+        the CP world size.  The caller is responsible for padding or
+        filtering requests that do not meet this requirement.
+
+    For causal attention, the standard Ring Attention schedule is used:
+    rank *i* only attends to KV chunks from ranks 0..i.  Step 0 (the
+    local chunk) uses ``causal=True``; subsequent steps use full
+    (non-causal) attention since those KV chunks are strictly earlier
+    in the sequence.
+
+    Args:
+        q: Query ``[total_q_tokens, num_q_heads, D]``.
+        k: Key   ``[total_k_tokens, num_kv_heads, D]``.
+        v: Value ``[total_k_tokens, num_kv_heads, D]``.
+        cu_seqlens_q: Cumulative local query lengths ``[B+1]``.
+        cu_seqlens_k: Cumulative local key lengths ``[B+1]``.
+        max_seqlen_q: Max local query length in batch.
+        max_seqlen_k: Max local key length in batch.
+        cp_group: Process group for context parallelism.
+        cp_stream: Dedicated CUDA stream for P2P comm.  If *None*,
+            uses a module-level cached stream.
+        softmax_scale: Attention scale.  Defaults to ``1/sqrt(D)``.
+        causal: Whether to apply causal masking.
+
+    Returns:
+        Output ``[total_q_tokens, num_q_heads, D]`` in original dtype.
+    """
+    if cp_stream is None:
+        cp_stream = _get_cp_stream()
+
+    comm = RingComm(cp_group, cp_stream)
+
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** -0.5
+
+    q = q.contiguous()
+    k = k.contiguous()
+    v = v.contiguous()
+
+    # Pack K and V into a single contiguous buffer for P2P transfer,
+    # halving the number of P2P operations per ring step (2 vs 4).
+    kv = torch.cat([k, v], dim=0)
+
+    # Double buffering: pre-allocate two receive buffers and alternate
+    # across steps for zero per-step memory allocation.
+    recv_bufs = (torch.empty_like(kv), torch.empty_like(kv))
+
+    out: torch.Tensor | None = None
+    lse: torch.Tensor | None = None
+
+    for step in range(comm.world_size):
+        if step + 1 < comm.world_size:
+            next_kv = comm.send_recv(kv, recv_tensor=recv_bufs[step % 2])
+            comm.commit()
+
+        k, v = kv.chunk(2, dim=0)
+
+        if not causal or step <= comm.rank:
+            # NOTE: return_attn_probs=True is the only way to obtain the
+            # softmax log-sum-exp (LSE) from this flash_attn version.
+            # Despite the name, it does NOT compute the full O(S^2) attention
+            # probability matrix; the third return value is always an empty
+            # tensor.  LSE is returned as the second value with shape [H, N].
+            block_out, block_lse, _ = flash_attn_varlen_func(
+                q, k, v,
+                cu_seqlens_q=cu_seqlens_q,
+                cu_seqlens_k=cu_seqlens_k,
+                max_seqlen_q=max_seqlen_q,
+                max_seqlen_k=max_seqlen_k,
+                softmax_scale=softmax_scale,
+                causal=causal and step == 0,
+                return_attn_probs=True,
+            )
+
+            if out is None:
+                out, lse = _init_out_and_lse(block_out, block_lse)
+            else:
+                out, lse = _update_out_and_lse(
+                    out, lse, block_out, block_lse)
+
+        if step + 1 < comm.world_size:
+            comm.wait()
+            kv = next_kv
+
+    assert out is not None
+    return out.to(q.dtype)

--- a/vllm/v1/attention/ops/ring_attn.py
+++ b/vllm/v1/attention/ops/ring_attn.py
@@ -46,7 +46,6 @@ from vllm.v1.attention.backends.fa_utils import (
     flash_attn_varlen_func,
 )
 
-
 # ---------------------------------------------------------------------------
 # Cached CUDA stream for P2P communication.
 # hipStreamCreate costs ~2ms on ROCm; caching avoids this on every call.
@@ -212,7 +211,9 @@ def ring_flash_attn_varlen_func(
             # probability matrix; the third return value is always an empty
             # tensor.  LSE is returned as the second value with shape [H, N].
             block_out, block_lse, _ = flash_attn_varlen_func(
-                q, k, v,
+                q,
+                k,
+                v,
                 cu_seqlens_q=cu_seqlens_q,
                 cu_seqlens_k=cu_seqlens_k,
                 max_seqlen_q=max_seqlen_q,
@@ -225,8 +226,7 @@ def ring_flash_attn_varlen_func(
             if out is None:
                 out, lse = _init_out_and_lse(block_out, block_lse)
             else:
-                out, lse = _update_out_and_lse(
-                    out, lse, block_out, block_lse)
+                out, lse = _update_out_and_lse(out, lse, block_out, block_lse)
 
         if step + 1 < comm.world_size:
             comm.wait()


### PR DESCRIPTION


## Purpose

Add Ring Attention primitives as a building block for Prefill Context Parallelism (PCP), delivering the **"Ring-CP style attention backend algorithm"** listed in the PCP roadmap ([RFC #25749](https://github.com/vllm-project/vllm/issues/25749), ref [RFC #26133](https://github.com/vllm-project/vllm/issues/26133)).

Ring Attention partitions the sequence across CP ranks: Q stays local while K/V circulate through a P2P ring. Each step computes a partial attention block and incrementally merges the result via online softmax correction (sigmoid/logsigmoid), enabling communication-computation overlap without the post-hoc all-gather + LSE correction required by the existing DCP approach (`cp_lse_ag_out_rs`).

**This PR provides the communication + computation framework only.** It does not enable PCP end-to-end; PCP integration (KV cache management, ModelRunner token sharding, `supports_pcp=True`) will follow in a subsequent PR. This follows the pattern of [#28718](https://github.com/vllm-project/vllm/pull/28718) (PCP infra merged separately from attention backend) and [#34883](https://github.com/vllm-project/vllm/pull/34883) (A2A comm backend for DCP added as a separate PR).

### New files

| File | Lines | Description |
|------|-------|-------------|
| `vllm/distributed/ring_comm.py` | 174 | Async ring P2P communicator with dedicated CUDA stream, event-based sync, and rank-parity deadlock avoidance) |
| `vllm/v1/attention/ops/ring_attn.py` | 236 | `ring_flash_attn_varlen_func` — Ring Attention for packed variable-length sequences, with online softmax merge, KV packing (halves P2P ops per step), double buffering (zero per-step allocation), and cached CUDA stream. Uses `fa_utils.flash_attn_varlen_func` for platform-agnostic FA dispatch. |
| `tests/distributed/test_ring_attn.py` | 293 | 14 correctness configs × CP={2,4}, covering bidirectional + causal, MHA + GQA, bf16 + fp16, single + multi-request packed batches. Supports both pytest+ray (CI) and standalone torchrun. |

### Key design choices

- **Communication-computation overlap**: `RingComm` runs P2P on a dedicated CUDA stream while FlashAttention runs on the compute stream. Profiled **94% of P2P time hidden behind FA compute** on MI300X at S=8192.
- **KV packing**: K and V are concatenated into a single contiguous buffer before P2P, reducing ops per ring step from 4 to 2.
- **Double buffering**: Two pre-allocated receive buffers alternate across steps, eliminating per-step `torch.empty_like` allocation.
- **Cached CUDA stream**: `hipStreamCreate` costs ~2ms on ROCm; a module-level cache avoids this on every call (TODO: move to backend init in PCP integration PR).
- **Uses `fa_utils` for FA dispatch**: No custom backend selection — platform adaptation (CUDA/ROCm/XPU) is handled by vLLM's existing `fa_utils.flash_attn_varlen_func`.

### Known limitations

- Sequence sharding assumes contiguous partitioning (no stripe/zigzag). Dual-chunk partitioning with per-step position-aware masking is planned for the PCP integration PR.
- Each request's `seq_len` must be divisible by `cp_size`.
- Not compatible with `torch.compile` (Python ring loop + `dist.batch_isend_irecv` + explicit CUDA stream management). This is consistent with existing DCP code which also runs in eager mode.
- Does not manage KV cache (caller's responsibility, same as other ops in `vllm/v1/attention/ops/`).

## Test Plan

```bash
# Correctness — torchrun (standalone, 2 GPU)
torchrun --nproc_per_node=2 tests/distributed/test_ring_attn.py

# Correctness — torchrun (standalone, 4 GPU)
torchrun --nproc_per_node=4 tests/distributed/test_ring_attn.py

# Correctness — pytest (CI mode, requires ray)
pytest tests/distributed/test_ring_attn.py -v
```

## Test Result

Tested on 8× AMD MI300X (ROCm 7.1.1, PyTorch 2.9.1, flash_attn 2.8.3).

**Correctness: CP=2 (14/14 PASS), CP=4 (14/14 PASS)** — all max_diff ≤ 0.003906 at ATOL=5e-3.

```
=== Ring Attention varlen tests (CP=2) ===
  [PASS] single_bidir_MHA       [PASS] multi_eq_bidir        [PASS] multi_diff_bidir
  [PASS] single_causal_MHA      [PASS] multi_eq_causal       [PASS] multi_diff_causal
  [PASS] single_bidir_GQA       [PASS] single_causal_GQA     [PASS] multi_bidir_GQA
  [PASS] multi_causal_GQA       [PASS] multi_bidir_fp16      [PASS] single_GQA_fp16
  [PASS] long_causal_GQA        [PASS] multi_long_causal_GQA
```

**Latency benchmark** (1 request, GQA 32q/8kv heads, D=128, bf16, MI300X):

*Bidirectional (perfectly balanced across ranks):*

| seq_len | FA 1GPU | CP=2 | Speedup | CP=4 | Speedup | CP=8 | Speedup |
|---------|---------|------|---------|------|---------|------|---------|
| 4K | 0.92ms | 0.88ms | 1.04x | 1.20ms | 0.77x | 2.51ms | 0.37x |
| 8K | 3.25ms | 2.25ms | 1.44x | 1.91ms | 1.71x | 2.47ms | 1.32x |
| 16K | 13.81ms | 7.47ms | **1.85x** | 4.90ms | **2.82x** | 3.96ms | **3.51x** |
| 32K | 56.36ms | 29.12ms | **1.94x** | 15.40ms | **3.69x** | 10.87ms | **5.22x** |

*Causal (contiguous partition, load imbalanced):*

| seq_len | FA 1GPU | CP=2 | Speedup | CP=4 | Speedup | CP=8 | Speedup |
|---------|---------|------|---------|------|---------|------|---------|
| 8K | 1.73ms | 1.84ms | 0.94x | 1.75ms | 1.02x | 2.28ms | 0.78x |
| 16K | 6.83ms | 5.73ms | **1.19x** | 4.45ms | **1.54x** | 3.57ms | **1.92x** |
| 32K | 26.76ms | 22.11ms | **1.21x** | 13.48ms | **2.03x** | 9.39ms | **2.91x** |

> Note: Causal results use contiguous partitioning without load balancing. Dual-chunk/zigzag partitioning (per-step position-aware masking, as in TransformerEngine) would improve causal scaling and is planned for the PCP integration PR.

**Overlap profiling** (S=8192, CP=2, `torch.profiler` trace):

```
compute stream:  |███████ step0 FA 4129us ██████|█|███████ step1 FA 3511us ██████|
comm stream:        |████ NCCL P2P 3769us ██████|
                 → 94% of P2P hidden behind FA compute
```

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
