### PR TITLE
[Kernel][MoE] Add A100 tuned config for E=64,N=1408 (Kimi-VL-A3B, GLM-4.5 Air)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/configs/E=64,N=1408,device_name=NVIDIA_A100-SXM4-80GB.json
+++ b/vllm/model_executor/layers/fused_moe/configs/E=64,N=1408,device_name=NVIDIA_A100-SXM4-80GB.json
@@ -1,0 +1,147 @@
+{
+    "triton_version": "3.6.0",
+    "1": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "2": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "4": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "8": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 64,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 4
+    },
+    "16": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "24": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "32": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "48": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "64": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "96": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "128": {
+        "BLOCK_SIZE_M": 16,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 8,
+        "num_stages": 3
+    },
+    "256": {
+        "BLOCK_SIZE_M": 32,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 2
+    },
+    "512": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 128,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 8,
+        "num_stages": 4
+    },
+    "1024": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "1536": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 1,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "2048": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "3072": {
+        "BLOCK_SIZE_M": 64,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 32,
+        "num_warps": 4,
+        "num_stages": 3
+    },
+    "4096": {
+        "BLOCK_SIZE_M": 128,
+        "BLOCK_SIZE_N": 128,
+        "BLOCK_SIZE_K": 64,
+        "GROUP_SIZE_M": 16,
+        "num_warps": 4,
+        "num_stages": 3
+    }
+}


### PR DESCRIPTION
## Purpose

Adds a tuned `fused_moe` config for `E=64, N=1408` on NVIDIA A100-SXM4-80GB.

This is the MoE shape used by:
- `moonshotai/Kimi-VL-A3B-Instruct` (DeepseekV3 text backbone)
- `zai-org/GLM-4.5-Air`

Prior to this PR, the only tuned config for `E=64, N=1408` was for B200 (from PR #26818). On A100, these models fell through to `get_default_config()`.

## Benchmark (bf16, hidden=2048, top_k=6, 1×A100 80GB SXM4)

| M | default µs | tuned µs | speedup |
|---:|---:|---:|---:|
| 1 | 183.5 | 183.5 | 1.00×¹ |
| 4 | 266.2 | 266.2 | 1.00×¹ |
| 16 | 542.6 | 523.3 | 1.04× |
| 64 | 698.1 | 677.6 | 1.03× |
| 256 | 769.5 | 717.0 | **1.07×** |
| 1024 | 1022.5 | 929.9 | **1.10×** |
| 4096 | 2919.0 | 2636.6 | **1.11×** |

¹ M=1, 2, 4, 8 entries mirror `get_default_config(...)` verbatim — the default heuristic was already near-optimal for decode-sized batches and the tuner didn't beat it. Keeping the entries (rather than removing) avoids `try_get_optimal_moe_config` nearest-match picking the M=16 config for tiny batches.

Wins grow with batch size: 1.07–1.11× at prefill-sized `M≥256`, small (3-4%) at mid range, parity at decode.

## How it was generated

Standalone tuner using the same reduced search space as `benchmarks/kernels/benchmark_moe.py` (`BLOCK_SIZE_M∈{16,32,64,128}`, `BLOCK_SIZE_N∈{32,64,128}`, `BLOCK_SIZE_K∈{64,128}`, `GROUP_SIZE_M∈{1,16,32}`, `num_warps∈{4,8}`, `num_stages∈{2,3,4}`) — 432 configs × 18 batch sizes, benchmarked via `triton.testing.do_bench(warmup=5, rep=30)`. Total sweep ~15 min on a single A100.

I didn't use `benchmark_moe.py` directly because `get_model_params` doesn't yet handle Kimi-VL's nested `text_config` (same pattern as the Gemma4 issue addressed in #40181). The standalone tuner bypasses model-config parsing by hardcoding the shape.

Triton version recorded: `3.6.0`.

## Test plan

- [x] Generated on 1× A100 80GB SXM4, CUDA 13.0, torch 2.10.0+cu130, triton 3.6.0
- [x] Validated config loads cleanly via `get_moe_configs(E=64, N=1408, dtype=None, block_n=0, block_k=0)`
- [x] Benchmarked tuned vs default across `M ∈ {1, 4, 16, 64, 256, 1024, 4096}`
- [x] Addressed gemini-code-assist review: M=1,2,4,8 entries now match default heuristic