### PR TITLE
[BugFix] Fix IndexError in streaming tool call finish path (#33916)

### DIFF
--- a/tests/tool_parsers/test_streamed_args_bounds.py
+++ b/tests/tool_parsers/test_streamed_args_bounds.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Regression test for #33916: IndexError when streamed_args_for_tool is
+shorter than prev_tool_call_arr in the streaming finish path.
+
+The test reproduces the exact access pattern from serving.py:1149 using
+plain dicts to avoid deep import chains that require GPU dependencies.
+"""
+import json
+
+
+def _simulate_finish_delta(prev_tool_call_arr, streamed_args_for_tool):
+    """Reproduces the access pattern from serving.py ~L1098-1158."""
+    auto_tools_called = len(prev_tool_call_arr) > 0
+    index = len(prev_tool_call_arr) - 1 if auto_tools_called else 0
+    if not auto_tools_called:
+        return "no_op"
+
+    args = prev_tool_call_arr[index].get("arguments", {})
+    expected_call = args if isinstance(args, str) else json.dumps(args, ensure_ascii=False)
+
+    # This is the guard added in the fix
+    if index < len(streamed_args_for_tool):
+        actual_call = streamed_args_for_tool[index]
+        remaining_call = expected_call.replace(actual_call, "", 1)
+        return ("remaining", remaining_call)
+
+    return ("skipped", None)
+
+
+def test_prev_set_streamed_empty_no_crash():
+    """#33916: Mistral parser sets prev_tool_call_arr but not streamed_args_for_tool."""
+    result = _simulate_finish_delta(
+        prev_tool_call_arr=[{"arguments": {"a": 1}}],
+        streamed_args_for_tool=[],
+    )
+    assert result == ("skipped", None)
+
+
+def test_both_populated_computes_remaining():
+    result = _simulate_finish_delta(
+        prev_tool_call_arr=[{"arguments": {"a": 1, "b": 2}}],
+        streamed_args_for_tool=['{"a": 1, '],
+    )
+    assert result[0] == "remaining"
+    assert '"b": 2}' in result[1]
+
+
+def test_empty_prev_skips():
+    result = _simulate_finish_delta(
+        prev_tool_call_arr=[],
+        streamed_args_for_tool=[],
+    )
+    assert result == "no_op"
+
+
+def test_multiple_tools_last_index_out_of_bounds():
+    result = _simulate_finish_delta(
+        prev_tool_call_arr=[{"arguments": {}}, {"arguments": {"x": 1}}],
+        streamed_args_for_tool=[""],
+    )
+    assert result == ("skipped", None)
+
+
+def test_without_guard_crashes():
+    """Verify the unpatched code path raises IndexError."""
+    prev_tool_call_arr = [{"arguments": {"a": 1}}]
+    streamed_args_for_tool = []
+    index = len(prev_tool_call_arr) - 1
+    try:
+        _ = streamed_args_for_tool[index]
+        raise AssertionError("Should have raised IndexError")
+    except IndexError:
+        pass

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1146,16 +1146,21 @@ class OpenAIServingChat(OpenAIServing):
 
                             # get what we've streamed so far for arguments
                             # for the current tool
-                            actual_call = tool_parser.streamed_args_for_tool[index]
-                            if latest_delta_len > 0:
-                                actual_call = actual_call[:-latest_delta_len]
+                            if index < len(tool_parser.streamed_args_for_tool):
+                                actual_call = tool_parser.streamed_args_for_tool[
+                                    index
+                                ]
+                                if latest_delta_len > 0:
+                                    actual_call = actual_call[:-latest_delta_len]
 
-                            # check to see if there's anything left to stream
-                            remaining_call = expected_call.replace(actual_call, "", 1)
-                            # set that as a delta message
-                            delta_message = self._create_remaining_args_delta(
-                                delta_message, remaining_call, index
-                            )
+                                # check to see if there's anything left to stream
+                                remaining_call = expected_call.replace(
+                                    actual_call, "", 1
+                                )
+                                # set that as a delta message
+                                delta_message = self._create_remaining_args_delta(
+                                    delta_message, remaining_call, index
+                                )
 
                         # Send the finish response for each request.n only once
                         # In OpenAI's API, when a tool is called, the


### PR DESCRIPTION
## Summary

Fix #33916 — `IndexError: list index out of range` in `chat_completion_stream_generator` when using `--tool-call-parser=mistral` during streaming tool calls.

## Root Cause

In `serving.py:1149`, the streaming finish path computes the "remaining" tool arguments to emit as a final delta:

```python
actual_call = tool_parser.streamed_args_for_tool[index]
```

where `index = len(tool_parser.prev_tool_call_arr) - 1`. However, the **Mistral tool parser** sets `prev_tool_call_arr` as a sentinel to bypass autocompletion (lines 631/870 in `mistral_tool_parser.py`) without ever appending to `streamed_args_for_tool`. This causes `index` to be valid for `prev_tool_call_arr` but out of bounds for `streamed_args_for_tool`.

Other tool parsers (hermes, llama, qwen3coder, etc.) keep both lists in sync. The Mistral parser explicitly does not, by design.

## Fix

Add a bounds check before indexing `streamed_args_for_tool`:

```python
if index < len(tool_parser.streamed_args_for_tool):
    # compute remaining args delta
    ...
```

When the list is shorter, the "remaining args" computation is safely skipped — the tool parser has already handled all streaming itself.

## Changes

| File | Change |
|------|--------|
| `vllm/entrypoints/openai/chat_completion/serving.py` | Guard `streamed_args_for_tool[index]` with bounds check |
| `tests/tool_parsers/test_streamed_args_bounds.py` | 5 regression tests |

## Test Plan

- [x] Reproduced the crash: `prev_tool_call_arr=[{...}]` + `streamed_args_for_tool=[]` → `IndexError`
- [x] Fix verified: same inputs no longer crash, delta returned as-is
- [x] Normal path preserved: when both lists are in sync, remaining args are still computed
- [x] Multi-tool case: last tool index out of bounds handled correctly

Reported with config: `--tool-call-parser=mistral --enable-auto-tool-choice --load-format=mistral --stream-interval=5` on Devstral-Small-2-24B.