### PR TITLE
[bugfix] Fix floating-point comparisons in GPU sampling kernels to use epsilon…

### DIFF
--- a/vllm/v1/worker/gpu/sample/gumbel.py
+++ b/vllm/v1/worker/gpu/sample/gumbel.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import torch
 
+from vllm.sampling_params import _SAMPLING_EPS
 from vllm.triton_utils import tl, triton
 
 
@@ -17,7 +18,7 @@ def _temperature_kernel(
     token_idx = tl.program_id(0)
     req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
     temperature = tl.load(temperature_ptr + req_state_idx).to(tl.float32)
-    if temperature == 0.0 or temperature == 1.0:
+    if tl.abs(temperature) < _SAMPLING_EPS or tl.abs(temperature - 1.0) < _SAMPLING_EPS:
         # Early return to avoid loading logits.
         return
 
@@ -80,7 +81,7 @@ def gumbel_block_argmax(
 ):
     req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
     temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
-    if temp != 0.0 and APPLY_TEMPERATURE:
+    if abs(temp) > _SAMPLING_EPS and APPLY_TEMPERATURE:
         # Apply temperature.
         # NOTE(woosuk): Match the behavior of _temperature_kernel.
         # E.g., if the kernel uses tl.div_rn, we should use tl.div_rn here too.
@@ -95,7 +96,7 @@ def gumbel_block_argmax(
         )
 
     logits = logits.to(tl.float64)
-    if temp != 0.0:
+    if abs(temp) > _SAMPLING_EPS:
         # Calculate the seed for gumbel noise.
         seed = tl.load(seeds_ptr + req_state_idx)
         pos = tl.load(pos_ptr + token_idx)

--- a/vllm/v1/worker/gpu/sample/min_p.py
+++ b/vllm/v1/worker/gpu/sample/min_p.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import torch
 
+from vllm.sampling_params import _SAMPLING_EPS
 from vllm.triton_utils import tl, triton
 
 
@@ -17,7 +18,7 @@ def _min_p_kernel(
     token_idx = tl.program_id(0)
     req_state_idx = tl.load(expanded_idx_mapping_ptr + token_idx)
     min_p = tl.load(min_p_ptr + req_state_idx).to(tl.float32)
-    if min_p == 0.0:
+    if tl.abs(min_p) < _SAMPLING_EPS:
         return
 
     max_val = float("-inf")

--- a/vllm/v1/worker/gpu/sample/states.py
+++ b/vllm/v1/worker/gpu/sample/states.py
@@ -3,7 +3,7 @@
 import numpy as np
 import torch
 
-from vllm.sampling_params import SamplingParams
+from vllm.sampling_params import _SAMPLING_EPS, SamplingParams
 from vllm.v1.sample.ops.topk_topp_sampler import apply_top_k_top_p
 from vllm.v1.worker.gpu.buffer_utils import UvaBackedTensor
 from vllm.v1.worker.gpu.sample.gumbel import apply_temperature
@@ -68,7 +68,9 @@ class SamplingStates:
         idx_mapping_np: np.ndarray,
     ) -> None:
         temp_np = self.temperature.np[idx_mapping_np]
-        if np.all((temp_np == 0.0) | (temp_np == 1.0)):
+        if np.all(
+            (np.abs(temp_np) < _SAMPLING_EPS) | (np.abs(temp_np - 1.0) < _SAMPLING_EPS)
+        ):
             # No request requires temperature. Skip the kernel launch.
             return
 
@@ -80,7 +82,7 @@ class SamplingStates:
         expanded_idx_mapping: torch.Tensor,
         idx_mapping_np: np.ndarray,
     ) -> None:
-        if np.all(self.min_p.np[idx_mapping_np] == 0.0):
+        if np.all(self.min_p.np[idx_mapping_np] < _SAMPLING_EPS):
             # No request uses min_p. Skip the kernel launch.
             return
         apply_min_p(logits, expanded_idx_mapping, self.min_p.gpu)
@@ -92,7 +94,7 @@ class SamplingStates:
         idx_mapping_np: np.ndarray,
     ) -> torch.Tensor:
         do_top_k = np.any(self.top_k.np[idx_mapping_np] != self.vocab_size)
-        do_top_p = np.any(self.top_p.np[idx_mapping_np] != 1.0)
+        do_top_p = np.any(np.abs(self.top_p.np[idx_mapping_np] - 1.0) > _SAMPLING_EPS)
         if not (do_top_k or do_top_p):
             return logits
 

--- a/vllm/v1/worker/gpu/spec_decode/probabilistic_rejection_sampler_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/probabilistic_rejection_sampler_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import torch
 
+from vllm.sampling_params import _SAMPLING_EPS
 from vllm.triton_utils import tl, triton
 from vllm.v1.worker.gpu.sample.gumbel import gumbel_block_argmax, tl_rand64
 
@@ -93,7 +94,7 @@ def _compute_block_stats_kernel(
     block_offsets = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = block_offsets < vocab_size
 
-    if temp == 0.0:
+    if abs(temp) < _SAMPLING_EPS:
         # Greedy sampling. Only the target max/argmax are needed.
         target_logits = tl.load(
             target_logits_ptr + logit_idx * target_logits_stride + block_offsets,
@@ -218,7 +219,7 @@ def _probabilistic_rejection_kernel(
         if accepted:
             logit_idx = start_idx + i
             draft_sampled = tl.load(draft_sampled_ptr + logit_idx + 1)
-            if temp == 0.0:
+            if abs(temp) < _SAMPLING_EPS:
                 # Greedy sampling. Accept IFF draft matches target argmax.
                 # NOTE: Target argmax is stored directly so that resampling
                 # can be skipped upon rejection.
@@ -331,7 +332,7 @@ def _resample_kernel(
 
     temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
     is_bonus = resample_token_idx == end_idx - 1
-    if temp == 0.0 and not is_bonus:
+    if abs(temp) < _SAMPLING_EPS and not is_bonus:
         # Greedy + non-bonus token. No resampling needed because
         # the target argmax is already in the sampled tensor.
         return
@@ -443,7 +444,7 @@ def _insert_resampled_kernel(
 
     temp = tl.load(temp_ptr + req_state_idx).to(tl.float32)
     is_bonus = resample_token_idx == end_idx - 1
-    if temp == 0.0 and not is_bonus:
+    if abs(temp) < _SAMPLING_EPS and not is_bonus:
         # Greedy + non-bonus token. The target argmax is already
         # in the sampled tensor.
         return


### PR DESCRIPTION


## Purpose

Fix remaining floating-point comparison issues in GPU sampling kernels to use epsilon-based checks instead of exact equality comparisons. This addresses similar issues that were fixed in PR #285 for `sampling_params.py`.

Direct equality comparisons with floating-point numbers (e.g., `== 0.0`, `!= 0.0`) can cause numerical instability due to precision errors. This PR replaces these unsafe comparisons with epsilon-based checks using `_SAMPLING_EPS = 1e-5`, the epsilon value already used consistently throughout vLLM's sampling code (see `sampling_params.py`, `v1/sample/sampler.py`, etc.).

**Fixes:** Floating-point comparison issues in:
- `vllm/v1/worker/gpu/sample/gumbel.py`
- `vllm/v1/worker/gpu/sample/states.py`
- `vllm/v1/worker/gpu/sample/min_p.py`
- `vllm/v1/worker/gpu/spec_decode/probabilistic_rejection_sampler_utils.py`

**Related:** PR #285 (Remove floats == 0 comparison)

## Test Plan

```bash
# Install dependencies
uv venv --python 3.12
source .venv/bin/activate
VLLM_USE_PRECOMPILED=1 uv pip install -e . --torch-backend=auto
uv pip install -r cuda.in

# Test v1 sampling (includes gumbel.py, states.py, min_p.py)
.venv/bin/python -m pytest tests/v1/sample/ -v

# Test speculative decoding (includes probabilistic_rejection_sampler_utils.py)
.venv/bin/python -m pytest tests/v1/spec_decode/ -v

# Test GPU worker sampling
.venv/bin/python -m pytest tests/v1/worker/gpu/ -k sample -v

# Test v0 samplers (for compatibility and regression testing)
.venv/bin/python -m pytest tests/samplers/ -v

# Run linters
pre-commit run --all-files