### PR TITLE
[Bugfix ] fix bailing_moe_linear

### DIFF
--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -55,9 +55,6 @@ class MambaStateDtypeCalculator:
         model_dtype: ModelDType | torch.dtype,
         mamba_cache_dtype: MambaDType,
     ) -> tuple[torch.dtype, ...]:
-        # TODO (tdoublep) requires testing
-        if mamba_cache_dtype == "float32":
-            raise ValueError("fp32 state for minimax is not yet supported")
         state_dtype = get_kv_cache_torch_dtype(mamba_cache_dtype, model_dtype)
         return (state_dtype,)
 

--- a/vllm/model_executor/models/bailing_moe_linear.py
+++ b/vllm/model_executor/models/bailing_moe_linear.py
@@ -17,6 +17,7 @@ from vllm.distributed import (
 )
 from vllm.forward_context import get_forward_context
 from vllm.logger import init_logger
+from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.fla.ops.layernorm_guard import (
     RMSNormGated,
     layernorm_fn,
@@ -211,7 +212,6 @@ class BailingMoeV25MLAAttention(nn.Module):
             max_position=max_position,
             is_neox_style=False,
             rope_parameters=rope_parameters or None,
-            dtype=torch.float32,
         )
 
         # Build MLAModules for MultiHeadLatentAttentionWrapper
@@ -425,13 +425,17 @@ class BailingGroupRMSNormGate(RMSNormGated):
         param.data.copy_(loaded_weight[shard].contiguous())
 
 
-class BailingMoELinearAttention(nn.Module, MambaBase):
-    """
-    Bailing MoE Linear Attention implementation using minimax backend.
+# --8<-- [start:bailing_moe_linear_attention]
+@PluggableLayer.register("bailing_moe_linear_attention")
+class BailingMoELinearAttention(PluggableLayer, MambaBase):
+    """Pluggable Bailing MoE Linear Attention layer which allows OOT backends
+    to add custom implementations.
 
-    This implements the linear attention mechanism from sglang, adapted for vLLM's
-    v1 engine with MambaBase interface support.
+    This implements the linear attention mechanism from sglang, adapted for
+    vLLM's v1 engine with MambaBase interface support.
     """
+
+    # --8<-- [end:bailing_moe_linear_attention]
 
     @property
     def mamba_type(self) -> str:
@@ -569,7 +573,6 @@ class BailingMoELinearAttention(nn.Module, MambaBase):
             self.head_dim,
             max_position=self.max_position_embeddings,
             is_neox_style=True,
-            dtype=torch.float32,
             rope_parameters=rope_parameters or None,
         )
 
@@ -754,8 +757,6 @@ class BailingMoELinearAttention(nn.Module, MambaBase):
 
     def _decode_infer(self, q, k, v, kv_cache, state_indices_tensor, attn_metadata):
         """Handle decode (single token per sequence)."""
-        num_prefill_tokens = attn_metadata.num_prefill_tokens
-        num_prefills = attn_metadata.num_prefills
         hidden = linear_attention_decode(
             q,
             k,
@@ -763,10 +764,10 @@ class BailingMoELinearAttention(nn.Module, MambaBase):
             kv_cache,
             self.tp_slope,
             state_indices_tensor,
-            q_start=num_prefill_tokens,
-            q_end=None,
-            slot_start=num_prefills,
-            slot_end=None,
+            q_start=0,
+            q_end=attn_metadata.num_decode_tokens,
+            slot_start=0,
+            slot_end=attn_metadata.num_decodes,
             block_size=32,
         )
         return hidden
@@ -1149,6 +1150,7 @@ class BailingMoeV25ForCausalLM(nn.Module, HasInnerState, IsHybrid, SupportsPP):
                 config.vocab_size,
                 config.hidden_size,
                 quant_config=quant_config,
+                prefix=maybe_prefix(prefix, "lm_head"),
             )
             self.logits_processor = LogitsProcessor(config.vocab_size)
         else:


### PR DESCRIPTION
## Purpose
1. fix decode idx err vllm v1 reorders batches as decode-first, but _decode_infer was ported from SGLang which uses prefill-first ordering. In mixed batches, this caused decode requests to read q/k/v from wrong positions and update wrong KV cache state slots, corrupting the recurrent state and leading to degenerate output (repeated newlines) in long-form generation.

    The bug is silently masked in decode-only batches (num_prefill_tokens=0) but triggers frequently under high concurrency when prefill and decode requests are scheduled together.

    Fix: use q_start=0/q_end=num_decode_tokens and slot_start=0/slot_end=num_decodes to correctly slice the decode portion.


2. make BailingMoELinearAttention a PluggableLayer Convert BailingMoELinearAttention from inheriting (nn.Module, MambaBase) to (PluggableLayer, MambaBase) and register it with 
`@PluggableLayer.register("bailing_moe_linear_attention").`

    This enables out-of-tree (OOT) backends to transparently replace the entire class at instantiation time via PluggableLayer.register_oot, instead of relying on fragile monkey-patching of individual methods.
    - Add PluggableLayer import to bailing_moe_linear.py
    - Change base class from nn.Module to PluggableLayer (which is itself an nn.Module subclass, so MRO remains compatible with MambaBase)
    - Add @PluggableLayer.register decorator with name "bailing_moe_linear_attention"
    - No functional change for existing GPU/CPU backends; the default forward path is unchanged

4. remove the restriction on float32 cache types in Mamba utilities 
5. ensures proper prefixing for the language model head
6. Remove the explicit float32 dtype specification in `get_rope` to let it use the model's default dtype. This change:
    - Fixes dtype compatibility errors on certain platforms
    - Aligns with the behavior of other models in vLLM
    - Matches the RoPE dtype used in SGLang's bailing adapter

## Test Plan

- Run GSM8K benchmark under high concurrency (mixed prefill/decode workloads)
- Compare accuracy before and after the fix
Test command:
```bash
# High concurrency GSM8K evaluation
source port.sh
evalscope eval \
  --model auto \
  --model-id auto \
  --datasets gsm8k \
  --dataset-dir /datasets/gsm8k\
  --chat-template true \
  --api-url http://localhost:${PORT}/v1\
  --eval-batch-size 32
```

## Test Result
Verified: GSM8K accuracy recovers from ~84% to ~96% under high concurrency.


Signed-off-by: ghphotoframe <854746559@qq.com>