### PR TITLE
[DSV4] Support top-level `thinking` parameter in chat completion request

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_chat.py
@@ -1002,6 +1002,63 @@ def test_chat_completion_request_n_parameter_default():
     assert sampling_params.n == 1, f"Expected n=1 (default), got n={sampling_params.n}"
 
 
+@pytest.mark.parametrize(
+    ("thinking", "expected"),
+    [
+        ({"type": "enabled"}, True),
+        ({"type": "disabled"}, False),
+    ],
+)
+def test_chat_completion_request_maps_top_level_thinking_to_template_kwargs(
+    thinking,
+    expected,
+):
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        thinking=thinking,
+    )
+
+    chat_params = request.build_chat_params(
+        default_template=None,
+        default_template_content_format="auto",
+    )
+
+    assert chat_params.chat_template_kwargs["thinking"] is expected
+
+
+def test_chat_completion_request_preserves_existing_thinking_template_kwargs():
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        chat_template_kwargs={"thinking": True, "enable_thinking": True},
+    )
+
+    chat_params = request.build_chat_params(
+        default_template=None,
+        default_template_content_format="auto",
+    )
+
+    assert chat_params.chat_template_kwargs["thinking"] is True
+    assert chat_params.chat_template_kwargs["enable_thinking"] is True
+
+
+def test_chat_completion_request_top_level_thinking_overrides_template_kwargs():
+    request = ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        chat_template_kwargs={"thinking": False},
+        thinking={"type": "enabled"},
+    )
+
+    chat_params = request.build_chat_params(
+        default_template=None,
+        default_template_content_format="auto",
+    )
+
+    assert chat_params.chat_template_kwargs["thinking"] is True
+
+
 def test_chat_completion_request_n_parameter_various_values():
     """Test n parameter with various values."""
     for n_value in [1, 2, 5, 10]:

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -147,6 +147,10 @@ class ChatCompletionNamedToolChoiceParam(OpenAIBaseModel):
     type: Literal["function"] = "function"
 
 
+class ChatCompletionThinkingParam(OpenAIBaseModel):
+    type: Literal["enabled", "disabled"]
+
+
 class ChatCompletionRequest(OpenAIBaseModel):
     # Ordered by official OpenAI API documentation
     # https://platform.openai.com/docs/api-reference/chat/create
@@ -265,6 +269,13 @@ class ChatCompletionRequest(OpenAIBaseModel):
         description=(
             "Additional keyword args to pass to the template renderer. "
             "Will be accessible by the chat template."
+        ),
+    )
+    thinking: ChatCompletionThinkingParam | None = Field(
+        default=None,
+        description=(
+            "Controls thinking mode for DeepSeek V4-style chat templates. "
+            "When set, this is mapped to the `thinking` chat template kwarg."
         ),
     )
     media_io_kwargs: dict[str, dict[str, Any]] | None = Field(
@@ -416,6 +427,9 @@ class ChatCompletionRequest(OpenAIBaseModel):
                     continue_final_message=self.continue_final_message,
                     documents=self.documents,
                     reasoning_effort=self.reasoning_effort,
+                    thinking=None
+                    if self.thinking is None
+                    else self.thinking.type == "enabled",
                 ),
             ),
             media_io_kwargs=self.media_io_kwargs,


### PR DESCRIPTION
## Purpose

Support DeepSeek-style top-level `thinking` controls in Chat Completions requests.

DeepSeek V4 documents thinking mode as:

```json
"thinking": { "type": "enabled" }
```

This PR accepts that top-level request shape and maps it into the existing renderer-facing `chat_template_kwargs["thinking"]` boolean:

- `{"type": "enabled"}` -> `thinking=True`
- `{"type": "disabled"}` -> `thinking=False`

Existing `chat_template_kwargs.thinking` and `chat_template_kwargs.enable_thinking` remain supported. If top-level `thinking` is provided, it takes precedence for the `thinking` kwarg.

----

Actually, I'm a bit unsure whether it's a good idea to include this model-specific field in the schema/docs, but given that DeepSeek will definitely be very popular in the future, it might be valuable to align with the official API.

## Test Plan

- Add request protocol tests for top-level `thinking` mapping.
- Cover both enabled and disabled values.
- Verify existing `chat_template_kwargs.thinking` and `chat_template_kwargs.enable_thinking` are preserved when top-level `thinking` is omitted.
- Verify top-level `thinking` overrides `chat_template_kwargs["thinking"]`.

## Test Result

```text
.venv/bin/python -m pytest tests/entrypoints/openai/chat_completion/test_chat.py::test_chat_completion_request_maps_top_level_thinking_to_template_kwargs tests/entrypoints/openai/chat_completion/test_chat.py::test_chat_completion_request_preserves_existing_thinking_template_kwargs tests/entrypoints/openai/chat_completion/test_chat.py::test_chat_completion_request_top_level_thinking_overrides_template_kwargs
.venv/bin/ruff check vllm/entrypoints/openai/chat_completion/protocol.py tests/entrypoints/openai/chat_completion/test_chat.py
.venv/bin/python -m py_compile vllm/entrypoints/openai/chat_completion/protocol.py
pre-commit hooks from git commit
```
