### PR TITLE
[Core] Add dynamo_timed tracing for compilation startup

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -926,6 +926,7 @@ class VllmBackend:
 
         return standalone_compile_artifacts, sym_shape_indices_map, returns_tuple_map
 
+    @dynamo_timed("vllm_configure_post_pass")
     def configure_post_pass(self) -> None:
         # TODO proper PassManager?
         pre_grad_pass_key = "pre_grad_custom_pass"
@@ -1168,27 +1169,30 @@ class VllmBackend:
         else:
             fx_split_ops = self.compilation_config.splitting_ops or []
 
-        self.split_gm, self.piecewise_graphs = split_graph(graph, fx_split_ops)
+        with dynamo_timed("vllm_split_graph"):
+            self.split_gm, self.piecewise_graphs = split_graph(graph, fx_split_ops)
 
         # keep a split_gm copy from BEFORE the interpreter replaces
         # submodules with PiecewiseBackend -- used for serialization
         original_split_gm = None
         if envs.VLLM_USE_MEGA_AOT_ARTIFACT:
-            original_split_gm = deepcopy(self.split_gm)
+            with dynamo_timed("vllm_deepcopy_split_gm"):
+                original_split_gm = deepcopy(self.split_gm)
 
-        from torch._dynamo.utils import lazy_format_graph_code
+        with dynamo_timed("vllm_graph_logging"):
+            from torch._dynamo.utils import lazy_format_graph_code
 
-        # depyf will hook lazy_format_graph_code and dump the graph
-        # for debugging, no need to print the graph here
-        lazy_format_graph_code("before split", self.graph)
-        lazy_format_graph_code("after split", self.split_gm)
+            # depyf will hook lazy_format_graph_code and dump the graph
+            # for debugging, no need to print the graph here
+            lazy_format_graph_code("before split", self.graph)
+            lazy_format_graph_code("after split", self.split_gm)
 
-        # Log the piecewise split graph for TORCH_TRACE/tlparse
-        trace_structured(
-            "graph_dump",
-            metadata_fn=lambda: {"name": "vllm_piecewise_split_graph"},
-            payload_fn=lambda: self.split_gm.print_readable(print_output=False),
-        )
+            # Log the piecewise split graph for TORCH_TRACE/tlparse
+            trace_structured(
+                "graph_dump",
+                metadata_fn=lambda: {"name": "vllm_piecewise_split_graph"},
+                payload_fn=lambda: self.split_gm.print_readable(print_output=False),
+            )
 
         compilation_counter.num_piecewise_graphs_seen += len(self.piecewise_graphs)
         submod_names_to_compile = [
@@ -1211,9 +1215,10 @@ class VllmBackend:
         # compile submodules with symbolic shapes, and compile all ranges
         # up front so that compilation is complete before the callable
         # is returned.
-        PiecewiseCompileInterpreter(
-            self.split_gm, submod_names_to_compile, self.vllm_config, self
-        ).run(*fake_args)
+        with dynamo_timed("vllm_piecewise_interpret"):
+            PiecewiseCompileInterpreter(
+                self.split_gm, submod_names_to_compile, self.vllm_config, self
+            ).run(*fake_args)
 
         # All compilation is done. Save the cache.
         time_before_saving = time.perf_counter()

--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -9,6 +9,7 @@ import threading
 
 import torch
 import torch.distributed as dist
+from torch._dynamo.utils import dynamo_timed
 from torch.distributed import ProcessGroup
 
 import vllm.envs as envs
@@ -51,15 +52,16 @@ def _create_workspace(
     rng_state = random.getstate()
     try:
         random.seed(int.from_bytes(os.urandom(16), byteorder="big"))
-        workspace = flashinfer_comm.create_allreduce_fusion_workspace(
-            backend=backend,
-            world_size=world_size,
-            rank=rank,
-            max_token_num=max_token_num,
-            hidden_dim=hidden_dim,
-            dtype=dtype,
-            comm_backend=comm_backend,
-        )
+        with dynamo_timed("vllm_fi_ar_create_allreduce_fusion_workspace"):
+            workspace = flashinfer_comm.create_allreduce_fusion_workspace(
+                backend=backend,
+                world_size=world_size,
+                rank=rank,
+                max_token_num=max_token_num,
+                hidden_dim=hidden_dim,
+                dtype=dtype,
+                comm_backend=comm_backend,
+            )
     except Exception as e:
         if "multicast" in str(e).lower():
             logger.warning_once(


### PR DESCRIPTION
## Purpose
When analyzing compile-time traces via TORCH_TRACE / tlparse,
there are unexplained gaps at the beginning of `VllmBackend.__call__`
before the actual Inductor compilation starts. This change adds
`dynamo_timed` instrumentation to the key steps in that window to
make costs visible:

- `vllm_configure_post_pass`: post-grad pass manager configuration
  including fusion pass initialization
- `vllm_fi_ar_create_allreduce_fusion_workspace`: flashinfer
  workspace creation (IPC handle exchange, device memory alloc)
- `vllm_split_graph`: FX graph splitting into piecewise subgraphs
- `vllm_deepcopy_split_gm`: deep copy of split graph for mega AOT
- `vllm_graph_logging`: graph debug logging and trace_structured
  dumps
- `vllm_piecewise_interpret`: piecewise compilation of all subgraphs
  and compile ranges

The instrumentation is cheap — all traced sections run only once
during startup, not on the compilation hot path.

No obviously redundant work was found, but
`vllm_fi_ar_create_allreduce_fusion_workspace` stands out as
notably expensive due to IPC handle exchange across ranks.

## Test Plan
Run vLLM with `TORCH_TRACE` enabled and verify the new timing
entries appear in the trace output.

## Test Result
Verified that all new timing entries appear in traces and account
for the previously unexplained gaps. No performance regression.

---
This PR was developed with AI assistance (Claude).