### PR TITLE
fix(gemma4): use weightless k_norm for KV-shared layers (#1)

### DIFF
--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -372,6 +372,15 @@ class Gemma4Attention(nn.Module):
                         f"{kv_shared_layer_index}.self_attn.attn"
                     )
 
+        # KV-shared layers don't apply k_norm in forward() and their
+        # checkpoints omit k_norm weights.  Replace the learnable k_norm
+        # created above with a weightless version so the parameter count
+        # matches the checkpoint.
+        if self.is_kv_shared_layer:
+            self.k_norm = RMSNorm(
+                self.head_dim, eps=config.rms_norm_eps, has_weight=False
+            )
+
         self.rotary_emb = get_rope(
             self.head_dim,
             max_position=max_position_embeddings,


### PR DESCRIPTION
Gemma-4 E4B checkpoints omit k_norm.weight for KV-shared layers (the last num_kv_shared_layers layers) because those layers reuse KV states from earlier layers and never apply k_norm in the forward pass.  vLLM, however, created a learnable k_norm for every layer, leading to a ValueError about uninitialized weights.

Fix: after detecting that a layer is KV-shared, replace k_norm with a weightless RMSNorm (has_weight=False) so no checkpoint weight is expected.

Co-authored-by: GitHub Copilot

Agent-Logs-Url: https://github.com/VarunGumma/vllm/sessions/f42f93c4-84b0-45e5-93c4-f0be054dcbea




## Purpose
To load Gemma-4-E4B/E2B models with shared `kv` layers, which fail as the saved checkpoint doesn't store the shared layer parameters. 

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

