### PR TITLE
[Bugfix] DeepEP LL: pass use_fabric for MNNVL cross-node NVLink

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -330,7 +330,7 @@ WORKDIR /workspace
 # Build DeepEP wheels
 COPY tools/ep_kernels/install_python_libraries.sh /tmp/install_python_libraries.sh
 # Defaults moved here from tools/ep_kernels/install_python_libraries.sh for centralized version management
-ARG DEEPEP_COMMIT_HASH=73b6ea4
+ARG DEEPEP_COMMIT_HASH=9249c25
 ARG NVSHMEM_VER
 RUN --mount=type=cache,target=/root/.cache/uv \
     mkdir -p /tmp/ep_kernels_workspace/dist && \

--- a/docker/versions.json
+++ b/docker/versions.json
@@ -53,7 +53,7 @@
       "default": "cuda"
     },
     "DEEPEP_COMMIT_HASH": {
-      "default": "73b6ea4"
+      "default": "9249c25"
     },
     "GIT_REPO_CHECK": {
       "default": "0"

--- a/tools/ep_kernels/install_python_libraries.sh
+++ b/tools/ep_kernels/install_python_libraries.sh
@@ -8,7 +8,7 @@ set -ex
 #   --nvshmem-ver <ver>  NVSHMEM version 
 
 CUDA_HOME=${CUDA_HOME:-/usr/local/cuda}
-DEEPEP_COMMIT_HASH=${DEEPEP_COMMIT_HASH:-"73b6ea4"}
+DEEPEP_COMMIT_HASH=${DEEPEP_COMMIT_HASH:-"9249c25"}
 NVSHMEM_VER=${NVSHMEM_VER:-"3.3.24"}  # Default supports both CUDA 12 and 13
 WORKSPACE=${WORKSPACE:-$(pwd)/ep_kernels_workspace}
 MODE=${MODE:-install}

--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -414,9 +414,11 @@ class DeepEPLLAll2AllManager(DeepEPAll2AllManagerBase):
             num_qps_per_rank=num_qps_per_rank,
         )
         if not current_platform.is_rocm():
+            use_mnnvl = envs.VLLM_DEEPEP_LOW_LATENCY_USE_MNNVL
             kwargs.update(
                 allow_nvlink_for_low_latency_mode=True,
-                allow_mnnvl=envs.VLLM_DEEPEP_LOW_LATENCY_USE_MNNVL,
+                allow_mnnvl=use_mnnvl,
+                use_fabric=use_mnnvl,
                 explicitly_destroy=True,
             )
         return kwargs


### PR DESCRIPTION
## Summary

- Pass `use_fabric=True` to `deep_ep.Buffer` when MNNVL is enabled, so cross-node NVLink memory sharing uses the cuMem fabric API instead of `cudaIpcOpenMemHandle`
- Bump `DEEPEP_COMMIT_HASH` from `73b6ea4` to `9249c25` ([deepseek-ai/DeepEP#217](https://github.com/deepseek-ai/DeepEP/pull/217)) which adds the `use_fabric` parameter

## Motivation

When `VLLM_DEEPEP_LOW_LATENCY_USE_MNNVL=1`, the NVL domain spans multiple physical nodes (e.g. GB200 NVL72). DeepEP `Buffer` defaults to `cudaIpcOpenMemHandle` for IPC, which only works within a single physical node. Cross-node NVLink memory sharing requires the cuMem fabric API (`cuMemExportToShareableHandle` / `cuMemImportFromShareableHandle`), activated by `use_fabric=True`.

Without this fix, `Buffer.sync()` raises:
```
RuntimeError: Failed: CUDA error .../deep_ep.cpp:226 'invalid resource handle'
```

## Test plan
- [x] Verified on 4-node GB200 MNNVL decode cluster (DP=16, TP=1) serving Kimi-K2.5-NVFP4 with DeepEP Low-Latency all2all
- [x] Confirmed `Buffer.sync()` no longer raises `invalid resource handle`
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)