### PR TITLE
[Bugfix][MoE] Only unpad routed output before shared expert add

### DIFF
--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -578,7 +578,9 @@ class MoERunner(MoERunnerInterface):
 
         # Extract outputs from result
         shared_output, fused_output = _unpack(result)
-        if shared_output is not None and hidden_dim_was_padded:
+        if (
+            shared_output is not None or self.routed_output_transform is not None
+        ) and hidden_dim_was_padded:
             fused_output = fused_output[..., :routed_hidden_dim]
 
         # If combine kernel already reduced fused, reduce shared to match.

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -552,6 +552,7 @@ class MoERunner(MoERunnerInterface):
 
         # Record before `_maybe_pad_hidden_states` pads activations to match
         # `moe_config.hidden_dim`, e.g. after `align_trtllm_fp4_moe_hidden_dim_for_fi`
+        # so routed output can be trimmed before shared+routed add if needed.
         routed_hidden_dim = hidden_states.shape[-1]
         hidden_states, og_hidden_dim = self._maybe_pad_hidden_states(
             shared_experts_input,
@@ -577,7 +578,7 @@ class MoERunner(MoERunnerInterface):
 
         # Extract outputs from result
         shared_output, fused_output = _unpack(result)
-        if hidden_dim_was_padded:
+        if shared_output is not None and hidden_dim_was_padded:
             fused_output = fused_output[..., :routed_hidden_dim]
 
         # If combine kernel already reduced fused, reduce shared to match.

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -552,7 +552,8 @@ class MoERunner(MoERunnerInterface):
 
         # Record before `_maybe_pad_hidden_states` pads activations to match
         # `moe_config.hidden_dim`, e.g. after `align_trtllm_fp4_moe_hidden_dim_for_fi`
-        # so routed output can be trimmed before shared+routed add if needed.
+        # so routed output can be trimmed before
+        # shared+routed add / latent up proj if needed.
         routed_hidden_dim = hidden_states.shape[-1]
         hidden_states, og_hidden_dim = self._maybe_pad_hidden_states(
             shared_experts_input,


### PR DESCRIPTION
Only trim padded routed output before shared+routed add / latent moe up-proj. No-shared MoE keeps late truncation.

Not duplicate: #40853 (draft auto-pr) reverts #40794; this preserves the shared-output fix.

I've reproduced the following error locally before this pr's change, and the test passes with the change:
```
python -m pytest -sv "./tests/evals/gpt_oss/test_gpqa_correctness.py::test_gpqa_correctness[gpt-oss-20b-flashinfer-mxfp4-bf16]" --config-list-file=configs/models-b200.txt
```

The PR skips fused truncation when there is no shared expert (or latent moe up-proj), as is the case with GPT-OSS. This restores GPT-OSS behavior to the state before #40794, while preserving #40794’s intent for Nemotron-Nano-v3: applying truncation before addition, which was broken by #35949.

There may still be an open Nemotron-Nano-v3 FI NVFP4 bug under investigation. This PR, like the previous one, does not attempt to fix that; it only aims to keep GPT-OSS working and make Nemotron-Nano-v3 TP=1 functional.

AI assistance was used.