### PR TITLE
Fix view shape assignment for chan_scales

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -818,7 +818,7 @@ def convert_bf16_scales_to_fp8(
 
     # restore original shape
     fp8_scales = fp8_scales.view(orig_shape)
-    chan_scales = chan_scales.view(orig_shape[:-1], -1)
+    chan_scales = chan_scales.view(*orig_shape[:-1], -1)
 
     return fp8_scales, chan_scales
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Fix a `TypeError` in `convert_bf16_scales_to_fp8` that prevents loading any W4A8-FP8 (INT4 weights + dynamic FP8 activations) compressed-tensors checkpoint produced by `llmcompressor`'s `GPTQModifier(scheme="W4AFP8", ...)`.

  `orig_shape` is a `torch.Size`, so `orig_shape[:-1]` is also a `torch.Size`. `Tensor.view` does not accept the signature `(torch.Size, int)` — only `(dtype,)` or `(*ints,)`. The fix unpacks the shape, matching the intent (reshape channel scales back to `(*orig_shape[:-1], -1)`):

```diff
  -    chan_scales = chan_scales.view(orig_shape[:-1], -1)
  +    chan_scales = chan_scales.view(*orig_shape[:-1], -1)
```

File: vllm/model_executor/layers/quantization/utils/quant_utils.py (line 811, inside convert_bf16_scales_to_fp8).

Call site: CutlassW4A8LinearKernel.process_weights_after_loading → convert_bf16_scales_to_fp8 (triggered for every W4A8-FP8 dense linear at model load).

## Test Plan

Load any W4A8-FP8 checkpoint — e.g. a Qwen3-MoE model quantized via:

```python
from llmcompressor import oneshot
from llmcompressor.modifiers.quantization import GPTQModifier

oneshot(
    model=model,
    dataset=calib_ds,
    recipe=GPTQModifier(
        targets="Linear",
        scheme="W4AFP8",
        ignore=["lm_head", r"re:.*\.mlp\.gate$"],  # MoE router must stay bf16
    ),
    max_seq_length=8192,
    num_calibration_samples=512,
)
model.save_pretrained("w4afp8-ckpt", save_compressed=True, quantization_format="pack-quantized")
```

Then run inference on SM ≥ 90 (Hopper+):

```python
from vllm import LLM, SamplingParams
llm = LLM(model="w4afp8-ckpt", dtype="bfloat16", quantization="compressed-tensors", max_model_len=8192)
print(llm.generate(["Hello"], SamplingParams(max_tokens=32))[0].outputs[0].text)
```

## Test Result

Before this patch (main):

```
  File ".../vllm/model_executor/layers/quantization/utils/quant_utils.py", line 811, in convert_bf16_scales_to_fp8
      chan_scales = chan_scales.view(orig_shape[:-1], -1)
  TypeError: view() received an invalid combination of arguments - got (torch.Size, int),
  but expected one of:
   * (torch.dtype dtype)
   * (tuple of ints size)
```
  Engine fails to start; no model loads.

  After this patch: engine starts normally:

```
  [compressed_tensors_w4a8_fp8.py] Using CutlassW4A8LinearKernel for CompressedTensorsW4A8Fp8
  [compressed_tensors_moe.py]      Using CompressedTensorsW4A8Fp8MoEMethod
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
