### PR TITLE
[Attention] Tune TRITON_MLA for SM120 + FP8 decode

### DIFF
--- a/vllm/v1/attention/backends/mla/triton_mla.py
+++ b/vllm/v1/attention/backends/mla/triton_mla.py
@@ -26,6 +26,8 @@ from vllm.v1.attention.ops.triton_decode_attention import decode_attention_fwd
 
 logger = init_logger(__name__)
 
+SM120_FP8_SINGLE_REQ_MAX_KV_SPLITS = 128
+
 
 class TritonMLABackend(MLACommonBackend):
     supported_dtypes: ClassVar[list[torch.dtype]] = [torch.float16, torch.bfloat16]
@@ -170,6 +172,17 @@ class TritonMLAImpl(MLACommonImpl[MLACommonMetadata]):
             # hardware dependent
             occupancy_multiplier = 2
             max_splits = self._sm_count * occupancy_multiplier
+            # On SM120 with FP8 KV cache, single-request long-context MLA decode
+            # peaks around 128 splits in local benchmarks. Letting the heuristic
+            # scale all the way to hundreds of splits adds stage1/stage2 merge
+            # overhead without improving occupancy.
+            if (
+                B == 1
+                and current_platform.is_cuda()
+                and current_platform.has_device_capability(120)
+                and is_quantized_kv_cache(self.kv_cache_dtype)
+            ):
+                max_splits = min(max_splits, SM120_FP8_SINGLE_REQ_MAX_KV_SPLITS)
             num_kv_splits = min(ideal_splits, max_splits)
 
         # TODO(lucas) Allocate ahead of time

--- a/vllm/v1/attention/ops/triton_decode_attention.py
+++ b/vllm/v1/attention/ops/triton_decode_attention.py
@@ -482,6 +482,15 @@ def _decode_grouped_att_m_fwd(
     kv_group_num = q.shape[1] // k_buffer.shape[-2]
 
     BLOCK_H = 16
+    # SM120 FP8 MLA with BLOCK_H=16 exceeds the 101376 B shared-memory
+    # limit by a narrow margin. Reduce the head tile to keep num_stages=2.
+    if (
+        is_mla
+        and current_platform.is_cuda()
+        and current_platform.has_device_capability(120)
+        and k_buffer.element_size() == 1
+    ):
+        BLOCK_H = 8
     NUM_KV_SPLITS = num_kv_splits
     grid = (
         batch,


### PR DESCRIPTION
## Summary
- cap `num_kv_splits` for `B=1`, `SM120`, `FP8 KV` MLA decode
- reduce `BLOCK_H` for the same narrow configuration

## Context
Tracked from #40608.

## Why
For Blackwell/SM120 MLA decode with FP8 KV cache, the default split heuristic can overshoot and increase split/merge overhead at large local sequence lengths. A narrower `BLOCK_H` setting is also useful for the same configuration.

## Scope
- `vllm/v1/attention/backends/mla/triton_mla.py`
- `vllm/v1/attention/ops/triton_decode_attention.py`

## Notes
This is intentionally a draft/discussion PR.
The tuning is narrow (`B=1`, `SM120`, `FP8 KV`) and should be evaluated on its own merits rather than mixed with correctness changes.
