### PR TITLE
fix: skip spec decode draft rejection after scheduler rewind

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1239,9 +1239,10 @@ class GPUModelRunner(
                 elif num_computed_tokens < req_state.num_computed_tokens:
                     # Scheduler rewound num_computed_tokens (e.g. KV load
                     # failure triggered recompute via
-                    # _update_requests_with_invalid_blocks). The previous
-                    # draft tokens are covered by the rewind, so skip
-                    # the optimistic acceptance assumption entirely.
+                    # _update_requests_with_invalid_blocks). All tokens past
+                    # the rewind point were invalidated, which includes the
+                    # context used to propose the previous drafts. Skip the
+                    # optimistic acceptance assumption entirely.
                     req_state.prev_num_draft_len = 0
                 else:
                     # Optimistically assume all accepted; queue up a correction

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1236,6 +1236,13 @@ class GPUModelRunner(
                 # when prev_num_draft_len > 0.
                 if req_index is None:
                     req_state.prev_num_draft_len = 0
+                elif num_computed_tokens < req_state.num_computed_tokens:
+                    # Scheduler rewound num_computed_tokens (e.g. KV load
+                    # failure triggered recompute via
+                    # _update_requests_with_invalid_blocks). The previous
+                    # draft tokens are covered by the rewind, so skip
+                    # the optimistic acceptance assumption entirely.
+                    req_state.prev_num_draft_len = 0
                 else:
                     # Optimistically assume all accepted; queue up a correction
                     # to be called after the model forward to preserve async


### PR DESCRIPTION
## Summary

When `kv_load_failure_policy=recompute` is enabled, the scheduler can rewind `request.num_computed_tokens` to an earlier block boundary via `_update_requests_with_invalid_blocks` (scheduler.py). However, the worker-side `_update_states` in `GPUModelRunner` still applies the spec decode draft rejection subtraction (`num_computed_tokens -= num_rejected`) on the already-rewound value.

This can drive `num_computed_tokens` negative when `prev_num_draft_len` exceeds the rewound token count, corrupting subsequent forward passes.

**Scenario:**
1. Step N: request has `num_computed_tokens=102` (100 prompt + 2 spec tokens), `prev_num_draft_len=2`
2. KV load failure detected — scheduler rewinds to `num_computed_tokens=0` (first block failed)
3. Worker receives rewound value `0`, but `prev_num_draft_len` is still `2` from step N
4. Worker computes `num_rejected=2`, then `num_computed_tokens = 0 - 2 = -2`

**Fix:** detect a scheduler rewind by checking `num_computed_tokens < req_state.num_computed_tokens`. When this happens, clear `prev_num_draft_len` to skip the stale rejection adjustment — the rewound tokens already cover the previous draft.

Ref: discussion in #38474 (comment by @Pz1116 about spec decoding + recompute compatibility)

## Test plan

- [ ] Verify `num_computed_tokens` never goes negative with async scheduling + spec decoding + KV load failure recompute
- [ ] Existing spec decoding tests continue to pass
- [ ] Existing KV load failure recovery tests continue to pass