### PR TITLE
Use set instead of list for scheduled_running_reqs in scheduler

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -359,7 +359,7 @@ class Scheduler(SchedulerInterface):
 
         scheduled_new_reqs: list[Request] = []
         scheduled_resumed_reqs: list[Request] = []
-        scheduled_running_reqs: set[Request] = set()
+        scheduled_running_reqs: dict[Request, None] = {}
         preempted_reqs: list[Request] = []
 
         req_to_new_blocks: dict[str, KVCacheBlocks] = {}
@@ -480,7 +480,7 @@ class Scheduler(SchedulerInterface):
                         self.running.remove(preempted_req)
                         if preempted_req in scheduled_running_reqs:
                             preempted_req_id = preempted_req.request_id
-                            scheduled_running_reqs.discard(preempted_req)
+                            scheduled_running_reqs.pop(preempted_req, None)
                             token_budget += num_scheduled_tokens.pop(preempted_req_id)
                             req_to_new_blocks.pop(preempted_req_id)
                             scheduled_spec_decode_tokens.pop(preempted_req_id, None)
@@ -510,7 +510,7 @@ class Scheduler(SchedulerInterface):
                 break
 
             # Schedule the request.
-            scheduled_running_reqs.add(request)
+            scheduled_running_reqs[request] = None
             request_id = request.request_id
             req_to_new_blocks[request_id] = new_blocks
             num_scheduled_tokens[request_id] = num_new_tokens
@@ -1051,7 +1051,7 @@ class Scheduler(SchedulerInterface):
 
     def _make_cached_request_data(
         self,
-        running_reqs: set[Request],
+        running_reqs: dict[Request, None],
         resumed_reqs: list[Request],
         num_scheduled_tokens: dict[str, int],
         spec_decode_tokens: dict[str, list[int]],

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -359,7 +359,7 @@ class Scheduler(SchedulerInterface):
 
         scheduled_new_reqs: list[Request] = []
         scheduled_resumed_reqs: list[Request] = []
-        scheduled_running_reqs: list[Request] = []
+        scheduled_running_reqs: set[Request] = set()
         preempted_reqs: list[Request] = []
 
         req_to_new_blocks: dict[str, KVCacheBlocks] = {}
@@ -480,7 +480,7 @@ class Scheduler(SchedulerInterface):
                         self.running.remove(preempted_req)
                         if preempted_req in scheduled_running_reqs:
                             preempted_req_id = preempted_req.request_id
-                            scheduled_running_reqs.remove(preempted_req)
+                            scheduled_running_reqs.discard(preempted_req)
                             token_budget += num_scheduled_tokens.pop(preempted_req_id)
                             req_to_new_blocks.pop(preempted_req_id)
                             scheduled_spec_decode_tokens.pop(preempted_req_id, None)
@@ -510,7 +510,7 @@ class Scheduler(SchedulerInterface):
                 break
 
             # Schedule the request.
-            scheduled_running_reqs.append(request)
+            scheduled_running_reqs.add(request)
             request_id = request.request_id
             req_to_new_blocks[request_id] = new_blocks
             num_scheduled_tokens[request_id] = num_new_tokens
@@ -1051,7 +1051,7 @@ class Scheduler(SchedulerInterface):
 
     def _make_cached_request_data(
         self,
-        running_reqs: list[Request],
+        running_reqs: set[Request],
         resumed_reqs: list[Request],
         num_scheduled_tokens: dict[str, int],
         spec_decode_tokens: dict[str, list[int]],


### PR DESCRIPTION
## Summary

- Change `scheduled_running_reqs` from `list` to `set` in the scheduler's `schedule()` method
- This improves membership checks (`in`) and removals from O(n) to O(1)
- These operations occur during preemption logic, which can be called multiple times per scheduling step under memory pressure

## Why this is safe

- Order does not matter: downstream `prepare_inputs()` re-sorts by token count
- No indexing or slicing is performed on this collection
- `_make_cached_request_data` builds parallel structures keyed by `req_id`, not dependent on iteration order
- `Request` uses default object identity for hashing (no custom `__hash__`/`__eq__`)

## Test plan

- [ ] Existing scheduler tests pass
- [ ] Verified under memory pressure scenarios with preemption

🤖 Generated with [Claude Code](https://claude.com/claude-code)