### PR TITLE
[ROCm] Pass moe_buf to AITER to eliminate MoE output copy

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -120,6 +120,7 @@ def _rocm_aiter_fused_moe_impl(
     intermediate_pad: int = 0,
     bias1: torch.Tensor | None = None,
     bias2: torch.Tensor | None = None,
+    moe_buf: torch.Tensor | None = None,
 ) -> torch.Tensor:
     from aiter import ActivationType, QuantType
     from aiter.fused_moe import fused_moe
@@ -147,6 +148,7 @@ def _rocm_aiter_fused_moe_impl(
         intermediate_pad=intermediate_pad,
         bias1=bias1,
         bias2=bias2,
+        moe_buf=moe_buf,
     )
 
 
@@ -170,7 +172,10 @@ def _rocm_aiter_fused_moe_fake(
     intermediate_pad: int = 0,
     bias1: torch.Tensor | None = None,
     bias2: torch.Tensor | None = None,
+    moe_buf: torch.Tensor | None = None,
 ) -> torch.Tensor:
+    if moe_buf is not None:
+        return torch.empty_like(moe_buf)
     if output_dtype is not None:
         return torch.empty_like(hidden_states, dtype=output_dtype)
     return torch.empty_like(hidden_states)
@@ -1318,7 +1323,7 @@ class rocm_aiter_ops:
             direct_register_custom_op(
                 op_name="rocm_aiter_fused_moe",
                 op_func=_rocm_aiter_fused_moe_impl,
-                mutates_args=[],
+                mutates_args=["moe_buf"],
                 fake_impl=_rocm_aiter_fused_moe_fake,
                 dispatch_key=current_platform.dispatch_key,
             )
@@ -1625,6 +1630,7 @@ class rocm_aiter_ops:
         intermediate_pad: int = 0,
         bias1: torch.Tensor | None = None,
         bias2: torch.Tensor | None = None,
+        moe_buf: torch.Tensor | None = None,
     ) -> torch.Tensor:
         return torch.ops.vllm.rocm_aiter_fused_moe(
             hidden_states,
@@ -1646,6 +1652,7 @@ class rocm_aiter_ops:
             intermediate_pad,
             bias1,
             bias2,
+            moe_buf,
         )
 
     @staticmethod

--- a/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
@@ -195,6 +195,7 @@ def rocm_aiter_fused_experts(
     a1q_scale: torch.Tensor | None = None,
     num_local_tokens: torch.Tensor | None = None,
     output_dtype: torch.dtype | None = None,
+    moe_buf: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """ROCm AITER fused MoE expert computation."""
     if quant_config is None:
@@ -309,6 +310,7 @@ def rocm_aiter_fused_experts(
             intermediate_pad=intermediate_pad,
             bias1=quant_config.w1_bias if quant_config.use_mxfp4_w4a16 else None,
             bias2=quant_config.w2_bias if quant_config.use_mxfp4_w4a16 else None,
+            moe_buf=moe_buf,
         )
 
 
@@ -422,7 +424,7 @@ class AiterExperts(mk.FusedMoEExpertsModular):
         else:
             num_local_tokens = None
 
-        result = rocm_aiter_fused_experts(
+        rocm_aiter_fused_experts(
             hidden_states=hidden_states,
             w1=w1,
             w2=w2,
@@ -436,5 +438,5 @@ class AiterExperts(mk.FusedMoEExpertsModular):
             a1q_scale=a1q_scale,
             num_local_tokens=num_local_tokens,
             output_dtype=output.dtype,
+            moe_buf=output,
         )
-        output.copy_(result)


### PR DESCRIPTION
## Summary

- Thread `moe_buf` through the vLLM AITER fused MoE custom op so the kernel writes directly into the caller's pre-allocated output buffer
- Eliminates a device-to-device copy of the full MoE output (`output.copy_(result)`) on every forward pass
- Backward compatible: when `moe_buf=None` (older AITER without ROCm/aiter#2687), the existing internal allocation behavior is preserved

## Changes

- `vllm/_aiter_ops.py`: Add `moe_buf` parameter to impl, fake, op registration (`mutates_args`), and static method
- `vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py`: Thread `moe_buf` through `rocm_aiter_fused_experts()` and pass `output` directly in `AiterExperts.apply()`

## Test plan

- [ ] Verify coherent output with Qwen3-Next-80B-A3B-Instruct-FP8 (TP1)
- [ ] Throughput benchmark (1k/1k, c=4/16) to confirm no regression and D2D copy elimination
- [ ] GSM8K accuracy check (flex >= 0.85, strict >= 0.80)

Depends on: ROCm/aiter#2687

Co-authored-by: Tres Popp <tres.popp@amd.com>