### PR TITLE
[V1][Spec Decode] Skip global RNG fill in rejection sampler when all drafted requests are seeded

### DIFF
--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -624,11 +624,24 @@ def generate_uniform_probs(
     # uniform_prob is sampled to be exact 0.0 as reported in
     # https://github.com/pytorch/pytorch/issues/16706. Using float64
     # mitigates the issue.
-    uniform_probs = torch.rand(
-        (num_tokens,),
-        dtype=torch.float64,
-        device=device,
+    # Skip the global `torch.rand` when every request with draft tokens has
+    # its own generator: the per-generator `uniform_` calls below will cover
+    # all read positions, so the global fill would just be overwritten.
+    needs_global_rand = any(
+        n > 0 and i not in generators for i, n in enumerate(num_draft_tokens)
     )
+    if needs_global_rand:
+        uniform_probs = torch.rand(
+            (num_tokens,),
+            dtype=torch.float64,
+            device=device,
+        )
+    else:
+        uniform_probs = torch.empty(
+            (num_tokens,),
+            dtype=torch.float64,
+            device=device,
+        )
     start_idx = 0
     for req_idx, n in enumerate(num_draft_tokens):
         # Do not generate random numbers for requests with no draft tokens.
@@ -665,8 +678,15 @@ def sample_recovered_tokens(
         dtype=torch.float32,
         device=device,
     )
-    q.exponential_()
-    for i, generator in sampling_metadata.generators.items():
+    # Skip the global `q.exponential_()` when every request with draft tokens
+    # has its own generator: rows with num_draft_tokens[i] == 0 are never read
+    # by `sample_recovered_tokens_kernel` (it early-exits on out-of-range
+    # positions), and the remaining rows are overwritten by the per-generator
+    # `q[i].exponential_` calls below.
+    generators = sampling_metadata.generators
+    if any(num_draft_tokens[i] > 0 and i not in generators for i in range(batch_size)):
+        q.exponential_()
+    for i, generator in generators.items():
         # Do not generate random numbers for requests with no draft tokens.
         # This can be important for reproducibility.
         if num_draft_tokens[i] > 0:


### PR DESCRIPTION
## Summary

\`generate_uniform_probs\` and \`sample_recovered_tokens\` in \`vllm/v1/sample/rejection_sampler.py\` always start by filling the whole RNG tensor with the global generator, then overwrite the slices/rows for requests that have their own \`torch.Generator\`. When every request with non-zero draft tokens has its own generator (e.g. deterministic eval workloads with per-request seeds), the global fill is fully overwritten — wasted work.

This PR adds a short-circuiting \`any(...)\` check that mirrors the existing pattern at \`vllm/v1/sample/ops/topk_topp_sampler.py:339-340\` and skips the global RNG when no read position would observe it.

The notable saving is in \`sample_recovered_tokens\`, where the global fill is a \`(batch_size, vocab_size)\` float32 exponential — at batch=64 / vocab=128k that's ~32MB of RNG per spec-decode step that's currently discarded under all-seeded workloads.

## Correctness

- **Fast path** (\`needs_global_rand=True\`, typical sparse-seed serving): bitwise identical to before. The global fill runs, then the per-generator loop overwrites the seeded slices.
- **Skip path** (\`needs_global_rand=False\`, all-seeded with non-zero drafts): every \`i\` with \`num_draft_tokens[i] > 0\` has \`i in generators\` and gets its slice/row overwritten before being read. Rows for requests with \`num_draft_tokens[i] == 0\` are never read by the consumer kernels:
  - \`rejection_random_sample_kernel\` only indexes inside \`[start_idx, start_idx + num_draft_tokens[i])\`.
  - \`sample_recovered_tokens_kernel\` early-exits when \`pos >= num_draft_tokens\` (line 859-860), so \`inv_q\` row \`i\` is only read when \`program_id(0)==i\` AND \`pos < num_draft_tokens[i]\`.

The predicate is slightly tighter than the \`topk_topp_sampler.py\` prior art: it checks \`n > 0 and i not in generators\` rather than \`len(generators) != batch_size\`, correctly handling the case where some seeded requests have \`n == 0\`.

## Performance

- Typical (sparse generators): \`any(...)\` short-circuits at the first non-seeded request with drafts. Negligible Python cost (single comparison + dict miss), zero kernel-side change.
- All-seeded: saves the global \`torch.rand((num_tokens,), float64)\` and the \`(batch_size, vocab_size)\` \`exponential_\` per step.

## Test plan

- [x] Walked through both code paths to confirm bitwise-identical behavior in the fast path and no out-of-bounds / uninitialized read in the skip path.
- [x] Existing rejection-sampling tests should pass unchanged (no observable behavior change in either path).