### PR TITLE
[Bugfix][Model] Qwen3-VL-MoE NVFP4 (ModelOpt) per-expert weight loading

### DIFF
--- a/tests/model_executor/test_qwen3_vl_moe_loader.py
+++ b/tests/model_executor/test_qwen3_vl_moe_loader.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for Qwen3-VL-MoE weight-loader name handling.
+
+Covers the ModelOpt NVFP4 per-expert path added to `load_weights` in
+`vllm/model_executor/models/qwen3_vl_moe.py`:
+
+- `_FUSED_EXPERT_RE` matches BMM-fused expert tensor names but excludes
+  un-BMM'd per-expert names (which would crash `transpose(-1, -2)` on
+  a 0-D scale tensor).
+- `_MODELOPT_PEREXP_RE` parses `experts.<proj>.<N>.<suffix>` so the
+  loader can remap to `experts.<N>.<proj>.<suffix>`.
+"""
+
+import pytest
+
+from vllm.model_executor.models.qwen3_vl_moe import (
+    _FUSED_EXPERT_RE,
+    _MODELOPT_PEREXP_RE,
+)
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        # BF16 bare Parameter form (HF-hosted unquantized checkpoint)
+        "model.layers.0.experts.gate_up_proj",
+        "model.layers.0.experts.down_proj",
+        # Linear-wrapped fused form
+        "model.layers.0.experts.gate_up_proj.weight",
+        "model.layers.0.experts.gate_up_proj.bias",
+        # NVFP4-fused expert tensor names (Llama4 / GPT-OSS style)
+        "model.layers.0.experts.down_proj.weight_packed",
+        "model.layers.0.experts.down_proj.weight_scale",
+        "model.layers.0.experts.down_proj.weight_scale_2",
+    ],
+)
+def test_fused_expert_re_matches(name):
+    assert _FUSED_EXPERT_RE.search(name), (
+        f"Expected {name!r} to match the BMM-fused expert pattern"
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        # ModelOpt NVFP4 un-BMM'd form (pre-remap)
+        "model.layers.0.experts.down_proj.0.weight_packed",
+        "model.layers.0.experts.down_proj.7.weight_scale",
+        "model.layers.0.experts.down_proj.127.weight_scale_2",
+        # Post-remap (after the loader rewrites `.<proj>.<N>.` → `.<N>.<proj>.`)
+        "model.layers.0.experts.0.down_proj.weight_packed",
+        "model.layers.0.experts.7.gate_proj.weight_packed",
+        "model.layers.0.experts.127.up_proj.weight_scale",
+    ],
+)
+def test_fused_expert_re_does_not_match(name):
+    assert not _FUSED_EXPERT_RE.search(name), (
+        f"Expected {name!r} to NOT match the BMM-fused expert pattern "
+        f"(would incorrectly trigger transpose on 0-D scale tensor)"
+    )
+
+
+def test_modelopt_perexp_re_remap_gate_proj():
+    name = "model.language_model.layers.3.mlp.experts.gate_proj.7.weight_packed"
+    m = _MODELOPT_PEREXP_RE.match(name)
+    assert m is not None
+    remapped = (
+        f"{m.group('prefix')}.{m.group('idx')}.{m.group('proj')}{m.group('suffix')}"
+    )
+    assert remapped == (
+        "model.language_model.layers.3.mlp.experts.7.gate_proj.weight_packed"
+    )
+
+
+def test_modelopt_perexp_re_remap_down_proj_scale_2():
+    name = "model.language_model.layers.47.mlp.experts.down_proj.123.weight_scale_2"
+    m = _MODELOPT_PEREXP_RE.match(name)
+    assert m is not None
+    remapped = (
+        f"{m.group('prefix')}.{m.group('idx')}.{m.group('proj')}{m.group('suffix')}"
+    )
+    assert remapped == (
+        "model.language_model.layers.47.mlp.experts.123.down_proj.weight_scale_2"
+    )
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        # Already-remapped Mixtral-style names must NOT match (would double-remap)
+        "model.layers.0.mlp.experts.7.gate_proj.weight_packed",
+        # Truly-fused names have no per-expert index
+        "model.layers.0.mlp.experts.down_proj.weight_packed",
+        "model.layers.0.mlp.experts.gate_up_proj.weight",
+        # Unrelated names
+        "model.embed_tokens.weight",
+        "model.layers.0.self_attn.q_proj.weight",
+    ],
+)
+def test_modelopt_perexp_re_does_not_match(name):
+    assert _MODELOPT_PEREXP_RE.match(name) is None, (
+        f"Expected {name!r} to NOT match the ModelOpt per-expert pattern"
+    )
+
+
+def test_modelopt_perexp_re_rejects_non_decimal_index():
+    # `\d+` must not match hex-style or alphanumeric segments.
+    name = "model.layers.0.experts.gate_proj.0xff.weight_packed"
+    assert _MODELOPT_PEREXP_RE.match(name) is None

--- a/vllm/model_executor/models/qwen3_vl_moe.py
+++ b/vllm/model_executor/models/qwen3_vl_moe.py
@@ -28,6 +28,7 @@ import typing
 from collections.abc import Callable, Iterable
 from itertools import islice
 
+import regex as re
 import torch
 from transformers.models.qwen3_vl_moe.configuration_qwen3_vl_moe import (
     Qwen3VLMoeConfig,
@@ -63,6 +64,18 @@ from .qwen3_vl import (
 from .utils import is_pp_missing_parameter, maybe_prefix
 
 logger = init_logger(__name__)
+
+# Match ModelOpt NVFP4 per-expert names (`experts.<proj>.<N>.<suffix>`)
+# and remap to vLLM's standard `experts.<N>.<proj>.<suffix>` ordering.
+_MODELOPT_PEREXP_RE = re.compile(
+    r"(?P<prefix>.*experts)\.(?P<proj>gate_proj|up_proj|down_proj)"
+    r"\.(?P<idx>\d+)(?P<suffix>\..*)"
+)
+# Match BMM-fused expert weights (Llama4 / GPT-OSS / unquantized HF). The
+# negative-lookahead excludes ModelOpt NVFP4 per-expert names, which are
+# remapped to fused-style ordering by `_MODELOPT_PEREXP_RE` above but must
+# still be loaded as 2D per-expert tensors.
+_FUSED_EXPERT_RE = re.compile(r"experts\.(gate_up_proj|down_proj)(?!\.\d)")
 
 
 class Qwen3VLMoeProcessingInfo(Qwen3VLProcessingInfo):
@@ -171,13 +184,18 @@ class Qwen3MoeLLMModel(Qwen3MoeModel):
             ("gate_up_proj", "up_proj", 1),
         ]
         # Skip loading extra parameters for GPTQ/modelopt models.
+        # ModelOpt NVFP4 adds weight_scale_2 / *_global_scale / pre_quant_scale.
         ignore_suffixes = (
             ".bias",
             "_bias",
             ".weight_scale",
             "_weight_scale",
+            ".weight_scale_2",
+            ".weight_global_scale",
             ".input_scale",
             "_input_scale",
+            ".input_global_scale",
+            ".pre_quant_scale",
         )
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
@@ -192,16 +210,29 @@ class Qwen3MoeLLMModel(Qwen3MoeModel):
         ]
         num_experts = self.config.num_experts
         for name, loaded_weight in weights:
+            # Remap ModelOpt un-BMM'd per-expert names from
+            # `experts.<proj>.<N>.<suffix>` to vLLM's standard
+            # `experts.<N>.<proj>.<suffix>` so the rest of the loader
+            # (which expects Mixtral-style per-expert ordering) works.
+            m = _MODELOPT_PEREXP_RE.match(name)
+            if m is not None:
+                name = (
+                    f"{m.group('prefix')}.{m.group('idx')}."
+                    f"{m.group('proj')}{m.group('suffix')}"
+                )
+
             if "scale" in name or "zero_point" in name:
                 name = maybe_remap_kv_scale_name(name, params_dict)
                 if name is None:
                     continue
 
-            for param_name, weight_name, shard_id in stacked_params_mapping:
-                if "experts.gate_up_proj" in name or "experts.down_proj" in name:
-                    is_fused_expert = True
-                    expert_params_mapping = fused_expert_params_mapping
+            # Detect BMM-fused expert weights once per outer iteration —
+            # depends on `name` only, so hoist out of the inner loop below.
+            if _FUSED_EXPERT_RE.search(name):
+                is_fused_expert = True
+                expert_params_mapping = fused_expert_params_mapping
 
+            for param_name, weight_name, shard_id in stacked_params_mapping:
                 # Skip non-stacked layers and experts (experts handled below).
                 if weight_name not in name:
                     continue


### PR DESCRIPTION
## Purpose

Fix checkpoint loading for Qwen3-VL-MoE models quantized by [NVIDIA TensorRT-Model-Optimizer](https://github.com/NVIDIA/TensorRT-Model-Optimizer) (`nvidia-modelopt >= 0.43`, `quant_algo: NVFP4`).

ModelOpt un-BMMs Qwen3-VL-MoE's fused expert tensors into per-expert `nn.ModuleList`s, producing names like `experts.gate_proj.0.weight_packed` instead of vLLM's expected `experts.0.gate_proj.weight_packed`. The current loader has three issues with this:

1. `is_fused_expert` uses substring matching (`"experts.down_proj" in name`) which false-positives on `experts.down_proj.0.weight_scale_2`. The loader then calls `transpose(-1, -2)` on a 0-D scale tensor and crashes with `IndexError: Dimension out of range`.
2. Even with the crash fixed, names need remapping from `experts.<proj>.<N>.<suffix>` to `experts.<N>.<proj>.<suffix>` so they flow through `make_expert_params_mapping`. Without it, scales are silently dropped and the model loads but outputs garbage.
3. `ignore_suffixes` does not list NVFP4 scale suffixes (`.weight_scale_2`, `.weight_global_scale`, `.input_global_scale`, `.pre_quant_scale`).

This PR adds, scoped to `qwen3_vl_moe.py` only:
1. A precise regex-based `is_fused_expert` check that targets the truly-fused BMM format and excludes per-expert un-BMM'd names.
2. An up-front name remap for the ModelOpt per-expert form.
3. The four NVFP4 scale suffixes added to `ignore_suffixes`.

The change is additive — Llama4-style BMM-fused NVFP4 checkpoints continue to load unchanged because the new regex matches them precisely. The recently added LoRA `base_layer.` adapter handling in `fused_expert_params_mapping` (#37114) is preserved.

Intended as a near-term stop-gap until [RFC #40182 ("Unified ModelOpt Quantization in vLLM")](https://github.com/vllm-project/vllm/issues/40182) lands; the per-model name-remap shim can be removed once the unified ModelOpt loader path is in place. Mirrors the per-model pattern established by [#39045](https://github.com/vllm-project/vllm/pull/39045) (Gemma 4 quantized MoE, MERGED).

Fixes: #40885

## AI assistance disclosure

Per `AGENTS.md`, this PR was produced with non-trivial assistance from an AI coding assistant (Anthropic Claude, model `claude-opus-4-7`). The submitter reviewed every changed line, ran `pre-commit run --all-files` (passes), executed the regex unit tests added under `tests/model_executor/`, and ran the integration test against a real ModelOpt NVFP4 Qwen3-VL-MoE checkpoint (`Code4me2/bu-30b-a3b-preview-NVFP4`). The BF16 vs NVFP4 accuracy comparison below confirms the scales are actually applied. The commit uses the `Co-authored-by: Claude` trailer per the AGENTS.md example.

This PR is **not** a duplicate: the only adjacent open work is RFC #40182 (long-term unified ModelOpt path) and the per-model fix series #39045/#39256/#39084/#39406 (Gemma 4 only). No open PR addresses Qwen3-VL-MoE specifically.

## Test Plan

**Unit tests** (added in `tests/model_executor/test_qwen3_vl_moe_loader.py`): cover the two regex patterns. Verify `_TRULY_FUSED_EXPERT_RE` matches the fused BMM format (BF16 bare Parameter, Linear-wrapped, NVFP4 fused) but does NOT match the un-BMM'd per-expert form, and that `_MODELOPT_PEREXP_RE` correctly remaps `experts.<proj>.<N>.<suffix>` → `experts.<N>.<proj>.<suffix>`.

**Integration test** (manual, against a published reference checkpoint):
```bash
vllm serve Code4me2/bu-30b-a3b-preview-NVFP4 \
    --max-model-len 32768 --dtype bfloat16 \
    --gpu-memory-utilization 0.85 --kv-cache-dtype fp8 --max-num-seqs 2
```
Confirms the loader no longer crashes and the served model produces correct outputs.

**Regression check**: Llama4-style BMM-fused NVFP4 checkpoints still load (the new fused-detection regex matches them unchanged because their `.weight` / `.weight_packed` suffix follows the proj name with no intermediate numeric index).

## Test Result

Before the patch (against `Code4me2/bu-30b-a3b-preview-NVFP4`):
```
ERROR [core.py:1104]   File ".../vllm/model_executor/models/qwen3_vl_moe.py", line 245, in load_weights
ERROR [core.py:1104]     loaded_weight = loaded_weight.transpose(-1, -2)
ERROR [core.py:1104] IndexError: Dimension out of range (expected to be in range of [-1, 0], but got -2)
RuntimeError: Engine core initialization failed.
```
After the patch: server starts, generation produces correct outputs (`"What is 7 times 8?"` → `"56"`).

Mini-eval, BF16 baseline vs NVFP4 (this patch), same vLLM build on Blackwell `sm_120`:

| Task | n | BF16 | NVFP4 | Δ | NVFP4 / BF16 wallclock |
|---|---|---|---|---|---|
| MMLU (0-shot generative) | 200 | 80.5 % | 76.5 % | −4.0 pp | **3.6× faster** (9.1s vs 32.9s) |
| GSM8K (0-shot CoT) | 200 | 89.5 % | 87.0 % | −2.5 pp | 1.2× faster (146s vs 174s) |

Accuracy deltas are within typical NVFP4 ranges for an MoE; the meaningful confirmation is that the deltas are *small*, which means the scales are actually being applied (a broken loader would produce a much larger gap).

## Checklist

- [x] Purpose described (and linked to issue #40885)
- [x] Test plan provided (unit tests + manual integration commands)
- [x] Test result provided (MMLU/GSM8K comparison above)
- [x] No documentation update needed (`supported_models.md` already lists Qwen3-VL-MoE)
- [x] DCO sign-off present
