### PR TITLE
[Startup] Remove unnecessary torch/transformers background preload thread

### DIFF
--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -12,31 +12,6 @@ import sys
 import threading as _threading
 
 
-# [startup] Kick off torch + transformers .so/module loading in a background
-# thread before we touch vllm.logger (which pulls vllm/__init__.py ->
-# vllm.env_override -> `import torch` on the main thread). Python import
-# lock serializes the same-module import across threads, but the .so dlopen
-# inside torch's init releases the GIL during file I/O. Main thread's
-# non-torch imports (vllm.envs submodules, stdlib, fastapi, etc.) can make
-# progress on the CPU while the background thread pays the ~2 s of cuda
-# .so loading. `import transformers` is also ~2 s of cold-disk work and
-# depends on torch; chain it after torch in the same thread so subsequent
-# `from transformers import ...` lines on the main thread hit a warm
-# module cache.
-def _bg_preload_torch() -> None:
-    try:
-        import torch  # noqa: F401
-    except Exception:
-        return
-    with contextlib.suppress(Exception):
-        import transformers  # noqa: F401
-
-
-_threading.Thread(
-    target=_bg_preload_torch, daemon=True, name="vllm-torch-preload"
-).start()
-
-
 # [startup] Pre-spawn EngineCore via forkserver preload, in a background
 # thread. Only fires for `vllm serve` (the only subcommand that spawns a
 # long-running EngineCore). The forkserver process is forked once and


### PR DESCRIPTION




## Purpose

[Startup] Remove superfluous torch/transformers background preload thread

fix https://github.com/vllm-project/vllm/pull/40331

## Test Plan
```
  vllm serve /mnt/data4/models/Qwen/Qwen3-8B --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser qwen3 --served-model-name my-model claude-haiku-4-5-20251001 claude-sonnet-4-6 claude-opus-4-6 gpt-5
Traceback (most recent call last):
  File "/mnt/data4/jxy/venv/bin/vllm", line 10, in <module>
    sys.exit(main())
             ^^^^^^
  File "/mnt/data4/jxy/vllm/vllm/entrypoints/cli/main.py", line 82, in main
    import vllm.entrypoints.cli.benchmark.main
  File "/mnt/data4/jxy/vllm/vllm/entrypoints/cli/benchmark/main.py", line 10, in <module>
    from vllm.entrypoints.utils import VLLM_SUBCMD_PARSER_EPILOG
  File "/mnt/data4/jxy/vllm/vllm/entrypoints/utils.py", line 19, in <module>
    from vllm.engine.arg_utils import EngineArgs
  File "/mnt/data4/jxy/vllm/vllm/engine/arg_utils.py", line 35, in <module>
    from vllm.config import (
  File "/mnt/data4/jxy/vllm/vllm/config/__init__.py", line 20, in <module>
    from vllm.config.model import (
  File "/mnt/data4/jxy/vllm/vllm/config/model.py", line 30, in <module>
    from vllm.transformers_utils.config import (
  File "/mnt/data4/jxy/vllm/vllm/transformers_utils/config.py", line 18, in <module>
    from transformers import GenerationConfig, PretrainedConfig
ImportError: cannot import name 'GenerationConfig' from 'transformers' (/mnt/data4/jxy/venv/lib/python3.12/site-packages/transformers/__init__.py)

```
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

