### PR TITLE
[Aiter][ROCm] gdn_linear_attn kernel fusion

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -1407,20 +1407,16 @@ class rocm_aiter_ops:
         # https://github.com/ROCm/aiter/blob/6a0e7b26ccf33164785531212cc2ec2cde0b9243/aiter/dist/device_communicators/custom_all_reduce.py#L272-L273
         return int(cls._ALL_REDUCE_MAX_SIZE / 2)
 
-    @staticmethod
-    def are_gdn_triton_kernels_available() -> bool:
+    @classmethod
+    @if_aiter_supported
+    def are_gdn_triton_kernels_available(cls) -> bool:
         """Check if AITER Triton kernels for GDN attention are importable.
 
         These are optional Triton kernels (conv1d fast-path, gated delta net)
         used by GatedDeltaNetAttention's decode fast-path.  They may be absent
-        in older aiter builds.  Combine with ``is_enabled()`` to also gate on
-        the environment variable::
-
-            if rocm_aiter_ops.is_enabled() and \\
-               rocm_aiter_ops.are_gdn_triton_kernels_available():
-                ...
+        in older aiter builds.
         """
-        if not is_aiter_found_and_supported():
+        if not cls._AITER_ENABLED:
             return False
         try:
             import aiter.ops.triton.causal_conv1d_update_single_token  # noqa: F401

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -1408,6 +1408,29 @@ class rocm_aiter_ops:
         return int(cls._ALL_REDUCE_MAX_SIZE / 2)
 
     @staticmethod
+    def are_gdn_triton_kernels_available() -> bool:
+        """Check if AITER Triton kernels for GDN attention are importable.
+
+        These are optional Triton kernels (conv1d fast-path, gated delta net)
+        used by GatedDeltaNetAttention's decode fast-path.  They may be absent
+        in older aiter builds.  Combine with ``is_enabled()`` to also gate on
+        the environment variable::
+
+            if rocm_aiter_ops.is_enabled() and \\
+               rocm_aiter_ops.are_gdn_triton_kernels_available():
+                ...
+        """
+        if not is_aiter_found_and_supported():
+            return False
+        try:
+            import aiter.ops.triton.causal_conv1d_update_single_token  # noqa: F401
+            import aiter.ops.triton.gated_delta_net  # noqa: F401
+
+            return True
+        except (ImportError, ModuleNotFoundError):
+            return False
+
+    @staticmethod
     @if_aiter_supported
     def register_ops_once() -> None:
         global _OPS_REGISTERED

--- a/vllm/model_executor/layers/fla/ops/chunk.py
+++ b/vllm/model_executor/layers/fla/ops/chunk.py
@@ -32,6 +32,7 @@ def chunk_gated_delta_rule_fwd(
     cu_seqlens: torch.Tensor | None = None,
     chunk_indices: torch.Tensor | None = None,
     chunk_offsets: torch.Tensor | None = None,
+    core_attn_out: torch.Tensor | None = None,
 ):
     g = chunk_local_cumsum(
         g, chunk_size=FLA_CHUNK_SIZE, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices
@@ -77,6 +78,7 @@ def chunk_gated_delta_rule_fwd(
         scale=scale,
         cu_seqlens=cu_seqlens,
         chunk_indices=chunk_indices,
+        core_attn_out=core_attn_out,
     )
     if SUPPRESS_LEVEL < 3:
         return g, o, A, final_state, None, None, None
@@ -102,6 +104,7 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         chunk_indices: torch.Tensor | None = None,
         chunk_offsets: torch.Tensor | None = None,
         use_qk_l2norm_in_kernel: bool = False,
+        core_attn_out: torch.Tensor | None = None,
     ):
         if use_qk_l2norm_in_kernel:
             q = l2norm_fwd(q)
@@ -119,9 +122,12 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
             cu_seqlens=cu_seqlens,
             chunk_indices=chunk_indices,
             chunk_offsets=chunk_offsets,
+            core_attn_out=core_attn_out,
         )
         ctx.scale = scale
         ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
+        if core_attn_out is not None:
+            assert q.dtype == o.dtype, "Incompatible dtype for inplace computation"
         return o.to(q.dtype), final_state
 
 
@@ -139,6 +145,7 @@ def chunk_gated_delta_rule(
     chunk_indices: torch.Tensor | None = None,
     chunk_offsets: torch.Tensor | None = None,
     use_qk_l2norm_in_kernel: bool = False,
+    core_attn_out: torch.Tensor | None = None,
 ):
     r"""
     Args:
@@ -230,5 +237,6 @@ def chunk_gated_delta_rule(
         chunk_indices,
         chunk_offsets,
         use_qk_l2norm_in_kernel,
+        core_attn_out,
     )
     return o, final_state

--- a/vllm/model_executor/layers/fla/ops/chunk.py
+++ b/vllm/model_executor/layers/fla/ops/chunk.py
@@ -127,6 +127,9 @@ class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
         ctx.scale = scale
         ctx.use_qk_l2norm_in_kernel = use_qk_l2norm_in_kernel
         if core_attn_out is not None:
+            assert not torch.is_grad_enabled(), (
+                "core_attn_out buffer reuse is only supported for inference"
+            )
             assert q.dtype == o.dtype, "Incompatible dtype for inplace computation"
         return o.to(q.dtype), final_state
 

--- a/vllm/model_executor/layers/fla/ops/chunk_o.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_o.py
@@ -148,6 +148,7 @@ def chunk_fwd_o(
     cu_seqlens: torch.Tensor | None = None,
     chunk_indices: torch.Tensor | None = None,
     chunk_size: int = FLA_CHUNK_SIZE,
+    core_attn_out: torch.Tensor | None = None,
 ) -> torch.Tensor:
     B, T, Hg, K, V = *q.shape, v.shape[-1]
     H = v.shape[-2]
@@ -158,7 +159,11 @@ def chunk_fwd_o(
     if scale is None:
         scale = k.shape[-1] ** -0.5
 
-    o = torch.empty_like(v)
+    o = (
+        core_attn_out[: v.numel()].view(*v.shape)
+        if core_attn_out is not None
+        else torch.empty_like(v)
+    )
 
     def grid(meta):
         return (triton.cdiv(V, meta["BV"]), NT, B * H)

--- a/vllm/model_executor/layers/fla/ops/chunk_o.py
+++ b/vllm/model_executor/layers/fla/ops/chunk_o.py
@@ -159,11 +159,13 @@ def chunk_fwd_o(
     if scale is None:
         scale = k.shape[-1] ** -0.5
 
-    o = (
-        core_attn_out[: v.numel()].view(*v.shape)
-        if core_attn_out is not None
-        else torch.empty_like(v)
-    )
+    if core_attn_out is not None:
+        assert core_attn_out.numel() >= v.numel(), (
+            f"core_attn_out too small: {core_attn_out.numel()} < {v.numel()}"
+        )
+        o = core_attn_out[: v.numel()].view(*v.shape)
+    else:
+        o = torch.empty_like(v)
 
     def grid(meta):
         return (triton.cdiv(V, meta["BV"]), NT, B * H)

--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -1345,7 +1345,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
                 conv_weights,
                 self.conv1d.bias,
                 self.activation,
-                conv_state_indices=non_spec_state_indices_tensor[
+                conv_state_indices=non_spec_state_indices_tensor[  # type: ignore[index]
                     : attn_metadata.num_actual_tokens
                 ],
                 validate_data=True,
@@ -1365,7 +1365,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             head_v_dim=self.head_v_dim,
             initial_state=ssm_state,
             inplace_final_state=True,
-            cu_seqlens=non_spec_query_start_loc[: attn_metadata.num_decodes + 1],
+            cu_seqlens=non_spec_query_start_loc[: attn_metadata.num_decodes + 1],  # type: ignore[index]
             ssm_state_indices=non_spec_state_indices_tensor,
             use_qk_l2norm_in_kernel=True,
             core_attn_out=core_attn_out.reshape(-1),

--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -69,9 +69,7 @@ from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 # Availability is checked centrally via rocm_aiter_ops; the actual function
 # references are imported here so that they can be called without per-call
 # import overhead.
-GDN_AITER_TRITON_AVAILABLE = (
-    rocm_aiter_ops.is_enabled() and rocm_aiter_ops.are_gdn_triton_kernels_available()
-)
+GDN_AITER_TRITON_AVAILABLE = rocm_aiter_ops.are_gdn_triton_kernels_available()
 
 if GDN_AITER_TRITON_AVAILABLE:
     from aiter.ops.triton.causal_conv1d_update_single_token import (
@@ -296,7 +294,6 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             else 0
         )
         self.gqa_interleaved_layout = gqa_interleaved_layout
-        self._forward_method = self.forward_cuda
         if current_platform.is_xpu():
             self._forward_method = self.forward_xpu
         elif current_platform.is_cpu():
@@ -306,6 +303,10 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
 
             register_cpu_gdn_attention_ops()
             self._forward_method = self.forward_cpu
+        elif current_platform.is_rocm():
+            self._forward_method = self.forward_rocm
+        else:
+            self._forward_method = self.forward_cuda
 
         # QKV
         self.conv_dim = self.key_dim * 2 + self.value_dim
@@ -680,22 +681,35 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
     ):
         self._forward_method(hidden_states, output)
 
-    def forward_cuda(
+    def _output_projection(
+        self,
+        core_attn_out: torch.Tensor,
+        z: torch.Tensor,
+        output: torch.Tensor,
+        num_tokens: int,
+    ):
+        """Part 3: RMSNormGated + output linear projection.
+
+        The RMSNormGated + quant sequence is eligible for fusion
+        by the compilation pass when fuse_norm_quant is enabled.
+        """
+        z_shape_og = z.shape
+        core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
+        z = z.reshape(-1, z.shape[-1])
+        core_attn_out = self.norm(core_attn_out, z)
+        core_attn_out = core_attn_out.reshape(z_shape_og)
+        core_attn_out = rearrange(core_attn_out, "... h d -> ... (h d)")
+        output[:num_tokens], _ = self.out_proj(core_attn_out)
+
+    def forward_rocm(
         self,
         hidden_states: torch.Tensor,
         output: torch.Tensor,
     ):
-        """
-        Forward pass with three parts:
-        1. Input projection
-        2. Core attention (custom op)
-        3. Output projection
-        """
-        num_tokens = hidden_states.size(0)
-        # ============================================================
-        # Fast path for with Triton decode kernels for part 1&2
-        # ============================================================
+        """ROCm forward using AITER Triton fused projection+attention when
+        available, otherwise falling back to the generic CUDA path."""
         if not self.has_lora_projections and GDN_AITER_TRITON_AVAILABLE:
+            num_tokens = hidden_states.size(0)
             projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
             projected_states_ba, _ = self.in_proj_ba(hidden_states)
             projected_states_qkvz = projected_states_qkvz.view(num_tokens, -1)
@@ -719,74 +733,82 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
                 fast_kernel=True,
                 layer_name=_encode_layer_name(self.prefix),
             )
+
+            self._output_projection(core_attn_out, z, output, num_tokens)
         else:
-            # ============================================================
-            # Part 1: Input Projection
-            # ============================================================
-            if self.has_lora_projections:
-                # LoRA path (Qwen3.5 only): separate in_proj_qkv and in_proj_z
-                mixed_qkv, _ = self.in_proj_qkv(hidden_states)
-                ba, _ = self.in_proj_ba(hidden_states)
-                z, _ = self.in_proj_z(hidden_states)
+            self.forward_cuda(hidden_states, output)
+
+    def forward_cuda(
+        self,
+        hidden_states: torch.Tensor,
+        output: torch.Tensor,
+    ):
+        """
+        Forward pass with three parts:
+        1. Input projection
+        2. Core attention (custom op)
+        3. Output projection
+        """
+        num_tokens = hidden_states.size(0)
+        # ============================================================
+        # Part 1: Input Projection
+        # ============================================================
+        if self.has_lora_projections:
+            # LoRA path (Qwen3.5 only): separate in_proj_qkv and in_proj_z
+            mixed_qkv, _ = self.in_proj_qkv(hidden_states)
+            ba, _ = self.in_proj_ba(hidden_states)
+            z, _ = self.in_proj_z(hidden_states)
+            z = z.reshape(z.size(0), -1, self.head_v_dim)
+            b, a = ba.chunk(2, dim=-1)
+            b = b.contiguous()
+            a = a.contiguous()
+        else:
+            mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
+            ba, _ = self.in_proj_ba(hidden_states)
+
+            if self.gqa_interleaved_layout:
+                # Qwen3-Next: unpack the interleaved GQA layout
+                query, key, value, z, b, a = self.fix_query_key_value_ordering(
+                    mixed_qkvz, ba
+                )
+                query, key, value = map(
+                    lambda x: rearrange(x, "l p d -> l (p d)"), (query, key, value)
+                )
+                mixed_qkv = torch.cat((query, key, value), dim=-1)
+            else:
+                # Qwen3.5: weights are already in [q, k, v, z] and [b, a] order
+                qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
+                z_size = self.value_dim // self.tp_size
+                mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)
                 z = z.reshape(z.size(0), -1, self.head_v_dim)
                 b, a = ba.chunk(2, dim=-1)
                 b = b.contiguous()
                 a = a.contiguous()
-            else:
-                mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
-                ba, _ = self.in_proj_ba(hidden_states)
 
-                if self.gqa_interleaved_layout:
-                    # Qwen3-Next: unpack the interleaved GQA layout
-                    query, key, value, z, b, a = self.fix_query_key_value_ordering(
-                        mixed_qkvz, ba
-                    )
-                    query, key, value = map(
-                        lambda x: rearrange(x, "l p d -> l (p d)"), (query, key, value)
-                    )
-                    mixed_qkv = torch.cat((query, key, value), dim=-1)
-                else:
-                    # Qwen3.5: weights are already in [q, k, v, z] and [b, a] order
-                    qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
-                    z_size = self.value_dim // self.tp_size
-                    mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)
-                    z = z.reshape(z.size(0), -1, self.head_v_dim)
-                    b, a = ba.chunk(2, dim=-1)
-                    b = b.contiguous()
-                    a = a.contiguous()
+        # ============================================================
+        # Part 2: Core Attention (Custom Op)
+        # ============================================================
+        # Note: we should not use torch.empty here like other attention backends,
+        # see discussions in https://github.com/vllm-project/vllm/pull/28182
+        core_attn_out = torch.zeros(
+            (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+            dtype=hidden_states.dtype,
+            device=hidden_states.device,
+        )
 
-            # ============================================================
-            # Part 2: Core Attention (Custom Op)
-            # ============================================================
-            # Note: we should not use torch.empty here like other attention backends,
-            # see discussions in https://github.com/vllm-project/vllm/pull/28182
-            core_attn_out = torch.zeros(
-                (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
-                dtype=hidden_states.dtype,
-                device=hidden_states.device,
-            )
-
-            torch.ops.vllm.gdn_attention_core(
-                mixed_qkv,
-                b,
-                a,
-                core_attn_out,
-                fast_kernel=False,
-                layer_name=_encode_layer_name(self.prefix),
-            )
+        torch.ops.vllm.gdn_attention_core(
+            mixed_qkv,
+            b,
+            a,
+            core_attn_out,
+            fast_kernel=False,
+            layer_name=_encode_layer_name(self.prefix),
+        )
 
         # ============================================================
         # Part 3: Output Projection
         # ============================================================
-        # The RMSNormGated + quant sequence below is eligible for fusion
-        # by the compilation pass when fuse_norm_quant is enabled.
-        z_shape_og = z.shape
-        core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
-        z = z.reshape(-1, z.shape[-1])
-        core_attn_out = self.norm(core_attn_out, z)
-        core_attn_out = core_attn_out.reshape(z_shape_og)
-        core_attn_out = rearrange(core_attn_out, "... h d -> ... (h d)")
-        output[:num_tokens], _ = self.out_proj(core_attn_out)
+        self._output_projection(core_attn_out, z, output, num_tokens)
 
     def forward_xpu(
         self,

--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -304,7 +304,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             register_cpu_gdn_attention_ops()
             self._forward_method = self.forward_cpu
         elif current_platform.is_rocm():
-            self._forward_method = self.forward_rocm
+            self._forward_method = self.forward_hip
         else:
             self._forward_method = self.forward_cuda
 
@@ -701,7 +701,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         core_attn_out = rearrange(core_attn_out, "... h d -> ... (h d)")
         output[:num_tokens], _ = self.out_proj(core_attn_out)
 
-    def forward_rocm(
+    def forward_hip(
         self,
         hidden_states: torch.Tensor,
         output: torch.Tensor,

--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -2,8 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Inference-only Qwen3-Next/Qwen3.5 model."""
 
-from typing import Any
-
 import torch
 from einops import rearrange
 from torch import nn
@@ -71,32 +69,17 @@ from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
 # Availability is checked centrally via rocm_aiter_ops; the actual function
 # references are imported here so that they can be called without per-call
 # import overhead.
-GDN_AITER_TRITON_AVAILABLE = False
-gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule: Any = None
-gdn_aiter_causal_conv1d_update_single_token: Any = None
-gdn_aiter_fused_reshape_causal_conv1d_update_single_token: Any = None
+GDN_AITER_TRITON_AVAILABLE = (
+    rocm_aiter_ops.is_enabled() and rocm_aiter_ops.are_gdn_triton_kernels_available()
+)
 
-if rocm_aiter_ops.is_enabled() and rocm_aiter_ops.are_gdn_triton_kernels_available():
+if GDN_AITER_TRITON_AVAILABLE:
     from aiter.ops.triton.causal_conv1d_update_single_token import (
-        causal_conv1d_update_single_token as _gdn_aiter_causal_conv1d_update_single_token,  # noqa: E501
-    )
-    from aiter.ops.triton.causal_conv1d_update_single_token import (
-        fused_reshape_causal_conv1d_update_single_token as _gdn_aiter_fused_reshape_causal_conv1d_update_single_token,  # noqa: E501
+        fused_reshape_causal_conv1d_update_single_token as gdn_aiter_fused_reshape_causal_conv1d_update_single_token,  # noqa: E501
     )
     from aiter.ops.triton.gated_delta_net import (
-        fused_rearrange_sigmoid_gated_delta_rule as _gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule,  # noqa: E501
+        fused_rearrange_sigmoid_gated_delta_rule as gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule,  # noqa: E501
     )
-
-    gdn_aiter_causal_conv1d_update_single_token = (
-        _gdn_aiter_causal_conv1d_update_single_token
-    )
-    gdn_aiter_fused_reshape_causal_conv1d_update_single_token = (
-        _gdn_aiter_fused_reshape_causal_conv1d_update_single_token
-    )
-    gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule = (
-        _gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule
-    )
-    GDN_AITER_TRITON_AVAILABLE = True
 
 logger = init_logger(__name__)
 
@@ -339,6 +322,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         # we need to create qkvz_proj adaptively here.
         # When create_in_proj_qkvz is False (e.g. LoRA enabled in Qwen3.5),
         # in_proj_qkv and in_proj_z are created separately instead.
+        self.has_lora_projections = not create_in_proj_qkvz
         if create_in_proj_qkvz:
             self.in_proj_qkvz = self.create_qkvz_proj(
                 hidden_size=self.hidden_size,
@@ -610,6 +594,13 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             dim=-1,
         )
 
+        # The split above produces non-contiguous views into the interleaved
+        # buffer.  Concatenating everything into a single flat tensor forces a
+        # contiguous copy, then slicing back out gives contiguous q/k/v/z/b/a
+        # tensors that downstream kernels require.  Doing this in one cat+slice
+        # keeps torch.compile in a single Triton graph instead of emitting
+        # separate copy kernels per tensor.  The original code used
+        # rearrange(...).contiguous() on each tensor individually.
         fused = torch.cat(
             [
                 mixed_qkv_logical.reshape(-1),
@@ -647,6 +638,14 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
 
     @torch.compile(fullgraph=True)
     def rearrange_mixed_qkv(self, mixed_qkv):
+        """Split packed qkv into contiguous (1, seq, heads, dim) tensors.
+
+        The original code used ``rearrange(x, "l (h d) -> 1 l h d", d=...)``
+        followed by ``.contiguous()`` on each tensor.  This version flattens
+        all three splits into a single buffer via ``torch.cat`` so that
+        torch.compile emits one Triton copy kernel instead of three separate
+        contiguous() calls.
+        """
         if mixed_qkv is None:
             return None, None, None
 
@@ -655,15 +654,12 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         k_dim = self.key_dim // self.tp_size
         v_dim = self.value_dim // self.tp_size
 
-        # 1. Create the non-contiguous 2D views
         query, key, value = torch.split(mixed_qkv, [q_dim, k_dim, v_dim], dim=-1)
 
-        # 2. Flatten and concatenate to force a single triton graph.
         fused = torch.cat(
             [query.reshape(-1), key.reshape(-1), value.reshape(-1)], dim=0
         )
 
-        # 3. Slice the single buffer.
         q_size = seq_len * q_dim
         k_size = seq_len * k_dim
 
@@ -671,7 +667,6 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         k_contig = fused[q_size : q_size + k_size]
         v_contig = fused[q_size + k_size :]
 
-        # 4. Zero cost reshape
         query = q_contig.view(1, seq_len, -1, self.head_k_dim)
         key = k_contig.view(1, seq_len, -1, self.head_k_dim)
         value = v_contig.view(1, seq_len, -1, self.head_v_dim)
@@ -700,7 +695,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         # ============================================================
         # Fast path for with Triton decode kernels for part 1&2
         # ============================================================
-        if not hasattr(self, "in_proj_qkv") and GDN_AITER_TRITON_AVAILABLE:
+        if not self.has_lora_projections and GDN_AITER_TRITON_AVAILABLE:
             projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
             projected_states_ba, _ = self.in_proj_ba(hidden_states)
             projected_states_qkvz = projected_states_qkvz.view(num_tokens, -1)
@@ -721,14 +716,14 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
                 projected_states_ba,
                 z,
                 core_attn_out,
-                True,
-                self.prefix,
+                fast_kernel=True,
+                layer_name=_encode_layer_name(self.prefix),
             )
         else:
             # ============================================================
             # Part 1: Input Projection
             # ============================================================
-            if hasattr(self, "in_proj_qkv"):
+            if self.has_lora_projections:
                 # LoRA path (Qwen3.5 only): separate in_proj_qkv and in_proj_z
                 mixed_qkv, _ = self.in_proj_qkv(hidden_states)
                 ba, _ = self.in_proj_ba(hidden_states)
@@ -776,8 +771,8 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
                 b,
                 a,
                 core_attn_out,
-                False,
-                _encode_layer_name(self.prefix),
+                fast_kernel=False,
+                layer_name=_encode_layer_name(self.prefix),
             )
 
         # ============================================================
@@ -806,7 +801,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         """
         num_tokens = hidden_states.size(0)
 
-        assert not hasattr(self, "in_proj_qkv"), "lora isn't supported on XPU."
+        assert not self.has_lora_projections, "lora isn't supported on XPU."
 
         # ============================================================
         # Part 1: Input Projection
@@ -1006,6 +1001,26 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         core_attn_out: torch.Tensor,
         fast_kernel: bool,
     ):
+        """Core conv1d + recurrent attention, dispatched by ``fast_kernel``.
+
+        The parameter semantics depend on ``fast_kernel``:
+
+        When ``fast_kernel=False`` (standard path):
+            qkv_or_qkvz: packed [q, k, v] projection  (num_tokens, qkv_dim)
+            b_or_ba:      beta gating vector           (num_tokens, num_heads)
+            a_or_z_out:   alpha gating vector           (num_tokens, num_heads)
+
+        When ``fast_kernel=True`` (AITER Triton fast path):
+            qkv_or_qkvz: packed [q, k, v, z] projection (num_tokens, qkvz_dim)
+            b_or_ba:      packed [b, a] gating vectors   (num_tokens, 2*num_heads)
+            a_or_z_out:   **output** buffer for z         (num_tokens, num_heads,
+                          head_dim); mutated in-place by the fused kernel.
+
+        Args:
+            core_attn_out: Pre-allocated output buffer for attention results.
+            fast_kernel: If True, use fused AITER Triton decode kernels that
+                consume the packed qkvz/ba layout directly.
+        """
         forward_context = get_forward_context()
         attn_metadata_raw = forward_context.attn_metadata
 
@@ -1298,13 +1313,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         core_attn_out: torch.Tensor,
         attn_metadata: GDNAttentionMetadata,
     ):
-        has_initial_state = attn_metadata.has_initial_state
-        spec_query_start_loc = attn_metadata.spec_query_start_loc
         non_spec_query_start_loc = attn_metadata.non_spec_query_start_loc
-        spec_sequence_masks = attn_metadata.spec_sequence_masks
-        spec_token_indx = attn_metadata.spec_token_indx
-        non_spec_token_indx = attn_metadata.non_spec_token_indx
-        spec_state_indices_tensor = attn_metadata.spec_state_indices_tensor  # noqa: E501
         non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor  # noqa: E501
         self_kv_cache = self.kv_cache
         # conv_state must be (..., dim, width-1) for the conv kernels.
@@ -1315,8 +1324,6 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             else self_kv_cache[0].transpose(-1, -2)
         )
         ssm_state = self_kv_cache[1]
-        num_actual_tokens = attn_metadata.num_actual_tokens
-        num_accepted_tokens = attn_metadata.num_accepted_tokens
 
         # 1. Convolution sequence transformation
         conv_weights = self.conv1d.weight.view(
@@ -1326,7 +1333,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         mixed_qkv_non_spec, b, a = (
             gdn_aiter_fused_reshape_causal_conv1d_update_single_token(
                 qkvz,
-                num_actual_tokens,
+                attn_metadata.num_actual_tokens,
                 self.num_k_heads // self.tp_size,
                 self.num_v_heads // self.tp_size,
                 self.head_k_dim,
@@ -1346,32 +1353,23 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         )
 
         # 2. Recurrent attention
-
-        core_attn_out_spec, last_recurrent_state = None, None
-
-        core_attn_out_non_spec, last_recurrent_state = (
-            gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule(
-                A_log=self.A_log,
-                a=a,
-                b=b,
-                dt_bias=self.dt_bias,
-                qkv=mixed_qkv_non_spec,
-                key_dim=self.key_dim // self.tp_size,
-                value_dim=self.value_dim // self.tp_size,
-                head_k_dim=self.head_k_dim,
-                head_v_dim=self.head_v_dim,
-                initial_state=ssm_state,
-                inplace_final_state=True,
-                cu_seqlens=non_spec_query_start_loc[
-                    : attn_metadata.num_decodes + 1
-                ],
-                ssm_state_indices=non_spec_state_indices_tensor,
-                use_qk_l2norm_in_kernel=True,
-                core_attn_out=core_attn_out.reshape(-1),
-            )
+        gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule(
+            A_log=self.A_log,
+            a=a,
+            b=b,
+            dt_bias=self.dt_bias,
+            qkv=mixed_qkv_non_spec,
+            key_dim=self.key_dim // self.tp_size,
+            value_dim=self.value_dim // self.tp_size,
+            head_k_dim=self.head_k_dim,
+            head_v_dim=self.head_v_dim,
+            initial_state=ssm_state,
+            inplace_final_state=True,
+            cu_seqlens=non_spec_query_start_loc[: attn_metadata.num_decodes + 1],
+            ssm_state_indices=non_spec_state_indices_tensor,
+            use_qk_l2norm_in_kernel=True,
+            core_attn_out=core_attn_out.reshape(-1),
         )
-
-        return
 
     def _forward_core_decode_non_spec(
         self,
@@ -1436,10 +1434,15 @@ def gdn_attention_core(
     fast_kernel: bool,
     layer_name: LayerNameType,
 ) -> None:
-    """
-    Custom op for the core attention computation.
-    Only handles the convolution + recurrent attention part.
-    Input/output projections are handled outside this op.
+    """Custom op wrapping GatedDeltaNetAttention._forward_core.
+
+    Handles conv1d + recurrent attention only; input/output projections
+    are performed by the caller.  See ``_forward_core`` for the
+    ``fast_kernel``-dependent parameter semantics.
+
+    ``a_or_z_out`` and ``core_attn_out`` are mutated in-place.
+    ``a_or_z_out`` is only written when ``fast_kernel=True`` (it serves
+    as the z output buffer); when ``fast_kernel=False`` it is read-only.
     """
     layer_name = _resolve_layer_name(layer_name)
     forward_context: ForwardContext = get_forward_context()

--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -1038,17 +1038,32 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             )
 
         if fast_kernel:
-            return self._forward_core_decode_fast(
-                qkvz=qkv_or_qkvz,
-                ba=b_or_ba,
-                z_out=a_or_z_out,
-                core_attn_out=core_attn_out,
-                attn_metadata=attn_metadata,
+            qkvz = qkv_or_qkvz
+            ba = b_or_ba
+            z_out = a_or_z_out
+            if (
+                attn_metadata.spec_sequence_masks is None
+                and attn_metadata.num_prefills == 0
+                and attn_metadata.num_decodes > 0
+            ):
+                return self._forward_core_decode_fast(
+                    qkvz=qkvz,
+                    ba=ba,
+                    z_out=z_out,
+                    core_attn_out=core_attn_out,
+                    attn_metadata=attn_metadata,
+                )
+            core_attn_out.zero_()
+            z_out.zero_()
+            num_tokens_all = qkvz.shape[0]
+            mixed_qkv, z, b, a = self.prepare_gdn_attention_core_inputs(
+                qkvz, ba, num_tokens_all
             )
-
-        mixed_qkv = qkv_or_qkvz
-        b = b_or_ba
-        a = a_or_z_out
+            z_out[:] = z
+        else:
+            mixed_qkv = qkv_or_qkvz
+            b = b_or_ba
+            a = a_or_z_out
 
         has_initial_state = attn_metadata.has_initial_state
         spec_query_start_loc = attn_metadata.spec_query_start_loc
@@ -1308,239 +1323,54 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             self.conv1d.weight.size(0), self.conv1d.weight.size(2)
         )
 
-        if spec_sequence_masks is not None or attn_metadata.num_prefills > 0:
-            core_attn_out.zero_()
-            z_out.zero_()
-            num_tokens_all = qkvz.shape[0]
-            mixed_qkv, z, b, a = self.prepare_gdn_attention_core_inputs(
-                qkvz, ba, num_tokens_all
-            )
-            z_out[:] = z
-            mixed_qkv = mixed_qkv[:num_actual_tokens]
-            b = b[:num_actual_tokens]
-            a = a[:num_actual_tokens]
-        else:
-            mixed_qkv, b, a = None, None, None
-
-        if spec_sequence_masks is not None:
-            if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
-                mixed_qkv_spec = mixed_qkv
-                mixed_qkv_non_spec = None
-            else:
-                mixed_qkv_spec = mixed_qkv.index_select(0, spec_token_indx)
-                mixed_qkv_non_spec = mixed_qkv.index_select(0, non_spec_token_indx)
-        elif attn_metadata.num_prefills > 0:
-            mixed_qkv_spec = None
-            mixed_qkv_non_spec = mixed_qkv
-        else:
-            mixed_qkv_spec = None
-            mixed_qkv_non_spec = None
-
-        # 1.1: Process the multi-query part
-        if spec_sequence_masks is not None:
-            mixed_qkv_spec = causal_conv1d_update(
-                mixed_qkv_spec,
+        mixed_qkv_non_spec, b, a = (
+            gdn_aiter_fused_reshape_causal_conv1d_update_single_token(
+                qkvz,
+                num_actual_tokens,
+                self.num_k_heads // self.tp_size,
+                self.num_v_heads // self.tp_size,
+                self.head_k_dim,
+                self.head_v_dim,
+                ba,
+                z_out,
+                core_attn_out,
                 conv_state,
                 conv_weights,
                 self.conv1d.bias,
                 self.activation,
-                conv_state_indices=spec_state_indices_tensor[:, 0][
-                    : attn_metadata.num_spec_decodes
+                conv_state_indices=non_spec_state_indices_tensor[
+                    : attn_metadata.num_actual_tokens
                 ],
-                num_accepted_tokens=num_accepted_tokens,
-                query_start_loc=spec_query_start_loc,
-                max_query_len=spec_state_indices_tensor.size(-1),
-                validate_data=False,
+                validate_data=True,
             )
-
-        # 1.2: Process the remaining part
-        if attn_metadata.num_prefills > 0:
-            assert mixed_qkv_non_spec is not None
-            mixed_qkv_non_spec_T = mixed_qkv_non_spec.transpose(0, 1)
-            # - "cache_indices" updates the conv_state cache in positions
-            #   pointed to by "state_indices_tensor"
-            mixed_qkv_non_spec = causal_conv1d_fn(
-                mixed_qkv_non_spec_T,
-                conv_weights,
-                self.conv1d.bias,
-                activation=self.activation,
-                conv_states=conv_state,
-                has_initial_state=has_initial_state,
-                cache_indices=non_spec_state_indices_tensor,
-                query_start_loc=non_spec_query_start_loc,
-                metadata=attn_metadata,
-            ).transpose(0, 1)
-        elif attn_metadata.num_decodes > 0:
-            if mixed_qkv_non_spec is not None:
-                mixed_qkv_non_spec = gdn_aiter_causal_conv1d_update_single_token(
-                    mixed_qkv_non_spec,
-                    conv_state,
-                    conv_weights,
-                    self.conv1d.bias,
-                    self.activation,
-                    conv_state_indices=non_spec_state_indices_tensor[
-                        : attn_metadata.num_actual_tokens
-                    ],
-                    validate_data=True,
-                )
-            else:
-                mixed_qkv_non_spec, b, a = (
-                    gdn_aiter_fused_reshape_causal_conv1d_update_single_token(
-                        qkvz,
-                        num_actual_tokens,
-                        self.num_k_heads // self.tp_size,
-                        self.num_v_heads // self.tp_size,
-                        self.head_k_dim,
-                        self.head_v_dim,
-                        ba,
-                        z_out,
-                        core_attn_out,
-                        conv_state,
-                        conv_weights,
-                        self.conv1d.bias,
-                        self.activation,
-                        conv_state_indices=non_spec_state_indices_tensor[
-                            : attn_metadata.num_actual_tokens
-                        ],
-                        validate_data=True,
-                    )
-                )
-        else:
-            mixed_qkv_non_spec = None
-
-        if attn_metadata.num_prefills > 0:
-            assert mixed_qkv_non_spec is not None, (
-                "mixed_qkv_non_spec must be provided for prefill path"
-            )
-            if spec_sequence_masks is not None:
-                a_non_spec = a.index_select(0, non_spec_token_indx)
-                b_non_spec = b.index_select(0, non_spec_token_indx)
-            else:
-                a_non_spec = a
-                b_non_spec = b
-
-            (
-                query_non_spec,
-                key_non_spec,
-                value_non_spec,
-                g_non_spec,
-                beta_non_spec,
-            ) = fused_post_conv_prep(
-                conv_output=mixed_qkv_non_spec,
-                a=a_non_spec,
-                b=b_non_spec,
-                A_log=self.A_log,
-                dt_bias=self.dt_bias,
-                num_k_heads=self.num_k_heads // self.tp_size,
-                head_k_dim=self.head_k_dim,
-                head_v_dim=self.head_v_dim,
-                apply_l2norm=True,
-                output_g_exp=False,
-            )
-            query_non_spec = query_non_spec.unsqueeze(0)
-            key_non_spec = key_non_spec.unsqueeze(0)
-            value_non_spec = value_non_spec.unsqueeze(0)
-            g_non_spec = g_non_spec.unsqueeze(0)
-            beta_non_spec = beta_non_spec.unsqueeze(0)
-        else:
-            g_non_spec = None
-            beta_non_spec = None
-
-        core_attn_flat = (
-            core_attn_out.reshape(-1) if spec_sequence_masks is None else None
         )
 
         # 2. Recurrent attention
 
-        # 2.1: Process the multi-query part
-        if spec_sequence_masks is not None:
-            core_attn_out_spec, last_recurrent_state = (
-                gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule(
-                    A_log=self.A_log,
-                    a=a,
-                    b=b,
-                    dt_bias=self.dt_bias,
-                    qkv=mixed_qkv_spec,
-                    key_dim=self.key_dim // self.tp_size,
-                    value_dim=self.value_dim // self.tp_size,
-                    head_k_dim=self.head_k_dim,
-                    head_v_dim=self.head_v_dim,
-                    initial_state=ssm_state,
-                    inplace_final_state=True,
-                    cu_seqlens=spec_query_start_loc[
-                        : attn_metadata.num_spec_decodes + 1
-                    ],
-                    ssm_state_indices=spec_state_indices_tensor,
-                    num_accepted_tokens=num_accepted_tokens,
-                    use_qk_l2norm_in_kernel=True,
-                    core_attn_out=core_attn_flat,
-                )
-            )
-        else:
-            core_attn_out_spec, last_recurrent_state = None, None
+        core_attn_out_spec, last_recurrent_state = None, None
 
-        # 2.2: Process the remaining part
-        if attn_metadata.num_prefills > 0:
-            initial_state = ssm_state[non_spec_state_indices_tensor].contiguous()
-            initial_state[~has_initial_state, ...] = 0
-            (
-                core_attn_out_non_spec,
-                last_recurrent_state,
-            ) = self.chunk_gated_delta_rule(
-                q=query_non_spec,
-                k=key_non_spec,
-                v=value_non_spec,
-                g=g_non_spec,
-                beta=beta_non_spec,
-                initial_state=initial_state,
-                output_final_state=True,
-                cu_seqlens=non_spec_query_start_loc,
-                chunk_indices=attn_metadata.chunk_indices,
-                chunk_offsets=attn_metadata.chunk_offsets,
-                use_qk_l2norm_in_kernel=False,
-                core_attn_out=core_attn_flat,
+        core_attn_out_non_spec, last_recurrent_state = (
+            gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule(
+                A_log=self.A_log,
+                a=a,
+                b=b,
+                dt_bias=self.dt_bias,
+                qkv=mixed_qkv_non_spec,
+                key_dim=self.key_dim // self.tp_size,
+                value_dim=self.value_dim // self.tp_size,
+                head_k_dim=self.head_k_dim,
+                head_v_dim=self.head_v_dim,
+                initial_state=ssm_state,
+                inplace_final_state=True,
+                cu_seqlens=non_spec_query_start_loc[
+                    : attn_metadata.num_decodes + 1
+                ],
+                ssm_state_indices=non_spec_state_indices_tensor,
+                use_qk_l2norm_in_kernel=True,
+                core_attn_out=core_attn_out.reshape(-1),
             )
-            # Init cache
-            ssm_state[non_spec_state_indices_tensor] = last_recurrent_state.to(
-                ssm_state.dtype
-            )
-        elif attn_metadata.num_decodes > 0:
-            core_attn_out_non_spec, last_recurrent_state = (
-                gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule(
-                    A_log=self.A_log,
-                    a=a,
-                    b=b,
-                    dt_bias=self.dt_bias,
-                    qkv=mixed_qkv_non_spec,
-                    key_dim=self.key_dim // self.tp_size,
-                    value_dim=self.value_dim // self.tp_size,
-                    head_k_dim=self.head_k_dim,
-                    head_v_dim=self.head_v_dim,
-                    initial_state=ssm_state,
-                    inplace_final_state=True,
-                    cu_seqlens=non_spec_query_start_loc[
-                        : attn_metadata.num_decodes + 1
-                    ],
-                    ssm_state_indices=non_spec_state_indices_tensor,
-                    use_qk_l2norm_in_kernel=True,
-                    core_attn_out=core_attn_flat,
-                )
-            )
-        else:
-            core_attn_out_non_spec, last_recurrent_state = None, None
+        )
 
-        # 3. Merge core attention output
-        if spec_sequence_masks is not None and core_attn_out_non_spec is not None:
-            merged_out = torch.empty(
-                (1, num_actual_tokens, *core_attn_out_spec.shape[2:]),
-                dtype=core_attn_out_non_spec.dtype,
-                device=core_attn_out_non_spec.device,
-            )
-            merged_out.index_copy_(1, spec_token_indx, core_attn_out_spec)
-            merged_out.index_copy_(1, non_spec_token_indx, core_attn_out_non_spec)
-            core_attn_out[:num_actual_tokens] = merged_out.squeeze(0)
-        elif spec_sequence_masks is not None:
-            core_attn_out[:num_actual_tokens] = core_attn_out_spec.squeeze(0)
         return
 
     def _forward_core_decode_non_spec(

--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -2,12 +2,15 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Inference-only Qwen3-Next/Qwen3.5 model."""
 
+from typing import Any
+
 import torch
 from einops import rearrange
 from torch import nn
 from transformers.activations import ACT2FN
 
 from vllm import envs
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.config import (
     VllmConfig,
     get_current_vllm_config,
@@ -63,6 +66,37 @@ from vllm.utils.torch_utils import (
     direct_register_custom_op,
 )
 from vllm.v1.attention.backends.gdn_attn import GDNAttentionMetadata
+
+# Optional ROCm AITER Triton kernels for the GDN decode fast-path.
+# Availability is checked centrally via rocm_aiter_ops; the actual function
+# references are imported here so that they can be called without per-call
+# import overhead.
+GDN_AITER_TRITON_AVAILABLE = False
+gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule: Any = None
+gdn_aiter_causal_conv1d_update_single_token: Any = None
+gdn_aiter_fused_reshape_causal_conv1d_update_single_token: Any = None
+
+if rocm_aiter_ops.is_enabled() and rocm_aiter_ops.are_gdn_triton_kernels_available():
+    from aiter.ops.triton.causal_conv1d_update_single_token import (
+        causal_conv1d_update_single_token as _gdn_aiter_causal_conv1d_update_single_token,  # noqa: E501
+    )
+    from aiter.ops.triton.causal_conv1d_update_single_token import (
+        fused_reshape_causal_conv1d_update_single_token as _gdn_aiter_fused_reshape_causal_conv1d_update_single_token,  # noqa: E501
+    )
+    from aiter.ops.triton.gated_delta_net import (
+        fused_rearrange_sigmoid_gated_delta_rule as _gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule,  # noqa: E501
+    )
+
+    gdn_aiter_causal_conv1d_update_single_token = (
+        _gdn_aiter_causal_conv1d_update_single_token
+    )
+    gdn_aiter_fused_reshape_causal_conv1d_update_single_token = (
+        _gdn_aiter_fused_reshape_causal_conv1d_update_single_token
+    )
+    gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule = (
+        _gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule
+    )
+    GDN_AITER_TRITON_AVAILABLE = True
 
 logger = init_logger(__name__)
 
@@ -169,8 +203,9 @@ class ChunkGatedDeltaRule(CustomOp):
         chunk_indices: torch.Tensor | None = None,
         chunk_offsets: torch.Tensor | None = None,
         use_qk_l2norm_in_kernel: bool = True,
+        core_attn_out: torch.Tensor | None = None,
     ):
-        return fi_chunk_gated_delta_rule(
+        o, final_state = fi_chunk_gated_delta_rule(
             q=q,
             k=k,
             v=v,
@@ -181,6 +216,11 @@ class ChunkGatedDeltaRule(CustomOp):
             cu_seqlens=cu_seqlens,
             use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
         )
+        if core_attn_out is not None:
+            o_flat = o.squeeze(0).reshape(-1)
+            co_flat = core_attn_out.reshape(-1)
+            co_flat[: o_flat.numel()].copy_(o_flat)
+        return o, final_state
 
     def forward_native(
         self,
@@ -195,6 +235,7 @@ class ChunkGatedDeltaRule(CustomOp):
         chunk_indices: torch.Tensor | None = None,
         chunk_offsets: torch.Tensor | None = None,
         use_qk_l2norm_in_kernel: bool = True,
+        core_attn_out: torch.Tensor | None = None,
     ):
         return fla_chunk_gated_delta_rule(
             q=q,
@@ -208,6 +249,7 @@ class ChunkGatedDeltaRule(CustomOp):
             chunk_indices=chunk_indices,
             chunk_offsets=chunk_offsets,
             use_qk_l2norm_in_kernel=use_qk_l2norm_in_kernel,
+            core_attn_out=core_attn_out,
         )
 
 
@@ -497,24 +539,144 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
 
         return query, key, value, z, b, a
 
-    def rearrange_mixed_qkv(self, mixed_qkv):
-        if mixed_qkv is None:
-            return None, None, None
-        query, key, value = torch.split(
-            mixed_qkv,
+    @torch.compile(fullgraph=True)
+    def prepare_gdn_attention_core_inputs(
+        self,
+        mixed_qkvz: torch.Tensor,
+        mixed_ba: torch.Tensor,
+        num_tokens: int,
+    ):
+        """
+        Derives mixed_qkv, z, b, a from projected qkvz/ba for the GDN custom op.
+
+        For gqa_interleaved_layout (Qwen3-Next): unpack the interleaved
+        [ng, (hk + hk + np/ng*hv + np/ng*hv)] layout into contiguous qkv.
+        For non-interleaved layout (Qwen3.5): simple split along last dim.
+        """
+        if not self.gqa_interleaved_layout:
+            # Qwen3.5: weights are in [q, k, v, z] order
+            assert num_tokens == mixed_qkvz.shape[0]
+            qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
+            z_size = self.value_dim // self.tp_size
+            mixed_qkv, z_flat = mixed_qkvz.split([qkv_size, z_size], dim=-1)
+            n = mixed_qkvz.shape[0]
+            z_out = z_flat.reshape(n, -1, self.head_v_dim)
+            b, a = mixed_ba.chunk(2, dim=-1)
+            return mixed_qkv, z_out, b, a
+
+        # Qwen3-Next: interleaved GQA layout
+        base_shape_qkvz = mixed_qkvz.size()[:-1]
+        base_shape_ba = mixed_ba.size()[:-1]
+        ng = self.num_k_heads // self.tp_size
+
+        new_tensor_shape_qkvz = base_shape_qkvz + (
+            ng,
+            (
+                self.head_k_dim
+                + self.head_k_dim
+                + (self.head_v_dim + self.head_v_dim)
+                * self.num_v_heads
+                // self.num_k_heads
+            ),
+        )
+        new_tensor_shape_ba = base_shape_ba + (
+            ng,
+            2 * self.num_v_heads // self.num_k_heads,
+        )
+
+        mixed_qkvz = mixed_qkvz.view(*new_tensor_shape_qkvz)
+        mixed_ba = mixed_ba.view(*new_tensor_shape_ba)
+
+        split_arg_list_qkvz = [
+            self.head_k_dim,
+            self.head_k_dim,
+            (self.num_v_heads // self.num_k_heads * self.head_v_dim),
+            (self.num_v_heads // self.num_k_heads * self.head_v_dim),
+        ]
+        split_arg_list_ba = [
+            self.num_v_heads // self.num_k_heads,
+            self.num_v_heads // self.num_k_heads,
+        ]
+
+        (query, key, value, z) = torch.split(mixed_qkvz, split_arg_list_qkvz, dim=-1)
+        (b, a) = torch.split(mixed_ba, split_arg_list_ba, dim=-1)
+
+        mixed_qkv_logical = torch.cat(
             [
-                self.key_dim // self.tp_size,
-                self.key_dim // self.tp_size,
-                self.value_dim // self.tp_size,
+                query.reshape(num_tokens, -1),
+                key.reshape(num_tokens, -1),
+                value.reshape(num_tokens, -1),
             ],
             dim=-1,
         )
-        query, key = map(
-            lambda x: rearrange(x, "l (h d) -> 1 l h d", d=self.head_k_dim),
-            (query, key),
+
+        fused = torch.cat(
+            [
+                mixed_qkv_logical.reshape(-1),
+                z.reshape(-1),
+                b.reshape(-1),
+                a.reshape(-1),
+            ],
+            dim=0,
         )
-        value = rearrange(value, "l (h d) -> 1 l h d", d=self.head_v_dim)
-        return query.contiguous(), key.contiguous(), value.contiguous()
+
+        curr = 0
+        qkv_numel = mixed_qkv_logical.numel()
+        z_numel = z.numel()
+        b_numel = b.numel()
+        a_numel = a.numel()
+
+        mixed_qkv_out = fused[curr : curr + qkv_numel].view(num_tokens, -1)
+        curr += qkv_numel
+
+        z_out = fused[curr : curr + z_numel].view(
+            num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim
+        )
+        curr += z_numel
+
+        b_out = fused[curr : curr + b_numel].view(
+            num_tokens, self.num_v_heads // self.tp_size
+        )
+        curr += b_numel
+
+        a_out = fused[curr : curr + a_numel].view(
+            num_tokens, self.num_v_heads // self.tp_size
+        )
+
+        return mixed_qkv_out, z_out, b_out, a_out
+
+    @torch.compile(fullgraph=True)
+    def rearrange_mixed_qkv(self, mixed_qkv):
+        if mixed_qkv is None:
+            return None, None, None
+
+        seq_len = mixed_qkv.shape[0]
+        q_dim = self.key_dim // self.tp_size
+        k_dim = self.key_dim // self.tp_size
+        v_dim = self.value_dim // self.tp_size
+
+        # 1. Create the non-contiguous 2D views
+        query, key, value = torch.split(mixed_qkv, [q_dim, k_dim, v_dim], dim=-1)
+
+        # 2. Flatten and concatenate to force a single triton graph.
+        fused = torch.cat(
+            [query.reshape(-1), key.reshape(-1), value.reshape(-1)], dim=0
+        )
+
+        # 3. Slice the single buffer.
+        q_size = seq_len * q_dim
+        k_size = seq_len * k_dim
+
+        q_contig = fused[0:q_size]
+        k_contig = fused[q_size : q_size + k_size]
+        v_contig = fused[q_size + k_size :]
+
+        # 4. Zero cost reshape
+        query = q_contig.view(1, seq_len, -1, self.head_k_dim)
+        key = k_contig.view(1, seq_len, -1, self.head_k_dim)
+        value = v_contig.view(1, seq_len, -1, self.head_v_dim)
+
+        return query, key, value
 
     def forward(
         self,
@@ -536,64 +698,94 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         """
         num_tokens = hidden_states.size(0)
         # ============================================================
-        # Part 1: Input Projection
+        # Fast path for with Triton decode kernels for part 1&2
         # ============================================================
-        if hasattr(self, "in_proj_qkv"):
-            # LoRA path (Qwen3.5 only): separate in_proj_qkv and in_proj_z
-            mixed_qkv, _ = self.in_proj_qkv(hidden_states)
-            ba, _ = self.in_proj_ba(hidden_states)
-            z, _ = self.in_proj_z(hidden_states)
-            z = z.reshape(z.size(0), -1, self.head_v_dim)
-            b, a = ba.chunk(2, dim=-1)
-            b = b.contiguous()
-            a = a.contiguous()
-        else:
-            mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
-            ba, _ = self.in_proj_ba(hidden_states)
+        if not hasattr(self, "in_proj_qkv") and GDN_AITER_TRITON_AVAILABLE:
+            projected_states_qkvz, _ = self.in_proj_qkvz(hidden_states)
+            projected_states_ba, _ = self.in_proj_ba(hidden_states)
+            projected_states_qkvz = projected_states_qkvz.view(num_tokens, -1)
+            projected_states_ba = projected_states_ba.view(num_tokens, -1)
+            core_attn_out = torch.empty(
+                (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+            z = torch.empty(
+                (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+                dtype=projected_states_qkvz.dtype,
+                device=projected_states_qkvz.device,
+            )
 
-            if self.gqa_interleaved_layout:
-                # Qwen3-Next: unpack the interleaved GQA layout
-                query, key, value, z, b, a = self.fix_query_key_value_ordering(
-                    mixed_qkvz, ba
-                )
-                query, key, value = map(
-                    lambda x: rearrange(x, "l p d -> l (p d)"), (query, key, value)
-                )
-                mixed_qkv = torch.cat((query, key, value), dim=-1)
-            else:
-                # Qwen3.5: weights are already in [q, k, v, z] and [b, a] order
-                qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
-                z_size = self.value_dim // self.tp_size
-                mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)
+            torch.ops.vllm.gdn_attention_core(
+                projected_states_qkvz,
+                projected_states_ba,
+                z,
+                core_attn_out,
+                True,
+                self.prefix,
+            )
+        else:
+            # ============================================================
+            # Part 1: Input Projection
+            # ============================================================
+            if hasattr(self, "in_proj_qkv"):
+                # LoRA path (Qwen3.5 only): separate in_proj_qkv and in_proj_z
+                mixed_qkv, _ = self.in_proj_qkv(hidden_states)
+                ba, _ = self.in_proj_ba(hidden_states)
+                z, _ = self.in_proj_z(hidden_states)
                 z = z.reshape(z.size(0), -1, self.head_v_dim)
                 b, a = ba.chunk(2, dim=-1)
                 b = b.contiguous()
                 a = a.contiguous()
+            else:
+                mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
+                ba, _ = self.in_proj_ba(hidden_states)
 
-        # ============================================================
-        # Part 2: Core Attention (Custom Op)
-        # ============================================================
-        # Note: we should not use torch.empty here like other attention backends,
-        # see discussions in https://github.com/vllm-project/vllm/pull/28182
-        core_attn_out = torch.zeros(
-            (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
-            dtype=hidden_states.dtype,
-            device=hidden_states.device,
-        )
+                if self.gqa_interleaved_layout:
+                    # Qwen3-Next: unpack the interleaved GQA layout
+                    query, key, value, z, b, a = self.fix_query_key_value_ordering(
+                        mixed_qkvz, ba
+                    )
+                    query, key, value = map(
+                        lambda x: rearrange(x, "l p d -> l (p d)"), (query, key, value)
+                    )
+                    mixed_qkv = torch.cat((query, key, value), dim=-1)
+                else:
+                    # Qwen3.5: weights are already in [q, k, v, z] and [b, a] order
+                    qkv_size = (self.key_dim * 2 + self.value_dim) // self.tp_size
+                    z_size = self.value_dim // self.tp_size
+                    mixed_qkv, z = mixed_qkvz.split([qkv_size, z_size], dim=-1)
+                    z = z.reshape(z.size(0), -1, self.head_v_dim)
+                    b, a = ba.chunk(2, dim=-1)
+                    b = b.contiguous()
+                    a = a.contiguous()
 
-        torch.ops.vllm.gdn_attention_core(
-            mixed_qkv,
-            b,
-            a,
-            core_attn_out,
-            _encode_layer_name(self.prefix),
-        )
+            # ============================================================
+            # Part 2: Core Attention (Custom Op)
+            # ============================================================
+            # Note: we should not use torch.empty here like other attention backends,
+            # see discussions in https://github.com/vllm-project/vllm/pull/28182
+            core_attn_out = torch.zeros(
+                (num_tokens, self.num_v_heads // self.tp_size, self.head_v_dim),
+                dtype=hidden_states.dtype,
+                device=hidden_states.device,
+            )
+
+            torch.ops.vllm.gdn_attention_core(
+                mixed_qkv,
+                b,
+                a,
+                core_attn_out,
+                False,
+                _encode_layer_name(self.prefix),
+            )
 
         # ============================================================
         # Part 3: Output Projection
         # ============================================================
+        # The RMSNormGated + quant sequence below is eligible for fusion
+        # by the compilation pass when fuse_norm_quant is enabled.
         z_shape_og = z.shape
-        # Reshape input data into 2D tensor
         core_attn_out = core_attn_out.reshape(-1, core_attn_out.shape[-1])
         z = z.reshape(-1, z.shape[-1])
         core_attn_out = self.norm(core_attn_out, z)
@@ -702,7 +894,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         core_attn_out = rearrange(core_attn_out, "... h d -> ... (h d)")
         output[:num_tokens], _ = self.out_proj(core_attn_out)
 
-    def _warmup_prefill_kernels(self, mixed_qkv: torch.Tensor) -> None:
+    def _warmup_prefill_kernels(self, qkv_or_qkvz: torch.Tensor, v_dim: int) -> None:
         """Warm up GDN prefill kernels during V1 profiling.
 
         During V1 profile runs, ``_forward_core`` returns early because
@@ -723,7 +915,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         ``BT = chunk_size`` (64).  A single warmup pass with T = 64
         is sufficient to populate the autotuner cache.
 
-        The decode path uses ``fused_sigmoid_gating_delta_rule_update``
+        The decode path uses ``gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule``
         which has fixed kernel parameters (no autotuning), so only the
         prefill (chunked) path needs warming up.
         """
@@ -731,8 +923,8 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             return
         self._prefill_kernels_warmed_up = True
 
-        device = mixed_qkv.device
-        dtype = mixed_qkv.dtype
+        device = qkv_or_qkvz.device
+        dtype = qkv_or_qkvz.dtype
         num_k_heads = self.num_k_heads // self.tp_size
         num_v_heads = self.num_v_heads // self.tp_size
         _, state_dtype = self.get_state_dtype()
@@ -743,7 +935,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         # then run chunk_gated_delta_rule with in-kernel L2 norm disabled.
         T = FLA_CHUNK_SIZE
         dummy_mixed_qkv = torch.randn(
-            T, mixed_qkv.shape[-1], device=device, dtype=dtype
+            T, qkv_or_qkvz.shape[-1] - v_dim, device=device, dtype=dtype
         )
         dummy_a = torch.randn(T, num_v_heads, device=device, dtype=dtype)
         dummy_b = torch.randn(T, num_v_heads, device=device, dtype=dtype)
@@ -808,10 +1000,11 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
 
     def _forward_core(
         self,
-        mixed_qkv: torch.Tensor,
-        b: torch.Tensor,
-        a: torch.Tensor,
+        qkv_or_qkvz: torch.Tensor,
+        b_or_ba: torch.Tensor,
+        a_or_z_out: torch.Tensor,
         core_attn_out: torch.Tensor,
+        fast_kernel: bool,
     ):
         forward_context = get_forward_context()
         attn_metadata_raw = forward_context.attn_metadata
@@ -819,7 +1012,10 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         if attn_metadata_raw is None:
             # V1 profile run — warm up prefill kernels so that
             # autotuning completes before KV cache allocation.
-            self._warmup_prefill_kernels(mixed_qkv)
+            v_dim = (
+                core_attn_out.shape[-1] * core_attn_out.shape[-2] if fast_kernel else 0
+            )
+            self._warmup_prefill_kernels(qkv_or_qkvz, v_dim)
             return
 
         assert isinstance(attn_metadata_raw, dict)
@@ -831,14 +1027,28 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             and attn_metadata.spec_sequence_masks is None
             and attn_metadata.num_prefills == 0
             and attn_metadata.num_decodes > 0
+            and not fast_kernel
         ):
             return self._forward_core_decode_non_spec(
-                mixed_qkv=mixed_qkv,
-                b=b,
-                a=a,
+                mixed_qkv=qkv_or_qkvz,
+                b=b_or_ba,
+                a=a_or_z_out,
                 core_attn_out=core_attn_out,
                 attn_metadata=attn_metadata,
             )
+
+        if fast_kernel:
+            return self._forward_core_decode_fast(
+                qkvz=qkv_or_qkvz,
+                ba=b_or_ba,
+                z_out=a_or_z_out,
+                core_attn_out=core_attn_out,
+                attn_metadata=attn_metadata,
+            )
+
+        mixed_qkv = qkv_or_qkvz
+        b = b_or_ba
+        a = a_or_z_out
 
         has_initial_state = attn_metadata.has_initial_state
         spec_query_start_loc = attn_metadata.spec_query_start_loc
@@ -1065,6 +1275,274 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         else:
             core_attn_out[:num_actual_tokens] = core_attn_out_non_spec.squeeze(0)
 
+    def _forward_core_decode_fast(
+        self,
+        qkvz: torch.Tensor,
+        ba: torch.Tensor,
+        z_out: torch.Tensor,
+        core_attn_out: torch.Tensor,
+        attn_metadata: GDNAttentionMetadata,
+    ):
+        has_initial_state = attn_metadata.has_initial_state
+        spec_query_start_loc = attn_metadata.spec_query_start_loc
+        non_spec_query_start_loc = attn_metadata.non_spec_query_start_loc
+        spec_sequence_masks = attn_metadata.spec_sequence_masks
+        spec_token_indx = attn_metadata.spec_token_indx
+        non_spec_token_indx = attn_metadata.non_spec_token_indx
+        spec_state_indices_tensor = attn_metadata.spec_state_indices_tensor  # noqa: E501
+        non_spec_state_indices_tensor = attn_metadata.non_spec_state_indices_tensor  # noqa: E501
+        self_kv_cache = self.kv_cache
+        # conv_state must be (..., dim, width-1) for the conv kernels.
+        # DS layout stores it that way directly; SD layout needs a transpose.
+        conv_state = (
+            self_kv_cache[0]
+            if is_conv_state_dim_first()
+            else self_kv_cache[0].transpose(-1, -2)
+        )
+        ssm_state = self_kv_cache[1]
+        num_actual_tokens = attn_metadata.num_actual_tokens
+        num_accepted_tokens = attn_metadata.num_accepted_tokens
+
+        # 1. Convolution sequence transformation
+        conv_weights = self.conv1d.weight.view(
+            self.conv1d.weight.size(0), self.conv1d.weight.size(2)
+        )
+
+        if spec_sequence_masks is not None or attn_metadata.num_prefills > 0:
+            core_attn_out.zero_()
+            z_out.zero_()
+            num_tokens_all = qkvz.shape[0]
+            mixed_qkv, z, b, a = self.prepare_gdn_attention_core_inputs(
+                qkvz, ba, num_tokens_all
+            )
+            z_out[:] = z
+            mixed_qkv = mixed_qkv[:num_actual_tokens]
+            b = b[:num_actual_tokens]
+            a = a[:num_actual_tokens]
+        else:
+            mixed_qkv, b, a = None, None, None
+
+        if spec_sequence_masks is not None:
+            if attn_metadata.num_prefills == 0 and attn_metadata.num_decodes == 0:
+                mixed_qkv_spec = mixed_qkv
+                mixed_qkv_non_spec = None
+            else:
+                mixed_qkv_spec = mixed_qkv.index_select(0, spec_token_indx)
+                mixed_qkv_non_spec = mixed_qkv.index_select(0, non_spec_token_indx)
+        elif attn_metadata.num_prefills > 0:
+            mixed_qkv_spec = None
+            mixed_qkv_non_spec = mixed_qkv
+        else:
+            mixed_qkv_spec = None
+            mixed_qkv_non_spec = None
+
+        # 1.1: Process the multi-query part
+        if spec_sequence_masks is not None:
+            mixed_qkv_spec = causal_conv1d_update(
+                mixed_qkv_spec,
+                conv_state,
+                conv_weights,
+                self.conv1d.bias,
+                self.activation,
+                conv_state_indices=spec_state_indices_tensor[:, 0][
+                    : attn_metadata.num_spec_decodes
+                ],
+                num_accepted_tokens=num_accepted_tokens,
+                query_start_loc=spec_query_start_loc,
+                max_query_len=spec_state_indices_tensor.size(-1),
+                validate_data=False,
+            )
+
+        # 1.2: Process the remaining part
+        if attn_metadata.num_prefills > 0:
+            assert mixed_qkv_non_spec is not None
+            mixed_qkv_non_spec_T = mixed_qkv_non_spec.transpose(0, 1)
+            # - "cache_indices" updates the conv_state cache in positions
+            #   pointed to by "state_indices_tensor"
+            mixed_qkv_non_spec = causal_conv1d_fn(
+                mixed_qkv_non_spec_T,
+                conv_weights,
+                self.conv1d.bias,
+                activation=self.activation,
+                conv_states=conv_state,
+                has_initial_state=has_initial_state,
+                cache_indices=non_spec_state_indices_tensor,
+                query_start_loc=non_spec_query_start_loc,
+                metadata=attn_metadata,
+            ).transpose(0, 1)
+        elif attn_metadata.num_decodes > 0:
+            if mixed_qkv_non_spec is not None:
+                mixed_qkv_non_spec = gdn_aiter_causal_conv1d_update_single_token(
+                    mixed_qkv_non_spec,
+                    conv_state,
+                    conv_weights,
+                    self.conv1d.bias,
+                    self.activation,
+                    conv_state_indices=non_spec_state_indices_tensor[
+                        : attn_metadata.num_actual_tokens
+                    ],
+                    validate_data=True,
+                )
+            else:
+                mixed_qkv_non_spec, b, a = (
+                    gdn_aiter_fused_reshape_causal_conv1d_update_single_token(
+                        qkvz,
+                        num_actual_tokens,
+                        self.num_k_heads // self.tp_size,
+                        self.num_v_heads // self.tp_size,
+                        self.head_k_dim,
+                        self.head_v_dim,
+                        ba,
+                        z_out,
+                        core_attn_out,
+                        conv_state,
+                        conv_weights,
+                        self.conv1d.bias,
+                        self.activation,
+                        conv_state_indices=non_spec_state_indices_tensor[
+                            : attn_metadata.num_actual_tokens
+                        ],
+                        validate_data=True,
+                    )
+                )
+        else:
+            mixed_qkv_non_spec = None
+
+        if attn_metadata.num_prefills > 0:
+            assert mixed_qkv_non_spec is not None, (
+                "mixed_qkv_non_spec must be provided for prefill path"
+            )
+            if spec_sequence_masks is not None:
+                a_non_spec = a.index_select(0, non_spec_token_indx)
+                b_non_spec = b.index_select(0, non_spec_token_indx)
+            else:
+                a_non_spec = a
+                b_non_spec = b
+
+            (
+                query_non_spec,
+                key_non_spec,
+                value_non_spec,
+                g_non_spec,
+                beta_non_spec,
+            ) = fused_post_conv_prep(
+                conv_output=mixed_qkv_non_spec,
+                a=a_non_spec,
+                b=b_non_spec,
+                A_log=self.A_log,
+                dt_bias=self.dt_bias,
+                num_k_heads=self.num_k_heads // self.tp_size,
+                head_k_dim=self.head_k_dim,
+                head_v_dim=self.head_v_dim,
+                apply_l2norm=True,
+                output_g_exp=False,
+            )
+            query_non_spec = query_non_spec.unsqueeze(0)
+            key_non_spec = key_non_spec.unsqueeze(0)
+            value_non_spec = value_non_spec.unsqueeze(0)
+            g_non_spec = g_non_spec.unsqueeze(0)
+            beta_non_spec = beta_non_spec.unsqueeze(0)
+        else:
+            g_non_spec = None
+            beta_non_spec = None
+
+        core_attn_flat = (
+            core_attn_out.reshape(-1) if spec_sequence_masks is None else None
+        )
+
+        # 2. Recurrent attention
+
+        # 2.1: Process the multi-query part
+        if spec_sequence_masks is not None:
+            core_attn_out_spec, last_recurrent_state = (
+                gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule(
+                    A_log=self.A_log,
+                    a=a,
+                    b=b,
+                    dt_bias=self.dt_bias,
+                    qkv=mixed_qkv_spec,
+                    key_dim=self.key_dim // self.tp_size,
+                    value_dim=self.value_dim // self.tp_size,
+                    head_k_dim=self.head_k_dim,
+                    head_v_dim=self.head_v_dim,
+                    initial_state=ssm_state,
+                    inplace_final_state=True,
+                    cu_seqlens=spec_query_start_loc[
+                        : attn_metadata.num_spec_decodes + 1
+                    ],
+                    ssm_state_indices=spec_state_indices_tensor,
+                    num_accepted_tokens=num_accepted_tokens,
+                    use_qk_l2norm_in_kernel=True,
+                    core_attn_out=core_attn_flat,
+                )
+            )
+        else:
+            core_attn_out_spec, last_recurrent_state = None, None
+
+        # 2.2: Process the remaining part
+        if attn_metadata.num_prefills > 0:
+            initial_state = ssm_state[non_spec_state_indices_tensor].contiguous()
+            initial_state[~has_initial_state, ...] = 0
+            (
+                core_attn_out_non_spec,
+                last_recurrent_state,
+            ) = self.chunk_gated_delta_rule(
+                q=query_non_spec,
+                k=key_non_spec,
+                v=value_non_spec,
+                g=g_non_spec,
+                beta=beta_non_spec,
+                initial_state=initial_state,
+                output_final_state=True,
+                cu_seqlens=non_spec_query_start_loc,
+                chunk_indices=attn_metadata.chunk_indices,
+                chunk_offsets=attn_metadata.chunk_offsets,
+                use_qk_l2norm_in_kernel=False,
+                core_attn_out=core_attn_flat,
+            )
+            # Init cache
+            ssm_state[non_spec_state_indices_tensor] = last_recurrent_state.to(
+                ssm_state.dtype
+            )
+        elif attn_metadata.num_decodes > 0:
+            core_attn_out_non_spec, last_recurrent_state = (
+                gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule(
+                    A_log=self.A_log,
+                    a=a,
+                    b=b,
+                    dt_bias=self.dt_bias,
+                    qkv=mixed_qkv_non_spec,
+                    key_dim=self.key_dim // self.tp_size,
+                    value_dim=self.value_dim // self.tp_size,
+                    head_k_dim=self.head_k_dim,
+                    head_v_dim=self.head_v_dim,
+                    initial_state=ssm_state,
+                    inplace_final_state=True,
+                    cu_seqlens=non_spec_query_start_loc[
+                        : attn_metadata.num_decodes + 1
+                    ],
+                    ssm_state_indices=non_spec_state_indices_tensor,
+                    use_qk_l2norm_in_kernel=True,
+                    core_attn_out=core_attn_flat,
+                )
+            )
+        else:
+            core_attn_out_non_spec, last_recurrent_state = None, None
+
+        # 3. Merge core attention output
+        if spec_sequence_masks is not None and core_attn_out_non_spec is not None:
+            merged_out = torch.empty(
+                (1, num_actual_tokens, *core_attn_out_spec.shape[2:]),
+                dtype=core_attn_out_non_spec.dtype,
+                device=core_attn_out_non_spec.device,
+            )
+            merged_out.index_copy_(1, spec_token_indx, core_attn_out_spec)
+            merged_out.index_copy_(1, non_spec_token_indx, core_attn_out_non_spec)
+            core_attn_out[:num_actual_tokens] = merged_out.squeeze(0)
+        elif spec_sequence_masks is not None:
+            core_attn_out[:num_actual_tokens] = core_attn_out_spec.squeeze(0)
+        return
+
     def _forward_core_decode_non_spec(
         self,
         mixed_qkv: torch.Tensor,
@@ -1121,10 +1599,11 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
 
 
 def gdn_attention_core(
-    mixed_qkv: torch.Tensor,
-    b: torch.Tensor,
-    a: torch.Tensor,
+    qkv_or_qkvz: torch.Tensor,
+    b_or_ba: torch.Tensor,
+    a_or_z_out: torch.Tensor,
     core_attn_out: torch.Tensor,
+    fast_kernel: bool,
     layer_name: LayerNameType,
 ) -> None:
     """
@@ -1136,18 +1615,20 @@ def gdn_attention_core(
     forward_context: ForwardContext = get_forward_context()
     self = forward_context.no_compile_layers[layer_name]
     self._forward_core(
-        mixed_qkv=mixed_qkv,
-        b=b,
-        a=a,
+        qkv_or_qkvz=qkv_or_qkvz,
+        b_or_ba=b_or_ba,
+        a_or_z_out=a_or_z_out,
         core_attn_out=core_attn_out,
+        fast_kernel=fast_kernel,
     )
 
 
 def gdn_attention_core_fake(
-    mixed_qkv: torch.Tensor,
-    b: torch.Tensor,
-    a: torch.Tensor,
+    qkv_or_qkvz: torch.Tensor,
+    b_or_ba: torch.Tensor,
+    a_or_z_out: torch.Tensor,
     core_attn_out: torch.Tensor,
+    fast_kernel: bool,
     layer_name: LayerNameType,
 ) -> None:
     """Fake implementation for torch.compile."""
@@ -1157,7 +1638,7 @@ def gdn_attention_core_fake(
 direct_register_custom_op(
     op_name="gdn_attention_core",
     op_func=gdn_attention_core,
-    mutates_args=["core_attn_out"],
+    mutates_args=["a_or_z_out", "core_attn_out"],
     fake_impl=gdn_attention_core_fake,
 )
 

--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -1015,44 +1015,86 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
 
         torch.accelerator.empty_cache()
 
-    def _forward_core(
+    def _forward_core_rocm(
         self,
-        qkv_or_qkvz: torch.Tensor,
-        b_or_ba: torch.Tensor,
-        a_or_z_out: torch.Tensor,
+        qkvz: torch.Tensor,
+        ba: torch.Tensor,
+        z_out: torch.Tensor,
         core_attn_out: torch.Tensor,
-        fast_kernel: bool,
     ):
-        """Core conv1d + recurrent attention, dispatched by ``fast_kernel``.
+        """ROCm AITER fast path: conv1d + recurrent attention from packed
+        qkvz/ba layout.
 
-        The parameter semantics depend on ``fast_kernel``:
-
-        When ``fast_kernel=False`` (standard path):
-            qkv_or_qkvz: packed [q, k, v] projection  (num_tokens, qkv_dim)
-            b_or_ba:      beta gating vector           (num_tokens, num_heads)
-            a_or_z_out:   alpha gating vector           (num_tokens, num_heads)
-
-        When ``fast_kernel=True`` (AITER Triton fast path):
-            qkv_or_qkvz: packed [q, k, v, z] projection (num_tokens, qkvz_dim)
-            b_or_ba:      packed [b, a] gating vectors   (num_tokens, 2*num_heads)
-            a_or_z_out:   **output** buffer for z         (num_tokens, num_heads,
-                          head_dim); mutated in-place by the fused kernel.
+        For decode-only (no spec, no prefill), dispatches directly to
+        ``_forward_core_decode_fast``.  Otherwise unpacks the packed
+        layout and falls through to ``_forward_core``.
 
         Args:
+            qkvz: packed [q, k, v, z] projection (num_tokens, qkvz_dim)
+            ba:   packed [b, a] gating vectors    (num_tokens, 2*num_heads)
+            z_out: **output** buffer for z        (num_tokens, num_heads,
+                   head_dim); mutated in-place.
             core_attn_out: Pre-allocated output buffer for attention results.
-            fast_kernel: If True, use fused AITER Triton decode kernels that
-                consume the packed qkvz/ba layout directly.
         """
         forward_context = get_forward_context()
         attn_metadata_raw = forward_context.attn_metadata
 
         if attn_metadata_raw is None:
-            # V1 profile run — warm up prefill kernels so that
-            # autotuning completes before KV cache allocation.
-            v_dim = (
-                core_attn_out.shape[-1] * core_attn_out.shape[-2] if fast_kernel else 0
+            v_dim = core_attn_out.shape[-1] * core_attn_out.shape[-2]
+            self._warmup_prefill_kernels(qkvz, v_dim)
+            return
+
+        assert isinstance(attn_metadata_raw, dict)
+        attn_metadata = attn_metadata_raw[self.prefix]  # type: ignore[index]
+        assert isinstance(attn_metadata, GDNAttentionMetadata)
+
+        if (
+            attn_metadata.spec_sequence_masks is None
+            and attn_metadata.num_prefills == 0
+            and attn_metadata.num_decodes > 0
+        ):
+            return self._forward_core_decode_fast(
+                qkvz=qkvz,
+                ba=ba,
+                z_out=z_out,
+                core_attn_out=core_attn_out,
+                attn_metadata=attn_metadata,
             )
-            self._warmup_prefill_kernels(qkv_or_qkvz, v_dim)
+
+        core_attn_out.zero_()
+        z_out.zero_()
+        num_tokens_all = qkvz.shape[0]
+        mixed_qkv, z, b, a = self.prepare_gdn_attention_core_inputs(
+            qkvz, ba, num_tokens_all
+        )
+        z_out[:] = z
+        self._forward_core(
+            mixed_qkv=mixed_qkv,
+            b=b,
+            a=a,
+            core_attn_out=core_attn_out,
+        )
+
+    def _forward_core(
+        self,
+        mixed_qkv: torch.Tensor,
+        b: torch.Tensor,
+        a: torch.Tensor,
+        core_attn_out: torch.Tensor,
+    ):
+        """Core conv1d + recurrent attention (standard path).
+
+        Args:
+            mixed_qkv: packed [q, k, v] projection (num_tokens, qkv_dim)
+            b: beta gating vector                   (num_tokens, num_heads)
+            a: alpha gating vector                  (num_tokens, num_heads)
+            core_attn_out: Pre-allocated output buffer for attention results.
+        """
+        forward_context = get_forward_context()
+        attn_metadata_raw = forward_context.attn_metadata
+
+        if attn_metadata_raw is None:
+            self._warmup_prefill_kernels(mixed_qkv, 0)
             return
 
         assert isinstance(attn_metadata_raw, dict)
@@ -1064,43 +1106,14 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             and attn_metadata.spec_sequence_masks is None
             and attn_metadata.num_prefills == 0
             and attn_metadata.num_decodes > 0
-            and not fast_kernel
         ):
             return self._forward_core_decode_non_spec(
-                mixed_qkv=qkv_or_qkvz,
-                b=b_or_ba,
-                a=a_or_z_out,
+                mixed_qkv=mixed_qkv,
+                b=b,
+                a=a,
                 core_attn_out=core_attn_out,
                 attn_metadata=attn_metadata,
             )
-
-        if fast_kernel:
-            qkvz = qkv_or_qkvz
-            ba = b_or_ba
-            z_out = a_or_z_out
-            if (
-                attn_metadata.spec_sequence_masks is None
-                and attn_metadata.num_prefills == 0
-                and attn_metadata.num_decodes > 0
-            ):
-                return self._forward_core_decode_fast(
-                    qkvz=qkvz,
-                    ba=ba,
-                    z_out=z_out,
-                    core_attn_out=core_attn_out,
-                    attn_metadata=attn_metadata,
-                )
-            core_attn_out.zero_()
-            z_out.zero_()
-            num_tokens_all = qkvz.shape[0]
-            mixed_qkv, z, b, a = self.prepare_gdn_attention_core_inputs(
-                qkvz, ba, num_tokens_all
-            )
-            z_out[:] = z
-        else:
-            mixed_qkv = qkv_or_qkvz
-            b = b_or_ba
-            a = a_or_z_out
 
         has_initial_state = attn_metadata.has_initial_state
         spec_query_start_loc = attn_metadata.spec_query_start_loc
@@ -1456,26 +1469,36 @@ def gdn_attention_core(
     fast_kernel: bool,
     layer_name: LayerNameType,
 ) -> None:
-    """Custom op wrapping GatedDeltaNetAttention._forward_core.
+    """Custom op dispatching to _forward_core or _forward_core_rocm.
 
     Handles conv1d + recurrent attention only; input/output projections
-    are performed by the caller.  See ``_forward_core`` for the
-    ``fast_kernel``-dependent parameter semantics.
+    are performed by the caller.
 
-    ``a_or_z_out`` and ``core_attn_out`` are mutated in-place.
-    ``a_or_z_out`` is only written when ``fast_kernel=True`` (it serves
-    as the z output buffer); when ``fast_kernel=False`` it is read-only.
+    When ``fast_kernel=False`` (standard path):
+        qkv_or_qkvz is [q, k, v], b_or_ba is b, a_or_z_out is a (read-only).
+    When ``fast_kernel=True`` (AITER Triton fast path, ROCm only):
+        qkv_or_qkvz is [q, k, v, z], b_or_ba is [b, a], a_or_z_out is the
+        z output buffer (mutated in-place).
+
+    ``core_attn_out`` is always mutated in-place.
     """
     layer_name = _resolve_layer_name(layer_name)
     forward_context: ForwardContext = get_forward_context()
     self = forward_context.no_compile_layers[layer_name]
-    self._forward_core(
-        qkv_or_qkvz=qkv_or_qkvz,
-        b_or_ba=b_or_ba,
-        a_or_z_out=a_or_z_out,
-        core_attn_out=core_attn_out,
-        fast_kernel=fast_kernel,
-    )
+    if fast_kernel:
+        self._forward_core_rocm(
+            qkvz=qkv_or_qkvz,
+            ba=b_or_ba,
+            z_out=a_or_z_out,
+            core_attn_out=core_attn_out,
+        )
+    else:
+        self._forward_core(
+            mixed_qkv=qkv_or_qkvz,
+            b=b_or_ba,
+            a=a_or_z_out,
+            core_attn_out=core_attn_out,
+        )
 
 
 def gdn_attention_core_fake(

--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -75,7 +75,7 @@ if GDN_AITER_TRITON_AVAILABLE:
     from aiter.ops.triton.causal_conv1d_update_single_token import (
         fused_reshape_causal_conv1d_update_single_token as gdn_aiter_fused_reshape_causal_conv1d_update_single_token,  # noqa: E501
     )
-    from aiter.ops.triton.gated_delta_net import (
+    from aiter.ops.triton.gated_delta_net.fused_rearrange_sigmoid_gdr import (
         fused_rearrange_sigmoid_gated_delta_rule as gdn_aiter_fused_rearrange_sigmoid_gated_delta_rule,  # noqa: E501
     )
 


### PR DESCRIPTION
Overview:
This change merges various triton compiled kernels into single kernels. For all backends, triton kernels are merged into one. For AITER, the triton kernels are further merged into optimized kernels for AMD.

Fusions remove 20-26us in launch overhead per layer (36 GDN layers and 12 attention layers per decode step) which corresponds to 5-8% improvements in TPOT and throughput depending on workload size and input/output size rations.

 Summary

  This PR integrates AITER's optimized Triton kernels into the GatedDeltaNetAttention decode path and restructures the forward pass to reduce overhead. When running on ROCm with AITER enabled, decode-only batches use fused Triton kernels for the
  convolution update, gating + delta rule update, and QKV rearrangement, replacing multiple individual PyTorch operations with fewer, more efficient kernel launches. The prefill and speculative-decode paths are factored out of the decode-only hot
  path to keep the CUDA-graphed decode region lean.


  Changes

  • Import and gate AITER Triton kernels at module level (gdn_linear_attn.py): Import causal_conv1d_update_single_token, fused_reshape_causal_conv1d_update_single_token, and fused_rearrange_sigmoid_gated_delta_rule from AITER behind a
    GDN_AITER_TRITON_AVAILABLE flag that checks rocm_aiter_ops.are_gdn_triton_kernels_available(). This avoids per-call import overhead and gracefully falls back on systems without these kernels.


  • Add _forward_core_decode_fast (gdn_linear_attn.py): A new decode fast-path method that uses the AITER Triton kernels for:
    • Fused reshape + causal conv1d single-token update (replacing separate reshape, conv1d, and state update operations)
    • Fused rearrange + sigmoid gating + delta rule state update (replacing separate sigmoid, gating, rearrangement, and recurrence operations)


  • Restructure forward (gdn_linear_attn.py): When AITER fast-path kernels are available, the forward method packs QKV and Z together, passes them through a prepare_gdn_attention_core_inputs compiled helper for prefill, and routes decode-only
    batches to the new _forward_core_decode_fast. The prefill and speculative-decode logic is factored out of the decode-only branch to minimize the CUDA-graphed region.


  • Pass core_attn_out into chunk kernels (chunk.py, chunk_o.py): Thread an optional core_attn_out tensor through the chunked GDN kernel pipeline so that prefill output can be written directly into the pre-allocated output buffer, eliminating a
    separate copy.


  • Add are_gdn_triton_kernels_available() (_aiter_ops.py): Centralized check for the optional AITER Triton kernels (conv1d single-token, gated delta net). Returns False on older AITER builds that lack these modules.


  AITER Dependency

  The AITER Triton kernels used in this PR are provided by ROCm/aiter#2423 (​https://github.com/ROCm/aiter/pull/2423​) ("[Triton] optimized decode kernels for Qwen3-Next model"). The fast-path is gated behind
  rocm_aiter_ops.are_gdn_triton_kernels_available(), so it is a no-op on AITER versions that do not include this PR — the existing decode path is used as-is.


  Benchmark Results

  Setup:
  • Model: Qwen/Qwen3-Next-80B-A3B-Instruct-FP8, TP=1
  • GPU: AMD MI355x (gfx950), single GPU
  • Base image: vllm/vllm-openai-rocm:nightly (vLLM v0.19.2rc1) with AITER rebuilt from aiter:main + ROCm/aiter#2423 (​https://github.com/ROCm/aiter/pull/2423​)
  • Attention backend: ROCM_AITER_FA
  • Compilation: cudagraph_mode=FULL_AND_PIECEWISE, custom_ops=["-rms_norm", "-silu_and_mul", "+quant_fp8"], pass_config={"fuse_norm_quant": true}
  • Benchmark: vllm bench serve --dataset_name random --random_input_len 1024 --random_output_len 1024 --max_concurrency 4 --num_prompts 32 --num_warmups 4 --seed 1 --temperature 0 --ignore_eos
  • Accuracy: lm_eval --model local-completions --tasks gsm8k --num_fewshot 5 against the running server
  • Baseline: same image and configuration without this PR applied

  Throughput (ISL=1024, OSL=1024, concurrency=4):

  ┌─────────────────────────────────┬──────────┬─────────┬───────┐
  │ Metric                          │ Baseline │ With PR │ Delta │
  ├─────────────────────────────────┼──────────┼─────────┼───────┤
  │ Output token throughput (tok/s) │ 456.52   │ 482.55  │ +5.7% │
  │ Total token throughput (tok/s)  │ 913.04   │ 965.09  │ +5.7% │
  │ Mean TPOT (ms)                  │ 8.66     │ 8.15    │ −5.9% │
  │ P99 TPOT (ms)                   │ 8.98     │ 8.28    │ −7.8% │
  │ Mean E2EL (ms)                  │ 8,971    │ 8,488   │ −5.4% │
  └─────────────────────────────────┴──────────┴─────────┴───────┘

  Accuracy (lm_eval, gsm8k, 5-shot):

  ┌──────────────────┬────────────────┬────────────────┬─────────────────────────────┐
  │ Filter           │ Baseline       │ With PR        │ Delta                       │
  ├──────────────────┼────────────────┼────────────────┼─────────────────────────────┤
  │ flexible-extract │ 0.8506 ±0.0098 │ 0.8605 ±0.0095 │ +0.0099 (within error bars) │
  │ strict-match     │ 0.8097 ±0.0108 │ 0.8203 ±0.0106 │ +0.0106 (within error bars) │
  └──────────────────┴────────────────┴────────────────┴─────────────────────────────┘

  Accuracy is statistically identical — all deltas are within the standard error bounds.


  Test plan

  • [x] vllm bench serve — 5.7% output throughput improvement, 5.9% TPOT reduction
  • [x] lm_eval --tasks gsm8k --num_fewshot 5 — accuracy unchanged vs. baseline (within stderr)
  • [x] Server starts and serves requests correctly with ROCM_AITER_FA attention backend
  • [x] Verified graceful fallback when AITER lacks GDN kernels (GDN_AITER_TRITON_AVAILABLE == False)
  • [x] torch.profiler trace generated and inspected for correct kernel dispatch