### PR TITLE
[WIP] Support ViT full CUDA graph for Kimi K2.5

### DIFF
--- a/tests/v1/cudagraph/test_encoder_cudagraph_kimi_k25.py
+++ b/tests/v1/cudagraph/test_encoder_cudagraph_kimi_k25.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Lightweight correctness tests for Kimi K2.5-VL encoder CUDA graph pieces.
+
+These tests exercise the two rewrites that make the Kimi-K2.5 vision tower
+capturable:
+
+* ``tpool_patch_merger_indexed`` — a static-shape variant of
+  ``tpool_patch_merger`` that consumes precomputed index buffers instead
+  of iterating over a Python list of per-item grids.
+* ``MoonViT3dPretrainedModel.prepare_encoder_metadata`` — feeds the
+  encoder / merger with those buffers.
+
+Both tests run on CPU; actual CUDA graph capture/replay is covered by the
+generic tests in ``test_encoder_cudagraph.py`` and by manual server-level
+validation noted in the plan.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+import torch
+
+from vllm.model_executor.models.kimi_k25_vit import (
+    _build_tpool_indices,
+    tpool_patch_merger,
+    tpool_patch_merger_indexed,
+)
+
+
+def _random_patches(
+    grid_thw_list: list[tuple[int, int, int]],
+    hidden: int,
+    seed: int = 0,
+) -> torch.Tensor:
+    torch.manual_seed(seed)
+    n = sum(t * h * w for t, h, w in grid_thw_list)
+    return torch.randn(n, hidden, dtype=torch.float32)
+
+
+@pytest.mark.parametrize(
+    "grid_thw_list",
+    [
+        # single image
+        [(1, 4, 4)],
+        # two images of different sizes
+        [(1, 4, 4), (1, 6, 8)],
+        # video chunk (t > 1) + image
+        [(4, 4, 4), (1, 2, 2)],
+        # multiple video chunks
+        [(4, 4, 6), (4, 6, 4)],
+    ],
+)
+def test_indexed_tpool_matches_eager(grid_thw_list):
+    """The indexed implementation must match the eager per-item loop bit-for-bit
+    (up to float rounding) when no padding is involved.
+
+    Slot 0 of the indexed output is the reserved dead slot; real output
+    slots live at indices 1..max_output_slots.
+    """
+    kh, kw = 2, 2
+    hidden = 8
+    x = _random_patches(grid_thw_list, hidden)
+
+    # Eager reference.
+    grid_thws_tensor = torch.tensor(grid_thw_list, dtype=torch.int32)
+    eager_list = tpool_patch_merger(x, grid_thws_tensor, merge_kernel_size=(kh, kw))
+    eager_packed = torch.cat(eager_list, dim=0)  # (sum(nh*nw), kh*kw, hidden)
+
+    # Indexed implementation with tight buffer sizes (no padding).
+    total_input_patches = sum(t * h * w for t, h, w in grid_thw_list)
+    total_post_tpool = sum(h * w for t, h, w in grid_thw_list)
+    total_output_slots = sum((h // kh) * (w // kw) for t, h, w in grid_thw_list)
+    (
+        temporal_gather_idx_np,
+        temporal_divisor_np,
+        spatial_gather_idx_np,
+    ) = _build_tpool_indices(
+        grid_thw_list,
+        kh=kh,
+        kw=kw,
+        max_total_patches=total_input_patches,
+        max_post_tpool_patches=total_post_tpool,
+        max_output_slots=total_output_slots,
+    )
+    metadata = {
+        "tpool_temporal_gather_idx": torch.from_numpy(temporal_gather_idx_np),
+        "tpool_temporal_divisor": torch.from_numpy(temporal_divisor_np),
+        "tpool_spatial_gather_idx": torch.from_numpy(spatial_gather_idx_np),
+    }
+    indexed_out = tpool_patch_merger_indexed(x, metadata, kh=kh, kw=kw)
+
+    # The indexed output does not have a leading dead slot because it's
+    # indexed by ``spatial_gather_idx`` which only covers real slots.
+    assert indexed_out.shape == eager_packed.shape
+    torch.testing.assert_close(indexed_out, eager_packed, rtol=1e-5, atol=1e-6)
+
+
+def test_indexed_tpool_dead_slot_is_zero():
+    """Slot 0 of the post-tpool space is reserved as the dead slot."""
+    kh, kw = 2, 2
+    grid_thw_list = [(1, 4, 4)]
+    total_post_tpool = 16
+    total_input_patches = 16
+    total_output_slots = 4
+
+    (temporal_gather_idx_np, temporal_divisor_np, spatial_gather_idx_np) = (
+        _build_tpool_indices(
+            grid_thw_list,
+            kh=kh,
+            kw=kw,
+            max_total_patches=total_input_patches,
+            max_post_tpool_patches=total_post_tpool,
+            max_output_slots=total_output_slots,
+        )
+    )
+    # Dead slot stays at index 0 with divisor 1.0 (not touched by real items).
+    assert temporal_divisor_np[0] == pytest.approx(1.0)
+    # All real indices are strictly positive.
+    assert int(temporal_gather_idx_np.min()) >= 1
+    assert int(spatial_gather_idx_np.min()) >= 1
+
+
+def test_indexed_tpool_temporal_pooling():
+    """Temporal averaging must divide by ``t`` per post-tpool slot."""
+    kh, kw = 2, 2
+    hidden = 3
+    # One video chunk with t=3, h=w=2 (one output slot).
+    grid_thw_list = [(3, 2, 2)]
+    n_patches = 3 * 2 * 2
+
+    # Craft input so each of the 3 temporal frames contributes a distinct,
+    # easy-to-verify value.  Patches are laid out as
+    #   frame0: 4 patches at t_idx=0
+    #   frame1: 4 patches at t_idx=1
+    #   frame2: 4 patches at t_idx=2
+    # Frame i has all its patches set to i. The expected mean is (0+1+2)/3 = 1.
+    x = torch.zeros(n_patches, hidden, dtype=torch.float32)
+    x[0:4] = 0.0
+    x[4:8] = 1.0
+    x[8:12] = 2.0
+
+    (
+        temporal_gather_idx_np,
+        temporal_divisor_np,
+        spatial_gather_idx_np,
+    ) = _build_tpool_indices(
+        grid_thw_list,
+        kh=kh,
+        kw=kw,
+        max_total_patches=n_patches,
+        max_post_tpool_patches=4,  # h*w for this item
+        max_output_slots=1,
+    )
+    # Real slots live at indices 1..4 (slot 0 is the dead slot with
+    # divisor 1.0).  Each of the 3 temporal frames contributes to one
+    # slot, so the divisor there is 3.
+    np.testing.assert_allclose(temporal_divisor_np[0], 1.0)
+    np.testing.assert_allclose(temporal_divisor_np[1:5], 3.0)
+
+    metadata = {
+        "tpool_temporal_gather_idx": torch.from_numpy(temporal_gather_idx_np),
+        "tpool_temporal_divisor": torch.from_numpy(temporal_divisor_np),
+        "tpool_spatial_gather_idx": torch.from_numpy(spatial_gather_idx_np),
+    }
+    out = tpool_patch_merger_indexed(x, metadata, kh=kh, kw=kw)
+    assert out.shape == (1, kh * kw, hidden)
+    torch.testing.assert_close(out, torch.ones_like(out), rtol=1e-5, atol=1e-6)

--- a/vllm/model_executor/models/kimi_k25.py
+++ b/vllm/model_executor/models/kimi_k25.py
@@ -8,6 +8,7 @@ Kimi-K2.5 extends Kimi-K2 with vision support.
 
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
+from math import isqrt
 from typing import Annotated, Any, Literal
 
 import torch
@@ -547,14 +548,37 @@ class KimiK25ForConditionalGeneration(
 
         frames_per_item = max(max_frames_per_batch // max(max_batch_size, 1), 1)
 
-        # Each output slot corresponds to kh*kw input patches per frame,
-        # so per-item input patches = t * (nh*kh) * (nw*kw) where
-        # nh*nw = per_item_output.  Pick a square-ish layout: use
-        # ``nh = 1`` and ``nw = per_item_output`` for simplicity; the
-        # encoder only cares that h % kh == 0 and w % kw == 0.
+        # Pick a (nh, nw) layout that keeps each dummy item inside the
+        # 2D RoPE table bounds. ``Rope2DPosEmbRepeated`` precomputes a
+        # ``max_height x max_width`` table (512x512 in the Kimi-K2.5
+        # config) and asserts every item satisfies
+        # ``h <= max_height`` and ``w <= max_width`` where
+        # ``h = nh*kh`` and ``w = nw*kw``.  Prefer a square-ish
+        # layout, but clamp each dim so the product of the clamped
+        # dims still covers ``per_item_output`` output slots (if the
+        # budget is too large for the RoPE table, capture the largest
+        # covered sub-grid; budgets beyond that land in the eager
+        # fallback at runtime, which is the correct behavior).
+        rope_2d = self.vision_tower.encoder.rope_2d
+        max_nh = max(rope_2d.max_height // kh, 1)
+        max_nw = max(rope_2d.max_width // kw, 1)
+
+        nh_cap = min(max(isqrt(max(per_item_output, 1)), 1), max_nh)
+        nw_cap = min(
+            (per_item_output + nh_cap - 1) // nh_cap,
+            max_nw,
+        )
+        nw_cap = max(nw_cap, 1)
+
+        # ``Learnable2DInterpPosEmbDivided_fixed`` asserts
+        # ``t <= self.num_frames``; clamp the capture-time t to that
+        # bound so dummy inputs are valid.  Replays with t <= num_frames
+        # still fit; anything beyond would need its own eager path.
+        max_num_frames = self.vision_tower.patch_embed.pos_emb.num_frames
         t_cap = frames_per_item if frames_per_item > 1 else 1
-        h_cap = kh  # 1 output row per item
-        w_cap = per_item_output * kw  # per_item_output output cols per item
+        t_cap = min(t_cap, max_num_frames)
+        h_cap = nh_cap * kh
+        w_cap = nw_cap * kw
 
         grid_config: list[list[int]] = [
             [t_cap, h_cap, w_cap] for _ in range(max(max_batch_size, 1))
@@ -571,10 +595,13 @@ class KimiK25ForConditionalGeneration(
         # patches that fit in the ``token_budget`` output slots.  An
         # output slot is a ``kh*kw`` window, so a frame with
         # ``token_budget`` output slots has ``token_budget * kh * kw``
-        # input patches.  Take that as the capture-time upper bound; any
-        # replay fits because total frames are bounded by
-        # ``max_frames_per_batch`` and per-frame length is <= this.
-        max_seqlen_override = max(token_budget * kh * kw, total_patches)
+        # input patches.  Clamp to the RoPE table footprint so the
+        # scalar baked into the captured graph stays consistent with
+        # the metadata buffers.
+        max_seqlen_override = max(
+            min(token_budget * kh * kw, max_nh * kh * max_nw * kw),
+            total_patches,
+        )
 
         buffers = self.vision_tower.prepare_encoder_metadata(
             grid_config,

--- a/vllm/model_executor/models/kimi_k25.py
+++ b/vllm/model_executor/models/kimi_k25.py
@@ -25,6 +25,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors import (
 from vllm.model_executor.models.interfaces import (
     SupportsEagle,
     SupportsEagle3,
+    SupportsEncoderCudaGraph,
     SupportsMultiModal,
     SupportsPP,
     SupportsQuant,
@@ -282,6 +283,7 @@ class KimiK25ForConditionalGeneration(
     SupportsQuant,
     SupportsEagle,
     SupportsEagle3,
+    SupportsEncoderCudaGraph,
 ):
     """Kimi-K2.5 model for conditional generation.
 
@@ -403,6 +405,264 @@ class KimiK25ForConditionalGeneration(
             pixel_values=pixel_values,
             grid_thws=grid_thws,
         )
+
+    # -- SupportsEncoderCudaGraph protocol methods --
+    # The runner batches multimodal items by the string modality returned
+    # from ``group_and_batch_mm_kwargs``.  Kimi-K2.5 uses a single
+    # ``vision_chunk`` modality for both image and video-chunk items (see
+    # ``KimiK25ProcessingInfo.get_supported_mm_limits``), so the config
+    # advertises that one key.  Image vs. video items differ only in
+    # ``grid_thws[:, 0]`` (``t=1`` vs ``t=num_frames_per_chunk``) and
+    # share the same CUDA graph.
+
+    def get_encoder_cudagraph_config(self):
+        from vllm.v1.worker.encoder_cudagraph_defs import EncoderCudaGraphConfig
+
+        return EncoderCudaGraphConfig(
+            modalities=["vision_chunk"],
+            input_key_by_modality={"vision_chunk": "pixel_values"},
+            buffer_keys=[
+                "pos_embeds",
+                "rope_freqs_cis",
+                "cu_seqlens",
+                "max_seqlen",
+                "sequence_lengths",
+                "tpool_temporal_gather_idx",
+                "tpool_temporal_divisor",
+                "tpool_spatial_gather_idx",
+            ],
+            out_hidden_size=self.config.vision_config.mm_hidden_size,
+        )
+
+    def get_input_modality(self, mm_kwargs: dict[str, Any]) -> str:
+        return "vision_chunk"
+
+    def get_encoder_cudagraph_budget_range(
+        self,
+        vllm_config: VllmConfig,
+    ) -> tuple[int, int]:
+        kh, kw = self.vision_tower.merge_kernel_size
+        # Min: one image item with one spatial merge window ->
+        # (h, w) = (kh, kw), so 1 output slot.
+        min_budget = 1
+        # Max: capped by the scheduler's batched-token budget.  The
+        # multimodal prefill path never exceeds this anyway.
+        max_budget = vllm_config.scheduler_config.max_num_batched_tokens
+        return (min_budget, max_budget)
+
+    def _get_grid_thws(self, mm_kwargs: dict[str, Any]) -> list[tuple[int, int, int]]:
+        grid = mm_kwargs["grid_thws"]
+        if isinstance(grid, torch.Tensor):
+            grid_list = grid.reshape(-1, grid.shape[-1]).tolist()
+        else:
+            grid_list = [list(x) for x in grid]
+        return [(int(t), int(h), int(w)) for t, h, w in grid_list]
+
+    def get_encoder_cudagraph_num_items(self, mm_kwargs: dict[str, Any]) -> int:
+        return len(self._get_grid_thws(mm_kwargs))
+
+    def get_encoder_cudagraph_per_item_output_tokens(
+        self,
+        mm_kwargs: dict[str, Any],
+    ) -> list[int]:
+        # Kimi temporal-pools across t, so per-item output tokens are
+        # ``(h // kh) * (w // kw)``, independent of ``t``.
+        kh, kw = self.vision_tower.merge_kernel_size
+        return [(h // kh) * (w // kw) for _, h, w in self._get_grid_thws(mm_kwargs)]
+
+    def get_encoder_cudagraph_per_item_input_sizes(
+        self,
+        mm_kwargs: dict[str, Any],
+    ) -> list[int]:
+        return [t * h * w for t, h, w in self._get_grid_thws(mm_kwargs)]
+
+    def select_encoder_cudagraph_items(
+        self,
+        mm_kwargs: dict[str, Any],
+        indices: list[int],
+    ) -> dict[str, Any]:
+        grid_thws_all = self._get_grid_thws(mm_kwargs)
+        pixel_values: torch.Tensor = mm_kwargs["pixel_values"]
+        grid_raw = mm_kwargs["grid_thws"]
+
+        if len(indices) == 0:
+            empty_grid: torch.Tensor | list[tuple[int, int, int]]
+            if isinstance(grid_raw, torch.Tensor):
+                empty_grid = grid_raw.reshape(-1, grid_raw.shape[-1])[:0]
+            else:
+                empty_grid = []
+            return {
+                "pixel_values": pixel_values[:0],
+                "grid_thws": empty_grid,
+            }
+
+        # pixel_values is laid out as concatenated per-item patches.
+        patches_per_item = [t * h * w for t, h, w in grid_thws_all]
+        cum = [0]
+        for p in patches_per_item:
+            cum.append(cum[-1] + p)
+
+        selected_pv = torch.cat(
+            [pixel_values[cum[i] : cum[i + 1]] for i in indices], dim=0
+        )
+        if isinstance(grid_raw, torch.Tensor):
+            flat = grid_raw.reshape(-1, grid_raw.shape[-1])
+            selected_grid: torch.Tensor | list[tuple[int, int, int]] = flat[indices]
+        else:
+            selected_grid = [grid_thws_all[i] for i in indices]
+
+        return {
+            "pixel_values": selected_pv,
+            "grid_thws": selected_grid,
+        }
+
+    def prepare_encoder_cudagraph_capture_inputs(
+        self,
+        token_budget: int,
+        max_batch_size: int,
+        max_frames_per_batch: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ):
+        from vllm.v1.worker.encoder_cudagraph_defs import (
+            EncoderCudaGraphCaptureInputs,
+        )
+
+        kh, kw = self.vision_tower.merge_kernel_size
+        patch_size = self.vision_tower.patch_embed.patch_size
+        p_h, p_w = patch_size
+        per_item_output = max(token_budget // max(max_batch_size, 1), 1)
+
+        frames_per_item = max(max_frames_per_batch // max(max_batch_size, 1), 1)
+
+        # Each output slot corresponds to kh*kw input patches per frame,
+        # so per-item input patches = t * (nh*kh) * (nw*kw) where
+        # nh*nw = per_item_output.  Pick a square-ish layout: use
+        # ``nh = 1`` and ``nw = per_item_output`` for simplicity; the
+        # encoder only cares that h % kh == 0 and w % kw == 0.
+        t_cap = frames_per_item if frames_per_item > 1 else 1
+        h_cap = kh  # 1 output row per item
+        w_cap = per_item_output * kw  # per_item_output output cols per item
+
+        grid_config: list[list[int]] = [
+            [t_cap, h_cap, w_cap] for _ in range(max(max_batch_size, 1))
+        ]
+
+        total_patches = sum(t * h * w for t, h, w in grid_config)
+        total_output_slots = sum((h // kh) * (w // kw) for t, h, w in grid_config)
+
+        dummy_pixel_values = torch.randn(
+            total_patches, 3, p_h, p_w, device=device, dtype=dtype
+        )
+
+        # Worst case max_seqlen for replays: a single frame covering all
+        # patches that fit in the ``token_budget`` output slots.  An
+        # output slot is a ``kh*kw`` window, so a frame with
+        # ``token_budget`` output slots has ``token_budget * kh * kw``
+        # input patches.  Take that as the capture-time upper bound; any
+        # replay fits because total frames are bounded by
+        # ``max_frames_per_batch`` and per-frame length is <= this.
+        max_seqlen_override = max(token_budget * kh * kw, total_patches)
+
+        buffers = self.vision_tower.prepare_encoder_metadata(
+            grid_config,
+            max_batch_size=max_batch_size,
+            max_frames_per_batch=max_frames_per_batch,
+            max_total_patches=total_patches,
+            max_output_slots=total_output_slots,
+            max_seqlen_override=max_seqlen_override,
+            device=device,
+        )
+
+        mm_kwargs = {
+            "pixel_values": dummy_pixel_values,
+            "grid_thws": grid_config,
+        }
+        return EncoderCudaGraphCaptureInputs(mm_kwargs=mm_kwargs, buffers=buffers)
+
+    def prepare_encoder_cudagraph_replay_buffers(
+        self,
+        mm_kwargs: dict[str, Any],
+        max_batch_size: int,
+        max_frames_per_batch: int,
+    ):
+        from vllm.v1.worker.encoder_cudagraph_defs import (
+            EncoderCudaGraphReplayBuffers,
+        )
+
+        grid_thws = self._get_grid_thws(mm_kwargs)
+        # Match the input/output sizing the capture used so scatter copies
+        # into the captured buffers are slice-consistent.
+        kh, kw = self.vision_tower.merge_kernel_size
+        max_total_patches = sum(t * h * w for t, h, w in grid_thws)
+        max_output_slots = sum((h // kh) * (w // kw) for t, h, w in grid_thws)
+        buffers = self.vision_tower.prepare_encoder_metadata(
+            grid_thws,
+            max_batch_size=max_batch_size,
+            max_frames_per_batch=max_frames_per_batch,
+            max_total_patches=max_total_patches,
+            max_output_slots=max_output_slots,
+        )
+        return EncoderCudaGraphReplayBuffers(buffers=buffers)
+
+    def encoder_cudagraph_forward(
+        self,
+        mm_kwargs: dict[str, Any],
+        buffers: dict[str, torch.Tensor],
+    ) -> torch.Tensor:
+        pixel_values = mm_kwargs["pixel_values"]
+        # ``grid_thws`` is only needed by the eager patch-embed
+        # (for position-embedding interpolation) and the eager
+        # merger; both are bypassed when ``encoder_metadata`` is
+        # provided, so we do not need to materialize a tensor here.
+        # A placeholder of the right type keeps downstream code happy.
+        grid_thws = mm_kwargs["grid_thws"]
+        if isinstance(grid_thws, torch.Tensor):
+            grid_thws_tensor = grid_thws
+        else:
+            # Pure-Python list: not used inside the captured ops, but
+            # the tower signature still accepts it.
+            grid_thws_tensor = grid_thws  # type: ignore[assignment]
+
+        target_dtype = next(self.vision_tower.parameters()).dtype
+        if pixel_values.dtype != target_dtype:
+            pixel_values = pixel_values.to(target_dtype)
+
+        vt_out = self.vision_tower(
+            pixel_values, grid_thws_tensor, encoder_metadata=buffers
+        )  # (max_output_slots, kh*kw, hidden)
+        # Projector expects (N, kh*kw, hidden); the internal
+        # ``view(-1, hidden_size=hidden*kh*kw)`` + two linears then
+        # collapses it to ``(N, mm_hidden)``.
+        proj_out = self.mm_projector(vt_out)
+        return proj_out
+
+    def encoder_eager_forward(
+        self,
+        mm_kwargs: dict[str, Any],
+    ) -> torch.Tensor:
+        pixel_values = mm_kwargs["pixel_values"]
+        grid_thws = mm_kwargs["grid_thws"]
+        if isinstance(grid_thws, list):
+            grid_thws_tensor = torch.tensor(
+                grid_thws, dtype=torch.int32, device=pixel_values.device
+            )
+        else:
+            grid_thws_tensor = grid_thws
+        target_dtype = next(self.vision_tower.parameters()).dtype
+        if pixel_values.dtype != target_dtype:
+            pixel_values = pixel_values.to(target_dtype)
+        features = vision_tower_forward(
+            self.vision_tower,
+            pixel_values,
+            grid_thws_tensor,
+            mm_projector=self.mm_projector,
+            use_data_parallel=self.use_data_parallel,
+        )
+        # Concatenate per-item outputs into a single packed tensor; the
+        # manager ``_scatter_output_slices`` splits them again using
+        # ``per_item_output_tokens``.
+        return torch.cat(features, dim=0)
 
     def _process_media_input(
         self, media_input: KimiK25MediaPixelInputs

--- a/vllm/model_executor/models/kimi_k25.py
+++ b/vllm/model_executor/models/kimi_k25.py
@@ -480,12 +480,25 @@ class KimiK25ForConditionalGeneration(
         return (min_budget, max_budget)
 
     def _get_grid_thws(self, mm_kwargs: dict[str, Any]) -> list[tuple[int, int, int]]:
+        # Cache the converted tuple list on the mm_kwargs dict itself.
+        # The manager invokes ``get_encoder_cudagraph_num_items``,
+        # ``get_encoder_cudagraph_per_item_output_tokens``,
+        # ``get_encoder_cudagraph_per_item_input_sizes``,
+        # ``select_encoder_cudagraph_items`` and
+        # ``prepare_encoder_cudagraph_replay_buffers`` per request — all
+        # of which need this list.  Without caching we do ``.tolist()``
+        # and tuple coercion 5+ times, which shows up on the hot path.
+        cached = mm_kwargs.get("_cached_grid_thws_tuples")
+        if cached is not None:
+            return cached
         grid = mm_kwargs["grid_thws"]
         if isinstance(grid, torch.Tensor):
             grid_list = grid.reshape(-1, grid.shape[-1]).tolist()
         else:
             grid_list = [list(x) for x in grid]
-        return [(int(t), int(h), int(w)) for t, h, w in grid_list]
+        out = [(int(t), int(h), int(w)) for t, h, w in grid_list]
+        mm_kwargs["_cached_grid_thws_tuples"] = out
+        return out
 
     def get_encoder_cudagraph_num_items(self, mm_kwargs: dict[str, Any]) -> int:
         return len(self._get_grid_thws(mm_kwargs))

--- a/vllm/model_executor/models/kimi_k25.py
+++ b/vllm/model_executor/models/kimi_k25.py
@@ -455,12 +455,28 @@ class KimiK25ForConditionalGeneration(
         vllm_config: VllmConfig,
     ) -> tuple[int, int]:
         kh, kw = self.vision_tower.merge_kernel_size
-        # Min: one image item with one spatial merge window ->
-        # (h, w) = (kh, kw), so 1 output slot.
-        min_budget = 1
-        # Max: capped by the scheduler's batched-token budget.  The
-        # multimodal prefill path never exceeds this anyway.
-        max_budget = vllm_config.scheduler_config.max_num_batched_tokens
+        # Per-item output tokens lower bound: a small 448x448 image
+        # (32x32 patches, spatial_merge=2) ≈ 256 output slots.  Use
+        # that as the min budget so ``_generate_budgets`` doesn't emit
+        # ``[1, 2, 4, 8, ...]`` which would inflate to 30+ graphs and
+        # push ``max_batch_size = max_budget // min_budget`` to an
+        # absurd value (e.g. 32k).
+        min_budget = 256
+
+        # Per-item output tokens upper bound: the RoPE table footprint.
+        # ``Rope2DPosEmbRepeated(head_dim, 512, 512)`` can only address
+        # (h<=512, w<=512), so a single item never has more than
+        # (512//kh) * (512//kw) output slots.  Capturing graphs bigger
+        # than that is wasted memory — any such request will always
+        # land in the eager fallback.
+        rope_2d = self.vision_tower.encoder.rope_2d
+        rope_max_slots = (rope_2d.max_height // kh) * (rope_2d.max_width // kw)
+
+        # Also cap by the scheduler budget so we never over-provision
+        # relative to the runtime batch.
+        scheduler_cap = vllm_config.scheduler_config.max_num_batched_tokens
+        max_budget = min(rope_max_slots, scheduler_cap)
+        max_budget = max(max_budget, min_budget)
         return (min_budget, max_budget)
 
     def _get_grid_thws(self, mm_kwargs: dict[str, Any]) -> list[tuple[int, int, int]]:

--- a/vllm/model_executor/models/kimi_k25.py
+++ b/vllm/model_executor/models/kimi_k25.py
@@ -420,7 +420,19 @@ class KimiK25ForConditionalGeneration(
 
         return EncoderCudaGraphConfig(
             modalities=["vision_chunk"],
-            input_key_by_modality={"vision_chunk": "pixel_values"},
+            # NOTE: ``EncoderCudaGraphManager._capture_budget_graph`` in
+            # ``encoder_cudagraph.py:178`` hardcodes a lookup on
+            # ``input_key_by_modality["image"]`` at capture time to
+            # locate the dummy input buffer.  Kimi's only runtime
+            # modality is ``"vision_chunk"`` (see
+            # ``KimiK25ProcessingInfo``), so we alias both keys to the
+            # same ``"pixel_values"`` tensor to satisfy both the
+            # capture-time hardcoded lookup and the replay-time
+            # ``get_input_modality`` → ``input_key_by_modality`` lookup.
+            input_key_by_modality={
+                "image": "pixel_values",
+                "vision_chunk": "pixel_values",
+            },
             buffer_keys=[
                 "pos_embeds",
                 "rope_freqs_cis",

--- a/vllm/model_executor/models/kimi_k25_vit.py
+++ b/vllm/model_executor/models/kimi_k25_vit.py
@@ -195,16 +195,25 @@ class Learnable2DInterpPosEmbDivided_fixed(nn.Module):
         ``device`` and optionally cast to ``dtype``.
         """
         pos_embs: list[torch.Tensor] = []
+        # Cache interpolated 2D grids per (h, w) within a single call so
+        # multiple items in the same batch with identical spatial shapes
+        # (common: a batch of same-resolution images) share one
+        # F.interpolate kernel launch.
+        pos_emb_2d_cache: dict[tuple[int, int], torch.Tensor] = {}
         for t, h, w in grid_thw_list:
             assert t <= self.num_frames, f"t:{t} > self.num_frames:{self.num_frames}"
-            if (h, w) == self.weight.shape[:-1]:
-                pos_emb_2d = self.weight.flatten(end_dim=1)
-            else:
-                pos_emb_2d = get_rope_shape(
-                    self.weight,
-                    interpolation_mode=self.interpolation_mode,
-                    shape=(h, w),
-                )
+            hw_key = (h, w)
+            pos_emb_2d = pos_emb_2d_cache.get(hw_key)
+            if pos_emb_2d is None:
+                if (h, w) == self.weight.shape[:-1]:
+                    pos_emb_2d = self.weight.flatten(end_dim=1)
+                else:
+                    pos_emb_2d = get_rope_shape(
+                        self.weight,
+                        interpolation_mode=self.interpolation_mode,
+                        shape=(h, w),
+                    )
+                pos_emb_2d_cache[hw_key] = pos_emb_2d
 
             if t == 1:
                 pos_emb_3d = pos_emb_2d
@@ -368,10 +377,18 @@ class Rope2DPosEmbRepeated(nn.Module):
             self.max_height,
             self.max_width,
         )
-        parts = [
-            self.freqs_cis[:h, :w].reshape(-1, self.dim // 2).repeat(t, 1)
-            for t, h, w in shapes
-        ]
+        # Cache per-(h, w) slices within a single call — common batches
+        # have repeated spatial shapes, and each cache hit replaces a
+        # narrow ``[:h, :w]`` slice + reshape on the GPU with a Python
+        # dict lookup.
+        slice_cache: dict[tuple[int, int], torch.Tensor] = {}
+        parts: list[torch.Tensor] = []
+        for t, h, w in shapes:
+            base = slice_cache.get((h, w))
+            if base is None:
+                base = self.freqs_cis[:h, :w].reshape(-1, self.dim // 2)
+                slice_cache[(h, w)] = base
+            parts.append(base.repeat(t, 1) if t != 1 else base)
         freqs_cis = (
             torch.cat(parts, dim=0)
             if parts
@@ -709,48 +726,61 @@ def _build_tpool_indices(
     post_tpool_offset = 1  # start at 1; slot 0 is the dead slot
     slot_offset = 0  # offset into flattened output slots (per-item nh*nw)
 
+    # Precompute kh*kw/kw-sized ranges once; reused per item to
+    # vectorize the inner fill and avoid Python-level loops (those
+    # dominated replay cost before: ~18K iters per typical batch).
+    kh_range = np.arange(kh, dtype=np.int64)
+    kw_range = np.arange(kw, dtype=np.int64)
+
     for t, h, w in grid_thw_list:
-        assert h % kh == 0 and w % kw == 0, (
-            f"grid ({h}, {w}) not divisible by merge kernel ({kh}, {kw})"
-        )
+        if h % kh != 0 or w % kw != 0:
+            raise ValueError(
+                f"grid ({h}, {w}) not divisible by merge kernel ({kh}, {kw})"
+            )
         nh = h // kh
         nw = w // kw
+        hw = h * w
+        n_item_patches = t * hw
+        n_item_slots = nh * nw
 
         # --- temporal scatter target ---
-        # Input patch flat index = t_idx * (h*w) + row * w + col
-        # Post-tpool slot = post_tpool_offset + row * w + col
-        # (all t_idx for the same (row, col) collapse to one slot)
-        for t_idx in range(t):
-            base = input_offset + t_idx * (h * w)
-            for r in range(h):
-                for c in range(w):
-                    temporal_gather_idx[base + r * w + c] = (
-                        post_tpool_offset + r * w + c
-                    )
-        # One slot per (row, col); each accumulates `t` frames
-        temporal_divisor[post_tpool_offset : post_tpool_offset + h * w] = float(t)
+        # For every input patch (t_idx, r, c) the post-tpool target is
+        # ``post_tpool_offset + r*w + c`` — independent of ``t_idx``.
+        # Build one (h*w,) row and tile it ``t`` times.
+        row_targets = post_tpool_offset + np.arange(hw, dtype=np.int64)
+        # Equivalent to ``np.tile(row_targets, t)`` but written as a
+        # broadcast to keep the allocation linear.
+        temporal_gather_idx[
+            input_offset : input_offset + n_item_patches
+        ] = np.broadcast_to(row_targets, (t, hw)).reshape(-1)
+        # Each post-tpool slot accumulates ``t`` frames.
+        temporal_divisor[post_tpool_offset : post_tpool_offset + hw] = float(t)
 
         # --- spatial rearrangement gather table ---
-        # Output layout per item: (nh*nw, kh*kw).
-        # Output position (slot, sub) -> src post-tpool slot
-        #   slot = nh_i*nw + nw_i, sub = kh_i*kw + kw_i
-        #   src = post_tpool_offset + (nh_i*kh + kh_i)*w + (nw_i*kw + kw_i)
-        for nh_i in range(nh):
-            for nw_i in range(nw):
-                for kh_i in range(kh):
-                    for kw_i in range(kw):
-                        out_slot = slot_offset + nh_i * nw + nw_i
-                        out_idx = out_slot * (kh * kw) + kh_i * kw + kw_i
-                        src = (
-                            post_tpool_offset
-                            + (nh_i * kh + kh_i) * w
-                            + (nw_i * kw + kw_i)
-                        )
-                        spatial_gather_idx[out_idx] = src
+        # For every (nh_i, nw_i, kh_i, kw_i):
+        #   out_slot = slot_offset + nh_i*nw + nw_i
+        #   out_idx  = out_slot*(kh*kw) + kh_i*kw + kw_i
+        #   src      = post_tpool_offset + (nh_i*kh+kh_i)*w + (nw_i*kw+kw_i)
+        # Build the 4D grid with broadcasting in one shot.
+        nh_i = np.arange(nh, dtype=np.int64).reshape(nh, 1, 1, 1)
+        nw_i = np.arange(nw, dtype=np.int64).reshape(1, nw, 1, 1)
+        kh_i = kh_range.reshape(1, 1, kh, 1)
+        kw_i = kw_range.reshape(1, 1, 1, kw)
+        src = (
+            post_tpool_offset
+            + (nh_i * kh + kh_i) * w
+            + (nw_i * kw + kw_i)
+        )  # (nh, nw, kh, kw)
+        # Output layout: ``(slot=nh*nw, kh*kw)`` flattened.  The 4D src
+        # is already in ``(nh, nw, kh, kw)`` order, so a flat reshape
+        # gives exactly the order expected by ``spatial_gather_idx``.
+        spatial_gather_idx[
+            slot_offset * (kh * kw) : (slot_offset + n_item_slots) * (kh * kw)
+        ] = src.reshape(-1)
 
-        input_offset += t * h * w
-        post_tpool_offset += h * w
-        slot_offset += nh * nw
+        input_offset += n_item_patches
+        post_tpool_offset += hw
+        slot_offset += n_item_slots
 
     # Dead-slot divisor stays 1.0 to keep the division finite.
     temporal_divisor[DEAD_SLOT] = 1.0

--- a/vllm/model_executor/models/kimi_k25_vit.py
+++ b/vllm/model_executor/models/kimi_k25_vit.py
@@ -31,6 +31,7 @@ from vllm.model_executor.layers.linear import (
 from vllm.model_executor.layers.quantization import QuantizationConfig
 from vllm.model_executor.models.utils import maybe_prefix
 from vllm.model_executor.models.vision import (
+    get_vit_attn_backend,
     is_vit_use_data_parallel,
     run_dp_sharded_mrope_vision_model,
 )
@@ -179,6 +180,60 @@ class Learnable2DInterpPosEmbDivided_fixed(nn.Module):
         out = x + torch.cat(pos_embs)
         return out
 
+    def compute_pos_embeds(
+        self,
+        grid_thw_list: list[list[int]] | list[tuple[int, int, int]],
+        device: torch.device,
+        dtype: torch.dtype | None = None,
+        pad_to: int | None = None,
+    ) -> torch.Tensor:
+        """Compute the additive position embedding tensor without adding it
+        to any input — used by ``prepare_encoder_metadata`` to precompute a
+        fixed-shape buffer for CUDA graph capture/replay.
+
+        Returns a tensor of shape ``(sum(t*h*w), dim)`` (or ``pad_to``), on
+        ``device`` and optionally cast to ``dtype``.
+        """
+        pos_embs: list[torch.Tensor] = []
+        for t, h, w in grid_thw_list:
+            assert t <= self.num_frames, f"t:{t} > self.num_frames:{self.num_frames}"
+            if (h, w) == self.weight.shape[:-1]:
+                pos_emb_2d = self.weight.flatten(end_dim=1)
+            else:
+                pos_emb_2d = get_rope_shape(
+                    self.weight,
+                    interpolation_mode=self.interpolation_mode,
+                    shape=(h, w),
+                )
+
+            if t == 1:
+                pos_emb_3d = pos_emb_2d
+            else:
+                pos_emb_3d = (
+                    pos_emb_2d.unsqueeze(0).repeat(t, 1, 1) + self.time_weight[0:t]
+                )
+            pos_embs.append(pos_emb_3d.reshape(-1, pos_emb_3d.shape[-1]))
+
+        if pos_embs:
+            out = torch.cat(pos_embs, dim=0)
+        else:
+            out = torch.zeros(
+                (0, self.dim), dtype=self.weight.dtype, device=self.weight.device
+            )
+
+        if device is not None and out.device != device:
+            out = out.to(device=device, non_blocking=True)
+        if dtype is not None and out.dtype != dtype:
+            out = out.to(dtype=dtype)
+        if pad_to is not None and out.size(0) < pad_to:
+            pad = torch.zeros(
+                (pad_to - out.size(0), out.size(1)),
+                dtype=out.dtype,
+                device=out.device,
+            )
+            out = torch.cat([out, pad], dim=0)
+        return out
+
 
 class MoonVision3dPatchEmbed(nn.Module):
     """3D patch embedding for vision tower."""
@@ -218,10 +273,22 @@ class MoonVision3dPatchEmbed(nn.Module):
         else:
             raise NotImplementedError(f"Not support pos_emb_type: {pos_emb_type}")
 
-    def forward(self, x: torch.Tensor, grid_thws: torch.Tensor) -> torch.Tensor:
+    def forward(
+        self,
+        x: torch.Tensor,
+        grid_thws: torch.Tensor,
+        *,
+        pos_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor:
         x = self.proj(x).view(x.size(0), -1)
-        # apply positional embedding
-        x = self.pos_emb(x, grid_thws)
+        # Precomputed path (CUDA graph replay): ``pos_embeds`` is padded
+        # to the same worst-case length as ``x``, so we can add them
+        # element-wise.  The padded tail adds zeros to padded pixel
+        # positions, whose attention contribution is later masked out by
+        # ``cu_seqlens`` and whose post-tpool contribution is routed to
+        # the dead slot.  Eager path falls back to the per-item
+        # interpolation loop in ``self.pos_emb``.
+        x = x + pos_embeds if pos_embeds is not None else self.pos_emb(x, grid_thws)
         return x
 
 
@@ -264,6 +331,12 @@ class Rope2DPosEmbRepeated(nn.Module):
         freqs_cis = freqs_cis.reshape(self.max_height, self.max_width, -1)
         return freqs_cis
 
+    def _ensure_freqs_cis(self, device: torch.device) -> None:
+        if not hasattr(self, "freqs_cis"):
+            self.register_buffer(
+                "freqs_cis", self._precompute_freqs_cis(device), persistent=False
+            )
+
     def get_freqs_cis(
         self, grid_thws: torch.Tensor, device: torch.device
     ) -> torch.Tensor:
@@ -274,12 +347,20 @@ class Rope2DPosEmbRepeated(nn.Module):
         Returns:
             freqs_cis: tensor of shape (sum(t * height * width), dim//2)
         """
-        if not hasattr(self, "freqs_cis"):
-            self.register_buffer(
-                "freqs_cis", self._precompute_freqs_cis(device), persistent=False
-            )
+        return self.get_freqs_cis_from_list(grid_thws.tolist(), device)
 
-        shapes = grid_thws.tolist()
+    def get_freqs_cis_from_list(
+        self,
+        shapes: list[list[int]] | list[tuple[int, int, int]],
+        device: torch.device,
+        pad_to: int | None = None,
+    ) -> torch.Tensor:
+        """List-based variant that avoids ``grid_thws.tolist()`` and
+        supports right-padding to a fixed worst-case length (needed
+        for CUDA graph capture/replay where buffer shapes are static).
+        """
+        self._ensure_freqs_cis(device)
+
         assert all(
             1 <= h <= self.max_height and 1 <= w <= self.max_width for t, h, w in shapes
         ), (
@@ -287,13 +368,23 @@ class Rope2DPosEmbRepeated(nn.Module):
             self.max_height,
             self.max_width,
         )
-        freqs_cis = torch.cat(
-            [
-                self.freqs_cis[:h, :w].reshape(-1, self.dim // 2).repeat(t, 1)
-                for t, h, w in shapes
-            ],
-            dim=0,
+        parts = [
+            self.freqs_cis[:h, :w].reshape(-1, self.dim // 2).repeat(t, 1)
+            for t, h, w in shapes
+        ]
+        freqs_cis = (
+            torch.cat(parts, dim=0)
+            if parts
+            else torch.empty((0, self.dim // 2), dtype=torch.complex64, device=device)
         )
+        if pad_to is not None and freqs_cis.shape[0] < pad_to:
+            pad_len = pad_to - freqs_cis.shape[0]
+            pad = torch.zeros(
+                (pad_len, self.dim // 2),
+                dtype=freqs_cis.dtype,
+                device=freqs_cis.device,
+            )
+            freqs_cis = torch.cat([freqs_cis, pad], dim=0)
         return freqs_cis
 
 
@@ -401,12 +492,21 @@ class MoonViTEncoderLayer(nn.Module):
         x: torch.Tensor,
         cu_seqlens: torch.Tensor,
         rope_freqs_cis: torch.Tensor | None = None,
+        max_seqlen: torch.Tensor | None = None,
+        sequence_lengths: torch.Tensor | None = None,
     ):
         """Compute self-attention with packed QKV.
 
         Args:
             x (torch.Tensor): (seqlen, hidden_dim)
             cu_seqlens (torch.Tensor): cumulative sequence lengths
+            rope_freqs_cis: precomputed 2D RoPE frequencies.
+            max_seqlen: precomputed max sequence length (scalar tensor).
+                If ``None`` it is computed on the fly from ``cu_seqlens``,
+                which triggers a D2H sync and should be avoided inside
+                CUDA graph capture.
+            sequence_lengths: per-sequence lengths, only consumed by the
+                FlashInfer CuDNN backend; ``None`` otherwise.
         """
         seq_length = x.size(0)
         xqkv, _ = self.wqkv(x)
@@ -422,13 +522,15 @@ class MoonViTEncoderLayer(nn.Module):
 
         xq, xk = apply_rope(xq, xk, rope_freqs_cis)
 
-        max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max()
+        if max_seqlen is None:
+            max_seqlen = (cu_seqlens[1:] - cu_seqlens[:-1]).max()
         attn_out = self.attn(
             xq.unsqueeze(0),
             xk.unsqueeze(0),
             xv.unsqueeze(0),
             cu_seqlens=cu_seqlens,
             max_seqlen=max_seqlen,
+            sequence_lengths=sequence_lengths,
         )
         attn_out = attn_out.reshape(
             seq_length,
@@ -443,12 +545,18 @@ class MoonViTEncoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         cu_seqlens: torch.Tensor,
         rope_freqs_cis: torch.Tensor | None = None,
+        max_seqlen: torch.Tensor | None = None,
+        sequence_lengths: torch.Tensor | None = None,
     ):
         residual = hidden_states
         hidden_states = self.norm0(hidden_states)
 
         hidden_states = self.attention_qkvpacked(
-            hidden_states, cu_seqlens, rope_freqs_cis
+            hidden_states,
+            cu_seqlens,
+            rope_freqs_cis,
+            max_seqlen=max_seqlen,
+            sequence_lengths=sequence_lengths,
         )
         hidden_states = residual + hidden_states
 
@@ -497,23 +605,39 @@ class MoonViT3dEncoder(nn.Module):
         self,
         hidden_states: torch.Tensor,
         grid_thws: torch.Tensor,
+        *,
+        encoder_metadata: dict[str, torch.Tensor | None] | None = None,
     ) -> torch.Tensor:
-        rope_freqs_cis = self.rope_2d.get_freqs_cis(
-            grid_thws=grid_thws, device=hidden_states.device
-        )
-
-        lengths = torch.cat(
-            (
-                torch.zeros(1, dtype=grid_thws.dtype, device=grid_thws.device),
-                grid_thws[:, 0] * grid_thws[:, 1] * grid_thws[:, 2],
+        if encoder_metadata is None:
+            rope_freqs_cis = self.rope_2d.get_freqs_cis(
+                grid_thws=grid_thws, device=hidden_states.device
             )
-        )
 
-        cu_seqlens = lengths.to(hidden_states.device).cumsum(dim=0, dtype=torch.int32)
+            lengths = torch.cat(
+                (
+                    torch.zeros(1, dtype=grid_thws.dtype, device=grid_thws.device),
+                    grid_thws[:, 0] * grid_thws[:, 1] * grid_thws[:, 2],
+                )
+            )
+
+            cu_seqlens = lengths.to(hidden_states.device).cumsum(
+                dim=0, dtype=torch.int32
+            )
+            max_seqlen = None
+            sequence_lengths = None
+        else:
+            rope_freqs_cis = encoder_metadata["rope_freqs_cis"]
+            cu_seqlens = encoder_metadata["cu_seqlens"]
+            max_seqlen = encoder_metadata.get("max_seqlen")
+            sequence_lengths = encoder_metadata.get("sequence_lengths")
 
         for block in self.blocks:
             hidden_states = block(
-                hidden_states, cu_seqlens, rope_freqs_cis=rope_freqs_cis
+                hidden_states,
+                cu_seqlens,
+                rope_freqs_cis=rope_freqs_cis,
+                max_seqlen=max_seqlen,
+                sequence_lengths=sequence_lengths,
             )
 
         hidden_states = self.final_layernorm(hidden_states)
@@ -545,6 +669,165 @@ def tpool_patch_merger(
     return outputs
 
 
+def _build_tpool_indices(
+    grid_thw_list: list[list[int]] | list[tuple[int, int, int]],
+    kh: int,
+    kw: int,
+    max_total_patches: int,
+    max_post_tpool_patches: int,
+    max_output_slots: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Precompute index buffers that turn :func:`tpool_patch_merger` into a
+    pair of pure tensor ops (``scatter_reduce`` + ``index_select``) so the
+    whole merger can live inside a CUDA graph.
+
+    The dead slot is **pinned to index 0** of the post-tpool space so that
+    the graph-captured buffers and smaller replay buffers agree regardless
+    of how many real slots are populated.  Real slots occupy indices
+    ``1 .. max_post_tpool_patches``; padded input patches and padded
+    output positions both route to index 0.
+
+    Returns three numpy arrays sized to the worst case:
+
+    * ``temporal_gather_idx`` ``(max_total_patches,)``: for each input
+      patch, the post-tpool slot (>= 1) it contributes to.  Padding
+      positions map to slot 0 (the dead slot).
+    * ``temporal_divisor`` ``(max_post_tpool_patches + 1,)``: per post-
+      tpool slot, the count of contributing frames (``t_i``).  Slot 0
+      has divisor 1.0 so the division is stable.
+    * ``spatial_gather_idx`` ``(max_output_slots * kh * kw,)``: gather
+      table mapping ``(item, nh, kh_off, nw, kw_off)`` to the
+      ``(slot=nh*nw, kh*kw)`` layout.  Padded positions map to slot 0.
+    """
+    DEAD_SLOT = 0  # fixed index across capture and replay
+
+    temporal_gather_idx = np.full(max_total_patches, DEAD_SLOT, dtype=np.int64)
+    temporal_divisor = np.ones(max_post_tpool_patches + 1, dtype=np.float32)
+    spatial_gather_idx = np.full(max_output_slots * kh * kw, DEAD_SLOT, dtype=np.int64)
+
+    input_offset = 0  # offset into concatenated input patches
+    post_tpool_offset = 1  # start at 1; slot 0 is the dead slot
+    slot_offset = 0  # offset into flattened output slots (per-item nh*nw)
+
+    for t, h, w in grid_thw_list:
+        assert h % kh == 0 and w % kw == 0, (
+            f"grid ({h}, {w}) not divisible by merge kernel ({kh}, {kw})"
+        )
+        nh = h // kh
+        nw = w // kw
+
+        # --- temporal scatter target ---
+        # Input patch flat index = t_idx * (h*w) + row * w + col
+        # Post-tpool slot = post_tpool_offset + row * w + col
+        # (all t_idx for the same (row, col) collapse to one slot)
+        for t_idx in range(t):
+            base = input_offset + t_idx * (h * w)
+            for r in range(h):
+                for c in range(w):
+                    temporal_gather_idx[base + r * w + c] = (
+                        post_tpool_offset + r * w + c
+                    )
+        # One slot per (row, col); each accumulates `t` frames
+        temporal_divisor[post_tpool_offset : post_tpool_offset + h * w] = float(t)
+
+        # --- spatial rearrangement gather table ---
+        # Output layout per item: (nh*nw, kh*kw).
+        # Output position (slot, sub) -> src post-tpool slot
+        #   slot = nh_i*nw + nw_i, sub = kh_i*kw + kw_i
+        #   src = post_tpool_offset + (nh_i*kh + kh_i)*w + (nw_i*kw + kw_i)
+        for nh_i in range(nh):
+            for nw_i in range(nw):
+                for kh_i in range(kh):
+                    for kw_i in range(kw):
+                        out_slot = slot_offset + nh_i * nw + nw_i
+                        out_idx = out_slot * (kh * kw) + kh_i * kw + kw_i
+                        src = (
+                            post_tpool_offset
+                            + (nh_i * kh + kh_i) * w
+                            + (nw_i * kw + kw_i)
+                        )
+                        spatial_gather_idx[out_idx] = src
+
+        input_offset += t * h * w
+        post_tpool_offset += h * w
+        slot_offset += nh * nw
+
+    # Dead-slot divisor stays 1.0 to keep the division finite.
+    temporal_divisor[DEAD_SLOT] = 1.0
+    return temporal_gather_idx, temporal_divisor, spatial_gather_idx
+
+
+def tpool_patch_merger_indexed(
+    x: torch.Tensor,
+    metadata: dict[str, torch.Tensor | None],
+    kh: int,
+    kw: int,
+) -> torch.Tensor:
+    """Static-shape variant of :func:`tpool_patch_merger` suitable for
+    CUDA graph capture/replay.
+
+    Unlike the eager implementation (which iterates over a Python list and
+    emits per-item tensors), this version does the whole merge with two
+    tensor ops against precomputed indices:
+
+    1. ``scatter_reduce_`` sums input patches into post-tpool slots (mean
+       is applied explicitly by dividing by ``tpool_temporal_divisor``).
+    2. ``index_select`` rearranges ``(item, nh, kh, nw, kw)`` into the
+       ``(slot=nh*nw, kh*kw)`` layout expected by the projector.
+
+    Slot 0 is reserved as a fixed "dead slot" so the index layout is
+    identical whether called from capture (worst-case-sized inputs) or
+    replay (partial-sized inputs copied into the captured buffers).
+    Padded input patches and unused output positions both route to it.
+
+    Args:
+        x: encoded patches, shape ``(max_total_patches, hidden)``.  Values
+            past the valid range are ignored because their corresponding
+            index rows point to slot 0 (dead slot).
+        metadata: dict containing ``tpool_temporal_gather_idx``,
+            ``tpool_temporal_divisor``, and ``tpool_spatial_gather_idx``
+            (see :func:`_build_tpool_indices`).
+        kh, kw: temporal-pool merge kernel.
+
+    Returns:
+        ``(max_output_slots, kh*kw, hidden)`` tensor, consumable by the
+        projector the same way the eager merger's per-item outputs are.
+        The dead slot lives in the internal ``spatial_sum`` buffer and
+        never appears in this output — ``spatial_gather_idx`` only
+        addresses real slots (1..max_post_tpool_patches).  Output rows
+        past the replay's valid range still live here but contain
+        padded (zero) slot values and must be dropped by the caller
+        using ``per_item_output_tokens``.
+    """
+    max_total_patches, hidden = x.shape
+    temporal_gather_idx = metadata["tpool_temporal_gather_idx"]
+    temporal_divisor = metadata["tpool_temporal_divisor"]
+    spatial_gather_idx = metadata["tpool_spatial_gather_idx"]
+
+    # temporal_divisor has shape (max_post_tpool_patches + 1,) where
+    # index 0 is the dead slot and 1..max_post_tpool_patches are real
+    # slots.  We allocate ``spatial_sum`` with the same leading dim.
+    num_slots_incl_dead = temporal_divisor.shape[0]
+
+    spatial_sum = torch.zeros(
+        num_slots_incl_dead,
+        hidden,
+        dtype=x.dtype,
+        device=x.device,
+    )
+    spatial_sum.scatter_reduce_(
+        0,
+        temporal_gather_idx.unsqueeze(-1).expand(max_total_patches, hidden),
+        x,
+        reduce="sum",
+        include_self=True,
+    )
+    spatial_mean = spatial_sum / temporal_divisor.unsqueeze(-1).to(spatial_sum.dtype)
+
+    gathered = spatial_mean.index_select(0, spatial_gather_idx)
+    return gathered.view(-1, kh * kw, hidden)
+
+
 class MoonViT3dPretrainedModel(nn.Module):
     """Main vision tower model.
 
@@ -563,6 +846,13 @@ class MoonViT3dPretrainedModel(nn.Module):
         self.merge_kernel_size = config.merge_kernel_size
         self.patch_size = config.patch_size
         self.merge_type = config.merge_type
+        # Expose encoder-shape fields for CUDA graph capture sizing.
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_size = config.hidden_size // config.num_attention_heads
+        self.tp_size = (
+            1 if is_vit_use_data_parallel() else get_tensor_model_parallel_world_size()
+        )
 
         self.patch_embed = MoonVision3dPatchEmbed(
             out_dim=config.hidden_size,
@@ -588,29 +878,226 @@ class MoonViT3dPretrainedModel(nn.Module):
             prefix=maybe_prefix(prefix, "encoder"),
         )
 
+        # Attention backend used by MMEncoderAttention inside each block.
+        # Cached here so ``prepare_encoder_metadata`` can ask
+        # ``MMEncoderAttention`` for backend-specific buffer transforms
+        # (FlashInfer ``cu_seqlens`` rewrite, ``sequence_lengths`` padding,
+        # bucketed ``max_seqlen``, ...).  Matches the cached state inside
+        # each ``MMEncoderAttention`` layer.
+        self.attn_backend = get_vit_attn_backend(
+            head_size=self.head_size,
+            dtype=torch.get_default_dtype(),
+        )
+
+    @property
+    def device(self) -> torch.device:
+        return self.patch_embed.proj.weight.device
+
+    @property
+    def dtype(self) -> torch.dtype:
+        return self.patch_embed.proj.weight.dtype
+
+    # -- CUDA graph metadata --------------------------------------------
+    def prepare_encoder_metadata(
+        self,
+        grid_thw_list: list[list[int]] | list[tuple[int, int, int]],
+        *,
+        max_batch_size: int | None = None,
+        max_frames_per_batch: int | None = None,
+        max_total_patches: int | None = None,
+        max_output_slots: int | None = None,
+        max_seqlen_override: int | None = None,
+        device: torch.device | None = None,
+    ) -> dict[str, torch.Tensor | None]:
+        """Compute encoder + tpool metadata from ``grid_thw_list``.
+
+        Shared by the eager path, CUDA graph capture, and CUDA graph
+        replay so all three paths read the same precomputed buffers.
+
+        Args:
+            grid_thw_list: per-item grids as lists of ``[t, h, w]``.
+            max_batch_size: if set, pad ``cu_seqlens`` to this length
+                (needed for graph replay where shapes are static).
+            max_frames_per_batch: if set, overrides ``max_batch_size`` for
+                ``cu_seqlens`` padding.  Each video item contributes ``t``
+                attention sequences (one per frame), so total sequences
+                can exceed ``max_batch_size``; this sizes the buffer to
+                the total frame budget.  Falls back to ``max_batch_size``.
+            max_total_patches: pad the input-patch-sized index buffers
+                to this length.  Defaults to the sum of ``t*h*w`` across
+                items (no padding).
+            max_output_slots: pad the output-slot-sized index buffers to
+                this length.  Defaults to the sum of ``(h//kh)*(w//kw)``.
+            max_seqlen_override: if set, use this instead of computing
+                ``max_seqlen`` from ``cu_seqlens`` (needed for capture:
+                the scalar is baked into the graph, so it must cover the
+                worst replay case).
+            device: placement for output tensors.  Defaults to
+                ``self.device``.
+        """
+        if device is None:
+            device = self.device
+        kh, kw = self.merge_kernel_size
+
+        # Normalize to list of 3-tuples so downstream code doesn't see
+        # torch tensors (we want pure-Python / numpy index construction
+        # to avoid capturing device kernels here).
+        shapes: list[tuple[int, int, int]] = [
+            (int(t), int(h), int(w)) for t, h, w in grid_thw_list
+        ]
+
+        metadata: dict[str, torch.Tensor | None] = {}
+
+        # Positional embeddings (learnable 2D interp + temporal sincos).
+        # Precomputed so that the patch_embed can do a simple tensor-add
+        # inside the graph instead of a Python loop + F.interpolate.
+        total_patches = sum(t * h * w for t, h, w in shapes)
+        if max_total_patches is None:
+            max_total_patches = total_patches
+        metadata["pos_embeds"] = self.patch_embed.pos_emb.compute_pos_embeds(
+            shapes,
+            device=device,
+            dtype=self.dtype,
+            pad_to=max_total_patches,
+        )
+
+        # 2D RoPE freqs — one entry per input patch (one-to-one with
+        # ``pos_embeds`` / ``hidden_states`` after patch embed).
+        rope_freqs_cis = self.encoder.rope_2d.get_freqs_cis_from_list(
+            shapes, device=device, pad_to=max_total_patches
+        )
+        metadata["rope_freqs_cis"] = rope_freqs_cis
+
+        # cu_seqlens — one sequence per frame (one per (item, t_idx))
+        patches_per_frame = np.array(
+            [h * w for t, h, w in shapes for _ in range(t)], dtype=np.int32
+        )
+        if patches_per_frame.size > 0:
+            cu_seqlens_np = np.concatenate(
+                [
+                    np.zeros(1, dtype=np.int32),
+                    patches_per_frame.cumsum(dtype=np.int32),
+                ]
+            )
+        else:
+            cu_seqlens_np = np.zeros(1, dtype=np.int32)
+
+        pad_to = (
+            max_frames_per_batch if max_frames_per_batch is not None else max_batch_size
+        )
+        if pad_to is not None:
+            num_seqs = len(cu_seqlens_np) - 1
+            if num_seqs < pad_to:
+                cu_seqlens_np = np.concatenate(
+                    [
+                        cu_seqlens_np,
+                        np.full(
+                            pad_to - num_seqs,
+                            cu_seqlens_np[-1],
+                            dtype=np.int32,
+                        ),
+                    ]
+                )
+
+        # Backend-specific sequence_lengths (FlashInfer).
+        metadata["sequence_lengths"] = MMEncoderAttention.maybe_compute_seq_lens(
+            self.attn_backend, cu_seqlens_np, device
+        )
+
+        # max_seqlen — kept on CPU so attention wrappers that call
+        # ``.item()`` don't induce a D2H sync in the captured graph
+        # (the scalar is baked at capture time; capture must pick a
+        # value >= any replay-time max seqlen).
+        if max_seqlen_override is not None:
+            max_seqlen_val = max_seqlen_override
+        else:
+            max_seqlen_val = MMEncoderAttention.compute_max_seqlen(
+                self.attn_backend, cu_seqlens_np
+            )
+        metadata["max_seqlen"] = torch.tensor(max_seqlen_val, dtype=torch.int32)
+
+        # cu_seqlens may also get backend-specific rewrites (FlashInfer).
+        metadata["cu_seqlens"] = MMEncoderAttention.maybe_recompute_cu_seqlens(
+            self.attn_backend,
+            cu_seqlens_np,
+            self.hidden_size,
+            self.tp_size,
+            device,
+        )
+
+        # Indexed tpool buffers (sized to worst case).
+        total_output_slots = sum((h // kh) * (w // kw) for t, h, w in shapes)
+        max_post_tpool_patches = sum(h * w for t, h, w in shapes)
+        if max_output_slots is None:
+            max_output_slots = total_output_slots
+        # post-tpool slots scale with h*w per item; align with output slots
+        # upper bound so replays with smaller inputs still fit.
+        max_post_tpool_patches = max(max_post_tpool_patches, max_output_slots * kh * kw)
+
+        (
+            temporal_gather_idx_np,
+            temporal_divisor_np,
+            spatial_gather_idx_np,
+        ) = _build_tpool_indices(
+            shapes,
+            kh=kh,
+            kw=kw,
+            max_total_patches=max_total_patches,
+            max_post_tpool_patches=max_post_tpool_patches,
+            max_output_slots=max_output_slots,
+        )
+
+        metadata["tpool_temporal_gather_idx"] = torch.from_numpy(
+            temporal_gather_idx_np
+        ).to(device=device, non_blocking=True)
+        metadata["tpool_temporal_divisor"] = torch.from_numpy(temporal_divisor_np).to(
+            device=device, non_blocking=True
+        )
+        metadata["tpool_spatial_gather_idx"] = torch.from_numpy(
+            spatial_gather_idx_np
+        ).to(device=device, non_blocking=True)
+
+        return metadata
+
     def forward(
-        self, pixel_values: torch.Tensor, grid_thws: torch.Tensor
-    ) -> torch.Tensor:
+        self,
+        pixel_values: torch.Tensor,
+        grid_thws: torch.Tensor,
+        *,
+        encoder_metadata: dict[str, torch.Tensor | None] | None = None,
+    ) -> torch.Tensor | list[torch.Tensor]:
         """
         Args:
             pixel_values (torch.Tensor): The input pixel values.
             grid_thws (torch.Tensor): Temporal, height and width.
+            encoder_metadata: precomputed buffers for CUDA graph replay.
+                When provided, the encoder and the patch merger read
+                from these buffers instead of computing per-batch state,
+                and the merger returns a packed ``(max_slots, kh*kw, d)``
+                tensor.  When ``None`` the eager per-item list output is
+                returned (unchanged from before this feature).
 
         Returns:
-            torch.Tensor: The output tokens.
+            List of per-item tensors in eager mode; a single
+            ``(max_slots, kh*kw, hidden)`` tensor in graph mode.
         """
-        hidden_states = self.patch_embed(pixel_values, grid_thws)
-        hidden_states = self.encoder(hidden_states, grid_thws)
-        if (
-            self.merge_type == "sd2_tpool"
-        ):  # spatial downsampling 2x with temporal pooling all
-            hidden_states = tpool_patch_merger(
-                hidden_states, grid_thws, merge_kernel_size=self.merge_kernel_size
-            )
-        else:
+        pos_embeds = None
+        if encoder_metadata is not None:
+            pos_embeds = encoder_metadata.get("pos_embeds")
+
+        hidden_states = self.patch_embed(pixel_values, grid_thws, pos_embeds=pos_embeds)
+        hidden_states = self.encoder(
+            hidden_states, grid_thws, encoder_metadata=encoder_metadata
+        )
+        if self.merge_type != "sd2_tpool":
             raise NotImplementedError(f"Not support {self.merge_type}")
 
-        return hidden_states
+        kh, kw = self.merge_kernel_size
+        if encoder_metadata is None:
+            return tpool_patch_merger(
+                hidden_states, grid_thws, merge_kernel_size=self.merge_kernel_size
+            )
+        return tpool_patch_merger_indexed(hidden_states, encoder_metadata, kh=kh, kw=kw)
 
 
 @torch.inference_mode()

--- a/vllm/model_executor/models/kimi_k25_vit.py
+++ b/vllm/model_executor/models/kimi_k25_vit.py
@@ -603,6 +603,22 @@ class MoonViT3dEncoder(nn.Module):
             f'video_attn_type must be "spatial_temporal", got {video_attn_type}'
         )
         self.video_attn_type = video_attn_type
+        # Cached encoder-shape fields so the (eager) forward can ask
+        # ``MMEncoderAttention`` for backend-specific metadata rewrites
+        # (FlashInfer ``cu_seqlens`` recomputation, ``sequence_lengths``
+        # padding, bucketed ``max_seqlen``) without a round-trip to the
+        # parent module.
+        self.hidden_size = hidden_dim
+        head_size = block_cfg["hidden_dim"] // block_cfg["num_heads"]
+        self.tp_size = (
+            1
+            if is_vit_use_data_parallel()
+            else get_tensor_model_parallel_world_size()
+        )
+        self.attn_backend = get_vit_attn_backend(
+            head_size=head_size,
+            dtype=torch.get_default_dtype(),
+        )
         self.rope_2d = Rope2DPosEmbRepeated(
             block_cfg["hidden_dim"] // block_cfg["num_heads"], 512, 512
         )
@@ -630,18 +646,44 @@ class MoonViT3dEncoder(nn.Module):
                 grid_thws=grid_thws, device=hidden_states.device
             )
 
-            lengths = torch.cat(
-                (
-                    torch.zeros(1, dtype=grid_thws.dtype, device=grid_thws.device),
-                    grid_thws[:, 0] * grid_thws[:, 1] * grid_thws[:, 2],
+            # Build cu_seqlens in numpy so we can feed it through the
+            # backend-aware MMEncoderAttention helpers (FlashInfer needs
+            # ``sequence_lengths`` + rewritten ``cu_seqlens`` + bucketed
+            # ``max_seqlen`` — if we hand it a bare CUDA tensor those
+            # helpers are never invoked and it asserts).
+            shapes_np = (
+                grid_thws.detach().cpu().numpy()
+                if isinstance(grid_thws, torch.Tensor)
+                else np.asarray(grid_thws, dtype=np.int32)
+            )
+            patches_per_frame = np.repeat(
+                (shapes_np[:, 1] * shapes_np[:, 2]).astype(np.int32),
+                shapes_np[:, 0].astype(np.int64),
+            )
+            if patches_per_frame.size > 0:
+                cu_seqlens_np = np.concatenate(
+                    [
+                        np.zeros(1, dtype=np.int32),
+                        patches_per_frame.cumsum(dtype=np.int32),
+                    ]
                 )
+            else:
+                cu_seqlens_np = np.zeros(1, dtype=np.int32)
+            device = hidden_states.device
+            sequence_lengths = MMEncoderAttention.maybe_compute_seq_lens(
+                self.attn_backend, cu_seqlens_np, device
             )
-
-            cu_seqlens = lengths.to(hidden_states.device).cumsum(
-                dim=0, dtype=torch.int32
+            max_seqlen_val = MMEncoderAttention.compute_max_seqlen(
+                self.attn_backend, cu_seqlens_np
             )
-            max_seqlen = None
-            sequence_lengths = None
+            max_seqlen = torch.tensor(max_seqlen_val, dtype=torch.int32)
+            cu_seqlens = MMEncoderAttention.maybe_recompute_cu_seqlens(
+                self.attn_backend,
+                cu_seqlens_np,
+                self.hidden_size,
+                self.tp_size,
+                device,
+            )
         else:
             rope_freqs_cis = encoder_metadata["rope_freqs_cis"]
             cu_seqlens = encoder_metadata["cu_seqlens"]

--- a/vllm/v1/worker/encoder_cudagraph.py
+++ b/vllm/v1/worker/encoder_cudagraph.py
@@ -133,9 +133,26 @@ class EncoderCudaGraphManager:
         return modality in self.config.modalities
 
     def capture(self):
-        """Capture CUDA graphs for all token budgets."""
-        for token_budget in self.token_budgets:
+        """Capture CUDA graphs for all token budgets.
+
+        All budget graphs share a single CUDA graph memory pool so the
+        peak allocation is driven by the largest budget rather than the
+        sum across budgets. Capture is run largest-first so the pool is
+        sized once at its high-water-mark and all subsequent smaller
+        captures allocate in-place.
+        """
+        # Allocate one shared memory pool for every encoder graph. The
+        # torch.cuda.graph(graph, pool=...) context reuses this pool,
+        # so the N budgets overlap their working memory instead of each
+        # holding a private ~hundreds-of-MB arena.
+        self._graph_pool = torch.cuda.graph_pool_handle()
+
+        for token_budget in sorted(self.token_budgets, reverse=True):
             self._capture_budget_graph(token_budget)
+            # Return any transient allocations to the allocator between
+            # captures so the pool's peak watermark is bounded by a
+            # single graph, not the cumulative sum.
+            torch.cuda.empty_cache()
 
         logger.info(
             "Encoder CUDA graph capture complete. Captured %d budget graphs.",
@@ -168,7 +185,10 @@ class EncoderCudaGraphManager:
             output_buffer = torch.empty_like(output)
 
         graph = torch.cuda.CUDAGraph()
-        with torch.inference_mode(), torch.cuda.graph(graph):
+        with (
+            torch.inference_mode(),
+            torch.cuda.graph(graph, pool=getattr(self, "_graph_pool", None)),
+        ):
             output = self.model.encoder_cudagraph_forward(mm_kwargs, buffers)
             output_buffer.copy_(output)
 


### PR DESCRIPTION



## Purpose

## Test Plan

## Test Result

### FLASH_ATTN

- w/ encoder cuda graph
  
```
MM Processor Metrics:
                     Stage  Mean Median   Std P99.0
          get_mm_hashes_ms  0.70   0.70  0.33  1.48
get_cache_missing_items_ms  0.01   0.01  0.00  0.02
     apply_hf_processor_ms 19.13  19.00 10.24 40.81
        merge_mm_kwargs_ms  0.06   0.05  0.09  0.24
   apply_prompt_updates_ms  0.09   0.09  0.02  0.14
     preprocessor_total_ms 20.00  19.86 10.56 42.37
        encoder_forward_ms 13.13  10.62  8.25 45.30
         num_encoder_calls  1.03   1.00  0.17  2.00

Summary: 3054 total encoder calls across 2962 requests.

End-to-End Latency (ms):
Metric Value (ms)
  Mean  300588.86
Median  304154.16
   Std   82785.62
 P99.0  398495.99
```

- w/o encoder cuda graph
  
```
MM Processor Metrics:
                     Stage  Mean Median   Std P99.0
          get_mm_hashes_ms  0.71   0.69  0.35  1.47
get_cache_missing_items_ms  0.02   0.02  0.00  0.03
     apply_hf_processor_ms 19.23  19.25 10.33 41.24
        merge_mm_kwargs_ms  0.07   0.05  0.13  0.23
   apply_prompt_updates_ms  0.09   0.09  0.03  0.16
     preprocessor_total_ms 20.12  20.14 10.65 42.86
        encoder_forward_ms  7.74   6.24  5.15 24.71
         num_encoder_calls  1.03   1.00  0.17  2.00

Summary: 3052 total encoder calls across 2962 requests.

End-to-End Latency (ms):
Metric Value (ms)
  Mean  289179.94
Median  291501.69
   Std   78007.63
 P99.0  382060.96
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

