### PR TITLE
[CPU][RISC-V] Add FAST_EXP and FAST_SPINNING macros for RVV

### DIFF
--- a/csrc/cpu/cpu_arch_macros.h
+++ b/csrc/cpu/cpu_arch_macros.h
@@ -110,4 +110,20 @@
 
 #endif  // __aarch64__
 
+// RISC-V RVV
+#ifdef __riscv_v
+  #include <riscv_vector.h>
+
+  #ifdef __riscv_zihintpause
+    #define FAST_SPINNING __riscv_pause();
+  #endif
+
+  // FP32Vec16::exp() in cpu_types_riscv.hpp already implements the full
+  // polynomial approximation for RVV, so we simply delegate to it.
+  #define DEFINE_FAST_EXP                             \
+    auto fast_exp = [&](const vec_op::FP32Vec16& vec) \
+                        __attribute__((always_inline)) { return vec.exp(); };
+
+#endif  // __riscv_v
+
 #endif


### PR DESCRIPTION
## Purpose

  Add `FAST_EXP` and `FAST_SPINNING` macros to `csrc/cpu/cpu_arch_macros.h`
  for the RISC-V RVV target, mirroring the existing x86 and ARM branches.

  - **`FAST_EXP`** delegates to `vec_op::FP32Vec16::exp()` in
    `cpu_types_riscv_impl.hpp`, which already implements the polynomial
    approximation for RVV. Reusing it avoids duplicating the coefficients
    and keeps numeric behavior consistent across call sites.
  - **`FAST_SPINNING`** expands to `__riscv_pause()` when the Zihintpause
    extension is available, and is intentionally left undefined otherwise.
    This matches the convention used by the ARM branch in the same file
    (which does not define `FAST_SPINNING` at all), and every call site
    in `cpu_attn_impl.hpp` guards usage with `#ifdef FAST_SPINNING`, so
    omitting the definition is a no-op hint rather than a compile error.

  These macros are consumed by the RVV-optimized attention kernels in
  PR #40119 and are suitable for reuse by future RVV CPU kernels (e.g.
  softmax, layernorm) that want an arch-neutral fast-exp path.

  ## Why not duplicating an existing PR

  Searched open PRs touching `csrc/cpu/cpu_arch_macros.h` and no other PR
  introduces an RVV branch to this file. The attention PR #40119 depends
  on these macros but does not itself modify `cpu_arch_macros.h`.

  ## Test plan

  - [x] Build on SG2044 (openEuler RISC-V 64, VLEN=128): passes.
  - [x] Build on x86_64 and aarch64: unaffected — the entire new block is
        guarded by `#ifdef __riscv_v`.
  - [x] `pre-commit run --files csrc/cpu/cpu_arch_macros.h` → Passed.
  - [x] Verified that `FAST_EXP` / `FAST_SPINNING` are correctly picked up
        by the consumer in `cpu_attn_impl.hpp` when building the attention
        kernels from PR #40119.

  ## Test result

  No regression on x86 / ARM (the change is invisible on those targets).
  On RVV the attention kernel build succeeds and the macros are expanded
  as expected.


