### PR TITLE
[Bugfix] fix bailing_moe_linear decode index err

### DIFF
--- a/vllm/model_executor/models/bailing_moe_linear.py
+++ b/vllm/model_executor/models/bailing_moe_linear.py
@@ -754,8 +754,6 @@ class BailingMoELinearAttention(nn.Module, MambaBase):
 
     def _decode_infer(self, q, k, v, kv_cache, state_indices_tensor, attn_metadata):
         """Handle decode (single token per sequence)."""
-        num_prefill_tokens = attn_metadata.num_prefill_tokens
-        num_prefills = attn_metadata.num_prefills
         hidden = linear_attention_decode(
             q,
             k,
@@ -763,10 +761,10 @@ class BailingMoELinearAttention(nn.Module, MambaBase):
             kv_cache,
             self.tp_slope,
             state_indices_tensor,
-            q_start=num_prefill_tokens,
-            q_end=None,
-            slot_start=num_prefills,
-            slot_end=None,
+            q_start=0,
+            q_end=attn_metadata.num_decode_tokens,
+            slot_start=0,
+            slot_end=attn_metadata.num_decodes,
             block_size=32,
         )
         return hidden


### PR DESCRIPTION
## Purpose

Fix a critical bug in mixed prefill/decode batch processing that causes incorrect KV cache updates and degenerate output (e.g., repeated newlines) in long-form generation.

In vLLM v1, batches are reordered as decode-first, but the `_decode_infer` function was ported from SGLang which uses prefill-first ordering. This mismatch causes decode requests in mixed batches to read Q/K/V tensors from wrong positions and update incorrect KV cache state slots, corrupting the recurrent state.

The bug is silently masked in decode-only batches (`num_prefill_tokens=0`) but triggers frequently under high concurrency when prefill and decode requests are scheduled together.

This PR fixes the tensor slicing logic by using `q_start=0`/`q_end=num_decode_tokens` and `slot_start=0`/`slot_end=num_decodes` to correctly isolate the decode portion of the batch.

## Test Plan

- Run GSM8K benchmark under high concurrency (mixed prefill/decode workloads)
- Compare accuracy before and after the fix
- Verify long-form generation quality doesn't exhibit degenerate patterns (repeated tokens/newlines)

Test command:
```bash
# High concurrency GSM8K evaluation
evalscope eval \
  --model auto \
  --model-id auto \
  --datasets gsm8k \
  --dataset-dir /datasets/gsm8k\
  --chat-template true \
  --api-url http://localhost:${PORT}/v1\
  --eval-batch-size 32
```

## Test Result
Before fix: GSM8K accuracy drops to ~74% under high concurrency due to corrupted KV cache state
<img width="741" height="186" alt="image" src="https://github.com/user-attachments/assets/c94ca3a7-0c05-474e-990a-0f50d0995342" />

After fix: GSM8K accuracy recovers to ~94%, matching expected performance
<img width="714" height="249" alt="image" src="https://github.com/user-attachments/assets/6d6c9037-4dc9-48f0-bc7e-7fbb27900777" />


