### PR TITLE
[Bugfix] Fix missing format argument in tensor IPC stale tensor warning

### DIFF
--- a/vllm/v1/engine/tensor_ipc.py
+++ b/vllm/v1/engine/tensor_ipc.py
@@ -147,9 +147,11 @@ class TensorIpcReceiver:
                 if tensor is not None:
                     if sender.current_message_id != message_id:
                         while tensors and (mid := next(iter(tensors))) < message_id:
-                            if sender.tensors.pop(mid):
+                            stale = sender.tensors.pop(mid)
+                            if stale:
                                 logger.warning(
                                     "Discarding %d stale tensors from sender %s",
+                                    len(stale),
                                     sender_id,
                                 )
                         sender.current_message_id = message_id


### PR DESCRIPTION
The logger.warning call in TensorIpcReceiver had two format placeholders (%d and %s) but only one argument (sender_id), causing a TypeError when stale tensors are discarded. Capture the popped dict and pass len(stale) as the missing count argument.



## Purpose

Fix a missing format argument in `TensorIpcReceiver.__call__()` that causes a `TypeError` when stale tensors are discarded during tensor IPC.

The `logger.warning("Discarding %d stale tensors from sender %s", sender_id)` had two format placeholders (`%d` and `%s`) but only one argument (`sender_id`). When this code path is hit, Python's logging module raises `TypeError: %d format: a real number is required, not str`, and the warning is never properly logged.

**Fix**: capture the return value of `sender.tensors.pop(mid)` and pass `len(stale)` as the missing count argument.

## Test Plan

The actual bug is in `vllm/v1/engine/tensor_ipc.py:151`:

```python
logger.warning("Discarding %d stale tensors from sender %s", sender_id)
```

This is a non-hot warning branch on the tensor IPC stale-tensor cleanup path (used for sharing multimodal tensors between API server and engine core), which I don't have a straightforward way to trigger end-to-end locally. However, the bug is a pure `logging`-API misuse — Python's `logging` module raises `TypeError` deterministically whenever a format string's specifier count exceeds the number of arguments, independent of the surrounding code. The minimal reproduction below uses the **same format string** and the **same argument arity pattern** (two `%` specifiers, one string argument) as the buggy line, and is therefore equivalent in behavior:

```python
import logging
logging.basicConfig(level=logging.WARNING)
logger = logging.getLogger('test')

# Before fix — TypeError (same format string + same arity as tensor_ipc.py:151):
logger.warning('Discarding %d stale tensors from sender %s', 'abc123')

# After fix — works correctly:
logger.warning('Discarding %d stale tensors from sender %s', 3, 'abc123')
```

`pre-commit run` on the changed file passed (ruff, ruff-format, typos, mypy, SPDX, etc.).

If reviewers prefer end-to-end coverage, I'm happy to add a unit test that constructs a `TensorIpcReceiver` with pre-populated stale tensors and asserts the warning logs without raising — guidance on the preferred test location welcome.

## Test Result

**Before fix:**

```
--- Logging error ---
Traceback (most recent call last):
  File "/home/xuch/anaconda3/envs/vllm-env/lib/python3.10/logging/__init__.py", line 1100, in emit
    msg = self.format(record)
  File "/home/xuch/anaconda3/envs/vllm-env/lib/python3.10/logging/__init__.py", line 943, in format
    return fmt.format(record)
  File "/home/xuch/anaconda3/envs/vllm-env/lib/python3.10/logging/__init__.py", line 678, in format
    record.message = record.getMessage()
  File "/home/xuch/anaconda3/envs/vllm-env/lib/python3.10/logging/__init__.py", line 368, in getMessage
    msg = msg % self.args
TypeError: %d format: a real number is required, not str
Call stack:
  File "<string>", line 5, in <module>
Message: 'Discarding %d stale tensors from sender %s'
Arguments: ('abc123',)
```

**After fix:**

```
WARNING:test:Discarding 3 stale tensors from sender abc123
```

---

<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

</details>

