### PR TITLE
opt: merge_attn_states_kernel reuse scale via shared memory

### DIFF
--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -38,6 +38,12 @@ __global__ void merge_attn_states_kernel(
 
   if (global_idx >= token_head_threads) return;
 
+  // shared memory config
+  const uint heads_per_block = NUM_THREADS / threads_per_head;
+  extern __shared__ float shmem[];
+  float* p_lse_smem = shmem;
+  float* s_lse_smem = shmem + heads_per_block;
+
   // global_idx -> token_idx + head_idx + pack_idx
   const uint token_head_idx = global_idx / threads_per_head;
   const uint pack_idx = global_idx % threads_per_head;
@@ -53,6 +59,16 @@ __global__ void merge_attn_states_kernel(
   const scalar_t* prefix_head_ptr = prefix_output + src_head_offset;
   const scalar_t* suffix_head_ptr = suffix_output + src_head_offset;
   output_t* output_head_ptr = output + dst_head_offset;
+
+  // store p_lse and s_lse into shared memory
+  if (pack_idx == 0)
+  {
+    float p_lse = prefix_lse[head_idx * num_tokens + token_idx];
+    float s_lse = suffix_lse[head_idx * num_tokens + token_idx];
+    p_lse_smem[head_idx % heads_per_block] = p_lse;
+    s_lse_smem[head_idx % heads_per_block] = s_lse;
+  }
+  __syncthreads();
 
   // Pre-invert scale: multiplication is faster than division
   float fp8_scale_inv = 1.0f;
@@ -84,15 +100,14 @@ __global__ void merge_attn_states_kernel(
       }
     }
     if (output_lse != nullptr && pack_idx == 0) {
-      float s_lse = suffix_lse[head_idx * num_tokens + token_idx];
-      output_lse[head_idx * num_tokens + token_idx] = s_lse;
+      output_lse[head_idx * num_tokens + token_idx] = s_lse_smem[head_idx % heads_per_block];   // load from shared memory
     }
     return;
   }
 
   // For tokens within prefix range, merge prefix and suffix
-  float p_lse = prefix_lse[head_idx * num_tokens + token_idx];
-  float s_lse = suffix_lse[head_idx * num_tokens + token_idx];
+  float p_lse = p_lse_smem[head_idx % heads_per_block];        // load p_lse from shared memory
+  float s_lse = s_lse_smem[head_idx % heads_per_block];        // load s_lse from shared memory
   p_lse = std::isinf(p_lse) ? -std::numeric_limits<float>::infinity() : p_lse;
   s_lse = std::isinf(s_lse) ? -std::numeric_limits<float>::infinity() : s_lse;
 
@@ -212,9 +227,11 @@ __global__ void merge_attn_states_kernel(
 #define LAUNCH_MERGE_ATTN_STATES(scalar_t, output_t, NUM_THREADS,           \
                                  USE_FP8_OUTPUT)                            \
   {                                                                         \
+    const uint heads_per_block = NUM_THREADS / threads_per_head;            \
+    const size_t smem_size = sizeof(float) * heads_per_block * 2;           \
     vllm::merge_attn_states_kernel<scalar_t, output_t, NUM_THREADS,         \
                                    USE_FP8_OUTPUT>                          \
-        <<<grid, block, 0, stream>>>(                                       \
+        <<<grid, block, smem_size, stream>>>(                               \
             reinterpret_cast<output_t*>(output.data_ptr()), output_lse_ptr, \
             reinterpret_cast<scalar_t*>(prefix_output.data_ptr()),          \
             reinterpret_cast<float*>(prefix_lse.data_ptr()),                \


### PR DESCRIPTION
This optimization builds on the work in #16173 , further improving SM efficiency.
This PR optimizes the `merge_attn_states_kernel` by using shared memory to avoid redundant global memory reads. Previously, every thread repeatedly read `p_lse` and `s_lse` from global memory, causing duplicated memory access. Now, we only load these values once per head (via the `pack_idx == 0` thread) and store them into shared memory. All other threads directly reuse the shared memory values for subsequent computation.

## Analysis
NUM_TOKENS = 4096, NUM_HEADS=32, HEAD_SIZE=128. Use Nsight Compute for analysis.

<img width="1694" height="718" alt="image" src="https://github.com/user-attachments/assets/b2be7fcb-e04a-4670-9f9b-e0a28f793966" />

Profiler results show:
- **SM Throughput increased by +26.66%** (from ~16.7% to 21.31%)
- **L1/TEX Cache Throughput** improved by +4.13%

## Test Result
#### Accuracy
```
NUM_TOKENS:4096, NUM_HEADS:64, HEAD_SIZE:256, input_dtype: torch.float32, Device: NVIDIA GeForce RTX 2080 Ti
----------------------------------------------------------------------------------------------------
Output diff, max abs diff:
(Triton vs Torch) : 9.5367431640625e-07
  (CUDA vs Torch) : 4.76837158203125e-07
  (CUDA vs Triton): 9.5367431640625e-07
  (Shared_mem CUDA vs CUDA): 0.0
  (Shared_mem CUDA vs Torch): 4.76837158203125e-07
----------------------------------------------------------------------------------------------------
Output LSE all match, max abs diff:
(Triton vs Torch) : 2.384185791015625e-07
  (CUDA vs Torch) : 0.0
  (CUDA vs Triton): 2.384185791015625e-07
  (Shared_mem CUDA vs CUDA): 0.0
  (Shared_mem CUDA vs CUDA): 0.0
```
#### Performance
| tokens | heads | headsize | dtype | device | torch(ms) | triton(ms) | cuda(ms) | Shared_mem cuda(ms) | cuda / Shared_mem cuda |
|--------|-------|----------|-------|--------|-----------|------------|----------|---------------------|------------------------|
| 1024   | 16    | 48       | float32 | RTX 2080 Ti | 0.16547 | 0.07637 | 0.02452 | 0.02460 | 0.9968x |
| 1536   | 16    | 48       | float32 | RTX 2080 Ti | 0.19390 | 0.09238 | 0.03422 | 0.03399 | 1.0068x |
| 4096   | 16    | 48       | float32 | RTX 2080 Ti | 0.29632 | 0.17606 | 0.07799 | 0.07790 | 1.0012x |
| 1024   | 32    | 128      | float32 | RTX 2080 Ti | 0.35196 | 0.14303 | 0.10017 | 0.09995 | 1.0022x |
| 1536   | 32    | 128      | float32 | RTX 2080 Ti | 0.45940 | 0.18982 | 0.14716 | 0.14620 | 1.0065x |
| 4096   | 32    | 128      | float32 | RTX 2080 Ti | 1.00560 | 0.43427 | 0.37759 | 0.37769 | 0.9997x |
| 1024   | 64    | 256      | float32 | RTX 2080 Ti | 1.00748 | 0.41372 | 0.37620 | 0.37588 | 1.0008x |
| 1536   | 64    | 256      | float32 | RTX 2080 Ti | 1.44618 | 0.59751 | 0.55964 | 0.55937 | 1.0005x |
| 4096   | 64    | 256      | float32 | RTX 2080 Ti | 3.61053 | 1.52362 | 1.47949 | 1.47952 | 1.0000x |

Benchmarks are evaluated on a single RTX 2080 Ti with various token lengths, head counts and head dimensions. From the latency results across all configurations, the shared memory optimized version shows almost identical performance to the original CUDA kernel, with performance ratios staying within 0.9968x ~ 1.0068x. There is no performance regression, and slight latency improvement can be observed in most cases. Due to the optimization that reduces redundant global memory accesses and improves on-chip resource utilization, there may be different performance variations across different hardware platforms.


