### PR TITLE
[vLLM IR] Propagate lowering annotations through source_fn_stack

### DIFF
--- a/tests/compile/passes/ir/test_lowering.py
+++ b/tests/compile/passes/ir/test_lowering.py
@@ -1,5 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
+from pathlib import Path
+
 import pytest
 import torch
 from torch import nn
@@ -61,9 +64,92 @@ def test_lowering_rms_norm(rms_provider, default_vllm_config):
     assert selected["rms_norm_1"] == rms_provider
     assert selected["rms_norm_2"] == "native"
 
+    annotations = lowering_pass.selected_annotations["rms_norm"]
+    assert len(annotations) == 3
+
+    assert annotations["rms_norm"]["op"] == "rms_norm"
+    assert annotations["rms_norm"]["provider"] == rms_provider
+    assert annotations["rms_norm"]["annotation"] == (
+        f"vllm_ir::rms_norm[{rms_provider}]"
+    )
+    assert annotations["rms_norm"]["source_fn_stack"] == (
+        f"vllm_ir_rms_norm_{rms_provider}"
+    )
+
+    assert annotations["rms_norm_1"]["op"] == "rms_norm"
+    assert annotations["rms_norm_1"]["provider"] == rms_provider
+    assert annotations["rms_norm_1"]["annotation"] == (
+        f"vllm_ir::rms_norm[{rms_provider}]"
+    )
+    assert annotations["rms_norm_1"]["source_fn_stack"] == (
+        f"vllm_ir_rms_norm_{rms_provider}"
+    )
+
+    assert annotations["rms_norm_2"]["op"] == "rms_norm"
+    assert annotations["rms_norm_2"]["provider"] == "native"
+    assert annotations["rms_norm_2"]["annotation"] == "vllm_ir::rms_norm[native]"
+    assert annotations["rms_norm_2"]["source_fn_stack"] == "vllm_ir_rms_norm_native"
+
     # Compiled function guards on global value, avoid recompilation
     with ir.enable_torch_wrap(True):
         output2 = compiled_model(x)
 
     torch.testing.assert_close(output_unlowered, output)
     torch.testing.assert_close(output_unlowered, output2)
+
+
+@pytest.mark.parametrize("rms_provider", ops.rms_norm.supported_providers())
+def test_lowering_rms_norm_annotation_dump(
+    rms_provider, tmp_path: Path, default_vllm_config
+):
+    torch.set_default_device(current_platform.device_type)
+
+    default_vllm_config.compilation_config.debug_dump_path = tmp_path
+
+    lowering_pass = VllmIRLoweringPass(get_current_vllm_config())
+    backend = TestBackend(lowering_pass)
+
+    model = Model()
+    x = torch.randn(8, 16, dtype=torch.bfloat16)
+
+    with (
+        ops.rms_norm.set_priority([rms_provider, "native"]),
+        ir.enable_torch_wrap(True),
+    ):
+        compiled_model = torch.compile(model, backend=backend, fullgraph=True)
+        _ = compiled_model(x)
+
+    dump_dir = lowering_pass.debug_dump_path
+    assert dump_dir is not None
+
+    dump_files = sorted(dump_dir.glob("ir_lowering_annotations.*.json"))
+    assert dump_files
+
+    payload = json.loads(dump_files[-1].read_text())
+    assert "rms_norm" in payload
+
+    rms_entries = payload["rms_norm"]
+    assert set(rms_entries.keys()) == {"rms_norm", "rms_norm_1", "rms_norm_2"}
+
+    assert rms_entries["rms_norm"]["op"] == "rms_norm"
+    assert rms_entries["rms_norm"]["provider"] == rms_provider
+    assert rms_entries["rms_norm"]["annotation"] == (
+        f"vllm_ir::rms_norm[{rms_provider}]"
+    )
+    assert rms_entries["rms_norm"]["source_fn_stack"] == (
+        f"vllm_ir_rms_norm_{rms_provider}"
+    )
+
+    assert rms_entries["rms_norm_1"]["op"] == "rms_norm"
+    assert rms_entries["rms_norm_1"]["provider"] == rms_provider
+    assert rms_entries["rms_norm_1"]["annotation"] == (
+        f"vllm_ir::rms_norm[{rms_provider}]"
+    )
+    assert rms_entries["rms_norm_1"]["source_fn_stack"] == (
+        f"vllm_ir_rms_norm_{rms_provider}"
+    )
+
+    assert rms_entries["rms_norm_2"]["op"] == "rms_norm"
+    assert rms_entries["rms_norm_2"]["provider"] == "native"
+    assert rms_entries["rms_norm_2"]["annotation"] == "vllm_ir::rms_norm[native]"
+    assert rms_entries["rms_norm_2"]["source_fn_stack"] == "vllm_ir_rms_norm_native"

--- a/vllm/compilation/passes/ir/lowering_pass.py
+++ b/vllm/compilation/passes/ir/lowering_pass.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
 from collections import defaultdict
 from collections.abc import Iterable
+from pathlib import Path
 
 from torch import fx
 from torch._inductor.pattern_matcher import (
@@ -53,6 +55,14 @@ def get_ir_op(node: fx.Node) -> IrOp | None:
     return ir_op
 
 
+def _source_fn_stack_name(ir_op: IrOp, provider: str) -> str:
+    return f"vllm_ir_{ir_op.name}_{provider}"
+
+
+def _profiler_annotation_name(ir_op: IrOp, provider: str) -> str:
+    return f"vllm_ir::{ir_op.name}[{provider}]"
+
+
 class VllmIRLoweringPass(VllmInductorPass):
     """
     This pass lowers vLLM IR ops to their implementations the priority list.
@@ -61,7 +71,11 @@ class VllmIRLoweringPass(VllmInductorPass):
     def __init__(self, vllm_config: VllmConfig) -> None:
         super().__init__(vllm_config)
         self.patterns = PatternMatcherPass(self.pass_name)
-        self.selected_impls: dict[str, dict[str, str]] = defaultdict(lambda: {})
+        self.selected_impls: dict[str, dict[str, str]] = defaultdict(dict)
+        self.selected_annotations: dict[str, dict[str, dict[str, str]]] = defaultdict(
+            dict
+        )
+        self.debug_dump_path: Path | None = vllm_config.compile_debug_dump_path()
         self.ops = [ir_op.torch_op for ir_op in IrOp.registry.values()]
 
         # Look for any call_function node where the target is a vLLM IR op.
@@ -83,7 +97,27 @@ class VllmIRLoweringPass(VllmInductorPass):
         # Select and record the implementation, using fake args
         fake_args = fx.map_arg(node.args, lambda arg: arg.meta["val"])
         ir_op_impl = ir_op.dispatch(*fake_args)
-        self.selected_impls[ir_op.name][node.name] = ir_op_impl.provider
+        provider = ir_op_impl.provider
+
+        self.selected_impls[ir_op.name][node.name] = provider
+
+        source_fn_name = _source_fn_stack_name(ir_op, provider)
+        annotation = _profiler_annotation_name(ir_op, provider)
+
+        node.meta["source_fn_stack"] = node.meta.get("source_fn_stack", []) + [
+            (node.name, source_fn_name)
+        ]
+
+        node.meta["vllm_ir_annotation"] = {
+            "op": ir_op.name,
+            "provider": provider,
+            "annotation": annotation,
+            "source_fn_stack": source_fn_name,
+        }
+
+        self.selected_annotations[ir_op.name][node.name] = node.meta[
+            "vllm_ir_annotation"
+        ]
 
         # replace_by_example wants node args, not the fake tensors
         # TODO(luka): Use aot_export_module to get functionalized graph
@@ -94,10 +128,33 @@ class VllmIRLoweringPass(VllmInductorPass):
         bound_args.apply_defaults()
         match.replace_by_example(ir_op_impl.impl_fn, bound_args.args)
 
+    def _dump_selected_annotations(self) -> None:
+        if self.debug_dump_path is None:
+            return
+
+        self.debug_dump_path.mkdir(parents=True, exist_ok=True)
+
+        from vllm.utils.system_utils import unique_filepath
+
+        file_path = unique_filepath(
+            lambda i: (
+                self.debug_dump_path
+                / f"ir_lowering_annotations.{self.pass_name}.{i}.json"
+            )
+        )
+
+        payload = {
+            op_name: dict(nodes) for op_name, nodes in self.selected_annotations.items()
+        }
+
+        with file_path.open("w", encoding="utf-8") as f:
+            json.dump(payload, f, indent=2, sort_keys=True)
+
     @VllmInductorPass.time_and_log
     def __call__(self, graph: fx.Graph) -> None:
         # clear at the beginning instead of end, so that tests can inspect
         self.selected_impls.clear()
+        self.selected_annotations.clear()
 
         count = self.patterns.apply(graph)
         logger.debug("VllmIRLoweringPass lowered %d vLLM IR nodes", count)
@@ -123,6 +180,7 @@ class VllmIRLoweringPass(VllmInductorPass):
                 )
             ),
         )
+        self._dump_selected_annotations()
 
         failed_nodes: list[fx.Node] = []
         failed_ops: set[str] = set()


### PR DESCRIPTION
## Purpose

Part of #39363. Related to #40685.

This PR follows the option-2 direction discussed in #39363: attach vLLM IR op/provider information to lowered node metadata, instead of inserting a high-level IR profiler range into the FX graph.

During `VllmIRLoweringPass`, this PR records the selected IR provider and attaches structured annotation metadata to the lowered IR node.

Specifically, this PR:

- Appends `vllm_ir_<op>_<provider>` to the existing `node.meta["source_fn_stack"]`.
- Preserves existing `source_fn_stack` entries instead of overwriting them.
- Stores structured metadata in `node.meta["vllm_ir_annotation"]`:
  - `op`
  - `provider`
  - `annotation`
  - `source_fn_stack`
- Tracks selected annotations in `VllmIRLoweringPass.selected_annotations`.
- Dumps selected lowering annotations under `debug_dump_path` for debugging.
- Adds tests based on `tests/compile/passes/ir/test_lowering.py`.

I previously tried wrapping the lowered implementation with `torch.profiler.record_function(...)`, but that inserts profiler enter/exit ops into the lowered FX graph and is not compatible with the current Inductor lowering path.

This PR intentionally does not mutate global Inductor config from the lowering pass. If descriptive Triton names are enabled by the caller, the appended `source_fn_stack` marker can be surfaced in generated kernel names.

Custom CUDA launch-path annotations such as NVTX / C++ `RECORD_FUNCTION` can be added as a follow-up using the same annotation naming convention.

## Test Plan

Run the focused lowering pass tests and lint the modified Python files:

```bash
pytest -q tests/compile/passes/ir/test_lowering.py
ruff check vllm/compilation/passes/ir/lowering_pass.py tests/compile/passes/ir/test_lowering.py
```

## Test Result

```
pytest -q tests/compile/passes/ir/test_lowering.py
# 4 passed

ruff check vllm/compilation/passes/ir/lowering_pass.py tests/compile/passes/ir/test_lowering.py
# All checks passed
```

## Note

I did not run the full pre-commit suite locally because unrelated network-installed hook environments, including `markdownlint-cli2` and `actionlint`, failed to install in my environment.