### PR TITLE
[Core] Fix Run:ai streamer loading for Mistral-format safetensors

### DIFF
--- a/tests/model_executor/model_loader/runai_streamer_loader/test_runai_model_streamer_loader.py
+++ b/tests/model_executor/model_loader/runai_streamer_loader/test_runai_model_streamer_loader.py
@@ -41,7 +41,6 @@ def test_runai_model_loader_selects_mistral_consolidated_weights(
     model_loader = get_runai_model_loader()
     model_dir = tmp_path / "mistral"
     model_dir.mkdir()
-    (model_dir / "params.json").touch()
     weight_files = [
         str(model_dir / "consolidated.safetensors"),
         str(model_dir / "model-00001-of-00002.safetensors"),
@@ -73,7 +72,6 @@ def test_runai_model_loader_selects_mistral_consolidated_object_weights(
     model_loader = get_runai_model_loader()
     model_dir = tmp_path / "mistral"
     model_dir.mkdir()
-    (model_dir / "params.json").touch()
     object_uri = "s3://bucket/mistral"
     weight_files = [
         f"{object_uri}/consolidated.safetensors",
@@ -90,7 +88,7 @@ def test_runai_model_loader_selects_mistral_consolidated_object_weights(
         model=str(model_dir),
         model_weights=object_uri,
         revision=None,
-        config_format="auto",
+        config_format="hf",
     )
 
     assert model_loader._prepare_weights(object_uri, model_config) == [
@@ -98,7 +96,7 @@ def test_runai_model_loader_selects_mistral_consolidated_object_weights(
     ]
 
 
-def test_runai_model_loader_keeps_object_weights_without_mistral_config(
+def test_runai_model_loader_keeps_object_weights_without_mistral_weights(
     tmp_path, monkeypatch: pytest.MonkeyPatch
 ):
     model_loader = get_runai_model_loader()
@@ -106,7 +104,6 @@ def test_runai_model_loader_keeps_object_weights_without_mistral_config(
     model_dir.mkdir()
     object_uri = "s3://bucket/hf"
     weight_files = [
-        f"{object_uri}/consolidated.safetensors",
         f"{object_uri}/model-00001-of-00002.safetensors",
         f"{object_uri}/model-00002-of-00002.safetensors",
     ]
@@ -120,7 +117,7 @@ def test_runai_model_loader_keeps_object_weights_without_mistral_config(
         model=str(model_dir),
         model_weights=object_uri,
         revision=None,
-        config_format="auto",
+        config_format="hf",
     )
 
     assert model_loader._prepare_weights(object_uri, model_config) == weight_files

--- a/tests/model_executor/model_loader/runai_streamer_loader/test_runai_model_streamer_loader.py
+++ b/tests/model_executor/model_loader/runai_streamer_loader/test_runai_model_streamer_loader.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from pathlib import Path
+from types import SimpleNamespace
+
 import pytest
 
 from vllm import SamplingParams
@@ -30,6 +33,97 @@ def get_runai_model_loader():
 def test_get_model_loader_with_runai_flag():
     model_loader = get_runai_model_loader()
     assert model_loader.__class__.__name__ == "RunaiModelStreamerLoader"
+
+
+def test_runai_model_loader_selects_mistral_consolidated_weights(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    model_loader = get_runai_model_loader()
+    model_dir = tmp_path / "mistral"
+    model_dir.mkdir()
+    (model_dir / "params.json").touch()
+    weight_files = [
+        str(model_dir / "consolidated.safetensors"),
+        str(model_dir / "model-00001-of-00002.safetensors"),
+        str(model_dir / "model-00002-of-00002.safetensors"),
+    ]
+    for weight_file in weight_files:
+        Path(weight_file).touch()
+
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.runai_streamer_loader.list_safetensors",
+        lambda path: weight_files,
+    )
+
+    model_config = SimpleNamespace(
+        model=str(model_dir),
+        model_weights="",
+        revision=None,
+        config_format="auto",
+    )
+
+    assert model_loader._prepare_weights(str(model_dir), model_config) == [
+        str(model_dir / "consolidated.safetensors")
+    ]
+
+
+def test_runai_model_loader_selects_mistral_consolidated_object_weights(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    model_loader = get_runai_model_loader()
+    model_dir = tmp_path / "mistral"
+    model_dir.mkdir()
+    (model_dir / "params.json").touch()
+    object_uri = "s3://bucket/mistral"
+    weight_files = [
+        f"{object_uri}/consolidated.safetensors",
+        f"{object_uri}/model-00001-of-00002.safetensors",
+        f"{object_uri}/model-00002-of-00002.safetensors",
+    ]
+
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.runai_streamer_loader.list_safetensors",
+        lambda path: weight_files,
+    )
+
+    model_config = SimpleNamespace(
+        model=str(model_dir),
+        model_weights=object_uri,
+        revision=None,
+        config_format="auto",
+    )
+
+    assert model_loader._prepare_weights(object_uri, model_config) == [
+        f"{object_uri}/consolidated.safetensors"
+    ]
+
+
+def test_runai_model_loader_keeps_object_weights_without_mistral_config(
+    tmp_path, monkeypatch: pytest.MonkeyPatch
+):
+    model_loader = get_runai_model_loader()
+    model_dir = tmp_path / "hf"
+    model_dir.mkdir()
+    object_uri = "s3://bucket/hf"
+    weight_files = [
+        f"{object_uri}/consolidated.safetensors",
+        f"{object_uri}/model-00001-of-00002.safetensors",
+        f"{object_uri}/model-00002-of-00002.safetensors",
+    ]
+
+    monkeypatch.setattr(
+        "vllm.model_executor.model_loader.runai_streamer_loader.list_safetensors",
+        lambda path: weight_files,
+    )
+
+    model_config = SimpleNamespace(
+        model=str(model_dir),
+        model_weights=object_uri,
+        revision=None,
+        config_format="auto",
+    )
+
+    assert model_loader._prepare_weights(object_uri, model_config) == weight_files
 
 
 def test_runai_model_loader_download_files(vllm_runner):

--- a/vllm/model_executor/model_loader/runai_streamer_loader.py
+++ b/vllm/model_executor/model_loader/runai_streamer_loader.py
@@ -17,13 +17,9 @@ from vllm.model_executor.model_loader.weight_utils import (
     filter_duplicate_safetensors_files,
     runai_safetensors_weights_iterator,
 )
-from vllm.transformers_utils.repo_utils import (
-    file_or_path_exists,
-    is_mistral_model_repo,
-)
+from vllm.transformers_utils.repo_utils import is_mistral_model_repo
 from vllm.transformers_utils.runai_utils import is_runai_obj_uri, list_safetensors
 
-MISTRAL_CONFIG_NAME = "params.json"
 MISTRAL_SAFETENSORS_PATTERN = "consolidated*.safetensors"
 MISTRAL_SAFETENSORS_INDEX_NAME = "consolidated.safetensors.index.json"
 
@@ -68,25 +64,14 @@ class RunaiModelStreamerLoader(BaseModelLoader):
     ) -> bool:
         if model_config.config_format == "mistral":
             return True
-        if model_config.config_format != "auto":
-            return False
 
         if is_runai_obj_uri(model_name_or_path):
-            # Object storage can point directly at weights while the model
-            # config is local/HF metadata. Use both sides to avoid treating an
-            # unrelated consolidated file as a Mistral checkpoint.
             if safetensors_files is None:
                 safetensors_files = list_safetensors(path=model_name_or_path)
-            has_mistral_config = file_or_path_exists(
-                model_config.model,
-                MISTRAL_CONFIG_NAME,
-                revision=model_config.revision,
-            )
-            has_mistral_weights = any(
+            return any(
                 self._matches_any_pattern(weight_file, [MISTRAL_SAFETENSORS_PATTERN])
                 for weight_file in safetensors_files
             )
-            return has_mistral_config and has_mistral_weights
 
         return is_mistral_model_repo(
             model_name_or_path,

--- a/vllm/model_executor/model_loader/runai_streamer_loader.py
+++ b/vllm/model_executor/model_loader/runai_streamer_loader.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import fnmatch
 import os
 from collections.abc import Generator
 
@@ -13,9 +14,18 @@ from vllm.model_executor.model_loader.base_loader import BaseModelLoader
 from vllm.model_executor.model_loader.weight_utils import (
     download_safetensors_index_file_from_hf,
     download_weights_from_hf,
+    filter_duplicate_safetensors_files,
     runai_safetensors_weights_iterator,
 )
+from vllm.transformers_utils.repo_utils import (
+    file_or_path_exists,
+    is_mistral_model_repo,
+)
 from vllm.transformers_utils.runai_utils import is_runai_obj_uri, list_safetensors
+
+MISTRAL_CONFIG_NAME = "params.json"
+MISTRAL_SAFETENSORS_PATTERN = "consolidated*.safetensors"
+MISTRAL_SAFETENSORS_INDEX_NAME = "consolidated.safetensors.index.json"
 
 
 class RunaiModelStreamerLoader(BaseModelLoader):
@@ -43,17 +53,79 @@ class RunaiModelStreamerLoader(BaseModelLoader):
             if runai_streamer_s3_endpoint is None and aws_endpoint_url is not None:
                 os.environ["RUNAI_STREAMER_S3_ENDPOINT"] = aws_endpoint_url
 
+    @staticmethod
+    def _matches_any_pattern(file_name: str, allow_patterns: list[str]) -> bool:
+        return any(
+            fnmatch.fnmatch(os.path.basename(file_name), pattern)
+            for pattern in allow_patterns
+        )
+
+    def _uses_mistral_weight_format(
+        self,
+        model_name_or_path: str,
+        model_config: ModelConfig,
+        safetensors_files: list[str] | None = None,
+    ) -> bool:
+        if model_config.config_format == "mistral":
+            return True
+        if model_config.config_format != "auto":
+            return False
+
+        if is_runai_obj_uri(model_name_or_path):
+            # Object storage can point directly at weights while the model
+            # config is local/HF metadata. Use both sides to avoid treating an
+            # unrelated consolidated file as a Mistral checkpoint.
+            if safetensors_files is None:
+                safetensors_files = list_safetensors(path=model_name_or_path)
+            has_mistral_config = file_or_path_exists(
+                model_config.model,
+                MISTRAL_CONFIG_NAME,
+                revision=model_config.revision,
+            )
+            has_mistral_weights = any(
+                self._matches_any_pattern(weight_file, [MISTRAL_SAFETENSORS_PATTERN])
+                for weight_file in safetensors_files
+            )
+            return has_mistral_config and has_mistral_weights
+
+        return is_mistral_model_repo(
+            model_name_or_path,
+            revision=model_config.revision,
+        )
+
+    def _get_safetensors_patterns(
+        self,
+        model_name_or_path: str,
+        model_config: ModelConfig,
+        safetensors_files: list[str] | None = None,
+    ) -> tuple[list[str], str]:
+        if self._uses_mistral_weight_format(
+            model_name_or_path,
+            model_config,
+            safetensors_files,
+        ):
+            return [MISTRAL_SAFETENSORS_PATTERN], MISTRAL_SAFETENSORS_INDEX_NAME
+
+        return ["*.safetensors"], SAFE_WEIGHTS_INDEX_NAME
+
     def _prepare_weights(
-        self, model_name_or_path: str, revision: str | None
+        self, model_name_or_path: str, model_config: ModelConfig
     ) -> list[str]:
         """Prepare weights for the model.
 
         If the model is not local, it will be downloaded."""
 
+        revision = model_config.revision
         is_object_storage_path = is_runai_obj_uri(model_name_or_path)
         is_local = os.path.isdir(model_name_or_path)
-        safetensors_pattern = "*.safetensors"
-        index_file = SAFE_WEIGHTS_INDEX_NAME
+        safetensors_files = (
+            list_safetensors(path=model_name_or_path)
+            if is_object_storage_path
+            else None
+        )
+        allow_patterns, index_file = self._get_safetensors_patterns(
+            model_name_or_path, model_config, safetensors_files
+        )
 
         hf_folder = (
             model_name_or_path
@@ -61,16 +133,28 @@ class RunaiModelStreamerLoader(BaseModelLoader):
             else download_weights_from_hf(
                 model_name_or_path,
                 self.load_config.download_dir,
-                [safetensors_pattern],
+                allow_patterns,
                 revision,
                 ignore_patterns=self.load_config.ignore_patterns,
             )
         )
-        hf_weights_files = list_safetensors(path=hf_folder)
+        if safetensors_files is None:
+            safetensors_files = list_safetensors(path=hf_folder)
+
+        hf_weights_files = [
+            weight_file
+            for weight_file in safetensors_files
+            if self._matches_any_pattern(weight_file, allow_patterns)
+        ]
 
         if not is_local and not is_object_storage_path:
             download_safetensors_index_file_from_hf(
                 model_name_or_path, index_file, self.load_config.download_dir, revision
+            )
+
+        if not is_object_storage_path:
+            hf_weights_files = filter_duplicate_safetensors_files(
+                hf_weights_files, hf_folder, index_file
             )
 
         if not hf_weights_files:
@@ -81,23 +165,22 @@ class RunaiModelStreamerLoader(BaseModelLoader):
         return hf_weights_files
 
     def _get_weights_iterator(
-        self, model_or_path: str, revision: str | None
+        self, model_or_path: str, model_config: ModelConfig
     ) -> Generator[tuple[str, torch.Tensor], None, None]:
         """Get an iterator for the model weights based on the load format."""
-        hf_weights_files = self._prepare_weights(model_or_path, revision)
+        hf_weights_files = self._prepare_weights(model_or_path, model_config)
         return runai_safetensors_weights_iterator(
             hf_weights_files, self.load_config.use_tqdm_on_load, self._is_distributed
         )
 
     def download_model(self, model_config: ModelConfig) -> None:
         """Download model if necessary"""
-        self._prepare_weights(model_config.model, model_config.revision)
+        model_weights = model_config.model_weights or model_config.model
+        self._prepare_weights(model_weights, model_config)
 
     def load_weights(self, model: nn.Module, model_config: ModelConfig) -> None:
         """Load weights into a model."""
         model_weights = model_config.model
         if model_weights_override := model_config.model_weights:
             model_weights = model_weights_override
-        model.load_weights(
-            self._get_weights_iterator(model_weights, model_config.revision)
-        )
+        model.load_weights(self._get_weights_iterator(model_weights, model_config))


### PR DESCRIPTION
## Purpose

Fixes #40765.

`runai_streamer` currently streams every `*.safetensors` file it finds. For Mistral-format checkpoints that publish both `consolidated*.safetensors` and Hugging Face sharded `model-*.safetensors`, this mixes two checkpoint layouts and can fail during weight loading.

This change makes `RunaiModelStreamerLoader` select `consolidated*.safetensors` for Mistral-format weights, matching the existing behavior in the default loader. For object-storage paths, the detection requires both a Mistral config marker (`params.json`) and consolidated weights, so an unrelated `consolidated.safetensors` file does not accidentally exclude HF shards.

## Test Plan

- Added unit tests for local Mistral-format safetensors selection.
- Added unit tests for object-storage Mistral-format safetensors selection.
- Added a regression test that object-storage paths without `params.json` keep normal `*.safetensors` behavior.

## Test Result

```bash
python -m py_compile \
  vllm/model_executor/model_loader/runai_streamer_loader.py \
  tests/model_executor/model_loader/runai_streamer_loader/test_runai_model_streamer_loader.py
```

```text
passed
```

```bash
git diff --check
```

```text
passed
```

Attempted focused pytest:

```bash
python -m pytest -q \
  tests/model_executor/model_loader/runai_streamer_loader/test_runai_model_streamer_loader.py \
  -k "mistral_consolidated or without_mistral_config"
```

```text
Blocked in this local source checkout because vLLM was not installed/built:
ModuleNotFoundError: No module named 'vllm._C'
```

Validated manually in a pip-installed vLLM 0.19.1 environment with the same patch:

```text
Ministral-3 with load_format="runai_streamer" selected only
consolidated.safetensors, loaded 1145 tensors instead of 2290, and inference
completed successfully without config_format="mistral" or tokenizer_mode="mistral".
```