### PR TITLE
Fix Gemma 4 + BitsAndBytes startup failure reported in #38884

### DIFF
--- a/vllm/model_executor/model_loader/bitsandbytes_loader.py
+++ b/vllm/model_executor/model_loader/bitsandbytes_loader.py
@@ -810,6 +810,13 @@ class BitsAndBytesModelLoader(BaseModelLoader):
             **expert_quant_state_dict,
             **stacked_quant_state_dict,
         }
+        postprocess_quant_states = getattr(
+            model, "maybe_postprocess_bitsandbytes_quant_state_dict", None
+        )
+        if callable(postprocess_quant_states):
+            stacked_quant_state_dict = postprocess_quant_states(
+                stacked_quant_state_dict
+            )
         self._bind_quant_states_to_params(model, stacked_quant_state_dict)
         torch.accelerator.empty_cache()
 

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -18,6 +18,7 @@
 # limitations under the License.
 """Gemma 4 model implementation for vLLM."""
 
+import copy
 from collections.abc import Iterable
 from dataclasses import replace
 from itertools import islice
@@ -79,6 +80,42 @@ from .utils import (
 )
 
 logger = init_logger(__name__)
+
+
+def _duplicate_k_eq_v_bnb_quant_states(
+    config,
+    stacked_quant_state_dict: dict[str, dict[int, object]],
+    *,
+    prefix: str = "",
+) -> dict[str, dict[int, object]]:
+    """Mirror K quantization states onto V for Gemma4 k_eq_v layers.
+
+    Gemma4 full-attention layers can omit ``v_proj`` in the checkpoint and
+    instead reuse ``k_proj``. ``Gemma4ForCausalLM.load_weights()`` already
+    duplicates the packed K weights into V, but BitsAndBytes tracks quant
+    states separately and only sees the original checkpoint tensors. Without
+    duplicating the K quant state as well, BnB matmul reconstructs only Q+K
+    and drops the synthetic V shard.
+    """
+
+    if not getattr(config, "attention_k_eq_v", False):
+        return stacked_quant_state_dict
+
+    updated = dict(stacked_quant_state_dict)
+    for layer_idx, layer_type in enumerate(config.layer_types):
+        if layer_type != "full_attention":
+            continue
+
+        qkv_param_name = f"{prefix}model.layers.{layer_idx}.self_attn.qkv_proj.weight"
+        quant_states = updated.get(qkv_param_name)
+        if quant_states is None or 1 not in quant_states or 2 in quant_states:
+            continue
+
+        duplicated_quant_states = dict(quant_states)
+        duplicated_quant_states[2] = copy.deepcopy(quant_states[1])
+        updated[qkv_param_name] = duplicated_quant_states
+
+    return updated
 
 
 @triton.jit
@@ -1612,6 +1649,15 @@ class Gemma4ForCausalLM(
         hidden_states: torch.Tensor,
     ) -> torch.Tensor | None:
         return self.logits_processor(self.lm_head, hidden_states)
+
+    def maybe_postprocess_bitsandbytes_quant_state_dict(
+        self,
+        stacked_quant_state_dict: dict[str, dict[int, object]],
+    ) -> dict[str, dict[int, object]]:
+        return _duplicate_k_eq_v_bnb_quant_states(
+            self.config,
+            stacked_quant_state_dict,
+        )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         # Checkpoint weight names use "language_model." prefix (from the

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -39,7 +39,10 @@ from vllm.inputs import MultiModalDataDict
 from vllm.logger import init_logger
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import ReplicatedLinear
-from vllm.model_executor.models.gemma4 import Gemma4ForCausalLM
+from vllm.model_executor.models.gemma4 import (
+    Gemma4ForCausalLM,
+    _duplicate_k_eq_v_bnb_quant_states,
+)
 from vllm.model_executor.models.module_mapping import MultiModelKeys
 from vllm.multimodal import MULTIMODAL_REGISTRY
 from vllm.multimodal.inputs import (
@@ -1325,6 +1328,16 @@ class Gemma4ForConditionalGeneration(
         hidden_states: torch.Tensor,
     ) -> torch.Tensor | None:
         return self.language_model.compute_logits(hidden_states)
+
+    def maybe_postprocess_bitsandbytes_quant_state_dict(
+        self,
+        stacked_quant_state_dict: dict[str, dict[int, object]],
+    ) -> dict[str, dict[int, object]]:
+        return _duplicate_k_eq_v_bnb_quant_states(
+            self.config.text_config,
+            stacked_quant_state_dict,
+            prefix="language_model.",
+        )
 
     # ------------------------------------------------------------------ #
     # Weight loading


### PR DESCRIPTION
Signed-off-by: SouthWest7 <miaoxinan@qq.com>



## Purpose
This change fixes the Gemma 4 + BitsAndBytes startup failure reported in #38884.

The root cause is a mismatch between the effective QKV weights and the BitsAndBytes quantization state for Gemma4 `attention_k_eq_v` full-attention layers. For those layers, the checkpoint provides `k_proj` but no separate `v_proj`, and vLLM already mirrors the K weight into V during weight loading so that `QKVParallelLinear` still operates on a full `q + k + v` layout.

However, prior to this change, the corresponding BitsAndBytes quant state was not mirrored. As a result, BnB matmul reconstructed only the `Q + K` portion of the packed projection output, while the model forward path still expected `Q + K + V`. This led to the runtime failure during:

Resolves https://github.com/vllm-project/vllm/issues/38884

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

