### PR TITLE
[Bugfix] Skip tool parsing when no tools are provided, add unified Mistral parser

### DIFF
--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -668,12 +668,12 @@ class OpenAIServing:
             use_mistral_tool_parser
             or (
                 enable_auto_tools
+                and request.tools
                 and (
                     request.tool_choice == "auto"
                     or request.tool_choice is None
                     or (
                         not tool_parser_cls.supports_required_and_named
-                        and request.tools
                         and (
                             request.tool_choice == "required"
                             or isinstance(

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -569,22 +569,24 @@ class OpenAIServingRender:
                 tokenizer, model_config=self.model_config
             ).adjust_request(request=request)
 
-        # tool parsing is done only if a tool_parser has been set and if
-        # tool_choice is not "none" (if tool_choice is "none" but a tool_parser
-        # is set, we want to prevent parsing a tool_call hallucinated by the LLM
+        # tool parsing is done only if a tool_parser has been set, tools are
+        # provided, and tool_choice is not "none" (if tool_choice is "none"
+        # but tools are provided and a tool_parser is set, we want to prevent
+        # parsing a tool_call hallucinated by the LLM).
         #
         # Exception: Mistral grammar-capable tokenizers always call
         # adjust_request — even for tool_choice="none" — so that the grammar
         # factory can prevent special-token leakage.
         if tool_parser is not None:
             tool_choice = getattr(request, "tool_choice", "none")
+            tools = getattr(request, "tools", None)
             tokenizer = renderer.get_tokenizer()
             is_mistral_grammar_eligible = (
                 issubclass(tool_parser, MistralToolParser)
                 and is_mistral_tokenizer(tokenizer)
                 and tokenizer.supports_grammar
             )
-            if tool_choice != "none" or is_mistral_grammar_eligible:
+            if (tool_choice != "none" and tools) or is_mistral_grammar_eligible:
                 if not isinstance(request, ChatCompletionRequest | ResponsesRequest):
                     msg = (
                         "Tool usage is only supported "
@@ -592,8 +594,6 @@ class OpenAIServingRender:
                         f"but got {type(request).__name__}"
                     )
                     raise NotImplementedError(msg)
-                request = tool_parser(tokenizer, request.tools).adjust_request(
-                    request=request
-                )
+                request = tool_parser(tokenizer, tools).adjust_request(request=request)
 
         return conversation, [engine_input]

--- a/vllm/parser/__init__.py
+++ b/vllm/parser/__init__.py
@@ -20,6 +20,10 @@ _PARSERS_TO_REGISTER = {
         "minimax_m2_parser",  # filename
         "MiniMaxM2Parser",  # class_name
     ),
+    "mistral": (
+        "mistral_parser",
+        "MistralParser",
+    ),
 }
 
 

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -674,5 +674,5 @@ class _WrappedParser(DelegatingParser):
             self._reasoning_parser = self.__class__.reasoning_parser_cls(
                 tokenizer, **kwargs
             )
-        if self.__class__.tool_parser_cls is not None:
+        if self.__class__.tool_parser_cls is not None and tools:
             self._tool_parser = self.__class__.tool_parser_cls(tokenizer, tools)

--- a/vllm/parser/minimax_m2_parser.py
+++ b/vllm/parser/minimax_m2_parser.py
@@ -54,7 +54,8 @@ class MiniMaxM2Parser(DelegatingParser):
 
         # Initialize the underlying parsers
         self._reasoning_parser = MiniMaxM2ReasoningParser(tokenizer, *args, **kwargs)
-        self._tool_parser = MinimaxM2ToolParser(tokenizer, tools)
+        if tools:
+            self._tool_parser = MinimaxM2ToolParser(tokenizer, tools)
 
         logger.debug(
             "vLLM Successfully initialized parser %s!", self.__class__.__name__

--- a/vllm/parser/mistral_parser.py
+++ b/vllm/parser/mistral_parser.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Mistral Parser - A unified parser for Mistral models.
+
+This parser combines MistralReasoningParser and MistralToolParser into a
+single unified interface.  Unlike ``_WrappedParser``, it **always**
+instantiates ``MistralToolParser`` even when no tools are provided, because
+the Mistral grammar path (``_grammar_from_tool_parser``) requires a live
+tool-parser instance for streaming extraction.
+"""
+
+from vllm.logger import init_logger
+from vllm.parser.abstract_parser import DelegatingParser
+from vllm.reasoning import ReasoningParser
+from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers.abstract_tool_parser import Tool
+from vllm.tool_parsers.mistral_tool_parser import MistralToolParser
+
+logger = init_logger(__name__)
+
+
+class MistralParser(DelegatingParser):
+    """
+    Unified parser for Mistral models that handles both reasoning
+    extraction and tool call parsing.
+
+    This parser delegates to the existing implementations:
+    - Any reasoning parser for reasoning extraction
+    - MistralToolParser for tool call parsing
+
+    The tool parser is always instantiated (even without tools) so the
+    Mistral grammar streaming path has the parser instance it requires.
+    """
+
+    # Any reasoning parser is supported.
+    reasoning_parser_cls: type[ReasoningParser] | None = None
+    tool_parser_cls: type[MistralToolParser] = MistralToolParser
+
+    def __init__(
+        self,
+        tokenizer: TokenizerLike,
+        tools: list[Tool] | None = None,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(tokenizer, *args, **kwargs)
+
+        cls = type(self)
+        if cls.reasoning_parser_cls:
+            self._reasoning_parser = cls.reasoning_parser_cls(tokenizer, **kwargs)
+
+        self._tool_parser = cls.tool_parser_cls(tokenizer, tools)
+
+        logger.debug("vLLM Successfully initialized parser %s!", cls)

--- a/vllm/parser/parser_manager.py
+++ b/vllm/parser/parser_manager.py
@@ -279,25 +279,50 @@ class ParserManager:
             except KeyError:
                 pass  # No unified parser with this name
 
-        # Strategy 2: Check for parser with either name
-        for name in [tool_parser_name, reasoning_parser_name]:
-            if name:
-                try:
-                    parser = cls.get_parser_internal(name)
-                    logger.info(
-                        "Using unified parser '%s' for reasoning and tool parsing.",
-                        name,
-                    )
-                    return parser
-                except KeyError:
-                    pass
-
-        # Strategy 3: Create a DelegatingParser with the individual parser classes
         reasoning_parser_cls = cls.get_reasoning_parser(reasoning_parser_name)
         tool_parser_cls = cls.get_tool_parser(
             tool_parser_name, enable_auto_tools, model_name
         )
 
+        # Strategy 2: Check if an unified parser matches either name
+        # If it does, try to specialize it with the specific reasoning and tool parsers.
+        for name in [tool_parser_name, reasoning_parser_name]:
+            if name:
+                try:
+                    parser = cls.get_parser_internal(name)
+                except KeyError:
+                    continue
+
+                if parser.reasoning_parser_cls is None:
+                    parser.reasoning_parser_cls = reasoning_parser_cls
+                elif parser.reasoning_parser_cls != reasoning_parser_cls:
+                    logger.warning(
+                        "Unified parser '%s' isn't used due to unsupported "
+                        "reasoning parser: expected %s but got %s",
+                        name,
+                        parser.reasoning_parser_cls,
+                        reasoning_parser_cls,
+                    )
+                    continue
+
+                if parser.tool_parser_cls is None:
+                    parser.tool_parser_cls = tool_parser_cls
+                elif parser.tool_parser_cls != tool_parser_cls:
+                    logger.warning(
+                        "Unified parser '%s' isn't used due to unsupported "
+                        "tool parser: expected %s but got %s",
+                        name,
+                        parser.tool_parser_cls,
+                        tool_parser_cls,
+                    )
+                    continue
+
+                logger.info(
+                    "Using unified parser '%s' for reasoning and tool parsing.",
+                    name,
+                )
+                return parser
+        # Strategy 3: Create a DelegatingParser with the individual parser classes
         if reasoning_parser_cls is None and tool_parser_cls is None:
             return None
 


### PR DESCRIPTION
## Purpose

When `tools=None`, the tool parser was still applied to model outputs, which could produce false-positive tool calls when none should exist. Following up #40314.

This PR skips tool-parser invocation when no tools are provided in the request. 

Also added a stub unified `MistralParser` to handle Mistral, which requires tool-parser invocation regardless of whether tools are provided in the `_grammar_from_tool_parser` path.

Harmony paths have their own tool-parser invocation logic and are not touched.

**Changes:**

- Add `not tools` guards at four call-sites:
  - **Prevent `adjust_request`** (pre-processing the request before inference): `render/serving.py`
  - **Prevent tool parser from running on model outputs**:
    - `engine/serving.py` — Chat Completion non-streaming
    - `abstract_parser.py` — `_WrappedParser` no longer instantiates the tool parser when tools are absent (Chat Completion streaming, Responses API streaming + non-streaming)
    - `minimax_m2_parser.py` — same guard as `_WrappedParser`
- Introduce `MistralParser` (`parser/mistral_parser.py`), a unified parser that **always** instantiates `MistralToolParser` (even without tools).
- When `ParserManager` resolves a unified parser (like `MistralParser`), it now backfills unset `reasoning_parser_cls` / `tool_parser_cls` slots from the CLI-configured values. This lets `MistralParser` inherit the user's reasoning parser while keeping its own `MistralToolParser`. Conflicting slots cause the candidate to be skipped with a warning.

## Test Plan

```
pytest -sv tests/tool_parsers
pytest -sv tests/tool_use
```

## Test Result

Tests pass

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

