### PR TITLE
[MM][CG] Support `--enable-vit-cuda-graph` option for VLM examples

### DIFF
--- a/examples/offline_inference/vision_language.py
+++ b/examples/offline_inference/vision_language.py
@@ -2598,16 +2598,6 @@ def maybe_add_vit_cuda_graph_compilation_config(args, engine_args):
 
         engine_args.compilation_config = {
             "cudagraph_mm_encoder": True,
-            "encoder_cudagraph_token_budgets": [
-                512,
-                1024,
-                1536,
-                2048,
-                2560,
-                3072,
-                3584,
-                4096,
-            ],
             "encoder_cudagraph_max_vision_items_per_batch": vision_items_per_batch,
         }
 

--- a/examples/offline_inference/vision_language.py
+++ b/examples/offline_inference/vision_language.py
@@ -2463,6 +2463,12 @@ MODELS_NEED_VIDEO_METADATA = [
 ]
 
 
+MODELS_SUPPORT_VIT_CUDA_GRAPH = [
+    "qwen3_vl",
+    "qwen3_vl_moe",
+]
+
+
 def get_multi_modal_input(args):
     """
     return {
@@ -2575,6 +2581,39 @@ def apply_image_repeat(
     return inputs, inputs_with_empty_media
 
 
+def maybe_add_vit_cuda_graph_compilation_config(args, engine_args):
+    model = args.model_type
+    modality = args.modality
+    enable_vit_cuda_graph = args.enable_vit_cuda_graph
+
+    if enable_vit_cuda_graph and model in MODELS_SUPPORT_VIT_CUDA_GRAPH:
+        if modality == "image" or modality == "video":
+            vision_items_per_batch = 1
+        elif modality == "image+video":
+            vision_items_per_batch = 2
+        else:
+            raise ValueError(
+                f"modality={modality} is not supported for vit cuda graph."
+            )
+
+        engine_args.compilation_config = {
+            "cudagraph_mm_encoder": True,
+            "encoder_cudagraph_token_budgets": [
+                512,
+                1024,
+                1536,
+                2048,
+                2560,
+                3072,
+                3584,
+                4096,
+            ],
+            "encoder_cudagraph_max_vision_items_per_batch": vision_items_per_batch,
+        }
+
+    return engine_args
+
+
 @contextmanager
 def time_counter(enable: bool):
     if enable:
@@ -2625,33 +2664,28 @@ def parse_args():
         default=0,
         help="Set the seed when initializing `vllm.LLM`.",
     )
-
     parser.add_argument(
         "--image-repeat-prob",
         type=float,
         default=None,
         help="Simulates the hit-ratio for multi-modal preprocessor cache (if enabled)",
     )
-
     parser.add_argument(
         "--disable-mm-processor-cache",
         action="store_true",
         help="If True, disables caching of multi-modal processor.",
     )
-
     parser.add_argument(
         "--time-generate",
         action="store_true",
         help="If True, then print the total generate() call time",
     )
-
     parser.add_argument(
         "--use-different-prompt-per-request",
         action="store_true",
         help="If True, then use different prompt (with the same multi-modal "
         "data) for each request.",
     )
-
     parser.add_argument(
         "--verify-mm-cache-hit-with-uuids",
         action="store_true",
@@ -2664,6 +2698,11 @@ def parse_args():
         type=int,
         default=None,
         help="Tensor parallel size to override the model's default setting. ",
+    )
+    parser.add_argument(
+        "--enable-vit-cuda-graph",
+        action="store_true",
+        help="If True, will enable vit cuda graph capture and replay for the model.",
     )
     return parser.parse_args()
 
@@ -2698,6 +2737,7 @@ def main(args):
     engine_args.mm_processor_cache_gb = mm_processor_cache_gb
     if args.tensor_parallel_size is not None:
         engine_args.tensor_parallel_size = args.tensor_parallel_size
+    engine_args = maybe_add_vit_cuda_graph_compilation_config(args, engine_args)
     llm = LLM.from_engine_args(engine_args)
 
     # Don't want to check the flag multiple times, so just hijack `prompts`.

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1802,6 +1802,7 @@ class Qwen3VLForConditionalGeneration(
         #                 spatial_merge_size=2 → 8x8 = 64 tokens
         min_budget = 64
         # Max: capped by max_num_batched_tokens
+        # TODO(shen-shanshan): the max_budget auto-infer needs to be optimized later.
         max_budget = min(
             vllm_config.scheduler_config.max_num_batched_tokens,
             self.model_config.max_model_len,

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -1802,7 +1802,10 @@ class Qwen3VLForConditionalGeneration(
         #                 spatial_merge_size=2 → 8x8 = 64 tokens
         min_budget = 64
         # Max: capped by max_num_batched_tokens
-        max_budget = vllm_config.scheduler_config.max_num_batched_tokens
+        max_budget = min(
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            self.model_config.max_model_len,
+        )
         return (min_budget, max_budget)
 
     def _get_pixel_values_by_modality(


### PR DESCRIPTION
## Purpose
Support `--enable-vit-cuda-graph` option for VLM examples.

## Test Plan
```bash
python examples/offline_inference/vision_language.py -m qwen3_vl --modality "image" --enable-vit-cuda-graph
python examples/offline_inference/vision_language.py -m qwen3_vl --modality "video" --enable-vit-cuda-graph
```

## Test Result
modality="image":
```
--------------------------------------------------
This image captures a beautiful and iconic scene from Tokyo, Japan, featuring the **Tokyo Skytree** framed by blooming **cherry blossoms** (sakura).

Here's a breakdown of the content:

*   **Foreground:** The image is dominated by the vibrant pink and white blossoms of cherry trees
--------------------------------------------------
This image captures a beautiful and iconic scene, likely from Japan, featuring:

- **Cherry Blossoms (Sakura)**: The foreground is filled with delicate pink cherry blossoms in full bloom, framing the view. The branches create a natural, organic frame, with some flowers in sharp focus and others softly blurred
--------------------------------------------------
This image captures a beautiful and iconic scene: the **Tokyo Skytree** viewed through the blossoming branches of **cherry blossom trees** (sakura).

Here's a breakdown of the content:

*   **Foreground:** The frame is filled with the delicate, pink petals of cherry blossoms. The branches
--------------------------------------------------
This image captures a beautiful and iconic scene: the **Tokyo Skytree**, Japan’s tallest tower, viewed through a canopy of blooming **cherry blossoms** (sakura).

Here’s a breakdown of the content:

*   **Foreground:** The image is framed by the dark, silhouetted
--------------------------------------------------
```

modality="video":
```
--------------------------------------------------
The video is funny because it shows a baby wearing glasses and pretending to read a book, which is an adorable and unexpected sight. The baby's serious demeanor while holding the book and trying to "read" it adds to the humor, as it's clear the baby doesn't actually understand the text. The contrast between the
--------------------------------------------------
The video is funny because it shows a baby wearing glasses and pretending to read a book. The baby's serious and focused expression, combined with the absurdity of a baby wearing glasses and trying to read, creates a humorous contrast. The baby's actions, such as turning the pages and looking at the book with concentration,
--------------------------------------------------
The video is funny because it shows a baby wearing glasses and pretending to read a book. The baby's serious and focused expression, combined with the absurdity of a baby wearing glasses and trying to read, creates a humorous contrast. The baby's actions, such as flipping through the pages and occasionally looking up as if trying
--------------------------------------------------
The video is funny because it shows a baby wearing glasses and pretending to read a book, which is an adorable and unexpected sight. The baby's serious demeanor while reading adds to the humor, as it contrasts with the typical image of a baby engaging in such an activity. The baby's actions, such as flipping through the
--------------------------------------------------
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

