### PR TITLE
[Bugfix] Fix prevent duplicate Prometheus metrics when using MultiConnector with multiple OffloadingConnector instances

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_metrics.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_metrics.py
@@ -32,34 +32,7 @@ def test_build_kv_connector_stats_reconstructs_offload_stats():
     """Test that OffloadingConnector stats are properly reconstructed with
     correct data."""
     serialized_data = {
-        "CPU_to_GPU": [
-            {"op_size": 16, "op_time": 1.0},
-            {"op_size": 8, "op_time": 0.5},
-        ],
-        "GPU_to_CPU": [
-            {"op_size": 1, "op_time": 0.1},
-            {"op_size": 2, "op_time": 0.2},
-        ],
-    }
-
-    stats = OffloadingConnector.build_kv_connector_stats(data=serialized_data)
-
-    offload_connector_stats = stats
-    assert isinstance(offload_connector_stats, OffloadingConnectorStats)
-    assert offload_connector_stats.data["CPU_to_GPU"] == [
-        {"op_size": 16, "op_time": 1.0},
-        {"op_size": 8, "op_time": 0.5},
-    ]
-    assert offload_connector_stats.data["GPU_to_CPU"] == [
-        {"op_size": 1, "op_time": 0.1},
-        {"op_size": 2, "op_time": 0.2},
-    ]
-
-
-def test_aggregate_same_connector():
-    """Test aggregating stats from the same connector type."""
-    stats1 = OffloadingConnectorStats(
-        data={
+        "CPUOffloadingSpec": {
             "CPU_to_GPU": [
                 {"op_size": 16, "op_time": 1.0},
                 {"op_size": 8, "op_time": 0.5},
@@ -69,15 +42,48 @@ def test_aggregate_same_connector():
                 {"op_size": 2, "op_time": 0.2},
             ],
         }
+    }
+
+    stats = OffloadingConnector.build_kv_connector_stats(data=serialized_data)
+
+    offload_connector_stats = stats
+    assert isinstance(offload_connector_stats, OffloadingConnectorStats)
+    assert offload_connector_stats.data["CPUOffloadingSpec"]["CPU_to_GPU"] == [
+        {"op_size": 16, "op_time": 1.0},
+        {"op_size": 8, "op_time": 0.5},
+    ]
+    assert offload_connector_stats.data["CPUOffloadingSpec"]["GPU_to_CPU"] == [
+        {"op_size": 1, "op_time": 0.1},
+        {"op_size": 2, "op_time": 0.2},
+    ]
+
+
+def test_aggregate_same_connector():
+    """Test aggregating stats from the same connector type."""
+    stats1 = OffloadingConnectorStats(
+        data={
+            "CPUOffloadingSpec": {
+                "CPU_to_GPU": [
+                    {"op_size": 16, "op_time": 1.0},
+                    {"op_size": 8, "op_time": 0.5},
+                ],
+                "GPU_to_CPU": [
+                    {"op_size": 1, "op_time": 0.1},
+                    {"op_size": 2, "op_time": 0.2},
+                ],
+            }
+        }
     )
 
     stats2 = OffloadingConnectorStats(
         data={
-            "CPU_to_GPU": [
-                {"op_size": 3, "op_time": 0.2},
-                {"op_size": 7, "op_time": 0.9},
-            ],
-            "GPU_to_CPU": [{"op_size": 16, "op_time": 2}],
+            "CPUOffloadingSpec": {
+                "CPU_to_GPU": [
+                    {"op_size": 3, "op_time": 0.2},
+                    {"op_size": 7, "op_time": 0.9},
+                ],
+                "GPU_to_CPU": [{"op_size": 16, "op_time": 2}],
+            }
         }
     )
 
@@ -85,13 +91,13 @@ def test_aggregate_same_connector():
 
     assert result is stats1  # Should return self
     offload_connector_stats = result
-    assert offload_connector_stats.data["CPU_to_GPU"] == [
+    assert offload_connector_stats.data["CPUOffloadingSpec"]["CPU_to_GPU"] == [
         {"op_size": 16, "op_time": 1.0},
         {"op_size": 8, "op_time": 0.5},
         {"op_size": 3, "op_time": 0.2},
         {"op_size": 7, "op_time": 0.9},
     ]
-    assert offload_connector_stats.data["GPU_to_CPU"] == [
+    assert offload_connector_stats.data["CPUOffloadingSpec"]["GPU_to_CPU"] == [
         {"op_size": 1, "op_time": 0.1},
         {"op_size": 2, "op_time": 0.2},
         {"op_size": 16, "op_time": 2},
@@ -102,17 +108,19 @@ def test_reduce():
     """Test that reduce() correctly reduces all nested connector stats."""
     stats = OffloadingConnectorStats(
         data={
-            "CPU_to_GPU": [
-                {"op_size": 16, "op_time": 1.0},
-                {"op_size": 8, "op_time": 0.5},
-                {"op_size": 3, "op_time": 0.2},
-                {"op_size": 7, "op_time": 0.9},
-            ],
-            "GPU_to_CPU": [
-                {"op_size": 1, "op_time": 0.1},
-                {"op_size": 2, "op_time": 0.2},
-                {"op_size": 16, "op_time": 2},
-            ],
+            "CPUOffloadingSpec": {
+                "CPU_to_GPU": [
+                    {"op_size": 16, "op_time": 1.0},
+                    {"op_size": 8, "op_time": 0.5},
+                    {"op_size": 3, "op_time": 0.2},
+                    {"op_size": 7, "op_time": 0.9},
+                ],
+                "GPU_to_CPU": [
+                    {"op_size": 1, "op_time": 0.1},
+                    {"op_size": 2, "op_time": 0.2},
+                    {"op_size": 16, "op_time": 2},
+                ],
+            }
         }
     )
 
@@ -120,25 +128,27 @@ def test_reduce():
 
     assert isinstance(reduced, dict)
     # Check that the stats were reduced (should have aggregated values)
-    assert "CPU_to_GPU_total_bytes" in reduced
-    assert "CPU_to_GPU_total_time" in reduced
-    assert "GPU_to_CPU_total_bytes" in reduced
-    assert "GPU_to_CPU_total_time" in reduced
-    assert reduced["CPU_to_GPU_total_bytes"] == 34
-    assert reduced["CPU_to_GPU_total_time"] == 2.6
-    assert reduced["GPU_to_CPU_total_time"] == 2.3
-    assert reduced["GPU_to_CPU_total_bytes"] == 19
+    # New nested structure
+    assert "CPUOffloadingSpec" in reduced
+    assert "CPU_to_GPU" in reduced["CPUOffloadingSpec"]
+    assert "GPU_to_CPU" in reduced["CPUOffloadingSpec"]
+    assert reduced["CPUOffloadingSpec"]["CPU_to_GPU"]["total_bytes"] == 34
+    assert reduced["CPUOffloadingSpec"]["CPU_to_GPU"]["total_time"] == 2.6
+    assert reduced["CPUOffloadingSpec"]["GPU_to_CPU"]["total_bytes"] == 19
+    assert reduced["CPUOffloadingSpec"]["GPU_to_CPU"]["total_time"] == 2.3
 
 
 def test_reset():
     """Test that reset() resets all nested connector stats."""
     offload_connector_stats = OffloadingConnectorStats(
         data={
-            "CPU_to_GPU": [
-                {"op_size": 3, "op_time": 0.2},
-                {"op_size": 7, "op_time": 0.9},
-            ],
-            "GPU_to_CPU": [{"op_size": 16, "op_time": 2}],
+            "CPUOffloadingSpec": {
+                "CPU_to_GPU": [
+                    {"op_size": 3, "op_time": 0.2},
+                    {"op_size": 7, "op_time": 0.9},
+                ],
+                "GPU_to_CPU": [{"op_size": 16, "op_time": 2}],
+            }
         }
     )
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -36,7 +36,7 @@ class KVConnectorStats:
         """
         raise NotImplementedError
 
-    def reduce(self) -> dict[str, int | float]:
+    def reduce(self) -> dict[str, Any]:
         """
         Reduce the observations collected during a time interval to one or
         more representative values (eg avg/median/sum of the series).

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -560,9 +560,13 @@ class MultiConnector(KVConnectorBase_V1):
         per_engine_labelvalues: dict[int, list[object]],
     ) -> KVConnectorPromMetrics:
         prom_metrics: dict[str, KVConnectorPromMetrics] = {}
+        seen_classes: set[type] = set()
         for connector_cls, temp_config in cls._get_connector_classes_and_configs(
             vllm_config
         ):
+            if connector_cls in seen_classes:
+                continue
+            seen_classes.add(connector_cls)
             connector_prom = connector_cls.build_prom_metrics(
                 temp_config, metric_types, labelnames, per_engine_labelvalues
             )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/metrics.py
@@ -24,56 +24,69 @@ class OffloadingOperationMetrics:
 
 @dataclass
 class OffloadingConnectorStats(KVConnectorStats):
+    # data = {spec_name: {transfer_type: [OffloadingOperationMetrics]}}
     def __post_init__(self):
         if not self.data:
             # Empty container init, no data is passed in.
             self.reset()
 
     def reset(self):
-        self.data: dict[str, list[OffloadingOperationMetrics]] = {}
+        self.data: dict[str, dict[str, list[OffloadingOperationMetrics]]] = {}
 
     def aggregate(self, other: KVConnectorStats) -> KVConnectorStats:
         if not other.is_empty():
-            for k, v in other.data.items():
-                if k not in self.data:
-                    self.data[k] = v
+            for spec_name, spec_data in other.data.items():
+                if spec_name not in self.data:
+                    self.data[spec_name] = spec_data
                 else:
-                    accumulator = self.data[k]
-                    assert isinstance(accumulator, list)
-                    accumulator.extend(v)
+                    for transfer_type, ops_list in spec_data.items():
+                        if transfer_type not in self.data[spec_name]:
+                            self.data[spec_name][transfer_type] = ops_list
+                        else:
+                            accumulator = self.data[spec_name][transfer_type]
+                            assert isinstance(accumulator, list)
+                            accumulator.extend(ops_list)
         return self
 
-    def reduce(self) -> dict[str, int | float]:
+    def reduce(self) -> dict[str, Any]:
         """
         Reduce the observations collected during a time interval to one or
         more representative values (eg avg/median/sum of the series).
         This is meant to be called by the logger to produce a summary of the
         stats for the last time interval.
         """
-        return_dict: dict[str, int | float] = {}
-        for transfer_type, ops_list in self.data.items():
-            assert isinstance(ops_list, list)
-            total_bytes = 0
-            total_time = 0.0
-            for op in ops_list:
-                assert isinstance(op, dict)
-                total_bytes += op["op_size"]
-                total_time += op["op_time"]
-            return_dict[f"{transfer_type}_total_bytes"] = total_bytes
-            return_dict[f"{transfer_type}_total_time"] = total_time
+        return_dict: dict[str, Any] = {}
+        for spec_name, spec_data in self.data.items():
+            return_dict[spec_name] = {}
+            for transfer_type, ops_list in spec_data.items():
+                assert isinstance(ops_list, list)
+                total_bytes = 0
+                total_time = 0.0
+                for op in ops_list:
+                    assert isinstance(op, dict)
+                    total_bytes += op["op_size"]
+                    total_time += op["op_time"]
+                return_dict[spec_name][transfer_type] = {
+                    "total_bytes": total_bytes,
+                    "total_time": total_time,
+                }
         return return_dict
 
     def is_empty(self) -> bool:
         return not self.data
 
-    def record_transfer(self, num_bytes: int, time: float, transfer_type: TransferType):
+    def record_transfer(
+        self, spec_name: str, num_bytes: int, time: float, transfer_type: TransferType
+    ):
         src, dst = transfer_type
         transfer_type_key = src + "_to_" + dst
         op = OffloadingOperationMetrics(num_bytes, time)
-        if transfer_type_key in self.data:
-            self.data[transfer_type_key].append(op)
+        if spec_name not in self.data:
+            self.data[spec_name] = {}
+        if transfer_type_key in self.data[spec_name]:
+            self.data[spec_name][transfer_type_key].append(op)
         else:
-            self.data[transfer_type_key] = [op]
+            self.data[spec_name][transfer_type_key] = [op]
 
 
 class OffloadPromMetrics(KVConnectorPromMetrics):
@@ -85,10 +98,10 @@ class OffloadPromMetrics(KVConnectorPromMetrics):
         per_engine_labelvalues: dict[int, list[object]],
     ):
         super().__init__(vllm_config, metric_types, labelnames, per_engine_labelvalues)
-        # (engine_idx, transfer_type) -> (metric with bounded labels)
-        self.histogram_transfer_size: dict[tuple[int, str], PromMetricT] = {}
-        self.counter_kv_bytes: dict[tuple[int, str], PromMetricT] = {}
-        self.counter_kv_transfer_time: dict[tuple[int, str], PromMetricT] = {}
+        # (engine_idx, spec_name, transfer_type) -> (metric with bounded labels)
+        self.histogram_transfer_size: dict[tuple[int, str, str], PromMetricT] = {}
+        self.counter_kv_bytes: dict[tuple[int, str, str], PromMetricT] = {}
+        self.counter_kv_transfer_time: dict[tuple[int, str, str], PromMetricT] = {}
         buckets = [  # In bytes
             1e6,
             5e6,
@@ -105,20 +118,20 @@ class OffloadPromMetrics(KVConnectorPromMetrics):
         self._counter_kv_bytes = self._counter_cls(
             name="vllm:kv_offload_total_bytes",
             documentation="Number of bytes offloaded by KV connector",
-            labelnames=labelnames + ["transfer_type"],
+            labelnames=labelnames + ["spec_name", "transfer_type"],
         )
 
         self._counter_kv_transfer_time = self._counter_cls(
             name="vllm:kv_offload_total_time",
             documentation="Total time measured by all KV offloading operations",
-            labelnames=labelnames + ["transfer_type"],
+            labelnames=labelnames + ["spec_name", "transfer_type"],
         )
 
         self._histogram_transfer_size = self._histogram_cls(
             name="vllm:kv_offload_size",
             documentation="Histogram of KV offload transfer size, in bytes.",
             buckets=buckets[:],
-            labelnames=labelnames + ["transfer_type"],
+            labelnames=labelnames + ["spec_name", "transfer_type"],
         )
 
     def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0):
@@ -128,38 +141,54 @@ class OffloadPromMetrics(KVConnectorPromMetrics):
         - keys are transfer type strings (e.g., "cpu_to_gpu", "gpu_to_cpu")
         - values are lists of OffloadingOperationMetrics objects
         """
-
-        for transfer_type, ops in transfer_stats_data.items():
-            # Cache:
-            if (engine_idx, transfer_type) not in self.histogram_transfer_size:
-                self.histogram_transfer_size[(engine_idx, transfer_type)] = (
-                    self._histogram_transfer_size.labels(
-                        *(self.per_engine_labelvalues[engine_idx] + [transfer_type])
+        for spec_name, transfer_type_data in transfer_stats_data.items():
+            for transfer_type, ops in transfer_type_data.items():
+                # Cache:
+                if (
+                    engine_idx,
+                    spec_name,
+                    transfer_type,
+                ) not in self.histogram_transfer_size:
+                    self.histogram_transfer_size[
+                        (engine_idx, spec_name, transfer_type)
+                    ] = self._histogram_transfer_size.labels(
+                        *(
+                            self.per_engine_labelvalues[engine_idx]
+                            + [spec_name, transfer_type]
+                        )
                     )
-                )
-                self.counter_kv_bytes[(engine_idx, transfer_type)] = (
-                    self._counter_kv_bytes.labels(
-                        *(self.per_engine_labelvalues[engine_idx] + [transfer_type])
+                    self.counter_kv_bytes[(engine_idx, spec_name, transfer_type)] = (
+                        self._counter_kv_bytes.labels(
+                            *(
+                                self.per_engine_labelvalues[engine_idx]
+                                + [spec_name, transfer_type]
+                            )
+                        )
                     )
-                )
-                self.counter_kv_transfer_time[(engine_idx, transfer_type)] = (
-                    self._counter_kv_transfer_time.labels(
-                        *(self.per_engine_labelvalues[engine_idx] + [transfer_type])
+                    self.counter_kv_transfer_time[
+                        (engine_idx, spec_name, transfer_type)
+                    ] = self._counter_kv_transfer_time.labels(
+                        *(
+                            self.per_engine_labelvalues[engine_idx]
+                            + [spec_name, transfer_type]
+                        )
                     )
-                )
+                    # Process ops:
+                    assert isinstance(ops, list)
+                    for (
+                        op
+                    ) in ops:  # ops is a list of serialized OffloadingOperationMetrics
+                        assert isinstance(op, dict)
+                        # Observe size histogram
+                        self.histogram_transfer_size[
+                            (engine_idx, spec_name, transfer_type)
+                        ].observe(op["op_size"])
 
-            # Process ops:
-            assert isinstance(ops, list)
-            for op in ops:  # ops is a list of serialized OffloadingOperationMetrics
-                assert isinstance(op, dict)
-                # Observe size histogram
-                self.histogram_transfer_size[(engine_idx, transfer_type)].observe(
-                    op["op_size"]
-                )
+                        # Increment byte and time counters
+                        self.counter_kv_bytes[
+                            (engine_idx, spec_name, transfer_type)
+                        ].inc(op["op_size"])
 
-                # Increment byte and time counters
-                self.counter_kv_bytes[(engine_idx, transfer_type)].inc(op["op_size"])
-
-                self.counter_kv_transfer_time[(engine_idx, transfer_type)].inc(
-                    op["op_time"]
-                )
+                        self.counter_kv_transfer_time[
+                            (engine_idx, spec_name, transfer_type)
+                        ].inc(op["op_time"])

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/worker.py
@@ -353,6 +353,7 @@ class OffloadingConnectorWorker:
                 and transfer_result.transfer_type is not None
             ):
                 self.kv_connector_stats.record_transfer(
+                    spec_name=self.spec.__class__.__name__,
                     num_bytes=transfer_result.transfer_size,
                     time=transfer_result.transfer_time,
                     transfer_type=transfer_result.transfer_type,


### PR DESCRIPTION


## Purpose
Fix https://github.com/vllm-project/vllm/issues/39906

 Fix prevent duplicate Prometheus metrics when using MultiConnector with multiple OffloadingConnector instances

## Test Plan

before
```
vllm serve /mnt/data4/models/Qwen/Qwen3-8B --enable-auto-tool-choice --tool-call-parser hermes --reasoning-parser qwen3 --served-model-name my-model claude-haiku-4-5-20251001 claude-sonnet-4-6 claude-opus-4-6 gpt-5 --kv-transfer-config '{
  "kv_connector":"MultiConnector",
  "kv_role":"kv_both",
  "kv_connector_extra_config": {
    "connectors": [
      {
        "kv_connector": "OffloadingConnector",
        "kv_role": "kv_both",
        "kv_connector_extra_config": {
          "cpu_bytes_to_use": 64424509440
        }
      },
      {
        "kv_connector": "OffloadingConnector",
        "kv_role": "kv_both",
        "kv_connector_extra_config": {
          "spec_name": "FileOffloadingSpec",
          "storage_dir": "/mnt/files-storage/",
          "num_blocks": 64
        }
      }
    ]
  }
}'
....
....

Server pid=307931)   File "/mnt/data4/jxy/vllm/vllm/v1/metrics/loggers.py", line 1329, in __init__
(APIServer pid=307931)     PrometheusStatLogger(vllm_config, self.engine_indexes)
(APIServer pid=307931)   File "/mnt/data4/jxy/vllm/vllm/v1/metrics/loggers.py", line 441, in __init__
(APIServer pid=307931)     self.kv_connector_prom = self._kv_connector_cls(
(APIServer pid=307931)                              ^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=307931)   File "/mnt/data4/jxy/vllm/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py", line 165, in __init__
(APIServer pid=307931)     self.prom_metrics = connector_cls.build_prom_metrics(
(APIServer pid=307931)                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=307931)   File "/mnt/data4/jxy/vllm/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py", line 566, in build_prom_metrics
(APIServer pid=307931)     connector_prom = connector_cls.build_prom_metrics(
(APIServer pid=307931)                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(APIServer pid=307931)   File "/mnt/data4/jxy/vllm/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py", line 175, in build_prom_metrics
(APIServer pid=307931)     return OffloadPromMetrics(
(APIServer pid=307931)            ^^^^^^^^^^^^^^^^^^^
(APIServer pid=307931)   File "/mnt/data4/jxy/vllm/vllm/distributed/kv_transfer/kv_connector/v1/offloading/metrics.py", line 105, in __init__
(APIServer pid=307931)     self._counter_kv_bytes = self._counter_cls(
(APIServer pid=307931)                              ^^^^^^^^^^^^^^^^^^
(APIServer pid=307931)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/prometheus_client/metrics.py", line 136, in __init__
(APIServer pid=307931)     registry.register(self)
(APIServer pid=307931)   File "/mnt/data4/jxy/venv/lib/python3.12/site-packages/prometheus_client/registry.py", line 43, in register
(APIServer pid=307931)     raise ValueError(
(APIServer pid=307931) ValueError: Duplicated timeseries in CollectorRegistry: {'vllm:kv_offload_total_bytes_total', 'vllm:kv_offload_total_bytes', 'vllm:kv_offload_total_bytes_created'}
```


this pr
```
vllm serve /mnt/data4/models/Qwen/Qwen3-8B --enable-auto-tool-choice --tool-call-parser hermes --reasoning-parser qwen3 --served-model-name my-model claude-haiku-4-5-20251001 claude-sonnet-4-6 claude-opus-4-6 gpt-5 --kv-transfer-config '{
  "kv_connector":"MultiConnector",
  "kv_role":"kv_both",
  "kv_connector_extra_config": {
    "connectors": [
      {
        "kv_connector": "OffloadingConnector",
        "kv_role": "kv_both",
        "kv_connector_extra_config": {
          "cpu_bytes_to_use": 64424509440
        }
      },
      {
        "kv_connector": "OffloadingConnector",
        "kv_role": "kv_both",
        "kv_connector_extra_config": {
          "spec_name": "FileOffloadingSpec",
          "storage_dir": "/mnt/files-storage/",
          "num_blocks": 64
        }
      }
    ]
  }
}'
ngineCore pid=343533) INFO 04-17 16:00:43 [factory.py:51] Creating offloading spec with name: CPUOffloadingSpec
(EngineCore pid=343533) WARNING 04-17 16:00:43 [spec.py:75] Initializing OffloadingSpec. This API is experimental and subject to change in the future as we iterate the design.
(EngineCore pid=343533) WARNING 04-17 16:00:43 [base.py:189] Initializing KVConnectorBase_V1. This API is experimental and subject to change in the future as we iterate the design.
(EngineCore pid=343533) INFO 04-17 16:00:43 [factory.py:51] Creating offloading spec with name: FileOffloadingSpec
(EngineCore pid=343533) WARNING 04-17 16:00:43 [spec.py:75] Initializing OffloadingSpec. This API is experimental and subject to change in the future as we iterate the design.
(EngineCore pid=343533) INFO 04-17 16:00:43 [spec.py:91] FileOffloadingSpec: storage_dir=/mnt/files-storage/, num_blocks=64, block_size_bytes=2359296
(EngineCore pid=343533) INFO 04-17 16:00:44 [vllm.py:834] Asynchronous scheduling is enabled.
(EngineCore pid=343533) INFO 04-17 16:00:44 [kernel.py:199] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'])
(APIServer pid=341409) INFO 04-17 16:00:44 [api_server.py:598] Supported tasks: ['generate']
(APIServer pid=341409) INFO 04-17 16:00:44 [parser_manager.py:202] "auto" tool choice has been enabled.
(APIServer pid=341409) WARNING 04-17 16:00:44 [model.py:1442] Default vLLM sampling parameters have been overridden by the model's `generation_config.json`: `{'temperature': 0.6, 'top_k': 20, 'top_p': 0.95}`. If this is not intended, please relaunch vLLM instance with `--generation-config vllm`.
(APIServer pid=341409) INFO 04-17 16:00:44 [hf.py:314] Detected the chat template content format to be 'string'. You can set `--chat-template-content-format` to override this.
(APIServer pid=341409) INFO 04-17 16:00:44 [api_server.py:602] Starting vLLM server on http://0.0.0.0:8000
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:37] Available routes are:
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /openapi.json, Methods: HEAD, GET
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /docs, Methods: HEAD, GET
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /docs/oauth2-redirect, Methods: HEAD, GET
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /redoc, Methods: HEAD, GET
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /tokenize, Methods: POST
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /detokenize, Methods: POST
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /load, Methods: GET
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /version, Methods: GET
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /health, Methods: GET
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /metrics, Methods: GET
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /v1/models, Methods: GET
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /ping, Methods: GET
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /ping, Methods: POST
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /invocations, Methods: POST
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /v1/chat/completions, Methods: POST
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /v1/chat/completions/batch, Methods: POST
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /v1/responses, Methods: POST
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /v1/responses/{response_id}, Methods: GET
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /v1/responses/{response_id}/cancel, Methods: POST
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /v1/completions, Methods: POST
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /v1/messages, Methods: POST
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /v1/messages/count_tokens, Methods: POST
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /inference/v1/generate, Methods: POST
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /scale_elastic_ep, Methods: POST
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /is_scaling_elastic_ep, Methods: POST
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /generative_scoring, Methods: POST
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /v1/chat/completions/render, Methods: POST
(APIServer pid=341409) INFO 04-17 16:00:44 [launcher.py:46] Route: /v1/completions/render, Methods: POST
(APIServer pid=341409) INFO:     Started server process [341409]
(APIServer pid=341409) INFO:     Waiting for application startup.
(APIServer pid=341409) INFO:     Application startup complete.
(APIServer pid=341409) INFO:     127.0.0.1:49308 - "GET /v1/models HTTP/1.1" 200 OK

```

## Test Result
metrics
``` 
# HELP vllm:kv_offload_total_bytes_total Number of bytes offloaded by KV connector
# TYPE vllm:kv_offload_total_bytes_total counter
vllm:kv_offload_total_bytes_total{engine="0",model_name="my-model",spec_name="CPUOffloadingSpec",transfer_type="GPU_to_CPU"} 4.2467328e+07
vllm:kv_offload_total_bytes_total{engine="0",model_name="my-model",spec_name="FileOffloadingSpec",transfer_type="GPU_to_FILE"} 4.2467328e+07
# HELP vllm:kv_offload_total_bytes_created Number of bytes offloaded by KV connector
# TYPE vllm:kv_offload_total_bytes_created gauge
vllm:kv_offload_total_bytes_created{engine="0",model_name="my-model",spec_name="CPUOffloadingSpec",transfer_type="GPU_to_CPU"} 1.7766709221073456e+09
vllm:kv_offload_total_bytes_created{engine="0",model_name="my-model",spec_name="FileOffloadingSpec",transfer_type="GPU_to_FILE"} 1.7766709221800816e+09
# HELP vllm:kv_offload_total_time_total Total time measured by all KV offloading operations
# TYPE vllm:kv_offload_total_time_total counter
vllm:kv_offload_total_time_total{engine="0",model_name="my-model",spec_name="CPUOffloadingSpec",transfer_type="GPU_to_CPU"} 0.0010362240076065064
vllm:kv_offload_total_time_total{engine="0",model_name="my-model",spec_name="FileOffloadingSpec",transfer_type="GPU_to_FILE"} 0.0855576004832983
# HELP vllm:kv_offload_total_time_created Total time measured by all KV offloading operations
# TYPE vllm:kv_offload_total_time_created gauge
vllm:kv_offload_total_time_created{engine="0",model_name="my-model",spec_name="CPUOffloadingSpec",transfer_type="GPU_to_CPU"} 1.776670922107355e+09
vllm:kv_offload_total_time_created{engine="0",model_name="my-model",spec_name="FileOffloadingSpec",transfer_type="GPU_to_FILE"} 1.7766709221800897e+09
# HELP vllm:kv_offload_size Histogram of KV offload transfer size, in bytes.
# TYPE vllm:kv_offload_size histogram
vllm:kv_offload_size_bucket{engine="0",le="1e+06",model_name="my-model",spec_name="CPUOffloadingSpec",transfer_type="GPU_to_CPU"} 0.0
vllm:kv_offload_size_bucket{engine="0",le="5e+06",model_name="my-model",spec_name="CPUOffloadingSpec",transfer_type="GPU_to_CPU"} 0.0
vllm:kv_offload_size_bucket{engine="0",le="1e+07",model_name="my-model",spec_name="CPUOffloadingSpec",transfer_type="GPU_to_CPU"} 0.0
vllm:kv_offload_size_bucket{engine="0",le="2e+07",model_name="my-model",spec_name="CPUOffloadingSpec",transfer_type="GPU_to_CPU"} 0.0
vllm:kv_offload_size_bucket{engine="0",le="4e+07",model_name="my-model",spec_name="CPUOffloadingSpec",transfer_type="GPU_to_CPU"} 0.0
vllm:kv_offload_size_bucket{engine="0",le="6e+07",model_name="my-model",spec_name="CPUOffloadingSpec",transfer_type="GPU_to_CPU"} 1.0
vllm:kv_offload_size_bucket{engine="0",le="8e+07",model_name="my-model",spec_name="CPUOffloadingSpec",transfer_type="GPU_to_CPU"} 1.0
vllm:kv_offload_size_bucket{engine="0",le="1e+08",model_name="my-model",spec_name="CPUOffloadingSpec",transfer_type="GPU_to_CPU"} 1.0
vllm:kv_offload_size_bucket{engine="0",le="1.5e+08",model_name="my-model",spec_name="CPUOffloadingSpec",transfer_type="GPU_to_CPU"} 1.0
vllm:kv_offload_size_bucket{engine="0",le="2e+08",model_name="my-model",spec_name="CPUOffloadingSpec",transfer_type="GPU_to_CPU"} 1.0
vllm:kv_offload_size_bucket{engine="0",le="+Inf",model_name="my-model",spec_name="CPUOffloadingSpec",transfer_type="GPU_to_CPU"} 1.0
vllm:kv_offload_size_count{engine="0",model_name="my-model",spec_name="CPUOffloadingSpec",transfer_type="GPU_to_CPU"} 1.0
vllm:kv_offload_size_sum{engine="0",model_name="my-model",spec_name="CPUOffloadingSpec",transfer_type="GPU_to_CPU"} 4.2467328e+07
vllm:kv_offload_size_bucket{engine="0",le="1e+06",model_name="my-model",spec_name="FileOffloadingSpec",transfer_type="GPU_to_FILE"} 0.0
vllm:kv_offload_size_bucket{engine="0",le="5e+06",model_name="my-model",spec_name="FileOffloadingSpec",transfer_type="GPU_to_FILE"} 0.0
vllm:kv_offload_size_bucket{engine="0",le="1e+07",model_name="my-model",spec_name="FileOffloadingSpec",transfer_type="GPU_to_FILE"} 0.0
vllm:kv_offload_size_bucket{engine="0",le="2e+07",model_name="my-model",spec_name="FileOffloadingSpec",transfer_type="GPU_to_FILE"} 0.0
vllm:kv_offload_size_bucket{engine="0",le="4e+07",model_name="my-model",spec_name="FileOffloadingSpec",transfer_type="GPU_to_FILE"} 0.0
vllm:kv_offload_size_bucket{engine="0",le="6e+07",model_name="my-model",spec_name="FileOffloadingSpec",transfer_type="GPU_to_FILE"} 1.0
vllm:kv_offload_size_bucket{engine="0",le="8e+07",model_name="my-model",spec_name="FileOffloadingSpec",transfer_type="GPU_to_FILE"} 1.0
vllm:kv_offload_size_bucket{engine="0",le="1e+08",model_name="my-model",spec_name="FileOffloadingSpec",transfer_type="GPU_to_FILE"} 1.0
vllm:kv_offload_size_bucket{engine="0",le="1.5e+08",model_name="my-model",spec_name="FileOffloadingSpec",transfer_type="GPU_to_FILE"} 1.0
vllm:kv_offload_size_bucket{engine="0",le="2e+08",model_name="my-model",spec_name="FileOffloadingSpec",transfer_type="GPU_to_FILE"} 1.0
vllm:kv_offload_size_bucket{engine="0",le="+Inf",model_name="my-model",spec_name="FileOffloadingSpec",transfer_type="GPU_to_FILE"} 1.0
vllm:kv_offload_size_count{engine="0",model_name="my-model",spec_name="FileOffloadingSpec",transfer_type="GPU_to_FILE"} 1.0
vllm:kv_offload_size_sum{engine="0",model_name="my-model",spec_name="FileOffloadingSpec",transfer_type="GPU_to_FILE"} 4.2467328e+07
# HELP vllm:kv_offload_size_created Histogram of KV offload transfer size, in bytes.

```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

