### PR TITLE
[Bugfix] Cap SWA/chunked-local runtime admission to startup pool-sizing bound

### DIFF
--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -2513,3 +2513,111 @@ def test_block_lookup_cache_multi_blocks_per_key():
     assert cache.pop(key1, 11) is block11
     assert cache.get_one_block(key1) is None
     assert cache.pop(key1, 12) is None
+
+
+def test_can_fit_full_sequence_swa_cap_admits_long_prompt():
+    """Hybrid full+SWA model with a pool sized at the startup minimum should
+    admit a prompt longer than the SWA cap, because SlidingWindowManager
+    recycles blocks during chunked prefill (issue #39734)."""
+    block_size = 16
+    sliding_window = 4 * block_size  # 64 tokens
+    max_num_batched_tokens = 8 * block_size  # 128 tokens
+    max_model_len = 64 * block_size  # 1024 tokens — much larger than the SWA cap
+    # Startup pool sizing: full demands cdiv(max_model_len, bs) = 64 blocks,
+    # SWA demands cdiv(SW-1+max_batched, bs) + 1 = cdiv(191, 16) + 1 = 13.
+    # Pool minimum = 64 + 13 = 77; +1 for the null block.
+    num_blocks = 64 + 13 + 1
+
+    config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer_full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["layer_swa"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=sliding_window,
+                ),
+            ),
+        ],
+    )
+
+    manager = KVCacheManager(
+        config,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=max_num_batched_tokens,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    # A prompt that is shorter than max_model_len but longer than SW + chunk:
+    # cdiv(prompt_len, bs) = 32 blocks. Without the cap, admission would
+    # demand 32 (full) + 32 (SWA) = 64 blocks. With the cap, SWA contributes
+    # only 13, so total = 32 + 13 = 45 ≤ pool size.
+    prompt_len = 32 * block_size
+    req = make_request("long", list(range(prompt_len)), block_size, sha256)
+
+    assert manager.can_fit_full_sequence(req)
+
+
+def test_can_fit_full_sequence_full_attention_still_gates_oversized():
+    """The cap only loosens the SWA group; a prompt that exceeds the
+    full-attention pool capacity must still be rejected."""
+    block_size = 16
+    sliding_window = 4 * block_size
+    max_num_batched_tokens = 8 * block_size
+    max_model_len = 64 * block_size
+    # Provide a tiny pool — even a small prompt should be rejected.
+    num_blocks = 5
+
+    config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer_full"],
+                FullAttentionSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["layer_swa"],
+                SlidingWindowSpec(
+                    block_size=block_size,
+                    num_kv_heads=1,
+                    head_size=1,
+                    dtype=torch.float32,
+                    sliding_window=sliding_window,
+                ),
+            ),
+        ],
+    )
+
+    manager = KVCacheManager(
+        config,
+        max_model_len=max_model_len,
+        max_num_batched_tokens=max_num_batched_tokens,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    # 16 blocks of full attention demand alone exceeds the 5-block pool.
+    prompt_len = 16 * block_size
+    req = make_request("oversized", list(range(prompt_len)), block_size, sha256)
+
+    assert not manager.can_fit_full_sequence(req)

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -22,11 +22,13 @@ pytestmark = pytest.mark.cpu_test
 
 
 def get_sliding_window_manager(sliding_window_spec, block_pool, enable_caching=True):
+    # Tests don't exercise admission gating; pass a large cap that is a no-op.
     return SlidingWindowManager(
         sliding_window_spec,
         block_pool=block_pool,
         enable_caching=enable_caching,
         kv_cache_group_id=0,
+        max_admission_blocks_per_request=10**9,
     )
 
 
@@ -38,6 +40,7 @@ def get_chunked_local_attention_manager(
         block_pool=block_pool,
         enable_caching=enable_caching,
         kv_cache_group_id=0,
+        max_admission_blocks_per_request=10**9,
     )
 
 

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -34,6 +34,7 @@ class KVCacheCoordinator(ABC):
         self,
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
+        max_num_batched_tokens: int,
         use_eagle: bool,
         enable_caching: bool,
         enable_kv_cache_events: bool,
@@ -59,6 +60,8 @@ class KVCacheCoordinator(ABC):
         self.single_type_managers = tuple(
             get_manager_for_kv_cache_spec(
                 kv_cache_spec=kv_cache_group.kv_cache_spec,
+                max_num_batched_tokens=max_num_batched_tokens,
+                max_model_len=max_model_len,
                 block_pool=self.block_pool,
                 enable_caching=enable_caching,
                 kv_cache_group_id=i,
@@ -265,6 +268,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
         self,
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
+        max_num_batched_tokens: int,
         use_eagle: bool,
         enable_kv_cache_events: bool,
         dcp_world_size: int,
@@ -275,6 +279,7 @@ class KVCacheCoordinatorNoPrefixCache(KVCacheCoordinator):
         super().__init__(
             kv_cache_config,
             max_model_len,
+            max_num_batched_tokens,
             use_eagle,
             False,
             enable_kv_cache_events,
@@ -310,6 +315,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
         self,
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
+        max_num_batched_tokens: int,
         use_eagle: bool,
         enable_caching: bool,
         enable_kv_cache_events: bool,
@@ -321,6 +327,7 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
         super().__init__(
             kv_cache_config,
             max_model_len,
+            max_num_batched_tokens,
             use_eagle,
             enable_caching,
             enable_kv_cache_events,
@@ -375,6 +382,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         self,
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
+        max_num_batched_tokens: int,
         use_eagle: bool,
         enable_caching: bool,
         enable_kv_cache_events: bool,
@@ -386,6 +394,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
         super().__init__(
             kv_cache_config,
             max_model_len,
+            max_num_batched_tokens,
             use_eagle,
             enable_caching,
             enable_kv_cache_events,
@@ -547,6 +556,7 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
 def get_kv_cache_coordinator(
     kv_cache_config: KVCacheConfig,
     max_model_len: int,
+    max_num_batched_tokens: int,
     use_eagle: bool,
     enable_caching: bool,
     enable_kv_cache_events: bool,
@@ -559,6 +569,7 @@ def get_kv_cache_coordinator(
         return KVCacheCoordinatorNoPrefixCache(
             kv_cache_config,
             max_model_len,
+            max_num_batched_tokens,
             use_eagle,
             enable_kv_cache_events,
             dcp_world_size=dcp_world_size,
@@ -570,6 +581,7 @@ def get_kv_cache_coordinator(
         return UnitaryKVCacheCoordinator(
             kv_cache_config,
             max_model_len,
+            max_num_batched_tokens,
             use_eagle,
             enable_caching,
             enable_kv_cache_events,
@@ -581,6 +593,7 @@ def get_kv_cache_coordinator(
     return HybridKVCacheCoordinator(
         kv_cache_config,
         max_model_len,
+        max_num_batched_tokens,
         use_eagle,
         enable_caching,
         enable_kv_cache_events,

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -109,6 +109,7 @@ class KVCacheManager:
         kv_cache_config: KVCacheConfig,
         max_model_len: int,
         hash_block_size: int,
+        max_num_batched_tokens: int | None = None,
         enable_caching: bool = True,
         use_eagle: bool = False,
         log_stats: bool = False,
@@ -118,6 +119,11 @@ class KVCacheManager:
         metrics_collector: KVCacheMetricsCollector | None = None,
     ) -> None:
         self.max_model_len = max_model_len
+        # When unset, fall back to `max_model_len` so the recycling-aware cap
+        # collapses to the prior (uncapped) admission behavior. The scheduler
+        # always supplies the real value at runtime.
+        if max_num_batched_tokens is None:
+            max_num_batched_tokens = max_model_len
 
         self.enable_caching = enable_caching
         self.use_eagle = use_eagle
@@ -131,6 +137,7 @@ class KVCacheManager:
         self.coordinator = get_kv_cache_coordinator(
             kv_cache_config=kv_cache_config,
             max_model_len=self.max_model_len,
+            max_num_batched_tokens=max_num_batched_tokens,
             use_eagle=self.use_eagle,
             enable_caching=self.enable_caching,
             enable_kv_cache_events=enable_kv_cache_events,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -225,6 +225,7 @@ class Scheduler(SchedulerInterface):
         self.kv_cache_manager = KVCacheManager(
             kv_cache_config=kv_cache_config,
             max_model_len=self.max_model_len,
+            max_num_batched_tokens=self.scheduler_config.max_num_batched_tokens,
             enable_caching=self.cache_config.enable_prefix_caching,
             use_eagle=self.use_eagle,
             log_stats=self.log_stats,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -488,11 +488,6 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
     ) -> None:
         super().__init__(kv_cache_spec, **kwargs)
         self.sliding_window = kv_cache_spec.sliding_window
-        # Recycling-aware admission cap: matches the bound used to size the
-        # pool at startup in `SlidingWindowSpec.max_memory_usage_bytes`. Per
-        # request, `remove_skipped_blocks` keeps the real-held block count
-        # from exceeding this; the admission gate composes per-request caps
-        # so total reservations never exceed the pool.
         self._max_admission_blocks_per_request = max_admission_blocks_per_request
 
     def get_num_blocks_to_allocate(
@@ -505,26 +500,23 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
     ) -> int:
         """Return the admission *reservation* (not lifetime block touches).
 
-        For a fresh request, the base implementation would ask for
+        For a fresh, request the base implementation asks for
         ``cdiv(num_tokens, block_size)`` blocks because
         ``get_num_skipped_tokens(0) == 0``. That over-counts: chunked prefill
-        invokes :meth:`remove_skipped_blocks` between chunks, which swaps
+        invokes `remove_skipped_blocks` between chunks, which swaps
         out-of-window blocks for ``null_block`` and returns their slots to
         the pool, so per-request real-held blocks plateau at roughly one
         window's worth.
 
-        We therefore cap demand at the same recycling-aware bound that
-        :meth:`SlidingWindowSpec.max_memory_usage_bytes
-        <vllm.v1.kv_cache_interface.SlidingWindowSpec.max_memory_usage_bytes>`
-        used to size the pool at startup. The two formulas MUST stay in sync
-        (drift re-introduces the deadlock from issue #39734 or, worse,
-        mid-prefill OOM); both derive from
-        :meth:`SlidingWindowSpec.max_admission_blocks_per_request
-        <vllm.v1.kv_cache_interface.SlidingWindowSpec.max_admission_blocks_per_request>`.
+        We cap demand at the same recycling-aware bound that
+        `SlidingWindowSpec.max_memory_usage_bytes` used to size the pool at
+        startup; both call `SlidingWindowSpec.max_admission_blocks_per_request`,
+        the single source of truth -- drift would re-introduce the deadlock
+        from issue #39734 or, worse, mid-prefill OOM.
 
-        Safety: per-request peak ≤ reservation (guaranteed by
-        :meth:`remove_skipped_blocks`), and the admission gate ensures
-        ``sum(reservations) ≤ pool``, so ``sum( peak_real_held) ≤ pool``.
+        Safety: per-request peak <= reservation (held by
+        `remove_skipped_blocks`), and the admission gate ensures
+        ``sum(reservations) <= pool``, so ``sum(peak_real_held) <= pool``.
         """
         capped_num_tokens = min(
             num_tokens, self._max_admission_blocks_per_request * self.block_size
@@ -681,9 +673,6 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
     ) -> None:
         super().__init__(kv_cache_spec, **kwargs)
         self.attention_chunk_size = kv_cache_spec.attention_chunk_size
-        # Recycling-aware admission cap, mirroring the startup pool sizer in
-        # `ChunkedLocalAttentionSpec.max_memory_usage_bytes`. See
-        # `SlidingWindowManager` for the safety argument.
         self._max_admission_blocks_per_request = max_admission_blocks_per_request
 
     def get_num_blocks_to_allocate(
@@ -696,15 +685,12 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
     ) -> int:
         """Return the admission *reservation* (not lifetime block touches).
 
-        Caps demand at the recycling-aware bound mirroring
-        :meth:`ChunkedLocalAttentionSpec.max_memory_usage_bytes
-        <vllm.v1.kv_cache_interface.ChunkedLocalAttentionSpec.max_memory_usage_bytes>`,
-        which the startup pool sizer uses. Both formulas derive from
-        :meth:`ChunkedLocalAttentionSpec.max_admission_blocks_per_request
-        <vllm.v1.kv_cache_interface.ChunkedLocalAttentionSpec.max_admission_blocks_per_request>`
-        and MUST stay in sync. See :meth:`SlidingWindowManager.get_num_blocks_to_allocate`
-        for the recycling-vs-reservation safety argument; the same invariant
-        holds here via :meth:`remove_skipped_blocks`.
+        Caps demand at the recycling-aware bound from
+        `ChunkedLocalAttentionSpec.max_admission_blocks_per_request`, which
+        the startup pool sizer (`max_memory_usage_bytes`) also uses. See
+        `SlidingWindowManager.get_num_blocks_to_allocate` for the
+        recycling-vs-reservation safety argument; the same invariant holds
+        here via `remove_skipped_blocks`.
         """
         capped_num_tokens = min(
             num_tokens, self._max_admission_blocks_per_request * self.block_size

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -40,6 +40,7 @@ class SingleTypeKVCacheManager(ABC):
         kv_cache_group_id: int,
         dcp_world_size: int = 1,
         pcp_world_size: int = 1,
+        max_admission_blocks_per_request: int | None = None,
     ) -> None:
         """
         Initializes the SingleTypeKVCacheManager.
@@ -47,6 +48,12 @@ class SingleTypeKVCacheManager(ABC):
             kv_cache_spec: The kv_cache_spec for this manager.
             block_pool: The block pool.
             kv_cache_group_id: The id of the kv cache group of this manager.
+            max_admission_blocks_per_request: Recycling-aware per-request
+                block cap used by `get_num_blocks_to_allocate`. Only set for
+                spec types that recycle blocks across chunks (SWA,
+                chunked-local); `None` (the default) means no cap, which is
+                correct for full-attention-style specs that hold every
+                block until the request finishes.
         """
         self.block_size = kv_cache_spec.block_size
         self.dcp_world_size = dcp_world_size
@@ -56,6 +63,7 @@ class SingleTypeKVCacheManager(ABC):
         self.kv_cache_spec = kv_cache_spec
         self.block_pool = block_pool
         self.enable_caching = enable_caching
+        self._max_admission_blocks_per_request = max_admission_blocks_per_request
         self.new_block_ids: list[int] = []
 
         # Mapping from request ID to blocks to track the blocks allocated
@@ -104,6 +112,19 @@ class SingleTypeKVCacheManager(ABC):
         """
 
         num_required_blocks = cdiv(num_tokens, self.block_size)
+        if self._max_admission_blocks_per_request is not None:
+            # Recycling-aware specs (SWA, chunked-local) cap the per-request
+            # reservation here so admission matches the startup pool sizer
+            # (`SlidingWindowSpec.max_admission_blocks_per_request` / its
+            # chunked-local counterpart). `remove_skipped_blocks` runs from
+            # `allocate_slots` before each chunk's `get_num_blocks_to_allocate`,
+            # so per-request peak real-held blocks <= this cap, which keeps
+            # `sum(reservations) <= pool` <=> `sum(peak_real_held) <= pool`.
+            # Drift between the two would re-introduce the deadlock from
+            # issue #39734 or, worse, mid-prefill OOM.
+            num_required_blocks = min(
+                num_required_blocks, self._max_admission_blocks_per_request
+            )
         num_req_blocks = len(self.req_to_blocks.get(request_id, ()))
 
         if request_id in self.num_cached_block:
@@ -479,55 +500,9 @@ class FullAttentionManager(SingleTypeKVCacheManager):
 
 
 class SlidingWindowManager(SingleTypeKVCacheManager):
-    def __init__(
-        self,
-        kv_cache_spec: SlidingWindowSpec,
-        *,
-        max_admission_blocks_per_request: int,
-        **kwargs,
-    ) -> None:
+    def __init__(self, kv_cache_spec: SlidingWindowSpec, **kwargs) -> None:
         super().__init__(kv_cache_spec, **kwargs)
         self.sliding_window = kv_cache_spec.sliding_window
-        self._max_admission_blocks_per_request = max_admission_blocks_per_request
-
-    def get_num_blocks_to_allocate(
-        self,
-        request_id: str,
-        num_tokens: int,
-        new_computed_blocks: Sequence[KVCacheBlock],
-        total_computed_tokens: int,
-        num_tokens_main_model: int,
-    ) -> int:
-        """Return the admission *reservation* (not lifetime block touches).
-
-        For a fresh, request the base implementation asks for
-        ``cdiv(num_tokens, block_size)`` blocks because
-        ``get_num_skipped_tokens(0) == 0``. That over-counts: chunked prefill
-        invokes `remove_skipped_blocks` between chunks, which swaps
-        out-of-window blocks for ``null_block`` and returns their slots to
-        the pool, so per-request real-held blocks plateau at roughly one
-        window's worth.
-
-        We cap demand at the same recycling-aware bound that
-        `SlidingWindowSpec.max_memory_usage_bytes` used to size the pool at
-        startup; both call `SlidingWindowSpec.max_admission_blocks_per_request`,
-        the single source of truth -- drift would re-introduce the deadlock
-        from issue #39734 or, worse, mid-prefill OOM.
-
-        Safety: per-request peak <= reservation (held by
-        `remove_skipped_blocks`), and the admission gate ensures
-        ``sum(reservations) <= pool``, so ``sum(peak_real_held) <= pool``.
-        """
-        capped_num_tokens = min(
-            num_tokens, self._max_admission_blocks_per_request * self.block_size
-        )
-        return super().get_num_blocks_to_allocate(
-            request_id,
-            capped_num_tokens,
-            new_computed_blocks,
-            total_computed_tokens,
-            num_tokens_main_model,
-        )
 
     @classmethod
     def find_longest_cache_hit(
@@ -664,44 +639,9 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
 
 
 class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
-    def __init__(
-        self,
-        kv_cache_spec: ChunkedLocalAttentionSpec,
-        *,
-        max_admission_blocks_per_request: int,
-        **kwargs,
-    ) -> None:
+    def __init__(self, kv_cache_spec: ChunkedLocalAttentionSpec, **kwargs) -> None:
         super().__init__(kv_cache_spec, **kwargs)
         self.attention_chunk_size = kv_cache_spec.attention_chunk_size
-        self._max_admission_blocks_per_request = max_admission_blocks_per_request
-
-    def get_num_blocks_to_allocate(
-        self,
-        request_id: str,
-        num_tokens: int,
-        new_computed_blocks: Sequence[KVCacheBlock],
-        total_computed_tokens: int,
-        num_tokens_main_model: int,
-    ) -> int:
-        """Return the admission *reservation* (not lifetime block touches).
-
-        Caps demand at the recycling-aware bound from
-        `ChunkedLocalAttentionSpec.max_admission_blocks_per_request`, which
-        the startup pool sizer (`max_memory_usage_bytes`) also uses. See
-        `SlidingWindowManager.get_num_blocks_to_allocate` for the
-        recycling-vs-reservation safety argument; the same invariant holds
-        here via `remove_skipped_blocks`.
-        """
-        capped_num_tokens = min(
-            num_tokens, self._max_admission_blocks_per_request * self.block_size
-        )
-        return super().get_num_blocks_to_allocate(
-            request_id,
-            capped_num_tokens,
-            new_computed_blocks,
-            total_computed_tokens,
-            num_tokens_main_model,
-        )
 
     @classmethod
     def find_longest_cache_hit(

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -479,9 +479,63 @@ class FullAttentionManager(SingleTypeKVCacheManager):
 
 
 class SlidingWindowManager(SingleTypeKVCacheManager):
-    def __init__(self, kv_cache_spec: SlidingWindowSpec, **kwargs) -> None:
+    def __init__(
+        self,
+        kv_cache_spec: SlidingWindowSpec,
+        *,
+        max_admission_blocks_per_request: int,
+        **kwargs,
+    ) -> None:
         super().__init__(kv_cache_spec, **kwargs)
         self.sliding_window = kv_cache_spec.sliding_window
+        # Recycling-aware admission cap: matches the bound used to size the
+        # pool at startup in `SlidingWindowSpec.max_memory_usage_bytes`. Per
+        # request, `remove_skipped_blocks` keeps the real-held block count
+        # from exceeding this; the admission gate composes per-request caps
+        # so total reservations never exceed the pool.
+        self._max_admission_blocks_per_request = max_admission_blocks_per_request
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        total_computed_tokens: int,
+        num_tokens_main_model: int,
+    ) -> int:
+        """Return the admission *reservation* (not lifetime block touches).
+
+        For a fresh request, the base implementation would ask for
+        ``cdiv(num_tokens, block_size)`` blocks because
+        ``get_num_skipped_tokens(0) == 0``. That over-counts: chunked prefill
+        invokes :meth:`remove_skipped_blocks` between chunks, which swaps
+        out-of-window blocks for ``null_block`` and returns their slots to
+        the pool, so per-request real-held blocks plateau at roughly one
+        window's worth.
+
+        We therefore cap demand at the same recycling-aware bound that
+        :meth:`SlidingWindowSpec.max_memory_usage_bytes
+        <vllm.v1.kv_cache_interface.SlidingWindowSpec.max_memory_usage_bytes>`
+        used to size the pool at startup. The two formulas MUST stay in sync
+        (drift re-introduces the deadlock from issue #39734 or, worse,
+        mid-prefill OOM); both derive from
+        :meth:`SlidingWindowSpec.max_admission_blocks_per_request
+        <vllm.v1.kv_cache_interface.SlidingWindowSpec.max_admission_blocks_per_request>`.
+
+        Safety: per-request peak ≤ reservation (guaranteed by
+        :meth:`remove_skipped_blocks`), and the admission gate ensures
+        ``sum(reservations) ≤ pool``, so ``sum( peak_real_held) ≤ pool``.
+        """
+        capped_num_tokens = min(
+            num_tokens, self._max_admission_blocks_per_request * self.block_size
+        )
+        return super().get_num_blocks_to_allocate(
+            request_id,
+            capped_num_tokens,
+            new_computed_blocks,
+            total_computed_tokens,
+            num_tokens_main_model,
+        )
 
     @classmethod
     def find_longest_cache_hit(
@@ -618,9 +672,50 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
 
 
 class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
-    def __init__(self, kv_cache_spec: ChunkedLocalAttentionSpec, **kwargs) -> None:
+    def __init__(
+        self,
+        kv_cache_spec: ChunkedLocalAttentionSpec,
+        *,
+        max_admission_blocks_per_request: int,
+        **kwargs,
+    ) -> None:
         super().__init__(kv_cache_spec, **kwargs)
         self.attention_chunk_size = kv_cache_spec.attention_chunk_size
+        # Recycling-aware admission cap, mirroring the startup pool sizer in
+        # `ChunkedLocalAttentionSpec.max_memory_usage_bytes`. See
+        # `SlidingWindowManager` for the safety argument.
+        self._max_admission_blocks_per_request = max_admission_blocks_per_request
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        total_computed_tokens: int,
+        num_tokens_main_model: int,
+    ) -> int:
+        """Return the admission *reservation* (not lifetime block touches).
+
+        Caps demand at the recycling-aware bound mirroring
+        :meth:`ChunkedLocalAttentionSpec.max_memory_usage_bytes
+        <vllm.v1.kv_cache_interface.ChunkedLocalAttentionSpec.max_memory_usage_bytes>`,
+        which the startup pool sizer uses. Both formulas derive from
+        :meth:`ChunkedLocalAttentionSpec.max_admission_blocks_per_request
+        <vllm.v1.kv_cache_interface.ChunkedLocalAttentionSpec.max_admission_blocks_per_request>`
+        and MUST stay in sync. See :meth:`SlidingWindowManager.get_num_blocks_to_allocate`
+        for the recycling-vs-reservation safety argument; the same invariant
+        holds here via :meth:`remove_skipped_blocks`.
+        """
+        capped_num_tokens = min(
+            num_tokens, self._max_admission_blocks_per_request * self.block_size
+        )
+        return super().get_num_blocks_to_allocate(
+            request_id,
+            capped_num_tokens,
+            new_computed_blocks,
+            total_computed_tokens,
+            num_tokens_main_model,
+        )
 
     @classmethod
     def find_longest_cache_hit(
@@ -1126,8 +1221,20 @@ spec_manager_map: dict[type[KVCacheSpec], type[SingleTypeKVCacheManager]] = {
 
 
 def get_manager_for_kv_cache_spec(
-    kv_cache_spec: KVCacheSpec, **kwargs
+    kv_cache_spec: KVCacheSpec,
+    max_num_batched_tokens: int,
+    max_model_len: int,
+    **kwargs,
 ) -> SingleTypeKVCacheManager:
     manager_class = spec_manager_map[type(kv_cache_spec)]
+    # SlidingWindow / ChunkedLocalAttention managers recycle blocks across
+    # chunks; the runtime admission cap must match the recycling-aware bound
+    # the startup pool sizer uses (single source of truth: the spec method).
+    if isinstance(kv_cache_spec, (SlidingWindowSpec, ChunkedLocalAttentionSpec)):
+        kwargs["max_admission_blocks_per_request"] = (
+            kv_cache_spec.max_admission_blocks_per_request(
+                max_num_batched_tokens, max_model_len
+            )
+        )
     manager = manager_class(kv_cache_spec, **kwargs)
     return manager

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -1159,7 +1159,8 @@ def get_manager_for_kv_cache_spec(
     if isinstance(kv_cache_spec, (SlidingWindowSpec, ChunkedLocalAttentionSpec)):
         kwargs["max_admission_blocks_per_request"] = (
             kv_cache_spec.max_admission_blocks_per_request(
-                max_num_batched_tokens, max_model_len
+                max_num_batched_tokens=max_num_batched_tokens,
+                max_model_len=max_model_len,
             )
         )
     manager = manager_class(kv_cache_spec, **kwargs)

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -343,9 +343,9 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
     ) -> int:
         """Per-request admission cap, in blocks.
 
-        Matches the recycling-aware bound used to size the pool at startup
-        (see `max_memory_usage_bytes`). Used by the runtime admission gate so
-        that requests admitted by startup can also be admitted at runtime.
+        Single source of truth for both startup pool sizing
+        (`max_memory_usage_bytes`) and the runtime admission gate, so requests
+        admitted by startup can also be admitted at runtime.
         """
         # During chunked prefill, we hold KV for at most one chunk window.
         num_tokens = min(
@@ -386,13 +386,11 @@ class SlidingWindowSpec(AttentionSpec):
     ) -> int:
         """Per-request admission cap, in blocks.
 
-        Matches the recycling-aware bound used to size the pool at startup
-        (see `max_memory_usage_bytes`). Used by the runtime admission gate so
-        that requests admitted by startup can also be admitted at runtime.
-
-        Safety: `SlidingWindowManager.remove_skipped_blocks` is invoked from
-        `allocate_slots` before each chunk's `get_num_blocks_to_allocate`, so
-        the per-request real-held block count plateaus at this bound.
+        Single source of truth for both startup pool sizing
+        (`max_memory_usage_bytes`) and the runtime admission gate. Per-request
+        real-held blocks plateau at this bound because
+        `SlidingWindowManager.remove_skipped_blocks` runs from `allocate_slots`
+        before each chunk's `get_num_blocks_to_allocate`.
         """
         # During chunked prefill, we hold KV for the last `sliding_window-1`
         # computed tokens plus the newly scheduled tokens, and never more

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -354,13 +354,12 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
         return cdiv(num_tokens, self.block_size)
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
-        return (
-            self.max_admission_blocks_per_request(
-                vllm_config.scheduler_config.max_num_batched_tokens,
-                vllm_config.model_config.max_model_len,
-            )
-            * self.page_size_bytes
+        max_model_len = vllm_config.model_config.max_model_len
+        max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        max_blocks = self.max_admission_blocks_per_request(
+            max_model_len, max_num_batched_tokens
         )
+        return max_blocks * self.page_size_bytes
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -407,13 +406,12 @@ class SlidingWindowSpec(AttentionSpec):
         assert vllm_config.parallel_config.decode_context_parallel_size == 1, (
             "DCP not support sliding window."
         )
-        return (
-            self.max_admission_blocks_per_request(
-                vllm_config.scheduler_config.max_num_batched_tokens,
-                vllm_config.model_config.max_model_len,
-            )
-            * self.page_size_bytes
+        max_model_len = vllm_config.model_config.max_model_len
+        max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        max_blocks = self.max_admission_blocks_per_request(
+            max_model_len, max_num_batched_tokens
         )
+        return max_blocks * self.page_size_bytes
 
 
 @dataclass(frozen=True)

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -338,19 +338,29 @@ class MLAAttentionSpec(FullAttentionSpec):
 class ChunkedLocalAttentionSpec(AttentionSpec):
     attention_chunk_size: int
 
-    def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
-        max_model_len = vllm_config.model_config.max_model_len
-        max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+    def max_admission_blocks_per_request(
+        self, max_num_batched_tokens: int, max_model_len: int
+    ) -> int:
+        """Per-request admission cap, in blocks.
 
-        # During chunked prefill, we allocate KV cache for at most
-        # `self.attention_chunk_size` computed tokens plus the newly scheduled
-        # tokens. And we won't allocate KV cache for more than `max_model_len`
-        # tokens.
+        Matches the recycling-aware bound used to size the pool at startup
+        (see `max_memory_usage_bytes`). Used by the runtime admission gate so
+        that requests admitted by startup can also be admitted at runtime.
+        """
+        # During chunked prefill, we hold KV for at most one chunk window.
         num_tokens = min(
             self.attention_chunk_size + max_num_batched_tokens, max_model_len
         )
+        return cdiv(num_tokens, self.block_size)
 
-        return cdiv(num_tokens, self.block_size) * self.page_size_bytes
+    def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
+        return (
+            self.max_admission_blocks_per_request(
+                vllm_config.scheduler_config.max_num_batched_tokens,
+                vllm_config.model_config.max_model_len,
+            )
+            * self.page_size_bytes
+        )
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -371,26 +381,41 @@ class SlidingWindowSpec(AttentionSpec):
             * get_dtype_size(self.dtype)
         )
 
+    def max_admission_blocks_per_request(
+        self, max_num_batched_tokens: int, max_model_len: int
+    ) -> int:
+        """Per-request admission cap, in blocks.
+
+        Matches the recycling-aware bound used to size the pool at startup
+        (see `max_memory_usage_bytes`). Used by the runtime admission gate so
+        that requests admitted by startup can also be admitted at runtime.
+
+        Safety: `SlidingWindowManager.remove_skipped_blocks` is invoked from
+        `allocate_slots` before each chunk's `get_num_blocks_to_allocate`, so
+        the per-request real-held block count plateaus at this bound.
+        """
+        # During chunked prefill, we hold KV for the last `sliding_window-1`
+        # computed tokens plus the newly scheduled tokens, and never more
+        # than `max_model_len`.
+        num_tokens = min(
+            self.sliding_window - 1 + max_num_batched_tokens, max_model_len
+        )
+        # +1 because the sliding window may not start from the beginning of
+        # the block. E.g. block size 4 and num_token 4 needs two blocks
+        # [XXCD][EF] to store the 6-token window [CDEF].
+        return cdiv(num_tokens, self.block_size) + 1
+
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         assert vllm_config.parallel_config.decode_context_parallel_size == 1, (
             "DCP not support sliding window."
         )
-        max_model_len = vllm_config.model_config.max_model_len
-        max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
-
-        # During chunked prefill, we allocate KV cache for the last
-        # `self.sliding_window-1` computed tokens plus the newly scheduled
-        # tokens. And we won't allocate KV cache for more than `max_model_len`
-        # tokens.
-        num_tokens = min(
-            self.sliding_window - 1 + max_num_batched_tokens, max_model_len
+        return (
+            self.max_admission_blocks_per_request(
+                vllm_config.scheduler_config.max_num_batched_tokens,
+                vllm_config.model_config.max_model_len,
+            )
+            * self.page_size_bytes
         )
-
-        # +1 here because the sliding window may not start from the beginning
-        # of the block. For example, if the block size is 4 and num_token
-        # is 4, we need two blocks [XXCD] [EF] to store the sliding
-        # window [CDEF] of 6 tokens.
-        return (cdiv(num_tokens, self.block_size) + 1) * self.page_size_bytes
 
 
 @dataclass(frozen=True)

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -357,7 +357,7 @@ class ChunkedLocalAttentionSpec(AttentionSpec):
         max_model_len = vllm_config.model_config.max_model_len
         max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         max_blocks = self.max_admission_blocks_per_request(
-            max_model_len, max_num_batched_tokens
+            max_num_batched_tokens=max_num_batched_tokens, max_model_len=max_model_len
         )
         return max_blocks * self.page_size_bytes
 
@@ -409,7 +409,7 @@ class SlidingWindowSpec(AttentionSpec):
         max_model_len = vllm_config.model_config.max_model_len
         max_num_batched_tokens = vllm_config.scheduler_config.max_num_batched_tokens
         max_blocks = self.max_admission_blocks_per_request(
-            max_model_len, max_num_batched_tokens
+            max_num_batched_tokens=max_num_batched_tokens, max_model_len=max_model_len
         )
         return max_blocks * self.page_size_bytes
 

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -110,6 +110,9 @@ class SimpleCPUOffloadScheduler:
         self.cpu_coordinator: KVCacheCoordinator = get_kv_cache_coordinator(
             kv_cache_config=self.cpu_kv_cache_config,
             max_model_len=vllm_config.model_config.max_model_len,
+            max_num_batched_tokens=(
+                vllm_config.scheduler_config.max_num_batched_tokens
+            ),
             use_eagle=False,
             enable_caching=True,
             enable_kv_cache_events=self.enable_kv_cache_events,


### PR DESCRIPTION
## Purpose

Fixes #39734 (and the same root cause that motivates #39866 / #40027): on hybrid full + sliding-window models with the pool sized at the startup minimum, runtime admission rejects long-but-fittable prompts because the SWA admission gate budgets the full sequence even though `SlidingWindowManager.remove_skipped_blocks` recycles out-of-window blocks each chunk. The startup pool sizer already accounts for this; the runtime gate did not. The two formulas drifted, producing scheduler stalls and head-of-line blocking on Gemma-4 31B-class workloads.

This PR makes startup pool sizing and runtime admission use the **same** recycling-aware bound by introducing a `max_admission_blocks_per_request` method on `SlidingWindowSpec` and `ChunkedLocalAttentionSpec`. Both `max_memory_usage_bytes` (startup sizer) and `get_num_blocks_to_allocate` (runtime gate) call it. They cannot drift.

## Relationship to existing PRs (per AGENTS.md duplicate-work check)

- **#39866** (open) — Same observed symptom; different design. #39866 caps in the **coordinator** by adding a separate admission method (`get_num_blocks_needed_for_admission`) alongside the existing `get_num_blocks_to_allocate`. The token-cap formula `min(num_tokens, sliding_window + max_num_batched_tokens)` is duplicated separately from the startup pool-sizing formula in `max_memory_usage_bytes`, so the two can drift. SWA only.
- **#40027** (open, follow-up to #39866) — Patches the admission/allocation gap that #39866 introduces, where admission succeeds with the capped count but the allocator still requires the uncapped count and raises `ValueError: Cannot get 1 free blocks from the pool`.

This PR's design avoids that gap by construction:

| Aspect | #39866 + #40027 | This PR |
|---|---|---|
| Where the cap lives | Coordinator wraps the manager call | Inside `SlidingWindowManager.get_num_blocks_to_allocate` |
| Admission vs. allocation | Two paths (capped vs. uncapped) → needs #40027 guard | Same path → no gap |
| Source of truth | Cap formula duplicated in coordinator | `max_admission_blocks_per_request` on the spec, called from both `max_memory_usage_bytes` and the manager |
| Block-level math | Token cap (`sliding_window + max_num_batched_tokens`) | Block cap matching startup formula (`cdiv(sliding_window-1+max_num_batched_tokens, block_size) + 1`, capped at `max_model_len`) |
| ChunkedLocalAttention | Not covered | Covered by the same mechanism |

I'd be happy to fold useful pieces (e.g., the head-of-line repro in #39866's bench numbers) into the discussion, or close in favor of either if the maintainers prefer the other shape.

## Changes

- `vllm/v1/kv_cache_interface.py` — add `SlidingWindowSpec.max_admission_blocks_per_request` and `ChunkedLocalAttentionSpec.max_admission_blocks_per_request`. Refactor each spec's `max_memory_usage_bytes` to call its own admission method, locking startup and runtime to one formula.
- `vllm/v1/core/single_type_kv_cache_manager.py` — `SlidingWindowManager` and `ChunkedLocalAttentionManager` accept `max_admission_blocks_per_request` and cap `num_tokens` inside `get_num_blocks_to_allocate` to `max_admission_blocks_per_request * block_size` (recycling-aware reservation, not lifetime touches).
- `vllm/v1/core/kv_cache_coordinator.py`, `vllm/v1/core/kv_cache_manager.py`, `vllm/v1/core/sched/scheduler.py`, `vllm/v1/simple_kv_offload/manager.py` — plumb `max_num_batched_tokens` through so the spec method can be called at manager-construction time. Defaults to `max_model_len` when not supplied (preserves the legacy uncapped behavior for direct callers).

## Safety argument

Per-request peak real-held blocks ≤ reservation, because `SlidingWindowManager.remove_skipped_blocks` (and the chunked-local equivalent) is invoked from `allocate_slots` before each chunk's `get_num_blocks_to_allocate`, swapping out-of-window blocks for `null_block`. The admission gate enforces `sum(reservations) ≤ pool`. Therefore `sum(peak_real_held) ≤ pool`. Drift between the two formulas would re-introduce #39734 or, worse, mid-prefill OOM — they MUST stay in sync, which is exactly what the single-source-of-truth design guarantees.

## Test plan

```bash
.venv/bin/python -m pytest tests/v1/core/test_prefix_caching.py tests/v1/core/test_single_type_kv_cache_manager.py -v
```

New tests:
- `test_can_fit_full_sequence_swa_cap_admits_long_prompt` — hybrid full+SWA, pool sized at startup minimum, prompt longer than SWA window. Without the cap: 32 (full) + 32 (SWA) = 64 blocks demanded → reject. With the cap: 32 (full) + 13 (SWA) = 45 ≤ pool. Asserts admission succeeds.
- `test_can_fit_full_sequence_full_attention_still_gates_oversized` — confirms the cap does not weaken the genuine-too-big rejection path on full-attention groups.

Reproduce head-of-line blocking on Gemma3:

```
.venv/bin/vllm serve google/gemma-3-12b-it \
    --tensor-parallel-size 1 \
    --max-num-seqs 8 \
    --max-num-batched-tokens 8192 \
    --max-model-len 131072 \
    --gpu-memory-utilization 0.25 \
    --enable-prefix-caching \
    --async-scheduling \
    --host 0.0.0.0 --port 8000
```

```
GPU KV cache size: 51,120 tokens
Maximum concurrency for 131,072 tokens per request: 1.73x
```

Send 4 requests of size: `[100_000, 5_000, 13_000, 14_000]` ("hello" * n).

Before the fix: 
```
Running: 0 reqs, Waiting: 4 reqs
```

After the fix all 4 went through.
## Test results

```
============================ 65 passed in 12.25s ============================
```

## AI-assisted contribution disclosure

This change was developed with AI assistance (Claude Code). The submitter has reviewed every changed line, runs the test suite locally, and stands behind the design choice and the safety argument above.

---

Signed-off-by: Dao Le <Dao007forever@gmail.com>

Co-authored-by: Claude