### PR TITLE
[Core] Avoid using extra thread in `UniProcExecutor`

### DIFF
--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import os
 from collections.abc import Callable
-from concurrent.futures import Future, ThreadPoolExecutor
+from concurrent.futures import Future
 from functools import cached_property
 from multiprocessing import Lock
 from typing import Any
@@ -23,6 +23,25 @@ from vllm.v1.worker.worker_base import WorkerWrapperBase
 logger = init_logger(__name__)
 
 
+class AsyncOutputFuture(Future):
+    def __init__(self, async_output: AsyncModelRunnerOutput, single_value: bool):
+        self.async_output = async_output
+        self.single_value = single_value
+        super().__init__()
+
+    def result(self, timeout=None):
+        if timeout is not None:
+            raise RuntimeError("timeout not implemented")
+
+        if not super().done():
+            try:
+                output = self.async_output.get_output()
+                self.set_result(output if self.single_value else [output])
+            except Exception as e:
+                self.set_exception(e)
+        return super().result()
+
+
 class UniProcExecutor(Executor):
     def _init_executor(self) -> None:
         """Initialize the worker and load the model."""
@@ -36,12 +55,6 @@ class UniProcExecutor(Executor):
             is_driver_worker=True,
             shared_worker_lock=Lock(),
         )
-
-        self.async_output_thread: ThreadPoolExecutor | None = None
-        if self.max_concurrent_batches > 1:
-            self.async_output_thread = ThreadPoolExecutor(
-                max_workers=1, thread_name_prefix="WorkerAsyncOutput"
-            )
 
         self.driver_worker.init_worker(all_kwargs=[kwargs])
         self.driver_worker.init_device()
@@ -83,15 +96,7 @@ class UniProcExecutor(Executor):
         try:
             result = run_method(self.driver_worker, method, args, kwargs)
             if isinstance(result, AsyncModelRunnerOutput):
-                if (async_thread := self.async_output_thread) is not None:
-                    if single_value:
-                        return async_thread.submit(result.get_output)
-
-                    def get_output_list() -> list[Any]:
-                        return [result.get_output()]
-
-                    return async_thread.submit(get_output_list)
-                result = result.get_output()
+                return AsyncOutputFuture(result, single_value)
             future = Future[Any]()
             future.set_result(result if single_value else [result])
         except Exception as e:


### PR DESCRIPTION
@zhuohan123's idea

Clear performance benefit, especially in low latency / high concurrency case.

### Benchmark

`--tensor-parallel-size 1 --distributed-executor-backend uni` on a single NVIDIA GB200 GPU.
Model: `Qwen/Qwen3-0.6B`. Each side is mean ± population std across **3 timed runs** sharing one server process; each run uses its own seed (1, 2, 3) and is preceded by a fresh warmup batch.
Δ = relative change of with-mean vs. without-mean (✓ = improvement, ✗ = regression).
256 in / 2048 out; ignore-eos, no prefix cache.

  | Metric | Concurrency 1 (32 prompts) | | | Concurrency 512 (1024 prompts) | | |
  |---|---:|---:|---:|---:|---:|---:|
  | | Without | With | Δ | Without | With | Δ |
  | Output throughput (tok/s) | 631.21 ±0.64 | 648.73 ±14.60 | +2.78% ✓ | 17221.96 ±168.39 | 18974.27 ±176.49 | +10.17% ✓ |
  | P50 TTFT (ms) | 19.00 ±0.16 | 19.21 ±0.19 | +1.10% ✗ | 910.12 ±36.45 | 851.30 ±69.16 | -6.46% ✓ |
  | P90 TTFT (ms) | 19.48 ±0.27 | 19.88 ±0.32 | +2.05% ✗ | 1309.86 ±49.79 | 1113.85 ±85.18 | -14.96% ✓ |
  | P50 TPOT (ms) | 1.572 ±0.001 | 1.530 ±0.032 | -2.66% ✓ | 28.946 ±0.199 | 26.383 ±0.352 | -8.85% ✓ |
  | P90 TPOT (ms) | 1.588 ±0.005 | 1.558 ±0.033 | -1.88% ✓ | 29.512 ±0.214 | 26.935 ±0.070 | -8.73% ✓ |
  | Mean ITL (ms) | 1.576 ±0.002 | 1.534 ±0.035 | -2.68% ✓ | 29.112 ±0.099 | 26.563 ±0.243 | -8.75% ✓ |
  | Mean E2EL (ms) | 3244.52 ±3.29 | 3158.44 ±71.05 | -2.65% ✓ | 60292.61 ±232.44 | 55010.05 ±510.73 | -8.76% ✓ |

