### PR TITLE
[Perf] Gemma4: output int64 from fused routing kernel to avoid redundant dtype copy

### DIFF
--- a/vllm/model_executor/layers/fused_moe/router/custom_routing_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/custom_routing_router.py
@@ -55,8 +55,9 @@ class CustomRoutingRouter(BaseRouter):
             renormalize=self.renormalize,
         )
 
-        target_dtype = torch.int32 if indices_type is None else indices_type
-        if topk_ids.dtype != target_dtype and topk_ids.dtype != torch.int64:
-            topk_ids = topk_ids.to(target_dtype)
+        if indices_type is not None:
+            topk_ids = topk_ids.to(indices_type)
+        elif topk_ids.dtype not in (torch.int32, torch.int64):
+            topk_ids = topk_ids.to(torch.int32)
 
         return topk_weights.to(torch.float32), topk_ids

--- a/vllm/model_executor/layers/fused_moe/router/custom_routing_router.py
+++ b/vllm/model_executor/layers/fused_moe/router/custom_routing_router.py
@@ -55,6 +55,8 @@ class CustomRoutingRouter(BaseRouter):
             renormalize=self.renormalize,
         )
 
-        return topk_weights.to(torch.float32), topk_ids.to(
-            torch.int32 if indices_type is None else indices_type
-        )
+        target_dtype = torch.int32 if indices_type is None else indices_type
+        if topk_ids.dtype != target_dtype and topk_ids.dtype != torch.int64:
+            topk_ids = topk_ids.to(target_dtype)
+
+        return topk_weights.to(torch.float32), topk_ids

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -157,7 +157,7 @@ def gemma4_fused_routing_kernel_triton(
     per_expert_scale = per_expert_scale.contiguous()
     T, E = gating_output.shape
     weights = torch.empty(T, topk, dtype=torch.float32, device=gating_output.device)
-    ids = torch.empty(T, topk, dtype=torch.int32, device=gating_output.device)
+    ids = torch.empty(T, topk, dtype=torch.int64, device=gating_output.device)
     BLOCK_E = triton.next_power_of_2(E)
     _gemma4_routing_kernel[(T,)](
         gating_output,


### PR DESCRIPTION
Summary:
This PR is a furthur optimization based on PR [https://github.com/vllm-project/vllm/pull/39083].
The Gemma4 fused Triton routing kernel (#39083) outputs `topk_ids` as `int32`, but all downstream consumers require `int64`:
- `remap_hidden_states` C++ kernel uses int64 indexing
- `cpu_fused_moe.py`: `topk_ids.to(torch.int64)` for scatter
- `gpt_oss_triton_kernels_moe.py`: `topk_ids_raw.to(torch.long)`
- `compressed_tensors_moe`: `topk_ids.to(torch.long)`

This mismatch causes **~30 unnecessary `aten::copy_` calls per forward pass** (one int32→int64 conversion per MoE layer), which becomes a measurable bottleneck on bandwidth-constrained platforms.

### Performance (Intel XPU × 4, TP=4, Gemma4-26B-A4B-it)

Relative to PR #39083 baseline (commit `45232a454`):




| Scenario | `copy_` calls | `copy_` XPU% | Throughput | TPOT |
|---|---|---|---|---|
| Prefill c=1 | 176 → **116** (−60) | 5.67% → **1.18%** | −4.9% (noise) | — |
| Prefill c=16 | 174 → **114** (−60) | — → **1.19%** | +4.3% | — |
| Decode c=1 | 1,706 → **1,106** (−600) | — → **1.99%** | +1.2% | −1.6% |
| Decode c=16 | 1,011 → **651** (−360) | — → **1.38%** | **+5.1%** | **−5.8%** |