### PR TITLE
[Core][KV] Retain prefix-cache across hybrid SWA+Full via `is_pinned` blocks

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1864,7 +1864,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Pin prefix-cached blocks by starting ref_cnt=2 and making SWA-DROP
     # decrement by 2. End-of-request free() decrements by 1, leaving blocks
     # at ref_cnt=1 (pinned, not in free queue). OOW blocks drain first.
-    "VLLM_PIN_PREFIX_BLOCKS": lambda: bool(int(os.getenv("VLLM_PIN_PREFIX_BLOCKS", "0"))),
+    "VLLM_PIN_PREFIX_BLOCKS": lambda: bool(
+        int(os.getenv("VLLM_PIN_PREFIX_BLOCKS", "0"))
+    ),
     # Number of tokens per SWA group to pin at each SWA-DROP (most-recent-N).
     # When > 0 and VLLM_PIN_PREFIX_BLOCKS=1, the most recent
     # (VLLM_PIN_SWA_TOKENS // block_size) blocks being dropped stay pinned

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -254,8 +254,7 @@ if TYPE_CHECKING:
     VLLM_USE_FBGEMM: bool = False
     VLLM_GC_DEBUG: str = ""
     VLLM_DEBUG_WORKSPACE: bool = False
-    VLLM_PIN_PREFIX_BLOCKS: bool = False
-    VLLM_PIN_SWA_TOKENS: int = 0
+    VLLM_PIN_SWA_TOKENS: bool = False
     VLLM_PIN_MIN_DROP_SIZE: int = 16
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
     VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD: int = 256
@@ -1861,17 +1860,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Debug workspace allocations.
     # logging of workspace resize operations.
     "VLLM_DEBUG_WORKSPACE": lambda: bool(int(os.getenv("VLLM_DEBUG_WORKSPACE", "0"))),
-    # Pin prefix-cached blocks by starting ref_cnt=2 and making SWA-DROP
-    # decrement by 2. End-of-request free() decrements by 1, leaving blocks
-    # at ref_cnt=1 (pinned, not in free queue). OOW blocks drain first.
-    "VLLM_PIN_PREFIX_BLOCKS": lambda: bool(
-        int(os.getenv("VLLM_PIN_PREFIX_BLOCKS", "0"))
-    ),
-    # Number of tokens per SWA group to pin at each SWA-DROP (most-recent-N).
-    # When > 0 and VLLM_PIN_PREFIX_BLOCKS=1, the most recent
-    # (VLLM_PIN_SWA_TOKENS // block_size) blocks being dropped stay pinned
-    # at ref_cnt=1 instead of being freed. Older blocks free normally.
-    "VLLM_PIN_SWA_TOKENS": lambda: int(os.getenv("VLLM_PIN_SWA_TOKENS", "0")),
+    # On/off switch (true/false) for sliding-window KV block pinning. When
+    # enabled, each SWA drop pins the current sliding window of KV blocks --
+    # the freshest cached blocks and the contiguous anchor a future request
+    # needs to hit the SWA prefix cache -- so they are evicted last. Disabled
+    # by default; all out-of-window blocks then free normally.
+    "VLLM_PIN_SWA_TOKENS": lambda: os.getenv("VLLM_PIN_SWA_TOKENS", "0").lower()
+    in ("1", "true"),
     # Minimum drop size (in blocks) required to activate pinning.
     # Decode-step drops (usually 1 block) skip pinning to avoid bloating the
     # pinned set with unique-tail hashes that provide no prefix-match value.

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -254,6 +254,9 @@ if TYPE_CHECKING:
     VLLM_USE_FBGEMM: bool = False
     VLLM_GC_DEBUG: str = ""
     VLLM_DEBUG_WORKSPACE: bool = False
+    VLLM_PIN_PREFIX_BLOCKS: bool = False
+    VLLM_PIN_SWA_TOKENS: int = 0
+    VLLM_PIN_MIN_DROP_SIZE: int = 16
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
     VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD: int = 256
     VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 1024
@@ -1858,6 +1861,19 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Debug workspace allocations.
     # logging of workspace resize operations.
     "VLLM_DEBUG_WORKSPACE": lambda: bool(int(os.getenv("VLLM_DEBUG_WORKSPACE", "0"))),
+    # Pin prefix-cached blocks by starting ref_cnt=2 and making SWA-DROP
+    # decrement by 2. End-of-request free() decrements by 1, leaving blocks
+    # at ref_cnt=1 (pinned, not in free queue). OOW blocks drain first.
+    "VLLM_PIN_PREFIX_BLOCKS": lambda: bool(int(os.getenv("VLLM_PIN_PREFIX_BLOCKS", "0"))),
+    # Number of tokens per SWA group to pin at each SWA-DROP (most-recent-N).
+    # When > 0 and VLLM_PIN_PREFIX_BLOCKS=1, the most recent
+    # (VLLM_PIN_SWA_TOKENS // block_size) blocks being dropped stay pinned
+    # at ref_cnt=1 instead of being freed. Older blocks free normally.
+    "VLLM_PIN_SWA_TOKENS": lambda: int(os.getenv("VLLM_PIN_SWA_TOKENS", "0")),
+    # Minimum drop size (in blocks) required to activate pinning.
+    # Decode-step drops (usually 1 block) skip pinning to avoid bloating the
+    # pinned set with unique-tail hashes that provide no prefix-match value.
+    "VLLM_PIN_MIN_DROP_SIZE": lambda: int(os.getenv("VLLM_PIN_MIN_DROP_SIZE", "16")),
     # Disables parallel execution of shared_experts via separate cuda stream
     "VLLM_DISABLE_SHARED_EXPERTS_STREAM": lambda: bool(
         int(os.getenv("VLLM_DISABLE_SHARED_EXPERTS_STREAM", "0"))

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -3,6 +3,7 @@
 from collections.abc import Iterable, Sequence
 from typing import Any
 
+import vllm.envs as envs
 from vllm.distributed.kv_events import (
     MEDIUM_GPU,
     AllBlocksCleared,
@@ -10,7 +11,6 @@ from vllm.distributed.kv_events import (
     BlockStored,
     KVCacheEvent,
 )
-import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import (
@@ -182,12 +182,9 @@ class BlockPool:
 
         self.metrics_collector = metrics_collector
 
-        # Oldest-first deque of blocks at ref_cnt=0 AND is_pinned=True.
-        # These blocks are prefix-cache retention candidates. They are
-        # NOT drained by get_new_blocks directly; demote_n() under
-        # pressure flips is_pinned=False and moves them to free_block_queue.
-        from collections import deque as _deque
-        self.pinned_free_deque: _deque = _deque()
+        # For Sliding Window block when VLLM_PIN_PREFIX_BLOCKS=1.
+        # The queue where the pinned blocks are stored
+        self.pinned_block_queue: FreeKVCacheBlockQueue = FreeKVCacheBlockQueue([])
 
     def get_cached_block(
         self, block_hash: BlockHash, kv_cache_group_ids: list[int]
@@ -411,22 +408,20 @@ class BlockPool:
 
     def touch(self, blocks: Sequence[KVCacheBlock]) -> None:
         """Touch a block increases its reference count by 1, and may remove
-        the block from whichever free tier it is in (regular or pinned).
-        This is used when a block is hit by another request with the same
-        prefix.
+        the block from the free queue. This is used when a block is hit by
+        another request with the same prefix.
 
         Args:
             blocks: A list of blocks to touch.
         """
         for block in blocks:
-            # ref_cnt=0 means this block is in some free tier (regular
-            # queue if is_pinned=False, pinned_free_deque if is_pinned=True).
+            # ref_cnt=0 means this block is in the free list (i.e. eviction
+            # candidate), so remove it.
             if block.ref_cnt == 0 and not block.is_null:
+                # block is only pinned when it belongs to Sliding Window
+                # attention with VLLM_PIN_PREFIX_BLOCKS=1.
                 if block.is_pinned:
-                    # Stale entries are common after demote_n; avoid O(n)
-                    # removal by leaving the stale entry in place — demote_n
-                    # will skip it on the next pop.
-                    pass
+                    self.pinned_block_queue.remove(block)
                 else:
                     self.free_block_queue.remove(block)
             block.ref_cnt += 1
@@ -434,53 +429,48 @@ class BlockPool:
                 self.metrics_collector.on_block_accessed(block)
 
     def demote_n(self, n: int) -> int:
-        """Under memory pressure, move up to n oldest pinned blocks to
-        the normal free queue by setting is_pinned=False. Their hashes
-        survive until _maybe_evict_cached_block fires on physical reuse.
-        Returns the number actually demoted."""
+        """Only used for Sliding Window attention with VLLM_PIN_PREFIX_BLOCKS=1.
+
+        When free blocks are needed but blocks are pinned, move up to n oldest
+        pinned blocks to the normal free queue by flipping is_pinned=False.
+        Their hashes survive until _maybe_evict_cached_block fires on physical
+        reuse. Returns the number actually demoted.
+        """
         if n <= 0:
             return 0
-        demoted = 0
-        while demoted < n and self.pinned_free_deque:
-            block = self.pinned_free_deque.popleft()
-            # Valid pinned entries satisfy ref_cnt==0 and is_pinned.
-            # Stale entries (e.g., re-touched since being queued) are
-            # just skipped.
-            if block.ref_cnt == 0 and block.is_pinned and not block.is_null:
-                block.is_pinned = False
-                self.free_block_queue.append_n([block])
-                demoted += 1
-        return demoted
+        num_to_demote = min(n, self.pinned_block_queue.num_free_blocks)
+        if num_to_demote <= 0:
+            return 0
+        blocks = self.pinned_block_queue.popleft_n(num_to_demote)
+        for block in blocks:
+            block.is_pinned = False
+        self.free_block_queue.append_n(blocks)
+        return num_to_demote
 
     def free_blocks(self, ordered_blocks: Iterable[KVCacheBlock]) -> None:
-        """Decrement ref_cnt by 1 on each block. Blocks whose ref_cnt
-        reaches 0 are routed to either the normal free queue or the
-        pinned_free_deque based on their is_pinned flag.
+        """Free a list of blocks. The blocks should be ordered by their
+        eviction priority, where the first block will be evicted first.
 
         Args:
-            ordered_blocks: list of blocks to free, ordered by eviction
-                priority (first = evicted first within its tier).
+            ordered_blocks: A list of blocks to free ordered by their eviction
+                priority.
         """
         blocks_list = list(ordered_blocks)
         for block in blocks_list:
-            # null_block is a shared singleton; its ref_cnt has no real meaning.
-            # Pre-patch code let it drift negative silently. Skip decrement here
-            # so the invariant holds for real blocks.
-            if block.is_null:
-                continue
             block.ref_cnt -= 1
-            assert block.ref_cnt >= 0, (
-                f"negative ref_cnt on block {block.block_id}"
-            )
-        # Route ref_cnt==0 blocks to the correct tier.
-        regular_free = []
-        for block in blocks_list:
-            if block.ref_cnt == 0 and not block.is_null:
-                if block.is_pinned:
-                    self.pinned_free_deque.append(block)
-                else:
-                    regular_free.append(block)
-        self.free_block_queue.append_n(regular_free)
+
+        freed = [b for b in blocks_list if b.ref_cnt == 0 and not b.is_null]
+        if not envs.VLLM_PIN_PREFIX_BLOCKS:
+            self.free_block_queue.append_n(freed)
+        else:
+            # Pinning enabled: route freed blocks to the regular vs pinned tier by
+            # is_pinned (pinned blocks are released later via demote_n).
+            regular_free = [b for b in freed if not b.is_pinned]
+            pinned_free = [b for b in freed if b.is_pinned]
+            if regular_free:
+                self.free_block_queue.append_n(regular_free)
+            if pinned_free:
+                self.pinned_block_queue.append_n(pinned_free)
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -182,7 +182,7 @@ class BlockPool:
 
         self.metrics_collector = metrics_collector
 
-        # For Sliding Window block when VLLM_PIN_PREFIX_BLOCKS=1.
+        # For Sliding Window block when VLLM_PIN_SWA_TOKENS enabled.
         # The queue where the pinned blocks are stored
         self.pinned_block_queue: FreeKVCacheBlockQueue = FreeKVCacheBlockQueue([])
 
@@ -419,7 +419,7 @@ class BlockPool:
             # candidate), so remove it.
             if block.ref_cnt == 0 and not block.is_null:
                 # block is only pinned when it belongs to Sliding Window
-                # attention with VLLM_PIN_PREFIX_BLOCKS=1.
+                # attention with VLLM_PIN_SWA_TOKENS enabled.
                 if block.is_pinned:
                     self.pinned_block_queue.remove(block)
                 else:
@@ -429,7 +429,7 @@ class BlockPool:
                 self.metrics_collector.on_block_accessed(block)
 
     def demote_n(self, n: int) -> int:
-        """Only used for Sliding Window attention with VLLM_PIN_PREFIX_BLOCKS=1.
+        """Only used for Sliding Window attention with VLLM_PIN_SWA_TOKENS enabled.
 
         When free blocks are needed but blocks are pinned, move up to n oldest
         pinned blocks to the normal free queue by flipping is_pinned=False.
@@ -460,7 +460,7 @@ class BlockPool:
             block.ref_cnt -= 1
 
         freed = [b for b in blocks_list if b.ref_cnt == 0 and not b.is_null]
-        if not envs.VLLM_PIN_PREFIX_BLOCKS:
+        if not envs.VLLM_PIN_SWA_TOKENS:
             self.free_block_queue.append_n(freed)
         else:
             # Pinning enabled: route freed blocks to the regular vs pinned tier by

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -182,6 +182,13 @@ class BlockPool:
 
         self.metrics_collector = metrics_collector
 
+        # Oldest-first deque of blocks at ref_cnt=0 AND is_pinned=True.
+        # These blocks are prefix-cache retention candidates. They are
+        # NOT drained by get_new_blocks directly; demote_n() under
+        # pressure flips is_pinned=False and moves them to free_block_queue.
+        from collections import deque as _deque
+        self.pinned_free_deque: _deque = _deque()
+
     def get_cached_block(
         self, block_hash: BlockHash, kv_cache_group_ids: list[int]
     ) -> list[KVCacheBlock] | None:
@@ -348,18 +355,19 @@ class BlockPool:
         ret: list[KVCacheBlock] = self.free_block_queue.popleft_n(num_blocks)
 
         # In order to only iterate the list once, we duplicated code a bit
-        _init_refcnt = 2 if envs.VLLM_PIN_PREFIX_BLOCKS else 1
         if self.enable_caching:
             for block in ret:
                 self._maybe_evict_cached_block(block)
                 assert block.ref_cnt == 0
-                block.ref_cnt += _init_refcnt
+                block.ref_cnt += 1
+                block.is_pinned = False
                 if self.metrics_collector:
                     self.metrics_collector.on_block_allocated(block)
         else:
             for block in ret:
                 assert block.ref_cnt == 0
-                block.ref_cnt += _init_refcnt
+                block.ref_cnt += 1
+                block.is_pinned = False
                 if self.metrics_collector:
                     self.metrics_collector.on_block_allocated(block)
         return ret
@@ -403,43 +411,76 @@ class BlockPool:
 
     def touch(self, blocks: Sequence[KVCacheBlock]) -> None:
         """Touch a block increases its reference count by 1, and may remove
-        the block from the free queue. This is used when a block is hit by
-        another request with the same prefix.
+        the block from whichever free tier it is in (regular or pinned).
+        This is used when a block is hit by another request with the same
+        prefix.
 
         Args:
             blocks: A list of blocks to touch.
         """
         for block in blocks:
-            # ref_cnt=0 means this block is in the free list (i.e. eviction
-            # candidate), so remove it.
+            # ref_cnt=0 means this block is in some free tier (regular
+            # queue if is_pinned=False, pinned_free_deque if is_pinned=True).
             if block.ref_cnt == 0 and not block.is_null:
-                self.free_block_queue.remove(block)
+                if block.is_pinned:
+                    # Stale entries are common after demote_n; avoid O(n)
+                    # removal by leaving the stale entry in place — demote_n
+                    # will skip it on the next pop.
+                    pass
+                else:
+                    self.free_block_queue.remove(block)
             block.ref_cnt += 1
             if self.metrics_collector:
                 self.metrics_collector.on_block_accessed(block)
 
-    def free_blocks(self, ordered_blocks: Iterable[KVCacheBlock],
-                    ref_cnt_delta: int = 1) -> None:
-        """Free a list of blocks. The blocks should be ordered by their
-        eviction priority, where the first block will be evicted first.
+    def demote_n(self, n: int) -> int:
+        """Under memory pressure, move up to n oldest pinned blocks to
+        the normal free queue by setting is_pinned=False. Their hashes
+        survive until _maybe_evict_cached_block fires on physical reuse.
+        Returns the number actually demoted."""
+        if n <= 0:
+            return 0
+        demoted = 0
+        while demoted < n and self.pinned_free_deque:
+            block = self.pinned_free_deque.popleft()
+            # Valid pinned entries satisfy ref_cnt==0 and is_pinned.
+            # Stale entries (e.g., re-touched since being queued) are
+            # just skipped.
+            if block.ref_cnt == 0 and block.is_pinned and not block.is_null:
+                block.is_pinned = False
+                self.free_block_queue.append_n([block])
+                demoted += 1
+        return demoted
+
+    def free_blocks(self, ordered_blocks: Iterable[KVCacheBlock]) -> None:
+        """Decrement ref_cnt by 1 on each block. Blocks whose ref_cnt
+        reaches 0 are routed to either the normal free queue or the
+        pinned_free_deque based on their is_pinned flag.
 
         Args:
-            ordered_blocks: A list of blocks to free ordered by their eviction
-                priority.
-            ref_cnt_delta: how much to decrement ref_cnt (default 1).
-                SWA-DROP path uses 2 when VLLM_PIN_PREFIX_BLOCKS is on,
-                to fully release OOW blocks while keeping end-of-request
-                blocks pinned at ref_cnt=1.
+            ordered_blocks: list of blocks to free, ordered by eviction
+                priority (first = evicted first within its tier).
         """
-        # Materialize the iterable to allow multiple passes.
         blocks_list = list(ordered_blocks)
         for block in blocks_list:
-            block.ref_cnt -= ref_cnt_delta
-        newly_free = [
-            block for block in blocks_list
-            if block.ref_cnt == 0 and not block.is_null
-        ]
-        self.free_block_queue.append_n(newly_free)
+            # null_block is a shared singleton; its ref_cnt has no real meaning.
+            # Pre-patch code let it drift negative silently. Skip decrement here
+            # so the invariant holds for real blocks.
+            if block.is_null:
+                continue
+            block.ref_cnt -= 1
+            assert block.ref_cnt >= 0, (
+                f"negative ref_cnt on block {block.block_id}"
+            )
+        # Route ref_cnt==0 blocks to the correct tier.
+        regular_free = []
+        for block in blocks_list:
+            if block.ref_cnt == 0 and not block.is_null:
+                if block.is_pinned:
+                    self.pinned_free_deque.append(block)
+                else:
+                    regular_free.append(block)
+        self.free_block_queue.append_n(regular_free)
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -10,6 +10,7 @@ from vllm.distributed.kv_events import (
     BlockStored,
     KVCacheEvent,
 )
+import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import (
@@ -347,17 +348,18 @@ class BlockPool:
         ret: list[KVCacheBlock] = self.free_block_queue.popleft_n(num_blocks)
 
         # In order to only iterate the list once, we duplicated code a bit
+        _init_refcnt = 2 if envs.VLLM_PIN_PREFIX_BLOCKS else 1
         if self.enable_caching:
             for block in ret:
                 self._maybe_evict_cached_block(block)
                 assert block.ref_cnt == 0
-                block.ref_cnt += 1
+                block.ref_cnt += _init_refcnt
                 if self.metrics_collector:
                     self.metrics_collector.on_block_allocated(block)
         else:
             for block in ret:
                 assert block.ref_cnt == 0
-                block.ref_cnt += 1
+                block.ref_cnt += _init_refcnt
                 if self.metrics_collector:
                     self.metrics_collector.on_block_allocated(block)
         return ret
@@ -416,21 +418,28 @@ class BlockPool:
             if self.metrics_collector:
                 self.metrics_collector.on_block_accessed(block)
 
-    def free_blocks(self, ordered_blocks: Iterable[KVCacheBlock]) -> None:
+    def free_blocks(self, ordered_blocks: Iterable[KVCacheBlock],
+                    ref_cnt_delta: int = 1) -> None:
         """Free a list of blocks. The blocks should be ordered by their
         eviction priority, where the first block will be evicted first.
 
         Args:
             ordered_blocks: A list of blocks to free ordered by their eviction
                 priority.
+            ref_cnt_delta: how much to decrement ref_cnt (default 1).
+                SWA-DROP path uses 2 when VLLM_PIN_PREFIX_BLOCKS is on,
+                to fully release OOW blocks while keeping end-of-request
+                blocks pinned at ref_cnt=1.
         """
         # Materialize the iterable to allow multiple passes.
         blocks_list = list(ordered_blocks)
         for block in blocks_list:
-            block.ref_cnt -= 1
-        self.free_block_queue.append_n(
-            [block for block in blocks_list if block.ref_cnt == 0 and not block.is_null]
-        )
+            block.ref_cnt -= ref_cnt_delta
+        newly_free = [
+            block for block in blocks_list
+            if block.ref_cnt == 0 and not block.is_null
+        ]
+        self.free_block_queue.append_n(newly_free)
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -6,8 +6,8 @@ from collections.abc import Sequence
 from dataclasses import dataclass
 from typing import Literal, overload
 
-from vllm.distributed.kv_events import BlockStored, KVCacheEvent
 import vllm.envs as envs
+from vllm.distributed.kv_events import BlockStored, KVCacheEvent
 from vllm.logger import init_logger
 from vllm.v1.core.kv_cache_coordinator import get_kv_cache_coordinator
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
@@ -162,6 +162,43 @@ class KVCacheManager:
             for group in kv_cache_config.kv_cache_groups
         )
 
+        # Surface a startup hint describing what prefix-cache pinning does,
+        # so operators can confirm the feature is active and how to tune it.
+        if envs.VLLM_PIN_PREFIX_BLOCKS:
+            tokens_per_block = self.block_pool.hash_block_size
+            # Reuse the per-group (kind, sliding_window) metadata computed above
+            # to report the SWA window size(s) without re-walking the groups.
+            swa_windows = sorted({sw for _, sw in self.kv_cache_event_metadata if sw})
+            swa_window_str = (
+                "/".join(str(w) for w in swa_windows) if swa_windows else "none"
+            )
+            pin_tokens = envs.VLLM_PIN_SWA_TOKENS
+            pin_blocks = pin_tokens // tokens_per_block if tokens_per_block else 0
+            # Total reusable span pinned per SWA layer = the in-window tokens
+            # attention keeps plus VLLM_PIN_SWA_TOKENS of out-of-window history.
+            pinned_total_str = (
+                "/".join(str(w + pin_tokens) for w in swa_windows)
+                if swa_windows
+                else str(pin_tokens)
+            )
+            logger.info(
+                "Prefix-cache pinning (VLLM_PIN_PREFIX_BLOCKS) is now ENABLED. "
+                "SWA layers keep a %s-tok sliding window and additionally PIN "
+                "the most-recent %d tok (%d blocks x %d tok) of out-of-window "
+                "history at higher priority, for %s tok pinned per layer "
+                "(window + VLLM_PIN_SWA_TOKENS); out-of-window blocks past the "
+                "pinned span are evicted first. When requests share "
+                "similar-length prefixes, this keeps the commonly reused "
+                "prefix blocks resident and evicts the uniformly unneeded tail "
+                "first, improving prefix-cache reuse. Tune with "
+                "VLLM_PIN_SWA_TOKENS.",
+                swa_window_str,
+                pin_tokens,
+                pin_blocks,
+                tokens_per_block,
+                pinned_total_str,
+            )
+
         # Pre-constructed KVCacheBlocks with no blocks, callers should use this
         # via create_kv_cache_blocks instead of creating new ones to avoid GC
         # overhead.
@@ -233,54 +270,6 @@ class KVCacheManager:
             )
 
         return self.create_kv_cache_blocks(computed_blocks), num_new_computed_tokens
-
-    def can_fit_full_sequence(
-        self,
-        request: Request,
-        num_new_computed_tokens: int = 0,
-        new_computed_blocks: KVCacheBlocks | None = None,
-        num_external_computed_tokens: int = 0,
-        num_encoder_tokens: int = 0,
-    ) -> bool:
-        """Check if the KV cache has enough free blocks to hold the full
-        sequence, accounting for prefix cache hits and sliding window.
-
-        This is used as an admission gate to prevent over-admitting requests
-        when chunked prefill would otherwise only check the first chunk.
-        """
-        if new_computed_blocks is not None:
-            new_computed_block_list = new_computed_blocks.blocks
-        else:
-            new_computed_block_list = self.empty_kv_cache_blocks.blocks
-
-        num_local_computed_tokens = (
-            request.num_computed_tokens + num_new_computed_tokens
-        )
-        total_computed_tokens = min(
-            num_local_computed_tokens + num_external_computed_tokens,
-            self.max_model_len,
-        )
-        full_num_tokens = min(request.num_tokens, self.max_model_len)
-
-        num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
-            request_id=request.request_id,
-            num_tokens=full_num_tokens,
-            new_computed_blocks=new_computed_block_list,
-            num_encoder_tokens=num_encoder_tokens,
-            total_computed_tokens=total_computed_tokens,
-            num_tokens_main_model=full_num_tokens,
-        )
-
-        num_free = self.block_pool.get_num_free_blocks()
-        if num_blocks_to_allocate > num_free and envs.VLLM_PIN_PREFIX_BLOCKS:
-            # Under pressure: demote oldest pinned blocks to make room.
-            # can_fit_full_sequence is called before allocate_slots and
-            # gates admission independently; without this hook the
-            # scheduler would stall even if demotable pins exist.
-            deficit = num_blocks_to_allocate - num_free
-            self.block_pool.demote_n(deficit)
-            num_free = self.block_pool.get_num_free_blocks()
-        return num_blocks_to_allocate <= num_free
 
     def allocate_slots(
         self,
@@ -405,7 +394,17 @@ class KVCacheManager:
                 num_tokens_main_model=full_num_tokens,
                 apply_admission_cap=True,
             )
-            if num_blocks_to_allocate > self.block_pool.get_num_free_blocks():
+            num_free = self.block_pool.get_num_free_blocks()
+            if envs.VLLM_PIN_PREFIX_BLOCKS and num_blocks_to_allocate > num_free:
+                # Under pressure: demote oldest pinned blocks to make room.
+                # The full_sequence_must_fit admission gate otherwise
+                # rejects without giving the pinned tier a chance to release,
+                # deadlocking once pinned blocks fill the pool. demote_n is
+                # best-effort, so re-check free space afterwards.
+                deficit = num_blocks_to_allocate - num_free
+                self.block_pool.demote_n(deficit)
+                num_free = self.block_pool.get_num_free_blocks()
+            if num_blocks_to_allocate > num_free:
                 return None
 
         num_tokens_main_model = total_computed_tokens + num_new_tokens
@@ -434,15 +433,16 @@ class KVCacheManager:
         )
 
         num_free_blocks = self.block_pool.get_num_free_blocks()
-        if num_blocks_to_allocate > num_free_blocks:
+        if envs.VLLM_PIN_PREFIX_BLOCKS and num_blocks_to_allocate > num_free_blocks:
             # Under pressure: demote oldest pinned blocks to make room.
             # Hashes survive until physically recycled, so demoted blocks
-            # remain prefix-cache candidates.
+            # remain prefix-cache candidates. demote_n is best-effort, so
+            # re-check free space afterwards.
             deficit = num_blocks_to_allocate - num_free_blocks
             self.block_pool.demote_n(deficit)
             num_free_blocks = self.block_pool.get_num_free_blocks()
-            if num_blocks_to_allocate > num_free_blocks:
-                return None
+        if num_blocks_to_allocate > num_free_blocks:
+            return None
 
         if (
             new_computed_block_list is not self.empty_kv_cache_blocks.blocks
@@ -492,7 +492,7 @@ class KVCacheManager:
         """
         # is_pinned design: when prefix-cache pinning is enabled, mark
         # all of this request's remaining (non-null) blocks as pinned so
-        # they land in the pinned_free_deque instead of the regular free
+        # they land in the pinned_block_queue instead of the regular free
         # queue. Full-attention blocks protect the full prefix; SWA
         # window blocks protect the last-window hashes.
         if envs.VLLM_PIN_PREFIX_BLOCKS:

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -164,39 +164,24 @@ class KVCacheManager:
 
         # Surface a startup hint describing what prefix-cache pinning does,
         # so operators can confirm the feature is active and how to tune it.
-        if envs.VLLM_PIN_PREFIX_BLOCKS:
-            tokens_per_block = self.block_pool.hash_block_size
+        if envs.VLLM_PIN_SWA_TOKENS:
             # Reuse the per-group (kind, sliding_window) metadata computed above
             # to report the SWA window size(s) without re-walking the groups.
             swa_windows = sorted({sw for _, sw in self.kv_cache_event_metadata if sw})
             swa_window_str = (
                 "/".join(str(w) for w in swa_windows) if swa_windows else "none"
             )
-            pin_tokens = envs.VLLM_PIN_SWA_TOKENS
-            pin_blocks = pin_tokens // tokens_per_block if tokens_per_block else 0
-            # Total reusable span pinned per SWA layer = the in-window tokens
-            # attention keeps plus VLLM_PIN_SWA_TOKENS of out-of-window history.
-            pinned_total_str = (
-                "/".join(str(w + pin_tokens) for w in swa_windows)
-                if swa_windows
-                else str(pin_tokens)
-            )
             logger.info(
-                "Prefix-cache pinning (VLLM_PIN_PREFIX_BLOCKS) is now ENABLED. "
-                "SWA layers keep a %s-tok sliding window and additionally PIN "
-                "the most-recent %d tok (%d blocks x %d tok) of out-of-window "
-                "history at higher priority, for %s tok pinned per layer "
-                "(window + VLLM_PIN_SWA_TOKENS); out-of-window blocks past the "
-                "pinned span are evicted first. When requests share "
-                "similar-length prefixes, this keeps the commonly reused "
-                "prefix blocks resident and evicts the uniformly unneeded tail "
-                "first, improving prefix-cache reuse. Tune with "
-                "VLLM_PIN_SWA_TOKENS.",
+                "Sliding Window KV block pinning (VLLM_PIN_SWA_TOKENS) is now "
+                "ENABLED. SWA layers will PIN the last sliding window block "
+                "(%s tokens) at a higher priority than the rest of the blocks "
+                "in the chunk, so all the last windows are evicted last. This "
+                "frees up KV cache pools by keeping only the KV blocks "
+                "holding the last window, but are able to reuse the entire "
+                "chunk through sliding window attention. The reuse rate "
+                "increases for some traffic by holding more active KV blocks "
+                "on the server. Set VLLM_PIN_SWA_TOKENS=false to disable.",
                 swa_window_str,
-                pin_tokens,
-                pin_blocks,
-                tokens_per_block,
-                pinned_total_str,
             )
 
         # Pre-constructed KVCacheBlocks with no blocks, callers should use this
@@ -394,17 +379,17 @@ class KVCacheManager:
                 num_tokens_main_model=full_num_tokens,
                 apply_admission_cap=True,
             )
-            num_free = self.block_pool.get_num_free_blocks()
-            if envs.VLLM_PIN_PREFIX_BLOCKS and num_blocks_to_allocate > num_free:
+            num_free_blocks = self.block_pool.get_num_free_blocks()
+            if envs.VLLM_PIN_SWA_TOKENS and num_blocks_to_allocate > num_free_blocks:
                 # Under pressure: demote oldest pinned blocks to make room.
                 # The full_sequence_must_fit admission gate otherwise
                 # rejects without giving the pinned tier a chance to release,
                 # deadlocking once pinned blocks fill the pool. demote_n is
                 # best-effort, so re-check free space afterwards.
-                deficit = num_blocks_to_allocate - num_free
+                deficit = num_blocks_to_allocate - num_free_blocks
                 self.block_pool.demote_n(deficit)
-                num_free = self.block_pool.get_num_free_blocks()
-            if num_blocks_to_allocate > num_free:
+                num_free_blocks = self.block_pool.get_num_free_blocks()
+            if num_blocks_to_allocate > num_free_blocks:
                 return None
 
         num_tokens_main_model = total_computed_tokens + num_new_tokens
@@ -433,7 +418,7 @@ class KVCacheManager:
         )
 
         num_free_blocks = self.block_pool.get_num_free_blocks()
-        if envs.VLLM_PIN_PREFIX_BLOCKS and num_blocks_to_allocate > num_free_blocks:
+        if envs.VLLM_PIN_SWA_TOKENS and num_blocks_to_allocate > num_free_blocks:
             # Under pressure: demote oldest pinned blocks to make room.
             # Hashes survive until physically recycled, so demoted blocks
             # remain prefix-cache candidates. demote_n is best-effort, so
@@ -495,7 +480,7 @@ class KVCacheManager:
         # they land in the pinned_block_queue instead of the regular free
         # queue. Full-attention blocks protect the full prefix; SWA
         # window blocks protect the last-window hashes.
-        if envs.VLLM_PIN_PREFIX_BLOCKS:
+        if envs.VLLM_PIN_SWA_TOKENS:
             for mgr in self.coordinator.single_type_managers:
                 for b in mgr.req_to_blocks.get(request.request_id, ()):
                     if not b.is_null:

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Literal, overload
 
 from vllm.distributed.kv_events import BlockStored, KVCacheEvent
+import vllm.envs as envs
 from vllm.logger import init_logger
 from vllm.v1.core.kv_cache_coordinator import get_kv_cache_coordinator
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
@@ -233,6 +234,54 @@ class KVCacheManager:
 
         return self.create_kv_cache_blocks(computed_blocks), num_new_computed_tokens
 
+    def can_fit_full_sequence(
+        self,
+        request: Request,
+        num_new_computed_tokens: int = 0,
+        new_computed_blocks: KVCacheBlocks | None = None,
+        num_external_computed_tokens: int = 0,
+        num_encoder_tokens: int = 0,
+    ) -> bool:
+        """Check if the KV cache has enough free blocks to hold the full
+        sequence, accounting for prefix cache hits and sliding window.
+
+        This is used as an admission gate to prevent over-admitting requests
+        when chunked prefill would otherwise only check the first chunk.
+        """
+        if new_computed_blocks is not None:
+            new_computed_block_list = new_computed_blocks.blocks
+        else:
+            new_computed_block_list = self.empty_kv_cache_blocks.blocks
+
+        num_local_computed_tokens = (
+            request.num_computed_tokens + num_new_computed_tokens
+        )
+        total_computed_tokens = min(
+            num_local_computed_tokens + num_external_computed_tokens,
+            self.max_model_len,
+        )
+        full_num_tokens = min(request.num_tokens, self.max_model_len)
+
+        num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
+            request_id=request.request_id,
+            num_tokens=full_num_tokens,
+            new_computed_blocks=new_computed_block_list,
+            num_encoder_tokens=num_encoder_tokens,
+            total_computed_tokens=total_computed_tokens,
+            num_tokens_main_model=full_num_tokens,
+        )
+
+        num_free = self.block_pool.get_num_free_blocks()
+        if num_blocks_to_allocate > num_free and envs.VLLM_PIN_PREFIX_BLOCKS:
+            # Under pressure: demote oldest pinned blocks to make room.
+            # can_fit_full_sequence is called before allocate_slots and
+            # gates admission independently; without this hook the
+            # scheduler would stall even if demotable pins exist.
+            deficit = num_blocks_to_allocate - num_free
+            self.block_pool.demote_n(deficit)
+            num_free = self.block_pool.get_num_free_blocks()
+        return num_blocks_to_allocate <= num_free
+
     def allocate_slots(
         self,
         request: Request,
@@ -384,9 +433,16 @@ class KVCacheManager:
             num_tokens_main_model=num_tokens_main_model,
         )
 
-        if num_blocks_to_allocate > self.block_pool.get_num_free_blocks():
-            # Cannot allocate new blocks
-            return None
+        num_free_blocks = self.block_pool.get_num_free_blocks()
+        if num_blocks_to_allocate > num_free_blocks:
+            # Under pressure: demote oldest pinned blocks to make room.
+            # Hashes survive until physically recycled, so demoted blocks
+            # remain prefix-cache candidates.
+            deficit = num_blocks_to_allocate - num_free_blocks
+            self.block_pool.demote_n(deficit)
+            num_free_blocks = self.block_pool.get_num_free_blocks()
+            if num_blocks_to_allocate > num_free_blocks:
+                return None
 
         if (
             new_computed_block_list is not self.empty_kv_cache_blocks.blocks
@@ -434,6 +490,16 @@ class KVCacheManager:
         Args:
             request: The request to free the blocks.
         """
+        # is_pinned design: when prefix-cache pinning is enabled, mark
+        # all of this request's remaining (non-null) blocks as pinned so
+        # they land in the pinned_free_deque instead of the regular free
+        # queue. Full-attention blocks protect the full prefix; SWA
+        # window blocks protect the last-window hashes.
+        if envs.VLLM_PIN_PREFIX_BLOCKS:
+            for mgr in self.coordinator.single_type_managers:
+                for b in mgr.req_to_blocks.get(request.request_id, ()):
+                    if not b.is_null:
+                        b.is_pinned = True
         self.coordinator.free(request.request_id)
 
     def remove_skipped_blocks(

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -133,7 +133,7 @@ class KVCacheBlock:
     is_null: bool = False
 
     # Whether the block is pinned as a prefix-cache retention candidate.
-    # Pinned blocks at ref_cnt=0 live in BlockPool.pinned_free_deque
+    # Pinned blocks at ref_cnt=0 live in BlockPool.pinned_block_queue
     # instead of the normal free queue; they are only reissued by
     # get_new_blocks after being demoted via pressure release.
     is_pinned: bool = False

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -132,6 +132,12 @@ class KVCacheBlock:
     # Whether the block is a null block that should never be cached.
     is_null: bool = False
 
+    # Whether the block is pinned as a prefix-cache retention candidate.
+    # Pinned blocks at ref_cnt=0 live in BlockPool.pinned_free_deque
+    # instead of the normal free queue; they are only reissued by
+    # get_new_blocks after being demoted via pressure release.
+    is_pinned: bool = False
+
     @property
     def block_hash(self) -> BlockHashWithGroupId | None:
         return self._block_hash

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -6,7 +6,6 @@ from collections import defaultdict
 from collections.abc import Sequence
 
 import vllm.envs as envs
-
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (
@@ -457,28 +456,7 @@ class SingleTypeKVCacheManager(ABC):
         # range), so we must cap to the number of blocks that currently exist for
         # this request.
         num_skipped_blocks = min(num_skipped_blocks, len(blocks))
-        # Split removed blocks into pinned (most-recent N) vs freed (older).
-        # pin_blocks is the number of MOST-RECENT blocks (closest to current
-        # window) to pin at each call — controlled by VLLM_PIN_SWA_TOKENS.
-        pin_blocks = 0
-        if envs.VLLM_PIN_PREFIX_BLOCKS and envs.VLLM_PIN_SWA_TOKENS > 0:
-            from vllm.v1.kv_cache_interface import SlidingWindowSpec
-            if isinstance(self.kv_cache_spec, SlidingWindowSpec):
-                pin_blocks = envs.VLLM_PIN_SWA_TOKENS // self.block_size
-        # Decode-step drops (small) contain unique-tail hashes; skip pinning.
-        # Count how many NEW blocks are being dropped this call
-        # (i.e., non-null blocks in the range [0, num_skipped_blocks-1]).
-        num_new_drops = 0
-        for _j in range(num_skipped_blocks - 1, -1, -1):
-            if blocks[_j] == self._null_block:
-                break
-            num_new_drops += 1
-        if num_new_drops < envs.VLLM_PIN_MIN_DROP_SIZE:
-            pin_blocks = 0
-        pin_threshold = max(0, num_skipped_blocks - pin_blocks)
-
-        to_free: list[KVCacheBlock] = []
-        to_pin: list[KVCacheBlock] = []
+        removed_blocks: list[KVCacheBlock] = []
         # Because the block starts from index 0, the num_skipped_block-th block
         # corresponds to index num_skipped_blocks - 1.
         for i in range(num_skipped_blocks - 1, -1, -1):
@@ -487,21 +465,9 @@ class SingleTypeKVCacheManager(ABC):
                 # should also have been set to null blocks by the previous calls
                 # to this function.
                 break
-            if pin_blocks > 0 and i >= pin_threshold:
-                to_pin.append(blocks[i])
-            else:
-                to_free.append(blocks[i])
+            removed_blocks.append(blocks[i])
             blocks[i] = self._null_block
-        # is_pinned design: mark pin candidates before freeing. free_blocks
-        # routes ref_cnt==0 blocks to pinned_free_deque if is_pinned=True,
-        # otherwise to the regular free queue. All deltas are 1 (standard).
-        for b in to_pin:
-            b.is_pinned = True
-        # to_pin and to_free both go through free_blocks (delta=1). The
-        # is_pinned flag determines which tier the freed block lands in.
-        all_released = to_free + to_pin
-        if all_released:
-            self.block_pool.free_blocks(all_released)
+        self.block_pool.free_blocks(removed_blocks)
 
     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
         """
@@ -684,6 +650,12 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
     def _cache_block_mask(
         self, num_cached_blocks: int, num_full_blocks: int, alignment_tokens: int
     ) -> list[bool] | None:
+        # When SWA-pinning is enabled (PR #40676), the pinned older blocks need
+        # to be in the prefix-cache hash map so future requests can hit them.
+        # The default mask skips them, defeating the pinning. Cache everything
+        # so the SWA-pin path can do its job.
+        if envs.VLLM_PIN_PREFIX_BLOCKS or envs.VLLM_PIN_SWA_TOKENS > 0:
+            return None
         assert alignment_tokens > self.block_size
         per_segment = alignment_tokens // self.block_size
         tail = cdiv(self.sliding_window - 1, self.block_size)
@@ -721,6 +693,53 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
             The number of tokens that will be skipped for attention computation.
         """
         return max(0, num_computed_tokens - self.sliding_window + 1)
+
+    def remove_skipped_blocks(
+        self, request_id: str, total_computed_tokens: int
+    ) -> None:
+        """Sliding-window block release with prefix-cache pinning.
+
+        As the window advances, the oldest in-window blocks fall out of
+        window. With VLLM_PIN_PREFIX_BLOCKS + VLLM_PIN_SWA_TOKENS>0, the most
+        recent VLLM_PIN_SWA_TOKENS of those out-of-window blocks are PINNED
+        (kept as reusable prefix cache); everything else falls back to the
+        base free-all path.
+        """
+        pin_blocks = 0
+        if envs.VLLM_PIN_PREFIX_BLOCKS and envs.VLLM_PIN_SWA_TOKENS > 0:
+            pin_blocks = envs.VLLM_PIN_SWA_TOKENS // self.block_size
+        if pin_blocks == 0:
+            return super().remove_skipped_blocks(request_id, total_computed_tokens)
+
+        num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
+        if num_skipped_tokens <= 0:
+            return
+        blocks = self.req_to_blocks[request_id]
+        num_skipped_blocks = min(num_skipped_tokens // self.block_size, len(blocks))
+
+        # Small decode-step drops carry unique-tail hashes (no reuse value).
+        num_new_drops = 0
+        for j in range(num_skipped_blocks - 1, -1, -1):
+            if blocks[j] == self._null_block:
+                break
+            num_new_drops += 1
+        if num_new_drops < envs.VLLM_PIN_MIN_DROP_SIZE:
+            return super().remove_skipped_blocks(request_id, total_computed_tokens)
+
+        pin_threshold = max(0, num_skipped_blocks - pin_blocks)
+        to_free: list[KVCacheBlock] = []
+        to_pin: list[KVCacheBlock] = []
+        for i in range(num_skipped_blocks - 1, -1, -1):
+            if blocks[i] == self._null_block:
+                break
+            if i >= pin_threshold:
+                blocks[i].is_pinned = True
+                to_pin.append(blocks[i])
+            else:
+                to_free.append(blocks[i])
+            blocks[i] = self._null_block
+        if to_free or to_pin:
+            self.block_pool.free_blocks(to_free + to_pin)
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         """

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -654,7 +654,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         # to be in the prefix-cache hash map so future requests can hit them.
         # The default mask skips them, defeating the pinning. Cache everything
         # so the SWA-pin path can do its job.
-        if envs.VLLM_PIN_PREFIX_BLOCKS or envs.VLLM_PIN_SWA_TOKENS > 0:
+        if envs.VLLM_PIN_SWA_TOKENS:
             return None
         assert alignment_tokens > self.block_size
         per_segment = alignment_tokens // self.block_size
@@ -700,15 +700,17 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         """Sliding-window block release with prefix-cache pinning.
 
         As the window advances, the oldest in-window blocks fall out of
-        window. With VLLM_PIN_PREFIX_BLOCKS + VLLM_PIN_SWA_TOKENS>0, the most
-        recent VLLM_PIN_SWA_TOKENS of those out-of-window blocks are PINNED
-        (kept as reusable prefix cache); everything else falls back to the
-        base free-all path.
+        window. With VLLM_PIN_SWA_TOKENS enabled, the CURRENT sliding
+        window blocks are PINNED -- they are the freshest cached blocks
+        and the exact contiguous run a future request needs to anchor an
+        SWA prefix-cache hit at this chunk boundary. The window blocks stay
+        live this step; marking is_pinned routes them to the pinned tier
+        when they later fall out of window. All out-of-window blocks are
+        freed -- any previously-pinned window among them survives via its
+        is_pinned flag, which free_blocks routes to the pinned tier.
+        Everything else falls back to the base free-all path.
         """
-        pin_blocks = 0
-        if envs.VLLM_PIN_PREFIX_BLOCKS and envs.VLLM_PIN_SWA_TOKENS > 0:
-            pin_blocks = envs.VLLM_PIN_SWA_TOKENS // self.block_size
-        if pin_blocks == 0:
+        if not envs.VLLM_PIN_SWA_TOKENS:
             return super().remove_skipped_blocks(request_id, total_computed_tokens)
 
         num_skipped_tokens = self.get_num_skipped_tokens(total_computed_tokens)
@@ -726,20 +728,24 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         if num_new_drops < envs.VLLM_PIN_MIN_DROP_SIZE:
             return super().remove_skipped_blocks(request_id, total_computed_tokens)
 
-        pin_threshold = max(0, num_skipped_blocks - pin_blocks)
+        # Pin the current sliding window (the freshest cached anchor). The
+        # blocks stay live now; is_pinned takes effect when they later drop.
+        window_blocks = cdiv(self.sliding_window, self.block_size)
+        win_end = min(num_skipped_blocks + window_blocks, len(blocks))
+        for i in range(num_skipped_blocks, win_end):
+            if blocks[i] != self._null_block:
+                blocks[i].is_pinned = True
+
+        # Free ALL out-of-window blocks. Any previously-pinned window blocks
+        # among them are routed to the pinned tier by free_blocks.
         to_free: list[KVCacheBlock] = []
-        to_pin: list[KVCacheBlock] = []
         for i in range(num_skipped_blocks - 1, -1, -1):
             if blocks[i] == self._null_block:
                 break
-            if i >= pin_threshold:
-                blocks[i].is_pinned = True
-                to_pin.append(blocks[i])
-            else:
-                to_free.append(blocks[i])
+            to_free.append(blocks[i])
             blocks[i] = self._null_block
-        if to_free or to_pin:
-            self.block_pool.free_blocks(to_free + to_pin)
+        if to_free:
+            self.block_pool.free_blocks(to_free)
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         """

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -492,14 +492,16 @@ class SingleTypeKVCacheManager(ABC):
             else:
                 to_free.append(blocks[i])
             blocks[i] = self._null_block
-        # Pin: decrement by 1 so ref_cnt goes 2→1 (stays pinned, not in free queue)
+        # is_pinned design: mark pin candidates before freeing. free_blocks
+        # routes ref_cnt==0 blocks to pinned_free_deque if is_pinned=True,
+        # otherwise to the regular free queue. All deltas are 1 (standard).
         for b in to_pin:
-            b.ref_cnt -= 1
-        # Free fully: decrement by 2 when VLLM_PIN_PREFIX_BLOCKS is on
-        # (blocks started at ref_cnt=2). Otherwise normal 1.
-        if to_free:
-            _delta = 2 if envs.VLLM_PIN_PREFIX_BLOCKS else 1
-            self.block_pool.free_blocks(to_free, ref_cnt_delta=_delta)
+            b.is_pinned = True
+        # to_pin and to_free both go through free_blocks (delta=1). The
+        # is_pinned flag determines which tier the freed block lands in.
+        all_released = to_free + to_pin
+        if all_released:
+            self.block_pool.free_blocks(all_released)
 
     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
         """

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -5,6 +5,8 @@ from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Sequence
 
+import vllm.envs as envs
+
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (
@@ -455,7 +457,28 @@ class SingleTypeKVCacheManager(ABC):
         # range), so we must cap to the number of blocks that currently exist for
         # this request.
         num_skipped_blocks = min(num_skipped_blocks, len(blocks))
-        removed_blocks: list[KVCacheBlock] = []
+        # Split removed blocks into pinned (most-recent N) vs freed (older).
+        # pin_blocks is the number of MOST-RECENT blocks (closest to current
+        # window) to pin at each call — controlled by VLLM_PIN_SWA_TOKENS.
+        pin_blocks = 0
+        if envs.VLLM_PIN_PREFIX_BLOCKS and envs.VLLM_PIN_SWA_TOKENS > 0:
+            from vllm.v1.kv_cache_interface import SlidingWindowSpec
+            if isinstance(self.kv_cache_spec, SlidingWindowSpec):
+                pin_blocks = envs.VLLM_PIN_SWA_TOKENS // self.block_size
+        # Decode-step drops (small) contain unique-tail hashes; skip pinning.
+        # Count how many NEW blocks are being dropped this call
+        # (i.e., non-null blocks in the range [0, num_skipped_blocks-1]).
+        num_new_drops = 0
+        for _j in range(num_skipped_blocks - 1, -1, -1):
+            if blocks[_j] == self._null_block:
+                break
+            num_new_drops += 1
+        if num_new_drops < envs.VLLM_PIN_MIN_DROP_SIZE:
+            pin_blocks = 0
+        pin_threshold = max(0, num_skipped_blocks - pin_blocks)
+
+        to_free: list[KVCacheBlock] = []
+        to_pin: list[KVCacheBlock] = []
         # Because the block starts from index 0, the num_skipped_block-th block
         # corresponds to index num_skipped_blocks - 1.
         for i in range(num_skipped_blocks - 1, -1, -1):
@@ -464,9 +487,19 @@ class SingleTypeKVCacheManager(ABC):
                 # should also have been set to null blocks by the previous calls
                 # to this function.
                 break
-            removed_blocks.append(blocks[i])
+            if pin_blocks > 0 and i >= pin_threshold:
+                to_pin.append(blocks[i])
+            else:
+                to_free.append(blocks[i])
             blocks[i] = self._null_block
-        self.block_pool.free_blocks(removed_blocks)
+        # Pin: decrement by 1 so ref_cnt goes 2→1 (stays pinned, not in free queue)
+        for b in to_pin:
+            b.ref_cnt -= 1
+        # Free fully: decrement by 2 when VLLM_PIN_PREFIX_BLOCKS is on
+        # (blocks started at ref_cnt=2). Otherwise normal 1.
+        if to_free:
+            _delta = 2 if envs.VLLM_PIN_PREFIX_BLOCKS else 1
+            self.block_pool.free_blocks(to_free, ref_cnt_delta=_delta)
 
     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
         """


### PR DESCRIPTION
## Purpose

Hybrid SWA + full-attention models (e.g. Gemma-3/4) get near-0% cross-request prefix-cache reuse once the prefix working set grows: as the sliding window advances, SWA layers drop out-of-window blocks and free them, the freed blocks rejoin the FIFO free queue, and they are recycled before the next request can reuse the shared prefix — even when the KV cache still has spare capacity.

<img width="1466" height="879" alt="image" src="https://github.com/user-attachments/assets/d375cdcc-cfc3-4567-96df-d38df290e25c" />

This PR adds opt-in SWA prefix-cache pinning behind a single boolean knob `VLLM_PIN_SWA_TOKENS` (default `false`). When enabled, each SWA window-drop PINS the current sliding-window blocks (one window per chunk) instead of freeing them, so the contiguous anchor a future request needs to hit the SWA prefix cache stays resident and is evicted last.

Implementation: an `is_pinned` flag plus a second `pinned_block_queue` tier in `BlockPool`; `SlidingWindowManager.remove_skipped_blocks` owns the pin policy while the base manager stays pinning-agnostic; pinned blocks remain registered in the prefix-cache hash map so they stay hittable; and `BlockPool.demote_n` releases the oldest pinned blocks (best-effort) under allocation pressure so the scheduler never stalls. Full-attention layers are unchanged.

| Env var | Default | Purpose |
|---|---|---|
| `VLLM_PIN_SWA_TOKENS` | `false` | On/off switch for SWA prefix-cache pinning. When enabled, each SWA window-drop pins the current sliding-window blocks (one window per chunk) instead of freeing them. |
| `VLLM_PIN_MIN_DROP_SIZE` | `16` | Minimum drop size (in blocks) required to pin; filters out small decode-step drops. |

## Test Plan

- Unit tests: `tests/v1/core/test_prefix_caching.py` (SWA block release, admission gating, full-sequence admission).
- A/B serving on Gemma-4-31B-IT, TP4, H200, conc=1, OSL=400, prefix caching on, sweeping the number of distinct ~28k-token prefixes (the working-set size) with only `VLLM_PIN_SWA_TOKENS` differing. KV cache = 1.47M tokens.
- `VLLM_PIN_MIN_DROP_SIZE` ablation (16 vs 0) at 30 prefixes.
- Accuracy: GSM8K 5-shot and SCBench RepoQA, pinning on vs off.
- Lint: full `pre-commit run --all-files`.

## Test Result

Unit tests: 61 passed. 

Prefix-working-set scaling — TTFT avg and output throughput (`—` = not run):

| Prefixes (total input) | TTFT (ms) (main) | TTFT (ms) PR | tok/s main | tok/s PR |
|---|---|---|---|---|
| 15 (0.43M, fits cache) | 403 | 404 | 73.3 | 73.3 |
| 30 (0.85M) | 1992 | 440 | 56.8 | 72.8 |
| 50 (1.42M) | — | 458 | — | 74.2 |
| 60 (1.70M) | — | 452 | — | 72.7 |

At 15 prefixes the working set fits the cache, nothing is evicted, and ON == OFF within noise (TTFT +0.6 ms, throughput identical) — pinning adds no measurable overhead when it is not needed. 
Upstream main loses SWA reuse as early as 20 prefixes and re-prefills the full ~28k prefix per request (TTFT 403 → 1990 ms, 73 → 57 tok/s), while pinning (ON) keeps TTFT ~440–458 ms and ~73 tok/s through 60 prefixes (1.70M tokens, above the 1.47M cache). At 30 prefixes that is −78% TTFT and +28% throughput. Decode is unaffected throughout (ITL 12.66 ms in every run).

With this, maximum prefix cache can be stored by max-num-batched-token / window_size times, in this case (8k, 1k), 8x more prefix cache can be stored on a server.

`VLLM_PIN_MIN_DROP_SIZE` ablation (ON, 30 prefixes): 16 vs 0 is perf-neutral — TTFT 440.0 vs 442.3 ms, throughput 72.8 vs 72.9 tok/s (within noise). The filter only matters under real pressure, where `=0` pins unique decode-tail blocks and adds demotion churn; `16` is the safe default.

Accuracy is unchanged (pinning only changes which KV blocks are reused, not the computation): GSM8K 5-shot identical within noise on vs off (0.7127 / 0.7043 vs 0.7157 / 0.7043, flexible / strict), SCBench RepoQA Pass@1 73.0% on both.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

