### PR TITLE
[Test] Increase qwen2_vl num_logprobs to fix torch 2.12 update

### DIFF
--- a/tests/models/multimodal/generation/test_common.py
+++ b/tests/models/multimodal/generation/test_common.py
@@ -921,6 +921,7 @@ VLM_TEST_SETTINGS = {
         multi_image_prompt="Picture 1: <vlm_image>\nPicture 2: <vlm_image>\nDescribe these two images with one paragraph respectively.",  # noqa: E501
         max_model_len=4096,
         max_num_seqs=2,
+        num_logprobs=10,
         auto_cls=AutoModelForImageTextToText,
         vllm_output_post_proc=model_utils.qwen2_vllm_to_hf_output,
         image_size_factors=[(0.25,), (0.25, 0.25, 0.25), (0.25, 0.2, 0.15)],


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/181168

When updating to torch 2.12, we're noticing a failure on the test_multi_image_models[qwen2_vl-test_case43] test. However this seems to only fail on L4 GPUs but passes on H100s. The HF vs. vLLM output is very close (e.g. "window" vs "archway"), and by changing num_logprobs=10 it seems to fix the issue. Also it seems like other models in the test suite also use num_logprobs=10.

cc @DarkLight1337 