### PR TITLE
[Bugfix] V1: skip non-local layers in get_attn_backends_for_group under PP

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6216,6 +6216,14 @@ class GPUModelRunner(
             # they are cached correctly, there will be different objects per
             # layer.
             for layer_name in kv_cache_group_spec.layer_names:
+                # KVCacheGroupSpec carries the full model's layer names,
+                # but under pipeline parallelism each worker only materialises
+                # the layers for its own stage — get_layers_from_vllm_config
+                # silently drops the rest. Skip names that aren't ours so PP
+                # ranks > 0 don't KeyError on global indices they never own
+                # (issue #40649).
+                if layer_name not in layers:
+                    continue
                 attn_backend = layers[layer_name].get_attn_backend()
 
                 if layer_name in self.kv_sharing_fast_prefill_eligible_layers:


### PR DESCRIPTION
Fixes #40649.

## The bug

Under `pipeline_parallel_size > 1` with the V1 engine (Ray backend in the report), non-zero PP ranks crash during `initialize_attn_backend` with e.g.:

\`\`\`
KeyError: 'model.layers.20.self_attn.attn'   # PP rank 1 (layers 20–39)
KeyError: 'model.layers.40.self_attn.attn'   # PP rank 2 (layers 40–59)
KeyError: 'model.layers.60.self_attn.attn'   # PP rank 3 (layers 60–79)
\`\`\`

PP rank 0 (layers 0–19) succeeds because its local slice starts at layer 0.

## Root cause

`KVCacheGroupSpec.layer_names` is built against the **full** model and references global layer indices. Each PP worker only instantiates its local stage, and \`get_layers_from_vllm_config\` already filters the returned dict to what exists on the current worker (there's a \`if layer_name in forward_context\` guard). The subsequent \`layers[layer_name].get_attn_backend()\` then \`KeyError\`s on every name belonging to another stage.

## Fix

One-line skip at the spec-iteration site: if the layer isn't on this worker, skip it. The surrounding \`attn_backend_layers[key].append(...)\` and \`create_attn_groups\` already tolerate shorter per-rank lists, so each worker ends up with an attention group scoped to its local layers — which is what the rest of the V1 pipeline expects.

## Why this is not duplicating an existing PR

Per the AGENTS.md duplicate-work check:

\`\`\`
$ gh pr list --repo vllm-project/vllm --state open --search "40649 in:body"
[]
$ gh pr list --repo vllm-project/vllm --state open --search "get_attn_backends_for_group pipeline"
[]
\`\`\`

No open PR references the issue or the function.

## Test plan / results

I don't have access to a 4-node Ray cluster with 4× RTX 4090, so I couldn't run the exact repro from the issue end-to-end. What I did verify locally:

- File parses cleanly and \`pre-commit run ruff-check\` is green (no style or lint regressions in the touched lines).
- Reviewed \`get_layers_from_vllm_config\` to confirm the filter behavior the fix relies on — its \`if layer_name in forward_context\` branch silently drops non-local names, so \`layers\` is a strict subset of \`kv_cache_group_spec.layer_names\`.
- Reviewed \`create_attn_groups\` / \`attn_backend_layers\` to confirm that producing shorter per-rank layer lists is already the expected shape.

Would appreciate a reviewer with a multi-node PP setup running the repro script from #40649 to confirm PP ranks 1–3 now initialize. Happy to iterate if a reviewer prefers pushing the filter one level up into \`KVCacheGroupSpec\` construction instead.

## AI assistance disclosure

This change was authored with AI assistance (Claude). I reviewed every changed line, verified the filter semantics against the upstream helper, and take responsibility for the fix.