### PR TITLE
Fix LFM2 decoding on ROCm

### DIFF
--- a/tests/models/test_config.py
+++ b/tests/models/test_config.py
@@ -1,0 +1,43 @@
+from types import SimpleNamespace
+
+from vllm.model_executor.models.config import Lfm2ForCausalLMConfig
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+
+def _vllm_config(backend=None):
+    return SimpleNamespace(attention_config=SimpleNamespace(backend=backend))
+
+
+def test_lfm2_forces_triton_attention_on_rocm(monkeypatch):
+    import vllm.platforms as platforms
+
+    monkeypatch.setattr(platforms, "current_platform", SimpleNamespace(is_rocm=lambda: True))
+
+    vllm_config = _vllm_config()
+    Lfm2ForCausalLMConfig.verify_and_update_config(vllm_config)
+
+    assert vllm_config.attention_config.backend == AttentionBackendEnum.TRITON_ATTN
+
+
+def test_lfm2_keeps_explicit_attention_backend_on_rocm(monkeypatch):
+    import vllm.platforms as platforms
+
+    monkeypatch.setattr(platforms, "current_platform", SimpleNamespace(is_rocm=lambda: True))
+
+    vllm_config = _vllm_config(AttentionBackendEnum.ROCM_ATTN)
+    Lfm2ForCausalLMConfig.verify_and_update_config(vllm_config)
+
+    assert vllm_config.attention_config.backend == AttentionBackendEnum.ROCM_ATTN
+
+
+def test_lfm2_does_not_force_attention_backend_off_rocm(monkeypatch):
+    import vllm.platforms as platforms
+
+    monkeypatch.setattr(
+        platforms, "current_platform", SimpleNamespace(is_rocm=lambda: False)
+    )
+
+    vllm_config = _vllm_config()
+    Lfm2ForCausalLMConfig.verify_and_update_config(vllm_config)
+
+    assert vllm_config.attention_config.backend is None

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -335,6 +335,21 @@ class LlamaNemotronVLConfig(VerifyAndUpdateConfig):
         model_config.pooler_config.seq_pooling_type = pooling_type
 
 
+class Lfm2ForCausalLMConfig(VerifyAndUpdateConfig):
+    @staticmethod
+    def verify_and_update_config(vllm_config: "VllmConfig") -> None:
+        from vllm.platforms import current_platform
+        from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+        if current_platform.is_rocm() and vllm_config.attention_config.backend is None:
+            vllm_config.attention_config.backend = AttentionBackendEnum.TRITON_ATTN
+            logger.info(
+                "Forcing TRITON_ATTN backend for LFM2 on ROCm to avoid "
+                "decode-time output corruption with the default ROCm attention "
+                "backend."
+            )
+
+
 class MambaModelConfig(VerifyAndUpdateConfig):
     @classmethod
     def verify_and_update_config(cls, vllm_config: "VllmConfig") -> None:
@@ -674,6 +689,8 @@ MODELS_CONFIG_MAP: dict[str, type[VerifyAndUpdateConfig]] = {
     "JambaForSequenceClassification": JambaForSequenceClassificationConfig,
     "JinaForRanking": JinaForRankingConfig,
     "JinaVLForRanking": JinaVLForSequenceClassificationConfig,
+    "Lfm2ForCausalLM": Lfm2ForCausalLMConfig,
+    "Lfm2MoeForCausalLM": Lfm2ForCausalLMConfig,
     "LlamaBidirectionalForSequenceClassification": LlamaBidirectionalConfig,
     "LlamaBidirectionalModel": LlamaBidirectionalConfig,
     "LlamaNemotronVLForSequenceClassification": LlamaNemotronVLConfig,


### PR DESCRIPTION
## Summary

- Force `TRITON_ATTN` for both `Lfm2ForCausalLM` and `Lfm2MoeForCausalLM` on ROCm when the user has not explicitly selected an attention backend.
- Add focused config tests for ROCm auto-selection, explicit-backend preservation, and non-ROCm behavior.

## Why

On AMD GPUs, the default ROCm attention backend for LFM2-family models can produce corrupted decode output after an initially plausible first token. Forcing `TRITON_ATTN` avoids the decode-time corruption and matches Hugging Face greedy generation on the validation prompts.

Baseline latest public ROCm wheel (`vllm==0.20.0+rocm721`) with `LiquidAI/LFM2-8B-A1B` generated:
- `4..`
- `Paris, in the context of Manoto Di Tella Declaration for our discussion:`
- invalid JSON/gibberish continuation

Baseline latest public ROCm wheel with `LiquidAI/LFM2.5-350M` selected `ROCM_ATTN` and also diverged from Hugging Face:
- HF: `4`; vLLM: `4 consideration consideration paris ing ...`
- HF: `Paris`; vLLM: `Paris's, amicate_query gain thelm`
- HF JSON prefix diverged to ` ```jsonx,`

Forcing `TRITON_ATTN` produced exact Hugging Face matches for both tested LFM2 models.

## Validation

- `python -m py_compile vllm/model_executor/models/config.py tests/models/test_config.py`
- `git diff --check`
- `python -m pytest tests/models/test_config.py -q` (`3 passed`)
- Slurm on AMD GPU compute nodes, `torch==2.10.0+git8514f05`, HIP `7.2.53211`, `transformers==5.6.2`, `vllm==0.20.0+rocm721`:
  - `LiquidAI/LFM2-8B-A1B` HF reference: `compare-lfm2-hf-rerun.json`
  - `LiquidAI/LFM2-8B-A1B` public vLLM baseline: `compare-lfm2-vllm-550279.out`
  - `LiquidAI/LFM2-8B-A1B` patched vLLM: `compare-lfm2-vllm-auto-fix-550430.out`
  - `LiquidAI/LFM2.5-350M` public vLLM baseline: `compare-lfm25-350m-557120.out` / `compare-lfm25-350m.json`
  - `LiquidAI/LFM2.5-350M` forced `TRITON_ATTN`: `compare-lfm25-350m-triton-lowmem-557156.out` / `compare-lfm25-350m-triton-lowmem.json`
