### PR TITLE
[Platform][XPU] Implement is_integrated_gpu() for unified-memory 
  accounting

### DIFF
--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -29,6 +29,22 @@ else:
 logger = init_logger(__name__)
 
 
+# Intel integrated-GPU PCI device IDs (UMA — share system memory with the host).
+# Used by is_integrated_gpu() so MemorySnapshot falls back to psutil for the
+# true free memory instead of torch.xpu.mem_get_info() (which underreports on
+# iGPU). See vllm PR #40295.
+_INTEL_IGPU_PCI_IDS: frozenset[int] = frozenset({
+    # Lunar Lake     (Xe2-LPG,  intel_gpu_lnl_m) — Arc 130V / 140V
+    0x64A0,
+    # Arrow Lake-H   (Xe-LPG+,  intel_gpu_arl_h) — Arc Pro 130T / 140T
+    0x7D51, 0x7DD1,
+    # Panther Lake   (Xe3-LPG,  intel_gpu_ptl_h / intel_gpu_ptl_u) — future
+    0xB080, 0xB081, 0xB082,
+    0xB090, 0xB091, 0xB092,
+    0xB0A0, 0xB0A1, 0xB0A2,
+})
+
+
 class XPUPlatform(Platform):
     _enum = PlatformEnum.XPU
     device_name: str = "xpu"
@@ -314,6 +330,27 @@ class XPUPlatform(Platform):
     def is_data_center_gpu(cls) -> bool:
         device_name = cls.get_device_name().lower()
         return device_name.count("data center gpu") > 0
+
+    @classmethod
+    def is_integrated_gpu(cls, device_id: int = 0) -> bool:
+        """Return True if the XPU at ``device_id`` is an integrated GPU
+        sharing system memory (UMA) with the host, False for discrete cards.
+
+        Detects via the PCI device ID exposed by
+        ``torch.xpu.get_device_properties(device_id).device_id``, matched
+        against ``_INTEL_IGPU_PCI_IDS``. Mirrors the AMD APU detection
+        pattern in ``vllm/platforms/rocm.py``.
+
+        Returning True causes ``vllm/utils/mem_utils.py::MemorySnapshot``
+        to fall back from ``torch.xpu.mem_get_info()`` (which on iGPU
+        underreports the unified pool) to ``psutil.virtual_memory()``.
+        See vllm PR #40295.
+        """
+        try:
+            pci_id = torch.xpu.get_device_properties(device_id).device_id
+        except (AssertionError, RuntimeError):
+            return False
+        return pci_id in _INTEL_IGPU_PCI_IDS
 
     @classmethod
     def get_device_communicator_cls(cls) -> str:


### PR DESCRIPTION
## Purpose

`XPUPlatform` does not implement `is_integrated_gpu()`, so it falls through to the
base `Platform` default (`False`) — and `vllm/utils/mem_utils.py::MemorySnapshot`
never switches to host-RAM accounting on Intel **integrated** GPUs.

On a UMA iGPU, `torch.xpu.mem_get_info()` underreports free memory (it ignores
reclaimable Linux page cache), so vLLM aborts at startup:

```
Free memory on device xpu:0 is less than desired GPU memory utilization
```

even with plenty of memory free.

This PR implements `XPUPlatform.is_integrated_gpu()` via the PCI device ID
(`torch.xpu.get_device_properties(device_id).device_id`) matched against a
curated set of Intel integrated-GPU IDs (Lunar Lake / Arrow Lake-H / Panther
Lake). `torch.xpu.get_device_properties()` exposes no `is_integrated` flag
(unlike CUDA), so explicit detection is required — mirroring the device-ID map
already maintained in `vllm/platforms/rocm.py` (`_ROCM_DEVICE_ID_NAME_MAP`).

Single file, additive: `vllm/platforms/xpu.py` (+37).

> Supersedes the original env-var version of this PR — `VLLM_XPU_UNIFIED_MEMORY`
> is removed in favour of auto-detection, per @jikunshang's review.

## Not a duplicate

- **#41370** ("[XPU] Fallback when torch.xpu mem_get_info is unsupported on
  integrated Intel GPU") handles the case where `mem_get_info()` *raises*. This
  PR is the complementary case — `mem_get_info()` *returns* a wrong,
  underreported value with no exception — and operates at a different layer (the
  `is_integrated_gpu()` platform method, not a `try/except` in `mem_utils.py`).
  #41370 has been inactive since April; happy to coordinate if it revives.
- No open PR implements `XPUPlatform.is_integrated_gpu()`.

## Test

Intel Arc 140V (Lunar Lake) iGPU, torch 2.11.0+xpu:

```
$ python -c "import torch; print(hex(torch.xpu.get_device_properties(0).device_id))"
0x64a0
$ python -c "from vllm.platforms import current_platform; print(current_platform.is_integrated_gpu())"
True
```

Without this patch vLLM aborts at startup on the free-memory check; with it,
`MemorySnapshot` uses `psutil.virtual_memory()`, the check passes, and vLLM
serves normally (verified end-to-end serving gpt-oss-20b and qwen3-coder-30B).

## AI assistance

Prepared with AI assistance (Claude). I have reviewed every line, verified the
behaviour on real Intel Arc 140V hardware, and take responsibility for the change.
