### PR TITLE
[Feature] Add --pre-warm-nccl to reduce first-request TTFT on multi-GPU

### DIFF
--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -188,6 +188,13 @@ class ParallelConfig:
     disable_custom_all_reduce: bool = False
     """Disable the custom all-reduce kernel and fall back to NCCL."""
 
+    pre_warm_nccl: bool = False
+    """Pre-warm NCCL/RCCL communicators during startup to reduce P99 TTFT
+    cold-start latency. When enabled, a single all-reduce is executed right
+    after the process group is created so that the first real inference
+    request does not pay the NCCL/RCCL initialization cost. Default: False
+    (enable explicitly via --pre-warm-nccl)."""
+
     enable_elastic_ep: bool = False
     """Enable elastic expert parallelism with stateless NCCL groups for DP/EP."""
 
@@ -704,6 +711,7 @@ class ParallelConfig:
             "nnodes",
             "max_parallel_loading_workers",
             "disable_custom_all_reduce",
+            "pre_warm_nccl",
             "ray_workers_use_nsight",
             "ray_runtime_env",
             "placement_group",

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -520,6 +520,7 @@ class EngineArgs:
     allow_deprecated_quantization: bool = ModelConfig.allow_deprecated_quantization
     enforce_eager: bool = ModelConfig.enforce_eager
     disable_custom_all_reduce: bool = ParallelConfig.disable_custom_all_reduce
+    pre_warm_nccl: bool = ParallelConfig.pre_warm_nccl
     language_model_only: bool = MultiModalConfig.language_model_only
     limit_mm_per_prompt: dict[str, int | dict[str, int]] = get_field(
         MultiModalConfig, "limit_per_prompt"
@@ -1046,6 +1047,10 @@ class EngineArgs:
         parallel_group.add_argument(
             "--disable-custom-all-reduce",
             **parallel_kwargs["disable_custom_all_reduce"],
+        )
+        parallel_group.add_argument(
+            "--pre-warm-nccl",
+            **parallel_kwargs["pre_warm_nccl"],
         )
         parallel_group.add_argument("--worker-cls", **parallel_kwargs["worker_cls"])
         parallel_group.add_argument(
@@ -1887,6 +1892,7 @@ class EngineArgs:
             expert_placement_strategy=self.expert_placement_strategy,
             max_parallel_loading_workers=self.max_parallel_loading_workers,
             disable_custom_all_reduce=self.disable_custom_all_reduce,
+            pre_warm_nccl=self.pre_warm_nccl,
             ray_workers_use_nsight=self.ray_workers_use_nsight,
             ray_runtime_env=ray_runtime_env,
             placement_group=placement_group,

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -4,6 +4,7 @@
 
 import gc
 import os
+import time
 from collections.abc import Callable
 from contextlib import AbstractContextManager, nullcontext
 from datetime import timedelta
@@ -267,6 +268,33 @@ class Worker(WorkerBase):
                 self.local_rank,
                 current_platform.dist_backend,
             )
+
+            # Pre-warm NCCL/RCCL to eliminate cold-start latency in
+            # the first request.  Controlled by --pre-warm-nccl flag.
+            if (
+                self.parallel_config.pre_warm_nccl
+                and (
+                    self.parallel_config.tensor_parallel_size > 1
+                    or self.parallel_config.pipeline_parallel_size > 1
+                )
+            ):
+                import torch.distributed as dist
+
+                warmup_start = time.perf_counter()
+                tp_group = get_tp_group().device_group
+                warmup_tensor = torch.zeros(
+                    1, device=self.device
+                )
+                dist.all_reduce(warmup_tensor, group=tp_group)
+                torch.cuda.synchronize()
+                warmup_elapsed = time.perf_counter() - warmup_start
+                logger.info(
+                    "NCCL/RCCL warmup completed in %.3fs "
+                    "(tp_size=%d, pp_size=%d)",
+                    warmup_elapsed,
+                    self.parallel_config.tensor_parallel_size,
+                    self.parallel_config.pipeline_parallel_size,
+                )
 
             if self.use_v2_model_runner:
                 logger.info_once("Using V2 Model Runner")


### PR DESCRIPTION
# [Feature] Add --pre-warm-nccl to reduce first-request TTFT on multi-GPU

## Purpose

With TP or PP enabled, the first inference request pays a one-time NCCL communicator init cost (~600ms on H200). This adds a `--pre-warm-nccl` flag that does a dummy all-reduce on the TP group during worker startup so the first real request doesn't eat that penalty.

Opt-in, default off. Skipped when tp=1 and pp=1 (no NCCL group).

## Test Plan

8x H200, Qwen2.5-1.5B-Instruct, TP=2, enforce-eager.

Server with pre-warm:
```
CUDA_VISIBLE_DEVICES=0,1 python -m vllm.entrypoints.openai.api_server \
  --model Qwen/Qwen2.5-1.5B-Instruct \
  --tensor-parallel-size 2 --port 8100 \
  --gpu-memory-utilization 0.4 --max-model-len 2048 \
  --enforce-eager --pre-warm-nccl
```

Baseline (different GPUs to isolate):
```
CUDA_VISIBLE_DEVICES=2,3 python -m vllm.entrypoints.openai.api_server \
  --model Qwen/Qwen2.5-1.5B-Instruct \
  --tensor-parallel-size 2 --port 8101 \
  --gpu-memory-utilization 0.4 --max-model-len 2048 \
  --enforce-eager
```

Measure first-token latency via streaming completions:
```
curl -s http://localhost:8100/v1/completions \
  -H "Content-Type: application/json" \
  -d '{"model":"Qwen/Qwen2.5-1.5B-Instruct","prompt":"Hello, how are you today?","max_tokens":10,"temperature":0,"stream":true}'
```

Checked: flag accepted in non-default args log, both workers print warmup timing, inference output correct, no regression without the flag.

## Test Result

First-request TTFT (cold start, averaged over 3 restarts):

```
                        1st req     2nd req     warm avg
--pre-warm-nccl          96 ms       24 ms        23 ms
baseline                704 ms       24 ms        22 ms
```

86% reduction on first request. Subsequent requests identical — confirms this is purely NCCL init overhead moved to startup.
