### PR TITLE
[Bugfix] use `served_model_name` for multimodal error message

### DIFF
--- a/tests/multimodal/test_registry.py
+++ b/tests/multimodal/test_registry.py
@@ -5,6 +5,8 @@ Unit tests for MultiModalRegistry.supports_multimodal_inputs and
 Qwen2.5-VL visual component loading behavior.
 """
 
+from types import SimpleNamespace
+
 import pytest
 
 from vllm.multimodal import MULTIMODAL_REGISTRY
@@ -32,3 +34,17 @@ def test_supports_multimodal_inputs(model_id, limit_mm_per_prompt, expected):
         limit_mm_per_prompt=limit_mm_per_prompt,
     )
     assert MULTIMODAL_REGISTRY.supports_multimodal_inputs(ctx.model_config) is expected
+
+
+def test_create_processor_error_uses_served_model_name():
+    model_config = SimpleNamespace(
+        is_multimodal_model=False,
+        model="/path/to/model/weights",
+        served_model_name="friendly-model-name",
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="friendly-model-name is not a multimodal model",
+    ):
+        MULTIMODAL_REGISTRY.create_processor(model_config)

--- a/vllm/multimodal/registry.py
+++ b/vllm/multimodal/registry.py
@@ -207,7 +207,8 @@ class MultiModalRegistry:
         Create a multi-modal processor for a specific model and tokenizer.
         """
         if not model_config.is_multimodal_model:
-            raise ValueError(f"{model_config.model} is not a multimodal model")
+            model_name = model_config.served_model_name or model_config.model
+            raise ValueError(f"{model_name} is not a multimodal model")
 
         model_cls = self._get_model_cls(model_config)
         factories = model_cls._processor_factory


### PR DESCRIPTION
 ## Purpose

Improve the non-multimodal error in `vllm/multimodal/registry.py` to show a user-facing model name (`served_model_name`, using the first alias when multiple are provided) instead of the model weights path. If not specified, we still fall back to the old behaviour instead of showing the path to the model weights.

## Test Plan

- Added a unit test in `tests/multimodal/test_registry.py` covering the non-multimodal error path.

## Test Result
- Passed:
  ```text    
  1 passed, 4 deselected in 0.21s
  ```