### PR TITLE
Defer flashinfer cubin download to avoid ~2.5 GB (decompressed) layer duplication

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -585,9 +585,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 ARG FLASHINFER_VERSION=0.6.8.post1
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system flashinfer-jit-cache==${FLASHINFER_VERSION} \
-        --extra-index-url https://flashinfer.ai/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.') \
-    && flashinfer show-config \
-    && flashinfer download-cubin
+        --extra-index-url https://flashinfer.ai/whl/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.')
 
 # ============================================================
 # OPENAI API SERVER DEPENDENCIES
@@ -668,6 +666,13 @@ RUN --mount=type=bind,from=build,src=/tmp/ep_kernels_workspace/dist,target=/vllm
     --mount=type=cache,target=/root/.cache/uv \
     uv pip install --system ep_kernels/dist/*.whl --verbose \
         --extra-index-url ${PYTORCH_CUDA_INDEX_BASE_URL}/cu$(echo $CUDA_VERSION | cut -d. -f1,2 | tr -d '.')
+
+# Download FlashInfer precompiled cubins AFTER all pip installs are done.
+# This must run after the vLLM wheel and EP kernels installs above, because
+# those can reinstall/touch flashinfer packages. Downloading cubins earlier
+# (in the flashinfer-jit-cache layer) causes ~2.5 GB of layer duplication
+# when a later pip install overwrites flashinfer package files.
+RUN flashinfer show-config && flashinfer download-cubin
 
 # CUDA image changed from /usr/local/nvidia to /usr/local/cuda in 12.8 but will
 # return to /usr/local/nvidia in 13.0 to allow container providers to mount drivers


### PR DESCRIPTION
Defer `flashinfer download-cubin` to after all pip installs, eliminating ~2.5 GB of cross-layer file duplication in the Docker image.

## Purpose

While looking at reducing image size with `Dive` and Claude Opus, I find few things. Here is the first one;

Running `flashinfer download-cubin` in the flashinfer-jit-cache install layer (L586) writes ~10,600 precompiled cubin files into the `flashinfer_cubin` package directory. When the vLLM wheel is installed later (L644), it resolves `flashinfer-python` and `flashinfer-cubin` as transitive dependencies (via `pyproject.toml` dynamic deps -> `setup.py` -> `requirements/cuda.txt`), touching/reinstalling those packages. The overlay filesystem keeps the original cubins from the earlier layer as **dead weight** even though they are fully shadowed.

[Dive](https://github.com/wagoodman/dive) analysis of the published `vllm/vllm-openai:v0.16.0` image (26.29 GB, efficiency 95.1%) confirms 2,452 MB of duplication across 10,598 flashinfer cubin/header files, each appearing in exactly two layers.

The fix moves only the cubin download to after the last pip install (EP kernels). The `flashinfer-jit-cache` pip install stays in its original layer to preserve Docker build cache behavior. No packages are added or removed; the image produces the same runtime environment.

## Test Plan

1. Build the image with and without the patch: `DOCKER_BUILDKIT=1 docker build -f docker/Dockerfile -t vllm-openai .`
2. Compare image sizes with `docker images` and confirm a ~2.5 GB reduction.
3. Run [Dive](https://github.com/wagoodman/dive) on both images (`dive vllm-openai`) and verify that `flashinfer_cubin` files no longer appear duplicated across layers (count should be 1 instead of 2).
4. Start the server with a model and confirm vLLM serves inference requests normally, including FlashInfer attention backend.

## Test Result

Not yet tested on a full build (requires CUDA build environment). The change is a pure layer reordering: same `flashinfer show-config && flashinfer download-cubin` commands, same packages, just executed after the last pip install instead of before. Dive data from the current `v0.16.0` image confirms the duplication mechanism and the expected savings.

Duplication data extracted from the published image:

| Metric | Value |
|---|---|
| Total image size | 26.29 GB |
| Inefficient bytes | 2,566 MB |
| flashinfer_cubin duplication | 2,452 MB (10,598 files, each in 2 layers) |
| Expected savings | ~2.5 GB |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.

</details>

---

*This PR was prepared with the help of Claude (Opus).*