### PR TITLE
[Distributed] Add MSCCL++ allreduce support for multi-node communication

### DIFF
--- a/vllm/distributed/device_communicators/cuda_communicator.py
+++ b/vllm/distributed/device_communicators/cuda_communicator.py
@@ -46,16 +46,19 @@ class CudaCommunicator(DeviceCommunicatorBase):
             use_custom_allreduce = False
             use_torch_symm_mem = False
             use_flashinfer_allreduce = False
+            use_mscclpp_allreduce = False
         else:
             from vllm.distributed.parallel_state import _ENABLE_CUSTOM_ALL_REDUCE
 
             use_custom_allreduce = _ENABLE_CUSTOM_ALL_REDUCE
             use_torch_symm_mem = envs.VLLM_ALLREDUCE_USE_SYMM_MEM
             use_flashinfer_allreduce = envs.VLLM_ALLREDUCE_USE_FLASHINFER
+            use_mscclpp_allreduce = envs.VLLM_ALLREDUCE_USE_MSCCLPP
 
         self.use_custom_allreduce = use_custom_allreduce
         self.use_torch_symm_mem = use_torch_symm_mem
         self.use_flashinfer_allreduce = use_flashinfer_allreduce
+        self.use_mscclpp_allreduce = use_mscclpp_allreduce
 
         # lazy import to avoid documentation build error
         from vllm.distributed.device_communicators.custom_all_reduce import (
@@ -63,6 +66,9 @@ class CudaCommunicator(DeviceCommunicatorBase):
         )
         from vllm.distributed.device_communicators.flashinfer_all_reduce import (
             FlashInferAllReduce,
+        )
+        from vllm.distributed.device_communicators.mscclpp_all_reduce import (
+            MscclppAllReduce,
         )
         from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
         from vllm.distributed.device_communicators.quick_all_reduce import (
@@ -83,6 +89,7 @@ class CudaCommunicator(DeviceCommunicatorBase):
         self.qr_comm: QuickAllReduce | None = None
         self.symm_mem_comm: SymmMemCommunicator | None = None
         self.fi_ar_comm: FlashInferAllReduce | None = None
+        self.mscclpp_comm: MscclppAllReduce | None = None
 
         if use_torch_symm_mem and current_platform.is_cuda():
             self.symm_mem_comm = SymmMemCommunicator(
@@ -92,6 +99,12 @@ class CudaCommunicator(DeviceCommunicatorBase):
 
         if self.use_flashinfer_allreduce and self.world_size > 1:
             self.fi_ar_comm = FlashInferAllReduce(
+                group=self.cpu_group,
+                device=self.device,
+            )
+
+        if self.use_mscclpp_allreduce and self.world_size > 1:
+            self.mscclpp_comm = MscclppAllReduce(
                 group=self.cpu_group,
                 device=self.device,
             )
@@ -204,6 +217,15 @@ class CudaCommunicator(DeviceCommunicatorBase):
             and fi_ar_comm.should_use_fi_ar(input_)
         ):
             out = fi_ar_comm.all_reduce(input_)
+            assert out is not None
+            return out
+        mscclpp_comm = self.mscclpp_comm
+        if (
+            mscclpp_comm is not None
+            and not mscclpp_comm.disabled
+            and mscclpp_comm.should_mscclpp_allreduce(input_)
+        ):
+            out = mscclpp_comm.all_reduce(input_)
             assert out is not None
             return out
         ca_comm = self.ca_comm
@@ -345,6 +367,9 @@ class CudaCommunicator(DeviceCommunicatorBase):
         if self.fi_ar_comm is not None:
             self.fi_ar_comm.destroy()
             self.fi_ar_comm = None
+        if self.mscclpp_comm is not None:
+            self.mscclpp_comm.destroy()
+            self.mscclpp_comm = None
         if self.all2all_manager is not None:
             self.all2all_manager.destroy()
             self.all2all_manager = None  # type: ignore[assignment]

--- a/vllm/distributed/device_communicators/mscclpp_all_reduce.py
+++ b/vllm/distributed/device_communicators/mscclpp_all_reduce.py
@@ -1,0 +1,230 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import bisect
+import math
+import os
+from contextlib import contextmanager
+from enum import IntEnum
+
+import torch
+import torch.distributed as dist
+from torch.distributed import ProcessGroup
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+class MscclContextSelection(IntEnum):
+    MSCCL1SHOT1NODELL = 1
+    MSCCL1SHOT2NODELL = 2
+
+
+def _is_weak_contiguous(inp: torch.Tensor) -> bool:
+    return inp.is_contiguous() or (
+        inp.storage().nbytes() - inp.storage_offset() * inp.element_size()
+        == inp.numel() * inp.element_size()
+    )
+
+
+def _bench_time(func, test_niter: int = 10, warmup_niter: int = 2) -> float:
+    for _ in range(warmup_niter):
+        func()
+    start_event = torch.cuda.Event(enable_timing=True)
+    end_event = torch.cuda.Event(enable_timing=True)
+    torch.cuda.synchronize()
+    dist.barrier()
+    start_event.record()
+    for _ in range(test_niter):
+        func()
+    end_event.record()
+    end_event.synchronize()
+    return start_event.elapsed_time(end_event) / test_niter * 1000
+
+
+def _load_mscclpp_ops():
+    try:
+        import vllm_mscclpp_ops  # noqa: F401
+
+        return torch.ops.vllm_mscclpp
+    except ImportError:
+        return None
+
+
+class MscclppAllReduce:
+    _SUPPORTED_WORLD_SIZES = [8, 16]
+    _SUPPORTED_DTYPES = [torch.float32, torch.float16, torch.bfloat16]
+    _DEFAULT_MAX_BYTES = int(os.getenv("VLLM_MSCCLPP_MAX_BYTES", "1048576"))
+
+    def __init__(
+        self,
+        group: ProcessGroup,
+        device: int | str | torch.device,
+        max_bytes: int | None = None,
+    ) -> None:
+        self.disabled = True
+        self._context = None
+
+        self._ops = _load_mscclpp_ops()
+        if self._ops is None:
+            logger.warning(
+                "MSCCL++ ops not available (vllm_mscclpp_ops not found). "
+                "MSCCL++ allreduce disabled."
+            )
+            return
+
+        self.group = group
+        rank = dist.get_rank(group=self.group)
+        world_size = dist.get_world_size(group=self.group)
+
+        if world_size == 1:
+            return
+
+        if world_size not in self._SUPPORTED_WORLD_SIZES:
+            logger.warning(
+                "MSCCL++ allreduce disabled: unsupported world size %d. Supported: %s",
+                world_size,
+                self._SUPPORTED_WORLD_SIZES,
+            )
+            return
+
+        ranks = dist.get_process_group_ranks(group)
+        if abs(ranks[-1] - ranks[0]) != world_size - 1:
+            logger.warning(
+                "MSCCL++ allreduce disabled: non-consecutive ranks %s",
+                ranks,
+            )
+            return
+
+        if isinstance(device, int):
+            device = torch.device(f"cuda:{device}")
+        elif isinstance(device, str):
+            device = torch.device(device)
+        assert isinstance(device, torch.device)
+        self.device = device
+
+        self.max_bytes = max_bytes or self._DEFAULT_MAX_BYTES
+        self.rank = rank
+        self.world_size = world_size
+        self.nranks_per_node = torch.cuda.device_count()
+
+        unique_id = [self._ops.mscclpp_generate_unique_id()] if rank == 0 else [None]
+        dist.broadcast_object_list(unique_id, src=ranks[0], group=self.group)
+        self.unique_id = unique_id[0]
+
+        self.rank_to_node = [r // 8 for r in range(world_size)]
+        self.rank_to_ib = [rank % 8 for _ in range(world_size)]
+
+        if world_size == 8:
+            self.context_selection = MscclContextSelection.MSCCL1SHOT1NODELL
+        elif world_size == 16:
+            self.context_selection = MscclContextSelection.MSCCL1SHOT2NODELL
+
+        self.scratch = torch.empty(
+            self.max_bytes * 8, dtype=torch.uint8, device=self.device
+        )
+        self.put_buffer = torch.empty(
+            self.max_bytes * 8 // self.nranks_per_node,
+            dtype=torch.uint8,
+            device=self.device,
+        )
+
+        self._context = self._ops.mscclpp_init_context(
+            self.unique_id,
+            self.rank,
+            self.world_size,
+            self.scratch,
+            self.put_buffer,
+            self.nranks_per_node,
+            self.rank_to_node,
+            self.rank_to_ib,
+            int(self.context_selection),
+        )
+
+        self.msg_size_for_finetune = [
+            2**i for i in range(10, math.floor(math.log2(self.max_bytes)) + 1)
+        ]
+        self.msg_size2best_config: dict[int, tuple[int, int]] = {}
+        self._pre_tune_config()
+
+        config_list = [self.msg_size2best_config] if rank == 0 else [None]
+        dist.broadcast_object_list(config_list, src=ranks[0], group=self.group)
+        self.msg_size2best_config = config_list[0]
+
+        self.disabled = True
+        logger.info(
+            "MSCCL++ allreduce initialized (rank=%d, world_size=%d, "
+            "max_bytes=%d, context=%s)",
+            rank,
+            world_size,
+            self.max_bytes,
+            self.context_selection.name,
+        )
+
+    def _pre_tune_config(self, dtype: torch.dtype = torch.bfloat16) -> None:
+        nthreads_to_try = [256, 512, 1024]
+        nblocks_to_try = [21, 42, 84]
+        inp_randn = torch.ones(
+            self.msg_size_for_finetune[-1] // dtype.itemsize,
+            dtype=dtype,
+            device=self.device,
+        )
+        oup_randn = torch.empty_like(inp_randn)
+        for msg_size in self.msg_size_for_finetune:
+            mock_inp = inp_randn[: msg_size // dtype.itemsize]
+            mock_outp = oup_randn[: msg_size // dtype.itemsize]
+            best_config = None
+            best_time = None
+            for nthreads in nthreads_to_try:
+                for nblocks in nblocks_to_try:
+                    cur_cost = _bench_time(
+                        lambda nt=nthreads, nb=nblocks, mi=mock_inp, mo=mock_outp: (
+                            self._ops.mscclpp_allreduce(self._context, mi, mo, nt, nb)
+                        )
+                    )
+                    if best_time is None or cur_cost < best_time:
+                        best_config = (nthreads, nblocks)
+                        best_time = cur_cost
+            self.msg_size2best_config[msg_size] = best_config
+            if self.rank == 0:
+                logger.debug(
+                    "MSCCL++ tune: msg_size=%d best_config=%s time=%.1fus",
+                    msg_size,
+                    best_config,
+                    best_time,
+                )
+
+    def should_mscclpp_allreduce(self, inp: torch.Tensor) -> bool:
+        if self.disabled or self._context is None:
+            return False
+        if inp.dtype not in self._SUPPORTED_DTYPES:
+            return False
+        if not _is_weak_contiguous(inp):
+            return False
+        return inp.numel() * inp.element_size() <= self.max_bytes
+
+    def all_reduce(self, inp: torch.Tensor) -> torch.Tensor:
+        msg_size = inp.numel() * inp.element_size()
+        index = bisect.bisect_left(self.msg_size_for_finetune, msg_size)
+        if index >= len(self.msg_size_for_finetune):
+            index = len(self.msg_size_for_finetune) - 1
+        msg_size_finetune = self.msg_size_for_finetune[index]
+        nthreads, nblocks = self.msg_size2best_config[msg_size_finetune]
+        result = torch.empty_like(inp)
+        self._ops.mscclpp_allreduce(self._context, inp, result, nthreads, nblocks)
+        return result
+
+    @contextmanager
+    def capture(self):
+        old_disabled = self.disabled
+        self.disabled = False
+        try:
+            yield
+        finally:
+            self.disabled = old_disabled
+
+    def destroy(self):
+        self._context = None
+        self.scratch = None
+        self.put_buffer = None

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -470,6 +470,7 @@ class GroupCoordinator:
         # only cuda uses this function,
         # so we don't abstract it into the base class
         maybe_ca_context = nullcontext()
+        maybe_mscclpp_context = nullcontext()
         from vllm.distributed.device_communicators.cuda_communicator import (
             CudaCommunicator,
         )
@@ -479,6 +480,9 @@ class GroupCoordinator:
             ca_comm = self.device_communicator.ca_comm
             if ca_comm is not None:
                 maybe_ca_context = ca_comm.capture()  # type: ignore
+            mscclpp_comm = self.device_communicator.mscclpp_comm
+            if mscclpp_comm is not None and mscclpp_comm._context is not None:
+                maybe_mscclpp_context = mscclpp_comm.capture()
 
         # ensure all initialization operations complete before attempting to
         # capture the graph on another stream
@@ -486,7 +490,7 @@ class GroupCoordinator:
         if curr_stream != stream:
             stream.wait_stream(curr_stream)
 
-        with torch.cuda.stream(stream), maybe_ca_context:
+        with torch.cuda.stream(stream), maybe_ca_context, maybe_mscclpp_context:
             yield graph_capture_context
 
     def all_reduce(self, input_: torch.Tensor) -> torch.Tensor:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -216,6 +216,7 @@ if TYPE_CHECKING:
     VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8_CUTLASS: bool = False
     VLLM_ALLREDUCE_USE_SYMM_MEM: bool = True
     VLLM_ALLREDUCE_USE_FLASHINFER: bool = False
+    VLLM_ALLREDUCE_USE_MSCCLPP: bool = False
     VLLM_TUNED_CONFIG_FOLDER: str | None = None
     VLLM_GPT_OSS_SYSTEM_TOOL_MCP_LABELS: set[str] = set()
     VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT: bool = False
@@ -1519,6 +1520,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Whether to use FlashInfer allreduce
     "VLLM_ALLREDUCE_USE_FLASHINFER": lambda: bool(
         int(os.getenv("VLLM_ALLREDUCE_USE_FLASHINFER", "0"))
+    ),
+    # Whether to use MSCCL++ allreduce
+    "VLLM_ALLREDUCE_USE_MSCCLPP": lambda: bool(
+        int(os.getenv("VLLM_ALLREDUCE_USE_MSCCLPP", "0"))
     ),
     # Experimental: use this to enable MCP tool calling for non harmony models
     "VLLM_USE_EXPERIMENTAL_PARSER_CONTEXT": lambda: bool(


### PR DESCRIPTION
## [Distributed] Add MSCCL++ low-latency allreduce for small messages

### Purpose

NCCL's ring allreduce has non-trivial fixed overhead (kernel launch, multi-round ring passes, synchronization) that dominates latency for small messages. In TP inference, decode-phase allreduce messages are typically in the tens-to-hundreds KB range, where this overhead matters.

This PR integrates MSCCL++ (Microsoft Collective Communication Library++) as an optional allreduce backend for messages <= 1MB. MSCCL++ uses a low-latency (LL) packet protocol with GPU shared memory channels to complete the reduce in a single kernel launch, avoiding multi-round ring passes. It is enabled only during CUDA graph capture, where Python/launch overhead is eliminated and the LL protocol's advantage is maximized.

The integration follows vLLM's existing allreduce priority chain pattern. MSCCL++ sits between FlashInfer and Custom Allreduce:

```
NCCL Symm Mem -> Quick AR -> FlashInfer -> MSCCL++ -> Custom AR -> Symm Mem -> PyNCCL
```

Default off. Opt-in via `VLLM_ALLREDUCE_USE_MSCCLPP=1`. If the MSCCL++ ops extension is not installed, it degrades gracefully with a warning. No impact on existing code paths.

Key design points:
- Auto-tuning at init: grid search over (nthreads x nblocks) per message size bucket, results broadcast from rank 0 to ensure consistency. Adds a few seconds to startup but finds hardware-optimal configs automatically.
- Graph-only activation via `capture()` context manager, same pattern as Custom Allreduce.
- Out-of-place allreduce, matching vLLM convention.
- Supports TP=8 (1-node LL) and TP=16 (2-node LL).

Files changed:
- `vllm/envs.py` -- add `VLLM_ALLREDUCE_USE_MSCCLPP`
- `vllm/distributed/device_communicators/mscclpp_all_reduce.py` -- new, MscclppAllReduce communicator
- `vllm/distributed/device_communicators/cuda_communicator.py` -- integrate into allreduce chain
- `vllm/distributed/parallel_state.py` -- add capture context for graph capture

### Test Plan

Tested on 8x H200 (single node), TP=8.

Prerequisites: build and install the `vllm_mscclpp_ops` torch extension that wraps MSCCL++'s CUDA kernels, then `export VLLM_ALLREDUCE_USE_MSCCLPP=1`.

1. Kernel correctness test

Validates MSCCL++ allreduce output matches NCCL `dist.all_reduce` across multiple sizes, dtypes, and execution modes.

```bash
torchrun --nproc_per_node=8 test_mscclpp_simple.py
```

Test matrix:
- Sizes: [512, 4096, 32768, 262144, 524288] elements
- Dtypes: [float32, float16, bfloat16]
- Modes: eager, CUDA graph
- Comparison: `torch.testing.assert_close(msccl_out, nccl_out)`
- Total: 5 sizes x 3 dtypes x 3 iterations x 2 modes = 84 test points (skip cases exceeding 1MB max_bytes)

2. Kernel latency benchmark

Compares NCCL eager, MSCCL++ eager, MSCCL++ graph, and PyNCCL graph latencies. Also includes inline correctness check.

```bash
torchrun --nproc_per_node=8 benchmark_mscclpp_aligned.py
```

Benchmark parameters:
- Message sizes: 2^10 to 2^20 bytes (1KB - 1MB), dtype=bfloat16
- Auto-tuning per size before measurement
- 10 warmup + 10 timed iterations per config
- Graph capture with 10 ops per graph for amortized measurement

3. End-to-end model test

```bash
# Baseline
python -m vllm.entrypoints.openai.api_server \
    --model Qwen/Qwen2.5-32B-Instruct \
    --tensor-parallel-size 8 \
    --max-model-len 512

# MSCCL++ enabled
VLLM_ALLREDUCE_USE_MSCCLPP=1 python -m vllm.entrypoints.openai.api_server \
    --model Qwen/Qwen2.5-32B-Instruct \
    --tensor-parallel-size 8 \
    --max-model-len 512
```

Benchmarked with:
```bash
python benchmarks/benchmark_serving.py \
    --model Qwen/Qwen2.5-32B-Instruct \
    --num-prompts 200 \
    --dataset-name random \
    --random-input-len 256 \
    --random-output-len 128
```

### Test Result

1. Kernel correctness: 84/84 passed

2. Kernel latency (H200 x8, TP=8, bfloat16):

| msg_size | NCCL eager (us) | MSCCL++ eager (us) | MSCCL++ graph (us) | PyNCCL graph (us) | vs PyNCCL graph |
| --- | --- | --- | --- | --- | --- |
| 2.0 KiB | 161.5 | 69.2 | 16.5 | 31.0 | 1.87x |
| 4.0 KiB | 53.6 | 27.3 | 9.3 | 20.6 | 2.21x |
| 8.0 KiB | 73.9 | 33.8 | 10.0 | 22.6 | 2.25x |
| 16.0 KiB | 68.4 | 31.9 | 13.8 | 23.2 | 1.68x |
| 32.0 KiB | 52.5 | 29.9 | 10.4 | 25.8 | 2.47x |
| 64.0 KiB | 60.1 | 28.1 | 11.6 | 33.0 | 2.86x |
| 128.0 KiB | 51.9 | 28.0 | 11.5 | 25.8 | 2.24x |
| 256.0 KiB | 55.5 | 27.0 | 13.1 | 26.4 | 2.01x |
| 512.0 KiB | 58.3 | 27.7 | 16.5 | 24.6 | 1.49x |
| 1.0 MiB | 34.8 | 21.1 | 17.9 | 33.4 | 1.87x |

MSCCL++ graph-captured allreduce is 1.5x-2.9x faster than PyNCCL graph across all tested sizes.

3. End-to-end (Qwen2.5-32B-Instruct, TP=8, 200 prompts, input=256/output=128):

| | throughput (tok/s) |
| --- | --- |
| Baseline | 17,777 |
| MSCCL++ | 17,658 |

Functionally correct -- both produce identical text outputs. Throughput is similar as expected: at TP=8 for a 32B model, allreduce is not the bottleneck. The kernel-level gains would be more visible with larger models or higher TP counts where allreduce latency represents a larger fraction of total step time.
