### PR TITLE
Fix encoder cache miss accounting

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -2835,6 +2835,10 @@ def test_ec_connector_cache_hit_external_load(use_kv_connector):
     # Scheduled encoder input should be empty; no mm to compute
     _assert_right_encoder_inputs(output, expected_total_reqs=0)
 
+    stats = scheduler.encoder_cache_manager.get_and_update_stats()
+    assert stats.queries == 0
+    assert stats.hits == 0
+
 
 @pytest.mark.parametrize("use_kv_connector", [False, True])
 def test_ec_connector_cache_miss_computes_locally(use_kv_connector):
@@ -2888,6 +2892,10 @@ def test_ec_connector_cache_miss_computes_locally(use_kv_connector):
         expected_encoder_inputs=[[0]],  # index 0 of the mm item
         expected_total_reqs=1,
     )
+
+    stats = scheduler.encoder_cache_manager.get_and_update_stats()
+    assert stats.queries == 1
+    assert stats.hits == 0
 
     # Then MODEL_RUNNER will execute the encoder and cache the result
 
@@ -2959,6 +2967,10 @@ def test_ec_connector_with_partial_cache_hit_multi_round(use_kv_connector):
         expected_encoder_inputs=[[0]],  # index 0 of the mm item ONLY
         expected_total_reqs=1,
     )
+
+    stats = scheduler.encoder_cache_manager.get_and_update_stats()
+    assert stats.queries == 1
+    assert stats.hits == 0
 
     # Simulate model execution 1 step
     model_output = ModelRunnerOutput(
@@ -3043,6 +3055,10 @@ def test_ec_connector_with_partial_cache_hit_multi_round(use_kv_connector):
         expected_encoder_inputs=[[1, 2]],
         expected_total_reqs=1,
     )
+
+    stats = scheduler.encoder_cache_manager.get_and_update_stats()
+    assert stats.queries == 3
+    assert stats.hits == 1
 
 
 @pytest.mark.parametrize("cache_exist", ["local", "connector_only", "no_where"])

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -835,6 +835,8 @@ class Scheduler(SchedulerInterface):
                     # Allocate the encoder cache.
                     for i in encoder_inputs_to_schedule:
                         self.encoder_cache_manager.allocate(request, i)
+                        # Scheduled a fresh encoder run -> GPU encoder-cache miss.
+                        self.encoder_cache_manager.record_miss()
                         if self.ec_connector is not None:
                             self.ec_connector.update_state_after_alloc(request, i)
                     encoder_compute_budget = new_encoder_compute_budget


### PR DESCRIPTION
## Summary
- Count locally scheduled encoder runs as encoder-cache misses for newly scheduled multimodal requests.
- Add scheduler regression assertions for connector hits, local misses, and local GPU-cache reuse.

## Root Cause
Fresh encoder inputs scheduled from the WAITING/new-request path allocated encoder-cache entries but did not call record_miss(), unlike the RUNNING-request path.

## Validation
- python3 -m py_compile vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py
- git diff --check upstream/releases/v0.19.0...HEAD

Note: targeted pytest was previously blocked in this local environment by missing test dependency tblib.