### PR TITLE
[Performance]Reduce cpu launch overheads for MultiGroupBlockTable and attn_meta_data handling on Blackwell

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -257,6 +257,7 @@ if TYPE_CHECKING:
     VLLM_NIXL_EP_MAX_NUM_RANKS: int = 32
     VLLM_XPU_ENABLE_XPU_GRAPH: bool = False
     VLLM_LORA_ENABLE_DUAL_STREAM: bool = False
+    VLLM_BATCH_PROCESS_ATTNMETADATA: bool = False
 
 
 def get_default_cache_root():
@@ -1706,6 +1707,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Whether to enable dual cuda streams for LoRA computation
     "VLLM_LORA_ENABLE_DUAL_STREAM": lambda: bool(
         int(os.getenv("VLLM_LORA_ENABLE_DUAL_STREAM", "0"))
+    ),
+    "VLLM_BATCH_PROCESS_ATTNMETADATA": lambda: bool(
+        int(os.getenv("VLLM_BATCH_PROCESS_ATTNMETADATA", "0"))
     ),
 }
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -280,6 +280,7 @@ if TYPE_CHECKING:
     VLLM_LORA_ENABLE_DUAL_STREAM: bool = False
     VLLM_GPU_NIC_PCIE_MAPPING: str = ""
     VLLM_NIC_SELECTION_VARS: str = ""
+    VLLM_BATCH_PROCESS_ATTNMETADATA: bool = False
 
 
 def get_default_cache_root():
@@ -1982,6 +1983,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Each entry is VAR_NAME or VAR_NAME:<suffix> (suffix appended to
     # RDMA device name). Must be set together with VLLM_GPU_NIC_PCIE_MAPPING.
     "VLLM_NIC_SELECTION_VARS": lambda: os.getenv("VLLM_NIC_SELECTION_VARS", ""),
+    "VLLM_BATCH_PROCESS_ATTNMETADATA": lambda: bool(
+        int(os.getenv("VLLM_BATCH_PROCESS_ATTNMETADATA", "0"))
+    ),
 }
 
 

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -520,7 +520,7 @@ def split_decodes_and_prefills(
     max_query_len = common_attn_metadata.max_query_len
     num_reqs = common_attn_metadata.num_reqs
     num_tokens = common_attn_metadata.num_actual_tokens
-    query_start_loc = common_attn_metadata.query_start_loc_cpu
+    query_start_loc_list = common_attn_metadata.query_start_loc_cpu.tolist()
 
     if (
         max_query_len <= decode_threshold
@@ -529,8 +529,8 @@ def split_decodes_and_prefills(
     ):
         return num_reqs, 0, num_tokens, 0
 
-    query_lens = query_start_loc[1:] - query_start_loc[:-1]
-    if query_lens[0].item() > decode_threshold:
+    query_lens_list = [query_start_loc_list[i+1] - query_start_loc_list[i] for i in range(len(query_start_loc_list) - 1)]
+    if query_lens_list[0] > decode_threshold:
         # first request is not decode, so no decode requests
         return 0, num_reqs, 0, num_tokens
 
@@ -538,23 +538,24 @@ def split_decodes_and_prefills(
         # check if we are in a padded uniform batch; this is used for full-CGs, some
         # requests may have a query length of 0 but since they are padding its fine
         # to treat them as decodes (ensures num_decodes matches the captured size)
-        if torch.all((query_lens == query_lens[0]) | (query_lens == 0)):
+        first_len = query_lens_list[0]
+        if all(l == first_len or l == 0 for l in query_lens_list):
             return num_reqs, 0, num_tokens, 0  # all decodes
-        is_prefill = query_lens != query_lens[0]
+        is_prefill_list = [length != first_len for length in query_lens_list]
     else:
-        is_prefill = query_lens > decode_threshold
+        is_prefill_list = [length > decode_threshold for length in query_lens_list]
 
     if not treat_short_extends_as_decodes:
         assert common_attn_metadata.is_prefilling is not None
-        is_prefill |= common_attn_metadata.is_prefilling
+        is_prefill_list |= common_attn_metadata.is_prefilling
 
-    if not torch.any(is_prefill):
+    if not any(is_prefill_list):
         return num_reqs, 0, num_tokens, 0
 
-    first_prefill = is_prefill.int().argmax(dim=-1).item()
+    first_prefill = is_prefill_list.index(True)
     num_decodes = first_prefill
     num_prefills = num_reqs - num_decodes
-    num_decode_tokens = query_start_loc[first_prefill].item()
+    num_decode_tokens = query_start_loc_list[first_prefill]
     num_prefill_tokens = num_tokens - num_decode_tokens
     return (num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens)
 

--- a/vllm/v1/attention/backends/utils.py
+++ b/vllm/v1/attention/backends/utils.py
@@ -563,7 +563,7 @@ def split_decodes_and_prefills(
     max_query_len = common_attn_metadata.max_query_len
     num_reqs = common_attn_metadata.num_reqs
     num_tokens = common_attn_metadata.num_actual_tokens
-    query_start_loc = common_attn_metadata.query_start_loc_cpu
+    query_start_loc_list = common_attn_metadata.query_start_loc_cpu.tolist()
 
     if (
         max_query_len <= decode_threshold
@@ -572,8 +572,8 @@ def split_decodes_and_prefills(
     ):
         return num_reqs, 0, num_tokens, 0
 
-    query_lens = query_start_loc[1:] - query_start_loc[:-1]
-    if query_lens[0].item() > decode_threshold:
+    query_lens_list = [query_start_loc_list[i+1] - query_start_loc_list[i] for i in range(len(query_start_loc_list) - 1)]
+    if query_lens_list[0] > decode_threshold:
         # first request is not decode, so no decode requests
         return 0, num_reqs, 0, num_tokens
 
@@ -581,23 +581,25 @@ def split_decodes_and_prefills(
         # check if we are in a padded uniform batch; this is used for full-CGs, some
         # requests may have a query length of 0 but since they are padding its fine
         # to treat them as decodes (ensures num_decodes matches the captured size)
-        if torch.all((query_lens == query_lens[0]) | (query_lens == 0)):
+        first_len = query_lens_list[0]
+        if all(l == first_len or l == 0 for l in query_lens_list):
             return num_reqs, 0, num_tokens, 0  # all decodes
-        is_prefill = query_lens != query_lens[0]
+        is_prefill_list = [length != first_len for length in query_lens_list]
     else:
-        is_prefill = query_lens > decode_threshold
+        is_prefill_list = [length > decode_threshold for length in query_lens_list]
 
     if not treat_short_extends_as_decodes:
         assert common_attn_metadata.is_prefilling is not None
-        is_prefill |= common_attn_metadata.is_prefilling
+        is_prefill_list = [a or b for a, b in zip(is_prefill_list,
+                                                common_attn_metadata.is_prefilling.tolist())]
 
-    if not torch.any(is_prefill):
+    if not any(is_prefill_list):
         return num_reqs, 0, num_tokens, 0
 
-    first_prefill = is_prefill.int().argmax(dim=-1).item()
+    first_prefill = is_prefill_list.index(True)
     num_decodes = first_prefill
     num_prefills = num_reqs - num_decodes
-    num_decode_tokens = query_start_loc[first_prefill].item()
+    num_decode_tokens = query_start_loc_list[first_prefill]
     num_prefill_tokens = num_tokens - num_decode_tokens
     return (num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens)
 

--- a/vllm/v1/worker/block_table.py
+++ b/vllm/v1/worker/block_table.py
@@ -11,6 +11,7 @@ from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.cp_utils import get_total_cp_world_size
+import vllm.envs as envs
 
 logger = init_logger(__name__)
 
@@ -273,6 +274,20 @@ class MultiGroupBlockTable:
             )
         ]
 
+        self.num_groups = len(self.block_tables)
+        self.src_ptrs_gpu = torch.zeros(self.num_groups, device=device, dtype=torch.int64)
+        self.dst_ptrs_gpu = torch.zeros(self.num_groups, device=device, dtype=torch.int64)
+        self.sm_ptrs_gpu = torch.zeros(self.num_groups, device=device, dtype=torch.int64)
+        src_ptrs = [bt.block_table.cpu.data_ptr() for bt in self.block_tables]
+        dst_ptrs = [bt.block_table.gpu.data_ptr() for bt in self.block_tables]
+        sm_ptrs = [bt.slot_mapping.gpu.data_ptr() for bt in self.block_tables]
+        self.src_ptrs_gpu.copy_(torch.tensor(src_ptrs, dtype=torch.int64))
+        self.dst_ptrs_gpu.copy_(torch.tensor(dst_ptrs, dtype=torch.int64))
+        self.sm_ptrs_gpu.copy_(torch.tensor(sm_ptrs, dtype=torch.int64))
+        first_bt = self.block_tables[0]
+        self.total_cp_world_size = first_bt.pcp_world_size * first_bt.dcp_world_size
+        self.total_cp_rank = first_bt.pcp_rank * first_bt.dcp_world_size + first_bt.dcp_rank
+
     def append_row(self, block_ids: tuple[list[int], ...], row_idx: int) -> None:
         for i, block_table in enumerate(self.block_tables):
             block_table.append_row(block_ids[i], row_idx)
@@ -299,12 +314,48 @@ class MultiGroupBlockTable:
         query_start_loc: torch.Tensor,
         positions: torch.Tensor,
     ) -> None:
-        for block_table in self.block_tables:
-            block_table.compute_slot_mapping(num_reqs, query_start_loc, positions)
+        if not envs.VLLM_BATCH_PROCESS_ATTNMETADATA:
+            for block_table in self.block_tables:
+                block_table.compute_slot_mapping(num_reqs, query_start_loc, positions)
+            return
+
+        first_bt = self.block_tables[0]
+        num_tokens = positions.shape[0]
+
+        # 2D Grid: [num_reqs + 1, num_groups]
+        grid = (num_reqs + 1, self.num_groups)
+
+        _batch_compute_slot_mapping_kernel[grid](
+            num_tokens,
+            first_bt.max_num_batched_tokens,
+            query_start_loc,
+            positions,
+            self.dst_ptrs_gpu,  # Use pre-allocated block table GPU ptrs
+            self.sm_ptrs_gpu,   # Use pre-allocated slot mapping GPU ptrs
+            first_bt.block_table.gpu.stride(0),
+            first_bt.block_size,
+            TOTAL_CP_WORLD_SIZE=self.total_cp_world_size,
+            TOTAL_CP_RANK=self.total_cp_rank,
+            CP_KV_CACHE_INTERLEAVE_SIZE=first_bt.cp_kv_cache_interleave_size,
+            PAD_ID=PAD_SLOT_ID,
+            BLOCK_SIZE=1024,
+        )
 
     def commit_block_table(self, num_reqs: int) -> None:
-        for block_table in self.block_tables:
-            block_table.commit_block_table(num_reqs)
+        if not envs.VLLM_BATCH_PROCESS_ATTNMETADATA:
+            for block_table in self.block_tables:
+                block_table.commit_block_table(num_reqs)
+            return
+
+        stride = self.block_tables[0].block_table.gpu.stride(0)
+
+        _batch_copy_kernel[(self.num_groups,)](
+            self.src_ptrs_gpu,
+            self.dst_ptrs_gpu,
+            num_reqs, # Pass as int, Triton handles scalar as constant
+            stride,
+            BLOCK_SIZE=1024,
+        )
 
     def clear(self) -> None:
         for block_table in self.block_tables:
@@ -334,7 +385,6 @@ def _compute_slot_mapping_kernel(
     req_idx = tl.program_id(0)
 
     if req_idx == tl.num_programs(0) - 1:
-        # Pad remaining slots for CUDA graph compatibility.
         for i in range(num_tokens, max_num_tokens, BLOCK_SIZE):
             offsets = i + tl.arange(0, BLOCK_SIZE)
             tl.store(
@@ -367,6 +417,90 @@ def _compute_slot_mapping_kernel(
         ) * CP_KV_CACHE_INTERLEAVE_SIZE + (
             virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE
         )
+
+        slot_ids = block_numbers * block_size + local_block_offsets
+        slot_ids = tl.where(is_local, slot_ids, PAD_ID)
+        tl.store(slot_mapping_ptr + offsets, slot_ids, mask=mask)
+
+@triton.jit
+def _batch_copy_kernel(
+    src_ptrs_ptr,      # [num_tables] - Pointer to array of addresses
+    dst_ptrs_ptr,      # [num_tables] - Pointer to array of addresses
+    num_reqs,          # Scalar: number of requests to copy per table
+    stride,            # Scalar: max_num_blocks_per_req
+    BLOCK_SIZE: tl.constexpr,
+):
+    # Each program handles one entire block table (one group)
+    pid = tl.program_id(0)
+
+    # Load the 64-bit memory addresses for this specific group
+    # We cast to int64 first to ensure we handle the full address space
+    src_addr = tl.load(src_ptrs_ptr + pid).to(tl.int64)
+    dst_addr = tl.load(dst_ptrs_ptr + pid).to(tl.int64)
+
+    # Cast raw addresses to pointers that Triton can dereference
+    src_base = src_addr.to(tl.pointer_type(tl.int32))
+    dst_base = dst_addr.to(tl.pointer_type(tl.int32))
+
+    # Total elements to copy for this table
+    total_elements = num_reqs * stride
+
+    for i in range(0, total_elements, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < total_elements
+
+        data = tl.load(src_base + offsets, mask=mask)
+        tl.store(dst_base + offsets, data, mask=mask)
+
+@triton.jit
+def _batch_compute_slot_mapping_kernel(
+    num_tokens,
+    max_num_tokens,
+    query_start_loc_ptr,
+    positions_ptr,
+    block_table_ptrs_ptr,    # [num_groups] - array of pointers to each block table
+    slot_mapping_ptrs_ptr,  # [num_groups] - array of pointers to each slot mapping buffer
+    block_table_stride,
+    block_size,
+    TOTAL_CP_WORLD_SIZE: tl.constexpr,
+    TOTAL_CP_RANK: tl.constexpr,
+    CP_KV_CACHE_INTERLEAVE_SIZE: tl.constexpr,
+    PAD_ID: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    req_idx = tl.program_id(0)
+    group_idx = tl.program_id(1)
+
+    # Load the specific pointers for this group
+    block_table_ptr = tl.load(block_table_ptrs_ptr + group_idx).to(tl.pointer_type(tl.int32))
+    slot_mapping_ptr = tl.load(slot_mapping_ptrs_ptr + group_idx).to(tl.pointer_type(tl.int64))
+
+    if req_idx == tl.num_programs(0) - 1:
+        for i in range(num_tokens, max_num_tokens, BLOCK_SIZE):
+            offsets = i + tl.arange(0, BLOCK_SIZE)
+            tl.store(slot_mapping_ptr + offsets, PAD_ID, mask=offsets < max_num_tokens)
+        return
+
+    start_idx = tl.load(query_start_loc_ptr + req_idx).to(tl.int64)
+    end_idx = tl.load(query_start_loc_ptr + req_idx + 1).to(tl.int64)
+
+    virtual_block_size = block_size * TOTAL_CP_WORLD_SIZE
+    row_offset = req_idx * block_table_stride
+
+    for i in range(start_idx, end_idx, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < end_idx
+        pos = tl.load(positions_ptr + offsets, mask=mask, other=0)
+
+        block_indices = pos // virtual_block_size
+        block_numbers = tl.load(block_table_ptr + row_offset + block_indices).to(tl.int64)
+
+        virtual_block_offsets = pos - block_indices * virtual_block_size
+        is_local = (virtual_block_offsets // CP_KV_CACHE_INTERLEAVE_SIZE) % TOTAL_CP_WORLD_SIZE == TOTAL_CP_RANK
+
+        local_block_offsets = (
+            virtual_block_offsets // (TOTAL_CP_WORLD_SIZE * CP_KV_CACHE_INTERLEAVE_SIZE)
+        ) * CP_KV_CACHE_INTERLEAVE_SIZE + (virtual_block_offsets % CP_KV_CACHE_INTERLEAVE_SIZE)
 
         slot_ids = block_numbers * block_size + local_block_offsets
         slot_ids = tl.where(is_local, slot_ids, PAD_ID)

--- a/vllm/v1/worker/block_table.py
+++ b/vllm/v1/worker/block_table.py
@@ -11,6 +11,11 @@ from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.utils import PAD_SLOT_ID
 from vllm.v1.utils import CpuGpuBuffer
 from vllm.v1.worker.cp_utils import get_total_cp_world_size
+from vllm.v1.worker.gpu.block_table import (
+    _compute_slot_mappings_kernel,
+    _load_ptr,
+)
+import vllm.envs as envs
 
 logger = init_logger(__name__)
 
@@ -280,6 +285,45 @@ class MultiGroupBlockTable:
             )
         ]
 
+        self.num_groups = len(self.block_tables)
+        self.src_ptrs_gpu = torch.zeros(self.num_groups, device=device, dtype=torch.uint64)
+        self.dst_ptrs_gpu = torch.zeros(self.num_groups, device=device, dtype=torch.uint64)
+        src_ptrs = [bt.block_table.cpu.data_ptr() for bt in self.block_tables]
+        dst_ptrs = [bt.block_table.gpu.data_ptr() for bt in self.block_tables]
+        self.src_ptrs_gpu.copy_(torch.tensor(src_ptrs, dtype=torch.uint64))
+        self.dst_ptrs_gpu.copy_(torch.tensor(dst_ptrs, dtype=torch.uint64))
+        first_bt = self.block_tables[0]
+        self.total_cp_world_size = first_bt.pcp_world_size * first_bt.dcp_world_size
+        self.total_cp_rank = first_bt.pcp_rank * first_bt.dcp_world_size + first_bt.dcp_rank
+
+        # Additional tensors needed by _compute_slot_mappings_kernel
+        self.block_table_strides_gpu = torch.tensor(
+            [bt.block_table.gpu.stride(0) for bt in self.block_tables],
+            dtype=torch.int64,
+            device=device,
+        )
+        self.block_sizes_gpu = torch.tensor(
+            [bt.block_size for bt in self.block_tables],
+            dtype=torch.int32,
+            device=device,
+        )
+        # 2D slot_mappings tensor: [num_groups, max_num_batched_tokens]
+        self.slot_mappings_gpu = torch.zeros(
+            self.num_groups,
+            max_num_batched_tokens,
+            dtype=torch.int64,
+            device=device,
+        )
+        self.slot_mappings_stride = self.slot_mappings_gpu.stride(0)
+        # Point individual BlockTable slot_mapping.gpu to rows of the 2D tensor
+        # so that consumers reading blk_table.slot_mapping.gpu see the results.
+        for i, bt in enumerate(self.block_tables):
+            bt.slot_mapping.gpu = self.slot_mappings_gpu[i]
+        # Identity idx_mapping (batch_idx == req_idx in this code path)
+        self.idx_mapping_gpu = torch.arange(
+            max_num_reqs, dtype=torch.int32, device=device
+        )
+
     def append_row(self, block_ids: tuple[list[int], ...], row_idx: int) -> None:
         for i, block_table in enumerate(self.block_tables):
             block_table.append_row(block_ids[i], row_idx)
@@ -306,12 +350,46 @@ class MultiGroupBlockTable:
         query_start_loc: torch.Tensor,
         positions: torch.Tensor,
     ) -> None:
-        for block_table in self.block_tables:
-            block_table.compute_slot_mapping(num_reqs, query_start_loc, positions)
+        if not envs.VLLM_BATCH_PROCESS_ATTNMETADATA:
+            for block_table in self.block_tables:
+                block_table.compute_slot_mapping(num_reqs, query_start_loc, positions)
+            return
+
+        first_bt = self.block_tables[0]
+
+        # Grid: [num_groups, num_reqs + 1]
+        grid = (self.num_groups, num_reqs + 1)
+
+        _compute_slot_mappings_kernel[grid](
+            first_bt.max_num_batched_tokens,
+            self.idx_mapping_gpu,
+            query_start_loc,
+            positions,
+            self.dst_ptrs_gpu,
+            self.block_table_strides_gpu,
+            self.block_sizes_gpu,
+            self.slot_mappings_gpu,
+            self.slot_mappings_stride,
+            self.total_cp_rank,
+            CP_SIZE=self.total_cp_world_size,
+            CP_INTERLEAVE=first_bt.cp_kv_cache_interleave_size,
+            PAD_ID=PAD_SLOT_ID,
+            TRITON_BLOCK_SIZE=1024,
+        )
 
     def commit_block_table(self, num_reqs: int) -> None:
-        for block_table in self.block_tables:
-            block_table.commit_block_table(num_reqs)
+        if not envs.VLLM_BATCH_PROCESS_ATTNMETADATA:
+            for block_table in self.block_tables:
+                block_table.commit_block_table(num_reqs)
+            return
+
+        _batch_copy_kernel[(self.num_groups,)](
+            self.src_ptrs_gpu,
+            self.dst_ptrs_gpu,
+            num_reqs,
+            self.block_table_strides_gpu,
+            BLOCK_SIZE=1024,
+        )
 
     def clear(self) -> None:
         for block_table in self.block_tables:
@@ -341,7 +419,6 @@ def _compute_slot_mapping_kernel(
     req_idx = tl.program_id(0)
 
     if req_idx == tl.num_programs(0) - 1:
-        # Pad remaining slots for CUDA graph compatibility.
         for i in range(num_tokens, max_num_tokens, BLOCK_SIZE):
             offsets = i + tl.arange(0, BLOCK_SIZE)
             tl.store(
@@ -378,3 +455,37 @@ def _compute_slot_mapping_kernel(
         slot_ids = block_numbers * block_size + local_block_offsets
         slot_ids = tl.where(is_local, slot_ids, PAD_ID)
         tl.store(slot_mapping_ptr + offsets, slot_ids, mask=mask)
+
+@triton.jit
+def _batch_copy_kernel(
+    src_ptrs_ptr,      # [num_tables] - Pointer to array of addresses
+    dst_ptrs_ptr,      # [num_tables] - Pointer to array of addresses
+    num_reqs,          # Scalar: number of requests to copy per table
+    strides_ptr,       # [num_tables] - Per-group strides
+    BLOCK_SIZE: tl.constexpr,
+):
+    # Each program handles one entire block table (one group)
+    pid = tl.program_id(0)
+
+    # Load the 64-bit memory addresses for this specific group
+    src_addr = tl.load(src_ptrs_ptr + pid).to(tl.int64)
+    dst_addr = tl.load(dst_ptrs_ptr + pid).to(tl.int64)
+
+    # Load per-group stride
+    stride = tl.load(strides_ptr + pid)
+
+    # Cast raw addresses to pointers that Triton can dereference
+    src_base = src_addr.to(tl.pointer_type(tl.int32))
+    dst_base = dst_addr.to(tl.pointer_type(tl.int32))
+
+    # Total elements to copy for this table
+    total_elements = num_reqs * stride
+
+    for i in range(0, total_elements, BLOCK_SIZE):
+        offsets = i + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < total_elements
+
+        data = tl.load(src_base + offsets, mask=mask)
+        tl.store(dst_base + offsets, data, mask=mask)
+
+


### PR DESCRIPTION
## Purpose
This PR optimizes the CPU-side overhead of managing attention metadata in the V1 engine, specifically targeting models with extensive amount of block tables.

In models where MultiGroupBlockTable manages an extensive amount of independent block tables, the original iterative commitment logic (`compute_slot_mapping`, `commit_block_table` and `split_decodes_and_prefills`) introduces a significant "launch cost" due to tensor handling.  On Blackwell (GB200), the cumulative overhead can exceed the GPU compute time, delaying kernel launch and completion.

## Key Changes:
Introduced an environment parameter to allow batch processing all tables in the same MultiGroupBlockTable at once with Triton kernels.  

## Test Result
Target/draft model: FP8 custom model
Nvidia GB200

Completed accuracy and latency benchmark; no accuracy degradation and bubbles in GPU activities are removed. The performance improvement is correlated with the size of `MultiGroupBlockTable` and models with a small size, such as Llama3.3 70B, Qwen3 235B, DeepSeek R1, and Gemma2, doesn't see much benefit because the size of MultiGroupBlockTable is either 1 or 2 for these models.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

