### PR TITLE
[Kernel] OAITritonExperts MXFP4: include SM 12.x in supported device range

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
@@ -42,11 +42,12 @@ def _triton_kernel_moe_supports_current_device() -> bool:
     p = current_platform
     if p.is_cuda():
         cap = p.get_device_capability()
-        # Keep the original `(9, 0) <= cap < (11, 0)` window on
-        # CUDA (covers Hopper SM90 and Blackwell SM100, excludes
-        # SM120) — this PR is ROCm-scoped and the broader CUDA
-        # range was not validated.
-        return cap is not None and (9, 0) <= (cap.major, cap.minor) < (11, 0)
+        # `(9, 0) <= cap < (13, 0)` covers Hopper SM90, datacenter
+        # Blackwell SM100/103, and consumer Blackwell SM120/SM121
+        # (RTX 50-series, GB10 / DGX Spark). The kernels are pure
+        # Triton JIT (no SM90-only wgmma or SM10x-only tcgen05.*),
+        # so the wider upper bound is safe; verified on SM 12.1.
+        return cap is not None and (9, 0) <= (cap.major, cap.minor) < (13, 0)
     if p.is_rocm():
         from vllm.platforms.rocm import on_gfx1x, on_gfx9
 


### PR DESCRIPTION
## Summary

The OAI Triton MXFP4 device gate — `_triton_kernel_moe_supports_current_device()`, shared by `BaseOAITritonExperts` and `OAITritonMxfp4ExpertsMonolithic` — caps CUDA capability at `< (11, 0)`:

```python
# covers CUDA SM90 (Hopper) and SM100+ (datacenter Blackwell)
return cap is not None and (9, 0) <= (cap.major, cap.minor) < (11, 0)
```

That excludes consumer Blackwell — SM 12.0 / SM 12.1 (RTX 50-series and GB10 / DGX Spark) — even though those parts execute the same Triton MXFP4 kernels just fine. On SM 12.x today the engine fails to start with:

```
ValueError: Mxfp4 MoE backend 'TRITON' does not support the
deployment configuration since kernel does not support current
device cuda.
```

This bumps the upper bound to `< (13, 0)`, which lets SM 100 / 103 / 120 / 121 all reach the Triton path. The kernels are pure Triton JIT — no SM 9.0-only `wgmma` or SM 10.x-only `tcgen05.*` instructions — so the wider gate is safe.

(Rebased on main: the per-class capability checks were consolidated into the shared `_triton_kernel_moe_supports_current_device()` helper since this PR was first opened, so the bound now moves in a single place instead of the two inline call sites.)

## Test plan

- [x] Verified locally on **dual NVIDIA GB10 / SM 12.1** (DGX Spark): `_triton_kernel_moe_supports_current_device()` returns `True` after the bump and engine init progresses past this gate.
- [x] No PTX or kernel changes — only the runtime gate moves; existing CI on SM 90 (H100) / SM 100 covers the unchanged paths.
- Subsequent failures observed on SM 12.x for some workloads (e.g. SILU activation on `OAITritonExperts`, which only supports SwiGLU) are model-specific and unrelated to this gate — they manifest as proper `kernel does not support …` errors after this PR, instead of being masked behind the device-capability gate.

## Cross-platform notes

| Platform | Pre-PR | Post-PR |
|---|---|---|
| SM 80 / SM 86 / SM 89 (Ampere/Ada) | ❌ rejected (correct, kernels don't target Ampere) | ❌ rejected (unchanged) |
| SM 90 (Hopper) | ✅ accepted | ✅ accepted |
| SM 100 / 103 (datacenter Blackwell) | ✅ accepted | ✅ accepted |
| **SM 120 / 121 (consumer Blackwell)** | **❌ rejected** | **✅ accepted** |
| ROCm gfx942 / gfx950 | ✅ accepted | ✅ accepted |
| Other archs ≥ (13,0) | ❌ rejected | ❌ rejected (intentional — re-evaluate when those ship) |

cc @mgoin @tlrmchlsmth @LucasWilkinson — small follow-up to the SM 12.x story alongside #40923.
