### PR TITLE
[FlashAttention] Don't overwrite `flash_attn_interface.py` when installing precompiled

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -350,21 +350,17 @@ class cmake_build_ext(build_ext):
             bundle_tcmalloc(self.build_lib)
 
         # copy vllm/vllm_flash_attn/**/*.py from self.build_lib to current
-        # directory so that they can be included in the editable build.
-        # Skip __init__.py and flash_attn_interface.py which are
-        # source-controlled in vllm (matching the cmake install exclusions).
+        # directory so that they can be included in the editable build
         import glob
 
-        vllm_fa_source_controlled = {"__init__.py", "flash_attn_interface.py"}
         files = glob.glob(
             os.path.join(self.build_lib, "vllm", "vllm_flash_attn", "**", "*.py"),
             recursive=True,
         )
         for file in files:
-            rel_path = file.split("vllm/vllm_flash_attn/")[-1]
-            if rel_path in vllm_fa_source_controlled:
-                continue
-            dst_file = os.path.join("vllm/vllm_flash_attn", rel_path)
+            dst_file = os.path.join(
+                "vllm/vllm_flash_attn", file.split("vllm/vllm_flash_attn/")[-1]
+            )
             print(f"Copying {file} to {dst_file}")
             os.makedirs(os.path.dirname(dst_file), exist_ok=True)
             self.copy_file(file, dst_file)

--- a/setup.py
+++ b/setup.py
@@ -350,17 +350,21 @@ class cmake_build_ext(build_ext):
             bundle_tcmalloc(self.build_lib)
 
         # copy vllm/vllm_flash_attn/**/*.py from self.build_lib to current
-        # directory so that they can be included in the editable build
+        # directory so that they can be included in the editable build.
+        # Skip __init__.py and flash_attn_interface.py which are
+        # source-controlled in vllm (matching the cmake install exclusions).
         import glob
 
+        vllm_fa_source_controlled = {"__init__.py", "flash_attn_interface.py"}
         files = glob.glob(
             os.path.join(self.build_lib, "vllm", "vllm_flash_attn", "**", "*.py"),
             recursive=True,
         )
         for file in files:
-            dst_file = os.path.join(
-                "vllm/vllm_flash_attn", file.split("vllm/vllm_flash_attn/")[-1]
-            )
+            rel_path = file.split("vllm/vllm_flash_attn/")[-1]
+            if rel_path in vllm_fa_source_controlled:
+                continue
+            dst_file = os.path.join("vllm/vllm_flash_attn", rel_path)
             print(f"Copying {file} to {dst_file}")
             os.makedirs(os.path.dirname(dst_file), exist_ok=True)
             self.copy_file(file, dst_file)

--- a/setup.py
+++ b/setup.py
@@ -697,6 +697,12 @@ class precompiled_wheel_utils:
                 flash_attn_regex = re.compile(
                     r"vllm/vllm_flash_attn/(?:[^/.][^/]*/)*(?!\.)[^/]*\.py"
                 )
+                # __init__.py and flash_attn_interface.py are source-controlled
+                # in vllm and should not be overwritten (matches cmake exclusions)
+                flash_attn_files_to_skip = {
+                    "vllm/vllm_flash_attn/__init__.py",
+                    "vllm/vllm_flash_attn/flash_attn_interface.py",
+                }
                 triton_kernels_regex = re.compile(
                     r"vllm/third_party/triton_kernels/(?:[^/.][^/]*/)*(?!\.)[^/]*\.py"
                 )
@@ -709,7 +715,11 @@ class precompiled_wheel_utils:
                     filter(lambda x: x.filename in files_to_copy, wheel.filelist)
                 )
                 file_members += list(
-                    filter(lambda x: flash_attn_regex.match(x.filename), wheel.filelist)
+                    filter(
+                        lambda x: flash_attn_regex.match(x.filename)
+                        and x.filename not in flash_attn_files_to_skip,
+                        wheel.filelist,
+                    )
                 )
                 file_members += list(
                     filter(


### PR DESCRIPTION


## Purpose
When installing with `VLLM_USE_PRECOMPILED=1`, we should skip copying `flash_attn_interface.py`, which is now source-controlled in vLLM. This mimics similar logic in `vllm_flash_attn.cmake`

## Test Plan
1. Make local changes to `flash_attn_interface.py`
2. Run `VLLM_USE_PRECOMPILED=1 uv pip install -e . --no-build-isolation`

## Test Result
main: Changes to `flash_attn_interface.py` are overwritten
PR: Changes to `flash_attn_interface.py` remain

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

