### PR TITLE
[Bugfix] Fix GLM45 reasoning token counting

### DIFF
--- a/tests/reasoning/test_glm4_moe_reasoning_parser.py
+++ b/tests/reasoning/test_glm4_moe_reasoning_parser.py
@@ -216,6 +216,52 @@ def test_reasoning(
     assert is_reasoning_end == param_dict["is_reasoning_end"]
 
 
+def test_reasoning_token_count(glm45_tokenizer):
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        glm45_tokenizer
+    )
+    output = glm45_tokenizer.tokenize("<think>This is a reasoning section</think>Final")
+    output_ids = glm45_tokenizer.convert_tokens_to_ids(output)
+
+    assert parser.count_reasoning_tokens(output_ids) > 0
+
+
+def test_reasoning_token_count_ignores_prefix_before_start_token(glm45_tokenizer):
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        glm45_tokenizer
+    )
+    output = glm45_tokenizer.tokenize("<think>This is a reasoning section</think>Final")
+    prefixed_output = glm45_tokenizer.tokenize(
+        "\n<think>This is a reasoning section</think>Final"
+    )
+
+    assert parser.count_reasoning_tokens(
+        glm45_tokenizer.convert_tokens_to_ids(prefixed_output)
+    ) == parser.count_reasoning_tokens(glm45_tokenizer.convert_tokens_to_ids(output))
+
+
+def test_reasoning_token_count_no_start_token(glm45_tokenizer):
+    """GLM5 outputs reasoning without <think> prefix, only </think> suffix."""
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        glm45_tokenizer
+    )
+    output = glm45_tokenizer.tokenize("This is a reasoning section</think>Final")
+    output_ids = glm45_tokenizer.convert_tokens_to_ids(output)
+
+    assert parser.count_reasoning_tokens(output_ids) > 0
+
+
+def test_reasoning_token_count_no_markers(glm45_tokenizer):
+    """Without markers, all output is reasoning until the parser sees otherwise."""
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        glm45_tokenizer
+    )
+    output = glm45_tokenizer.tokenize("This is plain content with no markers")
+    output_ids = glm45_tokenizer.convert_tokens_to_ids(output)
+
+    assert parser.count_reasoning_tokens(output_ids) == len(output_ids)
+
+
 @pytest.mark.parametrize("prompt, is_reasoning_end", REASONING_END_TEST_CASES)
 def test_is_reasoning_end_full_prompt(
     prompt: str, is_reasoning_end: bool, glm45_tokenizer

--- a/vllm/parser/glm47_moe.py
+++ b/vllm/parser/glm47_moe.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import functools
 import json
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 import regex as re
@@ -215,6 +216,18 @@ class Glm47MoeParser(ParserEngine):
         if not self.thinking_enabled:
             return input_ids
         return super().extract_content_ids(input_ids)
+
+    def count_reasoning_tokens(self, token_ids: Sequence[int]) -> int:
+        start_id = self._reasoning_start_token_id
+        end_id = self._reasoning_end_token_id
+        if start_id is None or end_id is None or start_id in token_ids:
+            return super().count_reasoning_tokens(token_ids)
+
+        # GLM may omit the start token, but still emits the end token.
+        for index, token_id in enumerate(token_ids):
+            if token_id == end_id:
+                return index
+        return len(token_ids)
 
     def extract_reasoning(
         self,


### PR DESCRIPTION
## Purpose

Fix GLM reasoning token accounting after the `glm45` and `glm47` reasoning parsers migrated to `Glm47MoeParserReasoningAdapter`.

GLM starts in the reasoning state and may omit the opening `<think>` marker. The generic parser-engine counter starts at depth zero, so it reported zero reasoning tokens when generated output contained only `</think>` or no reasoning markers, even though the same parser extracted that output as reasoning.

This change adds GLM-specific `count_reasoning_tokens()` behavior while preserving the generic nested-marker logic:

- with `<think>`, reuse the parser-engine counter so prefixes before the marker are excluded;
- with only `</think>`, count tokens before the first closing marker;
- with no markers, count the full output, consistent with GLM reasoning extraction.

This affects reasoning token accounting only; it does not change generated model output, so no model accuracy evaluation is required.

Duplicate-work check: refreshed searches of open PRs for "GLM45 reasoning token count", "glm45 reasoning_tokens", and "Glm47MoeParser count_reasoning_tokens". No open PR other than this one addresses GLM `count_reasoning_tokens()` accounting.

AI assistance was used to prepare this change. The submitter reviewed the final diff and ran the checks below.

## Test Plan

- `git diff --check main...HEAD`
- `HF_HUB_OFFLINE=1 .venv/bin/python -m pytest tests/reasoning/test_glm4_moe_reasoning_parser.py -q`
- `.venv/bin/pre-commit run --files vllm/parser/glm47_moe.py tests/reasoning/test_glm4_moe_reasoning_parser.py`

## Test Result

- `git diff --check main...HEAD`: passed
- GLM reasoning parser tests: `20 passed, 2 warnings in 4.78s`
- Changed-files pre-commit: passed, including ruff, mypy, SPDX, forbidden-import, and project-specific checks

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>