### PR TITLE
fix: default ChatMessage.tool_calls to None instead of empty list

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -58,7 +58,7 @@ class ChatMessage(OpenAIBaseModel):
     annotations: OpenAIAnnotation | None = None
     audio: OpenAIChatCompletionAudio | None = None
     function_call: FunctionCall | None = None
-    tool_calls: list[ToolCall] = Field(default_factory=list)
+    tool_calls: list[ToolCall] | None = None
 
     # vLLM-specific fields that are not in OpenAI spec
     reasoning: str | None = None

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -60,6 +60,12 @@ class ChatMessage(OpenAIBaseModel):
     function_call: FunctionCall | None = None
     tool_calls: list[ToolCall] | None = None
 
+    @model_validator(mode="after")
+    def _validate_tool_calls(self) -> "ChatMessage":
+        if self.tool_calls is not None and not self.tool_calls:
+            self.tool_calls = None
+        return self
+
     # vLLM-specific fields that are not in OpenAI spec
     reasoning: str | None = None
 


### PR DESCRIPTION
`ChatMessage.tool_calls` currently defaults to `[]` (empty list) via `Field(default_factory=list)`. 

This breaks agentic workflows - In these workflows, the model response is appended to conversation history and sent back for the next step. Downstream parsers (e.g [BFCL](https://github.com/ShishirPatil/gorilla/blob/main/berkeley-function-call-leaderboard/bfcl_eval/model_handler/api_inference/openai_completion.py#L109)) that iterate over `tool_calls` in a `try/except` rely on `None` to `throw` and fall back to reading `message.content`. With `[]`, the try succeeds silently and returns an empty list as the model response instead.

Test plan
Tested with BFCL (Berkeley Function Calling Leaderboard) agentic evaluations across multiple models (Nemotron-3-Super-120B, GPT-OSS-120B, Qwen3.5-397B, Llama-3.3-70B) — agentic categories scored 0% before the fix