### PR TITLE
[Model] Add RWKV-7 (Goose) inference support

### DIFF
--- a/docs/models/supported_models.md
+++ b/docs/models/supported_models.md
@@ -476,6 +476,7 @@ th {
 | `Qwen3MoeForCausalLM` | Qwen3MoE | `Qwen/Qwen3-30B-A3B`, etc. | ✅︎ | ✅︎ |
 | `Qwen3NextForCausalLM` | Qwen3NextMoE | `Qwen/Qwen3-Next-80B-A3B-Instruct`, etc. | ✅︎ | ✅︎ |
 | `RWForCausalLM` | Falcon RW | `tiiuae/falcon-40b`, etc. | | ✅︎ |
+| `RWKV7ForCausalLM` | RWKV-7 "Goose" | `fla-hub/rwkv7-0.1B-g1`, `fla-hub/rwkv7-1.5B-g1`, `fla-hub/rwkv7-2.9B-g1`, `fla-hub/rwkv7-1.5B-world`, etc. | | |
 | `Rnj1ForCausalLM` | Rnj1 | `EssentialAI/rnj-1-instruct`, etc. | | |
 | `SarvamMoEForCausalLM` | Sarvam 2 | `sarvamai/sarvam2-30b-a3b`, etc. | ✅︎ | ✅︎ |
 | `SarvamMLAForCausalLM` | Sarvam 2 | `sarvamai/sarvam2-105b-a9b`, etc. | | ✅︎ |

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -411,6 +411,10 @@ _TEXT_GENERATION_EXAMPLE_MODELS = {
             "random": "yujiepan/mamba2-codestral-v0.1-tiny-random",
         },
     ),
+    "RWKV7ForCausalLM": _HfExamplesInfo(
+        "fla-hub/rwkv7-0.1B-g1",
+        trust_remote_code=True,
+    ),
     "FalconMambaForCausalLM": _HfExamplesInfo("tiiuae/falcon-mamba-7b-instruct"),
     "MiniCPMForCausalLM": _HfExamplesInfo(
         "openbmb/MiniCPM-2B-sft-bf16", trust_remote_code=True

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -756,6 +756,8 @@ class CompilationConfig:
         "vllm::gdn_attention_core_xpu",
         "vllm::olmo_hybrid_gdn_full_forward",
         "vllm::kda_attention",
+        "vllm::rwkv7_attention",
+        "vllm::rwkv7_channel_mix",
         "vllm::sparse_attn_indexer",
         "vllm::rocm_aiter_sparse_attn_indexer",
         "vllm::deepseek_v4_attention",

--- a/vllm/model_executor/layers/fla/ops/rwkv7/__init__.py
+++ b/vllm/model_executor/layers/fla/ops/rwkv7/__init__.py
@@ -1,0 +1,13 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+
+from .chunk import chunk_rwkv7
+from .fused_recurrent import fused_mul_recurrent_rwkv7
+
+__all__ = ["chunk_rwkv7", "fused_mul_recurrent_rwkv7"]

--- a/vllm/model_executor/layers/fla/ops/rwkv7/chunk.py
+++ b/vllm/model_executor/layers/fla/ops/rwkv7/chunk.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# Adapted from
+# https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/rwkv7/chunk.py
+# https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/generalized_delta_rule/dplr/chunk.py
+# Forward path only.
+# ruff: noqa: E501
+
+import torch
+
+from ..index import prepare_chunk_indices
+from .chunk_a import chunk_dplr_fwd_intra
+from .chunk_h import chunk_dplr_fwd_h
+from .chunk_o import chunk_dplr_fwd_o
+from .cumsum import chunk_rwkv6_fwd_cumsum
+from .wy_fast import prepare_wy_repr_fwd
+
+
+def chunk_dplr_fwd(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    gk: torch.Tensor,
+    scale: float,
+    initial_state: torch.Tensor | None,
+    output_final_state: bool,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_size: int = 16,
+    safe_gate: bool = False,
+    chunk_indices: torch.Tensor | None = None,
+    return_varlen_states: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+    """Forward chunked DPLR delta rule, used by RWKV-7.
+
+    Computes ``o`` and the final recurrent state via chunk-parallel kernels:
+        gi, ge = cumsum(gk)              # cumulative decay
+        intra: A_*, projected qg/kg/ag/bg
+        wy:    w, u, A_ab_inv            # WY representation for inter-chunk recurrence
+        h:     chunk states + v_new      # recurrent state evolution
+        o:     final outputs
+    """
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+
+    gi, ge = chunk_rwkv6_fwd_cumsum(
+        gk, chunk_size, cu_seqlens=cu_seqlens, chunk_indices=chunk_indices
+    )
+
+    A_ab, A_qk, A_ak, A_qb, qg, kg, ag, bg = chunk_dplr_fwd_intra(
+        q=q,
+        k=k,
+        a=a,
+        b=b,
+        gi=gi,
+        ge=ge,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        safe_gate=safe_gate,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+    )
+
+    w, u, _A_ab_inv = prepare_wy_repr_fwd(
+        ag=ag,
+        A_ab=A_ab,
+        A_ak=A_ak,
+        v=v,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+    )
+
+    h, v_new, final_state, varlen_states = chunk_dplr_fwd_h(
+        kg=kg,
+        bg=bg,
+        v=v,
+        w=w,
+        u=u,
+        gk=gi,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+        return_varlen_states=return_varlen_states,
+    )
+
+    o = chunk_dplr_fwd_o(
+        qg=qg,
+        v=v,
+        v_new=v_new,
+        A_qk=A_qk,
+        A_qb=A_qb,
+        h=h,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        chunk_indices=chunk_indices,
+    )
+
+    return o.to(q.dtype), final_state, varlen_states
+
+
+def chunk_dplr_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    gk: torch.Tensor,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    safe_gate: bool = False,
+    chunk_size: int | None = None,
+    return_varlen_states: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+    if chunk_size is None:
+        chunk_size = 16
+    if cu_seqlens is not None:
+        if q.shape[0] != 1:
+            raise ValueError(
+                f"Batch size must be 1 when using cu_seqlens, got {q.shape[0]}"
+            )
+        if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
+            raise ValueError(
+                f"initial_state must have {len(cu_seqlens) - 1} sequences, "
+                f"got {initial_state.shape[0]}"
+            )
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    return chunk_dplr_fwd(
+        q=q,
+        k=k,
+        v=v,
+        a=a,
+        b=b,
+        gk=gk,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_size=chunk_size,
+        safe_gate=safe_gate,
+        return_varlen_states=return_varlen_states,
+    )
+
+
+def chunk_rwkv7(
+    r: torch.Tensor,
+    w: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    scale: float = 1.0,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    safe_gate: bool = False,
+    chunk_size: int | None = None,
+    return_varlen_states: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+    """Chunked-prefill DPLR delta rule for RWKV-7.
+
+    Args:
+        r: ``[B, T, H, K]`` (receptance / queries)
+        w: ``[B, T, H, K]`` log-decay
+        k: ``[B, T, H, K]`` keys
+        v: ``[B, T, H, V]`` values
+        a: ``[B, T, H, K]`` activations (== ``-kk`` for RWKV-7)
+        b: ``[B, T, H, K]`` betas (== ``kk * a_gate`` for RWKV-7)
+        initial_state: ``[N, H, K, V]`` per-sequence prior recurrent state
+        cu_seqlens: ``[N+1]`` cumulative sequence lengths (FlashAttention API)
+        safe_gate: if True, use the TensorCore-accelerated intra kernel
+            (requires gates in roughly ``[-5, 0)``)
+        chunk_size: chunk parallelism granularity. Default 16 (only 16 and 64
+            are tuned in the underlying kernels).
+
+    Returns ``(o, final_state, varlen_states)``. ``varlen_states`` is
+    ``None`` unless ``return_varlen_states=True``, in which case it has
+    shape ``[NT_total, H, K, V]`` carrying the recurrent state at the END
+    of each chunk (state after consuming chunk k, indexed in the same
+    flat-across-sequences layout the chunk kernels use).
+    """
+    return chunk_dplr_delta_rule(
+        q=r,
+        k=k,
+        v=v,
+        a=a,
+        b=b,
+        gk=w,
+        scale=scale,
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+        safe_gate=safe_gate,
+        chunk_size=chunk_size,
+        return_varlen_states=return_varlen_states,
+    )

--- a/vllm/model_executor/layers/fla/ops/rwkv7/chunk_a.py
+++ b/vllm/model_executor/layers/fla/ops/rwkv7/chunk_a.py
@@ -1,0 +1,456 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# Adapted from
+# https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/generalized_delta_rule/dplr/chunk_A_fwd.py
+# Forward path only.
+# ruff: noqa: E501
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+from ..index import prepare_chunk_indices
+from ..op import exp, gather
+from ..utils import is_amd, is_gather_supported, use_cuda_graph
+
+NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [2, 4, 8, 16, 32]
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in NUM_WARPS_AUTOTUNE
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BK", "BT"],
+    use_cuda_graph=use_cuda_graph,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_dplr_fwd_A_kernel_intra_sub_intra(
+    q,
+    k,
+    a,
+    b,
+    gi,
+    ge,
+    qg,
+    kg,
+    ag,
+    bg,
+    Aqk,
+    Aqb,
+    Aab,
+    Aak,
+    cu_seqlens,
+    chunk_indices,
+    scale: tl.constexpr,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    GATHER_SUPPORTED: tl.constexpr,
+):
+    i_t, i_b, i_h = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    if i_t * BT >= T:
+        return
+
+    o_i = tl.arange(0, BC)
+    o_k = tl.arange(0, BK)
+    m_k = o_k < K
+    m_A = (i_t * BT + tl.arange(0, BC)) < T
+    last_idx = min((i_t + 1) * BT, T) - 1
+    o_A = (bos + i_t * BT + tl.arange(0, BC)) * H * BT + i_h * BT
+    p_q = tl.make_block_ptr(
+        q + (bos * H + i_h) * K, (T, K), (H * K, 1), (i_t * BT, 0), (BC, BK), (1, 0)
+    )
+    p_k = tl.make_block_ptr(
+        k + (bos * H + i_h) * K, (T, K), (H * K, 1), (i_t * BT, 0), (BC, BK), (1, 0)
+    )
+    p_a = tl.make_block_ptr(
+        a + (bos * H + i_h) * K, (T, K), (H * K, 1), (i_t * BT, 0), (BC, BK), (1, 0)
+    )
+    p_b = tl.make_block_ptr(
+        b + (bos * H + i_h) * K, (T, K), (H * K, 1), (i_t * BT, 0), (BC, BK), (1, 0)
+    )
+    p_gi = tl.make_block_ptr(
+        gi + (bos * H + i_h) * K, (T, K), (H * K, 1), (i_t * BT, 0), (BC, BK), (1, 0)
+    )
+    p_ge = tl.make_block_ptr(
+        ge + (bos * H + i_h) * K, (T, K), (H * K, 1), (i_t * BT, 0), (BC, BK), (1, 0)
+    )
+    p_g_last = gi + (bos * H + i_h) * K + last_idx * H * K + tl.arange(0, BK)
+    b_g_last = tl.load(p_g_last, mask=m_k, other=0)
+    p_qg = tl.make_block_ptr(
+        qg + (bos * H + i_h) * K, (T, K), (H * K, 1), (i_t * BT, 0), (BC, BK), (1, 0)
+    )
+    p_kg = tl.make_block_ptr(
+        kg + (bos * H + i_h) * K, (T, K), (H * K, 1), (i_t * BT, 0), (BC, BK), (1, 0)
+    )
+    p_ag = tl.make_block_ptr(
+        ag + (bos * H + i_h) * K, (T, K), (H * K, 1), (i_t * BT, 0), (BC, BK), (1, 0)
+    )
+    p_bg = tl.make_block_ptr(
+        bg + (bos * H + i_h) * K, (T, K), (H * K, 1), (i_t * BT, 0), (BC, BK), (1, 0)
+    )
+
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_q = b_q * scale
+    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_a = tl.load(p_a, boundary_check=(0, 1))
+    b_b = tl.load(p_b, boundary_check=(0, 1))
+    b_gi = tl.load(p_gi, boundary_check=(0, 1)).to(tl.float32)
+    b_ge = tl.load(p_ge, boundary_check=(0, 1)).to(tl.float32)
+
+    g_exp = exp(b_gi)
+    g_exp_inv = exp(-b_gi + b_g_last[None, :])
+    b_qg = b_q * g_exp
+    b_kg = b_k * g_exp_inv
+    b_bg = b_b * g_exp_inv
+    b_ag = b_a * exp(b_ge)
+    tl.store(
+        p_qg,
+        b_qg.to(p_qg.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_bg,
+        b_bg.to(p_bg.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_ag,
+        b_ag.to(p_ag.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_kg,
+        b_kg.to(p_kg.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+
+    b_q = b_q.to(b_k.dtype)
+    for j in range(0, min(BC, T - i_t * BT)):
+        if GATHER_SUPPORTED:
+            row_idx = tl.full([1, BK], j, dtype=tl.int16)
+            b_k_j = gather(b_k, row_idx, axis=0)
+            b_gk_j = gather(b_gi, row_idx, axis=0)
+            b_b_j = gather(b_b, row_idx, axis=0)
+        else:
+            mask = tl.arange(0, BC) == j
+            b_k_j = tl.sum(tl.where(mask[:, None], b_k, 0), 0)[None, :]
+            b_gk_j = tl.sum(tl.where(mask[:, None], b_gi, 0), 0)[None, :]
+            b_b_j = tl.sum(tl.where(mask[:, None], b_b, 0), 0)[None, :]
+        tmp = exp(b_gi - b_gk_j)
+        b_A_qk = tl.sum(b_q * b_k_j * tmp, 1)
+        m_i = (o_i >= j).to(tl.float32)
+        b_A_qk = b_A_qk * m_i
+        b_A_qb = tl.sum(b_q * b_b_j * tmp, 1)
+        b_A_qb = b_A_qb * m_i
+        tmp2 = exp(b_ge - b_gk_j)
+        b_A_ak = tl.sum(b_a * b_k_j * tmp2, 1)
+        m_i2 = (o_i > j).to(tl.float32)
+        b_A_ak = b_A_ak * m_i2
+        b_A_ab = tl.sum(b_a * b_b_j * tmp2, 1)
+        b_A_ab = b_A_ab * m_i2
+
+        tl.store(
+            Aqk + o_A + j,
+            b_A_qk.to(dtype=Aqk.dtype.element_ty, fp_downcast_rounding="rtne"),
+            mask=m_A,
+        )
+        tl.store(
+            Aqb + o_A + j,
+            b_A_qb.to(dtype=Aqb.dtype.element_ty, fp_downcast_rounding="rtne"),
+            mask=m_A,
+        )
+        tl.store(
+            Aab + o_A + j,
+            b_A_ab.to(dtype=Aqb.dtype.element_ty, fp_downcast_rounding="rtne"),
+            mask=m_A,
+        )
+        tl.store(
+            Aak + o_A + j,
+            b_A_ak.to(dtype=Aqk.dtype.element_ty, fp_downcast_rounding="rtne"),
+            mask=m_A,
+        )
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [4, 8]
+        for num_stages in [2, 3]
+    ],
+    key=["BK", "BT"],
+    use_cuda_graph=use_cuda_graph,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_dplr_fwd_A_kernel_intra_tensorcore(
+    q,
+    k,
+    a,
+    b,
+    gi,
+    ge,
+    qg,
+    kg,
+    ag,
+    bg,
+    Aqk,
+    Aqb,
+    Aab,
+    Aak,
+    cu_seqlens,
+    chunk_indices,
+    scale: tl.constexpr,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    GATHER_SUPPORTED: tl.constexpr,
+):
+    i_t, i_b, i_h = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T_len = eos - bos
+    else:
+        bos = i_b * T
+        T_len = T
+
+    if i_t * BT >= T_len:
+        return
+
+    offset_base = (bos * H + i_h) * K
+
+    p_q = tl.make_block_ptr(
+        q + offset_base, (T_len, K), (H * K, 1), (i_t * BT, 0), (BT, BK), (1, 0)
+    )
+    p_k = tl.make_block_ptr(
+        k + offset_base, (T_len, K), (H * K, 1), (i_t * BT, 0), (BT, BK), (1, 0)
+    )
+    p_a = tl.make_block_ptr(
+        a + offset_base, (T_len, K), (H * K, 1), (i_t * BT, 0), (BT, BK), (1, 0)
+    )
+    p_b = tl.make_block_ptr(
+        b + offset_base, (T_len, K), (H * K, 1), (i_t * BT, 0), (BT, BK), (1, 0)
+    )
+    p_gi = tl.make_block_ptr(
+        gi + offset_base, (T_len, K), (H * K, 1), (i_t * BT, 0), (BT, BK), (1, 0)
+    )
+    p_ge = tl.make_block_ptr(
+        ge + offset_base, (T_len, K), (H * K, 1), (i_t * BT, 0), (BT, BK), (1, 0)
+    )
+
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_k = tl.load(p_k, boundary_check=(0, 1))
+    b_a = tl.load(p_a, boundary_check=(0, 1))
+    b_b = tl.load(p_b, boundary_check=(0, 1))
+    b_gi_val = tl.load(p_gi, boundary_check=(0, 1)).to(tl.float32)
+    b_ge_val = tl.load(p_ge, boundary_check=(0, 1)).to(tl.float32)
+
+    valid_len = min(T_len - i_t * BT, BT)
+    mid_idx = valid_len // 2
+
+    m_k = tl.arange(0, BK) < K
+    p_offset = gi + offset_base + (i_t * BT + mid_idx) * K + tl.arange(0, BK)
+    b_offset = tl.load(p_offset, mask=m_k, other=0.0).to(tl.float32)
+
+    b_gi_val = b_gi_val - b_offset[None, :]
+    b_ge_val = b_ge_val - b_offset[None, :]
+
+    exp_gi = tl.exp(b_gi_val)
+    inv_exp_gi = tl.exp(-b_gi_val)
+    exp_ge = tl.exp(b_ge_val)
+
+    b_q = (b_q * scale).to(tl.float32)
+
+    q_ops = (b_q * exp_gi).to(tl.float32)
+    k_ops = (b_k * inv_exp_gi).to(tl.float32)
+    b_ops = (b_b * inv_exp_gi).to(tl.float32)
+    a_ops = (b_a * exp_ge).to(tl.float32)
+
+    last_idx = min((i_t + 1) * BT, T_len) - 1
+    p_g_last = gi + offset_base + last_idx * H * K + tl.arange(0, BK)
+    b_g_last = tl.load(p_g_last, mask=m_k, other=0.0)
+
+    exp_offset = tl.exp(b_offset)
+    b_g_centered = b_g_last - b_offset
+    exp_g_centered = tl.exp(b_g_centered)
+
+    p_qg = tl.make_block_ptr(
+        qg + offset_base, (T_len, K), (H * K, 1), (i_t * BT, 0), (BT, BK), (1, 0)
+    )
+    p_kg = tl.make_block_ptr(
+        kg + offset_base, (T_len, K), (H * K, 1), (i_t * BT, 0), (BT, BK), (1, 0)
+    )
+    p_ag = tl.make_block_ptr(
+        ag + offset_base, (T_len, K), (H * K, 1), (i_t * BT, 0), (BT, BK), (1, 0)
+    )
+    p_bg = tl.make_block_ptr(
+        bg + offset_base, (T_len, K), (H * K, 1), (i_t * BT, 0), (BT, BK), (1, 0)
+    )
+
+    tl.store(
+        p_qg,
+        (q_ops * exp_offset[None, :]).to(p_qg.dtype.element_ty),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_ag,
+        (a_ops * exp_offset[None, :]).to(p_ag.dtype.element_ty),
+        boundary_check=(0, 1),
+    )
+
+    b_kg_g = k_ops * exp_g_centered[None, :]
+    b_bg_g = b_ops * exp_g_centered[None, :]
+    tl.store(p_kg, b_kg_g.to(p_kg.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_bg, b_bg_g.to(p_bg.dtype.element_ty), boundary_check=(0, 1))
+
+    k_ops_t = tl.trans(k_ops)
+    b_ops_t = tl.trans(b_ops)
+
+    q_ops_h = q_ops.to(b_q.dtype)
+    b_A_qk = tl.dot(q_ops_h, k_ops_t.to(b_q.dtype))
+    b_A_qb = tl.dot(q_ops_h, b_ops_t.to(b_q.dtype))
+    b_A_ak = tl.dot(a_ops, k_ops_t)
+    b_A_ab = tl.dot(a_ops, b_ops_t)
+
+    offs_n = tl.arange(0, BT)
+    offs_m = tl.arange(0, BT)
+    mask_inclusive = offs_m[:, None] >= offs_n[None, :]
+    mask_strict = offs_m[:, None] > offs_n[None, :]
+
+    b_A_qk = tl.where(mask_inclusive, b_A_qk, 0.0)
+    b_A_qb = tl.where(mask_inclusive, b_A_qb, 0.0)
+    b_A_ak = tl.where(mask_strict, b_A_ak, 0.0)
+    b_A_ab = tl.where(mask_strict, b_A_ab, 0.0)
+
+    offset_out_base = (bos * H + i_h) * BT
+
+    p_Aqk = tl.make_block_ptr(
+        Aqk + offset_out_base, (T_len, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+    )
+    p_Aqb = tl.make_block_ptr(
+        Aqb + offset_out_base, (T_len, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+    )
+    p_Aak = tl.make_block_ptr(
+        Aak + offset_out_base, (T_len, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+    )
+    p_Aab = tl.make_block_ptr(
+        Aab + offset_out_base, (T_len, BT), (H * BT, 1), (i_t * BT, 0), (BT, BT), (1, 0)
+    )
+
+    tl.store(p_Aqk, b_A_qk.to(p_Aqk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Aqb, b_A_qb.to(p_Aqb.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Aak, b_A_ak.to(p_Aak.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_Aab, b_A_ab.to(p_Aab.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_dplr_fwd_intra(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    a: torch.Tensor,
+    b: torch.Tensor,
+    gi: torch.Tensor,
+    ge: torch.Tensor,
+    scale: float,
+    chunk_size: int,
+    safe_gate: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+):
+    B, T, H, K = k.shape
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    Aqk = q.new_empty(B, T, H, BT, dtype=q.dtype)
+    Aqb = q.new_empty(B, T, H, BT, dtype=q.dtype)
+    # involving matrix inverse — keep these in fp32
+    Aab = q.new_empty(B, T, H, BT, dtype=torch.float32)
+    Aak = q.new_empty(B, T, H, BT, dtype=torch.float32)
+
+    grid = (NT, B, H)
+    BK = max(triton.next_power_of_2(K), 16)
+    qg = torch.empty_like(q)
+    kg = torch.empty_like(k, dtype=q.dtype)
+    ag = torch.empty_like(a, dtype=q.dtype)
+    bg = torch.empty_like(b, dtype=q.dtype)
+    if safe_gate:
+        kernel_func = chunk_dplr_fwd_A_kernel_intra_tensorcore
+    else:
+        kernel_func = chunk_dplr_fwd_A_kernel_intra_sub_intra
+    kernel_func[grid](
+        q=q,
+        k=k,
+        a=a,
+        b=b,
+        gi=gi,
+        ge=ge,
+        Aqk=Aqk,
+        Aqb=Aqb,
+        Aab=Aab,
+        Aak=Aak,
+        qg=qg,
+        kg=kg,
+        ag=ag,
+        bg=bg,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=scale,
+        T=T,
+        H=H,
+        K=K,
+        BT=BT,
+        BC=BT,
+        BK=BK,
+        GATHER_SUPPORTED=is_gather_supported,
+    )
+    return Aab, Aqk, Aak, Aqb, qg, kg, ag, bg

--- a/vllm/model_executor/layers/fla/ops/rwkv7/chunk_h.py
+++ b/vllm/model_executor/layers/fla/ops/rwkv7/chunk_h.py
@@ -1,0 +1,277 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# Adapted from
+# https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/generalized_delta_rule/dplr/chunk_h_fwd.py
+# Forward path only.
+# ruff: noqa: E501
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+from ..index import prepare_chunk_indices, prepare_chunk_offsets
+from ..op import exp
+from ..utils import check_shared_mem, is_amd, use_cuda_graph
+
+NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [2, 4, 8, 16, 32]
+
+
+@triton.heuristics(
+    {
+        "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
+        "STORE_FINAL_STATE": lambda args: args["ht"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in NUM_WARPS_AUTOTUNE
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BT", "BK", "BV"],
+    use_cuda_graph=use_cuda_graph,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_dplr_fwd_kernel_h(
+    kg,
+    v,
+    w,
+    bg,
+    u,
+    v_new,
+    gk,
+    h,
+    h0,
+    ht,
+    cu_seqlens,
+    chunk_offsets,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_n, i_h = i_nh // H, i_nh % H
+    if IS_VARLEN:
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+        boh = tl.load(chunk_offsets + i_n).to(tl.int32)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        NT = tl.cdiv(T, BT)
+        boh = i_n * NT
+    o_k = i_k * BK + tl.arange(0, BK)
+
+    b_h = tl.zeros([BK, BV], dtype=tl.float32)
+    if USE_INITIAL_STATE:
+        p_h0 = tl.make_block_ptr(
+            h0 + i_nh * K * V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0)
+        )
+        b_h = tl.load(p_h0, boundary_check=(0, 1)).to(tl.float32)
+
+    for i_t in range(NT):
+        p_h = tl.make_block_ptr(
+            h + ((boh + i_t) * H + i_h) * K * V,
+            (K, V),
+            (V, 1),
+            (i_k * BK, i_v * BV),
+            (BK, BV),
+            (1, 0),
+        )
+        tl.store(p_h, b_h.to(p_h.dtype.element_ty), boundary_check=(0, 1))
+
+        b_hc = tl.zeros([BK, BV], dtype=tl.float32)
+        for i_c in range(tl.cdiv(min(BT, T - i_t * BT), BC)):
+            p_kg = tl.make_block_ptr(
+                kg + (bos * H + i_h) * K,
+                (K, T),
+                (1, H * K),
+                (i_k * BK, i_t * BT + i_c * BC),
+                (BK, BC),
+                (0, 1),
+            )
+            p_bg = tl.make_block_ptr(
+                bg + (bos * H + i_h) * K,
+                (K, T),
+                (1, H * K),
+                (i_k * BK, i_t * BT + i_c * BC),
+                (BK, BC),
+                (0, 1),
+            )
+            p_w = tl.make_block_ptr(
+                w + (bos * H + i_h) * K,
+                (T, K),
+                (H * K, 1),
+                (i_t * BT + i_c * BC, i_k * BK),
+                (BC, BK),
+                (1, 0),
+            )
+            p_v = tl.make_block_ptr(
+                v + (bos * H + i_h) * V,
+                (T, V),
+                (H * V, 1),
+                (i_t * BT + i_c * BC, i_v * BV),
+                (BC, BV),
+                (1, 0),
+            )
+            p_u = tl.make_block_ptr(
+                u + (bos * H + i_h) * V,
+                (T, V),
+                (H * V, 1),
+                (i_t * BT + i_c * BC, i_v * BV),
+                (BC, BV),
+                (1, 0),
+            )
+            p_v_new = tl.make_block_ptr(
+                v_new + (bos * H + i_h) * V,
+                (T, V),
+                (H * V, 1),
+                (i_t * BT + i_c * BC, i_v * BV),
+                (BC, BV),
+                (1, 0),
+            )
+            b_kg = tl.load(p_kg, boundary_check=(0, 1))
+            b_v = tl.load(p_v, boundary_check=(0, 1))
+            b_w = tl.load(p_w, boundary_check=(0, 1))
+            b_bg = tl.load(p_bg, boundary_check=(0, 1))
+            b_v2 = tl.dot(b_w, b_h.to(b_w.dtype)) + tl.load(p_u, boundary_check=(0, 1))
+            b_hc += tl.dot(b_kg, b_v)
+            b_hc += tl.dot(b_bg.to(b_hc.dtype), b_v2)
+            tl.store(p_v_new, b_v2.to(p_v_new.dtype.element_ty), boundary_check=(0, 1))
+
+        last_idx = min((i_t + 1) * BT, T) - 1
+        b_g_last = tl.load(
+            gk + (bos + last_idx) * H * K + i_h * K + o_k, mask=o_k < K
+        ).to(tl.float32)
+        b_h *= exp(b_g_last[:, None])
+        b_h += b_hc
+
+    if STORE_FINAL_STATE:
+        p_ht = tl.make_block_ptr(
+            ht + i_nh * K * V, (K, V), (V, 1), (i_k * BK, i_v * BV), (BK, BV), (1, 0)
+        )
+        tl.store(
+            p_ht,
+            b_h.to(p_ht.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
+        )
+
+
+def chunk_dplr_fwd_h(
+    kg: torch.Tensor,
+    v: torch.Tensor,
+    w: torch.Tensor,
+    u: torch.Tensor,
+    bg: torch.Tensor,
+    gk: torch.Tensor,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.Tensor | None = None,
+    return_varlen_states: bool = False,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor | None, torch.Tensor | None]:
+    B, T, H, K, V = *kg.shape, u.shape[-1]
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    if cu_seqlens is None:
+        N, NT, chunk_offsets = B, triton.cdiv(T, BT), None
+    else:
+        N = len(cu_seqlens) - 1
+        NT = len(chunk_indices)
+        chunk_offsets = prepare_chunk_offsets(cu_seqlens, BT)
+    BK = max(triton.next_power_of_2(K), 16)
+    assert BK <= 256, "current kernel does not support head dimension larger than 256."
+
+    if check_shared_mem("hopper", kg.device.index):
+        BV = 64
+        BC = 64 if K <= 128 else 32
+    elif check_shared_mem("ampere", kg.device.index):
+        BV = 32
+        BC = 32
+    else:
+        BV = 16
+        BC = 16
+
+    BC = min(BT, BC)
+    NK = triton.cdiv(K, BK)
+    NV = triton.cdiv(V, BV)
+    assert NK == 1, "NK > 1 is not supported"
+
+    h = kg.new_empty(B, NT, H, K, V)
+    # When prefix caching is on we need per-chunk-END states too. Force-enable
+    # final_state in that case since the very last chunk's end is the
+    # per-sequence final state.
+    if return_varlen_states:
+        output_final_state = True
+    final_state = (
+        kg.new_empty(N, H, K, V, dtype=torch.float32) if output_final_state else None
+    )
+    v_new = torch.empty_like(u)
+    grid = (NK, NV, N * H)
+    chunk_dplr_fwd_kernel_h[grid](
+        kg=kg,
+        v=v,
+        w=w,
+        bg=bg,
+        u=u,
+        v_new=v_new,
+        h=h,
+        gk=gk,
+        h0=initial_state,
+        ht=final_state,
+        cu_seqlens=cu_seqlens,
+        chunk_offsets=chunk_offsets,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+        BC=BC,
+        BK=BK,
+        BV=BV,
+    )
+
+    varlen_states: torch.Tensor | None = None
+    if return_varlen_states:
+        # The kernel writes ``h[k]`` = state at the START of chunk k. For
+        # prefix caching we want state at the END of each chunk (= start of
+        # the next chunk in the same sequence, or final_state for the
+        # last chunk of each sequence). Keep varlen_states in fp32 to match
+        # final_state and the canonical recurrent-state cache dtype.
+        h_squeezed = h.view(B * NT, H, K, V) if cu_seqlens is None else h[0]
+        varlen_states = torch.empty(
+            h_squeezed.shape, dtype=torch.float32, device=h_squeezed.device
+        )
+        if h_squeezed.shape[0] > 1:
+            varlen_states[:-1] = h_squeezed[1:].to(torch.float32)
+        if cu_seqlens is None:
+            for b in range(B):
+                varlen_states[b * NT + NT - 1] = final_state[b]
+        else:
+            assert chunk_offsets is not None
+            last_chunk_indices = (chunk_offsets[1:] - 1).long()
+            varlen_states[last_chunk_indices] = final_state
+
+    return h, v_new, final_state, varlen_states

--- a/vllm/model_executor/layers/fla/ops/rwkv7/chunk_o.py
+++ b/vllm/model_executor/layers/fla/ops/rwkv7/chunk_o.py
@@ -1,0 +1,199 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# Adapted from
+# https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/generalized_delta_rule/dplr/chunk_o_fwd.py
+# Forward path only.
+# ruff: noqa: E501
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+from ..index import prepare_chunk_indices
+from ..utils import check_shared_mem, is_amd, use_cuda_graph
+
+NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [2, 4, 8, 16, 32]
+BK_LIST = [32, 64, 128] if check_shared_mem() else [16, 32]
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for BK in BK_LIST
+        for BV in BK_LIST
+        for num_warps in NUM_WARPS_AUTOTUNE
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BT"],
+    use_cuda_graph=use_cuda_graph,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_dplr_fwd_kernel_o(
+    qg,
+    v,
+    v_new,
+    A_qk,
+    A_qb,
+    h,
+    o,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+
+    if IS_VARLEN:
+        i_tg = i_t
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        i_tg = i_b * NT + i_t
+        bos, eos = i_b * T, i_b * T + T
+
+    b_o = tl.zeros([BT, BV], dtype=tl.float32)
+    for i_k in range(tl.cdiv(K, BK)):
+        p_qg = tl.make_block_ptr(
+            qg + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        p_h = tl.make_block_ptr(
+            h + (i_tg * H + i_h) * K * V,
+            (K, V),
+            (V, 1),
+            (i_k * BK, i_v * BV),
+            (BK, BV),
+            (1, 0),
+        )
+        b_qg = tl.load(p_qg, boundary_check=(0, 1))
+        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_o += tl.dot(b_qg, b_h)
+
+    p_Aqk = tl.make_block_ptr(
+        A_qk + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT, 0),
+        (BT, BT),
+        (1, 0),
+    )
+    p_Aqb = tl.make_block_ptr(
+        A_qb + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT, 0),
+        (BT, BT),
+        (1, 0),
+    )
+    p_v = tl.make_block_ptr(
+        v + (bos * H + i_h) * V,
+        (T, V),
+        (H * V, 1),
+        (i_t * BT, i_v * BV),
+        (BT, BV),
+        (1, 0),
+    )
+    p_v_new = tl.make_block_ptr(
+        v_new + (bos * H + i_h) * V,
+        (T, V),
+        (H * V, 1),
+        (i_t * BT, i_v * BV),
+        (BT, BV),
+        (1, 0),
+    )
+    p_o = tl.make_block_ptr(
+        o + (bos * H + i_h) * V,
+        (T, V),
+        (H * V, 1),
+        (i_t * BT, i_v * BV),
+        (BT, BV),
+        (1, 0),
+    )
+
+    m_s = tl.arange(0, BT)[:, None] >= tl.arange(0, BT)[None, :]
+    b_Aqk = tl.load(p_Aqk, boundary_check=(0, 1))
+    b_Aqb = tl.load(p_Aqb, boundary_check=(0, 1))
+    b_Aqk = tl.where(m_s, b_Aqk, 0)
+    b_Aqb = tl.where(m_s, b_Aqb, 0)
+    b_v = tl.load(p_v, boundary_check=(0, 1))
+    b_v_new = tl.load(p_v_new, boundary_check=(0, 1))
+    b_o = (
+        b_o
+        + tl.dot(b_Aqk.to(b_v.dtype), b_v)
+        + tl.dot(b_Aqb.to(b_v_new.dtype), b_v_new)
+    )
+    tl.store(p_o, b_o.to(p_o.dtype.element_ty), boundary_check=(0, 1))
+
+
+def chunk_dplr_fwd_o(
+    qg: torch.Tensor,
+    v: torch.Tensor,
+    v_new: torch.Tensor,
+    A_qk: torch.Tensor,
+    A_qb: torch.Tensor,
+    h: torch.Tensor,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_size: int = 64,
+    chunk_indices: torch.Tensor | None = None,
+) -> torch.Tensor:
+    B, T, H, K, V = *qg.shape, v.shape[-1]
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    o = torch.empty_like(v)
+
+    def grid(meta):
+        return (triton.cdiv(V, meta["BV"]), NT, B * H)
+
+    chunk_dplr_fwd_kernel_o[grid](
+        qg=qg,
+        v=v,
+        v_new=v_new,
+        A_qk=A_qk,
+        A_qb=A_qb,
+        h=h,
+        o=o,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+    )
+    return o

--- a/vllm/model_executor/layers/fla/ops/rwkv7/cumsum.py
+++ b/vllm/model_executor/layers/fla/ops/rwkv7/cumsum.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# Adapted from
+# https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/rwkv6/chunk.py
+# (only the forward cumsum helper is vendored — the rest of rwkv6/chunk.py
+# is not used by RWKV-7 inference).
+# ruff: noqa: E501
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+from ..index import prepare_chunk_indices
+from ..utils import use_cuda_graph
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BS": BS}, num_warps=num_warps, num_stages=num_stages)
+        for BS in [16, 32, 64]
+        for num_warps in [4, 8, 16]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["S", "BT"],
+    use_cuda_graph=use_cuda_graph,
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_rwkv6_fwd_cumsum_kernel(
+    s,
+    oi,
+    oe,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    S: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_s, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    o_i = tl.arange(0, BT)
+    m_i = tl.where(o_i[:, None] >= o_i[None, :], 1.0, 0.0).to(tl.float32)
+    m_e = tl.where(o_i[:, None] > o_i[None, :], 1.0, 0.0).to(tl.float32)
+
+    p_s = tl.make_block_ptr(
+        s + (bos * H + i_h) * S,
+        (T, S),
+        (H * S, 1),
+        (i_t * BT, i_s * BS),
+        (BT, BS),
+        (1, 0),
+    )
+    p_oi = tl.make_block_ptr(
+        oi + (bos * H + i_h) * S,
+        (T, S),
+        (H * S, 1),
+        (i_t * BT, i_s * BS),
+        (BT, BS),
+        (1, 0),
+    )
+    p_oe = tl.make_block_ptr(
+        oe + (bos * H + i_h) * S,
+        (T, S),
+        (H * S, 1),
+        (i_t * BT, i_s * BS),
+        (BT, BS),
+        (1, 0),
+    )
+    b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+    b_oi = tl.dot(m_i, b_s)
+    b_oe = tl.dot(m_e, b_s)
+    tl.store(
+        p_oi,
+        b_oi.to(p_oi.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_oe,
+        b_oe.to(p_oe.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+
+
+def chunk_rwkv6_fwd_cumsum(
+    g: torch.Tensor,
+    chunk_size: int,
+    cu_seqlens: torch.Tensor | None = None,
+    chunk_indices: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Cumulative decay (inclusive + exclusive) over chunks of size BT.
+
+    ``g`` has shape ``[B, T, H, S]``; returns ``(gi, ge)`` of the same shape
+    in fp32, where ``gi[i] = sum_{j <= i} g[j]`` (inclusive) and
+    ``ge[i] = sum_{j < i} g[j]`` (exclusive) within each chunk.
+    """
+    B, T, H, S = g.shape
+    BT = chunk_size
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, chunk_size)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+
+    gi = torch.empty_like(g, dtype=torch.float32)
+    ge = torch.empty_like(g, dtype=torch.float32)
+
+    def grid(meta):
+        return (triton.cdiv(meta["S"], meta["BS"]), NT, B * H)
+
+    chunk_rwkv6_fwd_cumsum_kernel[grid](
+        g,
+        gi,
+        ge,
+        cu_seqlens,
+        chunk_indices,
+        T=T,
+        H=H,
+        S=S,
+        BT=BT,
+    )
+    return gi, ge

--- a/vllm/model_executor/layers/fla/ops/rwkv7/fused_recurrent.py
+++ b/vllm/model_executor/layers/fla/ops/rwkv7/fused_recurrent.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+# ruff: noqa: E501
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+from ..op import exp
+from ..utils import input_guard, use_cuda_graph
+
+
+@triton.heuristics(
+    {
+        "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
+        "STORE_FINAL_STATE": lambda args: args["ht"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for BV in [16, 32, 64]
+        for num_warps in [2, 4, 8, 16]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BK"],
+    use_cuda_graph=use_cuda_graph,
+)
+@triton.jit(do_not_specialize=["T"])
+def fused_recurrent_rwkv7_fwd_kernel(
+    r,
+    w,
+    k,
+    v,
+    kk,
+    a,
+    o,
+    h0,
+    ht,
+    cu_seqlens,
+    scale,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    REVERSE: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,
+    STORE_FINAL_STATE: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    IS_DECODE: tl.constexpr,
+):
+    i_v, i_nh = tl.program_id(0).to(tl.int64), tl.program_id(1).to(tl.int64)
+    i_n, i_h = i_nh // H, i_nh % H
+
+    if IS_VARLEN:
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int64),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int64),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_n * T, i_n * T + T
+
+    o_k = tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+    p_r = r + (bos + ((T - 1) if REVERSE else 0)) * H * K + i_h * K + o_k
+    p_w = w + (bos + ((T - 1) if REVERSE else 0)) * H * K + i_h * K + o_k
+    p_k = k + (bos + ((T - 1) if REVERSE else 0)) * H * K + i_h * K + o_k
+    p_v = v + (bos + ((T - 1) if REVERSE else 0)) * H * V + i_h * V + o_v
+    p_a = a + (bos + ((T - 1) if REVERSE else 0)) * H * K + i_h * K + o_k
+    p_kk = kk + (bos + ((T - 1) if REVERSE else 0)) * H * K + i_h * K + o_k
+
+    p_o = o + (bos + ((T - 1) if REVERSE else 0)) * H * V + i_h * V + o_v
+
+    mask_k = o_k < K
+    mask_v = o_v < V
+    mask_h = mask_k[:, None] & mask_v[None, :]
+    b_h = tl.zeros([BK, BV], dtype=tl.float32)
+
+    if USE_INITIAL_STATE:
+        p_h0 = h0 + i_nh * K * V + o_k[:, None] * V + o_v
+        b_h += tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
+
+    if IS_DECODE:
+        b_r = tl.load(p_r, mask=mask_k, other=0).to(tl.float32) * scale
+        b_w = tl.load(p_w, mask=mask_k, other=0).to(tl.float32)
+        b_k = tl.load(p_k, mask=mask_k, other=0).to(tl.float32)
+        b_v = tl.load(p_v, mask=mask_v, other=0).to(tl.float32)
+        b_a = tl.load(p_a, mask=mask_k, other=0).to(tl.float32)
+        b_kk = tl.load(p_kk, mask=mask_k, other=0).to(tl.float32)
+        b_act_a = -b_kk
+        b_b = b_kk * b_a
+
+        b_h = (
+            exp(b_w)[:, None] * b_h
+            + b_b[:, None] * tl.sum(b_act_a[:, None] * b_h, 0)[None, :]
+        )
+        b_h += b_k[:, None] * b_v[None, :]
+        b_o = tl.sum(b_h * b_r[:, None], 0)
+
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=mask_v)
+    else:
+        for i_t in range(0, T):
+            b_r = tl.load(p_r, mask=mask_k, other=0).to(tl.float32) * scale
+            b_w = tl.load(p_w, mask=mask_k, other=0).to(tl.float32)
+            b_k = tl.load(p_k, mask=mask_k, other=0).to(tl.float32)
+            b_v = tl.load(p_v, mask=mask_v, other=0).to(tl.float32)
+            b_a = tl.load(p_a, mask=mask_k, other=0).to(tl.float32)
+            b_kk = tl.load(p_kk, mask=mask_k, other=0).to(tl.float32)
+            b_act_a = -b_kk
+            b_b = b_kk * b_a
+
+            b_h = (
+                exp(b_w)[:, None] * b_h
+                + b_b[:, None] * tl.sum(b_act_a[:, None] * b_h, 0)[None, :]
+            )
+            b_h += b_k[:, None] * b_v[None, :]
+            b_o = tl.sum(b_h * b_r[:, None], 0)
+
+            tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=mask_v)
+            p_r += (-1 if REVERSE else 1) * H * K
+            p_w += (-1 if REVERSE else 1) * H * K
+            p_k += (-1 if REVERSE else 1) * H * K
+            p_v += (-1 if REVERSE else 1) * H * V
+            p_a += (-1 if REVERSE else 1) * H * K
+            p_kk += (-1 if REVERSE else 1) * H * K
+            p_o += (-1 if REVERSE else 1) * H * V
+
+    if STORE_FINAL_STATE:
+        p_ht = ht + i_nh * K * V + o_k[:, None] * V + o_v
+        tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
+
+
+@input_guard
+def fused_recurrent_rwkv7_fwd(
+    r: torch.Tensor,
+    w: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    kk: torch.Tensor,
+    a: torch.Tensor,
+    scale: float | None = 1.0,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    reverse: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+):
+    B, T, H, K, V = *k.shape, v.shape[-1]
+    N = B if cu_seqlens is None else len(cu_seqlens) - 1
+    BK = triton.next_power_of_2(K)
+    IS_DECODE = T == 1
+
+    h0 = initial_state
+    ht = r.new_empty(N, H, K, V, dtype=torch.float32) if output_final_state else None
+    o = torch.empty_like(v)
+
+    def grid(meta):
+        return (triton.cdiv(V, meta["BV"]), N * H)
+
+    fused_recurrent_rwkv7_fwd_kernel[grid](
+        r,
+        w,
+        k,
+        v,
+        kk,
+        a,
+        o,
+        h0,
+        ht,
+        cu_seqlens,
+        scale,
+        T=T,
+        B=B,
+        H=H,
+        K=K,
+        V=V,
+        BK=BK,
+        REVERSE=reverse,
+        IS_DECODE=IS_DECODE,
+    )
+    return o, ht
+
+
+def fused_mul_recurrent_rwkv7(
+    r: torch.Tensor,
+    w: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    kk: torch.Tensor,
+    a: torch.Tensor,
+    scale: float = 1.0,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    reverse: bool = False,
+    cu_seqlens: torch.Tensor | None = None,
+    **kwargs,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    r"""Compute S_t = S_{t-1} (I + a_t b_t^T) + v_t k_t^T per token.
+
+    Args:
+        r:  shape ``[B, T, H, K]``
+        w:  log-decay shape ``[B, T, H, K]``
+        k:  shape ``[B, T, H, K]``
+        v:  shape ``[B, T, H, V]``
+        kk: shape ``[B, T, H, K]`` — pre-normalized (k * k_k) projection used
+            both as ``a`` and ``b`` factors inside the kernel
+            (a_t = -kk, b_t = kk * a)
+        a:  shape ``[B, T, H, K]`` — scalar gate
+        initial_state: ``[N, H, K, V]`` for ``N`` sequences (``B`` if
+            ``cu_seqlens`` is None, else ``len(cu_seqlens) - 1``)
+        output_final_state: if True returns ``ht`` of shape ``[N, H, K, V]``
+        cu_seqlens: ``[N+1]`` cumulative sequence lengths (FlashAttention API).
+            When provided, ``r.shape[0]`` must be 1 (packed batch).
+    """
+    if "head_first" in kwargs:
+        raise DeprecationWarning(
+            "head_first has been removed. Inputs must be in `[B, T, H, ...]` format.",
+        )
+    if cu_seqlens is not None:
+        if r.shape[0] != 1:
+            raise ValueError(
+                f"The batch size is expected to be 1 rather than {r.shape[0]} when using `cu_seqlens`. "
+                "Please flatten variable-length inputs before processing.",
+            )
+        if initial_state is not None and initial_state.shape[0] != len(cu_seqlens) - 1:
+            raise ValueError(
+                f"The number of initial states is expected to be equal to the number of input sequences, "
+                f"i.e., {len(cu_seqlens) - 1} rather than {initial_state.shape[0]}.",
+            )
+    if scale is None:
+        scale = r.shape[-1] ** -0.5
+    o, final_state = fused_recurrent_rwkv7_fwd(
+        r,
+        w,
+        k,
+        v,
+        kk,
+        a,
+        scale,
+        initial_state,
+        output_final_state,
+        reverse,
+        cu_seqlens,
+    )
+    return o, final_state

--- a/vllm/model_executor/layers/fla/ops/rwkv7/wy_fast.py
+++ b/vllm/model_executor/layers/fla/ops/rwkv7/wy_fast.py
@@ -1,0 +1,450 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# This file contains code copied from the flash-linear-attention project.
+# The original source code was licensed under the MIT license and included
+# the following copyright notice:
+# Copyright (c) 2023-2026, Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# Adapted from
+# https://github.com/fla-org/flash-linear-attention/blob/main/fla/ops/generalized_delta_rule/dplr/wy_fast_fwd.py
+# Forward path only.
+# ruff: noqa: E501
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+from ..index import prepare_chunk_indices
+from ..op import gather
+from ..utils import is_amd, is_gather_supported, use_cuda_graph
+
+NUM_WARPS_AUTOTUNE = [2, 4, 8, 16] if is_amd else [2, 4, 8, 16, 32]
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[triton.Config({}, num_warps=num_warps) for num_warps in [1, 2, 4, 8, 16]],
+    key=["BT"],
+    use_cuda_graph=use_cuda_graph,
+)
+@triton.jit(do_not_specialize=["T"])
+def prepare_wy_repr_fwd_kernel_chunk32(
+    A_ab,
+    A_ab_inv,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,  # placeholder
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+    p_Aab = tl.make_block_ptr(
+        A_ab + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT, 0),
+        (BT, BT),
+        (1, 0),
+    )
+    p_Aab_inv = tl.make_block_ptr(
+        A_ab_inv + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT, 0),
+        (BT, BT),
+        (1, 0),
+    )
+    b_A_ab = tl.load(p_Aab, boundary_check=(0, 1))
+    b_A_ab = tl.where(tl.arange(0, BT)[:, None] > tl.arange(0, BT)[None, :], b_A_ab, 0)
+    for i in range(1, BT):
+        mask = tl.arange(0, BT) == i
+        b_a = tl.sum(tl.where(mask[:, None], b_A_ab, 0), 0)
+        b_a = b_a + tl.sum(b_a[:, None] * b_A_ab, 0) * (tl.arange(0, BT) < i)
+        b_A_ab = tl.where(mask[:, None], b_a, b_A_ab)
+    b_A_ab += tl.arange(0, BT)[:, None] == tl.arange(0, BT)[None, :]
+    tl.store(p_Aab_inv, b_A_ab.to(p_Aab_inv.dtype.element_ty), boundary_check=(0, 1))
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["BC"],
+    use_cuda_graph=use_cuda_graph,
+)
+@triton.jit(do_not_specialize=["T"])
+def prepare_wy_repr_fwd_kernel_chunk64(
+    A_ab,
+    A_ab_inv,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    BT: tl.constexpr,
+    BC: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    GATHER_SUPPORTED: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    p_A1 = tl.make_block_ptr(
+        A_ab + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT, 0),
+        (BC, BC),
+        (1, 0),
+    )
+    p_A2 = tl.make_block_ptr(
+        A_ab + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT + BC, BC),
+        (BC, BC),
+        (1, 0),
+    )
+    p_A3 = tl.make_block_ptr(
+        A_ab + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT + BC, 0),
+        (BC, BC),
+        (1, 0),
+    )
+    p_A_inv1 = tl.make_block_ptr(
+        A_ab_inv + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT, 0),
+        (BC, BC),
+        (1, 0),
+    )
+    p_A_inv2 = tl.make_block_ptr(
+        A_ab_inv + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT + BC, BC),
+        (BC, BC),
+        (1, 0),
+    )
+    p_A_inv3 = tl.make_block_ptr(
+        A_ab_inv + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT + BC, 0),
+        (BC, BC),
+        (1, 0),
+    )
+    p_A_inv4 = tl.make_block_ptr(
+        A_ab_inv + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT, BC),
+        (BC, BC),
+        (1, 0),
+    )
+
+    b_A = tl.load(p_A1, boundary_check=(0, 1))
+    b_A2 = tl.load(p_A2, boundary_check=(0, 1))
+    b_A3 = tl.load(p_A3, boundary_check=(0, 1))
+    b_A = tl.where(tl.arange(0, BC)[:, None] > tl.arange(0, BC)[None, :], b_A, 0)
+    b_A2 = tl.where(tl.arange(0, BC)[:, None] > tl.arange(0, BC)[None, :], b_A2, 0)
+
+    for i in range(1, BC):
+        if GATHER_SUPPORTED:
+            row_idx = tl.full([1, BC], i, dtype=tl.int16)
+            b_a = tl.sum(gather(b_A, row_idx, axis=0), 0)
+            b_a2 = tl.sum(gather(b_A2, row_idx, axis=0), 0)
+        else:
+            mask = tl.arange(0, BC) == i
+            b_a = tl.sum(tl.where(mask[:, None], b_A, 0), 0)
+            b_a2 = tl.sum(tl.where(mask[:, None], b_A2, 0), 0)
+        mask = tl.arange(0, BC) == i
+        b_a = b_a + tl.sum(b_a[:, None] * b_A, 0) * (tl.arange(0, BC) < i)
+        b_a2 = b_a2 + tl.sum(b_a2[:, None] * b_A2, 0) * (tl.arange(0, BC) < i)
+        b_A = tl.where(mask[:, None], b_a, b_A)
+        b_A2 = tl.where(mask[:, None], b_a2, b_A2)
+
+    # blockwise lower-triangular inverse:
+    # [A11, 0; A21, A22]^-1 = [A11^-1, 0; -A22^-1 A21 A11^-1, A22^-1]
+    b_A += tl.arange(0, BC)[:, None] == tl.arange(0, BC)[None, :]
+    b_A2 += tl.arange(0, BC)[:, None] == tl.arange(0, BC)[None, :]
+    b_A3 = tl.dot(tl.dot(b_A2, b_A3), b_A)
+    tl.store(
+        p_A_inv1,
+        b_A.to(p_A_inv1.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_A_inv2,
+        b_A2.to(p_A_inv2.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_A_inv3,
+        b_A3.to(p_A_inv3.dtype.element_ty, fp_downcast_rounding="rtne"),
+        boundary_check=(0, 1),
+    )
+    tl.store(
+        p_A_inv4,
+        tl.zeros([BC, BC], dtype=tl.float32).to(p_A_inv4.dtype.element_ty),
+        boundary_check=(0, 1),
+    )
+
+
+@triton.heuristics(
+    {
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4, 8, 16]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["H", "K", "V", "BT", "BK", "BV", "IS_VARLEN"],
+    use_cuda_graph=use_cuda_graph,
+)
+@triton.jit(do_not_specialize=["T"])
+def wu_fwd_kernel(
+    w,
+    u,
+    ag,
+    v,
+    A_ab_inv,
+    A_ak,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+    o_s = tl.arange(0, BT)
+
+    p_A_ab_inv = tl.make_block_ptr(
+        A_ab_inv + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT, 0),
+        (BT, BT),
+        (1, 0),
+    )
+    p_A_ak = tl.make_block_ptr(
+        A_ak + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT, 0),
+        (BT, BT),
+        (1, 0),
+    )
+
+    b_Aab_inv = tl.load(p_A_ab_inv, boundary_check=(0, 1))
+    b_Aak = tl.load(p_A_ak, boundary_check=(0, 1))
+    b_Aab_inv = tl.where(o_s[:, None] >= o_s[None, :], b_Aab_inv, 0)
+    b_Aak = tl.where(o_s[:, None] > o_s[None, :], b_Aak, 0)
+    b_Aak = tl.dot(b_Aab_inv, b_Aak)
+    b_Aak = b_Aak.to(v.dtype.element_ty, fp_downcast_rounding="rtne")
+    b_Aab_inv = b_Aab_inv.to(ag.dtype.element_ty, fp_downcast_rounding="rtne")
+
+    for i_k in range(tl.cdiv(K, BK)):
+        p_ag = tl.make_block_ptr(
+            ag + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        p_w = tl.make_block_ptr(
+            w + (bos * H + i_h) * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        b_ag = tl.load(p_ag, boundary_check=(0, 1))
+        b_w = tl.dot(b_Aab_inv, b_ag)
+        tl.store(
+            p_w,
+            b_w.to(p_w.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
+        )
+
+    for i_v in range(tl.cdiv(V, BV)):
+        p_v = tl.make_block_ptr(
+            v + (bos * H + i_h) * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        p_u = tl.make_block_ptr(
+            u + (bos * H + i_h) * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_u = tl.dot(b_Aak, b_v)
+        tl.store(
+            p_u,
+            b_u.to(p_u.dtype.element_ty, fp_downcast_rounding="rtne"),
+            boundary_check=(0, 1),
+        )
+
+
+def wu_fwd(
+    ag: torch.Tensor,
+    v: torch.Tensor,
+    A_ak: torch.Tensor,
+    A_ab_inv: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
+    chunk_size: int,
+    chunk_indices: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, H, K, V = *ag.shape, v.shape[-1]
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    BK = min(max(triton.next_power_of_2(K), 16), 64)
+    BV = min(max(triton.next_power_of_2(V), 16), 64)
+
+    w = torch.empty_like(ag)
+    u = torch.empty_like(v)
+    wu_fwd_kernel[(NT, B * H)](
+        ag=ag,
+        v=v,
+        A_ak=A_ak,
+        A_ab_inv=A_ab_inv,
+        w=w,
+        u=u,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        K=K,
+        V=V,
+        BT=BT,
+        BK=BK,
+        BV=BV,
+    )
+    return w, u
+
+
+def prepare_wy_repr_fwd(
+    ag: torch.Tensor,
+    v: torch.Tensor,
+    A_ak: torch.Tensor,
+    A_ab: torch.Tensor,
+    cu_seqlens: torch.Tensor | None,
+    chunk_size: int = 64,
+    chunk_indices: torch.Tensor | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    B, T, H, _ = ag.shape
+    BT = chunk_size
+
+    if chunk_indices is None and cu_seqlens is not None:
+        chunk_indices = prepare_chunk_indices(cu_seqlens, BT)
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    BC = min(BT, 32)
+    A_ab_inv = torch.empty_like(A_ab)
+    if BT == 64:
+        prepare_wy_repr_fwd_kernel_chunk64[(NT, B * H)](
+            A_ab=A_ab,
+            A_ab_inv=A_ab_inv,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            T=T,
+            H=H,
+            BT=BT,
+            BC=BC,
+            GATHER_SUPPORTED=is_gather_supported,
+        )
+    else:
+        prepare_wy_repr_fwd_kernel_chunk32[(NT, B * H)](
+            A_ab=A_ab,
+            A_ab_inv=A_ab_inv,
+            cu_seqlens=cu_seqlens,
+            chunk_indices=chunk_indices,
+            T=T,
+            H=H,
+            BT=BT,
+            BC=BC,
+        )
+    w, u = wu_fwd(
+        ag=ag,
+        v=v,
+        A_ak=A_ak,
+        A_ab_inv=A_ab_inv,
+        cu_seqlens=cu_seqlens,
+        chunk_size=BT,
+        chunk_indices=chunk_indices,
+    )
+    return w, u, A_ab_inv

--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -259,9 +259,13 @@ class MambaStateShapeCalculator:
         # RWKV-7 has no causal conv1d. Each block does its own token_shift,
         # so we keep two independent 1-token shift buffers per layer:
         # one for the time-mix block, one for the channel-mix (FFN) block.
-        # Modeled as 1-step conv-style states for cache-allocator compatibility.
-        attn_shift_shape = (1, divide(hidden_size, tp_world_size))
-        ffn_shift_shape = (1, divide(hidden_size, tp_world_size))
+        # The shift operates on the layer input, which is the full-hidden
+        # (replicated) tensor that feeds the column-parallel projections,
+        # so the shift state holds the full hidden dim on every rank --
+        # it is not sharded along ``tp_world_size``. The duplicated bytes
+        # are negligible (one token per layer per sequence).
+        attn_shift_shape = (1, hidden_size)
+        ffn_shift_shape = (1, hidden_size)
         # Recurrent matrix-valued state per head: shape (H/tp, K, V).
         # For the dense Goose family K == V == head_dim, but we keep them
         # independent to support `value_dim` overrides in future configs.

--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -124,6 +124,20 @@ class MambaStateDtypeCalculator:
         state_dtype = get_kv_cache_torch_dtype(mamba_cache_dtype, model_dtype)
         return (state_dtype, state_dtype, state_dtype, torch.float32)
 
+    @classmethod
+    def rwkv7_state_dtype(
+        cls,
+        model_dtype: ModelDType | torch.dtype,
+        mamba_cache_dtype: MambaDType,
+    ) -> tuple[torch.dtype, torch.dtype, torch.dtype]:
+        # RWKV-7 keeps its recurrent state in fp32 regardless of cache dtype:
+        # the chunk/recurrent kernels accumulate `S = exp(w) * S + b @ a^T` per
+        # token and lose accuracy quickly in lower precision. The two shift
+        # buffers (attn + FFN) hold one previous hidden state each and follow
+        # the model dtype.
+        shift_state_dtype = get_kv_cache_torch_dtype(mamba_cache_dtype, model_dtype)
+        return (shift_state_dtype, shift_state_dtype, torch.float32)
+
 
 class MambaStateShapeCalculator:
     @classmethod
@@ -232,6 +246,31 @@ class MambaStateShapeCalculator:
             head_k_dim,
         )
         return conv_state_shape, temporal_state_shape
+
+    @classmethod
+    def rwkv7_state_shape(
+        cls,
+        tp_world_size: int,
+        hidden_size: int,
+        num_heads: int,
+        head_dim: int,
+        head_v_dim: int,
+    ) -> tuple[tuple[int, int], tuple[int, int], tuple[int, int, int]]:
+        # RWKV-7 has no causal conv1d. Each block does its own token_shift,
+        # so we keep two independent 1-token shift buffers per layer:
+        # one for the time-mix block, one for the channel-mix (FFN) block.
+        # Modeled as 1-step conv-style states for cache-allocator compatibility.
+        attn_shift_shape = (1, divide(hidden_size, tp_world_size))
+        ffn_shift_shape = (1, divide(hidden_size, tp_world_size))
+        # Recurrent matrix-valued state per head: shape (H/tp, K, V).
+        # For the dense Goose family K == V == head_dim, but we keep them
+        # independent to support `value_dim` overrides in future configs.
+        recurrent_state_shape = (
+            divide(num_heads, tp_world_size),
+            head_dim,
+            head_v_dim,
+        )
+        return attn_shift_shape, ffn_shift_shape, recurrent_state_shape
 
     @classmethod
     def kda_state_shape(
@@ -371,3 +410,11 @@ class MambaStateCopyFuncCalculator:
             get_conv_copy_spec,
             get_temporal_copy_spec,
         )
+
+    @classmethod
+    def rwkv7_state_copy_func(cls):
+        # Two shift caches (attn time-mix, FFN channel-mix) + recurrent state.
+        # Only invoked by mamba prefix-cache machinery in 'align' mode, which
+        # RWKV-7 does not enter on this branch (we use 'all' mode), so this
+        # is registered for parity with other recurrent models.
+        return (get_conv_copy_spec, get_conv_copy_spec, get_temporal_copy_spec)

--- a/vllm/model_executor/layers/mamba/rwkv7_mixer.py
+++ b/vllm/model_executor/layers/mamba/rwkv7_mixer.py
@@ -10,6 +10,7 @@ from vllm.config import (
     ModelConfig,
     get_current_vllm_config,
 )
+from vllm.distributed import divide
 from vllm.distributed.parallel_state import (
     get_tensor_model_parallel_rank,
     get_tensor_model_parallel_world_size,
@@ -21,6 +22,7 @@ from vllm.model_executor.layers.fla.ops.rwkv7 import (
 )
 from vllm.model_executor.layers.linear import (
     ColumnParallelLinear,
+    ReplicatedLinear,
     RowParallelLinear,
 )
 from vllm.model_executor.layers.mamba.abstract import MambaBase
@@ -29,6 +31,8 @@ from vllm.model_executor.layers.mamba.mamba_utils import (
     MambaStateShapeCalculator,
 )
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.model_loader.weight_utils import sharded_weight_loader
+from vllm.model_executor.utils import set_weight_attrs
 from vllm.utils.torch_utils import direct_register_custom_op
 from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
 from vllm.v1.attention.backends.rwkv7_attn import Rwkv7AttentionMetadata
@@ -39,8 +43,13 @@ class LoRA(nn.Module):
 
     Mirrors fla's `fla.layers.rwkv6.LoRA`: down → activation → up, with an
     optional bias added inside the up-projection. Parameter names
-    (`lora.0.weight`, `lora.2.weight`, `lora.2.bias`) match fla so that
-    `fla-hub/rwkv7-*` checkpoints load without remapping.
+    (``lora.0.weight``, ``lora.2.weight``, ``lora.2.bias``) match fla so
+    that ``fla-hub/rwkv7-*`` checkpoints load without remapping.
+
+    TP behavior: input is the full (replicated) hidden state, so the down
+    projection is replicated. Output shards along its head/channel axis,
+    so the up projection is column-parallel and returns the local rank's
+    slice without cross-rank gather.
     """
 
     def __init__(
@@ -50,6 +59,7 @@ class LoRA(nn.Module):
         low_rank_dim: int,
         bias: bool = True,
         activation: str | None = "tanh",
+        prefix: str = "",
     ) -> None:
         super().__init__()
         self.input_dim = input_dim
@@ -58,24 +68,43 @@ class LoRA(nn.Module):
         self.bias = bias
 
         if activation is None:
-            act: nn.Module = nn.Identity()
+            self.act: nn.Module = nn.Identity()
         elif activation == "sigmoid":
-            act = nn.Sigmoid()
+            self.act = nn.Sigmoid()
         elif activation == "tanh":
-            act = nn.Tanh()
+            self.act = nn.Tanh()
         elif activation == "relu":
-            act = nn.ReLU()
+            self.act = nn.ReLU()
         else:
             raise ValueError(f"Unsupported activation `{activation}`.")
 
-        self.lora = nn.Sequential(
-            nn.Linear(input_dim, low_rank_dim, bias=False),
-            act,
-            nn.Linear(low_rank_dim, output_dim, bias=bias),
+        # ``lora.0`` matches the fla checkpoint layout (down, then activation,
+        # then up). The down projection sees the full hidden input on every
+        # rank, so it stays replicated; the up projection's output is sharded
+        # along the head/channel axis to feed downstream per-rank ops.
+        self.lora = nn.ModuleDict(
+            {
+                "0": ReplicatedLinear(
+                    input_dim,
+                    low_rank_dim,
+                    bias=False,
+                    prefix=f"{prefix}.lora.0",
+                ),
+                "2": ColumnParallelLinear(
+                    low_rank_dim,
+                    output_dim,
+                    bias=bias,
+                    gather_output=False,
+                    prefix=f"{prefix}.lora.2",
+                ),
+            }
         )
 
     def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.lora(x)
+        h, _ = self.lora["0"](x)
+        h = self.act(h)
+        out, _ = self.lora["2"](h)
+        return out
 
 
 def compute_token_shift_delta(
@@ -347,12 +376,6 @@ class RWKV7Attention(nn.Module, MambaBase):
 
         self.tp_size = get_tensor_model_parallel_world_size()
         self.tp_rank = get_tensor_model_parallel_rank()
-        # TP > 1 needs head-dim sharding on r_k and the GroupNorm group count
-        # split. Punted to a follow-up — RWKV-7 weights are <6 GB at bf16,
-        # which fits a single Blackwell easily.
-        assert self.tp_size == 1, (
-            "RWKV-7 currently runs at tensor-parallel size 1 only."
-        )
 
         self.hidden_size = hidden_size
         self.key_dim = hidden_size
@@ -370,7 +393,15 @@ class RWKV7Attention(nn.Module, MambaBase):
         self.model_config = model_config
         self.cache_config = cache_config
 
-        # Time-shift mix scalars (broadcast across batch, time)
+        # Per-rank head/channel counts. ``divide`` raises if not evenly
+        # divisible, so the model surfaces a clear error instead of silently
+        # mis-sharding when ``num_heads`` is not a multiple of ``tp_size``.
+        self.num_heads_per_tp = divide(num_heads, self.tp_size)
+        self.key_dim_per_tp = self.num_heads_per_tp * head_dim
+        self.value_dim_per_tp = self.num_heads_per_tp * self.head_v_dim
+
+        # Time-shift mix scalars. Multiplied with the layer input (full hidden,
+        # replicated across ranks), so they stay replicated.
         self.x_r = nn.Parameter(torch.zeros(1, 1, hidden_size))
         self.x_w = nn.Parameter(torch.zeros(1, 1, hidden_size))
         self.x_k = nn.Parameter(torch.zeros(1, 1, hidden_size))
@@ -378,10 +409,16 @@ class RWKV7Attention(nn.Module, MambaBase):
         self.x_a = nn.Parameter(torch.zeros(1, 1, hidden_size))
         self.x_g = nn.Parameter(torch.zeros(1, 1, hidden_size))
 
-        # Per-channel and per-(head, head_dim) scalar gates
-        self.k_k = nn.Parameter(torch.zeros(self.key_dim))
-        self.k_a = nn.Parameter(torch.zeros(self.key_dim))
-        self.r_k = nn.Parameter(torch.zeros(self.num_heads, self.head_dim))
+        # Per-channel and per-(head, head_dim) scalar gates. These multiply
+        # post-projection tensors that are already sharded along the head
+        # axis, so the parameters shard the same way.
+        self.k_k = nn.Parameter(torch.zeros(self.key_dim_per_tp))
+        self.k_a = nn.Parameter(torch.zeros(self.key_dim_per_tp))
+        self.r_k = nn.Parameter(torch.zeros(self.num_heads_per_tp, head_dim))
+        for p in (self.k_k, self.k_a):
+            set_weight_attrs(p, {"weight_loader": sharded_weight_loader(0)})
+        # ``r_k`` shards along the head axis (dim 0).
+        set_weight_attrs(self.r_k, {"weight_loader": sharded_weight_loader(0)})
 
         # Full projections (no bias). At TP=1 these are just regular Linears.
         self.r_proj = ColumnParallelLinear(
@@ -414,11 +451,15 @@ class RWKV7Attention(nn.Module, MambaBase):
         )
 
         # LoRAs. Layer 0 has no v_lora (it sets v_first = v directly).
+        # Up-projection outputs feed downstream per-rank ops (kernel inputs,
+        # gate-output correction), so the up shards along head/channel axis
+        # via ColumnParallelLinear inside ``LoRA``.
         self.w_lora = LoRA(
             hidden_size,
             self.key_dim,
             low_rank_dim=decay_low_rank_dim,
             activation="tanh",
+            prefix=f"{prefix}.w_lora",
         )
         if self.layer_idx != 0:
             self.v_lora = LoRA(
@@ -426,12 +467,14 @@ class RWKV7Attention(nn.Module, MambaBase):
                 self.value_dim,
                 low_rank_dim=v_low_rank_dim,
                 activation=None,
+                prefix=f"{prefix}.v_lora",
             )
         self.a_lora = LoRA(
             hidden_size,
             self.key_dim,
             low_rank_dim=a_low_rank_dim,
             activation=None,
+            prefix=f"{prefix}.a_lora",
         )
         # g_lora has sigmoid between the two legs and no bias on the up-proj
         self.g_lora = LoRA(
@@ -440,15 +483,20 @@ class RWKV7Attention(nn.Module, MambaBase):
             low_rank_dim=gate_low_rank_dim,
             bias=False,
             activation="sigmoid",
+            prefix=f"{prefix}.g_lora",
         )
 
-        # GroupNorm over (num_heads, head_v_dim). RWKV-7 uses bias.
+        # GroupNorm operates on each rank's local head shard. The affine
+        # weight/bias are loaded sharded along channel axis 0.
         self.g_norm = nn.GroupNorm(
-            num_groups=self.num_heads,
-            num_channels=self.value_dim,
+            num_groups=self.num_heads_per_tp,
+            num_channels=self.value_dim_per_tp,
             eps=self.head_dim * norm_eps,
             affine=True,
         )
+        if self.tp_size > 1:
+            for p in (self.g_norm.weight, self.g_norm.bias):
+                set_weight_attrs(p, {"weight_loader": sharded_weight_loader(0)})
 
         compilation_config = get_current_vllm_config().compilation_config
         if prefix in compilation_config.static_forward_context:
@@ -499,21 +547,21 @@ class RWKV7Attention(nn.Module, MambaBase):
         ``v_first[:num_actual_tokens]`` with the freshly computed ``v``.
         """
         forward_context: ForwardContext = get_forward_context()
-        attn_metadata = forward_context.attn_metadata
-        if attn_metadata is None:
+        ctx_meta: object = forward_context.attn_metadata
+        if ctx_meta is None:
             return  # profile/dummy run
 
-        if isinstance(attn_metadata, dict):
-            attn_metadata = attn_metadata[self.prefix]
-        assert isinstance(attn_metadata, Rwkv7AttentionMetadata)
-
-        m = attn_metadata
+        if isinstance(ctx_meta, dict):
+            ctx_meta = ctx_meta[self.prefix]
+        assert isinstance(ctx_meta, Rwkv7AttentionMetadata)
+        m: Rwkv7AttentionMetadata = ctx_meta
         num_actual_tokens = m.num_actual_tokens
         num_decodes = m.num_decodes
         num_prefills = m.num_prefills
         num_decode_tokens = m.num_decode_tokens
         state_indices = m.state_indices_tensor
         query_start_loc = m.query_start_loc
+        assert state_indices is not None and query_start_loc is not None
         cu_seqlens = query_start_loc.to(torch.int32)
         is_all = m.is_mamba_cache_all
 
@@ -585,21 +633,31 @@ class RWKV7Attention(nn.Module, MambaBase):
         a = self.a_lora(xa).sigmoid()
         g = self.g_lora(xg)
 
-        kk = (k * self.k_k).view(num_actual_tokens, self.num_heads, self.head_dim)
+        kk = (k * self.k_k).view(
+            num_actual_tokens, self.num_heads_per_tp, self.head_dim
+        )
         kk = F.normalize(kk, dim=-1, p=2.0).reshape(num_actual_tokens, -1)
         k = k.addcmul(k * (a - 1), self.k_a)
 
-        # [1, T_total, H, D] reshape for the packed-batch kernel
-        r_4d = r.view(1, num_actual_tokens, self.num_heads, self.head_dim).contiguous()
-        w_4d = w.view(1, num_actual_tokens, self.num_heads, self.head_dim).contiguous()
-        k_4d = k.view(1, num_actual_tokens, self.num_heads, self.head_dim).contiguous()
+        # [1, T_total, H_per_tp, D] reshape for the packed-batch kernel
+        r_4d = r.view(
+            1, num_actual_tokens, self.num_heads_per_tp, self.head_dim
+        ).contiguous()
+        w_4d = w.view(
+            1, num_actual_tokens, self.num_heads_per_tp, self.head_dim
+        ).contiguous()
+        k_4d = k.view(
+            1, num_actual_tokens, self.num_heads_per_tp, self.head_dim
+        ).contiguous()
         v_4d = v.view(
-            1, num_actual_tokens, self.num_heads, self.head_v_dim
+            1, num_actual_tokens, self.num_heads_per_tp, self.head_v_dim
         ).contiguous()
         kk_4d = kk.view(
-            1, num_actual_tokens, self.num_heads, self.head_dim
+            1, num_actual_tokens, self.num_heads_per_tp, self.head_dim
         ).contiguous()
-        a_4d = a.view(1, num_actual_tokens, self.num_heads, self.head_dim).contiguous()
+        a_4d = a.view(
+            1, num_actual_tokens, self.num_heads_per_tp, self.head_dim
+        ).contiguous()
 
         initial_state = recurrent_state_cache[read_slot]
         if initial_state.dtype != torch.float32:
@@ -653,6 +711,9 @@ class RWKV7Attention(nn.Module, MambaBase):
         # Under prefix-caching ('all') mode, also fill the intermediate blocks
         # with the per-chunk-end recurrent states produced by chunk_rwkv7.
         if is_all and num_prefills > 0 and varlen_states is not None:
+            assert m.block_idx_first_scheduled_token is not None
+            assert m.block_idx_last_scheduled_token is not None
+            assert m.mamba_block_size is not None
             # Indices of the prefill rows in the [N, max_blocks] state table.
             state_indices_p = state_indices[num_decodes:]
             # Per-prefill chunk offsets in the global varlen_states tensor.
@@ -694,13 +755,13 @@ class RWKV7Attention(nn.Module, MambaBase):
                 recurrent_state_cache=recurrent_state_cache,
             )
 
-        o = self.g_norm(core_out.view(num_actual_tokens, self.value_dim))
+        o = self.g_norm(core_out.view(num_actual_tokens, self.value_dim_per_tp))
         o = _gate_output_correction(
             o,
-            r_4d.view(num_actual_tokens, self.num_heads, self.head_dim),
-            k_4d.view(num_actual_tokens, self.num_heads, self.head_dim),
+            r_4d.view(num_actual_tokens, self.num_heads_per_tp, self.head_dim),
+            k_4d.view(num_actual_tokens, self.num_heads_per_tp, self.head_dim),
             self.r_k,
-            v_4d.view(num_actual_tokens, self.num_heads, self.head_v_dim),
+            v_4d.view(num_actual_tokens, self.num_heads_per_tp, self.head_v_dim),
             g,
         )
         proj, _ = self.o_proj(o)
@@ -713,6 +774,9 @@ class RWKV7Attention(nn.Module, MambaBase):
             shift_state_cache=attn_shift_cache,
         )
         if is_all and num_prefills > 0:
+            assert m.block_idx_first_scheduled_token is not None
+            assert m.block_idx_last_scheduled_token is not None
+            assert m.mamba_block_size is not None
             cu_seqlens_p_long = (cu_seqlens[num_decodes:] - cu_seqlens[num_decodes]).to(
                 torch.long
             )

--- a/vllm/model_executor/layers/mamba/rwkv7_mixer.py
+++ b/vllm/model_executor/layers/mamba/rwkv7_mixer.py
@@ -209,7 +209,8 @@ def scatter_intermediate_shift_blocks(
         query_start_loc_p: cumulative offsets within the prefill chunk,
             shape ``[num_prefills + 1]``.
         state_indices_tensor_p: ``[num_prefills, max_blocks]`` cache slot ids.
-        block_idx_first_scheduled_p, block_idx_last_scheduled_p: ``[num_prefills]``
+        block_idx_first_scheduled_p: ``[num_prefills]`` first block to fill.
+        block_idx_last_scheduled_p: ``[num_prefills]`` last block (exclusive).
         num_computed_tokens_p: ``[num_prefills]`` tokens already cached
             entering this step (used to align to the prefill input).
         block_size: cache block size in tokens (= kernel chunk_size for

--- a/vllm/model_executor/layers/mamba/rwkv7_mixer.py
+++ b/vllm/model_executor/layers/mamba/rwkv7_mixer.py
@@ -688,6 +688,24 @@ class RWKV7Attention(nn.Module, MambaBase):
             # chunk_rwkv7 takes (a=-kk, b=kk*a_gate) — fla's parameterization
             a_chunk = -kk_4d
             b_chunk = kk_4d * a_4d
+            # In prefix-cache ('all') mode the chunk size must align with
+            # ``mamba_block_size`` so each cache block corresponds to exactly
+            # one chunk's end-state — ``scatter_intermediate_recurrent_blocks``
+            # samples ``varlen_states`` at stride
+            # ``block_size // chunk_size`` and would silently drop writes
+            # if that stride collapses to <1. The DPLR chunk kernel only has
+            # tuned configs for chunk_size 16 and 64, so the cache spec
+            # validates ``mamba_block_size`` against that set above.
+            if is_all:
+                assert m.mamba_block_size is not None
+                chunk_size: int = m.mamba_block_size
+            else:
+                chunk_size = 64
+            assert chunk_size in (16, 64), (
+                f"mamba_block_size must be 16 or 64 for RWKV-7 prefix caching "
+                f"(the only sizes the chunk kernel is tuned for); got "
+                f"{chunk_size}."
+            )
             core_out, final_state, varlen_states = chunk_rwkv7(
                 r=r_4d,
                 w=w_4d,
@@ -702,7 +720,7 @@ class RWKV7Attention(nn.Module, MambaBase):
                 # Our log-decay is `-0.6065 * sigmoid(...)`, which sits in
                 # (-0.607, 0] — well inside the safe-gate range.
                 safe_gate=True,
-                chunk_size=64,
+                chunk_size=chunk_size,
                 return_varlen_states=is_all,
             )
         # Write per-sequence final state to the last_scheduled cache slot.
@@ -720,7 +738,8 @@ class RWKV7Attention(nn.Module, MambaBase):
             # cu_seqlens for the prefill subset:
             cu_seqlens_p = cu_seqlens[num_decodes:] - cu_seqlens[num_decodes]
             cu_seqlens_p = cu_seqlens_p.to(torch.long)
-            chunk_size = 64
+            # ``chunk_size`` was bound above to either ``mamba_block_size``
+            # (so chunk_stride == 1 in scatter) or 64 for the non-prefix path.
             # Number of chunks per sequence = cdiv(seq_len, chunk_size).
             # varlen_states is laid out over the whole packed batch, including
             # decode chunks before the prefill region.

--- a/vllm/model_executor/layers/mamba/rwkv7_mixer.py
+++ b/vllm/model_executor/layers/mamba/rwkv7_mixer.py
@@ -1,0 +1,816 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+import torch.nn.functional as F
+from torch import nn
+
+from vllm.config import (
+    CacheConfig,
+    ModelConfig,
+    get_current_vllm_config,
+)
+from vllm.distributed.parallel_state import (
+    get_tensor_model_parallel_rank,
+    get_tensor_model_parallel_world_size,
+)
+from vllm.forward_context import ForwardContext, get_forward_context
+from vllm.model_executor.layers.fla.ops.rwkv7 import (
+    chunk_rwkv7,
+    fused_mul_recurrent_rwkv7,
+)
+from vllm.model_executor.layers.linear import (
+    ColumnParallelLinear,
+    RowParallelLinear,
+)
+from vllm.model_executor.layers.mamba.abstract import MambaBase
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateDtypeCalculator,
+    MambaStateShapeCalculator,
+)
+from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.utils.torch_utils import direct_register_custom_op
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
+from vllm.v1.attention.backends.rwkv7_attn import Rwkv7AttentionMetadata
+
+
+class LoRA(nn.Module):
+    """Low-rank projection used by RWKV-7's w/a/v/g gates.
+
+    Mirrors fla's `fla.layers.rwkv6.LoRA`: down → activation → up, with an
+    optional bias added inside the up-projection. Parameter names
+    (`lora.0.weight`, `lora.2.weight`, `lora.2.bias`) match fla so that
+    `fla-hub/rwkv7-*` checkpoints load without remapping.
+    """
+
+    def __init__(
+        self,
+        input_dim: int,
+        output_dim: int,
+        low_rank_dim: int,
+        bias: bool = True,
+        activation: str | None = "tanh",
+    ) -> None:
+        super().__init__()
+        self.input_dim = input_dim
+        self.output_dim = output_dim
+        self.low_rank_dim = low_rank_dim
+        self.bias = bias
+
+        if activation is None:
+            act: nn.Module = nn.Identity()
+        elif activation == "sigmoid":
+            act = nn.Sigmoid()
+        elif activation == "tanh":
+            act = nn.Tanh()
+        elif activation == "relu":
+            act = nn.ReLU()
+        else:
+            raise ValueError(f"Unsupported activation `{activation}`.")
+
+        self.lora = nn.Sequential(
+            nn.Linear(input_dim, low_rank_dim, bias=False),
+            act,
+            nn.Linear(low_rank_dim, output_dim, bias=bias),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.lora(x)
+
+
+def compute_token_shift_delta(
+    hidden_states: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    state_indices: torch.Tensor,
+    shift_state_cache: torch.Tensor,
+    has_initial_state: torch.Tensor | None,
+    num_decodes: int,
+    num_prefills: int,
+) -> torch.Tensor:
+    """Compute ``delta = shifted - hidden_states`` for the packed batch.
+
+    For each sequence the "shifted" tensor is::
+
+        [cached_prev_token, x_0, x_1, ..., x_{T-2}]
+
+    where ``cached_prev_token`` is the previous step's last hidden state for
+    the sequence (or zeros for a freshly-started prefill).
+
+    Args:
+        hidden_states: ``[T_total, D]``.
+        query_start_loc: ``[N+1]`` cumulative token offsets per sequence.
+        state_indices: ``[N]`` block ids in ``shift_state_cache``.
+        shift_state_cache: ``[num_blocks, 1, D]``.
+        has_initial_state: ``[num_prefills]`` bool, or ``None``. ``True`` means
+            the corresponding prefill sequence has cached state (resumed
+            prefill). Decode sequences (the first ``num_decodes`` slots) are
+            assumed to always have valid cached state.
+    """
+    T_total, D = hidden_states.shape
+    prev = hidden_states.new_zeros(T_total, D)
+    if T_total > 1:
+        prev[1:] = hidden_states[:-1]
+
+    seq_starts = query_start_loc[:-1].to(torch.long)
+    cached_prev = shift_state_cache[state_indices, 0]  # [N, D]
+    if has_initial_state is not None and num_prefills > 0:
+        mask = has_initial_state.to(cached_prev.dtype).unsqueeze(-1)
+        cached_prev_prefill = cached_prev[num_decodes:] * mask
+        cached_prev = torch.cat([cached_prev[:num_decodes], cached_prev_prefill], dim=0)
+    prev[seq_starts] = cached_prev.to(prev.dtype)
+    return prev - hidden_states
+
+
+def update_shift_state(
+    hidden_states: torch.Tensor,
+    query_start_loc: torch.Tensor,
+    state_indices: torch.Tensor,
+    shift_state_cache: torch.Tensor,
+) -> None:
+    """Write the last token of each sequence into ``shift_state_cache``."""
+    last_token_indices = query_start_loc[1:].to(torch.long) - 1
+    last_tokens = hidden_states[last_token_indices]  # [N, D]
+    shift_state_cache[state_indices, 0] = last_tokens.to(shift_state_cache.dtype)
+
+
+def resolve_state_slots(
+    state_indices_tensor: torch.Tensor,
+    block_idx_last_computed: torch.Tensor | None,
+    block_idx_last_scheduled: torch.Tensor | None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Pick the cache-slot indices for read (last computed) and write (last
+    scheduled) under either default or 'all' mamba_cache_mode.
+
+    Default mode: ``state_indices_tensor`` is 1D, both slots = same value.
+    'all' mode: ``state_indices_tensor`` is 2D ``[N, max_blocks]``; gather the
+    column at ``block_idx_*`` per sequence.
+    """
+    if block_idx_last_computed is None or block_idx_last_scheduled is None:
+        return state_indices_tensor, state_indices_tensor
+    read_idx = state_indices_tensor.gather(
+        1, block_idx_last_computed.long().unsqueeze(1)
+    ).squeeze(1)
+    write_idx = state_indices_tensor.gather(
+        1, block_idx_last_scheduled.long().unsqueeze(1)
+    ).squeeze(1)
+    return read_idx, write_idx
+
+
+def scatter_intermediate_shift_blocks(
+    hidden_states: torch.Tensor,
+    query_start_loc_p: torch.Tensor,
+    state_indices_tensor_p: torch.Tensor,
+    block_idx_first_scheduled_p: torch.Tensor,
+    block_idx_last_scheduled_p: torch.Tensor,
+    num_computed_tokens_p: torch.Tensor,
+    block_size: int,
+    shift_state_cache: torch.Tensor,
+    num_decode_tokens: int,
+) -> None:
+    """Snapshot the end-of-block tokens of each prefill into shift cache.
+
+    For prefill sequence ``i`` with ``first_scheduled=f``, ``last_scheduled=l``,
+    we write ``hidden_states`` at the absolute position
+    ``(k+1)*block_size - 1`` to ``shift_state_cache[state_indices_p[i, k]]``
+    for every fully-completed block ``k in [f, l)``. The last block ``l`` is
+    always written by ``update_shift_state`` separately (it may be partial).
+
+    Args:
+        hidden_states: ``[T_total, D]`` (the layer input).
+        query_start_loc_p: cumulative offsets within the prefill chunk,
+            shape ``[num_prefills + 1]``.
+        state_indices_tensor_p: ``[num_prefills, max_blocks]`` cache slot ids.
+        block_idx_first_scheduled_p, block_idx_last_scheduled_p: ``[num_prefills]``
+        num_computed_tokens_p: ``[num_prefills]`` tokens already cached
+            entering this step (used to align to the prefill input).
+        block_size: cache block size in tokens (= kernel chunk_size for
+            chunk_stride=1, which is what we use).
+        shift_state_cache: ``[num_blocks, 1, D]``
+        num_decode_tokens: prefill input starts at this offset in
+            ``hidden_states``.
+    """
+    num_prefills = block_idx_first_scheduled_p.shape[0]
+    if num_prefills == 0:
+        return
+
+    starts_p = query_start_loc_p[:-1].to(torch.long)
+    for i in range(num_prefills):
+        f = int(block_idx_first_scheduled_p[i].item())
+        last = int(block_idx_last_scheduled_p[i].item())
+        if last <= f:
+            continue
+        num_computed = int(num_computed_tokens_p[i].item())
+        seq_start_in_prefill = int(starts_p[i].item())
+        # Absolute end-of-block positions in the full sequence:
+        # (k+1)*block_size - 1
+        # Position within the prefill input: that minus num_computed
+        # Position in the global packed tensor:
+        # + num_decode_tokens + seq_start_in_prefill
+        for k in range(f, last):
+            end_of_block = (k + 1) * block_size - 1
+            pos_in_prefill = end_of_block - num_computed
+            if pos_in_prefill < 0:
+                continue  # block already fully cached, shouldn't happen
+            global_idx = num_decode_tokens + seq_start_in_prefill + pos_in_prefill
+            slot = int(state_indices_tensor_p[i, k].item())
+            shift_state_cache[slot, 0] = hidden_states[global_idx].to(
+                shift_state_cache.dtype
+            )
+
+
+def scatter_intermediate_recurrent_blocks(
+    varlen_states: torch.Tensor,
+    chunk_offsets_p: torch.Tensor,
+    state_indices_tensor_p: torch.Tensor,
+    block_idx_first_scheduled_p: torch.Tensor,
+    block_idx_last_scheduled_p: torch.Tensor,
+    num_computed_tokens_p: torch.Tensor,
+    block_size: int,
+    chunk_size: int,
+    recurrent_state_cache: torch.Tensor,
+) -> None:
+    """Scatter per-chunk-end recurrent states to intermediate cache blocks.
+
+    For prefill sequence ``i`` with ``first_scheduled=f``, ``last_scheduled=l``,
+    write the state at the END of each block ``k in [f, l)`` to
+    ``recurrent_state_cache[state_indices_p[i, k]]``. Block ``l`` is written
+    separately from ``final_state``.
+
+    With ``chunk_stride = block_size // chunk_size``, the state at the end of
+    block ``k`` corresponds to the chunk-state at index
+    ``chunk_offsets_p[i] + (k - first_scheduled) * chunk_stride - 1`` (with an
+    alignment offset when ``num_computed_tokens`` isn't block-aligned).
+    """
+    num_prefills = block_idx_first_scheduled_p.shape[0]
+    if num_prefills == 0:
+        return
+    chunk_stride = block_size // chunk_size
+    if chunk_stride < 1:
+        return  # block_size must be >= chunk_size
+    for i in range(num_prefills):
+        f = int(block_idx_first_scheduled_p[i].item())
+        last = int(block_idx_last_scheduled_p[i].item())
+        if last <= f:
+            continue
+        n_blocks_to_fill = last - f
+        # First chunk index of this prefill in the global varlen_states tensor.
+        first_chunk = int(chunk_offsets_p[i].item())
+        first_aligned_chunk = first_chunk + chunk_stride - 1
+        num_unaligned_computed = int(num_computed_tokens_p[i].item()) % block_size
+        if num_unaligned_computed > 0:
+            first_aligned_chunk -= num_unaligned_computed // chunk_size
+        idx_start = first_aligned_chunk
+        idx_step = chunk_stride
+        idx_end = idx_start + n_blocks_to_fill * idx_step
+        states_to_write = varlen_states[idx_start:idx_end:idx_step]
+        cache_slots = state_indices_tensor_p[i, f:last]
+        recurrent_state_cache[cache_slots] = states_to_write.to(
+            recurrent_state_cache.dtype
+        )
+
+
+def _gate_output_correction(
+    o: torch.Tensor,
+    r: torch.Tensor,
+    k: torch.Tensor,
+    r_k: torch.Tensor,
+    v: torch.Tensor,
+    g: torch.Tensor,
+) -> torch.Tensor:
+    """RWKV-7 post-attention residual + gate.
+
+    Equivalent to fla's Triton-fused `gate_output_correction`. Used because
+    the fused kernel adds significant vendoring weight for negligible
+    inference speedup at typical decode batch sizes.
+
+    Shapes: o [T, H*D], r/k/v [T, H, D], r_k [H, D], g [T, H*D].
+    """
+    correction = ((r * k * r_k.unsqueeze(0)).sum(-1, keepdim=True) * v).reshape(o.shape)
+    return (o + correction) * g
+
+
+class RWKV7Attention(nn.Module, MambaBase):
+    """RWKV-7 "Goose" time-mixer.
+
+    Attention-free recurrent block. Per-sequence per-layer state:
+      - shift_state: previous token's hidden state (for token_shift mix)
+      - recurrent_state: matrix-valued WKV state of shape (H, K, V), fp32
+
+    The model also threads a `v_first` value-residual through every layer:
+    layer 0 sets `v_first = v`; later layers do
+    `v ← lerp(v, v_first, sigmoid(v_lora(xv)))`. `v_first` is a Python
+    local in the model loop — never cached, never crosses the custom op
+    boundary.
+    """
+
+    @property
+    def mamba_type(self) -> MambaAttentionBackendEnum:
+        return MambaAttentionBackendEnum.RWKV7_ATTN
+
+    def get_state_dtype(self) -> tuple[torch.dtype, torch.dtype, torch.dtype]:  # type: ignore[override]
+        assert self.model_config is not None
+        assert self.cache_config is not None
+        return MambaStateDtypeCalculator.rwkv7_state_dtype(
+            self.model_config.dtype,
+            self.cache_config.mamba_cache_dtype,
+        )
+
+    def get_state_shape(  # type: ignore[override]
+        self,
+    ) -> tuple[tuple[int, int], tuple[int, int], tuple[int, int, int]]:
+        return MambaStateShapeCalculator.rwkv7_state_shape(
+            tp_world_size=self.tp_size,
+            hidden_size=self.hidden_size,
+            num_heads=self.num_heads,
+            head_dim=self.head_dim,
+            head_v_dim=self.head_v_dim,
+        )
+
+    def __init__(
+        self,
+        hidden_size: int,
+        head_dim: int,
+        num_heads: int,
+        decay_low_rank_dim: int,
+        gate_low_rank_dim: int,
+        a_low_rank_dim: int,
+        v_low_rank_dim: int,
+        norm_eps: float,
+        layer_idx: int,
+        value_dim: int | None = None,
+        model_config: ModelConfig | None = None,
+        cache_config: CacheConfig | None = None,
+        quant_config: QuantizationConfig | None = None,
+        prefix: str = "rwkv7_attn",
+    ) -> None:
+        super().__init__()
+
+        self.tp_size = get_tensor_model_parallel_world_size()
+        self.tp_rank = get_tensor_model_parallel_rank()
+        # TP > 1 needs head-dim sharding on r_k and the GroupNorm group count
+        # split. Punted to a follow-up — RWKV-7 weights are <6 GB at bf16,
+        # which fits a single Blackwell easily.
+        assert self.tp_size == 1, (
+            "RWKV-7 currently runs at tensor-parallel size 1 only."
+        )
+
+        self.hidden_size = hidden_size
+        self.key_dim = hidden_size
+        self.value_dim = value_dim if value_dim is not None else hidden_size
+        self.head_dim = head_dim
+        self.num_heads = num_heads
+        self.head_v_dim = self.value_dim // self.num_heads
+        self.decay_low_rank_dim = decay_low_rank_dim
+        self.gate_low_rank_dim = gate_low_rank_dim
+        self.a_low_rank_dim = a_low_rank_dim
+        self.v_low_rank_dim = v_low_rank_dim
+        self.norm_eps = norm_eps
+        self.layer_idx = layer_idx
+        self.prefix = prefix
+        self.model_config = model_config
+        self.cache_config = cache_config
+
+        # Time-shift mix scalars (broadcast across batch, time)
+        self.x_r = nn.Parameter(torch.zeros(1, 1, hidden_size))
+        self.x_w = nn.Parameter(torch.zeros(1, 1, hidden_size))
+        self.x_k = nn.Parameter(torch.zeros(1, 1, hidden_size))
+        self.x_v = nn.Parameter(torch.zeros(1, 1, hidden_size))
+        self.x_a = nn.Parameter(torch.zeros(1, 1, hidden_size))
+        self.x_g = nn.Parameter(torch.zeros(1, 1, hidden_size))
+
+        # Per-channel and per-(head, head_dim) scalar gates
+        self.k_k = nn.Parameter(torch.zeros(self.key_dim))
+        self.k_a = nn.Parameter(torch.zeros(self.key_dim))
+        self.r_k = nn.Parameter(torch.zeros(self.num_heads, self.head_dim))
+
+        # Full projections (no bias). At TP=1 these are just regular Linears.
+        self.r_proj = ColumnParallelLinear(
+            hidden_size,
+            self.key_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.r_proj",
+        )
+        self.k_proj = ColumnParallelLinear(
+            hidden_size,
+            self.key_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.k_proj",
+        )
+        self.v_proj = ColumnParallelLinear(
+            hidden_size,
+            self.value_dim,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.v_proj",
+        )
+        self.o_proj = RowParallelLinear(
+            self.value_dim,
+            hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj",
+        )
+
+        # LoRAs. Layer 0 has no v_lora (it sets v_first = v directly).
+        self.w_lora = LoRA(
+            hidden_size,
+            self.key_dim,
+            low_rank_dim=decay_low_rank_dim,
+            activation="tanh",
+        )
+        if self.layer_idx != 0:
+            self.v_lora = LoRA(
+                hidden_size,
+                self.value_dim,
+                low_rank_dim=v_low_rank_dim,
+                activation=None,
+            )
+        self.a_lora = LoRA(
+            hidden_size,
+            self.key_dim,
+            low_rank_dim=a_low_rank_dim,
+            activation=None,
+        )
+        # g_lora has sigmoid between the two legs and no bias on the up-proj
+        self.g_lora = LoRA(
+            hidden_size,
+            self.value_dim,
+            low_rank_dim=gate_low_rank_dim,
+            bias=False,
+            activation="sigmoid",
+        )
+
+        # GroupNorm over (num_heads, head_v_dim). RWKV-7 uses bias.
+        self.g_norm = nn.GroupNorm(
+            num_groups=self.num_heads,
+            num_channels=self.value_dim,
+            eps=self.head_dim * norm_eps,
+            affine=True,
+        )
+
+        compilation_config = get_current_vllm_config().compilation_config
+        if prefix in compilation_config.static_forward_context:
+            raise ValueError(f"Duplicate layer name: {prefix}")
+        compilation_config.static_forward_context[prefix] = self
+
+    # ------------------------------------------------------------------
+    # Forward
+    # ------------------------------------------------------------------
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        output: torch.Tensor,
+        v_first: torch.Tensor,
+    ) -> None:
+        """Apply the RWKV-7 mixer.
+
+        Both ``output`` and ``v_first`` are mutated in place. ``v_first`` is
+        written at layer 0 (with this layer's ``v`` projection) and read but
+        not written at later layers.
+
+        The whole body executes inside a single ``torch.ops.vllm.rwkv7_attention``
+        custom op so that ``@support_torch_compile`` on the model class
+        treats the mixer as opaque. This is required because the state I/O
+        in ``_full_forward`` reads ``self.kv_cache`` whose buffers are
+        allocated after model construction — tracing those reads under
+        Dynamo captures stale tensor pointers.
+        """
+        torch.ops.vllm.rwkv7_attention(
+            hidden_states,
+            output,
+            v_first,
+            self.prefix,
+        )
+
+    # ------------------------------------------------------------------
+    # Custom-op body
+    # ------------------------------------------------------------------
+    def _full_forward(
+        self,
+        hidden_states: torch.Tensor,
+        output: torch.Tensor,
+        v_first: torch.Tensor,
+    ) -> None:
+        """Run the entire mixer block including all state I/O.
+
+        Mutates ``output[:num_actual_tokens]`` and, at layer 0, mutates
+        ``v_first[:num_actual_tokens]`` with the freshly computed ``v``.
+        """
+        forward_context: ForwardContext = get_forward_context()
+        attn_metadata = forward_context.attn_metadata
+        if attn_metadata is None:
+            return  # profile/dummy run
+
+        if isinstance(attn_metadata, dict):
+            attn_metadata = attn_metadata[self.prefix]
+        assert isinstance(attn_metadata, Rwkv7AttentionMetadata)
+
+        m = attn_metadata
+        num_actual_tokens = m.num_actual_tokens
+        num_decodes = m.num_decodes
+        num_prefills = m.num_prefills
+        num_decode_tokens = m.num_decode_tokens
+        state_indices = m.state_indices_tensor
+        query_start_loc = m.query_start_loc
+        cu_seqlens = query_start_loc.to(torch.int32)
+        is_all = m.is_mamba_cache_all
+
+        # kv_cache layout (3-tuple, set up in get_state_shape):
+        #   [0] attn shift state  : [num_blocks, 1, D]
+        #   [1] ffn  shift state  : [num_blocks, 1, D]   — written by the FFN
+        #   [2] recurrent matrix  : [num_blocks, H, K, V]
+        attn_shift_cache = self.kv_cache[0]
+        ffn_shift_cache = self.kv_cache[1]
+        recurrent_state_cache = self.kv_cache[2]
+
+        # Resolved cache-slot ids per active sequence:
+        #   - read_slot[i]  = slot to load initial state from (last computed)
+        #   - write_slot[i] = slot to store the per-sequence final state to
+        # These come from metadata so decode CUDA graph capture sees stable
+        # tensor addresses even when prefix-cache hits change the slots.
+        if m.read_slot is None or m.write_slot is None:
+            read_slot, write_slot = resolve_state_slots(
+                state_indices,
+                m.block_idx_last_computed_token,
+                m.block_idx_last_scheduled_token,
+            )
+        else:
+            read_slot, write_slot = m.read_slot, m.write_slot
+        # Zero the read slot for freshly-started prefill sequences.
+        if num_prefills > 0 and m.has_initial_state is not None:
+            fresh_mask = ~m.has_initial_state
+            if fresh_mask.any():
+                fresh_read = read_slot[num_decodes:][fresh_mask]
+                attn_shift_cache[fresh_read] = 0
+                ffn_shift_cache[fresh_read] = 0
+                recurrent_state_cache[fresh_read] = 0
+
+        x = hidden_states[:num_actual_tokens]
+
+        delta = compute_token_shift_delta(
+            hidden_states=x,
+            query_start_loc=query_start_loc,
+            state_indices=read_slot,
+            shift_state_cache=attn_shift_cache,
+            has_initial_state=m.has_initial_state,
+            num_decodes=num_decodes,
+            num_prefills=num_prefills,
+        )
+
+        x_r = self.x_r.view(-1)
+        x_w = self.x_w.view(-1)
+        x_k = self.x_k.view(-1)
+        x_v = self.x_v.view(-1)
+        x_a = self.x_a.view(-1)
+        x_g = self.x_g.view(-1)
+        xr = torch.addcmul(x, delta, x_r)
+        xw = torch.addcmul(x, delta, x_w)
+        xk = torch.addcmul(x, delta, x_k)
+        xv = torch.addcmul(x, delta, x_v)
+        xa = torch.addcmul(x, delta, x_a)
+        xg = torch.addcmul(x, delta, x_g)
+
+        r, _ = self.r_proj(xr)
+        k, _ = self.k_proj(xk)
+        v, _ = self.v_proj(xv)
+        w = -0.6065306597126334 * self.w_lora(xw).sigmoid()
+
+        if self.layer_idx == 0:
+            v_first[:num_actual_tokens] = v
+        else:
+            v = torch.lerp(v, v_first[:num_actual_tokens], self.v_lora(xv).sigmoid())
+
+        a = self.a_lora(xa).sigmoid()
+        g = self.g_lora(xg)
+
+        kk = (k * self.k_k).view(num_actual_tokens, self.num_heads, self.head_dim)
+        kk = F.normalize(kk, dim=-1, p=2.0).reshape(num_actual_tokens, -1)
+        k = k.addcmul(k * (a - 1), self.k_a)
+
+        # [1, T_total, H, D] reshape for the packed-batch kernel
+        r_4d = r.view(1, num_actual_tokens, self.num_heads, self.head_dim).contiguous()
+        w_4d = w.view(1, num_actual_tokens, self.num_heads, self.head_dim).contiguous()
+        k_4d = k.view(1, num_actual_tokens, self.num_heads, self.head_dim).contiguous()
+        v_4d = v.view(
+            1, num_actual_tokens, self.num_heads, self.head_v_dim
+        ).contiguous()
+        kk_4d = kk.view(
+            1, num_actual_tokens, self.num_heads, self.head_dim
+        ).contiguous()
+        a_4d = a.view(1, num_actual_tokens, self.num_heads, self.head_dim).contiguous()
+
+        initial_state = recurrent_state_cache[read_slot]
+        if initial_state.dtype != torch.float32:
+            initial_state = initial_state.to(torch.float32)
+
+        # Dispatch:
+        #  - pure-decode batch (every active sequence is 1 token): use the
+        #    recurrent kernel; cheaper than chunk for T=1 and the only path
+        #    captured by cudagraphs (UNIFORM_SINGLE_TOKEN_DECODE).
+        #  - any prefill present: use the chunked kernel which processes
+        #    chunk_size tokens in parallel per program. Decodes within a
+        #    mixed batch ride along as length-1 chunks — cheap.
+        if num_prefills == 0:
+            core_out, final_state = fused_mul_recurrent_rwkv7(
+                r=r_4d,
+                w=w_4d,
+                k=k_4d,
+                v=v_4d,
+                kk=kk_4d,
+                a=a_4d,
+                scale=1.0,
+                initial_state=initial_state,
+                output_final_state=True,
+                cu_seqlens=cu_seqlens,
+            )
+            varlen_states = None
+        else:
+            # chunk_rwkv7 takes (a=-kk, b=kk*a_gate) — fla's parameterization
+            a_chunk = -kk_4d
+            b_chunk = kk_4d * a_4d
+            core_out, final_state, varlen_states = chunk_rwkv7(
+                r=r_4d,
+                w=w_4d,
+                k=k_4d,
+                v=v_4d,
+                a=a_chunk,
+                b=b_chunk,
+                scale=1.0,
+                initial_state=initial_state,
+                output_final_state=True,
+                cu_seqlens=cu_seqlens,
+                # Our log-decay is `-0.6065 * sigmoid(...)`, which sits in
+                # (-0.607, 0] — well inside the safe-gate range.
+                safe_gate=True,
+                chunk_size=64,
+                return_varlen_states=is_all,
+            )
+        # Write per-sequence final state to the last_scheduled cache slot.
+        recurrent_state_cache[write_slot] = final_state.to(recurrent_state_cache.dtype)
+
+        # Under prefix-caching ('all') mode, also fill the intermediate blocks
+        # with the per-chunk-end recurrent states produced by chunk_rwkv7.
+        if is_all and num_prefills > 0 and varlen_states is not None:
+            # Indices of the prefill rows in the [N, max_blocks] state table.
+            state_indices_p = state_indices[num_decodes:]
+            # Per-prefill chunk offsets in the global varlen_states tensor.
+            # cu_seqlens for the prefill subset:
+            cu_seqlens_p = cu_seqlens[num_decodes:] - cu_seqlens[num_decodes]
+            cu_seqlens_p = cu_seqlens_p.to(torch.long)
+            chunk_size = 64
+            # Number of chunks per sequence = cdiv(seq_len, chunk_size).
+            # varlen_states is laid out over the whole packed batch, including
+            # decode chunks before the prefill region.
+            seq_lens_all = cu_seqlens[1:].to(torch.long) - cu_seqlens[:-1].to(
+                torch.long
+            )
+            decode_chunk_offset = (
+                (seq_lens_all[:num_decodes] + chunk_size - 1) // chunk_size
+            ).sum()
+            seq_lens_p = cu_seqlens_p[1:] - cu_seqlens_p[:-1]
+            chunks_per_seq = (seq_lens_p + chunk_size - 1) // chunk_size
+            # Prefix sum to get the global start index of each prefill's chunks.
+            chunk_offsets_p = torch.zeros(
+                num_prefills + 1, dtype=torch.long, device=cu_seqlens.device
+            )
+            chunk_offsets_p[0] = decode_chunk_offset
+            chunk_offsets_p[1:] = decode_chunk_offset + chunks_per_seq.cumsum(0)
+
+            scatter_intermediate_recurrent_blocks(
+                varlen_states=varlen_states,
+                chunk_offsets_p=chunk_offsets_p,
+                state_indices_tensor_p=state_indices_p,
+                block_idx_first_scheduled_p=m.block_idx_first_scheduled_token[
+                    num_decodes:
+                ],
+                block_idx_last_scheduled_p=m.block_idx_last_scheduled_token[
+                    num_decodes:
+                ],
+                num_computed_tokens_p=m.num_computed_tokens_p,
+                block_size=m.mamba_block_size,
+                chunk_size=chunk_size,
+                recurrent_state_cache=recurrent_state_cache,
+            )
+
+        o = self.g_norm(core_out.view(num_actual_tokens, self.value_dim))
+        o = _gate_output_correction(
+            o,
+            r_4d.view(num_actual_tokens, self.num_heads, self.head_dim),
+            k_4d.view(num_actual_tokens, self.num_heads, self.head_dim),
+            self.r_k,
+            v_4d.view(num_actual_tokens, self.num_heads, self.head_v_dim),
+            g,
+        )
+        proj, _ = self.o_proj(o)
+        output[:num_actual_tokens] = proj
+
+        update_shift_state(
+            hidden_states=x,
+            query_start_loc=query_start_loc,
+            state_indices=write_slot,
+            shift_state_cache=attn_shift_cache,
+        )
+        if is_all and num_prefills > 0:
+            cu_seqlens_p_long = (cu_seqlens[num_decodes:] - cu_seqlens[num_decodes]).to(
+                torch.long
+            )
+            scatter_intermediate_shift_blocks(
+                hidden_states=x,
+                query_start_loc_p=cu_seqlens_p_long,
+                state_indices_tensor_p=state_indices[num_decodes:],
+                block_idx_first_scheduled_p=m.block_idx_first_scheduled_token[
+                    num_decodes:
+                ],
+                block_idx_last_scheduled_p=m.block_idx_last_scheduled_token[
+                    num_decodes:
+                ],
+                num_computed_tokens_p=m.num_computed_tokens_p,
+                block_size=m.mamba_block_size,
+                shift_state_cache=attn_shift_cache,
+                num_decode_tokens=num_decode_tokens,
+            )
+
+
+def rwkv7_attention(
+    hidden_states: torch.Tensor,
+    output: torch.Tensor,
+    v_first: torch.Tensor,
+    layer_name: str,
+) -> None:
+    forward_context: ForwardContext = get_forward_context()
+    self: RWKV7Attention = forward_context.no_compile_layers[layer_name]
+    self._full_forward(hidden_states=hidden_states, output=output, v_first=v_first)
+
+
+def rwkv7_attention_fake(
+    hidden_states: torch.Tensor,
+    output: torch.Tensor,
+    v_first: torch.Tensor,
+    layer_name: str,
+) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="rwkv7_attention",
+    op_func=rwkv7_attention,
+    mutates_args=["output", "v_first"],
+    fake_impl=rwkv7_attention_fake,
+)
+
+
+def rwkv7_channel_mix(
+    hidden_states: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    """Custom op wrapping the RWKV-7 channel-mix (FFN) block.
+
+    Same compile-opacity rationale as the time-mix op: state I/O on
+    ``self.kv_cache[1]`` (the FFN shift cache, owned by the parent mixer)
+    must not be traced by Dynamo.
+    """
+    forward_context: ForwardContext = get_forward_context()
+    self = forward_context.no_compile_layers[layer_name]
+    self._full_forward(hidden_states=hidden_states, output=output)
+
+
+def rwkv7_channel_mix_fake(
+    hidden_states: torch.Tensor,
+    output: torch.Tensor,
+    layer_name: str,
+) -> None:
+    return
+
+
+direct_register_custom_op(
+    op_name="rwkv7_channel_mix",
+    op_func=rwkv7_channel_mix,
+    mutates_args=["output"],
+    fake_impl=rwkv7_channel_mix_fake,
+)
+
+
+def _round_to_32(value: float) -> int:
+    return int(round(value / 32) * 32)
+
+
+def default_decay_lora(hidden_size: int, head_dim: int) -> int:
+    factor = head_dim / 64
+    return max(32, _round_to_32(2.5 * (hidden_size**0.5) * factor))
+
+
+def default_a_lora(hidden_size: int, head_dim: int) -> int:
+    factor = head_dim / 64
+    return max(32, _round_to_32(2.5 * (hidden_size**0.5) * factor))
+
+
+def default_v_lora(hidden_size: int, head_dim: int) -> int:
+    factor = head_dim / 64
+    return max(32, _round_to_32(1.7 * (hidden_size**0.5) * factor))
+
+
+def default_gate_lora(hidden_size: int) -> int:
+    return max(32, _round_to_32(5.0 * (hidden_size**0.5)))

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -680,6 +680,7 @@ MODELS_CONFIG_MAP: dict[str, type[VerifyAndUpdateConfig]] = {
     "LlamaNemotronVLModel": LlamaNemotronVLConfig,
     "Mamba2ForCausalLM": MambaModelConfig,
     "MambaForCausalLM": MambaModelConfig,
+    "RWKV7ForCausalLM": MambaModelConfig,
     "NemotronHForCausalLM": NemotronHForCausalLMConfig,
     "NemotronHPuzzleForCausalLM": NemotronHForCausalLMConfig,
     "NemotronH_Nano_VL_V2": NemotronHNanoVLV2Config,

--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -406,6 +406,35 @@ class MambaModelConfig(VerifyAndUpdateConfig):
                 cache_config.mamba_block_size = model_config.max_model_len
 
 
+class RWKV7ForCausalLMConfig(MambaModelConfig):
+    """RWKV-7 inherits the Mamba defaults but also constrains
+    ``mamba_block_size`` to one of the chunk sizes the DPLR chunk kernel is
+    tuned for (16, 64). The mixer uses the block size as ``chunk_size``
+    so each cache block lines up with exactly one chunk-end recurrent
+    state; mismatched values silently corrupt prefix-cache hits on long
+    prompts.
+    """
+
+    SUPPORTED_BLOCK_SIZES = (16, 64)
+
+    @classmethod
+    def verify_and_update_config(cls, vllm_config: "VllmConfig") -> None:
+        super().verify_and_update_config(vllm_config)
+        cache_config = vllm_config.cache_config
+        if not cache_config.enable_prefix_caching:
+            return
+        if cache_config.mamba_block_size not in cls.SUPPORTED_BLOCK_SIZES:
+            original = cache_config.mamba_block_size
+            cache_config.mamba_block_size = 64
+            logger.warning(
+                "RWKV-7 with prefix caching requires mamba_block_size in "
+                "%s (kernel-tuned chunk sizes); got %s. Falling back to "
+                "mamba_block_size=64.",
+                cls.SUPPORTED_BLOCK_SIZES,
+                original,
+            )
+
+
 class NemotronHForCausalLMConfig(VerifyAndUpdateConfig):
     DEFAULT_MAMBA_SSM_CACHE_DTYPE = "float32"
     """Only `float32` is known to have no accuracy issues by default."""
@@ -680,7 +709,7 @@ MODELS_CONFIG_MAP: dict[str, type[VerifyAndUpdateConfig]] = {
     "LlamaNemotronVLModel": LlamaNemotronVLConfig,
     "Mamba2ForCausalLM": MambaModelConfig,
     "MambaForCausalLM": MambaModelConfig,
-    "RWKV7ForCausalLM": MambaModelConfig,
+    "RWKV7ForCausalLM": RWKV7ForCausalLMConfig,
     "NemotronHForCausalLM": NemotronHForCausalLMConfig,
     "NemotronHPuzzleForCausalLM": NemotronHForCausalLMConfig,
     "NemotronH_Nano_VL_V2": NemotronHNanoVLV2Config,

--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -202,6 +202,7 @@ _TEXT_GENERATION_MODELS = {
     "Qwen3ForCausalLM": ("qwen3", "Qwen3ForCausalLM"),
     "Qwen3MoeForCausalLM": ("qwen3_moe", "Qwen3MoeForCausalLM"),
     "RWForCausalLM": ("falcon", "FalconForCausalLM"),
+    "RWKV7ForCausalLM": ("rwkv7", "RWKV7ForCausalLM"),
     "SarvamMoEForCausalLM": ("sarvam", "SarvamMoEForCausalLM"),
     "SarvamMLAForCausalLM": ("sarvam", "SarvamMLAForCausalLM"),
     "SeedOssForCausalLM": ("seed_oss", "SeedOssForCausalLM"),

--- a/vllm/model_executor/models/rwkv7.py
+++ b/vllm/model_executor/models/rwkv7.py
@@ -1,0 +1,530 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""PyTorch RWKV-7 "Goose" model.
+
+Attention-free recurrent LM. Per layer, per sequence the only state is a
+matrix-valued WKV state of shape ``(num_heads, head_dim, head_v_dim)`` plus a
+1-token shift buffer. There is no KV cache, so memory is constant in
+context length.
+
+Reference: https://arxiv.org/abs/2503.14456 (RWKV-7 "Goose").
+Public weights: ``fla-hub/rwkv7-{0.1B,0.4B,1.5B,2.9B}-{g1,world}``.
+
+Inference uses a vendored copy of fla's ``fused_mul_recurrent_rwkv7`` kernel
+(see ``vllm/model_executor/layers/fla/ops/rwkv7/``). The chunked prefill
+kernel is a planned follow-up; the recurrent kernel handles all sequence
+lengths but is slower for long prefills.
+"""
+
+from collections.abc import Iterable
+
+import torch
+from torch import nn
+
+from vllm.compilation.decorators import support_torch_compile
+from vllm.config import VllmConfig, get_current_vllm_config
+from vllm.distributed.parallel_state import get_pp_group
+from vllm.forward_context import ForwardContext, get_forward_context
+from vllm.model_executor.layers.logits_processor import LogitsProcessor
+from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaStateCopyFunc,
+    MambaStateCopyFuncCalculator,
+    MambaStateDtypeCalculator,
+    MambaStateShapeCalculator,
+)
+from vllm.model_executor.layers.mamba.rwkv7_mixer import (
+    RWKV7Attention,
+    compute_token_shift_delta,
+    default_a_lora,
+    default_decay_lora,
+    default_gate_lora,
+    default_v_lora,
+    resolve_state_slots,
+    scatter_intermediate_shift_blocks,
+    update_shift_state,
+)
+from vllm.model_executor.layers.vocab_parallel_embedding import (
+    ParallelLMHead,
+    VocabParallelEmbedding,
+)
+from vllm.model_executor.model_loader.weight_utils import default_weight_loader
+from vllm.model_executor.models.interfaces import (
+    HasInnerState,
+    IsAttentionFree,
+    SupportsMambaPrefixCaching,
+)
+from vllm.sequence import IntermediateTensors
+from vllm.v1.attention.backends.rwkv7_attn import Rwkv7AttentionMetadata
+
+from .utils import (
+    AutoWeightsLoader,
+    is_pp_missing_parameter,
+    make_empty_intermediate_tensors_factory,
+    make_layers,
+    maybe_prefix,
+)
+
+
+def _resolve_lora_dim(
+    config_value: int | None,
+    default_fn,
+    *args,
+) -> int:
+    return default_fn(*args) if config_value is None else int(config_value)
+
+
+def _resolve_value_dim(
+    config_value_dim,
+    layer_idx: int,
+    hidden_size: int,
+) -> int:
+    """Pick the per-layer value_dim, falling back to hidden_size."""
+    if config_value_dim is None:
+        return hidden_size
+    if isinstance(config_value_dim, (list, tuple)):
+        return int(config_value_dim[layer_idx])
+    return int(config_value_dim)
+
+
+def _resolve_num_heads(
+    config_num_heads: int | None,
+    hidden_size: int,
+    head_dim: int,
+) -> int:
+    # Mirror fla's RWKV7Attention precedence: when head_dim is set, num_heads
+    # is always derived from `hidden_size // head_dim`, even if the config
+    # also lists a num_heads field. The configured value is informational —
+    # several public checkpoints (e.g. fla-hub/rwkv7-0.1B-g1) ship a
+    # num_heads value that disagrees with hidden_size/head_dim, and fla
+    # silently uses the head_dim-derived value.
+    if head_dim is not None:
+        assert hidden_size % head_dim == 0, (
+            f"hidden_size ({hidden_size}) must be divisible by head_dim ({head_dim})"
+        )
+        return hidden_size // head_dim
+    if config_num_heads is None:
+        raise ValueError("Either head_dim or num_heads must be set")
+    return int(config_num_heads)
+
+
+class RWKV7FeedForward(nn.Module):
+    """Channel-mix FFN with cu_seqlens-aware token-shift, ReLU² activation.
+
+    Per RWKV-7, the FFN has its own token-shift (separate from the time-mix
+    attn block). The shift state cache lives on the parent ``RWKV7Attention``
+    mixer at ``mixer.kv_cache[1]`` (slot 0 is the attn shift; slot 1 is the
+    FFN shift; slot 2 is the recurrent matrix state).
+
+    Like the time-mix block, the entire FFN body (state I/O + projections)
+    runs inside a single ``torch.ops.vllm.rwkv7_channel_mix`` custom op so
+    the model's ``@support_torch_compile`` decorator treats the FFN as
+    opaque and does not trace stale ``mixer.kv_cache`` pointers.
+    """
+
+    def __init__(
+        self,
+        hidden_size: int,
+        intermediate_size: int,
+        attn_module: "RWKV7Attention",
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.hidden_size = hidden_size
+        self.intermediate_size = intermediate_size
+        self.attn_module = attn_module
+        self.prefix = prefix
+
+        self.x_k = nn.Parameter(torch.zeros(hidden_size))
+        self.key = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.value = nn.Linear(intermediate_size, hidden_size, bias=False)
+
+        compilation_config = get_current_vllm_config().compilation_config
+        if prefix in compilation_config.static_forward_context:
+            raise ValueError(f"Duplicate layer name: {prefix}")
+        compilation_config.static_forward_context[prefix] = self
+
+    def forward(self, hidden_states: torch.Tensor, output: torch.Tensor) -> None:
+        torch.ops.vllm.rwkv7_channel_mix(hidden_states, output, self.prefix)
+
+    def _full_forward(self, hidden_states: torch.Tensor, output: torch.Tensor) -> None:
+        forward_context: ForwardContext = get_forward_context()
+        attn_metadata = forward_context.attn_metadata
+        if attn_metadata is None:
+            return  # profile run
+
+        if isinstance(attn_metadata, dict):
+            attn_metadata = attn_metadata[self.attn_module.prefix]
+        assert isinstance(attn_metadata, Rwkv7AttentionMetadata)
+
+        m = attn_metadata
+        num_actual_tokens = m.num_actual_tokens
+        num_decodes = m.num_decodes
+        num_prefills = m.num_prefills
+        num_decode_tokens = m.num_decode_tokens
+        is_all = m.is_mamba_cache_all
+        x = hidden_states[:num_actual_tokens]
+
+        ffn_shift_cache = self.attn_module.kv_cache[1]
+
+        if m.read_slot is None or m.write_slot is None:
+            read_slot, write_slot = resolve_state_slots(
+                m.state_indices_tensor,
+                m.block_idx_last_computed_token,
+                m.block_idx_last_scheduled_token,
+            )
+        else:
+            read_slot, write_slot = m.read_slot, m.write_slot
+        delta = compute_token_shift_delta(
+            hidden_states=x,
+            query_start_loc=m.query_start_loc,
+            state_indices=read_slot,
+            shift_state_cache=ffn_shift_cache,
+            has_initial_state=m.has_initial_state,
+            num_decodes=num_decodes,
+            num_prefills=num_prefills,
+        )
+
+        mixed = x.addcmul(delta, self.x_k)
+        output[:num_actual_tokens] = self.value(torch.relu(self.key(mixed)).pow(2))
+
+        update_shift_state(
+            hidden_states=x,
+            query_start_loc=m.query_start_loc,
+            state_indices=write_slot,
+            shift_state_cache=ffn_shift_cache,
+        )
+        if is_all and num_prefills > 0:
+            cu_seqlens = m.query_start_loc.to(torch.int32)
+            cu_seqlens_p_long = (cu_seqlens[num_decodes:] - cu_seqlens[num_decodes]).to(
+                torch.long
+            )
+            scatter_intermediate_shift_blocks(
+                hidden_states=x,
+                query_start_loc_p=cu_seqlens_p_long,
+                state_indices_tensor_p=m.state_indices_tensor[num_decodes:],
+                block_idx_first_scheduled_p=m.block_idx_first_scheduled_token[
+                    num_decodes:
+                ],
+                block_idx_last_scheduled_p=m.block_idx_last_scheduled_token[
+                    num_decodes:
+                ],
+                num_computed_tokens_p=m.num_computed_tokens_p,
+                block_size=m.mamba_block_size,
+                shift_state_cache=ffn_shift_cache,
+                num_decode_tokens=num_decode_tokens,
+            )
+
+
+class RWKV7DecoderLayer(nn.Module):
+    """One transformer-style block: attn_norm → mixer → ffn_norm → ffn."""
+
+    def __init__(
+        self,
+        config,
+        vllm_config: VllmConfig,
+        layer_idx: int,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        self.config = config
+        self.layer_idx = layer_idx
+
+        norm_eps = getattr(config, "norm_eps", 1e-5)
+        norm_bias = getattr(config, "norm_bias", True)
+        norm_first = getattr(config, "norm_first", True)
+        hidden_size = config.hidden_size
+        head_dim = getattr(config, "head_dim", 64)
+        num_heads = _resolve_num_heads(
+            getattr(config, "num_heads", None), hidden_size, head_dim
+        )
+        value_dim = _resolve_value_dim(
+            getattr(config, "value_dim", None), layer_idx, hidden_size
+        )
+        decay_lora = _resolve_lora_dim(
+            getattr(config, "decay_low_rank_dim", None),
+            default_decay_lora,
+            hidden_size,
+            head_dim,
+        )
+        a_lora = _resolve_lora_dim(
+            getattr(config, "a_low_rank_dim", None),
+            default_a_lora,
+            hidden_size,
+            head_dim,
+        )
+        v_lora = _resolve_lora_dim(
+            getattr(config, "v_low_rank_dim", None),
+            default_v_lora,
+            hidden_size,
+            head_dim,
+        )
+        gate_lora = _resolve_lora_dim(
+            getattr(config, "gate_low_rank_dim", None),
+            default_gate_lora,
+            hidden_size,
+        )
+
+        # The leading-layer pre_norm only exists when norm_first=True (RWKV-7
+        # default). It normalizes the embeddings before they enter layer 0.
+        if norm_first and layer_idx == 0:
+            self.pre_norm = nn.LayerNorm(hidden_size, eps=norm_eps, bias=norm_bias)
+
+        self.attn_norm = nn.LayerNorm(hidden_size, eps=norm_eps, bias=norm_bias)
+        self.attn = RWKV7Attention(
+            hidden_size=hidden_size,
+            head_dim=head_dim,
+            num_heads=num_heads,
+            decay_low_rank_dim=decay_lora,
+            gate_low_rank_dim=gate_lora,
+            a_low_rank_dim=a_lora,
+            v_low_rank_dim=v_lora,
+            norm_eps=norm_eps,
+            layer_idx=layer_idx,
+            value_dim=value_dim,
+            model_config=vllm_config.model_config,
+            cache_config=vllm_config.cache_config,
+            quant_config=vllm_config.quant_config,
+            prefix=f"{prefix}.attn",
+        )
+        self.ffn_norm = nn.LayerNorm(hidden_size, eps=norm_eps, bias=norm_bias)
+        intermediate_size = getattr(
+            config,
+            "intermediate_size",
+            32 * (((hidden_size * 4) + 31) // 32),
+        )
+        self.ffn = RWKV7FeedForward(
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            attn_module=self.attn,
+            prefix=f"{prefix}.ffn",
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        v_first: torch.Tensor,
+    ) -> torch.Tensor:
+        """Run one decoder block. ``v_first`` is mutated in place at layer 0."""
+        # Layer 0 only: extra LayerNorm of the embeddings before the block.
+        if hasattr(self, "pre_norm"):
+            hidden_states = self.pre_norm(hidden_states)
+
+        residual = hidden_states
+        x = self.attn_norm(hidden_states)
+        attn_out = torch.zeros_like(x)
+        # Custom op: mutates attn_out, mutates v_first at layer 0.
+        self.attn(x, attn_out, v_first)
+        hidden_states = residual + attn_out
+
+        residual = hidden_states
+        x = self.ffn_norm(hidden_states)
+        ffn_out = torch.zeros_like(x)
+        self.ffn(x, ffn_out)
+        hidden_states = residual + ffn_out
+
+        return hidden_states
+
+
+@support_torch_compile
+class RWKV7Model(nn.Module):
+    """RWKV-7 backbone. Embeddings → N x DecoderLayer (with v_first thread) → norm."""
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        self.config = config
+
+        self.vocab_size = config.vocab_size
+        self.embeddings = VocabParallelEmbedding(
+            self.vocab_size,
+            config.hidden_size,
+        )
+
+        self.start_layer, self.end_layer, self.layers = make_layers(
+            config.num_hidden_layers,
+            lambda prefix: RWKV7DecoderLayer(
+                config=config,
+                vllm_config=vllm_config,
+                layer_idx=int(prefix.rsplit(".", 1)[-1]),
+                prefix=prefix,
+            ),
+            prefix=f"{prefix}.layers",
+        )
+
+        norm_eps = getattr(config, "norm_eps", 1e-5)
+        norm_bias = getattr(config, "norm_bias", True)
+        self.norm = nn.LayerNorm(config.hidden_size, eps=norm_eps, bias=norm_bias)
+
+        self.make_empty_intermediate_tensors = make_empty_intermediate_tensors_factory(
+            ["hidden_states", "v_first"], config.hidden_size
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.embeddings(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor | IntermediateTensors:
+        if get_pp_group().is_first_rank:
+            if inputs_embeds is not None:
+                hidden_states = inputs_embeds
+            else:
+                hidden_states = self.embed_input_ids(input_ids)
+            v_first = torch.zeros_like(hidden_states)
+        else:
+            assert intermediate_tensors is not None
+            hidden_states = intermediate_tensors["hidden_states"]
+            v_first = intermediate_tensors["v_first"]
+
+        for layer in self.layers:
+            hidden_states = layer(hidden_states, v_first)
+
+        if not get_pp_group().is_last_rank:
+            return IntermediateTensors(
+                {"hidden_states": hidden_states, "v_first": v_first}
+            )
+
+        return self.norm(hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        for name, loaded_weight in weights:
+            # Skip extra biases that GPTQ/AWQ checkpoints sometimes ship.
+            if name.endswith(".bias") and name not in params_dict:
+                continue
+            if is_pp_missing_parameter(name, self):
+                continue
+            if name not in params_dict:
+                # Layer 0 has no v_lora; checkpoints that do ship one
+                # (rare) should be ignored rather than rejected.
+                if ".v_lora." in name and ".layers.0." in name:
+                    continue
+                continue
+
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
+
+
+class RWKV7ForCausalLM(
+    nn.Module, HasInnerState, IsAttentionFree, SupportsMambaPrefixCaching
+):
+    """RWKV-7 LM head wrapper.
+
+    No KV cache. Cache machinery from ``HasInnerState`` plumbs in the per-
+    sequence (shift_state, recurrent_state) tuple. ``IsAttentionFree``
+    tells the engine not to allocate paged attention storage.
+
+    Speculative decoding, prefix caching, and pipeline parallelism are
+    not yet supported and are hard-asserted off.
+    """
+
+    @classmethod
+    def get_mamba_state_dtype_from_config(
+        cls,
+        vllm_config: "VllmConfig",
+    ) -> tuple[torch.dtype, torch.dtype, torch.dtype]:
+        return MambaStateDtypeCalculator.rwkv7_state_dtype(
+            vllm_config.model_config.dtype,
+            vllm_config.cache_config.mamba_cache_dtype,
+        )
+
+    @classmethod
+    def get_mamba_state_shape_from_config(
+        cls,
+        vllm_config: "VllmConfig",
+    ) -> tuple[tuple[int, int], tuple[int, int], tuple[int, int, int]]:
+        parallel_config = vllm_config.parallel_config
+        cfg = vllm_config.model_config.hf_config
+        head_dim = getattr(cfg, "head_dim", 64)
+        num_heads = _resolve_num_heads(
+            getattr(cfg, "num_heads", None), cfg.hidden_size, head_dim
+        )
+        # head_v_dim follows hidden_size for the dense Goose family. If a
+        # checkpoint ships a per-layer value_dim list with mixed values,
+        # the cache spec uses the first layer's value as a representative
+        # — uniform value_dim is enforced at runtime in the mixer.
+        value_dim = _resolve_value_dim(
+            getattr(cfg, "value_dim", None), 0, cfg.hidden_size
+        )
+        head_v_dim = value_dim // num_heads
+
+        return MambaStateShapeCalculator.rwkv7_state_shape(
+            tp_world_size=parallel_config.tensor_parallel_size,
+            hidden_size=cfg.hidden_size,
+            num_heads=num_heads,
+            head_dim=head_dim,
+            head_v_dim=head_v_dim,
+        )
+
+    @classmethod
+    def get_mamba_state_copy_func(cls) -> tuple[MambaStateCopyFunc, MambaStateCopyFunc]:
+        return MambaStateCopyFuncCalculator.rwkv7_state_copy_func()
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        config = vllm_config.model_config.hf_config
+
+        super().__init__()
+        # v1 limitations — surface them clearly at construction time so we
+        # don't fail mid-forward with confusing kernel asserts.
+        assert vllm_config.parallel_config.pipeline_parallel_size == 1, (
+            "RWKV-7 does not yet support pipeline parallelism"
+        )
+        # Speculative decoding is wired up at the kernel and mixer level
+        # but cross-round state alignment is not yet correct in production
+        # (subtle token-duplication on repetitive prompts, kv-cache allocator
+        # asserts on multi-request workloads). Keep this gate in place until
+        # those are resolved.
+        assert vllm_config.speculative_config is None, (
+            "RWKV-7 does not yet support speculative decoding"
+        )
+
+        self.config = config
+        self.vllm_config = vllm_config
+        self.model_config = vllm_config.model_config
+        self.scheduler_config = vllm_config.scheduler_config
+
+        self.model = RWKV7Model(
+            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
+        )
+
+        self.lm_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            prefix=maybe_prefix(prefix, "lm_head"),
+        )
+        if getattr(config, "tie_word_embeddings", False):
+            self.lm_head = self.lm_head.tie_weights(self.model.embeddings)
+
+        self.logits_processor = LogitsProcessor(config.vocab_size)
+
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+        **kwargs,
+    ):
+        return self.model(input_ids, positions, intermediate_tensors, inputs_embeds)
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return self.logits_processor(self.lm_head, hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights)

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -107,6 +107,7 @@ _CONFIG_REGISTRY: dict[str, type[PretrainedConfig]] = LazyConfigDict(
     isaac="IsaacConfig",
     kimi_k2="DeepseekV3Config",  # Kimi K2 uses same architecture as DeepSeek V3
     kimi_linear="KimiLinearConfig",
+    rwkv7="RWKV7Config",
     kimi_vl="KimiVLConfig",
     kimi_k25="KimiK25Config",
     RefinedWeb="RWConfig",  # For tiiuae/falcon-40b(-instruct)

--- a/vllm/transformers_utils/configs/__init__.py
+++ b/vllm/transformers_utils/configs/__init__.py
@@ -78,6 +78,7 @@ _CLASS_TO_MODULE: dict[str, str] = {
     "Qwen3_5TextConfig": "vllm.transformers_utils.configs.qwen3_5",
     "Qwen3_5MoeConfig": "vllm.transformers_utils.configs.qwen3_5_moe",
     "Qwen3_5MoeTextConfig": "vllm.transformers_utils.configs.qwen3_5_moe",
+    "RWKV7Config": "vllm.transformers_utils.configs.rwkv7",
     "Tarsier2Config": "vllm.transformers_utils.configs.tarsier2",
     # Special case: DeepseekV3Config is from HuggingFace Transformers
     "DeepseekV3Config": "transformers",
@@ -145,6 +146,7 @@ __all__ = [
     "Qwen3_5TextConfig",
     "Qwen3_5MoeConfig",
     "Qwen3_5MoeTextConfig",
+    "RWKV7Config",
     "Tarsier2Config",
 ]
 

--- a/vllm/transformers_utils/configs/rwkv7.py
+++ b/vllm/transformers_utils/configs/rwkv7.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-FileCopyrightText: Songlin Yang, Yu Zhang, Zhiyuan Li
+#
+# Adapted from
+# https://github.com/fla-org/flash-linear-attention/blob/main/fla/models/rwkv7/configuration_rwkv7.py
+# Original code licensed under the MIT license.
+
+from transformers.configuration_utils import PretrainedConfig
+
+
+class RWKV7Config(PretrainedConfig):
+    """RWKV-7 "Goose" config.
+
+    Vendored from `flash-linear-attention` so that vLLM can parse
+    `fla-hub/rwkv7-*` checkpoints without `trust_remote_code` being needed
+    just to read the config (their `auto_map` points at fla's modeling file
+    which imports the full fla package).
+    """
+
+    model_type = "rwkv7"
+    keys_to_ignore_at_inference = ["past_key_values"]
+
+    # vLLM uses ``model_config.get_mamba_chunk_size()`` to pick a
+    # ``mamba_block_size`` aligned to the recurrent kernel's chunk granularity.
+    # The chunk dispatch in ``RWKV7Attention`` uses ``chunk_size=64``, so the
+    # cache block size must be a multiple of 64 for prefix caching to scatter
+    # per-chunk states into the right blocks.
+    mamba_chunk_size = 64
+
+    def __init__(
+        self,
+        attn_mode: str = "chunk",
+        hidden_size: int = 2048,
+        hidden_ratio: int | None = 4,
+        intermediate_size: int | None = None,
+        num_hidden_layers: int = 24,
+        head_dim: int | None = 64,
+        num_heads: int | None = None,
+        decay_low_rank_dim: int = 64,
+        gate_low_rank_dim: int = 128,
+        a_low_rank_dim: int = 64,
+        v_low_rank_dim: int = 16,
+        hidden_act: str = "sqrelu",
+        max_position_embeddings: int = 2048,
+        norm_first: bool = True,
+        norm_bias: bool = True,
+        norm_eps: float = 1e-5,
+        attn: dict | None = None,
+        use_cache: bool = True,
+        pad_token_id: int | None = None,
+        bos_token_id: int = 1,
+        eos_token_id: int = 2,
+        tie_word_embeddings: bool = False,
+        initializer_range: float = 0.02,
+        fuse_norm: bool = True,
+        fuse_cross_entropy: bool = True,
+        fuse_linear_cross_entropy: bool = False,
+        use_l2warp: bool = True,
+        vocab_size: int = 32000,
+        value_dim: int | list[int] | None = None,
+        **kwargs,
+    ) -> None:
+        self.attn_mode = attn_mode
+        self.hidden_size = hidden_size
+        self.hidden_ratio = hidden_ratio
+        self.intermediate_size = intermediate_size
+        self.norm_first = norm_first
+        self.num_hidden_layers = num_hidden_layers
+
+        if head_dim is None and num_heads is not None:
+            head_dim = int(hidden_size // num_heads)
+        elif head_dim is not None and num_heads is None:
+            num_heads = int(hidden_size // head_dim)
+
+        if value_dim is None:
+            value_dim = [hidden_size] * num_hidden_layers
+        elif isinstance(value_dim, int):
+            assert value_dim >= hidden_size
+            assert value_dim % hidden_size == 0
+            value_dim = [value_dim] * num_hidden_layers
+        else:
+            assert len(value_dim) == num_hidden_layers
+
+        self.head_dim = head_dim
+        self.num_heads = num_heads
+        self.value_dim = value_dim
+
+        self.decay_low_rank_dim = decay_low_rank_dim
+        self.gate_low_rank_dim = gate_low_rank_dim
+        self.a_low_rank_dim = a_low_rank_dim
+        self.v_low_rank_dim = v_low_rank_dim
+        self.hidden_act = hidden_act
+        self.max_position_embeddings = max_position_embeddings
+        self.norm_bias = norm_bias
+        self.norm_eps = norm_eps
+        self.attn = attn
+        self.use_cache = use_cache
+        self.initializer_range = initializer_range
+        self.fuse_norm = fuse_norm
+        self.fuse_cross_entropy = fuse_cross_entropy
+        self.fuse_linear_cross_entropy = fuse_linear_cross_entropy
+        self.use_l2warp = use_l2warp
+        self.vocab_size = vocab_size
+
+        if attn is not None:
+            if not isinstance(attn, dict):
+                raise ValueError("attn must be a dictionary")
+            if "layers" not in attn:
+                raise ValueError(
+                    "Layer indices must be provided to initialize "
+                    "hybrid attention layers"
+                )
+            if "num_heads" not in attn:
+                raise ValueError(
+                    "Number of heads must be provided to initialize "
+                    "hybrid attention layers"
+                )
+            attn["num_kv_heads"] = attn.get("num_kv_heads", attn["num_heads"])
+            attn["qkv_bias"] = attn.get("qkv_bias", False)
+            attn["window_size"] = attn.get("window_size", None)
+            attn["rope_theta"] = attn.get("rope_theta", 10000.0)
+
+        super().__init__(
+            pad_token_id=pad_token_id,
+            bos_token_id=bos_token_id,
+            eos_token_id=eos_token_id,
+            tie_word_embeddings=tie_word_embeddings,
+            **kwargs,
+        )

--- a/vllm/v1/attention/backends/registry.py
+++ b/vllm/v1/attention/backends/registry.py
@@ -148,6 +148,7 @@ class MambaAttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
     SHORT_CONV = "vllm.v1.attention.backends.short_conv_attn.ShortConvAttentionBackend"
     LINEAR = "vllm.v1.attention.backends.linear_attn.LinearAttentionBackend"
     GDN_ATTN = "vllm.v1.attention.backends.gdn_attn.GDNAttentionBackend"
+    RWKV7_ATTN = "vllm.v1.attention.backends.rwkv7_attn.Rwkv7AttentionBackend"
     # Placeholder for third-party/custom backends - must be registered before use
     # set to None to avoid alias with other backend, whose value is an empty string
     CUSTOM = None

--- a/vllm/v1/attention/backends/rwkv7_attn.py
+++ b/vllm/v1/attention/backends/rwkv7_attn.py
@@ -1,0 +1,211 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from dataclasses import dataclass
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.utils.math_utils import cdiv
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionCGSupport,
+    AttentionMetadataBuilder,
+    CommonAttentionMetadata,
+)
+from vllm.v1.attention.backends.utils import (
+    mamba_get_block_table_tensor,
+    split_decodes_and_prefills,
+)
+from vllm.v1.kv_cache_interface import AttentionSpec, MambaSpec
+
+
+class Rwkv7AttentionBackend(AttentionBackend):
+    @staticmethod
+    def get_name() -> str:
+        return "RWKV7_ATTN"
+
+    @staticmethod
+    def get_builder_cls() -> type["Rwkv7AttentionMetadataBuilder"]:
+        return Rwkv7AttentionMetadataBuilder
+
+
+@dataclass
+class Rwkv7AttentionMetadata:
+    num_prefills: int
+    num_prefill_tokens: int
+    num_decodes: int
+    num_decode_tokens: int
+    num_actual_tokens: int
+
+    query_start_loc: torch.Tensor | None = None
+    seq_lens: torch.Tensor | None = None
+
+    # Cache block-table for the recurrent state.
+    # - In default mode (mamba_cache_mode != 'all'): shape [batch],
+    #   one cache block per active sequence; state is overwritten in place.
+    # - In 'all' mode (prefix caching): shape [batch, max_blocks]; each
+    #   sequence may use multiple blocks (one per ``mamba_block_size``
+    #   tokens), and ``block_idx_*_*`` index into the second dim.
+    state_indices_tensor: torch.Tensor | None = None
+
+    # Boolean mask over prefill sequences only: True when the sequence has
+    # cached state to load. None when num_prefills == 0.
+    has_initial_state: torch.Tensor | None = None
+
+    # Prefix-caching machinery (populated only when mamba_cache_mode == 'all').
+    is_mamba_cache_all: bool = False
+    mamba_block_size: int | None = None
+    block_idx_last_computed_token: torch.Tensor | None = None
+    block_idx_first_scheduled_token: torch.Tensor | None = None
+    block_idx_last_scheduled_token: torch.Tensor | None = None
+    num_computed_tokens_p: torch.Tensor | None = None
+
+    # Resolved per-request cache slots (decodes + prefills). 1D, length =
+    # num_decodes + num_prefills. Cudagraph-stable under prefix caching.
+    read_slot: torch.Tensor | None = None
+    write_slot: torch.Tensor | None = None
+
+
+class Rwkv7AttentionMetadataBuilder(AttentionMetadataBuilder[Rwkv7AttentionMetadata]):
+    reorder_batch_threshold: int = 1
+
+    _cudagraph_support = AttentionCGSupport.UNIFORM_SINGLE_TOKEN_DECODE
+
+    def __init__(
+        self,
+        kv_cache_spec: AttentionSpec,
+        layer_names: list[str],
+        vllm_config: VllmConfig,
+        device: torch.device,
+    ):
+        super().__init__(kv_cache_spec, layer_names, vllm_config, device)
+        assert isinstance(kv_cache_spec, MambaSpec)
+
+        self.compilation_config = vllm_config.compilation_config
+        self._init_reorder_batch_threshold(1, False)
+
+        self.use_full_cuda_graph: bool = (
+            self.compilation_config.cudagraph_mode.has_full_cudagraphs()
+        )
+
+        max_seqs = vllm_config.scheduler_config.max_num_seqs
+        self.decode_cudagraph_max_bs: int = max_seqs
+        if self.compilation_config.max_cudagraph_capture_size is not None:
+            self.decode_cudagraph_max_bs = min(
+                self.decode_cudagraph_max_bs,
+                self.compilation_config.max_cudagraph_capture_size,
+            )
+
+        # Persistent buffers used as cudagraph-stable destinations for the
+        # prefix-cache decode path. With ``mamba_cache_mode == 'all'`` the
+        # read / write block indices change per request as block boundaries
+        # shift, so we ``copy_`` into these fixed-address tensors during
+        # ``build()`` rather than allocating fresh ones.
+        self.read_slot: torch.Tensor = torch.empty(
+            (self.decode_cudagraph_max_bs,), dtype=torch.int32, device=device
+        )
+        self.write_slot: torch.Tensor = torch.empty(
+            (self.decode_cudagraph_max_bs,), dtype=torch.int32, device=device
+        )
+
+    def build(  # type: ignore[override]
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> Rwkv7AttentionMetadata:
+        m = common_attn_metadata
+        query_start_loc = m.query_start_loc
+        seq_lens = m.seq_lens
+
+        is_mamba_cache_all = self.vllm_config.cache_config.mamba_cache_mode == "all"
+        mamba_block_size = self.kv_cache_spec.block_size if is_mamba_cache_all else None
+
+        block_idx_last_computed_token: torch.Tensor | None = None
+        block_idx_first_scheduled_token: torch.Tensor | None = None
+        block_idx_last_scheduled_token: torch.Tensor | None = None
+        num_computed_tokens_p: torch.Tensor | None = None
+
+        if is_mamba_cache_all:
+            assert mamba_block_size is not None
+            block_table_tensor = m.block_table_tensor
+            num_computed_tokens = m.compute_num_computed_tokens()
+            block_idx_last_computed_token = torch.clamp(
+                cdiv(num_computed_tokens, mamba_block_size) - 1, min=0
+            )
+            block_idx_first_scheduled_token = (
+                cdiv(num_computed_tokens + 1, mamba_block_size) - 1
+            )
+            block_idx_last_scheduled_token = torch.clamp(
+                cdiv(seq_lens, mamba_block_size) - 1, min=0
+            )
+            state_indices_tensor = block_table_tensor
+            read_slot = block_table_tensor.gather(
+                1, block_idx_last_computed_token.long().unsqueeze(1)
+            ).squeeze(1)
+            write_slot = block_table_tensor.gather(
+                1, block_idx_last_scheduled_token.long().unsqueeze(1)
+            ).squeeze(1)
+        else:
+            block_table_tensor = mamba_get_block_table_tensor(
+                m.block_table_tensor,
+                m.seq_lens,
+                self.kv_cache_spec,
+                self.vllm_config.cache_config.mamba_cache_mode,
+            )
+            state_indices_tensor = block_table_tensor[:, 0]
+            read_slot = state_indices_tensor
+            write_slot = state_indices_tensor
+
+        num_decodes, num_prefills, num_decode_tokens, num_prefill_tokens = (
+            split_decodes_and_prefills(
+                m,
+                decode_threshold=self.reorder_batch_threshold,
+                treat_short_extends_as_decodes=False,
+            )
+        )
+
+        has_initial_state: torch.Tensor | None = None
+        if num_prefills > 0:
+            context_lens_tensor = m.compute_num_computed_tokens()
+            has_initial_state = context_lens_tensor[num_decodes:] > 0
+            if is_mamba_cache_all:
+                num_computed_tokens_p = context_lens_tensor[num_decodes:]
+
+        # Pre-allocate cudagraph-stable buffers when the batch is a uniform
+        # decode that fits in our captured size. The read / write slot
+        # values change per request as prefix-cache block boundaries shift,
+        # so we copy_ into fixed-address tensors.
+        if (
+            self.use_full_cuda_graph
+            and num_prefills == 0
+            and num_decodes <= self.decode_cudagraph_max_bs
+        ):
+            self.read_slot[:num_decodes].copy_(
+                read_slot[:num_decodes], non_blocking=True
+            )
+            read_slot = self.read_slot[: m.num_actual_tokens]
+            self.write_slot[:num_decodes].copy_(
+                write_slot[:num_decodes], non_blocking=True
+            )
+            write_slot = self.write_slot[: m.num_actual_tokens]
+
+        return Rwkv7AttentionMetadata(
+            num_prefills=num_prefills,
+            num_prefill_tokens=num_prefill_tokens,
+            num_decodes=num_decodes,
+            num_decode_tokens=num_decode_tokens,
+            num_actual_tokens=m.num_actual_tokens,
+            query_start_loc=query_start_loc,
+            seq_lens=seq_lens,
+            state_indices_tensor=state_indices_tensor,
+            has_initial_state=has_initial_state,
+            is_mamba_cache_all=is_mamba_cache_all,
+            mamba_block_size=mamba_block_size,
+            block_idx_last_computed_token=block_idx_last_computed_token,
+            block_idx_first_scheduled_token=block_idx_first_scheduled_token,
+            block_idx_last_scheduled_token=block_idx_last_scheduled_token,
+            num_computed_tokens_p=num_computed_tokens_p,
+            read_slot=read_slot,
+            write_slot=write_slot,
+        )


### PR DESCRIPTION
## Purpose

Adds [RWKV-7 ("Goose")](https://arxiv.org/abs/2503.14456) to vLLM v1, targeting the dense fla-format checkpoints at `fla-hub/rwkv7-{0.1B,0.4B,1.5B,2.9B}-{g1,world}`. RWKV-7 is an attention-free recurrent model: per-sequence per-layer state is a fixed `(num_heads, head_dim, head_v_dim)` fp32 matrix plus two 1-token shift buffers (one for the time-mix block, one for the channel-mix FFN). No KV cache, constant memory regardless of context length.

Resolves #3583 (which was originally requesting RWKV support generally; this PR covers v7, the production version of the family).

This is not a duplicate of #11193, which targeted RWKV-6 with a different state mechanism and was closed/stale.

### What's in the PR

- `vllm/model_executor/models/rwkv7.py` — model, decoder layer, channel-mix, `RWKV7ForCausalLM`. `HasInnerState + IsAttentionFree + SupportsMambaPrefixCaching`.
- `vllm/model_executor/layers/mamba/rwkv7_mixer.py` — time-mix block. Wraps the kernel call in `torch.ops.vllm.rwkv7_attention` so token-shift, projections, `v_first` lerp, GroupNorm, gate-output correction, and o_proj stay compile-friendly.
- `vllm/v1/attention/backends/rwkv7_attn.py` — thin metadata backend mirroring linear-attn / GDN style. Pure-decode batches use `UNIFORM_SINGLE_TOKEN_DECODE` cudagraphs; mixed batches and prefills route to `chunk_rwkv7`.
- `vllm/model_executor/layers/fla/ops/rwkv7/` — vendored forward-only Triton kernels (`chunk`, `fused_recurrent`, plus `wy_fast`/`chunk_h`/`chunk_o`/`chunk_a`/`cumsum` deps) copied from flash-linear-attention with bwd kernels and `Function.apply` wrappers stripped.
- `vllm/model_executor/layers/mamba/mamba_utils.py` — `rwkv7_state_shape` / `rwkv7_state_dtype` / `rwkv7_state_copy_func` for the two-shift + recurrent triple.
- `vllm/v1/attention/backends/registry.py` — `RWKV7_ATTN` enum + `"rwkv7" -> RWKV7_ATTN` mapping.
- `vllm/model_executor/models/registry.py` — `RWKV7ForCausalLM -> ("rwkv7", "RWKV7ForCausalLM")`.
- `vllm/transformers_utils/configs/rwkv7.py` + `transformers_utils/config.py` — native `RWKV7Config` (the fla-hub repos still need `--trust-remote-code` for the tokenizer config).
- `tests/models/registry.py` — `_HfExamplesInfo` entry.
- `docs/models/supported_models.md` — model card entry.

### Tensor parallelism

Sharded along the head axis on each rank:
- `r_k`, `k_k`, `k_a` — `sharded_weight_loader(0)`
- `g_norm` — constructed with `num_groups = num_heads // tp_size` and `num_channels = value_dim // tp_size`; affine weight/bias loaded sharded
- LoRA up-projections — `ColumnParallelLinear(gather_output=False)`
- LoRA down-projections — `ReplicatedLinear` (input is the full hidden, replicated)
- `r_proj` / `k_proj` / `v_proj` — already `ColumnParallelLinear`
- `o_proj` — already `RowParallelLinear`

The token-shift state stays at `(1, hidden_size)` per rank (not sharded) because the shift operates on the layer input pre-projection, which is the full replicated hidden state. The duplication is one token of hidden per layer per sequence — negligible.

### Out of scope

Asserted off in `__init__` so they fail fast with a clear message rather than mid-forward:

- Speculative decoding (kernel-side support sketched but cross-round state alignment is not yet correct; tracked on a private WIP branch).
- Pipeline parallelism.
- BlinkDL `.pth` checkpoint format.

## Test Plan

- Standalone kernel parity: feed identical inputs to `fused_mul_recurrent_rwkv7` token-by-token (single-token call per step) versus a single packed variable-length call; compare per-step outputs and final state.
- Manual end-to-end serve:
  ```bash
  vllm serve fla-hub/rwkv7-1.5B-g1 \
      --trust-remote-code --port 9091 \
      --max-model-len 1024 --gpu-memory-utilization 0.30 \
      --enable-prefix-caching
  curl -s localhost:9091/v1/completions -d '{
    "model": "fla-hub/rwkv7-1.5B-g1",
    "prompt": "The capital of France is",
    "max_tokens": 30, "temperature": 0
  }'
  ```
- Pre-commit: `ruff-check`, `ruff-format`, `mypy-3.10` on all touched files.

## Test Result

Verified on RTX PRO 6000 (Blackwell, sm_120) against the rebased branch (current `main` + TP-support commit), full local rebuild from source.

- **Kernel parity**: output diff `0.00e+00`, final-state diff `6.71e-04` (fp32 tolerance — bf16 inputs accumulating in fp32).
- **Serve smoke** at TP=1 with `--enable-prefix-caching`:

  | prompt | output | latency |
  |---|---|---|
  | `The capital of France is` | ` Paris.\nThe capital of France is Paris.\nThe capital of France is Paris.\nThe capi` | 54.9s cold (torch.compile) / 0.21s warm |
  | `Once upon a time,` | ` in a small town named Harmonyville, lived two best friends - Timmy the Tortoise` | 0.21s |
  | `def add(a, b):\n    return a + b\n\ndef sub(a, b):\n    return` | ` a - b\n```\nIn this example, we define two functions, ` `add` ` and ` `sub` `, that take ` | 0.21s |

  Outputs match the fla HF reference. Two identical requests produce identical output (per-request state reset). Mixed-batch concurrent requests stay independent (no state-indexing cross-talk).
- **TP > 1**: code is logically correct (per-rank head sharding, GroupNorm-per-rank, sharded weight loaders) and linter/type-check clean. Multi-GPU smoke needs CI runners — single-Blackwell test box can only validate TP=1.
- **Linters**: `ruff-check`, `ruff-format`, `mypy-3.10` all pass on the touched files.

## AI assistance

This PR was prepared with AI-assisted code review and refactoring (kernel vendoring, mixer dispatch, metadata backend wiring, TP sharding, doc/test-registry boilerplate). The submitting human has read every changed line and run the tests above end-to-end before flipping out of draft.