### PR TITLE
[SpecDecode] Allow draft-specific attention backend and KV dtype

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -5,10 +5,11 @@ import ast
 import copy
 from typing import TYPE_CHECKING, Any, Literal, get_args
 
-from pydantic import Field, SkipValidation, model_validator
+from pydantic import Field, SkipValidation, field_validator, model_validator
 from typing_extensions import Self
 
 from vllm.config import LoadConfig
+from vllm.config.cache import CacheDType
 from vllm.config.kernel import MoEBackend
 from vllm.config.model import ModelConfig
 from vllm.config.parallel import ParallelConfig
@@ -17,6 +18,7 @@ from vllm.logger import init_logger
 from vllm.transformers_utils.config import get_hf_text_config
 from vllm.utils.hashing import safe_hash
 from vllm.utils.import_utils import LazyLoader, has_arctic_inference
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
 if TYPE_CHECKING:
     from transformers import PretrainedConfig
@@ -103,6 +105,12 @@ class SpeculativeConfig:
     inherits the target model's `--moe-backend` setting. Useful when the
     drafter and generator require different MoE kernels (e.g. quantized
     generator with unquantized drafter)."""
+    draft_kv_cache_dtype: CacheDType | None = None
+    """KV cache dtype to use for the draft model. When `None`, the draft
+    model inherits the target model's `--kv-cache-dtype` setting."""
+    draft_attention_backend: AttentionBackendEnum | Literal["auto"] | None = None
+    """Attention backend to use for the draft model. When `None`, the draft
+    model inherits the target model's attention backend."""
     max_model_len: int | None = Field(default=None, ge=1)
     """The maximum model length of the draft model. Used when testing the
     ability to skip speculation for some sequences."""
@@ -194,6 +202,15 @@ class SpeculativeConfig:
     geometrically, calibrated so that the mean rate across all speculative
     positions equals this value. Only used when rejection_sample_method
     is 'synthetic'. Must be in [0, 1]."""
+
+    @field_validator("draft_attention_backend", mode="before")
+    @classmethod
+    def validate_draft_attention_backend_before(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            if value.lower() == "auto":
+                return "auto"
+            return AttentionBackendEnum[value.upper()]
+        return value
 
     def compute_hash(self) -> str:
         """

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -738,6 +738,33 @@ class AttentionImplBase(ABC, Generic[T]):
         )
         return self
 
+    def maybe_override_cp_for_vllm_config(
+        self,
+        vllm_config: "VllmConfig | None",
+    ) -> None:
+        if vllm_config is None:
+            return
+
+        parallel_config = vllm_config.parallel_config
+        if (
+            parallel_config.decode_context_parallel_size <= 1
+            and self.dcp_world_size > 1
+        ):
+            self.dcp_world_size = 1
+            self.dcp_rank = 0
+        if (
+            parallel_config.prefill_context_parallel_size <= 1
+            and self.pcp_world_size > 1
+        ):
+            self.pcp_world_size = 1
+            self.pcp_rank = 0
+
+        self.total_cp_world_size = self.pcp_world_size * self.dcp_world_size
+        self.total_cp_rank = self.pcp_rank * self.dcp_world_size + self.dcp_rank
+        self.need_to_return_lse_for_decode = (
+            self.dcp_world_size > 1 and self.can_return_lse_for_decode
+        )
+
     def process_weights_after_loading(self, act_dtype: torch.dtype):
         pass
 

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -660,19 +660,10 @@ class FlashAttentionImpl(AttentionImpl):
         self.supports_quant_query_input = flash_attn_supports_quant_query_input()
 
         vllm_config = get_current_vllm_config_or_none()
-        if (
-            vllm_config is not None
-            and vllm_config.parallel_config.decode_context_parallel_size <= 1
-            and self.dcp_world_size > 1
-        ):
-            self.dcp_world_size = 1
-            self.dcp_rank = 0
-            self.total_cp_world_size = self.pcp_world_size
-            self.total_cp_rank = self.pcp_rank
-            self.need_to_return_lse_for_decode = False
+        self.maybe_override_cp_for_vllm_config(vllm_config)
         dcp_a2a = (
-            vllm_config is not None
-            and vllm_config.parallel_config.decode_context_parallel_size > 1
+            self.dcp_world_size > 1
+            and vllm_config is not None
             and vllm_config.parallel_config.dcp_comm_backend == "a2a"
         )
         self.dcp_combine = dcp_a2a_lse_reduce if dcp_a2a else cp_lse_ag_out_rs

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -660,6 +660,16 @@ class FlashAttentionImpl(AttentionImpl):
         self.supports_quant_query_input = flash_attn_supports_quant_query_input()
 
         vllm_config = get_current_vllm_config_or_none()
+        if (
+            vllm_config is not None
+            and vllm_config.parallel_config.decode_context_parallel_size <= 1
+            and self.dcp_world_size > 1
+        ):
+            self.dcp_world_size = 1
+            self.dcp_rank = 0
+            self.total_cp_world_size = self.pcp_world_size
+            self.total_cp_rank = self.pcp_rank
+            self.need_to_return_lse_for_decode = False
         dcp_a2a = (
             vllm_config is not None
             and vllm_config.parallel_config.decode_context_parallel_size > 1

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -1296,13 +1296,14 @@ class FlashInferImpl(AttentionImpl):
             and vllm_config is not None
             and not vllm_config.attention_config.disable_flashinfer_q_quantization
         )
+        self.maybe_override_cp_for_vllm_config(vllm_config)
         self.bmm1_scale: float | None = None
         self.bmm2_scale: float | None = None
         self.o_sf_scale: float | None = None
 
         dcp_a2a = (
-            vllm_config is not None
-            and vllm_config.parallel_config.decode_context_parallel_size > 1
+            self.dcp_world_size > 1
+            and vllm_config is not None
             and vllm_config.parallel_config.dcp_comm_backend == "a2a"
         )
         if dcp_a2a:

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -1259,15 +1259,44 @@ class SpecDecodeBaseProposer:
         Subclasses may override to apply additional config changes.
         """
         spec_cfg = self.speculative_config
+        config = replace(
+            self.vllm_config,
+            parallel_config=replace(
+                spec_cfg.draft_parallel_config,
+                rank=self.vllm_config.parallel_config.rank,
+            ),
+            model_config=spec_cfg.draft_model_config,
+        )
         if spec_cfg.moe_backend is not None:
-            return replace(
-                self.vllm_config,
+            config = replace(
+                config,
                 kernel_config=replace(
-                    self.vllm_config.kernel_config,
+                    config.kernel_config,
                     moe_backend=spec_cfg.moe_backend,
                 ),
             )
-        return self.vllm_config
+        if spec_cfg.draft_kv_cache_dtype is not None:
+            config = replace(
+                config,
+                cache_config=replace(
+                    config.cache_config,
+                    cache_dtype=spec_cfg.draft_kv_cache_dtype,
+                ),
+            )
+        if spec_cfg.draft_attention_backend is not None:
+            draft_backend = (
+                None
+                if spec_cfg.draft_attention_backend == "auto"
+                else spec_cfg.draft_attention_backend
+            )
+            config = replace(
+                config,
+                attention_config=replace(
+                    config.attention_config,
+                    backend=draft_backend,
+                ),
+            )
+        return config
 
     def _get_model(self) -> nn.Module:
         """

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -27,7 +27,8 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                     "MTP with cp_kv_cache_interleave_size > 1 is not "
                     f"supported in {layer_impl.__class__.__name__}."
                 )
-            if dcp_size > 1:
+            effective_dcp_size = getattr(layer_impl, "dcp_world_size", dcp_size)
+            if dcp_size > 1 and effective_dcp_size > 1:
                 assert layer_impl.need_to_return_lse_for_decode, (
                     "Decode Context Parallelism (DCP) requires attention "
                     "implementations to return the softmax LSE during decode, "

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -28,6 +28,7 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                     f"supported in {layer_impl.__class__.__name__}."
                 )
             effective_dcp_size = getattr(layer_impl, "dcp_world_size", dcp_size)
+            effective_pcp_size = getattr(layer_impl, "pcp_world_size", pcp_size)
             if dcp_size > 1 and effective_dcp_size > 1:
                 assert layer_impl.need_to_return_lse_for_decode, (
                     "Decode Context Parallelism (DCP) requires attention "
@@ -37,7 +38,7 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                     "--attention-backend or disable DCP."
                 )
 
-            if pcp_size > 1:
+            if pcp_size > 1 and effective_pcp_size > 1:
                 assert layer_impl.supports_pcp, (
                     "PCP requires attention impls' support, "
                     f"but the impl {layer_impl.__class__.__name__} "


### PR DESCRIPTION
## Summary
- allow speculative draft models to use a different attention backend than the target model
- allow speculative draft models to use a different KV-cache dtype than the target model
- plumb the per-draft overrides through EAGLE setup

## Context
Tracked from #40608.

## Why
Kimi serving needs target/draft backend decoupling:
- the target model runs best with `TRITON_MLA`
- some draft models are non-MLA and need a different backend or KV-cache dtype

Without this split, otherwise valid target/draft pairings are forced onto a single backend/dtype choice.

## Scope
- `vllm/config/speculative.py`
- `vllm/v1/spec_decode/eagle.py`
- `vllm/v1/attention/backends/flash_attn.py`
- `vllm/v1/worker/cp_utils.py`

## Notes
Kept as draft for discussion because it broadens speculative-config surface area.
