### PR TITLE
feat: merge_attn_state fuses per-group fp8

### DIFF
--- a/benchmarks/fused_kernels/merge_attn_states_benchmarks.py
+++ b/benchmarks/fused_kernels/merge_attn_states_benchmarks.py
@@ -10,10 +10,17 @@ attention output:
   3. Unfused CUDA   -- CUDA merge + torch.compiled FP8 quant
   4. Unfused Triton  -- Triton merge + torch.compiled FP8 quant
 
-Usage:
-    python benchmarks/fused_kernels/merge_attn_states_benchmarks.py
-    python benchmarks/fused_kernels/merge_attn_states_benchmarks.py --tp 1 4 8
-    python benchmarks/fused_kernels/merge_attn_states_benchmarks.py --dtype bfloat16
+Quant modes (selected via --quant-mode):
+  * static    : per-tensor static FP8 (default)
+  * group128  : per-token-per-group FP8 with group_size=128
+  * group64   : per-token-per-group FP8 with group_size=64
+
+Usage (script = benchmarks/fused_kernels/merge_attn_states_benchmarks.py):
+    python <script>
+    python <script> --tp 1 4 8
+    python <script> --dtype bfloat16
+    python <script> --quant-mode group128
+    python <script> --quant-mode group128 --ue8m0
 """
 
 import argparse
@@ -24,6 +31,9 @@ import torch
 from vllm._custom_ops import merge_attn_states as merge_attn_states_cuda
 from vllm.benchmarks.lib.utils import default_vllm_config
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    per_token_group_quant_fp8,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
 from vllm.platforms import current_platform
 from vllm.triton_utils import triton
@@ -50,6 +60,8 @@ INPUT_DTYPES = [torch.float32, torch.float16, torch.bfloat16]
 
 QUANTILES = [0.5, 0.2, 0.8]
 
+QUANT_MODES = ["static", "group128", "group64"]
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -58,6 +70,17 @@ QUANTILES = [0.5, 0.2, 0.8]
 
 def short_dtype(dtype: torch.dtype) -> str:
     return str(dtype).removeprefix("torch.")
+
+
+def quant_mode_group_size(mode: str) -> int | None:
+    """Return the group size for a group-FP8 mode, or None for static."""
+    if mode == "group128":
+        return 128
+    if mode == "group64":
+        return 64
+    if mode == "static":
+        return None
+    raise ValueError(f"unknown quant mode: {mode}")
 
 
 def make_inputs(
@@ -81,6 +104,14 @@ def make_inputs(
     mask2 = torch.rand(num_heads, num_tokens, device="cuda") < 0.05
     suffix_lse[mask2] = float("inf")
     return prefix_output, suffix_output, prefix_lse, suffix_lse
+
+
+def alloc_group_fp8_sf(
+    num_tokens: int, num_heads: int, head_size: int, group_size: int
+) -> torch.Tensor:
+    """Allocate a row-major SF tensor compatible with per_token_group_quant_fp8."""
+    num_groups = num_heads * head_size // group_size
+    return torch.empty((num_tokens, num_groups), dtype=torch.float32, device="cuda")
 
 
 def build_configs(head_configs, num_tokens_list, input_dtypes, tp_sizes):
@@ -122,6 +153,19 @@ def parse_args():
         help="Input dtypes (e.g. bfloat16 float16 float32). "
         f"Default: {[short_dtype(d) for d in INPUT_DTYPES]}",
     )
+    parser.add_argument(
+        "--quant-mode",
+        type=str,
+        choices=QUANT_MODES,
+        default="static",
+        help="Output quant mode (default: static)",
+    )
+    parser.add_argument(
+        "--ue8m0",
+        action="store_true",
+        help="Round per-group FP8 scales to power-of-2 (UE8M0). "
+        "Only used when --quant-mode is group128 or group64.",
+    )
     return parser.parse_args()
 
 
@@ -143,6 +187,10 @@ else:
 
 configs = build_configs(HEAD_CONFIGS, num_tokens_list, input_dtypes, tp_sizes)
 
+quant_mode: str = args.quant_mode
+group_size: int | None = quant_mode_group_size(quant_mode)
+ue8m0: bool = args.ue8m0
+
 torch._dynamo.config.recompile_limit = 8888
 
 
@@ -160,7 +208,7 @@ torch._dynamo.config.recompile_limit = 8888
         line_names=["Fused CUDA", "Fused Triton", "Unfused CUDA", "Unfused Triton"],
         styles=[("blue", "-"), ("green", "-"), ("blue", "--"), ("green", "--")],
         ylabel="us",
-        plot_name="merge_attn_states FP8 (fused vs unfused)",
+        plot_name=f"merge_attn_states FP8 ({quant_mode}, fused vs unfused)",
         args={},
     )
 )
@@ -171,13 +219,66 @@ def benchmark(num_tokens, num_heads, head_size, dtype_str, provider):
     prefix_out, suffix_out, prefix_lse, suffix_lse = make_inputs(
         num_tokens, num_heads, head_size, input_dtype
     )
+
+    # Skip cases where head_size isn't a multiple of group_size — the kernel
+    # rejects these on the host side, so reporting them in the benchmark is
+    # misleading.
+    if group_size is not None and head_size % group_size != 0:
+        return float("nan"), float("nan"), float("nan")
+
+    if quant_mode == "static":
+        fn = _build_static_fp8_fn(
+            provider,
+            num_tokens,
+            num_heads,
+            head_size,
+            input_dtype,
+            fp8_dtype,
+            prefix_out,
+            suffix_out,
+            prefix_lse,
+            suffix_lse,
+        )
+    else:
+        assert group_size is not None
+        fn = _build_group_fp8_fn(
+            provider,
+            num_tokens,
+            num_heads,
+            head_size,
+            input_dtype,
+            fp8_dtype,
+            group_size,
+            ue8m0,
+            prefix_out,
+            suffix_out,
+            prefix_lse,
+            suffix_lse,
+        )
+
+    ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(fn, quantiles=QUANTILES)
+    return 1000 * ms, 1000 * max_ms, 1000 * min_ms  # us
+
+
+def _build_static_fp8_fn(
+    provider,
+    num_tokens,
+    num_heads,
+    head_size,
+    input_dtype,
+    fp8_dtype,
+    prefix_out,
+    suffix_out,
+    prefix_lse,
+    suffix_lse,
+):
     output_scale = torch.tensor([0.1], dtype=torch.float32, device="cuda")
 
     if provider == "fused_cuda":
         output = torch.empty(
             (num_tokens, num_heads, head_size), dtype=fp8_dtype, device="cuda"
         )
-        fn = lambda: merge_attn_states_cuda(
+        return lambda: merge_attn_states_cuda(
             output,
             prefix_out,
             prefix_lse,
@@ -185,11 +286,11 @@ def benchmark(num_tokens, num_heads, head_size, dtype_str, provider):
             suffix_lse,
             output_scale=output_scale,
         )
-    elif provider == "fused_triton":
+    if provider == "fused_triton":
         output = torch.empty(
             (num_tokens, num_heads, head_size), dtype=fp8_dtype, device="cuda"
         )
-        fn = lambda: merge_attn_states_triton(
+        return lambda: merge_attn_states_triton(
             output,
             prefix_out,
             prefix_lse,
@@ -197,51 +298,101 @@ def benchmark(num_tokens, num_heads, head_size, dtype_str, provider):
             suffix_lse,
             output_scale=output_scale,
         )
-    elif provider == "unfused_cuda":
-        merge_buf = torch.empty(
-            (num_tokens, num_heads, head_size), dtype=input_dtype, device="cuda"
+
+    # Unfused paths: merge → bf16, then a torch.compiled FP8 quant kernel.
+    merge_buf = torch.empty(
+        (num_tokens, num_heads, head_size), dtype=input_dtype, device="cuda"
+    )
+    quant_fp8 = QuantFP8(
+        static=True,
+        group_shape=GroupShape.PER_TENSOR,
+        column_major_scales=False,
+    )
+    quant_input = merge_buf.view(-1, head_size)
+    compiled_quant = torch.compile(
+        quant_fp8.forward_native, fullgraph=True, dynamic=False
+    )
+    merge = (
+        merge_attn_states_cuda
+        if provider == "unfused_cuda"
+        else merge_attn_states_triton
+    )
+
+    def unfused_fn():
+        merge(merge_buf, prefix_out, prefix_lse, suffix_out, suffix_lse)
+        compiled_quant(quant_input, output_scale)
+
+    return unfused_fn
+
+
+def _build_group_fp8_fn(
+    provider,
+    num_tokens,
+    num_heads,
+    head_size,
+    input_dtype,
+    fp8_dtype,
+    group_size,
+    ue8m0,
+    prefix_out,
+    suffix_out,
+    prefix_lse,
+    suffix_lse,
+):
+    if provider == "fused_cuda":
+        output = torch.empty(
+            (num_tokens, num_heads, head_size), dtype=fp8_dtype, device="cuda"
         )
-        quant_fp8 = QuantFP8(
-            static=True,
-            group_shape=GroupShape.PER_TENSOR,
-            column_major_scales=False,
+        sf = alloc_group_fp8_sf(num_tokens, num_heads, head_size, group_size)
+        return lambda: merge_attn_states_cuda(
+            output,
+            prefix_out,
+            prefix_lse,
+            suffix_out,
+            suffix_lse,
+            output_block_scale=sf,
+            quant_group_size=group_size,
+            quant_scale_ue8m0=ue8m0,
         )
-        quant_input = merge_buf.view(-1, head_size)
-        compiled_quant = torch.compile(
-            quant_fp8.forward_native, fullgraph=True, dynamic=False
+    if provider == "fused_triton":
+        output = torch.empty(
+            (num_tokens, num_heads, head_size), dtype=fp8_dtype, device="cuda"
+        )
+        sf = alloc_group_fp8_sf(num_tokens, num_heads, head_size, group_size)
+        return lambda: merge_attn_states_triton(
+            output,
+            prefix_out,
+            prefix_lse,
+            suffix_out,
+            suffix_lse,
+            output_block_scale=sf,
+            quant_group_size=group_size,
+            quant_scale_ue8m0=ue8m0,
         )
 
-        def unfused_fn():
-            merge_attn_states_cuda(
-                merge_buf, prefix_out, prefix_lse, suffix_out, suffix_lse
-            )
-            compiled_quant(quant_input, output_scale)
+    # Unfused paths: merge → bf16, then per_token_group_quant_fp8.
+    merge_buf = torch.empty(
+        (num_tokens, num_heads, head_size), dtype=input_dtype, device="cuda"
+    )
+    quant_input = merge_buf.view(num_tokens, num_heads * head_size)
+    quant_out = torch.empty_like(quant_input, dtype=fp8_dtype)
+    merge = (
+        merge_attn_states_cuda
+        if provider == "unfused_cuda"
+        else merge_attn_states_triton
+    )
 
-        fn = unfused_fn
-    else:  # unfused_triton
-        merge_buf = torch.empty(
-            (num_tokens, num_heads, head_size), dtype=input_dtype, device="cuda"
+    def unfused_fn():
+        merge(merge_buf, prefix_out, prefix_lse, suffix_out, suffix_lse)
+        per_token_group_quant_fp8(
+            quant_input,
+            group_size,
+            dtype=fp8_dtype,
+            use_ue8m0=ue8m0,
+            out_q=quant_out,
         )
-        quant_fp8 = QuantFP8(
-            static=True,
-            group_shape=GroupShape.PER_TENSOR,
-            column_major_scales=False,
-        )
-        quant_input = merge_buf.view(-1, head_size)
-        compiled_quant = torch.compile(
-            quant_fp8.forward_native, fullgraph=True, dynamic=False
-        )
 
-        def unfused_fn():
-            merge_attn_states_triton(
-                merge_buf, prefix_out, prefix_lse, suffix_out, suffix_lse
-            )
-            compiled_quant(quant_input, output_scale)
-
-        fn = unfused_fn
-
-    ms, min_ms, max_ms = triton.testing.do_bench_cudagraph(fn, quantiles=QUANTILES)
-    return 1000 * ms, 1000 * max_ms, 1000 * min_ms  # us
+    return unfused_fn
 
 
 # ---------------------------------------------------------------------------
@@ -256,6 +407,7 @@ def main():
     print(f"TP sizes: {tp_sizes}")
     print(f"Input dtypes: {[short_dtype(d) for d in input_dtypes]}")
     print(f"Head configs: {[(c[0], c[1], c[2]) for c in HEAD_CONFIGS]}")
+    print(f"Quant mode: {quant_mode}" + (" (UE8M0)" if ue8m0 else ""))
     benchmark.run(print_data=True)
 
 

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -3,6 +3,7 @@
 #include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <algorithm>
+#include <cstdint>
 #include <limits>
 
 #include "attention_dtypes.h"
@@ -191,6 +192,161 @@ __global__ void merge_attn_states_kernel(
   }
 }
 
+// Per-token-per-group FP8 merge kernel.
+//
+// Each thread handles `pack_size` elements (= 16 / sizeof(scalar_t), e.g. 8 for
+// bf16) and `THREADS_PER_GROUP = GROUP_SIZE / pack_size` threads cooperate to
+// quantize one group. Threads within a group share an absmax via warp shuffle,
+// the lowest-id thread in the group writes the FP8 scale into
+// output_block_scale (using caller-provided strides so any of row-major /
+// col-major / TMA-aligned layouts work), and every thread writes its own
+// quantized FP8 pack.
+template <typename scalar_t, typename fp8_t, const uint NUM_THREADS,
+          const int GROUP_SIZE, bool USE_UE8M0>
+__global__ void merge_attn_states_group_fp8_kernel(
+    fp8_t* output, float* output_lse, const scalar_t* prefix_output,
+    const float* prefix_lse, const scalar_t* suffix_output,
+    const float* suffix_lse, const uint num_tokens, const uint num_heads,
+    const uint head_size, const uint prefix_head_stride,
+    const uint output_head_stride, const uint prefix_num_tokens,
+    float* output_block_scale, const int64_t sf_token_stride,
+    const int64_t sf_group_stride) {
+  using input_pack_t = uint4;  // 128-bit load (matches existing kernel)
+  using output_pack_t = std::conditional_t<sizeof(scalar_t) == 4, uint, uint2>;
+
+  constexpr uint pack_size = 16 / sizeof(scalar_t);
+  constexpr uint threads_per_group = GROUP_SIZE / pack_size;
+  static_assert(threads_per_group > 0 && threads_per_group <= 32 &&
+                    (threads_per_group & (threads_per_group - 1)) == 0,
+                "GROUP_SIZE/pack_size must be a power-of-2 in [1, 32]");
+  // Full warp mask: butterfly shuffles with offset < threads_per_group stay
+  // within each threads_per_group-aligned chunk of lanes.
+  constexpr uint shfl_mask = 0xffffffffu;
+  const uint threads_per_head = head_size / pack_size;
+  const uint groups_per_head = head_size / GROUP_SIZE;
+
+  const uint global_idx = blockIdx.x * NUM_THREADS + threadIdx.x;
+  const uint token_head_threads = num_tokens * num_heads * threads_per_head;
+  if (global_idx >= token_head_threads) return;
+
+  const uint token_head_idx = global_idx / threads_per_head;
+  const uint pack_idx = global_idx % threads_per_head;
+  const uint token_idx = token_head_idx / num_heads;
+  const uint head_idx = token_head_idx % num_heads;
+
+  const uint pack_offset = pack_idx * pack_size;
+  const uint group_idx_in_head = pack_offset / GROUP_SIZE;
+  const uint global_group_idx = head_idx * groups_per_head + group_idx_in_head;
+  const uint thread_in_group = threadIdx.x % threads_per_group;
+
+  const uint src_head_offset = token_idx * num_heads * prefix_head_stride +
+                               head_idx * prefix_head_stride;
+  const uint dst_head_offset = token_idx * num_heads * output_head_stride +
+                               head_idx * output_head_stride;
+  const scalar_t* prefix_head_ptr = prefix_output + src_head_offset;
+  const scalar_t* suffix_head_ptr = suffix_output + src_head_offset;
+  fp8_t* output_head_ptr = output + dst_head_offset;
+
+  // Stage 1: compute fp32 merged values for this thread's pack.
+  float merged_f[pack_size];
+
+  if (token_idx >= prefix_num_tokens) {
+    input_pack_t s_pack = reinterpret_cast<const input_pack_t*>(
+        suffix_head_ptr)[pack_offset / pack_size];
+#pragma unroll
+    for (uint i = 0; i < pack_size; ++i) {
+      merged_f[i] =
+          vllm::to_float(reinterpret_cast<const scalar_t*>(&s_pack)[i]);
+    }
+    if (output_lse != nullptr && pack_idx == 0) {
+      output_lse[head_idx * num_tokens + token_idx] =
+          suffix_lse[head_idx * num_tokens + token_idx];
+    }
+  } else {
+    float p_lse = prefix_lse[head_idx * num_tokens + token_idx];
+    float s_lse = suffix_lse[head_idx * num_tokens + token_idx];
+    p_lse = std::isinf(p_lse) ? -std::numeric_limits<float>::infinity() : p_lse;
+    s_lse = std::isinf(s_lse) ? -std::numeric_limits<float>::infinity() : s_lse;
+    const float max_lse = fmaxf(p_lse, s_lse);
+
+    if (std::isinf(max_lse)) {
+      input_pack_t p_pack = reinterpret_cast<const input_pack_t*>(
+          prefix_head_ptr)[pack_offset / pack_size];
+#pragma unroll
+      for (uint i = 0; i < pack_size; ++i) {
+        merged_f[i] =
+            vllm::to_float(reinterpret_cast<const scalar_t*>(&p_pack)[i]);
+      }
+      if (output_lse != nullptr && pack_idx == 0) {
+        output_lse[head_idx * num_tokens + token_idx] = max_lse;
+      }
+    } else {
+      const float p_lse_n = p_lse - max_lse;
+      const float s_lse_n = s_lse - max_lse;
+      const float p_se = expf(p_lse_n);
+      const float s_se = expf(s_lse_n);
+      const float out_se = p_se + s_se;
+      const float p_scale = p_se / out_se;
+      const float s_scale = s_se / out_se;
+
+      input_pack_t p_pack = reinterpret_cast<const input_pack_t*>(
+          prefix_head_ptr)[pack_offset / pack_size];
+      input_pack_t s_pack = reinterpret_cast<const input_pack_t*>(
+          suffix_head_ptr)[pack_offset / pack_size];
+#pragma unroll
+      for (uint i = 0; i < pack_size; ++i) {
+        const float pf =
+            vllm::to_float(reinterpret_cast<const scalar_t*>(&p_pack)[i]);
+        const float sf =
+            vllm::to_float(reinterpret_cast<const scalar_t*>(&s_pack)[i]);
+        merged_f[i] = pf * p_scale + sf * s_scale;
+      }
+      if (output_lse != nullptr && pack_idx == 0) {
+        output_lse[head_idx * num_tokens + token_idx] = logf(out_se) + max_lse;
+      }
+    }
+  }
+
+  // Stage 2: per-thread absmax + intra-group reduction.
+  float local_max = 0.0f;
+#pragma unroll
+  for (uint i = 0; i < pack_size; ++i) {
+    local_max = fmaxf(local_max, fabsf(merged_f[i]));
+  }
+#pragma unroll
+  for (uint offset = threads_per_group / 2; offset > 0; offset /= 2) {
+    local_max = fmaxf(local_max, __shfl_xor_sync(shfl_mask, local_max, offset));
+  }
+
+  // Stage 3: derive scale (optionally UE8M0) and write SF.
+  constexpr float eps = 1e-10f;
+  const float fp8_max = quant_type_max_v<fp8_t>;
+  float scale_raw = fmaxf(local_max, eps) / fp8_max;
+  float scale;
+  if constexpr (USE_UE8M0) {
+    scale = exp2f(ceilf(log2f(scale_raw)));
+  } else {
+    scale = scale_raw;
+  }
+  if (thread_in_group == 0) {
+    output_block_scale[static_cast<int64_t>(token_idx) * sf_token_stride +
+                       static_cast<int64_t>(global_group_idx) *
+                           sf_group_stride] = scale;
+  }
+
+  // Stage 4: quantize + store.
+  const float inv_scale = 1.0f / scale;
+  output_pack_t out_pack;
+  fp8_t* out_ptr = reinterpret_cast<fp8_t*>(&out_pack);
+#pragma unroll
+  for (uint i = 0; i < pack_size; ++i) {
+    out_ptr[i] =
+        vllm::scaled_fp8_conversion<true, fp8_t>(merged_f[i], inv_scale);
+  }
+  reinterpret_cast<output_pack_t*>(output_head_ptr)[pack_offset / pack_size] =
+      out_pack;
+}
+
 }  // namespace vllm
 
 // The following macro is used to dispatch the conversion function based on
@@ -224,6 +380,22 @@ __global__ void merge_attn_states_kernel(
             prefix_num_tokens, output_scale_ptr);                           \
   }
 
+#define LAUNCH_MERGE_ATTN_STATES_GROUP_FP8(scalar_t, fp8_t, NUM_THREADS,   \
+                                           GROUP_SIZE, USE_UE8M0)          \
+  {                                                                        \
+    vllm::merge_attn_states_group_fp8_kernel<scalar_t, fp8_t, NUM_THREADS, \
+                                             GROUP_SIZE, USE_UE8M0>        \
+        <<<grid, block, 0, stream>>>(                                      \
+            reinterpret_cast<fp8_t*>(output.data_ptr()), output_lse_ptr,   \
+            reinterpret_cast<scalar_t*>(prefix_output.data_ptr()),         \
+            reinterpret_cast<float*>(prefix_lse.data_ptr()),               \
+            reinterpret_cast<scalar_t*>(suffix_output.data_ptr()),         \
+            reinterpret_cast<float*>(suffix_lse.data_ptr()), num_tokens,   \
+            num_heads, head_size, prefix_head_stride, output_head_stride,  \
+            prefix_num_tokens, output_block_scale_ptr, sf_token_stride,    \
+            sf_group_stride);                                              \
+  }
+
 /*@brief Merges the attention states from prefix and suffix
  * into the output tensor. NUM_TOKENS: n, NUM_HEADS: h, HEAD_SIZE: d
  *
@@ -249,7 +421,10 @@ void merge_attn_states_launcher(
     const torch::Tensor& prefix_output, const torch::Tensor& prefix_lse,
     const torch::Tensor& suffix_output, const torch::Tensor& suffix_lse,
     const std::optional<int64_t> prefill_tokens_with_context,
-    const std::optional<torch::Tensor>& output_scale) {
+    const std::optional<torch::Tensor>& output_scale,
+    const std::optional<torch::Tensor>& output_block_scale,
+    const std::optional<int64_t> quant_group_size,
+    const bool quant_scale_ue8m0) {
   constexpr uint NUM_THREADS = 128;
   const uint num_tokens = output.size(0);
   const uint num_heads = output.size(1);
@@ -287,7 +462,54 @@ void merge_attn_states_launcher(
   const c10::cuda::OptionalCUDAGuard device_guard(prefix_output.device());
   auto stream = at::cuda::getCurrentCUDAStream();
 
-  if (output_scale.has_value()) {
+  if (output_block_scale.has_value()) {
+    TORCH_CHECK(!output_scale.has_value(),
+                "output_scale must be None when output_block_scale is set");
+    TORCH_CHECK(quant_group_size.has_value(),
+                "quant_group_size is required for per-group FP8 output");
+    const int group_size = static_cast<int>(quant_group_size.value());
+    TORCH_CHECK(head_size % group_size == 0, "head_size (", head_size,
+                ") must be a multiple of quant_group_size (", group_size, ")");
+    TORCH_CHECK(group_size % pack_size == 0, "quant_group_size (", group_size,
+                ") must be a multiple of pack_size (", pack_size, ")");
+    // Intra-group warp shuffle requires uniform warps within a block.
+    TORCH_CHECK(((num_heads * threads_per_head) % 32) == 0,
+                "num_heads * (head_size / pack_size) must be a multiple of "
+                "warpSize (32) for group FP8 merge");
+    const torch::Tensor& sf = output_block_scale.value();
+    TORCH_CHECK(sf.scalar_type() == at::ScalarType::Float,
+                "output_block_scale must be FP32, got: ", sf.scalar_type());
+    TORCH_CHECK(sf.dim() == 2,
+                "output_block_scale must be 2D [num_tokens, num_groups]");
+    const int64_t sf_token_stride = sf.stride(0);
+    const int64_t sf_group_stride = sf.stride(1);
+    float* output_block_scale_ptr = sf.data_ptr<float>();
+
+#define LAUNCH_MERGE_GROUP_FP8(GROUP_SIZE)                                 \
+  if (quant_scale_ue8m0) {                                                 \
+    VLLM_DISPATCH_FP8_TYPES(                                               \
+        output.scalar_type(), "merge_attn_states_group_fp8", [&] {         \
+          LAUNCH_MERGE_ATTN_STATES_GROUP_FP8(scalar_t, fp8_t, NUM_THREADS, \
+                                             GROUP_SIZE, true);            \
+        });                                                                \
+  } else {                                                                 \
+    VLLM_DISPATCH_FP8_TYPES(                                               \
+        output.scalar_type(), "merge_attn_states_group_fp8", [&] {         \
+          LAUNCH_MERGE_ATTN_STATES_GROUP_FP8(scalar_t, fp8_t, NUM_THREADS, \
+                                             GROUP_SIZE, false);           \
+        });                                                                \
+  }
+
+    if (group_size == 128) {
+      LAUNCH_MERGE_GROUP_FP8(128);
+    } else if (group_size == 64) {
+      LAUNCH_MERGE_GROUP_FP8(64);
+    } else {
+      TORCH_CHECK(false, "Unsupported quant_group_size for group FP8 merge: ",
+                  group_size, ". Supported: 64, 128");
+    }
+#undef LAUNCH_MERGE_GROUP_FP8
+  } else if (output_scale.has_value()) {
     // FP8 output path - dispatch on output FP8 type
     VLLM_DISPATCH_FP8_TYPES(output.scalar_type(), "merge_attn_states_fp8", [&] {
       LAUNCH_MERGE_ATTN_STATES(scalar_t, fp8_t, NUM_THREADS, true);
@@ -302,7 +524,8 @@ void merge_attn_states_launcher(
   {                                                                   \
     merge_attn_states_launcher<scalar_t>(                             \
         output, output_lse, prefix_output, prefix_lse, suffix_output, \
-        suffix_lse, prefill_tokens_with_context, output_scale);       \
+        suffix_lse, prefill_tokens_with_context, output_scale,        \
+        output_block_scale, quant_group_size, quant_scale_ue8m0);     \
   }
 
 void merge_attn_states(torch::Tensor& output,
@@ -312,17 +535,21 @@ void merge_attn_states(torch::Tensor& output,
                        const torch::Tensor& suffix_output,
                        const torch::Tensor& suffix_lse,
                        std::optional<int64_t> prefill_tokens_with_context,
-                       const std::optional<torch::Tensor>& output_scale) {
-  if (output_scale.has_value()) {
+                       const std::optional<torch::Tensor>& output_scale,
+                       const std::optional<torch::Tensor>& output_block_scale,
+                       const std::optional<int64_t> quant_group_size,
+                       const bool quant_scale_ue8m0) {
+  if (output_scale.has_value() || output_block_scale.has_value()) {
     TORCH_CHECK(output.scalar_type() == at::ScalarType::Float8_e4m3fn ||
                     output.scalar_type() == at::ScalarType::Float8_e4m3fnuz,
-                "output must be FP8 when output_scale is provided, got: ",
+                "output must be FP8 when output_scale or output_block_scale "
+                "is provided, got: ",
                 output.scalar_type());
   } else {
     TORCH_CHECK(output.scalar_type() == prefix_output.scalar_type(),
                 "output dtype (", output.scalar_type(),
                 ") must match prefix_output dtype (",
-                prefix_output.scalar_type(), ") when output_scale is not set");
+                prefix_output.scalar_type(), ") when no quant scale is set");
   }
   // Always dispatch on prefix_output (input) dtype
   DISPATCH_BY_SCALAR_DTYPE(prefix_output.dtype(),

--- a/csrc/attention/merge_attn_states.cu
+++ b/csrc/attention/merge_attn_states.cu
@@ -472,10 +472,15 @@ void merge_attn_states_launcher(
                 ") must be a multiple of quant_group_size (", group_size, ")");
     TORCH_CHECK(group_size % pack_size == 0, "quant_group_size (", group_size,
                 ") must be a multiple of pack_size (", pack_size, ")");
-    // Intra-group warp shuffle requires uniform warps within a block.
-    TORCH_CHECK(((num_heads * threads_per_head) % 32) == 0,
-                "num_heads * (head_size / pack_size) must be a multiple of "
-                "warpSize (32) for group FP8 merge");
+    // Intra-group warp shuffle uses a full-warp mask, so every lane in a
+    // warp must take the same early-return decision. We need the total
+    // launched thread count to be a multiple of warpSize. (num_tokens can
+    // compensate for an odd per-token count.)
+    TORCH_CHECK(
+        (total_threads % 32) == 0,
+        "total_threads (num_tokens * num_heads * head_size / pack_size) must "
+        "be a multiple of warpSize (32) for group FP8 merge; got ",
+        total_threads);
     const torch::Tensor& sf = output_block_scale.value();
     TORCH_CHECK(sf.scalar_type() == at::ScalarType::Float,
                 "output_block_scale must be FP32, got: ", sf.scalar_type());

--- a/csrc/ops.h
+++ b/csrc/ops.h
@@ -59,7 +59,10 @@ void merge_attn_states(
     const torch::Tensor& prefix_output, const torch::Tensor& prefix_lse,
     const torch::Tensor& suffix_output, const torch::Tensor& suffix_lse,
     const std::optional<int64_t> prefill_tokens_with_context,
-    const std::optional<torch::Tensor>& output_scale = std::nullopt);
+    const std::optional<torch::Tensor>& output_scale = std::nullopt,
+    const std::optional<torch::Tensor>& output_block_scale = std::nullopt,
+    const std::optional<int64_t> quant_group_size = std::nullopt,
+    const bool quant_scale_ue8m0 = false);
 #ifndef USE_ROCM
 void convert_vertical_slash_indexes(
     torch::Tensor& block_count,      // [BATCH, N_HEADS, NUM_ROWS]

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -74,7 +74,10 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "    Tensor suffix_output,"
       "    Tensor suffix_lse,"
       "    int!? prefill_tokens_with_context,"
-      "    Tensor? output_scale=None) -> ()");
+      "    Tensor? output_scale=None,"
+      "    Tensor!? output_block_scale=None,"
+      "    int? quant_group_size=None,"
+      "    bool quant_scale_ue8m0=False) -> ()");
   ops.impl("merge_attn_states", torch::kCUDA, &merge_attn_states);
 #ifndef USE_ROCM
   ops.def(

--- a/tests/kernels/attention/test_merge_attn_states.py
+++ b/tests/kernels/attention/test_merge_attn_states.py
@@ -10,6 +10,9 @@ from vllm._custom_ops import (
 from vllm._custom_ops import (
     scaled_fp8_quant,
 )
+from vllm.model_executor.layers.quantization.utils.fp8_utils import (
+    per_token_group_quant_fp8,
+)
 from vllm.platforms import current_platform
 from vllm.v1.attention.ops.triton_merge_attn_states import (
     merge_attn_states as merge_attn_states_triton,
@@ -390,3 +393,151 @@ def test_merge_attn_states(
         len(NUM_BATCH_TOKENS) * len(HEAD_SIZES) * len(NUM_QUERY_HEADS) * len(DTYPES)
     ):
         generate_markdown_table()
+
+
+# Per-token-per-group FP8 merge tests. Reference: bf16 merge →
+# per_token_group_quant_fp8. Compares CUDA + Triton fused merge kernels in
+# dequantized space.
+GROUP_FP8_TOKENS = [16, 128, 257, 512]
+GROUP_FP8_HEADS = [16, 64, 128]
+GROUP_FP8_HEAD_SIZES = [128]
+GROUP_FP8_GROUP_SIZES = [64, 128]
+GROUP_FP8_INPUT_DTYPES = [torch.bfloat16, torch.float16]
+
+
+def _scale_layout_kwargs(layout: str) -> dict:
+    if layout == "row_major":
+        return {"column_major_scales": False, "tma_aligned_scales": False}
+    if layout == "col_major":
+        return {"column_major_scales": True, "tma_aligned_scales": False}
+    if layout == "col_major_tma":
+        return {"column_major_scales": True, "tma_aligned_scales": True}
+    raise ValueError(layout)
+
+
+def _bf16_merge_reference(
+    prefix_output, prefix_lse, suffix_output, suffix_lse, prefill_with_context
+):
+    output = torch.empty_like(prefix_output)
+    lse = torch.empty(
+        (prefix_output.shape[1], prefix_output.shape[0]),
+        device=prefix_output.device,
+        dtype=torch.float32,
+    )
+    merge_attn_states_torch(
+        output,
+        prefix_output.clone(),
+        prefix_lse.clone(),
+        suffix_output.clone(),
+        suffix_lse.clone(),
+        lse,
+        prefill_with_context,
+        None,
+    )
+    return output, lse
+
+
+def _broadcast_scales(
+    sf: torch.Tensor, num_heads: int, head_size: int, group_size: int
+) -> torch.Tensor:
+    num_tokens = sf.shape[0]
+    num_groups = num_heads * head_size // group_size
+    sf_rm = sf.contiguous().float().reshape(num_tokens, num_groups)
+    sf_full = sf_rm.repeat_interleave(group_size, dim=-1)
+    return sf_full.view(num_tokens, num_heads, head_size)
+
+
+@pytest.mark.parametrize("kernel", ["cuda", "triton"], ids=["cuda", "triton"])
+@pytest.mark.parametrize("scale_layout", ["row_major", "col_major", "col_major_tma"])
+@pytest.mark.parametrize("use_ue8m0", [False, True])
+@pytest.mark.parametrize("group_size", GROUP_FP8_GROUP_SIZES)
+@pytest.mark.parametrize("head_size", GROUP_FP8_HEAD_SIZES)
+@pytest.mark.parametrize("num_heads", GROUP_FP8_HEADS)
+@pytest.mark.parametrize("num_tokens", GROUP_FP8_TOKENS)
+@pytest.mark.parametrize("input_dtype", GROUP_FP8_INPUT_DTYPES)
+@torch.inference_mode()
+def test_merge_attn_states_group_fp8(
+    kernel: str,
+    scale_layout: str,
+    use_ue8m0: bool,
+    group_size: int,
+    head_size: int,
+    num_heads: int,
+    num_tokens: int,
+    input_dtype: torch.dtype,
+):
+    if not current_platform.is_cuda():
+        pytest.skip("group-FP8 merge fusion is CUDA-only")
+
+    fp8_dtype = current_platform.fp8_dtype()
+    prefill_with_context = num_tokens // 2
+
+    prefix_output = torch.randn(
+        num_tokens, num_heads, head_size, dtype=input_dtype, device="cuda"
+    )
+    suffix_output = torch.randn(
+        num_tokens, num_heads, head_size, dtype=input_dtype, device="cuda"
+    )
+    prefix_lse = torch.randn(num_heads, num_tokens, dtype=torch.float32, device="cuda")
+    suffix_lse = torch.randn(num_heads, num_tokens, dtype=torch.float32, device="cuda")
+
+    bf16_ref, _ = _bf16_merge_reference(
+        prefix_output, prefix_lse, suffix_output, suffix_lse, prefill_with_context
+    )
+    flat_ref = bf16_ref.reshape(num_tokens, num_heads * head_size)
+    ref_q, ref_s = per_token_group_quant_fp8(
+        flat_ref,
+        group_size,
+        dtype=fp8_dtype,
+        use_ue8m0=use_ue8m0,
+        **_scale_layout_kwargs(scale_layout),
+    )
+    ref_q = ref_q.view(num_tokens, num_heads, head_size)
+
+    test_q = torch.empty(
+        (num_tokens, num_heads, head_size), dtype=fp8_dtype, device="cuda"
+    )
+    test_s = torch.empty_strided(
+        ref_s.shape, ref_s.stride(), dtype=ref_s.dtype, device=ref_s.device
+    )
+    test_s.zero_()
+
+    output_lse = torch.empty(
+        (num_heads, num_tokens), dtype=torch.float32, device="cuda"
+    )
+
+    if kernel == "cuda":
+        merge_attn_states_cuda(
+            test_q,
+            prefix_output,
+            prefix_lse,
+            suffix_output,
+            suffix_lse,
+            output_lse,
+            prefill_with_context,
+            None,  # output_scale
+            test_s,
+            group_size,
+            use_ue8m0,
+        )
+    else:
+        merge_attn_states_triton(
+            test_q,
+            prefix_output,
+            prefix_lse,
+            suffix_output,
+            suffix_lse,
+            output_lse,
+            prefill_with_context,
+            None,
+            test_s,
+            group_size,
+            use_ue8m0,
+        )
+
+    test_deq = test_q.float() * _broadcast_scales(
+        test_s, num_heads, head_size, group_size
+    )
+    ref_deq = ref_q.float() * _broadcast_scales(ref_s, num_heads, head_size, group_size)
+
+    torch.testing.assert_close(test_deq, ref_deq, atol=2e-1, rtol=2e-1)

--- a/tests/kernels/attention/test_merge_attn_states.py
+++ b/tests/kernels/attention/test_merge_attn_states.py
@@ -424,7 +424,7 @@ def _bf16_merge_reference(
         device=prefix_output.device,
         dtype=torch.float32,
     )
-    merge_attn_states_torch(
+    output, lse = merge_attn_states_torch(
         output,
         prefix_output.clone(),
         prefix_lse.clone(),
@@ -540,4 +540,9 @@ def test_merge_attn_states_group_fp8(
     )
     ref_deq = ref_q.float() * _broadcast_scales(ref_s, num_heads, head_size, group_size)
 
+    # Both sides FP8-quantize the same merged values; the only source of
+    # divergence is ref's extra bf16 round-trip subtly shifting the absmax
+    # (and thus the scale) on a small fraction of groups, which can flip a
+    # value into an adjacent FP8 bucket. Empirically ~99.98% of FP8 bytes
+    # are bit-identical; tolerances cover the boundary cases.
     torch.testing.assert_close(test_deq, ref_deq, atol=2e-1, rtol=2e-1)

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -266,6 +266,9 @@ def merge_attn_states(
     output_lse: torch.Tensor | None = None,
     prefill_tokens_with_context: int | None = None,
     output_scale: torch.Tensor | None = None,
+    output_block_scale: torch.Tensor | None = None,
+    quant_group_size: int | None = None,
+    quant_scale_ue8m0: bool = False,
 ) -> None:
     torch.ops._C.merge_attn_states(
         output,
@@ -276,6 +279,9 @@ def merge_attn_states(
         suffix_lse,
         prefill_tokens_with_context,
         output_scale,
+        output_block_scale,
+        quant_group_size,
+        quant_scale_ue8m0,
     )
 
 

--- a/vllm/v1/attention/ops/merge_attn_states.py
+++ b/vllm/v1/attention/ops/merge_attn_states.py
@@ -15,6 +15,9 @@ def merge_attn_states(
     output_lse: torch.Tensor | None = None,
     prefill_tokens_with_context: int | None = None,
     output_scale: torch.Tensor | None = None,
+    output_block_scale: torch.Tensor | None = None,
+    quant_group_size: int | None = None,
+    quant_scale_ue8m0: bool = False,
 ) -> None:
     """Merge partial attention outputs from prefix (KV cache) and suffix
     (new tokens) into a single output tensor using the log-sum-exp (LSE)
@@ -44,16 +47,34 @@ def merge_attn_states(
             are treated as having context.
         output_scale: Optional scalar tensor for FP8 static quantization.
             When provided, output must be FP8 dtype.
+        output_block_scale: Optional FP32 tensor of shape
+            [NUM_TOKENS, NUM_GROUPS] for per-token-per-group FP8 quantization.
+            When provided, output must be FP8 dtype, ``output_scale`` must be
+            unset, and ``quant_group_size`` must be specified. Strides are
+            honored so any of the row-major / column-major / TMA-aligned
+            layouts produced by ``per_token_group_quant_fp8`` work directly.
+        quant_group_size: Group size for per-token-per-group FP8 quantization.
+            Must divide HEAD_SIZE. Required when ``output_block_scale`` is set.
+        quant_scale_ue8m0: If True, the per-group FP8 scale is rounded to a
+            power-of-two (UE8M0). Only used when ``output_block_scale`` is set.
     """
 
     # NOTE(DefTruth): Currently, custom merge_attn_states CUDA kernel
     # does not support FP8 dtype for inputs, fallback to use Triton kernel.
-    # However, when output_scale is provided, the inputs are still BF16/FP16
-    # and the output is FP8 — both CUDA and Triton support this.
-    # FP8 output requires output_scale to be set.
+    # However, when output_scale or output_block_scale is provided, the inputs
+    # are still BF16/FP16 and the output is FP8 — both CUDA and Triton support
+    # this. FP8 output requires output_scale or output_block_scale to be set.
     if output.dtype not in (torch.float32, torch.half, torch.bfloat16):
-        assert output_scale is not None, (
-            f"output_scale is required when output is {output.dtype}"
+        assert output_scale is not None or output_block_scale is not None, (
+            f"output_scale/output_block_scale is required when output is {output.dtype}"
+        )
+
+    if output_block_scale is not None:
+        assert quant_group_size is not None, (
+            "quant_group_size is required for per-token-per-group FP8 merge"
+        )
+        assert output_scale is None, (
+            "output_scale must be None for per-token-per-group FP8 merge"
         )
 
     def supported_dtypes(prefix: torch.Tensor) -> bool:
@@ -85,6 +106,9 @@ def merge_attn_states(
             output_lse,
             prefill_tokens_with_context,
             output_scale,
+            output_block_scale,
+            quant_group_size,
+            quant_scale_ue8m0,
         )
     else:
         from vllm.v1.attention.ops.triton_merge_attn_states import (
@@ -100,4 +124,7 @@ def merge_attn_states(
             output_lse,
             prefill_tokens_with_context,
             output_scale,
+            output_block_scale,
+            quant_group_size,
+            quant_scale_ue8m0,
         )

--- a/vllm/v1/attention/ops/triton_merge_attn_states.py
+++ b/vllm/v1/attention/ops/triton_merge_attn_states.py
@@ -20,6 +20,9 @@ def merge_attn_states(
     output_lse: torch.Tensor | None = None,
     prefill_tokens_with_context: int | None = None,
     output_scale: torch.Tensor | None = None,
+    output_block_scale: torch.Tensor | None = None,
+    quant_group_size: int | None = None,
+    quant_scale_ue8m0: bool = False,
 ) -> None:
     num_tokens = output.shape[0]
     num_query_heads = output.shape[1]
@@ -34,6 +37,41 @@ def merge_attn_states(
     # If prefill_tokens_with_context is None, all tokens should use prefix context
     if prefill_tokens_with_context is None:
         prefill_tokens_with_context = num_tokens
+
+    if output_block_scale is not None:
+        assert quant_group_size is not None, (
+            "quant_group_size is required for per-token-per-group FP8 merge"
+        )
+        assert output_scale is None, (
+            "output_scale must be None for per-token-per-group FP8 merge"
+        )
+        assert head_size % quant_group_size == 0, (
+            f"head_size ({head_size}) must be a multiple of "
+            f"quant_group_size ({quant_group_size})"
+        )
+        groups_per_head = head_size // quant_group_size
+        sf_token_stride, sf_group_stride = output_block_scale.stride()
+        merge_attn_states_group_fp8_kernel[(num_tokens, num_query_heads)](
+            output,
+            output_lse,
+            prefix_output,
+            prefix_lse,
+            suffix_output,
+            suffix_lse,
+            output_block_scale,
+            sf_token_stride,
+            sf_group_stride,
+            prefix_head_stride,
+            output_head_stride,
+            head_size,
+            quant_group_size,
+            groups_per_head,
+            triton.next_power_of_2(quant_group_size),
+            output_lse is not None,
+            prefill_tokens_with_context,
+            quant_scale_ue8m0,
+        )
+        return
 
     # TODO(woosuk): Use CUDA kernel instead of Triton to minimize CPU overhead.
     merge_attn_states_kernel[(num_tokens, num_query_heads)](
@@ -173,3 +211,116 @@ def merge_attn_states_kernel(
         out,
         mask=head_mask,
     )
+
+
+@triton.jit
+def merge_attn_states_group_fp8_kernel(
+    output,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE] fp8
+    output_lse,  # [NUM_HEADS, NUM_TOKENS]
+    prefix_output,  # [NUM_TOKENS, NUM_HEADS, HEAD_SIZE]
+    prefix_lse,
+    suffix_output,
+    suffix_lse,
+    output_block_scale,  # fp32 SF tensor; layout via strides
+    sf_token_stride,
+    sf_group_stride,
+    prefix_head_stride,
+    output_head_stride,
+    HEAD_SIZE: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    GROUPS_PER_HEAD: tl.constexpr,
+    PADDED_GROUP_SIZE: tl.constexpr,
+    OUTPUT_LSE: tl.constexpr,
+    prefill_tokens_with_context: tl.constexpr,
+    USE_UE8M0: tl.constexpr,
+    FP8_MIN: tl.constexpr = float8_info.min,
+    FP8_MAX: tl.constexpr = float8_info.max,
+    EPS: tl.constexpr = 1e-10,
+):
+    token_idx = tl.program_id(0)
+    num_tokens = tl.num_programs(0)
+    head_idx = tl.program_id(1)
+    num_heads = tl.num_programs(1)
+
+    prefix_mask = token_idx < prefill_tokens_with_context
+
+    if prefix_mask:
+        p_lse = tl.load(prefix_lse + head_idx * num_tokens + token_idx)
+        s_lse = tl.load(suffix_lse + head_idx * num_tokens + token_idx)
+        p_lse = float("-inf") if p_lse == float("inf") else p_lse
+        s_lse = float("-inf") if s_lse == float("inf") else s_lse
+        max_lse = tl.maximum(p_lse, s_lse)
+        p_lse_n = p_lse - max_lse
+        s_lse_n = s_lse - max_lse
+        p_se = tl.exp(p_lse_n)
+        s_se = tl.exp(s_lse_n)
+        out_se = p_se + s_se
+        if OUTPUT_LSE:
+            out_lse = tl.log(out_se) + max_lse
+            tl.store(output_lse + head_idx * num_tokens + token_idx, out_lse)
+        p_scale = p_se / out_se
+        s_scale = s_se / out_se
+    else:
+        if OUTPUT_LSE:
+            s_lse_only = tl.load(suffix_lse + head_idx * num_tokens + token_idx)
+            tl.store(output_lse + head_idx * num_tokens + token_idx, s_lse_only)
+        p_scale = 0.0
+        s_scale = 1.0
+
+    group_arange = tl.arange(0, PADDED_GROUP_SIZE)
+    group_mask = group_arange < GROUP_SIZE
+
+    for g in tl.static_range(0, GROUPS_PER_HEAD):
+        offsets = g * GROUP_SIZE + group_arange
+
+        if prefix_mask:
+            p_out = tl.load(
+                prefix_output
+                + token_idx * num_heads * prefix_head_stride
+                + head_idx * prefix_head_stride
+                + offsets,
+                mask=group_mask,
+                other=0.0,
+            )
+            s_out = tl.load(
+                suffix_output
+                + token_idx * num_heads * prefix_head_stride
+                + head_idx * prefix_head_stride
+                + offsets,
+                mask=group_mask,
+                other=0.0,
+            )
+            merged = p_out.to(tl.float32) * p_scale + s_out.to(tl.float32) * s_scale
+        else:
+            s_out = tl.load(
+                suffix_output
+                + token_idx * num_heads * prefix_head_stride
+                + head_idx * prefix_head_stride
+                + offsets,
+                mask=group_mask,
+                other=0.0,
+            )
+            merged = s_out.to(tl.float32)
+
+        absmax = tl.maximum(tl.max(tl.abs(merged)), EPS)
+        scale_raw = absmax * (1.0 / FP8_MAX)
+        scale = tl.math.exp2(tl.ceil(tl.log2(scale_raw))) if USE_UE8M0 else scale_raw
+
+        global_group_idx = head_idx * GROUPS_PER_HEAD + g
+        tl.store(
+            output_block_scale
+            + token_idx * sf_token_stride
+            + global_group_idx * sf_group_stride,
+            scale,
+        )
+
+        q = tl.clamp(merged * (1.0 / scale), FP8_MIN, FP8_MAX)
+        q = q.to(output.dtype.element_ty)
+        tl.store(
+            output
+            + token_idx * num_heads * output_head_stride
+            + head_idx * output_head_stride
+            + offsets,
+            q,
+            mask=group_mask,
+        )

--- a/vllm/v1/attention/ops/triton_merge_attn_states.py
+++ b/vllm/v1/attention/ops/triton_merge_attn_states.py
@@ -250,16 +250,26 @@ def merge_attn_states_group_fp8_kernel(
         p_lse = float("-inf") if p_lse == float("inf") else p_lse
         s_lse = float("-inf") if s_lse == float("inf") else s_lse
         max_lse = tl.maximum(p_lse, s_lse)
-        p_lse_n = p_lse - max_lse
-        s_lse_n = s_lse - max_lse
-        p_se = tl.exp(p_lse_n)
-        s_se = tl.exp(s_lse_n)
-        out_se = p_se + s_se
-        if OUTPUT_LSE:
-            out_lse = tl.log(out_se) + max_lse
-            tl.store(output_lse + head_idx * num_tokens + token_idx, out_lse)
-        p_scale = p_se / out_se
-        s_scale = s_se / out_se
+        # All-(-inf) edge case: chunked prefill can produce p_lse=s_lse=-inf
+        # for a token with no prefix hit; the normal path would yield NaN
+        # (-inf - (-inf)). Fall back to emitting prefix_output (expected to
+        # be zeros), matching the CUDA kernel.
+        if max_lse == float("-inf"):
+            if OUTPUT_LSE:
+                tl.store(output_lse + head_idx * num_tokens + token_idx, max_lse)
+            p_scale = 1.0
+            s_scale = 0.0
+        else:
+            p_lse_n = p_lse - max_lse
+            s_lse_n = s_lse - max_lse
+            p_se = tl.exp(p_lse_n)
+            s_se = tl.exp(s_lse_n)
+            out_se = p_se + s_se
+            if OUTPUT_LSE:
+                out_lse = tl.log(out_se) + max_lse
+                tl.store(output_lse + head_idx * num_tokens + token_idx, out_lse)
+            p_scale = p_se / out_se
+            s_scale = s_se / out_se
     else:
         if OUTPUT_LSE:
             s_lse_only = tl.load(suffix_lse + head_idx * num_tokens + token_idx)


### PR DESCRIPTION
## Purpose
- Addresses cell forward_mha(has_context=True) x per-group FP8 in https://github.com/vllm-project/vllm/issues/35792
- Add fused kernels (CUDA and Triton) for `merge_attn_state` + per-group FP8
- TODO: wire into forward_mha in mla_attention.py depending on PR #40908

## Test Plan
- [x] new and existing unit tests pass
- [x] run benchmark to compare performance
- [ ] benchmark on B200 with DeepseekV3 FP8 model

## Test Result
Test: tests/kernels/attention/test_merge_attn_states.py
```

  576 passed, 16 warnings in 81.13s         # group-FP8 sweep only (CUDA + Triton)
  3168 passed, 16 warnings in 528.28s       # full file (group-FP8 + existing static + bf16)

  Coverage (group-FP8 portion): kernel ∈ {CUDA, Triton} × group_size ∈ {64, 128} × SF layout ∈ {row_major, col_major, col_major_tma} × use_ue8m0 ∈ {False, True} × num_heads ∈ {16,
  64, 128} × num_tokens ∈ {16, 128, 257, 512} × input_dtype ∈ {bf16, fp16}, head_size = 128.
```


Benchmarks (NVIDIA GB10, sm_121, bf16 input, TP=1)
```
  Per-token-per-group FP8, group_size=128 (new)

  ┌─────────────┬────────┬────────────┬──────────────┬──────────────┬────────────────┬─────────────────────────┐
  │ heads × hsz │ tokens │ Fused CUDA │ Fused Triton │ Unfused CUDA │ Unfused Triton │ Fused-vs-unfused (CUDA) │
  ├─────────────┼────────┼────────────┼──────────────┼──────────────┼────────────────┼─────────────────────────┤
  │ 128 × 128   │     64 │       4.29 │        13.31 │         8.35 │          12.96 │                   1.95x │
  ├─────────────┼────────┼────────────┼──────────────┼──────────────┼────────────────┼─────────────────────────┤
  │ 128 × 128   │    256 │       26.4 │         58.5 │        126.6 │          129.8 │                   4.80x │
  ├─────────────┼────────┼────────────┼──────────────┼──────────────┼────────────────┼─────────────────────────┤
  │ 128 × 128   │   1024 │      340.1 │        398.5 │        638.0 │          639.9 │                   1.88x │
  ├─────────────┼────────┼────────────┼──────────────┼──────────────┼────────────────┼─────────────────────────┤
  │ 128 × 128   │   4096 │       1538 │         1627 │         2757 │           2787 │                   1.79x │
  ├─────────────┼────────┼────────────┼──────────────┼──────────────┼────────────────┼─────────────────────────┤
  │ 64 × 128    │    256 │       7.23 │         26.5 │         15.6 │           25.9 │                   2.16x │
  ├─────────────┼────────┼────────────┼──────────────┼──────────────┼────────────────┼─────────────────────────┤
  │ 32 × 128    │   1024 │       24.0 │         56.0 │        117.1 │          119.5 │                   4.88x │
  └─────────────┴────────┴────────────┴──────────────┴──────────────┴────────────────┴─────────────────────────┘

  Per-token-per-group FP8, group_size=128 + UE8M0

  ┌─────────────┬────────┬────────────┬──────────────┬──────────────┬────────────────┬─────────────────────────┐
  │ heads × hsz │ tokens │ Fused CUDA │ Fused Triton │ Unfused CUDA │ Unfused Triton │ Fused-vs-unfused (CUDA) │
  ├─────────────┼────────┼────────────┼──────────────┼──────────────┼────────────────┼─────────────────────────┤
  │ 128 × 128   │    256 │      21.98 │         63.4 │        127.3 │          125.1 │                   5.79x │
  ├─────────────┼────────┼────────────┼──────────────┼──────────────┼────────────────┼─────────────────────────┤
  │ 128 × 128   │   1024 │      337.8 │        407.6 │        642.4 │          636.0 │                   1.90x │
  ├─────────────┼────────┼────────────┼──────────────┼──────────────┼────────────────┼─────────────────────────┤
  │ 32 × 128    │   1024 │      19.66 │         62.3 │        114.1 │          115.4 │                   5.80x │
  └─────────────┴────────┴────────────┴──────────────┴──────────────┴────────────────┴─────────────────────────┘

  Per-token-per-group FP8, group_size=64 (new)

  ┌─────────────┬────────┬────────────┬──────────────┬──────────────┬────────────────┬─────────────────────────┐
  │ heads × hsz │ tokens │ Fused CUDA │ Fused Triton │ Unfused CUDA │ Unfused Triton │ Fused-vs-unfused (CUDA) │
  ├─────────────┼────────┼────────────┼──────────────┼──────────────┼────────────────┼─────────────────────────┤
  │ 128 × 128   │    256 │      21.85 │         85.6 │        132.8 │          134.5 │                   6.08x │
  ├─────────────┼────────┼────────────┼──────────────┼──────────────┼────────────────┼─────────────────────────┤
  │ 128 × 128   │   1024 │      335.6 │        489.2 │        647.3 │          667.5 │                   1.93x │
  ├─────────────┼────────┼────────────┼──────────────┼──────────────┼────────────────┼─────────────────────────┤
  │ 64 × 128    │   1024 │      185.4 │        221.7 │        313.9 │          316.6 │                   1.69x │
  ├─────────────┼────────┼────────────┼──────────────┼──────────────┼────────────────┼─────────────────────────┤
  │ 32 × 128    │    256 │       4.21 │         20.1 │         11.2 │           16.3 │                   2.66x │
  └─────────────┴────────┴────────────┴──────────────┴──────────────┴────────────────┴─────────────────────────┘

```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
