### PR TITLE
[Tests] Gate Isaac under Transformers v5

### DIFF
--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -958,6 +958,18 @@ _MULTIMODAL_EXAMPLE_MODELS = {
         "PerceptronAI/Isaac-0.1",
         trust_remote_code=True,
         extras={"0.2-2B-Preview": "PerceptronAI/Isaac-0.2-2B-Preview"},
+        max_transformers_version="4.57",
+        transformers_version_reason={
+            "vllm": (
+                "Custom Isaac code is not compatible with Transformers v5. "
+                "The model should be upstreamed to Transformers for "
+                "long-term support."
+            ),
+            "hf": (
+                "Isaac's remote model and processor code import or configure "
+                "APIs that changed in Transformers v5."
+            ),
+        },
     ),
     "InternS1ForConditionalGeneration": _HfExamplesInfo(
         "internlm/Intern-S1",


### PR DESCRIPTION
#### What this PR does / why we need it

Adds a Transformers v5 version gate for `IsaacForConditionalGeneration` in the model test registry.

The Isaac checkpoints still rely on custom Hub code that is not fully compatible with Transformers v5. The linked issue notes that this should be resolved sustainably by upstreaming Isaac into Transformers; until then, the vLLM/HF test registry should skip this model under Transformers v5 instead of failing during the Transformers v5 upgrade test run.

Refs #38389

#### Special notes for your reviewer

I kept this intentionally small and limited to the test registry metadata.

#### Does this PR introduce _any_ user-facing change?

No.

#### How was this patch tested?

- `uvx ruff check tests/models/registry.py`
- Verified locally with Transformers `5.7.0.dev0` that `HF_EXAMPLE_MODELS.get_hf_info("IsaacForConditionalGeneration").check_transformers_version(...)` skips for both `vllm` and `hf` checks.
