### PR TITLE
[Feature] add mean pool (embed) feature into generate API

### DIFF
--- a/tests/v1/e2e/test_prompt_pooled_accuracy.py
+++ b/tests/v1/e2e/test_prompt_pooled_accuracy.py
@@ -1,0 +1,229 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Accuracy tests for the runner-native return_embed flag.
+
+Compare the runner-native mean-pool (opted-in via
+``SamplingParams.extra_args["return_embed"] = True``) against vLLM's own
+``embed`` task with ``pooling_type="MEAN"``, which mean-pools the same
+hidden states through the standard pooler path. Both paths
+should agree within bf16 precision.
+
+Also exercises LoRA: the runner-native pool reads hidden states
+that already include LoRA deltas, so it should match the embed task with
+the same adapter applied.
+"""
+
+import gc
+
+import pytest
+import torch
+
+from vllm import LLM, SamplingParams
+from vllm.lora.request import LoRARequest
+
+LLAMA_MODEL = "meta-llama/Llama-3.2-3B-Instruct"
+QWEN_MODEL = "Qwen/Qwen3-0.6B"
+LLAMA_LORA_PATH = "jeeejeee/llama32-3b-text2sql-spider"
+
+
+pytestmark = pytest.mark.skipif(
+    not (hasattr(torch, "accelerator") and torch.accelerator.is_available()),
+    reason="Accelerator (CUDA) required",
+)
+
+
+def _opt_in(max_tokens: int = 8) -> SamplingParams:
+    return SamplingParams(
+        temperature=0.0,
+        max_tokens=max_tokens,
+        extra_args={"return_embed": True},
+    )
+
+
+def _embedding(out) -> list[float] | None:
+    if out.kv_transfer_params is None:
+        return None
+    return out.kv_transfer_params.get("embed")
+
+
+def _get_vllm_mean_pooled_embeddings(
+    model_name: str,
+    prompts: list[str],
+    lora_path: str | None = None,
+    max_lora_rank: int = 8,
+) -> list[torch.Tensor]:
+    """Run vLLM's embed task with MEAN pooling as a reference.
+
+    The runner-native pool and the embed task both operate on the same
+    hidden states from ``LlamaForCausalLM`` / ``Qwen3ForCausalLM``,
+    so their mean-pooled outputs should match (modulo dtype precision).
+    """
+    llm_kwargs: dict = {}
+    lora_request = None
+    if lora_path is not None:
+        llm_kwargs["enable_lora"] = True
+        llm_kwargs["max_loras"] = 1
+        llm_kwargs["max_lora_rank"] = max_lora_rank
+
+    llm = LLM(
+        model=model_name,
+        runner="pooling",
+        convert="embed",
+        pooler_config={
+            "pooling_type": "MEAN",
+            "use_activation": False,
+        },
+        max_model_len=128,
+        enforce_eager=True,
+        dtype="bfloat16",
+        gpu_memory_utilization=0.45,
+        **llm_kwargs,
+    )
+    if lora_path is not None:
+        lora_request = LoRARequest("ref_lora", 1, lora_path)
+        llm.llm_engine.add_lora(lora_request)
+
+    outputs = llm.embed(prompts, lora_request=lora_request, use_tqdm=False)
+    embeddings = [torch.tensor(o.outputs.embedding) for o in outputs]
+    del llm
+    gc.collect()
+    torch.accelerator.empty_cache()
+    return embeddings
+
+
+def _get_runner_native_embeddings(
+    model_name: str,
+    prompts: list[str],
+    lora_path: str | None = None,
+    max_lora_rank: int = 8,
+    max_tokens: int = 8,
+) -> list[list[float]]:
+    """Run the generate task with ``return_embed`` opted in."""
+    llm_kwargs: dict = {}
+    lora_request = None
+    if lora_path is not None:
+        llm_kwargs["enable_lora"] = True
+        llm_kwargs["max_loras"] = 1
+        llm_kwargs["max_lora_rank"] = max_lora_rank
+
+    llm = LLM(
+        model=model_name,
+        max_model_len=128,
+        enforce_eager=True,
+        dtype="bfloat16",
+        gpu_memory_utilization=0.45,
+        enable_return_embed=True,
+        **llm_kwargs,
+    )
+    if lora_path is not None:
+        lora_request = LoRARequest("text2sql", 1, lora_path)
+        llm.llm_engine.add_lora(lora_request)
+
+    outputs = llm.generate(
+        prompts,
+        _opt_in(max_tokens=max_tokens),
+        lora_request=lora_request,
+        use_tqdm=False,
+    )
+    pooled = []
+    for o in outputs:
+        emb = _embedding(o)
+        assert emb is not None, "expected 'embed' in kv_transfer_params"
+        pooled.append(emb)
+    del llm
+    gc.collect()
+    torch.accelerator.empty_cache()
+    return pooled
+
+
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        LLAMA_MODEL,
+        QWEN_MODEL,
+    ],
+)
+@torch.inference_mode()
+def test_runner_pool_accuracy_vs_embed_task(model_name: str):
+    """Compare runner-native mean-pool against vLLM's embed-task MEAN pooler.
+
+    The runner accumulates hidden states for prompt tokens and
+    divides by ``prompt_len``. The embed task applies ``MeanPool`` to the
+    same hidden states. Outputs should match within bf16 precision.
+    """
+    prompts = [
+        "The quick brown fox jumps over the lazy dog.",
+        "Machine learning is a subset of artificial intelligence.",
+    ]
+
+    # Reference: vLLM embed task with MEAN pooling.
+    embed_results = _get_vllm_mean_pooled_embeddings(model_name, prompts)
+
+    # System under test: generate task with return_embed opted in.
+    runner_results = _get_runner_native_embeddings(model_name, prompts)
+
+    assert len(runner_results) == len(prompts)
+
+    for i, (pooled_list, ref) in enumerate(zip(runner_results, embed_results)):
+        runner_pooled = torch.tensor(pooled_list)
+        assert runner_pooled.shape == ref.shape, (
+            f"Prompt {i}: shape mismatch: "
+            f"runner {runner_pooled.shape} vs embed {ref.shape}"
+        )
+
+        cos_sim = torch.nn.functional.cosine_similarity(
+            runner_pooled.float().unsqueeze(0),
+            ref.float().unsqueeze(0),
+        ).item()
+        assert cos_sim > 0.999, (
+            f"Prompt {i} ({model_name}): cosine similarity {cos_sim:.6f} "
+            f"below threshold 0.999."
+        )
+
+
+@torch.inference_mode()
+def test_runner_pool_with_lora_vs_embed_task():
+    """Compare LoRA-applied runner-native pool against LoRA-applied embed.
+
+    Same comparison as ``test_runner_pool_accuracy_vs_embed_task`` but with
+    the ``jeeejeee/llama32-3b-text2sql-spider`` adapter applied to every
+    request on both sides. Confirms the runner-native pool reflects
+    LoRA-modified hidden states and matches the standard MeanPool pooler
+    when LoRA is active.
+    """
+    hidden_size = 3072  # Llama-3.2-3B-Instruct
+    prompts = [
+        "Translate to SQL: list the names of all employees.",
+        "Translate to SQL: count the number of orders per customer.",
+    ]
+
+    # Reference: vLLM embed task with MEAN pooling, LoRA applied.
+    embed_results = _get_vllm_mean_pooled_embeddings(
+        LLAMA_MODEL, prompts, lora_path=LLAMA_LORA_PATH, max_lora_rank=8
+    )
+
+    # System under test: generate task with return_embed, LoRA applied.
+    runner_results = _get_runner_native_embeddings(
+        LLAMA_MODEL,
+        prompts,
+        lora_path=LLAMA_LORA_PATH,
+        max_lora_rank=8,
+        max_tokens=32,
+    )
+
+    assert len(runner_results) == len(prompts)
+
+    for i, (pooled_list, ref) in enumerate(zip(runner_results, embed_results)):
+        runner_pooled = torch.tensor(pooled_list)
+        assert runner_pooled.shape == (hidden_size,), (
+            f"Prompt {i}: shape {runner_pooled.shape} != ({hidden_size},)"
+        )
+        assert runner_pooled.shape == ref.shape
+
+        cos_sim = torch.nn.functional.cosine_similarity(
+            runner_pooled.float().unsqueeze(0),
+            ref.float().unsqueeze(0),
+        ).item()
+        assert cos_sim > 0.999, (
+            f"Prompt {i}: LoRA cosine similarity {cos_sim:.6f} below 0.999"
+        )

--- a/tests/v1/e2e/test_prompt_pooled_generation.py
+++ b/tests/v1/e2e/test_prompt_pooled_generation.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""End-to-end tests for the return_embed SamplingParams flag."""
+
+import gc
+
+import pytest
+import torch
+
+from vllm import LLM, SamplingParams
+
+MODEL = "meta-llama/Llama-3.2-1B"
+
+
+def _embedding(out) -> list[float] | None:
+    if out.kv_transfer_params is None:
+        return None
+    return out.kv_transfer_params.get("embed")
+
+
+@pytest.fixture(scope="module")
+def llm():
+    """Spin up a single LLM instance per module to avoid repeated init."""
+    if not (hasattr(torch, "accelerator") and torch.accelerator.is_available()):
+        pytest.skip("Accelerator (CUDA) required")
+    inst = LLM(
+        model=MODEL,
+        enforce_eager=True,
+        dtype="bfloat16",
+        max_model_len=512,
+        gpu_memory_utilization=0.45,
+        enable_return_embed=True,
+    )
+    yield inst
+    del inst
+    gc.collect()
+
+
+def _opt_in(max_tokens: int = 8) -> SamplingParams:
+    return SamplingParams(
+        temperature=0.0,
+        max_tokens=max_tokens,
+        extra_args={"return_embed": True},
+    )
+
+
+def _no_opt(max_tokens: int = 8) -> SamplingParams:
+    return SamplingParams(temperature=0.0, max_tokens=max_tokens)
+
+
+def test_pooled_embedding_returned(llm):
+    """Single opted-in request gets an embedding back."""
+    outs = llm.generate(
+        ["The quick brown fox jumps over the lazy dog."],
+        _opt_in(),
+    )
+    emb = _embedding(outs[0])
+    assert emb is not None, "expected 'embed' in kv_transfer_params"
+    hidden_size = llm.llm_engine.model_config.get_hidden_size()
+    assert len(emb) == hidden_size
+    # Sanity: not all zeros, not all NaN.
+    arr = torch.tensor(emb, dtype=torch.float32)
+    assert torch.isfinite(arr).all()
+    assert arr.abs().sum().item() > 0
+
+
+def test_no_opt_in_no_embedding(llm):
+    """Non-opted-in request has no embedding (kv_transfer_params should
+    not contain the key)."""
+    outs = llm.generate(["Hello world."], _no_opt())
+    emb = _embedding(outs[0])
+    assert emb is None
+
+
+def test_mixed_batch(llm):
+    """Mixing opted-in and non-opted-in requests in a single generate
+    call: only the opted-in one gets an embedding."""
+    prompts = [
+        "Opted-in: capital of France?",
+        "Not opted-in: capital of Germany?",
+    ]
+    params = [_opt_in(), _no_opt()]
+    outs = llm.generate(prompts, params)
+    assert _embedding(outs[0]) is not None
+    assert _embedding(outs[1]) is None
+
+
+def test_embedding_deterministic(llm):
+    """Same prompt twice gives the same embedding (up to fp drift)."""
+    prompt = "vLLM serves transformer models efficiently."
+    outs1 = llm.generate([prompt], _opt_in())
+    outs2 = llm.generate([prompt], _opt_in())
+    e1 = torch.tensor(_embedding(outs1[0]), dtype=torch.float32)
+    e2 = torch.tensor(_embedding(outs2[0]), dtype=torch.float32)
+    torch.testing.assert_close(e1, e2, atol=1e-3, rtol=1e-3)
+
+
+def test_prefix_cache_hit_preserves_embedding(llm):
+    """A second request whose prompt extends the first's must produce
+    the right mean even when the shared prefix is served from the prefix
+    cache."""
+    base = "vLLM serves transformer models efficiently. " * 4
+    extension = base + "It also supports prefix caching."
+
+    # First request populates the cache.
+    out_base = llm.generate([base], _opt_in())
+    e_base = _embedding(out_base[0])
+    assert e_base is not None
+
+    # Cold reference for the extension (run before the cache contains
+    # extension's prefix sums — but base's blocks are now in the cache,
+    # so this run will hit them).
+    out_ext_warm = llm.generate([extension], _opt_in())
+    e_ext_warm = _embedding(out_ext_warm[0])
+    assert e_ext_warm is not None
+
+    # Run extension again: this time both base AND extension's full
+    # prompt may be in the cache. Should still match.
+    out_ext_again = llm.generate([extension], _opt_in())
+    e_ext_again = _embedding(out_ext_again[0])
+    assert e_ext_again is not None
+
+    e1 = torch.tensor(e_ext_warm, dtype=torch.float32)
+    e2 = torch.tensor(e_ext_again, dtype=torch.float32)
+    torch.testing.assert_close(e1, e2, atol=1e-3, rtol=1e-3)

--- a/tests/v1/worker/test_aux_pool_state.py
+++ b/tests/v1/worker/test_aux_pool_state.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for AuxPoolState (worker-side prompt mean-pool state)."""
+
+import pytest
+import torch
+
+from vllm.v1.worker.aux_pool_state import AuxPoolState
+
+
+@pytest.fixture
+def device():
+    return torch.device(
+        "cuda"
+        if hasattr(torch, "accelerator") and torch.accelerator.is_available()
+        else "cpu"
+    )
+
+
+@pytest.fixture
+def state(device):
+    s = AuxPoolState(block_size=4, hidden_size=8, device=device)
+    s.enable(num_blocks=16)
+    return s
+
+
+def _hidden(num_tokens: int, hidden_size: int, device, seed: int = 0) -> torch.Tensor:
+    g = torch.Generator(device=device).manual_seed(seed)
+    return torch.randn(num_tokens, hidden_size, device=device, generator=g)
+
+
+def test_single_step_full_prompt(state, device):
+    """A request whose entire prompt is computed in one step gets the
+    correct mean."""
+    prompt_len = 8  # 2 full blocks at block_size=4
+    h = _hidden(prompt_len, 8, device)
+    slot_mapping = torch.arange(prompt_len, dtype=torch.int64, device=device)
+
+    state.init_request(
+        req_id="r0",
+        prompt_len=prompt_len,
+        cached_block_ids=[],
+        num_computed_tokens=0,
+    )
+    state.update_block_sums(slot_mapping, h)
+    pooled = state.update_request("r0", h)
+
+    assert pooled is not None
+    expected = h.float().mean(dim=0)
+    torch.testing.assert_close(pooled, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_chunked_prefill_across_steps(state, device):
+    """Same prompt arriving over multiple steps gives the same final
+    mean as a single-step run."""
+    prompt_len = 12  # 3 full blocks
+    h = _hidden(prompt_len, 8, device, seed=7)
+    slot_mapping = torch.arange(prompt_len, dtype=torch.int64, device=device)
+
+    state.init_request(
+        req_id="r0",
+        prompt_len=prompt_len,
+        cached_block_ids=[],
+        num_computed_tokens=0,
+    )
+    # Step 1: tokens [0..5)
+    state.update_block_sums(slot_mapping[:5], h[:5])
+    out1 = state.update_request("r0", h[:5])
+    assert out1 is None
+    # Step 2: tokens [5..9)
+    state.update_block_sums(slot_mapping[5:9], h[5:9])
+    out2 = state.update_request("r0", h[5:9])
+    assert out2 is None
+    # Step 3: tokens [9..12)
+    state.update_block_sums(slot_mapping[9:], h[9:])
+    out3 = state.update_request("r0", h[9:])
+
+    assert out3 is not None
+    expected = h.float().mean(dim=0)
+    torch.testing.assert_close(out3, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_prefix_cache_reuse_matches_cold(state, device):
+    """Two requests share the first 8 prompt tokens. Request A computes
+    them; request B cache-hits those blocks. B's pooled vector must
+    equal a fresh mean over its full prompt."""
+    block_size = 4
+    a_prompt_len = 8  # 2 full blocks
+    b_prompt_len = 12  # shares 2 blocks with A, plus 4 new tokens
+
+    h_shared = _hidden(8, 8, device, seed=11)
+    h_b_extra = _hidden(4, 8, device, seed=12)
+    h_b_full = torch.cat([h_shared, h_b_extra], dim=0)
+
+    # Request A: blocks 5 and 6 (arbitrary).
+    a_slot = torch.tensor(
+        [5 * block_size + i for i in range(block_size)]
+        + [6 * block_size + i for i in range(block_size)],
+        dtype=torch.int64,
+        device=device,
+    )
+    state.init_request("rA", a_prompt_len, cached_block_ids=[], num_computed_tokens=0)
+    state.update_block_sums(a_slot, h_shared)
+    pooled_a = state.update_request("rA", h_shared)
+    assert pooled_a is not None
+    state.cleanup("rA")
+
+    # Request B: prefix-cache hit on blocks [5, 6]; new block 9 for the
+    # last 4 tokens.
+    b_slot_new = torch.tensor(
+        [9 * block_size + i for i in range(block_size)],
+        dtype=torch.int64,
+        device=device,
+    )
+    state.init_request(
+        "rB",
+        b_prompt_len,
+        cached_block_ids=[5, 6, 9],  # last is the new (uncached) block
+        num_computed_tokens=8,  # 2 blocks * block_size
+    )
+    state.update_block_sums(b_slot_new, h_b_extra)
+    pooled_b = state.update_request("rB", h_b_extra)
+    assert pooled_b is not None
+    expected = h_b_full.float().mean(dim=0)
+    torch.testing.assert_close(pooled_b, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_block_reallocation_zeros_aux(state, device):
+    """A block_id reused for a new tenancy must not carry stale aux from
+    its previous tenant — slot 0 write zeros it."""
+    block_size = 4
+    block_id = 3
+    slot = torch.tensor(
+        [block_id * block_size + i for i in range(block_size)],
+        dtype=torch.int64,
+        device=device,
+    )
+
+    # First tenant.
+    h_old = _hidden(block_size, 8, device, seed=21)
+    state.update_block_sums(slot, h_old)
+
+    # Second tenant: same block_id, different content. The slot==0 write
+    # must zero aux first so we don't double-count h_old.
+    h_new = _hidden(block_size, 8, device, seed=22)
+    state.update_block_sums(slot, h_new)
+
+    # Now a new opted-in request with a cache-hit on this block must see
+    # only h_new's contribution.
+    state.init_request(
+        "rC",
+        prompt_len=block_size,
+        cached_block_ids=[block_id],
+        num_computed_tokens=block_size,
+    )
+    pooled = state.update_request("rC", torch.zeros(0, 8, device=device))
+    assert pooled is not None
+    torch.testing.assert_close(pooled, h_new.float().mean(dim=0), atol=1e-5, rtol=1e-5)
+
+
+def test_padding_slots_masked(state, device):
+    """slot_mapping == -1 (padding) must not corrupt aux."""
+    h = _hidden(6, 8, device, seed=33)
+    slot = torch.tensor([0, 1, 2, 3, -1, -1], dtype=torch.int64, device=device)
+    state.update_block_sums(slot, h)
+
+    state.init_request(
+        "rE",
+        prompt_len=4,
+        cached_block_ids=[0],
+        num_computed_tokens=4,
+    )
+    pooled = state.update_request("rE", torch.zeros(0, 8, device=device))
+    assert pooled is not None
+    expected = h[:4].float().mean(dim=0)
+    torch.testing.assert_close(pooled, expected, atol=1e-5, rtol=1e-5)
+
+
+def test_cleanup_removes_state(state, device):
+    state.init_request("rF", 4, [], 0)
+    assert state.has_request("rF")
+    state.cleanup("rF")
+    assert not state.has_request("rF")

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -253,6 +253,15 @@ class ModelConfig:
 
     WARNING: The vLLM engine may crash if incorrect shape of embeddings is passed.
     Only enable this flag for trusted users!"""
+    enable_return_embed: bool = False
+    """If `True`, the worker eagerly allocates an auxiliary per-block
+    fp32 store sized by the KV-cache block count, allowing generative
+    requests to opt in to a mean-pooled prompt embedding via
+    `SamplingParams.extra_args["return_embed"] = True`. The pooled vector
+    is shipped alongside generation in `kv_transfer_params["embed"]`.
+
+    When `False` (default), per-request `return_embed` is silently
+    ignored — no aux store is allocated, so there is zero overhead."""
     served_model_name: str | list[str] | None = None
     """The model name(s) used in the API. If multiple names are provided, the
     server will respond to any of the provided names. The model name in the

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -254,14 +254,15 @@ class ModelConfig:
     WARNING: The vLLM engine may crash if incorrect shape of embeddings is passed.
     Only enable this flag for trusted users!"""
     enable_return_embed: bool = False
-    """If `True`, the worker eagerly allocates an auxiliary per-block
-    fp32 store sized by the KV-cache block count, allowing generative
-    requests to opt in to a mean-pooled prompt embedding via
+    """Allow generative requests to opt in to a mean-pooled prompt embedding via
     `SamplingParams.extra_args["return_embed"] = True`. The pooled vector
     is shipped alongside generation in `kv_transfer_params["embed"]`.
 
     When `False` (default), per-request `return_embed` is silently
-    ignored — no aux store is allocated, so there is zero overhead."""
+    ignored — no aux store is allocated, so there is zero overhead.
+
+    Limitation: Safe for single-turn / stateless workloads (RAG indexing, scoring,
+    batch completion, system-prompt sharing across opt-in requests)."""
     served_model_name: str | list[str] | None = None
     """The model name(s) used in the API. If multiple names are provided, the
     server will respond to any of the provided names. The model name in the

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -413,6 +413,7 @@ class EngineArgs:
     convert: ConvertOption = ModelConfig.convert
     skip_tokenizer_init: bool = ModelConfig.skip_tokenizer_init
     enable_prompt_embeds: bool = ModelConfig.enable_prompt_embeds
+    enable_return_embed: bool = ModelConfig.enable_return_embed
     tokenizer_mode: TokenizerMode | str = ModelConfig.tokenizer_mode
     trust_remote_code: bool = ModelConfig.trust_remote_code
     allowed_local_media_path: str = ModelConfig.allowed_local_media_path
@@ -796,6 +797,9 @@ class EngineArgs:
         )
         model_group.add_argument(
             "--enable-prompt-embeds", **model_kwargs["enable_prompt_embeds"]
+        )
+        model_group.add_argument(
+            "--enable-return-embed", **model_kwargs["enable_return_embed"]
         )
         model_group.add_argument(
             "--served-model-name", **model_kwargs["served_model_name"]
@@ -1528,6 +1532,7 @@ class EngineArgs:
             disable_cascade_attn=self.disable_cascade_attn,
             skip_tokenizer_init=self.skip_tokenizer_init,
             enable_prompt_embeds=self.enable_prompt_embeds,
+            enable_return_embed=self.enable_return_embed,
             served_model_name=self.served_model_name,
             language_model_only=self.language_model_only,
             limit_mm_per_prompt=self.limit_mm_per_prompt,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1255,6 +1255,7 @@ class Scheduler(SchedulerInterface):
         prompt_logprobs_dict = model_runner_output.prompt_logprobs_dict
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
         pooler_outputs = model_runner_output.pooler_output
+        aux_pooled_output = model_runner_output.aux_pooled_output
         num_nans_in_logits = model_runner_output.num_nans_in_logits
         kv_connector_output = model_runner_output.kv_connector_output
         cudagraph_stats = model_runner_output.cudagraph_stats
@@ -1346,6 +1347,12 @@ class Scheduler(SchedulerInterface):
             kv_transfer_params = None
             status_before_stop = request.status
 
+            # Stash any newly-arrived prompt-pooled embedding
+            if aux_pooled_output is not None:
+                pooled = aux_pooled_output.get(req_id)
+                if pooled is not None:
+                    request.embed = pooled
+
             # Check for stop and update request status.
             if new_token_ids:
                 new_token_ids, stopped = self._update_request_with_output(
@@ -1388,6 +1395,10 @@ class Scheduler(SchedulerInterface):
                 finished = self._handle_stopped_request(request)
                 if finished:
                     kv_transfer_params = self._free_request(request)
+                    if request.embed is not None:
+                        if kv_transfer_params is None:
+                            kv_transfer_params = {}
+                        kv_transfer_params["embed"] = request.embed.tolist()
 
                 if status_before_stop == RequestStatus.RUNNING:
                     stopped_running_reqs.add(request)

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -191,6 +191,11 @@ class ModelRunnerOutput:
     # [num_reqs, hidden_size]
     pooler_output: list[torch.Tensor | None] | None = None
 
+    # req_id -> mean-pooled prompt hidden states (CPU tensor, [hidden_size]).
+    # Populated only for opted-in generative requests on the step that
+    # finalises their prompt. See AuxPoolState in worker.
+    aux_pooled_output: dict[str, torch.Tensor] | None = None
+
     kv_connector_output: KVConnectorOutput | None = None
 
     ec_connector_output: ECConnectorOutput | None = None

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -99,6 +99,10 @@ class Request:
 
         # P/D: Connector-specific KV transfer parameters.
         self.kv_transfer_params: dict[str, Any] | None = None
+        # Whether to mean-pool prompt hidden states and return them
+        self.return_embed: bool = False
+        # Mean-pooled prompt hidden states; populated by the runner the
+        self.embed: torch.Tensor | None = None
 
         if pooling_params is not None:
             # Pooling models.
@@ -113,6 +117,9 @@ class Request:
             if sampling_params.extra_args is not None:
                 self.kv_transfer_params = sampling_params.extra_args.get(
                     "kv_transfer_params"
+                )
+                self.return_embed = bool(
+                    sampling_params.extra_args.get("return_embed", False)
                 )
         else:
             raise ValueError("sampling_params and pooling_params can't both be unset")

--- a/vllm/v1/worker/aux_pool_state.py
+++ b/vllm/v1/worker/aux_pool_state.py
@@ -1,0 +1,178 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Worker-side state for auxiliary mean-pool of prompt hidden states.
+
+Supports generative requests opting in via
+``SamplingParams.extra_args["return_embed"] = True``. When enabled,
+the runner sums hidden states for prompt tokens and emits the
+per-prompt mean alongside generation, without taking over the whole batch.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+
+@dataclass
+class _ReqState:
+    """Per-request running sum for an opted-in generative request."""
+
+    prompt_len: int
+    # Number of prompt tokens whose hidden states have been added to
+    # ``running_sum`` so far (across cached-prefix + computed-suffix).
+    tokens_seen: int
+    # fp32 GPU tensor of shape [hidden_size]; accumulates the prompt sum.
+    running_sum: torch.Tensor
+    # True once we've emitted the final pooled vector.
+    finalized: bool = False
+
+
+class AuxPoolState:
+    """Per-block + per-request state for prompt mean-pool.
+
+    The per-block store is a dense GPU tensor sized by the worker's KV
+    cache block count, allocated eagerly at engine init when the server
+    is started with --enable-return-embed. Every prefill step sums its
+    tokens' hidden states into the matching block_aux_sums entry (via
+    ``index_add_``); the very first slot of each block is zeroed first
+    so a reused block_id doesn't carry stale data.
+
+    Per-request state holds the running sum (initialised from cached-prefix
+    block sums) and a tokens_seen counter; finalisation happens on the step
+    that brings ``tokens_seen`` up to ``prompt_len``.
+    """
+
+    def __init__(self, block_size: int, hidden_size: int, device: torch.device):
+        self._block_size = block_size
+        self._hidden_size = hidden_size
+        self._device = device
+        # block_id -> [hidden_size] fp32 sum on GPU.
+        # Allocated by enable(), called once kv_cache_config.num_blocks
+        # is known.
+        self._block_aux_sums: torch.Tensor | None = None
+        self._req_states: dict[str, _ReqState] = {}
+        self._enabled = False
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled
+
+    def enable(self, num_blocks: int) -> None:
+        """Allocate the per-block store. Idempotent."""
+        if self._enabled:
+            return
+        assert num_blocks > 0, f"num_blocks must be > 0, got {num_blocks}"
+        # Dense fp32 store. num_blocks × hidden_size × 4 bytes
+        self._block_aux_sums = torch.zeros(
+            (num_blocks, self._hidden_size),
+            dtype=torch.float32,
+            device=self._device,
+        )
+        self._enabled = True
+
+    def has_request(self, req_id: str) -> bool:
+        return req_id in self._req_states
+
+    def cleanup(self, req_id: str) -> None:
+        self._req_states.pop(req_id, None)
+
+    def init_request(
+        self,
+        req_id: str,
+        prompt_len: int,
+        cached_block_ids: list[int],
+        num_computed_tokens: int,
+    ) -> None:
+        """
+        Initialize with a request's running sum for
+        prefix-cache and chunked-prefill
+        """
+        assert self._block_aux_sums is not None
+        running_sum = torch.zeros(
+            self._hidden_size, dtype=torch.float32, device=self._device
+        )
+        if num_computed_tokens > 0 and cached_block_ids:
+            # pre-calculated prefix blocks
+            num_full_cached = num_computed_tokens // self._block_size
+            if num_full_cached > 0:
+                prefix_ids = torch.tensor(
+                    cached_block_ids[:num_full_cached],
+                    dtype=torch.long,
+                    device=self._device,
+                )
+                running_sum.add_(
+                    self._block_aux_sums.index_select(0, prefix_ids).sum(dim=0)
+                )
+        self._req_states[req_id] = _ReqState(
+            prompt_len=prompt_len,
+            tokens_seen=num_computed_tokens,
+            running_sum=running_sum,
+        )
+
+    def update_block_sums(
+        self,
+        slot_mapping: torch.Tensor,
+        hidden_states: torch.Tensor,
+    ) -> None:
+        """Accumulate per-token hidden states into per-block aux sums."""
+
+        assert self._enabled
+        assert self._block_aux_sums is not None
+
+        # Empty step (e.g. a no-op synchronisation/dummy step): nothing to do.
+        if slot_mapping.numel() == 0:
+            return
+
+        # Mask out padding slots (-1 from cudagraph padding).
+        valid = slot_mapping >= 0
+        if not valid.all():
+            slot_mapping = slot_mapping[valid]
+            hidden_states = hidden_states[valid]
+            if slot_mapping.numel() == 0:
+                return
+
+        block_ids = slot_mapping // self._block_size
+        slot_in_block = slot_mapping % self._block_size
+
+        # Zero out aux for blocks where this step is writing slot 0 — i.e.
+        # the block has been (re)allocated since its last full state.
+        first_slot_mask = slot_in_block == 0
+        if first_slot_mask.any():
+            first_block_ids = block_ids[first_slot_mask]
+            self._block_aux_sums.index_fill_(0, first_block_ids, 0.0)
+
+        self._block_aux_sums.index_add_(0, block_ids, hidden_states.float())
+
+    def update_request(
+        self,
+        req_id: str,
+        prompt_token_slice: torch.Tensor,
+    ) -> torch.Tensor | None:
+        """Add this step's prompt-token hidden states to a request's sum.
+
+        Returns the finalised pooled tensor (on GPU, shape [hidden_size])
+        if this step completes the prompt; otherwise ``None``.
+        Caller is responsible for the device->host copy and for
+        ``cleanup(req_id)`` once the value has been consumed.
+        """
+
+        assert self._enabled
+
+        state = self._req_states.get(req_id)
+
+        assert state is not None and not state.finalized, (
+            f"update_request called for {req_id!r} with no live state "
+            f"(state={state}); pool_req_ids out of sync with _req_states."
+        )
+
+        if prompt_token_slice.shape[0] > 0:
+            state.running_sum.add_(prompt_token_slice.sum(dim=0, dtype=torch.float32))
+            state.tokens_seen += prompt_token_slice.shape[0]
+
+        if state.tokens_seen >= state.prompt_len:
+            state.finalized = True
+            return state.running_sum / state.prompt_len
+
+        return None

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -3307,8 +3307,19 @@ class GPUModelRunner(
         slot_mapping = slot_mappings_by_group[0][:num_scheduled_tokens]
         flat_hidden = hidden_states[:num_scheduled_tokens]
 
-        # Accumulate per-block sums for every token in this step.
-        self.aux_pool_state.update_block_sums(slot_mapping, flat_hidden)
+        # Per-step CPU-only precheck: skip the GPU scatter-add when this
+        # step is pure-decode (no request is still in prefill). This trades
+        # multi-turn correctness — opt-in requests whose cache-hit prefix
+        # contains tokens written during a prior request's decode would see
+        # an undercounted mean — for substantial throughput on single-turn
+        # workloads where decoded tokens never become future prompt tokens.
+        any_prefill = any(
+            int(self.input_batch.num_computed_tokens_cpu[idx]) < req.num_prompt_tokens
+            for req_id, idx in self.input_batch.req_id_to_index.items()
+            if (req := self.requests.get(req_id)) is not None
+        )
+        if any_prefill:
+            self.aux_pool_state.update_block_sums(slot_mapping, flat_hidden)
 
         # no opted-in request arrived yet
         if not self.pool_req_ids:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -187,6 +187,7 @@ from vllm.v1.spec_decode.utils import update_num_computed_tokens_for_batch_chang
 from vllm.v1.structured_output.utils import apply_grammar_bitmask
 from vllm.v1.utils import CpuGpuBuffer, record_function_or_nullcontext
 from vllm.v1.worker import mamba_utils
+from vllm.v1.worker.aux_pool_state import AuxPoolState
 from vllm.v1.worker.cp_utils import (
     check_attention_cp_compatibility,
     get_total_cp_world_size,
@@ -394,6 +395,7 @@ class ExecuteModelState(NamedTuple):
     ec_connector_output: ECConnectorOutput | None
     cudagraph_stats: CUDAGraphStat | None
     slot_mappings: dict[str, torch.Tensor] | list[dict[str, torch.Tensor]] | None
+    aux_pooled_output: dict[str, torch.Tensor] | None
 
 
 class GPUModelRunner(
@@ -500,6 +502,17 @@ class GPUModelRunner(
         # self.model: nn.Module  # Set after load_model
         # Initialize in initialize_kv_cache
         self.kv_caches: list[torch.Tensor] = []
+        # Auxiliary mean-pool of prompt hidden states for requests
+        self.aux_pool_state: AuxPoolState | None = (
+            AuxPoolState(
+                block_size=self.cache_config.block_size,
+                hidden_size=self.model_config.get_hidden_size(),
+                device=self.device,
+            )
+            if self.model_config.enable_return_embed and get_pp_group().is_last_rank
+            else None
+        )
+        self.pool_req_ids: set[str] = set()
         # Initialize in initialize_kv_cache_tensors
         self.cross_layers_kv_cache: torch.Tensor | None = None
         self.cross_layers_attn_backend: type[AttentionBackend] | None = None
@@ -1084,6 +1097,10 @@ class GPUModelRunner(
         for req_id in scheduler_output.finished_req_ids:
             self.requests.pop(req_id, None)
             self.num_prompt_logprobs.pop(req_id, None)
+            if req_id in self.pool_req_ids:
+                assert self.aux_pool_state is not None
+                self.pool_req_ids.discard(req_id)
+                self.aux_pool_state.cleanup(req_id)
         self.late_interaction_runner.on_requests_finished(
             scheduler_output.finished_req_ids
         )
@@ -1189,6 +1206,25 @@ class GPUModelRunner(
             )
             self.requests[req_id] = req_state
             self.late_interaction_runner.register_request(req_id, pooling_params)
+
+            # Per-request opt-in to prompt mean-pool.
+            extra_args = sampling_params.extra_args if sampling_params else None
+            if self.aux_pool_state is not None and (extra_args or {}).get(
+                "return_embed"
+            ):
+                # Seed the per-request running sum from any cached prefix blocks.
+                # NOTE(zzaebok): models with multiple KV cache groups
+                # may need per-group aux stores;
+                cached_block_ids = (
+                    list(new_req_data.block_ids[0]) if new_req_data.block_ids else []
+                )
+                self.aux_pool_state.init_request(
+                    req_id=req_id,
+                    prompt_len=len(new_req_data.prompt_token_ids or []),
+                    cached_block_ids=cached_block_ids,
+                    num_computed_tokens=new_req_data.num_computed_tokens,
+                )
+                self.pool_req_ids.add(req_id)
 
             if sampling_params and sampling_params.prompt_logprobs is not None:
                 self.num_prompt_logprobs[req_id] = (
@@ -3258,6 +3294,61 @@ class GPUModelRunner(
             async_output_copy_stream=self._get_or_create_async_output_copy_stream(),
         )
 
+    def _maybe_run_aux_pool(
+        self,
+        hidden_states: torch.Tensor,
+        num_scheduled_tokens: int,
+        slot_mappings_by_group: dict[int, torch.Tensor] | None,
+    ) -> dict[str, torch.Tensor] | None:
+        """Mean-pool prompt hidden states for opted-in generative requests."""
+        if self.aux_pool_state is None or slot_mappings_by_group is None:
+            return None
+
+        slot_mapping = slot_mappings_by_group[0][:num_scheduled_tokens]
+        flat_hidden = hidden_states[:num_scheduled_tokens]
+
+        # Accumulate per-block sums for every token in this step.
+        self.aux_pool_state.update_block_sums(slot_mapping, flat_hidden)
+
+        # no opted-in request arrived yet
+        if not self.pool_req_ids:
+            return None
+
+        # Per-request: add this step's prompt-token contribution and check
+        # for finalization. Only opted-in requests have state.
+        results: dict[str, torch.Tensor] = {}
+        query_start_loc_cpu = self.query_start_loc.np
+        for req_id in list(self.pool_req_ids):
+            req_index = self.input_batch.req_id_to_index.get(req_id)
+            if req_index is None:
+                # Request not scheduled this step; nothing to do.
+                continue
+            start = int(query_start_loc_cpu[req_index])
+            end = int(query_start_loc_cpu[req_index + 1])
+            if end <= start:
+                # This request has 0 tokens to process at this step
+                continue
+
+            # Tokens in this step that are still part of the prompt.
+            num_computed = int(self.input_batch.num_computed_tokens_cpu[req_index])
+
+            req_state = self.requests[req_id]
+            prompt_len = req_state.num_prompt_tokens
+            num_prompt_tokens_in_slice = max(
+                0, min(end - start, prompt_len - num_computed)
+            )
+            if num_prompt_tokens_in_slice <= 0:
+                continue
+            slice_tensor = flat_hidden[start : start + num_prompt_tokens_in_slice]
+            pooled = self.aux_pool_state.update_request(req_id, slice_tensor)
+
+            if pooled is not None:
+                results[req_id] = pooled.cpu()
+                self.aux_pool_state.cleanup(req_id)
+                self.pool_req_ids.discard(req_id)
+
+        return results or None
+
     def _pad_for_sequence_parallelism(self, num_scheduled_tokens: int) -> int:
         # Pad tokens to multiple of tensor_parallel_size when
         # enabled collective fusion for SP
@@ -4141,6 +4232,12 @@ class GPUModelRunner(
                     self.kv_connector_output = kv_connector_output
                     return hidden_states
 
+                aux_pooled_output = self._maybe_run_aux_pool(
+                    hidden_states,
+                    num_scheduled_tokens,
+                    slot_mappings_by_group,
+                )
+
                 if self.is_pooling_model:
                     # Return the pooling output.
                     return self._pool(
@@ -4155,6 +4252,7 @@ class GPUModelRunner(
             else:
                 # Rare case.
                 assert not self.is_pooling_model
+                aux_pooled_output = None
 
                 sample_hidden_states = hidden_states[logits_indices]
                 if not get_pp_group().is_last_rank:
@@ -4193,6 +4291,7 @@ class GPUModelRunner(
             ec_connector_output,
             cudagraph_stats,
             slot_mappings,
+            aux_pooled_output,
         )
         self.kv_connector_output = kv_connector_output
 
@@ -4237,6 +4336,7 @@ class GPUModelRunner(
             ec_connector_output,
             cudagraph_stats,
             slot_mappings,
+            aux_pooled_output,
         ) = self.execute_model_state
         # Clear ephemeral state.
         self.execute_model_state = None
@@ -4427,6 +4527,7 @@ class GPUModelRunner(
                 num_nans_in_logits=num_nans_in_logits,
                 cudagraph_stats=cudagraph_stats,
                 routed_experts_dict=routed_experts_dict,
+                aux_pooled_output=aux_pooled_output,
             )
 
         if not self.use_async_scheduling:
@@ -6931,6 +7032,8 @@ class GPUModelRunner(
         """
         kv_cache_config = deepcopy(kv_cache_config)
         self.kv_cache_config = kv_cache_config
+        if self.aux_pool_state is not None:
+            self.aux_pool_state.enable(kv_cache_config.num_blocks)
         self._mamba_copy_bufs = None
         self.may_add_encoder_only_layers_to_kv_cache_config()
         self.maybe_add_kv_sharing_layers_to_kv_cache_groups(kv_cache_config)


### PR DESCRIPTION
## Purpose

Currently, vLLM doesn't officially support returning both the output text and the pooled vector, which leads to run two vLLM instances to get both results (very inefficient).

However, there are huge community demand for this feature:
- https://github.com/vllm-project/vllm/issues/5449
- https://github.com/vllm-project/vllm/issues/37971
- https://github.com/vllm-project/vllm/issues/11905
- https://github.com/vllm-project/vllm/issues/11577

The issues were closed due to recent feature `extract_hidden_states`. **However**, it is piggyback on speculative decoding (which is extremely slow and not support online serve). In many production cases, getting both output text and embedding vector are very common and useful (e.g., retrieval of user content)

### Implementation details

Implementations are included in model runner. Please follow the commits.

Added `--enable-return-embed` for server argument. For the client request, you can both opt-in / out the returning embedding vector via `extra_args["return_embed"]`. The runner first seeds its running sum from any prefix-cache hits and accumulates each step's prompt-token hidden states into it. When the prompt is fully observed, the mean is finalized, copied to host, and stashed on the request. The scheduler ships it as `kv_transfer_params["embed"]` on the request's final output, alongside the generated text.

Currently, the input args and output format is set temporarily (request is set using `extra_args` and return with `kv_transfer_params`, since it requires changing multiple files). **Will update the schema correctly after maintainers' review and concensus.**

**Current limitation**
- Does not support stream
- Does not support multi turn

However those functionalities is not necessary with the usecase. Normal usecase is getting single-turn output text and embedding vector.

## Test Plan & Test Results

GPU: A100

**1. Added unit tests to compare output with vllm embed**

output of mean pooled vector and output of `embed` endpoint shows
**>= 0.999 cosine similarity**

**2. Checked online serve and response**

```bash
vllm serve meta-llama/Llama-3.2-3B-Instruct \                                                                                          
    --max-model-len 128 --enforce-eager --dtype bfloat16 --port 8765 \
    --enable-return-embed
```

Tested with API calls `/v1/completions` and `/v1/chat/completions` with additional arguments, so that both kinds of requests are allowed (request embed or not)

```bash
curl -X POST http://localhost:8765/v1/completions \                                                                                    
  -H "Content-Type: application/json" \                                                                                                
  -d '{                                                                                                                                
    "model": "meta-llama/Llama-3.2-3B-Instruct",                                                                                       
    "prompt": "The quick brown fox jumps over the lazy dog.",                                                                          
    "max_tokens": 8,                                                                                                                   
    "temperature": 0.0,                                                                                                                
    "vllm_xargs": {"return_embed": 1}                                                                                                  
  }'
```

Output

```bash
{
  "id": "cmpl-...",
  "object": "text_completion",
  "created": 1745382...,
  "model": "meta-llama/Llama-3.2-3B-Instruct",
  "choices": [
    {
      "index": 0,
      "text": " This is a well-known pangram,",
      "logprobs": null,
      "finish_reason": "length",
      "stop_reason": null,
      "prompt_logprobs": null,
      "token_ids": null
    }
  ],
  "usage": {"prompt_tokens": 11, "completion_tokens": 8, "total_tokens": 19},
  "kv_transfer_params": {
    "embed": [-1.1253883838653564, -0.5150923728942871, 2.4300427436828613, -1.70556640625, ...3068 more floats...,
 0.7966974377632141, -0.27256083488464355, -0.4936384856700897, 0.25064921379089355]
  }
}
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

