### PR TITLE
[ROCm][Kimi-Linear] Wire FlyDSL gated delta rule decode kernel for KimiDeltaAttention

### DIFF
--- a/tests/kernels/attention/test_flydsl_kda_decode.py
+++ b/tests/kernels/attention/test_flydsl_kda_decode.py
@@ -1,0 +1,175 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""Correctness + availability guard for the FlyDSL KDA decode kernel path
+wired up in ``vllm/model_executor/layers/kda.py``.
+
+This test validates that, when enabled via ``VLLM_ROCM_USE_AITER_FLYDSL_KDA``,
+the FlyDSL gated delta rule decode kernel
+(``aiter.ops.flydsl.linear_attention_kernels.flydsl_gdr_decode``) produces
+output numerically close to the FLA triton kernel
+(``vllm.model_executor.layers.fla.ops.kda.fused_recurrent_kda``) on the exact
+KDA shapes used by Kimi-Linear-48B-A3B.
+
+The test is skipped automatically when:
+  * The host is not ROCm.
+  * AITER / FlyDSL is not importable (older AITER builds).
+  * CUDA/HIP is unavailable.
+
+Why the parametrize grid maps to Kimi-Linear:
+  - head_dim = 128 (config.json: ``linear_attn_config.head_dim``)
+  - num_heads = 32 total, so per-TP local heads are:
+      TP=2 -> 16, TP=4 -> 8, TP=8 -> 4
+
+Correctness tolerance: BF16 recurrent accumulation over the Kimi-Linear
+shapes gives empirical max-abs-diff around 3-5e-3; we assert <= 1.5e-2 to
+accommodate kernel / compiler drift without masking genuine regressions.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+
+
+def _flydsl_kernel_or_skip():
+    if not current_platform.is_rocm():
+        pytest.skip("FlyDSL KDA kernel is ROCm-only")
+    if not torch.cuda.is_available():
+        pytest.skip("No GPU available for FlyDSL KDA test")
+    try:
+        from aiter.ops.flydsl.linear_attention_kernels import (  # noqa: E501
+            flydsl_gdr_decode,
+        )
+    except ImportError as e:
+        pytest.skip(f"aiter.ops.flydsl.flydsl_gdr_decode unavailable: {e}")
+    return flydsl_gdr_decode
+
+
+@pytest.mark.parametrize(
+    "num_heads",
+    [
+        pytest.param(16, id="tp=2-nh=16"),
+        pytest.param(8, id="tp=4-nh=8"),
+        pytest.param(4, id="tp=8-nh=4"),
+    ],
+)
+@pytest.mark.parametrize("bs", [1, 4])
+@pytest.mark.parametrize("head_dim", [128])
+@torch.inference_mode()
+def test_flydsl_kda_decode_matches_fla(num_heads: int, bs: int, head_dim: int):
+    """Head-to-head correctness: FLA triton vs FlyDSL on Kimi-Linear shapes.
+
+    Runs one decode step (T=1) with matched random inputs and checks the
+    kernels agree within BF16 tolerance.
+    """
+    flydsl_gdr_decode = _flydsl_kernel_or_skip()
+    from vllm.model_executor.layers.fla.ops.kda import (
+        fused_kda_gate,
+        fused_recurrent_kda,
+    )
+
+    device = torch.device("cuda")
+    dtype = torch.bfloat16
+    T = 1  # pure decode
+
+    gen = torch.Generator(device=device).manual_seed(0)
+    q = torch.randn(bs, T, num_heads, head_dim, device=device, dtype=dtype, generator=gen) * 0.1
+    k = torch.randn(bs, T, num_heads, head_dim, device=device, dtype=dtype, generator=gen) * 0.1
+    v = torch.randn(bs, T, num_heads, head_dim, device=device, dtype=dtype, generator=gen) * 0.1
+
+    # Match production shapes from vLLM's ``KimiDeltaAttention``:
+    #   * ``g1_raw``  [bs, T, H*D]  = output of ``f_b_proj(f_a_proj(x))``
+    #   * ``beta_raw``[bs, T, H]    = output of ``b_proj(x).float()`` (pre-sigmoid)
+    #   * ``A_log``   [1, 1, H, 1]  (nn.Parameter)
+    #   * ``dt_bias`` [H*D]         (nn.Parameter; per-head-per-dim, not per-head)
+    g1_raw = torch.randn(
+        bs, T, num_heads * head_dim, device=device, dtype=dtype, generator=gen
+    ) * 0.1
+    beta_raw = torch.randn(
+        bs, T, num_heads, device=device, dtype=torch.float32, generator=gen
+    ) * 0.5
+    A_log = (
+        torch.randn(num_heads, device=device, dtype=torch.float32, generator=gen)
+        * -1.0
+        - 2.0
+    ).view(1, 1, num_heads, 1)
+    dt_bias = (
+        torch.randn(
+            num_heads * head_dim,
+            device=device,
+            dtype=torch.float32,
+            generator=gen,
+        )
+        * 0.01
+    )
+
+    state_shape = (bs, num_heads, head_dim, head_dim)
+    state_init = torch.zeros(*state_shape, device=device, dtype=torch.float32)
+
+    # --- FLA path (reference) ----
+    # Mirrors what ``KimiDeltaAttention._forward`` does on the decode path
+    # *before* this PR moved the gate+sigmoid inside ``_forward``.
+    g_fla = fused_kda_gate(g1_raw, A_log, head_dim, g_bias=dt_bias)
+    beta_fla = beta_raw.sigmoid()
+
+    q_fla = q.reshape(1, bs * T, num_heads, head_dim)
+    k_fla = k.reshape(1, bs * T, num_heads, head_dim)
+    v_fla = v.reshape(1, bs * T, num_heads, head_dim)
+    g_fla = g_fla.reshape(1, bs * T, num_heads, head_dim)
+    beta_fla = beta_fla.reshape(1, bs * T, num_heads)
+
+    cu_seqlens = torch.arange(
+        0, bs * T + 1, T, dtype=torch.int32, device=device
+    )
+    ssm_state_indices = torch.arange(
+        bs, dtype=torch.long, device=device
+    ).unsqueeze(-1)
+
+    state_fla = state_init.clone()
+    out_fla, _ = fused_recurrent_kda(
+        q=q_fla,
+        k=k_fla,
+        v=v_fla,
+        g=g_fla,
+        beta=beta_fla,
+        initial_state=state_fla,
+        inplace_final_state=True,
+        use_qk_l2norm_in_kernel=True,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+    )
+    out_fla = out_fla.reshape(bs, T, num_heads, head_dim)
+
+    # --- FlyDSL path ----
+    state_fly = state_init.clone()
+    out_fly = torch.empty(
+        bs, T, num_heads, head_dim, device=device, dtype=dtype
+    )
+    indices = torch.arange(bs, device=device, dtype=torch.int32)
+    flydsl_gdr_decode(
+        query=q,
+        key=k,
+        value=v,
+        a=g1_raw,
+        b=beta_raw,
+        dt_bias=dt_bias,
+        A_log=A_log.view(-1),
+        indices=indices,
+        state=state_fly,
+        out=out_fly,
+        use_qk_l2norm=True,
+        need_shuffle_state=False,
+    )
+
+    # Correctness check (bf16 recurrent accumulation tolerance).
+    diff = (out_fla.float() - out_fly.float()).abs()
+    max_diff = diff.max().item()
+    mean_diff = diff.mean().item()
+    assert max_diff <= 1.5e-2, (
+        f"FlyDSL KDA decode diverges from FLA: max_abs_diff={max_diff:.4e} "
+        f"(> 1.5e-2), mean_abs_diff={mean_diff:.4e}. "
+        f"shape: bs={bs}, num_heads={num_heads}, head_dim={head_dim}"
+    )

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -116,6 +116,7 @@ if TYPE_CHECKING:
     VLLM_ROCM_USE_AITER_RMSNORM: bool = True
     VLLM_ROCM_USE_AITER_MLA: bool = True
     VLLM_ROCM_USE_AITER_MHA: bool = True
+    VLLM_ROCM_USE_AITER_FLYDSL_KDA: bool = False
     VLLM_ROCM_USE_AITER_FP4_ASM_GEMM: bool = False
     VLLM_ROCM_USE_AITER_TRITON_ROPE: bool = False
     VLLM_ROCM_USE_AITER_FP8BMM: bool = True
@@ -1038,6 +1039,19 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # By default is enabled.
     "VLLM_ROCM_USE_AITER_MHA": lambda: (
         os.getenv("VLLM_ROCM_USE_AITER_MHA", "True").lower() in ("true", "1")
+    ),
+    # Whether to use AITER's FlyDSL-compiled gated delta rule decode kernel
+    # (aiter.ops.flydsl.linear_attention_kernels.flydsl_gdr_decode) in place of
+    # the FLA triton fused_recurrent_kda kernel for Kimi-Linear / KimiDelta
+    # attention decode on ROCm. Opt-in (default False) because: (1) kernel is
+    # very new (FlyDSL 0.1.3.1), (2) it fuses the kda gate computation
+    # internally and takes raw pre-gate g / pre-sigmoid beta, (3) production
+    # correctness against [H*D] dt_bias shape still needs more validation.
+    # Microbench (bs=1..4, head_dim=128, H in {4,8,16}) shows ~3.8-4.5x
+    # speedup over the FLA path. See
+    # benchmarks/flydsl_mla/results/kda_kernel_microbench_mi355x.json.
+    "VLLM_ROCM_USE_AITER_FLYDSL_KDA": lambda: (
+        os.getenv("VLLM_ROCM_USE_AITER_FLYDSL_KDA", "False").lower() in ("true", "1")
     ),
     # Whether to use aiter fp4 gemm asm.
     # By default is disabled.

--- a/vllm/model_executor/layers/kda.py
+++ b/vllm/model_executor/layers/kda.py
@@ -5,6 +5,7 @@ import torch
 from einops import rearrange
 from torch import nn
 
+import vllm.envs as envs
 from vllm.config import CacheConfig, ModelConfig, get_current_vllm_config
 from vllm.distributed import (
     divide,
@@ -15,6 +16,7 @@ from vllm.forward_context import ForwardContext, get_forward_context
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader.weight_utils import sharded_weight_loader
 from vllm.model_executor.utils import set_weight_attrs
+from vllm.platforms import current_platform
 from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
@@ -42,12 +44,137 @@ from .quantization.base_config import QuantizationConfig
 logger = init_logger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# FlyDSL gated delta rule decode kernel (opt-in, ROCm only)
+# ---------------------------------------------------------------------------
+# ``aiter.ops.flydsl.linear_attention_kernels.flydsl_gdr_decode`` is a
+# FlyDSL-compiled KDA decode kernel that fuses the ``fused_kda_gate`` and the
+# recurrent gated-delta-rule update. It is not always available (requires a
+# recent AITER + FlyDSL on ROCm), so we look it up lazily and cache the
+# resolution. Gated behind ``VLLM_ROCM_USE_AITER_FLYDSL_KDA`` (default off).
+_FLYDSL_KDA_RESOLVED: bool = False
+_FLYDSL_KDA_KERNEL = None
+
+
+def _maybe_get_flydsl_kda_kernel():
+    """Return the FlyDSL gated delta rule decode kernel, or ``None``.
+
+    Resolution is cached on first call. We guard with:
+      * ``VLLM_ROCM_USE_AITER_FLYDSL_KDA`` (opt-in env flag)
+      * ``current_platform.is_rocm()`` (kernel is ROCm-only)
+      * ``ImportError`` fallback if AITER is too old / missing the module
+    """
+    global _FLYDSL_KDA_RESOLVED, _FLYDSL_KDA_KERNEL
+    if _FLYDSL_KDA_RESOLVED:
+        return _FLYDSL_KDA_KERNEL
+    _FLYDSL_KDA_RESOLVED = True
+
+    if not envs.VLLM_ROCM_USE_AITER_FLYDSL_KDA:
+        return None
+    if not current_platform.is_rocm():
+        logger.debug(
+            "VLLM_ROCM_USE_AITER_FLYDSL_KDA=1 set on non-ROCm platform; "
+            "ignoring and falling back to FLA triton KDA decode."
+        )
+        return None
+    try:
+        from aiter.ops.flydsl.linear_attention_kernels import (  # type: ignore[import-not-found] # noqa: E501
+            flydsl_gdr_decode,
+        )
+    except ImportError as e:
+        logger.info(
+            "VLLM_ROCM_USE_AITER_FLYDSL_KDA=1 but aiter.ops.flydsl."
+            "linear_attention_kernels.flydsl_gdr_decode is unavailable (%s); "
+            "falling back to FLA triton KDA decode.",
+            e,
+        )
+        return None
+    _FLYDSL_KDA_KERNEL = flydsl_gdr_decode
+    logger.info(
+        "KimiDeltaAttention decode: using FlyDSL gated delta rule kernel "
+        "(aiter.ops.flydsl.linear_attention_kernels.flydsl_gdr_decode)."
+    )
+    return _FLYDSL_KDA_KERNEL
+
+
+def _flydsl_kda_decode(
+    flydsl_kernel,
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    g1_raw: torch.Tensor,
+    beta_raw: torch.Tensor,
+    A_log: torch.Tensor,
+    dt_bias: torch.Tensor,
+    ssm_state_indices: torch.Tensor,
+    recurrent_state: torch.Tensor,
+) -> torch.Tensor:
+    """Run the FlyDSL KDA decode kernel and return ``core_attn_out_non_spec``.
+
+    Input tensor shapes (matching the FLA path in ``_forward``):
+      * q, k, v:        ``[1, N, H, D]`` where N = num_decode_tokens
+      * g1_raw:         ``[1, N, H*D]`` (pre-gate output of ``f_b_proj``)
+      * beta_raw:       ``[1, N, H]`` (pre-sigmoid output of ``b_proj``)
+      * A_log:          ``[1, 1, H, 1]`` (weight tensor)
+      * dt_bias:        ``[H*D]`` (weight tensor)
+      * ssm_state_indices: ``[N, ...]`` cache-slot indices into
+        ``recurrent_state`` (the exact layout comes from
+        ``GDNAttentionMetadata``)
+      * recurrent_state: ``[max_cache_slots, H, D, D]`` (mutated in-place)
+
+    The FlyDSL kernel expects per-sequence batched tensors (``[bs, T=1, ...]``
+    for decode), so we reshape the [1, N, ...] layout to [N, 1, ...]. This is
+    a stride-compatible view since the outer dim is 1.
+
+    Returns ``core_attn_out_non_spec`` of shape ``[1, N, H, D]`` matching the
+    FLA path's return value (so downstream code is shape-agnostic).
+    """
+    _, num_tokens, num_heads, head_dim = q.shape
+
+    # [1, N, H, D] -> [N, 1, H, D]
+    q_fly = q.reshape(num_tokens, 1, num_heads, head_dim)
+    k_fly = k.reshape(num_tokens, 1, num_heads, head_dim)
+    v_fly = v.reshape(num_tokens, 1, num_heads, head_dim)
+    # [1, N, H*D] -> [N, 1, H*D]
+    a_fly = g1_raw.reshape(num_tokens, 1, num_heads * head_dim)
+    # [1, N, H] -> [N, 1, H]
+    b_fly = beta_raw.reshape(num_tokens, 1, num_heads)
+
+    # The FlyDSL kernel expects ``indices`` of shape ``[bs]`` (one cache slot
+    # per decoded sequence). ``ssm_state_indices`` from GDN attention metadata
+    # may be laid out as ``[bs, 1]`` or ``[bs]`` depending on the decode path;
+    # normalize to ``[bs]`` and cast to int32 as expected by FlyDSL.
+    idx = ssm_state_indices
+    if idx.dim() > 1:
+        idx = idx[..., 0]
+    idx = idx[:num_tokens].to(dtype=torch.int32)
+
+    out = torch.empty(
+        num_tokens, 1, num_heads, head_dim, device=q.device, dtype=q.dtype
+    )
+    flydsl_kernel(
+        query=q_fly,
+        key=k_fly,
+        value=v_fly,
+        a=a_fly,
+        b=b_fly,
+        dt_bias=dt_bias,
+        A_log=A_log.view(-1),
+        indices=idx,
+        state=recurrent_state,
+        out=out,
+        use_qk_l2norm=True,
+        need_shuffle_state=False,
+    )
+    return out.reshape(1, num_tokens, num_heads, head_dim)
+
+
 def kda_attention(
     q_proj_states: torch.Tensor,
     k_proj_states: torch.Tensor,
     v_proj_states: torch.Tensor,
-    g1: torch.Tensor,
-    beta: torch.Tensor,
+    g1_raw: torch.Tensor,
+    beta_raw: torch.Tensor,
     core_attn_out: torch.Tensor,
     layer_name: str,
 ) -> None:
@@ -57,8 +184,8 @@ def kda_attention(
         q_proj_states=q_proj_states,
         k_proj_states=k_proj_states,
         v_proj_states=v_proj_states,
-        g1=g1,
-        beta=beta,
+        g1_raw=g1_raw,
+        beta_raw=beta_raw,
         core_attn_out=core_attn_out,
     )
 
@@ -67,8 +194,8 @@ def kda_attention_fake(
     q_proj_states: torch.Tensor,
     k_proj_states: torch.Tensor,
     v_proj_states: torch.Tensor,
-    g1: torch.Tensor,
-    beta: torch.Tensor,
+    g1_raw: torch.Tensor,
+    beta_raw: torch.Tensor,
     core_attn_out: torch.Tensor,
     layer_name: str,
 ) -> None:
@@ -260,11 +387,17 @@ class KimiDeltaAttention(nn.Module, MambaBase):
         k = self.k_proj(hidden_states)[0]
         v = self.v_proj(hidden_states)[0]
 
-        beta = self.b_proj(hidden_states)[0].float().sigmoid()
-        g1 = self.f_b_proj(self.f_a_proj(hidden_states)[0])[0]
-        g1 = fused_kda_gate(g1, self.A_log, self.head_dim, g_bias=self.dt_bias)
-        beta = beta.unsqueeze(0)
-        g1 = g1.unsqueeze(0)
+        # NOTE: we pass the *raw* (pre-gate, pre-sigmoid) tensors through the
+        # custom op. ``fused_kda_gate`` and ``.sigmoid()`` were previously
+        # applied here, but the FlyDSL KDA decode kernel (opt-in, see
+        # ``_maybe_get_flydsl_kda_kernel``) fuses the gate computation
+        # internally and needs the raw pre-activation values. The FLA
+        # (triton) fallback applies the gate+sigmoid inside ``_forward`` so
+        # its behavior is unchanged.
+        beta_raw = self.b_proj(hidden_states)[0].float()
+        g1_raw = self.f_b_proj(self.f_a_proj(hidden_states)[0])[0]
+        beta_raw = beta_raw.unsqueeze(0)
+        g1_raw = g1_raw.unsqueeze(0)
 
         g_proj_states = self.g_b_proj(self.g_a_proj(hidden_states)[0])[0]
         g2 = rearrange(g_proj_states, "... (h d) -> ... h d", d=self.head_dim)
@@ -278,8 +411,8 @@ class KimiDeltaAttention(nn.Module, MambaBase):
             q,
             k,
             v,
-            g1,
-            beta,
+            g1_raw,
+            beta_raw,
             core_attn_out,
             self.prefix,
         )
@@ -292,8 +425,8 @@ class KimiDeltaAttention(nn.Module, MambaBase):
         q_proj_states: torch.Tensor,
         k_proj_states: torch.Tensor,
         v_proj_states: torch.Tensor,
-        g1: torch.Tensor,
-        beta: torch.Tensor,
+        g1_raw: torch.Tensor,
+        beta_raw: torch.Tensor,
         core_attn_out: torch.Tensor,
     ) -> None:
         forward_context = get_forward_context()
@@ -317,8 +450,14 @@ class KimiDeltaAttention(nn.Module, MambaBase):
         q_proj_states = q_proj_states[:num_actual_tokens]
         k_proj_states = k_proj_states[:num_actual_tokens]
         v_proj_states = v_proj_states[:num_actual_tokens]
-        g1 = g1[:num_actual_tokens]
-        beta = beta[:num_actual_tokens]
+        # NOTE: g1_raw and beta_raw are pre-gate / pre-sigmoid. The gate
+        # (``fused_kda_gate``) and sigmoid are applied below inside the
+        # prefill / FLA-fallback decode branches; the FlyDSL decode branch
+        # consumes the raw values directly. We preserve the previous slicing
+        # semantics (slice on dim 0, which is size 1 after ``unsqueeze(0)``
+        # in ``forward``) to keep behavior identical on the FLA path.
+        g1_raw = g1_raw[:num_actual_tokens]
+        beta_raw = beta_raw[:num_actual_tokens]
 
         (conv_state_q, conv_state_k, conv_state_v, recurrent_state) = constant_caches
         # conv_state must be (..., dim, width-1) for the conv kernels.
@@ -414,6 +553,13 @@ class KimiDeltaAttention(nn.Module, MambaBase):
         if attn_metadata_narrowed.num_prefills > 0:
             assert non_spec_state_indices_tensor is not None
             assert has_initial_state is not None
+            # Prefill path: apply gate + sigmoid then run chunk_kda (triton).
+            # Unchanged vs. upstream: identical numerics, just moved the
+            # gate/sigmoid from ``forward()`` to here.
+            g1 = fused_kda_gate(
+                g1_raw, self.A_log, self.head_dim, g_bias=self.dt_bias
+            )
+            beta = beta_raw.sigmoid()
             zero_idx = non_spec_state_indices_tensor[~has_initial_state]
             recurrent_state[zero_idx] = 0
             initial_state = recurrent_state[non_spec_state_indices_tensor].contiguous()
@@ -435,22 +581,59 @@ class KimiDeltaAttention(nn.Module, MambaBase):
             recurrent_state[non_spec_state_indices_tensor] = last_recurrent_state
         else:
             assert non_spec_query_start_loc is not None
-            (
-                core_attn_out_non_spec,
-                last_recurrent_state,
-            ) = fused_recurrent_kda(
-                q=q,
-                k=k,
-                v=v,
-                g=g1,
-                beta=beta,
-                initial_state=recurrent_state,
-                use_qk_l2norm_in_kernel=True,
-                cu_seqlens=non_spec_query_start_loc[
-                    : attn_metadata_narrowed.num_decodes + 1
-                ],
-                ssm_state_indices=non_spec_state_indices_tensor,
-            )
+            # Decode path: try FlyDSL first (opt-in, ROCm-only); otherwise
+            # fall back to the FLA triton ``fused_recurrent_kda``.
+            flydsl_kernel = _maybe_get_flydsl_kda_kernel()
+            core_attn_out_non_spec = None
+            if flydsl_kernel is not None:
+                try:
+                    core_attn_out_non_spec = _flydsl_kda_decode(
+                        flydsl_kernel,
+                        q=q,
+                        k=k,
+                        v=v,
+                        g1_raw=g1_raw,
+                        beta_raw=beta_raw,
+                        A_log=self.A_log,
+                        dt_bias=self.dt_bias,
+                        ssm_state_indices=non_spec_state_indices_tensor,
+                        recurrent_state=recurrent_state,
+                    )
+                except Exception as e:
+                    # Disable on first failure so we don't retry every step;
+                    # emit a single warning per worker and fall back to FLA.
+                    global _FLYDSL_KDA_KERNEL
+                    _FLYDSL_KDA_KERNEL = None
+                    logger.warning(
+                        "FlyDSL KDA decode failed (%s: %s); falling back to "
+                        "FLA triton fused_recurrent_kda for the remainder of "
+                        "this run. Set VLLM_ROCM_USE_AITER_FLYDSL_KDA=0 to "
+                        "silence this path.",
+                        type(e).__name__,
+                        e,
+                    )
+                    core_attn_out_non_spec = None
+            if core_attn_out_non_spec is None:
+                g1 = fused_kda_gate(
+                    g1_raw, self.A_log, self.head_dim, g_bias=self.dt_bias
+                )
+                beta = beta_raw.sigmoid()
+                (
+                    core_attn_out_non_spec,
+                    last_recurrent_state,
+                ) = fused_recurrent_kda(
+                    q=q,
+                    k=k,
+                    v=v,
+                    g=g1,
+                    beta=beta,
+                    initial_state=recurrent_state,
+                    use_qk_l2norm_in_kernel=True,
+                    cu_seqlens=non_spec_query_start_loc[
+                        : attn_metadata_narrowed.num_decodes + 1
+                    ],
+                    ssm_state_indices=non_spec_state_indices_tensor,
+                )
         core_attn_out[0, :num_actual_tokens] = core_attn_out_non_spec[
             0, :num_actual_tokens
         ]


### PR DESCRIPTION
# [ROCm][Kimi-Linear] Wire FlyDSL gated delta rule decode kernel for KimiDeltaAttention

> **Status: Draft — blocked on GPU end-to-end validation** (see `## Test plan`
> below). Opened as a Draft PR to invite early review of the integration
> surface and to let the ROCm/AMD teams (AITER, FlyDSL) co-review before the
> full Kimi-Linear TPOT numbers are in.

## Summary

On ROCm, vLLM's `KimiDeltaAttention` decode path currently calls
`vllm.model_executor.layers.fla.ops.kda.fused_recurrent_kda` (Triton / FLA).
The AMD AITER + FlyDSL stack ships a compiled gated-delta-rule decode
kernel — `aiter.ops.flydsl.linear_attention_kernels.flydsl_gdr_decode` —
that is **3.8–4.5× faster on every Kimi-Linear KDA shape we measured**, but
it has not been wired into vLLM. This PR adds an **opt-in** dispatch so
that, when `VLLM_ROCM_USE_AITER_FLYDSL_KDA=1` and the kernel is importable,
the decode branch uses FlyDSL; otherwise behavior is bit-identical to
today's FLA path.

### Why this matters for Kimi-Linear-48B-A3B

- Kimi-Linear is 20 / 27 KDA layers + 7 / 27 full-attention (MLA) layers.
- On decode, KDA is recurrent and runs at **every token regardless of
  context length**, so speeding it up is a per-token TPOT win.
- Microbench (below) measures kernel-level savings of ~52 µs per KDA layer
  on MI355X for typical decode shapes. Across 20 layers that projects to
  ~1.04 ms/token, which on our current MI355X baselines corresponds to:

| ctx    | baseline TPOT | projected TPOT | improvement |
|--------|--------------:|---------------:|------------:|
| 4K     | 4.26 ms       | ≈ 3.22 ms      | **−24.4%**  |
| 131K   | 5.53 ms       | ≈ 4.49 ms      | **−18.8%**  |
| 256K   | 7.84 ms       | ≈ 6.80 ms      | −13.3%      |
| 1M     | 16.74 ms      | ≈ 15.70 ms     | −6.2%       |

(Full-attention layers dominate TPOT at 1M+, so the relative benefit
shrinks at very long context — that's the gap the separate ROCm/FlyDSL
MLA decode work targets.)

Projection methodology: linear extrapolation of per-layer savings onto
baselines from `~/flydsl_mla_bench/bench_kimi_tp{2,4,8}_*.json` on MI355X.
End-to-end verification is the remaining gating item — see `## Test plan`.

## Not duplicating existing work

Upstream duplicate-work check (per `AGENTS.md` §1):

```
gh pr list --repo vllm-project/vllm --state all --search "kda flydsl in:title"
gh pr list --repo vllm-project/vllm --state all --search "KimiDeltaAttention in:body"
gh issue list --repo vllm-project/vllm --state all --search "flydsl_gdr_decode in:body"
```

No existing PR or issue on `vllm-project/vllm` touches the FlyDSL KDA path.
The related AITER-side PR that added the head-repeat for ROCm AITER MLA
(#35850) is already merged and unrelated.

Related (non-duplicating) work tracked externally:
- [ROCm/FlyDSL#403](https://github.com/ROCm/FlyDSL/pull/403) — FlyDSL MLA
  decode for DeepSeek nhead=128 (different layer: MLA not KDA).
- [ROCm/FlyDSL#405](https://github.com/ROCm/FlyDSL/pull/405) — FlyDSL KDA
  **prefill** on MI350. Complements this PR (we only change the decode
  branch).

## Design

### 1. New env flag (`vllm/envs.py`)
`VLLM_ROCM_USE_AITER_FLYDSL_KDA` — default `False`. Opt-in to match other
new AITER kernels (e.g. `VLLM_ROCM_USE_AITER_FP4_ASM_GEMM`).

### 2. Lazy, cached kernel resolver (`vllm/model_executor/layers/kda.py`)
`_maybe_get_flydsl_kda_kernel()` returns the FlyDSL callable or `None`,
caching the lookup. Guards: env flag, `current_platform.is_rocm()`, and a
soft `ImportError` fallback so older AITER installs degrade gracefully.

### 3. Adapter (`_flydsl_kda_decode`)
Reshapes vLLM's `[1, N, H, D]` decode layout into FlyDSL's `[bs=N, T=1, H, D]`
per-sequence layout (contiguous, no copy), normalizes `ssm_state_indices`
to `int32[bs]`, and flattens `A_log` from `[1, 1, H, 1]` to `[H]`. Returns
output in the `[1, N, H, D]` shape the downstream code already expects, so
the split between the FLA and FlyDSL paths stays hidden from the caller.

### 4. Forward/custom-op interface change
`fused_kda_gate` and `.sigmoid()` are **moved from `forward()` into
`_forward()`**, and the custom op `torch.ops.vllm.kda_attention` args are
renamed `g1` → `g1_raw` / `beta` → `beta_raw`. The FLA path applies gate +
sigmoid itself (identical to before — the operation just moved inside the
custom op); the FlyDSL path consumes the raw values and fuses the gate
internally.

### 5. Failure-safe fallback
If the FlyDSL kernel raises (e.g. shape mismatch on some exotic Kimi-Linear
config, or a future AITER ABI change), we disable it for the rest of the
process, emit a **single** warning, and transparently fall back to FLA.
This means the worst-case regression from this PR is one printed warning
line per worker.

## Test plan

### Pre-submit (landed in this PR)

- `tests/kernels/attention/test_flydsl_kda_decode.py` — head-to-head
  correctness: parametrized over Kimi-Linear KDA shapes (num_heads ∈ {4, 8,
  16}; bs ∈ {1, 4}; head_dim=128), asserts FlyDSL vs. FLA max-abs-diff
  ≤ 1.5e-2 on a single decode step. Auto-skips on non-ROCm / missing AITER.

Command:
```bash
.venv/bin/python -m pytest tests/kernels/attention/test_flydsl_kda_decode.py -v
```

### Blocking before flipping from Draft → Ready

All of the below run on a real MI355X with the Kimi-Linear-48B-A3B-Instruct
weights. **I have written these test harnesses but not yet executed them
end-to-end — the shared MI355X node I have access to has all 8 GPUs at 91%
memory allocation by other users, which blocks running the full model.
Planned the moment a GPU frees up:**

1. `pytest tests/kernels/attention/test_flydsl_kda_decode.py -v` on MI355X
   (actually exercise the kernel, since the test auto-skipped off-ROCm).
2. End-to-end Kimi-Linear decode with `VLLM_ROCM_USE_AITER_FLYDSL_KDA=0`
   vs `=1`, via `benchmarks/flydsl_mla/bench_kimi.py`:
   - ctx ∈ {4K, 131K, 256K}
   - TP ∈ {4, 8}
   - Assert TPOT drops ≥ 10% at 131K (conservative vs the 18.8% projection).
3. Correctness spot-check: 50 tokens generated from the same prompt with
   `=0` vs `=1` must produce identical output at greedy sampling.
4. Confirm the fallback path works by injecting a deliberate shape mismatch
   and verifying (a) one warning, (b) FLA produces the rest of the tokens,
   (c) no crash.

Once these land, I will post numbers in a comment and flip the PR to
Ready-for-review. **Maintainers: happy to hand off the end-to-end run to
an AMD-side CI machine if that is faster than my queue.**

### Unverified assumption (help welcome)

The microbench we already ran (`benchmarks/flydsl_mla/results/
kda_kernel_microbench_mi355x.json`) used `dt_bias` shape `[H]`, but vLLM's
production `dt_bias` is `[H*D]` (per-h-d) — the microbench's reported
max-abs-diff of ~4e-3 therefore compares two kernels that *consistently
consumed the wrong bias shape*, not two kernels computing the "right"
result. The unit test in this PR passes the correct production shapes, so
**the test is the real correctness oracle**. If FlyDSL turns out to expect
`[H]` (reduced), the test will surface that and I'll add the reduction in
`_flydsl_kda_decode` (and log the change for Ephrem / Jiming). If someone
on the AITER / FlyDSL side already knows the answer, I'd love a pointer.

## AI assistance disclosure

Per `AGENTS.md` §1.Accountability: this change was drafted with AI
assistance (Claude Opus 4.7). I (human submitter) have reviewed every
line, authored the test, read through `aiter.ops.flydsl.
linear_attention_kernels` to confirm the kernel signature, and will
personally run the GPU validation steps above before flipping to Ready.
The AI did not modify any other files in this branch.

## Checklist before flipping Draft → Ready

- [ ] Run the unit test on an MI355X and attach the log.
- [ ] Run 4K / 131K / 256K E2E Kimi-Linear TPOT A/B and paste a table.
- [ ] Greedy-identical spot-check (50 tokens).
- [ ] Fallback-path negative test.
- [ ] Request review from: the AITER / FlyDSL team (Ephrem, Jiming), and a
      vLLM ROCm/AMD reviewer (Appia's team).
