### PR TITLE
Cache dataclasses.fields() in multimodal serialization path

### DIFF
--- a/vllm/v1/serial_utils.py
+++ b/vllm/v1/serial_utils.py
@@ -51,6 +51,9 @@ MMF_CLASS_TO_FACTORY: dict[type[BaseMultiModalField], str] = {
     MultiModalBatchedField: "batched",
 }
 
+# Cache for dataclasses.fields() results, keyed by class type.
+_DATACLASS_FIELDS_CACHE: dict[type, tuple[dataclasses.Field, ...]] = {}
+
 bytestr: TypeAlias = bytes | bytearray | memoryview | zmq.Frame
 
 
@@ -306,7 +309,12 @@ class MsgpackEncoder:
 
         # We just need to copy all of the field values in order
         # which will be then used to reconstruct the field.
-        factory_kw = {f.name: getattr(field, f.name) for f in dataclasses.fields(field)}
+        cls = field.__class__
+        fields = _DATACLASS_FIELDS_CACHE.get(cls)
+        if fields is None:
+            fields = dataclasses.fields(field)
+            _DATACLASS_FIELDS_CACHE[cls] = fields
+        factory_kw = {f.name: getattr(field, f.name) for f in fields}
         return name, factory_kw
 
 


### PR DESCRIPTION
## Summary

- Cache `dataclasses.fields()` results by class type in a module-level dict in `vllm/v1/serial_utils.py`
- `dataclasses.fields()` constructs a new tuple via generator expression on every call. In `_encode_mm_field()`, this is invoked 16-24 times per request across only 3 unique dataclass types (`MultiModalFlatField`, `MultiModalSharedField`, `MultiModalBatchedField`), creating redundant tuple objects each time.
- The fix adds a `_DATACLASS_FIELDS_CACHE` dict that stores the fields tuple keyed by class type, turning repeated O(n) tuple constructions into O(1) dict lookups after the first call.

## Test plan

- [ ] Existing multimodal tests pass (no behavioral change — `dataclasses.fields()` is deterministic for a given class)
- [ ] Verified the cache is populated with the 3 expected field class types

🤖 Generated with [Claude Code](https://claude.com/claude-code)