### PR TITLE
Add NVTX and encoder cache accounting updates

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -2835,6 +2835,10 @@ def test_ec_connector_cache_hit_external_load(use_kv_connector):
     # Scheduled encoder input should be empty; no mm to compute
     _assert_right_encoder_inputs(output, expected_total_reqs=0)
 
+    stats = scheduler.encoder_cache_manager.get_and_update_stats()
+    assert stats.queries == 0
+    assert stats.hits == 0
+
 
 @pytest.mark.parametrize("use_kv_connector", [False, True])
 def test_ec_connector_cache_miss_computes_locally(use_kv_connector):
@@ -2888,6 +2892,10 @@ def test_ec_connector_cache_miss_computes_locally(use_kv_connector):
         expected_encoder_inputs=[[0]],  # index 0 of the mm item
         expected_total_reqs=1,
     )
+
+    stats = scheduler.encoder_cache_manager.get_and_update_stats()
+    assert stats.queries == 1
+    assert stats.hits == 0
 
     # Then MODEL_RUNNER will execute the encoder and cache the result
 
@@ -2959,6 +2967,10 @@ def test_ec_connector_with_partial_cache_hit_multi_round(use_kv_connector):
         expected_encoder_inputs=[[0]],  # index 0 of the mm item ONLY
         expected_total_reqs=1,
     )
+
+    stats = scheduler.encoder_cache_manager.get_and_update_stats()
+    assert stats.queries == 1
+    assert stats.hits == 0
 
     # Simulate model execution 1 step
     model_output = ModelRunnerOutput(
@@ -3043,6 +3055,10 @@ def test_ec_connector_with_partial_cache_hit_multi_round(use_kv_connector):
         expected_encoder_inputs=[[1, 2]],
         expected_total_reqs=1,
     )
+
+    stats = scheduler.encoder_cache_manager.get_and_update_stats()
+    assert stats.queries == 3
+    assert stats.hits == 1
 
 
 @pytest.mark.parametrize("cache_exist", ["local", "connector_only", "no_where"])

--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -55,6 +55,9 @@ from vllm.tool_parsers import ToolParser
 from vllm.utils import random_uuid
 from vllm.utils.mistral import is_mistral_tokenizer
 from vllm.utils.mistral import mt as _mt
+from vllm.v1.utils import record_function_or_nullcontext  # noqa: F401  (kept for other call sites)
+
+import time as _time
 
 logger = init_logger(__name__)
 
@@ -500,6 +503,13 @@ class OpenAIServingRender:
         tool_parser: type[ToolParser] | None = None,
     ) -> tuple[list[ConversationMessage], list[EngineInput]]:
         """Copied from OpenAIServing._preprocess_chat."""
+        # NVTX range removed: this whole body is async and spans `await`,
+        # so PushPop ranges nest across concurrent coroutines on the same
+        # event-loop thread. Use the [preproc] log line below for per-request
+        # wall-clock attribution instead.
+        _preproc_t0 = _time.perf_counter()
+        _req_id = getattr(request, "request_id", None) or "?"
+
         renderer = self.renderer
         mm_config = self.model_config.multimodal_config
 
@@ -516,10 +526,15 @@ class OpenAIServingRender:
             default_template, default_template_content_format
         ).with_defaults(
             default_template_kwargs,
-            default_media_io_kwargs=(mm_config.media_io_kwargs if mm_config else None),
-            default_mm_processor_kwargs=getattr(request, "mm_processor_kwargs", None),
+            default_media_io_kwargs=(
+                mm_config.media_io_kwargs if mm_config else None
+            ),
+            default_mm_processor_kwargs=getattr(
+                request, "mm_processor_kwargs", None
+            ),
         )
 
+        _render_t0 = _time.perf_counter()
         (conversation,), (engine_input,) = await renderer.render_chat_async(
             [messages],
             chat_params,
@@ -530,6 +545,7 @@ class OpenAIServingRender:
                 if (v := getattr(request, k, None)) is not None
             },
         )
+        _render_ms = (_time.perf_counter() - _render_t0) * 1000.0
 
         # tool parsing is done only if a tool_parser has been set and if
         # tool_choice is not "none" (if tool_choice is "none" but a tool_parser
@@ -537,7 +553,9 @@ class OpenAIServingRender:
         if tool_parser is not None:
             tool_choice = getattr(request, "tool_choice", "none")
             if tool_choice != "none":
-                if not isinstance(request, ChatCompletionRequest | ResponsesRequest):
+                if not isinstance(
+                    request, ChatCompletionRequest | ResponsesRequest
+                ):
                     msg = (
                         "Tool usage is only supported "
                         "for Chat Completions API or Responses API requests, "
@@ -549,4 +567,9 @@ class OpenAIServingRender:
                     request=request  # type: ignore[arg-type]
                 )
 
+        _wall_ms = (_time.perf_counter() - _preproc_t0) * 1000.0
+        logger.info(
+            "[preproc] req=%s wall_ms=%.1f render_ms=%.1f",
+            _req_id, _wall_ms, _render_ms,
+        )
         return conversation, [engine_input]

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -218,6 +218,7 @@ if TYPE_CHECKING:
     VLLM_TOOL_JSON_ERROR_AUTOMATIC_RETRY: bool = False
     VLLM_CUSTOM_SCOPES_FOR_PROFILING: bool = False
     VLLM_NVTX_SCOPES_FOR_PROFILING: bool = False
+    VLLM_MM_CACHE_PROBE: bool = False
     VLLM_KV_EVENTS_USE_INT_BLOCK_HASHES: bool = True
     VLLM_OBJECT_STORAGE_SHM_BUFFER_NAME: str = "VLLM_OBJECT_STORAGE_SHM_BUFFER"
     VLLM_DEEPEP_BUFFER_SIZE_MB: int = 1024
@@ -1521,6 +1522,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Add optional nvtx scopes for profiling, disable to avoid overheads
     "VLLM_NVTX_SCOPES_FOR_PROFILING": lambda: bool(
         int(os.getenv("VLLM_NVTX_SCOPES_FOR_PROFILING", "0"))
+    ),
+    # Enable per-invocation MM cache probe: [mmcache] log lines with per-image
+    # HIT/MISS vector, phase breakdown, and sub-NVTX ranges inside hf_processor.
+    "VLLM_MM_CACHE_PROBE": lambda: bool(
+        int(os.getenv("VLLM_MM_CACHE_PROBE", "0"))
     ),
     # Represent block hashes in KV cache events as 64-bit integers instead of
     # raw bytes. Defaults to True for backward compatibility.

--- a/vllm/model_executor/models/qwen3_vl.py
+++ b/vllm/model_executor/models/qwen3_vl.py
@@ -98,6 +98,38 @@ from vllm.tokenizers.protocol import TokenizerLike
 from vllm.tokenizers.registry import cached_tokenizer_from_config
 from vllm.utils.collection_utils import is_list_of
 from vllm.utils.math_utils import round_up
+from vllm.v1.utils import record_function_or_nullcontext as _nvtx_ctx
+
+
+def _install_smart_resize_nvtx() -> None:
+    """Wrap transformers.smart_resize with `mm:qwen:smart_resize` NVTX.
+
+    Patches at module load so every call site (image + video) gets the range,
+    regardless of whether it went through our renamed imports above or imported
+    smart_resize fresh from transformers elsewhere.
+    """
+    import transformers.models.qwen2_vl.image_processing_qwen2_vl as _img_mod
+    import transformers.models.qwen3_vl.video_processing_qwen3_vl as _vid_mod
+
+    for _mod, _label in (
+        (_img_mod, "mm:qwen:smart_resize"),
+        (_vid_mod, "mm:qwen:smart_resize_video"),
+    ):
+        _orig = getattr(_mod, "smart_resize", None)
+        if _orig is None or getattr(_orig, "_vllm_nvtx_patched", False):
+            continue
+
+        def _make(fn, label):
+            def _wrapped(*a, **kw):
+                with _nvtx_ctx(label):
+                    return fn(*a, **kw)
+            _wrapped._vllm_nvtx_patched = True  # type: ignore[attr-defined]
+            return _wrapped
+
+        _mod.smart_resize = _make(_orig, _label)
+
+
+_install_smart_resize_nvtx()
 
 from .interfaces import (
     MultiModalEmbeddings,

--- a/vllm/multimodal/hasher.py
+++ b/vllm/multimodal/hasher.py
@@ -13,6 +13,7 @@ from PIL import Image
 
 import vllm.envs as envs
 from vllm.logger import init_logger
+from vllm.v1.utils import record_function_or_nullcontext
 
 from .media import MediaWithBytes
 
@@ -52,83 +53,93 @@ class MultiModalHasher:
     def serialize_item(cls, obj: object) -> Iterable[bytes | memoryview]:
         # Simple cases
         if isinstance(obj, (bytes, memoryview)):
-            return (obj,)
+            with record_function_or_nullcontext("mm:hash:branch:bytes"):
+                return (obj,)
         if isinstance(obj, str):
-            return (obj.encode("utf-8"),)
+            with record_function_or_nullcontext("mm:hash:branch:str"):
+                return (obj.encode("utf-8"),)
         if isinstance(obj, (int, float)):
-            return (np.array(obj).tobytes(),)
+            with record_function_or_nullcontext("mm:hash:branch:num"):
+                return (np.array(obj).tobytes(),)
 
         if isinstance(obj, Image.Image):
-            exif = obj.getexif()
-            if Image.ExifTags.Base.ImageID in exif and isinstance(
-                exif[Image.ExifTags.Base.ImageID], uuid.UUID
-            ):
-                return (exif[Image.ExifTags.Base.ImageID].bytes,)
+            with record_function_or_nullcontext("mm:hash:branch:pil"):
+                exif = obj.getexif()
+                if Image.ExifTags.Base.ImageID in exif and isinstance(
+                    exif[Image.ExifTags.Base.ImageID], uuid.UUID
+                ):
+                    return (exif[Image.ExifTags.Base.ImageID].bytes,)
 
-            data = {"mode": obj.mode, "data": np.asarray(obj)}
-            palette = obj.palette
-            if palette is not None:
-                data["palette"] = palette.palette
-                if palette.rawmode is not None:
-                    data["palette_rawmode"] = palette.rawmode
+                with record_function_or_nullcontext("mm:hash:asarray"):
+                    arr = np.asarray(obj)
+                data = {"mode": obj.mode, "data": arr}
+                palette = obj.palette
+                if palette is not None:
+                    data["palette"] = palette.palette
+                    if palette.rawmode is not None:
+                        data["palette_rawmode"] = palette.rawmode
 
-            return cls.iter_item_to_bytes("image", data)
+                return cls.iter_item_to_bytes("image", data)
 
         if isinstance(obj, MediaWithBytes) and isinstance(obj.media, Image.Image):
-            exif = obj.media.getexif()
-            if Image.ExifTags.Base.ImageID in exif and isinstance(
-                exif[Image.ExifTags.Base.ImageID], uuid.UUID
-            ):
-                return (exif[Image.ExifTags.Base.ImageID].bytes,)
+            with record_function_or_nullcontext("mm:hash:branch:mwb"):
+                exif = obj.media.getexif()
+                if Image.ExifTags.Base.ImageID in exif and isinstance(
+                    exif[Image.ExifTags.Base.ImageID], uuid.UUID
+                ):
+                    return (exif[Image.ExifTags.Base.ImageID].bytes,)
 
-            return cls.iter_item_to_bytes("image", obj.original_bytes)
+                return cls.iter_item_to_bytes("image", obj.original_bytes)
 
         if isinstance(obj, torch.Tensor):
-            tensor_obj: torch.Tensor = obj.cpu()
-            tensor_dtype = tensor_obj.dtype
-            tensor_shape = tensor_obj.shape
+            with record_function_or_nullcontext("mm:hash:branch:tensor"):
+                tensor_obj: torch.Tensor = obj.cpu()
+                tensor_dtype = tensor_obj.dtype
+                tensor_shape = tensor_obj.shape
 
-            # NumPy does not support bfloat16.
-            # Workaround: View the tensor as a contiguous 1D array of bytes
-            if tensor_dtype == torch.bfloat16:
-                tensor_obj = tensor_obj.contiguous()
-                tensor_obj = tensor_obj.view((tensor_obj.numel(),)).view(torch.uint8)
+                # NumPy does not support bfloat16.
+                # Workaround: View the tensor as a contiguous 1D array of bytes
+                if tensor_dtype == torch.bfloat16:
+                    tensor_obj = tensor_obj.contiguous()
+                    tensor_obj = tensor_obj.view((tensor_obj.numel(),)).view(torch.uint8)
+
+                    return cls.iter_item_to_bytes(
+                        "tensor",
+                        {
+                            "original_dtype": str(tensor_dtype),
+                            "original_shape": tuple(tensor_shape),
+                            "data": tensor_obj.numpy(),
+                        },
+                    )
+
+                return cls.iter_item_to_bytes("tensor", tensor_obj.numpy())
+
+        if isinstance(obj, np.ndarray):
+            with record_function_or_nullcontext("mm:hash:branch:ndarray"):
+                if obj.ndim == 0:
+                    arr_data = obj.item()
+                elif obj.flags.c_contiguous:
+                    # Not valid for 0-D arrays
+                    arr_data = obj.view(np.uint8).data
+                else:
+                    # If the array is non-contiguous, we need to copy it first
+                    arr_data = obj.tobytes()
 
                 return cls.iter_item_to_bytes(
-                    "tensor",
+                    "ndarray",
                     {
-                        "original_dtype": str(tensor_dtype),
-                        "original_shape": tuple(tensor_shape),
-                        "data": tensor_obj.numpy(),
+                        "dtype": obj.dtype.str,
+                        "shape": obj.shape,
+                        "data": arr_data,
                     },
                 )
 
-            return cls.iter_item_to_bytes("tensor", tensor_obj.numpy())
-
-        if isinstance(obj, np.ndarray):
-            if obj.ndim == 0:
-                arr_data = obj.item()
-            elif obj.flags.c_contiguous:
-                # Not valid for 0-D arrays
-                arr_data = obj.view(np.uint8).data
-            else:
-                # If the array is non-contiguous, we need to copy it first
-                arr_data = obj.tobytes()
-
-            return cls.iter_item_to_bytes(
-                "ndarray",
-                {
-                    "dtype": obj.dtype.str,
-                    "shape": obj.shape,
-                    "data": arr_data,
-                },
+        with record_function_or_nullcontext("mm:hash:branch:pickle_fallback"):
+            logger.warning(
+                "No serialization method found for %s. Falling back to pickle.",
+                type(obj),
             )
-
-        logger.warning(
-            "No serialization method found for %s. Falling back to pickle.", type(obj)
-        )
-
-        return (pickle.dumps(obj),)
+            return (pickle.dumps(obj),)
 
     @classmethod
     def iter_item_to_bytes(
@@ -155,8 +166,13 @@ class MultiModalHasher:
         hasher_factory = _get_hasher_factory(envs.VLLM_MM_HASHER_ALGORITHM)
         hasher = hasher_factory()
 
-        for k, v in sorted(kwargs.items(), key=lambda kv: kv[0]):
-            for bytes_ in cls.iter_item_to_bytes(k, v):
-                hasher.update(bytes_)
+        total_bytes = 0
+        with record_function_or_nullcontext("mm:hash:digest"):
+            for k, v in sorted(kwargs.items(), key=lambda kv: kv[0]):
+                for bytes_ in cls.iter_item_to_bytes(k, v):
+                    with record_function_or_nullcontext("mm:hash:update"):
+                        hasher.update(bytes_)
+                    total_bytes += len(bytes_)
 
+        logger.info("[mm:hash] kwargs_keys=%s total_bytes=%d", sorted(kwargs.keys()), total_bytes)
         return hasher.hexdigest()

--- a/vllm/multimodal/processing/context.py
+++ b/vllm/multimodal/processing/context.py
@@ -53,6 +53,13 @@ class TimingContext:
     stage_secs: dict[str, float] = field(default_factory=dict)
     """The execution time (in seconds) for each processing stage."""
 
+    mm_is_cached: dict[str, list[bool]] | None = None
+    """Pre-apply per-item cache hit/miss vector, keyed by modality. Populated
+    by `_cached_apply_hf_processor` from the result of `_get_cache_missing_items`,
+    before any cache insertion — so it reflects the real request-time state.
+    Remains None when the processor has no cache or the call took the
+    passthrough short-circuit."""
+
     @property
     def total_secs(self) -> float:
         return sum(self.stage_secs.values())

--- a/vllm/multimodal/processing/processor.py
+++ b/vllm/multimodal/processing/processor.py
@@ -29,6 +29,7 @@ from vllm.inputs import (
 from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike
 from vllm.transformers_utils.processor import call_hf_processor_mm_only
+from vllm.v1.utils import record_function_or_nullcontext
 from vllm.utils.collection_utils import flatten_2d_lists, full_groupby
 
 from ..inputs import (
@@ -1453,20 +1454,27 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         if cache is None or passthrough_data:
             return self._apply_hf_processor(inputs, timing_ctx)
 
-        with timing_ctx.record("get_mm_hashes"):
+        with record_function_or_nullcontext("mm:hash"), timing_ctx.record(
+            "get_mm_hashes"
+        ):
             mm_hashes = inputs.get_mm_hashes(self.info.model_id)
 
-        with timing_ctx.record("get_cache_missing_items"):
+        with record_function_or_nullcontext(
+            "mm:cache_lookup"
+        ), timing_ctx.record("get_cache_missing_items"):
             mm_is_cached, mm_missing_data_items = self._get_cache_missing_items(
                 cache=cache,
                 mm_data_items=inputs.mm_data_items,
                 mm_hashes=mm_hashes,
             )
+        timing_ctx.mm_is_cached = mm_is_cached
 
         # NOTE: `prompt` does not correspond to `mm_missing_data_items`,
         # so we can't apply prompt updates until the new multimodal
         # items are combined with the cached multimodal items
-        with timing_ctx.record("apply_hf_processor"):
+        with record_function_or_nullcontext(
+            "mm:hf_call"
+        ), timing_ctx.record("apply_hf_processor"):
             (
                 prompt_ids,
                 mm_missing_processed_data,
@@ -1492,7 +1500,9 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
             mm_missing_kwargs,
         )
 
-        with timing_ctx.record("merge_mm_kwargs"):
+        with record_function_or_nullcontext(
+            "mm:merge"
+        ), timing_ctx.record("merge_mm_kwargs"):
             mm_kwargs, mm_prompt_updates = self._merge_mm_kwargs(
                 cache,
                 mm_hashes=mm_hashes,
@@ -1685,7 +1695,9 @@ class BaseMultiModalProcessor(ABC, Generic[_I]):
         ) = self._cached_apply_hf_processor(inputs, timing_ctx)
 
         # NOTE: tokenization_kwargs are not required to init processor
-        with timing_ctx.record("apply_prompt_updates"):
+        with record_function_or_nullcontext(
+            "mm:prompt_updates"
+        ), timing_ctx.record("apply_prompt_updates"):
             prompt_ids, mm_placeholders = self._maybe_apply_prompt_updates(
                 mm_items=inputs.mm_data_items,
                 prompt_ids=prompt_ids,

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -37,6 +37,8 @@ from vllm.multimodal.parse import (
 )
 from vllm.multimodal.processing import BaseMultiModalProcessor
 from vllm.multimodal.processing import ProcessorInputs as MMProcessorInputs
+from vllm.multimodal.processing import TimingContext as _TimingContext
+import vllm.envs as envs
 from vllm.multimodal.registry import MultiModalTimingRegistry
 from vllm.tokenizers import TokenizerLike
 from vllm.utils.async_utils import (
@@ -46,6 +48,7 @@ from vllm.utils.async_utils import (
 from vllm.utils.counter import AtomicCounter
 from vllm.utils.torch_utils import set_default_torch_num_threads
 from vllm.v1.metrics.stats import MultiModalCacheStats
+from vllm.v1.utils import record_function_or_nullcontext
 
 from .embed_utils import safe_load_prompt_embeds
 from .inputs import (
@@ -626,32 +629,75 @@ class BaseRenderer(ABC, Generic[_T]):
         mm_processor_kwargs: Mapping[str, object] | None,
         tokenization_kwargs: dict[str, Any] | None,
     ) -> "MultiModalInput":
-        mm_req_id = f"renderer{self.api_process_rank}-mm-{self._mm_req_counter.inc(1)}"
+        with record_function_or_nullcontext("hf_processor"):
+            # NVTX hf_processor is safe (runs on the MM executor thread, not the
+            # event loop) — non-overlapping per worker thread. The [mmproc] log
+            # below gives the same numbers as a per-request scalar.
+            _probe = envs.VLLM_MM_CACHE_PROBE
+            _mm_t0 = time.perf_counter()
+            _mm_cpu_t0 = time.thread_time_ns()
 
-        mm_processor = self.get_mm_processor()
+            mm_req_id = (
+                f"renderer{self.api_process_rank}-mm-{self._mm_req_counter.inc(1)}"
+            )
 
-        mm_data_items = mm_processor.info.parse_mm_data(mm_data)
-        mm_uuid_items = parse_mm_uuids(mm_uuids)
+            mm_processor = self.get_mm_processor()
 
-        mm_uuid_items = self._process_mm_uuids(
-            mm_data, mm_data_items, mm_uuid_items, mm_req_id
-        )
+            mm_data_items = mm_processor.info.parse_mm_data(mm_data)
+            mm_uuid_items = parse_mm_uuids(mm_uuids)
 
-        mm_processor_inputs = MMProcessorInputs(
-            prompt,
-            mm_data_items,
-            mm_uuid_items,
-            hf_processor_mm_kwargs=mm_processor_kwargs or {},
-            tokenization_kwargs=tokenization_kwargs or {},
-        )
-        mm_timing_ctx = self._mm_timing_registry.get(mm_req_id)
+            mm_uuid_items = self._process_mm_uuids(
+                mm_data, mm_data_items, mm_uuid_items, mm_req_id
+            )
 
-        with set_default_torch_num_threads():
-            mm_inputs = mm_processor.apply(mm_processor_inputs, mm_timing_ctx)
+            mm_processor_inputs = MMProcessorInputs(
+                prompt,
+                mm_data_items,
+                mm_uuid_items,
+                hf_processor_mm_kwargs=mm_processor_kwargs or {},
+                tokenization_kwargs=tokenization_kwargs or {},
+            )
+            if _probe:
+                mm_timing_ctx = _TimingContext(enabled=True)
+            else:
+                mm_timing_ctx = self._mm_timing_registry.get(mm_req_id)
 
-        self.update_mm_cache_stats()
+            _apply_t0 = time.perf_counter()
+            with set_default_torch_num_threads():
+                mm_inputs = mm_processor.apply(mm_processor_inputs, mm_timing_ctx)
+            _apply_ms = (time.perf_counter() - _apply_t0) * 1000.0
 
-        return mm_inputs
+            self.update_mm_cache_stats()
+
+            _total_ms = (time.perf_counter() - _mm_t0) * 1000.0
+            _cpu_ms = (time.thread_time_ns() - _mm_cpu_t0) / 1e6
+            logger.info(
+                "[mmproc] req=%s total_ms=%.1f cpu_ms=%.1f apply_ms=%.1f",
+                mm_req_id, _total_ms, _cpu_ms, _apply_ms,
+            )
+
+            if _probe:
+                hit_vec: dict[str, list[str]] = {}
+                if mm_timing_ctx.mm_is_cached is not None:
+                    hit_vec = {
+                        mod: ["H" if c else "M" for c in is_cached]
+                        for mod, is_cached in mm_timing_ctx.mm_is_cached.items()
+                    }
+                stages_ms = {
+                    k: v * 1000.0 for k, v in mm_timing_ctx.stage_secs.items()
+                }
+                logger.info(
+                    "[mmcache] req=%s total=%.1fms hits=%s "
+                    "hash=%.1fms miss_scan=%.1fms hf=%.1fms merge=%.1fms upd=%.1fms",
+                    mm_req_id, _total_ms, hit_vec,
+                    stages_ms.get("get_mm_hashes", 0.0),
+                    stages_ms.get("get_cache_missing_items", 0.0),
+                    stages_ms.get("apply_hf_processor", 0.0),
+                    stages_ms.get("merge_mm_kwargs", 0.0),
+                    stages_ms.get("apply_prompt_updates", 0.0),
+                )
+
+            return mm_inputs
 
     def _process_tokens(
         self,
@@ -717,6 +763,9 @@ class BaseRenderer(ABC, Generic[_T]):
 
         engine_input: TokensInput | MultiModalInput
         if multi_modal_data := prompt.get("multi_modal_data"):
+            # NVTX hf_processor_wait removed: it wraps `await` and PushPop-nests
+            # across concurrent coroutines on the event loop. Use the [mmproc]
+            # log line emitted from _process_multimodal for per-request CPU.
             engine_input = await self._process_multimodal_async(
                 prompt_token_ids,
                 multi_modal_data,

--- a/vllm/renderers/hf.py
+++ b/vllm/renderers/hf.py
@@ -32,6 +32,7 @@ from vllm.transformers_utils.chat_templates import get_chat_template_fallback_pa
 from vllm.transformers_utils.processor import cached_get_processor
 from vllm.utils.async_utils import make_async
 from vllm.utils.func_utils import supports_kw
+from vllm.v1.utils import record_function_or_nullcontext
 
 from .base import BaseRenderer
 from .inputs import DictPrompt
@@ -683,6 +684,10 @@ class HfRenderer(BaseRenderer[HfTokenizer]):
         messages: list[ChatCompletionMessageParam],
         params: ChatParams,
     ) -> tuple[list[ConversationMessage], DictPrompt]:
+        # NVTX ranges removed (render_messages / parse_chat / chat_template):
+        # all three wrap `await` calls and therefore PushPop-nest with other
+        # concurrent coroutines on the event loop. Use [preproc] / [mmproc]
+        # log lines for per-request attribution.
         model_config = self.model_config
         tokenizer = self.get_tokenizer()
 

--- a/vllm/v1/core/encoder_cache_manager.py
+++ b/vllm/v1/core/encoder_cache_manager.py
@@ -6,6 +6,7 @@ from collections.abc import Mapping
 from typing import TYPE_CHECKING
 
 from vllm.logger import init_logger
+from vllm.v1.metrics.stats import EncoderCacheStats
 from vllm.v1.request import Request
 
 if TYPE_CHECKING:
@@ -76,6 +77,13 @@ class EncoderCacheManager:
         self.freeable: OrderedDict[str, int] = OrderedDict()
         self.freed: list[str] = []
 
+        # Hit/miss counters since last `get_and_update_stats()` call.
+        # Hit = `check_and_update_cache` returned True (embedding already
+        # resident). Miss = scheduler decided to run the encoder
+        # (via `record_miss`). Budget-deferred items are not counted as misses.
+        self._hits = 0
+        self._misses = 0
+
     def reset(self) -> None:
         """Reset the encoder cache to its initial state.
 
@@ -87,6 +95,8 @@ class EncoderCacheManager:
         self.freed.clear()
         self.num_free_slots = self.cache_size
         self.num_freeable_slots = self.cache_size
+        self._hits = 0
+        self._misses = 0
 
     def check_and_update_cache(self, request: Request, input_id: int) -> bool:
         """Check if encoder output for a specific multimodal input is cached.
@@ -114,7 +124,29 @@ class EncoderCacheManager:
             self.num_freeable_slots -= num_encoder_embeds
 
         self.cached[mm_hash].add(request.request_id)
+        self._hits += 1
         return True
+
+    def record_miss(self) -> None:
+        """Record a cache miss.
+
+        Called by the scheduler once per encoder input that is actually
+        scheduled to run the encoder in this step (i.e. post-`can_allocate`
+        and post-`allocate`). This avoids counting inputs that were deferred
+        due to compute/space budget as misses.
+        """
+        self._misses += 1
+
+    def get_and_update_stats(self) -> EncoderCacheStats:
+        """Return hit/miss counters since the last call and reset them."""
+        stats = EncoderCacheStats()
+        stats.record(
+            num_queries=self._hits + self._misses,
+            num_hits=self._hits,
+        )
+        self._hits = 0
+        self._misses = 0
+        return stats
 
     def can_allocate(
         self,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -541,6 +541,8 @@ class Scheduler(SchedulerInterface):
                 # Allocate the encoder cache.
                 for i in encoder_inputs_to_schedule:
                     self.encoder_cache_manager.allocate(request, i)
+                    # Scheduled a fresh encoder run → GPU encoder-cache miss.
+                    self.encoder_cache_manager.record_miss()
                     if self.ec_connector is not None:
                         self.ec_connector.update_state_after_alloc(request, i)
                 encoder_compute_budget = new_encoder_compute_budget
@@ -1959,6 +1961,7 @@ class Scheduler(SchedulerInterface):
             encoder_cache_usage=self._get_encoder_cache_usage(),
             prefix_cache_stats=prefix_cache_stats,
             connector_prefix_cache_stats=connector_prefix_cache_stats,
+            encoder_cache_stats=self.encoder_cache_manager.get_and_update_stats(),
             kv_cache_eviction_events=eviction_events,
             spec_decoding_stats=spec_stats,
             kv_connector_stats=connector_stats_payload,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -837,6 +837,8 @@ class Scheduler(SchedulerInterface):
                     # Allocate the encoder cache.
                     for i in encoder_inputs_to_schedule:
                         self.encoder_cache_manager.allocate(request, i)
+                        # Scheduled a fresh encoder run -> GPU encoder-cache miss.
+                        self.encoder_cache_manager.record_miss()
                         if self.ec_connector is not None:
                             self.ec_connector.update_state_after_alloc(request, i)
                     encoder_compute_budget = new_encoder_compute_budget

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -105,6 +105,7 @@ class LoggingStatLogger(StatLoggerBase):
         self.prefix_caching_metrics = CachingMetrics()
         self.connector_prefix_caching_metrics = CachingMetrics()
         self.mm_caching_metrics = CachingMetrics()
+        self.encoder_caching_metrics = CachingMetrics()
 
         self.spec_decoding_logging = SpecDecodingLogging()
         kv_transfer_config = self.vllm_config.kv_transfer_config
@@ -186,6 +187,10 @@ class LoggingStatLogger(StatLoggerBase):
                 self.last_scheduler_stats = scheduler_stats
             if (perf_stats := scheduler_stats.perf_stats) and self._enable_perf_stats():
                 self.perf_metrics_logging.observe(perf_stats)
+            if scheduler_stats.encoder_cache_stats is not None:
+                self.encoder_caching_metrics.observe(
+                    scheduler_stats.encoder_cache_stats
+                )
         if mm_cache_stats:
             self.mm_caching_metrics.observe(mm_cache_stats)
 
@@ -255,6 +260,9 @@ class LoggingStatLogger(StatLoggerBase):
         if not self.mm_caching_metrics.empty:
             log_parts.append("MM cache hit rate: %.1f%%")
             log_args.append(self.mm_caching_metrics.hit_rate * 100)
+        if not self.encoder_caching_metrics.empty:
+            log_parts.append("Encoder cache hit rate: %.1f%%")
+            log_args.append(self.encoder_caching_metrics.hit_rate * 100)
 
         log_fn(
             self.log_prefix + ", ".join(log_parts),
@@ -574,6 +582,34 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         )
         self.counter_mm_cache_hits = create_metric_per_engine(
             counter_mm_cache_hits, per_engine_labelvalues
+        )
+
+        #
+        # Encoder cache (GPU-side embedding residency)
+        #
+
+        counter_encoder_cache_queries = self._counter_cls(
+            name="vllm:encoder_cache_queries",
+            documentation=(
+                "Encoder cache queries (hits + scheduled encoder runs), "
+                "in terms of number of multimodal inputs."
+            ),
+            labelnames=labelnames,
+        )
+        self.counter_encoder_cache_queries = create_metric_per_engine(
+            counter_encoder_cache_queries, per_engine_labelvalues
+        )
+
+        counter_encoder_cache_hits = self._counter_cls(
+            name="vllm:encoder_cache_hits",
+            documentation=(
+                "Encoder cache hits (embedding already resident on GPU, "
+                "ViT forward skipped)."
+            ),
+            labelnames=labelnames,
+        )
+        self.counter_encoder_cache_hits = create_metric_per_engine(
+            counter_encoder_cache_hits, per_engine_labelvalues
         )
 
         #
@@ -1104,6 +1140,14 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         if mm_cache_stats is not None:
             self.counter_mm_cache_queries[engine_idx].inc(mm_cache_stats.queries)
             self.counter_mm_cache_hits[engine_idx].inc(mm_cache_stats.hits)
+
+        if (
+            scheduler_stats is not None
+            and scheduler_stats.encoder_cache_stats is not None
+        ):
+            ec_stats = scheduler_stats.encoder_cache_stats
+            self.counter_encoder_cache_queries[engine_idx].inc(ec_stats.queries)
+            self.counter_encoder_cache_hits[engine_idx].inc(ec_stats.hits)
 
         if iteration_stats is None:
             return

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -159,6 +159,24 @@ class MultiModalCacheStats(BaseCacheStats):
 
 
 @dataclass
+class EncoderCacheStats(BaseCacheStats):
+    """
+    Stores encoder cache hit statistics.
+    - `queries`: Number of encoder-input lookups attempted
+      (hits + scheduler-decided misses).
+    - `hits`: Number of times the embedding was already resident on GPU.
+    """
+
+    def record(self, num_queries: int, num_hits: int) -> None:
+        """Aggregate scheduler-step information into the stats."""
+        if num_queries == 0:
+            return
+        self.requests += 1
+        self.queries += num_queries
+        self.hits += num_hits
+
+
+@dataclass
 class KVCacheEvictionEvent:
     """Single KV cache block eviction sample."""
 
@@ -183,6 +201,8 @@ class SchedulerStats:
 
     prefix_cache_stats: PrefixCacheStats = field(default_factory=PrefixCacheStats)
     connector_prefix_cache_stats: PrefixCacheStats | None = None
+
+    encoder_cache_stats: "EncoderCacheStats | None" = None
 
     kv_cache_eviction_events: list[KVCacheEvictionEvent] = field(default_factory=list)
 


### PR DESCRIPTION
## Summary
- Include the existing qiwa/0.19.nvtx branch changes.
- Add the encoder-cache accounting fix so newly scheduled local encoder runs count as misses.
- Add scheduler regression assertions for connector hits, local misses, and local GPU-cache reuse.

## Validation
- python3 -m py_compile vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py
- git diff --check upstream/releases/v0.19.0...HEAD

Note: targeted pytest was previously blocked in this local environment by missing test dependency tblib.