### PR TITLE
[Frontend] support extra_body params for /v1/messages (Anthropic)

### DIFF
--- a/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
+++ b/tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
@@ -635,3 +635,73 @@ class TestThinkingBlockConversion:
         # Redacted thinking is ignored, normal thinking still becomes reasoning.
         assert asst.get("reasoning") == "Thinking..."
         assert asst.get("content") == "Hi!"
+
+
+# ======================================================================
+# extra_body conversion
+# ======================================================================
+
+
+class TestExtraBodyConversion:
+    def test_extra_body_overrides_conflicting_top_level_fields(self):
+        request = _make_request(
+            [{"role": "user", "content": "Hello"}],
+            chat_template_kwargs={"enable_thinking": True},
+            extra_body={
+                "chat_template_kwargs": {
+                    "enable_thinking": False,
+                },
+                "request_id": "override-request-id",
+            },
+            request_id="top-level-request-id",
+        )
+
+        result = _convert(request)
+
+        assert result.chat_template_kwargs == {
+            "enable_thinking": False,
+        }
+        assert result.request_id == "override-request-id"
+
+    def test_extra_body_chat_template_kwargs_are_promoted(self):
+        request = _make_request(
+            [{"role": "user", "content": "Hello"}],
+            extra_body={
+                "chat_template_kwargs": {
+                    "enable_thinking": False,
+                }
+            },
+        )
+
+        result = _convert(request)
+
+        assert result.chat_template_kwargs == {
+            "enable_thinking": False,
+        }
+
+    def test_extra_body_openai_fields_are_promoted(self):
+        request = _make_request(
+            [{"role": "user", "content": "Hello"}],
+            extra_body={
+                "chat_template_kwargs": {
+                    "enable_thinking": False,
+                },
+                "documents": [{"title": "Doc 1", "text": "Body"}],
+                "media_io_kwargs": {"image": {"image_mode": "RGB"}},
+                "mm_processor_kwargs": {"max_dynamic_patch": 4},
+                "structured_outputs": {"json_object": True},
+                "request_id": "anthropic-extra-body",
+            },
+        )
+
+        result = _convert(request)
+
+        assert result.chat_template_kwargs == {
+            "enable_thinking": False,
+        }
+        assert result.documents == [{"title": "Doc 1", "text": "Body"}]
+        assert result.media_io_kwargs == {"image": {"image_mode": "RGB"}}
+        assert result.mm_processor_kwargs == {"max_dynamic_patch": 4}
+        assert result.structured_outputs is not None
+        assert result.structured_outputs.json_object is True
+        assert result.request_id == "anthropic-extra-body"

--- a/vllm/entrypoints/anthropic/protocol.py
+++ b/vllm/entrypoints/anthropic/protocol.py
@@ -5,7 +5,13 @@
 import time
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    field_validator,
+    model_validator,
+)
 
 
 class AnthropicError(BaseModel):
@@ -99,6 +105,8 @@ class AnthropicToolChoice(BaseModel):
 class AnthropicMessagesRequest(BaseModel):
     """Anthropic Messages API request"""
 
+    model_config = ConfigDict(extra="allow")
+
     model: str
     messages: list[AnthropicMessage]
     max_tokens: int
@@ -124,6 +132,28 @@ class AnthropicMessagesRequest(BaseModel):
             "Will be accessible by the template."
         ),
     )
+    extra_body: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Additional request fields to merge into the Anthropic request "
+            "body before conversion to the OpenAI-compatible request."
+        ),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def flatten_extra_body(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+
+        extra_body = data.get("extra_body")
+        if not isinstance(extra_body, dict):
+            return data
+
+        flattened = dict(data)
+        for key, value in extra_body.items():
+            flattened[key] = value
+        return flattened
 
     @field_validator("model")
     @classmethod
@@ -213,6 +243,8 @@ class AnthropicContextManagement(BaseModel):
 class AnthropicCountTokensRequest(BaseModel):
     """Anthropic messages.count_tokens request"""
 
+    model_config = ConfigDict(extra="allow")
+
     model: str
     messages: list[AnthropicMessage]
     system: str | list[AnthropicContentBlock] | None = None
@@ -227,6 +259,28 @@ class AnthropicCountTokensRequest(BaseModel):
             "Will be accessible by the template."
         ),
     )
+    extra_body: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Additional request fields to merge into the Anthropic request "
+            "body before conversion to the OpenAI-compatible request."
+        ),
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def flatten_extra_body(cls, data: Any) -> Any:
+        if not isinstance(data, dict):
+            return data
+
+        extra_body = data.get("extra_body")
+        if not isinstance(extra_body, dict):
+            return data
+
+        flattened = dict(data)
+        for key, value in extra_body.items():
+            flattened[key] = value
+        return flattened
 
     @field_validator("model")
     @classmethod

--- a/vllm/entrypoints/anthropic/serving.py
+++ b/vllm/entrypoints/anthropic/serving.py
@@ -132,6 +132,14 @@ class AnthropicServingMessages(OpenAIServingChat):
         cls._convert_tools(anthropic_request, req)
         return req
 
+    @staticmethod
+    def _get_extra_chat_completion_kwargs(
+        anthropic_request: AnthropicMessagesRequest | AnthropicCountTokensRequest,
+    ) -> dict[str, Any]:
+        extra_kwargs = dict(anthropic_request.model_extra or {})
+        extra_kwargs.pop("extra_body", None)
+        return extra_kwargs
+
     @classmethod
     def _convert_system_message(
         cls,
@@ -319,14 +327,17 @@ class AnthropicServingMessages(OpenAIServingChat):
         openai_messages: list[dict[str, Any]],
     ) -> ChatCompletionRequest:
         """Build base ChatCompletionRequest"""
+        extra_kwargs = cls._get_extra_chat_completion_kwargs(anthropic_request)
         if isinstance(anthropic_request, AnthropicCountTokensRequest):
             return ChatCompletionRequest(
+                **extra_kwargs,
                 model=anthropic_request.model,
                 messages=openai_messages,
                 chat_template_kwargs=anthropic_request.chat_template_kwargs,
             )
 
         return ChatCompletionRequest(
+            **extra_kwargs,
             model=anthropic_request.model,
             messages=openai_messages,
             max_tokens=anthropic_request.max_tokens,


### PR DESCRIPTION

This PR fixes Anthropic Messages API handling of `extra_body` so that OpenAI-compatible/vLLM-specific request fields are no longer silently ignored before Anthropic-to-OpenAI request conversion.

## Purpose

The Anthropic-compatible endpoint already accepts OpenAI-compatible behavior internally by converting requests into `ChatCompletionRequest`, but in practice many useful vLLM/OpenAI-specific fields could not be used through Anthropic clients.

In particular, Anthropic Python SDK users cannot place fields such as `chat_template_kwargs` directly at the top level, because the SDK validates the request schema and raises an error. The practical way to pass such fields is via `extra_body`, for example:

```python
message = client.messages.create(
    model=MODEL,
    max_tokens=6400,
    extra_body={
        "chat_template_kwargs": {
            "enable_thinking": True,
            "preserve_thinking": True,
        },
        "return_token_ids": True,
    },
    messages=[],
)
```

However, before this change, `extra_body` fields on the Anthropic endpoint were ignored before reaching `ChatCompletionRequest`. This meant runtime controls such as `chat_template_kwargs` had no effect even though equivalent fields work correctly on the OpenAI-compatible endpoint.

This PR adds support for `extra_body` on the Anthropic endpoint by:
- Preserving `extra_body` during Anthropic request parsing.
- Flattening/promoting `extra_body` fields so they can participate in Anthropic-to-OpenAI request conversion.
- Forwarding promoted extra fields into `ChatCompletionRequest`.
- Making `extra_body` take precedence over conflicting top-level fields, so runtime request overrides remain meaningful.

I did not find another open PR addressing this exact Anthropic `extra_body` preservation/promotion path; this change is specifically focused on making Anthropic SDK `extra_body` behave consistently with the OpenAI-compatible endpoint for vLLM-specific request parameters.

AI assistance was used to help implement and summarize this change.

## Test Plan

Manual validation against a local vLLM server using the Anthropic Python SDK:
- Send `client.messages.create(...)` requests with `extra_body.chat_template_kwargs`.
- Verify that `enable_thinking` / `preserve_thinking` change runtime behavior as expected.
- Send `extra_body.return_token_ids=True`.
- Verify the promoted field is visible in vLLM request handling/log output.
- Validate conflict behavior by ensuring `extra_body` values override same-name top-level request fields.

Targeted local command for unit coverage:
```bash
uv run -m pytest tests/entrypoints/anthropic/test_anthropic_messages_conversion.py -k extra_body -v
```

## Test Result

Manual test results:
- `extra_body["chat_template_kwargs"]` now takes effect on the Anthropic endpoint.
- Thinking behavior can be toggled through `chat_template_kwargs` passed via `extra_body`.
- `return_token_ids` and similar promoted fields are visible in vLLM runtime logs after request conversion.
- Conflict resolution behaves as intended: `extra_body` wins over conflicting top-level fields.

Additional lightweight local validation performed during development:
```bash
uv run python -m py_compile \
  vllm/entrypoints/anthropic/protocol.py \
  vllm/entrypoints/anthropic/serving.py \
  tests/entrypoints/anthropic/test_anthropic_messages_conversion.py
```

Note:
- In my local environment, full pytest execution was not completed end-to-end due dependency/runtime constraints, so the primary functional verification for this PR was manual API-level validation against a local vLLM deployment.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>