### PR TITLE
[Kernel] Add MixFP4 W4A16 Marlin inference support

### DIFF
--- a/csrc/quantization/marlin/dequant.h
+++ b/csrc/quantization/marlin/dequant.h
@@ -582,6 +582,11 @@ dequant_fp8_scales_mixed_bake_x4<nv_bfloat162>(int q, nv_bfloat162* frag_b,
   frag_b[1] = *reinterpret_cast<const nv_bfloat162*>(&Out1);
   frag_b[0] = *reinterpret_cast<const nv_bfloat162*>(&Out2);
 
+  // MixFP4 keeps the scale bytes in FP8 E4M3 layout so the sign bit can carry
+  // the FP4/INT4 selector. The bit expansion above intentionally leaves the
+  // BF16 exponent un-biased; multiplying by 2^127 restores the BF16 bias after
+  // the INT4 x4 exponent bake. The remaining FP4 exponent compensation is
+  // folded into the Python-side global scale preprocessing.
   constexpr uint32_t BITS_2_127 = 254u << 23;
   const float f_2_127 = *reinterpret_cast<const float*>(&BITS_2_127);
   const nv_bfloat162 v_2_127 = __float2bfloat162_rn(f_2_127);

--- a/csrc/quantization/marlin/dequant.h
+++ b/csrc/quantization/marlin/dequant.h
@@ -547,6 +547,66 @@ __device__ inline void dequant_fp8_scales<nv_bfloat162, vllm::kFE4M3fn.id()>(
   frag_b[0] = *reinterpret_cast<const nv_bfloat162*>(&Out2);
 }
 
+
+
+// MixFP4 reuses NVFP4 storage and treats each FP8 E4M3 scale sign bit as a
+// per-block FP4/INT4 selector. The INT4 path bakes the required x4 correction
+// directly into the decoded BF16 scale by adding 2 to the BF16 exponent field.
+template <typename scalar_t2>
+__device__ inline void dequant_fp8_scales_mixed_bake_x4(int q,
+                                                        scalar_t2* frag_b,
+                                                        int& flag_mask) {
+  flag_mask = 0;
+  dequant_fp8_scales<scalar_t2, vllm::kFE4M3fn.id()>(q, frag_b);
+}
+
+template <>
+__device__ inline void
+dequant_fp8_scales_mixed_bake_x4<nv_bfloat162>(int q, nv_bfloat162* frag_b,
+                                                int& flag_mask) {
+  flag_mask = (((q >> 7) & 0x01)) | (((q >> 15) & 0x01) << 1) |
+              (((q >> 23) & 0x01) << 2) | (((q >> 31) & 0x01) << 3);
+
+  constexpr int MASK = 0x7F007F00;
+  constexpr int RIGHT_SHIFT = 4;
+  int q_clean = q & 0x7F7F7F7F;
+  int Out1 = (q_clean & MASK) >> RIGHT_SHIFT;
+  int q_shifted = q_clean << 8;
+  int Out2 = (q_shifted & MASK) >> RIGHT_SHIFT;
+
+  int bake_1 = (q & 0x80008000) >> 7;
+  int bake_2 = (q & 0x00800080) << 1;
+  Out1 += bake_1;
+  Out2 += bake_2;
+
+  frag_b[1] = *reinterpret_cast<const nv_bfloat162*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const nv_bfloat162*>(&Out2);
+
+  constexpr uint32_t BITS_2_127 = 254u << 23;
+  const float f_2_127 = *reinterpret_cast<const float*>(&BITS_2_127);
+  const nv_bfloat162 v_2_127 = __float2bfloat162_rn(f_2_127);
+  frag_b[0] = __hmul2(frag_b[0], v_2_127);
+  frag_b[1] = __hmul2(frag_b[1], v_2_127);
+}
+
+template <typename scalar_t2>
+__device__ inline void dequant_mixed_fp4_or_int4(int q, bool is_int4,
+                                                 scalar_t2* frag_b) {
+  dequant<scalar_t2, vllm::kFE2M1f.id(), true>(q, frag_b);
+}
+
+template <>
+__device__ inline void dequant_mixed_fp4_or_int4<nv_bfloat162>(
+    int q, bool is_int4, nv_bfloat162* frag_b) {
+  constexpr int MASK = 0x70007000;
+  int shift = is_int4 ? 7 : 6;
+  int Out1 = (q & 0x80008000) | ((q & MASK) >> shift);
+  q <<= 4;
+  int Out2 = (q & 0x80008000) | ((q & MASK) >> shift);
+  frag_b[1] = *reinterpret_cast<const nv_bfloat162*>(&Out1);
+  frag_b[0] = *reinterpret_cast<const nv_bfloat162*>(&Out2);
+}
+
 template <>
 __device__ inline void dequant_fp8_scales<nv_bfloat162, vllm::kFE8M0fnu.id()>(
     int q, nv_bfloat162* frag_b) {

--- a/csrc/quantization/marlin/kernel.h
+++ b/csrc/quantization/marlin/kernel.h
@@ -17,7 +17,7 @@
       const int4 *__restrict__ zp_ptr, const int *__restrict__ g_idx,          \
       int num_groups, int prob_m, int prob_n, int prob_k, int lda, int *locks, \
       bool has_bias, bool use_atomic_add, bool use_fp32_reduce,                \
-      int max_shared_mem
+      int max_shared_mem, bool is_mixfp4
 
 namespace MARLIN_NAMESPACE_NAME {
 template <const vllm::ScalarTypeId a_type_id,  // A ScalarType id

--- a/csrc/quantization/marlin/marlin.cu
+++ b/csrc/quantization/marlin/marlin.cu
@@ -50,6 +50,8 @@ torch::Tensor marlin_gemm(
     torch::Tensor& a, std::optional<torch::Tensor> c_or_none,
     torch::Tensor& b_q_weight,
     std::optional<torch::Tensor> const& b_bias_or_none, torch::Tensor& b_scales,
+    std::optional<torch::Tensor> const& a_scales_or_none,
+    std::optional<torch::Tensor> const& global_scale_or_none,
     std::optional<torch::Tensor> const& b_zeros_or_none,
     std::optional<torch::Tensor> const& g_idx_or_none,
     std::optional<torch::Tensor> const& perm_or_none, torch::Tensor& workspace,
@@ -58,6 +60,22 @@ torch::Tensor marlin_gemm(
     bool is_zp_float) {
   TORCH_CHECK_NOT_IMPLEMENTED(false,
                               "marlin_gemm(..) requires CUDA_ARCH >= 7.5");
+  return torch::empty({1, 1});
+}
+
+torch::Tensor mixfp4_marlin_gemm(
+    torch::Tensor& a, std::optional<torch::Tensor> c_or_none,
+    torch::Tensor& b_q_weight,
+    std::optional<torch::Tensor> const& b_bias_or_none, torch::Tensor& b_scales,
+    std::optional<torch::Tensor> const& global_scale_or_none,
+    std::optional<torch::Tensor> const& b_zeros_or_none,
+    std::optional<torch::Tensor> const& g_idx_or_none,
+    std::optional<torch::Tensor> const& perm_or_none, torch::Tensor& workspace,
+    vllm::ScalarTypeId const& b_type_id, int64_t size_m, int64_t size_n,
+    int64_t size_k, bool is_k_full, bool use_atomic_add, bool use_fp32_reduce,
+    bool is_zp_float) {
+  TORCH_CHECK_NOT_IMPLEMENTED(false,
+                              "mixfp4_marlin_gemm(..) requires CUDA_ARCH >= 7.5");
   return torch::empty({1, 1});
 }
 
@@ -321,7 +339,7 @@ void marlin_mm(const void* A, const void* B, void* C, void* C_tmp, void* b_bias,
                bool has_act_order, bool is_k_full, bool has_zp, int num_groups,
                int group_size, int dev, cudaStream_t stream, int thread_k_init,
                int thread_n_init, int sms, bool use_atomic_add,
-               bool use_fp32_reduce, bool is_zp_float) {
+               bool use_fp32_reduce, bool is_zp_float, bool is_mixfp4) {
   bool is_a_8bit = a_type.size_bits() == 8;
   TORCH_CHECK(prob_m > 0 && prob_n > 0 && prob_k > 0, "Invalid MNK = [", prob_m,
               ", ", prob_n, ", ", prob_k, "]");
@@ -515,7 +533,7 @@ void marlin_mm(const void* A, const void* B, void* C, void* C_tmp, void* b_bias,
         A_ptr, B_ptr, C_ptr, C_tmp_ptr, bias_ptr, a_s_ptr, b_s_ptr, g_s_ptr, zp_ptr,
         g_idx_ptr, num_groups,
         prob_m_split, prob_n, prob_k, lda, locks, has_bias, part_use_atomic_add,
-        use_fp32_reduce, max_shared_mem_new);
+        use_fp32_reduce, max_shared_mem_new, is_mixfp4);
     // clang-format on
 
     bool is_a_8bit = a_type.size_bits() == 8;
@@ -528,7 +546,7 @@ void marlin_mm(const void* A, const void* B, void* C, void* C_tmp, void* b_bias,
 
 }  // namespace marlin
 
-torch::Tensor marlin_gemm(
+static torch::Tensor marlin_gemm_impl(
     torch::Tensor& a, std::optional<torch::Tensor> c_or_none,
     torch::Tensor& b_q_weight,
     std::optional<torch::Tensor> const& b_bias_or_none, torch::Tensor& b_scales,
@@ -539,7 +557,7 @@ torch::Tensor marlin_gemm(
     std::optional<torch::Tensor> const& perm_or_none, torch::Tensor& workspace,
     vllm::ScalarTypeId const& b_type_id, int64_t size_m, int64_t size_n,
     int64_t size_k, bool is_k_full, bool use_atomic_add, bool use_fp32_reduce,
-    bool is_zp_float) {
+    bool is_zp_float, bool is_mixfp4) {
   vllm::ScalarTypeId a_type_id, c_type_id, s_type_id;
 
   auto c_dtype = a.dtype();
@@ -613,6 +631,12 @@ torch::Tensor marlin_gemm(
   TORCH_CHECK(
       size_k % MARLIN_NAMESPACE_NAME::tile_size == 0, "size_k = ", size_k,
       " is not divisible by tile_size = ", MARLIN_NAMESPACE_NAME::tile_size);
+  if (is_mixfp4) {
+    TORCH_CHECK(
+        size_k % (2 * MARLIN_NAMESPACE_NAME::tile_size) == 0, "size_k = ",
+        size_k, " is not divisible by ", 2 * MARLIN_NAMESPACE_NAME::tile_size,
+        "; MixFP4 scale layout packs pairs of group-16 rows");
+  }
   TORCH_CHECK((size_k / MARLIN_NAMESPACE_NAME::tile_size) == b_q_weight.size(0),
               "Shape mismatch: b_q_weight.size(0) = ", b_q_weight.size(0),
               ", size_k = ", size_k,
@@ -752,11 +776,23 @@ torch::Tensor marlin_gemm(
   if (global_scale_or_none.has_value()) {
     global_scale = global_scale_or_none.value();
     TORCH_CHECK(b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn,
-                "global_scale can only be used for nvfp4 format.");
+                "global_scale can only be used for NVFP4/MixFP4 format.");
   } else {
     global_scale = torch::empty({0}, options_fp32);
     TORCH_CHECK(!(b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn),
-                "the global_scale parameter must be passed for nvfp4 format.");
+                "the global_scale parameter must be passed for NVFP4/MixFP4 format.");
+  }
+
+  if (is_mixfp4) {
+    TORCH_CHECK(a.scalar_type() == at::ScalarType::BFloat16,
+                "MixFP4 Marlin currently supports bfloat16 models only.");
+    TORCH_CHECK(b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn,
+                "MixFP4 Marlin only supports float4_e2m1f weights with "
+                "float8_e4m3fn scales. Got weight type = ", b_type.str(),
+                ", scale type = ", s_type.str());
+    TORCH_CHECK(group_size == 16,
+                "MixFP4 Marlin only supports group_size == 16, got ",
+                group_size);
   }
 
   bool has_bias = b_bias_or_none.has_value();
@@ -780,6 +816,9 @@ torch::Tensor marlin_gemm(
     b_zeros = torch::empty({0}, options);
   }
   bool has_zp = b_zeros.size(-1) > 0;
+  if (is_mixfp4) {
+    TORCH_CHECK(!has_zp, "MixFP4 Marlin does not support zero points.");
+  }
   if (has_zp) {
     TORCH_CHECK(
         b_type == vllm::kU4 || b_type == vllm::kU8,
@@ -851,13 +890,54 @@ torch::Tensor marlin_gemm(
       workspace.data_ptr(), a_type, b_type, c_type, s_type, has_bias,
       has_act_order, is_k_full, has_zp, num_groups, group_size, dev,
       at::cuda::getCurrentCUDAStream(dev), thread_k, thread_n, sms,
-      use_atomic_add, use_fp32_reduce, is_zp_float);
+      use_atomic_add, use_fp32_reduce, is_zp_float, is_mixfp4);
 
   return c;
+}
+
+torch::Tensor marlin_gemm(
+    torch::Tensor& a, std::optional<torch::Tensor> c_or_none,
+    torch::Tensor& b_q_weight,
+    std::optional<torch::Tensor> const& b_bias_or_none, torch::Tensor& b_scales,
+    std::optional<torch::Tensor> const& a_scales_or_none,
+    std::optional<torch::Tensor> const& global_scale_or_none,
+    std::optional<torch::Tensor> const& b_zeros_or_none,
+    std::optional<torch::Tensor> const& g_idx_or_none,
+    std::optional<torch::Tensor> const& perm_or_none, torch::Tensor& workspace,
+    vllm::ScalarTypeId const& b_type_id, int64_t size_m, int64_t size_n,
+    int64_t size_k, bool is_k_full, bool use_atomic_add, bool use_fp32_reduce,
+    bool is_zp_float) {
+  return marlin_gemm_impl(a, c_or_none, b_q_weight, b_bias_or_none, b_scales,
+                          a_scales_or_none, global_scale_or_none,
+                          b_zeros_or_none, g_idx_or_none, perm_or_none,
+                          workspace, b_type_id, size_m, size_n, size_k,
+                          is_k_full, use_atomic_add, use_fp32_reduce,
+                          is_zp_float, false);
+}
+
+torch::Tensor mixfp4_marlin_gemm(
+    torch::Tensor& a, std::optional<torch::Tensor> c_or_none,
+    torch::Tensor& b_q_weight,
+    std::optional<torch::Tensor> const& b_bias_or_none, torch::Tensor& b_scales,
+    std::optional<torch::Tensor> const& global_scale_or_none,
+    std::optional<torch::Tensor> const& b_zeros_or_none,
+    std::optional<torch::Tensor> const& g_idx_or_none,
+    std::optional<torch::Tensor> const& perm_or_none, torch::Tensor& workspace,
+    vllm::ScalarTypeId const& b_type_id, int64_t size_m, int64_t size_n,
+    int64_t size_k, bool is_k_full, bool use_atomic_add, bool use_fp32_reduce,
+    bool is_zp_float) {
+  std::optional<torch::Tensor> a_scales_or_none = std::nullopt;
+  return marlin_gemm_impl(a, c_or_none, b_q_weight, b_bias_or_none, b_scales,
+                          a_scales_or_none, global_scale_or_none,
+                          b_zeros_or_none, g_idx_or_none, perm_or_none,
+                          workspace, b_type_id, size_m, size_n, size_k,
+                          is_k_full, use_atomic_add, use_fp32_reduce,
+                          is_zp_float, true);
 }
 
 #endif
 
 TORCH_LIBRARY_IMPL_EXPAND(TORCH_EXTENSION_NAME, CUDA, m) {
   m.impl("marlin_gemm", &marlin_gemm);
+  m.impl("mixfp4_marlin_gemm", &mixfp4_marlin_gemm);
 }

--- a/csrc/quantization/marlin/marlin.cu
+++ b/csrc/quantization/marlin/marlin.cu
@@ -635,7 +635,7 @@ static torch::Tensor marlin_gemm_impl(
     TORCH_CHECK(
         size_k % (2 * MARLIN_NAMESPACE_NAME::tile_size) == 0, "size_k = ",
         size_k, " is not divisible by ", 2 * MARLIN_NAMESPACE_NAME::tile_size,
-        "; MixFP4 scale layout packs pairs of group-16 rows");
+        "; MixFP4 Marlin requires size_k divisible by 32");
   }
   TORCH_CHECK((size_k / MARLIN_NAMESPACE_NAME::tile_size) == b_q_weight.size(0),
               "Shape mismatch: b_q_weight.size(0) = ", b_q_weight.size(0),

--- a/csrc/quantization/marlin/marlin_template.h
+++ b/csrc/quantization/marlin/marlin_template.h
@@ -251,7 +251,7 @@ __global__ void Marlin(
     const float* __restrict__ a_scales_ptr,
     // fp16 quantization scales. shape (k/groupsize, n)
     const int4* __restrict__ scales_ptr,
-    // float global scale (for nvfp4// only)
+    // float global scale (for NVFP4/MixFP4 only)
     const float* __restrict__ global_scale_ptr,
     // 4bit packed zero-points of shape
     // (k/groupsize, n/pack_factor)
@@ -267,7 +267,8 @@ __global__ void Marlin(
     bool has_bias,
     bool use_atomic_add,   // whether to use atomic add to reduce
     bool use_fp32_reduce,  // whether to use fp32 global reduce
-    int max_shared_mem) {
+    int max_shared_mem,
+    bool is_mixfp4) {
   // Each threadblock processes one "stripe" of the B matrix with (roughly) the
   // same size, which might involve multiple column "slices" (of width 16 *
   // `thread_n_blocks`). Stripes are defined as shown in the 3x3 matrix 5 SM
@@ -1210,7 +1211,29 @@ __global__ void Marlin(
       }
     }
 
-    if constexpr (s_type == vllm::kFE4M3fn || s_type == vllm::kFE8M0fnu) {
+    int flags_pair[4] = {0, 0, 0, 0};
+    if constexpr (b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn) {
+      int s_quant_0 = reinterpret_cast<int*>(frag_s[k2])[0];
+      int s_quant_1 = reinterpret_cast<int*>(frag_s[k2])[1];
+
+      if (is_mixfp4) {
+        int fm0 = 0, fm1 = 0;
+        dequant_fp8_scales_mixed_bake_x4<c_scalar_t2>(
+            s_quant_0, reinterpret_cast<c_scalar_t2*>(&frag_s[k2]), fm0);
+        dequant_fp8_scales_mixed_bake_x4<c_scalar_t2>(
+            s_quant_1, reinterpret_cast<c_scalar_t2*>(&frag_s[k2]) + 2, fm1);
+        flags_pair[0] = ((fm0 >> 0) & 1) | (((fm0 >> 2) & 1) << 1);
+        flags_pair[1] = ((fm0 >> 1) & 1) | (((fm0 >> 3) & 1) << 1);
+        flags_pair[2] = ((fm1 >> 0) & 1) | (((fm1 >> 2) & 1) << 1);
+        flags_pair[3] = ((fm1 >> 1) & 1) | (((fm1 >> 3) & 1) << 1);
+      } else {
+        dequant_fp8_scales<c_scalar_t2, s_type_id>(
+            s_quant_0, reinterpret_cast<c_scalar_t2*>(&frag_s[k2]));
+        dequant_fp8_scales<c_scalar_t2, s_type_id>(
+            s_quant_1, reinterpret_cast<c_scalar_t2*>(&frag_s[k2]) + 2);
+      }
+    } else if constexpr (s_type == vllm::kFE4M3fn ||
+                         s_type == vllm::kFE8M0fnu) {
       int s_quant_0 = reinterpret_cast<int*>(frag_s[k2])[0];
       int s_quant_1 = reinterpret_cast<int*>(frag_s[k2])[1];
 
@@ -1241,8 +1264,22 @@ __global__ void Marlin(
         b_quant_1 = frag_b_quant_ptr[j * 2 + 1];
       }
 
-      dequant_data(b_quant_0, reinterpret_cast<scalar_32bit_t*>(&frag_b0));
-      dequant_data(b_quant_1, reinterpret_cast<scalar_32bit_t*>(&frag_b1));
+      if constexpr (b_type == vllm::kFE2M1f && s_type == vllm::kFE4M3fn) {
+        if (is_mixfp4) {
+          bool b1_int4 = (flags_pair[j] & 1) != 0;
+          bool b2_int4 = ((flags_pair[j] >> 1) & 1) != 0;
+          dequant_mixed_fp4_or_int4(b_quant_0, b1_int4,
+                                    reinterpret_cast<scalar_32bit_t*>(&frag_b0));
+          dequant_mixed_fp4_or_int4(b_quant_1, b2_int4,
+                                    reinterpret_cast<scalar_32bit_t*>(&frag_b1));
+        } else {
+          dequant_data(b_quant_0, reinterpret_cast<scalar_32bit_t*>(&frag_b0));
+          dequant_data(b_quant_1, reinterpret_cast<scalar_32bit_t*>(&frag_b1));
+        }
+      } else {
+        dequant_data(b_quant_0, reinterpret_cast<scalar_32bit_t*>(&frag_b0));
+        dequant_data(b_quant_1, reinterpret_cast<scalar_32bit_t*>(&frag_b1));
+      }
 
       if constexpr (dequant_skip_flop && has_zp && !is_zp_float && !is_a_8bit) {
         sub_zp<a_type_id>(frag_b0, frag_zp[j], 0);

--- a/csrc/torch_bindings.cpp
+++ b/csrc/torch_bindings.cpp
@@ -320,6 +320,16 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, ops) {
       "bool use_atomic_add, bool use_fp32_reduce, bool is_zp_float) -> Tensor");
   // conditionally compiled so impl registration is in source file
 
+  // MixFP4 W4A16 Marlin GEMM.
+  ops.def(
+      "mixfp4_marlin_gemm(Tensor a, Tensor? c_or_none, Tensor b_q_weight, "
+      "Tensor? b_bias_or_none,Tensor b_scales, "
+      "Tensor? global_scale, Tensor? b_zeros_or_none, Tensor? "
+      "g_idx_or_none, Tensor? perm_or_none, Tensor workspace, int b_q_type, "
+      "SymInt size_m, SymInt size_n, SymInt size_k, bool is_k_full, "
+      "bool use_atomic_add, bool use_fp32_reduce, bool is_zp_float) -> Tensor");
+  // conditionally compiled so impl registration is in source file
+
   // gptq_marlin repack from GPTQ.
   ops.def(
       "gptq_marlin_repack(Tensor b_q_weight, Tensor perm, "

--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -462,6 +462,54 @@ def test_mixfp4_create_weights_rejects_odd_group_count():
         )
 
 
+def test_mixfp4_process_weights_rejects_mismatched_global_scales(monkeypatch):
+    scheme = CompressedTensorsW4A16MixFP4()
+    layer = torch.nn.Module()
+    layer.weight_packed = torch.nn.Parameter(
+        torch.empty((2, 16), dtype=torch.uint8), requires_grad=False
+    )
+    layer.weight_global_scale = torch.nn.Parameter(
+        torch.tensor([1.0, 2.0], dtype=torch.float32), requires_grad=False
+    )
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
+        "compressed_tensors_w4a16_mixfp4.prepare_mixfp4_layer_for_marlin",
+        lambda layer: None,
+    )
+
+    with pytest.raises(ValueError, match="identical weight_global_scale"):
+        scheme.process_weights_after_loading(layer)
+
+
+def test_mixfp4_process_weights_accepts_identical_global_scales(monkeypatch):
+    scheme = CompressedTensorsW4A16MixFP4()
+    layer = torch.nn.Module()
+    layer.weight_packed = torch.nn.Parameter(
+        torch.empty((2, 16), dtype=torch.uint8), requires_grad=False
+    )
+    layer.weight_global_scale = torch.nn.Parameter(
+        torch.tensor([2.0, 2.0], dtype=torch.float32), requires_grad=False
+    )
+
+    called = False
+
+    def mock_prepare(layer):
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
+        "compressed_tensors_w4a16_mixfp4.prepare_mixfp4_layer_for_marlin",
+        mock_prepare,
+    )
+
+    scheme.process_weights_after_loading(layer)
+
+    assert called
+    assert torch.equal(layer.weight_global_scale, torch.tensor(0.5))
+
+
 @pytest.mark.parametrize(
     "args",
     [

--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -387,20 +387,22 @@ def _make_w4a16_fp4_args(observer: str | None = None) -> QuantizationArgs:
     return QuantizationArgs(**kwargs)
 
 
-def test_mixfp4_marlin_process_scales_rejects_odd_group_rows():
-    raw = torch.zeros((3, 8), dtype=torch.uint8)
+def test_mixfp4_marlin_process_scales_rejects_unaligned_n_dimension():
+    raw = torch.zeros((2, 6), dtype=torch.uint8)
 
-    with pytest.raises(ValueError, match="even number"):
+    with pytest.raises(ValueError, match="divisible by 4"):
         mixfp4_marlin_process_scales(raw.view(torch.float8_e4m3fn))
 
 
-def test_mixfp4_marlin_process_scales_preserves_even_shape():
-    raw = torch.arange(4 * 16, dtype=torch.uint8).reshape(4, 16)
+def test_mixfp4_marlin_process_scales_reorders_scale_lanes():
+    raw = torch.arange(3 * 8, dtype=torch.uint8).reshape(3, 8)
 
     processed = mixfp4_marlin_process_scales(raw.view(torch.float8_e4m3fn))
 
+    expected = raw.view(-1, 4)[:, [0, 2, 1, 3]].reshape_as(raw)
     assert processed.shape == raw.shape
     assert processed.dtype is torch.float8_e4m3fn
+    assert torch.equal(processed.view(torch.uint8), expected)
 
 
 @pytest.mark.parametrize(

--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -462,34 +462,23 @@ def test_mixfp4_create_weights_rejects_odd_group_count():
         )
 
 
-def test_mixfp4_process_weights_rejects_mismatched_global_scales(monkeypatch):
+def test_mixfp4_process_weights_folds_partition_global_scales(monkeypatch):
     scheme = CompressedTensorsW4A16MixFP4()
     layer = torch.nn.Module()
+    layer.logical_widths = [1, 1]
     layer.weight_packed = torch.nn.Parameter(
         torch.empty((2, 16), dtype=torch.uint8), requires_grad=False
+    )
+    raw_scale = torch.tensor([[2.0], [4.0]], dtype=torch.float32).to(
+        torch.float8_e4m3fn
+    )
+    raw_scale_bytes = raw_scale.view(torch.uint8).clone()
+    raw_scale_bytes[1, 0] |= 0x80
+    layer.weight_scale = torch.nn.Parameter(
+        raw_scale_bytes.view(torch.float8_e4m3fn), requires_grad=False
     )
     layer.weight_global_scale = torch.nn.Parameter(
         torch.tensor([1.0, 2.0], dtype=torch.float32), requires_grad=False
-    )
-
-    monkeypatch.setattr(
-        "vllm.model_executor.layers.quantization.compressed_tensors.schemes."
-        "compressed_tensors_w4a16_mixfp4.prepare_mixfp4_layer_for_marlin",
-        lambda layer: None,
-    )
-
-    with pytest.raises(ValueError, match="identical weight_global_scale"):
-        scheme.process_weights_after_loading(layer)
-
-
-def test_mixfp4_process_weights_accepts_identical_global_scales(monkeypatch):
-    scheme = CompressedTensorsW4A16MixFP4()
-    layer = torch.nn.Module()
-    layer.weight_packed = torch.nn.Parameter(
-        torch.empty((2, 16), dtype=torch.uint8), requires_grad=False
-    )
-    layer.weight_global_scale = torch.nn.Parameter(
-        torch.tensor([2.0, 2.0], dtype=torch.float32), requires_grad=False
     )
 
     called = False
@@ -507,7 +496,13 @@ def test_mixfp4_process_weights_accepts_identical_global_scales(monkeypatch):
     scheme.process_weights_after_loading(layer)
 
     assert called
-    assert torch.equal(layer.weight_global_scale, torch.tensor(0.5))
+    assert torch.equal(layer.weight_global_scale, torch.tensor(1.0))
+    folded_raw = layer.weight_scale.view(torch.uint8)
+    assert torch.equal(
+        (folded_raw & 0x7F).view(torch.float8_e4m3fn).float(),
+        torch.full((2, 1), 2.0),
+    )
+    assert (folded_raw[1, 0] & 0x80) != 0
 
 
 @pytest.mark.parametrize(

--- a/tests/quantization/test_compressed_tensors.py
+++ b/tests/quantization/test_compressed_tensors.py
@@ -26,6 +26,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tenso
     CompressedTensorsW4A4Fp4,
     CompressedTensorsW4A8Fp8,
     CompressedTensorsW4A16Fp4,
+    CompressedTensorsW4A16MixFP4,
     CompressedTensorsW8A8Fp8,
     CompressedTensorsW8A8Int8,
     CompressedTensorsW8A8Mxfp8,
@@ -33,6 +34,9 @@ from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tenso
     CompressedTensorsWNA16,
 )
 from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
+from vllm.model_executor.layers.quantization.utils.marlin_utils_mixfp4 import (
+    mixfp4_marlin_process_scales,
+)
 from vllm.model_executor.layers.quantization.utils.nvfp4_utils import (
     cutlass_fp4_supported,
 )
@@ -367,6 +371,95 @@ def test_compressed_tensors_kv_cache_fp8_per_attn_head(vllm_runner):
     with vllm_runner(model_path, attention_config={"backend": "FLASH_ATTN"}) as llm:
         output = llm.generate_greedy("Hello world!", max_tokens=4)
         assert output
+
+
+def _make_w4a16_fp4_args(observer: str | None = None) -> QuantizationArgs:
+    kwargs = {
+        "num_bits": 4,
+        "type": QuantizationType.FLOAT,
+        "strategy": QuantizationStrategy.TENSOR_GROUP,
+        "symmetric": True,
+        "dynamic": False,
+        "group_size": 16,
+    }
+    if observer is not None:
+        kwargs["observer"] = observer
+    return QuantizationArgs(**kwargs)
+
+
+def test_mixfp4_marlin_process_scales_rejects_odd_group_rows():
+    raw = torch.zeros((3, 8), dtype=torch.uint8)
+
+    with pytest.raises(ValueError, match="even number"):
+        mixfp4_marlin_process_scales(raw.view(torch.float8_e4m3fn))
+
+
+def test_mixfp4_marlin_process_scales_preserves_even_shape():
+    raw = torch.arange(4 * 16, dtype=torch.uint8).reshape(4, 16)
+
+    processed = mixfp4_marlin_process_scales(raw.view(torch.float8_e4m3fn))
+
+    assert processed.shape == raw.shape
+    assert processed.dtype is torch.float8_e4m3fn
+
+
+@pytest.mark.parametrize(
+    ("format", "observer"),
+    [
+        ("mixfp4-pack-quantized", None),
+        ("mixed-fp4-int4-pack-quantized", None),
+        ("nvfp4-pack-quantized", "mixfp4"),
+        ("nvfp4-pack-quantized", "mixed_fp4_int4"),
+    ],
+)
+def test_compressed_tensors_mixfp4_scheme_selection(format, observer):
+    config = CompressedTensorsConfig(
+        target_scheme_map={},
+        ignore=[],
+        quant_format=format,
+        sparsity_scheme_map={},
+        sparsity_ignore_list=[],
+    )
+
+    scheme = config._get_scheme_from_parts(
+        weight_quant=_make_w4a16_fp4_args(observer=observer),
+        input_quant=None,
+        format=format,
+    )
+
+    assert isinstance(scheme, CompressedTensorsW4A16MixFP4)
+
+
+def test_compressed_tensors_nvfp4_is_not_routed_to_mixfp4():
+    config = CompressedTensorsConfig(
+        target_scheme_map={},
+        ignore=[],
+        quant_format="nvfp4-pack-quantized",
+        sparsity_scheme_map={},
+        sparsity_ignore_list=[],
+    )
+
+    scheme = config._get_scheme_from_parts(
+        weight_quant=_make_w4a16_fp4_args(),
+        input_quant=None,
+        format="nvfp4-pack-quantized",
+    )
+
+    assert isinstance(scheme, CompressedTensorsW4A16Fp4)
+
+
+def test_mixfp4_create_weights_rejects_odd_group_count():
+    scheme = CompressedTensorsW4A16MixFP4()
+    layer = torch.nn.Module()
+
+    with pytest.raises(ValueError, match="divisible by 32"):
+        scheme.create_weights(
+            layer=layer,
+            output_partition_sizes=[64],
+            input_size_per_partition=48,
+            params_dtype=torch.bfloat16,
+            weight_loader=lambda *_args, **_kwargs: None,
+        )
 
 
 @pytest.mark.parametrize(

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -1415,6 +1415,78 @@ def marlin_gemm(
     )
 
 
+def mixfp4_marlin_gemm(
+    a: torch.Tensor,
+    c: torch.Tensor | None,
+    b_q_weight: torch.Tensor,
+    b_bias: torch.Tensor | None,
+    b_scales: torch.Tensor,
+    global_scale: torch.Tensor | None,
+    b_zeros: torch.Tensor | None,
+    g_idx: torch.Tensor | None,
+    perm: torch.Tensor | None,
+    workspace: torch.Tensor,
+    b_q_type: ScalarType,
+    size_m: int,
+    size_n: int,
+    size_k: int,
+    is_k_full: bool = True,
+    use_atomic_add: bool = False,
+    use_fp32_reduce: bool = False,
+    is_zp_float: bool = False,
+) -> torch.Tensor:
+    return torch.ops._C.mixfp4_marlin_gemm(
+        a,
+        c,
+        b_q_weight,
+        b_bias,
+        b_scales,
+        global_scale,
+        b_zeros,
+        g_idx,
+        perm,
+        workspace,
+        b_q_type.id,
+        size_m,
+        size_n,
+        size_k,
+        is_k_full,
+        use_atomic_add,
+        use_fp32_reduce,
+        is_zp_float,
+    )
+
+
+if hasattr(torch.ops._C, "mixfp4_marlin_gemm"):
+
+    @register_fake("_C::mixfp4_marlin_gemm")
+    def _mixfp4_marlin_gemm_fake(
+        a: torch.Tensor,
+        c: torch.Tensor | None,
+        b_q_weight: torch.Tensor,
+        b_bias: torch.Tensor | None,
+        b_scales: torch.Tensor,
+        global_scale: torch.Tensor | None,
+        b_zeros: torch.Tensor | None,
+        g_idx: torch.Tensor | None,
+        perm: torch.Tensor | None,
+        workspace: torch.Tensor,
+        b_q_type_id: int,
+        size_m: torch.SymInt,
+        size_n: torch.SymInt,
+        size_k: torch.SymInt,
+        is_k_full: bool = True,
+        use_atomic_add: bool = False,
+        use_fp32_reduce: bool = False,
+        is_zp_float: bool = False,
+    ) -> torch.Tensor:
+        if a.dtype != torch.bfloat16:
+            raise RuntimeError(
+                "MixFP4 Marlin currently supports bfloat16 models only."
+            )
+        return torch.empty((size_m, size_n), device=a.device, dtype=a.dtype)
+
+
 if hasattr(torch.ops._C, "marlin_gemm"):
 
     @register_fake("_C::marlin_gemm")

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -46,6 +46,7 @@ from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
     CompressedTensorsW4A8Fp8,
     CompressedTensorsW4A8Int,
     CompressedTensorsW4A16Fp4,
+    CompressedTensorsW4A16MixFP4,
     CompressedTensorsW4A16Mxfp4,
     CompressedTensorsW8A8Fp8,
     CompressedTensorsW8A8Int8,
@@ -386,6 +387,19 @@ class CompressedTensorsConfig(QuantizationConfig):
         )
 
     @staticmethod
+    def _is_mixfp4_format(format: str | None) -> bool:
+        return format in {
+            "mixfp4-pack-quantized",
+            "mixed-fp4-int4-pack-quantized",
+        }
+
+    @staticmethod
+    def _is_mixfp4_observer(quant_args: QuantizationArgs | None) -> bool:
+        if quant_args is None:
+            return False
+        return getattr(quant_args, "observer", None) in {"mixfp4", "mixed_fp4_int4"}
+
+    @staticmethod
     def _is_mxfp4(quant_args: QuantizationArgs) -> bool:
         if quant_args is None:
             return False
@@ -623,6 +637,10 @@ class CompressedTensorsConfig(QuantizationConfig):
 
         # Detect If Mixed Precision
         if self._is_nvfp4_format(weight_quant) and input_quant is None:
+            if self._is_mixfp4_format(format) or self._is_mixfp4_observer(
+                weight_quant
+            ):
+                return CompressedTensorsW4A16MixFP4()
             return CompressedTensorsW4A16Fp4()
 
         if self._is_mxfp4(weight_quant):

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/__init__.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/__init__.py
@@ -5,6 +5,7 @@ from .compressed_tensors_scheme import CompressedTensorsScheme
 from .compressed_tensors_w4a4_nvfp4 import CompressedTensorsW4A4Fp4
 from .compressed_tensors_w4a8_fp8 import CompressedTensorsW4A8Fp8
 from .compressed_tensors_w4a8_int import CompressedTensorsW4A8Int
+from .compressed_tensors_w4a16_mixfp4 import CompressedTensorsW4A16MixFP4
 from .compressed_tensors_w4a16_mxfp4 import CompressedTensorsW4A16Mxfp4
 from .compressed_tensors_w4a16_nvfp4 import CompressedTensorsW4A16Fp4
 from .compressed_tensors_w8a8_fp8 import CompressedTensorsW8A8Fp8
@@ -26,6 +27,7 @@ __all__ = [
     "CompressedTensors24",
     "CompressedTensorsW4A16Fp4",
     "CompressedTensorsW4A16Mxfp4",
+    "CompressedTensorsW4A16MixFP4",
     "CompressedTensorsW4A4Fp4",
     "CompressedTensorsW4A8Int",
     "CompressedTensorsW4A8Fp8",

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_mixfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_mixfp4.py
@@ -82,8 +82,22 @@ class CompressedTensorsW4A16MixFP4(CompressedTensorsScheme):
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         layer.weight = Parameter(layer.weight_packed.data, requires_grad=False)
         del layer.weight_packed
+
+        weight_global_scale = layer.weight_global_scale.to(torch.float32)
+        if weight_global_scale.numel() > 1:
+            first_global_scale = weight_global_scale.flatten()[0]
+            if not torch.allclose(
+                weight_global_scale,
+                first_global_scale.expand_as(weight_global_scale),
+                rtol=0,
+                atol=0,
+            ):
+                raise ValueError(
+                    "MixFP4 Marlin requires identical weight_global_scale values "
+                    "across fused output partitions."
+                )
         layer.weight_global_scale = Parameter(
-            1.0 / layer.weight_global_scale.max().to(torch.float32),
+            1.0 / weight_global_scale.max(),
             requires_grad=False,
         )
         prepare_mixfp4_layer_for_marlin(layer)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_mixfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_mixfp4.py
@@ -83,21 +83,23 @@ class CompressedTensorsW4A16MixFP4(CompressedTensorsScheme):
         layer.weight = Parameter(layer.weight_packed.data, requires_grad=False)
         del layer.weight_packed
 
-        weight_global_scale = layer.weight_global_scale.to(torch.float32)
+        weight_global_scale = layer.weight_global_scale.to(torch.float32).flatten()
         if weight_global_scale.numel() > 1:
-            first_global_scale = weight_global_scale.flatten()[0]
-            if not torch.allclose(
-                weight_global_scale,
-                first_global_scale.expand_as(weight_global_scale),
-                rtol=0,
-                atol=0,
-            ):
-                raise ValueError(
-                    "MixFP4 Marlin requires identical weight_global_scale values "
-                    "across fused output partitions."
-                )
+            common_global_scale = weight_global_scale.min()
+            layer.weight_scale = Parameter(
+                _fold_global_scales_into_weight_scale(
+                    weight_scale=layer.weight_scale,
+                    global_scales=weight_global_scale,
+                    common_global_scale=common_global_scale,
+                    logical_widths=layer.logical_widths,
+                ),
+                requires_grad=False,
+            )
+        else:
+            common_global_scale = weight_global_scale[0]
+
         layer.weight_global_scale = Parameter(
-            1.0 / weight_global_scale.max(),
+            1.0 / common_global_scale,
             requires_grad=False,
         )
         prepare_mixfp4_layer_for_marlin(layer)
@@ -118,3 +120,39 @@ class CompressedTensorsW4A16MixFP4(CompressedTensorsScheme):
             size_k=layer.input_size_per_partition,
             bias=bias,
         )
+
+
+def _fold_global_scales_into_weight_scale(
+    weight_scale: torch.Tensor,
+    global_scales: torch.Tensor,
+    common_global_scale: torch.Tensor,
+    logical_widths: list[int],
+) -> torch.Tensor:
+    if len(logical_widths) != global_scales.numel():
+        raise ValueError(
+            "MixFP4 expected one weight_global_scale per fused output partition, "
+            f"got {global_scales.numel()} scales for {len(logical_widths)} partitions."
+        )
+    if not torch.isfinite(global_scales).all() or not (global_scales > 0).all():
+        raise ValueError(
+            "MixFP4 weight_global_scale values must be finite and positive."
+        )
+
+    raw = weight_scale.detach().contiguous().view(torch.uint8)
+    flags = raw & 0x80
+    magnitudes = (raw & 0x7F).view(torch.float8_e4m3fn).to(torch.float32)
+
+    row_start = 0
+    for width, global_scale in zip(logical_widths, global_scales):
+        row_end = row_start + width
+        magnitudes[row_start:row_end] *= common_global_scale / global_scale
+        row_start = row_end
+    if row_start != weight_scale.size(0):
+        raise ValueError(
+            "MixFP4 fused output partition widths do not match weight_scale rows."
+        )
+
+    magnitude_raw = magnitudes.to(torch.float8_e4m3fn).contiguous().view(torch.uint8)
+    magnitude_raw &= 0x7F
+    flags = torch.where(magnitude_raw != 0, flags, torch.zeros_like(flags))
+    return (magnitude_raw | flags).view(torch.float8_e4m3fn)

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_mixfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_mixfp4.py
@@ -1,0 +1,106 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import Callable
+
+import torch
+from torch.nn.parameter import Parameter
+
+from vllm.model_executor.layers.quantization.compressed_tensors.schemes import (
+    CompressedTensorsScheme,
+)
+from vllm.model_executor.layers.quantization.utils.marlin_utils_mixfp4 import (
+    apply_mixfp4_marlin_linear,
+    prepare_mixfp4_layer_for_marlin,
+)
+from vllm.model_executor.parameter import (
+    GroupQuantScaleParameter,
+    ModelWeightParameter,
+    PerTensorScaleParameter,
+)
+
+__all__ = ["CompressedTensorsW4A16MixFP4"]
+
+
+class CompressedTensorsW4A16MixFP4(CompressedTensorsScheme):
+    def __init__(self):
+        self.group_size = 16
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        return 80
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        output_partition_sizes: list[int],
+        input_size_per_partition: int,
+        params_dtype: torch.dtype,
+        weight_loader: Callable,
+        **kwargs,
+    ):
+        output_size_per_partition = sum(output_partition_sizes)
+        if input_size_per_partition % (2 * self.group_size) != 0:
+            raise ValueError(
+                "MixFP4 Marlin requires input_size_per_partition to be "
+                f"divisible by {2 * self.group_size}, got "
+                f"{input_size_per_partition}."
+            )
+        layer.logical_widths = output_partition_sizes
+        layer.input_size_per_partition = input_size_per_partition
+        layer.output_size_per_partition = output_size_per_partition
+
+        weight = ModelWeightParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition // 2,
+                dtype=torch.uint8,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight_packed", weight)
+
+        weight_global_scale = PerTensorScaleParameter(
+            data=torch.empty(len(output_partition_sizes), dtype=torch.float32),
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight_global_scale", weight_global_scale)
+
+        weight_scale = GroupQuantScaleParameter(
+            data=torch.empty(
+                output_size_per_partition,
+                input_size_per_partition // self.group_size,
+                dtype=torch.float8_e4m3fn,
+            ),
+            input_dim=1,
+            output_dim=0,
+            weight_loader=weight_loader,
+        )
+        layer.register_parameter("weight_scale", weight_scale)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        layer.weight = Parameter(layer.weight_packed.data, requires_grad=False)
+        del layer.weight_packed
+        layer.weight_global_scale = Parameter(
+            1.0 / layer.weight_global_scale.max().to(torch.float32),
+            requires_grad=False,
+        )
+        prepare_mixfp4_layer_for_marlin(layer)
+
+    def apply_weights(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        return apply_mixfp4_marlin_linear(
+            input=x,
+            weight=layer.weight,
+            weight_scale=layer.weight_scale,
+            weight_global_scale=layer.weight_global_scale,
+            workspace=layer.workspace,
+            size_n=layer.output_size_per_partition,
+            size_k=layer.input_size_per_partition,
+            bias=bias,
+        )

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_mixfp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_mixfp4.py
@@ -19,26 +19,19 @@ _GROUP_SIZE = 16
 
 
 def mixfp4_marlin_process_scales(marlin_scales: torch.Tensor) -> torch.Tensor:
-    """Permute FP8 scales while preserving the MixFP4 sign-bit flag."""
+    """Reorder FP8 scale byte lanes while preserving MixFP4 flags."""
     raw = marlin_scales.contiguous().view(torch.uint8)
     if raw.dim() != 2:
         raise ValueError(
             "MixFP4 Marlin scales must be a 2D tensor after permutation, "
             f"got shape {tuple(raw.shape)}."
         )
-    if raw.size(0) % 2 != 0:
-        raise ValueError(
-            "MixFP4 Marlin scale layout requires an even number of "
-            f"group rows, got {raw.size(0)}. This corresponds to size_k "
-            "being divisible by 32 for group_size=16."
-        )
-    if raw.size(1) % 8 != 0:
+    if raw.size(1) % 4 != 0:
         raise ValueError(
             "MixFP4 Marlin scale layout requires the N dimension to be "
-            f"divisible by 8 after permutation, got {raw.size(1)}."
+            f"divisible by 4 after permutation, got {raw.size(1)}."
         )
-    raw = raw.view(raw.size(0) // 2, 2, -1, 8)
-    raw = raw.permute(0, 2, 1, 3).reshape(raw.size(0) * 2, -1)
+
     raw = raw.view(-1, 4)[:, [0, 2, 1, 3]].reshape(raw.size(0), -1)
     return raw.contiguous().view(torch.float8_e4m3fn)
 

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_mixfp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_mixfp4.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Marlin helpers for MixFP4 W4A16 weight-only quantization."""
+
+import torch
+
+from vllm import _custom_ops as ops
+from vllm.model_executor.layers.quantization.utils.marlin_utils import (
+    marlin_make_workspace_new,
+    marlin_permute_bias,
+    marlin_permute_scales,
+)
+from vllm.model_executor.layers.quantization.utils.marlin_utils_fp4 import (
+    nvfp4_marlin_process_global_scale,
+)
+from vllm.scalar_type import scalar_types
+
+_GROUP_SIZE = 16
+
+
+def mixfp4_marlin_process_scales(marlin_scales: torch.Tensor) -> torch.Tensor:
+    """Permute FP8 scales while preserving the MixFP4 sign-bit flag."""
+    raw = marlin_scales.contiguous().view(torch.uint8)
+    if raw.dim() != 2:
+        raise ValueError(
+            "MixFP4 Marlin scales must be a 2D tensor after permutation, "
+            f"got shape {tuple(raw.shape)}."
+        )
+    if raw.size(0) % 2 != 0:
+        raise ValueError(
+            "MixFP4 Marlin scale layout requires an even number of "
+            f"group rows, got {raw.size(0)}. This corresponds to size_k "
+            "being divisible by 32 for group_size=16."
+        )
+    if raw.size(1) % 8 != 0:
+        raise ValueError(
+            "MixFP4 Marlin scale layout requires the N dimension to be "
+            f"divisible by 8 after permutation, got {raw.size(1)}."
+        )
+    raw = raw.view(raw.size(0) // 2, 2, -1, 8)
+    raw = raw.permute(0, 2, 1, 3).reshape(raw.size(0) * 2, -1)
+    raw = raw.view(-1, 4)[:, [0, 2, 1, 3]].reshape(raw.size(0), -1)
+    return raw.contiguous().view(torch.float8_e4m3fn)
+
+
+def prepare_mixfp4_layer_for_marlin(layer: torch.nn.Module) -> None:
+    """Repack MixFP4 compressed-tensors weights into Marlin layout."""
+    part_size_n = layer.output_size_per_partition
+    part_size_k = layer.input_size_per_partition
+    param_dtype = layer.params_dtype
+    if param_dtype != torch.bfloat16:
+        raise RuntimeError("MixFP4 Marlin currently supports bfloat16 models only.")
+    if part_size_k % (2 * _GROUP_SIZE) != 0:
+        raise RuntimeError(
+            "MixFP4 Marlin requires input_size_per_partition to be divisible "
+            f"by {2 * _GROUP_SIZE}, got {part_size_k}."
+        )
+
+    assert layer.weight.shape == (part_size_n, part_size_k // 2)
+    device = layer.weight.device
+    layer.workspace = marlin_make_workspace_new(device)
+
+    perm = torch.empty(0, dtype=torch.int, device=device)
+    qweight = layer.weight.view(torch.int32).T.contiguous()
+    marlin_qweight = ops.gptq_marlin_repack(
+        b_q_weight=qweight,
+        perm=perm,
+        size_k=part_size_k,
+        size_n=part_size_n,
+        num_bits=4,
+    )
+    layer.weight = torch.nn.Parameter(marlin_qweight, requires_grad=False)
+
+    weight_scale = layer.weight_scale.T.contiguous()
+    scale_bf16 = weight_scale.to(torch.bfloat16)
+    scale_perm_bf16 = marlin_permute_scales(
+        s=scale_bf16,
+        size_k=part_size_k,
+        size_n=part_size_n,
+        group_size=_GROUP_SIZE,
+    )
+    flag_permuted = torch.signbit(scale_perm_bf16).to(torch.uint8)
+    mag_fp8 = scale_perm_bf16.abs().to(torch.float8_e4m3fn)
+    mag_bytes = mag_fp8.contiguous().view(torch.uint8)
+    scales_flagged = ((mag_bytes & 0x7F) | (flag_permuted << 7)).view(
+        torch.float8_e4m3fn
+    )
+    layer.weight_scale = torch.nn.Parameter(
+        mixfp4_marlin_process_scales(scales_flagged), requires_grad=False
+    )
+
+    weight_global_scale = layer.weight_global_scale.to(torch.float32)
+    weight_global_scale = nvfp4_marlin_process_global_scale(
+        weight_global_scale, param_dtype
+    )
+    layer.weight_global_scale = torch.nn.Parameter(
+        weight_global_scale, requires_grad=False
+    )
+
+    if hasattr(layer, "bias") and layer.bias is not None:
+        assert layer.bias.shape == (part_size_n,)
+        layer.bias = torch.nn.Parameter(
+            marlin_permute_bias(layer.bias), requires_grad=False
+        )
+
+
+def apply_mixfp4_marlin_linear(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    weight_global_scale: torch.Tensor,
+    workspace: torch.Tensor,
+    size_n: int,
+    size_k: int,
+    bias: torch.Tensor | None = None,
+) -> torch.Tensor:
+    """Apply the MixFP4 Marlin GEMM kernel."""
+    reshaped_x = input.reshape(-1, input.shape[-1])
+    out_shape = input.shape[:-1] + (size_n,)
+
+    output = ops.mixfp4_marlin_gemm(
+        a=reshaped_x,
+        c=None,
+        b_q_weight=weight,
+        b_bias=bias,
+        b_scales=weight_scale,
+        global_scale=weight_global_scale,
+        b_zeros=None,
+        g_idx=None,
+        perm=None,
+        workspace=workspace,
+        b_q_type=scalar_types.float4_e2m1f,
+        size_m=reshaped_x.size(0),
+        size_n=size_n,
+        size_k=size_k,
+        is_k_full=True,
+        use_atomic_add=False,
+        use_fp32_reduce=False,
+        is_zp_float=False,
+    )
+    return output.reshape(out_shape)


### PR DESCRIPTION
# Add MixFP4 W4A16 Marlin inference support

## Purpose

Add vLLM inference support for MixFP4A16 compressed-tensors checkpoints on the W4A16 Marlin path.

MixFP4 is an extension of NVFP4. For each 16-weight group, MixFP4 compares the reconstruction MSE and chooses whether the elements in that group use the NVFP4 FP4 codebook or the INT4 (E1M2) codebook.

MixFP4 keeps the NVFP4-style 4.5 bit/element storage layout. The packed weights remain 4 bits/element, and each 16-weight group has one FP8 scale byte. MixFP4 reuses the unused sign bit in that FP8 scale byte as the FP4/INT4 selector, so no side metadata is added.

## Implementation

- Add `mixfp4_marlin_gemm` custom op.
- Extend the existing Marlin HMMA path in `csrc/quantization/marlin` rather than adding a separate MixFP4 kernel directory.
- Decode the FP8 scale sign bit as the FP4/INT4 selector in the dequant path.
- Detect canonical format `mixfp4-pack-quantized`; keep legacy `mixed-fp4-int4-pack-quantized` and observer alias compatibility for existing checkpoints.
- Keep ordinary `nvfp4-pack-quantized` routed to the existing NVFP4 path.
- Support fused layers such as QKV and gate-up by keeping per-partition `weight_global_scale` instead of collapsing fused partitions into a single scalar.
- Current tested scope follows the existing Marlin/NVFP4 style path: tensor-parallel size 1, BF16 activation/model dtype, Qwen/Llama-like linear layers, H100 validation.

## Usage

A MixFP4 checkpoint produced by llm-compressor/compressed-tensors can be loaded like other compressed-tensors checkpoints. No separate MixFP4 runtime flag is needed when the checkpoint config contains `quant_method: compressed-tensors` and `format: mixfp4-pack-quantized`.

Python API:

```python
from vllm import LLM, SamplingParams

llm = LLM(model="path/to/mixfp4-checkpoint", dtype="bfloat16")
outputs = llm.generate(
    ["Solve: 17 + 25 ="],
    SamplingParams(max_tokens=32),
)
```

Server CLI:

```bash
vllm serve path/to/mixfp4-checkpoint --dtype bfloat16
```

If a local test checkpoint does not include the usual compressed-tensors quantization metadata, pass the existing compressed-tensors quantization selector explicitly:

```bash
vllm serve path/to/mixfp4-checkpoint --dtype bfloat16 --quantization compressed-tensors
```

## Cross-project workflow

MixFP4 is intended to be used across the compressed-tensors -> llm-compressor -> vLLM stack:

1. `compressed-tensors` defines the canonical `mixfp4-pack-quantized` format, the `MIXFP4A16` preset, and pack/unpack/fake-quant behavior.
2. `llm-compressor` exposes the user-facing quantization recipe: `QuantizationModifier(targets="Linear", scheme="MixFP4A16", ignore=["lm_head"])`.
3. `vLLM` loads the resulting compressed-tensors checkpoint and routes `mixfp4-pack-quantized` W4A16 layers to the MixFP4 Marlin path.

Related PRs:

- compressed-tensors: https://github.com/vllm-project/compressed-tensors/pull/687
- llm-compressor: https://github.com/vllm-project/llm-compressor/pull/2657
- vLLM: https://github.com/vllm-project/vllm/pull/41004

## Shared validation summary

Storage contract:

- Persisted tensors: `weight_packed`, `weight_scale`, `weight_global_scale`.
- `weight_packed` stores 4 bits/element.
- `weight_scale` remains `torch.float8_e4m3fn`, one scale byte per 16 weights; bit 7 stores the FP4/INT4 selector.
- No extra selector tensor or side metadata is emitted.

Accuracy / quality uses lm-eval + vLLM. Math/reasoning uses Qwen math prompts with chat template and math system instruction. MMLU uses lm-eval default `mmlu`, 5-shot, no chat template. WikiText uses lm-eval default `wikitext`; lower PPL is better.

| Model | Quant | GSM8K | MATH500 strict | AIME25 | MMLU | WikiText word PPL |
|---|---|---:|---:|---:|---:|---:|
| Qwen3-8B | BF16 | 93.71% | 76.20% | 70.00% | 74.93% | 13.4838 |
| Qwen3-8B | NVFP4 | 91.58% | 72.00% | 56.67% | 73.55% | 13.7782 |
| Qwen3-8B | MixFP4 | 93.40% | 76.20% | 56.67% | 73.88% | 13.5464 |
| Qwen3-14B | BF16 | 95.07% | 78.80% | 66.67% | 78.82% | 11.6597 |
| Qwen3-14B | NVFP4 | 95.38% | 79.20% | 70.00% | 78.08% | 11.9641 |
| Qwen3-14B | MixFP4 | 94.77% | 76.20% | 66.67% | 78.14% | 11.8100 |

Quality claim: MixFP4 is close to BF16 and improves over NVFP4 on Qwen3-8B for GSM8K, MATH500, MMLU, and WikiText PPL, while tying NVFP4 on AIME25 in the post-fix rerun. On Qwen3-14B, MixFP4 improves WikiText PPL over NVFP4 and is effectively tied on MMLU, while math/reasoning is mixed. AIME25 has only 30 examples, so small-sample deltas should not be overinterpreted.


Latest-vLLM E2E performance on Qwen3-8B with H100 80GB, CUDA 12.8, Torch 2.11, and FA3 enabled:

| Shape | Quant | Wall median ms | Total tok/s median | Decode tok/s median |
|---|---|---:|---:|---:|
| prefill-heavy in=1024 out=32 bs=1 | BF16 | 233.48 | 4522.9 | 148.4 |
| prefill-heavy in=1024 out=32 bs=1 | NVFP4 | 176.25 | 5991.5 | 244.4 |
| prefill-heavy in=1024 out=32 bs=1 | MixFP4 | 187.25 | 5639.6 | 230.1 |
| decode-heavy in=32 out=512 bs=1 | BF16 | 3402.27 | 159.9 | 150.6 |
| decode-heavy in=32 out=512 bs=1 | NVFP4 | 2073.25 | 262.4 | 247.4 |
| decode-heavy in=32 out=512 bs=1 | MixFP4 | 2182.98 | 249.2 | 235.0 |
| batched in=512 out=128 bs=8 | BF16 | 982.90 | 5209.1 | 1141.7 |
| batched in=512 out=128 bs=8 | NVFP4 | 736.97 | 6947.3 | 1837.8 |
| batched in=512 out=128 bs=8 | MixFP4 | 782.96 | 6539.3 | 1751.0 |

MixFP4 is about 5-6% slower than the existing NVFP4 Marlin path in these Qwen3-8B shapes, while remaining substantially faster than BF16 in decode-heavy and batched cases.

## Test Plan

- Run compressed-tensors quantization scheme routing tests for MixFP4 and NVFP4 non-regression.
- Build vLLM with the MixFP4 custom op enabled and verify op registration.
- Run decode-heavy generation smoke for NVFP4 and MixFP4 checkpoints.
- Run E2E benchmark on Qwen3-8B comparing BF16, NVFP4, and MixFP4 on H100.
- Run lm-eval accuracy/PPL validation on Qwen3-8B and Qwen3-14B MixFP4 checkpoints.

## Test Result

- Unit tests: `8 passed, 22 deselected`.
- Build smoke: `mixfp4_marlin_gemm` registered; canonical/legacy MixFP4 formats detected; NVFP4 not mis-routed.
- Decode smoke on Qwen3-8B, input 32, output 512, batch 1:

| Quant | Wall median ms | ITL median ms | Total tok/s median | Decode tok/s median |
|---|---:|---:|---:|---:|
| NVFP4 | 2075.85 | 4.047 | 262.1 | 247.1 |
| MixFP4 | 2193.67 | 4.275 | 248.0 | 233.9 |

- E2E benchmark on Qwen3-8B shows MixFP4 is about 5-6% slower than the existing NVFP4 Marlin path in the tested shapes, while remaining substantially faster than BF16 in decode-heavy and batched cases.
- Accuracy/PPL validation results are listed above.

## Documentation / disclosure

- The usage section above documents how compressed-tensors/llm-compressor/vLLM users can create and load MixFP4 checkpoints.
- This PR was prepared with AI-assisted coding/review; the author reviewed and validated the changes.

## Future work

- Add broader model/checkpoint coverage after the compressed-tensors and llm-compressor MixFP4 PRs are available upstream.
- Investigate a future WGMMA/Triton/CUTLASS path separately from this Marlin integration.

