### PR TITLE
KVConnector: Introduce bind_scheduler_context

### DIFF
--- a/tests/v1/kv_connector/unit/test_multi_connector.py
+++ b/tests/v1/kv_connector/unit/test_multi_connector.py
@@ -221,9 +221,10 @@ def test_multi_example_connector_consistency():
         )
 
     events = get_connector_events()
-    # First event is set_xfer_handshake_metadata from initialization, then
-    # get_num_new_matched_tokens and update_state_after_alloc from generate().
-    assert events["storage1-SCHEDULER"][:4] == [
+    # First events are bind_scheduler_context and set_xfer_handshake_metadata
+    # from initialization, then scheduler methods from generate().
+    assert events["storage1-SCHEDULER"][:5] == [
+        "bind_scheduler_context",
         "set_xfer_handshake_metadata",
         "get_num_new_matched_tokens 0",
         "update_state_after_alloc num_blocks=[0] 0",
@@ -241,7 +242,8 @@ def test_multi_example_connector_consistency():
         "wait_for_layer_load",
         "save_kv_layer",
     ]
-    assert events["storage2-SCHEDULER"][:4] == [
+    assert events["storage2-SCHEDULER"][:5] == [
+        "bind_scheduler_context",
         "set_xfer_handshake_metadata",
         "get_num_new_matched_tokens 0",
         "update_state_after_alloc num_blocks=[0] 0",
@@ -790,6 +792,14 @@ Options:
   1. Add delegation in MultiConnector (preferred)
   2. Add to INHERITED_OK if the base implementation works correctly
 """)
+
+
+def test_multi_connector_bind_scheduler_context(mc):
+    """Verify bind_scheduler_context is delegated to all sub-connectors."""
+    mock_ctx = MagicMock()
+    mc.bind_scheduler_context(mock_ctx)
+    for c in mc._connectors:
+        c.bind_scheduler_context.assert_called_once_with(mock_ctx)
 
 
 def test_multi_connector_prefer_cross_layer_blocks(mc):

--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -162,7 +162,7 @@ def make_scheduler(
         enable_caching=True,
         hash_block_size=BLOCK_SIZE,
     )
-    sched.bind_gpu_block_pool(gpu_block_pool)
+    sched.bind_kv_cache_state(gpu_block_pool)
 
     return SchedulerFixture(
         scheduler=sched,

--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -25,7 +25,7 @@ from vllm.v1.core.kv_cache_utils import (
     init_none_hash,
     make_block_hash_with_group_id,
 )
-from vllm.v1.core.kv_connector import KVConnectorKVCacheState
+from vllm.v1.core.kv_connector import KVConnectorSchedulerContext
 from vllm.v1.core.sched.output import (
     CachedRequestData,
     NewRequestData,
@@ -163,7 +163,7 @@ def make_scheduler(
         enable_caching=True,
         hash_block_size=BLOCK_SIZE,
     )
-    sched.bind_kv_cache_state(KVConnectorKVCacheState(gpu_block_pool))
+    sched.bind_scheduler_context(KVConnectorSchedulerContext(gpu_block_pool))
 
     return SchedulerFixture(
         scheduler=sched,

--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -25,6 +25,7 @@ from vllm.v1.core.kv_cache_utils import (
     init_none_hash,
     make_block_hash_with_group_id,
 )
+from vllm.v1.core.kv_connector import KVConnectorKVCacheState
 from vllm.v1.core.sched.output import (
     CachedRequestData,
     NewRequestData,
@@ -162,7 +163,7 @@ def make_scheduler(
         enable_caching=True,
         hash_block_size=BLOCK_SIZE,
     )
-    sched.bind_kv_cache_state(gpu_block_pool)
+    sched.bind_kv_cache_state(KVConnectorKVCacheState(gpu_block_pool))
 
     return SchedulerFixture(
         scheduler=sched,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/__init__.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/__init__.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVCacheBlock,
+    KVCacheState,
     KVConnectorBase_V1,
     KVConnectorRole,
     SupportsHMA,
@@ -11,6 +13,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.decode_bench_connector import 
 )
 
 __all__ = [
+    "KVCacheBlock",
+    "KVCacheState",
     "KVConnectorRole",
     "KVConnectorBase_V1",
     "supports_hma",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/__init__.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/__init__.py
@@ -1,10 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
-    KVCacheBlock,
-    KVCacheState,
+    KVCacheBlockView,
     KVConnectorBase_V1,
     KVConnectorRole,
+    SchedulerContext,
     SupportsHMA,
     supports_hma,
 )
@@ -13,8 +13,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.decode_bench_connector import 
 )
 
 __all__ = [
-    "KVCacheBlock",
-    "KVCacheState",
+    "KVCacheBlockView",
+    "SchedulerContext",
     "KVConnectorRole",
     "KVConnectorBase_V1",
     "supports_hma",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -163,7 +163,7 @@ class SchedulerContext(ABC):
         ...
 
     @abstractmethod
-    def iter_blocks(
+    def iter_free_blocks(
         self, after_block_id: int | None = None
     ) -> Iterator[KVCacheBlockView]:
         """Iterate over free-queue blocks in eviction (LRU) order.
@@ -175,7 +175,8 @@ class SchedulerContext(ABC):
         Args:
             after_block_id: If given, start iteration after this block
                 rather than from the head.  Useful for resuming a
-                previous scan.
+                previous scan.  If the block is no longer in the free
+                queue (ref_cnt > 0), the iterator yields nothing.
         """
         ...
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -42,8 +42,8 @@ The class provides the following primitives:
 
 import enum
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable
-from typing import TYPE_CHECKING, Any, Literal
+from collections.abc import Callable, Iterable, Iterator, Sequence
+from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 import torch
 
@@ -79,6 +79,54 @@ CopyBlocksOp = Callable[
 ]
 
 logger = init_logger(__name__)
+
+
+@runtime_checkable
+class KVCacheBlock(Protocol):
+    """Read-only view of a KV cache block exposed to connectors."""
+
+    @property
+    def block_id(self) -> int: ...
+    @property
+    def ref_cnt(self) -> int: ...
+    @property
+    def is_null(self) -> bool: ...
+    @property
+    def block_hash(self) -> bytes | None: ...
+    @property
+    def content_hash(self) -> bytes | None: ...
+    @property
+    def group_id(self) -> int | None: ...
+
+
+class KVCacheState(Protocol):
+    """Structural interface to the KV cache state for connectors.
+
+    Provides block-level operations without exposing internal data structures.
+    """
+
+    def get_block(self, block_id: int) -> KVCacheBlock:
+        """Get a read-only view of a block by ID."""
+        ...
+
+    def touch(self, blocks: Sequence[KVCacheBlock]) -> None:
+        """Increment ref_cnt for blocks, preventing eviction."""
+        ...
+
+    def free_blocks(self, ordered_blocks: Iterable[KVCacheBlock]) -> None:
+        """Decrement ref_cnt, returning blocks to free queue at 0."""
+        ...
+
+    def iter_blocks(
+        self, after_block: KVCacheBlock | None = None
+    ) -> Iterator[KVCacheBlock]:
+        """Yield free blocks in LRU order starting after the given block.
+
+        Args:
+            after_block: Resume iteration after this block, or from
+                the head if None.
+        """
+        ...
 
 
 class SupportsHMA(ABC):
@@ -445,6 +493,19 @@ class KVConnectorBase_V1(ABC):
     # ==============================
     # Scheduler-side methods
     # ==============================
+
+    def bind_kv_cache_state(self, kv_cache_state: KVCacheState) -> None:
+        """Bind the KV cache state to the connector.
+
+        Called by the scheduler after the KV cache manager is constructed.
+        Connectors that need to interact with the KV cache state should
+        override this method.
+
+        Args:
+            kv_cache_state: Provides block-level operations for the
+                connector (touch, free, iterate).
+        """
+        return
 
     @abstractmethod
     def get_num_new_matched_tokens(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -86,49 +86,96 @@ class KVCacheBlockView(Protocol):
     """Read-only view of a KV cache block exposed to connectors."""
 
     @property
-    def block_id(self) -> int: ...
+    def block_id(self) -> int:
+        """Unique integer identifier for this block."""
+        ...
+
     @property
-    def ref_cnt(self) -> int: ...
+    def ref_cnt(self) -> int:
+        """Reference count. A block with ref_cnt == 0 is in the free queue."""
+        ...
+
     @property
-    def is_null(self) -> bool: ...
+    def is_null(self) -> bool:
+        """True for the singleton null block (block_id 0, never allocatable).
+
+        Null blocks act as placeholders for positions that don't need
+        KV storage — for example, tokens that fall outside a sliding
+        window or positions occupied by non-attention layers (SSMs).
+        """
+        ...
+
     @property
-    def block_hash(self) -> bytes | None: ...
+    def block_hash(self) -> bytes | None:
+        """Hash derived from the token sequence and the KV cache group id.
+
+        Used as the key for prefix-cache lookups.  None if the block has
+        not been hashed yet (e.g. still being filled).
+        """
+        ...
+
     @property
-    def content_hash(self) -> bytes | None: ...
+    def content_hash(self) -> bytes | None:
+        """Hash derived from the token sequence only (no group id suffix).
+
+        This is the group-independent portion of ``block_hash``.  Two
+        blocks in different KV cache groups that cover the same token
+        range share the same ``content_hash`` but differ in ``block_hash``.
+        None if the block has not been hashed yet.
+        """
+        ...
+
     @property
-    def group_id(self) -> int | None: ...
+    def group_id(self) -> int | None:
+        """KV cache group this block belongs to, or None if not yet hashed."""
+        ...
 
 
 class SchedulerContext(ABC):
-    """Abstract interface to the KV cache state for connectors.
+    """Abstract interface to scheduler state for connectors.
 
-    Provides block-level operations without exposing internal data structures.
+    Provides block-level operations (inspect, touch, free, iterate)
+    without exposing internal scheduler data structures.  Bound to a
+    connector via ``KVConnectorBase_V1.bind_scheduler_context``.
     """
 
     @abstractmethod
     def get_block(self, block_id: int) -> KVCacheBlockView:
-        """Get a read-only view of a block by ID."""
+        """Return a read-only view of the block with the given id."""
         ...
 
     @abstractmethod
     def touch(self, block_ids: list[int]) -> None:
-        """Increment ref_cnt for blocks, preventing eviction."""
+        """Increment ref_cnt for the given blocks, preventing eviction.
+
+        Blocks that are touched are moved to the back of the free queue
+        so they are evicted last.
+        """
         ...
 
     @abstractmethod
     def free_blocks(self, block_ids: Iterable[int]) -> None:
-        """Decrement ref_cnt, returning blocks to free queue at 0."""
+        """Decrement ref_cnt for the given blocks.
+
+        When a block's ref_cnt reaches 0 it is returned to the free
+        queue and becomes eligible for eviction.
+        """
         ...
 
     @abstractmethod
     def iter_blocks(
         self, after_block_id: int | None = None
     ) -> Iterator[KVCacheBlockView]:
-        """Yield free blocks in LRU order starting after the given block.
+        """Iterate over free-queue blocks in eviction (LRU) order.
+
+        Yields ``KVCacheBlockView`` objects starting from the head of
+        the free queue (least-recently used).  Callers can use this to
+        scan candidate blocks for offloading or reclamation.
 
         Args:
-            after_block_id: Resume iteration after this block, or from
-                the head if None.
+            after_block_id: If given, start iteration after this block
+                rather than from the head.  Useful for resuming a
+                previous scan.
         """
         ...
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -82,7 +82,7 @@ logger = init_logger(__name__)
 
 
 @runtime_checkable
-class KVCacheBlock(Protocol):
+class KVCacheBlockView(Protocol):
     """Read-only view of a KV cache block exposed to connectors."""
 
     @property
@@ -99,14 +99,14 @@ class KVCacheBlock(Protocol):
     def group_id(self) -> int | None: ...
 
 
-class KVCacheState(ABC):
+class SchedulerContext(ABC):
     """Abstract interface to the KV cache state for connectors.
 
     Provides block-level operations without exposing internal data structures.
     """
 
     @abstractmethod
-    def get_block(self, block_id: int) -> KVCacheBlock:
+    def get_block(self, block_id: int) -> KVCacheBlockView:
         """Get a read-only view of a block by ID."""
         ...
 
@@ -121,7 +121,9 @@ class KVCacheState(ABC):
         ...
 
     @abstractmethod
-    def iter_blocks(self, after_block_id: int | None = None) -> Iterator[KVCacheBlock]:
+    def iter_blocks(
+        self, after_block_id: int | None = None
+    ) -> Iterator[KVCacheBlockView]:
         """Yield free blocks in LRU order starting after the given block.
 
         Args:
@@ -496,16 +498,22 @@ class KVConnectorBase_V1(ABC):
     # Scheduler-side methods
     # ==============================
 
-    def bind_kv_cache_state(self, kv_cache_state: KVCacheState) -> None:
-        """Bind the KV cache state to the connector.
+    def bind_scheduler_context(self, scheduler_context: SchedulerContext) -> None:
+        """Bind scheduler-side state to the connector.
 
-        Called by the scheduler after the KV cache manager is constructed.
-        Connectors that need to interact with the KV cache state should
-        override this method.
+        Called once by the scheduler after the KV cache manager is
+        initialized.  The provided ``SchedulerContext`` gives connectors
+        a controlled interface to inspect and manipulate KV cache blocks
+        (e.g. touch, free, iterate the free queue) without depending on
+        scheduler internals.
+
+        Connectors that need access to scheduler state should override
+        this method to store the reference.
 
         Args:
-            kv_cache_state: Provides block-level operations for the
-                connector (touch, free, iterate).
+            scheduler_context: Scheduler-provided context that exposes
+                block-level operations (get_block, touch, free_blocks,
+                iter_blocks).
         """
         return
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -42,7 +42,7 @@ The class provides the following primitives:
 
 import enum
 from abc import ABC, abstractmethod
-from collections.abc import Callable, Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator
 from typing import TYPE_CHECKING, Any, Literal, Protocol, runtime_checkable
 
 import torch
@@ -99,31 +99,33 @@ class KVCacheBlock(Protocol):
     def group_id(self) -> int | None: ...
 
 
-class KVCacheState(Protocol):
-    """Structural interface to the KV cache state for connectors.
+class KVCacheState(ABC):
+    """Abstract interface to the KV cache state for connectors.
 
     Provides block-level operations without exposing internal data structures.
     """
 
+    @abstractmethod
     def get_block(self, block_id: int) -> KVCacheBlock:
         """Get a read-only view of a block by ID."""
         ...
 
-    def touch(self, blocks: Sequence[KVCacheBlock]) -> None:
+    @abstractmethod
+    def touch(self, block_ids: list[int]) -> None:
         """Increment ref_cnt for blocks, preventing eviction."""
         ...
 
-    def free_blocks(self, ordered_blocks: Iterable[KVCacheBlock]) -> None:
+    @abstractmethod
+    def free_blocks(self, block_ids: Iterable[int]) -> None:
         """Decrement ref_cnt, returning blocks to free queue at 0."""
         ...
 
-    def iter_blocks(
-        self, after_block: KVCacheBlock | None = None
-    ) -> Iterator[KVCacheBlock]:
+    @abstractmethod
+    def iter_blocks(self, after_block_id: int | None = None) -> Iterator[KVCacheBlock]:
         """Yield free blocks in LRU order starting after the given block.
 
         Args:
-            after_block: Resume iteration after this block, or from
+            after_block_id: Resume iteration after this block, or from
                 the head if None.
         """
         ...

--- a/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/multi_connector.py
@@ -18,6 +18,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
     KVConnectorRole,
     KVConnectorWorkerMetadata,
+    SchedulerContext,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
     KVConnectorPromMetrics,
@@ -347,6 +348,10 @@ class MultiConnector(KVConnectorBase_V1):
     # ==============================
     # Scheduler-side methods
     # ==============================
+    def bind_scheduler_context(self, scheduler_context: SchedulerContext) -> None:
+        for c in self._connectors:
+            c.bind_scheduler_context(scheduler_context)
+
     def get_num_new_matched_tokens(
         self,
         request: "Request",

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -10,6 +10,7 @@ import torch
 from vllm.config import VllmConfig
 from vllm.distributed.kv_events import KVCacheEvent
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVCacheState,
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
@@ -31,7 +32,6 @@ from vllm.v1.simple_kv_offload.worker import (
 if TYPE_CHECKING:
     from vllm.forward_context import ForwardContext
     from vllm.v1.attention.backend import AttentionMetadata
-    from vllm.v1.core.block_pool import BlockPool
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
     from vllm.v1.kv_cache_interface import KVCacheConfig
     from vllm.v1.request import Request
@@ -165,10 +165,9 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
 
     # --- Scheduler-side methods ---
 
-    # NOTE: New API only for SimpleCPUOffloadConnector.
-    def bind_gpu_block_pool(self, gpu_block_pool: "BlockPool") -> None:
+    def bind_kv_cache_state(self, kv_cache_state: KVCacheState) -> None:
         if self.scheduler_manager is not None:
-            self.scheduler_manager.bind_gpu_block_pool(gpu_block_pool)
+            self.scheduler_manager.bind_kv_cache_state(kv_cache_state)
 
     def get_num_new_matched_tokens(
         self,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -10,10 +10,10 @@ import torch
 from vllm.config import VllmConfig
 from vllm.distributed.kv_events import KVCacheEvent
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
-    KVCacheState,
     KVConnectorBase_V1,
     KVConnectorMetadata,
     KVConnectorRole,
+    SchedulerContext,
     SupportsHMA,
 )
 from vllm.logger import init_logger
@@ -165,9 +165,9 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
 
     # --- Scheduler-side methods ---
 
-    def bind_kv_cache_state(self, kv_cache_state: KVCacheState) -> None:
+    def bind_scheduler_context(self, scheduler_context: SchedulerContext) -> None:
         if self.scheduler_manager is not None:
-            self.scheduler_manager.bind_kv_cache_state(kv_cache_state)
+            self.scheduler_manager.bind_scheduler_context(scheduler_context)
 
     def get_num_new_matched_tokens(
         self,

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Iterator, Sequence
 from typing import Any
 
 from vllm.distributed.kv_events import (
@@ -388,6 +388,10 @@ class BlockPool:
             )
         return True
 
+    def get_block(self, block_id: int) -> KVCacheBlock:
+        """Get a block by its ID."""
+        return self.blocks[block_id]
+
     def touch(self, blocks: Sequence[KVCacheBlock]) -> None:
         """Touch a block increases its reference count by 1, and may remove
         the block from the free queue. This is used when a block is hit by
@@ -420,6 +424,27 @@ class BlockPool:
         self.free_block_queue.append_n(
             [block for block in blocks_list if block.ref_cnt == 0 and not block.is_null]
         )
+
+    def iter_blocks(
+        self, after_block: KVCacheBlock | None = None
+    ) -> Iterator[KVCacheBlock]:
+        """Yield free blocks in LRU order starting after the given block.
+
+        Args:
+            after_block: Resume iteration after this block, or from
+                the head if None.
+        """
+        free_queue = self.free_block_queue
+        tail = free_queue.fake_free_list_tail
+
+        if after_block is not None:
+            node = after_block.next_free_block
+        else:
+            node = free_queue.fake_free_list_head.next_free_block
+
+        while node is not None and node is not tail:
+            yield node
+            node = node.next_free_block
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from collections.abc import Iterable, Iterator, Sequence
+from collections.abc import Iterable, Sequence
 from typing import Any
 
 from vllm.distributed.kv_events import (
@@ -388,10 +388,6 @@ class BlockPool:
             )
         return True
 
-    def get_block(self, block_id: int) -> KVCacheBlock:
-        """Get a block by its ID."""
-        return self.blocks[block_id]
-
     def touch(self, blocks: Sequence[KVCacheBlock]) -> None:
         """Touch a block increases its reference count by 1, and may remove
         the block from the free queue. This is used when a block is hit by
@@ -424,27 +420,6 @@ class BlockPool:
         self.free_block_queue.append_n(
             [block for block in blocks_list if block.ref_cnt == 0 and not block.is_null]
         )
-
-    def iter_blocks(
-        self, after_block: KVCacheBlock | None = None
-    ) -> Iterator[KVCacheBlock]:
-        """Yield free blocks in LRU order starting after the given block.
-
-        Args:
-            after_block: Resume iteration after this block, or from
-                the head if None.
-        """
-        free_queue = self.free_block_queue
-        tail = free_queue.fake_free_list_tail
-
-        if after_block is not None:
-            node = after_block.next_free_block
-        else:
-            node = free_queue.fake_free_list_head.next_free_block
-
-        while node is not None and node is not tail:
-            yield node
-            node = node.next_free_block
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -141,6 +141,20 @@ class KVCacheBlock:
         )
         self._block_hash = block_hash
 
+    @property
+    def content_hash(self) -> BlockHash | None:
+        """The block hash without the group id suffix."""
+        if self._block_hash is None:
+            return None
+        return get_block_hash(self._block_hash)
+
+    @property
+    def group_id(self) -> int | None:
+        """The KV cache group id, or None if no hash is set."""
+        if self._block_hash is None:
+            return None
+        return get_group_id(self._block_hash)
+
     def reset_hash(self):
         """Reset the block hash when the block is evicted."""
         self._block_hash = None

--- a/vllm/v1/core/kv_connector.py
+++ b/vllm/v1/core/kv_connector.py
@@ -37,7 +37,7 @@ class KVConnectorSchedulerContext(SchedulerContext):
         pool = self._block_pool
         pool.free_blocks(pool.blocks[bid] for bid in block_ids)
 
-    def iter_blocks(
+    def iter_free_blocks(
         self, after_block_id: int | None = None
     ) -> Iterator[KVCacheBlockView]:
         pool = self._block_pool

--- a/vllm/v1/core/kv_connector.py
+++ b/vllm/v1/core/kv_connector.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Concrete KVCacheState backed by a BlockPool."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from typing import TYPE_CHECKING
+
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVCacheBlock,
+    KVCacheState,
+)
+
+if TYPE_CHECKING:
+    from vllm.v1.core.block_pool import BlockPool
+
+
+class KVConnectorKVCacheState(KVCacheState):
+    """KVCacheState backed by a BlockPool.
+
+    Created by the scheduler and bound to connectors via
+    ``bind_kv_cache_state``.
+    """
+
+    def __init__(self, block_pool: BlockPool):
+        self._block_pool = block_pool
+
+    def get_block(self, block_id: int) -> KVCacheBlock:
+        return self._block_pool.blocks[block_id]  # type: ignore[return-value]
+
+    def touch(self, block_ids: list[int]) -> None:
+        pool = self._block_pool
+        pool.touch([pool.blocks[bid] for bid in block_ids])
+
+    def free_blocks(self, block_ids: Iterable[int]) -> None:
+        pool = self._block_pool
+        pool.free_blocks(pool.blocks[bid] for bid in block_ids)
+
+    def iter_blocks(self, after_block_id: int | None = None) -> Iterator[KVCacheBlock]:
+        pool = self._block_pool
+        free_queue = pool.free_block_queue
+        tail = free_queue.fake_free_list_tail
+
+        if after_block_id is not None:
+            node = pool.blocks[after_block_id].next_free_block
+        else:
+            node = free_queue.fake_free_list_head.next_free_block
+
+        while node is not None and node is not tail:
+            yield node  # type: ignore[misc]
+            node = node.next_free_block

--- a/vllm/v1/core/kv_connector.py
+++ b/vllm/v1/core/kv_connector.py
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Concrete KVCacheState backed by a BlockPool."""
+"""Concrete SchedulerContext backed by a BlockPool."""
 
 from __future__ import annotations
 
@@ -8,25 +8,25 @@ from collections.abc import Iterable, Iterator
 from typing import TYPE_CHECKING
 
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
-    KVCacheBlock,
-    KVCacheState,
+    KVCacheBlockView,
+    SchedulerContext,
 )
 
 if TYPE_CHECKING:
     from vllm.v1.core.block_pool import BlockPool
 
 
-class KVConnectorKVCacheState(KVCacheState):
-    """KVCacheState backed by a BlockPool.
+class KVConnectorSchedulerContext(SchedulerContext):
+    """SchedulerContext backed by a BlockPool.
 
     Created by the scheduler and bound to connectors via
-    ``bind_kv_cache_state``.
+    ``bind_scheduler_context``.
     """
 
     def __init__(self, block_pool: BlockPool):
         self._block_pool = block_pool
 
-    def get_block(self, block_id: int) -> KVCacheBlock:
+    def get_block(self, block_id: int) -> KVCacheBlockView:
         return self._block_pool.blocks[block_id]  # type: ignore[return-value]
 
     def touch(self, block_ids: list[int]) -> None:
@@ -37,7 +37,9 @@ class KVConnectorKVCacheState(KVCacheState):
         pool = self._block_pool
         pool.free_blocks(pool.blocks[bid] for bid in block_ids)
 
-    def iter_blocks(self, after_block_id: int | None = None) -> Iterator[KVCacheBlock]:
+    def iter_blocks(
+        self, after_block_id: int | None = None
+    ) -> Iterator[KVCacheBlockView]:
         pool = self._block_pool
         free_queue = pool.free_block_queue
         tail = free_queue.fake_free_list_tail

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -238,12 +238,12 @@ class Scheduler(SchedulerInterface):
             hash_block_size=hash_block_size,
             metrics_collector=self.kv_metrics_collector,
         )
-        # Bind GPU block pool to the KV connector. This must happen after
+        # Bind KV cache state to the KV connector. This must happen after
         # kv_cache_manager is constructed so block_pool is available.
-        if self.connector is not None and hasattr(
-            self.connector, "bind_gpu_block_pool"
-        ):
-            self.connector.bind_gpu_block_pool(self.kv_cache_manager.block_pool)
+        if self.connector is not None:
+            self.connector.bind_kv_cache_state(
+                self.kv_cache_manager.block_pool  # type: ignore[arg-type]
+            )
 
         self.use_pp = self.parallel_config.pipeline_parallel_size > 1
         self.use_v2_model_runner = envs.VLLM_USE_V2_MODEL_RUNNER

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -241,8 +241,10 @@ class Scheduler(SchedulerInterface):
         # Bind KV cache state to the KV connector. This must happen after
         # kv_cache_manager is constructed so block_pool is available.
         if self.connector is not None:
+            from vllm.v1.core.kv_connector import KVConnectorKVCacheState
+
             self.connector.bind_kv_cache_state(
-                self.kv_cache_manager.block_pool  # type: ignore[arg-type]
+                KVConnectorKVCacheState(self.kv_cache_manager.block_pool)
             )
 
         self.use_pp = self.parallel_config.pipeline_parallel_size > 1

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -238,13 +238,13 @@ class Scheduler(SchedulerInterface):
             hash_block_size=hash_block_size,
             metrics_collector=self.kv_metrics_collector,
         )
-        # Bind KV cache state to the KV connector. This must happen after
+        # Bind scheduler context to the KV connector. This must happen after
         # kv_cache_manager is constructed so block_pool is available.
         if self.connector is not None:
-            from vllm.v1.core.kv_connector import KVConnectorKVCacheState
+            from vllm.v1.core.kv_connector import KVConnectorSchedulerContext
 
-            self.connector.bind_kv_cache_state(
-                KVConnectorKVCacheState(self.kv_cache_manager.block_pool)
+            self.connector.bind_scheduler_context(
+                KVConnectorSchedulerContext(self.kv_cache_manager.block_pool)
             )
 
         self.use_pp = self.parallel_config.pipeline_parallel_size > 1

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -397,7 +397,7 @@ class SimpleCPUOffloadScheduler:
         block_hashes: list[bytes] = []
         last_visited = self._cursor
 
-        for covered, block in enumerate(gpu_state.iter_blocks(self._cursor)):
+        for covered, block in enumerate(gpu_state.iter_free_blocks(self._cursor)):
             if covered >= self._target_free or len(gpu_ids) >= num_cpu_free:
                 break
 

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -10,6 +10,10 @@ from typing import TYPE_CHECKING, Any
 from vllm.config import VllmConfig
 from vllm.distributed.kv_events import KVCacheEvent
 from vllm.distributed.kv_transfer.kv_connector.utils import yield_req_data
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVCacheBlock,
+    KVCacheState,
+)
 from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
@@ -31,7 +35,6 @@ from vllm.v1.simple_kv_offload.metadata import (
 
 if TYPE_CHECKING:
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
-    from vllm.v1.core.kv_cache_utils import KVCacheBlock
     from vllm.v1.kv_cache_interface import KVCacheConfig
     from vllm.v1.request import Request
 
@@ -122,8 +125,8 @@ class SimpleCPUOffloadScheduler:
         )
         self.cpu_block_pool: BlockPool = self.cpu_coordinator.block_pool
 
-        # GPU block pool reference - bound after scheduler builds kv_cache_manager
-        self._gpu_block_pool: BlockPool | None = None
+        # GPU KV cache state - bound after scheduler builds kv_cache_manager
+        self._gpu_kv_cache_state: KVCacheState | None = None
 
         # Load metadata
         self._reqs_to_load: dict[str, LoadRequestState] = {}
@@ -203,10 +206,10 @@ class SimpleCPUOffloadScheduler:
                 target += cdiv(max_num_batched_tokens, spec.block_size)
         return int(target * (1 + WATERMARK_RATIO))
 
-    def bind_gpu_block_pool(self, gpu_block_pool: BlockPool) -> None:
-        """Bind GPU block pool so that we can touch blocks during stores.
+    def bind_kv_cache_state(self, kv_cache_state: KVCacheState) -> None:
+        """Bind GPU KV cache state so that we can touch blocks during stores.
         Called by Scheduler after kv_cache_manager is ready."""
-        self._gpu_block_pool = gpu_block_pool
+        self._gpu_kv_cache_state = kv_cache_state
 
     def get_num_new_matched_tokens(
         self, request: "Request", num_computed_tokens: int
@@ -305,10 +308,9 @@ class SimpleCPUOffloadScheduler:
         self.cpu_block_pool.touch(cpu_blocks_to_touch)
 
         # Touch GPU blocks to prevent freeing during async load
-        assert self._gpu_block_pool is not None
-        self._gpu_block_pool.touch(
-            [self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids]
-        )
+        assert self._gpu_kv_cache_state is not None
+        gpu_state = self._gpu_kv_cache_state
+        gpu_state.touch([gpu_state.get_block(bid) for bid in gpu_block_ids])
 
         assert self._reqs_to_load.get(req_id) is None
         self._reqs_to_load[req_id] = LoadRequestState(
@@ -384,11 +386,10 @@ class SimpleCPUOffloadScheduler:
         free-or-offloaded (safe for the allocator to evict). Stops when
         target_free blocks are covered or CPU capacity is reached.
         """
-        gpu_pool = self._gpu_block_pool
-        if gpu_pool is None or self._target_free <= 0:
+        gpu_state = self._gpu_kv_cache_state
+        if gpu_state is None or self._target_free <= 0:
             return [], [], []
 
-        free_queue = gpu_pool.free_block_queue
         cpu_pool = self.cpu_block_pool
         num_cpu_free = cpu_pool.get_num_free_blocks()
 
@@ -396,37 +397,26 @@ class SimpleCPUOffloadScheduler:
         if self._cursor is not None and self._cursor.ref_cnt > 0:
             self._cursor = None
 
-        # Determine start node.
-        if self._cursor is None:
-            node = free_queue.fake_free_list_head.next_free_block
-        else:
-            node = self._cursor.next_free_block
-
-        tail = free_queue.fake_free_list_tail
         gpu_ids: list[int] = []
         block_hashes: list[bytes] = []
-        covered = 0
         last_visited = self._cursor
 
-        while (
-            node is not None
-            and node is not tail
-            and covered < self._target_free
-            and len(gpu_ids) < num_cpu_free
-        ):
-            last_visited = node
-            bhash = node.block_hash
+        for covered, block in enumerate(gpu_state.iter_blocks(self._cursor)):
+            if covered >= self._target_free or len(gpu_ids) >= num_cpu_free:
+                break
 
+            last_visited = block
+
+            bhash = block.block_hash
             if (
                 bhash is not None
-                and not node.is_null
-                and cpu_pool.cached_block_hash_to_block.get_one_block(bhash) is None
+                and cpu_pool.cached_block_hash_to_block.get_one_block(
+                    bhash  # type: ignore[arg-type]
+                )
+                is None
             ):
-                gpu_ids.append(node.block_id)
+                gpu_ids.append(block.block_id)
                 block_hashes.append(bhash)
-
-            covered += 1
-            node = node.next_free_block
 
         self._cursor = last_visited
 
@@ -437,7 +427,7 @@ class SimpleCPUOffloadScheduler:
             for cpu_blk, bhash in zip(cpu_blocks, block_hashes):  # type: ignore[assignment]
                 cpu_blk._block_hash = bhash  # type: ignore[assignment]
             # Touch GPU blocks to prevent eviction during async copy.
-            gpu_pool.touch([gpu_pool.blocks[bid] for bid in gpu_ids])
+            gpu_state.touch([gpu_state.get_block(bid) for bid in gpu_ids])
         else:
             cpu_ids = []
 
@@ -461,8 +451,8 @@ class SimpleCPUOffloadScheduler:
         merged_cpu_block_ids: list[int] = []
         req_ids: list[str] = []
 
-        gpu_block_pool = self._gpu_block_pool
-        if gpu_block_pool is None:
+        gpu_state = self._gpu_kv_cache_state
+        if gpu_state is None:
             return [], [], []
         cpu_block_pool = self.cpu_block_pool
         num_free = cpu_block_pool.get_num_free_blocks()
@@ -514,7 +504,7 @@ class SimpleCPUOffloadScheduler:
                 scannable = group_gpu_ids[already_stored_g:ready_blocks_g]
 
                 for gpu_block_id in scannable:
-                    gpu_block = gpu_block_pool.blocks[gpu_block_id]
+                    gpu_block = gpu_state.get_block(gpu_block_id)
                     if gpu_block.is_null:
                         advanced_per_group[g] += 1
                         continue
@@ -528,7 +518,7 @@ class SimpleCPUOffloadScheduler:
                     if (
                         gpu_block_id in gpu_blocks_this_step
                         or cpu_block_pool.cached_block_hash_to_block.get_one_block(
-                            bhash_with_group
+                            bhash_with_group  # type: ignore[arg-type]
                         )
                         is not None
                     ):
@@ -564,9 +554,7 @@ class SimpleCPUOffloadScheduler:
                 gpu_blocks_this_step.update(gpu_block_ids)
 
                 # Touch GPU blocks to prevent freeing during async copy
-                gpu_block_pool.touch(
-                    [gpu_block_pool.blocks[bid] for bid in gpu_block_ids]
-                )
+                gpu_state.touch([gpu_state.get_block(bid) for bid in gpu_block_ids])
 
                 logger.debug(
                     "Request %s: Scheduling store of %d blocks to CPU (%d groups)",
@@ -645,10 +633,9 @@ class SimpleCPUOffloadScheduler:
 
         # Free CPU and GPU blocks' ref counts to turn them into prefix cache
         self.cpu_block_pool.free_blocks(cpu_blocks)
-        assert self._gpu_block_pool is not None
-        self._gpu_block_pool.free_blocks(
-            self._gpu_block_pool.blocks[bid] for bid in gpu_block_ids
-        )
+        assert self._gpu_kv_cache_state is not None
+        gpu_state = self._gpu_kv_cache_state
+        gpu_state.free_blocks(gpu_state.get_block(bid) for bid in gpu_block_ids)
 
     def has_pending_stores(self) -> bool:
         """Return True if there are in-flight store transfers."""
@@ -715,10 +702,10 @@ class SimpleCPUOffloadScheduler:
                 for bid in state.transfer_meta.cpu_block_ids
             )
             # Free GPU touch refs
-            assert self._gpu_block_pool is not None
-            self._gpu_block_pool.free_blocks(
-                self._gpu_block_pool.blocks[bid]
-                for bid in state.transfer_meta.gpu_block_ids
+            assert self._gpu_kv_cache_state is not None
+            gpu_state = self._gpu_kv_cache_state
+            gpu_state.free_blocks(
+                gpu_state.get_block(bid) for bid in state.transfer_meta.gpu_block_ids
             )
 
     def _cleanup_store_request(self, req_id: str) -> None:

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any
 from vllm.config import VllmConfig
 from vllm.distributed.kv_events import KVCacheEvent
 from vllm.distributed.kv_transfer.kv_connector.utils import yield_req_data
-from vllm.distributed.kv_transfer.kv_connector.v1.base import KVCacheState
+from vllm.distributed.kv_transfer.kv_connector.v1.base import SchedulerContext
 from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
@@ -123,7 +123,7 @@ class SimpleCPUOffloadScheduler:
         self.cpu_block_pool: BlockPool = self.cpu_coordinator.block_pool
 
         # GPU KV cache state - bound after scheduler builds kv_cache_manager
-        self._gpu_kv_cache_state: KVCacheState | None = None
+        self._gpu_kv_cache_state: SchedulerContext | None = None
 
         # Load metadata
         self._reqs_to_load: dict[str, LoadRequestState] = {}
@@ -203,10 +203,10 @@ class SimpleCPUOffloadScheduler:
                 target += cdiv(max_num_batched_tokens, spec.block_size)
         return int(target * (1 + WATERMARK_RATIO))
 
-    def bind_kv_cache_state(self, kv_cache_state: KVCacheState) -> None:
-        """Bind GPU KV cache state so that we can touch blocks during stores.
+    def bind_scheduler_context(self, scheduler_context: SchedulerContext) -> None:
+        """Bind scheduler context so that we can touch blocks during stores.
         Called by Scheduler after kv_cache_manager is ready."""
-        self._gpu_kv_cache_state = kv_cache_state
+        self._gpu_kv_cache_state = scheduler_context
 
     def get_num_new_matched_tokens(
         self, request: "Request", num_computed_tokens: int

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -10,10 +10,7 @@ from typing import TYPE_CHECKING, Any
 from vllm.config import VllmConfig
 from vllm.distributed.kv_events import KVCacheEvent
 from vllm.distributed.kv_transfer.kv_connector.utils import yield_req_data
-from vllm.distributed.kv_transfer.kv_connector.v1.base import (
-    KVCacheBlock,
-    KVCacheState,
-)
+from vllm.distributed.kv_transfer.kv_connector.v1.base import KVCacheState
 from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
@@ -136,8 +133,8 @@ class SimpleCPUOffloadScheduler:
 
         # Store metadata
         self._lazy_mode = lazy_offload
-        # Lazy mode: use a cursor to track the last scanned block in the GPU free queue.
-        self._cursor: KVCacheBlock | None = None
+        # Lazy mode: block_id of the last scanned block in the GPU free queue.
+        self._cursor: int | None = None
         if self._lazy_mode:
             self._target_free = self._estimate_lazy_target_blocks(
                 kv_cache_config,
@@ -280,7 +277,7 @@ class SimpleCPUOffloadScheduler:
 
         gpu_block_ids: list[int] = []
         cpu_block_ids: list[int] = []
-        cpu_blocks_to_touch: list[KVCacheBlock] = []
+        cpu_blocks_to_touch = []
 
         for g in range(num_groups):
             cpu_blocks_g = cpu_hit_blocks[g]
@@ -309,8 +306,7 @@ class SimpleCPUOffloadScheduler:
 
         # Touch GPU blocks to prevent freeing during async load
         assert self._gpu_kv_cache_state is not None
-        gpu_state = self._gpu_kv_cache_state
-        gpu_state.touch([gpu_state.get_block(bid) for bid in gpu_block_ids])
+        self._gpu_kv_cache_state.touch(gpu_block_ids)
 
         assert self._reqs_to_load.get(req_id) is None
         self._reqs_to_load[req_id] = LoadRequestState(
@@ -394,7 +390,7 @@ class SimpleCPUOffloadScheduler:
         num_cpu_free = cpu_pool.get_num_free_blocks()
 
         # Validate cursor: stale if block was removed from free queue.
-        if self._cursor is not None and self._cursor.ref_cnt > 0:
+        if self._cursor is not None and gpu_state.get_block(self._cursor).ref_cnt > 0:
             self._cursor = None
 
         gpu_ids: list[int] = []
@@ -405,15 +401,12 @@ class SimpleCPUOffloadScheduler:
             if covered >= self._target_free or len(gpu_ids) >= num_cpu_free:
                 break
 
-            last_visited = block
+            last_visited = block.block_id
 
             bhash = block.block_hash
             if (
                 bhash is not None
-                and cpu_pool.cached_block_hash_to_block.get_one_block(
-                    bhash  # type: ignore[arg-type]
-                )
-                is None
+                and cpu_pool.cached_block_hash_to_block.get_one_block(bhash) is None  # type: ignore[arg-type]
             ):
                 gpu_ids.append(block.block_id)
                 block_hashes.append(bhash)
@@ -427,7 +420,7 @@ class SimpleCPUOffloadScheduler:
             for cpu_blk, bhash in zip(cpu_blocks, block_hashes):  # type: ignore[assignment]
                 cpu_blk._block_hash = bhash  # type: ignore[assignment]
             # Touch GPU blocks to prevent eviction during async copy.
-            gpu_state.touch([gpu_state.get_block(bid) for bid in gpu_ids])
+            gpu_state.touch(gpu_ids)
         else:
             cpu_ids = []
 
@@ -554,7 +547,7 @@ class SimpleCPUOffloadScheduler:
                 gpu_blocks_this_step.update(gpu_block_ids)
 
                 # Touch GPU blocks to prevent freeing during async copy
-                gpu_state.touch([gpu_state.get_block(bid) for bid in gpu_block_ids])
+                gpu_state.touch(gpu_block_ids)
 
                 logger.debug(
                     "Request %s: Scheduling store of %d blocks to CPU (%d groups)",
@@ -634,8 +627,7 @@ class SimpleCPUOffloadScheduler:
         # Free CPU and GPU blocks' ref counts to turn them into prefix cache
         self.cpu_block_pool.free_blocks(cpu_blocks)
         assert self._gpu_kv_cache_state is not None
-        gpu_state = self._gpu_kv_cache_state
-        gpu_state.free_blocks(gpu_state.get_block(bid) for bid in gpu_block_ids)
+        self._gpu_kv_cache_state.free_blocks(gpu_block_ids)
 
     def has_pending_stores(self) -> bool:
         """Return True if there are in-flight store transfers."""
@@ -703,10 +695,7 @@ class SimpleCPUOffloadScheduler:
             )
             # Free GPU touch refs
             assert self._gpu_kv_cache_state is not None
-            gpu_state = self._gpu_kv_cache_state
-            gpu_state.free_blocks(
-                gpu_state.get_block(bid) for bid in state.transfer_meta.gpu_block_ids
-            )
+            self._gpu_kv_cache_state.free_blocks(state.transfer_meta.gpu_block_ids)
 
     def _cleanup_store_request(self, req_id: str) -> None:
         """Release store metadata for a request.


### PR DESCRIPTION
This PR  introduces a scheduler-side API that allows connectors to query the core `BlockPool`, as well as touch and free blocks.

This is an alternative to #39654 and #41011.
The difference here is it decouples the connector API from the vLLM internal structs (BlockPool, KVCacheBlock, BlockHashWithGroupId).

cc @NickLucche @ivanium 

BTW the simple offloading tests are broken.
Apparently they are not part of the CI jobs.