### PR TITLE
[Doc] Fix outdated source reference comment in anthropic/serving.py

### DIFF
--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # Adapted from
-# https://github.com/vllm/vllm/entrypoints/openai/serving_chat.py
+# https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/openai/chat_completion/serving.py
 
 """Anthropic Messages API serving handler"""
 


### PR DESCRIPTION
The header comment in `vllm/entrypoints/anthropic/serving.py` referenced an outdated file path and incorrect repository URL.

## Changes
- Updated the source file reference:  
  `vllm/entrypoints/openai/serving_chat.py` → `vllm/entrypoints/openai/chat_completion/serving.py`  
  (renamed in #32240, commit `fefce4980`)
- Fixed GitHub repository URL:  
  `vllm/vllm` → `vllm-project/vllm`
- Added missing `/blob/main/` segment to ensure the link resolves correctly

## Notes
- This is a non-functional change that improves code documentation accuracy.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

