### PR TITLE
fix(vllm): port skip_kv_gather check and workspace reservation to ROCm MLA sparse attention

### DIFF
--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -473,15 +473,22 @@ def rocm_aiter_sparse_attn_indexer_fake(
     total_seq_lens: int,
     topk_indices_buffer: torch.Tensor | None,
 ) -> torch.Tensor:
-    # profile run
+    # Reserve workspace during profiling run
     # NOTE(Chen): create the max possible flattened_kv. So that
     # profile_run can get correct memory usage.
-    _flattened_kv = torch.empty(
-        [total_seq_lens, head_dim + 4], device=k.device, dtype=torch.uint8
-    )
     fp8_dtype = current_platform.fp8_dtype()
-    _k_fp8 = _flattened_kv[..., :head_dim].view(fp8_dtype).contiguous()
-    _k_scale = _flattened_kv[..., head_dim:].view(torch.float32).contiguous()
+    from vllm.v1.worker.workspace import current_workspace_manager
+
+    current_workspace_manager().get_simultaneous(
+        ((total_seq_lens, head_dim), fp8_dtype),
+        ((total_seq_lens, 4), torch.uint8),
+    )
+    _k_fp8 = torch.empty(
+        [total_seq_lens, head_dim], device=k.device, dtype=fp8_dtype
+    )
+    _k_scale = torch.empty(
+        [total_seq_lens, 4], device=k.device, dtype=torch.uint8
+    )
     return topk_indices_buffer
 
 
@@ -549,25 +556,26 @@ def rocm_aiter_sparse_attn_indexer(
     if has_prefill:
         prefill_metadata = layer_attn_metadata.prefill
         assert prefill_metadata is not None
-        for chunk in prefill_metadata.chunks:
-            k_fp8 = torch.empty(
-                [chunk.total_seq_lens, head_dim],
-                device=k.device,
-                dtype=fp8_dtype,
-            )
-            k_scale = torch.empty(
-                [chunk.total_seq_lens, 4],
-                device=k.device,
-                dtype=torch.uint8,
-            )
+        # Get shared workspace buffers once (allocate on first use)
+        from vllm.v1.worker.workspace import current_workspace_manager
 
-            ops.cp_gather_indexer_k_quant_cache(
-                kv_cache,
-                k_fp8,
-                k_scale,
-                chunk.block_table,
-                chunk.cu_seq_lens,
-            )
+        workspace_manager = current_workspace_manager()
+        k_fp8_full, k_scale_full = workspace_manager.get_simultaneous(
+            ((total_seq_lens, head_dim), fp8_dtype),
+            ((total_seq_lens, 4), torch.uint8),
+        )
+        for chunk in prefill_metadata.chunks:
+            k_fp8 = k_fp8_full[: chunk.total_seq_lens]
+            k_scale = k_scale_full[: chunk.total_seq_lens]
+
+            if not chunk.skip_kv_gather:
+                ops.cp_gather_indexer_k_quant_cache(
+                    kv_cache,
+                    k_fp8,
+                    k_scale,
+                    chunk.block_table,
+                    chunk.cu_seq_lens,
+                )
 
             logits = rocm_fp8_mqa_logits(
                 q_fp8[chunk.token_start : chunk.token_end],


### PR DESCRIPTION
## Summary

Fixes [ROCOM_AITER_MLA_SPARSE prefill producing garbage for prompt_len > ~20K tokens on gfx950 (MI355X)](https://github.com/vllm-project/vllm/issues/40018) by porting two missing patterns from the CUDA reference implementation in `sparse_attn_indexer.py`.

## Root Cause

Two bugs in `vllm/v1/attention/ops/rocm_aiter_mla_sparse.py`:

1. **Missing `skip_kv_gather` check**: The CUDA path skips the KV gather for sub-chunks marked `skip_kv_gather=True` (chunks after the first that re-use prior KV data). The ROCm path always re-gathered into fresh `torch.empty` buffers, causing memory competition during CUDA graph replay.

2. **Missing workspace reservation during profiling**: The `rocm_aiter_sparse_attn_indexer_fake` path allocated buffers with `torch.empty` directly instead of reserving workspace via `current_workspace_manager().get_simultaneous()`, leading to incorrect memory accounting during profiling.

## Changes

### `rocm_aiter_sparse_attn_indexer_fake`
- Reserve workspace buffers via `current_workspace_manager().get_simultaneous()` during profiling, matching the CUDA `sparse_attn_indexer.py` pattern (lines 55-60)

### `rocm_aiter_sparse_attn_indexer` prefill path
- Get shared persistent workspace buffers once via `workspace_manager.get_simultaneous()` and slice per-chunk (avoid per-iteration `torch.empty` allocation)
- Add `if not chunk.skip_kv_gather:` guard around `ops.cp_gather_indexer_k_quant_cache` call, matching `sparse_attn_indexer.py` lines 113-130

## Testing

Cannot test on AMD MI355X hardware directly. The fix is a direct port of the confirmed-correct CUDA pattern. The issue author noted their patch "helps but doesn't fully fix it" — this port of the complete CUDA pattern should close the gap.
