### PR TITLE
Revert "[Misc] `toy_proxy_server` handle min_tokens" (#39706)

### DIFF
--- a/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py
+++ b/tests/v1/kv_connector/nixl_integration/toy_proxy_server.py
@@ -173,9 +173,6 @@ async def send_request_to_service(
         req_data["max_completion_tokens"] = 1
     if "stream_options" in req_data:
         del req_data["stream_options"]
-    # These args are not supported for P
-    min_tokens = req_data.pop("min_tokens", None)
-    min_completion_tokens = req_data.pop("min_completion_tokens", None)
     headers = {
         "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
         "X-Request-Id": request_id,
@@ -189,10 +186,6 @@ async def send_request_to_service(
     # read/consume the response body to release the connection
     # otherwise, it would http.ReadError
     await response.aread()
-
-    # Add back the min_tokens and min_completion_tokens so D can use them
-    req_data["min_tokens"] = min_tokens
-    req_data["min_completion_tokens"] = min_completion_tokens
 
     return response
 


### PR DESCRIPTION
## Revert of PR #39706

**Original PR:** https://github.com/vllm-project/vllm/pull/39706
**Build:** https://buildkite.com/vllm/ci/builds/61784

### Reason
This PR is suspected of causing 1 CI failure(s):
- **Hyrbid SSM NixlConnector PD accuracy tests (4 GPUs)** — accuracy assertion failed (measured 0.7665 vs expected 0.8)

### Auto-generated
This revert was auto-generated by the CI failure analyzer.