### PR TITLE
[Performance] Stagger checkpoint file reads across ranks to reduce I/O contention

### DIFF
--- a/tests/model_executor/test_weight_utils.py
+++ b/tests/model_executor/test_weight_utils.py
@@ -5,11 +5,14 @@ import tempfile
 
 import huggingface_hub.constants
 import pytest
+import torch
 from huggingface_hub.utils import LocalEntryNotFoundError
 
 from vllm.model_executor.model_loader.weight_utils import (
+    _prefetch_all_checkpoints,
     download_weights_from_hf,
     maybe_remap_kv_scale_name,
+    safetensors_weights_iterator,
 )
 
 
@@ -158,6 +161,126 @@ class TestMaybeRemapKvScaleName:
             "model.layers.0.self_attn.qkv_proj.k_scale", empty_params
         )
         assert result is None
+
+
+def test_safetensors_prefetch_uses_global_order_before_rank_rotation(monkeypatch):
+    files = [
+        "model-00001-of-00004.safetensors",
+        "model-00002-of-00004.safetensors",
+        "model-00003-of-00004.safetensors",
+        "model-00004-of-00004.safetensors",
+    ]
+    prefetched_lists: list[list[str]] = []
+    opened_files: list[str] = []
+
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 1)
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 2)
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.weight_utils._get_fs_type",
+        lambda _: "nfs",
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.weight_utils._get_checkpoints_size_bytes",
+        lambda _: 1,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.weight_utils._get_available_ram_bytes",
+        lambda: 1024,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.weight_utils._prefetch_all_checkpoints",
+        lambda paths: prefetched_lists.append(list(paths)),
+    )
+
+    class FakeSafeOpen:
+        def __init__(self, path: str):
+            self.path = path
+
+        def __enter__(self):
+            opened_files.append(self.path)
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def keys(self):
+            return []
+
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.weight_utils.safe_open",
+        lambda path, framework="pt": FakeSafeOpen(path),
+    )
+
+    loaded = list(
+        safetensors_weights_iterator(
+            files,
+            False,
+            safetensors_load_strategy="prefetch",
+        )
+    )
+
+    assert loaded == []
+    assert prefetched_lists == [files]
+    assert opened_files == [
+        "model-00003-of-00004.safetensors",
+        "model-00004-of-00004.safetensors",
+        "model-00001-of-00004.safetensors",
+        "model-00002-of-00004.safetensors",
+    ]
+
+
+def test_prefetch_all_checkpoints_slices_files_per_rank(monkeypatch):
+    files = [f"model-{idx:05d}.safetensors" for idx in range(6)]
+    prefetched: list[str] = []
+
+    monkeypatch.setattr(torch.distributed, "is_initialized", lambda: True)
+    monkeypatch.setattr(torch.distributed, "get_rank", lambda: 1)
+    monkeypatch.setattr(torch.distributed, "get_world_size", lambda: 3)
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.weight_utils._prefetch_checkpoint",
+        lambda path: prefetched.append(path),
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.weight_utils.asyncio.to_thread",
+        lambda func, *args, **kwargs: _run_inline(func, *args, **kwargs),
+    )
+
+    async def _run_inline(func, *args, **kwargs):
+        func(*args, **kwargs)
+
+    class ImmediateThread:
+        def __init__(
+            self,
+            group=None,
+            target=None,
+            name=None,
+            args=(),
+            kwargs=None,
+            *,
+            daemon=None,
+        ):
+            self._target = target
+            self._args = args
+            self._kwargs = kwargs or {}
+            self.daemon = daemon
+            self.name = name
+
+        def start(self):
+            if self._target is not None:
+                self._target(*self._args, **self._kwargs)
+
+        def join(self, timeout=None):
+            return None
+
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.weight_utils.threading.Thread",
+        ImmediateThread,
+    )
+
+    _prefetch_all_checkpoints(files)
+
+    assert prefetched == files[1::3]
 
 
 if __name__ == "__main__":

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -374,6 +374,7 @@ class DefaultModelLoader(BaseModelLoader):
 
     @instrument(span_name="Load weights")
     def load_weights(self, model: nn.Module, model_config: ModelConfig) -> None:
+        logger.info_once("Starting load weights", scope="process")
         if model_config.quantization == "torchao":
             quant_config = get_quant_config(model_config, self.load_config)
             if (
@@ -391,6 +392,7 @@ class DefaultModelLoader(BaseModelLoader):
         logger.info_once(
             "Loading weights took %.2f seconds",
             self.counter_after_loading_weights - self.counter_before_loading_weights,
+            scope="process",
         )
         # We only enable strict check for non-quantized models
         # that have loaded weights tracking by default.

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -893,19 +893,6 @@ def safetensors_weights_iterator(
 
     sorted_files = sorted(hf_weights_files, key=_natural_sort_key)
 
-    # Stagger file reading order per rank to reduce I/O contention when
-    # multiple ranks read the same checkpoint files simultaneously.  Each
-    # rank starts at a different offset in the file list so that at any
-    # given moment the ranks are reading *different* files, distributing
-    # the I/O load across the storage backend.  Since tensors are matched
-    # by name, the reading order does not affect correctness.
-    if torch.distributed.is_initialized():
-        rank = torch.distributed.get_rank()
-        world_size = torch.distributed.get_world_size()
-        if world_size > 1 and len(sorted_files) > 1:
-            offset = len(sorted_files) * rank // world_size
-            sorted_files = sorted_files[offset:] + sorted_files[:offset]
-
     fs_type = _get_fs_type(sorted_files)
     is_net_fs = fs_type in ("nfs", "nfs4", "lustre")
     total_bytes = _get_checkpoints_size_bytes(sorted_files)
@@ -965,6 +952,19 @@ def safetensors_weights_iterator(
 
     if should_prefetch:
         _prefetch_all_checkpoints(sorted_files)
+
+    # Stagger file reading order per rank to reduce I/O contention when
+    # multiple ranks read the same checkpoint files simultaneously. Each
+    # rank starts at a different offset in the file list so that at any
+    # given moment the ranks are reading *different* files. This must
+    # happen after prefetch starts so prefetch still slices the original
+    # globally sorted list across ranks.
+    if torch.distributed.is_initialized():
+        rank = torch.distributed.get_rank()
+        world_size = torch.distributed.get_world_size()
+        if world_size > 1 and len(sorted_files) > 1:
+            offset = len(sorted_files) * rank // world_size
+            sorted_files = sorted_files[offset:] + sorted_files[:offset]
 
     leftover_state_dict: dict[str, torch.Tensor] = {}
     for st_file in tqdm(

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -893,6 +893,19 @@ def safetensors_weights_iterator(
 
     sorted_files = sorted(hf_weights_files, key=_natural_sort_key)
 
+    # Stagger file reading order per rank to reduce I/O contention when
+    # multiple ranks read the same checkpoint files simultaneously.  Each
+    # rank starts at a different offset in the file list so that at any
+    # given moment the ranks are reading *different* files, distributing
+    # the I/O load across the storage backend.  Since tensors are matched
+    # by name, the reading order does not affect correctness.
+    if torch.distributed.is_initialized():
+        rank = torch.distributed.get_rank()
+        world_size = torch.distributed.get_world_size()
+        if world_size > 1 and len(sorted_files) > 1:
+            offset = len(sorted_files) * rank // world_size
+            sorted_files = sorted_files[offset:] + sorted_files[:offset]
+
     fs_type = _get_fs_type(sorted_files)
     is_net_fs = fs_type in ("nfs", "nfs4", "lustre")
     total_bytes = _get_checkpoints_size_bytes(sorted_files)


### PR DESCRIPTION
## Purpose

Fix #39030 — In multi-rank TP/EP setups, one rank can take **7x longer** to load weights than the others. A user reported Worker_TP1_EP1 taking **197s** while the other three workers completed in **~27-30s** on a B200 VM with 163 safetensors shards.

**Root cause**: In `safetensors_weights_iterator()`, all ranks iterate checkpoint files in the **same sorted order**. At any moment, all N ranks issue I/O requests for the **same file**, causing storage-level contention, page cache thrashing, and amplified variance for late-starting ranks.

**Fix** (2 changes):

1. **Stagger file reading order per rank** (`weight_utils.py`): Each rank rotates the sorted file list by `offset = len(files) * rank // world_size`, so different ranks read different files at any given moment. This happens **after** `_prefetch_all_checkpoints()` so prefetch still slices the original globally-sorted list correctly. Since tensors are matched by name (not position), reading order does not affect correctness.

2. **Per-rank timing visibility** (`default_loader.py`): Changed weight loading timing logs from `scope="local"` (only local rank 0) to `scope="process"` (every rank reports), making per-rank load-time variance immediately visible without monkeypatching.

**Alternatives considered:**
- *Rank-0-only loading + NCCL broadcast*: Most efficient for I/O but very invasive, touches entire weight loading pipeline — left for follow-up
- *Only rank 0 calls `_prepare_weights()`*: Doesn't address main loading loop contention

**Not duplicating existing work**: No other open PRs address issue #39030.

**AI assistance**: This PR was developed with AI assistance (GitHub Copilot). All changes have been reviewed and understood by the human submitter.

## Test Plan

```bash
# Unit tests for stagger rotation and prefetch ordering
python -m pytest tests/model_executor/test_weight_utils.py -v

# Existing EP weight filter tests (use safetensors_weights_iterator)
python -m pytest tests/model_executor/model_loader/test_ep_weight_filter.py -v

# Lint check
ruff check vllm/model_executor/model_loader/weight_utils.py vllm/model_executor/model_loader/default_loader.py
```

## Test Result

- `test_weight_utils.py`: All tests pass — verifies prefetch receives globally-sorted list while iteration uses rank-rotated list
- `test_ep_weight_filter.py`: All tests pass — confirms no regression in EP filtering (tests run without `torch.distributed`, so stagger is correctly skipped)
- `ruff check`: Clean on both modified files
- The stagger is guarded by `torch.distributed.is_initialized()` — zero behavior change in single-process mode
- Fix is minimal (13 lines added to `weight_utils.py`, 2 lines changed in `default_loader.py`)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
