### PR TITLE
[Bugfix] Fix scheduling deadlock in _mamba_block_aligned_split with large multimodal inputs

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -325,7 +325,13 @@ class Scheduler(SchedulerInterface):
             num_computed_tokens_after_sched = num_computed_tokens + num_new_tokens
             if num_computed_tokens_after_sched < last_cache_position:
                 # align to block_size
-                num_new_tokens = num_new_tokens // block_size * block_size
+                # If num_new_tokens is less than block_size, the Mamba state
+                # is simply not cached for this chunk (no special handling
+                # needed), so keep the original value to avoid zero-collapse
+                # which would cause the scheduler to skip the request and
+                # deadlock when encoder cache is exhausted.
+                aligned = num_new_tokens // block_size * block_size
+                num_new_tokens = aligned if aligned > 0 else num_new_tokens
             elif (
                 num_computed_tokens
                 < last_cache_position

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -443,7 +443,18 @@ class Scheduler(SchedulerInterface):
                 max_prefill_tokens = min(max_prefill_tokens, long_prefill_threshold)
             aligned_end = end // block_size * block_size
             if aligned_end > start or block_size <= max_prefill_tokens:
-                end = aligned_end
+                # For multimodal requests, when the encoder-compute budget
+                # caps num_new_tokens below block_size the floor can collapse
+                # aligned_end to start (or below), producing 0 tokens.  The
+                # caller then ``break``s out of the waiting loop, stranding
+                # the entire queue when there are no running requests.
+                # In that case keep the original unaligned end so that the
+                # sub-block chunk still makes forward progress; its Mamba
+                # state simply won't be block-cached for this step.
+                if aligned_end <= start and request.has_encoder_inputs:
+                    pass  # keep original `end`
+                else:
+                    end = aligned_end
 
         next_block_boundary = (start // block_size + 1) * block_size
         tail_boundary = (


### PR DESCRIPTION
## Purpose

Fix a scheduling deadlock in `_mamba_block_aligned_split` (vllm/v1/core/sched/scheduler.py) that causes the engine to hang permanently when serving hybrid Mamba models (e.g., Qwen3.5-35B-A3B) with two or more large multimodal inputs under chunked prefill.

The root cause: when the remaining tokens before the next encoder input are fewer than `block_size` (16), the block-alignment expression `num_new_tokens // block_size * block_size` collapses to 0. The scheduler then skips the request entirely (`if num_new_tokens == 0: continue`), so Image 1's placeholder tokens are never consumed, its encoder cache entry is never freed, Image 2 can never be loaded, and the system deadlocks.

The existing code comment already documents the intended behavior: "if `num_new_tokens` is less than `block_size`, the state is simply not cached, requiring no special handling." The fix preserves the original `num_new_tokens` value when block alignment would produce 0, allowing the scheduler to make forward progress on the sub-block chunk without affecting Mamba block-boundary checkpointing for all other cases.

## Test Plan

Reproduce with Qwen3.5-35B-A3B and two 3024×4032 images:

```bash
python3 -m vllm.entrypoints.openai.api_server \
  --host 0.0.0.0 --port 8001 \
  --model Qwen/Qwen3.5-35B-A3B \
  --tensor-parallel-size 2 \
  --max-model-len 262144 \
  --gpu-memory-utilization 0.85 \
  --max-num-seqs 48 \
  --trust-remote-code \
  --enable-prefix-caching \
  --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":2}'
```

Then send a streaming `/v1/chat/completions` request containing two 3024×4032 images. Before the fix the request hangs indefinitely with 0% GPU compute; after the fix it completes normally.

Unit test: verify `_mamba_block_aligned_split` returns `num_new_tokens > 0` when the token gap is smaller than `block_size` and alignment would otherwise collapse to 0.

## Test Result

After the fix, Chunk 3 in the concrete example from the issue (4 tokens remaining, block_size=16) returns `num_new_tokens=4` instead of 0. The scheduler processes the chunk, Image 1's placeholder tokens are consumed, the encoder cache entry is freed, Image 2 loads, and the request completes.

Fixes #40707
