### PR TITLE
[torch.compile] Add hierarchical module trace dump for FX graphs

### DIFF
--- a/tests/compile/test_graph_trace_dump.py
+++ b/tests/compile/test_graph_trace_dump.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Tests for the hierarchical graph trace dump feature.
+See https://github.com/vllm-project/vllm/issues/39215
+"""
+
+import tempfile
+from collections import OrderedDict
+from pathlib import Path
+
+import torch
+
+from vllm.compilation.graph_trace_dump import (
+    dump_graph_hierarchy,
+    dump_graph_hierarchy_to_file,
+    trace_graph_structured,
+)
+
+
+def test_dump_graph_hierarchy_basic():
+    """Test basic hierarchical output with manually constructed graph."""
+    graph = torch.fx.Graph()
+
+    x = graph.placeholder("x")
+
+    # Node in outer module
+    add_node = graph.call_function(torch.add, (x, x))
+    add_node.meta["nn_module_stack"] = OrderedDict(
+        [
+            ("mod", ("", type("OuterModel", (), {}))),
+        ]
+    )
+
+    # Node in nested module
+    mul_node = graph.call_function(torch.mul, (add_node, add_node))
+    mul_node.meta["nn_module_stack"] = OrderedDict(
+        [
+            ("mod", ("", type("OuterModel", (), {}))),
+            ("mod.inner", ("inner", type("InnerModule", (), {}))),
+        ]
+    )
+
+    # Another node in outer module (after leaving inner)
+    neg_node = graph.call_function(torch.neg, (mul_node,))
+    neg_node.meta["nn_module_stack"] = OrderedDict(
+        [
+            ("mod", ("", type("OuterModel", (), {}))),
+        ]
+    )
+
+    graph.output(neg_node)
+
+    gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+    output = dump_graph_hierarchy(gm)
+
+    lines = output.strip().split("\n")
+    assert len(lines) >= 3, f"Expected at least 3 lines, got {len(lines)}: {output}"
+
+    # Check module headers appear
+    assert any("OuterModel" in line for line in lines), (
+        f"Expected OuterModel header in output:\n{output}"
+    )
+    assert any("InnerModule" in line for line in lines), (
+        f"Expected InnerModule header in output:\n{output}"
+    )
+
+    # Inner operations should be more indented than outer operations
+    outer_op_lines = [
+        line for line in lines if "torch.add" in line or "torch.neg" in line
+    ]
+    inner_op_lines = [line for line in lines if "torch.mul" in line]
+
+    assert len(outer_op_lines) >= 2, (
+        f"Expected >= 2 outer op lines, got: {outer_op_lines}"
+    )
+    assert len(inner_op_lines) >= 1, (
+        f"Expected >= 1 inner op lines, got: {inner_op_lines}"
+    )
+
+    for inner in inner_op_lines:
+        for outer in outer_op_lines:
+            inner_indent = len(inner) - len(inner.lstrip())
+            outer_indent = len(outer) - len(outer.lstrip())
+            assert inner_indent > outer_indent, (
+                f"Inner line should be more indented than outer.\n"
+                f"Inner ({inner_indent}): {inner!r}\n"
+                f"Outer ({outer_indent}): {outer!r}"
+            )
+
+
+def test_dump_graph_hierarchy_deep_nesting():
+    """Test with 3 levels of nesting."""
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+
+    OuterCls = type("OuterModel", (), {})
+    MiddleCls = type("MiddleLayer", (), {})
+    InnerCls = type("InnerLinear", (), {})
+
+    # Depth 3 node
+    deep_node = graph.call_function(torch.add, (x, x))
+    deep_node.meta["nn_module_stack"] = OrderedDict(
+        [
+            ("mod", ("", OuterCls)),
+            ("mod.layer", ("layer", MiddleCls)),
+            ("mod.layer.linear", ("layer.linear", InnerCls)),
+        ]
+    )
+
+    graph.output(deep_node)
+
+    gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+    output = dump_graph_hierarchy(gm)
+
+    lines = output.strip().split("\n")
+    # Should have 3 module headers + 1 op = 4 lines
+    assert len(lines) >= 4, f"Expected >= 4 lines, got {len(lines)}:\n{output}"
+
+    # The operation should be at depth 3 (6 spaces with indent_size=2)
+    op_line = [line for line in lines if "torch.add" in line]
+    assert len(op_line) == 1
+    indent = len(op_line[0]) - len(op_line[0].lstrip())
+    assert indent == 6, f"Expected indent of 6, got {indent}"
+
+
+def test_dump_graph_hierarchy_no_module_stack():
+    """Test nodes without nn_module_stack metadata."""
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+
+    # Node without nn_module_stack
+    add_node = graph.call_function(torch.add, (x, x))
+    # No meta set
+
+    graph.output(add_node)
+
+    gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+    output = dump_graph_hierarchy(gm)
+
+    # Should still produce output (at top level, no indent)
+    lines = output.strip().split("\n")
+    assert len(lines) >= 1
+    assert "torch.add" in lines[0]
+    # No indentation for top-level nodes
+    assert not lines[0].startswith(" ")
+
+
+def test_dump_graph_hierarchy_indexed_layers():
+    """Test that numeric fqn components produce [N] style display."""
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+
+    LayerCls = type("DecoderLayer", (), {})
+
+    node = graph.call_function(torch.add, (x, x))
+    node.meta["nn_module_stack"] = OrderedDict(
+        [
+            ("mod.layers.0", ("layers.0", LayerCls)),
+        ]
+    )
+
+    graph.output(node)
+
+    gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+    output = dump_graph_hierarchy(gm)
+
+    assert "layers[0]: DecoderLayer" in output, (
+        f"Expected 'layers[0]: DecoderLayer' in output:\n{output}"
+    )
+
+
+def test_dump_graph_hierarchy_layer_transition():
+    """Test transitioning between layers (e.g., layer 0 to layer 1)."""
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+
+    LayerCls = type("DecoderLayer", (), {})
+
+    node0 = graph.call_function(torch.add, (x, x))
+    node0.meta["nn_module_stack"] = OrderedDict(
+        [
+            ("mod.layers.0", ("layers.0", LayerCls)),
+        ]
+    )
+
+    node1 = graph.call_function(torch.mul, (node0, node0))
+    node1.meta["nn_module_stack"] = OrderedDict(
+        [
+            ("mod.layers.1", ("layers.1", LayerCls)),
+        ]
+    )
+
+    graph.output(node1)
+
+    gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+    output = dump_graph_hierarchy(gm)
+
+    assert "layers[0]: DecoderLayer" in output
+    assert "layers[1]: DecoderLayer" in output
+
+
+def test_dump_graph_hierarchy_to_file():
+    """Test file output."""
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+
+    node = graph.call_function(torch.add, (x, x))
+    node.meta["nn_module_stack"] = OrderedDict(
+        [
+            ("mod", ("", type("Model", (), {}))),
+        ]
+    )
+
+    graph.output(node)
+
+    gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".txt", delete=False) as f:
+        tmppath = f.name
+
+    dump_graph_hierarchy_to_file(gm, tmppath)
+
+    content = Path(tmppath).read_text()
+    assert len(content) > 0
+    assert "Model" in content
+    assert "torch.add" in content
+    Path(tmppath).unlink()
+
+
+def test_dump_graph_hierarchy_op_overload():
+    """Test formatting of torch._ops.OpOverload targets."""
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+
+    node = graph.call_function(torch.ops.aten.add.Tensor, (x, x))
+    node.meta["nn_module_stack"] = OrderedDict(
+        [
+            ("mod", ("", type("Model", (), {}))),
+        ]
+    )
+
+    graph.output(node)
+
+    gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+    output = dump_graph_hierarchy(gm)
+
+    assert "aten.add.Tensor" in output, (
+        f"Expected 'aten.add.Tensor' in output:\n{output}"
+    )
+
+
+def test_trace_graph_structured():
+    """Test that trace_graph_structured emits both raw and hierarchy dumps."""
+    from unittest.mock import patch
+
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+
+    node = graph.call_function(torch.add, (x, x))
+    node.meta["nn_module_stack"] = OrderedDict(
+        [
+            ("mod", ("", type("Model", (), {}))),
+        ]
+    )
+
+    graph.output(node)
+
+    gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+
+    with patch("vllm.compilation.graph_trace_dump.trace_structured") as mock_ts:
+        trace_graph_structured("test_graph", gm)
+
+        # Should be called exactly twice: once for raw dump, once for hierarchy
+        assert mock_ts.call_count == 2, (
+            f"Expected 2 trace_structured calls, got {mock_ts.call_count}"
+        )
+
+        # Verify the metadata names
+        first_call = mock_ts.call_args_list[0]
+        second_call = mock_ts.call_args_list[1]
+
+        assert first_call[0][0] == "graph_dump"
+        assert first_call[1]["metadata_fn"]() == {"name": "test_graph"}
+
+        assert second_call[0][0] == "graph_dump"
+        assert second_call[1]["metadata_fn"]() == {
+            "name": "test_graph_module_trace"
+        }
+
+        # Verify the hierarchy payload contains expected content
+        hierarchy_payload = second_call[1]["payload_fn"]()
+        assert "Model" in hierarchy_payload
+        assert "torch.add" in hierarchy_payload
+
+
+def test_dump_graph_hierarchy_source_context():
+    """Test that stack_trace metadata produces '# via func_name' annotations."""
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+
+    # Node with stack_trace pointing to a free function
+    add_node = graph.call_function(torch.add, (x, x))
+    add_node.meta["nn_module_stack"] = OrderedDict(
+        [
+            ("mod", ("", type("Model", (), {}))),
+        ]
+    )
+    add_node.meta["stack_trace"] = (
+        '  File "/home/user/project/model.py", line 10, in forward\n'
+        '  File "/home/user/project/utils.py", line 5, in my_helper_fn\n'
+    )
+
+    # Node without stack_trace (should have no annotation)
+    mul_node = graph.call_function(torch.mul, (add_node, add_node))
+    mul_node.meta["nn_module_stack"] = OrderedDict(
+        [
+            ("mod", ("", type("Model", (), {}))),
+        ]
+    )
+
+    graph.output(mul_node)
+
+    gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+    output = dump_graph_hierarchy(gm)
+
+    # The add node should have the free function annotation
+    assert "# via my_helper_fn" in output, (
+        f"Expected '# via my_helper_fn' in output:\n{output}"
+    )
+    # The mul node should NOT have an annotation
+    mul_lines = [line for line in output.split("\n") if "torch.mul" in line]
+    assert len(mul_lines) == 1
+    assert "# via" not in mul_lines[0], (
+        f"Unexpected '# via' annotation on mul node: {mul_lines[0]}"
+    )
+
+
+def test_dump_graph_hierarchy_source_context_skips_torch_internals():
+    """Test that torch internal frames are filtered out from source context."""
+    graph = torch.fx.Graph()
+    x = graph.placeholder("x")
+
+    node = graph.call_function(torch.add, (x, x))
+    node.meta["nn_module_stack"] = OrderedDict(
+        [
+            ("mod", ("", type("Model", (), {}))),
+        ]
+    )
+    # Stack trace with only torch internals and forward
+    node.meta["stack_trace"] = (
+        '  File "/usr/lib/python3.12/torch/nn/modules/module.py",'
+        ' line 1500, in _call_impl\n'
+        '  File "/home/user/project/model.py", line 20, in forward\n'
+    )
+
+    graph.output(node)
+
+    gm = torch.fx.GraphModule(torch.nn.Module(), graph)
+    output = dump_graph_hierarchy(gm)
+
+    # No "# via" annotation because only forward and torch internals
+    assert "# via" not in output, (
+        f"Unexpected '# via' annotation in output:\n{output}"
+    )

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -1163,12 +1163,22 @@ class VllmBackend:
         lazy_format_graph_code("before split", self.graph)
         lazy_format_graph_code("after split", self.split_gm)
 
-        # Log the piecewise split graph for TORCH_TRACE/tlparse
-        trace_structured(
-            "graph_dump",
-            metadata_fn=lambda: {"name": "vllm_piecewise_split_graph"},
-            payload_fn=lambda: self.split_gm.print_readable(print_output=False),
+        # Dump graphs with both raw print_readable and hierarchical
+        # module trace via the standard utility.
+        from vllm.compilation.graph_trace_dump import (
+            dump_graph_hierarchy_to_file,
+            trace_graph_structured,
         )
+
+        trace_graph_structured("vllm_graph_before_split", self.graph)
+        trace_graph_structured("vllm_piecewise_split_graph", self.split_gm)
+
+        debug_dump_path = self.vllm_config.compile_debug_dump_path()
+        if debug_dump_path is not None:
+            debug_dump_path.mkdir(parents=True, exist_ok=True)
+            filename = f"{self.prefix}_module_trace.txt"
+            trace_path = str(debug_dump_path / filename)
+            dump_graph_hierarchy_to_file(self.graph, trace_path)
 
         compilation_counter.num_piecewise_graphs_seen += len(self.piecewise_graphs)
         submod_names_to_compile = [

--- a/vllm/compilation/graph_trace_dump.py
+++ b/vllm/compilation/graph_trace_dump.py
@@ -1,0 +1,328 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Hierarchical graph trace dump for FX graphs.
+
+Reconstructs the module call hierarchy from nn_module_stack metadata
+on FX graph nodes, producing an indented, human-readable representation
+of the model's forward pass that shows both the module nesting and the
+individual operations/kernels within each module.
+
+Usage:
+    from vllm.compilation.graph_trace_dump import dump_graph_hierarchy
+    print(dump_graph_hierarchy(graph_module))
+
+See https://github.com/vllm-project/vllm/issues/39215
+"""
+
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+
+import torch
+import torch.fx as fx
+from torch._logging._internal import trace_structured
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+# Node ops that don't produce meaningful output lines
+_SKIP_OPS = {"placeholder", "output"}
+
+
+def _get_module_stack(
+    node: fx.Node,
+) -> list[tuple[str, str]]:
+    """
+    Extract the module call stack from a node's nn_module_stack metadata.
+
+    Returns a list of (fully_qualified_name, class_name) tuples,
+    ordered from outermost to innermost module scope.
+
+    nn_module_stack is an OrderedDict mapping scope keys to
+    (fqn: str, module_class: type) pairs. We convert the class to its
+    simple name for display.
+    """
+    nn_module_stack: OrderedDict[str, tuple[str, type]] | None = node.meta.get(
+        "nn_module_stack"
+    )
+    if not nn_module_stack:
+        return []
+
+    result = []
+    for _key, (fqn, module_cls) in nn_module_stack.items():
+        if isinstance(module_cls, type):
+            cls_name = module_cls.__name__
+        else:
+            # Sometimes it's already a string
+            cls_name = str(module_cls).rsplit(".", 1)[-1]
+        result.append((fqn, cls_name))
+    return result
+
+
+def _format_node(node: fx.Node) -> str:
+    """
+    Format a single FX node as a human-readable operation string.
+
+    For call_function nodes: target_name(arg0, arg1, ...)
+    For get_attr nodes: attr_name
+    For other nodes: the node's string representation
+    """
+    if node.op == "call_function":
+        target = node.target
+        if isinstance(target, torch._ops.OpOverload):
+            target_str = str(target)
+        elif hasattr(target, "__module__") and hasattr(target, "__qualname__"):
+            module = target.__module__ or ""
+            qualname = target.__qualname__
+            if module == "_operator" or module == "operator":
+                target_str = qualname
+            elif module == "torch" or module.startswith("torch."):
+                # Simplify internal class dispatch like
+                # torch._VariableFunctionsClass.add -> torch.add
+                simple_name = qualname.rsplit(".", 1)[-1]
+                target_str = f"torch.{simple_name}"
+            else:
+                target_str = f"{module}.{qualname}" if module else qualname
+        else:
+            target_str = str(target)
+
+        args_parts = []
+        for arg in node.args:
+            if isinstance(arg, fx.Node):
+                args_parts.append(arg.name)
+            elif isinstance(arg, (list, tuple)):
+                inner = ", ".join(
+                    a.name if isinstance(a, fx.Node) else repr(a) for a in arg
+                )
+                bracket = "[" if isinstance(arg, list) else "("
+                close = "]" if isinstance(arg, list) else ")"
+                args_parts.append(f"{bracket}{inner}{close}")
+            else:
+                args_parts.append(repr(arg))
+        for k, v in node.kwargs.items():
+            if isinstance(v, fx.Node):
+                args_parts.append(f"{k}={v.name}")
+            else:
+                args_parts.append(f"{k}={repr(v)}")
+
+        args_str = ", ".join(args_parts)
+        # Truncate very long argument strings
+        if len(args_str) > 120:
+            args_str = args_str[:117] + "..."
+
+        if node.name and not node.name.startswith("_"):
+            return f"{node.name} = {target_str}({args_str})"
+        else:
+            return f"{target_str}({args_str})"
+
+    elif node.op == "get_attr":
+        return f"{node.name} = self.{node.target}"
+
+    return str(node)
+
+
+def _module_display_name(fqn: str, cls_name: str) -> str:
+    """
+    Create a display name for a module scope entry.
+
+    Format: ``instance_name: ClassName`` so that multiple instances of the
+    same class are easy to distinguish at a glance.
+
+    Examples:
+        ("model.layers.0", "DecoderLayer") -> "layers[0]: DecoderLayer"
+        ("model.embed_tokens", "Embedding") -> "embed_tokens: Embedding"
+        ("layer.linear", "InnerLinear")     -> "linear: InnerLinear"
+        ("", "DeepseekV2Model")             -> "DeepseekV2Model"
+    """
+    if not fqn:
+        return cls_name
+
+    # Extract the last component of the fqn for the instance name
+    parts = fqn.rsplit(".", 1)
+    short_name = parts[-1] if len(parts) > 1 else fqn
+
+    # If the short name is a number, it's an indexed layer (e.g., layers.0)
+    # Display as "layers[0]: DecoderLayer".
+    # Edge case: if fqn is just "0" (no parent), rsplit produces ["0"]
+    # and we fall through to the default "0: ClassName" format.
+    if short_name.isdigit():
+        parent_parts = fqn.rsplit(".", 2)
+        if len(parent_parts) >= 2:
+            parent_name = parent_parts[-2]
+            return f"{parent_name}[{short_name}]: {cls_name}"
+
+    return f"{short_name}: {cls_name}"
+
+
+# Regex to parse Python traceback frames:
+#   File "/path/to/file.py", line 42, in function_name
+_TRACEBACK_FRAME_RE = re.compile(
+    r'File "([^"]+)", line (\d+), in (.+)'
+)
+
+# Function names from torch internals / nn.Module plumbing to skip
+_SKIP_FUNCTION_NAMES = frozenset({
+    "forward",
+    "_call_impl",
+    "_wrapped_call_impl",
+    "__call__",
+    "_call_with_frames_allowed",
+    "<module>",
+    "<lambda>",
+})
+
+
+def _get_source_context(node: fx.Node) -> str | None:
+    """
+    Extract non-module source context from a node's stack_trace metadata.
+
+    Parses the Python traceback recorded by torch.compile/Inductor to find
+    free functions and non-module class methods that are NOT already
+    represented in nn_module_stack.  Returns a short annotation string
+    like ``"my_free_fn"`` or ``None`` if no extra context is available.
+
+    This addresses reviewer Request #2: showing free functions and
+    non-module classes in the hierarchy dump.
+    """
+    stack_trace: str | None = node.meta.get("stack_trace")
+    if not stack_trace:
+        return None
+
+    # Parse traceback frames
+    frames = _TRACEBACK_FRAME_RE.findall(stack_trace)
+    if not frames:
+        return None
+
+    # Walk frames from innermost to outermost, find the first
+    # "interesting" user-defined function
+    for filepath, _lineno, func_name in reversed(frames):
+        if func_name in _SKIP_FUNCTION_NAMES:
+            continue
+        # Skip torch/dynamo internals
+        if "/torch/" in filepath or "/torch_" in filepath:
+            continue
+        # Skip vllm compilation internals
+        if "/vllm/compilation/" in filepath:
+            continue
+        # Found a user-defined free function or non-module method
+        return func_name
+
+    return None
+
+
+def dump_graph_hierarchy(
+    graph_module: fx.GraphModule,
+    *,
+    indent_size: int = 2,
+) -> str:
+    """
+    Produce a hierarchical, indented dump of the FX graph that shows
+    the module call structure alongside the individual operations.
+
+    Args:
+        graph_module: The FX GraphModule to dump.
+        indent_size: Number of spaces per indentation level.
+
+    Returns:
+        A multi-line string with the hierarchical trace.
+    """
+    lines: list[str] = []
+    # Track the current module stack to detect transitions
+    current_stack: list[tuple[str, str]] = []
+
+    for node in graph_module.graph.nodes:
+        if node.op in _SKIP_OPS:
+            continue
+
+        node_stack = _get_module_stack(node)
+
+        # Find the divergence point between current and new stack
+        common_depth = 0
+        for i, (cur, new) in enumerate(zip(current_stack, node_stack)):
+            if cur == new:
+                common_depth = i + 1
+            else:
+                break
+
+        # Emit new module scope headers for any new levels
+        for i in range(common_depth, len(node_stack)):
+            fqn, cls_name = node_stack[i]
+            indent = " " * (i * indent_size)
+            display = _module_display_name(fqn, cls_name)
+            lines.append(f"{indent}{display}")
+
+        current_stack = node_stack
+
+        # Emit the operation itself at the deepest module level + 1
+        op_depth = len(node_stack)
+        indent = " " * (op_depth * indent_size)
+        op_str = _format_node(node)
+
+        # Annotate with free function / non-module class context
+        source_ctx = _get_source_context(node)
+        if source_ctx:
+            op_str += f"  # via {source_ctx}"
+
+        lines.append(f"{indent}{op_str}")
+
+    return "\n".join(lines)
+
+
+def dump_graph_hierarchy_to_file(
+    graph_module: fx.GraphModule,
+    file_path: str,
+    *,
+    indent_size: int = 2,
+) -> None:
+    """
+    Dump the hierarchical graph trace to a file.
+
+    Args:
+        graph_module: The FX GraphModule to dump.
+        file_path: Path to write the dump to.
+        indent_size: Number of spaces per indentation level.
+    """
+    content = dump_graph_hierarchy(graph_module, indent_size=indent_size)
+    with open(file_path, "w", encoding="utf-8") as f:
+        f.write(content)
+    logger.debug("Hierarchical graph trace dumped to %s", file_path)
+
+
+def trace_graph_structured(
+    name: str,
+    graph_module: fx.GraphModule,
+) -> None:
+    """
+    Emit a structured trace for an FX graph, including both the raw
+    ``print_readable`` output and the hierarchical module trace.
+
+    This is the **standard utility** that every graph dump site should use
+    so that every dumped graph is also printed in structured (hierarchical)
+    form.  It emits two ``trace_structured`` events:
+
+    1. ``graph_dump`` with the raw ``print_readable`` output (name=*name*).
+    2. ``graph_dump`` with the hierarchical module trace
+       (name=*name* ``_module_trace``).
+
+    Args:
+        name: A short identifier for the graph (e.g.
+            ``"vllm_graph_before_split"``).  It is used as the ``"name"``
+            field in the ``trace_structured`` metadata.
+        graph_module: The FX ``GraphModule`` to dump.
+    """
+    # 1. Raw graph dump (same as the original print_readable output)
+    trace_structured(
+        "graph_dump",
+        metadata_fn=lambda: {"name": name},
+        payload_fn=lambda: graph_module.print_readable(print_output=False),
+    )
+
+    # 2. Hierarchical module trace
+    trace_structured(
+        "graph_dump",
+        metadata_fn=lambda: {"name": f"{name}_module_trace"},
+        payload_fn=lambda: dump_graph_hierarchy(graph_module),
+    )

--- a/vllm/compilation/piecewise_backend.py
+++ b/vllm/compilation/piecewise_backend.py
@@ -308,13 +308,11 @@ class PiecewiseBackend:
         if not self._graph_logged:
             self._graph_logged = True
             assert self.graph is not None
-            trace_structured(
-                "graph_dump",
-                metadata_fn=lambda: {
-                    "name": f"vllm_{submod_name}",
-                },
-                payload_fn=lambda: self.graph.print_readable(print_output=False),
+            from vllm.compilation.graph_trace_dump import (
+                trace_graph_structured,
             )
+
+            trace_graph_structured(f"vllm_{submod_name}", self.graph)
 
     def load_all_ranges(self) -> None:
         """Load all pre-compiled runnables for this piecewise subgraph.


### PR DESCRIPTION
## Purpose

Closes #39215.

As discussed in #sig-model-perf by @WoosukKwon and @ProExpertProg, it can be difficult to dig through the many layers used in model code when looking for fusion opportunities. The FX graphs produced by `torch.compile` are fully linearized, and normally only display the last level of the stack trace (e.g., `QuantFP8.forward_cuda` does not tell us where that instance lives in the model).

This PR adds a hierarchical graph trace dump that reconstructs the module call hierarchy from `nn_module_stack` metadata on FX graph nodes, producing an indented, human-readable representation of a model's forward pass.

**Example output** (for a nested model with norm + MLP layers):

```
pre_norm: InnerNorm
  norm: LayerNorm
    x = torch.layer_norm(l_x_, (64), weight, ...)
mlp: InnerMLP
  fc1: Linear
    x_1 = torch.linear(x, weight, None)
  x_2 = torch.silu(x_1)
  fc2: Linear
    x_3 = torch.linear(x_2, weight, None)
x_4 = add(x_3, l_x_)
post_norm: InnerNorm
  norm: LayerNorm
    x_5 = torch.layer_norm(x_4, (64), weight, ...)
```

## Design

Each FX node carries `node.meta['nn_module_stack']`, an `OrderedDict` mapping scope keys to `(fully_qualified_name, module_class)` tuples — ordered from outermost to innermost module. This metadata is populated by Dynamo during tracing but never consumed by vLLM today (it is even stripped during cache serialization in `caching.py`).

The algorithm walks all graph nodes in order, extracts each node's module stack, compares it against the previous node's stack to find the divergence point, emits new module scope headers only where the stack changes, and prints the operation itself at one indent level deeper than its deepest module scope. This produces the hierarchical view without any model-specific logic.

### Key features

- **`instance_name: ClassName` format** — e.g. `fc1: Linear`, `layers[0]: DecoderLayer` — so multiple instances of the same class are easy to distinguish
- **Free function / non-module class annotations** — when `stack_trace` metadata reveals a call through a free function or non-module method, the operation is annotated with `# via func_name`
- **`trace_graph_structured()` utility** — a single entry point that emits both the raw `print_readable` dump and the hierarchical module trace via `trace_structured`, integrated at every graph dump site (`VllmBackend.__call__` and `PiecewiseBackend`)

## Changes

- **New file `vllm/compilation/graph_trace_dump.py`**: core dump logic that walks FX graph nodes and reconstructs module nesting from `nn_module_stack`, plus the `trace_graph_structured()` utility
- **`vllm/compilation/backends.py`**: replaced raw `trace_structured` + `print_readable` calls with `trace_graph_structured()`, and writes `module_trace.txt` when debug dumping is enabled
- **`vllm/compilation/piecewise_backend.py`**: replaced raw `trace_structured` + `print_readable` calls with `trace_graph_structured()`
- **New test file `tests/compile/test_graph_trace_dump.py`**: 10 unit tests covering hierarchy, deep nesting, indexed layers, layer transitions, file output, OpOverload formatting, `trace_graph_structured` integration, source context annotations, and torch-internal filtering

## Test Plan

```bash
python -m pytest tests/compile/test_graph_trace_dump.py -xvs --noconftest
```

## Test Result

```
tests/compile/test_graph_trace_dump.py::test_dump_graph_hierarchy_basic PASSED
tests/compile/test_graph_trace_dump.py::test_dump_graph_hierarchy_deep_nesting PASSED
tests/compile/test_graph_trace_dump.py::test_dump_graph_hierarchy_no_module_stack PASSED
tests/compile/test_graph_trace_dump.py::test_dump_graph_hierarchy_indexed_layers PASSED
tests/compile/test_graph_trace_dump.py::test_dump_graph_hierarchy_layer_transition PASSED
tests/compile/test_graph_trace_dump.py::test_dump_graph_hierarchy_to_file PASSED
tests/compile/test_graph_trace_dump.py::test_dump_graph_hierarchy_op_overload PASSED
tests/compile/test_graph_trace_dump.py::test_trace_graph_structured PASSED
tests/compile/test_graph_trace_dump.py::test_dump_graph_hierarchy_source_context PASSED
tests/compile/test_graph_trace_dump.py::test_dump_graph_hierarchy_source_context_skips_torch_internals PASSED

========================= 10 passed in 2.25s ==================
```

Also verified E2E with a real Dynamo-traced nested model (LayerNorm + Linear + SiLU) on RTX 5050 — produces correct hierarchical output matching the format from the issue.

---

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [ ] (Optional) The necessary documentation update.