### PR TITLE
[Bugfix] Fix GPTQ not picking up desc_asc from model config

### DIFF
--- a/vllm/model_executor/layers/quantization/gptq.py
+++ b/vllm/model_executor/layers/quantization/gptq.py
@@ -181,6 +181,7 @@ class GPTQConfig(QuantizationConfig):
                 "quant_method": "gptq",
                 "bits": self.weight_bits,
                 "group_size": self.group_size,
+                "desc_act": self.desc_act,
                 "sym": True,  # GPTQ typically uses symmetric quantization
                 "lm_head": False,
             }


### PR DESCRIPTION



## Fix error with GPTQ models where desc_asc is missing

Issue: 
```
File "/opt/conda/envs/py_3.12/lib/python3.12/site-packages/vllm/model_executor/models/qwen3_5.py", line 230, in get_layer
  return Qwen3_5DecoderLayer(
         ^^^^^^^^^^^^^^^^^^^^
File "/opt/conda/envs/py_3.12/lib/python3.12/site-packages/vllm/model_executor/models/qwen3_5.py", line 157, in __init__
  self.mlp = Qwen3NextSparseMoeBlock(
             ^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/conda/envs/py_3.12/lib/python3.12/site-packages/vllm/model_executor/models/qwen3_next.py", line 148, in __init__
  self.experts = SharedFusedMoE(
                 ^^^^^^^^^^^^^^^
File "/opt/conda/envs/py_3.12/lib/python3.12/site-packages/vllm/model_executor/layers/fused_moe/layer.py", line 518, in __init__
  self.quant_method: FusedMoEMethodBase = _get_quant_method()
                                          ^^^^^^^^^^^^^^^^^^^
File "/opt/conda/envs/py_3.12/lib/python3.12/site-packages/vllm/model_executor/layers/fused_moe/layer.py", line 510, in _get_quant_method
  quant_method = self.quant_config.get_quant_method(self, prefix)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/conda/envs/py_3.12/lib/python3.12/site-packages/vllm/model_executor/layers/quantization/gptq.py", line 198, in get_quant_method
  return MoeWNA16Config.from_config(config).get_quant_method(layer, prefix)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/conda/envs/py_3.12/lib/python3.12/site-packages/vllm/model_executor/layers/quantization/moe_wna16.py", line 210, in get_quant_method
  temp_config = GPTQConfig.from_config(self.full_config)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/conda/envs/py_3.12/lib/python3.12/site-packages/vllm/model_executor/layers/quantization/gptq.py", line 156, in from_config
  desc_act = cls.get_from_keys(config, ["desc_act"])
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
File "/opt/conda/envs/py_3.12/lib/python3.12/site-packages/vllm/model_executor/layers/quantization/base_config.py", line 129, in get_from_keys
  raise ValueError(
ValueError: Cannot find any of ['desc_act'] in the model's quantization config.
ValueError: Cannot find any of ['desc_act'] in the model's quantization config.
```
## Test Plan

vllm serve bitbtbtyler09/Qwen3.6-35B-A3B-GPTQ-8bit

## Test Result

Starts properly with this fix.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

