### PR TITLE
reasoning: fix NemotronV3 content:null when --reasoning-config is used

### DIFF
--- a/tests/reasoning/test_nemotron_v3_reasoning_parser.py
+++ b/tests/reasoning/test_nemotron_v3_reasoning_parser.py
@@ -170,3 +170,53 @@ def test_nemotron_v3_with_thinking_keeps_truncated_reasoning(
 
     assert reasoning == "This is truncated reasoning"
     assert content is None
+
+
+def test_nemotron_v3_no_kwargs_plain_output_returns_content(
+    tokenizer: FakeNemotronTokenizer,
+):
+    """When --reasoning-config is used without per-request enable_thinking and
+    the model emits plain content (no <think> marker), the output must land in
+    content, not reasoning_content (issue #39103)."""
+    parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+    parser = parser_cls(tokenizer)
+    # No chat_template_kwargs at all — simulates a plain API call made while
+    # the server has --reasoning-config set but the request omits enable_thinking.
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[],
+    )
+
+    reasoning, content = run_reasoning_extraction(
+        parser,
+        ["The answer is 42."],
+        request=request,
+        streaming=False,
+    )
+
+    assert reasoning is None
+    assert content == "The answer is 42."
+
+
+def test_nemotron_v3_no_kwargs_truncated_reasoning_stays_in_reasoning(
+    tokenizer: FakeNemotronTokenizer,
+):
+    """When the model starts a <think> section but generation is truncated
+    before </think>, the partial reasoning must remain in reasoning_content
+    regardless of whether enable_thinking was supplied."""
+    parser_cls = ReasoningParserManager.get_reasoning_parser(parser_name)
+    parser = parser_cls(tokenizer)
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[],
+    )
+
+    reasoning, content = run_reasoning_extraction(
+        parser,
+        ["<think>", "I am still thinking"],
+        request=request,
+        streaming=False,
+    )
+
+    assert reasoning == "I am still thinking"
+    assert content is None

--- a/vllm/reasoning/nemotron_v3_reasoning_parser.py
+++ b/vllm/reasoning/nemotron_v3_reasoning_parser.py
@@ -20,14 +20,26 @@ class NemotronV3ReasoningParser(DeepSeekR1ReasoningParser):
         reasoning, final_content = super().extract_reasoning(model_output, request)
         chat_template_kwargs = getattr(request, "chat_template_kwargs", None)
 
-        if (
-            chat_template_kwargs
-            and (
-                chat_template_kwargs.get("enable_thinking") is False
-                or chat_template_kwargs.get("force_nonempty_content") is True
-            )
-            and final_content is None
-        ):
-            reasoning, final_content = final_content, reasoning
+        enable_thinking = (
+            chat_template_kwargs.get("enable_thinking", None)
+            if chat_template_kwargs
+            else None
+        )
+        force_nonempty = (
+            chat_template_kwargs.get("force_nonempty_content", False)
+            if chat_template_kwargs
+            else False
+        )
+
+        if final_content is None:
+            if enable_thinking is False or force_nonempty:
+                # Explicit non-thinking mode or force-nonempty: put output in
+                # content.
+                reasoning, final_content = final_content, reasoning
+            elif enable_thinking is not True and self.start_token not in model_output:
+                # No explicit enable_thinking=True and no start token in the
+                # output: the model did not enter a thinking section, so the
+                # entire output is regular content rather than reasoning.
+                reasoning, final_content = final_content, reasoning
 
         return reasoning, final_content


### PR DESCRIPTION
## Summary

When the server is started with `--reasoning-config` (e.g. to enable per-request `thinking_token_budget`) but individual requests do not include `chat_template_kwargs.enable_thinking=True`, the Nemotron model emits plain content with no `<think>...</think>` delimiters.

Previously `NemotronV3ReasoningParser.extract_reasoning` only swapped reasoning↔content when `enable_thinking` was explicitly `False` or `force_nonempty_content` was `True`. Any other request including the common case of no `chat_template_kwargs` at all would put the entire output in `reasoning_content` and return `content: null`, regardless of whether the model had actually entered a thinking section.

## Fix

When `final_content is None` and `enable_thinking` is not explicitly `True`, check whether the model output contains the start token (`<think>`):
- **No `<think>` found** → model never entered a thinking section → swap output to `content`
- **`<think>` found but no `</think>`** → truncated reasoning → keep in `reasoning_content` (unchanged behaviour)

Existing behaviour for explicit `enable_thinking=False` and `force_nonempty_content=True` is unchanged.

## Tests

Two new unit tests added to `tests/reasoning/test_nemotron_v3_reasoning_parser.py`:
- `test_nemotron_v3_no_kwargs_plain_output_returns_content` plain output with no kwargs goes to `content`
- `test_nemotron_v3_no_kwargs_truncated_reasoning_stays_in_reasoning` output with `<think>` but no `</think>` stays in `reasoning_content`

Fixes #39103