### PR TITLE
[Model Runner V2] Fix rejection sampling acceptance rate gap vs MRV1

### DIFF
--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -63,7 +63,8 @@ SpeculativeMethod = Literal[
     EagleModelTypes,
     NgramGPUTypes,
 ]
-RejectionSampleMethod = Literal["strict", "probabilistic", "synthetic"]
+RejectionSampleMethod = Literal["standard", "synthetic"]
+DraftSampleMethod = Literal["greedy", "gumbel"]
 
 
 @config
@@ -183,11 +184,11 @@ class SpeculativeConfig:
     """Load config for the draft model. If not specified, will use the load
     config from the target model."""
 
-    rejection_sample_method: RejectionSampleMethod = "strict"
-    """Whether to use strict (target and draft sampled tokens match exactly)
-    or probabilistic rejection sampling. Both respect the target model
-    distribution, but the latter yields a higher acceptance rate at the cost
-    of more memory to cache draft logits."""
+    rejection_sample_method: RejectionSampleMethod = "standard"
+    """The rejection sampling method to use. 'standard' uses probabilistic
+    rejection sampling (with or without cached draft logits, controlled by
+    draft_sample_method). 'synthetic' accepts draft tokens with a decaying
+    probability calibrated to synthetic_acceptance_rate."""
 
     synthetic_acceptance_rates: list[float] | None = None
     """Per-position *unconditional* acceptance rates for synthetic rejection
@@ -247,6 +248,14 @@ class SpeculativeConfig:
                 f"synthetic_acceptance_length must be in [1, {n + 1}], got {length}."
             )
         return SpeculativeConfig._acceptance_length_to_rates(length, n)
+
+    draft_sample_method: DraftSampleMethod = "greedy"
+    """How the draft model samples tokens. 'greedy' always picks the argmax
+    token, and the draft probabilities are treated as one-hot during rejection
+    sampling. 'gumbel' adds Gumbel noise for stochastic sampling, and the full
+    draft logits are used for the probability ratio test during rejection
+    sampling. This comes at the cost of additional GPU memory usage. This
+    parameter currently only applies to Model Runner V2."""
 
     def compute_hash(self) -> str:
         """

--- a/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
+++ b/vllm/v1/worker/gpu/spec_decode/eagle/speculator.py
@@ -94,7 +94,7 @@ class EagleSpeculator:
             )
 
         self.draft_logits: torch.Tensor | None = None
-        if self.speculative_config.rejection_sample_method == "probabilistic":
+        if self.speculative_config.draft_sample_method == "gumbel":
             self.draft_logits = torch.zeros(
                 self.max_num_reqs,
                 self.num_speculative_steps,
@@ -215,6 +215,28 @@ class EagleSpeculator:
             last_hidden_states, hidden_states = ret_hidden_states
         return last_hidden_states, hidden_states
 
+    def _sample_draft(
+        self,
+        logits: torch.Tensor,
+        idx_mapping: torch.Tensor,
+        pos: torch.Tensor,
+        step: int,
+    ) -> torch.Tensor:
+        if self.draft_logits is not None:
+            # NOTE(woosuk): We must add 1 to the positions to match the Gumbel noise
+            # used for draft and target sampling.
+            return gumbel_sample(
+                logits,
+                idx_mapping,
+                self.temperature,
+                self.seeds,
+                pos + 1,
+                apply_temperature=True,
+                processed_logits_out=self.draft_logits[:, step],
+            )
+        else:
+            return logits.argmax(dim=-1)
+
     def prefill(
         self,
         num_reqs: int,
@@ -240,18 +262,11 @@ class EagleSpeculator:
         sample_hidden_states = last_hidden_states[last_token_indices]
         logits = self.model.compute_logits(sample_hidden_states)
 
-        # NOTE(woosuk): We must add 1 to the positions to match the Gumbel noise
-        # used for draft and target sampling.
-        self.draft_tokens[:num_reqs, 0] = gumbel_sample(
+        self.draft_tokens[:num_reqs, 0] = self._sample_draft(
             logits,
             idx_mapping,
-            self.temperature,
-            self.seeds,
-            pos + 1,
-            apply_temperature=True,
-            processed_logits_out=self.draft_logits[:, 0]
-            if self.draft_logits is not None
-            else None,
+            pos,
+            step=0,
         )
         self.hidden_states[:num_reqs] = hidden_states[last_token_indices]
         self.input_buffers.positions[:num_reqs] = pos
@@ -281,18 +296,11 @@ class EagleSpeculator:
             hidden_states = hidden_states[:num_reqs]
             logits = self.model.compute_logits(last_hidden_states)
 
-            # NOTE(woosuk): We must add 1 to the positions to match the Gumbel noise
-            # used for draft and target sampling.
-            draft_tokens = gumbel_sample(
+            draft_tokens = self._sample_draft(
                 logits,
                 idx_mapping,
-                self.temperature,
-                self.seeds,
-                pos + 1,
-                apply_temperature=True,
-                processed_logits_out=self.draft_logits[:, step]
-                if self.draft_logits is not None
-                else None,
+                pos,
+                step=step,
             )
             self.draft_tokens[:num_reqs, step] = draft_tokens
 

--- a/vllm/v1/worker/gpu/spec_decode/probabilistic_rejection_sampler_utils.py
+++ b/vllm/v1/worker/gpu/spec_decode/probabilistic_rejection_sampler_utils.py
@@ -45,7 +45,7 @@ def _compute_global_lse(
 
 
 @triton.jit
-def _compute_block_max_and_sumexp_kernel(
+def _compute_block_stats_kernel(
     # [num_logits, num_blocks]
     target_local_argmax_ptr,
     target_local_argmax_stride,
@@ -77,6 +77,7 @@ def _compute_block_max_and_sumexp_kernel(
     vocab_size,
     num_speculative_steps,
     BLOCK_SIZE: tl.constexpr,
+    HAS_DRAFT_LOGITS: tl.constexpr,
 ):
     logit_idx = tl.program_id(0)
     draft_step_idx = tl.load(expanded_local_pos_ptr + logit_idx)
@@ -112,24 +113,6 @@ def _compute_block_max_and_sumexp_kernel(
             value,
         )
     else:
-        # Get local draft max and summed exponentials.
-        draft_logits = tl.load(
-            draft_logits_ptr
-            + req_state_idx * draft_logits_stride_0
-            + draft_step_idx * draft_logits_stride_1
-            + block_offsets,
-            mask=mask,
-            other=float("-inf"),
-        ).to(tl.float32)
-        draft_max, draft_sumexp = _compute_block_max_and_sumexp(draft_logits)
-        tl.store(
-            draft_local_max_ptr + logit_idx * draft_local_max_stride + block_idx,
-            draft_max,
-        )
-        tl.store(
-            draft_local_sumexp_ptr + logit_idx * draft_local_sumexp_stride + block_idx,
-            draft_sumexp,
-        )
         # Get local target max and summed exponentials.
         target_logits = tl.load(
             target_logits_ptr + logit_idx * target_logits_stride + block_offsets,
@@ -147,6 +130,27 @@ def _compute_block_max_and_sumexp_kernel(
             + block_idx,
             target_sumexp,
         )
+        if HAS_DRAFT_LOGITS:
+            # Get local draft max and summed exponentials.
+            draft_logits = tl.load(
+                draft_logits_ptr
+                + req_state_idx * draft_logits_stride_0
+                + draft_step_idx * draft_logits_stride_1
+                + block_offsets,
+                mask=mask,
+                other=float("-inf"),
+            ).to(tl.float32)
+            draft_max, draft_sumexp = _compute_block_max_and_sumexp(draft_logits)
+            tl.store(
+                draft_local_max_ptr + logit_idx * draft_local_max_stride + block_idx,
+                draft_max,
+            )
+            tl.store(
+                draft_local_sumexp_ptr
+                + logit_idx * draft_local_sumexp_stride
+                + block_idx,
+                draft_sumexp,
+            )
 
 
 @triton.jit
@@ -196,6 +200,7 @@ def _probabilistic_rejection_kernel(
     pos_ptr,
     vocab_num_blocks,
     PADDED_VOCAB_NUM_BLOCKS: tl.constexpr,
+    HAS_DRAFT_LOGITS: tl.constexpr,
 ):
     req_idx = tl.program_id(0)
     req_state_idx = tl.load(idx_mapping_ptr + req_idx)
@@ -238,12 +243,6 @@ def _probabilistic_rejection_kernel(
                 target_logit = tl.load(
                     target_logits_ptr + logit_idx * target_logits_stride + draft_sampled
                 ).to(tl.float32)
-                draft_logit = tl.load(
-                    draft_logits_ptr
-                    + req_state_idx * draft_logits_stride_0
-                    + i * draft_logits_stride_1
-                    + draft_sampled
-                ).to(tl.float32)
                 target_lse = _compute_global_lse(
                     target_local_max_ptr,
                     target_local_max_stride,
@@ -253,19 +252,29 @@ def _probabilistic_rejection_kernel(
                     vocab_num_blocks,
                     PADDED_VOCAB_NUM_BLOCKS,
                 )
-                draft_lse = _compute_global_lse(
-                    draft_local_max_ptr,
-                    draft_local_max_stride,
-                    draft_local_sumexp_ptr,
-                    draft_local_sumexp_stride,
-                    logit_idx,
-                    vocab_num_blocks,
-                    PADDED_VOCAB_NUM_BLOCKS,
-                )
                 target_log_prob = target_logit - target_lse
-                draft_log_prob = draft_logit - draft_lse
                 pos = tl.load(pos_ptr + logit_idx)
                 u = tl_rand64(seed, pos, includes_zero=False)
+                if HAS_DRAFT_LOGITS:
+                    draft_logit = tl.load(
+                        draft_logits_ptr
+                        + req_state_idx * draft_logits_stride_0
+                        + i * draft_logits_stride_1
+                        + draft_sampled
+                    ).to(tl.float32)
+                    draft_lse = _compute_global_lse(
+                        draft_local_max_ptr,
+                        draft_local_max_stride,
+                        draft_local_sumexp_ptr,
+                        draft_local_sumexp_stride,
+                        logit_idx,
+                        vocab_num_blocks,
+                        PADDED_VOCAB_NUM_BLOCKS,
+                    )
+                    draft_log_prob = draft_logit - draft_lse
+                else:
+                    # One-hot draft: q(draft_token) = 1, log_q = 0.
+                    draft_log_prob = 0
                 # Probability ratio test: p(x) > u * q(x)
                 # Equivalent log form: log_p(x) > log(u) + log_q(x)
                 accepted &= target_log_prob > tl.log(u) + draft_log_prob
@@ -301,6 +310,8 @@ def _resample_kernel(
     cu_num_logits_ptr,
     # [num_logits]
     expanded_idx_mapping_ptr,
+    # [num_logits]
+    draft_sampled_ptr,
     # [max_num_reqs]
     temp_ptr,
     # [max_num_reqs]
@@ -309,6 +320,7 @@ def _resample_kernel(
     pos_ptr,
     vocab_size,
     BLOCK_SIZE: tl.constexpr,
+    HAS_DRAFT_LOGITS: tl.constexpr,
 ):
     req_idx = tl.program_id(0)
     resample_idx = tl.load(rejected_step_ptr + req_idx)
@@ -327,22 +339,17 @@ def _resample_kernel(
     block_idx = tl.program_id(1)
     block = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = block < vocab_size
+    target_logits = tl.load(
+        target_logits_ptr + resample_token_idx * target_logits_stride + block,
+        mask=mask,
+        other=float("-inf"),
+    ).to(tl.float32)
 
-    # Compute the residual logits to resample the rejected token
-    # from. In the case of no rejections (bonus token), we directly
-    # use the target logits.
+    # Compute the residual logits to resample the rejected token from.
     if is_bonus:
-        residual_logits = tl.load(
-            target_logits_ptr + resample_token_idx * target_logits_stride + block,
-            mask=mask,
-            other=float("-inf"),
-        ).to(tl.float32)
-    else:
-        target_logits = tl.load(
-            target_logits_ptr + resample_token_idx * target_logits_stride + block,
-            mask=mask,
-            other=float("-inf"),
-        ).to(tl.float32)
+        # Bonus token (no rejections). Directly use the target logits.
+        residual_logits = target_logits
+    elif HAS_DRAFT_LOGITS:
         draft_logits = tl.load(
             draft_logits_ptr
             + req_state_idx * draft_logits_stride_0
@@ -363,6 +370,15 @@ def _resample_kernel(
         residual_logits = tl.where(
             ratio < 1.0,
             target_log_probs + tl.log(1 - ratio),
+            float("-inf"),
+        ).to(tl.float32)
+    else:
+        # One-hot draft. The residual is just the target distribution with
+        # the rejected draft token probability zeroed out.
+        rejected_draft_token = tl.load(draft_sampled_ptr + resample_token_idx + 1)
+        residual_logits = tl.where(
+            block != rejected_draft_token,
+            target_logits,
             float("-inf"),
         ).to(tl.float32)
 
@@ -456,7 +472,7 @@ def probabilistic_rejection_sample(
     # [num_logits, V]
     target_logits: torch.Tensor,
     # [max_num_reqs, num_speculative_steps, V]
-    draft_logits: torch.Tensor,
+    draft_logits: torch.Tensor | None,
     # [num_logits]
     draft_sampled: torch.Tensor,
     # [num_reqs + 1]
@@ -477,9 +493,17 @@ def probabilistic_rejection_sample(
 ) -> tuple[torch.Tensor, torch.Tensor]:
     num_reqs = cu_num_logits.shape[0] - 1
     num_logits, vocab_size = target_logits.shape
+    has_draft_logits = draft_logits is not None
 
-    # Gather draft logits, compute target argmax for greedy, and
-    # compute per-block LSE and max for non-greedy requests.
+    if draft_logits is None:
+        # When draft_logits is None, create a dummy tensor so that Triton
+        # kernel signatures receive valid pointers/strides. The kernels
+        # will never read from it when HAS_DRAFT_LOGITS=False.
+        draft_logits = target_logits.new_empty(1, 1, 1)
+
+    # Compute the block-level logits stats, such as target argmax
+    # (for greedy requests), and target max + softmax exponential
+    # (for non-greedy requests).
     VOCAB_BLOCK_SIZE = 8192
     vocab_num_blocks = triton.cdiv(vocab_size, VOCAB_BLOCK_SIZE)
     padded_vocab_num_blocks = triton.next_power_of_2(vocab_num_blocks)
@@ -498,7 +522,7 @@ def probabilistic_rejection_sample(
     draft_local_sumexp = target_logits.new_empty(
         num_logits, vocab_num_blocks, dtype=torch.float32
     )
-    _compute_block_max_and_sumexp_kernel[(num_logits, vocab_num_blocks)](
+    _compute_block_stats_kernel[(num_logits, vocab_num_blocks)](
         target_local_argmax,
         target_local_argmax.stride(0),
         target_local_max,
@@ -520,6 +544,7 @@ def probabilistic_rejection_sample(
         vocab_size,
         num_speculative_steps,
         BLOCK_SIZE=VOCAB_BLOCK_SIZE,
+        HAS_DRAFT_LOGITS=has_draft_logits,
     )
 
     # Sample up until the first rejected/bonus token, and store
@@ -559,6 +584,7 @@ def probabilistic_rejection_sample(
         pos,
         vocab_num_blocks,
         PADDED_VOCAB_NUM_BLOCKS=padded_vocab_num_blocks,
+        HAS_DRAFT_LOGITS=has_draft_logits,
         num_warps=1,
     )
 
@@ -587,11 +613,13 @@ def probabilistic_rejection_sample(
         num_sampled,
         cu_num_logits,
         expanded_idx_mapping,
+        draft_sampled,
         temperature,
         seed,
         pos,
         vocab_size,
         BLOCK_SIZE=RESAMPLE_BLOCK_SIZE,
+        HAS_DRAFT_LOGITS=has_draft_logits,
     )
 
     # Insert the resampled tokens into the output sampled.

--- a/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
+++ b/vllm/v1/worker/gpu/spec_decode/rejection_sampler.py
@@ -21,63 +21,6 @@ from vllm.v1.worker.gpu.spec_decode.synthetic_rejection_sampler_utils import (
 
 
 @triton.jit
-def _strict_rejection_sample_kernel(
-    sampled_ptr,  # [num_reqs, num_speculative_steps + 1]
-    sampled_stride,
-    num_sampled_ptr,  # [num_reqs]
-    target_sampled_ptr,  # [num_draft_tokens + num_reqs]
-    input_ids_ptr,  # [num_draft_tokens + num_reqs]
-    cu_num_logits_ptr,  # [num_reqs + 1]
-):
-    req_idx = tl.program_id(0)
-    start_idx = tl.load(cu_num_logits_ptr + req_idx)
-    end_idx = tl.load(cu_num_logits_ptr + req_idx + 1)
-    num_tokens = end_idx - start_idx
-
-    num_sampled = 0
-    rejected = False
-    for i in range(num_tokens - 1):
-        if not rejected:
-            target_sampled = tl.load(target_sampled_ptr + start_idx + i)
-            draft_sampled = tl.load(input_ids_ptr + start_idx + i + 1)
-            tl.store(sampled_ptr + req_idx * sampled_stride + i, target_sampled)
-            num_sampled += 1
-            if target_sampled != draft_sampled:
-                rejected = True
-    if not rejected:
-        target_sampled = tl.load(target_sampled_ptr + start_idx + num_tokens - 1)
-        tl.store(
-            sampled_ptr + req_idx * sampled_stride + num_tokens - 1, target_sampled
-        )
-        num_sampled += 1
-    tl.store(num_sampled_ptr + req_idx, num_sampled)
-
-
-def strict_rejection_sample(
-    # [num_draft_tokens + num_reqs]
-    target_sampled: torch.Tensor,
-    # [num_draft_tokens + num_reqs]
-    draft_sampled: torch.Tensor,
-    # [num_reqs + 1]
-    cu_num_logits: torch.Tensor,
-    num_speculative_steps,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    num_reqs = cu_num_logits.shape[0] - 1
-    sampled = target_sampled.new_empty(num_reqs, num_speculative_steps + 1)
-    num_sampled = target_sampled.new_empty(num_reqs, dtype=torch.int32)
-    _strict_rejection_sample_kernel[(num_reqs,)](
-        sampled,
-        sampled.stride(0),
-        num_sampled,
-        target_sampled,
-        draft_sampled,
-        cu_num_logits,
-        num_warps=1,
-    )
-    return sampled, num_sampled
-
-
-@triton.jit
 def _flatten_sampled_kernel(
     # [num_logits]
     flat_sampled_ptr,
@@ -163,17 +106,7 @@ class RejectionSampler:
         # that num_nans is computed before applying penalties and temperature.
         num_nans = get_num_nans(logits) if self.sampler.compute_nans else None
 
-        if self.rejection_sample_method == "strict":
-            sampler_output = self.sampler(logits, input_batch)
-            logprobs_tensors = sampler_output.logprobs_tensors
-            sampled, num_sampled = strict_rejection_sample(
-                sampler_output.sampled_token_ids.view(-1),
-                draft_sampled,
-                input_batch.cu_num_logits,
-                self.num_speculative_steps,
-            )
-        elif self.rejection_sample_method == "probabilistic":
-            assert draft_logits is not None
+        if self.rejection_sample_method == "standard":
             pos = input_batch.positions[input_batch.logits_indices]
             processed_logits = self.sampler.apply_sampling_params(
                 logits,


### PR DESCRIPTION
# Context
Currently, MRV1 does not use the true draft logits for rejection sampling. Instead, it [samples draft tokens via argmax](https://github.com/vllm-project/vllm/blob/22fa63cfe849c38bbdb590163043230a1a1a6148/vllm/v1/spec_decode/eagle.py#L398C9-L398C23), essentially treating the draft probability distribution, q(x), as one-hot. This changes the standard rejection sampling ratio probability test from u < p(x) / q(x) to u < p(x), as shown [here](https://github.com/vllm-project/vllm/blob/22fa63cfe849c38bbdb590163043230a1a1a6148/vllm/v1/sample/rejection_sampler.py#L738). If the token is rejected, it samples from the residual correction which is just p(x) with the draft token's probability zero-ed out, respecting the target distribution.

MRV2 currently uses strict acceptance by default, which only accepts a draft token if it exactly matches the target sampled token. This is suboptimal for rejection sampling acceptance rates. MRV2 also has a WIP "probabilistic" rejection sampling feature, but it uses the true, full draft probabilities for potentially higher acceptance rates, at the cost of more memory usage.

# This PR
Achieve parity with MRV1's rejection sampling by enabling the "middle-ground" rejection sampling in MRV2 which greedily samples draft tokens and treats the draft distribution as one-hot. This yields acceptance rates on par with MRV1, while not storing the full draft logits.

I added a separate parameter called "draft_sample_method". When set to `greedy`, argmax is used for the draft tokens, like in MRV1. When set to `gumbel`, gumbel sampling is used and we do rejection sampling with the full draft probabilities. By default, this parameter is set to `greedy`.

# Benchmarks
**Command**
```
VLLM_USE_V2_MODEL_RUNNER=0 vllm serve Qwen/Qwen3-8B \
  --no-enable-prefix-caching \
  --tensor-parallel-size 1 \
  --data-parallel-size 1 \
  --speculative-config '{"method": "eagle3", "model": "RedHatAI/Qwen3-8B-speculator.eagle3", "num_speculative_tokens": 7}'
```

## mt-bench, temperature = 0.0
Metric | MRV1 | MRV2 Before | MRV2 After
-- | -- | -- | --
Successful requests | 1000 | 1000 | 1000
Failed requests | 0 | 0 | 0
Maximum request concurrency | 64 | 64 | 64
Benchmark duration (s) | 18.80 | 15.92 | 15.81
Total input tokens | 67464 | 67464 | 67464
Total generated tokens | 128000 | 128000 | 128000
Request throughput (req/s) | 53.18 | 62.81 | 63.26
Output token throughput (tok/s) | 6807.12 | 8039.99 | 8097.38
Peak output token throughput (tok/s) | 3458.00 | 3531.00 | 3582.00
Peak concurrent requests | 131.00 | 132.00 | 133.00
Total token throughput (tok/s) | 10394.90 | 12277.57 | 12365.21
TTFT |   |   |  
Mean TTFT (ms) | 84.94 | 70.67 | 67.16
Median TTFT (ms) | 58.32 | 57.53 | 57.29
P99 TTFT (ms) | 729.46 | 220.55 | 226.36
P90 TTFT (ms) | 76.07 | 98.83 | 70.28
TPOT |   |   |  
Mean TPOT (ms) | 7.55 | 7.25 | 7.26
Median TPOT (ms) | 7.36 | 7.17 | 7.19
P99 TPOT (ms) | 11.78 | 9.94 | 10.04
P90 TPOT (ms) | 8.99 | 8.58 | 8.52
ITL |   |   |  
Mean ITL (ms) | 18.35 | 18.06 | 17.66
Median ITL (ms) | 18.57 | 17.31 | 17.85
P99 ITL (ms) | 29.69 | 33.03 | 28.00
P90 ITL (ms) | 21.69 | 22.04 | 21.28
E2EL |   |   |  
Mean E2EL (ms) | 1043.23 | 991.74 | 989.02
Median E2EL (ms) | 1001.96 | 980.03 | 976.66
P99 E2EL (ms) | 1758.04 | 1467.56 | 1461.79
P90 E2EL (ms) | 1245.77 | 1170.54 | 1151.91
Speculative Decoding |   |   |  
Acceptance rate (%) | 21.52 | 21.51 | 21.53
Acceptance length | 2.51 | 2.51 | 2.51
Drafts | 51217 | 51208 | 51202
Draft tokens | 358519 | 358456 | 358414
Accepted tokens | 77153 | 77110 | 77154
Position 0 acceptance (%) | 66.67 | 66.62 | 66.65
Position 1 acceptance (%) | 40.48 | 40.64 | 40.68
Position 2 acceptance (%) | 20.75 | 20.64 | 20.67
Position 3 acceptance (%) | 10.74 | 10.64 | 10.64
Position 4 acceptance (%) | 6.09 | 6.09 | 6.10
Position 5 acceptance (%) | 3.63 | 3.66 | 3.65
Position 6 acceptance (%) | 2.27 | 2.30 | 2.30

## mt-bench, temperature = 1.0
Metric | MRV1 | MRV2 Before | MRV2 After
-- | -- | -- | --
Successful requests | 1000 | 1000 | 1000
Failed requests | 0 | 0 | 0
Maximum request concurrency | 64 | 64 | 64
Benchmark duration (s) | 18.45 | 19.46 | 16.98
Total input tokens | 67464 | 67464 | 67464
Total generated tokens | 128000 | 128000 | 128000
Request throughput (req/s) | 54.19 | 51.38 | 58.90
Output token throughput (tok/s) | 6936.04 | 6576.37 | 7538.83
Peak output token throughput (tok/s) | 3177.00 | 3152.00 | 3454.00
Peak concurrent requests | 126.00 | 129.00 | 129.00
Total token throughput (tok/s) | 10591.77 | 10042.53 | 11512.27
TTFT |   |   |  
Mean TTFT (ms) | 100.60 | 70.85 | 69.23
Median TTFT (ms) | 62.71 | 62.69 | 59.63
P99 TTFT (ms) | 728.42 | 202.44 | 264.41
P90 TTFT (ms) | 78.58 | 79.71 | 77.62
TPOT |   |   |  
Mean TPOT (ms) | 8.33 | 9.07 | 7.84
Median TPOT (ms) | 8.34 | 9.13 | 7.91
P99 TPOT (ms) | 11.42 | 11.97 | 10.85
P90 TPOT (ms) | 9.91 | 10.61 | 9.19
ITL |   |   |  
Mean ITL (ms) | 19.92 | 19.90 | 18.72
Median ITL (ms) | 19.64 | 19.55 | 18.48
P99 ITL (ms) | 34.30 | 35.86 | 33.44
P90 ITL (ms) | 23.63 | 23.40 | 22.31
E2EL |   |   |  
Mean E2EL (ms) | 1158.92 | 1222.96 | 1065.17
Median E2EL (ms) | 1135.27 | 1228.25 | 1074.25
P99 E2EL (ms) | 1866.05 | 1587.92 | 1455.58
P90 E2EL (ms) | 1397.99 | 1425.59 | 1242.41
Speculative Decoding |   |   |  
Acceptance rate (%) | 20.82 | 17.55 | 20.63
Acceptance length | 2.46 | 2.23 | 2.44
Drafts | 52129 | 57417 | 52402
Draft tokens | 364903 | 401919 | 366814
Accepted tokens | 75975 | 70535 | 75670
Position 0 acceptance (%) | 64.71 | 59.84 | 64.53
Position 1 acceptance (%) | 39.10 | 33.09 | 39.10
Position 2 acceptance (%) | 19.98 | 15.05 | 19.60
Position 3 acceptance (%) | 10.40 | 7.41 | 9.97
Position 4 acceptance (%) | 5.83 | 3.88 | 5.66
Position 5 acceptance (%) | 3.52 | 2.22 | 3.42
Position 6 acceptance (%) | 2.19 | 1.36 | 2.14

# Future Work
synthetic rejection sampling needs to be modified so that it takes into account the performance of standard rejection sampling (with or without draft logits).