### PR TITLE
Fix FireRedASR2 hallucination on non-speech audio

### DIFF
--- a/vllm/model_executor/models/fireredasr2.py
+++ b/vllm/model_executor/models/fireredasr2.py
@@ -367,7 +367,12 @@ class FireRedASR2ForConditionalGeneration(
                 "Language must be specified when creating the fireredasr2 prompt"
             )
 
-        prompt_str = "<|im_start|>user\n<|AUDIO|>请转写音频为文字<|im_end|>\n<|im_start|>assistant\n"  # noqa: E501
+        prompt_str = (
+            "<|im_start|>user\n"
+            "<|AUDIO|>请转写音频为文字。如果是纯音乐、噪音或其他"
+            "非语音内容，请直接回复空内容。<|im_end|>\n"
+            "<|im_start|>assistant\n"
+        )  # noqa: E501
         prompt = {
             "prompt": prompt_str,
             "multi_modal_data": {


### PR DESCRIPTION
FireRedASR2 model was generating hallucinated text when processing pure music or other non-speech audio content. This update modifies the generation prompt to instruct the model to return empty content for non-speech inputs instead of forcing text generation.

Changes:
- Updated generation prompt in get_generation_prompt method
- Added explicit instruction to return empty content for non-speech audio
- Maintains existing behavior for speech transcription

This fix prevents the model from generating meaningless text when processing music, silence, or other non-speech audio content.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

