### PR TITLE
feat: support passing configuration to custom attention backends

### DIFF
--- a/tests/test_attention_backend_registry.py
+++ b/tests/test_attention_backend_registry.py
@@ -7,6 +7,7 @@ from vllm.v1.attention.backend import (
 from vllm.v1.attention.backends.registry import (
     AttentionBackendEnum,
     MambaAttentionBackendEnum,
+    get_backend_config,
     register_backend,
 )
 
@@ -167,3 +168,98 @@ def test_register_custom_mamba_backend_with_class_path():
     backend_cls = MambaAttentionBackendEnum.CUSTOM.get_class()
     assert backend_cls.get_name() == "CUSTOM_MAMBA"
     assert backend_cls.get_impl_cls() == CustomMambaAttentionImpl
+
+
+def test_register_backend_config_with_class_path():
+    """Test passing backend_config via register_backend() with class_path."""
+    config = {"log_level": "debug", "sample_rate": 0.1}
+
+    # Clean up any prior state
+    AttentionBackendEnum.CUSTOM.clear_override()
+    AttentionBackendEnum.CUSTOM.clear_config()
+
+    register_backend(
+        backend=AttentionBackendEnum.CUSTOM,
+        class_path="tests.test_attention_backend_registry.CustomAttentionBackend",
+        backend_config=config,
+    )
+
+    # Config should be retrievable via the enum method
+    assert AttentionBackendEnum.CUSTOM.get_config() == config
+    # Config should also be retrievable via the module-level function
+    assert get_backend_config(AttentionBackendEnum.CUSTOM) == config
+
+    # Clean up
+    AttentionBackendEnum.CUSTOM.clear_config()
+    assert AttentionBackendEnum.CUSTOM.get_config() is None
+
+
+def test_register_backend_config_with_decorator():
+    """Test passing backend_config via the @register_backend decorator."""
+    config = {"enable_tracing": True}
+
+    # Clean up any prior state
+    AttentionBackendEnum.CUSTOM.clear_override()
+    AttentionBackendEnum.CUSTOM.clear_config()
+
+    @register_backend(AttentionBackendEnum.CUSTOM, backend_config=config)
+    class _DecoratedBackend(CustomAttentionBackend):
+        pass
+
+    assert AttentionBackendEnum.CUSTOM.get_config() == config
+    assert get_backend_config(AttentionBackendEnum.CUSTOM) == config
+
+    # Clean up
+    AttentionBackendEnum.CUSTOM.clear_config()
+    AttentionBackendEnum.CUSTOM.clear_override()
+
+
+def test_register_mamba_backend_config():
+    """Test passing backend_config for a MambaAttentionBackendEnum."""
+    config = {"conv_width": 4}
+
+    MambaAttentionBackendEnum.CUSTOM.clear_config()
+
+    register_backend(
+        backend=MambaAttentionBackendEnum.CUSTOM,
+        class_path="tests.test_attention_backend_registry.CustomMambaAttentionBackend",
+        is_mamba=True,
+        backend_config=config,
+    )
+
+    assert MambaAttentionBackendEnum.CUSTOM.get_config() == config
+    assert get_backend_config(MambaAttentionBackendEnum.CUSTOM) == config
+
+    # Clean up
+    MambaAttentionBackendEnum.CUSTOM.clear_config()
+
+
+def test_backend_config_defaults_to_none():
+    """Test that config is None when not explicitly set."""
+    AttentionBackendEnum.CUSTOM.clear_config()
+
+    # Register without backend_config
+    register_backend(
+        backend=AttentionBackendEnum.CUSTOM,
+        class_path="tests.test_attention_backend_registry.CustomAttentionBackend",
+    )
+
+    assert AttentionBackendEnum.CUSTOM.get_config() is None
+    assert get_backend_config(AttentionBackendEnum.CUSTOM) is None
+
+
+def test_backend_config_clear():
+    """Test that clear_config removes the stored config."""
+    config = {"key": "value"}
+
+    AttentionBackendEnum.CUSTOM.clear_config()
+
+    register_backend(
+        backend=AttentionBackendEnum.CUSTOM,
+        class_path="tests.test_attention_backend_registry.CustomAttentionBackend",
+        backend_config=config,
+    )
+    assert AttentionBackendEnum.CUSTOM.get_config() == config
+
+    AttentionBackendEnum.CUSTOM.clear_config()
+    assert AttentionBackendEnum.CUSTOM.get_config() is None

--- a/vllm/v1/attention/backends/registry.py
+++ b/vllm/v1/attention/backends/registry.py
@@ -4,7 +4,7 @@
 
 from collections.abc import Callable
 from enum import Enum, EnumMeta
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from vllm.logger import init_logger
 from vllm.utils.import_utils import resolve_obj_by_qualname
@@ -130,6 +130,18 @@ class AttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
         """Clear any override for this backend, reverting to the default."""
         _ATTN_OVERRIDES.pop(self, None)
 
+    def get_config(self) -> Any:
+        """Get the configuration for this backend.
+
+        Returns:
+            The backend configuration, or None if not set.
+        """
+        return _ATTN_BACKEND_CONFIGS.get(self)
+
+    def clear_config(self) -> None:
+        """Clear any configuration for this backend."""
+        _ATTN_BACKEND_CONFIGS.pop(self, None)
+
 
 class MambaAttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
     """Enumeration of all supported mamba attention backends.
@@ -193,6 +205,18 @@ class MambaAttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
         """Clear any override for this backend, reverting to the default."""
         _MAMBA_ATTN_OVERRIDES.pop(self, None)
 
+    def get_config(self) -> Any:
+        """Get the configuration for this backend.
+
+        Returns:
+            The backend configuration, or None if not set.
+        """
+        return _MAMBA_ATTN_BACKEND_CONFIGS.get(self)
+
+    def clear_config(self) -> None:
+        """Clear any configuration for this backend."""
+        _MAMBA_ATTN_BACKEND_CONFIGS.pop(self, None)
+
 
 MAMBA_TYPE_TO_BACKEND_MAP = {
     "mamba1": MambaAttentionBackendEnum.MAMBA1.name,
@@ -207,11 +231,15 @@ MAMBA_TYPE_TO_BACKEND_MAP = {
 _ATTN_OVERRIDES: dict[AttentionBackendEnum, str] = {}
 _MAMBA_ATTN_OVERRIDES: dict[MambaAttentionBackendEnum, str] = {}
 
+_ATTN_BACKEND_CONFIGS: dict[AttentionBackendEnum, Any] = {}
+_MAMBA_ATTN_BACKEND_CONFIGS: dict[MambaAttentionBackendEnum, Any] = {}
+
 
 def register_backend(
     backend: AttentionBackendEnum | MambaAttentionBackendEnum,
     class_path: str | None = None,
     is_mamba: bool = False,
+    backend_config: Any = None,
 ) -> Callable[[type], type]:
     """Register or override a backend implementation.
 
@@ -219,6 +247,10 @@ def register_backend(
         backend: The AttentionBackendEnum member to register
         class_path: Optional class path. If not provided and used as
             decorator, will be auto-generated from the class.
+        is_mamba: Whether this is a mamba attention backend.
+        backend_config: Optional configuration to associate with the
+            backend. Can be any type (dict, dataclass, etc.). Retrievable
+            via ``backend.get_config()`` or ``get_backend_config(backend)``.
 
     Returns:
         Decorator function if class_path is None, otherwise a no-op
@@ -239,18 +271,27 @@ def register_backend(
         class MyCustomBackend:
             ...
 
-        # Direct registration
+        # Direct registration with configuration
         register_backend(
             AttentionBackendEnum.CUSTOM,
-            "my.module.MyCustomBackend"
+            "my.module.MyCustomBackend",
+            backend_config={"log_level": "debug", "sample_rate": 0.1},
         )
     """
+
+    def _store_config() -> None:
+        if backend_config is not None:
+            if is_mamba:
+                _MAMBA_ATTN_BACKEND_CONFIGS[backend] = backend_config  # type: ignore[index]
+            else:
+                _ATTN_BACKEND_CONFIGS[backend] = backend_config  # type: ignore[index]
 
     def decorator(cls: type) -> type:
         if is_mamba:
             _MAMBA_ATTN_OVERRIDES[backend] = f"{cls.__module__}.{cls.__qualname__}"  # type: ignore[index]
         else:
             _ATTN_OVERRIDES[backend] = f"{cls.__module__}.{cls.__qualname__}"  # type: ignore[index]
+        _store_config()
         return cls
 
     if class_path is not None:
@@ -258,6 +299,25 @@ def register_backend(
             _MAMBA_ATTN_OVERRIDES[backend] = class_path  # type: ignore[index]
         else:
             _ATTN_OVERRIDES[backend] = class_path  # type: ignore[index]
+        _store_config()
         return lambda x: x
 
     return decorator
+
+
+def get_backend_config(
+    backend: AttentionBackendEnum | MambaAttentionBackendEnum,
+) -> Any:
+    """Get the configuration associated with a backend.
+
+    This is the public function form of ``backend.get_config()``.
+
+    Args:
+        backend: The backend enum member to query.
+
+    Returns:
+        The backend configuration, or None if not set.
+    """
+    if isinstance(backend, MambaAttentionBackendEnum):
+        return _MAMBA_ATTN_BACKEND_CONFIGS.get(backend)
+    return _ATTN_BACKEND_CONFIGS.get(backend)


### PR DESCRIPTION
## What's broken?

Custom attention backends registered via `register_backend()` have no way to receive configuration. The `vllm.general_plugins` entry points are zero-argument callables, and `AttentionImpl.__init__` has a fixed constructor signature — there is no sanctioned injection point for plugin authors to pass config to their custom backends.

Workarounds like class-level attributes are fragile and not discoverable.

Ref: #40051

## Who is affected?

Anyone building custom attention backends (e.g. observability tools like [glassbox](https://github.com/dmaniloff/glassbox)) that need runtime configuration. Existing built-in backends and users not passing `backend_config` are **not affected** — this is fully backward-compatible.

## How did we fix it?

Added a `backend_config: Any = None` parameter to `register_backend()` in `vllm/v1/attention/backends/registry.py`. The value is stored in new module-level dicts (`_ATTN_BACKEND_CONFIGS` / `_MAMBA_ATTN_BACKEND_CONFIGS`) alongside the existing `_ATTN_OVERRIDES`.

**New public API surface:**
- `register_backend(..., backend_config={"key": "value"})` — store config at registration time
- `backend.get_config()` — enum method to retrieve config (returns `None` if not set)
- `backend.clear_config()` — enum method to clear stored config
- `get_backend_config(backend)` — module-level function (equivalent to `backend.get_config()`)

**Usage example:**
```python
# In your plugin's entry point:
from vllm.v1.attention.backends.registry import (
    AttentionBackendEnum, register_backend
)

register_backend(
    AttentionBackendEnum.CUSTOM,
    "my.module.MyObservabilityBackend",
    backend_config={"log_level": "debug", "sample_rate": 0.1},
)

# In your backend class:
from vllm.v1.attention.backends.registry import get_backend_config, AttentionBackendEnum

class MyObservabilityBackend(AttentionBackend):
    def __init__(self, ...):
        config = get_backend_config(AttentionBackendEnum.CUSTOM)
        # config == {"log_level": "debug", "sample_rate": 0.1}
```

**Design choices:**
- Pull-based pattern (backend reads config at init time) — matches how `_ATTN_OVERRIDES` already works
- No changes to `AttentionImpl.__init__` signature — zero disruption to existing backends
- Config is set per-process when the plugin loads — matches subprocess behavior documented in plugin docs
- Works with both decorator and direct-registration forms of `register_backend()`

## How do we know it works?

- 5 new unit tests added to `tests/test_attention_backend_registry.py`:
  - `test_register_backend_config_with_class_path` — config via direct registration
  - `test_register_backend_config_with_decorator` — config via `@register_backend` decorator
  - `test_register_mamba_backend_config` — config for `MambaAttentionBackendEnum`
  - `test_backend_config_defaults_to_none` — backward compat: no config = `None`
  - `test_backend_config_clear` — `clear_config()` removes stored config
- All existing tests continue to pass unchanged
- `ruff check` and `ruff format --check` pass

## Changes

- `vllm/v1/attention/backends/registry.py`: Added `backend_config` param, config storage dicts, `get_config()`/`clear_config()` enum methods, `get_backend_config()` function
- `tests/test_attention_backend_registry.py`: 5 new tests covering the config mechanism
