### PR TITLE
[fix] mismatch dim during capture graph if with --gpu-memory-utilization

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -7024,6 +7024,7 @@ class GPUModelRunner(
                 logitsprocs_need_output_token_ids=self.input_batch.logitsprocs_need_output_token_ids,
                 is_pooling_model=self.is_pooling_model,
                 reasoning_config=self.vllm_config.reasoning_config,
+                cp_kv_cache_interleave_size=self.parallel_config.cp_kv_cache_interleave_size,
             )
 
         assert self._init_block_sizes == block_sizes, (

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -658,19 +658,24 @@ class GPUModelRunner(
         placeholder_block_size = (
             self.cache_config.block_size or CacheConfig.DEFAULT_BLOCK_SIZE
         )
+        placeholder_max_num_blocks = None
+        placeholder_max_model_len = max(self.max_model_len, self.max_encoder_len)
         self._init_block_sizes = [placeholder_block_size]
         self._init_kernel_block_sizes = [placeholder_block_size]
+        self._init_max_num_blocks: list[int] | None = placeholder_max_num_blocks
+        self._init_max_model_len = placeholder_max_model_len
         self.input_batch = InputBatch(
             max_num_reqs=self.max_num_reqs,
             # We need to use the encoder length for encoder-decoder
             # because of KV cache for cross-attention.
-            max_model_len=max(self.max_model_len, self.max_encoder_len),
+            max_model_len=placeholder_max_model_len,
             max_num_batched_tokens=self.max_num_tokens,
             device=self.device,
             vocab_size=self.model_config.get_vocab_size(),
             block_sizes=[placeholder_block_size],
             kernel_block_sizes=[placeholder_block_size],
             num_spec_tokens=self.num_spec_tokens,
+            max_num_blocks_per_req=placeholder_max_num_blocks,
             logitsprocs=build_logitsprocs(
                 self.vllm_config,
                 self.device,
@@ -6998,9 +7003,13 @@ class GPUModelRunner(
         if (
             block_sizes != self._init_block_sizes
             or kernel_block_sizes != self._init_kernel_block_sizes
+            or max_num_blocks != self._init_max_num_blocks
+            or max_model_len != self._init_max_model_len
         ):
             self._init_block_sizes = block_sizes
             self._init_kernel_block_sizes = kernel_block_sizes
+            self._init_max_num_blocks = max_num_blocks
+            self._init_max_model_len = max_model_len
             self.input_batch = InputBatch(
                 max_num_reqs=self.max_num_reqs,
                 max_model_len=max_model_len,


### PR DESCRIPTION



## Purpose

Fix #40716.

## Test Plan

Test model `nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4` on 4x RTX 3090 with pr #38985 based on version `0.19.2rc1.dev134+gfe9c3d6c5`.

Although untested, this might also work for #39202.

## Test Result

Start the `vllm serve` successful, and crash with error `RuntimeError: The size of tensor a (58) must match the size of tensor b (63) at non-singleton dimension 1` if w/o this pr.

The test command:
```bash
VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=1 VLLM_MARLIN_USE_ATOMIC_ADD=1 VLLM_FLOAT32_MATMUL_PRECISION=high PYTORCH_ALLOC_CONF=expandable_segments:True CUDA_DEVICE_ORDER=PCI_BUS_ID vllm serve /models/nv-community/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 --served-model-name Nemotron-3-Super --tensor-parallel-size 4 --enable-expert-parallel --trust-remote-code --enable-auto-tool-choice --tool-call-parser qwen3_coder --reasoning-parser nemotron_v3 --gpu-memory-utilization 0.95 --max-model-len auto --async-scheduling --enable-prefix-caching --enable-chunked-prefill --max-num-seqs 4
```

Results:
```
$ docker compose exec lm-eval.ampere lm_eval --model local-completions  --model_args base_url=http://127.0.0.1:8000/v1/completions,model=Nemotron-3-Super,tokenizer=/models/nv-community/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4 --trust_remote_code --tasks lambada_openai --batch_size auto

local-completions ({'base_url': 'http://127.0.0.1:8000/v1/completions', 'model': 'Nemotron-3-Super', 'tokenizer': '/models/nv-community/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4'}), gen_kwargs: ({}), limit: None, num_fewshot: None, batch_size: auto
|    Tasks     |Version|Filter|n-shot|  Metric  |   |Value |   |Stderr|
|--------------|------:|------|-----:|----------|---|-----:|---|-----:|
|lambada_openai|      1|none  |     0|acc       |↑  |0.7603|±  |0.0059|
|              |       |none  |     0|perplexity|↓  |3.0028|±  |0.0604|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

