### PR TITLE
uncomment flex backend for batch invariant mode

### DIFF
--- a/tests/v1/determinism/utils.py
+++ b/tests/v1/determinism/utils.py
@@ -26,6 +26,7 @@ TEST_MODEL = os.getenv("VLLM_TEST_MODEL", DEFAULT_MODEL)
 BACKENDS: list[str] = [
     "FLASH_ATTN",
     "TRITON_ATTN",
+    "FLEX_ATTENTION",
 ]
 
 # FlashInfer temporarily disabled due to invariant CTA sizes.

--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -100,6 +100,10 @@ class FlexAttentionBackend(AttentionBackend):
         return attn_type in (AttentionType.DECODER, AttentionType.ENCODER_ONLY)
 
     @classmethod
+    def supports_batch_invariance(cls) -> bool:
+        return True
+
+    @classmethod
     def supports_mm_prefix(cls) -> bool:
         """FlexAttention supports full attention for image tokens."""
         return True
@@ -326,15 +330,9 @@ class BlockSparsityHint(NamedTuple):
 
 
 def copy_to_persistent(dst, src):
-    try:
-        dst = dst.as_strided(src.shape, src.stride())
-    except RuntimeError as e:
-        raise RuntimeError(
-            f"Fail to re-stride a persistent tensor of shape {dst.shape} "
-            f"for a tensor of shape {src.shape}"
-        ) from e
-    dst.copy_(src)
-    return dst
+    sliced = dst[tuple(slice(0, s) for s in src.shape)]
+    sliced.copy_(src)
+    return sliced
 
 
 @dataclass


### PR DESCRIPTION
re-enabling Flex Attention as an accepted backend for batch invariant mode. to fix the IMA issue, we need to use the strides of the persistent buffer instead of the current tensor so that the memory layout matches what was captured by the cuda graphs. 

`python -m pytest tests/v1/determinism/test_batch_invariance.py -v -k "FLEX_ATTENTION" -s`
before fix: 
<img width="2614" height="1406" alt="image" src="https://github.com/user-attachments/assets/eae8ebf3-8932-4ce2-a3fa-03d654781001" />

after fix: 
<img width="1297" height="736" alt="Screenshot 2026-04-27 at 4 28 56 PM" src="https://github.com/user-attachments/assets/1fafb752-7541-4a73-87db-5f18cd573b4c" />


running torchtitan GRPO RL loop with batch invariant mode enabled
<img width="1075" height="220" alt="Screenshot 2026-04-27 at 10 42 27 AM" src="https://github.com/user-attachments/assets/e1ad3795-dfb7-462e-82d2-71afcd3a9046" />

also ran torchtitan bitwise parity tests with Flex `torchtitan/torchtitan/experiments/rl/tests/test_bitwise_parity.py`
<img width="1014" height="235" alt="Screenshot 2026-04-27 at 10 59 00 AM" src="https://github.com/user-attachments/assets/ff62595b-376d-45aa-8969-75b632bebaad" />


