### PR TITLE
[MM][CG] Optimize default `max_frames_per_batch` auto-infer for ViT CUDA graph video inference

### DIFF
--- a/docs/design/cuda_graphs_multimodal.md
+++ b/docs/design/cuda_graphs_multimodal.md
@@ -76,6 +76,7 @@ Models opt-in to encoder CUDA Graphs by implementing the [SupportsEncoderCudaGra
 * `encoder_cudagraph_forward(...)` — forward pass using precomputed buffers (called during capture and replay).
 * `encoder_eager_forward(...)` — fallback eager forward when no graph fits.
 * `get_input_modality(...)` - return the modality of the inputs.
+* `get_max_frames_per_video()` - return model-specific max frames per video.
 
 !!! note
     The `SupportsEncoderCudaGraph` protocol is designed to be model-agnostic. New vision encoder models can opt-in by implementing the protocol methods without modifying the manager.
@@ -96,7 +97,7 @@ Three fields in `CompilationConfig` control encoder CUDA Graphs:
 * `cudagraph_mm_encoder` (`bool`, default `False`) — enable CUDA Graph capture for multimodal encoder. When enabled, captures the full encoder forward as a CUDA Graph for each token budget level.
 * `encoder_cudagraph_token_budgets` (`list[int]`, default `[]`) — token budget levels for capture. If empty (default), auto-inferred from model architecture as power-of-2 levels. User-provided values override auto-inference.
 * `encoder_cudagraph_max_vision_items_per_batch` (`int`, default `0`) — maximum number of images/videos per batch during capture. If 0 (default), auto-inferred as `max_budget // min_budget`.
-* `encoder_cudagraph_max_frames_per_batch` (`int`, default `0`) — maximum number of video frames per batch during capture. If 0 (default), auto-inferred as `encoder_cudagraph_max_vision_items_per_batch * 2` (to be optimized).
+* `encoder_cudagraph_max_frames_per_batch` (`int`, default `None`) — maximum number of video frames per batch during capture. If `None` (default), auto-inferred as `encoder_cudagraph_max_vision_items_per_batch * max_frames_per_video` (`max_frames_per_video` is a model-specific value according to its `processing_info`). If we limit the video count per prompt to `0`, it will also be set to `0` (i.e., fall back to image-only mode).
 
 ## Usage guide
 

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -535,13 +535,15 @@ class CompilationConfig:
     model's budget range. User-provided positive value overrides
     auto-inference."""
 
-    encoder_cudagraph_max_frames_per_batch: int = 0
+    encoder_cudagraph_max_frames_per_batch: int | None = None
     """Maximum total video frames per batch for encoder CUDA graph capture.
     Controls the cu_seqlens buffer size (one entry per attention sequence,
-    i.e. one per video frame). If 0 (default), auto-inferred per budget
-    level as token_budget (tight bound: packing guarantees
-    sum(T_i) <= token_budget). Positive value overrides auto-inference
-    and applies to all budget levels."""
+    i.e. one per video frame).
+    If None (default), auto-inferred as encoder_cudagraph_max_vision_items_per_batch
+    * max_frames_per_video (model-specific value according to processing_info).
+    Positive value overrides auto-inference and applies to all budget levels.
+    If we limit the video count per prompt to `0`, it will also be set to `0`
+    (i.e., fall back to image-only mode)."""
 
     # Inductor capture
     compile_sizes: list[int | str] | None = None
@@ -993,11 +995,12 @@ class CompilationConfig:
             )
         if (
             self.cudagraph_mm_encoder
+            and self.encoder_cudagraph_max_frames_per_batch is not None
             and self.encoder_cudagraph_max_frames_per_batch < 0
         ):
             raise ValueError(
                 "encoder_cudagraph_max_frames_per_batch must be "
-                "non-negative (0 = auto-infer)"
+                "non-negative (None = auto-infer)"
             )
 
         if self.backend == "":

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -1531,6 +1531,12 @@ class SupportsEncoderCudaGraph(Protocol):
         """Return the modality of the inputs."""
         ...
 
+    def get_max_frames_per_video(
+        self,
+    ) -> int:
+        """Return model-specific max frames per video."""
+        ...
+
     def get_encoder_cudagraph_budget_range(
         self,
         vllm_config: "VllmConfig",

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1640,6 +1640,7 @@ class Qwen3VLForConditionalGeneration(
         multimodal_config = vllm_config.model_config.multimodal_config
 
         self.config = config
+        self.model_config = vllm_config.model_config
         self._tokenizer = cached_tokenizer_from_config(vllm_config.model_config)
         self.multimodal_config = multimodal_config
         self.use_data_parallel = multimodal_config.mm_encoder_tp_mode == "data"
@@ -1782,6 +1783,15 @@ class Qwen3VLForConditionalGeneration(
         if "image_grid_thw" in mm_kwargs:
             return "image"
         return "video"
+
+    def get_max_frames_per_video(self) -> int:
+        mm_registry = MULTIMODAL_REGISTRY
+        info = mm_registry.get_processing_info(self.model_config)
+        max_frames_per_video = info.get_num_frames_with_most_features(
+            seq_len=self.model_config.max_model_len,
+            mm_counts={"video": self.multimodal_config.get_limit_per_prompt("video")},
+        )
+        return max_frames_per_video
 
     def get_encoder_cudagraph_budget_range(
         self,

--- a/vllm/multimodal/registry.py
+++ b/vllm/multimodal/registry.py
@@ -100,9 +100,6 @@ class MultiModalRegistry:
     A registry that dispatches data processing according to the model.
     """
 
-    def __init__(self):
-        self.info = None
-
     def supports_multimodal_inputs(self, model_config: "ModelConfig") -> bool:
         """
         Checks if the model supports multimodal inputs.
@@ -114,7 +111,7 @@ class MultiModalRegistry:
             return False
 
         mm_config = model_config.get_multimodal_config()
-        info = self.get_processing_info(model_config)
+        info = self._create_processing_info(model_config, tokenizer=None)
 
         # Check if all supported modalities have limit == 0
         if all(
@@ -197,9 +194,7 @@ class MultiModalRegistry:
         return factories.info(ctx)
 
     def get_processing_info(self, model_config: "ModelConfig") -> BaseProcessingInfo:
-        if self.info is None:
-            self.info = self._create_processing_info(model_config, tokenizer=None)
-        return self.info
+        return self._create_processing_info(model_config, tokenizer=None)
 
     def create_processor(
         self,

--- a/vllm/multimodal/registry.py
+++ b/vllm/multimodal/registry.py
@@ -100,6 +100,9 @@ class MultiModalRegistry:
     A registry that dispatches data processing according to the model.
     """
 
+    def __init__(self):
+        self.info = None
+
     def supports_multimodal_inputs(self, model_config: "ModelConfig") -> bool:
         """
         Checks if the model supports multimodal inputs.
@@ -111,7 +114,7 @@ class MultiModalRegistry:
             return False
 
         mm_config = model_config.get_multimodal_config()
-        info = self._create_processing_info(model_config, tokenizer=None)
+        info = self.get_processing_info(model_config)
 
         # Check if all supported modalities have limit == 0
         if all(
@@ -192,6 +195,11 @@ class MultiModalRegistry:
         factories = model_cls._processor_factory
         ctx = self._create_processing_ctx(model_config, tokenizer)
         return factories.info(ctx)
+
+    def get_processing_info(self, model_config: "ModelConfig") -> BaseProcessingInfo:
+        if self.info is None:
+            self.info = self._create_processing_info(model_config, tokenizer=None)
+        return self.info
 
     def create_processor(
         self,

--- a/vllm/v1/worker/encoder_cudagraph.py
+++ b/vllm/v1/worker/encoder_cudagraph.py
@@ -67,13 +67,15 @@ class EncoderCudaGraphManager:
 
         comp_config = vllm_config.compilation_config
         user_budgets = comp_config.encoder_cudagraph_token_budgets
-        user_max_mm_items = comp_config.encoder_cudagraph_max_vision_items_per_batch
+        user_max_vision_items = comp_config.encoder_cudagraph_max_vision_items_per_batch
         user_max_frames = comp_config.encoder_cudagraph_max_frames_per_batch
 
-        if user_budgets and user_max_mm_items > 0:
+        multimodal_config = vllm_config.model_config.multimodal_config
+
+        if user_budgets and user_max_vision_items > 0:
             # Fully user-specified
             self.token_budgets = sorted(user_budgets)
-            self.max_batch_size = user_max_mm_items
+            self.max_batch_size = user_max_vision_items
         else:
             # Auto-infer missing values from model
             min_budget, max_budget = model.get_encoder_cudagraph_budget_range(
@@ -85,14 +87,19 @@ class EncoderCudaGraphManager:
                 else self._generate_budgets(min_budget, max_budget)
             )
             self.max_batch_size = (
-                user_max_mm_items if user_max_mm_items > 0 else max_budget // min_budget
+                user_max_vision_items
+                if user_max_vision_items > 0
+                else max_budget // min_budget
             )
 
-        if user_max_frames > 0:
+        if multimodal_config.get_limit_per_prompt("video") == 0:
+            self.max_frames_per_batch = 0
+        elif user_max_frames is not None and user_max_frames > 0:
             self.max_frames_per_batch = user_max_frames
         else:
-            # TODO(shen-shanshan): optimize this auto-infer for max_frames_per_batch.
-            self.max_frames_per_batch = self.max_batch_size * 2
+            # Set it to the model-specific value according to its `processing_info`.
+            max_frames_per_video = self.model.get_max_frames_per_video()
+            self.max_frames_per_batch = self.max_batch_size * max_frames_per_video
 
         mm_config = vllm_config.model_config.multimodal_config
         self.use_dp = (
@@ -111,7 +118,7 @@ class EncoderCudaGraphManager:
             "budgets=%s, max_batch_size=%d, max_frames_per_batch=%s, use_dp=%s",
             self.token_budgets,
             self.max_batch_size,
-            self.max_frames_per_batch if self.max_frames_per_batch > 0 else "auto",
+            self.max_frames_per_batch,
             self.use_dp,
         )
 

--- a/vllm/v1/worker/encoder_cudagraph.py
+++ b/vllm/v1/worker/encoder_cudagraph.py
@@ -92,6 +92,7 @@ class EncoderCudaGraphManager:
                 else max_budget // min_budget
             )
 
+        assert multimodal_config is not None
         if multimodal_config.get_limit_per_prompt("video") == 0:
             self.max_frames_per_batch = 0
         elif user_max_frames is not None:

--- a/vllm/v1/worker/encoder_cudagraph.py
+++ b/vllm/v1/worker/encoder_cudagraph.py
@@ -94,7 +94,7 @@ class EncoderCudaGraphManager:
 
         if multimodal_config.get_limit_per_prompt("video") == 0:
             self.max_frames_per_batch = 0
-        elif user_max_frames is not None and user_max_frames > 0:
+        elif user_max_frames is not None:
             self.max_frames_per_batch = user_max_frames
         else:
             # Set it to the model-specific value according to its `processing_info`.


### PR DESCRIPTION
## Purpose

The previous auto-inference logic for `encoder_cudagraph_max_frames_per_batch` in the ViT encoder CUDA graph path used a hardcoded formula of `max_batch_size * 2`, which was both inaccurate and noted as a TODO. For models like Qwen3-VL, the actual max frames per video can be far greater than 2, causing the pre-allocated `cu_seqlens` buffer to be either too small (risking OOM or incorrect behavior) or unnecessarily large.

This PR replaces the hardcoded multiplier with a model-aware auto-inference path. The default value of `encoder_cudagraph_max_frames_per_batch` is changed from `0` to `None`, cleanly separating "auto-infer" from "user explicitly disabled video" (value `0`). When auto-inference is triggered, the manager calls the new `get_max_frames_per_video()` protocol method on the model, which queries `processing_info` to compute the actual per-video frame budget — making the buffer size accurate and model-specific. Image-only mode (video count per prompt limited to 0) is also correctly handled by forcing `max_frames_per_batch = 0`.

**Key Changes:**

- **`CompilationConfig.encoder_cudagraph_max_frames_per_batch`** (`vllm/config/compilation.py`): Type changed from `int = 0` to `int | None = None`. Validation guard updated to skip the non-negative check when the value is `None`.
- **`SupportsEncoderCudaGraph` protocol** (`vllm/model_executor/models/interfaces.py`): Added `get_max_frames_per_video() -> int` as a new required protocol method for models that opt into encoder CUDA graphs.
- **`Qwen3VLEncoder.get_max_frames_per_video()`** (`vllm/model_executor/models/qwen3_vl.py`): Implements the new protocol method by calling `processing_info.get_num_frames_with_most_features()` with the model's `max_model_len` and per-prompt video limit, returning an accurate model-specific max frame count.
- **`MultiModalRegistry.get_processing_info()`** (`vllm/multimodal/registry.py`): Exposes a thin public wrapper around `_create_processing_info()` (without caching, to be safe across multi-model scenarios) so models can access their processing info without internal API access.
- **`EncoderCudaGraphManager.__init__()`** (`vllm/v1/worker/encoder_cudagraph.py`): Updated frame budget selection logic — checks video-disabled condition first, then respects explicit user value (`is not None`), then falls back to `max_batch_size * model.get_max_frames_per_video()`.
- **`docs/design/cuda_graphs_multimodal.md`**: Updated field documentation for `encoder_cudagraph_max_frames_per_batch` and added `get_max_frames_per_video()` to the protocol method list.

## Test Plan

```bash
# Test-1:
# Pass compilation_config to EngineArgs in run_qwen3_vl()
# compilation_config={
#     "cudagraph_mm_encoder": True,
#     "encoder_cudagraph_token_budgets": [512, 1024, 1536, 2048, 2560, 3072, 3584, 4096, 4864],
#     "encoder_cudagraph_max_vision_items_per_batch": 8,
#     "encoder_cudagraph_max_frames_per_batch": 128,
# }
python examples/offline_inference/vision_language.py -m qwen3_vl --modality "image"

# Test-2:
# "encoder_cudagraph_max_frames_per_batch": 128
python examples/offline_inference/vision_language.py -m qwen3_vl --modality "video"

# Test-3:
# "encoder_cudagraph_max_frames_per_batch": None
python examples/offline_inference/vision_language.py -m qwen3_vl --modality "video"
```

## Test Result

```bash
# Test-1:
# Disable video modality, so max_frames_per_batch will be set to 0.
EncoderCudaGraphManager initialized with ..., max_frames_per_batch=0, ...

# Test-2:
# Use the value specified by the user.
EncoderCudaGraphManager initialized with ..., max_frames_per_batch=128, ...

# Test-3:
# Auto infer max_frames_per_batch according to processing_info.
EncoderCudaGraphManager initialized with ..., max_frames_per_batch=64, ...
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
