### PR TITLE
Use b''.join() for block hash concatenation in KV cache utils

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1684,7 +1684,8 @@ class BlockHashListWithBlockSize:
     def _get_value_at(self, idx: int) -> BlockHash:
         base = idx * self.scale_factor
         end = base + self.scale_factor
-        merged_hash: bytes = b''.join(self.block_hashes[base:end])
+        merged_hash: bytes = b''.join(
+            self.block_hashes[i] for i in range(base, end))
         return BlockHash(merged_hash)
 
 

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1684,9 +1684,7 @@ class BlockHashListWithBlockSize:
     def _get_value_at(self, idx: int) -> BlockHash:
         base = idx * self.scale_factor
         end = base + self.scale_factor
-        merged_hash: bytes = self.block_hashes[base]
-        for i in range(base + 1, end):
-            merged_hash += self.block_hashes[i]
+        merged_hash: bytes = b''.join(self.block_hashes[base:end])
         return BlockHash(merged_hash)
 
 


### PR DESCRIPTION
## Summary

- Replace O(n²) bytes `+=` loop with O(n) `b''.join()` in `BlockHashListWithBlockSize._get_value_at()`
- Each `+=` on immutable bytes allocates a new object and copies all previous data; `join()` pre-computes the total size and allocates once
- One-liner change producing identical output

## Context

`_get_value_at()` is called during KV cache hash scaling for prefix caching on every inference step when blocks need hash upscaling. The quadratic concatenation cost grows with `scale_factor`.

## Test plan

- [ ] Existing unit tests pass (`tests/v1/core/test_kv_cache_utils.py`)
- [ ] No functional change — `b''.join(items[base:end])` produces the same bytes as iterative `+=`

🤖 Generated with [Claude Code](https://claude.com/claude-code)