### PR TITLE
[Doc] Update ViT CUDA graph doc for mixed (image+video) inputs

### DIFF
--- a/docs/design/cuda_graphs_multimodal.md
+++ b/docs/design/cuda_graphs_multimodal.md
@@ -52,14 +52,14 @@ For each graph replay:
 
 When `mm_encoder_tp_mode="data"`, the manager distributes images across TP ranks using load-balanced assignment via `get_load_balance_assignment`, executes locally on each rank, then gathers results back in the original order via `tensor_model_parallel_all_gather`.
 
-### Video inference support (experimental)
+### Video inference support
 
 Following <https://github.com/vllm-project/vllm/pull/35963> (ViT full CUDA graph support for image inference), <https://github.com/vllm-project/vllm/pull/38061> extends the encoder CUDA graph framework to support video inference for Qwen3-VL. Previously, the CUDA graph capture/replay path only handled image inputs (`pixel_values` + `image_grid_thw`). Video inputs use different keys (`pixel_values_videos` + `video_grid_thw`) and require larger `cu_seqlens` buffers because each video item contributes multiple frames (`T` attention sequences). This PR generalizes the protocol and manager to handle both modalities through a single shared graph manager.
 
 !!! note
     Video CUDA graphs are automatically disabled when EVS (Efficient Video Sampling) pruning is enabled, since EVS makes the token count data-dependent and incompatible with CUDA graph capture.
 
-    Currently, we only support image-only or video-only inputs when enabling CUDA graph, mixed inputs (image + video) are not supported yet (we will work on it in the near future). Thus, it's recommended to turn off the image modality by `--limit-mm-per-prompt '{"image": 0}'` for video-only inputs.
+    Mixed inputs (image+video) per prompt are also supported now.
 
 ## Model integration via `SupportsEncoderCudaGraph`
 
@@ -142,7 +142,6 @@ Enable encoder CUDA Graphs via `compilation_config`:
 
 ```bash
 vllm serve Qwen/Qwen3-VL-32B \
-  --limit-mm-per-prompt '{"image": 0}' \
   --compilation-config '{"cudagraph_mm_encoder": true}'
 ```
 
@@ -150,7 +149,6 @@ With explicit budgets:
 
 ```bash
 vllm serve Qwen/Qwen3-VL-32B \
-  --limit-mm-per-prompt '{"image": 0}' \
   --compilation-config '{"cudagraph_mm_encoder": true, "encoder_cudagraph_token_budgets": [2048, 4096, 8192, 13824], "encoder_cudagraph_max_vision_items_per_batch": 8, "encoder_cudagraph_max_frames_per_batch": 64}'
 ```
 
@@ -169,7 +167,6 @@ compilation_config = {
 
 model = vllm.LLM(
     model="Qwen/Qwen3-VL-32B",
-    limit_mm_per_prompt='{"image": 0}',
     compilation_config=compilation_config,
 )
 ```


### PR DESCRIPTION
## Purpose

Following https://github.com/vllm-project/vllm/pull/35963 and https://github.com/vllm-project/vllm/pull/38061, we have supported ViT CUDA graph image/video inference for Qwen3-VL respectively. Now we have demonstrated that it's also compatible for mixed (image+video) inputs (per prompt).

Since we have grouped and batched multi-modal inputs in `_execute_mm_encoder()` through `group_and_batch_mm_kwargs()`, each call for `model.embed_multimodal()` or `encoder_cudagraph_manager.execute()` will only contain single modality.

```python
# vllm/vllm/v1/worker/gpu_model_runner.py
def _execute_mm_encoder(...):
    # ...
    for modality, num_items, mm_kwargs_batch in group_and_batch_mm_kwargs(...):
        # ...
        if enable_vit_cuda_graph:
            batch_outputs = self.encoder_cudagraph_manager.execute(mm_kwargs_batch)
        else:
            batch_outputs = model.embed_multimodal(**mm_kwargs_batch)


# vllm/vllm/multimodal/utils.py
def group_and_batch_mm_kwargs(mm_kwargs, ...):
    for modality, group in groupby(mm_kwargs, key=lambda x: x[0]):
        ...
        for num_items, mm_kwargs_batch in group_and_batch_mm_items(...):
            yield modality, num_items, mm_kwargs_batch
```

Thus, mixed inputs will be separated to different ViT processes (i.e., it's compatible for our CUDA graph implementation).

## Test Plan

Based on https://github.com/vllm-project/vllm/pull/40335.

```bash
# Pass compilation_config to EngineArgs in run_qwen3_vl()
# compilation_config={
#     "cudagraph_mm_encoder": True,
#     "encoder_cudagraph_token_budgets": [512, 1024, 1536, 2048, 2560, 3072, 3584, 4096, 4864],
#     "encoder_cudagraph_max_vision_items_per_batch": 8,
#     "encoder_cudagraph_max_frames_per_batch": 64,
# }
python examples/offline_inference/vision_language.py -m qwen3_vl --modality "image+video"
```

## Test Result

```
--------------------------------------------------
The image shows a baby girl sitting on a bed, wearing glasses and reading a book. She is focused on the book, turning the pages with her small hands. The room appears to be a bedroom, with a crib and some clothes visible in the background.

In the video, the baby girl continues to read the book, occasionally looking up and smiling. She seems to be enjoying her reading time, and her glasses add a touch of charm to her appearance. The video captures a sweet and innocent moment of a child engaging in a quiet activity.
--------------------------------------------------
The image shows a baby girl sitting on a bed, wearing glasses, and reading a book.

The video shows the same baby girl continuing to read the book, turning the pages, and occasionally looking up. She appears to be very focused on the book and is enjoying her reading time.
--------------------------------------------------
The image shows a baby girl sitting on a bed, wearing glasses, and reading a book. She is focused on the book, turning the pages with her small hands. The background includes a crib and some clothes, suggesting a cozy and comfortable setting.

In the video, the baby girl continues to read the book, occasionally looking up and smiling. She seems to be enjoying the activity and is fully engaged in the story. The video captures the innocence and curiosity of a young child exploring the world of books.
--------------------------------------------------
The image shows a baby sitting on a bed, wearing glasses, and reading a book. The baby is dressed in a light blue shirt and pink pants. The background includes a crib and some clothes on the bed.

In the video, the baby continues to read the book, turning the pages and occasionally looking up. The baby seems to be enjoying the activity and is focused on the book. The video captures the baby's concentration and curiosity as they explore the book.
--------------------------------------------------
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

