### PR TITLE
[torch.compile] Remove layer name from unified_kv_cache_update / unified_mla_kv_cache_update to fix cold-start (#33267)

### DIFF
--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -722,6 +722,25 @@ class CompilationConfig:
     """The names of all the MOE layers in the model
     """
 
+    fast_kv_cache_cold_start: bool | None = None
+    """Optimization for fast KV cache cold start, analogous to fast_moe_cold_start.
+
+    When enabled, the layer name string is removed from unified_kv_cache_update
+    and unified_mla_kv_cache_update custom ops, allowing torch.compile's Inductor
+    to reuse piecewise CUDA graphs across all attention layers instead of
+    compiling a separate graph per layer.
+
+    The options are:
+    - True: optimization is always on
+    - False: optimization is always off
+    - None: optimization is on unless speculative decoding is active
+    """
+
+    static_all_kv_cache_update_layers: list[str] = field(
+        default_factory=list, init=False
+    )
+    """The names of all attention layers that perform KV cache updates."""
+
     # Attention ops; used for piecewise cudagraphs
     # Use PyTorch operator format: "namespace::name"
     _attention_ops: ClassVar[list[str]] = [

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1021,6 +1021,15 @@ class VllmConfig:
                 self.speculative_config is None
             )
 
+        if HAS_OPAQUE_TYPE:
+            # On torch >= 2.11 the hoisted OpaqueObject approach supersedes
+            # fast_kv_cache_cold_start, so force it off.
+            self.compilation_config.fast_kv_cache_cold_start = False
+        elif self.compilation_config.fast_kv_cache_cold_start is None:
+            self.compilation_config.fast_kv_cache_cold_start = (
+                self.speculative_config is None
+            )
+
         self._set_max_num_scheduled_tokens()
 
         if current_platform.support_static_graph_mode():

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -178,6 +178,14 @@ class ForwardContext:
     all_moe_layers: list[str] | None = None
     moe_layer_index: int = 0
 
+    # Analogous to all_moe_layers / moe_layer_index but for KV cache update ops
+    # (unified_kv_cache_update and unified_mla_kv_cache_update). When set,
+    # those ops receive the sentinel "from_forward_context" instead of a
+    # layer-specific string, enabling Inductor to reuse piecewise CUDA graphs
+    # across all attention layers.
+    all_kv_cache_update_layers: list[str] | None = None
+    kv_cache_update_index: int = 0
+
     additional_kwargs: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self):
@@ -218,9 +226,17 @@ def create_forward_context(
     else:
         all_moe_layers = None
 
+    if vllm_config.compilation_config.fast_kv_cache_cold_start:
+        all_kv_cache_update_layers = (
+            vllm_config.compilation_config.static_all_kv_cache_update_layers
+        )
+    else:
+        all_kv_cache_update_layers = None
+
     return ForwardContext(
         no_compile_layers=vllm_config.compilation_config.static_forward_context,
         all_moe_layers=all_moe_layers,
+        all_kv_cache_update_layers=all_kv_cache_update_layers,
         attn_metadata=attn_metadata,
         slot_mapping=slot_mapping or {},
         dp_metadata=dp_metadata,

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -9,7 +9,7 @@ import torch.nn as nn
 import vllm.envs as envs
 from vllm.config import CacheConfig, get_current_vllm_config
 from vllm.config.vllm import VllmConfig
-from vllm.forward_context import ForwardContext, get_forward_context
+from vllm.forward_context import ForwardContext, get_forward_context, is_forward_context_available
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention.kv_transfer_utils import (
     maybe_transfer_kv_layer,
@@ -25,7 +25,9 @@ from vllm.model_executor.layers.quantization.kv_cache import BaseKVCacheMethod
 from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
 from vllm.platforms import current_platform
 from vllm.utils.torch_utils import (
+    LayerName,
     LayerNameType,
+    _USE_LAYERNAME,
     _encode_layer_name,
     _resolve_layer_name,
     direct_register_custom_op,
@@ -48,6 +50,28 @@ if TYPE_CHECKING:
     from vllm.model_executor.layers.attention import MLAAttention
 
 logger = init_logger(__name__)
+
+
+def _get_kv_cache_layer_name(layer_name: str) -> "str | LayerName":
+    """Return the layer name to pass to KV cache update custom ops.
+
+    On torch >= 2.11 (with LayerName hoisting), returns a LayerName opaque
+    object that torch.compile deduplicates across layers automatically.
+
+    Otherwise, returns the sentinel string "from_forward_context" when the
+    fast_kv_cache_cold_start optimisation is active, allowing Inductor to
+    reuse piecewise CUDA graphs across all attention layers.  Falls back to
+    the plain string when the optimisation is disabled or no forward context
+    is available (e.g. unit-tests).
+    """
+    if _USE_LAYERNAME:
+        return LayerName(layer_name)
+    if (
+        is_forward_context_available()
+        and get_forward_context().all_kv_cache_update_layers is not None
+    ):
+        return "from_forward_context"
+    return layer_name
 
 
 def validate_kv_sharing_target(
@@ -363,6 +387,18 @@ class Attention(nn.Module, AttentionLayerBase):
         compilation_config.static_forward_context[prefix] = self
         self.attn_type = attn_type
 
+        # Register for fast_kv_cache_cold_start optimisation.
+        # A layer only calls unified_kv_cache_update when both:
+        #   1. it does not share a KV cache with an earlier layer, AND
+        #   2. its backend does not handle the KV cache update internally.
+        # The registration must match this condition exactly so the index stays
+        # aligned with the runtime call sequence.
+        if (
+            kv_sharing_target_layer_name is None
+            and not self.attn_backend.forward_includes_kv_cache_update
+        ):
+            compilation_config.static_all_kv_cache_update_layers.append(prefix)
+
         if kv_sharing_target_layer_name is not None:
             validate_kv_sharing_target(
                 prefix,
@@ -538,7 +574,10 @@ class Attention(nn.Module, AttentionLayerBase):
             )
         else:
             # Skip this if sharing KV cache with an earlier attention layer.
-            encoded = _encode_layer_name(self.layer_name)
+            # Use _get_kv_cache_layer_name so that torch.compile sees the same
+            # sentinel string ("from_forward_context") for every layer, enabling
+            # CUDA graph reuse across all attention layers.
+            encoded = _get_kv_cache_layer_name(self.layer_name)
             if (
                 not self.attn_backend.forward_includes_kv_cache_update
                 and self.kv_sharing_target_layer_name is None
@@ -720,6 +759,15 @@ def unified_kv_cache_update(
     the data dependency between them to ensure torch.compile preserves ordering.
     """
     layer_name = _resolve_layer_name(layer_name)
+    forward_context: ForwardContext = get_forward_context()
+    if not _USE_LAYERNAME and layer_name == "from_forward_context":
+        all_layers = forward_context.all_kv_cache_update_layers
+        assert all_layers is not None, (
+            "unified_kv_cache_update received sentinel 'from_forward_context' "
+            "but ForwardContext.all_kv_cache_update_layers is None"
+        )
+        layer_name = all_layers[forward_context.kv_cache_update_index]
+        forward_context.kv_cache_update_index += 1
     _, attn_layer, kv_cache, layer_slot_mapping = get_attention_context(layer_name)
     if layer_slot_mapping is not None:
         assert hasattr(attn_layer.impl, "do_kv_cache_update"), (

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -218,6 +218,7 @@ from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.attention.attention import (
+    _get_kv_cache_layer_name,
     _init_kv_cache_quant,
     get_attention_context,
     set_default_quant_scales,
@@ -241,6 +242,7 @@ from vllm.utils.flashinfer import has_flashinfer, has_nvidia_artifactory
 from vllm.utils.math_utils import cdiv, round_down
 from vllm.utils.torch_utils import (
     LayerNameType,
+    _USE_LAYERNAME,
     _encode_layer_name,
     _resolve_layer_name,
     direct_register_custom_op,
@@ -418,6 +420,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         if prefix in compilation_config.static_forward_context:
             raise ValueError(f"Duplicate layer name: {prefix}")
         compilation_config.static_forward_context[prefix] = self
+        compilation_config.static_all_kv_cache_update_layers.append(prefix)
 
         self.kv_cache = torch.tensor([])
 
@@ -513,7 +516,10 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             )
             return output
         else:
-            encoded = _encode_layer_name(self.layer_name)
+            # Use _get_kv_cache_layer_name so that torch.compile sees the same
+            # sentinel string ("from_forward_context") for every MLA layer,
+            # enabling CUDA graph reuse across all attention layers.
+            encoded = _get_kv_cache_layer_name(self.layer_name)
             kv_cache_dummy_dep = torch.ops.vllm.unified_mla_kv_cache_update(
                 kv_c_normed,
                 k_pe,
@@ -919,6 +925,14 @@ def unified_mla_kv_cache_update(
     """
     layer_name = _resolve_layer_name(layer_name)
     forward_context = get_forward_context()
+    if not _USE_LAYERNAME and layer_name == "from_forward_context":
+        all_layers = forward_context.all_kv_cache_update_layers
+        assert all_layers is not None, (
+            "unified_mla_kv_cache_update received sentinel 'from_forward_context' "
+            "but ForwardContext.all_kv_cache_update_layers is None"
+        )
+        layer_name = all_layers[forward_context.kv_cache_update_index]
+        forward_context.kv_cache_update_index += 1
     attn_layer = forward_context.no_compile_layers[layer_name]
     kv_cache = attn_layer.kv_cache
 


### PR DESCRIPTION
## Purpose

Fixes #33267.

Each attention layer previously passed its unique `layer_name` string into `unified_kv_cache_update` / `unified_mla_kv_cache_update`. Because Inductor treats each distinct constant string as a different graph, it compiled a separate piecewise CUDA graph per attention layer, dramatically increasing cold-start time.

This mirrors the existing `fast_moe_cold_start` optimisation for MoE layers:

- `CompilationConfig.fast_kv_cache_cold_start` – tri-state flag (default `None`, resolved to `True` unless speculative decoding is active; forced off on torch >= 2.11 where `LayerName` hoisting supersedes it).
- `CompilationConfig.static_all_kv_cache_update_layers` – ordered list of all attention layer names that actually call `unified_kv_cache_update` at runtime.
- `ForwardContext.all_kv_cache_update_layers` / `.kv_cache_update_index` – runtime list + counter used to resolve the sentinel back to a real name.
- `_get_kv_cache_layer_name()` – helper returning the sentinel `"from_forward_context"` (old torch) or a hoisted `LayerName` opaque object (torch >= 2.11) instead of the layer-specific string.
- Both `Attention` and `MLAAttention` register themselves during `__init__` and use `_get_kv_cache_layer_name` in the compiled path.
- Custom ops resolve the sentinel to the real layer name via an ordered index, preserving execution order.

Registration conditions match runtime call conditions exactly to keep the index aligned:
- `Attention` layers register only when `kv_sharing_target_layer_name is None` **and** `not attn_backend.forward_includes_kv_cache_update`.
- `MLAAttention` layers always register (they always call the custom op unconditionally).

Previous PRs #36244 and #36007 addressed `Attention` only. This PR also covers `MLAAttention` / `unified_mla_kv_cache_update`.

## Test Plan



Run a multi-layer model forward pass with `fast_kv_cache_cold_start=True` and verify:
1. Output matches baseline (correctness).
2. Cold-start compilation time is reduced (Inductor reuses piecewise CUDA graphs across attention layers).

## Test Result

Patch applies cleanly on top of current `main`. Existing compile tests pass locally. Full GPU test results pending CI.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR: Fix torch.compile cold-start regression caused by per-layer string constants in KV cache update ops (fixes #33267).
- [x] The test plan: `pytest tests/compile/` + manual forward-pass correctness check.
- [ ] The test results: pending CI.
- [ ] (Optional) Documentation update: not required for this internal optimisation.
</details>

Signed-off-by: Doondi Ashlesh <126656890+Doondi-Ashlesh@users.noreply.github.com>