### PR TITLE
[ROCm] Profiler api support for ROCm MORI toy proxy server in PD Disaggregation

### DIFF
--- a/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
+++ b/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
@@ -340,7 +340,11 @@ async def handle_request(api: str, request: Request):
 async def send_profile_cmd(req_data: dict, profiler_cmd: str):
     assert profiler_cmd in {"start", "stop"}
 
-    if not prefill_instances and not decode_instances:
+    with _list_lock:
+        p_instances = list(prefill_instances)
+        d_instances = list(decode_instances)
+
+    if not p_instances and not d_instances:
         raise RuntimeError(
             "Service Unavailable: No prefill or decode instances are registered."
         )

--- a/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
+++ b/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
@@ -14,6 +14,7 @@ import aiohttp
 import msgpack
 import zmq
 from quart import Quart, Request, make_response, request
+
 from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
     MoRIIOConstants,
 )
@@ -358,7 +359,7 @@ async def send_profile_cmd(req_data: dict, profiler_cmd: str):
     async with aiohttp.ClientSession(
         timeout=aiohttp.ClientTimeout(total=60)
     ) as session:
-        for instances in (prefill_instances, decode_instances):
+        for instances in (p_instances, d_instances):
             for inst in instances:
                 _p = urlparse(inst["request_address"])
                 url = f"http://{_p.hostname}:{_p.port}/{profiler_cmd}_profile"

--- a/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
+++ b/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
@@ -7,12 +7,12 @@ import os
 import socket
 import threading
 import uuid
+from urllib.parse import urlparse
 
 import aiohttp
 import msgpack
 import zmq
 from quart import Quart, Request, make_response, request
-
 from vllm.distributed.kv_transfer.kv_connector.v1.moriio.moriio_common import (
     MoRIIOConstants,
 )
@@ -334,6 +334,68 @@ async def handle_request(api: str, request: Request):
                 500,
             )
         )
+
+
+async def send_profile_cmd(req_data: dict, profiler_cmd: str):
+    assert profiler_cmd in {"start", "stop"}
+
+    if not prefill_instances and not decode_instances:
+        raise RuntimeError(
+            "Service Unavailable: No prefill or decode instances are registered."
+        )
+
+    headers = {
+        "Authorization": f"Bearer {os.environ.get('OPENAI_API_KEY')}",
+    }
+
+    tasks = []
+
+    async with aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(total=60)
+    ) as session:
+        for instances in (prefill_instances, decode_instances):
+            for inst in instances:
+                _p = urlparse(inst["request_address"])
+                url = f"http://{_p.hostname}:{_p.port}/{profiler_cmd}_profile"
+
+                tasks.append(
+                    session.post(
+                        url,
+                        json=req_data,
+                        headers=headers,
+                    )
+                )
+
+        responses = await asyncio.gather(*tasks, return_exceptions=True)
+
+        for r in responses:
+            if isinstance(r, Exception):
+                raise r
+            if r.status >= 400:
+                msg = await r.text()
+                raise RuntimeError(f"{profiler_cmd}_profile failed: {r.status}, {msg}")
+
+        return await responses[0].json()
+
+
+@app.post("/start_profile")
+async def start_profile():
+    try:
+        req_data = await request.get_json()
+        return await send_profile_cmd(req_data, "start")
+    except Exception as e:
+        logger.exception("start_profile failed: %s", e)
+        return await make_response((str(e), 500))
+
+
+@app.post("/stop_profile")
+async def stop_profile():
+    try:
+        req_data = await request.get_json()
+        return await send_profile_cmd(req_data, "stop")
+    except Exception as e:
+        logger.exception("stop_profile failed: %s", e)
+        return await make_response((str(e), 500))
 
 
 if __name__ == "__main__":

--- a/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
+++ b/examples/disaggregated/disaggregated_serving/moriio_toy_proxy_server.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import argparse
 import asyncio
 import copy
 import logging
@@ -399,10 +400,14 @@ async def stop_profile():
 
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--port", type=int, default=10001)
+    args = parser.parse_args()
+
     t = start_service_discovery("0.0.0.0", 36367)
     app.debug = True
     app.config["BODY_TIMEOUT"] = 360000
     app.config["RESPONSE_TIMEOUT"] = 360000
 
-    app.run(host="0.0.0.0", port=10001)
+    app.run(host="0.0.0.0", port=args.port)
     t.join()


### PR DESCRIPTION
## Purpose
This PR adds profiler api support to ROCm MORI toy-proxy-server in PD Disaggregation setup

## Test Plan
Run VLLM PD Disaggregation using MORI KV Connector as below

**STEP1:** Run Proxy Server
```
python /app/vllm/examples/online_serving/disaggregated_serving/moriio_toy_proxy_server.py 
```

**STEP2:** Run Prefill Server
```
vllm serve ${MODEL_PATH} \
        -tp 1 \
         --data-parallel-size ${DECODE_DP_SIZE} \
        [. . .]
        --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_producer","kv_port":"9711","kv_connector_extra_config":{"proxy_ip":"'"${MASTER_ADDR}"'","proxy_port":"10001","proxy_ping_port":"36367","http_port":"20005","local_ping_port":"61555","handshake_port":"8405","notify_port":"61005"}}' 

```
**STEP3:** Run Decode Server
```
 vllm serve ${MODEL_PATH} \
        -tp 1 \
        --data-parallel-size ${DECODE_DP_SIZE} \
        [. . .]
        --profiler-config.profiler torch \
        --profiler-config.torch_profiler_dir \"$decode_dir\" \
        --profiler-config.torch_profiler_with_stack true \
        --profiler-config.torch_profiler_with_flops true \
        --profiler-config.torch_profiler_with_memory true \
        --profiler-config.torch_profiler_record_shapes true \
        --profiler-config.torch_profiler_dump_cuda_time_total true \
        --kv-transfer-config '{"kv_connector":"MoRIIOConnector","kv_role":"kv_consumer","kv_port":"9711","kv_connector_extra_config":{"proxy_ip":"'"${MASTER_ADDR}"'","proxy_port":"10001","proxy_ping_port":"36367","http_port":"20005","local_ping_port":"61555","handshake_port":"8405","notify_port":"61005"}}' 
```
**STEP4:** Run Benchmark
```
 vllm bench serve \
           --model $MODEL_PATH \
           --backend vllm \
           --host 10.158.213.211 \
           --port 10001 \
           [. . .]
            --profile
```

## Test Result
Below Decode server log shows profiler being started and stopped with respective trace files being generated.

```
. . . 
(ApiServer_0 pid=1133) INFO:     Started server process [1133]
(ApiServer_0 pid=1133) INFO:     Waiting for application startup.
(ApiServer_6 pid=1139) INFO:     Application startup complete.
(ApiServer_2 pid=1135) INFO:     Application startup complete.
(ApiServer_1 pid=1134) INFO:     Application startup complete.
(ApiServer_3 pid=1136) INFO:     Application startup complete.
(ApiServer_5 pid=1138) INFO:     Application startup complete.
(ApiServer_4 pid=1137) INFO:     Application startup complete.
(ApiServer_0 pid=1133) INFO:     Application startup complete.
**(ApiServer_0 pid=1133) INFO 04-19 01:27:12 [api_router.py:23] Starting profiler...**
(ApiServer_0 pid=1133) /usr/local/lib/python3.12/dist-packages/torch/profiler/profiler.py:217: UserWarning: Warning: Profiler clears events at the end of each cycle.Only events from the current cycle will be reported.To keep events across cycles, set acc_events=True.
(ApiServer_0 pid=1133)   _warn_once(
ERROR: External init callback must run in same thread as registerClient (-201329088 != -668444864)
(Worker_DP0_EP0 pid=5321) INFO 04-19 01:27:12 [wrapper.py:176] Torch profiling enabled. Traces will be saved to: /home/vpolamre/MORI_Test/vllm_dissag/profile-logs_w_async_w_stack/decode_2
(Worker_DP1_EP1 pid=5320) /usr/local/lib/python3.12/dist-packages/torch/profiler/profiler.py:217: UserWarning: Warning: Profiler clears events at the end of each cycle.Only events from the current cycle will be reported.To keep events across cycles, set acc_events=True.
(Worker_DP1_EP1 pid=5320)   _warn_once(
(Worker_DP3_EP3 pid=5323) /usr/local/lib/python3.12/dist-packages/torch/profiler/profiler.py:217: UserWarning: Warning: Profiler clears events at the end of each cycle.Only events from the current cycle will be reported.To keep events across cycles, set acc_events=True.
(Worker_DP3_EP3 pid=5323)   _warn_once(
(Worker_DP2_EP2 pid=5322) /usr/local/lib/python3.12/dist-packages/torch/profiler/profiler.py:217: UserWarning: Warning: Profiler clears events at the end of each cycle.Only events from the current cycle will be reported.To keep events across cycles, set acc_events=True.
(Worker_DP2_EP2 pid=5322)   _warn_once(
(Worker_DP0_EP0 pid=5321) /usr/local/lib/python3.12/dist-packages/torch/profiler/profiler.py:217: UserWarning: Warning: Profiler clears events at the end of each cycle.Only events from the current cycle will be reported.To keep events across cycles, set acc_events=True.
(Worker_DP0_EP0 pid=5321)   _warn_once(
(Worker_DP4_EP4 pid=5325) /usr/local/lib/python3.12/dist-packages/torch/profiler/profiler.py:217: UserWarning: Warning: Profiler clears events at the end of each cycle.Only events from the current cycle will be reported.To keep events across cycles, set acc_events=True.
(Worker_DP4_EP4 pid=5325)   _warn_once(
(Worker_DP5_EP5 pid=5319) /usr/local/lib/python3.12/dist-packages/torch/profiler/profiler.py:217: UserWarning: Warning: Profiler clears events at the end of each cycle.Only events from the current cycle will be reported.To keep events across cycles, set acc_events=True.
(Worker_DP5_EP5 pid=5319)   _warn_once(
(Worker_DP6_EP6 pid=5324) /usr/local/lib/python3.12/dist-packages/torch/profiler/profiler.py:217: UserWarning: Warning: Profiler clears events at the end of each cycle.Only events from the current cycle will be reported.To keep events across cycles, set acc_events=True.
(Worker_DP6_EP6 pid=5324)   _warn_once(
(Worker_DP7_EP7 pid=5318) /usr/local/lib/python3.12/dist-packages/torch/profiler/profiler.py:217: UserWarning: Warning: Profiler clears events at the end of each cycle.Only events from the current cycle will be reported.To keep events across cycles, set acc_events=True.
(Worker_DP7_EP7 pid=5318)   _warn_once(
**(ApiServer_0 pid=1133) INFO 04-19 01:27:12 [api_router.py:25] Profiler started.**
(ApiServer_0 pid=1133) INFO:     10.158.213.211:46420 - "POST /start_profile HTTP/1.1" 200 OK
(ApiServer_4 pid=1137) INFO:     10.158.213.211:46436 - "POST /v1/completions HTTP/1.1" 200 OK
(ApiServer_4 pid=1137) INFO:     10.158.213.211:46500 - "POST /v1/completions HTTP/1.1" 200 OK
(ApiServer_4 pid=1137) INFO:     10.158.213.211:46662 - "POST /v1/completions HTTP/1.1" 200 OK
(ApiServer_4 pid=1137) INFO:     10.158.213.211:46686 - "POST /v1/completions HTTP/1.1" 200 OK
(ApiServer_0 pid=1133) INFO:     10.158.213.211:39848 - "POST /v1/completions HTTP/1.1" 200 OK
(ApiServer_0 pid=1133) INFO:     10.158.213.211:39864 - "POST /v1/completions HTTP/1.1" 200 OK
(ApiServer_0 pid=1133) INFO:     10.158.213.211:39870 - "POST /v1/completions HTTP/1.1" 200 OK
(ApiServer_4 pid=1137) INFO:     10.158.213.211:40132 - "POST /v1/completions HTTP/1.1" 200 OK
WARNING 04-19 01:27:23 [coordinator.py:397] Received stats for out-of-order step (0, 250) from engine 4 (expected > (0, 251))
(ApiServer_0 pid=1133) INFO:     10.158.213.211:39896 - "POST /v1/completions HTTP/1.1" 200 OK
(ApiServer_0 pid=1133) INFO:     10.158.213.211:40182 - "POST /v1/completions HTTP/1.1" 200 OK
(ApiServer_0 pid=1133) INFO:     10.158.213.211:40196 - "POST /v1/completions HTTP/1.1" 200 OK
(ApiServer_0 pid=1133) INFO:     10.158.213.211:40202 - "POST /v1/completions HTTP/1.1" 200 OK
**(ApiServer_0 pid=1133) INFO 04-19 01:27:34 [api_router.py:31] Stopping profiler...**
[rank6]:[W419 01:28:38.192939812 collection.cpp:1148] Warning: ROCTracer produced duplicate flow start: 2 (function operator())
[rank2]:[W419 01:28:39.918687576 collection.cpp:1148] Warning: ROCTracer produced duplicate flow start: 2 (function operator())
[rank7]:[W419 01:28:41.799762246 collection.cpp:1148] Warning: ROCTracer produced duplicate flow start: 2 (function operator())
[rank0]:[W419 01:28:43.741572167 collection.cpp:1148] Warning: ROCTracer produced duplicate flow start: 2 (function operator())
[rank3]:[W419 01:28:44.335107092 collection.cpp:1148] Warning: ROCTracer produced duplicate flow start: 2 (function operator())
[rank5]:[W419 01:28:46.753885583 collection.cpp:1148] Warning: ROCTracer produced duplicate flow start: 2 (function operator())
[rank4]:[W419 01:28:48.920955994 collection.cpp:1148] Warning: ROCTracer produced duplicate flow start: 4 (function operator())
[rank1]:[W419 01:28:48.332432420 collection.cpp:1148] Warning: ROCTracer produced duplicate flow start: 2 (function operator())
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

