### PR TITLE
[Kernels] Integration for DeepGEMM MegaMoE kernel

### DIFF
--- a/tests/kernels/moe/test_deep_gemm_mega_moe.py
+++ b/tests/kernels/moe/test_deep_gemm_mega_moe.py
@@ -35,7 +35,7 @@ from vllm.model_executor.layers.fused_moe.prepare_finalize.no_dp_ep import (
 )
 from vllm.utils.deep_gemm import (
     calc_diff,
-    is_deep_gemm_supported,
+    is_deep_gemm_mega_moe_supported,
 )
 from vllm.utils.math_utils import cdiv, next_power_of_2
 from vllm.utils.torch_utils import set_random_seed
@@ -231,7 +231,9 @@ NUM_EXPERTS = [32]
 @pytest.mark.parametrize("topk", TOPKS)
 @pytest.mark.parametrize("num_experts", NUM_EXPERTS)
 @pytest.mark.parametrize("dp_size", [2])
-@pytest.mark.skipif(not is_deep_gemm_supported(), reason="Requires deep_gemm kernels")
+@pytest.mark.skipif(
+    not is_deep_gemm_mega_moe_supported(), reason="Requires deep_gemm kernels"
+)
 def test_deep_gemm_mega_moe(
     m: int,
     n: int,

--- a/tests/kernels/moe/test_deep_gemm_mega_moe.py
+++ b/tests/kernels/moe/test_deep_gemm_mega_moe.py
@@ -5,25 +5,30 @@ Unit-test DeepGEMM FP8 kernels (no DeepEP).
 Compare DeepGEMM path against the Triton fallback inside vLLM's fused_experts.
 """
 
-import math
-
 import pytest
 import torch
 
-from vllm.config import VllmConfig, get_current_vllm_config
 # vLLM fused-expert reference (Triton fallback + DeepGEMM option)
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
-from tests.kernels.moe.utils import make_dummy_moe_config
+from tests.kernels.moe.utils import make_test_weights
+from vllm.config import get_current_vllm_config
+from vllm.distributed import (
+    get_dp_group,
+    get_tensor_model_parallel_world_size,
+)
 from vllm.model_executor.layers.fused_moe.activation import (
     MoEActivation,
-)
-from vllm.model_executor.layers.fused_moe.config import (
-    fp8_w8a8_moe_quant_config,
 )
 from vllm.model_executor.layers.fused_moe.experts.deep_gemm_mega_moe import (
     DeepGemmMegaExperts,
 )
-from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts
+from vllm.model_executor.layers.fused_moe.fused_moe import (
+    FusedMoEConfig,
+    FusedMoEParallelConfig,
+    FusedMoEQuantConfig,
+    RoutingMethodType,
+    fused_experts,
+)
 from vllm.model_executor.layers.fused_moe.prepare_finalize.no_dp_ep import (
     make_moe_prepare_and_finalize_no_dp_ep,
 )
@@ -36,13 +41,9 @@ from vllm.model_executor.layers.quantization.utils.fp8_utils import (
 from vllm.utils.deep_gemm import (
     calc_diff,
     is_deep_gemm_supported,
-    per_block_cast_to_fp8,
 )
+from vllm.utils.math_utils import next_power_of_2
 from vllm.utils.torch_utils import set_random_seed
-from vllm.distributed import (
-    get_tensor_model_parallel_world_size,
-    get_dp_group,
-)
 
 from .parallel_utils import ProcessGroupInfo, parallel_launch
 
@@ -80,24 +81,24 @@ def run_single_case(
         n,
         k,
         torch.bfloat16,
-        "nvfp4",
-        False,
-        block_size,
+        quant_dtype="nvfp4",
+        per_out_ch_quant=False,
+        # block_shape=block_size,
     )
 
     (dg_w1, dg_w1_s), (dg_w2, dg_w2_s) = deep_gemm.transform_weights_for_mega_moe(
         (w1, w1_s), (w2, w2_s)
     )
 
-    a1_gscale = torch.ones((e,), device="cuda", dtype=torch.float32)
-    a2_gscale = torch.ones((e,), device="cuda", dtype=torch.float32)
+    a1_gscale = torch.ones((num_experts,), device="cuda", dtype=torch.float32)
+    a2_gscale = torch.ones((num_experts,), device="cuda", dtype=torch.float32)
     a1_scale = a1_gscale
     a2_scale = a2_gscale
 
     quant_config = FusedMoEQuantConfig.make(
         "nvfp4",
         per_act_token_quant=False,
-        block_shape=block_shape,
+        block_shape=None,  # block_shape,
         w1_scale=dg_w1_s,
         w2_scale=dg_w2_s,
         a1_gscale=a1_gscale,
@@ -122,11 +123,11 @@ def run_single_case(
         num_experts=num_experts,
         experts_per_token=topk,
         hidden_dim=k,
-        intermediate_size_per_partition=n, # // dp_size
+        intermediate_size_per_partition=n,  # // dp_size
         num_local_experts=num_experts,  # // dp_size
         num_logical_experts=num_experts,
         moe_parallel_config=moe_parallel_config,
-        in_dtype=torch.bfloat16, # or fp8?
+        in_dtype=torch.bfloat16,  # or fp8?
         max_num_tokens=next_power_of_2(m),
         activation=MoEActivation.SILU,
         device=vllm_config.device_config.device,

--- a/tests/kernels/moe/test_deep_gemm_mega_moe.py
+++ b/tests/kernels/moe/test_deep_gemm_mega_moe.py
@@ -10,24 +10,30 @@ import torch
 
 # vLLM fused-expert reference (Triton fallback + DeepGEMM option)
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
-from tests.kernels.moe.utils import make_test_weights
-from vllm.config import get_current_vllm_config
+from tests.kernels.moe.utils import (
+    make_test_weights,
+    per_token_cast_to_fp4,
+)
+from vllm.config import ParallelConfig, VllmConfig
 from vllm.distributed import (
     get_dp_group,
     get_tensor_model_parallel_world_size,
 )
+from vllm.model_executor.layers.fused_moe import (
+    FusedMoEConfig,
+    fused_experts,
+)
 from vllm.model_executor.layers.fused_moe.activation import (
     MoEActivation,
 )
-from vllm.model_executor.layers.fused_moe.experts.deep_gemm_mega_moe import (
-    DeepGemmMegaExperts,
-)
-from vllm.model_executor.layers.fused_moe.fused_moe import (
-    FusedMoEConfig,
+from vllm.model_executor.layers.fused_moe.config import (
+    FUSED_MOE_UNQUANTIZED_CONFIG,
     FusedMoEParallelConfig,
     FusedMoEQuantConfig,
     RoutingMethodType,
-    fused_experts,
+)
+from vllm.model_executor.layers.fused_moe.experts.deep_gemm_mega_moe import (
+    DeepGemmMegaExperts,
 )
 from vllm.model_executor.layers.fused_moe.prepare_finalize.no_dp_ep import (
     make_moe_prepare_and_finalize_no_dp_ep,
@@ -44,15 +50,40 @@ from vllm.utils.deep_gemm import (
 )
 from vllm.utils.math_utils import next_power_of_2
 from vllm.utils.torch_utils import set_random_seed
+from vllm.v1.worker.workspace import (
+    init_workspace_manager,
+    is_workspace_manager_initialized,
+)
 
-from .parallel_utils import ProcessGroupInfo, parallel_launch
+from .modular_kernel_tools.parallel_utils import (
+    ProcessGroupInfo,
+    parallel_launch_with_config,
+)
 
 BLOCK_SIZE = [128, 128]
+
+
+def cast_grouped_weights_to_fp4(
+    bf16_weights: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    import deep_gemm
+
+    num_groups, n, k = bf16_weights.shape
+    w = torch.empty((num_groups, n, k // 2), device="cuda", dtype=torch.int8)
+    w_sf = torch.empty((num_groups, n, k // 32), device="cuda", dtype=torch.float)
+    for i in range(num_groups):
+        w[i], w_sf[i] = per_token_cast_to_fp4(
+            bf16_weights[i], use_ue8m0=True, gran_k=32
+        )
+    w_sf = deep_gemm.transform_sf_into_required_layout(w_sf, n, k, (1, 32), num_groups)
+    return w, w_sf
 
 
 # activation fp8 x weights fp4
 def run_single_case(
     pgi: ProcessGroupInfo,
+    vllm_config: VllmConfig,
+    cpu_group,
     m: int,
     n: int,
     k: int,
@@ -66,6 +97,9 @@ def run_single_case(
     """
     import deep_gemm
 
+    if not is_workspace_manager_initialized():
+        init_workspace_manager(torch.accelerator.current_accelerator())
+
     router = create_fused_moe_router(topk, num_experts)
 
     tokens_bf16 = (
@@ -76,18 +110,22 @@ def run_single_case(
     _, a1_scale = per_token_group_quant_fp8(tokens_bf16, block_size[1])
 
     # expert weight tensors
-    (w1_bf16, w1, w1_s, w1_gs), (w2_bf16, w2, w2_s, w2_gs) = make_test_weights(
+    (w1, _, _, _), (w2, _, _, _) = make_test_weights(
         num_experts,
         n,
         k,
         torch.bfloat16,
-        quant_dtype="nvfp4",
+        quant_dtype=None,
         per_out_ch_quant=False,
-        # block_shape=block_size,
+        block_shape=None,
     )
 
+    w1_weights = cast_grouped_weights_to_fp4(w1)
+    w2_weights = cast_grouped_weights_to_fp4(w2)
+
     (dg_w1, dg_w1_s), (dg_w2, dg_w2_s) = deep_gemm.transform_weights_for_mega_moe(
-        (w1, w1_s), (w2, w2_s)
+        w1_weights,
+        w2_weights,
     )
 
     a1_gscale = torch.ones((num_experts,), device="cuda", dtype=torch.float32)
@@ -105,11 +143,11 @@ def run_single_case(
         a2_gscale=a2_gscale,
         a1_scale=a1_scale,
         a2_scale=a2_scale,
-        g1_alphas=(1 / w1_gs) if w1_gs is not None else None,
-        g2_alphas=(1 / w2_gs) if w2_gs is not None else None,
+        # g1_alphas=(1 / w1_gs) if w1_gs is not None else None,
+        # g2_alphas=(1 / w2_gs) if w2_gs is not None else None,
     )
 
-    vllm_config = get_current_vllm_config()
+    # vllm_config = get_current_vllm_config()
 
     moe_parallel_config = FusedMoEParallelConfig.make(
         tp_size_=get_tensor_model_parallel_world_size(),
@@ -157,15 +195,16 @@ def run_single_case(
         topk_weights=topk_weights,
         topk_ids=topk_ids,
         inplace=False,
-        quant_config=quant_config,
+        quant_config=FUSED_MOE_UNQUANTIZED_CONFIG,
     )
 
     # DeepGemm
     out_deepgemm = deep_gemm_experts.apply(
         hidden_states=tokens_bf16,
-        w1=w1,
-        w2=w2,
-        router_logits=router_logits,
+        w1=dg_w1,
+        w2=dg_w2,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
         activation=MoEActivation.SILU,
         global_num_experts=num_experts,
         apply_router_weight_on_input=False,
@@ -191,27 +230,40 @@ NUM_EXPERTS = [32]
 @pytest.mark.parametrize(("m", "n", "k"), MNKs)
 @pytest.mark.parametrize("topk", TOPKS)
 @pytest.mark.parametrize("num_experts", NUM_EXPERTS)
-@pytest.mark.parametrize("world_dp_size", [(2, 1)])
+@pytest.mark.parametrize("dp_size", [2])
 @pytest.mark.skipif(not is_deep_gemm_supported(), reason="Requires deep_gemm kernels")
 def test_deep_gemm_mega_moe(
-    m,
-    n,
-    k,
-    topk,
-    num_experts,
-    world_dp_size,
+    m: int,
+    n: int,
+    k: int,
+    topk: int,
+    num_experts: int,
+    dp_size: int,
     workspace_init,
 ):
     set_random_seed(7)
 
-    world_size, dp_size = world_dp_size
+    world_size = dp_size
 
     if topk > num_experts:
         pytest.skip(f"topk={topk} > num_experts={num_experts}")
 
-    parallel_launch(
+    parallel_config = ParallelConfig(
+        pipeline_parallel_size=1,
+        data_parallel_size=dp_size,
+        tensor_parallel_size=1,
+        # enable_expert_parallel=use_ep,
+        # all2all_backend=backend,
+        # enable_eplb=enable_eplb,
+    )
+
+    vllm_config = VllmConfig(parallel_config=parallel_config)
+
+    parallel_launch_with_config(
         world_size,
         run_single_case,
+        vllm_config,
+        None,  # env
         m,
         n,
         k,

--- a/tests/kernels/moe/test_deep_gemm_mega_moe.py
+++ b/tests/kernels/moe/test_deep_gemm_mega_moe.py
@@ -29,7 +29,9 @@ from vllm.model_executor.layers.fused_moe.config import (
 )
 from vllm.model_executor.layers.fused_moe.experts.deep_gemm_mega_moe import (
     DeepGemmMegaExperts,
-    MoEPrepareAndFinalizeMegaMoE,
+)
+from vllm.model_executor.layers.fused_moe.prepare_finalize.no_dp_ep import (
+    make_moe_prepare_and_finalize_no_dp_ep,
 )
 from vllm.utils.deep_gemm import (
     calc_diff,
@@ -149,7 +151,7 @@ def run_single_case(
 
     # Build FusedMoEQuantConfig with FP4 weight scales
     quant_config = FusedMoEQuantConfig.make(
-        quant_dtype=torch.float8_e4m3fn,
+        quant_dtype=None,  # torch.float8_e4m3fn,
         per_act_token_quant=False,
         block_shape=block_size,
         w1_scale=dg_w1_s,
@@ -181,7 +183,7 @@ def run_single_case(
 
     # Build modular kernel with DeepGemmMegaExperts
     deep_gemm_kernel = mk.FusedMoEKernel(
-        prepare_finalize=MoEPrepareAndFinalizeMegaMoE(),
+        prepare_finalize=make_moe_prepare_and_finalize_no_dp_ep(False),
         fused_experts=DeepGemmMegaExperts(
             moe_config=moe_config,
             quant_config=quant_config,
@@ -216,6 +218,8 @@ def run_single_case(
 
 
 MNKs = [
+    (512, 1024, 1024),
+    (4096, 4096, 1024),
     (512, 2048, 2048),
 ]
 

--- a/tests/kernels/moe/test_deep_gemm_mega_moe.py
+++ b/tests/kernels/moe/test_deep_gemm_mega_moe.py
@@ -156,6 +156,7 @@ def run_single_case(
         block_shape=block_size,
         w1_scale=dg_w1_s,
         w2_scale=dg_w2_s,
+        weight_dtype="mxfp4",
     )
 
     moe_parallel_config = FusedMoEParallelConfig.make(
@@ -187,7 +188,6 @@ def run_single_case(
         fused_experts=DeepGemmMegaExperts(
             moe_config=moe_config,
             quant_config=quant_config,
-            top_k=topk,
         ),
         inplace=False,
     )

--- a/tests/kernels/moe/test_deep_gemm_mega_moe.py
+++ b/tests/kernels/moe/test_deep_gemm_mega_moe.py
@@ -10,6 +10,7 @@ import math
 import pytest
 import torch
 
+from vllm.config import VllmConfig, get_current_vllm_config
 # vLLM fused-expert reference (Triton fallback + DeepGEMM option)
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from tests.kernels.moe.utils import make_dummy_moe_config
@@ -38,57 +39,14 @@ from vllm.utils.deep_gemm import (
     per_block_cast_to_fp8,
 )
 from vllm.utils.torch_utils import set_random_seed
+from vllm.distributed import (
+    get_tensor_model_parallel_world_size,
+    get_dp_group,
+)
 
 from .parallel_utils import ProcessGroupInfo, parallel_launch
 
 BLOCK_SIZE = [128, 128]
-
-
-def make_block_quant_fp8_weights(
-    e: int,
-    n: int,
-    k: int,
-    block_size: list[int],
-):
-    """
-    Generate (w1, w2) expert weights and their per-block scale tensors
-    in FP8 block-quantized format.
-
-      w1 shape: (E, 2N, K)
-      w2 shape: (E, K, N)
-    """
-    dtype = torch.bfloat16
-    fp8_max, fp8_min = (
-        torch.finfo(torch.float8_e4m3fn).max,
-        torch.finfo(torch.float8_e4m3fn).min,
-    )
-
-    # bf16 reference weights
-    w1_bf16 = torch.randn(e, 2 * n, k, device="cuda", dtype=dtype) / 10
-    w2_bf16 = torch.randn(e, k, n, device="cuda", dtype=dtype) / 10
-    w1_bf16.clamp_(fp8_min, fp8_max)
-    w2_bf16.clamp_(fp8_min, fp8_max)
-
-    block_n, block_k = block_size
-    n_tiles_w1 = math.ceil((2 * n) / block_n)
-    k_tiles_w1 = math.ceil(k / block_k)
-    n_tiles_w2 = math.ceil(k / block_n)
-    k_tiles_w2 = math.ceil(n / block_k)
-
-    w1 = torch.empty_like(w1_bf16, dtype=torch.float8_e4m3fn)
-    w2 = torch.empty_like(w2_bf16, dtype=torch.float8_e4m3fn)
-    w1_s = torch.empty(e, n_tiles_w1, k_tiles_w1, device="cuda", dtype=torch.float32)
-    w2_s = torch.empty(e, n_tiles_w2, k_tiles_w2, device="cuda", dtype=torch.float32)
-
-    for i in range(e):
-        w1[i], w1_s[i] = per_block_cast_to_fp8(
-            w1_bf16[i], block_size=block_size, use_ue8m0=True
-        )
-        w2[i], w2_s[i] = per_block_cast_to_fp8(
-            w2_bf16[i], block_size=block_size, use_ue8m0=True
-        )
-
-    return w1, w2, w1_s, w2_s
 
 
 # activation fp8 x weights fp4
@@ -117,19 +75,64 @@ def run_single_case(
     _, a1_scale = per_token_group_quant_fp8(tokens_bf16, block_size[1])
 
     # expert weight tensors
-    w1, w2, w1_s, w2_s = make_block_quant_fp8_weights(num_experts, n, k, block_size)
+    (w1_bf16, w1, w1_s, w1_gs), (w2_bf16, w2, w2_s, w2_gs) = make_test_weights(
+        num_experts,
+        n,
+        k,
+        torch.bfloat16,
+        "nvfp4",
+        False,
+        block_size,
+    )
 
     (dg_w1, dg_w1_s), (dg_w2, dg_w2_s) = deep_gemm.transform_weights_for_mega_moe(
         (w1, w1_s), (w2, w2_s)
     )
 
-    quant_config = fp8_w8a8_moe_quant_config(
-        w1_scale=w1_s,
-        w2_scale=w2_s,
+    a1_gscale = torch.ones((e,), device="cuda", dtype=torch.float32)
+    a2_gscale = torch.ones((e,), device="cuda", dtype=torch.float32)
+    a1_scale = a1_gscale
+    a2_scale = a2_gscale
+
+    quant_config = FusedMoEQuantConfig.make(
+        "nvfp4",
+        per_act_token_quant=False,
+        block_shape=block_shape,
+        w1_scale=dg_w1_s,
+        w2_scale=dg_w2_s,
+        a1_gscale=a1_gscale,
+        a2_gscale=a2_gscale,
         a1_scale=a1_scale,
-        block_shape=block_size,
+        a2_scale=a2_scale,
+        g1_alphas=(1 / w1_gs) if w1_gs is not None else None,
+        g2_alphas=(1 / w2_gs) if w2_gs is not None else None,
+    ),
+
+    vllm_config = get_current_vllm_config()
+
+    moe_parallel_config = FusedMoEParallelConfig.make(
+        tp_size_=get_tensor_model_parallel_world_size(),
+        pcp_size_=1,
+        dp_size_=get_dp_group().world_size,
+        sp_size_=1,
+        vllm_parallel_config=vllm_config.parallel_config,
     )
-    moe_config = make_dummy_moe_config()
+
+    moe_config = FusedMoEConfig(
+        num_experts=num_experts,
+        experts_per_token=topk,
+        hidden_dim=k,
+        intermediate_size_per_partition=n, # // dp_size
+        num_local_experts=num_experts,  # // dp_size
+        num_logical_experts=num_experts,
+        moe_parallel_config=moe_parallel_config,
+        in_dtype=torch.bfloat16, # or fp8?
+        max_num_tokens=next_power_of_2(m),
+        activation=MoEActivation.SILU,
+        device=vllm_config.device_config.device,
+        routing_method=RoutingMethodType.DeepSeekV3,
+        moe_parallel_config=moe_parallel_config,
+    )
 
     deep_gemm_experts = mk.FusedMoEKernel(
         prepare_finalize=make_moe_prepare_and_finalize_no_dp_ep(False),

--- a/tests/kernels/moe/test_deep_gemm_mega_moe.py
+++ b/tests/kernels/moe/test_deep_gemm_mega_moe.py
@@ -44,6 +44,7 @@ from vllm.model_executor.layers.fused_moe.router.router_factory import (
 from vllm.model_executor.layers.quantization.utils.fp8_utils import (
     per_token_group_quant_fp8,
 )
+from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import (
     calc_diff,
     is_deep_gemm_supported,
@@ -162,23 +163,22 @@ def run_single_case(
         w2_weights,
     )
 
-    a1_gscale = torch.ones((num_experts,), device="cuda", dtype=torch.float32)
-    a2_gscale = torch.ones((num_experts,), device="cuda", dtype=torch.float32)
+    # a1_gscale = torch.ones((num_experts,), device="cuda", dtype=torch.float32)
+    # a2_gscale = torch.ones((num_experts,), device="cuda", dtype=torch.float32)
     # a1_scale = a1_gscale
     # a2_scale = a2_gscale
 
     quant_config = FusedMoEQuantConfig.make(
-        "nvfp4",  # ?
+        current_platform.fp8_dtype(),
         per_act_token_quant=False,
-        block_shape=None,  # block_shape,
+        block_shape=block_size,
         w1_scale=dg_w1_s,
         w2_scale=dg_w2_s,
-        a1_gscale=a1_gscale,
-        a2_gscale=a2_gscale,
         a1_scale=a1_scale,
         # a2_scale=a2_scale,
         # g1_alphas=(1 / w1_gs) if w1_gs is not None else None,
         # g2_alphas=(1 / w2_gs) if w2_gs is not None else None,
+        weight_dtype="nvfp4",
     )
 
     # vllm_config = get_current_vllm_config()

--- a/tests/kernels/moe/test_deep_gemm_mega_moe.py
+++ b/tests/kernels/moe/test_deep_gemm_mega_moe.py
@@ -5,7 +5,6 @@ Unit-test DeepGEMM FP8 kernels (no DeepEP).
 Compare DeepGEMM path against the Triton fallback inside vLLM's fused_experts.
 """
 
-import importlib
 import math
 
 import pytest
@@ -38,6 +37,9 @@ from vllm.utils.deep_gemm import (
     is_deep_gemm_supported,
     per_block_cast_to_fp8,
 )
+from vllm.utils.torch_utils import set_random_seed
+
+from .parallel_utils import ProcessGroupInfo, parallel_launch
 
 BLOCK_SIZE = [128, 128]
 
@@ -89,7 +91,16 @@ def make_block_quant_fp8_weights(
     return w1, w2, w1_s, w2_s
 
 
-def run_single_case(m, n, k, topk, num_experts, block_size):
+# activation fp8 x weights fp4
+def run_single_case(
+    pgi: ProcessGroupInfo,
+    m: int,
+    n: int,
+    k: int,
+    topk: int,
+    num_experts: int,
+    block_size: list[int],
+):
     """
     Run one (M,N,K) configuration on a single GPU and assert DeepGEMM ==
     Triton baseline within tolerance.
@@ -163,10 +174,11 @@ def run_single_case(m, n, k, topk, num_experts, block_size):
 
 # Note: N <= 512 will disable the deepgemm path due to performance issues.
 MNKs = [
-    (1024, 768, 128),
-    (2048, 768, 512),
-    (512, 1024, 1024),
-    (4096, 4096, 1024),
+    # (1024, 768, 128),
+    # (2048, 768, 512),
+    # (512, 1024, 1024),
+    # (4096, 4096, 1024),
+    (512, 2048, 2048),
 ]
 
 TOPKS = [2, 6]
@@ -176,38 +188,31 @@ NUM_EXPERTS = [32]
 @pytest.mark.parametrize(("m", "n", "k"), MNKs)
 @pytest.mark.parametrize("topk", TOPKS)
 @pytest.mark.parametrize("num_experts", NUM_EXPERTS)
+@pytest.mark.parametrize("world_dp_size", [(2, 1)])
 @pytest.mark.skipif(not is_deep_gemm_supported(), reason="Requires deep_gemm kernels")
-def test_deepgemm_vs_triton(m, n, k, topk, num_experts, monkeypatch, workspace_init):
-    with monkeypatch.context() as mp:
-        mp.setenv("VLLM_USE_DEEP_GEMM", "1")
+def test_deep_gemm_mega_moe(
+    m,
+    n,
+    k,
+    topk,
+    num_experts,
+    world_dp_size,
+    workspace_init,
+):
+    set_random_seed(7)
 
-        _DeepGemmExperts = importlib.import_module(
-            "vllm.model_executor.layers.fused_moe.experts.deep_gemm_moe"
-        ).DeepGemmExperts
+    world_size, dp_size = world_dp_size
 
-        call_counter = {"cnt": 0}
+    if topk > num_experts:
+        pytest.skip(f"topk={topk} > num_experts={num_experts}")
 
-        orig_fn = _DeepGemmExperts.apply
-
-        def _spy_apply(*args, **kwargs):
-            call_counter["cnt"] += 1
-            return orig_fn(*args, **kwargs)
-
-        monkeypatch.setattr(_DeepGemmExperts, "apply", _spy_apply)
-        if topk > num_experts:
-            pytest.skip(f"topk={topk} > num_experts={num_experts}")
-
-        run_single_case(
-            m=m,
-            n=n,
-            k=k,
-            topk=topk,
-            num_experts=num_experts,
-            block_size=BLOCK_SIZE,
-        )
-
-        # ensure that the DeepGEMM path was indeed taken.
-        assert call_counter["cnt"] == 1, (
-            f"DeepGEMM path was not executed during the test. "
-            f"Call counter: {call_counter['cnt']}"
-        )
+    parallel_launch(
+        world_size,
+        run_single_case,
+        m,
+        n,
+        k,
+        topk,
+        num_experts,
+        BLOCK_SIZE,
+    )

--- a/tests/kernels/moe/test_deep_gemm_mega_moe.py
+++ b/tests/kernels/moe/test_deep_gemm_mega_moe.py
@@ -25,7 +25,7 @@ from vllm.model_executor.layers.fused_moe.experts.deep_gemm_mega_moe import (
 )
 from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts
 from vllm.model_executor.layers.fused_moe.prepare_finalize.no_dp_ep import (
-    MoEPrepareAndFinalizeNoDPEPMonolithic,
+    make_moe_prepare_and_finalize_no_dp_ep,
 )
 from vllm.model_executor.layers.fused_moe.router.router_factory import (
     create_fused_moe_router,
@@ -94,6 +94,10 @@ def run_single_case(m, n, k, topk, num_experts, block_size):
     Run one (M,N,K) configuration on a single GPU and assert DeepGEMM ==
     Triton baseline within tolerance.
     """
+    import deep_gemm
+
+    router = create_fused_moe_router(topk, num_experts)
+
     tokens_bf16 = (
         torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
         .clamp_min_(-1)
@@ -104,11 +108,9 @@ def run_single_case(m, n, k, topk, num_experts, block_size):
     # expert weight tensors
     w1, w2, w1_s, w2_s = make_block_quant_fp8_weights(num_experts, n, k, block_size)
 
-    router_logits = torch.randn(m, num_experts, device="cuda", dtype=torch.float32)
-
-    router = create_fused_moe_router(topk, num_experts)
-
-    topk_weights, topk_ids = router.select_experts(tokens_bf16, router_logits)
+    (dg_w1, dg_w1_s), (dg_w2, dg_w2_s) = deep_gemm.transform_weights_for_mega_moe(
+        (w1, w1_s), (w2, w2_s)
+    )
 
     quant_config = fp8_w8a8_moe_quant_config(
         w1_scale=w1_s,
@@ -119,14 +121,19 @@ def run_single_case(m, n, k, topk, num_experts, block_size):
     moe_config = make_dummy_moe_config()
 
     deep_gemm_experts = mk.FusedMoEKernel(
-        prepare_finalize=MoEPrepareAndFinalizeNoDPEPMonolithic(),
+        prepare_finalize=make_moe_prepare_and_finalize_no_dp_ep(False),
         fused_experts=DeepGemmMegaExperts(
             moe_config=moe_config,
             quant_config=quant_config,
-            router=router,
+            top_k=topk,
         ),
         inplace=False,
     )
+
+    #############################
+
+    router_logits = torch.randn(m, num_experts, device="cuda", dtype=torch.float32)
+    topk_weights, topk_ids = router.select_experts(tokens_bf16, router_logits)
 
     # triton reference
     out_triton = fused_experts(
@@ -140,7 +147,7 @@ def run_single_case(m, n, k, topk, num_experts, block_size):
     )
 
     # DeepGemm
-    out_deepgemm = deep_gemm_experts.apply_monolithic(
+    out_deepgemm = deep_gemm_experts.apply(
         hidden_states=tokens_bf16,
         w1=w1,
         w2=w2,

--- a/tests/kernels/moe/test_deep_gemm_mega_moe.py
+++ b/tests/kernels/moe/test_deep_gemm_mega_moe.py
@@ -48,7 +48,7 @@ from vllm.utils.deep_gemm import (
     calc_diff,
     is_deep_gemm_supported,
 )
-from vllm.utils.math_utils import next_power_of_2
+from vllm.utils.math_utils import cdiv, next_power_of_2
 from vllm.utils.torch_utils import set_random_seed
 from vllm.v1.worker.workspace import (
     init_workspace_manager,
@@ -77,6 +77,38 @@ def cast_grouped_weights_to_fp4(
         )
     w_sf = deep_gemm.transform_sf_into_required_layout(w_sf, n, k, (1, 32), num_groups)
     return w, w_sf
+
+
+def rank_chunk(num: int, r: int, w: int) -> int:
+    rem = num % w
+    return (num // w) + (1 if r < rem else 0)
+
+
+def chunk_by_rank(
+    t: torch.Tensor,
+    r: int,
+    w: int,
+    dim: int = 0,
+    device: torch.device | None = None,
+) -> torch.Tensor:
+    chunk = cdiv(t.shape[dim], w)
+    t = t.narrow(dim, r * chunk, chunk)
+    if device is not None:
+        t = t.to(device)
+    return t
+
+
+def maybe_chunk_by_rank(
+    t: torch.Tensor | None,
+    r: int,
+    w: int,
+    dim: int = 0,
+    device: torch.device | None = None,
+) -> torch.Tensor | None:
+    if t is not None:
+        return chunk_by_rank(t, r, w, dim, device)
+    else:
+        return t
 
 
 # activation fp8 x weights fp4
@@ -109,10 +141,12 @@ def run_single_case(
     )
     _, a1_scale = per_token_group_quant_fp8(tokens_bf16, block_size[1])
 
+    print(f"A1_SCALE {a1_scale.shape}")
+
     # expert weight tensors
     (w1, _, _, _), (w2, _, _, _) = make_test_weights(
         num_experts,
-        n,
+        n,  # dp_size,
         k,
         torch.bfloat16,
         quant_dtype=None,
@@ -130,11 +164,11 @@ def run_single_case(
 
     a1_gscale = torch.ones((num_experts,), device="cuda", dtype=torch.float32)
     a2_gscale = torch.ones((num_experts,), device="cuda", dtype=torch.float32)
-    a1_scale = a1_gscale
-    a2_scale = a2_gscale
+    # a1_scale = a1_gscale
+    # a2_scale = a2_gscale
 
     quant_config = FusedMoEQuantConfig.make(
-        "nvfp4",
+        "nvfp4",  # ?
         per_act_token_quant=False,
         block_shape=None,  # block_shape,
         w1_scale=dg_w1_s,
@@ -142,7 +176,7 @@ def run_single_case(
         a1_gscale=a1_gscale,
         a2_gscale=a2_gscale,
         a1_scale=a1_scale,
-        a2_scale=a2_scale,
+        # a2_scale=a2_scale,
         # g1_alphas=(1 / w1_gs) if w1_gs is not None else None,
         # g2_alphas=(1 / w2_gs) if w2_gs is not None else None,
     )

--- a/tests/kernels/moe/test_deep_gemm_mega_moe.py
+++ b/tests/kernels/moe/test_deep_gemm_mega_moe.py
@@ -131,7 +131,6 @@ def run_single_case(
         activation=MoEActivation.SILU,
         device=vllm_config.device_config.device,
         routing_method=RoutingMethodType.DeepSeekV3,
-        moe_parallel_config=moe_parallel_config,
     )
 
     deep_gemm_experts = mk.FusedMoEKernel(

--- a/tests/kernels/moe/test_deep_gemm_mega_moe.py
+++ b/tests/kernels/moe/test_deep_gemm_mega_moe.py
@@ -1,0 +1,206 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Unit-test DeepGEMM FP8 kernels (no DeepEP).
+Compare DeepGEMM path against the Triton fallback inside vLLM's fused_experts.
+"""
+
+import importlib
+import math
+
+import pytest
+import torch
+
+# vLLM fused-expert reference (Triton fallback + DeepGEMM option)
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from tests.kernels.moe.utils import make_dummy_moe_config
+from vllm.model_executor.layers.fused_moe.activation import (
+    MoEActivation,
+)
+from vllm.model_executor.layers.fused_moe.config import (
+    fp8_w8a8_moe_quant_config,
+)
+from vllm.model_executor.layers.fused_moe.experts.deep_gemm_mega_moe import (
+    DeepGemmMegaExperts,
+)
+from vllm.model_executor.layers.fused_moe.fused_moe import fused_experts
+from vllm.model_executor.layers.fused_moe.prepare_finalize.no_dp_ep import (
+    MoEPrepareAndFinalizeNoDPEPMonolithic,
+)
+from vllm.model_executor.layers.fused_moe.router.router_factory import (
+    create_fused_moe_router,
+)
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    per_token_group_quant_fp8,
+)
+from vllm.utils.deep_gemm import (
+    calc_diff,
+    is_deep_gemm_supported,
+    per_block_cast_to_fp8,
+)
+
+BLOCK_SIZE = [128, 128]
+
+
+def make_block_quant_fp8_weights(
+    e: int,
+    n: int,
+    k: int,
+    block_size: list[int],
+):
+    """
+    Generate (w1, w2) expert weights and their per-block scale tensors
+    in FP8 block-quantized format.
+
+      w1 shape: (E, 2N, K)
+      w2 shape: (E, K, N)
+    """
+    dtype = torch.bfloat16
+    fp8_max, fp8_min = (
+        torch.finfo(torch.float8_e4m3fn).max,
+        torch.finfo(torch.float8_e4m3fn).min,
+    )
+
+    # bf16 reference weights
+    w1_bf16 = torch.randn(e, 2 * n, k, device="cuda", dtype=dtype) / 10
+    w2_bf16 = torch.randn(e, k, n, device="cuda", dtype=dtype) / 10
+    w1_bf16.clamp_(fp8_min, fp8_max)
+    w2_bf16.clamp_(fp8_min, fp8_max)
+
+    block_n, block_k = block_size
+    n_tiles_w1 = math.ceil((2 * n) / block_n)
+    k_tiles_w1 = math.ceil(k / block_k)
+    n_tiles_w2 = math.ceil(k / block_n)
+    k_tiles_w2 = math.ceil(n / block_k)
+
+    w1 = torch.empty_like(w1_bf16, dtype=torch.float8_e4m3fn)
+    w2 = torch.empty_like(w2_bf16, dtype=torch.float8_e4m3fn)
+    w1_s = torch.empty(e, n_tiles_w1, k_tiles_w1, device="cuda", dtype=torch.float32)
+    w2_s = torch.empty(e, n_tiles_w2, k_tiles_w2, device="cuda", dtype=torch.float32)
+
+    for i in range(e):
+        w1[i], w1_s[i] = per_block_cast_to_fp8(
+            w1_bf16[i], block_size=block_size, use_ue8m0=True
+        )
+        w2[i], w2_s[i] = per_block_cast_to_fp8(
+            w2_bf16[i], block_size=block_size, use_ue8m0=True
+        )
+
+    return w1, w2, w1_s, w2_s
+
+
+def run_single_case(m, n, k, topk, num_experts, block_size):
+    """
+    Run one (M,N,K) configuration on a single GPU and assert DeepGEMM ==
+    Triton baseline within tolerance.
+    """
+    tokens_bf16 = (
+        torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
+        .clamp_min_(-1)
+        .clamp_max_(1)
+    )
+    _, a1_scale = per_token_group_quant_fp8(tokens_bf16, block_size[1])
+
+    # expert weight tensors
+    w1, w2, w1_s, w2_s = make_block_quant_fp8_weights(num_experts, n, k, block_size)
+
+    router_logits = torch.randn(m, num_experts, device="cuda", dtype=torch.float32)
+
+    router = create_fused_moe_router(topk, num_experts)
+
+    topk_weights, topk_ids = router.select_experts(tokens_bf16, router_logits)
+
+    quant_config = fp8_w8a8_moe_quant_config(
+        w1_scale=w1_s,
+        w2_scale=w2_s,
+        a1_scale=a1_scale,
+        block_shape=block_size,
+    )
+    moe_config = make_dummy_moe_config()
+
+    deep_gemm_experts = mk.FusedMoEKernel(
+        prepare_finalize=MoEPrepareAndFinalizeNoDPEPMonolithic(),
+        fused_experts=DeepGemmMegaExperts(
+            moe_config=moe_config,
+            quant_config=quant_config,
+            router=router,
+        ),
+        inplace=False,
+    )
+
+    # triton reference
+    out_triton = fused_experts(
+        hidden_states=tokens_bf16,
+        w1=w1,
+        w2=w2,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        inplace=False,
+        quant_config=quant_config,
+    )
+
+    # DeepGemm
+    out_deepgemm = deep_gemm_experts.apply_monolithic(
+        hidden_states=tokens_bf16,
+        w1=w1,
+        w2=w2,
+        router_logits=router_logits,
+        activation=MoEActivation.SILU,
+        global_num_experts=num_experts,
+        apply_router_weight_on_input=False,
+        expert_map=None,
+    )
+    diff = calc_diff(out_deepgemm, out_triton)
+    assert diff < 0.001, f"Diff exceeded 1%: {diff}"
+
+
+# Note: N <= 512 will disable the deepgemm path due to performance issues.
+MNKs = [
+    (1024, 768, 128),
+    (2048, 768, 512),
+    (512, 1024, 1024),
+    (4096, 4096, 1024),
+]
+
+TOPKS = [2, 6]
+NUM_EXPERTS = [32]
+
+
+@pytest.mark.parametrize(("m", "n", "k"), MNKs)
+@pytest.mark.parametrize("topk", TOPKS)
+@pytest.mark.parametrize("num_experts", NUM_EXPERTS)
+@pytest.mark.skipif(not is_deep_gemm_supported(), reason="Requires deep_gemm kernels")
+def test_deepgemm_vs_triton(m, n, k, topk, num_experts, monkeypatch, workspace_init):
+    with monkeypatch.context() as mp:
+        mp.setenv("VLLM_USE_DEEP_GEMM", "1")
+
+        _DeepGemmExperts = importlib.import_module(
+            "vllm.model_executor.layers.fused_moe.experts.deep_gemm_moe"
+        ).DeepGemmExperts
+
+        call_counter = {"cnt": 0}
+
+        orig_fn = _DeepGemmExperts.apply
+
+        def _spy_apply(*args, **kwargs):
+            call_counter["cnt"] += 1
+            return orig_fn(*args, **kwargs)
+
+        monkeypatch.setattr(_DeepGemmExperts, "apply", _spy_apply)
+        if topk > num_experts:
+            pytest.skip(f"topk={topk} > num_experts={num_experts}")
+
+        run_single_case(
+            m=m,
+            n=n,
+            k=k,
+            topk=topk,
+            num_experts=num_experts,
+            block_size=BLOCK_SIZE,
+        )
+
+        # ensure that the DeepGEMM path was indeed taken.
+        assert call_counter["cnt"] == 1, (
+            f"DeepGEMM path was not executed during the test. "
+            f"Call counter: {call_counter['cnt']}"
+        )

--- a/tests/kernels/moe/test_deep_gemm_mega_moe.py
+++ b/tests/kernels/moe/test_deep_gemm_mega_moe.py
@@ -1,17 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """
-Unit-test DeepGEMM FP8 kernels (no DeepEP).
-Compare DeepGEMM path against the Triton fallback inside vLLM's fused_experts.
+Unit-test DeepGEMM mega_moe kernel via the DeepGemmMegaExperts modular kernel.
+Compare mega_moe output against BF16 fused_experts reference.
 """
 
 import pytest
 import torch
 
-# vLLM fused-expert reference (Triton fallback + DeepGEMM option)
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from tests.kernels.moe.utils import (
-    make_test_weights,
     per_token_cast_to_fp4,
 )
 from vllm.config import ParallelConfig, VllmConfig
@@ -23,38 +21,23 @@ from vllm.model_executor.layers.fused_moe import (
     FusedMoEConfig,
     fused_experts,
 )
-from vllm.model_executor.layers.fused_moe.activation import (
-    MoEActivation,
-)
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.config import (
-    FUSED_MOE_UNQUANTIZED_CONFIG,
     FusedMoEParallelConfig,
     FusedMoEQuantConfig,
     RoutingMethodType,
 )
 from vllm.model_executor.layers.fused_moe.experts.deep_gemm_mega_moe import (
     DeepGemmMegaExperts,
+    MoEPrepareAndFinalizeMegaMoE,
 )
-from vllm.model_executor.layers.fused_moe.prepare_finalize.no_dp_ep import (
-    make_moe_prepare_and_finalize_no_dp_ep,
-)
-from vllm.model_executor.layers.fused_moe.router.router_factory import (
-    create_fused_moe_router,
-)
-from vllm.model_executor.layers.quantization.utils.fp8_utils import (
-    per_token_group_quant_fp8,
-)
-from vllm.platforms import current_platform
 from vllm.utils.deep_gemm import (
     calc_diff,
     is_deep_gemm_supported,
 )
 from vllm.utils.math_utils import cdiv, next_power_of_2
 from vllm.utils.torch_utils import set_random_seed
-from vllm.v1.worker.workspace import (
-    init_workspace_manager,
-    is_workspace_manager_initialized,
-)
+from vllm.v1.worker.workspace import init_workspace_manager
 
 from .modular_kernel_tools.parallel_utils import (
     ProcessGroupInfo,
@@ -80,11 +63,6 @@ def cast_grouped_weights_to_fp4(
     return w, w_sf
 
 
-def rank_chunk(num: int, r: int, w: int) -> int:
-    rem = num % w
-    return (num // w) + (1 if r < rem else 0)
-
-
 def chunk_by_rank(
     t: torch.Tensor,
     r: int,
@@ -97,19 +75,6 @@ def chunk_by_rank(
     if device is not None:
         t = t.to(device)
     return t
-
-
-def maybe_chunk_by_rank(
-    t: torch.Tensor | None,
-    r: int,
-    w: int,
-    dim: int = 0,
-    device: torch.device | None = None,
-) -> torch.Tensor | None:
-    if t is not None:
-        return chunk_by_rank(t, r, w, dim, device)
-    else:
-        return t
 
 
 # activation fp8 x weights fp4
@@ -125,68 +90,76 @@ def run_single_case(
     block_size: list[int],
 ):
     """
-    Run one (M,N,K) configuration on a single GPU and assert DeepGEMM ==
-    Triton baseline within tolerance.
+    Run one (M,N,K) configuration on a single GPU and assert DeepGEMM
+    mega_moe (via DeepGemmMegaExperts modular kernel) produces correct
+    results compared to BF16 reference.
     """
     import deep_gemm
 
-    if not is_workspace_manager_initialized():
-        init_workspace_manager(torch.accelerator.current_accelerator())
+    device = torch.device(f"cuda:{pgi.local_rank}")
+    init_workspace_manager(device)
 
-    router = create_fused_moe_router(topk, num_experts)
+    dp_rank = pgi.rank
+    dp_size = get_dp_group().world_size
+    num_local_experts = num_experts // dp_size
 
-    tokens_bf16 = (
-        torch.randn(m, k, device="cuda", dtype=torch.bfloat16)
-        .clamp_min_(-1)
-        .clamp_max_(1)
+    # Use fixed seed so all ranks generate identical "global" data
+    set_random_seed(7)
+
+    # Generate global data (same on all ranks due to shared seed)
+    tokens_bf16 = torch.randn(m, k, device="cuda", dtype=torch.bfloat16) / 10
+    w1_bf16 = (
+        torch.randn((num_experts, 2 * n, k), device="cuda", dtype=torch.bfloat16) / 15
     )
-    _, a1_scale = per_token_group_quant_fp8(tokens_bf16, block_size[1])
+    w2_bf16 = torch.randn((num_experts, k, n), device="cuda", dtype=torch.bfloat16) / 15
 
-    print(f"A1_SCALE {a1_scale.shape}")
-
-    # expert weight tensors
-    (w1, _, _, _), (w2, _, _, _) = make_test_weights(
-        num_experts,
-        n,  # dp_size,
-        k,
-        torch.bfloat16,
-        quant_dtype=None,
-        per_out_ch_quant=False,
-        block_shape=None,
+    # Global routing
+    scores = torch.randn(m, num_experts, device="cuda", dtype=torch.float32)
+    topk_weights, topk_ids = torch.topk(
+        scores, topk, dim=-1, largest=True, sorted=False
     )
 
-    w1_weights = cast_grouped_weights_to_fp4(w1)
-    w2_weights = cast_grouped_weights_to_fp4(w2)
+    # Shard tokens by DP rank
+    tokens_bf16 = chunk_by_rank(tokens_bf16, dp_rank, dp_size)
+    topk_weights = chunk_by_rank(topk_weights, dp_rank, dp_size)
+    topk_ids = chunk_by_rank(topk_ids, dp_rank, dp_size)
+    local_m = tokens_bf16.shape[0]
 
+    # BF16 unquantized reference (uses all experts, global topk_ids)
+    out_ref = fused_experts(
+        hidden_states=tokens_bf16,
+        w1=w1_bf16,
+        w2=w2_bf16,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        inplace=False,
+    )
+
+    # Shard weights by DP rank for mega_moe
+    # C++ assertion: buffer.num_experts == weight_experts_per_rank * num_ranks
+    w1_local = chunk_by_rank(w1_bf16, dp_rank, dp_size)
+    w2_local = chunk_by_rank(w2_bf16, dp_rank, dp_size)
+
+    # Cast to FP4 and transform for mega_moe layout
+    w1_weights = cast_grouped_weights_to_fp4(w1_local)
+    w2_weights = cast_grouped_weights_to_fp4(w2_local)
     (dg_w1, dg_w1_s), (dg_w2, dg_w2_s) = deep_gemm.transform_weights_for_mega_moe(
-        w1_weights,
-        w2_weights,
+        w1_weights, w2_weights
     )
 
-    # a1_gscale = torch.ones((num_experts,), device="cuda", dtype=torch.float32)
-    # a2_gscale = torch.ones((num_experts,), device="cuda", dtype=torch.float32)
-    # a1_scale = a1_gscale
-    # a2_scale = a2_gscale
-
+    # Build FusedMoEQuantConfig with FP4 weight scales
     quant_config = FusedMoEQuantConfig.make(
-        current_platform.fp8_dtype(),
+        quant_dtype=torch.float8_e4m3fn,
         per_act_token_quant=False,
         block_shape=block_size,
         w1_scale=dg_w1_s,
         w2_scale=dg_w2_s,
-        a1_scale=a1_scale,
-        # a2_scale=a2_scale,
-        # g1_alphas=(1 / w1_gs) if w1_gs is not None else None,
-        # g2_alphas=(1 / w2_gs) if w2_gs is not None else None,
-        weight_dtype="nvfp4",
     )
-
-    # vllm_config = get_current_vllm_config()
 
     moe_parallel_config = FusedMoEParallelConfig.make(
         tp_size_=get_tensor_model_parallel_world_size(),
         pcp_size_=1,
-        dp_size_=get_dp_group().world_size,
+        dp_size_=dp_size,
         sp_size_=1,
         vllm_parallel_config=vllm_config.parallel_config,
     )
@@ -195,19 +168,20 @@ def run_single_case(
         num_experts=num_experts,
         experts_per_token=topk,
         hidden_dim=k,
-        intermediate_size_per_partition=n,  # // dp_size
-        num_local_experts=num_experts,  # // dp_size
+        intermediate_size_per_partition=n,
+        num_local_experts=num_local_experts,
         num_logical_experts=num_experts,
         moe_parallel_config=moe_parallel_config,
-        in_dtype=torch.bfloat16,  # or fp8?
-        max_num_tokens=next_power_of_2(m),
+        in_dtype=torch.bfloat16,
+        max_num_tokens=next_power_of_2(local_m),
         activation=MoEActivation.SILU,
         device=vllm_config.device_config.device,
         routing_method=RoutingMethodType.DeepSeekV3,
     )
 
-    deep_gemm_experts = mk.FusedMoEKernel(
-        prepare_finalize=make_moe_prepare_and_finalize_no_dp_ep(False),
+    # Build modular kernel with DeepGemmMegaExperts
+    deep_gemm_kernel = mk.FusedMoEKernel(
+        prepare_finalize=MoEPrepareAndFinalizeMegaMoE(),
         fused_experts=DeepGemmMegaExperts(
             moe_config=moe_config,
             quant_config=quant_config,
@@ -216,24 +190,8 @@ def run_single_case(
         inplace=False,
     )
 
-    #############################
-
-    router_logits = torch.randn(m, num_experts, device="cuda", dtype=torch.float32)
-    topk_weights, topk_ids = router.select_experts(tokens_bf16, router_logits)
-
-    # triton reference
-    out_triton = fused_experts(
-        hidden_states=tokens_bf16,
-        w1=w1,
-        w2=w2,
-        topk_weights=topk_weights,
-        topk_ids=topk_ids,
-        inplace=False,
-        quant_config=FUSED_MOE_UNQUANTIZED_CONFIG,
-    )
-
-    # DeepGemm
-    out_deepgemm = deep_gemm_experts.apply(
+    # Run through the modular kernel
+    out_deepgemm = deep_gemm_kernel.apply(
         hidden_states=tokens_bf16,
         w1=dg_w1,
         w2=dg_w2,
@@ -244,16 +202,20 @@ def run_single_case(
         apply_router_weight_on_input=False,
         expert_map=None,
     )
-    diff = calc_diff(out_deepgemm, out_triton)
-    assert diff < 0.001, f"Diff exceeded 1%: {diff}"
+
+    # Compare mega_moe against BF16 reference using cosine similarity
+    diff = calc_diff(out_ref, out_deepgemm)
+    print(
+        f"RANK={dp_rank} calc_diff={diff:.6f} "
+        f"ref_std={out_ref.float().std():.4f} "
+        f"dg_std={out_deepgemm.float().std():.4f}"
+    )
+    # FP4 weights + FP8 activations introduce quantization error with random
+    # weights. Threshold accounts for this.
+    assert diff < 0.1, f"calc_diff={diff} too large (threshold 0.1)"
 
 
-# Note: N <= 512 will disable the deepgemm path due to performance issues.
 MNKs = [
-    # (1024, 768, 128),
-    # (2048, 768, 512),
-    # (512, 1024, 1024),
-    # (4096, 4096, 1024),
     (512, 2048, 2048),
 ]
 
@@ -286,9 +248,6 @@ def test_deep_gemm_mega_moe(
         pipeline_parallel_size=1,
         data_parallel_size=dp_size,
         tensor_parallel_size=1,
-        # enable_expert_parallel=use_ep,
-        # all2all_backend=backend,
-        # enable_eplb=enable_eplb,
     )
 
     vllm_config = VllmConfig(parallel_config=parallel_config)

--- a/tests/kernels/moe/test_deep_gemm_mega_moe.py
+++ b/tests/kernels/moe/test_deep_gemm_mega_moe.py
@@ -106,7 +106,7 @@ def run_single_case(
         a2_scale=a2_scale,
         g1_alphas=(1 / w1_gs) if w1_gs is not None else None,
         g2_alphas=(1 / w2_gs) if w2_gs is not None else None,
-    ),
+    )
 
     vllm_config = get_current_vllm_config()
 

--- a/tests/kernels/moe/utils.py
+++ b/tests/kernels/moe/utils.py
@@ -393,18 +393,6 @@ def per_token_cast_to_fp8(
     return fp8_data.view(m, n + pad_size)[:, :n], (x_amax / 448.0).view(m, -1)
 
 
-# replace with math
-def ceil_div(x: int, y: int) -> int:
-    return (x + y - 1) // y
-
-
-def align(x: int, y: int) -> int:
-    return ceil_div(x, y) * y
-
-
-# end replace with math
-
-
 def ceil_to_ue8m0(x: torch.Tensor):
     bits = x.abs().float().view(torch.int)
     exp = ((bits >> 23) & 0xFF) + (bits & 0x7FFFFF).bool().int()
@@ -440,7 +428,7 @@ def per_token_cast_to_fp4(
     m, n = x.shape
     assert n % 2 == 0
     assert not use_packed_ue8m0 or use_ue8m0
-    padded_n = align(n, gran_k)
+    padded_n = round_up(n, gran_k)
     x_padded = torch.zeros((m, padded_n), dtype=x.dtype, device=x.device)
     x_padded[:, :n] = x
     x_view = x_padded.view(m, -1, gran_k)

--- a/tests/kernels/moe/utils.py
+++ b/tests/kernels/moe/utils.py
@@ -393,6 +393,69 @@ def per_token_cast_to_fp8(
     return fp8_data.view(m, n + pad_size)[:, :n], (x_amax / 448.0).view(m, -1)
 
 
+# replace with math
+def ceil_div(x: int, y: int) -> int:
+    return (x + y - 1) // y
+
+
+def align(x: int, y: int) -> int:
+    return ceil_div(x, y) * y
+
+
+# end replace with math
+
+
+def ceil_to_ue8m0(x: torch.Tensor):
+    bits = x.abs().float().view(torch.int)
+    exp = ((bits >> 23) & 0xFF) + (bits & 0x7FFFFF).bool().int()
+    return (exp.clamp(1, 254) << 23).view(torch.float)
+
+
+def pack_ue8m0_to_int(x: torch.Tensor):
+    assert x.dtype == torch.float and x.size(-1) % 4 == 0
+    assert (x.view(torch.int) & ((1 << 23) - 1) == 0).all()
+    return (x.view(torch.int) >> 23).to(torch.uint8).view(torch.int)
+
+
+def _quantize_to_fp4_e2m1(x: torch.Tensor) -> torch.Tensor:
+    ax = x.abs().clamp_max(6.0)
+    # {0, 0.5, 1, 1.5, 2, 3, 4, 6}
+    # midpoints: 0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0
+    boundaries = torch.tensor(
+        [0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0], device=x.device, dtype=ax.dtype
+    )
+    idx = torch.bucketize(ax, boundaries)
+    code = idx.to(torch.uint8)
+    sign = (x < 0) & (idx != 0)
+    code = code | (sign.to(torch.uint8) << 3)
+    return code.view(torch.int8)
+
+
+def per_token_cast_to_fp4(
+    x: torch.Tensor,
+    use_ue8m0: bool,
+    gran_k: int = 128,
+    use_packed_ue8m0: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    m, n = x.shape
+    assert n % 2 == 0
+    assert not use_packed_ue8m0 or use_ue8m0
+    padded_n = align(n, gran_k)
+    x_padded = torch.zeros((m, padded_n), dtype=x.dtype, device=x.device)
+    x_padded[:, :n] = x
+    x_view = x_padded.view(m, -1, gran_k)
+    x_amax = x_view.abs().float().amax(dim=2).clamp_min(1e-4)
+    sf = x_amax / 6.0
+    sf = ceil_to_ue8m0(sf) if use_ue8m0 else sf
+    x_scaled = x_view * (1.0 / sf.unsqueeze(2))
+    codes = _quantize_to_fp4_e2m1(x_scaled).view(m, padded_n)  # int8, (m, padded_n)
+    codes2 = codes.view(m, padded_n // 2, 2)
+    packed = (codes2[:, :, 0] & 0x0F) | ((codes2[:, :, 1] & 0x0F) << 4)  # int8
+    return packed[:, : n // 2].contiguous(), pack_ue8m0_to_int(
+        sf
+    ) if use_packed_ue8m0 else sf
+
+
 def make_test_quant_config(
     e: int,
     n: int,

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
@@ -44,6 +44,9 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
 
         # Allocate symmetric memory buffer
         # NOTES: requires PyTorch >= 2.9
+
+        # print(f"DG MOE_CONFIG {moe_config}")
+
         self.buffer = deep_gemm.get_symm_buffer_for_mega_moe(
             get_dp_group().device_group,
             moe_config.num_experts,
@@ -77,7 +80,12 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
-        return activation in [MoEActivation.SILU, MoEActivation.SWIGLUSTEP]
+        return activation in [
+            MoEActivation.SILU,
+            MoEActivation.SWIGLUSTEP,
+            # TODO(bnell): hack temporarily add swigluoai for testing
+            MoEActivation.SWIGLUOAI,
+        ]
 
     @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
@@ -16,6 +16,9 @@ from vllm.model_executor.layers.fused_moe.config import (
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
 )
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    _upcast_e8m0_to_fp32,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kMxfp4Static,
@@ -133,15 +136,6 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         pass
 
     @staticmethod
-    def _ue8m0_uint8_to_float32(sf: torch.Tensor) -> torch.Tensor:
-        """Convert UE8M0 uint8 scale factors to float32.
-
-        Each uint8 is an E8M0 exponent byte. Reconstruct the float32 value
-        by placing the byte in the exponent field: float = 2^(byte - 127).
-        """
-        return (sf.to(torch.int32) << 23).view(torch.float32)
-
-    @staticmethod
     def convert_weights_for_mega_moe(
         w13_weight: torch.Tensor,
         w13_scale: torch.Tensor,
@@ -163,7 +157,7 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
 
         def xform_layout(w: torch.Tensor, w_sf: torch.Tensor) -> torch.Tensor:
             num_experts, w_mn, w_packed_k = w.shape
-            w_sf = DeepGemmMegaExperts._ue8m0_uint8_to_float32(w_sf)
+            w_sf = _upcast_e8m0_to_fp32(w_sf)
             return deep_gemm.transform_sf_into_required_layout(
                 w_sf, w_mn, w_packed_k * 2, (1, 32), num_experts
             )

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
@@ -175,7 +175,9 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         self.buffer.topk_weights[:num_tokens].copy_(topk_weights)
 
         # Run the fused mega MoE kernel
-        deep_gemm.fp8_fp4_mega_moe(output, w1, w2, self.buffer)
+        deep_gemm.fp8_fp4_mega_moe(
+            output, (w1, self.w1_scale), (w2, self.w2_scale), self.buffer
+        )
 
     def apply_monolithic(
         self,

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
@@ -29,6 +29,76 @@ from vllm.utils.deep_gemm import (
 logger = init_logger(__name__)
 
 
+class MoEPrepareAndFinalizeMegaMoE(mk.FusedMoEPrepareAndFinalizeModular):
+    """Prepare/finalize for mega_moe that quantizes activations to FP8
+    with UE8M0 packed scale factors (gran_k=32), as required by the
+    DeepGEMM mega_moe kernel."""
+
+    @property
+    def activation_format(self) -> mk.FusedMoEActivationFormat:
+        return mk.FusedMoEActivationFormat.Standard
+
+    def max_num_tokens_per_rank(self) -> int | None:
+        return None
+
+    def topk_indices_dtype(self) -> torch.dtype | None:
+        return None
+
+    def num_dispatchers(self) -> int:
+        return 1
+
+    def output_is_reduced(self) -> bool:
+        return False
+
+    def prepare(
+        self,
+        a1: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        num_experts: int,
+        expert_map: torch.Tensor | None,
+        apply_router_weight_on_input: bool,
+        quant_config: FusedMoEQuantConfig,
+        defer_input_quant: bool = False,
+    ) -> mk.PrepareResultType:
+        from deep_gemm.utils import per_token_cast_to_fp8
+
+        if apply_router_weight_on_input:
+            topk = topk_ids.size(1)
+            assert topk == 1, (
+                "apply_router_weight_on_input is only implemented for topk=1"
+            )
+            a1 = a1 * topk_weights.to(a1.dtype)
+
+        if defer_input_quant:
+            a1q, a1q_scale = a1, None
+        else:
+            # Quantize to FP8 with per-32 UE8M0 packed scale factors,
+            # the format required by DeepGEMM mega_moe.
+            a1q, a1q_scale = per_token_cast_to_fp8(
+                a1, use_ue8m0=True, gran_k=32, use_packed_ue8m0=True
+            )
+
+        return a1q, a1q_scale, None, None, None
+
+    def finalize(
+        self,
+        output: torch.Tensor,
+        fused_expert_output: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        apply_router_weight_on_input: bool,
+        weight_and_reduce_impl: mk.TopKWeightAndReduce,
+    ) -> None:
+        weight_and_reduce_impl.apply(
+            output=output,
+            fused_expert_output=fused_expert_output,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            apply_router_weight_on_input=apply_router_weight_on_input,
+        )
+
+
 class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
     """DeepGemm-based fused MoE expert implementation."""
 
@@ -54,7 +124,7 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         # Allocate symmetric memory buffer
         # NOTES: requires PyTorch >= 2.9
         self.buffer = deep_gemm.get_symm_buffer_for_mega_moe(
-            get_dp_group().device_group,  # ?
+            get_dp_group().device_group,
             moe_config.num_experts,
             moe_config.max_num_tokens,
             top_k,
@@ -113,8 +183,6 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         expert_tokens_meta: mk.ExpertTokensMetadata | None,
         activation: MoEActivation,
     ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
-        # assert self.block_shape is not None
-        print(f"K = {K}")
         workspace1 = (0,)
         workspace2 = (0,)
         output = (M, K)
@@ -155,20 +223,8 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
 
         num_tokens = hidden_states.shape[0]
 
-        print(
-            f"XXXX {
-                (
-                    num_tokens,
-                    self.buffer.x.shape,
-                    hidden_states.dtype,
-                    hidden_states.shape,
-                    a1q_scale.shape if a1q_scale is not None else None,
-                )
-            }"
-        )
-
-        # Copy inputs into the buffer before each call
-        # You may fuse these into previous kernels
+        # hidden_states and a1q_scale are already FP8 + UE8M0 packed scales
+        # from the prepare_finalize step. Just copy into the symmetric buffer.
         self.buffer.x[:num_tokens].copy_(hidden_states)
         self.buffer.x_sf[:num_tokens].copy_(a1q_scale)
         self.buffer.topk_idx[:num_tokens].copy_(topk_ids)
@@ -176,7 +232,10 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
 
         # Run the fused mega MoE kernel
         deep_gemm.fp8_fp4_mega_moe(
-            output, (w1, self.w1_scale), (w2, self.w2_scale), self.buffer
+            output,
+            (w1, self.quant_config.w1_scale),
+            (w2, self.quant_config.w2_scale),
+            self.buffer,
         )
 
     def apply_monolithic(

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
@@ -128,26 +128,24 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         output = (M, K)
         return (workspace1, workspace2, output)
 
-    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:  # noqa: B027
-        return
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         import deep_gemm
 
-        # TODO
-        # w1_weights = cast_grouped_weights_to_fp4(w1_local)
-        # w2_weights = cast_grouped_weights_to_fp4(w2_local)
-        # (dg_w1, dg_w1_s), (dg_w2, dg_w2_s) = deep_gemm.transform_weights_for_mega_moe(
-        #     w1_weights, w2_weights
-        # )
+        from vllm.model_executor.utils import replace_parameter
 
-        # Transform weights (FP4 with UE8M0 SF) into the required layout
-        # TODO: real names
         (
-            (layer.w13_weight, layer.w13_weight_scale),
-            (layer.w2_weight, layer.w2_weight_scale),
+            (w13_weight, w13_weight_scale),
+            (w2_weight, w2_weight_scale),
         ) = deep_gemm.transform_weights_for_mega_moe(
             (layer.w13_weight, layer.w13_weight_scale),
             (layer.w2_weight, layer.w2_weight_scale),
         )
+
+        # register or replace?
+        replace_parameter(layer, "w13_weight", w13_weight)
+        replace_parameter(layer, "w13_weight_scale", w13_weight_scale)
+        replace_parameter(layer, "w2_weight", w2_weight)
+        replace_parameter(layer, "w2_weight_scale", w2_weight_scale)
 
     def apply(
         self,

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
@@ -184,6 +184,8 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
     ) -> torch.Tensor:
         import deep_gemm
 
+        raise AssertionError("never get here")
+
         #
         # call experts
         #

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
@@ -29,76 +29,6 @@ from vllm.utils.deep_gemm import (
 logger = init_logger(__name__)
 
 
-class MoEPrepareAndFinalizeMegaMoE(mk.FusedMoEPrepareAndFinalizeModular):
-    """Prepare/finalize for mega_moe that quantizes activations to FP8
-    with UE8M0 packed scale factors (gran_k=32), as required by the
-    DeepGEMM mega_moe kernel."""
-
-    @property
-    def activation_format(self) -> mk.FusedMoEActivationFormat:
-        return mk.FusedMoEActivationFormat.Standard
-
-    def max_num_tokens_per_rank(self) -> int | None:
-        return None
-
-    def topk_indices_dtype(self) -> torch.dtype | None:
-        return None
-
-    def num_dispatchers(self) -> int:
-        return 1
-
-    def output_is_reduced(self) -> bool:
-        return False
-
-    def prepare(
-        self,
-        a1: torch.Tensor,
-        topk_weights: torch.Tensor,
-        topk_ids: torch.Tensor,
-        num_experts: int,
-        expert_map: torch.Tensor | None,
-        apply_router_weight_on_input: bool,
-        quant_config: FusedMoEQuantConfig,
-        defer_input_quant: bool = False,
-    ) -> mk.PrepareResultType:
-        from deep_gemm.utils import per_token_cast_to_fp8
-
-        if apply_router_weight_on_input:
-            topk = topk_ids.size(1)
-            assert topk == 1, (
-                "apply_router_weight_on_input is only implemented for topk=1"
-            )
-            a1 = a1 * topk_weights.to(a1.dtype)
-
-        if defer_input_quant:
-            a1q, a1q_scale = a1, None
-        else:
-            # Quantize to FP8 with per-32 UE8M0 packed scale factors,
-            # the format required by DeepGEMM mega_moe.
-            a1q, a1q_scale = per_token_cast_to_fp8(
-                a1, use_ue8m0=True, gran_k=32, use_packed_ue8m0=True
-            )
-
-        return a1q, a1q_scale, None, None, None
-
-    def finalize(
-        self,
-        output: torch.Tensor,
-        fused_expert_output: torch.Tensor,
-        topk_weights: torch.Tensor,
-        topk_ids: torch.Tensor,
-        apply_router_weight_on_input: bool,
-        weight_and_reduce_impl: mk.TopKWeightAndReduce,
-    ) -> None:
-        weight_and_reduce_impl.apply(
-            output=output,
-            fused_expert_output=fused_expert_output,
-            topk_weights=topk_weights,
-            topk_ids=topk_ids,
-            apply_router_weight_on_input=apply_router_weight_on_input,
-        )
-
-
 class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
     """DeepGemm-based fused MoE expert implementation."""
 
@@ -113,10 +43,10 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
 
         super().__init__(moe_config=moe_config, quant_config=quant_config)
         # assert quant_config.block_shape == get_mk_alignment_for_contiguous_layout()
-        assert (
-            quant_config.quant_dtype == torch.float8_e4m3fn
-            or quant_config.quant_dtype == "nvfp4"
-        )
+        # assert (
+        #    quant_config.quant_dtype == torch.float8_e4m3fn
+        #    or quant_config.quant_dtype == "nvfp4"
+        # )
         assert not quant_config.per_act_token_quant
         assert not quant_config.per_out_ch_quant
         # self.router = router
@@ -222,6 +152,13 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         import deep_gemm
 
         num_tokens = hidden_states.shape[0]
+
+        from deep_gemm.utils import per_token_cast_to_fp8  # FIX
+
+        assert a1q_scale is None
+        hidden_states, a1q_scale = per_token_cast_to_fp8(
+            hidden_states, use_ue8m0=True, gran_k=32, use_packed_ue8m0=True
+        )
 
         # hidden_states and a1q_scale are already FP8 + UE8M0 packed scales
         # from the prepare_finalize step. Just copy into the symmetric buffer.

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
@@ -20,7 +20,7 @@ from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
     kFp8Dynamic128Sym,
-    kFp8Static128BlockSym,
+    kMxfp4Static,
 )
 from vllm.utils.deep_gemm import (
     is_deep_gemm_supported,
@@ -36,8 +36,6 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         self,
         moe_config: FusedMoEConfig,
         quant_config: FusedMoEQuantConfig,
-        # router: FusedMoERouter,
-        top_k: int,
     ):
         import deep_gemm
 
@@ -47,6 +45,7 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         #    quant_config.quant_dtype == torch.float8_e4m3fn
         #    or quant_config.quant_dtype == "nvfp4"
         # )
+        assert quant_config.weight_quant_dtype == "mxfp4"
         assert not quant_config.per_act_token_quant
         assert not quant_config.per_out_ch_quant
         # self.router = router
@@ -57,7 +56,7 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
             get_dp_group().device_group,
             moe_config.num_experts,
             moe_config.max_num_tokens,
-            top_k,
+            moe_config.experts_per_token,
             moe_config.hidden_dim,  # XXXX for quant
             moe_config.intermediate_size_per_partition,
         )
@@ -80,7 +79,7 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         activation_key: QuantKey | None,
     ) -> bool:
         SUPPORTED_W_A = [
-            (kFp8Static128BlockSym, kFp8Dynamic128Sym),
+            (kMxfp4Static, kFp8Dynamic128Sym),
         ]
         return (weight_key, activation_key) in SUPPORTED_W_A
 
@@ -120,6 +119,13 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:  # noqa: B027
         import deep_gemm
+
+        # TODO
+        # w1_weights = cast_grouped_weights_to_fp4(w1_local)
+        # w2_weights = cast_grouped_weights_to_fp4(w2_local)
+        # (dg_w1, dg_w1_s), (dg_w2, dg_w2_s) = deep_gemm.transform_weights_for_mega_moe(
+        #     w1_weights, w2_weights
+        # )
 
         # Transform weights (FP4 with UE8M0 SF) into the required layout
         # TODO: real names

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
@@ -14,14 +14,8 @@ from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEParallelConfig,
     FusedMoEQuantConfig,
 )
-from vllm.model_executor.layers.fused_moe.router.fused_moe_router import (
-    FusedMoERouter,
-)
 from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
     TopKWeightAndReduceNoOP,
-)
-from vllm.model_executor.layers.fused_moe.utils import (
-    moe_kernel_quantize_input,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
@@ -36,15 +30,18 @@ from vllm.utils.deep_gemm import (
 logger = init_logger(__name__)
 
 
-class DeepGemmMegaExperts(mk.FusedMoEExpertsMonolithic):
+class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
     """DeepGemm-based fused MoE expert implementation."""
 
     def __init__(
         self,
         moe_config: FusedMoEConfig,
         quant_config: FusedMoEQuantConfig,
-        router: FusedMoERouter,
+        # router: FusedMoERouter,
+        top_k: int,
     ):
+        import deep_gemm
+
         super().__init__(moe_config=moe_config, quant_config=quant_config)
         assert quant_config.block_shape == get_mk_alignment_for_contiguous_layout()
         assert (
@@ -53,7 +50,18 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsMonolithic):
         )
         assert not quant_config.per_act_token_quant
         assert not quant_config.per_out_ch_quant
-        self.router = router
+        # self.router = router
+
+        # Allocate symmetric memory buffer
+        # NOTES: requires PyTorch >= 2.9
+        self.buffer = deep_gemm.get_symm_buffer_for_mega_moe(
+            get_dp_group(),
+            moe_config.num_experts,
+            moe_config.max_num_tokens,
+            top_k,
+            moe_config.hidden_dim,
+            moe_config.intermediate_size_per_partition,
+        )
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
@@ -112,7 +120,52 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsMonolithic):
         output = (M, K)
         return (workspace1, workspace2, output)
 
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:  # noqa: B027
+        import deep_gemm
+
+        # Transform weights (FP4 with UE8M0 SF) into the required layout
+        # TODO: real names
+        (
+            (layer.w13_weight, layer.w13_weight_scale),
+            (layer.w2_weight, layer.w2_weight_scale),
+        ) = deep_gemm.transform_weights_for_mega_moe(
+            (layer.w13_weight, layer.w13_weight_scale),
+            (layer.w2_weight, layer.w2_weight_scale),
+        )
+
     def apply(
+        self,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        a2_scale: torch.Tensor | None,
+        workspace13: torch.Tensor,
+        workspace2: torch.Tensor,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        apply_router_weight_on_input: bool,
+    ) -> None:
+        import deep_gemm
+
+        num_tokens = hidden_states.shape[0]
+
+        # Copy inputs into the buffer before each call
+        # You may fuse these into previous kernels
+        self.buffer.x[:num_tokens].copy_(hidden_states)
+        self.buffer.x_sf[:num_tokens].copy_(a1q_scale)
+        self.buffer.topk_idx[:num_tokens].copy_(topk_ids)
+        self.buffer.topk_weights[:num_tokens].copy_(topk_weights)
+
+        # Run the fused mega MoE kernel
+        deep_gemm.fp8_fp4_mega_moe(output, w1, w2, self.buffer)
+
+    def apply_monolithic(
         self,
         hidden_states: torch.Tensor,
         w1: torch.Tensor,
@@ -138,43 +191,18 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsMonolithic):
             hidden_states=hidden_states,
             router_logits=router_logits,
         )
-        top_k = topk_ids.size(0)
-
-        # Allocate symmetric memory buffer
-        # NOTES: requires PyTorch >= 2.9
-        buffer = deep_gemm.get_symm_buffer_for_mega_moe(
-            get_dp_group(),
-            self.moe_config.num_experts,
-            self.moe_config.max_num_tokens,
-            top_k,
-            self.moe_config.hidden_dim,
-            self.moe_config.intermediate_size_per_partition,
-        )
-
-        # Transform weights (FP4 with UE8M0 SF) into the required layout
-        transformed_l1, transformed_l2 = deep_gemm.transform_weights_for_mega_moe(
-            w1, w2
-        )
 
         num_tokens, K = hidden_states.shape
 
-        x, x_scales = moe_kernel_quantize_input(
-            hidden_states,
-            a1q_scale,
-            self.quant_config.quant_dtype,
-            self.quant_config.per_act_token_quant,
-            self.quant_config.block_shape,
-        )
-
         # Copy inputs into the buffer before each call
         # You may fuse these into previous kernels
-        buffer.x[:num_tokens].copy_(x)
-        buffer.x_sf[:num_tokens].copy_(x_scales)
-        buffer.topk_idx[:num_tokens].copy_(topk_ids)
-        buffer.topk_weights[:num_tokens].copy_(topk_weights)
+        self.buffer.x[:num_tokens].copy_(hidden_states)
+        self.buffer.x_sf[:num_tokens].copy_(a1q_scale)
+        self.buffer.topk_idx[:num_tokens].copy_(topk_ids)
+        self.buffer.topk_weights[:num_tokens].copy_(topk_weights)
 
         # Run the fused mega MoE kernel
         y = torch.empty_like(hidden_states, dtype=torch.bfloat16)
-        deep_gemm.fp8_fp4_mega_moe(y, transformed_l1, transformed_l2, buffer)
+        deep_gemm.fp8_fp4_mega_moe(y, w1, w2, self.buffer)
 
         return y

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
@@ -19,7 +19,6 @@ from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     QuantKey,
-    kFp8Dynamic128Sym,
     kMxfp4Static,
 )
 from vllm.utils.deep_gemm import (
@@ -40,12 +39,11 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         import deep_gemm
 
         super().__init__(moe_config=moe_config, quant_config=quant_config)
-        # assert quant_config.block_shape == get_mk_alignment_for_contiguous_layout()
-        # assert (
-        #    quant_config.quant_dtype == torch.float8_e4m3fn
-        #    or quant_config.quant_dtype == "nvfp4"
-        # )
-        assert quant_config.weight_quant_dtype == "mxfp4"
+        assert (
+            quant_config.quant_dtype == torch.float8_e4m3fn
+            or quant_config.quant_dtype == "nvfp4"
+            or quant_config.weight_quant_dtype == "mxfp4"
+        )
         assert not quant_config.per_act_token_quant
         assert not quant_config.per_out_ch_quant
         # self.router = router
@@ -79,7 +77,7 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         activation_key: QuantKey | None,
     ) -> bool:
         SUPPORTED_W_A = [
-            (kMxfp4Static, kFp8Dynamic128Sym),
+            (kMxfp4Static, None),
         ]
         return (weight_key, activation_key) in SUPPORTED_W_A
 
@@ -89,10 +87,16 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
-        # NOTE(rob): discovered an IMA with this combination. Needs investigation.
+        # Mega_moe handles all-to-all internally via symmetric memory.
+        # Reject any config that would use an external all-to-all backend.
         return not (
             moe_parallel_config.use_fi_nvl_two_sided_kernels
             or moe_parallel_config.use_fi_nvl_one_sided_kernels
+            or moe_parallel_config.use_deepep_ht_kernels
+            or moe_parallel_config.use_deepep_ll_kernels
+            or moe_parallel_config.use_mori_kernels
+            or moe_parallel_config.use_nixl_ep_kernels
+            or moe_parallel_config.use_batched_activation_format
         )
 
     @property
@@ -125,6 +129,7 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         return (workspace1, workspace2, output)
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:  # noqa: B027
+        return
         import deep_gemm
 
         # TODO

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
@@ -1,0 +1,180 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.distributed import (
+    get_dp_group,
+)
+from vllm.logger import init_logger
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEConfig,
+    FusedMoEParallelConfig,
+    FusedMoEQuantConfig,
+)
+from vllm.model_executor.layers.fused_moe.router.fused_moe_router import (
+    FusedMoERouter,
+)
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceNoOP,
+)
+from vllm.model_executor.layers.fused_moe.utils import (
+    moe_kernel_quantize_input,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    QuantKey,
+    kFp8Dynamic128Sym,
+    kFp8Static128BlockSym,
+)
+from vllm.utils.deep_gemm import (
+    get_mk_alignment_for_contiguous_layout,
+    is_deep_gemm_supported,
+)
+
+logger = init_logger(__name__)
+
+
+class DeepGemmMegaExperts(mk.FusedMoEExpertsMonolithic):
+    """DeepGemm-based fused MoE expert implementation."""
+
+    def __init__(
+        self,
+        moe_config: FusedMoEConfig,
+        quant_config: FusedMoEQuantConfig,
+        router: FusedMoERouter,
+    ):
+        super().__init__(moe_config=moe_config, quant_config=quant_config)
+        assert quant_config.block_shape == get_mk_alignment_for_contiguous_layout()
+        assert (
+            quant_config.quant_dtype == torch.float8_e4m3fn
+            or quant_config.quant_dtype == "nvfp4"
+        )
+        assert not quant_config.per_act_token_quant
+        assert not quant_config.per_out_ch_quant
+        self.router = router
+
+    @staticmethod
+    def activation_format() -> mk.FusedMoEActivationFormat:
+        return mk.FusedMoEActivationFormat.Standard
+
+    @staticmethod
+    def _supports_current_device() -> bool:
+        return is_deep_gemm_supported()
+
+    @staticmethod
+    def _supports_no_act_and_mul() -> bool:
+        return False
+
+    @staticmethod
+    def _supports_quant_scheme(
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> bool:
+        SUPPORTED_W_A = [
+            (kFp8Static128BlockSym, kFp8Dynamic128Sym),
+        ]
+        return (weight_key, activation_key) in SUPPORTED_W_A
+
+    @staticmethod
+    def _supports_activation(activation: MoEActivation) -> bool:
+        return activation in [MoEActivation.SILU, MoEActivation.SWIGLUSTEP]  # ???????
+
+    @staticmethod
+    def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
+        # NOTE(rob): discovered an IMA with this combination. Needs investigation.
+        return not (
+            moe_parallel_config.use_fi_nvl_two_sided_kernels
+            or moe_parallel_config.use_fi_nvl_one_sided_kernels
+        )
+
+    def supports_expert_map(self) -> bool:
+        return True
+
+    def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
+        return TopKWeightAndReduceNoOP()
+
+    def workspace_shapes(
+        self,
+        M: int,
+        N: int,
+        K: int,
+        topk: int,
+        global_num_experts: int,
+        local_num_experts: int,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        activation: MoEActivation,
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        assert self.block_shape is not None
+        workspace1 = (0,)
+        workspace2 = (0,)
+        output = (M, K)
+        return (workspace1, workspace2, output)
+
+    def apply(
+        self,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        router_logits: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        apply_router_weight_on_input: bool,
+        # grouped topk + fused topk bias parameters
+        num_expert_group: int | None = None,
+        e_score_correction_bias: torch.Tensor | None = None,
+        routed_scaling_factor: float | None = None,
+        topk_group: int | None = None,
+    ) -> torch.Tensor:
+        import deep_gemm
+
+        #
+        # call experts
+        #
+        topk_weights, topk_ids = self.router.select_experts(
+            hidden_states=hidden_states,
+            router_logits=router_logits,
+        )
+        top_k = topk_ids.size(0)
+
+        # Allocate symmetric memory buffer
+        # NOTES: requires PyTorch >= 2.9
+        buffer = deep_gemm.get_symm_buffer_for_mega_moe(
+            get_dp_group(),
+            self.moe_config.num_experts,
+            self.moe_config.max_num_tokens,
+            top_k,
+            self.moe_config.hidden_dim,
+            self.moe_config.intermediate_size_per_partition,
+        )
+
+        # Transform weights (FP4 with UE8M0 SF) into the required layout
+        transformed_l1, transformed_l2 = deep_gemm.transform_weights_for_mega_moe(
+            w1, w2
+        )
+
+        num_tokens, K = hidden_states.shape
+
+        x, x_scales = moe_kernel_quantize_input(
+            hidden_states,
+            a1q_scale,
+            self.quant_config.quant_dtype,
+            self.quant_config.per_act_token_quant,
+            self.quant_config.block_shape,
+        )
+
+        # Copy inputs into the buffer before each call
+        # You may fuse these into previous kernels
+        buffer.x[:num_tokens].copy_(x)
+        buffer.x_sf[:num_tokens].copy_(x_scales)
+        buffer.topk_idx[:num_tokens].copy_(topk_ids)
+        buffer.topk_weights[:num_tokens].copy_(topk_weights)
+
+        # Run the fused mega MoE kernel
+        y = torch.empty_like(hidden_states, dtype=torch.bfloat16)
+        deep_gemm.fp8_fp4_mega_moe(y, transformed_l1, transformed_l2, buffer)
+
+        return y

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
@@ -7,7 +7,6 @@ import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.distributed import (
     get_dp_group,
 )
-from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig,
@@ -25,8 +24,6 @@ from vllm.utils.deep_gemm import (
     is_deep_gemm_mega_moe_supported,
 )
 
-logger = init_logger(__name__)
-
 
 class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
     """DeepGemm-based fused MoE expert implementation."""
@@ -39,14 +36,11 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         import deep_gemm
 
         super().__init__(moe_config=moe_config, quant_config=quant_config)
-        assert (
-            quant_config.quant_dtype == torch.float8_e4m3fn
-            or quant_config.quant_dtype == "nvfp4"
-            or quant_config.weight_quant_dtype == "mxfp4"
-        )
+        # activation quantization is handled by apply
+        assert quant_config.quant_dtype is None
+        assert quant_config.weight_quant_dtype == "mxfp4"
         assert not quant_config.per_act_token_quant
         assert not quant_config.per_out_ch_quant
-        # self.router = router
 
         # Allocate symmetric memory buffer
         # NOTES: requires PyTorch >= 2.9
@@ -55,7 +49,7 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
             moe_config.num_experts,
             moe_config.max_num_tokens,
             moe_config.experts_per_token,
-            moe_config.hidden_dim,  # XXXX for quant
+            moe_config.hidden_dim,
             moe_config.intermediate_size_per_partition,
         )
 
@@ -83,7 +77,7 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def _supports_activation(activation: MoEActivation) -> bool:
-        return activation in [MoEActivation.SILU, MoEActivation.SWIGLUSTEP]  # ???????
+        return activation in [MoEActivation.SILU, MoEActivation.SWIGLUSTEP]
 
     @staticmethod
     def _supports_parallel_config(moe_parallel_config: FusedMoEParallelConfig) -> bool:
@@ -189,47 +183,3 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
             (w2, self.quant_config.w2_scale),
             self.buffer,
         )
-
-    def apply_monolithic(
-        self,
-        hidden_states: torch.Tensor,
-        w1: torch.Tensor,
-        w2: torch.Tensor,
-        router_logits: torch.Tensor,
-        activation: MoEActivation,
-        global_num_experts: int,
-        expert_map: torch.Tensor | None,
-        a1q_scale: torch.Tensor | None,
-        apply_router_weight_on_input: bool,
-        # grouped topk + fused topk bias parameters
-        num_expert_group: int | None = None,
-        e_score_correction_bias: torch.Tensor | None = None,
-        routed_scaling_factor: float | None = None,
-        topk_group: int | None = None,
-    ) -> torch.Tensor:
-        import deep_gemm
-
-        raise AssertionError("never get here")
-
-        #
-        # call experts
-        #
-        topk_weights, topk_ids = self.router.select_experts(
-            hidden_states=hidden_states,
-            router_logits=router_logits,
-        )
-
-        num_tokens, K = hidden_states.shape
-
-        # Copy inputs into the buffer before each call
-        # You may fuse these into previous kernels
-        self.buffer.x[:num_tokens].copy_(hidden_states)
-        self.buffer.x_sf[:num_tokens].copy_(a1q_scale)
-        self.buffer.topk_idx[:num_tokens].copy_(topk_ids)
-        self.buffer.topk_weights[:num_tokens].copy_(topk_weights)
-
-        # Run the fused mega MoE kernel
-        y = torch.empty_like(hidden_states, dtype=torch.bfloat16)
-        deep_gemm.fp8_fp4_mega_moe(y, w1, w2, self.buffer)
-
-        return y

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
@@ -42,11 +42,10 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         assert not quant_config.per_act_token_quant
         assert not quant_config.per_out_ch_quant
 
-        # Allocate symmetric memory buffer
-        # NOTES: requires PyTorch >= 2.9
-
         # print(f"DG MOE_CONFIG {moe_config}")
 
+        # Allocate symmetric memory buffer
+        # NOTES: requires PyTorch >= 2.9
         self.buffer = deep_gemm.get_symm_buffer_for_mega_moe(
             get_dp_group().device_group,
             moe_config.num_experts,
@@ -130,24 +129,74 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         output = (M, K)
         return (workspace1, workspace2, output)
 
-    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:  # noqa: B027
+        pass
+
+    @staticmethod
+    def _ue8m0_uint8_to_float32(sf: torch.Tensor) -> torch.Tensor:
+        """Convert UE8M0 uint8 scale factors to float32.
+
+        Each uint8 is an E8M0 exponent byte. Reconstruct the float32 value
+        by placing the byte in the exponent field: float = 2^(byte - 127).
+        """
+        return (sf.to(torch.int32) << 23).view(torch.float32)
+
+    @staticmethod
+    def convert_weights_for_mega_moe(
+        w13_weight: torch.Tensor,
+        w13_scale: torch.Tensor,
+        w2_weight: torch.Tensor,
+        w2_scale: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Convert gpt_oss checkpoint weights into mega_moe kernel format.
+
+        Handles three transformations:
+        1. De-interleave w13 gate/up rows from checkpoint interleaved layout
+        2. Convert uint8 UE8M0 scales to packed int32 via
+           transform_sf_into_required_layout
+        3. Apply transform_weights_for_mega_moe for final kernel layout
+
+        Returns (w13_weight, w13_scale, w2_weight, w2_scale) in mega_moe
+        format.
+        """
         import deep_gemm
 
-        from vllm.model_executor.utils import replace_parameter
+        # 1. De-interleave w13 gate/up rows.
+        #    Checkpoint: [gate[0], up[0], gate[1], up[1], ...]
+        #    mega_moe expects: [gate[0..N-1], up[0..N-1]]
+        gate_w, up_w = w13_weight[:, ::2, :], w13_weight[:, 1::2, :]
+        w13_weight = torch.cat([gate_w, up_w], dim=1).contiguous()
 
-        (
-            (w13_weight, w13_weight_scale),
-            (w2_weight, w2_weight_scale),
-        ) = deep_gemm.transform_weights_for_mega_moe(
-            (layer.w13_weight, layer.w13_weight_scale),
-            (layer.w2_weight, layer.w2_weight_scale),
+        gate_s, up_s = w13_scale[:, ::2, :], w13_scale[:, 1::2, :]
+        w13_scale = torch.cat([gate_s, up_s], dim=1).contiguous()
+
+        # 2. Convert uint8 UE8M0 scales to float32, then pack via
+        #    transform_sf_into_required_layout (TMA alignment + int32 packing).
+        #    k parameter must be the unpacked dimension (K, not K//2).
+        num_experts, w13_mn, w13_packed_k = w13_weight.shape
+        w13_scale = DeepGemmMegaExperts._ue8m0_uint8_to_float32(w13_scale)
+        w13_scale = deep_gemm.transform_sf_into_required_layout(
+            w13_scale, w13_mn, w13_packed_k * 2, (1, 32), num_experts
         )
 
-        # register or replace?
-        replace_parameter(layer, "w13_weight", w13_weight)
-        replace_parameter(layer, "w13_weight_scale", w13_weight_scale)
-        replace_parameter(layer, "w2_weight", w2_weight)
-        replace_parameter(layer, "w2_weight_scale", w2_weight_scale)
+        _, w2_mn, w2_packed_k = w2_weight.shape
+        w2_scale = DeepGemmMegaExperts._ue8m0_uint8_to_float32(w2_scale)
+        w2_scale = deep_gemm.transform_sf_into_required_layout(
+            w2_scale, w2_mn, w2_packed_k * 2, (1, 32), num_experts
+        )
+
+        # 3. Transform weights for mega_moe layout:
+        #    L1: re-interleave gate/up in groups of 8, transpose SF for UTCCP
+        #    L2: transpose SF for UTCCP
+        (
+            (w13_weight, w13_scale),
+            (w2_weight, w2_scale),
+        ) = deep_gemm.transform_weights_for_mega_moe(
+            (w13_weight, w13_scale),
+            (w2_weight, w2_scale),
+        )
+
+        return w13_weight, w13_scale, w2_weight, w2_scale
 
     def apply(
         self,
@@ -184,10 +233,12 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         self.buffer.topk_idx[:num_tokens].copy_(topk_ids)
         self.buffer.topk_weights[:num_tokens].copy_(topk_weights)
 
+        print(f"QQ {self.w1_scale.dtype, self.w1_scale.shape}")
+
         # Run the fused mega MoE kernel
         deep_gemm.fp8_fp4_mega_moe(
             output,
-            (w1, self.quant_config.w1_scale),
-            (w2, self.quant_config.w2_scale),
+            (w1, self.w1_scale),
+            (w2, self.w2_scale),
             self.buffer,
         )

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
@@ -58,7 +58,7 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
             moe_config.num_experts,
             moe_config.max_num_tokens,
             top_k,
-            moe_config.hidden_dim,
+            moe_config.hidden_dim,  # XXXX for quant
             moe_config.intermediate_size_per_partition,
         )
 
@@ -114,6 +114,7 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         activation: MoEActivation,
     ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
         # assert self.block_shape is not None
+        print(f"K = {K}")
         workspace1 = (0,)
         workspace2 = (0,)
         output = (M, K)
@@ -153,6 +154,18 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         import deep_gemm
 
         num_tokens = hidden_states.shape[0]
+
+        print(
+            f"XXXX {
+                (
+                    num_tokens,
+                    self.buffer.x.shape,
+                    hidden_states.dtype,
+                    hidden_states.shape,
+                    a1q_scale.shape if a1q_scale is not None else None,
+                )
+            }"
+        )
 
         # Copy inputs into the buffer before each call
         # You may fuse these into previous kernels

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
@@ -95,6 +95,13 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
             or moe_parallel_config.use_fi_nvl_one_sided_kernels
         )
 
+    @property
+    def expects_unquantized_inputs(self) -> bool:
+        # Activation FP8 quantization (UE8M0 packed scales, gran_k=32) is
+        # done inside apply(). Setting this to True causes the prepare step
+        # to pass defer_input_quant=True, skipping standard quantization.
+        return True
+
     def supports_expert_map(self) -> bool:
         return True
 
@@ -159,17 +166,16 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
 
         num_tokens = hidden_states.shape[0]
 
-        from deep_gemm.utils import per_token_cast_to_fp8  # FIX
-
+        # Quantize activations to FP8 with UE8M0 packed scale factors.
+        # expects_unquantized_inputs=True so hidden_states is BF16.
         assert a1q_scale is None
-        hidden_states, a1q_scale = per_token_cast_to_fp8(
+        tokens_fp8, tokens_sf = deep_gemm.utils.per_token_cast_to_fp8(
             hidden_states, use_ue8m0=True, gran_k=32, use_packed_ue8m0=True
         )
 
-        # hidden_states and a1q_scale are already FP8 + UE8M0 packed scales
-        # from the prepare_finalize step. Just copy into the symmetric buffer.
-        self.buffer.x[:num_tokens].copy_(hidden_states)
-        self.buffer.x_sf[:num_tokens].copy_(a1q_scale)
+        # Copy into the symmetric buffer.
+        self.buffer.x[:num_tokens].copy_(tokens_fp8)
+        self.buffer.x_sf[:num_tokens].copy_(tokens_sf)
         self.buffer.topk_idx[:num_tokens].copy_(topk_ids)
         self.buffer.topk_weights[:num_tokens].copy_(topk_weights)
 

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
@@ -22,7 +22,7 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kMxfp4Static,
 )
 from vllm.utils.deep_gemm import (
-    is_deep_gemm_supported,
+    is_deep_gemm_mega_moe_supported,
 )
 
 logger = init_logger(__name__)
@@ -65,7 +65,7 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
 
     @staticmethod
     def _supports_current_device() -> bool:
-        return is_deep_gemm_supported()
+        return is_deep_gemm_mega_moe_supported()
 
     @staticmethod
     def _supports_no_act_and_mul() -> bool:

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
@@ -161,6 +161,17 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         """
         import deep_gemm
 
+        def xform_layout(w: torch.Tensor, w_sf: torch.Tensor) -> torch.Tensor:
+            num_experts, w_mn, w_packed_k = w.shape
+            w_sf = DeepGemmMegaExperts._ue8m0_uint8_to_float32(w_sf)
+            return deep_gemm.transform_sf_into_required_layout(
+                w_sf, w_mn, w_packed_k * 2, (1, 32), num_experts
+            )
+
+        # 0. Cast uint8 packed FP4 weights to int8 (kPackedFP4 = torch::kInt8).
+        w13_weight = w13_weight.view(torch.int8)
+        w2_weight = w2_weight.view(torch.int8)
+
         # 1. De-interleave w13 gate/up rows.
         #    Checkpoint: [gate[0], up[0], gate[1], up[1], ...]
         #    mega_moe expects: [gate[0..N-1], up[0..N-1]]
@@ -173,17 +184,8 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         # 2. Convert uint8 UE8M0 scales to float32, then pack via
         #    transform_sf_into_required_layout (TMA alignment + int32 packing).
         #    k parameter must be the unpacked dimension (K, not K//2).
-        num_experts, w13_mn, w13_packed_k = w13_weight.shape
-        w13_scale = DeepGemmMegaExperts._ue8m0_uint8_to_float32(w13_scale)
-        w13_scale = deep_gemm.transform_sf_into_required_layout(
-            w13_scale, w13_mn, w13_packed_k * 2, (1, 32), num_experts
-        )
-
-        _, w2_mn, w2_packed_k = w2_weight.shape
-        w2_scale = DeepGemmMegaExperts._ue8m0_uint8_to_float32(w2_scale)
-        w2_scale = deep_gemm.transform_sf_into_required_layout(
-            w2_scale, w2_mn, w2_packed_k * 2, (1, 32), num_experts
-        )
+        w13_scale = xform_layout(w13_weight, w13_scale)
+        w2_scale = xform_layout(w2_weight, w2_scale)
 
         # 3. Transform weights for mega_moe layout:
         #    L1: re-interleave gate/up in groups of 8, transpose SF for UTCCP
@@ -232,8 +234,6 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         self.buffer.x_sf[:num_tokens].copy_(tokens_sf)
         self.buffer.topk_idx[:num_tokens].copy_(topk_ids)
         self.buffer.topk_weights[:num_tokens].copy_(topk_weights)
-
-        print(f"QQ {self.w1_scale.dtype, self.w1_scale.shape}")
 
         # Run the fused mega MoE kernel
         deep_gemm.fp8_fp4_mega_moe(

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_mega_moe.py
@@ -23,7 +23,6 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
     kFp8Static128BlockSym,
 )
 from vllm.utils.deep_gemm import (
-    get_mk_alignment_for_contiguous_layout,
     is_deep_gemm_supported,
 )
 
@@ -43,7 +42,7 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         import deep_gemm
 
         super().__init__(moe_config=moe_config, quant_config=quant_config)
-        assert quant_config.block_shape == get_mk_alignment_for_contiguous_layout()
+        # assert quant_config.block_shape == get_mk_alignment_for_contiguous_layout()
         assert (
             quant_config.quant_dtype == torch.float8_e4m3fn
             or quant_config.quant_dtype == "nvfp4"
@@ -55,7 +54,7 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         # Allocate symmetric memory buffer
         # NOTES: requires PyTorch >= 2.9
         self.buffer = deep_gemm.get_symm_buffer_for_mega_moe(
-            get_dp_group(),
+            get_dp_group().device_group,  # ?
             moe_config.num_experts,
             moe_config.max_num_tokens,
             top_k,
@@ -114,7 +113,7 @@ class DeepGemmMegaExperts(mk.FusedMoEExpertsModular):
         expert_tokens_meta: mk.ExpertTokensMetadata | None,
         activation: MoEActivation,
     ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
-        assert self.block_shape is not None
+        # assert self.block_shape is not None
         workspace1 = (0,)
         workspace2 = (0,)
         output = (M, K)

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -66,6 +66,8 @@ class Mxfp4MoeBackend(Enum):
     TRITON_UNFUSED = "TRITON_UNFUSED"
     # XPU
     XPU = "XPU"
+    # DeepGemm mega_moe
+    DEEPGEMM_MEGA = "DEEPGEMM_MEGA"
     # Emulation
     EMULATION = "EMULATION"
 
@@ -156,6 +158,13 @@ def backend_to_kernel_cls(
 
         return [XPUExpertsMXFp4]
 
+    elif backend == Mxfp4MoeBackend.DEEPGEMM_MEGA:
+        from vllm.model_executor.layers.fused_moe.experts.deep_gemm_mega_moe import (
+            DeepGemmMegaExperts,
+        )
+
+        return [DeepGemmMegaExperts]
+
     elif backend == Mxfp4MoeBackend.EMULATION:
         from vllm.model_executor.layers.fused_moe.experts.ocp_mx_emulation_moe import (
             OCP_MXQuantizationEmulationTritonExperts,
@@ -179,6 +188,7 @@ def map_mxfp4_backend(runner_backend: MoEBackend) -> Mxfp4MoeBackend:
         "triton_unfused": Mxfp4MoeBackend.TRITON_UNFUSED,
         "marlin": Mxfp4MoeBackend.MARLIN,
         "aiter": Mxfp4MoeBackend.AITER,
+        "deepgemm_mega": Mxfp4MoeBackend.DEEPGEMM_MEGA,
         "xpu": Mxfp4MoeBackend.XPU,
         "emulation": Mxfp4MoeBackend.EMULATION,
     }
@@ -196,6 +206,7 @@ def _get_priority_backends_for_gpt_oss() -> list[Mxfp4MoeBackend]:
     Only includes BF16 backends. MXFP8 backends are selected via env vars.
     """
     _AVAILABLE_BACKENDS = [
+        Mxfp4MoeBackend.DEEPGEMM_MEGA,
         Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_BF16,
         Mxfp4MoeBackend.AITER,
         Mxfp4MoeBackend.TRITON,
@@ -519,9 +530,13 @@ def mxfp4_round_up_hidden_size_and_intermediate_size(
     elif backend in TRTLLM_BACKENDS:
         intermediate_size = round_up(intermediate_size, 256)
         hidden_size = round_up(hidden_size, 256)
-    elif backend in (
-        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
-        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
+    elif (
+        backend
+        in (
+            Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
+            Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
+        )
+        or backend == Mxfp4MoeBackend.DEEPGEMM_MEGA
     ):
         intermediate_size = round_up(intermediate_size, 128)
         hidden_size = round_up(hidden_size, 128)
@@ -903,6 +918,26 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
             w13_bias,
             w2_bias,
         )
+    elif mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MEGA:
+        import deep_gemm
+
+        # transform_weights_for_mega_moe: interleaves gate/up for L1,
+        # transposes scale factors for UTCCP layout.
+        (w13_weight, w13_weight_scale), (w2_weight, w2_weight_scale) = (
+            deep_gemm.transform_weights_for_mega_moe(
+                (w13_weight, w13_weight_scale),
+                (w2_weight, w2_weight_scale),
+            )
+        )
+        return (
+            w13_weight,
+            w2_weight,
+            w13_weight_scale,
+            w2_weight_scale,
+            w13_bias,
+            w2_bias,
+        )
+
     elif mxfp4_backend == Mxfp4MoeBackend.XPU:
         # No additional transformation needed for XPU backend
         return (
@@ -1216,6 +1251,7 @@ def make_mxfp4_moe_quant_config(
         Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_BF16,
         Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
         Mxfp4MoeBackend.AITER,
+        Mxfp4MoeBackend.DEEPGEMM_MEGA,
     ):
         return mxfp4_w4a16_moe_quant_config(
             w1_bias=w1_bias,
@@ -1251,13 +1287,27 @@ def make_mxfp4_moe_kernel(
     is_monolithic = issubclass(experts_cls, mk.FusedMoEExpertsMonolithic)
 
     # Create Prepare/Finalize.
-    prepare_finalize = maybe_make_prepare_finalize(
-        moe=moe_config,
-        quant_config=moe_quant_config,
-        routing_tables=routing_tables,
-        allow_new_interface=True,
-        use_monolithic=is_monolithic,
-    )
+    prepare_finalize: mk.FusedMoEPrepareAndFinalize | None
+    if mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MEGA:
+        # Mega_moe handles all-to-all communication internally via symmetric
+        # memory. Do NOT use maybe_make_prepare_finalize() here — it would
+        # select an external all-to-all backend (DeepEP, etc.) that conflicts
+        # with mega_moe's built-in dispatch/combine.
+        from vllm.model_executor.layers.fused_moe.prepare_finalize.no_dp_ep import (
+            make_moe_prepare_and_finalize_no_dp_ep,
+        )
+
+        prepare_finalize = make_moe_prepare_and_finalize_no_dp_ep(
+            use_monolithic=False,
+        )
+    else:
+        prepare_finalize = maybe_make_prepare_finalize(
+            moe=moe_config,
+            quant_config=moe_quant_config,
+            routing_tables=routing_tables,
+            allow_new_interface=True,
+            use_monolithic=is_monolithic,
+        )
     assert prepare_finalize is not None
 
     logger.info_once("Using %s", prepare_finalize.__class__.__name__)

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -919,16 +919,8 @@ def convert_gpt_oss_weight_to_mxfp4_moe_kernel_format(
             w2_bias,
         )
     elif mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MEGA:
-        import deep_gemm
-
-        # transform_weights_for_mega_moe: interleaves gate/up for L1,
-        # transposes scale factors for UTCCP layout.
-        (w13_weight, w13_weight_scale), (w2_weight, w2_weight_scale) = (
-            deep_gemm.transform_weights_for_mega_moe(
-                (w13_weight, w13_weight_scale),
-                (w2_weight, w2_weight_scale),
-            )
-        )
+        # Weight transformation is handled by
+        # DeepGemmMegaExperts.process_weights_after_loading().
         return (
             w13_weight,
             w2_weight,

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -530,17 +530,13 @@ def mxfp4_round_up_hidden_size_and_intermediate_size(
     elif backend in TRTLLM_BACKENDS:
         intermediate_size = round_up(intermediate_size, 256)
         hidden_size = round_up(hidden_size, 256)
-    elif (
-        backend
-        in (
-            Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
-            Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
-        )
-        or backend == Mxfp4MoeBackend.DEEPGEMM_MEGA
+    elif backend in (
+        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
+        Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_MXFP8,
     ):
         intermediate_size = round_up(intermediate_size, 128)
         hidden_size = round_up(hidden_size, 128)
-    elif current_platform.is_rocm():
+    elif backend == Mxfp4MoeBackend.DEEPGEMM_MEGA or current_platform.is_rocm():
         intermediate_size = round_up(intermediate_size, 256)
         hidden_size = round_up(hidden_size, 256)
     else:

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -206,8 +206,8 @@ def _get_priority_backends_for_gpt_oss() -> list[Mxfp4MoeBackend]:
     Only includes BF16 backends. MXFP8 backends are selected via env vars.
     """
     _AVAILABLE_BACKENDS = [
-        Mxfp4MoeBackend.DEEPGEMM_MEGA,
         Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_BF16,
+        Mxfp4MoeBackend.DEEPGEMM_MEGA,
         Mxfp4MoeBackend.AITER,
         Mxfp4MoeBackend.TRITON,
         Mxfp4MoeBackend.FLASHINFER_CUTLASS_MXFP4_BF16,
@@ -230,6 +230,7 @@ def _get_priority_backends() -> list[Mxfp4MoeBackend]:
     """
     _AVAILABLE_BACKENDS = [
         Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_MXFP8,
+        Mxfp4MoeBackend.DEEPGEMM_MEGA,
         Mxfp4MoeBackend.DEEPGEMM_MXFP4,
         # TRITON_UNFUSED has bug with MTP support
         # TODO re-enable after kernel is fixed
@@ -989,6 +990,18 @@ def convert_weight_to_mxfp4_moe_kernel_format(
             w2_weight.data,
             _upcast_e8m0_to_fp32(w13_weight_scale.data),
             _upcast_e8m0_to_fp32(w2_weight_scale.data),
+            w13_bias,
+            w2_bias,
+        )
+
+    if mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MEGA:
+        # Weights stay as uint8 packed FP4 — no layout change needed.
+        # Convert E8M0 uint8 scales to float32.
+        return (
+            w13_weight.data,
+            w2_weight.data,
+            w13_weight_scale,
+            w2_weight_scale,
             w13_bias,
             w2_bias,
         )

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -368,6 +368,9 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
                 shared_experts=layer.shared_experts,
             )
 
+            # Let experts do backend-specific weight post-processing.
+            self.moe_kernel.fused_experts.process_weights_after_loading(layer)
+
     def process_weights_after_loading(self, layer):
         w13 = layer.w13_weight
         w2 = layer.w2_weight

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -702,6 +702,25 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             replace_parameter(layer, "w13_bias", w13_bias)
             replace_parameter(layer, "w2_bias", w2_bias)
 
+        # DEEPGEMM_MEGA: convert checkpoint weights/scales into the format
+        # expected by deep_gemm.fp8_fp4_mega_moe. Must happen before
+        # get_fused_moe_quant_config which reads scales from the layer.
+        if self.mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MEGA:
+            from vllm.model_executor.layers.fused_moe.experts.deep_gemm_mega_moe import (  # noqa: E501
+                DeepGemmMegaExperts,
+            )
+
+            w13_w, w13_s, w2_w, w2_s = DeepGemmMegaExperts.convert_weights_for_mega_moe(
+                layer.w13_weight.data,
+                layer.w13_weight_scale.data,
+                layer.w2_weight.data,
+                layer.w2_weight_scale.data,
+            )
+            replace_parameter(layer, "w13_weight", w13_w)
+            replace_parameter(layer, "w13_weight_scale", w13_s)
+            replace_parameter(layer, "w2_weight", w2_w)
+            replace_parameter(layer, "w2_weight_scale", w2_s)
+
         # Build quant config
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
 

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -354,6 +354,25 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
             replace_parameter(layer, "w13_bias", w13_bias)
             replace_parameter(layer, "w2_bias", w2_bias)
 
+        # DEEPGEMM_MEGA: convert checkpoint weights/scales into the format
+        # expected by deep_gemm.fp8_fp4_mega_moe. Must happen before
+        # get_fused_moe_quant_config which reads scales from the layer.
+        if self.mxfp4_backend == Mxfp4MoeBackend.DEEPGEMM_MEGA:
+            from vllm.model_executor.layers.fused_moe.experts.deep_gemm_mega_moe import (  # noqa: E501
+                DeepGemmMegaExperts,
+            )
+
+            w13_w, w13_s, w2_w, w2_s = DeepGemmMegaExperts.convert_weights_for_mega_moe(
+                layer.w13_weight.data,
+                layer.w13_weight_scale.data,
+                layer.w2_weight.data,
+                layer.w2_weight_scale.data,
+            )
+            replace_parameter(layer, "w13_weight", w13_w)
+            replace_parameter(layer, "w13_weight_scale", w13_s)
+            replace_parameter(layer, "w2_weight", w2_w)
+            replace_parameter(layer, "w2_weight_scale", w2_s)
+
         # Build quant config
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
 

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -93,6 +93,19 @@ def is_deep_gemm_supported() -> bool:
 
 
 @functools.cache
+def is_deep_gemm_mega_moe_supported() -> bool:
+    """Return `True` if DeepGEMM mega_moe is available.
+
+    Checks for ``fp8_fp4_mega_moe`` in the installed deep_gemm package,
+    which is only present in builds that include the mega_moe kernel.
+    """
+    if not is_deep_gemm_supported():
+        return False
+    dg = _import_deep_gemm()
+    return dg is not None and hasattr(dg, "fp8_fp4_mega_moe")
+
+
+@functools.cache
 def is_deep_gemm_e8m0_used() -> bool:
     """Return `True` if vLLM is configured to use DeepGEMM "
     "E8M0 scale on a Hopper or Blackwell-class GPU.
@@ -574,6 +587,7 @@ __all__ = [
     "get_paged_mqa_logits_metadata",
     "per_block_cast_to_fp8",
     "is_deep_gemm_e8m0_used",
+    "is_deep_gemm_mega_moe_supported",
     "is_deep_gemm_supported",
     "get_num_sms",
     "set_num_sms",


### PR DESCRIPTION

## Purpose

Integration for DeepGEMM MegaMoE kernel.

Weight creation/prep in the quant method is not right.  I'm not sure if I should create a whole new quant method or hack up the existing create_weights or add some further processing step, .e.g. `cast_grouped_weights_to_fp4`

TODO: consider making "deep_gemm_mega_moe" backend?

## Test Plan

Added unit test
TODO: test on mxfp4 model.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
