### PR TITLE
[Bugfix] Fix max_num_batched_token not captured in cuda graph 

### DIFF
--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -405,7 +405,7 @@ def test_should_split():
         (None, 0, 1, False, 2048, CUDAGraphMode.NONE, 0),
         # truncated to nearest multiple of 8 or 16
         (None, 257, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 256),
-        # max_num_batched_tokens < max_cudagraph_capture_size should always be
+        # max_num_batched_tokens <= max_cudagraph_capture_size should always be
         # captured even if not landing on a 16-stride step
         (None, 2048, 1, False, 257, CUDAGraphMode.FULL_AND_PIECEWISE, 257),
         # max from list

--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -403,6 +403,8 @@ def test_should_split():
         ([1, 256], None, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 256),
         ([], None, 1, False, 2048, CUDAGraphMode.NONE, 0),
         (None, 0, 1, False, 2048, CUDAGraphMode.NONE, 0),
+        # truncated to nearest multiple of 8 or 16
+        (None, 257, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 256),
         # max_num_batched_tokens < max_cudagraph_capture_size should always be
         # captured even if not landing on a 16-stride step
         (None, 2048, 1, False, 257, CUDAGraphMode.FULL_AND_PIECEWISE, 257),

--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -403,13 +403,9 @@ def test_should_split():
         ([1, 256], None, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 256),
         ([], None, 1, False, 2048, CUDAGraphMode.NONE, 0),
         (None, 0, 1, False, 2048, CUDAGraphMode.NONE, 0),
-        # user-specified max is preserved as the top capture size even when it
-        # doesn't land on a stride-16 step (256 is the stride boundary)
-        (None, 257, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 257),
-        # max_num_batched_tokens clamps max_cudagraph_capture_size and is kept
-        # as the top capture size (regression test: 700 used to truncate to 688
-        # causing steady-state decode batches to fall back to eager)
-        (None, 2048, 1, False, 700, CUDAGraphMode.FULL_AND_PIECEWISE, 700),
+        # max_num_batched_tokens < max_cudagraph_capture_size should always be
+        # captured even if not landing on a 16-stride step
+        (None, 2048, 1, False, 257, CUDAGraphMode.FULL_AND_PIECEWISE, 257),
         # max from list
         ([1, 2, 4, 15], None, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 15),
         # SP forces full-graph compilation, sizes are filtered by TP

--- a/tests/compile/test_config.py
+++ b/tests/compile/test_config.py
@@ -403,8 +403,13 @@ def test_should_split():
         ([1, 256], None, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 256),
         ([], None, 1, False, 2048, CUDAGraphMode.NONE, 0),
         (None, 0, 1, False, 2048, CUDAGraphMode.NONE, 0),
-        # truncated to nearest multiple of 8 or 16
-        (None, 257, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 256),
+        # user-specified max is preserved as the top capture size even when it
+        # doesn't land on a stride-16 step (256 is the stride boundary)
+        (None, 257, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 257),
+        # max_num_batched_tokens clamps max_cudagraph_capture_size and is kept
+        # as the top capture size (regression test: 700 used to truncate to 688
+        # causing steady-state decode batches to fall back to eager)
+        (None, 2048, 1, False, 700, CUDAGraphMode.FULL_AND_PIECEWISE, 700),
         # max from list
         ([1, 2, 4, 15], None, 1, False, 2048, CUDAGraphMode.FULL_AND_PIECEWISE, 15),
         # SP forces full-graph compilation, sizes are filtered by TP

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1432,7 +1432,7 @@ class VllmConfig:
         cudagraph_capture_sizes = [1, 2, 4] + list(range(8, 256, 8)) + list(
             range(256, max_graph_size + 1, 16))
 
-        `max_num_batched_tokens` is also appended to the list if it fits 
+        `max_num_batched_tokens` is also appended to the list if it fits
         within `max_cudagraph_capture_size`, so the max batch size is captured
         even when off-stride.
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1522,6 +1522,17 @@ class VllmConfig:
                     )
                 # de-duplicate and sort the sizes
                 cudagraph_capture_sizes = sorted(set(cudagraph_capture_sizes))
+                # Ensure max_cudagraph_capture_size is the last entry so that
+                # decode steps that fill the batch up to max_num_batched_tokens
+                # always hit a captured graph. Without this, e.g.
+                # max_num_batched_tokens=700 would round the top capture down
+                # to 688 (range stride 16), and every full-sized batch would
+                # silently fall back to eager in the dispatcher.
+                if (
+                    cudagraph_capture_sizes
+                    and cudagraph_capture_sizes[-1] < max_cudagraph_capture_size
+                ):
+                    cudagraph_capture_sizes.append(max_cudagraph_capture_size)
 
             if (
                 self.parallel_config.tensor_parallel_size > 1

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1521,8 +1521,11 @@ class VllmConfig:
                         range(256, max_cudagraph_capture_size + 1, 16)
                     )
                 # ensure max_num_tokens is captured if within max capture size
-                if max_cudagraph_capture_size not in cudagraph_capture_sizes:
-                    cudagraph_capture_sizes.append(max_cudagraph_capture_size)
+                if (
+                    max_num_tokens <= max_cudagraph_capture_size
+                    and max_num_tokens not in cudagraph_capture_sizes
+                ):
+                    cudagraph_capture_sizes.append(max_num_tokens)
                 # de-duplicate and sort the sizes
                 cudagraph_capture_sizes = sorted(set(cudagraph_capture_sizes))
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1520,7 +1520,7 @@ class VllmConfig:
                     cudagraph_capture_sizes += list(
                         range(256, max_cudagraph_capture_size + 1, 16)
                     )
-                # always ensure the max batch size is in the capture sizes
+                # ensure max_num_tokens is captured if within max capture size
                 if max_cudagraph_capture_size not in cudagraph_capture_sizes:
                     cudagraph_capture_sizes.append(max_cudagraph_capture_size)
                 # de-duplicate and sort the sizes

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1432,6 +1432,10 @@ class VllmConfig:
         cudagraph_capture_sizes = [1, 2, 4] + list(range(8, 256, 8)) + list(
             range(256, max_graph_size + 1, 16))
 
+        `max_num_batched_tokens` is also appended to the list if it fits 
+        within `max_cudagraph_capture_size`, so the max batch size is captured
+        even when off-stride.
+
         In the end, `vllm_config.compilation_config.cudagraph_capture_sizes`
         will be the final sizes to capture cudagraph (in ascending order).
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1520,19 +1520,11 @@ class VllmConfig:
                     cudagraph_capture_sizes += list(
                         range(256, max_cudagraph_capture_size + 1, 16)
                     )
+                # always ensure the max batch size is in the capture sizes
+                if max_cudagraph_capture_size not in cudagraph_capture_sizes:
+                    cudagraph_capture_sizes.append(max_cudagraph_capture_size)
                 # de-duplicate and sort the sizes
                 cudagraph_capture_sizes = sorted(set(cudagraph_capture_sizes))
-                # Ensure max_cudagraph_capture_size is the last entry so that
-                # decode steps that fill the batch up to max_num_batched_tokens
-                # always hit a captured graph. Without this, e.g.
-                # max_num_batched_tokens=700 would round the top capture down
-                # to 688 (range stride 16), and every full-sized batch would
-                # silently fall back to eager in the dispatcher.
-                if (
-                    cudagraph_capture_sizes
-                    and cudagraph_capture_sizes[-1] < max_cudagraph_capture_size
-                ):
-                    cudagraph_capture_sizes.append(max_cudagraph_capture_size)
 
             if (
                 self.parallel_config.tensor_parallel_size > 1


### PR DESCRIPTION
## Purpose
Currently, cuda graph capture sizes only include batch size that land on multiples of 8 or 16. When `max_num_batched_tokens` is not a multiple of the stride, it won't be captured. So when the model runs at max batch size, it falls back to eager mode, causing significant performance degradation.

This PR ensures `max_num_batched_tokens` is cuda graph captured when it is within `max_cudagraph_capture_size`

Example:

**max-cudagraph-capture-size: 2048
max-num-batched-tokens: 700**

Performance drops drastically when batch size reaches peak.
<img width="1202" height="1026" alt="image" src="https://github.com/user-attachments/assets/19b77023-6c3e-4f68-8776-96fe89676ced" />

```
vllm serve nvidia/MiniMax-M2.5-NVFP4 \
  --data-parallel-size 2 \
  --enable-expert-parallel \
  --max-model-len 2048 \
  --kv-cache-dtype fp8 \
  --max-cudagraph-capture-size 2048 \
  --max-num-batched-tokens 700 \
  --stream-interval 20 \
  --no-enable-prefix-caching \
  --trust-remote-code
```

Benchmark:
```
vllm bench serve \
  --backend vllm \
  --endpoint /v1/completions \
  --port 8000 \
  --num-prompts 4096 \
  --dataset-name random \
  --input-len 1024 \
  --output-len 1024 \
  --max-concurrency 2048 \
  --trust-remote-code \
  --num-warmups 10
```

Result:
```
============ Serving Benchmark Result ============
Successful requests:                     4096      
Failed requests:                         0         
Maximum request concurrency:             2048      
Benchmark duration (s):                  776.71    
Total input tokens:                      4194304   
Total generated tokens:                  4194304   
Request throughput (req/s):              5.27      
Output token throughput (tok/s):         5400.07   
Peak output token throughput (tok/s):    1018.00   
Peak concurrent requests:                2059.00   
Total token throughput (tok/s):          10800.14  
---------------Time to First Token----------------
Mean TTFT (ms):                          210700.29 
Median TTFT (ms):                        256142.99 
P99 TTFT (ms):                           349752.74 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          122.18    
Median TPOT (ms):                        130.50    
P99 TPOT (ms):                           133.12    
---------------Inter-token Latency----------------
Mean ITL (ms):                           2403.70   
Median ITL (ms):                         2564.90   
P99 ITL (ms):                            4575.28   
==================================================
```

Compared to using **max-num-batched-tokens: 768**:
```
============ Serving Benchmark Result ============
Successful requests:                     4096      
Failed requests:                         0         
Maximum request concurrency:             2048      
Benchmark duration (s):                  252.07    
Total input tokens:                      4194304   
Total generated tokens:                  4194304   
Request throughput (req/s):              16.25     
Output token throughput (tok/s):         16639.32  
Peak output token throughput (tok/s):    1098.00   
Peak concurrent requests:                2079.00   
Total token throughput (tok/s):          33278.64  
---------------Time to First Token----------------
Mean TTFT (ms):                          60547.79  
Median TTFT (ms):                        73715.61  
P99 TTFT (ms):                           103283.03 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          42.23     
Median TPOT (ms):                        43.65     
P99 TPOT (ms):                           44.54     
---------------Inter-token Latency----------------
Mean ITL (ms):                           830.75    
Median ITL (ms):                         872.96    
P99 ITL (ms):                            944.90    
==================================================
```

The difference in `max-num-batched-tokens` from 700 to 768 causes a 3x performance drop.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

