### PR TITLE
fix(qwen3-vl): reject oversized video placeholders early

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1297,6 +1297,15 @@ class Qwen3VLMultiModalProcessor(BaseMultiModalProcessor[Qwen3VLProcessingInfo])
                     select_token_id=select_token_id,
                 )
 
+                max_model_len = self.info.ctx.model_config.max_model_len
+                if len(video_repl.full) > max_model_len:
+                    raise ValueError(
+                        "Video placeholder token length "
+                        f"({len(video_repl.full)}) exceeds max_model_len "
+                        f"({max_model_len}). Reduce video resolution/fps/num_frames "
+                        "or enable stronger video pruning."
+                    )
+
                 # Convert token IDs to text for the HF processor flow
                 video_placeholder = tokenizer.decode(
                     video_repl.full, skip_special_tokens=False


### PR DESCRIPTION



## Purpose
- `#39876`: reject excessively large video placeholders as early as possible.

I deployed qwen3.5-27b using vllm for a video summary task, my start shell：
```sh
nohup ./.venv/bin/vllm serve "$MODEL_DIR" \
  --host "$HOST" \
  --port "$PORT" \
  --served-model-name "Qwen3.5-27B" \
  --tensor-parallel-size 2 \
  --dtype float16 \
  --reasoning-parser "qwen3" \
  --gpu-memory-utilization "0.9" \
  --max-model-len 260000 \
  --enable-auto-tool-choice \
  --tool-call-parser "$TOOL_CALL_PARSER_VALUE" \
  --override-generation-config "$OVERRIDE_GENERATION_CONFIG_VALUE" \
  --api-key "$VLLM_API_KEY_VALUE \
  >> "$LOG_FILE" 2>&1 < /dev/null &
```

but encountered the following log:

Apr 06 03:13:54 ubuntu start_vllm_qwen.sh[873947]: (APIServer pid=873947) Token indices sequence length is longer than the specified maximum sequence length for this model (422640 > 262144). Running this sequence through the model will result in indexing errors.

After that, all other text reasoning tasks timed out and there are no request logs.

I believe it's necessary to reject excessively large video placeholders as early as possible.



## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

