### PR TITLE
[Bugfix] Corrects estimate of torch memory use causing OOM due to incorrect KV cache space estimation when sleep mode on (Fixes #40256)

### DIFF
--- a/vllm/utils/mem_utils.py
+++ b/vllm/utils/mem_utils.py
@@ -96,14 +96,16 @@ class MemorySnapshot:
     def measure(self) -> None:
         device = self.device_
 
-        # we measure the torch peak memory usage via allocated_bytes,
+        # Obtain torch stats object, from which we will need to measure the allocated
+        # currently and at peak during profiling
+        stats = torch.accelerator.memory_stats(device)
+
+        # We measure the torch peak memory usage via allocated_bytes,
         # rather than `torch.accelerator.memory_reserved()` .
         # After `torch.accelerator.reset_peak_memory_stats()`,
         # `torch.accelerator.memory_reserved()` will keep growing, and only shrink
         # when we call `torch.accelerator.empty_cache()` or OOM happens.
-        self.torch_peak = torch.accelerator.memory_stats(device).get(
-            "allocated_bytes.all.peak", 0
-        )
+        self.torch_peak = stats.get("allocated_bytes.all.peak", 0)
 
         self.free_memory, self.total_memory = current_platform.mem_get_info(device)
         if current_platform.is_integrated_gpu(device.index):
@@ -117,10 +119,14 @@ class MemorySnapshot:
 
         self.cuda_memory = self.total_memory - self.free_memory
 
-        # torch.accelerator.memory_reserved() is how many bytes
+        # `torch.accelerator.memory_reserved()` is how many bytes
         # PyTorch gets from cuda (by calling cudaMalloc, etc.)
-        # this is used to measure the non-torch memory usage
-        self.torch_memory = torch.accelerator.memory_reserved(device)
+        # this was previously used to measure the non-torch memory usage
+        # Prior to implementation of sleep mode this may have been a good estimate
+        # of torch memory used, but with the implementation of sleep mode and
+        # custom allocators, this is no longer reliable. Torch memory is better
+        # estimated from `allocated_bytes.all.current` in torch stats.
+        self.torch_memory = stats.get("allocated_bytes.all.current", 0)
 
         self.non_torch_memory = self.cuda_memory - self.torch_memory
         self.timestamp = time.time()


### PR DESCRIPTION
## Purpose
**This PR repairs an erroneous memory estimation that arises during profiling when custom CUDA allocators are in use (e.g., sleep mode).** This fixes issue #40256.

To calculate how much memory is available for the KV cache vLLM profiles memory usage (gpu_worker.py calling mem_utils.py's measure() function).

The strategy vllm has been using is outlined in `MemoryShapshot.measure()`, which profiles the memory usage in terms of torch-related memory and non-torch memory. (This is because it also needs to keep track of peak torch memory, which may be transiently higher during the forward pass of a model).

The strategy vllm had been using is to measure torch memory using `torch.accelerator.memory.memory_reserved`. However, there were changes accepted to enable sleep mode recently. To support sleep mode, this uses a custom CUDA allocator that allows vllm to selectively discard some parts of GPU memory during sleep.

Unfortunately, when custom allocators are used, this causes the `measure()` method to over-estimate torch memory use. This is because `torch.accelerator.memory.memory_reserved` becomes an unreliable estimate of torch-related memory once custom allocaters are being used.

In some cases, this estimate can exceed all CUDA memory use, causing `measure()`  to incorrectly report that non-torch memory is negative. This is obviously incorrect and can lead to out of memory errors because vllm believes it has more memory to allocate to the KV cache than is truly available.

More details are shown in a related bug.

This PR makes one surgical change to the measure function, replacing the estimate of torch memory with

```python
stats.get("allocated_bytes.all.current", 0)
```

Where stats is:

```python
stats = torch.accelerator.memory_stats(device)
```

The problem can be illustrated by observing the intermediate variables in `measure()` on one CUDA device during 

| Measurement                                     | Sleep off old code | Sleep on old code |
| ----------------------------------------------- | -----------------: | ----------------: |
| Torch Peak                                      |              19.73 |             19.73 |
| Total memory                                    |              23.52 |             23.52 |
| Free memory                                     |               3.98 |              4.02 |
| Cuda memory                                     |              19.54 |              19.5 |
| Torch memory (old: memory_reserved)             |              18.92 |       **20.87 ←** |
| Torch memory (new: allocated_bytes.all.current) |              18.71 |             18.71 |
| Non-torch memory                                |               0.62 |       **-1.36 ←** |

A table in testing results, below, shows the correction of this problem with the proposed code change.

## Test Plan
I observed the measured memory calculated in the `mem_utils.py` `MemoryShapshot.measure()` function using the old calculation method (`memory_reserved()`) and then new method `stats.get("allocated_bytes.all.peak", 0)`. Results from a load of quantized Llama 70B on a 2x 4090 system are shown in the table (test result). Arrows and bold indicates the erroneous quantities using the memory_reserve

The command used to run was:

```bash
VLLM_SERVER_DEV_MODE=1 python -m vllm.entrypoints.openai.api_server \
  --model hugging-quants/Meta-Llama-3.1-70B-Instruct-AWQ-INT4 \
  --tensor-parallel-size 2 \
  --dtype half \
  --quantization awq_marlin \
  --kv-cache-dtype fp8 \
  --max-model-len 36000 \
  --max-num-seqs 1 \
  --gpu-memory-utilization 0.97 \
  --host 0.0.0.0 \
  --port 5555 \
  --enable-chunked-prefill --max-num-batched-tokens 8192 \
  --enforce-eager \
  --enable-sleep-mode
```

For the no sleep tests, the `--enable-sleep-mode` flag was disabled.

## Test Result

The table below shows intermediate calculations in `MemorySnapshot.measure()` when sleep (and therefore custom allocators) are on/off and in the old code as compared to the new code. When sleep is on, `memory_reserved` reports more memory use by torch than is being used in total by CUDA, which is not a correct estimate of the torch memory use (bolded cells with arrows). This leads to non-torch memory being estimated to be negataive. The downstream result of this

|                                     |    Sleep off |    Sleep off |     Sleep on |     Sleep on |
| ----------------------------------- | -----------: | -----------: | -----------: | -----------: |
| **Measurement (GiB)**               | **Old code** | **New code** | **Old code** | **New code** |
| Torch Peak                          |        19.73 |        19.73 |        19.73 |        19.73 |
| Total memory                        |        23.52 |        23.52 |        23.52 |        23.52 |
| Free memory                         |         3.98 |         3.98 |         4.02 |         4.02 |
| Cuda memory                         |        19.54 |        19.54 |         19.5 |         19.5 |
| Torch memory (old: memory_reserved) |        18.92 |        18.92 |  **20.87 ←** |  **20.87 ←** |
| Torch memory (new: bytes_allocated) |        18.71 |        18.71 |        18.71 |        18.71 |
| Non-torch memory                    |         0.62 |         0.83 |  **-1.36 ←** |         0.79 |


On the testing machine sleep on / old code lead to OOM because vllm overestimates how much space it can allocate to the KV cache, whereas sleep on / new code resolves the OOM.

Additionally, we can directly observe the KV cache estimates:

|                             |    Sleep off |    Sleep off |         Sleep on |     Sleep on |
| --------------------------- | -----------: | -----------: | ---------------: | -----------: |
| **Measurement (GiB)**       | **Old code** | **New code** |     **Old code** | **New code** |
| Estimate Available KV Cache |         3.17 |         2.96 | **5.16 ←** Wrong |          3.0 |

This the correction prevents discordance in the estimated available KV cache when sleep mode is enabled as compared to disabled, as expected by issue #40256.

## Contact

Please do not hesitant to contact me about remaining issues with this PR. Thank you for considering this change.

## AI Contributors
I consulted extensively with Github Copilot, ChatGPT Thinking/Pro, Claude 4.6/4.7 to understand the codebase and discuss possible solutions. I considered at length these recommendations, explored possible solutions myself, and personally verified the solution arrived at and proposed in this PR. I take responsibility for its proposal.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

