### PR TITLE
[Metrics] Export parallel config info

### DIFF
--- a/tests/entrypoints/serve/instrumentator/test_metrics.py
+++ b/tests/entrypoints/serve/instrumentator/test_metrics.py
@@ -191,6 +191,7 @@ EXPECTED_METRICS_V1 = [
     "vllm:generation_tokens_total",
     "vllm:iteration_tokens_total",
     "vllm:cache_config_info",
+    "vllm:parallel_config_info",
     "vllm:request_success_total",
     "vllm:request_prompt_tokens_sum",
     "vllm:request_prompt_tokens_bucket",
@@ -288,6 +289,9 @@ async def test_metrics_exist(
         if metric in HIDDEN_DEPRECATED_METRICS and not server.show_hidden_metrics:
             continue
         assert metric in response.text
+
+    assert 'decode_context_parallel_size="1"' in response.text
+    assert 'tensor_parallel_size="1"' in response.text
 
 
 @pytest.mark.asyncio

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -720,6 +720,27 @@ class ParallelConfig:
         factors = get_hash_factors(self, ignored_factors)
         return hash_factors(factors)
 
+    def metrics_info(self) -> dict[str, str]:
+        """Return stable, low-cardinality fields for Prometheus info metrics."""
+        return {
+            "pipeline_parallel_size": str(self.pipeline_parallel_size),
+            "tensor_parallel_size": str(self.tensor_parallel_size),
+            "prefill_context_parallel_size": str(
+                self.prefill_context_parallel_size
+            ),
+            "decode_context_parallel_size": str(self.decode_context_parallel_size),
+            "data_parallel_size": str(self.data_parallel_size),
+            "data_parallel_size_local": str(self.data_parallel_size_local),
+            "world_size": str(self.world_size),
+            "world_size_across_dp": str(self.world_size_across_dp),
+            "dcp_comm_backend": str(self.dcp_comm_backend),
+            "cp_kv_cache_interleave_size": str(self.cp_kv_cache_interleave_size),
+            "enable_expert_parallel": str(self.enable_expert_parallel),
+            "enable_dbo": str(self.enable_dbo),
+            "disable_custom_all_reduce": str(self.disable_custom_all_reduce),
+            "distributed_executor_backend": str(self.distributed_executor_backend),
+        }
+
     def __post_init__(self) -> None:
         # Continue with the rest of the initialization
         self.world_size = (

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1039,6 +1039,9 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         if type == "cache_config":
             name = "vllm:cache_config_info"
             documentation = "Information of the LLMEngine CacheConfig"
+        elif type == "parallel_config":
+            name = "vllm:parallel_config_info"
+            documentation = "Information of the LLMEngine ParallelConfig"
         assert name is not None, f"Unknown metrics info type {type}"
 
         # Info type metrics are syntactic sugar for a gauge permanently set to 1
@@ -1236,6 +1239,7 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
 
     def log_engine_initialized(self):
         self.log_metrics_info("cache_config", self.vllm_config.cache_config)
+        self.log_metrics_info("parallel_config", self.vllm_config.parallel_config)
 
 
 def build_buckets(mantissa_lst: list[int], max_value: int) -> list[int]:


### PR DESCRIPTION
## Summary

Add a `vllm:parallel_config_info` Prometheus info metric with stable low-cardinality parallel runtime labels, including:

- `tensor_parallel_size`, `pipeline_parallel_size`, `data_parallel_size`
- `prefill_context_parallel_size`, `decode_context_parallel_size`
- `world_size`, `world_size_across_dp`
- DCP/custom-allreduce/backend flags that affect distributed execution

## Why

vLLM already exports `vllm:cache_config_info`, including `num_gpu_blocks` and `block_size`, but for context-parallel/DCP deployments those values are local cache blocks. The startup log multiplies them by the CP world size, but the CP/DCP multiplier is not available through the HTTP API or Prometheus metrics.

That means remote benchmark and monitoring tools cannot reconstruct the effective GPU KV-cache token budget without parsing logs or knowing the launch command out of band. For example, with `--decode-context-parallel-size 8`, Prometheus exposes local KV blocks while the effective capacity is `num_gpu_blocks * block_size * prefill_context_parallel_size * decode_context_parallel_size`.

Exporting the parallel config makes this observable without changing scheduling, allocation, or runtime behavior.

## Validation

- `python3 -m py_compile vllm/config/parallel.py vllm/v1/metrics/loggers.py tests/entrypoints/serve/instrumentator/test_metrics.py`
- `git diff --check`
- Patched a local vLLM image and launched Kimi-K2.6 with `--tensor-parallel-size 8 --decode-context-parallel-size 8`
- Verified `/metrics` contains:

```text
vllm:parallel_config_info{...,decode_context_parallel_size="8",tensor_parallel_size="8",world_size="8",...} 1.0
```

- Verified a remote-style benchmark can compute effective KV budget from metrics:

```text
num_gpu_blocks=15254, block_size=16, prefill_context_parallel_size=1, decode_context_parallel_size=8
=> effective GPU KV cache size = 1,952,512 tokens
```
