### PR TITLE
[Bugfix] Fix FlashInfer AllReduce benchmark initialization and workspace size

### DIFF
--- a/benchmarks/kernels/benchmark_device_communicators.py
+++ b/benchmarks/kernels/benchmark_device_communicators.py
@@ -41,6 +41,10 @@ from vllm.distributed.device_communicators.pynccl_allocator import (
     set_graph_pool_id,
 )
 from vllm.distributed.device_communicators.symm_mem import SymmMemCommunicator
+from vllm.distributed.parallel_state import (
+    destroy_distributed_environment,
+    init_distributed_environment,
+)
 from vllm.logger import init_logger
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 
@@ -488,8 +492,7 @@ def main():
     args = parser.parse_args()
 
     # Initialize distributed
-    if not dist.is_initialized():
-        dist.init_process_group(backend="gloo")
+    init_distributed_environment(backend="gloo")
     rank = dist.get_rank()
     world_size = dist.get_world_size()
 
@@ -565,6 +568,7 @@ def main():
     # Cleanup
     if cpu_group != dist.group.WORLD:
         dist.destroy_process_group(cpu_group)
+    destroy_distributed_environment()
 
 
 if __name__ == "__main__":

--- a/benchmarks/kernels/benchmark_device_communicators.py
+++ b/benchmarks/kernels/benchmark_device_communicators.py
@@ -173,6 +173,7 @@ class CommunicatorBenchmark:
             self.fi_ar_comm = FlashInferAllReduce(
                 group=self.cpu_group,
                 device=self.device,
+                max_size_override=self.max_size_override,
             )
             if not self.fi_ar_comm.disabled:
                 logger.info("Rank %s: FlashInferAllReduce initialized", self.rank)

--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -231,6 +231,7 @@ class FlashInferAllReduce:
         self,
         group: ProcessGroup,
         device: int | str | torch.device,
+        max_size_override: int | None = None,
     ):
         self.disabled = True
 
@@ -253,20 +254,24 @@ class FlashInferAllReduce:
         if self.world_size == 1:
             return
 
-        # Use the same threshold as the allreduce-rms fusion pass
-        # TODO: tune the threshold
-        MiB = 1024 * 1024
-        max_workspace_size = PassConfig.default_fi_allreduce_fusion_max_size_mb().get(
-            self.world_size, None
-        )
-        if not max_workspace_size:
-            logger.warning(
-                "FlashInfer All Reduce is disabled because it "
-                "is not supported for world_size=%d.",
-                self.world_size,
+        # Use override max_size if provided, otherwise use default
+        if max_size_override is not None:
+            self.max_workspace_size = max_size_override
+        else:
+            # Use the same threshold as the allreduce-rms fusion pass
+            # TODO: tune the threshold
+            MiB = 1024 * 1024
+            max_workspace_size = PassConfig.default_fi_allreduce_fusion_max_size_mb().get(
+                self.world_size, None
             )
-            return
-        self.max_workspace_size = int(max_workspace_size * MiB)
+            if not max_workspace_size:
+                logger.warning(
+                    "FlashInfer All Reduce is disabled because it "
+                    "is not supported for world_size=%d.",
+                    self.world_size,
+                )
+                return
+            self.max_workspace_size = int(max_workspace_size * MiB)
         self.max_num_tokens = 0
         self.disabled = False
 

--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -261,8 +261,10 @@ class FlashInferAllReduce:
             # Use the same threshold as the allreduce-rms fusion pass
             # TODO: tune the threshold
             MiB = 1024 * 1024
-            max_workspace_size = PassConfig.default_fi_allreduce_fusion_max_size_mb().get(
-                self.world_size, None
+            max_workspace_size = (
+                PassConfig.default_fi_allreduce_fusion_max_size_mb().get(
+                    self.world_size, None
+                )
             )
             if not max_workspace_size:
                 logger.warning(

--- a/vllm/distributed/device_communicators/flashinfer_all_reduce.py
+++ b/vllm/distributed/device_communicators/flashinfer_all_reduce.py
@@ -266,7 +266,7 @@ class FlashInferAllReduce:
                 self.world_size,
             )
             return
-        self.max_workspace_size = max_workspace_size * MiB
+        self.max_workspace_size = int(max_workspace_size * MiB)
         self.max_num_tokens = 0
         self.disabled = False
 


### PR DESCRIPTION


## Purpose

Fix two bugs that prevent `benchmark_device_communicators.py` from running FlashInfer AllReduce (`flashinfer_mnnvl` / `flashinfer_trtllm`) benchmarks.

**Bug 1: Missing vLLM parallel state initialization**

The benchmark script only called `torch.distributed.init_process_group(backend="gloo")`, which does not initialize vLLM's internal `_NODE_COUNT`. When `FlashInferAllReduce.__init__` triggers workspace creation via `get_fi_ar_workspace` -> `get_node_count()`, it hits:

```
AssertionError: distributed environment is not initialized
```

**Fix:** Replace bare `dist.init_process_group` with `init_distributed_environment(backend="gloo")` (and add the matching `destroy_distributed_environment()` on cleanup). This initializes vLLM's `_WORLD` and `_NODE_COUNT` so `get_node_count()` works correctly.

**Bug 2: Float workspace size on SM90 8-GPU (workspace allocation failure)**

`FI_ALLREDUCE_FUSION_MAX_SIZE_MB` defines `{8: 0.5}` for SM90. The old code computed `max_workspace_size * MiB` which yields `524288.0` (a float). This float value is later passed to FlashInfer's workspace allocator which expects an integer byte count, causing allocation to fail.

**Fix:** Wrap the computation with `int(max_workspace_size * MiB)` to ensure an integer byte count. Also add a `max_size_override` parameter to `FlashInferAllReduce.__init__` so the benchmark can specify a custom workspace size (consistent with how `CustomAllreduce` and `SymmMemCommunicator` already accept `max_size_override`).

## Test Plan

### Benchmark (8 * H100)

```bash
NCCL_NVLS_ENABLE=1 NCCL_CUMEM_ENABLE=1 VLLM_USE_NCCL_SYMM_MEM=1 \
torchrun --nproc_per_node=8 benchmarks/kernels/benchmark_device_communicators.py \
    --sequence-lengths 16 64 128 512 1024 2048 4096 8192
```

## Test Result

### vLLM main

```
[rank1]: Traceback (most recent call last):
[rank1]:   File "<VLLM_ROOT>/benchmarks/kernels/benchmark_device_communicators.py", line 342, in benchmark_allreduce_single
[rank1]:     if not should_use_fn(tensor):
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "<VLLM_ROOT>/benchmarks/kernels/benchmark_device_communicators.py", line 274, in <lambda>
[rank1]:     lambda t, c=comm: c.should_use_fi_ar(t),
[rank1]:                       ^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "<VLLM_ROOT>/vllm/distributed/device_communicators/flashinfer_all_reduce.py", line 312, in should_use_fi_ar
[rank1]:     return self._ensure_workspace(hidden_dim, input_tensor.dtype)
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "<VLLM_ROOT>/vllm/distributed/device_communicators/flashinfer_all_reduce.py", line 278, in _ensure_workspace
[rank1]:     workspace = get_fi_ar_workspace(
[rank1]:                 ^^^^^^^^^^^^^^^^^^^^
[rank1]:   File "<VLLM_ROOT>/vllm/distributed/device_communicators/flashinfer_all_reduce.py", line 134, in get_fi_ar_workspace
[rank1]:     if get_node_count() > 1 and backend == "trtllm":
[rank1]:        ^^^^^^^^^^^^^^^^
[rank1]:   File "<VLLM_ROOT>/vllm/distributed/parallel_state.py", line 1851, in get_node_count
[rank1]:     assert _NODE_COUNT is not None, "distributed environment is not initialized"
[rank1]:            ^^^^^^^^^^^^^^^^^^^^^^^
[rank1]: AssertionError: distributed environment is not initialized
```

### This PR

```
==================================================================================================================================
Device Communicator Benchmark Results
World Size: 8, Data Type: torch.bfloat16, Hidden Size: 8192
==================================================================================================================================
Tensor Shape        Tensor Size    ca_1stage           ca_2stage           flashinfer_mnnvl    flashinfer_trtllm   pynccl              pynccl-symm         symm_mem_multimem   symm_mem_two_shot   Best (Speedup vs PyNccl)      
---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
(16, 8192)          0.25 MB        0.011               0.015               0.005               0.013               0.019               0.010               0.010               0.016               flashinfer_mnnvl (3.78x)      
(64, 8192)          1.00 MB        0.028               0.017               0.010               0.045               0.025               0.014               0.015               0.018               flashinfer_mnnvl (2.60x)      
(128, 8192)         2.00 MB        0.052               0.021               0.017               0.093               0.038               0.019               0.019               0.023               flashinfer_mnnvl (2.28x)      
(512, 8192)         8.00 MB        0.189               0.061               0.056               0.081               0.079               0.048               0.047               0.068               symm_mem_multimem (1.66x)     
(1024, 8192)        16.00 MB       0.374               0.113               0.106               0.137               0.121               0.083               0.092               0.133               pynccl-symm (1.45x)           
(2048, 8192)        32.00 MB       0.744               0.211               0.207               0.258               0.196               0.157               0.178               0.256               pynccl-symm (1.25x)           
(4096, 8192)        64.00 MB       1.492               0.410               0.408               0.487               0.320               0.301               0.344               0.503               pynccl-symm (1.06x)           
(8192, 8192)        128.00 MB      2.981               0.808               0.814               0.953               0.575               0.593               0.677               0.989               pynccl (1.00x)                
==================================================================================================================================
All times are in milliseconds (ms) per allreduce operation
Speedup column shows: fastest_algorithm (speedup_vs_pynccl)
```

## CC List

@wzhao18 @hjjq

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

