### PR TITLE
[Bugfix] Fix Deepseek V4 import error due to AOT compile cache loading

### DIFF
--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -1100,8 +1100,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         super().__init__()
 
         # Lazy import to avoid top-level tilelang dependency.
-        # Registers both torch.ops.vllm.mhc_pre and mhc_post,
-        # so hc_post() doesn't need its own import.
+        # Registers both torch.ops.vllm.mhc_pre and mhc_post
         import vllm.model_executor.layers.mhc  # noqa: F401
 
         config = vllm_config.model_config.hf_config

--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -1098,6 +1098,12 @@ class DeepseekV4DecoderLayer(nn.Module):
         aux_stream_dict: dict[AuxStreamType, torch.cuda.Stream] | None = None,
     ):
         super().__init__()
+
+        # Lazy import to avoid top-level tilelang dependency.
+        # Registers both torch.ops.vllm.mhc_pre and mhc_post,
+        # so hc_post() doesn't need its own import.
+        import vllm.model_executor.layers.mhc  # noqa: F401
+
         config = vllm_config.model_config.hf_config
         self.hidden_size = config.hidden_size
 
@@ -1170,11 +1176,6 @@ class DeepseekV4DecoderLayer(nn.Module):
         hc_scale: torch.Tensor,
         hc_base: torch.Tensor,
     ):
-        # Lazy import to avoid top-level tilelang dependency.
-        # Registers both torch.ops.vllm.mhc_pre and mhc_post,
-        # so hc_post() doesn't need its own import.
-        import vllm.model_executor.layers.mhc  # noqa: F401
-
         post_mix, res_mix, layer_input = torch.ops.vllm.mhc_pre(
             residual=x,
             fn=hc_fn,


### PR DESCRIPTION
## Purpose
Fix issue when starting deepseek v4 server:
```
 INFO 04-27 20:34:54 [caching.py:333] reconstructed serializable fn from standalone compile artifacts. num_artifacts=124 num_submods=62
 INFO 04-27 20:34:54 [decorators.py:305] Directly load AOT compilation from path /.cache/vllm/torch_compile_cache/torch_aot_compile/598e745eaf2c70ad8e573439d40e36b6d1dea587716fab7b69c496f00f2579ba/rank_0_0/model
 INFO 04-27 20:34:54 [monitor.py:53] torch.compile took 4.10 s in total
 INFO 04-27 20:34:54 [caching.py:333] reconstructed serializable fn from standalone compile artifacts. num_artifacts=124 num_submods=62
 INFO 04-27 20:34:54 [caching.py:333] reconstructed serializable fn from standalone compile artifacts. num_artifacts=124 num_submods=62
 INFO 04-27 20:34:54 [caching.py:333] reconstructed serializable fn from standalone compile artifacts. num_artifacts=124 num_submods=62
 ERROR 04-27 20:34:54 [multiproc_executor.py:962] WorkerProc hit an exception.
 ERROR 04-27 20:34:54 [multiproc_executor.py:962] Traceback (most recent call last):
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]   File "/vllm/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 2465, in __call__
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]     return self.compiled_fn(*args, **kwargs)
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]   File "/vllm/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 852, in runtime_wrapper
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]     all_outs = compiled_invoker.run(args, on_before_call=exit_prologue)
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]   File "/vllm/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 523, in run
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]     return call_func_at_runtime_with_args(
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]   File "/vllm/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/utils.py", line 126, in call_func_at_runtime_with_args
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]     out = normalize_as_list(f(args))
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]                             ^^^^^^^
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]   File "/vllm/.venv/lib/python3.12/site-packages/torch/_functorch/_aot_autograd/runtime_wrappers.py", line 925, in wrapper
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]     return compiled_fn(runtime_args)
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]   File "/vllm/.venv/lib/python3.12/site-packages/torch/_inductor/output_code.py", line 725, in __call__
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]     return self.current_callable(inputs)
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]   File "/.cache/vllm/torch_compile_cache/torch_aot_compile/598e745eaf2c70ad8e573439d40e36b6d1dea587716fab7b69c496f00f2579ba/inductor_cache/oq/coq5zrulh4ay2wch4tje7dbn4x366rdju345ywelbgrb7tbajecg.py", line 558, in call
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]     buf4 = torch.ops.vllm.mhc_pre.default(buf3, arg3_1, arg4_1, arg5_1, 1e-06, 1e-06, 1e-06, 2.0, 20, n_splits=1)
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]            ^^^^^^^^^^^^^^^^^^^^^^
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]   File "/vllm/.venv/lib/python3.12/site-packages/torch/_ops.py", line 1385, in __getattr__
 ERROR 04-27 20:34:54 [multiproc_executor.py:962]     raise AttributeError(
 ERROR 04-27 20:34:54 [multiproc_executor.py:962] AttributeError: '_OpNamespace' 'vllm' object has no attribute 'mhc_pre'
```

This happens when starting the server the second time, where it directly loads the model forward function from AOT compilation cache. In this case, the model does not run through the normal eager path, thus fails to lazily import the module.

This PR fixes this by moving the import to model init code.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

