### PR TITLE
REPRO: revert sparse MLA qk_norm_rope_fusion workaround

### DIFF
--- a/tests/compile/fusions_e2e/conftest.py
+++ b/tests/compile/fusions_e2e/conftest.py
@@ -116,18 +116,11 @@ def run_e2e_fusion_test(monkeypatch, caplog_mp_spawn):
         model_kwargs["attention_config"] = {"backend": attn_backend.backend.name}
         model_kwargs["tensor_parallel_size"] = tp_size
 
-        # Sparse MLA models (DSv3.2) hit an over-strict inductor assertion in
-        # decompose_auto_functionalized when +rotary_embedding is forced into
-        # the compile graph. Disable qk_norm+rope fusion (which auto-enables
-        # +rotary_embedding) for this combo to avoid the known torch bug.
-        # TODO: remove once upstream torch fix lands.
+        # REPRO: leave qk_norm_rope_fusion enabled for sparse models so the
+        # known torch.compile bug (replace_by_example node-count assert)
+        # fires. Keep the max_model_len bump only — that's an unrelated
+        # runtime guard for DSv3.2's persistent_topk(k=2048).
         if requires_sparse:
-            if "pass_config" in compilation_config:
-                compilation_config["pass_config"].enable_qk_norm_rope_fusion = False
-                matches_check = [m for m in matches_check if m != "norm_rope_fusion"]
-            # DSv3.2 sparse indexer uses persistent_topk with k=config.index_topk
-            # (2048 for the default config). max_model_len must be >= index_topk
-            # or the topk kernel raises "k out of range" at runtime.
             model_kwargs["max_model_len"] = max(
                 model_kwargs.get("max_model_len", 0), 2048
             )


### PR DESCRIPTION
Temporarily undo the workaround from #38877 so DSv3.2 + FLASHMLA_SPARSE exercises the +rotary_embedding path that crashes inductor's decompose_auto_functionalized at replace_by_example. Used only for diagnosing the upstream torch issue.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

