### PR TITLE
[Misc] Deprecate `VLLM_NIXL_ABORT_REQUEST_TIMEOUT`

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/scheduler.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Scheduler-side logic for the NIXL connector."""
 
+import os
 import threading
 import time
 from typing import TYPE_CHECKING, Any
@@ -87,6 +88,12 @@ class NixlConnectorScheduler:
         logger.info("Initializing NIXL Scheduler %s", engine_id)
         if vllm_config.scheduler_config.disable_hybrid_kv_cache_manager:
             logger.info("Hybrid Memory Allocator is enabled with NIXL")
+
+        if os.environ.get("VLLM_NIXL_ABORT_REQUEST_TIMEOUT") is not None:
+            logger.warning(
+                "VLLM_NIXL_ABORT_REQUEST_TIMEOUT is deprecated and will be "
+                "removed in release 0.21.0."
+            )
 
         # Background thread for handling new handshake requests.
         self._nixl_handshake_listener_t: threading.Thread | None = None

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/scheduler.py
@@ -92,7 +92,7 @@ class NixlConnectorScheduler:
         if os.environ.get("VLLM_NIXL_ABORT_REQUEST_TIMEOUT") is not None:
             logger.warning(
                 "VLLM_NIXL_ABORT_REQUEST_TIMEOUT is deprecated and will be "
-                "removed in release 0.21.0."
+                "removed in release 0.22.0."
             )
 
         # Background thread for handling new handshake requests.


### PR DESCRIPTION
This timeout mechanism is set to be deprecated and replaced by a more elaborate lease TTL solution https://docs.google.com/document/d/1i-O6kqY7WfF1lPyyftRpCQt5fwnFYIEDZKCxyB51Sjg/edit?usp=sharing
