### PR TITLE
[Bugfix] turboquant FP8 store crash with bf16 models on Ampere GPUs

### DIFF
--- a/vllm/v1/attention/ops/triton_turboquant_store.py
+++ b/vllm/v1/attention/ops/triton_turboquant_store.py
@@ -186,7 +186,10 @@ def _tq_fused_store_fp8(
     d_offs = tl.arange(0, BLOCK_D)
     d_mask = d_offs < D
     k_vals = tl.load(Key_ptr + base + d_offs, mask=d_mask, other=0.0)
-    k_fp8 = k_vals.to(tl.float8e4b15) if FP8_E4B15 else k_vals.to(tl.float8e4nv)
+    if FP8_E4B15:
+        k_fp8 = k_vals.to(tl.float16).to(tl.float8e4b15)
+    else:
+        k_fp8 = k_vals.to(tl.float8e4nv)
     k_bytes = k_fp8.to(tl.uint8, bitcast=True)
     tl.store(KV_cache_ptr + slot_base + d_offs, k_bytes, mask=d_mask)
 


### PR DESCRIPTION

## Purpose

Fix a Triton compilation error in the TurboQuant FP8 KV-store path.

The failure occurs while compiling `_tq_fused_store_fp8` at the direct FP8 cast


## Test Plan
Reproduced the Triton compilation failure on the TurboQuant FP8 KV-store path.

## Test Result
Observed the following error before this change:
```
triton.compiler.errors.CompilationError: at 45:12:
    k_fp8 = k_vals.to(tl.float8e4b15) if FP8_E4B15 else k_vals.to(tl.float8e4nv)
            ^
...
  File ".../triton/language/extra/cuda/utils.py", line 94, in convert_custom_float8
    assert arg.type.scalar.is_fp16() or arg.type.scalar.is_fp32()
AssertionError
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

