### PR TITLE
[Perf] Cache get_sm_version_num() in cutlass dispatch

### DIFF
--- a/csrc/cutlass_extensions/common.cpp
+++ b/csrc/cutlass_extensions/common.cpp
@@ -1,11 +1,32 @@
 #include "cutlass_extensions/common.hpp"
 
 int32_t get_sm_version_num() {
-  int32_t major_capability, minor_capability;
-  cudaDeviceGetAttribute(&major_capability, cudaDevAttrComputeCapabilityMajor,
-                         0);
-  cudaDeviceGetAttribute(&minor_capability, cudaDevAttrComputeCapabilityMinor,
-                         0);
-  int32_t version_num = major_capability * 10 + minor_capability;
-  return version_num;
+  // Cached: the prior implementation queried device 0 on every call, which
+  // added a couple of cudaDeviceGetAttribute driver calls (µs-scale) to the
+  // hot path of every cutlass_scaled_mm / nvfp4 / moe dispatch. The existing
+  // semantics already assumed a homogeneous device set (the device index was
+  // hard-coded to 0), so we preserve that by caching a single value.
+  static const int32_t cached = [] {
+    int32_t major_capability = 0;
+    int32_t minor_capability = 0;
+
+    cudaError_t err_major =
+        cudaDeviceGetAttribute(&major_capability,
+                               cudaDevAttrComputeCapabilityMajor, 0);
+    TORCH_CHECK(
+        err_major == cudaSuccess,
+        "cudaDeviceGetAttribute(cudaDevAttrComputeCapabilityMajor) failed: ",
+        cudaGetErrorString(err_major));
+
+    cudaError_t err_minor =
+        cudaDeviceGetAttribute(&minor_capability,
+                               cudaDevAttrComputeCapabilityMinor, 0);
+    TORCH_CHECK(
+        err_minor == cudaSuccess,
+        "cudaDeviceGetAttribute(cudaDevAttrComputeCapabilityMinor) failed: ",
+        cudaGetErrorString(err_minor));
+
+    return major_capability * 10 + minor_capability;
+  }();
+  return cached;
 }


### PR DESCRIPTION
## Summary

Cache the result of `get_sm_version_num()` instead of querying
`cudaDeviceGetAttribute(..., 0)` on every call.

## Motivation

The previous implementation queried the compute capability of device 0
on every invocation. This function sits on the hot path of several
quantized CUTLASS entry points, including `cutlass_scaled_mm`.

Since the prior implementation already hard-coded device 0, this PR
preserves existing semantics by caching that same device-0 result once,
rather than introducing new per-device behavior.

## Expected impact

This is a small perf cleanup that removes repeated device-attribute
queries from the dispatch hot path. It is not intended to fully resolve
small-M decode regressions by itself, but it should reduce a small amount
of fixed per-call CPU overhead across all call sites that use
`get_sm_version_num()`.

## Validation

I spot-checked the same small-M decode-side benchmark shapes I had been
using for the original investigation.

The results are somewhat noisy run-to-run, but the qualitative pattern is
unchanged. This is expected because this PR only removes one small repeated
dispatch-side cost (`get_sm_version_num()`), rather than addressing the
larger structural overhead in the generic small-M `scaled_mm` path.

<details>
<summary>Additional spot-check data</summary>

Single-point spot check (`llama3-8B-o`, `M=1`, `N=K=4096`):

- before: `bf16_us=12.78`, `fp8_us=20.59`, `fp8/base=1.61`
- after: `bf16_us=12.75`, `fp8_us=20.85`, `fp8/base=1.63`

Three-shape spot check:

| shape | benchmark_total_us | profiler_cpu_total_us | profiler_kernel_us | wrapper_overhead_us | bf16_total_us | fp8_over_bf16 |
|---|---:|---:|---:|---:|---:|---:|
| o_m1_n2048_k4096 | 22.02 | 15.82 | 5.06 | 16.97 | 16.20 | 1.36 |
| o_m1_n4096_k4096 | 27.48 | 16.48 | 6.72 | 20.76 | 16.78 | 1.64 |
| o_m1_n6144_k4096 | 27.58 | 15.86 | 8.45 | 19.13 | 31.25 | 0.88 |

</details>

So I am treating this as a low-risk hot-path cleanup, not as the full fix
for the broader regression.

## Notes

If per-device caching is desired in the future, that would be a separate
semantic change and should be handled independently.