### PR TITLE
[Bugfix] Add batched experts auto-upgrade for VLLM_FLASHINFER_MOE_BACKEND path

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -228,6 +228,12 @@ def select_nvfp4_moe_backend(
         elif envs.is_set("VLLM_FLASHINFER_MOE_BACKEND"):
             # If user is explicit about backend, validate it.
             backend = fi_2_vllm_backend_map[get_flashinfer_moe_backend()]
+            # For batched activation format, use batched variant if available.
+            if (
+                activation_format == mk.FusedMoEActivationFormat.BatchedExperts
+                and backend == NvFp4MoeBackend.FLASHINFER_CUTEDSL
+            ):
+                backend = NvFp4MoeBackend.FLASHINFER_CUTEDSL_BATCHED
             return _return_or_raise(
                 backend, config, weight_key, activation_key, activation_format
             )


### PR DESCRIPTION
## Summary

- PR #38251 added auto-upgrade logic to select `FLASHINFER_CUTEDSL_BATCHED` when the activation format is `BatchedExperts` and the user requests `FLASHINFER_CUTEDSL`, but only for the `moe_backend` config path (line 212-217).
- The same upgrade was missing from the `VLLM_FLASHINFER_MOE_BACKEND` environment variable path (line 228-233), causing a `ValueError` when using DeepEP Low-Latency with `VLLM_FLASHINFER_MOE_BACKEND=masked_gemm`.
- This PR adds the identical auto-upgrade logic to the env var path, making it consistent with the config path.

## Error reproduced

```
ValueError: NvFp4 MoE backend 'FLASHINFER_CUTEDSL' does not support the deployment configuration since kernel does not support ('batched_experts',) activation format.
```

Triggered when:
- `VLLM_USE_FLASHINFER_MOE_FP4=1`
- `VLLM_FLASHINFER_MOE_BACKEND=masked_gemm` (maps to `CUTEDSL`)
- DeepEP Low-Latency enabled (`use_deepep_ll_kernels=True`, requiring `BatchedExperts` format)

## Test plan

- [ ] Verify decode with `VLLM_FLASHINFER_MOE_BACKEND=masked_gemm` + DeepEP LL no longer crashes
- [ ] Verify the selected backend is `FLASHINFER_CUTEDSL_BATCHED` in logs
- [ ] Existing tests pass (no regression on standard activation format path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI assistance was used. This is not duplicating an existing PR — it fixes an omission in #38251.