### PR TITLE
[Model Runner V2][BugFix] fix num_sampled dtype for probabilistic rej…

### DIFF
--- a/vllm/v1/worker/gpu/spec_decode/probabilistic_rejection_sampler_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/probabilistic_rejection_sampler_utils.py
@@ -527,7 +527,7 @@ def probabilistic_rejection_sample(
     sampled = draft_sampled.new_empty(
         num_reqs, num_speculative_steps + 1, dtype=torch.int64
     )
-    num_sampled = sampled.new_empty(num_reqs)
+    num_sampled = sampled.new_empty(num_reqs, dtype=torch.int32)
     target_rejected_logsumexp = target_logits.new_empty(num_reqs, dtype=torch.float32)
     draft_rejected_logsumexp = target_logits.new_empty(num_reqs, dtype=torch.float32)
     _probabilistic_rejection_kernel[(num_reqs,)](


### PR DESCRIPTION
# Purpose
`num_sampled` returned by the probabilistic rejection sampler should be `int32`, which is the expected return type of `RejectionSampler`. This is also what is done by the strict rejection sampler (https://github.com/vllm-project/vllm/blob/7c636432c62e242d36bff056d5258474498d3a4e/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py#L67).

Currently it defaults to `int64`, which triggers the following error in `_prepare_eagle_inputs_kernel`:
```
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]   File "/home/gdelfin/vllm-1/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py", line 445, in propose
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]     prepare_eagle_inputs(
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]   File "/home/gdelfin/vllm-1/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py", line 672, in prepare_eagle_inputs
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]     _prepare_eagle_inputs_kernel[(num_reqs,)](
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]   File "/home/gdelfin/vllm-1/.venv/lib/python3.12/site-packages/triton/runtime/jit.py", line 370, in <lambda>
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]     return lambda *args, **kwargs: self.run(grid=grid, warmup=False, *args, **kwargs)
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]   File "/home/gdelfin/vllm-1/.venv/lib/python3.12/site-packages/triton/runtime/jit.py", line 720, in run
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]     kernel = self._do_compile(key, signature, device, constexprs, options, attrs, warmup)
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]   File "/home/gdelfin/vllm-1/.venv/lib/python3.12/site-packages/triton/runtime/jit.py", line 849, in _do_compile
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]     kernel = self.compile(src, target=target, options=options.__dict__)
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]   File "/home/gdelfin/vllm-1/.venv/lib/python3.12/site-packages/triton/compiler/compiler.py", line 304, in compile
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]     module = src.make_ir(target, options, codegen_fns, module_map, context)
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]   File "/home/gdelfin/vllm-1/.venv/lib/python3.12/site-packages/triton/compiler/compiler.py", line 80, in make_ir
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]     return ast_to_ttir(self.fn, self, context=context, options=options, codegen_fns=codegen_fns,
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971] triton.compiler.errors.CompilationError: at 62:4:
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]     # Copy positions.
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]     for i in range(0, query_len, BLOCK_SIZE):
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]         block = i + tl.arange(0, BLOCK_SIZE)
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]         mask = block < query_len
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]         target_pos = tl.load(target_positions_ptr + query_start + block, mask=mask)
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]         tl.store(eagle_positions_ptr + query_start + block, target_pos, mask=mask)
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971] 
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]     # Copy query start locations.
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]     tl.store(eagle_query_start_loc_ptr + req_idx, query_start)
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]     # Copy sequence lengths.
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]     tl.store(eagle_seq_lens_ptr + req_idx, seq_len)
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]     if req_idx == (num_reqs - 1):
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971]     ^
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971] AssertionError('initial value for `i` is of type int64[], but the then block redefines it as int32[]')
(Worker_TP2 pid=3468041) ERROR 04-15 22:08:00 [multiproc_executor.py:971] 
```

The fix was to simply change it to `int32` to match what is done by the strict rejection sampler.

Verified that the error no longer occurs.