### PR TITLE
[DO NOT REVIEW] Add rms_norm_per_block_quant UE8M0 handling for B200

### DIFF
--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -143,7 +143,8 @@ void rms_norm_per_block_quant(torch::Tensor& out, torch::Tensor const& input,
                               torch::Tensor& scales, double const epsilon,
                               std::optional<torch::Tensor> scale_ub,
                               std::optional<torch::Tensor> residual,
-                              int64_t group_size, bool is_scale_transposed);
+                              int64_t group_size, bool is_scale_transposed,
+                              bool scale_ue8m0);
 
 void silu_and_mul_per_block_quant(torch::Tensor& out,
                                   torch::Tensor const& input,

--- a/csrc/quantization/fused_kernels/fused_layernorm_dynamic_per_token_quant.cu
+++ b/csrc/quantization/fused_kernels/fused_layernorm_dynamic_per_token_quant.cu
@@ -92,7 +92,8 @@ __global__ void rms_norm_dynamic_per_token_quant_kernel(
 
 // RMS norm + quant kernel
 template <typename scalar_t, typename scalar_out_t, bool has_residual = false,
-          bool is_scale_transposed = false, int32_t group_size = 0>
+          bool is_scale_transposed = false, int32_t group_size = 0,
+          bool scale_ue8m0 = false>
 __global__ void rms_norm_per_block_quant_kernel(
     scalar_out_t* __restrict__ out,  // [..., hidden_size]
     float* __restrict__ scales,      // [num_tokens, hidden_size / group_size]
@@ -112,9 +113,9 @@ __global__ void rms_norm_per_block_quant_kernel(
   // Compute Scale
   // Always able to vectorize due to constraints on hidden_size and group_size
   vllm::vectorized::compute_dynamic_per_token_scales<
-      scalar_t, scalar_out_t, has_residual, is_scale_transposed, group_size>(
-      nullptr, scales, input, weight, rms, scale_ub, hidden_size, input_stride,
-      residual, outer_scale_stride);
+      scalar_t, scalar_out_t, has_residual, is_scale_transposed, group_size,
+      scale_ue8m0>(nullptr, scales, input, weight, rms, scale_ub, hidden_size,
+                   input_stride, residual, outer_scale_stride);
 
   // RMS Norm + Quant
   // Always able to vectorize due to constraints on hidden_size
@@ -207,7 +208,8 @@ void rms_norm_per_block_quant_dispatch(
     int32_t group_size,
     double const var_epsilon,  // Variance epsilon used in norm calculation
     std::optional<at::Tensor> const& scale_ub,
-    std::optional<at::Tensor>& residual, bool is_scale_transposed) {
+    std::optional<at::Tensor>& residual, bool is_scale_transposed,
+    bool scale_ue8m0) {
   int32_t hidden_size = input.size(-1);
   int32_t input_stride = input.view({-1, hidden_size}).stride(0);
 
@@ -232,22 +234,23 @@ void rms_norm_per_block_quant_dispatch(
         VLLM_DISPATCH_GROUP_SIZE(group_size, gs, [&] {
           VLLM_DISPATCH_BOOL(residual.has_value(), has_residual, [&] {
             VLLM_DISPATCH_BOOL(is_scale_transposed, transpose_scale, [&] {
-              VLLM_DISPATCH_QUANT_TYPES(
-                  out.scalar_type(), "rms_norm_per_block_quant_kernel", [&] {
-                    vllm::rms_norm_per_block_quant_kernel<scalar_in_t, scalar_t,
-                                                          has_residual,
-                                                          transpose_scale, gs>
-                        <<<grid, block, 0, stream>>>(
-                            out.data_ptr<scalar_t>(), scales.data_ptr<float>(),
-                            input.data_ptr<scalar_in_t>(),
-                            weight.data_ptr<scalar_in_t>(),
-                            scale_ub.has_value() ? scale_ub->data_ptr<float>()
-                                                 : nullptr,
-                            var_epsilon, hidden_size, input_stride,
-                            has_residual ? residual->data_ptr<scalar_in_t>()
-                                         : nullptr,
-                            scales.stride(1));
-                  });
+              VLLM_DISPATCH_BOOL(scale_ue8m0, ue8m0_scale, [&] {
+                VLLM_DISPATCH_QUANT_TYPES(
+                    out.scalar_type(), "rms_norm_per_block_quant_kernel", [&] {
+                      vllm::rms_norm_per_block_quant_kernel<
+                          scalar_in_t, scalar_t, has_residual, transpose_scale,
+                          gs, ue8m0_scale><<<grid, block, 0, stream>>>(
+                          out.data_ptr<scalar_t>(), scales.data_ptr<float>(),
+                          input.data_ptr<scalar_in_t>(),
+                          weight.data_ptr<scalar_in_t>(),
+                          scale_ub.has_value() ? scale_ub->data_ptr<float>()
+                                               : nullptr,
+                          var_epsilon, hidden_size, input_stride,
+                          has_residual ? residual->data_ptr<scalar_in_t>()
+                                       : nullptr,
+                          scales.stride(1));
+                    });
+              });
             });
           });
         });
@@ -259,7 +262,8 @@ void rms_norm_per_block_quant(torch::Tensor& out, torch::Tensor const& input,
                               torch::Tensor& scales, double const var_epsilon,
                               std::optional<torch::Tensor> scale_ub,
                               std::optional<torch::Tensor> residual,
-                              int64_t group_size, bool is_scale_transposed) {
+                              int64_t group_size, bool is_scale_transposed,
+                              bool scale_ue8m0) {
   static c10::ScalarType kFp8Type = is_fp8_ocp()
                                         ? c10::ScalarType::Float8_e4m3fn
                                         : c10::ScalarType::Float8_e4m3fnuz;
@@ -297,5 +301,5 @@ void rms_norm_per_block_quant(torch::Tensor& out, torch::Tensor const& input,
 
   rms_norm_per_block_quant_dispatch(out, input, weight, scales, group_size,
                                     var_epsilon, scale_ub, residual,
-                                    is_scale_transposed);
+                                    is_scale_transposed, scale_ue8m0);
 }

--- a/csrc/quantization/fused_kernels/layernorm_utils.cuh
+++ b/csrc/quantization/fused_kernels/layernorm_utils.cuh
@@ -13,6 +13,14 @@
 
 namespace vllm {
 
+// Round scale up to the nearest power of two so it fits the UE8M0 format
+// (exponent-only scale). fmaxf with MIN_SCALE_FOR_LOG guards log2f against
+// non-positive inputs.
+__device__ inline float adjust_scale_for_ue8m0(float scale) {
+  constexpr float MIN_SCALE_FOR_LOG = 1e-10f;
+  return exp2f(ceilf(log2f(fmaxf(scale, MIN_SCALE_FOR_LOG))));
+}
+
 // has_residual must be true, if residual is not a nullptr
 template <typename scalar_t, bool has_residual = false>
 __device__ void compute_rms(float* rms, scalar_t const* __restrict__ input,
@@ -71,7 +79,7 @@ __device__ float warpReduceMaxSpecialized(volatile float* val, int64_t tid,
 }
 
 template <typename scalar_t, typename scalar_out_t, bool has_residual = false,
-          bool is_scale_transposed = false>
+          bool is_scale_transposed = false, bool scale_ue8m0 = false>
 __device__ void compute_dynamic_per_token_scales(
     float* __restrict__ token_scale, float* __restrict__ all_token_scales,
     scalar_t const* __restrict__ input, scalar_t const* __restrict__ weight,
@@ -139,6 +147,9 @@ __device__ void compute_dynamic_per_token_scales(
       }
       // token scale computation
       scale = max(scale / qmax, min_scaling_factor<scalar_out_t>::val());
+      if constexpr (scale_ue8m0) {
+        scale = adjust_scale_for_ue8m0(scale);
+      }
       // Global output store
       if constexpr (is_scale_transposed) {
         int64_t const scale_rows = (gridDim.x + outer_scale_stride - 1) /
@@ -295,7 +306,8 @@ __device__ void compute_rms(float* rms, scalar_t const* __restrict__ input,
 // Vectorized version of vllm::compute_dynamic_per_token_scales
 // hidden_size must be a multiple of 4
 template <typename scalar_t, typename scalar_out_t, bool has_residual = false,
-          bool is_scale_transposed = false, int32_t group_size = 0>
+          bool is_scale_transposed = false, int32_t group_size = 0,
+          bool scale_ue8m0 = false>
 __device__ void compute_dynamic_per_token_scales(
     float* __restrict__ token_scale, float* __restrict__ all_token_scales,
     scalar_t const* __restrict__ input, scalar_t const* __restrict__ weight,
@@ -399,6 +411,9 @@ __device__ void compute_dynamic_per_token_scales(
       }
       // token scale computation
       scale = max(scale / qmax, min_scaling_factor<scalar_out_t>::val());
+      if constexpr (scale_ue8m0) {
+        scale = adjust_scale_for_ue8m0(scale);
+      }
       // Global output store
       if constexpr (is_scale_transposed) {
         int64_t const scale_rows = (gridDim.x + outer_scale_stride - 1) /

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -232,7 +232,7 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "rms_norm_per_block_quant(Tensor! result, Tensor input, "
       "Tensor weight, Tensor! scale, float epsilon, "
       "Tensor? scale_ub, Tensor!? residual, int group_size, "
-      "bool is_scale_transposed) -> ()");
+      "bool is_scale_transposed, bool scale_ue8m0) -> ()");
   ops.impl("rms_norm_per_block_quant", torch::kCUDA, &rms_norm_per_block_quant);
 
   // Rotary embedding

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1826,6 +1826,7 @@ class TestFP8Layer(torch.nn.Module):
             self.weight = torch.rand(weight_shape).to(dtype=FP8_DTYPE)
             self.input_scale = None
             self.weight_scale = None
+            self.weight_block_size = [block_size, block_size]
             if transpose_weights:
                 self.weight = self.weight.t()
         else:

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -535,6 +535,7 @@ def rms_norm_per_block_quant(
     residual: torch.Tensor | None = None,
     is_scale_transposed: bool = False,
     tma_alignment: int = 0,
+    scale_ue8m0: bool = False,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     assert len(group_size) == 2
     output = torch.empty(input.shape, dtype=quant_dtype, device=input.device)
@@ -579,6 +580,7 @@ def rms_norm_per_block_quant(
         residual,
         group_size[1],
         is_scale_transposed,
+        scale_ue8m0,
     )
     return output, scales
 

--- a/vllm/compilation/passes/fusion/rms_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/rms_quant_fusion.py
@@ -361,6 +361,7 @@ class FusedAddRMSNormGroupQuantPattern(RMSNormQuantPattern):
                 residual=residual,
                 group_size=self.group_shape[1],
                 is_scale_transposed=self.has_col_major_scales,
+                scale_ue8m0=self.is_e8m0,
             )
 
             # result, residual, scale
@@ -395,6 +396,7 @@ class RMSNormGroupQuantPattern(RMSNormQuantPattern):
             quant=QuantKey(dtype=quant_dtype, scale=scale, symmetric=symmetric),
         )
         self.group_shape = group_shape
+        self.is_e8m0 = is_e8m0
         self.has_col_major_scales = has_col_major_scales
         self.is_tma_aligned = is_tma_aligned
         super().__init__(
@@ -455,6 +457,7 @@ class RMSNormGroupQuantPattern(RMSNormQuantPattern):
                 residual=None,
                 group_size=self.group_shape[1],
                 is_scale_transposed=self.has_col_major_scales,
+                scale_ue8m0=self.is_e8m0,
             )
 
             # result, scale

--- a/vllm/model_executor/layers/quantization/input_quant_fp8.py
+++ b/vllm/model_executor/layers/quantization/input_quant_fp8.py
@@ -6,6 +6,7 @@ import torch.nn.functional as F
 
 from vllm import _custom_ops as ops
 from vllm._aiter_ops import rocm_aiter_ops
+from vllm.config import get_current_vllm_config
 from vllm.model_executor.custom_op import CustomOp
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     GroupShape,
@@ -67,6 +68,18 @@ class QuantFP8(CustomOp):
         self.use_ue8m0 = is_deep_gemm_e8m0_used() if use_ue8m0 is None else use_ue8m0
         self.use_deep_gemm_supported = is_deep_gemm_supported()
 
+        # TODO(quant-rms-fusion): when rms_norm_per_block_quant learns to emit
+        # packed UE8M0 scales (int32, TMA-aligned), drop this flag and let
+        # the packed path stay enabled alongside fusion. Today the fusion pass
+        # only matches per_token_group_fp8_quant (fp32 scales), so if fusion is
+        # enabled we avoid the packed op to let fusion rewrite the rms+quant.
+        vllm_config = get_current_vllm_config()
+        self._skip_packed_for_fusion = bool(
+            vllm_config is not None
+            and vllm_config.compilation_config is not None
+            and vllm_config.compilation_config.pass_config.fuse_norm_quant
+        )
+
         self.use_aiter = rocm_aiter_ops.is_linear_fp8_enabled()
 
         self.is_group_quant = group_shape.is_per_group()
@@ -94,6 +107,7 @@ class QuantFP8(CustomOp):
             and self.use_ue8m0
             and self.use_deep_gemm_supported
             and (DeepGemmQuantScaleFMT.from_oracle() == DeepGemmQuantScaleFMT.UE8M0)
+            and not self._skip_packed_for_fusion
         ):
             return fp8_utils.per_token_group_quant_fp8_packed_for_deepgemm(
                 x,


### PR DESCRIPTION



## Purpose
Draft implementation of fused rms_norm_per_quant

### Summary:
  - Kernel: scale_ue8m0 template flag on compute_dynamic_per_token_scales (scalar + vectorized).
  Power-of-two rounding extracted into adjust_scale_for_ue8m0 __device__ inline helper with a named  
  MIN_SCALE_FOR_LOG = 1e-10f constant; both call sites use the helper.
  - Op schema: rms_norm_per_block_quant gains bool scale_ue8m0 (csrc/ops.h, torch_bindings.cpp,      
  _custom_ops.py).                                                                       
  - Routing: rms_quant_fusion.py propagates scale_ue8m0=self.is_e8m0; input_quant_fp8.py adds        
  _skip_packed_for_fusion so fusion can match when fuse_norm_quant is on.                
  
## Test Plan
```
pytest tests/compile/passes/test_fusion.py::test_fusion_rmsnorm_quant
```
We also run a benchmark of this naive impl (fusion) vs the packed version

## Test Result

That is fair - here is the timing result:

  | N    | D    | packed unfused (µs) | fused UE8M0 (µs) | winner | Δ     |
  |------|------|---------------------|------------------|--------|-------|
  | 1    | 4096 | 38.1                | 30.0             | fused  | −21%  |
  | 1    | 7168 | 38.1                | 30.0             | fused  | −21%  |
  | 128  | 4096 | 39.2                | 30.5             | fused  | −22%  |
  | 128  | 7168 | 39.2                | 31.0             | fused  | −21%  |
  | 1024 | 4096 | 38.5                | 30.5             | fused  | −21%  |
  | 1024 | 7168 | 38.9                | 34.1             | fused  | −12%  |
  | 2048 | 4096 | 38.8                | 34.8             | fused  | −10%  |
  | 2048 | 7168 | 46.9                | 55.4             | packed | +18%  |
  | 3072 | 4096 | 42.6                | 49.3             | packed | +16%  |
  | 3072 | 7168 | 71.8                | 84.3             | packed | +17%  |
  | 4096 | 4096 | 53.4                | 65.7             | packed | +23%  |
  | 4096 | 7168 | 98.7                | 112.4            | packed | +14%  |
  | 8192 | 4096 | 114.5               | 130.4            | packed | +14%  |
  | 8192 | 7168 | 195.7               | 218.7            | packed | +12%  |



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

