### PR TITLE
[Bugfix][EC Connector] Fix ECExampleConnector load device under TP>1

### DIFF
--- a/tests/v1/ec_connector/unit/test_ec_example_connector.py
+++ b/tests/v1/ec_connector/unit/test_ec_example_connector.py
@@ -477,6 +477,96 @@ class TestCacheLoading:
         # Cache should remain empty
         assert len(encoder_cache) == 0
 
+    def test_start_load_caches_pins_device_to_current_rank(
+        self, mock_vllm_config_producer, mock_vllm_config_consumer
+    ):
+        """Regression test: load must pin to the calling rank's CUDA device.
+
+        `safetensors.torch.load_file(device="cuda")` ignores
+        `torch.cuda.set_device(rank)` and always lands tensors on `cuda:0`,
+        causing a device mismatch in downstream `masked_scatter_` under TP>1.
+        The connector must pass the fully-qualified `cuda:<rank>` string.
+        """
+        # Produce a real cache file so the load path has something to open.
+        producer = ECExampleConnector(
+            vllm_config=mock_vllm_config_producer,
+            role=ECConnectorRole.WORKER,
+        )
+        mm_hash = "rank_pinning_hash"
+        producer.save_caches({mm_hash: torch.zeros(4, 8)}, mm_hash)
+
+        consumer = ECExampleConnector(
+            vllm_config=mock_vllm_config_consumer,
+            role=ECConnectorRole.WORKER,
+        )
+        metadata = ECExampleConnectorMetadata()
+        metadata.add_mm_data(MMMeta.make_meta(mm_hash, 100))
+        consumer.bind_connector_metadata(metadata)
+
+        mock_platform = Mock()
+        mock_platform.device_type = "cuda"
+        mock_platform.is_cuda_alike.return_value = True
+
+        # Simulate running on TP rank 2 without requiring a multi-GPU host.
+        captured: dict = {}
+
+        def fake_load_file(filename, device):
+            captured["device"] = device
+            return {"ec_cache": torch.zeros(4, 8)}
+
+        with (
+            patch("vllm.platforms.current_platform", mock_platform),
+            patch("torch.cuda.current_device", return_value=2),
+            patch("safetensors.torch.load_file", side_effect=fake_load_file),
+        ):
+            encoder_cache: dict[str, torch.Tensor] = {}
+            consumer.start_load_caches(encoder_cache=encoder_cache)
+
+        assert captured["device"] == "cuda:2", (
+            f"Expected device='cuda:2' (pinned to current rank), "
+            f"got {captured['device']!r}. A bare 'cuda' string makes "
+            "safetensors load onto cuda:0 regardless of torch.cuda.set_device(), "
+            "which breaks non-rank-0 TP workers."
+        )
+
+    def test_start_load_caches_non_cuda_platform_uses_device_type(
+        self, mock_vllm_config_producer, mock_vllm_config_consumer
+    ):
+        """Non-CUDA platforms pass `device_type` through unchanged (no rank suffix)."""
+        producer = ECExampleConnector(
+            vllm_config=mock_vllm_config_producer,
+            role=ECConnectorRole.WORKER,
+        )
+        mm_hash = "cpu_device_hash"
+        producer.save_caches({mm_hash: torch.zeros(2, 4)}, mm_hash)
+
+        consumer = ECExampleConnector(
+            vllm_config=mock_vllm_config_consumer,
+            role=ECConnectorRole.WORKER,
+        )
+        metadata = ECExampleConnectorMetadata()
+        metadata.add_mm_data(MMMeta.make_meta(mm_hash, 100))
+        consumer.bind_connector_metadata(metadata)
+
+        mock_platform = Mock()
+        mock_platform.device_type = "cpu"
+        mock_platform.is_cuda_alike.return_value = False
+
+        captured: dict = {}
+
+        def fake_load_file(filename, device):
+            captured["device"] = device
+            return {"ec_cache": torch.zeros(2, 4)}
+
+        with (
+            patch("vllm.platforms.current_platform", mock_platform),
+            patch("safetensors.torch.load_file", side_effect=fake_load_file),
+        ):
+            encoder_cache: dict[str, torch.Tensor] = {}
+            consumer.start_load_caches(encoder_cache=encoder_cache)
+
+        assert captured["device"] == "cpu"
+
 
 class TestFilenameGeneration:
     """Test filename and path generation."""

--- a/tests/v1/ec_connector/unit/test_ec_example_connector.py
+++ b/tests/v1/ec_connector/unit/test_ec_example_connector.py
@@ -477,6 +477,89 @@ class TestCacheLoading:
         # Cache should remain empty
         assert len(encoder_cache) == 0
 
+    def test_start_load_caches_pins_device_to_current_rank(
+        self, mock_vllm_config_producer, mock_vllm_config_consumer
+    ):
+        """Load must pin to the selected device under tensor parallelism."""
+        # Produce a real cache file so the load path has something to open.
+        producer = ECExampleConnector(
+            vllm_config=mock_vllm_config_producer,
+            role=ECConnectorRole.WORKER,
+        )
+        mm_hash = "rank_pinning_hash"
+        producer.save_caches({mm_hash: torch.zeros(4, 8)}, mm_hash)
+
+        consumer = ECExampleConnector(
+            vllm_config=mock_vllm_config_consumer,
+            role=ECConnectorRole.WORKER,
+        )
+        metadata = ECExampleConnectorMetadata()
+        metadata.add_mm_data(MMMeta.make_meta(mm_hash, 100))
+        consumer.bind_connector_metadata(metadata)
+
+        mock_platform = Mock()
+        mock_platform.device_type = "cuda"
+        mock_platform.is_cuda_alike.return_value = True
+        mock_platform.current_device.return_value = 2
+
+        # Simulate running on TP rank 2 without requiring a multi-GPU host.
+        captured: dict = {}
+
+        def fake_load_file(filename, device):
+            captured["device"] = device
+            return {"ec_cache": torch.zeros(4, 8)}
+
+        with (
+            patch("vllm.platforms.current_platform", mock_platform),
+            patch("safetensors.torch.load_file", side_effect=fake_load_file),
+        ):
+            encoder_cache: dict[str, torch.Tensor] = {}
+            consumer.start_load_caches(encoder_cache=encoder_cache)
+
+        assert captured["device"] == "cuda:2", (
+            f"Expected device='cuda:2' (pinned to current rank), "
+            f"got {captured['device']!r}. A bare 'cuda' string makes "
+            "safetensors load onto cuda:0, which breaks non-rank-0 TP workers."
+        )
+
+    def test_start_load_caches_non_cuda_platform_uses_device_type(
+        self, mock_vllm_config_producer, mock_vllm_config_consumer
+    ):
+        """Non-CUDA platforms pass `device_type` through unchanged (no rank suffix)."""
+        producer = ECExampleConnector(
+            vllm_config=mock_vllm_config_producer,
+            role=ECConnectorRole.WORKER,
+        )
+        mm_hash = "cpu_device_hash"
+        producer.save_caches({mm_hash: torch.zeros(2, 4)}, mm_hash)
+
+        consumer = ECExampleConnector(
+            vllm_config=mock_vllm_config_consumer,
+            role=ECConnectorRole.WORKER,
+        )
+        metadata = ECExampleConnectorMetadata()
+        metadata.add_mm_data(MMMeta.make_meta(mm_hash, 100))
+        consumer.bind_connector_metadata(metadata)
+
+        mock_platform = Mock()
+        mock_platform.device_type = "cpu"
+        mock_platform.is_cuda_alike.return_value = False
+
+        captured: dict = {}
+
+        def fake_load_file(filename, device):
+            captured["device"] = device
+            return {"ec_cache": torch.zeros(2, 4)}
+
+        with (
+            patch("vllm.platforms.current_platform", mock_platform),
+            patch("safetensors.torch.load_file", side_effect=fake_load_file),
+        ):
+            encoder_cache: dict[str, torch.Tensor] = {}
+            consumer.start_load_caches(encoder_cache=encoder_cache)
+
+        assert captured["device"] == "cpu"
+
 
 class TestFilenameGeneration:
     """Test filename and path generation."""

--- a/vllm/distributed/ec_transfer/ec_connector/example_connector.py
+++ b/vllm/distributed/ec_transfer/ec_connector/example_connector.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import safetensors
+import torch
 
 from vllm.config import VllmConfig
 from vllm.distributed.ec_transfer.ec_connector.base import (
@@ -84,14 +85,21 @@ class ECExampleConnector(ECConnectorBase):
                 "In connector.start_load_caches, but the connector metadata is None"
             )
             return
+        # `safetensors.torch.load_file(device="cuda")` ignores the calling
+        # process's `torch.cuda.set_device(rank)` and always lands the tensor
+        # on `cuda:0`. Under TP>1 this produces a device mismatch in downstream
+        # `masked_scatter_` (see `_merge_multimodal_embeddings`), which crashes
+        # non-rank-0 workers and wedges the shared-memory broadcast. Pin the
+        # load to the current rank's device instead.
+        device = current_platform.device_type
+        if current_platform.is_cuda_alike():
+            device = f"{device}:{torch.cuda.current_device()}"
         # Load the EC for each mm data
         for mm_data in metadata.mm_datas:
             if mm_data.mm_hash in encoder_cache:
                 continue
             filename = self._generate_filename_debug(mm_data.mm_hash)
-            ec_cache = safetensors.torch.load_file(
-                filename, device=current_platform.device_type
-            )["ec_cache"]
+            ec_cache = safetensors.torch.load_file(filename, device=device)["ec_cache"]
             encoder_cache[mm_data.mm_hash] = ec_cache
             logger.debug("Success load encoder cache for hash %s", mm_data.mm_hash)
 

--- a/vllm/distributed/ec_transfer/ec_connector/example_connector.py
+++ b/vllm/distributed/ec_transfer/ec_connector/example_connector.py
@@ -87,14 +87,17 @@ class ECExampleConnector(ECConnectorBase):
                 "In connector.start_load_caches, but the connector metadata is None"
             )
             return
+        # A bare "cuda" makes safetensors load onto cuda:0. Pin the load to the
+        # selected device so tensor-parallel workers load the cache locally.
+        device = current_platform.device_type
+        if current_platform.is_cuda_alike():
+            device = f"{device}:{current_platform.current_device()}"
         # Load the EC for each mm data
         for mm_data in metadata.mm_datas:
             if mm_data.mm_hash in encoder_cache:
                 continue
             filename = self._generate_filename_debug(mm_data.mm_hash)
-            ec_cache = safetensors.torch.load_file(
-                filename, device=current_platform.device_type
-            )["ec_cache"]
+            ec_cache = safetensors.torch.load_file(filename, device=device)["ec_cache"]
             encoder_cache[mm_data.mm_hash] = ec_cache
             logger.debug("Success load encoder cache for hash %s", mm_data.mm_hash)
 


### PR DESCRIPTION
## Summary

`ECExampleConnector.start_load_caches` passed the bare device string `"cuda"`
to `safetensors.torch.load_file`. Safetensors resolves that to `cuda:0`, even
when a tensor-parallel worker is running on another selected device.

Under `tensor_parallel_size > 1`, a non-rank-0 worker could therefore load the
encoder cache on `cuda:0` and later fail when combining it with tensors on its
local device. This was reproduced on vLLM v0.17.0 with Qwen3-VL-4B-Instruct,
TP=4, and 4 x L4 GPUs.

## Fix

Pin CUDA-like loads to the device selected by vLLM's platform abstraction:

```python
device = current_platform.device_type
if current_platform.is_cuda_alike():
    device = f"{device}:{current_platform.current_device()}"
```

The platform abstraction keeps this compatible with CUDA-like backends, while
non-CUDA platforms continue to receive their unchanged `device_type`.

Two regression tests cover both paths:

- CUDA-like platforms load onto the selected device (for example, `cuda:2`).
- Non-CUDA platforms keep the bare platform device type.

## Validation

- [x] GitHub `pre-commit` workflow passes on the amended commit.
- [x] `check-torch-cuda-call`, Ruff check/format, and mypy 3.12 pass locally on
      the changed files.
- [x] The repository's manual-stage hook suite passes locally, excluding the
      Docker graph hook and Linux-only non-root entrypoint check on macOS.
- [ ] Full CI: [Buildkite #82780](https://buildkite.com/vllm/ci/builds/82780)
      (running).

The focused pytest file could not be rerun in the current macOS ARM environment
because vLLM does not publish a compatible precompiled wheel for that platform;
the regression tests are included in the requested Linux/GPU CI run.

## Checks

- [x] No matching open PR was found for this EC connector device-placement bug.
- [x] The fix includes targeted regression coverage.
- [x] AI assistance was used: Claude (Anthropic) assisted with the original
      investigation and test scaffolding; Codex (OpenAI) fixed the lint failure,
      updated validation, and prepared the amended commit. The author reviewed
      and validated the original change. AI co-author trailers are included in
      the commit.
