### PR TITLE
[Bugfix] add seq_lens_cpu_upper_bound to CommonAttentionMetadata in mla_runner.py

### DIFF
--- a/benchmarks/attention_benchmarks/mla_runner.py
+++ b/benchmarks/attention_benchmarks/mla_runner.py
@@ -404,6 +404,7 @@ def _build_attention_metadata(
         query_start_loc=q_start_gpu,
         query_start_loc_cpu=q_start_cpu,
         seq_lens=seq_lens_gpu,
+        seq_lens_cpu_upper_bound=seq_lens_cpu,
         _seq_lens_cpu=seq_lens_cpu,
         _num_computed_tokens_cpu=num_computed_tokens_cpu,
         slot_mapping=slot_mapping,


### PR DESCRIPTION
minor hotfix for mla attention benchmarks

`seq_lens_cpu_upper_bound` was added to CommonAttentionMetadata in #40654

@njhill

```
Traceback (most recent call last):
  File "/vllm/benchmarks/attention_benchmarks/benchmark.py", line 82, in run_benchmark
    return run_mla_benchmark(config, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/vllm/benchmarks/attention_benchmarks/benchmark.py", line 64, in run_mla_benchmark
    return run_mla(
           ^^^^^^^^
  File "/vllm/benchmarks/attention_benchmarks/mla_runner.py", line 1114, in run_mla_benchmark
    results = _run_mla_benchmark_batched(
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/vllm/benchmarks/attention_benchmarks/mla_runner.py", line 1035, in _run_mla_benchmark_batched
    result = _run_single_benchmark(
             ^^^^^^^^^^^^^^^^^^^^^^
  File "/vllm/benchmarks/attention_benchmarks/mla_runner.py", line 737, in _run_single_benchmark
    metadata, num_blocks = _build_attention_metadata(
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/vllm/benchmarks/attention_benchmarks/mla_runner.py", line 415, in _build_attention_metadata
    metadata = builder_instance.build(
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/vllm/vllm/model_executor/layers/attention/mla_attention.py", line 1829, in build
    assert seq_lens_cpu is not None
```