### PR TITLE
[Bugfix] Fix LLM priority normalization for single-string prompts

### DIFF
--- a/tests/entrypoints/llm/test_generate.py
+++ b/tests/entrypoints/llm/test_generate.py
@@ -91,6 +91,12 @@ def test_multiple_priority(llm: LLM):
         outputs = llm.generate(PROMPTS, sampling_params=None, priority=[])
 
 
+def test_single_prompt_priority(llm: LLM):
+    # Single string prompts should be normalized to one request.
+    outputs = llm.generate(PROMPTS[0], sampling_params=None, priority=[0])
+    assert len(outputs) == 1
+
+
 def test_max_model_len():
     max_model_len = 20
     llm = LLM(

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -1575,7 +1575,7 @@ class LLM:
         seq_prompts = prompt_to_seq(prompts)
         seq_params = self._params_to_seq(params, len(seq_prompts))
         seq_lora_requests = self._lora_request_to_seq(lora_request, len(seq_prompts))
-        seq_priority = self._priority_to_seq(priority, len(prompts))
+        seq_priority = self._priority_to_seq(priority, len(seq_prompts))
 
         return self._render_and_add_requests(
             prompts=(


### PR DESCRIPTION



## Purpose
Fix priority normalization for single-string prompts in `LLM.generate`.

Previously, priority normalization used the length of the original `prompts` input. When `prompts` is a plain string, `len(prompts)` counts characters instead of generation requests. As a result, a valid priority list such as `priority=[0]` for a single prompt could be incorrectly rejected.

This PR updates priority normalization to use `len(seq_prompts)`, where `seq_prompts` is the normalized prompt sequence. It also adds a regression test for:

`llm.generate(PROMPTS[0], sampling_params=None, priority=[0])`

## Test Plan


Run the targeted regression test:

```
pytest -q tests/entrypoints/llm/test_generate.py::test_single_prompt_priority
```
## Test Result
Local execution of the targeted GPU test was blocked by my server environment before reaching the changed logic.

I am relying on project CI to validate the targeted test in a supported environment.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

