### PR TITLE
[OOT] Support platform-specific config propagation via platform_extra

### DIFF
--- a/tests/config/test_platform_extra_decorator.py
+++ b/tests/config/test_platform_extra_decorator.py
@@ -3,6 +3,8 @@
 
 import pickle
 
+import pytest
+
 from vllm.config.cache import CacheConfig
 from vllm.config.device import DeviceConfig
 from vllm.config.load import LoadConfig
@@ -10,6 +12,23 @@ from vllm.config.parallel import ParallelConfig
 from vllm.config.scheduler import SchedulerConfig
 from vllm.config.utils import config, get_hash_factors, replace, update_config
 from vllm.config.vllm import VllmConfig
+
+
+def _make_vllm_config() -> VllmConfig:
+    return VllmConfig(
+        cache_config=CacheConfig(block_size=32),
+        device_config=DeviceConfig(device="cpu"),
+        parallel_config=ParallelConfig(
+            pipeline_parallel_size=1, tensor_parallel_size=1
+        ),
+        scheduler_config=SchedulerConfig(
+            max_num_batched_tokens=100,
+            max_num_seqs=50,
+            max_model_len=1024,
+            is_encoder_decoder=False,
+        ),
+        load_config=LoadConfig(),
+    )
 
 
 def test_platform_extra_in_cache_config():
@@ -30,20 +49,7 @@ def test_platform_extra_in_cache_config():
 
 
 def test_platform_extra_in_vllm_config():
-    v = VllmConfig(
-        cache_config=CacheConfig(block_size=32),
-        device_config=DeviceConfig(device="cpu"),
-        parallel_config=ParallelConfig(
-            pipeline_parallel_size=1, tensor_parallel_size=1
-        ),
-        scheduler_config=SchedulerConfig(
-            max_num_batched_tokens=100,
-            max_num_seqs=50,
-            max_model_len=1024,
-            is_encoder_decoder=False,
-        ),
-        load_config=LoadConfig(),
-    )
+    v = _make_vllm_config()
 
     v.platform_extra["global_hardware_id"] = "OOT-GPU-1"
     v.device_config.platform_extra["clock_speed"] = 1500
@@ -71,7 +77,6 @@ def test_platform_extra_inheritance():
     assert s.sub_val == 2
     assert s.platform_extra["injected"] is True
 
-    # Validate MRO logic: the shared extension point is inherited once.
     import dataclasses
 
     fields = [f.name for f in dataclasses.fields(SubConfig)]
@@ -104,3 +109,85 @@ def test_platform_extra_update_config_override():
     updated = update_config(c, {"platform_extra": {"oot_mode": "safe"}})
 
     assert updated.platform_extra == {"oot_mode": "safe"}
+
+
+def test_platform_extra_set_dispatches_to_existing_config_targets():
+    v = _make_vllm_config()
+
+    v.set_platform_extra("cache_config.oot_mode", "turbo")
+    v.set_platform_extra("device_config.clock_speed", 1500)
+    v.set_platform_extra("scheduler_config.custom_scheduler_policy", "LIFO")
+
+    assert v.cache_config.platform_extra == {"oot_mode": "turbo"}
+    assert v.device_config.platform_extra == {"clock_speed": 1500}
+    assert v.scheduler_config.platform_extra == {"custom_scheduler_policy": "LIFO"}
+
+
+def test_platform_extra_set_survives_replace_update_and_hash():
+    v = _make_vllm_config()
+    v.set_platform_extra("cache_config.oot_mode", "turbo")
+
+    replaced = replace(v, load_config=replace(v.load_config))
+    updated = update_config(v, {"load_config": {}})
+    factors = get_hash_factors(v.cache_config, set())
+
+    assert replaced.cache_config.platform_extra == {"oot_mode": "turbo"}
+    assert updated.cache_config.platform_extra == {"oot_mode": "turbo"}
+    assert factors["platform_extra"] == (("oot_mode", "turbo"),)
+
+
+def test_platform_extra_rejects_unsupported_unstable_values():
+    class UnsupportedValue:
+        pass
+
+    c = CacheConfig(block_size=16)
+    c.platform_extra["bad"] = UnsupportedValue()
+
+    with pytest.raises(TypeError, match="unsupported type"):
+        get_hash_factors(c, set())
+
+
+def test_platform_extra_read_does_not_materialize_state():
+    c = CacheConfig(block_size=16)
+
+    assert "_platform_extra" not in c.__dict__
+
+    _ = c.platform_extra
+
+    assert "_platform_extra" not in c.__dict__
+
+
+@pytest.mark.parametrize("mutator", [replace, update_config])
+def test_platform_extra_rejects_unsupported_values_deterministically(mutator):
+    c = CacheConfig(block_size=16)
+
+    with pytest.raises(TypeError, match="platform_extra"):
+        if mutator is replace:
+            mutator(c, platform_extra={"unsafe": object()})
+        else:
+            mutator(c, {"platform_extra": {"unsafe": object()}})
+
+
+
+def test_platform_extra_attribute_fallback():
+    c = CacheConfig(block_size=16)
+    
+    # 2. missing key raises AttributeError
+    with pytest.raises(AttributeError, match="'CacheConfig' object has no attribute 'missing'"):
+        _ = c.missing
+
+    # 1. read-only attribute fallback from platform_extra
+    c.platform_extra["oot_policy"] = "turbo"
+    assert c.oot_policy == "turbo"
+    
+    # 3. real field name collisions do not get shadowed by platform_extra
+    c.platform_extra["block_size"] = 99
+    assert c.block_size == 16
+    
+    # 4. worker/pickle path still works if attribute is read after restore
+    c_pickled = pickle.loads(pickle.dumps(c))
+    assert c_pickled.oot_policy == "turbo"
+    assert c_pickled.block_size == 16
+    with pytest.raises(AttributeError):
+        _ = c_pickled.missing
+

--- a/tests/config/test_platform_extra_decorator.py
+++ b/tests/config/test_platform_extra_decorator.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pickle
+
+from vllm.config.cache import CacheConfig
+from vllm.config.device import DeviceConfig
+from vllm.config.load import LoadConfig
+from vllm.config.parallel import ParallelConfig
+from vllm.config.scheduler import SchedulerConfig
+from vllm.config.utils import config, get_hash_factors, replace, update_config
+from vllm.config.vllm import VllmConfig
+
+
+def test_platform_extra_in_cache_config():
+    c_default = CacheConfig(block_size=16)
+    assert c_default.platform_extra == {}
+
+    c = CacheConfig(block_size=32)
+    c.platform_extra["oot_mode"] = "turbo"
+    c.platform_extra["dma_buffer"] = 1024
+
+    factors = get_hash_factors(c, set())
+    assert "platform_extra" in factors
+    assert factors["platform_extra"] == (("dma_buffer", 1024), ("oot_mode", "turbo"))
+
+    c_pickled = pickle.loads(pickle.dumps(c))
+    assert c_pickled.platform_extra["oot_mode"] == "turbo"
+    assert c_pickled.platform_extra["dma_buffer"] == 1024
+
+
+def test_platform_extra_in_vllm_config():
+    v = VllmConfig(
+        cache_config=CacheConfig(block_size=32),
+        device_config=DeviceConfig(device="cpu"),
+        parallel_config=ParallelConfig(
+            pipeline_parallel_size=1, tensor_parallel_size=1
+        ),
+        scheduler_config=SchedulerConfig(
+            max_num_batched_tokens=100,
+            max_num_seqs=50,
+            max_model_len=1024,
+            is_encoder_decoder=False,
+        ),
+        load_config=LoadConfig(),
+    )
+
+    v.platform_extra["global_hardware_id"] = "OOT-GPU-1"
+    v.device_config.platform_extra["clock_speed"] = 1500
+    v.scheduler_config.platform_extra["custom_scheduler_policy"] = "LIFO"
+
+    v_worker = pickle.loads(pickle.dumps(v))
+
+    assert v_worker.platform_extra["global_hardware_id"] == "OOT-GPU-1"
+    assert v_worker.device_config.platform_extra["clock_speed"] == 1500
+    assert v_worker.scheduler_config.platform_extra["custom_scheduler_policy"] == "LIFO"
+
+
+def test_platform_extra_inheritance():
+    @config
+    class BaseConfig:
+        base_val: int
+
+    @config
+    class SubConfig(BaseConfig):
+        sub_val: int
+
+    s = SubConfig(base_val=1, sub_val=2)
+    s.platform_extra["injected"] = True
+    assert s.base_val == 1
+    assert s.sub_val == 2
+    assert s.platform_extra["injected"] is True
+
+    # Validate MRO logic: the shared extension point is inherited once.
+    import dataclasses
+
+    fields = [f.name for f in dataclasses.fields(SubConfig)]
+    assert "platform_extra" not in fields
+
+
+def test_platform_extra_replace_preserves_state():
+    c = CacheConfig(block_size=16)
+    c.platform_extra["oot_mode"] = "turbo"
+
+    updated = replace(c, block_size=32)
+
+    assert updated.block_size == 32
+    assert updated.platform_extra == {"oot_mode": "turbo"}
+
+
+def test_platform_extra_replace_override():
+    c = CacheConfig(block_size=16)
+    c.platform_extra["oot_mode"] = "turbo"
+
+    updated = replace(c, platform_extra={"oot_mode": "safe", "lanes": 2})
+
+    assert updated.platform_extra == {"oot_mode": "safe", "lanes": 2}
+
+
+def test_platform_extra_update_config_override():
+    c = CacheConfig(block_size=16)
+    c.platform_extra["oot_mode"] = "turbo"
+
+    updated = update_config(c, {"platform_extra": {"oot_mode": "safe"}})
+
+    assert updated.platform_extra == {"oot_mode": "safe"}

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import dataclasses
 import json
 from argparse import ArgumentError
 from contextlib import AbstractContextManager, nullcontext
@@ -11,6 +12,7 @@ from pydantic import Field
 
 from vllm.config import AttentionConfig, CompilationConfig, ModelConfig, config
 from vllm.engine.arg_utils import (
+    AsyncEngineArgs,
     EngineArgs,
     _expand_json_human_readable_numbers,
     contains_type,
@@ -597,7 +599,6 @@ def test_ir_op_priority():
             kernel_config=KernelConfig(ir_op_priority=ir_op_priority),
         ).create_engine_config()
 
-
 @pytest.mark.parametrize(
     ("input_json", "expected_json"),
     [
@@ -625,3 +626,77 @@ def test_ir_op_priority():
 )
 def test_expand_json_human_readable_numbers(input_json, expected_json):
     assert _expand_json_human_readable_numbers(input_json) == expected_json
+
+
+class _DummyOOTPlatform:
+    @classmethod
+    def pre_register_and_update(cls, parser):
+        parser.add_argument("--oot-param", type=int)
+        return parser
+
+
+def test_add_cli_args_accepts_oot_args(monkeypatch):
+    monkeypatch.setattr("vllm.engine.arg_utils.load_general_plugins", lambda: None)
+    monkeypatch.setattr("vllm.engine.arg_utils.current_platform", _DummyOOTPlatform())
+
+    parser = AsyncEngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(["--oot-param", "7"])
+
+    assert args.oot_param == 7
+
+    engine_args = EngineArgs.from_cli_args(args=args)
+    assert engine_args.additional_config["oot_platform_params"]["oot_param"] == 7
+
+
+def test_add_cli_args_rejects_oot_flags(monkeypatch):
+    monkeypatch.setattr("vllm.engine.arg_utils.load_general_plugins", lambda: None)
+    monkeypatch.setattr("vllm.engine.arg_utils.current_platform", _DummyOOTPlatform())
+
+    parser = AsyncEngineArgs.add_cli_args(FlexibleArgumentParser())
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--unknown-flag", "7"])
+
+
+class _DummyNoPlatform:
+    @classmethod
+    def pre_register_and_update(cls, parser):
+        return parser
+
+
+def test_no_oot_platform_params_when_no_platform_args(monkeypatch):
+    monkeypatch.setattr("vllm.engine.arg_utils.load_general_plugins", lambda: None)
+    monkeypatch.setattr("vllm.engine.arg_utils.current_platform", _DummyNoPlatform())
+
+    parser = AsyncEngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args([])
+
+    engine_args = EngineArgs.from_cli_args(args=args)
+    assert "oot_platform_params" not in engine_args.additional_config
+
+
+def test_unrelated_extra_flag_not_captured_into_oot_platform_params(monkeypatch):
+    monkeypatch.setattr("vllm.engine.arg_utils.load_general_plugins", lambda: None)
+    monkeypatch.setattr("vllm.engine.arg_utils.current_platform", _DummyOOTPlatform())
+
+    parser = AsyncEngineArgs.add_cli_args(FlexibleArgumentParser())
+    parser.add_argument("--unrelated-flag", type=str, default="ignored")
+    args = parser.parse_args(["--oot-param", "3", "--unrelated-flag", "surprise"])
+
+    engine_args = EngineArgs.from_cli_args(args=args)
+    oot = engine_args.additional_config.get("oot_platform_params", {})
+    assert oot.get("oot_param") == 3
+    assert "unrelated_flag" not in oot
+
+
+def test_core_engine_args_not_duplicated_into_oot_platform_params(monkeypatch):
+    monkeypatch.setattr("vllm.engine.arg_utils.load_general_plugins", lambda: None)
+    monkeypatch.setattr("vllm.engine.arg_utils.current_platform", _DummyOOTPlatform())
+
+    parser = AsyncEngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(["--oot-param", "5"])
+
+    engine_args = EngineArgs.from_cli_args(args=args)
+    oot = engine_args.additional_config.get("oot_platform_params", {})
+    core_fields = {f.name for f in dataclasses.fields(EngineArgs)}
+    assert not (core_fields & set(oot.keys()))

--- a/tests/engine/test_oot_platform_propagation.py
+++ b/tests/engine/test_oot_platform_propagation.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pickle
+
+import pytest
+
+from vllm.config.cache import CacheConfig
+from vllm.config.device import DeviceConfig
+from vllm.config.load import LoadConfig
+from vllm.config.parallel import ParallelConfig
+from vllm.config.scheduler import SchedulerConfig
+from vllm.config.vllm import VllmConfig
+from vllm.platforms.interface import Platform, PlatformEnum
+
+
+class _OOTPlatformStub(Platform):
+    _enum = PlatformEnum.OOT
+    device_name = "StubDevice"
+    device_type: str = "privateuseone"
+    dispatch_key: str = "PrivateUse1"
+
+    @classmethod
+    def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
+        oot_vals = vllm_config.additional_config.get("oot_platform_params", {})
+
+        dma_buffer = oot_vals.get("dma_buffer")
+        if dma_buffer is not None:
+            vllm_config.set_platform_extra("cache_config.dma_buffer", dma_buffer)
+
+        hw_id = oot_vals.get("hardware_id")
+        if hw_id is not None:
+            vllm_config.set_platform_extra("hardware_id", hw_id)
+
+        scheduler_policy = oot_vals.get("scheduler_policy")
+        if scheduler_policy is not None:
+            vllm_config.set_platform_extra("scheduler_config.oot_policy", scheduler_policy)
+
+
+def _make_minimal_vllm_config(additional_config=None) -> VllmConfig:
+    return VllmConfig(
+        cache_config=CacheConfig(block_size=16),
+        device_config=DeviceConfig(device="cpu"),
+        parallel_config=ParallelConfig(
+            pipeline_parallel_size=1,
+            tensor_parallel_size=1,
+        ),
+        scheduler_config=SchedulerConfig(
+            max_num_batched_tokens=256,
+            max_num_seqs=32,
+            max_model_len=512,
+            is_encoder_decoder=False,
+        ),
+        load_config=LoadConfig(),
+        additional_config=additional_config or {},
+    )
+
+
+def test_oot_platform_check_and_update_reads_cli_derived_values():
+    cli_derived = {
+        "oot_platform_params": {
+            "dma_buffer": 4096,
+            "hardware_id": "OOT-GPU-42",
+            "scheduler_policy": "LIFO",
+        }
+    }
+
+    vllm_config = _make_minimal_vllm_config(additional_config=cli_derived)
+    _OOTPlatformStub.check_and_update_config(vllm_config)
+
+    assert vllm_config.cache_config.platform_extra.get("dma_buffer") == 4096, (
+        "CLI-derived dma_buffer must be propagated into cache_config.platform_extra "
+        "by the OOT platform's check_and_update_config. "
+        "Missing: path-based dispatch from additional_config to sub-config platform_extra."
+    )
+    assert vllm_config.platform_extra.get("hardware_id") == "OOT-GPU-42", (
+        "CLI-derived hardware_id must be propagated into top-level platform_extra."
+    )
+    assert vllm_config.scheduler_config.platform_extra.get("oot_policy") == "LIFO", (
+        "CLI-derived scheduler_policy must be propagated into scheduler_config.platform_extra."
+    )
+
+
+def test_oot_platform_extra_survives_pickle_worker_boundary():
+    cli_derived = {
+        "oot_platform_params": {
+            "dma_buffer": 8192,
+            "hardware_id": "OOT-ACCEL-7",
+        }
+    }
+
+    vllm_config = _make_minimal_vllm_config(additional_config=cli_derived)
+    _OOTPlatformStub.check_and_update_config(vllm_config)
+
+    worker_config = pickle.loads(pickle.dumps(vllm_config))
+
+    assert worker_config.cache_config.platform_extra.get("dma_buffer") == 8192, (
+        "After pickle round-trip (worker boundary), cache_config.platform_extra['dma_buffer'] "
+        "must equal the CLI-derived value. "
+        "Missing: end-to-end propagation from CLI -> check_and_update_config -> platform_extra -> pickle."
+    )
+    assert worker_config.platform_extra.get("hardware_id") == "OOT-ACCEL-7", (
+        "After pickle round-trip, top-level platform_extra['hardware_id'] must survive."
+    )
+
+
+def test_oot_platform_extra_no_phantom_injection():
+    vllm_config = _make_minimal_vllm_config(additional_config={})
+    _OOTPlatformStub.check_and_update_config(vllm_config)
+
+    assert "dma_buffer" not in vllm_config.cache_config.platform_extra, (
+        "dma_buffer must not appear in cache_config.platform_extra when not provided via CLI."
+    )
+    assert "hardware_id" not in vllm_config.platform_extra, (
+        "hardware_id must not appear in top-level platform_extra when not provided via CLI."
+    )
+
+
+def test_engine_args_additional_config_to_worker_propagation():
+    from vllm.engine.arg_utils import EngineArgs
+
+    engine_args = EngineArgs(
+        model="facebook/opt-125m",
+        additional_config={
+            "oot_platform_params": {
+                "dma_buffer": 2048,
+                "hardware_id": "CLI-OOT-1",
+            }
+        },
+    )
+
+    vllm_config = _make_minimal_vllm_config(
+        additional_config=engine_args.additional_config
+    )
+    _OOTPlatformStub.check_and_update_config(vllm_config)
+
+    worker_config = pickle.loads(pickle.dumps(vllm_config))
+
+    assert worker_config.cache_config.platform_extra.get("dma_buffer") == 2048, (
+        "CLI-derived dma_buffer (via EngineArgs.additional_config) must be visible "
+        "to workers after pickle round-trip. "
+        "This is the core Engine->Worker propagation requirement."
+    )
+    assert worker_config.platform_extra.get("hardware_id") == "CLI-OOT-1", (
+        "CLI-derived hardware_id must survive the Engine->Worker boundary."
+    )
+
+
+def test_platform_dispatch_platform_extra_helper_exists():
+    from vllm.platforms.interface import Platform
+
+    assert hasattr(Platform, "dispatch_platform_extra"), (
+        "Platform must expose a dispatch_platform_extra(vllm_config, path, value) "
+        "class method so OOT platforms can propagate CLI-derived values into "
+        "sub-config platform_extra fields without manual path traversal. "
+        "This is the MISSING standardized path-dispatch mechanism."
+    )
+
+
+def test_vllm_config_set_platform_extra_by_path():
+    vllm_config = _make_minimal_vllm_config()
+
+    assert hasattr(vllm_config, "set_platform_extra"), (
+        "VllmConfig must expose a set_platform_extra(path, value) method "
+        "so OOT platforms can use path-based dispatch (e.g., 'cache_config.dma_buffer') "
+        "instead of manual attribute traversal. "
+        "This is the MISSING path-dispatch API on VllmConfig."
+    )
+
+    vllm_config.set_platform_extra("cache_config.dma_buffer", 4096)
+    assert vllm_config.cache_config.platform_extra.get("dma_buffer") == 4096, (
+        "set_platform_extra('cache_config.dma_buffer', 4096) must set "
+        "vllm_config.cache_config.platform_extra['dma_buffer'] = 4096."
+    )
+
+    vllm_config.set_platform_extra("hardware_id", "OOT-GPU-1")
+    assert vllm_config.platform_extra.get("hardware_id") == "OOT-GPU-1", (
+        "set_platform_extra('hardware_id', value) must set top-level platform_extra."
+    )
+
+    worker_config = pickle.loads(pickle.dumps(vllm_config))
+    assert worker_config.cache_config.platform_extra.get("dma_buffer") == 4096
+    assert worker_config.platform_extra.get("hardware_id") == "OOT-GPU-1"
+
+def test_invalid_dispatch_path_raises_error():
+    vllm_config = _make_minimal_vllm_config()
+    with pytest.raises(AttributeError, match="VllmConfig has no attribute 'invalid_config'"):
+        vllm_config.set_platform_extra("invalid_config.foo", 123)
+
+
+
+def test_non_oot_default_no_platform_extra_materialized():
+    vllm_config = _make_minimal_vllm_config(additional_config={})
+
+    assert "oot_platform_params" not in vllm_config.additional_config, (
+        "Non-OOT path must not inject oot_platform_params into additional_config."
+    )
+    assert vllm_config.platform_extra == {}, (
+        "Top-level platform_extra must be empty on the non-OOT default path."
+    )
+    assert vllm_config.cache_config.platform_extra == {}, (
+        "cache_config.platform_extra must be empty on the non-OOT default path."
+    )
+    assert vllm_config.scheduler_config.platform_extra == {}, (
+        "scheduler_config.platform_extra must be empty on the non-OOT default path."
+    )
+
+
+def test_non_oot_default_pickle_round_trip_clean():
+    import pickle
+
+    vllm_config = _make_minimal_vllm_config(additional_config={})
+    worker_config = pickle.loads(pickle.dumps(vllm_config))
+
+    assert worker_config.platform_extra == {}, (
+        "After pickle round-trip on non-OOT config, top-level platform_extra must be empty."
+    )
+    assert worker_config.cache_config.platform_extra == {}, (
+        "After pickle round-trip on non-OOT config, cache_config.platform_extra must be empty."
+    )

--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -29,6 +29,74 @@ logger = init_logger(__name__)
 
 _PLATFORM_EXTRA_ATTR = "_platform_extra"
 
+
+class _PlatformExtraView(dict[str, Any]):
+
+    def __init__(self, owner: Any) -> None:
+        self._owner = owner
+
+    def _storage(self) -> dict[str, Any]:
+        platform_extra = self._owner.__dict__.get(_PLATFORM_EXTRA_ATTR)
+        if platform_extra is None:
+            platform_extra = {}
+            self._owner.__dict__[_PLATFORM_EXTRA_ATTR] = platform_extra
+        return cast(dict[str, Any], platform_extra)
+
+    def __getitem__(self, key: str) -> Any:
+        return self._storage()[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self._storage()[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self._storage()[key]
+
+    def __iter__(self):
+        return iter(self._owner.__dict__.get(_PLATFORM_EXTRA_ATTR, {}))
+
+    def __len__(self) -> int:
+        return len(self._owner.__dict__.get(_PLATFORM_EXTRA_ATTR, {}))
+
+    def __contains__(self, key: object) -> bool:
+        return key in self._owner.__dict__.get(_PLATFORM_EXTRA_ATTR, {})
+
+    def __eq__(self, other: object) -> bool:
+        return dict(self._owner.__dict__.get(_PLATFORM_EXTRA_ATTR, {})) == other
+
+    def __repr__(self) -> str:
+        return repr(dict(self._owner.__dict__.get(_PLATFORM_EXTRA_ATTR, {})))
+
+    def get(self, key: str, default: Any = None) -> Any:
+        return self._owner.__dict__.get(_PLATFORM_EXTRA_ATTR, {}).get(key, default)
+
+    def keys(self):
+        return self._owner.__dict__.get(_PLATFORM_EXTRA_ATTR, {}).keys()
+
+    def values(self):
+        return self._owner.__dict__.get(_PLATFORM_EXTRA_ATTR, {}).values()
+
+    def items(self):
+        return self._owner.__dict__.get(_PLATFORM_EXTRA_ATTR, {}).items()
+
+    def copy(self) -> dict[str, Any]:
+        return dict(self._owner.__dict__.get(_PLATFORM_EXTRA_ATTR, {}))
+
+    def update(self, *args: Any, **kwargs: Any) -> None:
+        self._storage().update(*args, **kwargs)
+
+    def setdefault(self, key: str, default: Any = None) -> Any:
+        return self._storage().setdefault(key, default)
+
+    def pop(self, key: str, default: Any = MISSING) -> Any:
+        storage = self._storage()
+        if default is MISSING:
+            return storage.pop(key)
+        return storage.pop(key, default)
+
+    def clear(self) -> None:
+        if _PLATFORM_EXTRA_ATTR in self._owner.__dict__:
+            self._owner.__dict__[_PLATFORM_EXTRA_ATTR].clear()
+
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance
 else:
@@ -77,13 +145,16 @@ def config(
     def get_platform_extra(self: Any) -> dict[str, Any]:
         platform_extra = self.__dict__.get(_PLATFORM_EXTRA_ATTR)
         if platform_extra is None:
-            platform_extra = {}
-            self.__dict__[_PLATFORM_EXTRA_ATTR] = platform_extra
+            return cast(dict[str, Any], _PlatformExtraView(self))
         return cast(dict[str, Any], platform_extra)
 
     def set_platform_extra(self: Any, value: Mapping[str, Any]) -> None:
         if not isinstance(value, Mapping):
             raise TypeError("platform_extra must be a mapping (e.g., dict).")
+        try:
+            normalize_value(value)
+        except TypeError as e:
+            raise TypeError(f"Invalid platform_extra value: {e}")
         self.__dict__[_PLATFORM_EXTRA_ATTR] = dict(value)
 
     def decorator(cls: type[ConfigT]) -> type[ConfigT]:
@@ -95,6 +166,14 @@ def config(
 
         if not has_platform_extra:
             cls.platform_extra = property(get_platform_extra, set_platform_extra)
+
+        if not hasattr(cls, "__getattr__"):
+            def __getattr__(self: Any, name: str) -> Any:
+                platform_extra = self.__dict__.get(_PLATFORM_EXTRA_ATTR)
+                if platform_extra and name in platform_extra:
+                    return platform_extra[name]
+                raise AttributeError(f"'{cls.__name__}' object has no attribute '{name}'")
+            cls.__getattr__ = __getattr__
 
         return dataclass(cls, config=merged_config, **kwargs)  # type: ignore[return-value]
 
@@ -158,7 +237,12 @@ def replace(dataclass_instance: ConfigT, /, **kwargs) -> ConfigT:
     dataclass_dict = {
         k: v
         for k, v in dataclass_dict.items()
-        if k in dataclass_field_names and is_init_field(cls, k)
+        if (
+            k in dataclass_field_names
+            and is_init_field(cls, k)
+            and not (dataclass_field_names[k].default_factory is not MISSING and v is None)
+            and not (dataclass_field_names[k].default is None and v is None)
+        )
     }
     dataclass_dict.update(kwargs)
     new_instance = cls(**dataclass_dict)
@@ -311,10 +395,8 @@ def normalize_value(x):
     if callable(x):
         raise TypeError("normalize_value: function or callable instance unsupported")
 
-    # Torch dtype: stringify (torch.float64 -> "torch.float64").
-    # We rely on the string form here; dtype-bearing fields that need additional
-    # disambiguation should encode that at the config layer.
-    if isinstance(x, torch.dtype):
+    # Torch dtype and device: stringify.
+    if isinstance(x, (torch.dtype, torch.device)):
         return str(x)
 
     # Bytes

--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -27,6 +27,8 @@ from vllm.logger import init_logger
 
 logger = init_logger(__name__)
 
+_PLATFORM_EXTRA_ATTR = "_platform_extra"
+
 if TYPE_CHECKING:
     from _typeshed import DataclassInstance
 else:
@@ -44,7 +46,9 @@ def config(cls: type[ConfigT]) -> type[ConfigT]: ...
 @overload
 @dataclass_transform(field_specifiers=(PydanticField,))
 def config(
-    *, config: ConfigDict | None = None, **kwargs: Any
+    *,
+    config: ConfigDict | None = None,
+    **kwargs: Any,
 ) -> Callable[[type[ConfigT]], type[ConfigT]]: ...
 
 
@@ -70,7 +74,28 @@ def config(
     if config is not None:
         merged_config.update(config)
 
+    def get_platform_extra(self: Any) -> dict[str, Any]:
+        platform_extra = self.__dict__.get(_PLATFORM_EXTRA_ATTR)
+        if platform_extra is None:
+            platform_extra = {}
+            self.__dict__[_PLATFORM_EXTRA_ATTR] = platform_extra
+        return cast(dict[str, Any], platform_extra)
+
+    def set_platform_extra(self: Any, value: Mapping[str, Any]) -> None:
+        if not isinstance(value, Mapping):
+            raise TypeError("platform_extra must be a mapping (e.g., dict).")
+        self.__dict__[_PLATFORM_EXTRA_ATTR] = dict(value)
+
     def decorator(cls: type[ConfigT]) -> type[ConfigT]:
+        has_platform_extra = False
+        for base in getattr(cls, "__mro__", []):
+            if hasattr(base, "platform_extra"):
+                has_platform_extra = True
+                break
+
+        if not has_platform_extra:
+            cls.platform_extra = property(get_platform_extra, set_platform_extra)
+
         return dataclass(cls, config=merged_config, **kwargs)  # type: ignore[return-value]
 
     # Called with arguments: @config(config=...)
@@ -122,9 +147,33 @@ def replace(dataclass_instance: ConfigT, /, **kwargs) -> ConfigT:
     of `dataclasses.field`"""
     cls = type(dataclass_instance)
     dataclass_dict = dataclass_instance.__dict__
-    dataclass_dict = {k: v for k, v in dataclass_dict.items() if is_init_field(cls, k)}
+    dataclass_field_names = getattr(cls, "__dataclass_fields__", {})
+    has_dynamic_platform_extra = (
+        hasattr(cls, "platform_extra")
+        and "platform_extra" not in dataclass_field_names
+    )
+    platform_extra = MISSING
+    if has_dynamic_platform_extra and "platform_extra" in kwargs:
+        platform_extra = kwargs.pop("platform_extra")
+    dataclass_dict = {
+        k: v
+        for k, v in dataclass_dict.items()
+        if k in dataclass_field_names and is_init_field(cls, k)
+    }
     dataclass_dict.update(kwargs)
-    return cls(**dataclass_dict)
+    new_instance = cls(**dataclass_dict)
+
+    # Copy fields that are not in the __init__ method from the original
+    # instance, matching the behavior of dataclasses.replace.
+    for f in dataclass_field_names.values():
+        if not f.init:
+            setattr(new_instance, f.name, getattr(dataclass_instance, f.name))
+
+    if has_dynamic_platform_extra:
+        if platform_extra is MISSING:
+            platform_extra = dataclass_instance.__dict__.get(_PLATFORM_EXTRA_ATTR, {})
+        new_instance.platform_extra = dict(platform_extra)
+    return new_instance
 
 
 def getattr_iter(
@@ -282,11 +331,14 @@ def normalize_value(x):
     # Dataclasses: represent as (FQN, sorted(field,value) tuple) for stability.
     if is_dataclass(x):
         type_fqn = f"{x.__class__.__module__}.{x.__class__.__qualname__}"
-        items = tuple(
-            (f.name, normalize_value(getattr(x, f.name)))
-            for f in sorted(fields(x), key=lambda f: f.name)
-        )
-        return (type_fqn, items)
+        dc_fields = tuple(sorted(fields(x), key=lambda f: f.name))
+        items = [(f.name, normalize_value(getattr(x, f.name))) for f in dc_fields]
+        if not any(f.name == "platform_extra" for f in dc_fields):
+            platform_extra = getattr(x, "__dict__", {}).get(_PLATFORM_EXTRA_ATTR)
+            if platform_extra:
+                items.append(("platform_extra", normalize_value(platform_extra)))
+                items.sort(key=lambda x: x[0])
+        return (type_fqn, tuple(items))
 
     # Containers (generic)
     if isinstance(x, Mapping):
@@ -339,6 +391,16 @@ def get_hash_factors(config: ConfigT, ignored_factors: set[str]) -> dict[str, ob
                 f"get_hash_factors: unsupported type for key '{factor}' "
                 f"({type(value).__name__})"
             ) from e
+    if "platform_extra" not in ignored_factors and "platform_extra" not in factors:
+        platform_extra = getattr(config, "__dict__", {}).get(_PLATFORM_EXTRA_ATTR)
+        if platform_extra:
+            try:
+                factors["platform_extra"] = normalize_value(platform_extra)
+            except TypeError as e:
+                raise TypeError(
+                    "get_hash_factors: unsupported type for key 'platform_extra' "
+                    f"({type(platform_extra).__name__})"
+                ) from e
     return factors
 
 

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1400,6 +1400,25 @@ class VllmConfig:
         # Log the custom passes that are enabled
         self.compilation_config.pass_config.log_enabled_passes()
 
+    def set_platform_extra(self, path: str, value: Any) -> None:
+        if not path:
+            raise ValueError("path must be non-empty")
+
+        parts = path.split(".")
+        if len(parts) == 1:
+            self.platform_extra[parts[0]] = value
+            return
+
+        target: Any = self
+        for part in parts[:-1]:
+            if not hasattr(target, part):
+                raise AttributeError(
+                    f"{type(target).__name__} has no attribute '{part}' in path '{path}'"
+                )
+            target = getattr(target, part)
+
+        target.platform_extra[parts[-1]] = value
+
     def update_sizes_for_sequence_parallelism(self, possible_sizes: list) -> list:
         # remove the sizes that not multiple of tp_size when
         # enable sequence parallelism

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1474,10 +1474,22 @@ class EngineArgs:
     def from_cli_args(cls, args: argparse.Namespace):
         # Get the list of attributes of this dataclass.
         attrs = [attr.name for attr in dataclasses.fields(cls)]
+        oot_dest_names: set[str] = getattr(args, "_oot_platform_dest_names", set())
+        platform_only_args = {
+            key: vars(args)[key]
+            for key in oot_dest_names
+            if key in vars(args)
+        }
         # Set the attributes from the parsed arguments.
         engine_args = cls(
             **{attr: getattr(args, attr) for attr in attrs if hasattr(args, attr)}
         )
+        if platform_only_args:
+            additional_config = dict(engine_args.additional_config)
+            oot_platform_params = dict(additional_config.get("oot_platform_params", {}))
+            oot_platform_params.update(platform_only_args)
+            additional_config["oot_platform_params"] = oot_platform_params
+            engine_args.additional_config = additional_config
         return engine_args
 
     def create_model_config(self) -> ModelConfig:
@@ -2458,7 +2470,10 @@ class AsyncEngineArgs(EngineArgs):
             "- DEBUG: Prompt inputs (e.g: text, token IDs).\n"
             "You can set the minimum log level via `VLLM_LOGGING_LEVEL`.",
         )
+        dests_before = {a.dest for a in parser._actions}
         current_platform.pre_register_and_update(parser)
+        oot_dests = {a.dest for a in parser._actions} - dests_before
+        parser.set_defaults(_oot_platform_dest_names=oot_dests)
         return parser
 
 

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -443,6 +443,18 @@ class Platform:
         pass
 
     @classmethod
+    def dispatch_platform_extra(
+        cls,
+        vllm_config: "VllmConfig",
+        path: str,
+        value: Any,
+    ) -> None:
+        """Dispatch an OOT platform value into the appropriate config object's
+        platform_extra storage using a dot-separated path.
+        """
+        vllm_config.set_platform_extra(path, value)
+
+    @classmethod
     def _find_non_ssm_backend(
         cls, vllm_config: "VllmConfig"
     ) -> "type[AttentionBackend] | None":


### PR DESCRIPTION
Fixes #40813
## Summary
This PR adds a minimal and explicit extension path for Out-of-Tree (OOT) platforms to propagate platform-specific values through the existing vLLM lifecycle without introducing per-config schema fields into core config dataclasses.
The current flow is:
1. OOT platforms explicitly register CLI arguments through the existing platform hook
2. only platform-registered OOT args are propagated through `additional_config["oot_platform_params"]`
3. the active platform consumes them in `check_and_update_config(vllm_config)`
4. values are dispatched into existing config objects via `platform_extra`
This keeps the extension path OOT-scoped, explicit, and reusable across CLI -> Engine -> Worker.
---
## Motivation
OOT platforms can already participate in platform registration, but they still lack a standard way to carry platform-specific values from CLI parsing into existing config objects.
Without a shared path, OOT integrations tend to require one-off plumbing or repeated core schema changes. That increases maintenance cost for OOT platform implementations and makes the integration boundary less clear.
This PR fills that gap with a constrained extension seam that reuses the existing platform lifecycle rather than introducing a new plugin/config model.
---
## What this PR adds
### 1. Explicit OOT CLI registration path
OOT platforms continue to register their own CLI args through the existing:
- `pre_register_and_update(parser)`
This keeps argument visibility explicit and preserves normal CLI help / parser behavior.
### 2. Explicit transport through `additional_config`
Platform-registered OOT args are transported through:
- `additional_config["oot_platform_params"]`
Importantly, this path is now limited to **platform-registered** args only. Unrelated parser extensions are not swept into the OOT payload.
### 3. Explicit config-local storage through `platform_extra`
The active platform can dispatch values onto existing config objects through:
- `VllmConfig.set_platform_extra(path, value)`
- `Platform.dispatch_platform_extra(vllm_config, path, value)`
For example, an OOT platform can place a value on:
- `scheduler_config`
- `cache_config`
- `device_config`
without requiring a dedicated core schema field for each OOT-only option.
### 4. End-to-end worker-visible propagation
The resulting values remain available across the expected lifecycle boundaries, including CLI -> Engine -> Worker paths.
---
## Scope / Non-goals
This PR intentionally keeps the scope narrow:
- keeps strict CLI parsing
- does **not** introduce generic unknown-flag handling
- does **not** add per-config OOT fields to core dataclasses
- does **not** require modifying every config class for OOT-specific options
- does **not** introduce a separate plugin/config framework
The goal is to provide a reusable OOT extension seam with minimal core churn.
---
## Safety / Compatibility
This PR is intended to remain non-disruptive for default non-OOT users:
- default non-OOT paths remain clean
- no OOT payload is added when no platform args are registered
- unrelated parser extensions are not captured into OOT transport
- `platform_extra` remains the explicit storage path
- `replace()` preserves state correctly
- hash / pickle related behavior is covered by targeted validation
---
## Validation
Targeted tests cover:
- OOT parser registration
- undeclared OOT flag rejection
- no OOT payload when no platform args are registered
- unrelated extra parser flags not being captured
- core engine fields not being duplicated into OOT payload
- `platform_extra` hash / replace / pickle behavior
- CLI -> Engine -> Worker propagation with an in-tree OOT stub
- invalid dispatch path rejection
Focused verification passed for the OOT-related scope, including:
- `tests/engine/test_arg_utils.py` (OOT-related cases)
- `tests/engine/test_oot_platform_propagation.py`
- `tests/config/test_platform_extra_decorator.py`
---
## Why this helps OOT platform maintainers
This PR gives OOT platform implementations a more complete and maintainable integration path:
- **CLI usability**: OOT-specific args can be registered explicitly through the existing platform hook
- **transport completeness**: those values can move through engine creation without ad hoc plumbing
- **config reuse**: values can be attached to existing config objects without expanding upstream schemas
- **worker visibility**: values remain available across serialization / worker boundaries
- **lower maintenance cost**: OOT platform authors no longer need repeated one-off handling for each new platform-specific knob
In short, this aims to make OOT platform support more usable in practice while keeping the upstream extension surface narrow and explicit.