### PR TITLE
[Bugfix] Fix DeepSeek V2-Lite Accuracy drop

### DIFF
--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -335,7 +335,7 @@ class MoERunner(MoERunnerInterface):
         """All-reduce shared expert output when the combine kernel already
         reduced fused output.
 
-        * If the combine kernel does the reduction for fused_ouput, reduce
+        * If the combine kernel does the reduction for fused_output, reduce
           shared_output separately. O.w, reduce fused_output+shared_output later.
         * If we have SP (TP=N, DP=M, EP), there is a separate AG step handled
           in the model.

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -335,9 +335,10 @@ class MoERunner(MoERunnerInterface):
         """All-reduce shared expert output when the combine kernel already
         reduced fused output.
 
-        This is the "early" all-reduce path. When the combine kernel produces
-        already-reduced fused output, shared output must be reduced separately
-        to match.
+        * If the combine kernel does the reduction for fused_ouput, reduce
+          shared_output separately. O.w, reduce fused_output+shared_output later.
+        * If we have SP (TP=N, DP=M, EP), there is a separate AG step handled
+          in the model.
         """
         if (
             shared_output is not None

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -216,6 +216,10 @@ class MoERunner(MoERunnerInterface):
         self.gate = gate
         self.quant_method = quant_method
         self.enable_dbo = enable_dbo
+        self._fused_output_is_reduced = (
+            self.quant_method.moe_kernel is not None
+            and self.quant_method.moe_kernel.output_is_reduced()
+        )
 
         self._shared_experts: SharedExperts | None = None
         if shared_experts is not None:
@@ -258,6 +262,10 @@ class MoERunner(MoERunnerInterface):
         if self._shared_experts is not None:
             self._shared_experts._quant_method = quant_method
         self.quant_method = quant_method
+        self._fused_output_is_reduced = (
+            self.quant_method.moe_kernel is not None
+            and self.quant_method.moe_kernel.output_is_reduced()
+        )
 
     def is_internal_router(self) -> bool:
         return self.gate is not None
@@ -320,13 +328,6 @@ class MoERunner(MoERunnerInterface):
             elif shared_output is not None:
                 shared_output *= 1.0 / self.routed_scaling_factor
         return shared_output, fused_output
-
-    @property
-    def _fused_output_is_reduced(self) -> bool:
-        return (
-            self.quant_method.moe_kernel is not None
-            and self.quant_method.moe_kernel.output_is_reduced()
-        )
 
     def _maybe_reduce_shared_expert_output(
         self,

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -216,10 +216,6 @@ class MoERunner(MoERunnerInterface):
         self.gate = gate
         self.quant_method = quant_method
         self.enable_dbo = enable_dbo
-        self._fused_output_is_reduced = (
-            self.quant_method.moe_kernel is not None
-            and self.quant_method.moe_kernel.output_is_reduced()
-        )
 
         self._shared_experts: SharedExperts | None = None
         if shared_experts is not None:
@@ -262,10 +258,6 @@ class MoERunner(MoERunnerInterface):
         if self._shared_experts is not None:
             self._shared_experts._quant_method = quant_method
         self.quant_method = quant_method
-        self._fused_output_is_reduced = (
-            self.quant_method.moe_kernel is not None
-            and self.quant_method.moe_kernel.output_is_reduced()
-        )
 
     def is_internal_router(self) -> bool:
         return self.gate is not None
@@ -329,6 +321,13 @@ class MoERunner(MoERunnerInterface):
                 shared_output *= 1.0 / self.routed_scaling_factor
         return shared_output, fused_output
 
+    @property
+    def _fused_output_is_reduced(self) -> bool:
+        return (
+            self.quant_method.moe_kernel is not None
+            and self.quant_method.moe_kernel.output_is_reduced()
+        )
+
     def _maybe_reduce_shared_expert_output(
         self,
         shared_output: torch.Tensor | None,
@@ -340,7 +339,11 @@ class MoERunner(MoERunnerInterface):
         already-reduced fused output, shared output must be reduced separately
         to match.
         """
-        if shared_output is not None and self._fused_output_is_reduced:
+        if (
+            shared_output is not None
+            and not self.moe_config.is_sequence_parallel
+            and self._fused_output_is_reduced
+        ):
             shared_output = tensor_model_parallel_all_reduce(shared_output)
         return shared_output
 


### PR DESCRIPTION
## Purpose

Fix DeepSeek V2-Lite Accuracy drop introduced by https://github.com/vllm-project/vllm/pull/40560

## Test Plan

Run ` bash .buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_ep_eplb.sh 0.25 200 8010`
Ran + verified all models from https://github.com/vllm-project/vllm/pull/39956
CI MoE Refactor tests

## Test Result

Accuracy went from 0.02 -> 0.35

cc @robertgshaw2-redhat 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

