### PR TITLE
[Bugfix] Improve DCP unsupported backend error message

### DIFF
--- a/tests/v1/worker/test_cp_utils.py
+++ b/tests/v1/worker/test_cp_utils.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.v1.worker import cp_utils
+
+
+def test_dcp_unsupported_backend_error_mentions_attention_backend_env(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class UnsupportedDCPImpl:
+        need_to_return_lse_for_decode = False
+        supports_mtp_with_cp_non_trivial_interleave_size = True
+        supports_pcp = True
+
+    vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            prefill_context_parallel_size=1,
+            decode_context_parallel_size=2,
+            cp_kv_cache_interleave_size=1,
+        ),
+        speculative_config=None,
+    )
+
+    monkeypatch.setattr(
+        cp_utils,
+        "get_layers_from_vllm_config",
+        lambda *_args, **_kwargs: {
+            "layer.0": SimpleNamespace(impl=UnsupportedDCPImpl())
+        },
+    )
+
+    with pytest.raises(AssertionError) as exc_info:
+        cp_utils.check_attention_cp_compatibility(vllm_config)
+
+    message = str(exc_info.value)
+    assert "Decode Context Parallelism (DCP)" in message
+    assert "--attention-backend" in message
+    assert "VLLM_ATTENTION_BACKEND" in message

--- a/vllm/v1/worker/cp_utils.py
+++ b/vllm/v1/worker/cp_utils.py
@@ -32,8 +32,9 @@ def check_attention_cp_compatibility(vllm_config: VllmConfig) -> None:
                     "Decode Context Parallelism (DCP) requires attention "
                     "implementations to return the softmax LSE during decode, "
                     f"but {layer_impl.__class__.__name__} does not. "
-                    "Try a different backend by setting "
-                    "--attention-backend or disable DCP."
+                    "Try a different attention backend by setting "
+                    "--attention-backend or the VLLM_ATTENTION_BACKEND "
+                    "environment variable, or disable DCP."
                 )
 
             if pcp_size > 1:


### PR DESCRIPTION
## Purpose

Fixes #28407.

This PR improves the DCP unsupported backend error message. When an attention backend does not support DCP, the error now suggests trying a different backend via `--attention-backend` or the `VLLM_ATTENTION_BACKEND` environment variable.

This makes the failure more actionable for users who hit DCP/backend compatibility issues.

AI assistance was used to prepare this change. I reviewed the diff and ran the relevant test.

## Test Plan

Run the DCP compatibility error-message unit test:

```bash
env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/v1/worker/test_cp_utils.py
```

## Test Result

```text
============================= test session starts ==============================
collected 1 item

tests/v1/worker/test_cp_utils.py .                                       [100%]

======================== 1 passed, 5 warnings in 0.16s =========================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

