### PR TITLE
[Kernel] Add SM>=89 guard for Triton block FP8 kernel

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/triton.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/triton.py
@@ -161,6 +161,14 @@ class TritonFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
     def is_supported(cls, compute_capability=None):
         if not current_platform.is_cuda_alike():
             return False, "only cuda like devices are supported."
+        if compute_capability is None:
+            _cc = current_platform.get_device_capability()
+            if _cc is not None:
+                compute_capability = _cc[0] * 10 + _cc[1]
+        if compute_capability is not None and compute_capability < 89:
+            return False, (
+                f"Triton block FP8 needs SM>=89 (fp8e4nv), got SM {compute_capability}."
+            )
         return True, None
 
     def apply_block_scaled_mm(


### PR DESCRIPTION
## Purpose

`TritonFp8BlockScaledMMKernel` uses `tl.dtype('fp8e4nv')` which requires SM 8.9+. On SM<89 (Ampere SM 8.6 / SM 8.0, Turing) the kernel compiles but fails at launch with a cryptic fp8e4nv error.

This adds a version guard inside `is_supported()` so backend selection cleanly rejects the kernel on pre-SM89 hardware, letting `choose_scaled_mm_linear_kernel` pick the next viable candidate.

On CUDA, that next candidate is now Marlin, after #40105 registered `MarlinFP8ScaledMMLinearKernel` in `_POSSIBLE_FP8_BLOCK_KERNELS[PlatformEnum.CUDA]`.

## Scope change

This PR originally also contained a `try/except ValueError` wrapper in `vllm/model_executor/kernels/linear/__init__.py` to fall back to per-tensor FP8 if all block kernels failed. After #40105 merged (placing Marlin ahead of Triton in the candidate list), that wrapper is redundant for the Ampere+CUDA path — Marlin's own `is_supported()` now handles selection without an exception. The hunk has been dropped; this PR is now minimal: 8 lines in `triton.py` only.

## Test Plan

Ran vLLM v0.19.2rc1 on 2× RTX A5000 (SM 8.6, TP=2) with `Qwen3.6-35B-A3B-FP8` (`turboquant_k8v4` KV). With the guard:
- Triton block-FP8 kernel is correctly rejected at `is_supported()` time
- Marlin is selected transparently
- No `try/except` required at call site

## Test Result

- Server starts cleanly, no fp8e4nv runtime errors
- `GPU KV cache size: 946,656 tokens @ 163,840 context` with Marlin path
- Decode 149.9 tok/s (median over 20 requests, stdev 0.09)
- 32/33 quality harness pass (same as Hopper-class baseline)