### PR TITLE
[Sampler] Remove redundant float32 dtype conversion

### DIFF
--- a/vllm/v1/sample/sampler.py
+++ b/vllm/v1/sample/sampler.py
@@ -81,14 +81,15 @@ class Sampler(nn.Module):
         if num_logprobs is not None:
             if logprobs_mode == "raw_logprobs":
                 raw_logprobs = self.compute_logprobs(logits)
-            elif logprobs_mode == "raw_logits":
-                if logits.dtype == torch.float32:
-                    raw_logprobs = logits.clone()
-                else:
-                    raw_logprobs = logits.to(torch.float32)
 
         # Use float32 for the logits.
         logits = logits.to(torch.float32)
+
+        if num_logprobs is not None:
+            if logprobs_mode == "raw_logits":
+                # Clone the float32 logits before they are modified
+                # by logits processors below.
+                raw_logprobs = logits.clone()
 
         logits = self.apply_logits_processors(
             logits, sampling_metadata, predict_bonus_token


### PR DESCRIPTION
## Summary
- When `logprobs_mode` is `"raw_logits"` and input logits are not float32, the sampler converted logits to float32 twice: once for `raw_logprobs` (line 88) and again for the main `logits` (line 91)
- Restructured to perform the float32 conversion once, then clone for `raw_logprobs`, eliminating one redundant dtype conversion
- No behavioral change: `raw_logprobs` still captures the pre-logits-processor float32 logits

## Test plan
- [ ] Existing sampler tests pass
- [ ] Verify logprobs output is identical with float16/bfloat16 model inputs
- [ ] Verify no regression in sampling correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)