### PR TITLE
[ROCm] Add AITER fused dual RMSNorm for MLA

### DIFF
--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -846,61 +846,55 @@ def _rocm_aiter_rmsnorm_with_add_fp8_group_quant_fake(
     )
 
 
-def _rocm_aiter_mla_dual_rmsnorm_fp8_group_quant_impl(
+def _rocm_aiter_mla_dual_rmsnorm_impl(
     q_c: torch.Tensor,
     q_a_layernorm_weight: torch.Tensor,
     q_a_layernorm_variance_epsilon: float,
     kv_c: torch.Tensor,
     kv_a_layernorm_weight: torch.Tensor,
     kv_a_layernorm_variance_epsilon: float,
-    group_size: int,
-    transpose_scale: bool,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Fused dual RMSNorm for MLA.
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Fused dual RMSNorm for MLA using aiter's fused_qk_rmsnorm.
 
-    Fuses RMSNorm on q_c and kv_c. Returns unquantized BF16 outputs to allow
-    Linear layers to choose optimal quantization strategy and avoid forcing
-    block-scaled GEMM.
+    Fuses RMSNorm on q_c and kv_c into a single kernel call. Returns BF16
+    outputs, ~2× faster than separate RMS norms.
+
+    Uses aiter.ops.fused_qk_norm_rope_cache_quant.fused_qk_rmsnorm which is
+    optimized for dual RMS norm with 2D grid parallelization and automatic
+    fallback to separate norms for very large batch sizes (≥16384 tokens).
 
     Returns:
-        (q_c_normed, None, kv_c_normed)
+        (q_c_normed, kv_c_normed): Both BF16 tensors after RMSNorm
     """
-    from aiter.ops.triton.fused_fp8_quant import fused_rms_fp8_group_quant
+    from aiter.ops.fused_qk_norm_rope_cache_quant import fused_qk_rmsnorm
 
-    _, q_c_normed, kv_c_normed, _ = fused_rms_fp8_group_quant(
+    q_c_normed, kv_c_normed = fused_qk_rmsnorm(
         q_c,
         q_a_layernorm_weight,
         q_a_layernorm_variance_epsilon,
         kv_c,
         kv_a_layernorm_weight,
         kv_a_layernorm_variance_epsilon,
-        group_size,
-        FP8_DTYPE,
-        None,
-        True,  # output_unquantized_inp1 - return BF16 instead of FP8
-        transpose_scale,
     )
-    return q_c_normed, None, kv_c_normed
+    return q_c_normed, kv_c_normed
 
 
-def _rocm_aiter_mla_dual_rmsnorm_fp8_group_quant_fake(
+def _rocm_aiter_mla_dual_rmsnorm_fake(
     q_c: torch.Tensor,
     q_a_layernorm_weight: torch.Tensor,
     q_a_layernorm_variance_epsilon: float,
     kv_c: torch.Tensor,
     kv_a_layernorm_weight: torch.Tensor,
     kv_a_layernorm_variance_epsilon: float,
-    group_size: int,
-    transpose_scale: bool,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor]:
     """Fake implementation for torch.compile/CUDA graphs.
 
-    Returns unquantized BF16 outputs (just RMSNorm) to match real implementation.
+    Returns BF16 outputs (just RMSNorm) to match real implementation.
     """
-    # Return BF16 RMSNorm outputs, no quantization or scales
+    # Return BF16 RMSNorm outputs
     out1_normed = torch.empty_like(q_c)  # BF16 q_c after RMSNorm
     out2_normed = torch.empty_like(kv_c)  # BF16 kv_c after RMSNorm
-    return out1_normed, None, out2_normed
+    return out1_normed, out2_normed
 
 
 def _rocm_aiter_rmsnorm_fp8_group_quant_impl(
@@ -1545,9 +1539,9 @@ class rocm_aiter_ops:
             )
 
             direct_register_custom_op(
-                op_name="rocm_aiter_mla_dual_rmsnorm_fp8_group_quant",
-                op_func=_rocm_aiter_mla_dual_rmsnorm_fp8_group_quant_impl,
-                fake_impl=_rocm_aiter_mla_dual_rmsnorm_fp8_group_quant_fake,
+                op_name="rocm_aiter_mla_dual_rmsnorm",
+                op_func=_rocm_aiter_mla_dual_rmsnorm_impl,
+                fake_impl=_rocm_aiter_mla_dual_rmsnorm_fake,
             )
 
             direct_register_custom_op(
@@ -1642,8 +1636,8 @@ class rocm_aiter_ops:
         return torch.ops.vllm.rocm_aiter_rmsnorm_with_add_fp8_group_quant.default
 
     @staticmethod
-    def get_mla_dual_rmsnorm_fp8_group_quant_op() -> OpOverload:
-        return torch.ops.vllm.rocm_aiter_mla_dual_rmsnorm_fp8_group_quant.default
+    def get_mla_dual_rmsnorm_op() -> OpOverload:
+        return torch.ops.vllm.rocm_aiter_mla_dual_rmsnorm.default
 
     @staticmethod
     def get_per_token_quant_op() -> OpOverload:

--- a/vllm/_aiter_ops.py
+++ b/vllm/_aiter_ops.py
@@ -846,6 +846,63 @@ def _rocm_aiter_rmsnorm_with_add_fp8_group_quant_fake(
     )
 
 
+def _rocm_aiter_mla_dual_rmsnorm_fp8_group_quant_impl(
+    q_c: torch.Tensor,
+    q_a_layernorm_weight: torch.Tensor,
+    q_a_layernorm_variance_epsilon: float,
+    kv_c: torch.Tensor,
+    kv_a_layernorm_weight: torch.Tensor,
+    kv_a_layernorm_variance_epsilon: float,
+    group_size: int,
+    transpose_scale: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fused dual RMSNorm for MLA.
+
+    Fuses RMSNorm on q_c and kv_c. Returns unquantized BF16 outputs to allow
+    Linear layers to choose optimal quantization strategy and avoid forcing
+    block-scaled GEMM.
+
+    Returns:
+        (q_c_normed, None, kv_c_normed)
+    """
+    from aiter.ops.triton.fused_fp8_quant import fused_rms_fp8_group_quant
+
+    _, q_c_normed, kv_c_normed, _ = fused_rms_fp8_group_quant(
+        q_c,
+        q_a_layernorm_weight,
+        q_a_layernorm_variance_epsilon,
+        kv_c,
+        kv_a_layernorm_weight,
+        kv_a_layernorm_variance_epsilon,
+        group_size,
+        FP8_DTYPE,
+        None,
+        True,  # output_unquantized_inp1 - return BF16 instead of FP8
+        transpose_scale,
+    )
+    return q_c_normed, None, kv_c_normed
+
+
+def _rocm_aiter_mla_dual_rmsnorm_fp8_group_quant_fake(
+    q_c: torch.Tensor,
+    q_a_layernorm_weight: torch.Tensor,
+    q_a_layernorm_variance_epsilon: float,
+    kv_c: torch.Tensor,
+    kv_a_layernorm_weight: torch.Tensor,
+    kv_a_layernorm_variance_epsilon: float,
+    group_size: int,
+    transpose_scale: bool,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Fake implementation for torch.compile/CUDA graphs.
+
+    Returns unquantized BF16 outputs (just RMSNorm) to match real implementation.
+    """
+    # Return BF16 RMSNorm outputs, no quantization or scales
+    out1_normed = torch.empty_like(q_c)  # BF16 q_c after RMSNorm
+    out2_normed = torch.empty_like(kv_c)  # BF16 kv_c after RMSNorm
+    return out1_normed, None, out2_normed
+
+
 def _rocm_aiter_rmsnorm_fp8_group_quant_impl(
     x: torch.Tensor,
     weight: torch.Tensor,
@@ -1488,6 +1545,12 @@ class rocm_aiter_ops:
             )
 
             direct_register_custom_op(
+                op_name="rocm_aiter_mla_dual_rmsnorm_fp8_group_quant",
+                op_func=_rocm_aiter_mla_dual_rmsnorm_fp8_group_quant_impl,
+                fake_impl=_rocm_aiter_mla_dual_rmsnorm_fp8_group_quant_fake,
+            )
+
+            direct_register_custom_op(
                 op_name="rocm_aiter_act_mul_and_fp8_group_quant",
                 op_func=_rocm_aiter_act_mul_and_fp8_group_quant_impl,
                 fake_impl=_rocm_aiter_act_mul_and_fp8_group_quant_fake,
@@ -1577,6 +1640,10 @@ class rocm_aiter_ops:
     @staticmethod
     def get_rmsnorm_group_add_fused_quant_op() -> OpOverload:
         return torch.ops.vllm.rocm_aiter_rmsnorm_with_add_fp8_group_quant.default
+
+    @staticmethod
+    def get_mla_dual_rmsnorm_fp8_group_quant_op() -> OpOverload:
+        return torch.ops.vllm.rocm_aiter_mla_dual_rmsnorm_fp8_group_quant.default
 
     @staticmethod
     def get_per_token_quant_op() -> OpOverload:

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -5,9 +5,21 @@ from dataclasses import dataclass
 import torch
 
 from vllm.config import CacheConfig
+from vllm.logger import init_logger
 from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.attention import MLAAttention
 from vllm.model_executor.layers.quantization import QuantizationConfig
+
+logger = init_logger(__name__)
+
+# Check if AITER ops are available
+try:
+    from vllm._aiter_ops import rocm_aiter_ops
+
+    _AITER_AVAILABLE = rocm_aiter_ops.is_linear_fp8_enabled()
+except ImportError:
+    _AITER_AVAILABLE = False
+    rocm_aiter_ops = None
 
 
 @dataclass
@@ -64,6 +76,7 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        fp8_group_size: int = 128,
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -110,6 +123,26 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
 
         self.prefix = prefix
 
+        # Enable RMSNorm+Quant fusion when AITER is available with FP8
+        self.quant_config = quant_config
+        self.quant_dtype = None
+        self.fuse_qknorm_quant = False
+        self.fp8_group_size = fp8_group_size
+
+        if _AITER_AVAILABLE and quant_config is not None:
+            from vllm.model_executor.layers.quantization.fp8 import Fp8Config
+            from vllm.platforms import current_platform
+
+            if isinstance(quant_config, Fp8Config):
+                self.quant_dtype = current_platform.fp8_dtype()
+                self.fuse_qknorm_quant = True
+                logger.info(
+                    "[MLA_FUSION_INIT] Fusion enabled for %s: "
+                    "AITER available and FP8 quantization detected (group_size=%d)",
+                    prefix,
+                    self.fp8_group_size,
+                )
+
     def forward(
         self,
         positions: torch.Tensor,
@@ -130,13 +163,40 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
                 "q_b_proj is required when q_lora_rank is not None"
             )
 
+            # Step 1: QKV projection (use existing layer)
             qkv_lora = self.fused_qkv_a_proj(hidden_states)[0]
             q_c, kv_lora = qkv_lora.split(
                 [self.q_lora_rank, self.kv_lora_rank + self.qk_rope_head_dim],
                 dim=-1,
             )
-            q_c = self.q_a_layernorm(q_c)
-            q = self.q_b_proj(q_c)[0]
+            kv_c, k_pe = kv_lora.split(
+                [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+            )
+
+            # Step 2: Apply RMSNorm (fused if available)
+            if self.fuse_qknorm_quant:
+                # Fused dual RMSNorm using AITER op
+                # Returns BF16 to allow Linear layer to choose optimal quantization
+                mla_dual_quant_op = (
+                    rocm_aiter_ops.get_mla_dual_rmsnorm_fp8_group_quant_op()
+                )
+                q_c_normed, _, kv_c_normed = mla_dual_quant_op(
+                    q_c,
+                    self.q_a_layernorm.weight,
+                    self.q_a_layernorm.variance_epsilon,
+                    kv_c,
+                    self.kv_a_layernorm.weight,
+                    self.kv_a_layernorm.variance_epsilon,
+                    self.fp8_group_size,
+                    False,  # transpose_scale (unused when returning BF16)
+                )
+                # q_c_normed is BF16, same as unfused path below
+                q = self.q_b_proj(q_c_normed)[0]
+            else:
+                # Unfused path: RMSNorm only
+                q_c = self.q_a_layernorm(q_c)
+                kv_c_normed = self.kv_a_layernorm(kv_c)
+                q = self.q_b_proj(q_c)[0]
         else:
             assert self.kv_a_proj_with_mqa is not None, (
                 "kv_a_proj_with_mqa is required when q_lora_rank is None"
@@ -146,9 +206,10 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
             )
             kv_lora = self.kv_a_proj_with_mqa(hidden_states)[0]
             q = self.q_proj(hidden_states)[0]
-
-        kv_c, k_pe = kv_lora.split([self.kv_lora_rank, self.qk_rope_head_dim], dim=-1)
-        kv_c_normed = self.kv_a_layernorm(kv_c)
+            kv_c, k_pe = kv_lora.split(
+                [self.kv_lora_rank, self.qk_rope_head_dim], dim=-1
+            )
+            kv_c_normed = self.kv_a_layernorm(kv_c)
 
         q = q.view(-1, self.num_heads, self.qk_head_dim)
         # Add head dim of 1 to k_pe

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -76,7 +76,6 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
-        fp8_group_size: int = 128,
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -123,24 +122,18 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
 
         self.prefix = prefix
 
-        # Enable RMSNorm+Quant fusion when AITER is available with FP8
-        self.quant_config = quant_config
-        self.quant_dtype = None
-        self.fuse_qknorm_quant = False
-        self.fp8_group_size = fp8_group_size
+        # Enable dual RMSNorm fusion when AITER is available
+        self.fuse_dual_rmsnorm = False
 
-        if _AITER_AVAILABLE and quant_config is not None:
-            from vllm.model_executor.layers.quantization.fp8 import Fp8Config
-            from vllm.platforms import current_platform
+        if _AITER_AVAILABLE:
+            from vllm._aiter_ops import check_aiter_fused_qk_rmsnorm
 
-            if isinstance(quant_config, Fp8Config):
-                self.quant_dtype = current_platform.fp8_dtype()
-                self.fuse_qknorm_quant = True
+            if check_aiter_fused_qk_rmsnorm():
+                self.fuse_dual_rmsnorm = True
                 logger.info(
-                    "[MLA_FUSION_INIT] Fusion enabled for %s: "
-                    "AITER available and FP8 quantization detected (group_size=%d)",
+                    "[MLA_FUSION_INIT] Dual RMSNorm fusion enabled for %s: "
+                    "Using aiter.fused_qk_rmsnorm (2× faster than separate norms)",
                     prefix,
-                    self.fp8_group_size,
                 )
 
     def forward(
@@ -174,26 +167,22 @@ class MultiHeadLatentAttentionWrapper(PluggableLayer):
             )
 
             # Step 2: Apply RMSNorm (fused if available)
-            if self.fuse_qknorm_quant:
-                # Fused dual RMSNorm using AITER op
-                # Returns BF16 to allow Linear layer to choose optimal quantization
-                mla_dual_quant_op = (
-                    rocm_aiter_ops.get_mla_dual_rmsnorm_fp8_group_quant_op()
-                )
-                q_c_normed, _, kv_c_normed = mla_dual_quant_op(
+            if self.fuse_dual_rmsnorm:
+                # Fused dual RMSNorm using AITER op (2× faster than separate)
+                # Returns BF16 outputs, same as unfused path
+                mla_dual_rmsnorm_op = rocm_aiter_ops.get_mla_dual_rmsnorm_op()
+                q_c_normed, kv_c_normed = mla_dual_rmsnorm_op(
                     q_c,
                     self.q_a_layernorm.weight,
                     self.q_a_layernorm.variance_epsilon,
                     kv_c,
                     self.kv_a_layernorm.weight,
                     self.kv_a_layernorm.variance_epsilon,
-                    self.fp8_group_size,
-                    False,  # transpose_scale (unused when returning BF16)
                 )
                 # q_c_normed is BF16, same as unfused path below
                 q = self.q_b_proj(q_c_normed)[0]
             else:
-                # Unfused path: RMSNorm only
+                # Unfused path: Separate RMSNorm calls
                 q_c = self.q_a_layernorm(q_c)
                 kv_c_normed = self.kv_a_layernorm(kv_c)
                 q = self.q_b_proj(q_c)[0]

--- a/vllm/model_executor/layers/mla.py
+++ b/vllm/model_executor/layers/mla.py
@@ -12,11 +12,11 @@ from vllm.model_executor.layers.quantization import QuantizationConfig
 
 logger = init_logger(__name__)
 
-# Check if AITER ops are available
+# Check if AITER RMSNorm ops are available
 try:
     from vllm._aiter_ops import rocm_aiter_ops
 
-    _AITER_AVAILABLE = rocm_aiter_ops.is_linear_fp8_enabled()
+    _AITER_AVAILABLE = rocm_aiter_ops.is_rmsnorm_enabled()
 except ImportError:
     _AITER_AVAILABLE = False
     rocm_aiter_ops = None


### PR DESCRIPTION
## Summary

This PR adds AITER's fused dual RMSNorm kernel for DeepSeek MLA models on AMD ROCm.

- **Fused Dual RMSNorm**: Uses AITER's `fused_qk_rmsnorm` to combine Q and KV RMSNorm operations in a single kernel
- **BF16 Output**: Returns unquantized BF16 tensors to preserve downstream quantization flexibility

### Accuracy Testing
Verified on GSM8K benchmark:
```bash
export VLLM_ROCM_USE_AITER=1
export HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7

lm_eval \
  --model vllm \
  --model_args "pretrained=deepseek-ai/DeepSeek-V3,tensor_parallel_size=8,max_model_len=8192,max_num_batched_tokens=131072,gpu_memory_utilization=0.9,dtype=bfloat16,kv_cache_dtype=fp8,trust_remote_code=true" \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size auto \
  --limit 500
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.934|±  |0.0111|
|     |       |strict-match    |     5|exact_match|↑  |0.934|±  |0.0111|


### Performance

**Output Token Throughput (tok/s)**

| Version      |    1 RPS |    3 RPS |   10 RPS |   20 RPS |   50 RPS |  inf RPS |
|--------------|----------|----------|----------|----------|----------|----------|
| vLLM Main    |   944.14 |  2172.84 |  3574.87 |  4160.66 |  4663.24 |  4946.94 |
| vLLM RMSNorm |   939.34 |  2142.75 |  3534.06 |  4140.91 |  4654.78 |  4942.26 |

**Total Token Throughput (tok/s)**

| Version      |    1 RPS |    3 RPS |   10 RPS |   20 RPS |   50 RPS |  inf RPS |
|--------------|----------|----------|----------|----------|----------|----------|
| vLLM Main    |  1888.29 |  4345.67 |  7149.73 |  8321.32 |  9326.57 |  9893.88 |
| vLLM RMSNorm |  1878.69 |  4285.49 |  7068.12 |  8281.81 |  9309.55 |  9884.52 |

**Time to First Token - Mean (ms)**

| Version      |  1 RPS |  3 RPS | 10 RPS | 20 RPS | 50 RPS | inf RPS |
|--------------|--------|--------|--------|--------|--------|---------|
| vLLM Main    | 164.72 | 137.51 | 177.05 | 224.57 | 281.14 | 1440.02 |
| vLLM RMSNorm | 176.35 | 179.48 | 209.91 | 238.33 | 278.93 | 1323.77 |

**Time Per Output Token - Mean (ms)**

| Version      | 1 RPS | 3 RPS | 10 RPS | 20 RPS | 50 RPS | inf RPS |
|--------------|-------|-------|--------|--------|--------|---------|
| vLLM Main    | 27.91 | 41.11 |  50.70 |  52.01 |  51.24 |   50.31 |
| vLLM RMSNorm | 29.43 | 45.53 |  52.77 |  52.54 |  51.29 |   50.47 |

**Inter-token Latency - Mean (ms)**

| Version      | 1 RPS | 3 RPS | 10 RPS | 20 RPS | 50 RPS | inf RPS |
|--------------|-------|-------|--------|--------|--------|---------|
| vLLM Main    | 27.91 | 41.11 |  50.70 |  52.01 |  51.24 |   50.31 |
| vLLM RMSNorm | 29.43 | 45.53 |  52.77 |  52.54 |  51.29 |   50.47 |


