### PR TITLE
[ROCm] Enable building MoRI with Broadcom bnxt (Thor2) NIC stack

### DIFF
--- a/docker/Dockerfile.rocm
+++ b/docker/Dockerfile.rocm
@@ -3,6 +3,13 @@ ARG REMOTE_VLLM="0"
 ARG COMMON_WORKDIR=/app
 ARG BASE_IMAGE=rocm/vllm-dev:base
 
+# AMD NIC backend
+ARG NIC_BACKEND=none
+# AMD AINIC apt repo settings
+ARG AINIC_VERSION=1.117.5
+ARG UBUNTU_CODENAME=jammy
+ARG RDMA_CORE_VERSION=50.0
+
 # Sccache configuration (only used in release pipeline)
 ARG USE_SCCACHE
 ARG SCCACHE_DOWNLOAD_URL
@@ -12,6 +19,8 @@ ARG SCCACHE_REGION_NAME=us-west-2
 ARG SCCACHE_S3_NO_CREDENTIALS=0
 
 FROM ${BASE_IMAGE} AS base
+
+
 
 ARG ARG_PYTORCH_ROCM_ARCH
 ENV PYTORCH_ROCM_ARCH=${ARG_PYTORCH_ROCM_ARCH:-${PYTORCH_ROCM_ARCH}}
@@ -216,6 +225,86 @@ RUN git clone ${DEEPEP_REPO} \
  && git checkout ${DEEPEP_BRANCH} \
  && python3 setup.py --variant rocm --nic ${DEEPEP_NIC} bdist_wheel --dist-dir=/app/deep_install
 
+# MoRI runtime dependencies live in Dockerfile.rocm so NIC backend changes do
+# not force users to rebuild the long-lived Dockerfile.rocm_base image.
+FROM base AS mori_base
+ARG NIC_BACKEND
+ARG AINIC_VERSION
+ARG UBUNTU_CODENAME
+ARG RDMA_CORE_VERSION
+RUN /bin/bash -lc 'set -euo pipefail; \
+ echo "[MORI] Install MoRI proxy deps"; \
+ pip install --quiet --ignore-installed blinker && \
+ pip install --quiet quart msgpack aiohttp pyzmq; \
+ echo "[MORI] NIC_BACKEND=${NIC_BACKEND}"; \
+  \
+  # NIC backend deps — mori auto-detects NIC at runtime (MORI_DEVICE_NIC env var override).
+  # Only vendor packages are installed here for dlopen (e.g. libionic.so); no compile-time flags needed.
+  case "${NIC_BACKEND}" in \
+    # default: mlx5
+    none) \
+      ;; \
+    # Add Broadcom bnxt packages/repos here later.
+      bnxt) \
+      # Build rdma-core from source — Ubuntu 22.04 ships v39, but BCM57608 (Thor2) support
+      # requires v50+: https://github.com/linux-rdma/rdma-core/commit/cef835de7f4764e80d57d82de05cd47263f06c1a
+      # Source: https://github.com/linux-rdma/rdma-core (GPL-2.0 / MIT / BSD)
+      apt-get update -y && apt-get install -y --no-install-recommends \
+        cmake \
+        ninja-build \
+        libudev-dev \
+        libnl-3-dev \
+        libnl-route-3-dev \
+        pkg-config \
+        python3-docutils \
+        pandoc \
+        ibverbs-utils \
+      && rm -rf /var/lib/apt/lists/*; \
+      git clone --branch v${RDMA_CORE_VERSION} --depth 1 \
+        https://github.com/linux-rdma/rdma-core.git /tmp/rdma-core; \
+      cmake -GNinja \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DNO_MAN_PAGES=1 \
+        -DNO_PYVERBS=1 \
+        -B/tmp/rdma-core/build \
+        /tmp/rdma-core; \
+      ninja -C /tmp/rdma-core/build install; \
+      ldconfig; \
+      rm -rf /tmp/rdma-core; \
+      ;; \
+    *) \
+    # echo "[MORI] Add Broadcom bnxt packages/repos here later."; \
+      echo "ERROR: unknown NIC_BACKEND=${NIC_BACKEND}. Use one of: none, bnxt, ainic"; \
+      exit 2; \
+      ;; \
+  esac;'
+      bnxt | ainic) \
+       ;; \
+    *) \
+      echo "ERROR: unknown NIC_BACKEND=${NIC_BACKEND}. Use one of: none, bnxt, ainic"; \
+      exit 2; \
+      ;; \
+  esac; \
+  apt-get update -y && apt-get install -y --no-install-recommends \
+    build-essential \
+    g++ \
+    jq \
+    libopenmpi-dev \
+    libpci-dev \
+    initramfs-tools \
+  && rm -rf /var/lib/apt/lists/*; \
+  case "${NIC_BACKEND}" in \
+    bnxt) \
+      export USE_IONIC="OFF"; \
+      export USE_BNXT="ON"; \
+      ;; \
+    ainic) \
+      export USE_IONIC="ON"; \
+      export USE_BNXT="OFF"; \
+      ;; \
+  esac; \
+
 # -----------------------
 # vLLM wheel release build stage (for building distributable wheels)
 # This stage pins dependencies to custom ROCm wheel versions and handles version detection
@@ -294,7 +383,7 @@ COPY --from=build_vllm_wheel_release ${COMMON_WORKDIR}/vllm/vllm/v1 /vllm_v1
 
 # -----------------------
 # Test vLLM image
-FROM base AS test
+FROM base AS mori_base
 
 RUN python3 -m pip install --upgrade pip && rm -rf /var/lib/apt/lists/*
 
@@ -385,7 +474,7 @@ RUN printf '%s\n' \
 
 # -----------------------
 # Final vLLM image
-FROM base AS final
+FROM mori_base AS final
 
 RUN python3 -m pip install --upgrade pip && rm -rf /var/lib/apt/lists/*
 
@@ -422,6 +511,9 @@ RUN --mount=type=bind,from=export_vllm,src=/,target=/install \
 
 ARG COMMON_WORKDIR
 ARG BASE_IMAGE
+ARG NIC_BACKEND
+ARG AINIC_VERSION
+ARG RDMA_CORE_VERSION
 
 # Copy over the benchmark scripts as well
 COPY --from=export_vllm /benchmarks ${COMMON_WORKDIR}/vllm/benchmarks
@@ -439,7 +531,10 @@ ENV HIP_FORCE_DEV_KERNARG=1
 # Workaround for ROCm profiler limits
 RUN echo "ROCTRACER_MAX_EVENTS=10000000" > ${COMMON_WORKDIR}/libkineto.conf
 ENV KINETO_CONFIG="${COMMON_WORKDIR}/libkineto.conf"
-RUN echo "VLLM_BASE_IMAGE=${BASE_IMAGE}" >> ${COMMON_WORKDIR}/versions.txt
+RUN echo "VLLM_BASE_IMAGE=${BASE_IMAGE}" >> ${COMMON_WORKDIR}/versions.txt \
+    && echo "MORI_NIC_BACKEND=${NIC_BACKEND}" >> ${COMMON_WORKDIR}/versions.txt \
+    && echo "AINIC_VERSION=${AINIC_VERSION}" >> ${COMMON_WORKDIR}/versions.txt \
+    && echo "RDMA_CORE_VERSION=${RDMA_CORE_VERSION}" >> ${COMMON_WORKDIR}/versions.txt
 
 CMD ["/bin/bash"]
 

--- a/docker/Dockerfile.rocm_base
+++ b/docker/Dockerfile.rocm_base
@@ -11,7 +11,7 @@ ARG FA_BRANCH="0e60e394"
 ARG FA_REPO="https://github.com/Dao-AILab/flash-attention.git"
 ARG AITER_BRANCH="v0.1.10.post3"
 ARG AITER_REPO="https://github.com/ROCm/aiter.git"
-ARG MORI_BRANCH="2d02c6a9"
+ARG MORI_BRANCH="v1.1.0"
 ARG MORI_REPO="https://github.com/ROCm/mori.git"
 
 # Sccache configuration (only used in release pipeline)


### PR DESCRIPTION
## Summary
Updates the ROCm image build (docker/Dockerfile.rocm and docker/Dockerfile.rocm_base) so MORI can be built with an optional AMD BNXT (broadcom)" NIC stack, following the same approach as SGLang’s [docker/rocm.Dockerfile](https://github.com/sgl-project/sglang/blob/main/docker/rocm.Dockerfile#L366) MORI section.

Co-authored with: @ichbinblau @simondanielsson

This PR adds support for installing Thor2 drivers and userspace libraries directly into Dockerfile.rocm. This way we can build images vllm/vllm-openai-rocm:nightly-<commit-id>-bxnt that can run MoRI-IO on Thor2 devices:

## Usage (build vLLM ROCm image with Broadcom Thor2 bnxt NIC backend):
 docker build -f docker/Dockerfile.rocm \
 --build-arg NIC_BACKEND=bnxt \
  -t vllm/vllm-openai-rocm:nightly-<commit-id>-bxnt .


## Motivation
Upgrade MoRI to v1.1.0
Support NIC_BACKEND=bnxt when building the MORI wheel so users targeting Thor NICs get libionic-dev / ionic-common.
Install common MoriIO proxy Python packages in the dev base image for disaggregated / KV workflows that use the proxy.

## How to build
  docker build -f docker/Dockerfile.rocm \
  --build-arg NIC_BACKEND=bnxt \
 -t vllm/vllm-openai-rocm:nightly-<commit-id>-bxnt .
            .

## Test Plan
Build image without errors:
docker build \
    --build-arg NIC_BACKEND=bnxt \
    --build-arg RDMA_CORE_VERSION=50.0 \
    -f docker/Dockerfile.rocm .

1.docker build -f docker/Dockerfile.rocm .  (default NIC_BACKEND=none) completes.
2.docker build --build-arg NIC_BACKEND=bnxt -f docker/Dockerfile.rocm . completes where AMD  Thor NIC repo is reachable.


