### PR TITLE
[Core] Added Sleep 3 -- Keep weights on GPU, discard KV cache and everything else

### DIFF
--- a/tests/basic_correctness/test_cumem.py
+++ b/tests/basic_correctness/test_cumem.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import asyncio
+import gc
 
 import pytest
 import torch
@@ -280,3 +281,162 @@ def test_deep_sleep_fp8_kvcache():
 
     # cmp output
     assert output[0].outputs[0].text == output2[0].outputs[0].text
+
+
+@create_new_process_for_each_test("fork" if not current_platform.is_rocm() else "spawn")
+def test_sleep_level3_preserves_weights_tag():
+    """
+    CuMem sleep with preserve_tags_on_gpu: weights stay mapped, kv_cache discarded.
+    """
+    allocator = CuMemAllocator.get_instance()
+
+    # Allocates a GPU tensor tagged as "weights" and fills it with 7
+    with allocator.use_memory_pool(tag="weights"):
+        w = torch.empty(4096, dtype=torch.uint8, device=DEVICE_TYPE)
+        w.fill_(7)
+    # Allocates a GPU tensor tagged as "kv_cache"
+    with allocator.use_memory_pool(tag="kv_cache"):
+        torch.empty(4096, dtype=torch.uint8, device=DEVICE_TYPE)
+
+    # Puts to sleep mode 3, which should preserve "weights" on GPU but not "kv_cache"
+    allocator.sleep(
+        offload_tags=tuple(),
+        preserve_tags_on_gpu=frozenset({"weights"}),
+    )
+
+    # Checking the internal state of the allocator to ensure "weights" is preserved
+    # and "kv_cache" is not
+    for _ptr, d in allocator.pointer_to_data.items():
+        if d.tag == "weights":
+            assert d.preserved_during_sleep is True
+            assert d.cpu_backup_tensor is None
+        elif d.tag == "kv_cache":
+            assert d.preserved_during_sleep is False
+            assert d.cpu_backup_tensor is None
+
+    allocator.wake_up(None)
+    # The weights tensor should contain 7, proving the weight allocation stayed
+    # valid on the GPU
+    assert torch.all(w == 7)
+    for d in allocator.pointer_to_data.values():
+        assert d.preserved_during_sleep is False
+
+
+@create_new_process_for_each_test()
+def test_sleep_level3_llm_same_greedy_output():
+    """
+    Sleep level 3: weights stay on GPU; greedy decode unchanged after wake_up.
+    End-to-end test with LLM to verify sleep(3) semantics.
+    """
+    model = "hmellor/tiny-random-LlamaForCausalLM"
+    llm = LLM(
+        model=model,
+        enable_sleep_mode=True,
+        enforce_eager=True,
+        max_model_len=512,
+        gpu_memory_utilization=0.05,
+    )
+    prompt = "How are you?"
+    sampling_params = SamplingParams(temperature=0, max_tokens=8)
+    output = llm.generate(prompt, sampling_params)
+    text_before = output[0].outputs[0].text
+
+    torch.accelerator.synchronize()
+
+    # Records free GPU memory
+    free_before, _ = torch.cuda.mem_get_info()
+    llm.sleep(level=3)
+    torch.accelerator.synchronize()
+    free_after, _ = torch.cuda.mem_get_info()
+
+    message = "sleep(3) should return some KV pool VRAM"
+    assert (free_after - free_before) > 0, message
+
+    # Proves that after wake up, the model behaves identally for
+    # deterministic generation
+    llm.wake_up()
+    output2 = llm.generate(prompt, sampling_params)
+    assert output2[0].outputs[0].text == text_before
+
+
+@create_new_process_for_each_test()
+def test_sleep_level3_llm_partial_wake_kv_only():
+    """
+    After sleep(3), wake_up(tags=['kv_cache']) is enough; greedy output unchanged.
+    Tests that after sleep(3) wakeup, the output is the same with deterministic model
+    """
+    model = "hmellor/tiny-random-LlamaForCausalLM"
+    llm = LLM(
+        model=model,
+        enable_sleep_mode=True,
+        enforce_eager=True,
+        max_model_len=512,
+        gpu_memory_utilization=0.05,
+    )
+    prompt = "How are you?"
+    sampling_params = SamplingParams(temperature=0, max_tokens=8)
+    output = llm.generate(prompt, sampling_params)
+    text_before = output[0].outputs[0].text
+
+    # Check if the second generated output is the same as the first one
+    llm.sleep(level=3)
+    llm.wake_up(tags=["kv_cache"])
+    output2 = llm.generate(prompt, sampling_params)
+    assert output2[0].outputs[0].text == text_before
+
+
+@create_new_process_for_each_test("fork" if not current_platform.is_rocm() else "spawn")
+def test_sleep_level3_allocator_frees_less_than_sleep1():
+    """
+    This tests proves that sleep 3 frees less GPU memory than sleep 1
+    Sleep 3 does not free the weights from the GPU memory
+    """
+
+    # creates two large tensors, "weight" and "kv cache"
+    allocator = CuMemAllocator.get_instance()
+    mb = 1024 * 1024
+    size_w = 64 * mb
+    size_kv = 64 * mb
+
+    with allocator.use_memory_pool(tag="weights"):
+        w = torch.empty(size_w, dtype=torch.uint8, device=DEVICE_TYPE)
+    with allocator.use_memory_pool(tag="kv_cache"):
+        kv = torch.empty(size_kv, dtype=torch.uint8, device=DEVICE_TYPE)
+
+    # determine the amount of memory freed during sleep(3)
+    torch.accelerator.synchronize()
+    free_before_s3, _ = torch.cuda.mem_get_info()
+    allocator.sleep(
+        offload_tags=tuple(),
+        preserve_tags_on_gpu=frozenset({"weights"}),
+    )
+    torch.accelerator.synchronize()
+    free_after_s3, _ = torch.cuda.mem_get_info()
+    freed_s3 = (free_after_s3 - free_before_s3) / mb
+
+    allocator.wake_up(None)
+    torch.accelerator.synchronize()
+
+    # determine the amount of memory freed during sleep(1)
+    free_before_s1, _ = torch.cuda.mem_get_info()
+    allocator.sleep(offload_tags=("weights",))
+    torch.accelerator.synchronize()
+    free_after_s1, _ = torch.cuda.mem_get_info()
+    freed_s1 = (free_after_s1 - free_before_s1) / mb
+
+    allocator.wake_up(None)
+    torch.accelerator.synchronize()
+
+    del w, kv
+    gc.collect()
+
+    assert freed_s3 < freed_s1, (
+        f"sleep(3) should free less GPU memory than sleep(1); "
+        f"got {freed_s3:.1f} MB vs {freed_s1:.1f} MB"
+    )
+    assert freed_s3 > size_kv / mb * 0.5, (
+        f"sleep(3) should free a substantial KV-sized amount; got {freed_s3:.1f} MB"
+    )
+    assert freed_s3 < size_w / mb + size_kv / mb * 1.5, (
+        f"sleep(3) should not free weights+KV combined; got {freed_s3:.1f} MB"
+    )

--- a/tests/entrypoints/serve/dev/test_sleep.py
+++ b/tests/entrypoints/serve/dev/test_sleep.py
@@ -6,7 +6,8 @@ from prometheus_client.parser import text_string_to_metric_families
 
 from tests.utils import RemoteOpenAIServer
 
-MODEL_NAME = "meta-llama/Llama-3.2-1B"
+MODEL_NAME = "hmellor/tiny-random-LlamaForCausalLM"
+# "meta-llama/Llama-3.2-1B"
 
 
 def test_sleep_mode():
@@ -81,6 +82,62 @@ def test_sleep_mode():
         response = requests.get(remote_server.url_for("metrics"))
         assert response.status_code == 200
         awake, weights_offloaded, discard_all = _get_sleep_metrics_from_api(response)
+        assert awake == 1
+        assert weights_offloaded == 0
+        assert discard_all == 0
+
+
+def test_sleep_mode_level3_metrics():
+    """
+    Sleep level 3: weights stay on GPU
+    Prometheus gauges match level-3 semantics.
+    """
+    args = [
+        "--dtype",
+        "bfloat16",
+        "--max-model-len",
+        "8192",
+        "--max-num-seqs",
+        "128",
+        "--enable-sleep-mode",
+    ]
+
+    with RemoteOpenAIServer(
+        MODEL_NAME,
+        args,
+        env_dict={"VLLM_SERVER_DEV_MODE": "1", "CUDA_VISIBLE_DEVICES": "0"},
+    ) as remote_server:
+        response = requests.post(remote_server.url_for("sleep"), params={"level": "3"})
+        assert response.status_code == 200
+        response = requests.get(remote_server.url_for("is_sleeping"))
+        assert response.status_code == 200
+        assert response.json().get("is_sleeping") is True
+
+        response = requests.get(remote_server.url_for("metrics"))
+        assert response.status_code == 200
+        awake, weights_offloaded, discard_all = _get_sleep_metrics_from_api(response)
+
+        """
+        For sleep 3:
+        1. after it is sleeping, it should not be awake
+        2. the weights should not be offloaded (since they stay on GPU)
+        3. discard_all should be false since we did not discard the weights
+        """
+        assert awake == 0
+        assert weights_offloaded == 0
+        assert discard_all == 0
+
+        response = requests.post(remote_server.url_for("wake_up"))
+        assert response.status_code == 200
+        response = requests.get(remote_server.url_for("is_sleeping"))
+        assert response.status_code == 200
+        assert response.json().get("is_sleeping") is False
+
+        response = requests.get(remote_server.url_for("metrics"))
+        assert response.status_code == 200
+        awake, weights_offloaded, discard_all = _get_sleep_metrics_from_api(response)
+
+        # Should be awake now
         assert awake == 1
         assert weights_offloaded == 0
         assert discard_all == 0

--- a/vllm/device_allocator/cumem.py
+++ b/vllm/device_allocator/cumem.py
@@ -53,6 +53,8 @@ class AllocationData:
     handle: HandleType
     tag: str
     cpu_backup_tensor: torch.Tensor | None = None
+    # True when sleep() skipped unmap_and_release (e.g. sleep level 3 weights)
+    preserved_during_sleep: bool = False
 
 
 def create_and_map(allocation_handle: HandleType) -> None:
@@ -174,7 +176,12 @@ class CuMemAllocator:
         )
         return data.handle
 
-    def sleep(self, offload_tags: tuple[str, ...] | str | None = None) -> None:
+    def sleep(
+        self,
+        offload_tags: tuple[str, ...] | str | None = None,
+        *,
+        preserve_tags_on_gpu: frozenset[str] | None = None,
+    ) -> None:
         """
         Put the allocator in sleep mode.
         All data in the memory allocation with the specified tag will be
@@ -183,6 +190,8 @@ class CuMemAllocator:
         Args:
             offload_tags: The tags of the memory allocation that will be
                 offloaded. The rest of the memory allocation will be discarded.
+            preserve_tags_on_gpu: If set, allocations with these tags are
+                left mapped on GPU (no backup, no unmap). Used for sleep level 3.
         """
         if offload_tags is None:
             # by default, allocated tensors are offloaded
@@ -198,6 +207,15 @@ class CuMemAllocator:
 
         for ptr, data in self.pointer_to_data.items():
             handle = data.handle
+
+            # by default, all data is not preserved during sleep,
+            # which means it will be discarded/backed up on CPU
+            data.preserved_during_sleep = False
+            # mark the weights on the GPU as preserved during sleep
+            if preserve_tags_on_gpu and data.tag in preserve_tags_on_gpu:
+                data.preserved_during_sleep = True
+                continue
+
             total_bytes += handle[1]
             if data.tag in offload_tags:
                 backup_bytes += handle[1]
@@ -237,9 +255,13 @@ class CuMemAllocator:
                 back to GPU memory.
         """
         for ptr, data in self.pointer_to_data.items():
+            if data.preserved_during_sleep:
+                data.preserved_during_sleep = False
+                continue
             if tags is None or data.tag in tags:
                 handle = data.handle
                 create_and_map(handle)
+
                 if data.cpu_backup_tensor is not None:
                     cpu_backup_tensor = data.cpu_backup_tensor
                     if cpu_backup_tensor is not None:

--- a/vllm/entrypoints/llm.py
+++ b/vllm/entrypoints/llm.py
@@ -824,6 +824,10 @@ class LLM(BeamSearchOfflineMixin, PoolingOfflineMixin, OfflineInferenceMixin):
                            a different model or update the model, where
                            previous model weights are not needed. It reduces
                            CPU memory pressure.
+                - Level 3: Keep model weights on GPU; discard KV cache and
+                           other non-weight pooled memory. No CPU backup of
+                           weights. Useful to reclaim KV VRAM while avoiding
+                           weight offload latency and CPU RAM use.
             mode: How to handle any existing requests, can be "abort", "wait",
                 or "keep".
         """

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -736,6 +736,11 @@ class EngineCore:
             mode: Pause mode - how to deal with any existing requests, see
                 documentation of pause_scheduler method.
         """
+        if level >= 1 and level not in (1, 2, 3):
+            raise ValueError(
+                f"""Invalid sleep level {level}; supported GPU sleep levels are 
+                1, 2, and 3."""
+            )
 
         # Pause scheduler before sleeping.
         clear_prefix_cache = level >= 1

--- a/vllm/v1/executor/abstract.py
+++ b/vllm/v1/executor/abstract.py
@@ -322,7 +322,12 @@ class Executor(ABC):
         time_before_sleep = time.perf_counter()
         self.collective_rpc("sleep", kwargs=dict(level=level))
         time_after_sleep = time.perf_counter()
-        self.sleeping_tags = {"weights", "kv_cache"}
+
+        if level == 3:
+            self.sleeping_tags = {"kv_cache"}
+        else:
+            self.sleeping_tags = {"weights", "kv_cache"}
+
         self.is_sleeping = True
         logger.info(
             "It took %.6f seconds to fall asleep.", time_after_sleep - time_before_sleep

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -497,6 +497,7 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 "awake = 1 means engine is awake; "
                 "weights_offloaded = 1 means sleep level 1; "
                 "discard_all = 1 means sleep level 2."
+                "sleep level 3 leaves both at 0 (weights on GPU, KV discarded)."
             ),
             labelnames=labelnames + ["sleep_state"],
             multiprocess_mode="mostrecent",
@@ -1227,6 +1228,7 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
                 weights_offloaded = 1
             elif level == 2:
                 discard_all = 1
+            # Level 3: weights stay on GPU; neither legacy gauge applies
 
         for engine_idx in self.engine_indexes:
             self.gauge_engine_sleep_state["discard_all"][engine_idx].set(discard_all)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -174,7 +174,22 @@ class Worker(WorkerBase):
             }
 
         allocator = CuMemAllocator.get_instance()
-        allocator.sleep(offload_tags=("weights",) if level == 1 else tuple())
+
+        if level == 1:
+            allocator.sleep(offload_tags=("weights",))
+        elif level == 3:
+            # Keep weights on GPU, discard KV and other pooled allocations
+            allocator.sleep(
+                offload_tags=tuple(),
+                preserve_tags_on_gpu=frozenset(
+                    {
+                        "weights",
+                    }
+                ),
+            )
+        else:
+            allocator.sleep(offload_tags=tuple())
+
         free_bytes_after_sleep, total = torch.cuda.mem_get_info()
         freed_bytes = free_bytes_after_sleep - free_bytes_before_sleep
         used_bytes = total - free_bytes_after_sleep


### PR DESCRIPTION



## Purpose
Sleep Mode Level 3: GPU-Resident Weights with Selective Memory Discard

Sleep Mode Level 3 introduces a hybrid memory strategy designed to minimize wake latency while still reclaiming a meaningful portion of GPU memory. In this mode, model weights remain resident (mapped and ready) on the GPU, while non-essential allocations (such as the KV cache and other discardable memory pools) are released during sleep.

Unlike lower sleep levels (e.g., Levels 1 and 2), which may offload weights to CPU memory or fully deallocate GPU resources, Level 3 avoids the costly step of reloading or reconstructing model weights on wake. This significantly reduces cold start latency, since the largest and most time-consuming data (the weights) are already present on the GPU.

At the same time, by discarding transient data like the KV cache, Level 3 still frees up GPU memory that would otherwise remain occupied. These structures can be rebuilt quickly when the model resumes, making the tradeoff favorable in scenarios where responsiveness is critical but some memory pressure relief is still needed.

## Test Plan
Run:
```bash
pytest -q tests/basic_correctness/test_cumem.py
pytest -q tests/entrypoints/serve/instrumentator/test_sleep.py
```

The tests were added to test_cumem.py and test_sleep.py

In test_cumem.py:
1. Verify weights remain preserved/mapped while kv_cache is discarded after sleep(3)
2. Verify deterministic greedy output is unchanged across sleep(3) -> wake_up()
3. Verify partial wake (wake_up(tags=["kv_cache"])) after sleep(3) is sufficient for correctness
4. Verify sleep(3) frees less GPU memory than sleep(1) (since weights remain on GPU)

In test_sleep.py:
1. Verify sleep(3) metrics/state reflect weights not offloaded and discard_all = false

## Test Result

Below are pasted results from calling

python -m pytest tests/basic_correctness/test_cumem.py -v

================================================================== test session starts ==================================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /file path
cachedir: .pytest_cache
rootdir: --redacted--
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 12 items                                                                                                                                      

tests/basic_correctness/test_cumem.py::test_python_error PASSED                                                                                   [  8%]
tests/basic_correctness/test_cumem.py::test_basic_cumem PASSED                                                                                    [ 16%]
tests/basic_correctness/test_cumem.py::test_cumem_with_cudagraph PASSED                                                                           [ 25%]
tests/basic_correctness/test_cumem.py::test_end_to_end[hmellor/tiny-random-LlamaForCausalLM] PASSED                                               [ 33%]
tests/basic_correctness/test_cumem.py::test_end_to_end[facebook/opt-125m] PASSED                                                                  [ 41%]
tests/basic_correctness/test_cumem.py::test_deep_sleep PASSED                                                                                     [ 50%]
tests/basic_correctness/test_cumem.py::test_deep_sleep_async PASSED                                                                               [ 58%]
tests/basic_correctness/test_cumem.py::test_deep_sleep_fp8_kvcache SKIPPED (FP8 is not supported on this GPU (requires Hopper or Ada architec...) [ 66%]
tests/basic_correctness/test_cumem.py::test_sleep_level3_preserves_weights_tag PASSED                                                             [ 75%]
tests/basic_correctness/test_cumem.py::test_sleep_level3_llm_same_greedy_output PASSED                                                            [ 83%]
tests/basic_correctness/test_cumem.py::test_sleep_level3_llm_partial_wake_kv_only PASSED                                                          [ 91%]
tests/basic_correctness/test_cumem.py::test_sleep_level3_allocator_frees_less_than_sleep1 PASSED                                                  [100%]

Below are pasted results from calling

python -m pytest tests/entrypoints/serve/instrumentator/test_sleep.py -v

================================================================== test session starts ==================================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0 -- /file path
cachedir: .pytest_cache
rootdir:--redacted--
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 2 items                                                                                                                                       

tests/entrypoints/serve/instrumentator/test_sleep.py::test_sleep_mode PASSED                                                                      [ 50%]
tests/entrypoints/serve/instrumentator/test_sleep.py::test_sleep_mode_level3_metrics PASSED                                                       [100%]

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

