### PR TITLE
[Feat]Make EPLB max expert redundancy configurable

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,7 @@ import vllm.config.vllm as vllm_config_module
 from vllm.compilation.backends import VllmBackend
 from vllm.config import (
     CompilationConfig,
+    EPLBConfig,
     KernelConfig,
     ModelConfig,
     ParallelConfig,
@@ -1266,6 +1267,11 @@ def test_renderer_num_workers_with_mm_cache():
     # Should pass: single worker + cache enabled (default)
     config = ModelConfig(mm_model, renderer_num_workers=1)
     assert config.renderer_num_workers == 1
+
+
+def test_eplb_config_rejects_redundancy_above_max():
+    with pytest.raises(ValidationError, match="num_redundant_experts"):
+        EPLBConfig(num_redundant_experts=2, max_expert_redundancy=1)
 
 
 def test_eagle_draft_model_config():

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -68,6 +68,9 @@ class EPLBConfig:
     num_redundant_experts: int = Field(default=0, ge=0)
     """Number of redundant experts to use for expert parallelism."""
 
+    max_expert_redundancy: int = Field(default=1023, ge=0)
+    """Maximum redundant expert capacity reserved by EPLB state."""
+
     log_balancedness: bool = False
     """
     Log the balancedness each step of expert parallelism.
@@ -100,6 +103,13 @@ class EPLBConfig:
             raise ValueError("Async EPLB is only supported with the default policy.")
         if self.log_balancedness and self.log_balancedness_interval <= 0:
             raise ValueError("log_balancedness_interval must be greater than 0.")
+        if self.num_redundant_experts > self.max_expert_redundancy:
+            raise ValueError(
+                "num_redundant_experts "
+                f"({self.num_redundant_experts}) must be <= "
+                "max_expert_redundancy "
+                f"({self.max_expert_redundancy})."
+            )
         return self
 
 

--- a/vllm/distributed/eplb/eplb_state.py
+++ b/vllm/distributed/eplb/eplb_state.py
@@ -113,7 +113,11 @@ class EplbModelState:
 
     This is a sparse matrix, where -1 indicates no mapping.
 
-    Shape: (num_moe_layers, num_logical_experts, num_redundant_experts + 1)
+    Shape: (num_moe_layers, num_logical_experts,
+        max_expert_redundancy + 1)
+
+    The last dimension is reserved capacity. Active replicas are tracked by
+    `logical_replica_count`.
 
     # Example
 
@@ -391,15 +395,15 @@ class EplbState:
             physical_to_logical_map_list,
             device=self.device,
         )
+        max_expert_redundancy = self.parallel_config.eplb_config.max_expert_redundancy
         # Assuming 8 GPUs per node, this supports up to
-        # (1023 + 1) / 8 = 128 nodes for now.
-        # TODO(rui): make this configurable
-        MAX_EXPERT_REDUNDANCY = 1023
-        assert model.num_redundant_experts <= MAX_EXPERT_REDUNDANCY, (
-            f"num_redundant_experts {model.num_redundant_experts} "
-            f"must be less than or equal to {MAX_EXPERT_REDUNDANCY}"
+        # (max_expert_redundancy + 1) / 8 nodes.
+        assert model.num_redundant_experts <= max_expert_redundancy, (
+            f"num_redundant_experts {model.num_redundant_experts} must be less "
+            "than or equal to eplb_config.max_expert_redundancy "
+            f"{max_expert_redundancy}"
         )
-        max_slots_per_logical_expert = MAX_EXPERT_REDUNDANCY + 1
+        max_slots_per_logical_expert = max_expert_redundancy + 1
         logical_to_physical_map = torch.full(
             (model.num_logical_experts, max_slots_per_logical_expert),
             -1,
@@ -734,7 +738,7 @@ class EplbState:
             )
 
         # Map the physical expert load to global logical experts
-        global_expert_load_windows = []
+        global_expert_load_windows = []  # 在一个window内，负载的情况
         for eplb_model_state in self.model_states.values():
             expert_load_window = eplb_model_state.expert_load_window[
                 :, :, : self.num_valid_physical_experts


### PR DESCRIPTION
Add max_expert_redundancy to EPLBConfig, validate it against num_redundant_experts, and use it when sizing EPLB state.
## Purpose

This PR makes the EPLB max redundancy cap configurable instead of hardcoding
`1023` in `EplbState.add_model()`.

Changes included:
- add `max_expert_redundancy` to `EPLBConfig`
- validate `num_redundant_experts <= max_expert_redundancy`
- use `eplb_config.max_expert_redundancy` when sizing EPLB state

This PR intentionally does not change Elastic EP behavior. It only wires the
existing EPLB capacity limit through config.

I checked for overlapping open PRs before preparing this change and did not
find one covering this exact config-only scope.

## Test Plan

- `./.venv/bin/python -m pytest tests/test_config.py -k eplb_config_rejects_redundancy_above_max -v`

## Test Result

- Passed locally:
  - `tests/test_config.py::test_eplb_config_rejects_redundancy_above_max`