### PR TITLE
[Tests][Transformers v5] Skip InternVL2 HF-runner tests incompatible with meta device init

### DIFF
--- a/tests/models/multimodal/generation/test_common.py
+++ b/tests/models/multimodal/generation/test_common.py
@@ -533,6 +533,15 @@ VLM_TEST_SETTINGS = {
         max_model_len=4096,
         use_tokenizer_eos=True,
         patch_hf_runner=model_utils.internvl_patch_hf_runner,
+        marks=[
+            pytest.mark.skipif(
+                Version(TRANSFORMERS_VERSION) >= Version("5.0.0"),
+                reason="InternVL2 custom code calls Tensor.item() during model "
+                "init, which is incompatible with Transformers v5 meta device "
+                "initialization. The fix requires upstreaming the model to "
+                "Transformers. See: https://github.com/vllm-project/vllm/issues/38425",
+            )
+        ],
     ),
     "intern_vl-video": VLMTestInfo(
         models=[
@@ -959,6 +968,15 @@ VLM_TEST_SETTINGS = {
                 limit_mm_per_prompt={"image": 2},
             )
             for inp in custom_inputs.different_patch_input_cases_internvl()
+        ],
+        marks=[
+            pytest.mark.skipif(
+                Version(TRANSFORMERS_VERSION) >= Version("5.0.0"),
+                reason="InternVL2 custom code calls Tensor.item() during model "
+                "init, which is incompatible with Transformers v5 meta device "
+                "initialization. The fix requires upstreaming the model to "
+                "Transformers. See: https://github.com/vllm-project/vllm/issues/38425",
+            )
         ],
     ),
     "llava_onevision-multiple-images": VLMTestInfo(


### PR DESCRIPTION
## Summary

- Adds `pytest.mark.skipif` marks to the `intern_vl` and `intern_vl-diff-patches` `VLMTestInfo` entries in `tests/models/multimodal/generation/test_common.py`
- These tests are skipped when `transformers >= 5.0.0` is installed, since `OpenGVLab/InternVL2-1B` and `OpenGVLab/InternVL2-2B` custom code calls `Tensor.item()` during model initialization
- This is incompatible with Transformers v5's meta device initialization pattern, causing `RuntimeError: Tensor.item() cannot be called on meta tensors`

Fixes #38425

## Why this is not a duplicate

No existing open PRs address #38425. Checked with:
```
gh pr list --repo vllm-project/vllm --state open --search "38425 in:body"
```

## Root cause

Transformers v5 initializes models on the meta device first, then loads weights. The InternVL2 custom code (HuggingFace Hub, `trust_remote_code=True`) calls `Tensor.item()` during `__init__`, which is not permitted on meta tensors. This only affects the HF reference runner used for comparison — vLLM's own `InternVLChatModel` is unaffected.

## Long-term fix

The proper solution is to upstream InternVL2 to Transformers using Modular Transformers (reusing the Qwen2 text backbone), as described in the issue. This PR provides the necessary short-term workaround.

## Test plan

- [x] `ruff check tests/models/multimodal/generation/test_common.py` — passes
- [ ] `pytest tests/models/multimodal/generation/test_common.py -k "intern_vl-"` — requires GPU; skipped locally

**Note:** These tests only need to be verified as *skipped* with `transformers>=5.0.0` and *passing* with `transformers<5.0.0`.

## AI assistance

This PR was developed with Claude Code assistance. All changed lines were reviewed by the submitter.