### PR TITLE
[Models][Gemma3/Gemma4] Support hidden_act variants in gated MLP

### DIFF
--- a/tests/model_executor/test_gemma_hidden_act.py
+++ b/tests/model_executor/test_gemma_hidden_act.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.activation import (
+    GeluAndMul,
+    SiluAndMul,
+    get_act_and_mul_fn,
+    get_act_fn,
+)
+from vllm.model_executor.models.gemma3 import Gemma3MLP
+from vllm.model_executor.models.gemma4 import Gemma4MLP
+
+
+@pytest.mark.parametrize(
+    ("activation_name", "expected_type"),
+    [
+        ("gelu_pytorch_tanh", GeluAndMul),
+        ("silu", SiluAndMul),
+        ("swish", SiluAndMul),
+    ],
+)
+def test_get_act_and_mul_fn_supports_gemma_hidden_act_aliases(
+    activation_name: str,
+    expected_type: type[torch.nn.Module],
+    default_vllm_config,
+) -> None:
+    assert isinstance(get_act_and_mul_fn(activation_name), expected_type)
+
+
+def test_get_act_fn_supports_swish_alias() -> None:
+    assert isinstance(get_act_fn("swish"), torch.nn.SiLU)
+
+
+@pytest.mark.parametrize("mlp_cls", [Gemma3MLP, Gemma4MLP])
+@pytest.mark.parametrize(
+    ("activation_name", "expected_type"),
+    [
+        ("gelu_pytorch_tanh", GeluAndMul),
+        ("silu", SiluAndMul),
+        ("swish", SiluAndMul),
+    ],
+)
+def test_gemma_mlp_supports_hidden_act_variants(
+    mlp_cls: type[torch.nn.Module],
+    activation_name: str,
+    expected_type: type[torch.nn.Module],
+    default_vllm_config,
+    dist_init,
+) -> None:
+    mlp = mlp_cls(
+        hidden_size=16,
+        intermediate_size=32,
+        hidden_activation=activation_name,
+    )
+
+    assert isinstance(mlp.act_fn, expected_type)
+    assert mlp(torch.randn(3, 16)).shape == (3, 16)

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -712,6 +712,7 @@ _ACTIVATION_REGISTRY = LazyDict(
         "relu": lambda: nn.ReLU(),
         "relu2": lambda: ReLUSquaredActivation(),
         "silu": lambda: nn.SiLU(),
+        "swish": lambda: nn.SiLU(),
         "quick_gelu": lambda: QuickGELU(),
         "tanh": lambda: nn.Tanh(),
         "sigmoid": lambda: nn.Sigmoid(),
@@ -751,7 +752,9 @@ def get_act_fn(act_fn_name: str) -> nn.Module:
 _ACTIVATION_AND_MUL_REGISTRY: LazyDict[nn.Module] = LazyDict(
     {
         "gelu": lambda: GeluAndMul(),
+        "gelu_pytorch_tanh": lambda: GeluAndMul(approximate="tanh"),
         "silu": lambda: SiluAndMul(),
+        "swish": lambda: SiluAndMul(),
         "geglu": lambda: GeluAndMul(),
         "swigluoai": lambda: SwigluOAIAndMul(),
     }

--- a/vllm/model_executor/models/gemma3.py
+++ b/vllm/model_executor/models/gemma3.py
@@ -26,7 +26,7 @@ from vllm.compilation.decorators import support_torch_compile
 from vllm.config import CacheConfig, VllmConfig
 from vllm.distributed import get_pp_group, get_tensor_model_parallel_world_size
 from vllm.logger import init_logger
-from vllm.model_executor.layers.activation import GeluAndMul
+from vllm.model_executor.layers.activation import get_act_and_mul_fn
 from vllm.model_executor.layers.attention import (
     Attention,
     EncoderOnlyAttention,
@@ -88,13 +88,7 @@ class Gemma3MLP(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.down_proj",
         )
-        if hidden_activation != "gelu_pytorch_tanh":
-            raise ValueError(
-                "Gemma3 uses `gelu_pytorch_tanh` as the hidden activation "
-                "function. Please set `hidden_act` and `hidden_activation` to "
-                "`gelu_pytorch_tanh`."
-            )
-        self.act_fn = GeluAndMul(approximate="tanh")
+        self.act_fn = get_act_and_mul_fn(hidden_activation)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         gate_up, _ = self.gate_up_proj(x)

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -35,7 +35,7 @@ from vllm.distributed import (
 )
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
-from vllm.model_executor.layers.activation import GeluAndMul
+from vllm.model_executor.layers.activation import get_act_and_mul_fn
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (
     FusedMoE,
@@ -238,13 +238,7 @@ class Gemma4MLP(nn.Module):
             quant_config=quant_config,
             prefix=f"{prefix}.down_proj",
         )
-        if hidden_activation != "gelu_pytorch_tanh":
-            raise ValueError(
-                "Gemma4 uses `gelu_pytorch_tanh` as the hidden activation "
-                "function. Please set `hidden_act` and `hidden_activation` to "
-                "`gelu_pytorch_tanh`."
-            )
-        self.act_fn = GeluAndMul(approximate="tanh")
+        self.act_fn = get_act_and_mul_fn(hidden_activation)
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         gate_up, _ = self.gate_up_proj(x)


### PR DESCRIPTION
Co-authored-by: Codex




## Purpose

We (Preferred Networks) developed new models which can be defined as variants of gemma3/gemma4. To achieve this, we want to enable models that are written by `transformers` config to run on vllm as well.

This PR updates Gemma3 and Gemma4 MLP activation handling so that vLLM no longer hard-codes `hidden_activation == "gelu_pytorch_tanh"` in the model definitions.

Instead, both models now resolve their gated MLP activation through `get_act_and_mul_fn`, which allows them to support the hidden activation variants exposed by configs/checkpoints, including:
- `gelu_pytorch_tanh`
- `silu`
- `swish`

Concretely, this PR:
- adds `gelu_pytorch_tanh` to `_ACTIVATION_AND_MUL_REGISTRY` as `GeluAndMul(approximate="tanh")`
- adds `swish` as an alias for `SiLU` / `SiluAndMul`
- switches Gemma3 and Gemma4 MLPs to use `get_act_and_mul_fn(hidden_activation)` instead of raising on anything except `gelu_pytorch_tanh`

This is intended to improve compatibility with Gemma checkpoints/configs that use non-default `hidden_act` variants, while preserving the existing `gelu_pytorch_tanh` behavior.

duplication check:
- I checked open PRs with searches for `gemma3 hidden_act`, `gemma4 hidden_act`, and `gemma activation`.
- I did not find an open PR addressing Gemma3/Gemma4 hidden activation variant support. The only nearby open Gemma PR I found was #39582, which is about Gemma4 quantized MoE weight loading and KV cache spec merge, not activation handling.

AI assistance:
This change was mainly written with AI assistance (codex), and the final diff was reviewed by a human before submission and tests have been run on the local machine.

Notes:
While `swish` and `silu` behave similarly, I added `swish` to `get_act_and_mul_fn` since transformers defines both silu and swish in its activation mapping: https://github.com/huggingface/transformers/blob/main/src/transformers/activations.py

## Test Plan

Check: `pytest tests/model_executor/test_gemma_hidden_act.py -q`

## Test Result

```
...
10 passed, 16 warnings in 27.13s
```

Pre-commit hooks (ruff, mypy, typos, markdownlint) all pass.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

