### PR TITLE
[SpecDecode] Add local argmax helper for Llama Eagle3 drafts

### DIFF
--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -304,6 +304,7 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
             torch.zeros(self.config.draft_vocab_size, dtype=torch.long),
             requires_grad=False,
         )
+        self._has_identity_draft_vocab_mapping = True
 
         self.use_parallel_drafting = vllm_config.speculative_config.parallel_drafting
 
@@ -334,6 +335,15 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
         inputs_embeds: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         return self.model(input_ids, positions, hidden_states, inputs_embeds)
+
+    def get_top_tokens(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor:
+        """Vocab-parallel argmax without gathering full logits when possible."""
+        if not self._has_identity_draft_vocab_mapping:
+            return self.compute_logits(hidden_states).argmax(dim=-1)
+        return self.logits_processor.get_top_tokens(self.lm_head, hidden_states)
 
     def compute_logits(
         self,
@@ -423,3 +433,9 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
             skip_substrs=skip_substrs,
         )
         loader.load_weights(model_weights.items())
+        if includes_draft_id_mapping:
+            self._has_identity_draft_vocab_mapping = bool(
+                not torch.count_nonzero(self.draft_id_to_target_id).item()
+            )
+        else:
+            self._has_identity_draft_vocab_mapping = True

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -340,10 +340,13 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
         self,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
-        """Vocab-parallel argmax without gathering full logits when possible."""
-        if not self._has_identity_draft_vocab_mapping:
-            return self.compute_logits(hidden_states).argmax(dim=-1)
-        return self.logits_processor.get_top_tokens(self.lm_head, hidden_states)
+        """TP-safe vocab-parallel argmax without gathering full logits."""
+        draft_top_tokens = self.logits_processor.get_top_tokens(
+            self.lm_head, hidden_states
+        )
+        if self._has_identity_draft_vocab_mapping:
+            return draft_top_tokens
+        return draft_top_tokens + self.draft_id_to_target_id[draft_top_tokens]
 
     def compute_logits(
         self,


### PR DESCRIPTION
## Summary
- add `get_top_tokens()` support for `LlamaForCausalLMEagle3`
- enable local argmax reduction for Llama-based EAGLE3 drafts when vocab mapping is identity

## Context
Tracked from #40608.

## Why
Large-vocab speculative draft models benefit from reducing TP communication with local argmax reduction. This brings the Llama-based EAGLE3 path in line with the same optimization already being discussed for other draft families.

## Scope
- `vllm/model_executor/models/llama_eagle3.py`

## Related
- complements existing upstream work in #39419 rather than replacing it
