### PR TITLE
Replace O(n log n) sort with O(n) direct indexing in ubatch result ordering

### DIFF
--- a/vllm/v1/worker/gpu_ubatch_wrapper.py
+++ b/vllm/v1/worker/gpu_ubatch_wrapper.py
@@ -265,8 +265,10 @@ class UBatchWrapper:
                 ubatch_metadata[0].context.cpu_wait_event.set()
                 for thread in ubatch_threads:
                     thread.join()
-                sorted_results = [value for position, value in sorted(results)]
-                result = torch.cat(sorted_results, dim=0)
+                sorted_results: list[torch.Tensor | None] = [None] * len(results)
+                for position, value in results:
+                    sorted_results[position] = value
+                result = torch.cat(sorted_results, dim=0)  # type: ignore[arg-type]
                 cudagraph_metadata.outputs = result
                 # Join offloader's copy stream after forward to avoid unjoined
                 # stream error. The last layer's start_prefetch forks copy_stream,
@@ -309,8 +311,10 @@ class UBatchWrapper:
             ubatch_metadata[0].context.cpu_wait_event.set()
             for thread in ubatch_threads:
                 thread.join()
-        sorted_results = [value for position, value in sorted(results)]
-        result = torch.cat(sorted_results, dim=0)
+        sorted_results: list[torch.Tensor | None] = [None] * len(results)
+        for position, value in results:
+            sorted_results[position] = value
+        result = torch.cat(sorted_results, dim=0)  # type: ignore[arg-type]
         return result
 
     def _make_ubatch_metadata(


### PR DESCRIPTION
## Summary

- In `_capture_cuda_graph()` (line ~268) and `_run_ubatches()` (line ~312), results from multithreaded ubatch execution are collected as `(position, value)` tuples and then sorted via `sorted()` to reconstruct the correct order.
- Since `position` is `UBatchContext.id`, which is assigned as `id=i` in a `range(num_micro_batches)` loop, positions are guaranteed to be consecutive 0-based integers.
- Replace the `O(n log n)` sorted list comprehension with `O(n)` direct index assignment into a pre-allocated list.

## Test plan

- [ ] Existing CI tests pass (no behavioral change — output order is identical)
- [ ] Verified that `UBatchContext.id` is always set to `i` from `range(num_micro_batches)` in `create_ubatch_contexts()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)