### PR TITLE
Add prompt field to GenerateRequest protocol and update render endpoints

### DIFF
--- a/tests/entrypoints/serve/render/test_render.py
+++ b/tests/entrypoints/serve/render/test_render.py
@@ -53,10 +53,13 @@ async def test_completion_render_basic(client):
     assert "sampling_params" in first_prompt
     assert "model" in first_prompt
     assert "request_id" in first_prompt
+    assert "prompt" in first_prompt
     assert isinstance(first_prompt["token_ids"], list)
     assert len(first_prompt["token_ids"]) > 0
     assert first_prompt["model"] == MODEL_NAME
     assert first_prompt["request_id"].startswith("cmpl-")
+    assert isinstance(first_prompt["prompt"], str)
+    assert len(first_prompt["prompt"]) > 0
 
 
 @pytest.mark.asyncio
@@ -91,6 +94,11 @@ async def test_chat_completion_render_basic(client):
     token_ids = data["token_ids"]
     assert all(isinstance(tid, int) for tid in token_ids)
     assert token_ids[0] == 1
+
+    # Verify rendered prompt text is included
+    assert "prompt" in data
+    assert isinstance(data["prompt"], str)
+    assert len(data["prompt"]) > 0
 
 
 @pytest.mark.asyncio

--- a/vllm/entrypoints/serve/disagg/protocol.py
+++ b/vllm/entrypoints/serve/disagg/protocol.py
@@ -62,6 +62,14 @@ class GenerateRequest(BaseModel):
             "through out the inference process and return in response."
         ),
     )
+    prompt: str | None = Field(
+        default=None,
+        description=(
+            "The rendered prompt text (detokenized from token_ids). "
+            "Useful for debugging and introspection of the preprocessing "
+            "pipeline. Populated by the render endpoints."
+        ),
+    )
     token_ids: list[int]
     """The token ids to generate text from."""
 

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -170,8 +170,12 @@ class OpenAIServingRender:
 
         request_id = f"chatcmpl-{random_uuid()}"
 
+        tokenizer = self.renderer.get_tokenizer()
+        prompt_text = tokenizer.decode(token_ids)
+
         return GenerateRequest(
             request_id=request_id,
+            prompt=prompt_text,
             token_ids=token_ids,
             features=self._extract_mm_features(engine_input),
             sampling_params=params,
@@ -281,6 +285,7 @@ class OpenAIServingRender:
         if isinstance(result, ErrorResponse):
             return result
         generate_requests: list[GenerateRequest] = []
+        tokenizer = self.renderer.get_tokenizer()
         for engine_input in result:
             prompt_components = extract_prompt_components(
                 self.model_config, engine_input
@@ -303,10 +308,12 @@ class OpenAIServingRender:
             )
 
             request_id = f"cmpl-{random_uuid()}"
+            prompt_text = tokenizer.decode(token_ids)
 
             generate_requests.append(
                 GenerateRequest(
                     request_id=request_id,
+                    prompt=prompt_text,
                     token_ids=token_ids,
                     features=self._extract_mm_features(engine_input),
                     sampling_params=params,

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -170,8 +170,10 @@ class OpenAIServingRender:
 
         request_id = f"chatcmpl-{random_uuid()}"
 
-        tokenizer = self.renderer.get_tokenizer()
-        prompt_text = tokenizer.decode(token_ids)
+        prompt_text = prompt_components.text
+        if prompt_text is None:
+            async_tokenizer = self.renderer.get_async_tokenizer()
+            prompt_text = await async_tokenizer.decode(token_ids)
 
         return GenerateRequest(
             request_id=request_id,
@@ -285,7 +287,6 @@ class OpenAIServingRender:
         if isinstance(result, ErrorResponse):
             return result
         generate_requests: list[GenerateRequest] = []
-        tokenizer = self.renderer.get_tokenizer()
         for engine_input in result:
             prompt_components = extract_prompt_components(
                 self.model_config, engine_input
@@ -308,7 +309,10 @@ class OpenAIServingRender:
             )
 
             request_id = f"cmpl-{random_uuid()}"
-            prompt_text = tokenizer.decode(token_ids)
+            prompt_text = prompt_components.text
+            if prompt_text is None:
+                async_tokenizer = self.renderer.get_async_tokenizer()
+                prompt_text = await async_tokenizer.decode(token_ids)
 
             generate_requests.append(
                 GenerateRequest(


### PR DESCRIPTION
Closes #39819.

Adds a prompt field to the GenerateRequest protocol and populates it in both render endpoints (/v1/completions/render and /v1/chat/completions/render) by detokenizing token_ids back to text.

- Add optional prompt: str | None field to GenerateRequest in `vllm/entrypoints/serve/disagg/protocol.py`
- Decode token_ids via the tokenizer and populate the prompt field in both the chat completion and completion render paths in `vllm/entrypoints/serve/render/serving.py`
- Add test assertions verifying the prompt field is present, is a non-empty string, in `tests/entrypoints/serve/render/test_render.py`
