### PR TITLE
Fix CLI transformers preload import race

### DIFF
--- a/tests/entrypoints/test_cli_main.py
+++ b/tests/entrypoints/test_cli_main.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import builtins
+
+from vllm.entrypoints.cli import main as cli_main
+
+
+def test_bg_preload_torch_does_not_import_transformers(monkeypatch):
+    original_import = builtins.__import__
+    imported_modules: list[str] = []
+
+    def tracking_import(name, globals=None, locals=None, fromlist=(), level=0):
+        imported_modules.append(name)
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", tracking_import)
+
+    cli_main._bg_preload_torch()
+
+    assert "torch" in imported_modules
+    assert "transformers" not in imported_modules

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -5,31 +5,24 @@
 Note that all future modules must be lazily loaded within main
 to avoid certain eager import breakage."""
 
-import contextlib
 import importlib.metadata
 import os
 import sys
 import threading as _threading
 
 
-# [startup] Kick off torch + transformers .so/module loading in a background
-# thread before we touch vllm.logger (which pulls vllm/__init__.py ->
-# vllm.env_override -> `import torch` on the main thread). Python import
-# lock serializes the same-module import across threads, but the .so dlopen
-# inside torch's init releases the GIL during file I/O. Main thread's
-# non-torch imports (vllm.envs submodules, stdlib, fastapi, etc.) can make
-# progress on the CPU while the background thread pays the ~2 s of cuda
-# .so loading. `import transformers` is also ~2 s of cold-disk work and
-# depends on torch; chain it after torch in the same thread so subsequent
-# `from transformers import ...` lines on the main thread hit a warm
-# module cache.
+# [startup] Kick off torch .so/module loading in a background thread before
+# we touch vllm.logger (which pulls vllm/__init__.py -> vllm.env_override ->
+# `import torch` on the main thread). Python import lock serializes the
+# same-module import across threads, but the .so dlopen inside torch's init
+# releases the GIL during file I/O. Main thread's non-torch imports
+# (vllm.envs submodules, stdlib, fastapi, etc.) can make progress on the
+# CPU while the background thread pays the ~2 s of cuda .so loading.
 def _bg_preload_torch() -> None:
     try:
         import torch  # noqa: F401
     except Exception:
         return
-    with contextlib.suppress(Exception):
-        import transformers  # noqa: F401
 
 
 _threading.Thread(


### PR DESCRIPTION
## Summary

This fixes a CLI startup import race caused by the background preload thread in `vllm/entrypoints/cli/main.py`.

The CLI currently starts a background thread that preloads both `torch` and `transformers` at module import time. Meanwhile the main thread proceeds into the CLI import path and reaches `from transformers import GenerationConfig, PretrainedConfig` in `vllm/transformers_utils/config.py`.

In practice this can fail with:

```text
ImportError: cannot import name 'GenerationConfig' from 'transformers'
```

Removing the background `transformers` preload avoids the race while preserving the background `torch` preload.

This PR also adds a regression test to ensure `_bg_preload_torch()` does not import `transformers`.

## Why this is not duplicating an existing PR

I checked open PRs for related fixes using searches for:

- `GenerationConfig`
- `transformers preload`
- `cli main preload thread`

and did not find an open PR addressing this CLI preload race.

## Reproduction

Before this patch:

```bash
.venv/bin/vllm --help
```

could fail during CLI startup with the `GenerationConfig` import error above.

After this patch, the same command prints CLI help successfully.

## Tests run

```bash
.venv/bin/python -m pytest tests/entrypoints/test_cli_main.py -v
.venv/bin/vllm --help
```

Results:

- `tests/entrypoints/test_cli_main.py`: passed
- `.venv/bin/vllm --help`: succeeded

## AI assistance

This change was prepared with AI assistance and then reviewed end-to-end by the submitter.
