### PR TITLE
[CI/Build] Auto-detect manylinux ABI tag for nightly wheels

### DIFF
--- a/.buildkite/release-pipeline.yaml
+++ b/.buildkite/release-pipeline.yaml
@@ -27,7 +27,7 @@ steps:
           - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg CUDA_VERSION=12.9.1 --build-arg torch_cuda_arch_list=\"${CUDA_ARCH_AARCH64_CU129}\" --tag vllm-ci:build-image --target build --progress plain -f docker/Dockerfile ."
           - "mkdir artifacts"
           - "docker run --rm -v $(pwd)/artifacts:/artifacts_host vllm-ci:build-image bash -c 'cp -r dist /artifacts_host && chmod -R a+rw /artifacts_host'"
-          - "bash .buildkite/scripts/upload-nightly-wheels.sh manylinux_2_31"
+          - "bash .buildkite/scripts/upload-nightly-wheels.sh"
         env:
           DOCKER_BUILDKIT: "1"
 
@@ -40,7 +40,7 @@ steps:
           - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg CUDA_VERSION=13.0.2 --build-arg torch_cuda_arch_list=\"${CUDA_ARCH_AARCH64}\" --build-arg BUILD_BASE_IMAGE=nvidia/cuda:13.0.2-devel-ubuntu22.04  --tag vllm-ci:build-image --target build --progress plain -f docker/Dockerfile ."
           - "mkdir artifacts"
           - "docker run --rm -v $(pwd)/artifacts:/artifacts_host vllm-ci:build-image bash -c 'cp -r dist /artifacts_host && chmod -R a+rw /artifacts_host'"
-          - "bash .buildkite/scripts/upload-nightly-wheels.sh manylinux_2_35"
+          - "bash .buildkite/scripts/upload-nightly-wheels.sh"
         env:
           DOCKER_BUILDKIT: "1"
 
@@ -53,7 +53,7 @@ steps:
           - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg GIT_REPO_CHECK=1 --build-arg VLLM_BUILD_ACL=ON --tag vllm-ci:build-image --target vllm-build --progress plain -f docker/Dockerfile.cpu ."
           - "mkdir artifacts"
           - "docker run --rm -v $(pwd)/artifacts:/artifacts_host vllm-ci:build-image bash -c 'cp -r dist /artifacts_host && chmod -R a+rw /artifacts_host'"
-          - "bash .buildkite/scripts/upload-nightly-wheels.sh manylinux_2_35"
+          - "bash .buildkite/scripts/upload-nightly-wheels.sh"
         env:
           DOCKER_BUILDKIT: "1"
 
@@ -66,7 +66,7 @@ steps:
           - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg CUDA_VERSION=12.9.1 --build-arg torch_cuda_arch_list=\"${CUDA_ARCH_X86_CU129}\" --tag vllm-ci:build-image --target build --progress plain -f docker/Dockerfile ."
           - "mkdir artifacts"
           - "docker run --rm -v $(pwd)/artifacts:/artifacts_host vllm-ci:build-image bash -c 'cp -r dist /artifacts_host && chmod -R a+rw /artifacts_host'"
-          - "bash .buildkite/scripts/upload-nightly-wheels.sh manylinux_2_31"
+          - "bash .buildkite/scripts/upload-nightly-wheels.sh"
         env:
           DOCKER_BUILDKIT: "1"
 
@@ -79,7 +79,7 @@ steps:
           - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg USE_SCCACHE=1 --build-arg GIT_REPO_CHECK=1 --build-arg CUDA_VERSION=13.0.2 --build-arg torch_cuda_arch_list=\"${CUDA_ARCH_X86}\" --build-arg BUILD_BASE_IMAGE=nvidia/cuda:13.0.2-devel-ubuntu22.04 --tag vllm-ci:build-image --target build --progress plain -f docker/Dockerfile ."
           - "mkdir artifacts"
           - "docker run --rm -v $(pwd)/artifacts:/artifacts_host vllm-ci:build-image bash -c 'cp -r dist /artifacts_host && chmod -R a+rw /artifacts_host'"
-          - "bash .buildkite/scripts/upload-nightly-wheels.sh manylinux_2_35"
+          - "bash .buildkite/scripts/upload-nightly-wheels.sh"
         env:
           DOCKER_BUILDKIT: "1"
 
@@ -92,7 +92,7 @@ steps:
           - "DOCKER_BUILDKIT=1 docker build --build-arg max_jobs=16 --build-arg GIT_REPO_CHECK=1 --build-arg VLLM_CPU_X86=true --tag vllm-ci:build-image --target vllm-build --progress plain -f docker/Dockerfile.cpu ."
           - "mkdir artifacts"
           - "docker run --rm -v $(pwd)/artifacts:/artifacts_host vllm-ci:build-image bash -c 'cp -r dist /artifacts_host && chmod -R a+rw /artifacts_host'"
-          - "bash .buildkite/scripts/upload-nightly-wheels.sh manylinux_2_35"
+          - "bash .buildkite/scripts/upload-nightly-wheels.sh"
         env:
           DOCKER_BUILDKIT: "1"
 

--- a/.buildkite/scripts/detect-manylinux-tag.py
+++ b/.buildkite/scripts/detect-manylinux-tag.py
@@ -34,7 +34,11 @@ import argparse
 import sys
 from pathlib import Path
 
-from auditwheel.error import NonPlatformWheelError, WheelToolsError
+from auditwheel.error import (
+    AuditwheelError,
+    NonPlatformWheelError,
+    WheelToolsError,
+)
 from auditwheel.wheel_abi import analyze_wheel_abi
 from auditwheel.wheeltools import get_wheel_architecture, get_wheel_libc
 
@@ -108,10 +112,23 @@ def main() -> int:
         print(f"error: {wheel_path} is not a file", file=sys.stderr)
         return 1
 
-    new_tag = detect_platform_tag(wheel_path)
-    print(f"detected platform tag: {new_tag}", file=sys.stderr)
+    # Catch the things that ``analyze_wheel_abi`` and ``rename_wheel`` can
+    # raise: any subclass of ``AuditwheelError`` (pure-Python wheels,
+    # invalid libc, malformed wheels), filesystem errors, or our own
+    # ``ValueError`` for an unrecognised wheel filename. Print a single
+    # ``ERROR_TYPE: message`` line to stderr instead of a Python
+    # traceback, which is much friendlier in CI logs.
+    try:
+        new_tag = detect_platform_tag(wheel_path)
+        print(f"detected platform tag: {new_tag}", file=sys.stderr)
+        new_path = rename_wheel(wheel_path, new_tag)
+    except (AuditwheelError, ValueError, OSError) as e:
+        print(
+            f"error: failed to retag {wheel_path.name}: {type(e).__name__}: {e}",
+            file=sys.stderr,
+        )
+        return 2
 
-    new_path = rename_wheel(wheel_path, new_tag)
     if new_path != wheel_path:
         print(f"renamed {wheel_path.name} -> {new_path.name}", file=sys.stderr)
     else:

--- a/.buildkite/scripts/detect-manylinux-tag.py
+++ b/.buildkite/scripts/detect-manylinux-tag.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Detect the manylinux platform tag for a wheel and rename it in place.
+
+vLLM's build images produce wheels with the generic ``linux_<arch>`` platform
+tag, which installers like ``pip`` won't accept off PyPI/our index. We need to
+rewrite the platform tag to the appropriate ``manylinux_<major>_<minor>_<arch>``
+before uploading.
+
+Historically the tag was hard-coded per build (``manylinux_2_31`` for the
+Ubuntu 20.04-based image, ``manylinux_2_35`` for the Ubuntu 22.04-based
+images). That is brittle: bumping the base image silently produces wheels
+labelled with the wrong glibc requirement. This script asks ``auditwheel``
+to derive the tag from the symbol versions actually referenced by the
+binaries inside the wheel, so the label tracks reality.
+
+We can't simply call ``auditwheel repair`` -- it tries to graft external
+shared libraries into the wheel and fails on vLLM's CUDA/cuBLAS dependencies.
+Instead we use ``auditwheel.wheel_abi.analyze_wheel_abi`` directly, which is
+the same call that powers ``auditwheel show``, and read off
+``winfo.sym_policy.name``.
+
+Usage:
+    detect-manylinux-tag.py <wheel_path>
+
+The wheel is renamed in place; the new path is printed on stdout. All
+diagnostics go to stderr so callers can capture stdout safely.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+from auditwheel.error import NonPlatformWheelError, WheelToolsError
+from auditwheel.wheel_abi import analyze_wheel_abi
+from auditwheel.wheeltools import get_wheel_architecture, get_wheel_libc
+
+
+def detect_platform_tag(wheel_path: Path) -> str:
+    """Return the most precise platform tag the wheel is consistent with.
+
+    Mirrors ``auditwheel show`` but returns ``sym_policy`` rather than
+    ``overall_policy``: we only care about the glibc symbol versions used,
+    not about other policy axes (ISA extensions, blacklist, etc.) that
+    ``overall_policy`` folds in.
+    """
+    fn = wheel_path.name
+
+    try:
+        arch = get_wheel_architecture(fn)
+    except (WheelToolsError, NonPlatformWheelError):
+        # Architecture isn't deducible from the filename; let auditwheel
+        # infer it from the ELF binaries inside the wheel.
+        arch = None
+
+    try:
+        libc = get_wheel_libc(fn)
+    except WheelToolsError:
+        # An unrepaired wheel uses ``linux_<arch>``, which doesn't encode
+        # libc. Let auditwheel infer it from the ELF binaries.
+        libc = None
+
+    winfo = analyze_wheel_abi(
+        libc,
+        arch,
+        wheel_path,
+        frozenset(),
+        disable_isa_ext_check=False,
+        allow_graft=False,
+    )
+    return winfo.sym_policy.name
+
+
+def rename_wheel(wheel_path: Path, new_platform_tag: str) -> Path:
+    """Rename the wheel in place, replacing only its platform tag."""
+    # Wheel filename per PEP 427:
+    #   {distribution}-{version}(-{build})?-{python}-{abi}-{platform}.whl
+    # The platform tag is always the last ``-``-separated token before
+    # ``.whl``. Compound tags like ``manylinux_2_31_x86_64`` use ``_`` as the
+    # internal separator, so ``-``-splitting is unambiguous.
+    parts = wheel_path.stem.split("-")
+    if len(parts) < 5:
+        raise ValueError(f"Unrecognised wheel filename: {wheel_path.name}")
+    parts[-1] = new_platform_tag
+    new_path = wheel_path.with_name("-".join(parts) + ".whl")
+    if new_path != wheel_path:
+        wheel_path.rename(new_path)
+    return new_path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Detect a wheel's manylinux platform tag with "
+        "auditwheel and rename the wheel in place."
+    )
+    parser.add_argument(
+        "wheel",
+        type=Path,
+        help="Path to the wheel to inspect and rename.",
+    )
+    args = parser.parse_args()
+
+    wheel_path: Path = args.wheel
+    if not wheel_path.is_file():
+        print(f"error: {wheel_path} is not a file", file=sys.stderr)
+        return 1
+
+    new_tag = detect_platform_tag(wheel_path)
+    print(f"detected platform tag: {new_tag}", file=sys.stderr)
+
+    new_path = rename_wheel(wheel_path, new_tag)
+    if new_path != wheel_path:
+        print(f"renamed {wheel_path.name} -> {new_path.name}", file=sys.stderr)
+    else:
+        print(f"wheel already tagged {new_tag}", file=sys.stderr)
+
+    print(new_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.buildkite/scripts/generate-and-upload-nightly-index.sh
+++ b/.buildkite/scripts/generate-and-upload-nightly-index.sh
@@ -10,20 +10,13 @@ set -ex
 BUCKET="vllm-wheels"
 INDICES_OUTPUT_DIR="indices"
 DEFAULT_VARIANT_ALIAS="cu130" # align with vLLM_MAIN_CUDA_VERSION in vllm/envs.py
-PYTHON="${PYTHON_PROG:-python3}" # try to read from env var, otherwise use python3
 SUBPATH=$BUILDKITE_COMMIT
 S3_COMMIT_PREFIX="s3://$BUCKET/$SUBPATH/"
 
-# detect if python3.12+ is available
-has_new_python=$($PYTHON -c "print(1 if __import__('sys').version_info >= (3,12) else 0)")
-if [[ "$has_new_python" -eq 0 ]]; then
-    # use new python from docker
-    docker pull python:3-slim
-    PYTHON="docker run --rm -u $(id -u):$(id -g) -v $(pwd):/app -w /app python:3-slim python3"
-fi
-
-echo "Using python interpreter: $PYTHON"
-echo "Python version: $($PYTHON --version)"
+# Select python3 (>= 3.12) -- local if available, else a docker fallback.
+# shellcheck source=lib/select-python.sh
+source .buildkite/scripts/lib/select-python.sh
+select_python
 
 # ======== generate and upload indices ========
 

--- a/.buildkite/scripts/lib/manylinux.sh
+++ b/.buildkite/scripts/lib/manylinux.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Shared helper for rewriting a wheel's platform tag from the generic
+# ``linux_<arch>`` to the correct ``manylinux_<major>_<minor>_<arch>``.
+#
+# Sourcing this file eagerly creates an isolated venv with auditwheel and
+# registers an EXIT trap to clean it up. After sourcing, call
+# ``apply_manylinux_tag <wheel>`` on each ``linux_<arch>`` wheel; the renamed
+# path is printed on stdout.
+#
+# The venv is created eagerly (rather than lazily on first call) because
+# callers use ``apply_manylinux_tag`` inside command substitution, which
+# runs in a subshell -- any state or trap set up there would be lost the
+# moment the substitution returns.
+#
+# Caveats for callers:
+# - The library installs an EXIT trap. Callers must not set their own EXIT
+#   trap, or they will clobber the cleanup. (None of the current callers
+#   do.)
+# - The library expects ``python3`` (>= 3.10, auditwheel's floor) on PATH.
+
+if [[ -n "${_MANYLINUX_LIB_SOURCED:-}" ]]; then
+    return 0
+fi
+_MANYLINUX_LIB_SOURCED=1
+
+# Resolve our own directory regardless of caller cwd, so we can locate
+# ``detect-manylinux-tag.py`` next to us.
+_MANYLINUX_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_MANYLINUX_DETECT_SCRIPT="${_MANYLINUX_LIB_DIR}/../detect-manylinux-tag.py"
+
+_MANYLINUX_VENV_PARENT="$(mktemp -d)"
+_MANYLINUX_VENV="${_MANYLINUX_VENV_PARENT}/auditwheel-venv"
+python3 -m venv "$_MANYLINUX_VENV"
+"$_MANYLINUX_VENV/bin/pip" install --quiet --disable-pip-version-check auditwheel
+# shellcheck disable=SC2064  # Expand the path now, not when the trap fires.
+trap "rm -rf '$_MANYLINUX_VENV_PARENT'" EXIT
+
+# Detect the manylinux platform tag for a single wheel and rename it in
+# place, printing the renamed wheel path on stdout. Returns non-zero on
+# failure (which under ``set -e`` propagates to caller).
+apply_manylinux_tag() {
+    local wheel="$1"
+    local new_wheel
+    new_wheel="$("$_MANYLINUX_VENV/bin/python" "$_MANYLINUX_DETECT_SCRIPT" "$wheel")"
+    if [[ -z "$new_wheel" || ! -f "$new_wheel" ]]; then
+        echo "apply_manylinux_tag: detect-manylinux-tag.py did not produce a valid wheel path for $wheel" >&2
+        return 1
+    fi
+    printf '%s\n' "$new_wheel"
+}

--- a/.buildkite/scripts/lib/manylinux.sh
+++ b/.buildkite/scripts/lib/manylinux.sh
@@ -7,19 +7,28 @@
 #
 # Sourcing this file eagerly creates an isolated venv with auditwheel and
 # registers an EXIT trap to clean it up. After sourcing, call
-# ``apply_manylinux_tag <wheel>`` on each ``linux_<arch>`` wheel; the renamed
-# path is printed on stdout.
+# ``apply_manylinux_tag <wheel>`` on each ``linux_<arch>`` wheel; the
+# renamed path is printed on stdout.
 #
 # The venv is created eagerly (rather than lazily on first call) because
 # callers use ``apply_manylinux_tag`` inside command substitution, which
 # runs in a subshell -- any state or trap set up there would be lost the
 # moment the substitution returns.
 #
-# Caveats for callers:
-# - The library installs an EXIT trap. Callers must not set their own EXIT
-#   trap, or they will clobber the cleanup. (None of the current callers
-#   do.)
-# - The library expects ``python3`` (>= 3.10, auditwheel's floor) on PATH.
+# Configuration:
+# - ``MANYLINUX_PYTHON`` (env var, default ``python3``): the Python
+#   interpreter used to build the venv. Must point to a directly-callable
+#   ``python3`` >= 3.10 (auditwheel's floor); a Docker-wrapped Python
+#   won't work because ``python3 -m venv`` would create the venv inside
+#   the container.
+#
+# Trap behaviour:
+# - Sourcing installs an EXIT trap that calls ``manylinux_cleanup``. Any
+#   EXIT trap that was already in place when this file was sourced is
+#   captured and run AFTER our cleanup, so we don't silently clobber it.
+# - If a caller sets a new EXIT trap *after* sourcing, that trap will
+#   replace ours. In that case the caller should call
+#   ``manylinux_cleanup`` from their own handler.
 
 if [[ -n "${_MANYLINUX_LIB_SOURCED:-}" ]]; then
     return 0
@@ -31,16 +40,51 @@ _MANYLINUX_LIB_SOURCED=1
 _MANYLINUX_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 _MANYLINUX_DETECT_SCRIPT="${_MANYLINUX_LIB_DIR}/../detect-manylinux-tag.py"
 
+# Pin auditwheel: ``detect-manylinux-tag.py`` reads the internal
+# ``analyze_wheel_abi`` / ``sym_policy`` API, which is not part of any
+# stability promise, so an upstream release could silently change the
+# resulting platform tag. Bump this deliberately and re-test the
+# detection on a representative wheel from each build target.
+_MANYLINUX_AUDITWHEEL_VERSION="6.6.0"
+
+_MANYLINUX_PYTHON="${MANYLINUX_PYTHON:-python3}"
 _MANYLINUX_VENV_PARENT="$(mktemp -d)"
 _MANYLINUX_VENV="${_MANYLINUX_VENV_PARENT}/auditwheel-venv"
-python3 -m venv "$_MANYLINUX_VENV"
-"$_MANYLINUX_VENV/bin/pip" install --quiet --disable-pip-version-check auditwheel
-# shellcheck disable=SC2064  # Expand the path now, not when the trap fires.
-trap "rm -rf '$_MANYLINUX_VENV_PARENT'" EXIT
+"$_MANYLINUX_PYTHON" -m venv "$_MANYLINUX_VENV"
+"$_MANYLINUX_VENV/bin/pip" install --quiet --disable-pip-version-check \
+    "auditwheel==${_MANYLINUX_AUDITWHEEL_VERSION}"
+
+# Public cleanup function -- safe to call multiple times.
+manylinux_cleanup() {
+    rm -rf "$_MANYLINUX_VENV_PARENT"
+}
+
+# Capture any EXIT trap that was already in place so we can chain to it
+# rather than overwrite it. ``trap -p EXIT`` prints the existing handler
+# in eval-able form (``trap -- 'CMD' EXIT``) or nothing if unset; we
+# strip the wrapper to recover ``CMD``. This handles the common case --
+# CMDs without embedded single quotes -- and degrades gracefully (we
+# still run our own cleanup) for the pathological case.
+_manylinux_prev_exit_trap_cmd=""
+_manylinux_existing_exit_trap="$(trap -p EXIT)"
+if [[ -n "$_manylinux_existing_exit_trap" ]]; then
+    _tmp="${_manylinux_existing_exit_trap#trap -- \'}"
+    _manylinux_prev_exit_trap_cmd="${_tmp%\' EXIT}"
+    unset _tmp
+fi
+unset _manylinux_existing_exit_trap
+
+_manylinux_run_exit_chain() {
+    manylinux_cleanup
+    if [[ -n "$_manylinux_prev_exit_trap_cmd" ]]; then
+        eval "$_manylinux_prev_exit_trap_cmd"
+    fi
+}
+trap _manylinux_run_exit_chain EXIT
 
 # Detect the manylinux platform tag for a single wheel and rename it in
 # place, printing the renamed wheel path on stdout. Returns non-zero on
-# failure (which under ``set -e`` propagates to caller).
+# failure (which under ``set -e`` propagates to the caller).
 apply_manylinux_tag() {
     local wheel="$1"
     local new_wheel

--- a/.buildkite/scripts/lib/manylinux.sh
+++ b/.buildkite/scripts/lib/manylinux.sh
@@ -4,30 +4,36 @@
 #
 # Shared helper for rewriting a wheel's platform tag from the generic
 # ``linux_<arch>`` to the correct ``manylinux_<major>_<minor>_<arch>``.
+# After sourcing, call ``apply_manylinux_tag <wheel>`` on each wheel
+# that still carries the generic tag; the renamed path is printed on
+# stdout (logs go to stderr).
 #
-# Sourcing this file eagerly creates an isolated venv with auditwheel and
-# registers an EXIT trap to clean it up. After sourcing, call
-# ``apply_manylinux_tag <wheel>`` on each ``linux_<arch>`` wheel; the
-# renamed path is printed on stdout.
+# Why a pinned Docker container instead of using whatever Python
+# happens to be on the agent:
+#   - vLLM's release agents are heterogeneous -- they don't agree on
+#     a Python minor version, and we can't rely on a particular
+#     ``auditwheel`` being installed.
+#   - ``detect-manylinux-tag.py`` reads ``auditwheel.wheel_abi`` and
+#     ``Policy.sym_policy``, which are *internal* APIs without a
+#     stability promise. Pinning both Python and auditwheel makes the
+#     detected tag a function of the inputs alone, and shifts version
+#     bumps from "implicit drift" to "deliberate, retested change".
+#   - Other release scripts (``generate-and-upload-nightly-index.sh``,
+#     ``upload-rocm-wheels.sh``) already use the python:3-slim image
+#     when the agent's interpreter is too old; this is the same idea
+#     made stricter.
 #
-# The venv is created eagerly (rather than lazily on first call) because
-# callers use ``apply_manylinux_tag`` inside command substitution, which
-# runs in a subshell -- any state or trap set up there would be lost the
-# moment the substitution returns.
-#
-# Configuration:
-# - ``MANYLINUX_PYTHON`` (env var, default ``python3``): the Python
-#   interpreter used to build the venv. Must point to a directly-callable
-#   ``python3`` >= 3.10 (auditwheel's floor); a Docker-wrapped Python
-#   won't work because ``python3 -m venv`` would create the venv inside
-#   the container.
+# To keep the per-wheel cost down (the ROCm upload retags ~10 wheels
+# each run), we install auditwheel into a long-lived helper container
+# once on source, then ``docker exec`` into it for each call.
 #
 # Trap behaviour:
-# - Sourcing installs an EXIT trap that calls ``manylinux_cleanup``. Any
-#   EXIT trap that was already in place when this file was sourced is
-#   captured and run AFTER our cleanup, so we don't silently clobber it.
+# - Sourcing installs an EXIT trap that calls ``manylinux_cleanup`` to
+#   tear down the helper container. Any EXIT trap that was already in
+#   place when this file was sourced is captured and run AFTER our
+#   cleanup, so we don't silently clobber it.
 # - If a caller sets a new EXIT trap *after* sourcing, that trap will
-#   replace ours. In that case the caller should call
+#   replace ours; in that case the caller should call
 #   ``manylinux_cleanup`` from their own handler.
 
 if [[ -n "${_MANYLINUX_LIB_SOURCED:-}" ]]; then
@@ -35,34 +41,50 @@ if [[ -n "${_MANYLINUX_LIB_SOURCED:-}" ]]; then
 fi
 _MANYLINUX_LIB_SOURCED=1
 
-# Resolve our own directory regardless of caller cwd, so we can locate
-# ``detect-manylinux-tag.py`` next to us.
-_MANYLINUX_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-_MANYLINUX_DETECT_SCRIPT="${_MANYLINUX_LIB_DIR}/../detect-manylinux-tag.py"
-
-# Pin auditwheel: ``detect-manylinux-tag.py`` reads the internal
-# ``analyze_wheel_abi`` / ``sym_policy`` API, which is not part of any
-# stability promise, so an upstream release could silently change the
-# resulting platform tag. Bump this deliberately and re-test the
-# detection on a representative wheel from each build target.
+# Pin both sides. Bump these deliberately and re-run a representative
+# wheel from each build target through the detection.
+_MANYLINUX_PYTHON_IMAGE="python:3.12-slim"
 _MANYLINUX_AUDITWHEEL_VERSION="6.6.0"
 
-_MANYLINUX_PYTHON="${MANYLINUX_PYTHON:-python3}"
-_MANYLINUX_VENV_PARENT="$(mktemp -d)"
-_MANYLINUX_VENV="${_MANYLINUX_VENV_PARENT}/auditwheel-venv"
-"$_MANYLINUX_PYTHON" -m venv "$_MANYLINUX_VENV"
-"$_MANYLINUX_VENV/bin/pip" install --quiet --disable-pip-version-check \
+# Resolve our own directory (and the sibling detect script) using the
+# canonical, symlink-resolved path. The container mounts cwd at the
+# same absolute path on both sides, so all paths we hand to it -- the
+# script, the wheel -- must canonicalise to a location under cwd.
+_MANYLINUX_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+_MANYLINUX_DETECT_SCRIPT="$(cd "${_MANYLINUX_LIB_DIR}/.." && pwd -P)/detect-manylinux-tag.py"
+_MANYLINUX_CWD="$(pwd -P)"
+
+docker pull --quiet "$_MANYLINUX_PYTHON_IMAGE" >/dev/null
+
+# Spin up a long-lived helper container so we install auditwheel once
+# and then ``docker exec`` into it for each wheel.
+#
+# The container runs as root so ``pip install`` can write into the
+# system site-packages; individual ``docker exec`` calls below pin
+# themselves to the host UID so any file rename happens with host
+# ownership, not root.
+_MANYLINUX_CONTAINER="$(docker run -d --rm \
+    -v "$_MANYLINUX_CWD:$_MANYLINUX_CWD" \
+    -w "$_MANYLINUX_CWD" \
+    "$_MANYLINUX_PYTHON_IMAGE" \
+    sleep infinity)"
+docker exec "$_MANYLINUX_CONTAINER" \
+    pip install --quiet --disable-pip-version-check \
+    --root-user-action=ignore \
     "auditwheel==${_MANYLINUX_AUDITWHEEL_VERSION}"
 
-# Public cleanup function -- safe to call multiple times.
+# Public cleanup -- safe to call multiple times.
 manylinux_cleanup() {
-    rm -rf "$_MANYLINUX_VENV_PARENT"
+    if [[ -n "${_MANYLINUX_CONTAINER:-}" ]]; then
+        docker rm -f "$_MANYLINUX_CONTAINER" >/dev/null 2>&1 || true
+        _MANYLINUX_CONTAINER=""
+    fi
 }
 
-# Capture any EXIT trap that was already in place so we can chain to it
-# rather than overwrite it. ``trap -p EXIT`` prints the existing handler
-# in eval-able form (``trap -- 'CMD' EXIT``) or nothing if unset; we
-# strip the wrapper to recover ``CMD``. This handles the common case --
+# Capture any EXIT trap that was already in place so we can chain to
+# it rather than overwrite it. ``trap -p EXIT`` prints the handler in
+# eval-able form (``trap -- 'CMD' EXIT``) or nothing if unset; we
+# strip the wrapper to recover ``CMD``. Handles the common case --
 # CMDs without embedded single quotes -- and degrades gracefully (we
 # still run our own cleanup) for the pathological case.
 _manylinux_prev_exit_trap_cmd=""
@@ -82,13 +104,21 @@ _manylinux_run_exit_chain() {
 }
 trap _manylinux_run_exit_chain EXIT
 
-# Detect the manylinux platform tag for a single wheel and rename it in
-# place, printing the renamed wheel path on stdout. Returns non-zero on
-# failure (which under ``set -e`` propagates to the caller).
+# Detect the manylinux platform tag for a single wheel and rename it
+# in place, printing the renamed wheel path on stdout. Returns
+# non-zero on failure (which under ``set -e`` propagates to caller).
+#
+# The wheel must be reachable via a path under the host cwd so it's
+# visible inside the helper container; in CI the wheels always live
+# under ``artifacts/`` so this is fine.
 apply_manylinux_tag() {
     local wheel="$1"
+    local abs_wheel
+    abs_wheel="$(realpath "$wheel")"
     local new_wheel
-    new_wheel="$("$_MANYLINUX_VENV/bin/python" "$_MANYLINUX_DETECT_SCRIPT" "$wheel")"
+    new_wheel="$(docker exec -u "$(id -u):$(id -g)" \
+        "$_MANYLINUX_CONTAINER" \
+        python "$_MANYLINUX_DETECT_SCRIPT" "$abs_wheel")"
     if [[ -z "$new_wheel" || ! -f "$new_wheel" ]]; then
         echo "apply_manylinux_tag: detect-manylinux-tag.py did not produce a valid wheel path for $wheel" >&2
         return 1

--- a/.buildkite/scripts/lib/select-python.sh
+++ b/.buildkite/scripts/lib/select-python.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+#
+# Pick a Python interpreter for buildkite scripts: prefer a local
+# ``python3`` if it is recent enough (>= 3.12), otherwise fall back to
+# a one-shot Docker container running ``python:3-slim``. After
+# ``select_python`` returns, ``$PYTHON`` is set in the caller's shell
+# and is safe to use as a command (e.g. ``$PYTHON some_script.py``).
+#
+# The 3.12 threshold matches what the existing nightly-index work
+# expects -- typing features used by ``generate-nightly-index.py``.
+# This helper does not pin the *minor* version; if you need stricter
+# reproducibility (e.g. relying on auditwheel internals), invoke
+# Docker yourself with a pinned tag rather than calling this.
+
+if [[ -n "${_SELECT_PYTHON_LIB_SOURCED:-}" ]]; then
+    return 0
+fi
+_SELECT_PYTHON_LIB_SOURCED=1
+
+# Sets ``PYTHON`` in the caller's shell and exports it. Idempotent --
+# calling twice is safe and the second call simply re-runs the probe.
+select_python() {
+    local py="${PYTHON_PROG:-python3}"
+    local has_new_python
+    has_new_python=$("$py" -c \
+        "print(1 if __import__('sys').version_info >= (3,12) else 0)" \
+        2>/dev/null || echo 0)
+    if [[ "$has_new_python" -eq 0 ]]; then
+        # ``-u $(id -u):$(id -g)`` so files created via the container
+        # end up owned by the host user, not root.
+        docker pull python:3-slim
+        PYTHON="docker run --rm -u $(id -u):$(id -g) -v $(pwd):/app -w /app python:3-slim python3"
+    else
+        PYTHON="$py"
+    fi
+    export PYTHON
+    echo "Using python interpreter: $PYTHON"
+    echo "Python version: $($PYTHON --version)"
+}

--- a/.buildkite/scripts/upload-nightly-wheels.sh
+++ b/.buildkite/scripts/upload-nightly-wheels.sh
@@ -2,14 +2,18 @@
 
 set -ex
 
-# Upload a single wheel to S3 (rename linux -> manylinux).
+# Upload a single wheel to S3, after detecting and applying the appropriate
+# manylinux platform tag with auditwheel.
 # Index generation is handled separately by generate-and-upload-nightly-index.sh.
+
+# shellcheck source=lib/manylinux.sh
+source .buildkite/scripts/lib/manylinux.sh
 
 BUCKET="vllm-wheels"
 SUBPATH=$BUILDKITE_COMMIT
 S3_COMMIT_PREFIX="s3://$BUCKET/$SUBPATH/"
 
-# ========= collect, rename & upload the wheel ==========
+# ========= locate the wheel ==========
 
 # Assume wheels are in artifacts/dist/*.whl
 wheel_files=(artifacts/dist/*.whl)
@@ -21,19 +25,9 @@ if [[ ${#wheel_files[@]} -ne 1 ]]; then
 fi
 wheel="${wheel_files[0]}"
 
-# default build image uses ubuntu 20.04, which corresponds to manylinux_2_31
-# we also accept params as manylinux tag
-# refer to https://github.com/mayeut/pep600_compliance?tab=readme-ov-file#acceptable-distros-to-build-wheels
-manylinux_version="${1:-manylinux_2_31}"
+# ========= detect manylinux tag and rename ==========
 
-# Rename 'linux' to the appropriate manylinux version in the wheel filename
-if [[ "$wheel" != *"linux"* ]]; then
-  echo "Error: Wheel filename does not contain 'linux': $wheel"
-  exit 1
-fi
-new_wheel="${wheel/linux/$manylinux_version}"
-mv -- "$wheel" "$new_wheel"
-wheel="$new_wheel"
+wheel="$(apply_manylinux_tag "$wheel")"
 echo "Renamed wheel to: $wheel"
 
 # Extract the version from the wheel

--- a/.buildkite/scripts/upload-rocm-wheels.sh
+++ b/.buildkite/scripts/upload-rocm-wheels.sh
@@ -15,9 +15,6 @@
 
 set -ex
 
-# shellcheck source=lib/manylinux.sh
-source .buildkite/scripts/lib/manylinux.sh
-
 # ======== Configuration ========
 BUCKET="${S3_BUCKET:-vllm-wheels}"
 ROCM_SUBPATH="rocm/${BUILDKITE_COMMIT}"
@@ -47,6 +44,16 @@ fi
 
 echo "Using python interpreter: $PYTHON"
 echo "Python version: $($PYTHON --version)"
+
+# Source the manylinux helper *after* Python detection above so the venv
+# it builds (for auditwheel) uses an interpreter we know is available
+# directly on the agent. The Docker-wrapped fallback above can run the
+# index-generation script, but ``python3 -m venv`` would create the venv
+# inside the throwaway container, so we deliberately don't reuse it
+# here. Override with ``MANYLINUX_PYTHON=`` if the agent's default
+# ``python3`` is too old (auditwheel requires >= 3.10).
+# shellcheck source=lib/manylinux.sh
+source .buildkite/scripts/lib/manylinux.sh
 
 # ======== Part 1: Collect and prepare wheels ========
 

--- a/.buildkite/scripts/upload-rocm-wheels.sh
+++ b/.buildkite/scripts/upload-rocm-wheels.sh
@@ -15,15 +15,15 @@
 
 set -ex
 
+# shellcheck source=lib/manylinux.sh
+source .buildkite/scripts/lib/manylinux.sh
+
 # ======== Configuration ========
 BUCKET="${S3_BUCKET:-vllm-wheels}"
 ROCM_SUBPATH="rocm/${BUILDKITE_COMMIT}"
 S3_COMMIT_PREFIX="s3://$BUCKET/$ROCM_SUBPATH/"
 INDICES_OUTPUT_DIR="rocm-indices"
 PYTHON="${PYTHON_PROG:-python3}"
-
-# ROCm uses manylinux_2_35 (Ubuntu 22.04 based)
-MANYLINUX_VERSION="manylinux_2_35"
 
 echo "========================================"
 echo "ROCm Wheel Upload Configuration"
@@ -63,11 +63,18 @@ if [ "$WHEEL_COUNT" -eq 0 ]; then
     exit 1
 fi
 
-# Rename linux to manylinux in wheel filenames
+# Detect the appropriate manylinux platform tag for any wheel that still
+# carries the generic ``linux_<arch>`` tag, and rename it in place. We use
+# auditwheel via ``apply_manylinux_tag`` (see lib/manylinux.sh) rather than
+# a hard-coded ``manylinux_2_35`` string so that the label tracks the actual
+# glibc symbol versions used by the binaries (and stays correct if the
+# rocm_base image is rebased).
+#
+# The ``linux``/``manylinux`` filter below skips both pre-tagged wheels
+# (e.g. upstream torch) and pure-Python ``-any.whl`` wheels.
 for wheel in all-rocm-wheels/*.whl; do
     if [[ "$wheel" == *"linux"* ]] && [[ "$wheel" != *"manylinux"* ]]; then
-        new_wheel="${wheel/linux/$MANYLINUX_VERSION}"
-        mv -- "$wheel" "$new_wheel"
+        new_wheel="$(apply_manylinux_tag "$wheel")"
         echo "Renamed: $(basename "$wheel") -> $(basename "$new_wheel")"
     fi
 done

--- a/.buildkite/scripts/upload-rocm-wheels.sh
+++ b/.buildkite/scripts/upload-rocm-wheels.sh
@@ -20,7 +20,6 @@ BUCKET="${S3_BUCKET:-vllm-wheels}"
 ROCM_SUBPATH="rocm/${BUILDKITE_COMMIT}"
 S3_COMMIT_PREFIX="s3://$BUCKET/$ROCM_SUBPATH/"
 INDICES_OUTPUT_DIR="rocm-indices"
-PYTHON="${PYTHON_PROG:-python3}"
 
 echo "========================================"
 echo "ROCm Wheel Upload Configuration"
@@ -31,27 +30,19 @@ echo "Commit: $BUILDKITE_COMMIT"
 echo "Branch: $BUILDKITE_BRANCH"
 echo "========================================"
 
-# ======== Part 0: Setup Python ========
+# ======== Part 0: Setup Python and helpers ========
 
-# Detect if python3.12+ is available
-has_new_python=$($PYTHON -c "print(1 if __import__('sys').version_info >= (3,12) else 0)" 2>/dev/null || echo 0)
-if [[ "$has_new_python" -eq 0 ]]; then
-    # Use new python from docker
-    # Use --user to ensure files are created with correct ownership (not root)
-    docker pull python:3-slim
-    PYTHON="docker run --rm --user $(id -u):$(id -g) -v $(pwd):/app -w /app python:3-slim python3"
-fi
+# Pick a Python interpreter for index generation -- local if recent
+# enough, else a one-shot docker fallback.
+# shellcheck source=lib/select-python.sh
+source .buildkite/scripts/lib/select-python.sh
+select_python
 
-echo "Using python interpreter: $PYTHON"
-echo "Python version: $($PYTHON --version)"
-
-# Source the manylinux helper *after* Python detection above so the venv
-# it builds (for auditwheel) uses an interpreter we know is available
-# directly on the agent. The Docker-wrapped fallback above can run the
-# index-generation script, but ``python3 -m venv`` would create the venv
-# inside the throwaway container, so we deliberately don't reuse it
-# here. Override with ``MANYLINUX_PYTHON=`` if the agent's default
-# ``python3`` is too old (auditwheel requires >= 3.10).
+# Set up auditwheel-in-a-container for the manylinux retagging step.
+# Distinct from select_python: ``manylinux.sh`` deliberately pins both
+# the Python and auditwheel versions (the script reads auditwheel
+# internals) and so always runs in a known-good container regardless
+# of what's on the agent.
 # shellcheck source=lib/manylinux.sh
 source .buildkite/scripts/lib/manylinux.sh
 

--- a/.gitignore
+++ b/.gitignore
@@ -237,6 +237,7 @@ ep_kernels_workspace/
 
 # Allow tracked library source folders under submodules (e.g., benchmarks/lib)
 !vllm/benchmarks/lib/
+!.buildkite/scripts/lib/
 
 # Generated gRPC protobuf files (compiled at build time from vllm_engine.proto)
 vllm/grpc/vllm_engine_pb2.py


### PR DESCRIPTION
## Purpose

The release pipeline currently hard-codes the manylinux platform tag per build (`manylinux_2_31` for the Ubuntu 20.04-based image, `manylinux_2_35` for the Ubuntu 22.04-based ones, similar in `upload-rocm-wheels.sh`). That label is decoupled from reality: when we bump a base image we silently end up with wheels labelled with the wrong glibc requirement, and there is no signal in CI when the two drift apart.

This PR replaces the hard-coded strings with `auditwheel`-based detection, so the platform tag is derived from the glibc symbol versions the binaries actually reference.

`auditwheel repair` doesn't work for us — it tries to graft external shared libraries (CUDA/cuBLAS/...) into the wheel and fails. Instead we call `auditwheel.wheel_abi.analyze_wheel_abi` directly (the same call that powers `auditwheel show`) and read off `winfo.sym_policy.name`.

## Test Plan

- Local dry run passed.
- Tested with release pipeline and check artifacts.

## Test Result

https://wheels.vllm.ai/49fbd4170bf5af140551d22da84139da969c05ba/
https://buildkite.com/vllm/release-v2/builds/1055/

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

