### PR TITLE
Auto-disable expandable_segments around cumem memory pool

### DIFF
--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -296,8 +296,8 @@ class CuMemAllocator:
                     if allocation["allocated_size"] == 0:
                         handle = self._python_free_callback(allocation["address"])
                         unmap_and_release(handle)
-                self.current_tag = old_tag
         finally:
+            self.current_tag = old_tag
             if expandable_was_enabled:
                 torch.cuda.memory._set_allocator_settings("expandable_segments:True")
 

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -262,8 +262,8 @@ class CuMemAllocator:
         # If the user has enabled expandable segments via
         # PYTORCH_CUDA_ALLOC_CONF, temporarily disable them for the duration
         # of the memory pool context and restore on exit.
-        alloc_settings = torch.cuda.memory.get_allocator_settings()
-        expandable_was_enabled = alloc_settings.get('expandable_segments', False)
+        conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
+        expandable_was_enabled = "expandable_segments:True" in conf
         if expandable_was_enabled:
             torch.cuda.memory._set_allocator_settings("expandable_segments:False")
 

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -128,13 +128,6 @@ class CuMemAllocator:
         return CuMemAllocator.instance
 
     def __init__(self):
-        conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
-        assert "expandable_segments:True" not in conf, (
-            "Expandable segments are not compatible with memory pool. "
-            "Please track https://github.com/pytorch/pytorch/issues/147851 "
-            "for the latest updates."
-        )
-
         self.pointer_to_data: dict[int, AllocationData] = {}
         self.current_tag: str = CuMemAllocator.default_tag
         self.allocator_and_pools: dict[str, Any] = {}
@@ -264,34 +257,49 @@ class CuMemAllocator:
 
         assert isinstance(tag, str)
 
+        # Expandable segments are incompatible with the memory pool used for
+        # sleep mode (see https://github.com/pytorch/pytorch/issues/147851).
+        # If the user has enabled expandable segments via
+        # PYTORCH_CUDA_ALLOC_CONF, temporarily disable them for the duration
+        # of the memory pool context and restore on exit.
+        conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
+        expandable_was_enabled = "expandable_segments:True" in conf
+        if expandable_was_enabled:
+            torch.cuda.memory._set_allocator_settings("expandable_segments:False")
+
         old_tag = self.current_tag
         self.current_tag = tag
-        with use_memory_pool_with_allocator(
-            self.python_malloc_callback, self.python_free_callback
-        ) as data:
-            # start to hit another PyTorch bug in PyTorch 2.6,
-            # possibly because of gc-related issue w.r.t. the allocator and
-            # the memory pool.
-            # to avoid the issue, we keep a reference of the data.
-            # see https://github.com/pytorch/pytorch/issues/146431 .
-            self.allocator_and_pools[tag] = data
-            yield
-            # PyTorch's bug, calling torch.cuda.empty_cache() will error
-            # when using pluggable allocator, see
-            # https://github.com/pytorch/pytorch/issues/145168 .
-            # if we have some memory allocated and then freed,
-            # the memory will not be released, e.g. in online quantization,
-            # where the model is created in higher precision, and then
-            # quantized in lower precision.
-            # Find all unused allocations and manually release them.
-            # TODO: we should expose `empty_cache` method in the memory pool.
-            # TODO: ask for help from PyTorch team to expose this method.
-            allocations = data[0].snapshot()
-            for allocation in allocations:
-                if allocation["allocated_size"] == 0:
-                    handle = self._python_free_callback(allocation["address"])
-                    unmap_and_release(handle)
-            self.current_tag = old_tag
+        try:
+            with use_memory_pool_with_allocator(
+                self.python_malloc_callback, self.python_free_callback
+            ) as data:
+                # start to hit another PyTorch bug in PyTorch 2.6,
+                # possibly because of gc-related issue w.r.t. the allocator
+                # and the memory pool.
+                # to avoid the issue, we keep a reference of the data.
+                # see https://github.com/pytorch/pytorch/issues/146431 .
+                self.allocator_and_pools[tag] = data
+                yield
+                # PyTorch's bug, calling torch.cuda.empty_cache() will error
+                # when using pluggable allocator, see
+                # https://github.com/pytorch/pytorch/issues/145168 .
+                # if we have some memory allocated and then freed,
+                # the memory will not be released, e.g. in online
+                # quantization, where the model is created in higher
+                # precision, and then quantized in lower precision.
+                # Find all unused allocations and manually release them.
+                # TODO: we should expose `empty_cache` method in the memory
+                # pool.
+                # TODO: ask for help from PyTorch team to expose this method.
+                allocations = data[0].snapshot()
+                for allocation in allocations:
+                    if allocation["allocated_size"] == 0:
+                        handle = self._python_free_callback(allocation["address"])
+                        unmap_and_release(handle)
+                self.current_tag = old_tag
+        finally:
+            if expandable_was_enabled:
+                torch.cuda.memory._set_allocator_settings("expandable_segments:True")
 
     def get_current_usage(self) -> int:
         """

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -262,8 +262,8 @@ class CuMemAllocator:
         # If the user has enabled expandable segments via
         # PYTORCH_CUDA_ALLOC_CONF, temporarily disable them for the duration
         # of the memory pool context and restore on exit.
-        conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
-        expandable_was_enabled = "expandable_segments:True" in conf
+        alloc_settings = torch.cuda.memory.get_allocator_settings()
+        expandable_was_enabled = alloc_settings.get('expandable_segments', False)
         if expandable_was_enabled:
             torch.cuda.memory._set_allocator_settings("expandable_segments:False")
 


### PR DESCRIPTION
## Summary

- Remove the hard assertion in `CuMemAllocator.__init__` that forbade `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` when sleep mode is in use.
- In `CuMemAllocator.use_memory_pool`, detect `expandable_segments:True` on entry and toggle it off via `torch.cuda.memory._set_allocator_settings(\"expandable_segments:False\")`, then restore it on exit in a `finally` block.

Expandable segments are incompatible with the memory pool used by the cumem allocator (pytorch/pytorch#147851). Previously, enabling both at the same time raised an assert, forcing users to pick one for the whole process. With this change, allocations outside `use_memory_pool` can keep using expandable segments while the pool itself runs with them disabled.

## Why this is not a duplicate

Searched open PRs on `vllm-project/vllm` for `expandable_segments`, `expandable segment`, and `cumem sleep expandable` — no open PR addresses this.

## Test plan

- [ ] Run `tests/basic_correctness/test_cumem.py` with `PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True` set, to confirm sleep/wake works without tripping the old assert.
- [ ] Run the same test without the env var set, to confirm the no-op path is unchanged.

(AI-assisted change; local GPU environment not available to the author at time of writing — the submitter will run the tests above before merging.)

## Note

AI assistance was used to author this patch.