### PR TITLE
Bugfix: fix RMSNormGated input_guard torch.compile dynamo tracing on CUDA

### DIFF
--- a/vllm/model_executor/layers/fla/ops/utils.py
+++ b/vllm/model_executor/layers/fla/ops/utils.py
@@ -18,6 +18,7 @@ from typing import Any, Literal
 import torch
 
 from vllm.platforms import current_platform
+from vllm.platforms.interface import get_device_context
 from vllm.triton_utils import triton
 
 logger = logging.getLogger(__name__)
@@ -107,7 +108,7 @@ def input_guard(fn: Callable[..., torch.Tensor]) -> Callable[..., torch.Tensor]:
                     break
 
         if tensor is not None:
-            ctx = torch.accelerator.device_index(tensor.device.index)
+            ctx = get_device_context(tensor.device)
         else:
             ctx = contextlib.nullcontext()
 

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -58,6 +58,17 @@ def get_assigned_physical_gpu_ids() -> list[int] | None:
     return _assigned_physical_gpu_ids
 
 
+def get_device_context(
+    device: torch.device,
+) -> contextlib.AbstractContextManager[Any]:
+    if device.type == "cuda":
+        # torch.accelerator.device_index is generally preferred, but it
+        # will cause a torch.compile Dynamo break issue.
+        # see https://github.com/pytorch/pytorch/issues/181540
+        return torch.cuda.device(device.index)
+    return torch.accelerator.device_index(device.index)
+
+
 @functools.cache
 def in_wsl() -> bool:
     # Reference: https://github.com/microsoft/WSL/issues/4071


### PR DESCRIPTION



## Purpose

This PR  fixes  #40919  a startup dynamo failure when serving Qwen3.5

`vllm/model_executor/layers/fla/ops/utils.py::input_guard` currently uses:

```python
torch.accelerator.device_index(tensor.device.index)
```

On PyTorch 2.11, Dynamo cannot trace `device_index.__init__` in fullgraph mode, causing engine initialization to fail during the profiling run.

The fix keeps the generic accelerator path for non-CUDA devices (like tpu), but uses the original CUDA-specific context manager for CUDA tensors.
