### PR TITLE
[Misc] Allow install empty package from pip

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -995,35 +995,39 @@ def get_vllm_version() -> str:
     version = get_version(write_to="vllm/_version.py")
     sep = "+" if "+" not in version else "."  # dev versions might contain +
 
-    if _no_device():
-        if envs.VLLM_TARGET_DEVICE == "empty":
-            version += f"{sep}empty"
-    elif _is_cuda():
-        if USE_PRECOMPILED_EXTENSIONS and not envs.VLLM_SKIP_PRECOMPILED_VERSION_SUFFIX:
-            version += f"{sep}precompiled"
+    if not envs.VLLM_SKIP_VERSION_SUFFIX:
+        if _no_device():
+            if envs.VLLM_TARGET_DEVICE == "empty":
+                version += f"{sep}empty"
+        elif _is_cuda():
+            if (
+                USE_PRECOMPILED_EXTENSIONS
+                and not envs.VLLM_SKIP_PRECOMPILED_VERSION_SUFFIX
+            ):
+                version += f"{sep}precompiled"
+            else:
+                cuda_version = str(get_nvcc_cuda_version())
+                if cuda_version != envs.VLLM_MAIN_CUDA_VERSION:
+                    cuda_version_str = cuda_version.replace(".", "")[:3]
+                    # skip this for source tarball, required for pypi
+                    if "sdist" not in sys.argv:
+                        version += f"{sep}cu{cuda_version_str}"
+        elif _is_hip():
+            # Get the Rocm Version
+            rocm_version = get_rocm_version() or torch.version.hip
+            if rocm_version and rocm_version != envs.VLLM_MAIN_CUDA_VERSION:
+                version += f"{sep}rocm{rocm_version.replace('.', '')[:3]}"
+        elif _is_tpu():
+            version += f"{sep}tpu"
+        elif _is_cpu():
+            # Check the local VLLM_TARGET_DEVICE (may be set by auto-detect above),
+            # not envs.VLLM_TARGET_DEVICE, so CPU-only hosts still get `+cpu`.
+            if VLLM_TARGET_DEVICE == "cpu":
+                version += f"{sep}cpu"
+        elif _is_xpu():
+            version += f"{sep}xpu"
         else:
-            cuda_version = str(get_nvcc_cuda_version())
-            if cuda_version != envs.VLLM_MAIN_CUDA_VERSION:
-                cuda_version_str = cuda_version.replace(".", "")[:3]
-                # skip this for source tarball, required for pypi
-                if "sdist" not in sys.argv:
-                    version += f"{sep}cu{cuda_version_str}"
-    elif _is_hip():
-        # Get the Rocm Version
-        rocm_version = get_rocm_version() or torch.version.hip
-        if rocm_version and rocm_version != envs.VLLM_MAIN_CUDA_VERSION:
-            version += f"{sep}rocm{rocm_version.replace('.', '')[:3]}"
-    elif _is_tpu():
-        version += f"{sep}tpu"
-    elif _is_cpu():
-        # Check the local VLLM_TARGET_DEVICE (may be set by auto-detect above),
-        # not envs.VLLM_TARGET_DEVICE, so CPU-only hosts still get `+cpu`.
-        if VLLM_TARGET_DEVICE == "cpu":
-            version += f"{sep}cpu"
-    elif _is_xpu():
-        version += f"{sep}xpu"
-    else:
-        raise RuntimeError("Unknown runtime environment")
+            raise RuntimeError("Unknown runtime environment")
 
     return version
 

--- a/setup.py
+++ b/setup.py
@@ -1256,35 +1256,39 @@ def get_vllm_version() -> str:
     version = get_version(write_to="vllm/_version.py")
     sep = "+" if "+" not in version else "."  # dev versions might contain +
 
-    if _no_device():
-        if envs.VLLM_TARGET_DEVICE == "empty":
-            version += f"{sep}empty"
-    elif _is_cuda():
-        if USE_PRECOMPILED_EXTENSIONS and not envs.VLLM_SKIP_PRECOMPILED_VERSION_SUFFIX:
-            version += f"{sep}precompiled"
+    if not envs.VLLM_SKIP_VERSION_SUFFIX:
+        if _no_device():
+            if envs.VLLM_TARGET_DEVICE == "empty":
+                version += f"{sep}empty"
+        elif _is_cuda():
+            if (
+                USE_PRECOMPILED_EXTENSIONS
+                and not envs.VLLM_SKIP_PRECOMPILED_VERSION_SUFFIX
+            ):
+                version += f"{sep}precompiled"
+            else:
+                cuda_version = str(get_nvcc_cuda_version())
+                if cuda_version != envs.VLLM_MAIN_CUDA_VERSION:
+                    cuda_version_str = cuda_version.replace(".", "")[:3]
+                    # skip this for source tarball, required for pypi
+                    if "sdist" not in sys.argv:
+                        version += f"{sep}cu{cuda_version_str}"
+        elif _is_hip():
+            # Get the Rocm Version
+            rocm_version = get_rocm_version() or torch.version.hip
+            if rocm_version and rocm_version != envs.VLLM_MAIN_CUDA_VERSION:
+                version += f"{sep}rocm{rocm_version.replace('.', '')[:3]}"
+        elif _is_tpu():
+            version += f"{sep}tpu"
+        elif _is_cpu():
+            # Check the local VLLM_TARGET_DEVICE (may be set by auto-detect above),
+            # not envs.VLLM_TARGET_DEVICE, so CPU-only hosts still get `+cpu`.
+            if VLLM_TARGET_DEVICE == "cpu":
+                version += f"{sep}cpu"
+        elif _is_xpu():
+            version += f"{sep}xpu"
         else:
-            cuda_version = str(get_nvcc_cuda_version())
-            if cuda_version != envs.VLLM_MAIN_CUDA_VERSION:
-                cuda_version_str = cuda_version.replace(".", "")[:3]
-                # skip this for source tarball, required for pypi
-                if "sdist" not in sys.argv:
-                    version += f"{sep}cu{cuda_version_str}"
-    elif _is_hip():
-        # Get the Rocm Version
-        rocm_version = get_rocm_version() or torch.version.hip
-        if rocm_version and rocm_version != envs.VLLM_MAIN_CUDA_VERSION:
-            version += f"{sep}rocm{rocm_version.replace('.', '')[:3]}"
-    elif _is_tpu():
-        version += f"{sep}tpu"
-    elif _is_cpu():
-        # Check the local VLLM_TARGET_DEVICE (may be set by auto-detect above),
-        # not envs.VLLM_TARGET_DEVICE, so CPU-only hosts still get `+cpu`.
-        if VLLM_TARGET_DEVICE == "cpu":
-            version += f"{sep}cpu"
-    elif _is_xpu():
-        version += f"{sep}xpu"
-    else:
-        raise RuntimeError("Unknown runtime environment")
+            raise RuntimeError("Unknown runtime environment")
 
     return version
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1887,6 +1887,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Each entry is VAR_NAME or VAR_NAME:<suffix> (suffix appended to
     # RDMA device name). Must be set together with VLLM_GPU_NIC_PCIE_MAPPING.
     "VLLM_NIC_SELECTION_VARS": lambda: os.getenv("VLLM_NIC_SELECTION_VARS", ""),
+    # Whether to skip version suffix when building package
+    "VLLM_SKIP_VERSION_SUFFIX": lambda: bool(
+        int(os.getenv("VLLM_SKIP_VERSION_SUFFIX", "0"))
+    ),
 }
 
 
@@ -2039,6 +2043,7 @@ def compile_factors() -> dict[str, object]:
         "LOCAL_RANK",
         "CUDA_VISIBLE_DEVICES",
         "NO_COLOR",
+        "VLLM_SKIP_VERSION_SUFFIX",
     }
 
     from vllm.config.utils import normalize_value

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -2204,6 +2204,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Each op additionally checks its own shape / dtype constraints and falls
     # back to the eager path when they do not hold.
     "VLLM_ENABLE_HPC_OPS": lambda: bool(int(os.getenv("VLLM_ENABLE_HPC_OPS", "0"))),
+    # Whether to skip version suffix when building package
+    "VLLM_SKIP_VERSION_SUFFIX": lambda: bool(
+        int(os.getenv("VLLM_SKIP_VERSION_SUFFIX", "0"))
+    ),
 }
 
 
@@ -2373,6 +2377,7 @@ def compile_factors() -> dict[str, object]:
         "LOCAL_RANK",
         "CUDA_VISIBLE_DEVICES",
         "NO_COLOR",
+        "VLLM_SKIP_VERSION_SUFFIX",
     }
 
     from vllm.config.utils import normalize_value


### PR DESCRIPTION
## Purpose

when a user want to install an vllm oot backend, the `vllm` package should be installed with `empty` backend first. Currently, users must clone and install it from source. It's a little complex.  And `pip install vllm` doesn't work at all.  If run something like `VLLM_TARGET_DEVICE=empty pip install vllm==0.19.0`, the error will raise:
```
version: expected '0.19.0', but metadata has '0.19.0+empty'
```
it because that vllm setup step adds `+<backend_tag>` to the version string, which breaks pep440.

This PR fix the problem, allow users install empty vllm via `pip install` command. It helps users to install vllm with oot backend in a quick way.

After this PR, the command works now:
`VLLM_TARGET_DEVICE=empty VLLM_SKIP_VERSION_SUFFIX=true pip install -v --no-binary vllm vllm==0.19.0`

A new env `VLLM_SKIP_VERSION_SUFFIX` is added to keep backward capability. The default value is false, if users want to install `empty` vllm,  set it to true.

## Test Plan

I published a test package to pypi with this PR. `https://pypi.org/project/wxy-test/0.19.0/` 

try:
`VLLM_TARGET_DEVICE=empty VLLM_SKIP_VERSION_SUFFIX=true pip install -v --no-binary wxy-test wxy-test==0.19.0`

you can find that an empty wxy-test(vllm) is installed.

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

