### PR TITLE
[CI][AMD][BugFix] Update request URL in test_moriio_connector to match vllm-router compatibility changes

### DIFF
--- a/tests/v1/kv_connector/unit/test_moriio_connector.py
+++ b/tests/v1/kv_connector/unit/test_moriio_connector.py
@@ -3,6 +3,7 @@
 import importlib.util
 import os
 import subprocess
+import uuid
 from unittest.mock import MagicMock, patch
 
 import msgspec
@@ -98,6 +99,11 @@ def _setup_kv_transfer_request(
             "remote_handshake_port": fake_port,
             "remote_engine_id": "test_engine",
         }
+    )
+    zmq_addr = f"host:{remote_host},handshake:{fake_port},notify:{fake_port}"
+    fake_uuid = uuid.uuid4().hex
+    request.request_id = (
+        f"___prefill_addr_{zmq_addr}___decode_addr_{zmq_addr}_{fake_uuid}"
     )
     return request
 
@@ -254,12 +260,13 @@ def test_write_mode_saves_local_block_ids():
         do_remote_decode=True,
         do_remote_prefill=False,
     )
+
+    # Setup KV transfer params and embed ZMQ addrs in request_id before
+    # adding to scheduler so the ID is consistent everywhere.
+    request = _setup_kv_transfer_request(request)
     request_id = request.request_id
 
     scheduler.add_request(request)
-
-    # Fake Config
-    request = _setup_kv_transfer_request(request)
 
     # Remote Prefill, triggers MoRIIOConnectorMetadata.
     scheduler_output = scheduler.schedule()
@@ -312,12 +319,13 @@ def test_write_mode_with_chunked_prefill_saves_local_block_ids():
         do_remote_decode=True,
         do_remote_prefill=False,
     )
+
+    # Setup KV transfer params and embed ZMQ addrs in request_id before
+    # adding to scheduler so the ID is consistent everywhere.
+    request = _setup_kv_transfer_request(request)
     request_id = request.request_id
 
     scheduler.add_request(request)
-
-    # Fake Config
-    request = _setup_kv_transfer_request(request)
 
     # Remote Prefill with chunked prefill, triggers multiple schedules.
     expected_counts = [(0, 0, 0), (0, 0, 0), (1, 0, 0)]
@@ -363,14 +371,16 @@ def test_read_mode_loads_remote_block_ids(moriio_read_mode):
         do_remote_decode=False,
         do_remote_prefill=True,
     )
+
+    # Setup KV transfer params and embed ZMQ addrs in request_id before
+    # adding to scheduler so the ID is consistent everywhere.
+    request = _setup_kv_transfer_request(request)
     request_id = request.request_id
 
     scheduler.add_request(request)
     block_list = scheduler.kv_cache_manager.coordinator.single_type_managers[
         0
     ].req_to_blocks[request_id]
-
-    request = _setup_kv_transfer_request(request)
 
     # Set remote block ids to be fetched.
     request.kv_transfer_params["remote_block_ids"] = block_list


### PR DESCRIPTION

## Purpose
This [PR ](https://github.com/vllm-project/vllm/pull/39565) changed the moriio KV connector to make it compatible with `vllm-router`, which changes the format of the request url to include the prefill, decode, and uuid values.  However, the tests in test_moriio_connector were not updated.

The requests generated did not include the changes to the URL needed to maintain compatibility.  This PR updates the test to generate requests that are compatible with the new pattern matching implemented to support `vllm-router` compatibility.
## Test Plan
`pytest -sv  v1/kv_connector/unit/test_moriio_connector.py`
## Test Result
`5 passed, 18 warnings in 5.13s`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X ] The test plan, such as providing test command.
- [X ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

