### PR TITLE
[Bugfix] Run FlashInfer autotuning before KV cache allocation

### DIFF
--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -40,8 +40,20 @@ def kernel_warmup(worker: "Worker"):
         worker.vllm_config.kernel_config.enable_flashinfer_autotune
     )
     # FlashInfer autotune for Hopper (SM 9.0) and Blackwell (SM 10.0) GPUs
+    # NOTE: Autotuning may have already been run early (before KV cache
+    # allocation) in gpu_worker.determine_available_memory() to avoid OOM.
+    # When early autotuning ran, we skip the second call here because the
+    # autotuner workspace buffers would compete with the now-allocated KV
+    # cache for GPU memory, causing OOM on shapes not covered by the early
+    # run's cache.
+    _did_early_autotune = getattr(worker, "_did_flashinfer_autotune_early", False)
     if enable_flashinfer_autotune is False:
         logger.info("Skipping FlashInfer autotune because it is disabled.")
+    elif _did_early_autotune:
+        logger.info(
+            "Skipping FlashInfer autotune in kernel_warmup — "
+            "already completed early (before KV cache allocation)."
+        )
     elif has_flashinfer() and current_platform.has_device_capability(90):
         flashinfer_autotune(worker.model_runner)
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -38,12 +38,16 @@ from vllm.distributed.parallel_state import (
 from vllm.distributed.weight_transfer import WeightTransferEngineFactory
 from vllm.logger import init_logger
 from vllm.lora.request import LoRARequest
-from vllm.model_executor.warmup.kernel_warmup import kernel_warmup
+from vllm.model_executor.warmup.kernel_warmup import (
+    flashinfer_autotune,
+    kernel_warmup,
+)
 from vllm.platforms import current_platform
 from vllm.profiler.wrapper import CudaProfilerWrapper, TorchProfilerWrapper
 from vllm.sequence import IntermediateTensors
 from vllm.tasks import SupportedTask
 from vllm.tracing import instrument
+from vllm.utils.flashinfer import has_flashinfer
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.mem_utils import MemorySnapshot, format_gib, memory_profiling
 from vllm.utils.torch_utils import is_quantized_kv_cache, set_random_seed
@@ -359,6 +363,7 @@ class Worker(WorkerBase):
                 "correspondingly."
             )
             logger.info(msg)
+            self._maybe_flashinfer_autotune_early()
             return kv_cache_memory_bytes
 
         # Execute a forward pass with dummy inputs to profile the memory usage
@@ -481,7 +486,43 @@ class Worker(WorkerBase):
                     suggested_util,
                 )
 
+        self._maybe_flashinfer_autotune_early()
         return int(self.available_kv_cache_memory_bytes)
+
+    def _maybe_flashinfer_autotune_early(self) -> None:
+        """Run FlashInfer autotuning while KV cache is not yet allocated.
+
+        The FlashInfer autotuner benchmarks many kernel tactics, each of which
+        allocates temporary workspace buffers.  When autotuning runs *after*
+        KV cache allocation (the previous behavior), these workspace buffers
+        compete with the KV cache for GPU memory and frequently OOM — causing
+        the autotuner to silently fall back to the default (untuned) tactic.
+
+        By running autotuning here — after model weights are loaded and memory
+        profiling is done, but *before* KV cache is allocated — the autotuner
+        has access to the full free GPU memory and can successfully benchmark
+        all candidate tactics.  The tuning results are cached in FlashInfer's
+        singleton AutoTuner and persist for the lifetime of the process, so
+        the later kernel_warmup() call will skip the redundant autotuning.
+        """
+        enable_flashinfer_autotune = (
+            self.vllm_config.kernel_config.enable_flashinfer_autotune
+        )
+        if enable_flashinfer_autotune is False:
+            return
+        if not (has_flashinfer() and current_platform.has_device_capability(90)):
+            return
+
+        logger.info(
+            "Running FlashInfer autotuning early (before KV cache allocation) "
+            "to avoid autotuner OOM."
+        )
+        flashinfer_autotune(self.model_runner)
+        # Free any transient memory the autotuner allocated.
+        torch.accelerator.empty_cache()
+        # Mark that early autotuning completed so kernel_warmup() skips
+        # the redundant (and potentially OOM-prone) second autotuning call.
+        self._did_flashinfer_autotune_early = True
 
     def get_kv_connector_handshake_metadata(self) -> dict | None:
         """Get KV connector metadata from this worker if available."""

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -519,6 +519,7 @@ class Worker(WorkerBase):
         )
         flashinfer_autotune(self.model_runner)
         # Free any transient memory the autotuner allocated.
+        gc.collect()
         torch.accelerator.empty_cache()
         # Mark that early autotuning completed so kernel_warmup() skips
         # the redundant (and potentially OOM-prone) second autotuning call.


### PR DESCRIPTION
## Summary

FlashInfer autotuning runs after KV cache allocation, where it frequently OOMs and silently falls back to untuned default kernel tactics. This PR adds an early autotuning call before KV cache allocation — where the GPU has enough free memory — and skips the original post-KV-cache call that was causing the OOMs.

## Problem

During vLLM startup, the worker lifecycle is:

```
load_model()                  → weights loaded
determine_available_memory()  → profile_run() measures peak activation
initialize_from_config()      → KV cache allocated (fills remaining GPU memory)
compile_or_warm_up_model()    → kernel_warmup() → flashinfer_autotune()  ← OOMs here
```

FlashInfer's autotuner benchmarks multiple CUTLASS kernel tactics for each GEMM shape. Each tactic allocates temporary workspace buffers. After KV cache allocation, there isn't enough free memory, so every tactic OOMs:

```
[Autotuner]: OOM detected, falling back to default tactic  (×64)
```

This affects any model using FlashInfer GEMM autotuning (NVFP4, FP8 block-scale, etc.) at `gpu_memory_utilization ≥ 0.95`.

## Fix

Move `flashinfer_autotune()` into `determine_available_memory()`, which runs before KV cache allocation. Set a `_did_flashinfer_autotune_early` flag so `kernel_warmup()` skips the original post-KV-cache autotuning call that was causing the OOMs.

### Changes

- `vllm/v1/worker/gpu_worker.py`: Add `_maybe_flashinfer_autotune_early()`, call at end of `determine_available_memory()`
- `vllm/model_executor/warmup/kernel_warmup.py`: Skip autotuning if `_did_flashinfer_autotune_early` is set

### Safety

- KV cache sizes identical between baseline and patched (verified: 540,256 tokens at 0.95 util)
- Non-NVFP4 models unaffected (tested GPTQ-Int4)
- FlashInfer attention warmup unchanged (stays in `kernel_warmup()`)

## Test Results

### RTX PRO 6000 Blackwell (102 GB, SM 12.0), `nvidia/Qwen3-32B-NVFP4`

| Metric | Baseline (0.95 util) | Patched (0.95 util) |
|---|---|---|
| Autotuner OOM fallbacks | 64 | **0** |
| Throughput (tok/s) | 172.2 | **177.3 (+3.0%)** |
| KV cache tokens | 540,256 | 540,256 (identical) |

### NVIDIA H200 (143 GB), `Qwen3-32B` bf16, 0.90 util

| Metric | Baseline | Patched |
|---|---|---|
| KV tokens | 252,320 | 252,080 (identical within noise) |
| Throughput (tok/s) | 53.3–53.4 | 53.6 (no regression) |
| Early autotune log | N/A | ✅ "Running FlashInfer autotuning early" |
| kernel_warmup skip log | N/A | ✅ "Skipping FlashInfer autotune in kernel_warmup" |

AI assistance was used in preparing this PR.