### PR TITLE
fused_moe: treat NIXL EP as batched experts

### DIFF
--- a/vllm/model_executor/layers/fused_moe/config.py
+++ b/vllm/model_executor/layers/fused_moe/config.py
@@ -994,6 +994,10 @@ class FusedMoEParallelConfig:
         return self.use_deepep_ll_kernels or self.use_nixl_ep_kernels
 
     @property
+    def needs_round_robin_routing_tables(self):
+        return self.use_deepep_ll_kernels or self.use_nixl_ep_kernels
+
+    @property
     def use_ag_rs_all2all_kernels(self):
         return (
             self.use_all2all_kernels
@@ -1294,3 +1298,7 @@ class FusedMoEConfig:
     @property
     def use_nixl_ep_kernels(self):
         return self.moe_parallel_config.use_nixl_ep_kernels
+
+    @property
+    def needs_round_robin_routing_tables(self):
+        return self.moe_parallel_config.needs_round_robin_routing_tables

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -180,8 +180,7 @@ def determine_expert_placement_strategy(
             return "linear"
         if (
             moe_parallel_config.use_all2all_kernels
-            and not moe_parallel_config.use_deepep_ll_kernels
-            and not moe_parallel_config.use_nixl_ep_kernels
+            and not moe_parallel_config.needs_round_robin_routing_tables
         ):
             logger.warning(
                 "Round-robin expert placement currently only supports "
@@ -687,8 +686,7 @@ class FusedMoE(PluggableLayer):
         # Currently routing_tables only needed for round-robin expert placement
         # with DeepEP-ll or NIXL EP all2all backends.
         if self.expert_placement_strategy != "round_robin" or (
-            not self.moe_parallel_config.use_deepep_ll_kernels
-            and not self.moe_parallel_config.use_nixl_ep_kernels
+            not self.moe_parallel_config.needs_round_robin_routing_tables
         ):
             return None
 

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -884,8 +884,7 @@ def make_mxfp4_moe_kernel(
         experts,
         shared_experts=(
             shared_experts
-            if moe_config.moe_parallel_config.use_deepep_ll_kernels
-            or moe_config.moe_parallel_config.use_nixl_ep_kernels
+            if moe_config.moe_parallel_config.use_batched_activation_format
             else None
         ),
         inplace=(

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -885,6 +885,7 @@ def make_mxfp4_moe_kernel(
         shared_experts=(
             shared_experts
             if moe_config.moe_parallel_config.use_deepep_ll_kernels
+            or moe_config.moe_parallel_config.use_nixl_ep_kernels
             else None
         ),
         inplace=(

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -168,13 +168,7 @@ def select_nvfp4_moe_backend(
         NvFp4MoeBackend.EMULATION,
     ]
 
-    # NOTE(rob): this is kind of a hack. We need to peak into
-    # the prepare-finalize selection to determine if we are using
-    # the batched or standard expert format.
-    use_batched = (
-        config.moe_parallel_config.use_deepep_ll_kernels
-        or config.moe_parallel_config.use_nixl_ep_kernels
-    )
+    use_batched = config.moe_parallel_config.use_batched_activation_format
     activation_format = (
         mk.FusedMoEActivationFormat.BatchedExperts
         if use_batched

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -171,7 +171,10 @@ def select_nvfp4_moe_backend(
     # NOTE(rob): this is kind of a hack. We need to peak into
     # the prepare-finalize selection to determine if we are using
     # the batched or standard expert format.
-    use_batched = config.moe_parallel_config.use_deepep_ll_kernels
+    use_batched = (
+        config.moe_parallel_config.use_deepep_ll_kernels
+        or config.moe_parallel_config.use_nixl_ep_kernels
+    )
     activation_format = (
         mk.FusedMoEActivationFormat.BatchedExperts
         if use_batched


### PR DESCRIPTION
NIXL EP follows the batched-expert activation path, but parts of the fused MoE config and FP4 oracle selection only checked for DeepEP LL.

Include NIXL EP in those batched-format checks so activation format selection, shared-expert handling, and FP4 backend selection stay consistent when NIXL EP kernels are enabled.

