### PR TITLE
[Core] Optimize sliding-window cache hit search in SlidingWindowManager

### DIFF
--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -41,6 +41,76 @@ def get_chunked_local_attention_manager(
     )
 
 
+def find_sliding_window_cache_hit_reference(
+    block_hashes,
+    max_length,
+    kv_cache_group_ids,
+    block_pool,
+    kv_cache_spec,
+    use_eagle,
+    alignment_tokens,
+):
+    sliding_window_contiguous_blocks = (
+        kv_cache_spec.sliding_window - 1 + kv_cache_spec.block_size - 1
+    ) // kv_cache_spec.block_size
+    if use_eagle:
+        sliding_window_contiguous_blocks += 1
+
+    max_num_blocks = max_length // kv_cache_spec.block_size
+    computed_blocks = tuple(
+        [block_pool.null_block] * max_num_blocks
+        for _ in range(len(kv_cache_group_ids))
+    )
+    block_size = kv_cache_spec.block_size
+    num_contiguous_blocks = 0
+    match_found = False
+    for i in range(max_num_blocks - 1, -1, -1):
+        if cached_block := block_pool.get_cached_block(
+            block_hashes[i], kv_cache_group_ids
+        ):
+            if (
+                num_contiguous_blocks == 0
+                and block_size != alignment_tokens
+                and (i + 1) * block_size % alignment_tokens != 0
+            ):
+                continue
+            for computed, cached in zip(computed_blocks, cached_block):
+                computed[i] = cached
+            num_contiguous_blocks += 1
+            if num_contiguous_blocks >= sliding_window_contiguous_blocks:
+                for computed in computed_blocks:
+                    del computed[i + num_contiguous_blocks :]
+                match_found = True
+                break
+        else:
+            num_contiguous_blocks = 0
+    if not match_found:
+        for computed in computed_blocks:
+            del computed[num_contiguous_blocks:]
+        while (
+            block_size != alignment_tokens
+            and len(computed_blocks[0]) * block_size % alignment_tokens != 0
+        ):
+            for computed in computed_blocks:
+                computed.pop()
+    if use_eagle and computed_blocks[0]:
+        for computed in computed_blocks:
+            computed.pop()
+        while (
+            block_size != alignment_tokens
+            and len(computed_blocks[0]) * block_size % alignment_tokens != 0
+        ):
+            for computed in computed_blocks:
+                computed.pop()
+    return computed_blocks
+
+
+def block_ids_by_group(computed_blocks):
+    return tuple(
+        tuple(block.block_id for block in blocks) for blocks in computed_blocks
+    )
+
+
 def test_chunked_local_attention_possible_cached_prefix():
     block_size = 2
     chunked_local_attention_spec = ChunkedLocalAttentionSpec(
@@ -183,6 +253,89 @@ def test_sliding_window_possible_cached_prefix():
         [True, True, False, True, False, False, True, True, False, False, False, True],
         8,
     )
+
+
+def test_sliding_window_cache_hit_matches_reference():
+    rng = random.Random(0)
+    kv_cache_group_ids = [0, 1]
+    explicit_patterns = [
+        [],
+        [False],
+        [True],
+        [True, False],
+        [True, True],
+        [False, True],
+        [False, True, True],
+        [True, True, False, True],
+        [False, False, True, True, False, True, True, True],
+        [True, True, False, True, False, False, True, True, False, True],
+    ]
+    random_patterns = [
+        [rng.random() < hit_rate for _ in range(rng.randint(0, 48))]
+        for hit_rate in (0.0, 0.05, 0.2, 0.5, 0.9, 1.0)
+        for _ in range(20)
+    ]
+
+    for block_size, sliding_window, alignment_tokens, use_eagle in [
+        (2, 1, 2, False),
+        (2, 1, 2, True),
+        (2, 4, 2, False),
+        (2, 4, 2, True),
+        (2, 6, 4, False),
+        (2, 6, 4, True),
+        (3, 7, 6, False),
+        (3, 7, 6, True),
+    ]:
+        sliding_window_spec = SlidingWindowSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=sliding_window,
+        )
+        block_pool = BlockPool(
+            num_gpu_blocks=1000, enable_caching=True, hash_block_size=block_size
+        )
+
+        for block_is_cached in explicit_patterns + random_patterns:
+            block_hash_list = [
+                BlockHash(str(i).encode()) for i in range(len(block_is_cached))
+            ]
+            for max_num_blocks in range(len(block_is_cached) + 1):
+                block_pool.cached_block_hash_to_block._cache.clear()
+                for i, (block_hash, is_cached) in enumerate(
+                    zip(block_hash_list, block_is_cached)
+                ):
+                    if is_cached:
+                        for group_id in kv_cache_group_ids:
+                            block_pool.cached_block_hash_to_block.insert(
+                                make_block_hash_with_group_id(block_hash, group_id),
+                                block_pool.blocks[
+                                    1 + i * len(kv_cache_group_ids) + group_id
+                                ],
+                            )
+
+                max_length = max_num_blocks * block_size
+                expected = find_sliding_window_cache_hit_reference(
+                    block_hashes=block_hash_list,
+                    max_length=max_length,
+                    kv_cache_group_ids=kv_cache_group_ids,
+                    block_pool=block_pool,
+                    kv_cache_spec=sliding_window_spec,
+                    use_eagle=use_eagle,
+                    alignment_tokens=alignment_tokens,
+                )
+                actual = SlidingWindowManager.find_longest_cache_hit(
+                    block_hashes=block_hash_list,
+                    max_length=max_length,
+                    kv_cache_group_ids=kv_cache_group_ids,
+                    block_pool=block_pool,
+                    kv_cache_spec=sliding_window_spec,
+                    use_eagle=use_eagle,
+                    alignment_tokens=alignment_tokens,
+                )
+
+                assert block_ids_by_group(actual) == block_ids_by_group(expected)
 
 
 def test_chunked_local_attention_remove_skipped_blocks():

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -514,49 +514,149 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             # the last matched block.
             sliding_window_contiguous_blocks += 1
 
-        # TODO: reduce i by sliding_window_contiguous_blocks when cache miss, to
-        # optimize the time complexity from O(max_num_blocks) to
-        # O(max_num_blocks / sliding_window_contiguous_blocks +
-        # sliding_window_contiguous_blocks),
-        # which is good for low cache hit rate scenarios.
         max_num_blocks = max_length // kv_cache_spec.block_size
         computed_blocks = tuple(
             [block_pool.null_block] * max_num_blocks
             for _ in range(len(kv_cache_group_ids))
         )
         block_size = kv_cache_spec.block_size
-        num_contiguous_blocks = 0
-        match_found = False
-        # Search from right to left and early stop when a match is found.
-        for i in range(max_num_blocks - 1, -1, -1):
-            if cached_block := block_pool.get_cached_block(
-                block_hashes[i], kv_cache_group_ids
-            ):
-                # Skip prefix matching check if the block is not aligned with
-                # `alignment_tokens`.
+
+        if sliding_window_contiguous_blocks <= 0:
+            for i in range(max_num_blocks - 1, -1, -1):
+                cached_block = block_pool.get_cached_block(
+                    block_hashes[i], kv_cache_group_ids
+                )
+                if cached_block is None:
+                    continue
                 if (
-                    num_contiguous_blocks == 0
-                    and block_size != alignment_tokens  # Faster for common case.
+                    block_size != alignment_tokens
                     and (i + 1) * block_size % alignment_tokens != 0
                 ):
                     continue
-                # Add the cached block to the computed blocks.
                 for computed, cached in zip(computed_blocks, cached_block):
                     computed[i] = cached
-                num_contiguous_blocks += 1
-                if num_contiguous_blocks >= sliding_window_contiguous_blocks:
-                    # Trim the trailing blocks.
-                    # E.g., [NULL, NULL, 8, 3, NULL, 9] -> [NULL, NULL, 8, 3]
-                    # when sliding_window_contiguous_blocks=2.
-                    for computed in computed_blocks:
-                        del computed[i + num_contiguous_blocks :]
-                    match_found = True
-                    break
+                for computed in computed_blocks:
+                    del computed[i + 1 :]
+                break
             else:
-                num_contiguous_blocks = 0
+                for computed in computed_blocks:
+                    del computed[:]
+
+            if use_eagle and computed_blocks[0]:
+                for computed in computed_blocks:
+                    computed.pop()
+                while (
+                    block_size != alignment_tokens
+                    and len(computed_blocks[0]) * block_size % alignment_tokens != 0
+                ):
+                    for computed in computed_blocks:
+                        computed.pop()
+            return computed_blocks
+
+        def get_prev_aligned_index(index: int) -> int:
+            if block_size == alignment_tokens:
+                return index
+            while index >= 0 and (index + 1) * block_size % alignment_tokens != 0:
+                index -= 1
+            return index
+
+        match_found = False
+
+        cached_blocks_by_idx: dict[int, list[KVCacheBlock] | None] = {}
+        cache_miss = object()
+
+        def get_cached_blocks(index: int) -> list[KVCacheBlock] | None:
+            cached_blocks = cached_blocks_by_idx.get(index, cache_miss)
+            if cached_blocks is cache_miss:
+                cached_blocks = block_pool.get_cached_block(
+                    block_hashes[index], kv_cache_group_ids
+                )
+                cached_blocks_by_idx[index] = cached_blocks
+            return cached_blocks
+
+        # Any valid contiguous window of size W contains one of the anchors
+        # spaced W blocks apart. Search anchors from right to left; on a miss,
+        # every window containing that anchor is impossible and can be skipped.
+        end = get_prev_aligned_index(max_num_blocks - 1)
+        anchor = end
+        if end >= sliding_window_contiguous_blocks - 1:
+            start = end - sliding_window_contiguous_blocks + 1
+            cached_window: list[list[KVCacheBlock]] = []
+            miss_index = -1
+            for i in range(end, start - 1, -1):
+                cached_block = block_pool.get_cached_block(
+                    block_hashes[i], kv_cache_group_ids
+                )
+                if cached_block is None:
+                    miss_index = i
+                    break
+                cached_window.append(cached_block)
+
+            if len(cached_window) >= sliding_window_contiguous_blocks:
+                for i, cached_block in zip(
+                    range(end, start - 1, -1), cached_window
+                ):
+                    for computed, cached in zip(computed_blocks, cached_block):
+                        computed[i] = cached
+                for computed in computed_blocks:
+                    del computed[end + 1 :]
+                match_found = True
+            else:
+                anchor = get_prev_aligned_index(miss_index - 1)
+
+        while not match_found and anchor >= 0:
+            if get_cached_blocks(anchor) is None:
+                anchor -= sliding_window_contiguous_blocks
+                continue
+
+            right = anchor
+            max_right = min(
+                max_num_blocks - 1, anchor + sliding_window_contiguous_blocks - 1
+            )
+            while right < max_right and get_cached_blocks(right + 1) is not None:
+                right += 1
+
+            end = get_prev_aligned_index(right)
+            if end < anchor:
+                anchor -= sliding_window_contiguous_blocks
+                continue
+            start = end - sliding_window_contiguous_blocks + 1
+            if start < 0:
+                anchor -= sliding_window_contiguous_blocks
+                continue
+            left = anchor
+            while left > start and get_cached_blocks(left - 1) is not None:
+                left -= 1
+
+            if left <= start:
+                for i in range(start, end + 1):
+                    cached_block = get_cached_blocks(i)
+                    assert cached_block is not None
+                    for computed, cached in zip(computed_blocks, cached_block):
+                        computed[i] = cached
+
+                # Trim the trailing blocks.
+                # E.g., [NULL, NULL, 8, 3, NULL, 9] -> [NULL, NULL, 8, 3]
+                # when sliding_window_contiguous_blocks=2.
+                for computed in computed_blocks:
+                    del computed[end + 1 :]
+                match_found = True
+                break
+
+            anchor -= sliding_window_contiguous_blocks
+
         if not match_found:
             # The first `num_contiguous_blocks` is a cache hit even if
             # `num_contiguous_blocks < sliding_window_contiguous_blocks`.
+            num_contiguous_blocks = 0
+            for i in range(max_num_blocks):
+                cached_block = get_cached_blocks(i)
+                if cached_block is None:
+                    break
+                for computed, cached in zip(computed_blocks, cached_block):
+                    computed[i] = cached
+                num_contiguous_blocks += 1
+
             for computed in computed_blocks:
                 del computed[num_contiguous_blocks:]
             while (


### PR DESCRIPTION


  ## Purpose

  Optimize `SlidingWindowManager.find_longest_cache_hit` for miss-heavy / low-reuse
  sliding-window prefix-cache lookups.

  The previous implementation scanned backward block-by-block until it either found a
  full valid sliding window or fell back to the prefix-from-start case. For long
  prompts with little or no reusable sliding-window cache, this made lookup cost
  scale with prompt length.

  This change switches the search to an anchor-based strategy:
  - scan anchors from right to left at sliding-window-sized intervals
  - skip entire impossible windows on anchor misses
  - locally expand around a hit anchor to recover the same rightmost valid window as
  before

  This preserves existing output semantics while reducing block lookups substantially
  for long miss-heavy prompts.

  This PR includes AI-assisted drafting and iteration using OpenAI Codex. I reviewed
  the generated changes, validated the behavior, and ran the tests below myself.

  ## Test Plan

  Unit / regression tests:
  ```bash
  pytest --confcutdir=tests/v1/core -q \
      tests/v1/core/test_single_type_kv_cache_manager.py \
      tests/v1/core/test_prefix_caching.py
  ```

  Local function-level microbenchmark of `SlidingWindowManager.find_longest_cache_hit`:
  ```bash
  python3 bench.py
  ```

  ## Test Result

  Unit / regression tests:

  ```bash
  64 passed, 2 warnings in 2.83s
  ```
  Added / updated test coverage:

  - differential test comparing the new sliding-window search against the previous
    behavior across explicit and random hit/miss patterns
  - multiple KV cache groups
  - use_eagle=True/False
  - alignment_tokens == block_size
  - alignment_tokens != block_size
  - sliding_window=1

  Local function-level microbenchmark:

  - replay after cache pressure
    miss-heavy lookup shape corresponding to replaying a long prompt after many unrelated prompts have evicted its sliding-window cache entries
  - chat prefix with changed tail
    long shared prefix with only the tail changed
  - no reuse new prompt
    unrelated long prompt with effectively no reusable prefix cache
  - exact replay hot cache
    same long prompt replayed while the sliding-window cache is still hot

  Benchmark result:

  ```text
base_ref=origin/main  runs=100 avg after 10 warmup  prompt_blocks=8192  block_size=16  sliding_window=4096 tokens  window_blocks=256
replay after cache pressure    cached=   0/8192  first_miss=   0  returned=   0 blks  old=  1163.1us/ 8192 calls  new=    14.8us/   34 calls  speedup= 78.5x
chat prefix with changed tail  cached=8064/8192  first_miss=8064  returned=8064 blks  old=    93.8us/  384 calls  new=    97.5us/  259 calls  speedup= 0.96x
no reuse new prompt            cached=   0/8192  first_miss=   0  returned=   0 blks  old=  1261.2us/ 8192 calls  new=    14.7us/   34 calls  speedup= 85.5x
exact replay hot cache         cached=8192/8192  first_miss=8192  returned=8192 blks  old=    71.7us/  256 calls  new=    69.2us/  256 calls  speedup= 1.04x
  ```

  In this microbenchmark harness, the lookup-call counts are the primary signal; the reported microseconds are local measurements of the isolated lookup path.

  These results show the main benefit on long miss-heavy / low-reuse workloads, with large reductions in block lookups and corresponding lookup latency. The long shared-prefix chat-style workload and the already-efficient all-hit hot-cache path remain effectively flat.

No documentation update needed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

