### PR TITLE
[ROCm][CI] Fix `trust_remote_code` AttributeError in EAGLE3 acceptance length test

### DIFF
--- a/tests/v1/spec_decode/test_acceptance_length.py
+++ b/tests/v1/spec_decode/test_acceptance_length.py
@@ -165,6 +165,7 @@ def get_mt_bench_prompts(
         no_stream=True,
         disable_shuffle=False,
         skip_chat_template=False,
+        trust_remote_code=False,
     )
     samples = get_samples(args, tokenizer)
     prompt_ids = [
@@ -210,8 +211,8 @@ def extract_acceptance_metrics(metrics, num_spec_tokens: int) -> dict:
 
 @large_gpu_mark(min_gb=40)
 @pytest.mark.skipif(
-    not current_platform.is_cuda(),
-    reason="This test is only supported on CUDA platform.",
+    not current_platform.is_cuda_alike(),
+    reason="This test is only supported on CUDA-alike platforms.",
 )
 @pytest.mark.parametrize(
     "model_config",


### PR DESCRIPTION
Fixes `test_eagle3_acceptance_length` in the `tests/v1/spec_decode` test group (V1 speculative decoding tests). The test's `get_mt_bench_prompts` helper built a `SimpleNamespace` to pass into `vllm.benchmarks.datasets.get_samples`, but omitted `trust_remote_code`. `get_samples` reads `args.trust_remote_code` when constructing the HuggingFace dataset, causing every parametrization of `test_eagle3_acceptance_length` to fail with:

```
AttributeError: 'types.SimpleNamespace' object has no attribute 'trust_remote_code'
```

This patch adds `trust_remote_code=False` to the namespace so the dataset can be constructed as intended.

### Testing

- [x] `pytest tests/v1/spec_decode/test_acceptance_length.py`

cc @kenroche 
