### PR TITLE
Qwen 3 VL: Track and use buffer correctly

### DIFF
--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1572,6 +1572,10 @@ class Qwen3LLMForCausalLM(Qwen3ForCausalLM):
         )
 
 
+def _deepstack_name(idx: int) -> str:
+    return f"deepstack_input_embeds_{idx}"
+
+
 @MULTIMODAL_REGISTRY.register_processor(
     Qwen3VLMultiModalProcessor,
     info=Qwen3VLProcessingInfo,
@@ -1655,13 +1659,15 @@ class Qwen3VLForConditionalGeneration(
 
             # register buffer for deepstack
             if self.use_deepstack:
-                self.deepstack_input_embeds = [
+                deepstack_input_embeds = [
                     torch.zeros(
                         vllm_config.scheduler_config.max_num_batched_tokens,
                         config.text_config.hidden_size,
                     )
                     for _ in range(self.deepstack_num_level)
                 ]
+                for idx, tensor in enumerate(deepstack_input_embeds):
+                    self.register_buffer(_deepstack_name(idx), tensor, persistent=False)
 
         with self._mark_language_model(vllm_config):
             self.language_model = Qwen3LLMForCausalLM(
@@ -1687,13 +1693,13 @@ class Qwen3VLForConditionalGeneration(
         self,
         num_tokens: int,
     ) -> IntermediateTensors | None:
-        if not getattr(self, "deepstack_input_embeds", None):
+        if not self.use_deepstack:
             return None  # If vision tower is skipped
 
         # get deepstack_input_embeds from buffer, and clear the buffer
         return IntermediateTensors(
             {
-                f"deepstack_input_embeds_{idx}": self.deepstack_input_embeds[idx][
+                f"deepstack_input_embeds_{idx}": self.get_buffer(_deepstack_name(idx))[
                     :num_tokens
                 ]
                 for idx in range(self.deepstack_num_level)
@@ -1701,34 +1707,34 @@ class Qwen3VLForConditionalGeneration(
         )
 
     def _set_deepstack_input_embeds(self, deepstack_input_embeds: torch.Tensor) -> None:
-        if not getattr(self, "deepstack_input_embeds", None):
+        if not self.use_deepstack:
             return
 
         # set deepstack_input_embeds to buffer
         num_tokens = deepstack_input_embeds.size(1)
-        if num_tokens > self.deepstack_input_embeds[0].size(0):
-            self.deepstack_input_embeds = [
-                torch.zeros(
+        if num_tokens > self.get_buffer(_deepstack_name(0)).size(0):
+            for idx in range(self.deepstack_num_level):
+                old_buffer = self.get_buffer(_deepstack_name(idx))
+                new_buffer = torch.zeros(
                     num_tokens,
                     self.config.text_config.hidden_size,
-                    device=self.deepstack_input_embeds[0].device,
-                    dtype=self.deepstack_input_embeds[0].dtype,
+                    device=old_buffer.device,
+                    dtype=old_buffer.dtype,
                 )
-                for _ in range(self.deepstack_num_level)
-            ]
+                self.register_buffer(_deepstack_name(idx), new_buffer, persistent=False)
+
         for idx in range(self.deepstack_num_level):
-            self.deepstack_input_embeds[idx][:num_tokens].copy_(
-                deepstack_input_embeds[idx]
-            )
+            buffer = self.get_buffer(_deepstack_name(idx))
+            buffer[:num_tokens].copy_(deepstack_input_embeds[idx])
 
     def _clear_deepstack_input_embeds(self, num_tokens: int) -> None:
-        if not getattr(self, "deepstack_input_embeds", None):
+        if not self.use_deepstack:
             return
 
         # clear deepstack_input_embeds in buffer
         if num_tokens > 0:
             for idx in range(self.deepstack_num_level):
-                self.deepstack_input_embeds[idx][:num_tokens].zero_()
+                self.get_buffer(_deepstack_name(idx))[:num_tokens].zero_()
 
     # -- SupportsEncoderCudaGraph protocol methods --
 

--- a/vllm/model_executor/models/qwen3_vl_moe.py
+++ b/vllm/model_executor/models/qwen3_vl_moe.py
@@ -59,6 +59,7 @@ from .qwen3_vl import (
     Qwen3VLForConditionalGeneration,
     Qwen3VLMultiModalProcessor,
     Qwen3VLProcessingInfo,
+    _deepstack_name,
 )
 from .utils import is_pp_missing_parameter, maybe_prefix
 
@@ -434,13 +435,15 @@ class Qwen3VLMoeForConditionalGeneration(
 
             # register buffer for deepstack
             if self.use_deepstack:
-                self.deepstack_input_embeds = [
+                deepstack_input_embeds = [
                     torch.zeros(
                         vllm_config.scheduler_config.max_num_batched_tokens,
                         config.text_config.hidden_size,
                     )
                     for _ in range(self.deepstack_num_level)
                 ]
+                for idx, tensor in enumerate(deepstack_input_embeds):
+                    self.register_buffer(_deepstack_name(idx), tensor, persistent=False)
 
         with self._mark_language_model(vllm_config):
             self.language_model = Qwen3MoeLLMForCausalLM(

--- a/vllm/model_executor/models/qwen3_vl_moe.py
+++ b/vllm/model_executor/models/qwen3_vl_moe.py
@@ -54,6 +54,7 @@ from .qwen3_moe import (
     Qwen3MoeSparseMoeBlock,
 )
 from .qwen3_vl import (
+    _deepstack_name,
     Qwen3_VisionTransformer,
     Qwen3VLDummyInputsBuilder,
     Qwen3VLForConditionalGeneration,
@@ -434,13 +435,15 @@ class Qwen3VLMoeForConditionalGeneration(
 
             # register buffer for deepstack
             if self.use_deepstack:
-                self.deepstack_input_embeds = [
+                deepstack_input_embeds = [
                     torch.zeros(
                         vllm_config.scheduler_config.max_num_batched_tokens,
                         config.text_config.hidden_size,
                     )
                     for _ in range(self.deepstack_num_level)
                 ]
+                for idx, tensor in enumerate(deepstack_input_embeds):
+                    self.register_buffer(_deepstack_name(idx), tensor, persistent=False)
 
         with self._mark_language_model(vllm_config):
             self.language_model = Qwen3MoeLLMForCausalLM(


### PR DESCRIPTION
Tensor in list member is not tracked by PyTorch module as a *buffer*.

Manually tracking them so the buffers got moved correctly when calling `.to(device=...)` on the module object.

## Purpose

For some vLLM accelerator, e.g. vLLM-TPU, we need to move parameters and buffers manually.
As we need `named_parameters`/`named_buffers` to iterate through them, If some parameters/buffers are not tracked correctly by the nn.Module, we encounter runtime error.
(When we later want to do operation between tensors on CPU and tensors on accelerator.)

This PR preserve original computation logic while tracking the buffers into the nn.Module.

Related docs

- https://docs.pytorch.org/docs/stable/generated/torch.nn.Module.html#torch.nn.Module.register_buffer
- https://docs.pytorch.org/docs/stable/generated/torch.nn.parameter.Buffer.html

## Test Plan

Run (partial) MMMU evaluation, and checking the score is identical before the fix.

```sh
# For GPU A100 4

lm_eval \
  --model vllm-vlm \
  --model_args pretrained="Qwen/Qwen3-VL-30B-A3B-Thinking",tensor_parallel_size=4,dtype="bfloat16",max_model_len=8192,max_num_batched_tokens=64,max_num_seqs=64,gpu_memory_utilization=0.8 \
  --tasks mmmu_val_science \
  --batch_size auto \
  --gen_kwargs '{"temperature":0.0}' \
  --apply_chat_template
```

Before and after this PR, the scores are the same.

```
|   Tasks    |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|------------|------:|------|-----:|------|---|-----:|---|-----:|
|Science     |      0|none  |      |acc   |↑  |0.3533|±  |0.0391|
| - Biology  |      0|none  |     0|acc   |↑  |0.4333|±  |0.0920|
| - Chemistry|      0|none  |     0|acc   |↑  |0.2000|±  |0.0743|
| - Geography|      0|none  |     0|acc   |↑  |0.3667|±  |0.0895|
| - Math     |      0|none  |     0|acc   |↑  |0.3333|±  |0.0875|
| - Physics  |      0|none  |     0|acc   |↑  |0.4333|±  |0.0920|

|Groups |Version|Filter|n-shot|Metric|   |Value |   |Stderr|
|-------|------:|------|------|------|---|-----:|---|-----:|
|Science|      0|none  |      |acc   |↑  |0.3533|±  |0.0391|
```

## Test Result

Pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

