### PR TITLE
[Bugfix] avoid loading errors for dense qwen3_next models

### DIFF
--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -669,7 +669,15 @@ class QwenNextMixtureOfExperts(MixtureOfExperts):
                 self.moe_layers.append(layer.mlp.experts)
 
         if example_moe is None:
-            logger.warning_once(f"No Qwen3Next layer found in the model.layers.")
+            logger.warning_once(f"No SparseMoe layer found in the model.layers. Make sure you are loading a dense model.")
+            self.num_moe_layers = 0
+            self.num_expert_groups = 0
+            self.num_shared_experts = 0
+            self.num_logical_experts = 0
+            self.num_physical_experts = 0
+            self.num_local_physical_experts = 0
+            self.num_routed_experts = 0
+            self.num_redundant_experts = 0
             return
 
         # Set MoE hyperparameters

--- a/vllm/model_executor/models/qwen3_next.py
+++ b/vllm/model_executor/models/qwen3_next.py
@@ -669,7 +669,8 @@ class QwenNextMixtureOfExperts(MixtureOfExperts):
                 self.moe_layers.append(layer.mlp.experts)
 
         if example_moe is None:
-            raise RuntimeError("No Qwen3Next layer found in the model.layers.")
+            logger.warning_once(f"No Qwen3Next layer found in the model.layers.")
+            return
 
         # Set MoE hyperparameters
         self.num_moe_layers = len(self.moe_layers)


### PR DESCRIPTION
The qwen3_next config in HF format supports dense models, as well as the rest part of this vllm implementation. 
However, the function set_moe_parameter just raise an Error if no MOE layers exists. 
This patch replaces the Error with a warning, so that it can process models in Qwen3Next architectures which contains no Moe layers.




## Purpose
Fix code bug to support models in Qwen3Next architectures which contains no Moe layers.

## Test Plan
We can extract the weights from Qwen3.6-27B and convert it into Qwen3-Next. 
Then serve the converted model with latest vllm.

## Test Result
Passed.
The converted model got similar scores in ClawEval benchmark with Qwen3.6-27B.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

