### PR TITLE
[Bugfix][ROCm] Fix OOB query read in paged_attention_rocm for head_size < 128

### DIFF
--- a/csrc/rocm/attention.cu
+++ b/csrc/rocm/attention.cu
@@ -1055,13 +1055,19 @@ __launch_bounds__(NUM_THREADS) void paged_attention_ll4mi_QKV_mfma4_kernel(
         q + query_start_off * q_stride + wg_start_head_idx * HEAD_SIZE;
     const _B16x8* q_ptrh8 = reinterpret_cast<const _B16x8*>(q_ptr);
     const int qhead_elemh8 = laneid / 4;
+    const bool qhead_elemh8_in_range = qhead_elemh8 < (HEAD_SIZE / 8);
 
     for (int h = 0; h < QHLOOP - 1; h++) {
       const int qhead_idx = h * 4 + lane4id;
-      Qlocal[h] = q_ptrh8[qhead_idx * HEAD_SIZE / 8 + qhead_elemh8];
+      if (qhead_elemh8_in_range) {
+        Qlocal[h] = q_ptrh8[qhead_idx * HEAD_SIZE / 8 + qhead_elemh8];
+      } else {
+        Qlocal[h].xy[0] = {0};
+        Qlocal[h].xy[1] = {0};
+      }
     }
     const int final_qhead_idx = 4 * (QHLOOP - 1) + lane4id;
-    if (final_qhead_idx < GQA_RATIO) {
+    if (final_qhead_idx < GQA_RATIO && qhead_elemh8_in_range) {
       Qlocal[QHLOOP - 1] =
           q_ptrh8[final_qhead_idx * HEAD_SIZE / 8 + qhead_elemh8];
     } else {


### PR DESCRIPTION
**Summary**
paged_attention_ll4mi_QKV_mfma4_kernel (and the mfma16 variant) in csrc/rocm/attention.cu performs an out-of-bounds read on the query tensor for any model with head_size < 128. The OOB is up to 64 bytes per affected wavefront.

**Root cause**
Each thread in the 64-lane wavefront computes a Q-tensor chunk index as qhead_elemh8 = laneid / 4, ranging over [0, 16). The kernel was designed assuming HEAD_SIZE = 128, which gives exactly 16 chunks per head. For HEAD_SIZE = 64 (e.g. Gemma2), there are only 8 chunks per head, so the upper half of the wavefront (lanes 32–63) loads chunks 8–15 — up to 64 bytes past the end of the query allocation.

```
// csrc/rocm/attention.cu (around line 1057)
const _B16x8* q_ptrh8 = reinterpret_cast<const _B16x8*>(q_ptr);
const int qhead_elemh8 = laneid / 4;          // [0, 16)
...
Qlocal[QHLOOP - 1] =
    q_ptrh8[final_qhead_idx * HEAD_SIZE / 8 + qhead_elemh8];   // OOB when qhead_elemh8 >= HEAD_SIZE/8
```

The MFMA instruction that consumes Qlocal only broadcasts from lanes that hold in-bounds data (x < HEAD_SIZE/8 in the QK_mfma loop), so the OOB values are silently discarded and numerical output is correct. The illegal load itself is still real and triggers hipErrorIllegalAddress whenever the 64-byte over-read happens to fall on an unmapped GPU page.

**Why this is latent on most workloads**
The crash depends entirely on where the caching allocator places the query tensor:

If the bytes right after Q are part of another allocation → silently reads garbage, no crash.
If they fall on a guard page → hipErrorIllegalAddress.
The same compiled kernel runs on __gfx90a__ (MI210/MI250), __gfx942__ (MI300), and __gfx950__ (MI355).