### PR TITLE
[Bugfix] Fix KeyError in get_attn_backends_for_group when using PP

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6211,7 +6211,7 @@ class GPUModelRunner(
             # attention backend subclasses (e.g. ChunkedLocalAttention) unless
             # they are cached correctly, there will be different objects per
             # layer.
-            for layer_name in kv_cache_group_spec.layer_names:
+            for layer_name in layers:
                 attn_backend = layers[layer_name].get_attn_backend()
 
                 if layer_name in self.kv_sharing_fast_prefill_eligible_layers:


### PR DESCRIPTION
## Latest Status

The reported issue runs normally when using 1-node ray with 4x4090. 
I think this bug will only happen with 4 distinct ray nodes. Given I do not have access to this environment setup, I will just close this PR.

## Purpose

Closes #40649. 

When models use pipeline parallel, each rank only has its local stage's layers. But the code still tries to access `kv_cache_group_spec.layer_names`, which are global and contain layer names from other ranks, so it triggers key error. Changing code to only access local layer names on each machine fix this error. Because the `layers` are already filtered to the local stage by `get_layers_from_vllm_config`.

## Test Plan

The described error can be reproduced using this script, 

<details>

```
"""
Minimal repro for vllm-project/vllm#40649:
KeyError in `get_attn_backends_for_group` on non-zero PP ranks.

Bug: `get_attn_backends_for_group` iterates `kv_cache_group_spec.layer_names`
(global across all PP stages) but indexes into `layers` (filtered to only the
local stage by `get_layers_from_vllm_config`). On any PP rank > 0 the lookup
misses and raises KeyError.

Fix: iterate `layers` directly, which is already the local-rank subset.

Run:
    .venv/bin/python repro_40649.py            # buggy behavior
    .venv/bin/python repro_40649.py --fixed    # patched behavior
"""

import argparse
import sys


class FakeLayer:
    def __init__(self, idx: int) -> None:
        self.idx = idx

    def get_attn_backend(self) -> str:
        return f"FakeAttnBackend(layer={self.idx})"


def simulate_pp_rank(
    pp_rank: int,
    pp_size: int,
    num_layers: int,
    fixed: bool,
) -> None:
    # kv_cache_group_spec.layer_names is global across all PP stages.
    global_layer_names = [
        f"model.layers.{i}.self_attn.attn" for i in range(num_layers)
    ]

    # Each PP rank only owns its local stage. This mirrors what
    # `get_layers_from_vllm_config(..., kv_cache_group_spec.layer_names)`
    # returns on a PP worker: the spec's names filtered to the layers
    # actually present in this worker's static_forward_context.
    per_rank = num_layers // pp_size
    local_start = pp_rank * per_rank
    local_end = local_start + per_rank
    layers = {
        f"model.layers.{i}.self_attn.attn": FakeLayer(i)
        for i in range(local_start, local_end)
    }

    # The loop in get_attn_backends_for_group.
    visited: list[str] = []
    try:
        iterable = layers if fixed else global_layer_names
        for layer_name in iterable:
            layers[layer_name].get_attn_backend()
            visited.append(layer_name)
    except KeyError as e:
        print(
            f"[pp_rank={pp_rank}] FAILED after visiting {len(visited)} layers: "
            f"KeyError({e})"
        )
        return
    print(
        f"[pp_rank={pp_rank}] OK — built backends for {len(visited)} local layers"
    )


def main() -> int:
    parser = argparse.ArgumentParser()
    parser.add_argument("--fixed", action="store_true", help="use the patched loop")
    parser.add_argument("--pp-size", type=int, default=4)
    parser.add_argument("--num-layers", type=int, default=80)
    args = parser.parse_args()

    label = "FIXED" if args.fixed else "BUGGY"
    print(f"=== {label}: pp_size={args.pp_size}, num_layers={args.num_layers} ===")
    for rank in range(args.pp_size):
        simulate_pp_rank(rank, args.pp_size, args.num_layers, fixed=args.fixed)
    return 0


if __name__ == "__main__":
    sys.exit(main())

```

</details>

If you run with the script using original version and `--fixed`, you can see 

```
 === BUGGY: pp_size=4, num_layers=80 ===                   
  [pp_rank=0] FAILED after visiting 20 layers: KeyError('model.layers.20.self_attn.attn')
  [pp_rank=1] FAILED after visiting 0 layers: KeyError('model.layers.0.self_attn.attn')                                                  
  [pp_rank=2] FAILED after visiting 0 layers: KeyError('model.layers.0.self_attn.attn')                                                  
  [pp_rank=3] FAILED after visiting 0 layers: KeyError('model.layers.0.self_attn.attn') 

=== FIXED: pp_size=4, num_layers=80 ===                   
  [pp_rank=0] OK — built backends for 20 local layers                                                                                    
  [pp_rank=1] OK — built backends for 20 local layers       
  [pp_rank=2] OK — built backends for 20 local layers                                                                                    
  [pp_rank=3] OK — built backends for 20 local layers

```


## Test Result

Similarly, you can just run the original issue's command, serve `Llama-3.3-70B-AWQ` across a 4-node Ray cluster (1× RTX 4090 each), 

```
vllm serve casperhansen/llama-3.3-70b-instruct-awq \                                                                                   
    --tensor-parallel-size 1 \                                                                                                           
    --pipeline-parallel-size 4 \
    --distributed-executor-backend ray \                                                                                                 
    --quantization awq_marlin \                             
    --attention-backend FLASH_ATTN \                                                                                                     
    --max-model-len 8192 \
    --trust-remote-code  
```

Before: crashes on PP ranks 1/2/3 with KeyError: 'model.layers.N.self_attn.attn' during initialize_attn_backend.                     
After: engine initializes; a one-shot /v1/completions request returns a response.

I will paste the before and after result within an hour


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

