### PR TITLE
[SpecDecode] Fix async proposer synchronization

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4124,6 +4124,22 @@ class GPUModelRunner(
     def sample_tokens(
         self, grammar_output: "GrammarOutput | None"
     ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
+        try:
+            return self._sample_tokens_impl(grammar_output)
+        finally:
+            # Re-record the prepare_inputs_event AFTER sample_tokens
+            # (which includes the spec-decode proposer) so the NEXT
+            # batch's execute_model waits for ALL GPU work from this
+            # step -- not just execute_model but also the proposer.
+            # Without this, the batch queue allows the next batch's
+            # _update_states to modify block tables while the current
+            # batch's proposer is still reading them on the GPU.
+            if self.prepare_inputs_event is not None:
+                self.prepare_inputs_event.record()
+
+    def _sample_tokens_impl(
+        self, grammar_output: "GrammarOutput | None"
+    ) -> ModelRunnerOutput | AsyncModelRunnerOutput | IntermediateTensors:
         if self.execute_model_state is None:
             kv_connector_output = self.kv_connector_output
             self.kv_connector_output = None


### PR DESCRIPTION
## Summary
- move `prepare_inputs_event.record()` so speculative proposer GPU work is included in the synchronization window
- prevent the next async batch from reusing persistent state and block-table-related metadata while proposer work from the previous batch is still in flight

## Context
Tracked from #40608.

## Root cause
This came from debugging `async scheduling + speculative decode` ordering, not from a single clean deterministic stacktrace.

The key issue was the lifetime of `prepare_inputs_event` versus the actual proposer GPU work:
- the event was being recorded from the input-preparation path, which made the step look "finished" too early
- proposer-side GPU work for speculative decode runs later from `sample_tokens()`
- that ordering allowed the next batch to enter `execute_model()` / `_update_states()` and start mutating persistent batch state while the proposer from the previous batch was still reading it on the GPU

In practice this is a concurrency-sensitive race: the failure mode is timing-dependent and can show up as nondeterministic instability / stale state usage rather than one obvious reproducible exception.

The shared state at risk here includes the persistent structures used across batches in the async path, especially block-table-related metadata and other proposer inputs derived from the batch state.

## Why this fix
This patch makes `prepare_inputs_event` represent the full GPU lifetime of the step, not just the input-preparation portion of it.

Concretely, it re-records the event after `sample_tokens()` finishes, which is the point where speculative proposer GPU work has also completed. That closes the race where the next batch could otherwise observe and mutate shared state too early.

I kept the change intentionally small and local to `gpu_model_runner.py` because the regression surface is concurrency-sensitive, and this is the least invasive way to restore the intended happens-before relationship.

## Scope
- `vllm/v1/worker/gpu_model_runner.py`

## Notes
This is kept as a draft PR because the code change is small but the regression surface is concurrency-sensitive.