### PR TITLE
[Bugfix] Fix load balancer waiting count

### DIFF
--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -1394,7 +1394,13 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
     ):
         if outputs.finished_requests and self.reqs_in_flight:
             for req_id in outputs.finished_requests:
-                self.reqs_in_flight.pop(req_id, None)
+                engine = self.reqs_in_flight.pop(req_id, None)
+                if engine is not None:
+                    eng_idx = self.core_engines.index(engine)
+                    if eng_idx < len(self.lb_engines):
+                        self.lb_engines[eng_idx][0] = max(
+                            0, self.lb_engines[eng_idx][0] - 1
+                        )
 
     @staticmethod
     async def eep_process_engine_core_notification(


### PR DESCRIPTION
## Summary

Fix for issue #40279 - Load Balancer doesn't work

**Problem:** The DPLBAsyncMPClient load balancer increments the waiting count when assigning a request to an engine, but never decrements it when requests complete. This causes requests to accumulate on a single engine over time.

**Solution:** Decrement the waiting count in  when requests finish.

## Changes

- In : Decrement  when each request completes
- Added bounds check to prevent negative counts

## Test

- Verified syntax with py_compile

## Related Issue

#40279 [Bug]: Load Balancer doesn't work