### PR TITLE
[Bugfix][CI] Fix `v1/kv_connector/unit/test_nixl_connector_hma.py::test_fewer_blocks_with_hma`

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -2,9 +2,11 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Unit tests for NixlConnectorScheduler with HMA and Mamba N-1 prefill."""
 
+import gc
 from unittest.mock import patch
 
 import pytest
+import torch
 
 from vllm import LLM, SamplingParams
 from vllm.config import KVTransferConfig
@@ -196,12 +198,13 @@ def test_fewer_blocks_with_hma(monkeypatch, model_name, sw_size):
     llm_kwargs = {
         "model": model_name,
         "enforce_eager": True,
-        "gpu_memory_utilization": 0.47,
+        "gpu_memory_utilization": 0.3,
         "kv_transfer_config": kv_transfer_config,
         "max_model_len": 2048,
+        "max_num_seqs": 1,
         # NOTE: Make sure HMA is enabled
         "disable_hybrid_kv_cache_manager": False,
-        "max_num_batched_tokens": 1024,
+        "max_num_batched_tokens": 2048,
         "enable_prefix_caching": False,
         "block_size": block_size,
     }
@@ -248,6 +251,8 @@ def test_fewer_blocks_with_hma(monkeypatch, model_name, sw_size):
             assert len(group_block_ids) == expected_num_remote_blocks
 
     def run_test_and_cleanup():
+        gc.collect()
+        torch.accelerator.empty_cache()
         llm = LLM(**llm_kwargs)
         try:
             run_hma_test(llm)


### PR DESCRIPTION
This test is still broken https://buildkite.com/vllm/ci/builds/62326/steps/canvas?jid=019db0a3-9861-43f2-b686-7ba06c50977f&tab=output#019db0a3-9861-43f2-b686-7ba06c50977f
```
[2026-04-21T15:52:21Z] FAILED v1/kv_connector/unit/test_nixl_connector_hma.py::test_fewer_blocks_with_hma[google/gemma-3-1b-it-512] - ValueError: Free memory on device cuda:0 (4.51/22.05 GiB) on startup is less than desired GPU memory utilization (0.47, 10.36 GiB). Decrease GPU memory utilization or reduce GPU memory used by other processes.
```

The fix proposed in https://github.com/vllm-project/vllm/pull/39938/ doesn't really address the core issue. 
Both model and context are already plenty small here, but as shown by the logs there's leftovers still hogging memory.
I suspect this might be due to `VLLM_ENABLE_V1_MULTIPROCESSING=0` which makes cleaning up from other tests less "automatic", as the allocation happens on main process and things aren't cleaned up at (worst case) during process exit when executing in a subprocess.

Here I am attempting to flush memory manually. 
We can resort to `clean_gpu_memory_between_tests` if things keep failing.