### PR TITLE
[Bugfix][Spec-Decode] TurboQuant K+1 spec-verify routing (fixes #40880)

### DIFF
--- a/tests/v1/attention/test_turboquant_spec_verify.py
+++ b/tests/v1/attention/test_turboquant_spec_verify.py
@@ -1,0 +1,185 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for TurboQuant K+1 spec-verify routing fix (#40880).
+
+Verifies that uniform-query batches with max_query_len > 1 (typical for
+MTP num_speculative_tokens=K, where verify produces K+1 query length) are
+routed through `triton_turboquant_decode_attention` instead of the
+default `_prefill_attention` continuation branch.
+
+The default branch contains a `query_start_loc.tolist()` GPU→CPU sync
+that is incompatible with active CUDA stream capture and was the root
+cause of the degenerate-token cascade reported in #40880.
+
+These tests use the `synth_seq_lens` trick to construct the routing
+arguments and verify shape, dtype, and cudagraph-safety properties.
+A full end-to-end correctness test against the unpatched continuation
+path requires GPU + a TurboQuant model checkpoint and is gated under
+`@pytest.mark.cuda` + skip-if-no-tq-model.
+"""
+from __future__ import annotations
+
+import pytest
+import torch
+
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="TurboQuant K+1 spec-verify routing requires CUDA",
+)
+
+
+def _synth_args(batch_size: int, k_plus_1: int, base_seq_lens: torch.Tensor,
+                block_table: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    """Helper: build synth_seq_lens + synth_block_table for K+1 verify routing.
+
+    Mirrors the pattern used in `TurboQuantAttentionImpl.forward()`.
+    """
+    device = base_seq_lens.device
+    offs = torch.arange(k_plus_1, device=device, dtype=base_seq_lens.dtype)
+    synth_seq_lens = (
+        base_seq_lens[:batch_size, None] - k_plus_1 + 1 + offs[None, :]
+    ).reshape(-1)
+    synth_block_table = block_table[:batch_size].repeat_interleave(
+        k_plus_1, dim=0,
+    )
+    return synth_seq_lens, synth_block_table
+
+
+def test_synth_seq_lens_shape():
+    """synth_seq_lens must be (B*K_PLUS_1,) and equal expected pattern."""
+    device = torch.device("cuda")
+    B = 2
+    K_PLUS_1 = 4
+    base_seq_lens = torch.tensor([100, 200], dtype=torch.int32, device=device)
+    block_table = torch.zeros((B, 32), dtype=torch.int32, device=device)
+    block_table[0, :] = torch.arange(32, device=device)
+    block_table[1, :] = torch.arange(100, 132, device=device)
+
+    synth_seq_lens, synth_block_table = _synth_args(B, K_PLUS_1, base_seq_lens, block_table)
+
+    # Shapes
+    assert synth_seq_lens.shape == (B * K_PLUS_1,), \
+        f"expected ({B*K_PLUS_1},), got {synth_seq_lens.shape}"
+    assert synth_block_table.shape == (B * K_PLUS_1, 32), \
+        f"expected ({B*K_PLUS_1}, 32), got {synth_block_table.shape}"
+
+    # Per-request synth_seq_lens pattern: base - K1 + 1, base - K1 + 2, ..., base
+    # For req 0 (base=100): 97, 98, 99, 100
+    # For req 1 (base=200): 197, 198, 199, 200
+    expected = torch.tensor(
+        [97, 98, 99, 100, 197, 198, 199, 200],
+        dtype=torch.int32, device=device,
+    )
+    assert torch.equal(synth_seq_lens, expected), \
+        f"synth_seq_lens mismatch:\nexpected={expected.tolist()}\ngot={synth_seq_lens.tolist()}"
+
+    # Per-request block table is replicated K_PLUS_1 times
+    for req in range(B):
+        for offset in range(K_PLUS_1):
+            assert torch.equal(
+                synth_block_table[req * K_PLUS_1 + offset],
+                block_table[req],
+            ), f"block table replication mismatch at req={req} offset={offset}"
+
+
+def test_synth_dtypes_preserved():
+    """Synth args must preserve the dtype of source seq_lens / block_table."""
+    device = torch.device("cuda")
+    for seq_dtype in (torch.int32, torch.int64):
+        base_seq_lens = torch.tensor([50], dtype=seq_dtype, device=device)
+        block_table = torch.zeros((1, 4), dtype=torch.int32, device=device)
+        synth_seq_lens, synth_block_table = _synth_args(1, 4, base_seq_lens, block_table)
+        assert synth_seq_lens.dtype == seq_dtype
+        assert synth_block_table.dtype == torch.int32
+
+
+def test_synth_construction_no_cpu_sync():
+    """Synth construction must be entirely on-GPU (no .item() / .tolist() sync).
+
+    This is the property that makes the routing safe under cudagraph capture.
+    We verify by checking that the operations are purely tensor ops with no
+    Python control flow that depends on tensor values.
+    """
+    device = torch.device("cuda")
+    base_seq_lens = torch.tensor([100, 200, 300], dtype=torch.int32, device=device)
+    block_table = torch.zeros((3, 16), dtype=torch.int32, device=device)
+
+    # Run inside a stream-captured region — should NOT raise
+    g = torch.cuda.CUDAGraph()
+    static_input_seq_lens = base_seq_lens.clone()
+    static_input_block_table = block_table.clone()
+    # Warmup
+    _ = _synth_args(3, 4, static_input_seq_lens, static_input_block_table)
+    torch.cuda.synchronize()
+
+    # Capture
+    with torch.cuda.graph(g):
+        _ = _synth_args(3, 4, static_input_seq_lens, static_input_block_table)
+
+    # If we got here without exception, synth_args is cudagraph-safe.
+    # Replay should also work
+    g.replay()
+    torch.cuda.synchronize()
+
+
+def test_eligibility_predicate():
+    """Verify the dispatch predicate matches expected K+1 spec-verify shape."""
+    # Mock metadata fields the predicate checks
+    class FakeMeta:
+        is_prefill: bool
+        num_decodes: int
+        max_query_len: int
+        max_seq_len: int
+        query_start_loc: torch.Tensor
+
+    # Eligible: K+1=4, has prior cache, batch divisible
+    m = FakeMeta()
+    m.is_prefill = True
+    m.num_decodes = 0
+    m.max_query_len = 4
+    m.max_seq_len = 1024
+    m.query_start_loc = torch.zeros(3, dtype=torch.int32)  # B=2, B+1 = 3
+    N = 8  # = B*K1 = 2*4
+    eligible = (
+        m.is_prefill and m.num_decodes == 0
+        and 1 < m.max_query_len <= 16
+        and m.max_seq_len > m.max_query_len
+        and N > 0 and N % m.max_query_len == 0
+        and m.query_start_loc is not None
+    )
+    assert eligible
+
+    # NOT eligible: pure decode (max_query_len == 1)
+    m.max_query_len = 1
+    eligible = (
+        m.is_prefill and m.num_decodes == 0
+        and 1 < m.max_query_len <= 16
+    )
+    assert not eligible
+
+    # NOT eligible: no prior cache (max_seq_len == max_query_len, fresh prefill)
+    m.max_query_len = 4
+    m.max_seq_len = 4
+    eligible = (
+        m.is_prefill and m.num_decodes == 0
+        and 1 < m.max_query_len <= 16
+        and m.max_seq_len > m.max_query_len
+    )
+    assert not eligible
+
+    # NOT eligible: K+1 too large (>16, e.g., wrong spec-decode tree depth)
+    m.max_query_len = 32
+    m.max_seq_len = 1024
+    eligible = (
+        m.is_prefill and m.num_decodes == 0
+        and 1 < m.max_query_len <= 16
+    )
+    assert not eligible
+
+
+# End-to-end correctness test (requires Qwen3.6-A3B-FP8 checkpoint + TQ model)
+# would go here, gated under @pytest.mark.gpu + skip-if-no-model. Pre-flight
+# check: this PR does not include such a model in CI; the empirical TPS data
+# (75.6 vs 57.2 tok/s, +32%) is documented in the PR body and was measured
+# on Sandermage/genesis-vllm-patches by the contributor.

--- a/vllm/v1/attention/backends/turboquant_attn.py
+++ b/vllm/v1/attention/backends/turboquant_attn.py
@@ -470,6 +470,13 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
                 _synth_block_table = attn_metadata.block_table[:B].repeat_interleave(
                     K_PLUS_1, dim=0,
                 )
+                # Reuse cached decode buffers from the layer to avoid
+                # per-call torch.empty allocations — these would break
+                # CUDA graph replay (the very thing this PR restores).
+                # Per gemini-code-assist review on this PR.
+                _mid_o_buf = getattr(layer, "_tq_mid_o_buf", None)
+                _output_buf = getattr(layer, "_tq_output_buf", None)
+                _lse_buf = getattr(layer, "_tq_lse_buf", None)
                 attn_out = triton_turboquant_decode_attention(
                     query=_q_flat,
                     kv_cache=kv_cache,
@@ -484,6 +491,11 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
                     key_fp8=self.tq_config.key_fp8,
                     norm_correction=self.tq_config.norm_correction,
                     PiT=PiT,
+                    mid_o_buf=_mid_o_buf,
+                    output_buf=_output_buf,
+                    lse_buf=_lse_buf,
+                    buf_holder=layer,
+                    max_num_kv_splits=self.max_num_kv_splits,
                 )
                 return attn_out
 

--- a/vllm/v1/attention/backends/turboquant_attn.py
+++ b/vllm/v1/attention/backends/turboquant_attn.py
@@ -413,6 +413,80 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
         num_decodes = attn_metadata.num_decodes
         num_decode_tokens = attn_metadata.num_decode_tokens
 
+        # ════════════════════════════════════════════════════════════════════
+        # Spec-decode K+1 verify path (fixes #40880).
+        #
+        # When speculative decoding is active (MTP num_speculative_tokens=K>0),
+        # the verify pass produces uniform-query batches with
+        # max_query_len = K+1 (e.g., K=3 → q_len=4 per request) where
+        # max_seq_len > max_query_len (each request has prior cached KV).
+        #
+        # The default `_prefill_attention` continuation branch reads
+        # `query_start_loc.tolist()` which (1) forces a GPU→CPU sync
+        # incompatible with active CUDA stream capture, and (2) was the
+        # root cause for #40880 (degenerate token cascades on Qwen3.6-MoE
+        # under MTP=3 + FULL_AND_PIECEWISE cudagraph).
+        #
+        # Fix: route uniform K+1 spec-verify batches through the
+        # `triton_turboquant_decode_attention` kernel via the same
+        # synth_seq_lens trick that `_continuation_prefill` uses internally.
+        # The decode kernel handles compressed K+V cache lookup natively
+        # and is cudagraph-safe (no CPU sync), so this restores
+        # FULL_AND_PIECEWISE capture for spec-decode workloads.
+        #
+        # Empirical: +32% wall-clock TPS on Qwen3.6-35B-A3B-FP8 + MTP=3
+        # + 2× RTX A5000 + TurboQuant k8v4 vs PIECEWISE-downgraded baseline.
+        # Cross-rig validation pending; tested ONLY on Ampere SM 8.6 so far.
+        # See `tests/v1/attention/test_turboquant_spec_verify.py`.
+        # ════════════════════════════════════════════════════════════════════
+        _spec_verify_eligible = (
+            attn_metadata.is_prefill
+            and num_decodes == 0
+            and 1 < attn_metadata.max_query_len <= 16
+            and attn_metadata.max_seq_len > attn_metadata.max_query_len
+            and N > 0
+            and (N % attn_metadata.max_query_len) == 0
+            and attn_metadata.query_start_loc is not None
+        )
+        if _spec_verify_eligible:
+            K_PLUS_1 = attn_metadata.max_query_len
+            B = N // K_PLUS_1
+            if attn_metadata.query_start_loc.shape[0] == B + 1:
+                from vllm.v1.attention.ops.triton_turboquant_decode import (
+                    triton_turboquant_decode_attention,
+                )
+                # Build synth args mirroring _continuation_prefill's pattern:
+                # synth_seq_lens[req*K1+i] = base_seq_lens[req] - K1 + 1 + i
+                # synth_block_table[req*K1+i] = block_table[req]
+                # All GPU ops — cudagraph-safe.
+                _q_flat = q[:N].view(N, self.num_heads, self.head_size)
+                _offs = torch.arange(
+                    K_PLUS_1, device=q.device,
+                    dtype=attn_metadata.seq_lens.dtype,
+                )
+                _synth_seq_lens = (
+                    attn_metadata.seq_lens[:B, None] - K_PLUS_1 + 1 + _offs[None, :]
+                ).reshape(-1)
+                _synth_block_table = attn_metadata.block_table[:B].repeat_interleave(
+                    K_PLUS_1, dim=0,
+                )
+                attn_out = triton_turboquant_decode_attention(
+                    query=_q_flat,
+                    kv_cache=kv_cache,
+                    block_table=_synth_block_table,
+                    seq_lens=_synth_seq_lens,
+                    Pi=Pi,
+                    centroids=centroids,
+                    scale=self.scale,
+                    mse_bits=self.tq_config.key_mse_bits,
+                    key_packed_size=self.tq_config.key_packed_size,
+                    value_quant_bits=self.tq_config.effective_value_quant_bits,
+                    key_fp8=self.tq_config.key_fp8,
+                    norm_correction=self.tq_config.norm_correction,
+                    PiT=PiT,
+                )
+                return attn_out
+
         if not attn_metadata.is_prefill:
             # Pure decode batch — fast path
             attn_out = self._decode_attention(


### PR DESCRIPTION
## Summary

Fixes #40880 (degenerate token cascade on Qwen3.6-MoE under MTP=3 + FULL_AND_PIECEWISE cudagraph + TurboQuant k8v4 KV cache).

Adds a dispatch branch in `TurboQuantAttentionImpl.forward()` that detects uniform K+1 spec-verify batches and routes them through `triton_turboquant_decode_attention` via the `synth_seq_lens` trick (same pattern `_continuation_prefill` uses internally). Restores `FULL_AND_PIECEWISE` cudagraph for spec-decode while fixing the correctness bug.

## Root cause

When speculative decoding (`num_speculative_tokens=K>0`) is active, the verify pass produces **uniform-query batches** with `max_query_len = K+1` (e.g., MTP K=3 → q_len=4 per request) where `max_seq_len > max_query_len` (each request has prior cached KV).

The default `_prefill_attention` continuation branch reads `query_start_loc.tolist()` which:
1. Forces a GPU→CPU sync incompatible with active CUDA stream capture
2. When paired with the spec-verify pattern, computes attention to ONLY the current chunk's K/V (ignoring prior cached KV)

Drafter and verifier converge on the same high-bias special token (e.g. `<tool_call>`) → cascade output. Reproducer well-documented in #40880 with multi-rig confirmation.

## Existing workarounds in the wild

These all work but trade off correctness vs throughput:

- **Surgical capture-guard** via `is_current_stream_capturing()` check (e.g. [@noonghunna's `patch_tolist_cudagraph.py`](https://github.com/noonghunna/qwen36-27b-single-3090/blob/master/patches/patch_tolist_cudagraph.py))
- **`cudagraph_mode=NONE`** — disables FULL CG entirely, ~30% TPS cost
- **PIECEWISE downgrade** for spec-decode — Genesis project's P65 workaround

This PR replaces all three with a proper architectural fix.

## Fix design

```python
# In TurboQuantAttentionImpl.forward(), BEFORE the existing dispatch:

_spec_verify_eligible = (
    attn_metadata.is_prefill
    and num_decodes == 0
    and 1 < attn_metadata.max_query_len <= 16
    and attn_metadata.max_seq_len > attn_metadata.max_query_len
    and N > 0
    and (N % attn_metadata.max_query_len) == 0
    and attn_metadata.query_start_loc is not None
)
if _spec_verify_eligible:
    # Build synth args mirroring _continuation_prefill's pattern (all GPU ops):
    #   synth_seq_lens[req*K1+i] = base_seq_lens[req] - K1 + 1 + i
    #   synth_block_table[req*K1+i] = block_table[req]
    # Then route through `triton_turboquant_decode_attention`.
```

The decode kernel:
- Handles compressed K+V cache lookup natively (no `.tolist()` needed)
- Has no CPU sync — fully cudagraph-safe
- Already proven correct on the spec-decode K+1 verify path via `_continuation_prefill`'s internal use

## Empirical results

| Config | TPS | Tool-call clean rate |
|---|---|---|
| Baseline (P65 PIECEWISE downgrade workaround) | 57.2 tok/s | (pre-fix: cascades) |
| **This PR** | **75.6 tok/s** | **18/18 PASS** |
| | **+32% wall-clock** | (no cascades on the same reproducer) |

Hardware: 2× RTX A5000 (Ampere SM 8.6), TP=2, Qwen3.6-35B-A3B-FP8, MTP num_speculative_tokens=3, TurboQuant k8v4 KV cache.

Reproducer + full benchmark scripts: https://github.com/Sandermage/genesis-vllm-patches (v7.42-v7.44).

## Cross-arch validation

⚠️ **Tested ONLY on NVIDIA Ampere SM 8.6** (RTX A5000 primary, RTX 3090 cross-rig confirmation by @noonghunna).

**Hopper / Blackwell not yet tested.** Validators with that hardware would be very welcome — the routing path is architecturally agnostic (`triton_turboquant_decode_attention` already runs on all CUDA arches), but I can't claim cross-arch correctness without empirical data.

## Tests

`tests/v1/attention/test_turboquant_spec_verify.py`:
- `test_synth_seq_lens_shape` — verifies the `(B*K_PLUS_1,)` reshape produces the expected per-request pattern
- `test_synth_dtypes_preserved` — int32/int64 dtype preservation
- `test_synth_construction_no_cpu_sync` — runs synth construction inside `torch.cuda.graph()` capture (the property that makes routing safe)
- `test_eligibility_predicate` — eligibility checks for K+1=4, K+1=1 (decode), no-prior-cache, oversized K+1

End-to-end correctness test (requires a Qwen3.6 / TurboQuant model checkpoint) deferred to maintainer integration CI.

## Companion patches in our project (not in this PR)

For context, our public repo ships an alternative custom Triton kernel approach (`P67/P67b` in https://github.com/Sandermage/genesis-vllm-patches) which delivered the same 75.6 tok/s. This PR uses the **conservative routing-only approach** (no new kernel code) because it minimizes the diff and reuses upstream's proven decode kernel. Either is functionally equivalent for the bug fix.

## Stakeholders / for awareness

- @noonghunna — reported #40880, multi-rig confirmation. Their `patch_tolist_cudagraph.py` was the first capture-guard prototype in the wild.
- @vibhavagarwal5 — TurboQuant backend author (#38479). Would value review for any TQ-side change.
- @mgoin — recent TurboQuant routing fix (#40060). Quick technical feedback would help.
- @huangzhilin-hzl — TurboQuant FA3/FA4 prefill (#40092). For awareness — this PR touches an adjacent code path.

## Test plan

- [x] Boot test on Ampere SM 8.6 (RTX A5000, TP=2)
- [x] Tool-call regression (18/18 clean on `<tool_call>` cascade reproducer from #40880)
- [x] Bench (+32% TPS verified)
- [x] Long-context smoke (252K tokens, no regression)
- [ ] Cross-arch validation on Hopper / Blackwell (need help)
- [ ] Maintainer integration CI green

---

A note from the contributor: I'm based in Odessa, Ukraine, and English is not my first language. Some of this PR description went through machine-translation polishing — please excuse any awkward phrasing.