### PR TITLE
[Tracing] Add cache read tokens, finish reasons, and new standard OTel attributes

### DIFF
--- a/tests/v1/tracing/test_tracing.py
+++ b/tests/v1/tracing/test_tracing.py
@@ -89,9 +89,16 @@ def test_traces(
             assert attributes.get(SpanAttributes.GEN_AI_USAGE_PROMPT_TOKENS) == len(
                 outputs[0].prompt_token_ids
             )
+            assert attributes.get(SpanAttributes.GEN_AI_USAGE_INPUT_TOKENS) == len(
+                outputs[0].prompt_token_ids
+            )
             completion_tokens = sum(len(o.token_ids) for o in outputs[0].outputs)
             assert (
                 attributes.get(SpanAttributes.GEN_AI_USAGE_COMPLETION_TOKENS)
+                == completion_tokens
+            )
+            assert (
+                attributes.get(SpanAttributes.GEN_AI_USAGE_OUTPUT_TOKENS)
                 == completion_tokens
             )
 

--- a/tests/v1/tracing/test_tracing.py
+++ b/tests/v1/tracing/test_tracing.py
@@ -98,6 +98,7 @@ def test_traces(
             assert attributes.get(SpanAttributes.GEN_AI_LATENCY_TIME_IN_QUEUE) > 0
             assert attributes.get(SpanAttributes.GEN_AI_LATENCY_TIME_TO_FIRST_TOKEN) > 0
             assert attributes.get(SpanAttributes.GEN_AI_LATENCY_E2E) > 0
+            assert SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS in attributes
         finally:
             if llm is not None:
                 shutdown_timeout = 60.0 if current_platform.is_rocm() else 5.0

--- a/vllm/tracing/utils.py
+++ b/vllm/tracing/utils.py
@@ -21,12 +21,16 @@ class SpanAttributes:
     """
 
     # Attribute names copied from OTel semantic conventions to avoid version conflicts
-    GEN_AI_USAGE_COMPLETION_TOKENS = "gen_ai.usage.completion_tokens"
-    GEN_AI_USAGE_PROMPT_TOKENS = "gen_ai.usage.prompt_tokens"
+    # Deprecated fields: https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/
+    GEN_AI_USAGE_COMPLETION_TOKENS = "gen_ai.usage.completion_tokens"  # deprecated
+    GEN_AI_USAGE_OUTPUT_TOKENS = "gen_ai.usage.output_tokens"
+    GEN_AI_USAGE_PROMPT_TOKENS = "gen_ai.usage.prompt_tokens"  # deprecated
+    GEN_AI_USAGE_INPUT_TOKENS = "gen_ai.usage.input_tokens"
     GEN_AI_REQUEST_MAX_TOKENS = "gen_ai.request.max_tokens"
     GEN_AI_REQUEST_TOP_P = "gen_ai.request.top_p"
     GEN_AI_REQUEST_TEMPERATURE = "gen_ai.request.temperature"
     GEN_AI_RESPONSE_MODEL = "gen_ai.response.model"
+    GEN_AI_RESPONSE_FINISH_REASONS = "gen_ai.response.finish_reasons"
 
     # Custom attributes added until they are standardized
     GEN_AI_REQUEST_ID = "gen_ai.request.id"

--- a/vllm/tracing/utils.py
+++ b/vllm/tracing/utils.py
@@ -32,6 +32,7 @@ class SpanAttributes:
     GEN_AI_REQUEST_ID = "gen_ai.request.id"
     GEN_AI_REQUEST_N = "gen_ai.request.n"
     GEN_AI_USAGE_NUM_SEQUENCES = "gen_ai.usage.num_sequences"
+    GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS = "gen_ai.usage.cache_read.input_tokens"
     GEN_AI_LATENCY_TIME_IN_QUEUE = "gen_ai.latency.time_in_queue"
     GEN_AI_LATENCY_TIME_TO_FIRST_TOKEN = "gen_ai.latency.time_to_first_token"
     GEN_AI_LATENCY_E2E = "gen_ai.latency.e2e"

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -758,6 +758,9 @@ class OutputProcessor:
             SpanAttributes.GEN_AI_USAGE_COMPLETION_TOKENS: (
                 metrics.num_generation_tokens
             ),
+            SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS: (
+                req_state.num_cached_tokens
+            ),
             SpanAttributes.GEN_AI_LATENCY_TIME_IN_MODEL_PREFILL: prefill_time,
             SpanAttributes.GEN_AI_LATENCY_TIME_IN_MODEL_DECODE: decode_time,
             SpanAttributes.GEN_AI_LATENCY_TIME_IN_MODEL_INFERENCE: inference_time,

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -700,7 +700,12 @@ class OutputProcessor:
                         req_state, finish_reason, iteration_stats
                     )
                     if self.tracing_enabled:
-                        self.do_tracing(engine_core_output, req_state, iteration_stats)
+                        self.do_tracing(
+                            engine_core_output,
+                            req_state,
+                            iteration_stats,
+                            finish_reason,
+                        )
 
         return OutputProcessorOutput(
             request_outputs=request_outputs,
@@ -729,6 +734,7 @@ class OutputProcessor:
         engine_core_output: EngineCoreOutput,
         req_state: RequestState,
         iteration_stats: IterationStats | None,
+        finish_reason: FinishReason | None,
     ) -> None:
         assert req_state.stats is not None
         assert iteration_stats is not None
@@ -755,9 +761,11 @@ class OutputProcessor:
             SpanAttributes.GEN_AI_LATENCY_E2E: e2e_time,
             SpanAttributes.GEN_AI_LATENCY_TIME_IN_QUEUE: queued_time,
             SpanAttributes.GEN_AI_USAGE_PROMPT_TOKENS: prompt_length,
+            SpanAttributes.GEN_AI_USAGE_INPUT_TOKENS: prompt_length,
             SpanAttributes.GEN_AI_USAGE_COMPLETION_TOKENS: (
                 metrics.num_generation_tokens
             ),
+            SpanAttributes.GEN_AI_USAGE_OUTPUT_TOKENS: (metrics.num_generation_tokens),
             SpanAttributes.GEN_AI_USAGE_CACHE_READ_INPUT_TOKENS: (
                 req_state.num_cached_tokens
             ),
@@ -765,6 +773,11 @@ class OutputProcessor:
             SpanAttributes.GEN_AI_LATENCY_TIME_IN_MODEL_DECODE: decode_time,
             SpanAttributes.GEN_AI_LATENCY_TIME_IN_MODEL_INFERENCE: inference_time,
             SpanAttributes.GEN_AI_REQUEST_ID: req_state.external_req_id,
+            SpanAttributes.GEN_AI_RESPONSE_FINISH_REASONS: (
+                # Note: Only supports n=1. For n>1, each completion would have
+                # its own finish reason that should be collected separately.
+                [finish_reason.name.lower()] if finish_reason else []
+            ),
         }
 
         # Add optional request parameters


### PR DESCRIPTION
## Purpose

### 1. Add `gen_ai.usage.cache_read.input_tokens` attribute

The current OpenTelemetry trace only exposes `gen_ai.usage.prompt_tokens` (total prompt tokens) but not the number of cached tokens. When analyzing `gen_ai.latency.time_in_model_prefill` latency, the total prefill token count alone is insufficient. The cache hit rate must also be considered. By adding the `gen_ai.usage.cache_read.input_tokens` attribute, users can directly obtain the number of tokens served from cache, enabling better evaluation of cache impact on prefill performance.

**Related OpenTelemetry semantic convention**: [gen_ai.usage.cache_read.input_tokens](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/) -- "The number of input tokens served from a provider-managed cache."

### 2. Add `gen_ai.response.finish_reasons` attribute

The current trace lacks request finish reasons (stop / length / truncated). This attribute follows the OTel standard convention and facilitates request completion analysis.

### 3. Update deprecated fields

According to the [OpenTelemetry semantic conventions](https://opentelemetry.io/docs/specs/semconv/registry/attributes/gen-ai/), the following fields are deprecated:

| Deprecated field | New standard field |
|---|---|
| `gen_ai.usage.completion_tokens` | `gen_ai.usage.output_tokens` |
| `gen_ai.usage.prompt_tokens` | `gen_ai.usage.input_tokens` |

This PR marks the deprecated OpenTelemetry fields with deprecation comments, which can be considered for removal in future releases. For backward compatibility, only the new standard fields are added; the old fields are left untouched.

---

## Changes

- Report `gen_ai.usage.cache_read.input_tokens` in trace spans
- Report `gen_ai.response.finish_reasons` in trace spans
- Add new standard fields (`gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`)
- Mark deprecated fields with deprecation comments (old fields kept for backward compatibility)
- Add assertions in tracing tests for the new attributes

---

## Test Plan

```bash
pytest tests/v1/tracing/test_tracing.py -v
```

## Test Result

Tests passed. All new attributes (gen_ai.usage.cache_read.input_tokens, gen_ai.response.finish_reasons, gen_ai.usage.input_tokens, gen_ai.usage.output_tokens) are confirmed present in trace spans.