### PR TITLE
[Benchmark] Support multi-image requests in multimodal samplers

### DIFF
--- a/tests/benchmarks/test_multi_image_dataset.py
+++ b/tests/benchmarks/test_multi_image_dataset.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for multi-image support in benchmark dataset samplers.
+
+These tests are pure-Python and never instantiate an engine, model, or
+network call — they monkeypatch ``self.data`` on the dataset instances and
+exercise only the sampler logic.
+"""
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from PIL import Image
+
+from vllm.benchmarks.datasets import (
+    CustomMMDataset,
+    SampleRequest,
+    VisionArenaDataset,
+)
+from vllm.benchmarks.datasets.datasets import BenchmarkDataset
+
+# These tests are pure-Python and never initialize torch / a device
+# allocator, so the autouse global-cleanup fixture in tests/conftest.py
+# (which exists for tests that load models or allocate GPU memory) is
+# unnecessary here. Skipping it follows the convention documented on
+# `should_do_global_cleanup_after_test` in tests/conftest.py and gives a
+# ~10x speedup for non-GPU unit tests.
+pytestmark = [pytest.mark.benchmark, pytest.mark.skip_global_cleanup]
+
+
+class _ConcreteBenchmarkDataset(BenchmarkDataset):
+    """Concrete BenchmarkDataset subclass for unit-testing helpers."""
+
+    def sample(self, *args, **kwargs):  # type: ignore[override]
+        raise NotImplementedError
+
+
+def _tiny_image() -> Image.Image:
+    return Image.new("RGB", (8, 8), color=(255, 0, 0))
+
+
+def _fake_tokenizer() -> Any:
+    """Tokenizer stub matching the two interfaces the samplers use."""
+    tok = MagicMock()
+    tok.encode.side_effect = lambda s: [0] * max(len(s), 1)
+    tok.return_value = MagicMock(input_ids=[0, 0, 0])
+    return tok
+
+
+def _make_vision_arena_dataset(items: list[dict]) -> VisionArenaDataset:
+    """Build a VisionArenaDataset without triggering HF download."""
+    inst = VisionArenaDataset.__new__(VisionArenaDataset)
+    # Required attrs that __init__ would normally set:
+    inst.dataset_path = "lmarena-ai/VisionArena-Chat"
+    inst.hf_name = "lmarena-ai/VisionArena-Chat"
+    inst.dataset_split = "train"
+    inst.dataset_subset = None
+    inst.load_stream = False
+    inst.trust_remote_code = False
+    inst.random_seed = 0
+    inst.disable_shuffle = True
+    inst.data = items
+    return inst
+
+
+def _make_custom_mm_dataset(items: list[dict]) -> CustomMMDataset:
+    inst = CustomMMDataset.__new__(CustomMMDataset)
+    inst.dataset_path = "test.jsonl"
+    inst.random_seed = 0
+    inst.disable_shuffle = True
+    inst.data = items
+    return inst
+
+
+def _va_item(prompt: str, num_images: int) -> dict:
+    """Build a VisionArena-Chat-shaped item with N images."""
+    return {
+        "conversation": [[{"content": prompt, "role": "user"}]],
+        "images": [_tiny_image() for _ in range(num_images)],
+    }
+
+
+def _custom_mm_item(prompt: str, num_images: int) -> dict:
+    return {
+        "prompt": prompt,
+        # CustomMMDataset accepts string paths/URLs; use data: URLs to skip I/O.
+        "image_files": ["data:image/jpeg;base64,/9j/AAA=" for _ in range(num_images)],
+    }
+
+
+@pytest.mark.benchmark
+def test_vision_arena_single_image_yields_dict() -> None:
+    """Default cap=1 + single-image item → mm_content is a dict (back-compat)."""
+    ds = _make_vision_arena_dataset([_va_item("hello", 1)])
+    out = ds.sample(tokenizer=_fake_tokenizer(), num_requests=1, output_len=8)
+    assert len(out) == 1
+    assert isinstance(out[0].multi_modal_data, dict)
+    assert out[0].multi_modal_data["type"] == "image_url"
+
+
+@pytest.mark.benchmark
+def test_vision_arena_multi_image_capped_to_one_by_default() -> None:
+    """Without limit_mm_per_prompt, a 3-image item still produces a single dict."""
+    ds = _make_vision_arena_dataset([_va_item("hello", 3)])
+    out = ds.sample(tokenizer=_fake_tokenizer(), num_requests=1, output_len=8)
+    assert isinstance(out[0].multi_modal_data, dict)
+
+
+@pytest.mark.benchmark
+def test_vision_arena_multi_image_emits_list_when_cap_raised() -> None:
+    """With limit_mm_per_prompt={'image': 4}, a 3-image item → list of 3 dicts."""
+    ds = _make_vision_arena_dataset([_va_item("hello", 3)])
+    out = ds.sample(
+        tokenizer=_fake_tokenizer(),
+        num_requests=1,
+        output_len=8,
+        limit_mm_per_prompt={"image": 4},
+    )
+    mm = out[0].multi_modal_data
+    assert isinstance(mm, list)
+    assert len(mm) == 3
+    assert all(isinstance(item, dict) for item in mm)
+    assert all(item["type"] == "image_url" for item in mm)
+
+
+@pytest.mark.benchmark
+def test_vision_arena_cap_truncates_excess_images() -> None:
+    """Cap of 2 against a 5-image item yields a list of exactly 2."""
+    ds = _make_vision_arena_dataset([_va_item("hello", 5)])
+    out = ds.sample(
+        tokenizer=_fake_tokenizer(),
+        num_requests=1,
+        output_len=8,
+        limit_mm_per_prompt={"image": 2},
+    )
+    mm = out[0].multi_modal_data
+    assert isinstance(mm, list)
+    assert len(mm) == 2
+
+
+@pytest.mark.benchmark
+def test_vision_arena_cap_one_collapses_to_dict() -> None:
+    """Even with explicit cap=1, the result is a dict (not a 1-element list)."""
+    ds = _make_vision_arena_dataset([_va_item("hello", 3)])
+    out = ds.sample(
+        tokenizer=_fake_tokenizer(),
+        num_requests=1,
+        output_len=8,
+        limit_mm_per_prompt={"image": 1},
+    )
+    assert isinstance(out[0].multi_modal_data, dict)
+
+
+@pytest.mark.benchmark
+def test_vision_arena_cap_zero_yields_no_mm_content() -> None:
+    """A cap of 0 disables image attachment; mm_content is None."""
+    ds = _make_vision_arena_dataset([_va_item("hello", 3)])
+    out = ds.sample(
+        tokenizer=_fake_tokenizer(),
+        num_requests=1,
+        output_len=8,
+        limit_mm_per_prompt={"image": 0},
+    )
+    assert out[0].multi_modal_data is None
+
+
+@pytest.mark.benchmark
+def test_custom_mm_multi_image_emits_list() -> None:
+    """CustomMMDataset emits list[dict] for >1 image when cap allows it."""
+    ds = _make_custom_mm_dataset([_custom_mm_item("describe the images", 3)])
+    out = ds.sample(
+        tokenizer=_fake_tokenizer(),
+        num_requests=1,
+        output_len=8,
+        limit_mm_per_prompt={"image": 8},
+    )
+    mm = out[0].multi_modal_data
+    assert isinstance(mm, list)
+    assert len(mm) == 3
+
+
+@pytest.mark.benchmark
+def test_custom_mm_default_cap_preserves_single_image_shape() -> None:
+    """CustomMMDataset default cap=1 collapses multi-image input to a dict."""
+    ds = _make_custom_mm_dataset([_custom_mm_item("describe", 4)])
+    out = ds.sample(tokenizer=_fake_tokenizer(), num_requests=1, output_len=8)
+    assert isinstance(out[0].multi_modal_data, dict)
+
+
+@pytest.mark.benchmark
+def test_sample_request_type_contract_is_respected() -> None:
+    """Every emitted multi_modal_data is None, dict, or list[dict]."""
+    ds = _make_vision_arena_dataset(
+        [
+            _va_item("p1", 1),
+            _va_item("p2", 2),
+            _va_item("p3", 4),
+        ]
+    )
+    out = ds.sample(
+        tokenizer=_fake_tokenizer(),
+        num_requests=3,
+        output_len=8,
+        limit_mm_per_prompt={"image": 3},
+    )
+    for req in out:
+        mm = req.multi_modal_data
+        assert (
+            mm is None
+            or isinstance(mm, dict)
+            or (isinstance(mm, list) and all(isinstance(x, dict) for x in mm))
+        )
+
+
+@pytest.mark.benchmark
+def test_chat_transformation_round_trip_with_list() -> None:
+    """apply_multimodal_chat_transformation correctly unfolds a list of mm dicts."""
+    base = _ConcreteBenchmarkDataset.__new__(_ConcreteBenchmarkDataset)
+    mm_list = [
+        {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,A"}},
+        {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,B"}},
+        {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,C"}},
+    ]
+    chat = base.apply_multimodal_chat_transformation("describe the images", mm_list)
+    assert isinstance(chat, list)
+    assert len(chat) == 1
+    assert chat[0]["role"] == "user"
+    content = chat[0]["content"]
+    # 1 text block + 3 image blocks, in order.
+    assert len(content) == 4
+    assert content[0] == {"text": "describe the images", "type": "text"}
+    assert content[1:] == mm_list
+
+
+@pytest.mark.benchmark
+def test_throughput_prompt_builder_accepts_list_form() -> None:
+    """Mirror the throughput.py prompt-build assertion for the list-form path.
+
+    The on-engine code at vllm/benchmarks/throughput.py does:
+        if request.multi_modal_data:
+            assert isinstance(request.multi_modal_data, (dict, list))
+            prompt["multi_modal_data"] = request.multi_modal_data
+    This test re-runs that check against a synthetic list-form SampleRequest.
+    """
+    req = SampleRequest(
+        prompt="x",
+        prompt_len=1,
+        expected_output_len=1,
+        multi_modal_data=[
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,A"}},
+            {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,B"}},
+        ],
+    )
+    if req.multi_modal_data:
+        assert isinstance(req.multi_modal_data, (dict, list))
+    # Confirm dict form still passes.
+    req_dict = SampleRequest(
+        prompt="x",
+        prompt_len=1,
+        expected_output_len=1,
+        multi_modal_data={
+            "type": "image_url",
+            "image_url": {"url": "data:image/jpeg;base64,A"},
+        },
+    )
+    if req_dict.multi_modal_data:
+        assert isinstance(req_dict.multi_modal_data, (dict, list))

--- a/vllm/benchmarks/datasets/datasets.py
+++ b/vllm/benchmarks/datasets/datasets.py
@@ -1825,6 +1825,7 @@ def get_samples(args, tokenizer: TokenizerLike) -> list[SampleRequest]:
             enable_multimodal_chat=args.enable_multimodal_chat,
             request_id_prefix=args.request_id_prefix,
             no_oversample=args.no_oversample,
+            limit_mm_per_prompt=getattr(args, "random_mm_limit_mm_per_prompt", None),
         )
 
     elif args.dataset_name == "sonnet":
@@ -1869,6 +1870,9 @@ def get_samples(args, tokenizer: TokenizerLike) -> list[SampleRequest]:
             dataset_class = VisionArenaDataset
             args.hf_split = args.hf_split if args.hf_split else "train"
             args.hf_subset = None
+            hf_kwargs["limit_mm_per_prompt"] = getattr(
+                args, "random_mm_limit_mm_per_prompt", None
+            )
         elif (
             args.dataset_path in MMVUDataset.SUPPORTED_DATASET_PATHS
             or args.hf_name in MMVUDataset.SUPPORTED_DATASET_PATHS
@@ -2260,7 +2264,8 @@ class CustomMMDataset(CustomDataset):
     }
     ```
 
-    NOTE: Only the first image file in "image_files" is used for each sample request.
+    NOTE: All images in "image_files" are used per request, capped by
+    ``limit_mm_per_prompt["image"]`` (default 1 for back-compat).
 
     This is used to benchmark multimodal LLMs on arbitrary datasets.
     """
@@ -2275,6 +2280,7 @@ class CustomMMDataset(CustomDataset):
         enable_multimodal_chat: bool = False,
         request_id_prefix: str = "",
         no_oversample: bool = False,
+        limit_mm_per_prompt: dict[str, int] | None = None,
         **kwargs,
     ) -> list[SampleRequest]:
         # load all data if needed
@@ -2287,6 +2293,8 @@ class CustomMMDataset(CustomDataset):
                 num_requests,
             )
 
+        image_cap = (limit_mm_per_prompt or {}).get("image", 1)
+
         sampled_requests = []
         for i, item in enumerate(self.data):
             if len(sampled_requests) >= num_requests:
@@ -2294,14 +2302,14 @@ class CustomMMDataset(CustomDataset):
             prompt = item["prompt"]
 
             prompt_len = len(tokenizer(prompt).input_ids)
-            images = item["image_files"]
-            if len(images) > 1:
-                logger.warning(
-                    "Multiple image files found for sample %d. "
-                    "Only the first image will be used.",
-                    i,
-                )
-            mm_content = process_image(images[0])
+            raw_images = item["image_files"][:image_cap] if image_cap > 0 else []
+            mm_items = [process_image(img) for img in raw_images]
+            if not mm_items:
+                mm_content = None
+            elif len(mm_items) == 1:
+                mm_content = mm_items[0]
+            else:
+                mm_content = mm_items
             if enable_multimodal_chat:
                 # Note: when chat is enabled the request prompt_len is no longer
                 # accurate and we will be using request output to count the
@@ -2735,6 +2743,7 @@ class VisionArenaDataset(HuggingFaceDataset):
         no_oversample: bool = False,
         output_len: int | None = None,
         enable_multimodal_chat: bool = False,
+        limit_mm_per_prompt: dict[str, int] | None = None,
         **kwargs,
     ) -> list[SampleRequest]:
         parser_fn = self.SUPPORTED_DATASET_PATHS.get(self.hf_name)
@@ -2742,6 +2751,7 @@ class VisionArenaDataset(HuggingFaceDataset):
             raise ValueError(f"Unsupported dataset path: {self.hf_name}")
 
         output_len = output_len if output_len is not None else self.DEFAULT_OUTPUT_LEN
+        image_cap = (limit_mm_per_prompt or {}).get("image", 1)
 
         sampled_requests = []
         for i, item in enumerate(self.data):
@@ -2749,7 +2759,14 @@ class VisionArenaDataset(HuggingFaceDataset):
                 break
 
             prompt = parser_fn(item)
-            mm_content = process_image(item["images"][0])
+            raw_images = item["images"][:image_cap] if image_cap > 0 else []
+            mm_items = [process_image(img) for img in raw_images]
+            if not mm_items:
+                mm_content = None
+            elif len(mm_items) == 1:
+                mm_content = mm_items[0]
+            else:
+                mm_content = mm_items
             prompt_len = len(tokenizer.encode(prompt))
             if enable_multimodal_chat:
                 # Note: when chat is enabled the request prompt_len is no longer

--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -72,7 +72,7 @@ def run_vllm(
             else TextPrompt(prompt=request.prompt)
         )
         if request.multi_modal_data:
-            assert isinstance(request.multi_modal_data, dict)
+            assert isinstance(request.multi_modal_data, (dict, list))
             prompt["multi_modal_data"] = request.multi_modal_data
         prompts.append(prompt)
 
@@ -213,7 +213,7 @@ async def run_vllm_async(
             )
 
             if request.multi_modal_data:
-                assert isinstance(request.multi_modal_data, dict)
+                assert isinstance(request.multi_modal_data, (dict, list))
                 prompt["multi_modal_data"] = request.multi_modal_data
 
             sampling_params.append(
@@ -398,6 +398,9 @@ def get_requests(args, tokenizer):
             common_kwargs["dataset_subset"] = None
             common_kwargs["dataset_split"] = "train"
             sample_kwargs["enable_multimodal_chat"] = True
+            sample_kwargs["limit_mm_per_prompt"] = getattr(
+                args, "random_mm_limit_mm_per_prompt", None
+            )
         elif args.dataset_path in InstructCoderDataset.SUPPORTED_DATASET_PATHS:
             dataset_cls = InstructCoderDataset
             common_kwargs["dataset_split"] = "train"


### PR DESCRIPTION



## Purpose
The multimodal HF/custom dataset samplers (`VisionArenaDataset`, `CustomMMDataset`) previously discarded all but the first image per source item, even though `SampleRequest.multi_modal_data` is typed `dict | list[dict] | None` and the chat-format helper, OpenAI request func, and serve.py validation already accept the list form.

This change:
- VisionArenaDataset.sample and CustomMMDataset.sample now emit list[dict] when an item carries multiple images, capped by limit_mm_per_prompt["image"]. Default cap remains 1 for back-compat; single-image items still produce a dict.
- Relaxes two `assert isinstance(..., dict)` guards in throughput.py so list-form requests survive the vllm / vllm-async backends.
- Forwards --random-mm-limit-mm-per-prompt to the multimodal HF/custom samplers (previously only honored on the random-mm path).


## Test Plan
- tests/benchmarks/test_multi_image_dataset.py: 11 new unit tests covering sampler shape across 1/2/3 source images and caps 0/1/2/3/4, back-compat dict shape, chat-transform list round-trip, and the throughput.py prompt-build assertion path. All pass.
- pre-commit run --files <changed> green (ruff, ruff-format, mypy, SPDX, all hooks).

- E2E against a vanilla vllm serve Qwen/Qwen2.5-VL-7B-Instruct endpoint (engine --limit-mm-per-prompt image= is ≥10).
- Dataset (/tmp/multi_image.jsonl, two prompts):
```
  {"prompt": "Describe these images.", "image_files": ["https://picsum.photos/256?1", "https://picsum.photos/256?2", "https://picsum.photos/256?3"]}
  {"prompt": "Compare the images.", "image_files": ["https://picsum.photos/256?4", "https://picsum.photos/256?5"]}
```

```
    --backend openai-chat \
    --base-url <endpoint> \
    --model Qwen/Qwen2.5-VL-7B-Instruct \
    --endpoint /v1/chat/completions \
    --dataset-name custom_mm \
    --dataset-path /tmp/multi_image.jsonl \
    --num-prompts 2 \
    --random-mm-limit-mm-per-prompt '{"image": 1}' \
    --disable-shuffle \
    --save-result --result-dir /tmp --result-filename cap1.json
```

## Test Result

 | Run | `--random-mm-limit-mm-per-prompt` | Prompts | Images sent | `completed` | `total_input_tokens` |
  |-----|-----------------------------------|---------|-------------|-------------|----------------------|
  | A   | `{"image": 1}`                    | 2       | 2 (1+1)     | 2 / 2       | **212**              |
  | B   | `{"image": 3}`                    | 2       | 5 (3+2)     | 2 / 2       | **461**              |
  | C   | `{"image": 10}`                   | 1       | 10          | 1 / 1       | **857**              |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

