### PR TITLE
[Doc] Fix CLI help examples: remove phantom --help=listgroup and --help=page modes

### DIFF
--- a/docs/cli/README.md
+++ b/docs/cli/README.md
@@ -37,10 +37,13 @@ vllm serve meta-llama/Llama-2-7b-hf --uds /tmp/vllm.sock
 Check with --help for more options:
 
 ```bash
-# To list all groups
-vllm serve --help=listgroup
+# To view all config groups and their descriptions
+vllm serve --help
 
-# To view a argument group
+# To view all parameters
+vllm serve --help=all
+
+# To view an argument group
 vllm serve --help=ModelConfig
 
 # To view a single argument
@@ -48,9 +51,6 @@ vllm serve --help=max-num-seqs
 
 # To search by keyword
 vllm serve --help=max
-
-# To view full help with pager (less/more)
-vllm serve --help=page
 ```
 
 See [vllm serve](./serve.md) for the full reference of all available arguments.


### PR DESCRIPTION
## Summary

Fixes the CLI README help examples referenced in #39613 (findings 1 & 2).

The docs described two `--help` modes that don't exist in the argparse implementation (`vllm/utils/argparse_utils.py`):

1. **`--help=listgroup`** — documented as "list all groups" but no such mode exists. The default `--help` (without arguments) already shows all config groups.
2. **`--help=page`** — documented as "view full help with pager" but no pager integration exists in the parser.

## Changes

- Replaced `--help=listgroup` with `--help` (the default behavior already lists groups)
- Added `--help=all` example (shows all parameters, which is the existing behavior)
- Removed `--help=page` since no pager mode is implemented
- Minor: fixed "a argument group" → "an argument group"

## Before submitting

- [x] Make sure you already searched for relevant issues
- [x] The PR fixes docs only; no code changes needed

Co-authored-by: opencode