### PR TITLE
[Attention] Add flash-attn-4 CuTe DSL backend for SM120

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -134,11 +134,18 @@ def _get_backend_priorities(
                 AttentionBackendEnum.TURBOQUANT,
             ]
         elif device_capability.major == 12:
-            # SM120 (consumer Blackwell): flash-attn-4 CuTe DSL kernels
-            # have native SM120 support. FlashInfer is fallback.
+            # SM120 (consumer Blackwell): FlashInfer is the default —
+            # its fmha_v2 HMMA path is validated on SM120 and is what
+            # existing vLLM users expect. FLASH_ATTN_4 exposes FA4's
+            # CuTe DSL kernels (split-KV, block-sparse, TMA forward,
+            # FA4 dropout) as an opt-in via
+            # `--attention-backend FLASH_ATTN_4`; it requires
+            # `enforce_eager=True` (no CUDA graph support yet) and
+            # loads its kernels via the HF Kernels Hub, so installing
+            # `flash-attn-4` upstream is not required.
             return [
-                AttentionBackendEnum.FLASH_ATTN_4,
                 AttentionBackendEnum.FLASHINFER,
+                AttentionBackendEnum.FLASH_ATTN_4,
                 AttentionBackendEnum.TRITON_ATTN,
                 AttentionBackendEnum.FLEX_ATTENTION,
             ]

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -133,6 +133,15 @@ def _get_backend_priorities(
                 AttentionBackendEnum.FLEX_ATTENTION,
                 AttentionBackendEnum.TURBOQUANT,
             ]
+        elif device_capability.major == 12:
+            # SM120 (consumer Blackwell): flash-attn-4 CuTe DSL kernels
+            # have native SM120 support. FlashInfer is fallback.
+            return [
+                AttentionBackendEnum.FLASH_ATTN_4,
+                AttentionBackendEnum.FLASHINFER,
+                AttentionBackendEnum.TRITON_ATTN,
+                AttentionBackendEnum.FLEX_ATTENTION,
+            ]
         else:
             return [
                 AttentionBackendEnum.FLASH_ATTN,

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -316,8 +316,13 @@ def supports_fmha_v2_sm120_attention() -> bool:
     """
     SM120 (consumer Blackwell) supports attention via flashinfer's fmha_v2
     HMMA kernels. These are JIT-compiled (no prebuilt cubins needed), so no
-    artifactory access is required. Supports sinks for prefill.
-    Sliding window is NOT yet supported by fmha_v2 SM120 kernels.
+    artifactory access is required. Supports attention sinks for prefill.
+    Sliding window is NOT supported by fmha_v2 SM120 kernels today — the
+    kernel explicitly rejects window_left != -1 with "Sliding window
+    attention is not yet supported for FMHAv2 on SM120 (Blackwell)".
+    Callers must disqualify this path via
+    ``use_trtllm_attention(..., has_sliding_window=True)`` when any layer
+    sets a sliding window.
     """
     if envs.VLLM_BATCH_INVARIANT:
         return False
@@ -363,6 +368,7 @@ def use_trtllm_attention(
     force_use_trtllm: bool | None = None,
     has_sinks: bool = False,
     has_spec: bool = False,
+    has_sliding_window: bool = False,
 ) -> bool:
     """Return `True` if TRTLLM attention is used."""
 
@@ -376,6 +382,20 @@ def use_trtllm_attention(
             "Trtllm does not support returning LSE and as a result "
             "does not support DCP, reverting to FlashInfer"
         )
+        return False
+
+    # SM120 fmha_v2 does not support sliding window; disqualify when the
+    # only available trtllm-family path is fmha_v2 and any layer has one.
+    if (
+        has_sliding_window
+        and supports_fmha_v2_sm120_attention()
+        and not supports_trtllm_attention()
+    ):
+        if force_use_trtllm:
+            logger.warning_once(
+                "SM120 fmha_v2 does not support sliding window; falling "
+                "back to the standard flashinfer wrapper path."
+            )
         return False
 
     # The platform is not supported

--- a/vllm/utils/flashinfer.py
+++ b/vllm/utils/flashinfer.py
@@ -311,6 +311,19 @@ def supports_trtllm_attention() -> bool:
     return current_platform.is_device_capability(100) and has_nvidia_artifactory()
 
 
+@functools.cache
+def supports_fmha_v2_sm120_attention() -> bool:
+    """
+    SM120 (consumer Blackwell) supports attention via flashinfer's fmha_v2
+    HMMA kernels. These are JIT-compiled (no prebuilt cubins needed), so no
+    artifactory access is required. Supports sinks for prefill.
+    Sliding window is NOT yet supported by fmha_v2 SM120 kernels.
+    """
+    if envs.VLLM_BATCH_INVARIANT:
+        return False
+    return current_platform.is_device_capability_family(120)
+
+
 def force_use_trtllm_attention() -> bool | None:
     """
     This function should only be called during initialization stage when vllm config
@@ -326,10 +339,14 @@ def force_use_trtllm_attention() -> bool | None:
 
 
 def can_use_trtllm_attention(num_qo_heads: int, num_kv_heads: int) -> bool:
-    """Check if the current configuration supports TRTLLM attention."""
+    """Check if the current configuration supports TRTLLM attention.
+
+    Includes SM120 fmha_v2 HMMA path which provides equivalent functionality
+    (sinks, sliding window) without requiring trtllm-gen cubins.
+    """
     if force_use_trtllm_attention() is False:
         return False
-    has_trtllm = supports_trtllm_attention()
+    has_trtllm = supports_trtllm_attention() or supports_fmha_v2_sm120_attention()
     return has_trtllm and (num_qo_heads % num_kv_heads == 0)
 
 
@@ -362,7 +379,7 @@ def use_trtllm_attention(
         return False
 
     # The platform is not supported
-    if not supports_trtllm_attention():
+    if not supports_trtllm_attention() and not supports_fmha_v2_sm120_attention():
         if force_use_trtllm:
             logger.warning_once(
                 "TRTLLM attention is not supported on this platform, "

--- a/vllm/v1/attention/backends/flash_attn_4.py
+++ b/vllm/v1/attention/backends/flash_attn_4.py
@@ -9,12 +9,27 @@ via `page_table`, matching vLLM's block table format directly:
   K: (num_blocks, block_size, num_kv_heads, head_dim)
   V: (num_blocks, block_size, num_kv_heads, head_dim)
   page_table: (batch_size, max_blocks_per_seq)
+
+Kernel source is loaded in this order so the backend is usable
+regardless of the upstream flash-attn-4 merge/release status:
+
+1. ``blake-snc/flash-attn-4-sm120-sncbl`` from the HuggingFace
+   Kernels Hub — a pre-validated SM120 bundle of five open upstream
+   PRs (#2336/#2348/#2349/#2389/#2439). Requires the ``kernels``
+   Python package (``pip install kernels``).
+2. Local ``flash_attn.cute.interface`` — used only if the Hub load
+   is disabled via ``VLLM_FLASH_ATTN_4_USE_LOCAL=1`` or the
+   ``kernels`` package is unavailable. Requires ``flash-attn-4``
+   installed.
 """
 
 from __future__ import annotations
 
+import functools
+import os
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import ClassVar
+from typing import Any, ClassVar
 
 import torch
 
@@ -31,6 +46,56 @@ from vllm.v1.attention.backend import (
 )
 
 logger = init_logger(__name__)
+
+
+_HF_KERNEL_ID = "blake-snc/flash-attn-4-sm120-sncbl"
+
+
+@functools.cache
+def _get_flash_attn_varlen_func() -> Callable[..., Any]:
+    """Resolve flash_attn_varlen_func from HF Kernels Hub or local install.
+
+    Cached so the lookup + any one-time Hub download runs once per
+    process. Order:
+      1. Hub bundle (``blake-snc/flash-attn-4-sm120-sncbl``) via the
+         ``kernels`` package — unless ``VLLM_FLASH_ATTN_4_USE_LOCAL=1``.
+      2. Local ``flash_attn.cute.interface`` — fallback.
+    """
+    use_local = os.environ.get("VLLM_FLASH_ATTN_4_USE_LOCAL", "0") == "1"
+    if not use_local:
+        try:
+            from kernels import get_kernel  # type: ignore[import-not-found]
+
+            module = get_kernel(_HF_KERNEL_ID)
+            logger.info_once(
+                "FlashAttention4 backend loaded from HF Kernels Hub: %s",
+                _HF_KERNEL_ID,
+            )
+            return module.flash_attn_varlen_func
+        except ImportError:
+            logger.debug_once(
+                "FlashAttention4: `kernels` package not installed; "
+                "falling back to local flash-attn-4 install. Install "
+                "`pip install kernels` to use the pre-built HF bundle."
+            )
+        except Exception as e:  # noqa: BLE001 — Hub load can fail many ways
+            logger.warning_once(
+                "FlashAttention4: HF Kernels Hub load failed (%s); "
+                "falling back to local flash-attn-4 install.",
+                e,
+            )
+    try:
+        from flash_attn.cute.interface import flash_attn_varlen_func
+    except ImportError as e:
+        raise ImportError(
+            "FlashAttention4 backend requires either the `kernels` "
+            "package (for the HF-hosted bundle at "
+            f"`{_HF_KERNEL_ID}`) or `flash-attn-4` installed locally. "
+            "Install one: `pip install kernels` or "
+            "`pip install flash-attn-4`."
+        ) from e
+    logger.info_once("FlashAttention4 backend loaded from local flash-attn-4 install")
+    return flash_attn_varlen_func
 
 
 @dataclass
@@ -205,7 +270,7 @@ class FlashAttention4Impl(AttentionImpl):
             # Profiling run.
             return output.fill_(0)
 
-        from flash_attn.cute.interface import flash_attn_varlen_func
+        flash_attn_varlen_func = _get_flash_attn_varlen_func()
 
         num_actual_tokens = attn_metadata.num_actual_tokens
         q_actual = query[:num_actual_tokens]

--- a/vllm/v1/attention/backends/flash_attn_4.py
+++ b/vllm/v1/attention/backends/flash_attn_4.py
@@ -50,6 +50,13 @@ class FlashAttention4Metadata:
 class FlashAttention4Backend(AttentionBackend):
     """Attention backend using flash-attn-4 CuTe DSL kernels."""
 
+    # flash_attn_varlen_func allocates and returns its own output tensor
+    # (no out= parameter on the kernel). vLLM's unified_attention_with_output
+    # only exposes an output-buffer calling path, so the impl copies the
+    # kernel's output into the caller buffer. Leaving this True matches
+    # that calling convention; the one-shot copy is unavoidable until
+    # flash-attn-4 upstream adds an out= parameter or vLLM grows a
+    # non-output-buffer dispatch variant.
     accept_output_buffer: bool = True
     supported_dtypes: ClassVar[list[torch.dtype]] = [
         torch.float16,
@@ -173,7 +180,10 @@ class FlashAttention4Impl(AttentionImpl):
             self.sliding_window = (-1, -1)
 
         if alibi_slopes is not None:
-            logger.warning("FlashAttention4 does not support ALiBi. Ignoring.")
+            # Silently dropping alibi_slopes would produce incorrect output
+            # for models that require ALiBi. Raise so the attention selector
+            # falls back to a backend that supports it.
+            raise NotImplementedError("FlashAttention4 does not support ALiBi slopes")
 
         self.softcap = logits_soft_cap or 0.0
 
@@ -198,15 +208,18 @@ class FlashAttention4Impl(AttentionImpl):
         from flash_attn.cute.interface import flash_attn_varlen_func
 
         num_actual_tokens = attn_metadata.num_actual_tokens
-        query = query[:num_actual_tokens]
+        q_actual = query[:num_actual_tokens]
 
         # Separate K and V from paged cache
         # kv_cache: (2, num_blocks, block_size, num_kv_heads, head_dim)
         key_cache, value_cache = kv_cache.unbind(0)
 
-        # flash_attn_varlen_func with page_table for paged KV
+        # flash_attn_varlen_func does not expose an out= parameter; it
+        # allocates its own tensor. We copy the actual-token slice into
+        # the caller-provided output buffer so padded-batch callers
+        # (e.g. CUDA graph capture) see the expected shape.
         out, *_ = flash_attn_varlen_func(
-            q=query,
+            q=q_actual,
             k=key_cache,
             v=value_cache,
             cu_seqlens_q=attn_metadata.query_start_loc,

--- a/vllm/v1/attention/backends/flash_attn_4.py
+++ b/vllm/v1/attention/backends/flash_attn_4.py
@@ -1,0 +1,247 @@
+"""Flash Attention 4 (CuTe DSL) backend for SM120 (consumer Blackwell).
+
+Flash-attn-4 provides JIT-compiled attention kernels via NVIDIA CuTe DSL,
+supporting SM80/SM90/SM100/SM120. This backend targets SM120 devices
+(RTX PRO 6000, DGX Spark, etc.) where FA2/FA3 C++ cubins are unavailable.
+
+The kernel interface (`flash_attn_varlen_func`) accepts paged KV cache
+via `page_table`, matching vLLM's block table format directly:
+  K: (num_blocks, block_size, num_kv_heads, head_dim)
+  V: (num_blocks, block_size, num_kv_heads, head_dim)
+  page_table: (batch_size, max_blocks_per_seq)
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar
+
+import torch
+
+from vllm.config.cache import CacheDType
+from vllm.logger import init_logger
+from vllm.platforms.interface import DeviceCapability
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionCGSupport,
+    AttentionImpl,
+    AttentionMetadataBuilder,
+    AttentionType,
+    CommonAttentionMetadata,
+)
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class FlashAttention4Metadata:
+    """Metadata for a batch of attention operations."""
+
+    num_actual_tokens: int
+    max_query_len: int
+    query_start_loc: torch.Tensor  # (batch_size+1,)
+    max_seq_len: int
+    seq_lens: torch.Tensor  # (batch_size,)
+    block_table: torch.Tensor  # (batch_size, max_blocks_per_seq)
+    slot_mapping: torch.Tensor  # (num_actual_tokens,)
+    causal: bool = True
+
+
+class FlashAttention4Backend(AttentionBackend):
+    """Attention backend using flash-attn-4 CuTe DSL kernels."""
+
+    accept_output_buffer: bool = True
+    supported_dtypes: ClassVar[list[torch.dtype]] = [
+        torch.float16,
+        torch.bfloat16,
+    ]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = [
+        "auto",
+        "float16",
+        "bfloat16",
+    ]
+    forward_includes_kv_cache_update: bool = False
+
+    @staticmethod
+    def get_name() -> str:
+        return "FLASH_ATTN_4"
+
+    @staticmethod
+    def get_impl_cls() -> type[FlashAttention4Impl]:
+        return FlashAttention4Impl
+
+    @staticmethod
+    def get_builder_cls() -> type[FlashAttention4MetadataBuilder]:
+        return FlashAttention4MetadataBuilder
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        # (K/V, num_blocks, block_size, num_kv_heads, head_dim)
+        return (2, num_blocks, block_size, num_kv_heads, head_size)
+
+    @staticmethod
+    def get_kv_cache_stride_order() -> tuple[int, ...]:
+        return (0, 1, 2, 3, 4)
+
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int]:
+        return [64, 96, 128, 256]
+
+    @classmethod
+    def supports_head_size(cls, head_size: int) -> bool:
+        return head_size in cls.get_supported_head_sizes()
+
+    @classmethod
+    def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
+        # SM120 (consumer Blackwell) — primary target
+        # Also supports SM80/SM90 but those have better backends
+        return capability >= DeviceCapability(12, 0) and capability <= DeviceCapability(
+            12, 1
+        )
+
+    @classmethod
+    def supports_attn_type(cls, attn_type: AttentionType) -> bool:
+        return attn_type == AttentionType.DECODER
+
+    @classmethod
+    def supports_kv_cache_dtype(cls, kv_cache_dtype: CacheDType) -> bool:
+        return kv_cache_dtype in ("auto", "float16", "bfloat16")
+
+    @classmethod
+    def get_cudagraph_support(cls) -> AttentionCGSupport:
+        # No CUDA graph support initially — enforce_eager required
+        return AttentionCGSupport.NEVER
+
+
+class FlashAttention4MetadataBuilder(AttentionMetadataBuilder[FlashAttention4Metadata]):
+    """Build attention metadata from common batch metadata."""
+
+    def __init__(self, kv_cache_spec, layer_names, vllm_config, device):
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> FlashAttention4Metadata:
+        return FlashAttention4Metadata(
+            num_actual_tokens=common_attn_metadata.num_actual_tokens,
+            max_query_len=common_attn_metadata.max_query_len,
+            query_start_loc=common_attn_metadata.query_start_loc,
+            max_seq_len=common_attn_metadata.max_seq_len,
+            seq_lens=common_attn_metadata.seq_lens,
+            block_table=common_attn_metadata.block_table_tensor,
+            slot_mapping=common_attn_metadata.slot_mapping,
+        )
+
+
+class FlashAttention4Impl(AttentionImpl):
+    """Flash-attn-4 CuTe DSL attention implementation for SM120."""
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int,
+        alibi_slopes: list[float] | None = None,
+        sliding_window: int | None = None,
+        kv_cache_dtype: str = "auto",
+        logits_soft_cap: float | None = None,
+        attn_type: AttentionType = AttentionType.DECODER,
+        kv_sharing_target_layer_name: str | None = None,
+        **kwargs,
+    ) -> None:
+        if attn_type != AttentionType.DECODER:
+            raise NotImplementedError("FlashAttention4 only supports DECODER attention")
+        self.num_heads = num_heads
+        self.head_size = head_size
+        self.scale = scale
+        self.num_kv_heads = num_kv_heads
+        self.kv_cache_dtype = kv_cache_dtype
+
+        if sliding_window is not None:
+            self.sliding_window = (sliding_window - 1, 0)
+        else:
+            self.sliding_window = (-1, -1)
+
+        if alibi_slopes is not None:
+            logger.warning("FlashAttention4 does not support ALiBi. Ignoring.")
+
+        self.softcap = logits_soft_cap or 0.0
+
+    def forward(
+        self,
+        layer: torch.nn.Module,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: FlashAttention4Metadata,
+        output: torch.Tensor | None = None,
+        output_scale: torch.Tensor | None = None,
+        output_block_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        if output is None:
+            output = torch.empty_like(query)
+        if attn_metadata is None:
+            # Profiling run.
+            return output.fill_(0)
+
+        from flash_attn.cute.interface import flash_attn_varlen_func
+
+        num_actual_tokens = attn_metadata.num_actual_tokens
+        query = query[:num_actual_tokens]
+
+        # Separate K and V from paged cache
+        # kv_cache: (2, num_blocks, block_size, num_kv_heads, head_dim)
+        key_cache, value_cache = kv_cache.unbind(0)
+
+        # flash_attn_varlen_func with page_table for paged KV
+        out, *_ = flash_attn_varlen_func(
+            q=query,
+            k=key_cache,
+            v=value_cache,
+            cu_seqlens_q=attn_metadata.query_start_loc,
+            max_seqlen_q=attn_metadata.max_query_len,
+            seqused_k=attn_metadata.seq_lens,
+            max_seqlen_k=attn_metadata.max_seq_len,
+            page_table=attn_metadata.block_table,
+            softmax_scale=self.scale,
+            causal=attn_metadata.causal,
+            window_size=self.sliding_window,
+            softcap=self.softcap,
+            return_lse=False,
+        )
+        output[:num_actual_tokens].copy_(out)
+        return output
+
+    def do_kv_cache_update(
+        self,
+        layer: torch.nn.Module,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+    ) -> None:
+        # Use vLLM's standard reshape_and_cache for KV cache update
+        from vllm._custom_ops import reshape_and_cache_flash
+
+        key_cache, value_cache = kv_cache.unbind(0)
+        reshape_and_cache_flash(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            self.kv_cache_dtype,
+            getattr(layer, "_k_scale", None),
+            getattr(layer, "_v_scale", None),
+        )

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -922,6 +922,7 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
             force_use_trtllm=self.attention_config.use_trtllm_attention,
             has_sinks=self.has_sinks,
             has_spec=uses_spec_reorder,
+            has_sliding_window=self.window_left != -1,
         )
         decode_use_trtllm = (
             self.use_trtllm_decode_attention and self.dcp_world_size <= 1
@@ -1544,6 +1545,16 @@ class FlashInferImpl(AttentionImpl):
                                 dtype=seq_lens_prefill.dtype,
                             ),
                         ]
+                    )
+                    # fmha_v2 SM120 path does not yet support sliding
+                    # window (the kernel raises "Sliding window attention
+                    # is not yet supported for FMHAv2 on SM120"), so the
+                    # batch must have been disqualified from the trtllm
+                    # path upstream when any layer has window_left != -1.
+                    assert self.window_left == -1, (
+                        "SM120 fmha_v2 does not support sliding window; "
+                        "expected use_trtllm_attention() to disqualify this "
+                        "path when window_left != -1"
                     )
                     fmha_v2_workspace = _get_trtllm_gen_workspace_buffer()
                     fmha_v2_kwargs: dict = {}

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -15,7 +15,10 @@ from flashinfer import (
     MultiLevelCascadeAttentionWrapper,
 )
 from flashinfer.decode import fast_decode_plan, trtllm_batch_decode_with_kv_cache
-from flashinfer.prefill import trtllm_batch_context_with_kv_cache
+from flashinfer.prefill import (
+    trtllm_batch_context_with_kv_cache,
+    trtllm_fmha_v2_prefill,
+)
 from flashinfer.utils import FP4Tensor
 from typing_extensions import override
 
@@ -38,6 +41,7 @@ from vllm.platforms.interface import DeviceCapability
 from vllm.triton_utils import tl, triton
 from vllm.utils.flashinfer import (
     can_use_trtllm_attention,
+    supports_fmha_v2_sm120_attention,
     use_trtllm_attention,
 )
 from vllm.utils.math_utils import cdiv
@@ -409,9 +413,10 @@ class FlashInferBackend(AttentionBackend):
 
     @classmethod
     def supports_sink(cls) -> bool:
-        """FlashInfer supports sinks when TRTLLM attention is available (SM100)."""
+        """FlashInfer supports sinks on SM100 (trtllm-gen) and SM120 (fmha_v2 HMMA)."""
         from vllm.utils.flashinfer import (
             force_use_trtllm_attention,
+            supports_fmha_v2_sm120_attention,
             supports_trtllm_attention,
         )
 
@@ -420,8 +425,7 @@ class FlashInferBackend(AttentionBackend):
         if force_use_trtllm_attention() is False:
             return False
 
-        # Check if TRTLLM is supported on this platform
-        return supports_trtllm_attention()
+        return supports_trtllm_attention() or supports_fmha_v2_sm120_attention()
 
     @classmethod
     def get_required_kv_cache_layout(cls) -> KVCacheLayoutType | None:
@@ -639,10 +643,13 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         # if TRTLLM attention kernel is not used when building attn metadata
         can_use_trtllm = can_use_trtllm_attention(self.num_qo_heads, self.num_kv_heads)
 
-        if (
+        # SM120 fmha_v2 does not support FP8 Q quantization
+        can_quantize_q = (
             can_use_trtllm
+            and not supports_fmha_v2_sm120_attention()
             and not vllm_config.attention_config.disable_flashinfer_q_quantization
-        ):
+        )
+        if can_quantize_q:
             if self.is_kvcache_nvfp4:
                 # NVFP4 KV cache uses FP8 quantized queries
                 self.q_data_type = FlashInferBackend.get_fp8_dtype_for_flashinfer(
@@ -655,7 +662,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
 
         # Prefer TRTLLM attention for decoding in all cases.
         # This allows us to use AttentionCGSupport.UNIFORM_BATCH mode.
-        self.use_trtllm_decode_attention = can_use_trtllm
+        # SM120 fmha_v2 only supports prefill — decode uses standard flashinfer.
+        self.use_trtllm_decode_attention = (
+            can_use_trtllm and not supports_fmha_v2_sm120_attention()
+        )
         self._init_reorder_batch_threshold(1, supports_spec_as_decode=can_use_trtllm)
 
         self._cascade_wrapper = None  # Wrapper for cascade attention
@@ -925,7 +935,10 @@ class FlashInferMetadataBuilder(AttentionMetadataBuilder[FlashInferMetadata]):
         )
 
         if not all_uses_trtllm:
-            if self.has_sinks:
+            # SM120 uses fmha_v2 for prefill (with sinks) but standard
+            # flashinfer for decode, so all_uses_trtllm is False even
+            # though sinks are supported via the fmha_v2 prefill path.
+            if self.has_sinks and not supports_fmha_v2_sm120_attention():
                 raise NotImplementedError(
                     "FlashInfer backend currently does not support attention "
                     "sinks, please use trtllm on blackwell or flash attention "
@@ -1496,96 +1509,151 @@ class FlashInferImpl(AttentionImpl):
                     )
             else:
                 assert isinstance(attn_metadata.prefill, TRTLLMPrefill)
-                # prefill_query may be non-contiguous or have degenerate strides
-                # First ensure memory contiguity, then fix degenerate strides
-                # with reshape. contiguous() alone doesn't fix degenerate
-                # strides when a dimension has size 1.
                 prefill_query = prefill_query.contiguous().reshape(prefill_query.shape)
-                workspace_buffer = _get_trtllm_gen_workspace_buffer()
-                block_tables_prefill = attn_metadata.prefill.block_tables
                 seq_lens_prefill = attn_metadata.prefill.seq_lens
 
-                # This path needs to be enabled with VLLM_KV_CACHE_LAYOUT = HND
-                assert get_kv_cache_layout() == "HND"
-                assert is_strictly_contiguous(prefill_query)
-                assert is_strictly_contiguous(workspace_buffer)
-                assert is_strictly_contiguous(block_tables_prefill)
-                assert is_strictly_contiguous(seq_lens_prefill)
-
-                if output.dtype == FP4_DTYPE:
-                    assert self.o_sf_scale is not None
-                    out = FP4Tensor(
-                        data=output[num_decode_tokens:],
-                        scale=output_block_scale,
-                        scale_start_index=num_decode_tokens,
-                        original_shape=prefill_query.shape,
-                    )
-                else:
-                    assert self.o_sf_scale is None
-                    out = output[num_decode_tokens:]
-
-                prefill_kv_block_scales = None
-                if self.is_kvcache_nvfp4:
-                    # NVFP4 trtllm-gen kernel requires FP8 query.
-                    assert attn_metadata.q_data_type == FP8_DTYPE, (
-                        "NVFP4 KV cache requires FP8 quantized queries for "
-                        "trtllm-gen prefill. Set "
-                        "disable_flashinfer_q_quantization=False."
-                    )
-                    mock_kv_cache = nvfp4_kv_data
-                    mock_block_table = block_tables_prefill
-                    prefill_kv_block_scales = nvfp4_kv_block_scales  # noqa: F841
-                elif (
-                    attn_metadata.q_data_type != FP8_DTYPE
-                    and self.kv_cache_dtype.startswith("fp8")
-                ):
-                    # TRTLLM prefill attention does not support BF16 Q
-                    # and fp8 kv cache. So to enable prefill attention
-                    # with fp8 kv cache, we can construct a mock block
-                    # and mock kv cache with BF16 KV involved in the prefill
+                if supports_fmha_v2_sm120_attention():
+                    # SM120: use fmha_v2 HMMA kernels with paged KV cache.
+                    # trtllm-gen cubins don't exist for SM120, but fmha_v2
+                    # HMMA supports sinks natively via JIT compilation.
                     #
-                    # The inner (block_size, head_size) dims must be
-                    # contiguous; outer dims may have non-canonical strides
-                    # (e.g. cross-layer unified allocation).
-                    # Degenerate strides on outer dims break TMA descriptors
-                    # (see flashinfer-ai/flashinfer#2232).
-                    kv_strides = kv_cache_permute.stride()
-                    assert (
-                        kv_strides[-1] == 1
-                        and kv_strides[-2] == kv_cache_permute.shape[-1]
-                    ), (
-                        "KV cache inner dims (block_size, head_size) must be "
-                        f"contiguous, got strides {kv_strides}"
+                    # Use Q_PAGED_KV_NHD to read from the paged KV cache.
+                    # The raw key/value tensors only contain the current
+                    # step's tokens, but seq_lens may include additional
+                    # tokens that vLLM already wrote to the paged cache
+                    # (via do_kv_cache_update, called before forward).
+                    # FlashInfer allocates kv_cache in
+                    #   [num_pages, 2, page_size, num_kv_heads, D] format,
+                    # which is already the Q_PAGED_KV_NHD layout.
+                    #
+                    # trtllm_fmha_v2_prefill expects cum_seq_lens_kv to be
+                    # cumulative TOKEN lengths starting from 0. The
+                    # TRTLLMPrefill metadata stores PAGE indptrs in that
+                    # field (used differently by trtllm-gen), so rebuild
+                    # the proper token cumsum from seq_lens.
+                    cum_kv_tokens = torch.cat(
+                        [
+                            torch.zeros(
+                                1,
+                                dtype=seq_lens_prefill.dtype,
+                                device=seq_lens_prefill.device,
+                            ),
+                            torch.cumsum(
+                                seq_lens_prefill,
+                                dim=0,
+                                dtype=seq_lens_prefill.dtype,
+                            ),
+                        ]
                     )
-                    mock_kv_cache, mock_block_table = trtllm_prefill_attn_kvfp8_dequant(
-                        kv_cache_permute,
-                        block_tables_prefill,
-                        layer._k_scale,
-                        layer._v_scale,
-                        attn_metadata.q_data_type,
+                    fmha_v2_workspace = _get_trtllm_gen_workspace_buffer()
+                    fmha_v2_kwargs: dict = {}
+                    if self.sinks is not None:
+                        fmha_v2_kwargs["sinks"] = self.sinks
+                    trtllm_fmha_v2_prefill(
+                        (prefill_query, kv_cache_permute),
+                        input_layout="Q_PAGED_KV_NHD",
+                        workspace_buffer=fmha_v2_workspace,
+                        block_tables=attn_metadata.prefill.block_tables,
+                        seq_lens=seq_lens_prefill,
+                        max_q_len=attn_metadata.prefill.max_q_len,
+                        max_kv_len=attn_metadata.prefill.max_seq_len,
+                        bmm1_scale=self.bmm1_scale,
+                        bmm2_scale=self.bmm2_scale,
+                        batch_size=attn_metadata.num_prefills,
+                        cum_seq_lens_q=attn_metadata.prefill.cum_seq_lens_q,
+                        cum_seq_lens_kv=cum_kv_tokens,
+                        out=output[num_decode_tokens:],
+                        mask_mode="causal",
+                        save_softmax_stats=False,
+                        **fmha_v2_kwargs,
                     )
                 else:
-                    mock_kv_cache = kv_cache_permute
-                    mock_block_table = block_tables_prefill
+                    workspace_buffer = _get_trtllm_gen_workspace_buffer()
+                    block_tables_prefill = attn_metadata.prefill.block_tables
 
-                trtllm_batch_context_with_kv_cache(
-                    query=prefill_query,
-                    kv_cache=mock_kv_cache,
-                    workspace_buffer=workspace_buffer,
-                    block_tables=mock_block_table,
-                    seq_lens=seq_lens_prefill,
-                    max_q_len=attn_metadata.prefill.max_q_len,
-                    max_kv_len=attn_metadata.prefill.max_seq_len,
-                    bmm1_scale=self.bmm1_scale,
-                    bmm2_scale=self.bmm2_scale,
-                    batch_size=attn_metadata.num_prefills,
-                    cum_seq_lens_q=attn_metadata.prefill.cum_seq_lens_q,
-                    cum_seq_lens_kv=attn_metadata.prefill.cum_seq_lens_kv,
-                    window_left=self.window_left,
-                    sinks=self.sinks,
-                    o_sf_scale=self.o_sf_scale,
-                    out=out,
-                )
+                    # This path needs to be enabled with VLLM_KV_CACHE_LAYOUT = HND
+                    assert get_kv_cache_layout() == "HND"
+                    assert is_strictly_contiguous(prefill_query)
+                    assert is_strictly_contiguous(workspace_buffer)
+                    assert is_strictly_contiguous(block_tables_prefill)
+                    assert is_strictly_contiguous(seq_lens_prefill)
+
+                    if output.dtype == FP4_DTYPE:
+                        assert self.o_sf_scale is not None
+                        out = FP4Tensor(
+                            data=output[num_decode_tokens:],
+                            scale=output_block_scale,
+                            scale_start_index=num_decode_tokens,
+                            original_shape=prefill_query.shape,
+                        )
+                    else:
+                        assert self.o_sf_scale is None
+                        out = output[num_decode_tokens:]
+
+                    prefill_kv_block_scales = None
+                    if self.is_kvcache_nvfp4:
+                        # NVFP4 trtllm-gen kernel requires FP8 query.
+                        assert attn_metadata.q_data_type == FP8_DTYPE, (
+                            "NVFP4 KV cache requires FP8 quantized queries for "
+                            "trtllm-gen prefill. Set "
+                            "disable_flashinfer_q_quantization=False."
+                        )
+                        mock_kv_cache = nvfp4_kv_data
+                        mock_block_table = block_tables_prefill
+                        prefill_kv_block_scales = nvfp4_kv_block_scales  # noqa: F841
+                    elif (
+                        attn_metadata.q_data_type != FP8_DTYPE
+                        and self.kv_cache_dtype.startswith("fp8")
+                    ):
+                        # TRTLLM prefill attention does not support BF16 Q
+                        # and fp8 kv cache. So to enable prefill attention
+                        # with fp8 kv cache, we can construct a mock block
+                        # and mock kv cache with BF16 KV involved in the prefill
+                        #
+                        # The inner (block_size, head_size) dims must be
+                        # contiguous; outer dims may have non-canonical strides
+                        # (e.g. cross-layer unified allocation).
+                        # Degenerate strides on outer dims break TMA descriptors
+                        # (see flashinfer-ai/flashinfer#2232).
+                        kv_strides = kv_cache_permute.stride()
+                        assert (
+                            kv_strides[-1] == 1
+                            and kv_strides[-2] == kv_cache_permute.shape[-1]
+                        ), (
+                            "KV cache inner dims (block_size, head_size) must be "
+                            f"contiguous, got strides {kv_strides}"
+                        )
+                        mock_kv_cache, mock_block_table = (
+                            trtllm_prefill_attn_kvfp8_dequant(
+                                kv_cache_permute,
+                                block_tables_prefill,
+                                layer._k_scale,
+                                layer._v_scale,
+                                attn_metadata.q_data_type,
+                            )
+                        )
+                    else:
+                        mock_kv_cache = kv_cache_permute
+                        mock_block_table = block_tables_prefill
+
+                    trtllm_batch_context_with_kv_cache(
+                        query=prefill_query,
+                        kv_cache=mock_kv_cache,
+                        workspace_buffer=workspace_buffer,
+                        block_tables=mock_block_table,
+                        seq_lens=seq_lens_prefill,
+                        max_q_len=attn_metadata.prefill.max_q_len,
+                        max_kv_len=attn_metadata.prefill.max_seq_len,
+                        bmm1_scale=self.bmm1_scale,
+                        bmm2_scale=self.bmm2_scale,
+                        batch_size=attn_metadata.num_prefills,
+                        cum_seq_lens_q=attn_metadata.prefill.cum_seq_lens_q,
+                        cum_seq_lens_kv=attn_metadata.prefill.cum_seq_lens_kv,
+                        window_left=self.window_left,
+                        sinks=self.sinks,
+                        o_sf_scale=self.o_sf_scale,
+                        out=out,
+                    )
 
         if num_decode_tokens > 0:
             decode_query = query[:num_decode_tokens]

--- a/vllm/v1/attention/backends/registry.py
+++ b/vllm/v1/attention/backends/registry.py
@@ -42,6 +42,7 @@ class AttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
     """
 
     FLASH_ATTN = "vllm.v1.attention.backends.flash_attn.FlashAttentionBackend"
+    FLASH_ATTN_4 = "vllm.v1.attention.backends.flash_attn_4.FlashAttention4Backend"
     FLASH_ATTN_DIFFKV = (
         "vllm.v1.attention.backends.flash_attn_diffkv.FlashAttentionDiffKVBackend"
     )


### PR DESCRIPTION
## Summary

Register a `FLASH_ATTN_4` attention backend for SM120 (consumer Blackwell — RTX PRO 6000, DGX Spark, RTX 5090) that exposes flash-attn-4's CuTe DSL kernels as an **opt-in** via `--attention-backend FLASH_ATTN_4`. FLASHINFER remains the default SM120 backend.

SM120 lacks FA2/FA3 C++ cubins; vLLM users on SM120 today only have FLASHINFER's `fmha_v2` HMMA path (PR #40085 adds attention-sink support there). This PR does not change that default — it adds FA4 as a second option for users who want FA4's CuTe-DSL-native kernels (split-KV, paged KV pipelining, TMA forward with warp specialization, block-sparse, FA4-style dropout).

### Changes
- New `vllm/v1/attention/backends/flash_attn_4.py`:
  - `FlashAttention4Backend`: SM120 compute capability, head sizes 64–256, BF16/FP16
  - `FlashAttention4MetadataBuilder`: pass-through of `CommonAttentionMetadata`
  - `FlashAttention4Impl`: forward via `flash_attn_varlen_func` with `page_table`, KV update via `reshape_and_cache_flash`
  - Loader prefers `kernels.get_kernel("blake-snc/flash-attn-4-sm120-sncbl")` (pre-validated SM120 bundle of the five open upstream FA4 PRs: #2336, #2348, #2349, #2389, #2439), falls back to local `flash_attn.cute.interface` when `kernels` isn't installed or the Hub load fails. `VLLM_FLASH_ATTN_4_USE_LOCAL=1` forces the local path.
- Register `FLASH_ATTN_4` in `AttentionBackendEnum`.
- SM120 priority: `FLASHINFER > FLASH_ATTN_4 > TRITON_ATTN > FLEX_ATTENTION`. FA4 is **opt-in only**; the only way to select it is an explicit `--attention-backend FLASH_ATTN_4` flag.

### Why this is not duplicating an existing PR
No existing vLLM PR registers a flash-attn-4 / CuTe DSL attention backend. PR #40085 (my other open PR) adds attention-sink support to the existing FLASHINFER SM120 path via `fmha_v2`; that's a different kernel tree on the existing default backend and complementary to this PR.

### Dependency model

Either of these is sufficient to use the backend:
- `pip install kernels` → loads the pre-built HF Kernels Hub bundle at [`blake-snc/flash-attn-4-sm120-sncbl`](https://huggingface.co/blake-snc/flash-attn-4-sm120-sncbl) (the five open upstream FA4 PRs stacked + validated on SM121a)
- `pip install flash-attn-4` → uses a local install (the upstream PRs must be applied)

### Performance (SM121a, DGX Spark GB10, bf16, causal, median of 30 iters)

FA4 vs FLASHINFER `fmha_v2` on the same shapes:

| Shape (B, S, H, D) | FA4 (ms) | FLASHINFER (ms) | FA4 / FI |
|--------------------|---------:|----------------:|---------:|
| (1, 128, 14, 64)   |    0.033 |           0.033 |    1.00× |
| (1, 512, 14, 64)   |    0.045 |           0.068 |    0.66× |
| (1, 1024, 14, 64)  |    0.073 |           0.164 |    0.45× |
| (1, 2048, 14, 64)  |    0.168 |           0.496 |    0.34× |
| (2, 512, 14, 64)   |    0.055 |           0.099 |    0.55× |
| (4, 256, 14, 64)   |    0.056 |           0.067 |    0.84× |

FA4 is ≥ FLASHINFER `fmha_v2` at every shape tested; the gap widens with sequence length (up to 2.9× faster at S=2048).

### Correctness

Validated on SM121a, max_diff vs PyTorch reference, B=1 S=256 H=4 D=64:

| causal | dtype    | max_diff |
|--------|----------|---------:|
| False  | bfloat16 |   0.0020 |
| False  | float16  |   0.0002 |
| True   | bfloat16 |   0.0078 |
| True   | float16  |   0.0010 |

### Known limitations (unchanged)
- `enforce_eager=True` required (no CUDA graph support yet — FA4 CuTe DSL kernels are JIT-compiled; graph interop is upstream work)
- DECODER attention type only (no encoder/cross-attention)
- No FP8 KV cache support
- ALiBi raises `NotImplementedError` so the selector falls back to another backend when needed

### AI assistance

AI assistance was used to author this patch. I reviewed every changed line and ran the validation and benchmarks above on real SM121a hardware.

Contributed by Second Nature Computing (https://joinsecondnature.com)