### PR TITLE
[Bugfix] Align chat completion tool_choice/tools validation with OpenAI spec

### DIFF
--- a/tests/tool_use/test_chat_completion_request_validations.py
+++ b/tests/tool_use/test_chat_completion_request_validations.py
@@ -26,22 +26,20 @@ def test_chat_completion_request_with_no_tools():
     )
     assert request.tool_choice == "none"
 
-    # tools key present but empty -- should be rejected
-    with pytest.raises(ValueError, match="must not be an empty array"):
-        ChatCompletionRequest.model_validate(
-            {
-                "messages": [{"role": "user", "content": "Hello"}],
-                "model": "facebook/opt-125m",
-                "tools": [],
-            }
-        )
+    # tools key present but empty -- accepted per OpenAI spec
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "model": "facebook/opt-125m",
+            "tools": [],
+        }
+    )
+    assert request.tool_choice == "none"
 
 
-@pytest.mark.parametrize("tool_choice", ["auto", "required"])
+@pytest.mark.parametrize("tool_choice", ["none", "auto", "required"])
 def test_chat_completion_request_with_tool_choice_but_no_tools(tool_choice):
-    with pytest.raises(
-        ValueError, match="When using `tool_choice`, `tools` must be set."
-    ):
+    with pytest.raises(ValueError, match="`tool_choice` is only allowed when"):
         ChatCompletionRequest.model_validate(
             {
                 "messages": [{"role": "user", "content": "Hello"}],
@@ -50,14 +48,56 @@ def test_chat_completion_request_with_tool_choice_but_no_tools(tool_choice):
             }
         )
 
-    with pytest.raises(
-        ValueError, match="When using `tool_choice`, `tools` must be set."
-    ):
+    with pytest.raises(ValueError, match="`tool_choice` is only allowed when"):
         ChatCompletionRequest.model_validate(
             {
                 "messages": [{"role": "user", "content": "Hello"}],
                 "model": "facebook/opt-125m",
                 "tool_choice": tool_choice,
                 "tools": None,
+            }
+        )
+
+
+@pytest.mark.parametrize("tool_choice", ["none", "auto", "required"])
+def test_chat_completion_request_with_empty_tools_and_string_tool_choice(
+    tool_choice,
+):
+    request = ChatCompletionRequest.model_validate(
+        {
+            "messages": [{"role": "user", "content": "Hello"}],
+            "model": "facebook/opt-125m",
+            "tools": [],
+            "tool_choice": tool_choice,
+        }
+    )
+    assert request.tool_choice == tool_choice
+
+
+def test_chat_completion_request_with_empty_tools_and_named_tool_choice():
+    with pytest.raises(ValueError, match="does not match any"):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "tools": [],
+                "tool_choice": {
+                    "type": "function",
+                    "function": {"name": "foo"},
+                },
+            }
+        )
+
+
+def test_chat_completion_request_named_tool_choice_without_tools():
+    with pytest.raises(ValueError, match="`tool_choice` is only allowed when"):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "tool_choice": {
+                    "type": "function",
+                    "function": {"name": "foo"},
+                },
             }
         )

--- a/tests/tool_use/test_chat_completion_request_validations.py
+++ b/tests/tool_use/test_chat_completion_request_validations.py
@@ -26,15 +26,15 @@ def test_chat_completion_request_with_no_tools():
     )
     assert request.tool_choice == "none"
 
-    # tools key present but empty -- accepted per OpenAI spec
-    request = ChatCompletionRequest.model_validate(
-        {
-            "messages": [{"role": "user", "content": "Hello"}],
-            "model": "facebook/opt-125m",
-            "tools": [],
-        }
-    )
-    assert request.tool_choice == "none"
+    # tools key present but empty -- should be rejected
+    with pytest.raises(ValueError, match="must not be an empty array"):
+        ChatCompletionRequest.model_validate(
+            {
+                "messages": [{"role": "user", "content": "Hello"}],
+                "model": "facebook/opt-125m",
+                "tools": [],
+            }
+        )
 
 
 @pytest.mark.parametrize("tool_choice", ["none", "auto", "required"])
@@ -55,36 +55,6 @@ def test_chat_completion_request_with_tool_choice_but_no_tools(tool_choice):
                 "model": "facebook/opt-125m",
                 "tool_choice": tool_choice,
                 "tools": None,
-            }
-        )
-
-
-@pytest.mark.parametrize("tool_choice", ["none", "auto", "required"])
-def test_chat_completion_request_with_empty_tools_and_string_tool_choice(
-    tool_choice,
-):
-    request = ChatCompletionRequest.model_validate(
-        {
-            "messages": [{"role": "user", "content": "Hello"}],
-            "model": "facebook/opt-125m",
-            "tools": [],
-            "tool_choice": tool_choice,
-        }
-    )
-    assert request.tool_choice == tool_choice
-
-
-def test_chat_completion_request_with_empty_tools_and_named_tool_choice():
-    with pytest.raises(ValueError, match="does not match any"):
-        ChatCompletionRequest.model_validate(
-            {
-                "messages": [{"role": "user", "content": "Hello"}],
-                "model": "facebook/opt-125m",
-                "tools": [],
-                "tool_choice": {
-                    "type": "function",
-                    "function": {"name": "foo"},
-                },
             }
         )
 

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -686,30 +686,22 @@ class ChatCompletionRequest(OpenAIBaseModel):
         if not isinstance(data, dict):
             return data
 
-        # Reject empty tools array, matching OpenAI API behavior
-        if data.get("tools") == []:
+        # If tool_choice is explicitly specified, tools must also be specified
+        if (
+            "tool_choice" in data
+            and data["tool_choice"] is not None
+            and ("tools" not in data or data["tools"] is None)
+        ):
             raise ValueError(
-                "`tools` must not be an empty array. "
-                "Either provide at least one tool or omit the field entirely."
+                "`tool_choice` is only allowed when 'tools' are specified."
             )
 
-        # if "tool_choice" is not specified but tools are provided,
-        # default to "auto" tool_choice
+        # Default tool_choice to "auto" when tools are provided (non-empty)
+        # but tool_choice is not specified
         if "tool_choice" not in data and data.get("tools"):
             data["tool_choice"] = "auto"
 
-        # if "tool_choice" is "none" -- no validation is needed for tools
-        if "tool_choice" in data and data["tool_choice"] == "none":
-            return data
-
-        # if "tool_choice" is specified -- validation
-        if "tool_choice" in data and data["tool_choice"] is not None:
-            # ensure that if "tool choice" is specified, tools are present
-            if "tools" not in data or data["tools"] is None:
-                raise ValueError("When using `tool_choice`, `tools` must be set.")
-
-            # make sure that tool choice is either a named tool
-            # OR that it's set to "auto" or "required"
+        if "tool_choice" in data and data["tool_choice"] not in (None, "none"):
             if data["tool_choice"] not in ["auto", "required"] and not isinstance(
                 data["tool_choice"], dict
             ):
@@ -719,8 +711,6 @@ class ChatCompletionRequest(OpenAIBaseModel):
                     "are supported."
                 )
 
-            # ensure that if "tool_choice" is specified as an object,
-            # it matches a valid tool
             correct_usage_message = (
                 'Correct usage: `{"type": "function",'
                 ' "function": {"name": "my_function"}}`'

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -693,7 +693,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             and ("tools" not in data or data["tools"] is None)
         ):
             raise ValueError(
-                "`tool_choice` is only allowed when 'tools' are specified."
+                "`tool_choice` is only allowed when `tools` are specified."
             )
 
         # Default tool_choice to "auto" when tools are provided (non-empty)

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -695,7 +695,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
 
         # if "tool_choice" is not specified but tools are provided,
         # default to "auto" tool_choice
-        if "tool_choice" not in data and data.get("tools"):
+        if ("tool_choice" not in data or data["tool_choice"] is None) and data.get(
+            "tools"
+        ):
             data["tool_choice"] = "auto"
 
         # if "tool_choice" is specified -- validation

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -686,27 +686,31 @@ class ChatCompletionRequest(OpenAIBaseModel):
         if not isinstance(data, dict):
             return data
 
-        # If tool_choice is explicitly specified, tools must also be specified
-        if (
-            "tool_choice" in data
-            and data["tool_choice"] is not None
-            and ("tools" not in data or data["tools"] is None)
-        ):
+        tools = data.get("tools")
+        tool_choice = data.get("tool_choice")
+        has_tools = tools is not None
+        has_tool_choice = tool_choice is not None
+
+        if tools is not None and len(tools) == 0:
             raise ValueError(
-                "`tool_choice` is only allowed when `tools` are specified."
+                "`tools` must not be an empty array. "
+                "Either provide at least one tool or omit the field entirely."
             )
 
-        # Default tool_choice to "auto" when tools are provided (non-empty)
-        # but tool_choice is not specified
-        if "tool_choice" not in data and data.get("tools"):
+        if has_tool_choice and not has_tools:
+            raise ValueError(
+                "'tool_choice' is only allowed when 'tools' are specified."
+            )
+
+        if not has_tool_choice and tools:
             data["tool_choice"] = "auto"
 
-        if "tool_choice" in data and data["tool_choice"] not in (None, "none"):
-            if data["tool_choice"] not in ["auto", "required"] and not isinstance(
-                data["tool_choice"], dict
+        if has_tool_choice and tool_choice != "none":
+            if tool_choice not in ("auto", "required") and not isinstance(
+                tool_choice, dict
             ):
                 raise ValueError(
-                    f"Invalid value for `tool_choice`: {data['tool_choice']}! "
+                    f"Invalid value for `tool_choice`: {tool_choice}! "
                     'Only named tools, "none", "auto" or "required" '
                     "are supported."
                 )

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -686,35 +686,41 @@ class ChatCompletionRequest(OpenAIBaseModel):
         if not isinstance(data, dict):
             return data
 
-        tools = data.get("tools")
-        tool_choice = data.get("tool_choice")
-        has_tools = tools is not None
-        has_tool_choice = tool_choice is not None
-
-        if tools is not None and len(tools) == 0:
+        # Reject empty tools array, matching OpenAI API behavior
+        if data.get("tools") == []:
             raise ValueError(
                 "`tools` must not be an empty array. "
                 "Either provide at least one tool or omit the field entirely."
             )
 
-        if has_tool_choice and not has_tools:
-            raise ValueError(
-                "'tool_choice' is only allowed when 'tools' are specified."
-            )
-
-        if not has_tool_choice and tools:
+        # if "tool_choice" is not specified but tools are provided,
+        # default to "auto" tool_choice
+        if "tool_choice" not in data and data.get("tools"):
             data["tool_choice"] = "auto"
 
-        if has_tool_choice and tool_choice != "none":
-            if tool_choice not in ("auto", "required") and not isinstance(
-                tool_choice, dict
-            ):
+        # if "tool_choice" is specified -- validation
+        if "tool_choice" in data and data["tool_choice"] is not None:
+            # ensure that if "tool choice" is specified, tools are present
+            if "tools" not in data or data["tools"] is None:
                 raise ValueError(
-                    f"Invalid value for `tool_choice`: {tool_choice}! "
+                    "`tool_choice` is only allowed when 'tools' are specified."
+                )
+
+            # make sure that tool choice is either a named tool
+            # OR that it's set to "auto" or "required"
+            if data["tool_choice"] not in [
+                "none",
+                "auto",
+                "required",
+            ] and not isinstance(data["tool_choice"], dict):
+                raise ValueError(
+                    f"Invalid value for `tool_choice`: {data['tool_choice']}! "
                     'Only named tools, "none", "auto" or "required" '
                     "are supported."
                 )
 
+            # ensure that if "tool_choice" is specified as an object,
+            # it matches a valid tool
             correct_usage_message = (
                 'Correct usage: `{"type": "function",'
                 ' "function": {"name": "my_function"}}`'
@@ -744,8 +750,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
                         break
                 if not valid_tool:
                     raise ValueError(
-                        "The tool specified in `tool_choice` does not match any"
-                        " of the specified `tools`"
+                        "The tool specified in `tool_choice` does not match"
+                        " any of the specified `tools`"
                     )
         return data
 

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -578,13 +578,14 @@ class OpenAIServingRender:
         # factory can prevent special-token leakage.
         if tool_parser is not None:
             tool_choice = getattr(request, "tool_choice", "none")
+            tools = getattr(request, "tools", None)
             tokenizer = renderer.get_tokenizer()
             is_mistral_grammar_eligible = (
                 issubclass(tool_parser, MistralToolParser)
                 and is_mistral_tokenizer(tokenizer)
                 and tokenizer.supports_grammar
             )
-            if tool_choice != "none" or is_mistral_grammar_eligible:
+            if (tool_choice != "none" and tools) or is_mistral_grammar_eligible:
                 if not isinstance(request, ChatCompletionRequest | ResponsesRequest):
                     msg = (
                         "Tool usage is only supported "
@@ -592,8 +593,6 @@ class OpenAIServingRender:
                         f"but got {type(request).__name__}"
                     )
                     raise NotImplementedError(msg)
-                request = tool_parser(tokenizer, request.tools).adjust_request(
-                    request=request
-                )
+                request = tool_parser(tokenizer, tools).adjust_request(request=request)
 
         return conversation, [engine_input]

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -577,7 +577,7 @@ class OpenAIServingRender:
         # adjust_request — even for tool_choice="none" — so that the grammar
         # factory can prevent special-token leakage.
         if tool_parser is not None:
-            tool_choice = getattr(request, "tool_choice", "none")
+            tool_choice = getattr(request, "tool_choice", None)
             tools = getattr(request, "tools", None)
             tokenizer = renderer.get_tokenizer()
             is_mistral_grammar_eligible = (


### PR DESCRIPTION
## Purpose
Align the tool_choice/tools validation for chat completion api according to the OpenAI spec. 
I verified the expected behaviour by calling the real OpenAI api via [script](https://gist.github.com/sfeng33/b0fb0e1c5c23e4709e576ea47a362bc8).

| Case | Before (vLLM main) | After (this PR) |
|---|---|---|
| No tools, no `tool_choice` | OK — generates text | OK — generates text |
| No tools, `tool_choice="none"` | OK — generates text | ERROR — `tool_choice` not allowed without tools |
| No tools, `tool_choice="auto"` | ERROR — tools must be set | ERROR — `tool_choice` not allowed without tools |
| No tools, `tool_choice="required"` | ERROR — tools must be set | ERROR — `tool_choice` not allowed without tools |
| Empty `tools=[]`, no `tool_choice` | ERROR — tools must not be empty array | ERROR — tools must not be empty array |
| Empty `tools=[]`, `tool_choice="required"` | ERROR — tools must not be empty array | ERROR — tools must not be empty array |
| No tools, named `tool_choice` | ERROR — tools must be set | ERROR — `tool_choice` not allowed without tools |
| Tools present, no `tool_choice` | OK | OK — defaults to `"auto"` |
| Tools present, `tool_choice="none"` | OK — generates text, no tool calls | OK — generates text, no tool calls |
| Tools present, `tool_choice="auto"` | OK — model decides | OK — model decides |
| Tools present, `tool_choice="required"` | OK — model must call a tool | OK — model must call a tool |
| Named `tool_choice` (matches a tool) | OK — calls that specific tool | OK — calls that specific tool |

## Test Plan
```
pytest tests/tool_use/test_chat_completion_request_validations.py -v
```