### PR TITLE
[Fix] Add Spacing when Requesting Output Token > max_model_len

### DIFF
--- a/vllm/renderers/params.py
+++ b/vllm/renderers/params.py
@@ -204,7 +204,7 @@ class TokenizeParams:
             and max_output_tokens > max_total_tokens
         ):
             raise VLLMValidationError(
-                f"{self.max_output_tokens_param}={max_output_tokens}"
+                f"{self.max_output_tokens_param}={max_output_tokens} "
                 f"cannot be greater than "
                 f"{self.max_total_tokens_param}={max_total_tokens=}. "
                 f"Please request fewer output tokens.",


### PR DESCRIPTION



## Purpose
Purpose of the PR is to fix a minor spacing issue when requesting a output token > max_model_len.
## Test Plan
Run a curl request to the vllm server and request an amount of output token to generate > server's max_model_len.
Test command after vllm server starts up.
`curl 'http://localhost:8000/v1/completions'   -H 'Content-Type: application/json'   -d '{
    "model": "/models/granite-3.3-8b-instruct",
    "prompt": "write a sample python code for bubble sort",
    "max_tokens": 38000
  }'`
## Test Result
Before/Original:
`{"error":{"message":"max_tokens=38000cannot be greater than max_model_len=max_total_tokens=32768. Please request fewer output tokens. (parameter=max_tokens, value=38000)","type":"BadRequestError","param":"max_tokens","code":400}}`

Fix:
``{"error":{"message":"max_tokens=38000 cannot be greater than max_model_len=max_total_tokens=32768. Please request fewer output tokens. (parameter=max_tokens, value=38000)","type":"BadRequestError","param":"max_tokens","code":400}}``

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

