### PR TITLE
[torch.compile] reuse aot_compile_hash_factors in VllmBackend

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -1024,8 +1024,9 @@ class VllmBackend:
 
         # Minimal hashing here with existing utilities, reused below.
         # Compute config/compiler/code hashes once and reuse
-        env_hash, config_hash, *_ = aot_compile_hash_factors(vllm_config)
-        env_factors = envs.compile_factors()
+        result = aot_compile_hash_factors(vllm_config)
+        env_hash, config_hash, *_ = result.hashes
+        env_factors = result.env_factors
         compiler_hash = self.compiler_manager.compute_hash(vllm_config)
         forward_code_files = list(sorted(self.compilation_config.traced_files))
 

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -29,7 +29,7 @@ from vllm.compilation.codegen import (
 )
 from vllm.config import CompilationConfig, CUDAGraphMode, VllmConfig
 from vllm.config.compilation import DynamicShapesType
-from vllm.config.utils import Range, hash_factors
+from vllm.config.utils import Range
 from vllm.logger import init_logger
 from vllm.logging_utils import lazy
 from vllm.platforms import current_platform
@@ -37,6 +37,7 @@ from vllm.tracing import instrument, instrument_manual
 from vllm.utils.import_utils import resolve_obj_by_qualname
 from vllm.utils.torch_utils import is_torch_equal_or_newer
 
+from .caching import aot_compile_hash_factors
 from .compiler_interface import (
     CompilerInterface,
     EagerAdaptor,
@@ -1022,11 +1023,9 @@ class VllmBackend:
         self._log_compilation_config()
 
         # Minimal hashing here with existing utilities, reused below.
-
-        env_factors = envs.compile_factors()
-        env_hash = hash_factors(env_factors)
         # Compute config/compiler/code hashes once and reuse
-        config_hash = vllm_config.compute_hash()
+        env_hash, config_hash, *_ = aot_compile_hash_factors(vllm_config)
+        env_factors = envs.compile_factors()
         compiler_hash = self.compiler_manager.compute_hash(vllm_config)
         forward_code_files = list(sorted(self.compilation_config.traced_files))
 

--- a/vllm/compilation/caching.py
+++ b/vllm/compilation/caching.py
@@ -7,7 +7,7 @@ import inspect
 import os
 import pickle
 from collections.abc import Callable, Sequence
-from typing import Any, Literal
+from typing import Any, Literal, NamedTuple
 from unittest.mock import patch
 
 import torch
@@ -562,23 +562,26 @@ def reconstruct_serializable_fn_from_mega_artifact(
     return fn
 
 
-def aot_compile_hash_factors(vllm_config: VllmConfig) -> list[str]:
-    factors = []
+class AotCompileHashFactors(NamedTuple):
+    hashes: list[str]
+    env_factors: dict
+
+
+def aot_compile_hash_factors(vllm_config: VllmConfig) -> AotCompileHashFactors:
+    raw_env = envs.compile_factors()
     # 0. factors come from the env, for example, The values of
     # VLLM_PP_LAYER_PARTITION will affect the computation graph.
-    env_hash = hash_factors(envs.compile_factors())
-    factors.append(env_hash)
+    factors: list[str] = [hash_factors(raw_env)]
 
     # 1. factors come from the vllm_config (it mainly summarizes how the
     #    model is created)
-    config_hash = vllm_config.compute_hash()
-    factors.append(config_hash)
+    factors.append(vllm_config.compute_hash())
 
     # 2. inductor factors if applicable
     if envs.VLLM_USE_MEGA_AOT_ARTIFACT:
         factors.extend(get_inductor_factors())
 
-    return factors
+    return AotCompileHashFactors(hashes=factors, env_factors=raw_env)
 
 
 def _compute_code_hash_with_content(file_contents: dict[str, str]) -> str:

--- a/vllm/compilation/decorators.py
+++ b/vllm/compilation/decorators.py
@@ -536,7 +536,7 @@ def _support_torch_compile(
             """
             from .caching import aot_compile_hash_factors
 
-            factors: list[str] = aot_compile_hash_factors(self.vllm_config)
+            factors: list[str] = list(aot_compile_hash_factors(self.vllm_config).hashes)
 
             factors.append(_model_hash_key(self.forward))
             hash_key = hashlib.sha256(str(factors).encode()).hexdigest()


### PR DESCRIPTION
## Purpose

Addresses https://github.com/vllm-project/vllm/issues/39479 (item 5).

Replaces the inlined `env_hash` / `config_hash` computation in
`VllmBackend.__call__` with a call to the existing `aot_compile_hash_factors`
helper in `caching.py`, reducing duplication. Also removes the now-unused
`hash_factors` import from `backends.py`.

## Why not a duplicate
This PR addresses item 5 (shared helper) which is not covered there.

## Test Plan
```bash
pre-commit run ruff-check --files vllm/compilation/backends.py
.venv/bin/python -c "from vllm.compilation.backends import VllmBackend; print('ok')"
.venv/bin/python -m pytest tests/compile/test_config.py -v
