### PR TITLE
fix(gemma4): remap compressed-tensors AWQ MoE keys in _weight_iterator

### DIFF
--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -1674,6 +1674,29 @@ class Gemma4ForCausalLM(
                 #
                 # No transpose needed: checkpoint orientation already
                 # matches FusedMoE's expected layout.
+                # PATCH: AWQ compressed-tensors key remapping
+                if "moe.gate_up_proj_packed" in name and weight.dim() == 3:
+                    mid = weight.size(1) // 2
+                    for e in range(weight.size(0)):
+                        base = name.replace("moe.", f"moe.experts.{e}.")
+                        yield base.replace("gate_up_proj_packed", "gate_proj.weight_packed"), weight[e, :mid]
+                        yield base.replace("gate_up_proj_packed", "up_proj.weight_packed"), weight[e, mid:]
+                    continue
+                if "moe.gate_up_proj_scale" in name and weight.dim() == 3:
+                    mid = weight.size(1) // 2
+                    for e in range(weight.size(0)):
+                        base = name.replace("moe.", f"moe.experts.{e}.")
+                        yield base.replace("gate_up_proj_scale", "gate_proj.weight_scale"), weight[e, :mid]
+                        yield base.replace("gate_up_proj_scale", "up_proj.weight_scale"), weight[e, mid:]
+                    continue
+                if "moe.down_proj_packed" in name and weight.dim() == 3:
+                    for e in range(weight.size(0)):
+                        yield name.replace("moe.", f"moe.experts.{e}.").replace("down_proj_packed", "down_proj.weight_packed"), weight[e]
+                    continue
+                if "moe.down_proj_scale" in name and weight.dim() == 3:
+                    for e in range(weight.size(0)):
+                        yield name.replace("moe.", f"moe.experts.{e}.").replace("down_proj_scale", "down_proj.weight_scale"), weight[e]
+                    continue
                 if "moe.gate_up_proj" in name and weight.dim() == 3:
                     num_experts = weight.size(0)
                     intermediate_size = weight.size(1) // 2


### PR DESCRIPTION
## Summary

The `cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit` Gemma4 26B MoE checkpoint uses compressed-tensors pack-quantized format, storing expert weights with `_packed` (int32) and `_scale` (bfloat16) suffixes. The existing `_weight_iterator` in `gemma4.py` only handles float checkpoints and does not remap these keys, causing a `KeyError` on model load.

## Root Cause

`_weight_iterator` renames checkpoint keys from `experts.gate_up_proj` to `moe.gate_up_proj` but has no handling for the `_packed`/`_scale` suffixed variants. The compressed-tensors FusedMoE weight_loader expects per-expert keys ending in `.weight_packed` and `.weight_scale`. Without remapping, all MoE weights fall through to the generic loader and fail.

## Fix

Add 4 interception cases before the existing float explosion code:

| Checkpoint key | Yields (per expert e) |
|---|---|
| moe.gate_up_proj_packed [E,2I,H/8] | moe.experts.{e}.gate_proj.weight_packed + up_proj.weight_packed |
| moe.gate_up_proj_scale [E,2I,G] | moe.experts.{e}.gate_proj.weight_scale + up_proj.weight_scale |
| moe.down_proj_packed [E,H,I/8] | moe.experts.{e}.down_proj.weight_packed |
| moe.down_proj_scale [E,H,G] | moe.experts.{e}.down_proj.weight_scale |

Zero deletions. Zero new imports. Float checkpoint path unchanged.

## Testing

- Hardware: RTX 3090 24GB, Proxmox LXC, CUDA 12.4
- vLLM: 0.19.1
- Model: cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit (17.2GB, 128 experts)
- Unit test confirmed all 6 per-expert weight types correctly remapped via safetensors inspection
- Full end-to-end inference blocked by vLLM v1 dual-process VRAM constraints on 24GB GPU (separate issue)

## Related

- Model: https://huggingface.co/cyankiwi/gemma-4-26B-A4B-it-AWQ-4bit
- quantization: compressed-tensors, format: pack-quantized, group_size=32