### PR TITLE
[Bugfix] Fix nixl installation on CU12 images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -777,8 +777,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
                 libcublas-dev-${CUDA_VERSION_DASH} \
                 libcusolver-dev-${CUDA_VERSION_DASH}"; \
     if [ "$INSTALL_KV_CONNECTORS" = "true" ]; then \
-        if [ "$CUDA_MAJOR" -ge 13 ]; then \
-            uv pip install --system nixl-cu13; \
+        # nixl metapackage ships with default nixl-cu12 (nixl<1.1.0). Explicitly strip nixl-cu13 
+        # from the requirements on non-cu13 images to prevent it from shadowing the correct cu12 one.
+        if [ "$(echo $CUDA_VERSION | cut -d. -f1)" != "13" ]; then \
+            sed -i '/^nixl-cu13/d' /tmp/kv_connectors.txt; \
         fi; \
         uv pip install --system -r /tmp/kv_connectors.txt --no-build || ( \
             # if the above fails, install from source

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -779,7 +779,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     if [ "$INSTALL_KV_CONNECTORS" = "true" ]; then \
         # nixl metapackage ships with default nixl-cu12 (nixl<1.1.0). Explicitly strip nixl-cu13 
         # from the requirements on non-cu13 images to prevent it from shadowing the correct cu12 one.
-        if [ "$(echo $CUDA_VERSION | cut -d. -f1)" != "13" ]; then \
+        if [ "$CUDA_MAJOR" -lt 13 ]; then \
             sed -i '/^nixl-cu13/d' /tmp/kv_connectors.txt; \
         fi; \
         uv pip install --system -r /tmp/kv_connectors.txt --no-build || ( \


### PR DESCRIPTION
Fix https://github.com/vllm-project/vllm/issues/41048 by avoiding installation of nixl-cu13 on CU12 systems.
More context here https://github.com/vllm-project/vllm/issues/36676.

cc @robertgshaw2-redhat @ovidiusm @cjackal
