### PR TITLE
fix: remove redundant None default in dict.get() calls

### DIFF
--- a/examples/online_serving/disaggregated_serving_p2p_nccl_xpyd/disagg_proxy_p2p_nccl_xpyd.py
+++ b/examples/online_serving/disaggregated_serving_p2p_nccl_xpyd/disagg_proxy_p2p_nccl_xpyd.py
@@ -46,7 +46,7 @@ def _listen_for_register(poller, router_socket):
                 global prefill_instances
                 global prefill_cv
                 with prefill_cv:
-                    node = prefill_instances.get(data["http_address"], None)
+                    node = prefill_instances.get(data["http_address"])
                     prefill_instances[data["http_address"]] = (
                         data["zmq_address"],
                         time.time() + DEFAULT_PING_SECONDS,
@@ -57,7 +57,7 @@ def _listen_for_register(poller, router_socket):
                 global decode_instances
                 global decode_cv
                 with decode_cv:
-                    node = decode_instances.get(data["http_address"], None)
+                    node = decode_instances.get(data["http_address"])
                     decode_instances[data["http_address"]] = (
                         data["zmq_address"],
                         time.time() + DEFAULT_PING_SECONDS,

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -267,7 +267,7 @@ class LlamaBidirectionalConfig(VerifyAndUpdateConfig):
             "last": "LAST",
         }
 
-        pooling_type = pooling_type_map.get(hf_config.pooling, None)
+        pooling_type = pooling_type_map.get(hf_config.pooling)
         if pooling_type is None:
             raise ValueError(f"pool_type {hf_config.pooling!r} not supported")
 


### PR DESCRIPTION
## Summary

`dict.get(key, None)` is identical to `dict.get(key)` — `None` is already the default return value. This removes the redundant argument in 3 call sites:

- `examples/online_serving/disaggregated_serving_p2p_nccl_xpyd/disagg_proxy_p2p_nccl_xpyd.py` (2 occurrences)
- `vllm/model_executor/models/config.py` (1 occurrence)

All three are plain `dict` objects — no custom `__getitem__` or wrapper classes. Zero behavior change.

Flagged by [ruff PIE804](https://docs.astral.sh/ruff/rules/unnecessary-dict-kwargs/) via [HUMMBL Arbiter](https://hummbl.io/audit).