### PR TITLE
[Bugfix][Reasoning] Handle buffered Step3 end-token deltas

### DIFF
--- a/tests/reasoning/test_step3_reasoning_parser.py
+++ b/tests/reasoning/test_step3_reasoning_parser.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import regex as re
+
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+from vllm.reasoning import ReasoningParserManager
+
+
+class FakeStep3Tokenizer:
+    def __init__(self):
+        self._vocab = {
+            "</think>": 1,
+            "answer": 2,
+            "step one": 3,
+        }
+        self._pattern = re.compile(r"(</think>)")
+
+    def get_vocab(self) -> dict[str, int]:
+        return self._vocab
+
+    def tokenize(self, text: str) -> list[str]:
+        tokens: list[str] = []
+        for part in self._pattern.split(text):
+            if part:
+                tokens.append(part)
+        return tokens
+
+    def convert_tokens_to_string(self, tokens: list[str]) -> str:
+        return "".join(tokens)
+
+
+def test_step3_streaming_waits_for_buffered_end_token_text():
+    parser_cls = ReasoningParserManager.get_reasoning_parser("step3")
+    parser = parser_cls(FakeStep3Tokenizer())
+
+    result = parser.extract_reasoning_streaming(
+        previous_text="step one",
+        current_text="step one",
+        delta_text="",
+        previous_token_ids=[3],
+        current_token_ids=[3, parser.think_end_token_id],
+        delta_token_ids=[parser.think_end_token_id],
+    )
+
+    assert result is None
+
+
+def test_step3_streaming_splits_when_buffered_end_token_text_flushes():
+    parser_cls = ReasoningParserManager.get_reasoning_parser("step3")
+    parser = parser_cls(FakeStep3Tokenizer())
+
+    result = parser.extract_reasoning_streaming(
+        previous_text="step one",
+        current_text="step one</think>answer",
+        delta_text="</think>answer",
+        previous_token_ids=[3, parser.think_end_token_id],
+        current_token_ids=[3, parser.think_end_token_id, 2],
+        delta_token_ids=[2],
+    )
+
+    assert isinstance(result, DeltaMessage)
+    assert result.reasoning == ""
+    assert result.content == "answer"

--- a/vllm/reasoning/step3_reasoning_parser.py
+++ b/vllm/reasoning/step3_reasoning_parser.py
@@ -68,8 +68,9 @@ class Step3ReasoningParser(ReasoningParser):
         if len(delta_token_ids) == 1 and delta_token_ids[0] == self.think_end_token_id:
             return None
 
-        if self.think_end_token_id in delta_token_ids:
-            # </think> in delta, extract reasoning content and remaining content
+        if self.think_end_token in delta_text:
+            # Split based on visible text first. With buffered stop strings,
+            # the end-token ID may arrive before the literal `</think>` text.
             end_index = delta_text.find(self.think_end_token)
             reasoning = delta_text[:end_index]
             content = delta_text[end_index + len(self.think_end_token) :]
@@ -77,6 +78,10 @@ class Step3ReasoningParser(ReasoningParser):
                 reasoning=reasoning,
                 content=content if content else None,
             )
+        elif self.think_end_token_id in delta_token_ids:
+            # The end-token ID arrived but its text has not been flushed yet.
+            # Wait until `</think>` becomes visible so we can split correctly.
+            return None
         elif self.think_end_token_id in previous_token_ids:
             # </think> already seen in previous text, everything is content
             return DeltaMessage(content=delta_text)


### PR DESCRIPTION
## Summary

Fix `Step3ReasoningParser` streaming extraction when the `</think>` token ID arrives before the literal `</think>` text is flushed into `delta_text`.

- Split on visible `</think>` text first when it is present in the delta.
- Return `None` when only the end-token ID has arrived and the text is still buffered.
- Add focused regression tests for the buffered two-step streaming case.

## Why this is not a duplicate

- Not duplicating #39044. That PR applies the buffered end-token fix pattern to `BaseThinkingReasoningParser`, `DeepSeekR1ReasoningParser`, `Ernie45ReasoningParser`, and `Step3p5ReasoningParser`, but it does not touch `Step3ReasoningParser`.
- I did not find any open PR already modifying `vllm/reasoning/step3_reasoning_parser.py` for this issue.

## Test plan

- `env -u https_proxy -u http_proxy -u all_proxy /home/wuyingjun/llm/vllm/.venv/bin/python -m pytest -q tests/reasoning/test_step3_reasoning_parser.py`
  - Result: `2 passed`
- `/home/wuyingjun/llm/vllm/.venv/bin/pre-commit run --files vllm/reasoning/step3_reasoning_parser.py tests/reasoning/test_step3_reasoning_parser.py`
  - Result: passed
- Local GPU OpenAI server smoke test using `/home/wuyingjun/code/model/Qwen3-0.6B` with `--reasoning-parser step3`
  - Result: server started successfully, streamed reasoning deltas and completed a chat response end-to-end

## AI assistance

This PR was prepared with AI assistance. I reviewed the diff and ran the validation steps above.
