### PR TITLE
[Bugfix][V1] KV cache: handle None block_size for Mamba/SSM groups

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2166,3 +2166,47 @@ def test_hma_not_disabled_when_kv_events_enabled():
     assert vllm_config.scheduler_config.disable_hybrid_kv_cache_manager is False, (
         "kv_events_config must not force-disable the hybrid KV cache manager."
     )
+
+
+@pytest.mark.parametrize(
+    "specs",
+    [
+        # Hybrid: SSM group (block_size=None) plus a regular attention
+        # group. Without the fix this hits min(None, 16) and crashes.
+        [
+            new_mamba_spec(block_size=None),
+            new_kv_cache_spec(block_size=16),
+        ],
+        # All-Mamba: every group has block_size=None. The fallback should
+        # still produce a sensible non-zero minimum.
+        [
+            new_mamba_spec(block_size=None),
+            new_mamba_spec(block_size=None),
+        ],
+    ],
+)
+def test_report_kv_cache_config_handles_none_block_size(monkeypatch, specs):
+    """_report_kv_cache_config should survive Mamba/SSM groups whose
+    block_size is None (the embedded min() used to crash)."""
+    model_config = ModelConfig(
+        "Qwen/Qwen1.5-7B",
+        runner="generate",
+        dtype="float16",
+        max_model_len=4096,
+    )
+    vllm_config = VllmConfig(model_config=model_config)
+    kv_cache_config = KVCacheConfig(
+        num_blocks=64,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec([f"layer_{i}"], spec) for i, spec in enumerate(specs)
+        ],
+    )
+
+    # Stub out the heavy helper; it isn't what this test exercises.
+    monkeypatch.setattr(
+        kv_cache_utils, "get_max_concurrency_for_kv_cache_config", lambda *a, **k: 1.0
+    )
+
+    # Should not raise. Without the fix, min([None, 16]) raises TypeError.
+    kv_cache_utils._report_kv_cache_config(vllm_config, kv_cache_config)

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1688,9 +1688,15 @@ def _report_kv_cache_config(
         vllm_config: The global VllmConfig
         kv_cache_config: The resolved KV cache configuration
     """
-    min_block_size = min(
-        [group.kv_cache_spec.block_size for group in kv_cache_config.kv_cache_groups]
-    )
+    # Mamba/SSM groups have block_size=None (state is per sequence, not
+    # per token-block). Drop them before min() so a hybrid attention+SSM
+    # config doesn't crash here on min(None, 16).
+    block_sizes = [
+        group.kv_cache_spec.block_size
+        for group in kv_cache_config.kv_cache_groups
+        if group.kv_cache_spec.block_size is not None
+    ]
+    min_block_size = min(block_sizes) if block_sizes else 1
 
     # Log the KV cache size and maximum concurrency.
     num_tokens = (

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -860,7 +860,12 @@ class MambaManager(SingleTypeKVCacheManager):
         # that we might actually need.
         num_computed_tokens = max(0, num_computed_tokens - self.num_speculative_blocks)
 
-        super().remove_skipped_blocks(request_id, num_computed_tokens)
+        if self.block_size is None:
+            # Mamba state is per-sequence; there's no per-token-block
+            # notion to skip on, so nothing to do here.
+            pass
+        else:
+            super().remove_skipped_blocks(request_id, num_computed_tokens)
         if self.mamba_cache_mode == "align":
             # `last_state_block_idx` refers to the block index allocated two steps ago.
             # The block allocated in the previous step is used to copy Mamba states
@@ -905,6 +910,14 @@ class MambaManager(SingleTypeKVCacheManager):
             # and don't schedule it in the current step.
             return self.block_pool.num_gpu_blocks + 1
         if self.mamba_cache_mode != "align":
+            if self.block_size is None:
+                # Mamba state is per-sequence with no token-block notion.
+                # First call: allocate one block for the SSM state plus
+                # any speculative blocks. Later calls for the same request
+                # need nothing.
+                if len(self.req_to_blocks.get(request_id, ())) > 0:
+                    return 0
+                return 1 + self.num_speculative_blocks
             # Allocate extra `num_speculative_blocks` blocks for
             # speculative decoding (MTP/EAGLE) with linear attention.
             if self.num_speculative_blocks > 0:
@@ -956,6 +969,17 @@ class MambaManager(SingleTypeKVCacheManager):
     ) -> list[KVCacheBlock]:
         assert isinstance(self.kv_cache_spec, MambaSpec)
         if self.mamba_cache_mode != "align":
+            if self.block_size is None:
+                # Mamba state is per-sequence: one block per request, total.
+                # (Plus speculative blocks if any.)
+                req_blocks = self.req_to_blocks[request_id]
+                if len(req_blocks) > 0:
+                    return []
+                new_blocks = self.block_pool.get_new_blocks(
+                    1 + self.num_speculative_blocks
+                )
+                req_blocks.extend(new_blocks)
+                return new_blocks
             # Allocate extra `num_speculative_blocks` blocks for
             # speculative decoding (MTP/EAGLE) with linear attention.
             if self.num_speculative_blocks > 0:
@@ -970,7 +994,7 @@ class MambaManager(SingleTypeKVCacheManager):
             # We can ignore lookahead tokens because current draft models don't have
             # mamba layers.
             num_tokens = num_tokens_main_model
-            req_blocks: list[KVCacheBlock] = self.req_to_blocks[request_id]
+            req_blocks = self.req_to_blocks[request_id]
             # NOTE(tdouble): this is an over-estimate of how many blocks we need because
             # num_tokens can include draft tokens that will later be rejected.
             num_required_blocks = (

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -273,9 +273,16 @@ class EngineCore:
         vllm_config.cache_config.num_gpu_blocks = scheduler_kv_cache_config.num_blocks
         kv_cache_groups = scheduler_kv_cache_config.kv_cache_groups
         if kv_cache_groups:
-            vllm_config.cache_config.block_size = min(
-                g.kv_cache_spec.block_size for g in kv_cache_groups
-            )
+            # Mamba/SSM groups have block_size=None; filter them out
+            # before min() so a hybrid attention+SSM model doesn't crash
+            # here on min(None, 16).
+            block_sizes = [
+                g.kv_cache_spec.block_size
+                for g in kv_cache_groups
+                if g.kv_cache_spec.block_size is not None
+            ]
+            if block_sizes:
+                vllm_config.cache_config.block_size = min(block_sizes)
 
         vllm_config.validate_block_size()
 

--- a/vllm/v1/worker/block_table.py
+++ b/vllm/v1/worker/block_table.py
@@ -144,6 +144,12 @@ class BlockTable:
         query_start_loc: torch.Tensor,
         positions: torch.Tensor,
     ) -> None:
+        if self.block_size is None:
+            # Mamba/SSM block tables have block_size=None and the SSM
+            # forward path doesn't use slot_mapping anyway. Skip the
+            # kernel; calling it would compute None * TOTAL_CP_WORLD_SIZE
+            # and crash.
+            return
         num_tokens = positions.shape[0]
         total_cp_world_size = self.pcp_world_size * self.dcp_world_size
         total_cp_rank = self.pcp_rank * self.dcp_world_size + self.dcp_rank


### PR DESCRIPTION
## Problem

In hybrid attention+SSM models (e.g. Qwen3.5-35B-A3B with GatedDeltaNet layers), Mamba/SSM KV cache groups have `block_size=None` because their state is per-sequence rather than per token-block. Two call sites pass the full list of groups directly into `min()`, which crashes with `TypeError: '<' not supported between instances of 'NoneType' and 'int'`:

- `vllm/v1/core/kv_cache_utils.py` — `_report_kv_cache_config`
- `vllm/v1/engine/core.py` — `EngineCore._initialize_kv_caches`

Two additional sites in `MambaManager` (`remove_skipped_blocks`, `get_num_new_blocks`) assume `block_size` is always an integer and would compute `None * TOTAL_CP_WORLD_SIZE` or call `super()` unconditionally, both of which fail at runtime for `block_size=None`.

`BlockTable.update_slot_mapping_for_cp` has the same issue: it multiplies `self.block_size` before the early return that checks shape, so an SSM block table crashes the kernel call.

## Fix

- Filter out `None` block sizes before `min()` in both call sites; fall back to `1` when every group is SSM-only (all-Mamba model).
- Guard `remove_skipped_blocks` and `get_num_new_blocks`/`allocate_slots` in `MambaManager` with `if self.block_size is None` branches that return early with the correct SSM-state semantics (one block per sequence, nothing to skip).
- Guard `BlockTable.update_slot_mapping_for_cp` with an early return when `block_size is None`.

## Test

Added `test_report_kv_cache_config_handles_none_block_size` in `tests/v1/core/test_kv_cache_utils.py` covering:
- hybrid spec (SSM group with `block_size=None` + attention group with `block_size=16`)
- all-SSM spec (both groups `block_size=None`)

Both cases must not raise; without the fix, `min([None, 16])` raises `TypeError`.

## Related

Surfaced while adding GGUF loading support for Qwen3.5/3.6-35B-A3B (hybrid GatedDeltaNet+GQA attention). Independent of that work and applicable to any model using `MambaSpec` groups.