### PR TITLE
[CI/Build] Make opencv-python-headless an optional dependency

### DIFF
--- a/docs/features/multimodal_inputs.md
+++ b/docs/features/multimodal_inputs.md
@@ -278,6 +278,9 @@ print("caption:", caption_out)
 
 ### Video Inputs
 
+!!! note
+    Video processing uses PyAV by default. To use the OpenCV video backend, install with extra video dependencies using `pip install vllm[video]`.
+
 You can pass a list of NumPy arrays directly to the `'video'` field of the multi-modal dictionary
 instead of using multi-image input.
 
@@ -839,7 +842,7 @@ vllm serve Qwen/Qwen3-VL-30B-A3B-Instruct \
 3. The next successfully grabbed frame (before reaching the next target) is used to recover the failed frame
 4. This approach handles both mid-video corruption and end-of-video truncation
 
-Works with common video formats like MP4 when using OpenCV backends.
+Works with common video formats like MP4 when using OpenCV backends (requires `pip install vllm[video]`).
 
 #### Pre-extracted Frame Sequences with `media_io_kwargs`
 

--- a/docs/getting_started/installation/cpu.s390x.inc.md
+++ b/docs/getting_started/installation/cpu.s390x.inc.md
@@ -11,7 +11,7 @@ Currently, the CPU implementation for s390x architecture supports FP32, BF16 and
 - OS: `Linux`
 - SDK: `gcc/g++ >= 14.0.0` or later with Command Line Tools
 - Instruction Set Architecture (ISA): VXE support is required. Works with Z14 and above.
-- Build install python packages: `torchvision`, `llvmlite`, `numba`, `pyarrow (for testing)`, `opencv-headless`
+- Build install python packages: `torchvision`, `llvmlite`, `numba`, `pyarrow (for testing)`, `opencv-headless` (optional, only needed for the OpenCV video backend: `pip install vllm[video]`)
 
 --8<-- [end:requirements]
 --8<-- [start:set-up-using-python]
@@ -44,7 +44,7 @@ curl https://sh.rustup.rs -sSf | sh -s -- -y && \
 Execute the following commands to build and install vLLM from source.
 
 !!! tip
-    Please build the following dependencies, `torchvision`, `llvmlite`, `numba`, `llguidance`, `pyarrow`, `opencv-headless` from source before building vLLM.
+    Please build the following dependencies, `torchvision`, `llvmlite`, `numba`, `llguidance`, `pyarrow` from source before building vLLM. If you need the OpenCV video backend, also build `opencv-headless` from source and install with `pip install vllm[video]`.
 
 ```bash
     uv pip install -v \

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -32,8 +32,7 @@ partial-json-parser # used for parsing partial JSON outputs
 pyzmq >= 25.0.0
 msgspec
 gguf >= 0.17.0
-mistral_common[image] >= 1.11.2
-opencv-python-headless >= 4.13.0    # required for video IO
+mistral_common >= 1.11.2
 pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
 setuptools>=77.0.3,<81.0.0; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12

--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -549,7 +549,6 @@ opencensus-context==0.1.3
     # via opencensus
 opencv-python-headless==4.13.0.90
     # via
-    #   -c requirements/common.txt
     #   -r requirements/test/cuda.in
     #   albumentations
     #   mistral-common

--- a/requirements/test/rocm.txt
+++ b/requirements/test/rocm.txt
@@ -640,8 +640,6 @@ opencensus-context==0.1.3
     # via opencensus
 opencv-python-headless==4.13.0.92
     # via
-    #   -c requirements/common.txt
-    #   -r requirements/test/../common.txt
     #   -r requirements/test/rocm.in
     #   albumentations
     #   mistral-common

--- a/requirements/test/xpu.txt
+++ b/requirements/test/xpu.txt
@@ -364,7 +364,6 @@ openai-harmony==0.0.8
     #   gpt-oss
 opencv-python-headless==4.13.0.92
     # via
-    #   -c requirements/common.txt
     #   albumentations
     #   mistral-common
 packaging==26.0

--- a/setup.py
+++ b/setup.py
@@ -1179,7 +1179,7 @@ setup(
             "soundfile",
             "mistral_common[audio]",
         ],  # Required for audio processing
-        "video": [],  # Kept for backwards compatibility
+        "video": ["opencv-python-headless>=4.13.0"],
         "flashinfer": [],  # Kept for backwards compatibility
         # Optional deps for Helion kernel development
         # NOTE: When updating helion version, also update CI files:

--- a/vllm/assets/video.py
+++ b/vllm/assets/video.py
@@ -11,6 +11,7 @@ from PIL import Image
 
 from vllm.multimodal.media.audio import load_audio_pyav
 from vllm.transformers_utils.repo_utils import hf_api
+from vllm.utils.import_utils import PlaceholderModule
 
 from .base import get_cache_dir
 
@@ -37,7 +38,10 @@ def download_video_asset(filename: str) -> str:
 
 
 def video_to_ndarrays(path: str, num_frames: int = -1) -> npt.NDArray:
-    import cv2
+    try:
+        import cv2
+    except ImportError:
+        cv2 = PlaceholderModule("cv2")  # type: ignore[assignment]
 
     cap = cv2.VideoCapture(path)
     if not cap.isOpened():
@@ -74,7 +78,10 @@ def video_to_pil_images_list(path: str, num_frames: int = -1) -> list[Image.Imag
 
 
 def video_get_metadata(path: str, num_frames: int = -1) -> dict[str, Any]:
-    import cv2
+    try:
+        import cv2
+    except ImportError:
+        cv2 = PlaceholderModule("cv2")  # type: ignore[assignment]
 
     cap = cv2.VideoCapture(path)
     if not cap.isOpened():

--- a/vllm/benchmarks/datasets/datasets.py
+++ b/vllm/benchmarks/datasets/datasets.py
@@ -947,7 +947,10 @@ class RandomMultiModalDataset(RandomDataset):
         Creates a video with random pixel values, encodes it to MP4 format,
         and returns the content as bytes.
         """
-        import cv2
+        try:
+            import cv2
+        except ImportError:
+            cv2 = PlaceholderModule("cv2")  # type: ignore[assignment]
 
         random_pixels = self._rng.integers(
             0,


### PR DESCRIPTION
## Why these changes are needed

This PR makes `opencv-python-headless` an optional dependency by moving it to the existing `video` extra (`pip install vllm[video]`). This resolves the FIPS/CVE deadlock that currently blocks pinning opencv for all users.

**Problem:** opencv-python-headless cannot be safely required by default:
- **CVE-2026-22778** (CVSS 9.8 RCE) affects versions <4.13.0, blocking pinning to 4.12
- **FIPS compliance failure** affects 4.13.0+ which statically bundles OpenSSL 1.1.1k, causing `FATAL FIPS SELFTEST FAILURE` crashes on FIPS-enabled systems (#33147, #39986)
- The upstream fix (opencv/opencv-python#1190) is unmerged with no timeline

**Context:** PR #40276 already made PyAV optional due to LGPL licensing concerns. Both video backends now have blockers for default inclusion. This PR makes the video backend stance consistent — both are optional extras, users choose based on their needs.

**Why this is the right fix:**
- The majority of vLLM users run LLM text inference without video support
- Forcing all users to install a package with either a critical CVE or FIPS crash for unused video features is the wrong default
- Making opencv optional allows FIPS users to run vLLM and non-FIPS users to opt into video support with `pip install vllm[video]`
- This is the pragmatic interim solution until upstream resolves the FIPS issue

## Implementation details

- Remove `opencv-python-headless` from `requirements/common.txt`
- Drop the `[image]` extra from `mistral_common` in `requirements/common.txt` — this extra is an alias for `[opencv]` and was re-introducing opencv as a transitive dependency. All mistral_common classes vllm uses (`ImageChunk`, `ImageEncoder`, etc.) work without the extra installed.
- Add `opencv-python-headless>=4.13.0` to the existing `video` extra in `setup.py`
- Add `PlaceholderModule` import guards in `vllm/assets/video.py` and `vllm/benchmarks/datasets/datasets.py` (matching the existing pattern in `vllm/multimodal/video.py`)
- Update test lockfiles (`cuda.txt`, `rocm.txt`, `xpu.txt`) to reflect the removed constraint
- Update s390x installation docs and multimodal inputs docs to note opencv is optional

All `import cv2` statements in vllm/ source are now guarded:
- `vllm/multimodal/video.py` — already guarded (pre-existing)
- `vllm/assets/video.py` — guarded by this PR (2 sites)
- `vllm/benchmarks/datasets/datasets.py` — guarded by this PR (1 site)

Selecting the opencv video backend without the package installed raises a clear `PlaceholderModule` error directing users to install with `pip install vllm[video]`.

## Test plan

Validated the following:
- `pip install -e .` (without `[video]`) succeeds without installing opencv
- `pip install -e ".[video]"` installs `opencv-python-headless`
- `python -c "import vllm"` succeeds without opencv installed
- `tests/standalone_tests/lazy_imports.py` passes (validates cv2 is not eagerly imported)
- All `mistral_common` classes used by vllm (ImageChunk, ImageEncoder, etc.) import successfully without opencv
- Attempting to use opencv video backend without the package raises `PlaceholderModule` error
- Existing test suites unaffected (test requirements independently list opencv-python-headless)
- Pre-commit hooks pass; test lockfiles auto-updated correctly

## Related issues and PRs

Fixes #40741
Related: #33147, #33756, #39986, #40276

CC @russellb @Isotr0py

---

AI Assistance Disclosure: This PR was developed with AI assistance (Claude). All changes were reviewed, tested, and validated by the human submitter.