### PR TITLE
[Kernel] Give a helpful error when benchmark_moe.py hits an unknown arch

### DIFF
--- a/benchmarks/kernels/benchmark_moe.py
+++ b/benchmarks/kernels/benchmark_moe.py
@@ -810,13 +810,23 @@ def get_model_params(config):
         # recurse to get their parameters
         return get_model_params(config.get_text_config())
     else:
-        # Support for llama4
-        config = config.get_text_config()
-        # Default: Mixtral.
-        E = config.num_local_experts
-        topk = config.num_experts_per_tok
-        intermediate_size = config.intermediate_size
-        hidden_size = config.hidden_size
+        # Fallback: Mixtral/Llama4-style fields on the text config.
+        try:
+            text_config = config.get_text_config()
+            E = text_config.num_local_experts
+            topk = text_config.num_experts_per_tok
+            intermediate_size = text_config.intermediate_size
+            hidden_size = text_config.hidden_size
+        except AttributeError as e:
+            raise NotImplementedError(
+                f"Architecture {architecture!r} is not recognized by "
+                "benchmark_moe.py. The Mixtral/Llama4-style fallback failed "
+                f"with: {e}. To add support, introduce a new `elif` branch in "
+                "`get_model_params()` that reads the MoE shape "
+                "(num_experts, topk, intermediate_size, hidden_size) from "
+                "this architecture's config. See existing branches for "
+                "examples."
+            ) from e
     return E, topk, intermediate_size, hidden_size
 
 


### PR DESCRIPTION
## Purpose

When \`benchmark_moe.py --model <X>\` runs on an architecture that isn't in \`get_model_params\`'s dispatch, execution falls through to the Mixtral/Llama4-style fallback which reads \`num_local_experts\`, \`num_experts_per_tok\`, \`intermediate_size\`, \`hidden_size\` off the text config. If any of those attributes don't exist — the common case for architectures the fallback wasn't designed for — the user gets a raw \`AttributeError: '<X>Config' object has no attribute 'num_local_experts'\` with no hint about the real problem.

This wraps the fallback in try/except and converts the AttributeError into a \`NotImplementedError\` that names the architecture, shows the underlying attribute miss, and tells the user where to add a new dispatch branch.

No behavior change for architectures where the fallback already works (Mixtral, Llama4).

## Test plan
- [x] Architectures that currently succeed still succeed (Mixtral, Llama4 use the fallback)
- [x] On architectures that currently raise \`AttributeError\`, the new error identifies the architecture and points at the fix