### PR TITLE
[Bugfix] Fix forced tool_choice crash when reasoning_parser consumes all content

### DIFF
--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1414,7 +1414,7 @@ class OpenAIServingChat(OpenAIServing):
                 request.tool_choice
                 and type(request.tool_choice) is ChatCompletionNamedToolChoiceParam
             ):
-                assert tool_calls is not None and len(tool_calls) > 0
+                tool_calls = tool_calls or []
                 tool_call_class_items = []
                 for idx, tc in enumerate(tool_calls):
                     # Use native ID if available (e.g., Kimi K2),

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -626,7 +626,7 @@ class OpenAIServing:
             and request.tool_choice
             and isinstance(request.tool_choice, ToolChoiceFunction)
         ):
-            assert content is not None
+            content = content or ""
             # Forced Function Call (Responses API)
             function_calls.append(
                 FunctionCall(name=request.tool_choice.name, arguments=content)
@@ -639,7 +639,7 @@ class OpenAIServing:
             and (tool_parser_cls is None or tool_parser_cls.supports_required_and_named)
         ):
             # Named function with standard JSON-based parsing
-            assert content is not None
+            content = content or ""
             function_calls.append(
                 FunctionCall(name=request.tool_choice.function.name, arguments=content)
             )

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -436,7 +436,7 @@ class DelegatingParser(Parser):
 
         if request.tool_choice and isinstance(request.tool_choice, ToolChoiceFunction):
             # Forced Function Call (Responses API style)
-            assert content is not None
+            content = content or ""
             function_calls.append(
                 FunctionCall(name=request.tool_choice.name, arguments=content)
             )
@@ -446,7 +446,7 @@ class DelegatingParser(Parser):
             request.tool_choice, ChatCompletionNamedToolChoiceParam
         ):
             # Forced Function Call (Chat Completion API style)
-            assert content is not None
+            content = content or ""
             function_calls.append(
                 FunctionCall(name=request.tool_choice.function.name, arguments=content)
             )


### PR DESCRIPTION
## Summary

When using `--reasoning-parser` (e.g., `glm45`, `deepseek_r1`) with forced `tool_choice`, the reasoning parser may consume the entire model output into `<think>...</think>` tags, leaving `content` as `None`. This causes `AssertionError` crashes in the forced tool_choice code paths.

**Fix**: Normalize `None` content to empty string `""` (consistent with the existing `"required"` branch which already does `content = content or ""`), and replace the downstream `assert tool_calls` with a defensive fallback.

## Changes

| File | Change |
|------|--------|
| `vllm/entrypoints/openai/engine/serving.py` | Replace 2x `assert content is not None` → `content = content or ""` |
| `vllm/parser/abstract_parser.py` | Replace 2x `assert content is not None` → `content = content or ""` |
| `vllm/entrypoints/openai/chat_completion/serving.py` | Replace `assert tool_calls is not None and len(tool_calls) > 0` → `tool_calls = tool_calls or []` |

Total: 5 lines changed across 3 files.

## How to reproduce

```bash
vllm serve <reasoning-model> --reasoning-parser glm45 --enable-auto-tool-choice --tool-call-parser hermes
```

```python
response = client.chat.completions.create(
    model="<model>",
    messages=[{"role": "user", "content": "What's the weather?"}],
    tools=[{"type": "function", "function": {"name": "get_weather", "parameters": {}}}],
    tool_choice={"type": "function", "function": {"name": "get_weather"}}
)
# Crash: AssertionError (no message) when model output is all <think>...</think>
```

## Why this is not a duplicate

PR #40148 fixes `engine/serving.py` and `abstract_parser.py` but does **not** fix the downstream `assert` in `chat_completion/serving.py` (line 1417). This PR covers all 5 crash points across all 3 files.

Fixes #40528
Related: #40147, #40148

## Test

The fix is consistent with the existing `"required"` branch pattern which already uses `content = content or ""` and `tool_calls = tool_calls or []`.

## AI Disclosure

AI assistance was used in identifying and fixing this bug.

Signed-off-by: liuchenbing <liuchenbing2026@outlook.com>