### PR TITLE
[ROCm] Allow Triton MXFP4 MoE support checks on gfx11xx

### DIFF
--- a/tests/kernels/moe/test_mxfp4_support.py
+++ b/tests/kernels/moe/test_mxfp4_support.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.model_executor.layers.fused_moe.experts.gpt_oss_triton_kernels_moe import (
+    BaseOAITritonExperts,
+    OAITritonMxfp4ExpertsMonolithic,
+)
+from vllm.model_executor.layers.fused_moe import utils as fused_moe_utils
+from vllm.platforms.interface import DeviceCapability
+
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+class FakePlatform:
+
+    def __init__(self, *, is_rocm: bool, capability: tuple[int, int]):
+        self._is_rocm = is_rocm
+        self._capability = capability
+
+    def is_cuda_alike(self) -> bool:
+        return True
+
+    def is_rocm(self) -> bool:
+        return self._is_rocm
+
+    def is_cuda(self) -> bool:
+        return not self._is_rocm
+
+    def get_device_capability(self):
+        return DeviceCapability(*self._capability)
+
+
+def test_supports_triton_mxfp4_device_respects_platform_specific_ceiling():
+    assert fused_moe_utils.supports_triton_mxfp4_device(
+        FakePlatform(is_rocm=False, capability=(10, 0))
+    )
+    assert not fused_moe_utils.supports_triton_mxfp4_device(
+        FakePlatform(is_rocm=False, capability=(11, 0))
+    )
+    assert fused_moe_utils.supports_triton_mxfp4_device(
+        FakePlatform(is_rocm=True, capability=(11, 5))
+    )
+    assert not fused_moe_utils.supports_triton_mxfp4_device(
+        FakePlatform(is_rocm=True, capability=(12, 0))
+    )
+
+
+def test_oai_triton_experts_allow_rocm_rdna35(monkeypatch):
+    monkeypatch.setattr(
+        fused_moe_utils,
+        "current_platform",
+        FakePlatform(is_rocm=True, capability=(11, 5)),
+    )
+
+    assert BaseOAITritonExperts._supports_current_device()
+    assert OAITritonMxfp4ExpertsMonolithic._supports_current_device()
+
+
+def test_oai_triton_experts_keep_cuda_sm110_disabled(monkeypatch):
+    monkeypatch.setattr(
+        fused_moe_utils,
+        "current_platform",
+        FakePlatform(is_rocm=False, capability=(11, 0)),
+    )
+
+    assert not BaseOAITritonExperts._supports_current_device()
+    assert not OAITritonMxfp4ExpertsMonolithic._supports_current_device()

--- a/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
@@ -19,7 +19,10 @@ from vllm.model_executor.layers.fused_moe.config import (
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
-from vllm.model_executor.layers.fused_moe.utils import _resize_cache
+from vllm.model_executor.layers.fused_moe.utils import (
+    _resize_cache,
+    supports_triton_mxfp4_device,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kMxfp4Static,
@@ -489,15 +492,7 @@ class BaseOAITritonExperts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def _supports_current_device() -> bool:
-        p = current_platform
-        if not p.is_cuda_alike():
-            return False
-        cap = p.get_device_capability()
-        if cap is None:
-            return False
-        # (9,0) <= cap < (11,0) covers CUDA SM90 (Hopper), SM100+ (Blackwell)
-        # and ROCm gfx942/gfx950 (which map to 9.4/9.5).
-        return (9, 0) <= (cap.major, cap.minor) < (11, 0)
+        return supports_triton_mxfp4_device()
 
     @staticmethod
     def _supports_no_act_and_mul() -> bool:
@@ -821,15 +816,7 @@ class OAITritonMxfp4ExpertsMonolithic(mk.FusedMoEExpertsMonolithic):
 
     @staticmethod
     def _supports_current_device() -> bool:
-        p = current_platform
-        if not p.is_cuda_alike():
-            return False
-        cap = p.get_device_capability()
-        if cap is None:
-            return False
-        # (9,0) <= cap < (11,0) covers CUDA SM90 (Hopper), SM100+ (Blackwell)
-        # and ROCm gfx942/gfx950 (which map to 9.4/9.5).
-        return (9, 0) <= (cap.major, cap.minor) < (11, 0)
+        return supports_triton_mxfp4_device()
 
     @staticmethod
     def _supports_no_act_and_mul() -> bool:

--- a/vllm/model_executor/layers/fused_moe/utils.py
+++ b/vllm/model_executor/layers/fused_moe/utils.py
@@ -26,9 +26,34 @@ from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
     per_tensor_dequantize,
 )
 from vllm.platforms import current_platform
+from vllm.platforms.interface import Platform
 from vllm.triton_utils import tl, triton
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+
+def supports_triton_mxfp4_device(platform: Platform | None = None) -> bool:
+    """Return whether Triton MXFP4 MoE kernels support the current device.
+
+    CUDA support remains capped below SM110 until those kernels are validated.
+    ROCm uses a different capability mapping, so allow gfx11xx (reported as
+    11.x) while still excluding gfx12xx and newer pending validation.
+    """
+    if platform is None:
+        platform = current_platform
+
+    if not platform.is_cuda_alike():
+        return False
+
+    cap = platform.get_device_capability()
+    if cap is None:
+        return False
+
+    cap_tuple = (cap.major, cap.minor)
+    if platform.is_rocm():
+        return (9, 0) <= cap_tuple < (12, 0)
+
+    return (9, 0) <= cap_tuple < (11, 0)
 
 
 @triton.jit


### PR DESCRIPTION
Add a shared helper for Triton MXFP4 device support checks and use it in the GPT-OSS Triton MXFP4 experts support paths.

This keeps the CUDA < 11.0 guard unchanged, while allowing ROCm gfx11xx devices (for example gfx1151 / RDNA3.5) to pass the support check.

Also add unit coverage for the platform-specific capability ceilings.

Tested with:
- .venv/bin/python -m pytest tests/kernels/moe/test_mxfp4_support.py -v

AI assistance was used to prepare this change, and I reviewed the final diff.

Co-authored-by: OpenAI Codex




## Purpose
This PR fixes the Triton MXFP4 MoE support check for ROCm gfx11xx devices such as gfx1151 / RDNA3.5.
Changes:
- add a shared helper for Triton MXFP4 device support checks
- keep the existing CUDA `< 11.0` guard unchanged
- allow ROCm gfx11xx devices through the Triton MXFP4 support path
- add unit coverage for the platform-specific capability ceilings

### Why this is not duplicate work

I checked issue #40301 and searched for open PRs referencing `#40301` and related terms before opening this PR. I did not find an open PR covering this specific ROCm gfx11xx support-check fix.

## Test Plan
Ran:
- `.venv/bin/python -m pytest tests/kernels/moe/test_mxfp4_support.py -v`

## Test Result
Result:
- `3 passed`

## AI assistance

This is an AI-assisted contribution. I reviewed the final diff and verified the test command above before submitting.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

