### PR TITLE
[BE] Fix compile time message to be consistent (use monitoring)

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -283,10 +283,6 @@ class CompilerManager:
                 # after loading the last graph for this shape, record the time.
                 # there can be multiple graphs due to piecewise compilation.
                 elapsed = time.perf_counter() - compilation_start_time
-                if is_encoder:
-                    compilation_config.encoder_compilation_time += elapsed
-                else:
-                    compilation_config.compilation_time += elapsed
                 logger.info_once(
                     "Directly load the compiled graph(s) for compile range %s "
                     "from the cache, took %.3f s",
@@ -388,10 +384,6 @@ class CompilerManager:
         # after compiling the last graph, record the end time
         if graph_index == num_graphs - 1:
             elapsed = time.perf_counter() - compilation_start_time
-            if is_encoder:
-                compilation_config.encoder_compilation_time += elapsed
-            else:
-                compilation_config.compilation_time += elapsed
             logger.info_once(
                 "Compiling a graph for compile range %s takes %.2f s",
                 str(compile_range),
@@ -1129,11 +1121,10 @@ class VllmBackend:
         from .monitor import torch_compile_start_time
 
         dynamo_time = time.perf_counter() - torch_compile_start_time
-        logger.info_once("Dynamo bytecode transform time: %.2f s", dynamo_time)
-        if self.is_encoder:
-            self.compilation_config.encoder_compilation_time += dynamo_time
-        else:
-            self.compilation_config.compilation_time += dynamo_time
+        logger.info_once(
+            "Dynamo bytecode transform time: %.2f s",
+            dynamo_time,
+        )
 
         # Record Dynamo time in tracing if available
         start_time = int(torch_compile_start_time * 1e9)

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -285,7 +285,7 @@ def _try_load_aot_compiled_fn(
     Re-raises on failure when ``VLLM_FORCE_AOT_LOAD`` is set.
     """
     try:
-        with monitor_torch_compile(model.vllm_config):
+        with monitor_torch_compile(model.vllm_config, is_encoder=model._is_encoder):
             with (
                 set_current_vllm_config(model.vllm_config),
                 open(aot_compilation_path, "rb") as f,
@@ -617,7 +617,9 @@ def _support_torch_compile(
                 # store the path for saving after warmup
                 self._aot_compilation_path = aot_compilation_path
                 self._aot_cache_dir = cache_dir
-                with monitor_torch_compile(self.vllm_config):
+                with monitor_torch_compile(
+                    self.vllm_config, is_encoder=self._is_encoder
+                ):
                     self.aot_compiled_fn = self.aot_compile(*args, **kwargs)
                     compilation_counter.num_aot_compiles += 1
                     # All compilation is done at this point, save the
@@ -631,6 +633,7 @@ def _support_torch_compile(
                     self.vllm_config,
                     "torch.compile and initial profiling/warmup "
                     "run together took %.2f s in total",
+                    is_encoder=self._is_encoder,
                 ):
                     output = TorchCompileWithNoGuardsWrapper.__call__(
                         self,  # type: ignore[arg-type]

--- a/vllm/compilation/monitor.py
+++ b/vllm/compilation/monitor.py
@@ -18,6 +18,7 @@ torch_compile_start_time: float = 0.0
 def monitor_torch_compile(
     vllm_config: VllmConfig,
     message: str = "torch.compile took %.2f s in total",
+    is_encoder: bool = False,
 ) -> Generator[None, None, None]:
     """Context manager that times torch.compile and manages depyf debugging.
 
@@ -45,6 +46,10 @@ def monitor_torch_compile(
     else:
         total_compile_time = time.perf_counter() - torch_compile_start_time
         if compilation_config.mode == CompilationMode.VLLM_COMPILE:
+            if is_encoder:
+                compilation_config.encoder_compilation_time += total_compile_time
+            else:
+                compilation_config.compilation_time += total_compile_time
             logger.info_once(message, total_compile_time)
     finally:
         if depyf_cm is not None:


### PR DESCRIPTION
Accounts for previously missing aot_autograd caching timing in compiler/encoder compilation times




## Purpose

See title - @zou3519 noticed a mismatch in timing reported by monitor and logging from backend in https://github.com/vllm-project/vllm/pull/39240

After investigation, we discovered the backend was not accounting for aot caching time, so updated the monitor logic to handle the encoder portion

## Test Plan
```bash
with-proxy  vllm serve Qwen/Qwen2.5-VL-7B-Instruct --max-model-len 2048 --gpu-memory-utilization 0.8 --compilation-config '{"mode": 3, "compile_mm_encoder": true}'
```

```bash
with-proxy vllm bench startup --model Qwen/Qwen2.5-VL-7B-Instruct --compilation-config
```
## Test Result

```bash
(EngineCore pid=2121190) INFO 04-22 12:50:03 [monitor.py:53] torch.compile took 0.66 s in total
(EngineCore pid=2121190) INFO 04-22 12:50:03 [monitor.py:81] Initial profiling/warmup run took 0.14 s
(EngineCore pid=2121190) INFO 04-22 12:50:03 [backends.py:1069] Using cache directory: /home/lucaskabela/.cache/vllm/torch_compile_cache/59c36e2dce/rank_0_0/Qwen2_5_VisionBlock for vLLM's torch.compile
(EngineCore pid=2121190) INFO 04-22 12:50:03 [backends.py:1129] Dynamo bytecode transform time: 0.29 s
...
(EngineCore pid=2121190) INFO 04-22 12:50:26 [monitor.py:53] torch.compile took 16.77 s in total
(EngineCore pid=2121190) INFO 04-22 12:50:27 [monitor.py:81] Initial profiling/warmup run took 0.62 s
(EngineCore pid=2121190) INFO 04-22 12:50:32 [kv_cache_utils.py:829] Overriding num_gpu_blocks=0 with num_gpu_blocks_override=512
(EngineCore pid=2121190) INFO 04-22 12:50:39 [core.py:288] init engine (profile, create kv cache, warmup model) took 37.83 s (compilation: 23.67 s — language_model: 16.77 s, encoder: 6.89 s)
(EngineCore pid=2121190) INFO 04-22 12:50:39 [kernel.py:199] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'])
(APIServer pid=2100651) INFO 04-22 12:50:40 [api_server.py:598] Supported tasks: ['generate']
```

```bash
============================================================
STARTUP TIME BENCHMARK RESULTS
============================================================

COLD STARTUP:
Avg startup time: 66.77 seconds
Avg compilation time: 17.37 seconds
Avg encoder compilation time: 8.63 seconds
Startup time percentiles:
  10%: 66.03 seconds
  25%: 66.05 seconds
  50%: 66.10 seconds
  75%: 67.15 seconds
  90%: 67.78 seconds
  99%: 68.16 seconds
Compilation time percentiles:
  10%: 17.22 seconds
  25%: 17.22 seconds
  50%: 17.23 seconds
  75%: 17.45 seconds
  90%: 17.58 seconds
  99%: 17.66 seconds
Encoder compilation time percentiles:
  10%: 8.57 seconds
  25%: 8.59 seconds
  50%: 8.62 seconds
  75%: 8.67 seconds
  90%: 8.70 seconds
  99%: 8.72 seconds
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

