### PR TITLE
[Misc] Lazy import pandas in _aiter_ops to fix startup crash

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -3,7 +3,6 @@
 import functools
 from collections.abc import Callable
 
-import pandas as pd
 import torch
 from torch._ops import OpOverload
 
@@ -62,6 +61,7 @@ def _load_gemm_tuned_configs(
     q_dtype_w: torch.dtype, csv_path: str
 ) -> set[tuple[int, int, int]]:
     try:
+        import pandas as pd
         df = pd.read_csv(csv_path).drop_duplicates()
         df = df[df["q_dtype_w"] == str(q_dtype_w)]
         return set(zip(df["N"].astype(int), df["K"].astype(int), df["M"].astype(int)))


### PR DESCRIPTION
## Essential Changes

Move `import pandas as pd` from module-level to inside `_load_gemm_tuned_configs()` in `vllm/_aiter_ops.py` — the only function that uses it.

## Problem

The top-level import causes `ModuleNotFoundError: No module named 'pandas'` on every `vllm serve` invocation. The CLI entrypoint unconditionally imports this module through the chain:

```
cli → benchmarks → lora.utils → model_executor.layers → _aiter_ops → import pandas
```

Since `pandas` is not declared as a core dependency, any fresh install without it crashes immediately at startup.

## Fix

Lazy import inside the function, consistent with how **all other modules** under `vllm/` already handle pandas:

- `vllm/profiler/layerwise_profile.py` — lazy
- `vllm/benchmarks/mm_processor.py` — lazy
- `vllm/benchmarks/sweep/*.py` — lazy
- `vllm/benchmarks/datasets/datasets.py` — lazy

The function already has a `try/except Exception` block, so if pandas is missing on a ROCm system that actually calls this path, it gracefully returns an empty set instead of crashing.

## Test plan

- [x] `vllm serve` starts without pandas installed (previously crashed)
- [x] No behavior change when pandas is installed — `_load_gemm_tuned_configs()` still works identically

🤖 Generated with [Claude Code](https://claude.com/claude-code)