### PR TITLE
[Doc] Clarify Qwen3-Omni OpenAI transcription client and docs (#29405)

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -679,9 +679,14 @@ Speech2Text models trained specifically for Automatic Speech Recognition.
 | `GlmAsrForConditionalGeneration` | GLM-ASR | `zai-org/GLM-ASR-Nano-2512` | ✅︎ | ✅︎ |
 | `GraniteSpeechForConditionalGeneration` | Granite Speech | `ibm-granite/granite-4.0-1b-speech`, `ibm-granite/granite-speech-3.3-2b`, etc. | ✅︎ | ✅︎ |
 | `Qwen3ASRForConditionalGeneration` | Qwen3-ASR | `Qwen/Qwen3-ASR-1.7B`, etc. | ✅︎ | ✅︎ |
-| `Qwen3OmniMoeThinkerForConditionalGeneration` | Qwen3-Omni | `Qwen/Qwen3-Omni-30B-A3B-Instruct`, etc. | | ✅︎ |
+| `Qwen3OmniMoeThinkerForConditionalGeneration` | Qwen3-Omni | `Qwen/Qwen3-Omni-30B-A3B-Instruct`, `Qwen/Qwen3-Omni-30B-A3B-Thinking`, etc. | | ✅︎ |
 | `VoxtralForConditionalGeneration` | Voxtral (Mistral format) | `mistralai/Voxtral-Mini-3B-2507`, `mistralai/Voxtral-Small-24B-2507`, etc. | ✅︎ | ✅︎ |
 | `WhisperForConditionalGeneration` | Whisper | `openai/whisper-small`, `openai/whisper-large-v3-turbo`, etc. | | |
+
+!!! note "Qwen3-Omni on the transcriptions API"
+    Multimodal Qwen3-Omni uses the same OpenAI-compatible [`/v1/audio/transcriptions`](../serving/openai_compatible_server.md#transcriptions-api) and [`/v1/audio/translations`](../serving/openai_compatible_server.md#translations-api) entrypoints as other [SupportsTranscription](../../vllm/model_executor/models/interfaces.py) models (for example Whisper).
+    Start the server with a supported checkpoint (for example `vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct`), then call those HTTP APIs or reuse [examples/online_serving/openai_transcription_client.py](../../examples/online_serving/openai_transcription_client.py).
+    For offline thinker-only audio+text generation (without the HTTP server), see [examples/offline_inference/qwen3_omni/only_thinker.py](../../examples/offline_inference/qwen3_omni/only_thinker.py).
 
 !!! note
     `VoxtralForConditionalGeneration` requires `mistral-common[audio]` to be installed.

--- a/examples/online_serving/openai_transcription_client.py
+++ b/examples/online_serving/openai_transcription_client.py
@@ -4,9 +4,17 @@
 This script demonstrates how to use the vLLM API server to perform audio
 transcription with the `openai/whisper-large-v3` model.
 
-Before running this script, you must start the vLLM server with the following command:
+The same client flow applies to any model listed under **Transcription** in
+`docs/models/supported_models.md#transcription` (for example multimodal
+`Qwen/Qwen3-Omni-30B-A3B-Instruct`).
+
+Before running this script, start the vLLM server with the desired model, e.g.:
 
     vllm serve openai/whisper-large-v3
+    # or
+    vllm serve Qwen/Qwen3-Omni-30B-A3B-Instruct
+
+The script will automatically detect the served model ID.
 
 Requirements:
 - vLLM with audio support


### PR DESCRIPTION
## Purpose

- Document that `examples/online_serving/openai_transcription_client.py` works for **any** model listed under **Transcription** in `docs/models/supported_models.md#transcription`, including multimodal **Qwen3-Omni** (not only Whisper).
- In `docs/models/supported_models.md`, add an explicit note linking OpenAI-compatible [`/v1/audio/transcriptions`](https://github.com/vllm-project/vllm/blob/main/docs/serving/openai_compatible_server.md#transcriptions-api) / [`translations`](https://github.com/vllm-project/vllm/blob/main/docs/serving/openai_compatible_server.md#translations-api) entrypoints, `openai_transcription_client.py`, and offline [`only_thinker.py`](https://github.com/vllm-project/vllm/blob/main/examples/offline_inference/qwen3_omni/only_thinker.py).

Related: #29405 (documentation clarity; avoids overlapping open PRs that change chunked-audio / timestamp behavior in `speech_to_text.py`).

## Duplicate-work check

- Open PRs touching transcription timestamps / chunked audio: out of scope here; this PR is **docs + example docstring only**.
- No other open PR found that only expands transcription docs for Qwen3-Omni + shared client example.

## Files

- `examples/online_serving/openai_transcription_client.py` — module docstring.
- `docs/models/supported_models.md` — Transcription table + **Qwen3-Omni on the transcriptions API** note.

## Test plan

```bash
python3 -m py_compile examples/online_serving/openai_transcription_client.py
uv run pre-commit run --files examples/online_serving/openai_transcription_client.py docs/models/supported_models.md
```

## AI assistance

Drafted with AI assistance; submitter should review the diff and run `pre-commit` before merge.

## Signed-off-by

Commits include: `Signed-off-by: Happy Bhati <hbhati@redhat.com>`

## CI note (vLLM repo policy)

The `pre-run-check` job requires the PR to have the **`verified`** or **`ready`** label, or the author must have **4+ merged PRs** in this repo (see `.github/workflows/pre-commit.yml`). Until a maintainer adds one of those labels, `pre-commit` will stay skipped and `pre-run-check` may fail even though the patch is fine.