### PR TITLE
[Bugfix] Skip bias tensors in online FP8 quantization pipeline

### DIFF
--- a/tests/model_executor/model_loader/test_reload.py
+++ b/tests/model_executor/model_loader/test_reload.py
@@ -257,3 +257,22 @@ def test_online_quantize_reload(
         mul_perp = llm.generate_prompt_perplexity(["3 4 = 12"], mask=["3 4 ="])[0]
         add_perp = llm.generate_prompt_perplexity(["3 4 = 7"], mask=["3 4 ="])[0]
         assert add_perp < mul_perp
+
+
+def test_capture_layer_to_meta_skips_bias():
+    """Regression for #39663: bias parameters must be skipped by online loader.
+
+    Online FP8 quantization wraps all non-SKIP_TENSORS params through a
+    deferred load pipeline that never materialized bias tensors, silently
+    leaving them at zero for Qwen2/2.5/GPT-2/Phi (bias=True linear layers).
+    Fix is to add "bias" to SKIP_TENSORS so it takes the normal load path.
+    """
+    from vllm.model_executor.model_loader.reload.meta import SKIP_TENSORS
+
+    assert "bias" in SKIP_TENSORS
+
+    layer = torch.nn.Linear(2, 3, bias=True)
+    params, _buffers = capture_layer_to_meta(layer)
+
+    assert "weight" in params
+    assert "bias" not in params

--- a/vllm/model_executor/model_loader/reload/meta.py
+++ b/vllm/model_executor/model_loader/reload/meta.py
@@ -23,11 +23,12 @@ SKIP_MODULES: set[str] = {"HadamardTransform"}
 
 SKIP_TENSORS: set[str] = {
     "_expert_map",
-    "expert_mask",
-    "expert_global_to_physical",
-    "expert_physical_to_global",
-    "expert_local_to_global",
+    "bias",
     "e_score_correction_bias",
+    "expert_global_to_physical",
+    "expert_local_to_global",
+    "expert_mask",
+    "expert_physical_to_global",
 }
 
 


### PR DESCRIPTION
## Summary

Add `"bias"` to `SKIP_TENSORS` in `vllm/model_executor/model_loader/reload/meta.py` so bias parameters bypass `make_online_process_loader` wrapping during `initialize_online_processing`.

Fixes #39663. Resubmit of #39665 (auto-closed by my notification cleanup without maintainer review).

## Problem

With `--quantization fp8` on BF16 checkpoints, models that register `bias=True` linear layers (Qwen2/2.5, GPT-2, Phi, etc.) produce garbage output: bias tensors get wrapped by the online processing pipeline but never materialize — they silently stay at zero.

## Root cause

`initialize_online_processing` in `layerwise.py` wraps weight loaders for all tensors not in `SKIP_TENSORS`. Bias parameters (1D, small) don't need FP8 quantization and are not designed to flow through the deferred loading pipeline. Same class of bug previously addressed for `e_score_correction_bias` (already in the set).

Reporter @alankessler filed #39663 with the full env capture and repro (Qwen2/2.5 producing garbage output under `--quantization fp8`).

## Fix

Add `"bias"` to the `SKIP_TENSORS` set. vLLM parallel linear layers (`ColumnParallelLinear`, `QKVParallelLinear`, `RowParallelLinear`, etc.) register bias as exactly `self.bias` via `Parameter(...)` / `register_parameter("bias", ...)`, so the exact-name match in `SKIP_TENSORS` targets precisely the affected tensors.

## Test

Added `test_capture_layer_to_meta_skips_bias` — CPU-only unit test that verifies:
1. `"bias"` is present in `SKIP_TENSORS`
2. `torch.nn.Linear(bias=True)` → `capture_layer_to_meta` drops the bias but keeps the weight

The negative case (accidental over-skip) is constrained by the existing `test_reload_lifecycle` test, which exercises end-to-end capture/restore/materialize on a `torch.nn.Linear` and would fail if weight tensors were incorrectly skipped.

## Notes

- 1-line functional change (alphabetized SKIP_TENSORS for diff noise). No test infra changes, no new deps.
- Previous submission #39665 had Codex adversarial review flagging WEAK_CONCERNS about "bias" being a generic name. The mitigating evidence: reporter's repro plus shared precedent (`e_score_correction_bias`) of the same exact-name skip pattern + existing `e_score_correction_bias` precedent (also a narrow exact-name skip).
