### PR TITLE
Optimize LoRA index lookup from O(n) to O(1) in convert_mapping

### DIFF
--- a/vllm/lora/punica_wrapper/utils.py
+++ b/vllm/lora/punica_wrapper/utils.py
@@ -90,14 +90,19 @@ def convert_mapping(
     embedding_indices = index_mapping_indices.copy()
     lora_indices = index_mapping_indices.copy()
 
+    # Build a reverse lookup dict (id -> index) to replace O(n) list.index()
+    # calls with O(1) dict lookups.
+    lora_id_to_index: dict[int | None, int] = {
+        lora_id: idx for idx, lora_id in enumerate(lora_index_to_id)
+    }
+
     prompt_mapping: list[int] = [
-        lora_index_to_id.index(x) if x > 0 else -1 for x in mapping.prompt_mapping
+        lora_id_to_index[x] if x > 0 else -1 for x in mapping.prompt_mapping
     ]
     lora_idx = None
     for i in range(len(index_mapping_indices)):
-        # TODO index can be slow. optimize
         lora_idx = (
-            lora_index_to_id.index(index_mapping_indices[i])
+            lora_id_to_index[index_mapping_indices[i]]
             if index_mapping_indices[i] > 0
             else -1
         )


### PR DESCRIPTION
## Summary

- Replace `list.index()` calls with a pre-built reverse lookup dict in `convert_mapping()` (`vllm/lora/punica_wrapper/utils.py`)
- The original code used `lora_index_to_id.index(x)` which performs O(n) linear scan on every call
- Since this runs per-token in the batch (potentially thousands of tokens during prefill), this is unnecessary overhead
- Build a `lora_id_to_index` dict once (O(max_loras)) and use O(1) dict lookups instead
- Resolves the existing `# TODO index can be slow. optimize` comment

## Test plan

- [x] No change in semantics — `list.index()` returns first occurrence, which is equivalent to the dict since LoRA IDs are unique per slot
- [ ] Existing LoRA tests pass
- [ ] Verified with multi-LoRA serving workload