### PR TITLE
[codex] Ignore empty connector-polling profiling steps

### DIFF
--- a/tests/v1/worker/test_gpu_profiler.py
+++ b/tests/v1/worker/test_gpu_profiler.py
@@ -5,6 +5,8 @@ import pytest
 from vllm.config import ProfilerConfig
 from vllm.config.profiler import _is_uri_path
 from vllm.profiler.wrapper import WorkerProfiler
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.utils import should_profile_scheduler_output
 
 
 class ConcreteWorkerProfiler(WorkerProfiler):
@@ -203,6 +205,28 @@ def test_mixed_delay_and_stop(default_profiler_config):
     profiler.step()
 
     assert profiler.start_call_count == 0
+
+
+def test_should_profile_scheduler_output_keeps_empty_non_connector_step():
+    scheduler_output = SchedulerOutput.make_empty()
+
+    assert should_profile_scheduler_output(scheduler_output) is True
+
+
+def test_should_profile_scheduler_output_skips_empty_connector_step():
+    scheduler_output = SchedulerOutput.make_empty()
+    scheduler_output.kv_connector_metadata = object()
+
+    assert should_profile_scheduler_output(scheduler_output) is False
+
+
+def test_should_profile_scheduler_output_keeps_non_empty_connector_step():
+    scheduler_output = SchedulerOutput.make_empty()
+    scheduler_output.kv_connector_metadata = object()
+    scheduler_output.num_scheduled_tokens = {"req-0": 1}
+    scheduler_output.total_num_scheduled_tokens = 1
+
+    assert should_profile_scheduler_output(scheduler_output) is True
 
 
 class TestIsUriPath:

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -501,3 +501,22 @@ def compute_iteration_details(scheduler_output: SchedulerOutput) -> IterationDet
         num_generation_requests,
         num_generation_tokens,
     )
+
+
+def should_profile_scheduler_output(scheduler_output: SchedulerOutput) -> bool:
+    """Whether a scheduler step should consume profiler iterations.
+
+    Zero-token steps are sometimes used only to advance KV connector state,
+    such as async remote-KV polling or handshake completion. Those steps do
+    not execute model kernels, so profiling them only burns through delayed
+    start and max-iteration budgets without capturing useful data.
+
+    We keep the previous behavior for non-connector zero-token steps (for
+    example, dummy passes in other execution modes) by only skipping the step
+    when a KV connector is active.
+    """
+
+    return (
+        scheduler_output.total_num_scheduled_tokens > 0
+        or scheduler_output.kv_connector_metadata is None
+    )

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -54,7 +54,11 @@ from vllm.v1.outputs import (
     DraftTokenIds,
     ModelRunnerOutput,
 )
-from vllm.v1.utils import compute_iteration_details, report_usage_stats
+from vllm.v1.utils import (
+    compute_iteration_details,
+    report_usage_stats,
+    should_profile_scheduler_output,
+)
 from vllm.v1.worker.utils import is_residual_scattered_for_sp
 from vllm.v1.worker.worker_base import CompilationTimes, WorkerBase
 from vllm.v1.worker.workspace import init_workspace_manager
@@ -721,7 +725,7 @@ class Worker(WorkerBase):
         # add trace annotation so that we can easily distinguish
         # context/generation request numbers in each iteration.
         # A context request is a request that has not yet generated any tokens
-        if not self.profiler:
+        if not self.profiler or not should_profile_scheduler_output(scheduler_output):
             return nullcontext()
 
         self.profiler.step()


### PR DESCRIPTION
## What changed

This change stops worker profiling from consuming iterations on zero-token scheduler steps that only advance KV connector state.

Concretely, it:
- adds a small `should_profile_scheduler_output(...)` helper
- skips `profiler.step()` in `GPUWorker.annotate_profile()` for empty connector-only steps
- adds focused tests covering empty connector, empty non-connector, and non-empty connector scheduler outputs

## Why this changed

In P/D disaggregated decode, async remote-KV polling and handshake completion can produce repeated empty scheduler steps with `total_num_scheduled_tokens == 0` while a KV connector is active.

Those steps do not execute model kernels, but they still advanced the CUDA profiler delay/max-iteration counters. In practice, that could exhaust the profiling window on connector polling before the real decode workload arrived.

## Impact

Profiler windows now stay aligned with actual model work instead of connector-only bookkeeping.

This should make CUDA / Nsight captures much more representative for remote-prefill decode profiling, especially when connector handshake or async KV loading happens before useful decode kernels begin.

## Validation

Ran:
- `python -m py_compile vllm/v1/utils.py vllm/v1/worker/gpu_worker.py tests/v1/worker/test_gpu_profiler.py`
- direct helper assertions for the three relevant scheduler-output cases:
  - empty non-connector step is still profiled
  - empty connector-only step is skipped
  - non-empty connector step is still profiled
