### PR TITLE
[Fix] Resolve docker build-time LegacyKeyValueFormat warnings

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -735,10 +735,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system -e tests/vllm_test_utils
 
 # enable fast downloads from hf (for testing)
-ENV HF_XET_HIGH_PERFORMANCE 1
+ENV HF_XET_HIGH_PERFORMANCE=1
 
 # increase timeout for hf downloads (for testing)
-ENV HF_HUB_DOWNLOAD_TIMEOUT 60
+ENV HF_HUB_DOWNLOAD_TIMEOUT=60
 
 # Copy in the v1 package for testing (it isn't distributed yet)
 COPY vllm/v1 /usr/local/lib/python${PYTHON_VERSION}/dist-packages/vllm/v1
@@ -791,7 +791,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         ); \
     fi
 
-ENV VLLM_USAGE_SOURCE production-docker-image
+ENV VLLM_USAGE_SOURCE=production-docker-image
 
 # define sagemaker first, so it is not default from `docker build`
 FROM vllm-openai-base AS vllm-sagemaker

--- a/docker/Dockerfile.cpu
+++ b/docker/Dockerfile.cpu
@@ -199,10 +199,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install -e tests/vllm_test_utils
 
 # enable fast downloads from hf (for testing)
-ENV HF_XET_HIGH_PERFORMANCE 1
+ENV HF_XET_HIGH_PERFORMANCE=1
 
 # increase timeout for hf downloads (for testing)
-ENV HF_HUB_DOWNLOAD_TIMEOUT 60
+ENV HF_HUB_DOWNLOAD_TIMEOUT=60
 
 ######################### RELEASE IMAGE #########################
 FROM base AS vllm-openai

--- a/docker/Dockerfile.nightly_torch
+++ b/docker/Dockerfile.nightly_torch
@@ -269,10 +269,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system -e tests/vllm_test_utils
 
 # enable fast downloads from hf (for testing)
-ENV HF_XET_HIGH_PERFORMANCE 1
+ENV HF_XET_HIGH_PERFORMANCE=1
 
 # increase timeout for hf downloads (for testing)
-ENV HF_HUB_DOWNLOAD_TIMEOUT 60
+ENV HF_HUB_DOWNLOAD_TIMEOUT=60
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system -r requirements/test/nightly-torch.txt

--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -389,7 +389,7 @@ RUN cd /vllm-workspace \
 ENV HF_XET_HIGH_PERFORMANCE=1
 
 # increase timeout for hf downloads (for testing)
-ENV HF_HUB_DOWNLOAD_TIMEOUT 60
+ENV HF_HUB_DOWNLOAD_TIMEOUT=60
 
 # install audio decode package `torchcodec` from source (required due to 
 # ROCm and torch version mismatch) for tests with datasets package


### PR DESCRIPTION


## Purpose

Fix build-time docker env var format warnings:

```
 - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 794)
```

`ENV KEY=value` is supported since Docker 1.4.0 (2014) so backwards compatibility is not a concern.

## Test Plan

Images built and confirmed working in a testbed setup.
