### PR TITLE
[vLLM IR] Port mul_and_silu to IR op

### DIFF
--- a/tests/kernels/core/test_activation.py
+++ b/tests/kernels/core/test_activation.py
@@ -8,6 +8,13 @@ import torch
 
 from tests.kernels.allclose_default import get_default_atol, get_default_rtol
 from tests.kernels.utils import opcheck
+from vllm import ir
+from vllm.config import (
+    CompilationConfig,
+    VllmConfig,
+    get_cached_compilation_config,
+    set_current_vllm_config,
+)
 from vllm.model_executor.layers.activation import (
     FastGELU,
     FatreluAndMul,
@@ -152,3 +159,41 @@ def test_activation(
 
     out = torch.empty_like(x)
     opcheck(fn, (out, x))
+
+
+def test_mul_and_silu_disabled_custom_op_uses_native_impl(monkeypatch):
+    vllm_config = VllmConfig(
+        compilation_config=CompilationConfig(
+            backend="eager", custom_ops=["all", "-mul_and_silu"]
+        )
+    )
+    get_cached_compilation_config.cache_clear()
+
+    x = torch.randn(8, 16, dtype=torch.float32)
+    call_tracker = {"native": False, "dispatch": False}
+    native_impl = ir.ops.mul_and_silu.impls["native"]
+    original_native_impl = native_impl.impl_fn
+
+    def tracked_native_impl(x: torch.Tensor) -> torch.Tensor:
+        call_tracker["native"] = True
+        return original_native_impl(x)
+
+    def dispatch_should_not_run(*args, **kwargs) -> torch.Tensor:
+        call_tracker["dispatch"] = True
+        raise AssertionError(
+            "MulAndSilu.forward_native() should not call the dispatching IR op "
+            "when the custom op is disabled."
+        )
+
+    monkeypatch.setattr(native_impl, "impl_fn", tracked_native_impl)
+    monkeypatch.setattr(ir.ops.mul_and_silu, "torch_op", dispatch_should_not_run)
+
+    with set_current_vllm_config(vllm_config):
+        layer = MulAndSilu()
+
+        assert not layer.enabled()
+        out = layer(x)
+
+    torch.testing.assert_close(out, original_native_impl(x), atol=0.0, rtol=0.0)
+    assert call_tracker["native"]
+    assert not call_tracker["dispatch"]

--- a/tests/kernels/ir/test_mul_and_silu.py
+++ b/tests/kernels/ir/test_mul_and_silu.py
@@ -31,8 +31,7 @@ def test_mul_and_silu_registration():
         "xpu_kernels": current_platform.is_xpu(),
     }
     actual = {
-        provider: impl.supported
-        for provider, impl in ir.ops.mul_and_silu.impls.items()
+        provider: impl.supported for provider, impl in ir.ops.mul_and_silu.impls.items()
     }
     assert actual == expected
 

--- a/tests/kernels/ir/test_mul_and_silu.py
+++ b/tests/kernels/ir/test_mul_and_silu.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+import torch
+
+import vllm.kernels  # noqa: F401
+from tests.kernels.allclose_default import get_default_rtol
+from vllm import ir
+from vllm.platforms import current_platform
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def mul_and_silu_inputs(n_tokens: int, d: int, dtype: torch.dtype):
+    x = torch.randn(n_tokens, 2 * d, dtype=dtype)
+    return (x,)
+
+
+mul_and_silu_native = ir.ops.mul_and_silu.impls["native"].impl_fn
+
+
+def _priority(provider: str) -> list[str]:
+    return [provider] if provider == "native" else [provider, "native"]
+
+
+def test_mul_and_silu_registration():
+    expected = {
+        "native": True,
+        "vllm_c": current_platform.is_cuda_alike(),
+        "xpu_kernels": current_platform.is_xpu(),
+    }
+    actual = {
+        provider: impl.supported
+        for provider, impl in ir.ops.mul_and_silu.impls.items()
+    }
+    assert actual == expected
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("n_tokens", [1, 8, 17])
+@pytest.mark.parametrize("d", [16, 256, 2048])
+class TestMulAndSilu:
+    def test_native_semantics(self, dtype, n_tokens, d):
+        (x,) = mul_and_silu_inputs(n_tokens, d, dtype)
+        out_ir = ir.ops.mul_and_silu(x)
+        out_native = mul_and_silu_native(x)
+        torch.testing.assert_close(out_ir, out_native, rtol=0.0, atol=0.0)
+
+    @pytest.mark.parametrize("provider", ["vllm_c", "xpu_kernels"])
+    def test_impls(self, dtype, n_tokens, d, provider):
+        impl = ir.ops.mul_and_silu.impls[provider]
+        if not impl.supported:
+            pytest.skip(f"{provider} not supported")
+
+        torch.set_default_device(current_platform.device_type)
+        (x,) = mul_and_silu_inputs(n_tokens, d, dtype)
+        out_impl = impl.impl_fn(x)
+        out_native = mul_and_silu_native(x)
+        torch.testing.assert_close(
+            out_impl, out_native, rtol=get_default_rtol(out_impl), atol=1e-3
+        )
+
+        with ir.ops.mul_and_silu.set_priority(_priority(provider)):
+            out_dispatched = ir.ops.mul_and_silu(x)
+        torch.testing.assert_close(out_dispatched, out_impl, rtol=0.0, atol=0.0)
+
+    @pytest.mark.parametrize("provider", ["native", "vllm_c", "xpu_kernels"])
+    def test_torch_opcheck(self, dtype, n_tokens, d, provider):
+        if not ir.ops.mul_and_silu.impls[provider].supported:
+            pytest.skip(f"{provider} not supported")
+
+        (x,) = mul_and_silu_inputs(n_tokens, d, dtype)
+        with ir.ops.mul_and_silu.set_priority(_priority(provider)):
+            torch.library.opcheck(torch.ops.vllm_ir.mul_and_silu, (x,))

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -31,6 +31,9 @@ class IrOpPriorityConfig:
     rms_norm: list[str] = Field(default_factory=list)
     """Priority list for vllm.ir.ops.rms_norm"""
 
+    mul_and_silu: list[str] = Field(default_factory=list)
+    """Priority list for vllm.ir.ops.mul_and_silu"""
+
     def compute_hash(self) -> str:
         """
         Produces a hash unique to the pass configuration.

--- a/vllm/ir/ops/__init__.py
+++ b/vllm/ir/ops/__init__.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from .activation import mul_and_silu
 from .layernorm import rms_norm
 
-__all__ = ["rms_norm"]
+__all__ = ["rms_norm", "mul_and_silu"]

--- a/vllm/ir/ops/activation.py
+++ b/vllm/ir/ops/activation.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from ..op import register_op
+
+
+@register_op
+def mul_and_silu(x: Tensor) -> Tensor:
+    """Activation function for SwiGLU with multiplication before SiLU."""
+    d = x.shape[-1] // 2
+    return x[..., :d] * F.silu(x[..., d:])
+
+
+@mul_and_silu.register_input_generator
+def _mul_and_silu_input_generator(
+    num_tokens: int, hidden_size: int, dtype: torch.dtype
+) -> tuple:
+    x = torch.randn(num_tokens, 2 * hidden_size, dtype=dtype)
+    return (x,)

--- a/vllm/kernels/vllm_c.py
+++ b/vllm/kernels/vllm_c.py
@@ -31,3 +31,12 @@ def rms_norm(
     output = torch.empty(x.shape, device=x.device, dtype=x.dtype)
     torch.ops._C.rms_norm(output, x, weight, epsilon)
     return output
+
+
+@ir.ops.mul_and_silu.register_impl("vllm_c", supported=CUDA_ALIKE)
+def mul_and_silu(x: Tensor) -> Tensor:
+    d = x.shape[-1] // 2
+    output_shape = x.shape[:-1] + (d,)
+    out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+    torch.ops._C.mul_and_silu(out, x)
+    return out

--- a/vllm/kernels/xpu_ops.py
+++ b/vllm/kernels/xpu_ops.py
@@ -38,9 +38,7 @@ def rms_norm(
     return output
 
 
-@ir.ops.mul_and_silu.register_impl(
-    "xpu_kernels", supported=XPU_KERNELS_SUPPORTED
-)
+@ir.ops.mul_and_silu.register_impl("xpu_kernels", supported=XPU_KERNELS_SUPPORTED)
 def mul_and_silu(x: Tensor) -> Tensor:
     d = x.shape[-1] // 2
     output_shape = x.shape[:-1] + (d,)

--- a/vllm/kernels/xpu_ops.py
+++ b/vllm/kernels/xpu_ops.py
@@ -36,3 +36,14 @@ def rms_norm(
     output = torch.empty(x.shape, device=x.device, dtype=x.dtype)
     torch.ops._C.rms_norm(output, x, weight, epsilon)
     return output
+
+
+@ir.ops.mul_and_silu.register_impl(
+    "xpu_kernels", supported=XPU_KERNELS_SUPPORTED
+)
+def mul_and_silu(x: Tensor) -> Tensor:
+    d = x.shape[-1] // 2
+    output_shape = x.shape[:-1] + (d,)
+    out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+    torch.ops._C.mul_and_silu(out, x)
+    return out

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -8,6 +8,8 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+import vllm.kernels  # noqa: F401
+from vllm import ir
 from vllm.distributed import (
     divide,
     get_tensor_model_parallel_rank,
@@ -174,15 +176,10 @@ class MulAndSilu(CustomOp):
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
         """PyTorch-native implementation equivalent to forward()."""
-        d = x.shape[-1] // 2
-        return x[..., :d] * F.silu(x[..., d:])
+        return ir.ops.mul_and_silu(x)
 
     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
-        d = x.shape[-1] // 2
-        output_shape = x.shape[:-1] + (d,)
-        out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
-        self.op(out, x)
-        return out
+        return ir.ops.mul_and_silu(x)
 
     def forward_xpu(self, x: torch.Tensor) -> torch.Tensor:
         return self.forward_cuda(x)

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -176,7 +176,7 @@ class MulAndSilu(CustomOp):
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
         """PyTorch-native implementation equivalent to forward()."""
-        return ir.ops.mul_and_silu(x)
+        return ir.ops.mul_and_silu.impls["native"].impl_fn(x)
 
     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
         return ir.ops.mul_and_silu(x)


### PR DESCRIPTION



## Purpose

This PR ports `mul_and_silu` to a vLLM IR op as part of the activation IR migration in [#40406](https://github.com/vllm-project/vllm/issues/40406).

Following changes were made:
- adds `vllm.ir.ops.mul_and_silu`
- routes `MulAndSilu.forward_native()` and `forward_cuda()` through `ir.ops.mul_and_silu(...)`
- registers `vllm_c` and `xpu_kernels` IR providers
- adds the IR priority config entry for `mul_and_silu`
- adds an input generator for the new IR op
- adds focused IR tests for registration, dispatch, provider parity, and `torch.library.opcheck`
- reuses the existing `torch.ops._C.mul_and_silu` kernel through the IR provider.

## Test Plan

```bash
.venv/bin/python -m pytest tests/kernels/core/test_activation.py -k mul_and_silu -v
.venv/bin/python -m pytest tests/kernels/ir/test_ir_ops.py::test_all_ops_have_input_generator -v
.venv/bin/python -m pytest tests/kernels/ir/test_mul_and_silu.py -v
```

Manual verification of the CUDA IR provider path:

```bash
.venv/bin/python - <<'PY'
import torch
import vllm.kernels  # noqa: F401
from vllm import ir
from vllm.config import VllmConfig, set_current_vllm_config
from vllm.model_executor.layers.activation import MulAndSilu

cfg = VllmConfig()
cfg.kernel_config.ir_op_priority.mul_and_silu = ["vllm_c", "native"]

x = torch.randn(4, 16, device="cuda", dtype=torch.float16)

with set_current_vllm_config(cfg):
    layer = MulAndSilu()
    with cfg.kernel_config.ir_op_priority.set_priority():
        print("Active IR priority:", ir.ops.mul_and_silu.get_priority())
        print("Selected provider:", ir.ops.mul_and_silu.dispatch(x).provider)

        y = layer.forward_cuda(x)

        ref = torch.empty((4, 8), device="cuda", dtype=torch.float16)
        torch.ops._C.mul_and_silu(ref, x)

        torch.testing.assert_close(y, ref, atol=0.0, rtol=0.0)
        print("Matched torch.ops._C.mul_and_silu exactly")
PY
```

## Test Result

- .venv/bin/python -m pytest tests/kernels/core/test_activation.py -k mul_and_silu -v 
   18 passed, 162 deselected
- .venv/bin/python -m pytest tests/kernels/ir/test_ir_ops.py::test_all_ops_have_input_generator -v
   1 passed
- .venv/bin/python -m pytest tests/kernels/ir/test_mul_and_silu.py -v
   109 passed, 54 skipped

Manual IR provider verification:

- active IR priority: ['vllm_c']
- selected provider: vllm_c
- output matched torch.ops._C.mul_and_silu exactly

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

