### PR TITLE
[Bugfix] Fix MiniMax tool-call arguments not streamed incrementally

### DIFF
--- a/tests/tool_parsers/test_minimax_tool_parser.py
+++ b/tests/tool_parsers/test_minimax_tool_parser.py
@@ -1258,8 +1258,9 @@ def test_streaming_tool_args_not_buffered_until_end(minimax_tool_parser):
 
     accumulated = ""
     tool_call_messages = []
+    first_arg_delta_idx = None
 
-    for delta in deltas:
+    for idx, delta in enumerate(deltas):
         previous = accumulated
         accumulated += delta
         result = minimax_tool_parser.extract_tool_calls_streaming(
@@ -1273,6 +1274,9 @@ def test_streaming_tool_args_not_buffered_until_end(minimax_tool_parser):
         )
         if result is not None and hasattr(result, "tool_calls") and result.tool_calls:
             tool_call_messages.append(result)
+            tc = result.tool_calls[0]
+            if first_arg_delta_idx is None and tc.function and tc.function.arguments:
+                first_arg_delta_idx = idx
 
     assert len(tool_call_messages) > 0, (
         "Tool call streaming should emit at least one DeltaMessage"
@@ -1286,10 +1290,13 @@ def test_streaming_tool_args_not_buffered_until_end(minimax_tool_parser):
     ]
     assert "get_weather" in names, f"Expected function name 'get_weather', got: {names}"
 
-    # Verify we got argument fragments (not all at once at the end)
-    arg_messages = [
-        m
-        for m in tool_call_messages
-        if m.tool_calls[0].function and m.tool_calls[0].function.arguments
-    ]
-    assert len(arg_messages) >= 1, "Should have received at least one argument fragment"
+    # Verify arguments arrived BEFORE the final </tool_calls> delta,
+    # proving they were streamed incrementally and not buffered until end.
+    assert first_arg_delta_idx is not None, (
+        "Should have received at least one argument fragment"
+    )
+    assert first_arg_delta_idx < len(deltas) - 1, (
+        f"Arguments first appeared at delta {first_arg_delta_idx} "
+        f"(last delta is {len(deltas) - 1}); "
+        "they should arrive before the final </tool_calls> delta"
+    )

--- a/tests/tool_parsers/test_minimax_tool_parser.py
+++ b/tests/tool_parsers/test_minimax_tool_parser.py
@@ -1225,3 +1225,71 @@ def test_streaming_character_by_character_with_buffering(minimax_tool_parser):
     assert "done" in final_content, "Final content should be preserved"
 
     print("✓ Buffering character-by-character test passed")
+
+
+def test_streaming_tool_args_not_buffered_until_end(minimax_tool_parser):
+    """Regression test for #40779.
+
+    Verify that tool-call argument tokens are streamed incrementally,
+    not buffered until generation completes.
+    """
+    minimax_tool_parser.current_tool_name_sent = False
+    minimax_tool_parser.prev_tool_call_arr = []
+    minimax_tool_parser.current_tool_id = -1
+    minimax_tool_parser.streamed_args_for_tool = []
+    minimax_tool_parser.pending_buffer = ""
+    minimax_tool_parser.in_thinking_tag = False
+
+    # Simulate token-by-token streaming as vLLM would deliver it
+    deltas = [
+        "<tool_calls>",
+        "\n",
+        '{"name": "get_weather",',
+        ' "arguments": {',
+        '"city": ',
+        '"Tokyo"',
+        ", ",
+        '"unit": ',
+        '"celsius"',
+        "}}",
+        "\n",
+        "</tool_calls>",
+    ]
+
+    accumulated = ""
+    tool_call_messages = []
+
+    for delta in deltas:
+        previous = accumulated
+        accumulated += delta
+        result = minimax_tool_parser.extract_tool_calls_streaming(
+            previous_text=previous,
+            current_text=accumulated,
+            delta_text=delta,
+            previous_token_ids=[],
+            current_token_ids=[],
+            delta_token_ids=[],
+            request=None,
+        )
+        if result is not None and hasattr(result, "tool_calls") and result.tool_calls:
+            tool_call_messages.append(result)
+
+    assert len(tool_call_messages) > 0, (
+        "Tool call streaming should emit at least one DeltaMessage"
+    )
+
+    # Verify we got the function name
+    names = [
+        m.tool_calls[0].function.name
+        for m in tool_call_messages
+        if m.tool_calls[0].function and m.tool_calls[0].function.name
+    ]
+    assert "get_weather" in names, f"Expected function name 'get_weather', got: {names}"
+
+    # Verify we got argument fragments (not all at once at the end)
+    arg_messages = [
+        m
+        for m in tool_call_messages
+        if m.tool_calls[0].function and m.tool_calls[0].function.arguments
+    ]
+    assert len(arg_messages) >= 1, "Should have received at least one argument fragment"

--- a/vllm/tool_parsers/minimax_tool_parser.py
+++ b/vllm/tool_parsers/minimax_tool_parser.py
@@ -267,17 +267,25 @@ class MinimaxToolParser(ToolParser):
                 return True
         return False
 
-    def _should_buffer_content(self, delta_text: str) -> bool:
+    def _should_buffer_content(self, delta_text: str, current_text: str) -> bool:
         """
         Determine if content should be buffered for later processing.
 
+        Once the tool-call start tag has been found in the accumulated
+        text, stop buffering so that argument tokens flow to the
+        streaming tool-call handlers instead of accumulating silently
+        in ``pending_buffer``. (#40779)
+
         Args:
             delta_text: Delta text to check
+            current_text: Full accumulated text so far
 
         Returns:
             True if content should be buffered
         """
         if self.in_thinking_tag:
+            return False
+        if self.tool_call_start_token in current_text:
             return False
         return bool(
             self.pending_buffer
@@ -709,9 +717,21 @@ class MinimaxToolParser(ToolParser):
         if self.in_thinking_tag:
             return DeltaMessage(content=delta_text)
 
-        if self._should_buffer_content(delta_text):
+        if self._should_buffer_content(delta_text, current_text):
             buffered_output = self._process_buffer(delta_text)
             return DeltaMessage(content=buffered_output) if buffered_output else None
+
+        # Flush any remaining buffered content (e.g. text after the
+        # <tool_calls> tag was stripped) into the current delta so that
+        # the tool-call argument handlers below can process it.
+        if self.pending_buffer:
+            delta_text = self.pending_buffer + delta_text
+            current_text = (
+                current_text[: -len(delta_text)] + delta_text
+                if len(delta_text) <= len(current_text)
+                else current_text
+            )
+            self.pending_buffer = ""
 
         if self._is_end_tool_calls(current_text):
             return DeltaMessage(content=delta_text)

--- a/vllm/tool_parsers/minimax_tool_parser.py
+++ b/vllm/tool_parsers/minimax_tool_parser.py
@@ -286,7 +286,11 @@ class MinimaxToolParser(ToolParser):
         if self.in_thinking_tag:
             return False
         if self.tool_call_start_token in current_text:
-            return False
+            return bool(
+                self.tool_call_start_token in delta_text
+                or self.tool_call_end_token in delta_text
+                or self._is_potential_tag_start(self.pending_buffer + delta_text)
+            )
         return bool(
             self.pending_buffer
             or self.tool_call_start_token in delta_text
@@ -726,11 +730,6 @@ class MinimaxToolParser(ToolParser):
         # the tool-call argument handlers below can process it.
         if self.pending_buffer:
             delta_text = self.pending_buffer + delta_text
-            current_text = (
-                current_text[: -len(delta_text)] + delta_text
-                if len(delta_text) <= len(current_text)
-                else current_text
-            )
             self.pending_buffer = ""
 
         if self._is_end_tool_calls(current_text):


### PR DESCRIPTION
## Purpose

Fix a streaming bug where MiniMax tool-call arguments are buffered until generation completes instead of being streamed incrementally.

This PR fixes https://github.com/vllm-project/vllm/issues/40779.

### Why is this not duplicating an existing PR?

No open PRs reference issue #40779. Checked via:
```
gh pr list --repo vllm-project/vllm --state open --search "40779 in:body"
```

## Root Cause

`MinimaxToolParser._should_buffer_content()` was sticky: once `pending_buffer` was set when the `<tool_calls>` tag arrived, every subsequent delta was routed through `_process_buffer()` instead of the streaming argument handlers (`_handle_tool_name_streaming` / `_handle_tool_args_streaming`). This caused all function call argument tokens to accumulate silently in `pending_buffer` and only appear after generation completed.

The `pending_buffer` condition on line 283 made the buffer guard permanently true:
```python
return bool(
    self.pending_buffer  # ← once set, always true
    or ...
)
```

## Fix

1. **`_should_buffer_content()`** — once the `<tool_calls>` start tag has been found in accumulated `current_text`, return `False` so argument tokens flow to the streaming handlers.
2. **Buffer flush** — any remaining `pending_buffer` content (text after the stripped `<tool_calls>` tag) is flushed into `delta_text` at the transition point.

**Changed file:** `vllm/tool_parsers/minimax_tool_parser.py`

## Test Plan

Added regression test `test_streaming_tool_args_not_buffered_until_end` in `tests/tool_parsers/test_minimax_tool_parser.py`:

```bash
pytest tests/tool_parsers/test_minimax_tool_parser.py::test_streaming_tool_args_not_buffered_until_end -v
```

The test simulates token-by-token streaming and verifies that tool-call DeltaMessages are emitted during streaming (not only at the end).

### AI Assistance Disclosure

This PR was developed with AI assistance (Claude). The human submitter has reviewed all changed lines.