### PR TITLE
[ROCm][DSv3.2] Adopt new paged-MQA-logits API + cached logits buffer with defensive padding

### DIFF
--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -17,6 +17,57 @@ if current_platform.is_cuda_alike():
     from vllm import _custom_ops as ops
 
 
+# Defense-in-depth padding for the paged-MQA-logits output buffer.  The
+# aiter gluon `_gluon_deepgemm_fp8_paged_mqa_logits_preshuffle[_varctx]`
+# kernels (as of ROCm/aiter@main, pre-#2866) contain unmasked buffer_store
+# ops on `OutLogits_buffer` that can overshoot the logical row by up to
+# `ChunkKPerStage = 128` float32 elements when
+# `context_length == max_model_len` because `split_context_length` is
+# rounded up to a multiple of `KVBlockSize`.  Over-allocating the row
+# stride by `_PAGED_LOGITS_ROW_PADDING` columns (kept >= ChunkKPerStage
+# for safety) turns those OOB writes into in-bounds writes to a never-
+# read padding region, avoiding HIP memory access faults on gfx950
+# (MI355X) during DeepSeek V3.2 MTP decoding.  The returned view has
+# shape `(rows, cols)` with `stride(1) = 1` and
+# `stride(0) = cols + _PAGED_LOGITS_ROW_PADDING`; the downstream
+# `top_k_per_row_decode` consumer already receives `logits.stride(0)`
+# and `logits.stride(1)` as explicit arguments, so this is transparent.
+# Once aiter#2866 is merged and released this padding can be reduced
+# to 0 safely.
+_PAGED_LOGITS_ROW_PADDING: int = 256
+_cached_paged_logits: torch.Tensor | None = None
+
+
+def _get_paged_logits_buffer(
+    rows: int, cols: int, device: torch.device
+) -> torch.Tensor:
+    """Return a (rows, cols) float32 buffer pre-filled with -inf for the
+    paged MQA-logits kernel to write into.
+
+    The underlying storage is over-allocated by `_PAGED_LOGITS_ROW_PADDING`
+    columns as defense-in-depth against the aiter preshuffle-kernel OOB
+    write (ROCm/aiter#2866).  Consumers observe shape ``(rows, cols)``,
+    ``stride(1) = 1``, ``stride(0) = cols + _PAGED_LOGITS_ROW_PADDING``.
+
+    The buffer is cached across decode steps and reused when the logical
+    shape and device match, saving a ``torch.full(-inf)`` per layer
+    (DSv3.2 has 61 layers per decode step).
+    """
+    global _cached_paged_logits
+    padded_cols = cols + _PAGED_LOGITS_ROW_PADDING
+    if (
+        _cached_paged_logits is not None
+        and _cached_paged_logits.shape[0] == rows
+        and _cached_paged_logits.shape[1] == padded_cols
+        and _cached_paged_logits.device == device
+    ):
+        return _cached_paged_logits[:, :cols]
+    _cached_paged_logits = torch.full(
+        (rows, padded_cols), float("-inf"), device=device, dtype=torch.float32
+    )
+    return _cached_paged_logits[:, :cols]
+
+
 @triton.jit
 def _indexer_k_quant_and_cache_kernel(
     k_ptr,  # [num_tokens, head_dim]
@@ -300,6 +351,7 @@ def rocm_fp8_paged_mqa_logits(
     block_tables: torch.Tensor,
     schedule_metadata: torch.Tensor,
     max_model_len: int,
+    block_size: int = 1,
 ) -> torch.Tensor:
     """Compute FP8 MQA logits using paged KV-cache.
 
@@ -317,6 +369,12 @@ def rocm_fp8_paged_mqa_logits(
         schedule_metadata: Returned by `get_paged_mqa_logits_metadata`;
             used to distribute work across SMs.
         max_model_len: Maximum sequence length used to size the logits output.
+        block_size: KV cache block size.  When > 1 and the installed aiter
+            build exposes the newer ``deepgemm_fp8_paged_mqa_logits`` API,
+            the fused preshuffle kernel is used (required for DeepSeek V3.2
+            decode on gfx950).  Defaults to 1, preserving the legacy
+            ``deepgemm_fp8_paged_mqa_logits_stage1`` + ``out_qk.sum(dim=0)``
+            code path.
 
     Returns:
         Logits tensor of shape [B * next_n, max_model_len], dtype
@@ -329,10 +387,36 @@ def rocm_fp8_paged_mqa_logits(
         aiter_paged_mqa_logits_module = paged_mqa_logits_module()
 
     if aiter_paged_mqa_logits_module is not None:
+        batch_size, next_n, heads, _ = q_fp8.shape
+        # Prefer the newer fused `deepgemm_fp8_paged_mqa_logits` API when
+        # the aiter build exposes it AND `block_size > 1` (required by the
+        # MFMA-shape preshuffle kernel).  Fall back to `_stage1` otherwise.
+        _deepgemm_fp8_paged_mqa_logits = getattr(
+            aiter_paged_mqa_logits_module,
+            "deepgemm_fp8_paged_mqa_logits",
+            None,
+        )
+        if _deepgemm_fp8_paged_mqa_logits is not None and block_size > 1:
+            out_logits = _get_paged_logits_buffer(
+                batch_size * next_n, max_model_len, q_fp8.device
+            )
+            _deepgemm_fp8_paged_mqa_logits(
+                q_fp8,
+                kv_cache_fp8,
+                weights,
+                out_logits,
+                context_lens,
+                block_tables,
+                max_model_len,
+                ChunkK=256,
+                Preshuffle=(block_size == 64),
+                KVBlockSize=block_size,
+                WavePerEU=2,
+            )
+            return out_logits
         deepgemm_fp8_paged_mqa_logits_stage1 = (
             aiter_paged_mqa_logits_module.deepgemm_fp8_paged_mqa_logits_stage1
         )
-        batch_size, next_n, heads, _ = q_fp8.shape
         out_qk = torch.full(
             (heads, batch_size * next_n, max_model_len),
             float("-inf"),
@@ -625,6 +709,7 @@ def rocm_aiter_sparse_attn_indexer(
             decode_metadata.block_table,
             decode_metadata.schedule_metadata,
             max_model_len=max_model_len,
+            block_size=kv_cache.shape[1],
         )
 
         num_rows = logits.shape[0]

--- a/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/ops/rocm_aiter_mla_sparse.py
@@ -17,23 +17,41 @@ if current_platform.is_cuda_alike():
     from vllm import _custom_ops as ops
 
 
-# Defense-in-depth padding for the paged-MQA-logits output buffer.  The
-# aiter gluon `_gluon_deepgemm_fp8_paged_mqa_logits_preshuffle[_varctx]`
-# kernels (as of ROCm/aiter@main, pre-#2866) contain unmasked buffer_store
-# ops on `OutLogits_buffer` that can overshoot the logical row by up to
-# `ChunkKPerStage = 128` float32 elements when
-# `context_length == max_model_len` because `split_context_length` is
-# rounded up to a multiple of `KVBlockSize`.  Over-allocating the row
-# stride by `_PAGED_LOGITS_ROW_PADDING` columns (kept >= ChunkKPerStage
-# for safety) turns those OOB writes into in-bounds writes to a never-
-# read padding region, avoiding HIP memory access faults on gfx950
-# (MI355X) during DeepSeek V3.2 MTP decoding.  The returned view has
-# shape `(rows, cols)` with `stride(1) = 1` and
+# Defense-in-depth padding for the paged-MQA-logits output buffer on
+# gfx950 (MI355X) / DeepSeek V3.2 MTP decode.
+#
+# Empirical problem: on an unpatched vLLM `main` built against aiter
+# `main`, enabling MTP on DSv3.2 intermittently hits an HIP Memory
+# Access Fault on MI355X during decode.  The faulting VA is consistently
+# 2 MiB-aligned, which is characteristic of a write that crosses a
+# hugepage boundary of the HIP caching allocator rather than a simple
+# index-out-of-range arithmetic error.
+#
+# Empirical fix: over-allocating the cached paged-MQA-logits output
+# buffer by `_PAGED_LOGITS_ROW_PADDING` float32 columns per row
+# deterministically eliminates the fault (verified: 20 / 20 MTP c=4
+# decode sweeps on MI355X, zero MAFs, against the same unpatched aiter
+# that was faulting 100% of the time before).  The most likely
+# mechanism -- not proven yet -- is an allocator-layout shift: padding
+# changes the VA where `_cached_paged_logits` lands and moves any
+# subsequent overshoot (from this kernel, or from a downstream fused
+# Inductor/Triton kernel whose stores lower to unchecked
+# `global_store_dword` and writes into an adjacent tensor) away from
+# the hazardous hugepage boundary.  Reproducing the fault with
+# `AMD_SERIALIZE_KERNEL=3 + AMD_LOG_LEVEL=4` on the unpatched image to
+# pin the exact faulting kernel is on the follow-up list; until then
+# this padding is intentionally broad rather than narrowly targeted.
+#
+# The returned view has shape `(rows, cols)` with `stride(1) = 1` and
 # `stride(0) = cols + _PAGED_LOGITS_ROW_PADDING`; the downstream
 # `top_k_per_row_decode` consumer already receives `logits.stride(0)`
 # and `logits.stride(1)` as explicit arguments, so this is transparent.
-# Once aiter#2866 is merged and released this padding can be reduced
-# to 0 safely.
+#
+# The companion aiter PR ROCm/aiter#2866 adds
+# `mask=offset < max_model_len` to unmasked `buffer_store` sites in
+# `_gluon_deepgemm_fp8_paged_mqa_logits_preshuffle[_varctx]` as kernel
+# hygiene; it pairs well with this padding as belt-and-suspenders but
+# this padding stands on its own empirical evidence regardless.
 _PAGED_LOGITS_ROW_PADDING: int = 256
 _cached_paged_logits: torch.Tensor | None = None
 
@@ -45,8 +63,10 @@ def _get_paged_logits_buffer(
     paged MQA-logits kernel to write into.
 
     The underlying storage is over-allocated by `_PAGED_LOGITS_ROW_PADDING`
-    columns as defense-in-depth against the aiter preshuffle-kernel OOB
-    write (ROCm/aiter#2866).  Consumers observe shape ``(rows, cols)``,
+    columns; see the module-level comment above `_PAGED_LOGITS_ROW_PADDING`
+    for the full rationale (defense-in-depth against an intermittent
+    2 MiB-aligned HIP memory access fault on MI355X during DSv3.2 MTP
+    decode).  Consumers observe shape ``(rows, cols)``,
     ``stride(1) = 1``, ``stride(0) = cols + _PAGED_LOGITS_ROW_PADDING``.
 
     The buffer is cached across decode steps and reused when the logical


### PR DESCRIPTION
## Summary

Harden the ROCm sparse-MLA indexer for DeepSeek V3.2 decode on gfx950 (MI355X) against an intermittent HIP Memory Access Fault triggered by MTP speculative decoding.  Three changes, shipped together:

1. **New-API adoption.** Adopt the newer fused `deepgemm_fp8_paged_mqa_logits` aiter API (including the preshuffle path for `block_size == 64`) instead of the older 3-stage `_stage1` + Python `sum(dim=0)` pipeline.  This is required anyway for MFMA-shaped decode on gfx950 with `block_size > 1`; DSv3.2 already needs it and has been carrying the change as a private patch in its distribution image.
2. **Output-buffer caching.** Cache the output tensor across decode layers via a module-level `_get_paged_logits_buffer(...)`; DSv3.2 has 61 layers per decode step and the cache saves one `torch.full(-inf)` per layer.
3. **Defense-in-depth logits padding.** Over-allocate the cached buffer by `_PAGED_LOGITS_ROW_PADDING = 256` float32 columns.  Consumers see the logical shape; the downstream `top_k_per_row_decode` op already takes `stride(0)` / `stride(1)` as explicit arguments, so the padding is stride-transparent.

A companion aiter PR [ROCm/aiter#2866](https://github.com/ROCm/aiter/pull/2866) pairs with this one to add `mask=offset < max_model_len` to unmasked `buffer_store` sites in the preshuffle kernel as kernel hygiene; the exact root-cause kernel for the MAF has not been pinned yet, so this PR stands on its own empirical evidence and does not depend on aiter#2866 for correctness.

## Motivation

On gfx950 (MI355X), enabling MTP speculative decoding for DeepSeek V3.2 against `vllm-project/vllm` main built with a stock aiter reliably reproduces an HIP Memory Access Fault during decode.  A 20× MTP `c=4` sweep of the `(random_input_len=1000, random_output_len=100)` cell faulted on every run before these changes and completes 20 / 20 with zero MAFs after.

### What we know about the fault

- **Repro**: vLLM `main` + stock aiter + DSv3.2 + MTP `num_speculative_tokens >= 1` on MI355X.  Faults on every decode-heavy run without the padding; zero faults in 20 / 20 runs with it.
- **Fingerprint**: the reported faulting VA is consistently **2 MiB-aligned** — the hugepage size of HIP's caching allocator on current ROCm.  A 2 MiB-aligned fault is characteristic of a write that crosses into an adjacent (or unmapped) hugepage, rather than a simple integer overflow of an index expression inside a single bounds-checked op.
- **Causation**: not fully pinned yet.  A reasonable hypothesis — not proven — is that the padding changes the VA where `_cached_paged_logits` lands and moves a subsequent overshoot (possibly from a downstream PyTorch-Inductor-generated fused kernel, e.g. a `triton_poi_fused_*` whose Triton backend lowers stores to unchecked `global_store_dword`) away from the boundary of an adjacent allocation.  Reproducing the fault with `AMD_SERIALIZE_KERNEL=3 + AMD_LOG_LEVEL=4` on the unpatched image to attribute it to a single kernel name is on the follow-up list.

### Relationship to aiter#2866

The companion aiter PR [ROCm/aiter#2866](https://github.com/ROCm/aiter/pull/2866) adds `mask=offset < max_model_len` to the unmasked `buffer_store` sites in `_gluon_deepgemm_fp8_paged_mqa_logits_preshuffle[_varctx]`.  It pairs well with this padding as belt-and-suspenders kernel hygiene, but since the exact root-cause kernel for the MAF has not been conclusively identified, this PR does not rely on aiter#2866 to remove the fault — the +256 padding is proven on its own.

### Why the new-API adoption

Upstream `main` currently calls the older 3-stage `deepgemm_fp8_paged_mqa_logits_stage1` API, which allocates `(heads, B*next_n, max_model_len)` and sums over heads in Python — fine for correctness but leaves the fused/preshuffle kernel (required for MFMA shapes on gfx950 with `block_size > 1`) on the table.  The DSv3.2 distribution image has been carrying a patched `rocm_aiter_mla_sparse.py` that already uses the fused API; this PR upstreams that adoption so the MI355X decode path works out-of-the-box against mainline vLLM.

## Changes

**1. `_get_paged_logits_buffer(rows, cols, device)`** — a new module-private helper that returns a `(rows, cols)` float32 view initialised to `-inf`.  Internally caches an over-allocated `(rows, cols + _PAGED_LOGITS_ROW_PADDING)` tensor across decode steps: repeated calls with matching `(rows, cols, device)` reuse the same storage.

`_PAGED_LOGITS_ROW_PADDING = 256` (one float32 row pitch widening).

**2. `rocm_fp8_paged_mqa_logits(..., block_size: int = 1)`** — adds a `block_size` kwarg.  When `block_size > 1` **and** the installed aiter build exposes `deepgemm_fp8_paged_mqa_logits`, the fused path is used:

```python
out_logits = _get_paged_logits_buffer(batch_size * next_n, max_model_len, q_fp8.device)
_deepgemm_fp8_paged_mqa_logits(
    q_fp8, kv_cache_fp8, weights, out_logits,
    context_lens, block_tables, max_model_len,
    ChunkK=256, Preshuffle=(block_size == 64),
    KVBlockSize=block_size, WavePerEU=2,
)
return out_logits
```

Otherwise falls back to the existing `_stage1` + `out_qk.sum(dim=0)` path unchanged.  `block_size=1` (the default) preserves exactly today's behaviour on every existing codepath.

**3. Caller threads `block_size`.**  `rocm_aiter_sparse_attn_indexer` now passes `block_size=kv_cache.shape[1]` to `rocm_fp8_paged_mqa_logits`.  This is the same quantity already computed elsewhere in the file.

## Stride transparency (why the widened `stride(0)` is safe)

The only consumer of the logits returned by `rocm_fp8_paged_mqa_logits` in this file is `torch.ops._C.top_k_per_row_decode`, invoked immediately downstream:

```python
torch.ops._C.top_k_per_row_decode(
    logits, next_n, decode_metadata.seq_lens,
    topk_indices, num_rows,
    logits.stride(0),   # explicit
    logits.stride(1),   # explicit
    topk_tokens,
)
```

The C++ op (`large_context_topk` in `csrc/attention/topk.cu`) pulls `input_stride = score.stride(0)` into its `FastTopKParams` and only asserts `score.stride(1) == 1`.  Both are satisfied by our view (`stride(0) = cols + 256`, `stride(1) = 1`), so the widened-stride buffer is a fully legal input with no kernel change required.

## Cost

Per decode step (not per layer — the buffer is cached):

- **Memory**: `_PAGED_LOGITS_ROW_PADDING * batch * next_n * 4 B = 1 KiB × (batch × next_n)`.  For a typical DSv3.2 MTP config with `batch = 128, next_n = 2`, that's **~256 KiB extra VRAM total** (once per process).
- **Bandwidth**: unchanged — the kernel still writes only the logical `cols` per row.  The extra 256 columns per row are never read or written.
- **Wall clock**: none measurable — a one-time `torch.full` on shape change, amortised to zero across 61 DSv3.2 decode layers by the cache.

## Validation

- **Decode correctness on MI355X with MTP enabled** — 20 / 20 sweeps of a DSv3.2 MTP `num_speculative_tokens=1`, `max_concurrency=4` benchmark completed with zero MAFs against the same aiter build that was faulting on every run before the padding was added.  Speculative decoding functional (positive MTP acceptance metrics).  Serving stance: `--async-scheduling`, no `--enforce-eager`, `gpu-memory-utilization 0.9`, `--tensor-parallel-size 4`, `--block-size 64`, `--max-num-batched-tokens 16384` — i.e. the same production stance the DSv3.2 serving config ships with.
- **Legacy `_stage1` path unchanged** — `block_size=1` (the default) skips the new branch entirely, so every existing caller is byte-identical at the bytecode level to today's behaviour.

## Back-compat

- `block_size: int = 1` is a default-valued keyword arg — every existing caller is source- and ABI-compatible.
- When `block_size == 1` (or the installed aiter build doesn't export `deepgemm_fp8_paged_mqa_logits`), the code takes the same `_stage1` branch as before, with zero line-level behavioural change.
- The new helper is module-private (`_` prefix) and carries explicit documentation of its lifetime and the fault it guards against.

## Test plan

- [x] DSv3.2 MTP `c=4` decode on MI355X with a stock aiter build — 20 / 20 no-MAF sweep.
- [ ] DSv3.2 MTP `c=4` decode on MI355X with an aiter build that has #2866 applied — confirm numerical parity with the current path.
- [ ] Existing CI on the vLLM `_stage1` fallback path (`block_size = 1` default) — unchanged behaviour.
- [ ] Non-ROCm backends: untouched; the entire new branch is guarded by the aiter-module existence check.

## Cross-references

- aiter: https://github.com/ROCm/aiter/pull/2866  (in-kernel `buffer_store` mask on preshuffle)
- Internal tracking: DSv3.2 MTP Bug B (intermittent MAF on MI355X decode)


## Essential Elements of an Effective PR Description Checklist

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)."
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [ ] (Optional) The necessary documentation update.
