### PR TITLE
[compile] Skip computation_graph.py dump unless debug/trace is active

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -1241,11 +1241,7 @@ class VllmBackend:
                 src = src.replace("<lambda>", "GraphModule")
                 with open(graph_path, "w") as f:
                     f.write(src)
-                logger.debug_once(
-                    "Computation graph saved to %s",
-                    graph_path,
-                    scope="local",
-                )
+                logger.debug_once("Computation graph saved to %s", graph_path)
 
         self._called = True
         graph_to_serialize = (

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -1228,20 +1228,24 @@ class VllmBackend:
                 if r.lower == 2:
                     fake_mode.shape_env.var_to_range[s] = ValueRanges(0, r.upper)
 
-        graph_path = os.path.join(local_cache_dir, "computation_graph.py")
-        if not os.path.exists(graph_path):
-            # code adapted from
-            # https://github.com/thuml/depyf/blob/dab831108a752d1facc00acdd6d4243891845c37/depyf/explain/patched_lazy_format_graph_code.py#L30
-            # use `print_readable` because it can include submodules
-            src = (
-                "from __future__ import annotations\nimport torch\n"
-                + self.split_gm.print_readable(print_output=False)
-            )
-            src = src.replace("<lambda>", "GraphModule")
-            with open(graph_path, "w") as f:
-                f.write(src)
-
-            logger.debug_once("Computation graph saved to %s", graph_path)
+        if os.environ.get("TORCH_TRACE") or logger.isEnabledFor(10):
+            graph_path = os.path.join(local_cache_dir, "computation_graph.py")
+            if not os.path.exists(graph_path):
+                # code adapted from
+                # https://github.com/thuml/depyf/blob/dab831108a752d1facc00acdd6d4243891845c37/depyf/explain/patched_lazy_format_graph_code.py#L30
+                # use `print_readable` because it can include submodules
+                src = (
+                    "from __future__ import annotations\nimport torch\n"
+                    + self.split_gm.print_readable(print_output=False)
+                )
+                src = src.replace("<lambda>", "GraphModule")
+                with open(graph_path, "w") as f:
+                    f.write(src)
+                logger.debug_once(
+                    "Computation graph saved to %s",
+                    graph_path,
+                    scope="local",
+                )
 
         self._called = True
         graph_to_serialize = (


### PR DESCRIPTION
## Summary
- `VllmBackend.__call__` unconditionally writes `computation_graph.py` by calling `print_readable()` on the split graph module, costing ~0.17s for graph formatting and file I/O
- This file is purely for human inspection and not needed for compilation or cache operation
- Gate the write behind `TORCH_TRACE` being set or the logger being at DEBUG level

## Benchmark (H100, single GPU, TP=1)
Qwen2.5-0.5B (24 layers):
- Cold compile: saves ~0.17s

Co-authored-by: Claude