### PR TITLE
[Bugfix] Fix double off-by-one in align_to_block_size in example_connector

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/example_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/example_connector.py
@@ -292,7 +292,7 @@ class ExampleConnector(KVConnectorBase_V1):
         # Now, first num_tokens_to_check tokens are hit, we need to prepare
         # the metadata for the worker connector to correctly load the KV
         token_ids = request.prompt_token_ids or []
-        num_tokens_to_check = align_to_block_size(len(token_ids) - 1, self._block_size)
+        num_tokens_to_check = align_to_block_size(len(token_ids), self._block_size)
 
         return num_tokens_to_check - num_computed_tokens, False
 
@@ -404,7 +404,7 @@ class ExampleConnector(KVConnectorBase_V1):
         mm_hashes: list[str],
     ) -> bool:
         num_tokens_to_check = align_to_block_size(
-            len(prompt_token_ids) - 1, self._block_size
+            len(prompt_token_ids), self._block_size
         )
         foldername = self._generate_foldername_debug(
             torch.tensor(prompt_token_ids)[:num_tokens_to_check],


### PR DESCRIPTION
## Purpose
Fix an off-by-one error in `ExampleConnector` (`vllm/distributed/kv_transfer/kv_connector/v1/example_connector.py`) that caused KV cache misses at  block-size boundaries.

  `align_to_block_size` already subtracts 1 internally:

  ```python
  return (num_tokens - 1) // block_size * block_size
  ```

  However, two call sites additionally passed len(...) - 1, resulting in a double subtraction. For example, with 17 tokens and block_size=16:

    Before: ((17 - 1) - 1) // 16 * 16 = 0   → cache miss
    After:  (17 - 1)        // 16 * 16 = 16 → cache hit

  Affected call sites:
  - get_num_new_matched_tokens (line 297)
  - _found_match_for_prompt (line 408)

## Test Plan

1. In `examples/offline_inference/disaggregated-prefill-v1/prefill_example.py`, I constructed a sample 17-token prompt to verify the disaggregated prefill logic.

Modified `read_prompts()` as follows:
```python
def read_prompts():
    return [
        "hello Hi, I am tom , I am a student. The capital city of USA"
    ]
```
2. Check the KV cache files in the local_storage directory.
3. Run the examples/offline_inference/disaggregated-prefill-v1/decode_example.py script and check the logs to verify if the KV cache files were used during the prefill stage.

## Test Result

- bofore  :  kv cache miss 

<img width="1834" height="981" alt="image" src="https://github.com/user-attachments/assets/d04b5b89-bc93-4108-ab73-266db26f66d7" />

- after : hit cache

prefill

<img width="1846" height="136" alt="image" src="https://github.com/user-attachments/assets/b660d7d3-cb48-4793-afb5-401f526f61d2" />
 
  **decode**  **: hit cache**
<img width="1832" height="1014" alt="image" src="https://github.com/user-attachments/assets/ad0c365a-11f3-43d4-8121-95020a649bf6" />




