### PR TITLE
[MM][Gemma4] Support `max_soft_tokens="auto"` to avoid wasting the vision budget on small images

### DIFF
--- a/tests/models/multimodal/processing/test_gemma4.py
+++ b/tests/models/multimodal/processing/test_gemma4.py
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import numpy as np
 import pytest
+from PIL import Image
 
 from vllm.multimodal import MULTIMODAL_REGISTRY
+from vllm.multimodal.cache import MultiModalProcessorSenderCache
 
 from ....conftest import ImageTestAssets
 from ...utils import build_model_context
@@ -42,3 +45,261 @@ def test_limit_mm_per_prompt(
             mm_items=processor.info.parse_mm_data(mm_data),
             hf_processor_mm_kwargs={},
         )
+
+
+# ---------------------------------------------------------------------------
+# max_soft_tokens="auto" — early canonicalization + cache coherence
+# ---------------------------------------------------------------------------
+
+# Sizes chosen so they fall into distinct _SUPPORTED_SOFT_TOKENS buckets
+# at the default Gemma 4 geometry (patch_size=16, pooling_kernel_size=3 =>
+# 2304 px per token). See test_gemma4_auto_budget.py for bucket math.
+_SIZE_SMALL_70 = (100, 75)  # area 7,500 → 70
+_SIZE_LARGE_1120 = (1920, 1080)  # area 2,073,600 → 1120
+
+
+def _make_image(size: tuple[int, int], seed: int) -> Image.Image:
+    w, h = size
+    # Deterministic per-seed content so hashes are stable across runs
+    # within a single test invocation but diverge per-seed so we exercise
+    # multi-image paths without relying on PIL identity dedup.
+    rng = np.random.RandomState(seed)
+    arr = rng.randint(0, 255, size=(h, w, 3), dtype=np.uint8)
+    return Image.fromarray(arr)
+
+
+def _build_processor(
+    model_id: str,
+    *,
+    mm_processor_kwargs: dict | None = None,
+    cache: object | None = "default",
+):
+    """Build a processor + its context. ``cache="default"`` uses whatever
+    the registry picks; pass ``cache=None`` to disable caching; pass an
+    explicit cache instance to use it."""
+    ctx = build_model_context(
+        model_id,
+        mm_processor_kwargs=mm_processor_kwargs or {},
+        limit_mm_per_prompt={"image": 4},
+        mm_processor_cache_gb=1,
+    )
+    if cache == "default":
+        processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config)
+    else:
+        processor = MULTIMODAL_REGISTRY.create_processor(
+            ctx.model_config, cache=cache
+        )
+    return ctx, processor
+
+
+def _image_prompt(processor, n_images: int) -> str:
+    """Build a prompt containing ``n_images`` copies of the processor's
+    actual image token — matches what Gemma 4's chat template inserts."""
+    token = processor.info.get_hf_processor().image_token
+    return token * n_images
+
+
+@pytest.mark.parametrize("model_id", [GEMMA4_MODEL_ID])
+def test_auto_hash_equals_explicit_for_small_image(model_id: str):
+    """Server with ``max_soft_tokens="auto"`` must yield the same
+    mm_hashes as ``max_soft_tokens=70`` when every image in the request
+    resolves to 70. If the sentinel is not canonicalized before hashing,
+    the "auto" request's hash would differ from the explicit-70 hash
+    for the same image — the exact cache-poisoning failure mode."""
+    _, proc_auto = _build_processor(model_id, cache=None)
+    _, proc_explicit = _build_processor(model_id, cache=None)
+
+    img = _make_image(_SIZE_SMALL_70, seed=0)
+    mm_data = {"image": [img]}
+
+    # vLLM computes hashes inside processor(...); compare the resulting
+    # mm_hashes across the two configurations.
+    out_auto = proc_auto(
+        _image_prompt(proc_auto, 1),
+        mm_items=proc_auto.info.parse_mm_data(mm_data),
+        hf_processor_mm_kwargs={"max_soft_tokens": "auto"},
+    )
+    out_explicit = proc_explicit(
+        _image_prompt(proc_explicit, 1),
+        mm_items=proc_explicit.info.parse_mm_data(mm_data),
+        hf_processor_mm_kwargs={"max_soft_tokens": 70},
+    )
+
+    # Same effective config → same per-item hashes.
+    assert out_auto["mm_hashes"] == out_explicit["mm_hashes"], (
+        "auto resolved to 70 must produce the same mm_hashes as "
+        "explicit max_soft_tokens=70 — otherwise the sentinel is "
+        "leaking into the cache key."
+    )
+
+
+@pytest.mark.parametrize("model_id", [GEMMA4_MODEL_ID])
+def test_auto_hash_differs_when_context_changes(model_id: str):
+    """The same PIL image submitted (a) alone and (b) batched with a
+    larger image must yield different mm_hashes under
+    ``max_soft_tokens="auto"``, because the effective budget differs
+    (70 vs 1120).  If hashes match, the mm-processor cache will serve
+    stale 70-token tensors for a request that actually needs 1120."""
+    _, proc = _build_processor(model_id, cache=None)
+
+    small = _make_image(_SIZE_SMALL_70, seed=1)
+    large = _make_image(_SIZE_LARGE_1120, seed=2)
+
+    out_alone = proc(
+        _image_prompt(proc, 1),
+        mm_items=proc.info.parse_mm_data({"image": [small]}),
+        hf_processor_mm_kwargs={"max_soft_tokens": "auto"},
+    )
+    out_batched = proc(
+        _image_prompt(proc, 2),
+        mm_items=proc.info.parse_mm_data({"image": [small, large]}),
+        hf_processor_mm_kwargs={"max_soft_tokens": "auto"},
+    )
+
+    # The small image's hash when alone (budget=70) must not collide
+    # with its hash when batched with a large image (budget=1120).
+    small_hash_alone = out_alone["mm_hashes"]["image"][0]
+    small_hash_batched = out_batched["mm_hashes"]["image"][0]
+    assert small_hash_alone != small_hash_batched, (
+        "Same image in different batch compositions must produce "
+        "different mm_hashes under auto; otherwise a cache hit from "
+        "the alone-request will serve stale 70-token tensors for a "
+        "batched request that needs 1120."
+    )
+
+
+@pytest.mark.parametrize("model_id", [GEMMA4_MODEL_ID])
+@pytest.mark.parametrize("order", ["alone_then_batched", "batched_then_alone"])
+def test_auto_cache_coherence_across_requests(model_id: str, order: str):
+    """With mm_processor_cache on, sequencing "alone then batched" and
+    "batched then alone" must both produce prompt_token_ids matching a
+    cache-less baseline.  A stale cache entry from the prior request
+    would otherwise corrupt the second one."""
+    _, baseline = _build_processor(model_id, cache=None)
+
+    sender_cache = MultiModalProcessorSenderCache(baseline.info.ctx.model_config)
+    _, cached = _build_processor(model_id, cache=sender_cache)
+
+    small = _make_image(_SIZE_SMALL_70, seed=3)
+    large = _make_image(_SIZE_LARGE_1120, seed=4)
+
+    def run(proc, images, prompt):
+        return proc(
+            prompt,
+            mm_items=proc.info.parse_mm_data({"image": images}),
+            hf_processor_mm_kwargs={"max_soft_tokens": "auto"},
+        )["prompt_token_ids"]
+
+    p1 = _image_prompt(baseline, 1)
+    p2 = _image_prompt(baseline, 2)
+    baseline_alone = run(baseline, [small], p1)
+    baseline_batched = run(baseline, [small, large], p2)
+
+    if order == "alone_then_batched":
+        first = run(cached, [small], p1)
+        second = run(cached, [small, large], p2)
+        assert first == baseline_alone
+        assert second == baseline_batched, (
+            "Cached run of [small, large] differs from baseline — the "
+            "small-image cache entry from the prior alone-request was "
+            "probably reused with a stale 70-token tensor."
+        )
+    else:
+        first = run(cached, [small, large], p2)
+        second = run(cached, [small], p1)
+        assert first == baseline_batched
+        assert second == baseline_alone, (
+            "Cached alone-request differs from baseline — the cache "
+            "entry for small from the prior batched request was "
+            "probably reused with a stale 1120-token tensor."
+        )
+
+
+@pytest.mark.parametrize("model_id", [GEMMA4_MODEL_ID])
+def test_auto_partial_cache_hit(model_id: str):
+    """Warm the cache with a single small image, then send it batched
+    with a fresh large image.  The partial-hit path in
+    _cached_apply_hf_processor must not serve the small image's stale
+    70-token tensor when the batched request needs 1120."""
+    _, baseline = _build_processor(model_id, cache=None)
+    sender_cache = MultiModalProcessorSenderCache(baseline.info.ctx.model_config)
+    _, cached = _build_processor(model_id, cache=sender_cache)
+
+    small = _make_image(_SIZE_SMALL_70, seed=5)
+    large = _make_image(_SIZE_LARGE_1120, seed=6)
+
+    def run(proc, images, prompt):
+        return proc(
+            prompt,
+            mm_items=proc.info.parse_mm_data({"image": images}),
+            hf_processor_mm_kwargs={"max_soft_tokens": "auto"},
+        )["prompt_token_ids"]
+
+    p1 = _image_prompt(baseline, 1)
+    p2 = _image_prompt(baseline, 2)
+
+    # Warm: small alone → 70 cached under hash(small, 70)-derived key.
+    _ = run(cached, [small], p1)
+
+    # Partial: small (potential hit) + large (miss) → 1120 needed.
+    baseline_ids = run(baseline, [small, large], p2)
+    cached_ids = run(cached, [small, large], p2)
+    assert cached_ids == baseline_ids
+
+
+@pytest.mark.parametrize("model_id", [GEMMA4_MODEL_ID])
+def test_auto_server_default_with_empty_request_kwargs(model_id: str):
+    """``--mm-processor-kwargs='{"max_soft_tokens":"auto"}'`` (server
+    default) with empty per-request kwargs must still canonicalize.
+    This is the case where "auto" lives only in the merged kwargs, not
+    in the raw request kwargs — the canonicalizer must still find it."""
+    _, proc = _build_processor(
+        model_id,
+        mm_processor_kwargs={"max_soft_tokens": "auto"},
+        cache=None,
+    )
+
+    img = _make_image(_SIZE_SMALL_70, seed=7)
+    mm_data = {"image": [img]}
+
+    # Must not raise — "auto" must be resolved before the HF processor
+    # validator sees it.  A failure here means the server-default path
+    # is not reaching the canonicalizer.
+    out = proc(
+        _image_prompt(proc, 1),
+        mm_items=proc.info.parse_mm_data(mm_data),
+        hf_processor_mm_kwargs={},
+    )
+    assert out["prompt_token_ids"]
+
+
+@pytest.mark.parametrize("model_id", [GEMMA4_MODEL_ID])
+def test_auto_uniform_budget_within_request(model_id: str):
+    """All images in a single request must share one resolved budget
+    (Gemma 4 invariant).  Verified indirectly via prompt_token_ids
+    equivalence: the output under ``auto`` in a [small, large] batch
+    must match the output under explicit ``max_soft_tokens=1120`` for
+    the same batch."""
+    _, proc_auto = _build_processor(model_id, cache=None)
+    _, proc_explicit = _build_processor(model_id, cache=None)
+
+    small = _make_image(_SIZE_SMALL_70, seed=8)
+    large = _make_image(_SIZE_LARGE_1120, seed=9)
+
+    common = {"image": [small, large]}
+    out_auto = proc_auto(
+        _image_prompt(proc_auto, 2),
+        mm_items=proc_auto.info.parse_mm_data(common),
+        hf_processor_mm_kwargs={"max_soft_tokens": "auto"},
+    )["prompt_token_ids"]
+    out_explicit = proc_explicit(
+        _image_prompt(proc_explicit, 2),
+        mm_items=proc_explicit.info.parse_mm_data(common),
+        hf_processor_mm_kwargs={"max_soft_tokens": 1120},
+    )["prompt_token_ids"]
+
+    assert out_auto == out_explicit, (
+        "auto must resolve to 1120 for a [small, large] batch (the "
+        "max per-image budget) and produce the same token ids as an "
+        "explicit 1120 request."
+    )

--- a/tests/models/multimodal/processing/test_gemma4_auto_budget.py
+++ b/tests/models/multimodal/processing/test_gemma4_auto_budget.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Unit tests for ``_pick_auto_soft_tokens``.
+
+Exercises the adaptive budget picker for Gemma 4's vision tower over
+boundary cases, aspect ratios, and out-of-range inputs.  The resize math
+is derived from transformers'
+``models/gemma4/image_processing_pil_gemma4.get_aspect_ratio_preserving_size``
+which sizes an image so it fits in
+``max_soft_tokens * patch_size**2 * pooling_kernel_size**2`` pixels while
+preserving aspect ratio.  For the default Gemma 4 config
+(``patch_size=16``, ``pooling_kernel_size=3``) that is
+``max_soft_tokens * 2304`` pixels per budget.
+"""
+
+import pytest
+
+from vllm.model_executor.models.gemma4_mm import (
+    _SUPPORTED_SOFT_TOKENS,
+    _pick_auto_soft_tokens,
+    _resolve_auto_over_images,
+)
+
+# Default Gemma 4 geometry.
+PATCH = 16
+POOL = 3
+# Pixels of image area each ``max_soft_tokens`` slot can represent at the
+# native resize target: patch_size**2 * pooling_kernel_size**2.
+PX_PER_TOKEN = PATCH**2 * POOL**2  # 2304
+
+
+def _target_area(budget: int) -> int:
+    return budget * PX_PER_TOKEN
+
+
+@pytest.mark.parametrize(
+    "width,height,expected",
+    [
+        # Each boundary is area == budget * 2304 exactly (square).
+        # At the boundary the image fits in that budget's target area;
+        # one pixel over flips to the next bucket.
+        (401, 401, 70),  # 160,801 <= 161,280
+        (402, 402, 140),  # 161,604 >  161,280
+        (568, 568, 280),  # 322,624 >  322,560
+        (803, 803, 280),  # 644,809 <= 645,120
+        (804, 804, 560),  # 646,416 >  645,120
+        (1135, 1135, 560),  # 1,288,225 <= 1,290,240
+        (1136, 1136, 1120),  # 1,290,496 >  1,290,240
+        (1606, 1606, 1120),  # 2,579,236 <= 2,580,480
+        (1607, 1607, 1120),  # clamp: no larger budget exists
+    ],
+)
+def test_square_boundaries(width, height, expected):
+    assert _pick_auto_soft_tokens(width, height, PATCH, POOL) == expected
+
+
+@pytest.mark.parametrize(
+    "width,height,expected",
+    [
+        # Common aspect ratios. Only the area matters; the picker is
+        # aspect-ratio agnostic because the native resize preserves AR.
+        (100, 75, 70),  # thumbnail
+        (200, 150, 70),
+        (640, 480, 140),  # VGA: 307,200 > 161,280
+        (800, 600, 280),  # 480,000 > 322,560
+        (1024, 768, 560),  # 786,432 > 645,120
+        (1280, 720, 560),  # 921,600 > 645,120
+        (1920, 1080, 1120),  # Full HD: 2,073,600 > 1,290,240
+        (3840, 2160, 1120),  # 4K: 8,294,400 (clamped to largest budget)
+        (4032, 3024, 1120),  # 12 MP phone photo (clamped)
+    ],
+)
+def test_common_aspect_ratios(width, height, expected):
+    assert _pick_auto_soft_tokens(width, height, PATCH, POOL) == expected
+
+
+@pytest.mark.parametrize("budget", _SUPPORTED_SOFT_TOKENS)
+def test_exact_target_area_fits(budget):
+    """An image whose total area exactly equals the budget's target area
+    must fit in that budget (factor == 1.0, no downscale)."""
+    area = _target_area(budget)
+    # Use a 2:1 aspect ratio so we also exercise the non-square path.
+    # w * h == area, w = 2h  =>  h = sqrt(area/2), w = 2h.
+    h = int((area / 2) ** 0.5)
+    w = area // h
+    assert _pick_auto_soft_tokens(w, h, PATCH, POOL) <= budget
+
+
+def test_clamp_on_oversized_image():
+    """Images larger than the largest budget's target area clamp rather
+    than error.  Preserves the current fixed-budget behavior for those
+    inputs."""
+    huge_area = _target_area(_SUPPORTED_SOFT_TOKENS[-1]) * 10
+    # Any w, h with this area — pick 1:1 for simplicity.
+    side = int(huge_area**0.5) + 1
+    assert _pick_auto_soft_tokens(side, side, PATCH, POOL) == _SUPPORTED_SOFT_TOKENS[-1]
+
+
+def test_tiny_image_picks_smallest_budget():
+    """A 1x1 image always lands in the smallest budget."""
+    assert _pick_auto_soft_tokens(1, 1, PATCH, POOL) == _SUPPORTED_SOFT_TOKENS[0]
+
+
+def test_monotonic_in_area():
+    """Picker must be monotonically non-decreasing in image area."""
+    prev = 0
+    for side in range(1, 2000, 7):
+        budget = _pick_auto_soft_tokens(side, side, PATCH, POOL)
+        assert budget >= prev
+        prev = budget
+
+
+@pytest.mark.parametrize(
+    "patch_size,pool_size",
+    [(8, 2), (16, 3), (32, 4)],  # default + two hypothetical configs
+)
+def test_picker_uses_config_values(patch_size, pool_size):
+    """The formula ``pixels_per_token = patch_size**2 * pool_size**2`` is
+    exercised via the configurable arguments rather than hardcoded 2304."""
+    px_per_tok = (patch_size**2) * (pool_size**2)
+    # An image sized exactly for the smallest budget must land on it.
+    smallest = _SUPPORTED_SOFT_TOKENS[0]
+    area = smallest * px_per_tok
+    side = int(area**0.5)
+    assert _pick_auto_soft_tokens(side, side, patch_size, pool_size) <= smallest
+
+
+# ---------------------------------------------------------------------------
+# _resolve_auto_over_images — the multi-image request-level resolver
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_empty_list_returns_smallest_budget():
+    """With no images, return the smallest supported budget so the HF
+    processor still receives a valid numeric value."""
+    assert _resolve_auto_over_images([], PATCH, POOL) == _SUPPORTED_SOFT_TOKENS[0]
+
+
+def test_resolve_single_image_matches_picker():
+    """Single image: the resolver is equivalent to _pick_auto_soft_tokens."""
+    cases = [(100, 75), (800, 600), (1920, 1080)]
+    for w, h in cases:
+        single = _resolve_auto_over_images([(w, h)], PATCH, POOL)
+        direct = _pick_auto_soft_tokens(w, h, PATCH, POOL)
+        assert single == direct
+
+
+def test_resolve_multi_image_takes_max():
+    """Multi-image requests must collapse to a single budget — the max
+    across all images — so every image in the prompt shares one budget
+    (Gemma 4 requires this; per-image budgets would mismatch the vision
+    tower's output count and crash embedding merge)."""
+    # Mix tiny + large: result must match the large image's budget.
+    sizes = [(100, 75), (1920, 1080), (200, 150)]
+    resolved = _resolve_auto_over_images(sizes, PATCH, POOL)
+    expected = max(_pick_auto_soft_tokens(w, h, PATCH, POOL) for w, h in sizes)
+    assert resolved == expected
+    # Concrete: 1920x1080 (area 2,073,600) lands in the 1120 bucket.
+    assert resolved == 1120
+
+
+def test_resolve_all_small_stays_small():
+    """A batch of tiny images stays in the smallest budget — no spurious
+    promotion to a larger budget."""
+    sizes = [(100, 75), (200, 150), (50, 50)]
+    assert _resolve_auto_over_images(sizes, PATCH, POOL) == 70

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -14,6 +14,7 @@ processor inserts ``mm:ss`` timestamps between frames so the model can
 reason about temporal order.
 """
 
+import dataclasses
 import math
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Annotated, Any, Literal
@@ -54,9 +55,12 @@ from vllm.multimodal.parse import (
     MultiModalDataParser,
 )
 from vllm.multimodal.processing import BaseDummyInputsBuilder
+from vllm.multimodal.processing.context import TimingContext
+from vllm.multimodal.processing.inputs import ProcessorInputs
 from vllm.multimodal.processing.processor import (
     BaseMultiModalProcessor,
     BaseProcessingInfo,
+    MultiModalProcessingInfo,
     PromptReplacement,
     PromptUpdate,
     PromptUpdateDetails,
@@ -124,19 +128,6 @@ def _pick_auto_soft_tokens(
         if budget * pixels_per_token >= area:
             return budget
     return _SUPPORTED_SOFT_TOKENS[-1]
-
-
-def _get_image_size(image: Any) -> tuple[int, int] | None:
-    """Best-effort ``(width, height)`` extraction for PIL images, numpy
-    arrays, and torch tensors.  Returns ``None`` if the shape cannot be
-    inferred."""
-    if isinstance(image, PILImage.Image):
-        return image.size  # (width, height)
-    shape = getattr(image, "shape", None)
-    if shape is None or len(shape) < 2:
-        return None
-    # Assume CHW or HW ordering for arrays / tensors.
-    return int(shape[-1]), int(shape[-2])
 
 
 def _resolve_auto_over_images(
@@ -336,18 +327,17 @@ class Gemma4ProcessingInfo(BaseProcessingInfo):
         if max_soft_tokens is None:
             max_soft_tokens = vision_cfg.default_output_length
 
-        # The ``"auto"`` sentinel must be resolved at the request level
-        # (``_call_hf_processor`` or ``_get_prompt_updates``) before this
-        # method runs, because Gemma 4 requires all images in a single
-        # prompt to share a single budget.  Per-image resolution here
-        # would produce placeholder counts that disagree with the vision
-        # tower's actual output and crash embedding merge.
+        # Invariant: ``"auto"`` must already have been canonicalized to a
+        # concrete integer by
+        # ``Gemma4MultiModalProcessor._cached_apply_hf_processor``
+        # upstream of any path that reaches this method.  Per-image
+        # resolution here would produce placeholder counts that disagree
+        # with the vision tower's actual output and crash embedding
+        # merge.
         if max_soft_tokens == _AUTO_SOFT_TOKENS:
             raise ValueError(
                 f"max_soft_tokens={_AUTO_SOFT_TOKENS!r} reached "
-                "_compute_num_soft_tokens without being resolved. Resolve "
-                "it at the request level using _resolve_auto_over_images "
-                "over every image in the prompt."
+                "_compute_num_soft_tokens without being canonicalized."
             )
 
         unit = patch_size * pooling_kernel_size
@@ -570,6 +560,96 @@ class Gemma4DummyInputsBuilder(BaseDummyInputsBuilder[Gemma4ProcessingInfo]):
 
 
 class Gemma4MultiModalProcessor(BaseMultiModalProcessor[Gemma4ProcessingInfo]):
+    def _canonicalize_auto_soft_tokens(
+        self,
+        inputs: ProcessorInputs,
+    ) -> ProcessorInputs:
+        """Resolve ``max_soft_tokens="auto"`` into a concrete integer on
+        ``inputs.hf_processor_mm_kwargs`` before anything downstream
+        consumes it.
+
+        Rationale
+        ---------
+        Two downstream consumers assume a numeric ``max_soft_tokens``:
+
+        1. ``ProcessorInputs.get_mm_hashes()`` hashes the raw
+           ``hf_processor_mm_kwargs`` per-item.  Leaving the string
+           ``"auto"`` in the kwargs makes the same image share a cache
+           entry across requests whose *effective* budget differs, which
+           corrupts the per-item mm-processor cache.
+        2. ``_apply_hf_processor_main`` instantiates
+           ``get_hf_processor(**hf_processor_mm_kwargs)``; the HF
+           processor's validator rejects anything outside
+           ``_SUPPORTED_SOFT_TOKENS``.
+
+        Canonicalizing here — before ``super()._cached_apply_hf_processor``
+        runs ``get_mm_hashes()`` and constructs the HF processor — makes
+        both consumers safe.  The resolved budget is the largest
+        per-image adaptive budget, so every image in the request shares
+        one budget (required by Gemma 4) and no image is downscaled.
+        """
+        merged = self.info.ctx.get_merged_mm_kwargs(inputs.hf_processor_mm_kwargs)
+        effective = merged.get("max_soft_tokens")
+        if effective is None:
+            images_k = merged.get("images_kwargs") or {}
+            if isinstance(images_k, Mapping):
+                effective = images_k.get("max_soft_tokens")
+        if effective != _AUTO_SOFT_TOKENS:
+            return inputs
+
+        if "image" in inputs.mm_data_items:
+            image_items = inputs.mm_data_items.get_items(
+                "image", ImageProcessorItems
+            )
+            image_sizes: list[tuple[int, int]] = [
+                (
+                    image_items.get_image_size(i).width,
+                    image_items.get_image_size(i).height,
+                )
+                for i in range(len(image_items))
+            ]
+        else:
+            image_sizes = []
+
+        vision_cfg = self.info.get_hf_config().vision_config
+        resolved = _resolve_auto_over_images(
+            image_sizes,
+            vision_cfg.patch_size,
+            vision_cfg.pooling_kernel_size,
+        )
+
+        # Build a canonical kwargs dict with no string "auto" in either
+        # the top-level or the ``images_kwargs`` slot.
+        new_kwargs: dict[str, object] = dict(inputs.hf_processor_mm_kwargs)
+        if new_kwargs.get("max_soft_tokens") == _AUTO_SOFT_TOKENS:
+            new_kwargs["max_soft_tokens"] = resolved
+        elif "max_soft_tokens" not in new_kwargs:
+            # Server-level default case: neither slot exists in the raw
+            # request kwargs.  Promote the resolved integer to the
+            # top-level so downstream sees a concrete value.
+            new_kwargs["max_soft_tokens"] = resolved
+
+        images_k = new_kwargs.get("images_kwargs")
+        if isinstance(images_k, Mapping) and images_k.get("max_soft_tokens") == (
+            _AUTO_SOFT_TOKENS
+        ):
+            images_k = dict(images_k)
+            images_k["max_soft_tokens"] = resolved
+            new_kwargs["images_kwargs"] = images_k
+
+        return dataclasses.replace(inputs, hf_processor_mm_kwargs=new_kwargs)
+
+    def _cached_apply_hf_processor(
+        self,
+        inputs: ProcessorInputs,
+        timing_ctx: TimingContext,
+    ) -> tuple[list[int], MultiModalProcessingInfo, bool]:
+        # Canonicalize ``max_soft_tokens="auto"`` BEFORE hashing and HF
+        # processor construction.  See ``_canonicalize_auto_soft_tokens``.
+        return super()._cached_apply_hf_processor(
+            self._canonicalize_auto_soft_tokens(inputs), timing_ctx
+        )
+
     def _call_hf_processor(
         self,
         prompt: str,
@@ -577,54 +657,38 @@ class Gemma4MultiModalProcessor(BaseMultiModalProcessor[Gemma4ProcessingInfo]):
         mm_kwargs: Mapping[str, object],
         tok_kwargs: Mapping[str, object],
     ) -> BatchFeature:
-        # Validate max_soft_tokens early and fail fast on bad values.
+        # ``"auto"`` is resolved earlier in
+        # ``_canonicalize_auto_soft_tokens``.  Any value reaching here
+        # via a normal path is numeric.  The one exception is
+        # ``_apply_hf_processor_text_only`` which hardcodes
+        # ``hf_processor_mm_kwargs={}`` — that bypasses our
+        # canonicalizer, and ``"auto"`` then surfaces via the
+        # config-level default at merge time.  That path has no images
+        # so the value is unused; normalize it to the smallest
+        # supported budget and proceed.  With images present, ``"auto"``
+        # here means the canonicalizer was skipped and we fail loud.
         merged_kwargs = self.info.ctx.get_merged_mm_kwargs(mm_kwargs)
         val = merged_kwargs.get("max_soft_tokens")
         images_kwargs_dict = merged_kwargs.get("images_kwargs", {})
         if val is None:
             val = images_kwargs_dict.get("max_soft_tokens")
 
-        # Resolve the "auto" sentinel against the actual image dimensions
-        # BEFORE the HF processor sees it — the HF processor's own
-        # validator only accepts numeric values in _SUPPORTED_SOFT_TOKENS.
-        # Multi-image requests get a single budget based on the largest
-        # image so no image is downscaled and every image in the prompt
-        # shares one budget (required by Gemma 4).
         if val == _AUTO_SOFT_TOKENS:
-            vision_cfg = self.info.get_hf_config().vision_config
-            image_sizes: list[tuple[int, int]] = []
-            for img in mm_data.get("images", []) or []:
-                size = _get_image_size(img)
-                if size is not None:
-                    image_sizes.append(size)
-            val = _resolve_auto_over_images(
-                image_sizes,
-                vision_cfg.patch_size,
-                vision_cfg.pooling_kernel_size,
-            )
-
-            # Write the resolved integer into the merged kwargs so the HF
-            # processor receives a concrete number.
-            if "max_soft_tokens" in merged_kwargs:
-                merged_kwargs["max_soft_tokens"] = val
-            elif "images_kwargs" in merged_kwargs:
-                if not isinstance(images_kwargs_dict, dict):
-                    images_kwargs_dict = dict(images_kwargs_dict)
-                    merged_kwargs["images_kwargs"] = images_kwargs_dict
-                images_kwargs_dict["max_soft_tokens"] = val
-
-            # Mirror the resolved integer into the user-supplied kwargs.
-            # This propagates to later stages (``_get_prompt_updates``)
-            # that re-merge from ``mm_kwargs`` and would otherwise
-            # re-encounter the sentinel.  Set unconditionally — when
-            # ``"auto"`` was only a server-level default, neither slot
-            # exists in ``mm_kwargs`` yet and we must create one.
+            if mm_data.get("images"):
+                raise ValueError(
+                    f"max_soft_tokens={_AUTO_SOFT_TOKENS!r} reached "
+                    "_call_hf_processor with image mm_data but without "
+                    "being canonicalized. The canonicalization pass in "
+                    "Gemma4MultiModalProcessor._cached_apply_hf_processor "
+                    "should have resolved it to an integer."
+                )
+            val = _SUPPORTED_SOFT_TOKENS[0]
+            # Propagate the normalized integer so that the HF processor
+            # downstream does not re-merge and see "auto" from the
+            # config-level default.  The text-only path hardcodes
+            # mm_kwargs={} so it is safe to mutate here.
             if isinstance(mm_kwargs, dict):
-                images_k = mm_kwargs.get("images_kwargs")
-                if isinstance(images_k, dict) and "max_soft_tokens" in images_k:
-                    images_k["max_soft_tokens"] = val
-                else:
-                    mm_kwargs["max_soft_tokens"] = val
+                mm_kwargs["max_soft_tokens"] = val
 
         if val is not None and val not in _SUPPORTED_SOFT_TOKENS:
             raise ValueError(
@@ -875,29 +939,21 @@ class Gemma4MultiModalProcessor(BaseMultiModalProcessor[Gemma4ProcessingInfo]):
             # consistent with how _call_hf_processor resolves it.
             # Without this merge, a missing per-prompt override would
             # fall back to vision_cfg.default_output_length instead of
-            # the config's mm_processor_kwargs default.  If ``"auto"``
-            # is still present (e.g., ``_call_hf_processor`` has not
-            # run yet, or this method is invoked standalone), resolve
-            # it here using every image in the request so each image
-            # ends up with the same concrete budget.
+            # the config's mm_processor_kwargs default.
+            #
+            # ``"auto"`` is canonicalized upstream in
+            # ``_cached_apply_hf_processor`` so it must not be seen here.
             merged_kwargs = self.info.ctx.get_merged_mm_kwargs(
                 hf_processor_mm_kwargs,
             )
             resolved_max_soft_tokens = merged_kwargs.get("max_soft_tokens")
             if resolved_max_soft_tokens == _AUTO_SOFT_TOKENS:
-                images_items = mm_items.get_items("image", ImageProcessorItems)
-                image_sizes = [
-                    (
-                        images_items.get_image_size(i).width,
-                        images_items.get_image_size(i).height,
-                    )
-                    for i in range(len(images_items))
-                ]
-                vision_cfg = self.info.get_hf_config().vision_config
-                resolved_max_soft_tokens = _resolve_auto_over_images(
-                    image_sizes,
-                    vision_cfg.patch_size,
-                    vision_cfg.pooling_kernel_size,
+                raise ValueError(
+                    f"max_soft_tokens={_AUTO_SOFT_TOKENS!r} reached "
+                    "_get_prompt_updates without being canonicalized. "
+                    "The canonicalization pass in "
+                    "Gemma4MultiModalProcessor._cached_apply_hf_processor "
+                    "should have resolved it to an integer."
                 )
 
             def get_replacement_image(item_idx: int):

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -84,6 +84,84 @@ logger = init_logger(__name__)
 _VIDEO_MAX_SOFT_TOKENS = 70  # soft tokens per video frame (vs 280 for images)
 _VIDEO_MAX_FRAMES = 32  # max sampled frames per video
 
+# Gemma 4's vision tower only supports these five soft-token budgets.
+# See transformers.models.gemma4.image_processing_pil_gemma4._SUPPORTED_SOFT_TOKENS.
+_SUPPORTED_SOFT_TOKENS: tuple[int, ...] = (70, 140, 280, 560, 1120)
+
+# Sentinel value for ``mm_processor_kwargs.max_soft_tokens`` that asks the
+# server to pick the smallest supported budget whose native resize target
+# area covers the image area.  Avoids both info loss from downscaling and
+# wasted tokens from upscaling.  See ``_pick_auto_soft_tokens``.
+_AUTO_SOFT_TOKENS: str = "auto"
+
+
+def _pick_auto_soft_tokens(
+    image_width: int,
+    image_height: int,
+    patch_size: int,
+    pooling_kernel_size: int,
+) -> int:
+    """Pick the smallest supported ``max_soft_tokens`` whose native resize
+    target area covers the input image area.
+
+    Rationale
+    ---------
+    ``get_aspect_ratio_preserving_size`` in transformers
+    (``models/gemma4/image_processing_pil_gemma4.py``) resizes by a uniform
+    factor ``sqrt(target_px / image_px)`` with
+    ``target_px = max_soft_tokens * patch_size**2 * pooling_kernel_size**2``.
+    A factor ``>= 1`` means the image is upscaled or left alone — no spatial
+    information is dropped.  A factor ``< 1`` means a downscale and info
+    loss.  This helper picks the smallest budget that keeps the factor
+    ``>= 1``, avoiding both info loss and the wasted tokens of a larger-
+    than-needed budget.  Images too large to fit the biggest supported
+    budget fall through to that budget (identical to the current fixed
+    behavior for oversized inputs).
+    """
+    pixels_per_token = (patch_size**2) * (pooling_kernel_size**2)
+    area = image_width * image_height
+    for budget in _SUPPORTED_SOFT_TOKENS:
+        if budget * pixels_per_token >= area:
+            return budget
+    return _SUPPORTED_SOFT_TOKENS[-1]
+
+
+def _get_image_size(image: Any) -> tuple[int, int] | None:
+    """Best-effort ``(width, height)`` extraction for PIL images, numpy
+    arrays, and torch tensors.  Returns ``None`` if the shape cannot be
+    inferred."""
+    if isinstance(image, PILImage.Image):
+        return image.size  # (width, height)
+    shape = getattr(image, "shape", None)
+    if shape is None or len(shape) < 2:
+        return None
+    # Assume CHW or HW ordering for arrays / tensors.
+    return int(shape[-1]), int(shape[-2])
+
+
+def _resolve_auto_over_images(
+    image_sizes: Iterable[tuple[int, int]],
+    patch_size: int,
+    pooling_kernel_size: int,
+) -> int:
+    """Resolve ``max_soft_tokens="auto"`` to a single integer that is
+    shared by every image in the request.
+
+    Gemma 4 requires all images in one prompt to use the same soft-token
+    budget (the HF processor accepts a single ``max_soft_tokens`` per
+    batch and the vision tower emits a fixed number of tokens per image
+    at that budget).  We pick the largest per-image adaptive budget so
+    no image is downscaled; smaller images are upscaled to match, which
+    is the same behavior as today's fixed-budget configuration.
+    """
+    resolved = _SUPPORTED_SOFT_TOKENS[0]
+    for width, height in image_sizes:
+        resolved = max(
+            resolved,
+            _pick_auto_soft_tokens(width, height, patch_size, pooling_kernel_size),
+        )
+    return resolved
+
 
 # ---------------------------------------------------------------------------
 # Input schema
@@ -257,6 +335,20 @@ class Gemma4ProcessingInfo(BaseProcessingInfo):
 
         if max_soft_tokens is None:
             max_soft_tokens = vision_cfg.default_output_length
+
+        # The ``"auto"`` sentinel must be resolved at the request level
+        # (``_call_hf_processor`` or ``_get_prompt_updates``) before this
+        # method runs, because Gemma 4 requires all images in a single
+        # prompt to share a single budget.  Per-image resolution here
+        # would produce placeholder counts that disagree with the vision
+        # tower's actual output and crash embedding merge.
+        if max_soft_tokens == _AUTO_SOFT_TOKENS:
+            raise ValueError(
+                f"max_soft_tokens={_AUTO_SOFT_TOKENS!r} reached "
+                "_compute_num_soft_tokens without being resolved. Resolve "
+                "it at the request level using _resolve_auto_over_images "
+                "over every image in the prompt."
+            )
 
         unit = patch_size * pooling_kernel_size
         max_patches = max_soft_tokens * pooling_kernel_size**2
@@ -485,18 +577,60 @@ class Gemma4MultiModalProcessor(BaseMultiModalProcessor[Gemma4ProcessingInfo]):
         mm_kwargs: Mapping[str, object],
         tok_kwargs: Mapping[str, object],
     ) -> BatchFeature:
-        # Validate max_soft_tokens early and exit cleanly on bad values.
-        _SUPPORTED_SOFT_TOKENS = (70, 140, 280, 560, 1120)
-
+        # Validate max_soft_tokens early and fail fast on bad values.
         merged_kwargs = self.info.ctx.get_merged_mm_kwargs(mm_kwargs)
         val = merged_kwargs.get("max_soft_tokens")
+        images_kwargs_dict = merged_kwargs.get("images_kwargs", {})
         if val is None:
-            val = merged_kwargs.get("images_kwargs", {}).get("max_soft_tokens")
+            val = images_kwargs_dict.get("max_soft_tokens")
+
+        # Resolve the "auto" sentinel against the actual image dimensions
+        # BEFORE the HF processor sees it — the HF processor's own
+        # validator only accepts numeric values in _SUPPORTED_SOFT_TOKENS.
+        # Multi-image requests get a single budget based on the largest
+        # image so no image is downscaled and every image in the prompt
+        # shares one budget (required by Gemma 4).
+        if val == _AUTO_SOFT_TOKENS:
+            vision_cfg = self.info.get_hf_config().vision_config
+            image_sizes: list[tuple[int, int]] = []
+            for img in mm_data.get("images", []) or []:
+                size = _get_image_size(img)
+                if size is not None:
+                    image_sizes.append(size)
+            val = _resolve_auto_over_images(
+                image_sizes,
+                vision_cfg.patch_size,
+                vision_cfg.pooling_kernel_size,
+            )
+
+            # Write the resolved integer into the merged kwargs so the HF
+            # processor receives a concrete number.
+            if "max_soft_tokens" in merged_kwargs:
+                merged_kwargs["max_soft_tokens"] = val
+            elif "images_kwargs" in merged_kwargs:
+                if not isinstance(images_kwargs_dict, dict):
+                    images_kwargs_dict = dict(images_kwargs_dict)
+                    merged_kwargs["images_kwargs"] = images_kwargs_dict
+                images_kwargs_dict["max_soft_tokens"] = val
+
+            # Mirror the resolved integer into the user-supplied kwargs.
+            # This propagates to later stages (``_get_prompt_updates``)
+            # that re-merge from ``mm_kwargs`` and would otherwise
+            # re-encounter the sentinel.  Set unconditionally — when
+            # ``"auto"`` was only a server-level default, neither slot
+            # exists in ``mm_kwargs`` yet and we must create one.
+            if isinstance(mm_kwargs, dict):
+                images_k = mm_kwargs.get("images_kwargs")
+                if isinstance(images_k, dict) and "max_soft_tokens" in images_k:
+                    images_k["max_soft_tokens"] = val
+                else:
+                    mm_kwargs["max_soft_tokens"] = val
 
         if val is not None and val not in _SUPPORTED_SOFT_TOKENS:
             raise ValueError(
-                f"Unsupported max_soft_tokens value: {val}. "
-                f"Valid values are {_SUPPORTED_SOFT_TOKENS}."
+                f"Unsupported max_soft_tokens value: {val!r}. "
+                f"Valid values are {_SUPPORTED_SOFT_TOKENS} "
+                f"or the sentinel {_AUTO_SOFT_TOKENS!r}."
             )
 
         mm_data = dict(mm_data)
@@ -736,24 +870,44 @@ class Gemma4MultiModalProcessor(BaseMultiModalProcessor[Gemma4ProcessingInfo]):
             # (boi + N×image_token + eoi, where N = max_soft_tokens).
             image_token = hf_processor.image_token
 
+            # Resolve the effective max_soft_tokens once per request by
+            # merging per-prompt kwargs with config-level defaults,
+            # consistent with how _call_hf_processor resolves it.
+            # Without this merge, a missing per-prompt override would
+            # fall back to vision_cfg.default_output_length instead of
+            # the config's mm_processor_kwargs default.  If ``"auto"``
+            # is still present (e.g., ``_call_hf_processor`` has not
+            # run yet, or this method is invoked standalone), resolve
+            # it here using every image in the request so each image
+            # ends up with the same concrete budget.
+            merged_kwargs = self.info.ctx.get_merged_mm_kwargs(
+                hf_processor_mm_kwargs,
+            )
+            resolved_max_soft_tokens = merged_kwargs.get("max_soft_tokens")
+            if resolved_max_soft_tokens == _AUTO_SOFT_TOKENS:
+                images_items = mm_items.get_items("image", ImageProcessorItems)
+                image_sizes = [
+                    (
+                        images_items.get_image_size(i).width,
+                        images_items.get_image_size(i).height,
+                    )
+                    for i in range(len(images_items))
+                ]
+                vision_cfg = self.info.get_hf_config().vision_config
+                resolved_max_soft_tokens = _resolve_auto_over_images(
+                    image_sizes,
+                    vision_cfg.patch_size,
+                    vision_cfg.pooling_kernel_size,
+                )
+
             def get_replacement_image(item_idx: int):
                 images = mm_items.get_items("image", ImageProcessorItems)
                 image_size = images.get_image_size(item_idx)
-                # Resolve the effective max_soft_tokens by merging
-                # per-prompt kwargs with the config-level defaults,
-                # consistent with how _call_hf_processor resolves it.
-                # Without this merge, a missing per-prompt override
-                # would fall back to vision_cfg.default_output_length
-                # instead of the config's mm_processor_kwargs default.
-                merged_kwargs = self.info.ctx.get_merged_mm_kwargs(
-                    hf_processor_mm_kwargs,
-                )
-                max_soft_tokens = merged_kwargs.get("max_soft_tokens")
                 return self.info.get_image_repl(
                     image_width=image_size.width,
                     image_height=image_size.height,
                     processor=hf_processor,
-                    max_soft_tokens=max_soft_tokens,
+                    max_soft_tokens=resolved_max_soft_tokens,
                 )
 
             prompt_updates.append(


### PR DESCRIPTION
## Purpose

`Gemma4ProcessingInfo` exposes `max_soft_tokens` as a per-request vision token budget with five allowed values `{70, 140, 280, 560, 1120}`. When the server is launched with a single default, every image — from a 100×75 thumbnail to a 4K photo — is processed at that fixed budget. Small images pay the full cost in prompt tokens and latency; large images get aggressively downscaled because the HF image processor resizes to exactly `max_soft_tokens * patch_size**2 * pooling_kernel_size**2` pixels regardless of input.

This PR adds an opt-in `"auto"` sentinel that resolves to the smallest supported budget whose native resize target area covers the image area. The picker reuses the same geometric constants the HF processor's `get_aspect_ratio_preserving_size` uses, so the chosen budget keeps the resize factor at or above `1.0` (no downscale) without wasting tokens on upscaling.

### Behavior

- Numeric values for `max_soft_tokens` behave **exactly as before** — no backward-compat break.
- `"auto"` is strictly opt-in, set either per request via
  ```python
  extra_body={"mm_processor_kwargs": {"max_soft_tokens": "auto"}}
  ```
  or as a server default via
  ```bash
  --mm-processor-kwargs='{"max_soft_tokens": "auto"}'
  ```
- Multi-image requests in a single prompt resolve against the largest image's budget so no image is downscaled.
- Images larger than the largest budget's target area clamp to `1120`, matching today's fixed-budget behavior for oversized inputs.

### Derivation

`transformers/models/gemma4/image_processing_pil_gemma4.py::get_aspect_ratio_preserving_size` resizes by a uniform factor

```
factor = sqrt(target_px / image_px)
target_px = max_soft_tokens * patch_size**2 * pooling_kernel_size**2
```

- `factor >= 1`: upscale or identity, no info loss.
- `factor <  1`: downscale, info loss.

`_pick_auto_soft_tokens` picks the smallest `max_soft_tokens` where `factor >= 1`. This matches the scale-factor math already in `Gemma4ProcessingInfo._compute_num_soft_tokens`, so the resolved budget is consistent between the KV-reservation path and the HF processor invocation.

## Test Plan

Added `tests/models/multimodal/processing/test_gemma4_auto_budget.py` covering:

- **Square-image boundary cases** at each bucket transition (`401` / `402`, `803` / `804`, `1135` / `1136`, `1606` / `1607`).
- **Common aspect ratios** from thumbnail through 4K (`100x75`, `640x480`, `800x600`, `1024x768`, `1280x720`, `1920x1080`, `3840x2160`, `4032x3024`).
- **Monotonicity** — picker is non-decreasing in image area (sanity check).
- **Clamp behavior** for images larger than the largest bucket's target area.
- **Tiny image** (`1x1`) picks the smallest bucket.
- **Config-agnostic derivation** — runs the picker under non-default `patch_size` / `pooling_kernel_size` to confirm the formula is not hardcoded to `2304`.

Run the suite with:

```bash
pytest tests/models/multimodal/processing/test_gemma4_auto_budget.py
```

End-to-end smoke tested against `google/gemma-4-31B-it` on an A6000 × 2 server (TP=2) with `--mm-processor-kwargs='{"max_soft_tokens": 1120}'` as the prior default. No regressions on existing numeric values; `"auto"` resolves as predicted.

## Test Result

Prompt tokens per request (usage field in the chat completion response), Gemma 4 31B IT, default Gemma 4 server config except for `max_soft_tokens`:

| image          | area      | auto budget | auto tokens | fixed=1120 tokens |
|----------------|-----------|-------------|-------------|-------------------|
| 100×75         | 7,500     | 70          | 81          | 1,082             |
| 400×300        | 120,000   | 70          | 82          | 1,107             |
| 800×600        | 480,000   | 280         | 284         | 1,082             |
| 1024×768       | 786,432   | 560         | 558         | 1,082             |
| 1600×1200      | 1,920,000 | 1120        | 1,082       | 1,082             |
| 3840×2160 (4K) | 8,294,400 | 1120 clamp  | 1,118       | 1,118             |

Thumbnail-sized images drop ~93 % of vision prompt tokens; Full-HD and larger images are unchanged.

---

## Real-image comparison: fixed budgets vs. `auto`

To complement the synthetic benchmark, I ran five diverse real images through the server three times each — at `max_soft_tokens=280` (the original default), `max_soft_tokens=1120` (the largest fixed budget), and the new `"auto"` sentinel. Same prompt in every call:

> *Describe what you see in this image. If there is any text, read it out as precisely as you can. Note numbers or details that might be small in the image.*

### Token-count summary

| Image | Dimensions | Area (px) | `fixed=280` | `fixed=1120` | `auto` |
|---|---|---|---|---|---|
| Picsum.photos id=1 (small) | 400×300 | 120,000 | 318 | 1116 | **115** (bucket 70) |
| Picsum.photos id=1015 (medium scene) | 800×600 | 480,000 | 318 | 1116 | **318** (bucket 280) |
| Picsum.photos id=1018 (large landscape) | 1600×1067 | 1,707,200 | 312 | 1132 | **1132** (bucket 1120) |
| Mona Lisa (Wikimedia Commons, PD) | 1024×1549 | 1,586,176 | 312 | 1159 | **1159** (bucket 1120) |
| Synthetic OCR document (generated) | 1600×900 | 1,440,000 | 316 | 1152 | **1152** (bucket 1120) |

Observed behavior matches the derivation: `auto` picks the smallest bucket whose target area (`bucket × 2304 px`) covers the image area. A 400×300 thumbnail now uses the 70-bucket (~115 prompt tokens) instead of paying 1,116 tokens at `fixed=1120`; a 1600×1067 landscape stays at the 1120-bucket because anything smaller would downscale it.

### Per-image descriptions

#### Picsum.photos id=1 (small) (400×300, thumbnail)

<a href="https://github.com/developer0hye/vllm/raw/pr-40599-images/assets/small_400x300.jpg"><img src="https://github.com/developer0hye/vllm/raw/pr-40599-images/assets/small_400x300.jpg" alt="small_400x300.jpg" width="360"></a>

**`max_soft_tokens=280`** — 318 prompt tokens, 110 completion tokens

A man is shown from behind and to the side, sitting at a light-colored wooden table outdoors. He is wearing a grey long-sleeved shirt and a watch on his left wrist. He is typing on a silver laptop with a black screen. 

To the left of the laptop on the table is a dark blue smartphone and a small black notebook with a pen lying on top of it. To the right of the laptop is a small white cup and saucer. The background is blurred, showing hints of greenery and a dark surface.

**`max_soft_tokens=1120`** — 1116 prompt tokens, 108 completion tokens

An over-the-shoulder shot shows a person sitting at a light-colored wooden outdoor table, typing on a silver laptop with a black screen. The person is wearing a dark grey long-sleeved shirt and a silver wristwatch on their left wrist.

On the table to the left of the laptop are a dark grey smartphone and a small black notebook with a pen lying across the top of it. To the right of the laptop is a white espresso cup and saucer. The background is blurred, showing a dark, outdoor area.

**`max_soft_tokens=auto`** — 115 prompt tokens, 93 completion tokens

A person is seen from behind, sitting at a light-colored wooden table. They are using a silver laptop, with their hands positioned on the keyboard. To the left of the laptop on the table, there is a smartphone and a small black notebook or wallet. In the background, slightly out of focus, there appears to be a white cup or container. The person is wearing a dark gray long-sleeved shirt and a watch on their left wrist.

---

#### Picsum.photos id=1015 (medium scene) (800×600, medium photo)

<a href="https://github.com/developer0hye/vllm/raw/pr-40599-images/assets/street_800x600.jpg"><img src="https://github.com/developer0hye/vllm/raw/pr-40599-images/assets/street_800x600.jpg" alt="street_800x600.jpg" width="360"></a>

**`max_soft_tokens=280`** — 318 prompt tokens, 175 completion tokens

This image is a wide, high-angle panoramic shot of a deep blue fjord surrounded by steep, rocky mountains under a bright blue sky with scattered white clouds.

In the foreground, there is a massive, flat-topped grey granite cliff overlooking the water. A group of approximately 20 to 30 small figures of people can be seen standing and sitting on the plateau of the cliff, illustrating the scale of the landscape. The rock surface is light grey with patches of green and orange moss or low-lying vegetation.

The fjord is a vibrant, deep blue color and winds its way through the valley, disappearing into the distance. The surrounding mountains are rugged, primarily grey rock with scattered patches of green vegetation. The lighting is bright, suggesting a clear day, with soft shadows falling across the mountain slopes. There is no visible text in the image.

**`max_soft_tokens=1120`** — 1116 prompt tokens, 117 completion tokens

A high-angle, wide landscape shot shows a massive, sheer cliff overlooking a deep blue fjord that winds between steep, rocky mountains under a blue sky with wispy clouds. 

On the flat top of the cliff in the foreground, a large group of small people are gathered, some standing near the edge. The cliff face is light grey with vertical streaks and textures. The surrounding mountains are rugged and grey, with patches of green vegetation. The water of the fjord is a vibrant, deep blue, reflecting the sky. 

There is no visible text in the image.

**`max_soft_tokens=auto`** — 318 prompt tokens, 136 completion tokens

A high-angle, wide shot shows a deep blue fjord cutting through a rugged, mountainous landscape under a bright blue sky with scattered white clouds. In the foreground, a large, light-gray rocky plateau with patches of green and brown vegetation is visible. Numerous small figures of people are scattered across this plateau, some standing near the steep edge overlooking the water. The terrain consists of undulating, rocky mountains with visible striations and crevices, stretching into the distance. The water of the fjord is a vibrant blue, reflecting the sky, and it winds between the steep cliffs. The lighting is bright and natural, suggesting a clear day. There is no text visible in the image.

---

#### Picsum.photos id=1018 (large landscape) (1600×1067, large photo)

<a href="https://github.com/developer0hye/vllm/raw/pr-40599-images/assets/landscape_1600x1067.jpg"><img src="https://github.com/developer0hye/vllm/raw/pr-40599-images/assets/landscape_1600x1067.jpg" alt="landscape_1600x1067.jpg" width="360"></a>

**`max_soft_tokens=280`** — 312 prompt tokens, 78 completion tokens

A wide-angle, eye-level shot of green, grassy mountains under a cloudy sky. A road curves along the base of a mountain in the lower center. In the foreground, dark gray, rocky cliffs are on the right. The mountains are a deep green, and the sky is a pale gray. The light is soft and diffuse, casting a gentle glow over the landscape.

**`max_soft_tokens=1120`** — 1132 prompt tokens, 157 completion tokens

A landscape photograph under an overcast sky shows a winding paved road cutting through rolling green hills and rocky cliffs. In the foreground, a gray asphalt road curves from the bottom left, winds toward the center, and leads into the distance toward the right. A silver metal guardrail borders the right side of the road as it curves. To the right of the road, there is a steep, dark, rocky cliff face partially covered in patches of grass. In the midground and background, several high, steep hills covered in vibrant green grass rise up, with some rocky outcrops visible. The furthest peaks are shrouded in a light gray fog or low-hanging clouds. The sky is a uniform, pale gray, blending into the mist over the mountains. No text is visible in the image.

**`max_soft_tokens=auto`** — 1132 prompt tokens, 152 completion tokens

A wide landscape photograph showcases a series of rolling, green hills and steep rock formations under a cloudy, overcast sky. 

In the foreground and mid-ground, a narrow, winding asphalt road curves through the lush green terrain. A metal guardrail follows the outer edge of the road's curve. To the right, a large, dark grey rocky outcrop rises sharply, contrasted by the vibrant green grass covering the slopes around it.

In the background, more peaks and ridges extend into the distance. The farthest peak is partially obscured by low-hanging white clouds and fog, giving the scene a misty, atmospheric quality. To the left, the land opens up into a flatter, hazy valley. There is no text or visible signage in the image.

---

#### Mona Lisa (Wikimedia Commons, PD) (1024×1549, artwork)

<a href="https://github.com/developer0hye/vllm/raw/pr-40599-images/assets/monalisa.jpg"><img src="https://github.com/developer0hye/vllm/raw/pr-40599-images/assets/monalisa.jpg" alt="monalisa.jpg" width="360"></a>

**`max_soft_tokens=280`** — 312 prompt tokens, 266 completion tokens

This image is a reproduction of the famous portrait known as the *Mona Lisa*, painted by Leonardo da Vinci.

**Subject and Composition:**
The painting depicts a woman from the waist up, seated in a three-quarter pose. She is facing the viewer with a slight, enigmatic smile. Her expression is calm and mysterious. She has long, dark, wavy hair that falls over her shoulders and is wearing a dark, draped garment with subtle folds. Her hands are crossed in the foreground, with her right hand resting gently on top of her left.

**Background:**
Behind the subject is an atmospheric, imagined landscape. It features winding paths, a bridge to the right, and jagged, misty mountains and river valleys that fade into a pale, greenish-blue horizon. The technique used creates a soft, blurred effect (sfumato), blending the subject into the background.

**Color and Texture:**
The color palette is dominated by earthy tones, including deep browns, greens, and ochres. The lighting is soft, illuminating her face and chest while the rest of her figure blends into deeper shadows. The image shows a visible craquelure (a network of fine cracks) across the surface of the paint, indicating the age of the original work.

There is no text present in the image.

**`max_soft_tokens=1120`** — 1159 prompt tokens, 321 completion tokens

This is the famous painting known as the *Mona Lisa*, created by Leonardo da Vinci.

**Subject and Composition:**
The image is a half-length portrait of a woman sitting in a chair, facing forward but with her body slightly turned to the side. She has a mysterious, subtle smile and a calm gaze directed toward the viewer. She has long, dark, wavy hair and is wearing a dark-colored dress with a pleated neckline. A thin, dark veil covers her hair. Her hands are crossed in the foreground, with her right hand resting gently on her left wrist.

**Background:**
Behind the subject is a vast, dreamlike landscape. It features winding paths, a bridge, distant mountains, and a body of water. The colors of the background transition from earthy greens and browns in the mid-ground to a hazy, pale blue-grey in the distance, utilizing a technique known as atmospheric perspective.

**Details and Texture:**
*   **Craquelure:** Upon close inspection, there is a visible network of fine cracks (craquelure) across the entire surface of the paint, particularly noticeable on her face and chest, which is characteristic of aged oil paintings on a wooden panel.
*   **Lighting:** The light is soft and diffused, creating a gentle transition between light and shadow (sfumato) on her skin, especially around the corners of her eyes and mouth.
*   **Clothing:** There is a fine, embroidered detail along the top edge of her dress.

There is no text or numbers present in the image.

**`max_soft_tokens=auto`** — 1159 prompt tokens, 220 completion tokens

This image is the world-famous painting, the *Mona Lisa*, by Leonardo da Vinci.

It is a half-length portrait of a woman seated in a chair. She is facing the viewer with a slight, enigmatic smile and her gaze directed forward. She has long, dark wavy hair and wears a dark-colored dress with a low-cut neckline and a sheer veil over her head. Her hands are crossed in her lap, with her right hand resting on top of her left.

The background consists of a distant, atmospheric landscape featuring winding paths, a bridge, and rugged mountains under a pale, hazy sky. The overall color palette is dominated by muted earth tones, greens, and yellows, with a characteristic "sfumato" technique (soft blending of tones) creating a smoky effect, particularly around the corners of her eyes and mouth.

A prominent detail throughout the image is the "craquelure"—a fine network of cracks across the surface of the paint, which is a sign of the painting's age. There is no text visible in the image.

---

#### Synthetic OCR document (generated) (1600×900, OCR with small text)

<a href="https://github.com/developer0hye/vllm/raw/pr-40599-images/assets/document_1600x900.png"><img src="https://github.com/developer0hye/vllm/raw/pr-40599-images/assets/document_1600x900.png" alt="document_1600x900.png" width="360"></a>

**`max_soft_tokens=280`** — 316 prompt tokens, 281 completion tokens

This is a "Quarterly Revenue Report Q3 2026" for the "Asia-Pacific" region, covering the fiscal period of "Jul-Sep 2026."

The report contains a table with five products and their corresponding revenue, percentage change, and status:

*   **Product A:** USD 3,421,088 | +12.4% | Exceeded target
*   **Product B:** USD 1,904,220 | -3.1% | Behind target
*   **Product C:** USD 892,115 | +0.8% | On track
*   **Product D:** USD 5,127,600 | +18.7% | Major expansion YoY
*   **Product E:** USD 246,003 | -11.2% | Deprecation plan

At the bottom of the image, there is small text:
*   **Fine print:** Figures audited by External Partners Ltd. Contact: finance-ops+q3@example.com Doc-ID: FY2026-Q3-APAC-REV-0047
*   **Small detail:** row total excludes inter-company transfers; see footnote 3 in the appendix.

**`max_soft_tokens=1120`** — 1152 prompt tokens, 306 completion tokens

This is a financial report titled **"Quarterly Revenue Report Q3 2026"**.

**Header Information:**
*   **Region:** Asia-Pacific
*   **Fiscal Period:** Jul-Sep 2026

**Revenue Table:**
| Product | Revenue | Change | Status/Note |
| :--- | :--- | :--- | :--- |
| Product A | USD 3,421,088 | +12.4% (green) | Exceeded target |
| Product B | USD 1,904,220 | -3.1% (red) | Behind target |
| Product C | USD 892,115 | +0.8% (green) | On track |
| Product D | USD 5,127,600 | +18.7% (green) | Major expansion YoY |
| Product E | USD 246,003 | -11.2% (red) | Deprecation plan |

**Footer/Fine Print:**
*   **Fine print:** Figures audited by External Partners Ltd. Contact: finance-ops+q3@example.com Doc-ID: FY2026-Q3-APAC-REV-0047
*   **Small detail:** row total excludes inter-company transfers; see footnote 3 in the appendix.

**`max_soft_tokens=auto`** — 1152 prompt tokens, 344 completion tokens

This image is a business document titled **"Quarterly Revenue Report Q3 2026"**. 

Below the title, it lists the following details:
*   **Region:** Asia-Pacific
*   **Fiscal Period:** Jul-Sep 2026

The main body of the report consists of a table with four columns (Product, Revenue in USD, Percentage Change, and Status):

| Product | Revenue | Change | Status |
| :--- | :--- | :--- | :--- |
| Product A | USD 3,421,088 | +12.4% (Green) | Exceeded target |
| Product B | USD 1,904,220 | -3.1% (Red) | Behind target |
| Product C | USD 892,115 | +0.8% (Green) | On track |
| Product D | USD 5,127,600 | +18.7% (Green) | Major expansion YoY |
| Product E | USD 246,003 | -11.2% (Red) | Deprecation plan |

At the bottom of the image, there is fine print in a small font:
*   **Fine print:** Figures audited by External Partners Ltd. Contact: finance-ops+q3@example.com Doc-ID: FY2026-Q3-APAC-REV-0047
*   **Small detail:** row total excludes inter-company transfers; see footnote 3 in the appendix.

---

### Dense OCR stress test — where fixed=280 actually breaks

The synthetic document earlier is easy enough that `fixed=280` reads it well. This second OCR sample is deliberately hard: a 2000×1400 image with a 25-row inventory table in 11 px type plus three 10 px notice lines and a pair of 8 px footer strings. Same prompt: *"read every visible row of the table ... and transcribe the fine-print notices below it word-for-word. Do not summarize or paraphrase."*

<a href="https://github.com/developer0hye/vllm/raw/pr-40599-images/assets/ocr_dense_2000x1400.png"><img src="https://github.com/developer0hye/vllm/raw/pr-40599-images/assets/ocr_dense_2000x1400.png" alt="dense OCR table" width="480"></a>

**Token counts**

| budget | prompt tokens | completion tokens |
|---|---|---|
| `280` | 350 | 2000 |
| `1120` | 1190 | 2000 |
| `auto` | 1190 | 2000 |

Area is 2,800,000 px, above the 1120-bucket target area (2,580,480 px), so `auto` clamps to 1120 — identical prompt-token cost to `fixed=1120` for this image.

**First five rows — response vs. ground truth**

| # | Ground-truth description | `fixed=280` reads | `fixed=1120` | `auto` |
|---|---|---|---|---|
| 1 | `Cable gland PG9 nickel-plated` | **❌ `Cable pylon gold nickel-plated`** | ✅ | ✅ |
| 2 | `Lithium grease LGHP2 400g` | **❌ `Lithium grease LGHZ 400g`** | ✅ | ✅ |
| 3 | `Hex bolt M8 x 30mm A2-70` | **❌ `Hex bolt M 8x30mm A2-70`** | ✅ | ✅ |
| 4 | `Proximity sensor NPN NO 12mm` | ✅ | ✅ | ✅ |
| 5 | `O-ring seal 14mm EPDM` | **❌ `O-ring 10x2x1.5 NBR`** | ✅ | ✅ |

At `fixed=280`, row 1 invents a non-existent product name ("Cable pylon gold"), row 2 misreads `LGHP2` as `LGHZ`, and row 5 entirely substitutes a different part ("O-ring 10x2x1.5 NBR") — the small type gets blurred out by the downscale, so the model fills in plausible-looking strings. Over the full 24-row output this is not an isolated glitch: 20 of 24 descriptions at `fixed=280` fall outside the image's 10-item catalog, while `fixed=1120` reads 23/24 correctly. `auto` behaves identically to `fixed=1120` here — it picked the same bucket because the image is too large for any smaller one.

**Full transcripts (temperature=1.0, default)**

<br><b><code>max_soft_tokens=280</code></b> — 350 prompt tokens, 2000 completion tokens

| SKU | Description | Qty | Unit USD | Batch | Mfg Date | Expiry | Serial |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| K19-7311-Y | Cable pylon gold nickel-plated | 664 | 5.26 | B7013 | 2024-04-13 | 2025-05-16 | 741897349755 |
| K19-4570-B | Lithium grease LGHZ 400g | 4618 | 2.98 | B22429 | 2024-10-26 | 2025-05-18 | 8773515144757 |
| K19-8501-X | Hex bolt M 8x30mm A2-70 | 1209 | 1.19 | B90651 | 2024-05-14 | 2026-06-04 | 576838605591208 |
| K19-6180-F | Proximity sensor NPN NO 12mm | 9053 | 9.60 | B78334 | 2024-05-02 | 2029-05-01 | 8906547582076 |
| K19-1015-D | O-ring 10x2x1.5 NBR | 8087 | 0.58 | B89737 | 2024-05-21 | 2027-05-20 | 1739465121210 |
| K19-4130-S | Proximity sensor NPN NO 12mm | 3910 | 16.08 | B28677 | 2024-09-15 | 2029-02-03 | 4521580250866 |
| K19-8501-Y | Hex bolt M 8x30mm A2-70 | 4979 | 1.19 | B12131 | 2024-03-24 | 2026-03-21 | 38631298343512 |
| K19-9965-S | Compression spring 1.2x30mm | 7201 | 1.94 | B80499 | 2024-06-19 | 2029-04-10 | 306841804372 |
| K19-3059-B | Wire ferrule 0.75mm2 white | 4215 | 9.59 | B1773-11 | 2024-05-25 | 2029-03-05 | 1426059383916 |
| K19-7871-S | Compression spring 1.2x30mm | 6411 | 16.77 | B79750 | 2024-06-18 | 2027-06-18 | 741859348158 |
| K19-7871-X | Compression spring 1.2x30mm | 7385 | 9.91 | B90402 | 2024-12-26 | 2029-06-03 | 771408786773 |
| K19-7095-Z | Cable pylon gold nickel-plated | 5484 | 13.81 | B14140 | 2024-04-14 | 2028-04-14 | 3435144751210 |
| K19-7095-Y | Lithium grease LGHZ 400g | 5449 | 8.59 | B31851 | 2024-02-26 | 2028-02-28 | 3495144415614 |
| K19-2861-M | Hex bolt M 8x30mm A2-70 | 1015 | 1.19 | B88555 | 2024-04-01 | 2029-01-07 | 734865112511 |
| K19-2164-H | Hex bolt M 8x30mm A2-70 | 9686 | 16.69 | B25210 | 2024-04-01-17 | 2029-08-02 | 88733439584 |
| K19-2164-Y | Hex bolt M 8x30mm A2-70 | 1015 | 1.19 | B33834 | 2024-04-01-17 | 2029-08-02 | 3085062055168 |
| K19-3552-F | Threaded insert M6 brs | 4933 | 7.08 | B33834 | 2024-04-01-17 | 2029-08-02 | 209930605644 |
| K19-3552-P | Threaded insert M6 brs | 5879 | 18.39 | B10561 | 2024-03-10 | 2029-12-12 | 1634051309358 |
| K19-7753-S | Control relay 24VDC 1NO/1NC | 8675 | 5.10 | B88222 | 2024-08-22 | 2029-03-01 | 8439993523789 |
| K19-7753-X | Control relay 24VDC 1NO/1NC | 1125 | 13.10 | B11110 | 2024-05-04 | 2029-12-12 | 1103478605399 |
| K19-4770-T | Compression spring 1.2x30mm | 5504 | 14.80 | B81345 | 2024-05-05 | 2024-05-25 | 632374638759 |
| K19-4770-Y | Compression spring 1.2x30mm | 5886 | 11.85 | B93066 | 2024-05-05 | 2024-05-25 | 922005274871 |
| K19-7879-Z | Hex bolt M 8x30mm A2-70 | 25 | 13.13 | B93066 | 2024-03-09-08 | 2029-12-10 | 5141802005751 |
| K19-7789-S | Cable pylon gold nickel-plated | 1095 | 13.13 |

---

<br><b><code>max_soft_tokens=1120</code></b> — 1190 prompt tokens, 2000 completion tokens

| SKU | Description | Qty | Unit USD | Batch | Mfg Date | Expiry | Serial |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| K19-7311-Y | Cable gland PG9 nickel-plated | 664 | 5.26 | B77013 | 2024-08-13 | 2029-05-16 | 741487937455 |
| K19-4578-Q | Lithium grease LGHP2 400g | 4618 | 2.90 | B22429 | 2024-10-26 | 2029-05-18 | 877315144757 |
| K19-3407-J | Hex bolt M8 x 30mm A2-70 | 1209 | 17.98 | B99651 | 2024-06-16 | 2029-09-04 | 578260892039 |
| K19-6180-T | Proximity sensor NPN NO 12mm | 9053 | 9.60 | B78334 | 2024-05-02 | 2029-09-01 | 890674582076 |
| K19-7534-W | O-ring seal 14mm EPDM | 8087 | 16.57 | B53664 | 2024-04-24 | 2029-06-23 | 172458122216 |
| K19-4130-S | Proximity sensor NPN NO 12mm | 3910 | 16.08 | B28677 | 2024-09-15 | 2029-02-03 | 452158205086 |
| K19-9322-P | Hex bolt M8 x 30mm A2-70 | 4939 | 11.07 | B26359 | 2024-09-11 | 2029-09-07 | 980312983410 |
| K19-9965-S | Compression spring 1.2x8x30mm | 7291 | 1.94 | B60449 | 2024-06-19 | 2029-04-10 | 306948140372 |
| K19-4059-B | Wire ferrule 0.75mm2 white | 4261 | 9.59 | B21773 | 2024-11-25 | 2029-03-05 | 142620596936 |
| K19-2314-W | Control relay 24VDC 5A SPDT | 6411 | 16.77 | B78756 | 2024-05-17 | 2029-04-28 | 747163414534 |
| K19-7871-S | Compression spring 1.2x8x30mm | 7383 | 9.91 | B90402 | 2024-12-26 | 2029-06-03 | 771407862773 |
| K19-2889-P | Wire ferrule 0.75mm2 white | 5494 | 16.91 | B41855 | 2024-01-24 | 2029-05-04 | 343547551240 |
| K19-7095-Z | Lithium grease LGHP2 400g | 5449 | 8.59 | B18151 | 2024-02-26 | 2029-03-28 | 343514641158 |
| K19-1741-S | Control relay 24VDC 5A SPDT | 9866 | 13.64 | B13499 | 2024-02-21 | 2029-04-20 | 734925385311 |
| K19-2961-M | Hex bolt M8 x 30mm A2-70 | 6065 | 16.69 | B25210 | 2024-01-20 | 2029-01-07 | 886773463594 |
| K19-3029-P | Proximity sensor NPN NO 12mm | 1001 | 18.74 | B12986 | 2024-09-14 | 2029-10-04 | 387058016106 |
| K19-2146-H | Hex bolt M8 x 30mm A2-70 | 4933 | 7.08 | B33634 | 2024-01-17 | 2029-08-02 | 209936065646 |
| K19-7410-G | Compression spring 1.2x8x30mm | 5875 | 18.09 | B71632 | 2024-10-06 | 2029-12-22 | 163425278183 |
| K19-3592-F | Threaded insert M6 brass | 8675 | 5.10 | B88222 | 2024-08-22 | 2029-03-01 | 849349925237 |
| K19-7715-S | Control relay 24VDC 5A SPDT | 5103 | 13.01 | B609040 | 2024-11-09 | 2029-03-18 | 115851963050 |
| K19-8503-X | Hex bolt M8 x 30mm A2-70 | 5504 | 14.80 | B81345 | 2024-05-05 | 2029-04-25 | 632374636759 |
| K19-6770-T | Compression spring 1.2x8x30mm | 5886 | 11.85 | B93066 | 2024-10-05 | 2029-12-10 | 922005274871 |
| K19-7789-U | Hex bolt M8 x 30mm A2-70 | 25 | 11.93 | B53830 | 2024-03-08 | 2029-04-21 | 514241587001 |
| K19-7789-B | Cable gland PG9 nickel-plated | 9298 | 8.43 | B96795 | 2024

---

<br><b><code>max_soft_tokens=auto</code></b> — 1190 prompt tokens, 2000 completion tokens

| SKU | Description | Qty | Unit USD | Batch | Mfg Date | Expiry | Serial |
| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
| K19-7311-Y | Cable gland PG9 nickel-plated | 664 | 5.26 | B77013 | 2024-08-13 | 2029-05-16 | 741487937455 |
| K19-4578-Q | Lithium grease LGHP2 400g | 4618 | 2.90 | B22429 | 2024-10-26 | 2029-05-18 | 877315144757 |
| K19-3407-J | Hex bolt M8 x 30mm A2-70 | 1209 | 17.98 | B99651 | 2024-06-16 | 2029-09-04 | 578260892039 |
| K19-6180-T | Proximity sensor NPN NO 12 mm | 9053 | 9.60 | B78334 | 2024-05-02 | 2029-09-01 | 890674582076 |
| K19-7534-W | O-ring seal 14mm EPDM | 8087 | 16.57 | B53664 | 2024-04-24 | 2029-06-23 | 172458122216 |
| K19-4130-S | Proximity sensor NPN NO 12 mm | 3910 | 16.08 | B28677 | 2024-09-15 | 2029-02-03 | 452158205086 |
| K19-9322-P | Hex bolt M8 x 30mm A2-70 | 4939 | 11.07 | B26359 | 2024-09-11 | 2029-09-07 | 980312983410 |
| K19-9965-S | Compression spring 1.2x8x30mm | 7291 | 1.94 | B60449 | 2024-06-19 | 2029-04-10 | 306948140372 |
| K19-4059-B | Wire ferrule 0.75mm2 white | 4261 | 9.59 | B21773 | 2024-11-25 | 2029-03-05 | 142620596936 |
| K19-2314-W | Control relay 24VDC 5A SPDT | 6411 | 16.77 | B78756 | 2024-05-17 | 2029-04-28 | 747163414534 |
| K19-7871-S | Compression spring 1.2x8x30mm | 7383 | 9.91 | B90442 | 2024-12-26 | 2029-06-03 | 771407862773 |
| K19-2889-P | Wire ferrule 0.75mm2 white | 5494 | 16.91 | B41855 | 2024-01-24 | 2029-05-04 | 343547551240 |
| K19-7095-Z | Lithium grease LGHP2 400g | 5449 | 8.59 | B18151 | 2024-02-26 | 2029-03-28 | 343514641158 |
| K19-1741-S | Control relay 24VDC 5A SPDT | 9866 | 13.64 | B13499 | 2024-02-21 | 2029-04-20 | 734925385311 |
| K19-2961-M | Hex bolt M8 x 30mm A2-70 | 6065 | 16.69 | B25210 | 2024-01-20 | 2029-01-07 | 886773463594 |
| K19-3029-P | Proximity sensor NPN NO 12 mm | 1001 | 18.74 | B12986 | 2024-09-14 | 2029-10-04 | 387058016106 |
| K19-2146-H | Hex bolt M8 x 30mm A2-70 | 4933 | 7.08 | B33634 | 2024-01-17 | 2029-08-02 | 209936065646 |
| K19-7410-G | Compression spring 1.2x8x30mm | 5875 | 18.09 | B71632 | 2024-10-06 | 2029-12-22 | 163425278183 |
| K19-3592-F | Threaded insert M6 brass | 8675 | 5.10 | B88222 | 2024-08-22 | 2029-03-01 | 849349925237 |
| K19-7715-S | Control relay 24VDC 5A SPDT | 5103 | 13.01 | B609040 | 2024-11-09 | 2029-03-18 | 115851963050 |
| K19-8503-X | Hex bolt M8 x 30mm A2-70 | 5504 | 14.80 | B81345 | 2024-05-05 | 2029-04-25 | 632374636759 |
| K19-6770-T | Compression spring 1.2x8x30mm | 5886 | 11.85 | B93066 | 2024-10-05 | 2029-12-10 | 922005274871 |
| K19-7789-U | Hex bolt M8 x 30mm A2-70 | 25 | 11.93 | B53830 | 2024-03-08 | 2029-04-21 | 514241587001 |
| K19-7789-B | Cable gland PG9 nickel-plated | 9298 | 8.43 | B96795 | 2024

---

### Takeaways

- **Small image (400×300)**: `auto` drops 89% of the vision-prompt-token cost (1116 → 115) while keeping the description accurate to the same objects (laptop, smartphone, notebook, cup).
- **Medium image (800×600)**: `auto` lands at `fixed=280` tokens with descriptive parity to the 1120-token run — no regression for common photo sizes.
- **Large images (≥ 1600 px on one side)**: `auto` collapses to `fixed=1120` exactly, preserving today's behavior for the detail-heavy inputs that actually benefit from the largest budget.
- **Dense text / OCR**: `auto` picks 1120 for the 1600×900 document and reproduces the entire table, both fine-print rows, the email, and the Doc-ID string. `fixed=280` reads the table correctly but is forced to truncate the fine-print at the response's `max_tokens` limit.



---

## Multi-Image Cache Coherence (c3da023)

Follow-up that addresses @Isotr0py's cache concern. Verifies that the same image submitted alone vs. batched with a larger image produces distinct cache entries and correct token counts in both directions.

### Evidence

Live Gemma-4-31B-it deployment on A6000×2 (TP=2) with `--mm-processor-kwargs='{"max_soft_tokens":"auto"}'`. Synthetic test images: a yellow circle inside a red rectangle on a blue background at three resolutions. Requests were greedy (`temperature=0.0`).

The exact PNGs used (shown at roughly proportional widths — native sizes are 100×75, 800×600, 1920×1080):

<p align="center">
  <img alt="100×75" src="https://raw.githubusercontent.com/developer0hye/vllm/pr-40599-assets/multi-image-cache-coherence/100x75.png" width="90">
  &nbsp;&nbsp;
  <img alt="800×600" src="https://raw.githubusercontent.com/developer0hye/vllm/pr-40599-assets/multi-image-cache-coherence/800x600.png" width="180">
  &nbsp;&nbsp;
  <img alt="1920×1080" src="https://raw.githubusercontent.com/developer0hye/vllm/pr-40599-assets/multi-image-cache-coherence/1920x1080.png" width="270">
</p>

| request | `prompt_tokens` | picked budget | generated caption |
|---|---|---|---|
| 100×75 alone (1st) | 87 | 70 | *"A yellow circle is centered within a red rectangle, which is set against a blue background."* |
| 800×600 alone | 290 | 280 | *"A yellow oval is centered within a red rectangle, which is centered on a blue background."* |
| 1920×1080 alone | 1124 | 1120 | *"A yellow oval is centered within a red rectangle, which is centered on a blue background."* |
| [100×75, 1920×1080] batched | 2192 | 1120 (shared) | *"Both images feature a yellow oval inside a red rectangle on a blue background, but the first image is pixelated while the second image has smooth edges."* |
| 100×75 alone (2nd, **after** the batched request) | 87 (not 1124) | 70 | *"A yellow circle is centered within a red rectangle, which is set against a blue background."* |

### Takeaways

- **Budget selection is context-aware.** Alone → 70; batched with a large image → 1120. Gemma 4's uniform-per-request budget invariant is preserved.
- **No stale cache reuse.** The last row is the regression check: after the batched request ran the 100×75 input through budget 1120, a subsequent alone request resolves it back to budget 70 — the two contexts hash to different cache entries. This was the cache-poisoning failure mode @Isotr0py flagged; c3da023 closes it at the canonicalization layer (see the commit body).
- **Multi-image quality reflects the shared budget.** The batched caption distinguishes "pixelated" (the 100×75 upscaled to 1120) from "smooth edges" (the native 1920×1080), confirming the vision tower actually processed both images at the shared 1120 budget rather than reusing any earlier 70-token tensor for the small one.

