### PR TITLE
[Waiting on v4 deprecation] Update fast image processing files and classes names after upgrade to Transformers v5

### DIFF
--- a/vllm/model_executor/models/cohere2_vision.py
+++ b/vllm/model_executor/models/cohere2_vision.py
@@ -10,8 +10,8 @@ import torch
 from torch import nn
 from transformers import BatchFeature, PretrainedConfig
 from transformers.models.cohere2_vision import Cohere2VisionConfig
-from transformers.models.cohere2_vision.image_processing_cohere2_vision_fast import (  # noqa: E501
-    Cohere2VisionImageProcessorFast,
+from transformers.models.cohere2_vision.image_processing_cohere2_vision import (  # noqa: E501
+    Cohere2VisionImageProcessor,
 )
 from transformers.models.cohere2_vision.processing_cohere2_vision import (
     Cohere2VisionProcessor,
@@ -173,7 +173,7 @@ class Cohere2VisionProcessingInfo(BaseProcessingInfo):
         Calculate the number of image patches for a given image.
         Uses the HF processor to determine the actual number of patches.
         """
-        image_processor: Cohere2VisionImageProcessorFast = processor.image_processor
+        image_processor: Cohere2VisionImageProcessor = processor.image_processor
 
         return image_processor.get_number_of_image_patches(
             image_height,

--- a/vllm/model_executor/models/gemma3n_mm.py
+++ b/vllm/model_executor/models/gemma3n_mm.py
@@ -15,7 +15,7 @@ from transformers.models.gemma3n import (
     Gemma3nTextConfig,
     Gemma3nVisionConfig,
 )
-from transformers.models.siglip import SiglipImageProcessorFast
+from transformers.models.siglip import SiglipImageProcessor
 
 from vllm.config import ModelConfig, SpeechToTextConfig, VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
@@ -183,7 +183,7 @@ class Gemma3nDummyInputsBuilder(BaseDummyInputsBuilder[Gemma3nProcessingInfo]):
             processor.feature_extractor
         )
         audio_len = audio_feature_extractor.fft_length
-        image_processor: SiglipImageProcessorFast = processor.image_processor
+        image_processor: SiglipImageProcessor = processor.image_processor
         img_width = image_processor.size.get("width", 224)
         img_height = image_processor.size.get("height", 224)
 

--- a/vllm/model_executor/models/glm4v.py
+++ b/vllm/model_executor/models/glm4v.py
@@ -48,7 +48,7 @@ from vllm.multimodal.processing import (
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.configs.chatglm import ChatGLMConfig
 from vllm.transformers_utils.processors.glm4v import (
-    GLM4VImageProcessorFast,
+    GLM4VImageProcessor,
     GLM4VProcessor,
 )
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
@@ -398,7 +398,7 @@ class GLM4VProcessingInfo(BaseProcessingInfo):
         kwargs = self.ctx.get_merged_mm_kwargs(kwargs)
         kwargs.setdefault("size", {"width": image_size, "height": image_size})
 
-        return GLM4VImageProcessorFast(**kwargs)
+        return GLM4VImageProcessor(**kwargs)
 
     def get_hf_processor(self, **kwargs: object) -> GLM4VProcessor:
         return GLM4VProcessor(

--- a/vllm/model_executor/models/interns1.py
+++ b/vllm/model_executor/models/interns1.py
@@ -14,8 +14,8 @@ import torch
 import torch.nn as nn
 from transformers import BatchFeature, InternVLProcessor, PretrainedConfig
 from transformers.activations import ACT2FN
-from transformers.models.got_ocr2.image_processing_got_ocr2_fast import (
-    GotOcr2ImageProcessorFast,
+from transformers.models.got_ocr2.image_processing_got_ocr2 import (
+    GotOcr2ImageProcessor,
 )
 from transformers.models.internvl.video_processing_internvl import (
     InternVLVideoProcessor,
@@ -200,7 +200,7 @@ class InternS1ProcessingInfo(BaseProcessingInfo):
         processor: InternVLProcessor,
         mm_kwargs: Mapping[str, object],
     ) -> int:
-        image_processor: GotOcr2ImageProcessorFast = processor.image_processor
+        image_processor: GotOcr2ImageProcessor = processor.image_processor
 
         num_image_patches = image_processor.get_number_of_image_patches(
             image_height,

--- a/vllm/model_executor/models/lfm2_vl.py
+++ b/vllm/model_executor/models/lfm2_vl.py
@@ -12,8 +12,8 @@ from transformers import BatchFeature
 from transformers.activations import ACT2FN
 from transformers.models.lfm2_vl import Lfm2VlProcessor
 from transformers.models.lfm2_vl.configuration_lfm2_vl import Lfm2VlConfig
-from transformers.models.lfm2_vl.image_processing_lfm2_vl_fast import (
-    Lfm2VlImageProcessorFast,
+from transformers.models.lfm2_vl.image_processing_lfm2_vl import (
+    Lfm2VlImageProcessor,
     find_closest_aspect_ratio,
     round_by_factor,
 )
@@ -88,7 +88,7 @@ class Lfm2VLProcessingInfo(BaseProcessingInfo):
     def get_hf_processor(self, **kwargs):
         return self.ctx.get_hf_processor(Lfm2VlProcessor, **kwargs)
 
-    def get_image_processor(self, **kwargs: object) -> Lfm2VlImageProcessorFast:
+    def get_image_processor(self, **kwargs: object) -> Lfm2VlImageProcessor:
         return self.get_hf_processor(**kwargs).image_processor
 
     def get_default_tok_params(self) -> TokenizeParams:
@@ -197,7 +197,7 @@ class Lfm2VLProcessingInfo(BaseProcessingInfo):
         processor: Lfm2VlProcessor,
         mm_kwargs: Mapping[str, object],
     ) -> tuple[int, int, int]:
-        image_processor: Lfm2VlImageProcessorFast = processor.image_processor
+        image_processor: Lfm2VlImageProcessor = processor.image_processor
 
         mm_kwargs = self.ctx.get_merged_mm_kwargs(mm_kwargs)
         downsample_factor = mm_kwargs.get(
@@ -313,7 +313,7 @@ class Lfm2VLProcessingInfo(BaseProcessingInfo):
         processor: Lfm2VlProcessor,
         mm_kwargs: Mapping[str, object],
     ) -> tuple[int, int]:
-        image_processor: Lfm2VlImageProcessorFast = processor.image_processor
+        image_processor: Lfm2VlImageProcessor = processor.image_processor
 
         mm_kwargs = self.ctx.get_merged_mm_kwargs(mm_kwargs)
         downsample_factor = mm_kwargs.get(

--- a/vllm/model_executor/models/mllama4.py
+++ b/vllm/model_executor/models/mllama4.py
@@ -26,7 +26,7 @@ from torch import nn
 from transformers import BatchFeature, Llama4Config, Llama4VisionConfig
 from transformers.image_utils import SizeDict
 from transformers.models.llama4 import Llama4Processor
-from transformers.models.llama4.image_processing_llama4_fast import (
+from transformers.models.llama4.image_processing_llama4 import (
     find_supported_resolutions,
     get_best_fit,
 )
@@ -101,7 +101,7 @@ class Llama4ImagePatchInputs(TensorSchema):
     patches_per_image: Annotated[torch.Tensor, TensorShape("batch_size")]
     """
     The number of total patches for each image in the batch.
-    
+
     This is used to split the embeddings which has the first two dimensions
     flattened just like `pixel_values`.
     """

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -34,7 +34,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 from transformers import BatchFeature
-from transformers.models.qwen2_vl import Qwen2VLImageProcessorFast
+from transformers.models.qwen2_vl import Qwen2VLImageProcessor
 from transformers.models.qwen2_vl.image_processing_qwen2_vl import (
     smart_resize as image_smart_resize,
 )
@@ -862,7 +862,7 @@ class Qwen3VLProcessingInfo(Qwen2VLProcessingInfo):
             **kwargs,
         )
 
-    def get_image_processor(self, **kwargs: object) -> Qwen2VLImageProcessorFast:
+    def get_image_processor(self, **kwargs: object) -> Qwen2VLImageProcessor:
         return self.get_hf_processor(**kwargs).image_processor
 
     def get_video_processor(self, **kwargs: object) -> Qwen3VLVideoProcessor:
@@ -882,7 +882,7 @@ class Qwen3VLProcessingInfo(Qwen2VLProcessingInfo):
         image_height: int,
         num_frames: int = 2,
         do_resize: bool = True,
-        image_processor: Qwen2VLImageProcessorFast | Qwen3VLVideoProcessor,
+        image_processor: Qwen2VLImageProcessor | Qwen3VLVideoProcessor,
         mm_kwargs: Mapping[str, object],
     ) -> tuple[ImageSize, int]:
         is_video = isinstance(image_processor, Qwen3VLVideoProcessor)

--- a/vllm/model_executor/models/qwen_vl.py
+++ b/vllm/model_executor/models/qwen_vl.py
@@ -45,7 +45,7 @@ from vllm.multimodal.processing import (
 )
 from vllm.sequence import IntermediateTensors
 from vllm.transformers_utils.processors.qwen_vl import (
-    QwenVLImageProcessorFast,
+    QwenVLImageProcessor,
     QwenVLProcessor,
 )
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
@@ -443,7 +443,7 @@ class QwenVLProcessingInfo(BaseProcessingInfo):
         kwargs = self.ctx.get_merged_mm_kwargs(kwargs)
         kwargs.setdefault("size", {"width": image_size, "height": image_size})
 
-        return QwenVLImageProcessorFast(**kwargs)
+        return QwenVLImageProcessor(**kwargs)
 
     def get_hf_processor(self, **kwargs: object) -> QwenVLProcessor:
         return QwenVLProcessor(

--- a/vllm/transformers_utils/processors/glm4v.py
+++ b/vllm/transformers_utils/processors/glm4v.py
@@ -4,12 +4,12 @@
 # Adapted from
 # https://github.com/zai-org/CogAgent
 from transformers import PreTrainedTokenizer
-from transformers.image_processing_utils_fast import BaseImageProcessorFast
+from transformers.image_processing_backends import TorchvisionBackend
 from transformers.image_utils import PILImageResampling
 from transformers.processing_utils import ProcessorMixin
 
 
-class GLM4VImageProcessorFast(BaseImageProcessorFast):
+class GLM4VImageProcessor(TorchvisionBackend):
     """
     Port of https://huggingface.co/zai-org/glm-4v-9b/blob/main/tokenization_chatglm.py#L177
     to HF Transformers.
@@ -29,7 +29,7 @@ class GLM4VProcessor(ProcessorMixin):
 
     def __init__(
         self,
-        image_processor: GLM4VImageProcessorFast,
+        image_processor: GLM4VImageProcessor,
         tokenizer: PreTrainedTokenizer,
     ) -> None:
         self.image_processor = image_processor

--- a/vllm/transformers_utils/processors/qwen_vl.py
+++ b/vllm/transformers_utils/processors/qwen_vl.py
@@ -4,14 +4,14 @@
 # Adapted from
 # https://huggingface.co/Qwen/Qwen-VL/blob/main/modeling_qwen.py
 # Copyright (c) Alibaba Cloud.
-from transformers.image_processing_utils_fast import BaseImageProcessorFast
+from transformers.image_processing_backends import TorchvisionBackend
 from transformers.image_utils import PILImageResampling
 from transformers.processing_utils import ProcessorMixin
 
 from vllm.tokenizers.qwen_vl import QwenVLTokenizer
 
 
-class QwenVLImageProcessorFast(BaseImageProcessorFast):
+class QwenVLImageProcessor(TorchvisionBackend):
     """
     Port of https://huggingface.co/Qwen/Qwen-VL/blob/main/visual.py#L354
     to HF Transformers.
@@ -31,7 +31,7 @@ class QwenVLProcessor(ProcessorMixin):
 
     def __init__(
         self,
-        image_processor: QwenVLImageProcessorFast,
+        image_processor: QwenVLImageProcessor,
         tokenizer: QwenVLTokenizer,
     ) -> None:
         self.image_processor = image_processor


### PR DESCRIPTION
## Purpose

Transformers v5 contains a fully reworked image processors API, introducing backends (`torchvision`/`pil`) to replace "fast" and "slow" classes.

While the image processors API in Transformers v5 should be fully backward compatible, this update would avoid having deprecation messages cluttering the terminal.

I'm not sure if we can remove these two lines as well (is this used for remote code as well?), so I left them for now:

https://github.com/vllm-project/vllm/blob/595562651a5a4539ffa910d8570c08fb5169bdc9/tests/entrypoints/offline_mode/test_offline_mode.py#L115-L116


Cc @hmellor 