### PR TITLE
[CI] Add FusedMoE layer-level DP+EP tests

### DIFF
--- a/.buildkite/test_areas/kernels.yaml
+++ b/.buildkite/test_areas/kernels.yaml
@@ -184,6 +184,20 @@ steps:
     - pytest -v -s kernels/moe/test_deepep_deepgemm_moe.py
     - pytest -v -s kernels/moe/test_deepep_moe.py
 
+- label: Kernels FusedMoE DP+EP Test (2 B200s)
+  timeout_in_minutes: 30
+  device: b200
+  num_devices: 2
+  optional: true
+  source_file_dependencies:
+  - vllm/model_executor/layers/fused_moe/experts/flashinfer_cutedsl_moe.py
+  - vllm/model_executor/layers/fused_moe/experts/flashinfer_cutedsl_batched_moe.py
+  - vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_ll.py
+  - vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_ht.py
+  - tests/kernels/moe/test_fused_moe_ep_dp.py
+  commands:
+    - pytest -v -s tests/kernels/moe/test_fused_moe_ep_dp.py
+
 - label: Kernels Fp4 MoE Test (B200)
   timeout_in_minutes: 60
   device: b200

--- a/tests/kernels/moe/test_fused_moe_ep_dp.py
+++ b/tests/kernels/moe/test_fused_moe_ep_dp.py
@@ -9,6 +9,9 @@ Exercises the full FusedMoE nn.Module end-to-end including:
 - Weight handling and expert sharding
 - The DefaultMoERunner orchestration
 
+Launches processes once per backend and loops over shapes inside the worker
+to minimize process creation overhead.
+
 Run: pytest -v -s tests/kernels/moe/test_fused_moe_ep_dp.py
 """
 
@@ -18,7 +21,7 @@ import pytest
 import torch
 import torch.multiprocessing as mp
 
-from tests.kernels.moe.utils import make_test_quant_config
+from tests.kernels.moe.utils import make_test_weights
 from tests.kernels.quantization.nvfp4_utils import (
     FLOAT4_E2M1_MAX,
     FLOAT8_E4M3_MAX,
@@ -28,6 +31,7 @@ from vllm import _custom_ops as ops
 from vllm.config import VllmConfig, set_current_vllm_config
 from vllm.distributed.parallel_state import (
     ensure_model_parallel_initialized,
+    get_ep_group,
     init_distributed_environment,
 )
 from vllm.forward_context import set_forward_context
@@ -38,7 +42,6 @@ from vllm.model_executor.layers.fused_moe.router.fused_topk_router import (
 )
 from vllm.model_executor.layers.quantization.modelopt import (
     ModelOptNvFp4Config,
-    ModelOptNvFp4FusedMoE,
 )
 from vllm.platforms import current_platform
 from vllm.utils.import_utils import has_deep_ep
@@ -50,6 +53,11 @@ from vllm.v1.worker.workspace import init_workspace_manager
 from ...utils import multi_gpu_test
 
 mp.set_start_method("spawn", force=True)
+
+
+# ---------------------------------------------------------------------------
+# Distributed launch helpers
+# ---------------------------------------------------------------------------
 
 
 def _distributed_run(fn, world_size, *args, extra_env=None):
@@ -92,6 +100,33 @@ def _init_worker(env: dict[str, str]):
     return rank, device
 
 
+def _cleanup_between_configs(prefix: str, backend: str):
+    """Clean up state between test config iterations.
+
+    Follows the pattern from test_moe_layer.py:
+    clear compilation state and destroy DeepEP all2all buffers on SM100.
+    """
+    vllm_config = VllmConfig()
+    cc = vllm_config.compilation_config
+    if prefix in cc.static_forward_context:
+        del cc.static_forward_context[prefix]
+        if prefix in cc.static_all_moe_layers:
+            cc.static_all_moe_layers.remove(prefix)
+
+    cap = current_platform.get_device_capability()
+    if (
+        cap is not None
+        and cap.major == 10
+        and backend in ("deepep_low_latency", "deepep_high_throughput")
+    ):
+        torch.accelerator.synchronize()
+        all2all_manager = get_ep_group().device_communicator.all2all_manager
+        if all2all_manager is not None:
+            all2all_manager.destroy()
+
+    torch.accelerator.empty_cache()
+
+
 def torch_moe_ref(
     a: torch.Tensor,
     w1: torch.Tensor,
@@ -124,9 +159,7 @@ def _worker_bf16(
     backend: str,
     num_experts: int,
     topk: int,
-    hidden_size: int,
-    intermediate_size: int,
-    M: int,
+    shapes: list[tuple[int, int, int]],
 ):
     dtype = torch.bfloat16
     rank, device = _init_worker(env)
@@ -146,106 +179,83 @@ def _worker_bf16(
             pipeline_model_parallel_size=1,
         )
 
-        # Generate full weights (same seed on all ranks)
-        set_random_seed(42)
-        w13_full = (
-            torch.randn(
-                num_experts,
-                2 * intermediate_size,
-                hidden_size,
-                device=device,
-                dtype=dtype,
+        for m, hidden_size, intermediate_size in shapes:
+            prefix = f"test_bf16_{rank}_{m}_{hidden_size}"
+
+            set_random_seed(42)
+            w13_full = (
+                torch.randn(
+                    num_experts,
+                    2 * intermediate_size,
+                    hidden_size,
+                    device=device,
+                    dtype=dtype,
+                )
+                / 10
             )
-            / 10
-        )
-        w2_full = (
-            torch.randn(
-                num_experts,
-                hidden_size,
-                intermediate_size,
-                device=device,
-                dtype=dtype,
+            w2_full = (
+                torch.randn(
+                    num_experts,
+                    hidden_size,
+                    intermediate_size,
+                    device=device,
+                    dtype=dtype,
+                )
+                / 10
             )
-            / 10
-        )
 
-        # Generate per-rank input (different per rank)
-        set_random_seed(100 + rank)
-        hidden_states = (
-            torch.randn(
-                M,
-                hidden_size,
-                device=device,
-                dtype=dtype,
+            set_random_seed(100 + rank)
+            hidden_states = torch.randn(m, hidden_size, device=device, dtype=dtype) / 10
+            router_logits = torch.randn(m, num_experts, device=device, dtype=dtype) / 10
+
+            topk_weights, topk_ids, _ = fused_topk(
+                hidden_states,
+                router_logits.float(),
+                topk,
+                renormalize=True,
             )
-            / 10
-        )
-        router_logits = (
-            torch.randn(
-                M,
-                num_experts,
-                device=device,
-                dtype=dtype,
+            ref_output = torch_moe_ref(
+                hidden_states, w13_full, w2_full, topk_ids, topk_weights
             )
-            / 10
-        )
 
-        # Reference output using all experts locally
-        topk_weights, topk_ids, _ = fused_topk(
-            hidden_states,
-            router_logits.float(),
-            topk,
-            renormalize=True,
-        )
-        ref_output = torch_moe_ref(
-            hidden_states,
-            w13_full,
-            w2_full,
-            topk_ids,
-            topk_weights,
-        )
+            fml = FusedMoE(
+                num_experts=num_experts,
+                top_k=topk,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                prefix=prefix,
+                activation="silu",
+                is_act_and_mul=True,
+                params_dtype=dtype,
+                reduce_results=False,
+            )
+            fml = fml.to(device)
 
-        # Create FusedMoE layer
-        fml = FusedMoE(
-            num_experts=num_experts,
-            top_k=topk,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            prefix=f"test_bf16_{rank}",
-            activation="silu",
-            is_act_and_mul=True,
-            params_dtype=dtype,
-            reduce_results=False,
-        )
-        fml = fml.to(device)
+            ep_rank = fml.moe_parallel_config.ep_rank
+            n_local = fml.local_num_experts
+            start = ep_rank * n_local
+            end = start + n_local
+            fml.w13_weight.data.copy_(w13_full[start:end])
+            fml.w2_weight.data.copy_(w2_full[start:end])
 
-        # Fill local expert weights from the full set
-        ep_rank = fml.moe_parallel_config.ep_rank
-        n_local = fml.local_num_experts
-        start = ep_rank * n_local
-        end = start + n_local
-        fml.w13_weight.data.copy_(w13_full[start:end])
-        fml.w2_weight.data.copy_(w2_full[start:end])
+            fml.quant_method.process_weights_after_loading(fml)
+            fml.maybe_init_modular_kernel()
 
-        # Process weights and init kernel
-        fml.quant_method.process_weights_after_loading(fml)
-        fml.maybe_init_modular_kernel()
+            num_tokens_across_dp = torch.tensor(
+                [m] * world_size, dtype=torch.int, device="cpu"
+            )
+            with set_forward_context(
+                None,
+                vllm_config,
+                num_tokens=m,
+                num_tokens_across_dp=num_tokens_across_dp,
+            ):
+                output = fml(hidden_states, router_logits)
 
-        # Forward
-        num_tokens_across_dp = torch.tensor(
-            [M] * world_size,
-            dtype=torch.int,
-            device="cpu",
-        )
-        with set_forward_context(
-            None,
-            vllm_config,
-            num_tokens=M,
-            num_tokens_across_dp=num_tokens_across_dp,
-        ):
-            output = fml(hidden_states, router_logits)
+            torch.testing.assert_close(ref_output, output, atol=5e-2, rtol=5e-2)
 
-        torch.testing.assert_close(ref_output, output, atol=5e-2, rtol=5e-2)
+            del fml
+            _cleanup_between_configs(prefix, backend)
 
 
 BACKENDS = [
@@ -256,19 +266,15 @@ BACKENDS = [
 
 BF16_SHAPES = [
     (16, 2048, 512),
-    (64, 4096, 1024),
+    (16, 4096, 1024),
 ]
 
 
 @pytest.mark.parametrize("backend", BACKENDS)
-@pytest.mark.parametrize("m,hidden_size,intermediate_size", BF16_SHAPES)
 @pytest.mark.parametrize("num_experts,topk", [(8, 2)])
 @multi_gpu_test(num_gpus=2)
 def test_fused_moe_ep_dp(
     backend: str,
-    m: int,
-    hidden_size: int,
-    intermediate_size: int,
     num_experts: int,
     topk: int,
 ):
@@ -284,28 +290,24 @@ def test_fused_moe_ep_dp(
         backend,
         num_experts,
         topk,
-        hidden_size,
-        intermediate_size,
-        m,
+        BF16_SHAPES,
     )
 
 
 # ---------------------------------------------------------------------------
-# NVFP4 + DP+EP test (CuTeDSL experts + DeepEP LL)
+# NVFP4 + DP+EP test (CuTeDSL experts)
 # ---------------------------------------------------------------------------
 
 
 def _worker_nvfp4(
     env: dict[str, str],
     world_size: int,
+    backend: str,
     num_experts: int,
     topk: int,
-    hidden_size: int,
-    intermediate_size: int,
-    M: int,
+    shapes: list[tuple[int, int, int]],
 ):
     dtype = torch.bfloat16
-    backend = "deepep_low_latency"
     rank, device = _init_worker(env)
     init_workspace_manager(device)
 
@@ -316,6 +318,9 @@ def _worker_nvfp4(
     vllm_config.parallel_config.all2all_backend = backend
     vllm_config.parallel_config.is_moe_model = True
     vllm_config.compilation_config.fast_moe_cold_start = False
+    # Force CuteDSL backend. Auto-upgrades to batched variant for
+    # DeepEP LL (BatchedExperts format) via oracle lines 212-217.
+    vllm_config.kernel_config.moe_backend = "flashinfer_cutedsl"
 
     with set_current_vllm_config(vllm_config):
         ensure_model_parallel_initialized(
@@ -323,206 +328,147 @@ def _worker_nvfp4(
             pipeline_model_parallel_size=1,
         )
 
-        # Number of local experts for this rank
-        num_local_experts = num_experts // world_size
+        for m, hidden_size, intermediate_size in shapes:
+            prefix = f"test_nvfp4_{rank}_{m}_{hidden_size}"
+            num_local_experts = num_experts // world_size
 
-        # Create FusedMoE layer with NVFP4 quant config
-        quant_config = ModelOptNvFp4Config(
-            is_checkpoint_nvfp4_serialized=True,
-            kv_cache_quant_algo=None,
-            exclude_modules=[],
-        )
-        fml = FusedMoE(
-            num_experts=num_experts,
-            top_k=topk,
-            hidden_size=hidden_size,
-            intermediate_size=intermediate_size,
-            prefix=f"test_nvfp4_{rank}",
-            activation="silu",
-            is_act_and_mul=True,
-            params_dtype=dtype,
-            reduce_results=False,
-            quant_config=quant_config,
-        )
-
-        # Register NVFP4 weight parameters
-        nvfp4_method = ModelOptNvFp4FusedMoE(quant_config, fml)
-        nvfp4_method.create_weights(
-            fml,
-            num_local_experts,
-            hidden_size,
-            intermediate_size,
-            params_dtype=torch.uint8,
-            global_num_experts=num_experts,
-        )
-        fml = fml.to(device)
-
-        # Generate quantized weights (same seed on all ranks)
-        set_random_seed(42)
-        w1_q, w2_q, _ = make_test_quant_config(
-            num_local_experts,
-            intermediate_size,
-            hidden_size,
-            in_dtype=dtype,
-            quant_dtype="nvfp4",
-            block_shape=None,
-            per_act_token_quant=False,
-        )
-
-        # Fill local expert weights and scales
-        fml.w13_weight.data = w1_q
-        fml.w2_weight.data = w2_q
-        fml.w2_input_scale.data = torch.randn_like(fml.w2_input_scale.data) / 5
-        fml.w13_input_scale.data = torch.randn_like(fml.w13_input_scale.data) / 5
-        fml.w2_weight_scale_2.data = torch.randn_like(fml.w2_weight_scale_2.data) / 5
-        fml.w13_weight_scale_2.data = torch.randn_like(fml.w13_weight_scale_2.data) / 5
-        fml.w2_weight_scale.data = (
-            torch.randn(fml.w2_weight_scale.data.shape, device=device) / 5
-        ).to(fml.w2_weight_scale.data.dtype)
-        fml.w13_weight_scale.data = (
-            torch.randn(fml.w13_weight_scale.data.shape, device=device) / 5
-        ).to(fml.w13_weight_scale.data.dtype)
-
-        # Dequantize weights BEFORE process_weights_after_loading, which
-        # transforms scales into kernel-specific format.
-        w13_deq = torch.empty(
-            num_local_experts,
-            2 * intermediate_size,
-            hidden_size,
-            device=device,
-            dtype=dtype,
-        )
-        w2_deq = torch.empty(
-            num_local_experts,
-            hidden_size,
-            intermediate_size,
-            device=device,
-            dtype=dtype,
-        )
-        for idx in range(num_local_experts):
-            w13_deq[idx] = dequantize_nvfp4_to_dtype(
-                fml.w13_weight.data[idx],
-                fml.w13_weight_scale.data[idx],
-                fml.w13_weight_scale_2.data[idx, 0],
-                dtype,
-                device,
-            )
-            w2_deq[idx] = dequantize_nvfp4_to_dtype(
-                fml.w2_weight.data[idx],
-                fml.w2_weight_scale.data[idx],
-                fml.w2_weight_scale_2.data[idx],
-                dtype,
-                device,
-            )
-
-        # Now transform weights for the kernel
-        nvfp4_method.process_weights_after_loading(fml)
-        fml.maybe_init_modular_kernel()
-
-        # Generate per-rank input (different per rank)
-        set_random_seed(100 + rank)
-        hidden_states = (
-            torch.randn(
-                M,
-                hidden_size,
-                device=device,
-                dtype=dtype,
-            )
-            / 10
-        )
-        router_logits = (
-            torch.randn(
-                M,
+            # Generate FULL quantized weights with matching scales
+            # (same seed on all ranks so weights are identical)
+            set_random_seed(42)
+            (_, w13_q, w13_bs, w13_gs), (_, w2_q, w2_bs, w2_gs) = make_test_weights(
                 num_experts,
-                device=device,
+                intermediate_size,
+                hidden_size,
+                in_dtype=dtype,
+                quant_dtype="nvfp4",
+            )
+
+            # Dequantize FULL weights for reference BEFORE any transforms
+            w13_deq = torch.empty(
+                num_experts,
+                2 * intermediate_size,
+                hidden_size,
+                device="cuda",
                 dtype=dtype,
             )
-            / 10
-        )
+            w2_deq = torch.empty(
+                num_experts,
+                hidden_size,
+                intermediate_size,
+                device="cuda",
+                dtype=dtype,
+            )
+            for idx in range(num_experts):
+                w13_deq[idx] = dequantize_nvfp4_to_dtype(
+                    w13_q[idx], w13_bs[idx], w13_gs[idx], dtype, device
+                )
+                w2_deq[idx] = dequantize_nvfp4_to_dtype(
+                    w2_q[idx], w2_bs[idx], w2_gs[idx], dtype, device
+                )
 
-        # Build full-expert dequantized weights for reference
-        # (allgather across ranks)
-        w13_full = torch.zeros(
-            num_experts,
-            2 * intermediate_size,
-            hidden_size,
-            device=device,
-            dtype=dtype,
-        )
-        w2_full = torch.zeros(
-            num_experts,
-            hidden_size,
-            intermediate_size,
-            device=device,
-            dtype=dtype,
-        )
-        ep_rank = fml.moe_parallel_config.ep_rank
-        start = ep_rank * num_local_experts
-        end = start + num_local_experts
-        w13_full[start:end] = w13_deq
-        w2_full[start:end] = w2_deq
-        torch.distributed.all_reduce(w13_full)
-        torch.distributed.all_reduce(w2_full)
+            # Create FusedMoE layer with NVFP4 quant config
+            # FusedMoE.__init__ creates quant_method and registers weights
+            quant_config = ModelOptNvFp4Config(
+                is_checkpoint_nvfp4_serialized=True,
+                kv_cache_quant_algo=None,
+                exclude_modules=[],
+            )
+            fml = FusedMoE(
+                num_experts=num_experts,
+                top_k=topk,
+                hidden_size=hidden_size,
+                intermediate_size=intermediate_size,
+                prefix=prefix,
+                activation="silu",
+                is_act_and_mul=True,
+                params_dtype=dtype,
+                reduce_results=False,
+                quant_config=quant_config,
+            )
+            fml = fml.to(device)
 
-        # Reference: quantize activations, dequantize, run torch_moe_ref
-        a_global_scale = (
-            (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX)
-            / torch.amax(hidden_states.abs().flatten(), dim=-1)
-        ).to(torch.float32)
-        a_fp4, a_scale = ops.scaled_fp4_quant(hidden_states, a_global_scale)
-        a_deq = dequantize_nvfp4_to_dtype(
-            a_fp4,
-            a_scale,
-            a_global_scale,
-            dtype,
-            device,
-        )
+            # Fill LOCAL expert weights and scales from make_test_weights
+            ep_rank = fml.moe_parallel_config.ep_rank
+            start = ep_rank * num_local_experts
+            end = start + num_local_experts
+            fml.w13_weight.data.copy_(w13_q[start:end])
+            fml.w2_weight.data.copy_(w2_q[start:end])
+            fml.w13_weight_scale.data.copy_(w13_bs[start:end])
+            fml.w2_weight_scale.data.copy_(w2_bs[start:end])
+            # weight_scale_2 stores 1/global_scale (the kernel applies it
+            # as alpha = 1/(a_scale * w_scale), see test_cutedsl_moe.py:428)
+            fml.w13_weight_scale_2.data[:, 0] = 1.0 / w13_gs[start:end]
+            fml.w13_weight_scale_2.data[:, 1] = 1.0 / w13_gs[start:end]
+            fml.w2_weight_scale_2.data.copy_(1.0 / w2_gs[start:end])
+            fml.w13_input_scale.data.fill_(1.0)
+            fml.w2_input_scale.data.fill_(1.0)
 
-        topk_weights, topk_ids, _ = fused_topk(
-            hidden_states,
-            router_logits.float(),
-            topk,
-            renormalize=True,
-        )
-        ref_output = torch_moe_ref(
-            a_deq,
-            w13_full,
-            w2_full,
-            topk_ids,
-            topk_weights,
-        )
+            fml.quant_method.process_weights_after_loading(fml)
+            fml.maybe_init_modular_kernel()
 
-        # Forward
-        num_tokens_across_dp = torch.tensor(
-            [M] * world_size,
-            dtype=torch.int,
-            device="cpu",
-        )
-        with set_forward_context(
-            None,
-            vllm_config,
-            num_tokens=M,
-            num_tokens_across_dp=num_tokens_across_dp,
-        ):
-            output = fml(hidden_states, router_logits)
+            # Generate per-rank input
+            set_random_seed(100 + rank)
+            hidden_states = torch.randn(m, hidden_size, device=device, dtype=dtype) / 10
+            router_logits = torch.randn(m, num_experts, device=device, dtype=dtype) / 10
 
-        torch.testing.assert_close(ref_output, output, atol=1e-1, rtol=1e-1)
+            # Reference: quantize+dequantize activations, then torch_moe_ref
+            a_global_scale = (
+                (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX)
+                / torch.amax(hidden_states.abs().flatten(), dim=-1)
+            ).to(torch.float32)
+            a_fp4, a_scale = ops.scaled_fp4_quant(hidden_states, a_global_scale)
+            a_deq = dequantize_nvfp4_to_dtype(
+                a_fp4, a_scale, a_global_scale, dtype, device
+            )
+
+            topk_weights, topk_ids, _ = fused_topk(
+                hidden_states,
+                router_logits.float(),
+                topk,
+                renormalize=True,
+            )
+            ref_output = torch_moe_ref(a_deq, w13_deq, w2_deq, topk_ids, topk_weights)
+
+            # Forward
+            num_tokens_across_dp = torch.tensor(
+                [m] * world_size, dtype=torch.int, device="cpu"
+            )
+            with set_forward_context(
+                None,
+                vllm_config,
+                num_tokens=m,
+                num_tokens_across_dp=num_tokens_across_dp,
+            ):
+                output = fml(hidden_states, router_logits)
+
+            # FP4 quantization + distributed dispatch introduces error.
+            # test_cutedsl_moe.py uses atol=2e-1 for kernel-level tests.
+            torch.testing.assert_close(ref_output, output, atol=4e-1, rtol=4e-1)
+
+            del fml
+            _cleanup_between_configs(prefix, backend)
 
 
 NVFP4_SHAPES = [
-    # hidden_size must be in DeepEP LL SUPPORTED_HIDDEN_SIZES
+    # hidden_size must be in DeepEP LL SUPPORTED_HIDDEN_SIZES.
+    # M kept small for DeepEP LL buffer constraints.
     (16, 2048, 256),
-    (64, 4096, 512),
+    (32, 4096, 512),
+]
+
+NVFP4_BACKENDS = [
+    # deepep_high_throughput -> Standard format -> masked_gemm CuteDSL
+    "deepep_high_throughput",
+    # TODO: deepep_low_latency needs LL buffer pre-allocation for
+    # batched CuteDSL. Add once buffer sizing is resolved.
 ]
 
 
-@pytest.mark.parametrize("m,hidden_size,intermediate_size", NVFP4_SHAPES)
+@pytest.mark.parametrize("backend", NVFP4_BACKENDS)
 @pytest.mark.parametrize("num_experts,topk", [(8, 2)])
 @multi_gpu_test(num_gpus=2)
 def test_fused_moe_ep_dp_nvfp4(
-    m: int,
-    hidden_size: int,
-    intermediate_size: int,
+    backend: str,
     num_experts: int,
     topk: int,
 ):
@@ -535,13 +481,8 @@ def test_fused_moe_ep_dp_nvfp4(
     _distributed_run(
         _worker_nvfp4,
         2,
+        backend,
         num_experts,
         topk,
-        hidden_size,
-        intermediate_size,
-        m,
-        extra_env={
-            "VLLM_USE_FLASHINFER_MOE_FP4": "1",
-            "VLLM_FLASHINFER_MOE_BACKEND": "cutedsl",
-        },
+        NVFP4_SHAPES,
     )

--- a/tests/kernels/moe/test_fused_moe_ep_dp.py
+++ b/tests/kernels/moe/test_fused_moe_ep_dp.py
@@ -342,6 +342,8 @@ def _worker_nvfp4(
                 in_dtype=dtype,
                 quant_dtype="nvfp4",
             )
+            assert w13_bs is not None and w13_gs is not None
+            assert w2_bs is not None and w2_gs is not None
 
             # Dequantize FULL weights for reference BEFORE any transforms
             w13_deq = torch.empty(

--- a/tests/kernels/moe/test_fused_moe_ep_dp.py
+++ b/tests/kernels/moe/test_fused_moe_ep_dp.py
@@ -1,490 +1,390 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
-Layer-level test for FusedMoE with DP+EP and all-to-all backends.
+Layer-level FusedMoE tests with data-parallel + expert-parallel routing.
 
-Exercises the full FusedMoE nn.Module end-to-end including:
-- Router (fused_topk)
-- All-to-all dispatch/combine (DeepEP HT, DeepEP LL, allgather-reducescatter)
-- Weight handling and expert sharding
-- The DefaultMoERunner orchestration
+Two public tests, each launching 2 worker processes once and sweeping
+configs internally to amortize spawn cost:
 
-Launches processes once per backend and loops over shapes inside the worker
-to minimize process creation overhead.
+- test_fused_moe_ep_dp_bf16:   bf16 weights, sweeps 3 a2a backends x 2 shapes
+- test_fused_moe_ep_dp_nvfp4:  NVFP4 weights + FlashInfer CuTeDSL (masked_gemm)
+                               + DeepEP low-latency, sweeps 2 shapes
 
-Run: pytest -v -s tests/kernels/moe/test_fused_moe_ep_dp.py
+Reference for NVFP4 follows the convention in tests/kernels/moe/test_cutedsl_moe.py:
+per-expert weight global scales from amax, unit input global scale, and
+quant-dequant both activations and weights before a pure-torch MoE reference.
 """
 
-import os
+import gc
 
 import pytest
 import torch
-import torch.multiprocessing as mp
+from torch.distributed import ProcessGroup
 
+from tests.kernels.moe.modular_kernel_tools.parallel_utils import (
+    ProcessGroupInfo,
+    parallel_launch_with_config,
+)
 from tests.kernels.moe.utils import make_test_weights
 from tests.kernels.quantization.nvfp4_utils import (
-    FLOAT4_E2M1_MAX,
-    FLOAT8_E4M3_MAX,
     dequantize_nvfp4_to_dtype,
 )
-from vllm import _custom_ops as ops
 from vllm.config import VllmConfig, set_current_vllm_config
-from vllm.distributed.parallel_state import (
-    ensure_model_parallel_initialized,
-    get_ep_group,
-    init_distributed_environment,
-)
 from vllm.forward_context import set_forward_context
 from vllm.model_executor.layers.activation import SiluAndMul
 from vllm.model_executor.layers.fused_moe.layer import FusedMoE
-from vllm.model_executor.layers.fused_moe.router.fused_topk_router import (
-    fused_topk,
+from vllm.model_executor.layers.fused_moe.prepare_finalize.deepep_ll import (
+    DeepEPLLPrepareAndFinalize,
 )
-from vllm.model_executor.layers.quantization.modelopt import (
-    ModelOptNvFp4Config,
-)
+from vllm.model_executor.layers.fused_moe.router.fused_topk_router import fused_topk
+from vllm.model_executor.layers.quantization.modelopt import ModelOptNvFp4Config
 from vllm.platforms import current_platform
 from vllm.utils.import_utils import has_deep_ep
-from vllm.utils.network_utils import get_open_port
-from vllm.utils.system_utils import update_environment_variables
 from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.worker.workspace import init_workspace_manager
 
 from ...utils import multi_gpu_test
 
-mp.set_start_method("spawn", force=True)
+NUM_EXPERTS = 8
+TOPK = 2
+WORLD_SIZE = 2
 
-
-# ---------------------------------------------------------------------------
-# Distributed launch helpers
-# ---------------------------------------------------------------------------
-
-
-def _distributed_run(fn, world_size, *args, extra_env=None):
-    """Launch fn across world_size processes with dynamic port allocation."""
-    port = get_open_port()
-    processes: list[mp.Process] = []
-    for i in range(world_size):
-        env: dict[str, str] = {
-            "RANK": str(i),
-            "LOCAL_RANK": str(i),
-            "WORLD_SIZE": str(world_size),
-            "LOCAL_WORLD_SIZE": str(world_size),
-            "MASTER_ADDR": "localhost",
-            "MASTER_PORT": str(port),
-        }
-        if extra_env:
-            env.update(extra_env)
-        p = mp.Process(target=fn, args=(env, world_size, *args))
-        processes.append(p)
-        p.start()
-
-    for p in processes:
-        p.join()
-
-    for p in processes:
-        assert p.exitcode == 0
-
-
-def _init_worker(env: dict[str, str]):
-    """Initialize distributed environment for a worker process."""
-    update_environment_variables(env)
-    rank = int(os.environ["LOCAL_RANK"])
-    torch.accelerator.set_device_index(rank)
-    device = torch.device(f"cuda:{rank}")
-
-    bare_config = VllmConfig()
-    with set_current_vllm_config(bare_config):
-        init_distributed_environment()
-
-    return rank, device
-
-
-def _cleanup_between_configs(prefix: str, backend: str):
-    """Clean up state between test config iterations.
-
-    Follows the pattern from test_moe_layer.py:
-    clear compilation state and destroy DeepEP all2all buffers on SM100.
-    """
-    vllm_config = VllmConfig()
-    cc = vllm_config.compilation_config
-    if prefix in cc.static_forward_context:
-        del cc.static_forward_context[prefix]
-        if prefix in cc.static_all_moe_layers:
-            cc.static_all_moe_layers.remove(prefix)
-
-    cap = current_platform.get_device_capability()
-    if (
-        cap is not None
-        and cap.major == 10
-        and backend in ("deepep_low_latency", "deepep_high_throughput")
-    ):
-        torch.accelerator.synchronize()
-        all2all_manager = get_ep_group().device_communicator.all2all_manager
-        if all2all_manager is not None:
-            all2all_manager.destroy()
-
-    torch.accelerator.empty_cache()
-
-
-def torch_moe_ref(
-    a: torch.Tensor,
-    w1: torch.Tensor,
-    w2: torch.Tensor,
-    topk_ids: torch.Tensor,
-    topk_weights: torch.Tensor,
-) -> torch.Tensor:
-    """Single-GPU PyTorch MoE reference (all experts, no sharding)."""
-    m, _ = a.shape
-    topk = topk_ids.size(1)
-    out = torch.zeros_like(a)
-    for i in range(m):
-        for j in range(topk):
-            e = topk_ids[i][j]
-            e_w = topk_weights[i][j]
-            x = a[i] @ w1[e].transpose(0, 1)
-            x = SiluAndMul()(x.unsqueeze(0)).squeeze(0)
-            out[i] += (x @ w2[e].transpose(0, 1)) * e_w
-    return out
-
-
-# ---------------------------------------------------------------------------
-# BF16 DP+EP test
-# ---------------------------------------------------------------------------
-
-
-def _worker_bf16(
-    env: dict[str, str],
-    world_size: int,
-    backend: str,
-    num_experts: int,
-    topk: int,
-    shapes: list[tuple[int, int, int]],
-):
-    dtype = torch.bfloat16
-    rank, device = _init_worker(env)
-    init_workspace_manager(device)
-
-    vllm_config = VllmConfig()
-    vllm_config.parallel_config.data_parallel_size = world_size
-    vllm_config.parallel_config.data_parallel_rank = rank
-    vllm_config.parallel_config.enable_expert_parallel = True
-    vllm_config.parallel_config.all2all_backend = backend
-    vllm_config.parallel_config.is_moe_model = True
-    vllm_config.compilation_config.fast_moe_cold_start = False
-
-    with set_current_vllm_config(vllm_config):
-        ensure_model_parallel_initialized(
-            tensor_model_parallel_size=1,
-            pipeline_model_parallel_size=1,
-        )
-
-        for m, hidden_size, intermediate_size in shapes:
-            prefix = f"test_bf16_{rank}_{m}_{hidden_size}"
-
-            set_random_seed(42)
-            w13_full = (
-                torch.randn(
-                    num_experts,
-                    2 * intermediate_size,
-                    hidden_size,
-                    device=device,
-                    dtype=dtype,
-                )
-                / 10
-            )
-            w2_full = (
-                torch.randn(
-                    num_experts,
-                    hidden_size,
-                    intermediate_size,
-                    device=device,
-                    dtype=dtype,
-                )
-                / 10
-            )
-
-            set_random_seed(100 + rank)
-            hidden_states = torch.randn(m, hidden_size, device=device, dtype=dtype) / 10
-            router_logits = torch.randn(m, num_experts, device=device, dtype=dtype) / 10
-
-            topk_weights, topk_ids, _ = fused_topk(
-                hidden_states,
-                router_logits.float(),
-                topk,
-                renormalize=True,
-            )
-            ref_output = torch_moe_ref(
-                hidden_states, w13_full, w2_full, topk_ids, topk_weights
-            )
-
-            fml = FusedMoE(
-                num_experts=num_experts,
-                top_k=topk,
-                hidden_size=hidden_size,
-                intermediate_size=intermediate_size,
-                prefix=prefix,
-                activation="silu",
-                is_act_and_mul=True,
-                params_dtype=dtype,
-                reduce_results=False,
-            )
-            fml = fml.to(device)
-
-            ep_rank = fml.moe_parallel_config.ep_rank
-            n_local = fml.local_num_experts
-            start = ep_rank * n_local
-            end = start + n_local
-            fml.w13_weight.data.copy_(w13_full[start:end])
-            fml.w2_weight.data.copy_(w2_full[start:end])
-
-            fml.quant_method.process_weights_after_loading(fml)
-            fml.maybe_init_modular_kernel()
-
-            num_tokens_across_dp = torch.tensor(
-                [m] * world_size, dtype=torch.int, device="cpu"
-            )
-            with set_forward_context(
-                None,
-                vllm_config,
-                num_tokens=m,
-                num_tokens_across_dp=num_tokens_across_dp,
-            ):
-                output = fml(hidden_states, router_logits)
-
-            torch.testing.assert_close(ref_output, output, atol=5e-2, rtol=5e-2)
-
-            del fml
-            _cleanup_between_configs(prefix, backend)
-
-
-BACKENDS = [
+BF16_BACKENDS = [
     "allgather_reducescatter",
     "deepep_high_throughput",
     "deepep_low_latency",
 ]
 
+# (M, hidden_size, intermediate_size).
+# hidden_size must be in DeepEPLLPrepareAndFinalize.SUPPORTED_HIDDEN_SIZES
+# because deepep_low_latency rounds the layer's hidden_size up to the nearest
+# supported value, which would then mismatch the weight tensor shape.
 BF16_SHAPES = [
     (16, 2048, 512),
-    (16, 4096, 1024),
+    (64, 4096, 1024),
 ]
 
+NVFP4_SHAPES = [
+    (16, 2048, 256),
+    (64, 4096, 512),
+]
 
-@pytest.mark.parametrize("backend", BACKENDS)
-@pytest.mark.parametrize("num_experts,topk", [(8, 2)])
-@multi_gpu_test(num_gpus=2)
-def test_fused_moe_ep_dp(
-    backend: str,
-    num_experts: int,
-    topk: int,
-):
+BF16_TOL = dict(atol=5e-2, rtol=5e-2)
+
+
+def _nvfp4_tol(hidden_size: int) -> dict:
+    # Matches tests/kernels/moe/test_moe_layer.py modelopt_fp4 formula:
+    # error scales linearly with the GEMM K-dimension.
+    tol = 1e-1 + hidden_size * 5e-4
+    return dict(atol=tol, rtol=tol)
+
+
+def _torch_moe_ref(
+    a: torch.Tensor,
+    w13: torch.Tensor,
+    w2: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+) -> torch.Tensor:
+    """Dense per-token MoE reference in the tensor dtype of `a`."""
+    m = a.size(0)
+    topk = topk_ids.size(1)
+    silu_and_mul = SiluAndMul()
+    out = torch.zeros_like(a)
+    for i in range(m):
+        for j in range(topk):
+            e = topk_ids[i, j]
+            w = topk_weights[i, j]
+            out[i] += (silu_and_mul(a[i] @ w13[e].T) @ w2[e].T) * w
+    return out
+
+
+def _make_forward_ctx(vllm_config: VllmConfig, m: int):
+    num_tokens_across_dp = torch.tensor([m] * WORLD_SIZE, dtype=torch.int, device="cpu")
+    return set_forward_context(
+        None,
+        vllm_config,
+        num_tokens=m,
+        num_tokens_across_dp=num_tokens_across_dp,
+    )
+
+
+def _cleanup_between_configs() -> None:
+    gc.collect()
+    torch.accelerator.synchronize()
+    torch.accelerator.empty_cache()
+    torch.distributed.barrier()
+
+
+def _run_bf16_one(
+    pgi: ProcessGroupInfo,
+    vllm_config: VllmConfig,
+    m: int,
+    hidden_size: int,
+    intermediate_size: int,
+) -> None:
+    dtype = torch.bfloat16
+    backend = vllm_config.parallel_config.all2all_backend
+
+    with set_current_vllm_config(vllm_config):
+        set_random_seed(42)
+        w13_full = (
+            torch.randn(
+                NUM_EXPERTS,
+                2 * intermediate_size,
+                hidden_size,
+                device="cuda",
+                dtype=dtype,
+            )
+            / 10
+        )
+        w2_full = (
+            torch.randn(
+                NUM_EXPERTS,
+                hidden_size,
+                intermediate_size,
+                device="cuda",
+                dtype=dtype,
+            )
+            / 10
+        )
+
+        set_random_seed(100 + pgi.rank)
+        hidden_states = torch.randn(m, hidden_size, device="cuda", dtype=dtype) / 10
+        router_logits = torch.randn(m, NUM_EXPERTS, device="cuda", dtype=dtype) / 10
+
+        topk_weights, topk_ids, _ = fused_topk(
+            hidden_states,
+            router_logits.float(),
+            TOPK,
+            renormalize=True,
+        )
+        ref_output = _torch_moe_ref(
+            hidden_states, w13_full, w2_full, topk_ids, topk_weights
+        )
+
+        fml = FusedMoE(
+            num_experts=NUM_EXPERTS,
+            top_k=TOPK,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            prefix=f"bf16_{backend}_{m}_{hidden_size}_{intermediate_size}",
+            activation="silu",
+            is_act_and_mul=True,
+            params_dtype=dtype,
+            reduce_results=False,
+        ).to("cuda")
+
+        ep_rank = fml.moe_parallel_config.ep_rank
+        n_local = fml.local_num_experts
+        start, end = ep_rank * n_local, (ep_rank + 1) * n_local
+        fml.w13_weight.data.copy_(w13_full[start:end])
+        fml.w2_weight.data.copy_(w2_full[start:end])
+
+        fml.quant_method.process_weights_after_loading(fml)
+        fml.maybe_init_modular_kernel()
+
+        with _make_forward_ctx(vllm_config, m):
+            output = fml(hidden_states, router_logits)
+
+        torch.testing.assert_close(
+            output,
+            ref_output,
+            msg=(
+                f"bf16 mismatch: backend={backend} "
+                f"M={m} H={hidden_size} I={intermediate_size} rank={pgi.rank}"
+            ),
+            **BF16_TOL,
+        )
+
+    del fml
+
+
+def _run_nvfp4_one(
+    pgi: ProcessGroupInfo,
+    vllm_config: VllmConfig,
+    m: int,
+    hidden_size: int,
+    intermediate_size: int,
+) -> None:
+    dtype = torch.bfloat16
+
+    with set_current_vllm_config(vllm_config):
+        set_random_seed(42)
+        (_, w13_q, w13_bs, w13_gs), (_, w2_q, w2_bs, w2_gs) = make_test_weights(
+            NUM_EXPERTS,
+            intermediate_size,
+            hidden_size,
+            in_dtype=dtype,
+            quant_dtype="nvfp4",
+        )
+        assert w13_bs is not None and w13_gs is not None
+        assert w2_bs is not None and w2_gs is not None
+
+        # Convention match test_cutedsl_moe.py: unit input global scale on
+        # both layer and reference so they use the same effective scale.
+        input_gs = torch.ones(1, dtype=torch.float32, device="cuda")
+
+        set_random_seed(100 + pgi.rank)
+        hidden_states = torch.randn(m, hidden_size, device="cuda", dtype=dtype) / 10
+        router_logits = torch.randn(m, NUM_EXPERTS, device="cuda", dtype=dtype) / 10
+
+        from flashinfer import fp4_quantize
+
+        a_fp4, a_sf = fp4_quantize(hidden_states, input_gs)
+        a_deq = dequantize_nvfp4_to_dtype(
+            a_fp4, a_sf, input_gs, dtype, hidden_states.device
+        )
+
+        w13_deq = torch.empty(
+            NUM_EXPERTS,
+            2 * intermediate_size,
+            hidden_size,
+            device="cuda",
+            dtype=dtype,
+        )
+        w2_deq = torch.empty(
+            NUM_EXPERTS, hidden_size, intermediate_size, device="cuda", dtype=dtype
+        )
+        for e in range(NUM_EXPERTS):
+            w13_deq[e] = dequantize_nvfp4_to_dtype(
+                w13_q[e], w13_bs[e], w13_gs[e], dtype, w13_q.device
+            )
+            w2_deq[e] = dequantize_nvfp4_to_dtype(
+                w2_q[e], w2_bs[e], w2_gs[e], dtype, w2_q.device
+            )
+
+        topk_weights, topk_ids, _ = fused_topk(
+            hidden_states,
+            router_logits.float(),
+            TOPK,
+            renormalize=True,
+        )
+        ref_output = _torch_moe_ref(a_deq, w13_deq, w2_deq, topk_ids, topk_weights)
+
+        quant_config = ModelOptNvFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            kv_cache_quant_algo=None,
+            exclude_modules=[],
+        )
+        fml = FusedMoE(
+            num_experts=NUM_EXPERTS,
+            top_k=TOPK,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            prefix=f"nvfp4_{m}_{hidden_size}_{intermediate_size}",
+            activation="silu",
+            is_act_and_mul=True,
+            params_dtype=dtype,
+            reduce_results=False,
+            quant_config=quant_config,
+        ).to("cuda")
+
+        ep_rank = fml.moe_parallel_config.ep_rank
+        n_local = fml.local_num_experts
+        start, end = ep_rank * n_local, (ep_rank + 1) * n_local
+
+        fml.w13_weight.data.copy_(w13_q[start:end])
+        fml.w2_weight.data.copy_(w2_q[start:end])
+        fml.w13_weight_scale.data.copy_(w13_bs[start:end])
+        fml.w2_weight_scale.data.copy_(w2_bs[start:end])
+
+        # weight_scale_2 stores the RECIPROCAL of the global scale: the kernel
+        # computes g_alphas = a_scale * weight_scale_2, which needs 1/w_gs for
+        # correct dequantization (see tests/kernels/moe/test_moe_layer.py).
+        # w13 packs gate and up; replicate for both halves.
+        w13_inv_gs = (1.0 / w13_gs[start:end]).unsqueeze(1).expand(-1, 2).contiguous()
+        fml.w13_weight_scale_2.data.copy_(w13_inv_gs)
+        fml.w2_weight_scale_2.data.copy_(1.0 / w2_gs[start:end])
+
+        # Match the reference's unit input scale.
+        fml.w13_input_scale.data.fill_(1.0)
+        fml.w2_input_scale.data.fill_(1.0)
+
+        fml.quant_method.process_weights_after_loading(fml)
+        fml.maybe_init_modular_kernel()
+
+        with _make_forward_ctx(vllm_config, m):
+            output = fml(hidden_states, router_logits)
+
+        torch.testing.assert_close(output, ref_output, **_nvfp4_tol(hidden_size))
+
+    del fml
+
+
+def _worker_bf16_all_shapes(
+    pgi: ProcessGroupInfo,
+    vllm_config: VllmConfig,
+    cpu_group: ProcessGroup,
+    shapes: list[tuple[int, int, int]],
+) -> None:
+    init_workspace_manager(pgi.device)
+    for m, h, i in shapes:
+        _run_bf16_one(pgi, vllm_config, m, h, i)
+        _cleanup_between_configs()
+
+
+def _worker_nvfp4_all_shapes(
+    pgi: ProcessGroupInfo,
+    vllm_config: VllmConfig,
+    cpu_group: ProcessGroup,
+    shapes: list[tuple[int, int, int]],
+) -> None:
+    init_workspace_manager(pgi.device)
+    for m, h, i in shapes:
+        _run_nvfp4_one(pgi, vllm_config, m, h, i)
+        _cleanup_between_configs()
+
+
+def _base_vllm_config(all2all_backend: str) -> VllmConfig:
+    cfg = VllmConfig()
+    cfg.parallel_config.data_parallel_size = WORLD_SIZE
+    cfg.parallel_config.enable_expert_parallel = True
+    cfg.parallel_config.is_moe_model = True
+    cfg.parallel_config.all2all_backend = all2all_backend
+    cfg.compilation_config.fast_moe_cold_start = False
+    # Keep moe.max_num_tokens below the DeepEP LL nvshmem_qp_depth bound
+    # (default qp_depth=1024 -> assertion needs max_tokens_per_rank <= 511).
+    cfg.scheduler_config.max_num_batched_tokens = 128
+    return cfg
+
+
+@pytest.mark.parametrize("backend", BF16_BACKENDS)
+@multi_gpu_test(num_gpus=WORLD_SIZE)
+def test_fused_moe_ep_dp_bf16(backend: str):
+    if torch.accelerator.device_count() < WORLD_SIZE:
+        pytest.skip(f"Need {WORLD_SIZE} GPUs, have {torch.accelerator.device_count()}")
     if (
         backend in ("deepep_high_throughput", "deepep_low_latency")
         and not has_deep_ep()
     ):
         pytest.skip("DeepEP not available")
 
-    _distributed_run(
-        _worker_bf16,
-        2,
-        backend,
-        num_experts,
-        topk,
+    parallel_launch_with_config(
+        WORLD_SIZE,
+        _worker_bf16_all_shapes,
+        _base_vllm_config(backend),
+        None,
         BF16_SHAPES,
     )
 
 
-# ---------------------------------------------------------------------------
-# NVFP4 + DP+EP test (CuTeDSL experts)
-# ---------------------------------------------------------------------------
-
-
-def _worker_nvfp4(
-    env: dict[str, str],
-    world_size: int,
-    backend: str,
-    num_experts: int,
-    topk: int,
-    shapes: list[tuple[int, int, int]],
-):
-    dtype = torch.bfloat16
-    rank, device = _init_worker(env)
-    init_workspace_manager(device)
-
-    vllm_config = VllmConfig()
-    vllm_config.parallel_config.data_parallel_size = world_size
-    vllm_config.parallel_config.data_parallel_rank = rank
-    vllm_config.parallel_config.enable_expert_parallel = True
-    vllm_config.parallel_config.all2all_backend = backend
-    vllm_config.parallel_config.is_moe_model = True
-    vllm_config.compilation_config.fast_moe_cold_start = False
-    # Force CuteDSL backend. Auto-upgrades to batched variant for
-    # DeepEP LL (BatchedExperts format) via oracle lines 212-217.
-    vllm_config.kernel_config.moe_backend = "flashinfer_cutedsl"
-
-    with set_current_vllm_config(vllm_config):
-        ensure_model_parallel_initialized(
-            tensor_model_parallel_size=1,
-            pipeline_model_parallel_size=1,
-        )
-
-        for m, hidden_size, intermediate_size in shapes:
-            prefix = f"test_nvfp4_{rank}_{m}_{hidden_size}"
-            num_local_experts = num_experts // world_size
-
-            # Generate FULL quantized weights with matching scales
-            # (same seed on all ranks so weights are identical)
-            set_random_seed(42)
-            (_, w13_q, w13_bs, w13_gs), (_, w2_q, w2_bs, w2_gs) = make_test_weights(
-                num_experts,
-                intermediate_size,
-                hidden_size,
-                in_dtype=dtype,
-                quant_dtype="nvfp4",
-            )
-            assert w13_bs is not None and w13_gs is not None
-            assert w2_bs is not None and w2_gs is not None
-
-            # Dequantize FULL weights for reference BEFORE any transforms
-            w13_deq = torch.empty(
-                num_experts,
-                2 * intermediate_size,
-                hidden_size,
-                device="cuda",
-                dtype=dtype,
-            )
-            w2_deq = torch.empty(
-                num_experts,
-                hidden_size,
-                intermediate_size,
-                device="cuda",
-                dtype=dtype,
-            )
-            for idx in range(num_experts):
-                w13_deq[idx] = dequantize_nvfp4_to_dtype(
-                    w13_q[idx], w13_bs[idx], w13_gs[idx], dtype, device
-                )
-                w2_deq[idx] = dequantize_nvfp4_to_dtype(
-                    w2_q[idx], w2_bs[idx], w2_gs[idx], dtype, device
-                )
-
-            # Create FusedMoE layer with NVFP4 quant config
-            # FusedMoE.__init__ creates quant_method and registers weights
-            quant_config = ModelOptNvFp4Config(
-                is_checkpoint_nvfp4_serialized=True,
-                kv_cache_quant_algo=None,
-                exclude_modules=[],
-            )
-            fml = FusedMoE(
-                num_experts=num_experts,
-                top_k=topk,
-                hidden_size=hidden_size,
-                intermediate_size=intermediate_size,
-                prefix=prefix,
-                activation="silu",
-                is_act_and_mul=True,
-                params_dtype=dtype,
-                reduce_results=False,
-                quant_config=quant_config,
-            )
-            fml = fml.to(device)
-
-            # Fill LOCAL expert weights and scales from make_test_weights
-            ep_rank = fml.moe_parallel_config.ep_rank
-            start = ep_rank * num_local_experts
-            end = start + num_local_experts
-            fml.w13_weight.data.copy_(w13_q[start:end])
-            fml.w2_weight.data.copy_(w2_q[start:end])
-            fml.w13_weight_scale.data.copy_(w13_bs[start:end])
-            fml.w2_weight_scale.data.copy_(w2_bs[start:end])
-            # weight_scale_2 stores 1/global_scale (the kernel applies it
-            # as alpha = 1/(a_scale * w_scale), see test_cutedsl_moe.py:428)
-            fml.w13_weight_scale_2.data[:, 0] = 1.0 / w13_gs[start:end]
-            fml.w13_weight_scale_2.data[:, 1] = 1.0 / w13_gs[start:end]
-            fml.w2_weight_scale_2.data.copy_(1.0 / w2_gs[start:end])
-            fml.w13_input_scale.data.fill_(1.0)
-            fml.w2_input_scale.data.fill_(1.0)
-
-            fml.quant_method.process_weights_after_loading(fml)
-            fml.maybe_init_modular_kernel()
-
-            # Generate per-rank input
-            set_random_seed(100 + rank)
-            hidden_states = torch.randn(m, hidden_size, device=device, dtype=dtype) / 10
-            router_logits = torch.randn(m, num_experts, device=device, dtype=dtype) / 10
-
-            # Reference: quantize+dequantize activations, then torch_moe_ref
-            a_global_scale = (
-                (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX)
-                / torch.amax(hidden_states.abs().flatten(), dim=-1)
-            ).to(torch.float32)
-            a_fp4, a_scale = ops.scaled_fp4_quant(hidden_states, a_global_scale)
-            a_deq = dequantize_nvfp4_to_dtype(
-                a_fp4, a_scale, a_global_scale, dtype, device
-            )
-
-            topk_weights, topk_ids, _ = fused_topk(
-                hidden_states,
-                router_logits.float(),
-                topk,
-                renormalize=True,
-            )
-            ref_output = torch_moe_ref(a_deq, w13_deq, w2_deq, topk_ids, topk_weights)
-
-            # Forward
-            num_tokens_across_dp = torch.tensor(
-                [m] * world_size, dtype=torch.int, device="cpu"
-            )
-            with set_forward_context(
-                None,
-                vllm_config,
-                num_tokens=m,
-                num_tokens_across_dp=num_tokens_across_dp,
-            ):
-                output = fml(hidden_states, router_logits)
-
-            # FP4 quantization + distributed dispatch introduces error.
-            # test_cutedsl_moe.py uses atol=2e-1 for kernel-level tests.
-            torch.testing.assert_close(ref_output, output, atol=4e-1, rtol=4e-1)
-
-            del fml
-            _cleanup_between_configs(prefix, backend)
-
-
-NVFP4_SHAPES = [
-    # hidden_size must be in DeepEP LL SUPPORTED_HIDDEN_SIZES.
-    # M kept small for DeepEP LL buffer constraints.
-    (16, 2048, 256),
-    (32, 4096, 512),
-]
-
-NVFP4_BACKENDS = [
-    # deepep_high_throughput -> Standard format -> masked_gemm CuteDSL
-    "deepep_high_throughput",
-    # TODO: deepep_low_latency needs LL buffer pre-allocation for
-    # batched CuteDSL. Add once buffer sizing is resolved.
-]
-
-
-@pytest.mark.parametrize("backend", NVFP4_BACKENDS)
-@pytest.mark.parametrize("num_experts,topk", [(8, 2)])
-@multi_gpu_test(num_gpus=2)
-def test_fused_moe_ep_dp_nvfp4(
-    backend: str,
-    num_experts: int,
-    topk: int,
-):
+@multi_gpu_test(num_gpus=WORLD_SIZE)
+def test_fused_moe_ep_dp_nvfp4():
     if not current_platform.has_device_capability(100):
-        pytest.skip("NVFP4 CuTeDSL requires SM100+ (Blackwell)")
-
+        pytest.skip("NVFP4 + CuTeDSL masked_gemm requires SM100+")
+    if torch.accelerator.device_count() < WORLD_SIZE:
+        pytest.skip(f"Need {WORLD_SIZE} GPUs, have {torch.accelerator.device_count()}")
     if not has_deep_ep():
         pytest.skip("DeepEP not available")
 
-    _distributed_run(
-        _worker_nvfp4,
-        2,
-        backend,
-        num_experts,
-        topk,
-        NVFP4_SHAPES,
+    for _, h, _ in NVFP4_SHAPES:
+        assert h in DeepEPLLPrepareAndFinalize.SUPPORTED_HIDDEN_SIZES, (
+            f"hidden_size={h} not in DeepEP LL supported sizes"
+        )
+
+    cfg = _base_vllm_config("deepep_low_latency")
+    cfg.kernel_config.moe_backend = "flashinfer_cutedsl"
+    parallel_launch_with_config(
+        WORLD_SIZE, _worker_nvfp4_all_shapes, cfg, None, NVFP4_SHAPES
     )

--- a/tests/kernels/moe/test_fused_moe_ep_dp.py
+++ b/tests/kernels/moe/test_fused_moe_ep_dp.py
@@ -1,0 +1,547 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Layer-level test for FusedMoE with DP+EP and all-to-all backends.
+
+Exercises the full FusedMoE nn.Module end-to-end including:
+- Router (fused_topk)
+- All-to-all dispatch/combine (DeepEP HT, DeepEP LL, allgather-reducescatter)
+- Weight handling and expert sharding
+- The DefaultMoERunner orchestration
+
+Run: pytest -v -s tests/kernels/moe/test_fused_moe_ep_dp.py
+"""
+
+import os
+
+import pytest
+import torch
+import torch.multiprocessing as mp
+
+from tests.kernels.moe.utils import make_test_quant_config
+from tests.kernels.quantization.nvfp4_utils import (
+    FLOAT4_E2M1_MAX,
+    FLOAT8_E4M3_MAX,
+    dequantize_nvfp4_to_dtype,
+)
+from vllm import _custom_ops as ops
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.distributed.parallel_state import (
+    ensure_model_parallel_initialized,
+    init_distributed_environment,
+)
+from vllm.forward_context import set_forward_context
+from vllm.model_executor.layers.activation import SiluAndMul
+from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+from vllm.model_executor.layers.fused_moe.router.fused_topk_router import (
+    fused_topk,
+)
+from vllm.model_executor.layers.quantization.modelopt import (
+    ModelOptNvFp4Config,
+    ModelOptNvFp4FusedMoE,
+)
+from vllm.platforms import current_platform
+from vllm.utils.import_utils import has_deep_ep
+from vllm.utils.network_utils import get_open_port
+from vllm.utils.system_utils import update_environment_variables
+from vllm.utils.torch_utils import set_random_seed
+from vllm.v1.worker.workspace import init_workspace_manager
+
+from ...utils import multi_gpu_test
+
+mp.set_start_method("spawn", force=True)
+
+
+def _distributed_run(fn, world_size, *args, extra_env=None):
+    """Launch fn across world_size processes with dynamic port allocation."""
+    port = get_open_port()
+    processes: list[mp.Process] = []
+    for i in range(world_size):
+        env: dict[str, str] = {
+            "RANK": str(i),
+            "LOCAL_RANK": str(i),
+            "WORLD_SIZE": str(world_size),
+            "LOCAL_WORLD_SIZE": str(world_size),
+            "MASTER_ADDR": "localhost",
+            "MASTER_PORT": str(port),
+        }
+        if extra_env:
+            env.update(extra_env)
+        p = mp.Process(target=fn, args=(env, world_size, *args))
+        processes.append(p)
+        p.start()
+
+    for p in processes:
+        p.join()
+
+    for p in processes:
+        assert p.exitcode == 0
+
+
+def _init_worker(env: dict[str, str]):
+    """Initialize distributed environment for a worker process."""
+    update_environment_variables(env)
+    rank = int(os.environ["LOCAL_RANK"])
+    torch.accelerator.set_device_index(rank)
+    device = torch.device(f"cuda:{rank}")
+
+    bare_config = VllmConfig()
+    with set_current_vllm_config(bare_config):
+        init_distributed_environment()
+
+    return rank, device
+
+
+def torch_moe_ref(
+    a: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_ids: torch.Tensor,
+    topk_weights: torch.Tensor,
+) -> torch.Tensor:
+    """Single-GPU PyTorch MoE reference (all experts, no sharding)."""
+    m, _ = a.shape
+    topk = topk_ids.size(1)
+    out = torch.zeros_like(a)
+    for i in range(m):
+        for j in range(topk):
+            e = topk_ids[i][j]
+            e_w = topk_weights[i][j]
+            x = a[i] @ w1[e].transpose(0, 1)
+            x = SiluAndMul()(x.unsqueeze(0)).squeeze(0)
+            out[i] += (x @ w2[e].transpose(0, 1)) * e_w
+    return out
+
+
+# ---------------------------------------------------------------------------
+# BF16 DP+EP test
+# ---------------------------------------------------------------------------
+
+
+def _worker_bf16(
+    env: dict[str, str],
+    world_size: int,
+    backend: str,
+    num_experts: int,
+    topk: int,
+    hidden_size: int,
+    intermediate_size: int,
+    M: int,
+):
+    dtype = torch.bfloat16
+    rank, device = _init_worker(env)
+    init_workspace_manager(device)
+
+    vllm_config = VllmConfig()
+    vllm_config.parallel_config.data_parallel_size = world_size
+    vllm_config.parallel_config.data_parallel_rank = rank
+    vllm_config.parallel_config.enable_expert_parallel = True
+    vllm_config.parallel_config.all2all_backend = backend
+    vllm_config.parallel_config.is_moe_model = True
+    vllm_config.compilation_config.fast_moe_cold_start = False
+
+    with set_current_vllm_config(vllm_config):
+        ensure_model_parallel_initialized(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+        )
+
+        # Generate full weights (same seed on all ranks)
+        set_random_seed(42)
+        w13_full = (
+            torch.randn(
+                num_experts,
+                2 * intermediate_size,
+                hidden_size,
+                device=device,
+                dtype=dtype,
+            )
+            / 10
+        )
+        w2_full = (
+            torch.randn(
+                num_experts,
+                hidden_size,
+                intermediate_size,
+                device=device,
+                dtype=dtype,
+            )
+            / 10
+        )
+
+        # Generate per-rank input (different per rank)
+        set_random_seed(100 + rank)
+        hidden_states = (
+            torch.randn(
+                M,
+                hidden_size,
+                device=device,
+                dtype=dtype,
+            )
+            / 10
+        )
+        router_logits = (
+            torch.randn(
+                M,
+                num_experts,
+                device=device,
+                dtype=dtype,
+            )
+            / 10
+        )
+
+        # Reference output using all experts locally
+        topk_weights, topk_ids, _ = fused_topk(
+            hidden_states,
+            router_logits.float(),
+            topk,
+            renormalize=True,
+        )
+        ref_output = torch_moe_ref(
+            hidden_states,
+            w13_full,
+            w2_full,
+            topk_ids,
+            topk_weights,
+        )
+
+        # Create FusedMoE layer
+        fml = FusedMoE(
+            num_experts=num_experts,
+            top_k=topk,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            prefix=f"test_bf16_{rank}",
+            activation="silu",
+            is_act_and_mul=True,
+            params_dtype=dtype,
+            reduce_results=False,
+        )
+        fml = fml.to(device)
+
+        # Fill local expert weights from the full set
+        ep_rank = fml.moe_parallel_config.ep_rank
+        n_local = fml.local_num_experts
+        start = ep_rank * n_local
+        end = start + n_local
+        fml.w13_weight.data.copy_(w13_full[start:end])
+        fml.w2_weight.data.copy_(w2_full[start:end])
+
+        # Process weights and init kernel
+        fml.quant_method.process_weights_after_loading(fml)
+        fml.maybe_init_modular_kernel()
+
+        # Forward
+        num_tokens_across_dp = torch.tensor(
+            [M] * world_size,
+            dtype=torch.int,
+            device="cpu",
+        )
+        with set_forward_context(
+            None,
+            vllm_config,
+            num_tokens=M,
+            num_tokens_across_dp=num_tokens_across_dp,
+        ):
+            output = fml(hidden_states, router_logits)
+
+        torch.testing.assert_close(ref_output, output, atol=5e-2, rtol=5e-2)
+
+
+BACKENDS = [
+    "allgather_reducescatter",
+    "deepep_high_throughput",
+    "deepep_low_latency",
+]
+
+BF16_SHAPES = [
+    (16, 2048, 512),
+    (64, 4096, 1024),
+]
+
+
+@pytest.mark.parametrize("backend", BACKENDS)
+@pytest.mark.parametrize("m,hidden_size,intermediate_size", BF16_SHAPES)
+@pytest.mark.parametrize("num_experts,topk", [(8, 2)])
+@multi_gpu_test(num_gpus=2)
+def test_fused_moe_ep_dp(
+    backend: str,
+    m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    topk: int,
+):
+    if (
+        backend in ("deepep_high_throughput", "deepep_low_latency")
+        and not has_deep_ep()
+    ):
+        pytest.skip("DeepEP not available")
+
+    _distributed_run(
+        _worker_bf16,
+        2,
+        backend,
+        num_experts,
+        topk,
+        hidden_size,
+        intermediate_size,
+        m,
+    )
+
+
+# ---------------------------------------------------------------------------
+# NVFP4 + DP+EP test (CuTeDSL experts + DeepEP LL)
+# ---------------------------------------------------------------------------
+
+
+def _worker_nvfp4(
+    env: dict[str, str],
+    world_size: int,
+    num_experts: int,
+    topk: int,
+    hidden_size: int,
+    intermediate_size: int,
+    M: int,
+):
+    dtype = torch.bfloat16
+    backend = "deepep_low_latency"
+    rank, device = _init_worker(env)
+    init_workspace_manager(device)
+
+    vllm_config = VllmConfig()
+    vllm_config.parallel_config.data_parallel_size = world_size
+    vllm_config.parallel_config.data_parallel_rank = rank
+    vllm_config.parallel_config.enable_expert_parallel = True
+    vllm_config.parallel_config.all2all_backend = backend
+    vllm_config.parallel_config.is_moe_model = True
+    vllm_config.compilation_config.fast_moe_cold_start = False
+
+    with set_current_vllm_config(vllm_config):
+        ensure_model_parallel_initialized(
+            tensor_model_parallel_size=1,
+            pipeline_model_parallel_size=1,
+        )
+
+        # Number of local experts for this rank
+        num_local_experts = num_experts // world_size
+
+        # Create FusedMoE layer with NVFP4 quant config
+        quant_config = ModelOptNvFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            kv_cache_quant_algo=None,
+            exclude_modules=[],
+        )
+        fml = FusedMoE(
+            num_experts=num_experts,
+            top_k=topk,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            prefix=f"test_nvfp4_{rank}",
+            activation="silu",
+            is_act_and_mul=True,
+            params_dtype=dtype,
+            reduce_results=False,
+            quant_config=quant_config,
+        )
+
+        # Register NVFP4 weight parameters
+        nvfp4_method = ModelOptNvFp4FusedMoE(quant_config, fml)
+        nvfp4_method.create_weights(
+            fml,
+            num_local_experts,
+            hidden_size,
+            intermediate_size,
+            params_dtype=torch.uint8,
+            global_num_experts=num_experts,
+        )
+        fml = fml.to(device)
+
+        # Generate quantized weights (same seed on all ranks)
+        set_random_seed(42)
+        w1_q, w2_q, _ = make_test_quant_config(
+            num_local_experts,
+            intermediate_size,
+            hidden_size,
+            in_dtype=dtype,
+            quant_dtype="nvfp4",
+            block_shape=None,
+            per_act_token_quant=False,
+        )
+
+        # Fill local expert weights and scales
+        fml.w13_weight.data = w1_q
+        fml.w2_weight.data = w2_q
+        fml.w2_input_scale.data = torch.randn_like(fml.w2_input_scale.data) / 5
+        fml.w13_input_scale.data = torch.randn_like(fml.w13_input_scale.data) / 5
+        fml.w2_weight_scale_2.data = torch.randn_like(fml.w2_weight_scale_2.data) / 5
+        fml.w13_weight_scale_2.data = torch.randn_like(fml.w13_weight_scale_2.data) / 5
+        fml.w2_weight_scale.data = (
+            torch.randn(fml.w2_weight_scale.data.shape, device=device) / 5
+        ).to(fml.w2_weight_scale.data.dtype)
+        fml.w13_weight_scale.data = (
+            torch.randn(fml.w13_weight_scale.data.shape, device=device) / 5
+        ).to(fml.w13_weight_scale.data.dtype)
+
+        # Dequantize weights BEFORE process_weights_after_loading, which
+        # transforms scales into kernel-specific format.
+        w13_deq = torch.empty(
+            num_local_experts,
+            2 * intermediate_size,
+            hidden_size,
+            device=device,
+            dtype=dtype,
+        )
+        w2_deq = torch.empty(
+            num_local_experts,
+            hidden_size,
+            intermediate_size,
+            device=device,
+            dtype=dtype,
+        )
+        for idx in range(num_local_experts):
+            w13_deq[idx] = dequantize_nvfp4_to_dtype(
+                fml.w13_weight.data[idx],
+                fml.w13_weight_scale.data[idx],
+                fml.w13_weight_scale_2.data[idx, 0],
+                dtype,
+                device,
+            )
+            w2_deq[idx] = dequantize_nvfp4_to_dtype(
+                fml.w2_weight.data[idx],
+                fml.w2_weight_scale.data[idx],
+                fml.w2_weight_scale_2.data[idx],
+                dtype,
+                device,
+            )
+
+        # Now transform weights for the kernel
+        nvfp4_method.process_weights_after_loading(fml)
+        fml.maybe_init_modular_kernel()
+
+        # Generate per-rank input (different per rank)
+        set_random_seed(100 + rank)
+        hidden_states = (
+            torch.randn(
+                M,
+                hidden_size,
+                device=device,
+                dtype=dtype,
+            )
+            / 10
+        )
+        router_logits = (
+            torch.randn(
+                M,
+                num_experts,
+                device=device,
+                dtype=dtype,
+            )
+            / 10
+        )
+
+        # Build full-expert dequantized weights for reference
+        # (allgather across ranks)
+        w13_full = torch.zeros(
+            num_experts,
+            2 * intermediate_size,
+            hidden_size,
+            device=device,
+            dtype=dtype,
+        )
+        w2_full = torch.zeros(
+            num_experts,
+            hidden_size,
+            intermediate_size,
+            device=device,
+            dtype=dtype,
+        )
+        ep_rank = fml.moe_parallel_config.ep_rank
+        start = ep_rank * num_local_experts
+        end = start + num_local_experts
+        w13_full[start:end] = w13_deq
+        w2_full[start:end] = w2_deq
+        torch.distributed.all_reduce(w13_full)
+        torch.distributed.all_reduce(w2_full)
+
+        # Reference: quantize activations, dequantize, run torch_moe_ref
+        a_global_scale = (
+            (FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX)
+            / torch.amax(hidden_states.abs().flatten(), dim=-1)
+        ).to(torch.float32)
+        a_fp4, a_scale = ops.scaled_fp4_quant(hidden_states, a_global_scale)
+        a_deq = dequantize_nvfp4_to_dtype(
+            a_fp4,
+            a_scale,
+            a_global_scale,
+            dtype,
+            device,
+        )
+
+        topk_weights, topk_ids, _ = fused_topk(
+            hidden_states,
+            router_logits.float(),
+            topk,
+            renormalize=True,
+        )
+        ref_output = torch_moe_ref(
+            a_deq,
+            w13_full,
+            w2_full,
+            topk_ids,
+            topk_weights,
+        )
+
+        # Forward
+        num_tokens_across_dp = torch.tensor(
+            [M] * world_size,
+            dtype=torch.int,
+            device="cpu",
+        )
+        with set_forward_context(
+            None,
+            vllm_config,
+            num_tokens=M,
+            num_tokens_across_dp=num_tokens_across_dp,
+        ):
+            output = fml(hidden_states, router_logits)
+
+        torch.testing.assert_close(ref_output, output, atol=1e-1, rtol=1e-1)
+
+
+NVFP4_SHAPES = [
+    # hidden_size must be in DeepEP LL SUPPORTED_HIDDEN_SIZES
+    (16, 2048, 256),
+    (64, 4096, 512),
+]
+
+
+@pytest.mark.parametrize("m,hidden_size,intermediate_size", NVFP4_SHAPES)
+@pytest.mark.parametrize("num_experts,topk", [(8, 2)])
+@multi_gpu_test(num_gpus=2)
+def test_fused_moe_ep_dp_nvfp4(
+    m: int,
+    hidden_size: int,
+    intermediate_size: int,
+    num_experts: int,
+    topk: int,
+):
+    if not current_platform.has_device_capability(100):
+        pytest.skip("NVFP4 CuTeDSL requires SM100+ (Blackwell)")
+
+    if not has_deep_ep():
+        pytest.skip("DeepEP not available")
+
+    _distributed_run(
+        _worker_nvfp4,
+        2,
+        num_experts,
+        topk,
+        hidden_size,
+        intermediate_size,
+        m,
+        extra_env={
+            "VLLM_USE_FLASHINFER_MOE_FP4": "1",
+            "VLLM_FLASHINFER_MOE_BACKEND": "cutedsl",
+        },
+    )


### PR DESCRIPTION
## Summary
Add layer-level FusedMoE tests for DP+EP with multiple all-to-all backends.

- BF16 test: `allgather_reducescatter`, DeepEP HT, DeepEP LL
- NVFP4 test: CuteDSL experts (masked_gemm) + DeepEP LL (SM100+ only)
- Both validate distributed output against a single-GPU PyTorch reference

## Motivation
No existing test exercises FusedMoE through the full layer with distributed dispatch/combine. For example, https://github.com/vllm-project/vllm/issues/31918 (CuteDSL missing from global scale factor list, 4% GSM8K accuracy with DeepSeek-R1 NVFP4) was found manually via lm_eval and would have been caught immediately by the numerical comparison in this test.

## Approach
- Worker entry via `parallel_launch_with_config` from `tests.kernels.moe.modular_kernel_tools.parallel_utils` — same helper used by `test_moe_layer.py`; sets up WORLD / TP / PP / DP / EP groups consistently.
- Backend parametrized at the pytest level (one spawn per a2a backend); shapes batched inside the worker with a barrier + cache clean between configs.
- CuteDSL selected via `kernel_config.moe_backend = "flashinfer_cutedsl"` (config, not env vars).
- `weight_scale_2` stored as `1/w_gs` to match the kernel's `g_alphas = a_scale * weight_scale_2` dequant convention.
- Shape-aware NVFP4 tolerance `1e-1 + k*5e-4` (matches `test_moe_layer.py` modelopt_fp4).
- BF16 `hidden_size` values chosen from `DeepEPLLPrepareAndFinalize.SUPPORTED_HIDDEN_SIZES` so the LL backend does not round hidden up and mismatch the weight tensor.
- `scheduler_config.max_num_batched_tokens = 128` so `moe.max_num_tokens` fits under the DeepEP LL `nvshmem_qp_depth` assertion.

## CI
- Registered in `.buildkite/test_areas/kernels.yaml` as a dedicated **optional nightly** job `Kernels FusedMoE DP+EP Test (2 B200s)`.
- Runtime: ~95 s per pytest run on 2x B200 (verified).

## Test plan
- [x] `pytest -v -s tests/kernels/moe/test_fused_moe_ep_dp.py` on 2x B200 (GB200 NVL72) — 3 consecutive runs, 4/4 passing, ~95 s each.
- [x] NVFP4 test guarded by `current_platform.has_device_capability(100)` (skips on non-SM100 hardware).
- [x] BF16 test guarded by `has_deep_ep()` for DeepEP backends; `allgather_reducescatter` remains available when DeepEP is not built in.