### PR TITLE
[Bugfix] Gemma4: fix multimodal embedder norm order to match HF reference

### DIFF
--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -849,22 +849,23 @@ class Gemma4MultimodalEmbedder(nn.Module):
             or multimodal_config.hidden_size
         )
 
+        self.embedding_pre_projection_norm = RMSNorm(
+            embedding_dim,
+            eps=self.eps,
+            has_weight=False,
+        )
+
         self.embedding_projection = ReplicatedLinear(
             embedding_dim,
             self.text_hidden_size,
             bias=False,
         )
 
-        self.embedding_post_projection_norm = RMSNorm(
-            self.text_hidden_size,
-            eps=self.eps,
-            has_weight=False,
-        )
-
     def forward(self, inputs_embeds: torch.Tensor) -> torch.Tensor:
         """Project soft tokens from a multimodal tower into LM space."""
-        embs_proj, _ = self.embedding_projection(inputs_embeds)
-        return self.embedding_post_projection_norm(embs_proj)
+        embs_normed = self.embedding_pre_projection_norm(inputs_embeds)
+        embs_proj, _ = self.embedding_projection(embs_normed)
+        return embs_proj
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Purpose

Fix the norm ordering in `Gemma4MultimodalEmbedder` to match the HF transformers reference implementation. The vLLM implementation had **post-projection** RMSNorm while the HF reference uses **pre-projection** RMSNorm.

- before (incorrect): `Linear(768→hidden)` then `RMSNorm(hidden)`
- after (correct): `RMSNorm(768)` then `Linear(768→hidden)`

The norm uses `has_weight=False` (no learnable scale parameter) in both cases, so no checkpoint weight mapping changes are needed — this is a pure computation-order fix.

This affects all Gemma4 multimodal variants (vision and audio embedders) since both use `Gemma4MultimodalEmbedder`.

Ref: HF transformers `Gemma4MultimodalEmbedder` uses `embedding_pre_projection_norm` (RMSNorm without scale) applied before the linear projection.

## Test Result

**ScreenSpot-Pro (gemma-4-31B-it, 1580 samples):**

| Config | Click Accuracy | Parse Error Rate |
|--------|---------------|-----------------|
| Before (post-norm) | 36.77% | 0.21% |
| After (pre-norm) | **38.65%** | 0.42% |

**+1.88pp improvement** in click accuracy from correcting the norm order.