### PR TITLE
Revert "[Bugfix][MoE] Unpad routed output before shared expert add [Fixes #35949]" (#40794)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -550,14 +550,10 @@ class MoERunner(MoERunnerInterface):
             hidden_states
         )
 
-        # Record before `_maybe_pad_hidden_states` pads activations to match
-        # `moe_config.hidden_dim`, e.g. after `align_trtllm_fp4_moe_hidden_dim_for_fi`
-        routed_hidden_dim = hidden_states.shape[-1]
         hidden_states, og_hidden_dim = self._maybe_pad_hidden_states(
             shared_experts_input,
             hidden_states,
         )
-        hidden_dim_was_padded = hidden_states.shape[-1] > routed_hidden_dim
 
         result = self._forward_entry(
             hidden_states,
@@ -577,8 +573,6 @@ class MoERunner(MoERunnerInterface):
 
         # Extract outputs from result
         shared_output, fused_output = _unpack(result)
-        if hidden_dim_was_padded:
-            fused_output = fused_output[..., :routed_hidden_dim]
 
         # If combine kernel already reduced fused, reduce shared to match.
         # See note above re: the two all-reduce points.


### PR DESCRIPTION
## Revert of https://github.com/vllm-project/vllm/pull/40794

**Reason:** This PR introduced 3 new CI failures in [build #62894](https://buildkite.com/vllm/ci/builds/62894):

- **GPQA Eval (GPT-OSS) (B200)** — `RuntimeError: view size is not compatible with input tensor's size and stride` in `symm_mem.py:133` during `all_reduce`. The unpadded tensor slice (`fused_output[..., :routed_hidden_dim]`) produces a non-contiguous tensor that fails `view(-1)`.
- **GPQA Eval (GPT-OSS) (H100)** — Same tensor view error via `moe_runner.py:371 _maybe_reduce_final_output` -> `tensor_model_parallel_all_reduce` -> `symm_mem.all_reduce`.
- **LoRA TP (Distributed)** — `test_gpt_oss_lora_tp2[True-False]` generates garbled output instead of SQL, indicating model correctness regression in gpt-oss MoE with LoRA in TP mode.

**Root cause:** The PR adds `fused_output = fused_output[..., :routed_hidden_dim]` which creates a non-contiguous view. When this tensor is later passed to `tensor_model_parallel_all_reduce`, the `symm_mem` communicator calls `.view(-1)` which requires contiguous memory. A `.contiguous()` call before the all-reduce would likely fix the issue.

Auto-generated by CI failure analyzer.