### PR TITLE
[Core] Fix redundant None append in StepPool.forward for chunked prefill

### DIFF
--- a/vllm/model_executor/layers/pooler/tokwise/methods.py
+++ b/vllm/model_executor/layers/pooler/tokwise/methods.py
@@ -111,7 +111,7 @@ class StepPool(AllPool):
                 if step_tag_id is not None:
                     data = data[token_id == step_tag_id]
 
-            pooled_data.append(data)
+                pooled_data.append(data)
 
         return pooled_data
 


### PR DESCRIPTION
This PR fixes a logic error in vllm/model_executor/layers/pooler.py (or the respective StepPool implementation file) where None is appended twice to the output list when handling unfinished chunks during chunked prefill.

This fix is critical for embedding models that utilize StepPool to process long sequences across multiple forward passes. Without this fix, the pooling output becomes misaligned with the batch requests.

Checklist

[x] I have performed a self-review of my code.
[x] Correctness verified with long-sequence prefill (4K+ tokens) on TPU.