### PR TITLE
[Bugfix] Remove duplicate size_k divisibility check in get_moe_wna16_block_config

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1184,7 +1184,6 @@ def get_moe_wna16_block_config(
         if (
             num_m_blocks <= 16
             and size_k % (block_size_k * 2) == 0
-            and size_k % (block_size_k * 2) == 0
             and block_size_k <= 512
             and num_blocks >= 512
         ):


### PR DESCRIPTION
## Purpose

\`get_moe_wna16_block_config\` in \`vllm/model_executor/layers/fused_moe/fused_moe.py\` checks \`size_k % (block_size_k * 2) == 0\` on two adjacent lines inside the same \`if\`. The duplicate clause is a no-op.

\`\`\`python
if (
    num_m_blocks <= 16
    and size_k % (block_size_k * 2) == 0
    and size_k % (block_size_k * 2) == 0  # <-- this line
    and block_size_k <= 512
    and num_blocks >= 512
):
\`\`\`

## Note for reviewer

Looking at surrounding code, \`size_n\` is also in scope and is the other dimension that \`block_size_k\` divides (line 1172: \`num_k_blocks = size_n // block_size_k\`). It's plausible the second clause was meant to read \`size_n % (block_size_k * 2) == 0\` — which would make the \`block_size_k\` doubling path safer on shapes where \`size_n\` isn't aligned to the larger block size.

Keeping this PR to the literal dedupe rather than changing semantics. Happy to submit a follow-up PR promoting the second clause to \`size_n\`-based if that was the original intent.

## Test plan
- [x] No existing tests exercise this exact path, but the change is literally removing a duplicate condition — the resulting expression is logically equivalent.