### PR TITLE
[Bugfix] Fix `NameError` on `AsyncEngineArgs.quantization_config` forward reference

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import json
+import typing
 from argparse import ArgumentError
 from contextlib import AbstractContextManager, nullcontext
 from typing import Annotated, Literal
@@ -11,6 +12,7 @@ from pydantic import Field
 
 from vllm.config import AttentionConfig, CompilationConfig, config
 from vllm.engine.arg_utils import (
+    AsyncEngineArgs,
     EngineArgs,
     _expand_json_human_readable_numbers,
     contains_type,
@@ -161,6 +163,16 @@ def test_is_not_builtin(type_hint, expected):
 )
 def test_get_type_hints(type_hint, expected):
     assert get_type_hints(type_hint) == expected
+
+
+@pytest.mark.parametrize("cls", [EngineArgs, AsyncEngineArgs])
+def test_engine_args_typing_get_type_hints(cls):
+    # All field annotations on EngineArgs / AsyncEngineArgs must be
+    # resolvable at runtime. Forward references that name a symbol only
+    # imported under TYPE_CHECKING raise NameError here, which breaks
+    # downstream consumers (e.g. Ray Serve LLM) that introspect the
+    # dataclass with typing.get_type_hints.
+    typing.get_type_hints(cls)
 
 
 def test_get_kwargs():

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -128,6 +128,7 @@ else:
     QuantizationMethods = Any
     LoadFormats = Any
     UsageContext = Any
+    OnlineQuantizationConfigArgs = Any
 
 
 logger = init_logger(__name__)


### PR DESCRIPTION
## Purpose

`OnlineQuantizationConfigArgs` is imported in `vllm/engine/arg_utils.py` under `if TYPE_CHECKING:`, but the matching `else:` block — which provides runtime fallbacks for the four sibling type-only imports — was missed when this symbol was added in #38138. The `quantization_config` field annotation is a forward-reference string, so `typing.get_type_hints(AsyncEngineArgs)` raises `NameError` at runtime.

This is hit by [Ray Serve LLM](https://github.com/ray-project/ray/blob/f9d5aa91cecd6f1e0daf43c7b61cc187a71833dc/python/ray/llm/_internal/serve/engines/vllm/vllm_engine.py#L102), which calls `typing.get_type_hints(AsyncEngineArgs)` while building its engine config from `engine_kwargs`.

The fix is a one-line addition in `vllm/engine/arg_utils.py` matching the existing pattern:

```diff
 else:
     Executor = Any
     QuantizationMethods = Any
     LoadFormats = Any
     UsageContext = Any
+    OnlineQuantizationConfigArgs = Any
```

`quantization_config` defaults to `None`; this only makes the type annotation evaluable.

## Test Plan

Added `test_engine_args_typing_get_type_hints` in `tests/engine/test_arg_utils.py`, parametrized over `EngineArgs` and `AsyncEngineArgs`. Verified it fails on `main` and passes with the fix.

## Test Result

```bash
$ .venv/bin/python -m pytest tests/engine/test_arg_utils.py -v
======================= 69 passed in 45.24s =======================

$ .venv/bin/pre-commit run --files vllm/engine/arg_utils.py tests/engine/test_arg_utils.py
(all hooks pass — ruff, ruff-format, mypy, typos, SPDX, ...)
```

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>