### PR TITLE
[Bugfix][MoE] Unpad routed output before shared expert add [Fixes #35949]

### DIFF
--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -550,10 +550,14 @@ class MoERunner(MoERunnerInterface):
             hidden_states
         )
 
+        # Record before `_maybe_pad_hidden_states` pads activations to match
+        # `moe_config.hidden_dim`, e.g. after `align_trtllm_fp4_moe_hidden_dim_for_fi`
+        routed_hidden_dim = hidden_states.shape[-1]
         hidden_states, og_hidden_dim = self._maybe_pad_hidden_states(
             shared_experts_input,
             hidden_states,
         )
+        hidden_dim_was_padded = hidden_states.shape[-1] > routed_hidden_dim
 
         result = self._forward_entry(
             hidden_states,
@@ -573,6 +577,8 @@ class MoERunner(MoERunnerInterface):
 
         # Extract outputs from result
         shared_output, fused_output = _unpack(result)
+        if hidden_dim_was_padded:
+            fused_output = fused_output[..., :routed_hidden_dim]
 
         # If combine kernel already reduced fused, reduce shared to match.
         # See note above re: the two all-reduce points.


### PR DESCRIPTION
Fixes https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-NVFP4.

FI TRTLLM NVFP4 MoE can pad the routed hidden dim, e.g. `2688 -> 2816`, via `align_trtllm_fp4_moe_hidden_dim_for_fi`.

Before #35949, `FusedMoE` returned routed and shared outputs separately. The routed output was truncated back to the original hidden dim before model code added the shared expert output, so the world looked like:

```text
routed kernel output: [tokens, 2816] -> truncate -> [tokens, 2688]
shared output:        [tokens, 2688]
add:                  [tokens, 2688] + [tokens, 2688]
```

#35949 moved the shared/routed add into `MoERunner`. That changed the order to add first and truncate later:

```text
routed kernel output: [tokens, 2816]
shared output:        [tokens, 2688]
add:                  [tokens, 2816] + [tokens, 2688]
```

Dynamo catches this during fake tensor tracing as a shape mismatch.

This PR records the routed hidden dim before `_maybe_pad_hidden_states()` and trims the fused routed output back to that dim before shared expert addition.

`DailyOmni` is on par for nano-v3-omni before and after this pr.