### PR TITLE
[Kernel][Bugfix] Marlin W4A16: pad sub-tile output dims on load

### DIFF
--- a/tests/kernels/quantization/test_marlin_gemm.py
+++ b/tests/kernels/quantization/test_marlin_gemm.py
@@ -17,6 +17,7 @@ from vllm.model_executor.layers.quantization.utils.int8_utils import (
     per_token_quant_int8,
 )
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
+    GPTQ_MARLIN_MIN_THREAD_N,
     marlin_make_empty_g_idx,
     marlin_make_workspace_new,
     marlin_permute_bias,
@@ -617,4 +618,79 @@ def test_marlin_gemm_with_bias(size_m):
 
     max_diff = compute_max_diff(output, output_ref)
 
+    assert max_diff < 0.04
+
+
+@pytest.mark.skipif(
+    not is_quant_method_supported("gptq_marlin"),
+    reason="Marlin is not supported on this GPU type.",
+)
+@pytest.mark.parametrize("orig_n", [32, 48, 96])
+def test_marlin_gemm_sub_tile_n_pad(orig_n):
+    """Verify the pad-on-load strategy implemented in
+    `MarlinLinearKernel` for shapes where `size_n` is not a multiple of
+    `GPTQ_MARLIN_MIN_THREAD_N`.
+
+    The kernel pads qweight/scales/qzeros along the output dim to the
+    next tile multiple at `process_weights_after_loading` time and
+    slices the extra columns off the output in `apply_weights`. This
+    test replays that sequence directly against `ops.marlin_gemm` and
+    checks the sliced output against a reference matmul on the
+    un-padded weight.
+    """
+    quant_type = scalar_types.uint4b8
+    group_size = 128
+    size_m, size_k = 32, 1024
+
+    padded_n = (
+        (orig_n + GPTQ_MARLIN_MIN_THREAD_N - 1) // GPTQ_MARLIN_MIN_THREAD_N
+    ) * GPTQ_MARLIN_MIN_THREAD_N
+
+    a_input = rand_data((size_m, size_k))
+    b_weight = rand_data((size_k, orig_n))
+
+    # Zero-pad the weight along the output dim up to padded_n. The
+    # kernel pad lives at the pre-repack layer — padding the raw
+    # qweight with zeros and then running repack at the padded n
+    # produces a valid Marlin layout whose padded output columns
+    # decode to zero.
+    b_weight_padded = torch.nn.functional.pad(b_weight, (0, padded_n - orig_n), value=0)
+
+    w_ref_padded, marlin_q_w, marlin_s, g_idx, sort_indices, _ = marlin_quantize(
+        b_weight_padded, quant_type, group_size, False
+    )
+
+    marlin_zp = marlin_make_empty_g_idx(marlin_s.device)
+    workspace = marlin_make_workspace_new(a_input.device)
+
+    output_padded = ops.marlin_gemm(
+        a_input,
+        None,
+        marlin_q_w,
+        None,
+        marlin_s,
+        None,
+        None,
+        marlin_zp,
+        g_idx,
+        sort_indices,
+        workspace,
+        quant_type,
+        size_m,
+        padded_n,
+        size_k,
+        is_k_full=True,
+        use_atomic_add=False,
+        use_fp32_reduce=True,
+        is_zp_float=False,
+    )
+
+    # Slice back to the un-padded output — the columns Marlin wrote
+    # for the zero-weight padding are discarded.
+    output = output_padded[..., :orig_n].contiguous()
+    output_ref = torch.matmul(a_input, w_ref_padded[:, :orig_n])
+
+    torch.accelerator.synchronize()
+
+    max_diff = compute_max_diff(output, output_ref)
     assert max_diff < 0.04

--- a/vllm/model_executor/kernels/linear/mixed_precision/MPLinearKernel.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/MPLinearKernel.py
@@ -24,6 +24,12 @@ class MPLinearLayerConfig:
 
 
 class MPLinearKernel(ABC):
+    config: MPLinearLayerConfig
+    w_q_name: str
+    w_s_name: str
+    w_zp_name: str | None
+    w_gidx_name: str | None
+
     @classmethod
     @abstractmethod
     def get_min_capability(cls) -> int:

--- a/vllm/model_executor/kernels/linear/mixed_precision/marlin.py
+++ b/vllm/model_executor/kernels/linear/mixed_precision/marlin.py
@@ -2,10 +2,15 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import dataclasses
+
 import torch
+import torch.nn.functional as F
 
 from vllm import _custom_ops as ops
+from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.utils.marlin_utils import (
+    GPTQ_MARLIN_MIN_THREAD_N,
     MARLIN_SUPPORTED_GROUP_SIZES,
     apply_gptq_marlin_linear,
     check_marlin_supports_shape,
@@ -23,8 +28,11 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
 from vllm.model_executor.parameter import BasevLLMParameter, permute_param_layout_
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
+from vllm.utils.math_utils import round_up
 
 from .MPLinearKernel import MPLinearKernel, MPLinearLayerConfig
+
+logger = init_logger(__name__)
 
 
 class MarlinLinearKernel(MPLinearKernel):
@@ -54,17 +62,87 @@ class MarlinLinearKernel(MPLinearKernel):
                 f"{MARLIN_SUPPORTED_GROUP_SIZES}",
             )
 
+        # Allow shapes where out_features is not divisible by the Marlin
+        # tile (GPTQ_MARLIN_MIN_THREAD_N). We pad the weight/scales/zeros
+        # at load time inside `process_weights_after_loading` and mask the
+        # extra columns by slicing the output in `apply_weights`. The
+        # runtime cost is zero — padding is a one-time load-time operation.
+        padded_n = round_up(c.partition_weight_shape[1], GPTQ_MARLIN_MIN_THREAD_N)
         return check_marlin_supports_shape(
-            c.partition_weight_shape[1],  # out_features
+            padded_n,  # out_features (possibly padded up to tile multiple)
             c.partition_weight_shape[0],  # in_features
             c.full_weight_shape[0],  # in_features
             c.group_size,
+        )
+
+    def _maybe_pad_n(self, layer: torch.nn.Module) -> None:
+        """Pad weight / scales / zeros / bias along the output dim to the
+        next multiple of GPTQ_MARLIN_MIN_THREAD_N so Marlin can run on
+        shards whose per-rank out-dim is not tile-aligned (e.g. the
+        n=32 shard produced by Intel AutoRound Int4 on TP=2).
+
+        Stores `layer._marlin_orig_n` for later output slicing and
+        replaces `self.config` with a new config whose
+        partition_weight_shape reports the padded out-dim so that
+        downstream transforms (repack, permute_scales, marlin_zero_points)
+        see the padded size.
+        """
+        c = self.config
+        orig_n = c.partition_weight_shape[1]
+        padded_n = round_up(orig_n, GPTQ_MARLIN_MIN_THREAD_N)
+        layer._marlin_orig_n = orig_n
+        if padded_n == orig_n:
+            return
+
+        pad = padded_n - orig_n
+        pack_factor = 32 // c.weight_type.size_bits
+
+        # qweight: [k/pack, n] int32, output_dim=1, unpacked along dim 1.
+        # Pad with zeros → those output columns decode to weight 0.
+        q = getattr(layer, self.w_q_name)
+        q_padded = F.pad(q.data, (0, pad), value=0)
+        q.data = q_padded
+
+        # scales: [num_groups, n], output_dim=1. Pad with zeros
+        # (values don't matter; the padded weight columns are zero).
+        s = getattr(layer, self.w_s_name)
+        s_padded = F.pad(s.data, (0, pad), value=0)
+        s.data = s_padded
+
+        # qzeros: [num_groups, n/pack] int32, packed_dim=1. Pad by
+        # pad/pack extra packed columns. Pad value 0 is safe (used only
+        # for padded weight columns, which are already zero).
+        if c.zero_points and self.w_zp_name is not None:
+            zp = getattr(layer, self.w_zp_name, None)
+            if zp is not None:
+                zp_pad_cols = pad // pack_factor
+                if zp_pad_cols > 0:
+                    zp.data = F.pad(zp.data, (0, zp_pad_cols), value=0)
+
+        # bias: [n] → [padded_n]
+        if hasattr(layer, "bias") and layer.bias is not None:
+            layer.bias.data = F.pad(layer.bias.data, (0, pad), value=0)
+
+        # Swap config so that all downstream transforms use padded n.
+        self.config = dataclasses.replace(
+            c,
+            partition_weight_shape=(c.partition_weight_shape[0], padded_n),
+        )
+        logger.info_once(
+            "Marlin: padded output dim %d → %d to satisfy tile_n=%d",
+            orig_n,
+            padded_n,
+            GPTQ_MARLIN_MIN_THREAD_N,
         )
 
     # note assumes that
     #  `weight_packed` is: {input_dim = 0, output_dim = 1, packed_dim = 0}
     #  `weight_scale` is: {input_dim = 0, output_dim = 1}
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        # Pad out-dim up to the Marlin tile multiple before any repack /
+        # permute / zero-point processing touches the tensors.
+        self._maybe_pad_n(layer)
+
         device = getattr(layer, self.w_q_name).device
         c = self.config
         is_a_8bit = c.act_type is not None and c.act_type.itemsize == 1
@@ -182,7 +260,15 @@ class MarlinLinearKernel(MPLinearKernel):
         # `process_weights_after_loading` will ensure w_zp and w_gidx are not
         #  None for marlin
 
-        return apply_gptq_marlin_linear(
+        padded_n = c.partition_weight_shape[1]
+        orig_n = getattr(layer, "_marlin_orig_n", padded_n)
+
+        # If caller supplied a bias sized for the unpadded output, pad it
+        # here so the fused bias-add inside marlin_gemm sees padded_n.
+        if bias is not None and bias.shape[-1] != padded_n:
+            bias = F.pad(bias, (0, padded_n - bias.shape[-1]), value=0)
+
+        out = apply_gptq_marlin_linear(
             input=x,
             weight=w_q,
             weight_scale=w_s,
@@ -192,9 +278,14 @@ class MarlinLinearKernel(MPLinearKernel):
             workspace=self.workspace,
             wtype=c.weight_type,
             input_size_per_partition=c.partition_weight_shape[0],
-            output_size_per_partition=c.partition_weight_shape[1],
+            output_size_per_partition=padded_n,
             is_k_full=self.is_k_full,
             input_global_scale=getattr(layer, "input_global_scale", None),
             bias=bias,
             input_dtype=c.act_type,
         )
+
+        # Discard the extra columns produced by the padded matmul.
+        if orig_n != padded_n:
+            out = out[..., :orig_n].contiguous()
+        return out


### PR DESCRIPTION
## Summary

The Marlin W4A16 kernel requires each per-rank output dim to be a multiple of
`GPTQ_MARLIN_MIN_THREAD_N = 64`. When a packed layer's natural output dim
shards below 64 under TP (e.g. Qwen3.5 `GatedDeltaNet.in_proj_ba` with
`num_v_heads=64` at TP>=2, or `Intel/Qwen3.6-35B-A3B-int4-AutoRound` whose
packing yields an n=32 shard at TP=2), load fails with
`size_n=... not divisible by tile_n_size=64`. On Ampere there is no stock
fallback (Machete / CutlassW4A8 are sm_90+, AllSpark requires
`group_size=-1`, etc.), so TP=2 is effectively unusable for these quants.

This PR adds a generic pad-on-load path inside `MarlinLinearKernel`:

- **`can_implement`** validates the shape check against `round_up(n, 64)`.
- **`process_weights_after_loading`** pads qweight, scales, qzeros and bias
  along the output dim to the next tile multiple with zeros, swaps
  `self.config.partition_weight_shape` to the padded value so downstream
  repack / permute / zero-point transforms see the padded size, and stores
  the original n on the layer for later slicing.
- **`apply_weights`** calls `marlin_gemm` at `padded_n` and slices the
  extra columns off the output.

Runtime cost is zero — padding happens once at load. VRAM cost is a few
KB per affected layer (zero-filled padding along output dim). When the
shard is already tile-aligned, `_maybe_pad_n` returns early with
`padded_n == orig_n` and the path is a no-op.

Also adds explicit attribute annotations to `MPLinearKernel` so mypy can
type-check `self.config` / `self.w_*_name` accesses the new code introduces
(also clears two pre-existing `has-type` errors in `marlin.py`).

## Why not duplicating #36329?

| | #36329 (sonusflow) | This PR |
|---|---|---|
| Scope | Qwen3.5 GDN `in_proj_ba` only | Any layer, any Marlin-backed quant |
| Approach | Swap `MergedColumnParallelLinear` -> `ReplicatedLinear` | Pad inside the kernel itself |
| Future models with the same bug | Still need a per-model PR | Auto-handled |
| VRAM cost per affected layer | Full replication (~MB) | Zero-padded columns (~KB) |

These are complementary — #36329 removes a specific Marlin call site;
this PR makes the remaining Marlin call sites tolerate sub-tile n.

Closes #35924 (generically, not Qwen3.5-GDN-specific)
Related: #40354

## Testing

- `test_marlin_gemm_sub_tile_n_pad[{32,48,96}]` (new) in
  `tests/kernels/quantization/test_marlin_gemm.py` exercises the
  pad-before-repack -> marlin_gemm -> slice sequence and checks numerical
  parity against a reference matmul on the un-padded weight. All three
  parametrizations pass on RTX 3090 (sm_86, CUDA 12.9, nightly base).
- End-to-end on 2x RTX 3090 with `Intel/Qwen3.6-35B-A3B-int4-AutoRound`
  at TP=2: model loads, produces coherent output on OpenAI-compat
  `/v1/completions`, benches at **170.5 tok/s** (up from 156 tok/s at TP=1
  on the same hardware, and 137 tok/s `palmfuture/Qwen3.6-35B-A3B-GPTQ-Int4`
  TP=2 baseline).
- Regression on `Intel/gemma-4-31B-it-int4-AutoRound` at TP=2
  (tile-aligned shards): no padding log fires, 60.4 tok/s vs 61.0 on
  `:latest` — within noise.
- `pre-commit run --files` clean (ruff, ruff format, typos, mypy, SPDX, ...).

## Test plan

- [x] `pytest tests/kernels/quantization/test_marlin_gemm.py::test_marlin_gemm_sub_tile_n_pad -v`
- [x] End-to-end TP=2 smoke bench on an AutoRound n=32-shard model
- [x] Regression bench on a tile-aligned AutoRound model (fast path untouched)
- [ ] CI tests (needs `ready` label from a maintainer)

AI assistance (Claude Opus 4.7) was used to draft and verify the patch;
the submitter reviewed every changed line.