### PR TITLE
Fix Cohere embed task prefix rendering

### DIFF
--- a/tests/entrypoints/pooling/embed/test_io_processor.py
+++ b/tests/entrypoints/pooling/embed/test_io_processor.py
@@ -316,6 +316,7 @@ class TestPreProcessCohereOnline:
     def _make_handler():
         handler = object.__new__(EmbedIOProcessor)
         handler._validate_input_type = lambda _input_type: None
+        handler._should_inline_task_prefix = lambda: False
         return handler
 
     def test_text_only_without_task_prefix_uses_completion_path(self):
@@ -405,7 +406,7 @@ class TestPreProcessCohereOnline:
                                 content=[CohereEmbedContent(type="text", text="hello")]
                             ),
                             task_prefix="query: ",
-                            inline_task_prefix=True,
+                            inline_task_prefix=False,
                         )
                     ],
                     "truncate_prompt_tokens": -1,
@@ -413,3 +414,136 @@ class TestPreProcessCohereOnline:
                 },
             )
         ]
+
+    def test_text_only_with_single_message_template_inlines_task_prefix(self):
+        handler = self._make_handler()
+        ctx = self._make_context(texts=["hello"], input_type="query")
+        calls: list[tuple[str, object]] = []
+
+        def batch_render_chat(
+            request,
+            all_messages,
+            truncate_prompt_tokens,
+            truncation_side,
+        ):
+            calls.append(("chat", all_messages))
+            return ["chat"]
+
+        handler._get_task_instruction_prefix = lambda _input_type: "query: "
+        handler._has_chat_template = lambda: True
+        handler._should_inline_task_prefix = lambda: True
+        handler._batch_render_chat = batch_render_chat
+        handler._preprocess_cmpl_online = lambda *_args, **_kwargs: (
+            pytest.fail("completion path should be skipped when a template exists")
+        )
+
+        handler._pre_process_cohere_online(ctx)
+
+        assert ctx.engine_inputs == ["chat"]
+        assert calls == [
+            (
+                "chat",
+                [
+                    handler._mixed_input_to_messages(
+                        CohereEmbedInput(
+                            content=[CohereEmbedContent(type="text", text="hello")]
+                        ),
+                        task_prefix="query: ",
+                        inline_task_prefix=True,
+                    )
+                ],
+            )
+        ]
+
+    def test_inputs_with_single_message_template_inlines_task_prefix(self):
+        handler = self._make_handler()
+        ctx = self._make_context(
+            inputs=[
+                CohereEmbedInput(
+                    content=[
+                        CohereEmbedContent(type="text", text="machine learning"),
+                        CohereEmbedContent(type="text", text="the cat sat on the mat"),
+                    ]
+                )
+            ],
+            input_type="query",
+        )
+        calls: list[tuple[str, object]] = []
+
+        def batch_render_chat(
+            request,
+            all_messages,
+            truncate_prompt_tokens,
+            truncation_side,
+        ):
+            calls.append(("chat", all_messages))
+            return ["chat"]
+
+        handler._get_task_instruction_prefix = lambda _input_type: "query: "
+        handler._should_inline_task_prefix = lambda: True
+        handler._batch_render_chat = batch_render_chat
+
+        handler._pre_process_cohere_online(ctx)
+
+        assert ctx.engine_inputs == ["chat"]
+        assert calls == [
+            (
+                "chat",
+                [
+                    handler._mixed_input_to_messages(
+                        ctx.request.inputs[0],
+                        task_prefix="query: ",
+                        inline_task_prefix=True,
+                    )
+                ],
+            )
+        ]
+
+
+class TestShouldInlineTaskPrefix:
+    """Unit tests for EmbedIOProcessor._should_inline_task_prefix."""
+
+    @staticmethod
+    def _make_handler(chat_template: str | None):
+        handler = object.__new__(EmbedIOProcessor)
+
+        class _Tokenizer:
+            def get_chat_template(self, *_args, **_kwargs):
+                return chat_template
+
+        class _Renderer:
+            tokenizer = _Tokenizer()
+
+        class _ModelConfig:
+            trust_remote_code = False
+
+            class hf_config:
+                model_type = "test"
+
+        handler.renderer = _Renderer()
+        handler.chat_template = chat_template
+        handler.model_config = _ModelConfig()
+        return handler
+
+    def test_template_with_single_message_guard_inlines(self):
+        handler = self._make_handler(
+            "{%- if messages | length > 1 -%}"
+            "{{ raise_exception('only one message') }}"
+            "{%- endif -%}"
+        )
+
+        assert handler._should_inline_task_prefix()
+
+    def test_regular_template_keeps_system_message(self):
+        handler = self._make_handler(
+            "{%- for message in messages -%}"
+            "{{ message['role'] }}: {{ message['content'] }}"
+            "{%- endfor -%}"
+        )
+
+        assert not handler._should_inline_task_prefix()
+
+    def test_template_without_raise_exception_keeps_system_message(self):
+        handler = self._make_handler("{{ messages | length > 1 }}")
+
+        assert not handler._should_inline_task_prefix()

--- a/tests/entrypoints/pooling/embed/test_io_processor.py
+++ b/tests/entrypoints/pooling/embed/test_io_processor.py
@@ -112,6 +112,94 @@ class TestApplyStPrompt:
         assert handler._apply_task_instruction(texts, "passage") is texts
 
 
+class TestMixedInputToMessages:
+    """Unit tests for EmbedIOProcessor._mixed_input_to_messages."""
+
+    def test_task_prefix_defaults_to_system_message(self):
+        messages = EmbedIOProcessor._mixed_input_to_messages(
+            CohereEmbedInput(content=[CohereEmbedContent(type="text", text="hello")]),
+            task_prefix="query: ",
+        )
+
+        assert len(messages) == 2
+        assert messages[0]["role"] == "system"
+        assert messages[1]["role"] == "user"
+        assert messages[1]["content"][0]["text"] == "hello"
+
+    def test_inline_task_prefix_text_input(self):
+        messages = EmbedIOProcessor._mixed_input_to_messages(
+            CohereEmbedInput(content=[CohereEmbedContent(type="text", text="hello")]),
+            task_prefix="query: ",
+            inline_task_prefix=True,
+        )
+
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+        assert messages[0]["content"][0]["text"] == "query: hello"
+
+    def test_inline_task_prefix_only_first_text_part(self):
+        messages = EmbedIOProcessor._mixed_input_to_messages(
+            CohereEmbedInput(
+                content=[
+                    CohereEmbedContent(type="text", text="hello"),
+                    CohereEmbedContent(type="text", text="world"),
+                ]
+            ),
+            task_prefix="query: ",
+            inline_task_prefix=True,
+        )
+
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+        content = messages[0]["content"]
+        assert content[0]["text"] == "query: hello"
+        assert content[1]["text"] == "world"
+
+    def test_inline_task_prefix_mixed_input(self):
+        messages = EmbedIOProcessor._mixed_input_to_messages(
+            CohereEmbedInput(
+                content=[
+                    CohereEmbedContent(type="text", text="hello"),
+                    CohereEmbedContent(
+                        type="image_url",
+                        image_url={"url": "https://example.com/image.png"},
+                    ),
+                ]
+            ),
+            task_prefix="query: ",
+            inline_task_prefix=True,
+        )
+
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+        content = messages[0]["content"]
+        assert content[0]["text"] == "query: hello"
+        assert content[1]["type"] == "image_url"
+        assert content[1]["image_url"]["url"] == "https://example.com/image.png"
+
+    def test_inline_task_prefix_image_only_input(self):
+        messages = EmbedIOProcessor._mixed_input_to_messages(
+            CohereEmbedInput(
+                content=[
+                    CohereEmbedContent(
+                        type="image_url",
+                        image_url={"url": "https://example.com/image.png"},
+                    )
+                ]
+            ),
+            task_prefix="query: ",
+            inline_task_prefix=True,
+        )
+
+        assert len(messages) == 1
+        assert messages[0]["role"] == "user"
+        content = messages[0]["content"]
+        assert content[0]["type"] == "text"
+        assert content[0]["text"] == "query: "
+        assert content[1]["type"] == "image_url"
+        assert content[1]["image_url"]["url"] == "https://example.com/image.png"
+
+
 class TestLoadTaskInstructions:
     """Unit tests for EmbedIOProcessor._load_task_instructions."""
 
@@ -317,6 +405,7 @@ class TestPreProcessCohereOnline:
                                 content=[CohereEmbedContent(type="text", text="hello")]
                             ),
                             task_prefix="query: ",
+                            inline_task_prefix=True,
                         )
                     ],
                     "truncate_prompt_tokens": -1,

--- a/vllm/entrypoints/pooling/embed/io_processor.py
+++ b/vllm/entrypoints/pooling/embed/io_processor.py
@@ -290,13 +290,17 @@ class EmbedIOProcessor(PoolingIOProcessor):
         inp: CohereEmbedInput,
         *,
         task_prefix: str | None = None,
+        inline_task_prefix: bool = False,
     ) -> list[ChatCompletionMessageParam]:
         """Build chat messages from a mixed text+image input.
 
-        When *task_prefix* is given, it is used as the system prompt.
+        When *task_prefix* is given, it is used as the system prompt by
+        default. If *inline_task_prefix* is set, the prefix is instead
+        prepended to the user content so single-message embedding templates
+        can render the request.
         """
         messages: list[ChatCompletionMessageParam] = []
-        if task_prefix is not None:
+        if task_prefix is not None and not inline_task_prefix:
             messages.append(
                 CustomChatCompletionMessageParam(
                     role="system",
@@ -309,11 +313,18 @@ class EmbedIOProcessor(PoolingIOProcessor):
             )
 
         parts: list[ChatCompletionContentPartParam] = []
+        task_prefix_inlined = False
         for item in inp.content:
             if item.type == "text" and item.text is not None:
-                parts.append(
-                    ChatCompletionContentPartTextParam(type="text", text=item.text)
-                )
+                text = item.text
+                if (
+                    task_prefix is not None
+                    and inline_task_prefix
+                    and not task_prefix_inlined
+                ):
+                    text = task_prefix + text
+                    task_prefix_inlined = True
+                parts.append(ChatCompletionContentPartTextParam(type="text", text=text))
             elif item.type == "image_url" and item.image_url is not None:
                 parts.append(
                     ChatCompletionContentPartImageParam(
@@ -321,6 +332,11 @@ class EmbedIOProcessor(PoolingIOProcessor):
                         image_url=ImageURL(url=item.image_url["url"]),
                     )
                 )
+        if task_prefix is not None and inline_task_prefix and not task_prefix_inlined:
+            parts.insert(
+                0,
+                ChatCompletionContentPartTextParam(type="text", text=task_prefix),
+            )
         messages.append(CustomChatCompletionMessageParam(role="user", content=parts))
         return messages
 
@@ -418,6 +434,7 @@ class EmbedIOProcessor(PoolingIOProcessor):
                         content=[CohereEmbedContent(type="text", text=text)]
                     ),
                     task_prefix=task_prefix,
+                    inline_task_prefix=True,
                 )
                 for text in texts
             ]
@@ -439,7 +456,12 @@ class EmbedIOProcessor(PoolingIOProcessor):
 
         task_prefix = self._get_task_instruction_prefix(input_type)
         all_messages = [
-            self._mixed_input_to_messages(inp, task_prefix=task_prefix) for inp in input
+            self._mixed_input_to_messages(
+                inp,
+                task_prefix=task_prefix,
+                inline_task_prefix=True,
+            )
+            for inp in input
         ]
         ctx.engine_inputs = self._batch_render_chat(
             request, all_messages, truncate_prompt_tokens, truncation_side

--- a/vllm/entrypoints/pooling/embed/io_processor.py
+++ b/vllm/entrypoints/pooling/embed/io_processor.py
@@ -428,17 +428,18 @@ class EmbedIOProcessor(PoolingIOProcessor):
                 )
                 return
 
-            all_messages = [
-                self._mixed_input_to_messages(
-                    CohereEmbedInput(
-                        content=[CohereEmbedContent(type="text", text=text)]
-                    ),
-                    task_prefix=task_prefix,
-                    inline_task_prefix=True,
-                )
-                for text in texts
-            ]
             if self._has_chat_template():
+                inline_task_prefix = self._should_inline_task_prefix()
+                all_messages = [
+                    self._mixed_input_to_messages(
+                        CohereEmbedInput(
+                            content=[CohereEmbedContent(type="text", text=text)]
+                        ),
+                        task_prefix=task_prefix,
+                        inline_task_prefix=inline_task_prefix,
+                    )
+                    for text in texts
+                ]
                 ctx.engine_inputs = self._batch_render_chat(
                     request,
                     all_messages,
@@ -455,11 +456,14 @@ class EmbedIOProcessor(PoolingIOProcessor):
             return
 
         task_prefix = self._get_task_instruction_prefix(input_type)
+        inline_task_prefix = (
+            task_prefix is not None and self._should_inline_task_prefix()
+        )
         all_messages = [
             self._mixed_input_to_messages(
                 inp,
                 task_prefix=task_prefix,
-                inline_task_prefix=True,
+                inline_task_prefix=inline_task_prefix,
             )
             for inp in input
         ]
@@ -477,6 +481,18 @@ class EmbedIOProcessor(PoolingIOProcessor):
             )
             is not None
         )
+
+    def _should_inline_task_prefix(self) -> bool:
+        chat_template = resolve_chat_template(
+            self.renderer.tokenizer,
+            chat_template=self.chat_template,
+            tools=None,
+            model_config=self.model_config,
+        )
+        if chat_template is None or "raise_exception" not in chat_template:
+            return False
+
+        return "messages|length>1" in "".join(chat_template.split())
 
     def _preprocess_cohere_text_completion(
         self,


### PR DESCRIPTION
Fixes #40616

  ## Purpose

  Cohere `/v2/embed` requests with `input_type` can map to model task instructions. Before this change, vLLM rendered that task instruction as a
  separate `system` message and the embedding input as a `user` message.

  That creates an internal multi-message conversation even though the caller only sent a normal `/v2/embed` request. Embedding templates such as
  `examples/pooling/embed/template/nemotron_embed_vl.jinja` intentionally reject multi-message inputs, so the request failed with:

  `Embedding models should only embed one message at a time`

  This change keeps Cohere embed task instructions inside the single user message by inlining the task prefix into the text content before chat-
  template rendering.

  This does not change `/v1/embeddings` `messages` semantics and does not implement batch embedding support for `messages`.

  Duplicate checks:

  - `gh issue view 40616 --repo vllm-project/vllm --json number,title,state,assignees,comments,url`
    - Issue is open, with no assignees and no comments.
  - `gh pr list --repo vllm-project/vllm --state open --search "40616 in:body"`
    - No open PRs found.
  - `gh pr list --repo vllm-project/vllm --state open --search "nemotron embed vl input_type"`
    - No open PRs found.

  AI assistance was used.

  ## Test Plan

  - Run focused unit tests for Cohere embed preprocessing.
  - Run ruff on the modified files.
  - Manually reproduce the original `/v2/embed` request against `nvidia/llama-nemotron-embed-vl-1b-v2` served from a local model path with
  `nemotron_embed_vl.jinja`.

  ## Test Result

  `.venv/bin/python -m pytest tests/entrypoints/pooling/embed/test_io_processor.py -v`

  Result: `33 passed, 2 warnings in 6.79s`

  `pre-commit run ruff-check --files vllm/entrypoints/pooling/embed/io_processor.py tests/entrypoints/pooling/embed/test_io_processor.py`

  Result: `ruff check...............................................................Passed`

  Manual repro command:

  ```bash
  curl -sS -X POST http://localhost:8000/v2/embed \
    -H "Content-Type: application/json" \
    -d '{
      "model": "/root/workspace/models_dir/nv_llama",
      "texts": ["machine learning", "the cat sat on the mat"],
      "input_type": "query",
      "embedding_types": ["float"]
    }'
```
  ```bash
  curl -sS -X POST http://localhost:8000/v2/embed \
    -H "Content-Type: application/json" \
    -d '{
      "model": "/root/workspace/models_dir/nv_llama",
      "inputs": [
        {
          "content": [
            {"type": "text", "text": "machine learning"},
            {"type": "text", "text": "the cat sat on the mat"}
          ]
        }
      ],
      "input_type": "query",
      "embedding_types": ["float"]
    }'
```
  Result: the request returns embeddings instead of failing with Embedding models should only embed one message at a time.
<img width="2431" height="1243" alt="1d6718e6-d645-49c8-8cbd-d9197d1c272f" src="https://github.com/user-attachments/assets/553c6701-5d88-4dc2-8f65-0a7b5ba5d8bb" />
<img width="2452" height="1339" alt="921d05f9-d7c7-4e64-a5dc-6fb48e9a8bd7" src="https://github.com/user-attachments/assets/3b8149e4-519e-44ce-a36e-d72f53fe986a" />
<img width="1530" height="559" alt="image" src="https://github.com/user-attachments/assets/2faa6382-3253-4f47-826c-a4693b56c5e6" />
Note: I ran pre-commit run --all-files and all hooks passed except mypy-local and shellcheck, the failure I observed was   from repository-wide mypy-local checks in unrelated files.
The mypy-local failures are all in unrelated files:
- vllm/transformers_utils/model_arch_config_convertor.py
- vllm/config/compilation.py
- vllm/compilation/backends.py
- vllm/compilation/piecewise_backend.py
- vllm/entrypoints/openai/chat_completion/protocol.py
- vllm/entrypoints/openai/completion/protocol.py
- vllm/entrypoints/openai/responses/serving.py
- vllm/tool_parsers/mistral_tool_parser.py

These 27 mypy errors are pre-existing issues in the repository and outside the scope of this PR.

This PR only modifies:
- vllm/entrypoints/pooling/embed/io_processor.py
- tests/entrypoints/pooling/embed/test_io_processor.py

These modified files pass all focused unit tests, ruff-format, ruff-check, and have zero mypy errors.

I did not fix the unrelated mypy issues to keep this PR focused on #40616.
