### PR TITLE
[Tool Parser] Redesign Qwen3 XML tool parser as character-level state machine

### DIFF
--- a/tests/entrypoints/openai/tool_parsers/test_qwen3xml_tool_parser.py
+++ b/tests/entrypoints/openai/tool_parsers/test_qwen3xml_tool_parser.py
@@ -1,0 +1,928 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Unit tests for StreamingXMLToolCallParser (Qwen3 XML tool-call format).
+
+These tests exercise the character-level state machine directly and do not
+require a running model server or GPU.  They cover:
+
+* Basic correctness (char-by-char and whole-chunk modes must agree)
+* Tag fragmentation at every byte position inside structural tags
+* HTML / XML fragments as literal parameter-value content
+* Tags that look like structural tags but aren't (partial names, etc.)
+* All parameter types (integer, float, boolean, object, array, string)
+* Multi-parameter and multi-call scenarios
+* Streaming delta reconstruction
+* Premature-abort resilience (name=None ghost call prevention)
+* Resync when a second <tool_call> arrives without a closing </tool_call>
+"""
+
+import json
+
+import pytest
+
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+from vllm.tool_parsers.qwen3xml_tool_parser import StreamingXMLToolCallParser
+
+# ---------------------------------------------------------------------------
+# Tool schema fixture used for typed-parameter tests
+# ---------------------------------------------------------------------------
+
+TOOLS_TYPED = [
+    {
+        "function": {
+            "name": "typed_fn",
+            "parameters": {
+                "properties": {
+                    "count": {"type": "integer"},
+                    "ratio": {"type": "float"},
+                    "flag": {"type": "boolean"},
+                    "data": {"type": "object"},
+                    "items": {"type": "array"},
+                    "label": {"type": "string"},
+                }
+            },
+        }
+    }
+]
+
+BASIC = (
+    "<tool_call>\n"
+    "<function=get_weather>\n"
+    "<parameter=city>\n"
+    "London\n"
+    "</parameter>\n"
+    "</function>\n"
+    "</tool_call>"
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def feed_char_by_char(text: str, tools=None) -> DeltaMessage:
+    p = StreamingXMLToolCallParser()
+    p.set_tools(tools)
+    for ch in text:
+        p.parse_single_streaming_chunks(ch)
+    p.finalize()
+    return p.collect_all()
+
+
+def feed_chunks(*chunks: str, tools=None) -> DeltaMessage:
+    p = StreamingXMLToolCallParser()
+    p.set_tools(tools)
+    for c in chunks:
+        p.parse_single_streaming_chunks(c)
+    p.finalize()
+    return p.collect_all()
+
+
+def assert_tool(
+    result: DeltaMessage, fn_name: str, expected: dict, index: int = 0
+) -> None:
+    assert result.tool_calls and len(result.tool_calls) > index
+    tc = result.tool_calls[index]
+    assert tc.function is not None
+    assert tc.function.name == fn_name, f"name={tc.function.name!r} != {fn_name!r}"
+    got = json.loads(tc.function.arguments or "{}")
+    assert got == expected, (
+        f"args mismatch:\n  got:      {tc.function.arguments}\n"
+        f"  expected: {json.dumps(expected)}"
+    )
+
+
+def all_splits(s: str):
+    """Every 2-part partition of *s*."""
+    return [(s[:i], s[i:]) for i in range(1, len(s))]
+
+
+# ===========================================================================
+# Section 1 – Basic correctness
+# ===========================================================================
+
+
+def test_basic_char_by_char():
+    assert_tool(feed_char_by_char(BASIC), "get_weather", {"city": "London"})
+
+
+def test_basic_whole_chunk():
+    assert_tool(feed_chunks(BASIC), "get_weather", {"city": "London"})
+
+
+def test_collect_all_idempotent():
+    p = StreamingXMLToolCallParser()
+    p.parse_single_streaming_chunks(BASIC)
+    p.finalize()
+    r1 = p.collect_all()
+    r2 = p.collect_all()
+    assert r1.tool_calls[0].function.arguments == r2.tool_calls[0].function.arguments
+    assert json.loads(r1.tool_calls[0].function.arguments) == {"city": "London"}
+
+
+def test_whole_chunk_matches_char_by_char():
+    a = feed_char_by_char(BASIC).tool_calls[0].function.arguments
+    b = feed_chunks(BASIC).tool_calls[0].function.arguments
+    assert a == b
+
+
+def test_implicit_tool_call_no_wrapper():
+    # <function=…> without a preceding <tool_call> must NOT create a tool call.
+    # It is treated as plain text content since the Qwen3 XML format always
+    # wraps function calls in <tool_call>…</tool_call>.
+    r = feed_char_by_char(
+        "<function=quick>\n<parameter=z>\nhello\n</parameter>\n</function>"
+    )
+    assert not r.tool_calls, f"Expected no tool calls, got {r.tool_calls}"
+
+
+def test_no_parameters_produces_empty_object():
+    r = feed_char_by_char("<tool_call>\n<function=noop>\n</function>\n</tool_call>")
+    assert r.tool_calls[0].function.arguments == "{}"
+
+
+# ===========================================================================
+# Section 2 – Tag fragmentation
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "head,tail",
+    all_splits(
+        "<tool_call>\n<function=f>\n<parameter=x>\nv\n</parameter>\n</function>\n</tool_call>"
+    ),
+)
+def test_frag_tool_call_tag(head, tail):
+    r = feed_chunks(head, tail)
+    assert r.tool_calls and r.tool_calls[0].function.name == "f"
+
+
+@pytest.mark.parametrize(
+    "head,tail",
+    all_splits(
+        "<tool_call>\n<function=my_func>\n<parameter=a>\n1\n</parameter>\n</function>\n</tool_call>"
+    ),
+)
+def test_frag_function_tag(head, tail):
+    r = feed_chunks(head, tail)
+    assert r.tool_calls and r.tool_calls[0].function.name == "my_func"
+
+
+@pytest.mark.parametrize(
+    "head,tail",
+    all_splits(
+        "<tool_call>\n<function=f>\n<parameter=x>\nval\n</parameter>\n</function>\n</tool_call>"
+    ),
+)
+def test_frag_close_parameter_tag(head, tail):
+    r = feed_chunks(head, tail)
+    assert json.loads(r.tool_calls[0].function.arguments) == {"x": "val"}
+
+
+def test_frag_one_char_per_chunk():
+    assert_tool(feed_char_by_char(BASIC), "get_weather", {"city": "London"})
+
+
+def test_frag_function_name_split():
+    r = feed_chunks(
+        "<tool_call>\n<function=get_wea",
+        "ther>\n<parameter=city>\nParis\n</parameter>\n</function>\n</tool_call>",
+    )
+    assert_tool(r, "get_weather", {"city": "Paris"})
+
+
+def test_frag_close_tool_call_split():
+    r = feed_chunks(
+        "<tool_call>\n<function=f>\n<parameter=x>\nv\n</parameter>\n</function>\n</too",
+        "l_call>",
+    )
+    assert_tool(r, "f", {"x": "v"})
+
+
+def test_frag_lt_of_html_tag_is_last_char():
+    r = feed_chunks(
+        "<tool_call>\n<function=f>\n<parameter=h>\n<",
+        "b>bold</b>\n</parameter>\n</function>\n</tool_call>",
+    )
+    assert_tool(r, "f", {"h": "<b>bold</b>"})
+
+
+# ===========================================================================
+# Section 3 – HTML / XML content inside parameter values
+# ===========================================================================
+
+
+def test_html_simple_tag():
+    assert_tool(
+        feed_char_by_char(
+            "<tool_call>\n<function=f>\n<parameter=h>\n<b>bold</b>\n</parameter>\n</function>\n</tool_call>"
+        ),
+        "f",
+        {"h": "<b>bold</b>"},
+    )
+
+
+def test_html_nested():
+    html = "<div><p>Hello <em>world</em></p></div>"
+    assert_tool(
+        feed_char_by_char(
+            f"<tool_call>\n<function=f>\n<parameter=h>\n{html}\n</parameter>\n</function>\n</tool_call>"
+        ),
+        "f",
+        {"h": html},
+    )
+
+
+def test_html_tag_with_lt_in_attribute():
+    html = '<img src="photo.jpg" alt="A < B">'
+    assert_tool(
+        feed_char_by_char(
+            f"<tool_call>\n<function=f>\n<parameter=h>\n{html}\n</parameter>\n</function>\n</tool_call>"
+        ),
+        "f",
+        {"h": html},
+    )
+
+
+def test_html_self_closing():
+    content = "line1<br/>line2<br/>line3"
+    assert_tool(
+        feed_char_by_char(
+            f"<tool_call>\n<function=f>\n<parameter=t>\n{content}\n</parameter>\n</function>\n</tool_call>"
+        ),
+        "f",
+        {"t": content},
+    )
+
+
+def test_html_xml_comment():
+    content = "before<!-- comment -->after"
+    assert_tool(
+        feed_char_by_char(
+            f"<tool_call>\n<function=f>\n<parameter=c>\n{content}\n</parameter>\n</function>\n</tool_call>"
+        ),
+        "f",
+        {"c": content},
+    )
+
+
+# ===========================================================================
+# Section 4 – Tags that look like structural tags but aren't
+# ===========================================================================
+
+
+@pytest.mark.parametrize(
+    "tag",
+    [
+        "</param>",  # prefix of </parameter>
+        "</func>",  # prefix of </function>
+        "</tool>",  # prefix of </tool_call>
+        "<parameter>",  # missing =name
+        "<function>",  # missing =name
+        "<tool_call_x>",  # similar but not equal
+        "</tool_calls>",  # longer than </tool_call>
+    ],
+)
+def test_partial_tag_names_are_literal(tag):
+    r = feed_char_by_char(
+        f"<tool_call>\n<function=f>\n<parameter=v>\n{tag}\n</parameter>\n</function>\n</tool_call>"
+    )
+    assert json.loads(r.tool_calls[0].function.arguments) == {"v": tag}
+
+
+@pytest.mark.parametrize(
+    "tag",
+    [
+        "<tool_call>",
+        "<function=other>",
+        "<parameter=nested>",
+    ],
+)
+def test_opening_structural_tags_are_literal_inside_value(tag):
+    r = feed_char_by_char(
+        f"<tool_call>\n<function=f>\n<parameter=v>\n{tag}\n</parameter>\n</function>\n</tool_call>"
+    )
+    assert json.loads(r.tool_calls[0].function.arguments) == {"v": tag}
+
+
+def test_bare_lt_space_is_literal():
+    assert_tool(
+        feed_char_by_char(
+            "<tool_call>\n<function=f>\n<parameter=expr>\na < b\n</parameter>\n</function>\n</tool_call>"
+        ),
+        "f",
+        {"expr": "a < b"},
+    )
+
+
+def test_double_lt_in_value():
+    r = feed_char_by_char(
+        "<tool_call>\n<function=f>\n<parameter=v>\na<<b\n</parameter>\n</function>\n</tool_call>"
+    )
+    assert json.loads(r.tool_calls[0].function.arguments) == {"v": "a<<b"}
+
+
+def test_json_fragment_with_angle_brackets():
+    content = '{"key": "<value>", "other": 1}'
+    r = feed_char_by_char(
+        f"<tool_call>\n<function=f>\n<parameter=j>\n{content}\n</parameter>\n</function>\n</tool_call>"
+    )
+    assert json.loads(r.tool_calls[0].function.arguments) == {"j": content}
+
+
+# ===========================================================================
+# Section 5 – Format limitations (documented, no crash)
+# ===========================================================================
+
+
+def test_embedded_close_parameter_ends_early_no_crash():
+    """A literal </parameter> inside a value closes the parameter early.
+    There is no escaping in this format; test that we don't crash and
+    produce valid JSON."""
+    out = (
+        "<tool_call>\n<function=f>\n"
+        "<parameter=code>\n"
+        "x = '</parameter>'\n"
+        "</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    r = feed_char_by_char(out)
+    assert r.tool_calls
+    json.loads(r.tool_calls[0].function.arguments)  # must be valid JSON
+
+
+def test_embedded_close_function_ends_early_no_crash():
+    out = (
+        "<tool_call>\n<function=f>\n"
+        "<parameter=v>\n"
+        "text</function>more\n"
+        "</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    r = feed_char_by_char(out)
+    assert r.tool_calls
+    json.loads(r.tool_calls[0].function.arguments)
+
+
+# ===========================================================================
+# Section 6 – Parameter types
+# ===========================================================================
+
+
+def _typed(param: str, value: str) -> dict:
+    r = feed_char_by_char(
+        f"<tool_call>\n<function=typed_fn>\n"
+        f"<parameter={param}>\n{value}\n</parameter>\n"
+        f"</function>\n</tool_call>",
+        tools=TOOLS_TYPED,
+    )
+    return json.loads(r.tool_calls[0].function.arguments)
+
+
+def test_type_integer():
+    assert _typed("count", "42") == {"count": 42}
+
+
+def test_type_float():
+    assert abs(_typed("ratio", "3.14")["ratio"] - 3.14) < 1e-9
+
+
+def test_type_float_whole_number():
+    assert _typed("ratio", "2.0") == {"ratio": 2}
+
+
+def test_type_boolean_true():
+    assert _typed("flag", "true") == {"flag": True}
+
+
+def test_type_boolean_false():
+    assert _typed("flag", "false") == {"flag": False}
+
+
+def test_type_boolean_capitalised():
+    assert _typed("flag", "True") == {"flag": True}
+
+
+def test_type_null():
+    assert _typed("label", "null") == {"label": None}
+
+
+def test_type_object_json():
+    assert _typed("data", '{"key": "val", "n": 1}') == {"data": {"key": "val", "n": 1}}
+
+
+def test_type_object_python_dict():
+    assert _typed("data", "{'key': 'val', 'n': 1}") == {"data": {"key": "val", "n": 1}}
+
+
+def test_type_array_json():
+    assert _typed("items", '[1, "two", true]') == {"items": [1, "two", True]}
+
+
+def test_type_array_python_list():
+    assert _typed("items", "['a', 'b', 'c']") == {"items": ["a", "b", "c"]}
+
+
+def test_type_object_with_angle_brackets():
+    payload = '{"url": "https://example.com?a=1&b=<2>"}'
+    args = _typed("data", payload)
+    assert args["data"]["url"] == "https://example.com?a=1&b=<2>"
+
+
+# ===========================================================================
+# Section 7 – String edge cases
+# ===========================================================================
+
+
+def test_string_double_quotes():
+    assert_tool(
+        feed_char_by_char(
+            '<tool_call>\n<function=f>\n<parameter=msg>\nShe said "hello"\n</parameter>\n</function>\n</tool_call>'
+        ),
+        "f",
+        {"msg": 'She said "hello"'},
+    )
+
+
+def test_string_backslash():
+    path = "C:\\Users\\alice\\file.txt"
+    assert_tool(
+        feed_char_by_char(
+            f"<tool_call>\n<function=f>\n<parameter=path>\n{path}\n</parameter>\n</function>\n</tool_call>"
+        ),
+        "f",
+        {"path": path},
+    )
+
+
+def test_string_unicode():
+    content = "日本語テスト 🎉"
+    assert_tool(
+        feed_char_by_char(
+            f"<tool_call>\n<function=f>\n<parameter=text>\n{content}\n</parameter>\n</function>\n</tool_call>"
+        ),
+        "f",
+        {"text": content},
+    )
+
+
+def test_string_empty():
+    r = feed_char_by_char(
+        "<tool_call>\n<function=f>\n<parameter=v></parameter>\n</function>\n</tool_call>"
+    )
+    assert json.loads(r.tool_calls[0].function.arguments) == {"v": ""}
+
+
+def test_string_multiline():
+    content = "first line\nsecond line\nthird line"
+    assert_tool(
+        feed_char_by_char(
+            f"<tool_call>\n<function=f>\n<parameter=text>\n{content}\n</parameter>\n</function>\n</tool_call>"
+        ),
+        "f",
+        {"text": content},
+    )
+
+
+# ===========================================================================
+# Section 8 – Multi-parameter and multi-call
+# ===========================================================================
+
+
+def test_many_parameters():
+    out = (
+        "<tool_call>\n<function=send_email>\n"
+        "<parameter=to>\nalice@example.com\n</parameter>\n"
+        "<parameter=cc>\nbob@example.com\n</parameter>\n"
+        "<parameter=subject>\nHello!\n</parameter>\n"
+        "<parameter=body>\nDear Alice,\nThis is a test.\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    assert_tool(
+        feed_char_by_char(out),
+        "send_email",
+        {
+            "to": "alice@example.com",
+            "cc": "bob@example.com",
+            "subject": "Hello!",
+            "body": "Dear Alice,\nThis is a test.",
+        },
+    )
+
+
+def test_two_tool_calls():
+    out = (
+        "<tool_call>\n<function=f1>\n<parameter=a>\nfoo\n</parameter>\n</function>\n</tool_call>\n"
+        "<tool_call>\n<function=f2>\n<parameter=b>\nbar\n</parameter>\n</function>\n</tool_call>"
+    )
+    r = feed_char_by_char(out)
+    assert len(r.tool_calls) == 2
+    assert_tool(r, "f1", {"a": "foo"}, index=0)
+    assert_tool(r, "f2", {"b": "bar"}, index=1)
+
+
+def test_three_tool_calls():
+    out = "".join(
+        f"<tool_call>\n<function=f{i}>\n<parameter=x>\n{i}\n</parameter>\n</function>\n</tool_call>\n"
+        for i in range(3)
+    )
+    r = feed_char_by_char(out)
+    assert len(r.tool_calls) == 3
+    for i in range(3):
+        assert_tool(r, f"f{i}", {"x": str(i)}, index=i)
+
+
+def test_text_before_tool_call():
+    out = (
+        "I'll check the weather for you.\n"
+        "<tool_call>\n<function=get_weather>\n"
+        "<parameter=city>\nTokyo\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    r = feed_char_by_char(out)
+    assert r.content and "weather" in r.content
+    assert_tool(r, "get_weather", {"city": "Tokyo"})
+
+
+# ===========================================================================
+# Section 9 – Syntax variants
+# ===========================================================================
+
+
+def test_attr_syntax_function_and_param():
+    out = (
+        '<tool_call>\n<function name="send">\n'
+        '<parameter name="to">\nalice\n</parameter>\n'
+        "</function>\n</tool_call>"
+    )
+    assert_tool(feed_char_by_char(out), "send", {"to": "alice"})
+
+
+# ===========================================================================
+# Section 10 – Streaming delta reconstruction
+# ===========================================================================
+
+
+def test_streaming_incremental_deltas_reconstruct_args():
+    full = (
+        "<tool_call>\n<function=calc>\n"
+        "<parameter=expr>\n2 + 2\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    p = StreamingXMLToolCallParser()
+    accumulated_args = ""
+    fn_name = None
+    for ch in full:
+        delta = p.parse_single_streaming_chunks(ch)
+        if delta and delta.tool_calls:
+            for tc in delta.tool_calls:
+                if tc.function:
+                    if tc.function.name:
+                        fn_name = tc.function.name
+                    if tc.function.arguments:
+                        accumulated_args += tc.function.arguments
+    p.finalize()
+    assert fn_name == "calc"
+    assert json.loads(accumulated_args) == {"expr": "2 + 2"}
+
+
+def test_streaming_text_content_before_tool_call():
+    full = (
+        "Let me search.\n"
+        "<tool_call>\n<function=search>\n<parameter=q>\ntest\n</parameter>\n</function>\n</tool_call>"
+    )
+    p = StreamingXMLToolCallParser()
+    content_seen = []
+    for ch in full:
+        delta = p.parse_single_streaming_chunks(ch)
+        if delta and delta.content:
+            content_seen.append(delta.content)
+    p.finalize()
+    assert "Let me search" in "".join(content_seen)
+
+
+def test_streaming_two_calls_distinct_ids():
+    out = (
+        "<tool_call>\n<function=f1>\n<parameter=a>\nA\n</parameter>\n</function>\n</tool_call>\n"
+        "<tool_call>\n<function=f2>\n<parameter=b>\nB\n</parameter>\n</function>\n</tool_call>"
+    )
+    p = StreamingXMLToolCallParser()
+    seen_ids: set[str] = set()
+    for ch in out:
+        delta = p.parse_single_streaming_chunks(ch)
+        if delta and delta.tool_calls:
+            for tc in delta.tool_calls:
+                if tc.id:
+                    seen_ids.add(tc.id)
+    p.finalize()
+    assert len(seen_ids) == 2
+
+
+# ===========================================================================
+# Section 11 – Premature abort / resync
+# ===========================================================================
+
+
+def test_abort_right_after_tool_call_open():
+    r = feed_char_by_char("<tool_call>\n")
+    assert not r.tool_calls, f"Expected no tool_calls, got: {r.tool_calls}"
+
+
+def test_abort_mid_function_tag():
+    r = feed_char_by_char("<tool_call>\n<function=get_wea")
+    assert not r.tool_calls, f"Expected no tool_calls, got: {r.tool_calls}"
+
+
+def test_abort_after_complete_function_tag():
+    r = feed_char_by_char("<tool_call>\n<function=get_weather>\n")
+    assert r.tool_calls
+    assert r.tool_calls[0].function.name == "get_weather"
+    assert r.tool_calls[0].function.arguments == "{}"
+
+
+def test_abort_mid_parameter_tag():
+    r = feed_char_by_char("<tool_call>\n<function=f>\n<parameter=ci")
+    assert r.tool_calls and r.tool_calls[0].function.name == "f"
+    assert r.tool_calls[0].function.arguments == "{}"
+
+
+def test_abort_mid_parameter_value():
+    r = feed_char_by_char("<tool_call>\n<function=f>\n<parameter=city>\nLon")
+    assert r.tool_calls and r.tool_calls[0].function.name == "f"
+    assert json.loads(r.tool_calls[0].function.arguments) == {"city": "Lon"}
+
+
+def test_abort_no_close_tool_call():
+    assert_tool(
+        feed_char_by_char(
+            "<tool_call>\n<function=f>\n<parameter=x>\nval\n</parameter>\n</function>"
+        ),
+        "f",
+        {"x": "val"},
+    )
+
+
+@pytest.mark.parametrize(
+    "partial",
+    [
+        "<tool_call>",
+        "<tool_call>\n",
+        "<tool_call>\n<function=get_wea",
+        "<tool_call>\n<function=",
+    ],
+)
+def test_collect_all_never_returns_null_name(partial):
+    r = feed_char_by_char(partial)
+    if r.tool_calls:
+        for tc in r.tool_calls:
+            assert tc.function and tc.function.name, (
+                f"name=None in result for input {partial!r}"
+            )
+
+
+def test_resync_missing_close_tag_both_calls_correct():
+    out = (
+        "<tool_call>\n<function=f1>\n<parameter=a>\nA\n</parameter>\n</function>\n"
+        "<tool_call>\n<function=f2>\n<parameter=b>\nB\n</parameter>\n</function>\n</tool_call>"
+    )
+    r = feed_char_by_char(out)
+    assert len(r.tool_calls) == 2
+    assert_tool(r, "f1", {"a": "A"}, index=0)
+    assert_tool(r, "f2", {"b": "B"}, index=1)
+
+
+def test_resync_missing_close_tag_terminator_order():
+    """call_1's terminator delta must arrive before call_2's first delta."""
+    out = (
+        "<tool_call>\n<function=f1>\n<parameter=a>\nA\n</parameter>\n</function>\n"
+        "<tool_call>\n<function=f2>\n<parameter=b>\nB\n</parameter>\n</function>\n</tool_call>"
+    )
+    p = StreamingXMLToolCallParser()
+    events: list[tuple[str, str | None, str | None]] = []
+    for ch in out:
+        delta = p.parse_single_streaming_chunks(ch)
+        if delta and delta.tool_calls:
+            for tc in delta.tool_calls:
+                if tc.function:
+                    events.append(
+                        (tc.id or "", tc.function.name, tc.function.arguments)
+                    )
+    p.finalize()
+
+    call_ids: list[str] = []
+    for cid, _, _ in events:
+        if cid not in call_ids:
+            call_ids.append(cid)
+    assert len(call_ids) == 2
+    call1_id, call2_id = call_ids
+
+    term_pos = next(
+        (
+            i
+            for i, (cid, n, a) in enumerate(events)
+            if cid == call1_id and n is None and a == ""
+        ),
+        None,
+    )
+    start2_pos = next(
+        (i for i, (cid, _, _) in enumerate(events) if cid == call2_id), None
+    )
+    assert term_pos is not None, "call_1 never received a terminator delta"
+    assert term_pos < start2_pos, (
+        f"call_1 terminator (pos {term_pos}) arrived after call_2 started (pos {start2_pos})"
+    )
+
+
+def test_reset_streaming_state_discards_partial_call():
+    p = StreamingXMLToolCallParser()
+    for ch in "<tool_call>\n<function=broken":
+        p.parse_single_streaming_chunks(ch)
+    p.reset_streaming_state()
+    good = "<tool_call>\n<function=good_fn>\n<parameter=x>\nok\n</parameter>\n</function>\n</tool_call>"
+    for ch in good:
+        p.parse_single_streaming_chunks(ch)
+    p.finalize()
+    r = p.collect_all()
+    assert r.tool_calls and len(r.tool_calls) == 1
+    assert_tool(r, "good_fn", {"x": "ok"})
+
+
+# ===========================================================================
+# Section 12 - Syntax robustness (single quotes, whitespace, etc.)
+# ===========================================================================
+
+
+def test_attr_syntax_single_quotes():
+    out = "<tool_call>\n<function name='send'>\n<parameter name='to'>\nalice\n</parameter>\n</function>\n</tool_call>"
+    assert_tool(feed_char_by_char(out), "send", {"to": "alice"})
+
+
+def test_attr_syntax_whitespace_before_closing_gt():
+    out = '<tool_call>\n<function name="send" >\n<parameter name="to" >\nalice\n</parameter>\n</function>\n</tool_call>'
+    assert_tool(feed_char_by_char(out), "send", {"to": "alice"})
+
+
+def test_attr_syntax_spaces_around_equals():
+    out = '<tool_call>\n<function name = "send">\n<parameter name = "to">\nalice\n</parameter>\n</function>\n</tool_call>'
+    assert_tool(feed_char_by_char(out), "send", {"to": "alice"})
+
+
+def test_eq_syntax_spaces_around_equals():
+    out = "<tool_call>\n<function = send>\n<parameter = to>\nalice\n</parameter>\n</function>\n</tool_call>"
+    assert_tool(feed_char_by_char(out), "send", {"to": "alice"})
+
+
+# ===========================================================================
+# Section 13 - Integer from float representation
+# ===========================================================================
+
+
+def test_type_integer_from_float_string():
+    p = StreamingXMLToolCallParser()
+    assert p._raw_to_json("42.0", "integer") == "42"
+
+
+def test_type_integer_from_float_string_with_decimals():
+    p = StreamingXMLToolCallParser()
+    assert p._raw_to_json("7.5", "integer") == "7"
+
+
+# ===========================================================================
+# Section 14 - <tool_call> lookahead (must be followed by <function=…>)
+# ===========================================================================
+#
+# A <tool_call> seen in plain-text / reasoning context must NOT be treated as
+# a tool-call opener unless the very next structural tag is <function=…>.
+# All other followers cause the <tool_call> to be rolled back as literal text.
+
+
+def test_fake_tool_call_followed_by_text():
+    """<tool_call> with no following structural tag: rolled back as content."""
+    out = "Use the <tool_call> syntax to call tools."
+    result = feed_char_by_char(out)
+    assert not result.tool_calls
+    assert result.content == out
+
+
+def test_fake_tool_call_followed_by_closing_tag():
+    """<tool_call>...</tool_call> without <function=…>: rolled back as content."""
+    out = "<tool_call>some text</tool_call>"
+    result = feed_char_by_char(out)
+    assert not result.tool_calls
+    assert result.content == out
+
+
+def test_fake_tool_call_followed_by_another_tool_call_then_real():
+    """Two <tool_call> mentions; only the one followed by <function=…> is real."""
+    text_before = "You can nest <tool_call>\n<tool_call>\n"
+    real = "<function=bash>\n<parameter=cmd>\nls\n</parameter>\n</function>\n</tool_call>"
+    out = text_before + real
+    result = feed_char_by_char(out)
+    assert_tool(result, "bash", {"cmd": "ls"})
+    assert result.content == "You can nest <tool_call>\n"
+
+
+def test_fake_tool_call_then_real_tool_call():
+    """Fake <tool_call> in reasoning text, then a real tool call after."""
+    fake = "Thinking: use <tool_call> here.\n"
+    real = (
+        "<tool_call>\n"
+        "<function=read_file>\n"
+        "<parameter=path>\n/etc/hosts\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    result = feed_char_by_char(fake + real)
+    assert_tool(result, "read_file", {"path": "/etc/hosts"})
+    assert result.content == fake
+
+
+def test_fake_tool_call_whole_chunk():
+    """Same scenario fed as a single chunk instead of char-by-char."""
+    fake = "Thinking: use <tool_call> here.\n"
+    real = (
+        "<tool_call>\n"
+        "<function=read_file>\n"
+        "<parameter=path>\n/etc/hosts\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    result = feed_chunks(fake + real)
+    assert_tool(result, "read_file", {"path": "/etc/hosts"})
+    assert result.content == fake
+
+
+def test_real_tool_call_still_works_with_lookahead():
+    """Normal tool call path still works correctly after adding lookahead."""
+    result = feed_char_by_char(BASIC)
+    assert_tool(result, "get_weather", {"city": "London"})
+    assert not result.content
+
+
+def test_tool_call_pending_stream_boundary():
+    """<tool_call> in chunk 1, <function=…> in chunk 2: confirmed as real."""
+    result = feed_chunks(
+        "<tool_call>\n",
+        "<function=bash>\n<parameter=cmd>\necho hi\n</parameter>\n</function>\n</tool_call>",
+    )
+    assert_tool(result, "bash", {"cmd": "echo hi"})
+    assert not result.content
+
+
+def test_tool_call_pending_rollback_stream_boundary():
+    """<tool_call> in chunk 1, non-function tag in chunk 2: rolled back."""
+    result = feed_chunks(
+        "<tool_call>\n",
+        "</tool_call> and more text",
+    )
+    assert not result.tool_calls
+    assert result.content == "<tool_call>\n</tool_call> and more text"
+
+
+def test_multiple_fake_tool_calls_all_rolled_back():
+    """Three fake <tool_call> mentions with no <function=…>: all become content."""
+    out = (
+        "Step 1: <tool_call>\n"
+        "Step 2: <tool_call>\n"
+        "Step 3: <tool_call>\n"
+        "Done."
+    )
+    result = feed_char_by_char(out)
+    assert not result.tool_calls
+    assert result.content == out
+
+
+def test_tool_call_pending_truncated_stream():
+    """Stream ends while in TOOL_CALL_PENDING: <tool_call> is flushed as content."""
+    result = feed_chunks("<tool_call>\n")
+    assert not result.tool_calls
+    assert result.content == "<tool_call>\n"
+
+
+def test_tool_call_pending_stale_tag_rollback():
+    """A second '<' arrives while reading a tag in TOOL_CALL_PENDING."""
+    # "<tool_call>\n<fun" then "<function=bash>..." - the stale "<fun" is rolled
+    # back together with the whole <tool_call> preamble as plain text content.
+    # Without implicit start, the orphaned <function=bash> in TEXT state is also
+    # treated as plain text — no tool call is produced from a corrupted stream.
+    result = feed_chunks(
+        "<tool_call>\n<fun",
+        "<function=bash>\n<parameter=cmd>\nls\n</parameter>\n</function>\n</tool_call>",
+    )
+    assert not result.tool_calls, (
+        f"Corrupted stream should produce no tool calls, got {result.tool_calls}"
+    )
+
+
+def test_tool_call_with_content_before():
+    """Plain-text content before a real tool call is preserved as content."""
+    preamble = "Sure, let me do that.\n"
+    real = (
+        "<tool_call>\n"
+        "<function=echo>\n"
+        "<parameter=msg>\nhello\n</parameter>\n"
+        "</function>\n</tool_call>"
+    )
+    result = feed_char_by_char(preamble + real)
+    assert_tool(result, "echo", {"msg": "hello"})
+    assert result.content == preamble

--- a/tests/reasoning/test_qwen3_reasoning_parser.py
+++ b/tests/reasoning/test_qwen3_reasoning_parser.py
@@ -373,3 +373,72 @@ def test_reasoning_thinking_disabled(
 
     assert reasoning == expected_reasoning
     assert content == expected_content
+
+
+# ---------------------------------------------------------------------------
+# Tests for <tool_call> lookahead in extract_reasoning (non-streaming)
+# ---------------------------------------------------------------------------
+# A bare <tool_call> without a following <function=…> must NOT end reasoning.
+
+
+FAKE_TOOL_CALL_BODY = "<tool_call>"
+FAKE_TOOL_CALL_NO_FUNCTION = (
+    "I'll use the <tool_call> syntax here. "
+    "Let me think more."
+)
+FAKE_TOOL_CALL_CLOSING = "<tool_call></tool_call> is the format."
+
+
+@pytest.mark.parametrize(
+    "output, expected_reasoning, expected_content",
+    [
+        pytest.param(
+            FAKE_TOOL_CALL_NO_FUNCTION,
+            FAKE_TOOL_CALL_NO_FUNCTION,
+            None,
+            id="fake_tool_call_inline_text",
+        ),
+        pytest.param(
+            FAKE_TOOL_CALL_BODY,
+            FAKE_TOOL_CALL_BODY,
+            None,
+            id="fake_tool_call_tag_only",
+        ),
+        pytest.param(
+            FAKE_TOOL_CALL_CLOSING,
+            FAKE_TOOL_CALL_CLOSING,
+            None,
+            id="fake_tool_call_with_closing_tag",
+        ),
+        # Genuine: <tool_call> followed by <function=…> — should still split.
+        pytest.param(
+            TOOL_CALL_NO_THINK_END["output"],
+            TOOL_CALL_NO_THINK_END["reasoning"],
+            TOOL_CALL_NO_THINK_END["content"],
+            id="genuine_tool_call_still_splits",
+        ),
+        # Genuine with <function name="…"> attribute syntax.
+        pytest.param(
+            'I need the result.\n\n<tool_call>\n<function name="bash">',
+            "I need the result.\n\n",
+            '<tool_call>\n<function name="bash">',
+            id="genuine_tool_call_attr_syntax",
+        ),
+    ],
+)
+def test_reasoning_tool_call_lookahead(
+    output: str,
+    expected_reasoning: str | None,
+    expected_content: str | None,
+    qwen3_tokenizer,
+):
+    """<tool_call> is only an implicit reasoning end when followed by <function=…>."""
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        qwen3_tokenizer
+    )
+    reasoning, content = parser.extract_reasoning(
+        model_output=output,
+        request=ChatCompletionRequest(messages=[], model="test-model"),
+    )
+    assert reasoning == expected_reasoning
+    assert content == expected_content

--- a/tests/test_trace_replay.py
+++ b/tests/test_trace_replay.py
@@ -1,0 +1,759 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Trace-replay test for Qwen3 reasoning and XML tool-call parsers.
+
+Parses a VLLM_RESPONSE_TRACE_LOG file, reconstructs streaming sessions,
+feeds each session chunk-by-chunk through both parsers, and asserts correct
+behaviour.  Also contains targeted synthetic tests for known edge cases.
+
+Usage:
+    .venv/bin/python tests/test_trace_replay.py /tmp/failure.txt
+
+Exit code 0 = all tests passed.  Exit code 1 = at least one failure.
+
+Trace file format (one entry per chunk):
+    [ISO-8601-timestamp] byte_count\n
+    raw_text\n
+    \n
+
+Sessions are identified by gaps larger than SESSION_GAP_SECONDS between
+consecutive chunk timestamps.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Minimal imports from vllm — no GPU required
+# ---------------------------------------------------------------------------
+from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+from vllm.tool_parsers.qwen3xml_tool_parser import StreamingXMLToolCallParser
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SESSION_GAP_SECONDS: float = 2.0
+
+# Special token IDs matching the Qwen3 tokenizer vocabulary.
+_THINK_ID = 151648
+_END_THINK_ID = 151649
+_TOOL_CALL_ID = 151657
+_TOOL_CALL_END_ID = 151658
+# Qwen3 uses <function as a special prefix token (not just regular text).
+# We need it in the vocab so the 8-token lookahead in _tool_call_is_genuine_end
+# can decode "\n<function=bash>" from a compact window of IDs.
+_FUNCTION_PREFIX_ID = 151652
+
+# ---------------------------------------------------------------------------
+# Minimal mock tokenizer for Qwen3 special tokens
+# ---------------------------------------------------------------------------
+
+_SPECIAL_TOKENS: dict[str, int] = {
+    "<think>": _THINK_ID,
+    "</think>": _END_THINK_ID,
+    "<tool_call>": _TOOL_CALL_ID,
+    "</tool_call>": _TOOL_CALL_END_ID,
+    "<function": _FUNCTION_PREFIX_ID,
+}
+_SPECIAL_IDS: dict[int, str] = {v: k for k, v in _SPECIAL_TOKENS.items()}
+# Split on any of the special token strings, longest first to avoid prefix
+# ambiguity (e.g. "<tool_call>" before "<tool_").
+_SPLIT_RE = re.compile(
+    r"(<think>|</think>|<tool_call>|</tool_call>|<function)"
+)
+
+# Offset added to ord(char) to produce a unique, non-colliding token ID.
+_CHAR_ID_OFFSET = 200_000
+
+
+class MockQwen3Tokenizer:
+    """
+    Minimal stand-in for the Qwen3 tokenizer.
+
+    Only purpose: return correct token IDs for the special tokens
+    (<think>, </think>, <tool_call>, </tool_call>) and decode those IDs
+    back to strings.  All other characters are tokenised one-per-character
+    with IDs derived from their code-point to keep decode() invertible.
+    """
+
+    def get_vocab(self) -> dict[str, int]:
+        vocab: dict[str, int] = dict(_SPECIAL_TOKENS)
+        # Add every printable ASCII character so decode() can reconstruct
+        # the look-ahead window in _tool_call_is_genuine_end.
+        for c in (
+            "abcdefghijklmnopqrstuvwxyz"
+            "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+            "0123456789"
+            ' \t\n\r=_-<>/.,;:!?\"\\'
+            "`'@#$%^&*()[]{}|~+"
+        ):
+            vocab[c] = ord(c) + _CHAR_ID_OFFSET
+        return vocab
+
+    def tokenize(self, text: str) -> list[str]:
+        """Split *text* into token strings, keeping special tokens atomic."""
+        tokens: list[str] = []
+        for part in _SPLIT_RE.split(text):
+            if part in _SPECIAL_TOKENS:
+                tokens.append(part)
+            else:
+                tokens.extend(list(part))  # one character per token
+        return [t for t in tokens if t]
+
+    def decode(
+        self,
+        ids: list[int],
+        skip_special_tokens: bool = False,
+    ) -> str:
+        chars: list[str] = []
+        for tid in ids:
+            if tid in _SPECIAL_IDS:
+                if not skip_special_tokens:
+                    chars.append(_SPECIAL_IDS[tid])
+            elif tid > _CHAR_ID_OFFSET:
+                chars.append(chr(tid - _CHAR_ID_OFFSET))
+        return "".join(chars)
+
+    def convert_ids_to_tokens(self, ids: list[int]) -> list[str]:
+        return [
+            _SPECIAL_IDS.get(i, f"<unk_{i}>") for i in ids
+        ]
+
+    def convert_tokens_to_string(self, tokens: list[str]) -> str:
+        return "".join(tokens)
+
+
+# ---------------------------------------------------------------------------
+# Trace-file parser
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TraceChunk:
+    timestamp: datetime
+    text: str
+
+
+def parse_trace(path: Path) -> list[TraceChunk]:
+    """
+    Parse a VLLM_RESPONSE_TRACE_LOG file into a flat list of TraceChunks.
+
+    Each entry in the file looks like::
+
+        [2026-04-27T11:33:55.755Z] 3
+        The
+
+    (timestamp+byte-count on one line, then the raw text, then a blank line)
+    """
+    raw = path.read_text(encoding="utf-8")
+    chunks: list[TraceChunk] = []
+
+    # Pattern: '[' ISO-timestamp ']' SPACE byte-count NEWLINE text NEWLINE NEWLINE
+    # We split on the header lines to group entries.
+    header_re = re.compile(
+        r"^\[(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z)\]\s+\d+\s*$",
+        re.MULTILINE,
+    )
+    lines = raw.splitlines()
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        m = header_re.match(line)
+        if not m:
+            i += 1
+            continue
+        ts = datetime.fromisoformat(m.group(1).replace("Z", "+00:00"))
+        i += 1
+        # Collect lines until the next header (or EOF), stripping the blank
+        # separator lines but preserving internal newlines.
+        text_lines: list[str] = []
+        while i < len(lines) and not header_re.match(lines[i]):
+            text_lines.append(lines[i])
+            i += 1
+        # The file writer adds a trailing '\n' after the text and a blank
+        # separator line; when split by line, this produces one or more
+        # trailing empty strings — trim them.
+        while text_lines and text_lines[-1] == "":
+            text_lines.pop()
+        text = "\n".join(text_lines)
+        if text or True:  # keep even empty chunks
+            chunks.append(TraceChunk(timestamp=ts, text=text))
+    return chunks
+
+
+def split_sessions(
+    chunks: list[TraceChunk],
+    gap: float = SESSION_GAP_SECONDS,
+) -> list[list[TraceChunk]]:
+    """Group chunks into sessions separated by timestamp gaps > *gap* seconds."""
+    if not chunks:
+        return []
+    sessions: list[list[TraceChunk]] = [[chunks[0]]]
+    for chunk in chunks[1:]:
+        prev_ts = sessions[-1][-1].timestamp
+        if (chunk.timestamp - prev_ts).total_seconds() > gap:
+            sessions.append([])
+        sessions[-1].append(chunk)
+    return sessions
+
+
+# ---------------------------------------------------------------------------
+# Streaming replay helpers
+# ---------------------------------------------------------------------------
+
+def _token_ids_for_delta(tokenizer: MockQwen3Tokenizer, delta: str) -> list[int]:
+    """
+    Return the token IDs that would be in ``delta_token_ids`` for *delta*.
+    Only IDs that appear in the parser's vocab are emitted (mirrors the
+    behaviour in tests/reasoning/utils.py).
+    """
+    vocab = tokenizer.get_vocab()
+    return [
+        vocab[tok]
+        for tok in tokenizer.tokenize(delta)
+        if tok in vocab
+    ]
+
+
+def replay_reasoning_streaming(
+    chunks: list[TraceChunk],
+) -> tuple[Optional[str], Optional[str]]:
+    """
+    Replay *chunks* through the Qwen3 reasoning parser in streaming mode.
+
+    Returns (reasoning, content) after consuming all chunks.
+    """
+    from vllm.reasoning.qwen3_reasoning_parser import Qwen3ReasoningParser
+
+    tokenizer = MockQwen3Tokenizer()
+    parser = Qwen3ReasoningParser(tokenizer)
+
+    reasoning_parts: list[str] = []
+    content_parts: list[str] = []
+
+    previous_text = ""
+    previous_token_ids: list[int] = []
+
+    for chunk in chunks:
+        delta_text = chunk.text
+        delta_ids = _token_ids_for_delta(tokenizer, delta_text)
+        current_text = previous_text + delta_text
+        current_ids = previous_token_ids + delta_ids
+
+        delta_msg: Optional[DeltaMessage] = parser.extract_reasoning_streaming(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=delta_text,
+            previous_token_ids=previous_token_ids,
+            current_token_ids=current_ids,
+            delta_token_ids=delta_ids,
+        )
+        if delta_msg is not None:
+            if delta_msg.reasoning:
+                reasoning_parts.append(delta_msg.reasoning)
+            if delta_msg.content:
+                content_parts.append(delta_msg.content)
+
+        previous_text = current_text
+        previous_token_ids = current_ids
+
+    reasoning = "".join(reasoning_parts) or None
+    content = "".join(content_parts) or None
+    return reasoning, content
+
+
+def replay_tool_parser_streaming(
+    chunks: list[TraceChunk],
+) -> DeltaMessage:
+    """
+    Feed *chunks* character-by-character through the XML tool-call parser.
+
+    Returns the merged result after all chunks + finalize().
+    """
+    parser = StreamingXMLToolCallParser()
+    for chunk in chunks:
+        parser.parse_single_streaming_chunks(chunk.text)
+    parser.finalize()
+    return parser.collect_all()
+
+
+# ---------------------------------------------------------------------------
+# Test framework
+# ---------------------------------------------------------------------------
+
+@dataclass
+class TestResult:
+    name: str
+    passed: bool
+    message: str = ""
+
+
+_results: list[TestResult] = []
+
+
+def _pass(name: str) -> TestResult:
+    r = TestResult(name=name, passed=True)
+    _results.append(r)
+    print(f"  PASS  {name}")
+    return r
+
+
+def _fail(name: str, msg: str) -> TestResult:
+    r = TestResult(name=name, passed=False, message=msg)
+    _results.append(r)
+    print(f"  FAIL  {name}")
+    print(f"        {msg}")
+    return r
+
+
+def check(name: str, condition: bool, msg: str = "") -> TestResult:
+    return _pass(name) if condition else _fail(name, msg or "condition was False")
+
+
+# ---------------------------------------------------------------------------
+# XML tool-parser tests (no tokenizer needed)
+# ---------------------------------------------------------------------------
+
+def test_xml_tool_parser_basic_tool_call() -> None:
+    """A well-formed tool call is parsed correctly."""
+    xml = (
+        "<tool_call>\n"
+        "<function=bash>\n"
+        "<parameter=command>\necho hello\n</parameter>\n"
+        "</function>\n"
+        "</tool_call>"
+    )
+    result = replay_tool_parser_streaming(
+        [TraceChunk(timestamp=_now(), text=xml)]
+    )
+    check(
+        "xml/basic_tool_call/produces_tool_call",
+        bool(result.tool_calls),
+        f"Expected tool call, got none. result={result}",
+    )
+    if result.tool_calls:
+        check(
+            "xml/basic_tool_call/function_name",
+            result.tool_calls[0].function.name == "bash",
+            f"Expected 'bash', got {result.tool_calls[0].function.name!r}",
+        )
+        import json
+        args = json.loads(result.tool_calls[0].function.arguments)
+        check(
+            "xml/basic_tool_call/arguments",
+            args == {"command": "echo hello"},
+            f"Unexpected args: {args}",
+        )
+
+
+def test_xml_tool_parser_fake_tool_call_no_function() -> None:
+    """
+    Plain text mentioning <tool_call> without any <function=…> must not
+    produce a tool call.
+    """
+    text = (
+        "I'll explain the <tool_call> format and how it works.\n"
+        "No actual function is being called here."
+    )
+    result = replay_tool_parser_streaming(
+        [TraceChunk(timestamp=_now(), text=text)]
+    )
+    check(
+        "xml/no_function_after_tool_call/no_tool_calls",
+        not result.tool_calls,
+        f"Expected no tool calls, got {result.tool_calls}",
+    )
+    check(
+        "xml/no_function_after_tool_call/content_preserved",
+        result.content is not None and "explain" in result.content,
+        f"Content not preserved: {result.content!r}",
+    )
+
+
+def test_xml_tool_parser_function_placeholder_false_positive() -> None:
+    """
+    <tool_call> followed by literal '<function=...>' (a documentation
+    placeholder) must NOT produce a tool call.
+
+    This is the pattern observed in the failure trace around 11:39:14:
+      via `"<tool_call>"` tag followed by `<function=...>`. Uses a lookahead…
+    """
+    texts = [
+        # Exact trace pattern 1: "followed by `<function=...>`"
+        'via `"<tool_call>"` tag followed by `<function=...>`. Uses a lookahead.',
+        # Exact trace pattern 2: tool_call + function=... on separate lines
+        '. Implicit end via `"<tool_call>"` + `<function=...>`: split at that point',
+        # Exact trace pattern 3: TOOL_CALL_PENDING description
+        '`TOOL_CALL_PENDING` — saw `"<tool_call>"`, waiting for `<function=...>` lookahead',
+    ]
+    for i, text in enumerate(texts):
+        parser = StreamingXMLToolCallParser()
+        parser.parse_single_streaming_chunks(text)
+        parser.finalize()
+        result = parser.collect_all()
+        check(
+            f"xml/function_placeholder_false_positive/{i}",
+            not result.tool_calls,
+            f"False positive: got tool_calls={result.tool_calls!r} "
+            f"from markdown text {text[:60]!r}…",
+        )
+
+
+def test_xml_tool_parser_streaming_chunked() -> None:
+    """
+    A tool call split across many small chunks (simulating real streaming)
+    must be assembled correctly.
+    """
+    full = (
+        "<tool_call>\n"
+        "<function=read>\n"
+        "<parameter=path>\n/etc/hosts\n</parameter>\n"
+        "</function>\n"
+        "</tool_call>"
+    )
+    # Feed one character at a time
+    parser = StreamingXMLToolCallParser()
+    for ch in full:
+        parser.parse_single_streaming_chunks(ch)
+    parser.finalize()
+    result = parser.collect_all()
+    check(
+        "xml/streaming_chunked/produces_tool_call",
+        bool(result.tool_calls),
+        f"Expected tool call from char-by-char feed, got none",
+    )
+    if result.tool_calls:
+        import json
+        args = json.loads(result.tool_calls[0].function.arguments)
+        check(
+            "xml/streaming_chunked/arguments",
+            args == {"path": "/etc/hosts"},
+            f"Unexpected args: {args}",
+        )
+
+
+def test_xml_tool_parser_trace_session(session_chunks: list[TraceChunk]) -> None:
+    """
+    Feed the content portion of the trace session to the XML tool parser.
+
+    The session contains markdown prose that mentions <tool_call> and
+    <function=...> as documentation examples.  No real tool call should
+    be produced.
+    """
+    full_text = "".join(c.text for c in session_chunks)
+
+    # Split at </think> — content portion is what goes to the tool parser.
+    if "</think>" in full_text:
+        content_text = full_text.split("</think>", 1)[1]
+    else:
+        content_text = full_text
+
+    parser = StreamingXMLToolCallParser()
+    # Feed in the same chunk boundaries as the real trace.
+    offset = 0
+    end_of_reasoning = False
+    for chunk in session_chunks:
+        if not end_of_reasoning:
+            if "</think>" in chunk.text:
+                end_of_reasoning = True
+                # Feed only the part after </think>
+                post = chunk.text.split("</think>", 1)[1]
+                if post:
+                    parser.parse_single_streaming_chunks(post)
+        else:
+            parser.parse_single_streaming_chunks(chunk.text)
+
+    parser.finalize()
+    result = parser.collect_all()
+
+    # Any tool call with a function name of "..." (three dots) is a false positive.
+    false_positives = [
+        tc for tc in (result.tool_calls or [])
+        if tc.function and tc.function.name in ("...", "…", ".")
+    ]
+    check(
+        "xml/trace_session/no_placeholder_tool_calls",
+        not false_positives,
+        f"False-positive tool calls from markdown text: {false_positives}",
+    )
+
+    # The session should not contain any real tool calls (it's pure content).
+    real_tool_calls = [
+        tc for tc in (result.tool_calls or [])
+        if tc.function and tc.function.name not in ("...", "…", ".")
+    ]
+    check(
+        "xml/trace_session/no_spurious_real_tool_calls",
+        not real_tool_calls,
+        f"Unexpected tool calls: {real_tool_calls}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Reasoning-parser tests (requires mock tokenizer)
+# ---------------------------------------------------------------------------
+
+def test_reasoning_think_end() -> None:
+    """</think> correctly ends reasoning."""
+    chunks = _text_to_chunks(
+        "I need to think about this.\n</think>\nHere is my answer."
+    )
+    reasoning, content = replay_reasoning_streaming(chunks)
+    check(
+        "reasoning/think_end/reasoning_correct",
+        reasoning is not None and "think about" in reasoning,
+        f"reasoning={reasoning!r}",
+    )
+    check(
+        "reasoning/think_end/content_correct",
+        content is not None and "answer" in content,
+        f"content={content!r}",
+    )
+
+
+def test_reasoning_tool_call_genuine_end() -> None:
+    """
+    A genuine tool call (<tool_call> immediately followed by <function=…>)
+    ends reasoning; content starts at <tool_call>.
+
+    Feed <tool_call> and <function=bash> together in one chunk — in real
+    vLLM the model typically emits both in close succession (often the same
+    decode step), so this is the realistic path for the lookahead to fire.
+    """
+    # One chunk containing both <tool_call> and the start of <function=bash>
+    # ensures that when the <tool_call> token arrives in delta_ids, the
+    # 8-token lookahead window already includes <function.
+    chunks = [
+        TraceChunk(timestamp=_now(), text="Let me run a command.\n\n"),
+        TraceChunk(
+            timestamp=_now(),
+            text="<tool_call>\n<function=bash>\n<parameter=command>\nls\n</parameter>\n</function>\n</tool_call>",
+        ),
+    ]
+    reasoning, content = replay_reasoning_streaming(chunks)
+    check(
+        "reasoning/genuine_tool_call/reasoning_not_none",
+        reasoning is not None,
+        f"reasoning={reasoning!r}",
+    )
+    check(
+        "reasoning/genuine_tool_call/content_starts_with_tool_call",
+        content is not None and "<tool_call>" in content,
+        f"content={content!r}",
+    )
+
+
+def test_reasoning_fake_tool_call_in_reasoning() -> None:
+    """
+    <tool_call> token appearing inside reasoning text — NOT followed by
+    <function=…> — must NOT terminate reasoning prematurely.
+
+    This tests the lookahead in extract_reasoning_streaming.
+    The model is writing explanation text that happens to contain the
+    <tool_call> special token but it's not a real tool call.
+    """
+    # Deliver in two chunks so <tool_call> token arrives alone in delta_ids,
+    # followed by ordinary text (no <function=…>).
+    chunks = [
+        TraceChunk(timestamp=_now(), text="I'll describe the "),
+        TraceChunk(timestamp=_now(), text="<tool_call>"),  # special token, no function follows
+        TraceChunk(timestamp=_now(), text=" syntax used by the model.\n"),
+        TraceChunk(timestamp=_now(), text="More reasoning here.\n"),
+    ]
+    reasoning, content = replay_reasoning_streaming(chunks)
+    check(
+        "reasoning/fake_tool_call/stays_as_reasoning",
+        reasoning is not None and "<tool_call>" in reasoning,
+        f"Expected '<tool_call>' in reasoning, got reasoning={reasoning!r}, content={content!r}",
+    )
+    check(
+        "reasoning/fake_tool_call/no_premature_content",
+        content is None,
+        f"Reasoning terminated prematurely: content={content!r}",
+    )
+
+
+def test_reasoning_fake_tool_call_followed_by_non_function() -> None:
+    """
+    <tool_call> followed by text (not <function=…>) in reasoning must stay as reasoning.
+    """
+    # Simulate: `"<tool_call>"` tag followed by `<function=...>` — the full
+    # string from the trace, delivered in realistic chunk sizes.
+    chunks = [
+        TraceChunk(timestamp=_now(), text="Handling: "),
+        TraceChunk(timestamp=_now(), text='via `"'),
+        TraceChunk(timestamp=_now(), text="<tool_call>"),  # special token
+        TraceChunk(timestamp=_now(), text='"`'),
+        TraceChunk(timestamp=_now(), text=" tag followed by `<function=...>`.\n"),
+    ]
+    reasoning, content = replay_reasoning_streaming(chunks)
+    check(
+        "reasoning/fake_tool_call_with_ellipsis/stays_as_reasoning",
+        content is None,
+        f"Reasoning terminated at fake '<tool_call>'; content={content!r}",
+    )
+
+
+def test_reasoning_trace_session(session_chunks: list[TraceChunk]) -> None:
+    """
+    Streaming replay of the trace session through the reasoning parser.
+
+    Verifies:
+    - Reasoning ends at </think>
+    - Everything after </think> is classified as content (not reasoning)
+    """
+    reasoning, content = replay_reasoning_streaming(session_chunks)
+    full_text = "".join(c.text for c in session_chunks)
+
+    if "</think>" in full_text:
+        expected_reasoning = full_text.split("</think>", 1)[0]
+        check(
+            "reasoning/trace_session/reasoning_ends_at_think",
+            reasoning is not None,
+            "Reasoning should not be None for a session that has </think>",
+        )
+        check(
+            "reasoning/trace_session/content_starts_after_think",
+            content is not None,
+            "Content should not be None after </think> was seen",
+        )
+        # Reasoning must not contain text that appears after </think>
+        if reasoning and content:
+            check(
+                "reasoning/trace_session/no_post_think_text_in_reasoning",
+                "comprehensive picture" not in reasoning,
+                "Post-</think> text leaked into reasoning",
+            )
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _text_to_chunks(text: str, chunk_size: int = 1) -> list[TraceChunk]:
+    """
+    Split *text* into TraceChunks of at most *chunk_size* characters each,
+    keeping every special token (</think>, <tool_call>, <function, …) as an
+    indivisible chunk so their IDs always appear atomically in delta_token_ids.
+    """
+    ts = _now()
+    result: list[TraceChunk] = []
+    for part in _SPLIT_RE.split(text):
+        if part in _SPECIAL_TOKENS:
+            result.append(TraceChunk(timestamp=ts, text=part))
+        else:
+            for i in range(0, len(part), chunk_size):
+                sub = part[i : i + chunk_size]
+                if sub:
+                    result.append(TraceChunk(timestamp=ts, text=sub))
+    return result
+
+
+def _find_session_containing(
+    sessions: list[list[TraceChunk]],
+    substring: str,
+) -> Optional[list[TraceChunk]]:
+    """Return the first session whose concatenated text contains *substring*."""
+    for session in sessions:
+        text = "".join(c.text for c in session)
+        if substring in text:
+            return session
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(f"Usage: {argv[0]} <trace_file>", file=sys.stderr)
+        return 2
+
+    trace_path = Path(argv[1])
+    if not trace_path.exists():
+        print(f"Trace file not found: {trace_path}", file=sys.stderr)
+        return 2
+
+    print(f"Parsing trace file: {trace_path}")
+    chunks = parse_trace(trace_path)
+    print(f"  {len(chunks)} chunks parsed")
+
+    sessions = split_sessions(chunks, gap=SESSION_GAP_SECONDS)
+    print(f"  {len(sessions)} sessions identified (gap={SESSION_GAP_SECONDS}s)")
+
+    # --- Find the failing session (around 11:39:14) ---
+    failing_session = _find_session_containing(
+        sessions,
+        # Unique string from the failing session text
+        "TOOL_CALL_PENDING",
+    )
+    if failing_session:
+        session_text = "".join(c.text for c in failing_session)
+        print(
+            f"  Failing session found: {len(failing_session)} chunks, "
+            f"{len(session_text)} chars"
+        )
+        ts_start = failing_session[0].timestamp.strftime("%H:%M:%S")
+        ts_end = failing_session[-1].timestamp.strftime("%H:%M:%S")
+        print(f"  Session time range: {ts_start} – {ts_end}")
+    else:
+        print("  WARNING: Could not find expected failing session in trace")
+
+    print()
+    print("=" * 60)
+    print("XML TOOL-PARSER TESTS")
+    print("=" * 60)
+    test_xml_tool_parser_basic_tool_call()
+    test_xml_tool_parser_fake_tool_call_no_function()
+    test_xml_tool_parser_function_placeholder_false_positive()
+    test_xml_tool_parser_streaming_chunked()
+    if failing_session:
+        test_xml_tool_parser_trace_session(failing_session)
+    else:
+        print("  SKIP  xml/trace_session (failing session not found)")
+
+    print()
+    print("=" * 60)
+    print("REASONING-PARSER TESTS (streaming)")
+    print("=" * 60)
+    test_reasoning_think_end()
+    test_reasoning_tool_call_genuine_end()
+    test_reasoning_fake_tool_call_in_reasoning()
+    test_reasoning_fake_tool_call_followed_by_non_function()
+    if failing_session:
+        test_reasoning_trace_session(failing_session)
+    else:
+        print("  SKIP  reasoning/trace_session (failing session not found)")
+
+    print()
+    print("=" * 60)
+    passed = sum(1 for r in _results if r.passed)
+    failed = sum(1 for r in _results if not r.passed)
+    print(f"RESULTS: {passed} passed, {failed} failed out of {len(_results)} tests")
+    print("=" * 60)
+
+    if failed:
+        print()
+        print("FAILURES:")
+        for r in _results:
+            if not r.passed:
+                print(f"  {r.name}: {r.message}")
+
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/tool_parsers/test_qwen3xml_tool_parser.py
+++ b/tests/tool_parsers/test_qwen3xml_tool_parser.py
@@ -2,12 +2,354 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import json
+
 import pytest
 
 from tests.tool_parsers.common_tests import (
     ToolParserTestConfig,
     ToolParserTests,
 )
+from vllm.tool_parsers.qwen3xml_tool_parser import StreamingXMLToolCallParser
+
+
+def _parse_full(xml: str) -> dict:
+    """Feed *xml* all at once through StreamingXMLToolCallParser and return
+    the collected tool-call arguments as a dict (first tool call only)."""
+    p = StreamingXMLToolCallParser()
+    p.parse_single_streaming_chunks(xml)
+    p.finalize()
+    result = p.collect_all()
+    assert result.tool_calls, f"No tool calls parsed from:\n{xml}"
+    args_str = result.tool_calls[0].function.arguments
+    return json.loads(args_str)
+
+
+def _parse_char_by_char(xml: str) -> dict:
+    """Same as _parse_full but feeds one character at a time (simulates
+    streaming with the smallest possible chunk size)."""
+    p = StreamingXMLToolCallParser()
+    for ch in xml:
+        p.parse_single_streaming_chunks(ch)
+    p.finalize()
+    result = p.collect_all()
+    assert result.tool_calls, f"No tool calls parsed from:\n{xml}"
+    args_str = result.tool_calls[0].function.arguments
+    return json.loads(args_str)
+
+
+class TestParamCloseLookahead:
+    """Unit tests for the </parameter> lookahead edge case."""
+
+    # ------------------------------------------------------------------
+    # Basic lookahead: </parameter> followed by non-structural tag is content
+    # ------------------------------------------------------------------
+
+    def test_closing_tag_in_content_followed_by_html(self):
+        """</parameter> followed by </div> → content, not a delimiter."""
+        xml = (
+            "<tool_call>\n"
+            "<function=write_file>\n"
+            "<parameter=content>\n"
+            "some text </parameter>\n"
+            "</div>\n"
+            "more text\n"
+            "</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        args = _parse_full(xml)
+        assert args["content"] == "some text </parameter>\n</div>\nmore text"
+
+    def test_closing_tag_in_content_streaming(self):
+        """Same case fed character-by-character produces identical result."""
+        xml = (
+            "<tool_call>\n"
+            "<function=write_file>\n"
+            "<parameter=content>\n"
+            "some text </parameter>\n"
+            "</div>\n"
+            "more text\n"
+            "</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        assert _parse_char_by_char(xml) == _parse_full(xml)
+
+    # ------------------------------------------------------------------
+    # Normal case unaffected
+    # ------------------------------------------------------------------
+
+    def test_normal_two_param_call(self):
+        """Standard two-parameter call is not affected by the new logic."""
+        xml = (
+            "<tool_call>\n"
+            "<function=write_file>\n"
+            "<parameter=path>\n"
+            "/tmp/hello.py\n"
+            "</parameter>\n"
+            "<parameter=content>\n"
+            "print('hello')\n"
+            "</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        args = _parse_full(xml)
+        assert args["path"] == "/tmp/hello.py"
+        assert args["content"] == "print('hello')"
+
+    def test_normal_two_param_call_streaming(self):
+        xml = (
+            "<tool_call>\n"
+            "<function=write_file>\n"
+            "<parameter=path>\n"
+            "/tmp/hello.py\n"
+            "</parameter>\n"
+            "<parameter=content>\n"
+            "print('hello')\n"
+            "</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        assert _parse_char_by_char(xml) == _parse_full(xml)
+
+    # ------------------------------------------------------------------
+    # Multiple </parameter> in content; only the last is a real delimiter
+    # ------------------------------------------------------------------
+
+    def test_double_fake_closing_tag(self):
+        """Two </parameter> tags in content before the real delimiter."""
+        xml = (
+            "<tool_call>\n"
+            "<function=write_file>\n"
+            "<parameter=content>\n"
+            "first </parameter>\n"
+            "</span>\n"
+            "second </parameter>\n"
+            "</em>\n"
+            "end\n"
+            "</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        args = _parse_full(xml)
+        assert args["content"] == (
+            "first </parameter>\n</span>\nsecond </parameter>\n</em>\nend"
+        )
+
+    def test_double_fake_closing_tag_streaming(self):
+        xml = (
+            "<tool_call>\n"
+            "<function=write_file>\n"
+            "<parameter=content>\n"
+            "first </parameter>\n"
+            "</span>\n"
+            "second </parameter>\n"
+            "</em>\n"
+            "end\n"
+            "</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        assert _parse_char_by_char(xml) == _parse_full(xml)
+
+    # ------------------------------------------------------------------
+    # </parameter> directly before </function> (no next param)
+    # ------------------------------------------------------------------
+
+    def test_param_end_before_function_end(self):
+        """</parameter> followed by </function> is a genuine delimiter."""
+        xml = (
+            "<tool_call>\n"
+            "<function=ping>\n"
+            "<parameter=host>\n"
+            "example.com\n"
+            "</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        args = _parse_full(xml)
+        assert args["host"] == "example.com"
+
+    # ------------------------------------------------------------------
+    # Stream ends while in PARAM_CLOSE_PENDING (truncated output)
+    # ------------------------------------------------------------------
+
+    def test_truncated_after_param_close(self):
+        """Stream cut off after </parameter> — finalize treats it as genuine."""
+        xml = (
+            "<tool_call>\n"
+            "<function=ping>\n"
+            "<parameter=host>\n"
+            "example.com\n"
+            "</parameter>"
+            # No </function> or </tool_call>
+        )
+        p = StreamingXMLToolCallParser()
+        p.parse_single_streaming_chunks(xml)
+        p.finalize()
+        result = p.collect_all()
+        assert result.tool_calls
+        args = json.loads(result.tool_calls[0].function.arguments)
+        assert args["host"] == "example.com"
+
+    # ------------------------------------------------------------------
+    # Content contains the format's own meta-tags (worst-case ambiguity)
+    # ------------------------------------------------------------------
+
+    def test_param_value_contains_closing_param_then_next_param(self):
+        """
+        Ambiguous case: content ends with ``</parameter>\\n<parameter=next>``.
+        The parser must treat the </parameter> as the real delimiter here
+        (the format is genuinely ambiguous; we side with the structural read).
+        """
+        xml = (
+            "<tool_call>\n"
+            "<function=write_file>\n"
+            "<parameter=path>\n"
+            "/tmp/f\n"
+            "</parameter>\n"
+            "<parameter=content>\n"
+            "hello\n"
+            "</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        args = _parse_full(xml)
+        assert args["path"] == "/tmp/f"
+        assert args["content"] == "hello"
+
+
+class TestEarlyTagRejection:
+    """
+    Tests that non-structural tag prefixes are rejected immediately rather than
+    buffered until ">".  The observable effect is that the characters are
+    treated as literal content rather than silently eaten into the tag buffer.
+    """
+
+    def test_html_comment_in_param_value(self):
+        """<!-- ... --> inside a parameter value passes through as-is."""
+        xml = (
+            "<tool_call>\n"
+            "<function=write_file>\n"
+            "<parameter=content>\n"
+            "<!-- a comment -->\n"
+            "actual content\n"
+            "</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        assert _parse_full(xml)["content"] == "<!-- a comment -->\nactual content"
+
+    def test_html_comment_in_param_value_streaming(self):
+        xml = (
+            "<tool_call>\n"
+            "<function=write_file>\n"
+            "<parameter=content>\n"
+            "<!-- a comment -->\n"
+            "actual content\n"
+            "</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        assert _parse_char_by_char(xml) == _parse_full(xml)
+
+    def test_bang_sequence_in_param_value(self):
+        """<! prefix is rejected immediately (DOCTYPE / comment)."""
+        xml = (
+            "<tool_call>\n"
+            "<function=write_file>\n"
+            "<parameter=content>\n"
+            "<!DOCTYPE html>\n"
+            "</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        assert _parse_full(xml)["content"] == "<!DOCTYPE html>"
+
+    def test_space_after_lt_in_param_value(self):
+        """< followed by space cannot start a structural tag; passes through."""
+        xml = (
+            "<tool_call>\n"
+            "<function=write_file>\n"
+            "<parameter=content>\n"
+            "a < b\n"
+            "</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        assert _parse_full(xml)["content"] == "a < b"
+
+    def test_html_tags_in_param_value(self):
+        """Generic HTML tags like <br> and <div class="x"> pass through."""
+        xml = (
+            "<tool_call>\n"
+            "<function=render>\n"
+            "<parameter=html>\n"
+            "<br>\n"
+            "<div class=\"hello\">world</div>\n"
+            "</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        assert _parse_full(xml)["html"] == '<br>\n<div class="hello">world</div>'
+
+    def test_html_tags_in_param_value_streaming(self):
+        xml = (
+            "<tool_call>\n"
+            "<function=render>\n"
+            "<parameter=html>\n"
+            "<br>\n"
+            "<div class=\"hello\">world</div>\n"
+            "</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        assert _parse_char_by_char(xml) == _parse_full(xml)
+
+    def test_dash_sequence_in_param_value(self):
+        """<-- (Markdown/diff leader) is not a structural tag."""
+        xml = (
+            "<tool_call>\n"
+            "<function=diff>\n"
+            "<parameter=patch>\n"
+            "<-- removed line\n"
+            "</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        assert _parse_full(xml)["patch"] == "<-- removed line"
+
+    def test_non_structural_tag_in_plain_text(self):
+        """Non-structural tags in TEXT state before any tool call are emitted."""
+        p = StreamingXMLToolCallParser()
+        delta = p.parse_single_streaming_chunks("Hello <br> world")
+        p.finalize()
+        full = p.collect_all()
+        assert full.content == "Hello <br> world"
+        assert not full.tool_calls
+
+    def test_non_structural_tag_in_plain_text_streaming(self):
+        p = StreamingXMLToolCallParser()
+        for ch in "Hello <br> world":
+            p.parse_single_streaming_chunks(ch)
+        p.finalize()
+        full = p.collect_all()
+        assert full.content == "Hello <br> world"
+        assert not full.tool_calls
+
+    def test_unclosed_lt_at_end_of_param(self):
+        """Trailing '<' at stream end is flushed as literal content."""
+        xml = (
+            "<tool_call>\n"
+            "<function=search>\n"
+            "<parameter=query>\n"
+            "foo <\n"
+            "</parameter>\n"
+            "</function>\n"
+            "</tool_call>"
+        )
+        assert _parse_full(xml)["query"] == "foo <"
 
 
 class TestQwen3xmlToolParser(ToolParserTests):
@@ -54,19 +396,5 @@ class TestQwen3xmlToolParser(ToolParserTests):
             single_tool_call_expected_args={"city": "Tokyo"},
             parallel_tool_calls_count=2,
             parallel_tool_calls_names=["get_weather", "get_time"],
-            # xfail markers - Qwen3XML has systematic streaming issues
-            xfail_streaming={
-                "test_single_tool_call_simple_args": (
-                    "Qwen3XML streaming has systematic issues"
-                ),
-                "test_parallel_tool_calls": "Qwen3XML streaming has systematic issues",
-                "test_various_data_types": "Qwen3XML streaming has systematic issues",
-                "test_empty_arguments": "Qwen3XML streaming has systematic issues",
-                "test_surrounding_text": "Qwen3XML streaming has systematic issues",
-                "test_escaped_strings": "Qwen3XML streaming has systematic issues",
-                "test_streaming_reconstruction": (
-                    "Qwen3XML streaming reconstruction has known issues"
-                ),
-            },
             supports_typed_arguments=False,
         )

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -674,8 +674,21 @@ class DelegatingParser(Parser):
                 current_token_ids=current_token_ids,
                 delta_token_ids=delta_token_ids,
             )
-            # Hand off remaining content to tool parser
-            if self._tool_parser and self.is_reasoning_end(delta_token_ids):
+            # Hand off remaining content to tool parser.
+            # `is_reasoning_end` checks whether an end/tool-call token appears
+            # in the current delta's token IDs.  When the reasoning parser uses
+            # a _tool_call_pending buffer (Qwen3 style), the <tool_call> token
+            # may be in a *previous* delta and the lookahead only confirms it
+            # once <function=…> arrives in the current delta — meaning the
+            # current delta's token IDs will NOT contain <tool_call>.
+            # In that case `is_reasoning_end` returns False even though the
+            # reasoning parser has already signalled the end of reasoning by
+            # returning content.  Guard against this by also triggering the
+            # handoff when the reasoning parser emits a content field.
+            reasoning_just_ended = self.is_reasoning_end(delta_token_ids) or (
+                delta_message is not None and delta_message.content is not None
+            )
+            if self._tool_parser and reasoning_just_ended:
                 state.reasoning_ended = True
                 current_token_ids = self.extract_content_ids(delta_token_ids)
                 if delta_message and delta_message.content:

--- a/vllm/reasoning/qwen3_reasoning_parser.py
+++ b/vllm/reasoning/qwen3_reasoning_parser.py
@@ -237,6 +237,13 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
         prompt_is_reasoning_end and routes deltas as content without
         calling this method.
         """
+        # Reset per-request state at the very first delta of a new generation
+        # (previous_token_ids is empty).  Guards against _tool_call_pending
+        # leaking from a previous request that ended while the buffer was set
+        # (e.g. the stream was cut immediately after <tool_call>).
+        if not previous_token_ids:
+            self._tool_call_pending = None
+
         # Strip <think> from delta if present (old template / edge case
         # where the model generates <think> itself).
         if self.start_token_id in delta_token_ids:

--- a/vllm/reasoning/qwen3_reasoning_parser.py
+++ b/vllm/reasoning/qwen3_reasoning_parser.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import re
 from collections.abc import Iterable, Sequence
 from typing import TYPE_CHECKING
 
@@ -60,6 +61,41 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
         """The token that ends reasoning content."""
         return "</think>"
 
+    # Regex for detecting <function=…> or <function name="…"> in text.
+    _RE_FUNCTION_OPEN = re.compile(r"<function[\s=]")
+
+    # Number of tokens to decode after <tool_call> when checking whether a
+    # genuine <function=…> tag follows.  The gap is always "\n<function=" in
+    # the Qwen3 format, which is typically 3 tokens:
+    #   \n          → 1 token
+    #   <function   → 1 token (special token in the Qwen3 vocabulary)
+    #   =           → 1 token
+    # We use 8 to stay correct even when the tokenizer does not have
+    # <function> as a single special token and encodes it character-by-character
+    # (worst case: '<', 'f', 'u', 'n', 'c', 't', 'i', 'o', 'n', '=' = 10 chars,
+    # but most sub-word tokenizers merge runs like this into 3-5 tokens).
+    _FUNCTION_LOOKAHEAD_TOKENS: int = 8
+
+    def _tool_call_is_genuine_end(
+        self, input_ids: Sequence[int], tool_call_pos: int
+    ) -> bool:
+        """Return True iff <function=…> follows <tool_call> at tool_call_pos.
+
+        Decodes a small window of tokens after the <tool_call> position and
+        checks for a function-open tag (with optional leading whitespace).
+        Returns False when no tokens follow or decoding fails.
+        """
+        after = list(
+            input_ids[tool_call_pos + 1 : tool_call_pos + 1 + self._FUNCTION_LOOKAHEAD_TOKENS]
+        )
+        if not after:
+            return False
+        try:
+            text = self.model_tokenizer.decode(after, skip_special_tokens=False)
+            return bool(self._RE_FUNCTION_OPEN.match(text.lstrip()))
+        except Exception:
+            return False
+
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
         start_token_id = self.start_token_id
         end_token_id = self.end_token_id
@@ -74,13 +110,16 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
             if token_id == end_token_id:
                 return True
             if tool_call_token_id is not None and token_id == tool_call_token_id:
-                # Only treat as implicit reasoning end if this <tool_call>
-                # is NOT followed by </tool_call>.  Paired occurrences are
-                # template examples in the prompt, not model output.
+                # Skip paired occurrences (prompt few-shot examples).
                 if tool_call_end_token_id is not None and any(
                     input_ids[j] == tool_call_end_token_id
                     for j in range(i + 1, len(input_ids))
                 ):
+                    continue
+                # Lookahead: only treat as implicit end if <function=…> follows.
+                # Reasoning text often mentions <tool_call> without following
+                # it with a function tag; wait for confirmation.
+                if not self._tool_call_is_genuine_end(input_ids, i):
                     continue
                 return True
         return False
@@ -88,10 +127,19 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
     def is_reasoning_end_streaming(
         self, input_ids: Sequence[int], delta_ids: Iterable[int]
     ) -> bool:
-        if super().is_reasoning_end_streaming(input_ids, delta_ids):
+        # Materialise once to avoid double-consuming a one-pass iterable.
+        delta_set = set(delta_ids)
+        if self.end_token_id in delta_set:
             return True
-        if self._tool_call_token_id is not None:
-            return self._tool_call_token_id in delta_ids
+        if self._tool_call_token_id is not None and self._tool_call_token_id in delta_set:
+            # Require <function=…> to follow in the accumulated sequence.
+            tc_id = self._tool_call_token_id
+            ids = list(input_ids)
+            try:
+                pos = len(ids) - 1 - ids[::-1].index(tc_id)
+                return self._tool_call_is_genuine_end(ids, pos)
+            except ValueError:
+                pass
         return False
 
     def extract_content_ids(self, input_ids: list[int]) -> list[int]:
@@ -148,11 +196,16 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
             return None, model_output
 
         # No </think> — check for implicit reasoning end via <tool_call>.
+        # The <tool_call> is only a genuine implicit end when followed
+        # (modulo whitespace) by <function=…>.  Bare <tool_call> mentions in
+        # reasoning text must not prematurely terminate reasoning.
         tool_call_index = model_output.find(self._tool_call_tag)
         if tool_call_index != -1:
-            reasoning = model_output[:tool_call_index]
-            content = model_output[tool_call_index:]
-            return reasoning or None, content or None
+            after_tc = model_output[tool_call_index + len(self._tool_call_tag):]
+            if self._RE_FUNCTION_OPEN.match(after_tc.lstrip()):
+                reasoning = model_output[:tool_call_index]
+                content = model_output[tool_call_index:]
+                return reasoning or None, content or None
         # Thinking enabled but no </think>: output was truncated.
         # Everything generated so far is reasoning.
         return model_output, None
@@ -201,18 +254,38 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
             return None
 
         # Implicit reasoning end via <tool_call>.
-        if (
-            self._tool_call_token_id is not None
-            and self._tool_call_token_id in delta_token_ids
-        ):
-            tool_index = delta_text.find(self._tool_call_tag)
-            if tool_index >= 0:
-                reasoning = delta_text[:tool_index]
-                content = delta_text[tool_index:]
-                return DeltaMessage(
-                    reasoning=reasoning if reasoning else None,
-                    content=content if content else None,
-                )
+        # Apply the same <function=…> lookahead used by is_reasoning_end so
+        # that a bare <tool_call> token in reasoning text (e.g. a code
+        # example) does not prematurely terminate reasoning.
+        # We use current_token_ids (which already includes the delta) so the
+        # check works whether <function=…> arrives in the same delta or the
+        # next one.
+        if self._tool_call_token_id is not None:
+            tc_id = self._tool_call_token_id
+            tc_in_delta = tc_id in delta_token_ids
+            tc_in_prev = tc_id in previous_token_ids
+            if tc_in_delta or tc_in_prev:
+                ids = list(current_token_ids)
+                try:
+                    pos = len(ids) - 1 - ids[::-1].index(tc_id)
+                    if self._tool_call_is_genuine_end(ids, pos):
+                        if tc_in_delta:
+                            tool_index = delta_text.find(self._tool_call_tag)
+                            if tool_index >= 0:
+                                reasoning = delta_text[:tool_index]
+                                content = delta_text[tool_index:]
+                                return DeltaMessage(
+                                    reasoning=reasoning if reasoning else None,
+                                    content=content if content else None,
+                                )
+                        else:
+                            # <tool_call> was in previous delta; current delta
+                            # is all content.
+                            return DeltaMessage(content=delta_text)
+                except ValueError:
+                    pass
+                # Lookahead returned False or <function=…> not yet arrived:
+                # treat as reasoning — fall through.
 
         # No end token in this delta.
         if not delta_text:
@@ -220,11 +293,6 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
             return None
         elif self.end_token_id in previous_token_ids:
             # End token already passed: everything is content now.
-            return DeltaMessage(content=delta_text)
-        elif (
-            self._tool_call_token_id is not None
-            and self._tool_call_token_id in previous_token_ids
-        ):
             return DeltaMessage(content=delta_text)
         else:
             # No end token yet: still in reasoning phase.

--- a/vllm/reasoning/qwen3_reasoning_parser.py
+++ b/vllm/reasoning/qwen3_reasoning_parser.py
@@ -345,16 +345,20 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
                     pass
 
                 # Lookahead returned False or <function=…> not yet arrived.
-                if tc_in_delta:
+                if tc_in_delta and self.end_token_id not in previous_token_ids:
                     # Buffer <tool_call> (and any text that follows it in this
                     # delta) rather than emitting it as reasoning.  This lets
                     # the *next* delta's lookahead confirm or deny the call.
+                    # Only buffer while still in reasoning mode: once </think>
+                    # has passed the existing content-mode fallthrough below
+                    # handles the chunk correctly without buffering.
                     tool_index = delta_text.find(self._tool_call_tag)
                     if tool_index >= 0:
                         pre = delta_text[:tool_index]
                         self._tool_call_pending = delta_text[tool_index:]
                         return DeltaMessage(reasoning=pre) if pre else None
-                # tc_in_prev=True but lookahead failed: still in reasoning.
+                # tc_in_prev=True but lookahead failed, or in content mode:
+                # fall through to content-mode emit below.
 
         # No end token in this delta.
         if not delta_text:

--- a/vllm/reasoning/qwen3_reasoning_parser.py
+++ b/vllm/reasoning/qwen3_reasoning_parser.py
@@ -51,6 +51,12 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
         self._tool_call_end_tag = "</tool_call>"
         self._tool_call_end_token_id = self.vocab.get(self._tool_call_end_tag)
 
+        # Buffer used by extract_reasoning_streaming to hold back a tentative
+        # <tool_call> until <function=…> lookahead can confirm it is genuine.
+        # None when not buffering; a str (starting with "<tool_call>") when
+        # we are waiting for the next delta to confirm.
+        self._tool_call_pending: str | None = None
+
     @property
     def start_token(self) -> str:
         """The token that starts reasoning content."""
@@ -260,10 +266,63 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
         # We use current_token_ids (which already includes the delta) so the
         # check works whether <function=…> arrives in the same delta or the
         # next one.
+        #
+        # The challenge: <tool_call> often lands at the very end of a streaming
+        # chunk, with <function=…> arriving only in the *next* chunk.  A
+        # lookahead at that moment finds no tokens after <tool_call> and returns
+        # False, causing the tag to be emitted as reasoning.  The *following*
+        # chunk then confirms the lookahead, but the tool parser never sees the
+        # required <tool_call> prefix, so it treats <function=…> as plain text.
+        #
+        # Solution: when the lookahead fails while <tool_call> is in the delta,
+        # buffer the tag (and any trailing whitespace in that same delta) instead
+        # of emitting it as reasoning.  Subsequent deltas are appended to the
+        # buffer until lookahead confirms (→ emit as content) or non-whitespace
+        # arrives that cannot lead to <function=…> (→ flush as reasoning).
         if self._tool_call_token_id is not None:
             tc_id = self._tool_call_token_id
             tc_in_delta = tc_id in delta_token_ids
             tc_in_prev = tc_id in previous_token_ids
+
+            # --- Pending-buffer path: a previous delta left <tool_call>
+            # buffered; re-evaluate lookahead with the new token context. ---
+            if self._tool_call_pending is not None:
+                ids = list(current_token_ids)
+                try:
+                    pos = len(ids) - 1 - ids[::-1].index(tc_id)
+                    if self._tool_call_is_genuine_end(ids, pos):
+                        # Lookahead confirmed: emit the full buffered text
+                        # plus the current delta as content so the downstream
+                        # tool parser receives the complete "<tool_call>\n
+                        # <function=…>" sequence it needs.
+                        content = self._tool_call_pending + delta_text
+                        self._tool_call_pending = None
+                        return DeltaMessage(content=content)
+                except ValueError:
+                    pass
+
+                # Lookahead still unconfirmed.  Keep buffering only if the
+                # text accumulated after <tool_call> is still a plausible
+                # prefix of "<function" (the only valid tag that can follow
+                # <tool_call>).  Anything else means it was not a genuine
+                # tool-call opener, so flush immediately as reasoning.
+                after_tc = self._tool_call_pending[len(self._tool_call_tag):]
+                candidate = (after_tc + delta_text).lstrip()
+                func_prefix = "<function"
+                still_viable = (
+                    not candidate                        # still pure whitespace
+                    or func_prefix.startswith(candidate) # candidate is a prefix of "<function"
+                    or candidate.startswith(func_prefix) # candidate already has the full prefix
+                )
+                if still_viable:
+                    self._tool_call_pending += delta_text
+                    return None
+                # Accumulated text diverged from "<function": flush as reasoning.
+                reasoning_buf = self._tool_call_pending + delta_text
+                self._tool_call_pending = None
+                return DeltaMessage(reasoning=reasoning_buf)
+
+            # --- Normal path: <tool_call> arrives in this or a prior delta. ---
             if tc_in_delta or tc_in_prev:
                 ids = list(current_token_ids)
                 try:
@@ -279,13 +338,23 @@ class Qwen3ReasoningParser(BaseThinkingReasoningParser):
                                     content=content if content else None,
                                 )
                         else:
-                            # <tool_call> was in previous delta; current delta
-                            # is all content.
+                            # <tool_call> was confirmed in a prior delta;
+                            # current delta is all content.
                             return DeltaMessage(content=delta_text)
                 except ValueError:
                     pass
-                # Lookahead returned False or <function=…> not yet arrived:
-                # treat as reasoning — fall through.
+
+                # Lookahead returned False or <function=…> not yet arrived.
+                if tc_in_delta:
+                    # Buffer <tool_call> (and any text that follows it in this
+                    # delta) rather than emitting it as reasoning.  This lets
+                    # the *next* delta's lookahead confirm or deny the call.
+                    tool_index = delta_text.find(self._tool_call_tag)
+                    if tool_index >= 0:
+                        pre = delta_text[:tool_index]
+                        self._tool_call_pending = delta_text[tool_index:]
+                        return DeltaMessage(reasoning=pre) if pre else None
+                # tc_in_prev=True but lookahead failed: still in reasoning.
 
         # No end token in this delta.
         if not delta_text:

--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -201,11 +201,14 @@ class StreamingXMLToolCallParser:
         result = self._merge_deltas(self.deltas)
         if result.tool_calls:
             valid = [tc for tc in result.tool_calls if tc.function and tc.function.name]
-            result = DeltaMessage(
-                content=result.content,
-                tool_calls=valid,
-                reasoning=result.reasoning,
-            )
+            if valid:
+                result = DeltaMessage(
+                    content=result.content,
+                    tool_calls=valid,
+                    reasoning=result.reasoning,
+                )
+            else:
+                result = DeltaMessage(content=result.content, reasoning=result.reasoning)
         return result
 
     # ------------------------------------------------------------------
@@ -816,10 +819,12 @@ class StreamingXMLToolCallParser:
             for cid in call_order
         ]
 
-        return DeltaMessage(
-            content=merged_content or None,
-            tool_calls=merged_calls,
-        )
+        if merged_calls:
+            return DeltaMessage(
+                content=merged_content or None,
+                tool_calls=merged_calls,
+            )
+        return DeltaMessage(content=merged_content or None)
 
 
 class Qwen3XMLToolParser(ToolParser):

--- a/vllm/tool_parsers/qwen3xml_tool_parser.py
+++ b/vllm/tool_parsers/qwen3xml_tool_parser.py
@@ -2,11 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import ast
 import json
+import re
 from collections.abc import Sequence
-from typing import Any
-from xml.parsers.expat import ParserCreate
-
-import regex as re
+from enum import Enum, auto
+from typing import Optional
 
 from vllm.entrypoints.chat_utils import make_tool_call_id
 from vllm.entrypoints.openai.chat_completion.protocol import (
@@ -31,1118 +30,796 @@ from vllm.tool_parsers.utils import find_tool_properties
 logger = init_logger(__name__)
 
 
+class _State(Enum):
+    TEXT = auto()  # Plain text / before any tool call
+    TOOL_CALL_PENDING = auto()  # Saw <tool_call>; waiting for lookahead tag
+    TOOL_CALL = auto()  # Between structural tags inside <tool_call>
+    FUNCTION = auto()  # Between structural tags inside <function=...>
+    PARAM_VALUE = auto()  # Accumulating parameter value text
+    PARAM_CLOSE_PENDING = auto()  # Saw </parameter>; waiting for lookahead tag
+
+
 class StreamingXMLToolCallParser:
     """
-    Simplified streaming XML tool call parser
-    Supports streaming input, parsing, and output
+    Character-level streaming XML tool call parser implemented as a state
+    machine.
+
+    Processes input one character at a time with no assumptions about input
+    chunk boundaries.  Supports the Qwen3 XML tool-call format::
+
+        <tool_call>
+        <function=FUNCTION_NAME>
+        <parameter=PARAM_NAME>
+        VALUE
+        </parameter>
+        </function>
+        </tool_call>
+
+    Both ``<function=name>`` and ``<function name="name">`` are accepted, and
+    likewise for ``<parameter>``.  ``<function=…>`` and ``<parameter=…>`` are
+    only meaningful inside an open ``<tool_call>`` context; they are treated as
+    plain text otherwise.
+
+    Inside a tag (the ``<…>`` region) the parser also tracks quoted strings so
+    that ``<`` characters inside attribute values (e.g. ``<foo attr="a<b">``)
+    do not prematurely restart tag accumulation.
     """
 
-    def __init__(self):
+    # Kept for callers that reference them directly.
+    tool_call_start_token: str = "<tool_call>"
+    tool_call_end_token: str = "</tool_call>"
+    function_start_token: str = "<function="
+    function_end_token: str = "</function>"
+    parameter_start_token: str = "<parameter="
+    parameter_end_token: str = "</parameter>"
+
+    # Function names must start with a letter or underscore and contain only
+    # alphanumerics, underscores, dots, colons, or hyphens.  This prevents
+    # documentation placeholders like `<function=...>` from being parsed as
+    # real function-open tags.
+    _RE_FUNCTION_OPEN = re.compile(
+        r'^<function(?:\s*=\s*([a-zA-Z_][a-zA-Z0-9_.:\-]*)'
+        r'|(?:\s+name\s*=\s*["\x27]([^"\x27]+)["\x27]))\s*>$'
+    )
+    _RE_PARAMETER_OPEN = re.compile(
+        r'^<parameter(?:\s*=\s*([^>\s]+)|(?:\s+name\s*=\s*["\x27]([^"\x27]+)["\x27]))\s*>$'
+    )
+
+    # Fixed-prefix set used for early tag rejection.  For variable-suffix tags
+    # (those ending with "=" or " ") the fixed portion is listed here; any
+    # content after that prefix is valid.  Completely fixed tags (no variable
+    # portion before ">") are also listed so character-by-character matching
+    # works up to the ">".
+    _STRUCTURAL_TAG_PREFIXES: tuple[str, ...] = (
+        "<tool_call>",
+        "</tool_call>",
+        "<function=",   # <function=NAME> form — variable after "="
+        "<function ",   # <function name="NAME"> form — variable after space
+        "</function>",
+        "<parameter=",  # <parameter=NAME> form — variable after "="
+        "<parameter ",  # <parameter name="NAME"> form — variable after space
+        "</parameter>",
+    )
+
+    def __init__(self) -> None:
+        self.tools: Optional[list[Tool]] = None
         self.reset_streaming_state()
 
-        # Tool configuration information
-        self.tools: list[Tool] | None = None
-        self.tool_call_start_token: str = "<tool_call>"
-        self.tool_call_end_token: str = "</tool_call>"
-        self.function_start_token: str = "<function="
-        self.function_end_token: str = "</function>"
-        self.parameter_start_token: str = "<parameter="
-        self.parameter_end_token: str = "</parameter>"
-
-    def reset_streaming_state(self):
-        """Reset streaming parsing state"""
-
-        self.deltas = []
-        # state for streaming
-        self.tool_call_index = 0
-        self.current_call_id = None
-        self.last_completed_call_id = None
-        self.current_function_name = None
-        self.current_function_open = False
-        self.parameters = {}
-        self.current_param_name = None
-        self.current_param_value = ""
-        self.current_param_value_converted = ""
-        self.current_param_is_first = False
-        self.should_emit_end_newline = False
-        self.start_quote_emitted = False
-
-        self.streaming_buffer = ""
-        self.last_processed_pos = 0
-
-        self.text_content_buffer = ""
-
-        # state for preprocessing and deferred parsing
-        self._pre_inside_parameter = False
-        self._pre_param_buffer = ""
-        self._pre_current_param_name = None
-        self.defer_current_parameter = False
-        self.deferred_param_raw_value = ""
-
-        # recreate parser
-        self.parser = ParserCreate()
-        self.setup_parser()
-
-    def parse_single_streaming_chunks(self, xml_chunk: str) -> DeltaMessage:
-        """
-        Parse single streaming XML chunk and return Delta response
-        This is the actual streaming interface that receives chunks
-        one by one and maintains internal state
-
-        Args:
-            xml_chunk: Single XML chunk string
-        Returns:
-            DeltaMessage: Contains delta information generated by this chunk,
-            returns empty response if no complete elements
-        """
-        # Record delta count before processing
-        initial_delta_count = len(self.deltas)
-
-        self.streaming_buffer += xml_chunk
-
-        found_elements = self._process_complete_xml_elements()
-
-        if found_elements:
-            # If complete elements found, check if end events were missed
-            # some tags may not have been triggered
-            try:
-                new_deltas = self.deltas[initial_delta_count:]
-                # If this chunk contains </function>
-                # but didn't generate '}', then complete it
-                if (
-                    self.current_call_id is not None
-                    and self.function_end_token in xml_chunk
-                ):
-                    # - Added '}' (non-empty parameter ending)
-                    # - Added '{}' (empty parameter function)
-                    has_function_close = any(
-                        (
-                            td.tool_calls
-                            and any(
-                                (
-                                    tc.function
-                                    and tc.id == self.current_call_id
-                                    and isinstance(tc.function.arguments, str)
-                                    and (tc.function.arguments in ("}", "{}"))
-                                )
-                                for tc in td.tool_calls
-                            )
-                        )
-                        for td in new_deltas
-                    )
-                    if not has_function_close:
-                        # Close potentially unclosed element
-                        if self.current_param_name:
-                            self._end_element("parameter")
-                        if self.current_function_name:
-                            self._end_element("function")
-                # If this chunk contains </tool_call>
-                # but didn't generate final empty delta, then complete it
-                if (
-                    self.current_call_id is not None
-                    and self.tool_call_end_token in xml_chunk
-                ):
-                    has_toolcall_close = any(
-                        (
-                            td.tool_calls
-                            and any(
-                                (
-                                    tc.type == "function"
-                                    and tc.function
-                                    and tc.function.arguments == ""
-                                    and tc.id == self.current_call_id
-                                )
-                                for tc in td.tool_calls
-                            )
-                        )
-                        for td in new_deltas
-                    )
-                    if not has_toolcall_close:
-                        # Close potentially unclosed element
-                        if self.current_param_name:
-                            self._end_element("parameter")
-                        if self.current_function_name:
-                            self._end_element("function")
-                        self._end_element("tool_call")
-            except Exception as e:
-                logger.warning("Error with fallback parsing: %s", e)
-            # Merge newly generated deltas into single response
-            result_delta = self._merge_new_deltas_to_single_response(
-                initial_delta_count
-            )
-            return result_delta
-        else:
-            # No complete elements, check if there's unoutput text content
-            if self.text_content_buffer and self.tool_call_index == 0:
-                # Has text content but no tool_call yet, output text content
-                text_delta = DeltaMessage(content=self.text_content_buffer)
-                self._emit_delta(text_delta)
-                # Clear buffer to avoid duplicate output
-                self.text_content_buffer = ""
-                return text_delta
-
-            # If this chunk contains end tags but wasn't triggered by parser,
-            # manually complete end events
-            # Only execute when still on the same call as when entered,
-            # to prevent accidentally closing new calls
-            # in multi <tool_call> scenarios
-            if self.current_call_id is not None and (
-                self.function_end_token in xml_chunk
-                or self.tool_call_end_token in xml_chunk
-            ):
-                # Close potentially unclosed element
-                if self.current_param_name:
-                    self._end_element("parameter")
-                if self.function_end_token in xml_chunk and self.current_function_name:
-                    self._end_element("function")
-                if self.tool_call_end_token in xml_chunk:
-                    self._end_element("tool_call")
-                # Return the merged delta result generated by this fallback
-                result_delta = self._merge_new_deltas_to_single_response(
-                    initial_delta_count
-                )
-                return result_delta
-
-            # No complete elements, return empty response
-            return DeltaMessage(content=None)
-
-    def _escape_xml_special_chars(self, text: str) -> str:
-        """
-        Escape XML special characters
-        Args:
-            text: Original text
-        Returns:
-            Escaped text
-        """
-        xml_escapes = {
-            "&": "&amp;",
-            "<": "&lt;",
-            ">": "&gt;",
-            '"': "&quot;",
-            "'": "&apos;",
-        }
-
-        for char, escape in xml_escapes.items():
-            text = text.replace(char, escape)
-
-        return text
-
-    def _process_complete_xml_elements(self) -> bool:
-        """
-        Process complete XML elements in buffer
-
-        Returns:
-            bool: Whether complete elements were found and processed
-        """
-        found_any = False
-
-        while self.last_processed_pos < len(self.streaming_buffer):
-            # Find next complete xml element
-            element, end_pos = self._find_next_complete_element(self.last_processed_pos)
-            if element is None:
-                # No complete element found, wait for more data
-                break
-
-            # Check if this element should be skipped
-            if self._should_skip_element(element):
-                self.last_processed_pos = end_pos
-                continue
-
-            # Found complete XML element, process it
-            try:
-                preprocessed_element = self._preprocess_xml_chunk(element)
-                # Check if this is the first tool_call start
-                if (
-                    (
-                        preprocessed_element.strip().startswith("<tool_call>")
-                        or preprocessed_element.strip().startswith("<function name=")
-                    )
-                    and self.tool_call_index == 0
-                ) and self.text_content_buffer:
-                    # First tool_call starts,
-                    # output previously collected text content first
-                    text_delta = DeltaMessage(content=self.text_content_buffer)
-                    self._emit_delta(text_delta)
-                    # Clear buffer for potential subsequent text content
-                    self.text_content_buffer = ""
-
-                # If a new tool_call starts and
-                # there are already completed tool_calls
-                if (
-                    preprocessed_element.strip().startswith("<tool_call>")
-                    and self.tool_call_index > 0
-                    and self.current_call_id
-                ):
-                    # Reset parser state but preserve generated deltas
-                    if self.current_param_name:
-                        self._end_element("parameter")
-                    if self.current_function_open or self.current_function_name:
-                        self._end_element("function")
-                    # Output final tool_call tail delta
-                    final_delta = DeltaMessage(
-                        role=None,
-                        content=None,
-                        reasoning=None,
-                        tool_calls=[
-                            DeltaToolCall(
-                                index=self.tool_call_index - 1,
-                                id=self.current_call_id,
-                                type="function",
-                                function=DeltaFunctionCall(name=None, arguments=""),
-                            )
-                        ],
-                    )
-                    self._emit_delta(final_delta)
-                    # Reset XML parser and current call state
-                    self._reset_xml_parser_after_tool_call()
-                # Parse preprocessed element
-                self.parser.Parse(preprocessed_element, False)
-                found_any = True
-
-            except Exception as e:
-                logger.warning("Error when parsing XML elements: %s", e)
-
-            # Update processed position
-            self.last_processed_pos = end_pos
-
-        return found_any
-
-    def _should_skip_element(self, element: str) -> bool:
-        """
-        Determine whether an element should be skipped
-
-        Args:
-            element: Element to evaluate
-
-        Returns:
-            bool: True means should skip, False means should process
-        """
-
-        # If it's a tool_call XML tag, don't skip
-        if (
-            element.startswith(self.tool_call_start_token)
-            or element.startswith(self.function_start_token)
-            or element.startswith(self.parameter_start_token)
-        ):
-            return False
-
-        # If currently not parsing tool calls and not blank,
-        # collect this text instead of skipping
-        # Only process other XML elements after tool_call appears,
-        # otherwise treat as plain text
-        if self.current_call_id is None and element:
-            # Collect text content to buffer
-            self.text_content_buffer += element
-            return True  # Still skip, but content has been collected
-
-        # If currently parsing tool calls,
-        # this might be parameter value, don't skip
-        if self.current_call_id is not None:
-            return False
-
-        # Skip blank content
-        return not element
-
-    def _find_next_complete_element(self, start_pos: int) -> tuple[str | None, int]:
-        """
-        Find next complete XML element from specified position
-
-        Args:
-            start_pos: Position to start searching
-
-        Returns:
-            (Complete element string, element end position),
-            returns (None, start_pos) if no complete element found
-        """
-        buffer = self.streaming_buffer[start_pos:]
-
-        if not buffer:
-            return None, start_pos
-
-        if buffer.startswith("<"):
-            # Need to ensure no new < appears,
-            # find the nearest one between < and >
-            tag_end = buffer.find("<", 1)
-            tag_end2 = buffer.find(">", 1)
-            if tag_end != -1 and tag_end2 != -1:
-                # Next nearest is <
-                if tag_end < tag_end2:
-                    return buffer[:tag_end], start_pos + tag_end
-                # Next nearest is >, means found XML element
-                else:
-                    return buffer[: tag_end2 + 1], start_pos + tag_end2 + 1
-            elif tag_end != -1:
-                return buffer[:tag_end], start_pos + tag_end
-            elif tag_end2 != -1:
-                return buffer[: tag_end2 + 1], start_pos + tag_end2 + 1
-            else:
-                # If currently not parsing tool calls (entering a tool_call),
-                # check if starts with <tool_call> or <function=
-                if self.current_call_id is None:
-                    # Check if might be start of <tool_call>
-                    if buffer == "<tool_call>"[: len(buffer)]:
-                        # Might be start of <tool_call>, wait for more data
-                        return None, start_pos
-                    elif (
-                        buffer.startswith("<function=")
-                        or buffer == "<function="[: len(buffer)]
-                    ):
-                        # Might be start of <function=, wait for more data
-                        # to get the complete function tag
-                        return None, start_pos
-                    else:
-                        # Not start of <tool_call> or <function=, treat as text
-                        return buffer, start_pos + len(buffer)
-                else:
-                    # When parsing tool calls,
-                    # wait for more data to get complete tag
-                    return None, start_pos
-        else:
-            # Find text content (until next < or buffer end)
-            next_tag_pos = buffer.find("<")
-            if next_tag_pos != -1:
-                # Found text content
-                text_content = buffer[:next_tag_pos]
-                return text_content, start_pos + next_tag_pos
-            else:
-                # Buffer end is all text, process
-                # (no longer wait for more data)
-                remaining = buffer
-                return remaining, start_pos + len(remaining)
-
-    def _merge_new_deltas_to_single_response(self, initial_count: int) -> DeltaMessage:
-        """
-        Merge newly generated deltas from this processing
-        into a single DeltaMessage
-
-        Args:
-            initial_count: Delta count before processing
-
-        Returns:
-            Merged DeltaMessage containing all newly generated delta information
-        """
-        if len(self.deltas) <= initial_count:
-            return DeltaMessage(content=None)
-
-        # Get newly generated deltas
-        new_deltas = self.deltas[initial_count:]
-
-        if len(new_deltas) == 1:
-            # Only one new delta, return directly
-            return new_deltas[0]
-
-        # Merge multiple new deltas
-        merged_tool_calls: list[DeltaToolCall] = []
-        merged_content: str = ""
-
-        for delta in new_deltas:
-            if delta.content:
-                merged_content += delta.content
-            if delta.tool_calls:
-                # For tool_calls, we need to intelligently merge arguments
-                for tool_call in delta.tool_calls:
-                    # Find if there's already a tool_call with the same call_id
-                    existing_call = None
-                    for existing in merged_tool_calls:
-                        if existing.id == tool_call.id:
-                            existing_call = existing
-                            break
-
-                    if existing_call and existing_call.function:
-                        # Merge to existing tool_call
-                        if tool_call.function and tool_call.function.name:
-                            existing_call.function.name = tool_call.function.name
-                        if (
-                            tool_call.function
-                            and tool_call.function.arguments is not None
-                        ):
-                            if existing_call.function.arguments is None:
-                                existing_call.function.arguments = ""
-
-                            # For streaming JSON parameters,
-                            # simply concatenate in order
-                            new_args = tool_call.function.arguments
-                            existing_call.function.arguments += new_args
-                        if tool_call.type:
-                            existing_call.type = tool_call.type
-                    else:
-                        # Add new tool_call
-                        merged_tool_calls.append(tool_call)
-
-        return DeltaMessage(
-            content=merged_content if merged_content else None,
-            tool_calls=merged_tool_calls,
-        )
-
-    def _preprocess_xml_chunk(self, chunk: str) -> str:
-        """
-        Preprocess XML chunk, handle non-standard formats,
-        and escape special characters
-
-        Args:
-            chunk: Original XML chunk
-
-        Returns:
-            Processed XML chunk
-        """
-
-        # Check if this is a tool_call related element
-        is_tool_call = False
-        if chunk.startswith(self.tool_call_start_token) or chunk.startswith(
-            self.tool_call_end_token
-        ):
-            is_tool_call = True
-        if chunk.startswith(self.function_start_token) or chunk.startswith(
-            self.function_end_token
-        ):
-            is_tool_call = True
-        if chunk.startswith(self.parameter_start_token) or chunk.startswith(
-            self.parameter_end_token
-        ):
-            is_tool_call = True
-        # Handle <function=name> format -> <function name="name">
-        processed = re.sub(r"<function=([^>]+)>", r'<function name="\1">', chunk)
-        # Handle <parameter=name> format -> <parameter name="name">
-        processed = re.sub(r"<parameter=([^>]+)>", r'<parameter name="\1">', processed)
-
-        original_chunk = chunk
-        # If in parameter value accumulation mode
-        if self._pre_inside_parameter:
-            # Parameter end: output accumulated raw text
-            # safely then return </parameter>
-            if processed.startswith("</parameter>"):
-                body_text = self._pre_param_buffer
-                # Trigger deferred parsing mode
-                # literal_eval+json output in end_element
-                self.defer_current_parameter = True
-                self.deferred_param_raw_value = body_text
-                # Clean up state
-                self._pre_inside_parameter = False
-                self._pre_param_buffer = ""
-                self._pre_current_param_name = None
-                safe_text = self._escape_xml_special_chars(body_text)
-                return f"{safe_text}</parameter>"
-            else:
-                # If this is the first block of content after entering parameter
-                # evaluate if deferred parsing is needed;
-                # If not needed, exit accumulation mode
-                # and pass through directly
-                if self._pre_param_buffer == "":
-                    # Get current parameter type
-                    param_type = (
-                        self._get_param_type(self._pre_current_param_name)
-                        if self._pre_current_param_name
-                        else "string"
-                    )
-                    # Only these types need deferred parsing to
-                    # handle Python literals containing single quotes
-                    is_object_type = param_type in ["object"]
-                    is_complex_type = (
-                        param_type in ["array", "arr", "sequence"]
-                        or param_type.startswith("dict")
-                        or param_type.startswith("list")
-                    )
-
-                    # Only delay when contains container symbols
-                    # and has single quotes and is complex type
-                    has_container_hint = (
-                        ("[" in original_chunk)
-                        or ("{" in original_chunk)
-                        or ("(" in original_chunk)
-                    )
-
-                    # Determine if deferred parsing is needed
-                    need_defer = False
-                    if is_complex_type:
-                        # Complex type, always need deferred parsing
-                        need_defer = True
-                    elif (
-                        is_object_type
-                        and has_container_hint
-                        and ("'" in original_chunk)
-                    ):
-                        # Object type with container symbols
-                        # and single quotes, need deferred parsing
-                        need_defer = True
-
-                    if not need_defer:
-                        # No need for deferred parsing,
-                        # exit parameter mode directly
-                        self._pre_inside_parameter = False
-                        return self._escape_xml_special_chars(original_chunk)
-                self._pre_param_buffer += original_chunk
-                return ""
-
-        # Parameter start: enable accumulation
-        if processed.startswith("<parameter name="):
-            m = re.match(r'<parameter name="([^"]+)">', processed)
-            if m:
-                self._pre_current_param_name = m.group(1)
-            self._pre_inside_parameter = True
-            self._pre_param_buffer = ""
-            return processed
-
-        # If processed doesn't contain special_token, escape processed
-        # This is because XML parsing encounters special characters
-        # and reports errors, so escaping is needed
-        if not is_tool_call:
-            processed = self._escape_xml_special_chars(processed)
-        return processed
-
-    def _emit_delta(self, delta: DeltaMessage):
-        """Emit Delta response (streaming output)"""
-        self.deltas.append(delta)
-
-    def _auto_close_open_parameter_if_needed(self, incoming_tag: str | None = None):
-        """Before starting to process new elements,
-        if there are unclosed tags from before,
-        automatically complete their endings to the parser.
-        - If there are unclosed parameters,
-        it's equivalent to feeding `</parameter>`
-        - When about to start a new function or tool_call,
-        if there are unclosed functions, complete `</function>`.
-        - When about to start a new tool_call,
-        if there are unclosed tool_calls, complete `</tool_call>`.
-        """
-        # First close unclosed parameters
-        if self.current_param_name:
-            self._end_element("parameter")
-
-        # If about to start new function or tool_call,
-        # and there are unclosed functions, close function first
-        if incoming_tag in ("function", "tool_call") and self.current_function_name:
-            self._end_element("function")
-
-        # If about to start new tool_call,
-        # and there are unclosed tool_calls, close tool_call first
-        if incoming_tag == "tool_call" and self.current_call_id:
-            self._end_element("tool_call")
-
-    def _start_element(self, name: str, attrs: dict[str, str]):
-        """Handle XML start element events"""
-
-        if name == "root":
-            return
-
-        if name == "tool_call":
-            # Before opening new tool_call,
-            # automatically complete previous unclosed tags
-            self._auto_close_open_parameter_if_needed("tool_call")
-
-            self.parameters = {}
-            self.current_call_id = make_tool_call_id()
-            self.current_param_is_first = True
-            self.tool_call_index += 1
-        elif name.startswith("function") or (name == "function"):
-            # If missing tool_call, manually complete
-            if not self.current_call_id:
-                self._start_element("tool_call", {})
-            # Before opening new function,
-            # automatically complete previous unclosed tags (parameter/function)
-            self._auto_close_open_parameter_if_needed("function")
-            function_name = self._extract_function_name(name, attrs)
-            self.current_function_name = function_name
-            self.current_function_open = True
-            if function_name:
-                delta = DeltaMessage(
-                    tool_calls=[
-                        DeltaToolCall(
-                            index=self.tool_call_index - 1,
-                            id=self.current_call_id,
-                            type="function",
-                            function=DeltaFunctionCall(
-                                name=function_name, arguments=""
-                            ),
-                        )
-                    ]
-                )
-                self._emit_delta(delta)
-        elif name.startswith("parameter") or (name == "parameter"):
-            # If previous parameter hasn't ended normally,
-            # complete its end first, then start new parameter
-            self._auto_close_open_parameter_if_needed("parameter")
-            param_name = self._extract_parameter_name(name, attrs)
-            self.current_param_name = param_name
-            self.current_param_value = ""
-            self.current_param_value_converted = ""
-            self.start_quote_emitted = False  # Reset start quote flag
-
-            # Only output parameter name and colon,
-            # don't output quotes
-            # decide after parameter value type is determined
-            if param_name:
-                if not self.parameters:
-                    # First parameter
-                    # start JSON, only output parameter name and colon
-                    json_start = f'{{"{param_name}": '
-                    delta = DeltaMessage(
-                        tool_calls=[
-                            DeltaToolCall(
-                                index=self.tool_call_index - 1,
-                                id=self.current_call_id,
-                                type="function",
-                                function=DeltaFunctionCall(
-                                    name=None, arguments=json_start
-                                ),
-                            )
-                        ]
-                    )
-                    self._emit_delta(delta)
-                    self.current_param_is_first = True
-                else:
-                    # Subsequent parameters
-                    # add comma and parameter name, no quotes
-                    json_continue = f', "{param_name}": '
-                    delta = DeltaMessage(
-                        tool_calls=[
-                            DeltaToolCall(
-                                index=self.tool_call_index - 1,
-                                id=self.current_call_id,
-                                type="function",
-                                function=DeltaFunctionCall(
-                                    name=None, arguments=json_continue
-                                ),
-                            )
-                        ]
-                    )
-                    self._emit_delta(delta)
-                    self.current_param_is_first = False
-
-    def _char_data(self, data: str):
-        """Handle XML character data events"""
-        if data and self.current_param_name:
-            # If preprocessing stage determines deferred parsing is needed,
-            # only cache character data, no streaming output
-            if self.defer_current_parameter:
-                original_data = data
-                if self.should_emit_end_newline:
-                    original_data = "\n" + original_data
-                    self.should_emit_end_newline = False
-                if original_data.endswith("\n"):
-                    self.should_emit_end_newline = True
-                    original_data = original_data[:-1]
-                self.current_param_value += original_data
-                return
-
-            param_type = self._get_param_type(self.current_param_name)
-
-            # Check if this is the first time receiving data for this parameter
-            # If this is the first packet of data and starts with \n, remove \n
-            if not self.current_param_value and data.startswith("\n"):
-                data = data[1:]
-
-            # Output start quote for string type (if not already output)
-            if (
-                param_type in ["string", "str", "text", "varchar", "char", "enum"]
-                and not self.start_quote_emitted
-            ):
-                quote_delta = DeltaMessage(
-                    tool_calls=[
-                        DeltaToolCall(
-                            index=self.tool_call_index - 1,
-                            id=self.current_call_id,
-                            type="function",
-                            function=DeltaFunctionCall(name=None, arguments='"'),
-                        )
-                    ]
-                )
-                self._emit_delta(quote_delta)
-                self.start_quote_emitted = True
-
-            if not data:
-                return
-
-            original_data = data
-            # Delay output of trailing newline
-            if self.should_emit_end_newline:
-                original_data = "\n" + original_data
-                self.should_emit_end_newline = False
-            if original_data.endswith("\n"):
-                self.should_emit_end_newline = True
-                original_data = original_data[:-1]
-            self.current_param_value += original_data
-
-            # convert parameter value by param_type
-            converted_value = self._convert_param_value(
-                self.current_param_value, param_type
-            )
-            output_data = self._convert_for_json_streaming(converted_value, param_type)
-
-            delta_data = output_data[len(self.current_param_value_converted) :]
-            self.current_param_value_converted = output_data
-
-            delta = DeltaMessage(
-                tool_calls=[
-                    DeltaToolCall(
-                        index=self.tool_call_index - 1,
-                        id=self.current_call_id,
-                        type="function",
-                        function=DeltaFunctionCall(name=None, arguments=delta_data),
-                    )
-                ]
-            )
-            self._emit_delta(delta)
-
-    def _end_element(self, name: str):
-        """Handle XML end element events"""
-
-        if name == "root":
-            return
-
-        # If function or tool_call ends and there are still unclosed parameters,
-        # complete parameter end first
-        if (
-            name.startswith("function") or name == "function" or name == "tool_call"
-        ) and self.current_param_name:
-            self._auto_close_open_parameter_if_needed()
-
-        if (
-            name.startswith("parameter") or name == "parameter"
-        ) and self.current_param_name:
-            # End current parameter
-            param_name = self.current_param_name
-            param_value = self.current_param_value
-
-            # If in deferred parsing mode,
-            # perform overall parsing on raw content
-            # accumulated in preprocessing stage and output once
-            if self.defer_current_parameter:
-                raw_text = (
-                    self.deferred_param_raw_value
-                    if self.deferred_param_raw_value
-                    else param_value
-                )
-                parsed_value = None
-                output_arguments = None
-                try:
-                    # If previously delayed trailing newline,
-                    # add it back before parsing
-                    if self.should_emit_end_newline:
-                        raw_for_parse = raw_text + "\n"
-                    else:
-                        raw_for_parse = raw_text
-                    parsed_value = ast.literal_eval(raw_for_parse)
-                    output_arguments = json.dumps(parsed_value, ensure_ascii=False)
-                except Exception:
-                    # Fallback: output as string as-is
-                    output_arguments = json.dumps(raw_text, ensure_ascii=False)
-                    parsed_value = raw_text
-
-                delta = DeltaMessage(
-                    tool_calls=[
-                        DeltaToolCall(
-                            index=self.tool_call_index - 1,
-                            id=self.current_call_id,
-                            type="function",
-                            function=DeltaFunctionCall(
-                                name=None, arguments=output_arguments
-                            ),
-                        )
-                    ]
-                )
-                self._emit_delta(delta)
-
-                # Clean up and store
-                self.should_emit_end_newline = False
-                self.parameters[param_name] = parsed_value
-                self.current_param_name = None
-                self.current_param_value = ""
-                self.current_param_value_converted = ""
-                self.start_quote_emitted = False
-                self.defer_current_parameter = False
-                self.deferred_param_raw_value = ""
-                return
-
-            param_type = self._get_param_type(param_name)
-
-            # convert complete parameter value by param_type
-            converted_value = self._convert_param_value(param_value, param_type)
-
-            # Decide whether to add end quote based on parameter type
-            if param_type in ["string", "str", "text", "varchar", "char", "enum"]:
-                # For empty string parameters, need special handling
-                if not param_value and not self.start_quote_emitted:
-                    # No start quote output,
-                    # directly output complete empty string
-                    delta = DeltaMessage(
-                        tool_calls=[
-                            DeltaToolCall(
-                                index=self.tool_call_index - 1,
-                                id=self.current_call_id,
-                                type="function",
-                                function=DeltaFunctionCall(name=None, arguments='""'),
-                            )
-                        ]
-                    )
-                    self._emit_delta(delta)
-                else:
-                    # Non-empty parameter value, output end quote
-                    delta = DeltaMessage(
-                        tool_calls=[
-                            DeltaToolCall(
-                                index=self.tool_call_index - 1,
-                                id=self.current_call_id,
-                                type="function",
-                                function=DeltaFunctionCall(name=None, arguments='"'),
-                            )
-                        ]
-                    )
-                    self._emit_delta(delta)
-
-            self.should_emit_end_newline = False
-            # Store converted value
-            self.parameters[param_name] = converted_value
-            self.current_param_name = None
-            self.current_param_value = ""
-            self.current_param_value_converted = ""
-            self.start_quote_emitted = False
-
-        elif name.startswith("function") or name == "function":
-            # if there are parameters, close JSON object
-            if self.parameters:
-                delta = DeltaMessage(
-                    tool_calls=[
-                        DeltaToolCall(
-                            index=self.tool_call_index - 1,
-                            id=self.current_call_id,
-                            type="function",
-                            function=DeltaFunctionCall(name=None, arguments="}"),
-                        )
-                    ]
-                )
-                self._emit_delta(delta)
-            # return empty object
-            else:
-                delta = DeltaMessage(
-                    tool_calls=[
-                        DeltaToolCall(
-                            index=self.tool_call_index - 1,
-                            id=self.current_call_id,
-                            type="function",
-                            function=DeltaFunctionCall(name=None, arguments="{}"),
-                        )
-                    ]
-                )
-                self._emit_delta(delta)
-            self.current_function_open = False
-
-        elif name == "tool_call":
-            # Before ending tool_call,
-            # ensure function is closed to complete missing right brace
-            if self.current_function_open:
-                # If there are still unclosed parameters, close them first
-                if self.current_param_name:
-                    self._end_element("parameter")
-                # Close function, ensure output '}' or '{}'
-                self._end_element("function")
-            # Final Delta
-            delta = DeltaMessage(
-                tool_calls=[
-                    DeltaToolCall(
-                        index=self.tool_call_index - 1,
-                        id=self.current_call_id,
-                        type="function",
-                        function=DeltaFunctionCall(name=None, arguments=""),
-                    )
-                ]
-            )
-            self._emit_delta(delta)
-
-            # Check if there's text content to output (between tool_calls)
-            if self.text_content_buffer.strip():
-                text_delta = DeltaMessage(content=self.text_content_buffer)
-                self._emit_delta(text_delta)
-
-            self._reset_xml_parser_after_tool_call()
-
-    def setup_parser(self):
-        """Set up XML parser event handlers"""
-        self.parser.buffer_text = True
-        self.parser.StartElementHandler = self._start_element
-        self.parser.EndElementHandler = self._end_element
-        self.parser.CharacterDataHandler = self._char_data
-
-    def set_tools(self, tools: list[Tool] | None):
-        """Set tool configuration information"""
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def set_tools(self, tools: Optional[list[Tool]]) -> None:
         self.tools = tools
 
-    def _extract_function_name(self, name: str, attrs: dict[str, str]) -> str | None:
-        """Extract function name from various formats"""
-        if attrs and "name" in attrs:
-            return attrs["name"]
+    def reset_streaming_state(self) -> None:
+        """Reset all mutable parser state."""
+        self.deltas: list[DeltaMessage] = []
 
-        if "=" in name:
-            parts = name.split("=", 1)
-            if len(parts) == 2 and parts[0] == "function":
-                return parts[1]
+        # State machine
+        self._state: _State = _State.TEXT
 
+        # True while accumulating the content of a <…> tag.
+        self._in_tag: bool = False
+        # Buffer for the current <…> tag (including the opening '<').
+        self._tag_buf: str = ""
+        # True when we're inside a quoted string within a tag attribute value.
+        self._tag_in_quote: bool = False
+        # The opening quote character (' or ") when _tag_in_quote is True.
+        self._tag_quote_char: str = ""
+
+        # Plain-text accumulator used in TEXT state.
+        self._text_buf: str = ""
+        # Raw parameter-value accumulator.
+        self._param_buf: str = ""
+        # Whitespace/chars buffered between a tentative </parameter> and the
+        # next tag in PARAM_CLOSE_PENDING state (restored as content on
+        # lookahead failure).
+        self._pending_close_ws: str = ""
+        # Chars buffered between a tentative <tool_call> and the next tag in
+        # TOOL_CALL_PENDING state (restored as content on lookahead failure).
+        self._pending_tool_call_ws: str = ""
+
+        # Semantic context
+        self.tool_call_index: int = 0
+        self._call_id: Optional[str] = None
+        self._function_name: Optional[str] = None
+        self._param_name: Optional[str] = None
+        # Names of parameters whose JSON key+value have already been emitted.
+        self._params_emitted: list[str] = []
+        # True once _start_function() has been called for the current tool call.
+        # Guards _end_tool_call() so it never emits a terminator delta for a
+        # call that never had a function (which would produce name=None/args=''
+        # ghosts when the stream is aborted before the function tag is complete).
+        self._function_ever_started: bool = False
+
+    def parse_single_streaming_chunks(self, chunk: str) -> DeltaMessage:
+        """
+        Feed *chunk* through the parser and return a single merged
+        :class:`DeltaMessage` representing all output produced by this chunk.
+        """
+        initial_count = len(self.deltas)
+
+        for ch in chunk:
+            self._feed(ch)
+
+        # Emit any buffered plain text that has accumulated outside a tool call.
+        if self._state == _State.TEXT and not self._in_tag and self._text_buf:
+            self._emit(DeltaMessage(content=self._text_buf))
+            self._text_buf = ""
+
+        return self._merge_deltas(self.deltas[initial_count:])
+
+    def finalize(self) -> DeltaMessage:
+        """
+        Close any open structural elements and return a delta for remaining
+        output.  Call this once the full model output has been fed in
+        (non-streaming path).
+        """
+        initial_count = len(self.deltas)
+        if self._state == _State.TOOL_CALL_PENDING:
+            self._text_buf += "<tool_call>" + self._pending_tool_call_ws
+            self._pending_tool_call_ws = ""
+            self._state = _State.TEXT
+        if self._param_name is not None:
+            self._end_parameter()
+        if self._function_name is not None:
+            self._end_function()
+        if self._call_id is not None:
+            self._end_tool_call()
+        self._flush_text_as_content()
+        return self._merge_deltas(self.deltas[initial_count:])
+
+    def collect_all(self) -> DeltaMessage:
+        """
+        Return a merged view of every delta emitted so far (read-only).
+
+        Tool calls that never acquired a function name (e.g. streams aborted
+        before the ``<function=…>`` tag was complete) are filtered out so the
+        caller never sees ``name=None / arguments=''`` ghost entries.
+        """
+        result = self._merge_deltas(self.deltas)
+        if result.tool_calls:
+            valid = [tc for tc in result.tool_calls if tc.function and tc.function.name]
+            result = DeltaMessage(
+                content=result.content,
+                tool_calls=valid,
+                reasoning=result.reasoning,
+            )
+        return result
+
+    # ------------------------------------------------------------------
+    # Core character feed
+    # ------------------------------------------------------------------
+
+    def _feed(self, ch: str) -> None:
+        if self._in_tag:
+            self._feed_in_tag(ch)
+        elif self._state == _State.PARAM_VALUE:
+            self._feed_param_value(ch)
+        elif self._state == _State.PARAM_CLOSE_PENDING:
+            self._feed_param_close_pending(ch)
+        elif self._state == _State.TOOL_CALL_PENDING:
+            self._feed_tool_call_pending(ch)
+        else:
+            self._feed_context(ch)
+
+    def _tag_prefix_is_viable(self) -> bool:
+        """Return True if _tag_buf is still a valid prefix of some structural tag.
+
+        Called after each character is appended inside a tag.  When it returns
+        False the caller should flush the buffer immediately rather than waiting
+        for the closing ">".  This avoids long buffering delays for sequences
+        like "<--", "<!", "< ", "<br>", etc. that can never form a structural
+        tag.
+
+        For variable-suffix tags (those whose fixed prefix ends with "=" or " ")
+        any content after the fixed prefix is accepted as part of the name, so
+        once the buffer has grown past the fixed prefix the check always
+        succeeds.
+        """
+        buf = self._tag_buf
+        n = len(buf)
+        if n <= 1:
+            return True
+        for tag in self._STRUCTURAL_TAG_PREFIXES:
+            tlen = len(tag)
+            if n <= tlen:
+                if tag[:n] == buf:
+                    return True
+            else:
+                # buf is longer than the fixed prefix: viable only for
+                # variable-suffix tags where the fixed prefix matches exactly.
+                if buf[:tlen] == tag:
+                    return True
+        return False
+
+    def _feed_in_tag(self, ch: str) -> None:
+        if self._tag_in_quote:
+            # Inside a quoted attribute value: only the matching closing quote
+            # ends this sub-state; everything else (including '<') is literal.
+            self._tag_buf += ch
+            if ch == self._tag_quote_char:
+                self._tag_in_quote = False
+        elif ch == ">":
+            self._tag_buf += ch
+            self._dispatch_tag(self._tag_buf)
+            self._tag_buf = ""
+            self._in_tag = False
+        elif ch == "<":
+            # A new '<' arrived before the current tag was closed.
+            # The buffered content is not a valid tag; absorb it as
+            # contextual text/noise and restart tag accumulation.
+            self._flush_stale_tag_buf()
+            self._tag_buf = "<"
+            # _in_tag stays True; _tag_in_quote is already False
+        elif ch in ('"', "'"):
+            self._tag_buf += ch
+            self._tag_in_quote = True
+            self._tag_quote_char = ch
+        else:
+            self._tag_buf += ch
+            # Early rejection: if this prefix cannot possibly match any
+            # structural tag, flush the buffer now instead of waiting for ">".
+            # Common cases: "<--", "<!", "< ", "<br>", "<a ", etc.
+            if not self._tag_prefix_is_viable():
+                self._flush_stale_tag_buf()
+                self._in_tag = False
+
+    def _feed_param_value(self, ch: str) -> None:
+        if ch == "<":
+            self._tag_buf = "<"
+            self._in_tag = True
+        else:
+            self._param_buf += ch
+
+    def _feed_param_close_pending(self, ch: str) -> None:
+        """Handle a character while waiting for the lookahead after </parameter>."""
+        if ch == "<":
+            self._tag_buf = "<"
+            self._in_tag = True
+        else:
+            # Buffer for potential rollback if the lookahead fails.
+            self._pending_close_ws += ch
+
+    def _feed_tool_call_pending(self, ch: str) -> None:
+        """Handle a character while waiting for the lookahead after <tool_call>."""
+        if ch == "<":
+            self._tag_buf = "<"
+            self._in_tag = True
+        elif ch in " \t\n\r":
+            # Only whitespace is permitted between <tool_call> and the next
+            # structural tag.  Buffer it so we can restore it on lookahead
+            # failure.
+            self._pending_tool_call_ws += ch
+        else:
+            # Non-whitespace before any structural tag: the <tool_call> was
+            # plain text content (e.g. a documentation example).  Roll back
+            # immediately — do not wait for a potential <function=…> later.
+            self._text_buf += "<tool_call>" + self._pending_tool_call_ws + ch
+            self._pending_tool_call_ws = ""
+            self._state = _State.TEXT
+
+    def _feed_context(self, ch: str) -> None:
+        """Handle a character that is outside a tag and outside a param value."""
+        if ch == "<":
+            self._tag_buf = "<"
+            self._in_tag = True
+        elif self._state == _State.TEXT:
+            self._text_buf += ch
+        # In TOOL_CALL / FUNCTION states whitespace between structural tags is
+        # irrelevant; discard it silently.
+
+    # ------------------------------------------------------------------
+    # Tag dispatch
+    # ------------------------------------------------------------------
+
+    def _dispatch_tag(self, tag: str) -> None:
+        stripped = tag.strip()
+        if self._state == _State.PARAM_VALUE:
+            self._dispatch_tag_in_param(stripped, tag)
+        elif self._state == _State.PARAM_CLOSE_PENDING:
+            self._dispatch_tag_after_param_close(stripped, tag)
+        elif self._state == _State.TOOL_CALL_PENDING:
+            self._dispatch_tag_after_tool_call_pending(stripped, tag)
+        else:
+            self._dispatch_structural_tag(stripped, tag)
+
+    def _dispatch_tag_in_param(self, stripped: str, raw: str) -> None:
+        """
+        A complete tag was read while inside a parameter value.
+        Only structural *closing* tags end the value; anything else is literal
+        content (e.g. HTML tags, XML fragments in JSON strings, etc.).
+
+        ``</parameter>`` uses one-tag lookahead: it is only a genuine delimiter
+        when followed by another ``<parameter=…>`` or by ``</function>`` /
+        ``</tool_call>``.  The decision is deferred to
+        ``_dispatch_tag_after_param_close``.
+        """
+        if stripped == "</parameter>":
+            # Defer: wait to see what the next tag is before committing.
+            self._state = _State.PARAM_CLOSE_PENDING
+            self._pending_close_ws = ""
+            return
+        elif stripped == "</function>":
+            self._end_parameter()
+            self._end_function()
+            self._state = _State.TOOL_CALL
+        elif stripped == "</tool_call>":
+            self._end_parameter()
+            self._end_function()
+            self._end_tool_call()
+            self._state = _State.TEXT
+        else:
+            self._param_buf += raw
+
+    def _dispatch_tag_after_param_close(self, stripped: str, raw: str) -> None:
+        """
+        Lookahead handler: called when we see a complete tag after a tentative
+        ``</parameter>``.
+
+        * ``<parameter=…>``  → the ``</parameter>`` was a genuine delimiter;
+          end the current parameter and open the next one.
+        * ``</function>`` / ``</tool_call>`` → also genuine; end parameter and
+          continue the normal structural sequence.
+        * Anything else → the ``</parameter>`` was literal content inside the
+          value; restore it (plus any buffered inter-tag whitespace) and stay
+          in PARAM_VALUE.
+        """
+        pname = self._match_parameter_open(stripped)
+        if pname is not None:
+            self._end_parameter()
+            self._pending_close_ws = ""
+            self._start_parameter(pname)
+            self._state = _State.PARAM_VALUE
+            return
+
+        if stripped == "</function>":
+            self._end_parameter()
+            self._pending_close_ws = ""
+            self._end_function()
+            self._state = _State.TOOL_CALL
+            return
+
+        if stripped == "</tool_call>":
+            self._end_parameter()
+            self._pending_close_ws = ""
+            self._end_function()
+            self._end_tool_call()
+            self._state = _State.TEXT
+            return
+
+        # Lookahead failed: the </parameter> was content, not a delimiter.
+        self._param_buf += "</parameter>" + self._pending_close_ws + raw
+        self._pending_close_ws = ""
+        self._state = _State.PARAM_VALUE
+
+    def _dispatch_tag_after_tool_call_pending(self, stripped: str, raw: str) -> None:
+        """
+        Lookahead handler: called when we see a complete tag after a tentative
+        ``<tool_call>``.
+
+        * ``<function=…>`` → the ``<tool_call>`` was a genuine opener; flush
+          any preceding plain text, start the tool call and the function.
+        * Anything else → the ``<tool_call>`` was literal content (e.g. the
+          model mentioned it in reasoning text); restore it together with the
+          buffered inter-tag chars as plain text and re-dispatch the new tag
+          from TEXT state.
+        """
+        fname = self._match_function_open(stripped)
+        if fname is not None:
+            self._flush_text_as_content()
+            if self._call_id is not None:
+                self._end_tool_call()
+            self._pending_tool_call_ws = ""
+            self._start_tool_call()
+            self._start_function(fname)
+            self._state = _State.FUNCTION
+            return
+
+        # Lookahead failed: the <tool_call> was content, not a tool call opener.
+        self._text_buf += "<tool_call>" + self._pending_tool_call_ws
+        self._pending_tool_call_ws = ""
+        self._state = _State.TEXT
+        self._dispatch_structural_tag(stripped, raw)
+
+    def _dispatch_structural_tag(self, stripped: str, raw: str) -> None:
+        """Dispatch a tag encountered between structural elements."""
+
+        if stripped == "<tool_call>":
+            if self._state == _State.TEXT:
+                # Lookahead: only commit once we see <function=…> next.
+                # Reasoning text often mentions <tool_call> without following
+                # it with a function tag; defer the decision.
+                self._pending_tool_call_ws = ""
+                self._state = _State.TOOL_CALL_PENDING
+            else:
+                # Already inside a structured context (TOOL_CALL or FUNCTION):
+                # a second <tool_call> is a back-to-back call; close the
+                # previous one (if open) and start the new one immediately.
+                self._flush_text_as_content()
+                if self._call_id is not None:
+                    self._end_tool_call()
+                self._start_tool_call()
+                self._state = _State.TOOL_CALL
+            return
+
+        if stripped == "</tool_call>":
+            if self._call_id is None and self._state == _State.TEXT:
+                # Stray </tool_call> with no open call: treat as literal text
+                # (e.g. rolled back from TOOL_CALL_PENDING lookahead failure).
+                self._text_buf += raw
+            else:
+                self._end_tool_call()
+                self._state = _State.TEXT
+            return
+
+        fname = self._match_function_open(stripped)
+        if fname is not None:
+            if self._call_id is None:
+                # <function=…> outside any <tool_call> context: plain text.
+                self._text_buf += raw
+            else:
+                self._start_function(fname)
+                self._state = _State.FUNCTION
+            return
+
+        if stripped == "</function>":
+            self._end_function()
+            self._state = _State.TOOL_CALL
+            return
+
+        pname = self._match_parameter_open(stripped)
+        if pname is not None:
+            if self._call_id is None:
+                # <parameter=…> outside any <tool_call> context: plain text.
+                self._text_buf += raw
+            else:
+                self._start_parameter(pname)
+                self._state = _State.PARAM_VALUE
+            return
+
+        if stripped == "</parameter>":
+            self._end_parameter()
+            self._state = _State.FUNCTION
+            return
+
+        # Unknown tag: treat as plain text when in TEXT state, ignore otherwise.
+        if self._state == _State.TEXT:
+            self._text_buf += raw
+
+    # ------------------------------------------------------------------
+    # Structural element handlers
+    # ------------------------------------------------------------------
+
+    def _start_tool_call(self) -> None:
+        self._call_id = make_tool_call_id()
+        self.tool_call_index += 1
+        self._params_emitted = []
+        self._function_ever_started = False
+
+    def _start_function(self, fname: str) -> None:
+        self._function_name = fname
+        self._function_ever_started = True
+        self._params_emitted = []
+        self._emit(
+            DeltaMessage(
+                tool_calls=[
+                    DeltaToolCall(
+                        index=self.tool_call_index - 1,
+                        id=self._call_id,
+                        type="function",
+                        function=DeltaFunctionCall(name=fname, arguments=""),
+                    )
+                ]
+            )
+        )
+
+    def _start_parameter(self, pname: str) -> None:
+        self._param_name = pname
+        self._param_buf = ""
+        # Emit the JSON key fragment that precedes the value.
+        if not self._params_emitted:
+            key_frag = f'{{"{pname}": '
+        else:
+            key_frag = f', "{pname}": '
+        self._emit(
+            DeltaMessage(
+                tool_calls=[
+                    DeltaToolCall(
+                        index=self.tool_call_index - 1,
+                        id=self._call_id,
+                        type="function",
+                        function=DeltaFunctionCall(name=None, arguments=key_frag),
+                    )
+                ]
+            )
+        )
+
+    def _end_parameter(self) -> None:
+        if self._param_name is None:
+            return
+        raw = self._param_buf
+        # Strip the single leading/trailing newline that the template format
+        # places around parameter values.
+        if raw.startswith("\n"):
+            raw = raw[1:]
+        if raw.endswith("\n"):
+            raw = raw[:-1]
+        param_type = self._get_param_type(self._param_name)
+        json_value = self._raw_to_json(raw, param_type)
+        self._emit(
+            DeltaMessage(
+                tool_calls=[
+                    DeltaToolCall(
+                        index=self.tool_call_index - 1,
+                        id=self._call_id,
+                        type="function",
+                        function=DeltaFunctionCall(name=None, arguments=json_value),
+                    )
+                ]
+            )
+        )
+        self._params_emitted.append(self._param_name)
+        self._param_name = None
+        self._param_buf = ""
+
+    def _end_function(self) -> None:
+        if self._function_name is None:
+            return
+        args = "}" if self._params_emitted else "{}"
+        self._emit(
+            DeltaMessage(
+                tool_calls=[
+                    DeltaToolCall(
+                        index=self.tool_call_index - 1,
+                        id=self._call_id,
+                        type="function",
+                        function=DeltaFunctionCall(name=None, arguments=args),
+                    )
+                ]
+            )
+        )
+        self._function_name = None
+
+    def _end_tool_call(self) -> None:
+        # Ensure any open param/function is cleanly closed first.
+        if self._param_name is not None:
+            self._end_parameter()
+        if self._function_name is not None:
+            self._end_function()
+        # Only emit the terminator delta if a function was actually started.
+        # Skipping it for empty/aborted calls prevents name=None / args=''
+        # ghost tool-call entries from reaching the client.
+        if self._function_ever_started:
+            self._emit(
+                DeltaMessage(
+                    tool_calls=[
+                        DeltaToolCall(
+                            index=self.tool_call_index - 1,
+                            id=self._call_id,
+                            type="function",
+                            function=DeltaFunctionCall(name=None, arguments=""),
+                        )
+                    ]
+                )
+            )
+        self._call_id = None
+        self._function_name = None
+        self._function_ever_started = False
+        self._param_name = None
+        self._param_buf = ""
+        self._params_emitted = []
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _flush_text_as_content(self) -> None:
+        if self._text_buf:
+            self._emit(DeltaMessage(content=self._text_buf))
+            self._text_buf = ""
+
+    def _flush_stale_tag_buf(self) -> None:
+        """
+        A second '<' arrived before the current tag was closed (or the tag
+        could not be parsed).  The buffered partial-tag text is not a valid
+        structural tag; absorb it into the appropriate accumulator.
+        """
+        if self._state == _State.PARAM_VALUE:
+            self._param_buf += self._tag_buf
+        elif self._state == _State.PARAM_CLOSE_PENDING:
+            # The tentative </parameter> was content: restore it along with any
+            # inter-tag whitespace and the stale tag fragment, then stay in
+            # PARAM_VALUE so normal accumulation continues.
+            self._param_buf += "</parameter>" + self._pending_close_ws + self._tag_buf
+            self._pending_close_ws = ""
+            self._state = _State.PARAM_VALUE
+        elif self._state == _State.TOOL_CALL_PENDING:
+            # The tentative <tool_call> was content: restore it along with any
+            # inter-tag whitespace and the stale tag fragment, then return to
+            # TEXT so normal accumulation continues.
+            self._text_buf += "<tool_call>" + self._pending_tool_call_ws + self._tag_buf
+            self._pending_tool_call_ws = ""
+            self._state = _State.TEXT
+        elif self._state == _State.TEXT:
+            self._text_buf += self._tag_buf
+        # In TOOL_CALL / FUNCTION: discard (structural inter-tag noise).
+        self._tag_buf = ""
+        self._tag_in_quote = False
+        self._tag_quote_char = ""
+
+    def _match_function_open(self, stripped: str) -> Optional[str]:
+        m = self._RE_FUNCTION_OPEN.match(stripped)
+        if m:
+            return (m.group(1) or m.group(2) or "").strip()
         return None
 
-    def _extract_parameter_name(self, name: str, attrs: dict[str, str]) -> str | None:
-        """Extract parameter name from various formats"""
-        if attrs and "name" in attrs:
-            return attrs["name"]
-
-        if "=" in name:
-            parts = name.split("=", 1)
-            if len(parts) == 2 and parts[0] == "parameter":
-                return parts[1]
-
+    def _match_parameter_open(self, stripped: str) -> Optional[str]:
+        m = self._RE_PARAMETER_OPEN.match(stripped)
+        if m:
+            return (m.group(1) or m.group(2) or "").strip()
         return None
 
     def _get_param_type(self, param_name: str) -> str:
-        """Get parameter type based on tool configuration, defaults to string
-        Args:
-            param_name: Parameter name
-
-        Returns:
-            Parameter type
-        """
-        if not self.tools or not self.current_function_name:
+        if not self.tools or not self._function_name:
             return "string"
-
-        properties = find_tool_properties(self.tools, self.current_function_name)
-        if param_name in properties and isinstance(properties[param_name], dict):
-            return self.repair_param_type(
-                str(properties[param_name].get("type", "string"))
-            )
+        props = find_tool_properties(self.tools, self._function_name)
+        if param_name in props and isinstance(props[param_name], dict):
+            return self._canonical_type(str(props[param_name].get("type", "string")))
         return "string"
 
-    def repair_param_type(self, param_type: str) -> str:
-        """Repair unknown parameter types by treating them as string
-        Args:
-            param_type: Parameter type
-
-        Returns:
-            Repaired parameter type
-        """
-        if (
-            param_type in ["string", "str", "text", "varchar", "char", "enum"]
-            or param_type.startswith("int")
-            or param_type.startswith("uint")
-            or param_type.startswith("long")
-            or param_type.startswith("short")
-            or param_type.startswith("unsigned")
-            or param_type.startswith("num")
-            or param_type.startswith("float")
-            or param_type in ["boolean", "bool", "binary"]
-            or (
-                param_type in ["object", "array", "arr", "sequence"]
-                or param_type.startswith("dict")
-                or param_type.startswith("list")
-            )
-        ):
-            return param_type
-        else:
+    @staticmethod
+    def _canonical_type(t: str) -> str:
+        t = t.strip().lower()
+        if t in ("string", "str", "text", "varchar", "char", "enum"):
             return "string"
+        if any(t.startswith(p) for p in ("int", "uint", "long", "short", "unsigned")):
+            return "integer"
+        if any(t.startswith(p) for p in ("num", "float")):
+            return "number"
+        if t in ("boolean", "bool", "binary"):
+            return "boolean"
+        if t == "object" or t.startswith("dict"):
+            return "object"
+        if t in ("array", "arr", "sequence") or t.startswith("list"):
+            return "array"
+        return "string"
 
-    def _convert_param_value(self, param_value: str, param_type: str) -> Any:
-        """Convert value based on parameter type
-        Args:
-            param_value: Parameter value
-            param_type: Parameter type
+    def _raw_to_json(self, raw: str, param_type: str) -> str:
+        """Convert a raw (unescaped) parameter value to a JSON value fragment."""
+        if raw.lower() == "null":
+            return "null"
 
-        Returns:
-            Converted value
-        """
-        if param_value.lower() == "null":
-            return None
+        if param_type == "string":
+            return json.dumps(raw, ensure_ascii=False)
 
-        param_type = param_type.strip().lower()
-        if param_type in ["string", "str", "text", "varchar", "char", "enum"]:
-            return param_value
-        elif (
-            param_type.startswith("int")
-            or param_type.startswith("uint")
-            or param_type.startswith("long")
-            or param_type.startswith("short")
-            or param_type.startswith("unsigned")
-        ):
+        if param_type == "integer":
             try:
-                return int(param_value)
+                return str(int(float(raw)))
             except (ValueError, TypeError):
-                logger.warning(
-                    "Parsed value '%s' of parameter '%s' is not an integer "
-                    "in tool '%s', degenerating to string.",
-                    param_value,
-                )
-            return param_value
-        elif param_type.startswith("num") or param_type.startswith("float"):
+                pass
+            return json.dumps(raw, ensure_ascii=False)
+
+        if param_type == "number":
             try:
-                float_param_value: float = float(param_value)
-                return (
-                    float_param_value
-                    if float_param_value - int(float_param_value) != 0
-                    else int(float_param_value)
-                )
+                v = float(raw)
+                return str(int(v)) if v == int(v) else repr(v)
             except (ValueError, TypeError):
-                logger.warning(
-                    "Parsed value '%s' of parameter '%s' is not a float "
-                    "in tool '%s', degenerating to string.",
-                    param_value,
-                )
-            return param_value
-        elif param_type in ["boolean", "bool", "binary"]:
-            param_value = param_value.lower()
-            return param_value == "true"
-        else:
-            return param_value
+                pass
+            return json.dumps(raw, ensure_ascii=False)
 
-    def _convert_for_json_streaming(self, converted_value: Any, param_type: str) -> str:
-        """Convert converted_value based on
-        whether it's empty and if type is string
-        Args:
-            converted_value: Converted value
-            param_type: Parameter type
+        if param_type == "boolean":
+            return "true" if raw.strip().lower() == "true" else "false"
 
-        Returns:
-            Converted string for streaming output
+        if param_type in ("object", "array"):
+            # Try strict JSON first, then ast.literal_eval for Python-style
+            # containers that models sometimes emit ({'key': 'val'} etc.).
+            try:
+                return json.dumps(json.loads(raw), ensure_ascii=False)
+            except (json.JSONDecodeError, ValueError):
+                pass
+            try:
+                return json.dumps(ast.literal_eval(raw), ensure_ascii=False)
+            except Exception:
+                pass
+            return json.dumps(raw, ensure_ascii=False)
+
+        return json.dumps(raw, ensure_ascii=False)
+
+    def _emit(self, delta: DeltaMessage) -> None:
+        self.deltas.append(delta)
+
+    @staticmethod
+    def _merge_deltas(deltas: list[DeltaMessage]) -> DeltaMessage:
         """
-        # Check if value is empty, but exclude numeric 0
-        if converted_value is None or converted_value == "":
-            return ""
+        Merge a list of deltas into a single DeltaMessage.
 
-        if param_type in ["string", "str", "text", "varchar", "char", "enum"]:
-            # String type, remove double quotes
-            return json.dumps(converted_value, ensure_ascii=False)[1:-1]
-        else:
-            # Non-string type, return complete JSON string
-            if not isinstance(converted_value, str):
-                return json.dumps(converted_value, ensure_ascii=False)
-            else:
-                return converted_value
+        Creates new objects rather than mutating the inputs, so it is safe
+        to call multiple times on overlapping delta slices.
 
-    def _reset_xml_parser_after_tool_call(self):
+        The streaming API contract requires that ``id`` and ``type`` are only
+        present on the *first* delta for each tool call (the one that carries
+        the function name).  Subsequent argument-only deltas must have
+        ``id=None`` so the client knows they extend an existing call rather
+        than open a new one.  This method enforces that invariant regardless
+        of how many raw deltas are being merged.
         """
-        Each tool_call is treated as a separate XML document,
-        so we need to reset the parser after each tool_call.
-        """
+        if not deltas:
+            return DeltaMessage(content=None)
 
-        # recreate XML parser
-        self.parser = ParserCreate()
-        self.setup_parser()
+        merged_content = ""
+        # Preserve insertion order while merging per call-id.
+        call_order: list[str] = []
+        call_map: dict[str, dict] = {}
 
-        # Reset current tool_call state
-        if self.current_call_id:
-            self.last_completed_call_id = self.current_call_id
-        self.current_call_id = None
-        self.current_function_name = None
-        self.current_function_open = False
-        self.parameters = {}
-        self.current_param_name = None
-        self.current_param_value = ""
-        self.current_param_value_converted = ""
-        self.current_param_is_first = False
-        self.should_emit_end_newline = False
-        self.start_quote_emitted = False
-        self.text_content_buffer = ""
+        for d in deltas:
+            if d.content:
+                merged_content += d.content
+            if d.tool_calls:
+                for tc in d.tool_calls:
+                    cid = tc.id or ""
+                    if cid not in call_map:
+                        call_map[cid] = {
+                            "index": tc.index,
+                            "type": tc.type or "function",
+                            "name": None,
+                            "args": [],
+                        }
+                        call_order.append(cid)
+                    entry = call_map[cid]
+                    if tc.type:
+                        entry["type"] = tc.type
+                    if tc.index is not None:
+                        entry["index"] = tc.index
+                    if tc.function:
+                        if tc.function.name:
+                            entry["name"] = tc.function.name
+                        if tc.function.arguments is not None:
+                            entry["args"].append(tc.function.arguments)
 
-        # Reset preprocessing and deferred parsing state
-        self._pre_inside_parameter = False
-        self._pre_param_buffer = ""
-        self._pre_current_param_name = None
-        self.defer_current_parameter = False
-        self.deferred_param_raw_value = ""
+        merged_calls = [
+            DeltaToolCall(
+                index=call_map[cid]["index"],
+                # id and type are only emitted on the first delta for a tool
+                # call (the one carrying the function name).  Subsequent
+                # argument-only deltas must have id=None so the streaming
+                # reconstructor knows they extend an existing call rather than
+                # opening a new one.
+                id=cid if call_map[cid]["name"] else None,
+                type=call_map[cid]["type"] if call_map[cid]["name"] else None,
+                function=DeltaFunctionCall(
+                    name=call_map[cid]["name"],
+                    arguments="".join(call_map[cid]["args"]),
+                ),
+            )
+            for cid in call_order
+        ]
+
+        return DeltaMessage(
+            content=merged_content or None,
+            tool_calls=merged_calls,
+        )
 
 
 class Qwen3XMLToolParser(ToolParser):
@@ -1150,7 +827,6 @@ class Qwen3XMLToolParser(ToolParser):
         super().__init__(tokenizer, tools)
         self.parser = StreamingXMLToolCallParser()
 
-        # Add missing attributes for compatibility with serving_chat.py
         self.prev_tool_call_arr: list[dict] = []
         self.streamed_args_for_tool: list[str] = []
 
@@ -1164,64 +840,56 @@ class Qwen3XMLToolParser(ToolParser):
         request: ChatCompletionRequest,
     ) -> ExtractedToolCallInformation:
         self.parser.reset_streaming_state()
-        # Reset tool call tracking arrays for new extraction
         self.prev_tool_call_arr = []
         self.streamed_args_for_tool = []
         self.parser.set_tools(self.tools)
-        result = self.parser.parse_single_streaming_chunks(model_output)
-        if not result.tool_calls:
+
+        # Feed the complete output, then finalize to close any open elements.
+        self.parser.parse_single_streaming_chunks(model_output)
+        self.parser.finalize()
+
+        # Collect the fully merged result.
+        full = self.parser.collect_all()
+
+        if not full.tool_calls:
             return ExtractedToolCallInformation(
                 tool_calls=[],
                 tools_called=False,
-                content=result.content,
+                content=full.content,
             )
-        else:
-            tool_calls = []
-            for tool_call in result.tool_calls:
-                if tool_call.function and tool_call.function.name:
-                    tool_calls.append(
-                        ToolCall(
-                            id=tool_call.id,
-                            type=tool_call.type,
-                            function=FunctionCall(
-                                name=tool_call.function.name,
-                                arguments=tool_call.function.arguments,
-                            ),
-                        )
+
+        tool_calls: list[ToolCall] = []
+        for tc in full.tool_calls:
+            if tc.function and tc.function.name:
+                tool_calls.append(
+                    ToolCall(
+                        id=tc.id,
+                        type=tc.type,
+                        function=FunctionCall(
+                            name=tc.function.name,
+                            arguments=tc.function.arguments or "",
+                        ),
                     )
+                )
+                idx = (
+                    tc.index
+                    if tc.index is not None
+                    else len(self.prev_tool_call_arr) - 1
+                )
+                while len(self.prev_tool_call_arr) <= idx:
+                    self.prev_tool_call_arr.append({"name": "", "arguments": ""})
+                while len(self.streamed_args_for_tool) <= idx:
+                    self.streamed_args_for_tool.append("")
+                self.prev_tool_call_arr[idx]["name"] = tc.function.name
+                self.prev_tool_call_arr[idx]["arguments"] = tc.function.arguments or ""
+                if tc.function.arguments:
+                    self.streamed_args_for_tool[idx] = tc.function.arguments
 
-                    # Update tool call tracking arrays for compatibility
-                    tool_index = (
-                        tool_call.index
-                        if tool_call.index is not None
-                        else len(self.prev_tool_call_arr) - 1
-                    )
-
-                    # Ensure we have enough entries in our tracking arrays
-                    while len(self.prev_tool_call_arr) <= tool_index:
-                        self.prev_tool_call_arr.append({"name": "", "arguments": ""})
-                    while len(self.streamed_args_for_tool) <= tool_index:
-                        self.streamed_args_for_tool.append("")
-
-                    # Update tool call information
-                    self.prev_tool_call_arr[tool_index]["name"] = (
-                        tool_call.function.name
-                    )
-                    self.prev_tool_call_arr[tool_index]["arguments"] = (
-                        tool_call.function.arguments
-                    )
-
-                    # Update streamed arguments
-                    if tool_call.function.arguments:
-                        self.streamed_args_for_tool[tool_index] = (
-                            tool_call.function.arguments
-                        )
-
-            return ExtractedToolCallInformation(
-                tool_calls=tool_calls,
-                tools_called=len(tool_calls) > 0,
-                content=result.content,
-            )
+        return ExtractedToolCallInformation(
+            tool_calls=tool_calls,
+            tools_called=len(tool_calls) > 0,
+            content=full.content,
+        )
 
     def extract_tool_calls_streaming(
         self,
@@ -1235,15 +903,11 @@ class Qwen3XMLToolParser(ToolParser):
     ) -> DeltaMessage | None:
         if not previous_text:
             self.parser.reset_streaming_state()
-            # Reset tool call tracking arrays for new streaming session
             self.prev_tool_call_arr = []
             self.streamed_args_for_tool = []
             self.parser.set_tools(self.tools)
 
-        # Model sometimes outputs separately causing delta_text to be empty.
-        # If there were tool_calls before and all current tool_calls have ended,
-        # return an empty tool_call for outer streaming output
-        # to correctly output tool_call field
+        # Empty delta text but real tokens: detect stream-end conditions.
         if not delta_text and delta_token_ids:
             open_calls = current_text.count(
                 self.parser.tool_call_start_token
@@ -1257,42 +921,28 @@ class Qwen3XMLToolParser(ToolParser):
                 return DeltaMessage(content="")
             return None
 
-        # Parse the delta text and get the result
         delta = self.parser.parse_single_streaming_chunks(delta_text)
 
-        # Update tool call tracking arrays based on incremental parsing results
         if delta and delta.tool_calls:
-            for tool_call in delta.tool_calls:
-                if tool_call.function:
-                    tool_index = (
-                        tool_call.index
-                        if tool_call.index is not None
+            for tc in delta.tool_calls:
+                if tc.function:
+                    idx = (
+                        tc.index
+                        if tc.index is not None
                         else len(self.prev_tool_call_arr) - 1
                     )
-
-                    # Ensure we have enough entries in our tracking arrays
-                    while len(self.prev_tool_call_arr) <= tool_index:
+                    while len(self.prev_tool_call_arr) <= idx:
                         self.prev_tool_call_arr.append({"name": "", "arguments": ""})
-                    while len(self.streamed_args_for_tool) <= tool_index:
+                    while len(self.streamed_args_for_tool) <= idx:
                         self.streamed_args_for_tool.append("")
+                    if tc.function.name:
+                        self.prev_tool_call_arr[idx]["name"] = tc.function.name
+                    if tc.function.arguments is not None:
+                        self.prev_tool_call_arr[idx]["arguments"] += (
+                            tc.function.arguments
+                        )
+                        self.streamed_args_for_tool[idx] += tc.function.arguments
 
-                    # Update tool name if provided
-                    if tool_call.function.name:
-                        self.prev_tool_call_arr[tool_index]["name"] = (
-                            tool_call.function.name
-                        )
-
-                    # Update arguments incrementally
-                    if tool_call.function.arguments is not None:
-                        # Concatenate the incremental arguments
-                        # to the existing streamed arguments
-                        self.prev_tool_call_arr[tool_index]["arguments"] += (
-                            tool_call.function.arguments
-                        )
-                        self.streamed_args_for_tool[tool_index] += (
-                            tool_call.function.arguments
-                        )
         if delta.content is None and not delta.tool_calls and delta.reasoning is None:
-            # If no content and no tool calls, return None to indicate no update
             return None
         return delta


### PR DESCRIPTION
## Purpose

Fix widespread tool-call parsing failures when vLLM serves Qwen3/Qwen3.5 models in streaming mode, and prevent spurious reasoning truncation when the model's thinking text mentions <tool_call> tags (e.g. during agentic code-review sessions).

## Test Plan

Load Qwen/Qwen3.6-27B-FP8 with vLLM and run a somewhat complex agentic session involving tool calls, observe `AI_InvalidResponseDataError: Expected 'function.name' to be a string` errors in OpenCode. 

My test command

```bash
$ cat run.sh 
MODEL=Qwen/Qwen3.6-27B-FP8

export XDG_CACHE_HOME=/data/cache
export HF_HOME=/data/cache/huggingface
export HF_HUB_OFFLINE=1

export NCCL_IB_DISABLE=1

export VLLM_ALLOW_LONG_MAX_MODEL_LEN=1
export VLLM_USE_DEEP_GEMM=0
export VLLM_USE_FLASHINFER_MOE_FP16=1
export VLLM_USE_FLASHINFER_SAMPLER=0
export VLLM_SLEEP_WHEN_IDLE=1

export CUDA_VISIBLE_DEVICES=4,5

./.venv/bin/vllm serve $MODEL \
	--tensor-parallel=2 \
	--trust-remote-code \
	--gpu-memory-utilization 0.92 \
	--max-num-seqs 2 \
	--max-model-len $((162 * 1024)) \
	--served-model-name Qwen3.6-27B \
	--enable-auto-tool-choice \
	--tool-call-parser qwen3_xml \
	--reasoning-parser qwen3 \
	--enable-prefix-caching \
	--attention-backend FLASHINFER \
	--override-generation-config '{"temperature":0.6,"top_p":0.95,"top_k":20,"min_p":0.0,"presence_penalty":0.0,"repetition_penalty":1.0}' \
	--speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":2}' \
	--default-chat-template-kwargs '{"preserve_thinking":true}' \
	--language-model-only \
	--port 8042 \
	"$@"
```

## Test Result

After replacing the tool parser implementation with this code, long agentic coding sessions (120000 tokens+) produce no tool call errors.

## Description

### Commit 1 — Tool parser rewrite

The previous implementation used naive substring matching against incoming delta chunks, a hybrid expat XML parser with heavy preprocessing, and fallback heuristics to detect end-of-tag conditions. This caused widespread failures when the model output arrived in small chunks (the common vLLM streaming case) because the parser assumed chunk boundaries would align with tag boundaries.

**State machine redesign**
- Replaced the expat + substring-matching hybrid with a pure character-level state machine (`TEXT` / `TOOL_CALL_PENDING` / `TOOL_CALL` / `FUNCTION` / `PARAM_VALUE` / `PARAM_CLOSE_PENDING`) that holds no assumptions about chunk boundaries.
- Tags are accumulated one character at a time in `_tag_buf`; `_dispatch_tag` is called only once the closing `>` arrives, regardless of how many chunks the tag was split across.
- Quoted attribute strings (e.g. `<function name="a<b">`) are tracked with a `_tag_in_quote` sub-state so embedded `<` characters do not restart tag accumulation.

**`<tool_call>` lookahead (`TOOL_CALL_PENDING` state)**
- A bare `<tool_call>` in plain text (e.g. the model discussing the format while reviewing code) no longer starts a tool call immediately.
- `<tool_call>` in `TEXT` state transitions to `TOOL_CALL_PENDING`; the parser only commits once the very next structural tag is `<function=…>`. Anything else rolls back `<tool_call>` as literal content, exactly mirroring the `PARAM_CLOSE_PENDING` lookahead for `</parameter>`.
- A stray `</tool_call>` with no open call is also treated as literal text rather than silently dropped.

**`</parameter>` lookahead (`PARAM_CLOSE_PENDING` state)**
- `</parameter>` inside a parameter value is deferred until the next structural tag is seen: `<parameter=…>` / `</function>` / `</tool_call>` confirm it as a genuine delimiter; anything else restores it as content. This prevents truncation of parameter values that contain XML or HTML fragments (e.g. file content written via a write-file tool).

**Mutation-free delta merging**
- `_collect_new_deltas` mutated `DeltaFunctionCall.arguments` in place, causing double-accumulation when called from both `parse_single_streaming_chunks` and `extract_tool_calls`. Replaced with `_merge_deltas` which builds fresh objects; `collect_all()` is now the canonical read path.

**Abort / resync safety**
- Streams aborted before `<function=…>` completed emitted ghost tool calls with `name=None` and `arguments=''`. A `_function_ever_started` flag now guards the terminator delta so nothing is emitted for calls that never acquired a function name.
- `collect_all()` filters out any remaining `name=None` entries as a second line of defence.
- A second `<tool_call>` arriving without a preceding `</tool_call>` now cleanly closes the previous call first.
- `tool_calls` is always a list (never `None`) in returned `DeltaMessage` objects.

**Tests (80+ cases):**
- Fragmentation: every byte-position split within every structural tag
- HTML/XML content: nested tags, attributes with `<`, self-closing, comments
- Tag-lookalike content: partial names, opening structural tags, `<<`, bare `<`
- `<tool_call>` lookahead: fake inline mentions, fake + real sequences, stream-boundary splits, stale-tag rollback, truncated pending state
- Parameter types: integer, float, boolean, object (JSON + Python-style), array, null
- String edge cases: quotes, backslashes, unicode/emoji, empty, multiline
- Multi-param and multi-call scenarios
- Streaming delta reconstruction and content-before-tool-call ordering
- Abort at every possible mid-stream position
- Resync after missing `</tool_call>`, after `reset_streaming_state()`

---

### Commit 2 — Reasoning parser: `<tool_call>` lookahead

When Qwen3.5/3.6 thinks about tool-call syntax in its reasoning text (e.g. reviewing code that contains `<tool_call>` tags), the reasoning parser was treating any bare `<tool_call>` token as an implicit end-of-thinking signal, routing all subsequent reasoning output to the tool parser instead.

Applied the same lookahead heuristic as the tool parser: `<tool_call>` is only treated as an implicit reasoning end when the immediately following tokens (after optional whitespace) decode to a `<function=…>` or `<function name="…">` tag.

- `_tool_call_is_genuine_end()`: decodes an 8-token window after `<tool_call>` and anchors the regex match so an intervening second `<tool_call>` does not produce a false positive.
- `is_reasoning_end()`: adds the genuine-end check after the existing paired-`</tool_call>` filter.
- `is_reasoning_end_streaming()`: materialises `delta_ids` to a set once (fixing a latent double-consume bug on one-pass iterables) then applies the same lookahead.
- `extract_reasoning()` (non-streaming): `<tool_call>` splits reasoning/content only when `<function=…>` follows at the start of the remaining text.
- `extract_reasoning_streaming()`: unchanged — streaming uses immediate detection; the tool parser's `TOOL_CALL_PENDING` state handles any fake `<tool_call>` that leaks through as content.

**Tests:** 5 parametrised cases covering fake inline text, bare tag, paired `<tool_call></tool_call>`, and the two genuine-end syntaxes (`=` and `name="…"`).