### PR TITLE
[Bugfix] Fix `RuntimeError: Already borrowed` by deepcopying tokenizer for AsyncMicrobatchTokenizer

### DIFF
--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -154,8 +154,11 @@ class BaseRenderer(ABC, Generic[_T]):
 
     def get_async_tokenizer(self) -> AsyncMicrobatchTokenizer:
         if self._async_tokenizer is None:
+            # Deep-copy the tokenizer so the AsyncMicrobatchTokenizer,
+            # which runs in an executor thread, gets its own Rust backend
+            tok = copy.deepcopy(self.get_tokenizer())
             self._async_tokenizer = AsyncMicrobatchTokenizer(
-                self.get_tokenizer(), executor=self._executor
+                tok, executor=self._executor
             )
 
         return self._async_tokenizer


### PR DESCRIPTION
## Purpose

Fix `RuntimeError: Already borrowed` when HuggingFace's Rust tokenizer backend is accessed simultaneously from parsers or `InputProcessor` in the request handling loop and from `AsyncMicrobatchTokenizer` in the renderer.

This PR follow up https://github.com/vllm-project/vllm/pull/40059, which patched all the tool parsers to no longer call `encode`.

This PR address the root cause by passing a deepcopy of the `tokenizer` to `AsyncMicrobatchTokenizer` to remove mutually exclusive sharing. Similar to https://github.com/vllm-project/vllm/pull/3655, which does the same between the multimodal processor and `AsyncMicrobatchTokenizer`.

More detailed issue: #40949

## Test Plan

Run on branch before https://github.com/vllm-project/vllm/pull/40059
```
BFCL_MODEL="meta-llama/Llama-3.3-70B-Instruct" \
BFCL_TOOL_CALL_PARSER="llama3_json" \
BFCL_TP_SIZE=2 \
BFCL_TEST_CATEGORY="multi_turn" \
BFCL_MAX_MODEL_LEN=16384 \
BFCL_EXTRA_ARGS="--data-parallel-size 2" \
bash .buildkite/scripts/tool_call/run-bfcl-eval.sh
```

Serve any chat completion capable model. Send concurrent chat completion requests with `bad_words` in SamplingParams.

## Test Result

No more HTTP 500 errors from BFCL or chat completion logs.

[llama-after2.out.txt](https://github.com/user-attachments/files/27066101/llama-after2.out.txt)
[llama-before.out.txt](https://github.com/user-attachments/files/27066102/llama-before.out.txt)


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

Made with [Cursor](https://cursor.com)