### PR TITLE
[Bugfix] Fix MiniMaxM2Parser missing **kwargs in __init__

### DIFF
--- a/vllm/parser/minimax_m2_parser.py
+++ b/vllm/parser/minimax_m2_parser.py
@@ -43,11 +43,13 @@ class MiniMaxM2Parser(DelegatingParser):
     reasoning_parser_cls = MiniMaxM2ReasoningParser
     tool_parser_cls = MinimaxM2ToolParser
 
-    def __init__(self, tokenizer: TokenizerLike, tools: list[Tool] | None = None):
+    def __init__(
+        self, tokenizer: TokenizerLike, tools: list[Tool] | None = None, **kwargs
+    ):
         super().__init__(tokenizer)
 
         # Initialize the underlying parsers
-        self._reasoning_parser = MiniMaxM2ReasoningParser(tokenizer)
+        self._reasoning_parser = MiniMaxM2ReasoningParser(tokenizer, **kwargs)
         self._tool_parser = MinimaxM2ToolParser(tokenizer, tools)
 
         logger.debug(


### PR DESCRIPTION
## Purpose

Fix #41065

`MiniMaxM2Parser.__init__()` did not accept `**kwargs`, but `serving.py` always passes `chat_template_kwargs` when instantiating parsers, causing a `TypeError` crash on every request when using the MiniMax M2 parser.

PR #39683 fixed the missing `tools` parameter but forgot to add `**kwargs`.

## Changes

In `vllm/parser/minimax_m2_parser.py`:
- Added `**kwargs` to `MiniMaxM2Parser.__init__()` signature
- Pass `**kwargs` through to `MiniMaxM2ReasoningParser` (consistent with how `_WrappedParser` handles it)

## Test Plan

Minimal reproduction (no GPU needed):

```python
from unittest.mock import MagicMock
from vllm.parser.minimax_m2_parser import MiniMaxM2Parser

tokenizer = MagicMock()
tokenizer.get_vocab.return_value = {
    "<think>": 100, "</think>": 101,
    "<minimax:tool_call>": 200, "</minimax:tool_call>": 201,
}

# Before fix: TypeError
# After fix: OK
parser = MiniMaxM2Parser(tokenizer, None, chat_template_kwargs={})
```

## Why this is not a duplicate

Searched open issues and PRs — no existing fix for this specific `chat_template_kwargs` crash. Related PRs (#39683, #38803) address different MiniMax M2 issues.

AI assistance was used to identify the bug. All changed lines have been reviewed.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)