### PR TITLE
feat(qwen): register Qwen3_5ForCausalLM and Qwen3_5MoeForCausalLM architectures

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -513,6 +513,14 @@ _TEXT_GENERATION_EXAMPLE_MODELS = {
     "Qwen2MoeForCausalLM": _HfExamplesInfo("Qwen/Qwen1.5-MoE-A2.7B-Chat"),
     "Qwen3ForCausalLM": _HfExamplesInfo("Qwen/Qwen3-8B"),
     "Qwen3MoeForCausalLM": _HfExamplesInfo("Qwen/Qwen3-30B-A3B"),
+    "Qwen3_5ForCausalLM": _HfExamplesInfo(
+        "Qwen/Qwen3.5-0.8B",
+        max_model_len=4096,
+    ),
+    "Qwen3_5MoeForCausalLM": _HfExamplesInfo(
+        "Qwen/Qwen3.5-35B-A3B",
+        max_model_len=4096,
+    ),
     "Qwen3NextForCausalLM": _HfExamplesInfo(
         "Qwen/Qwen3-Next-80B-A3B-Instruct",
         extras={"tiny-random": "tiny-random/qwen3-next-moe"},

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -195,6 +195,8 @@ _TEXT_GENERATION_MODELS = {
     "Qwen2MoeForCausalLM": ("qwen2_moe", "Qwen2MoeForCausalLM"),
     "Qwen3ForCausalLM": ("qwen3", "Qwen3ForCausalLM"),
     "Qwen3MoeForCausalLM": ("qwen3_moe", "Qwen3MoeForCausalLM"),
+    "Qwen3_5ForCausalLM": ("qwen3_5", "Qwen3_5ForCausalLM"),
+    "Qwen3_5MoeForCausalLM": ("qwen3_5", "Qwen3_5MoeForCausalLM"),
     "RWForCausalLM": ("falcon", "FalconForCausalLM"),
     "SarvamMoEForCausalLM": ("sarvam", "SarvamMoEForCausalLM"),
     "SarvamMLAForCausalLM": ("sarvam", "SarvamMLAForCausalLM"),


### PR DESCRIPTION
## Summary

The concrete `Qwen3_5ForCausalLM` and `Qwen3_5MoeForCausalLM` classes already exist in [`vllm/model_executor/models/qwen3_5.py`](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/qwen3_5.py) (lines 552 and 556), but they were never added to the `_TEXT_GENERATION_MODELS` registry dict in `vllm/model_executor/models/registry.py`. Only the `*ForConditionalGeneration` variants are registered today.

Consequence: loading a text-only Qwen3.5 checkpoint whose `config.json` declares `architectures=["Qwen3_5MoeForCausalLM"]` (e.g. a pruned student or a vanilla text build) fails with a `pydantic.ValidationError` on `ModelConfig` before the engine starts, because `_ModelRegistry.inspect_model_cls` rejects the unknown architecture name. The user has to hack `hf-overrides` or monkey-patch the registry at runtime.

## Change

Two-line addition in `vllm/model_executor/models/registry.py`:

```python
    "Qwen3_5ForCausalLM": ("qwen3_5", "Qwen3_5ForCausalLM"),
    "Qwen3_5MoeForCausalLM": ("qwen3_5", "Qwen3_5MoeForCausalLM"),
```

placed next to `Qwen3MoeForCausalLM` to match the existing Qwen3 Moe convention.

Also adds the corresponding `_HfExamplesInfo` stubs in `tests/models/registry.py` per the "please also update `tests/models/registry.py`" comment at the top of the main registry file.

## Why not just subclass / add to `_MULTIMODAL_MODELS`?

- No code changes are needed. The classes already inherit from `Qwen3_5ForCausalLMBase` and are production-ready; they were simply unreachable through the registry.
- These are pure text-generation architectures (no multimodal inputs), so `_TEXT_GENERATION_MODELS` is the correct dict. The `*ForConditionalGeneration` entries in `_MULTIMODAL_MODELS` remain unchanged.

## Test plan

- [x] Classes confirmed to exist in `qwen3_5.py` at the referenced lines (no implementation changes).
- [x] `_HfExamplesInfo` stubs added using the same HF model IDs already referenced by the `*ForConditionalGeneration` variants (`Qwen/Qwen3.5-0.8B`, `Qwen/Qwen3.5-35B-A3B`).
- [ ] CI on this PR will exercise the registry round-trip.

## Context

Discovered while loading a BLADE-pruned Qwen3.5 MoE student with vLLM 0.19.1. Full writeup and the downstream monkey-patch we shipped in the meantime are in our internal repo; happy to share details if useful.