### PR TITLE
[Spec Decode] Inherit online quantization for draft models

### DIFF
--- a/tests/model_executor/test_eagle_quantization.py
+++ b/tests/model_executor/test_eagle_quantization.py
@@ -19,7 +19,9 @@ DEVICES = (
 
 
 def test_get_draft_quant_config_with_draft_model():
+    """Draft model with its own quantization returns that config."""
     mock_draft_model_config = Mock(spec=ModelConfig)
+    mock_draft_model_config.quantization = "fp8"
     mock_load_config = Mock(spec=LoadConfig)
     mock_speculative_config = Mock(spec=SpeculativeConfig)
     mock_speculative_config.draft_model_config = mock_draft_model_config
@@ -52,6 +54,74 @@ def test_get_draft_quant_config_without_draft_model():
     result = get_draft_quant_config(mock_vllm_config)
 
     assert result is None
+
+
+def test_get_draft_quant_config_inherits_online_quant():
+    """Draft without explicit quant inherits target's OnlineQuantizationConfig."""
+    from vllm.model_executor.layers.quantization.online.base import (
+        OnlineQuantizationConfig,
+    )
+
+    mock_draft_model_config = Mock(spec=ModelConfig)
+    mock_draft_model_config.quantization = None
+    mock_speculative_config = Mock(spec=SpeculativeConfig)
+    mock_speculative_config.draft_model_config = mock_draft_model_config
+
+    mock_online_config = Mock(spec=OnlineQuantizationConfig)
+
+    mock_vllm_config = Mock(spec=VllmConfig)
+    mock_vllm_config.speculative_config = mock_speculative_config
+    mock_vllm_config.load_config = Mock(spec=LoadConfig)
+    mock_vllm_config.quant_config = mock_online_config
+
+    result = get_draft_quant_config(mock_vllm_config)
+
+    assert result is mock_online_config
+
+
+def test_get_draft_quant_config_no_inherit_non_online():
+    """Draft without explicit quant does NOT inherit non-online target config."""
+    mock_draft_model_config = Mock(spec=ModelConfig)
+    mock_draft_model_config.quantization = None
+    mock_speculative_config = Mock(spec=SpeculativeConfig)
+    mock_speculative_config.draft_model_config = mock_draft_model_config
+
+    mock_vllm_config = Mock(spec=VllmConfig)
+    mock_vllm_config.speculative_config = mock_speculative_config
+    mock_vllm_config.load_config = Mock(spec=LoadConfig)
+    # Target uses a non-online quant config (e.g., checkpoint-based GPTQ)
+    mock_vllm_config.quant_config = Mock()
+
+    result = get_draft_quant_config(mock_vllm_config)
+
+    assert result is None
+
+
+def test_get_draft_quant_config_fallback_on_config_error():
+    """Draft with explicit quant that fails config lookup falls through
+    to online quant inheritance."""
+    from vllm.model_executor.layers.quantization.online.base import (
+        OnlineQuantizationConfig,
+    )
+
+    mock_draft_model_config = Mock(spec=ModelConfig)
+    mock_draft_model_config.quantization = "nvfp4_per_tensor"
+    mock_speculative_config = Mock(spec=SpeculativeConfig)
+    mock_speculative_config.draft_model_config = mock_draft_model_config
+
+    mock_online_config = Mock(spec=OnlineQuantizationConfig)
+
+    mock_vllm_config = Mock(spec=VllmConfig)
+    mock_vllm_config.speculative_config = mock_speculative_config
+    mock_vllm_config.load_config = Mock(spec=LoadConfig)
+    mock_vllm_config.quant_config = mock_online_config
+
+    with patch.object(
+        VllmConfig, "get_quantization_config", side_effect=ValueError("bad config")
+    ):
+        result = get_draft_quant_config(mock_vllm_config)
+
+    assert result is mock_online_config
 
 
 @torch.inference_mode()

--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -22,6 +22,9 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig,
 )
+from vllm.model_executor.layers.quantization.online.base import (
+    OnlineQuantizationConfig,
+)
 from vllm.model_executor.model_loader.reload import (
     support_quantized_model_reload_from_hp_weights,
 )
@@ -720,22 +723,49 @@ def get_draft_quant_config(
     """Get quantization config for Draft models.
 
     Draft models should use their own quantization config instead of the verifier/target
-    model's config. This helper retrieves the draft model's quantization config.
+    model's config. This helper retrieves the draft model's quantization
+    config.
+
+    When the target model uses online quantization (e.g., fp8) and the
+    draft model has no explicit quantization, the target's
+    online quant config is inherited so that the draft model's weights are
+    also quantized, reducing memory bandwidth during draft steps.
 
     Args:
         vllm_config: The vLLM configuration object.
 
     Returns:
-        The draft model's config if available, None otherwise.
+        The draft model's quantization config if available, None otherwise.
     """
     draft_model_config = vllm_config.speculative_config.draft_model_config
+    if not draft_model_config:
+        return None
+
     draft_load_config = vllm_config.load_config
 
-    return (
-        VllmConfig.get_quantization_config(draft_model_config, draft_load_config)
-        if draft_model_config
-        else None
-    )
+    # If the draft model has its own quantization, use it.
+    if draft_model_config.quantization:
+        try:
+            return VllmConfig.get_quantization_config(
+                draft_model_config, draft_load_config
+            )
+        except (ValueError, FileNotFoundError) as exc:
+            # Online quant methods may fail through the checkpoint-based
+            # config path (e.g., hf_overrides is a callable, not a dict).
+            # Fall through to the target inheritance path below.
+            logger.warning(
+                "Draft model has quantization=%s but "
+                "get_quantization_config failed: %s. "
+                "Falling back to target model's quant config.",
+                draft_model_config.quantization,
+                exc,
+            )
+
+    # Inherit target model's online quantization config for the draft model.
+    if isinstance(vllm_config.quant_config, OnlineQuantizationConfig):
+        return vllm_config.quant_config
+
+    return None
 
 
 def extract_layer_index(layer_name: str, num_attn_module: int = 1) -> int:


### PR DESCRIPTION
## Purpose

Propagate online quantization (e.g., `--quantization fp8_per_tensor`) to speculative decoding draft models (Eagle3, Medusa, etc.) so that draft weights are also quantized at load time, reducing draft model memory footprint.

Currently the draft model always loads in BF16 regardless of the target's quantization.

## Background

When using speculative decoding with online quantization, vLLM quantizes the target model's weights but leaves the draft model in full precision:

```bash
# Target: FP8 (32.0 GiB) — Draft: BF16 (1.45 GiB) — NOT quantized!
vllm serve Qwen/Qwen3-32B --quantization fp8_per_tensor \
  --speculative-config '{"method":"eagle3","model":"thoughtworks/Qwen3-32B-Eagle3","num_speculative_tokens":3}'
```

This wastes memory: a 530M-parameter Eagle3 draft model uses 1.45 GiB in BF16 but only 0.53 GiB in FP8 — memory that could instead be used for KV cache.

### Root Cause

In `SpeculativeConfig.__post_init__`, quantization inheritance only runs inside the `if self.model is None` block (line 22), which is only entered for MTP (where draft = target model). For external draft models (Eagle, Eagle3, DFlash, Medusa), `self.model` is set to the draft model path, so the block is skipped. The draft's `quantization` defaults to `None` → BF16.

Even if we propagate the quantization string, `get_draft_quant_config()` calls `get_quant_config()` which crashes for online methods because it tries to read quant config from `hf_overrides` — a callable (`SpeculativeConfig.hf_config_override`), not a dict.

## Fix

One function change in `vllm/model_executor/models/utils.py`:

When `get_draft_quant_config()` finds no draft-specific quantization, check if the **target** model uses `OnlineQuantizationConfig`. If so, inherit it directly for the draft model. This bypasses the `get_quant_config()` → `hf_overrides` crash path entirely.

```python
def get_draft_quant_config(vllm_config):
    draft_model_config = vllm_config.speculative_config.draft_model_config
    if not draft_model_config:
        return None

    # If the draft model has its own quantization, use it.
    if draft_model_config.quantization:
        try:
            return VllmConfig.get_quantization_config(
                draft_model_config, draft_load_config)
        except (ValueError, FileNotFoundError):
            pass  # Online quant fails through checkpoint path; fall through

    # Inherit target's online quantization for the draft model.
    if isinstance(vllm_config.quant_config, OnlineQuantizationConfig):
        return vllm_config.quant_config

    return None
```

## Changes

- `vllm/model_executor/models/utils.py`: Modify `get_draft_quant_config()` to inherit the target's `OnlineQuantizationConfig` when the draft has no explicit quantization.

## Key Results

### FP8 online + Eagle3 (Qwen3-32B, RTX PRO 6000 Blackwell, batch=1)

| Config | tok/s | Latency | Memory |
|---|---|---|---|
| FP8 target + BF16 draft (before) | 77.8 | 1.646s | 33.43 GiB |
| FP8 target + **FP8 draft** (after) | 77.9 | 1.643s | **32.86 GiB** |
| **Delta** | neutral | neutral | **−0.57 GiB** |

Draft model memory: 1.45 GiB (BF16) → 0.88 GiB (FP8) = **40% reduction**.

Throughput is neutral because the CUTLASS FP8 kernel has comparable per-call overhead to BF16 matmul for a small (530M-param) draft model. The benefit is purely memory savings — freeing ~0.57 GiB for additional KV cache.

### FP8 Acceptance Rate (20 diverse prompts × 3 rounds)

| Metric | BF16 draft | FP8 draft | Delta |
|---|---|---|---|
| Accepted tokens | 6,257 | 6,213 | −0.7% |
| Drafted tokens | 17,139 | 17,271 | +0.8% |
| Draft steps | 5,713 | 5,757 | +0.8% |
| **Acceptance Rate** | **0.3651** | **0.3597** | **−1.5%** |
| Accepted / step | 1.095 | 1.079 | −1.5% |

AR drop is negligible. FP8 weight-only quant preserves BF16 activation precision, so draft prediction quality is nearly unchanged.

### Output Quality

Both configurations produce identical coherent output for temperature=0.0:

```
<think>
Okay, I need to write a Python function to find the longest common
subsequence (LCS) of two strings. Let me think about how to approach this.

First, I remember that a subsequence is a sequen...
```

### Full Eagle3 + Online Quantization Sweep (batch=1)

| Config | tok/s | Latency | Eagle3 Speedup |
|---|---|---|---|
| FP8 (no SD) | 38.8 | 3.30s | — |
| FP8 + Eagle3 (BF16 draft) | 77.8 | 1.65s | 2.01× |
| FP8 + Eagle3 (**FP8 draft**) | **77.9** | **1.64s** | **2.01×** |

## Benchmark Configuration

| Parameter | Value |
|---|---|
| Target model | Qwen/Qwen3-32B (BF16, 64 layers) |
| Draft model | thoughtworks/Qwen3-32B-Eagle3 (~530M params) |
| GPU | NVIDIA RTX PRO 6000 Blackwell (SM 12.0, 102 GB GDDR7) |
| vLLM | 0.19.2rc1.dev144 |
| FlashInfer | 0.6.8.post1 |
| PyTorch | 2.11.0+cu130, CUDA 13.0 |
| Spec decode | Eagle3, DL=3 |
| CUDA graphs + torch.compile | Yes (production parity) |
| max_model_len | 4,096 |
| gpu_memory_utilization | 0.92 |
| AL/AR dataset | 20 diverse prompts × 3 rounds, temperature=0.0 |
