### PR TITLE
fix(libtorch_stable): guard mxfp4 ops behind ENABLE_NVFP4_SM100

### DIFF
--- a/csrc/libtorch_stable/torch_bindings.cpp
+++ b/csrc/libtorch_stable/torch_bindings.cpp
@@ -155,6 +155,7 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "Tensor input, Tensor input_global_scale, Tensor input_offset_by_experts,"
       "Tensor output_scale_offset_by_experts) -> ()");
 
+#ifdef ENABLE_NVFP4_SM100
   // Compute MXFP4 experts quantization (32-element blocks, E8M0 SFs).
   ops.def(
       "mxfp4_experts_quant(Tensor! output, Tensor! output_scale,"
@@ -167,6 +168,7 @@ STABLE_TORCH_LIBRARY_FRAGMENT(_C, ops) {
       "output_scale,"
       "Tensor input, Tensor input_offset_by_experts,"
       "Tensor output_scale_offset_by_experts, int n_experts) -> ()");
+#endif  // ENABLE_NVFP4_SM100
 
   // Fused SiLU+Mul+NVFP4 quantization.
   ops.def(
@@ -252,9 +254,11 @@ STABLE_TORCH_LIBRARY_IMPL(_C, CUDA, ops) {
   ops.impl("silu_and_mul_scaled_fp4_experts_quant",
            TORCH_BOX(&silu_and_mul_scaled_fp4_experts_quant));
   ops.impl("silu_and_mul_nvfp4_quant", TORCH_BOX(&silu_and_mul_nvfp4_quant));
+#ifdef ENABLE_NVFP4_SM100
   ops.impl("mxfp4_experts_quant", TORCH_BOX(&mxfp4_experts_quant));
   ops.impl("silu_and_mul_mxfp4_experts_quant",
            TORCH_BOX(&silu_and_mul_mxfp4_experts_quant));
+#endif  // ENABLE_NVFP4_SM100
 
   // W4A8 ops: impl registrations are in the source files
   // (w4a8_mm_entry.cu and w4a8_grouped_mm_entry.cu)


### PR DESCRIPTION
## Problem

`mxfp4_experts_quant` and `silu_and_mul_mxfp4_experts_quant` kernels (added in #37463) are only compiled when `FP4_ARCHS` is non-empty — i.e. SM100/Blackwell (CC 10.0+). However `torch_bindings.cpp` registers both `ops.def` and `ops.impl` unconditionally, causing an undefined symbol crash at import time on Ampere and older GPUs:

```
ImportError: /opt/vllm/vllm/_C_stable_libtorch.abi3.so: undefined symbol:
_Z19mxfp4_experts_quantRN5torch6stable6TensorES2_RKS1_S4_S4_l
```

Reproduced on 2x RTX 3090 (SM 8.6, Ampere), `TORCH_CUDA_ARCH_LIST=8.6`.

## Fix

Wrap the affected `ops.def` and `ops.impl` blocks in `#ifdef ENABLE_NVFP4_SM100` to match the `CMakeLists.txt` conditional that sets this macro only when `FP4_ARCHS` is non-empty.

## Testing

- Builds and imports cleanly on SM 8.6 (Ampere) after patch
- `python -c 'import vllm._C_stable_libtorch; print("OK")'` passes
- vLLM server starts and serves requests normally