### PR TITLE
fix: prevent streaming sessions from exceeding max_model_len

### DIFF
--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -54,6 +54,7 @@ def create_scheduler() -> Scheduler:
     vllm_config.model_config = MagicMock()
     vllm_config.model_config.skip_tokenizer_init = True
     vllm_config.model_config.is_multimodal_model = False
+    vllm_config.model_config.is_encoder_decoder = False
     vllm_config.model_config.max_model_len = 1024
     vllm_config.model_config.enable_return_routed_experts = False
     vllm_config.cache_config = MagicMock()
@@ -655,3 +656,33 @@ class TestStreamingScheduler(unittest.TestCase):
         # Session should be finished and removed.
         assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
         assert "audio_session" not in scheduler.requests
+
+    def test_streaming_session_length_capped_waiting_request_does_not_block_queue(
+        self,
+    ):
+        scheduler = create_scheduler()
+        max_model_len = scheduler.max_model_len
+
+        capped = DummyRequest(
+            request_id="audio_session",
+            prompt_token_ids=list(range(max_model_len)),
+            max_tokens=max_model_len,
+        )
+        capped.num_computed_tokens = max_model_len - 1
+        tail = DummyRequest(
+            request_id="tail",
+            prompt_token_ids=[1],
+            max_tokens=max_model_len,
+        )
+
+        scheduler.add_request(capped)
+        scheduler.add_request(tail)
+
+        output = scheduler.schedule()
+
+        assert output.finished_req_ids == {capped.request_id}
+        assert capped.status == RequestStatus.FINISHED_LENGTH_CAPPED
+        assert capped.request_id not in scheduler.requests
+        assert [req.req_id for req in output.scheduled_new_reqs] == [tail.request_id]
+        assert [req.request_id for req in scheduler.running] == [tail.request_id]
+        assert not scheduler.waiting

--- a/tests/v1/streaming_input/test_scheduler_streaming.py
+++ b/tests/v1/streaming_input/test_scheduler_streaming.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import unittest
+from collections import deque
 from unittest.mock import MagicMock
 
 import torch
@@ -572,3 +573,85 @@ class TestStreamingScheduler(unittest.TestCase):
             cached_state_cycle1["prompt_token_ids"]
             is not cached_state_cycle3["prompt_token_ids"]
         ), "Cached states from different cycles should be independent objects."
+
+    def test_streaming_session_max_model_len_cap_via_handle_stopped(self):
+        """Streaming sessions must not exceed max_model_len.
+
+        When a resumable request accumulates tokens past max_model_len
+        through repeated _update_request_as_session calls (e.g. continuous
+        audio streaming), _handle_stopped_request must finish the request
+        with FINISHED_LENGTH_CAPPED instead of re-enqueuing it.
+
+        Regression test for https://github.com/vllm-project/vllm/issues/39996
+        """
+        scheduler = create_scheduler()
+        max_model_len = scheduler.max_model_len  # 1024
+
+        # Create a session with prompt that's near max_model_len.
+        prompt = list(range(max_model_len - 5))  # 1019 tokens
+        session = DummyRequest(
+            request_id="audio_session",
+            prompt_token_ids=prompt,
+            max_tokens=max_model_len,
+        )
+        scheduler.add_request(session)
+        session.num_computed_tokens = len(prompt)
+
+        # Simulate the session being stopped (e.g. EOS) and resumed.
+        session.status = RequestStatus.RUNNING
+        session._output_token_ids = [99]  # One output token
+        session.num_computed_tokens = len(prompt) + 1  # 1020
+
+        # Queue a streaming update that would push past max_model_len.
+        new_tokens = list(range(10))  # 10 new tokens → total = 1020 + 10 = 1030
+        next_chunk = DummyRequest(
+            request_id="audio_session",
+            prompt_token_ids=new_tokens,
+            max_tokens=max_model_len,
+        )
+        update = StreamingUpdate.from_request(next_chunk)
+        session.streaming_queue = deque([update])
+
+        # _handle_stopped_request should detect the overflow.
+        finished = scheduler._handle_stopped_request(session)
+
+        assert finished is True
+        assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
+
+    def test_streaming_session_max_model_len_cap_via_add_request(self):
+        """Streaming sessions must not exceed max_model_len via add_request.
+
+        When a session is in WAITING_FOR_STREAMING_REQ and a new chunk
+        pushes it past max_model_len, add_request must finish the request.
+
+        Regression test for https://github.com/vllm-project/vllm/issues/39996
+        """
+        scheduler = create_scheduler()
+        max_model_len = scheduler.max_model_len  # 1024
+
+        # Create a session near max_model_len.
+        prompt = list(range(max_model_len - 2))  # 1022 tokens
+        session = DummyRequest(
+            request_id="audio_session",
+            prompt_token_ids=prompt,
+            max_tokens=max_model_len,
+        )
+        scheduler.add_request(session)
+
+        # Simulate: session ran, stopped, now waiting for more input.
+        session.num_computed_tokens = len(prompt)
+        session.status = RequestStatus.WAITING_FOR_STREAMING_REQ
+        scheduler.num_waiting_for_streaming_input += 1
+
+        # New streaming chunk pushes past max_model_len.
+        new_tokens = list(range(10))  # 10 new tokens → total = 1022 + 10 = 1032
+        next_chunk = DummyRequest(
+            request_id="audio_session",
+            prompt_token_ids=new_tokens,
+            max_tokens=max_model_len,
+        )
+        scheduler.add_request(next_chunk)
+
+        # Session should be finished and removed.
+        assert session.status == RequestStatus.FINISHED_LENGTH_CAPPED
+        assert "audio_session" not in scheduler.requests

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -671,6 +671,13 @@ class Scheduler(SchedulerInterface):
                     # `request.num_prompt_tokens` to consider the resumed
                     # requests, which have output tokens.
                     num_new_tokens = request.num_tokens - num_computed_tokens
+                    # Clamp to max_model_len (mirrors the RUNNING path
+                    # guard). This is needed for streaming/resumable
+                    # requests whose prompt can grow across updates.
+                    num_new_tokens = min(
+                        num_new_tokens,
+                        self.max_model_len - 1 - num_computed_tokens,
+                    )
                     threshold = self.scheduler_config.long_prefill_token_threshold
                     if 0 < threshold < num_new_tokens:
                         num_new_tokens = threshold
@@ -686,7 +693,10 @@ class Scheduler(SchedulerInterface):
                         break
 
                     num_new_tokens = min(num_new_tokens, token_budget)
-                    assert num_new_tokens > 0
+                    if num_new_tokens <= 0:
+                        # Request has reached max_model_len; skip it so
+                        # check_stop can finish it on the next output step.
+                        break
 
                     # Schedule encoder inputs.
                     if request.has_encoder_inputs:
@@ -1596,6 +1606,20 @@ class Scheduler(SchedulerInterface):
                 # Streaming request finished.
                 return True
             self._update_request_as_session(request, update)
+            # After extending the session with new streaming input, check
+            # if accumulated tokens exceed max_model_len. This prevents a
+            # fatal assertion in the model runner when encoder tokens (e.g.
+            # from continuous audio streaming) grow unboundedly.
+            if request.num_tokens >= self.max_model_len:
+                logger.warning(
+                    "Streaming session %s exceeded max_model_len "
+                    "(%d >= %d) after session update. Finishing request.",
+                    request.request_id,
+                    request.num_tokens,
+                    self.max_model_len,
+                )
+                request.status = RequestStatus.FINISHED_LENGTH_CAPPED
+                return True
         else:
             request.status = RequestStatus.WAITING_FOR_STREAMING_REQ
             self.num_waiting_for_streaming_input += 1
@@ -1745,6 +1769,23 @@ class Scheduler(SchedulerInterface):
             elif update is not None:
                 # Commence next input chunk.
                 self._update_request_as_session(existing, update)
+                # Check if the session exceeded max_model_len after the
+                # update (e.g. continuous audio streaming accumulating
+                # encoder tokens). Finish the request gracefully instead
+                # of letting it crash in the model runner.
+                if existing.num_tokens >= self.max_model_len:
+                    logger.warning(
+                        "Streaming session %s exceeded max_model_len "
+                        "(%d >= %d) after session update. Finishing "
+                        "request.",
+                        existing.request_id,
+                        existing.num_tokens,
+                        self.max_model_len,
+                    )
+                    self.finish_requests(
+                        existing.request_id,
+                        RequestStatus.FINISHED_LENGTH_CAPPED,
+                    )
             else:
                 # Streaming-input session finished.
                 self.finish_requests(request.request_id, RequestStatus.FINISHED_ABORTED)

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -694,9 +694,12 @@ class Scheduler(SchedulerInterface):
 
                     num_new_tokens = min(num_new_tokens, token_budget)
                     if num_new_tokens <= 0:
-                        # Request has reached max_model_len; skip it so
-                        # check_stop can finish it on the next output step.
-                        break
+                        # Finish length-capped waiting requests immediately so
+                        # they do not block later requests in the queue.
+                        self.finish_requests(
+                            request_id, RequestStatus.FINISHED_LENGTH_CAPPED
+                        )
+                        continue
 
                     # Schedule encoder inputs.
                     if request.has_encoder_inputs:


### PR DESCRIPTION
## What's broken?

Long-lived WebSocket sessions (e.g., streaming speech-to-text with Voxtral via `/v1/realtime`) crash with a fatal `AssertionError` after ~15 minutes of continuous audio streaming. The engine dies and cannot recover.

## Who is affected?

Any user running continuous audio streaming through the Realtime WebSocket API with encoder models (e.g., `mistralai/Voxtral-Mini-4B-Realtime-2602`). Short sessions are unaffected — the crash only occurs when accumulated encoder tokens exceed `max_model_len`.

## When does it trigger?

The crash is deterministic: once total tokens (prompt + encoder + output) reach `max_model_len + 1`, the assertion fires. With `max_model_len=16384`, this takes ~15 minutes of continuous audio streaming.

## Where is the bug?

Three missing safeguards in `vllm/v1/core/sched/scheduler.py`:

1. **`_update_request_as_session` (line 1028-1042)**: Extends `prompt_token_ids` and `mm_features` with each streaming update but never checks if the total exceeds `max_model_len`.

2. **WAITING scheduling path (line 673)**: Computes `num_new_tokens = request.num_tokens - num_computed_tokens` without the `max_model_len` clamp that exists in the RUNNING path (line 415-416).

3. **`_handle_stopped_request` / `add_request`**: After `_update_request_as_session` updates the session, neither caller checks if the session now exceeds `max_model_len`.

The assertion that crashes is in `gpu_model_runner.py:_bookkeeping_sync`:
```python
assert end_idx <= self.max_model_len  # end_idx = 16385 > 16384
```

## Why does it happen?

The Realtime WebSocket API continuously streams audio chunks. Each chunk:
1. Gets converted to encoder tokens (`mm_features`) and prompt tokens
2. Is appended to the session via `_update_request_as_session`
3. Previous output tokens are folded back into `prompt_token_ids`

Both `prompt_token_ids` and `mm_features` grow monotonically — there is no eviction, truncation, or `max_model_len` check. When the accumulated total exceeds `max_model_len`, the model runner's safety assertion catches the overflow and crashes instead of handling it gracefully.

## How did we fix it?

Three layers of defense (all in `scheduler.py`):

1. **`_handle_stopped_request`**: After calling `_update_request_as_session`, check if `request.num_tokens >= max_model_len`. If so, finish the request with `FINISHED_LENGTH_CAPPED` instead of re-enqueuing it.

2. **`add_request`**: Same check when a `WAITING_FOR_STREAMING_REQ` session receives a new streaming chunk. Calls `finish_requests()` to cleanly remove it.

3. **WAITING scheduling path**: Added `max_model_len` clamp (`min(num_new_tokens, max_model_len - 1 - num_computed_tokens)`) mirroring the existing RUNNING path guard. Changed `assert num_new_tokens > 0` to a graceful `break` when the clamp yields ≤ 0.

**Backward compatibility**: Default behavior is unchanged — the checks only activate when tokens actually reach `max_model_len`, which doesn't happen in normal (non-streaming) usage.

## How do we know it works?

Added two unit tests in `tests/v1/streaming_input/test_scheduler_streaming.py`:
- `test_streaming_session_max_model_len_cap_via_handle_stopped`: Verifies `_handle_stopped_request` returns `finished=True` with `FINISHED_LENGTH_CAPPED` when a streaming update pushes past `max_model_len`.
- `test_streaming_session_max_model_len_cap_via_add_request`: Verifies `add_request` finishes and removes the session when a new chunk exceeds the limit.

Fixes #39996
