### PR TITLE
Fix MoE backend selection for LoRA (unquantized MoE)

### DIFF
--- a/tests/kernels/moe/test_unquantized_backend_selection.py
+++ b/tests/kernels/moe/test_unquantized_backend_selection.py
@@ -91,7 +91,10 @@ def test_select_default_backend_by_platform(
 @pytest.mark.skipif(
     not current_platform.is_rocm(), reason="ROCm-specific backend selection test"
 )
-def test_select_rocm_aiter_backend(mock_aiter_enabled, mock_has_flashinfer):
+@pytest.mark.parametrize("is_lora_enabled", [False, True])
+def test_select_rocm_aiter_backend(
+    mock_aiter_enabled, mock_has_flashinfer, is_lora_enabled
+):
     """Test ROCm backend selection when AITER is available."""
     with patch(
         "vllm.model_executor.layers.fused_moe.oracle.unquantized.current_platform"
@@ -104,6 +107,7 @@ def test_select_rocm_aiter_backend(mock_aiter_enabled, mock_has_flashinfer):
         mock_platform.is_out_of_tree.return_value = False
 
         moe_config = make_dummy_moe_config()
+        moe_config.is_lora_enabled = is_lora_enabled
         selected_backend, expert_cls = select_unquantized_moe_backend(
             moe_config=moe_config,
         )
@@ -237,3 +241,23 @@ def test_select_lora_explicit_non_triton_backend_raises():
 
         with pytest.raises(ValueError, match="LoRA is only supported"):
             select_unquantized_moe_backend(moe_config=moe_config)
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Only supported on NVIDIA platforms."
+)
+def test_select_cuda_lora_ignores_flashinfer_env(monkeypatch):
+    """CUDA LoRA path should still choose Triton even if FlashInfer env is on."""
+    with mock_cuda_platform():
+        monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP16", "1")
+        monkeypatch.setenv("VLLM_FLASHINFER_MOE_BACKEND", "throughput")
+
+        moe_config = make_dummy_moe_config()
+        moe_config.is_lora_enabled = True
+
+        selected_backend, experts_cls = select_unquantized_moe_backend(
+            moe_config=moe_config
+        )
+
+        assert selected_backend == UnquantizedMoeBackend.TRITON
+        assert experts_cls is not None

--- a/tests/kernels/moe/test_unquantized_backend_selection.py
+++ b/tests/kernels/moe/test_unquantized_backend_selection.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
@@ -11,6 +10,11 @@ from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
     select_unquantized_moe_backend,
 )
 from vllm.platforms import current_platform
+
+skipif_lora = pytest.mark.skipif(
+    not (current_platform.is_cuda() or current_platform.is_rocm()),
+    reason="Only supported on CUDA/ROCm platforms.",
+)
 
 
 @pytest.mark.parametrize(
@@ -91,10 +95,7 @@ def test_select_default_backend_by_platform(
 @pytest.mark.skipif(
     not current_platform.is_rocm(), reason="ROCm-specific backend selection test"
 )
-@pytest.mark.parametrize("is_lora_enabled", [False, True])
-def test_select_rocm_aiter_backend(
-    mock_aiter_enabled, mock_has_flashinfer, is_lora_enabled
-):
+def test_select_rocm_aiter_backend(mock_aiter_enabled, mock_has_flashinfer):
     """Test ROCm backend selection when AITER is available."""
     with patch(
         "vllm.model_executor.layers.fused_moe.oracle.unquantized.current_platform"
@@ -107,7 +108,6 @@ def test_select_rocm_aiter_backend(
         mock_platform.is_out_of_tree.return_value = False
 
         moe_config = make_dummy_moe_config()
-        moe_config.is_lora_enabled = is_lora_enabled
         selected_backend, expert_cls = select_unquantized_moe_backend(
             moe_config=moe_config,
         )
@@ -197,96 +197,81 @@ def test_select_cuda_flashinfer_cutlass_backend(
         assert experts_cls is not None
 
 
-@contextmanager
-def mock_cuda_moe_config(is_lora_enabled: bool = False):
-    with (
-        patch.object(current_platform, "is_cuda", return_value=True),
-        patch.object(current_platform, "is_rocm", return_value=False),
-        patch.object(current_platform, "is_cpu", return_value=False),
-        patch.object(current_platform, "is_xpu", return_value=False),
-        patch.object(current_platform, "is_tpu", return_value=False),
-        patch.object(current_platform, "is_out_of_tree", return_value=False),
-    ):
-        moe_config = make_dummy_moe_config()
-        moe_config.is_lora_enabled = is_lora_enabled
-        yield moe_config
-
-
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="Only supported on NVIDIA platforms."
-)
+@skipif_lora
 def test_select_lora_backend_prefers_triton():
     """LoRA-enabled unquantized MoE should select Triton backend."""
-    with mock_cuda_moe_config(is_lora_enabled=True) as moe_config:
-        selected_backend, experts_cls = select_unquantized_moe_backend(
-            moe_config=moe_config
-        )
+    moe_config = make_dummy_moe_config()
+    moe_config.is_lora_enabled = True
+    selected_backend, experts_cls = select_unquantized_moe_backend(
+        moe_config=moe_config
+    )
 
-        assert selected_backend == UnquantizedMoeBackend.TRITON
-        assert experts_cls is not None
-
-
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="Only supported on NVIDIA platforms."
-)
-def test_select_lora_explicit_non_triton_backend_raises():
-    """LoRA should reject explicit non-Triton unquantized backends."""
-    with mock_cuda_moe_config(is_lora_enabled=True) as moe_config:
-        # Use string from mapping in function map_unquantized_backend()
-        moe_config.moe_backend = "flashinfer_cutlass"
-
-        with pytest.raises(ValueError, match="LoRA is only supported"):
-            select_unquantized_moe_backend(moe_config=moe_config)
+    assert selected_backend == UnquantizedMoeBackend.TRITON
+    assert experts_cls is not None
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="Only supported on NVIDIA platforms."
-)
+@skipif_lora
+def test_select_lora_explicit_non_triton_backend():
+    """LoRA should override explicit non-Triton backend to Triton."""
+    moe_config = make_dummy_moe_config()
+    moe_config.is_lora_enabled = True
+
+    # Use string from mapping in function map_unquantized_backend()
+    moe_config.moe_backend = "flashinfer_cutlass"
+
+    selected_backend, experts_cls = select_unquantized_moe_backend(
+        moe_config=moe_config
+    )
+
+    assert selected_backend == UnquantizedMoeBackend.TRITON
+    assert experts_cls is not None
+
+
+@skipif_lora
 @pytest.mark.parametrize("is_lora_enabled", [False, True])
 def test_select_explicit_triton_backend(is_lora_enabled):
     """Explicit triton backend selection should return Triton."""
-    with mock_cuda_moe_config(is_lora_enabled=is_lora_enabled) as moe_config:
-        moe_config.moe_backend = "triton"
+    moe_config = make_dummy_moe_config()
+    moe_config.is_lora_enabled = is_lora_enabled
+    moe_config.moe_backend = "triton"
 
-        selected_backend, experts_cls = select_unquantized_moe_backend(
-            moe_config=moe_config
-        )
+    selected_backend, experts_cls = select_unquantized_moe_backend(
+        moe_config=moe_config
+    )
 
-        assert selected_backend == UnquantizedMoeBackend.TRITON
-        assert experts_cls is not None
+    assert selected_backend == UnquantizedMoeBackend.TRITON
+    assert experts_cls is not None
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="Only supported on NVIDIA platforms."
-)
+@skipif_lora
 def test_select_explicit_triton_ignores_flashinfer_env(monkeypatch):
     """Explicit triton backend should override FlashInfer env selection."""
-    with mock_cuda_moe_config(is_lora_enabled=False) as moe_config:
-        monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP16", "1")
-        monkeypatch.setenv("VLLM_FLASHINFER_MOE_BACKEND", "throughput")
+    monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP16", "1")
+    monkeypatch.setenv("VLLM_FLASHINFER_MOE_BACKEND", "throughput")
 
-        moe_config.moe_backend = "triton"
+    moe_config = make_dummy_moe_config()
+    moe_config.is_lora_enabled = False
+    moe_config.moe_backend = "triton"
 
-        selected_backend, experts_cls = select_unquantized_moe_backend(
-            moe_config=moe_config
-        )
+    selected_backend, experts_cls = select_unquantized_moe_backend(
+        moe_config=moe_config
+    )
 
-        assert selected_backend == UnquantizedMoeBackend.TRITON
-        assert experts_cls is not None
+    assert selected_backend == UnquantizedMoeBackend.TRITON
+    assert experts_cls is not None
 
 
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="Only supported on NVIDIA platforms."
-)
-def test_select_cuda_lora_ignores_flashinfer_env(monkeypatch):
-    """CUDA LoRA path should still choose Triton even if FlashInfer env is on."""
-    with mock_cuda_moe_config(is_lora_enabled=True) as moe_config:
-        monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP16", "1")
-        monkeypatch.setenv("VLLM_FLASHINFER_MOE_BACKEND", "throughput")
+@skipif_lora
+def test_select_lora_ignores_flashinfer_env(monkeypatch):
+    """LoRA path should still choose Triton even if FlashInfer env is on."""
+    monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP16", "1")
+    monkeypatch.setenv("VLLM_FLASHINFER_MOE_BACKEND", "throughput")
 
-        selected_backend, experts_cls = select_unquantized_moe_backend(
-            moe_config=moe_config
-        )
+    moe_config = make_dummy_moe_config()
+    moe_config.is_lora_enabled = True
+    selected_backend, experts_cls = select_unquantized_moe_backend(
+        moe_config=moe_config
+    )
 
-        assert selected_backend == UnquantizedMoeBackend.TRITON
-        assert experts_cls is not None
+    assert selected_backend == UnquantizedMoeBackend.TRITON
+    assert experts_cls is not None

--- a/tests/kernels/moe/test_unquantized_backend_selection.py
+++ b/tests/kernels/moe/test_unquantized_backend_selection.py
@@ -190,3 +190,68 @@ def test_select_cuda_flashinfer_cutlass_backend(
 
         assert selected_backend == UnquantizedMoeBackend.FLASHINFER_CUTLASS
         assert experts_cls is not None
+
+
+def test_select_lora_backend_prefers_triton():
+    """LoRA-enabled unquantized MoE should select Triton backend."""
+    with (
+        patch.object(current_platform, "is_cuda", return_value=True),
+        patch.object(current_platform, "is_rocm", return_value=False),
+        patch.object(current_platform, "is_cpu", return_value=False),
+        patch.object(current_platform, "is_xpu", return_value=False),
+        patch.object(current_platform, "is_tpu", return_value=False),
+        patch.object(current_platform, "is_out_of_tree", return_value=False),
+    ):
+        moe_config = make_dummy_moe_config()
+        moe_config.is_lora_enabled = True
+
+        selected_backend, experts_cls = select_unquantized_moe_backend(
+            moe_config=moe_config
+        )
+
+        assert selected_backend == UnquantizedMoeBackend.TRITON
+        assert experts_cls is not None
+
+
+def test_select_lora_backend_prefers_batched_triton():
+    """LoRA-enabled batched activation format should use Batched Triton."""
+    with (
+        patch.object(current_platform, "is_cuda", return_value=True),
+        patch.object(current_platform, "is_rocm", return_value=False),
+        patch.object(current_platform, "is_cpu", return_value=False),
+        patch.object(current_platform, "is_xpu", return_value=False),
+        patch.object(current_platform, "is_tpu", return_value=False),
+        patch.object(current_platform, "is_out_of_tree", return_value=False),
+    ):
+        moe_config = make_dummy_moe_config()
+        moe_config.is_lora_enabled = True
+        # Batched activation format is computed from DP+EP with deepep_low_latency.
+        moe_config.moe_parallel_config.dp_size = 2
+        moe_config.moe_parallel_config.use_ep = True
+        moe_config.moe_parallel_config.all2all_backend = "deepep_low_latency"
+
+        selected_backend, experts_cls = select_unquantized_moe_backend(
+            moe_config=moe_config
+        )
+
+        assert selected_backend == UnquantizedMoeBackend.BATCHED_TRITON
+        assert experts_cls is not None
+
+
+def test_select_lora_explicit_non_triton_backend_raises():
+    """LoRA should reject explicit non-Triton unquantized backends."""
+    with (
+        patch.object(current_platform, "is_cuda", return_value=True),
+        patch.object(current_platform, "is_rocm", return_value=False),
+        patch.object(current_platform, "is_cpu", return_value=False),
+        patch.object(current_platform, "is_xpu", return_value=False),
+        patch.object(current_platform, "is_tpu", return_value=False),
+        patch.object(current_platform, "is_out_of_tree", return_value=False),
+    ):
+        moe_config = make_dummy_moe_config()
+        moe_config.is_lora_enabled = True
+        # Use string from mapping in function map_unquantized_backend()
+        moe_config.moe_backend = "flashinfer_cutlass"
+
+        with pytest.raises(ValueError, match="LoRA is only supported"):
+            select_unquantized_moe_backend(moe_config=moe_config)

--- a/tests/kernels/moe/test_unquantized_backend_selection.py
+++ b/tests/kernels/moe/test_unquantized_backend_selection.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from contextlib import contextmanager
 from unittest.mock import patch
 
 import pytest
@@ -192,8 +193,8 @@ def test_select_cuda_flashinfer_cutlass_backend(
         assert experts_cls is not None
 
 
-def test_select_lora_backend_prefers_triton():
-    """LoRA-enabled unquantized MoE should select Triton backend."""
+@contextmanager
+def mock_cuda_platform():
     with (
         patch.object(current_platform, "is_cuda", return_value=True),
         patch.object(current_platform, "is_rocm", return_value=False),
@@ -202,6 +203,15 @@ def test_select_lora_backend_prefers_triton():
         patch.object(current_platform, "is_tpu", return_value=False),
         patch.object(current_platform, "is_out_of_tree", return_value=False),
     ):
+        yield
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Only supported on NVIDIA platforms."
+)
+def test_select_lora_backend_prefers_triton():
+    """LoRA-enabled unquantized MoE should select Triton backend."""
+    with mock_cuda_platform():
         moe_config = make_dummy_moe_config()
         moe_config.is_lora_enabled = True
 
@@ -213,18 +223,15 @@ def test_select_lora_backend_prefers_triton():
         assert experts_cls is not None
 
 
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Only supported on NVIDIA platforms."
+)
 def test_select_lora_backend_prefers_batched_triton():
-    """LoRA-enabled batched activation format should use Batched Triton."""
-    with (
-        patch.object(current_platform, "is_cuda", return_value=True),
-        patch.object(current_platform, "is_rocm", return_value=False),
-        patch.object(current_platform, "is_cpu", return_value=False),
-        patch.object(current_platform, "is_xpu", return_value=False),
-        patch.object(current_platform, "is_tpu", return_value=False),
-        patch.object(current_platform, "is_out_of_tree", return_value=False),
-    ):
+    """LoRA-enabled batched activation format should select batched Triton."""
+    with mock_cuda_platform():
         moe_config = make_dummy_moe_config()
         moe_config.is_lora_enabled = True
+
         # Batched activation format is computed from DP+EP with deepep_low_latency.
         moe_config.moe_parallel_config.dp_size = 2
         moe_config.moe_parallel_config.use_ep = True
@@ -238,18 +245,15 @@ def test_select_lora_backend_prefers_batched_triton():
         assert experts_cls is not None
 
 
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Only supported on NVIDIA platforms."
+)
 def test_select_lora_explicit_non_triton_backend_raises():
     """LoRA should reject explicit non-Triton unquantized backends."""
-    with (
-        patch.object(current_platform, "is_cuda", return_value=True),
-        patch.object(current_platform, "is_rocm", return_value=False),
-        patch.object(current_platform, "is_cpu", return_value=False),
-        patch.object(current_platform, "is_xpu", return_value=False),
-        patch.object(current_platform, "is_tpu", return_value=False),
-        patch.object(current_platform, "is_out_of_tree", return_value=False),
-    ):
+    with mock_cuda_platform():
         moe_config = make_dummy_moe_config()
         moe_config.is_lora_enabled = True
+
         # Use string from mapping in function map_unquantized_backend()
         moe_config.moe_backend = "flashinfer_cutlass"
 

--- a/tests/kernels/moe/test_unquantized_backend_selection.py
+++ b/tests/kernels/moe/test_unquantized_backend_selection.py
@@ -246,6 +246,45 @@ def test_select_lora_explicit_non_triton_backend_raises():
 @pytest.mark.skipif(
     not current_platform.is_cuda(), reason="Only supported on NVIDIA platforms."
 )
+@pytest.mark.parametrize("is_lora_enabled", [False, True])
+def test_select_explicit_triton_backend(is_lora_enabled):
+    """Explicit triton backend selection should return Triton."""
+    with mock_cuda_platform():
+        moe_config = make_dummy_moe_config()
+        moe_config.is_lora_enabled = is_lora_enabled
+        moe_config.moe_backend = "triton"
+
+        selected_backend, experts_cls = select_unquantized_moe_backend(
+            moe_config=moe_config
+        )
+
+        assert selected_backend == UnquantizedMoeBackend.TRITON
+        assert experts_cls is not None
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Only supported on NVIDIA platforms."
+)
+def test_select_explicit_triton_ignores_flashinfer_env(monkeypatch):
+    """Explicit triton backend should override FlashInfer env selection."""
+    with mock_cuda_platform():
+        monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP16", "1")
+        monkeypatch.setenv("VLLM_FLASHINFER_MOE_BACKEND", "throughput")
+
+        moe_config = make_dummy_moe_config()
+        moe_config.moe_backend = "triton"
+
+        selected_backend, experts_cls = select_unquantized_moe_backend(
+            moe_config=moe_config
+        )
+
+        assert selected_backend == UnquantizedMoeBackend.TRITON
+        assert experts_cls is not None
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="Only supported on NVIDIA platforms."
+)
 def test_select_cuda_lora_ignores_flashinfer_env(monkeypatch):
     """CUDA LoRA path should still choose Triton even if FlashInfer env is on."""
     with mock_cuda_platform():

--- a/tests/kernels/moe/test_unquantized_backend_selection.py
+++ b/tests/kernels/moe/test_unquantized_backend_selection.py
@@ -226,28 +226,6 @@ def test_select_lora_backend_prefers_triton():
 @pytest.mark.skipif(
     not current_platform.is_cuda(), reason="Only supported on NVIDIA platforms."
 )
-def test_select_lora_backend_prefers_batched_triton():
-    """LoRA-enabled batched activation format should select batched Triton."""
-    with mock_cuda_platform():
-        moe_config = make_dummy_moe_config()
-        moe_config.is_lora_enabled = True
-
-        # Batched activation format is computed from DP+EP with deepep_low_latency.
-        moe_config.moe_parallel_config.dp_size = 2
-        moe_config.moe_parallel_config.use_ep = True
-        moe_config.moe_parallel_config.all2all_backend = "deepep_low_latency"
-
-        selected_backend, experts_cls = select_unquantized_moe_backend(
-            moe_config=moe_config
-        )
-
-        assert selected_backend == UnquantizedMoeBackend.BATCHED_TRITON
-        assert experts_cls is not None
-
-
-@pytest.mark.skipif(
-    not current_platform.is_cuda(), reason="Only supported on NVIDIA platforms."
-)
 def test_select_lora_explicit_non_triton_backend_raises():
     """LoRA should reject explicit non-Triton unquantized backends."""
     with mock_cuda_platform():

--- a/tests/kernels/moe/test_unquantized_backend_selection.py
+++ b/tests/kernels/moe/test_unquantized_backend_selection.py
@@ -11,7 +11,7 @@ from vllm.model_executor.layers.fused_moe.oracle.unquantized import (
 )
 from vllm.platforms import current_platform
 
-skipif_lora = pytest.mark.skipif(
+skipif_not_cuda_rocm = pytest.mark.skipif(
     not (current_platform.is_cuda() or current_platform.is_rocm()),
     reason="Only supported on CUDA/ROCm platforms.",
 )
@@ -197,7 +197,7 @@ def test_select_cuda_flashinfer_cutlass_backend(
         assert experts_cls is not None
 
 
-@skipif_lora
+@skipif_not_cuda_rocm
 def test_select_lora_backend_prefers_triton():
     """LoRA-enabled unquantized MoE should select Triton backend."""
     moe_config = make_dummy_moe_config()
@@ -210,7 +210,7 @@ def test_select_lora_backend_prefers_triton():
     assert experts_cls is not None
 
 
-@skipif_lora
+@skipif_not_cuda_rocm
 def test_select_lora_explicit_non_triton_backend():
     """LoRA should override explicit non-Triton backend to Triton."""
     moe_config = make_dummy_moe_config()
@@ -227,7 +227,7 @@ def test_select_lora_explicit_non_triton_backend():
     assert experts_cls is not None
 
 
-@skipif_lora
+@skipif_not_cuda_rocm
 @pytest.mark.parametrize("is_lora_enabled", [False, True])
 def test_select_explicit_triton_backend(is_lora_enabled):
     """Explicit triton backend selection should return Triton."""
@@ -243,7 +243,7 @@ def test_select_explicit_triton_backend(is_lora_enabled):
     assert experts_cls is not None
 
 
-@skipif_lora
+@skipif_not_cuda_rocm
 def test_select_explicit_triton_ignores_flashinfer_env(monkeypatch):
     """Explicit triton backend should override FlashInfer env selection."""
     monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP16", "1")
@@ -261,7 +261,7 @@ def test_select_explicit_triton_ignores_flashinfer_env(monkeypatch):
     assert experts_cls is not None
 
 
-@skipif_lora
+@skipif_not_cuda_rocm
 def test_select_lora_ignores_flashinfer_env(monkeypatch):
     """LoRA path should still choose Triton even if FlashInfer env is on."""
     monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP16", "1")

--- a/tests/kernels/moe/test_unquantized_backend_selection.py
+++ b/tests/kernels/moe/test_unquantized_backend_selection.py
@@ -198,7 +198,7 @@ def test_select_cuda_flashinfer_cutlass_backend(
 
 
 @contextmanager
-def mock_cuda_platform():
+def mock_cuda_moe_config(is_lora_enabled: bool = False):
     with (
         patch.object(current_platform, "is_cuda", return_value=True),
         patch.object(current_platform, "is_rocm", return_value=False),
@@ -207,7 +207,9 @@ def mock_cuda_platform():
         patch.object(current_platform, "is_tpu", return_value=False),
         patch.object(current_platform, "is_out_of_tree", return_value=False),
     ):
-        yield
+        moe_config = make_dummy_moe_config()
+        moe_config.is_lora_enabled = is_lora_enabled
+        yield moe_config
 
 
 @pytest.mark.skipif(
@@ -215,10 +217,7 @@ def mock_cuda_platform():
 )
 def test_select_lora_backend_prefers_triton():
     """LoRA-enabled unquantized MoE should select Triton backend."""
-    with mock_cuda_platform():
-        moe_config = make_dummy_moe_config()
-        moe_config.is_lora_enabled = True
-
+    with mock_cuda_moe_config(is_lora_enabled=True) as moe_config:
         selected_backend, experts_cls = select_unquantized_moe_backend(
             moe_config=moe_config
         )
@@ -232,10 +231,7 @@ def test_select_lora_backend_prefers_triton():
 )
 def test_select_lora_explicit_non_triton_backend_raises():
     """LoRA should reject explicit non-Triton unquantized backends."""
-    with mock_cuda_platform():
-        moe_config = make_dummy_moe_config()
-        moe_config.is_lora_enabled = True
-
+    with mock_cuda_moe_config(is_lora_enabled=True) as moe_config:
         # Use string from mapping in function map_unquantized_backend()
         moe_config.moe_backend = "flashinfer_cutlass"
 
@@ -249,9 +245,7 @@ def test_select_lora_explicit_non_triton_backend_raises():
 @pytest.mark.parametrize("is_lora_enabled", [False, True])
 def test_select_explicit_triton_backend(is_lora_enabled):
     """Explicit triton backend selection should return Triton."""
-    with mock_cuda_platform():
-        moe_config = make_dummy_moe_config()
-        moe_config.is_lora_enabled = is_lora_enabled
+    with mock_cuda_moe_config(is_lora_enabled=is_lora_enabled) as moe_config:
         moe_config.moe_backend = "triton"
 
         selected_backend, experts_cls = select_unquantized_moe_backend(
@@ -267,11 +261,10 @@ def test_select_explicit_triton_backend(is_lora_enabled):
 )
 def test_select_explicit_triton_ignores_flashinfer_env(monkeypatch):
     """Explicit triton backend should override FlashInfer env selection."""
-    with mock_cuda_platform():
+    with mock_cuda_moe_config(is_lora_enabled=False) as moe_config:
         monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP16", "1")
         monkeypatch.setenv("VLLM_FLASHINFER_MOE_BACKEND", "throughput")
 
-        moe_config = make_dummy_moe_config()
         moe_config.moe_backend = "triton"
 
         selected_backend, experts_cls = select_unquantized_moe_backend(
@@ -287,12 +280,9 @@ def test_select_explicit_triton_ignores_flashinfer_env(monkeypatch):
 )
 def test_select_cuda_lora_ignores_flashinfer_env(monkeypatch):
     """CUDA LoRA path should still choose Triton even if FlashInfer env is on."""
-    with mock_cuda_platform():
+    with mock_cuda_moe_config(is_lora_enabled=True) as moe_config:
         monkeypatch.setenv("VLLM_USE_FLASHINFER_MOE_FP16", "1")
         monkeypatch.setenv("VLLM_FLASHINFER_MOE_BACKEND", "throughput")
-
-        moe_config = make_dummy_moe_config()
-        moe_config.is_lora_enabled = True
 
         selected_backend, experts_cls = select_unquantized_moe_backend(
             moe_config=moe_config

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -163,11 +163,7 @@ def select_unquantized_moe_backend(
     if current_platform.is_out_of_tree():
         return UnquantizedMoeBackend.OOT, None
 
-    # Both CUDA and ROCm require Triton for LoRA support
-    # Triton not relevant for current_platform.is_xpu()
-    triton_lora_supported = current_platform.is_cuda() or current_platform.is_rocm()
-
-    if moe_config.is_lora_enabled and triton_lora_supported:
+    if moe_config.is_lora_enabled:
         return UnquantizedMoeBackend.TRITON, backend_to_kernel_cls(
             UnquantizedMoeBackend.TRITON
         )

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -166,6 +166,15 @@ def select_unquantized_moe_backend(
     # NOTE: the kernels are selected in the following order.
     AVAILABLE_BACKENDS = _get_priority_backends(moe_config)
 
+    if moe_config.is_lora_enabled:
+        # LoRA currently only supports Triton-based backends.
+        AVAILABLE_BACKENDS = [
+            backend
+            for backend in AVAILABLE_BACKENDS
+            if backend
+            in (UnquantizedMoeBackend.TRITON, UnquantizedMoeBackend.BATCHED_TRITON)
+        ]
+
     # NOTE(rob): We need to peak into the P/F selection to determine
     # if we are using the batched or standard expert format, which
     # if not ideal. Once we unify TP + DP/EP, we can select P/F first.
@@ -212,6 +221,13 @@ def select_unquantized_moe_backend(
     runner_backend = moe_config.moe_backend
     if runner_backend != "auto":
         requested_backend = map_unquantized_backend(runner_backend)
+        if moe_config.is_lora_enabled and requested_backend not in (
+            UnquantizedMoeBackend.TRITON,
+            UnquantizedMoeBackend.BATCHED_TRITON,
+        ):
+            raise ValueError(
+                "LoRA is only supported for Triton-based unquantized MoE backends."
+            )
         if (
             activation_format == mk.FusedMoEActivationFormat.BatchedExperts
             and requested_backend == UnquantizedMoeBackend.TRITON

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -171,8 +171,7 @@ def select_unquantized_moe_backend(
         AVAILABLE_BACKENDS = [
             backend
             for backend in AVAILABLE_BACKENDS
-            if backend
-            in (UnquantizedMoeBackend.TRITON, UnquantizedMoeBackend.BATCHED_TRITON)
+            if backend == UnquantizedMoeBackend.TRITON
         ]
 
     # NOTE(rob): We need to peak into the P/F selection to determine
@@ -221,12 +220,12 @@ def select_unquantized_moe_backend(
     runner_backend = moe_config.moe_backend
     if runner_backend != "auto":
         requested_backend = map_unquantized_backend(runner_backend)
-        if moe_config.is_lora_enabled and requested_backend not in (
-            UnquantizedMoeBackend.TRITON,
-            UnquantizedMoeBackend.BATCHED_TRITON,
+        if (
+            moe_config.is_lora_enabled
+            and requested_backend != UnquantizedMoeBackend.TRITON
         ):
             raise ValueError(
-                "LoRA is only supported for Triton-based unquantized MoE backends."
+                "LoRA is only supported for Triton unquantized MoE backend."
             )
         if (
             activation_format == mk.FusedMoEActivationFormat.BatchedExperts

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -163,17 +163,17 @@ def select_unquantized_moe_backend(
     if current_platform.is_out_of_tree():
         return UnquantizedMoeBackend.OOT, None
 
+    # Both CUDA and ROCm require Triton for LoRA support
+    # Triton not relevant for current_platform.is_xpu()
+    triton_lora_supported = current_platform.is_cuda() or current_platform.is_rocm()
+
+    if moe_config.is_lora_enabled and triton_lora_supported:
+        return UnquantizedMoeBackend.TRITON, backend_to_kernel_cls(
+            UnquantizedMoeBackend.TRITON
+        )
+
     # NOTE: the kernels are selected in the following order.
     AVAILABLE_BACKENDS = _get_priority_backends(moe_config)
-
-    is_cuda_lora = moe_config.is_lora_enabled and current_platform.is_cuda()
-    if is_cuda_lora:
-        # LoRA currently only supports Triton-based backends.
-        AVAILABLE_BACKENDS = [
-            backend
-            for backend in AVAILABLE_BACKENDS
-            if backend == UnquantizedMoeBackend.TRITON
-        ]
 
     # NOTE(rob): We need to peak into the P/F selection to determine
     # if we are using the batched or standard expert format, which
@@ -221,10 +221,6 @@ def select_unquantized_moe_backend(
     runner_backend = moe_config.moe_backend
     if runner_backend != "auto":
         requested_backend = map_unquantized_backend(runner_backend)
-        if is_cuda_lora and requested_backend != UnquantizedMoeBackend.TRITON:
-            raise ValueError(
-                "LoRA is only supported for Triton unquantized MoE backend."
-            )
         if (
             activation_format == mk.FusedMoEActivationFormat.BatchedExperts
             and requested_backend == UnquantizedMoeBackend.TRITON
@@ -234,7 +230,7 @@ def select_unquantized_moe_backend(
         return _return_or_raise(requested_backend, moe_config, activation_format)
 
     # Handle explicit FlashInfer FP16 configuration.
-    if envs.is_set("VLLM_USE_FLASHINFER_MOE_FP16") and not is_cuda_lora:
+    if envs.is_set("VLLM_USE_FLASHINFER_MOE_FP16"):
         if not envs.VLLM_USE_FLASHINFER_MOE_FP16:
             if UnquantizedMoeBackend.FLASHINFER_TRTLLM in AVAILABLE_BACKENDS:
                 AVAILABLE_BACKENDS.remove(UnquantizedMoeBackend.FLASHINFER_TRTLLM)

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -166,7 +166,8 @@ def select_unquantized_moe_backend(
     # NOTE: the kernels are selected in the following order.
     AVAILABLE_BACKENDS = _get_priority_backends(moe_config)
 
-    if moe_config.is_lora_enabled:
+    is_cuda_lora = moe_config.is_lora_enabled and current_platform.is_cuda()
+    if is_cuda_lora:
         # LoRA currently only supports Triton-based backends.
         AVAILABLE_BACKENDS = [
             backend
@@ -220,10 +221,7 @@ def select_unquantized_moe_backend(
     runner_backend = moe_config.moe_backend
     if runner_backend != "auto":
         requested_backend = map_unquantized_backend(runner_backend)
-        if (
-            moe_config.is_lora_enabled
-            and requested_backend != UnquantizedMoeBackend.TRITON
-        ):
+        if is_cuda_lora and requested_backend != UnquantizedMoeBackend.TRITON:
             raise ValueError(
                 "LoRA is only supported for Triton unquantized MoE backend."
             )
@@ -236,7 +234,7 @@ def select_unquantized_moe_backend(
         return _return_or_raise(requested_backend, moe_config, activation_format)
 
     # Handle explicit FlashInfer FP16 configuration.
-    if envs.is_set("VLLM_USE_FLASHINFER_MOE_FP16"):
+    if envs.is_set("VLLM_USE_FLASHINFER_MOE_FP16") and not is_cuda_lora:
         if not envs.VLLM_USE_FLASHINFER_MOE_FP16:
             if UnquantizedMoeBackend.FLASHINFER_TRTLLM in AVAILABLE_BACKENDS:
                 AVAILABLE_BACKENDS.remove(UnquantizedMoeBackend.FLASHINFER_TRTLLM)


### PR DESCRIPTION



## Purpose

When using LoRA adapters with Nemotron Nano BF16:
https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16

The following error was raised:

```
Using FlashInfer CUTLASS Unquantized MoE backend out of potential backends: ['FlashInfer TRTLLM', 'FlashInfer CUTLASS', 'TRITON', 'BATCHED_TRITON'].
...
File "/my_home/workspace/my_vllm/vllm/lora/layers/fused_moe.py", line 164, in _inject_lora_into_fused_moe
assert isinstance(m_fused_moe_fn.impl.fused_experts, TritonExperts)
```

In previous vLLM versions the default backend for unquantized MoE was `TritonExperts`. 
The new default  backend "FlashInfer CUTLASS" does not support LoRA (see class `FlashInferExperts`, function `moe_sum`).

This PR selects `TritonExperts` when LoRA is enabled.

This change aligns with `select_fp8_moe_backend`, `select_mxfp8_moe_backend`, `select_gpt_oss_mxfp4_moe_backend`.

## Test Plan

Add new test(s) in `pytest tests/kernels/moe/test_unquantized_backend_selection.py`

Check that LoRA works with Nemotron Nano BF16.

## Test Result

All tests in `test_unquantized_backend_selection.py` passed.

LoRA adapters now work with Nemotron Nano BF16 (TP1/2/4):

```
Using TRITON Unquantized MoE backend out of potential backends: ['TRITON', 'BATCHED_TRITON'].
```

When running **without** LoRA adapters, the expected default backend is selected:

```
Using FlashInfer CUTLASS Unquantized MoE backend out of potential backends: ['FlashInfer TRTLLM', 'FlashInfer CUTLASS', 'TRITON', 'BATCHED_TRITON'].
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

