### PR TITLE
[Bugfix] Fix k_proj's bias for GLM-ASR

### DIFF
--- a/vllm/model_executor/models/glmasr.py
+++ b/vllm/model_executor/models/glmasr.py
@@ -66,7 +66,7 @@ from .interfaces import (
     SupportsTranscription,
 )
 from .utils import AutoWeightsLoader, init_vllm_registered_model, maybe_prefix
-from .whisper import ISO639_1_SUPPORTED_LANGS
+from .whisper import ISO639_1_SUPPORTED_LANGS, _create_fake_bias_for_k_proj
 
 
 class GlmAsrEncoderRotaryEmbedding(nn.Module):
@@ -498,6 +498,8 @@ class GlmAsrEncoder(nn.Module):
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         """Custom weight loading to handle q_proj/k_proj/v_proj -> qkv_proj mapping."""
         from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+
+        weights = _create_fake_bias_for_k_proj(weights, ".k_proj.weight")
 
         stacked_params_mapping = [
             # (param_name, shard_name, shard_id)


### PR DESCRIPTION
## Purpose

GLM-ASR has `bias = true` only for `q_proj` and `v_proj` not for [`k_proj`](https://github.com/huggingface/transformers/blob/main/src/transformers/models/glmasr/modeling_glmasr.py#L187-L190)

So, if we use `QKVParallelLinear` to fuse its `qkv_proj`, the bias part for `k_proj` will remain uninitialized during weight loading. On CPU backend, this part can fill with quite large values (e.g. 1.00e+30) or `NaN`' s and cause overflows. 

Added zero bias for `k_proj`to fix this.

Similar to #12342

## Test Plan

Ran this script below:
<details>
<summary>Test</summary>

```python
import argparse
import json
import os
from pathlib import Path
import subprocess
import sys


INNER = r"""
import gc
import json
import os

os.environ["VLLM_CONFIGURE_LOGGING"] = "0"
os.environ["VLLM_LOGGING_LEVEL"] = "ERROR"

import torch
from transformers import GlmAsrEncoderConfig

from vllm.config import VllmConfig, set_current_vllm_config
from vllm.distributed import (
    cleanup_dist_env_and_memory,
    ensure_model_parallel_initialized,
    init_distributed_environment,
)
from vllm.model_executor.models.glmasr import GlmAsrEncoder
from vllm.utils.network_utils import get_open_port


def fill_reused_tensor_memory(total_size: int, dtype: torch.dtype) -> None:
    junk_blocks = []
    for _ in range(256):
        t = torch.empty(total_size, dtype=dtype)
        t.fill_(1.0e30)
        t[::7] = float("nan")
        t[1::7] = -3.0e20
        t[2::7] = 42.0
        junk_blocks.append(t)
    del junk_blocks
    gc.collect()


def fmt(values):
    rendered = []
    for x in values[:4]:
        if isinstance(x, float):
            if x != x:
                rendered.append("NaN")
            elif abs(x) >= 1.0e4 or (0 < abs(x) < 1.0e-3):
                rendered.append(f"{x:.2e}")
            else:
                rendered.append(f"{x:.1f}")
        else:
            rendered.append(str(x))
    return "[" + ", ".join(rendered) + "]"


config = GlmAsrEncoderConfig(
    hidden_size=256,
    intermediate_size=512,
    num_hidden_layers=1,
    num_attention_heads=4,
    num_key_value_heads=2,
    num_mel_bins=4,
    max_position_embeddings=32,
    rope_parameters={"rope_theta": 10000.0, "rope_type": "default"},
)

head_dim = config.hidden_size // config.num_attention_heads
q_size = config.num_attention_heads * head_dim
kv_size = config.num_key_value_heads * head_dim
total_size = q_size + kv_size + kv_size

port = get_open_port()
with set_current_vllm_config(VllmConfig()):
    init_distributed_environment(
        world_size=1,
        rank=0,
        local_rank=0,
        distributed_init_method=f"tcp://127.0.0.1:{port}",
        backend="gloo",
    )
    ensure_model_parallel_initialized(1, 1, backend="gloo")
    try:
        result = None
        for _ in range(50):
            fill_reused_tensor_memory(total_size, torch.float32)
            model = GlmAsrEncoder(config)
            attn = model.layers[0].self_attn

            before_q, before_k, before_v = attn.qkv_proj.bias.detach().clone().split(
                [q_size, kv_size, kv_size]
            )
            has_garbage = bool((before_k != 0).any() or torch.isnan(before_k).any())
            if not has_garbage:
                del model
                gc.collect()
                continue

            q_bias = torch.arange(q_size, dtype=attn.qkv_proj.bias.dtype)
            v_bias = torch.arange(kv_size, dtype=attn.qkv_proj.bias.dtype) + 100

            model.load_weights([
                ("layers.0.self_attn.q_proj.weight",
                 torch.randn(q_size, config.hidden_size)),
                ("layers.0.self_attn.q_proj.bias", q_bias),
                ("layers.0.self_attn.k_proj.weight",
                 torch.randn(kv_size, config.hidden_size)),
                # no k_proj.bias on purpose
                ("layers.0.self_attn.v_proj.weight",
                 torch.randn(kv_size, config.hidden_size)),
                ("layers.0.self_attn.v_proj.bias", v_bias),
            ])

            after_q, after_k, after_v = attn.qkv_proj.bias.detach().clone().split(
                [q_size, kv_size, kv_size]
            )

            result = {
                "before load_weights": {
                    "Q": fmt(before_q.tolist()),
                    "K": fmt(before_k.tolist()),
                    "V": fmt(before_v.tolist()),
                },
                "after load_weights": {
                    "Q": fmt(after_q.tolist()),
                    "K": fmt(after_k.tolist()),
                    "V": fmt(after_v.tolist()),
                },
            }
            break

        if result is None:
            result = {"message": "did not observe garbage in K"}

        print(json.dumps(result))
    finally:
        cleanup_dist_env_and_memory()
"""


def run_probe(root: Path) -> dict:
    env = os.environ.copy()
    env["PYTHONPATH"] = str(root)
    proc = subprocess.run(
        [sys.executable, "-c", INNER],
        text=True,
        capture_output=True,
        cwd=str(root),
        env=env,
        check=True,
    )
    return json.loads(proc.stdout.strip().splitlines()[-1])


def print_section(title: str, data: dict) -> None:
    print(title)
    print("slice | before load_weights | after load_weights")
    print("---- | ------------------- | ------------------")
    for label in ("Q", "K", "V"):
        print(
            f"{label} | {data['before load_weights'][label]} "
            f"| {data['after load_weights'][label]}"
        )
    print()


def main() -> None:
    parser = argparse.ArgumentParser()
    parser.add_argument("--before-root", required=True)
    parser.add_argument("--after-root", required=True)
    args = parser.parse_args()

    before = run_probe(Path(args.before_root).resolve())
    after = run_probe(Path(args.after_root).resolve())

    print_section("Before", before)
    print_section("After", after)


if __name__ == "__main__":
    main()
```

</details>

that:
* Fills reused tensor memory with large values and NaNs to expose uninitialized memory reuse.
* In a subprocess, repeatedly creates a tiny GLM-ASR encoder until the K slice of `attn.qkv_proj.bias` shows unexpected pre-`load_weights` values (up to 50 attempts).
* Calls `load_weights` with `q_proj.bias` and `v_proj.bias`, but intentionally leaves out `k_proj.bias` while still loading `k_proj.weight`.
* Prints the Q/K/V bias slices before and after loading to show whether the missing K bias stays garbage or gets zeroed.


## Test Results

**Before:**

slice | before load_weights | after load_weights
---- | ------------------- | ------------------
Q | [2.87e-42, 0.0, 3.59e-43, 0.0] | [0.0, 1.0, 2.0, 3.0]
K | [42.0, 1.00e+30, 1.00e+30, 1.00e+30] | [42.0, 1.00e+30, 1.00e+30, 1.00e+30]
V | [1.00e+30, 1.00e+30, 1.00e+30, NaN] | [100.0, 101.0, 102.0, 103.0]

**After:**

slice | before load_weights | after load_weights
---- | ------------------- | ------------------
Q | [2.87e-42, 0.0, 3.59e-43, 0.0] | [0.0, 1.0, 2.0, 3.0]
K | [42.0, 1.00e+30, 1.00e+30, 1.00e+30] | [0.0, 0.0, 0.0, 0.0]
V | [1.00e+30, 1.00e+30, 1.00e+30, NaN] | [100.0, 101.0, 102.0, 103.0]
