### PR TITLE
[Hardware] DeepGEMM MoE: extend device gates to SM 12.x consumer Blackwell

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
@@ -355,9 +355,9 @@ class DeepGemmFP4Experts(mk.FusedMoEExpertsModular):
     def _supports_current_device() -> bool:
         from vllm.platforms import current_platform
 
-        return (
-            is_deep_gemm_supported()
-            and current_platform.is_device_capability_family(100)
+        return is_deep_gemm_supported() and (
+            current_platform.is_device_capability_family(100)
+            or current_platform.is_device_capability_family(120)
         )
 
     @staticmethod

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -555,8 +555,11 @@ class CudaPlatformBase(Platform):
 
     @classmethod
     def support_deep_gemm(cls) -> bool:
-        """Currently, only Hopper and Blackwell GPUs are supported."""
-        return cls.is_device_capability(90) or cls.is_device_capability_family(100)
+        """Currently, Hopper, datacenter Blackwell (SM 100+) and consumer
+        Blackwell (SM 12x — RTX 50-series, GB10/DGX Spark) are supported."""
+        return (cls.is_device_capability(90)
+                or cls.is_device_capability_family(100)
+                or cls.is_device_capability_family(120))
 
     @classmethod
     def is_integrated_gpu(cls, device_id: int = 0) -> bool:


### PR DESCRIPTION
## Summary

Two parallel device-capability gates currently exclude SM 12.x (consumer Blackwell — RTX 50-series and GB10 / DGX Spark) from the DeepGEMM-backed MXFP4 MoE path:

**Gate 1: `CudaPlatformBase.support_deep_gemm()`** (`vllm/platforms/cuda.py`)
```python
return cls.is_device_capability(90) or cls.is_device_capability_family(100)
```

**Gate 2: `DeepGemmFP4Experts._supports_current_device()`** (`vllm/model_executor/layers/fused_moe/experts/deep_gemm_moe.py`)
```python
return (
    is_deep_gemm_supported()
    and current_platform.is_device_capability_family(100)
)
```

Together these hard-code SM 100 / 100a / 103 only — dropping SM 120 / 121 even when DeepGEMM (or a fork) provides the kernels. On dual DGX Spark / SM 121 hardware today both gates short-circuit to `False`, so any V4-Flash deployment using `--moe-backend deep_gemm` raises:

```
ValueError: Mxfp4 MoE backend 'DEEPGEMM_MXFP4' does not support
the deployment configuration since kernel does not support
current device cuda.
```

## Fix

This PR widens both gates to also accept `is_device_capability_family(120)`, matching the comment intent in `support_deep_gemm` ("Hopper and Blackwell GPUs are supported"). The kernel-level fallback to `tcgen05.*` is still guarded by DeepGEMM's own dispatch, which now has paths for SM 12.x in active forks (e.g. `jasl/DeepGEMM` per #40899).

## Test plan

- [x] Verified locally on dual NVIDIA GB10 / SM 121 (DGX Spark): with this change `is_deep_gemm_supported() == True` and `DeepGemmFP4Experts._supports_current_device() == True`. The Mxfp4 oracle no longer raises on backend lookup.
- [x] Engine-init progresses past these gates; subsequent failures (if DeepGEMM lacks SM 12.x kernel implementations for specific ops the deployment uses) now surface as proper kernel-level errors rather than being masked behind the device-capability check, which is the correct UX.
- No SM 90 (Hopper) / SM 100 (datacenter Blackwell) / ROCm path changes.

## Cross-platform table

| Device | Pre-PR | Post-PR |
|---|---|---|
| SM 80 / 86 / 89 (Ampere/Ada) | rejected (correct) | rejected (unchanged) |
| SM 90 (Hopper) | accepted | accepted |
| SM 100 / 103 (datacenter Blackwell) | accepted | accepted |
| **SM 120 / 121 (consumer Blackwell)** | **rejected** | **accepted** |
| ROCm | unaffected | unaffected |

## Companion PRs

- #40923 — Marlin SM 12.x cubin (Approved by @Harry-Chen)
- #41028 — OAITritonExperts MXFP4 SM 12.x device range
- #40082 — flashinfer b12x MoE for SM 120/121 (separate path)

cc @mgoin @tlrmchlsmth @LucasWilkinson — small follow-up to the SM 12.x story.