### PR TITLE
Fix Qwen3 streaming content routing

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_thinking_token_budget.py
+++ b/tests/entrypoints/openai/chat_completion/test_thinking_token_budget.py
@@ -287,3 +287,49 @@ async def test_thinking_token_budget_qwen35_fp8_mtp_concurrent_mixed_budget_and_
                 f"index {i}: reasoning decode token ids ({n_reason}) != "
                 f"thinking_token_budget ({expected_budget})"
             )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("client", ["default", "auto_config"], indirect=True)
+async def test_streaming_with_thinking_disabled_stays_in_content(
+    client: openai.AsyncOpenAI,
+):
+    request_kwargs = {
+        "model": MODEL_NAME,
+        "messages": [
+            {
+                "role": "user",
+                "content": (
+                    "Which is larger, 4 or 12? "
+                    "Output exactly one token: 4 or 12."
+                ),
+            }
+        ],
+        "max_tokens": 16,
+        "temperature": 0.0,
+        "extra_body": {"chat_template_kwargs": {"enable_thinking": False}},
+    }
+
+    response = await client.chat.completions.create(**request_kwargs)
+    message = response.choices[0].message
+    assert message.content is not None and message.content.strip() != ""
+    assert getattr(message, "reasoning", None) in (None, "")
+
+    stream = await client.chat.completions.create(
+        **request_kwargs,
+        stream=True,
+    )
+
+    content_chunks = []
+    reasoning_chunks = []
+    async for chunk in stream:
+        if not chunk.choices:
+            continue
+        delta = chunk.choices[0].delta
+        if getattr(delta, "content", None):
+            content_chunks.append(delta.content)
+        if getattr(delta, "reasoning", None):
+            reasoning_chunks.append(delta.reasoning)
+
+    assert "".join(content_chunks).strip() != ""
+    assert reasoning_chunks == []

--- a/tests/entrypoints/openai/chat_completion/test_thinking_token_budget.py
+++ b/tests/entrypoints/openai/chat_completion/test_thinking_token_budget.py
@@ -299,10 +299,8 @@ async def test_streaming_with_thinking_disabled_stays_in_content(
         "messages": [
             {
                 "role": "user",
-                "content": (
-                    "Which is larger, 4 or 12? "
-                    "Output exactly one token: 4 or 12."
-                ),
+                "content": "Which is larger, 4 or 12?"
+                " Output exactly one token: 4 or 12.",
             }
         ],
         "max_tokens": 16,

--- a/tests/parser/__init__.py
+++ b/tests/parser/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project

--- a/tests/parser/test_streaming.py
+++ b/tests/parser/test_streaming.py
@@ -1,0 +1,165 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+from vllm.parser.abstract_parser import _WrappedParser
+from vllm.reasoning.basic_parsers import BaseThinkingReasoningParser
+from vllm.tool_parsers.hermes_tool_parser import Hermes2ProToolParser
+
+
+class ThinkReasoningParser(BaseThinkingReasoningParser):
+    @property
+    def start_token(self) -> str:
+        return "<think>"
+
+    @property
+    def end_token(self) -> str:
+        return "</think>"
+
+
+MODEL_OUTPUT = (
+    "<think>let me think about this</think>"
+    '<tool_call>\n{"name": "get_weather", '
+    '"arguments": {"city": "Dallas"}}\n</tool_call>'
+)
+
+
+@pytest.fixture(scope="module")
+def tokenizer():
+    from vllm.tokenizers import get_tokenizer
+
+    return get_tokenizer("Qwen/Qwen3-32B")
+
+
+@pytest.fixture
+def request_obj():
+    return ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+
+def make_parser(tokenizer, reasoning=False, tool=False):
+    _WrappedParser.reasoning_parser_cls = ThinkReasoningParser if reasoning else None
+    _WrappedParser.tool_parser_cls = Hermes2ProToolParser if tool else None
+    return _WrappedParser(tokenizer)
+
+
+def stream_text(parser, tokenizer, text, request, prompt_token_ids=None):
+    token_ids = tokenizer.encode(text, add_special_tokens=False)
+    results: list[DeltaMessage | None] = []
+    for tid in token_ids:
+        delta_text = tokenizer.decode([tid])
+        result = parser.parse_delta(
+            delta_text, [tid], request, prompt_token_ids=prompt_token_ids
+        )
+        prompt_token_ids = None
+        results.append(result)
+    return results
+
+
+def collect_fields(results):
+    all_reasoning = "".join(r.reasoning for r in results if r and r.reasoning)
+    all_content = "".join(r.content for r in results if r and r.content)
+    all_tool_calls = [tc for r in results if r and r.tool_calls for tc in r.tool_calls]
+    return all_reasoning, all_content, all_tool_calls
+
+
+def test_parse_delta_neither_parser(tokenizer, request_obj):
+    parser = make_parser(tokenizer, reasoning=False, tool=False)
+    results = stream_text(
+        parser, tokenizer, MODEL_OUTPUT, request_obj, prompt_token_ids=[]
+    )
+    reasoning, content, tool_calls = collect_fields(results)
+
+    assert reasoning == ""
+    assert len(tool_calls) == 0
+    assert "<think>" in content
+    assert "let me think about this" in content
+    assert "<tool_call>" in content
+    assert "get_weather" in content
+
+
+def test_parse_delta_tool_parser_only(tokenizer, request_obj):
+    parser = make_parser(tokenizer, reasoning=False, tool=True)
+    results = stream_text(
+        parser, tokenizer, MODEL_OUTPUT, request_obj, prompt_token_ids=[]
+    )
+    reasoning, content, tool_calls = collect_fields(results)
+
+    assert reasoning == ""
+    assert "<think>" in content
+    assert "let me think about this" in content
+    assert "</think>" in content
+
+    assert len(tool_calls) > 0
+    assert tool_calls[0].function.name == "get_weather"
+    tool_args = "".join(
+        tc.function.arguments for tc in tool_calls if tc.function.arguments
+    )
+    assert json.loads(tool_args) == {"city": "Dallas"}
+
+
+def test_parse_delta_reasoning_parser_only(tokenizer, request_obj):
+    parser = make_parser(tokenizer, reasoning=True, tool=False)
+    results = stream_text(
+        parser, tokenizer, MODEL_OUTPUT, request_obj, prompt_token_ids=[]
+    )
+    reasoning, content, tool_calls = collect_fields(results)
+
+    assert "let me think about this" in reasoning
+    assert len(tool_calls) == 0
+    assert "<tool_call>" in content
+    assert "get_weather" in content
+    assert "</tool_call>" in content
+
+
+def test_parse_delta_both_parsers(tokenizer, request_obj):
+    parser = make_parser(tokenizer, reasoning=True, tool=True)
+    results = stream_text(
+        parser, tokenizer, MODEL_OUTPUT, request_obj, prompt_token_ids=[]
+    )
+    reasoning, content, tool_calls = collect_fields(results)
+
+    assert "let me think about this" in reasoning
+    assert content == ""
+
+    assert len(tool_calls) > 0
+    assert tool_calls[0].function.name == "get_weather"
+    tool_args = "".join(
+        tc.function.arguments for tc in tool_calls if tc.function.arguments
+    )
+    assert json.loads(tool_args) == {"city": "Dallas"}
+
+
+def test_parse_delta_reasoning_only_thinking_disabled(tokenizer, request_obj):
+    """Regression test for vllm-project/vllm#40466.
+
+    When enable_thinking=False, the chat template places <think>\\n\\n</think>
+    in the prompt. The model then generates pure content (no think tokens).
+    All streaming output must go to delta.content, not delta.reasoning.
+    """
+    parser = make_parser(tokenizer, reasoning=True, tool=False)
+
+    end_token_id = parser._reasoning_parser.end_token_id
+    prompt_token_ids = [1, 2, end_token_id, 3]
+
+    content_text = "Hello! How can I assist you today?"
+    results = stream_text(
+        parser,
+        tokenizer,
+        content_text,
+        request_obj,
+        prompt_token_ids=prompt_token_ids,
+    )
+    reasoning, content, tool_calls = collect_fields(results)
+
+    assert reasoning == "", f"Expected no reasoning, got: {reasoning!r}"
+    assert "Hello" in content
+    assert "assist" in content
+    assert len(tool_calls) == 0

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -272,8 +272,10 @@ class OpenAIServingChat(OpenAIServing):
         # Schedule the request and get the result generator.
         max_model_len = self.model_config.max_model_len
         generators: list[AsyncGenerator[RequestOutput, None]] = []
+        stream_prompt_token_ids: list[int] | None = None
         for i, engine_input in enumerate(engine_inputs):
             prompt_token_ids = self._extract_prompt_components(engine_input).token_ids
+            stream_prompt_token_ids = prompt_token_ids
 
             # If we are creating sub requests for multiple prompts, ensure that they
             # have unique request ids.
@@ -369,6 +371,7 @@ class OpenAIServingChat(OpenAIServing):
                 tokenizer,
                 request_metadata,
                 reasoning_parser,
+                prompt_token_ids=stream_prompt_token_ids,
                 chat_template_kwargs=chat_template_kwargs,
             )
 
@@ -415,6 +418,7 @@ class OpenAIServingChat(OpenAIServing):
         tokenizer: TokenizerLike,
         request_metadata: RequestResponseMetadata,
         reasoning_parser: ReasoningParser | None = None,
+        prompt_token_ids: list[int] | None = None,
         chat_template_kwargs: dict[str, Any] | None = None,
     ) -> AsyncGenerator[str, None]:
         created_time = int(time.time())
@@ -482,7 +486,14 @@ class OpenAIServingChat(OpenAIServing):
             # These are only required in "auto" tool choice case
             all_previous_token_ids = [[] for _ in range(num_choices)]
             reasoning_end_arr = [False] * num_choices
-            prompt_is_reasoning_end_arr: list[bool | None] = [None] * num_choices
+            prompt_is_reasoning_end = (
+                reasoning_parser.is_reasoning_end(prompt_token_ids)
+                if reasoning_parser is not None and prompt_token_ids is not None
+                else None
+            )
+            prompt_is_reasoning_end_arr: list[bool | None] = [
+                prompt_is_reasoning_end
+            ] * num_choices
         else:
             all_previous_token_ids = None
 
@@ -612,11 +623,14 @@ class OpenAIServingChat(OpenAIServing):
 
                     if (
                         reasoning_parser
-                        and res.prompt_token_ids
+                        and res.prompt_token_ids is not None
                         and prompt_is_reasoning_end_arr[i] is None
                     ):
-                        # only check once per choice, because prompt_token_ids
-                        # are the same for all deltas in that choice
+                        # Fall back to RequestOutput prompt tokens only when
+                        # the rendered request did not expose them up front.
+                        # This keeps streaming on the content path for
+                        # enable_thinking=False even if intermediate outputs
+                        # omit prompt_token_ids.
                         prompt_is_reasoning_end_arr[i] = (
                             reasoning_parser.is_reasoning_end(res.prompt_token_ids)
                         )

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -272,10 +272,8 @@ class OpenAIServingChat(OpenAIServing):
         # Schedule the request and get the result generator.
         max_model_len = self.model_config.max_model_len
         generators: list[AsyncGenerator[RequestOutput, None]] = []
-        stream_prompt_token_ids: list[int] | None = None
         for i, engine_input in enumerate(engine_inputs):
             prompt_token_ids = self._extract_prompt_components(engine_input).token_ids
-            stream_prompt_token_ids = prompt_token_ids
 
             # If we are creating sub requests for multiple prompts, ensure that they
             # have unique request ids.
@@ -371,7 +369,6 @@ class OpenAIServingChat(OpenAIServing):
                 tokenizer,
                 request_metadata,
                 reasoning_parser,
-                prompt_token_ids=stream_prompt_token_ids,
                 chat_template_kwargs=chat_template_kwargs,
             )
 
@@ -418,7 +415,6 @@ class OpenAIServingChat(OpenAIServing):
         tokenizer: TokenizerLike,
         request_metadata: RequestResponseMetadata,
         reasoning_parser: ReasoningParser | None = None,
-        prompt_token_ids: list[int] | None = None,
         chat_template_kwargs: dict[str, Any] | None = None,
     ) -> AsyncGenerator[str, None]:
         created_time = int(time.time())
@@ -486,14 +482,7 @@ class OpenAIServingChat(OpenAIServing):
             # These are only required in "auto" tool choice case
             all_previous_token_ids = [[] for _ in range(num_choices)]
             reasoning_end_arr = [False] * num_choices
-            prompt_is_reasoning_end = (
-                reasoning_parser.is_reasoning_end(prompt_token_ids)
-                if reasoning_parser is not None and prompt_token_ids is not None
-                else None
-            )
-            prompt_is_reasoning_end_arr: list[bool | None] = [
-                prompt_is_reasoning_end
-            ] * num_choices
+            prompt_is_reasoning_end_arr: list[bool | None] = [None] * num_choices
         else:
             all_previous_token_ids = None
 
@@ -623,14 +612,11 @@ class OpenAIServingChat(OpenAIServing):
 
                     if (
                         reasoning_parser
-                        and res.prompt_token_ids is not None
+                        and res.prompt_token_ids
                         and prompt_is_reasoning_end_arr[i] is None
                     ):
-                        # Fall back to RequestOutput prompt tokens only when
-                        # the rendered request did not expose them up front.
-                        # This keeps streaming on the content path for
-                        # enable_thinking=False even if intermediate outputs
-                        # omit prompt_token_ids.
+                        # only check once per choice, because prompt_token_ids
+                        # are the same for all deltas in that choice
                         prompt_is_reasoning_end_arr[i] = (
                             reasoning_parser.is_reasoning_end(res.prompt_token_ids)
                         )

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -635,15 +635,11 @@ class DelegatingParser(Parser):
     def _in_reasoning_phase(self, state: StreamState) -> bool:
         if self._reasoning_parser is None:
             return False
-        if self._tool_parser is None:
-            return True
         return not state.reasoning_ended
 
     def _in_tool_call_phase(self, state: StreamState) -> bool:
         if self._tool_parser is None:
             return False
-        if self._reasoning_parser is None:
-            return True
         return state.reasoning_ended
 
     def parse_delta(
@@ -657,7 +653,9 @@ class DelegatingParser(Parser):
 
         if not state.prompt_reasoning_checked and prompt_token_ids is not None:
             state.prompt_reasoning_checked = True
-            if self.is_reasoning_end(prompt_token_ids):
+            if self._reasoning_parser is None or self.is_reasoning_end(
+                prompt_token_ids
+            ):
                 state.reasoning_ended = True
 
         current_text = state.previous_text + delta_text
@@ -708,8 +706,12 @@ class DelegatingParser(Parser):
                 )
             )
 
-        # No parsers: pass through as content
-        if self._reasoning_parser is None and self._tool_parser is None:
+        # No phase active: pass through as content
+        if (
+            delta_message is None
+            and not self._in_reasoning_phase(state)
+            and not self._in_tool_call_phase(state)
+        ):
             delta_message = DeltaMessage(content=delta_text)
 
         state.previous_text = current_text


### PR DESCRIPTION


## Purpose

Fix a Qwen3 streaming routing bug in the OpenAI-compatible `/v1/chat/completions`
endpoint when `--reasoning-parser qwen3` is enabled and
`chat_template_kwargs.enable_thinking=false`.

This PR is related to https://github.com/vllm-project/vllm/issues/40816.

Before this change:

- Non-streaming requests correctly returned the answer in `message.content`
- Streaming requests could incorrectly emit the answer in
  `choices[0].delta.reasoning`
- OpenAI-compatible streaming clients that only read `delta.content` would miss
  the final answer

Root cause:

- The streaming path relied on `res.prompt_token_ids` to determine whether the
  prompt had already ended the reasoning block
- For Qwen3 with `enable_thinking=false`, the rendered prompt already contains
  the empty reasoning terminator
- Some streaming `RequestOutput` chunks do not carry `prompt_token_ids`, so the
  answer tokens could be misrouted into `delta.reasoning`

Fix:

- Capture rendered `prompt_token_ids` before streaming starts
- Pass them into `chat_completion_stream_generator`
- Initialize `prompt_is_reasoning_end_arr` from those prompt tokens up front
- Only fall back to `res.prompt_token_ids` when needed

This makes streaming behavior consistent with non-streaming behavior for
Qwen3/Qwen3.5 requests with thinking disabled.

## Test Plan

Code-level regression coverage:

```bash
pytest -q tests/entrypoints/openai/chat_completion/test_thinking_token_budget.py \
  -k streaming_with_thinking_disabled_stays_in_content
```

Manual validation against a running container:

```bash
curl -sS http://localhost:8000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model":"qwen3.6-35b-nvfp4",
    "messages":[{"role":"user","content":"Which is larger, 4 or 12? Output exactly one token: 4 or 12."}],
    "temperature":0.1,
    "max_tokens":16,
    "chat_template_kwargs":{"enable_thinking":false}
  }'
```

```bash
curl -N -sS http://localhost:8000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{
    "model":"qwen3.6-35b-nvfp4",
    "messages":[{"role":"user","content":"Which is larger, 4 or 12? Output exactly one token: 4 or 12."}],
    "stream":true,
    "temperature":0.1,
    "max_tokens":16,
    "chat_template_kwargs":{"enable_thinking":false},
    "stream_options":{"include_usage":true}
  }'
```

## Test Result

Environment used for manual verification:

- Model: `qwen3.6-35b-nvfp4`
- Server args include:
  - `--reasoning-parser qwen3`
  - `--default-chat-template-kwargs '{"enable_thinking": false}'`

Before fix:

- Non-streaming response returned `message.content: "12"`
- Streaming response emitted:
  - `delta.reasoning: "1"`
  - `delta.reasoning: "2"`
  - no usable `delta.content`

After fix:

- Non-streaming response returns:

```json
{
  "choices": [
    {
      "message": {
        "content": "12",
        "reasoning": null
      }
    }
  ]
}
```

- Streaming response emits:

```text
data: {"choices":[{"delta":{"role":"assistant","content":""},"finish_reason":null}]}
data: {"choices":[{"delta":{"content":"1"},"finish_reason":null}]}
data: {"choices":[{"delta":{"content":"2"},"finish_reason":null}]}
data: {"choices":[{"delta":{},"finish_reason":"stop"}]}
data: [DONE]
```

Observed result:

- Answer tokens now stay in `delta.content`
- No `delta.reasoning` is emitted for the disabled-thinking request

Documentation update:

- No documentation update required for this bug fix

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

