### PR TITLE
[compile] Add fast-path in graph serialization reducer override

### DIFF
--- a/vllm/compilation/caching.py
+++ b/vllm/compilation/caching.py
@@ -220,11 +220,15 @@ class VllmSerializableFunction(SerializableCallable):  # type: ignore[misc]
 
         graph_reducer_override = GraphPickler.reducer_override
 
+        _PASSTHROUGH = (int, float, str, bytes, bool, type(None))
+
         def _graph_reducer_override(
             self: GraphPickler, obj: Any
         ) -> tuple[Callable[..., Any], tuple[Any, ...]] | Any:
+            if type(obj) in _PASSTHROUGH:
+                return NotImplemented
             if (
-                inspect.isclass(obj)
+                isinstance(obj, type)
                 and issubclass(obj, sympy.Function)
                 and hasattr(obj, "_torch_unpickler")
             ):


### PR DESCRIPTION
## Summary
- `_graph_reducer_override` in `caching.py` is called 262k times during AOT artifact serialization. Added an early return for primitive types (`int`, `float`, `str`, `bytes`, `bool`, `None`) to skip the `sympy.Function` and `FakeTensorMode` isinstance checks that never match for these types
- Replaced `inspect.isclass(obj)` with `isinstance(obj, type)` to avoid function call overhead

## Benchmark (H100, single GPU, TP=1)
Qwen2.5-0.5B (24 layers):
- `_graph_reducer_override` tottime: 0.146s → 0.090s (38% faster)
- `save_aot_compiled_function`: 5.14s → 4.81s (6.4% faster)

Co-authored-by: Claude