### PR TITLE
[Bugfix] [ROCm] Add gfx12x FP8 support for fused_batched_moe kernels

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_batched_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_batched_moe.py
@@ -918,14 +918,18 @@ class BatchedTritonExperts(mk.FusedMoEExpertsModular):
     ) -> bool:
         p = current_platform
         if p.is_rocm():
-            from vllm.platforms.rocm import on_gfx9
+            from vllm.platforms.rocm import on_gfx9, on_gfx12x
 
             is_rocm_on_gfx9 = on_gfx9()
+            is_rocm_on_gfx12x = on_gfx12x()
         else:
             is_rocm_on_gfx9 = False
+            is_rocm_on_gfx12x = False
 
-        device_supports_fp8 = is_rocm_on_gfx9 or (
-            p.is_cuda() and p.has_device_capability((8, 9))
+        device_supports_fp8 = (
+            is_rocm_on_gfx9
+            or is_rocm_on_gfx12x
+            or (p.is_cuda() and p.has_device_capability((8, 9)))
         )
 
         SUPPORTED_W_A_FP8 = [


### PR DESCRIPTION
## Purpose
Fix NotImplementedError: No FP8 MoE backend supports the deployment configuration when running FP8 MoE models on AMD gfx12x GPUs.

TritonExperts._supports_quant_scheme() in fused_batched_moe.py (vllm/model_executor/layers/fused_moe/fused_batched_moe.py) didn't recognize gfx12x as FP8 capable, which it is.
When I tried to run Qwen/Qwen3-30B-A3B-Instruct-2507-FP8 model, i encountered the following error:
```bash
Before: NotImplementedError: No FP8 MoE backend supports the deployment configuration
```
This error was resolved by adding changes to vllm/model_executor/layers/fused_moe/fused_moe.py, and I noticed that same error occurs in fused_batched_moe.py file.

## Test Plan
Model Qwen/Qwen3-30B-A3B-Instruct-2507-FP8 was tested with original fix in vllm/model_executor/layers/fused_moe/fused_moe.py that is added now in vllm/model_executor/layers/fused_moe/fused_batched_moe.py

## Test Result
Model worked with fix included. No models triggered fused_batched_moe path, so it is not tested, but fix is very small and identical to fix in fused_moe.py

