### PR TITLE
[Bugfix][Reasoning] Strip grouped think markers from streaming deltas

### DIFF
--- a/tests/reasoning/test_base_thinking_reasoning_parser.py
+++ b/tests/reasoning/test_base_thinking_reasoning_parser.py
@@ -349,6 +349,24 @@ class TestBaseThinkingReasoningParserStreaming:
         assert reasoning == "Some reasoning"
         assert content == "Answer"
 
+    def test_streaming_with_prefixed_start_token_grouped_with_text(
+        self, test_tokenizer
+    ):
+        """Prefixes before grouped start tokens should be dropped."""
+        parser = TestThinkingReasoningParser(test_tokenizer)
+
+        deltas = [
+            "\n<test:think>Some ",
+            "reasoning",
+            "</test:think>",
+            "Answer",
+        ]
+
+        reasoning, content = run_reasoning_extraction(parser, deltas, streaming=True)
+
+        assert reasoning == "Some reasoning"
+        assert content == "Answer"
+
     def test_streaming_no_end_token(self, test_tokenizer):
         """Test streaming when no end token is encountered."""
         parser = TestThinkingReasoningParser(test_tokenizer)

--- a/tests/reasoning/test_base_thinking_reasoning_parser.py
+++ b/tests/reasoning/test_base_thinking_reasoning_parser.py
@@ -333,6 +333,22 @@ class TestBaseThinkingReasoningParserStreaming:
         assert reasoning == "Some reasoning"
         assert content == "Answer"
 
+    def test_streaming_with_start_token_grouped_with_text(self, test_tokenizer):
+        """Grouped start-token deltas should not leak the start marker."""
+        parser = TestThinkingReasoningParser(test_tokenizer)
+
+        deltas = [
+            "<test:think>Some ",
+            "reasoning",
+            "</test:think>",
+            "Answer",
+        ]
+
+        reasoning, content = run_reasoning_extraction(parser, deltas, streaming=True)
+
+        assert reasoning == "Some reasoning"
+        assert content == "Answer"
+
     def test_streaming_no_end_token(self, test_tokenizer):
         """Test streaming when no end token is encountered."""
         parser = TestThinkingReasoningParser(test_tokenizer)

--- a/tests/reasoning/test_kimi_k2_reasoning_parser.py
+++ b/tests/reasoning/test_kimi_k2_reasoning_parser.py
@@ -153,3 +153,48 @@ def test_streaming_tool_section_ends_reasoning(kimi_k2_tokenizer):
     )
     assert isinstance(result, DeltaMessage)
     assert result.content == "<|tool_calls_section_begin|>"
+
+
+def test_streaming_same_delta_think_end_and_content(kimi_k2_tokenizer):
+    """Grouped <think>...</think> deltas should not leak the start marker."""
+    parser = KimiK2ReasoningParser(kimi_k2_tokenizer)
+
+    think_id = parser._start_token_id
+    end_think_id = parser._end_token_id
+    reasoning_ids = kimi_k2_tokenizer.encode("step one", add_special_tokens=False)
+    content_ids = kimi_k2_tokenizer.encode("answer", add_special_tokens=False)
+
+    result = parser.extract_reasoning_streaming(
+        previous_text="",
+        current_text="<think>step one</think>answer",
+        delta_text="<think>step one</think>answer",
+        previous_token_ids=[],
+        current_token_ids=[think_id, *reasoning_ids, end_think_id, *content_ids],
+        delta_token_ids=[think_id, *reasoning_ids, end_think_id, *content_ids],
+    )
+
+    assert isinstance(result, DeltaMessage)
+    assert result.reasoning == "step one"
+    assert result.content == "answer"
+
+
+def test_streaming_same_delta_think_and_tool_section(kimi_k2_tokenizer):
+    """Grouped <think>...tool-section deltas should not leak the start marker."""
+    parser = KimiK2ReasoningParser(kimi_k2_tokenizer)
+
+    think_id = parser._start_token_id
+    tool_begin_id = parser._tool_section_start_token_id
+    reasoning_ids = kimi_k2_tokenizer.encode("step one", add_special_tokens=False)
+
+    result = parser.extract_reasoning_streaming(
+        previous_text="",
+        current_text="<think>step one<|tool_calls_section_begin|>",
+        delta_text="<think>step one<|tool_calls_section_begin|>",
+        previous_token_ids=[],
+        current_token_ids=[think_id, *reasoning_ids, tool_begin_id],
+        delta_token_ids=[think_id, *reasoning_ids, tool_begin_id],
+    )
+
+    assert isinstance(result, DeltaMessage)
+    assert result.reasoning == "step one"
+    assert result.content == "<|tool_calls_section_begin|>"

--- a/tests/reasoning/test_kimi_k2_reasoning_parser.py
+++ b/tests/reasoning/test_kimi_k2_reasoning_parser.py
@@ -178,6 +178,43 @@ def test_streaming_same_delta_think_end_and_content(kimi_k2_tokenizer):
     assert result.content == "answer"
 
 
+def test_streaming_same_delta_with_prefix_before_think(kimi_k2_tokenizer):
+    """Prefixes before <think> stay in reasoning while the tag is removed."""
+    parser = KimiK2ReasoningParser(kimi_k2_tokenizer)
+
+    prefix = "lead "
+    think_id = parser._start_token_id
+    end_think_id = parser._end_token_id
+    prefix_ids = kimi_k2_tokenizer.encode(prefix, add_special_tokens=False)
+    reasoning_ids = kimi_k2_tokenizer.encode("step one", add_special_tokens=False)
+    content_ids = kimi_k2_tokenizer.encode("answer", add_special_tokens=False)
+
+    result = parser.extract_reasoning_streaming(
+        previous_text="",
+        current_text=f"{prefix}<think>step one</think>answer",
+        delta_text=f"{prefix}<think>step one</think>answer",
+        previous_token_ids=[],
+        current_token_ids=[
+            *prefix_ids,
+            think_id,
+            *reasoning_ids,
+            end_think_id,
+            *content_ids,
+        ],
+        delta_token_ids=[
+            *prefix_ids,
+            think_id,
+            *reasoning_ids,
+            end_think_id,
+            *content_ids,
+        ],
+    )
+
+    assert isinstance(result, DeltaMessage)
+    assert result.reasoning == "lead step one"
+    assert result.content == "answer"
+
+
 def test_streaming_same_delta_think_and_tool_section(kimi_k2_tokenizer):
     """Grouped <think>...tool-section deltas should not leak the start marker."""
     parser = KimiK2ReasoningParser(kimi_k2_tokenizer)

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -148,9 +148,12 @@ class BaseThinkingReasoningParser(ReasoningParser):
                 )
             else:
                 # start token in delta, no end token in delta,
-                # reasoning content continues. Strip the leading start token when
-                # it is grouped with reasoning text in the same delta.
-                return DeltaMessage(reasoning=delta_text.removeprefix(self.start_token))
+                # reasoning content continues. Match the non-streaming parser by
+                # dropping any prefix before the start token along with the tag.
+                delta_parts = delta_text.partition(self.start_token)
+                return DeltaMessage(
+                    reasoning=delta_parts[2] if delta_parts[1] else delta_text
+                )
         else:
             # not find thinking start token
             return DeltaMessage(content=delta_text)

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -148,8 +148,9 @@ class BaseThinkingReasoningParser(ReasoningParser):
                 )
             else:
                 # start token in delta, no end token in delta,
-                # reasoning content continues
-                return DeltaMessage(reasoning=delta_text)
+                # reasoning content continues. Strip the leading start token when
+                # it is grouped with reasoning text in the same delta.
+                return DeltaMessage(reasoning=delta_text.removeprefix(self.start_token))
         else:
             # not find thinking start token
             return DeltaMessage(content=delta_text)

--- a/vllm/reasoning/kimi_k2_reasoning_parser.py
+++ b/vllm/reasoning/kimi_k2_reasoning_parser.py
@@ -213,7 +213,7 @@ class KimiK2ReasoningParser(ReasoningParser):
             return None
 
         delta_reasoning = (
-            delta_text.removeprefix(self._start_token)
+            delta_text.replace(self._start_token, "", 1)
             if (
                 self._start_token_id in delta_token_ids
                 and self._start_token_id not in previous_token_ids

--- a/vllm/reasoning/kimi_k2_reasoning_parser.py
+++ b/vllm/reasoning/kimi_k2_reasoning_parser.py
@@ -212,19 +212,28 @@ class KimiK2ReasoningParser(ReasoningParser):
         ]:
             return None
 
+        delta_reasoning = (
+            delta_text.removeprefix(self._start_token)
+            if (
+                self._start_token_id in delta_token_ids
+                and self._start_token_id not in previous_token_ids
+            )
+            else delta_text
+        )
+
         if self._end_token_id in delta_token_ids:
-            end_index = delta_text.find(self._end_token)
-            reasoning = delta_text[:end_index]
-            content = delta_text[end_index + len(self._end_token) :]
+            end_index = delta_reasoning.find(self._end_token)
+            reasoning = delta_reasoning[:end_index]
+            content = delta_reasoning[end_index + len(self._end_token) :]
             return DeltaMessage(
                 reasoning=reasoning, content=content if content else None
             )
 
         if self._tool_section_start_token_id in delta_token_ids:
-            tool_index = delta_text.find(self._tool_section_start_token)
-            reasoning = delta_text[:tool_index]
-            content = delta_text[tool_index:]
+            tool_index = delta_reasoning.find(self._tool_section_start_token)
+            reasoning = delta_reasoning[:tool_index]
+            content = delta_reasoning[tool_index:]
             return DeltaMessage(reasoning=reasoning, content=content)
 
         # still reasoning (no end token)
-        return DeltaMessage(reasoning=delta_text)
+        return DeltaMessage(reasoning=delta_reasoning)


### PR DESCRIPTION
## Summary

Fix streaming reasoning parsing when the thinking start marker is grouped into the same delta as reasoning text, including prefixed same-delta cases.

- Strip grouped start markers in `BaseThinkingReasoningParser` before emitting reasoning text, matching the non-streaming `partition` behavior.
- Apply the same normalization in `KimiK2ReasoningParser` before splitting on `</think>` or `<|tool_calls_section_begin|>`, while preserving any implicit reasoning prefix before `<think>`.
- Add regression tests for grouped start-token streaming cases, including prefixed deltas and Kimi same-delta end/content and tool-section transitions.

## Why this is not a duplicate

- Not duplicating #39044. That PR fixes end-token / buffered stop-sequence desync; this PR fixes start-token leakage when `<think>` and reasoning text are grouped into one streaming delta.
- Not duplicating #37384. That PR rewrites the Kimi-K2.5 tool parser; this change is in the reasoning parsers and covers grouped start markers before tool-section routing.

## Test plan

- `/home/wuyingjun/llm/vllm/.venv/bin/python -m pytest -q tests/reasoning/test_base_thinking_reasoning_parser.py tests/reasoning/test_kimi_k2_reasoning_parser.py`
  - Result: `37 passed`
- `/home/wuyingjun/llm/vllm/.venv/bin/pre-commit run --files vllm/reasoning/basic_parsers.py vllm/reasoning/kimi_k2_reasoning_parser.py tests/reasoning/test_base_thinking_reasoning_parser.py tests/reasoning/test_kimi_k2_reasoning_parser.py`
  - Result: passed
- Local GPU OpenAI server smoke test using `/home/wuyingjun/code/model/Qwen3-0.6B`
  - Result: server started successfully, emitted streaming reasoning chunks, and returned final content `1 + 1 = 2.`

## AI assistance

This PR was prepared with AI assistance. I reviewed the diff and ran the validation steps above.
