### PR TITLE
[AMD][CI][BugFix] Override normalize_e4m3fn_to_e4m3fnuz for fnuz machines in test_moe_layer_no_parallel

### DIFF
--- a/tests/kernels/moe/test_moe_layer.py
+++ b/tests/kernels/moe/test_moe_layer.py
@@ -17,6 +17,7 @@ from typing import get_args
 import pytest
 import torch
 
+import vllm.model_executor.layers.quantization.utils.w8a8_utils
 from tests.kernels.moe.modular_kernel_tools.parallel_utils import (
     ProcessGroupInfo,
     _set_vllm_config,
@@ -130,6 +131,22 @@ EPLB_SUPPORTED_QUANTS: list[str | None] = [None, "fp8"]
 # deepep backends fail in get_expert_weights / rearrange_expert_weights_inplace.
 # TODO(bnell): check this
 EPLB_SUPPORTED_BACKENDS: list[str] = ["allgather_reducescatter"]
+
+
+def mock_normalize_e4m3fn_to_e4m3fnuz(
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    input_scale: torch.Tensor | None = None,
+):
+    return weight, weight_scale, input_scale
+
+
+# Needed since weights will already be in e4m3fnuz format on platforms that
+# use the fnuz fp8 format and the normalize_e4m3fn_to_e4m3fnuz() function
+# is not being tested here.
+# NOTE: Not able to use monkeypatch because of the spawned parallel workers.
+def override_normalize_e4m3fn_to_e4m3fnuz():
+    vllm.model_executor.layers.quantization.utils.w8a8_utils.normalize_e4m3fn_to_e4m3fnuz = mock_normalize_e4m3fn_to_e4m3fnuz  # noqa: E501
 
 
 def maybe_roundup_layer_hidden_size(
@@ -1420,24 +1437,10 @@ def test_moe_layer_no_parallel(
     if os.environ.get("VLLM_LOGGING_LEVEL") is None:
         monkeypatch.setenv("VLLM_LOGGING_LEVEL", "ERROR")
 
-    # This is needed during testing since the MoE layers will already be in
-    # fnuz format on fnuz machines.
+    # Needed since weights will already be in e4m3fnuz format and the
+    # normalize_e4m3fn_to_e4m3fnuz() function is not being tested here.
     if current_platform.is_fp8_fnuz():
-
-        def mock_normalize_e4m3fn_to_e4m3fnuz(
-            weight: torch.Tensor,
-            weight_scale: torch.Tensor,
-            input_scale: torch.Tensor | None = None,
-        ):
-            return weight, weight_scale, input_scale
-
-        import vllm.model_executor.layers.quantization.utils.w8a8_utils
-
-        monkeypatch.setattr(
-            vllm.model_executor.layers.quantization.utils.w8a8_utils,
-            "normalize_e4m3fn_to_e4m3fnuz",
-            mock_normalize_e4m3fn_to_e4m3fnuz,
-        )
+        override_normalize_e4m3fn_to_e4m3fnuz()
 
     test_config = MoETestConfig(
         m,
@@ -1513,6 +1516,9 @@ def _parallel_worker(
     fail_ids = []
 
     dp_rank = vllm_config.parallel_config.data_parallel_rank
+
+    if current_platform.is_fp8_fnuz():
+        override_normalize_e4m3fn_to_e4m3fnuz()
 
     for test_config in test_configs:
         cc = vllm_config.compilation_config

--- a/tests/kernels/moe/test_moe_layer.py
+++ b/tests/kernels/moe/test_moe_layer.py
@@ -144,6 +144,8 @@ def mock_normalize_e4m3fn_to_e4m3fnuz(
 # Needed since weights will already be in e4m3fnuz format on platforms that
 # use the fnuz fp8 format and the normalize_e4m3fn_to_e4m3fnuz() function
 # is not being tested here.
+# NOTE: The weights are quantized by moe_quantize_weights_2d in
+# _quantize_fp8_halves.
 # NOTE: Not able to use monkeypatch because of the spawned parallel workers.
 def override_normalize_e4m3fn_to_e4m3fnuz():
     vllm.model_executor.layers.quantization.utils.w8a8_utils.normalize_e4m3fn_to_e4m3fnuz = mock_normalize_e4m3fn_to_e4m3fnuz  # noqa: E501

--- a/tests/kernels/moe/test_moe_layer.py
+++ b/tests/kernels/moe/test_moe_layer.py
@@ -1420,6 +1420,25 @@ def test_moe_layer_no_parallel(
     if os.environ.get("VLLM_LOGGING_LEVEL") is None:
         monkeypatch.setenv("VLLM_LOGGING_LEVEL", "ERROR")
 
+    # This is needed during testing since the MoE layers will already be in
+    # fnuz format on fnuz machines.
+    if current_platform.is_fp8_fnuz():
+
+        def mock_normalize_e4m3fn_to_e4m3fnuz(
+            weight: torch.Tensor,
+            weight_scale: torch.Tensor,
+            input_scale: torch.Tensor | None = None,
+        ):
+            return weight, weight_scale, input_scale
+
+        import vllm.model_executor.layers.quantization.utils.w8a8_utils
+
+        monkeypatch.setattr(
+            vllm.model_executor.layers.quantization.utils.w8a8_utils,
+            "normalize_e4m3fn_to_e4m3fnuz",
+            mock_normalize_e4m3fn_to_e4m3fnuz,
+        )
+
     test_config = MoETestConfig(
         m,
         n,


### PR DESCRIPTION


## Purpose
On machines, .e.g. MI300, that use the  `e4m3fnuz `fp8 datatype, the moe layer that is created is already in the fnuz format.  This leads to the following assertion error:
```
    def normalize_e4m3fn_to_e4m3fnuz(
        weight: torch.Tensor,
        weight_scale: torch.Tensor,
        input_scale: torch.Tensor | None = None,
    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None]:
>       assert weight.dtype == torch.float8_e4m3fn
E       AssertionError
```
since the layer is already in the fnuz format.
 
This means that `normalize_e4m3fn_to_e4m3fnuz `effectively has nothing to do.  So, monkeypatching the function in this way makes all the tests pass.

**NOTE**: The same problem occurs in the `test_moe_layer::test_moe_layer` test, but because of the spawned parallel workers, it is not possible to use monkeypatching, so an override is used instead.

## Test Plan
`pytest -sv kernels/moe/test_moe_layer.py::test_moe_layer_no_parallel`
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

