### PR TITLE
[Bugfix] Gemma-4: Add bnb QuantState alias hook on k_eq_v to load Gemma-4 BNB 4-bit weights

### DIFF
--- a/vllm/model_executor/model_loader/bitsandbytes_loader.py
+++ b/vllm/model_executor/model_loader/bitsandbytes_loader.py
@@ -800,6 +800,23 @@ class BitsAndBytesModelLoader(BaseModelLoader):
                     "Following weights were not initialized from "
                     f"checkpoint: {weights_not_loaded}"
                 )
+
+        # Models can declare `get_bnb_quant_state_aliases() -> {alias: src}`
+        # when one checkpoint weight backs multiple module slots (e.g.,
+        # Gemma-4 k_eq_v full_attention layers, where v_proj is absent
+        # and V is loaded from k_proj). The model's load_weights copies
+        # the packed uint8 buffer into each slot; this hook also aliases
+        # the per-slot QuantState so all shards appear in the packed
+        # parameter's bnb_shard_offsets.
+        get_aliases = getattr(model, "get_bnb_quant_state_aliases", None)
+        if get_aliases is not None:
+            for alias_name, source_name in get_aliases().items():
+                if alias_name in quant_state_dict:
+                    continue
+                source_state = quant_state_dict.get(source_name)
+                if source_state is not None:
+                    quant_state_dict[alias_name] = source_state
+
         expert_quant_state_dict = self._fuse_moe_quant_states(model, quant_state_dict)
 
         stacked_quant_state_dict = self._stack_quantization_states(

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -399,31 +399,18 @@ class Gemma4Attention(nn.Module):
         # Q/K norms with learnable weights handle scaling implicitly.
         self.scaling = 1.0
 
-        if self.use_k_eq_v:
-            self.q_proj = ColumnParallelLinear(
-                hidden_size,
-                self.total_num_heads * self.head_dim,
-                bias=config.attention_bias,
-                quant_config=quant_config,
-                prefix=f"{prefix}.q_proj",
-            )
-            self.k_proj = ColumnParallelLinear(
-                hidden_size,
-                self.total_num_kv_heads * self.head_dim,
-                bias=config.attention_bias,
-                quant_config=quant_config,
-                prefix=f"{prefix}.k_proj",
-            )
-        else:
-            self.qkv_proj = QKVParallelLinear(
-                hidden_size,
-                self.head_dim,
-                self.total_num_heads,
-                self.total_num_kv_heads,
-                bias=config.attention_bias,
-                quant_config=quant_config,
-                prefix=f"{prefix}.qkv_proj",
-            )
+        # QKVParallelLinear handles GQA correctly for all layer types.
+        # k_eq_v layers load K weights into both K and V slots via
+        # _weight_iterator remapping — no structural difference needed.
+        self.qkv_proj = QKVParallelLinear(
+            hidden_size,
+            self.head_dim,
+            self.total_num_heads,
+            self.total_num_kv_heads,
+            bias=config.attention_bias,
+            quant_config=quant_config,
+            prefix=f"{prefix}.qkv_proj",
+        )
         self.o_proj = RowParallelLinear(
             self.total_num_heads * self.head_dim,
             hidden_size,
@@ -516,13 +503,11 @@ class Gemma4Attention(nn.Module):
         hidden_states: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
-        if self.use_k_eq_v:
-            q, _ = self.q_proj(hidden_states)
-            k, _ = self.k_proj(hidden_states)
-            v = k
-        else:
-            qkv, _ = self.qkv_proj(hidden_states)
-            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        # Unified QKV path (works for both k_eq_v and standard layers).
+        # For k_eq_v, K weights are loaded into both K and V slots of
+        # qkv_proj, so V == K automatically.
+        qkv, _ = self.qkv_proj(hidden_states)
+        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
         # Q norm (always applied)
         q = q.unflatten(-1, (self.num_heads, self.head_dim))
@@ -1627,11 +1612,35 @@ class Gemma4ForCausalLM(
     ) -> torch.Tensor | None:
         return self.logits_processor(self.lm_head, hidden_states)
 
+    def get_bnb_quant_state_aliases(self) -> dict[str, str]:
+        # See Gemma4ForConditionalGeneration.get_bnb_quant_state_aliases.
+        # Used when this class is loaded as the top-level model (text-only
+        # path); the checkpoint prefix is just `model.*` here.
+        if not getattr(self.config, "attention_k_eq_v", False):
+            return {}
+        aliases: dict[str, str] = {}
+        for idx, layer_type in enumerate(self.config.layer_types):
+            if layer_type != "full_attention":
+                continue
+            prefix = f"model.layers.{idx}.self_attn"
+            aliases[f"{prefix}.v_proj.weight"] = f"{prefix}.k_proj.weight"
+        return aliases
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         # Checkpoint weight names use "language_model." prefix (from the
         # Gemma4ForConditionalGeneration wrapper). Strip it to map to our
         # model tree which is just "model.*".
         def _weight_iterator():
+            use_k_eq_v = getattr(self.config, "attention_k_eq_v", False)
+            # Build set of k_eq_v layer indices (full_attention layers
+            # when attention_k_eq_v is enabled). These layers have k_proj
+            # but no v_proj in checkpoint — we duplicate k_proj as v_proj.
+            k_eq_v_layer_indices: set[int] = set()
+            if use_k_eq_v:
+                for idx, lt in enumerate(self.config.layer_types):
+                    if lt == "full_attention":
+                        k_eq_v_layer_indices.add(idx)
+
             for name, weight in weights:
                 # Remap "language_model." → "" to match our model tree.
                 # Checkpoint: model.language_model.layers.X.*
@@ -1693,6 +1702,18 @@ class Gemma4ForCausalLM(
                         expert_name = name.replace("moe.", f"moe.experts.{expert_id}.")
                         yield expert_name, weight[expert_id]
                     continue
+
+                # k_eq_v layers: checkpoint has k_proj but no v_proj.
+                # QKVParallelLinear expects both, so duplicate k_proj
+                # as v_proj so V gets identical weights to K.
+                # ONLY for full_attention layers — sliding layers have
+                # their own real v_proj weights.
+                if "self_attn.k_proj" in name and k_eq_v_layer_indices:
+                    m = re.search(r"layers\.(\d+)\.", name)
+                    if m and int(m.group(1)) in k_eq_v_layer_indices:
+                        yield name, weight
+                        yield name.replace("k_proj", "v_proj"), weight.clone()
+                        continue
 
                 yield name, weight
 

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -399,18 +399,31 @@ class Gemma4Attention(nn.Module):
         # Q/K norms with learnable weights handle scaling implicitly.
         self.scaling = 1.0
 
-        # QKVParallelLinear handles GQA correctly for all layer types.
-        # k_eq_v layers load K weights into both K and V slots via
-        # _weight_iterator remapping — no structural difference needed.
-        self.qkv_proj = QKVParallelLinear(
-            hidden_size,
-            self.head_dim,
-            self.total_num_heads,
-            self.total_num_kv_heads,
-            bias=config.attention_bias,
-            quant_config=quant_config,
-            prefix=f"{prefix}.qkv_proj",
-        )
+        if self.use_k_eq_v:
+            self.q_proj = ColumnParallelLinear(
+                hidden_size,
+                self.total_num_heads * self.head_dim,
+                bias=config.attention_bias,
+                quant_config=quant_config,
+                prefix=f"{prefix}.q_proj",
+            )
+            self.k_proj = ColumnParallelLinear(
+                hidden_size,
+                self.total_num_kv_heads * self.head_dim,
+                bias=config.attention_bias,
+                quant_config=quant_config,
+                prefix=f"{prefix}.k_proj",
+            )
+        else:
+            self.qkv_proj = QKVParallelLinear(
+                hidden_size,
+                self.head_dim,
+                self.total_num_heads,
+                self.total_num_kv_heads,
+                bias=config.attention_bias,
+                quant_config=quant_config,
+                prefix=f"{prefix}.qkv_proj",
+            )
         self.o_proj = RowParallelLinear(
             self.total_num_heads * self.head_dim,
             hidden_size,
@@ -503,11 +516,13 @@ class Gemma4Attention(nn.Module):
         hidden_states: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
-        # Unified QKV path (works for both k_eq_v and standard layers).
-        # For k_eq_v, K weights are loaded into both K and V slots of
-        # qkv_proj, so V == K automatically.
-        qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        if self.use_k_eq_v:
+            q, _ = self.q_proj(hidden_states)
+            k, _ = self.k_proj(hidden_states)
+            v = k
+        else:
+            qkv, _ = self.qkv_proj(hidden_states)
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
         # Q norm (always applied)
         q = q.unflatten(-1, (self.num_heads, self.head_dim))
@@ -1617,16 +1632,6 @@ class Gemma4ForCausalLM(
         # Gemma4ForConditionalGeneration wrapper). Strip it to map to our
         # model tree which is just "model.*".
         def _weight_iterator():
-            use_k_eq_v = getattr(self.config, "attention_k_eq_v", False)
-            # Build set of k_eq_v layer indices (full_attention layers
-            # when attention_k_eq_v is enabled). These layers have k_proj
-            # but no v_proj in checkpoint — we duplicate k_proj as v_proj.
-            k_eq_v_layer_indices: set[int] = set()
-            if use_k_eq_v:
-                for idx, lt in enumerate(self.config.layer_types):
-                    if lt == "full_attention":
-                        k_eq_v_layer_indices.add(idx)
-
             for name, weight in weights:
                 # Remap "language_model." → "" to match our model tree.
                 # Checkpoint: model.language_model.layers.X.*
@@ -1688,18 +1693,6 @@ class Gemma4ForCausalLM(
                         expert_name = name.replace("moe.", f"moe.experts.{expert_id}.")
                         yield expert_name, weight[expert_id]
                     continue
-
-                # k_eq_v layers: checkpoint has k_proj but no v_proj.
-                # QKVParallelLinear expects both, so duplicate k_proj
-                # as v_proj so V gets identical weights to K.
-                # ONLY for full_attention layers — sliding layers have
-                # their own real v_proj weights.
-                if "self_attn.k_proj" in name and k_eq_v_layer_indices:
-                    m = re.search(r"layers\.(\d+)\.", name)
-                    if m and int(m.group(1)) in k_eq_v_layer_indices:
-                        yield name, weight
-                        yield name.replace("k_proj", "v_proj"), weight.clone()
-                        continue
 
                 yield name, weight
 

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -1331,6 +1331,26 @@ class Gemma4ForConditionalGeneration(
     # Weight loading
     # ------------------------------------------------------------------ #
 
+    def get_bnb_quant_state_aliases(self) -> dict[str, str]:
+        # k_eq_v full_attention layers ship no v_proj in the checkpoint;
+        # _weight_iterator copies the k_proj packed buffer into qkv_proj's
+        # V slot, but the bnb QuantState dict is keyed by checkpoint name
+        # and has no v_proj entry. Alias the v_proj QuantState to k_proj's
+        # so the packed parameter's bnb_shard_offsets cover all 3 shards.
+        # Keys use the post-mapper layout (`language_model.model.*`)
+        # since the bnb loader populates quant_state_dict from mapped
+        # names.
+        text_cfg = self.config.text_config
+        if not getattr(text_cfg, "attention_k_eq_v", False):
+            return {}
+        aliases: dict[str, str] = {}
+        for idx, layer_type in enumerate(text_cfg.layer_types):
+            if layer_type != "full_attention":
+                continue
+            prefix = f"language_model.model.layers.{idx}.self_attn"
+            aliases[f"{prefix}.v_proj.weight"] = f"{prefix}.k_proj.weight"
+        return aliases
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         # Some checkpoints have vestigial embed_vision.embedding and
         # embed_audio.embedding weights from the Gemma3n architecture


### PR DESCRIPTION
This PR has been verified by issue raiser to be effective. 

## Purpose
Closes vllm-project/vllm#40437. 

When we load a Gemma 4 checkpoint that uses `--quantization bitsandbytes` and `attention_k_eq_v=true`, like `unsloth/gemma-4-31B-it-unsloth-bnb-4bit` and `unsloth/gemma-4-31B-unsloth-bnb-4bit` , vllm crashes. 

This is because for these models, the `full_attention` layers ship only `q_proj` and `k_proj` in the checkpoint. `v_proj` is omitted because V is identical to K by design. So on the main branch, when `BitsAndBytesModelLoader` builds a`QuantState` dict, it cannot register`v_proj` entries. So the quantised dimension `q_size + k_size = 16384 + 2048 = 18432`, instead of `q_size + k_size + v_size = 16384 + 2048 + 2048 = 20480`, resulting in a mismatch.

To fix it, we let gemma 4 declare some alias that needs to be copied into `QuantState`, including `k_proj` and `v_proj`. Then we let `BitsAndBytesModelLoader` pick up these alias, so `v_proj` information will be included. 

Note that we should not edit gemma 4 files to load k and v separately as done in https://github.com/vllm-project/vllm/pull/40606/commits/ed2bab8a1ed9a9391703e6c14e04eed124cb034a, it will break GQA as pointed out by [review bot comment](https://github.com/vllm-project/vllm/pull/40606#discussion_r3123315801). So this is the only way to fix it
 

## Test Plan

run the following:
```
CUDA_VISIBLE_DEVICES=0 python -m vllm.entrypoints.openai.api_server \
    --model /root/models/gemma-4-31B-it-unsloth-bnb-4bit \                                                                               
    --gpu-memory-utilization 0.6 --max-model-len 16392 \                                                                                 
    --port 18003 --max-num-seqs 1 \                                                                                                      
    --enforce-eager --quantization bitsandbytes
```

## Test Result

<details><summary> before fix : EngineCore crashes during profile_run. </summary>
                                                            
  ```                                                                                                                                    
  INFO 04-22 09:02:32 [gpu_model_runner.py:4820] Model loading took 19.61 GiB memory and 7.13 seconds
  INFO 04-22 09:02:32 [gpu_model_runner.py:5753] Encoder cache will be initialized with a budget of 8192 tokens, ...                     
  ERROR 04-22 09:02:33 [core.py:1108] EngineCore failed to start.                                                                        
  ERROR 04-22 09:02:33 [core.py:1108] Traceback (most recent call last):                                                                 
  ...                                                                                                                                    
  ERROR 04-22 09:02:33 [core.py:1108]   File "/usr/local/lib/python3.11/dist-packages/vllm/v1/worker/gpu_worker.py", line 370, in        
  determine_available_memory                                                                                                             
  ERROR 04-22 09:02:33 [core.py:1108]     self.model_runner.profile_run()
  ERROR 04-22 09:02:33 [core.py:1108]   File "/usr/local/lib/python3.11/dist-packages/vllm/v1/worker/gpu_model_runner.py", line 5782, in 
  profile_run                                                                                                                            
  ERROR 04-22 09:02:33 [core.py:1108]     hidden_states, last_hidden_states = self._dummy_run(                                           
  ERROR 04-22 09:02:33 [core.py:1108]   File "/usr/local/lib/python3.11/dist-packages/vllm/model_executor/models/gemma4_mm.py", line     
  1312, in forward                                                                                                                       
  ERROR 04-22 09:02:33 [core.py:1108]     hidden_states = self.language_model.model(...)                                                 
  ERROR 04-22 09:02:33 [core.py:1108]   File "/usr/local/lib/python3.11/dist-packages/vllm/model_executor/models/gemma4.py", line 1226,  
  in forward                                                                                                                             
  ERROR 04-22 09:02:33 [core.py:1108]     hidden_states, residual = layer(...)                                                           
  ERROR 04-22 09:02:33 [core.py:1108]   File "/usr/local/lib/python3.11/dist-packages/vllm/model_executor/models/gemma4.py", line 601, in
   forward                                                                                                                               
  ERROR 04-22 09:02:33 [core.py:1108]     hidden_states = self.self_attn(...)                                                            
  ERROR 04-22 09:02:33 [core.py:1108]   File "/usr/local/lib/python3.11/dist-packages/vllm/model_executor/models/gemma4.py", line 405, in
   forward                                                                                                                               
  ERROR 04-22 09:02:33 [core.py:1108]     q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)                         
  ERROR 04-22 09:02:33 [core.py:1108] RuntimeError: split_with_sizes expects split_sizes to sum exactly to 18432                         
                                         (input tensor's size at dimension -1), but got split_sizes=[16384, 2048, 2048]                  
  ```                                                                     
</details>

<details>
<summary> after fix: bnb-4bit version can be used normally. </summary>

 ```console                                                                                                                             
  $ curl -s -X POST http://127.0.0.1:18003/v1/chat/completions \
      -H 'Content-Type: application/json' \
      -d '{"model":"/root/models/gemma-4-31B-it-unsloth-bnb-4bit",                                                                       
           "messages":[{"role":"system","content":"You are a helpful assistant."},
                       {"role":"user","content":"What is the capital of France? Answer in one sentence."}],                              
           "max_tokens":80,"temperature":0}'                
                                                                                                                                         
  The capital of France is Paris.                           
  ```  

</details>

<details>
<summary>  no regression: google/gemma-4-E2B-it still runs. </summary>

```
INFO 04-22 10:38:36 [default_loader.py:384] Loading weights took 1.90 seconds
INFO 04-22 10:38:37 [gpu_model_runner.py:4820] Model loading took 9.89 GiB memory and 2.60 seconds
```
</details>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

