### PR TITLE
[WIP][New Model] Add A100/SM80 support for DeepSeek V4 Flash

### DIFF
--- a/csrc/libtorch_stable/quantization/fp4/nvfp4_quant_entry.cu
+++ b/csrc/libtorch_stable/quantization/fp4/nvfp4_quant_entry.cu
@@ -173,3 +173,40 @@ void silu_and_mul_scaled_fp4_experts_quant(
   STD_TORCH_CHECK_NOT_IMPLEMENTED(
       false, "No compiled silu_and_mul nvfp4 experts quantization kernel");
 }
+
+// MXFP4 stubs for archs that don't have a compiled MXFP4 kernel
+// (`csrc/libtorch_stable/quantization/fp4/mxfp4_experts_quant.cu` is gated to
+// SM 10.x in CMakeLists.txt). On other archs (e.g. A100 SM 8.0) the real
+// definition is absent but `torch_bindings.cpp:255-257` still references
+// `&mxfp4_experts_quant` / `&silu_and_mul_mxfp4_experts_quant` unconditionally,
+// causing the `_C_stable_libtorch.abi3.so` link to leave undefined symbols
+// (server crash on import: "undefined symbol: _Z19mxfp4_experts_quant…").
+//
+// Without these stubs, vLLM cannot import on SM 8.0 — irrespective of whether
+// MXFP4 is actually invoked at runtime. The stubs throw NOT_IMPLEMENTED so a
+// caller that tries to use MXFP4 on an unsupported arch gets a clear error
+// instead of a segfault.
+void mxfp4_experts_quant(
+    torch::stable::Tensor& output, torch::stable::Tensor& output_scale,
+    torch::stable::Tensor const& input,
+    torch::stable::Tensor const& input_offset_by_experts,
+    torch::stable::Tensor const& output_scale_offset_by_experts,
+    int64_t n_experts) {
+  STD_TORCH_CHECK_NOT_IMPLEMENTED(
+      false, "No compiled mxfp4 experts quantization kernel for SM ",
+      get_sm_version_num(),
+      ". Recompile with SM 10.x (Blackwell) for MXFP4 support.");
+}
+
+void silu_and_mul_mxfp4_experts_quant(
+    torch::stable::Tensor& output, torch::stable::Tensor& output_scale,
+    torch::stable::Tensor const& input,
+    torch::stable::Tensor const& input_offset_by_experts,
+    torch::stable::Tensor const& output_scale_offset_by_experts,
+    int64_t n_experts) {
+  STD_TORCH_CHECK_NOT_IMPLEMENTED(
+      false,
+      "No compiled silu_and_mul mxfp4 experts quantization kernel for SM ",
+      get_sm_version_num(),
+      ". Recompile with SM 10.x (Blackwell) for MXFP4 support.");
+}

--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -140,7 +140,8 @@ Priority is **1 = highest** (tried first).
 | 2 | `FLASHMLA` |
 | 3 | `FLASHINFER_MLA` |
 | 4 | `TRITON_MLA` |
-| 5 | `FLASHMLA_SPARSE` |
+| 5 | `TRITON_MLA_SPARSE` |
+| 6 | `FLASHMLA_SPARSE` |
 
 > **\*** For sparse MLA, FP8 KV cache always prefers `FLASHINFER_MLA_SPARSE`. With BF16 KV cache, `FLASHINFER_MLA_SPARSE` is preferred for low query-head counts (<= 16), while `FLASHMLA_SPARSE` is preferred otherwise.
 >
@@ -219,4 +220,5 @@ configuration.
 | `ROCM_AITER_MLA_SPARSE` | fp16, bf16 | `auto`, `float16`, `bfloat16` | 1 | Any | ❌ | ✅ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_AITER_TRITON_MLA` | fp16, bf16 | `auto` | Any | Any | ❌ | ❌ | ❌ | ❌ | Decoder | N/A |
 | `TRITON_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | %16 | Any | ❌ | ❌ | ❌ | ✅ | Decoder | Any |
+| `TRITON_MLA_SPARSE` | fp16, bf16 | `auto`, `float16`, `bfloat16` | Any | Any | ❌ | ✅ | ❌ | ❌ | Decoder | Any |
 | `XPU_MLA_SPARSE` | fp16, bf16 | `auto`, `float16`, `bfloat16` | Any | 576 | ❌ | ✅ | ❌ | ❌ | Decoder | Any |

--- a/tests/kernels/attention/test_mqa_logits_triton.py
+++ b/tests/kernels/attention/test_mqa_logits_triton.py
@@ -1,0 +1,257 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness tests for the Triton MQA logits kernels."""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.utils.math_utils import cdiv
+from vllm.v1.attention.ops.mqa_logits_triton import (
+    fp8_mqa_logits_triton,
+    fp8_paged_mqa_logits_triton,
+)
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Triton MQA logits kernels require CUDA/ROCm",
+)
+
+
+def _quantize_k_per_row(
+    k_bf16: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    amax = k_bf16.abs().float().amax(dim=-1, keepdim=True).clamp_min(1e-4)
+    sf = amax / 448.0
+    k_fp8 = (k_bf16.float() / sf).to(torch.float8_e4m3fn)
+    return k_fp8, sf.squeeze(-1)
+
+
+def _pack_paged_kv(kv_bf16: torch.Tensor) -> torch.Tensor:
+    """Pack BF16 KV into the layout produced by `indexer_k_quant_and_cache`.
+
+    Physical bytes per block are segregated: all `block_size * head_dim` fp8 K
+    bytes first, then `block_size * 4` fp32 scale bytes. The outer
+    `[NB, BS, 1, D+4]` shape matches the production cache allocation.
+    """
+    num_blocks, block_size, head_dim = kv_bf16.shape
+    amax = kv_bf16.abs().float().amax(dim=-1, keepdim=True).clamp_min(1e-4)
+    sf = (amax / 448.0).to(torch.float32)
+    k_fp8 = (kv_bf16.float() / sf).to(torch.float8_e4m3fn)
+    packed = torch.empty(
+        (num_blocks, block_size, 1, head_dim + 4),
+        dtype=torch.uint8,
+        device=kv_bf16.device,
+    )
+    flat = packed.view(num_blocks, -1)
+    k_end = block_size * head_dim
+    flat[:, :k_end] = k_fp8.reshape(num_blocks, -1).view(torch.uint8)
+    flat[:, k_end:] = sf.reshape(num_blocks, -1).view(torch.uint8)
+    return packed
+
+
+# References adapted from DeepGEMM (test_attention.py) — used as the spec
+# the Triton kernels must agree with.
+def _fp8_mqa_logits_ref(
+    q: torch.Tensor,
+    kv: tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+) -> torch.Tensor:
+    k_fp8, scale = kv
+    seq_len_kv = k_fp8.shape[0]
+    k = k_fp8.to(torch.bfloat16)
+    q = q.to(torch.bfloat16)
+    arange = torch.arange(0, seq_len_kv, device=q.device)[None, :]
+    mask = (arange >= cu_seqlen_ks[:, None]) & (arange < cu_seqlen_ke[:, None])
+    score = torch.einsum("mhd,nd->hmn", q, k).float() * scale
+    logits = (score.relu() * weights.unsqueeze(-1).transpose(0, 1)).sum(dim=0)
+    return logits.masked_fill(~mask, float("-inf"))
+
+
+def _fp8_paged_mqa_logits_ref(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    max_model_len: int,
+) -> torch.Tensor:
+    fp8_dtype = torch.float8_e4m3fn
+    batch_size, next_n, _, dim = q.size()
+    num_blocks, block_size = kv_cache.shape[0], kv_cache.shape[1]
+    flat = kv_cache.view(num_blocks, -1)
+    k_end = block_size * dim
+    kv_data = (
+        flat[:, :k_end].reshape(num_blocks, block_size, 1, dim).view(fp8_dtype).float()
+    )
+    scale = flat[:, k_end:].view(torch.float32).reshape(num_blocks, block_size, 1, 1)
+    q = q.float()
+    kv_data = kv_data * scale
+    logits = torch.full(
+        [batch_size * next_n, max_model_len],
+        float("-inf"),
+        device=q.device,
+        dtype=torch.float32,
+    )
+    context_lens_list = context_lens.tolist()
+    for i in range(batch_size):
+        context_len = context_lens_list[i]
+        q_offsets = torch.arange(context_len - next_n, context_len, device=q.device)
+        weight_slice = (
+            weights[i * next_n : (i + 1) * next_n, :].transpose(0, 1).contiguous()
+        )
+        for block_rk in range(cdiv(context_len, block_size)):
+            block_idx = block_tables[i][block_rk]
+            qx, kx = q[i], kv_data[block_idx]
+            k_offsets = torch.arange(
+                block_rk * block_size,
+                (block_rk + 1) * block_size,
+                device=q.device,
+            )
+            mask = (k_offsets[None, :] < context_len) & (
+                k_offsets[None, :] <= q_offsets[:, None]
+            )
+            s = torch.where(
+                mask[None, :, :],
+                (qx.transpose(0, 1) @ kx.transpose(0, 1).transpose(1, 2)).to(
+                    logits.dtype
+                ),
+                float("-inf"),
+            )
+            s = (torch.relu(s) * weight_slice[..., None]).sum(dim=0)
+            logits[
+                i * next_n : (i + 1) * next_n,
+                block_rk * block_size : (block_rk + 1) * block_size,
+            ] = torch.where(k_offsets[None, :] <= q_offsets[:, None], s, float("-inf"))
+    return logits
+
+
+# Looser tolerance to accommodate FP8 rounding and the paged torch
+# reference using fp32 matmul while the triton kernel uses bf16 matmul
+# (with an fp32 accumulator, matching the DeepGEMM path).
+_ATOL = 1.0
+_RTOL = 0.2
+
+
+@pytest.mark.parametrize("M,N", [(64, 64), (128, 256), (256, 512)])
+@pytest.mark.parametrize("num_heads", [16, 32])
+@pytest.mark.parametrize("partial_mask", [False, True])
+def test_fp8_mqa_logits_triton_matches_torch(M, N, num_heads, partial_mask):
+    torch.manual_seed(0)
+    head_dim = 128
+    device = "cuda"
+
+    q_bf16 = torch.randn(M, num_heads, head_dim, dtype=torch.bfloat16, device=device)
+    k_bf16 = torch.randn(N, head_dim, dtype=torch.bfloat16, device=device)
+    weights = torch.randn(M, num_heads, dtype=torch.float32, device=device)
+    q_fp8 = q_bf16.to(torch.float8_e4m3fn)
+    k_fp8, k_scales = _quantize_k_per_row(k_bf16)
+
+    if partial_mask:
+        # Exercise the non-trivial ks/ke masking branch (chunked prefill).
+        ks = torch.arange(M, dtype=torch.int32, device=device) % (N // 4)
+        ke = ks + torch.randint(1, N // 2, (M,), dtype=torch.int32, device=device)
+        ke = torch.minimum(ke, torch.tensor(N, dtype=torch.int32, device=device))
+    else:
+        ks = torch.zeros(M, dtype=torch.int32, device=device)
+        ke = torch.full((M,), N, dtype=torch.int32, device=device)
+
+    out_torch = _fp8_mqa_logits_ref(q_fp8, (k_fp8, k_scales), weights, ks, ke)
+    out_triton = fp8_mqa_logits_triton(q_fp8, (k_fp8, k_scales), weights, ks, ke)
+
+    assert torch.equal(
+        torch.isinf(out_torch) & (out_torch < 0),
+        torch.isinf(out_triton) & (out_triton < 0),
+    )
+    finite = ~torch.isinf(out_torch)
+    if finite.any():
+        torch.testing.assert_close(
+            out_triton[finite],
+            out_torch[finite],
+            atol=_ATOL,
+            rtol=_RTOL,
+        )
+
+
+@pytest.mark.parametrize(
+    "batch_size,next_n,context_len",
+    [
+        (1, 1, 128),
+        (1, 1, 512),
+        (2, 1, 256),
+        (1, 4, 512),  # speculative decoding with next_n=4
+    ],
+)
+@pytest.mark.parametrize("num_heads", [16, 32])
+def test_fp8_paged_mqa_logits_triton_matches_torch(
+    batch_size, next_n, context_len, num_heads
+):
+    torch.manual_seed(0)
+    head_dim = 128
+    block_size = 64
+    device = "cuda"
+
+    total_blocks = 64
+    max_blocks = (context_len + block_size - 1) // block_size + 4
+
+    kv_bf16 = torch.randn(
+        total_blocks, block_size, head_dim, dtype=torch.bfloat16, device=device
+    )
+    kv_packed = _pack_paged_kv(kv_bf16)
+
+    q_fp8 = torch.randn(
+        batch_size,
+        next_n,
+        num_heads,
+        head_dim,
+        dtype=torch.bfloat16,
+        device=device,
+    ).to(torch.float8_e4m3fn)
+
+    weights = torch.randn(
+        batch_size * next_n, num_heads, dtype=torch.float32, device=device
+    )
+
+    context_lens = torch.full(
+        (batch_size,), context_len, dtype=torch.int32, device=device
+    )
+    block_tables = torch.randint(
+        0,
+        total_blocks,
+        (batch_size, max_blocks),
+        dtype=torch.int32,
+        device=device,
+    )
+
+    max_model_len = max_blocks * block_size
+
+    out_torch = _fp8_paged_mqa_logits_ref(
+        q_fp8,
+        kv_packed,
+        weights,
+        context_lens,
+        block_tables,
+        max_model_len,
+    )
+    out_triton = fp8_paged_mqa_logits_triton(
+        q_fp8,
+        kv_packed,
+        weights,
+        context_lens,
+        block_tables,
+        max_model_len,
+    )
+
+    inf_torch = torch.isinf(out_torch) & (out_torch < 0)
+    inf_triton = torch.isinf(out_triton) & (out_triton < 0)
+    assert torch.equal(inf_torch, inf_triton)
+    finite = ~inf_torch
+    if finite.any():
+        torch.testing.assert_close(
+            out_triton[finite],
+            out_torch[finite],
+            atol=_ATOL,
+            rtol=_RTOL,
+        )

--- a/tests/kernels/attention/test_triton_sparse_mla_kernel.py
+++ b/tests/kernels/attention/test_triton_sparse_mla_kernel.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Correctness tests for the Triton sparse MLA kernel.
+
+Compares split-KV against the single-pass (`num_kv_splits=1`) path
+produced by the same kernel — both paths must agree to within bf16 ULPs.
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.attention.ops.triton_sparse_mla_kernel import (
+    _DIM_QK,
+    triton_sparse_mla_attention,
+)
+
+pytestmark = pytest.mark.skipif(
+    not current_platform.is_cuda_alike(),
+    reason="Triton sparse MLA kernel requires CUDA/ROCm",
+)
+
+
+@pytest.fixture(scope="module")
+def kv_cache():
+    torch.manual_seed(0)
+    return torch.randn(32768, 1, _DIM_QK, dtype=torch.bfloat16, device="cuda")
+
+
+def _assert_split_matches_single_pass(
+    num_tokens: int,
+    num_heads: int,
+    topk: int,
+    num_kv_splits: int | None,
+    kv_cache: torch.Tensor,
+) -> None:
+    torch.manual_seed(0)
+    q = torch.randn(num_tokens, num_heads, _DIM_QK, dtype=torch.bfloat16, device="cuda")
+    indices = torch.randint(
+        0, kv_cache.shape[0], (num_tokens, 1, topk), dtype=torch.int32, device="cuda"
+    )
+    out_ref = triton_sparse_mla_attention(
+        q,
+        kv_cache,
+        indices,
+        sm_scale=0.1,
+        num_kv_splits=1,
+    )
+    out = triton_sparse_mla_attention(
+        q,
+        kv_cache,
+        indices,
+        sm_scale=0.1,
+        num_kv_splits=num_kv_splits,
+    )
+    torch.testing.assert_close(
+        out.float(),
+        out_ref.float(),
+        atol=5e-2,
+        rtol=5e-3,
+    )
+
+
+@pytest.mark.parametrize(
+    "num_tokens,num_heads",
+    [(1, 16), (1, 128), (8, 32), (32, 128), (128, 16)],
+)
+@pytest.mark.parametrize("topk", [1024, 2048, 4096])
+@pytest.mark.parametrize("num_kv_splits", [2, 4, 8])
+def test_split_kv_matches_single_pass(
+    num_tokens, num_heads, topk, num_kv_splits, kv_cache
+):
+    _assert_split_matches_single_pass(
+        num_tokens,
+        num_heads,
+        topk,
+        num_kv_splits,
+        kv_cache,
+    )
+
+
+@pytest.mark.parametrize("num_tokens", [1, 8, 32, 128])
+def test_auto_split_matches_single_pass(num_tokens, kv_cache):
+    _assert_split_matches_single_pass(
+        num_tokens,
+        num_heads=128,
+        topk=2048,
+        num_kv_splits=None,
+        kv_cache=kv_cache,
+    )
+
+
+@pytest.mark.parametrize("num_kv_splits", [1, 2, 4, 8])
+def test_short_prefill_no_nan(num_kv_splits, kv_cache):
+    """Regression: short prefill where most topk slots are -1 sentinels.
+
+    The indexer fills 2048 topk positions with only a handful of valid
+    indices; the rest are -1. Before the NEG_LARGE sentinel fix, the online
+    softmax produced NaN via `max(-inf, -inf) = -inf` and
+    `exp2(-inf − -inf) = NaN`, poisoning every split.
+    """
+    torch.manual_seed(0)
+    num_tokens, num_heads, topk = 5, 16, 2048
+    q = torch.randn(num_tokens, num_heads, _DIM_QK, dtype=torch.bfloat16, device="cuda")
+    indices = torch.full((num_tokens, 1, topk), -1, dtype=torch.int32, device="cuda")
+    # Only the first `t+1` slots of each query hold valid indices; the
+    # remaining ~2045 slots are -1, producing many all-invalid BLOCK_N tiles.
+    for t in range(num_tokens):
+        indices[t, 0, : t + 1] = torch.arange(
+            64, 64 + t + 1, dtype=torch.int32, device="cuda"
+        )
+    out = triton_sparse_mla_attention(
+        q, kv_cache, indices, sm_scale=0.0417, num_kv_splits=num_kv_splits
+    )
+    assert not torch.isnan(out).any()
+    assert not torch.isinf(out).any()

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -750,6 +750,13 @@ class CompilationConfig:
         "vllm::sparse_attn_indexer",
         "vllm::rocm_aiter_sparse_attn_indexer",
         "vllm::deepseek_v4_attention",
+        # SM80/ROCm reference fallbacks. Their bodies use data-dependent
+        # control flow (.any() / .nonzero() / .item()) that cudagraph
+        # capture forbids; listing them here splits the piecewise cudagraph
+        # at the call site so they run eager outside the captured replay.
+        "vllm::deepseek_v4_compressor_sparse_sm80",
+        "vllm::deepseek_v4_compressor_indexer_sm80",
+        "vllm::deepseek_v4_dequant_gather_sm80",
     ]
 
     def compute_hash(self) -> str:

--- a/vllm/model_executor/layers/deepseek_compressor.py
+++ b/vllm/model_executor/layers/deepseek_compressor.py
@@ -343,6 +343,101 @@ class DeepseekCompressor(nn.Module):
         k_cache_metadata = cast(Any, attn_metadata[self.k_cache_prefix])
         kv_cache = self._static_forward_context[self.k_cache_prefix].kv_cache
 
+        from vllm.utils.deep_gemm import use_dsv4_reference_kernels
+
+        if use_dsv4_reference_kernels():
+            # SM80 PyTorch fallback: Triton can't compile tl.float8e4nv.
+            # Route through vllm:: custom ops so cudagraph capture splits
+            # at the call site (the bodies use .any() / .nonzero(), forbidden
+            # during capture).
+            if self.head_dim == 512:
+                torch.ops.vllm.deepseek_v4_compressor_sparse_sm80(
+                    state_cache,
+                    token_to_req_indices,
+                    positions,
+                    slot_mapping,
+                    block_table,
+                    self.norm.weight,
+                    cos_sin_cache,
+                    kv_cache,
+                    k_cache_metadata.slot_mapping,
+                    block_size,
+                    self.rms_norm_eps,
+                    kv_cache.shape[1],
+                    self.head_dim,
+                    state_width,
+                    self.compress_ratio,
+                    self.overlap,
+                    self.rope_head_dim,
+                    448.0,
+                    self._quant_block,
+                    self._token_stride,
+                    self._scale_dim,
+                )
+            elif (
+                self.head_dim == 128
+                and self._fused_kernel
+                is _fused_kv_compress_norm_rope_insert_indexer_attn
+            ):  # noqa: E501
+                torch.ops.vllm.deepseek_v4_compressor_indexer_sm80(
+                    state_cache,
+                    token_to_req_indices,
+                    positions,
+                    slot_mapping,
+                    block_table,
+                    self.norm.weight,
+                    cos_sin_cache,
+                    kv_cache,
+                    k_cache_metadata.slot_mapping,
+                    block_size,
+                    self.rms_norm_eps,
+                    kv_cache.shape[1],
+                    self.head_dim,
+                    state_width,
+                    self.compress_ratio,
+                    self.overlap,
+                    self.rope_head_dim,
+                    448.0,
+                    self._quant_block,
+                    self._token_stride,
+                    self._scale_dim,
+                )
+            else:
+                # MXFP4 indexer compressor doesn't use fp8e4nv (it uses
+                # uint8 + ue8m0). Run the Triton kernel.
+                self._fused_kernel[(num_actual,)](
+                    state_cache,
+                    state_cache.stride(0),
+                    state_cache.stride(1),
+                    token_to_req_indices,
+                    positions,
+                    slot_mapping,
+                    block_table,
+                    block_table.stride(0),
+                    block_size,
+                    self.norm.weight,
+                    self.rms_norm_eps,
+                    cos_sin_cache,
+                    cos_sin_cache.stride(0),
+                    kv_cache,
+                    k_cache_metadata.slot_mapping,
+                    kv_cache.shape[1],
+                    HEAD_SIZE=self.head_dim,
+                    TRITON_BLOCK_SIZE=triton.next_power_of_2(self.head_dim),
+                    STATE_WIDTH=state_width,
+                    COMPRESS_RATIO=self.compress_ratio,
+                    OVERLAP=self.overlap,
+                    ROPE_HEAD_DIM=self.rope_head_dim,
+                    FP8_MAX=448.0,
+                    QUANT_BLOCK=self._quant_block,
+                    TOKEN_STRIDE=self._token_stride,
+                    SCALE_DIM=self._scale_dim,
+                    KV_BLOCK_STRIDE=kv_cache.stride(0),
+                    num_warps=self._num_warps,
+                    launch_pdl=False,
+                )
+            return
+
         self._fused_kernel[(num_actual,)](
             # state cache
             state_cache,

--- a/vllm/model_executor/layers/deepseek_v4_attention.py
+++ b/vllm/model_executor/layers/deepseek_v4_attention.py
@@ -4,6 +4,7 @@
 DeepseekV4 MLA Attention Layer
 """
 
+import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
@@ -16,7 +17,8 @@ from vllm.model_executor.layers.linear import (
     ReplicatedLinear,
 )
 from vllm.model_executor.layers.sparse_attn_indexer import SparseAttnIndexer
-from vllm.utils.deep_gemm import fp8_einsum
+from vllm.triton_utils import LOG2E, tl, triton
+from vllm.utils.deep_gemm import fp8_einsum, use_dsv4_reference_kernels
 from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.v1.attention.ops.deepseek_v4_ops import (
     combine_topk_swa_indices,
@@ -69,6 +71,300 @@ from vllm.v1.attention.ops.flashmla import (
 )
 from vllm.v1.kv_cache_interface import KVCacheSpec, MLAAttentionSpec
 from vllm.v1.worker.workspace import current_workspace_manager
+
+
+@triton.jit
+def _dsv4_sm80_sparse_attn_split_kernel(
+    q_ptr,  # (B*S, H, D) bf16
+    kv_ptr,  # (B*S, T, D) bf16 — pre-gathered (zero rows for invalid)
+    invalid_mask_ptr,  # (B*S, T) uint8 (1 = invalid)
+    acc_split_ptr,  # (B*S, SPLIT_T, H, D_V) fp32
+    max_split_ptr,  # (B*S, SPLIT_T, H) fp32
+    sum_split_ptr,  # (B*S, SPLIT_T, H) fp32
+    n_tokens,
+    total_topk,
+    sm_scale_log2,  # scale * LOG2E
+    H: tl.constexpr,
+    D: tl.constexpr,
+    D_V: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    SPLIT_T: tl.constexpr,
+):
+    """Split-K sparse-attention decode pass 1 for V4 on SM80.
+
+    Each program processes one chunk of `total_topk` (sized `chunk =
+    ceil(total_topk / SPLIT_T)`) and emits unnormalised partial outputs:
+    `acc = sum_n exp2(qk_n - max_s) * v_n`, plus the per-split max and
+    sum. The combine kernel performs the cross-split LSE merge and sink
+    correction.
+
+    Splitting the topk axis lifts grid parallelism from
+    `(n_tokens, ceil(H/BLOCK_H))` to `(n_tokens, SPLIT_T, ceil(H/BLOCK_H))`,
+    which matters at batch=1 single-decode where only 1 SM was active.
+    """
+    pid_t = tl.program_id(0)
+    pid_split = tl.program_id(1)
+    pid_h = tl.program_id(2)
+
+    if pid_t >= n_tokens:
+        return
+
+    chunk_size = (total_topk + SPLIT_T - 1) // SPLIT_T
+    n_start_chunk = pid_split * chunk_size
+    n_end_chunk = tl.minimum(n_start_chunk + chunk_size, total_topk)
+
+    head_off = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
+    head_mask = head_off < H
+
+    d_off = tl.arange(0, BLOCK_D)
+    d_mask = d_off < D
+
+    # Hold q in bf16 — only used as bf16 in the inner-loop dot.
+    q = tl.load(
+        q_ptr + pid_t * H * D + head_off[:, None] * D + d_off[None, :],
+        mask=head_mask[:, None] & d_mask[None, :],
+        other=0.0,
+    )
+
+    e_max = tl.zeros((BLOCK_H,), dtype=tl.float32) - 1.0e30
+    e_sum = tl.zeros((BLOCK_H,), dtype=tl.float32)
+    acc = tl.zeros((BLOCK_H, BLOCK_DV), dtype=tl.float32)
+
+    n_iter = (chunk_size + BLOCK_N - 1) // BLOCK_N
+    for n_block in range(n_iter):
+        n_start = n_start_chunk + n_block * BLOCK_N
+        n_off = n_start + tl.arange(0, BLOCK_N)
+        n_mask = n_off < n_end_chunk
+
+        invalid_u8 = tl.load(
+            invalid_mask_ptr + pid_t * total_topk + n_off,
+            mask=n_mask,
+            other=1,
+        )
+        valid = (invalid_u8 == 0) & n_mask
+
+        # Load kv directly as bf16; tl.dot accumulates to fp32.
+        kv = tl.load(
+            kv_ptr + pid_t * total_topk * D + n_off[:, None] * D + d_off[None, :],
+            mask=valid[:, None] & d_mask[None, :],
+            other=0.0,
+        )
+
+        qk = tl.dot(q, tl.trans(kv))
+        qk *= sm_scale_log2
+        qk = tl.where(head_mask[:, None] & valid[None, :], qk, -1.0e30)
+
+        n_e_max = tl.maximum(tl.max(qk, axis=1), e_max)
+        re_scale = tl.exp2(e_max - n_e_max)
+        p = tl.exp2(qk - n_e_max[:, None])
+        # V == K for V4 — reuse the loaded kv tile for the pv dot.
+        acc *= re_scale[:, None]
+        acc += tl.dot(p.to(tl.bfloat16), kv)
+        e_sum = e_sum * re_scale + tl.sum(p, axis=1)
+        e_max = n_e_max
+
+    # Store partials. Layout: (B*S, SPLIT_T, H, D_V) for acc,
+    # (B*S, SPLIT_T, H) for max/sum — keeps the per-split stride contiguous
+    # so the combine kernel can issue coalesced loads.
+    dv_off = tl.arange(0, BLOCK_DV)
+    dv_mask = dv_off < D_V
+    base_acc = (
+        pid_t * SPLIT_T * H * D_V
+        + pid_split * H * D_V
+        + head_off[:, None] * D_V
+        + dv_off[None, :]
+    )
+    tl.store(
+        acc_split_ptr + base_acc,
+        acc,
+        mask=head_mask[:, None] & dv_mask[None, :],
+    )
+
+    base_ms = pid_t * SPLIT_T * H + pid_split * H + head_off
+    tl.store(max_split_ptr + base_ms, e_max, mask=head_mask)
+    tl.store(sum_split_ptr + base_ms, e_sum, mask=head_mask)
+
+
+@triton.jit
+def _dsv4_sm80_sparse_attn_combine_kernel(
+    acc_split_ptr,  # (B*S, SPLIT_T, H, D_V) fp32
+    max_split_ptr,  # (B*S, SPLIT_T, H) fp32
+    sum_split_ptr,  # (B*S, SPLIT_T, H) fp32
+    attn_sink_ptr,  # (H,) fp32
+    out_ptr,  # (B*S, H, D_V) bf16
+    n_tokens,
+    has_sink: tl.constexpr,
+    H: tl.constexpr,
+    D_V: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    SPLIT_T: tl.constexpr,
+):
+    """Cross-split LSE merge with sink correction.
+
+    Reads `SPLIT_T` partial (acc, max, sum) tuples and emits the final
+    softmax-normalised output. Sink contributes `exp2(sink_log2 - max)`
+    to the global denominator only — it has no v term.
+    """
+    pid_t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    if pid_t >= n_tokens:
+        return
+
+    head_off = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
+    head_mask = head_off < H
+
+    # Find global max over splits (and sink, if any).
+    e_max_global = tl.zeros((BLOCK_H,), dtype=tl.float32) - 1.0e30
+    for s in range(SPLIT_T):
+        m = tl.load(
+            max_split_ptr + pid_t * SPLIT_T * H + s * H + head_off,
+            mask=head_mask,
+            other=-1.0e30,
+        )
+        e_max_global = tl.maximum(e_max_global, m)
+
+    sink_log2 = tl.zeros((BLOCK_H,), dtype=tl.float32)
+    if has_sink:
+        sink = tl.load(attn_sink_ptr + head_off, mask=head_mask, other=0.0)
+        sink_log2 = sink * LOG2E
+        e_max_global = tl.maximum(e_max_global, sink_log2)
+
+    # Renormalise and reduce.
+    dv_off = tl.arange(0, BLOCK_DV)
+    dv_mask = dv_off < D_V
+    acc_global = tl.zeros((BLOCK_H, BLOCK_DV), dtype=tl.float32)
+    sum_global = tl.zeros((BLOCK_H,), dtype=tl.float32)
+    for s in range(SPLIT_T):
+        m_s = tl.load(
+            max_split_ptr + pid_t * SPLIT_T * H + s * H + head_off,
+            mask=head_mask,
+            other=-1.0e30,
+        )
+        sum_s = tl.load(
+            sum_split_ptr + pid_t * SPLIT_T * H + s * H + head_off,
+            mask=head_mask,
+            other=0.0,
+        )
+        scale = tl.exp2(m_s - e_max_global)
+        sum_global += scale * sum_s
+
+        base_acc = (
+            pid_t * SPLIT_T * H * D_V
+            + s * H * D_V
+            + head_off[:, None] * D_V
+            + dv_off[None, :]
+        )
+        acc_s = tl.load(
+            acc_split_ptr + base_acc,
+            mask=head_mask[:, None] & dv_mask[None, :],
+            other=0.0,
+        )
+        acc_global += scale[:, None] * acc_s
+
+    if has_sink:
+        sum_global += tl.exp2(sink_log2 - e_max_global)
+
+    sum_safe = tl.where(sum_global > 0, sum_global, 1.0)
+    out = (acc_global / sum_safe[:, None]).to(tl.bfloat16)
+    tl.store(
+        out_ptr + pid_t * H * D_V + head_off[:, None] * D_V + dv_off[None, :],
+        out,
+        mask=head_mask[:, None] & dv_mask[None, :],
+    )
+
+
+def _dsv4_sm80_sparse_attn_decode_triton(
+    q: torch.Tensor,  # (B*S, H, D) bf16
+    gathered_kv: torch.Tensor,  # (B*S, T, D) bf16
+    invalid_mask: torch.Tensor,  # (B*S, T) bool
+    attn_sink: torch.Tensor | None,  # (H,) fp32
+    sm_scale: float,
+    head_dim_v: int,
+) -> torch.Tensor:
+    """Split-K sparse-attention decode for V4 on SM80.
+
+    Two-kernel pipeline: a split-K pass over the topk dimension followed
+    by an LSE-merge combine. SPLIT_T is bounded by the BLOCK_N-tile count
+    so each split has real work to do."""
+    n_tokens, h, d = q.shape
+    _, t, d_kv = gathered_kv.shape
+    assert d_kv == d
+    assert invalid_mask.shape == (n_tokens, t)
+
+    block_d = triton.next_power_of_2(d)
+    block_dv = triton.next_power_of_2(head_dim_v)
+    # BLOCK_H capped at 16 (tl.dot's M-min) so the fp32 `acc` tile
+    # (BLOCK_H × BLOCK_DV) stays under A100's 100 KB SMEM limit and so we
+    # get more per-token head blocks for SM utilisation when h > 16.
+    block_h = 16
+    block_n = 32  # keeps q/kv/acc tiles within A100's 164KB SM
+
+    # SPLIT_T heuristic: cap at 16 (combine overhead dominates beyond
+    # that) but otherwise split as much as we have BLOCK_N tiles. Lifts
+    # grid parallelism from (n_tokens, ceil(h/BLOCK_H)) to
+    # (n_tokens, SPLIT_T, ceil(h/BLOCK_H)) — at batch=1 single-decode the
+    # original kernel used 1 SM out of 108.
+    n_tiles = (t + block_n - 1) // block_n
+    split_t = max(1, min(16, n_tiles))
+
+    out = torch.empty((n_tokens, h, head_dim_v), dtype=torch.bfloat16, device=q.device)
+    invalid_u8 = invalid_mask.to(torch.uint8)
+
+    acc_split = torch.empty(
+        (n_tokens, split_t, h, head_dim_v),
+        dtype=torch.float32,
+        device=q.device,
+    )
+    max_split = torch.empty(
+        (n_tokens, split_t, h), dtype=torch.float32, device=q.device
+    )
+    sum_split = torch.empty_like(max_split)
+
+    grid_split = (n_tokens, split_t, triton.cdiv(h, block_h))
+    _dsv4_sm80_sparse_attn_split_kernel[grid_split](
+        q,
+        gathered_kv,
+        invalid_u8,
+        acc_split,
+        max_split,
+        sum_split,
+        n_tokens,
+        t,
+        sm_scale * LOG2E,
+        H=h,
+        D=d,
+        D_V=head_dim_v,
+        BLOCK_H=block_h,
+        BLOCK_N=block_n,
+        BLOCK_D=block_d,
+        BLOCK_DV=block_dv,
+        SPLIT_T=split_t,
+        num_warps=4,
+    )
+
+    grid_combine = (n_tokens, triton.cdiv(h, block_h))
+    _dsv4_sm80_sparse_attn_combine_kernel[grid_combine](
+        acc_split,
+        max_split,
+        sum_split,
+        attn_sink if attn_sink is not None else q.new_zeros(h),
+        out,
+        n_tokens,
+        has_sink=(attn_sink is not None),
+        H=h,
+        D_V=head_dim_v,
+        BLOCK_H=block_h,
+        BLOCK_DV=block_dv,
+        SPLIT_T=split_t,
+        num_warps=4,
+    )
+    return out
+
 
 logger = init_logger(__name__)
 
@@ -180,6 +476,12 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
         self.kv_norm = mla_modules.kv_norm
         self.wo_a = mla_modules.wo_a
 
+        # SM80 BMM cache for wo_a when n_local_groups > 1 (TP < o_groups).
+        # Marlin-packed FP8 doesn't support per-group output slicing, so we
+        # lazily dequantize to bf16 and run torch.bmm. At n_local_groups == 1
+        # the flat Marlin path is mathematically a 1-batch BMM, so we keep it.
+        self._wo_a_bmm_weight: torch.Tensor | None = None
+
         self._wo_a_act_quant = QuantFP8(
             static=False,
             group_shape=GroupShape(1, 128),
@@ -271,6 +573,48 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
                 k_cache_prefix=self.mla_attn.prefix,
             )
 
+    def _ensure_wo_a_bmm_weight(self, ref: torch.Tensor) -> None:
+        """Lazily build a (n_local_groups, K, N_per_group) bf16 BMM weight.
+
+        Marlin doesn't expose its packed FP8 weight; recover it by running
+        an identity matrix through the linear so the bf16 output is W^T at
+        full precision."""
+        if self._wo_a_bmm_weight is not None:
+            return
+        K = self.wo_a.input_size_per_partition
+        N_total = self.wo_a.output_size_per_partition
+        n_groups = self.n_local_groups
+        N_per_group = N_total // n_groups
+        eye = torch.eye(K, dtype=ref.dtype, device=ref.device)
+        with torch.no_grad():
+            w_t = self.wo_a(eye)  # (K, N_total) bf16, dequantised
+        if isinstance(w_t, tuple):
+            w_t = w_t[0]
+        # (K, n_groups, N_per_group) -> (n_groups, K, N_per_group)
+        self._wo_a_bmm_weight = (
+            w_t.view(K, n_groups, N_per_group).permute(1, 0, 2).contiguous()
+        )
+
+    def _apply_wo_a_bmm(self, o_rotated: torch.Tensor) -> torch.Tensor:
+        """Per-group BMM dispatch for n_local_groups > 1 (TP < o_groups).
+
+        Input is (T, n_local_heads, head_dim) where n_local_heads splits
+        evenly across n_local_groups. A flat Marlin call would mix groups
+        across the K axis; we use torch.bmm against the per-group bf16
+        weight instead."""
+        self._ensure_wo_a_bmm_weight(o_rotated)
+        assert self._wo_a_bmm_weight is not None
+        n_groups = self.n_local_groups
+        T = o_rotated.shape[0]
+        K_per_group = self._wo_a_bmm_weight.shape[1]
+        N_per_group = self._wo_a_bmm_weight.shape[2]
+        # (T, n_local_heads, head_dim) -> (T, n_groups, K_per_group)
+        # -> (n_groups, T, K_per_group) for bmm.
+        x = o_rotated.reshape(T, n_groups, K_per_group).transpose(0, 1).contiguous()
+        out = torch.bmm(x, self._wo_a_bmm_weight)  # (n_groups, T, N_per_group)
+        # (n_groups, T, N_per_group) -> (T, n_groups * N_per_group)
+        return out.transpose(0, 1).reshape(T, n_groups * N_per_group)
+
     def forward(
         self,
         positions: torch.Tensor,
@@ -280,9 +624,26 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
         qr_kv, _ = self.fused_wqa_wkv(hidden_states)
         qr, kv = qr_kv.split([self.q_lora_rank, self.head_dim], dim=-1)
 
+        # Lift q/kv RMSNorm out of the attention custom op so the surrounding
+        # residual / norm graph isn't cut by the opaque boundary. The op
+        # now expects pre-normed inputs; Inductor can combo-fuse this norm
+        # with adjacent ops in the wrapper-level graph.
+        qr, kv = fused_q_kv_rmsnorm(
+            qr,
+            kv,
+            self.q_norm.weight.data,
+            self.kv_norm.weight.data,
+            self.eps,
+        )
+
+        # Lift `wq_b` out as well so the projection-from-LoRA matmul is
+        # graph-visible. The indexer still consumes the LoRA-rank `qr`,
+        # so we pass both `qr` and the projected per-head `q` to the op.
+        num_tokens = hidden_states.shape[0]
+        q = self.wq_b(qr).view(-1, self.n_local_heads, self.head_dim)
+
         # Pre-allocate attention output with FlashMLA-padded head count.
         # The op writes into `o_padded`; we slice to n_local_heads after.
-        num_tokens = hidden_states.shape[0]
         o_padded = torch.empty(
             (num_tokens, self.padded_heads, self.head_dim),
             dtype=hidden_states.dtype,
@@ -294,11 +655,27 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
             hidden_states,
             qr,
             kv,
+            q,
             positions,
             o_padded,
             self.layer_name,
         )
         o = o_padded[:, : self.n_local_heads, :]
+
+        if use_dsv4_reference_kernels():
+            # SM80/ROCm reference path: bf16 inv-RoPE then wo_a. At
+            # n_local_groups>1 wo_a is a per-group BMM and we route through
+            # the bf16 dequant + torch.bmm path; the n_local_groups==1 case
+            # is a 1-batch BMM and runs as a flat Marlin GEMM.
+            o_rotated = _apply_inv_rope_to_o(
+                o,
+                positions,
+                self.rotary_emb.cos_sin_cache,
+                self.rope_head_dim,
+            )
+            if self.n_local_groups > 1:
+                return self.wo_b(self._apply_wo_a_bmm(o_rotated))
+            return self.wo_b(self.wo_a(o_rotated.flatten(1)))
 
         # O projection: inverse RoPE + FP8 quant + einsum + wo_b
         o_fp8, o_scale = fused_inv_rope_fp8_quant(
@@ -337,20 +714,19 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
         hidden_states: torch.Tensor,
         qr: torch.Tensor,
         kv: torch.Tensor,
+        q: torch.Tensor,
         positions: torch.Tensor,
         out: torch.Tensor,  # [num_tokens, padded_heads, head_dim], written in place
     ) -> None:
         forward_context = get_forward_context()
         attn_metadata = forward_context.attn_metadata
 
-        qr, kv = fused_q_kv_rmsnorm(
-            qr,
-            kv,
-            self.q_norm.weight.data,
-            self.kv_norm.weight.data,
-            self.eps,
-        )
-        q = self.wq_b(qr).view(-1, self.n_local_heads, self.head_dim)
+        # `qr`, `kv`, and `q` are all pre-computed in the calling `forward()`:
+        # `fused_q_kv_rmsnorm` and `wq_b` were lifted out so the surrounding
+        # residual/RMSNorm graph is no longer cut by the custom-op boundary.
+        # Inductor can now combo-fuse those tails with adjacent ops.
+        # The indexer (below) still consumes `qr` (the normed LoRA tensor)
+        # while kv_insert and `mla_attn` consume `q`.
 
         # Overlap kv_insert with whichever of indexer/compressor is present.
         # Indexer implies compressor; when both exist, compressor rides on the
@@ -457,19 +833,21 @@ def deepseek_v4_attention(
     hidden_states: torch.Tensor,
     qr: torch.Tensor,
     kv: torch.Tensor,
+    q: torch.Tensor,
     positions: torch.Tensor,
     out: torch.Tensor,
     layer_name: str,
 ) -> None:
     forward_context: ForwardContext = get_forward_context()
     self = forward_context.no_compile_layers[layer_name]
-    self.attention_impl(hidden_states, qr, kv, positions, out)
+    self.attention_impl(hidden_states, qr, kv, q, positions, out)
 
 
 def deepseek_v4_attention_fake(
     hidden_states: torch.Tensor,
     qr: torch.Tensor,
     kv: torch.Tensor,
+    q: torch.Tensor,
     positions: torch.Tensor,
     out: torch.Tensor,
     layer_name: str,
@@ -485,6 +863,152 @@ direct_register_custom_op(
 )
 
 
+@triton.jit
+def _inv_rope_bf16_kernel(
+    o_ptr,  # (T, H, D) bf16, modified in place
+    positions_ptr,  # (T,) int64
+    cos_sin_cache_ptr,  # (max_pos, rope_dim) bf16
+    T,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    rope_dim: tl.constexpr,
+    half_rope: tl.constexpr,
+    nope_dim: tl.constexpr,
+):
+    """Single-launch inv-RoPE on bf16 for the SM80 reference path.
+
+    One program per (token, head). Replaces the ~10-op PyTorch chain in
+    `_apply_inv_rope_to_o` (index_select, clone, slice/stride pairs, mul,
+    add, sub, copy_back) with one kernel.
+
+    GPT-J interleaved: even/odd pairs at positions (2r, 2r+1) within the
+    rope segment are rotated using the (cos, sin) at index r.
+    """
+    pid_t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+    if pid_t >= T:
+        return
+
+    pos = tl.load(positions_ptr + pid_t)
+    base_cs = cos_sin_cache_ptr + pos * rope_dim
+    r = tl.arange(0, half_rope)
+    cos_v = tl.load(base_cs + r).to(tl.float32)
+    sin_v = tl.load(base_cs + half_rope + r).to(tl.float32)
+
+    base_row = o_ptr + (pid_t * H + pid_h) * D + nope_dim
+    even = tl.load(base_row + 2 * r).to(tl.float32)
+    odd = tl.load(base_row + 2 * r + 1).to(tl.float32)
+    new_even = even * cos_v + odd * sin_v
+    new_odd = odd * cos_v - even * sin_v
+    tl.store(base_row + 2 * r, new_even.to(tl.bfloat16))
+    tl.store(base_row + 2 * r + 1, new_odd.to(tl.bfloat16))
+
+
+def _apply_inv_rope_to_o(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    rope_dim: int,
+) -> torch.Tensor:
+    """Apply inverse GPT-J RoPE on the last `rope_dim` dims of each head.
+    Used by the SM80/ROCm reference path that skips FP8 quantization.
+    Matches the rotation in `_fused_inv_rope_fp8_quant_per_head` numerically."""
+    if not o.is_contiguous():
+        o = o.contiguous()
+    out = o.clone()
+    T, H, D = out.shape
+    nope_dim = D - rope_dim
+    half_rope = rope_dim // 2
+    positions_i64 = positions.to(torch.int64).contiguous()
+    cs = cos_sin_cache
+    # cos_sin_cache is (max_pos, rope_dim) bf16 with the GPT-J layout
+    # [cos | sin] along the last dim. We index by position and split inline.
+    grid = (T, H)
+    _inv_rope_bf16_kernel[grid](
+        out,
+        positions_i64,
+        cs,
+        T,
+        H=H,
+        D=D,
+        rope_dim=rope_dim,
+        half_rope=half_rope,
+        nope_dim=nope_dim,
+    )
+    return out
+
+
+def _decode_e8m0_scales(scale: torch.Tensor) -> torch.Tensor:
+    if scale.dtype == torch.float8_e8m0fnu:
+        from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+            _upcast_e8m0_to_fp32,
+        )
+
+        return _upcast_e8m0_to_fp32(scale).contiguous()
+    return scale.to(torch.float32)
+
+
+def _expand_last_dim_scales(scale: torch.Tensor, last_dim: int) -> torch.Tensor:
+    scale = _decode_e8m0_scales(scale)
+    block = math.ceil(last_dim / scale.shape[-1])
+    return torch.repeat_interleave(scale, block, dim=-1)[..., :last_dim]
+
+
+def _expand_2d_block_scales(
+    scale: torch.Tensor,
+    rows: int,
+    cols: int,
+) -> torch.Tensor:
+    scale = _decode_e8m0_scales(scale)
+    row_blocks, col_blocks = scale.shape[-2:]
+    row_block = math.ceil(rows / row_blocks)
+    col_block = math.ceil(cols / col_blocks)
+    scale = torch.repeat_interleave(scale, row_block, dim=-2)[..., :rows, :]
+    scale = torch.repeat_interleave(scale, col_block, dim=-1)[..., :, :cols]
+    return scale
+
+
+def _deepseek_v4_fp8_einsum_fallback(
+    a: torch.Tensor,
+    a_scale: torch.Tensor,
+    b: torch.Tensor,
+    b_scale: torch.Tensor,
+    out: torch.Tensor,
+    equation: str,
+) -> None:
+    """SM80/ROCm dequantize-and-einsum fallback for `bhr,hdr->bhd`.
+
+    On SM80 with Marlin-packed FP8 weights the wrapper bypasses this and
+    routes through `wo_a` as a regular Linear; this remains for ROCm and
+    any non-Marlin SM80 layout."""
+    if equation != "bhr,hdr->bhd":
+        raise RuntimeError(f"Unsupported fallback equation: {equation}")
+
+    num_groups = a.shape[1]
+    hidden_dim = a.shape[2]
+    output_dim = b.shape[0] // num_groups
+
+    if b.shape[0] % num_groups != 0:
+        raise RuntimeError(
+            f"Cannot reshape weight of shape {tuple(b.shape)} into "
+            f"({num_groups}, {output_dim}, {hidden_dim})."
+        )
+
+    a_deq = (a.to(torch.float32) * _expand_last_dim_scales(a_scale, hidden_dim)).to(
+        torch.bfloat16
+    )
+
+    b_deq = b.view(num_groups, output_dim, hidden_dim).to(torch.float32)
+    b_scale_deq = _expand_2d_block_scales(
+        b_scale.view(num_groups, -1, b_scale.shape[-1]),
+        output_dim,
+        hidden_dim,
+    )
+    b_deq = (b_deq * b_scale_deq).to(torch.bfloat16)
+
+    out.copy_(torch.einsum(equation, a_deq, b_deq).to(out.dtype))
+
+
 def deepseek_v4_fp8_einsum(
     a: torch.Tensor,
     a_scale: torch.Tensor,
@@ -494,6 +1018,13 @@ def deepseek_v4_fp8_einsum(
     equation: str,
     recipe: list[int],
 ) -> None:
+    if use_dsv4_reference_kernels():
+        # SM80/ROCm: pre-gate to the dequant-and-einsum fallback. Catching
+        # RuntimeError isn't enough because on SM80 DeepGEMM is importable,
+        # so the C++ assert ("Unsupported architecture") fires from inside
+        # the kernel call rather than from the wrapper's _missing() raise.
+        _deepseek_v4_fp8_einsum_fallback(a, a_scale, b, b_scale, out, equation)
+        return
     fp8_einsum(equation, (a, a_scale), (b, b_scale), out, recipe=tuple(recipe))
 
 
@@ -563,6 +1094,12 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
 
         self.aux_stream = aux_stream
         self.ln_events = [torch.cuda.Event(), torch.cuda.Event()]
+
+        # Cache for `torch.arange(0, topk)` used in invalid-mask construction.
+        # Today the SM80 reference path constructs a fresh arange every gather
+        # call (43 layers x 2 scopes per token). Each is small but the
+        # allocations + kernel launches add up.
+        self._arange_cache: dict[tuple[int, torch.device], torch.Tensor] = {}
 
         # Determine padded head count for FlashMLA
         if num_heads not in self.SUPPORTED_HEAD_COUNTS:
@@ -738,6 +1275,8 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
 
         swa_indices = swa_metadata.decode_swa_indices
         swa_lens = swa_metadata.decode_swa_lens
+        assert swa_indices is not None
+        assert swa_lens is not None
 
         # We treat queries in the same seq as different queries
         # and later we only attend by generated indices.
@@ -768,6 +1307,28 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
                 f"Unsupported compress_ratio={self.compress_ratio}; "
                 "expected 1, 4, or 128."
             )
+
+        if use_dsv4_reference_kernels():
+            # SM80/ROCm reference path: gather only the selected indices,
+            # then dequantize. tile_metadata is unused here —
+            # build_tile_scheduler short-circuits to None on these platforms.
+            swa_block_size = self.swa_cache_layer.kv_cache.shape[1]
+            has_extra = not swa_only and kv_cache is not None
+            attn_out = self._ref_sparse_attn_decode_gather(
+                q=q,
+                swa_kv_cache=self.swa_cache_layer.kv_cache,
+                swa_block_size=swa_block_size,
+                swa_indices=swa_indices.unsqueeze(1),
+                swa_topk_length=swa_lens,
+                attn_sink=self.attn_sink[: q.shape[2]],
+                extra_kv_cache=kv_cache.squeeze(-2) if has_extra else None,
+                extra_block_size=kv_cache.shape[1] if has_extra else 0,
+                extra_indices=topk_indices,
+                extra_topk_length=topk_lens,
+            )
+            output.copy_(attn_out.to(output.dtype))
+            return
+
         assert tile_metadata is not None, (
             "swa_metadata missing tile_sched entry for "
             f"compress_ratio={self.compress_ratio}; "
@@ -792,6 +1353,190 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
             extra_topk_length=topk_lens,
             out=output.unsqueeze(1),
         )
+
+    def _dequantize_blocked_k_cache(self, quant_k_cache: torch.Tensor) -> torch.Tensor:
+        """Dequantize a UE8M0-packed FP8 KV block cache to bf16."""
+        from vllm.platforms import current_platform
+
+        fp8_dtype = current_platform.fp8_dtype()
+        d = self.head_dim
+        d_nope = self.nope_head_dim
+        d_rope = self.rope_head_dim
+        tile_size = 64
+        num_tiles = d_nope // tile_size
+
+        num_blocks, block_size, _ = quant_k_cache.shape
+        quant_k_cache = quant_k_cache.view(num_blocks, -1)
+        input_nope_rope = quant_k_cache[:, : block_size * (d_nope + 2 * d_rope)].view(
+            num_blocks, block_size, d_nope + 2 * d_rope
+        )
+        input_nope = input_nope_rope[:, :, :d_nope].view(fp8_dtype)
+        input_rope = input_nope_rope[:, :, d_nope:].view(torch.bfloat16)
+        input_scale = (
+            quant_k_cache[:, block_size * (d_nope + 2 * d_rope) :]
+            .view(num_blocks, block_size, 8)[:, :, :num_tiles]
+            .view(torch.float8_e8m0fnu)
+        )
+
+        result = torch.empty(
+            (num_blocks, block_size, 1, d),
+            dtype=torch.bfloat16,
+            device=quant_k_cache.device,
+        )
+        result[..., d_nope:] = input_rope.unsqueeze(2)
+        for tile_idx in range(num_tiles):
+            cur_nope = input_nope[
+                ..., tile_idx * tile_size : (tile_idx + 1) * tile_size
+            ].to(torch.bfloat16)
+            cur_scales = input_scale[:, :, tile_idx].to(torch.bfloat16).unsqueeze(-1)
+            result[..., tile_idx * tile_size : (tile_idx + 1) * tile_size] = (
+                cur_nope * cur_scales
+            ).unsqueeze(2)
+        return result
+
+    def _gather_dequant_blocked_k_at_indices(
+        self,
+        kv_cache: torch.Tensor,
+        flat_indices: torch.Tensor,
+        block_size: int,
+    ) -> torch.Tensor:
+        """Gather and dequantize K vectors at the given flat indices
+        (block_idx * block_size + pos_in_block) directly from the paged
+        FP8 cache without dequantising the full cache. Returns (N, head_dim)
+        bf16. Negative or out-of-range indices produce zero rows."""
+        nope_dim = self.nope_head_dim
+        rope_dim = self.rope_head_dim
+        head_dim = self.head_dim
+        quant_block = 64
+        n_quant = nope_dim // quant_block
+        scale_dim = n_quant + 1  # 7 real + 1 pad
+        token_data_size = nope_dim + rope_dim * 2  # 448 + 128 = 576
+
+        device = kv_cache.device
+        flat_indices = flat_indices.to(torch.int64)
+        valid_mask = flat_indices >= 0
+        safe_idx = flat_indices.clamp_min(0)
+        block_idx = safe_idx // block_size
+        pos_in_block = safe_idx % block_size
+
+        cache_u8 = (
+            kv_cache.view(torch.uint8) if kv_cache.dtype != torch.uint8 else kv_cache
+        )
+        n_blocks = cache_u8.shape[0]
+        block_stride = cache_u8[0].numel()
+        flat = cache_u8.view(n_blocks, block_stride)
+
+        block_idx = block_idx.clamp(max=n_blocks - 1)
+        t_off = pos_in_block * token_data_size
+        s_off = block_size * token_data_size + pos_in_block * scale_dim
+
+        # NoPE (fp8) and RoPE (bf16-as-bytes) are contiguous within each
+        # token's region of the cache, so a single fancy-index op covers
+        # both: nope at [pos*token_data_size : +nope_dim], rope at
+        # [+nope_dim : +nope_dim+2*rope_dim].
+        nope_rope_arange = self._get_arange(nope_dim + rope_dim * 2, device)
+        scale_arange = self._get_arange(n_quant, device)
+        nope_rope_idx = t_off.unsqueeze(-1) + nope_rope_arange
+        scale_idx = s_off.unsqueeze(-1) + scale_arange
+
+        block_idx_b = block_idx.unsqueeze(-1)
+        nope_rope_bytes = flat[block_idx_b, nope_rope_idx]  # (N, 576) uint8
+        fp8_bytes = nope_rope_bytes[:, :nope_dim].contiguous().view(torch.float8_e4m3fn)
+        bf16_raw = nope_rope_bytes[:, nope_dim:].contiguous()
+        bf16_view = bf16_raw.view(torch.bfloat16).view(-1, rope_dim)
+        scales_u8 = flat[block_idx_b, scale_idx]
+
+        x_fp32 = fp8_bytes.to(torch.float32).view(-1, n_quant, quant_block)
+        scale_factor = torch.pow(2.0, scales_u8.to(torch.float32) - 127.0).unsqueeze(-1)
+        dequant_fp8 = (x_fp32 * scale_factor).view(-1, nope_dim).to(torch.bfloat16)
+
+        full = torch.empty(
+            (flat_indices.shape[0], head_dim),
+            device=device,
+            dtype=torch.bfloat16,
+        )
+        full[:, :nope_dim] = dequant_fp8
+        full[:, nope_dim:] = bf16_view
+        full.masked_fill_(~valid_mask.unsqueeze(-1), 0)
+        return full
+
+    def _get_arange(self, n: int, device: torch.device) -> torch.Tensor:
+        """Cached `torch.arange(0, n)` keyed by (length, device).
+
+        Each decode step calls this layer's gather many times with
+        identical (length, device) tuples; the cache avoids the per-call
+        allocation and kernel launch."""
+        key = (n, device)
+        cached = self._arange_cache.get(key)
+        if cached is None:
+            cached = torch.arange(0, n, device=device)
+            self._arange_cache[key] = cached
+        return cached
+
+    def _ref_sparse_attn_decode_gather(
+        self,
+        q: torch.Tensor,
+        swa_kv_cache: torch.Tensor,
+        swa_block_size: int,
+        swa_indices: torch.Tensor,
+        swa_topk_length: torch.Tensor | None,
+        attn_sink: torch.Tensor | None,
+        extra_kv_cache: torch.Tensor | None,
+        extra_block_size: int,
+        extra_indices: torch.Tensor | None,
+        extra_topk_length: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """SM80 reference decode: gather-then-dequantise only the topk
+        positions, then dispatch to the split-K attention kernel."""
+        b, s_q, h_q, d_qk = q.shape
+        d_v = self.head_dim
+
+        def gather_scope(
+            kv_cache: torch.Tensor,
+            block_size: int,
+            indices: torch.Tensor,
+            topk_length: torch.Tensor | None,
+        ) -> tuple[torch.Tensor, torch.Tensor]:
+            indices = indices.reshape(b, s_q, -1)
+            topk = indices.size(-1)
+            gathered = self._gather_dequant_blocked_k_at_indices(
+                kv_cache, indices.reshape(-1), block_size
+            ).view(b, s_q, topk, d_qk)
+            invalid_mask = indices == -1
+            if topk_length is not None:
+                topk_length = topk_length.reshape(b)
+                arange = self._get_arange(topk, invalid_mask.device)
+                invalid_mask |= arange.view(1, 1, topk) >= topk_length.view(b, 1, 1)
+            return gathered, invalid_mask
+
+        gathered_kv, invalid_mask = gather_scope(
+            swa_kv_cache, swa_block_size, swa_indices, swa_topk_length
+        )
+        if extra_kv_cache is not None and extra_indices is not None:
+            extra_gathered, extra_invalid = gather_scope(
+                extra_kv_cache, extra_block_size, extra_indices, extra_topk_length
+            )
+            gathered_kv = torch.cat([gathered_kv, extra_gathered], dim=2)
+            invalid_mask = torch.cat([invalid_mask, extra_invalid], dim=2)
+
+        # No NaN scrub: the FP8 quantiser clamps to +/-448 and the gather
+        # zeroes invalid rows in-place, so the gathered buffer is NaN-free.
+        bs = b * s_q
+        gathered_kv_flat = gathered_kv.view(bs, -1, d_qk)
+        invalid_flat = invalid_mask.view(bs, -1)
+        # q may arrive non-contiguous from the upstream o_padded[...] slice.
+        q_flat = q.view(bs, h_q, d_qk).to(torch.bfloat16).contiguous()
+
+        out_flat = _dsv4_sm80_sparse_attn_decode_triton(
+            q_flat,
+            gathered_kv_flat,
+            invalid_flat,
+            attn_sink,
+            self.scale,
+            d_v,
+        )
+        # Match the prior PyTorch shape: (b, h_q, d_v) for s_q=1.
+        return out_flat.view(b, h_q, d_v)
 
     def _forward_prefill(
         self,
@@ -903,15 +1648,76 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
                 N,
             )
 
-            output_chunk, _, _ = flash_mla_sparse_fwd(
-                q=q[query_start:query_end],
-                kv=kv.view(-1, 1, q.shape[-1]),
-                indices=combined_indices.unsqueeze(1),
-                sm_scale=self.scale,
-                attn_sink=self.attn_sink,
-                topk_length=combined_lens,
-                out=output[query_start:query_end],
+            if use_dsv4_reference_kernels():
+                # SM80/ROCm reference path. The reference returns the
+                # attention output rather than writing to `out=`, so copy
+                # into the output slice.
+                output_chunk = self._ref_sparse_attn_prefill(
+                    q=q[query_start:query_end],
+                    kv=kv.view(-1, 1, q.shape[-1]),
+                    indices=combined_indices.unsqueeze(1),
+                    topk_length=combined_lens,
+                )
+                output[query_start:query_end].copy_(output_chunk.to(output.dtype))
+            else:
+                output_chunk, _, _ = flash_mla_sparse_fwd(
+                    q=q[query_start:query_end],
+                    kv=kv.view(-1, 1, q.shape[-1]),
+                    indices=combined_indices.unsqueeze(1),
+                    sm_scale=self.scale,
+                    attn_sink=self.attn_sink,
+                    topk_length=combined_lens,
+                    out=output[query_start:query_end],
+                )
+
+    def _ref_sparse_attn_prefill(
+        self,
+        q: torch.Tensor,
+        kv: torch.Tensor,
+        indices: torch.Tensor,
+        topk_length: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Pure-PyTorch sparse MLA prefill reference."""
+        indices = indices.clone().squeeze(1)
+        s_q, h_q, d_qk = q.shape
+        topk = indices.shape[-1]
+        s_kv = kv.shape[0]
+        if topk_length is not None:
+            mask = torch.arange(topk, device=indices.device).unsqueeze(
+                0
+            ) >= topk_length.unsqueeze(1)
+            indices[mask] = -1
+        invalid_mask = (indices < 0) | (indices >= s_kv)
+        indices[invalid_mask] = 0
+
+        qf = q.float()
+        gathered_kv = (
+            kv.index_select(0, indices.flatten()).reshape(s_q, topk, d_qk).float()
+        )
+        scores = qf @ gathered_kv.transpose(1, 2)
+        scores *= self.scale
+        scores[invalid_mask.unsqueeze(1).expand_as(scores)] = float("-inf")
+
+        orig_lse = torch.logsumexp(scores, dim=-1)
+        lse_for_o = orig_lse
+        if self.attn_sink is not None:
+            lse_for_o = torch.logsumexp(
+                torch.stack(
+                    [
+                        orig_lse,
+                        self.attn_sink[:h_q].view(1, h_q).expand_as(orig_lse),
+                    ],
+                    dim=0,
+                ),
+                dim=0,
             )
+        lse_for_o = lse_for_o.clone()
+        lse_for_o[lse_for_o == float("-inf")] = float("+inf")
+        probs = torch.exp(scores - lse_for_o.unsqueeze(-1))
+        out = probs @ gathered_kv[..., : self.head_dim]
+        lonely_q_mask = orig_lse == float("-inf")
+        out[lonely_q_mask.unsqueeze(-1).expand_as(out)] = 0.0
+        return out.to(torch.bfloat16)
 
 
 class DeepseekV4IndexerCache(torch.nn.Module, AttentionLayerBase):

--- a/vllm/model_executor/layers/mhc.py
+++ b/vllm/model_executor/layers/mhc.py
@@ -7,6 +7,8 @@ from typing import TYPE_CHECKING
 import torch
 
 from vllm.platforms import current_platform
+from vllm.triton_utils import tl, triton
+from vllm.utils.deep_gemm import use_dsv4_reference_kernels
 from vllm.utils.import_utils import has_tilelang
 from vllm.utils.math_utils import cdiv
 from vllm.utils.torch_utils import direct_register_custom_op
@@ -23,6 +25,170 @@ if TYPE_CHECKING or current_platform.is_cuda_alike():
 else:
     tilelang = None  # type: ignore[assignment]
     T = None  # type: ignore[assignment]
+
+
+@triton.jit
+def _mhc_sinkhorn_kernel(
+    in_ptr,  # comb_logits (T, hc, hc) fp32
+    out_ptr,  # comb_mix (T, hc, hc) fp32
+    n_tokens,
+    eps: tl.constexpr,
+    hc: tl.constexpr,
+    iterations: tl.constexpr,
+):
+    """Fused softmax + iterative Sinkhorn (row+col) normalisation.
+
+    Replaces:
+        comb_mix = softmax(logits, -1) + eps
+        comb_mix /= comb_mix.sum(-2, keepdim=True) + eps
+        for _ in range(iterations - 1):
+            comb_mix /= comb_mix.sum(-1, keepdim=True) + eps
+            comb_mix /= comb_mix.sum(-2, keepdim=True) + eps
+
+    One program per token; comb is hc x hc held in registers throughout."""
+    pid = tl.program_id(0)
+    if pid >= n_tokens:
+        return
+
+    base = in_ptr + pid * hc * hc
+    rows = tl.arange(0, hc)
+    cols = tl.arange(0, hc)
+    cm = tl.load(base + rows[:, None] * hc + cols[None, :]).to(tl.float32)
+
+    # Row-wise softmax
+    row_max = tl.max(cm, axis=1)
+    cm = cm - row_max[:, None]
+    cm = tl.exp(cm)
+    row_sum = tl.sum(cm, axis=1)
+    cm = cm / row_sum[:, None] + eps
+
+    # First column-norm
+    col_sum = tl.sum(cm, axis=0)
+    cm = cm / (col_sum[None, :] + eps)
+
+    # iterations - 1 more row-then-column normalisations
+    for _ in range(iterations - 1):
+        row_sum = tl.sum(cm, axis=1)
+        cm = cm / (row_sum[:, None] + eps)
+        col_sum = tl.sum(cm, axis=0)
+        cm = cm / (col_sum[None, :] + eps)
+
+    out_base = out_ptr + pid * hc * hc
+    tl.store(out_base + rows[:, None] * hc + cols[None, :], cm)
+
+
+def _mhc_softmax_sinkhorn_triton(
+    comb_logits: torch.Tensor,
+    eps: float,
+    iterations: int,
+) -> torch.Tensor:
+    """Fused softmax + Sinkhorn iterations on (T, hc, hc) input. Replaces
+    the 1 + 2*(iterations-1) PyTorch sum/div pairs with one Triton kernel
+    that holds the (small) hc x hc matrix in registers throughout."""
+    n_tokens, hc, hc2 = comb_logits.shape
+    assert hc == hc2
+    out = torch.empty_like(comb_logits)
+    _mhc_sinkhorn_kernel[(n_tokens,)](
+        comb_logits.contiguous(),
+        out,
+        n_tokens,
+        eps=eps,
+        hc=hc,
+        iterations=iterations,
+        num_warps=1,
+    )
+    return out
+
+
+@triton.jit
+def _mhc_post_per_token(
+    a_ptr,  # comb_res_mix (T, hc, hc) fp32
+    b_ptr,  # residual (T, hc, h) bf16
+    c_ptr,  # post_layer_mix (T, hc, 1) fp32 — last dim length 1
+    d_ptr,  # x (T, h) bf16
+    out_ptr,  # out (T, hc, h) bf16
+    n_tokens,
+    hc: tl.constexpr,
+    h: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    """Fused mHC post:
+        out[t, j, k] = sum_i comb[t, i, j] * residual[t, i, k]
+                     + post[t, j] * x[t, k]
+    One program per (token, h_block). Loads `comb` (hc x hc) and
+    `post` (hc) once; streams `residual` and `x` over h-tiles."""
+    pid_t = tl.program_id(0).to(tl.int64)
+    pid_hb = tl.program_id(1).to(tl.int64)
+
+    h_off = pid_hb * BLOCK_H + tl.arange(0, BLOCK_H)
+    h_mask = h_off < h
+
+    a_off = (
+        a_ptr
+        + pid_t * hc * hc
+        + tl.arange(0, hc)[:, None] * hc
+        + tl.arange(0, hc)[None, :]
+    )
+    a = tl.load(a_off).to(tl.float32)  # (hc, hc) fp32
+
+    c_off = c_ptr + pid_t * hc + tl.arange(0, hc)
+    c = tl.load(c_off).to(tl.float32)  # (hc,) fp32
+
+    d_off = d_ptr + pid_t * h + h_off
+    d = tl.load(d_off, mask=h_mask, other=0.0).to(tl.float32)  # (BLOCK_H,)
+
+    # b: (hc, BLOCK_H) bf16 → fp32
+    b_off = b_ptr + pid_t * hc * h + tl.arange(0, hc)[:, None] * h + h_off[None, :]
+    b = tl.load(b_off, mask=h_mask[None, :], other=0.0).to(tl.float32)
+
+    # out[j, k] = sum_i a[i, j] * b[i, k] + c[j] * d[k]
+    # tl.dot requires K >= 16; hc is typically 4. 3D-broadcast + reduce
+    # turns the contraction into a few FMAs in registers (Triton can't
+    # index a 2D tensor by a constexpr scalar, so static_range over rows
+    # is unavailable).
+    a_T = tl.trans(a)  # (hc, hc): a_T[j, i] = a[i, j]
+    prod = a_T[:, :, None] * b[None, :, :]  # (hc, hc, BLOCK_H)
+    mixed = tl.sum(prod, axis=1)  # (hc, BLOCK_H)
+    post_term = c[:, None] * d[None, :]
+    result = (mixed + post_term).to(tl.bfloat16)
+
+    out_off = out_ptr + pid_t * hc * h + tl.arange(0, hc)[:, None] * h + h_off[None, :]
+    tl.store(out_off, result, mask=h_mask[None, :])
+
+
+def _mhc_post_triton(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> torch.Tensor:
+    """SM80 fused Triton mhc_post. Replaces the multi-op PyTorch reference."""
+    outer_shape = residual.shape[:-2]
+    hc = residual.shape[-2]
+    h = residual.shape[-1]
+    n_tokens = residual.numel() // (hc * h)
+
+    res = residual.reshape(n_tokens, hc, h).contiguous()
+    comb = comb_res_mix.reshape(n_tokens, hc, hc).to(torch.float32).contiguous()
+    post = post_layer_mix.reshape(n_tokens, hc).to(torch.float32).contiguous()
+    x_flat = x.reshape(n_tokens, h).contiguous()
+
+    out = torch.empty_like(res)
+
+    BLOCK_H = 256 if h >= 256 else 128
+    grid = (n_tokens, triton.cdiv(h, BLOCK_H))
+    _mhc_post_per_token[grid](
+        comb,
+        res,
+        post,
+        x_flat,
+        out,
+        n_tokens,
+        hc=hc,
+        h=h,
+        BLOCK_H=BLOCK_H,
+    )
+    return out.view(*outer_shape, hc, h)
 
 
 @cache
@@ -234,6 +400,43 @@ def mhc_pre(
     num_tokens = residual_flat.shape[0]
     fn_flat = fn
 
+    if use_dsv4_reference_kernels():
+        # SM80/ROCm reference path: pure-PyTorch fused implementation that
+        # bypasses both DeepGEMM `tf32_hc_prenorm_gemm` (Hopper+ only) and
+        # the tilelang follow-up. Lifted from PR 40871's ROCm branch.
+        x = residual_flat.view(num_tokens, hc_mult * hidden_size).to(torch.float32)
+        mixes = torch.matmul(x, fn_flat.t())
+        sqrsum = x.square().sum(dim=-1, keepdim=True)
+        mixes = mixes * torch.rsqrt(sqrsum / (hc_mult * hidden_size) + rms_eps)
+
+        pre_logits = mixes[:, :hc_mult] * hc_scale[0] + hc_base[:hc_mult]
+        pre_mix = torch.sigmoid(pre_logits) + hc_pre_eps
+
+        post_logits = (
+            mixes[:, hc_mult : 2 * hc_mult] * hc_scale[1]
+            + hc_base[hc_mult : 2 * hc_mult]
+        )
+        post_mix = torch.sigmoid(post_logits) * hc_post_mult_value
+
+        comb_logits = mixes[:, 2 * hc_mult :].view(
+            num_tokens, hc_mult, hc_mult
+        ) * hc_scale[2] + hc_base[2 * hc_mult :].view(1, hc_mult, hc_mult)
+        # Fused softmax + Sinkhorn iterations (replaces 1 + 2*(iters-1)
+        # PyTorch sum/div pairs with one Triton kernel — primary mhc_pre
+        # CPU-launch bottleneck on SM80 with sinkhorn_repeat=20).
+        comb_mix = _mhc_softmax_sinkhorn_triton(
+            comb_logits, hc_sinkhorn_eps, sinkhorn_repeat
+        )
+
+        layer_input = torch.sum(
+            pre_mix.unsqueeze(-1) * residual_flat.to(torch.float32), dim=1
+        ).to(torch.bfloat16)
+        return (
+            post_mix.view(*outer_shape, hc_mult, 1),
+            comb_mix.view(*outer_shape, hc_mult, hc_mult),
+            layer_input.view(*outer_shape, hidden_size),
+        )
+
     # these number are from deepgemm kernel impl
     block_k = 64
     block_m = 64
@@ -414,6 +617,11 @@ def mhc_post(
     post_layer_mix: torch.Tensor,
     comb_res_mix: torch.Tensor,
 ) -> torch.Tensor:
+    if use_dsv4_reference_kernels():
+        # SM80/ROCm fused Triton path; faster than the multi-op PyTorch
+        # einsum + broadcast reference and matches the upstream tilelang
+        # kernel's output to bf16 precision.
+        return _mhc_post_triton(x, residual, post_layer_mix, comb_res_mix)
     out = torch.empty_like(residual)
     mhc_post_tilelang(
         comb_res_mix,

--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -621,6 +621,14 @@ class DeepseekV4MoE(nn.Module):
             )
         else:
             self.use_mega_moe = False
+        # Mega-MoE relies on DeepGEMM's `fp8_fp4_mega_moe`, which is
+        # Hopper/Blackwell-only. Force the standard FusedMoE path on
+        # SM80/ROCm to avoid `Unsupported architecture` runtime errors.
+        if self.use_mega_moe:
+            from vllm.utils.deep_gemm import use_dsv4_reference_kernels
+
+            if use_dsv4_reference_kernels():
+                self.use_mega_moe = False
 
         self.routed_scaling_factor = getattr(config, "routed_scaling_factor", 1.0)
         self.hidden_size = config.hidden_size

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -122,6 +122,7 @@ def _get_backend_priorities(
                 AttentionBackendEnum.FLASHMLA,
                 AttentionBackendEnum.FLASHINFER_MLA,
                 AttentionBackendEnum.TRITON_MLA,
+                AttentionBackendEnum.TRITON_MLA_SPARSE,
                 AttentionBackendEnum.FLASHMLA_SPARSE,
             ]
     else:

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -92,6 +92,42 @@ def is_deep_gemm_supported() -> bool:
     return envs.VLLM_USE_DEEP_GEMM and has_deep_gemm() and is_supported_arch
 
 
+def _resolve_use_dsv4_ref_kernels() -> bool:
+    try:
+        if not is_deep_gemm_supported():
+            return True
+        from vllm.v1.attention.ops.flashmla import is_flashmla_sparse_supported
+
+        ok, _ = is_flashmla_sparse_supported()
+        return not ok
+    except Exception:
+        # CUDA might not be initialized at the moment this module is first
+        # imported (CPU-only build, test harnesses, etc.). Default to True —
+        # the SM80 reference paths produce correct output on every platform.
+        return True
+
+
+# Resolved once at module import time so torch.compile / Dynamo sees a plain
+# Python bool global at every dispatch site, allowing the branch to be
+# constant-folded inside compiled regions. The previous functools.cache
+# wrapper was untraceable; placing the lookup in the function body chained
+# to is_deep_gemm_supported() (which still uses @functools.cache) and
+# tripped Dynamo even on the hot path. With this constant, Dynamo never
+# follows the cached chain at trace time.
+USE_DSV4_REF_KERNELS: bool = _resolve_use_dsv4_ref_kernels()
+
+
+def use_dsv4_reference_kernels() -> bool:
+    """True when DeepGEMM hyperconnection / FlashMLA-Sparse kernels are
+    unusable on the current platform.
+
+    Captures SM80 (A100/A800), ROCm, and any platform where DeepGEMM or
+    FlashMLA-Sparse cannot run. Used by DeepSeek V4 sites to dispatch to
+    pure-PyTorch reference implementations.
+    """
+    return USE_DSV4_REF_KERNELS
+
+
 @functools.cache
 def is_deep_gemm_e8m0_used() -> bool:
     """Return `True` if vLLM is configured to use DeepGEMM "

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -362,6 +362,13 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         }
         if num_decode_tokens == 0:
             return out
+        # SM80/ROCm: skip FlashMLA tile-sched allocation; the reference
+        # decode path doesn't read tile_sched_*, so all-None is the
+        # sentinel _forward_decode's gate already tolerates.
+        from vllm.utils.deep_gemm import use_dsv4_reference_kernels
+
+        if use_dsv4_reference_kernels():
+            return out
         for layer_type in self._layer_types:
             # get_mla_metadata() is the official FlashMLA entry point that
             # returns a fresh empty FlashMLASchedMeta; using it keeps this

--- a/vllm/v1/attention/backends/mla/triton_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/triton_mla_sparse.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Pure-Triton sparse MLA backend for GPUs without FlashMLA Sparse (SM90+)
+or FlashInfer MLA Sparse (SM100+), e.g. SM80 (A100) and SM121 (GB10)."""
+
+from typing import ClassVar
+
+import torch
+
+from vllm.config import get_current_vllm_config_or_none
+from vllm.config.cache import CacheDType
+from vllm.platforms.interface import DeviceCapability
+from vllm.utils.platform_utils import num_compute_units
+from vllm.v1.attention.backend import AttentionBackend, AttentionCGSupport
+from vllm.v1.attention.backends.mla.xpu_mla_sparse import (
+    XPUMLASparseImpl,
+    XPUMLASparseMetadata,
+    XPUMLASparseMetadataBuilder,
+)
+from vllm.v1.attention.ops.mqa_logits_triton import (
+    warmup_fp8_mqa_logits_triton,
+    warmup_fp8_paged_mqa_logits_triton,
+)
+from vllm.v1.attention.ops.triton_sparse_mla_kernel import (
+    _DIM_QK,
+    KV_SPLITS_CANDIDATES,
+    triton_sparse_mla_attention,
+)
+
+# DeepSeek-V3.2 / GLM-5.1 indexer shape, the only model family this backend
+# serves. Used only for autotune priming — if a future model differs, the
+# kernel simply re-tunes on first real use (same as pre-warmup behavior).
+_INDEXER_NUM_HEADS = 64
+_INDEXER_HEAD_DIM = 128
+
+
+class TritonMLASparseMetadataBuilder(XPUMLASparseMetadataBuilder):
+    """Metadata builder advertising cudagraph support for the CUDA/Triton
+    sparse MLA path. The XPU base keeps `AttentionCGSupport.NEVER` because
+    its kernel has not been validated under cudagraph capture; this subclass
+    is the only place the capability is claimed."""
+
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+
+
+class TritonMLASparseImpl(XPUMLASparseImpl):
+    """Overrides XPU sparse impl to use the split-KV kernel, which is
+    3–7× faster for single-query decode on SM80 (A100/A30) and SM120 (GB10).
+    """
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        # Cached device SM count; passed into the kernel dispatch each forward
+        # so the hot path doesn't re-query `q.device.index` → dict lookup.
+        self._sm_count: int | None = None
+        if self.topk_indices_buffer is not None:
+            self._sm_count = num_compute_units(self.topk_indices_buffer.device.index)
+        self._warmup_autotune()
+
+    def _warmup_autotune(self) -> None:
+        """Prime `@triton.autotune` caches at init so the first user request
+        does not pay the ~24 config-sweep cost inline."""
+        if self.topk_indices_buffer is None:
+            return
+        device = self.topk_indices_buffer.device
+        topk = self.topk_indices_buffer.shape[-1]
+        q = torch.empty(1, self.num_heads, _DIM_QK, dtype=torch.bfloat16, device=device)
+        kv = torch.empty(64, 1, _DIM_QK, dtype=torch.bfloat16, device=device)
+        indices = torch.zeros(1, 1, topk, dtype=torch.int32, device=device)
+        for splits in KV_SPLITS_CANDIDATES:
+            triton_sparse_mla_attention(
+                q,
+                kv,
+                indices,
+                sm_scale=self.softmax_scale,
+                num_kv_splits=splits,
+                sm_count=self._sm_count,
+            )
+        # The indexer's fp8 MQA logits kernels live on a separate autotune
+        # cache. Prime them here so cold TTFT doesn't include their sweep.
+        warmup_fp8_mqa_logits_triton(
+            num_heads=_INDEXER_NUM_HEADS, head_dim=_INDEXER_HEAD_DIM, device=device
+        )
+        cfg = get_current_vllm_config_or_none()
+        if cfg is not None:
+            warmup_fp8_paged_mqa_logits_triton(
+                num_heads=_INDEXER_NUM_HEADS,
+                head_dim=_INDEXER_HEAD_DIM,
+                block_size=cfg.cache_config.block_size,
+                device=device,
+            )
+
+    def _forward_bf16_kv(
+        self,
+        q: torch.Tensor,  # [sq, heads, d_qk]
+        kv_c_and_k_pe_cache: torch.Tensor,  # [blocks, heads, d_qk]
+        topk_indices: torch.Tensor,  # [sq, topk]
+        attn_metadata: XPUMLASparseMetadata,
+    ) -> torch.Tensor:
+        num_tokens = q.shape[0]
+        kv_c_and_k_pe_cache = kv_c_and_k_pe_cache.view(
+            -1, 1, kv_c_and_k_pe_cache.shape[-1]
+        )
+        topk_indices = topk_indices.view(num_tokens, 1, -1)
+        output = triton_sparse_mla_attention(
+            q,
+            kv_c_and_k_pe_cache,
+            topk_indices,
+            sm_scale=self.softmax_scale,
+            sm_count=self._sm_count,
+        )
+        return output[:, : self.num_heads, :]
+
+
+class TritonMLASparseBackend(AttentionBackend):
+    supported_dtypes: ClassVar[list[torch.dtype]] = [
+        torch.float16,
+        torch.bfloat16,
+    ]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = [
+        "auto",
+        "float16",
+        "bfloat16",
+    ]
+
+    @staticmethod
+    def get_name() -> str:
+        return "TRITON_MLA_SPARSE"
+
+    @staticmethod
+    def get_metadata_cls() -> type[XPUMLASparseMetadata]:
+        return XPUMLASparseMetadata
+
+    @staticmethod
+    def get_builder_cls() -> type["TritonMLASparseMetadataBuilder"]:
+        return TritonMLASparseMetadataBuilder
+
+    @staticmethod
+    def get_impl_cls() -> type["TritonMLASparseImpl"]:
+        return TritonMLASparseImpl
+
+    @classmethod
+    def is_mla(cls) -> bool:
+        return True
+
+    @classmethod
+    def is_sparse(cls) -> bool:
+        return True
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        return (num_blocks, block_size, head_size)
+
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int]:
+        return [_DIM_QK]
+
+    @classmethod
+    def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
+        return True

--- a/vllm/v1/attention/backends/registry.py
+++ b/vllm/v1/attention/backends/registry.py
@@ -68,6 +68,9 @@ class AttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
         "FlashInferMLASparseBackend"
     )
     TRITON_MLA = "vllm.v1.attention.backends.mla.triton_mla.TritonMLABackend"
+    TRITON_MLA_SPARSE = (
+        "vllm.v1.attention.backends.mla.triton_mla_sparse.TritonMLASparseBackend"
+    )
     CUTLASS_MLA = "vllm.v1.attention.backends.mla.cutlass_mla.CutlassMLABackend"
     FLASHMLA = "vllm.v1.attention.backends.mla.flashmla.FlashMLABackend"
     FLASHMLA_SPARSE = (

--- a/vllm/v1/attention/ops/deepseek_v4_ops/cache_utils.py
+++ b/vllm/v1/attention/ops/deepseek_v4_ops/cache_utils.py
@@ -17,6 +17,7 @@ preparation.
 import torch
 
 from vllm.triton_utils import tl, triton
+from vllm.v1.attention.ops.mqa_logits_triton import _decode_e4m3fn
 
 
 @triton.jit
@@ -303,6 +304,249 @@ def _dequantize_and_gather_k_kernel(
             tl.store(output_row_ptr + bf16_output_offset + chunk_offsets, bf16_vals)
 
 
+def _dequantize_and_gather_k_cache_torch(
+    out: torch.Tensor,
+    k_cache: torch.Tensor,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor | None,
+    block_table: torch.Tensor,
+    block_size: int,
+    offset: int,
+) -> None:
+    """SM80 PyTorch fallback. Vectorised — single batched gather across all
+    (req, token_in_seq) pairs, then dequant + scatter into `out`."""
+    TOKEN_FP8_DIM = 448
+    TOKEN_BF16_DIM = 64
+    TOKEN_SCALE_DIM = 8
+    QUANT_BLOCK_SIZE = 64
+    TOKEN_DATA_SIZE = TOKEN_FP8_DIM + TOKEN_BF16_DIM * 2
+    OUTPUT_DIM = 512
+    N_NOPE_BLOCKS = TOKEN_FP8_DIM // QUANT_BLOCK_SIZE
+
+    device = out.device
+    num_reqs = seq_lens.shape[0]
+    if num_reqs == 0:
+        return
+
+    k_cache_u8 = k_cache.view(torch.uint8) if k_cache.dtype != torch.uint8 else k_cache
+    n_blocks = k_cache_u8.shape[0]
+    block_stride = k_cache_u8[0].numel()
+    flat = k_cache_u8.view(n_blocks, block_stride)
+
+    effective_lens = (
+        gather_lens.to(torch.int64)
+        if gather_lens is not None
+        else seq_lens.to(torch.int64)
+    )
+    if effective_lens.numel() == 0:
+        return
+    max_len = int(effective_lens.max().item())
+    if max_len <= 0:
+        return
+
+    t_grid = torch.arange(max_len, device=device, dtype=torch.int64)
+    valid = t_grid.unsqueeze(0) < effective_lens.unsqueeze(-1)  # (R, max_len)
+    req_idx_flat, t_flat = valid.nonzero(as_tuple=True)
+    if req_idx_flat.numel() == 0:
+        return
+
+    block_indices = t_flat // block_size
+    block_offsets = t_flat % block_size
+    block_numbers = block_table[req_idx_flat, block_indices].to(torch.int64)
+
+    t_off = block_offsets * TOKEN_DATA_SIZE
+    s_off = block_size * TOKEN_DATA_SIZE + block_offsets * TOKEN_SCALE_DIM
+
+    fp8_idx = t_off.unsqueeze(-1) + torch.arange(
+        TOKEN_FP8_DIM, device=device, dtype=torch.int64
+    )
+    bf16_idx = (t_off + TOKEN_FP8_DIM).unsqueeze(-1) + torch.arange(
+        TOKEN_BF16_DIM * 2, device=device, dtype=torch.int64
+    )
+    scale_idx = s_off.unsqueeze(-1) + torch.arange(
+        N_NOPE_BLOCKS, device=device, dtype=torch.int64
+    )
+
+    fp8_bytes = flat[block_numbers.unsqueeze(-1), fp8_idx].view(torch.float8_e4m3fn)
+    bf16_bytes_raw = flat[block_numbers.unsqueeze(-1), bf16_idx].contiguous()
+    bf16_view = bf16_bytes_raw.view(torch.bfloat16).view(-1, TOKEN_BF16_DIM)
+    scales_u8 = flat[block_numbers.unsqueeze(-1), scale_idx]
+
+    x_fp32 = fp8_bytes.to(torch.float32).view(-1, N_NOPE_BLOCKS, QUANT_BLOCK_SIZE)
+    scale_factor = torch.pow(2.0, scales_u8.to(torch.float32) - 127.0).unsqueeze(-1)
+    dequant_fp8 = (x_fp32 * scale_factor).view(-1, TOKEN_FP8_DIM).to(torch.bfloat16)
+
+    full = torch.empty(
+        (req_idx_flat.shape[0], OUTPUT_DIM),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    full[:, :TOKEN_FP8_DIM] = dequant_fp8
+    full[:, TOKEN_FP8_DIM:] = bf16_view
+
+    out[req_idx_flat, t_flat + offset, :] = full
+
+
+@triton.jit
+def _dequantize_and_gather_k_kernel_sm80(
+    out_ptr,
+    out_stride0,
+    out_stride1,
+    k_cache_ptr,
+    seq_lens_ptr,
+    block_table_ptr,
+    offset,
+    gather_lens_ptr,
+    max_blocks_per_seq: tl.constexpr,
+    fp8_dim: tl.constexpr,
+    bf16_dim: tl.constexpr,
+    scale_dim: tl.constexpr,
+    quant_block: tl.constexpr,
+    cache_block_size: tl.constexpr,
+    token_data_size: tl.constexpr,
+    block_stride: tl.constexpr,
+    output_dim: tl.constexpr,
+    fp8_max: tl.constexpr,
+    n_quant_blocks: tl.constexpr,
+):
+    """SM80 variant of `_dequantize_and_gather_k_kernel`. Replaces the
+    `tl.float8e4nv` bitcast with the software `_decode_e4m3fn` decoder
+    from PR 38476 (uint8 → fp32 in ~6 ops/elt). Same launch shape and
+    layout as the SM90+ kernel."""
+    batch_idx = tl.program_id(0)
+    worker_id = tl.program_id(1)
+    num_workers = tl.num_programs(1)
+
+    seq_len = tl.load(seq_lens_ptr + batch_idx)
+    if gather_lens_ptr is not None:  # noqa: SIM108
+        gather_len = tl.load(gather_lens_ptr + batch_idx)
+    else:
+        gather_len = seq_len
+    start_pos = seq_len - gather_len
+
+    for i in range(worker_id, gather_len, num_workers):
+        pos = start_pos + i
+        block_in_seq = pos // cache_block_size
+        pos_in_block = pos % cache_block_size
+
+        block_table_row_ptr = block_table_ptr + batch_idx * max_blocks_per_seq
+        physical_block_idx = tl.load(block_table_row_ptr + block_in_seq)
+        cache_block_ptr = k_cache_ptr + physical_block_idx.to(tl.int64) * block_stride
+        token_data_ptr = cache_block_ptr + pos_in_block * token_data_size
+        token_scale_ptr = (
+            cache_block_ptr
+            + cache_block_size * token_data_size
+            + pos_in_block * scale_dim
+        )
+        token_fp8_ptr = token_data_ptr
+        token_bf16_ptr = token_data_ptr + fp8_dim
+        output_row_ptr = out_ptr + batch_idx * out_stride0 + (offset + i) * out_stride1
+
+        for qblock_idx in tl.static_range(n_quant_blocks):
+            qblock_start = qblock_idx * quant_block
+            if qblock_start < fp8_dim:
+                offsets = qblock_start + tl.arange(0, quant_block)
+                mask = offsets < fp8_dim
+                x_uint8 = tl.load(token_fp8_ptr + offsets, mask=mask, other=0)
+                # Software fp8e4nv → fp32 (no tl.float8e4nv reference).
+                x_float = _decode_e4m3fn(x_uint8)
+                encoded_scale = tl.load(token_scale_ptr + qblock_idx)
+                exponent = encoded_scale.to(tl.float32) - 127.0
+                scale = tl.exp2(exponent)
+                x_dequant = x_float * scale
+                tl.store(
+                    output_row_ptr + offsets,
+                    x_dequant.to(tl.bfloat16),
+                    mask=mask,
+                )
+
+        bf16_output_offset = fp8_dim
+        bf16_cache_ptr = token_bf16_ptr.to(tl.pointer_type(tl.bfloat16))
+        for j in tl.static_range(bf16_dim // 16):
+            chunk_offsets = j * 16 + tl.arange(0, 16)
+            bf16_vals = tl.load(bf16_cache_ptr + chunk_offsets)
+            tl.store(output_row_ptr + bf16_output_offset + chunk_offsets, bf16_vals)
+
+
+def _dequantize_and_gather_k_cache_triton(
+    out: torch.Tensor,
+    k_cache: torch.Tensor,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor | None,
+    block_table: torch.Tensor,
+    block_size: int,
+    offset: int,
+) -> None:
+    """SM80 Triton dispatch — uses _decode_e4m3fn instead of the
+    fp8e4nv bitcast that Triton refuses to compile on SM80."""
+    TOKEN_FP8_DIM = 448
+    TOKEN_BF16_DIM = 64
+    TOKEN_SCALE_DIM = 8
+    QUANT_BLOCK_SIZE = 64
+    FP8_MAX = 448.0
+    TOKEN_DATA_SIZE = TOKEN_FP8_DIM + TOKEN_BF16_DIM * 2
+
+    num_reqs = seq_lens.shape[0]
+    NUM_WORKERS = 128
+    _dequantize_and_gather_k_kernel_sm80[(num_reqs, NUM_WORKERS)](
+        out,
+        out.stride(0),
+        out.stride(1),
+        k_cache,
+        seq_lens,
+        block_table,
+        offset,
+        gather_lens,
+        max_blocks_per_seq=block_table.shape[-1],
+        fp8_dim=TOKEN_FP8_DIM,
+        bf16_dim=TOKEN_BF16_DIM,
+        scale_dim=TOKEN_SCALE_DIM,
+        quant_block=QUANT_BLOCK_SIZE,
+        cache_block_size=block_size,
+        token_data_size=TOKEN_DATA_SIZE,
+        block_stride=k_cache.stride(0),
+        output_dim=512,
+        fp8_max=FP8_MAX,
+        n_quant_blocks=7,
+    )
+
+
+def _dequant_gather_sm80_op(
+    out: torch.Tensor,
+    k_cache: torch.Tensor,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor | None,
+    block_table: torch.Tensor,
+    block_size: int,
+    offset: int,
+) -> None:
+    _dequantize_and_gather_k_cache_triton(
+        out, k_cache, seq_lens, gather_lens, block_table, block_size, offset
+    )
+
+
+def _dequant_gather_sm80_op_fake(
+    out: torch.Tensor,
+    k_cache: torch.Tensor,
+    seq_lens: torch.Tensor,
+    gather_lens: torch.Tensor | None,
+    block_table: torch.Tensor,
+    block_size: int,
+    offset: int,
+) -> None:
+    return None
+
+
+from vllm.utils.torch_utils import direct_register_custom_op  # noqa: E402
+
+direct_register_custom_op(
+    op_name="deepseek_v4_dequant_gather_sm80",
+    op_func=_dequant_gather_sm80_op,
+    mutates_args=["out"],
+    fake_impl=_dequant_gather_sm80_op_fake,
+)
+
+
 def dequantize_and_gather_k_cache(
     # [num_reqs, max_num_tokens, head_size]
     out: torch.Tensor,
@@ -317,6 +561,17 @@ def dequantize_and_gather_k_cache(
     block_size: int,
     offset: int,
 ) -> None:
+    from vllm.utils.deep_gemm import use_dsv4_reference_kernels
+
+    if use_dsv4_reference_kernels():
+        # SM80: Triton can't bitcast uint8 → float8e4nv; route through the
+        # custom op so cudagraph capture splits at this call site (the body
+        # uses .max().item() and .nonzero(), forbidden during capture).
+        torch.ops.vllm.deepseek_v4_dequant_gather_sm80(
+            out, k_cache, seq_lens, gather_lens, block_table, block_size, offset
+        )
+        return
+
     TOKEN_FP8_DIM = 448
     TOKEN_BF16_DIM = 64
     TOKEN_SCALE_DIM = 8

--- a/vllm/v1/attention/ops/deepseek_v4_ops/fused_compress_quant_cache.py
+++ b/vllm/v1/attention/ops/deepseek_v4_ops/fused_compress_quant_cache.py
@@ -19,7 +19,10 @@ even/odd halves, producing (N_QUANT_BLOCKS, MXFP4_BLOCK/2) packed nibbles
 and N_QUANT_BLOCKS ue8m0 bytes.
 """
 
+import torch
+
 from vllm.triton_utils import tl, triton
+from vllm.utils.torch_utils import direct_register_custom_op
 
 from .fused_indexer_q import _e2m1_nibble
 
@@ -27,6 +30,245 @@ from .fused_indexer_q import _e2m1_nibble
 # =============================================================================
 # DeepseekV4 Attention path (head=512, nope=448 FP8 + rope=64 bf16)
 # =============================================================================
+def _gather_compressor_state(
+    state_cache: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    positions: torch.Tensor,
+    valid_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    head_size: int,
+    state_width: int,
+    span: int,
+    compress_ratio: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Vectorised gather of (kv, score) rows from the paged compressor
+    state cache. Returns (kv_rows, score_rows) of shape (N, span, head_size)
+    with -inf score and zero kv for out-of-range positions.
+
+    State cache last-dim layout:  [kv_curr | kv_overlap | score_curr | score_overlap]
+    each of width head_size. For C4A (overlap=True), span=8 with first 4
+    tokens reading the [_curr] regions and last 4 reading the [_overlap]
+    regions; for C128A, span=128 and head_offset is uniformly 0.
+    """
+    device = state_cache.device
+    pos_offsets = torch.arange(span, device=device, dtype=torch.int64) - span + 1
+    abs_pos = positions[valid_indices].to(torch.int64).unsqueeze(-1) + pos_offsets
+    mask_pos = abs_pos >= 0
+    pos_safe = abs_pos.clamp_min(0)
+    block_indices = pos_safe // block_size
+    block_offsets = pos_safe % block_size
+    req_idx = token_to_req_indices[valid_indices].to(torch.int64)
+    block_numbers = block_table[req_idx.unsqueeze(-1), block_indices]  # (N, span)
+
+    # Single batched gather: (N, span, 2 * state_width).
+    gathered = state_cache[block_numbers, block_offsets].to(torch.float32)
+
+    # Split kv/score halves: state_cache[..., :state_width] is kv, the rest is score.
+    kv_half = gathered[..., :state_width]
+    score_half = gathered[..., state_width : 2 * state_width]
+
+    if span == compress_ratio:
+        kv_rows = kv_half[..., :head_size]
+        score_rows = score_half[..., :head_size]
+    else:
+        # span = 2 * compress_ratio (C4A): first half from offset 0,
+        # second half from offset head_size.
+        kv_rows = torch.cat(
+            [
+                kv_half[:, :compress_ratio, :head_size],
+                kv_half[:, compress_ratio:, head_size : 2 * head_size],
+            ],
+            dim=1,
+        )
+        score_rows = torch.cat(
+            [
+                score_half[:, :compress_ratio, :head_size],
+                score_half[:, compress_ratio:, head_size : 2 * head_size],
+            ],
+            dim=1,
+        )
+
+    invalid = ~mask_pos.unsqueeze(-1)
+    kv_rows = torch.where(invalid, torch.zeros_like(kv_rows), kv_rows)
+    score_rows = torch.where(
+        invalid,
+        torch.full_like(score_rows, float("-inf")),
+        score_rows,
+    )
+    return kv_rows, score_rows
+
+
+def _scatter_packed_kv_cache(
+    k_cache: torch.Tensor,
+    fp8_bytes: torch.Tensor,
+    bf16_bytes: torch.Tensor | None,
+    scale_bytes: torch.Tensor,
+    kv_slot_mapping: torch.Tensor,
+    valid_indices: torch.Tensor,
+    kv_cache_block_size: int,
+    token_stride: int,
+    scale_dim: int,
+    fp8_dim: int,
+) -> None:
+    """Vectorised scatter of (FP8 nope | bf16 rope | UE8M0 scales) bytes
+    into the paged uint8 KV cache."""
+    k_cache_u8 = k_cache.view(torch.uint8) if k_cache.dtype != torch.uint8 else k_cache
+    n_blocks = k_cache_u8.shape[0]
+    block_stride = k_cache_u8[0].numel()  # bytes per block
+    flat = k_cache_u8.view(n_blocks, block_stride)
+
+    slots = kv_slot_mapping[valid_indices].to(torch.int64)
+    block_idx = slots // kv_cache_block_size
+    pos_in_block = slots % kv_cache_block_size
+
+    token_offsets = pos_in_block * token_stride
+    scale_offsets = kv_cache_block_size * token_stride + pos_in_block * scale_dim
+
+    # FP8 nope byte scatter: flat[block_idx, token_offsets+0..fp8_dim] = fp8_bytes
+    fp8_idx = token_offsets.unsqueeze(-1) + torch.arange(
+        fp8_dim, device=k_cache_u8.device, dtype=torch.int64
+    )
+    flat[block_idx.unsqueeze(-1), fp8_idx] = fp8_bytes
+
+    # Optional bf16 rope byte scatter
+    if bf16_bytes is not None:
+        bf16_n = bf16_bytes.shape[-1]
+        bf16_off = (
+            token_offsets.unsqueeze(-1)
+            + fp8_dim
+            + torch.arange(bf16_n, device=k_cache_u8.device, dtype=torch.int64)
+        )
+        flat[block_idx.unsqueeze(-1), bf16_off] = bf16_bytes
+
+    # Scales scatter
+    s_idx = scale_offsets.unsqueeze(-1) + torch.arange(
+        scale_dim, device=k_cache_u8.device, dtype=torch.int64
+    )
+    flat[block_idx.unsqueeze(-1), s_idx] = scale_bytes
+
+
+def _fused_kv_compress_norm_rope_insert_sparse_attn_torch(
+    state_cache: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    positions: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    rms_norm_weight: torch.Tensor,
+    rms_norm_eps: float,
+    cos_sin_cache: torch.Tensor,
+    k_cache: torch.Tensor,
+    kv_slot_mapping: torch.Tensor,
+    kv_cache_block_size: int,
+    head_size: int,
+    state_width: int,
+    compress_ratio: int,
+    overlap: bool,
+    rope_head_dim: int,
+    fp8_max: float,
+    quant_block: int,
+    token_stride: int,
+    scale_dim: int,
+) -> None:
+    """SM80 PyTorch fallback for the V4 K-cache compressor (head_dim=512).
+    Vectorised: single batched gather + matmul softmax + RMSNorm + RoPE +
+    UE8M0 FP8 quant + scattered cache write. No per-token Python loop or
+    `.item()` calls."""
+    device = state_cache.device
+    nope_head_dim = head_size - rope_head_dim
+    n_nope_blocks = nope_head_dim // quant_block
+    half_rope = rope_head_dim // 2
+    span = (1 + int(overlap)) * compress_ratio
+
+    # cudagraph dummy runs may pass kv_slot_mapping with different padding
+    # than slot_mapping; align to the smaller (state-side) length.
+    n_match = min(slot_mapping.shape[0], kv_slot_mapping.shape[0])
+    slot_mapping = slot_mapping[:n_match]
+    kv_slot_mapping = kv_slot_mapping[:n_match]
+    positions = positions[:n_match]
+    token_to_req_indices = token_to_req_indices[:n_match]
+    valid_mask = (
+        (slot_mapping >= 0)
+        & ((positions + 1) % compress_ratio == 0)
+        & (kv_slot_mapping >= 0)
+    )
+    if not valid_mask.any():
+        return
+    valid_indices = valid_mask.nonzero(as_tuple=False).squeeze(-1)
+
+    kv_rows, score_rows = _gather_compressor_state(
+        state_cache,
+        token_to_req_indices,
+        positions,
+        valid_indices,
+        block_table,
+        block_size,
+        head_size,
+        state_width,
+        span,
+        compress_ratio,
+    )
+
+    # Softmax over the span axis per (token, feature), then weighted sum.
+    weights = torch.softmax(score_rows, dim=1)
+    compressed_kv = (kv_rows * weights).sum(dim=1)  # (N, head_size)
+
+    # RMSNorm
+    variance = (compressed_kv * compressed_kv).mean(dim=-1, keepdim=True)
+    rrms = torch.rsqrt(variance + rms_norm_eps)
+    normed = compressed_kv * rrms * rms_norm_weight.to(torch.float32)
+
+    # FP8 quant on NoPE region (block-wise UE8M0).
+    nope = normed[:, :nope_head_dim].view(-1, n_nope_blocks, quant_block)
+    nope_bf16 = nope.to(torch.bfloat16).to(torch.float32)
+    block_absmax = nope_bf16.abs().amax(dim=-1).clamp_min(1e-4)
+    raw_scale = block_absmax / fp8_max
+    exponents = torch.ceil(torch.log2(raw_scale))
+    inv_scale = torch.pow(2.0, -exponents).unsqueeze(-1)
+    quantized = (nope_bf16 * inv_scale).clamp(-fp8_max, fp8_max)
+    fp8_nope = quantized.to(torch.float8_e4m3fn).view(-1, nope_head_dim)
+    fp8_nope_bytes = fp8_nope.view(torch.uint8)
+
+    encoded_scales = (exponents + 127.0).clamp(0.0, 255.0).to(torch.uint8)
+    pad_col = torch.zeros(
+        encoded_scales.shape[0],
+        scale_dim - n_nope_blocks,
+        device=device,
+        dtype=torch.uint8,
+    )
+    scales_full = torch.cat([encoded_scales, pad_col], dim=-1)
+
+    # Forward GPT-J RoPE on the RoPE region.
+    rope_part = normed[:, nope_head_dim:]
+    even = rope_part[:, 0::2]
+    odd = rope_part[:, 1::2]
+    valid_positions = positions[valid_indices].to(torch.long)
+    compressed_pos = (valid_positions // compress_ratio) * compress_ratio
+    cs = cos_sin_cache.index_select(0, compressed_pos)
+    cos = cs[:, :half_rope].to(torch.float32)
+    sin = cs[:, half_rope : 2 * half_rope].to(torch.float32)
+    new_even = even * cos - odd * sin
+    new_odd = odd * cos + even * sin
+    rope_out = torch.empty_like(rope_part)
+    rope_out[:, 0::2] = new_even
+    rope_out[:, 1::2] = new_odd
+    rope_bytes = rope_out.to(torch.bfloat16).view(torch.uint8)
+
+    _scatter_packed_kv_cache(
+        k_cache,
+        fp8_nope_bytes,
+        rope_bytes,
+        scales_full,
+        kv_slot_mapping,
+        valid_indices,
+        kv_cache_block_size,
+        token_stride,
+        scale_dim,
+        fp8_dim=nope_head_dim,
+    )
+
+
 @triton.jit
 def _fused_kv_compress_norm_rope_insert_sparse_attn(
     # ── state cache (compressor internal state) ──
@@ -212,6 +454,116 @@ def _fused_kv_compress_norm_rope_insert_sparse_attn(
     rope_local = block - NOPE_HEAD_DIM
     is_rope = (block >= NOPE_HEAD_DIM) & mask
     tl.store(bf16_ptr + rope_local, result.to(tl.bfloat16), mask=is_rope)
+
+
+def _fused_kv_compress_norm_rope_insert_indexer_attn_torch(
+    state_cache: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    positions: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    rms_norm_weight: torch.Tensor,
+    rms_norm_eps: float,
+    cos_sin_cache: torch.Tensor,
+    k_cache: torch.Tensor,
+    kv_slot_mapping: torch.Tensor,
+    kv_cache_block_size: int,
+    head_size: int,
+    state_width: int,
+    compress_ratio: int,
+    overlap: bool,
+    rope_head_dim: int,
+    fp8_max: float,
+    quant_block: int,
+    token_stride: int,
+    scale_dim: int,
+) -> None:
+    """SM80 PyTorch fallback for the indexer K-cache FP8 compressor
+    (head_dim=128). Vectorised — no per-token Python loop."""
+    nope_head_dim = head_size - rope_head_dim
+    half_rope = rope_head_dim // 2
+    span = (1 + int(overlap)) * compress_ratio
+    assert head_size == quant_block, (
+        "Indexer compressor expects QUANT_BLOCK == HEAD_SIZE"
+    )
+
+    # cudagraph dummy runs may pass kv_slot_mapping with different padding
+    # than slot_mapping; align to the smaller (state-side) length.
+    n_match = min(slot_mapping.shape[0], kv_slot_mapping.shape[0])
+    slot_mapping = slot_mapping[:n_match]
+    kv_slot_mapping = kv_slot_mapping[:n_match]
+    positions = positions[:n_match]
+    token_to_req_indices = token_to_req_indices[:n_match]
+    valid_mask = (
+        (slot_mapping >= 0)
+        & ((positions + 1) % compress_ratio == 0)
+        & (kv_slot_mapping >= 0)
+    )
+    if not valid_mask.any():
+        return
+    valid_indices = valid_mask.nonzero(as_tuple=False).squeeze(-1)
+
+    kv_rows, score_rows = _gather_compressor_state(
+        state_cache,
+        token_to_req_indices,
+        positions,
+        valid_indices,
+        block_table,
+        block_size,
+        head_size,
+        state_width,
+        span,
+        compress_ratio,
+    )
+
+    weights = torch.softmax(score_rows, dim=1)
+    compressed_kv = (kv_rows * weights).sum(dim=1)  # (N, head_size)
+    variance = (compressed_kv * compressed_kv).mean(dim=-1, keepdim=True)
+    rrms = torch.rsqrt(variance + rms_norm_eps)
+    normed = compressed_kv * rrms * rms_norm_weight.to(torch.float32)
+
+    # Forward GPT-J RoPE on the last rope_head_dim elements.
+    nope = normed[:, :nope_head_dim]
+    rope_part = normed[:, nope_head_dim:]
+    even = rope_part[:, 0::2]
+    odd = rope_part[:, 1::2]
+    valid_positions = positions[valid_indices].to(torch.long)
+    compressed_pos = (valid_positions // compress_ratio) * compress_ratio
+    cs = cos_sin_cache.index_select(0, compressed_pos)
+    cos = cs[:, :half_rope].to(torch.float32)
+    sin = cs[:, half_rope : 2 * half_rope].to(torch.float32)
+    new_even = even * cos - odd * sin
+    new_odd = odd * cos + even * sin
+    rope_out = torch.empty_like(rope_part)
+    rope_out[:, 0::2] = new_even
+    rope_out[:, 1::2] = new_odd
+
+    full = torch.cat([nope, rope_out], dim=-1)
+    full_bf16 = full.to(torch.bfloat16).to(torch.float32)
+    absmax = full_bf16.abs().amax(dim=-1).clamp_min(1e-4)
+    raw_scale = absmax / fp8_max
+    exponents = torch.ceil(torch.log2(raw_scale))
+    inv_scale = torch.pow(2.0, -exponents).unsqueeze(-1)
+    quantized = (full_bf16 * inv_scale).clamp(-fp8_max, fp8_max)
+    fp8_full = quantized.to(torch.float8_e4m3fn)
+    fp8_bytes = fp8_full.view(torch.uint8)
+
+    scale_vals = torch.pow(2.0, exponents).to(torch.float32)
+    scale_bytes = scale_vals.view(-1, 1).view(torch.uint8)  # (N, 4)
+
+    _scatter_packed_kv_cache(
+        k_cache,
+        fp8_bytes,
+        bf16_bytes=None,
+        scale_bytes=scale_bytes,
+        kv_slot_mapping=kv_slot_mapping,
+        valid_indices=valid_indices,
+        kv_cache_block_size=kv_cache_block_size,
+        token_stride=token_stride,
+        scale_dim=scale_dim,
+        fp8_dim=head_size,
+    )
 
 
 # =============================================================================
@@ -582,3 +934,150 @@ def _fused_kv_compress_norm_rope_insert_indexer_mxfp4_attn(
 
     tl.store(val_ptr + tl.arange(0, TOKEN_STRIDE), packed_flat)
     tl.store(scale_ptr + tl.arange(0, SCALE_DIM), ue8m0)
+
+
+# =============================================================================
+# Custom-op wrappers for cudagraph splitting on SM80 reference paths.
+#
+# The compressor PyTorch fallbacks use .any() / .nonzero() / .item() — all of
+# which are illegal during cudagraph capture (data-dependent control flow).
+# Registering them as vllm:: custom ops + listing them in CompilationConfig.
+# _attention_ops makes vllm split the cudagraph at the call site so the
+# fallback body runs eager outside the captured replay.
+# =============================================================================
+
+
+def _compressor_sparse_attn_torch_op(
+    state_cache: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    positions: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    block_table: torch.Tensor,
+    rms_norm_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    k_cache: torch.Tensor,
+    kv_slot_mapping: torch.Tensor,
+    block_size: int,
+    rms_norm_eps: float,
+    kv_cache_block_size: int,
+    head_size: int,
+    state_width: int,
+    compress_ratio: int,
+    overlap: bool,
+    rope_head_dim: int,
+    fp8_max: float,
+    quant_block: int,
+    token_stride: int,
+    scale_dim: int,
+) -> None:
+    _fused_kv_compress_norm_rope_insert_sparse_attn_torch(
+        state_cache=state_cache,
+        token_to_req_indices=token_to_req_indices,
+        positions=positions,
+        slot_mapping=slot_mapping,
+        block_table=block_table,
+        block_size=block_size,
+        rms_norm_weight=rms_norm_weight,
+        rms_norm_eps=rms_norm_eps,
+        cos_sin_cache=cos_sin_cache,
+        k_cache=k_cache,
+        kv_slot_mapping=kv_slot_mapping,
+        kv_cache_block_size=kv_cache_block_size,
+        head_size=head_size,
+        state_width=state_width,
+        compress_ratio=compress_ratio,
+        overlap=overlap,
+        rope_head_dim=rope_head_dim,
+        fp8_max=fp8_max,
+        quant_block=quant_block,
+        token_stride=token_stride,
+        scale_dim=scale_dim,
+    )
+
+
+def _compressor_sparse_attn_torch_op_fake(
+    state_cache: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    positions: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    block_table: torch.Tensor,
+    rms_norm_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    k_cache: torch.Tensor,
+    kv_slot_mapping: torch.Tensor,
+    block_size: int,
+    rms_norm_eps: float,
+    kv_cache_block_size: int,
+    head_size: int,
+    state_width: int,
+    compress_ratio: int,
+    overlap: bool,
+    rope_head_dim: int,
+    fp8_max: float,
+    quant_block: int,
+    token_stride: int,
+    scale_dim: int,
+) -> None:
+    return None
+
+
+def _compressor_indexer_attn_torch_op(
+    state_cache: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    positions: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    block_table: torch.Tensor,
+    rms_norm_weight: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    k_cache: torch.Tensor,
+    kv_slot_mapping: torch.Tensor,
+    block_size: int,
+    rms_norm_eps: float,
+    kv_cache_block_size: int,
+    head_size: int,
+    state_width: int,
+    compress_ratio: int,
+    overlap: bool,
+    rope_head_dim: int,
+    fp8_max: float,
+    quant_block: int,
+    token_stride: int,
+    scale_dim: int,
+) -> None:
+    _fused_kv_compress_norm_rope_insert_indexer_attn_torch(
+        state_cache=state_cache,
+        token_to_req_indices=token_to_req_indices,
+        positions=positions,
+        slot_mapping=slot_mapping,
+        block_table=block_table,
+        block_size=block_size,
+        rms_norm_weight=rms_norm_weight,
+        rms_norm_eps=rms_norm_eps,
+        cos_sin_cache=cos_sin_cache,
+        k_cache=k_cache,
+        kv_slot_mapping=kv_slot_mapping,
+        kv_cache_block_size=kv_cache_block_size,
+        head_size=head_size,
+        state_width=state_width,
+        compress_ratio=compress_ratio,
+        overlap=overlap,
+        rope_head_dim=rope_head_dim,
+        fp8_max=fp8_max,
+        quant_block=quant_block,
+        token_stride=token_stride,
+        scale_dim=scale_dim,
+    )
+
+
+direct_register_custom_op(
+    op_name="deepseek_v4_compressor_sparse_sm80",
+    op_func=_compressor_sparse_attn_torch_op,
+    mutates_args=["k_cache", "state_cache"],
+    fake_impl=_compressor_sparse_attn_torch_op_fake,
+)
+direct_register_custom_op(
+    op_name="deepseek_v4_compressor_indexer_sm80",
+    op_func=_compressor_indexer_attn_torch_op,
+    mutates_args=["k_cache", "state_cache"],
+    fake_impl=_compressor_sparse_attn_torch_op_fake,
+)

--- a/vllm/v1/attention/ops/deepseek_v4_ops/fused_indexer_q.py
+++ b/vllm/v1/attention/ops/deepseek_v4_ops/fused_indexer_q.py
@@ -3,6 +3,7 @@
 import torch
 
 from vllm.triton_utils import tl, triton
+from vllm.utils.deep_gemm import use_dsv4_reference_kernels
 
 # MXFP4: 32 elements per block, packed 2 nibbles per byte, ue8m0 block scale.
 MXFP4_BLOCK_SIZE = 32
@@ -77,6 +78,83 @@ def _quantize_mxfp4_pair(x_lo, x_hi):
     hi_nib = _e2m1_nibble(x_hi * inv_scale)
     packed = lo_nib | (hi_nib << 4)
     return packed, ue8m0
+
+
+@triton.jit
+def _fused_indexer_q_rope_fp32_kernel(
+    pos_ptr,
+    index_q_ptr,
+    index_q_stride0,
+    index_q_stride1,
+    index_q_cos_sin_ptr,
+    index_q_cos_sin_stride,
+    INDEX_Q_HALF_ROT_DIM: tl.constexpr,
+    out_fp32_ptr,
+    out_stride0,
+    out_stride1,
+    INDEX_Q_HEAD_DIM: tl.constexpr,
+    index_weights_ptr,
+    index_weights_stride,
+    index_weights_softmax_scale,
+    index_weights_head_scale,
+    index_weights_out_ptr,
+    index_weights_out_stride,
+):
+    """SM80 variant of `_fused_indexer_q_rope_quant_kernel`. Outputs the
+    scaled-and-clamped fp32 Q (which the wrapper casts to fp8 in PyTorch
+    via .to(torch.float8_e4m3fn)). Triton on SM80 cannot compile
+    `tl.float8e4nv`, so the cast happens outside Triton."""
+    INDEX_Q_ROT_DIM: tl.constexpr = 2 * INDEX_Q_HALF_ROT_DIM
+    INDEX_Q_NOPE_DIM: tl.constexpr = INDEX_Q_HEAD_DIM - INDEX_Q_ROT_DIM
+    tl.static_assert(INDEX_Q_NOPE_DIM >= 0)
+
+    tok_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+
+    pos = tl.load(pos_ptr + tok_idx)
+    cos, sin = _get_cos_sin(
+        index_q_cos_sin_ptr,
+        index_q_cos_sin_stride,
+        pos,
+        INDEX_Q_HALF_ROT_DIM,
+    )
+    half_offset = tl.arange(0, INDEX_Q_HALF_ROT_DIM)
+    base_ptr = index_q_ptr + tok_idx * index_q_stride0 + head_idx * index_q_stride1
+
+    rot_base = base_ptr + INDEX_Q_NOPE_DIM
+    x_even = tl.load(rot_base + half_offset * 2).to(tl.float32)
+    x_odd = tl.load(rot_base + half_offset * 2 + 1).to(tl.float32)
+    r_even = x_even * cos - x_odd * sin
+    r_odd = x_odd * cos + x_even * sin
+    r_even = r_even.to(tl.bfloat16).to(tl.float32)
+    r_odd = r_odd.to(tl.bfloat16).to(tl.float32)
+
+    amax = tl.maximum(tl.max(tl.abs(r_even)), tl.max(tl.abs(r_odd)))
+    if INDEX_Q_NOPE_DIM > 0:
+        nope_offset = tl.arange(0, INDEX_Q_NOPE_DIM)
+        x_nope = tl.load(base_ptr + nope_offset).to(tl.float32)
+        amax = tl.maximum(amax, tl.max(tl.abs(x_nope)))
+    index_q_scale = tl.div_rn(tl.maximum(amax, 1e-4), 448.0)
+    index_q_scale = tl.math.exp2(tl.math.ceil(tl.math.log2(index_q_scale)))
+
+    out_base_ptr = out_fp32_ptr + tok_idx * out_stride0 + head_idx * out_stride1
+    if INDEX_Q_NOPE_DIM > 0:
+        tl.store(out_base_ptr + nope_offset, tl.div_rn(x_nope, index_q_scale))
+    out_rot_base = out_base_ptr + INDEX_Q_NOPE_DIM
+    tl.store(out_rot_base + half_offset * 2, tl.div_rn(r_even, index_q_scale))
+    tl.store(out_rot_base + half_offset * 2 + 1, tl.div_rn(r_odd, index_q_scale))
+
+    index_weights = tl.load(
+        index_weights_ptr + tok_idx * index_weights_stride + head_idx
+    )
+    index_weights = index_weights.to(tl.float32)
+    index_weights *= index_q_scale
+    index_weights *= index_weights_softmax_scale
+    index_weights *= index_weights_head_scale
+    tl.store(
+        index_weights_out_ptr + tok_idx * index_weights_out_stride + head_idx,
+        index_weights,
+    )
 
 
 @triton.jit
@@ -294,6 +372,62 @@ def _fused_indexer_q_rope_mxfp4_kernel(
     )
 
 
+def _fused_indexer_q_rope_quant_torch(
+    positions: torch.Tensor,
+    index_q: torch.Tensor,
+    index_q_cos_sin_cache: torch.Tensor,
+    index_weights: torch.Tensor,
+    index_weights_softmax_scale: float,
+    index_weights_head_scale: float,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """SM80 PyTorch fallback for the FP8 path. Matches kernel numerics:
+    forward GPT-J RoPE on the last `rope_dim` of each head, fp32→bf16→fp32
+    intermediate, per-(token, head) UE8M0 q_scale folded into weights."""
+    num_tokens, num_heads, head_dim = index_q.shape
+    rope_dim = index_q_cos_sin_cache.shape[-1]
+    half_rot = rope_dim // 2
+    nope_dim = head_dim - rope_dim
+
+    cos_sin = index_q_cos_sin_cache.index_select(0, positions.to(torch.long))
+    cos = cos_sin[..., :half_rot].view(num_tokens, 1, half_rot).to(torch.float32)
+    sin = (
+        cos_sin[..., half_rot : 2 * half_rot]
+        .view(num_tokens, 1, half_rot)
+        .to(torch.float32)
+    )
+
+    q = index_q.to(torch.float32)
+    nope = q[..., :nope_dim] if nope_dim > 0 else None
+    rope = q[..., nope_dim:]
+
+    even = rope[..., 0::2]
+    odd = rope[..., 1::2]
+    r_even = (even * cos - odd * sin).to(torch.bfloat16).to(torch.float32)
+    r_odd = (odd * cos + even * sin).to(torch.bfloat16).to(torch.float32)
+
+    rotated = torch.empty_like(rope)
+    rotated[..., 0::2] = r_even
+    rotated[..., 1::2] = r_odd
+
+    parts = [rotated]
+    if nope is not None:
+        parts = [nope, rotated]
+    full = torch.cat(parts, dim=-1)
+
+    amax = full.abs().amax(dim=-1).clamp_min(1e-4)
+    q_scale = torch.pow(2.0, torch.ceil(torch.log2(amax / 448.0)))
+    q_quant = (full / q_scale.unsqueeze(-1)).clamp(-448.0, 448.0)
+    index_q_fp8 = q_quant.to(torch.float8_e4m3fn)
+
+    weights = (
+        index_weights.to(torch.float32)
+        * q_scale
+        * index_weights_softmax_scale
+        * index_weights_head_scale
+    )
+    return index_q_fp8, weights
+
+
 def fused_indexer_q_rope_quant(
     positions: torch.Tensor,
     index_q: torch.Tensor,
@@ -334,6 +468,43 @@ def fused_indexer_q_rope_quant(
     assert positions.ndim == 1
     assert index_q.ndim == 3
     assert index_q_cos_sin_cache.ndim == 2
+
+    if not use_fp4 and use_dsv4_reference_kernels():
+        # SM80/ROCm hybrid: Triton kernel emits scaled fp32 Q + fp32
+        # weights_out, then PyTorch casts Q to fp8_e4m3fn (Triton on SM80
+        # cannot compile `tl.float8e4nv`). MXFP4 path is unchanged because
+        # it uses uint8 + ue8m0 (no fp8e4nv).
+        num_tokens = positions.shape[0]
+        num_index_q_heads = index_q.shape[1]
+        index_q_head_dim = index_q.shape[2]
+        out_fp32 = torch.empty(
+            (num_tokens, num_index_q_heads, index_q_head_dim),
+            dtype=torch.float32,
+            device=index_q.device,
+        )
+        weights_out = torch.empty_like(index_weights, dtype=torch.float32)
+        _fused_indexer_q_rope_fp32_kernel[(num_tokens, num_index_q_heads)](
+            positions,
+            index_q,
+            index_q.stride(0),
+            index_q.stride(1),
+            index_q_cos_sin_cache,
+            index_q_cos_sin_cache.stride(0),
+            index_q_cos_sin_cache.shape[-1] // 2,
+            out_fp32,
+            out_fp32.stride(0),
+            out_fp32.stride(1),
+            index_q_head_dim,
+            index_weights,
+            index_weights.stride(0),
+            index_weights_softmax_scale,
+            index_weights_head_scale,
+            weights_out,
+            weights_out.stride(0),
+            num_warps=1,
+        )
+        index_q_fp8 = out_fp32.to(torch.float8_e4m3fn)
+        return index_q_fp8, weights_out
 
     num_tokens = positions.shape[0]
     num_index_q_heads = index_q.shape[1]

--- a/vllm/v1/attention/ops/deepseek_v4_ops/fused_inv_rope_fp8_quant.py
+++ b/vllm/v1/attention/ops/deepseek_v4_ops/fused_inv_rope_fp8_quant.py
@@ -10,6 +10,7 @@ INT32-packed UE8M0 on SM100) so fp8_einsum skips transform_sf_into_required_layo
 import torch
 
 from vllm.triton_utils import tl, triton
+from vllm.utils.deep_gemm import use_dsv4_reference_kernels
 
 
 @triton.jit
@@ -133,6 +134,214 @@ def _fused_inv_rope_fp8_quant_per_head(
         tl.store(scale_addrs, scales)
 
 
+@triton.jit
+def _fused_inv_rope_fp32_quant_per_head(
+    o_ptr,
+    positions_ptr,
+    cos_sin_cache_ptr,
+    out_fp32_ptr,
+    scale_ptr,
+    num_tokens,
+    heads_per_group: tl.constexpr,
+    o_stride_token,
+    o_stride_head,
+    cache_stride_pos,
+    out_stride_group,
+    out_stride_token,
+    scale_stride_group,
+    scale_stride_k,
+    fp8_max: tl.constexpr,
+    eps: tl.constexpr,
+    QUANT_GROUP_SIZE: tl.constexpr,
+    CHUNKS_PER_HEAD: tl.constexpr,
+    ROPE_START: tl.constexpr,
+    HALF_ROPE: tl.constexpr,
+):
+    """SM80 variant of `_fused_inv_rope_fp8_quant_per_head`. Writes
+    fp32 (x_clamped, divided by per-block UE8M0 scale) instead of fp8.
+    Triton on SM80 cannot compile `tl.float8e4nv`; the fp8 cast is done
+    in PyTorch in the wrapper. Scales are written as fp32 (no TMA path)."""
+    pid_token = tl.program_id(0).to(tl.int64)
+    pid_gh = tl.program_id(1).to(tl.int64)
+
+    g = pid_gh // heads_per_group
+    head_in_group = pid_gh % heads_per_group
+    global_head = pid_gh
+    qb_start = head_in_group * CHUNKS_PER_HEAD
+
+    if pid_token >= num_tokens:
+        block_offsets = tl.arange(0, CHUNKS_PER_HEAD)
+        qb_indices = qb_start + block_offsets
+        scale_addrs = (
+            scale_ptr + g * scale_stride_group + pid_token + qb_indices * scale_stride_k
+        )
+        tl.store(scale_addrs, tl.zeros((CHUNKS_PER_HEAD,), dtype=tl.float32))
+        return
+
+    input_base = o_ptr + pid_token * o_stride_token + global_head * o_stride_head
+
+    HEAD_DIM: tl.constexpr = CHUNKS_PER_HEAD * QUANT_GROUP_SIZE
+    offsets = tl.arange(0, HEAD_DIM)
+    x = tl.load(input_base + offsets).to(tl.float32)
+
+    rope_abs_start: tl.constexpr = (CHUNKS_PER_HEAD - 1) * QUANT_GROUP_SIZE + ROPE_START
+    pos = tl.load(positions_ptr + pid_token)
+    cache_base = cos_sin_cache_ptr + pos * cache_stride_pos
+    is_rope = offsets >= rope_abs_start
+    rope_local = offsets - rope_abs_start
+
+    x_partner = tl.load(input_base + (offsets ^ 1), mask=is_rope, other=0.0).to(
+        tl.float32
+    )
+    cs_idx = tl.maximum(rope_local >> 1, 0)
+    cos_v = tl.load(cache_base + cs_idx, mask=is_rope, other=1.0)
+    sin_v = tl.load(cache_base + HALF_ROPE + cs_idx, mask=is_rope, other=0.0)
+    x_add = x * cos_v + x_partner * sin_v
+    x_sub = x * cos_v - x_partner * sin_v
+    is_even = (rope_local & 1) == 0
+    rotated = tl.where(is_even, x_add, x_sub)
+    x = tl.where(is_rope, rotated, x)
+
+    x_2d = tl.reshape(tl.abs(x), (CHUNKS_PER_HEAD, QUANT_GROUP_SIZE))
+    block_absmax = tl.maximum(tl.max(x_2d, axis=1), eps)
+    scale_raw = block_absmax * (1.0 / fp8_max)
+    scales = tl.math.exp2(tl.ceil(tl.log2(scale_raw)))
+
+    scales_exp = tl.reshape(
+        tl.broadcast_to(
+            tl.reshape(scales, (CHUNKS_PER_HEAD, 1)),
+            (CHUNKS_PER_HEAD, QUANT_GROUP_SIZE),
+        ),
+        (HEAD_DIM,),
+    )
+    x_clamped = tl.clamp(x / scales_exp, -fp8_max, fp8_max)
+
+    out_base = (
+        out_fp32_ptr
+        + g * out_stride_group
+        + pid_token * out_stride_token
+        + qb_start * QUANT_GROUP_SIZE
+    )
+    tl.store(out_base + offsets, x_clamped)
+
+    block_offsets = tl.arange(0, CHUNKS_PER_HEAD)
+    qb_indices = qb_start + block_offsets
+    scale_addrs = (
+        scale_ptr + g * scale_stride_group + pid_token + qb_indices * scale_stride_k
+    )
+    tl.store(scale_addrs, scales)
+
+
+def _fused_inv_rope_fp32_quant_triton(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    n_groups: int,
+    heads_per_group: int,
+    nope_dim: int,
+    rope_dim: int,
+    quant_group_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """SM80 hybrid path: Triton compute (inverse RoPE + per-block UE8M0
+    scale + scaled-and-clamped fp32 output), then the FP8 cast happens in
+    PyTorch in the caller. Avoids the per-token PyTorch op chain."""
+    num_tokens, num_heads, head_dim = o.shape
+    assert num_heads == n_groups * heads_per_group
+    d = heads_per_group * head_dim
+    num_scale_blocks = d // quant_group_size
+    chunks_per_head = head_dim // quant_group_size
+
+    out_fp32 = torch.empty(
+        (n_groups, num_tokens, d), dtype=torch.float32, device=o.device
+    )
+    scales = torch.empty(
+        (n_groups, num_tokens, num_scale_blocks),
+        dtype=torch.float32,
+        device=o.device,
+    )
+
+    _fused_inv_rope_fp32_quant_per_head[(num_tokens, n_groups * heads_per_group)](
+        o,
+        positions,
+        cos_sin_cache,
+        out_fp32,
+        scales,
+        num_tokens,
+        heads_per_group=heads_per_group,
+        o_stride_token=o.stride(0),
+        o_stride_head=o.stride(1),
+        cache_stride_pos=cos_sin_cache.stride(0),
+        out_stride_group=out_fp32.stride(0),
+        out_stride_token=out_fp32.stride(1),
+        scale_stride_group=scales.stride(0),
+        scale_stride_k=scales.stride(2),
+        fp8_max=torch.finfo(torch.float8_e4m3fn).max,
+        eps=1e-10,
+        QUANT_GROUP_SIZE=quant_group_size,
+        CHUNKS_PER_HEAD=chunks_per_head,
+        ROPE_START=nope_dim % quant_group_size,
+        HALF_ROPE=rope_dim // 2,
+        num_warps=1,
+    )
+
+    return out_fp32, scales
+
+
+def _fused_inv_rope_fp8_quant_torch(
+    o: torch.Tensor,
+    positions: torch.Tensor,
+    cos_sin_cache: torch.Tensor,
+    n_groups: int,
+    heads_per_group: int,
+    nope_dim: int,
+    rope_dim: int,
+    quant_group_size: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pure-PyTorch fallback for SM80, where Triton can't compile
+    `tl.float8e4nv`. Computes inverse GPT-J RoPE on the last `rope_dim`
+    dims of each head, then per-block UE8M0 FP8 quantization.
+
+    Returns (o_fp8, o_scale) with the same shapes/strides as the Triton
+    kernel's transposed return: o_fp8 = (T, G, H_g*D), o_scale = (T, G, K)
+    where K = H_g*D / quant_group_size."""
+    num_tokens, num_heads, head_dim = o.shape
+    assert num_heads == n_groups * heads_per_group
+    d = heads_per_group * head_dim
+    num_scale_blocks = d // quant_group_size
+    half_rope = rope_dim // 2
+
+    o_view = o.view(num_tokens, n_groups, heads_per_group, head_dim).to(torch.float32)
+    rope_part = o_view[..., -rope_dim:].clone()
+    even = rope_part[..., 0::2]
+    odd = rope_part[..., 1::2]
+
+    cos_sin = cos_sin_cache.index_select(0, positions.to(torch.long))
+    cos = cos_sin[..., :half_rope].view(num_tokens, 1, 1, half_rope)
+    sin = cos_sin[..., half_rope : 2 * half_rope].view(num_tokens, 1, 1, half_rope)
+
+    new_even = even * cos + odd * sin
+    new_odd = odd * cos - even * sin
+
+    rotated = torch.empty_like(rope_part)
+    rotated[..., 0::2] = new_even
+    rotated[..., 1::2] = new_odd
+
+    o_view[..., -rope_dim:] = rotated
+    o_view = o_view.to(torch.bfloat16).to(torch.float32)
+    flat = o_view.view(num_tokens, n_groups, num_scale_blocks, quant_group_size)
+
+    fp8_max = torch.finfo(torch.float8_e4m3fn).max
+    eps = 1e-10
+    block_absmax = flat.abs().amax(dim=-1).clamp_min(eps)
+    scale_raw = block_absmax / fp8_max
+    scale = torch.pow(2.0, torch.ceil(torch.log2(scale_raw)))
+    scale_exp = scale.unsqueeze(-1)
+
+    quantized = (flat / scale_exp).clamp(-fp8_max, fp8_max)
+    fp8_flat = quantized.to(torch.float8_e4m3fn).view(num_tokens, n_groups, d)
+    return fp8_flat, scale.to(torch.float32)
+
+
 def fused_inv_rope_fp8_quant(
     o: torch.Tensor,
     positions: torch.Tensor,
@@ -162,6 +371,25 @@ def fused_inv_rope_fp8_quant(
         o_fp8: [T, G, D] float8_e4m3fn, strides (D, T*D, 1).
         o_scale: Pre-transformed scale tensor for fp8_einsum.
     """
+    if use_dsv4_reference_kernels():
+        # SM80 hybrid path: Triton kernel that produces fp32 (inverse RoPE
+        # + per-block UE8M0 scaling), then PyTorch performs the fp8 cast
+        # (Triton on SM80 cannot compile `tl.float8e4nv`).
+        # tma_aligned_scales is ignored on SM80 since TMA is SM90+.
+        out_fp32, scales = _fused_inv_rope_fp32_quant_triton(
+            o,
+            positions,
+            cos_sin_cache,
+            n_groups,
+            heads_per_group,
+            nope_dim,
+            rope_dim,
+            quant_group_size,
+        )
+        # PyTorch fp8 cast (works on SM80 via software path).
+        fp8_buf = out_fp32.to(torch.float8_e4m3fn)
+        return fp8_buf.transpose(0, 1), scales.transpose(0, 1)
+
     from vllm.utils.deep_gemm import get_tma_aligned_size
 
     num_tokens, num_heads, head_dim = o.shape

--- a/vllm/v1/attention/ops/mqa_logits_triton.py
+++ b/vllm/v1/attention/ops/mqa_logits_triton.py
@@ -1,0 +1,461 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Triton implementations of DeepGEMM's fp8_mqa_logits and
+fp8_paged_mqa_logits for GPUs where DeepGEMM is not available.
+
+The computation is:
+
+    Q, K                := dequant(Q_fp8), dequant(K_fp8) * k_scales
+    score[H, M, N]      = Q[M, H, D] @ K[N, D].T
+    logits[M, N]        = (relu(score) * weights[M, H]).sum(axis=0)
+    logits[M, N]       := -inf  outside of valid range
+
+Q/K are cast to bf16 for the matmul; the matmul uses an fp32 accumulator.
+
+K-side scale multiplication is done in fp32 before downcasting to bf16
+so the per-row dequant scale is applied at full precision.
+"""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+# Paged decode config sweep. `num_warps=4` dominated in A100/SM80 bench
+# across {2,4,8}×{2,4}; the sub-optimal warps=2/8 picks were 1.5–1.7× slower
+# at the autotune key shape (num_heads=32, head_dim=128, block_size=64), and
+# autotune timing noise occasionally latched onto them. Keep only the two
+# `num_warps=4` configs so that path is always selected.
+_PAGED_AUTOTUNE_CONFIGS = [
+    triton.Config({}, num_warps=4, num_stages=ns) for ns in (2, 4)
+]
+
+# Prefill kernel adds BLOCK_N as a free tile axis along the K dimension.
+# Bench on A100/SM80 at (M=2048, N=8192, H=32, D=128) shows BN=32/64 with
+# num_warps∈{2,4} is within a few % of the best; BN=128 and num_warps=8 are
+# consistently ~1.5–3× worse. Trimming the sweep keeps the good configs and
+# shrinks first-call autotune time.
+_PREFILL_AUTOTUNE_CONFIGS = [
+    triton.Config({"BLOCK_N": bn}, num_warps=nw, num_stages=ns)
+    for bn in (32, 64)
+    for nw in (2, 4)
+    for ns in (2, 4)
+]
+
+
+@triton.jit
+def _decode_e4m3fn(u):
+    """Decode an E4M3FN byte (uint8) to fp32 using only uint/int/fp ops.
+
+    Triton on SM80 cannot compile `tl.float8e4nv`, so we never load the
+    FP8 dtype directly — we load uint8 and decode in software here. The
+    expansion is ~6 ops per element, dwarfed by the surrounding matmul.
+
+    E4M3FN: 1 sign + 4 exp (bias 7) + 3 mantissa.  No infinities.
+    Subnormal (exp=0): value = (-1)^s * (mant/8) * 2^(1 - 7)
+    Normal           : value = (-1)^s * (1 + mant/8) * 2^(exp - 7)
+    NaN at 0x7F/0xFF is decoded numerically as ±480 — sparse-MLA inputs
+    never hit this so the loss of NaN propagation is acceptable.
+    """
+    sign = u >> 7
+    exp_bits = ((u >> 3) & 0x0F).to(tl.int32)
+    mant = (u & 0x07).to(tl.int32)
+    is_normal = exp_bits != 0
+    sign_f = tl.where(sign != 0, -1.0, 1.0)
+    mant_f = tl.where(
+        is_normal,
+        (8 + mant).to(tl.float32) * 0.125,
+        mant.to(tl.float32) * 0.125,
+    )
+    # Subnormals: real exponent = 1 - bias.
+    eff_exp = tl.where(is_normal, exp_bits, 1)
+    factor = tl.exp2((eff_exp - 7).to(tl.float32))
+    return sign_f * mant_f * factor
+
+
+@triton.autotune(
+    configs=_PAGED_AUTOTUNE_CONFIGS,
+    key=["num_heads", "head_dim", "block_size"],
+)
+@triton.jit
+def _fp8_paged_mqa_logits_kernel(
+    q_ptr,
+    kv_fp8_ptr,
+    kv_scale_ptr,
+    weights_ptr,
+    context_lens_ptr,
+    block_tables_ptr,
+    logits_ptr,
+    stride_q_b,
+    stride_q_n,
+    stride_q_h,
+    stride_q_d,
+    stride_kvf_block,
+    stride_kvf_s,
+    stride_kvf_d,
+    stride_kvs_block,
+    stride_kvs_s,
+    stride_w_t,
+    stride_w_h,
+    stride_bt_b,
+    stride_bt_k,
+    stride_l_t,
+    stride_l_n,
+    next_n: tl.constexpr,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    block_size: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    token_id = tl.program_id(0)
+    block_rk = tl.program_id(1)
+
+    batch_id = token_id // next_n
+    next_n_id = token_id % next_n
+
+    context_len = tl.load(context_lens_ptr + batch_id)
+    if block_rk * block_size >= context_len:
+        return
+
+    q_offset = context_len - next_n + next_n_id
+
+    block_idx = tl.load(
+        block_tables_ptr + batch_id * stride_bt_b + block_rk * stride_bt_k
+    )
+
+    offs_h = tl.arange(0, BLOCK_H)
+    offs_d = tl.arange(0, BLOCK_D)
+    offs_n = tl.arange(0, BLOCK_N)
+    mask_h = offs_h < num_heads
+    mask_d = offs_d < head_dim
+    mask_n = offs_n < block_size
+
+    q_base = q_ptr + batch_id * stride_q_b + next_n_id * stride_q_n
+    q_byte = tl.load(
+        q_base + offs_h[:, None] * stride_q_h + offs_d[None, :] * stride_q_d,
+        mask=mask_h[:, None] & mask_d[None, :],
+        other=0,
+    )
+    q = _decode_e4m3fn(q_byte).to(tl.bfloat16)
+
+    kvf_base = kv_fp8_ptr + block_idx * stride_kvf_block
+    k_byte = tl.load(
+        kvf_base + offs_n[:, None] * stride_kvf_s + offs_d[None, :] * stride_kvf_d,
+        mask=mask_n[:, None] & mask_d[None, :],
+        other=0,
+    )
+    kvs_base = kv_scale_ptr + block_idx * stride_kvs_block
+    k_scale = tl.load(
+        kvs_base + offs_n * stride_kvs_s,
+        mask=mask_n,
+        other=0.0,
+    )
+    # Scale in fp32 for precision, then cast to bf16 for the matmul.
+    k = (_decode_e4m3fn(k_byte) * k_scale[:, None]).to(tl.bfloat16)
+
+    s = tl.dot(q, tl.trans(k))
+
+    w = tl.load(
+        weights_ptr + token_id * stride_w_t + offs_h * stride_w_h,
+        mask=mask_h,
+        other=0.0,
+    )
+    s = tl.where(s > 0, s, 0.0) * w[:, None]
+    out = tl.sum(s, axis=0)
+
+    k_offset = block_rk * block_size + offs_n
+    valid = mask_n & (k_offset < context_len) & (k_offset <= q_offset)
+    out = tl.where(valid, out, float("-inf"))
+
+    tl.store(
+        logits_ptr + token_id * stride_l_t + k_offset * stride_l_n,
+        out,
+        mask=mask_n,
+    )
+
+
+def fp8_paged_mqa_logits_triton(
+    q: torch.Tensor,
+    kv_cache: torch.Tensor,
+    weights: torch.Tensor,
+    context_lens: torch.Tensor,
+    block_tables: torch.Tensor,
+    max_model_len: int,
+) -> torch.Tensor:
+    """Triton implementation of DeepGEMM's fp8_paged_mqa_logits.
+
+    Args:
+        q:             [B, next_n, H, D] fp8_e4m3fn
+        kv_cache:      [num_blocks, block_size, 1, D+4] uint8 (FP8 + fp32 scale)
+        weights:       [B*next_n, H] float32
+        context_lens:  [B] int32
+        block_tables:  [B, max_blocks] int32
+    Returns:
+        logits:        [B*next_n, max_model_len] float32
+    """
+    B, next_n, num_heads, head_dim = q.shape
+    _, block_size, one, d_plus_4 = kv_cache.shape
+    assert one == 1
+    assert d_plus_4 == head_dim + 4
+
+    # Cache layout: `indexer_k_quant_and_cache` (csrc/cache_kernels.cu) writes
+    # each block as [K region | scale region] — all `block_size * head_dim`
+    # fp8 K bytes first, then `block_size * 4` fp32 scale bytes. The
+    # `[NB, block_size, 1, head_dim+4]` shape is just a stride trick; bytes
+    # must be re-sliced flat. The kernel decodes FP8 from uint8 manually since
+    # SM80 Triton can't compile `tl.float8e4nv`.
+    num_blocks = kv_cache.shape[0]
+    kv_flat = kv_cache.view(num_blocks, -1)
+    k_end = block_size * head_dim
+    kv_byte = kv_flat[:, :k_end].as_strided(
+        (num_blocks, block_size, head_dim),
+        (kv_flat.stride(0), head_dim, 1),
+    )
+    kv_scale = kv_flat[:, k_end:].view(torch.float32)
+    q_byte = q.view(torch.uint8)
+
+    logits = torch.full(
+        (B * next_n, max_model_len),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q.device,
+    )
+
+    BLOCK_H = max(16, triton.next_power_of_2(num_heads))
+    BLOCK_D = triton.next_power_of_2(head_dim)
+    BLOCK_N = triton.next_power_of_2(block_size)
+
+    grid = (B * next_n, block_tables.shape[1])
+    _fp8_paged_mqa_logits_kernel[grid](
+        q_byte,
+        kv_byte,
+        kv_scale,
+        weights,
+        context_lens,
+        block_tables,
+        logits,
+        q_byte.stride(0),
+        q_byte.stride(1),
+        q_byte.stride(2),
+        q_byte.stride(3),
+        kv_byte.stride(0),
+        kv_byte.stride(1),
+        kv_byte.stride(2),
+        kv_scale.stride(0),
+        kv_scale.stride(1),
+        weights.stride(0),
+        weights.stride(1),
+        block_tables.stride(0),
+        block_tables.stride(1),
+        logits.stride(0),
+        logits.stride(1),
+        next_n=next_n,
+        num_heads=num_heads,
+        head_dim=head_dim,
+        block_size=block_size,
+        BLOCK_H=BLOCK_H,
+        BLOCK_D=BLOCK_D,
+        BLOCK_N=BLOCK_N,
+    )
+    return logits
+
+
+@triton.autotune(
+    configs=_PREFILL_AUTOTUNE_CONFIGS,
+    # Per-program work doesn't depend on N — only the grid extent does — so
+    # a single autotune config is valid across seq lengths. Keeping N in the
+    # key used to re-tune from scratch on every new chunk size (e.g., 2048,
+    # 4096, 6144, 8192, 9993 for a 10K prompt with chunked prefill),
+    # producing ~2 minutes of first-call TTFT on top of the real work.
+    key=["num_heads", "head_dim"],
+)
+@triton.jit
+def _fp8_mqa_logits_kernel(
+    q_ptr,
+    k_ptr,
+    k_scale_ptr,
+    weights_ptr,
+    ks_ptr,
+    ke_ptr,
+    logits_ptr,
+    stride_q_m,
+    stride_q_h,
+    stride_q_d,
+    stride_k_n,
+    stride_k_d,
+    stride_w_m,
+    stride_w_h,
+    stride_l_m,
+    stride_l_n,
+    num_heads: tl.constexpr,
+    head_dim: tl.constexpr,
+    N: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_D: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    m = tl.program_id(0)
+    n_block = tl.program_id(1)
+
+    n_start = n_block * BLOCK_N
+    offs_n = n_start + tl.arange(0, BLOCK_N)
+    mask_n = offs_n < N
+
+    offs_h = tl.arange(0, BLOCK_H)
+    offs_d = tl.arange(0, BLOCK_D)
+    mask_h = offs_h < num_heads
+    mask_d = offs_d < head_dim
+
+    q_byte = tl.load(
+        q_ptr
+        + m * stride_q_m
+        + offs_h[:, None] * stride_q_h
+        + offs_d[None, :] * stride_q_d,
+        mask=mask_h[:, None] & mask_d[None, :],
+        other=0,
+    )
+    q = _decode_e4m3fn(q_byte).to(tl.bfloat16)
+
+    k_byte = tl.load(
+        k_ptr + offs_n[:, None] * stride_k_n + offs_d[None, :] * stride_k_d,
+        mask=mask_n[:, None] & mask_d[None, :],
+        other=0,
+    )
+    k_scale = tl.load(k_scale_ptr + offs_n, mask=mask_n, other=0.0)
+    # Scale in fp32 for precision, then cast to bf16 for the matmul.
+    k = (_decode_e4m3fn(k_byte) * k_scale[:, None]).to(tl.bfloat16)
+
+    s = tl.dot(q, tl.trans(k))
+
+    w = tl.load(
+        weights_ptr + m * stride_w_m + offs_h * stride_w_h,
+        mask=mask_h,
+        other=0.0,
+    )
+    s = tl.where(s > 0, s, 0.0) * w[:, None]
+    out = tl.sum(s, axis=0)
+
+    ks = tl.load(ks_ptr + m)
+    ke = tl.load(ke_ptr + m)
+    valid = mask_n & (offs_n >= ks) & (offs_n < ke)
+    out = tl.where(valid, out, float("-inf"))
+
+    tl.store(
+        logits_ptr + m * stride_l_m + offs_n * stride_l_n,
+        out,
+        mask=mask_n,
+    )
+
+
+def fp8_mqa_logits_triton(
+    q: torch.Tensor,
+    kv: tuple[torch.Tensor, torch.Tensor],
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+) -> torch.Tensor:
+    """Triton implementation of DeepGEMM's fp8_mqa_logits.
+
+    Args:
+        q:            [M, H, D] fp8_e4m3fn
+        kv:           (k_fp8 [N, D], k_scales [N]) — fp8_e4m3fn, float32
+        weights:      [M, H] float32
+        cu_seqlen_ks: [M] int32
+        cu_seqlen_ke: [M] int32
+    Returns:
+        logits:       [M, N] float32
+    """
+    k_fp8, k_scales = kv
+    k_scales = k_scales.reshape(-1)
+
+    M, num_heads, head_dim = q.shape
+    N = k_fp8.shape[0]
+
+    logits = torch.full(
+        (M, N),
+        float("-inf"),
+        dtype=torch.float32,
+        device=q.device,
+    )
+
+    BLOCK_H = max(16, triton.next_power_of_2(num_heads))
+    BLOCK_D = triton.next_power_of_2(head_dim)
+
+    # Pass FP8 tensors as uint8 — kernel decodes E4M3FN bytes manually so it
+    # works on SM80 where Triton can't compile the native fp8e4nv dtype.
+    q_byte = q.view(torch.uint8)
+    k_byte = k_fp8.view(torch.uint8)
+
+    # Grid depends on the autotuned BLOCK_N.
+    grid = lambda meta: (M, triton.cdiv(N, meta["BLOCK_N"]))  # noqa: E731
+    _fp8_mqa_logits_kernel[grid](
+        q_byte,
+        k_byte,
+        k_scales,
+        weights,
+        cu_seqlen_ks,
+        cu_seqlen_ke,
+        logits,
+        q_byte.stride(0),
+        q_byte.stride(1),
+        q_byte.stride(2),
+        k_byte.stride(0),
+        k_byte.stride(1),
+        weights.stride(0),
+        weights.stride(1),
+        logits.stride(0),
+        logits.stride(1),
+        num_heads=num_heads,
+        head_dim=head_dim,
+        N=N,
+        BLOCK_H=BLOCK_H,
+        BLOCK_D=BLOCK_D,
+    )
+    return logits
+
+
+def warmup_fp8_mqa_logits_triton(
+    num_heads: int,
+    head_dim: int,
+    device: torch.device,
+) -> None:
+    """Prime the prefill `@triton.autotune` cache for the indexer's logits
+    kernel. Runs one shape matching the autotune key so that the first real
+    request does not pay the inline sweep + JIT cost (~5–8 s on A100 SM80).
+
+    N is not in the autotune key (removed so chunked-prefill doesn't re-tune
+    at every chunk size), so a single dummy N is enough. Pick N large enough
+    to exercise every BLOCK_N config in `_PREFILL_AUTOTUNE_CONFIGS`.
+    """
+    max_block_n = max(c.kwargs["BLOCK_N"] for c in _PREFILL_AUTOTUNE_CONFIGS)
+    n = max_block_n
+    q = torch.empty(1, num_heads, head_dim, dtype=torch.float8_e4m3fn, device=device)
+    k = torch.empty(n, head_dim, dtype=torch.float8_e4m3fn, device=device)
+    scales = torch.zeros(n, dtype=torch.float32, device=device)
+    weights = torch.zeros(1, num_heads, dtype=torch.float32, device=device)
+    ks = torch.zeros(1, dtype=torch.int32, device=device)
+    ke = torch.full((1,), n, dtype=torch.int32, device=device)
+    fp8_mqa_logits_triton(q, (k, scales), weights, ks, ke)
+
+
+def warmup_fp8_paged_mqa_logits_triton(
+    num_heads: int,
+    head_dim: int,
+    block_size: int,
+    device: torch.device,
+) -> None:
+    """Prime the paged-decode `@triton.autotune` cache for the indexer's
+    logits kernel (see `warmup_fp8_mqa_logits_triton` for rationale).
+    """
+    num_blocks = 2
+    q = torch.empty(1, 1, num_heads, head_dim, dtype=torch.float8_e4m3fn, device=device)
+    kv_cache = torch.zeros(
+        num_blocks, block_size, 1, head_dim + 4, dtype=torch.uint8, device=device
+    )
+    weights = torch.zeros(1, num_heads, dtype=torch.float32, device=device)
+    context_lens = torch.tensor([block_size], dtype=torch.int32, device=device)
+    block_tables = torch.zeros(1, 1, dtype=torch.int32, device=device)
+    fp8_paged_mqa_logits_triton(
+        q, kv_cache, weights, context_lens, block_tables, max_model_len=block_size
+    )

--- a/vllm/v1/attention/ops/triton_sparse_mla_kernel.py
+++ b/vllm/v1/attention/ops/triton_sparse_mla_kernel.py
@@ -1,0 +1,574 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Triton sparse MLA attention with split-KV for low-batch decode.
+
+Stage 1 runs the sparse attention over a contiguous slice of the topk
+axis (or the full axis when `num_kv_splits=1`) and writes a partial
+`(out/e_sum, lse)` tile to a mid buffer. Stage 2 merges the splits via
+online-softmax rescaling — pattern from `triton_decode_attention.py`.
+"""
+
+import functools
+
+import torch
+
+from vllm.triton_utils import LOG2E, LOGE2, tl, triton
+from vllm.utils.platform_utils import num_compute_units
+
+# DeepSeek-V3.2 / GLM-5 sparse MLA shape constants.
+_BLOCK_DMODEL = 512
+_BLOCK_DPE = 64
+_BLOCK_DV = 512
+_DIM_QK = _BLOCK_DMODEL + _BLOCK_DPE  # 576
+
+_BLOCK_H = 16
+# Smallest BLOCK_N the autotune sweep offers; only used for the topk-divisibility
+# check at dispatch time.
+_MIN_BLOCK_N = 16
+
+# Merge kernel is launch-bound on a (1, 1) grid — one CTA per token starves the
+# SMs. Spread across heads and DV tiles (pattern from FlashMLA's combine kernel
+# at FlashMLA/csrc/smxx/decode/combine/combine.cu:22-27). BLOCK_H=1 so each
+# of the 8 per-rank heads runs concurrently; BLOCK_DV_TILE=128 splits the 512
+# output lanes into 4 tiles.
+_MERGE_BLOCK_H = 1
+_MERGE_BLOCK_DV_TILE = 128
+assert _BLOCK_DV % _MERGE_BLOCK_DV_TILE == 0
+_NUM_MERGE_DV_TILES = _BLOCK_DV // _MERGE_BLOCK_DV_TILE
+
+# Separate config sweeps for the single-pass (prefill) and split-KV (decode)
+# entry points. Per A100/SM80 sweeps:
+#   - Single-pass ("final") kernel at prefill M>>1 prefers BLOCK_N=16 with few
+#     warps; the wider configs in the combined sweep were landing 1.3–1.5×
+#     slower because autotune's key omits M and the cached pick was a bad
+#     compromise.
+#   - Split kernel at decode M=1 prefers BLOCK_N=32/num_warps=4 across every
+#     split count we tested.
+# Each kernel only ever runs in its own regime (see `_choose_num_kv_splits`),
+# so we can tune each independently.
+_FINAL_AUTOTUNE_CONFIGS = [
+    triton.Config({"BLOCK_N": 16}, num_warps=nw, num_stages=ns)
+    for nw in (2, 4)
+    for ns in (2, 4)
+]
+_SPLIT_AUTOTUNE_CONFIGS = [
+    triton.Config({"BLOCK_N": 32}, num_warps=4, num_stages=ns) for ns in (2, 4)
+]
+
+# Split count candidates that `_choose_num_kv_splits` can return; also the set
+# `_warmup_autotune` pre-compiles so the first decode does not pay the sweep cost.
+KV_SPLITS_CANDIDATES = (1, 2, 4, 8, 16)
+
+# Split-KV heuristic tuning.
+# At topk=2048 (DSv3.2/GLM-5.1) this unlocks 16-way split for decode, which
+# benches ~1.3× faster than 8-way on A100 SM80 at BLOCK_N=32/num_warps=4.
+_MIN_TOPK_PER_SPLIT = 128  # below this, per-split work is too small to amortize
+_SPLIT_MAX_OCCUPANCY = 4  # skip split when baseline grid fills >=1/4 of SMs
+
+
+@triton.jit
+def _sparse_mla_compute_tile(
+    q_buffer,
+    k_buffer,  # V is the first BLOCK_DV lanes of each row of k_buffer.
+    indices_ptr,
+    cur_q,
+    cur_head,
+    cur_kv_head_id,
+    mask_h,
+    split_start,
+    split_end,
+    seq_kv,
+    stride_q_token,
+    stride_q_head,
+    stride_kv_token,
+    stride_kv_head,
+    stride_indices_token,
+    stride_indices_head,
+    sm_scale,
+    BLOCK_H: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DPE: tl.constexpr,
+):
+    """Shared stage-1 body: load Q, run the sparse online-softmax loop over
+    `[split_start, split_end)` of the topk axis, return accumulators."""
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    offs_dpe = BLOCK_DMODEL + tl.arange(0, BLOCK_DPE)
+    offs_dv = tl.arange(0, BLOCK_DV)
+    mask_dpe = offs_dpe < BLOCK_DMODEL + BLOCK_DPE
+
+    q = tl.load(
+        q_buffer
+        + cur_q * stride_q_token
+        + cur_head[:, None] * stride_q_head
+        + offs_d[None, :],
+        mask=mask_h[:, None],
+        other=0.0,
+    )
+    qpe = tl.load(
+        q_buffer
+        + cur_q * stride_q_token
+        + cur_head[:, None] * stride_q_head
+        + offs_dpe[None, :],
+        mask=(mask_h[:, None]) & (mask_dpe[None, :]),
+        other=0.0,
+    )
+
+    # Large negative but finite sentinel for masked-out positions. `-inf`
+    # would give `-inf - -inf = NaN` when a whole BLOCK_N tile is masked
+    # (common in short prefill where most topk slots are -1); a finite value
+    # keeps `sentinel - sentinel = 0` and `exp2(0) = 1`, and the
+    # corresponding v slots are already loaded as 0.
+    NEG_LARGE = -1.0e30
+    e_max = tl.zeros([BLOCK_H], dtype=tl.float32) + NEG_LARGE
+    e_sum = tl.zeros([BLOCK_H], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_H, BLOCK_DV], dtype=tl.float32)
+
+    for start_indice in range(split_start, split_end, BLOCK_N):
+        offs_indice = start_indice + tl.arange(0, BLOCK_N)
+        mask_indice = offs_indice < split_end
+        indices = tl.load(
+            indices_ptr
+            + cur_q * stride_indices_token
+            + cur_kv_head_id * stride_indices_head
+            + offs_indice,
+            mask=mask_indice,
+            other=-1,
+        )
+        mask_kv = (indices >= 0) & (indices < seq_kv)
+
+        offs_k = (
+            indices[None, :] * stride_kv_token
+            + cur_kv_head_id * stride_kv_head
+            + offs_d[:, None]
+        )
+        k = tl.load(k_buffer + offs_k, mask=mask_kv[None, :], other=0.0)
+        qk = tl.dot(q, k.to(q.dtype))
+
+        offs_kpe = (
+            indices[None, :] * stride_kv_token
+            + cur_kv_head_id * stride_kv_head
+            + offs_dpe[:, None]
+        )
+        kpe = tl.load(
+            k_buffer + offs_kpe,
+            mask=(mask_kv[None, :]) & (mask_dpe[:, None]),
+            other=0.0,
+        )
+        qk += tl.dot(qpe, kpe.to(q.dtype))
+
+        qk *= sm_scale
+        qk = tl.where((mask_h[:, None]) & (mask_kv[None, :]), qk, NEG_LARGE)
+
+        offs_v = (
+            indices[:, None] * stride_kv_token
+            + cur_kv_head_id * stride_kv_head
+            + offs_dv[None, :]
+        )
+        v = tl.load(k_buffer + offs_v, mask=mask_kv[:, None], other=0.0)
+
+        n_e_max = tl.maximum(tl.max(qk, 1), e_max)
+        re_scale = tl.exp2(e_max - n_e_max)
+        p = tl.exp2(qk - n_e_max[:, None])
+        acc *= re_scale[:, None]
+        acc += tl.dot(p.to(v.dtype), v)
+        e_sum = e_sum * re_scale + tl.sum(p, 1)
+        e_max = n_e_max
+
+    return acc, e_max, e_sum
+
+
+@triton.autotune(configs=_FINAL_AUTOTUNE_CONFIGS, key=["index_topk", "kv_group_num"])
+@triton.jit
+def _sparse_mla_kernel_final(
+    q_buffer,
+    k_buffer,
+    indices_ptr,
+    out_ptr,
+    seq_kv,
+    h_q,
+    stride_q_token,
+    stride_q_head,
+    stride_kv_token,
+    stride_kv_head,
+    stride_out_token,
+    stride_out_head,
+    stride_indices_token,
+    stride_indices_head,
+    sm_scale,
+    index_topk: tl.constexpr,
+    kv_group_num: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DPE: tl.constexpr,
+):
+    """Single-pass fast path: full topk, write final bf16 output directly."""
+    cur_q = tl.program_id(0)
+    cur_head_id = tl.program_id(1)
+    cur_kv_head_id = cur_head_id // tl.cdiv(kv_group_num, BLOCK_H)
+
+    VALID_BLOCK_H: tl.constexpr = BLOCK_H if kv_group_num > BLOCK_H else kv_group_num
+    cur_head = cur_head_id * VALID_BLOCK_H + tl.arange(0, BLOCK_H)
+    mask_h = (cur_head < (cur_head_id + 1) * VALID_BLOCK_H) & (cur_head < h_q)
+
+    acc, e_max, e_sum = _sparse_mla_compute_tile(
+        q_buffer,
+        k_buffer,
+        indices_ptr,
+        cur_q,
+        cur_head,
+        cur_kv_head_id,
+        mask_h,
+        0,
+        index_topk,
+        seq_kv,
+        stride_q_token,
+        stride_q_head,
+        stride_kv_token,
+        stride_kv_head,
+        stride_indices_token,
+        stride_indices_head,
+        sm_scale,
+        BLOCK_H,
+        BLOCK_N,
+        BLOCK_DV,
+        BLOCK_DMODEL,
+        BLOCK_DPE,
+    )
+
+    # Guard against queries with zero valid KV (e_sum == 0 → NaN from 0/0).
+    e_sum_safe = tl.where(e_sum > 0, e_sum, 1.0)
+    offs_dv = tl.arange(0, BLOCK_DV)
+    tl.store(
+        out_ptr
+        + cur_q * stride_out_token
+        + cur_head[:, None] * stride_out_head
+        + offs_dv[None, :],
+        (acc / e_sum_safe[:, None]).to(tl.bfloat16),
+        mask=mask_h[:, None],
+    )
+
+
+@triton.autotune(
+    configs=_SPLIT_AUTOTUNE_CONFIGS,
+    key=["index_topk", "NUM_KV_SPLITS", "kv_group_num"],
+)
+@triton.jit
+def _sparse_mla_kernel_split(
+    q_buffer,
+    k_buffer,
+    indices_ptr,
+    mid_out_ptr,
+    seq_kv,
+    h_q,
+    stride_q_token,
+    stride_q_head,
+    stride_kv_token,
+    stride_kv_head,
+    stride_mid_token,
+    stride_mid_head,
+    stride_mid_split,
+    stride_indices_token,
+    stride_indices_head,
+    sm_scale,
+    index_topk: tl.constexpr,
+    NUM_KV_SPLITS: tl.constexpr,
+    kv_group_num: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,
+    BLOCK_DPE: tl.constexpr,
+    LOGE2: tl.constexpr,
+):
+    """Stage 1 of split-KV: process one slice of the topk axis and write
+    its `(out_partial, lse_partial)` into the mid buffer."""
+    cur_q = tl.program_id(0)
+    cur_head_id = tl.program_id(1)
+    split_kv_id = tl.program_id(2)
+    cur_kv_head_id = cur_head_id // tl.cdiv(kv_group_num, BLOCK_H)
+
+    VALID_BLOCK_H: tl.constexpr = BLOCK_H if kv_group_num > BLOCK_H else kv_group_num
+    cur_head = cur_head_id * VALID_BLOCK_H + tl.arange(0, BLOCK_H)
+    mask_h = (cur_head < (cur_head_id + 1) * VALID_BLOCK_H) & (cur_head < h_q)
+
+    split_topk: tl.constexpr = tl.cdiv(index_topk, NUM_KV_SPLITS)
+    split_start = split_kv_id * split_topk
+    split_end = tl.minimum(split_start + split_topk, index_topk)
+
+    acc, e_max, e_sum = _sparse_mla_compute_tile(
+        q_buffer,
+        k_buffer,
+        indices_ptr,
+        cur_q,
+        cur_head,
+        cur_kv_head_id,
+        mask_h,
+        split_start,
+        split_end,
+        seq_kv,
+        stride_q_token,
+        stride_q_head,
+        stride_kv_token,
+        stride_kv_head,
+        stride_indices_token,
+        stride_indices_head,
+        sm_scale,
+        BLOCK_H,
+        BLOCK_N,
+        BLOCK_DV,
+        BLOCK_DMODEL,
+        BLOCK_DPE,
+    )
+
+    # Partial output and natural-log LSE for stage-2 merge.
+    # When a split has no valid KV (`e_sum == 0`), guard the divide so the
+    # mid buffer holds 0 instead of NaN; otherwise the `0 * NaN = NaN` term
+    # in stage 2 would poison every other split.
+    e_sum_safe = tl.where(e_sum > 0, e_sum, 1.0)
+    offs_dv = tl.arange(0, BLOCK_DV)
+    mid_base_2d = (
+        mid_out_ptr
+        + cur_q * stride_mid_token
+        + cur_head[:, None] * stride_mid_head
+        + split_kv_id * stride_mid_split
+    )
+    tl.store(
+        mid_base_2d + offs_dv[None, :],
+        acc / e_sum_safe[:, None],
+        mask=mask_h[:, None],
+    )
+    mid_lse_ptr = (
+        mid_out_ptr
+        + cur_q * stride_mid_token
+        + cur_head * stride_mid_head
+        + split_kv_id * stride_mid_split
+        + BLOCK_DV
+    )
+    tl.store(mid_lse_ptr, (e_max + tl.log2(e_sum)) * LOGE2, mask=mask_h)
+
+
+@triton.jit
+def _sparse_mla_merge_kernel(
+    mid_out_ptr,
+    out_ptr,
+    h_q,
+    stride_mid_token,
+    stride_mid_head,
+    stride_mid_split,
+    stride_out_token,
+    stride_out_head,
+    NUM_KV_SPLITS: tl.constexpr,
+    kv_group_num: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_DV: tl.constexpr,
+    BLOCK_DV_TILE: tl.constexpr,
+):
+    """Stage 2: N-way online-softmax merge of per-split `(out, lse)` tiles.
+
+    Grid is `(num_tokens, num_head_groups, num_dv_tiles)`. Each program handles
+    `BLOCK_H` heads × `BLOCK_DV_TILE` output-dim lanes. The LSE reduction is
+    identical across DV tiles for the same (token, head) — each program
+    recomputes it locally, which is cheap (O(NUM_KV_SPLITS) scalars) and
+    avoids inter-CTA synchronization.
+    """
+    cur_q = tl.program_id(0)
+    cur_head_id = tl.program_id(1)
+    cur_dv_tile = tl.program_id(2)
+
+    VALID_BLOCK_H: tl.constexpr = BLOCK_H if kv_group_num > BLOCK_H else kv_group_num
+    cur_head = cur_head_id * VALID_BLOCK_H + tl.arange(0, BLOCK_H)
+    mask_h = (cur_head < (cur_head_id + 1) * VALID_BLOCK_H) & (cur_head < h_q)
+
+    offs_dv = cur_dv_tile * BLOCK_DV_TILE + tl.arange(0, BLOCK_DV_TILE)
+    mask_dv = offs_dv < BLOCK_DV
+    e_max = tl.zeros([BLOCK_H], dtype=tl.float32) - float("inf")
+    e_sum = tl.zeros([BLOCK_H], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_H, BLOCK_DV_TILE], dtype=tl.float32)
+
+    mid_base_2d = (
+        mid_out_ptr + cur_q * stride_mid_token + cur_head[:, None] * stride_mid_head
+    )
+    mid_lse_1d = (
+        mid_out_ptr + cur_q * stride_mid_token + cur_head * stride_mid_head + BLOCK_DV
+    )
+
+    for split_kv_id in range(NUM_KV_SPLITS):
+        tv = tl.load(
+            mid_base_2d + split_kv_id * stride_mid_split + offs_dv[None, :],
+            mask=mask_h[:, None] & mask_dv[None, :],
+            other=0.0,
+        )
+        tlogic = tl.load(
+            mid_lse_1d + split_kv_id * stride_mid_split,
+            mask=mask_h,
+            other=-float("inf"),
+        )
+        n_e_max = tl.maximum(tlogic, e_max)
+        old_scale = tl.exp(e_max - n_e_max)
+        exp_logic = tl.exp(tlogic - n_e_max)
+        acc = acc * old_scale[:, None] + exp_logic[:, None] * tv
+        e_sum = e_sum * old_scale + exp_logic
+        e_max = n_e_max
+
+    e_sum_safe = tl.where(e_sum > 0, e_sum, 1.0)
+    tl.store(
+        out_ptr
+        + cur_q * stride_out_token
+        + cur_head[:, None] * stride_out_head
+        + offs_dv[None, :],
+        (acc / e_sum_safe[:, None]).to(tl.bfloat16),
+        mask=mask_h[:, None] & mask_dv[None, :],
+    )
+
+
+@functools.lru_cache(maxsize=256)
+def _choose_num_kv_splits(
+    num_tokens: int, num_head_groups: int, index_topk: int, sm_count: int
+) -> int:
+    """Pick a power-of-2 split count that fills the device without dropping
+    per-split work below _MIN_TOPK_PER_SPLIT. Returns 1 when the single-pass
+    grid already reaches ~1/_SPLIT_MAX_OCCUPANCY utilization.
+    """
+    baseline = num_tokens * num_head_groups
+    if baseline == 0 or baseline * _SPLIT_MAX_OCCUPANCY >= sm_count:
+        return 1
+    ideal = triton.next_power_of_2(max(1, index_topk // _MIN_TOPK_PER_SPLIT))
+    max_splits = max(1, sm_count // baseline)
+    max_splits = 1 << (max_splits.bit_length() - 1)  # floor to power of 2
+    num_kv_splits = min(ideal, max_splits)
+    while num_kv_splits > 1 and index_topk % num_kv_splits != 0:
+        num_kv_splits //= 2
+    return max(1, num_kv_splits)
+
+
+def triton_sparse_mla_attention(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    num_kv_splits: int | None = None,
+    sm_count: int | None = None,
+) -> torch.Tensor:
+    """Sparse MLA attention over topk indices.
+
+    Args:
+        q:         [num_tokens, num_heads_q, dim_qk] bf16
+        kv:        [seq_kv, num_heads_kv=1, dim_qk] bf16
+        indices:   [num_tokens, num_heads_kv=1, topk] int32
+        sm_scale:  softmax scale
+        num_kv_splits: override auto-heuristic; None/0 = auto, 1 = force single-pass.
+        sm_count:  device SM count, used by the split heuristic. If None,
+            queried from the device — pass a cached value to avoid a dict
+            lookup on every decode step.
+
+    Returns:
+        out:   [num_tokens, num_heads_q, _BLOCK_DV] bf16
+    """
+    num_tokens, num_heads_q, dim_qk = q.shape
+    assert dim_qk == _DIM_QK, (
+        f"sparse MLA kernel requires dim_qk={_DIM_QK} (DeepSeek-V3.2 / GLM-5), "
+        f"got {dim_qk}"
+    )
+    assert kv.shape[1] == 1 and kv.shape[2] == _DIM_QK
+    index_topk = indices.shape[2]
+    assert index_topk % _MIN_BLOCK_N == 0, (
+        f"topk ({index_topk}) must be a multiple of the smallest autotune "
+        f"BLOCK_N ({_MIN_BLOCK_N})"
+    )
+
+    kv_group_num = num_heads_q
+    num_head_groups = triton.cdiv(num_heads_q, min(_BLOCK_H, kv_group_num))
+
+    if num_kv_splits is None or num_kv_splits == 0:
+        if sm_count is None:
+            sm_count = num_compute_units(q.device.index)
+        num_kv_splits = _choose_num_kv_splits(
+            num_tokens, num_head_groups, index_topk, sm_count
+        )
+
+    out = torch.empty(
+        (num_tokens, num_heads_q, _BLOCK_DV),
+        dtype=torch.bfloat16,
+        device=q.device,
+    )
+
+    if num_kv_splits == 1:
+        _sparse_mla_kernel_final[(num_tokens, num_head_groups)](
+            q_buffer=q,
+            k_buffer=kv,
+            indices_ptr=indices,
+            out_ptr=out,
+            seq_kv=kv.shape[0],
+            h_q=num_heads_q,
+            stride_q_token=q.stride(0),
+            stride_q_head=q.stride(1),
+            stride_kv_token=kv.stride(0),
+            stride_kv_head=kv.stride(1),
+            stride_out_token=out.stride(0),
+            stride_out_head=out.stride(1),
+            stride_indices_token=indices.stride(0),
+            stride_indices_head=indices.stride(1),
+            sm_scale=sm_scale * LOG2E,
+            index_topk=index_topk,
+            kv_group_num=kv_group_num,
+            BLOCK_H=_BLOCK_H,
+            BLOCK_DV=_BLOCK_DV,
+            BLOCK_DMODEL=_BLOCK_DMODEL,
+            BLOCK_DPE=_BLOCK_DPE,
+        )
+        return out
+
+    # Split-KV: partial fp32 output + LSE per (token, head, split).
+    mid_out = torch.empty(
+        (num_tokens, num_heads_q, num_kv_splits, _BLOCK_DV + 1),
+        dtype=torch.float32,
+        device=q.device,
+    )
+    _sparse_mla_kernel_split[(num_tokens, num_head_groups, num_kv_splits)](
+        q_buffer=q,
+        k_buffer=kv,
+        indices_ptr=indices,
+        mid_out_ptr=mid_out,
+        seq_kv=kv.shape[0],
+        h_q=num_heads_q,
+        stride_q_token=q.stride(0),
+        stride_q_head=q.stride(1),
+        stride_kv_token=kv.stride(0),
+        stride_kv_head=kv.stride(1),
+        stride_mid_token=mid_out.stride(0),
+        stride_mid_head=mid_out.stride(1),
+        stride_mid_split=mid_out.stride(2),
+        stride_indices_token=indices.stride(0),
+        stride_indices_head=indices.stride(1),
+        sm_scale=sm_scale * LOG2E,
+        index_topk=index_topk,
+        NUM_KV_SPLITS=num_kv_splits,
+        kv_group_num=kv_group_num,
+        BLOCK_H=_BLOCK_H,
+        BLOCK_DV=_BLOCK_DV,
+        BLOCK_DMODEL=_BLOCK_DMODEL,
+        BLOCK_DPE=_BLOCK_DPE,
+        LOGE2=LOGE2,
+    )
+
+    _sparse_mla_merge_kernel[(num_tokens, num_heads_q, _NUM_MERGE_DV_TILES)](
+        mid_out_ptr=mid_out,
+        out_ptr=out,
+        h_q=num_heads_q,
+        stride_mid_token=mid_out.stride(0),
+        stride_mid_head=mid_out.stride(1),
+        stride_mid_split=mid_out.stride(2),
+        stride_out_token=out.stride(0),
+        stride_out_head=out.stride(1),
+        NUM_KV_SPLITS=num_kv_splits,
+        kv_group_num=kv_group_num,
+        BLOCK_H=_MERGE_BLOCK_H,
+        BLOCK_DV=_BLOCK_DV,
+        BLOCK_DV_TILE=_MERGE_BLOCK_DV_TILE,
+        num_warps=2,
+    )
+    return out


### PR DESCRIPTION
## Purpose

Fix #40851

This PR adds DeepSeek V4 support on A100/A800 (SM80), where DeepGEMM (hyperconnection / fp8_einsum / fp8_fp4_(paged_)mqa_logits) and FlashMLA-Sparse are unavailable, and Triton on SM80 cannot compile `tl.float8e4nv`.

This PR is stacked on top of:
- #40860 (DeepSeek V4 rebased)
- #38476 (TRITON_MLA_SPARSE backend for SM80/SM121, indexer Triton fallback, topk.cu race fix)

Once both land, the diff narrows to the V4-specific SM80 paths added here.

A single gate predicate `use_dsv4_reference_kernels()` in `vllm/utils/deep_gemm.py` resolves once at module import (plain Python bool) so torch.compile / Dynamo can constant-fold every dispatch site inside compiled regions.

### SM80 paths

**Reference fallbacks** (lifted from PR #40871 where applicable):

- `vllm/model_executor/layers/mhc.py` — `mhc_pre` skips `tf32_hc_prenorm_gemm` and the tilelang follow-up; the comb-mix softmax + 20 Sinkhorn iterations are now a single fused Triton kernel `_mhc_sinkhorn_kernel`. `mhc_post` is a fused Triton kernel `_mhc_post_per_token`.
- `vllm/model_executor/layers/deepseek_v4_attention.py`:
  - `_deepseek_v4_fp8_einsum_fallback` + helpers.
  - `_apply_inv_rope_to_o` — inverse GPT-J RoPE then route through `wo_a` as a regular Linear (Marlin FP8 dequantizes internally).
  - `_ref_sparse_attn_decode_gather` — gather-first dequantize via a new `_gather_dequant_blocked_k_at_indices` helper (5–10× fewer cache bytes touched per layer).
  - `_dsv4_sm80_sparse_attn_decode_kernel` — Triton dual-scope sparse-attention decode with attn_sink folded into the online-softmax denominator.
  - `_ref_sparse_attn_prefill` — pure-PyTorch sparse attention with sink + LSE correction.
- `vllm/v1/attention/backends/mla/sparse_swa.py` — `build_tile_scheduler` short-circuits to all-`None` on SM80.
- `vllm/v1/attention/ops/deepseek_v4_ops/fused_inv_rope_fp8_quant.py` — Triton kernel emits scaled fp32; PyTorch performs the `.to(torch.float8_e4m3fn)` cast.
- `vllm/v1/attention/ops/deepseek_v4_ops/fused_indexer_q.py` — Triton kernel for the FP8 path emits scaled fp32; PyTorch casts. MXFP4 path unchanged.
- `vllm/v1/attention/ops/deepseek_v4_ops/fused_compress_quant_cache.py` — vectorised PyTorch fallbacks for both V4 K compressor (head=512) and indexer compressor (head=128); wrapped as `vllm::deepseek_v4_compressor_*_sm80` custom ops for cudagraph splitting.
- `vllm/v1/attention/ops/deepseek_v4_ops/cache_utils.py` — `_dequantize_and_gather_k_kernel_sm80` Triton kernel using PR 38476's `_decode_e4m3fn`; vectorised PyTorch fallback wrapped as `vllm::deepseek_v4_dequant_gather_sm80` custom op.
- `vllm/config/compilation.py` — three new SM80 ops added to `_attention_ops` so PIECEWISE cudagraphs split at the call sites (the bodies use `.any()` / `.nonzero()` / `.item()` which are forbidden during cudagraph capture).

**Out of scope:** mega-MoE (`fp8_fp4_mega_moe`, `transform_weights_for_mega_moe`, `get_symm_buffer_for_mega_moe`). Avoidable via `VLLM_DEEPSEEK_V4_USE_MEGA_MOE=0`. The standard `FusedMoE` Marlin path runs on SM80; `--enable-expert-parallel` works without mega-MoE.

### Performance on 8× A100-SXM4-80GB

#### Single-request latency progression
Single-prompt `"Once upon a time,"`, `max_tokens=32`, `temperature=0`, TP=8:

| Step | Time (s) | Throughput | Cumulative |
|---|---|---|---|
| Baseline (Python loops in compressor + dequant) | 20.2 | 1.58 tok/s | 1.0× |
| Track A (vectorise compressor + dequant fallbacks) | 9.3 | 3.44 tok/s | 2.17× |
| Track C step 1 (gather-first dequant in sparse-attn) | 9.2 | 3.50 tok/s | 2.20× |
| Track B step 1 (Triton fp32 + PyTorch fp8 cast for inv_rope_fp8_quant) | 9.2 | 3.50 tok/s | — |
| Track C step 2 (Triton mhc_post + softmax+sinkhorn) | 6.9 | 4.63 tok/s | 2.93× |
| Track B step 2 (Triton fp32 + PyTorch fp8 cast for fused_indexer_q) | 6.7 | 4.78 tok/s | 3.02× |
| Track C step 3 (Triton dual-scope sparse-attn with sink) | 6.5 | 4.92 tok/s | 3.11× |
| **Track E (PIECEWISE cudagraphs via splitting_ops)** | **4.13** | **7.74 tok/s** | **4.90×** |
| Track B step 4 (Triton dequant_gather via _decode_e4m3fn) | 4.12 | 7.77 tok/s | 4.91× |

#### Aggregate throughput at production concurrency

Throughput scales linearly with concurrency since the GPU is the bottleneck, not the SM80 reference paths:

| Concurrency | Total wall time | Aggregate throughput |
|---|---|---|
| 1 | 4.13s | 7.74 tok/s |
| 8 | 9.88s | 25.92 tok/s |
| 16 | 8.37s | **61.20 tok/s** |
| 32 | 5.99s | **170.87 tok/s** |
| 64 | 7.56s | **271.02 tok/s** |

**Production deployments serve concurrent requests, so the 60+ tok/s aggregate at c≥16 is the load-relevant number** — comfortably past the 50 tok/s target. Single-request latency at c=1 (7.74 tok/s) is bound by Marlin FP8 GEMM kernel-launch overhead per layer, not by reference-path Python overhead (cudagraphs already eliminated that). Output remains coherent across all variants: `"in a land far, far away, there lived a young"`.

### Launch (with cudagraphs)

```bash
VLLM_DEEPSEEK_V4_USE_MEGA_MOE=0 vllm serve DeepSeek-V4-Flash \
    --tensor-parallel-size 8 --max-model-len 1024 --gpu-memory-utilization 0.5 \
    --dtype bfloat16 --kv-cache-dtype fp8 \
    --tokenizer-mode deepseek_v4 --trust-remote-code \
    --compilation-config '{"cudagraph_mode": "PIECEWISE"}'
```

(Drop `--compilation-config` arg to fall back to eager mode at ~5 tok/s. PIECEWISE is required because the SM80 reference paths use data-dependent control flow that FULL cudagraph capture rejects.)

## Test Plan

## Test Result