### PR TITLE
[Doc] Fix broken "full example" links in structured_outputs.md

### DIFF
--- a/docs/features/structured_outputs.md
+++ b/docs/features/structured_outputs.md
@@ -165,7 +165,7 @@ As an example, we can use to define a specific format of simplified SQL queries:
     print(completion.choices[0].message.content)
     ```
 
-See also: [full example](../examples/online_serving/structured_outputs.md)
+See also: [full example](../../examples/online_serving/structured_outputs/structured_outputs.py)
 
 ## Reasoning Outputs
 
@@ -208,7 +208,7 @@ Note that you can use reasoning with any provided structured outputs feature. Th
     print("content: ", completion.choices[0].message.content)
     ```
 
-See also: [full example](../examples/online_serving/structured_outputs.md)
+See also: [full example](../../examples/online_serving/structured_outputs/structured_outputs.py)
 
 !!! note
     When using Qwen3 Coder models with reasoning enabled, structured outputs might become disabled if the reasoning content does not get parsed into the `reasoning` field separately (v0.11.2+).
@@ -339,4 +339,4 @@ shown below:
     print(outputs[0].outputs[0].text)
     ```
 
-See also: [full example](../examples/online_serving/structured_outputs.md)
+See also: [full example](../../examples/online_serving/structured_outputs/structured_outputs.py)


### PR DESCRIPTION
## Purpose
Fix broken "See also: full example" links in `docs/features/structured_outputs.md`.

The links previously pointed to a non-existent `.md` file and used incorrect relative paths.

Closes #39889

## Test Plan
- Verified that the updated relative paths correctly point to the existing example file:
  `examples/online_serving/structured_outputs/structured_outputs.py`
- Opened the file locally and confirmed the links resolve correctly.

## Test Result
- All updated links now correctly resolve to the intended example file.
- No broken references remain in the document.