### PR TITLE
[Gemma4][Bugfix]: add missing get_expert_mapping

### DIFF
--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -1612,6 +1612,16 @@ class Gemma4ForCausalLM(
     ) -> torch.Tensor | None:
         return self.logits_processor(self.lm_head, hidden_states)
 
+    def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
+        return FusedMoE.make_expert_params_mapping(
+            self,
+            ckpt_gate_proj_name="gate_proj",
+            ckpt_down_proj_name="down_proj",
+            ckpt_up_proj_name="up_proj",
+            num_experts=self.config.num_experts,
+            num_redundant_experts=self.num_redundant_experts,
+        )
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         # Checkpoint weight names use "language_model." prefix (from the
         # Gemma4ForConditionalGeneration wrapper). Strip it to map to our


### PR DESCRIPTION
## Purpose
The below servver launch cmd doesnt work without this fix
```
export VLLM_ALLOW_RUNTIME_LORA_UPDATING=True
vllm serve google/gemma-4-26B-A4B -dp 1 -tp 1 --gpu-memory-utilization 0.8 --enable-lora --max-lora-rank 16 --max-loras 4 | tee infer_out.log
```

## Test Plan
TBD. Need to train a gemma4 lora first