### PR TITLE
[Bugfix] Temporarily disable B200 fp4 MoE layer tests

### DIFF
--- a/tests/kernels/moe/test_moe_layer.py
+++ b/tests/kernels/moe/test_moe_layer.py
@@ -465,6 +465,14 @@ def is_valid_config(config: MoETestConfig) -> tuple[bool, str | None]:
     if config.enable_eplb and config.ep_size == 1:
         return False, "EPLB only works with EP+DP"
 
+    # Disable fp4 tests until flashinfer is updated or the Dockerfile is
+    # modified to install cublasLt.h. See #39525.
+    if (
+        config.quantization == "modelopt_fp4"
+        and current_platform.is_device_capability_family(100)
+    ):
+        return False, "Temporarily skip until #39525 is resolved"
+
     return True, None
 
 


### PR DESCRIPTION

## Purpose

Disable the `modelopt_fp4` tests on B200 for now.  To fix the underlying issue, the `Dockerfile` can be updated to install `libcublas-dev` instead of `libcublas` or we can wait for a newer version of flashinfer, e.g. 0.6.8rc1.

See https://github.com/vllm-project/vllm/issues/39525

## Test Plan

Run B200 MoE layer test

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

