### PR TITLE
[Bugfix] Fix layerwise weight reload: VllmConfig context + kernel-tensor copy

### DIFF
--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -375,13 +375,20 @@ def _get_weight_loader(tensor: torch.Tensor):
 
 def _copy_and_restore_kernel_tensors(layer: torch.nn.Module, info: LayerReloadingInfo):
     """Copy processed values into original kernel tensor storage and restore
-    kernel tensor references on the layer. Preserves cudagraph references."""
+    kernel tensor references on the layer. Preserves cudagraph references.
+
+    Only copies tensors actually loaded this round; others (e.g. MambaMixer2's
+    `conv_weights` view, KV-scale sentinels) keep prior values to avoid
+    stamping uninitialized materialize_layer() data into shared storage."""
     assert info.kernel_tensors is not None
+    loaded_names = {n for n, _ in info.loaded_weights}
     parameters, buffers = info.kernel_tensors
     for name, param in parameters.items():
-        param.data.copy_(getattr(layer, name))
+        if name in loaded_names:
+            param.data.copy_(getattr(layer, name))
     for name, buffer in buffers.items():
-        buffer.data.copy_(getattr(layer, name))
+        if name in loaded_names:
+            buffer.data.copy_(getattr(layer, name))
 
     _place_kernel_tensors(layer, info)
 

--- a/vllm/model_executor/model_loader/reload/layerwise.py
+++ b/vllm/model_executor/model_loader/reload/layerwise.py
@@ -2,12 +2,13 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import inspect
 from collections.abc import Callable
+from contextlib import nullcontext
 from functools import wraps
 from weakref import WeakKeyDictionary
 
 import torch
 
-from vllm.config import ModelConfig
+from vllm.config import ModelConfig, get_current_vllm_config, set_current_vllm_config
 from vllm.logger import init_logger
 from vllm.model_executor.layers.attention import Attention, MLAAttention
 from vllm.model_executor.layers.quantization.base_config import QuantizeMethodBase
@@ -43,6 +44,28 @@ LAYERWISE_INFO: WeakKeyDictionary[torch.nn.Module, LayerReloadingInfo] = (
     WeakKeyDictionary()
 )
 
+# Capture VllmConfig at init so reload-path process_weights_after_loading
+# (which runs outside set_current_vllm_config) can re-enter the context.
+_cached_vllm_config = None
+
+
+def _capture_vllm_config() -> None:
+    global _cached_vllm_config
+    try:
+        _cached_vllm_config = get_current_vllm_config()
+    except Exception:
+        pass
+
+
+def _vllm_config_ctx():
+    if _cached_vllm_config is None:
+        return nullcontext()
+    try:
+        get_current_vllm_config()
+        return nullcontext()
+    except Exception:
+        return set_current_vllm_config(_cached_vllm_config)
+
 
 def get_layerwise_info(layer: torch.nn.Module) -> LayerReloadingInfo:
     """
@@ -65,6 +88,7 @@ def record_metadata_for_reloading(model: torch.nn.Module):
     Stores parameter and buffer metadata as meta tensors for restoration.
     Must be called before `initialize_layerwise_reload`.
     """
+    _capture_vllm_config()
     for layer in model.modules():
         info = get_layerwise_info(layer)
         info.restore_metadata = capture_layer_to_meta(layer)
@@ -90,6 +114,10 @@ def initialize_layerwise_reload(model: torch.nn.Module):
     # disable torchao reloading to avoid infinite recursion
     model._original_do_torchao_reload = getattr(model, "_do_torchao_reload", False)
     model._do_torchao_reload = False
+
+    # Fallback capture if record_metadata_for_reloading ran before ctx was set.
+    if _cached_vllm_config is None:
+        _capture_vllm_config()
 
     for layer in model.modules():
         info = get_layerwise_info(layer)
@@ -259,7 +287,8 @@ def _finalize_attention_layer(
         )
     else:
         _place_kernel_tensors(layer, info)
-    layer.process_weights_after_loading(model_config.dtype)
+    with _vllm_config_ctx():
+        layer.process_weights_after_loading(model_config.dtype)
 
 
 def _reload_attention_scales(layer: torch.nn.Module, info: LayerReloadingInfo) -> None:
@@ -282,7 +311,8 @@ def _reload_attention_scales(layer: torch.nn.Module, info: LayerReloadingInfo) -
         args.arguments["param"] = param
         _get_weight_loader(param)(*args.args, **args.kwargs)
 
-    quant_method.process_weights_after_loading(layer)
+    with _vllm_config_ctx():
+        quant_method.process_weights_after_loading(layer)
 
     _copy_and_restore_kernel_tensors(layer, info)
 
@@ -318,7 +348,8 @@ def _layerwise_process(layer: torch.nn.Module, info: LayerReloadingInfo):
     # Process weights (quantization, repacking, etc.)
     quant_method = getattr(layer, "quant_method", None)
     if isinstance(quant_method, QuantizeMethodBase):
-        quant_method.process_weights_after_loading(layer)
+        with _vllm_config_ctx():
+            quant_method.process_weights_after_loading(layer)
 
     # Copy processed values into original tensor storage (preserves cudagraph refs)
     # this code is a no-op if not reloading (because kernel tensors is empty)


### PR DESCRIPTION
## Purpose

Two independent bugs in `vllm/model_executor/model_loader/reload/layerwise.py` that surface when a running server reloads weights (e.g. `VLLM_SERVER_DEV_MODE=1 vllm serve --weight-transfer-config '{"backend":"nccl"}'` driving an online GRPO loop). Each is a separate commit on this branch.

### 1. Re-enter `VllmConfig` context during reload

`FlashInferCutlassMoE.__init__` (and other kernels) read `get_current_vllm_config()` inside `process_weights_after_loading`. On initial model load that runs inside a `set_current_vllm_config(...)` block. The reload path reaches the same code from the weight-update RPC with no active context, so the assertion in `get_current_vllm_config` trips and the reload aborts.

Snapshot `VllmConfig` the first time we observe it (during `record_metadata_for_reloading` / `initialize_layerwise_reload`) and re-enter it around the three reload-path `process_weights_after_loading` calls.

### 2. Only restore kernel tensors for weights actually reloaded

`_copy_and_restore_kernel_tensors` unconditionally copies every parameter and buffer in `info.kernel_tensors` back from the materialized layer. For tensors not touched by a weight loader this round, that materialized data is `materialize_layer()` placeholder garbage. Two concrete cases observed:

- `MambaMixer2.conv_weights` is a buffer aliasing `conv1d.weight` in a submodule — the submodule's `conv1d.weight` gets loaded normally, but `conv_weights` is never the target of a weight loader. The unconditional copy stamped uninitialized data over the shared storage.
- Attention KV-scale sentinels likewise have no weight_loader calls on typical reload.

Restrict the copy-back to names that appear in `info.loaded_weights`.

## Test Plan

Reload an MoE + Mamba hybrid model (e.g. NVIDIA Nemotron-3-Nano-30B-A3B-BF16) through the NCCL weight-transfer path:

```
VLLM_SERVER_DEV_MODE=1 vllm serve <model> \
    --weight-transfer-config '{"backend":"nccl"}' --trust-remote-code ...
```
then drive `/update_weights` from an online RL trainer and run a forward pass after the reload.

## Test Result

- Without fix 1: reload aborts with an assertion from `get_current_vllm_config` inside `FlashInferCutlassMoE`.
- Without fix 2: reload completes but subsequent generations produce corrupted output due to garbage in `MambaMixer2` conv state / KV-scale storage.
- With both fixes: reload completes cleanly and post-reload generations match the updated weights.