### PR TITLE
[Kernel] Support fused_moe tuning with Kimi-VL-A3B

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -795,6 +795,14 @@ def get_model_params(config):
         topk = text_config.num_experts_per_tok
         intermediate_size = text_config.moe_intermediate_size
         hidden_size = text_config.hidden_size
+    elif architecture == "KimiVLForConditionalGeneration":
+        # Kimi-VL wraps a DeepseekV3-family text backbone in a vision-language
+        # outer config; the MoE fields live on the inner text_config.
+        text_config = config.get_text_config()
+        E = text_config.n_routed_experts
+        topk = text_config.num_experts_per_tok
+        intermediate_size = text_config.moe_intermediate_size
+        hidden_size = text_config.hidden_size
     elif architecture == "HunYuanMoEV1ForCausalLM":
         E = config.num_experts
         topk = config.moe_topk[0]

--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -798,6 +798,14 @@ def get_model_params(config):
         topk = text_config.top_k_experts
         intermediate_size = text_config.moe_intermediate_size
         hidden_size = text_config.hidden_size
+    elif architecture == "KimiVLForConditionalGeneration":
+        # Kimi-VL wraps a DeepseekV3-family text backbone in a vision-language
+        # outer config; the MoE fields live on the inner text_config.
+        text_config = config.get_text_config()
+        E = text_config.n_routed_experts
+        topk = text_config.num_experts_per_tok
+        intermediate_size = text_config.moe_intermediate_size
+        hidden_size = text_config.hidden_size
     elif architecture == "HunYuanMoEV1ForCausalLM":
         E = config.num_experts
         topk = config.moe_topk[0]


### PR DESCRIPTION
## Purpose

Adds \`KimiVLForConditionalGeneration\` to \`get_model_params\` in \`benchmarks/kernels/benchmark_moe.py\`.

Kimi-VL wraps a DeepseekV3-family text backbone inside a vision-language outer config. The MoE fields (\`n_routed_experts\`, \`num_experts_per_tok\`, \`moe_intermediate_size\`, \`hidden_size\`) live on \`config.get_text_config()\`, so the existing default fallback — which reads \`num_local_experts\` off the text_config, Mixtral-style — raises \`AttributeError\` on this architecture.

Same pattern as the \`Qwen3VLMoeForConditionalGeneration\` dispatch branch immediately above, and parallel to #40181 which does the same for Gemma4.

After this PR, \`benchmark_moe.py --model moonshotai/Kimi-VL-A3B-Instruct --tune\` works without a \`--model-prefix\` hack.

## Test plan
- [x] Confirmed Kimi-VL-A3B-Instruct text_config is a \`DeepseekV3Config\` with the expected fields (\`n_routed_experts=64\`, \`num_experts_per_tok=6\`, \`moe_intermediate_size=1408\`, \`hidden_size=2048\`)
- [x] Tuning sweep driven by these shape values produced the JSON shipped in #40542

## Related
- #40542 — A100 tuning config that this script would generate
- #40181 — same fix pattern for Gemma4