### PR TITLE
[TurboQuant] Add NIAH long-context eval for TurboQuant KV cache

### DIFF
--- a/tests/evals/niah/__init__.py
+++ b/tests/evals/niah/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/tests/evals/niah/configs/Qwen3-4B-TQ-k3v4nc-niah.yaml
+++ b/tests/evals/niah/configs/Qwen3-4B-TQ-k3v4nc-niah.yaml
@@ -1,0 +1,6 @@
+model_name: "Qwen/Qwen3-4B"
+accuracy_threshold: 0.70
+context_lengths: [4096, 8192, 16384, 32768]
+depths: [0.0, 0.25, 0.5, 0.75, 1.0]
+num_trials: 3
+server_args: "--kv-cache-dtype turboquant_k3v4_nc --max-model-len 32768"

--- a/tests/evals/niah/configs/Qwen3-4B-TQ-k8v4-niah.yaml
+++ b/tests/evals/niah/configs/Qwen3-4B-TQ-k8v4-niah.yaml
@@ -1,0 +1,6 @@
+model_name: "Qwen/Qwen3-4B"
+accuracy_threshold: 0.80
+context_lengths: [4096, 8192, 16384, 32768]
+depths: [0.0, 0.25, 0.5, 0.75, 1.0]
+num_trials: 3
+server_args: "--kv-cache-dtype turboquant_k8v4 --max-model-len 32768"

--- a/tests/evals/niah/configs/Qwen3-4B-TQ-t3nc-niah.yaml
+++ b/tests/evals/niah/configs/Qwen3-4B-TQ-t3nc-niah.yaml
@@ -1,0 +1,6 @@
+model_name: "Qwen/Qwen3-4B"
+accuracy_threshold: 0.65
+context_lengths: [4096, 8192, 16384, 32768]
+depths: [0.0, 0.25, 0.5, 0.75, 1.0]
+num_trials: 3
+server_args: "--kv-cache-dtype turboquant_3bit_nc --max-model-len 32768"

--- a/tests/evals/niah/configs/Qwen3-4B-TQ-t4nc-niah.yaml
+++ b/tests/evals/niah/configs/Qwen3-4B-TQ-t4nc-niah.yaml
@@ -1,0 +1,6 @@
+model_name: "Qwen/Qwen3-4B"
+accuracy_threshold: 0.75
+context_lengths: [4096, 8192, 16384, 32768]
+depths: [0.0, 0.25, 0.5, 0.75, 1.0]
+num_trials: 3
+server_args: "--kv-cache-dtype turboquant_4bit_nc --max-model-len 32768"

--- a/tests/evals/niah/configs/Qwen3-4B-baseline-niah.yaml
+++ b/tests/evals/niah/configs/Qwen3-4B-baseline-niah.yaml
@@ -1,0 +1,6 @@
+model_name: "Qwen/Qwen3-4B"
+accuracy_threshold: 0.90
+context_lengths: [4096, 8192, 16384, 32768]
+depths: [0.0, 0.25, 0.5, 0.75, 1.0]
+num_trials: 3
+server_args: "--max-model-len 32768"

--- a/tests/evals/niah/configs/models-turboquant.txt
+++ b/tests/evals/niah/configs/models-turboquant.txt
@@ -1,0 +1,5 @@
+Qwen3-4B-baseline-niah.yaml
+Qwen3-4B-TQ-k8v4-niah.yaml
+Qwen3-4B-TQ-t4nc-niah.yaml
+Qwen3-4B-TQ-k3v4nc-niah.yaml
+Qwen3-4B-TQ-t3nc-niah.yaml

--- a/tests/evals/niah/conftest.py
+++ b/tests/evals/niah/conftest.py
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from pathlib import Path
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--config-list-file",
+        default="configs/models-turboquant.txt",
+        help="File containing list of config files to test",
+    )
+
+
+def pytest_generate_tests(metafunc):
+    if "config_filename" in metafunc.fixturenames:
+        config_list_file = metafunc.config.getoption("--config-list-file")
+
+        config_list_path = Path(config_list_file)
+        if not config_list_path.is_absolute():
+            test_dir_path = Path(__file__).parent / config_list_file
+            if test_dir_path.exists():
+                config_list_path = test_dir_path
+            else:
+                config_list_path = Path.cwd() / config_list_file
+
+        config_files = []
+        if config_list_path.exists():
+            config_dir = config_list_path.parent
+            with open(config_list_path) as f:
+                for line in f:
+                    line = line.strip()
+                    if line and not line.startswith("#"):
+                        config_path = config_dir / line
+                        if config_path.exists():
+                            config_files.append(config_path)
+
+        if config_files:
+            metafunc.parametrize(
+                "config_filename",
+                config_files,
+                ids=[cf.stem for cf in config_files],
+            )

--- a/tests/evals/niah/niah_eval.py
+++ b/tests/evals/niah/niah_eval.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Needle-in-a-Haystack (NIAH) evaluation for long-context KV cache quality.
+
+Inserts a fact ("needle") at a specific depth within a long filler text
+("haystack"), then asks the model to recall it. Measures retrieval accuracy
+across context lengths and needle depths.
+"""
+
+import asyncio
+import random
+import time
+
+import aiohttp
+
+HAYSTACK_SENTENCE = (
+    "The grass is green. The sky is blue. The sun is yellow. "
+    "Filler text for context padding. Here is some more text. "
+)
+
+NEEDLE_TEMPLATE = "The special magic number is {number}."
+
+QUERY = "What is the special magic number mentioned in the text above?"
+
+
+def build_niah_prompt(
+    context_tokens: int,
+    depth: float,
+    tokenizer,
+    needle_number: int,
+) -> tuple[str, str]:
+    """Build a NIAH prompt with needle at given depth.
+
+    Returns (prompt, expected_answer).
+    """
+    needle = NEEDLE_TEMPLATE.format(number=needle_number)
+    query_tokens = len(tokenizer.encode(QUERY))
+    needle_tokens = len(tokenizer.encode(needle))
+    available = context_tokens - query_tokens - needle_tokens - 20
+
+    haystack_sentence_tokens = len(tokenizer.encode(HAYSTACK_SENTENCE))
+    num_sentences = max(1, available // haystack_sentence_tokens)
+    insert_pos = max(0, int(num_sentences * depth))
+
+    sentences = [HAYSTACK_SENTENCE] * num_sentences
+    sentences.insert(insert_pos, needle + " ")
+    haystack = "".join(sentences)
+
+    prompt = f"{haystack}\n\n{QUERY}"
+    return prompt, str(needle_number)
+
+
+async def _send_request(
+    session: aiohttp.ClientSession,
+    url: str,
+    model: str,
+    prompt: str,
+    max_tokens: int = 32,
+) -> str:
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "temperature": 0,
+    }
+    async with session.post(f"{url}/v1/completions", json=payload) as resp:
+        data = await resp.json()
+        return data["choices"][0]["text"].strip()
+
+
+async def evaluate_niah(
+    host: str,
+    port: int,
+    model: str,
+    context_lengths: list[int],
+    depths: list[float],
+    tokenizer,
+    num_trials: int = 1,
+) -> dict:
+    """Run NIAH evaluation grid.
+
+    Returns dict with results per (context_length, depth).
+    """
+    url = f"{host}:{port}"
+    results = {}
+    total = 0
+    correct = 0
+
+    async with aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(total=300)
+    ) as session:
+        for ctx_len in context_lengths:
+            for depth in depths:
+                hits = 0
+                for trial in range(num_trials):
+                    number = random.randint(100000, 999999)
+                    prompt, expected = build_niah_prompt(
+                        ctx_len, depth, tokenizer, number
+                    )
+                    output = await _send_request(
+                        session, url, model, prompt
+                    )
+                    if expected in output:
+                        hits += 1
+                        correct += 1
+                    total += 1
+
+                accuracy = hits / num_trials
+                results[(ctx_len, depth)] = accuracy
+                tag = "✓" if accuracy >= 0.5 else "✗"
+                print(
+                    f"  {tag} ctx={ctx_len:>7}, depth={depth:.1f}: "
+                    f"{hits}/{num_trials} ({accuracy:.0%})"
+                )
+
+    overall = correct / total if total > 0 else 0
+    print(f"\nOverall: {correct}/{total} ({overall:.1%})")
+    return {
+        "grid": results,
+        "overall_accuracy": overall,
+        "total": total,
+        "correct": correct,
+    }

--- a/tests/evals/niah/test_niah_correctness.py
+++ b/tests/evals/niah/test_niah_correctness.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Needle-in-a-Haystack (NIAH) long-context evaluation.
+
+Tests KV cache quantization quality at various context lengths by inserting
+a retrievable fact at different positions and measuring recall accuracy.
+
+Usage:
+    pytest -s -v tests/evals/niah/test_niah_correctness.py \
+        --config-list-file=configs/models-turboquant.txt
+"""
+
+import asyncio
+import shlex
+
+import pytest
+import yaml
+from transformers import AutoTokenizer
+
+from tests.utils import RemoteOpenAIServer
+
+from .niah_eval import evaluate_niah
+
+
+def test_niah_correctness(config_filename):
+    eval_config = yaml.safe_load(config_filename.read_text(encoding="utf-8"))
+
+    server_args_str = eval_config.get("server_args", "")
+    server_args = shlex.split(server_args_str) if server_args_str else []
+    server_args.extend(["--trust-remote-code", "--disable-uvicorn-access-log"])
+
+    model_name = eval_config["model_name"]
+    context_lengths = eval_config.get("context_lengths", [4096, 8192, 16384, 32768])
+    depths = eval_config.get("depths", [0.0, 0.25, 0.5, 0.75, 1.0])
+    accuracy_threshold = eval_config.get("accuracy_threshold", 0.8)
+    num_trials = eval_config.get("num_trials", 3)
+
+    tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+
+    print(f"Starting NIAH evaluation for model: {model_name}")
+    print(f"Context lengths: {context_lengths}")
+    print(f"Depths: {depths}")
+    print(f"Trials per cell: {num_trials}")
+    print(f"Accuracy threshold: {accuracy_threshold}")
+    print(f"Server args: {' '.join(server_args)}")
+
+    with RemoteOpenAIServer(
+        model_name,
+        server_args,
+        max_wait_seconds=eval_config.get("startup_max_wait_seconds", 600),
+    ) as remote_server:
+        url = remote_server.url_for("health")
+        host = url.rsplit("/health", 1)[0]
+        if ":" in host.rsplit("//", 1)[-1]:
+            base, port_str = host.rsplit(":", 1)
+            port = int(port_str)
+            host = base
+        else:
+            port = 8000
+
+        results = asyncio.run(
+            evaluate_niah(
+                host=host,
+                port=port,
+                model=model_name,
+                context_lengths=context_lengths,
+                depths=depths,
+                tokenizer=tokenizer,
+                num_trials=num_trials,
+            )
+        )
+
+    overall = results["overall_accuracy"]
+    print(f"\nNIAH Results for {model_name}:")
+    print(f"  Overall accuracy: {overall:.3f}")
+    print(f"  Threshold: {accuracy_threshold}")
+    print(f"  Total probes: {results['total']}")
+    print(f"  Correct: {results['correct']}")
+
+    assert overall >= accuracy_threshold, (
+        f"NIAH accuracy {overall:.3f} below threshold {accuracy_threshold} "
+        f"for {model_name}"
+    )
+    print(f"✅ NIAH test passed for {model_name}")


### PR DESCRIPTION
## Purpose

Resolves part of https://github.com/vllm-project/vllm/issues/40069 (Accuracy: long-context evaluations).

Adds a Needle-in-a-Haystack (NIAH) evaluation framework to validate TurboQuant KV cache quantization quality at long context lengths. Inserts a retrievable fact at various depths within filler text and measures recall accuracy across context lengths × needle depths × trials.

This initial PR covers **Qwen3-4B up to 32K context** (the model's max position embeddings). Follow-up PRs will add longer-context models to evaluate at 64K/128K/256K/1M, as well as more comprehensive benchmarks (RULER, LongBench v2).


## Test Plan

```bash
# Run NIAH eval for baseline + all 4 TQ presets
python -m pytest -s -v tests/evals/niah/test_niah_correctness.py \
    --config-list-file=tests/evals/niah/configs/models-turboquant.txt
```

## Test Result

**Hardware:** NVIDIA H20 (SM90 / Hopper)
**Model:** Qwen/Qwen3-4B
**Grid:** 4 context lengths × 5 depths × 3 trials = 60 probes per config

| Config | 4K | 8K | 16K | 32K | Overall | Result |
|--------|----|----|-----|-----|---------|--------|
| Baseline (FP16) | 15/15 | 15/15 | 15/15 | 15/15 | 60/60 (100%) | **PASSED** |
| k8v4 (FP8 key + 4-bit val) | 15/15 | 15/15 | 15/15 | 15/15 | 60/60 (100%) | **PASSED** |
| t4nc (4-bit MSE + NC) | 15/15 | 15/15 | 15/15 | 15/15 | 60/60 (100%) | **PASSED** |
| k3v4nc (3-bit key + 4-bit val + NC) | 14/15 | 15/15 | 15/15 | 15/15 | 59/60 (98.3%) | **PASSED** |
| t3nc (3-bit all + NC) | 15/15 | 15/15 | 15/15 | 15/15 | 60/60 (100%) | **PASSED** |

k3v4nc single miss: ctx=4096 depth=0.8 (2/3) — random fluctuation, within threshold.


---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update
</details>
