### PR TITLE
[Bugfix] Respect immediate process shutdown timeout

### DIFF
--- a/vllm/utils/system_utils.py
+++ b/vllm/utils/system_utils.py
@@ -260,8 +260,12 @@ def kill_process_tree(pid: int):
     except psutil.NoSuchProcess:
         return
 
-    # Get all children recursively
-    children = parent.children(recursive=True)
+    # Get all children recursively. The process may exit after the Process
+    # object is created, especially on abort shutdown paths.
+    try:
+        children = parent.children(recursive=True)
+    except psutil.NoSuchProcess:
+        return
 
     # Send SIGKILL to all children first
     for child in children:

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -335,8 +335,10 @@ def shutdown(procs: list[BaseProcess], timeout: float | None = None) -> None:
     if timeout is None:
         timeout = 0.0
 
-    # Allow at least 5 seconds for remaining procs to terminate.
-    timeout = max(timeout, 5.0)
+    # Allow at least 5 seconds for remaining procs to terminate unless
+    # the caller explicitly requested immediate abort.
+    if timeout > 0:
+        timeout = max(timeout, 5.0)
 
     # Shutdown the process.
     for proc in procs:


### PR DESCRIPTION
## Purpose

Fix `timeout=0` process shutdown semantics so an explicit immediate-abort timeout is not expanded to the 5 second graceful shutdown floor.

This is needed for Python-supervised server modes where the parent process is expected to exit promptly after SIGTERM when `--shutdown-timeout 0` is configured. The change keeps the existing 5 second minimum for positive timeouts, and also handles the race where a process exits after `psutil.Process(pid)` succeeds but before child lookup.

## Test Plan

- Run ruff on the changed files.
- Run mypy on the changed files.
- Reproduce the Rust frontend shutdown timeout cases locally with the Rust frontend shutdown-timeout support branch.

## Test Result

```bash
.venv-lint/bin/ruff check vllm/v1/utils.py vllm/utils/system_utils.py
# All checks passed!

.venv-lint/bin/mypy vllm/v1/utils.py vllm/utils/system_utils.py
# Success: no issues found in 2 source files
```

Local Rust frontend reproduction:

```text
entrypoints/openai/completion/test_shutdown.py::test_abort_timeout_exits_quickly[0.0] PASSED
entrypoints/openai/completion/test_shutdown.py::test_abort_timeout_exits_quickly[2.0] PASSED
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

