### PR TITLE
[Test]add pytest.mark.device_type for hardcoded device strings refactoring

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ markers = [
     "hybrid_model: models that contain mamba layers (including pure SSM and hybrid architectures)",
     "cpu_model: enable this model test in CPU tests",
     "cpu_test: mark test as CPU-only test",
+    "device_type: mark test to run on a specific hardware platform (e.g., cuda, rocm, mps)",
     "split: run this test as part of a split",
     "distributed: run this test only in distributed GPU tests",
     "optional: optional tests that are automatically skipped, include --optional to run them",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -305,6 +305,23 @@ def dynamo_reset():
     torch._dynamo.reset()
 
 
+@pytest.fixture(autouse=True)
+def set_default_device_from_mark(request):
+    # Retrieve the 'device_type' marker if it exists on the test function
+    marker = request.node.get_closest_marker("device_type")
+
+    if marker:
+        # The first argument passed to the marker (e.g., 'cuda' or 'cpu')
+        device = marker.args[0]
+
+        # Set the default device context for the duration of the test
+        with torch.device(device):
+            yield
+    else:
+        # Standard execution if no marker is found
+        yield
+
+
 @pytest.fixture
 def example_prompts() -> list[str]:
     return [prompt for filename in _TEST_PROMPTS for prompt in _read_prompts(filename)]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -311,6 +311,9 @@ def set_default_device_from_mark(request):
     marker = request.node.get_closest_marker("device_type")
 
     if marker:
+        if not marker.args:
+            yield
+            return
         # The first argument passed to the marker (e.g., 'cuda' or 'cpu')
         device = marker.args[0]
 

--- a/tests/lora/test_moe_lora_align_sum.py
+++ b/tests/lora/test_moe_lora_align_sum.py
@@ -9,6 +9,7 @@ from vllm import _custom_ops as ops
 from vllm.platforms import current_platform
 
 DEVICE_TYPE = current_platform.device_type
+pytestmark = pytest.mark.device_type(DEVICE_TYPE)
 
 
 def round_up(x, base):
@@ -30,7 +31,7 @@ def sample_data(num_experts, max_loras, num_tokens, topk_num):
             topk_ids[i, j] = pool[j]
         token_lora_mapping[i] = random.randint(0, max_loras - 1)
 
-    return topk_ids.to(DEVICE_TYPE), token_lora_mapping.to(DEVICE_TYPE)
+    return topk_ids, token_lora_mapping
 
 
 @pytest.mark.parametrize("num_tokens", [100, 200, 1024, 4096])  # 81920
@@ -59,21 +60,15 @@ def test_moe_lora_align_block_size(
         (max_loras * max_num_tokens_padded,),
         topk_ids.numel(),
         dtype=torch.int32,
-        device=DEVICE_TYPE,
     )
     expert_ids = torch.full(
         (max_loras * max_num_m_blocks,),
         num_experts,
         dtype=torch.int32,
-        device=DEVICE_TYPE,
     )
-    num_tokens_post_pad = torch.zeros(
-        (max_loras,), dtype=torch.int32, device=DEVICE_TYPE
-    )
-    adapter_enabled = torch.ones(
-        (max_loras + 1,), dtype=torch.int32, device=DEVICE_TYPE
-    )
-    lora_ids = torch.arange(max_loras + 2, dtype=torch.int32, device=DEVICE_TYPE)
+    num_tokens_post_pad = torch.zeros((max_loras,), dtype=torch.int32)
+    adapter_enabled = torch.ones((max_loras + 1,), dtype=torch.int32)
+    lora_ids = torch.arange(max_loras + 2, dtype=torch.int32)
 
     # call kernel
     ops.moe_lora_align_block_size(
@@ -152,9 +147,6 @@ def _build_and_run_align(
         for j in range(topk_num):
             topk_ids[i, j] = pool[j]
         token_lora_mapping[i] = 0 if i < num_lora_tokens else -1
-    topk_ids = topk_ids.to(DEVICE_TYPE)
-    token_lora_mapping = token_lora_mapping.to(DEVICE_TYPE)
-
     max_num_tokens_padded = topk_ids.numel() + num_experts * (block_size - 1)
     max_num_tokens_padded = round_up(max_num_tokens_padded, block_size)
     if topk_ids.numel() < num_experts:
@@ -162,18 +154,14 @@ def _build_and_run_align(
     max_num_m_blocks = CEILDIV(max_num_tokens_padded, block_size)
 
     if lora_ids_override is None:
-        lora_ids = torch.full(
-            (max_loras + 1,), -1, dtype=torch.int32, device=DEVICE_TYPE
-        )
+        lora_ids = torch.full((max_loras + 1,), -1, dtype=torch.int32)
         unique_ids = torch.unique(token_lora_mapping, sorted=True)
         lora_ids[: unique_ids.numel()] = unique_ids.to(torch.int32)
     else:
         assert lora_ids_override.numel() == max_loras + 1
-        lora_ids = lora_ids_override.to(dtype=torch.int32, device=DEVICE_TYPE)
+        lora_ids = lora_ids_override.to(dtype=torch.int32)
 
-    adapter_enabled = torch.ones(
-        (max_loras + 1,), dtype=torch.int32, device=DEVICE_TYPE
-    )
+    adapter_enabled = torch.ones((max_loras + 1,), dtype=torch.int32)
     for slot in disabled_slots:
         adapter_enabled[slot] = 0
 
@@ -181,16 +169,14 @@ def _build_and_run_align(
         (max_loras * max_num_tokens_padded,),
         SENTINEL_TOKEN,
         dtype=torch.int32,
-        device=DEVICE_TYPE,
     )
     expert_ids = torch.full(
         (max_loras * max_num_m_blocks,),
         SENTINEL_EXPERT,
         dtype=torch.int32,
-        device=DEVICE_TYPE,
     )
     num_tokens_post_pad = torch.full(
-        (max_loras,), SENTINEL_NPAD, dtype=torch.int32, device=DEVICE_TYPE
+        (max_loras,), SENTINEL_NPAD, dtype=torch.int32
     )
 
     ops.moe_lora_align_block_size(

--- a/tests/lora/test_moe_lora_align_sum.py
+++ b/tests/lora/test_moe_lora_align_sum.py
@@ -175,9 +175,7 @@ def _build_and_run_align(
         SENTINEL_EXPERT,
         dtype=torch.int32,
     )
-    num_tokens_post_pad = torch.full(
-        (max_loras,), SENTINEL_NPAD, dtype=torch.int32
-    )
+    num_tokens_post_pad = torch.full((max_loras,), SENTINEL_NPAD, dtype=torch.int32)
 
     ops.moe_lora_align_block_size(
         topk_ids,

--- a/tests/models/test_deepseek_v4_mega_moe.py
+++ b/tests/models/test_deepseek_v4_mega_moe.py
@@ -13,6 +13,8 @@ from vllm.models.deepseek_v4.nvidia.model import (
 from vllm.models.deepseek_v4.nvidia.ops.prepare_megamoe import prepare_megamoe_inputs
 from vllm.platforms import current_platform
 
+DEVICE_TYPE = current_platform.device_type
+
 pytestmark = pytest.mark.skipif(
     not current_platform.is_cuda(),
     reason="DeepSeek V4 MegaMoE requires CUDA",
@@ -110,10 +112,11 @@ def test_deepseek_v4_mega_moe_weight_loader_uses_ep_expert_ownership():
     not torch.cuda.is_available(),
     reason="DeepSeek V4 MegaMoE fused input staging requires CUDA.",
 )
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_deepseek_v4_mega_moe_fused_input_staging_is_bitwise_exact():
     from vllm.third_party.deep_gemm.utils import per_token_cast_to_fp8
 
-    device = torch.device("cuda")
+    device = torch.device(DEVICE_TYPE)
     num_tokens = 7
     hidden_size = 256
     top_k = 8

--- a/tests/quantization/test_fp8.py
+++ b/tests/quantization/test_fp8.py
@@ -238,6 +238,7 @@ def test_online_quant_load_format_dummy(
     reason="FP8 is not supported on this GPU type.",
 )
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_scaled_fp8_quant(dtype) -> None:
     def quantize_ref(tensor, inv_scale):
         # The reference implementation that fully aligns to
@@ -255,7 +256,7 @@ def test_scaled_fp8_quant(dtype) -> None:
 
     # Note that we use a shape % 4 != 0 to cover edge cases,
     # because scaled_fp8_quant is vectorized by 4.
-    x = (torch.randn(size=(11, 11), device=DEVICE_TYPE) * 13).to(dtype)
+    x = (torch.randn(size=(11, 11)) * 13).to(dtype)
 
     # Dynamic quantization
     ref_y, inv_scale = ops.scaled_fp8_quant(x, None)
@@ -279,9 +280,7 @@ def test_scaled_fp8_quant(dtype) -> None:
 
     # non-contiguous input with padding
     m, n, padded_stride = 975, 512, 576
-    padded_tensor = (torch.randn(size=(m, padded_stride), device=DEVICE_TYPE) * 13).to(
-        dtype
-    )
+    padded_tensor = (torch.randn(size=(m, padded_stride)) * 13).to(dtype)
     x_nc = padded_tensor[:, :n]  # shape (m, n) with stride (padded_stride, 1)
 
     assert not x_nc.is_contiguous()

--- a/tests/quantization/test_fp8_per_channel.py
+++ b/tests/quantization/test_fp8_per_channel.py
@@ -32,6 +32,8 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 )
 from vllm.platforms import current_platform
 
+DEVICE_TYPE = current_platform.device_type
+
 
 def test_fp8_per_channel_shorthand_registered() -> None:
     """The `fp8_per_channel` CLI shorthand must resolve to a config that
@@ -56,12 +58,13 @@ def test_fp8_per_channel_shorthand_registered() -> None:
     not is_quant_method_supported("fp8"),
     reason="FP8 is not supported on this GPU type.",
 )
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_scaled_fp8_quant_per_channel_shape() -> None:
     """Verify the kernel call per-channel quant depends on: passing a 2D
     weight to `ops.scaled_fp8_quant` with `use_per_token_if_dynamic=True`
     yields one scale per output row -- a [N, 1] fp32 tensor.
     """
-    x = (torch.randn(size=(96, 256), device="cuda") * 13).to(torch.bfloat16)
+    x = (torch.randn(size=(96, 256)) * 13).to(torch.bfloat16)
     y, s = ops.scaled_fp8_quant(x, scale=None, use_per_token_if_dynamic=True)
     assert y.shape == (96, 256)
     assert y.dtype == current_platform.fp8_dtype()

--- a/tests/quantization/test_quark.py
+++ b/tests/quantization/test_quark.py
@@ -362,11 +362,12 @@ def test_mxfp4_gsm8k_correctness(config: AccuracyTestConfig):
 )
 @pytest.mark.parametrize("float_dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("scalings", [[2.3, 0.03, 7.3, 0.1, 0.004, 17.3, 1e4, 1e-4]])
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_mxfp4_fused_qdq_match_quark(float_dtype: torch.dtype, scalings: list[int]):
     torch.manual_seed(0)
 
     hidden_size = 64 * 32
-    inp = (torch.rand(1, hidden_size, dtype=float_dtype, device=DEVICE_TYPE) - 0.5) * 2
+    inp = (torch.rand(1, hidden_size, dtype=float_dtype) - 0.5) * 2
     for i in range(hidden_size // 32):
         inp[:, i * 32 : (i + 1) * 32] = (
             inp[:, i * 32 : (i + 1) * 32] * scalings[i % len(scalings)]
@@ -393,6 +394,7 @@ def test_mxfp4_fused_qdq_match_quark(float_dtype: torch.dtype, scalings: list[in
 )
 @pytest.mark.parametrize("float_dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.parametrize("scalings", [[2.3, 0.03, 7.3, 0.1, 0.004, 17.3, 1e4, 1e-4]])
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_mxfp4_dequant_kernel_match_quark(
     float_dtype: torch.dtype, scalings: list[int]
 ):
@@ -418,7 +420,7 @@ def test_mxfp4_dequant_kernel_match_quark(
     hidden_size = 512
     shape = (11008, hidden_size)
 
-    w = (torch.rand(shape, device=DEVICE_TYPE, dtype=float_dtype) - 0.5) * 2
+    w = (torch.rand(shape, dtype=float_dtype) - 0.5) * 2
 
     # Make it so that different groups have different scales.
     for i in range(hidden_size // 32):
@@ -430,7 +432,7 @@ def test_mxfp4_dequant_kernel_match_quark(
     scale, _ = observer._calculate_qparams()
     weight_quantizer.scale = scale
 
-    w_mxfp4 = weight_quantizer.to_real_quantize_params(w).to(DEVICE_TYPE)
+    w_mxfp4 = weight_quantizer.to_real_quantize_params(w)
     weight_quantizer.maybe_convert_and_transpose_scale()
 
     scale = weight_quantizer.scale

--- a/tests/v1/cudagraph/test_cudagraph_dispatch.py
+++ b/tests/v1/cudagraph/test_cudagraph_dispatch.py
@@ -269,12 +269,13 @@ class TestCudagraphDispatcher:
 
 
 @pytest.mark.skipif(not current_platform.is_cuda(), reason="Skip if not cuda")
+@pytest.mark.device_type(DEVICE_TYPE)
 class TestCUDAGraphWrapper:
     def setup_method(self):
         self.vllm_config = _create_vllm_config(CompilationConfig())
-        self.model = SimpleMLP().to(DEVICE_TYPE)
-        self.persistent_input_buffer = torch.zeros(1, 10, device=DEVICE_TYPE)
-        self.input_tensor = torch.randn(1, 10, device=DEVICE_TYPE)
+        self.model = SimpleMLP()
+        self.persistent_input_buffer = torch.zeros(1, 10)
+        self.input_tensor = torch.randn(1, 10)
 
     def test_capture_and_replay(self):
         wrapper = CUDAGraphWrapper(

--- a/tests/v1/determinism/test_matmul_batch_invariant.py
+++ b/tests/v1/determinism/test_matmul_batch_invariant.py
@@ -48,15 +48,15 @@ DEVICE_TYPE = current_platform.device_type
     ],
 )
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_matmul_correctness(a_shape, b_shape, dtype):
     """
     Compare matmul_batch_invariant against torch.matmul for various shapes.
     """
-    device = torch.device(DEVICE_TYPE)
 
     torch.manual_seed(42)
-    a = torch.rand(a_shape, dtype=dtype, device=device)
-    b = torch.rand(b_shape, dtype=dtype, device=device)
+    a = torch.rand(a_shape, dtype=dtype)
+    b = torch.rand(b_shape, dtype=dtype)
 
     # Standard implementation (CUDA ops)
     standard_output = torch.matmul(a, b)
@@ -82,21 +82,20 @@ def test_matmul_correctness(a_shape, b_shape, dtype):
 
 @skip_unsupported
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_matmul_batch_invariance(dtype):
     """
     Verify that the result for one item is bitwise identical regardless
     of what other items are in the batch.
     """
 
-    device = torch.device(DEVICE_TYPE)
-
     torch.manual_seed(42)
-    a_single = torch.rand((1, 64, 32), dtype=dtype, device=device)
-    b = torch.rand((32, 128), dtype=dtype, device=device)
+    a_single = torch.rand((1, 64, 32), dtype=dtype)
+    b = torch.rand((32, 128), dtype=dtype)
 
     standard_output = matmul_batch_invariant(a_single, b)
 
-    a_batch = torch.rand((8, 64, 32), dtype=dtype, device=device)
+    a_batch = torch.rand((8, 64, 32), dtype=dtype)
     a_batch[3] = a_single[0]
 
     batch_output = matmul_batch_invariant(a_batch, b)

--- a/tests/v1/determinism/test_nvfp4_batch_invariant_scaled_mm.py
+++ b/tests/v1/determinism/test_nvfp4_batch_invariant_scaled_mm.py
@@ -32,6 +32,7 @@ DTYPES = [torch.float16, torch.bfloat16]
 SHAPES = [(128, 128, 64), (128, 128, 128), (256, 128, 64), (128, 256, 128)]
 PAD_SHAPES = [(150, 128, 64), (128, 128, 96)]
 SHAPES.extend(PAD_SHAPES)
+DEVICE_TYPE = current_platform.device_type
 
 
 CONSISTENCY_SHAPES = [
@@ -48,6 +49,7 @@ CONSISTENCY_SHAPES = [
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("shape", CONSISTENCY_SHAPES)
 @torch.inference_mode()
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_nvfp4_gemm_batch_invariance(
     dtype: torch.dtype,
     shape: tuple[int, int, int],
@@ -64,8 +66,8 @@ def test_nvfp4_gemm_batch_invariance(
     m, n, packed_k = shape
     k = packed_k * 2  # real K (FP4 elements)
 
-    a_dtype = torch.randn((m, k), dtype=dtype, device="cuda")
-    b_dtype = torch.randn((n, k), dtype=dtype, device="cuda")
+    a_dtype = torch.randn((m, k), dtype=dtype)
+    b_dtype = torch.randn((n, k), dtype=dtype)
 
     a_global_scale = get_nvfp4_global_scale(a_dtype)
     b_global_scale = get_nvfp4_global_scale(b_dtype)

--- a/tests/v1/determinism/test_rms_norm_batch_invariant.py
+++ b/tests/v1/determinism/test_rms_norm_batch_invariant.py
@@ -25,6 +25,7 @@ DEVICE_TYPE = current_platform.device_type
 @pytest.mark.parametrize("hidden_size", [512, 2048, 4096, 8192])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("eps", [1e-6, 1e-5])
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_rms_norm_batch_invariant_vs_standard(
     default_vllm_config,
     batch_size: int,
@@ -39,15 +40,13 @@ def test_rms_norm_batch_invariant_vs_standard(
     equivalent results to the standard CUDA implementation across various
     configurations.
     """
-    device = torch.device(DEVICE_TYPE)
-
     # Create test input and weight
     torch.manual_seed(42)
-    input_tensor = torch.randn(batch_size, hidden_size, dtype=dtype, device=device)
-    weight = torch.randn(hidden_size, dtype=dtype, device=device)
+    input_tensor = torch.randn(batch_size, hidden_size, dtype=dtype)
+    weight = torch.randn(hidden_size, dtype=dtype)
 
     # Standard implementation (CUDA ops)
-    rms_norm_layer = RMSNorm(hidden_size, eps=eps, dtype=dtype).to(device)
+    rms_norm_layer = RMSNorm(hidden_size, eps=eps, dtype=dtype)
     rms_norm_layer.weight.data = weight.clone()
 
     standard_output = rms_norm_layer.forward_cuda(input_tensor)
@@ -77,6 +76,7 @@ def test_rms_norm_batch_invariant_vs_standard(
 @pytest.mark.parametrize("hidden_size", [512, 4096])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
 @pytest.mark.parametrize("eps", [1e-6])
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_fused_add_rms_norm_batch_invariant_residual_path(
     hidden_size: int,
     dtype: torch.dtype,
@@ -85,24 +85,22 @@ def test_fused_add_rms_norm_batch_invariant_residual_path(
     """
     Test the batch-invariant fused residual-add + RMSNorm helper directly.
     """
-    device = torch.device(DEVICE_TYPE)
-
     torch.manual_seed(42)
-    x_single = torch.randn(1, hidden_size, dtype=dtype, device=device)
-    residual_single = torch.randn(1, hidden_size, dtype=dtype, device=device)
-    weight = torch.randn(hidden_size, dtype=dtype, device=device)
+    x_single = torch.randn(1, hidden_size, dtype=dtype)
+    residual_single = torch.randn(1, hidden_size, dtype=dtype)
+    weight = torch.randn(hidden_size, dtype=dtype)
 
     x_batch = torch.cat(
         [
             x_single,
-            torch.randn(3, hidden_size, dtype=dtype, device=device),
+            torch.randn(3, hidden_size, dtype=dtype),
         ],
         dim=0,
     )
     residual_batch = torch.cat(
         [
             residual_single,
-            torch.randn(3, hidden_size, dtype=dtype, device=device),
+            torch.randn(3, hidden_size, dtype=dtype),
         ],
         dim=0,
     )
@@ -170,6 +168,7 @@ def test_fused_add_rms_norm_batch_invariant_residual_path(
 @pytest.mark.parametrize("batch_size", [1, 16, 128])
 @pytest.mark.parametrize("seq_len", [1, 32, 512])
 @pytest.mark.parametrize("hidden_size", [2048, 4096])
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_rms_norm_3d_input(
     default_vllm_config, batch_size: int, seq_len: int, hidden_size: int
 ):
@@ -179,18 +178,17 @@ def test_rms_norm_3d_input(
     Ensures that the batch-invariant RMS norm correctly handles multi-dimensional
     inputs that are common in transformer models.
     """
-    device = torch.device(DEVICE_TYPE)
     dtype = torch.bfloat16
     eps = 1e-6
 
     torch.manual_seed(42)
     input_tensor = torch.randn(
-        batch_size, seq_len, hidden_size, dtype=dtype, device=device
+        batch_size, seq_len, hidden_size, dtype=dtype
     )
-    weight = torch.randn(hidden_size, dtype=dtype, device=device)
+    weight = torch.randn(hidden_size, dtype=dtype)
 
     # Standard implementation
-    rms_norm_layer = RMSNorm(hidden_size, eps=eps, dtype=dtype).to(device)
+    rms_norm_layer = RMSNorm(hidden_size, eps=eps, dtype=dtype)
     rms_norm_layer.weight.data = weight.clone()
     standard_output = rms_norm_layer.forward_cuda(input_tensor)
 
@@ -211,6 +209,7 @@ def test_rms_norm_3d_input(
 
 
 @skip_unsupported
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_rms_norm_numerical_stability(default_vllm_config):
     """
     Test RMS norm numerical stability with extreme values.
@@ -218,7 +217,6 @@ def test_rms_norm_numerical_stability(default_vllm_config):
     Ensures that both implementations handle edge cases like very small or large
     values without producing NaN or Inf.
     """
-    device = torch.device(DEVICE_TYPE)
     dtype = torch.float16
     eps = 1e-6
     hidden_size = 2048
@@ -226,20 +224,20 @@ def test_rms_norm_numerical_stability(default_vllm_config):
     # Test cases with extreme values
     test_cases = [
         # Very small values
-        torch.ones(4, hidden_size, dtype=dtype, device=device) * 1e-5,
+        torch.ones(4, hidden_size, dtype=dtype) * 1e-5,
         # Very large values
-        torch.ones(4, hidden_size, dtype=dtype, device=device) * 1e4,
+        torch.ones(4, hidden_size, dtype=dtype) * 1e4,
         # Mixed small and large
-        torch.randn(4, hidden_size, dtype=dtype, device=device) * 100,
+        torch.randn(4, hidden_size, dtype=dtype) * 100,
         # Values near zero
-        torch.randn(4, hidden_size, dtype=dtype, device=device) * 1e-6,
+        torch.randn(4, hidden_size, dtype=dtype) * 1e-6,
     ]
 
-    weight = torch.ones(hidden_size, dtype=dtype, device=device)
+    weight = torch.ones(hidden_size, dtype=dtype)
 
     for idx, input_tensor in enumerate(test_cases):
         # Standard implementation
-        rms_norm_layer = RMSNorm(hidden_size, eps=eps, dtype=dtype).to(device)
+        rms_norm_layer = RMSNorm(hidden_size, eps=eps, dtype=dtype)
         rms_norm_layer.weight.data = weight.clone()
         standard_output = rms_norm_layer.forward_cuda(input_tensor)
 
@@ -271,20 +269,20 @@ def test_rms_norm_numerical_stability(default_vllm_config):
 
 
 @skip_unsupported
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_rms_norm_formula(default_vllm_config):
     """
     Test that RMS norm follows the correct mathematical formula.
 
     Verifies: output = input / sqrt(mean(input^2) + eps) * weight
     """
-    device = torch.device(DEVICE_TYPE)
     dtype = torch.float32  # Use float32 for higher precision in formula check
     eps = 1e-6
     hidden_size = 1024
 
     torch.manual_seed(42)
-    input_tensor = torch.randn(8, hidden_size, dtype=dtype, device=device)
-    weight = torch.randn(hidden_size, dtype=dtype, device=device)
+    input_tensor = torch.randn(8, hidden_size, dtype=dtype)
+    weight = torch.randn(hidden_size, dtype=dtype)
 
     # Compute expected output using the formula
     variance = (input_tensor.pow(2).mean(dim=-1, keepdim=True)).to(dtype)
@@ -305,6 +303,7 @@ def test_rms_norm_formula(default_vllm_config):
 
 @skip_unsupported
 @pytest.mark.parametrize("hidden_size", [128, 1024, 4096, 16384])
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_rms_norm_different_hidden_sizes(default_vllm_config, hidden_size: int):
     """
     Test RMS norm with various hidden sizes to ensure block size handling.
@@ -312,17 +311,16 @@ def test_rms_norm_different_hidden_sizes(default_vllm_config, hidden_size: int):
     The Triton kernel uses a fixed BLOCK_SIZE=1024, so this tests that it
     correctly handles hidden sizes both smaller and larger than the block size.
     """
-    device = torch.device(DEVICE_TYPE)
     dtype = torch.bfloat16
     eps = 1e-6
     batch_size = 16
 
     torch.manual_seed(42)
-    input_tensor = torch.randn(batch_size, hidden_size, dtype=dtype, device=device)
-    weight = torch.randn(hidden_size, dtype=dtype, device=device)
+    input_tensor = torch.randn(batch_size, hidden_size, dtype=dtype)
+    weight = torch.randn(hidden_size, dtype=dtype)
 
     # Standard implementation
-    rms_norm_layer = RMSNorm(hidden_size, eps=eps, dtype=dtype).to(device)
+    rms_norm_layer = RMSNorm(hidden_size, eps=eps, dtype=dtype)
     rms_norm_layer.weight.data = weight.clone()
     standard_output = rms_norm_layer.forward_cuda(input_tensor)
 
@@ -342,6 +340,7 @@ def test_rms_norm_different_hidden_sizes(default_vllm_config, hidden_size: int):
 
 
 @skip_unsupported
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_rms_norm_determinism(default_vllm_config):
     """
     Test that batch-invariant RMS norm produces deterministic results.
@@ -349,15 +348,14 @@ def test_rms_norm_determinism(default_vllm_config):
     Runs the same input through the kernel multiple times and verifies
     identical outputs.
     """
-    device = torch.device(DEVICE_TYPE)
     dtype = torch.bfloat16
     eps = 1e-6
     hidden_size = 4096
     batch_size = 32
 
     torch.manual_seed(42)
-    input_tensor = torch.randn(batch_size, hidden_size, dtype=dtype, device=device)
-    weight = torch.randn(hidden_size, dtype=dtype, device=device)
+    input_tensor = torch.randn(batch_size, hidden_size, dtype=dtype)
+    weight = torch.randn(hidden_size, dtype=dtype)
 
     # Run multiple times
     outputs = []

--- a/tests/v1/determinism/test_rms_norm_batch_invariant.py
+++ b/tests/v1/determinism/test_rms_norm_batch_invariant.py
@@ -182,9 +182,7 @@ def test_rms_norm_3d_input(
     eps = 1e-6
 
     torch.manual_seed(42)
-    input_tensor = torch.randn(
-        batch_size, seq_len, hidden_size, dtype=dtype
-    )
+    input_tensor = torch.randn(batch_size, seq_len, hidden_size, dtype=dtype)
     weight = torch.randn(hidden_size, dtype=dtype)
 
     # Standard implementation

--- a/tests/v1/e2e/general/test_mamba_prefix_cache.py
+++ b/tests/v1/e2e/general/test_mamba_prefix_cache.py
@@ -73,7 +73,6 @@ def get_fake_sample_fn() -> SamplerOutput:
             return SamplerOutput(
                 sampled_token_ids=torch.tensor(
                     [[prompt_token_ids[first_token_id_index]]],
-                    device=DEVICE_TYPE,
                     dtype=torch.int32,
                 ),
                 logprobs_tensors=None,
@@ -86,7 +85,6 @@ def get_fake_sample_fn() -> SamplerOutput:
         return SamplerOutput(
             sampled_token_ids=torch.tensor(
                 [sampled_token_ids],
-                device=DEVICE_TYPE,
                 dtype=torch.int32,
             ),
             logprobs_tensors=None,
@@ -132,13 +130,11 @@ def get_fake_propose_draft_token_ids_fn():
                 - 1
                 + num_accepted_tokens
             ],
-            device=DEVICE_TYPE,
             dtype=torch.int32,
         )
 
         valid_sampled_tokens_count = torch.tensor(
             [num_accepted_tokens],
-            device=DEVICE_TYPE,
             dtype=torch.int32,
         )
 
@@ -146,7 +142,6 @@ def get_fake_propose_draft_token_ids_fn():
 
         return torch.tensor(
             proposed_draft_token_ids,
-            device=DEVICE_TYPE,
             dtype=torch.int32,
         )
 
@@ -495,6 +490,7 @@ def apply_patch(monkeypatch: pytest.MonkeyPatch):
 
 
 @create_new_process_for_each_test()
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_mamba_prefix_cache(monkeypatch: pytest.MonkeyPatch):
     run_ref_mamba_state_in_subprocess()
     apply_patch(monkeypatch)

--- a/tests/v1/e2e/general/test_mamba_prefix_cache.py
+++ b/tests/v1/e2e/general/test_mamba_prefix_cache.py
@@ -495,7 +495,6 @@ def apply_patch(monkeypatch: pytest.MonkeyPatch):
 
 
 @create_new_process_for_each_test()
-@pytest.mark.device_type(DEVICE_TYPE)
 def test_mamba_prefix_cache(monkeypatch: pytest.MonkeyPatch):
     run_ref_mamba_state_in_subprocess()
     apply_patch(monkeypatch)

--- a/tests/v1/e2e/general/test_mamba_prefix_cache.py
+++ b/tests/v1/e2e/general/test_mamba_prefix_cache.py
@@ -73,6 +73,7 @@ def get_fake_sample_fn() -> SamplerOutput:
             return SamplerOutput(
                 sampled_token_ids=torch.tensor(
                     [[prompt_token_ids[first_token_id_index]]],
+                    device=DEVICE_TYPE,
                     dtype=torch.int32,
                 ),
                 logprobs_tensors=None,
@@ -85,6 +86,7 @@ def get_fake_sample_fn() -> SamplerOutput:
         return SamplerOutput(
             sampled_token_ids=torch.tensor(
                 [sampled_token_ids],
+                device=DEVICE_TYPE,
                 dtype=torch.int32,
             ),
             logprobs_tensors=None,
@@ -130,11 +132,13 @@ def get_fake_propose_draft_token_ids_fn():
                 - 1
                 + num_accepted_tokens
             ],
+            device=DEVICE_TYPE,
             dtype=torch.int32,
         )
 
         valid_sampled_tokens_count = torch.tensor(
             [num_accepted_tokens],
+            device=DEVICE_TYPE,
             dtype=torch.int32,
         )
 
@@ -142,6 +146,7 @@ def get_fake_propose_draft_token_ids_fn():
 
         return torch.tensor(
             proposed_draft_token_ids,
+            device=DEVICE_TYPE,
             dtype=torch.int32,
         )
 
@@ -729,7 +734,6 @@ def test_mamba_prefix_cache(monkeypatch: pytest.MonkeyPatch):
 
     engine = LLM(
         model=MODEL,
-        device="cpu",
         enable_prefix_caching=True,
         block_size=BLOCK_SIZE,
         mamba_cache_mode="align",

--- a/tests/v1/e2e/general/test_mamba_prefix_cache.py
+++ b/tests/v1/e2e/general/test_mamba_prefix_cache.py
@@ -729,6 +729,7 @@ def test_mamba_prefix_cache(monkeypatch: pytest.MonkeyPatch):
 
     engine = LLM(
         model=MODEL,
+        device="cpu",
         enable_prefix_caching=True,
         block_size=BLOCK_SIZE,
         mamba_cache_mode="align",

--- a/tests/v1/spec_decode/test_eagle_step_kernel.py
+++ b/tests/v1/spec_decode/test_eagle_step_kernel.py
@@ -48,21 +48,21 @@ def _reference_eagle_step_slot_mapping(
     return clamped_positions, slot_mapping, new_seq_lens
 
 
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_eagle_step_slot_mapping_kernel():
     """Test fused kernel matches Python reference for slot mapping and metadata."""
-    device = torch.device(DEVICE_TYPE)
     batch_size = 32
     block_size = 16
     max_model_len = 4096
     n_blocks_per_req = (max_model_len + block_size - 1) // block_size
 
     positions_1d = torch.randint(
-        0, max_model_len - 10, (batch_size,), dtype=torch.int64, device=device
+        0, max_model_len - 10, (batch_size,), dtype=torch.int64
     )
     block_table_tensor = torch.randint(
-        0, 1000, (batch_size, n_blocks_per_req), dtype=torch.int32, device=device
+        0, 1000, (batch_size, n_blocks_per_req), dtype=torch.int32
     )
-    seq_lens = torch.randint(1, 100, (batch_size,), dtype=torch.int32, device=device)
+    seq_lens = torch.randint(1, 100, (batch_size,), dtype=torch.int32)
 
     ref_clamped, ref_slot, ref_seq_lens = _reference_eagle_step_slot_mapping(
         positions_1d.clone(),
@@ -72,8 +72,8 @@ def test_eagle_step_slot_mapping_kernel():
         max_model_len,
     )
 
-    out_clamped = torch.zeros(batch_size, dtype=torch.int64, device=device)
-    out_slot = torch.zeros(batch_size, dtype=torch.int64, device=device)
+    out_clamped = torch.zeros(batch_size, dtype=torch.int64)
+    out_slot = torch.zeros(batch_size, dtype=torch.int64)
     seq_lens_copy = seq_lens.clone()
     eagle_step_update_slot_mapping_and_metadata(
         positions_1d=positions_1d,
@@ -94,22 +94,22 @@ def test_eagle_step_slot_mapping_kernel():
     )
 
 
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_eagle_step_slot_mapping_kernel_exceeds_max():
     """Test fused kernel when position exceeds max_model_len."""
-    device = torch.device(DEVICE_TYPE)
     batch_size = 4
     block_size = 16
     max_model_len = 100
     n_blocks_per_req = (max_model_len + block_size - 1) // block_size
 
-    positions_1d = torch.tensor([50, 98, 99, 100], dtype=torch.int64, device=device)
+    positions_1d = torch.tensor([50, 98, 99, 100], dtype=torch.int64)
     block_table_tensor = torch.randint(
-        0, 100, (batch_size, n_blocks_per_req), dtype=torch.int32, device=device
+        0, 100, (batch_size, n_blocks_per_req), dtype=torch.int32
     )
-    seq_lens = torch.tensor([51, 99, 100, 101], dtype=torch.int32, device=device)
+    seq_lens = torch.tensor([51, 99, 100, 101], dtype=torch.int32)
 
-    out_clamped = torch.zeros(batch_size, dtype=torch.int64, device=device)
-    out_slot = torch.zeros(batch_size, dtype=torch.int64, device=device)
+    out_clamped = torch.zeros(batch_size, dtype=torch.int64)
+    out_slot = torch.zeros(batch_size, dtype=torch.int64)
     eagle_step_update_slot_mapping_and_metadata(
         positions_1d=positions_1d,
         block_table_tensor=block_table_tensor,
@@ -130,21 +130,21 @@ def test_eagle_step_slot_mapping_kernel_exceeds_max():
     assert seq_lens[3].item() == 1
 
 
+@pytest.mark.device_type(DEVICE_TYPE)
 def test_eagle_step_slot_mapping_kernel_cudagraph_padding():
     """Test that padding threads write PADDING_SLOT_ID when
     input_batch_size > batch_size (cudagraph padding)."""
-    device = torch.device(DEVICE_TYPE)
     batch_size = 4
     input_batch_size = 8
     block_size = 16
     max_model_len = 4096
     n_blocks_per_req = (max_model_len + block_size - 1) // block_size
 
-    positions_1d = torch.tensor([10, 20, 30, 40], dtype=torch.int64, device=device)
+    positions_1d = torch.tensor([10, 20, 30, 40], dtype=torch.int64)
     block_table_tensor = torch.randint(
-        0, 100, (batch_size, n_blocks_per_req), dtype=torch.int32, device=device
+        0, 100, (batch_size, n_blocks_per_req), dtype=torch.int32
     )
-    seq_lens = torch.tensor([11, 21, 31, 41], dtype=torch.int32, device=device)
+    seq_lens = torch.tensor([11, 21, 31, 41], dtype=torch.int32)
 
     ref_clamped, ref_slot, ref_seq_lens = _reference_eagle_step_slot_mapping(
         positions_1d.clone(),
@@ -154,8 +154,8 @@ def test_eagle_step_slot_mapping_kernel_cudagraph_padding():
         max_model_len,
     )
 
-    out_clamped = torch.zeros(batch_size, dtype=torch.int64, device=device)
-    out_slot = torch.full((input_batch_size,), -999, dtype=torch.int64, device=device)
+    out_clamped = torch.zeros(batch_size, dtype=torch.int64)
+    out_slot = torch.full((input_batch_size,), -999, dtype=torch.int64)
     seq_lens_copy = seq_lens.clone()
     eagle_step_update_slot_mapping_and_metadata(
         positions_1d=positions_1d,


### PR DESCRIPTION

## Purpose
as described in https://github.com/vllm-project/vllm/issues/39871, this is the first pr for it.
In this pr will
1. add marker pytest.mark.device_type
2. register this marker
3. using this decorator and refine the code under tests/v1
## Test Plan
CI
## Test Result
NA
## Limitation
This decorator can not work with the @create_new_process_for_each_test().
It is because vLLM's @create_new_process_for_each_test() forces the execution of the test function inside a completely separate, brand new OS subprocess to ensure CUDA runtime isolation, any process-specific Python state—including PyTorch’s active with torch.device(...) thread-local context wrapper—is completely erased when the new process boots up.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>


