### PR TITLE
fix: Do not make function calls when request has no tools for /v1/responses

### DIFF
--- a/vllm/entrypoints/openai/responses/utils.py
+++ b/vllm/entrypoints/openai/responses/utils.py
@@ -264,7 +264,7 @@ def convert_tool_responses_to_completions_format(tool: dict) -> dict:
 def construct_tool_dicts(
     tools: list[Tool], tool_choice: ToolChoice
 ) -> list[dict[str, Any]] | None:
-    if tools is None or (tool_choice == "none"):
+    if not tools or (tool_choice == "none"):
         tool_dicts = None
     else:
         tool_dicts = [


### PR DESCRIPTION
`/v1/responses` unconditionally defaults `tool_choice` to `"auto"`, and `construct_tool_dicts` only skipped tool setup for `None`, not for empty lists. So a no-tools request still told the model to make hallucinated function calls when `--enable-auto-tool-choice` was active.

This PR changed correctly disable tool-calling and aligns behavior with `/v1/chat/completions`, which only sets `tool_choice="auto"` when tools are actually provided.      