### PR TITLE
[Quantization] Add TurboQuant online weight compression (Linear-only)

### DIFF
--- a/docs/features/quantization/README.md
+++ b/docs/features/quantization/README.md
@@ -20,6 +20,7 @@ The following are the supported quantization formats for vLLM:
 - [AMD Quark](quark.md)
 - [Quantized KV Cache](quantized_kvcache.md)
 - [TorchAO](torchao.md)
+- [TurboQuant](turboquant.md)
 
 ## Supported Hardware
 
@@ -52,6 +53,7 @@ th:not(:first-child) {
 | Marlin (GPTQ/AWQ/FP8/FP4) | ❌    | ✅︎*    | ✅︎     | ✅︎  | ✅︎     | ❌      | ❌        | ❌      |
 | INT8 (W8A8)               | ❌    | ✅︎     | ✅︎     | ✅︎  | ✅︎     | ❌      | ❌        | ✅︎      |
 | FP8 (W8A8)                | ❌    | ❌     | ❌     | ✅︎  | ✅︎     | ✅︎      | ❌        | ❌      |
+| TurboQuant                | ❌    | ❌     | ✅︎     | ✅︎  | ✅︎     | ❌      | ❌        | ❌      |
 | bitsandbytes              | ✅︎    | ✅︎     | ✅︎     | ✅︎  | ✅︎     | ❌      | ❌        | ❌      |
 | DeepSpeedFP               | ✅︎    | ✅︎     | ✅︎     | ✅︎  | ✅︎     | ❌      | ❌        | ❌      |
 | GGUF                      | ✅︎    | ✅︎     | ✅︎     | ✅︎  | ✅︎     | ✅︎      | ❌        | ❌      |

--- a/docs/features/quantization/README.md
+++ b/docs/features/quantization/README.md
@@ -23,6 +23,7 @@ The following are the supported quantization formats for vLLM:
 - [Quantized KV Cache](quantized_kvcache.md)
 - [TorchAO](torchao.md)
 - [FP8 ViT Encoder Attention](fp8_vit_attn.md)
+- [TurboQuant](turboquant.md)
 
 ## Supported Hardware
 

--- a/docs/features/quantization/turboquant.md
+++ b/docs/features/quantization/turboquant.md
@@ -1,12 +1,20 @@
 # TurboQuant (Online 3-4 bit Weight Compression)
 
-TurboQuant is an online weight-only quantization scheme based on [Zandieh et al., ICLR 2026](https://arxiv.org/abs/2503.19878). It compresses BF16 weights to 3 or 4 bits at model load time and requires **no calibration data**.
+`--quantization turboquant` is an online weight-only quantization scheme that compresses BF16 weights to 3 or 4 bits at model load time and requires **no calibration data**.
 
-TurboQuant combines three techniques:
+It combines three techniques:
 
 1. **Walsh–Hadamard randomized rotation** of weight groups. After rotation each coordinate is approximately `N(0, 1/d)`, which lets a small shared codebook work well across all weights.
 2. **Lloyd–Max optimal scalar quantization** at 2/3/4 bits into a 4/8/16-entry codebook.
-3. **Per-group norm correction** — we store `original_norm / reconstruction_norm` (not raw L2 norms), which halves the quantization error at 3 bits in practice.
+3. **Per-group shape-gain decomposition** — we store `original_norm / reconstruction_norm` (the classical shape-gain factor, Gray 1984) rather than raw L2 norms. This halves the 3-bit reconstruction error in practice by accounting for the norm shrinkage introduced by the quantization step itself.
+
+## Background and naming
+
+The algorithm implemented here is the **scalar case of HIGGS** (Malinovskii, Panferov, Ilin, Guo, Richtárik, Alistarh — *Pushing the Limits of Large Language Model Quantization via the Linearity Theorem*, [NAACL 2025](https://aclanthology.org/2025.naacl-long.543/); preprint [arXiv:2411.17525](https://arxiv.org/abs/2411.17525)). HIGGS describes exactly this combination of Random Hadamard Transform pre-processing, MSE-optimal Lloyd–Max grid, and per-group L2 normalization. A reference implementation also exists in [HuggingFace transformers](https://github.com/huggingface/transformers/blob/main/docs/source/en/quantization/higgs.md).
+
+The implementation was originally based on **TurboQuant** ([Zandieh et al., ICLR 2026, arXiv:2504.19874](https://arxiv.org/abs/2504.19874)), which is actually an **online vector quantizer for KV-cache and approximate nearest-neighbour search**, not for static weight compression. Engineering simplifications during development — choosing scalar over vector quantization, WHT over general random rotations, Lloyd–Max over learned grids — converged the weight path onto the HIGGS scalar algorithm. The KV-cache application of TurboQuant is implemented separately in [#38479](https://github.com/vllm-project/vllm/pull/38479) by @vibhavagarwal5.
+
+The `turboquant` name is kept for API and plugin-package compatibility (`--quantization turboquant`, `OnlineQuantScheme.TURBOQUANT`), but **HIGGS is the correct primary citation** for the algorithm in this weight-compression path.
 
 ## When to use TurboQuant
 

--- a/docs/features/quantization/turboquant.md
+++ b/docs/features/quantization/turboquant.md
@@ -42,6 +42,7 @@ Defaults to 3-bit weights with group size 128.
 
 - **Linear layers** — compressed to 3-bit (default) using `TurboQuantOnlineLinearMethod`.
 - **MoE experts** — kept at BF16 in this release. Dispatch falls back to the default unquantized MoE method. MoE support is planned in a follow-up.
+- **Hardware-native FP4 (MXFP4/NVFP4) is out of scope.** The Walsh–Hadamard rotation is applied globally across each weight group, which is fine for per-row scaling but conflicts with per-block scaled formats — a global rotation spreads outlier mass across block boundaries and pollutes the per-block scales. Block-aligned rotation for those formats is a separate PR.
 
 Layers can be excluded via the `ignore` list in the `OnlineQuantizationConfigArgs`:
 

--- a/docs/features/quantization/turboquant.md
+++ b/docs/features/quantization/turboquant.md
@@ -36,7 +36,17 @@ from vllm import LLM
 llm = LLM(model="...", quantization="turboquant")
 ```
 
-Defaults to 3-bit weights with group size 128.
+Defaults to 3-bit weights with group size 128. To pick a different bit width (2, 3, or 4):
+
+```bash
+vllm serve <model> --quantization turboquant --quantization-config '{"bits": 4}'
+```
+
+Or via the Python API:
+
+```python
+llm = LLM(model="...", quantization="turboquant", quantization_config={"bits": 4})
+```
 
 ## What gets quantized
 

--- a/docs/features/quantization/turboquant.md
+++ b/docs/features/quantization/turboquant.md
@@ -1,0 +1,63 @@
+# TurboQuant (Online 3-4 bit Weight Compression)
+
+TurboQuant is an online weight-only quantization scheme based on [Zandieh et al., ICLR 2026](https://arxiv.org/abs/2503.19878). It compresses BF16 weights to 3 or 4 bits at model load time and requires **no calibration data**.
+
+TurboQuant combines three techniques:
+
+1. **Walsh–Hadamard randomized rotation** of weight groups. After rotation each coordinate is approximately `N(0, 1/d)`, which lets a small shared codebook work well across all weights.
+2. **Lloyd–Max optimal scalar quantization** at 2/3/4 bits into a 4/8/16-entry codebook.
+3. **Per-group norm correction** — we store `original_norm / reconstruction_norm` (not raw L2 norms), which halves the quantization error at 3 bits in practice.
+
+## When to use TurboQuant
+
+- You have a standard BF16 checkpoint and want to serve it at ~4× smaller GPU memory with **zero calibration work**.
+- You want a serving-time drop-in: no offline pre-processing of the checkpoint, no additional tools.
+- You accept a small quality cost in exchange for fitting larger models on smaller GPUs.
+
+## Quick start
+
+```bash
+vllm serve <model> --quantization turboquant
+```
+
+Or via the Python API:
+
+```python
+from vllm import LLM
+
+llm = LLM(model="...", quantization="turboquant")
+```
+
+Defaults to 3-bit weights with group size 128.
+
+## What gets quantized
+
+- **Linear layers** — compressed to 3-bit (default) using `TurboQuantOnlineLinearMethod`.
+- **MoE experts** — kept at BF16 in this release. Dispatch falls back to the default unquantized MoE method. MoE support is planned in a follow-up.
+
+Layers can be excluded via the `ignore` list in the `OnlineQuantizationConfigArgs`:
+
+```python
+llm = LLM(
+    model="...",
+    quantization="turboquant",
+    quantization_config={
+        "ignore": ["re:.*lm_head.*", "model.layers.0.self_attn.o_proj"],
+    },
+)
+```
+
+## Implementation notes
+
+- **Zero GPU memory at init**. Weights are allocated on the meta device; only the compressed form materializes on GPU, per layer, during `process_weights_after_loading`.
+- **Two Triton kernels** are registered as `torch.library.custom_op` with `register_fake`, so they're fullgraph- and `torch.compile`-safe. The runtime picks between them based on output dimension — a fused dequant-GEMM for smaller outputs, and an FWHT-on-input GEMM for larger outputs (single rotation of the activation instead of N inverse rotations of rows).
+- **BF16 tensor cores** are used for the main GEMM. The accumulator is kept in FP32.
+- A PyTorch fallback path runs when Triton is unavailable (useful for CPU debugging).
+
+## Minimum hardware
+
+| Implementation | Volta | Turing | Ampere | Ada | Hopper |
+| -------------- | ----- | ------ | ------ | --- | ------ |
+| TurboQuant     | ❌    | ❌     | ✅︎     | ✅︎  | ✅︎     |
+
+Minimum compute capability is 8.0 (Ampere). The GEMM kernels cast to the model's activation dtype (BF16 or FP16) before `tl.dot` to use Tensor Cores. BF16 Tensor Cores were introduced in Ampere; Turing's 2nd-gen Tensor Cores only support FP16 and would fail on BF16 weights.

--- a/docs/features/quantization/turboquant.md
+++ b/docs/features/quantization/turboquant.md
@@ -1,0 +1,75 @@
+# TurboQuant (Online 2-4 bit Weight Compression)
+
+`--quantization turboquant` is an online weight-only quantization scheme that compresses BF16 weights to 2, 3, or 4 bits at model load time and requires **no calibration data**.
+
+It combines three techniques:
+
+1. **Walsh–Hadamard randomized rotation** of weight groups. After rotation each coordinate is approximately `N(0, 1/d)`, which lets a small shared codebook work well across all weights.
+2. **Lloyd–Max optimal scalar quantization** at 2/3/4 bits into a 4/8/16-entry codebook.
+3. **Per-group shape-gain decomposition** — we store `original_norm / reconstruction_norm` (the classical shape-gain factor, Gray 1984) rather than raw L2 norms. This halves the 3-bit reconstruction error in practice by accounting for the norm shrinkage introduced by the quantization step itself.
+
+## Background and naming
+
+The algorithm implemented here is the **scalar case of HIGGS** (Malinovskii, Panferov, Ilin, Guo, Richtárik, Alistarh — *Pushing the Limits of Large Language Model Quantization via the Linearity Theorem*, [NAACL 2025](https://aclanthology.org/2025.naacl-long.543/); preprint [arXiv:2411.17525](https://arxiv.org/abs/2411.17525)). HIGGS describes exactly this combination of Random Hadamard Transform pre-processing, MSE-optimal Lloyd–Max grid, and per-group L2 normalization. A reference implementation also exists in [HuggingFace transformers](https://github.com/huggingface/transformers/blob/main/docs/source/en/quantization/higgs.md).
+
+The implementation was originally based on **TurboQuant** ([Zandieh et al., ICLR 2026, arXiv:2504.19874](https://arxiv.org/abs/2504.19874)), which is actually an **online vector quantizer for KV-cache and approximate nearest-neighbour search**, not for static weight compression. Engineering simplifications during development — choosing scalar over vector quantization, WHT over general random rotations, Lloyd–Max over learned grids — converged the weight path onto the HIGGS scalar algorithm. The KV-cache application of TurboQuant is implemented separately in [#38479](https://github.com/vllm-project/vllm/pull/38479) by @vibhavagarwal5.
+
+The `turboquant` name is kept for API and plugin-package compatibility, but **HIGGS is the correct primary citation** for the algorithm in this weight-compression path.
+
+## When to use TurboQuant
+
+- You have a standard BF16 checkpoint and want to serve it at ~4× smaller GPU memory with **zero calibration work**.
+- You want a serving-time drop-in: no offline pre-processing of the checkpoint, no additional tools.
+- You accept a small quality cost in exchange for fitting larger models on smaller GPUs.
+
+## Quick start
+
+```bash
+vllm serve <model> --quantization turboquant            # TQ3, group 128 (default)
+vllm serve <model> --quantization turboquant_4bit       # TQ4 (conservative)
+vllm serve <model> --quantization turboquant_2bit       # TQ2 (aggressive)
+```
+
+Or via the Python API:
+
+```python
+from vllm import LLM
+
+llm = LLM(model="...", quantization="turboquant")        # TQ3
+llm = LLM(model="...", quantization="turboquant_4bit")   # TQ4
+```
+
+Each shorthand maps to a distinct `QuantKey` (`kTurboquantW2` / `kTurboquantW3` / `kTurboquantW4`) and a matching method class. Group size 128 is the only validated codebook today.
+
+## What gets quantized
+
+- **Linear layers** — compressed to the selected bit width via `TurboQuantW2/W3/W4OnlineLinearMethod`.
+- **MoE experts** — kept at BF16 in this release. The dispatch table has no MoE entry for the TurboQuant `QuantKey`s, so `OnlineQuantizationConfig` falls through to the default unquantized MoE method. MoE support is planned in a follow-up.
+- **Hardware-native FP4 (MXFP4/NVFP4) is out of scope.** The Walsh–Hadamard rotation is applied globally across each weight group, which is fine for per-row scaling but conflicts with per-block scaled formats — a global rotation spreads outlier mass across block boundaries and pollutes the per-block scales. Block-aligned rotation for those formats is a separate PR.
+
+Layers can be excluded via the `ignore` list on `quantization_config`:
+
+```python
+llm = LLM(
+    model="...",
+    quantization="turboquant",
+    quantization_config={
+        "ignore": ["re:.*lm_head.*", "model.layers.0.self_attn.o_proj"],
+    },
+)
+```
+
+## Implementation notes
+
+- **Zero GPU memory at init**. Weights are allocated on the meta device; only the compressed form materializes on GPU, per layer, during `process_weights_after_loading`.
+- **Two Triton kernels** are registered as `torch.library.custom_op` with `register_fake`, so they're fullgraph- and `torch.compile`-safe. The runtime picks between them based on output dimension — a fused dequant-GEMM for smaller outputs, and an FWHT-on-input GEMM for larger outputs (single rotation of the activation instead of N inverse rotations of rows).
+- **BF16 tensor cores** are used for the main GEMM. The accumulator is kept in FP32.
+- A PyTorch fallback path runs when Triton is unavailable (useful for CPU debugging).
+
+## Minimum hardware
+
+| Implementation | Volta | Turing | Ampere | Ada | Hopper |
+| -------------- | ----- | ------ | ------ | --- | ------ |
+| TurboQuant     | ❌    | ❌     | ✅︎     | ✅︎  | ✅︎     |
+
+Minimum compute capability is 8.0 (Ampere). The GEMM kernels cast to the model's activation dtype (BF16 or FP16) before `tl.dot` to use Tensor Cores. BF16 Tensor Cores were introduced in Ampere; Turing's 2nd-gen Tensor Cores only support FP16 and would fail on BF16 weights.

--- a/tests/quantization/test_turboquant_online.py
+++ b/tests/quantization/test_turboquant_online.py
@@ -1,0 +1,452 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for TurboQuant online weight compression.
+
+Tests the codebook, pack/unpack, quantize/dequantize, and WHT rotation
+from vllm.model_executor.layers.quantization.online.turboquant.
+
+These are all CPU-only and can run without a GPU.
+
+Run: python -m pytest tests/quantization/test_turboquant_online.py -v
+"""
+
+import math
+
+import pytest
+import torch
+import torch.nn as nn
+
+from vllm.model_executor.layers.quantization.online.turboquant import (
+    TurboQuantOnlineLinearMethod,
+    _fast_wht_batch,
+    _get_quantizer,
+    _lloyd_max_centroids,
+    _optimal_centroids,
+    _pack_indices,
+    _padded_size,
+    _PolarQuant,
+    _unpack_indices,
+)
+from vllm.utils.math_utils import next_power_of_2
+
+# ============================================================================
+# Codebook tests
+# ============================================================================
+
+
+class TestCodebook:
+    @pytest.mark.parametrize("bits", [2, 3, 4])
+    def test_centroid_count(self, bits):
+        centroids = _optimal_centroids(bits, dim=128)
+        assert len(centroids) == 2**bits
+
+    @pytest.mark.parametrize("bits", [2, 3, 4])
+    def test_centroids_sorted(self, bits):
+        centroids = _optimal_centroids(bits, dim=128)
+        for i in range(len(centroids) - 1):
+            assert centroids[i] < centroids[i + 1]
+
+    @pytest.mark.parametrize("bits", [2, 3, 4])
+    def test_centroids_symmetric(self, bits):
+        centroids = _optimal_centroids(bits, dim=128)
+        assert abs(centroids[0] + centroids[-1]) < 1e-3
+
+    @pytest.mark.parametrize("bits", [3, 4])
+    def test_lloyd_max_converges(self, bits):
+        sigma = 1.0 / math.sqrt(128)
+        centroids = _lloyd_max_centroids(2**bits, sigma)
+        assert len(centroids) == 2**bits
+        for c in centroids:
+            assert abs(c) < 4 * sigma
+
+    @pytest.mark.parametrize("dim", [64, 128, 256, 512])
+    def test_centroids_scale_with_dim(self, dim):
+        """Centroids should scale as ~1/sqrt(dim) for post-rotation coordinates."""
+        c = _optimal_centroids(3, dim)
+        # Magnitude should decrease with increasing dim
+        max_c = max(abs(v) for v in c)
+        assert max_c < 2.0 / math.sqrt(dim)
+
+
+# ============================================================================
+# 3-bit packing — the hard part (cross-byte boundaries)
+#
+# The breakthrough fix: 8 values × 3 bits = 24 bits = 3 bytes.
+# Values at positions 2 and 5 cross byte boundaries.
+# ============================================================================
+
+
+class TestPackUnpack:
+    @pytest.mark.parametrize("bits", [2, 3, 4])
+    @pytest.mark.parametrize("dim", [64, 128, 256])
+    def test_roundtrip(self, bits, dim):
+        n_rows = 16
+        max_val = 2**bits
+        indices = torch.randint(0, max_val, (n_rows, dim), dtype=torch.int64)
+        packed = _pack_indices(indices, bits)
+        unpacked = _unpack_indices(packed, bits, dim)
+        assert torch.equal(unpacked, indices), (
+            f"bits={bits}, dim={dim}: pack/unpack roundtrip failed"
+        )
+
+    @pytest.mark.parametrize("bits", [2, 3, 4])
+    def test_packed_is_smaller(self, bits):
+        dim = 128
+        n_rows = 8
+        indices = torch.randint(0, 2**bits, (n_rows, dim), dtype=torch.int64)
+        packed = _pack_indices(indices, bits)
+        assert packed.numel() * packed.element_size() < indices.numel() * indices.element_size()
+
+    def test_unpack_truncates_to_dim(self):
+        """Unpack should return exactly `dim` columns even with non-aligned dim."""
+        dim = 100  # not aligned to 8 (for 3-bit)
+        indices = torch.randint(0, 8, (4, dim), dtype=torch.int64)
+        packed = _pack_indices(indices, bits=3)
+        unpacked = _unpack_indices(packed, bits=3, dim=dim)
+        assert unpacked.shape == (4, dim)
+        assert torch.equal(unpacked, indices)
+
+    def test_3bit_cross_byte_boundary(self):
+        """Verify 3-bit packing handles cross-byte values at positions 2 and 5.
+
+        Layout: 8 values → 3 bytes
+        byte0: [v0:3][v1:3][v2_lo:2]
+        byte1: [v2_hi:1][v3:3][v4:3][v5_lo:1]
+        byte2: [v5_hi:2][v6:3][v7:3]
+
+        Values at positions 2 and 5 split across two bytes.
+        """
+        # All max values (0b111 = 7) to stress every bit
+        indices = torch.full((1, 8), 7, dtype=torch.int64)
+        packed = _pack_indices(indices, bits=3)
+        unpacked = _unpack_indices(packed, bits=3, dim=8)
+        assert torch.equal(unpacked, indices)
+
+        # Alternating pattern: catches swap/shift errors
+        indices = torch.tensor([[0, 7, 0, 7, 0, 7, 0, 7]], dtype=torch.int64)
+        packed = _pack_indices(indices, bits=3)
+        unpacked = _unpack_indices(packed, bits=3, dim=8)
+        assert torch.equal(unpacked, indices)
+
+        # Specifically test cross-byte positions 2 and 5
+        for pos in [2, 5]:
+            for val in range(8):
+                indices = torch.zeros(1, 8, dtype=torch.int64)
+                indices[0, pos] = val
+                packed = _pack_indices(indices, bits=3)
+                unpacked = _unpack_indices(packed, bits=3, dim=8)
+                assert unpacked[0, pos] == val, (
+                    f"3-bit cross-byte fail: pos={pos}, val={val}, got={unpacked[0, pos]}"
+                )
+
+    @pytest.mark.parametrize("dim", [8, 16, 24, 48, 120, 128])
+    def test_3bit_various_dims(self, dim):
+        """3-bit packing at various dimensions including exact and non-exact multiples of 8."""
+        indices = torch.randint(0, 8, (4, dim), dtype=torch.int64)
+        packed = _pack_indices(indices, bits=3)
+        unpacked = _unpack_indices(packed, bits=3, dim=dim)
+        assert torch.equal(unpacked, indices)
+
+    def test_3bit_compression_ratio(self):
+        """3-bit packing should achieve 3/8 bytes per element (62.5% savings)."""
+        dim = 128
+        indices = torch.randint(0, 8, (1, dim), dtype=torch.int64)
+        packed = _pack_indices(indices, bits=3)
+        # 128 values × 3 bits = 384 bits = 48 bytes
+        assert packed.shape[1] == 48, (
+            f"Expected 48 packed bytes for dim=128, got {packed.shape[1]}"
+        )
+
+
+# ============================================================================
+# Padded size helper
+# ============================================================================
+
+
+class TestPaddedSize:
+    def test_exact_multiple(self):
+        padded, n_groups = _padded_size(256, 128)
+        assert padded == 256
+        assert n_groups == 2
+
+    def test_needs_padding(self):
+        padded, n_groups = _padded_size(200, 128)
+        assert padded == 256
+        assert n_groups == 2
+
+    def test_small_dim(self):
+        padded, n_groups = _padded_size(64, 128)
+        assert padded == 128
+        assert n_groups == 1
+
+
+# ============================================================================
+# WHT rotation
+# ============================================================================
+
+
+class TestWHT:
+    @pytest.mark.parametrize("n", [64, 128, 256])
+    def test_wht_involution(self, n):
+        """WHT applied twice (with normalization) should return the original."""
+        x = torch.randn(4, n)
+        y = _fast_wht_batch(x.clone())
+        z = _fast_wht_batch(y.clone())
+        assert torch.allclose(z, x, atol=1e-5), "WHT is not an involution"
+
+    def test_wht_orthogonal(self):
+        """WHT should preserve norms (up to float precision)."""
+        x = torch.randn(8, 128)
+        y = _fast_wht_batch(x.clone())
+        x_norms = torch.linalg.norm(x, dim=1)
+        y_norms = torch.linalg.norm(y, dim=1)
+        assert torch.allclose(x_norms, y_norms, atol=1e-4)
+
+    def test_wht_requires_power_of_2(self):
+        """WHT only works with power-of-2 dimensions."""
+        x = torch.randn(2, 128, device="cpu")
+        y = _fast_wht_batch(x.clone())
+        assert y.shape == (2, 128)
+
+
+# ============================================================================
+# PolarQuant quantize/dequantize
+# ============================================================================
+
+
+class TestPolarQuant:
+    @pytest.mark.parametrize("bits", [3, 4])
+    def test_roundtrip_error(self, bits):
+        """Quantize→dequantize should have bounded relative error."""
+        dim = 128
+        pq = _PolarQuant(dim, bits, device="cpu")
+        x = torch.randn(32, dim)
+        indices, norms = pq.quantize(x)
+        x_hat = pq.dequantize(indices, norms)
+
+        row_err = (x - x_hat).norm(dim=1) / x.norm(dim=1).clamp(min=1e-8)
+        mean_err = row_err.mean().item()
+
+        # TQ3 ~18%, TQ4 ~10% relative error
+        max_acceptable = 0.30 if bits == 3 else 0.20
+        assert mean_err < max_acceptable, (
+            f"bits={bits}: mean relative error {mean_err:.3f} > {max_acceptable}"
+        )
+
+    @pytest.mark.parametrize("bits", [3, 4])
+    def test_indices_in_range(self, bits):
+        dim = 128
+        pq = _PolarQuant(dim, bits, device="cpu")
+        x = torch.randn(16, dim)
+        indices, _ = pq.quantize(x)
+        assert indices.min() >= 0
+        assert indices.max() < 2**bits
+
+    def test_deterministic(self):
+        pq = _PolarQuant(128, 3, device="cpu")
+        x = torch.randn(8, 128)
+        idx1, n1 = pq.quantize(x)
+        idx2, n2 = pq.quantize(x)
+        assert torch.equal(idx1, idx2)
+        assert torch.equal(n1, n2)
+
+    def test_zero_vector(self):
+        """Zero input should not crash."""
+        pq = _PolarQuant(128, 3, device="cpu")
+        x = torch.zeros(2, 128)
+        indices, norms = pq.quantize(x)
+        x_hat = pq.dequantize(indices, norms)
+        assert torch.allclose(x_hat, torch.zeros_like(x_hat), atol=1e-6)
+
+    def test_norm_correction(self):
+        """Stored norms should differ from raw L2 norms (norm correction ratio).
+
+        PolarQuant stores original_norm / reconstruction_norm, not raw norms.
+        This correction is critical for quality — without it, TQ3 error is ~2x worse.
+        """
+        dim = 128
+        pq = _PolarQuant(dim, 3, device="cpu")
+        x = torch.randn(16, dim)
+        raw_norms = torch.linalg.norm(x, dim=1)
+        _, corrected_norms = pq.quantize(x)
+
+        # Corrected norms should be close to but not exactly equal to raw norms
+        # (ratio = original_norm / recon_norm, which is ~1.0 but not 1.0)
+        assert not torch.equal(raw_norms, corrected_norms), (
+            "Norms should be corrected (original/recon ratio), not raw L2"
+        )
+        # But they should be in the same ballpark
+        ratio = corrected_norms / raw_norms.clamp(min=1e-8)
+        assert ratio.mean().item() == pytest.approx(1.0, abs=0.1)
+
+    @pytest.mark.parametrize("dim", [64, 96, 200])
+    def test_non_power_of_2_dim(self, dim):
+        """PolarQuant should handle non-power-of-2 dims by padding internally."""
+        pq = _PolarQuant(dim, 3, device="cpu")
+        assert pq.padded_dim == next_power_of_2(dim)
+        assert pq.padded_dim >= dim
+
+        x = torch.randn(8, dim)
+        indices, norms = pq.quantize(x)
+        x_hat = pq.dequantize(indices, norms)
+        assert x_hat.shape == (8, dim)
+
+    def test_rotation_is_orthogonal(self):
+        """Forward and inverse rotation should compose to identity."""
+        pq = _PolarQuant(128, 3, device="cpu")
+        x = torch.randn(4, 128)
+        y = pq._rotate(x)
+        x_back = pq._rotate_inverse(y)
+        assert torch.allclose(x_back, x, atol=1e-5)
+
+    def test_quantizer_cache(self):
+        """_get_quantizer should return the same instance for same params."""
+        q1 = _get_quantizer(128, 3, "cpu")
+        q2 = _get_quantizer(128, 3, "cpu")
+        assert q1 is q2
+
+        q3 = _get_quantizer(128, 4, "cpu")
+        assert q3 is not q1
+
+
+# ============================================================================
+# process_weights_after_loading: idempotency guard
+#
+# vLLM calls this twice (online processing + global sweep).
+# Second call must be a no-op.
+# ============================================================================
+
+
+class TestProcessWeightsIdempotency:
+    def test_double_call_is_noop(self):
+        """Second call to process_weights_after_loading should be a no-op."""
+        method = TurboQuantOnlineLinearMethod(bits=3, group_size=128)
+        layer = nn.Module()
+        layer.weight = nn.Parameter(torch.randn(64, 128, device="cpu"))
+
+        method.process_weights_after_loading(layer)
+
+        # After first call: weight replaced with empty, TQ buffers present
+        assert layer.weight.numel() == 0
+        assert hasattr(layer, "tq_packed_weight")
+        packed_id = id(layer.tq_packed_weight)
+
+        # Second call should be a no-op (guard fires)
+        method.process_weights_after_loading(layer)
+        assert id(layer.tq_packed_weight) == packed_id
+
+    def test_weight_kept_as_empty(self):
+        """After compression, layer.weight should be empty(0) — not deleted.
+
+        MLA post-processing in vLLM expects layer.weight to exist.
+        """
+        method = TurboQuantOnlineLinearMethod(bits=3, group_size=128)
+        layer = nn.Module()
+        layer.weight = nn.Parameter(torch.randn(64, 128, device="cpu"))
+
+        method.process_weights_after_loading(layer)
+        assert hasattr(layer, "weight")
+        assert layer.weight.numel() == 0
+
+    def test_guard_attribute_set(self):
+        """The _already_called flag should be set after processing."""
+        method = TurboQuantOnlineLinearMethod(bits=3, group_size=128)
+        layer = nn.Module()
+        layer.weight = nn.Parameter(torch.randn(64, 128, device="cpu"))
+
+        assert not getattr(layer, "_already_called_process_weights_after_loading", False)
+        method.process_weights_after_loading(layer)
+        assert layer._already_called_process_weights_after_loading is True
+
+
+# ============================================================================
+# End-to-end: compress a Linear weight, check output
+# ============================================================================
+
+
+class TestLinearCompression:
+    @pytest.mark.parametrize("bits", [3, 4])
+    def test_compress_and_matmul(self, bits):
+        """Compress a weight matrix, decompress, verify matmul is close."""
+        in_dim, out_dim = 128, 64
+        group_size = 128
+
+        w = torch.randn(out_dim, in_dim)
+        x = torch.randn(4, in_dim)
+        ref = x @ w.t()
+
+        pq = _PolarQuant(group_size, bits, device="cpu")
+        grouped = w.reshape(-1, group_size)
+        indices, norms_raw = pq.quantize(grouped)
+        packed = _pack_indices(indices, bits)
+
+        unpacked = _unpack_indices(packed, bits, group_size)
+        w_hat_groups = pq.dequantize(unpacked, norms_raw)
+        w_hat = w_hat_groups.reshape(out_dim, -1)[:, :in_dim]
+
+        out = x @ w_hat.t()
+        cos_sim = torch.nn.functional.cosine_similarity(ref, out, dim=1)
+        threshold = 0.85 if bits == 3 else 0.92
+        assert cos_sim.min().item() > threshold, (
+            f"bits={bits}: min cosine similarity {cos_sim.min():.4f} < {threshold}"
+        )
+
+    def test_apply_fallback_path(self):
+        """TurboQuantOnlineLinearMethod.apply() PyTorch fallback (no Triton)."""
+        method = TurboQuantOnlineLinearMethod(bits=3, group_size=128)
+        layer = nn.Module()
+        layer.weight = nn.Parameter(torch.randn(64, 128, device="cpu"))
+
+        method.process_weights_after_loading(layer)
+
+        # Force PyTorch fallback by clearing Triton dispatch
+        layer._tq_primary_fn = None
+
+        x = torch.randn(2, 128, device="cpu")
+        out = method.apply(layer, x, bias=None)
+        assert out.shape == (2, 64)
+
+        # With bias
+        bias = torch.randn(64, device="cpu")
+        out_bias = method.apply(layer, x, bias=bias)
+        assert out_bias.shape == (2, 64)
+
+    def test_apply_with_padding(self):
+        """Compression should work when in_dim is not a multiple of group_size."""
+        method = TurboQuantOnlineLinearMethod(bits=3, group_size=128)
+        layer = nn.Module()
+        # in_dim=200 requires padding to 256 (2 groups of 128)
+        layer.weight = nn.Parameter(torch.randn(64, 200, device="cpu"))
+
+        method.process_weights_after_loading(layer)
+        layer._tq_primary_fn = None  # force fallback
+
+        x = torch.randn(2, 200, device="cpu")
+        out = method.apply(layer, x, bias=None)
+        assert out.shape == (2, 64)
+
+    def test_apply_zero_tokens(self):
+        """apply() should handle M=0 (zero-token batch in chunked prefill)."""
+        method = TurboQuantOnlineLinearMethod(bits=3, group_size=128)
+        layer = nn.Module()
+        layer.weight = nn.Parameter(torch.randn(64, 128, device="cpu"))
+
+        method.process_weights_after_loading(layer)
+        layer._tq_primary_fn = None
+
+        x = torch.randn(0, 128, device="cpu")
+        out = method.apply(layer, x, bias=None)
+        assert out.shape == (0, 64)
+
+    def test_3d_input(self):
+        """apply() should handle 3D input (batch, seq, features)."""
+        method = TurboQuantOnlineLinearMethod(bits=3, group_size=128)
+        layer = nn.Module()
+        layer.weight = nn.Parameter(torch.randn(64, 128, device="cpu"))
+
+        method.process_weights_after_loading(layer)
+        layer._tq_primary_fn = None
+
+        x = torch.randn(2, 8, 128, device="cpu")
+        out = method.apply(layer, x, bias=None)
+        assert out.shape == (2, 8, 64)

--- a/tests/quantization/test_turboquant_online.py
+++ b/tests/quantization/test_turboquant_online.py
@@ -10,8 +10,6 @@ These are all CPU-only and can run without a GPU.
 Run: python -m pytest tests/quantization/test_turboquant_online.py -v
 """
 
-import math
-
 import pytest
 import torch
 import torch.nn as nn
@@ -20,8 +18,6 @@ from vllm.model_executor.layers.quantization.online.turboquant import (
     TurboQuantOnlineLinearMethod,
     _fast_wht_batch,
     _get_quantizer,
-    _lloyd_max_centroids,
-    _optimal_centroids,
     _pack_indices,
     _padded_size,
     _PolarQuant,
@@ -29,43 +25,9 @@ from vllm.model_executor.layers.quantization.online.turboquant import (
 )
 from vllm.utils.math_utils import next_power_of_2
 
-# ============================================================================
-# Codebook tests
-# ============================================================================
-
-
-class TestCodebook:
-    @pytest.mark.parametrize("bits", [2, 3, 4])
-    def test_centroid_count(self, bits):
-        centroids = _optimal_centroids(bits, dim=128)
-        assert len(centroids) == 2**bits
-
-    @pytest.mark.parametrize("bits", [2, 3, 4])
-    def test_centroids_sorted(self, bits):
-        centroids = _optimal_centroids(bits, dim=128)
-        for i in range(len(centroids) - 1):
-            assert centroids[i] < centroids[i + 1]
-
-    @pytest.mark.parametrize("bits", [2, 3, 4])
-    def test_centroids_symmetric(self, bits):
-        centroids = _optimal_centroids(bits, dim=128)
-        assert abs(centroids[0] + centroids[-1]) < 1e-3
-
-    @pytest.mark.parametrize("bits", [3, 4])
-    def test_lloyd_max_converges(self, bits):
-        sigma = 1.0 / math.sqrt(128)
-        centroids = _lloyd_max_centroids(2**bits, sigma)
-        assert len(centroids) == 2**bits
-        for c in centroids:
-            assert abs(c) < 4 * sigma
-
-    @pytest.mark.parametrize("dim", [64, 128, 256, 512])
-    def test_centroids_scale_with_dim(self, dim):
-        """Centroids should scale as ~1/sqrt(dim) for post-rotation coordinates."""
-        c = _optimal_centroids(3, dim)
-        # Magnitude should decrease with increasing dim
-        max_c = max(abs(v) for v in c)
-        assert max_c < 2.0 / math.sqrt(dim)
+# Codebook correctness is tested in tests/quantization/test_turboquant.py
+# (covers the shared vllm.model_executor.layers.quantization.turboquant.centroids
+# module this PR reuses).
 
 
 # ============================================================================

--- a/tests/quantization/test_turboquant_online.py
+++ b/tests/quantization/test_turboquant_online.py
@@ -412,3 +412,30 @@ class TestLinearCompression:
         x = torch.randn(2, 8, 128, device="cpu")
         out = method.apply(layer, x, bias=None)
         assert out.shape == (2, 8, 64)
+
+
+class TestTurboQuantConfigValidation:
+    """Constructor rejects bit widths and group sizes the packing code can't handle."""
+
+    @pytest.mark.parametrize("bits", [2, 3, 4])
+    def test_accepts_supported_bits(self, bits):
+        method = TurboQuantOnlineLinearMethod(bits=bits)
+        assert method.bits == bits
+
+    @pytest.mark.parametrize("bits", [0, 1, 5, 8, -1])
+    def test_rejects_unsupported_bits(self, bits):
+        with pytest.raises(ValueError, match=r"turboquant bits must be 2, 3, or 4"):
+            TurboQuantOnlineLinearMethod(bits=bits)
+
+    @pytest.mark.parametrize("group_size", [0, -128, 7, 15, 129])
+    def test_rejects_bad_group_size(self, group_size):
+        with pytest.raises(
+            ValueError, match=r"turboquant group_size must be a positive"
+        ):
+            TurboQuantOnlineLinearMethod(group_size=group_size)
+
+    def test_default_params(self):
+        """Default construction matches the documented defaults."""
+        method = TurboQuantOnlineLinearMethod()
+        assert method.bits == 3
+        assert method.group_size == 128

--- a/tests/quantization/test_turboquant_online.py
+++ b/tests/quantization/test_turboquant_online.py
@@ -1,0 +1,458 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for TurboQuant online weight compression.
+
+Tests the codebook, pack/unpack, quantize/dequantize, and WHT rotation
+from vllm.model_executor.layers.quantization.online.turboquant.
+
+These are all CPU-only and can run without a GPU.
+
+Run: python -m pytest tests/quantization/test_turboquant_online.py -v
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+
+from vllm.model_executor.layers.quantization.online.turboquant import (
+    TurboQuantW2OnlineLinearMethod,
+    TurboQuantW3OnlineLinearMethod,
+    TurboQuantW4OnlineLinearMethod,
+    _fast_wht_batch,
+    _get_quantizer,
+    _pack_indices,
+    _padded_size,
+    _PolarQuant,
+    _TurboQuantOnlineLinearMethodBase,
+    _unpack_indices,
+)
+from vllm.utils.math_utils import next_power_of_2
+
+# Codebook correctness is tested in tests/quantization/test_turboquant.py
+# (covers the shared vllm.model_executor.layers.quantization.turboquant.centroids
+# module this PR reuses).
+
+
+# ============================================================================
+# 3-bit packing — the hard part (cross-byte boundaries)
+#
+# The breakthrough fix: 8 values × 3 bits = 24 bits = 3 bytes.
+# Values at positions 2 and 5 cross byte boundaries.
+# ============================================================================
+
+
+class TestPackUnpack:
+    @pytest.mark.parametrize("bits", [2, 3, 4])
+    @pytest.mark.parametrize("dim", [64, 128, 256])
+    def test_roundtrip(self, bits, dim):
+        n_rows = 16
+        max_val = 2**bits
+        indices = torch.randint(0, max_val, (n_rows, dim), dtype=torch.int64)
+        packed = _pack_indices(indices, bits)
+        unpacked = _unpack_indices(packed, bits, dim)
+        assert torch.equal(unpacked, indices), (
+            f"bits={bits}, dim={dim}: pack/unpack roundtrip failed"
+        )
+
+    @pytest.mark.parametrize("bits", [2, 3, 4])
+    def test_packed_is_smaller(self, bits):
+        dim = 128
+        n_rows = 8
+        indices = torch.randint(0, 2**bits, (n_rows, dim), dtype=torch.int64)
+        packed = _pack_indices(indices, bits)
+        assert (
+            packed.numel() * packed.element_size()
+            < indices.numel() * indices.element_size()
+        )
+
+    def test_unpack_truncates_to_dim(self):
+        """Unpack should return exactly `dim` columns even with non-aligned dim."""
+        dim = 100  # not aligned to 8 (for 3-bit)
+        indices = torch.randint(0, 8, (4, dim), dtype=torch.int64)
+        packed = _pack_indices(indices, bits=3)
+        unpacked = _unpack_indices(packed, bits=3, dim=dim)
+        assert unpacked.shape == (4, dim)
+        assert torch.equal(unpacked, indices)
+
+    def test_3bit_cross_byte_boundary(self):
+        """Verify 3-bit packing handles cross-byte values at positions 2 and 5.
+
+        Layout: 8 values → 3 bytes
+        byte0: [v0:3][v1:3][v2_lo:2]
+        byte1: [v2_hi:1][v3:3][v4:3][v5_lo:1]
+        byte2: [v5_hi:2][v6:3][v7:3]
+
+        Values at positions 2 and 5 split across two bytes.
+        """
+        # All max values (0b111 = 7) to stress every bit
+        indices = torch.full((1, 8), 7, dtype=torch.int64)
+        packed = _pack_indices(indices, bits=3)
+        unpacked = _unpack_indices(packed, bits=3, dim=8)
+        assert torch.equal(unpacked, indices)
+
+        # Alternating pattern: catches swap/shift errors
+        indices = torch.tensor([[0, 7, 0, 7, 0, 7, 0, 7]], dtype=torch.int64)
+        packed = _pack_indices(indices, bits=3)
+        unpacked = _unpack_indices(packed, bits=3, dim=8)
+        assert torch.equal(unpacked, indices)
+
+        # Specifically test cross-byte positions 2 and 5
+        for pos in [2, 5]:
+            for val in range(8):
+                indices = torch.zeros(1, 8, dtype=torch.int64)
+                indices[0, pos] = val
+                packed = _pack_indices(indices, bits=3)
+                unpacked = _unpack_indices(packed, bits=3, dim=8)
+                assert unpacked[0, pos] == val, (
+                    f"3-bit cross-byte fail: pos={pos}, val={val}, "
+                    f"got={unpacked[0, pos]}"
+                )
+
+    @pytest.mark.parametrize("dim", [8, 16, 24, 48, 120, 128])
+    def test_3bit_various_dims(self, dim):
+        """3-bit packing at various dims including non-multiples of 8."""
+        indices = torch.randint(0, 8, (4, dim), dtype=torch.int64)
+        packed = _pack_indices(indices, bits=3)
+        unpacked = _unpack_indices(packed, bits=3, dim=dim)
+        assert torch.equal(unpacked, indices)
+
+    def test_3bit_compression_ratio(self):
+        """3-bit packing should achieve 3/8 bytes per element (62.5% savings)."""
+        dim = 128
+        indices = torch.randint(0, 8, (1, dim), dtype=torch.int64)
+        packed = _pack_indices(indices, bits=3)
+        # 128 values × 3 bits = 384 bits = 48 bytes
+        assert packed.shape[1] == 48, (
+            f"Expected 48 packed bytes for dim=128, got {packed.shape[1]}"
+        )
+
+
+# ============================================================================
+# Padded size helper
+# ============================================================================
+
+
+class TestPaddedSize:
+    def test_exact_multiple(self):
+        padded, n_groups = _padded_size(256, 128)
+        assert padded == 256
+        assert n_groups == 2
+
+    def test_needs_padding(self):
+        padded, n_groups = _padded_size(200, 128)
+        assert padded == 256
+        assert n_groups == 2
+
+    def test_small_dim(self):
+        padded, n_groups = _padded_size(64, 128)
+        assert padded == 128
+        assert n_groups == 1
+
+
+# ============================================================================
+# WHT rotation
+# ============================================================================
+
+
+class TestWHT:
+    @pytest.mark.parametrize("n", [64, 128, 256])
+    def test_wht_involution(self, n):
+        """WHT applied twice (with normalization) should return the original."""
+        x = torch.randn(4, n)
+        y = _fast_wht_batch(x.clone())
+        z = _fast_wht_batch(y.clone())
+        assert torch.allclose(z, x, atol=1e-5), "WHT is not an involution"
+
+    def test_wht_orthogonal(self):
+        """WHT should preserve norms (up to float precision)."""
+        x = torch.randn(8, 128)
+        y = _fast_wht_batch(x.clone())
+        x_norms = torch.linalg.norm(x, dim=1)
+        y_norms = torch.linalg.norm(y, dim=1)
+        assert torch.allclose(x_norms, y_norms, atol=1e-4)
+
+    def test_wht_requires_power_of_2(self):
+        """WHT only works with power-of-2 dimensions."""
+        x = torch.randn(2, 128, device="cpu")
+        y = _fast_wht_batch(x.clone())
+        assert y.shape == (2, 128)
+
+
+# ============================================================================
+# PolarQuant quantize/dequantize
+# ============================================================================
+
+
+class TestPolarQuant:
+    @pytest.mark.parametrize("bits", [3, 4])
+    def test_roundtrip_error(self, bits):
+        """Quantize→dequantize should have bounded relative error."""
+        dim = 128
+        pq = _PolarQuant(dim, bits, device="cpu")
+        x = torch.randn(32, dim)
+        indices, norms = pq.quantize(x)
+        x_hat = pq.dequantize(indices, norms)
+
+        row_err = (x - x_hat).norm(dim=1) / x.norm(dim=1).clamp(min=1e-8)
+        mean_err = row_err.mean().item()
+
+        # TQ3 ~18%, TQ4 ~10% relative error
+        max_acceptable = 0.30 if bits == 3 else 0.20
+        assert mean_err < max_acceptable, (
+            f"bits={bits}: mean relative error {mean_err:.3f} > {max_acceptable}"
+        )
+
+    @pytest.mark.parametrize("bits", [3, 4])
+    def test_indices_in_range(self, bits):
+        dim = 128
+        pq = _PolarQuant(dim, bits, device="cpu")
+        x = torch.randn(16, dim)
+        indices, _ = pq.quantize(x)
+        assert indices.min() >= 0
+        assert indices.max() < 2**bits
+
+    def test_deterministic(self):
+        pq = _PolarQuant(128, 3, device="cpu")
+        x = torch.randn(8, 128)
+        idx1, n1 = pq.quantize(x)
+        idx2, n2 = pq.quantize(x)
+        assert torch.equal(idx1, idx2)
+        assert torch.equal(n1, n2)
+
+    def test_zero_vector(self):
+        """Zero input should not crash."""
+        pq = _PolarQuant(128, 3, device="cpu")
+        x = torch.zeros(2, 128)
+        indices, norms = pq.quantize(x)
+        x_hat = pq.dequantize(indices, norms)
+        assert torch.allclose(x_hat, torch.zeros_like(x_hat), atol=1e-6)
+
+    def test_norm_correction(self):
+        """Stored norms should differ from raw L2 norms (norm correction ratio).
+
+        PolarQuant stores original_norm / reconstruction_norm, not raw norms.
+        This correction is critical for quality — without it, TQ3 error is
+        ~2x worse.
+        """
+        dim = 128
+        pq = _PolarQuant(dim, 3, device="cpu")
+        x = torch.randn(16, dim)
+        raw_norms = torch.linalg.norm(x, dim=1)
+        _, corrected_norms = pq.quantize(x)
+
+        # Corrected norms should be close to but not exactly equal to raw norms
+        # (ratio = original_norm / recon_norm, which is ~1.0 but not 1.0)
+        assert not torch.equal(raw_norms, corrected_norms), (
+            "Norms should be corrected (original/recon ratio), not raw L2"
+        )
+        # But they should be in the same ballpark
+        ratio = corrected_norms / raw_norms.clamp(min=1e-8)
+        assert ratio.mean().item() == pytest.approx(1.0, abs=0.1)
+
+    @pytest.mark.parametrize("dim", [64, 96, 200])
+    def test_non_power_of_2_dim(self, dim):
+        """PolarQuant should handle non-power-of-2 dims by padding internally."""
+        pq = _PolarQuant(dim, 3, device="cpu")
+        assert pq.padded_dim == next_power_of_2(dim)
+        assert pq.padded_dim >= dim
+
+        x = torch.randn(8, dim)
+        indices, norms = pq.quantize(x)
+        x_hat = pq.dequantize(indices, norms)
+        assert x_hat.shape == (8, dim)
+
+    def test_rotation_is_orthogonal(self):
+        """Forward and inverse rotation should compose to identity."""
+        pq = _PolarQuant(128, 3, device="cpu")
+        x = torch.randn(4, 128)
+        y = pq._rotate(x)
+        x_back = pq._rotate_inverse(y)
+        assert torch.allclose(x_back, x, atol=1e-5)
+
+    def test_quantizer_cache(self):
+        """_get_quantizer should return the same instance for same params."""
+        q1 = _get_quantizer(128, 3, "cpu")
+        q2 = _get_quantizer(128, 3, "cpu")
+        assert q1 is q2
+
+        q3 = _get_quantizer(128, 4, "cpu")
+        assert q3 is not q1
+
+
+# ============================================================================
+# process_weights_after_loading: idempotency guard
+#
+# vLLM calls this twice (online processing + global sweep).
+# Second call must be a no-op.
+# ============================================================================
+
+
+class TestProcessWeightsIdempotency:
+    def test_double_call_is_noop(self):
+        """Second call to process_weights_after_loading should be a no-op."""
+        method = TurboQuantW3OnlineLinearMethod()
+        layer = nn.Module()
+        layer.weight = nn.Parameter(torch.randn(64, 128, device="cpu"))
+
+        method.process_weights_after_loading(layer)
+
+        # After first call: weight replaced with empty, TQ buffers present
+        assert layer.weight.numel() == 0
+        assert hasattr(layer, "tq_packed_weight")
+        packed_id = id(layer.tq_packed_weight)
+
+        # Second call should be a no-op (guard fires)
+        method.process_weights_after_loading(layer)
+        assert id(layer.tq_packed_weight) == packed_id
+
+    def test_weight_kept_as_empty(self):
+        """After compression, layer.weight should be empty(0) — not deleted.
+
+        MLA post-processing in vLLM expects layer.weight to exist.
+        """
+        method = TurboQuantW3OnlineLinearMethod()
+        layer = nn.Module()
+        layer.weight = nn.Parameter(torch.randn(64, 128, device="cpu"))
+
+        method.process_weights_after_loading(layer)
+        assert hasattr(layer, "weight")
+        assert layer.weight.numel() == 0
+
+    def test_guard_attribute_set(self):
+        """The _already_called flag should be set after processing."""
+        method = TurboQuantW3OnlineLinearMethod()
+        layer = nn.Module()
+        layer.weight = nn.Parameter(torch.randn(64, 128, device="cpu"))
+
+        assert not getattr(
+            layer, "_already_called_process_weights_after_loading", False
+        )
+        method.process_weights_after_loading(layer)
+        assert layer._already_called_process_weights_after_loading is True
+
+
+# ============================================================================
+# End-to-end: compress a Linear weight, check output
+# ============================================================================
+
+
+class TestLinearCompression:
+    @pytest.mark.parametrize("bits", [3, 4])
+    def test_compress_and_matmul(self, bits):
+        """Compress a weight matrix, decompress, verify matmul is close."""
+        in_dim, out_dim = 128, 64
+        group_size = 128
+
+        w = torch.randn(out_dim, in_dim)
+        x = torch.randn(4, in_dim)
+        ref = x @ w.t()
+
+        pq = _PolarQuant(group_size, bits, device="cpu")
+        grouped = w.reshape(-1, group_size)
+        indices, norms_raw = pq.quantize(grouped)
+        packed = _pack_indices(indices, bits)
+
+        unpacked = _unpack_indices(packed, bits, group_size)
+        w_hat_groups = pq.dequantize(unpacked, norms_raw)
+        w_hat = w_hat_groups.reshape(out_dim, -1)[:, :in_dim]
+
+        out = x @ w_hat.t()
+        cos_sim = torch.nn.functional.cosine_similarity(ref, out, dim=1)
+        threshold = 0.85 if bits == 3 else 0.92
+        assert cos_sim.min().item() > threshold, (
+            f"bits={bits}: min cosine similarity {cos_sim.min():.4f} < {threshold}"
+        )
+
+    def test_apply_fallback_path(self):
+        """apply() PyTorch fallback (no Triton)."""
+        method = TurboQuantW3OnlineLinearMethod()
+        layer = nn.Module()
+        layer.weight = nn.Parameter(torch.randn(64, 128, device="cpu"))
+
+        method.process_weights_after_loading(layer)
+
+        # Force PyTorch fallback by clearing Triton dispatch
+        layer._tq_primary_fn = None
+
+        x = torch.randn(2, 128, device="cpu")
+        out = method.apply(layer, x, bias=None)
+        assert out.shape == (2, 64)
+
+        # With bias
+        bias = torch.randn(64, device="cpu")
+        out_bias = method.apply(layer, x, bias=bias)
+        assert out_bias.shape == (2, 64)
+
+    def test_apply_with_padding(self):
+        """Compression should work when in_dim is not a multiple of group_size."""
+        method = TurboQuantW3OnlineLinearMethod()
+        layer = nn.Module()
+        # in_dim=200 requires padding to 256 (2 groups of 128)
+        layer.weight = nn.Parameter(torch.randn(64, 200, device="cpu"))
+
+        method.process_weights_after_loading(layer)
+        layer._tq_primary_fn = None  # force fallback
+
+        x = torch.randn(2, 200, device="cpu")
+        out = method.apply(layer, x, bias=None)
+        assert out.shape == (2, 64)
+
+    def test_apply_zero_tokens(self):
+        """apply() should handle M=0 (zero-token batch in chunked prefill)."""
+        method = TurboQuantW3OnlineLinearMethod()
+        layer = nn.Module()
+        layer.weight = nn.Parameter(torch.randn(64, 128, device="cpu"))
+
+        method.process_weights_after_loading(layer)
+        layer._tq_primary_fn = None
+
+        x = torch.randn(0, 128, device="cpu")
+        out = method.apply(layer, x, bias=None)
+        assert out.shape == (0, 64)
+
+    def test_3d_input(self):
+        """apply() should handle 3D input (batch, seq, features)."""
+        method = TurboQuantW3OnlineLinearMethod()
+        layer = nn.Module()
+        layer.weight = nn.Parameter(torch.randn(64, 128, device="cpu"))
+
+        method.process_weights_after_loading(layer)
+        layer._tq_primary_fn = None
+
+        x = torch.randn(2, 8, 128, device="cpu")
+        out = method.apply(layer, x, bias=None)
+        assert out.shape == (2, 8, 64)
+
+
+class TestTurboQuantClassRegistry:
+    """The three concrete subclasses encode bits/group_size as class attrs."""
+
+    @pytest.mark.parametrize(
+        ("cls", "bits"),
+        [
+            (TurboQuantW2OnlineLinearMethod, 2),
+            (TurboQuantW3OnlineLinearMethod, 3),
+            (TurboQuantW4OnlineLinearMethod, 4),
+        ],
+    )
+    def test_concrete_subclasses(self, cls, bits):
+        method = cls()
+        assert bits == method.BITS
+        assert method.GROUP_SIZE == 128
+
+    def test_base_rejects_unsupported_bits(self):
+        class _Bad(_TurboQuantOnlineLinearMethodBase):
+            BITS = 5
+
+        with pytest.raises(ValueError, match=r"turboquant BITS must be 2, 3, or 4"):
+            _Bad()
+
+    def test_base_rejects_bad_group_size(self):
+        class _Bad(_TurboQuantOnlineLinearMethodBase):
+            BITS = 3
+            GROUP_SIZE = 7
+
+        with pytest.raises(
+            ValueError, match=r"turboquant GROUP_SIZE must be a positive"
+        ):
+            _Bad()

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -26,6 +26,10 @@ class OnlineQuantScheme(Enum):
     # mxfp8, weights scaled in blocks of 1x32 elements (microscaling FP8)
     MXFP8 = "mxfp8"
 
+    # 3-4 bit weight compression via WHT rotation + Lloyd-Max codebook.
+    # ~4x smaller weights, zero calibration data.
+    TURBOQUANT = "turboquant"
+
 
 @config
 class OnlineQuantizationConfigArgs:

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -54,6 +54,16 @@ class OnlineQuantizationConfigArgs:
     patterns with ``re:`` prefix (e.g. ``re:.*attn.*``), consistent with
     compressed_tensors layer skipping."""
 
+    bits: int | None = None
+    """Weight bit width. Only used by schemes that support variable bit
+    widths (``turboquant``: 2, 3, or 4; default 3). Ignored for
+    ``fp8_per_tensor`` and ``fp8_per_block``."""
+
+    group_size: int | None = None
+    """Weight group size for block-scaled schemes. Only used by schemes
+    that support variable group sizes (``turboquant``: default 128).
+    Ignored for ``fp8_per_tensor`` and ``fp8_per_block``."""
+
     @field_validator(
         "global_scheme", "linear_scheme_override", "moe_scheme_override", mode="before"
     )

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -17,6 +17,9 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kInt8StaticChannelSym,
     kMxfp4Dynamic,
     kMxfp8Dynamic,
+    kTurboquantW2,
+    kTurboquantW3,
+    kTurboquantW4,
 )
 
 # User-facing names addressable from quantization_config.
@@ -29,6 +32,9 @@ QUANT_KEY_NAMES: dict[str, QuantKey] = {
     "mxfp8": kMxfp8Dynamic,
     "mxfp4": kMxfp4Dynamic,
     "int8_per_channel_static": kInt8StaticChannelSym,
+    "turboquant_2bit": kTurboquantW2,
+    "turboquant_3bit": kTurboquantW3,
+    "turboquant_4bit": kTurboquantW4,
 }
 
 
@@ -125,6 +131,18 @@ _ONLINE_SHORTHANDS: dict[str, QuantizationConfigArgs] = {
     # INT8 weight-only on MoE; linear stays unquantized (no `linear` field).
     "int8_per_channel_weight_only": QuantizationConfigArgs(
         moe=QuantSpec(weight=kInt8StaticChannelSym),
+    ),
+    # TurboQuant: Linear-only today (MoE pass-through). Bare "turboquant"
+    # defaults to 3-bit (the sweet spot for quality / compression on most
+    # models); explicit 2/4-bit shorthands available.
+    "turboquant": QuantizationConfigArgs(
+        linear=QuantSpec(weight=kTurboquantW3),
+    ),
+    "turboquant_2bit": QuantizationConfigArgs(
+        linear=QuantSpec(weight=kTurboquantW2),
+    ),
+    "turboquant_4bit": QuantizationConfigArgs(
+        linear=QuantSpec(weight=kTurboquantW4),
     ),
 }
 

--- a/vllm/config/quantization.py
+++ b/vllm/config/quantization.py
@@ -134,12 +134,16 @@ _ONLINE_SHORTHANDS: dict[str, QuantizationConfigArgs] = {
     ),
     # TurboQuant: Linear-only today (MoE pass-through). Bare "turboquant"
     # defaults to 3-bit (the sweet spot for quality / compression on most
-    # models); explicit 2/4-bit shorthands available.
+    # models); explicit `turboquant_{2,3,4}bit` shorthands cover every
+    # validated codebook.
     "turboquant": QuantizationConfigArgs(
         linear=QuantSpec(weight=kTurboquantW3),
     ),
     "turboquant_2bit": QuantizationConfigArgs(
         linear=QuantSpec(weight=kTurboquantW2),
+    ),
+    "turboquant_3bit": QuantizationConfigArgs(
+        linear=QuantSpec(weight=kTurboquantW3),
     ),
     "turboquant_4bit": QuantizationConfigArgs(
         linear=QuantSpec(weight=kTurboquantW4),

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -41,6 +41,7 @@ QuantizationMethods = Literal[
     "fp8_per_block",
     "int8_per_channel_weight_only",
     "mxfp8",
+    "turboquant",
 ]
 QUANTIZATION_METHODS: list[str] = list(get_args(QuantizationMethods))
 

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -42,6 +42,9 @@ QuantizationMethods = Literal[
     "fp8_per_block",
     "int8_per_channel_weight_only",
     "mxfp8",
+    "turboquant",
+    "turboquant_2bit",
+    "turboquant_4bit",
 ]
 QUANTIZATION_METHODS: list[str] = list(get_args(QuantizationMethods))
 

--- a/vllm/model_executor/layers/quantization/__init__.py
+++ b/vllm/model_executor/layers/quantization/__init__.py
@@ -44,6 +44,7 @@ QuantizationMethods = Literal[
     "mxfp8",
     "turboquant",
     "turboquant_2bit",
+    "turboquant_3bit",
     "turboquant_4bit",
 ]
 QUANTIZATION_METHODS: list[str] = list(get_args(QuantizationMethods))

--- a/vllm/model_executor/layers/quantization/online/base.py
+++ b/vllm/model_executor/layers/quantization/online/base.py
@@ -116,7 +116,12 @@ class OnlineQuantizationConfig(QuantizationConfig):
                 )
                 return UnquantizedLinearMethod()
             elif linear_scheme == OnlineQuantScheme.TURBOQUANT:
-                return TurboQuantOnlineLinearMethod()
+                tq_kwargs: dict[str, Any] = {}
+                if self.args.bits is not None:
+                    tq_kwargs["bits"] = self.args.bits
+                if self.args.group_size is not None:
+                    tq_kwargs["group_size"] = self.args.group_size
+                return TurboQuantOnlineLinearMethod(**tq_kwargs)
             elif linear_scheme == OnlineQuantScheme.FP8_PER_BLOCK:
                 return Fp8PerBlockOnlineLinearMethod()
             elif linear_scheme == OnlineQuantScheme.MXFP8:

--- a/vllm/model_executor/layers/quantization/online/base.py
+++ b/vllm/model_executor/layers/quantization/online/base.py
@@ -41,6 +41,9 @@ from vllm.model_executor.layers.quantization.online.mxfp8 import (
     Mxfp8OnlineLinearMethod,
     Mxfp8OnlineMoEMethod,
 )
+from vllm.model_executor.layers.quantization.online.turboquant import (
+    TurboQuantOnlineLinearMethod,
+)
 
 logger = init_logger(__name__)
 
@@ -112,6 +115,8 @@ class OnlineQuantizationConfig(QuantizationConfig):
                     "weights. linear layers remain in full precision."
                 )
                 return UnquantizedLinearMethod()
+            elif linear_scheme == OnlineQuantScheme.TURBOQUANT:
+                return TurboQuantOnlineLinearMethod()
             elif linear_scheme == OnlineQuantScheme.FP8_PER_BLOCK:
                 return Fp8PerBlockOnlineLinearMethod()
             elif linear_scheme == OnlineQuantScheme.MXFP8:
@@ -129,6 +134,9 @@ class OnlineQuantizationConfig(QuantizationConfig):
             moe_scheme = self.args.moe_scheme_override or self.args.global_scheme
             if moe_scheme == OnlineQuantScheme.INT8_PER_CHANNEL_WEIGHT_ONLY:
                 return Int8OnlineMoEMethod(layer=layer)
+            elif moe_scheme == OnlineQuantScheme.TURBOQUANT:
+                # TurboQuant MoE not yet supported — keep bf16
+                return UnquantizedFusedMoEMethod(layer.moe_config)
             elif moe_scheme == OnlineQuantScheme.FP8_PER_BLOCK:
                 return Fp8PerBlockOnlineMoEMethod(layer=layer)
             elif moe_scheme == OnlineQuantScheme.MXFP8:

--- a/vllm/model_executor/layers/quantization/online/base.py
+++ b/vllm/model_executor/layers/quantization/online/base.py
@@ -38,12 +38,20 @@ from vllm.model_executor.layers.quantization.online.mxfp8 import (
     Mxfp8OnlineLinearMethod,
     Mxfp8OnlineMoEMethod,
 )
+from vllm.model_executor.layers.quantization.online.turboquant import (
+    TurboQuantW2OnlineLinearMethod,
+    TurboQuantW3OnlineLinearMethod,
+    TurboQuantW4OnlineLinearMethod,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kFp8Static128BlockSym,
     kFp8StaticTensorSym,
     kInt8StaticChannelSym,
     kMxfp8Dynamic,
+    kTurboquantW2,
+    kTurboquantW3,
+    kTurboquantW4,
 )
 
 logger = init_logger(__name__)
@@ -56,6 +64,9 @@ _ONLINE_LINEAR_METHODS: dict[QuantKey, type] = {
     kFp8StaticTensorSym: Fp8PerTensorOnlineLinearMethod,
     kFp8Static128BlockSym: Fp8PerBlockOnlineLinearMethod,
     kMxfp8Dynamic: Mxfp8OnlineLinearMethod,
+    kTurboquantW2: TurboQuantW2OnlineLinearMethod,
+    kTurboquantW3: TurboQuantW3OnlineLinearMethod,
+    kTurboquantW4: TurboQuantW4OnlineLinearMethod,
 }
 
 _ONLINE_MOE_METHODS: dict[QuantKey, type] = {

--- a/vllm/model_executor/layers/quantization/online/turboquant.py
+++ b/vllm/model_executor/layers/quantization/online/turboquant.py
@@ -1,0 +1,768 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""TurboQuant online weight quantization for vLLM.
+
+3-4 bit weight compression via WHT rotation + Lloyd-Max codebook.
+Load any BF16 checkpoint, compress weights at startup, serve with
+~4x smaller GPU memory. Zero calibration data needed.
+
+Based on TurboQuant (Zandieh et al., ICLR 2026).
+
+Usage:
+    vllm serve <model> --quantization turboquant
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import LinearMethodBase
+from vllm.model_executor.model_loader.reload.layerwise import (
+    initialize_online_processing,
+)
+from vllm.model_executor.parameter import ModelWeightParameter
+from vllm.utils.math_utils import next_power_of_2, round_up
+
+logger = init_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Codebook: Lloyd-Max optimal centroids for N(0, 1/d)
+# ---------------------------------------------------------------------------
+
+
+def _gaussian_cond_expect(sigma: float, a: float, b: float) -> float:
+    """E[X | a < X < b] for X ~ N(0, sigma^2)."""
+    from scipy import stats
+
+    a_std = a / sigma if math.isfinite(a) else a
+    b_std = b / sigma if math.isfinite(b) else b
+    if not math.isfinite(a_std):
+        prob = stats.norm.cdf(b_std)
+    elif not math.isfinite(b_std):
+        prob = stats.norm.sf(a_std)
+    else:
+        prob = stats.norm.cdf(b_std) - stats.norm.cdf(a_std)
+    if prob < 1e-15:
+        return (a + b) / 2.0 if math.isfinite(a) and math.isfinite(b) else 0.0
+    return sigma * (stats.norm.pdf(a_std) - stats.norm.pdf(b_std)) / prob
+
+
+def _lloyd_max_centroids(n: int, sigma: float, n_iter: int = 100) -> list[float]:
+    """Lloyd's algorithm for optimal scalar quantization of N(0, sigma^2)."""
+    from scipy import stats
+
+    boundaries = list(stats.norm.ppf([i / n for i in range(1, n)], scale=sigma))
+    centroids = [0.0] * n
+    for _ in range(n_iter):
+        centroids[0] = _gaussian_cond_expect(sigma, -math.inf, boundaries[0])
+        for i in range(1, n - 1):
+            centroids[i] = _gaussian_cond_expect(sigma, boundaries[i - 1], boundaries[i])
+        centroids[-1] = _gaussian_cond_expect(sigma, boundaries[-1], math.inf)
+        boundaries = [(centroids[i] + centroids[i + 1]) / 2 for i in range(n - 1)]
+    return sorted(centroids)
+
+
+def _optimal_centroids(bits: int, dim: int) -> list[float]:
+    """Optimal centroids for post-rotation coordinates ~ N(0, 1/d)."""
+    n = 1 << bits
+    if bits == 1:
+        c = math.sqrt(2.0 / (math.pi * dim))
+        return [-c, c]
+    if bits == 2:
+        s = math.sqrt(dim)
+        return [-1.51 / s, -0.453 / s, 0.453 / s, 1.51 / s]
+    return _lloyd_max_centroids(n, sigma=1.0 / math.sqrt(dim))
+
+
+# ---------------------------------------------------------------------------
+# Fast Walsh-Hadamard Transform
+# ---------------------------------------------------------------------------
+
+
+def _fast_wht_batch(x: torch.Tensor) -> torch.Tensor:
+    """Batched fast WHT. x: (batch, n) where n is power of 2."""
+    n = x.shape[1]
+    h = 1
+    while h < n:
+        x_view = x.view(x.shape[0], n // (h * 2), 2, h)
+        a = x_view[:, :, 0, :].clone()
+        b = x_view[:, :, 1, :].clone()
+        x_view[:, :, 0, :] = a + b
+        x_view[:, :, 1, :] = a - b
+        h *= 2
+    return x / math.sqrt(n)
+
+
+
+
+# ---------------------------------------------------------------------------
+# PolarQuant quantizer
+# ---------------------------------------------------------------------------
+
+# Cache: (group_size, bits, device_str) → PolarQuant instance
+_quantizers: dict[tuple[int, int, str], "_PolarQuant"] = {}
+
+
+def _get_quantizer(group_size: int, bits: int, device: str) -> "_PolarQuant":
+    dev = torch.device(device)
+    if dev.type == "cuda" and dev.index is None:
+        dev = torch.device("cuda", torch.cuda.current_device())
+    key = (group_size, bits, str(dev))
+    if key not in _quantizers:
+        _quantizers[key] = _PolarQuant(group_size, bits, device=str(dev))
+    return _quantizers[key]
+
+
+class _PolarQuant:
+    """WHT rotation + Gaussian Lloyd-Max codebook quantizer."""
+
+    def __init__(self, dim: int, bits: int, seed: int = 42, device: str = "cuda"):
+        self.dim = dim
+        self.bits = bits
+        dev = torch.device(device)
+        if dev.type == "cuda" and dev.index is None:
+            dev = torch.device("cuda", torch.cuda.current_device())
+        self.device = dev
+
+        gen = torch.Generator(device="cpu").manual_seed(seed)
+        self.padded_dim = next_power_of_2(dim)
+        self.signs1 = (torch.randint(0, 2, (self.padded_dim,), generator=gen) * 2 - 1).float().to(dev)
+        self.signs2 = (torch.randint(0, 2, (self.padded_dim,), generator=gen) * 2 - 1).float().to(dev)
+
+        centroids_list = _optimal_centroids(bits, dim)
+        self.centroids = torch.tensor(centroids_list, dtype=torch.float32, device=dev)
+        self.boundaries = (self.centroids[:-1] + self.centroids[1:]) / 2
+
+    def _rotate(self, x: torch.Tensor) -> torch.Tensor:
+        batch = x.shape[0]
+        if self.padded_dim > self.dim:
+            padded = torch.zeros(batch, self.padded_dim, device=x.device, dtype=x.dtype)
+            padded[:, : self.dim] = x
+        else:
+            padded = x.clone()
+        padded *= self.signs1.unsqueeze(0)
+        padded = _fast_wht_batch(padded)
+        padded *= self.signs2.unsqueeze(0)
+        return padded[:, : self.dim]
+
+    def _rotate_inverse(self, y: torch.Tensor) -> torch.Tensor:
+        batch = y.shape[0]
+        if self.padded_dim > self.dim:
+            padded = torch.zeros(batch, self.padded_dim, device=y.device, dtype=y.dtype)
+            padded[:, : self.dim] = y
+        else:
+            padded = y.clone()
+        padded *= self.signs2.unsqueeze(0)
+        padded = _fast_wht_batch(padded)
+        padded *= self.signs1.unsqueeze(0)
+        return padded[:, : self.dim]
+
+    def quantize(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Quantize grouped vectors. x: (n_groups, group_size). Returns (indices, norms)."""
+        x = x.to(device=self.device, dtype=torch.float32)
+        norms = torch.linalg.norm(x, dim=1)
+        safe_norms = torch.where(norms > 0, norms, torch.ones_like(norms))
+        x_unit = x / safe_norms.unsqueeze(1)
+        y = self._rotate(x_unit)
+        indices = torch.searchsorted(self.boundaries, y.contiguous())
+        # Norm correction: store original_norm / reconstruction_norm
+        y_hat = self.centroids[indices]
+        x_hat_unit = self._rotate_inverse(y_hat)
+        recon_norm = torch.linalg.norm(x_hat_unit, dim=1)
+        safe_recon = torch.where(recon_norm > 0, recon_norm, torch.ones_like(recon_norm))
+        norms = norms / safe_recon
+        return indices, norms
+
+    def dequantize(self, indices: torch.Tensor, norms: torch.Tensor) -> torch.Tensor:
+        """Dequantize. indices: (n_groups, group_size). Returns (n_groups, group_size)."""
+        indices = indices.to(device=self.device)
+        norms = norms.to(device=self.device, dtype=torch.float32)
+        y_hat = self.centroids[indices]
+        x_hat_unit = self._rotate_inverse(y_hat)
+        return x_hat_unit * norms.unsqueeze(1)
+
+
+# ---------------------------------------------------------------------------
+# Bit packing: pack/unpack quantization indices into uint8
+# ---------------------------------------------------------------------------
+
+
+def _padded_size(dim: int, group_size: int) -> tuple[int, int]:
+    """Return (padded_dim, n_groups) for group quantization."""
+    padded = round_up(dim, group_size)
+    return padded, padded // group_size
+
+
+def _pack_indices(indices: torch.Tensor, bits: int) -> torch.Tensor:
+    """Pack quantization indices into uint8."""
+    if bits == 4:
+        flat = indices.reshape(-1, indices.shape[-1])
+        lo = flat[:, 0::2].to(torch.uint8)
+        hi = flat[:, 1::2].to(torch.uint8)
+        return (lo | (hi << 4)).reshape(indices.shape[0], -1)
+    elif bits == 3:
+        n_rows, n_cols = indices.shape[0], indices.shape[-1]
+        flat = indices.reshape(n_rows, -1).to(torch.uint8)
+        pad = (8 - n_cols % 8) % 8
+        if pad > 0:
+            flat = torch.nn.functional.pad(flat, (0, pad))
+        n_packed_cols = flat.shape[1] // 8 * 3
+        packed = torch.zeros(n_rows, n_packed_cols, dtype=torch.uint8, device=indices.device)
+        for i in range(flat.shape[1] // 8):
+            v = flat[:, i * 8 : (i + 1) * 8]
+            packed[:, i * 3] = v[:, 0] | (v[:, 1] << 3) | ((v[:, 2] & 0x3) << 6)
+            packed[:, i * 3 + 1] = (v[:, 2] >> 2) | (v[:, 3] << 1) | (v[:, 4] << 4) | ((v[:, 5] & 0x1) << 7)
+            packed[:, i * 3 + 2] = (v[:, 5] >> 1) | (v[:, 6] << 2) | (v[:, 7] << 5)
+        return packed
+    elif bits == 2:
+        flat = indices.reshape(-1, indices.shape[-1])
+        shifts = torch.tensor([0, 2, 4, 6], device=indices.device, dtype=torch.uint8)
+        parts = torch.stack([flat[:, i::4].to(torch.uint8) for i in range(4)], dim=-1)
+        return (parts << shifts).sum(dim=-1).to(torch.uint8).reshape(indices.shape[0], -1)
+    return indices.to(torch.uint8)
+
+
+def _unpack_indices(packed: torch.Tensor, bits: int, dim: int) -> torch.Tensor:
+    """Unpack uint8 packed indices back to int64."""
+    if bits == 4:
+        flat = packed.reshape(-1, packed.shape[-1])
+        lo = (flat & 0x0F).to(torch.int64)
+        hi = ((flat >> 4) & 0x0F).to(torch.int64)
+        unpacked = torch.zeros(flat.shape[0], flat.shape[1] * 2, dtype=torch.int64, device=packed.device)
+        unpacked[:, 0::2] = lo
+        unpacked[:, 1::2] = hi
+        return unpacked.reshape(packed.shape[0], -1)[:, :dim]
+    elif bits == 3:
+        flat = packed.reshape(-1, packed.shape[-1])
+        n_rows = flat.shape[0]
+        n_groups_of_3 = flat.shape[1] // 3
+        unpacked = torch.zeros(n_rows, n_groups_of_3 * 8, dtype=torch.int64, device=packed.device)
+        for i in range(n_groups_of_3):
+            b0 = flat[:, i * 3].to(torch.int64)
+            b1 = flat[:, i * 3 + 1].to(torch.int64)
+            b2 = flat[:, i * 3 + 2].to(torch.int64)
+            unpacked[:, i * 8 + 0] = b0 & 0x7
+            unpacked[:, i * 8 + 1] = (b0 >> 3) & 0x7
+            unpacked[:, i * 8 + 2] = ((b0 >> 6) | (b1 << 2)) & 0x7
+            unpacked[:, i * 8 + 3] = (b1 >> 1) & 0x7
+            unpacked[:, i * 8 + 4] = (b1 >> 4) & 0x7
+            unpacked[:, i * 8 + 5] = ((b1 >> 7) | (b2 << 1)) & 0x7
+            unpacked[:, i * 8 + 6] = (b2 >> 2) & 0x7
+            unpacked[:, i * 8 + 7] = (b2 >> 5) & 0x7
+        return unpacked[:, :dim]
+    elif bits == 2:
+        flat = packed.reshape(-1, packed.shape[-1])
+        unpacked = torch.zeros(flat.shape[0], flat.shape[1] * 4, dtype=torch.int64, device=packed.device)
+        for i in range(4):
+            unpacked[:, i::4] = ((flat >> (i * 2)) & 0x03).to(torch.int64)
+        return unpacked.reshape(packed.shape[0], -1)[:, :dim]
+    return packed.to(torch.int64)
+
+
+# ---------------------------------------------------------------------------
+# Triton kernels (FWHT-on-input GEMM + fused dequant-GEMM)
+# ---------------------------------------------------------------------------
+
+try:
+    import triton
+    import triton.language as tl
+
+    _HAS_TRITON = True
+except ImportError:
+    _HAS_TRITON = False
+
+# Rotation matrix cache: (id(signs1), id(signs2), group_size) → tensor
+_rotation_matrix_cache: dict[tuple, torch.Tensor] = {}
+
+
+def _build_rotation_matrix(
+    signs1: torch.Tensor, signs2: torch.Tensor, group_size: int,
+) -> torch.Tensor:
+    """Pre-compute inverse rotation matrix W_rot = H @ D2 @ D1 / sqrt(n)."""
+    n = group_size
+    eye = torch.eye(n, device=signs1.device, dtype=torch.float32)
+    rotated = eye * signs2.unsqueeze(0)
+    rotated = _fast_wht_batch(rotated)
+    rotated = rotated * signs1.unsqueeze(0)
+    return rotated
+
+
+def _get_cached_rotation_matrix(
+    signs1: torch.Tensor, signs2: torch.Tensor, group_size: int,
+) -> torch.Tensor:
+    """Get or build cached rotation matrix."""
+    key = (id(signs1), id(signs2), group_size)
+    if key not in _rotation_matrix_cache:
+        _rotation_matrix_cache[key] = _build_rotation_matrix(
+            signs1, signs2, group_size,
+        ).contiguous()
+    return _rotation_matrix_cache[key]
+
+
+def _rotate_input(
+    x: torch.Tensor,
+    signs1: torch.Tensor,
+    signs2: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    """Apply forward rotation to input, grouped by group_size."""
+    batch = x.shape[0]
+    K = x.shape[1]
+    padded_K = ((K + group_size - 1) // group_size) * group_size
+    if padded_K > K:
+        x = torch.nn.functional.pad(x, (0, padded_K - K))
+    w_rot = _get_cached_rotation_matrix(signs1, signs2, group_size)
+    x_grouped = x.reshape(-1, group_size)
+    x_grouped = torch.matmul(x_grouped, w_rot.T)
+    return x_grouped.reshape(batch, padded_K)
+
+
+if _HAS_TRITON:
+
+    @triton.jit
+    def _tq_fused_gemm_kernel(
+        a_ptr, stride_am, stride_ak,
+        packed_ptr, norms_ptr,
+        stride_packed_n, stride_packed_k, stride_norms_n, stride_norms_g,
+        w_rot_ptr, centroids_ptr,
+        c_ptr, stride_cm, stride_cn,
+        bias_ptr,
+        M, N, K, n_groups,
+        GROUP_SIZE: tl.constexpr, BITS: tl.constexpr,
+        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+    ):
+        """Fused TQ dequant-GEMM: unpack + codebook + rotate + scale + accumulate.
+
+        Note: 3-bit unpacking logic is duplicated in _polar_fused_gemm_kernel
+        (Triton JIT kernels cannot share helper functions).
+        """
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        offs_k = tl.arange(0, GROUP_SIZE)
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        rot_offs = offs_k[:, None] * GROUP_SIZE + offs_k[None, :]
+        w_rot = tl.load(w_rot_ptr + rot_offs)
+        for g in range(n_groups):
+            k_start = g * GROUP_SIZE
+            a_offs = offs_m[:, None] * stride_am + (k_start + offs_k[None, :]) * stride_ak
+            a_mask = (offs_m[:, None] < M) & ((k_start + offs_k[None, :]) < K)
+            a_tile = tl.load(a_ptr + a_offs, mask=a_mask, other=0.0).to(tl.float32)
+            packed_row = offs_n * n_groups + g
+            if BITS == 4:
+                byte_idx = offs_k // 2
+                is_hi = (offs_k % 2).to(tl.int32)
+                pe = packed_row[:, None] * stride_packed_n + byte_idx[None, :] * stride_packed_k
+                pb = tl.load(packed_ptr + pe, mask=offs_n[:, None] < N, other=0).to(tl.int32)
+                indices = tl.where(is_hi[None, :] > 0, (pb >> 4) & 0xF, pb & 0xF)
+            elif BITS == 3:
+                g8 = offs_k // 8
+                p8 = offs_k % 8
+                bo = p8 * 3
+                fb = bo // 8
+                bib = (bo % 8).to(tl.int32)
+                crosses = bib > 5
+                bi0 = g8 * 3 + fb
+                bi1 = bi0 + 1
+                p0 = packed_row[:, None] * stride_packed_n + bi0[None, :] * stride_packed_k
+                b0 = tl.load(packed_ptr + p0, mask=offs_n[:, None] < N, other=0).to(tl.int32)
+                p1 = packed_row[:, None] * stride_packed_n + bi1[None, :] * stride_packed_k
+                b1 = tl.load(packed_ptr + p1, mask=offs_n[:, None] < N, other=0).to(tl.int32)
+                single = (b0 >> bib[None, :]) & 0x7
+                cross = ((b0 >> bib[None, :]) | (b1 << (8 - bib[None, :]))) & 0x7
+                indices = tl.where(crosses[None, :], cross, single)
+            elif BITS == 2:
+                byte_idx = offs_k // 4
+                shift = (offs_k % 4).to(tl.int32) * 2
+                pe = packed_row[:, None] * stride_packed_n + byte_idx[None, :] * stride_packed_k
+                pb = tl.load(packed_ptr + pe, mask=offs_n[:, None] < N, other=0).to(tl.int32)
+                indices = (pb >> shift[None, :]) & 0x3
+            else:
+                pe = packed_row[:, None] * stride_packed_n + offs_k[None, :] * stride_packed_k
+                indices = tl.load(packed_ptr + pe, mask=offs_n[:, None] < N, other=0).to(tl.int32)
+            centroid_vec = tl.load(centroids_ptr + indices)
+            w_deq = tl.dot(centroid_vec, w_rot)
+            norm_offs = offs_n * stride_norms_n + g * stride_norms_g
+            norms = tl.load(norms_ptr + norm_offs, mask=offs_n < N, other=0.0)
+            w_deq = w_deq * norms[:, None]
+            # Cast to output dtype for tensor core GEMM (bf16/fp16 ~2x faster)
+            out_dt = c_ptr.type.element_ty
+            acc += tl.dot(a_tile.to(out_dt), tl.trans(w_deq).to(out_dt))
+        if bias_ptr:
+            bias = tl.load(bias_ptr + offs_n, mask=offs_n < N, other=0.0)
+            acc += bias[None, :]
+        c_offs = offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+        c_mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+        tl.store(c_ptr + c_offs, acc.to(c_ptr.type.element_ty), mask=c_mask)
+
+    @triton.autotune(
+        configs=[
+            triton.Config({"BLOCK_M": 1, "BLOCK_N": 128}, num_warps=4, num_stages=2),
+            triton.Config({"BLOCK_M": 1, "BLOCK_N": 256}, num_warps=8, num_stages=2),
+            triton.Config({"BLOCK_M": 4, "BLOCK_N": 128}, num_warps=4, num_stages=2),
+            triton.Config({"BLOCK_M": 8, "BLOCK_N": 64}, num_warps=4, num_stages=2),
+            triton.Config({"BLOCK_M": 8, "BLOCK_N": 128}, num_warps=4, num_stages=2),
+            triton.Config({"BLOCK_M": 16, "BLOCK_N": 64}, num_warps=4, num_stages=2),
+            triton.Config({"BLOCK_M": 16, "BLOCK_N": 128}, num_warps=8, num_stages=2),
+            triton.Config({"BLOCK_M": 32, "BLOCK_N": 64}, num_warps=4, num_stages=2),
+            triton.Config({"BLOCK_M": 32, "BLOCK_N": 128}, num_warps=8, num_stages=2),
+            triton.Config({"BLOCK_M": 64, "BLOCK_N": 64}, num_warps=4, num_stages=2),
+        ],
+        key=["out_f", "in_f_padded"],
+    )
+    @triton.jit
+    def _polar_fused_gemm_kernel(
+        x_rot_ptr, stride_xm, stride_xk,
+        codes_ptr, stride_cn, stride_ck,
+        norms_ptr, stride_nn, stride_ng,
+        ct_ptr,
+        out_ptr, stride_om, stride_on,
+        bias_ptr,
+        batch_size, out_f, in_f_padded, n_groups,
+        BLOCK_K: tl.constexpr, BITS: tl.constexpr,
+        BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr,
+    ):
+        """FWHT-on-input: codebook dot product with pre-rotated input.
+
+        Note: 3-bit unpacking logic is duplicated in _tq_fused_gemm_kernel
+        (Triton JIT kernels cannot share helper functions).
+        """
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        mask_m = offs_m < batch_size
+        mask_n = offs_n < out_f
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        for g in range(n_groups):
+            offs_k = tl.arange(0, BLOCK_K)
+            x_ptrs = offs_m[:, None] * stride_xm + (g * BLOCK_K + offs_k)[None, :] * stride_xk
+            x_tile = tl.load(x_rot_ptr + x_ptrs, mask=mask_m[:, None], other=0.0)
+            packed_row = offs_n * n_groups + g
+            if BITS == 4:
+                bi = offs_k // 2
+                ih = offs_k % 2
+                cp = packed_row[:, None] * stride_cn + bi[None, :] * stride_ck
+                pk = tl.load(codes_ptr + cp, mask=mask_n[:, None], other=0).to(tl.int32)
+                codes = tl.where(ih[None, :] > 0, (pk >> 4) & 0xF, pk & 0xF)
+            elif BITS == 3:
+                g8 = offs_k // 8
+                p8 = offs_k % 8
+                bo = p8 * 3
+                fb = bo // 8
+                bib = (bo % 8).to(tl.int32)
+                crosses = bib > 5
+                bi0 = g8 * 3 + fb
+                bi1 = bi0 + 1
+                p0 = packed_row[:, None] * stride_cn + bi0[None, :] * stride_ck
+                b0 = tl.load(codes_ptr + p0, mask=mask_n[:, None], other=0).to(tl.int32)
+                p1 = packed_row[:, None] * stride_cn + bi1[None, :] * stride_ck
+                b1 = tl.load(codes_ptr + p1, mask=mask_n[:, None], other=0).to(tl.int32)
+                single = (b0 >> bib[None, :]) & 0x7
+                cross = ((b0 >> bib[None, :]) | (b1 << (8 - bib[None, :]))) & 0x7
+                codes = tl.where(crosses[None, :], cross, single)
+            elif BITS == 2:
+                bi = offs_k // 4
+                sh = (offs_k % 4).to(tl.int32) * 2
+                cp = packed_row[:, None] * stride_cn + bi[None, :] * stride_ck
+                pk = tl.load(codes_ptr + cp, mask=mask_n[:, None], other=0).to(tl.int32)
+                codes = (pk >> sh[None, :]) & 0x3
+            else:
+                cp = packed_row[:, None] * stride_cn + offs_k[None, :] * stride_ck
+                codes = tl.load(codes_ptr + cp, mask=mask_n[:, None], other=0).to(tl.int32)
+            values = tl.load(ct_ptr + codes)
+            norm_ptrs = offs_n * stride_nn + g * stride_ng
+            norms = tl.load(norms_ptr + norm_ptrs, mask=mask_n, other=0.0)
+            values = values * norms[:, None]
+            out_dt = out_ptr.type.element_ty
+            acc += tl.dot(x_tile.to(out_dt), tl.trans(values).to(out_dt))
+        if bias_ptr:
+            bias = tl.load(bias_ptr + offs_n, mask=mask_n, other=0.0)
+            acc += bias[None, :]
+        out_ptrs = offs_m[:, None] * stride_om + offs_n[None, :] * stride_on
+        out_mask = mask_m[:, None] & mask_n[None, :]
+        tl.store(out_ptr + out_ptrs, acc.to(out_ptr.type.element_ty), mask=out_mask)
+
+
+def _tq_fused_gemm_launcher(
+    x: torch.Tensor,
+    packed_weight: torch.Tensor,
+    norms: torch.Tensor,
+    signs1: torch.Tensor,
+    signs2: torch.Tensor,
+    centroids: torch.Tensor,
+    group_size: int = 128,
+    bits: int = 4,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Fused TQ dequant + GEMM launcher."""
+    orig_shape = x.shape
+    x = x.reshape(-1, x.shape[-1])
+    M, K = x.shape
+    N = norms.shape[0]
+    if M == 0:
+        return torch.empty((*orig_shape[:-1], N), dtype=x.dtype, device=x.device)
+    n_groups = norms.shape[1]
+    if K % group_size != 0 or K // group_size != n_groups:
+        raise ValueError(f"K={K} not aligned with group_size={group_size}")
+    w_rot = _get_cached_rotation_matrix(signs1, signs2, group_size)
+    output = torch.empty(M, N, dtype=x.dtype, device=x.device)
+    # Rotation matrix uses GROUP_SIZE^2 * 4 bytes of shared memory;
+    # cap block sizes to stay within hardware limits (~100 KB on Ada).
+    max_block = 16 if group_size >= 128 else 32
+    BLOCK_M = min(max_block, triton.next_power_of_2(M))
+    BLOCK_N = min(max_block, triton.next_power_of_2(N))
+    if not packed_weight.is_contiguous():
+        packed_weight = packed_weight.contiguous()
+    if not norms.is_contiguous():
+        norms = norms.contiguous()
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    _tq_fused_gemm_kernel[grid](
+        x, x.stride(0), x.stride(1),
+        packed_weight, norms,
+        packed_weight.stride(0), packed_weight.stride(1),
+        norms.stride(0), norms.stride(1),
+        w_rot, centroids,
+        output, output.stride(0), output.stride(1),
+        bias, M, N, K, n_groups,
+        GROUP_SIZE=group_size, BITS=bits,
+        BLOCK_M=BLOCK_M, BLOCK_N=BLOCK_N,
+    )
+    if len(orig_shape) > 2:
+        output = output.reshape(*orig_shape[:-1], N)
+    return output
+
+
+def _tq_fwht_input_gemm_launcher(
+    x: torch.Tensor,
+    packed_weight: torch.Tensor,
+    norms: torch.Tensor,
+    signs1: torch.Tensor,
+    signs2: torch.Tensor,
+    centroids: torch.Tensor,
+    group_size: int = 128,
+    bits: int = 4,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """FWHT-on-input GEMM launcher. Rotates input once, then codebook dot."""
+    orig_shape = x.shape
+    x = x.reshape(-1, x.shape[-1])
+    M, K = x.shape
+    N = norms.shape[0]
+    if M == 0:
+        return torch.empty((*orig_shape[:-1], N), dtype=x.dtype, device=x.device)
+    n_groups = norms.shape[1]
+    padded_K = n_groups * group_size
+    if K != padded_K:
+        raise ValueError(f"K={K} != padded_K={padded_K}")
+    x_rot = _rotate_input(x.float(), signs1, signs2, group_size)
+    output = torch.empty(M, N, dtype=x.dtype, device=x.device)
+    BLOCK_K = group_size
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_M"]),
+        triton.cdiv(N, META["BLOCK_N"]),
+    )
+    _polar_fused_gemm_kernel[grid](
+        x_rot, x_rot.stride(0), x_rot.stride(1),
+        packed_weight, packed_weight.stride(0), packed_weight.stride(1),
+        norms, norms.stride(0), norms.stride(1),
+        centroids,
+        output, output.stride(0), output.stride(1),
+        bias, M, N, padded_K, n_groups,
+        BLOCK_K=BLOCK_K, BITS=bits,
+    )
+    if len(orig_shape) > 2:
+        output = output.reshape(*orig_shape[:-1], N)
+    return output
+
+
+# Register as torch.library.custom_op for fullgraph compatibility.
+# Dynamo treats custom ops as opaque (no tracing into kernel body).
+try:
+
+    @torch.library.custom_op(
+        "turboquant::tq_fused_gemm", mutates_args=(), device_types=("cuda",),
+    )
+    def _tq_fused_gemm_op(
+        x: torch.Tensor, packed_weight: torch.Tensor, norms: torch.Tensor,
+        signs1: torch.Tensor, signs2: torch.Tensor, centroids: torch.Tensor,
+        group_size: int, bits: int, bias: torch.Tensor | None,
+    ) -> torch.Tensor:
+        return _tq_fused_gemm_launcher(
+            x, packed_weight, norms, signs1, signs2, centroids,
+            group_size=group_size, bits=bits, bias=bias,
+        )
+
+    @_tq_fused_gemm_op.register_fake
+    def _(x, packed_weight, norms, signs1, signs2, centroids, group_size, bits, bias):
+        N = norms.shape[0]
+        return x.new_empty((*x.shape[:-1], N))
+
+    @torch.library.custom_op(
+        "turboquant::tq_fwht_input_gemm", mutates_args=(), device_types=("cuda",),
+    )
+    def _tq_fwht_input_gemm_op(
+        x: torch.Tensor, packed_weight: torch.Tensor, norms: torch.Tensor,
+        signs1: torch.Tensor, signs2: torch.Tensor, centroids: torch.Tensor,
+        group_size: int, bits: int, bias: torch.Tensor | None,
+    ) -> torch.Tensor:
+        return _tq_fwht_input_gemm_launcher(
+            x, packed_weight, norms, signs1, signs2, centroids,
+            group_size=group_size, bits=bits, bias=bias,
+        )
+
+    @_tq_fwht_input_gemm_op.register_fake
+    def _(x, packed_weight, norms, signs1, signs2, centroids, group_size, bits, bias):
+        N = norms.shape[0]
+        return x.new_empty((*x.shape[:-1], N))
+
+    def tq_fused_gemm(x, packed_weight, norms, signs1, signs2, centroids,
+                      group_size=128, bits=4, bias=None):
+        return torch.ops.turboquant.tq_fused_gemm(
+            x, packed_weight, norms, signs1, signs2, centroids,
+            group_size, bits, bias,
+        )
+
+    def tq_fwht_input_gemm(x, packed_weight, norms, signs1, signs2, centroids,
+                           group_size=128, bits=4, bias=None):
+        return torch.ops.turboquant.tq_fwht_input_gemm(
+            x, packed_weight, norms, signs1, signs2, centroids,
+            group_size, bits, bias,
+        )
+except (AttributeError, RuntimeError, NameError):
+    # Triton not available — tq_fused_gemm / tq_fwht_input_gemm undefined
+    tq_fused_gemm = None  # type: ignore[assignment]
+    tq_fwht_input_gemm = None  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# TurboQuantOnlineLinearMethod
+# ---------------------------------------------------------------------------
+
+
+class TurboQuantOnlineLinearMethod(LinearMethodBase):
+    """Online TQ3/TQ4 weight compression for Linear layers.
+
+    Allocates bf16 weight on meta device (zero GPU at init). After
+    weight loading materializes the bf16 on GPU, compresses to TQ
+    packed format. Forward pass uses Triton dequant-GEMM kernels.
+    """
+
+    uses_meta_device: bool = True
+
+    def __init__(self, bits: int = 3, group_size: int = 128):
+        self.bits = bits
+        self.group_size = group_size
+
+    def create_weights(
+        self,
+        layer: nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs: Any,
+    ) -> None:
+        output_size_per_partition = sum(output_partition_sizes)
+        weight_loader = extra_weight_attrs.get("weight_loader")
+
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition,
+                device="meta",
+                dtype=params_dtype,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight", weight)
+        initialize_online_processing(layer)
+
+    def process_weights_after_loading(self, layer: nn.Module) -> None:
+        if getattr(layer, "_already_called_process_weights_after_loading", False):
+            return
+
+        weight = layer.weight.data
+        bits = self.bits
+        group_size = self.group_size
+
+        out_dim, in_dim = weight.shape
+        padded_in, n_groups = _padded_size(in_dim, group_size)
+
+        if padded_in > in_dim:
+            padded = torch.zeros(out_dim, padded_in, dtype=weight.dtype, device=weight.device)
+            padded[:, :in_dim] = weight
+        else:
+            padded = weight
+
+        grouped = padded.reshape(-1, group_size)
+        quantizer = _get_quantizer(group_size, bits, str(weight.device))
+        indices, norms_raw = quantizer.quantize(grouped)
+        packed = _pack_indices(indices, bits)
+        norms = norms_raw.reshape(out_dim, n_groups)
+
+        # Keep weight attr for vLLM's MLA post-processing (expects it to exist)
+        layer.weight.data = torch.empty(0, device=weight.device, dtype=weight.dtype)
+        layer.register_buffer("tq_packed_weight", packed)
+        layer.register_buffer("tq_norms", norms)
+        layer.register_buffer("tq_signs1", quantizer.signs1)
+        layer.register_buffer("tq_signs2", quantizer.signs2)
+        layer.register_buffer("tq_centroids", quantizer.centroids)
+        layer.tq_in_features = in_dim
+        layer.tq_out_features = out_dim
+        layer.tq_padded_in = padded_in
+
+        if tq_fused_gemm is not None:
+            layer._tq_primary_fn = tq_fwht_input_gemm if out_dim >= 4096 else tq_fused_gemm
+            layer._tq_fallback_fn = tq_fused_gemm if out_dim >= 4096 else tq_fwht_input_gemm
+        else:
+            layer._tq_primary_fn = None
+
+        layer._already_called_process_weights_after_loading = True
+        del weight, padded, grouped, indices, norms_raw
+
+    def apply(
+        self,
+        layer: nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # Pad input if in_dim was not a multiple of group_size
+        if x.shape[-1] != layer.tq_padded_in:
+            x = torch.nn.functional.pad(x, (0, layer.tq_padded_in - x.shape[-1]))
+
+        if layer._tq_primary_fn is not None:
+            args = (
+                x,
+                layer.tq_packed_weight,
+                layer.tq_norms,
+                layer.tq_signs1,
+                layer.tq_signs2,
+                layer.tq_centroids,
+            )
+            try:
+                return layer._tq_primary_fn(*args, group_size=self.group_size, bits=self.bits, bias=bias)
+            except (ValueError, RuntimeError) as e:
+                logger.warning_once("TurboQuant primary kernel failed, using fallback: %s", e)
+                return layer._tq_fallback_fn(*args, group_size=self.group_size, bits=self.bits, bias=bias)
+
+        # PyTorch fallback (no Triton)
+        indices = _unpack_indices(layer.tq_packed_weight, self.bits, self.group_size)
+        norms_flat = layer.tq_norms.reshape(-1)
+        quantizer = _get_quantizer(self.group_size, self.bits, str(x.device))
+        w_groups = quantizer.dequantize(indices, norms_flat)
+        w_deq = w_groups.reshape(layer.tq_out_features, layer.tq_padded_in).to(x.dtype)
+        output = torch.matmul(x, w_deq.t())
+        if bias is not None:
+            output = output + bias
+        return output

--- a/vllm/model_executor/layers/quantization/online/turboquant.py
+++ b/vllm/model_executor/layers/quantization/online/turboquant.py
@@ -6,7 +6,15 @@
 Load any BF16 checkpoint, compress weights at startup, serve with
 ~4x smaller GPU memory. Zero calibration data needed.
 
-Based on TurboQuant (Zandieh et al., ICLR 2026).
+Algorithm: scalar case of HIGGS (Malinovskii et al., NAACL 2025,
+aclanthology.org/2025.naacl-long.543; preprint arXiv:2411.17525) —
+Random Hadamard Transform + MSE-optimal Lloyd-Max grid + per-group
+normalization. The implementation was originally based on TurboQuant
+(Zandieh et al., ICLR 2026, arXiv:2504.19874), which targets online
+KV-cache and ANN vector search; engineering simplifications (scalar
+over vector, WHT over general random rotations) converged the weight
+path onto the HIGGS scalar case. The ``turboquant`` name is kept
+for API and plugin-package compatibility.
 
 Usage:
     vllm serve <model> --quantization turboquant
@@ -132,7 +140,10 @@ class _PolarQuant:
         x_unit = x / safe_norms.unsqueeze(1)
         y = self._rotate(x_unit)
         indices = torch.searchsorted(self.boundaries, y.contiguous())
-        # Norm correction: store original_norm / reconstruction_norm
+        # Shape-gain decomposition (classical VQ technique, Gray 1984):
+        # store original_norm / reconstruction_norm instead of raw L2 norm.
+        # Accounts for the reconstruction-norm shrinkage from the quantization
+        # step itself; ~2x lower 3-bit reconstruction error vs raw L2.
         y_hat = self.centroids[indices]
         x_hat_unit = self._rotate_inverse(y_hat)
         recon_norm = torch.linalg.norm(x_hat_unit, dim=1)

--- a/vllm/model_executor/layers/quantization/online/turboquant.py
+++ b/vllm/model_executor/layers/quantization/online/turboquant.py
@@ -25,6 +25,9 @@ from vllm.model_executor.layers.linear import LinearMethodBase
 from vllm.model_executor.layers.quantization.turboquant.centroids import (
     get_centroids,
 )
+from vllm.model_executor.layers.quantization.turboquant.quantizer import (
+    generate_wht_signs,
+)
 from vllm.model_executor.model_loader.reload.layerwise import (
     initialize_online_processing,
 )
@@ -84,10 +87,12 @@ class _PolarQuant:
             dev = torch.device("cuda", torch.cuda.current_device())
         self.device = dev
 
-        gen = torch.Generator(device="cpu").manual_seed(seed)
+        # Reuse the shared sign-vector helper (added in #38479). Two
+        # independent seeds keep signs1 and signs2 uncorrelated — both
+        # are needed by the randomized Walsh-Hadamard rotation.
         self.padded_dim = next_power_of_2(dim)
-        self.signs1 = (torch.randint(0, 2, (self.padded_dim,), generator=gen) * 2 - 1).float().to(dev)
-        self.signs2 = (torch.randint(0, 2, (self.padded_dim,), generator=gen) * 2 - 1).float().to(dev)
+        self.signs1 = generate_wht_signs(self.padded_dim, seed=seed, device=dev)
+        self.signs2 = generate_wht_signs(self.padded_dim, seed=seed + 1, device=dev)
 
         # Reuse the Lloyd-Max codebook from the KV-cache TurboQuant module
         # (added in #38479). It's scipy-free (trapezoid integration) and

--- a/vllm/model_executor/layers/quantization/online/turboquant.py
+++ b/vllm/model_executor/layers/quantization/online/turboquant.py
@@ -22,6 +22,9 @@ import torch.nn as nn
 
 from vllm.logger import init_logger
 from vllm.model_executor.layers.linear import LinearMethodBase
+from vllm.model_executor.layers.quantization.turboquant.centroids import (
+    get_centroids,
+)
 from vllm.model_executor.model_loader.reload.layerwise import (
     initialize_online_processing,
 )
@@ -29,55 +32,6 @@ from vllm.model_executor.parameter import ModelWeightParameter
 from vllm.utils.math_utils import next_power_of_2, round_up
 
 logger = init_logger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Codebook: Lloyd-Max optimal centroids for N(0, 1/d)
-# ---------------------------------------------------------------------------
-
-
-def _gaussian_cond_expect(sigma: float, a: float, b: float) -> float:
-    """E[X | a < X < b] for X ~ N(0, sigma^2)."""
-    from scipy import stats
-
-    a_std = a / sigma if math.isfinite(a) else a
-    b_std = b / sigma if math.isfinite(b) else b
-    if not math.isfinite(a_std):
-        prob = stats.norm.cdf(b_std)
-    elif not math.isfinite(b_std):
-        prob = stats.norm.sf(a_std)
-    else:
-        prob = stats.norm.cdf(b_std) - stats.norm.cdf(a_std)
-    if prob < 1e-15:
-        return (a + b) / 2.0 if math.isfinite(a) and math.isfinite(b) else 0.0
-    return sigma * (stats.norm.pdf(a_std) - stats.norm.pdf(b_std)) / prob
-
-
-def _lloyd_max_centroids(n: int, sigma: float, n_iter: int = 100) -> list[float]:
-    """Lloyd's algorithm for optimal scalar quantization of N(0, sigma^2)."""
-    from scipy import stats
-
-    boundaries = list(stats.norm.ppf([i / n for i in range(1, n)], scale=sigma))
-    centroids = [0.0] * n
-    for _ in range(n_iter):
-        centroids[0] = _gaussian_cond_expect(sigma, -math.inf, boundaries[0])
-        for i in range(1, n - 1):
-            centroids[i] = _gaussian_cond_expect(sigma, boundaries[i - 1], boundaries[i])
-        centroids[-1] = _gaussian_cond_expect(sigma, boundaries[-1], math.inf)
-        boundaries = [(centroids[i] + centroids[i + 1]) / 2 for i in range(n - 1)]
-    return sorted(centroids)
-
-
-def _optimal_centroids(bits: int, dim: int) -> list[float]:
-    """Optimal centroids for post-rotation coordinates ~ N(0, 1/d)."""
-    n = 1 << bits
-    if bits == 1:
-        c = math.sqrt(2.0 / (math.pi * dim))
-        return [-c, c]
-    if bits == 2:
-        s = math.sqrt(dim)
-        return [-1.51 / s, -0.453 / s, 0.453 / s, 1.51 / s]
-    return _lloyd_max_centroids(n, sigma=1.0 / math.sqrt(dim))
 
 
 # ---------------------------------------------------------------------------
@@ -135,8 +89,10 @@ class _PolarQuant:
         self.signs1 = (torch.randint(0, 2, (self.padded_dim,), generator=gen) * 2 - 1).float().to(dev)
         self.signs2 = (torch.randint(0, 2, (self.padded_dim,), generator=gen) * 2 - 1).float().to(dev)
 
-        centroids_list = _optimal_centroids(bits, dim)
-        self.centroids = torch.tensor(centroids_list, dtype=torch.float32, device=dev)
+        # Reuse the Lloyd-Max codebook from the KV-cache TurboQuant module
+        # (added in #38479). It's scipy-free (trapezoid integration) and
+        # cached via lru_cache on (dim, bits).
+        self.centroids = get_centroids(dim, bits).to(dev)
         self.boundaries = (self.centroids[:-1] + self.centroids[1:]) / 2
 
     def _rotate(self, x: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/layers/quantization/online/turboquant.py
+++ b/vllm/model_executor/layers/quantization/online/turboquant.py
@@ -630,6 +630,13 @@ class TurboQuantOnlineLinearMethod(LinearMethodBase):
     uses_meta_device: bool = True
 
     def __init__(self, bits: int = 3, group_size: int = 128):
+        if bits not in (2, 3, 4):
+            raise ValueError(f"turboquant bits must be 2, 3, or 4; got {bits}")
+        if group_size <= 0 or group_size % 8 != 0:
+            raise ValueError(
+                "turboquant group_size must be a positive multiple of 8; "
+                f"got {group_size}"
+            )
         self.bits = bits
         self.group_size = group_size
 

--- a/vllm/model_executor/layers/quantization/online/turboquant.py
+++ b/vllm/model_executor/layers/quantization/online/turboquant.py
@@ -335,6 +335,13 @@ if _HAS_TRITON:
                 pb = tl.load(packed_ptr + pe, mask=offs_n[:, None] < N, other=0).to(tl.int32)
                 indices = tl.where(is_hi[None, :] > 0, (pb >> 4) & 0xF, pb & 0xF)
             elif BITS == 3:
+                # Bulk-load all 48 packed bytes per row in one coalesced
+                # transaction (padded to 64 = pow-of-2 for Triton tile
+                # constraint, with the tail 16 masked out). Then gather the
+                # per-k bytes from the in-register buffer. Replaces two
+                # uncoalesced per-thread scatter loads whose stride pattern
+                # (bi0[k]=[0,0,0,1,1,1,2,2,...]) could not be vectorized
+                # by Triton and cost ~50x at bs=1 on real models.
                 g8 = offs_k // 8
                 p8 = offs_k % 8
                 bo = p8 * 3
@@ -342,11 +349,19 @@ if _HAS_TRITON:
                 bib = (bo % 8).to(tl.int32)
                 crosses = bib > 5
                 bi0 = g8 * 3 + fb
-                bi1 = bi0 + 1
-                p0 = packed_row[:, None] * stride_packed_n + bi0[None, :] * stride_packed_k
-                b0 = tl.load(packed_ptr + p0, mask=offs_n[:, None] < N, other=0).to(tl.int32)
-                p1 = packed_row[:, None] * stride_packed_n + bi1[None, :] * stride_packed_k
-                b1 = tl.load(packed_ptr + p1, mask=offs_n[:, None] < N, other=0).to(tl.int32)
+                bi1 = tl.minimum(bi0 + 1, 47)
+                byte_offs = tl.arange(0, 64)
+                valid_byte = byte_offs < 48
+                bulk_p = packed_row[:, None] * stride_packed_n + byte_offs[None, :] * stride_packed_k
+                bulk = tl.load(
+                    packed_ptr + bulk_p,
+                    mask=(offs_n[:, None] < N) & valid_byte[None, :],
+                    other=0,
+                ).to(tl.int32)
+                bi0_bc = tl.broadcast_to(bi0[None, :], (BLOCK_N, GROUP_SIZE))
+                bi1_bc = tl.broadcast_to(bi1[None, :], (BLOCK_N, GROUP_SIZE))
+                b0 = tl.gather(bulk, bi0_bc, axis=1)
+                b1 = tl.gather(bulk, bi1_bc, axis=1)
                 single = (b0 >> bib[None, :]) & 0x7
                 cross = ((b0 >> bib[None, :]) | (b1 << (8 - bib[None, :]))) & 0x7
                 indices = tl.where(crosses[None, :], cross, single)
@@ -425,6 +440,9 @@ if _HAS_TRITON:
                 pk = tl.load(codes_ptr + cp, mask=mask_n[:, None], other=0).to(tl.int32)
                 codes = tl.where(ih[None, :] > 0, (pk >> 4) & 0xF, pk & 0xF)
             elif BITS == 3:
+                # Bulk-load all 48 packed bytes per row in one coalesced
+                # transaction, then gather per-k bytes from the in-register
+                # buffer. See identical fix in _tq_fused_gemm_kernel.
                 g8 = offs_k // 8
                 p8 = offs_k % 8
                 bo = p8 * 3
@@ -432,11 +450,19 @@ if _HAS_TRITON:
                 bib = (bo % 8).to(tl.int32)
                 crosses = bib > 5
                 bi0 = g8 * 3 + fb
-                bi1 = bi0 + 1
-                p0 = packed_row[:, None] * stride_cn + bi0[None, :] * stride_ck
-                b0 = tl.load(codes_ptr + p0, mask=mask_n[:, None], other=0).to(tl.int32)
-                p1 = packed_row[:, None] * stride_cn + bi1[None, :] * stride_ck
-                b1 = tl.load(codes_ptr + p1, mask=mask_n[:, None], other=0).to(tl.int32)
+                bi1 = tl.minimum(bi0 + 1, 47)
+                byte_offs = tl.arange(0, 64)
+                valid_byte = byte_offs < 48
+                bulk_p = packed_row[:, None] * stride_cn + byte_offs[None, :] * stride_ck
+                bulk = tl.load(
+                    codes_ptr + bulk_p,
+                    mask=mask_n[:, None] & valid_byte[None, :],
+                    other=0,
+                ).to(tl.int32)
+                bi0_bc = tl.broadcast_to(bi0[None, :], (BLOCK_N, BLOCK_K))
+                bi1_bc = tl.broadcast_to(bi1[None, :], (BLOCK_N, BLOCK_K))
+                b0 = tl.gather(bulk, bi0_bc, axis=1)
+                b1 = tl.gather(bulk, bi1_bc, axis=1)
                 single = (b0 >> bib[None, :]) & 0x7
                 cross = ((b0 >> bib[None, :]) | (b1 << (8 - bib[None, :]))) & 0x7
                 codes = tl.where(crosses[None, :], cross, single)

--- a/vllm/model_executor/layers/quantization/online/turboquant.py
+++ b/vllm/model_executor/layers/quantization/online/turboquant.py
@@ -1,0 +1,1018 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""TurboQuant online weight quantization for vLLM.
+
+2-4 bit weight compression via WHT rotation + Lloyd-Max codebook.
+Load any BF16 checkpoint, compress weights at startup, serve with
+~4x smaller GPU memory. Zero calibration data needed.
+
+Algorithm: scalar case of HIGGS (Malinovskii et al., NAACL 2025,
+aclanthology.org/2025.naacl-long.543; preprint arXiv:2411.17525) —
+Random Hadamard Transform + MSE-optimal Lloyd-Max grid + per-group
+normalization. The implementation was originally based on TurboQuant
+(Zandieh et al., ICLR 2026, arXiv:2504.19874), which targets online
+KV-cache and ANN vector search; engineering simplifications (scalar
+over vector, WHT over general random rotations) converged the weight
+path onto the HIGGS scalar case. The ``turboquant`` name is kept for
+API and plugin-package compatibility. NVFP4 / MXFP4 are explicitly
+out of scope — those are hardware-accelerated tensor-core formats
+served by separate online methods.
+
+Usage:
+    vllm serve <model> --quantization turboquant            # TQ3, group 128
+    vllm serve <model> --quantization turboquant_4bit       # TQ4
+    vllm serve <model> --quantization turboquant_2bit       # TQ2
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from vllm.logger import init_logger
+from vllm.model_executor.layers.linear import LinearMethodBase
+from vllm.model_executor.layers.quantization.turboquant.centroids import (
+    get_centroids,
+)
+from vllm.model_executor.model_loader.reload.layerwise import (
+    initialize_online_processing,
+)
+from vllm.model_executor.parameter import ModelWeightParameter
+from vllm.utils.math_utils import next_power_of_2, round_up
+
+logger = init_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Fast Walsh-Hadamard Transform
+# ---------------------------------------------------------------------------
+
+
+def _fast_wht_batch(x: torch.Tensor) -> torch.Tensor:
+    """Batched fast WHT. x: (batch, n) where n is power of 2."""
+    n = x.shape[1]
+    h = 1
+    while h < n:
+        x_view = x.view(x.shape[0], n // (h * 2), 2, h)
+        a = x_view[:, :, 0, :].clone()
+        b = x_view[:, :, 1, :].clone()
+        x_view[:, :, 0, :] = a + b
+        x_view[:, :, 1, :] = a - b
+        h *= 2
+    return x / math.sqrt(n)
+
+
+def _generate_wht_signs(dim: int, seed: int, device: torch.device) -> torch.Tensor:
+    """Deterministic ±1 sign vector for the randomized WHT rotation.
+
+    Inlined locally instead of imported from the legacy KV-cache
+    `turboquant/quantizer.py` (deleted upstream in #40194 / #42889).
+    """
+    gen = torch.Generator(device=device)
+    gen.manual_seed(seed)
+    bits = torch.randint(0, 2, (dim,), generator=gen, device=device, dtype=torch.int8)
+    return (bits.to(torch.float32) * 2.0 - 1.0).contiguous()
+
+
+# ---------------------------------------------------------------------------
+# PolarQuant quantizer
+# ---------------------------------------------------------------------------
+
+# Cache: (group_size, bits, device_str) -> PolarQuant instance
+_quantizers: dict[tuple[int, int, str], _PolarQuant] = {}
+
+
+def _get_quantizer(group_size: int, bits: int, device: str) -> _PolarQuant:
+    dev = torch.device(device)
+    if dev.type == "cuda" and dev.index is None:
+        # Per RFC: use torch.accelerator instead of torch.cuda for device-index
+        # lookup (see vllm-project/vllm#30679 and pre-commit hook).
+        dev = torch.device("cuda", torch.accelerator.current_device_index())
+    key = (group_size, bits, str(dev))
+    if key not in _quantizers:
+        _quantizers[key] = _PolarQuant(group_size, bits, device=str(dev))
+    return _quantizers[key]
+
+
+class _PolarQuant:
+    """WHT rotation + Gaussian Lloyd-Max codebook quantizer."""
+
+    def __init__(self, dim: int, bits: int, seed: int = 42, device: str = "cuda"):
+        self.dim = dim
+        self.bits = bits
+        dev = torch.device(device)
+        if dev.type == "cuda" and dev.index is None:
+            dev = torch.device("cuda", torch.accelerator.current_device_index())
+        self.device = dev
+
+        # Two independent seeds keep signs1 and signs2 uncorrelated — both
+        # are needed by the randomized Walsh-Hadamard rotation.
+        self.padded_dim = next_power_of_2(dim)
+        self.signs1 = _generate_wht_signs(self.padded_dim, seed=seed, device=dev)
+        self.signs2 = _generate_wht_signs(self.padded_dim, seed=seed + 1, device=dev)
+
+        # Reuse the Lloyd-Max codebook from the KV-cache TurboQuant module
+        # (added in #38479). It's scipy-free (trapezoid integration) and
+        # cached via lru_cache on (dim, bits).
+        self.centroids = get_centroids(dim, bits).to(dev)
+        self.boundaries = (self.centroids[:-1] + self.centroids[1:]) / 2
+
+    def _rotate(self, x: torch.Tensor) -> torch.Tensor:
+        batch = x.shape[0]
+        if self.padded_dim > self.dim:
+            padded = torch.zeros(batch, self.padded_dim, device=x.device, dtype=x.dtype)
+            padded[:, : self.dim] = x
+        else:
+            padded = x.clone()
+        padded *= self.signs1.unsqueeze(0)
+        padded = _fast_wht_batch(padded)
+        padded *= self.signs2.unsqueeze(0)
+        return padded[:, : self.dim]
+
+    def _rotate_inverse(self, y: torch.Tensor) -> torch.Tensor:
+        batch = y.shape[0]
+        if self.padded_dim > self.dim:
+            padded = torch.zeros(batch, self.padded_dim, device=y.device, dtype=y.dtype)
+            padded[:, : self.dim] = y
+        else:
+            padded = y.clone()
+        padded *= self.signs2.unsqueeze(0)
+        padded = _fast_wht_batch(padded)
+        padded *= self.signs1.unsqueeze(0)
+        return padded[:, : self.dim]
+
+    def quantize(self, x: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """Quantize grouped vectors. x: (n_groups, group_size).
+
+        Returns (indices, norms).
+        """
+        x = x.to(device=self.device, dtype=torch.float32)
+        norms = torch.linalg.norm(x, dim=1)
+        safe_norms = torch.where(norms > 0, norms, torch.ones_like(norms))
+        x_unit = x / safe_norms.unsqueeze(1)
+        y = self._rotate(x_unit)
+        indices = torch.searchsorted(self.boundaries, y.contiguous())
+        # Shape-gain decomposition (classical VQ, Gray 1984): store
+        # original_norm / reconstruction_norm instead of raw L2 norm.
+        # Accounts for the reconstruction-norm shrinkage from the
+        # quantization step itself; ~2x lower 3-bit reconstruction error
+        # vs raw L2.
+        y_hat = self.centroids[indices]
+        x_hat_unit = self._rotate_inverse(y_hat)
+        recon_norm = torch.linalg.norm(x_hat_unit, dim=1)
+        safe_recon = torch.where(
+            recon_norm > 0, recon_norm, torch.ones_like(recon_norm)
+        )
+        norms = norms / safe_recon
+        return indices, norms
+
+    def dequantize(self, indices: torch.Tensor, norms: torch.Tensor) -> torch.Tensor:
+        """Dequantize. indices: (n_groups, group_size)."""
+        indices = indices.to(device=self.device)
+        norms = norms.to(device=self.device, dtype=torch.float32)
+        y_hat = self.centroids[indices]
+        x_hat_unit = self._rotate_inverse(y_hat)
+        return x_hat_unit * norms.unsqueeze(1)
+
+
+# ---------------------------------------------------------------------------
+# Bit packing: pack/unpack quantization indices into uint8
+# ---------------------------------------------------------------------------
+
+
+def _padded_size(dim: int, group_size: int) -> tuple[int, int]:
+    """Return (padded_dim, n_groups) for group quantization."""
+    padded = round_up(dim, group_size)
+    return padded, padded // group_size
+
+
+def _pack_indices(indices: torch.Tensor, bits: int) -> torch.Tensor:
+    """Pack quantization indices into uint8."""
+    if bits == 4:
+        flat = indices.reshape(-1, indices.shape[-1])
+        lo = flat[:, 0::2].to(torch.uint8)
+        hi = flat[:, 1::2].to(torch.uint8)
+        return (lo | (hi << 4)).reshape(indices.shape[0], -1)
+    elif bits == 3:
+        n_rows, n_cols = indices.shape[0], indices.shape[-1]
+        flat = indices.reshape(n_rows, -1).to(torch.uint8)
+        pad = (8 - n_cols % 8) % 8
+        if pad > 0:
+            flat = torch.nn.functional.pad(flat, (0, pad))
+        n_packed_cols = flat.shape[1] // 8 * 3
+        packed = torch.zeros(
+            n_rows, n_packed_cols, dtype=torch.uint8, device=indices.device
+        )
+        for i in range(flat.shape[1] // 8):
+            v = flat[:, i * 8 : (i + 1) * 8]
+            packed[:, i * 3] = v[:, 0] | (v[:, 1] << 3) | ((v[:, 2] & 0x3) << 6)
+            packed[:, i * 3 + 1] = (
+                (v[:, 2] >> 2)
+                | (v[:, 3] << 1)
+                | (v[:, 4] << 4)
+                | ((v[:, 5] & 0x1) << 7)
+            )
+            packed[:, i * 3 + 2] = (v[:, 5] >> 1) | (v[:, 6] << 2) | (v[:, 7] << 5)
+        return packed
+    elif bits == 2:
+        flat = indices.reshape(-1, indices.shape[-1])
+        shifts = torch.tensor([0, 2, 4, 6], device=indices.device, dtype=torch.uint8)
+        parts = torch.stack([flat[:, i::4].to(torch.uint8) for i in range(4)], dim=-1)
+        return (
+            (parts << shifts).sum(dim=-1).to(torch.uint8).reshape(indices.shape[0], -1)
+        )
+    return indices.to(torch.uint8)
+
+
+def _unpack_indices(packed: torch.Tensor, bits: int, dim: int) -> torch.Tensor:
+    """Unpack uint8 packed indices back to int64."""
+    if bits == 4:
+        flat = packed.reshape(-1, packed.shape[-1])
+        lo = (flat & 0x0F).to(torch.int64)
+        hi = ((flat >> 4) & 0x0F).to(torch.int64)
+        unpacked = torch.zeros(
+            flat.shape[0],
+            flat.shape[1] * 2,
+            dtype=torch.int64,
+            device=packed.device,
+        )
+        unpacked[:, 0::2] = lo
+        unpacked[:, 1::2] = hi
+        return unpacked.reshape(packed.shape[0], -1)[:, :dim]
+    elif bits == 3:
+        flat = packed.reshape(-1, packed.shape[-1])
+        n_rows = flat.shape[0]
+        n_groups_of_3 = flat.shape[1] // 3
+        unpacked = torch.zeros(
+            n_rows, n_groups_of_3 * 8, dtype=torch.int64, device=packed.device
+        )
+        for i in range(n_groups_of_3):
+            b0 = flat[:, i * 3].to(torch.int64)
+            b1 = flat[:, i * 3 + 1].to(torch.int64)
+            b2 = flat[:, i * 3 + 2].to(torch.int64)
+            unpacked[:, i * 8 + 0] = b0 & 0x7
+            unpacked[:, i * 8 + 1] = (b0 >> 3) & 0x7
+            unpacked[:, i * 8 + 2] = ((b0 >> 6) | (b1 << 2)) & 0x7
+            unpacked[:, i * 8 + 3] = (b1 >> 1) & 0x7
+            unpacked[:, i * 8 + 4] = (b1 >> 4) & 0x7
+            unpacked[:, i * 8 + 5] = ((b1 >> 7) | (b2 << 1)) & 0x7
+            unpacked[:, i * 8 + 6] = (b2 >> 2) & 0x7
+            unpacked[:, i * 8 + 7] = (b2 >> 5) & 0x7
+        return unpacked[:, :dim]
+    elif bits == 2:
+        flat = packed.reshape(-1, packed.shape[-1])
+        unpacked = torch.zeros(
+            flat.shape[0],
+            flat.shape[1] * 4,
+            dtype=torch.int64,
+            device=packed.device,
+        )
+        for i in range(4):
+            unpacked[:, i::4] = ((flat >> (i * 2)) & 0x03).to(torch.int64)
+        return unpacked.reshape(packed.shape[0], -1)[:, :dim]
+    return packed.to(torch.int64)
+
+
+# ---------------------------------------------------------------------------
+# Triton kernels (FWHT-on-input GEMM + fused dequant-GEMM)
+# ---------------------------------------------------------------------------
+
+try:
+    import triton
+    import triton.language as tl
+
+    _HAS_TRITON = True
+except ImportError:
+    _HAS_TRITON = False
+
+# Rotation matrix cache: (id(signs1), id(signs2), group_size) -> tensor
+_rotation_matrix_cache: dict[tuple, torch.Tensor] = {}
+
+
+def _build_rotation_matrix(
+    signs1: torch.Tensor,
+    signs2: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    """Pre-compute inverse rotation matrix W_rot = H @ D2 @ D1 / sqrt(n)."""
+    n = group_size
+    eye = torch.eye(n, device=signs1.device, dtype=torch.float32)
+    rotated = eye * signs2.unsqueeze(0)
+    rotated = _fast_wht_batch(rotated)
+    rotated = rotated * signs1.unsqueeze(0)
+    return rotated
+
+
+def _get_cached_rotation_matrix(
+    signs1: torch.Tensor,
+    signs2: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    key = (id(signs1), id(signs2), group_size)
+    if key not in _rotation_matrix_cache:
+        _rotation_matrix_cache[key] = _build_rotation_matrix(
+            signs1, signs2, group_size
+        ).contiguous()
+    return _rotation_matrix_cache[key]
+
+
+def _rotate_input(
+    x: torch.Tensor,
+    signs1: torch.Tensor,
+    signs2: torch.Tensor,
+    group_size: int,
+) -> torch.Tensor:
+    """Apply forward rotation to input, grouped by group_size."""
+    batch = x.shape[0]
+    K = x.shape[1]
+    padded_K = ((K + group_size - 1) // group_size) * group_size
+    if padded_K > K:
+        x = torch.nn.functional.pad(x, (0, padded_K - K))
+    w_rot = _get_cached_rotation_matrix(signs1, signs2, group_size)
+    x_grouped = x.reshape(-1, group_size)
+    x_grouped = torch.matmul(x_grouped, w_rot.T)
+    return x_grouped.reshape(batch, padded_K)
+
+
+if _HAS_TRITON:
+
+    @triton.jit
+    def _tq_fused_gemm_kernel(
+        a_ptr,
+        stride_am,
+        stride_ak,
+        packed_ptr,
+        norms_ptr,
+        stride_packed_n,
+        stride_packed_k,
+        stride_norms_n,
+        stride_norms_g,
+        w_rot_ptr,
+        centroids_ptr,
+        c_ptr,
+        stride_cm,
+        stride_cn,
+        bias_ptr,
+        M,
+        N,
+        K,
+        n_groups,
+        GROUP_SIZE: tl.constexpr,
+        BITS: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+    ):
+        """Fused TQ dequant-GEMM: unpack + codebook + rotate + scale + accumulate.
+
+        Note: 3-bit unpacking logic is duplicated in _polar_fused_gemm_kernel
+        (Triton JIT kernels cannot share helper functions).
+        """
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        offs_k = tl.arange(0, GROUP_SIZE)
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        rot_offs = offs_k[:, None] * GROUP_SIZE + offs_k[None, :]
+        w_rot = tl.load(w_rot_ptr + rot_offs)
+        for g in range(n_groups):
+            k_start = g * GROUP_SIZE
+            a_offs = (
+                offs_m[:, None] * stride_am + (k_start + offs_k[None, :]) * stride_ak
+            )
+            a_mask = (offs_m[:, None] < M) & ((k_start + offs_k[None, :]) < K)
+            a_tile = tl.load(a_ptr + a_offs, mask=a_mask, other=0.0).to(tl.float32)
+            packed_row = offs_n * n_groups + g
+            if BITS == 4:
+                byte_idx = offs_k // 2
+                is_hi = (offs_k % 2).to(tl.int32)
+                pe = (
+                    packed_row[:, None] * stride_packed_n
+                    + byte_idx[None, :] * stride_packed_k
+                )
+                pb = tl.load(packed_ptr + pe, mask=offs_n[:, None] < N, other=0).to(
+                    tl.int32
+                )
+                indices = tl.where(is_hi[None, :] > 0, (pb >> 4) & 0xF, pb & 0xF)
+            elif BITS == 3:
+                # Bulk-load all 48 packed bytes per row in one coalesced
+                # transaction (padded to 64 = pow-of-2 for Triton tile
+                # constraint, with the tail 16 masked out). Then gather the
+                # per-k bytes from the in-register buffer. Replaces two
+                # uncoalesced per-thread scatter loads whose stride pattern
+                # (bi0[k]=[0,0,0,1,1,1,2,2,...]) could not be vectorized
+                # by Triton and cost ~50x at bs=1 on real models.
+                g8 = offs_k // 8
+                p8 = offs_k % 8
+                bo = p8 * 3
+                fb = bo // 8
+                bib = (bo % 8).to(tl.int32)
+                crosses = bib > 5
+                bi0 = g8 * 3 + fb
+                bi1 = tl.minimum(bi0 + 1, 47)
+                byte_offs = tl.arange(0, 64)
+                valid_byte = byte_offs < 48
+                bulk_p = (
+                    packed_row[:, None] * stride_packed_n
+                    + byte_offs[None, :] * stride_packed_k
+                )
+                bulk = tl.load(
+                    packed_ptr + bulk_p,
+                    mask=(offs_n[:, None] < N) & valid_byte[None, :],
+                    other=0,
+                ).to(tl.int32)
+                bi0_bc = tl.broadcast_to(bi0[None, :], (BLOCK_N, GROUP_SIZE))
+                bi1_bc = tl.broadcast_to(bi1[None, :], (BLOCK_N, GROUP_SIZE))
+                b0 = tl.gather(bulk, bi0_bc, axis=1)
+                b1 = tl.gather(bulk, bi1_bc, axis=1)
+                single = (b0 >> bib[None, :]) & 0x7
+                cross = ((b0 >> bib[None, :]) | (b1 << (8 - bib[None, :]))) & 0x7
+                indices = tl.where(crosses[None, :], cross, single)
+            elif BITS == 2:
+                byte_idx = offs_k // 4
+                shift = (offs_k % 4).to(tl.int32) * 2
+                pe = (
+                    packed_row[:, None] * stride_packed_n
+                    + byte_idx[None, :] * stride_packed_k
+                )
+                pb = tl.load(packed_ptr + pe, mask=offs_n[:, None] < N, other=0).to(
+                    tl.int32
+                )
+                indices = (pb >> shift[None, :]) & 0x3
+            else:
+                pe = (
+                    packed_row[:, None] * stride_packed_n
+                    + offs_k[None, :] * stride_packed_k
+                )
+                indices = tl.load(
+                    packed_ptr + pe, mask=offs_n[:, None] < N, other=0
+                ).to(tl.int32)
+            centroid_vec = tl.load(centroids_ptr + indices)
+            w_deq = tl.dot(centroid_vec, w_rot)
+            norm_offs = offs_n * stride_norms_n + g * stride_norms_g
+            norms = tl.load(norms_ptr + norm_offs, mask=offs_n < N, other=0.0)
+            w_deq = w_deq * norms[:, None]
+            # Cast to output dtype for tensor core GEMM (bf16/fp16 ~2x faster)
+            out_dt = c_ptr.type.element_ty
+            acc += tl.dot(a_tile.to(out_dt), tl.trans(w_deq).to(out_dt))
+        if bias_ptr:
+            bias = tl.load(bias_ptr + offs_n, mask=offs_n < N, other=0.0)
+            acc += bias[None, :]
+        c_offs = offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+        c_mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+        tl.store(c_ptr + c_offs, acc.to(c_ptr.type.element_ty), mask=c_mask)
+
+    @triton.autotune(
+        configs=[
+            triton.Config({"BLOCK_M": 1, "BLOCK_N": 128}, num_warps=4, num_stages=2),
+            triton.Config({"BLOCK_M": 1, "BLOCK_N": 256}, num_warps=8, num_stages=2),
+            triton.Config({"BLOCK_M": 4, "BLOCK_N": 128}, num_warps=4, num_stages=2),
+            triton.Config({"BLOCK_M": 8, "BLOCK_N": 64}, num_warps=4, num_stages=2),
+            triton.Config({"BLOCK_M": 8, "BLOCK_N": 128}, num_warps=4, num_stages=2),
+            triton.Config({"BLOCK_M": 16, "BLOCK_N": 64}, num_warps=4, num_stages=2),
+            triton.Config({"BLOCK_M": 16, "BLOCK_N": 128}, num_warps=8, num_stages=2),
+            triton.Config({"BLOCK_M": 32, "BLOCK_N": 64}, num_warps=4, num_stages=2),
+            triton.Config({"BLOCK_M": 32, "BLOCK_N": 128}, num_warps=8, num_stages=2),
+            triton.Config({"BLOCK_M": 64, "BLOCK_N": 64}, num_warps=4, num_stages=2),
+        ],
+        key=["out_f", "in_f_padded"],
+    )
+    @triton.jit
+    def _polar_fused_gemm_kernel(
+        x_rot_ptr,
+        stride_xm,
+        stride_xk,
+        codes_ptr,
+        stride_cn,
+        stride_ck,
+        norms_ptr,
+        stride_nn,
+        stride_ng,
+        ct_ptr,
+        out_ptr,
+        stride_om,
+        stride_on,
+        bias_ptr,
+        batch_size,
+        out_f,
+        in_f_padded,
+        n_groups,
+        BLOCK_K: tl.constexpr,
+        BITS: tl.constexpr,
+        BLOCK_M: tl.constexpr,
+        BLOCK_N: tl.constexpr,
+    ):
+        """FWHT-on-input: codebook dot product with pre-rotated input.
+
+        Note: 3-bit unpacking logic is duplicated in _tq_fused_gemm_kernel
+        (Triton JIT kernels cannot share helper functions).
+        """
+        pid_m = tl.program_id(0)
+        pid_n = tl.program_id(1)
+        offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        mask_m = offs_m < batch_size
+        mask_n = offs_n < out_f
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+        for g in range(n_groups):
+            offs_k = tl.arange(0, BLOCK_K)
+            x_ptrs = (
+                offs_m[:, None] * stride_xm
+                + (g * BLOCK_K + offs_k)[None, :] * stride_xk
+            )
+            x_tile = tl.load(x_rot_ptr + x_ptrs, mask=mask_m[:, None], other=0.0)
+            packed_row = offs_n * n_groups + g
+            if BITS == 4:
+                bi = offs_k // 2
+                ih = offs_k % 2
+                cp = packed_row[:, None] * stride_cn + bi[None, :] * stride_ck
+                pk = tl.load(codes_ptr + cp, mask=mask_n[:, None], other=0).to(tl.int32)
+                codes = tl.where(ih[None, :] > 0, (pk >> 4) & 0xF, pk & 0xF)
+            elif BITS == 3:
+                # Bulk-load all 48 packed bytes per row in one coalesced
+                # transaction, then gather per-k bytes from the in-register
+                # buffer. See identical fix in _tq_fused_gemm_kernel.
+                g8 = offs_k // 8
+                p8 = offs_k % 8
+                bo = p8 * 3
+                fb = bo // 8
+                bib = (bo % 8).to(tl.int32)
+                crosses = bib > 5
+                bi0 = g8 * 3 + fb
+                bi1 = tl.minimum(bi0 + 1, 47)
+                byte_offs = tl.arange(0, 64)
+                valid_byte = byte_offs < 48
+                bulk_p = (
+                    packed_row[:, None] * stride_cn + byte_offs[None, :] * stride_ck
+                )
+                bulk = tl.load(
+                    codes_ptr + bulk_p,
+                    mask=mask_n[:, None] & valid_byte[None, :],
+                    other=0,
+                ).to(tl.int32)
+                bi0_bc = tl.broadcast_to(bi0[None, :], (BLOCK_N, BLOCK_K))
+                bi1_bc = tl.broadcast_to(bi1[None, :], (BLOCK_N, BLOCK_K))
+                b0 = tl.gather(bulk, bi0_bc, axis=1)
+                b1 = tl.gather(bulk, bi1_bc, axis=1)
+                single = (b0 >> bib[None, :]) & 0x7
+                cross = ((b0 >> bib[None, :]) | (b1 << (8 - bib[None, :]))) & 0x7
+                codes = tl.where(crosses[None, :], cross, single)
+            elif BITS == 2:
+                bi = offs_k // 4
+                sh = (offs_k % 4).to(tl.int32) * 2
+                cp = packed_row[:, None] * stride_cn + bi[None, :] * stride_ck
+                pk = tl.load(codes_ptr + cp, mask=mask_n[:, None], other=0).to(tl.int32)
+                codes = (pk >> sh[None, :]) & 0x3
+            else:
+                cp = packed_row[:, None] * stride_cn + offs_k[None, :] * stride_ck
+                codes = tl.load(codes_ptr + cp, mask=mask_n[:, None], other=0).to(
+                    tl.int32
+                )
+            values = tl.load(ct_ptr + codes)
+            norm_ptrs = offs_n * stride_nn + g * stride_ng
+            norms = tl.load(norms_ptr + norm_ptrs, mask=mask_n, other=0.0)
+            values = values * norms[:, None]
+            out_dt = out_ptr.type.element_ty
+            acc += tl.dot(x_tile.to(out_dt), tl.trans(values).to(out_dt))
+        if bias_ptr:
+            bias = tl.load(bias_ptr + offs_n, mask=mask_n, other=0.0)
+            acc += bias[None, :]
+        out_ptrs = offs_m[:, None] * stride_om + offs_n[None, :] * stride_on
+        out_mask = mask_m[:, None] & mask_n[None, :]
+        tl.store(out_ptr + out_ptrs, acc.to(out_ptr.type.element_ty), mask=out_mask)
+
+
+def _tq_fused_gemm_launcher(
+    x: torch.Tensor,
+    packed_weight: torch.Tensor,
+    norms: torch.Tensor,
+    signs1: torch.Tensor,
+    signs2: torch.Tensor,
+    centroids: torch.Tensor,
+    group_size: int = 128,
+    bits: int = 4,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Fused TQ dequant + GEMM launcher."""
+    orig_shape = x.shape
+    x = x.reshape(-1, x.shape[-1])
+    M, K = x.shape
+    N = norms.shape[0]
+    if M == 0:
+        return torch.empty((*orig_shape[:-1], N), dtype=x.dtype, device=x.device)
+    n_groups = norms.shape[1]
+    if K % group_size != 0 or K // group_size != n_groups:
+        raise ValueError(f"K={K} not aligned with group_size={group_size}")
+    w_rot = _get_cached_rotation_matrix(signs1, signs2, group_size)
+    output = torch.empty(M, N, dtype=x.dtype, device=x.device)
+    # Rotation matrix uses GROUP_SIZE^2 * 4 bytes of shared memory;
+    # cap block sizes to stay within hardware limits (~100 KB on Ada).
+    max_block = 16 if group_size >= 128 else 32
+    BLOCK_M = min(max_block, triton.next_power_of_2(M))
+    BLOCK_N = min(max_block, triton.next_power_of_2(N))
+    if not packed_weight.is_contiguous():
+        packed_weight = packed_weight.contiguous()
+    if not norms.is_contiguous():
+        norms = norms.contiguous()
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    _tq_fused_gemm_kernel[grid](
+        x,
+        x.stride(0),
+        x.stride(1),
+        packed_weight,
+        norms,
+        packed_weight.stride(0),
+        packed_weight.stride(1),
+        norms.stride(0),
+        norms.stride(1),
+        w_rot,
+        centroids,
+        output,
+        output.stride(0),
+        output.stride(1),
+        bias,
+        M,
+        N,
+        K,
+        n_groups,
+        GROUP_SIZE=group_size,
+        BITS=bits,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+    )
+    if len(orig_shape) > 2:
+        output = output.reshape(*orig_shape[:-1], N)
+    return output
+
+
+def _tq_fwht_input_gemm_launcher(
+    x: torch.Tensor,
+    packed_weight: torch.Tensor,
+    norms: torch.Tensor,
+    signs1: torch.Tensor,
+    signs2: torch.Tensor,
+    centroids: torch.Tensor,
+    group_size: int = 128,
+    bits: int = 4,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """FWHT-on-input GEMM launcher. Rotates input once, then codebook dot."""
+    orig_shape = x.shape
+    x = x.reshape(-1, x.shape[-1])
+    M, K = x.shape
+    N = norms.shape[0]
+    if M == 0:
+        return torch.empty((*orig_shape[:-1], N), dtype=x.dtype, device=x.device)
+    n_groups = norms.shape[1]
+    padded_K = n_groups * group_size
+    if padded_K != K:
+        raise ValueError(f"K={K} != padded_K={padded_K}")
+    x_rot = _rotate_input(x.float(), signs1, signs2, group_size)
+    output = torch.empty(M, N, dtype=x.dtype, device=x.device)
+    BLOCK_K = group_size
+
+    def _grid(META):
+        return (
+            triton.cdiv(M, META["BLOCK_M"]),
+            triton.cdiv(N, META["BLOCK_N"]),
+        )
+
+    _polar_fused_gemm_kernel[_grid](
+        x_rot,
+        x_rot.stride(0),
+        x_rot.stride(1),
+        packed_weight,
+        packed_weight.stride(0),
+        packed_weight.stride(1),
+        norms,
+        norms.stride(0),
+        norms.stride(1),
+        centroids,
+        output,
+        output.stride(0),
+        output.stride(1),
+        bias,
+        M,
+        N,
+        padded_K,
+        n_groups,
+        BLOCK_K=BLOCK_K,
+        BITS=bits,
+    )
+    if len(orig_shape) > 2:
+        output = output.reshape(*orig_shape[:-1], N)
+    return output
+
+
+# Register as torch.library.custom_op for fullgraph compatibility.
+# Dynamo treats custom ops as opaque (no tracing into kernel body).
+try:
+
+    @torch.library.custom_op(
+        "turboquant::tq_fused_gemm",
+        mutates_args=(),
+        device_types=("cuda",),
+    )
+    def _tq_fused_gemm_op(
+        x: torch.Tensor,
+        packed_weight: torch.Tensor,
+        norms: torch.Tensor,
+        signs1: torch.Tensor,
+        signs2: torch.Tensor,
+        centroids: torch.Tensor,
+        group_size: int,
+        bits: int,
+        bias: torch.Tensor | None,
+    ) -> torch.Tensor:
+        return _tq_fused_gemm_launcher(
+            x,
+            packed_weight,
+            norms,
+            signs1,
+            signs2,
+            centroids,
+            group_size=group_size,
+            bits=bits,
+            bias=bias,
+        )
+
+    @_tq_fused_gemm_op.register_fake
+    def _(
+        x,
+        packed_weight,
+        norms,
+        signs1,
+        signs2,
+        centroids,
+        group_size,
+        bits,
+        bias,
+    ):
+        N = norms.shape[0]
+        return x.new_empty((*x.shape[:-1], N))
+
+    @torch.library.custom_op(
+        "turboquant::tq_fwht_input_gemm",
+        mutates_args=(),
+        device_types=("cuda",),
+    )
+    def _tq_fwht_input_gemm_op(
+        x: torch.Tensor,
+        packed_weight: torch.Tensor,
+        norms: torch.Tensor,
+        signs1: torch.Tensor,
+        signs2: torch.Tensor,
+        centroids: torch.Tensor,
+        group_size: int,
+        bits: int,
+        bias: torch.Tensor | None,
+    ) -> torch.Tensor:
+        return _tq_fwht_input_gemm_launcher(
+            x,
+            packed_weight,
+            norms,
+            signs1,
+            signs2,
+            centroids,
+            group_size=group_size,
+            bits=bits,
+            bias=bias,
+        )
+
+    @_tq_fwht_input_gemm_op.register_fake
+    def _(
+        x,
+        packed_weight,
+        norms,
+        signs1,
+        signs2,
+        centroids,
+        group_size,
+        bits,
+        bias,
+    ):
+        N = norms.shape[0]
+        return x.new_empty((*x.shape[:-1], N))
+
+    def tq_fused_gemm(
+        x,
+        packed_weight,
+        norms,
+        signs1,
+        signs2,
+        centroids,
+        group_size=128,
+        bits=4,
+        bias=None,
+    ):
+        return torch.ops.turboquant.tq_fused_gemm(
+            x,
+            packed_weight,
+            norms,
+            signs1,
+            signs2,
+            centroids,
+            group_size,
+            bits,
+            bias,
+        )
+
+    def tq_fwht_input_gemm(
+        x,
+        packed_weight,
+        norms,
+        signs1,
+        signs2,
+        centroids,
+        group_size=128,
+        bits=4,
+        bias=None,
+    ):
+        return torch.ops.turboquant.tq_fwht_input_gemm(
+            x,
+            packed_weight,
+            norms,
+            signs1,
+            signs2,
+            centroids,
+            group_size,
+            bits,
+            bias,
+        )
+except (AttributeError, RuntimeError, NameError):
+    # Triton not available — tq_fused_gemm / tq_fwht_input_gemm undefined
+    tq_fused_gemm = None  # type: ignore[assignment]
+    tq_fwht_input_gemm = None  # type: ignore[assignment]
+
+
+# ---------------------------------------------------------------------------
+# TurboQuantOnlineLinearMethod
+# ---------------------------------------------------------------------------
+
+
+class _TurboQuantOnlineLinearMethodBase(LinearMethodBase):
+    """Shared algorithm core for TurboQuant W2/W3/W4 online weight quant.
+
+    Concrete subclasses set ``BITS``; group size is fixed at 128 (the
+    block-128 codebook is the only one validated end-to-end). Allocates
+    bf16 weight on meta device (zero GPU at init); after weight loading
+    materializes the bf16 on GPU, compresses to TQ packed format. The
+    forward pass uses Triton dequant-GEMM kernels with a PyTorch fallback.
+    """
+
+    BITS: int  # set by concrete subclasses
+    GROUP_SIZE: int = 128
+
+    uses_meta_device: bool = True
+
+    def __init__(self) -> None:
+        if self.BITS not in (2, 3, 4):
+            raise ValueError(
+                f"turboquant BITS must be 2, 3, or 4; got {self.BITS!r} "
+                f"on {type(self).__name__}"
+            )
+        if self.GROUP_SIZE <= 0 or self.GROUP_SIZE % 8 != 0:
+            raise ValueError(
+                "turboquant GROUP_SIZE must be a positive multiple of 8; "
+                f"got {self.GROUP_SIZE!r} on {type(self).__name__}"
+            )
+
+    def create_weights(
+        self,
+        layer: nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes: list[int],
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs: Any,
+    ) -> None:
+        output_size_per_partition = sum(output_partition_sizes)
+        weight_loader = extra_weight_attrs.get("weight_loader")
+
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition,
+                device="meta",
+                dtype=params_dtype,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight", weight)
+        initialize_online_processing(layer)
+
+    def process_weights_after_loading(self, layer: nn.Module) -> None:
+        if getattr(layer, "_already_called_process_weights_after_loading", False):
+            return
+
+        weight = layer.weight.data
+        bits = self.BITS
+        group_size = self.GROUP_SIZE
+
+        out_dim, in_dim = weight.shape
+        padded_in, n_groups = _padded_size(in_dim, group_size)
+
+        if padded_in > in_dim:
+            padded = torch.zeros(
+                out_dim, padded_in, dtype=weight.dtype, device=weight.device
+            )
+            padded[:, :in_dim] = weight
+        else:
+            padded = weight
+
+        grouped = padded.reshape(-1, group_size)
+        quantizer = _get_quantizer(group_size, bits, str(weight.device))
+        indices, norms_raw = quantizer.quantize(grouped)
+        packed = _pack_indices(indices, bits)
+        norms = norms_raw.reshape(out_dim, n_groups)
+
+        # Keep weight attr present for vLLM's MLA post-processing
+        # (which expects layer.weight to exist).
+        layer.weight.data = torch.empty(0, device=weight.device, dtype=weight.dtype)
+        layer.register_buffer("tq_packed_weight", packed)
+        layer.register_buffer("tq_norms", norms)
+        layer.register_buffer("tq_signs1", quantizer.signs1)
+        layer.register_buffer("tq_signs2", quantizer.signs2)
+        layer.register_buffer("tq_centroids", quantizer.centroids)
+        layer.tq_in_features = in_dim
+        layer.tq_out_features = out_dim
+        layer.tq_padded_in = padded_in
+
+        if tq_fused_gemm is not None:
+            layer._tq_primary_fn = (
+                tq_fwht_input_gemm if out_dim >= 4096 else tq_fused_gemm
+            )
+            layer._tq_fallback_fn = (
+                tq_fused_gemm if out_dim >= 4096 else tq_fwht_input_gemm
+            )
+        else:
+            layer._tq_primary_fn = None
+
+        layer._already_called_process_weights_after_loading = True
+        del weight, padded, grouped, indices, norms_raw
+
+    def apply(
+        self,
+        layer: nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        # Pad input if in_dim was not a multiple of group_size
+        if x.shape[-1] != layer.tq_padded_in:
+            x = torch.nn.functional.pad(x, (0, layer.tq_padded_in - x.shape[-1]))
+
+        if layer._tq_primary_fn is not None:
+            args = (
+                x,
+                layer.tq_packed_weight,
+                layer.tq_norms,
+                layer.tq_signs1,
+                layer.tq_signs2,
+                layer.tq_centroids,
+            )
+            try:
+                return layer._tq_primary_fn(
+                    *args, group_size=self.GROUP_SIZE, bits=self.BITS, bias=bias
+                )
+            except (ValueError, RuntimeError) as e:
+                logger.warning_once(
+                    "TurboQuant primary kernel failed, using fallback: %s", e
+                )
+                return layer._tq_fallback_fn(
+                    *args, group_size=self.GROUP_SIZE, bits=self.BITS, bias=bias
+                )
+
+        # PyTorch fallback (no Triton)
+        indices = _unpack_indices(layer.tq_packed_weight, self.BITS, self.GROUP_SIZE)
+        norms_flat = layer.tq_norms.reshape(-1)
+        quantizer = _get_quantizer(self.GROUP_SIZE, self.BITS, str(x.device))
+        w_groups = quantizer.dequantize(indices, norms_flat)
+        w_deq = w_groups.reshape(layer.tq_out_features, layer.tq_padded_in).to(x.dtype)
+        output = torch.matmul(x, w_deq.t())
+        if bias is not None:
+            output = output + bias
+        return output
+
+
+class TurboQuantW2OnlineLinearMethod(_TurboQuantOnlineLinearMethodBase):
+    """TurboQuant 2-bit (TQ2). Aggressive compression; quality-sensitive."""
+
+    BITS = 2
+
+
+class TurboQuantW3OnlineLinearMethod(_TurboQuantOnlineLinearMethodBase):
+    """TurboQuant 3-bit (TQ3). Default; near-FP16 quality on most models."""
+
+    BITS = 3
+
+
+class TurboQuantW4OnlineLinearMethod(_TurboQuantOnlineLinearMethodBase):
+    """TurboQuant 4-bit (TQ4). Conservative; matches FP16 quality."""
+
+    BITS = 4

--- a/vllm/model_executor/layers/quantization/online/turboquant.py
+++ b/vllm/model_executor/layers/quantization/online/turboquant.py
@@ -708,8 +708,12 @@ def _tq_fwht_input_gemm_launcher(
 
 
 # Register as torch.library.custom_op for fullgraph compatibility.
-# Dynamo treats custom ops as opaque (no tracing into kernel body).
-try:
+# Dynamo treats custom ops as opaque (no tracing into kernel body). Gated
+# on _HAS_TRITON because the registered ops dispatch into launchers that
+# call `triton.cdiv`/`triton.next_power_of_2` at call time; without
+# Triton, leaving them bound would crash with NameError on the first
+# forward and bypass the PyTorch fallback path below.
+if _HAS_TRITON:
 
     @torch.library.custom_op(
         "turboquant::tq_fused_gemm",
@@ -842,8 +846,8 @@ try:
             bits,
             bias,
         )
-except (AttributeError, RuntimeError, NameError):
-    # Triton not available — tq_fused_gemm / tq_fwht_input_gemm undefined
+else:
+    # Triton missing — the PyTorch fallback in apply() handles it.
     tq_fused_gemm = None  # type: ignore[assignment]
     tq_fwht_input_gemm = None  # type: ignore[assignment]
 
@@ -988,8 +992,11 @@ class _TurboQuantOnlineLinearMethodBase(LinearMethodBase):
                     *args, group_size=self.GROUP_SIZE, bits=self.BITS, bias=bias
                 )
 
-        # PyTorch fallback (no Triton)
-        indices = _unpack_indices(layer.tq_packed_weight, self.BITS, self.GROUP_SIZE)
+        # PyTorch fallback (no Triton). Unpack the full padded width
+        # (out_features × padded_in indices), then reshape into per-group
+        # rows for the Lloyd-Max dequant before the matmul.
+        indices = _unpack_indices(layer.tq_packed_weight, self.BITS, layer.tq_padded_in)
+        indices = indices.reshape(-1, self.GROUP_SIZE)
         norms_flat = layer.tq_norms.reshape(-1)
         quantizer = _get_quantizer(self.GROUP_SIZE, self.BITS, str(x.device))
         w_groups = quantizer.dequantize(indices, norms_flat)

--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -178,6 +178,20 @@ kInt4Static = QuantKey(INT4_DTYPE, scale=kInt4StaticGroupScale, symmetric=True)
 kInt8StaticGroupScale = ScaleDesc(torch.float16, True, GroupShape(1, -1))
 kInt8Static = QuantKey(INT8_DTYPE, scale=kInt8StaticGroupScale, symmetric=True)
 
+# TurboQuant: WHT rotation + Lloyd-Max codebook. Per-group bf16 norm scale.
+# Three bit-widths; one QuantKey each so the online dispatch table picks the
+# right method class. Group size 128 is the only validated codebook today.
+kTurboquantGroupNormScale = ScaleDesc(torch.bfloat16, False, GroupShape(1, 128))
+kTurboquantW2 = QuantKey(
+    scalar_types.uint2b2, scale=kTurboquantGroupNormScale, symmetric=True
+)
+kTurboquantW3 = QuantKey(
+    scalar_types.uint3b4, scale=kTurboquantGroupNormScale, symmetric=True
+)
+kTurboquantW4 = QuantKey(
+    scalar_types.uint4b8, scale=kTurboquantGroupNormScale, symmetric=True
+)
+
 kInt4Static32GroupScale = ScaleDesc(torch.float16, True, GroupShape(1, 32))
 kInt4Static32 = QuantKey(INT4_DTYPE, scale=kInt4Static32GroupScale, symmetric=True)
 


### PR DESCRIPTION
## Purpose

Adds an online weight-only quantization scheme for Linear layers. Follows the pattern established in #38138 — a new enum value on `OnlineQuantScheme`, a matching `LinearMethodBase` implementation, wired into `OnlineQuantizationConfig.get_quant_method`.

The technique implemented is the **scalar case of HIGGS** (Malinovskii et al., *Pushing the Limits of Large Language Model Quantization via the Linearity Theorem*, [NAACL 2025](https://aclanthology.org/2025.naacl-long.543/); preprint [arXiv:2411.17525](https://arxiv.org/abs/2411.17525)): Random Hadamard Transform + MSE-optimal Lloyd–Max grid + per-group normalization. ~4x compression at 3 bits with **zero calibration data**. A reference implementation also exists in [HF transformers](https://github.com/huggingface/transformers/blob/main/docs/source/en/quantization/higgs.md).

1. **Walsh–Hadamard randomized rotation** projects weight groups so each coordinate is approximately `N(0, 1/d)`
2. **Lloyd–Max optimal scalar quantization** at 2/3/4 bits into a small shared codebook
3. **Per-group shape-gain decomposition** (classical VQ technique, Gray 1984) — store `original_norm / reconstruction_norm` rather than raw L2; halves error at 3 bits in practice

The implementation was originally based on TurboQuant ([Zandieh et al., ICLR 2026, arXiv:2504.19874](https://arxiv.org/abs/2504.19874)), which is actually an online vector quantizer for **KV-cache and ANN vector search**, not weights. Engineering simplifications (scalar over vector, WHT over general random rotations, Lloyd-Max over learned grids) converged the weight path onto the HIGGS scalar algorithm. The KV-cache application of TurboQuant is implemented separately in #38479 by @vibhavagarwal5. The `turboquant` API name is kept here for plugin-package compatibility; HIGGS is the correct primary citation for this PR. Thanks to @dalistarh for the attribution catches.

**Scope: Linear layers only.** MoE dispatch explicitly falls back to `UnquantizedFusedMoEMethod` with a comment — MoE compression needs per-expert scratch pool management and is deferred to a follow-up. The `OnlineQuantScheme.TURBOQUANT` enum value makes the extension point obvious.

**Usage:**

```bash
vllm serve <model> --quantization turboquant
```

Or via the Python API:

```python
from vllm import LLM
llm = LLM(model="...", quantization="turboquant")
```

**Key implementation points:**
- **Meta-device init** — bf16 weights never materialize on GPU; compression runs in `process_weights_after_loading` per-layer immediately after load.
- **Two Triton kernels** registered as `torch.library.custom_op` with `register_fake` for fullgraph / `torch.compile` compat:
  - **Fused dequant-GEMM** for small output dims (loads rotation matrix into shared memory, fuses unpack+rotate+matmul)
  - **FWHT-on-input GEMM** for larger output dims (rotates activation once on host, avoids N inverse rotations)
- **BF16 tensor cores** — main GEMM casts inputs to the output dtype before `tl.dot`; accumulator stays FP32 for precision.
- **Robustness** — handles zero-token batches (`M=0` chunked prefill), non-aligned hidden dims (auto-padding), shared memory caps (Ada/Hopper safe), PyTorch fallback when Triton unavailable.

## Test Plan

```bash
pytest tests/quantization/test_turboquant_online.py -v
```

33 CPU-only tests covering the known hard parts:
- 3-bit packing cross-byte boundaries (positions 2 and 5 span bytes)
- WHT rotation invariants (orthogonality, involution)
- Padding logic for irregular tensor dimensions
- PolarQuant norm correction round-trip error bounds
- `process_weights_after_loading` idempotency (double-call guard)
- Weight kept as `empty(0)` for MLA compatibility
- `M=0` zero-token batch early exit
- Cosine similarity validation (>0.85 for TQ3, >0.92 for TQ4)

Integration validated end-to-end on **RTX 6000 Ada 48GB (sm_89)** with Qwen2.5-0.5B:

```bash
vllm serve Qwen/Qwen2.5-0.5B --quantization turboquant --enforce-eager
```

— model loads, compresses, and serves coherent output via `/v1/chat/completions`.

Both Triton kernels verified against a PyTorch dequant-then-matmul reference:

| Kernel | Dim | cosine_sim vs reference |
|---|---|---|
| Fused dequant-GEMM | 64 | **1.0000** |
| FWHT-on-input GEMM | 4096 | **1.0000** |

## Test Result

```
============================= test session starts ==============================
platform darwin -- Python 3.13.7, pytest-9.0.2
collected 33 items

tests/quantization/test_turboquant_online.py ..............................
============================== 33 passed in 8.94s ==============================
```

Hardware coverage: Ampere (A100), Ada (L40S / RTX 6000 Ada), Hopper (H100/H200). Minimum compute capability 8.0 — BF16 Tensor Cores were introduced in Ampere; Turing's 2nd-gen Tensor Cores only support FP16, so Turing is not supported for BF16 models. Documented in `docs/features/quantization/turboquant.md` and the hardware support table.

## Related

- Builds on #38138 (online quantization frontend by @vkuzo)
- Complements @vibhavagarwal5's KV-cache variant in #38479
- Primary algorithm reference: **HIGGS** — Malinovskii et al., *Pushing the Limits of LLM Quantization via the Linearity Theorem*, [NAACL 2025](https://aclanthology.org/2025.naacl-long.543/) (preprint [arXiv:2411.17525](https://arxiv.org/abs/2411.17525)); reference implementation in [HF transformers](https://github.com/huggingface/transformers/blob/main/docs/source/en/quantization/higgs.md)
- Original framework that this work simplified from: **TurboQuant** — [Zandieh et al., ICLR 2026, arXiv:2504.19874](https://arxiv.org/abs/2504.19874) (online vector quantizer for KV-cache + ANN; the KV-cache application is in @vibhavagarwal5's #38479)

## Follow-ups (explicitly out of scope)

- MoE compression (per-expert packed format, shared scratch pool) — tracked separately
- Parametrized integration test in `tests/quantization/test_online.py`
- Autotune configs for the fused dequant-GEMM kernel (currently heuristic on `group_size`)
- Per-scheme `get_min_capability` on `OnlineQuantizationConfig` (currently all schemes share the `75` floor; TurboQuant actually needs 80)
- Shared host-side turboquant math module — `pack/unpack`, `fast_wht_batch`, and `PolarQuant` pipeline currently live here; converge with the KV-cache turboquant module once bit layouts harmonize (see thread w/ @vibhavagarwal5)

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR
- [x] The test plan
- [x] The test results
- [x] Documentation updated (`docs/features/quantization/turboquant.md` + hardware table)
- [ ] (Optional) Release notes — will update if reviewers request

</details>
