### PR TITLE
[CI/Build] install_deepgemm.sh: auto-install git when missing

### DIFF
--- a/tools/install_deepgemm.sh
+++ b/tools/install_deepgemm.sh
@@ -76,6 +76,32 @@ if [ "$CUDA_MAJOR" -lt 12 ] || { [ "$CUDA_MAJOR" -eq 12 ] && [ "$CUDA_MINOR" -lt
     exit 0
 fi
 
+# Ensure git is available — some vllm runtime images (e.g. the slim
+# *-cu130-ubuntu2404 variants) ship without it, but the clone below needs it.
+if ! command -v git >/dev/null 2>&1; then
+    echo "git not found; attempting to install it..."
+    if [ "$(id -u)" -eq 0 ]; then
+        SUDO=""
+    elif command -v sudo >/dev/null 2>&1; then
+        SUDO="sudo"
+    else
+        echo "Error: git is required but not installed, and no root/sudo access is available." >&2
+        exit 1
+    fi
+    if command -v apt-get >/dev/null 2>&1; then
+        $SUDO apt-get update && $SUDO apt-get install -y --no-install-recommends git
+    elif command -v dnf >/dev/null 2>&1; then
+        $SUDO dnf install -y git
+    elif command -v yum >/dev/null 2>&1; then
+        $SUDO yum install -y git
+    elif command -v apk >/dev/null 2>&1; then
+        $SUDO apk add --no-cache git
+    else
+        echo "Error: git is required but no supported package manager (apt/dnf/yum/apk) was found." >&2
+        exit 1
+    fi
+fi
+
 echo "Preparing DeepGEMM build..."
 echo "Repository: $DEEPGEMM_GIT_REPO"
 echo "Reference: $DEEPGEMM_GIT_REF"


### PR DESCRIPTION
## Purpose

The slim vllm runtime images (e.g. `vllm/vllm-openai:v0.20.0-x86_64-cu130-ubuntu2404`) don't ship `git`, so running `tools/install_deepgemm.sh` inside those containers fails with

```
Preparing DeepGEMM build...
Repository: https://github.com/deepseek-ai/DeepGEMM.git
Reference: 891d57b4db1071624b5c8fa0d1e51cb317fa709f
/dev/fd/63: line 88: git: command not found
```

before the DeepGEMM clone even starts. Today every caller has to `apt-get install -y git` themselves before invoking the script (e.g. https://github.com/SemiAnalysisAI/InferenceX/pull/1204).

trying to follow the official vllm 0.20 recipe rn
<img width="910" height="549" alt="image" src="https://github.com/user-attachments/assets/3679036e-eab1-4053-8a35-a0168825697d" />


## Changes

Add an early check that auto-installs `git` via the host's package manager when it is missing:

- `command -v git` short-circuits when git is already present (no-op for the official build images, which already have it).
- When missing, pick `sudo` vs root via `id -u` / `command -v sudo`.
- Try the package managers in order: `apt-get` → `dnf` → `yum` → `apk`. Covers Debian/Ubuntu, RHEL/CentOS/Fedora, and Alpine.
- If neither root/sudo nor a supported package manager is available, exit `1` with a clear error message — so the failure mode is explicit instead of the opaque `git: command not found` from inside `set -e`.

The new block lives after the CUDA version check so that `CUDA<12.8` short-circuits without touching the package manager.

## Test plan

- Verified `bash -n tools/install_deepgemm.sh` (syntax check) passes.
- Manually exercised inside `vllm/vllm-openai:v0.20.0-x86_64-cu130-ubuntu2404` (Ubuntu 24.04, root, no git pre-installed): script now installs git via apt-get and proceeds to the DeepGEMM clone/build successfully.
- No-op on images that already have git (the `command -v git` early-out).

Signed-off-by: functionstackx <47992694+functionstackx@users.noreply.github.com>