### PR TITLE
[Misc] Support Human-readable (k/K/m/M..) json cli arg

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -12,6 +12,7 @@ from pydantic import Field
 from vllm.config import AttentionConfig, CompilationConfig, config
 from vllm.engine.arg_utils import (
     EngineArgs,
+    _expand_json_human_readable_numbers,
     contains_type,
     get_kwargs,
     get_type,
@@ -563,3 +564,32 @@ def test_ir_op_priority():
             ir_op_priority=ir_op_priority,
             kernel_config=KernelConfig(ir_op_priority=ir_op_priority),
         ).create_engine_config()
+
+
+@pytest.mark.parametrize(
+    ("input_json", "expected_json"),
+    [
+        # Decimal suffixes (lowercase)
+        ('{"x": 80g}', '{"x": 80000000000}'),
+        ('{"x": 1k}', '{"x": 1000}'),
+        ('{"x": 5m}', '{"x": 5000000}'),
+        ('{"x": 2t}', '{"x": 2000000000000}'),
+        # Binary suffixes (uppercase)
+        ('{"x": 1K}', f'{{"x": {2**10}}}'),
+        ('{"x": 1G}', f'{{"x": {2**30}}}'),
+        # Decimal values
+        ('{"x": 1.5g}', '{"x": 1500000000}'),
+        # Quoted strings must NOT be modified
+        ('{"my_key": 80g}', '{"my_key": 80000000000}'),
+        ('{"name": "80g"}', '{"name": "80g"}'),
+        ('{"model_name": "foo_bar"}', '{"model_name": "foo_bar"}'),
+        # Multiple values
+        ('{"a": 1k, "b": 2m}', '{"a": 1000, "b": 2000000}'),
+        # Plain numbers are untouched
+        ('{"x": 42}', '{"x": 42}'),
+        # Nested JSON
+        ('{"outer": {"inner": 10g}}', '{"outer": {"inner": 10000000000}}'),
+    ],
+)
+def test_expand_json_human_readable_numbers(input_json, expected_json):
+    assert _expand_json_human_readable_numbers(input_json) == expected_json

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -259,10 +259,10 @@ def _maybe_add_docs_url(cls: Any) -> str:
 def _expand_json_human_readable_numbers(val: str) -> str:
     """Expand human-readable number suffixes in a JSON string.
 
-    Reuses :func:`human_readable_int` so that the ``k/m/g/t`` (decimal) and
-    ``K/M/G/T`` (binary) conventions already supported by scalar CLI args
-    like ``--max-model-len 1m`` also work inside JSON config arguments such
-    as ``--kv-transfer-config '{"cpu_bytes_to_use": 80g}'``.
+    Based on :func:`human_readable_int` so that the ``k/m/g/t`` (decimal) and
+    ``K/M/G/T`` (binary) conventions work out the box.
+    Also works inside JSON config arguments such
+    as ``--kv-transfer-config '{"cpu_bytes_to_use": 80m}'``.
 
     Only bare (unquoted) tokens are replaced so that JSON string values
     like ``"model_name"`` are never modified.

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -105,7 +105,11 @@ from vllm.transformers_utils.config import (
 from vllm.transformers_utils.gguf_utils import is_gguf
 from vllm.transformers_utils.repo_utils import get_model_path
 from vllm.transformers_utils.utils import is_cloud_storage
-from vllm.utils.argparse_utils import FlexibleArgumentParser
+from vllm.utils.argparse_utils import (
+    FlexibleArgumentParser,
+    human_readable_int,
+    human_readable_int_or_auto,
+)
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.network_utils import get_ip
 from vllm.utils.torch_utils import resolve_kv_cache_dtype_string
@@ -271,7 +275,7 @@ def _expand_json_human_readable_numbers(val: str) -> str:
     parts = re.split(r'("(?:[^"\\]|\\.)*")', val)
     for i in range(0, len(parts), 2):  # even indices = outside strings
         parts[i] = re.sub(
-            r"\d+(?:\.\d+)?[kKmMgGtT]",
+            r"\b\d+(?:\.\d+)?[kKmMgGtT]\b",
             lambda m: str(human_readable_int(m.group())),
             parts[i],
         )
@@ -2445,68 +2449,3 @@ def _raise_unsupported_error(feature_name: str):
         f"remove {feature_name} from your config."
     )
     raise NotImplementedError(msg)
-
-
-def human_readable_int(value: str) -> int:
-    """Parse human-readable integers like '1k', '2M', etc.
-    Including decimal values with decimal multipliers.
-
-    Examples:
-    - '1k' -> 1,000
-    - '1K' -> 1,024
-    - '25.6k' -> 25,600
-    """
-    value = value.strip()
-
-    match = re.fullmatch(r"(\d+(?:\.\d+)?)([kKmMgGtT])", value)
-    if match:
-        decimal_multiplier = {
-            "k": 10**3,
-            "m": 10**6,
-            "g": 10**9,
-            "t": 10**12,
-        }
-        binary_multiplier = {
-            "K": 2**10,
-            "M": 2**20,
-            "G": 2**30,
-            "T": 2**40,
-        }
-
-        number, suffix = match.groups()
-        if suffix in decimal_multiplier:
-            mult = decimal_multiplier[suffix]
-            return int(float(number) * mult)
-        elif suffix in binary_multiplier:
-            mult = binary_multiplier[suffix]
-            # Do not allow decimals with binary multipliers
-            try:
-                return int(number) * mult
-            except ValueError as e:
-                raise argparse.ArgumentTypeError(
-                    "Decimals are not allowed "
-                    f"with binary suffixes like {suffix}. Did you mean to use "
-                    f"{number}{suffix.lower()} instead?"
-                ) from e
-
-    # Regular plain number.
-    return int(value)
-
-
-def human_readable_int_or_auto(value: str) -> int:
-    """Parse human-readable integers like '1k', '2M', etc.
-    Including decimal values with decimal multipliers.
-    Also accepts -1 or 'auto' as a special value for auto-detection.
-
-    Examples:
-    - '1k' -> 1,000
-    - '1K' -> 1,024
-    - '25.6k' -> 25,600
-    - '-1' or 'auto' -> -1 (special value for auto-detection)
-    """
-    value = value.strip()
-
-    if value == "-1" or value.lower() == "auto":
-        return -1
-
-    return human_readable_int(value)

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -256,6 +256,28 @@ def _maybe_add_docs_url(cls: Any) -> str:
     return f"\n\nAPI docs: https://docs.vllm.ai/en/{version}/api/vllm/config/#vllm.config.{cls.__name__}"
 
 
+def _expand_json_human_readable_numbers(val: str) -> str:
+    """Expand human-readable number suffixes in a JSON string.
+
+    Reuses :func:`human_readable_int` so that the ``k/m/g/t`` (decimal) and
+    ``K/M/G/T`` (binary) conventions already supported by scalar CLI args
+    like ``--max-model-len 1m`` also work inside JSON config arguments such
+    as ``--kv-transfer-config '{"cpu_bytes_to_use": 80g}'``.
+
+    Only bare (unquoted) tokens are replaced so that JSON string values
+    like ``"model_name"`` are never modified.
+    """
+    # Split on quoted strings so we only touch non-string regions.
+    parts = re.split(r'("(?:[^"\\]|\\.)*")', val)
+    for i in range(0, len(parts), 2):  # even indices = outside strings
+        parts[i] = re.sub(
+            r"\d+(?:\.\d+)?[kKmMgGtT]",
+            lambda m: str(human_readable_int(m.group())),
+            parts[i],
+        )
+    return "".join(parts)
+
+
 @functools.lru_cache(maxsize=30)
 def _compute_kwargs(cls: ConfigType) -> dict[str, dict[str, Any]]:
     # Save time only getting attr docs if we're generating help text
@@ -301,6 +323,7 @@ def _compute_kwargs(cls: ConfigType) -> dict[str, dict[str, Any]]:
 
             def parse_dataclass(val: str, cls=dataclass_cls) -> Any:
                 try:
+                    val = _expand_json_human_readable_numbers(val)
                     return TypeAdapter(cls).validate_json(val)
                 except ValidationError as e:
                     raise argparse.ArgumentTypeError(repr(e)) from e

--- a/vllm/utils/argparse_utils.py
+++ b/vllm/utils/argparse_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Argument parsing utilities for vLLM."""
 
+import argparse
 import json
 import sys
 import textwrap
@@ -23,6 +24,71 @@ import yaml
 from vllm.logger import init_logger
 
 logger = init_logger(__name__)
+
+
+def human_readable_int(value: str) -> int:
+    """Parse human-readable integers like '1k', '2M', etc.
+    Including decimal values with decimal multipliers.
+
+    Examples:
+    - '1k' -> 1,000
+    - '1K' -> 1,024
+    - '25.6k' -> 25,600
+    """
+    value = value.strip()
+
+    match = re.fullmatch(r"(\d+(?:\.\d+)?)([kKmMgGtT])", value)
+    if match:
+        decimal_multiplier = {
+            "k": 10**3,
+            "m": 10**6,
+            "g": 10**9,
+            "t": 10**12,
+        }
+        binary_multiplier = {
+            "K": 2**10,
+            "M": 2**20,
+            "G": 2**30,
+            "T": 2**40,
+        }
+
+        number, suffix = match.groups()
+        if suffix in decimal_multiplier:
+            mult = decimal_multiplier[suffix]
+            return int(float(number) * mult)
+        elif suffix in binary_multiplier:
+            mult = binary_multiplier[suffix]
+            # Do not allow decimals with binary multipliers
+            try:
+                return int(number) * mult
+            except ValueError as e:
+                raise argparse.ArgumentTypeError(
+                    "Decimals are not allowed "
+                    f"with binary suffixes like {suffix}. Did you mean to use "
+                    f"{number}{suffix.lower()} instead?"
+                ) from e
+
+    # Regular plain number.
+    return int(value)
+
+
+def human_readable_int_or_auto(value: str) -> int:
+    """Parse human-readable integers like '1k', '2M', etc.
+    Including decimal values with decimal multipliers.
+    Also accepts -1 or 'auto' as a special value for auto-detection.
+
+    Examples:
+    - '1k' -> 1,000
+    - '1K' -> 1,024
+    - '25.6k' -> 25,600
+    - '-1' or 'auto' -> -1 (special value for auto-detection)
+    """
+    value = value.strip()
+
+    if value == "-1" or value.lower() == "auto":
+        return -1
+
+    return human_readable_int(value)
 
 
 class SortedHelpFormatter(ArgumentDefaultsHelpFormatter, RawDescriptionHelpFormatter):
@@ -338,11 +404,10 @@ class FlexibleArgumentParser(ArgumentParser):
                 try:
                     value = json.loads(value_str)
                 except json.decoder.JSONDecodeError:
-                    # Attempt human-readable suffixes (e.g. 1k, 80g) conversion
+                    # Support human-readable suffixes (e.g. 1k, 80g) for
+                    # dotted config args like --config.field 80g
                     try:
-                        from vllm.engine.arg_utils import human_readable_int
-
-                        value = human_readable_int(value_str)
+                        value = human_readable_int(value_str)  # type: ignore[assignment]
                     except (ValueError, ArgumentTypeError):
                         value = value_str
 

--- a/vllm/utils/argparse_utils.py
+++ b/vllm/utils/argparse_utils.py
@@ -338,7 +338,13 @@ class FlexibleArgumentParser(ArgumentParser):
                 try:
                     value = json.loads(value_str)
                 except json.decoder.JSONDecodeError:
-                    value = value_str
+                    # Attempt human-readable suffixes (e.g. 1k, 80g) conversion
+                    try:
+                        from vllm.engine.arg_utils import human_readable_int
+
+                        value = human_readable_int(value_str)
+                    except (ValueError, ArgumentTypeError):
+                        value = value_str
 
                 # Merge all values with the same key into a single dict
                 arg_dict = create_nested_dict(keys, value)


### PR DESCRIPTION
A different take on https://github.com/vllm-project/vllm/pull/39794 whereby we're allowing human-readable numbers (m/k/g..) similar to what's already available for `--max-model-len`, as per @mgoin suggestion.

```
vllm serve Qwen/Qwen3-0.6B --kv-transfer-config '{"kv_connector":"OffloadingConnector","kv_connector_extra_config":{"cpu_bytes_to_use":80m}, "kv_role": "kv_both"}'
[. . .]
(APIServer pid=1463878) INFO 04-21 13:49:25 [utils.py:233] non-default args: {'model_tag': 'Qwen/Qwen3-0.6B', 'kv_transfer_config': KVTransferConfig(kv_connector='OffloadingConnector', engine_id='11363e3d-6b80-4e89-8e61-3606f5564071', kv_buffer_device='cuda', kv_buffer_size=1000000000.0, kv_role='kv_both', kv_rank=None, kv_parallel_size=1, kv_ip='127.0.0.1', kv_port=14579, kv_connector_extra_config={'cpu_bytes_to_use': 80000000}, kv_connector_module_path=None, enable_permute_local_kv=False, kv_load_failure_policy='fail')}
```
or
```
vllm serve Qwen/Qwen3-0.6B --compilation-config.max_cudagraph_capture_size 1k
[. . .]
(APIServer pid=1517275) INFO 04-21 15:16:37 [utils.py:233] non-default args: {'model_tag': 'Qwen/Qwen3-0.6B', 'compilation_config': {'mode': None, 'debug_dump_path': None, 'cache_dir': '', 'compile_cache_save_format': 'binary', '
]. . .], 
'cudagraph_copy_inputs': False, 'cudagraph_specialize_lora': True, 'use_inductor_graph_partition': None, 'pass_config': {}, 'max_cudagraph_capture_size': 1000
```
in particular to enable this last one I edited `parse_args` in `argparse_utils.py` to attempt a human-readable conversion first.
This change might be a bit more invasive than what we had in the previous PR.

cc @hmellor  @DarkLight1337 