### PR TITLE
[Bugfix] Fix use_existing_torch.py removing unrelated packages

### DIFF
--- a/use_existing_torch.py
+++ b/use_existing_torch.py
@@ -5,6 +5,8 @@ import argparse
 import glob
 import sys
 
+import regex as re
+
 # Only strip targeted libraries when checking prefix
 TORCH_LIB_PREFIXES = (
     # requirements/*.txt/in
@@ -15,6 +17,13 @@ TORCH_LIB_PREFIXES = (
     '"torch =',
     '"torchvision =',
     '"torchaudio =',
+)
+
+# Match lines where the package name is exactly torch/torchvision/torchaudio,
+# not a substring of another package (e.g. terratorch, open_clip_torch).
+_TORCH_PKG_RE = re.compile(
+    r"""^\s*['"]?\s*(?:torchvision|torchaudio|torch)\s*(?:[=<>!;\[,\]'"@~#(]|$)""",
+    re.IGNORECASE,
 )
 
 
@@ -43,7 +52,7 @@ def main(argv):
                         args.prefix
                         and not line.lower().strip().startswith(TORCH_LIB_PREFIXES)
                         or not args.prefix
-                        and "torch" not in line.lower()
+                        and not _TORCH_PKG_RE.match(line)
                     ):
                         f.write(line)
                     else:


### PR DESCRIPTION
## Purpose

The default (non-prefix) mode uses `"torch" in line.lower()` which matches any line containing "torch" as a substring. This incorrectly removes packages like `terratorch`, `open_clip_torch`, and `vector-quantize-pytorch`, as well as comment lines like `# via torch`.

Replace the substring check with a regex that only matches lines where the package name is exactly torch/torchvision/torchaudio, followed by a version specifier or end of line.

## Test Plan

Run `use_existing_torch.py` locally
