### PR TITLE
[vLLM IR] Propagate IR op name and provider to profiler annotations

### DIFF
--- a/vllm/compilation/passes/ir/lowering_pass.py
+++ b/vllm/compilation/passes/ir/lowering_pass.py
@@ -3,6 +3,9 @@
 from collections import defaultdict
 from collections.abc import Iterable
 
+import torch
+import torch._inductor.config as inductor_config
+import torch._inductor.pattern_matcher as _pm
 from torch import fx
 from torch._inductor.pattern_matcher import (
     CallFunctionVarArgs,
@@ -63,6 +66,8 @@ class VllmIRLoweringPass(VllmInductorPass):
         self.patterns = PatternMatcherPass(self.pass_name)
         self.selected_impls: dict[str, dict[str, str]] = defaultdict(lambda: {})
         self.ops = [ir_op.torch_op for ir_op in IrOp.registry.values()]
+        
+        inductor_config.triton.descriptive_names = "torch"
 
         # Look for any call_function node where the target is a vLLM IR op.
         # Then, lower_matched_op will select, trace, and insert the implementation.
@@ -88,6 +93,10 @@ class VllmIRLoweringPass(VllmInductorPass):
         # replace_by_example wants node args, not the fake tensors
         # TODO(luka): Use aot_export_module to get functionalized graph
         # TODO(luka): Cache the fx_replacement to avoid re-tracing the same impl
+
+        # ``replace_by_example`` transfers metadata from the matched node
+        #  so stamping here is enough to annotate generated kernels.
+        node.meta["source_fn_stack"] = [(node.name, f"vllm_ir_{ir_op.name}_{ir_op_impl.provider}")]
 
         # Defaults not present on node.args but required for replacement tracing
         bound_args = ir_op._py_signature.bind(*node.args)


### PR DESCRIPTION
Closes: #39363 

### Problem Description

When examining a torch.profiler trace or nsys timeline, it is not obvious which GPU kernel corresponds to which vLLM IR operation or which implementation provider was selected. For example, after lowering vllm_ir::rms_norm, the profiler shows a kernel (aten op names) with no indication of the IR op or whether the native or vllm_c (custom CUDA) provider was used.

### Solution:
In `lower_matched_op`, we stamp source_fn_stack on the IR node:

`node.meta["source_fn_stack"] = [(node.name, f"vllm_ir_{ir_op.name}_{ir_op_impl.provider}")]`

With inductor's `triton.descriptive_names = "torch"`, the string surfaces directly in the generated Triton function name:

`triton_per_fused_vllm_ir_rms_norm_native_0`

- Why NVTX and record_function don't work:
-> NVTX markers were removed by CUDA Graphs!
-> torch.profiler.record_function- these are real ATen ops (profiler._record_function_enter_new / _record_function_exit). However, inductor's standard post_grad_passes pipeline removes them. See https://github.com/pytorch/pytorch/blob/2c2148d27530f277012e6b891877d32692b7d9ad/torch/_inductor/fx_passes/post_grad.py#L90

Without IR Lowering: `triton_per_fused__to_copy_add_mean_mul_pow_rsqrt_2`
With IR Lowering: `triton_per_fused_vllm_ir_rms_norm_native_2`


cc @ProExpertProg 