### PR TITLE
[Nixl] Bump Nixl version to 0.10.1

### DIFF
--- a/requirements/kv_connectors.txt
+++ b/requirements/kv_connectors.txt
@@ -1,5 +1,5 @@
 lmcache >= 0.3.9
-nixl[cu13] >= 0.7.1, < 0.10.0 # Required for disaggregated prefill
-nixl-cu12 >= 0.7.1, < 0.10.0
-nixl-cu13 >= 0.7.1, < 0.10.0
+nixl[cu13] >= 0.7.1, <= 0.10.1 # Required for disaggregated prefill
+nixl-cu12 >= 0.7.1, <= 0.10.1
+nixl-cu13 >= 0.7.1, <= 0.10.1
 mooncake-transfer-engine >= 0.3.8


### PR DESCRIPTION
As highlighted here https://github.com/vllm-project/vllm/pull/39797#issuecomment-4252561348 we're having some issues updating to nixl 1.0 due to the reported bug listed above.

I am upping the patch version for now, given that @ZhanqiuHu recently addressed issues we've had with nixl-cu13 pinning version on >=0.10 (https://github.com/vllm-project/vllm/issues/36676).