### PR TITLE
[CI Bug] fix flaky test test_fewer_blocks_with_hma[google/gemma-3-1b-it-512]

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -102,7 +102,7 @@ def test_fewer_blocks_with_hma(monkeypatch, model_name, sw_size):
     llm_kwargs = {
         "model": model_name,
         "enforce_eager": True,
-        "gpu_memory_utilization": 0.5,
+        "gpu_memory_utilization": 0.47,
         "kv_transfer_config": kv_transfer_config,
         "max_model_len": 2048,
         # NOTE: Make sure HMA is enabled


### PR DESCRIPTION
## Purpose

Fix flaky test  https://buildkite.com/vllm/ci/builds/61473#019d9263-db86-4c91-93ff-2341dfe34a12

```bash

[2026-04-15T18:44:57Z] _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
--
[2026-04-15T18:44:57Z]
[2026-04-15T18:44:57Z] init_snapshot = torch_peak=11.17GiB, free_memory=10.93GiB, total_memory=22.05GiB, cuda_memory=11.12GiB, torch_memory=10.86GiB, non_torch_memory=0.25GiB, timestamp=1776278696.4859822, auto_measure=True
[2026-04-15T18:44:57Z] cache_config = CacheConfig(block_size=16, user_specified_block_size=True, user_specified_mamba_block_size=False, gpu_memory_utilizati...=False, kv_cache_memory_bytes=None, kv_offloading_size=None, kv_offloading_backend='native', _block_size_resolved=True)
[2026-04-15T18:44:57Z]
[2026-04-15T18:44:57Z]     def request_memory(init_snapshot: MemorySnapshot, cache_config: CacheConfig) -> int:
[2026-04-15T18:44:57Z]         """
[2026-04-15T18:44:57Z]         Calculate the amount of memory required by vLLM, then validate
[2026-04-15T18:44:57Z]         that the current amount of free memory is sufficient for that.
[2026-04-15T18:44:57Z]         """
[2026-04-15T18:44:57Z]         requested_memory = math.ceil(
[2026-04-15T18:44:57Z]             init_snapshot.total_memory * cache_config.gpu_memory_utilization
[2026-04-15T18:44:57Z]         )
[2026-04-15T18:44:57Z]
[2026-04-15T18:44:57Z]         if init_snapshot.free_memory < requested_memory:
[2026-04-15T18:44:57Z] >           raise ValueError(
[2026-04-15T18:44:57Z]                 f"Free memory on device {init_snapshot.device_} "
[2026-04-15T18:44:57Z]                 f"({format_gib(init_snapshot.free_memory)}/"
[2026-04-15T18:44:57Z]                 f"{format_gib(init_snapshot.total_memory)} GiB) on startup "
[2026-04-15T18:44:57Z]                 f"is less than desired GPU memory utilization "
[2026-04-15T18:44:57Z]                 f"({cache_config.gpu_memory_utilization}, "
[2026-04-15T18:44:57Z]                 f"{format_gib(requested_memory)} GiB). Decrease GPU memory "
[2026-04-15T18:44:57Z]                 f"utilization or reduce GPU memory used by other processes."
[2026-04-15T18:44:57Z]             )
[2026-04-15T18:44:57Z] E           ValueError: Free memory on device cuda:0 (10.93/22.05 GiB) on startup is less than desired GPU memory utilization (0.5, 11.02 GiB). Decrease GPU memory utilization or reduce GPU memory used by other processes.
[2026-04-15T18:44:57Z]
[2026-04-15T18:44:57Z] /usr/local/lib/python3.12/dist-packages/vllm/v1/worker/utils.py:413: ValueError

[2026-04-15T18:44:57Z] =========================== short test summary info ============================
--
[2026-04-15T18:44:57Z] FAILED v1/kv_connector/unit/test_nixl_connector_hma.py::test_fewer_blocks_with_hma[google/gemma-3-1b-it-512] - ValueError: Free memory on device cuda:0 (10.93/22.05 GiB) on startup is less than desired GPU memory utilization (0.5, 11.02 GiB). Decrease GPU memory utilization or reduce GPU memory used by other processes.
[2026-04-15T18:44:57Z] = 1 failed, 217 passed, 13 skipped, 42 deselected, 20 warnings in 367.79s (0:06:07) =
```

## Test 

Covered in CI