### PR TITLE
[BugFix][CPU] fix error on CPU runner shutdown

### DIFF
--- a/vllm/v1/worker/cpu_model_runner.py
+++ b/vllm/v1/worker/cpu_model_runner.py
@@ -21,6 +21,9 @@ logger = init_logger(__name__)
 
 class CPUModelRunner(GPUModelRunner):
     def __init__(self, vllm_config: VllmConfig, device: torch.device):
+        # avoid calling accelerator APIs for methods inherited from super class
+        _set_torch_accelerator_to_noop()
+
         with _torch_cuda_wrapper():
             super().__init__(vllm_config, device)
 
@@ -244,3 +247,11 @@ def _set_global_compilation_settings(config: VllmConfig):
         yield
     finally:
         torch_inductor_config.freezing = freezing_value
+
+
+def _set_torch_accelerator_to_noop() -> None:
+    def noop(*args: Any, **kwargs: Any) -> None:
+        pass
+
+    torch.accelerator.synchronize = noop
+    torch.accelerator.empty_cache = noop


### PR DESCRIPTION
## Purpose

[BugFix][CPU] fix error on CPU runner shutdown

Fixes: #41033 which is a `RuntimeError: Cannot access accelerator device when none is available.` due to calling `torch.accelerator.synchronize()` in `CPUModelRunner.shutdown()` which we inherit from `GPUModelRunner`.

The fix money patches `torch.accelerator` APIs at init time to make them a no-op on CPU.

## Test Plan

```
vllm bench throughput --num-prompts
```

## Test Result

Worker exits cleanly.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [Y] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [Y] The test plan, such as providing test command.
- [Y] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

