### PR TITLE
Optimize TPU token ID swap to copy only valid tokens

### DIFF
--- a/vllm/v1/worker/tpu_input_batch.py
+++ b/vllm/v1/worker/tpu_input_batch.py
@@ -376,10 +376,14 @@ class InputBatch:
         # self.token_ids_cpu[i1, ...], self.token_ids_cpu[i2, ...], =\
         #     self.token_ids_cpu[i2, ...], self.token_ids_cpu[i1, ...]
         # instead, we need to temporarily copy the data for one of the indices
-        # TODO(lucas): optimize this by only copying valid indices
-        tmp = self.token_ids_cpu[i1, ...].copy()
-        self.token_ids_cpu[i1, ...] = self.token_ids_cpu[i2, ...]
-        self.token_ids_cpu[i2, ...] = tmp
+        # Only swap the valid token region, not the full padded row.
+        i1_num_tokens = int(self.num_tokens_no_spec[i1])
+        i2_num_tokens = int(self.num_tokens_no_spec[i2])
+        max_num_tokens = max(i1_num_tokens, i2_num_tokens)
+
+        tmp = self.token_ids_cpu[i1, :max_num_tokens].copy()
+        self.token_ids_cpu[i1, :max_num_tokens] = self.token_ids_cpu[i2, :max_num_tokens]
+        self.token_ids_cpu[i2, :max_num_tokens] = tmp
 
         swap_dict_values(self.generators, i1, i2)
         swap_dict_values(self.min_tokens, i1, i2)


### PR DESCRIPTION
## Summary

- In `TPUInputBatch.swap_states()`, the token ID swap currently copies the entire padded row (`max_model_len` tokens) even though only a small fraction contains valid data
- Replace with partial copy using `num_tokens_no_spec` to determine the valid region
- For typical requests (~100 tokens with `max_model_len=4096`), this reduces per-swap memory copy by ~97%
- The GPU input batch (`gpu_input_batch.py`) already uses this optimization — this brings TPU in line

## Test plan

- [ ] Existing TPU tests pass
- [ ] Verified swap semantics are preserved (padding is never read by downstream ops)