### PR TITLE
fix: clear response_format when tool_choice is auto to allow tool calls

### DIFF
--- a/tests/tool_use/test_tool_parser_adjust_request.py
+++ b/tests/tool_use/test_tool_parser_adjust_request.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.engine.protocol import ResponseFormat
+from vllm.tool_parsers.abstract_tool_parser import ToolParser
+
+MODEL = "facebook/opt-125m"
+
+WEATHER_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "get_weather",
+        "parameters": {
+            "type": "object",
+            "properties": {"location": {"type": "string"}},
+        },
+    },
+}
+
+
+def _json_object_format() -> ResponseFormat:
+    return ResponseFormat(type="json_object")
+
+
+def _parser() -> ToolParser:
+    return ToolParser(MagicMock())
+
+
+@pytest.mark.parametrize("tool_choice", ["auto", None])
+def test_adjust_request_clears_response_format_for_auto(tool_choice):
+    kwargs = {
+        "model": MODEL,
+        "messages": [],
+        "tools": [WEATHER_TOOL],
+        "response_format": _json_object_format(),
+    }
+    if tool_choice is not None:
+        kwargs["tool_choice"] = tool_choice
+    request = ChatCompletionRequest(**kwargs)  # type: ignore[arg-type]
+
+    adjusted = _parser().adjust_request(request)
+
+    assert adjusted.response_format is None
+
+
+def test_adjust_request_preserves_response_format_for_none():
+    response_format = _json_object_format()
+    request = ChatCompletionRequest(
+        model=MODEL,
+        messages=[],
+        tools=[WEATHER_TOOL],
+        tool_choice="none",
+        response_format=response_format,
+    )  # type: ignore[arg-type]
+
+    adjusted = _parser().adjust_request(request)
+
+    assert adjusted.response_format is response_format
+
+
+def test_adjust_request_preserves_response_format_without_tools():
+    response_format = _json_object_format()
+    request = ChatCompletionRequest(
+        model=MODEL,
+        messages=[],
+        response_format=response_format,
+    )  # type: ignore[arg-type]
+
+    adjusted = _parser().adjust_request(request)
+
+    assert adjusted.response_format is response_format

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -166,6 +166,16 @@ class ToolParser:
                         strict=True,
                     )
                 )
+        elif isinstance(request, ChatCompletionRequest) and request.tool_choice in (
+            "auto",
+            None,
+        ):
+            # tool_choice="auto" (or unset, which defaults to auto when tools
+            # are provided): clear response_format so constrained JSON decoding
+            # doesn't box the model into the schema and block tool-call tokens.
+            # tool_choice="none" is intentionally left alone — the caller asked
+            # for response_format and no tools.
+            request.response_format = None
 
         return request
 


### PR DESCRIPTION
## Summary

When a request includes both `tools` and `response_format` (e.g. `json_object`) with `tool_choice: "auto"` (the default), constrained JSON decoding from `response_format` forces the model to produce JSON content and prevents it from generating tool call tokens. The model returns `tool_calls: []` and answers directly as JSON.

This was already fixed for `tool_choice: "required"` in #32006, but the `tool_choice: "auto"` case was missed.

## Fix

In `adjust_request()`, when `get_json_schema_from_tools` returns `None` (the `"auto"` case) but tools are present, clear `response_format` so the model can freely choose between tool calls and text output. The tool parser handles extraction regardless of output format.

Fixes #39929

## Changes

1 file changed — `vllm/tool_parsers/abstract_tool_parser.py`

```python
# Before: response_format only cleared for "required"/"forced function"
if json_schema_from_tool is not None:
    request.response_format = None

# After: also cleared for "auto" when tools are present
if json_schema_from_tool is not None:
    request.response_format = None
elif isinstance(request, ChatCompletionRequest):
    # tool_choice: "auto" -- clear response_format so constrained
    # decoding doesn't prevent the model from generating tool calls.
    request.response_format = None
```

## Test plan

- [x] Code review: the `elif` only triggers when `json_schema_from_tool is None` (i.e. `tool_choice="auto"`) and `request.tools` is non-empty (checked at line 80)
- [ ] With `tool_choice="auto"` + `response_format=json_object` + tools → model can now return tool_calls
- [ ] Without tools, `adjust_request` returns early (line 80-81), so response_format is preserved
- [ ] `tool_choice="required"` path unchanged (still goes through the `if` branch)