### PR TITLE
[Scheduler] Priority scheduling supports preemption of requests in the running queue by requests in the waiting queue

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -2773,6 +2773,125 @@ def test_priority_scheduling_waiting_queue_order():
     assert waiting_priorities == [1, 2, 3]
 
 
+def test_priority_preemption_at_max_num_seqs():
+    """High-priority waiting request preempts a low-priority running request
+    when max_num_seqs is the bottleneck (no KV-cache pressure).
+
+    Setup: max_num_seqs=2, ample KV blocks.
+    Step 1: lo1 and lo2 (priority 5) enter running.
+    Step 2: hi1 (priority 0) arrives.  max_num_seqs is full, but hi1 has
+            higher priority than both running requests → lo1 or lo2 is
+            preempted and hi1 is scheduled in its place.
+    """
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=2,
+        max_num_batched_tokens=512,
+        num_blocks=10000,
+    )
+
+    lo1, lo2 = create_requests_with_priority(
+        num_requests=2,
+        priorities=[5, 5],
+        arrival_times=[1.0, 2.0],
+        num_tokens=10,
+        req_ids=["lo1", "lo2"],
+    )
+    scheduler.add_request(lo1)
+    scheduler.add_request(lo2)
+
+    output = scheduler.schedule()
+    assert len(scheduler.running) == 2
+
+    model_output = ModelRunnerOutput(
+        req_ids=["lo1", "lo2"],
+        req_id_to_index={"lo1": 0, "lo2": 1},
+        sampled_token_ids=[[100], [100]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+
+    # Now max_num_seqs is full.  Add a high-priority request.
+    hi1 = create_requests_with_priority(
+        num_requests=1,
+        priorities=[0],
+        arrival_times=[3.0],
+        num_tokens=10,
+        req_ids=["hi1"],
+    )[0]
+    scheduler.add_request(hi1)
+
+    output = scheduler.schedule()
+
+    # hi1 must be running.
+    running_ids = {r.request_id for r in scheduler.running}
+    assert "hi1" in running_ids, "hi1 should have been admitted via preemption"
+
+    # Exactly one of the low-priority requests must have been preempted.
+    lo1_req = scheduler.requests["lo1"]
+    lo2_req = scheduler.requests["lo2"]
+    preempted = sum(
+        1
+        for r in (lo1_req, lo2_req)
+        if r.status == RequestStatus.PREEMPTED
+    )
+    assert preempted == 1, "Exactly one low-priority request should be preempted"
+
+    # Total running count must not exceed max_num_seqs.
+    assert len(scheduler.running) <= 2
+
+
+def test_priority_no_capacity_preemption_equal_priority():
+    """No capacity-triggered preemption when the waiting request has the
+    same (or lower) priority as all running requests."""
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=2,
+        max_num_batched_tokens=512,
+        num_blocks=10000,
+    )
+
+    lo1, lo2 = create_requests_with_priority(
+        num_requests=2,
+        priorities=[2, 2],
+        arrival_times=[1.0, 2.0],
+        num_tokens=10,
+        req_ids=["lo1", "lo2"],
+    )
+    scheduler.add_request(lo1)
+    scheduler.add_request(lo2)
+
+    output = scheduler.schedule()
+    assert len(scheduler.running) == 2
+
+    model_output = ModelRunnerOutput(
+        req_ids=["lo1", "lo2"],
+        req_id_to_index={"lo1": 0, "lo2": 1},
+        sampled_token_ids=[[100], [100]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+
+    # Add a request with the *same* priority — must not trigger preemption.
+    eq = create_requests_with_priority(
+        num_requests=1,
+        priorities=[2],
+        arrival_times=[3.0],
+        num_tokens=10,
+        req_ids=["eq1"],
+    )[0]
+    scheduler.add_request(eq)
+
+    output = scheduler.schedule()
+
+    # eq1 must still be waiting; lo1 and lo2 keep running.
+    assert "eq1" not in {r.request_id for r in scheduler.running}
+    assert scheduler.requests["lo1"].status == RequestStatus.RUNNING
+    assert scheduler.requests["lo2"].status == RequestStatus.RUNNING
+
+
 def test_priority_scheduling_fcfs_fallback():
     """Test that FCFS behavior is maintained when all
     requests have same priority."""

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3272,6 +3272,136 @@ def test_priority_capacity_preemption_skips_lora_limited_waiter():
     assert len(scheduler.running) == 2
 
 
+def test_priority_capacity_preemption_keeps_lora_of_admitted_waiter():
+    """Evicting a runner must not discard a LoRA still used by a waiter
+    admitted earlier in the same scheduling pass.
+
+    Cascade in one schedule() call (``max_num_seqs=4``, ``max_loras=2``):
+    w1 (lora-a) evicts r1, then w2 (lora-b) evicts r2 (lora-a).  At that
+    point lora-a is only referenced by w1, which sits in
+    ``scheduled_new_reqs`` — if the discard check only scans
+    ``scheduled_running_reqs``, lora-a leaks out of ``scheduled_loras``
+    and w3 (lora-c) is admitted as a third distinct LoRA in the batch.
+    """
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=4,
+        max_num_batched_tokens=512,
+        num_blocks=10000,
+        lora_config=LoRAConfig(max_loras=2, max_cpu_loras=4),
+    )
+
+    lora_a = LoRARequest("lora-a", 1, "/tmp/lora-a")
+    lora_b = LoRARequest("lora-b", 2, "/tmp/lora-b")
+    lora_c = LoRARequest("lora-c", 3, "/tmp/lora-c")
+
+    r1, r2, r3, r4 = create_requests_with_priority(
+        num_requests=4,
+        priorities=[9, 8, 7, 0],
+        arrival_times=[1.0, 2.0, 3.0, 4.0],
+        num_tokens=10,
+        req_ids=["r1", "r2", "r3", "r4"],
+    )
+    r1.lora_request = lora_a
+    r2.lora_request = lora_a
+    for req in (r1, r2, r3, r4):
+        scheduler.add_request(req)
+
+    output = scheduler.schedule()
+    assert len(scheduler.running) == 4
+
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["r1", "r2", "r3", "r4"],
+            req_id_to_index={"r1": 0, "r2": 1, "r3": 2, "r4": 3},
+            sampled_token_ids=[[100], [100], [100], [100]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    w1, w2, w3 = create_requests_with_priority(
+        num_requests=3,
+        priorities=[1, 2, 3],
+        arrival_times=[5.0, 6.0, 7.0],
+        num_tokens=10,
+        req_ids=["w1", "w2", "w3"],
+    )
+    w1.lora_request = lora_a
+    w2.lora_request = lora_b
+    w3.lora_request = lora_c
+    for req in (w1, w2, w3):
+        scheduler.add_request(req)
+
+    scheduler.schedule()
+
+    running_ids = {r.request_id for r in scheduler.running}
+    assert running_ids == {"r3", "r4", "w1", "w2"}
+    assert scheduler.requests["r1"].status == RequestStatus.PREEMPTED
+    assert scheduler.requests["r2"].status == RequestStatus.PREEMPTED
+    # w3 would be the third distinct LoRA in the batch: must stay waiting
+    # and must not cost r3 a wasted eviction.
+    assert scheduler.requests["r3"].status == RequestStatus.RUNNING
+    assert scheduler.requests["w3"].status == RequestStatus.WAITING
+
+
+def test_priority_capacity_preemption_skips_blocked_waiter():
+    """A blocked top-priority waiter (e.g. WAITING_FOR_REMOTE_KVS) must not
+    stall capacity preemption for admittable lower-priority waiters."""
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=2,
+        max_num_batched_tokens=512,
+        num_blocks=10000,
+    )
+
+    lo1, lo2 = create_requests_with_priority(
+        num_requests=2,
+        priorities=[5, 4],
+        arrival_times=[1.0, 2.0],
+        num_tokens=10,
+        req_ids=["lo1", "lo2"],
+    )
+    scheduler.add_request(lo1)
+    scheduler.add_request(lo2)
+
+    output = scheduler.schedule()
+    assert len(scheduler.running) == 2
+
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["lo1", "lo2"],
+            req_id_to_index={"lo1": 0, "lo2": 1},
+            sampled_token_ids=[[100], [100]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    blocked, hi = create_requests_with_priority(
+        num_requests=2,
+        priorities=[0, 1],
+        arrival_times=[3.0, 4.0],
+        num_tokens=10,
+        req_ids=["blocked", "hi"],
+    )
+    scheduler.add_request(blocked)
+    scheduler.add_request(hi)
+    # Simulate a pending remote KV transfer: promotion fails until the
+    # worker reports the transfer finished.
+    scheduler.requests["blocked"].status = RequestStatus.WAITING_FOR_REMOTE_KVS
+
+    scheduler.schedule()
+
+    running_ids = {r.request_id for r in scheduler.running}
+    assert "hi" in running_ids
+    assert scheduler.requests["lo1"].status == RequestStatus.PREEMPTED
+    assert scheduler.requests["lo2"].status == RequestStatus.RUNNING
+    assert scheduler.requests["blocked"].status == RequestStatus.WAITING_FOR_REMOTE_KVS
+
+
 def test_priority_scheduling_fcfs_fallback():
     """Test that FCFS behavior is maintained when all
     requests have same priority."""

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -3009,7 +3009,7 @@ def test_priority_combined_max_num_seqs_and_kv_preemption():
     scheduler.add_request(lo1)
     scheduler.add_request(lo2)
 
-    output = scheduler.schedule()
+    scheduler.schedule()
     assert len(scheduler.running) == 2
 
     # Intentionally skip update_from_output so lo1/lo2 are not in decode

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -2832,9 +2832,7 @@ def test_priority_preemption_at_max_num_seqs():
     lo1_req = scheduler.requests["lo1"]
     lo2_req = scheduler.requests["lo2"]
     preempted = sum(
-        1
-        for r in (lo1_req, lo2_req)
-        if r.status == RequestStatus.PREEMPTED
+        1 for r in (lo1_req, lo2_req) if r.status == RequestStatus.PREEMPTED
     )
     assert preempted == 1, "Exactly one low-priority request should be preempted"
 
@@ -2890,6 +2888,205 @@ def test_priority_no_capacity_preemption_equal_priority():
     assert "eq1" not in {r.request_id for r in scheduler.running}
     assert scheduler.requests["lo1"].status == RequestStatus.RUNNING
     assert scheduler.requests["lo2"].status == RequestStatus.RUNNING
+
+
+def test_priority_kv_preemption_from_waiting():
+    """High-priority waiting request preempts a low-priority running request
+    when KV-cache (not ``max_num_seqs``) is the bottleneck.
+
+    Block math
+    ----------
+    block_size = 16, num_blocks = 5 (1 null → 4 usable).
+    max_num_seqs = 3 (ample seq headroom).
+
+    Phase 1: lo1 (priority 5, 48 tokens) → 3 blocks.  1 free.
+             Decode → lo1 has 49 tokens (needs 4th block on next schedule).
+    Phase 2: hi1 (priority 0, 32 tokens = 2 blocks) arrives.
+             schedule():
+               - Phase 1 grows lo1 to 4 blocks (0 free).  No preemption.
+               - Phase 2 tries to admit hi1; allocate_slots returns None
+                 because no free blocks remain.  KV-cache preemption
+                 path frees lo1 and re-allocates → hi1 admitted.
+    """
+    block_size = 16
+    num_blocks = 5  # 1 null block → 4 usable
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=3,
+        max_num_batched_tokens=200,
+        num_blocks=num_blocks,
+        block_size=block_size,
+    )
+
+    # --- Phase 1: low-priority request starts running ---
+    lo1 = create_requests_with_priority(
+        num_requests=1,
+        priorities=[5],
+        arrival_times=[1.0],
+        num_tokens=block_size * 3,  # exactly 3 blocks
+        req_ids=["lo1"],
+    )[0]
+    scheduler.add_request(lo1)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 1
+
+    # Decode lo1 → 49 tokens, needs a 4th block on the next allocate.
+    model_output = ModelRunnerOutput(
+        req_ids=["lo1"],
+        req_id_to_index={"lo1": 0},
+        sampled_token_ids=[[100]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+
+    # --- Phase 2: high-priority request arrives with no KV headroom ---
+    hi1 = create_requests_with_priority(
+        num_requests=1,
+        priorities=[0],
+        arrival_times=[2.0],
+        num_tokens=block_size * 2,  # 2 blocks needed for prefill
+        req_ids=["hi1"],
+    )[0]
+    scheduler.add_request(hi1)
+
+    output = scheduler.schedule()
+
+    # hi1 must be admitted; lo1 must be the preemption victim.
+    running_ids = {r.request_id for r in scheduler.running}
+    assert "hi1" in running_ids, "hi1 should have been admitted via KV-cache preemption"
+    assert scheduler.requests["lo1"].status == RequestStatus.PREEMPTED, (
+        "Low-priority lo1 should have been preempted to free KV blocks"
+    )
+    # Seq headroom was never the bottleneck.
+    assert len(scheduler.running) <= 3
+
+
+def test_priority_combined_max_num_seqs_and_kv_preemption():
+    """Both ``max_num_seqs`` and KV-cache are bottlenecks at once.
+
+    The high-priority waiting request first triggers a ``max_num_seqs``
+    preemption (running queue drops below the seq cap); a single
+    preemption does not free enough KV blocks, so the KV-cache
+    preemption path in Phase 2 fires again to make room.
+
+    Block math
+    ----------
+    block_size = 16, num_blocks = 5 (1 null → 4 usable).
+    max_num_seqs = 2.
+
+    Setup: lo1 and lo2 (priority 5, 32 tokens = 2 blocks each) are admitted
+           on the first schedule().  4 blocks used, 0 free, running full.
+           ``update_from_output`` is not called, so on the next schedule()
+           Phase 1 has no decode work for lo1/lo2 (``num_new_tokens == 0``)
+           and skips them — no Phase 1 preemption.
+    Step:  hi1 (priority 0, 48 tokens = 3 blocks) arrives.
+             Phase 2 iter 1: running == 2 == max_num_seqs → max_num_seqs
+               path preempts lo2 (latest arrival among priority 5).  2 blocks
+               freed, ``continue``.
+             Phase 2 iter 2: running == 1 < 2 → normal path; allocate
+               returns None (need 3, have 2 free).  KV-cache path preempts
+               lo1, freeing 2 more blocks.  Re-allocate succeeds and hi1
+               is admitted.
+    """
+    block_size = 16
+    num_blocks = 5  # 1 null block → 4 usable
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=2,
+        max_num_batched_tokens=512,
+        num_blocks=num_blocks,
+        block_size=block_size,
+    )
+
+    lo1, lo2 = create_requests_with_priority(
+        num_requests=2,
+        priorities=[5, 5],
+        arrival_times=[1.0, 2.0],
+        num_tokens=block_size * 2,  # 2 blocks each
+        req_ids=["lo1", "lo2"],
+    )
+    scheduler.add_request(lo1)
+    scheduler.add_request(lo2)
+
+    output = scheduler.schedule()
+    assert len(scheduler.running) == 2
+
+    # Intentionally skip update_from_output so lo1/lo2 are not in decode
+    # mode on the next schedule().  This avoids Phase 1 KV preemption and
+    # forces both Phase 2 preemption paths to fire for hi1.
+
+    hi1 = create_requests_with_priority(
+        num_requests=1,
+        priorities=[0],
+        arrival_times=[3.0],
+        num_tokens=block_size * 3,  # 3 blocks needed; > one victim's blocks
+        req_ids=["hi1"],
+    )[0]
+    scheduler.add_request(hi1)
+
+    scheduler.schedule()
+
+    running_ids = {r.request_id for r in scheduler.running}
+    assert "hi1" in running_ids, (
+        "hi1 should have been admitted via combined seq + KV preemption"
+    )
+    # Both low-priority requests must have been preempted: one for the
+    # seq slot, one for the remaining KV deficit.
+    assert scheduler.requests["lo1"].status == RequestStatus.PREEMPTED
+    assert scheduler.requests["lo2"].status == RequestStatus.PREEMPTED
+    assert len(scheduler.running) <= 2
+
+
+def test_priority_no_kv_preemption_for_equal_priority():
+    """Equal-priority waiting request must not displace a running request
+    even under KV-cache pressure."""
+    block_size = 16
+    num_blocks = 5  # same setup as the KV-preemption test
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=3,
+        max_num_batched_tokens=200,
+        num_blocks=num_blocks,
+        block_size=block_size,
+    )
+
+    lo1 = create_requests_with_priority(
+        num_requests=1,
+        priorities=[5],
+        arrival_times=[1.0],
+        num_tokens=block_size * 3,
+        req_ids=["lo1"],
+    )[0]
+    scheduler.add_request(lo1)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 1
+
+    model_output = ModelRunnerOutput(
+        req_ids=["lo1"],
+        req_id_to_index={"lo1": 0},
+        sampled_token_ids=[[100]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(output, model_output)
+
+    # Same priority as lo1 — must not trigger KV preemption.
+    eq1 = create_requests_with_priority(
+        num_requests=1,
+        priorities=[5],
+        arrival_times=[2.0],
+        num_tokens=block_size * 2,
+        req_ids=["eq1"],
+    )[0]
+    scheduler.add_request(eq1)
+
+    scheduler.schedule()
+
+    # eq1 must still be waiting; lo1 must keep running.
+    assert "eq1" not in {r.request_id for r in scheduler.running}
+    assert scheduler.requests["lo1"].status == RequestStatus.RUNNING
 
 
 def test_priority_scheduling_fcfs_fallback():

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -11,12 +11,14 @@ from vllm.config import (
     CacheConfig,
     ECTransferConfig,
     KVTransferConfig,
+    LoRAConfig,
     ModelConfig,
     SchedulerConfig,
     SpeculativeConfig,
     VllmConfig,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.lora.request import LoRARequest
 from vllm.multimodal.inputs import (
     MultiModalFeatureSpec,
     MultiModalKwargsItem,
@@ -2202,6 +2204,7 @@ def create_scheduler_with_priority(
     use_ec_connector: bool = False,
     ec_role: str | None = None,
     use_v2_model_runner: bool | None = None,
+    lora_config: LoRAConfig | None = None,
 ) -> Scheduler:
     """Create scheduler with priority policy enabled.
 
@@ -2276,6 +2279,7 @@ def create_scheduler_with_priority(
         kv_transfer_config=kv_transfer_config,
         speculative_config=speculative_config,
         ec_transfer_config=ec_transfer_config,
+        lora_config=lora_config,
     )
     kv_cache_config = KVCacheConfig(
         num_blocks=num_blocks,  # A large number of blocks to hold all requests
@@ -3087,6 +3091,185 @@ def test_priority_no_kv_preemption_for_equal_priority():
     # eq1 must still be waiting; lo1 must keep running.
     assert "eq1" not in {r.request_id for r in scheduler.running}
     assert scheduler.requests["lo1"].status == RequestStatus.RUNNING
+
+
+def test_priority_no_capacity_preemption_equal_priority_earlier_arrival():
+    """An equal-priority waiting request that arrived *earlier* than a
+    runner must NOT trigger a max_num_seqs preemption.
+
+    Comparing with ``Request.__lt__`` would preempt here because the
+    tiebreaker falls back to ``arrival_time``.  Since a preempted request
+    keeps its earlier arrival time, it would immediately reclaim the slot
+    on the next step — ping-pong.  Preemption must key on ``priority``
+    only.
+    """
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=2,
+        max_num_batched_tokens=512,
+        num_blocks=10000,
+    )
+
+    lo1, lo2 = create_requests_with_priority(
+        num_requests=2,
+        priorities=[2, 2],
+        arrival_times=[2.0, 3.0],
+        num_tokens=10,
+        req_ids=["lo1", "lo2"],
+    )
+    scheduler.add_request(lo1)
+    scheduler.add_request(lo2)
+
+    output = scheduler.schedule()
+    assert len(scheduler.running) == 2
+
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["lo1", "lo2"],
+            req_id_to_index={"lo1": 0, "lo2": 1},
+            sampled_token_ids=[[100], [100]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    # Same priority as the runners but an EARLIER arrival time (1.0).
+    eq = create_requests_with_priority(
+        num_requests=1,
+        priorities=[2],
+        arrival_times=[1.0],
+        num_tokens=10,
+        req_ids=["eq1"],
+    )[0]
+    scheduler.add_request(eq)
+
+    scheduler.schedule()
+
+    # No preemption: equal priority must never displace a runner.
+    assert "eq1" not in {r.request_id for r in scheduler.running}
+    assert scheduler.requests["lo1"].status == RequestStatus.RUNNING
+    assert scheduler.requests["lo2"].status == RequestStatus.RUNNING
+    assert scheduler.requests["eq1"].status == RequestStatus.WAITING
+
+
+def test_priority_no_kv_preemption_equal_priority_earlier_arrival():
+    """KV-cache preemption must also key on priority only: an equal-priority
+    waiting request arriving earlier than the runner must not evict it."""
+    block_size = 16
+    num_blocks = 5  # 1 null block → 4 usable
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=3,
+        max_num_batched_tokens=200,
+        num_blocks=num_blocks,
+        block_size=block_size,
+    )
+
+    lo1 = create_requests_with_priority(
+        num_requests=1,
+        priorities=[5],
+        arrival_times=[1.0],
+        num_tokens=block_size * 3,
+        req_ids=["lo1"],
+    )[0]
+    scheduler.add_request(lo1)
+
+    output = scheduler.schedule()
+    assert len(output.scheduled_new_reqs) == 1
+
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["lo1"],
+            req_id_to_index={"lo1": 0},
+            sampled_token_ids=[[100]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    # Same priority as lo1 but an EARLIER arrival time (0.5 < 1.0).
+    eq1 = create_requests_with_priority(
+        num_requests=1,
+        priorities=[5],
+        arrival_times=[0.5],
+        num_tokens=block_size * 2,
+        req_ids=["eq1"],
+    )[0]
+    scheduler.add_request(eq1)
+
+    scheduler.schedule()
+
+    assert "eq1" not in {r.request_id for r in scheduler.running}
+    assert scheduler.requests["lo1"].status == RequestStatus.RUNNING
+
+
+def test_priority_capacity_preemption_skips_lora_limited_waiter():
+    """A higher-priority waiting request that would exceed ``max_loras``
+    must not cause a wasted eviction at ``max_num_seqs``.
+
+    Both runners share a single LoRA (``max_loras=1``).  A higher-priority
+    waiter needs a *different* LoRA, so it cannot be admitted this step.
+    Preemption must be skipped rather than evicting a runner for a request
+    that the LoRA limit rejects anyway.
+    """
+    scheduler = create_scheduler_with_priority(
+        max_num_seqs=2,
+        max_num_batched_tokens=512,
+        num_blocks=10000,
+        lora_config=LoRAConfig(max_loras=1, max_cpu_loras=2),
+    )
+
+    lora_a = LoRARequest("lora-a", 1, "/tmp/lora-a")
+    lora_b = LoRARequest("lora-b", 2, "/tmp/lora-b")
+
+    lo1, lo2 = create_requests_with_priority(
+        num_requests=2,
+        priorities=[5, 5],
+        arrival_times=[1.0, 2.0],
+        num_tokens=10,
+        req_ids=["lo1", "lo2"],
+    )
+    lo1.lora_request = lora_a
+    lo2.lora_request = lora_a
+    scheduler.add_request(lo1)
+    scheduler.add_request(lo2)
+
+    output = scheduler.schedule()
+    assert len(scheduler.running) == 2
+
+    scheduler.update_from_output(
+        output,
+        ModelRunnerOutput(
+            req_ids=["lo1", "lo2"],
+            req_id_to_index={"lo1": 0, "lo2": 1},
+            sampled_token_ids=[[100], [100]],
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+        ),
+    )
+
+    # Higher priority, but needs a new LoRA that exceeds max_loras=1.
+    hi1 = create_requests_with_priority(
+        num_requests=1,
+        priorities=[0],
+        arrival_times=[3.0],
+        num_tokens=10,
+        req_ids=["hi1"],
+    )[0]
+    hi1.lora_request = lora_b
+    scheduler.add_request(hi1)
+
+    scheduler.schedule()
+
+    # No runner was evicted: hi1 could not be admitted anyway.
+    assert "hi1" not in {r.request_id for r in scheduler.running}
+    assert scheduler.requests["lo1"].status == RequestStatus.RUNNING
+    assert scheduler.requests["lo2"].status == RequestStatus.RUNNING
+    assert scheduler.requests["hi1"].status == RequestStatus.WAITING
+    assert len(scheduler.running) == 2
 
 
 def test_priority_scheduling_fcfs_fallback():

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -679,9 +679,15 @@ class Scheduler(SchedulerInterface):
                     and victim.lora_request.lora_int_id > 0
                 ):
                     lora_id = victim.lora_request.lora_int_id
+                    # Waiting requests admitted earlier in this pass also
+                    # occupy LoRA slots in the batch, not only running ones.
                     if not any(
                         r.lora_request and r.lora_request.lora_int_id == lora_id
-                        for r in scheduled_running_reqs
+                        for r in itertools.chain(
+                            scheduled_running_reqs,
+                            scheduled_new_reqs,
+                            scheduled_resumed_reqs,
+                        )
                     ):
                         scheduled_loras.discard(lora_id)
             self._preempt_request(victim, scheduled_timestamp)
@@ -712,13 +718,16 @@ class Scheduler(SchedulerInterface):
                         top_waiting = candidate_queue.peek_request()
                         # Don't preempt for a request that cannot be
                         # admitted yet (e.g. waiting for grammar/KV
-                        # transfer). Defer to the next schedule() call.
+                        # transfer); skip it so the next candidate can
+                        # still be considered.
                         if self._is_blocked_waiting_status(
                             top_waiting.status
                         ) and not self._try_promote_blocked_waiting_request(
                             top_waiting
                         ):
-                            break
+                            candidate_queue.pop_request()
+                            step_skipped_waiting.prepend_request(top_waiting)
+                            continue
                         # Don't evict a runner for a waiting request that
                         # max_loras would itself reject this step; skip it
                         # so the eviction is not wasted.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -719,6 +719,19 @@ class Scheduler(SchedulerInterface):
                             top_waiting
                         ):
                             break
+                        # Don't evict a runner for a waiting request that
+                        # max_loras would itself reject this step; skip it
+                        # so the eviction is not wasted.
+                        if (
+                            self.lora_config
+                            and top_waiting.lora_request
+                            and len(scheduled_loras) == self.lora_config.max_loras
+                            and top_waiting.lora_request.lora_int_id
+                            not in scheduled_loras
+                        ):
+                            candidate_queue.pop_request()
+                            step_skipped_waiting.prepend_request(top_waiting)
+                            continue
                         lowest_running = max(
                             self.running,
                             key=lambda r: (
@@ -727,7 +740,11 @@ class Scheduler(SchedulerInterface):
                                 r.request_id,
                             ),
                         )
-                        if top_waiting < lowest_running:
+                        # Preempt only for strictly higher priority (lower
+                        # numeric value). Equal priority must not preempt:
+                        # a preempted request keeps its arrival time and
+                        # would reclaim the slot next step, causing churn.
+                        if top_waiting.priority < lowest_running.priority:
                             _evict_running_for_waiting(lowest_running)
                             continue
                     break
@@ -985,11 +1002,6 @@ class Scheduler(SchedulerInterface):
                 # Mirrors the Phase 1 preempt-one-and-retry loop at
                 # `scheduler.py:423-468` so admit-time KV pressure is
                 # handled symmetrically to in-flight KV pressure.
-                request_key = (
-                    request.priority,
-                    request.arrival_time,
-                    request.request_id,
-                )
                 reserved_blocks = 0
                 if load_kv_async:
                     # An async load holds its blocks for the whole transfer with
@@ -1016,10 +1028,12 @@ class Scheduler(SchedulerInterface):
                         break
                     if self.policy != SchedulingPolicy.PRIORITY:
                         break
+                    # Only strictly-higher-priority requests may evict a
+                    # runner. Equal priority must not preempt to avoid
+                    # ping-pong (a preempted request keeps its arrival
+                    # time and would reclaim the blocks next step).
                     candidates = [
-                        r
-                        for r in self.running
-                        if request_key < (r.priority, r.arrival_time, r.request_id)
+                        r for r in self.running if request.priority < r.priority
                     ]
                     if not candidates:
                         break

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -719,6 +719,22 @@ class Scheduler(SchedulerInterface):
                                         .get_num_encoder_embeds(i)
                                         for i in evicted_enc
                                     )
+                                if (
+                                    self.lora_config
+                                    and lowest_running.lora_request
+                                    and lowest_running.lora_request
+                                    .lora_int_id > 0
+                                ):
+                                    lora_id = (
+                                        lowest_running.lora_request.lora_int_id
+                                    )
+                                    if not any(
+                                        r.lora_request
+                                        and r.lora_request.lora_int_id
+                                        == lora_id
+                                        for r in scheduled_running_reqs
+                                    ):
+                                        scheduled_loras.discard(lora_id)
                             self._preempt_request(
                                 lowest_running, scheduled_timestamp
                             )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -654,6 +654,39 @@ class Scheduler(SchedulerInterface):
             )
             assert len(scheduled_loras) <= self.lora_config.max_loras
 
+        def _evict_running_for_waiting(victim: Request) -> None:
+            """Preempt a running request to free a seq slot and/or KV
+            blocks for a higher-priority waiting request, undoing any
+            scheduling state already accumulated for the victim in this
+            step.
+            """
+            nonlocal token_budget, encoder_compute_budget
+            self.running.remove(victim)
+            v_id = victim.request_id
+            if victim in scheduled_running_reqs:
+                scheduled_running_reqs.remove(victim)
+                token_budget += num_scheduled_tokens.pop(v_id)
+                req_to_new_blocks.pop(v_id)
+                scheduled_spec_decode_tokens.pop(v_id, None)
+                evicted_enc = scheduled_encoder_inputs.pop(v_id, None)
+                if evicted_enc:
+                    encoder_compute_budget += sum(
+                        victim.get_num_encoder_embeds(i) for i in evicted_enc
+                    )
+                if (
+                    self.lora_config
+                    and victim.lora_request
+                    and victim.lora_request.lora_int_id > 0
+                ):
+                    lora_id = victim.lora_request.lora_int_id
+                    if not any(
+                        r.lora_request and r.lora_request.lora_int_id == lora_id
+                        for r in scheduled_running_reqs
+                    ):
+                        scheduled_loras.discard(lora_id)
+            self._preempt_request(victim, scheduled_timestamp)
+            preempted_reqs.append(victim)
+
         # Next, schedule the WAITING requests.
         # NOTE: Phase 2 is intentionally skipped when Phase 1 caused any
         # preemption (preempted_reqs is non-empty).  Mixing memory-pressure
@@ -674,9 +707,7 @@ class Scheduler(SchedulerInterface):
                         # max_num_seqs (not memory) is the bottleneck.
                         # The outer while condition guarantees at least one
                         # queue is non-empty, so the result is never None.
-                        candidate_queue = (
-                            self._select_waiting_queue_for_scheduling()
-                        )
+                        candidate_queue = self._select_waiting_queue_for_scheduling()
                         assert candidate_queue is not None
                         top_waiting = candidate_queue.peek_request()
                         # Don't preempt for a request that cannot be
@@ -697,48 +728,7 @@ class Scheduler(SchedulerInterface):
                             ),
                         )
                         if top_waiting < lowest_running:
-                            self.running.remove(lowest_running)
-                            lp_req_id = lowest_running.request_id
-                            if lowest_running in scheduled_running_reqs:
-                                scheduled_running_reqs.remove(
-                                    lowest_running
-                                )
-                                token_budget += num_scheduled_tokens.pop(
-                                    lp_req_id
-                                )
-                                req_to_new_blocks.pop(lp_req_id)
-                                scheduled_spec_decode_tokens.pop(
-                                    lp_req_id, None
-                                )
-                                evicted_enc = scheduled_encoder_inputs.pop(
-                                    lp_req_id, None
-                                )
-                                if evicted_enc:
-                                    encoder_compute_budget += sum(
-                                        lowest_running
-                                        .get_num_encoder_embeds(i)
-                                        for i in evicted_enc
-                                    )
-                                if (
-                                    self.lora_config
-                                    and lowest_running.lora_request
-                                    and lowest_running.lora_request
-                                    .lora_int_id > 0
-                                ):
-                                    lora_id = (
-                                        lowest_running.lora_request.lora_int_id
-                                    )
-                                    if not any(
-                                        r.lora_request
-                                        and r.lora_request.lora_int_id
-                                        == lora_id
-                                        for r in scheduled_running_reqs
-                                    ):
-                                        scheduled_loras.discard(lora_id)
-                            self._preempt_request(
-                                lowest_running, scheduled_timestamp
-                            )
-                            preempted_reqs.append(lowest_running)
+                            _evict_running_for_waiting(lowest_running)
                             continue
                     break
 
@@ -990,6 +980,16 @@ class Scheduler(SchedulerInterface):
                         for i in encoder_inputs_to_schedule
                     )
 
+                # Allocate KV blocks, retrying after preempting strictly
+                # lower-priority running requests under PRIORITY policy.
+                # Mirrors the Phase 1 preempt-one-and-retry loop at
+                # `scheduler.py:423-468` so admit-time KV pressure is
+                # handled symmetrically to in-flight KV pressure.
+                request_key = (
+                    request.priority,
+                    request.arrival_time,
+                    request.request_id,
+                )
                 reserved_blocks = 0
                 if load_kv_async:
                     # An async load holds its blocks for the whole transfer with
@@ -998,19 +998,36 @@ class Scheduler(SchedulerInterface):
                     # avoid deadlock and predictable preemptions.
                     reserved_blocks = self._inflight_prefill_reserved_blocks()
 
-                new_blocks = self.kv_cache_manager.allocate_slots(
-                    request,
-                    num_new_tokens,
-                    num_new_computed_tokens=num_new_local_computed_tokens,
-                    new_computed_blocks=new_computed_blocks,
-                    num_lookahead_tokens=effective_lookahead_tokens,
-                    num_external_computed_tokens=num_external_computed_tokens,
-                    delay_cache_blocks=load_kv_async,
-                    num_encoder_tokens=num_encoder_tokens,
-                    full_sequence_must_fit=self.scheduler_reserve_full_isl,
-                    reserved_blocks=reserved_blocks,
-                    has_scheduled_reqs=bool(self.running),
-                )
+                while True:
+                    new_blocks = self.kv_cache_manager.allocate_slots(
+                        request,
+                        num_new_tokens,
+                        num_new_computed_tokens=num_new_local_computed_tokens,
+                        new_computed_blocks=new_computed_blocks,
+                        num_lookahead_tokens=effective_lookahead_tokens,
+                        num_external_computed_tokens=num_external_computed_tokens,
+                        delay_cache_blocks=load_kv_async,
+                        num_encoder_tokens=num_encoder_tokens,
+                        full_sequence_must_fit=self.scheduler_reserve_full_isl,
+                        reserved_blocks=reserved_blocks,
+                        has_scheduled_reqs=bool(self.running),
+                    )
+                    if new_blocks is not None:
+                        break
+                    if self.policy != SchedulingPolicy.PRIORITY:
+                        break
+                    candidates = [
+                        r
+                        for r in self.running
+                        if request_key < (r.priority, r.arrival_time, r.request_id)
+                    ]
+                    if not candidates:
+                        break
+                    victim = max(
+                        candidates,
+                        key=lambda r: (r.priority, r.arrival_time, r.request_id),
+                    )
+                    _evict_running_for_waiting(victim)
 
                 if new_blocks is None:
                     # The request cannot be scheduled.

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -655,6 +655,11 @@ class Scheduler(SchedulerInterface):
             assert len(scheduled_loras) <= self.lora_config.max_loras
 
         # Next, schedule the WAITING requests.
+        # NOTE: Phase 2 is intentionally skipped when Phase 1 caused any
+        # preemption (preempted_reqs is non-empty).  Mixing memory-pressure
+        # preemption with capacity-triggered preemption in a single cycle
+        # would risk cascading evictions; deferring to the next step keeps
+        # the running queue stable.
         if not preempted_reqs and self._pause_state == PauseState.UNPAUSED:
             step_skipped_waiting = create_request_queue(self.policy)
 
@@ -663,6 +668,62 @@ class Scheduler(SchedulerInterface):
                 # in `running` but still hold a model-runner request slot.
                 num_running = len(self.running) + self.num_waiting_for_streaming_input
                 if num_running >= self.max_num_running_reqs:
+                    if self.policy == SchedulingPolicy.PRIORITY and self.running:
+                        # In priority mode, a high-priority waiting request
+                        # may preempt a lower-priority running request when
+                        # max_num_seqs (not memory) is the bottleneck.
+                        # The outer while condition guarantees at least one
+                        # queue is non-empty, so the result is never None.
+                        candidate_queue = (
+                            self._select_waiting_queue_for_scheduling()
+                        )
+                        assert candidate_queue is not None
+                        top_waiting = candidate_queue.peek_request()
+                        # Don't preempt for a request that cannot be
+                        # admitted yet (e.g. waiting for grammar/KV
+                        # transfer). Defer to the next schedule() call.
+                        if self._is_blocked_waiting_status(
+                            top_waiting.status
+                        ) and not self._try_promote_blocked_waiting_request(
+                            top_waiting
+                        ):
+                            break
+                        lowest_running = max(
+                            self.running,
+                            key=lambda r: (
+                                r.priority,
+                                r.arrival_time,
+                                r.request_id,
+                            ),
+                        )
+                        if top_waiting < lowest_running:
+                            self.running.remove(lowest_running)
+                            lp_req_id = lowest_running.request_id
+                            if lowest_running in scheduled_running_reqs:
+                                scheduled_running_reqs.remove(
+                                    lowest_running
+                                )
+                                token_budget += num_scheduled_tokens.pop(
+                                    lp_req_id
+                                )
+                                req_to_new_blocks.pop(lp_req_id)
+                                scheduled_spec_decode_tokens.pop(
+                                    lp_req_id, None
+                                )
+                                evicted_enc = scheduled_encoder_inputs.pop(
+                                    lp_req_id, None
+                                )
+                                if evicted_enc:
+                                    encoder_compute_budget += sum(
+                                        lowest_running
+                                        .get_num_encoder_embeds(i)
+                                        for i in evicted_enc
+                                    )
+                            self._preempt_request(
+                                lowest_running, scheduled_timestamp
+                            )
+                            preempted_reqs.append(lowest_running)
+                            continue
                     break
 
                 request_queue = self._select_waiting_queue_for_scheduling()


### PR DESCRIPTION
## Purpose
Priority scheduling supports preemption of requests in the running queue by requests in the waiting queue

Fixes: #40004

## Test Plan

```bash
pytest tests/v1/core/test_scheduler.py::test_priority_preemption_at_max_num_seqs
```

## Test Result

```bash
======================================================== test session starts =========================================================
platform linux -- Python 3.12.13, pytest-9.0.3, pluggy-1.6.0
rootdir: /home/name/.test/.gpu/vllm
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 1 item                                                                                                                     

tests/v1/core/test_scheduler.py .                                                                                              [100%]

========================================================== warnings summary ==========================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: 14 warnings
  /home/name/.test/.gpu/vllm/.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

tests/v1/core/test_scheduler.py::test_priority_preemption_at_max_num_seqs
  /home/name/.test/.gpu/vllm/.venv/lib/python3.12/site-packages/transformers/models/gpt2/tokenization_gpt2.py:110: DeprecationWarning: Deprecated in 0.9.0: BPE.__init__ will not create from files anymore, try `BPE.from_file` instead
    BPE(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================== 1 passed, 17 warnings in 3.86s ===================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

