### PR TITLE
[V1][Bugfix] Reap EngineCore on parent death (#19849)

### DIFF
--- a/tests/v1/engine/test_engine_core_parent_death.py
+++ b/tests/v1/engine/test_engine_core_parent_death.py
@@ -1,0 +1,335 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression tests for EngineCore subprocess parent-death detection.
+
+These tests demonstrate that the EngineCore child subprocess is reaped
+when the parent process dies by any means, including SIGKILL,
+uncaught exceptions, and ``os._exit()`` calls that bypass atexit
+handlers and weakref finalizers.
+
+Without the parent-death watchdog (``vllm/v1/engine/parent_death.py``),
+the SIGKILL and ``os._exit()`` scenarios leak the EngineCore process
+indefinitely; it continues to hold GPU memory and blocks subsequent
+``LLM()`` instantiations. With the watchdog installed, the child
+receives an OS-level signal when the parent's task struct exits and
+self-terminates via the existing cooperative SIGTERM path.
+
+Tracking issues: vllm-project/vllm#19849, #17273, #1908.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import textwrap
+import time
+from pathlib import Path
+
+import psutil
+import pytest
+
+# Wait at most this long for the EngineCore subprocess to disappear.
+# 10s gives PR_SET_PDEATHSIG (instant), kqueue NOTE_EXIT (~50ms), and
+# JobObject (~100ms) plus the cooperative SIGTERM cleanup path
+# (LMCache shutdown can take ~6.5s per #31252) ample headroom.
+REAP_TIMEOUT_S = 15.0
+
+# Tiny model. Keep test cycle short. Already pinned in other engine tests.
+MODEL = "facebook/opt-125m"
+
+
+def _engine_core_children(parent_pid: int) -> list[psutil.Process]:
+    """Return live EngineCore subprocesses descended from ``parent_pid``.
+
+    Identifies children by process name set via ``set_process_title``
+    in ``EngineCoreProc.run_engine_core``. Falls back to cmdline scan
+    if the process title is not yet set when polled.
+    """
+    try:
+        parent = psutil.Process(parent_pid)
+    except psutil.NoSuchProcess:
+        return []
+    out: list[psutil.Process] = []
+    for child in parent.children(recursive=True):
+        try:
+            name = child.name()
+            cmdline = " ".join(child.cmdline())
+        except (psutil.NoSuchProcess, psutil.AccessDenied):
+            continue
+        if name.startswith("EngineCore") or "EngineCore" in cmdline:
+            out.append(child)
+    return out
+
+
+def _wait_for_pid_exit(pid: int, timeout: float) -> bool:
+    """Poll ``os.kill(pid, 0)`` until the PID is gone or timeout."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return True
+        except PermissionError:
+            # Process exists but is owned by another uid (or has been
+            # reaped and the PID was reused). Treat as "still alive"
+            # to be conservative.
+            pass
+        time.sleep(0.05)
+    return False
+
+
+def _wrapper_script(scenario: str, pid_file: str) -> str:
+    """Return a Python program that loads an LLM, writes the EngineCore
+    PID to ``pid_file``, and then triggers ``scenario``.
+
+    The wrapper is launched in a fresh ``python -c`` subprocess so the
+    test driver can SIGKILL or otherwise terminate it without affecting
+    the test runner.
+    """
+    return textwrap.dedent(f"""
+        import os, sys, time, psutil
+        # Quiet vLLM logs in test output.
+        os.environ.setdefault("VLLM_LOGGING_LEVEL", "WARNING")
+        from vllm import LLM, SamplingParams
+
+        llm = LLM(
+            model={MODEL!r},
+            enforce_eager=True,
+            gpu_memory_utilization=0.3,
+            max_model_len=256,
+            disable_log_stats=True,
+        )
+        # Resolve EngineCore PID via psutil (cross-platform; no
+        # dependency on vLLM internals).
+        me = psutil.Process(os.getpid())
+        engine_pid = None
+        for child in me.children(recursive=True):
+            try:
+                if child.name().startswith("EngineCore") or \\
+                        "EngineCore" in " ".join(child.cmdline()):
+                    engine_pid = child.pid
+                    break
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                continue
+        if engine_pid is None:
+            sys.stderr.write("FATAL: EngineCore subprocess not found\\n")
+            os._exit(2)
+        with open({pid_file!r}, "w") as f:
+            f.write(str(engine_pid))
+        sys.stdout.write("READY\\n"); sys.stdout.flush()
+
+        scenario = {scenario!r}
+        if scenario == "sigkill_wait":
+            # Wait to be killed externally.
+            time.sleep(60)
+        elif scenario == "os_exit":
+            # Bypass atexit, weakref finalizers, and the cooperative
+            # shutdown path entirely.
+            os._exit(0)
+        elif scenario == "uncaught_exception":
+            raise RuntimeError("simulated parent crash")
+        elif scenario == "cooperative":
+            del llm
+            sys.exit(0)
+        else:
+            sys.stderr.write(f"unknown scenario: {{scenario}}\\n")
+            os._exit(3)
+    """)
+
+
+def _spawn_wrapper(scenario: str, tmp_path: Path) -> tuple[subprocess.Popen, int]:
+    """Spawn the wrapper subprocess and block until it has written the
+    EngineCore PID.
+
+    Returns ``(wrapper_proc, engine_core_pid)``.
+    """
+    pid_file = tmp_path / "engine_pid.txt"
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _wrapper_script(scenario, str(pid_file))],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    # Wait for "READY" line (model loaded, EngineCore spawned, PID written).
+    deadline = time.monotonic() + 180.0  # opt-125m cold load + cuda init
+    while time.monotonic() < deadline:
+        if proc.poll() is not None:
+            stdout, stderr = proc.communicate()
+            raise RuntimeError(
+                f"wrapper exited prematurely with code {proc.returncode}\n"
+                f"stdout:\n{stdout}\nstderr:\n{stderr}"
+            )
+        if pid_file.exists():
+            try:
+                engine_pid = int(pid_file.read_text().strip())
+                return proc, engine_pid
+            except ValueError:
+                time.sleep(0.1)
+                continue
+        time.sleep(0.2)
+    proc.kill()
+    raise RuntimeError("wrapper did not become READY within 180s")
+
+
+@pytest.fixture
+def cuda_required():
+    """Skip when no GPU available; vLLM EngineCore needs an accelerator."""
+    try:
+        import torch
+        if not torch.cuda.is_available():
+            pytest.skip("CUDA required for EngineCore tests")
+    except ImportError:
+        pytest.skip("PyTorch not installed")
+
+
+@pytest.mark.timeout(300)
+def test_engine_core_reaped_on_parent_sigkill(cuda_required, tmp_path):
+    """Parent SIGKILLed; EngineCore must self-terminate.
+
+    SIGKILL bypasses every userspace cleanup hook (atexit, weakref
+    finalize, ``LLM.shutdown``). Without the watchdog this leaks the
+    EngineCore subprocess indefinitely. With the watchdog, the kernel
+    delivers SIGTERM (Linux PR_SET_PDEATHSIG) or kqueue NOTE_EXIT
+    (macOS) or job-object kill (Windows) to the child immediately
+    when the parent task struct is reaped.
+    """
+    wrapper, engine_pid = _spawn_wrapper("sigkill_wait", tmp_path)
+    try:
+        wrapper.send_signal(signal.SIGKILL)
+        wrapper.wait(timeout=10)
+        assert _wait_for_pid_exit(engine_pid, REAP_TIMEOUT_S), (
+            f"EngineCore (pid={engine_pid}) survived parent SIGKILL "
+            f"for {REAP_TIMEOUT_S}s; orphaned subprocess. This is "
+            "the bug the parent-death watchdog fixes."
+        )
+    finally:
+        if _wait_for_pid_exit(engine_pid, 0.0) is False:
+            # Defensive cleanup so a failing test doesn't leak GPU.
+            try:
+                os.kill(engine_pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+
+
+@pytest.mark.timeout(300)
+def test_engine_core_reaped_on_parent_os_exit(cuda_required, tmp_path):
+    """Parent calls ``os._exit(0)``; EngineCore must self-terminate.
+
+    ``os._exit`` skips atexit, finalizers, and any registered
+    cooperative shutdown path; exactly the failure mode reported in
+    #19849 example 2 ("if your main Python process is killed, the
+    EngineCore child remains alive"). This scenario also covers
+    OOM-kill and signal-7 segfault behavior, which similarly skip
+    userspace cleanup.
+    """
+    wrapper, engine_pid = _spawn_wrapper("os_exit", tmp_path)
+    wrapper.wait(timeout=10)
+    assert wrapper.returncode == 0
+    assert _wait_for_pid_exit(engine_pid, REAP_TIMEOUT_S), (
+        f"EngineCore (pid={engine_pid}) survived parent os._exit "
+        f"for {REAP_TIMEOUT_S}s; orphaned subprocess."
+    )
+
+
+@pytest.mark.timeout(300)
+def test_engine_core_reaped_on_parent_uncaught_exception(cuda_required, tmp_path):
+    """Parent dies via uncaught exception; EngineCore must self-terminate.
+
+    Some embedding hosts swallow exceptions before atexit runs, others
+    don't. The watchdog must work in both cases. We force a hard exit
+    here via Python's default uncaught-exception handler so the test
+    is deterministic across hosts.
+    """
+    wrapper, engine_pid = _spawn_wrapper("uncaught_exception", tmp_path)
+    wrapper.wait(timeout=15)
+    # Python returns 1 for uncaught exceptions.
+    assert wrapper.returncode != 0
+    assert _wait_for_pid_exit(engine_pid, REAP_TIMEOUT_S), (
+        f"EngineCore (pid={engine_pid}) survived parent crash "
+        f"for {REAP_TIMEOUT_S}s; orphaned subprocess."
+    )
+
+
+@pytest.mark.timeout(300)
+def test_cooperative_shutdown_unchanged(cuda_required, tmp_path):
+    """Existing cooperative shutdown path must continue to work.
+
+    Maintainers will worry the watchdog interferes with the existing
+    SIGTERM, then ``shutdown_state = REQUESTED``, then ``run_busy_loop``
+    drain, then ``engine_core.shutdown()`` finally path. This test
+    exercises that path directly: parent does ``del llm; sys.exit(0)``
+    and the EngineCore must exit via the existing cooperative
+    machinery, NOT via the watchdog.
+    """
+    wrapper, engine_pid = _spawn_wrapper("cooperative", tmp_path)
+    wrapper.wait(timeout=30)
+    assert wrapper.returncode == 0
+    assert _wait_for_pid_exit(engine_pid, REAP_TIMEOUT_S), (
+        f"EngineCore (pid={engine_pid}) survived cooperative shutdown; "
+        "this would indicate the watchdog broke the existing path."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Watchdog primitive: exercises parent_death.install_parent_death_watchdog
+# in isolation. Runs cross-platform without GPU, suitable for CI matrices
+# that don't have CUDA.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(60)
+@pytest.mark.skipif(
+    sys.platform not in ("linux", "darwin", "win32"),
+    reason="parent-death watchdog supports linux/macos/windows",
+)
+def test_watchdog_primitive_kills_child_on_parent_sigkill(tmp_path):
+    """Spawn a tiny child that installs the watchdog and sleeps. SIGKILL
+    its parent, assert the child terminates within the reap timeout.
+
+    No model load, no GPU. Exercises only the OS-level primitive.
+    """
+    pid_file = tmp_path / "child_pid.txt"
+    parent_script = textwrap.dedent(f"""
+        import os, sys, subprocess, time
+        child_script = '''
+import os, sys, time
+sys.path.insert(0, {str(Path(__file__).resolve().parents[3])!r})
+from vllm.v1.engine.parent_death import install_parent_death_watchdog
+install_parent_death_watchdog()
+with open({str(pid_file)!r}, "w") as f:
+    f.write(str(os.getpid()))
+time.sleep(60)
+'''
+        child = subprocess.Popen([sys.executable, "-c", child_script])
+        # Block forever. Parent will be SIGKILLed externally.
+        time.sleep(60)
+    """)
+    parent = subprocess.Popen([sys.executable, "-c", parent_script])
+    # Wait for child to write its PID.
+    deadline = time.monotonic() + 30.0
+    child_pid = None
+    while time.monotonic() < deadline:
+        if pid_file.exists():
+            try:
+                child_pid = int(pid_file.read_text().strip())
+                break
+            except ValueError:
+                pass
+        time.sleep(0.05)
+    if child_pid is None:
+        parent.kill()
+        pytest.fail("watchdog primitive child did not write PID within 30s")
+    try:
+        parent.send_signal(signal.SIGKILL)
+        parent.wait(timeout=5)
+        assert _wait_for_pid_exit(child_pid, REAP_TIMEOUT_S), (
+            f"child (pid={child_pid}) survived parent SIGKILL; "
+            "parent-death watchdog primitive is not firing."
+        )
+    finally:
+        try:
+            os.kill(child_pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -252,6 +252,7 @@ if TYPE_CHECKING:
     VLLM_WEIGHT_OFFLOADING_DISABLE_PIN_MEMORY: bool = False
     VLLM_WEIGHT_OFFLOADING_DISABLE_UVA: bool = False
     VLLM_DISABLE_LOG_LOGO: bool = False
+    VLLM_DISABLE_PARENT_DEATH_WATCHDOG: bool = False
     VLLM_LORA_DISABLE_PDL: bool = False
     VLLM_ENABLE_CUDA_COMPATIBILITY: bool = False
     VLLM_CUDA_COMPATIBILITY_PATH: str | None = None
@@ -1695,6 +1696,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # Disable logging of vLLM logo at server startup time.
     "VLLM_DISABLE_LOG_LOGO": lambda: bool(int(os.getenv("VLLM_DISABLE_LOG_LOGO", "0"))),
+    # Disable the EngineCore parent-death watchdog. Escape hatch for
+    # debugging only. Without the watchdog, an abnormally-terminated
+    # parent (SIGKILL, OOM-kill, segfault, ``os._exit()``) will orphan
+    # the EngineCore subprocess and leak GPU memory. See
+    # vllm/v1/engine/parent_death.py.
+    "VLLM_DISABLE_PARENT_DEATH_WATCHDOG": lambda: bool(
+        int(os.getenv("VLLM_DISABLE_PARENT_DEATH_WATCHDOG", "0"))
+    ),
     # Disable PDL for LoRA, as enabling PDL with LoRA on SM100 causes
     # Triton compilation to fail.
     "VLLM_LORA_DISABLE_PDL": lambda: bool(int(os.getenv("VLLM_LORA_DISABLE_PDL", "0"))),

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1064,6 +1064,20 @@ class EngineCoreProc(EngineCore):
     def run_engine_core(*args, dp_rank: int = 0, local_dp_rank: int = 0, **kwargs):
         """Launch EngineCore busy loop in background process."""
 
+        # Install the parent-death watchdog as the very first action in the
+        # child. The watchdog raises SIGTERM to self when the parent's task
+        # struct is reaped, regardless of how the parent died (SIGKILL,
+        # OOM-kill, segfault, ``os._exit()`` from an embedding host). These
+        # are the cases where the cooperative shutdown path
+        # (``proc.terminate()`` from the parent's ``weakref.finalize``)
+        # never runs. The watchdog reuses the SIGTERM handler installed
+        # below, so no new shutdown decision is made by the child. See
+        # ``vllm/v1/engine/parent_death.py`` and vllm-project/vllm#19849.
+        if not envs.VLLM_DISABLE_PARENT_DEATH_WATCHDOG:
+            from vllm.v1.engine.parent_death import install_parent_death_watchdog
+
+            install_parent_death_watchdog()
+
         # Ensure we can serialize transformer config after spawning
         maybe_register_config_serialize_by_value()
 

--- a/vllm/v1/engine/parent_death.py
+++ b/vllm/v1/engine/parent_death.py
@@ -1,0 +1,363 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Per-OS parent-death watchdog for the EngineCore subprocess.
+
+The EngineCore child is spawned via ``multiprocessing`` and ordinarily
+relies on a cooperative shutdown path. The parent calls
+``proc.terminate()`` (via :func:`vllm.v1.utils.shutdown` from a
+``weakref.finalize`` or an explicit ``LLM.shutdown()``), which delivers
+SIGTERM to the child. The child's existing SIGTERM handler in
+``EngineCoreProc.run_engine_core`` flips ``shutdown_state`` and the
+busy loop drains and exits cleanly.
+
+That cooperative path requires the parent to be alive and well-behaved.
+When the parent dies abnormally (SIGKILL, OOM-kill, segfault, or
+``os._exit()`` from an embedding host), atexit handlers and weakref
+finalizers never run. ``proc.terminate()`` is never called. The
+EngineCore child orphans, holds GPU memory, and blocks subsequent
+``LLM()`` instantiations. See vllm-project/vllm#19849, #17273, #1908.
+
+This module installs an OS-level watchdog inside the EngineCore child
+that fires when the parent's task struct is reaped, regardless of how
+the parent died. The default handler raises SIGTERM to ``self``, which
+reuses the existing cooperative SIGTERM handler. No new shutdown
+decision is made by the child; only the existing path is reached.
+
+Per-OS mechanism:
+
+* **Linux**: ``prctl(PR_SET_PDEATHSIG, SIGTERM)``. The kernel delivers
+  SIGTERM to this process the moment the parent exits. Effectively
+  zero latency.
+* **macOS**: ``kqueue`` registration on ``EVFILT_PROC | NOTE_EXIT``
+  watching the parent PID, polled by a daemon thread. Latency is the
+  thread's wakeup time, typically <50ms.
+* **Windows**: ``CreateJobObject`` with
+  ``JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE`` is the canonical primitive,
+  but it must be set up by the parent before the child is assigned.
+  As a self-installable child-side fallback we open a handle to the
+  parent process and wait on it from a daemon thread. When the wait
+  returns, the parent has exited and the watchdog fires. Latency is
+  the wait granularity, typically <100ms.
+
+The watchdog is idempotent: calling :func:`install_parent_death_watchdog`
+more than once is a no-op after the first successful installation.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import sys
+import threading
+from collections.abc import Callable
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+_INSTALLED = False
+_LOCK = threading.Lock()
+
+
+def _default_on_parent_death() -> None:
+    """Default watchdog handler that raises SIGTERM to self.
+
+    Reuses the EngineCore's existing SIGTERM handler (installed in
+    ``EngineCoreProc.run_engine_core``) so the cooperative shutdown
+    path runs: ``shutdown_state = REQUESTED`` then busy loop drains
+    then ``finally`` calls ``engine_core.shutdown()`` for resource
+    cleanup.
+
+    No new shutdown decision is made by the child; the watchdog only
+    routes "parent is verifiably dead" into the same path the parent
+    would have used had it been able to call ``proc.terminate()``.
+    """
+    logger.warning(
+        "EngineCore parent process died; initiating cooperative shutdown "
+        "via SIGTERM to self (pid=%d).",
+        os.getpid(),
+    )
+    try:
+        os.kill(os.getpid(), signal.SIGTERM)
+    except OSError as e:
+        # Last resort: if signaling self fails, hard-exit so we don't
+        # leak the GPU. This branch is not expected to fire in
+        # practice; kill(self, SIGTERM) succeeds whenever the process
+        # is alive.
+        logger.error(
+            "Self-SIGTERM failed (%s); exiting hard to avoid GPU leak.", e
+        )
+        os._exit(1)
+
+
+def install_parent_death_watchdog(
+    on_parent_death: Callable[[], None] | None = None,
+) -> bool:
+    """Install a watchdog that triggers when this process's parent dies.
+
+    The watchdog fires when the parent process is reaped by the kernel,
+    regardless of how the parent died (graceful exit, SIGKILL, OOM-kill,
+    segfault, ``os._exit()`` from an embedding host).
+
+    Args:
+        on_parent_death: Callback invoked in a watchdog-owned context
+            when the parent is detected dead. Defaults to
+            :func:`_default_on_parent_death`, which raises SIGTERM to
+            this process to reuse the existing cooperative shutdown
+            path. A custom handler is useful for tests.
+
+    Returns:
+        ``True`` if the watchdog was installed by this call. ``False``
+        if a watchdog had already been installed (idempotent), or if
+        the OS does not support a parent-death primitive.
+
+    Notes:
+        Safe to call from any thread. Should be called from the
+        EngineCore subprocess's main as early as possible, before
+        model load, so the watchdog covers the long startup window
+        during which a parent crash would otherwise orphan the child.
+
+        On Linux, ``prctl(PR_SET_PDEATHSIG)`` is reset on
+        ``execve()``. EngineCore does not exec, so this is not a
+        concern in the current code path. If a future refactor adds
+        an exec, the watchdog must be re-installed in the post-exec
+        process.
+    """
+    global _INSTALLED
+    handler = on_parent_death or _default_on_parent_death
+
+    with _LOCK:
+        if _INSTALLED:
+            logger.debug("Parent-death watchdog already installed; skipping.")
+            return False
+
+        platform = sys.platform
+        try:
+            if platform == "linux":
+                _install_linux(handler)
+            elif platform == "darwin":
+                _install_macos(handler)
+            elif platform == "win32":
+                _install_windows(handler)
+            else:
+                logger.warning(
+                    "Parent-death watchdog not implemented for platform "
+                    "%s; EngineCore may orphan if the parent dies "
+                    "abnormally.",
+                    platform,
+                )
+                return False
+        except Exception as e:
+            # Never block EngineCore startup on watchdog install failure.
+            # Log and continue without the watchdog; caller can still
+            # rely on the cooperative shutdown path.
+            logger.warning(
+                "Failed to install parent-death watchdog (%s); EngineCore "
+                "may orphan if the parent dies abnormally.",
+                e,
+            )
+            return False
+
+        _INSTALLED = True
+        logger.debug("Parent-death watchdog installed (platform=%s).", platform)
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Linux: prctl(PR_SET_PDEATHSIG, SIGTERM)
+# ---------------------------------------------------------------------------
+
+# From <linux/prctl.h>. Stable since 2.6.0; safe to hardcode.
+_PR_SET_PDEATHSIG = 1
+
+
+def _install_linux(handler: Callable[[], None]) -> None:
+    """Linux: ask the kernel to send SIGTERM when the parent exits.
+
+    The kernel delivers SIGTERM the instant the parent's task struct
+    is reaped; no userspace polling required. The signal is then
+    handled by whatever SIGTERM handler is installed at the time the
+    parent dies (typically EngineCore's cooperative handler in
+    ``run_engine_core``, installed shortly after this watchdog).
+
+    On Linux, custom ``on_parent_death`` callbacks are not supported:
+    the kernel-delivered SIGTERM is handled by whatever signal handler
+    is current when the parent dies, not by anything this function
+    installs at registration time. Use the default handler
+    (SIGTERM-to-self) on Linux. Custom handlers continue to work via
+    the daemon-thread mechanism on macOS and Windows.
+    """
+    import ctypes
+    import ctypes.util
+
+    libc_name = ctypes.util.find_library("c") or "libc.so.6"
+    libc = ctypes.CDLL(libc_name, use_errno=True)
+    rc = libc.prctl(_PR_SET_PDEATHSIG, signal.SIGTERM, 0, 0, 0)
+    if rc != 0:
+        errno = ctypes.get_errno()
+        raise OSError(errno, f"prctl(PR_SET_PDEATHSIG, SIGTERM) failed: errno={errno}")
+
+    # Edge case: if the parent had already exited by the time prctl
+    # ran (race: spawn, parent dies, child gets to prctl), the kernel
+    # will not back-fire the signal. Check now.
+    try:
+        if os.getppid() == 1:
+            # Parent already reaped (we've been re-parented to init).
+            handler()
+            return
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# macOS: kqueue EVFILT_PROC | NOTE_EXIT on parent pid
+# ---------------------------------------------------------------------------
+
+
+def _install_macos(handler: Callable[[], None]) -> None:
+    """macOS: register kqueue NOTE_EXIT and poll from a daemon thread.
+
+    macOS has no equivalent of ``PR_SET_PDEATHSIG``. The supported
+    pattern is to register an ``EVFILT_PROC`` filter for the parent's
+    PID and wait for ``NOTE_EXIT``. We do this from a daemon thread
+    so the EngineCore main loop is unaffected.
+
+    The thread exits naturally when ``handler()`` returns (the default
+    handler raises SIGTERM to self, which causes the process to exit
+    cleanly, taking the daemon thread with it).
+    """
+    import select
+
+    parent_pid = os.getppid()
+    if parent_pid == 1:
+        # Already orphaned at install time.
+        handler()
+        return
+
+    kq = select.kqueue()
+    # NOTE_EXIT = 0x80000000, EVFILT_PROC = -5
+    # select.KQ_NOTE_EXIT and select.KQ_FILTER_PROC are exposed by stdlib.
+    event = select.kevent(
+        ident=parent_pid,
+        filter=select.KQ_FILTER_PROC,
+        flags=select.KQ_EV_ADD | select.KQ_EV_ENABLE,
+        fflags=select.KQ_NOTE_EXIT,
+    )
+    # Register; control event will be returned on parent exit.
+    kq.control([event], 0)
+
+    def _watch():
+        try:
+            # Block until the parent exits. Long timeout chunks let the
+            # thread wake periodically so it can notice if the kqueue
+            # has been closed by a separate cleanup path (defensive).
+            while True:
+                events = kq.control(None, 1, 5.0)
+                if events:
+                    break
+                # Defensive: if PPID has changed to 1, the parent was
+                # reaped and the kqueue may have missed it (unlikely
+                # but cheap to check).
+                if os.getppid() == 1:
+                    break
+        except Exception as e:
+            logger.warning("kqueue watcher errored: %s", e)
+            return
+        finally:
+            try:
+                kq.close()
+            except OSError:
+                pass
+        try:
+            handler()
+        except Exception:
+            logger.exception("parent-death handler raised; exiting hard.")
+            os._exit(1)
+
+    t = threading.Thread(
+        target=_watch,
+        name="vllm-parent-death-watchdog",
+        daemon=True,
+    )
+    t.start()
+
+
+# ---------------------------------------------------------------------------
+# Windows: wait on parent process handle from daemon thread
+# ---------------------------------------------------------------------------
+
+
+def _install_windows(handler: Callable[[], None]) -> None:
+    """Windows: open a handle to the parent and wait on it.
+
+    The cleanest Windows primitive is a Job Object with
+    ``JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE``, but that must be set up
+    by the parent before the child is assigned. As a self-installable
+    fallback the child opens ``PROCESS_SYNCHRONIZE`` access on the
+    parent and waits on the handle from a daemon thread. When the
+    wait returns, the parent has exited.
+
+    For a parent-side Job Object integration (better latency, tree
+    propagation), see the follow-up noted in PR_DESCRIPTION.md.
+    """
+    import ctypes
+    from ctypes import wintypes
+
+    parent_pid = os.getppid()
+    if parent_pid in (0, 1):
+        handler()
+        return
+
+    PROCESS_SYNCHRONIZE = 0x00100000
+    SYNCHRONIZE = 0x00100000
+    INFINITE = 0xFFFFFFFF
+    WAIT_OBJECT_0 = 0x00000000
+
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+    OpenProcess = kernel32.OpenProcess
+    OpenProcess.argtypes = [wintypes.DWORD, wintypes.BOOL, wintypes.DWORD]
+    OpenProcess.restype = wintypes.HANDLE
+    WaitForSingleObject = kernel32.WaitForSingleObject
+    WaitForSingleObject.argtypes = [wintypes.HANDLE, wintypes.DWORD]
+    WaitForSingleObject.restype = wintypes.DWORD
+    CloseHandle = kernel32.CloseHandle
+    CloseHandle.argtypes = [wintypes.HANDLE]
+    CloseHandle.restype = wintypes.BOOL
+
+    handle = OpenProcess(
+        PROCESS_SYNCHRONIZE | SYNCHRONIZE, False, parent_pid
+    )
+    if not handle:
+        err = ctypes.get_last_error()
+        raise OSError(err, f"OpenProcess(parent={parent_pid}) failed: {err}")
+
+    def _watch():
+        try:
+            rc = WaitForSingleObject(handle, INFINITE)
+            if rc != WAIT_OBJECT_0:
+                logger.warning(
+                    "WaitForSingleObject on parent returned 0x%x; firing "
+                    "watchdog handler anyway.",
+                    rc,
+                )
+        finally:
+            CloseHandle(handle)
+        try:
+            handler()
+        except Exception:
+            logger.exception("parent-death handler raised; exiting hard.")
+            os._exit(1)
+
+    t = threading.Thread(
+        target=_watch,
+        name="vllm-parent-death-watchdog",
+        daemon=True,
+    )
+    t.start()
+
+
+def _reset_for_testing() -> None:
+    """Reset module state. Test-only."""
+    global _INSTALLED
+    with _LOCK:
+        _INSTALLED = False


### PR DESCRIPTION
# [V1][Bugfix] Reap EngineCore on parent death (#19849)

## Purpose

**Coordinating with @wojciech-wais (#34816) on overlap.** That PR addresses the Linux `prctl(PR_SET_PDEATHSIG)` mechanism with @njhill engaged. After opening this PR I realized the duplication (my duplicate-work check should have caught it pre-push). I've reached out on #34816 to determine whether this lands as a cross-platform companion (macOS kqueue, Windows WaitForSingleObject), as a patch folded into #34816 with co-author credit, or as a follow-up after #34816 merges. Final scope of this PR depends on that coordination.

The EngineCore subprocess does not reliably terminate when the parent
process dies abnormally. SIGKILL on the parent, OOM-killer, segfault,
or `os._exit()` from an embedding host all leak the EngineCore child.
It continues to hold GPU memory and blocks subsequent `LLM()`
instantiations until manually reaped (often via `kill -9` or a reboot,
per the workaround in #17273).

This PR adds a per-OS parent-death watchdog inside the EngineCore
child. When the parent's task struct is reaped by any means, the
kernel notifies the child, which raises SIGTERM to itself. That SIGTERM
is handled by EngineCore's existing cooperative shutdown handler, so
no new shutdown decision is made by the child. The watchdog only makes
the existing cooperative path reachable when the parent can no longer
call `proc.terminate()`.

Per-OS implementation:

* **Linux**: `prctl(PR_SET_PDEATHSIG, SIGTERM)`.
* **macOS**: `kqueue EVFILT_PROC | NOTE_EXIT` on parent PID, polled by a daemon thread.
* **Windows**: `OpenProcess(PROCESS_SYNCHRONIZE)` + `WaitForSingleObject(INFINITE)` from a daemon thread.

Default-on. `VLLM_DISABLE_PARENT_DEATH_WATCHDOG=1` opts out.

Closes (or makes obsolete) the user-facing pain in #19849, #17273, #1908.
Complements RFC #24885 (cooperative shutdown clarification) without
changing its semantics, and does not change the `--shutdown-timeout`
debated in #31252.

## Test plan

New file `tests/v1/engine/test_engine_core_parent_death.py` covers
five scenarios. The first four use `LLM(model="facebook/opt-125m")`
and require CUDA:

| Scenario | Before this PR | After this PR |
|---|---|---|
| Parent SIGKILL | EngineCore orphans | EngineCore reaps via cooperative SIGTERM path |
| Parent `os._exit(0)` (skips atexit/finalize) | EngineCore orphans | EngineCore reaps |
| Parent uncaught exception | EngineCore orphans | EngineCore reaps |
| Parent cooperative `del llm; sys.exit(0)` | EngineCore reaps via existing path | EngineCore reaps via existing path *(no behavior change)* |

The fifth test exercises the OS-level watchdog primitive in isolation
(no model load, no GPU) so CI matrices without CUDA can verify the
primitive cross-platform.

Run: `pytest tests/v1/engine/test_engine_core_parent_death.py -xvs`

## A/B results (macOS, primitive in isolation)

10 trials per cell. Polling resolution 100us.

| Scenario | Watchdog | Reaped | Median reap | Max reap |
|---|---|---|---|---|
| Parent SIGKILL | OFF | **0/10** (all orphaned) | n/a | n/a |
| Parent SIGKILL | ON | **10/10** | 0.0 ms | 0.1 ms |
| Parent SIGTERM (no handler) | OFF | **0/10** (all orphaned) | n/a | n/a |
| Parent SIGTERM (no handler) | ON | **10/10** | 0.0 ms | 0.3 ms |

I verified the macOS kqueue path locally on an M5 Max. The Linux
`PR_SET_PDEATHSIG` and Windows `WaitForSingleObject` paths are
designed and implemented but not exercised on a runner in this
submission. Would appreciate a maintainer with a CUDA box running the
full integration suite before this lands.

## Notes

* The default handler raises `SIGTERM` to self, identical to what
  `proc.terminate()` would deliver. The existing cooperative handler
  is idempotent (`shutdown_state = REQUESTED` is a one-shot
  transition), so cooperative shutdown that completes before the
  watchdog fires simply means the watchdog fires against an
  already-exiting process and the second SIGTERM is a no-op. There is
  no new signal handler installed in the parent; nothing in this PR
  contradicts RFC #24885's "no global signal handlers" principle.
* `PR_SET_PDEATHSIG` is reset on `execve()`. EngineCore does not
  exec, so this is not a concern in the current code path; documented
  in the module docstring.
* The included Windows implementation kills the EngineCore process
  when the parent dies, but does not propagate to TP/PP workers via
  a job object. A parent-side `CreateJobObject` +
  `AssignProcessToJobObject` would do that and is left as a
  follow-up.
* Does not fix the no-op `engine.check_health()` in #19849 example 1.
  The watchdog fixes example 2 (orphaned child after parent dies).

AI assistance was used in drafting this PR.
