### PR TITLE
[Bugfix][Metrics] Fix RayPrometheusMetric.labels() returning shared labeled child

### DIFF
--- a/tests/v1/metrics/test_ray_metrics.py
+++ b/tests/v1/metrics/test_ray_metrics.py
@@ -1,13 +1,21 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from unittest.mock import MagicMock
+
 import pytest
 import ray
 
 from vllm.config.model import ModelDType
 from vllm.sampling_params import SamplingParams
 from vllm.v1.engine.async_llm import AsyncEngineArgs, AsyncLLM
-from vllm.v1.metrics.ray_wrappers import RayPrometheusMetric, RayPrometheusStatLogger
+from vllm.v1.metrics.ray_wrappers import (
+    RayCounterWrapper,
+    RayGaugeWrapper,
+    RayHistogramWrapper,
+    RayPrometheusMetric,
+    RayPrometheusStatLogger,
+)
 
 MODELS = [
     "distilbert/distilgpt2",
@@ -94,3 +102,129 @@ def test_sanitized_opentelemetry_name():
 
     # Test empty string
     assert RayPrometheusMetric._get_sanitized_opentelemetry_name("") == ""
+
+
+def _install_mock_metric(wrapper: RayPrometheusMetric) -> MagicMock:
+    """Swap the wrapper's underlying Ray metric for a MagicMock while
+    preserving the real metric's ``_tag_keys`` (labels() reads them to
+    validate arity)."""
+    real_metric = wrapper.metric
+    mock = MagicMock()
+    mock._tag_keys = real_metric._tag_keys
+    wrapper.metric = mock
+    return mock
+
+
+def test_ray_counter_labels_returns_independent_children():
+    """Regression test: RayCounterWrapper.labels() must return distinct
+    labeled children that each carry their own tag set.
+
+    Prior to the fix, labels() mutated the wrapped Ray counter's default
+    tags in place and returned ``self``, so every FinishReason-partitioned
+    child pointed at the same counter and every vllm:request_success
+    increment was attributed to the last FinishReason iterated
+    (``repetition``).
+    """
+    base = RayCounterWrapper(
+        name="vllm_test_finish_reason",
+        documentation="",
+        labelnames=["reason"],
+    )
+
+    stop_child = base.labels("stop")
+    rep_child = base.labels("repetition")
+
+    assert stop_child is not rep_child
+    assert stop_child._tags["reason"] == "stop"
+    assert rep_child._tags["reason"] == "repetition"
+    # Mutating one child's tags must not leak into another.
+    stop_child._tags["reason"] = "mutated"
+    assert rep_child._tags["reason"] == "repetition"
+
+
+def test_ray_counter_inc_forwards_per_child_tags():
+    """.inc() on a labeled counter must forward that child's tags to the
+    underlying Ray metric (not rely on a shared set_default_tags)."""
+    wrapper = RayCounterWrapper(
+        name="vllm_test_counter_tag_forward",
+        documentation="",
+        labelnames=["reason"],
+    )
+    mock = _install_mock_metric(wrapper)
+
+    wrapper.labels("stop").inc()
+    wrapper.labels("repetition").inc(3)
+    wrapper.labels("stop").inc(0)  # zero increment must be a no-op.
+
+    # The zero-increment call should not reach the underlying metric.
+    assert mock.inc.call_count == 2
+    first, second = mock.inc.call_args_list
+    assert first.args == (1.0,)
+    assert first.kwargs["tags"]["reason"] == "stop"
+    assert second.args == (3,)
+    assert second.kwargs["tags"]["reason"] == "repetition"
+
+
+def test_ray_gauge_labels_returns_independent_children_and_forwards_tags():
+    wrapper = RayGaugeWrapper(
+        name="vllm_test_gauge_tag_forward",
+        documentation="",
+        labelnames=["kind"],
+    )
+    mock = _install_mock_metric(wrapper)
+
+    a = wrapper.labels("a")
+    b = wrapper.labels("b")
+    assert a is not b
+
+    a.set(1)
+    b.set(2)
+    assert mock.set.call_args_list[0].args == (1,)
+    assert mock.set.call_args_list[0].kwargs["tags"]["kind"] == "a"
+    assert mock.set.call_args_list[1].args == (2,)
+    assert mock.set.call_args_list[1].kwargs["tags"]["kind"] == "b"
+
+
+def test_ray_histogram_labels_returns_independent_children_and_forwards_tags():
+    wrapper = RayHistogramWrapper(
+        name="vllm_test_histogram_tag_forward",
+        documentation="",
+        labelnames=["bucket"],
+        buckets=[1.0, 2.0, 5.0],
+    )
+    mock = _install_mock_metric(wrapper)
+
+    x = wrapper.labels("x")
+    y = wrapper.labels("y")
+    assert x is not y
+
+    x.observe(0.5)
+    y.observe(4.0)
+    assert mock.observe.call_args_list[0].args == (0.5,)
+    assert mock.observe.call_args_list[0].kwargs["tags"]["bucket"] == "x"
+    assert mock.observe.call_args_list[1].args == (4.0,)
+    assert mock.observe.call_args_list[1].kwargs["tags"]["bucket"] == "y"
+
+
+def test_ray_counter_labels_accepts_non_string_label_values():
+    """RayPrometheusStatLogger passes ``str(idx)`` for engine indexes; this
+    covers the coercion path for any caller that passes a non-string label
+    value positionally."""
+    wrapper = RayCounterWrapper(
+        name="vllm_test_nonstr_label",
+        documentation="",
+        labelnames=["engine", "reason"],
+    )
+    child = wrapper.labels(0, "stop")
+    assert child._tags["engine"] == "0"
+    assert child._tags["reason"] == "stop"
+
+
+def test_ray_counter_labels_arity_validation():
+    wrapper = RayCounterWrapper(
+        name="vllm_test_arity",
+        documentation="",
+        labelnames=["a", "b"],
+    )
+    with pytest.raises(ValueError, match="Number of labels must match"):
+        wrapper.labels("only-one")

--- a/vllm/v1/metrics/ray_wrappers.py
+++ b/vllm/v1/metrics/ray_wrappers.py
@@ -28,6 +28,10 @@ def _get_replica_id() -> str | None:
 
 
 class RayPrometheusMetric:
+    # Set by each concrete subclass to the matching _LabeledRay* class so that
+    # labels() returns the correct recording API (inc / set / observe).
+    _labeled_cls: type["_LabeledRayMetric"]
+
     def __init__(self):
         if ray_metrics is None:
             raise ImportError("RayPrometheusMetric requires Ray to be installed.")
@@ -39,7 +43,7 @@ class RayPrometheusMetric:
         labels.append("ReplicaId")
         return tuple(labels)
 
-    def labels(self, *labels, **labelskwargs):
+    def _build_tags(self, *labels, **labelskwargs) -> dict[str, str]:
         if labels:
             # -1 because ReplicaId was added automatically
             expected = len(self.metric._tag_keys) - 1
@@ -52,12 +56,18 @@ class RayPrometheusMetric:
 
         labelskwargs["ReplicaId"] = _get_replica_id() or ""
 
-        if labelskwargs:
-            for k, v in labelskwargs.items():
-                if not isinstance(v, str):
-                    labelskwargs[k] = str(v)
-            self.metric.set_default_tags(labelskwargs)
-        return self
+        return {k: v if isinstance(v, str) else str(v) for k, v in labelskwargs.items()}
+
+    def labels(self, *labels, **labelskwargs) -> "_LabeledRayMetric":
+        # Each call returns an independent labeled child carrying its own
+        # tag set, matching the prometheus_client.Metric.labels() contract
+        # that callsites rely on. Earlier versions mutated the underlying
+        # Ray metric's default tags in place and returned self, so every
+        # labeled "child" shared the last-set label values -- e.g. every
+        # vllm:request_success increment was attributed to the last
+        # FinishReason iterated (REPETITION).
+        tags = self._build_tags(*labels, **labelskwargs)
+        return self._labeled_cls(self, tags)
 
     @staticmethod
     def _get_sanitized_opentelemetry_name(name: str) -> str:
@@ -75,9 +85,53 @@ class RayPrometheusMetric:
         return re.sub(r"[^a-zA-Z0-9_]", "_", name)
 
 
+class _LabeledRayMetric:
+    """A per-label-set view of a Ray metric.
+
+    Each instance carries its own tag set and forwards recording operations
+    to the underlying Ray metric with ``tags=self._tags`` on every call. Per
+    Ray's metric API, per-call tags take precedence over any default tags on
+    the wrapped metric, so concurrent labeled children do not clobber each
+    other.
+    """
+
+    __slots__ = ("_wrapper", "_tags")
+
+    def __init__(self, wrapper: RayPrometheusMetric, tags: dict[str, str]):
+        self._wrapper = wrapper
+        self._tags = tags
+
+    def labels(self, *labels, **labelskwargs) -> "_LabeledRayMetric":
+        # Re-labeling a labeled child is unusual, but route through the root
+        # wrapper so tag-key validation happens against the original schema.
+        return self._wrapper.labels(*labels, **labelskwargs)
+
+
+class _LabeledRayCounter(_LabeledRayMetric):
+    def inc(self, value: int | float = 1.0):
+        if value == 0:
+            return
+        return self._wrapper.metric.inc(value, tags=self._tags)
+
+
+class _LabeledRayGauge(_LabeledRayMetric):
+    def set(self, value: int | float):
+        return self._wrapper.metric.set(value, tags=self._tags)
+
+    def set_to_current_time(self):
+        return self._wrapper.metric.set(time.time(), tags=self._tags)
+
+
+class _LabeledRayHistogram(_LabeledRayMetric):
+    def observe(self, value: int | float):
+        return self._wrapper.metric.observe(value, tags=self._tags)
+
+
 class RayGaugeWrapper(RayPrometheusMetric):
     """Wraps around ray.util.metrics.Gauge to provide same API as
     prometheus_client.Gauge"""
+
+    _labeled_cls = _LabeledRayGauge
 
     def __init__(
         self,
@@ -112,6 +166,8 @@ class RayCounterWrapper(RayPrometheusMetric):
     """Wraps around ray.util.metrics.Counter to provide same API as
     prometheus_client.Counter"""
 
+    _labeled_cls = _LabeledRayCounter
+
     def __init__(
         self,
         name: str,
@@ -135,6 +191,8 @@ class RayCounterWrapper(RayPrometheusMetric):
 class RayHistogramWrapper(RayPrometheusMetric):
     """Wraps around ray.util.metrics.Histogram to provide same API as
     prometheus_client.Histogram"""
+
+    _labeled_cls = _LabeledRayHistogram
 
     def __init__(
         self,


### PR DESCRIPTION
## Purpose

When vLLM runs with the Ray Prometheus path (Ray Serve, `ray.data.llm`, etc.), `vllm:request_success{finished_reason=...}` only ever increments the `repetition` bucket regardless of the request's actual finish reason; `stop`, `length`, `abort`, and `error` stay at zero.

**Root cause.** `RayPrometheusMetric.labels()` mutated the wrapped Ray metric's default tags in place (via `set_default_tags`) and returned `self`, so every `.labels(...)` call on a given wrapper returned the same object. In `PrometheusStatLogger`, the initialization loop partitions `counter_request_success` over `FinishReason`; all five entries end up pointing at the same wrapper, whose default tags get frozen at the last-iterated member (`REPETITION`). Subsequent `.inc()` calls record under that tag, no matter the request's actual `finish_reason`.

The same flaw affects every other `.labels(...)`-partitioned counter, gauge, and histogram on the Ray path — per-engine splits via `create_metric_per_engine`, plus spec-decoding, KV-connector, perf, and NIXL metrics. Any alerting, SLO, or capacity-planning built on multi-bucket vLLM-on-Ray metrics is silently wrong.

**Fix.** `labels()` now returns an independent `_LabeledRayMetric` that carries its own tag dict and forwards `.inc()` / `.set()` / `.observe()` to the underlying Ray metric with `tags=self._tags` on every call. Per Ray's metric API, per-call tags take precedence over default tags, so concurrent labeled children cannot clobber each other. This matches the `prometheus_client.Metric.labels()` contract that callsites rely on — no callsite changes needed.

Per [AGENTS.md §1](https://github.com/vllm-project/vllm/blob/main/AGENTS.md): searched open/closed PRs and issues for `request_success finished_reason`, `RayPrometheusMetric labels`, `set_default_tags ray`, `ray metrics labels independent` — no duplicate work.

## Test Plan

New unit tests in `tests/v1/metrics/test_ray_metrics.py` (no Ray cluster required — the underlying Ray metric is swapped for a `MagicMock`):

- `test_ray_counter_labels_returns_independent_children` — two `.labels(...)` calls return distinct objects with independent tag dicts.
- `test_ray_counter_inc_forwards_per_child_tags` — each child's tags reach the underlying Ray counter; `.inc(0)` stays a no-op.
- `test_ray_gauge_labels_returns_independent_children_and_forwards_tags` — same for `RayGaugeWrapper.set`.
- `test_ray_histogram_labels_returns_independent_children_and_forwards_tags` — same for `RayHistogramWrapper.observe`.
- `test_ray_counter_labels_accepts_non_string_label_values` — covers the `str(idx)` coercion path used by the per-engine split.
- `test_ray_counter_labels_arity_validation` — arity check still fires.

Local commands run:

```bash
pre-commit run ruff-check  --files vllm/v1/metrics/ray_wrappers.py tests/v1/metrics/test_ray_metrics.py
pre-commit run ruff-format --files vllm/v1/metrics/ray_wrappers.py tests/v1/metrics/test_ray_metrics.py
pre-commit run typos       --files vllm/v1/metrics/ray_wrappers.py tests/v1/metrics/test_ray_metrics.py
pre-commit run mypy-local  --files vllm/v1/metrics/ray_wrappers.py tests/v1/metrics/test_ray_metrics.py
```

The existing `test_engine_log_metrics_ray` smoke test requires a built vLLM + GPU environment and is deferred to CI.

## Test Result

All four pre-commit hooks pass locally:

```
ruff check...............................................................Passed
ruff format..............................................................Passed
typos....................................................................Passed
Run mypy locally for lowest supported Python version.......................Passed
```

Production-workload evidence motivating the fix (ground truth via an in-worker `check_stop` probe, compared against the Prometheus scrape on the same run):

| `request.status` (ground truth) | Count |
| --- | --- |
| `FINISHED_STOPPED` | 87 |
| `FINISHED_LENGTH_CAPPED` | 0 |
| `FINISHED_REPETITION` | 0 |

Pre-fix, Prometheus reported 100% of those increments under `vllm:request_success{finished_reason="repetition"}`. With the fix, increments land on the matching `FinishReason` string (`stop` in this run).

---

AI-assisted (per AGENTS.md §1.3). Every changed line was reviewed by the submitter.
