### PR TITLE
compilation: cap cudagraph sizes for TP Marlin on Ampere

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -34,6 +34,30 @@ from . import silly_attention  # noqa: F401
 DEVICE_TYPE = current_platform.device_type
 
 
+def test_cudagraph_sizes_capped_for_tp_marlin_on_ampere():
+    vllm_config = VllmConfig(
+        model_config=MagicMock(
+            enforce_eager=False,
+            quantization="awq_marlin",
+        ),
+        parallel_config=ParallelConfig(tensor_parallel_size=2),
+        scheduler_config=SchedulerConfig(max_num_seqs=32, max_num_batched_tokens=8192),
+    )
+
+    vllm_config.compilation_config.cudagraph_mode = CUDAGraphMode.FULL_AND_PIECEWISE
+    vllm_config.compilation_config.cudagraph_capture_sizes = None
+    vllm_config.compilation_config.max_cudagraph_capture_size = None
+
+    with (
+        patch.object(current_platform, "is_cuda", return_value=True),
+        patch.object(current_platform, "is_device_capability_family", return_value=True),
+    ):
+        vllm_config._set_cudagraph_sizes()
+
+    assert vllm_config.compilation_config.max_cudagraph_capture_size == 8
+    assert vllm_config.compilation_config.cudagraph_capture_sizes == [1, 2, 4, 8]
+
+
 def test_version():
     # Test the version comparison logic using the private function
     assert _is_torch_equal_or_newer("2.8.0.dev20250624+cu128", "2.8.0.dev")

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1467,6 +1467,8 @@ class VllmConfig:
             and not self.model_config.enforce_eager
             and self.compilation_config.cudagraph_mode != CUDAGraphMode.NONE
         ):
+            from vllm.platforms import current_platform
+
             # determine the initial max_cudagraph_capture_size
             max_cudagraph_capture_size = (
                 self.compilation_config.max_cudagraph_capture_size

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1484,6 +1484,28 @@ class VllmConfig:
             max_num_tokens = self.scheduler_config.max_num_batched_tokens
             max_cudagraph_capture_size = min(max_num_tokens, max_cudagraph_capture_size)
 
+            # Mitigation for potential illegal memory access during CUDA graph
+            # replay in some TP>1 + Marlin-quantized configs on Ampere GPUs.
+            # See: https://github.com/vllm-project/vllm/issues/40121
+            if (
+                self.compilation_config.cudagraph_capture_sizes is None
+                and self.compilation_config.max_cudagraph_capture_size is None
+                and self.parallel_config.tensor_parallel_size > 1
+                and current_platform.is_cuda()
+                and current_platform.is_device_capability_family(80)
+            ):
+                quant = getattr(self.model_config, "quantization", None)
+                if isinstance(quant, str) and quant.endswith("_marlin"):
+                    if max_cudagraph_capture_size > 8:
+                        logger.warning_once(
+                            "Capping max_cudagraph_capture_size to 8 for TP>1 with %s "
+                            "on Ampere GPUs to mitigate potential CUDA graph replay "
+                            "instability. Override with --compilation-config if needed.",
+                            quant,
+                            scope="local",
+                        )
+                    max_cudagraph_capture_size = min(max_cudagraph_capture_size, 8)
+
             assert max_cudagraph_capture_size >= 1, (
                 "Maximum cudagraph size should be greater than or equal to 1 "
                 "when using cuda graph."


### PR DESCRIPTION
## Fix/Mitigation:
- Caps default `max_cudagraph_capture_size` to `8` when:
  - `tensor_parallel_size > 1`
  - Ampere (sm80 family)
  - `quantization` ends with `"_marlin"`
  - user did not set `cudagraph_capture_sizes` / `max_cudagraph_capture_size`
## Why:
- Mitigates CUDA graph replay instability reported in #40121
- Matches known workaround: limiting capture sizes to `<= 8`
## Test:
- Adds `test_cudagraph_sizes_capped_for_tp_marlin_on_ampere`