### PR TITLE
fix(docker): add SM103a (GB300) to DeepEP CUDA arch list

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -334,7 +334,7 @@ ARG DEEPEP_COMMIT_HASH=73b6ea4
 ARG NVSHMEM_VER
 RUN --mount=type=cache,target=/root/.cache/uv \
     mkdir -p /tmp/ep_kernels_workspace/dist && \
-    export TORCH_CUDA_ARCH_LIST='9.0a 10.0a' && \
+    export TORCH_CUDA_ARCH_LIST='9.0a 10.0a 10.3a' && \
     /tmp/install_python_libraries.sh \
         --workspace /tmp/ep_kernels_workspace \
         --mode wheel \


### PR DESCRIPTION
## Summary

The `extensions-build` stage in `docker/Dockerfile` hardcodes `TORCH_CUDA_ARCH_LIST='9.0a 10.0a'` for the DeepEP build, which does not include SM103a (GB300 NVL72).

DeepEP relies on NVSHMEM for symmetric memory operations, which require native SASS, PTX forward compatibility is not sufficient. Without SM103a in the arch list, DeepEP fails on GB300 with:
`RuntimeError: Failed: CUDA error /tmp/ep_kernels_workspace/DeepEP/csrc/deep_ep.cpp:226 'invalid resource handle'`

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

