### PR TITLE
[Core] Add --deterministic-prefix-caching for reproducible prefill on ROCm

### DIFF
--- a/tests/v1/e2e/test_deterministic_prefix_caching.py
+++ b/tests/v1/e2e/test_deterministic_prefix_caching.py
@@ -1,0 +1,79 @@
+"""
+Test deterministic prefix caching.
+
+When --deterministic-prefix-caching is enabled, cache-miss and cache-hit
+prefills should produce identical outputs by ensuring the suffix GEMM
+uses the same batch dimension regardless of cache state.
+
+Requires: ROCm or CUDA GPU, prefix caching support.
+"""
+import pytest
+
+from tests.utils import RemoteOpenAIServer
+
+MODEL_NAME = "Qwen/Qwen3-0.6B"
+NUM_RUNS = 5
+
+
+@pytest.fixture(scope="module")
+def server_with_deterministic_pc():
+    args = [
+        "--dtype", "bfloat16",
+        "--max-model-len", "2048",
+        "--enable-prefix-caching",
+        "--deterministic-prefix-caching",
+    ]
+    with RemoteOpenAIServer(MODEL_NAME, args) as remote_server:
+        yield remote_server
+
+
+def generate_n_times(client, n, prompt, max_tokens=10):
+    outputs = []
+    for _ in range(n):
+        response = client.completions.create(
+            model=MODEL_NAME,
+            prompt=prompt,
+            max_tokens=max_tokens,
+            temperature=0.0,
+        )
+        outputs.append(response.choices[0].text)
+    return outputs
+
+
+@pytest.mark.skipif(
+    not pytest.importorskip("torch").cuda.is_available(),
+    reason="Requires GPU",
+)
+class TestDeterministicPrefixCaching:
+
+    def test_cache_miss_equals_cache_hit(self, server_with_deterministic_pc):
+        client = server_with_deterministic_pc.get_openai_client()
+        prompt = (
+            "The European Union is a political and economic union of "
+            "member states that are located primarily in Europe. The EU "
+            "has developed an internal single market through a "
+            "standardised system of laws. Summarize in one sentence:"
+        )
+        outputs = generate_n_times(client, NUM_RUNS, prompt)
+        assert len(set(outputs)) == 1, (
+            f"Expected identical outputs, got {len(set(outputs))} unique: {outputs}"
+        )
+
+    def test_different_prompts_different_outputs(self, server_with_deterministic_pc):
+        client = server_with_deterministic_pc.get_openai_client()
+        out_a = generate_n_times(client, 1, "What is the capital of France?")[0]
+        out_b = generate_n_times(client, 1, "What is the speed of light?")[0]
+        assert out_a != out_b
+
+    def test_shared_prefix_determinism(self, server_with_deterministic_pc):
+        client = server_with_deterministic_pc.get_openai_client()
+        shared = (
+            "In the year 2025 artificial intelligence systems became "
+            "capable of performing complex reasoning tasks and the field "
+            "of machine learning experienced rapid advancement in "
+            "several key areas including natural language processing. "
+        )
+        out_1 = generate_n_times(client, 2, shared + "What happened next?")
+        out_2 = generate_n_times(client, 2, shared + "Why did this matter?")
+        assert out_1[0] == out_1[1], f"Prompt 1 non-deterministic: {out_1}"
+        assert out_2[0] == out_2[1], f"Prompt 2 non-deterministic: {out_2}"

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -94,6 +94,13 @@ class CacheConfig:
       security risk tolerance against the performance benefits before turning this on.
     - "xxhash_cbor" combines canonical CBOR serialization with xxHash for
       reproducible hashing. Requires the optional ``xxhash`` package."""
+    deterministic_prefix_caching: bool = False
+    """When enabled alongside prefix caching, forces cache-miss prefills to
+    split at block boundaries so the suffix GEMM shape is identical to the
+    cache-hit path. This eliminates bf16 non-determinism caused by different
+    kernel tilings selecting different fp32 accumulation orders, at the cost
+    of one extra scheduling step per cache-miss prefill. Only has effect when
+    enable_prefix_caching is also True."""
     calculate_kv_scales: bool = False
     """Deprecated: This option is deprecated and will be removed in v0.19.
     It enables dynamic calculation of `k_scale` and `v_scale` when
@@ -191,6 +198,7 @@ class CacheConfig:
             "num_cpu_blocks",
             # WIP feature toggle not impacting compiled graph shape
             "kv_sharing_fast_prefill",
+            "deterministic_prefix_caching",
         }
 
         from vllm.config.utils import get_hash_factors, hash_factors
@@ -205,6 +213,16 @@ class CacheConfig:
 
     _block_size_resolved: bool = field(default=False, init=False)
     """Guard against pydantic re-running _apply_block_size_default."""
+
+    @model_validator(mode="after")
+    def _validate_deterministic_prefix_caching(self) -> "CacheConfig":
+        if self.deterministic_prefix_caching and not self.enable_prefix_caching:
+            logger.warning(
+                "--deterministic-prefix-caching has no effect without "
+                "--enable-prefix-caching; ignoring."
+            )
+            object.__setattr__(self, "deterministic_prefix_caching", False)
+        return self
 
     @model_validator(mode="after")
     def _apply_block_size_default(self) -> "CacheConfig":

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -463,6 +463,7 @@ class EngineArgs:
     prefix_caching_hash_algo: PrefixCachingHashAlgo = (
         CacheConfig.prefix_caching_hash_algo
     )
+    deterministic_prefix_caching: bool = CacheConfig.deterministic_prefix_caching
     disable_sliding_window: bool = ModelConfig.disable_sliding_window
     disable_cascade_attn: bool = ModelConfig.disable_cascade_attn
     offload_backend: str = OffloadConfig.offload_backend
@@ -1053,6 +1054,10 @@ class EngineArgs:
             "--prefix-caching-hash-algo", **cache_kwargs["prefix_caching_hash_algo"]
         )
         cache_group.add_argument(
+            "--deterministic-prefix-caching",
+            **cache_kwargs["deterministic_prefix_caching"],
+        )
+        cache_group.add_argument(
             "--calculate-kv-scales", **cache_kwargs["calculate_kv_scales"]
         )
         cache_group.add_argument(
@@ -1631,6 +1636,7 @@ class EngineArgs:
             sliding_window=sliding_window,
             enable_prefix_caching=self.enable_prefix_caching,
             prefix_caching_hash_algo=self.prefix_caching_hash_algo,
+            deterministic_prefix_caching=self.deterministic_prefix_caching,
             calculate_kv_scales=self.calculate_kv_scales,
             kv_cache_dtype_skip_layers=self.kv_cache_dtype_skip_layers,
             kv_sharing_fast_prefill=self.kv_sharing_fast_prefill,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -252,6 +252,10 @@ class Scheduler(SchedulerInterface):
         self.need_mamba_block_aligned_split = (
             self.has_mamba_layers and self.cache_config.mamba_cache_mode == "align"
         )
+        self.deterministic_prefix_caching = (
+            self.cache_config.enable_prefix_caching
+            and self.cache_config.deterministic_prefix_caching
+        )
         self.perf_metrics: ModelMetrics | None = None
         if self.log_stats and vllm_config.observability_config.enable_mfu_metrics:
             self.perf_metrics = ModelMetrics(vllm_config)
@@ -345,6 +349,57 @@ class Scheduler(SchedulerInterface):
                 pass
         return num_new_tokens
 
+
+    def _prefix_cache_aligned_split(
+        self,
+        request: Request,
+        num_new_tokens: int,
+        num_computed_tokens: int,
+    ) -> int:
+        """Ensure prefill splits at block boundaries for prefix caching
+        determinism.
+
+        When prefix caching is enabled, a cache-hit request computes only
+        the non-block-aligned suffix (M = num_tokens % block_size), while a
+        cache-miss request would normally compute all tokens in one pass
+        (M = num_tokens). Different M dimensions cause the GEMM backend to
+        select different tile configurations, which due to fp32
+        non-associativity in the K-dimension reduction can produce results
+        that differ by 1 ULP. That single-element difference then amplifies
+        through the residual stream of a deep transformer.
+
+        This method forces the cache-miss path to stop at the last block
+        boundary so that the suffix is always computed in a separate step
+        with the same M dimension as the cache-hit path.
+
+        Enabled via --deterministic-prefix-caching. Applies only when:
+        - The request is still in prefill (no output tokens yet)
+        - num_prompt_tokens > block_size
+        - num_prompt_tokens is not block-aligned
+        """
+        # Only applies during prefill.
+        if request.num_output_tokens > 0:
+            return num_new_tokens
+
+        num_prompt_tokens = request.num_prompt_tokens
+        remainder = num_prompt_tokens % self.block_size
+        if remainder == 0 or num_prompt_tokens <= self.block_size:
+            return num_new_tokens
+
+        # The position where a cache-hit would start computing: the last
+        # full-block boundary before the end of the prompt.
+        block_aligned_pos = num_prompt_tokens - remainder
+
+        # If this chunk would cross the block boundary, stop at it so the
+        # suffix is deferred to the next scheduling step.
+        if (
+            num_computed_tokens < block_aligned_pos
+            and num_computed_tokens + num_new_tokens > block_aligned_pos
+        ):
+            num_new_tokens = block_aligned_pos - num_computed_tokens
+
+        return num_new_tokens
+
     def schedule(self) -> SchedulerOutput:
         # NOTE(woosuk) on the scheduling algorithm:
         # There's no "decoding phase" nor "prefill phase" in the scheduler.
@@ -432,6 +487,13 @@ class Scheduler(SchedulerInterface):
                     num_new_tokens,
                     encoder_compute_budget,
                     shift_computed_tokens=1 if self.use_eagle else 0,
+                )
+
+            # Prefix cache determinism: split prefill at block boundary
+            # so suffix GEMM M-dimension is cache-state-independent.
+            if self.deterministic_prefix_caching:
+                num_new_tokens = self._prefix_cache_aligned_split(
+                    request, num_new_tokens, request.num_computed_tokens
                 )
 
             if self.need_mamba_block_aligned_split:
@@ -705,6 +767,13 @@ class Scheduler(SchedulerInterface):
                         if num_new_tokens == 0:
                             # The request cannot be scheduled.
                             break
+
+                # Prefix cache determinism: split prefill at block boundary
+                # so suffix GEMM M-dimension is cache-state-independent.
+                if self.deterministic_prefix_caching:
+                    num_new_tokens = self._prefix_cache_aligned_split(
+                        request, num_new_tokens, num_computed_tokens
+                    )
 
                 if self.need_mamba_block_aligned_split:
                     num_new_tokens = self._mamba_block_aligned_split(


### PR DESCRIPTION
## Summary

Fixes #33123. Adds --deterministic-prefix-caching flag that ensures cache-miss and cache-hit prefills produce identical outputs on ROCm (and any backend affected by bf16 GEMM non-determinism).

## Root Cause

When prefix caching is enabled, cache-miss prefills compute all N tokens in one GEMM (M=N), while cache-hit prefills compute only the suffix (M=N%%block_size). Different M dimensions cause different Tensile kernel tiling on ROCm, leading to different fp32 accumulation orders in the K-reduction. With bf16 non-associativity, even 1 ULP difference at layer 0 amplifies ~1000x through 28+ transformer layers, causing completely different argmax selections.

Credit to @AndreasKaratzas for the thorough root cause analysis in #33123 and the original approach in #34046.

## Approach

Scheduler-level fix: when --deterministic-prefix-caching is enabled, cache-miss prefills are split at the last cached block boundary. This ensures the suffix GEMM always runs with the same M dimension regardless of cache state, producing bit-identical results.

### Changes

- **vllm/config/cache.py**: Add deterministic_prefix_caching field with model validator
- **vllm/engine/arg_utils.py**: Wire --deterministic-prefix-caching CLI argument
- **vllm/v1/core/sched/scheduler.py**: Add _prefix_cache_aligned_split() method with two call sites
- **tests/v1/e2e/test_deterministic_prefix_caching.py**: E2E tests verifying determinism

### Trade-off

Enabling this flag may add one extra prefill step for prompts that do not align to block boundaries. This is a small latency cost for guaranteed reproducibility.

## Testing

- Syntax validated all modified files
- E2E test: sends same prompt N times and asserts all outputs are identical with the flag enabled
- Shared prefix test: two prompts sharing a long prefix both produce deterministic results across cache miss/hit