### PR TITLE
[Bugfix][Distributed] Tear down stale NCCL group on reinit in NCCLWeightTransferEngine

### DIFF
--- a/vllm/distributed/weight_transfer/nccl_engine.py
+++ b/vllm/distributed/weight_transfer/nccl_engine.py
@@ -130,6 +130,14 @@ class NCCLWeightTransferEngine(
                       rank offset, and world size
         """
 
+        # Destroy any stale comm from a previous call
+        if self.model_update_group is not None:
+            try:
+                self.model_update_group.destroy()
+            except Exception:
+                pass
+            self.model_update_group = None
+
         # Calculate the global rank in the trainer-worker process group
         # Must account for data parallel to get unique ranks across all workers
         dp_rank = self.parallel_config.data_parallel_index


### PR DESCRIPTION
## Purpose

`NCCLWeightTransferEngine.init_weight_update_group` does not tear down an existing `PyNcclCommunicator` before creating a new one. When a remote weight-update client disconnects (e.g. an online RL trainer crashes mid-run) while the vLLM server keeps running, the next client's reconnect calls `ncclCommInitRank` with `self.model_update_group` still pointing at the now-dead comm. The call fails with `unhandled cuda error` and the server cannot accept further weight updates without restart.

This blocks online RL flows (e.g. online GRPO) where the trainer may restart while the rollout server runs continuously.

Destroy any existing group and clear the reference before (re)initializing.

## Test Plan

1. Start vLLM in dev mode with NCCL weight transfer:
   ```
   VLLM_SERVER_DEV_MODE=1 vllm serve <model> \
       --weight-transfer-config '{"backend":"nccl"}' --trust-remote-code ...
   ```
2. Connect a client, call `init_weight_update_group`, drop the client.
3. Reconnect and call `init_weight_update_group` again.

## Test Result

- Before: second call raises `unhandled cuda error` on `ncclCommInitRank`; server must be restarted to recover.
- After: reconnect succeeds; subsequent `/update_weights` calls return normally. Verified against NVIDIA Nemotron-3-Nano-30B-A3B-BF16 on a Blackwell host driving an online GRPO training loop.