### PR TITLE
[MM][Misc] Support image+video mixed inputs (per prompt) for VLM examples

### DIFF
--- a/examples/offline_inference/vision_language.py
+++ b/examples/offline_inference/vision_language.py
@@ -403,15 +403,15 @@ def run_ernie45_vl(questions: list[str], modality: str) -> ModelRequestData:
         trust_remote_code=True,
     )
 
+    image_placeholder = "Picture 1:<|IMAGE_START|><|image@placeholder|><|IMAGE_END|>"
+    video_placeholder = "Video 1:<|VIDEO_START|><|video@placeholder|><|VIDEO_END|>"
+
     if modality == "image":
-        placeholder = "Picture 1:<|IMAGE_START|><|image@placeholder|><|IMAGE_END|>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "Video 1:<|VIDEO_START|><|video@placeholder|><|VIDEO_END|>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = (
-            "Picture 1:<|IMAGE_START|><|image@placeholder|><|IMAGE_END|>"
-            "Video 1:<|VIDEO_START|><|video@placeholder|><|VIDEO_END|>"
-        )
+        placeholder = image_placeholder + video_placeholder
 
     prompts = [
         (
@@ -444,12 +444,15 @@ def run_exaone4_5(questions: list[str], modality: str) -> ModelRequestData:
         limit_mm_per_prompt=mm_limit,
     )
 
+    image_placeholder = "<vision><|image_pad|></vision>"
+    video_placeholder = "<vision><|video_pad|></vision>"
+
     if modality == "image":
-        placeholder = "<vision><|image_pad|></vision>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "<vision><|video_pad|></vision>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = "<vision><|image_pad|></vision><vision><|video_pad|></vision>"
+        placeholder = image_placeholder + video_placeholder
 
     prompts = [
         (
@@ -588,15 +591,15 @@ def run_glm4_1v(questions: list[str], modality: str) -> ModelRequestData:
         enforce_eager=True,
     )
 
+    image_placeholder = "<|begin_of_image|><|image|><|end_of_image|>"
+    video_placeholder = "<|begin_of_video|><|video|><|end_of_video|>"
+
     if modality == "image":
-        placeholder = "<|begin_of_image|><|image|><|end_of_image|>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "<|begin_of_video|><|video|><|end_of_video|>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = (
-            "<|begin_of_image|><|image|><|end_of_image|>"
-            "<|begin_of_video|><|video|><|end_of_video|>"
-        )
+        placeholder = image_placeholder + video_placeholder
 
     prompts = [
         (
@@ -631,15 +634,15 @@ def run_glm4_5v(questions: list[str], modality: str) -> ModelRequestData:
         tensor_parallel_size=4,
     )
 
+    image_placeholder = "<|begin_of_image|><|image|><|end_of_image|>"
+    video_placeholder = "<|begin_of_video|><|video|><|end_of_video|>"
+
     if modality == "image":
-        placeholder = "<|begin_of_image|><|image|><|end_of_image|>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "<|begin_of_video|><|video|><|end_of_video|>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = (
-            "<|begin_of_image|><|image|><|end_of_image|>"
-            "<|begin_of_video|><|video|><|end_of_video|>"
-        )
+        placeholder = image_placeholder + video_placeholder
 
     prompts = [
         (
@@ -674,15 +677,15 @@ def run_glm4_5v_fp8(questions: list[str], modality: str) -> ModelRequestData:
         tensor_parallel_size=4,
     )
 
+    image_placeholder = "<|begin_of_image|><|image|><|end_of_image|>"
+    video_placeholder = "<|begin_of_video|><|video|><|end_of_video|>"
+
     if modality == "image":
-        placeholder = "<|begin_of_image|><|image|><|end_of_image|>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "<|begin_of_video|><|video|><|end_of_video|>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = (
-            "<|begin_of_image|><|image|><|end_of_image|>"
-            "<|begin_of_video|><|video|><|end_of_video|>"
-        )
+        placeholder = image_placeholder + video_placeholder
 
     prompts = [
         (
@@ -716,15 +719,15 @@ def run_glm_ocr(questions: list[str], modality: str) -> ModelRequestData:
         enforce_eager=True,
     )
 
+    image_placeholder = "<|begin_of_image|><|image|><|end_of_image|>"
+    video_placeholder = "<|begin_of_video|><|video|><|end_of_video|>"
+
     if modality == "image":
-        placeholder = "<|begin_of_image|><|image|><|end_of_image|>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "<|begin_of_video|><|video|><|end_of_video|>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = (
-            "<|begin_of_image|><|image|><|end_of_image|>"
-            "<|begin_of_video|><|video|><|end_of_video|>"
-        )
+        placeholder = image_placeholder + video_placeholder
 
     prompts = [
         (
@@ -943,12 +946,15 @@ def run_interns1(questions: list[str], modality: str) -> ModelRequestData:
         enforce_eager=True,
     )
 
+    image_placeholder = "<IMG_CONTEXT>"
+    video_placeholder = "<video>"
+
     if modality == "image":
-        placeholder = "<IMG_CONTEXT>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "<video>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = "<IMG_CONTEXT>\n<video>"
+        placeholder = image_placeholder + "\n" + video_placeholder
 
     tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
     messages = [
@@ -980,15 +986,15 @@ def run_interns1_pro(questions: list[str], modality: str) -> ModelRequestData:
         tensor_parallel_size=4,
     )
 
+    image_placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+    video_placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+
     if modality == "image":
-        placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = (
-            "<|vision_start|><|image_pad|><|vision_end|>"
-            "<|vision_start|><|video_pad|><|vision_end|>"
-        )
+        placeholder = image_placeholder + video_placeholder
 
     tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
     messages = [
@@ -1017,12 +1023,15 @@ def run_internvl(questions: list[str], modality: str) -> ModelRequestData:
         limit_mm_per_prompt=mm_limit,
     )
 
+    image_placeholder = "<image>"
+    video_placeholder = "<video>"
+
     if modality == "image":
-        placeholder = "<image>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "<video>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = "<image>\n<video>"
+        placeholder = image_placeholder + "\n" + video_placeholder
 
     tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
     messages = [
@@ -1087,15 +1096,15 @@ def run_keye_vl(questions: list[str], modality: str) -> ModelRequestData:
         limit_mm_per_prompt=mm_limit,
     )
 
+    image_placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+    video_placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+
     if modality == "image":
-        placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = (
-            "<|vision_start|><|image_pad|><|vision_end|>"
-            "<|vision_start|><|video_pad|><|vision_end|>"
-        )
+        placeholder = image_placeholder + video_placeholder
 
     prompts = [
         (
@@ -1124,15 +1133,15 @@ def run_keye_vl1_5(questions: list[str], modality: str) -> ModelRequestData:
         limit_mm_per_prompt=mm_limit,
     )
 
+    image_placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+    video_placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+
     if modality == "image":
-        placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = (
-            "<|vision_start|><|image_pad|><|vision_end|>"
-            "<|vision_start|><|video_pad|><|vision_end|>"
-        )
+        placeholder = image_placeholder + video_placeholder
 
     prompts = [
         (
@@ -1340,24 +1349,20 @@ def run_llava_next_video(questions: list[str], modality: str) -> ModelRequestDat
 
 # LLaVA-OneVision
 def run_llava_onevision(questions: list[str], modality: str) -> ModelRequestData:
-    if modality == "video":
-        prompts = [
-            f"<|im_start|>user <video>\n{question}<|im_end|><|im_start|>assistant\n"
-            for question in questions
-        ]
-    elif modality == "image":
-        prompts = [
-            f"<|im_start|>user <image>\n{question}<|im_end|><|im_start|>assistant\n"
-            for question in questions
-        ]
+    image_placeholder = "<image>"
+    video_placeholder = "<video>"
+
+    if modality == "image":
+        placeholder = image_placeholder
+    elif modality == "video":
+        placeholder = video_placeholder
     elif modality == "image+video":
-        prompts = [
-            (
-                f"<|im_start|>user <image>\n<video>\n{question}<|im_end|>"
-                f"<|im_start|>assistant\n"
-            )
-            for question in questions
-        ]
+        placeholder = image_placeholder + "\n" + video_placeholder
+
+    prompts = [
+        (f"<|im_start|>user {placeholder}\n{question}<|im_end|><|im_start|>assistant\n")
+        for question in questions
+    ]
 
     mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
@@ -1437,21 +1442,22 @@ def run_minicpmv_base(questions: list[str], modality: str, model_name):
     stop_tokens = ["<|im_end|>", "<|endoftext|>"]
     stop_token_ids = [tokenizer.convert_tokens_to_ids(i) for i in stop_tokens]
 
-    if modality == "image+video":
-        content_prefix = "(<image>./</image>)\n(<video>./</video>)"
-    else:
-        modality_placeholder = {
-            "image": "(<image>./</image>)",
-            "video": "(<video>./</video>)",
-        }
-        content_prefix = modality_placeholder[modality]
+    image_placeholder = "(<image>./</image>)"
+    video_placeholder = "(<video>./</video>)"
+
+    if modality == "image":
+        placeholder = image_placeholder
+    elif modality == "video":
+        placeholder = video_placeholder
+    elif modality == "image+video":
+        placeholder = image_placeholder + "\n" + video_placeholder
 
     prompts = [
         tokenizer.apply_chat_template(
             [
                 {
                     "role": "user",
-                    "content": f"{content_prefix}\n{question}",
+                    "content": f"{placeholder}\n{question}",
                 }
             ],
             tokenize=False,
@@ -1569,14 +1575,15 @@ def run_molmo2(questions: list[str], modality: str) -> ModelRequestData:
         max_num_batched_tokens=36864,
     )
 
+    image_placeholder = "<|image|>"
+    video_placeholder = "<|video|>"
+
     if modality == "image":
-        placeholder = "<|image|>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "<|video|>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = "<|image|><|video|>"
-    else:
-        raise ValueError(f"Unsupported modality for molmo2: {modality}")
+        placeholder = image_placeholder + video_placeholder
 
     prompts = [
         f"{placeholder}<|im_start|>user\n{question}<|im_end|>\n<|im_start|>assistant\n"
@@ -1670,12 +1677,15 @@ def run_openpangu_vl(questions: list[str], modality: str) -> ModelRequestData:
         limit_mm_per_prompt=mm_limit,
     )
 
+    image_placeholder = "[unused19]"
+    video_placeholder = "[unused32]"
+
     if modality == "image":
-        placeholder = "[unused19]"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "[unused32]"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = "[unused19][unused32]"
+        placeholder = image_placeholder + video_placeholder
 
     prompts = [
         (
@@ -1732,12 +1742,16 @@ def run_ovis2_5(questions: list[str], modality: str) -> ModelRequestData:
         dtype="half",
         limit_mm_per_prompt=mm_limit,
     )
+
+    image_placeholder = "<image>"
+    video_placeholder = "<video>"
+
     if modality == "image":
-        placeholder = "<image>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "<video>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = "<image>\n<video>"
+        placeholder = image_placeholder + "\n" + video_placeholder
 
     prompts = [
         f"<|im_start|>user\n\n{placeholder}\n{question}<|im_end|>\n<|im_start|>assistant\n"
@@ -1962,15 +1976,15 @@ def run_qwen2_vl(questions: list[str], modality: str) -> ModelRequestData:
         limit_mm_per_prompt=mm_limit,
     )
 
+    image_placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+    video_placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+
     if modality == "image":
-        placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = (
-            "<|vision_start|><|image_pad|><|vision_end|>"
-            "<|vision_start|><|video_pad|><|vision_end|>"
-        )
+        placeholder = image_placeholder + video_placeholder
 
     prompts = [
         (
@@ -2005,15 +2019,15 @@ def run_qwen2_5_vl(questions: list[str], modality: str) -> ModelRequestData:
         limit_mm_per_prompt=mm_limit,
     )
 
+    image_placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+    video_placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+
     if modality == "image":
-        placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = (
-            "<|vision_start|><|image_pad|><|vision_end|>"
-            "<|vision_start|><|video_pad|><|vision_end|>"
-        )
+        placeholder = image_placeholder + video_placeholder
 
     prompts = [
         (
@@ -2048,14 +2062,15 @@ def run_qwen2_5_omni(questions: list[str], modality: str):
         limit_mm_per_prompt=mm_limit,
     )
 
+    image_placeholder = "<|vision_bos|><|IMAGE|><|vision_eos|>"
+    video_placeholder = "<|vision_bos|><|VIDEO|><|vision_eos|>"
+
     if modality == "image":
-        placeholder = "<|vision_bos|><|IMAGE|><|vision_eos|>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "<|vision_bos|><|VIDEO|><|vision_eos|>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = (
-            "<|vision_bos|><|IMAGE|><|vision_eos|><|vision_bos|><|VIDEO|><|vision_eos|>"
-        )
+        placeholder = image_placeholder + video_placeholder
 
     default_system = (
         "You are Qwen, a virtual human developed by the Qwen Team, Alibaba "
@@ -2138,15 +2153,15 @@ def run_qwen3_vl_moe(questions: list[str], modality: str) -> ModelRequestData:
         limit_mm_per_prompt=mm_limit,
     )
 
+    image_placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+    video_placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+
     if modality == "image":
-        placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = (
-            "<|vision_start|><|image_pad|><|vision_end|>"
-            "<|vision_start|><|video_pad|><|vision_end|>"
-        )
+        placeholder = image_placeholder + video_placeholder
 
     prompts = [
         (
@@ -2333,15 +2348,15 @@ def run_tarsier2(questions: list[str], modality: str) -> ModelRequestData:
         limit_mm_per_prompt=mm_limit,
     )
 
+    image_placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+    video_placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+
     if modality == "image":
-        placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = (
-            "<|vision_start|><|image_pad|><|vision_end|>"
-            "<|vision_start|><|video_pad|><|vision_end|>"
-        )
+        placeholder = image_placeholder + video_placeholder
 
     prompts = [
         (

--- a/examples/offline_inference/vision_language.py
+++ b/examples/offline_inference/vision_language.py
@@ -394,11 +394,12 @@ def run_eagle2_5(questions: list[str], modality: str) -> ModelRequestData:
 def run_ernie45_vl(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "baidu/ERNIE-4.5-VL-28B-A3B-PT"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         max_model_len=4096,
         max_num_seqs=5,
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
         trust_remote_code=True,
     )
 
@@ -406,6 +407,11 @@ def run_ernie45_vl(questions: list[str], modality: str) -> ModelRequestData:
         placeholder = "Picture 1:<|IMAGE_START|><|image@placeholder|><|IMAGE_END|>"
     elif modality == "video":
         placeholder = "Video 1:<|VIDEO_START|><|video@placeholder|><|VIDEO_END|>"
+    elif modality == "image+video":
+        placeholder = (
+            "Picture 1:<|IMAGE_START|><|image@placeholder|><|IMAGE_END|>"
+            "Video 1:<|VIDEO_START|><|video@placeholder|><|VIDEO_END|>"
+        )
 
     prompts = [
         (
@@ -425,6 +431,7 @@ def run_ernie45_vl(questions: list[str], modality: str) -> ModelRequestData:
 def run_exaone4_5(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "LGAI-EXAONE/EXAONE-4.5-33B"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         max_model_len=4096,
@@ -434,18 +441,20 @@ def run_exaone4_5(questions: list[str], modality: str) -> ModelRequestData:
             "max_pixels": 1280 * 28 * 28,
             "fps": 1,
         },
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
     )
 
     if modality == "image":
-        placeholder = "<|image_pad|>"
+        placeholder = "<vision><|image_pad|></vision>"
     elif modality == "video":
-        placeholder = "<|video_pad|>"
+        placeholder = "<vision><|video_pad|></vision>"
+    elif modality == "image+video":
+        placeholder = "<vision><|image_pad|></vision><vision><|video_pad|></vision>"
 
     prompts = [
         (
             "<|system|>\nYou are a helpful assistant.<|endofturn|>\n"
-            f"<|user|>\n<vision>{placeholder}</vision>"
+            f"<|user|>\n{placeholder}"
             f"{question}<|endofturn|>\n"
             "<|assistant|>\n"
         )
@@ -566,6 +575,7 @@ def run_glm4v(questions: list[str], modality: str) -> ModelRequestData:
 def run_glm4_1v(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "zai-org/GLM-4.1V-9B-Thinking"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         max_model_len=4096,
@@ -574,7 +584,7 @@ def run_glm4_1v(questions: list[str], modality: str) -> ModelRequestData:
             "size": {"shortest_edge": 12544, "longest_edge": 47040000},
             "fps": 1,
         },
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
         enforce_eager=True,
     )
 
@@ -582,6 +592,11 @@ def run_glm4_1v(questions: list[str], modality: str) -> ModelRequestData:
         placeholder = "<|begin_of_image|><|image|><|end_of_image|>"
     elif modality == "video":
         placeholder = "<|begin_of_video|><|video|><|end_of_video|>"
+    elif modality == "image+video":
+        placeholder = (
+            "<|begin_of_image|><|image|><|end_of_image|>"
+            "<|begin_of_video|><|video|><|end_of_video|>"
+        )
 
     prompts = [
         (
@@ -602,6 +617,7 @@ def run_glm4_1v(questions: list[str], modality: str) -> ModelRequestData:
 def run_glm4_5v(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "zai-org/GLM-4.5V"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         max_model_len=4096,
@@ -610,7 +626,7 @@ def run_glm4_5v(questions: list[str], modality: str) -> ModelRequestData:
             "size": {"shortest_edge": 12544, "longest_edge": 47040000},
             "fps": 1,
         },
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
         enforce_eager=True,
         tensor_parallel_size=4,
     )
@@ -619,6 +635,11 @@ def run_glm4_5v(questions: list[str], modality: str) -> ModelRequestData:
         placeholder = "<|begin_of_image|><|image|><|end_of_image|>"
     elif modality == "video":
         placeholder = "<|begin_of_video|><|video|><|end_of_video|>"
+    elif modality == "image+video":
+        placeholder = (
+            "<|begin_of_image|><|image|><|end_of_image|>"
+            "<|begin_of_video|><|video|><|end_of_video|>"
+        )
 
     prompts = [
         (
@@ -639,6 +660,7 @@ def run_glm4_5v(questions: list[str], modality: str) -> ModelRequestData:
 def run_glm4_5v_fp8(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "zai-org/GLM-4.5V-FP8"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         max_model_len=4096,
@@ -647,7 +669,7 @@ def run_glm4_5v_fp8(questions: list[str], modality: str) -> ModelRequestData:
             "size": {"shortest_edge": 12544, "longest_edge": 47040000},
             "fps": 1,
         },
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
         enforce_eager=True,
         tensor_parallel_size=4,
     )
@@ -656,6 +678,11 @@ def run_glm4_5v_fp8(questions: list[str], modality: str) -> ModelRequestData:
         placeholder = "<|begin_of_image|><|image|><|end_of_image|>"
     elif modality == "video":
         placeholder = "<|begin_of_video|><|video|><|end_of_video|>"
+    elif modality == "image+video":
+        placeholder = (
+            "<|begin_of_image|><|image|><|end_of_image|>"
+            "<|begin_of_video|><|video|><|end_of_video|>"
+        )
 
     prompts = [
         (
@@ -676,6 +703,7 @@ def run_glm4_5v_fp8(questions: list[str], modality: str) -> ModelRequestData:
 def run_glm_ocr(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "zai-org/GLM-OCR"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         max_model_len=4096,
@@ -684,7 +712,7 @@ def run_glm_ocr(questions: list[str], modality: str) -> ModelRequestData:
             "size": {"shortest_edge": 12544, "longest_edge": 47040000},
             "fps": 1,
         },
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
         enforce_eager=True,
     )
 
@@ -692,6 +720,11 @@ def run_glm_ocr(questions: list[str], modality: str) -> ModelRequestData:
         placeholder = "<|begin_of_image|><|image|><|end_of_image|>"
     elif modality == "video":
         placeholder = "<|begin_of_video|><|video|><|end_of_video|>"
+    elif modality == "image+video":
+        placeholder = (
+            "<|begin_of_image|><|image|><|end_of_image|>"
+            "<|begin_of_video|><|video|><|end_of_video|>"
+        )
 
     prompts = [
         (
@@ -772,11 +805,12 @@ def run_hyperclovax_seed_vision(
     model_name = "naver-hyperclovax/HyperCLOVAX-SEED-Vision-Instruct-3B"
     tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         trust_remote_code=True,
-        max_model_len=8192 if modality == "image" else 16384,
-        limit_mm_per_prompt={modality: 1},
+        max_model_len=16384 if modality in ("video", "image+video") else 8192,
+        limit_mm_per_prompt=mm_limit,
     )
 
     messages = list()
@@ -817,6 +851,29 @@ def run_hyperclovax_seed_vision(
                     {
                         "role": "user",
                         "content": [
+                            {
+                                "type": "video",
+                            },
+                            {
+                                "type": "text",
+                                "text": question,
+                            },
+                        ],
+                    }
+                ]
+            )
+        elif modality == "image+video":
+            messages.append(
+                [
+                    {
+                        "role": "user",
+                        "content": [
+                            {
+                                "type": "image",
+                                "ocr": "",
+                                "lens_keywords": "",
+                                "lens_local_keywords": "",
+                            },
                             {
                                 "type": "video",
                             },
@@ -876,12 +933,13 @@ def run_idefics3(questions: list[str], modality: str) -> ModelRequestData:
 def run_interns1(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "internlm/Intern-S1-mini"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         trust_remote_code=True,
         max_model_len=8192,
         max_num_seqs=2,
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
         enforce_eager=True,
     )
 
@@ -889,6 +947,8 @@ def run_interns1(questions: list[str], modality: str) -> ModelRequestData:
         placeholder = "<IMG_CONTEXT>"
     elif modality == "video":
         placeholder = "<video>"
+    elif modality == "image+video":
+        placeholder = "<IMG_CONTEXT>\n<video>"
 
     tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
     messages = [
@@ -909,12 +969,13 @@ def run_interns1(questions: list[str], modality: str) -> ModelRequestData:
 def run_interns1_pro(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "internlm/Intern-S1-Pro"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         trust_remote_code=True,
         max_model_len=8192,
         max_num_seqs=2,
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
         enforce_eager=True,
         tensor_parallel_size=4,
     )
@@ -923,6 +984,11 @@ def run_interns1_pro(questions: list[str], modality: str) -> ModelRequestData:
         placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
     elif modality == "video":
         placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+    elif modality == "image+video":
+        placeholder = (
+            "<|vision_start|><|image_pad|><|vision_end|>"
+            "<|vision_start|><|video_pad|><|vision_end|>"
+        )
 
     tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
     messages = [
@@ -943,17 +1009,20 @@ def run_interns1_pro(questions: list[str], modality: str) -> ModelRequestData:
 def run_internvl(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "OpenGVLab/InternVL3-2B"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         trust_remote_code=True,
         max_model_len=8192,
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
     )
 
     if modality == "image":
         placeholder = "<image>"
     elif modality == "video":
         placeholder = "<video>"
+    elif modality == "image+video":
+        placeholder = "<image>\n<video>"
 
     tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
     messages = [
@@ -1010,21 +1079,27 @@ def run_kanana_v(questions: list[str], modality: str) -> ModelRequestData:
 def run_keye_vl(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "Kwai-Keye/Keye-VL-8B-Preview"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         max_model_len=8192,
         trust_remote_code=True,
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
     )
 
     if modality == "image":
-        placeholder = "<|image_pad|>"
+        placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
     elif modality == "video":
-        placeholder = "<|video_pad|>"
+        placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+    elif modality == "image+video":
+        placeholder = (
+            "<|vision_start|><|image_pad|><|vision_end|>"
+            "<|vision_start|><|video_pad|><|vision_end|>"
+        )
 
     prompts = [
         (
-            f"<|im_start|>user\n<|vision_start|>{placeholder}<|vision_end|>"
+            f"<|im_start|>user\n{placeholder}"
             f"{question}<|im_end|>\n"
             "<|im_start|>assistant\n"
         )
@@ -1041,21 +1116,27 @@ def run_keye_vl(questions: list[str], modality: str) -> ModelRequestData:
 def run_keye_vl1_5(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "Kwai-Keye/Keye-VL-1.5-8B"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         max_model_len=8192,
         trust_remote_code=True,
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
     )
 
     if modality == "image":
-        placeholder = "<|image_pad|>"
+        placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
     elif modality == "video":
-        placeholder = "<|video_pad|>"
+        placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+    elif modality == "image+video":
+        placeholder = (
+            "<|vision_start|><|image_pad|><|vision_end|>"
+            "<|vision_start|><|video_pad|><|vision_end|>"
+        )
 
     prompts = [
         (
-            f"<|im_start|>user\n<|vision_start|>{placeholder}<|vision_end|>"
+            f"<|im_start|>user\n{placeholder}"
             f"{question}<|im_end|>\n"
             "<|im_start|>assistant\n"
         )
@@ -1264,17 +1345,23 @@ def run_llava_onevision(questions: list[str], modality: str) -> ModelRequestData
             f"<|im_start|>user <video>\n{question}<|im_end|><|im_start|>assistant\n"
             for question in questions
         ]
-
     elif modality == "image":
         prompts = [
             f"<|im_start|>user <image>\n{question}<|im_end|><|im_start|>assistant\n"
             for question in questions
         ]
+    elif modality == "image+video":
+        prompts = [
+            f"<|im_start|>user <image>\n<video>\n{question}<|im_end|>"
+            f"<|im_start|>assistant\n"
+            for question in questions
+        ]
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model="llava-hf/llava-onevision-qwen2-7b-ov-hf",
         max_model_len=16384,
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
     )
 
     return ModelRequestData(
@@ -1307,7 +1394,7 @@ def run_mantis(questions: list[str], modality: str) -> ModelRequestData:
 
 # MiniCPM-V
 def run_minicpmv_base(questions: list[str], modality: str, model_name):
-    assert modality in ["image", "video"]
+    assert modality in ["image", "video", "image+video"]
     # If you want to use `MiniCPM-o-2_6` with audio inputs, check `audio_language.py` # noqa
 
     # 2.0
@@ -1329,12 +1416,13 @@ def run_minicpmv_base(questions: list[str], modality: str, model_name):
     # o2.6: image, video, audio
     # model_name = "openbmb/MiniCPM-o-2_6"
     tokenizer = AutoTokenizer.from_pretrained(model_name, trust_remote_code=True)
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         max_model_len=4096,
         max_num_seqs=2,
         trust_remote_code=True,
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
     )
     # NOTE The stop_token_ids are different for various versions of MiniCPM-V
     # 2.0
@@ -1347,17 +1435,21 @@ def run_minicpmv_base(questions: list[str], modality: str, model_name):
     stop_tokens = ["<|im_end|>", "<|endoftext|>"]
     stop_token_ids = [tokenizer.convert_tokens_to_ids(i) for i in stop_tokens]
 
-    modality_placeholder = {
-        "image": "(<image>./</image>)",
-        "video": "(<video>./</video>)",
-    }
+    if modality == "image+video":
+        content_prefix = "(<image>./</image>)\n(<video>./</video>)"
+    else:
+        modality_placeholder = {
+            "image": "(<image>./</image>)",
+            "video": "(<video>./</video>)",
+        }
+        content_prefix = modality_placeholder[modality]
 
     prompts = [
         tokenizer.apply_chat_template(
             [
                 {
                     "role": "user",
-                    "content": f"{modality_placeholder[modality]}\n{question}",
+                    "content": f"{content_prefix}\n{question}",
                 }
             ],
             tokenize=False,
@@ -1466,11 +1558,12 @@ def run_molmo(questions: list[str], modality: str) -> ModelRequestData:
 def run_molmo2(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "allenai/Molmo2-8B"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         trust_remote_code=True,
         dtype="bfloat16",
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
         max_num_batched_tokens=36864,
     )
 
@@ -1478,6 +1571,8 @@ def run_molmo2(questions: list[str], modality: str) -> ModelRequestData:
         placeholder = "<|image|>"
     elif modality == "video":
         placeholder = "<|video|>"
+    elif modality == "image+video":
+        placeholder = "<|image|><|video|>"
     else:
         raise ValueError(f"Unsupported modality for molmo2: {modality}")
 
@@ -1563,19 +1658,22 @@ def run_nvlm_d(questions: list[str], modality: str) -> ModelRequestData:
 def run_openpangu_vl(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "FreedomIntelligence/openPangu-VL-7B"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         max_model_len=4096,
         max_num_seqs=4,
         trust_remote_code=True,
         enforce_eager=True,
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
     )
 
     if modality == "image":
         placeholder = "[unused19]"
     elif modality == "video":
         placeholder = "[unused32]"
+    elif modality == "image+video":
+        placeholder = "[unused19][unused32]"
 
     prompts = [
         (
@@ -1623,18 +1721,21 @@ def run_ovis(questions: list[str], modality: str) -> ModelRequestData:
 def run_ovis2_5(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "AIDC-AI/Ovis2.5-2B"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         max_model_len=4096,
         max_num_seqs=2,
         trust_remote_code=True,
         dtype="half",
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
     )
     if modality == "image":
         placeholder = "<image>"
     elif modality == "video":
         placeholder = "<video>"
+    elif modality == "image+video":
+        placeholder = "<image>\n<video>"
 
     prompts = [
         f"<|im_start|>user\n\n{placeholder}\n{question}<|im_end|>\n<|im_start|>assistant\n"
@@ -1846,6 +1947,7 @@ def run_qwen_vl(questions: list[str], modality: str) -> ModelRequestData:
 def run_qwen2_vl(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "Qwen/Qwen2-VL-7B-Instruct"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         max_model_len=4096,
@@ -1855,18 +1957,23 @@ def run_qwen2_vl(questions: list[str], modality: str) -> ModelRequestData:
             "min_pixels": 28 * 28,
             "max_pixels": 1280 * 28 * 28,
         },
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
     )
 
     if modality == "image":
-        placeholder = "<|image_pad|>"
+        placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
     elif modality == "video":
-        placeholder = "<|video_pad|>"
+        placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+    elif modality == "image+video":
+        placeholder = (
+            "<|vision_start|><|image_pad|><|vision_end|>"
+            "<|vision_start|><|video_pad|><|vision_end|>"
+        )
 
     prompts = [
         (
             "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
-            f"<|im_start|>user\n<|vision_start|>{placeholder}<|vision_end|>"
+            f"<|im_start|>user\n{placeholder}"
             f"{question}<|im_end|>\n"
             "<|im_start|>assistant\n"
         )
@@ -1883,6 +1990,7 @@ def run_qwen2_vl(questions: list[str], modality: str) -> ModelRequestData:
 def run_qwen2_5_vl(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "Qwen/Qwen2.5-VL-3B-Instruct"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         max_model_len=4096,
@@ -1892,18 +2000,23 @@ def run_qwen2_5_vl(questions: list[str], modality: str) -> ModelRequestData:
             "max_pixels": 1280 * 28 * 28,
             "fps": 1,
         },
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
     )
 
     if modality == "image":
-        placeholder = "<|image_pad|>"
+        placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
     elif modality == "video":
-        placeholder = "<|video_pad|>"
+        placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+    elif modality == "image+video":
+        placeholder = (
+            "<|vision_start|><|image_pad|><|vision_end|>"
+            "<|vision_start|><|video_pad|><|vision_end|>"
+        )
 
     prompts = [
         (
             "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
-            f"<|im_start|>user\n<|vision_start|>{placeholder}<|vision_end|>"
+            f"<|im_start|>user\n{placeholder}"
             f"{question}<|im_end|>\n"
             "<|im_start|>assistant\n"
         )
@@ -1920,6 +2033,7 @@ def run_qwen2_5_vl(questions: list[str], modality: str) -> ModelRequestData:
 def run_qwen2_5_omni(questions: list[str], modality: str):
     model_name = "Qwen/Qwen2.5-Omni-7B"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         max_model_len=4096,
@@ -1929,13 +2043,17 @@ def run_qwen2_5_omni(questions: list[str], modality: str):
             "max_pixels": 1280 * 28 * 28,
             "fps": 1,
         },
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
     )
 
     if modality == "image":
-        placeholder = "<|IMAGE|>"
+        placeholder = "<|vision_bos|><|IMAGE|><|vision_eos|>"
     elif modality == "video":
-        placeholder = "<|VIDEO|>"
+        placeholder = "<|vision_bos|><|VIDEO|><|vision_eos|>"
+    elif modality == "image+video":
+        placeholder = (
+            "<|vision_bos|><|IMAGE|><|vision_eos|><|vision_bos|><|VIDEO|><|vision_eos|>"
+        )
 
     default_system = (
         "You are Qwen, a virtual human developed by the Qwen Team, Alibaba "
@@ -1946,7 +2064,7 @@ def run_qwen2_5_omni(questions: list[str], modality: str):
     prompts = [
         (
             f"<|im_start|>system\n{default_system}<|im_end|>\n"
-            f"<|im_start|>user\n<|vision_bos|>{placeholder}<|vision_eos|>"
+            f"<|im_start|>user\n{placeholder}"
             f"{question}<|im_end|>\n"
             "<|im_start|>assistant\n"
         )
@@ -1960,8 +2078,10 @@ def run_qwen2_5_omni(questions: list[str], modality: str):
 
 # Qwen3-VL-Dense
 def run_qwen3_vl(questions: list[str], modality: str) -> ModelRequestData:
-    model_name = "Qwen/Qwen3-VL-4B-Instruct"
+    # model_name = "Qwen/Qwen3-VL-4B-Instruct"
+    model_name = "/shared/models/modelscope/models/Qwen/Qwen3-VL-8B-Instruct"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         max_model_len=4096,
@@ -1971,18 +2091,23 @@ def run_qwen3_vl(questions: list[str], modality: str) -> ModelRequestData:
             "max_pixels": 1280 * 28 * 28,
             "fps": 1,
         },
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
     )
 
     if modality == "image":
-        placeholder = "<|image_pad|>"
+        placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
     elif modality == "video":
-        placeholder = "<|video_pad|>"
+        placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+    elif modality == "image+video":
+        placeholder = (
+            "<|vision_start|><|image_pad|><|vision_end|>"
+            "<|vision_start|><|video_pad|><|vision_end|>"
+        )
 
     prompts = [
         (
             "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
-            f"<|im_start|>user\n<|vision_start|>{placeholder}<|vision_end|>"
+            f"<|im_start|>user\n{placeholder}"
             f"{question}<|im_end|>\n"
             "<|im_start|>assistant\n"
         )
@@ -1999,6 +2124,7 @@ def run_qwen3_vl(questions: list[str], modality: str) -> ModelRequestData:
 def run_qwen3_vl_moe(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "Qwen/Qwen3-VL-30B-A3B-Instruct"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         max_model_len=4096,
@@ -2008,18 +2134,23 @@ def run_qwen3_vl_moe(questions: list[str], modality: str) -> ModelRequestData:
             "max_pixels": 1280 * 28 * 28,
             "fps": 1,
         },
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
     )
 
     if modality == "image":
-        placeholder = "<|image_pad|>"
+        placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
     elif modality == "video":
-        placeholder = "<|video_pad|>"
+        placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+    elif modality == "image+video":
+        placeholder = (
+            "<|vision_start|><|image_pad|><|vision_end|>"
+            "<|vision_start|><|video_pad|><|vision_end|>"
+        )
 
     prompts = [
         (
             "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
-            f"<|im_start|>user\n<|vision_start|>{placeholder}<|vision_end|>"
+            f"<|im_start|>user\n{placeholder}"
             f"{question}<|im_end|>\n"
             "<|im_start|>assistant\n"
         )
@@ -2190,6 +2321,7 @@ def run_tarsier(questions: list[str], modality: str) -> ModelRequestData:
 def run_tarsier2(questions: list[str], modality: str) -> ModelRequestData:
     model_name = "omni-research/Tarsier2-Recap-7b"
 
+    mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(
         model=model_name,
         max_model_len=4096,
@@ -2197,18 +2329,23 @@ def run_tarsier2(questions: list[str], modality: str) -> ModelRequestData:
             "architectures": ["Tarsier2ForConditionalGeneration"],
             "model_type": "tarsier2",
         },
-        limit_mm_per_prompt={modality: 1},
+        limit_mm_per_prompt=mm_limit,
     )
 
     if modality == "image":
-        placeholder = "<|image_pad|>"
+        placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
     elif modality == "video":
-        placeholder = "<|video_pad|>"
+        placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+    elif modality == "image+video":
+        placeholder = (
+            "<|vision_start|><|image_pad|><|vision_end|>"
+            "<|vision_start|><|video_pad|><|vision_end|>"
+        )
 
     prompts = [
         (
             "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n"
-            f"<|im_start|>user\n<|vision_start|>{placeholder}<|vision_end|>"
+            f"<|im_start|>user\n{placeholder}"
             f"{question}<|im_end|>\n"
             "<|im_start|>assistant\n"
         )
@@ -2357,6 +2494,24 @@ def get_multi_modal_input(args):
             "questions": vision_chunk_questions,
         }
 
+    if args.modality == "image+video":
+        image = convert_image_mode(ImageAsset("cherry_blossom").pil_image, "RGB")
+        needs_metadata = args.model_type in MODELS_NEED_VIDEO_METADATA
+        video = VideoAsset(name="baby_reading", num_frames=args.num_frames).np_ndarrays
+        metadata = VideoAsset(name="baby_reading", num_frames=args.num_frames).metadata
+        img_video_questions = [
+            "What is shown in the image? What happens in the video?",
+            "Describe both the image and the video content.",
+        ]
+
+        return {
+            "data": {
+                "image": image,
+                "video": ([(video, metadata)] if needs_metadata else video),
+            },
+            "questions": img_video_questions,
+        }
+
     msg = f"Modality {args.modality} is not supported."
     raise ValueError(msg)
 
@@ -2439,7 +2594,7 @@ def parse_args():
         "--modality",
         type=str,
         default="image",
-        choices=["image", "video", "vision_chunk"],
+        choices=["image", "video", "image+video", "vision_chunk"],
         help="Modality of the input.",
     )
     parser.add_argument(
@@ -2546,23 +2701,42 @@ def main(args):
         else req_data.sampling_params
     )
 
+    def _mm_data(data, modality):
+        if modality == "image+video":
+            return {"image": data["image"], "video": data["video"]}
+        return {modality: data}
+
+    def _mm_uuid(uuid, modality):
+        if modality == "image+video":
+            return {"image": uuid, "video": uuid + "v"}
+        return {modality: uuid}
+
+    def _mm_empty(modality):
+        if modality == "image+video":
+            return {"image": None, "video": None}
+        return {modality: None}
+
     assert args.num_prompts > 0
     if args.num_prompts == 1:
         # Single inference
         uuid = "uuid_0"
         inputs = {
             "prompt": prompts[0],
-            "multi_modal_data": {modality: data},
-            "multi_modal_uuids": {modality: uuid},
+            "multi_modal_data": _mm_data(data, modality),
+            "multi_modal_uuids": _mm_uuid(uuid, modality),
         }
         inputs_with_empty_media = {
             "prompt": prompts[0],
-            "multi_modal_data": {modality: None},
-            "multi_modal_uuids": {modality: uuid},
+            "multi_modal_data": _mm_empty(modality),
+            "multi_modal_uuids": _mm_uuid(uuid, modality),
         }
     else:
         # Batch inference
         if args.image_repeat_prob is not None:
+            if modality == "image+video":
+                raise ValueError(
+                    "--image-repeat-prob is not supported for 'image+video' modality"
+                )
             # Repeat images with specified probability of "image_repeat_prob"
             inputs, inputs_with_empty_media = apply_image_repeat(
                 args.image_repeat_prob,
@@ -2572,7 +2746,7 @@ def main(args):
                 modality,
             )
         else:
-            # Use the same image for all prompts
+            # Use the same image/video for all prompts
             inputs = []
             inputs_with_empty_media = []
             for i in range(args.num_prompts):
@@ -2580,15 +2754,15 @@ def main(args):
                 inputs.append(
                     {
                         "prompt": prompts[i % len(prompts)],
-                        "multi_modal_data": {modality: data},
-                        "multi_modal_uuids": {modality: uuid},
+                        "multi_modal_data": _mm_data(data, modality),
+                        "multi_modal_uuids": _mm_uuid(uuid, modality),
                     }
                 )
                 inputs_with_empty_media.append(
                     {
                         "prompt": prompts[i % len(prompts)],
-                        "multi_modal_data": {modality: None},
-                        "multi_modal_uuids": {modality: uuid},
+                        "multi_modal_data": _mm_empty(modality),
+                        "multi_modal_uuids": _mm_uuid(uuid, modality),
                     }
                 )
 

--- a/examples/offline_inference/vision_language.py
+++ b/examples/offline_inference/vision_language.py
@@ -2110,15 +2110,15 @@ def run_qwen3_vl(questions: list[str], modality: str) -> ModelRequestData:
         limit_mm_per_prompt=mm_limit,
     )
 
+    image_placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+    video_placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+
     if modality == "image":
-        placeholder = "<|vision_start|><|image_pad|><|vision_end|>"
+        placeholder = image_placeholder
     elif modality == "video":
-        placeholder = "<|vision_start|><|video_pad|><|vision_end|>"
+        placeholder = video_placeholder
     elif modality == "image+video":
-        placeholder = (
-            "<|vision_start|><|image_pad|><|vision_end|>"
-            "<|vision_start|><|video_pad|><|vision_end|>"
-        )
+        placeholder = image_placeholder + video_placeholder
 
     prompts = [
         (

--- a/examples/offline_inference/vision_language.py
+++ b/examples/offline_inference/vision_language.py
@@ -1352,8 +1352,10 @@ def run_llava_onevision(questions: list[str], modality: str) -> ModelRequestData
         ]
     elif modality == "image+video":
         prompts = [
-            f"<|im_start|>user <image>\n<video>\n{question}<|im_end|>"
-            f"<|im_start|>assistant\n"
+            (
+                f"<|im_start|>user <image>\n<video>\n{question}<|im_end|>"
+                f"<|im_start|>assistant\n"
+            )
             for question in questions
         ]
 

--- a/examples/offline_inference/vision_language.py
+++ b/examples/offline_inference/vision_language.py
@@ -2080,8 +2080,7 @@ def run_qwen2_5_omni(questions: list[str], modality: str):
 
 # Qwen3-VL-Dense
 def run_qwen3_vl(questions: list[str], modality: str) -> ModelRequestData:
-    # model_name = "Qwen/Qwen3-VL-4B-Instruct"
-    model_name = "/shared/models/modelscope/models/Qwen/Qwen3-VL-8B-Instruct"
+    model_name = "Qwen/Qwen3-VL-4B-Instruct"
 
     mm_limit = {"image": 1, "video": 1} if modality == "image+video" else {modality: 1}
     engine_args = EngineArgs(


### PR DESCRIPTION
## Purpose

The VLM offline inference example (`examples/offline_inference/vision_language.py`) previously only accepted a single modality per run — either `image` or `video`. Users who wanted to test vision-language models on prompts that combine both an image and a video in the same context had no way to do so through the example script.

This PR adds a new `--modality "image+video"` option to the example, enabling per-prompt mixed image+video inputs. When this modality is selected, `limit_mm_per_prompt` is set to `{"image": 1, "video": 1}` and the appropriate combined placeholder token string is constructed for each model's chat template. The change covers ~20 VLM model runner functions and also fixes several pre-existing placeholder wrapping bugs (e.g., Qwen-series models had placeholder tokens double-wrapped inside vision boundary markers).

**Key Changes:**

- **`mm_limit` pattern** (all updated model runners): Replaces the hard-coded `{modality: 1}` with `{"image": 1, "video": 1} if modality == "image+video" else {modality: 1}` so `EngineArgs.limit_mm_per_prompt` correctly allows one image and one video per prompt.
- **`elif modality == "image+video":` placeholder branches** (all updated model runners): Concatenates the model-specific image placeholder and video placeholder tokens into a single prompt prefix string.
- **`run_hyperclovax_seed_vision`**: Adds a message-content-list branch that inserts both `{"type": "image", ...}` and `{"type": "video"}` content blocks; also widens `max_model_len` to `16384` for `image+video` (matching video-only behavior).
- **`run_minicpmv_base`**: Replaces the `modality_placeholder` dict lookup with an explicit `content_prefix` variable that concatenates image and video template strings for `image+video`.
- **`run_llava_onevision`**: Adds `image+video` prompt template branch before the `EngineArgs` construction block.
- **Placeholder correctness fixes** (EXAONE-4.5, Keye-VL/1.5, Qwen2-VL, Qwen2.5-VL, Qwen2.5-Omni, Qwen3-VL, Qwen3-VL-MoE): Moves vision boundary markers (`<|vision_start|>...<|vision_end|>`, `<|vision_bos|>...<|vision_eos|>`) from the outer prompt template string into the per-modality placeholder variable, so all three branches (image / video / image+video) are consistent.

**Models with added `image+video` support:**

ERNIE-4.5-VL, EXAONE-4.5, GLM-4.1V, GLM-4.5V, GLM-4.5V-FP8, GLM-OCR, HyperCLOVAX-SEED-Vision, Intern-S1, Intern-S1-Pro, InternVL3, Keye-VL, Keye-VL-1.5, LLaVA-OneVision, MiniCPM-V series, Molmo2, openPangu-VL, Ovis2.5, Qwen2-VL, Qwen2.5-VL, Qwen2.5-Omni, Qwen3-VL, Qwen3-VL-MoE, Tarsier2.

## Test Plan

```bash
python examples/offline_inference/vision_language.py -m qwen3_vl --modality "image+video"
```

## Test Result

```
--------------------------------------------------
The image shows a baby sitting on a bed, wearing glasses, and reading a book. The baby is focused on the book, turning the pages with curiosity and interest. The baby's glasses add a charming and adorable touch to the scene, making it seem like the baby is taking the reading activity seriously. The baby's movements are gentle and deliberate as they turn the pages, indicating a sense of engagement and enjoyment in the activity. The overall atmosphere of the image is cozy and heartwarming, capturing a sweet moment of a baby exploring the world of books.

In the video, the baby continues to read the book, occasionally looking up and smiling, showing their enjoyment and fascination with the story. The baby's glasses remain on, adding to the charm of the scene. The baby's movements are gentle and deliberate as they turn the pages, indicating a sense of engagement and enjoyment in the activity. The overall atmosphere of the video is cozy and heartwarming, capturing a sweet moment of a baby exploring
--------------------------------------------------
The image shows a baby wearing glasses, sitting on a bed and reading a book. The baby is dressed in a light blue shirt and pink pants. The baby is holding the book with both hands and appears to be focused on reading. The background shows a bedroom with a crib and some clothes on the bed.

In the video, the baby continues to read the book, turning the pages and occasionally looking up. The baby seems to be enjoying the activity and is fully engaged in reading. The video captures the baby's concentration and curiosity as they explore the book.
--------------------------------------------------
The image shows a baby girl sitting on a bed, wearing glasses and reading a book. She is surrounded by a cozy bedroom setting with a crib and clothes in the background.

In the video, the baby girl continues to read the book, turning the pages and occasionally looking up. She seems to be enjoying her reading time, fully immersed in the story. The video captures a sweet and adorable moment of a young child engaging in a quiet, intellectual activity.
--------------------------------------------------
The image shows a baby girl sitting on a bed, wearing glasses and reading a book. She is focused on the book, turning the pages and occasionally looking up. The background includes a crib and some clothes on the bed.

In the video, the baby girl continues to read the book, turning the pages and looking at the text. She occasionally looks up and smiles, showing her enjoyment of the activity. The video captures the baby's concentration and curiosity as she engages with the book.
--------------------------------------------------
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

