### PR TITLE
[Build] Fall back to system libgomp when torch has no vendored copy

### DIFF
--- a/cmake/cpu_extension.cmake
+++ b/cmake/cpu_extension.cmake
@@ -37,15 +37,18 @@ else()
     # exists and the shim dir is empty; fall back to the system libgomp in that case.
     vllm_prepare_torch_gomp_shim(VLLM_TORCH_GOMP_SHIM_DIR)
 
-    find_library(OPEN_MP
-        NAMES gomp
-        HINTS ${VLLM_TORCH_GOMP_SHIM_DIR}
-        REQUIRED
-    )
-    # If the vendored shim was picked, put it on LD_LIBRARY_PATH so the build uses the
-    # same libgomp as PyTorch. Skip this when we fell back to the system libgomp.
-    if (OPEN_MP AND VLLM_TORCH_GOMP_SHIM_DIR AND OPEN_MP MATCHES "^${VLLM_TORCH_GOMP_SHIM_DIR}/")
+    if(VLLM_TORCH_GOMP_SHIM_DIR)
+        find_library(OPEN_MP
+            NAMES gomp
+            PATHS "${VLLM_TORCH_GOMP_SHIM_DIR}"
+            NO_DEFAULT_PATH
+            REQUIRED
+        )
+        # Use the same libgomp as PyTorch at runtime
         set(ENV{LD_LIBRARY_PATH} "${VLLM_TORCH_GOMP_SHIM_DIR}:$ENV{LD_LIBRARY_PATH}")
+    else()
+        # Fall back to system / toolchain libgomp
+        find_library(OPEN_MP NAMES gomp REQUIRED)
     endif()
 endif()
 

--- a/cmake/cpu_extension.cmake
+++ b/cmake/cpu_extension.cmake
@@ -32,17 +32,19 @@ else()
         "-DVLLM_CPU_EXTENSION")
 
     # locate PyTorch's libgomp (e.g. site-packages/torch.libs/libgomp-947d5fa1.so.1.0.0)
-    # and create a local shim dir with it
+    # and create a local shim dir with it. When PyTorch is built from source or packaged
+    # by a distro (common on RISC-V, s390x, Fedora/RHEL aarch64), no vendored libgomp
+    # exists and the shim dir is empty; fall back to the system libgomp in that case.
     vllm_prepare_torch_gomp_shim(VLLM_TORCH_GOMP_SHIM_DIR)
 
     find_library(OPEN_MP
         NAMES gomp
-        PATHS ${VLLM_TORCH_GOMP_SHIM_DIR}
-        NO_DEFAULT_PATH
+        HINTS ${VLLM_TORCH_GOMP_SHIM_DIR}
         REQUIRED
     )
-    # Set LD_LIBRARY_PATH to include the shim dir at build time to use the same libgomp as PyTorch
-    if (OPEN_MP)
+    # If the vendored shim was picked, put it on LD_LIBRARY_PATH so the build uses the
+    # same libgomp as PyTorch. Skip this when we fell back to the system libgomp.
+    if (OPEN_MP AND VLLM_TORCH_GOMP_SHIM_DIR AND OPEN_MP MATCHES "^${VLLM_TORCH_GOMP_SHIM_DIR}/")
         set(ENV{LD_LIBRARY_PATH} "${VLLM_TORCH_GOMP_SHIM_DIR}:$ENV{LD_LIBRARY_PATH}")
     endif()
 endif()


### PR DESCRIPTION
## Summary

`vllm_prepare_torch_gomp_shim()` only populates `VLLM_TORCH_GOMP_SHIM_DIR` when the installed PyTorch ships a vendored libgomp (the pip wheels under `site-packages/torch.libs/`). When PyTorch is built from source or installed from a distro package — common on **RISC-V**, **s390x**, and **Fedora / RHEL aarch64** — the shim dir is empty and the `REQUIRED` `find_library(OPEN_MP ... NO_DEFAULT_PATH)` call fails with:

```
CMake Error: Could NOT find OPEN_MP (missing: OPEN_MP)
```

This blocks the CPU extension build on any platform without vendored libgomp, regardless of whether a perfectly usable `libgomp.so` exists in the system library path.

## Changes

- `PATHS ${VLLM_TORCH_GOMP_SHIM_DIR}` + `NO_DEFAULT_PATH` → `HINTS ${VLLM_TORCH_GOMP_SHIM_DIR}`, so CMake searches the shim dir first and then falls back to the standard library paths.
- Only prepend the shim dir to `LD_LIBRARY_PATH` at build time when the vendored copy was actually picked (`OPEN_MP MATCHES "^${VLLM_TORCH_GOMP_SHIM_DIR}/"`). Injecting an empty directory otherwise is harmless but misleading.
- No behaviour change for x86_64 pip-wheel installs: the shim dir is non-empty there, `HINTS` resolves to the same vendored file.

## Why this matters

- Unblocks RISC-V CPU builds where PyTorch is built from source.
- Same fix applies to s390x and Fedora/RHEL aarch64 PyTorch packages.
- x86_64 wheel users are unaffected.

## Test plan

- [ ] x86_64 pip-wheel environment: build resolves to `torch.libs/libgomp-*.so` (same file as before).
- [ ] RISC-V openEuler + source-built PyTorch: build now resolves to system `/usr/lib64/libgomp.so.1`; CPU extension compiles successfully.
- [ ] CI build on aarch64 (pip wheel) — no change expected.

## AI assistance disclosure

AI assistance was used to draft the commit message and PR description. The root cause was diagnosed manually on RISC-V hardware (openEuler RISC-V, SG2044, no vendored libgomp in the source-built torch), and every changed line was reviewed and tested by the submitter.

Signed-off-by: liuyudong &lt;liuyudong@iscas.ac.cn&gt;
