### PR TITLE
[CI/Build] Add retry to apt-get update in Dockerfile CUDA install step

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -531,7 +531,10 @@ RUN apt-get update -y \
 # (FlashInfer, DeepGEMM, EP kernels all require compilation at runtime)
 RUN CUDA_VERSION_DASH=$(echo $CUDA_VERSION | cut -d. -f1,2 | tr '.' '-') && \
     CUDA_VERSION_SHORT=$(echo $CUDA_VERSION | cut -d. -f1,2) && \
-    apt-get update -y && \
+    for i in 1 2 3; do \
+        apt-get update -y && break || \
+        { echo "apt-get update attempt $i failed, retrying in 5s..."; sleep 5; }; \
+    done && \
     apt-get install -y --no-install-recommends --allow-change-held-packages \
         cuda-nvcc-${CUDA_VERSION_DASH} \
         cuda-cudart-${CUDA_VERSION_DASH} \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -510,7 +510,8 @@ RUN apt-get update -y \
     else \
         for i in 1 2 3; do \
             add-apt-repository -y ppa:deadsnakes/ppa && break || \
-            { echo "Attempt $i failed, retrying in 5s..."; sleep 5; }; \
+            { if [ $i -eq 3 ]; then echo "add-apt-repository failed after 3 attempts"; exit 1; fi; \
+              echo "Attempt $i failed, retrying in 5s..."; sleep 5; }; \
         done ; \
     fi \
     && apt-get update -y \
@@ -533,7 +534,8 @@ RUN CUDA_VERSION_DASH=$(echo $CUDA_VERSION | cut -d. -f1,2 | tr '.' '-') && \
     CUDA_VERSION_SHORT=$(echo $CUDA_VERSION | cut -d. -f1,2) && \
     for i in 1 2 3; do \
         apt-get update -y && break || \
-        { echo "apt-get update attempt $i failed, retrying in 5s..."; sleep 5; }; \
+        { if [ $i -eq 3 ]; then echo "apt-get update failed after 3 attempts"; exit 1; fi; \
+          echo "apt-get update attempt $i failed, retrying in 5s..."; sleep 5; }; \
     done && \
     apt-get install -y --no-install-recommends --allow-change-held-packages \
         cuda-nvcc-${CUDA_VERSION_DASH} \


### PR DESCRIPTION
 ## Summary                                                      
  - Adds a retry loop (3 attempts, 5s backoff) around `apt-get update` in the
    CUDA dev tools install step (Dockerfile line 534), fixing transient nightly                                             
    Docker build failures caused by Ubuntu mirror mid-sync issues.                                                          
  - Matches the existing retry pattern already used for `add-apt-repository`                                                
    earlier in the same Dockerfile.                                                                                         
                                                                                                                            
  ## Context                                                      
  The nightly Docker build failed on 2026-04-16 because `archive.ubuntu.com` was                                            
  mid-sync during `apt-get update`:                                                                                         
  E: Failed to fetch .../jammy-updates/universe/binary-amd64/Packages.gz                                                    
     File has unexpected size (1622816 != 1622900). Mirror sync in progress?                                                
                                                                                                                            
  This is a known transient issue with Ubuntu mirrors. A simple retry resolves it.                                          
   
  ## Test plan                                                                                                              
  - [ ] Verify nightly Docker build passes on retry               
  - [ ] Confirm the retry loop syntax is correct by building the Docker image locally