### PR TITLE
[Core] Reduce mm scheduler, get_num_embed overhead

### DIFF
--- a/tests/multimodal/test_inputs.py
+++ b/tests/multimodal/test_inputs.py
@@ -26,11 +26,8 @@ def test_placeholder_range_get_num_embeds(is_embed, expected):
     "is_embed,expected",
     [
         (None, None),
-        (
-            torch.tensor([False, True, False, True, True]),
-            torch.tensor([0, 1, 1, 2, 3]),
-        ),
-        (torch.tensor([True, True, True]), torch.tensor([1, 2, 3])),
+        (torch.tensor([False, True, False, True, True]), [0, 1, 1, 2, 3]),
+        (torch.tensor([True, True, True]), [1, 2, 3]),
     ],
 )
 def test_placeholder_range_embeds_cumsum(is_embed, expected):
@@ -41,6 +38,6 @@ def test_placeholder_range_embeds_cumsum(is_embed, expected):
         assert pr.embeds_cumsum is None
         return
 
-    assert torch.equal(pr.embeds_cumsum, expected)
+    assert pr.embeds_cumsum == expected
     # cached_property should return the same object on repeated access
     assert pr.embeds_cumsum is pr.embeds_cumsum

--- a/vllm/multimodal/inputs.py
+++ b/vllm/multimodal/inputs.py
@@ -153,7 +153,7 @@ class PlaceholderRange:
         if self.embeds_cumsum is None:
             return self.length
 
-        return self.embeds_cumsum[-1]
+        return self.embeds_cumsum[-1] if self.embeds_cumsum else 0
 
     def get_embeds_indices_in_range(
         self, start_idx: int, end_idx: int
@@ -172,7 +172,7 @@ class PlaceholderRange:
             return start_idx, end_idx
 
         embeds_start_idx = self.embeds_cumsum[start_idx - 1] if start_idx > 0 else 0
-        embeds_end_idx = self.embeds_cumsum[end_idx - 1]
+        embeds_end_idx = self.embeds_cumsum[end_idx - 1] if end_idx > 0 else 0
 
         return embeds_start_idx, embeds_end_idx
 

--- a/vllm/multimodal/inputs.py
+++ b/vllm/multimodal/inputs.py
@@ -145,14 +145,15 @@ class PlaceholderRange:
     """
 
     @cached_property
-    def embeds_cumsum(self) -> torch.Tensor | None:
-        return None if self.is_embed is None else self.is_embed.cumsum(dim=0)
+    def embeds_cumsum(self) -> list[int] | None:
+        # python list so python indexing avoids torch C++ overhead/conversions/deallocs
+        return None if self.is_embed is None else self.is_embed.cumsum(dim=0).tolist()
 
     def get_num_embeds(self) -> int:
         if self.embeds_cumsum is None:
             return self.length
 
-        return int(self.embeds_cumsum[-1])
+        return self.embeds_cumsum[-1]
 
     def get_embeds_indices_in_range(
         self, start_idx: int, end_idx: int
@@ -170,10 +171,8 @@ class PlaceholderRange:
         if self.embeds_cumsum is None:
             return start_idx, end_idx
 
-        embeds_start_idx = (
-            int(self.embeds_cumsum[start_idx - 1]) if start_idx > 0 else 0
-        )
-        embeds_end_idx = int(self.embeds_cumsum[end_idx - 1])
+        embeds_start_idx = self.embeds_cumsum[start_idx - 1] if start_idx > 0 else 0
+        embeds_end_idx = self.embeds_cumsum[end_idx - 1]
 
         return embeds_start_idx, embeds_end_idx
 


### PR DESCRIPTION
## Purpose

With multimodal workloads, for every iteration, the scheduler iterates over every request in the batch and calls `_try_schedule_encoder_inputs`. This function, for each multimodal feature of the request, calls `get_num_embeds` in order to do some checks around cursor position.

`get_num_embeds` was not cached. It depends on the `embeds_cumsum` property which is cached, but that property is a full CPU torch tensor. So accessing the last element of that tensor, converting it to a python scalar, and then having to destroy the torch objects when the scope goes out, can be quite expensive.

For heavy multimodal workloads with many mm items per request, or large mm items / embeddings, This could cause so much overhead as to prevent the scheduling to fully overlap with the GPU work, and creates idle bubbles.

## Profiles
Before:
<img width="1549" height="395" alt="image" src="https://github.com/user-attachments/assets/6066e6da-624a-4d8d-a6e6-6be95caeed1d" />
<img width="1549" height="395" alt="image" src="https://github.com/user-attachments/assets/340c54ef-8954-4fbb-be9b-99bcb83903d6" />

After:
<img width="1549" height="395" alt="image" src="https://github.com/user-attachments/assets/e2876413-041c-4009-9be9-16db37c25659" />




## Benchmarks

```
Gemma-4-E4B @ c=128, 32 images 1024×1536, baseline vs This PR:

  ┌────────────────────────────┬───────────┬───────────┬─────────┐
  │           Metric           │ baseline  │  This PR  │    Δ    │
  ├────────────────────────────┼───────────┼───────────┼─────────┤
  │ Duration (s)               │ 413.16    │ 325.41    │ −21.2 % │
  ├────────────────────────────┼───────────┼───────────┼─────────┤
  │ Successful reqs            │ 128/128   │ 128/128   │ —       │
  ├────────────────────────────┼───────────┼───────────┼─────────┤
  │ Total input tokens         │ 1 080 576 │ 1 080 576 │ —       │
  ├────────────────────────────┼───────────┼───────────┼─────────┤
  │ Total generated tokens     │ 1 024 000 │ 1 024 000 │ —       │
  ├────────────────────────────┼───────────┼───────────┼─────────┤
  │ Request throughput (req/s) │ 0.31      │ 0.39      │ +26.9 % │
  ├────────────────────────────┼───────────┼───────────┼─────────┤
  │ Output tok/s               │ 2 478.5   │ 3 146.8   │ +27.0 % │
  ├────────────────────────────┼───────────┼───────────┼─────────┤
  │ Total tok/s                │ 5 093.9   │ 6 467.5   │ +27.0 % │
  ├────────────────────────────┼───────────┼───────────┼─────────┤
  │ Peak output tok/s          │ 6 158     │ 9 088     │ +47.6 % │
  ├────────────────────────────┼───────────┼───────────┼─────────┤
  │ Mean TTFT (s)              │ 137.9     │ 124.3     │ −9.8 %  │
  ├────────────────────────────┼───────────┼───────────┼─────────┤
  │ Median TTFT (s)            │ 137.9     │ 126.9     │ −8.0 %  │
  ├────────────────────────────┼───────────┼───────────┼─────────┤
  │ P99 TTFT (s)               │ 213.5     │ 181.9     │ −14.8 % │
  ├────────────────────────────┼───────────┼───────────┼─────────┤
  │ Mean TPOT (ms)             │ 33.81     │ 24.58     │ −27.3 % │
  ├────────────────────────────┼───────────┼───────────┼─────────┤
  │ P99 TPOT (ms)              │ 45.15     │ 34.55     │ −23.5 % │
  ├────────────────────────────┼───────────┼───────────┼─────────┤
  │ Mean ITL (ms)              │ 33.80     │ 24.58     │ −27.3 % │
  ├────────────────────────────┼───────────┼───────────┼─────────┤
  │ P99 ITL (ms)               │ 30.73     │ 19.74     │ −35.8 % │
  └────────────────────────────┴───────────┴───────────┴─────────┘
```
