### PR TITLE
[ROCm] Add missing gfx1152, gfx1153, and enable all gpu arch to AITER in docker

### DIFF
--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -41,7 +41,8 @@ using __hip_fp8_e5m2 = __hip_fp8_e5m2_fnuz;
 #endif
 
 #if defined(__HIPCC__) && (defined(__gfx1100__) || defined(__gfx1101__) || \
-                           defined(__gfx1150__) || defined(__gfx1151__))
+                           defined(__gfx1150__) || defined(__gfx1151__) || \
+                           defined(__gfx1152__) || defined(__gfx1153__))
   #define __HIP__GFX11__
 #endif
 

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -28,7 +28,8 @@
 
 #if defined(__HIPCC__) &&                                                    \
     (defined(__gfx1100__) || defined(__gfx1101__) || defined(__gfx1150__) || \
-     defined(__gfx1151__) || defined(__gfx1200__) || defined(__gfx1201__))
+     defined(__gfx1151__) || defined(__gfx1152__) || defined(__gfx1153__) || \
+     defined(__gfx1200__) || defined(__gfx1201__))
   #define __HIP__GFX1X__
 #endif
 

--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -27,9 +27,9 @@ FROM ${BASE_IMAGE} AS base
 ENV PATH=/opt/rocm/llvm/bin:/opt/rocm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 ENV ROCM_PATH=/opt/rocm
 ENV LD_LIBRARY_PATH=/opt/rocm/lib:/usr/local/lib:
-ARG PYTORCH_ROCM_ARCH=gfx90a;gfx942;gfx950;gfx1100;gfx1101;gfx1200;gfx1201;gfx1150;gfx1151
+ARG PYTORCH_ROCM_ARCH=gfx90a;gfx942;gfx950;gfx1100;gfx1101;gfx1150;gfx1151;gfx1152;gfx1153;gfx1200;gfx1201
 ENV PYTORCH_ROCM_ARCH=${PYTORCH_ROCM_ARCH}
-ENV AITER_ROCM_ARCH=gfx942;gfx950
+ENV AITER_ROCM_ARCH=${PYTORCH_ROCM_ARCH}
 ENV MORI_GPU_ARCHS=gfx942;gfx950
 
 # Required for RCCL in ROCm7.1

--- a/docs/getting_started/installation/gpu.rocm.inc.md
+++ b/docs/getting_started/installation/gpu.rocm.inc.md
@@ -13,7 +13,7 @@ vLLM supports AMD GPUs with ROCm 6.3 or above. Pre-built wheels are available fo
 --8<-- [end:installation]
 --8<-- [start:requirements]
 
-- GPU: MI200s (gfx90a), MI300 (gfx942), MI350 (gfx950), Radeon RX 7900 series (gfx1100/1101), Radeon RX 9000 series (gfx1200/1201), Ryzen AI MAX / AI 300 Series (gfx1151/1150)
+- GPU: MI200s (gfx90a), MI300 (gfx942), MI350 (gfx950), Radeon RX 7900 series (gfx1100/1101), Radeon RX 9000 series (gfx1200/1201), Ryzen AI MAX / AI 300 Series (gfx1153/gfx1152/gfx1151/1150)
 - ROCm 6.3 or above
     - MI350 requires ROCm 7.0 or above
     - Ryzen AI MAX / AI 300 Series requires ROCm 7.0.2 or above


### PR DESCRIPTION
Add missing targets gfx1152, gfx1153.
And enable all GPU TARGET on AITER they all seems to be compatible : [https://github.com/ROCm/aiter/blob/cf12b1381dcdec4b5d90d136a5403e718c7541ec/aiter/jit/utils/build_targets.py#L9-L28](https://github.com/ROCm/aiter/blob/cf12b1381dcdec4b5d90d136a5403e718c7541ec/aiter/jit/utils/build_targets.py#L9-L28)