### PR TITLE
Use nested compile_factors in config hashing

### DIFF
--- a/tests/config/test_config_utils.py
+++ b/tests/config/test_config_utils.py
@@ -154,6 +154,26 @@ def test_enum_vs_int_disambiguation():
     assert isinstance(h_enum, str) and len(h_enum) == 64
 
 
+def test_get_hash_factors_uses_nested_compile_factors():
+    class CompileFactorsConfig:
+        def compile_factors(self):
+            return {"z": 3, "a": [2, 1]}
+
+    factors = get_hash_factors(SimpleConfig(CompileFactorsConfig()), set())
+
+    assert factors["a"] == (("a", (2, 1)), ("z", 3))
+
+
+def test_normalize_value_uses_compile_factors_recursively():
+    class CompileFactorsConfig:
+        def compile_factors(self):
+            return {"z": 3, "a": [2, 1]}
+
+    value = {"nested": [CompileFactorsConfig()]}
+
+    assert normalize_value(value) == (("nested", ((("a", (2, 1)), ("z", 3)),)),)
+
+
 def test_classes_are_types():
     """Types normalize to FQNs; include real vLLM types."""
     # Only classes allowed; functions/lambdas are rejected.

--- a/vllm/config/utils.py
+++ b/vllm/config/utils.py
@@ -203,6 +203,11 @@ class SupportsHash(Protocol):
     def compute_hash(self) -> str: ...
 
 
+@runtime_checkable
+class SupportsCompileFactors(Protocol):
+    def compile_factors(self) -> dict[str, object]: ...
+
+
 class SupportsMetricsInfo(Protocol):
     def metrics_info(self) -> dict[str, str]: ...
 
@@ -232,6 +237,9 @@ def normalize_value(x):
     Order: primitives, special types (Enum, callable, torch.dtype, Path), then
     generic containers (Mapping/Set/Sequence) with recursion.
     """
+    if isinstance(x, SupportsCompileFactors):
+        return normalize_value(x.compile_factors())
+
     # Fast path
     if x is None or isinstance(x, (bool, int, float, str)):
         return x


### PR DESCRIPTION
This PR addresses one narrow part of #39479: when collecting dataclass hash factors, check whether a nested field value exposes `compile_factors()` before normalizing it.

This keeps nested config objects from being treated as plain dataclass/value blobs when they already define their own compile-sensitive factor list.

I noticed #40246 covers a broader refactor in the same area, so I am opening this as draft. If maintainers prefer the broader PR, this can be closed; if a smaller CPU-only slice is useful, this PR keeps the change and test focused.

Testing:

```
VLLM_USE_PRECOMPILED=1 uv run --with pytest --with pydantic --with typing_extensions --with torch --with numpy --with tblib python -m pytest tests/config/test_config_utils.py -q
```

Result locally: `21 passed, 2 warnings in 43.21s`.

Fixes a subtask of #39479.