### PR TITLE
[Kernel] Tune default fp8 block-scaled Triton config for M<=8 decode

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -889,13 +889,26 @@ def w8a8_triton_block_scaled_mm(
         # Default config
         # Block-wise quant: BLOCK_SIZE_N must be divisible by block_size[0]
         # BLOCK_SIZE_K must be divisible by block_size[1]
+        # M-aware tuning for low-M decode: the previous default of
+        # BLOCK_SIZE_M=64 wastes 98% of the M-dim for single-request decode
+        # (M=1) and short MTP-style draft batches. Specialize only the M<=8
+        # case to keep blast radius small; larger M keeps the previous default.
+        # num_stages=3 is gated to non-ROCm because MI300/MI250X LDS (64 KB)
+        # is borderline for 3-stage Triton pipelining at typical [128,128]
+        # block sizes; on ROCm we keep num_stages=2 so the M<=8 branch still
+        # gets the BLOCK_SIZE_M=16 wave-quantisation win without LDS pressure.
+        if M <= 8:
+            block_m = 16
+            num_stages = 2 if current_platform.is_rocm() else 3
+        else:
+            block_m, num_stages = 64, 2
         config = {
-            "BLOCK_SIZE_M": 64,
+            "BLOCK_SIZE_M": block_m,
             "BLOCK_SIZE_N": block_size[0],
             "BLOCK_SIZE_K": block_size[1],
             "GROUP_SIZE_M": 32,
             "num_warps": 4,
-            "num_stages": 2,
+            "num_stages": num_stages,
         }
 
     def grid(META):


### PR DESCRIPTION
## Purpose

`w8a8_triton_block_scaled_mm` falls back to a hardcoded default config when no pre-tuned `configs/N=*,K=*,device_name=*.json` file matches the GPU. The default uses `BLOCK_SIZE_M=64`, which wastes 98% of the M dimension for single-request decode (M=1). GPUs without a pre-tuned JSON for their (N, K) tuple pay this cost.

This PR specializes only the **M ≤ 8** branch (single-request decode and short MTP-style draft batches) to use `BLOCK_SIZE_M=16, num_stages=3`. **Larger M is unchanged** to keep blast radius small.

| M range | BLOCK_SIZE_M | num_stages |
|---|---|---|
| `M <= 8` | 16 | 3 (new) |
| else | 64 (unchanged) | 2 (unchanged) |

Pre-tuned JSON configs are unaffected — they short-circuit before this branch. Workloads that already have a tuned JSON for their `(N, K, device)` keep the exact same kernel as before.

## Test Plan

1. On a host without a pre-tuned JSON for the (N, K, device) of the model under test, run single-request fp8 block-scaled decode at M=1.
2. Measure median tokens/sec over a steady-state window.
3. Verify output text is coherent.
4. Confirm no behavioral change for prefill (large M) or for hosts with a pre-tuned JSON.

## Test Result

**Hardware:** dual DGX Spark (GB10, sm_121), TP=2. **Model:** DeepSeek-V4-Flash. **Mode:** single request, decode-dominated.

| | Before (BLOCK_SIZE_M=64 default) | After (M ≤ 8 specialised) |
|---|---|---|
| Median decode throughput | 5.45 t/s | **6.73 t/s** |
| Speedup | — | **+23%** |
| Output coherence | OK | OK |

Run config: `--moe-backend marlin --kv-cache-dtype fp8_ds_mla --gpu-memory-utilization 0.88 --load-format instanttensor`, max_tokens=80, temperature=0, 5 warm runs, statistical median.

**No-regression check:** for M ≥ 9 the patch falls into the existing `else` branch with `BLOCK_SIZE_M=64, num_stages=2`, matching the prior default exactly. For hosts with a tuned JSON, the `if configs:` branch fires and this code path is never reached.

## Notes

- **Scope deliberately narrow**: only `M <= 8` is changed. M > 8 keeps the previous default. This is intentionally smaller than my first internal draft (which also added an M ≤ 32 branch) to minimise risk on archs where I don't have a way to verify (Hopper / Ampere / Datacenter Blackwell).
- **Cross-arch claim is honest**: the win is measured **only on GB10 (sm_121)**. The 98%-of-M-dim waste argument generalises (any decoder with M=1 single-request load lacking a tuned JSON), but I cannot verify on Hopper/Ampere from this hardware. **Reviewers on those archs are welcome to push back or confirm.** If a regression is found on a specific arch, narrowing to `if capability_family == 12` is straightforward.
- **num_stages=3** for the M ≤ 8 branch is the local optimum from a short autotune sweep on GB10. On Hopper, num_stages can interact with shared-mem occupancy. If this regresses, the safe fallback is to keep num_stages=2 in the M ≤ 8 branch (BLOCK_M=16 alone still recovers most of the win).
- Conservative: I deliberately do **not** change `BLOCK_SIZE_N`, `BLOCK_SIZE_K`, `GROUP_SIZE_M`, or `num_warps`, because changing them has second-order effects that vary by arch.

## Related

- Refs #40860 (ivanium V4 Rebased) — orthogonal scope
- Refs #40899 (jasl ds4-sm120) — orthogonal scope; that PR fixes SM 12.x kernel selection, this PR is a generic decode-config improvement
- Per-arch tuned JSONs are the right long-term answer — those still belong in `configs/N=*,K=*,device_name=*.json` files, not in this default branch.

## Checklist

- [x] Tested on real hardware (GB10 / DGX Spark, sm_121, TP=2)
- [x] No change for `M > 8` (existing default preserved)
- [x] No change when a tuned JSON config is present (short-circuited above)
- [x] Commit signed-off (DCO)
- [ ] Pre-commit lint run locally (`pre-commit run --files vllm/model_executor/layers/quantization/utils/fp8_utils.py`)
- [ ] CI passes (will be confirmed once submitted; pending `ready` label from maintainer per first-time-contributor gate)
