### PR TITLE
Revert "[Bugfix] Fix scaled_mm output narrowing for 3D input tensors" (#38093)

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/pytorch.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/pytorch.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import math
 
 import torch
 
@@ -12,13 +11,6 @@ from .ScaledMMLinearKernel import (
     FP8ScaledMMLinearKernel,
     FP8ScaledMMLinearLayerConfig,
 )
-
-
-def _get_num_tokens(output_shape: list) -> int:
-    # torch._scaled_mm works with 2D tensors, so input tensors are
-    # flattened if they are 3D. If output_shape is 3D, num_tokens is
-    # the product of all dims except the last (hidden dim).
-    return math.prod(output_shape[:-1])
 
 
 class TorchFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
@@ -86,8 +78,7 @@ class PerTensorTorchFP8ScaledMMLinearKernel(TorchFP8ScaledMMLinearKernel):
         if type(output) is tuple and len(output) == 2:
             output = output[0]
 
-        num_tokens = _get_num_tokens(output_shape)
-        return torch.narrow(output, 0, 0, num_tokens).view(*output_shape)
+        return torch.narrow(output, 0, 0, output_shape[0]).view(*output_shape)
 
 
 class RowWiseTorchFP8ScaledMMLinearKernel(TorchFP8ScaledMMLinearKernel):
@@ -154,8 +145,7 @@ class RowWiseTorchFP8ScaledMMLinearKernel(TorchFP8ScaledMMLinearKernel):
             bias=bias,
         )
 
-        num_tokens = _get_num_tokens(output_shape)
-        return torch.narrow(output, 0, 0, num_tokens).view(*output_shape)
+        return torch.narrow(output, 0, 0, output_shape[0]).view(*output_shape)
 
 
 class ChannelWiseTorchFP8ScaledMMLinearKernel(TorchFP8ScaledMMLinearKernel):
@@ -216,9 +206,8 @@ class ChannelWiseTorchFP8ScaledMMLinearKernel(TorchFP8ScaledMMLinearKernel):
             output = output[0]
 
         # Unpad (undo num_token_padding)
-        num_tokens = _get_num_tokens(output_shape)
-        output = torch.narrow(output, 0, 0, num_tokens)
-        x_scale = torch.narrow(As, 0, 0, num_tokens)
+        output = torch.narrow(output, 0, 0, output_shape[0])
+        x_scale = torch.narrow(As, 0, 0, output_shape[0])
 
         # DQ
         # C = sw * sx * (X * W) + bias


### PR DESCRIPTION
## Revert of #38093

This reverts the merge commit 58631d7c3f9984f979e3cd5abf20a61590b36b1f from PR https://github.com/vllm-project/vllm/pull/38093.

**Reason:** This PR is suspected of causing the following CI failure in [build #62198](https://buildkite.com/vllm/ci/builds/62198):

- **Fusion and Compile Unit Tests (2xB200)** — `test_mla_attention_quant_pattern` failed with `AssertionError: Tensor-likes are not close!` (NaN values, 4.3% mismatched elements) in the FP8 static quantization path

The PR modified the FP8 `scaled_mm` pytorch kernel (`vllm/model_executor/kernels/linear/scaled_mm/pytorch.py`), which is in the code path used by the MLA attention quantization fusion test on B200 GPUs.

---
*Auto-generated by CI failure analyzer. 1 new failure linked to this PR.*