### PR TITLE
[Bugfix] Quiet weight prefetch logs when executor is shutting down

### DIFF
--- a/tests/model_executor/test_weight_utils.py
+++ b/tests/model_executor/test_weight_utils.py
@@ -1,13 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import logging
 import tempfile
 
 import huggingface_hub.constants
 import pytest
 from huggingface_hub.utils import LocalEntryNotFoundError
 
+from vllm.model_executor.model_loader import weight_utils
 from vllm.model_executor.model_loader.weight_utils import (
+    _prefetch_all_checkpoints,
     download_weights_from_hf,
     maybe_remap_kv_scale_name,
 )
@@ -158,6 +161,62 @@ class TestMaybeRemapKvScaleName:
             "model.layers.0.self_attn.qkv_proj.k_scale", empty_params
         )
         assert result is None
+
+
+def test_prefetch_quiet_on_executor_shutdown(monkeypatch, caplog):
+    """When the prefetch thread pool is shut down mid-prefetch, the remaining
+    tasks should not each emit a full WARNING traceback.
+
+    Regression test for https://github.com/vllm-project/vllm/issues/40564
+    """
+
+    def _raise_shutdown(*_args, **_kwargs) -> None:
+        raise RuntimeError("cannot schedule new futures after shutdown")
+
+    monkeypatch.setattr(weight_utils, "_prefetch_checkpoint", _raise_shutdown)
+
+    paths = [f"/tmp/shard-{i}.safetensors" for i in range(16)]
+    with caplog.at_level(logging.DEBUG, logger=weight_utils.logger.name):
+        thread = _prefetch_all_checkpoints(paths)
+        thread.join(timeout=5.0)
+        assert not thread.is_alive(), "prefetch thread did not finish"
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.WARNING and r.name == weight_utils.logger.name
+    ]
+    assert warnings == [], (
+        f"expected no WARNING-level records on shutdown, got: "
+        f"{[r.getMessage() for r in warnings]}"
+    )
+
+
+def test_prefetch_warns_on_non_shutdown_failure(monkeypatch, caplog):
+    """A prefetch failure that is *not* the executor-shutdown case must still
+    produce a WARNING — the shutdown short-circuit must not swallow real bugs.
+    """
+
+    def _raise_other(*_args, **_kwargs) -> None:
+        raise RuntimeError("disk on fire")
+
+    monkeypatch.setattr(weight_utils, "_prefetch_checkpoint", _raise_other)
+
+    paths = [f"/tmp/shard-{i}.safetensors" for i in range(2)]
+    with caplog.at_level(logging.WARNING, logger=weight_utils.logger.name):
+        thread = _prefetch_all_checkpoints(paths)
+        thread.join(timeout=5.0)
+        assert not thread.is_alive(), "prefetch thread did not finish"
+
+    warnings = [
+        r
+        for r in caplog.records
+        if r.levelno >= logging.WARNING and r.name == weight_utils.logger.name
+    ]
+    assert len(warnings) == len(paths), (
+        f"expected one WARNING per file, got {len(warnings)}: "
+        f"{[r.getMessage() for r in warnings]}"
+    )
 
 
 if __name__ == "__main__":

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -815,12 +815,23 @@ def _prefetch_checkpoint(
             pass
 
 
+# Raised by concurrent.futures.ThreadPoolExecutor.submit (and therefore by
+# loop.run_in_executor / asyncio.to_thread) once the pool's _shutdown flag is
+# set. There is no dedicated exception subclass for this case in CPython, so we
+# match on the message text.
+_EXECUTOR_SHUTDOWN_MSG = "cannot schedule new futures after shutdown"
+
+
 def _prefetch_all_checkpoints(
     sorted_files: list[str],
     num_prefetch_threads: int = DEFAULT_SAFETENSORS_PREFETCH_NUM_THREADS,
     block_size: int = DEFAULT_SAFETENSORS_PREFETCH_BLOCK_SIZE,
-) -> None:
-    """Start prefetching checkpoint files into page cache in a background thread."""
+) -> threading.Thread:
+    """Start prefetching checkpoint files into page cache in a background thread.
+
+    Returns the background thread so tests (and callers that care) can wait on
+    it. Daemon=True, so callers that ignore the return value are unaffected.
+    """
     if num_prefetch_threads < 1:
         raise ValueError("safetensors prefetch num threads must be >= 1")
     if block_size < 1:
@@ -835,16 +846,19 @@ def _prefetch_all_checkpoints(
     paths_to_prefetch = sorted_files[rank::world_size]
     total_for_rank = len(paths_to_prefetch)
 
-    async def _prefetch_all() -> None:
+    async def _prefetch_all() -> bool:
         loop = asyncio.get_running_loop()
         completed = 0
         next_log_pct = 10
+        aborted = False
 
         async def prefetch_one(
             path: str,
             executor: concurrent.futures.ThreadPoolExecutor,
         ) -> None:
-            nonlocal completed, next_log_pct
+            nonlocal completed, next_log_pct, aborted
+            if aborted:
+                return
             try:
                 await loop.run_in_executor(
                     executor, _prefetch_checkpoint, path, block_size
@@ -860,6 +874,19 @@ def _prefetch_all_checkpoints(
                             total_for_rank,
                         )
                         next_log_pct += 10
+            except RuntimeError as e:
+                # On interpreter/engine teardown the thread pool is shut down,
+                # so further submits fail. Short-circuit the remaining tasks
+                # rather than emitting one traceback per file (which would
+                # bury the real startup error).
+                if _EXECUTOR_SHUTDOWN_MSG in str(e):
+                    if not aborted:
+                        aborted = True
+                        logger.debug("Prefetch aborted: executor is shutting down.")
+                    return
+                logger.warning(
+                    "Failed to prefetch checkpoint file %r.", path, exc_info=True
+                )
             except Exception:
                 logger.warning(
                     "Failed to prefetch checkpoint file %r.", path, exc_info=True
@@ -871,15 +898,22 @@ def _prefetch_all_checkpoints(
             await asyncio.gather(
                 *(prefetch_one(p, executor) for p in paths_to_prefetch)
             )
+        return aborted
 
     def _run_prefetch() -> None:
         start = time.perf_counter()
-        asyncio.run(_prefetch_all())
+        aborted = asyncio.run(_prefetch_all())
         elapsed = time.perf_counter() - start
-        logger.info(
-            "Prefetching checkpoint files into page cache finished in %.2fs",
-            elapsed,
-        )
+        if aborted:
+            logger.info(
+                "Prefetching checkpoint files interrupted by shutdown after %.2fs.",
+                elapsed,
+            )
+        else:
+            logger.info(
+                "Prefetching checkpoint files into page cache finished in %.2fs",
+                elapsed,
+            )
 
     logger.info(
         "Prefetching checkpoint files into page cache started "
@@ -887,7 +921,9 @@ def _prefetch_all_checkpoints(
         num_prefetch_threads,
         block_size,
     )
-    threading.Thread(target=_run_prefetch, daemon=True).start()
+    thread = threading.Thread(target=_run_prefetch, daemon=True)
+    thread.start()
+    return thread
 
 
 def safetensors_weights_iterator(


### PR DESCRIPTION
## Summary

- Fixes #40564.
- On engine-startup failure, every remaining `prefetch_one` task in `_prefetch_all_checkpoints` raises `RuntimeError: cannot schedule new futures after shutdown` from `asyncio.to_thread`, and each one is logged with a full multi-line traceback. For a 16-shard model that's a wall of ~160 lines of identical tracebacks that buries the actual startup error above.
- This PR catches that specific `RuntimeError`, sets an `aborted` flag that short-circuits the remaining tasks, logs a single `debug` line, and swaps the final "finished in Xs" message for an "interrupted by shutdown after Xs" line when the abort path was taken. Non-shutdown prefetch failures still produce a full warning/traceback — only the shutdown spam is suppressed.

The function now returns the background `threading.Thread` so tests can `.join()` on it; the single existing caller ignored the return value and is unaffected (daemon thread, unchanged behavior).

## Not a duplicate

`gh pr list --repo vllm-project/vllm --state all --search "40564"` and searches for `prefetch weight_utils` / `cannot schedule new futures` returned no PRs targeting this issue.

## Test plan

- New unit test `tests/model_executor/test_weight_utils.py::test_prefetch_quiet_on_executor_shutdown` — monkeypatches `_prefetch_checkpoint` to raise the shutdown `RuntimeError`, runs `_prefetch_all_checkpoints` on 16 fake paths, joins the background thread, and asserts zero `WARNING`-level records are emitted from the module logger.
- Pre-existing tests in `tests/model_executor/test_weight_utils.py` are untouched.

Command to run:

```
.venv/bin/python -m pytest tests/model_executor/test_weight_utils.py -v
```

Note: I was not able to run the test locally (no `uv`/venv set up in this environment) — flagging this explicitly so a reviewer can verify.