### PR TITLE
[SpecDecode] Add seq-length gate for speculative decode

### DIFF
--- a/vllm/v1/core/sched/async_scheduler.py
+++ b/vllm/v1/core/sched/async_scheduler.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
+
 from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
@@ -14,6 +16,10 @@ class AsyncScheduler(Scheduler):
         super().__init__(*args, **kwargs)
         # reusable read-only placeholder list for speculative decoding.
         self._spec_token_placeholders: list[int] = [-1] * self.num_spec_tokens
+        disable_above = os.getenv("VLLM_SPECULATIVE_DISABLE_ABOVE_SEQ_LEN")
+        self._disable_spec_above_seq_len = (
+            int(disable_above) if disable_above else None
+        )
 
     def _update_after_schedule(self, scheduler_output: SchedulerOutput) -> None:
         super()._update_after_schedule(scheduler_output)
@@ -32,7 +38,14 @@ class AsyncScheduler(Scheduler):
             request.num_output_placeholders += 1 + cur_num_spec_tokens
             # Add placeholders for the new draft/spec tokens.
             # We will update the actual spec token ids in the worker process.
-            request.spec_token_ids = self._spec_token_placeholders
+            if (
+                self._disable_spec_above_seq_len is not None
+                and request.num_computed_tokens
+                >= self._disable_spec_above_seq_len
+            ):
+                request.spec_token_ids = []
+            else:
+                request.spec_token_ids = self._spec_token_placeholders
 
     def _update_request_with_output(
         self, request: Request, new_token_ids: list[int]

--- a/vllm/v1/core/sched/async_scheduler.py
+++ b/vllm/v1/core/sched/async_scheduler.py
@@ -1,12 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import os
-
 from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.request import Request, RequestStatus
+from vllm.v1.spec_decode.utils import get_speculative_disable_above_seq_len
 
 logger = init_logger(__name__)
 
@@ -16,10 +15,7 @@ class AsyncScheduler(Scheduler):
         super().__init__(*args, **kwargs)
         # reusable read-only placeholder list for speculative decoding.
         self._spec_token_placeholders: list[int] = [-1] * self.num_spec_tokens
-        disable_above = os.getenv("VLLM_SPECULATIVE_DISABLE_ABOVE_SEQ_LEN")
-        self._disable_spec_above_seq_len = (
-            int(disable_above) if disable_above else None
-        )
+        self._disable_spec_above_seq_len = get_speculative_disable_above_seq_len()
 
     def _update_after_schedule(self, scheduler_output: SchedulerOutput) -> None:
         super()._update_after_schedule(scheduler_output)

--- a/vllm/v1/spec_decode/utils.py
+++ b/vllm/v1/spec_decode/utils.py
@@ -1,14 +1,36 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import os
+
 import torch
 
+from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.utils import (
     CommonAttentionMetadata,
 )
 
+logger = init_logger(__name__)
+
 PADDING_SLOT_ID = -1
+
+
+def get_speculative_disable_above_seq_len() -> int | None:
+    env_val = os.getenv("VLLM_SPECULATIVE_DISABLE_ABOVE_SEQ_LEN")
+    if not env_val:
+        return None
+    try:
+        value = int(env_val)
+    except ValueError:
+        logger.warning(
+            "Invalid value for VLLM_SPECULATIVE_DISABLE_ABOVE_SEQ_LEN: '%s'. "
+            "Must be an integer. Speculative decoding seq-length gate is "
+            "disabled.",
+            env_val,
+        )
+        return None
+    return value if value > 0 else None
 
 
 def next_power_of_2(n: int) -> int:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4,6 +4,7 @@
 import functools
 import gc
 import itertools
+import os
 import threading
 import time
 from collections import defaultdict
@@ -588,6 +589,19 @@ class GPUModelRunner(
                 self.effective_drafter_max_model_len = draft_config.max_model_len
             else:
                 self.effective_drafter_max_model_len = self.max_model_len
+            draft_disable_above_seq_len = int(
+                os.getenv("VLLM_SPECULATIVE_DISABLE_ABOVE_SEQ_LEN", "0")
+            )
+            if draft_disable_above_seq_len > 0:
+                self.effective_drafter_max_model_len = min(
+                    self.effective_drafter_max_model_len,
+                    draft_disable_above_seq_len,
+                )
+                logger.info(
+                    "Speculative decoding will be disabled for sequence lengths "
+                    "above %d via VLLM_SPECULATIVE_DISABLE_ABOVE_SEQ_LEN.",
+                    self.effective_drafter_max_model_len,
+                )
         self.use_async_spec_decode = (
             self.use_async_scheduling and self.num_spec_tokens > 0
         )
@@ -862,6 +876,14 @@ class GPUModelRunner(
             draft_config = self.speculative_config.draft_model_config
             if draft_config is None or draft_config.max_model_len is None:
                 self.effective_drafter_max_model_len = self.max_model_len
+            draft_disable_above_seq_len = int(
+                os.getenv("VLLM_SPECULATIVE_DISABLE_ABOVE_SEQ_LEN", "0")
+            )
+            if draft_disable_above_seq_len > 0:
+                self.effective_drafter_max_model_len = min(
+                    self.effective_drafter_max_model_len,
+                    draft_disable_above_seq_len,
+                )
 
     def reset_mm_cache(self) -> None:
         """
@@ -4209,6 +4231,19 @@ class GPUModelRunner(
                 spec_decode_common_attn_metadata.max_seq_len + self.num_spec_tokens
                 <= self.effective_drafter_max_model_len
             )
+            # The draft attention metadata can under-report long prompt length for
+            # EAGLE-style decode paths, so also gate on the actual request seq len.
+            if input_fits_in_drafter and self.input_batch.num_reqs > 0:
+                actual_max_seq_len = int(
+                    self.optimistic_seq_lens_cpu[: self.input_batch.num_reqs].max()
+                )
+                # optimistic_seq_lens_cpu already tracks the global request length.
+                # Multiplying by dcp_world_size double-counts context length and
+                # incorrectly disables drafting for DCP runs.
+                if actual_max_seq_len + self.num_spec_tokens > (
+                    self.effective_drafter_max_model_len
+                ):
+                    input_fits_in_drafter = False
             use_gpu_toks = (
                 spec_config.use_eagle()
                 or spec_config.uses_draft_model()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4,7 +4,6 @@
 import functools
 import gc
 import itertools
-import os
 import threading
 import time
 from collections import defaultdict
@@ -179,7 +178,10 @@ from vllm.v1.spec_decode.ngram_proposer_gpu import (
     update_scheduler_for_invalid_drafts,
 )
 from vllm.v1.spec_decode.suffix_decoding import SuffixDecodingProposer
-from vllm.v1.spec_decode.utils import update_num_computed_tokens_for_batch_change
+from vllm.v1.spec_decode.utils import (
+    get_speculative_disable_above_seq_len,
+    update_num_computed_tokens_for_batch_change,
+)
 from vllm.v1.structured_output.utils import apply_grammar_bitmask
 from vllm.v1.utils import CpuGpuBuffer, record_function_or_nullcontext
 from vllm.v1.worker import mamba_utils
@@ -589,8 +591,8 @@ class GPUModelRunner(
                 self.effective_drafter_max_model_len = draft_config.max_model_len
             else:
                 self.effective_drafter_max_model_len = self.max_model_len
-            draft_disable_above_seq_len = int(
-                os.getenv("VLLM_SPECULATIVE_DISABLE_ABOVE_SEQ_LEN", "0")
+            draft_disable_above_seq_len = (
+                get_speculative_disable_above_seq_len() or 0
             )
             if draft_disable_above_seq_len > 0:
                 self.effective_drafter_max_model_len = min(
@@ -876,8 +878,8 @@ class GPUModelRunner(
             draft_config = self.speculative_config.draft_model_config
             if draft_config is None or draft_config.max_model_len is None:
                 self.effective_drafter_max_model_len = self.max_model_len
-            draft_disable_above_seq_len = int(
-                os.getenv("VLLM_SPECULATIVE_DISABLE_ABOVE_SEQ_LEN", "0")
+            draft_disable_above_seq_len = (
+                get_speculative_disable_above_seq_len() or 0
             )
             if draft_disable_above_seq_len > 0:
                 self.effective_drafter_max_model_len = min(


### PR DESCRIPTION
## Summary
- add an opt-in seq-length gate that disables speculative decode above a configured threshold
- make the gate effective both in the scheduler path and in the worker-side drafter fit check

## Context
Tracked from #40608.

## Why
For Kimi MLA long-context workloads, speculative decode can become slower than target-only decoding even when acceptance is healthy. An explicit seq-length gate is a pragmatic way to keep short-context wins without forcing long-context regressions.

## Scope
- `vllm/v1/core/sched/async_scheduler.py`
- `vllm/v1/worker/gpu_model_runner.py`

## Notes
This is intentionally a draft/discussion PR.
The current implementation is an environment-based runtime knob used in local deployment recipes, not a proposed final public API shape.
