### PR TITLE
[Bugfix] fix incorrect apply_interleaved_rope in mrope under torch.compile

### DIFF
--- a/vllm/model_executor/layers/rotary_embedding/mrope.py
+++ b/vllm/model_executor/layers/rotary_embedding/mrope.py
@@ -192,10 +192,13 @@ def apply_interleaved_rope(x: torch.Tensor, mrope_section: list[int]) -> torch.T
     Reorganizes frequency layout from chunked [TTT...HHH...WWW] to
     interleaved [THTHWHTHW...TT], preserving frequency continuity.
     """
-    x_t = x[0].clone()
-    x_t[..., 1 : mrope_section[1] * 3 : 3] = x[1, ..., 1 : mrope_section[1] * 3 : 3]
-    x_t[..., 2 : mrope_section[2] * 3 : 3] = x[2, ..., 2 : mrope_section[2] * 3 : 3]
-    return x_t
+    half_rd = x.shape[-1]
+    idx = torch.arange(half_rd, device=x.device)
+    h_mask = (idx % 3 == 1) & (idx < 3 * mrope_section[1])
+    w_mask = (idx % 3 == 2) & (idx < 3 * mrope_section[2])
+    out = torch.where(h_mask, x[1], x[0])
+    out = torch.where(w_mask, x[2], out)
+    return out
 
 
 class MRotaryEmbedding(RotaryEmbeddingBase):


### PR DESCRIPTION



## Purpose
Hi there, I observed a potential bug in vllm/model_executor/layers/rotary_embedding/mrope.py: apply_interleaved_rope behaves differently before and after torch.compile on CUDA.

Root cause: a Triton compiler bug (Triton 3.5.1 / PyTorch 2.10.0-rc6). Specifically, a stride-3 slice_scatter on 3D tensors where source and destination are different slices along dim 0 produces cyclically shifted values in the compiled PTX/cubin. The generated Triton kernel is logically correct, but the compiled output is wrong. The issue is triggered only for stride = 3.

Impact: compiled model produces incorrect rotary embedding values for the interleaved RoPE codepath. This can lead to  significant errors in attention outputs when using torch.compile.

## Test Plan

## Test Result

Reproduction
```python
import torch


def apply_interleaved_rope(x: torch.Tensor, mrope_section: list[int]) -> torch.Tensor:
    x_t = x[0].clone()
    x_t[..., 1 : mrope_section[1] * 3 : 3] = x[1, ..., 1 : mrope_section[1] * 3 : 3]
    x_t[..., 2 : mrope_section[2] * 3 : 3] = x[2, ..., 2 : mrope_section[2] * 3 : 3]
    return x_t


def apply_interleaved_rope2(x: torch.Tensor, mrope_section: list) -> torch.Tensor:
    half_rd = x.shape[-1]
    idx = torch.arange(half_rd, device=x.device)
    h_mask = (idx % 3 == 1) & (idx < 3 * mrope_section[1])
    w_mask = (idx % 3 == 2) & (idx < 3 * mrope_section[2])
    out = torch.where(h_mask, x[1], x[0])
    out = torch.where(w_mask, x[2], out)
    return out


def main():
    torch.manual_seed(0)
    mrope_section = [24, 20, 20]            # sum = 64 = head_dim // 2
    x = torch.randn(3, 3167, 64, dtype=torch.bfloat16, device="cuda")

    y_eager = apply_interleaved_rope(x, mrope_section)
    y_compiled = torch.compile(apply_interleaved_rope)(x, mrope_section)
    y_compiled2 = torch.compile(apply_interleaved_rope2)(x, mrope_section)

    diff = (y_eager.float() - y_compiled.float()).abs()
    print(f"max abs error : {diff.max().item():.6e}")
    print(f"mean abs error: {diff.mean().item():.6e}")

    print('-----')

    diff = (y_eager.float() - y_compiled2.float()).abs()
    print(f"max abs error : {diff.max().item():.6e}")
    print(f"mean abs error: {diff.mean().item():.6e}")


if __name__ == "__main__":
    main()
```

Environment: Triton 3.5.1 / PyTorch 2.10.0-rc6

Output:
```
max abs error : 6.320312e+00
mean abs error: 5.269650e-01
-----
max abs error : 0.000000e+00
mean abs error: 0.000000e+00
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

