### PR TITLE
[Bugfix] Clarify FLASHINFER limitation for per-attention-head KV quantization

### DIFF
--- a/docs/features/quantization/quantized_kvcache.md
+++ b/docs/features/quantization/quantized_kvcache.md
@@ -95,7 +95,7 @@ print(out)
 
 ### 3. **[Recommended] Calibration Using a Dataset (with `llm-compressor`)**
 
-For the highest-quality quantization, we recommend calibrating against a dataset using `llm-compressor`. This enables advanced strategies such as per-attention-head quantization.
+For the highest-quality quantization, we recommend calibrating against a dataset using `llm-compressor`. This enables advanced strategies such as per-attention-head quantization. Per-attention-head KV-cache quantization is currently supported only with the `FLASH_ATTN` backend.
 
 #### Install the required package
 

--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -369,6 +369,22 @@ def test_compressed_tensors_kv_cache_fp8_per_attn_head(vllm_runner):
         assert output
 
 
+@pytest.mark.skipif(
+    not current_platform.is_cuda(), reason="This test is skipped on non-CUDA platform."
+)
+def test_compressed_tensors_kv_cache_fp8_per_attn_head_rejects_flashinfer(
+    vllm_runner,
+):
+    model_path = "nm-testing/TinyLlama-1.1B-Chat-v1.0-kvcache-fp8-attn_head"
+
+    with pytest.raises(
+        ValueError,
+        match="Per-attention-head KV-cache quantization.*FLASH_ATTN.*FLASHINFER",
+    ):
+        with vllm_runner(model_path, attention_config={"backend": "FLASHINFER"}):
+            pass
+
+
 @pytest.mark.parametrize(
     "args",
     [

--- a/tests/test_attention_backend_registry.py
+++ b/tests/test_attention_backend_registry.py
@@ -1,5 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.platforms.interface import DeviceCapability
 from vllm.v1.attention.backend import (
     AttentionBackend,
     AttentionImpl,
@@ -167,3 +172,41 @@ def test_register_custom_mamba_backend_with_class_path():
     backend_cls = MambaAttentionBackendEnum.CUSTOM.get_class()
     assert backend_cls.get_name() == "CUSTOM_MAMBA"
     assert backend_cls.get_impl_cls() == CustomMambaAttentionImpl
+
+
+@pytest.mark.parametrize(
+    ("backend_cls", "expected_match"),
+    [
+        (
+            AttentionBackendEnum.FLASHINFER.get_class(),
+            "Per-attention-head KV-cache quantization is currently supported only with FLASH_ATTN, not FLASHINFER",
+        ),
+        (
+            CustomAttentionBackend,
+            "per-head quant scales not supported",
+        ),
+    ],
+)
+def test_validate_configuration_reports_per_head_quant_scale_support(
+    backend_cls: type[AttentionBackend],
+    expected_match: str,
+):
+    invalid_reasons = backend_cls.validate_configuration(
+        head_size=128,
+        dtype=torch.bfloat16,
+        kv_cache_dtype="fp8",
+        block_size=16,
+        use_mla=False,
+        has_sink=False,
+        use_sparse=False,
+        use_mm_prefix=False,
+        use_per_head_quant_scales=True,
+        device_capability=DeviceCapability(9, 0),
+        attn_type="decoder",
+    )
+
+    assert any(expected_match in reason for reason in invalid_reasons)
+
+    if backend_cls is CustomAttentionBackend:
+        assert all("FLASH_ATTN" not in reason for reason in invalid_reasons)
+        assert all("FLASHINFER" not in reason for reason in invalid_reasons)

--- a/tests/test_attention_backend_registry.py
+++ b/tests/test_attention_backend_registry.py
@@ -175,10 +175,10 @@ def test_register_custom_mamba_backend_with_class_path():
 
 
 @pytest.mark.parametrize(
-    ("backend_cls", "expected_match"),
+    ("backend", "expected_match"),
     [
         (
-            AttentionBackendEnum.FLASHINFER.get_class(),
+            AttentionBackendEnum.FLASHINFER,
             "Per-attention-head KV-cache quantization is currently supported only with FLASH_ATTN, not FLASHINFER",
         ),
         (
@@ -188,9 +188,16 @@ def test_register_custom_mamba_backend_with_class_path():
     ],
 )
 def test_validate_configuration_reports_per_head_quant_scale_support(
-    backend_cls: type[AttentionBackend],
+    backend: AttentionBackendEnum | type[AttentionBackend],
     expected_match: str,
 ):
+    if isinstance(backend, AttentionBackendEnum):
+        if backend == AttentionBackendEnum.FLASHINFER:
+            pytest.importorskip("flashinfer")
+        backend_cls = backend.get_class()
+    else:
+        backend_cls = backend
+
     invalid_reasons = backend_cls.validate_configuration(
         head_size=128,
         dtype=torch.bfloat16,
@@ -207,6 +214,6 @@ def test_validate_configuration_reports_per_head_quant_scale_support(
 
     assert any(expected_match in reason for reason in invalid_reasons)
 
-    if backend_cls is CustomAttentionBackend:
+    if backend is CustomAttentionBackend:
         assert all("FLASH_ATTN" not in reason for reason in invalid_reasons)
         assert all("FLASHINFER" not in reason for reason in invalid_reasons)

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -303,13 +303,7 @@ class AttentionBackend(ABC):
             else:
                 invalid_reasons.append("non-sparse not supported")
         if use_per_head_quant_scales and not cls.supports_per_head_quant_scales():
-            if cls.get_name() == "FLASHINFER":
-                invalid_reasons.append(
-                    "Per-attention-head KV-cache quantization is currently "
-                    "supported only with FLASH_ATTN, not FLASHINFER"
-                )
-            else:
-                invalid_reasons.append("per-head quant scales not supported")
+            invalid_reasons.append("per-head quant scales not supported")
         if not cls.supports_compute_capability(device_capability):
             invalid_reasons.append("compute capability not supported")
         if not cls.supports_attn_type(attn_type):

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -303,7 +303,13 @@ class AttentionBackend(ABC):
             else:
                 invalid_reasons.append("non-sparse not supported")
         if use_per_head_quant_scales and not cls.supports_per_head_quant_scales():
-            invalid_reasons.append("per-head quant scales not supported")
+            if cls.get_name() == "FLASHINFER":
+                invalid_reasons.append(
+                    "Per-attention-head KV-cache quantization is currently "
+                    "supported only with FLASH_ATTN, not FLASHINFER"
+                )
+            else:
+                invalid_reasons.append("per-head quant scales not supported")
         if not cls.supports_compute_capability(device_capability):
             invalid_reasons.append("compute capability not supported")
         if not cls.supports_attn_type(attn_type):

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -424,6 +424,48 @@ class FlashInferBackend(AttentionBackend):
         return supports_trtllm_attention()
 
     @classmethod
+    def validate_configuration(
+        cls,
+        head_size: int,
+        dtype: torch.dtype,
+        kv_cache_dtype: CacheDType | None,
+        block_size: int | None,
+        use_mla: bool,
+        has_sink: bool,
+        use_sparse: bool,
+        use_mm_prefix: bool,
+        use_per_head_quant_scales: bool,
+        device_capability: DeviceCapability,
+        attn_type: str,
+        use_non_causal: bool = False,
+    ) -> list[str]:
+        invalid_reasons = super().validate_configuration(
+            head_size=head_size,
+            dtype=dtype,
+            kv_cache_dtype=kv_cache_dtype,
+            block_size=block_size,
+            use_mla=use_mla,
+            has_sink=has_sink,
+            use_sparse=use_sparse,
+            use_mm_prefix=use_mm_prefix,
+            use_per_head_quant_scales=use_per_head_quant_scales,
+            device_capability=device_capability,
+            attn_type=attn_type,
+            use_non_causal=use_non_causal,
+        )
+        if use_per_head_quant_scales and not cls.supports_per_head_quant_scales():
+            invalid_reasons = [
+                (
+                    "Per-attention-head KV-cache quantization is currently "
+                    "supported only with FLASH_ATTN, not FLASHINFER"
+                )
+                if reason == "per-head quant scales not supported"
+                else reason
+                for reason in invalid_reasons
+            ]
+        return invalid_reasons
+
+    @classmethod
     def get_required_kv_cache_layout(cls) -> KVCacheLayoutType | None:
         capability = current_platform.get_device_capability()
         if capability is not None and capability.major == 10:


### PR DESCRIPTION
Fixes #40444

## Summary
- raise a clear validation error when per-attention-head KV-cache quantization is requested with the `FLASHINFER` backend
- add regression coverage for the `FLASHINFER` failure path while keeping the existing `FLASH_ATTN` success path
- document that per-attention-head KV-cache quantization currently requires `FLASH_ATTN`

## Why this is not duplicate work
- I checked issue/PR state for `#40444` and did not find an open PR that already addresses this fix
- this PR does not add FlashInfer kernel support; it makes the current backend limitation explicit and fail-fast

## Test plan
- [x] `uv run --no-project python -m py_compile vllm/v1/attention/backend.py tests/test_attention_backend_registry.py tests/quantization/test_compressed_tensors.py`
- [x] `./.venv/bin/python -m pytest tests/test_attention_backend_registry.py -k per_head_quant_scale_support -v`
- [x] `./.venv/bin/python -m pytest tests/quantization/test_compressed_tensors.py -k per_attn_head -v`

## AI assistance
- This PR was prepared with AI assistance, and the final changes were reviewed by a human submitter.