### PR TITLE
[WIP] Prototype pre-spawn EngineCore to overlap child imports with parent init

### DIFF
--- a/tools/pre_commit/check_forbidden_imports.py
+++ b/tools/pre_commit/check_forbidden_imports.py
@@ -41,6 +41,7 @@ CHECK_IMPORTS = {
             "vllm/distributed/weight_transfer/ipc_engine.py",
             "tests/distributed/test_weight_transfer.py",
             "vllm/utils/hashing.py",
+            "vllm/v1/engine/prespawn.py",
             "tests/multimodal/media/test_base.py",
             "tests/tokenizers_/test_hf.py",
             "tests/utils_/test_hashing.py",

--- a/vllm/entrypoints/cli/serve.py
+++ b/vllm/entrypoints/cli/serve.py
@@ -45,6 +45,18 @@ class ServeSubcommand(CLISubcommand):
         if hasattr(args, "model_tag") and args.model_tag is not None:
             args.model = args.model_tag
 
+        # Kick off the EngineCore subprocess now so its imports overlap the
+        # parent's VllmConfig construction. The handle is picked up later
+        # by CoreEngineProcManager. Skipped for headless / gRPC paths.
+        if (
+            envs.VLLM_PRESPAWN_ENGINE
+            and not getattr(args, "grpc", False)
+            and not args.headless
+        ):
+            from vllm.v1.engine.prespawn import prespawn_engine_core
+
+            prespawn_engine_core()
+
         if getattr(args, "grpc", False):
             from vllm.entrypoints.grpc_server import serve_grpc
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -63,6 +63,7 @@ if TYPE_CHECKING:
     VLLM_USE_RAY_V2_EXECUTOR_BACKEND: bool = False
     VLLM_XLA_USE_SPMD: bool = False
     VLLM_WORKER_MULTIPROC_METHOD: Literal["fork", "spawn"] = "fork"
+    VLLM_PRESPAWN_ENGINE: bool = False
     VLLM_ASSETS_CACHE: str = os.path.join(VLLM_CACHE_ROOT, "assets")
     VLLM_ASSETS_CACHE_MODEL_CLEAN: bool = False
     VLLM_IMAGE_FETCH_TIMEOUT: int = 5
@@ -769,6 +770,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_WORKER_MULTIPROC_METHOD": env_with_choices(
         "VLLM_WORKER_MULTIPROC_METHOD", "fork", ["spawn", "fork"]
     ),
+    # If set, `vllm serve` launches the EngineCore subprocess before parsing
+    # args / building VllmConfig so that its heavy imports overlap parent
+    # startup. Only `data_parallel_size_local == 1` is supported; other
+    # topologies fall back to the normal spawn path.
+    "VLLM_PRESPAWN_ENGINE": lambda: bool(int(os.getenv("VLLM_PRESPAWN_ENGINE", "0"))),
     # Path to the cache for storing downloaded assets
     "VLLM_ASSETS_CACHE": lambda: os.path.expanduser(
         os.getenv(

--- a/vllm/v1/engine/prespawn.py
+++ b/vllm/v1/engine/prespawn.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pre-spawn helper for EngineCore startup.
+
+Fires off the EngineCore subprocess before the parent has finished building
+`VllmConfig`, so the child's heavy imports (torch, vllm) overlap the
+parent's own init. When the parent is ready, it sends the kwargs for
+`EngineCoreProc.run_engine_core` over a ZMQ PAIR socket and the child
+dispatches into the normal EngineCore boot path.
+
+Usage pattern:
+    # CLI entrypoint, before VllmConfig is constructed:
+    prespawn_engine_core()
+
+    # Later, CoreEngineProcManager calls take_pending() to find the handle
+    # and send kwargs to the already-running child.
+"""
+
+import atexit
+import pickle
+from dataclasses import dataclass
+from multiprocessing.process import BaseProcess
+
+import zmq
+
+from vllm.utils.network_utils import get_open_zmq_ipc_path
+from vllm.utils.system_utils import get_mp_context
+
+# Upper bound on how long the child will wait for config before exiting.
+# Parent-side work is normally a few seconds; this just prevents orphaned
+# children from hanging forever if the parent dies mid-startup.
+_CONFIG_TIMEOUT_MS = 120_000
+
+_pending: list["PrespawnedEngine"] = []
+
+
+@dataclass
+class PrespawnedEngine:
+    """Handle for an EngineCore subprocess spawned before its config is ready."""
+
+    proc: BaseProcess
+    sock: zmq.Socket
+
+    def send_config(self, **run_engine_core_kwargs) -> None:
+        """Hand `run_engine_core` kwargs to the waiting child."""
+        self.sock.send(pickle.dumps(run_engine_core_kwargs))
+        self.sock.close()
+
+    def shutdown(self) -> None:
+        """Kill the child if it's still waiting for config (e.g. on fallback)."""
+        self.sock.close(linger=0)
+        if self.proc.is_alive():
+            self.proc.terminate()
+        self.proc.join(timeout=5.0)
+
+
+def prespawn_engine_core() -> PrespawnedEngine:
+    """Spawn EngineCore now; `CoreEngineProcManager` will hand it kwargs later."""
+    addr = get_open_zmq_ipc_path()
+    sock = zmq.Context.instance().socket(zmq.PAIR)
+    sock.bind(addr)
+
+    proc = get_mp_context().Process(
+        target=_child_main,
+        kwargs={"config_addr": addr},
+        name="EngineCore",
+    )
+    proc.start()
+    handle = PrespawnedEngine(proc=proc, sock=sock)
+    _pending.append(handle)
+    return handle
+
+
+def take_pending() -> list[PrespawnedEngine]:
+    """Drain and return any pre-spawned handles registered with the module."""
+    handles, _pending[:] = list(_pending), []
+    return handles
+
+
+@atexit.register
+def _cleanup_unconsumed() -> None:
+    """Terminate any handles still waiting at interpreter exit (parent-side)."""
+    for handle in take_pending():
+        handle.shutdown()
+
+
+def _child_main(config_addr: str) -> None:
+    # Heavy imports here run in parallel with the parent's argparse +
+    # VllmConfig construction — that's the whole point of prespawn.
+    from vllm.v1.engine.core import EngineCoreProc
+
+    sock = zmq.Context.instance().socket(zmq.PAIR)
+    sock.connect(config_addr)
+    # Bail out if the parent dies before sending config: PAIR sockets don't
+    # surface peer death, so without a bounded wait the child would hang.
+    if not sock.poll(timeout=_CONFIG_TIMEOUT_MS):
+        return
+    kwargs = pickle.loads(sock.recv())
+    sock.close()
+    EngineCoreProc.run_engine_core(**kwargs)

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -115,30 +115,52 @@ class CoreEngineProcManager:
         is_dp = vllm_config.parallel_config.data_parallel_size > 1
 
         from vllm.v1.engine.core import EngineCoreProc
+        from vllm.v1.engine.prespawn import take_pending
+
+        # Adopt any pre-spawned children as the first `len(prespawned)` engines.
+        # Falls back to the normal spawn path if the topology doesn't match.
+        prespawned = take_pending()
+        if prespawned and len(prespawned) != local_engine_count:
+            for p in prespawned:
+                p.shutdown()
+            prespawned = []
 
         self.processes: list[BaseProcess] = []
         local_dp_ranks = []
         for index in range(local_engine_count):
             local_index = local_start_index + index
             global_index = start_index + index
+            kwargs = common_kwargs | {
+                "dp_rank": global_index,
+                "local_dp_rank": local_index,
+            }
 
             # Start EngineCore in background process.
             local_dp_ranks.append(local_index)
-            self.processes.append(
-                context.Process(
-                    target=EngineCoreProc.run_engine_core,
-                    name=f"EngineCore_DP{global_index}" if is_dp else "EngineCore",
-                    kwargs=common_kwargs
-                    | {"dp_rank": global_index, "local_dp_rank": local_index},
+            if index < len(prespawned):
+                # Child was spawned earlier; hand it the kwargs it's blocked on.
+                prespawned[index].send_config(**kwargs)
+                self.processes.append(prespawned[index].proc)
+            else:
+                self.processes.append(
+                    context.Process(
+                        target=EngineCoreProc.run_engine_core,
+                        name=f"EngineCore_DP{global_index}" if is_dp else "EngineCore",
+                        kwargs=kwargs,
+                    )
                 )
-            )
 
         self._finalizer = weakref.finalize(self, shutdown, self.processes)
         self.manager_stopped = threading.Event()
         self.failed_proc_name: str | None = None
 
         try:
-            for proc, local_dp_rank in zip(self.processes, local_dp_ranks):
+            for index, (proc, local_dp_rank) in enumerate(
+                zip(self.processes, local_dp_ranks)
+            ):
+                if index < len(prespawned):
+                    # Already running (prespawned path).
+                    continue
                 # Adjust device control in DP for non-CUDA platforms
                 # as well as external and ray launchers
                 # For CUDA platforms, we use torch.accelerator.set_device_index()()


### PR DESCRIPTION
## Purpose

Adds `VLLM_PRESPAWN_ENGINE=1` (opt-in) which fires off the EngineCore subprocess at the top of `vllm serve`, before the parent has finished building `VllmConfig`. The child's heavy imports (torch, vllm) then run in parallel with the parent's config construction; later, `CoreEngineProcManager` hands the child its kwargs over a ZMQ PAIR socket instead of spawning fresh.

<img width="1119" height="333" alt="Screenshot 2026-04-16 at 5 29 27 PM" src="https://github.com/user-attachments/assets/7c419856-5b42-4aeb-8d22-6025c33b3df8" />

Follow-ups if we adopt this:
- DP>1: pre-spawn N children once --data-parallel-size-local is known from argparse.
- Headless / gRPC serve paths?

AI assistance was used in the investigation and drafting of this patch.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

