### PR TITLE
[ROCm] Eliminate redundant MoE buffer copies in AITER fused experts

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -120,34 +120,46 @@ def _rocm_aiter_fused_moe_impl(
     intermediate_pad: int = 0,
     bias1: torch.Tensor | None = None,
     bias2: torch.Tensor | None = None,
-) -> torch.Tensor:
+    moe_buf: torch.Tensor | None = None,
+) -> None:
     from aiter import ActivationType, QuantType
     from aiter.fused_moe import fused_moe
 
     activation = ActivationType(activation_method)
     quant_type = QuantType(quant_method)
 
-    return fused_moe(
-        hidden_states,
-        w1,
-        w2,
-        topk_weight,
-        topk_ids,
-        expert_mask,
-        activation,
-        quant_type,
-        doweight_stage1,
-        w1_scale,
-        w2_scale,
-        a1_scale,
-        a2_scale,
-        num_local_tokens=num_local_tokens,
-        dtype=output_dtype,
-        hidden_pad=hidden_pad,
-        intermediate_pad=intermediate_pad,
-        bias1=bias1,
-        bias2=bias2,
-    )
+    try:
+        from aiter.fused_moe import output_buffer_override
+        ctx = output_buffer_override(moe_buf) if moe_buf is not None else None
+    except ImportError:
+        ctx = None
+
+    from contextlib import nullcontext
+    with ctx if ctx is not None else nullcontext():
+        result = fused_moe(
+            hidden_states,
+            w1,
+            w2,
+            topk_weight,
+            topk_ids,
+            expert_mask,
+            activation,
+            quant_type,
+            doweight_stage1,
+            w1_scale,
+            w2_scale,
+            a1_scale,
+            a2_scale,
+            num_local_tokens=num_local_tokens,
+            dtype=output_dtype,
+            hidden_pad=hidden_pad,
+            intermediate_pad=intermediate_pad,
+            bias1=bias1,
+            bias2=bias2,
+        )
+
+    if moe_buf is not None and result is not moe_buf:
+        moe_buf.copy_(result)
 
 
 def _rocm_aiter_fused_moe_fake(
@@ -170,10 +182,9 @@ def _rocm_aiter_fused_moe_fake(
     intermediate_pad: int = 0,
     bias1: torch.Tensor | None = None,
     bias2: torch.Tensor | None = None,
-) -> torch.Tensor:
-    if output_dtype is not None:
-        return torch.empty_like(hidden_states, dtype=output_dtype)
-    return torch.empty_like(hidden_states)
+    moe_buf: torch.Tensor | None = None,
+) -> None:
+    pass
 
 
 def _rocm_aiter_asm_moe_tkw1_impl(
@@ -1372,7 +1383,7 @@ class rocm_aiter_ops:
             direct_register_custom_op(
                 op_name="rocm_aiter_fused_moe",
                 op_func=_rocm_aiter_fused_moe_impl,
-                mutates_args=[],
+                mutates_args=["moe_buf"],
                 fake_impl=_rocm_aiter_fused_moe_fake,
                 dispatch_key=current_platform.dispatch_key,
             )
@@ -1690,8 +1701,16 @@ class rocm_aiter_ops:
         intermediate_pad: int = 0,
         bias1: torch.Tensor | None = None,
         bias2: torch.Tensor | None = None,
+        moe_buf: torch.Tensor | None = None,
     ) -> torch.Tensor:
-        return torch.ops.vllm.rocm_aiter_fused_moe(
+        if moe_buf is None:
+            M = topk_ids.shape[0]
+            model_dim = w2.shape[1]
+            dtype = output_dtype if output_dtype is not None else hidden_states.dtype
+            moe_buf = torch.empty(
+                (M, model_dim), dtype=dtype, device=hidden_states.device
+            )
+        torch.ops.vllm.rocm_aiter_fused_moe(
             hidden_states,
             w1,
             w2,
@@ -1711,7 +1730,9 @@ class rocm_aiter_ops:
             intermediate_pad,
             bias1,
             bias2,
+            moe_buf,
         )
+        return moe_buf
 
     @staticmethod
     def asm_moe_tkw1(

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -1215,6 +1215,7 @@ class FusedMoEKernelModularImpl:
         expert_map: torch.Tensor | None,
         apply_router_weight_on_input: bool,
         expert_tokens_meta: ExpertTokensMetadata | None,
+        final_output: torch.Tensor | None = None,
     ) -> torch.Tensor:
         _, M_full, N, K, top_k = self.fused_experts.moe_problem_size(
             a1q, w1, w2, topk_ids
@@ -1242,6 +1243,16 @@ class FusedMoEKernelModularImpl:
             expert_tokens_meta,
             activation,
         )
+
+        # When expert workspaces are both empty (e.g. AiterExperts manages
+        # its own buffers), write directly into the caller's output tensor
+        # to avoid a redundant copy in the finalize step.
+        if (
+            final_output is not None
+            and prod(workspace13.shape) == 0
+            and prod(workspace2.shape) == 0
+        ):
+            fused_out = final_output
 
         self.fused_experts.apply(
             output=fused_out,
@@ -1403,6 +1414,7 @@ class FusedMoEKernelModularImpl:
             expert_map=expert_map,
             apply_router_weight_on_input=apply_router_weight_on_input,
             expert_tokens_meta=expert_tokens_meta,
+            final_output=output,
         )
 
         return self._finalize(

--- a/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
@@ -195,6 +195,7 @@ def rocm_aiter_fused_experts(
     a1q_scale: torch.Tensor | None = None,
     num_local_tokens: torch.Tensor | None = None,
     output_dtype: torch.dtype | None = None,
+    moe_buf: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """ROCm AITER fused MoE expert computation."""
     if quant_config is None:
@@ -309,6 +310,7 @@ def rocm_aiter_fused_experts(
             intermediate_pad=intermediate_pad,
             bias1=quant_config.w1_bias if quant_config.use_mxfp4_w4a16 else None,
             bias2=quant_config.w2_bias if quant_config.use_mxfp4_w4a16 else None,
+            moe_buf=moe_buf,
         )
 
 
@@ -436,5 +438,7 @@ class AiterExperts(mk.FusedMoEExpertsModular):
             a1q_scale=a1q_scale,
             num_local_tokens=num_local_tokens,
             output_dtype=output.dtype,
+            moe_buf=output,
         )
-        output.copy_(result)
+        if result is not output:
+            output.copy_(result)

--- a/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
+++ b/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
@@ -62,6 +62,9 @@ class TopKWeightAndReduceNoOP(mk.TopKWeightAndReduce):
         if output is None:
             return fused_expert_output
 
+        if output is fused_expert_output:
+            return output
+
         # MoEPrepareAndFinalizeNoDPEPModular needs the output to be in the `output`
         # tensor.
         assert output.size() == fused_expert_output.size(), (


### PR DESCRIPTION
## Purpose

Eliminate redundant `__amd_rocclr_copyBuffer` DMA kernel launches from the ROCm AITER fused MoE decode path by passing the caller's output tensor directly as AITER's destination buffer.

On DeepSeek-V3.2 TP4 (4x MI355X), this removes 116 copy kernels per decode step and yields a 2.3% per-step improvement (500 us savings), with a secondary benefit from reduced memory bandwidth contention on the custom allreduce.

## Changes

- **`_aiter_ops.py`**: Add `moe_buf` parameter to `rocm_aiter_fused_moe` custom op. Change return type to void and declare `mutates_args=["moe_buf"]` so torch.compile tracks the in-place write correctly. Pre-allocate `moe_buf` at the Python call site when not provided. Use AITER's `output_buffer_override` context manager when available, fall back to allocate+copy otherwise.
- **`rocm_aiter_fused_moe.py`**: Thread `moe_buf=output` from `AiterExperts.apply()` through `rocm_aiter_fused_experts`. Add identity check to skip self-copy when AITER wrote directly into the output tensor.
- **`modular_kernel.py`**: Add `final_output` parameter to `_fused_experts`. When expert workspaces are both empty (AITER manages its own buffers), write directly into the caller's output tensor, bypassing the intermediate allocation and finalize copy.
- **`topk_weight_and_reduce.py`**: Add identity check in `TopKWeightAndReduceNoOP.apply()` to skip copy when output already aliases `fused_expert_output`.

4 files, ~60 lines net.

## Test Result

### Performance (DeepSeek-V3.2, 1K input / 100 output, TP4, 4x MI355X)

| Metric | Baseline | This PR | Delta |
|---|---|---|---|
| `__amd_rocclr_copyBuffer` calls/step | 177 | 61 | **-116 (-66%)** |
| `copyBuffer` total time | 743 us | 251 us | **-492 us** |
| **Total decode step** | **21,952 us** | **21,456 us** | **-496 us (-2.3%)** |

**Before** — two `copyBuffer` calls between MoE GEMM and allreduce:
<img width="1058" height="356" alt="Screenshot 2026-04-27 at 16 39 05" src="https://github.com/user-attachments/assets/9be90395-7c60-4273-9fa9-0a1b35befda3" />

**After** — copies eliminated, MoE GEMM feeds directly into allreduce:
<img width="1058" height="356" alt="Screenshot 2026-04-27 at 16 39 15" src="https://github.com/user-attachments/assets/4b191be1-f279-4f7f-83ba-f1158502361b" />

### Accuracy (GSM8K 5-shot, exact_match, TP4)

| Config | Score | ± |
|---|---|---|
| This PR | 0.9431 | 0.0064 |

## Test Plan

- [x] Profile confirms copyBuffer reduction (177 → 61 calls)
- [x] Kernel dispatch unchanged (same MoE GEMM variants, same dense GEMM backend)
- [ ] DeepSeek-V3.2 TP4 decode produces identical outputs
- [ ] No regressions with torch.compile / HIP graphs
- [ ] Quark MoE paths unchanged (don't pass moe_buf, use default alloc)

## Dependencies

Requires AITER commit [`da318d0`](https://github.com/ROCm/aiter/commit/da318d0c10038cff73d5a6c38c471b9601fccaeb) which adds two things to `aiter/fused_moe.py`:

1. **`output_buffer_override(buf)`** — a thread-local context manager. While active, `fused_moe` writes its result into `buf` instead of allocating a fresh `moe_buf`.
2. **`_maybe_take_override_buf(M, model_dim, dtype, device)`** — called inside `fused_moe` at the point where `moe_buf` is normally allocated. If a matching override buffer exists (same shape, dtype, device, contiguous), it is used; otherwise allocation proceeds as before.

The AITER diff is ~40 lines. Prior art: [ROCm/aiter#2663](https://github.com/ROCm/aiter/pull/2663) by @tpopp (closed).

When `output_buffer_override` is not importable (older AITER), this vLLM PR falls back to the existing allocate+copy path — no crash, no regression, just no speedup.

## Related PRs

- [#39393](https://github.com/vllm-project/vllm/pull/39393) (@tpopp) — related output-copy elimination attempt (CLOSED, prior art)
- [#40341](https://github.com/vllm-project/vllm/pull/40341) — bias dtype fix (no overlap, already addressed upstream)

```
Co-authored-by: Jouni Hartikainen <jhartika@amd.com>
```
