### PR TITLE
[Bugfix] Increase bench_serve aiohttp read buffer for long-context throughput

### DIFF
--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -658,6 +658,7 @@ async def benchmark(
         connector=connector,
         trust_env=True,
         timeout=aiohttp.ClientTimeout(total=6 * 60 * 60),
+        read_bufsize=4 * 1024 * 1024,
     )
 
     print("Starting initial single prompt test run...")


### PR DESCRIPTION
## Summary

Fixes #39963 — `vllm bench serve` throughput collapses ~10x at 50K+ input tokens with high concurrency due to aiohttp's default 64KB `read_bufsize`.

Large streaming chunks from the server fill this tiny buffer, creating backpressure that cascades into the server's scheduler.  Bump to 4MB so the client can drain responses without bottlenecking.

**Before (50K context, concurrent):** ~44 tok/s, TTFT 134s
**After:** throughput should match other bench tools (~486 tok/s)

## Changes

One-line change in `vllm/benchmarks/serve.py`: add `read_bufsize=4 * 1024 * 1024` to the `aiohttp.ClientSession` constructor.

## Test plan

- [ ] Run `vllm bench serve` at 50K+ context length and verify throughput matches expectations
- [ ] Confirm no regression at shorter contexts (8K/32K)