### PR TITLE
[CI] Only build release Docker images when NIGHTLY=1

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -100,6 +100,7 @@ steps:
 
   - group: "Build release Docker images"
     key: "build-release-images"
+    if: build.env("NIGHTLY") == "1"
     steps:
       - label: "Build release image - x86_64 - CUDA 12.9"
         depends_on: ~
@@ -230,6 +231,7 @@ steps:
 
   - group: "Publish release images"
     key: "publish-release-images"
+    if: build.env("NIGHTLY") == "1"
     steps:
       - label: "Create multi-arch manifest - CUDA 12.9"
         depends_on:
@@ -616,6 +618,7 @@ steps:
   # ROCm Job 6: Build ROCm Release Docker Image
   - label: ":docker: Build release image - x86_64 - ROCm"
     id: build-rocm-release-image
+    if: build.env("NIGHTLY") == "1"
     depends_on:
       - step: build-rocm-base-wheels
         allow_failure: false

--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -98,9 +98,14 @@ steps:
     commands:
       - "bash .buildkite/scripts/generate-and-upload-nightly-index.sh"
 
+  - block: "Unblock to build release Docker images"
+    key: block-build-release-images
+    if: build.env("NIGHTLY") != "1"
+
   - group: "Build release Docker images"
     key: "build-release-images"
-    if: build.env("NIGHTLY") == "1"
+    depends_on: block-build-release-images
+    allow_dependency_failure: true
     steps:
       - label: "Build release image - x86_64 - CUDA 12.9"
         depends_on: ~
@@ -231,7 +236,6 @@ steps:
 
   - group: "Publish release images"
     key: "publish-release-images"
-    if: build.env("NIGHTLY") == "1"
     steps:
       - label: "Create multi-arch manifest - CUDA 12.9"
         depends_on:
@@ -618,8 +622,9 @@ steps:
   # ROCm Job 6: Build ROCm Release Docker Image
   - label: ":docker: Build release image - x86_64 - ROCm"
     id: build-rocm-release-image
-    if: build.env("NIGHTLY") == "1"
     depends_on:
+      - step: block-build-release-images
+        allow_failure: true
       - step: build-rocm-base-wheels
         allow_failure: false
     agents:

--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -99,6 +99,7 @@ steps:
       - "bash .buildkite/scripts/generate-and-upload-nightly-index.sh"
 
   - block: "Unblock to build release Docker images"
+    depends_on: ~
     key: block-build-release-images
     if: build.env("NIGHTLY") != "1"
 


### PR DESCRIPTION
## Summary
- Add a block step before release Docker image builds that is **auto-skipped when `NIGHTLY=1`** (images build automatically) but **requires manual unblock otherwise**
- This applies to CUDA/Ubuntu GPU image builds, multi-arch manifests, and ROCm image builds
- Wheels continue to build on every commit regardless
- People can still manually unblock to trigger image builds on non-nightly runs

## Test plan
- [ ] Verify nightly builds (`NIGHTLY=1`) auto-skip the block and build images as before
- [ ] Verify non-nightly runs show the block step and wait for manual unblock
- [ ] Verify unblocking triggers all image builds correctly

AI assistance was used. This is not duplicating an existing PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)