### PR TITLE
Add torch compile for qwen3_vl encoder

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -48,7 +48,10 @@ from transformers.models.qwen3_vl.video_processing_qwen3_vl import (
 )
 from transformers.video_utils import VideoMetadata
 
-from vllm.compilation.decorators import support_torch_compile
+from vllm.compilation.decorators import (
+    should_torch_compile_mm_encoder,
+    support_torch_compile,
+)
 from vllm.config import VllmConfig
 from vllm.config.multimodal import BaseDummyOptions, VideoDummyOptions
 from vllm.distributed import get_pp_group, parallel_state
@@ -343,6 +346,13 @@ def pos_embed_interpolate_native(
     return repeated.to(dtype=dtype)
 
 
+@support_torch_compile(
+    dynamic_arg_dims={
+        "x": 0,
+    },
+    enable_if=should_torch_compile_mm_encoder,
+    is_encoder=True,
+)
 class Qwen3_VisionPatchEmbed(nn.Module):
     def __init__(
         self,
@@ -409,6 +419,16 @@ class Qwen3_VisionMLP(nn.Module):
         return mlp_output
 
 
+@support_torch_compile(
+    dynamic_arg_dims={
+        "x": 0,
+        "cu_seqlens": 0,
+        "rotary_pos_emb_cos": 0,
+        "rotary_pos_emb_sin": 0,
+    },
+    enable_if=should_torch_compile_mm_encoder,
+    is_encoder=True,
+)
 class Qwen3_VisionBlock(nn.Module):
     def __init__(
         self,
@@ -463,6 +483,13 @@ class Qwen3_VisionBlock(nn.Module):
         return x
 
 
+@support_torch_compile(
+    dynamic_arg_dims={
+        "x": 0,
+    },
+    enable_if=should_torch_compile_mm_encoder,
+    is_encoder=True,
+)
 class Qwen3_VisionPatchMerger(nn.Module):
     def __init__(
         self,

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -425,6 +425,7 @@ class Qwen3_VisionMLP(nn.Module):
         "cu_seqlens": 0,
         "rotary_pos_emb_cos": 0,
         "rotary_pos_emb_sin": 0,
+        "sequence_lengths": 0,
     },
     enable_if=should_torch_compile_mm_encoder,
     is_encoder=True,

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -48,7 +48,10 @@ from transformers.models.qwen3_vl.video_processing_qwen3_vl import (
 )
 from transformers.video_utils import VideoMetadata
 
-from vllm.compilation.decorators import support_torch_compile
+from vllm.compilation.decorators import (
+    should_torch_compile_mm_encoder,
+    support_torch_compile,
+)
 from vllm.config import VllmConfig
 from vllm.config.multimodal import (
     BaseDummyOptions,
@@ -356,6 +359,13 @@ def pos_embed_interpolate_native(
     return repeated.to(dtype=dtype)
 
 
+@support_torch_compile(
+    dynamic_arg_dims={
+        "x": 0,
+    },
+    enable_if=should_torch_compile_mm_encoder,
+    is_encoder=True,
+)
 class Qwen3_VisionPatchEmbed(nn.Module):
     def __init__(
         self,
@@ -422,6 +432,16 @@ class Qwen3_VisionMLP(nn.Module):
         return mlp_output
 
 
+@support_torch_compile(
+    dynamic_arg_dims={
+        "x": 0,
+        "cu_seqlens": 0,
+        "rotary_pos_emb_cos": 0,
+        "rotary_pos_emb_sin": 0,
+    },
+    enable_if=should_torch_compile_mm_encoder,
+    is_encoder=True,
+)
 class Qwen3_VisionBlock(nn.Module):
     def __init__(
         self,
@@ -476,6 +496,13 @@ class Qwen3_VisionBlock(nn.Module):
         return x
 
 
+@support_torch_compile(
+    dynamic_arg_dims={
+        "x": 0,
+    },
+    enable_if=should_torch_compile_mm_encoder,
+    is_encoder=True,
+)
 class Qwen3_VisionPatchMerger(nn.Module):
     def __init__(
         self,

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -438,6 +438,7 @@ class Qwen3_VisionMLP(nn.Module):
         "cu_seqlens": 0,
         "rotary_pos_emb_cos": 0,
         "rotary_pos_emb_sin": 0,
+        "sequence_lengths": 0,
     },
     enable_if=should_torch_compile_mm_encoder,
     is_encoder=True,

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -497,13 +497,6 @@ class Qwen3_VisionBlock(nn.Module):
         return x
 
 
-@support_torch_compile(
-    dynamic_arg_dims={
-        "x": 0,
-    },
-    enable_if=should_torch_compile_mm_encoder,
-    is_encoder=True,
-)
 class Qwen3_VisionPatchMerger(nn.Module):
     def __init__(
         self,


### PR DESCRIPTION


## Purpose

torch.compile can accelerate the computation of the encoder

## Test Plan

```shell
python benchmark_qwen3_vl_encoder.py --model Qwen/Qwen3-VL-2B-Instruct \
    --grid-configs 1-8-8 1-16-16 1-32-32 1-48-48 4-16-16 8-16-16 \
    --num-warmup 10 --num-iters 30
```

<details>

<summary>benchmark_qwen3_vl_encoder.py</summary>

```
"""Benchmark Qwen3 VL vision encoder with and without torch.compile.

This script directly instantiates the Qwen3_VisionTransformer module,
feeds it dummy pixel data, and compares eager vs. compiled latency.

Usage:
    # Quick run with default settings
    python benchmarks/benchmark_qwen3_vl_encoder.py \
        --model Qwen/Qwen3-VL-2B

    # Custom grid configs and iterations
    python benchmarks/benchmark_qwen3_vl_encoder.py \
        --model Qwen/Qwen3-VL-2B \
        --grid-configs 1-16-16 1-32-32 4-16-16 \
        --num-warmup 10 --num-iters 30

    # Use bfloat16 precision
    python benchmarks/benchmark_qwen3_vl_encoder.py \
        --model Qwen/Qwen3-VL-2B --dtype bfloat16

    # Force FlashInfer for vision self-attention (same as --mm-encoder-attn-backend)
    python benchmarks/benchmark_qwen3_vl_encoder.py \
        --model Qwen/Qwen3-VL-2B \
        --mm-encoder-attn-backend FLASHINFER
"""

import argparse
import time
from unittest.mock import MagicMock

import torch
import torch.nn as nn
from transformers import AutoConfig

torch._dynamo.config.recompile_limit = 1000

# Default grid configurations to benchmark.
# Format: [t, h, w] where t=temporal frames, h/w=spatial grid in patch units.
# h and w must be divisible by spatial_merge_size (default 2).
DEFAULT_GRID_CONFIGS = [
    # Small image (224x224 -> 16x16 patches)
    [1, 16, 16],
    # Medium image (448x448 -> 32x32 patches)
    [1, 32, 32],
    # Large image (672x672 -> 48x48 patches)
    [1, 48, 48],
    # Short video (4 frames, 224x224)
    [4, 16, 16],
    # Longer video (8 frames, 224x224)
    [8, 16, 16],
]

DTYPE_MAP = {
    "float16": torch.float16,
    "bfloat16": torch.bfloat16,
    "float32": torch.float32,
}


def parse_mm_encoder_attn_backend(value: str):
    """Parse `--mm-encoder-attn-backend` (same names as vLLM CLI)."""
    from vllm.v1.attention.backends.registry import AttentionBackendEnum

    key = value.strip()
    if key.lower() == "auto":
        return None
    try:
        return AttentionBackendEnum[key.upper()]
    except KeyError as exc:
        names = ", ".join(sorted(b.name for b in AttentionBackendEnum))
        raise argparse.ArgumentTypeError(
            f"Unknown MM encoder attention backend {value!r}. "
            f"Use 'auto' or one of: {names}"
        ) from exc


def parse_grid_config(s: str) -> list[int]:
    """Parse a grid config string like '1-16-16' into [1, 16, 16]."""
    parts = s.split("-")
    if len(parts) != 3:
        raise argparse.ArgumentTypeError(
            f"Grid config must be in format 't-h-w', got '{s}'"
        )
    return [int(p) for p in parts]


def _init_distributed_env():
    """Initialize a minimal single-GPU distributed environment.

    Qwen3_VisionTransformer's __init__ calls
    parallel_state.get_tensor_model_parallel_world_size(), which requires
    the TP group to be initialized.  For a standalone single-GPU benchmark
    we mock the TP group with world_size=1.
    """
    import vllm.distributed.parallel_state as ps

    if ps._TP is not None:
        return  # already initialised

    mock_tp = MagicMock()
    mock_tp.world_size = 1
    mock_tp.rank_in_group = 0
    mock_tp.rank = 0
    mock_tp.local_rank = 0
    ps._TP = mock_tp


def build_encoder(
    model_name: str,
    dtype: torch.dtype,
    mm_encoder_attn_backend=None,
) -> nn.Module:
    """Build a Qwen3_VisionTransformer from the HF model config."""
    _init_distributed_env()

    from vllm.config import ModelConfig, VllmConfig, set_current_vllm_config
    from vllm.model_executor.models.qwen3_vl import Qwen3_VisionTransformer

    hf_config = AutoConfig.from_pretrained(model_name, trust_remote_code=True)
    vision_config = hf_config.vision_config

    if mm_encoder_attn_backend is None:
        vllm_config = VllmConfig()
    else:
        # VllmConfig.model_config must be a real ModelConfig (Pydantic), not a stub,
        # so get_vit_attn_backend can read multimodal_config.mm_encoder_attn_backend.
        model_config = ModelConfig(
            model=model_name,
            trust_remote_code=True,
            mm_encoder_attn_backend=mm_encoder_attn_backend,
        )
        vllm_config = VllmConfig(model_config=model_config)
    with set_current_vllm_config(vllm_config):
        encoder = Qwen3_VisionTransformer(vision_config)
    encoder = encoder.to(device="cuda", dtype=dtype)
    encoder.eval()
    return encoder


def make_dummy_input(
    encoder: nn.Module,
    grid_thw: list[list[int]],
    dtype: torch.dtype,
) -> tuple[torch.Tensor, dict[str, torch.Tensor]]:
    """Create dummy pixel values and pre-compute encoder metadata."""
    patch_size = encoder.patch_size
    temporal_patch_size = encoder.temporal_patch_size
    in_channels = encoder.patch_embed.proj.in_channels

    flattened_size = in_channels * temporal_patch_size * patch_size * patch_size
    num_patches = sum(t * h * w for t, h, w in grid_thw)

    x = torch.randn(num_patches, flattened_size, device="cuda", dtype=dtype)
    metadata = encoder.prepare_encoder_metadata(grid_thw)
    return x, metadata


def compile_encoder(encoder: nn.Module, backend: str) -> nn.Module:
    """Apply torch.compile to the encoder sub-modules."""
    encoder.patch_embed = torch.compile(encoder.patch_embed, backend=backend)
    for i, block in enumerate(encoder.blocks):
        encoder.blocks[i] = torch.compile(block, backend=backend)
    encoder.merger = torch.compile(encoder.merger, backend=backend)
    # Also compile deepstack mergers if present
    for i, merger in enumerate(encoder.deepstack_merger_list):
        encoder.deepstack_merger_list[i] = torch.compile(merger, backend=backend)
    return encoder


def benchmark_forward(
    encoder: nn.Module,
    x: torch.Tensor,
    grid_thw: list[list[int]],
    metadata: dict[str, torch.Tensor],
    num_warmup: int,
    num_iters: int,
) -> list[float]:
    """Run forward passes and return per-iteration latencies in ms."""
    # Warmup
    for _ in range(num_warmup):
        with torch.no_grad():
            _ = encoder(x, grid_thw, encoder_metadata=metadata)
    torch.cuda.synchronize()

    # Timed runs
    latencies = []
    for _ in range(num_iters):
        start_event = torch.cuda.Event(enable_timing=True)
        end_event = torch.cuda.Event(enable_timing=True)

        start_event.record()
        with torch.no_grad():
            _ = encoder(x, grid_thw, encoder_metadata=metadata)
        end_event.record()
        torch.cuda.synchronize()

        latencies.append(start_event.elapsed_time(end_event))

    return latencies


def format_grid(grid: list[int]) -> str:
    """Format grid config for display."""
    t, h, w = grid
    patch_size = 14  # standard for Qwen3-VL
    img_h, img_w = h * patch_size, w * patch_size
    if t == 1:
        return f"image {img_h}x{img_w} (1-{h}-{w})"
    else:
        return f"video {t}f {img_h}x{img_w} ({t}-{h}-{w})"


def main():
    parser = argparse.ArgumentParser(
        description="Benchmark Qwen3 VL vision encoder with torch.compile"
    )
    parser.add_argument(
        "--model",
        type=str,
        default="Qwen/Qwen3-VL-2B",
        help="HF model name or local path (default: Qwen/Qwen3-VL-2B)",
    )
    parser.add_argument(
        "--grid-configs",
        type=parse_grid_config,
        nargs="+",
        default=None,
        help=(
            "Grid configs to benchmark, format: t-h-w "
            "(e.g. 1-16-16 1-32-32 4-16-16). "
            "Default: a representative set of image/video sizes."
        ),
    )
    parser.add_argument(
        "--num-warmup",
        type=int,
        default=5,
        help="Number of warmup iterations (default: 5)",
    )
    parser.add_argument(
        "--num-iters",
        type=int,
        default=20,
        help="Number of timed iterations (default: 20)",
    )
    parser.add_argument(
        "--dtype",
        type=str,
        default="float16",
        choices=list(DTYPE_MAP.keys()),
        help="Data type (default: float16)",
    )
    parser.add_argument(
        "--compile-backend",
        type=str,
        default="inductor",
        help="torch.compile backend (default: inductor)",
    )
    parser.add_argument(
        "--mm-encoder-attn-backend",
        type=parse_mm_encoder_attn_backend,
        default=None,
        metavar="BACKEND",
        help=(
            "Override vision-encoder self-attention backend (vLLM "
            "`--mm-encoder-attn-backend`), e.g. FLASHINFER or FLASH_ATTN. "
            "Default: auto (platform picks the first supported backend)."
        ),
    )
    args = parser.parse_args()

    from vllm.v1.attention.backends.registry import AttentionBackendEnum

    if args.mm_encoder_attn_backend == AttentionBackendEnum.FLASHINFER:
        try:
            import flashinfer  # noqa: F401
        except ImportError as exc:
            raise SystemExit(
                "FLASHINFER backend requires the flashinfer package "
                "(install flashinfer or use a different "
                "`--mm-encoder-attn-backend`)."
            ) from exc

    grid_configs = args.grid_configs or DEFAULT_GRID_CONFIGS
    dtype = DTYPE_MAP[args.dtype]

    mm_be = args.mm_encoder_attn_backend
    mm_be_str = mm_be.name if mm_be is not None else "auto"

    print("=" * 72)
    print("Qwen3 VL Vision Encoder Benchmark")
    print("=" * 72)
    print(f"  Model:           {args.model}")
    print(f"  dtype:           {args.dtype}")
    print(f"  MM attn backend: {mm_be_str}")
    print(f"  Compile backend: {args.compile_backend}")
    print(f"  Warmup iters:    {args.num_warmup}")
    print(f"  Timed iters:     {args.num_iters}")
    print(f"  Grid configs:    {len(grid_configs)}")
    print("=" * 72)

    # ---- Build two copies: eager and compiled ----
    print("\n[1/4] Building eager encoder...")
    t0 = time.perf_counter()
    eager_encoder = build_encoder(
        args.model, dtype, mm_encoder_attn_backend=args.mm_encoder_attn_backend
    )
    print(f"       Done in {time.perf_counter() - t0:.1f}s")
    print(f"       Resolved vision attn backend: {eager_encoder.attn_backend.name}")

    print(
        "[2/4] Building compiled encoder "
        "(rebuild + state_dict + torch.compile)..."
    )
    t0 = time.perf_counter()
    # deepcopy() fails on vLLM's BasevLLMParameter; rebuild and copy weights.
    compiled_encoder = build_encoder(
        args.model, dtype, mm_encoder_attn_backend=args.mm_encoder_attn_backend
    )
    compiled_encoder.load_state_dict(eager_encoder.state_dict())
    compile_encoder(compiled_encoder, args.compile_backend)
    print(f"       Done in {time.perf_counter() - t0:.1f}s")

    # ---- Run benchmarks ----
    results = []  # list of (grid_str, eager_mean, eager_std, comp_mean, comp_std)

    for idx, grid in enumerate(grid_configs):
        grid_str = format_grid(grid)
        grid_thw = [grid]
        num_patches = grid[0] * grid[1] * grid[2]
        merge = eager_encoder.spatial_merge_size
        out_tokens = num_patches // (merge**2)

        print(
            f"\n[3/4] Benchmarking config {idx + 1}/{len(grid_configs)}: "
            f"{grid_str}  ({num_patches} patches -> {out_tokens} tokens)"
        )

        # Prepare dummy inputs (shared between eager and compiled)
        x, metadata = make_dummy_input(eager_encoder, grid_thw, dtype)
        # Deep copy metadata for compiled encoder (different device tensors)
        metadata_compiled = {
            k: (v.clone() if isinstance(v, torch.Tensor) else v)
            for k, v in metadata.items()
        }

        # Eager benchmark
        print("       Running eager...")
        eager_lats = benchmark_forward(
            eager_encoder,
            x,
            grid_thw,
            metadata,
            args.num_warmup,
            args.num_iters,
        )
        eager_mean = sum(eager_lats) / len(eager_lats)
        eager_std = (
            sum((l - eager_mean) ** 2 for l in eager_lats) / len(eager_lats)
        ) ** 0.5

        # Compiled benchmark
        print("       Running compiled...")
        comp_lats = benchmark_forward(
            compiled_encoder,
            x,
            grid_thw,
            metadata_compiled,
            args.num_warmup,
            args.num_iters,
        )
        comp_mean = sum(comp_lats) / len(comp_lats)
        comp_std = (
            sum((l - comp_mean) ** 2 for l in comp_lats) / len(comp_lats)
        ) ** 0.5

        speedup = eager_mean / comp_mean if comp_mean > 0 else float("inf")
        results.append((grid_str, eager_mean, eager_std, comp_mean, comp_std))

        print(
            f"       Eager:    {eager_mean:8.2f} +/- {eager_std:.2f} ms"
        )
        print(
            f"       Compiled: {comp_mean:8.2f} +/- {comp_std:.2f} ms"
        )
        print(f"       Speedup:  {speedup:.2f}x")

    # ---- Summary Table ----
    print("\n")
    print("=" * 72)
    print("Summary")
    print("=" * 72)
    header = (
        f"{'Config':<35} {'Eager (ms)':>12} {'Compiled (ms)':>14} "
        f"{'Speedup':>8}"
    )
    print(header)
    print("-" * len(header))
    for grid_str, e_mean, e_std, c_mean, c_std in results:
        speedup = e_mean / c_mean if c_mean > 0 else float("inf")
        pct = (1 - c_mean / e_mean) * 100 if e_mean > 0 else 0
        print(
            f"{grid_str:<35} {e_mean:7.2f}+/-{e_std:<4.1f} "
            f"{c_mean:8.2f}+/-{c_std:<4.1f}  "
            f"{speedup:5.2f}x ({pct:+.1f}%)"
        )
    print("=" * 72)


if __name__ == "__main__":
    main()
```

</details>


## Test Result

```
========================================================================
Summary
========================================================================
Config                                Eager (ms)      Compiled (ms)  Speedup
------------------------------------------------------------------------
image 112x112 (1-8-8)                 11.17+/-0.3     10.22+/-0.6    1.09x (+8.5%)
image 224x224 (1-16-16)               11.26+/-0.4     10.02+/-0.2    1.12x (+11.0%)
image 448x448 (1-32-32)               11.82+/-0.3     10.36+/-0.5    1.14x (+12.4%)
image 672x672 (1-48-48)               21.29+/-0.1     20.67+/-0.1    1.03x (+2.9%)
video 4f 224x224 (4-16-16)            11.78+/-0.2     10.39+/-0.3    1.13x (+11.8%)
video 8f 224x224 (8-16-16)            15.17+/-0.0     14.60+/-0.1    1.04x (+3.7%)
========================================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

