### PR TITLE
[model] Add M2M100ForConditionalGeneration to OOT supported models

### DIFF
--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -676,6 +676,7 @@ _OOT_SUPPORTED_MODELS = {
     "BartForConditionalGeneration": "https://github.com/vllm-project/bart-plugin",
     "Florence2ForConditionalGeneration": "https://github.com/vllm-project/bart-plugin",
     "MBartForConditionalGeneration": "https://github.com/vllm-project/bart-plugin",
+    "M2M100ForConditionalGeneration": "https://github.com/vllm-project/bart-plugin",
 }
 
 


### PR DESCRIPTION
## Summary

Registers `M2M100ForConditionalGeneration` in `_OOT_SUPPORTED_MODELS`, pointing to the [bart-plugin](https://github.com/vllm-project/bart-plugin).

This covers Meta's NLLB distilled translation models:
- `facebook/nllb-200-distilled-600M`
- `facebook/nllb-200-distilled-1.3B`
- `facebook/nllb-200-3.3B`

The implementation is in a companion PR to bart-plugin: vllm-project/bart-plugin#19

## Change

One line added to `_OOT_SUPPORTED_MODELS` in `registry.py`:

```python
"M2M100ForConditionalGeneration": "https://github.com/vllm-project/bart-plugin",
```

This allows users to load NLLB models with a clear error message pointing to the plugin if the plugin is not installed, consistent with how BART and mBART are handled.

## Test plan

- Tested end-to-end on NVIDIA GB10 (DGX Spark) with vLLM 0.18.0
- 13 integration tests in bart-plugin cover English→French/German/Arabic/Chinese and non-English sources (Amharic, Hindi, French)
- All 13 pass