### PR TITLE
[Model] Fix quantized DFlash Qwen3 draft support

### DIFF
--- a/tests/model_executor/test_eagle_quantization.py
+++ b/tests/model_executor/test_eagle_quantization.py
@@ -1,12 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
 import torch
+from transformers import Qwen3Config
 
-from vllm.config import LoadConfig, ModelConfig, SpeculativeConfig, VllmConfig
+from vllm.config import (
+    LoadConfig,
+    ModelConfig,
+    SpeculativeConfig,
+    VllmConfig,
+    set_current_vllm_config,
+)
 from vllm.model_executor.models.utils import get_draft_quant_config
 from vllm.platforms import current_platform
 
@@ -213,3 +221,188 @@ def test_load_weights_kv_scale_handling():
 
             assert scale_name == "layers.0.self_attn.kv_scale"
             assert weight_to_load == loaded_weight_tensor[0]
+
+
+def test_dflash_qwen3_layers_receive_quant_config(default_vllm_config):
+    from vllm.model_executor.models.qwen3_dflash import DFlashQwen3Model
+
+    mock_quant_config = Mock()
+    hf_config = Qwen3Config(
+        vocab_size=1000,
+        hidden_size=256,
+        intermediate_size=512,
+        num_hidden_layers=2,
+        num_attention_heads=8,
+        num_key_value_heads=4,
+    )
+    hf_config.dflash_config = {"use_aux_hidden_state": False}
+
+    default_vllm_config.speculative_config = Mock()
+    default_vllm_config.speculative_config.draft_model_config = Mock()
+    default_vllm_config.speculative_config.draft_model_config.hf_config = hf_config
+
+    decoder_layer_ctor = Mock(side_effect=lambda *args, **kwargs: torch.nn.Identity())
+
+    with (
+        patch(
+            "vllm.model_executor.models.qwen3_dflash.VocabParallelEmbedding",
+            return_value=torch.nn.Identity(),
+        ),
+        patch(
+            "vllm.model_executor.models.qwen3_dflash.DFlashQwen3DecoderLayer",
+            decoder_layer_ctor,
+        ),
+        patch(
+            "vllm.model_executor.models.qwen3_dflash.RMSNorm",
+            return_value=torch.nn.Identity(),
+        ),
+        patch(
+            "vllm.model_executor.models.qwen3_dflash.get_draft_quant_config",
+            return_value=mock_quant_config,
+        ),
+        patch(
+            "vllm.model_executor.models.qwen3_dflash.get_current_vllm_config",
+            return_value=default_vllm_config,
+        ),
+        set_current_vllm_config(default_vllm_config),
+    ):
+        DFlashQwen3Model(vllm_config=default_vllm_config)
+
+    assert decoder_layer_ctor.call_count == hf_config.num_hidden_layers
+    for call in decoder_layer_ctor.call_args_list:
+        assert call.kwargs["quant_config"] is mock_quant_config
+
+
+def test_dflash_qwen3_attention_uses_qkv_proj_module():
+    from vllm.model_executor.models.qwen3_dflash import DFlashQwen3Attention
+
+    class DummyQKVProj:
+        def __init__(self, qkv_output: torch.Tensor):
+            self.bias = None
+            self.qkv_output = qkv_output
+            self.calls: list[torch.Tensor] = []
+
+        @property
+        def weight(self) -> torch.Tensor:
+            raise AssertionError("raw qkv weight access should be avoided")
+
+        def __call__(self, hidden_states: torch.Tensor):
+            self.calls.append(hidden_states)
+            return self.qkv_output, None
+
+    attention = object.__new__(DFlashQwen3Attention)
+    torch.nn.Module.__init__(attention)
+    attention.q_size = 4
+    attention.kv_size = 2
+    attention.head_dim = 2
+    attention.qkv_proj = DummyQKVProj(torch.arange(8, dtype=torch.float32).view(1, 8))
+    attention.q_norm = Mock(side_effect=lambda x: x)
+    attention.k_norm = Mock(side_effect=lambda x: x)
+    attention.rotary_emb = Mock(side_effect=lambda positions, q, k: (q, k))
+    attention.attn = Mock(side_effect=lambda q, k, v: q)
+    attention.o_proj = Mock(side_effect=lambda output: (output, None))
+
+    hidden_states = torch.randn(1, 6)
+    output = attention.forward(torch.tensor([0]), hidden_states)
+
+    assert len(attention.qkv_proj.calls) == 1
+    assert attention.qkv_proj.calls[0] is hidden_states
+    assert output.shape == (1, 4)
+
+
+def test_dflash_qwen3_precompute_uses_quantized_kv_fallback():
+    from vllm.model_executor.models.qwen3_dflash import DFlashQwen3Model
+
+    class DummyQKVProj:
+        def __init__(self, qkv_output: torch.Tensor):
+            self.bias = None
+            self.qkv_output = qkv_output
+            self.calls = 0
+
+        @property
+        def weight(self) -> torch.Tensor:
+            raise AssertionError("quantized fallback should not build fused weights")
+
+        def __call__(self, hidden_states: torch.Tensor):
+            self.calls += 1
+            return self.qkv_output, None
+
+    num_ctx = 3
+    hidden_size = 4
+    q_size = 4
+    kv_size = 2
+    head_dim = 2
+    num_kv_heads = 1
+    context_states = torch.randn(num_ctx, hidden_size)
+    context_positions = torch.arange(num_ctx)
+    context_slot_mapping = torch.arange(num_ctx, dtype=torch.int64)
+
+    model = object.__new__(DFlashQwen3Model)
+    torch.nn.Module.__init__(model)
+    model.quant_config = Mock()
+    model.hidden_norm = SimpleNamespace(
+        weight=torch.nn.Parameter(torch.ones(hidden_size))
+    )
+    model.layers = []
+
+    qkv_outputs = [
+        torch.arange(num_ctx * (q_size + 2 * kv_size), dtype=torch.float32).view(
+            num_ctx, q_size + 2 * kv_size
+        ),
+        torch.arange(
+            num_ctx * (q_size + 2 * kv_size), 2 * num_ctx * (q_size + 2 * kv_size),
+            dtype=torch.float32
+        ).view(num_ctx, q_size + 2 * kv_size),
+    ]
+
+    attn_layers = []
+    for qkv_output in qkv_outputs:
+        qkv_proj = DummyQKVProj(qkv_output)
+        k_norm = Mock(side_effect=lambda x: x)
+        k_norm.weight = torch.nn.Parameter(torch.ones(head_dim))
+        q_norm = SimpleNamespace(variance_epsilon=1e-6)
+        rotary_emb = SimpleNamespace(
+            head_size=head_dim,
+            cos_sin_cache=torch.zeros(16, dtype=torch.float32),
+            is_neox_style=False,
+        )
+        attn_impl = SimpleNamespace(do_kv_cache_update=Mock())
+        attn = SimpleNamespace(impl=attn_impl, kv_cache=object())
+        attn_layer = SimpleNamespace(
+            qkv_proj=qkv_proj,
+            q_size=q_size,
+            kv_size=kv_size,
+            num_kv_heads=num_kv_heads,
+            head_dim=head_dim,
+            k_norm=k_norm,
+            q_norm=q_norm,
+            rotary_emb=rotary_emb,
+            attn=attn,
+        )
+        attn_layers.append(attn_layer)
+        model.layers.append(SimpleNamespace(self_attn=attn_layer))
+
+    with (
+        patch(
+            "vllm.model_executor.models.qwen3_dflash.ops.rms_norm",
+            side_effect=lambda out, x, weight, eps: out.copy_(x),
+        ),
+        patch(
+            "vllm.model_executor.models.qwen3_dflash.ops.rotary_embedding",
+            side_effect=lambda *args, **kwargs: None,
+        ),
+        patch(
+            "vllm.model_executor.models.qwen3_dflash.F.linear",
+            side_effect=AssertionError("fused dense linear should not run"),
+        ),
+    ):
+        model.precompute_and_store_context_kv(
+            context_states,
+            context_positions,
+            context_slot_mapping,
+        )
+
+    assert model._use_quantized_kv_fallback is True
+    for attn_layer in attn_layers:
+        assert attn_layer.qkv_proj.calls == 1
+        attn_layer.attn.impl.do_kv_cache_update.assert_called_once()

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -131,7 +131,7 @@ class DFlashQwen3Attention(nn.Module):
         with the context K/V from the target model's hidden states. This forward op
         computes attention for the query tokens only.
         See also: precompute_and_store_context_kv"""
-        qkv = F.linear(hidden_states, self.qkv_proj.weight, self.qkv_proj.bias)
+        qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
         # Per-head RMSNorm
@@ -249,6 +249,7 @@ class DFlashQwen3Model(nn.Module):
                     current_vllm_config,
                     prefix=maybe_prefix(prefix, f"layers.{layer_idx + start_layer_id}"),
                     config=self.config,
+                    quant_config=self.quant_config,
                 )
                 for layer_idx in range(self.config.num_hidden_layers)
             ]
@@ -294,21 +295,23 @@ class DFlashQwen3Model(nn.Module):
         """
         layers_attn = [layer.self_attn for layer in self.layers]
         attn0 = layers_attn[0]
-        has_bias = attn0.qkv_proj.bias is not None
-
         self._hidden_norm_weight = self.hidden_norm.weight.data
-
-        # KV projection weights: [num_layers * 2 * kv_size, hidden_size]
-        kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
-        self._fused_kv_weight = torch.cat(kv_weights, dim=0)
-        if has_bias:
-            kv_biases = [a.qkv_proj.bias[a.q_size :] for a in layers_attn]
-            self._fused_kv_bias: torch.Tensor | None = torch.cat(kv_biases, dim=0)
-        else:
-            self._fused_kv_bias = None
+        self._use_quantized_kv_fallback = self.quant_config is not None
 
         # K-norm weights: list of [head_dim] tensors, one per layer.
         self._k_norm_weights = [a.k_norm.weight.data for a in layers_attn]
+
+        if not self._use_quantized_kv_fallback:
+            has_bias = attn0.qkv_proj.bias is not None
+
+            # KV projection weights: [num_layers * 2 * kv_size, hidden_size]
+            kv_weights = [a.qkv_proj.weight[a.q_size :] for a in layers_attn]
+            self._fused_kv_weight = torch.cat(kv_weights, dim=0)
+            if has_bias:
+                kv_biases = [a.qkv_proj.bias[a.q_size :] for a in layers_attn]
+                self._fused_kv_bias: torch.Tensor | None = torch.cat(kv_biases, dim=0)
+            else:
+                self._fused_kv_bias = None
 
         # RoPE parameters
         self._rope_head_size = attn0.rotary_emb.head_size
@@ -378,6 +381,48 @@ class DFlashQwen3Model(nn.Module):
             self._hidden_norm_weight,
             self._rms_norm_eps,
         )
+        if self._use_quantized_kv_fallback:
+            for layer in self.layers:
+                attn_layer = layer.self_attn
+                qkv, _ = attn_layer.qkv_proj(normed_context_states)
+                _, k, v = qkv.split(
+                    [attn_layer.q_size, attn_layer.kv_size, attn_layer.kv_size], dim=-1
+                )
+
+                k = attn_layer.k_norm(
+                    k.view(num_ctx, attn_layer.num_kv_heads, attn_layer.head_dim)
+                )
+                v = v.view(num_ctx, attn_layer.num_kv_heads, attn_layer.head_dim)
+                k_flat = k.contiguous().view(num_ctx, attn_layer.kv_size)
+
+                cos_sin_cache = attn_layer.rotary_emb.cos_sin_cache
+                if cos_sin_cache.dtype != k_flat.dtype:
+                    cos_sin_cache = cos_sin_cache.to(dtype=k_flat.dtype)
+                ops.rotary_embedding(
+                    context_positions,
+                    k_flat,
+                    None,
+                    attn_layer.rotary_emb.head_size,
+                    cos_sin_cache,
+                    attn_layer.rotary_emb.is_neox_style,
+                )
+
+                if context_slot_mapping is None:
+                    continue
+
+                attn = attn_layer.attn
+                kv_cache = attn.kv_cache
+                attn.impl.do_kv_cache_update(
+                    attn,
+                    k_flat.view(
+                        num_ctx, attn_layer.num_kv_heads, attn_layer.head_dim
+                    ),
+                    v,
+                    kv_cache,
+                    context_slot_mapping,
+                )
+            return
+
         all_kv_flat = F.linear(
             normed_context_states, self._fused_kv_weight, self._fused_kv_bias
         )


### PR DESCRIPTION
## Summary
- pass the draft `quant_config` into `DFlashQwen3DecoderLayer` so quantized draft checkpoints initialize quantized linears instead of dense modules
- use `self.qkv_proj(hidden_states)` in `DFlashQwen3Attention.forward` instead of bypassing quantized linear modules with raw `F.linear(...)`
- keep the existing fused dense KV precompute fast path for unquantized drafts, but use a per-layer quantization-aware fallback for quantized drafts during context KV precompute

## Why this is not duplicating an existing PR
- `#39995` is about DFlash with FlashInfer attention backend behavior and does not make `qwen3_dflash.py` quantization-aware
- `#40334` fixes a dtype mismatch in `combine_hidden_states` and does not propagate `quant_config` into DFlash layers or handle quantized context-KV precompute

## Testing
- `uv run --project /home/infatoshi/qwen3.6 ruff check vllm/model_executor/models/qwen3_dflash.py tests/model_executor/test_eagle_quantization.py`
  - `All checks passed!`
- `PYTHONPATH=$PWD uv run --project /home/infatoshi/qwen3.6 --with tblib pytest tests/model_executor/test_eagle_quantization.py -v`
  - `11 passed`

## Notes
- this is intended as a correctness and compatibility fix for quantized DFlash draft checkpoints; it does not claim a throughput improvement over BF16 drafts
- I also manually validated the same logic in a local vLLM runtime with a quantized Qwen3.6 DFlash NVFP4 draft serving real requests in eager and graph modes

## AI Assistance
This PR was prepared with AI assistance. The changed lines, duplicate-work check, and local validation results were reviewed before submission.
