### PR TITLE
[Bugfix] Raise clear error when --enable-eplb on non-EPLB model

### DIFF
--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -311,6 +311,19 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         )
         self.eplb.maybe_start_async_loop(eplb_models_added)
 
+        if (
+            self.parallel_config.enable_eplb
+            and not load_dummy_weights
+            and not eplb_models_added
+        ):
+            raise ValueError(
+                "--enable-eplb was requested, but no loaded model "
+                "implements the MixtureOfExperts interface required "
+                f"by EPLB (main model: {type(self.model).__name__}). "
+                "Either remove --enable-eplb, or use a MoE model "
+                "whose vLLM implementation supports EPLB."
+            )
+
         if not self.is_first_pp_rank:
             # For non-first PP ranks, create intermediate tensors sized
             # for the max capture size so they can be sliced per batch.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4863,6 +4863,19 @@ class GPUModelRunner(
                     )
                     eplb_models += 1
 
+                if (
+                    self.parallel_config.enable_eplb
+                    and not load_dummy_weights
+                    and eplb_models == 0
+                ):
+                    raise ValueError(
+                        "--enable-eplb was requested, but no loaded model "
+                        "implements the MixtureOfExperts interface required "
+                        f"by EPLB (main model: {type(self.model).__name__}). "
+                        "Either remove --enable-eplb, or use a MoE model "
+                        "whose vLLM implementation supports EPLB."
+                    )
+
                 time_after_load = time.perf_counter()
             self.model_memory_usage = m.consumed_memory
         except torch.cuda.OutOfMemoryError as e:


### PR DESCRIPTION
Fixes #40740.

## Summary

When users pass `--enable-eplb` with a model whose vLLM implementation does not implement the `MixtureOfExperts` interface, the worker silently registers no models for EPLB and only crashes later via a bare `AssertionError` in `eplb_step()` at `gpu_model_runner.py:3103`. The reporter confirmed this affects at least three model families:

- `microsoft/Phi-mini-MoE-instruct` (`PhiMoEForCausalLM`)
- `Qwen/Qwen1.5-MoE-A2.7B-Chat`
- `ModelCloud/DeepSeek-V2-Lite-gptq-4bit`

## Fix

Validate at model-load time in both runners (`gpu_model_runner.py` and `gpu/model_runner.py`) and raise a `ValueError` that names the offending model class and tells the user how to recover:

```
--enable-eplb was requested, but no loaded model implements the
MixtureOfExperts interface required by EPLB (main model: PhiMoEForCausalLM).
Either remove --enable-eplb, or use a MoE model whose vLLM implementation
supports EPLB.
```

## Reproduction

```
vllm serve microsoft/Phi-mini-MoE-instruct --enable-expert-parallel \
  --tensor-parallel-size 2 --data-parallel-size 1 \
  --gpu-memory-utilization 0.85 --max-model-len 1024 --enable-eplb
```

Before: `AssertionError` at runtime in `eplb_step()`.
After: clear `ValueError` at startup naming the model and the fix.