### PR TITLE
Fix test_startup.py for torch 2.12

### DIFF
--- a/tests/compile/h100/test_startup.py
+++ b/tests/compile/h100/test_startup.py
@@ -135,10 +135,9 @@ MODEL_SPECS = [
             model="deepseek-ai/DeepSeek-V3.2",
             hf_overrides=_SMALL_MOE_OVERRIDES,
             cold_artifacts_saved=4,
-            # TODO: https://github.com/vllm-project/vllm/issues/38051
-            # We shouldn't be saving any artifacts on warm start.
-            warm_artifacts_saved=4,
-            warm_artifacts_loaded=0,
+            # https://github.com/vllm-project/vllm/issues/38051
+            warm_artifacts_saved=0 if is_torch_equal_or_newer("2.12.0") else 4,
+            warm_artifacts_loaded=4 if is_torch_equal_or_newer("2.12.0") else 0,
         ),
         id="deepseek_v3.2",
     ),
@@ -147,10 +146,9 @@ MODEL_SPECS = [
             model="moonshotai/Kimi-K2.5",
             hf_overrides={"text_config": _SMALL_MOE_OVERRIDES},
             cold_artifacts_saved=4,
-            # TODO: https://github.com/vllm-project/vllm/issues/38051
-            # We shouldn't be saving any artifacts on warm start.
-            warm_artifacts_saved=4,
-            warm_artifacts_loaded=0,
+            # https://github.com/vllm-project/vllm/issues/38051
+            warm_artifacts_saved=0 if is_torch_equal_or_newer("2.12.0") else 4,
+            warm_artifacts_loaded=4 if is_torch_equal_or_newer("2.12.0") else 0,
         ),
         id="kimi_k2.5",
     ),

--- a/tests/compile/test_dynamic_shapes_compilation.py
+++ b/tests/compile/test_dynamic_shapes_compilation.py
@@ -28,7 +28,7 @@ def get_test_models():
         "Qwen/Qwen2-7B-Instruct",
         "meta-llama/Llama-3.1-8B",
     ]
-    if is_torch_equal_or_newer("2.12.0"):
+    if is_torch_equal_or_newer("2.12.0.dev"):
         models.append("Qwen/Qwen3-4B-Instruct-2507")
     return models
 

--- a/vllm/env_override.py
+++ b/vllm/env_override.py
@@ -553,7 +553,7 @@ def _apply_constrain_to_fx_strides_patch():
     _lowering.constrain_to_fx_strides = _patched
 
 
-if is_torch_equal_or_newer("2.10.0") and not is_torch_equal_or_newer("2.12.0"):
+if is_torch_equal_or_newer("2.10.0") and not is_torch_equal_or_newer("2.12.0.dev"):
     import builtins as _builtins
     import pickle
 


### PR DESCRIPTION
When [testing on torch 2.12 release](https://github.com/pytorch/pytorch/issues/180912), we see expected warm artifacts saved = 0 and warm artifacts loaded = 4. Seems like this can also fix https://github.com/vllm-project/vllm/issues/38051? 

cc @zou3519 