### PR TITLE
docs: remove outdated LD_PRELOAD instructions [CPU-Backend]

### DIFF
--- a/docs/getting_started/installation/cpu.arm.inc.md
+++ b/docs/getting_started/installation/cpu.arm.inc.md
@@ -28,19 +28,21 @@ uv pip install https://github.com/vllm-project/vllm/releases/download/v${VLLM_VE
     pip install https://github.com/vllm-project/vllm/releases/download/v${VLLM_VERSION}/vllm-${VLLM_VERSION}+cpu-cp38-abi3-manylinux_2_35_aarch64.whl
     ```
 
-!!! warning "set `LD_PRELOAD`"
-    Before use vLLM CPU installed via wheels, make sure TCMalloc is installed and added to `LD_PRELOAD`:
-    ```bash
-    # install TCMalloc
-    sudo apt-get install -y --no-install-recommends libtcmalloc-minimal4
+#### Runtime Performance Optimization
 
-    # manually find the path
-    sudo find / -iname *libtcmalloc_minimal.so.4
-    TC_PATH=...
+Manual configuration of `LD_PRELOAD` is no longer required for standard installations.
 
-    # add them to LD_PRELOAD
-    export LD_PRELOAD="$TC_PATH:$LD_PRELOAD"
-    ```
+##### What vLLM Configures Automatically
+
+- **Memory Allocation (TCMalloc)**  
+  vLLM attempts to locate and preload `libtcmalloc` to reduce memory allocation overhead and fragmentation.  
+  If available in the Python environment or system paths, it is applied automatically.
+- **Parallelism (OpenMP)**  
+  vLLM detects the appropriate OpenMP runtime:
+  - `libiomp5` for x86 (Intel/AMD)
+  - `libgomp` for ARM and PowerPC  
+- **Thread Binding**  
+  CPU thread affinity is configured automatically to reduce context switching and improve cache locality.
 
 The `uv` approach works for vLLM `v0.6.6` and later. A unique feature of `uv` is that packages in `--extra-index-url` have [higher priority than the default index](https://docs.astral.sh/uv/pip/compatibility/#packages-that-exist-on-multiple-indexes). If the latest public release is `v0.6.6.post1`, `uv`'s behavior allows installing a commit before `v0.6.6.post1` by specifying the `--extra-index-url`. In contrast, `pip` combines packages from `--extra-index-url` and the default index, choosing only the latest version, which makes it difficult to install a development version prior to the released version.
 
@@ -121,19 +123,21 @@ VLLM_TARGET_DEVICE=cpu uv pip install -e . --no-build-isolation
 
 Testing has been conducted on AWS Graviton3 instances for compatibility.
 
-!!! warning "set `LD_PRELOAD`"
-    Before use vLLM CPU installed via wheels, make sure TCMalloc is installed and added to `LD_PRELOAD`:
-    ```bash
-    # install TCMalloc
-    sudo apt-get install -y --no-install-recommends libtcmalloc-minimal4
+#### Runtime Performance Optimization
 
-    # manually find the path
-    sudo find / -iname *libtcmalloc_minimal.so.4
-    TC_PATH=...
+Manual configuration of `LD_PRELOAD` is no longer required for standard installations.
 
-    # add them to LD_PRELOAD
-    export LD_PRELOAD="$TC_PATH:$LD_PRELOAD"
-    ```
+##### What vLLM Configures Automatically
+
+- **Memory Allocation (TCMalloc)**  
+  vLLM attempts to locate and preload `libtcmalloc` to reduce memory allocation overhead and fragmentation.  
+  If available in the Python environment or system paths, it is applied automatically.
+- **Parallelism (OpenMP)**  
+  vLLM detects the appropriate OpenMP runtime:
+  - `libiomp5` for x86 (Intel/AMD)
+  - `libgomp` for ARM and PowerPC  
+- **Thread Binding**  
+  CPU thread affinity is configured automatically to reduce context switching and improve cache locality.
 
 --8<-- [end:build-wheel-from-source]
 --8<-- [start:pre-built-images]

--- a/docs/getting_started/installation/cpu.x86.inc.md
+++ b/docs/getting_started/installation/cpu.x86.inc.md
@@ -32,21 +32,21 @@ uv pip install https://github.com/vllm-project/vllm/releases/download/v${VLLM_VE
     # use pip
     pip install https://github.com/vllm-project/vllm/releases/download/v${VLLM_VERSION}/vllm-${VLLM_VERSION}+cpu-cp38-abi3-manylinux_2_35_x86_64.whl --extra-index-url https://download.pytorch.org/whl/cpu
     ```
-!!! warning "set `LD_PRELOAD`"
-    Before use vLLM CPU installed via wheels, make sure TCMalloc and Intel OpenMP are installed and added to `LD_PRELOAD`:
-    ```bash
-    # install TCMalloc, Intel OpenMP is installed with vLLM CPU
-    sudo apt-get install -y --no-install-recommends libtcmalloc-minimal4
+#### Runtime Performance Optimization
 
-    # manually find the path
-    sudo find / -iname *libtcmalloc_minimal.so.4
-    sudo find / -iname *libiomp5.so
-    TC_PATH=...
-    IOMP_PATH=...
+Manual configuration of `LD_PRELOAD` is no longer required for standard installations.
 
-    # add them to LD_PRELOAD
-    export LD_PRELOAD="$TC_PATH:$IOMP_PATH:$LD_PRELOAD"
-    ```
+##### What vLLM Configures Automatically
+
+- **Memory Allocation (TCMalloc)**  
+  vLLM attempts to locate and preload `libtcmalloc` to reduce memory allocation overhead and fragmentation.  
+  If available in the Python environment or system paths, it is applied automatically.
+- **Parallelism (OpenMP)**  
+  vLLM detects the appropriate OpenMP runtime:
+  - `libiomp5` for x86 (Intel/AMD)
+  - `libgomp` for ARM and PowerPC  
+- **Thread Binding**  
+  CPU thread affinity is configured automatically to reduce context switching and improve cache locality.
 
 #### Install the latest code
 
@@ -130,21 +130,21 @@ uv pip install dist/*.whl
     pip install dist/*.whl
     ```
 
-!!! warning "set `LD_PRELOAD`"
-    Before use vLLM CPU installed via wheels, make sure TCMalloc and Intel OpenMP are installed and added to `LD_PRELOAD`:
-    ```bash
-    # install TCMalloc, Intel OpenMP is installed with vLLM CPU
-    sudo apt-get install -y --no-install-recommends libtcmalloc-minimal4
+#### Runtime Performance Optimization
 
-    # manually find the path
-    sudo find / -iname *libtcmalloc_minimal.so.4
-    sudo find / -iname *libiomp5.so
-    TC_PATH=...
-    IOMP_PATH=...
+Manual configuration of `LD_PRELOAD` is no longer required for standard installations.
 
-    # add them to LD_PRELOAD
-    export LD_PRELOAD="$TC_PATH:$IOMP_PATH:$LD_PRELOAD"
-    ```
+##### What vLLM Configures Automatically
+
+- **Memory Allocation (TCMalloc)**  
+  vLLM attempts to locate and preload `libtcmalloc` to reduce memory allocation overhead and fragmentation.  
+  If available in the Python environment or system paths, it is applied automatically.
+- **Parallelism (OpenMP)**  
+  vLLM detects the appropriate OpenMP runtime:
+  - `libiomp5` for x86 (Intel/AMD)
+  - `libgomp` for ARM and PowerPC  
+- **Thread Binding**  
+  CPU thread affinity is configured automatically to reduce context switching and improve cache locality.
 
 !!! example "Troubleshooting"
     - **NumPy ≥2.0 error**: Downgrade using `pip install "numpy<2.0"`.


### PR DESCRIPTION



## Purpose
In the PR #37607 , for the new wheels there's no longer a need of `LD_PRELOAD` , updated the docs for the same instruction
cc @fadara01

## Test Plan
None
## Test Result
None (how do i test this?)

---
Changed the docs to notify the new functionality and a short summary of whats happening under the hood now

PS : This is my first PR , apologies if any mistakes 

---

