### PR TITLE
fix: correct typo 'Hyrbid' to 'Hybrid' in test-amd.yaml

### DIFF
--- a/.buildkite/test-amd.yaml
+++ b/.buildkite/test-amd.yaml
@@ -2401,7 +2401,7 @@ steps:
   - uv pip install --system -r /vllm-workspace/requirements/kv_connectors_rocm.txt
   - DP_EP=1 ROCM_ATTN=1 bash v1/kv_connector/nixl_integration/config_sweep_accuracy_test.sh
 
-- label: Hyrbid SSM NixlConnector PD accuracy tests (4 GPUs) # TBD
+- label: Hybrid SSM NixlConnector PD accuracy tests (4 GPUs) # TBD
   timeout_in_minutes: 180
   mirror_hardwares: [amdexperimental, amdproduction, amdgfx942nightly, amdmi300]
   agent_pool: mi300_4


### PR DESCRIPTION
### 🐛 What this PR does
This PR fixes a simple typo in the AMD test configuration file.

### 🔍 Details
I found that `Hyrbid` should be `Hybrid` in the test label.
- **Location:** `./vllm/.buildkite/test-amd.yaml:2404`
- **Context:** `label: Hyrbid SSM NixlConnector PD accuracy tests (4 GPUs) # TBD`

### 🙋‍♂️ Note
This is my first contribution to vLLM. I am excited to start contributing and look forward to maintaining and improving the project together with the community in the future!