### PR TITLE
[Bugfix] Fix device mismatch triggering in testing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -463,6 +463,13 @@ class HfRunner:
                 and len({p.device for p in model.parameters()}) < 2
             ):
                 model = model.to(device=self.device)
+                # accelerate hooks can prevent .to() from moving
+                # non-persistent buffers (e.g. inv_freq in RoPE),
+                # causing Triton dispatch errors in newer PyTorch.
+                target = torch.device(self.device)
+                for _, buf in model.named_buffers():
+                    if buf.device != target:
+                        buf.data = buf.data.to(target)
 
             self.model = model
 


### PR DESCRIPTION



## Purpose
vLLM side fix for https://github.com/pytorch/pytorch/issues/180909

After model.to(device) in HfRunner._init(), sweep any buffers still on CPU to the target device. This fixes 6 CI test failures where triton 3.6.0 crashes on a CPU inv_freq buffer during HF RoPE inference.      

## Test Plan
```bash
test_single_image_models_heavy[chameleon-broadcast-test_case0]                                     
test_single_image_models_heavy[chameleon-broadcast-test_case1]
test_single_image_models_heavy[llava-broadcast-test_case2]                                         
test_single_image_models_heavy[llava-broadcast-test_case3]
test_single_image_models_heavy[llava_next-broadcast-test_case4]                                    
test_single_image_models_heavy[llava_next-broadcast-test_case5]   
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

