### PR TITLE
[vLLM IR] Add the `symbolic_shapes` feature to the generator.

### DIFF
--- a/tests/ir/test_op.py
+++ b/tests/ir/test_op.py
@@ -12,6 +12,7 @@ from torch.fx.experimental.proxy_tensor import make_fx
 
 import vllm.ir.op
 from vllm.ir.op import RESERVED_PROVIDERS, IrOp, IrOpImpl
+from vllm.ir.ops.layernorm import rms_norm
 
 # This should not exist
 assert "_custom_add" not in IrOp.registry
@@ -560,3 +561,40 @@ class TestTolerance:
         op = IrOp("_tol_test_unknown", _test_native)
         with pytest.raises(ValueError, match="No tolerance defined"):
             op.get_tolerance(torch.complex64)
+
+
+class TestEnableSymbolic:
+    def test_enable_symbolic_context_manager(self):
+        """Test context manager toggles symbolic mode on/off."""
+        assert rms_norm._symbolic_mode is False
+
+        with rms_norm.enable_symbolic():
+            assert rms_norm._symbolic_mode is True
+
+        assert rms_norm._symbolic_mode is False
+
+    def test_generate_inputs_symbolic_replaces_first_dim(self):
+        """Test symbolic mode replaces first dim with SymInt."""
+        from torch import SymInt
+
+        # Normal mode
+        result = rms_norm.generate_inputs(
+            num_tokens=128, hidden_size=64, dtype=torch.float32
+        )
+        assert result[0].shape == (128, 64)
+        assert result[1].shape == (64,)
+
+        # Symbolic mode
+        with rms_norm.enable_symbolic():
+            result = rms_norm.generate_inputs(
+                num_tokens=128, hidden_size=64, dtype=torch.float32
+            )
+            # First dim is SymInt
+            assert isinstance(result[0].shape[0], SymInt)
+            # Remaining dims preserved
+            assert result[0].shape[1:] == (64,)
+            # Meta device
+            assert result[0].device.type == "meta"
+            assert result[1].device.type == "meta"
+            # dtype preserved
+            assert result[0].dtype == torch.float32

--- a/tests/ir/test_op.py
+++ b/tests/ir/test_op.py
@@ -590,9 +590,12 @@ class TestEnableSymbolic:
                 num_tokens=128, hidden_size=64, dtype=torch.float32
             )
             # First dim is SymInt
+            # First dim is SymInt
             assert isinstance(result[0].shape[0], SymInt)
             # Remaining dims preserved
             assert result[0].shape[1:] == (64,)
+            # Weight shape preserved (not symbolic)
+            assert result[1].shape == (64,)
             # Meta device
             assert result[0].device.type == "meta"
             assert result[1].device.type == "meta"

--- a/tests/ir/test_op.py
+++ b/tests/ir/test_op.py
@@ -590,14 +590,12 @@ class TestEnableSymbolic:
                 num_tokens=128, hidden_size=64, dtype=torch.float32
             )
             # First dim is SymInt
-            # First dim is SymInt
             assert isinstance(result[0].shape[0], SymInt)
             # Remaining dims preserved
             assert result[0].shape[1:] == (64,)
-            # Weight shape preserved (not symbolic)
-            assert result[1].shape == (64,)
-            # Meta device
+            # First tensor converted to meta device
             assert result[0].device.type == "meta"
-            assert result[1].device.type == "meta"
+            # Weight unchanged (kept as original, not converted to meta)
+            assert result[1].device.type != "meta"
             # dtype preserved
             assert result[0].dtype == torch.float32

--- a/vllm/ir/op.py
+++ b/vllm/ir/op.py
@@ -118,6 +118,7 @@ class IrOp:
         self._schema_str = infer_schema(native_impl, mutates_args=[])
         self._input_generator: InputGenerator | None = None
         self._tolerance_overrides: ToleranceSpec = {}
+        self._symbolic_mode: bool = False
 
         # native implementation
         self.impls["native"] = IrOpImpl(
@@ -329,13 +330,57 @@ class IrOp:
         self._input_generator = fn
         return fn
 
+    @contextlib.contextmanager
+    def enable_symbolic(self, enabled: bool = True):
+        """
+        Context manager to enable/disable symbolic mode for input generation.
+
+        In symbolic mode, generate_inputs() replaces the first dimension
+        (num_tokens) of input tensors with a SymInt, making them suitable
+        for torch.compile graph tracing.
+
+        Example:
+            with rms_norm.enable_symbolic():
+                inputs = rms_norm.generate_inputs(
+                    num_tokens=128, hidden_size=4096, dtype=torch.float16
+                )
+                # inputs[0].shape[0] is a SymInt, not a concrete number
+        """
+        old = self._symbolic_mode
+        try:
+            self._symbolic_mode = enabled
+            yield
+        finally:
+            self._symbolic_mode = old
+
+    def _make_symbolic(self, args: tuple) -> tuple[Any, ...]:
+        """Replace the first dimension of tensors in args with a SymInt."""
+        from torch.fx.experimental.symbolic_shapes import ShapeEnv
+
+        shape_env = ShapeEnv()
+        sym_num_tokens = shape_env.create_unbacked_symint()
+
+        result: list[Any] = []
+        for arg in args:
+            if isinstance(arg, torch.Tensor) and arg.dim() >= 1:
+                new_shape = (sym_num_tokens,) + arg.shape[1:]
+                result.append(
+                    torch.empty(new_shape, device="meta", dtype=arg.dtype)
+                )
+            else:
+                result.append(arg)
+        return tuple(result)
+
     def generate_inputs(self, **kwargs: Any) -> tuple[Any, ...]:
         if self._input_generator is None:
             raise RuntimeError(
                 f"No input generator registered for op '{self.name}'. "
                 f"Use @ir.ops.{self.name}.register_input_generator"
             )
-        return self._input_generator(**kwargs)
+        args = self._input_generator(**kwargs)
+        if self._symbolic_mode:
+            return self._make_symbolic(args)
+        return args
 
     def override_tolerance(
         self, dtype: torch.dtype, *, atol: float, rtol: float

--- a/vllm/ir/op.py
+++ b/vllm/ir/op.py
@@ -354,15 +354,26 @@ class IrOp:
             self._symbolic_mode = old
 
     def _make_symbolic(self, args: tuple) -> tuple[Any, ...]:
-        """Replace the first dimension of tensors in args with a SymInt."""
+        """Replace the first dimension of the first tensor with a SymInt.
+
+        Only the first tensor (typically the input) gets its first dimension
+        replaced with a SymInt. Other parameters like weight, bias, epsilon
+        remain unchanged.
+        """
         from torch.fx.experimental.symbolic_shapes import ShapeEnv
 
         shape_env = ShapeEnv()
         sym_num_tokens = shape_env.create_unbacked_symint()
 
         result: list[Any] = []
+        first_tensor_found = False
         for arg in args:
-            if isinstance(arg, torch.Tensor) and arg.dim() >= 1:
+            if (
+                isinstance(arg, torch.Tensor)
+                and arg.dim() >= 1
+                and not first_tensor_found
+            ):
+                first_tensor_found = True
                 new_shape = (sym_num_tokens,) + arg.shape[1:]
                 result.append(torch.empty(new_shape, device="meta", dtype=arg.dtype))
             else:

--- a/vllm/ir/op.py
+++ b/vllm/ir/op.py
@@ -364,9 +364,7 @@ class IrOp:
         for arg in args:
             if isinstance(arg, torch.Tensor) and arg.dim() >= 1:
                 new_shape = (sym_num_tokens,) + arg.shape[1:]
-                result.append(
-                    torch.empty(new_shape, device="meta", dtype=arg.dtype)
-                )
+                result.append(torch.empty(new_shape, device="meta", dtype=arg.dtype))
             else:
                 result.append(arg)
         return tuple(result)


### PR DESCRIPTION
## Purpose
 - https://github.com/vllm-project/vllm/pull/40167

Following this task, generators can greatly facilitate testing.

This feature was added to support the requirements of e2e lowering testing.
 - https://github.com/vllm-project/vllm/pull/40319



### Basic Principle
Replace the generator's first tensor with a tensor of indeterminate shape[0].

**If this integration is unnecessary—and should instead be handled within the tests—please feel free to point that out.**

## Test Plan
```
pytest tests/ir/test_op.py::TestEnableSymbolic -v
```
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

