### PR TITLE
FIX: support language_model.backbone naming in NemotronH Nano VL quantization config

### DIFF
--- a/vllm/model_executor/models/nano_nemotron_vl.py
+++ b/vllm/model_executor/models/nano_nemotron_vl.py
@@ -37,6 +37,7 @@ from vllm.model_executor.models.nemotron_h import NemotronHForCausalLM
 from vllm.model_executor.models.parakeet import ParakeetExtractor, ProjectedParakeet
 from vllm.model_executor.models.radio import RadioModel, calc_seq_lens
 from vllm.model_executor.models.utils import (
+    WeightsMapper,
     init_vllm_registered_model,
     maybe_prefix,
 )
@@ -902,6 +903,12 @@ class NemotronH_Nano_VL_V2(
 ):
     requires_sequential_video_encoding = True
     """Temporarily needed for dynamic res video w/ conv3d, doesn't support bs>1 yet"""
+
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "language_model.backbone": "language_model.model",
+        },
+    )
 
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:


### PR DESCRIPTION
Models quantized with ModelOpt may ship `config.json` with` language_model.backbone.layers.* `paths in quantized_layers, but vLLM internally renames backbone to model (via NemotronHForCausalLM's WeightsMapper). This mismatch causes _resolve_quant_algo lookups to fail at runtime.

Adds an `hf_to_vllm_mapper` to `NemotronH_Nano_VL_V2` that remaps language_model.backbone → language_model.model in the quantization config, matching the existing weight-name remapping in the inner language model.