### PR TITLE
fix: handle non-divisible page sizes in hybrid model KV cache unification

### DIFF
--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -931,7 +931,6 @@ def unify_kv_cache_spec_page_size(
         The updated KVCacheSpec with the same page_size_bytes.
     """
     import math
-    from functools import reduce
 
     page_sizes = {layer.page_size_bytes for layer in kv_cache_spec.values()}
     if len(page_sizes) <= 1:
@@ -949,10 +948,8 @@ def unify_kv_cache_spec_page_size(
     else:
         # Hybrid model: page sizes not naturally divisible.
         # Pad max_page_size UP to nearest multiple of LCM of smaller sizes.
-        def _lcm(a, b):
-            return a * b // math.gcd(a, b)
-        smaller_lcm = reduce(_lcm, smaller_sizes)
-        target_page_size = math.ceil(max_page_size / smaller_lcm) * smaller_lcm
+        smaller_lcm = math.lcm(*smaller_sizes)
+        target_page_size = ((max_page_size + smaller_lcm - 1) // smaller_lcm) * smaller_lcm
         logger.info(
             "Page size unification: padding max %d -> %d (LCM of smaller = %d, "
             "overhead %.3f%%)",

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -917,8 +917,12 @@ def unify_kv_cache_spec_page_size(
     """
     Unify the page size of the given KVCacheSpec. If the page size of all layers
     are the same, return the original KVCacheSpec. If not same, unify the page
-    size by increasing the block size of layers with smaller page size. Raise
-    NotImplementedError if failed to unify the page size.
+    size by increasing the block size of layers with smaller page size.
+
+    For hybrid models (e.g. TurboQuant + DeltaNet/Mamba), page sizes may not
+    be naturally divisible. In this case, the largest page size is padded UP
+    to the nearest multiple of all smaller page sizes using page_size_padded.
+    Memory overhead is typically <0.1%.
 
     Args:
         kv_cache_spec: The KVCacheSpec of each attention layer in the model
@@ -926,27 +930,66 @@ def unify_kv_cache_spec_page_size(
     Returns:
         The updated KVCacheSpec with the same page_size_bytes.
     """
+    import math
+    from functools import reduce
+
     page_sizes = {layer.page_size_bytes for layer in kv_cache_spec.values()}
     if len(page_sizes) <= 1:
         # All layers have the same page size, no need to unify.
         return kv_cache_spec
 
     max_page_size = max(page_sizes)
+
+    # Check if all smaller pages divide max evenly (fast path)
+    smaller_sizes = sorted(ps for ps in page_sizes if ps < max_page_size)
+    all_divide = all(max_page_size % ps == 0 for ps in smaller_sizes)
+
+    if all_divide:
+        target_page_size = max_page_size
+    else:
+        # Hybrid model: page sizes not naturally divisible.
+        # Pad max_page_size UP to nearest multiple of LCM of smaller sizes.
+        def _lcm(a, b):
+            return a * b // math.gcd(a, b)
+        smaller_lcm = reduce(_lcm, smaller_sizes)
+        target_page_size = math.ceil(max_page_size / smaller_lcm) * smaller_lcm
+        logger.info(
+            "Page size unification: padding max %d -> %d (LCM of smaller = %d, "
+            "overhead %.3f%%)",
+            max_page_size, target_page_size, smaller_lcm,
+            (target_page_size - max_page_size) / max_page_size * 100,
+        )
+
     new_kv_cache_spec = {}
     for layer_name, layer_spec in kv_cache_spec.items():
-        if layer_spec.page_size_bytes == max_page_size:
+        layer_page = layer_spec.page_size_bytes
+        if layer_page == target_page_size:
             new_kv_cache_spec[layer_name] = layer_spec
-        else:
-            layer_page_size = layer_spec.page_size_bytes
-            if max_page_size % layer_page_size != 0:
-                raise NotImplementedError(
-                    "The page size of the layer is not divisible by the "
-                    "maximum page size. Cannot unify by adjusting block_size."
-                )
-            ratio = max_page_size // layer_page_size
+        elif layer_page < target_page_size and target_page_size % layer_page == 0:
+            # Scale up block_size so page matches target
+            ratio = target_page_size // layer_page
             new_block_size = layer_spec.block_size * ratio
             new_spec = replace(layer_spec, block_size=new_block_size)
-            assert new_spec.page_size_bytes == max_page_size
+            assert new_spec.page_size_bytes == target_page_size, (
+                f"Page size mismatch after block_size adjust: "
+                f"{new_spec.page_size_bytes} != {target_page_size}"
+            )
+            new_kv_cache_spec[layer_name] = new_spec
+        else:
+            # Layer had the original max page size but target was padded up.
+            # Use page_size_padded to pad this layer to target.
+            try:
+                new_spec = replace(layer_spec, page_size_padded=target_page_size)
+            except TypeError:
+                raise NotImplementedError(
+                    f"Cannot pad page size for {type(layer_spec).__name__}: "
+                    f"page_size_padded not supported. "
+                    f"Layer page={layer_page}, target={target_page_size}"
+                )
+            assert new_spec.page_size_bytes == target_page_size, (
+                f"Page size mismatch after padding: "
+                f"{new_spec.page_size_bytes} != {target_page_size}"
+            )
             new_kv_cache_spec[layer_name] = new_spec
     return new_kv_cache_spec
 


### PR DESCRIPTION
## Summary

`unify_kv_cache_spec_page_size()` raises `NotImplementedError` when page sizes across different layer types are not evenly divisible. This breaks hybrid models that mix attention (with TurboQuant KV cache) and recurrent layers (Mamba/DeltaNet).

**Root cause**: TurboQuant k8v4 with `head_dim=256` yields `page_size = block_size × num_kv_heads × 388 = 12416` bytes, while DeltaNet/Mamba state is ~12.6 MiB. `12648448 % 12416 ≠ 0`, triggering the error.

## Changes

Replace the hard `NotImplementedError` with LCM-based padding:

1. **Fast path preserved**: when all smaller page sizes divide `max_page_size` evenly, behavior is unchanged
2. **Slow path (new)**: compute `LCM` of all smaller page sizes, pad `max_page_size` UP to the nearest multiple of that LCM
3. For the padded layer, use `page_size_padded` via `dataclasses.replace()`; for layers that divide evenly, scale `block_size` as before
4. Memory overhead is typically <0.1% (logged at INFO level)

## Testing

Tested on **Qwen3.6-35B-A3B-FP8** (hybrid: 30 MoE + 10 dense layers) with TurboQuant k8v4 KV cache on 2× RTX A5000:
- Model loads successfully with unified page sizes
- 145+ tok/s, 160k context window, 10/10 stability runs

Without this fix: crash at model init with `NotImplementedError: The page size of the layer is not divisible by the maximum page size`.

## Related

- Refs https://github.com/vllm-project/vllm/issues/40124
- Genesis Project patches: https://github.com/Sandermage/genesis-vllm-patches