### PR TITLE
[CI] De-flake test_chat_completion_n_parameter_non_streaming

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_chat.py
@@ -845,9 +845,10 @@ async def test_chat_completion_n_parameter_non_streaming(
     chat_completion = await client.chat.completions.create(
         model=model_name,
         messages=messages,
-        max_completion_tokens=20,
-        temperature=0.7,
+        max_completion_tokens=50,
+        temperature=1.0,
         n=3,
+        seed=42,
         stream=False,
     )
 
@@ -859,7 +860,6 @@ async def test_chat_completion_n_parameter_non_streaming(
         assert choice.message.content is not None
         assert len(choice.message.content) > 0
 
-    # Verify all responses are different (highly likely with temperature > 0)
     contents = [choice.message.content for choice in chat_completion.choices]
     assert len(set(contents)) > 1, "Expected different responses with n=3"
 


### PR DESCRIPTION
## Purpose

De-flake `test_chat_completion_n_parameter_non_streaming`. The test asserted `len(set(contents)) > 1` for `n=3` samples at `temperature=0.7` with no seed and only 20 output tokens on a low-entropy prompt — all three samples can collapse to the same string (seen on [Buildkite #63256](https://buildkite.com/vllm/ci/builds/63256/canvas?sid=019dd30c-69ac-411c-bab5-d0de2f42c5f0&tab=output)).

Pin `seed=42`, raise `temperature` to `1.0`, and widen `max_completion_tokens` to `50`, mirroring `tests/entrypoints/openai/completion/test_completion.py`. With a parent seed, vLLM derives distinct per-child seeds (42/43/44), so divergence is deterministic.

## Test Plan

## Test Result