### PR TITLE
[Kernel][vllm IR] Add relu2 to vLLM IR

### DIFF
--- a/csrc/activation_kernels.cu
+++ b/csrc/activation_kernels.cu
@@ -566,6 +566,12 @@ __device__ __forceinline__ T gelu_quick_kernel(const T& x) {
   return (T)(((float)x) / (1.0f + expf(-1.702f * (float)x)));
 }
 
+template <typename T>
+__device__ __forceinline__ T relu2_kernel(const T& x) {
+  const float f = (float)x;
+  return f > 0.0f ? (T)(f * f) : (T)0.0f;
+}
+
 }  // namespace vllm
 
 void gelu_new(torch::Tensor& out,    // [..., d]
@@ -584,4 +590,10 @@ void gelu_quick(torch::Tensor& out,    // [..., d]
                 torch::Tensor& input)  // [..., d]
 {
   LAUNCH_ACTIVATION_KERNEL(vllm::gelu_quick_kernel);
+}
+
+void relu2(torch::Tensor& out,    // [..., d]
+           torch::Tensor& input)  // [..., d]
+{
+  LAUNCH_ACTIVATION_KERNEL(vllm::relu2_kernel);
 }

--- a/csrc/activation_kernels.cu
+++ b/csrc/activation_kernels.cu
@@ -569,7 +569,7 @@ __device__ __forceinline__ T gelu_quick_kernel(const T& x) {
 template <typename T>
 __device__ __forceinline__ T relu2_kernel(const T& x) {
   const float f = (float)x;
-  return f > 0.0f ? (T)(f * f) : (T)0.0f;
+  return f <= 0.0f ? (T)0.0f : (T)(f * f);
 }
 
 }  // namespace vllm

--- a/csrc/cpu/activation.cpp
+++ b/csrc/cpu/activation.cpp
@@ -82,6 +82,16 @@ FORCE_INLINE vec_op::FP32Vec8 gelu_tanh_act(const vec_op::FP32Vec8& x) {
   const vec_op::FP32Vec8 inner = w1 * (x + x_3 * w3);
   return x * w2 * (ones + inner.tanh());
 }
+
+template <typename scalar_t>
+void relu2_kernel(const int64_t numel, const scalar_t* in_ptr,
+                  scalar_t* out_ptr) {
+#pragma omp parallel for
+  for (int64_t i = 0; i < numel; ++i) {
+    const float x = static_cast<float>(in_ptr[i]);
+    out_ptr[i] = static_cast<scalar_t>(x > 0.0f ? x * x : 0.0f);
+  }
+}
 };  // namespace
 
 void silu_and_mul(torch::Tensor& out, torch::Tensor& input) {
@@ -159,5 +169,16 @@ void gelu_quick(torch::Tensor& out, torch::Tensor& input) {
     activation_kernel<scalar_t, gelu_quick_act, false>(
         num_tokens, d, input.data_ptr<scalar_t>(), out.data_ptr<scalar_t>());
     CPU_KERNEL_GUARD_OUT(gelu_quick_impl)
+  });
+}
+
+void relu2(torch::Tensor& out, torch::Tensor& input) {
+  const int64_t numel = input.numel();
+
+  VLLM_DISPATCH_FLOATING_TYPES(input.scalar_type(), "relu2_impl", [&] {
+    CPU_KERNEL_GUARD_IN(relu2_impl)
+    relu2_kernel<scalar_t>(numel, input.data_ptr<scalar_t>(),
+                           out.data_ptr<scalar_t>());
+    CPU_KERNEL_GUARD_OUT(relu2_impl)
   });
 }

--- a/csrc/cpu/activation.cpp
+++ b/csrc/cpu/activation.cpp
@@ -83,13 +83,39 @@ FORCE_INLINE vec_op::FP32Vec8 gelu_tanh_act(const vec_op::FP32Vec8& x) {
   return x * w2 * (ones + inner.tanh());
 }
 
+FORCE_INLINE float relu2_scalar(float x) { return x <= 0.0f ? 0.0f : x * x; }
+
+FORCE_INLINE vec_op::FP32Vec8 relu2_act(const vec_op::FP32Vec8& x) {
+  using VecReg = decltype(x.reg);
+  vec_op::AliasReg<VecReg, float, vec_op::FP32Vec8::VEC_ELEM_NUM> in{x.reg};
+  vec_op::AliasReg<VecReg, float, vec_op::FP32Vec8::VEC_ELEM_NUM> out{};
+
+  for (int i = 0; i < vec_op::FP32Vec8::VEC_ELEM_NUM; ++i) {
+    out.values[i] = relu2_scalar(in.values[i]);
+  }
+
+  return vec_op::FP32Vec8(out.reg);
+}
+
 template <typename scalar_t>
 void relu2_kernel(const int64_t numel, const scalar_t* in_ptr,
                   scalar_t* out_ptr) {
+  using scalar_vec_t = vec_op::vec_t<scalar_t>;
+  constexpr int VEC_ELEM_NUM = scalar_vec_t::get_elem_num();
+  const int64_t vec_numel = numel / VEC_ELEM_NUM * VEC_ELEM_NUM;
+
 #pragma omp parallel for
-  for (int64_t i = 0; i < numel; ++i) {
-    const float x = static_cast<float>(in_ptr[i]);
-    out_ptr[i] = static_cast<scalar_t>(x > 0.0f ? x * x : 0.0f);
+  for (int64_t i = 0; i < vec_numel; i += VEC_ELEM_NUM) {
+    const scalar_vec_t x(in_ptr + i);
+    const vec_op::FP32Vec8 f32_x(x);
+    const vec_op::FP32Vec8 f32_ans = relu2_act(f32_x);
+    const scalar_vec_t result(f32_ans);
+    result.save(out_ptr + i);
+  }
+
+  for (int64_t i = vec_numel; i < numel; ++i) {
+    out_ptr[i] = static_cast<scalar_t>(relu2_scalar(
+        static_cast<float>(in_ptr[i])));
   }
 }
 };  // namespace

--- a/csrc/cpu/torch_bindings.cpp
+++ b/csrc/cpu/torch_bindings.cpp
@@ -236,6 +236,10 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def("gelu_quick(Tensor! out, Tensor input) -> ()");
   ops.impl("gelu_quick", torch::kCPU, &gelu_quick);
 
+  // Squared ReLU implementation.
+  ops.def("relu2(Tensor! out, Tensor input) -> ()");
+  ops.impl("relu2", torch::kCPU, &relu2);
+
 #if (defined(__aarch64__) && !defined(__APPLE__))
 
   ops.def(

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -190,6 +190,8 @@ void gelu_fast(torch::Tensor& out, torch::Tensor& input);
 
 void gelu_quick(torch::Tensor& out, torch::Tensor& input);
 
+void relu2(torch::Tensor& out, torch::Tensor& input);
+
 void cutlass_mla_decode(torch::Tensor const& out, torch::Tensor const& q_nope,
                         torch::Tensor const& q_pe,
                         torch::Tensor const& kv_c_and_k_pe_cache,

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -155,6 +155,10 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
   ops.def("gelu_quick(Tensor! out, Tensor input) -> ()");
   ops.impl("gelu_quick", torch::kCUDA, &gelu_quick);
 
+  // Squared ReLU implementation.
+  ops.def("relu2(Tensor! out, Tensor input) -> ()");
+  ops.impl("relu2", torch::kCUDA, &relu2);
+
   // Layernorm
   // Apply Root Mean Square (RMS) Normalization to the input tensor.
   ops.def(

--- a/tests/kernels/ir/test_relu2.py
+++ b/tests/kernels/ir/test_relu2.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+
+# This registers op implementations
+import vllm.kernels  # noqa: F401
+from tests.ir.ir_test_utils import assert_close, clone_args, supported_providers
+from vllm import ir
+from vllm.platforms import current_platform
+
+RELU2_HIDDEN_SIZES = [16, 128, 1024]
+RELU2_NUM_TOKENS = [1, 17, 512]
+relu2_native = ir.ops.relu2.impls["native"].impl_fn
+
+
+def test_relu2_registration():
+    expected = {
+        "native": True,
+        "vllm_c": current_platform.is_cuda_alike(),
+        "xpu_kernels": False,
+    }
+
+    actual = {
+        provider: impl.supported for provider, impl in ir.ops.relu2.impls.items()
+    }
+
+    assert actual == expected
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+@pytest.mark.parametrize("n_tokens", RELU2_NUM_TOKENS)
+@pytest.mark.parametrize("hidden_size", RELU2_HIDDEN_SIZES)
+class TestRelu2:
+    @classmethod
+    def setup_class(cls, **kwargs):
+        torch.set_default_device(current_platform.device_type)
+
+    def test_native_semantics(self, dtype, n_tokens, hidden_size):
+        (x,) = ir.ops.relu2.generate_inputs(
+            num_tokens=n_tokens, hidden_size=hidden_size, dtype=dtype
+        )
+        out = relu2_native(x)
+
+        assert out.shape == x.shape
+        assert out.dtype == x.dtype
+        assert out.device == x.device
+        torch.testing.assert_close(
+            out, torch.square(torch.relu(x)), rtol=0.0, atol=0.0
+        )
+
+    @pytest.mark.parametrize("provider", supported_providers(ir.ops.relu2))
+    def test_impls(self, dtype, n_tokens, hidden_size, provider):
+        impl = ir.ops.relu2.impls[provider]
+        args = ir.ops.relu2.generate_inputs(
+            num_tokens=n_tokens, hidden_size=hidden_size, dtype=dtype
+        )
+
+        if not impl.supports_args(*args):
+            pytest.skip(f"{provider} does not support args")
+
+        ref_output = relu2_native(*clone_args(args))
+        output = impl.impl_fn(*clone_args(args))
+        assert_close(ir.ops.relu2, output, ref_output)
+
+        with ir.ops.relu2.set_priority([provider, "native"]):
+            out_dispatched = ir.ops.relu2(*args)
+        out_direct = impl.impl_fn(*args)
+        torch.testing.assert_close(out_dispatched, out_direct, rtol=0.0, atol=0.0)
+
+    @pytest.mark.parametrize("provider", ["vllm_c", "native"])
+    def test_torch_opcheck(self, dtype, n_tokens, hidden_size, provider):
+        if not ir.ops.relu2.impls[provider].supported:
+            pytest.skip(f"{provider} impl not supported on this platform")
+
+        args = ir.ops.relu2.generate_inputs(
+            num_tokens=n_tokens, hidden_size=hidden_size, dtype=dtype
+        )
+
+        with ir.ops.relu2.set_priority([provider, "native"]):
+            torch.library.opcheck(torch.ops.vllm_ir.relu2, args)

--- a/tests/kernels/ir/test_relu2.py
+++ b/tests/kernels/ir/test_relu2.py
@@ -11,13 +11,14 @@ from vllm.platforms import current_platform
 
 RELU2_HIDDEN_SIZES = [16, 128, 1024]
 RELU2_NUM_TOKENS = [1, 17, 512]
+VLLM_C_SUPPORTED = current_platform.is_cuda_alike() or current_platform.is_cpu()
 relu2_native = ir.ops.relu2.impls["native"].impl_fn
 
 
 def test_relu2_registration():
     expected = {
         "native": True,
-        "vllm_c": current_platform.is_cuda_alike(),
+        "vllm_c": VLLM_C_SUPPORTED,
         "xpu_kernels": False,
     }
 
@@ -67,6 +68,35 @@ class TestRelu2:
             out_dispatched = ir.ops.relu2(*args)
         out_direct = impl.impl_fn(*args)
         torch.testing.assert_close(out_dispatched, out_direct, rtol=0.0, atol=0.0)
+
+    @pytest.mark.parametrize("provider", ["vllm_c", "native"])
+    def test_preserves_nan(self, dtype, n_tokens, hidden_size, provider):
+        impl = ir.ops.relu2.impls[provider]
+        if not impl.supported:
+            pytest.skip(f"{provider} impl not supported on this platform")
+
+        x = torch.tensor(
+            [
+                float("nan"),
+                -2.0,
+                -0.0,
+                0.0,
+                1.5,
+                float("nan"),
+                3.0,
+                -4.0,
+                2.5,
+                -1.0,
+            ],
+            dtype=dtype,
+            device=current_platform.device_type,
+        ).reshape(2, 5)
+
+        expected = relu2_native(x.clone())
+        output = impl.impl_fn(x.clone())
+        torch.testing.assert_close(
+            output, expected, rtol=0.0, atol=0.0, equal_nan=True
+        )
 
     @pytest.mark.parametrize("provider", ["vllm_c", "native"])
     def test_torch_opcheck(self, dtype, n_tokens, hidden_size, provider):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1295,11 +1295,16 @@ def test_ir_op_priority_default():
     # Assert default is applied to ops
     priority_config = IrOpPriorityConfig.with_default(["vllm_c", "native"])
     assert priority_config.rms_norm == ["vllm_c", "native"]
+    assert priority_config.relu2 == ["vllm_c", "native"]
 
     # Assert single ops override the default
     assert IrOpPriorityConfig.with_default(
-        ["vllm_c", "native"], rms_norm=["oink", "native"]
-    ) == IrOpPriorityConfig(rms_norm=["oink", "native"])
+        ["vllm_c", "native"],
+        rms_norm=["oink", "native"],
+    ) == IrOpPriorityConfig(
+        rms_norm=["oink", "native"],
+        relu2=["vllm_c", "native"],
+    )
 
 
 def test_ir_op_priority_str():

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -31,6 +31,9 @@ class IrOpPriorityConfig:
     rms_norm: list[str] = Field(default_factory=list)
     """Priority list for vllm.ir.ops.rms_norm"""
 
+    relu2: list[str] = Field(default_factory=list)
+    """Priority list for vllm.ir.ops.relu2"""
+
     def compute_hash(self) -> str:
         """
         Produces a hash unique to the pass configuration.

--- a/vllm/ir/ops/__init__.py
+++ b/vllm/ir/ops/__init__.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from .activation import relu2
 from .layernorm import rms_norm
 
-__all__ = ["rms_norm"]
+__all__ = ["relu2", "rms_norm"]

--- a/vllm/ir/ops/activation.py
+++ b/vllm/ir/ops/activation.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from ..op import register_op
+
+
+@register_op
+def relu2(x: Tensor) -> Tensor:
+    """Squared ReLU activation."""
+    return torch.square(F.relu(x))
+
+
+@relu2.register_input_generator
+def _relu2_input_generator(
+    num_tokens: int, hidden_size: int, dtype: torch.dtype
+) -> tuple:
+    x = torch.randn(num_tokens, hidden_size, dtype=dtype)
+    return (x,)

--- a/vllm/kernels/vllm_c.py
+++ b/vllm/kernels/vllm_c.py
@@ -31,3 +31,10 @@ def rms_norm(
     output = torch.empty(x.shape, device=x.device, dtype=x.dtype)
     torch.ops._C.rms_norm(output, x, weight, epsilon)
     return output
+
+
+@ir.ops.relu2.register_impl("vllm_c", supported=CUDA_ALIKE)
+def relu2(x: Tensor) -> Tensor:
+    output = torch.empty_like(x)
+    torch.ops._C.relu2(output, x)
+    return output

--- a/vllm/kernels/vllm_c.py
+++ b/vllm/kernels/vllm_c.py
@@ -11,6 +11,9 @@ current_platform.import_kernels()
 CUDA_ALIKE = current_platform.is_cuda_alike()
 """Most kernels in this file are supported on all CUDA-alike platforms."""
 
+RELU2_VLLM_C_SUPPORTED = CUDA_ALIKE or current_platform.is_cpu()
+"""relu2 is available in the _C extension on CUDA-like platforms and CPU."""
+
 rms_no_var_size = (
     lambda x, weight, epsilon, variance_size=None: variance_size is None
     and (weight is None or weight.dtype == x.dtype)
@@ -33,7 +36,7 @@ def rms_norm(
     return output
 
 
-@ir.ops.relu2.register_impl("vllm_c", supported=CUDA_ALIKE)
+@ir.ops.relu2.register_impl("vllm_c", supported=RELU2_VLLM_C_SUPPORTED)
 def relu2(x: Tensor) -> Tensor:
     output = torch.empty_like(x)
     torch.ops._C.relu2(output, x)

--- a/vllm/kernels/xpu_ops.py
+++ b/vllm/kernels/xpu_ops.py
@@ -36,3 +36,10 @@ def rms_norm(
     output = torch.empty(x.shape, device=x.device, dtype=x.dtype)
     torch.ops._C.rms_norm(output, x, weight, epsilon)
     return output
+
+
+# Register the provider name so relu2 can participate in platform defaults.
+# XPU does not have a fused relu2 kernel yet, so dispatch falls back to native.
+@ir.ops.relu2.register_impl("xpu_kernels", supported=False)
+def relu2(x: Tensor) -> Tensor:
+    return torch.square(torch.relu(x))

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from vllm import ir
 from vllm.distributed import (
     divide,
     get_tensor_model_parallel_rank,
@@ -497,11 +498,10 @@ class ReLUSquaredActivation(CustomOp):
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
         """PyTorch-native implementation equivalent to forward()."""
-        return torch.square(F.relu(x))
+        return ir.ops.relu2(x)
 
     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
-        # TODO : implement cuda kernels
-        return self.forward_native(x)
+        return ir.ops.relu2(x)
 
 
 # --8<-- [start:xielu]


### PR DESCRIPTION

## Purpose
This PR ports relu2 to a vLLM IR op as part of the activation IR migration in https://github.com/vllm-project/vllm/issues/40406.

- add `ir.ops.relu2` and export it from `vllm.ir.ops`
- register a `vllm_c` implementation for `relu2`
- add CUDA and CPU `_C.relu2` bindings/kernels
- route `ReLUSquaredActivation` through `ir.ops.relu2`
- add IR-level correctness and config coverage for `relu2`

## Test Plan
- Ran a manual CUDA smoke test on an NVIDIA L4 after `import vllm._C` to verify:
  - `torch.ops._C.relu2` is registered
  - CUDA output matches `torch.square(torch.relu(x))`
  - NaNs are preserved correctly
- Ran:
  - `.venv/bin/python -m pytest tests/kernels/ir/test_relu2.py -v`
  - `.venv/bin/python -m pytest tests/test_config.py -k ir_op_priority -v`
 
## Test Result
- CUDA smoke test on NVIDIA L4: passed
- `.venv/bin/python -m pytest tests/kernels/ir/test_relu2.py -v`
  - `163 passed`
- `.venv/bin/python -m pytest tests/test_config.py -k ir_op_priority -v`
  - `2 passed`
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

