### PR TITLE
[ROCm] Fuse Q/K RMSNorm in MLA attention via AITER `fused_qk_rmsnorm`

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -622,6 +622,30 @@ def _rocm_aiter_rms_norm_fake(
     return torch.empty_like(x)
 
 
+def _rocm_aiter_fused_qk_rmsnorm_impl(
+    q: torch.Tensor,
+    q_weight: torch.Tensor,
+    q_eps: float,
+    k: torch.Tensor,
+    k_weight: torch.Tensor,
+    k_eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from aiter import fused_qk_rmsnorm
+
+    return fused_qk_rmsnorm(q, q_weight, q_eps, k, k_weight, k_eps)
+
+
+def _rocm_aiter_fused_qk_rmsnorm_fake(
+    q: torch.Tensor,
+    q_weight: torch.Tensor,
+    q_eps: float,
+    k: torch.Tensor,
+    k_weight: torch.Tensor,
+    k_eps: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return torch.empty_like(q), torch.empty_like(k)
+
+
 def _rocm_aiter_rmsnorm2d_fwd_with_add_impl(
     x: torch.Tensor,
     residual: torch.Tensor,
@@ -1396,6 +1420,12 @@ class rocm_aiter_ops:
             )
 
             direct_register_custom_op(
+                op_name="rocm_aiter_fused_qk_rmsnorm",
+                op_func=_rocm_aiter_fused_qk_rmsnorm_impl,
+                fake_impl=_rocm_aiter_fused_qk_rmsnorm_fake,
+            )
+
+            direct_register_custom_op(
                 op_name="rocm_aiter_rmsnorm2d_fwd_with_add",
                 op_func=_rocm_aiter_rmsnorm2d_fwd_with_add_impl,
                 fake_impl=_rocm_aiter_rmsnorm2d_fwd_with_add_fake,
@@ -1547,6 +1577,19 @@ class rocm_aiter_ops:
     ) -> tuple[torch.Tensor, torch.Tensor]:
         return torch.ops.vllm.rocm_aiter_rmsnorm2d_fwd_with_add(
             x, residual, weight, variance_epsilon
+        )
+
+    @staticmethod
+    def fused_qk_rmsnorm(
+        q: torch.Tensor,
+        q_weight: torch.Tensor,
+        q_eps: float,
+        k: torch.Tensor,
+        k_weight: torch.Tensor,
+        k_eps: float,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        return torch.ops.vllm.rocm_aiter_fused_qk_rmsnorm(
+            q, q_weight, q_eps, k, k_weight, k_eps
         )
 
     @staticmethod

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 import torch
 
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import CacheConfig
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.attention import MLAAttention
@@ -109,6 +110,10 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
         )
 
         self.prefix = prefix
+        self._use_fused_qk_rmsnorm = (
+            self.q_lora_rank is not None
+            and rocm_aiter_ops.is_rmsnorm_enabled()
+        )
 
     def forward(
         self,
@@ -135,7 +140,21 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
                 [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
                 dim=-1,
             )
-            q_c = self.q_a_layernorm(q_c)
+            kv_c, k_pe = kv_lora.split(
+                [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+            )
+            if self._use_fused_qk_rmsnorm:
+                q_c, kv_c_normed = rocm_aiter_ops.fused_qk_rmsnorm(
+                    q_c,
+                    self.q_a_layernorm.weight,
+                    self.q_a_layernorm.variance_epsilon,
+                    kv_c,
+                    self.kv_a_layernorm.weight,
+                    self.kv_a_layernorm.variance_epsilon,
+                )
+            else:
+                q_c = self.q_a_layernorm(q_c)
+                kv_c_normed = self.kv_a_layernorm(kv_c)
             q = self.q_b_proj(q_c)[0]
         else:
             assert self.kv_a_proj_with_mqa is not None, (
@@ -146,9 +165,10 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
             )
             kv_lora = self.kv_a_proj_with_mqa(hidden_states)[0]
             q = self.q_proj(hidden_states)[0]
-
-        kv_c, k_pe = kv_lora.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
-        kv_c_normed = self.kv_a_layernorm(kv_c)
+            kv_c, k_pe = kv_lora.split(
+                [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+            )
+            kv_c_normed = self.kv_a_layernorm(kv_c)
 
         q = q.view(-1, self.num_heads, self.qk_head_dim)
         # Add head dim of 1 to k_pe


### PR DESCRIPTION
## Summary

Fuse the two separate RMSNorm kernel launches (`q_a_layernorm` and `kv_a_layernorm`) in Multi-head Latent Attention (MLA) into a single AITER `fused_qk_rmsnorm` kernel on ROCm. This eliminates one GPU kernel launch per transformer layer per decode step for DeepSeek V2/V3/Kimi models.

## Motivation

During decode on MI3XX with DeepSeek V3 / Kimi-K2.5-MXFP4, the MLA attention block performs two consecutive RMSNorm operations on the compressed latent tensors:

1. `q_a_layernorm(q_c)` -- normalizes the compressed query latent (dim=512)
2. `kv_a_layernorm(kv_c)` -- normalizes the compressed key-value latent (dim=1536)

Each is a separate GPU kernel launch. At decode time, where per-kernel compute is ~4-5us but kernel launch overhead is significant, eliminating launches directly improves latency.

AITER provides a `fused_qk_rmsnorm` kernel that fuses both operations into a single launch using a 2D grid where `blockIdx.y` selects the Q (y=0) or K (y=1) normalization path, running both in parallel across different CUs.

**Impact**: Eliminates 1 kernel launch per layer per step. With 61 layers in DeepSeek V3, this saves 61 kernel launches per decode step.


## Design decisions

- **Model-level change, not a fusion pass**: The existing `QKNormRoPEFusionPass` targets a different pattern (standard QKV per-head norm + RoPE). The MLA pattern has different tensor shapes (latent-space norms on dims 512 and 1536, not per-head norms) and the two norms are separated from RoPE by a GEMM (`q_b_proj`). A direct model-level change in `mla.py` is more reliable than a graph pattern match.
- **Guarded behind AITER availability**: The fused path only activates when all conditions are met: ROCm platform, AITER installed, AITER rmsnorm enabled via env var. All other platforms and configurations use the existing two-norm path with zero behavioral change.
- **AITER's built-in fallback**: The AITER `fused_qk_rmsnorm` function automatically falls back to two separate `rmsnorm2d_fwd` calls when `num_tokens >= 16384` (large prefill), since at that batch size the separate kernels already have sufficient CU occupancy.

## Kernel timeline (per layer)

**Before:**

<img width="1157" height="148" alt="2_rmsnorm" src="https://github.com/user-attachments/assets/c1f2f291-179b-441a-abdd-02c909eba3d0" />

**After:**

<img width="1157" height="206" alt="fused_rmsnorm" src="https://github.com/user-attachments/assets/bf681262-da46-483a-a7fe-ad3d2e7b2365" />


## Test results

Tested on MI355X with Kimi-K2.5-MXFP4:

Accuracy with the fused kernel (``VLLM_ROCM_USE_AITER=1` & `VLLM_ROCM_USE_AITER_RMSNORM=1`)

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.928|±  |0.0071|
|     |       |strict-match    |     5|exact_match|↑  |0.928|±  |0.0071|

Accuracy with the unfused kernel (``VLLM_ROCM_USE_AITER=1` & `VLLM_ROCM_USE_AITER_RMSNORM=0`)

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9242|±  |0.0073|
|     |       |strict-match    |     5|exact_match|↑  |0.9212|±  |0.0074|

The fused kernel is numerically equivalent to the two separate RMSNorm calls.


## Test plan

- [x] **Correctness -- fused vs fallback:** Compared accuracy between the fused path and the fallback path (`VLLM_ROCM_USE_AITER_RMSNORM=0`) on MI355X with Kimi-K2.5-MXFP4. Both produce 0.93 accuracy.
- [x] **Kernel presence (ROCm):** Verify `fused_qk_rmsnorm_kernel` appears in the Perfetto trace, replacing the two separate `Rmsnorm2dFwd` kernels.
