### PR TITLE
[Model Runner v2] Fix block table IMA issue

### DIFF
--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -84,6 +84,21 @@ class BlockTables:
             [t.data_ptr() for t in x], dtype=torch.uint64, device=self.device
         )
 
+    def refresh_metadata(self) -> None:
+        # rebuild pointer/stride tensors after CuMem kv_cache wake-up.
+        self.block_table_ptrs = self._make_ptr_tensor(
+            [block_table.gpu for block_table in self.block_tables]
+        )
+        self.block_table_strides = torch.tensor(
+            [block_table.gpu.stride(0) for block_table in self.block_tables],
+            dtype=torch.int64,
+            device=self.device,
+        )
+        self.block_sizes_tensor = torch.tensor(
+            self.block_sizes, dtype=torch.int32, device=self.device
+        )
+        self.input_block_table_ptrs = self._make_ptr_tensor(self.input_block_tables)
+
     def append_block_ids(
         self,
         req_index: int,

--- a/vllm/v1/worker/gpu/block_table.py
+++ b/vllm/v1/worker/gpu/block_table.py
@@ -47,18 +47,7 @@ class BlockTables:
                 device=device,
             )
             self.block_tables.append(block_table)
-        self.block_table_ptrs = self._make_ptr_tensor(
-            [b.gpu for b in self.block_tables]
-        )
-        self.block_table_strides = torch.tensor(
-            [b.gpu.stride(0) for b in self.block_tables],
-            dtype=torch.int64,
-            device=self.device,
-        )
 
-        self.block_sizes_tensor = torch.tensor(
-            self.block_sizes, dtype=torch.int32, device=self.device
-        )
         self.num_blocks = UvaBackedTensor(
             (self.num_kv_cache_groups, self.max_num_reqs),
             dtype=torch.int32,
@@ -69,7 +58,6 @@ class BlockTables:
         self.input_block_tables: list[torch.Tensor] = [
             torch.zeros_like(b.gpu) for b in self.block_tables
         ]
-        self.input_block_table_ptrs = self._make_ptr_tensor(self.input_block_tables)
 
         self.slot_mappings = torch.zeros(
             self.num_kv_cache_groups,
@@ -78,19 +66,25 @@ class BlockTables:
             device=self.device,
         )
 
+        self.init_block_table_layout_tensors()
+
     def _make_ptr_tensor(self, x: Iterable[torch.Tensor]) -> torch.Tensor:
         # NOTE(woosuk): Use uint64 instead of int64 to cover all possible addresses.
         return torch.tensor(
             [t.data_ptr() for t in x], dtype=torch.uint64, device=self.device
         )
 
-    def refresh_metadata(self) -> None:
-        # rebuild pointer/stride tensors after CuMem kv_cache wake-up.
+    def init_block_table_layout_tensors(self) -> None:
+        # Called at init and after a CuMem kv_cache wake-up. The ptr tensors
+        # cache raw data_ptr() values that go stale once the underlying tensors
+        # are reallocated on wake; block_sizes_tensor needs re-populating
+        # because its storage lives under the kv_cache pool tag and comes back
+        # with undefined contents.
         self.block_table_ptrs = self._make_ptr_tensor(
-            [block_table.gpu for block_table in self.block_tables]
+            [b.gpu for b in self.block_tables]
         )
         self.block_table_strides = torch.tensor(
-            [block_table.gpu.stride(0) for block_table in self.block_tables],
+            [b.gpu.stride(0) for b in self.block_tables],
             dtype=torch.int64,
             device=self.device,
         )

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -548,6 +548,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         del hidden_states, sample_hidden_states
         gc.collect()
 
+    def post_kv_cache_wake_up(self) -> None:
+        self.block_tables.init_block_table_layout_tensors()
+
     def reset_mm_cache(self) -> None:
         if self.encoder_cache is not None:
             self.encoder_cache.reset_mm_cache()

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -881,6 +881,9 @@ class GPUModelRunner(
         self.encoder_cache.clear()
         self.late_interaction_runner.clear()
 
+    def post_kv_cache_wake_up(self) -> None:
+        self.init_fp8_kv_scales()
+
     @torch.inference_mode()
     def init_fp8_kv_scales(self) -> None:
         """

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -192,6 +192,9 @@ class Worker(WorkerBase):
                     buffer.data.copy_(self._sleep_saved_buffers[name].data)
             self._sleep_saved_buffers = {}
 
+        if self.use_v2_model_runner and (tags is None or "kv_cache" in tags):
+            self.model_runner.block_tables.refresh_metadata()
+
         # If the KV cache has just been woken up,
         # the internal state of cache_engine must be reset,
         # especially the FP8 scaling factor.

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -46,7 +46,7 @@ from vllm.tasks import SupportedTask
 from vllm.tracing import instrument
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.mem_utils import MemorySnapshot, format_gib, memory_profiling
-from vllm.utils.torch_utils import is_quantized_kv_cache, set_random_seed
+from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig, KVCacheSpec
 from vllm.v1.outputs import (
@@ -192,18 +192,8 @@ class Worker(WorkerBase):
                     buffer.data.copy_(self._sleep_saved_buffers[name].data)
             self._sleep_saved_buffers = {}
 
-        if self.use_v2_model_runner and (tags is None or "kv_cache" in tags):
-            self.model_runner.block_tables.refresh_metadata()
-
-        # If the KV cache has just been woken up,
-        # the internal state of cache_engine must be reset,
-        # especially the FP8 scaling factor.
-        if (
-            (tags is None or "kv_cache" in tags)
-            and is_quantized_kv_cache(self.cache_config.cache_dtype)
-            and hasattr(self.model_runner, "init_fp8_kv_scales")
-        ):
-            self.model_runner.init_fp8_kv_scales()
+        if tags is None or "kv_cache" in tags:
+            self.model_runner.post_kv_cache_wake_up()
 
     def _maybe_get_memory_pool_context(self, tag: str) -> AbstractContextManager:
         if not self.vllm_config.model_config.enable_sleep_mode:


### PR DESCRIPTION
## Purpose

Part of the https://github.com/vllm-project/vllm/pull/39337

`VLLM_USE_V2_MODEL_RUNNER=1 pytest tests/basic_correctness/test_cumem.py -k "test_end_to_end and opt-125m" -sv`

Originally

```bash
(EngineCore pid=2694707)   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 1205, in _process_engine_step
(EngineCore pid=2694707)     outputs, model_executed = self.step_fn()
(EngineCore pid=2694707)                               ^^^^^^^^^^^^^^
(EngineCore pid=2694707)   File "/home/yewentao256/vllm-source/vllm/v1/engine/core.py", line 475, in step_with_batch_queue
(EngineCore pid=2694707)     exec_future = self.model_executor.execute_model(
(EngineCore pid=2694707)                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2694707)   File "/home/yewentao256/vllm-source/vllm/v1/executor/uniproc_executor.py", line 114, in execute_model
(EngineCore pid=2694707)     output.result()
(EngineCore pid=2694707)   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 449, in result
(EngineCore pid=2694707)     return self.__get_result()
(EngineCore pid=2694707)            ^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2694707)   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
(EngineCore pid=2694707)     raise self._exception
(EngineCore pid=2694707)   File "/home/yewentao256/vllm-source/vllm/v1/executor/uniproc_executor.py", line 84, in collective_rpc
(EngineCore pid=2694707)     result = run_method(self.driver_worker, method, args, kwargs)
(EngineCore pid=2694707)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2694707)   File "/home/yewentao256/vllm-source/vllm/v1/serial_utils.py", line 510, in run_method
(EngineCore pid=2694707)     return func(*args, **kwargs)
(EngineCore pid=2694707)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2694707)   File "/home/yewentao256/vllm-source/vllm/v1/worker/worker_base.py", line 337, in execute_model
(EngineCore pid=2694707)     return self.worker.execute_model(scheduler_output)
(EngineCore pid=2694707)            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2694707)   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(EngineCore pid=2694707)     return func(*args, **kwargs)
(EngineCore pid=2694707)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2694707)   File "/home/yewentao256/vllm-source/vllm/v1/worker/gpu_worker.py", line 814, in execute_model
(EngineCore pid=2694707)     output = self.model_runner.execute_model(
(EngineCore pid=2694707)              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2694707)   File "/home/yewentao256/.venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 124, in decorate_context
(EngineCore pid=2694707)     return func(*args, **kwargs)
(EngineCore pid=2694707)            ^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2694707)   File "/home/yewentao256/vllm-source/vllm/v1/worker/gpu/model_runner.py", line 1020, in execute_model
(EngineCore pid=2694707)     attn_metadata = self.model_state.prepare_attn(
(EngineCore pid=2694707)                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2694707)   File "/home/yewentao256/vllm-source/vllm/v1/worker/gpu/model_states/default.py", line 176, in prepare_attn
(EngineCore pid=2694707)     attn_metadata = build_attn_metadata(
(EngineCore pid=2694707)                     ^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2694707)   File "/home/yewentao256/vllm-source/vllm/v1/worker/gpu/attn_utils.py", line 263, in build_attn_metadata
(EngineCore pid=2694707)     metadata = attn_metadata_builder.build(
(EngineCore pid=2694707)                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(EngineCore pid=2694707)   File "/home/yewentao256/vllm-source/vllm/v1/attention/backends/flashinfer.py", line 1096, in build
(EngineCore pid=2694707)     paged_kv_indptr_prefill_gpu[0] = 0
(EngineCore pid=2694707)     ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
(EngineCore pid=2694707) torch.AcceleratorError: CUDA error: an illegal memory access was encountered
(EngineCore pid=2694707) Search for `cudaErrorIllegalAddress' in https://docs.nvidia.com/cuda/cuda-runtime-api/group__CUDART__TYPES.html for more information.
(EngineCore pid=2694707) CUDA kernel errors might be asynchronously reported at some other API call, so the stacktrace below might be incorrect.
(EngineCore pid=2694707) For debugging consider passing CUDA_LAUNCH_BLOCKING=1
(EngineCore pid=2694707) Compile with `TORCH_USE_CUDA_DSA` to enable device-side assertions.
(EngineCore pid=2694707) 
[rank0]:[W422 15:45:41.364245121 ProcessGroupNCCL.cpp:1553] Warning: WARNING: destroy_process_group() was not called before program exit, which can leak resources. For more info, please see https://pytorch.org/docs/stable/distributed.html#shutdown (function operator())
FAILED
```

Now

```bash
========================= 1 passed, 7 deselected, 17 warnings in 20.25s ==========================
```

CC @njhill 