### PR TITLE
[Core] Add parent indices to SpecDecodeMetadata

### DIFF
--- a/vllm/v1/spec_decode/metadata.py
+++ b/vllm/v1/spec_decode/metadata.py
@@ -22,6 +22,8 @@ class SpecDecodeMetadata:
     bonus_logits_indices: torch.Tensor
     # [num_tokens + batch_size]
     logits_indices: torch.Tensor
+    # [num_tokens]
+    parents: torch.Tensor | None = None
 
     def __post_init__(self):
         self.max_spec_len = max(self.num_draft_tokens)
@@ -55,6 +57,13 @@ class SpecDecodeMetadata:
         logits_indices = torch.zeros(
             num_tokens + batch_size, dtype=torch.int32, device=device
         )
+
+        parents_np = np.arange(num_tokens, dtype=np.int32) - 1
+        if num_tokens > 0:
+            cu_starts = np.cumsum([0] + num_draft_tokens[:-1], dtype=np.int32)
+            parents_np[cu_starts] = -1
+        parents_tensor = torch.from_numpy(parents_np).to(device)
+
         return cls(
             draft_token_ids=draft_token_ids_tensor,
             num_draft_tokens=num_draft_tokens,
@@ -63,4 +72,5 @@ class SpecDecodeMetadata:
             target_logits_indices=target_logits_indices,
             bonus_logits_indices=bonus_logits_indices,
             logits_indices=logits_indices,
+            parents=parents_tensor,
         )

--- a/vllm/v1/spec_decode/metadata.py
+++ b/vllm/v1/spec_decode/metadata.py
@@ -61,7 +61,7 @@ class SpecDecodeMetadata:
         parents_np = np.arange(num_tokens, dtype=np.int32) - 1
         if num_tokens > 0:
             cu_starts = np.cumsum([0] + num_draft_tokens[:-1], dtype=np.int32)
-            parents_np[cu_starts] = -1
+            parents_np[cu_starts[cu_starts < num_tokens]] = -1
         parents_tensor = torch.from_numpy(parents_np).to(device)
 
         return cls(


### PR DESCRIPTION


## Purpose
This PR introduces a parents tensor field to SpecDecodeMetadata in the V1 engine. Currently, the speculative decoding metadata only supports linear sequences (Top-1). Adding parent indices allows the engine to represent tree structures, which is a prerequisite for supporting non-linear (Top-k) speculative decoding methods such as Medusa, Eagle3, and Suffix Decoding in the V1 architecture.

Key Changes:

- Added parents: torch.Tensor | None = None to SpecDecodeMetadata to track the ancestry of flattened draft tokens.

- Updated make_dummy to generate default linear parent indices using vectorized NumPy operations. This ensures that existing CUDA graph capture and profiling workflows remain functional and backward compatible.

## Test Plan
Verified the correctness of the parent index generation logic using a manual sanity check command.

**Test command**

```
python3 -c "import torch; from vllm.v1.spec_decode.metadata import SpecDecodeMetadata; meta = SpecDecodeMetadata.make_dummy([[1,2], [3]], device='cpu'); print(meta.parents)"
```

## Test Result

The command output confirms that the vectorized logic correctly handles multiple requests by assigning -1 to the root of each sequence and linear indices to subsequent tokens.

```
tensor([-1,  0, -1], dtype=torch.int32)
```

- Verified that parents tensor shape matches num_tokens.
- Confirmed backward compatibility with existing static analysis tools (ruff, mypy).


This is a minor metadata extension. Full integration tests will be included in subsequent PRs that implement actual tree-based proposers (like Suffix Decoding)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

