### PR TITLE
[Bugfix] Skip flashinfer-rope variant in QK norm+RoPE fusion

### DIFF
--- a/vllm/compilation/passes/fusion/qk_norm_rope_fusion.py
+++ b/vllm/compilation/passes/fusion/qk_norm_rope_fusion.py
@@ -216,7 +216,16 @@ class QKNormRoPEFusionPass(VllmPatternMatcherPass):
         for epsilon in [1e-5, 1e-6]:
             for neox in [True, False]:
                 if RotaryEmbedding.enabled():
-                    for rope_flashinfer in [False, True]:
+                    # NOTE: skip the flashinfer-rope variant of the pattern.
+                    # PyTorch Inductor's pattern matcher trips an over-strict
+                    # assertion when matching custom ops that mutate multiple
+                    # tensor arguments sharing a symbolic dim — which is the
+                    # case for `flashinfer_rotary_embedding(query, key, ...)`
+                    # used by DeepSeek-V3.2 sparse-MLA. Models that don't use
+                    # flashinfer rope (Qwen, Llama, etc.) still match the
+                    # `rope_flashinfer=False` pattern and get the fusion.
+                    # Tracked in vllm-project/vllm#40587.
+                    for rope_flashinfer in [False]:
                         QkNormRopePattern(
                             head_dim=layer.head_size,
                             num_heads=layer.num_heads,


### PR DESCRIPTION
PyTorch Inductor's pattern matcher trips an over-strict assertion when matching custom ops that mutate multiple tensor arguments sharing a symbolic dim. This is exactly the shape of `flashinfer_rotary_embedding` (`mutates_args=["query", "key"]`), which DeepSeek-V3.2 sparse-MLA uses on B200, causing a crash whenever `enable_qk_norm_rope_fusion` is on.

This change drops the `rope_flashinfer=True` arm of the QK norm+RoPE fusion pattern. Models that don't use flashinfer rope (Qwen, Llama, etc.) still match the `rope_flashinfer=False` pattern and get the fusion. Flashinfer-rope models simply fall back to the unfused path.

The "long-term" upstream-PyTorch fix called out in #40587 is unlikely to be needed once rope is ported to vLLM IR; this is the minimal short-term mitigation.

Fixes #40587

Co-authored-by: Claude




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

