### PR TITLE
fix: create DeepGEMM JIT cache directory before import

### DIFF
--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -113,6 +113,23 @@ torch._inductor.config.compile_threads = 1
 # in the environment.
 os.environ.setdefault("TRITON_CACHE_AUTOTUNING", "1")
 
+# Ensure DG_JIT_CACHE_DIR is set and the directory exists before
+# deep_gemm is ever imported.  DeepGEMM's C++ _C.init() reads
+# this env var at import time; if the var is missing or the path
+# doesn't exist, it irreversibly falls back to in-memory JIT cache.
+if "DG_JIT_CACHE_DIR" not in os.environ:
+    _dg_cache = os.path.join(
+        os.path.expanduser(
+            os.environ.get(
+                "VLLM_CACHE_ROOT",
+                os.path.join(os.environ.get("XDG_CACHE_HOME", "~/.cache"), "vllm"),
+            )
+        ),
+        "deep_gemm",
+    )
+    os.environ["DG_JIT_CACHE_DIR"] = _dg_cache
+os.makedirs(os.environ["DG_JIT_CACHE_DIR"], exist_ok=True)
+
 # ===================================================
 # torch 2.9 Inductor PythonWrapperCodegen monkeypatch
 # ===================================================

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -128,7 +128,14 @@ if "DG_JIT_CACHE_DIR" not in os.environ:
         "deep_gemm",
     )
     os.environ["DG_JIT_CACHE_DIR"] = _dg_cache
-os.makedirs(os.environ["DG_JIT_CACHE_DIR"], exist_ok=True)
+try:
+    os.makedirs(os.environ["DG_JIT_CACHE_DIR"], exist_ok=True)
+except OSError:
+    logger.warning(
+        "Failed to create DeepGEMM JIT cache directory %s. "
+        "Falling back to in-memory JIT cache.",
+        os.environ["DG_JIT_CACHE_DIR"],
+    )
 
 # ===================================================
 # torch 2.9 Inductor PythonWrapperCodegen monkeypatch

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -203,6 +203,9 @@ def _lazy_init() -> None:
         os.environ[DEEP_GEMM_JIT_CACHE_ENV_NAME] = os.path.join(
             envs.VLLM_CACHE_ROOT, "deep_gemm"
         )
+    # Directory must exist before DeepGEMM's C++ init, otherwise it
+    # silently falls back to in-memory-only JIT cache.
+    os.makedirs(os.environ[DEEP_GEMM_JIT_CACHE_ENV_NAME], exist_ok=True)
 
     _dg = _import_deep_gemm()
     if _dg is None:

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -7,7 +7,6 @@ Users of vLLM should always import **only** these wrappers.
 
 import functools
 import importlib
-import os
 from collections.abc import Callable
 from enum import Enum
 from typing import Any, NoReturn
@@ -196,16 +195,6 @@ def _lazy_init() -> None:
 
     if not has_deep_gemm():
         return
-
-    # Set up deep_gemm cache path
-    DEEP_GEMM_JIT_CACHE_ENV_NAME = "DG_JIT_CACHE_DIR"
-    if not os.environ.get(DEEP_GEMM_JIT_CACHE_ENV_NAME, None):
-        os.environ[DEEP_GEMM_JIT_CACHE_ENV_NAME] = os.path.join(
-            envs.VLLM_CACHE_ROOT, "deep_gemm"
-        )
-    # Directory must exist before DeepGEMM's C++ init, otherwise it
-    # silently falls back to in-memory-only JIT cache.
-    os.makedirs(os.environ[DEEP_GEMM_JIT_CACHE_ENV_NAME], exist_ok=True)
 
     _dg = _import_deep_gemm()
     if _dg is None:


### PR DESCRIPTION
## Purpose

DeepGEMM's C++ `_C.init()` reads `DG_JIT_CACHE_DIR` at import time and irreversibly disables persistent JIT cache if the variable is unset or the directory doesn't exist. vLLM's `_lazy_init()` used to set the variable, but too late — `deep_gemm` may already be imported by model loading code (e.g. nvfp4 quantization).

Moved `DG_JIT_CACHE_DIR` setup and directory creation to `env_override.py`, which runs at `import vllm` time — before any `deep_gemm` import can happen.

## Test Result

Before fix:
```
vllm serve nvidia/Qwen3.5-397B-A17B-NVFP4 -tp 1 -pp 1 -dp 8 --enable-expert-parallel
```
Server logs flooded with:
```
(Worker_DP1_EP1 pid=3859804) 2026-04-15 16:42:29.058 DEBUG Persistent cache disabled, using in-memory JIT cache
```

After fix: same command, no such messages.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>
