### PR TITLE
[Frontend] Delegate to vLLM Omni When `--omni` Passed

### DIFF
--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -38,10 +38,13 @@ def main():
     if "--omni" in sys.argv:
         try:
             from vllm_omni.entrypoints.cli.main import main as omni_main
+
             logger.info("Delegating entrypoint handling to vllm-omni")
             omni_main()
         except ImportError:
-            logger.error("--omni flag requires a valid instance of vllm-omni to be installed.")
+            logger.error(
+                "--omni flag requires a valid instance of vllm-omni to be installed."
+            )
     else:
         # For 'vllm bench *': use CPU instead of UnspecifiedPlatform by default
         if len(sys.argv) > 1 and sys.argv[1] == "bench":

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -7,6 +7,7 @@ to avoid certain eager import breakage."""
 
 import importlib.metadata
 import sys
+from importlib.util import find_spec
 
 from vllm.logger import init_logger
 
@@ -36,13 +37,16 @@ def main():
 
     # If `--omni` arg is passed to the CLI, delegate to vLLM Omni's entrypoint handling
     if "--omni" in sys.argv:
-        try:
-            from vllm_omni.entrypoints.cli.main import main as omni_main
-        except ImportError:
+        # NOTE: Check the spec instead of importing directly here, since things could
+        # fail with ImportError due to mismatched versions if things are moved around.
+        spec = find_spec("vllm_omni")
+        if spec is None:
             logger.error(
                 "--omni flag requires a valid instance of vllm-omni to be installed."
             )
             sys.exit(1)
+
+        from vllm_omni.entrypoints.cli.main import main as omni_main
 
         logger.info("Delegating entrypoint handling to vllm-omni")
         omni_main()

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -38,13 +38,14 @@ def main():
     if "--omni" in sys.argv:
         try:
             from vllm_omni.entrypoints.cli.main import main as omni_main
-
-            logger.info("Delegating entrypoint handling to vllm-omni")
-            omni_main()
         except ImportError:
             logger.error(
                 "--omni flag requires a valid instance of vllm-omni to be installed."
             )
+            sys.exit(1)
+
+        logger.info("Delegating entrypoint handling to vllm-omni")
+        omni_main()
     else:
         # For 'vllm bench *': use CPU instead of UnspecifiedPlatform by default
         if len(sys.argv) > 1 and sys.argv[1] == "bench":

--- a/vllm/entrypoints/cli/main.py
+++ b/vllm/entrypoints/cli/main.py
@@ -34,47 +34,56 @@ def main():
 
     cli_env_setup()
 
-    # For 'vllm bench *': use CPU instead of UnspecifiedPlatform by default
-    if len(sys.argv) > 1 and sys.argv[1] == "bench":
-        logger.debug(
-            "Bench command detected, must ensure current platform is not "
-            "UnspecifiedPlatform to avoid device type inference error"
-        )
-        from vllm import platforms
-
-        if platforms.current_platform.is_unspecified():
-            from vllm.platforms.cpu import CpuPlatform
-
-            platforms.current_platform = CpuPlatform()
-            logger.info(
-                "Unspecified platform detected, switching to CPU Platform instead."
-            )
-
-    parser = FlexibleArgumentParser(
-        description="vLLM CLI",
-        epilog=VLLM_SUBCMD_PARSER_EPILOG.format(subcmd="[subcommand]"),
-    )
-    parser.add_argument(
-        "-v",
-        "--version",
-        action="version",
-        version=importlib.metadata.version("vllm"),
-    )
-    subparsers = parser.add_subparsers(required=False, dest="subparser")
-    cmds = {}
-    for cmd_module in CMD_MODULES:
-        new_cmds = cmd_module.cmd_init()
-        for cmd in new_cmds:
-            cmd.subparser_init(subparsers).set_defaults(dispatch_function=cmd.cmd)
-            cmds[cmd.name] = cmd
-    args = parser.parse_args()
-    if args.subparser in cmds:
-        cmds[args.subparser].validate(args)
-
-    if hasattr(args, "dispatch_function"):
-        args.dispatch_function(args)
+    # If `--omni` arg is passed to the CLI, delegate to vLLM Omni's entrypoint handling
+    if "--omni" in sys.argv:
+        try:
+            from vllm_omni.entrypoints.cli.main import main as omni_main
+            logger.info("Delegating entrypoint handling to vllm-omni")
+            omni_main()
+        except ImportError:
+            logger.error("--omni flag requires a valid instance of vllm-omni to be installed.")
     else:
-        parser.print_help()
+        # For 'vllm bench *': use CPU instead of UnspecifiedPlatform by default
+        if len(sys.argv) > 1 and sys.argv[1] == "bench":
+            logger.debug(
+                "Bench command detected, must ensure current platform is not "
+                "UnspecifiedPlatform to avoid device type inference error"
+            )
+            from vllm import platforms
+
+            if platforms.current_platform.is_unspecified():
+                from vllm.platforms.cpu import CpuPlatform
+
+                platforms.current_platform = CpuPlatform()
+                logger.info(
+                    "Unspecified platform detected, switching to CPU Platform instead."
+                )
+
+        parser = FlexibleArgumentParser(
+            description="vLLM CLI",
+            epilog=VLLM_SUBCMD_PARSER_EPILOG.format(subcmd="[subcommand]"),
+        )
+        parser.add_argument(
+            "-v",
+            "--version",
+            action="version",
+            version=importlib.metadata.version("vllm"),
+        )
+        subparsers = parser.add_subparsers(required=False, dest="subparser")
+        cmds = {}
+        for cmd_module in CMD_MODULES:
+            new_cmds = cmd_module.cmd_init()
+            for cmd in new_cmds:
+                cmd.subparser_init(subparsers).set_defaults(dispatch_function=cmd.cmd)
+                cmds[cmd.name] = cmd
+        args = parser.parse_args()
+        if args.subparser in cmds:
+            cmds[args.subparser].validate(args)
+
+        if hasattr(args, "dispatch_function"):
+            args.dispatch_function(args)
+        else:
+            parser.print_help()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Purpose
Currently vLLM Omni hijacks vLLM's entrypoint, but this causes a lot of confusion for a few reasons, the most serious of which is that the installation order of vLLM & vLLM Omni matters. More specifically:
- If vLLM Omni is installed, but then vLLM is reinstalled, `--omni` stuff may not work as expected since it'll rewrite the hijacked entrypoint
- If vLLM Omni is uninstalled, it'll uninstall the vLLM command with it, since they are both registered in pyproject.toml in vLLM Omni so that it can hijack.

A better approach is to just call out to the CLI `main` in vLLM Omni from the vLLM CLI if `--omni` is in argv,and log + exit if vLLM Omni isn't installed. This will fix the first issue immediately, since overwriting the hijacked entrypoint with the vLLM version would ensure it delegates to vLLM Omni. After it's merged, we can also safely remove the entrypoint hijack from vLLM Omni since `--omni` will just be handled by the vLLM CLI.

CC @hsliuustc0106 @lishunyang12 @DarkLight1337 @ywang96 @redwhitecat could you PTAL?