### PR TITLE
[Model][DeepSeekV4] Use FlashMLA KV-cache path for prefill

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -307,6 +307,20 @@ def test_attention_config():
     assert args is not None
     engine_args = EngineArgs.from_cli_args(args)
     assert engine_args.attention_config == AttentionConfig()
+    attention_config = engine_args.attention_config
+    assert attention_config.use_deepseek_v4_flashmla_direct_kvcache_prefill is True
+
+    # opt out via dot notation
+    args = parser.parse_args(
+        [
+            "--attention-config.use_deepseek_v4_flashmla_direct_kvcache_prefill",
+            "false",
+        ]
+    )
+    assert args is not None
+    engine_args = EngineArgs.from_cli_args(args)
+    attention_config = engine_args.attention_config
+    assert attention_config.use_deepseek_v4_flashmla_direct_kvcache_prefill is False
 
     # set backend via dot notation
     args = parser.parse_args(["--attention-config.backend", "FLASH_ATTN"])
@@ -337,6 +351,8 @@ def test_attention_config():
             "true",
             "--attention-config.use_trtllm_ragged_deepseek_prefill",
             "true",
+            "--attention-config.use_deepseek_v4_flashmla_direct_kvcache_prefill",
+            "true",
             "--attention-config.use_trtllm_attention",
             "true",
             "--attention-config.disable_flashinfer_prefill",
@@ -354,6 +370,8 @@ def test_attention_config():
     assert engine_args.attention_config.flash_attn_max_num_splits_for_cuda_graph == 16
     assert engine_args.attention_config.use_cudnn_prefill is True
     assert engine_args.attention_config.use_trtllm_ragged_deepseek_prefill is True
+    attention_config = engine_args.attention_config
+    assert attention_config.use_deepseek_v4_flashmla_direct_kvcache_prefill is True
     assert engine_args.attention_config.use_trtllm_attention is True
     assert engine_args.attention_config.disable_flashinfer_prefill is True
     assert engine_args.attention_config.disable_flashinfer_q_quantization is True
@@ -367,6 +385,7 @@ def test_attention_config():
             '"flash_attn_max_num_splits_for_cuda_graph": 8, '
             '"use_cudnn_prefill": false, '
             '"use_trtllm_ragged_deepseek_prefill": false, '
+            '"use_deepseek_v4_flashmla_direct_kvcache_prefill": true, '
             '"use_trtllm_attention": false, '
             '"disable_flashinfer_prefill": false, '
             '"disable_flashinfer_q_quantization": false}',
@@ -381,6 +400,8 @@ def test_attention_config():
     assert engine_args.attention_config.flash_attn_max_num_splits_for_cuda_graph == 8
     assert engine_args.attention_config.use_cudnn_prefill is False
     assert engine_args.attention_config.use_trtllm_ragged_deepseek_prefill is False
+    attention_config = engine_args.attention_config
+    assert attention_config.use_deepseek_v4_flashmla_direct_kvcache_prefill is True
     assert engine_args.attention_config.use_trtllm_attention is False
     assert engine_args.attention_config.disable_flashinfer_prefill is False
     assert engine_args.attention_config.disable_flashinfer_q_quantization is False

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -308,19 +308,19 @@ def test_attention_config():
     engine_args = EngineArgs.from_cli_args(args)
     assert engine_args.attention_config == AttentionConfig()
     attention_config = engine_args.attention_config
-    assert attention_config.use_deepseek_v4_flashmla_direct_kvcache_prefill is True
+    assert attention_config.use_deepseek_v4_flashmla_direct_kvcache_prefill is False
 
-    # opt out via dot notation
+    # opt in via dot notation
     args = parser.parse_args(
         [
             "--attention-config.use_deepseek_v4_flashmla_direct_kvcache_prefill",
-            "false",
+            "true",
         ]
     )
     assert args is not None
     engine_args = EngineArgs.from_cli_args(args)
     attention_config = engine_args.attention_config
-    assert attention_config.use_deepseek_v4_flashmla_direct_kvcache_prefill is False
+    assert attention_config.use_deepseek_v4_flashmla_direct_kvcache_prefill is True
 
     # set backend via dot notation
     args = parser.parse_args(["--attention-config.backend", "FLASH_ATTN"])

--- a/tests/kernels/attention/test_flashmla_sparse.py
+++ b/tests/kernels/attention/test_flashmla_sparse.py
@@ -29,8 +29,9 @@ def test_sparse_flashmla_metadata_smoke():
         topk=topk,
         is_fp8_kvcache=True,
     )
-    assert tile_md.dtype == torch.int32
-    assert num_splits.dtype == torch.int32
+    assert isinstance(tile_md, fm.FlashMLASchedMeta)
+    assert tile_md.have_initialized is False
+    assert num_splits is None
 
 
 def test_sparse_flashmla_decode_smoke():
@@ -116,7 +117,7 @@ def test_sparse_flashmla_prefill_smoke():
     kv = torch.zeros((s_kv, h_kv, d_qk), dtype=torch.bfloat16, device=device)
     indices = torch.zeros((s_q, h_kv, topk), dtype=torch.int32, device=device)
 
-    out, max_logits, lse = fm.flash_mla_sparse_prefill(q, kv, indices, 1.0, d_v)
+    out, max_logits, lse = fm.flash_mla_sparse_fwd(q, kv, indices, 1.0, d_v)
     assert out.shape == (s_q, h_q, d_v)
     assert max_logits.shape == (s_q, h_q)
     assert lse.shape == (s_q, h_q)

--- a/vllm/config/attention.py
+++ b/vllm/config/attention.py
@@ -38,7 +38,7 @@ class AttentionConfig:
     use_trtllm_ragged_deepseek_prefill: bool = False
     """Whether to use TRTLLM ragged deepseek prefill."""
 
-    use_deepseek_v4_flashmla_direct_kvcache_prefill: bool = True
+    use_deepseek_v4_flashmla_direct_kvcache_prefill: bool = False
     """Use FlashMLA's direct KV-cache path for DeepSeek V4 prefill attention."""
 
     use_trtllm_attention: bool | None = None

--- a/vllm/config/attention.py
+++ b/vllm/config/attention.py
@@ -38,6 +38,9 @@ class AttentionConfig:
     use_trtllm_ragged_deepseek_prefill: bool = False
     """Whether to use TRTLLM ragged deepseek prefill."""
 
+    use_deepseek_v4_flashmla_direct_kvcache_prefill: bool = True
+    """Use FlashMLA's direct KV-cache path for DeepSeek V4 prefill attention."""
+
     use_trtllm_attention: bool | None = None
     """If set to True/False, use or don't use the TRTLLM attention backend
     in flashinfer. If None, auto-detect the attention backend in flashinfer."""

--- a/vllm/model_executor/layers/deepseek_v4_attention.py
+++ b/vllm/model_executor/layers/deepseek_v4_attention.py
@@ -683,11 +683,12 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
         self_kv_cache = self.kv_cache if not swa_only else None
         swa_kv_cache = self.swa_cache_layer.kv_cache
 
-        if not self.use_flashmla_direct_kvcache_prefill:
-            num_decodes = swa_metadata.num_decodes
-            num_prefills = swa_metadata.num_prefills
-            num_decode_tokens = swa_metadata.num_decode_tokens
+        num_decodes = swa_metadata.num_decodes
+        num_prefills = swa_metadata.num_prefills
+        num_decode_tokens = swa_metadata.num_decode_tokens
+        num_prefill_tokens = swa_metadata.num_prefill_tokens
 
+        if not self.use_flashmla_direct_kvcache_prefill:
             if num_prefills > 0:
                 self._forward_prefill(
                     q=q[num_decode_tokens:],
@@ -712,17 +713,19 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
                 )
             return
 
-        self._forward_decode(
-            q=q,
-            kv_cache=self_kv_cache,
-            swa_k_cache=swa_kv_cache,
-            swa_metadata=swa_metadata,
-            attn_metadata=flashmla_metadata,
-            swa_only=swa_only,
-            output=output,
-            token_slice=slice(0, q.shape[0]),
-            tile_metadata=None,
-        )
+        num_tokens = num_decode_tokens + num_prefill_tokens
+        if num_tokens > 0:
+            self._forward_decode(
+                q=q[:num_tokens],
+                kv_cache=self_kv_cache,
+                swa_k_cache=swa_kv_cache,
+                swa_metadata=swa_metadata,
+                attn_metadata=flashmla_metadata,
+                swa_only=swa_only,
+                output=output[:num_tokens],
+                token_slice=slice(0, num_tokens),
+                tile_metadata=None,
+            )
 
     def _forward_decode(
         self,
@@ -759,13 +762,23 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
                 )
                 topk_indices = global_indices.view(num_tokens, 1, -1)
             elif self.compress_ratio == 128:
-                # C128A: pre-computed during metadata build for all tokens.
-                c128a_topk_indices = attn_metadata.c128a_global_topk_indices
-                c128a_topk_lens = attn_metadata.c128a_topk_lens
-                assert c128a_topk_indices is not None
-                assert c128a_topk_lens is not None
-                topk_indices = c128a_topk_indices[token_slice]
-                topk_lens = c128a_topk_lens[token_slice]
+                total_tokens = (
+                    swa_metadata.num_decode_tokens + swa_metadata.num_prefill_tokens
+                )
+                is_full_mixed_slice = (
+                    token_slice.start == 0
+                    and token_slice.stop == total_tokens
+                    and attn_metadata.c128a_global_topk_indices is not None
+                )
+                if is_full_mixed_slice:
+                    topk_indices = attn_metadata.c128a_global_topk_indices
+                    topk_lens = attn_metadata.c128a_topk_lens
+                    assert topk_lens is not None
+                else:
+                    topk_indices = attn_metadata.c128a_global_decode_topk_indices
+                    topk_lens = attn_metadata.c128a_decode_topk_lens
+                    assert topk_indices is not None
+                    assert topk_lens is not None
             else:
                 raise ValueError(
                     f"Unsupported compress_ratio={self.compress_ratio}; "
@@ -814,10 +827,6 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
             "DeepseekSparseSWAMetadataBuilder.build_tile_scheduler did not "
             "allocate one for this layer type."
         )
-        scheduler_valid_count = None
-        if swa_metadata.refresh_tile_scheduler and not tile_metadata.have_initialized:
-            scheduler_valid_count = swa_metadata.scheduler_valid_count
-            assert scheduler_valid_count is not None
         out, _ = flash_mla_with_kvcache(
             q=q,
             k_cache=swa_cache,
@@ -833,7 +842,6 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
             extra_k_cache=extra_k_cache,
             extra_indices_in_kvcache=topk_indices,
             extra_topk_length=topk_lens,
-            scheduler_valid_count=scheduler_valid_count,
             out=output.unsqueeze(1),
         )
 

--- a/vllm/model_executor/layers/deepseek_v4_attention.py
+++ b/vllm/model_executor/layers/deepseek_v4_attention.py
@@ -62,7 +62,9 @@ from vllm.v1.attention.backends.mla.indexer import (
     DeepseekV4IndexerBackend,
     get_max_prefill_buffer_size,
 )
-from vllm.v1.attention.backends.mla.sparse_swa import DeepseekV4SWACache
+from vllm.v1.attention.backends.mla.sparse_swa import (
+    DeepseekV4SWACache,
+)
 from vllm.v1.attention.ops.flashmla import (
     flash_mla_sparse_fwd,
     flash_mla_with_kvcache,
@@ -111,8 +113,7 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
     The class does the following:
 
     1. MLA Preprocess.
-    2. Perform multi-head attention to prefill tokens and
-       multi-query attention to decode tokens separately.
+    2. Process attention through the configured DeepSeek V4 FlashMLA path.
     3. Return the output tensor.
     """
 
@@ -682,22 +683,12 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
         self_kv_cache = self.kv_cache if not swa_only else None
         swa_kv_cache = self.swa_cache_layer.kv_cache
 
-        # Split prefill and decode
-        num_decodes = swa_metadata.num_decodes
-        num_prefills = swa_metadata.num_prefills
-        num_decode_tokens = swa_metadata.num_decode_tokens
+        if not self.use_flashmla_direct_kvcache_prefill:
+            num_decodes = swa_metadata.num_decodes
+            num_prefills = swa_metadata.num_prefills
+            num_decode_tokens = swa_metadata.num_decode_tokens
 
-        if num_prefills > 0:
-            if self.use_flashmla_direct_kvcache_prefill:
-                self._forward_prefill_direct_kvcache(
-                    q=q[num_decode_tokens:],
-                    compressed_k_cache=self_kv_cache,
-                    swa_k_cache=swa_kv_cache,
-                    output=output[num_decode_tokens:],
-                    attn_metadata=flashmla_metadata,
-                    swa_metadata=swa_metadata,
-                )
-            else:
+            if num_prefills > 0:
                 self._forward_prefill(
                     q=q[num_decode_tokens:],
                     positions=positions[num_decode_tokens:],
@@ -707,53 +698,88 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
                     attn_metadata=flashmla_metadata,
                     swa_metadata=swa_metadata,
                 )
-        if num_decodes > 0:
-            self._forward_decode(
-                q=q[:num_decode_tokens],
-                kv_cache=self_kv_cache,
-                swa_metadata=swa_metadata,
-                attn_metadata=flashmla_metadata,
-                swa_only=swa_only,
-                output=output[:num_decode_tokens],
-            )
+            if num_decodes > 0:
+                self._forward_decode(
+                    q=q[:num_decode_tokens],
+                    kv_cache=self_kv_cache,
+                    swa_k_cache=swa_kv_cache,
+                    swa_metadata=swa_metadata,
+                    attn_metadata=flashmla_metadata,
+                    swa_only=swa_only,
+                    output=output[:num_decode_tokens],
+                    token_slice=slice(0, num_decode_tokens),
+                    tile_metadata=None,
+                )
+            return
+
+        self._forward_decode(
+            q=q,
+            kv_cache=self_kv_cache,
+            swa_k_cache=swa_kv_cache,
+            swa_metadata=swa_metadata,
+            attn_metadata=flashmla_metadata,
+            swa_only=swa_only,
+            output=output,
+            token_slice=slice(0, q.shape[0]),
+            tile_metadata=None,
+        )
 
     def _forward_decode(
         self,
         q: torch.Tensor,
         kv_cache: torch.Tensor | None,  # Only used when compress_ratio > 1
+        swa_k_cache: torch.Tensor,
         swa_metadata: "DeepseekSparseSWAMetadata",
         attn_metadata: FlashMLASparseMetadata | None,
         swa_only: bool,
         output: torch.Tensor,
+        token_slice: slice,
+        tile_metadata,
     ) -> None:
-        num_decodes = swa_metadata.num_decodes
-        num_decode_tokens = swa_metadata.num_decode_tokens
+        num_tokens = q.shape[0]
 
         topk_indices = None
         topk_lens = None
+        extra_k_cache = None
         if not swa_only:
             assert attn_metadata is not None
             assert swa_metadata.is_valid_token is not None
+            assert swa_metadata.token_to_req_indices is not None
             block_size = attn_metadata.block_size // self.compress_ratio
-            is_valid = swa_metadata.is_valid_token[:num_decode_tokens]
+            is_valid = swa_metadata.is_valid_token[token_slice]
             if self.compress_ratio == 4:
                 # C4A: local indices differ per layer (filled by Indexer).
                 assert self.topk_indices_buffer is not None
                 global_indices, topk_lens = compute_global_topk_indices_and_lens(
-                    self.topk_indices_buffer[:num_decode_tokens],
-                    swa_metadata.token_to_req_indices,
-                    attn_metadata.block_table[:num_decodes],
+                    self.topk_indices_buffer[token_slice],
+                    swa_metadata.token_to_req_indices[token_slice],
+                    attn_metadata.block_table,
                     block_size,
                     is_valid,
                 )
-                topk_indices = global_indices.view(num_decode_tokens, 1, -1)
+                topk_indices = global_indices.view(num_tokens, 1, -1)
+            elif self.compress_ratio == 128:
+                # C128A: pre-computed during metadata build for all tokens.
+                c128a_topk_indices = attn_metadata.c128a_global_topk_indices
+                c128a_topk_lens = attn_metadata.c128a_topk_lens
+                assert c128a_topk_indices is not None
+                assert c128a_topk_lens is not None
+                topk_indices = c128a_topk_indices[token_slice]
+                topk_lens = c128a_topk_lens[token_slice]
             else:
-                # C128A: pre-computed during metadata build.
-                topk_indices = attn_metadata.c128a_global_decode_topk_indices
-                topk_lens = attn_metadata.c128a_decode_topk_lens
+                raise ValueError(
+                    f"Unsupported compress_ratio={self.compress_ratio}; "
+                    "expected 1, 4, or 128."
+                )
+            assert kv_cache is not None
+            extra_k_cache = kv_cache.unsqueeze(-2)
 
-        swa_indices = swa_metadata.decode_swa_indices
-        swa_lens = swa_metadata.decode_swa_lens
+        swa_indices_all = swa_metadata.swa_indices
+        swa_lens_all = swa_metadata.swa_lens
+        assert swa_indices_all is not None
+        assert swa_lens_all is not None
+        swa_indices = swa_indices_all[token_slice]
+        swa_lens = swa_lens_all[token_slice]
 
         # We treat queries in the same seq as different queries
         # and later we only attend by generated indices.
@@ -762,35 +788,36 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
 
         # Prepare SWA cache (num_blocks, swa_block_size, 1, head_bytes)
         # Use unsqueeze to preserve strides (handles padded blocks correctly)
-        swa_cache = self.swa_cache_layer.kv_cache.unsqueeze(-2)
-        # Reshape KV cache to (num_blocks, block_size, 1, head_bytes)
-        if kv_cache is not None:
-            kv_cache = kv_cache.unsqueeze(-2)
+        swa_cache = swa_k_cache.unsqueeze(-2)
 
         # One FlashMLASchedMeta per layer type, shared across all same-type
-        # layers within this decode step. The first forward call per type
+        # layers within this step. The first forward call per type
         # triggers the in-kernel planner (allocating tile_scheduler_metadata
         # and num_splits via PyTorch's graph-aware allocator so CUDA graph
         # capture reuses the same addresses on replay); subsequent same-type
         # layers see have_initialized=True and skip the planner.
-        if self.compress_ratio <= 1:
-            tile_metadata = swa_metadata.tile_sched_swaonly
-        elif self.compress_ratio == 4:
-            tile_metadata = swa_metadata.tile_sched_c4a
-        elif self.compress_ratio == 128:
-            tile_metadata = swa_metadata.tile_sched_c128a
-        else:
-            raise ValueError(
-                f"Unsupported compress_ratio={self.compress_ratio}; "
-                "expected 1, 4, or 128."
-            )
+        if tile_metadata is None:
+            if self.compress_ratio <= 1:
+                tile_metadata = swa_metadata.tile_sched_swaonly
+            elif self.compress_ratio == 4:
+                tile_metadata = swa_metadata.tile_sched_c4a
+            elif self.compress_ratio == 128:
+                tile_metadata = swa_metadata.tile_sched_c128a
+            else:
+                raise ValueError(
+                    f"Unsupported compress_ratio={self.compress_ratio}; "
+                    "expected 1, 4, or 128."
+                )
         assert tile_metadata is not None, (
             "swa_metadata missing tile_sched entry for "
             f"compress_ratio={self.compress_ratio}; "
             "DeepseekSparseSWAMetadataBuilder.build_tile_scheduler did not "
             "allocate one for this layer type."
         )
-
+        scheduler_valid_count = None
+        if swa_metadata.refresh_tile_scheduler and not tile_metadata.have_initialized:
+            scheduler_valid_count = swa_metadata.scheduler_valid_count
+            assert scheduler_valid_count is not None
         out, _ = flash_mla_with_kvcache(
             q=q,
             k_cache=swa_cache,
@@ -803,100 +830,10 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
             topk_length=swa_lens,
             softmax_scale=self.scale,
             attn_sink=self.attn_sink,
-            extra_k_cache=kv_cache if not swa_only else None,
-            extra_indices_in_kvcache=topk_indices,
-            extra_topk_length=topk_lens,
-            out=output.unsqueeze(1),
-        )
-
-    def _forward_prefill_direct_kvcache(
-        self,
-        q: torch.Tensor,
-        compressed_k_cache: torch.Tensor | None,
-        swa_k_cache: torch.Tensor,
-        output: torch.Tensor,
-        attn_metadata: FlashMLASparseMetadata | None,
-        swa_metadata: "DeepseekSparseSWAMetadata",
-    ) -> None:
-        swa_only = compressed_k_cache is None
-        num_prefill_tokens = swa_metadata.num_prefill_tokens
-        num_decode_tokens = swa_metadata.num_decode_tokens
-
-        assert q.shape[0] == num_prefill_tokens
-        assert output.shape[0] == num_prefill_tokens
-        assert swa_metadata.prefill_swa_indices is not None
-        assert swa_metadata.prefill_swa_lens is not None
-
-        topk_indices = None
-        topk_lens = None
-        extra_k_cache = None
-        if not swa_only:
-            assert attn_metadata is not None
-            assert compressed_k_cache is not None
-            assert swa_metadata.is_valid_token is not None
-            assert swa_metadata.token_to_req_indices is not None
-
-            token_slice = slice(
-                num_decode_tokens, num_decode_tokens + num_prefill_tokens
-            )
-            block_size = attn_metadata.block_size // self.compress_ratio
-            is_valid = swa_metadata.is_valid_token[token_slice]
-            token_to_req_indices = swa_metadata.token_to_req_indices[token_slice]
-
-            if self.compress_ratio == 4:
-                assert self.topk_indices_buffer is not None
-                local_topk_indices = self.topk_indices_buffer[token_slice]
-            elif self.compress_ratio == 128:
-                local_topk_indices = attn_metadata.c128a_prefill_topk_indices
-                assert local_topk_indices is not None
-            else:
-                raise ValueError(
-                    f"Unsupported compress_ratio={self.compress_ratio}; "
-                    "expected 1, 4, or 128."
-                )
-
-            global_indices, topk_lens = compute_global_topk_indices_and_lens(
-                local_topk_indices,
-                token_to_req_indices,
-                attn_metadata.block_table,
-                block_size,
-                is_valid,
-            )
-            topk_indices = global_indices.view(num_prefill_tokens, 1, -1)
-            extra_k_cache = compressed_k_cache.unsqueeze(-2)
-
-        if self.compress_ratio <= 1:
-            tile_metadata = swa_metadata.prefill_tile_sched_swaonly
-        elif self.compress_ratio == 4:
-            tile_metadata = swa_metadata.prefill_tile_sched_c4a
-        elif self.compress_ratio == 128:
-            tile_metadata = swa_metadata.prefill_tile_sched_c128a
-        else:
-            raise ValueError(
-                f"Unsupported compress_ratio={self.compress_ratio}; "
-                "expected 1, 4, or 128."
-            )
-        assert tile_metadata is not None, (
-            "swa_metadata missing prefill tile_sched entry for "
-            f"compress_ratio={self.compress_ratio}; "
-            "DeepseekSparseSWAMetadataBuilder did not allocate one."
-        )
-
-        flash_mla_with_kvcache(
-            q=q.unsqueeze(1),
-            k_cache=swa_k_cache.unsqueeze(-2),
-            block_table=None,
-            cache_seqlens=None,
-            head_dim_v=512,
-            tile_scheduler_metadata=tile_metadata,
-            is_fp8_kvcache=True,
-            indices=swa_metadata.prefill_swa_indices,
-            topk_length=swa_metadata.prefill_swa_lens,
-            attn_sink=self.attn_sink,
             extra_k_cache=extra_k_cache,
             extra_indices_in_kvcache=topk_indices,
             extra_topk_length=topk_lens,
-            softmax_scale=self.scale,
+            scheduler_valid_count=scheduler_valid_count,
             out=output.unsqueeze(1),
         )
 
@@ -935,10 +872,16 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
                 assert self.topk_indices_buffer is not None
                 topk_indices = self.topk_indices_buffer[num_decode_tokens:]
                 topk_indices = topk_indices[:num_prefill_tokens]
-            else:
+            elif self.compress_ratio == 128:
                 # C128A: pre-computed during metadata build.
                 assert attn_metadata is not None
                 topk_indices = attn_metadata.c128a_prefill_topk_indices
+                assert topk_indices is not None
+            else:
+                raise ValueError(
+                    f"Unsupported compress_ratio={self.compress_ratio}; "
+                    "expected 1, 4, or 128."
+                )
             top_k = topk_indices.shape[-1]
             # Compressed region must fit the full compressed pool (seq_len //
             # compress_ratio), not just top_k. top_k bounds how many indices
@@ -963,7 +906,7 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
             chunk_end = min(chunk_start + PREFILL_CHUNK_SIZE, num_prefills)
             chunk_size = chunk_end - chunk_start
             if not swa_only:
-                # Gather compressed KV
+                # Gather compressed KV.
                 assert attn_metadata is not None
                 block_table = attn_metadata.block_table[num_decodes:]
                 dequantize_and_gather_k_cache(
@@ -976,7 +919,7 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
                     offset=0,
                 )
 
-            # Gather SWA KV
+            # Gather SWA KV.
             swa_block_table = swa_metadata.block_table[num_decodes:]
             dequantize_and_gather_k_cache(
                 kv[:chunk_size],
@@ -988,7 +931,7 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
                 offset=N,
             )
 
-            # Combine the topk indices and SWA indices for gathered KV cache
+            # Combine the topk indices and SWA indices for gathered KV cache.
             query_start = (
                 query_start_loc_cpu[num_decodes + chunk_start] - prefill_token_base
             )

--- a/vllm/model_executor/layers/deepseek_v4_attention.py
+++ b/vllm/model_executor/layers/deepseek_v4_attention.py
@@ -394,16 +394,18 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
             # run returns before mla_attn runs, so without this the shared
             # workspace locks below the real prefill size.
             sub = self.mla_attn
-            swa_only = sub.compress_ratio <= 1
-            N = (
-                0
-                if swa_only
-                else (sub.max_model_len + sub.compress_ratio - 1) // sub.compress_ratio
-            )
-            M = N + sub.window_size + sub.max_num_batched_tokens
-            current_workspace_manager().get_simultaneous(
-                ((PREFILL_CHUNK_SIZE, M, q.shape[-1]), torch.bfloat16),
-            )
+            if not sub.use_flashmla_direct_kvcache_prefill:
+                swa_only = sub.compress_ratio <= 1
+                N = (
+                    0
+                    if swa_only
+                    else (sub.max_model_len + sub.compress_ratio - 1)
+                    // sub.compress_ratio
+                )
+                M = N + sub.window_size + sub.max_num_batched_tokens
+                current_workspace_manager().get_simultaneous(
+                    ((PREFILL_CHUNK_SIZE, M, q.shape[-1]), torch.bfloat16),
+                )
             out.zero_()
             return
 
@@ -587,6 +589,10 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
 
         # Get vllm config for cache setup
         vllm_config = get_current_vllm_config()
+        attention_config = vllm_config.attention_config
+        self.use_flashmla_direct_kvcache_prefill = (
+            attention_config.use_deepseek_v4_flashmla_direct_kvcache_prefill
+        )
         self.max_num_batched_tokens = (
             vllm_config.scheduler_config.max_num_batched_tokens
         )
@@ -682,15 +688,25 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
         num_decode_tokens = swa_metadata.num_decode_tokens
 
         if num_prefills > 0:
-            self._forward_prefill(
-                q=q[num_decode_tokens:],
-                positions=positions[num_decode_tokens:],
-                compressed_k_cache=self_kv_cache,
-                swa_k_cache=swa_kv_cache,
-                output=output[num_decode_tokens:],
-                attn_metadata=flashmla_metadata,
-                swa_metadata=swa_metadata,
-            )
+            if self.use_flashmla_direct_kvcache_prefill:
+                self._forward_prefill_direct_kvcache(
+                    q=q[num_decode_tokens:],
+                    compressed_k_cache=self_kv_cache,
+                    swa_k_cache=swa_kv_cache,
+                    output=output[num_decode_tokens:],
+                    attn_metadata=flashmla_metadata,
+                    swa_metadata=swa_metadata,
+                )
+            else:
+                self._forward_prefill(
+                    q=q[num_decode_tokens:],
+                    positions=positions[num_decode_tokens:],
+                    compressed_k_cache=self_kv_cache,
+                    swa_k_cache=swa_kv_cache,
+                    output=output[num_decode_tokens:],
+                    attn_metadata=flashmla_metadata,
+                    swa_metadata=swa_metadata,
+                )
         if num_decodes > 0:
             self._forward_decode(
                 q=q[:num_decode_tokens],
@@ -790,6 +806,97 @@ class DeepseekV4MLAAttention(nn.Module, AttentionLayerBase):
             extra_k_cache=kv_cache if not swa_only else None,
             extra_indices_in_kvcache=topk_indices,
             extra_topk_length=topk_lens,
+            out=output.unsqueeze(1),
+        )
+
+    def _forward_prefill_direct_kvcache(
+        self,
+        q: torch.Tensor,
+        compressed_k_cache: torch.Tensor | None,
+        swa_k_cache: torch.Tensor,
+        output: torch.Tensor,
+        attn_metadata: FlashMLASparseMetadata | None,
+        swa_metadata: "DeepseekSparseSWAMetadata",
+    ) -> None:
+        swa_only = compressed_k_cache is None
+        num_prefill_tokens = swa_metadata.num_prefill_tokens
+        num_decode_tokens = swa_metadata.num_decode_tokens
+
+        assert q.shape[0] == num_prefill_tokens
+        assert output.shape[0] == num_prefill_tokens
+        assert swa_metadata.prefill_swa_indices is not None
+        assert swa_metadata.prefill_swa_lens is not None
+
+        topk_indices = None
+        topk_lens = None
+        extra_k_cache = None
+        if not swa_only:
+            assert attn_metadata is not None
+            assert compressed_k_cache is not None
+            assert swa_metadata.is_valid_token is not None
+            assert swa_metadata.token_to_req_indices is not None
+
+            token_slice = slice(
+                num_decode_tokens, num_decode_tokens + num_prefill_tokens
+            )
+            block_size = attn_metadata.block_size // self.compress_ratio
+            is_valid = swa_metadata.is_valid_token[token_slice]
+            token_to_req_indices = swa_metadata.token_to_req_indices[token_slice]
+
+            if self.compress_ratio == 4:
+                assert self.topk_indices_buffer is not None
+                local_topk_indices = self.topk_indices_buffer[token_slice]
+            elif self.compress_ratio == 128:
+                local_topk_indices = attn_metadata.c128a_prefill_topk_indices
+                assert local_topk_indices is not None
+            else:
+                raise ValueError(
+                    f"Unsupported compress_ratio={self.compress_ratio}; "
+                    "expected 1, 4, or 128."
+                )
+
+            global_indices, topk_lens = compute_global_topk_indices_and_lens(
+                local_topk_indices,
+                token_to_req_indices,
+                attn_metadata.block_table,
+                block_size,
+                is_valid,
+            )
+            topk_indices = global_indices.view(num_prefill_tokens, 1, -1)
+            extra_k_cache = compressed_k_cache.unsqueeze(-2)
+
+        if self.compress_ratio <= 1:
+            tile_metadata = swa_metadata.prefill_tile_sched_swaonly
+        elif self.compress_ratio == 4:
+            tile_metadata = swa_metadata.prefill_tile_sched_c4a
+        elif self.compress_ratio == 128:
+            tile_metadata = swa_metadata.prefill_tile_sched_c128a
+        else:
+            raise ValueError(
+                f"Unsupported compress_ratio={self.compress_ratio}; "
+                "expected 1, 4, or 128."
+            )
+        assert tile_metadata is not None, (
+            "swa_metadata missing prefill tile_sched entry for "
+            f"compress_ratio={self.compress_ratio}; "
+            "DeepseekSparseSWAMetadataBuilder did not allocate one."
+        )
+
+        flash_mla_with_kvcache(
+            q=q.unsqueeze(1),
+            k_cache=swa_k_cache.unsqueeze(-2),
+            block_table=None,
+            cache_seqlens=None,
+            head_dim_v=512,
+            tile_scheduler_metadata=tile_metadata,
+            is_fp8_kvcache=True,
+            indices=swa_metadata.prefill_swa_indices,
+            topk_length=swa_metadata.prefill_swa_lens,
+            attn_sink=self.attn_sink,
+            extra_k_cache=extra_k_cache,
+            extra_indices_in_kvcache=topk_indices,
+            extra_topk_length=topk_lens,
+            softmax_scale=self.scale,
             out=output.unsqueeze(1),
         )
 

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -245,11 +245,11 @@ class FlashMLASparseMetadata(AttentionMetadata):
     fp8_extra_metadata: FP8SeparatePrefillDecode | FP8KernelMetadata | None = None
     fp8_use_mixed_batch: bool = False
 
-    # Pre-computed C128A metadata (DeepseekV4 only, compress_ratio == 128).
-    # Decode: global slot ids + valid-entry counts (fused from positions).
-    c128a_global_decode_topk_indices: torch.Tensor | None = None
-    c128a_decode_topk_lens: torch.Tensor | None = None
-    # Prefill: local topk indices (used by combine_topk_swa_indices).
+    # Pre-computed C128A metadata for all DeepseekV4 tokens
+    # (compress_ratio == 128): global slot ids + valid-entry counts.
+    c128a_global_topk_indices: torch.Tensor | None = None
+    c128a_topk_lens: torch.Tensor | None = None
+    # Prefill-local top-k indices for the DeepSeek V4 bf16 prefill fallback.
     c128a_prefill_topk_indices: torch.Tensor | None = None
 
 
@@ -390,15 +390,14 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
                 # Stored so _build_c128a_metadata passes it as the kernel's
                 # max_compressed_tokens, matching the buffer stride. Otherwise
                 # the kernel's default 8192 iterates past row width and spills
-                # writes into adjacent rows (present in both decode and prefill
-                # branches of _build_c128a_topk_metadata_kernel).
+                # writes into adjacent rows.
                 self.c128a_max_compressed = c128a_max_compressed
-                self.c128a_global_decode_buffer = torch.empty(
+                self.c128a_global_topk_buffer = torch.empty(
                     (max_num_batched_tokens, c128a_max_compressed),
                     dtype=torch.int32,
                     device=self.device,
                 )
-                self.c128a_decode_lens_buffer = torch.empty(
+                self.c128a_topk_lens_buffer = torch.empty(
                     max_num_batched_tokens,
                     dtype=torch.int32,
                     device=self.device,
@@ -663,46 +662,37 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
         cm: CommonAttentionMetadata,
         req_id_per_token: torch.Tensor,
     ) -> dict[str, torch.Tensor | None]:
-        """Pre-compute C128A topk indices for DeepseekV4 (compress_ratio >= 128)."""
-        # Must match SWA's decode split (no `require_uniform=True`) so
-        # `c128a_global_decode_topk_indices.shape[0]` lines up with q in
-        # `_forward_decode`. The per-token C128A kernel handles non-uniform
-        # query lengths.
-        (num_decodes, _, num_decode_tokens, num_prefill_tokens) = (
-            split_decodes_and_prefills(
-                cm,
-                decode_threshold=self.reorder_batch_threshold or 1,
-            )
-        )
-
-        num_total = num_decode_tokens + num_prefill_tokens
+        """Pre-compute global C128A topk indices for all DeepseekV4 tokens."""
+        num_total = cm.num_actual_tokens
         if num_total == 0:
             return {}
+        (_, _, num_decode_tokens, num_prefill_tokens) = split_decodes_and_prefills(
+            cm,
+            decode_threshold=self.reorder_batch_threshold or 1,
+        )
 
         assert cm.positions is not None, (
             "positions is required for C128A metadata build"
         )
         block_size = self.kv_cache_spec.block_size // self.compress_ratio
-        global_decode, decode_lens, prefill_local = build_c128a_topk_metadata(
+        global_topk, topk_lens, prefill_local = build_c128a_topk_metadata(
             cm.positions[:num_total],
             self.compress_ratio,
             num_decode_tokens,
-            req_id_per_token,
-            cm.block_table_tensor[:num_decodes],
+            req_id_per_token[:num_total],
+            cm.block_table_tensor,
             block_size,
-            cm.slot_mapping,
-            self.c128a_global_decode_buffer,
-            self.c128a_decode_lens_buffer,
+            cm.slot_mapping[:num_total],
+            self.c128a_global_topk_buffer,
+            self.c128a_topk_lens_buffer,
             self.c128a_prefill_buffer,
             max_compressed_tokens=self.c128a_max_compressed,
         )
 
-        result: dict[str, torch.Tensor | None] = {}
-        if num_decode_tokens > 0:
-            result["c128a_global_decode_topk_indices"] = global_decode.view(
-                num_decode_tokens, 1, -1
-            )
-            result["c128a_decode_topk_lens"] = decode_lens
+        result: dict[str, torch.Tensor | None] = {
+            "c128a_global_topk_indices": global_topk.view(num_total, 1, -1),
+            "c128a_topk_lens": topk_lens,
+        }
         if num_prefill_tokens > 0:
             result["c128a_prefill_topk_indices"] = prefill_local
         return result
@@ -1059,15 +1049,12 @@ def build_c128a_topk_metadata(
     block_table: torch.Tensor,
     block_size: int,
     slot_mapping: torch.Tensor,
-    global_decode_buffer: torch.Tensor,
-    decode_lens_buffer: torch.Tensor,
+    global_topk_buffer: torch.Tensor,
+    topk_lens_buffer: torch.Tensor,
     prefill_buffer: torch.Tensor,
     max_compressed_tokens: int = 8192,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Single kernel for all C128A tokens (decode + prefill).
-
-    Decode tokens: position → block_table lookup → global slot ids + topk_lens.
-    Prefill tokens: position → local indices [0, ..., n-1, -1, ...].
+    """Build global C128A topk metadata for all tokens.
 
     Writes into pre-allocated buffers for CUDA graph address stability.
     Returns slices of the buffers.
@@ -1075,17 +1062,17 @@ def build_c128a_topk_metadata(
     num_tokens = positions.shape[0]
     num_prefill_tokens = num_tokens - num_decode_tokens
 
-    global_decode = global_decode_buffer[:num_decode_tokens]
-    decode_lens = decode_lens_buffer[:num_decode_tokens]
+    global_topk = global_topk_buffer[:num_tokens]
+    topk_lens = topk_lens_buffer[:num_tokens]
     prefill_local = prefill_buffer[:num_prefill_tokens]
 
     if num_tokens == 0:
-        return global_decode, decode_lens, prefill_local
+        return global_topk, topk_lens, prefill_local
 
     _build_c128a_topk_metadata_kernel[(num_tokens,)](
-        global_decode_buffer,
-        global_decode_buffer.stride(0),
-        decode_lens_buffer,
+        global_topk_buffer,
+        global_topk_buffer.stride(0),
+        topk_lens_buffer,
         prefill_buffer,
         prefill_buffer.stride(0),
         positions,
@@ -1099,16 +1086,15 @@ def build_c128a_topk_metadata(
         slot_mapping,
         BLOCK_SIZE=1024,
     )
-    return global_decode, decode_lens, prefill_local
+    return global_topk, topk_lens, prefill_local
 
 
 @triton.jit
 def _build_c128a_topk_metadata_kernel(
-    # Decode outputs
-    global_decode_ptr,
-    global_decode_stride,
-    decode_lens_ptr,
-    # Prefill output
+    # Outputs
+    global_topk_ptr,
+    global_topk_stride,
+    topk_lens_ptr,
     prefill_local_ptr,
     prefill_local_stride,
     # Inputs
@@ -1127,45 +1113,56 @@ def _build_c128a_topk_metadata_kernel(
     position = tl.load(positions_ptr + token_idx)
     num_compressed = (position + 1) // compress_ratio
     num_compressed = tl.minimum(num_compressed, max_compressed_tokens)
-    is_decode = token_idx < num_decode_tokens
+    is_prefill = token_idx >= num_decode_tokens
 
-    if is_decode:
-        # --- Decode: block-table lookup → global slot ids + count ---
-        is_valid_token = tl.load(slot_mapping_ptr + token_idx) >= 0
-        req_idx = tl.load(token_to_req_indices_ptr + token_idx)
-        count = tl.zeros((), dtype=tl.int32)
+    is_valid_token = tl.load(slot_mapping_ptr + token_idx) >= 0
+    if not is_valid_token:
         for i in range(0, max_compressed_tokens, BLOCK_SIZE):
             offset = i + tl.arange(0, BLOCK_SIZE)
             mask = offset < max_compressed_tokens
-            is_valid = offset < num_compressed
-
-            block_indices = offset // block_size
-            block_numbers = tl.load(
-                block_table_ptr + req_idx * block_table_stride + block_indices,
-                mask=mask & is_valid,
-            )
-            block_offsets = offset % block_size
-            slot_ids = block_numbers * block_size + block_offsets
-            slot_ids = tl.where(is_valid, slot_ids, -1)
             tl.store(
-                global_decode_ptr + token_idx * global_decode_stride + offset,
-                slot_ids,
+                global_topk_ptr + token_idx * global_topk_stride + offset,
+                -1,
                 mask=mask,
             )
-            count += tl.sum(is_valid.to(tl.int32), axis=0)
-
-        tl.store(
-            decode_lens_ptr + token_idx,
-            tl.where(is_valid_token, count, 0),
-        )
-    else:
-        # --- Prefill: write local indices ---
-        pfx_idx = token_idx - num_decode_tokens
-        for i in range(0, max_compressed_tokens, BLOCK_SIZE):
-            offset = i + tl.arange(0, BLOCK_SIZE)
-            mask = offset < max_compressed_tokens
+            pfx_idx = token_idx - num_decode_tokens
             tl.store(
                 prefill_local_ptr + pfx_idx * prefill_local_stride + offset,
-                tl.where(offset < num_compressed, offset, -1),
-                mask=mask,
+                -1,
+                mask=mask & is_prefill,
             )
+        tl.store(topk_lens_ptr + token_idx, 0)
+        return
+
+    req_idx = tl.load(token_to_req_indices_ptr + token_idx)
+    count = tl.zeros((), dtype=tl.int32)
+    for i in range(0, max_compressed_tokens, BLOCK_SIZE):
+        offset = i + tl.arange(0, BLOCK_SIZE)
+        mask = offset < max_compressed_tokens
+        is_valid = offset < num_compressed
+
+        block_indices = offset // block_size
+        block_numbers = tl.load(
+            block_table_ptr + req_idx * block_table_stride + block_indices,
+            mask=mask & is_valid,
+        )
+        block_offsets = offset % block_size
+        slot_ids = block_numbers * block_size + block_offsets
+        slot_ids = tl.where(is_valid, slot_ids, -1)
+        tl.store(
+            global_topk_ptr + token_idx * global_topk_stride + offset,
+            slot_ids,
+            mask=mask,
+        )
+        pfx_idx = token_idx - num_decode_tokens
+        tl.store(
+            prefill_local_ptr + pfx_idx * prefill_local_stride + offset,
+            tl.where(offset < num_compressed, offset, -1),
+            mask=mask & is_prefill,
+        )
+        count += tl.sum(is_valid.to(tl.int32), axis=0)
+
+    tl.store(
+        topk_lens_ptr + token_idx,
+        tl.where(is_valid_token, count, 0),
+    )

--- a/vllm/v1/attention/backends/mla/flashmla_sparse.py
+++ b/vllm/v1/attention/backends/mla/flashmla_sparse.py
@@ -245,11 +245,14 @@ class FlashMLASparseMetadata(AttentionMetadata):
     fp8_extra_metadata: FP8SeparatePrefillDecode | FP8KernelMetadata | None = None
     fp8_use_mixed_batch: bool = False
 
-    # Pre-computed C128A metadata for all DeepseekV4 tokens
-    # (compress_ratio == 128): global slot ids + valid-entry counts.
+    # Pre-computed C128A metadata (DeepseekV4 only, compress_ratio == 128).
+    # Direct KV-cache prefill uses the mixed global fields for the single
+    # FlashMLA decode-kernel call. The decode/prefill-specific fields are kept
+    # for the normal bf16-prefill fallback path.
     c128a_global_topk_indices: torch.Tensor | None = None
     c128a_topk_lens: torch.Tensor | None = None
-    # Prefill-local top-k indices for the DeepSeek V4 bf16 prefill fallback.
+    c128a_global_decode_topk_indices: torch.Tensor | None = None
+    c128a_decode_topk_lens: torch.Tensor | None = None
     c128a_prefill_topk_indices: torch.Tensor | None = None
 
 
@@ -662,14 +665,17 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
         cm: CommonAttentionMetadata,
         req_id_per_token: torch.Tensor,
     ) -> dict[str, torch.Tensor | None]:
-        """Pre-compute global C128A topk indices for all DeepseekV4 tokens."""
-        num_total = cm.num_actual_tokens
+        """Pre-compute C128A topk indices for DeepseekV4."""
+        (num_decodes, _, num_decode_tokens, num_prefill_tokens) = (
+            split_decodes_and_prefills(
+                cm,
+                decode_threshold=self.reorder_batch_threshold or 1,
+            )
+        )
+
+        num_total = num_decode_tokens + num_prefill_tokens
         if num_total == 0:
             return {}
-        (_, _, num_decode_tokens, num_prefill_tokens) = split_decodes_and_prefills(
-            cm,
-            decode_threshold=self.reorder_batch_threshold or 1,
-        )
 
         assert cm.positions is not None, (
             "positions is required for C128A metadata build"
@@ -679,20 +685,24 @@ class FlashMLASparseMetadataBuilder(AttentionMetadataBuilder[FlashMLASparseMetad
             cm.positions[:num_total],
             self.compress_ratio,
             num_decode_tokens,
-            req_id_per_token[:num_total],
+            req_id_per_token,
             cm.block_table_tensor,
             block_size,
-            cm.slot_mapping[:num_total],
+            cm.slot_mapping,
             self.c128a_global_topk_buffer,
             self.c128a_topk_lens_buffer,
             self.c128a_prefill_buffer,
             max_compressed_tokens=self.c128a_max_compressed,
         )
 
-        result: dict[str, torch.Tensor | None] = {
-            "c128a_global_topk_indices": global_topk.view(num_total, 1, -1),
-            "c128a_topk_lens": topk_lens,
-        }
+        result: dict[str, torch.Tensor | None] = {}
+        result["c128a_global_topk_indices"] = global_topk.view(num_total, 1, -1)
+        result["c128a_topk_lens"] = topk_lens
+        if num_decode_tokens > 0:
+            result["c128a_global_decode_topk_indices"] = global_topk[
+                :num_decode_tokens
+            ].view(num_decode_tokens, 1, -1)
+            result["c128a_decode_topk_lens"] = topk_lens[:num_decode_tokens]
         if num_prefill_tokens > 0:
             result["c128a_prefill_topk_indices"] = prefill_local
         return result
@@ -1054,7 +1064,11 @@ def build_c128a_topk_metadata(
     prefill_buffer: torch.Tensor,
     max_compressed_tokens: int = 8192,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Build global C128A topk metadata for all tokens.
+    """Build C128A topk metadata for decode and prefill tokens.
+
+    All tokens: position -> block_table lookup -> global slot ids + topk_lens.
+    Prefill tokens additionally keep local indices [0, ..., n - 1, -1, ...]
+    for the bf16-prefill fallback path.
 
     Writes into pre-allocated buffers for CUDA graph address stability.
     Returns slices of the buffers.
@@ -1113,38 +1127,20 @@ def _build_c128a_topk_metadata_kernel(
     position = tl.load(positions_ptr + token_idx)
     num_compressed = (position + 1) // compress_ratio
     num_compressed = tl.minimum(num_compressed, max_compressed_tokens)
-    is_prefill = token_idx >= num_decode_tokens
-
     is_valid_token = tl.load(slot_mapping_ptr + token_idx) >= 0
-    if not is_valid_token:
-        for i in range(0, max_compressed_tokens, BLOCK_SIZE):
-            offset = i + tl.arange(0, BLOCK_SIZE)
-            mask = offset < max_compressed_tokens
-            tl.store(
-                global_topk_ptr + token_idx * global_topk_stride + offset,
-                -1,
-                mask=mask,
-            )
-            pfx_idx = token_idx - num_decode_tokens
-            tl.store(
-                prefill_local_ptr + pfx_idx * prefill_local_stride + offset,
-                -1,
-                mask=mask & is_prefill,
-            )
-        tl.store(topk_lens_ptr + token_idx, 0)
-        return
 
     req_idx = tl.load(token_to_req_indices_ptr + token_idx)
     count = tl.zeros((), dtype=tl.int32)
     for i in range(0, max_compressed_tokens, BLOCK_SIZE):
         offset = i + tl.arange(0, BLOCK_SIZE)
         mask = offset < max_compressed_tokens
-        is_valid = offset < num_compressed
+        is_valid = is_valid_token & (offset < num_compressed)
 
         block_indices = offset // block_size
         block_numbers = tl.load(
             block_table_ptr + req_idx * block_table_stride + block_indices,
             mask=mask & is_valid,
+            other=0,
         )
         block_offsets = offset % block_size
         slot_ids = block_numbers * block_size + block_offsets
@@ -1154,15 +1150,18 @@ def _build_c128a_topk_metadata_kernel(
             slot_ids,
             mask=mask,
         )
-        pfx_idx = token_idx - num_decode_tokens
-        tl.store(
-            prefill_local_ptr + pfx_idx * prefill_local_stride + offset,
-            tl.where(offset < num_compressed, offset, -1),
-            mask=mask & is_prefill,
-        )
         count += tl.sum(is_valid.to(tl.int32), axis=0)
 
-    tl.store(
-        topk_lens_ptr + token_idx,
-        tl.where(is_valid_token, count, 0),
-    )
+    tl.store(topk_lens_ptr + token_idx, count)
+
+    if token_idx >= num_decode_tokens:
+        pfx_idx = token_idx - num_decode_tokens
+        for i in range(0, max_compressed_tokens, BLOCK_SIZE):
+            offset = i + tl.arange(0, BLOCK_SIZE)
+            mask = offset < max_compressed_tokens
+            is_valid = is_valid_token & (offset < num_compressed)
+            tl.store(
+                prefill_local_ptr + pfx_idx * prefill_local_stride + offset,
+                tl.where(is_valid, offset, -1),
+                mask=mask,
+            )

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -168,16 +168,14 @@ class DeepseekSparseSWAMetadata:
     tile_sched_swaonly: "FlashMLASchedMeta | None" = None
     tile_sched_c4a: "FlashMLASchedMeta | None" = None
     tile_sched_c128a: "FlashMLASchedMeta | None" = None
-    refresh_tile_scheduler: bool = False
-    scheduler_valid_count: torch.Tensor | None = None  # CUDA int32 scalar [1]
 
 
 class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
     """Builds metadata for DeepseekV4 SWA cache.
 
     This keeps the decode/prefill split counts for compatibility with other
-    DeepseekV4 metadata builders, but produces a single set of token metadata
-    consumed by FlashMLA's direct KV-cache path.
+    DeepseekV4 metadata builders, and produces token metadata consumed by
+    FlashMLA's direct KV-cache path.
 
     Supports:
     - Mixed decode/prefill batches
@@ -249,19 +247,6 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
             dtype=torch.bool,
             device=self.device,
         )
-        self.scheduler_valid_count = torch.zeros(
-            (1,),
-            dtype=torch.int32,
-            device=self.device,
-        )
-
-        compilation_config = self.vllm_config.compilation_config
-        self._use_cudagraph_tile_scheduler = (
-            compilation_config.cudagraph_mode.has_full_cudagraphs()
-        )
-        self._max_cudagraph_capture_size = (
-            compilation_config.max_cudagraph_capture_size or 0
-        )
 
     def build(
         self,
@@ -271,8 +256,7 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
     ) -> DeepseekSparseSWAMetadata:
         """Build SWA metadata for mixed decode/prefill batches.
 
-        The batch is assumed to be reordered with decodes first by the scheduler,
-        but all actual tokens are processed by a single FlashMLA call.
+        The batch is assumed to be reordered with decodes first by the scheduler.
         """
         num_reqs = common_attn_metadata.num_reqs
         seq_lens = common_attn_metadata.seq_lens
@@ -338,20 +322,9 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
                 query_start_loc,
             )
 
-        # Per-layer-type tile-scheduler plan holders. Empty FlashMLASchedMeta
-        # per present DeepseekV4 layer type; the first flash_mla_with_kvcache call of
-        # each type triggers the planner and all same-type layers reuse the
-        # resulting plan for the rest of the step.
-        refresh_tile_scheduler = (
-            self._use_cudagraph_tile_scheduler
-            and num_prefills == 0
-            and 0 < num_swa_tokens <= self._max_cudagraph_capture_size
-        )
-        scheduler_valid_count = None
-        if refresh_tile_scheduler:
-            self.scheduler_valid_count[0] = int(query_start_loc_cpu[-1])
-            scheduler_valid_count = self.scheduler_valid_count
-
+        # Per-layer-type tile-scheduler plan holders. The direct KV-cache
+        # prefill path uses one FlashMLA decode-kernel call for all tokens, so
+        # the scheduler is built for the same token count as swa_indices.
         tile_sched = self.build_tile_scheduler(num_swa_tokens)
 
         return DeepseekSparseSWAMetadata(
@@ -372,8 +345,6 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
             tile_sched_swaonly=tile_sched[_LAYER_TYPE_SWAONLY],
             tile_sched_c4a=tile_sched[_LAYER_TYPE_C4A],
             tile_sched_c128a=tile_sched[_LAYER_TYPE_C128A],
-            refresh_tile_scheduler=refresh_tile_scheduler,
-            scheduler_valid_count=scheduler_valid_count,
             **deepseek_v4_fields,
         )
 

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -149,10 +149,8 @@ class DeepseekSparseSWAMetadata:
 
     is_valid_token: torch.Tensor | None = None  # [num_tokens]
     token_to_req_indices: torch.Tensor | None = None  # [num_tokens]
-    decode_swa_indices: torch.Tensor | None = None  # [num_decode_tokens, window_size]
-    decode_swa_lens: torch.Tensor | None = None  # [num_decode_tokens]
-    prefill_swa_indices: torch.Tensor | None = None
-    prefill_swa_lens: torch.Tensor | None = None
+    swa_indices: torch.Tensor | None = None  # [num_tokens, 1, window_size]
+    swa_lens: torch.Tensor | None = None  # [num_tokens]
 
     # Number of decode/prefill requests/tokens (batch is reordered: decodes first)
     num_decodes: int = 0
@@ -160,34 +158,31 @@ class DeepseekSparseSWAMetadata:
     num_decode_tokens: int = 0
     num_prefill_tokens: int = 0
 
-    # Pre-computed prefill metadata shared across all DeepseekV4 attention layers.
+    # Pre-computed prefill metadata shared across all DeepseekV4 attention layers
+    # when using the bf16 prefill fallback path.
     prefill_seq_lens: torch.Tensor | None = None
     prefill_gather_lens: torch.Tensor | None = None
 
-    # Per-layer-type FlashMLA tile-scheduler metadata. Decode and direct
-    # prefill use separate FlashMLASchedMeta objects because their batch shapes
-    # differ, but same-type layers share the object within a step. The first
-    # forward call of a given type triggers the in-kernel planner; subsequent
-    # same-type calls reuse the populated plan.
+    # Per-layer-type FlashMLA tile-scheduler metadata. All tokens in a scheduler
+    # step share one FlashMLASchedMeta per DeepseekV4 layer type.
     tile_sched_swaonly: "FlashMLASchedMeta | None" = None
     tile_sched_c4a: "FlashMLASchedMeta | None" = None
     tile_sched_c128a: "FlashMLASchedMeta | None" = None
-    prefill_tile_sched_swaonly: "FlashMLASchedMeta | None" = None
-    prefill_tile_sched_c4a: "FlashMLASchedMeta | None" = None
-    prefill_tile_sched_c128a: "FlashMLASchedMeta | None" = None
+    refresh_tile_scheduler: bool = False
+    scheduler_valid_count: torch.Tensor | None = None  # CUDA int32 scalar [1]
 
 
 class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
     """Builds metadata for DeepseekV4 SWA cache.
 
-    Similar to the indexer, this handles mixed batches by:
-    1. Using split_decodes_and_prefills() to determine the boundary
-    2. Building separate metadata for decode and prefill portions
+    This keeps the decode/prefill split counts for compatibility with other
+    DeepseekV4 metadata builders, but produces a single set of token metadata
+    consumed by FlashMLA's direct KV-cache path.
 
     Supports:
     - Mixed decode/prefill batches
     - MTP (Multi-Token Prediction) where decode has query_len > 1
-    - Chunked prefill (aligns with the indexer's chunking)
+    - Chunked prefill tokens treated as independent decode-kernel queries
     """
 
     # Base threshold: query_len <= 1 is decode
@@ -237,14 +232,14 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
             dtype=torch.int32,
             device=self.device,
         )
-        self.decode_swa_indices = torch.zeros(
+        self.swa_indices = torch.zeros(
             max_tokens,
             1,
             self.window_size,
             dtype=torch.int32,
             device=self.device,
         )
-        self.decode_swa_lens = torch.zeros(
+        self.swa_lens = torch.zeros(
             max_tokens,
             dtype=torch.int32,
             device=self.device,
@@ -253,6 +248,19 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
             max_tokens,
             dtype=torch.bool,
             device=self.device,
+        )
+        self.scheduler_valid_count = torch.zeros(
+            (1,),
+            dtype=torch.int32,
+            device=self.device,
+        )
+
+        compilation_config = self.vllm_config.compilation_config
+        self._use_cudagraph_tile_scheduler = (
+            compilation_config.cudagraph_mode.has_full_cudagraphs()
+        )
+        self._max_cudagraph_capture_size = (
+            compilation_config.max_cudagraph_capture_size or 0
         )
 
     def build(
@@ -263,11 +271,8 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
     ) -> DeepseekSparseSWAMetadata:
         """Build SWA metadata for mixed decode/prefill batches.
 
-        The batch is assumed to be reordered with decodes first (by vLLM scheduler).
-        We use split_decodes_and_prefills() to find the boundary, then build
-        separate window_topk_idxs for each portion.
-
-        For prefill, we use chunked prefill to align with the indexer's chunking.
+        The batch is assumed to be reordered with decodes first by the scheduler,
+        but all actual tokens are processed by a single FlashMLA call.
         """
         num_reqs = common_attn_metadata.num_reqs
         seq_lens = common_attn_metadata.seq_lens
@@ -284,25 +289,33 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         )
 
         # NOTE: Ensure all metadata tensors maintain fixed memory addresses
-        # for CUDA graph compatibility.
+        # for CUDA graph compatibility. Padded full-cudagraph decode rows have
+        # zero query length, so the repeated request-id list can be shorter
+        # than the padded token count. Keep the exposed slice padded and use a
+        # dummy request id for invalid rows; validity is carried separately by
+        # is_valid_token.
         query_lens = query_start_loc_cpu[1:] - query_start_loc_cpu[:-1]
         x = torch.repeat_interleave(torch.arange(num_reqs), query_lens).pin_memory()
-        token_to_req_indices = self.token_to_req_indices[: x.shape[0]]
-        token_to_req_indices.copy_(x, non_blocking=True)
+        num_tokens = num_decode_tokens + num_prefill_tokens
+        token_to_req_indices = self.token_to_req_indices[:num_tokens]
+        token_to_req_indices.zero_()
+        token_to_req_indices[: x.shape[0]].copy_(x, non_blocking=True)
 
-        is_valid_token = self.is_valid_token[: slot_mapping.shape[0]]
+        is_valid_token = self.is_valid_token[:num_tokens]
         is_valid_token.copy_(slot_mapping >= 0)
 
-        num_swa_tokens = num_decode_tokens
-        if self.use_flashmla_direct_kvcache_prefill:
-            num_swa_tokens += num_prefill_tokens
+        num_swa_tokens = (
+            num_tokens
+            if self.use_flashmla_direct_kvcache_prefill
+            else num_decode_tokens
+        )
 
         if num_swa_tokens > 0:
-            self.decode_swa_lens[num_swa_tokens:] = 0
+            self.swa_lens[num_swa_tokens:] = 0
             _compute_swa_indices_and_lens_kernel[(num_swa_tokens,)](
-                self.decode_swa_indices,
-                self.decode_swa_indices.stride(0),
-                self.decode_swa_lens,
+                self.swa_indices,
+                self.swa_indices.stride(0),
+                self.swa_lens,
                 self.window_size,
                 query_start_loc,
                 seq_lens,
@@ -314,29 +327,32 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
                 TRITON_BLOCK_SIZE=1024,
             )
 
-        prefill_swa_indices = None
-        prefill_swa_lens = None
-        if self.use_flashmla_direct_kvcache_prefill and num_prefill_tokens > 0:
-            prefill_end = num_decode_tokens + num_prefill_tokens
-            prefill_swa_indices = self.decode_swa_indices[num_decode_tokens:prefill_end]
-            prefill_swa_lens = self.decode_swa_lens[num_decode_tokens:prefill_end]
-
-        # Pre-compute DeepseekV4 prefill metadata shared across all attention layers.
-        deepseek_v4_fields = self._build_deepseek_v4_metadata(
-            num_decodes,
-            num_prefills,
-            seq_lens,
-            query_start_loc,
-        )
+        deepseek_v4_fields = {}
+        if not self.use_flashmla_direct_kvcache_prefill:
+            # Pre-compute DeepseekV4 prefill metadata shared across all
+            # attention layers for the bf16 prefill fallback.
+            deepseek_v4_fields = self._build_deepseek_v4_metadata(
+                num_decodes,
+                num_prefills,
+                seq_lens,
+                query_start_loc,
+            )
 
         # Per-layer-type tile-scheduler plan holders. Empty FlashMLASchedMeta
         # per present DeepseekV4 layer type; the first flash_mla_with_kvcache call of
         # each type triggers the planner and all same-type layers reuse the
         # resulting plan for the rest of the step.
-        tile_sched = self.build_tile_scheduler(num_decode_tokens)
-        prefill_tile_sched = self.build_tile_scheduler(
-            num_prefill_tokens if self.use_flashmla_direct_kvcache_prefill else 0
+        refresh_tile_scheduler = (
+            self._use_cudagraph_tile_scheduler
+            and num_prefills == 0
+            and 0 < num_swa_tokens <= self._max_cudagraph_capture_size
         )
+        scheduler_valid_count = None
+        if refresh_tile_scheduler:
+            self.scheduler_valid_count[0] = int(query_start_loc_cpu[-1])
+            scheduler_valid_count = self.scheduler_valid_count
+
+        tile_sched = self.build_tile_scheduler(num_swa_tokens)
 
         return DeepseekSparseSWAMetadata(
             seq_lens=seq_lens,
@@ -346,10 +362,8 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
             slot_mapping=slot_mapping,
             is_valid_token=is_valid_token,
             token_to_req_indices=token_to_req_indices,
-            decode_swa_indices=self.decode_swa_indices[:num_decode_tokens],
-            decode_swa_lens=self.decode_swa_lens[:num_decode_tokens],
-            prefill_swa_indices=prefill_swa_indices,
-            prefill_swa_lens=prefill_swa_lens,
+            swa_indices=self.swa_indices[:num_swa_tokens],
+            swa_lens=self.swa_lens[:num_swa_tokens],
             block_size=self.block_size,
             num_decodes=num_decodes,
             num_prefills=num_prefills,
@@ -358,14 +372,14 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
             tile_sched_swaonly=tile_sched[_LAYER_TYPE_SWAONLY],
             tile_sched_c4a=tile_sched[_LAYER_TYPE_C4A],
             tile_sched_c128a=tile_sched[_LAYER_TYPE_C128A],
-            prefill_tile_sched_swaonly=prefill_tile_sched[_LAYER_TYPE_SWAONLY],
-            prefill_tile_sched_c4a=prefill_tile_sched[_LAYER_TYPE_C4A],
-            prefill_tile_sched_c128a=prefill_tile_sched[_LAYER_TYPE_C128A],
+            refresh_tile_scheduler=refresh_tile_scheduler,
+            scheduler_valid_count=scheduler_valid_count,
             **deepseek_v4_fields,
         )
 
     def build_tile_scheduler(
-        self, num_tokens: int
+        self,
+        num_tokens: int,
     ) -> dict[str, FlashMLASchedMeta | None]:
         """Allocate one empty ``FlashMLASchedMeta`` per present DeepseekV4 layer type.
 
@@ -390,7 +404,8 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
             # returns a fresh empty FlashMLASchedMeta; using it keeps this
             # call site aligned with the rest of the vLLM FlashMLA backends
             # that already go through the same stub.
-            out[layer_type] = get_mla_metadata()[0]
+            sched_meta = get_mla_metadata()[0]
+            out[layer_type] = sched_meta
         return out
 
     def _build_deepseek_v4_metadata(
@@ -400,17 +415,9 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         seq_lens: torch.Tensor,
         query_start_loc: torch.Tensor,
     ) -> dict[str, torch.Tensor | None]:
-        """Pre-compute DeepseekV4 prefill metadata during the metadata build phase.
-
-        Returns a dict of keyword arguments to pass to the
-        DeepseekSparseSWAMetadata constructor.
-
-        Note: C128A topk indices are computed by the FlashMLASparse builder
-        (which owns the C128A block_table), not here.
-        """
+        """Pre-compute metadata for the DeepSeek V4 bf16 prefill fallback."""
         result: dict[str, torch.Tensor | None] = {}
 
-        # --- Prefill query metadata (single Triton kernel + CPU slicing) ---
         if num_prefills > 0:
             pfx_gather_lens = torch.empty(
                 num_prefills, dtype=torch.int32, device=seq_lens.device

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -151,6 +151,8 @@ class DeepseekSparseSWAMetadata:
     token_to_req_indices: torch.Tensor | None = None  # [num_tokens]
     decode_swa_indices: torch.Tensor | None = None  # [num_decode_tokens, window_size]
     decode_swa_lens: torch.Tensor | None = None  # [num_decode_tokens]
+    prefill_swa_indices: torch.Tensor | None = None
+    prefill_swa_lens: torch.Tensor | None = None
 
     # Number of decode/prefill requests/tokens (batch is reordered: decodes first)
     num_decodes: int = 0
@@ -162,19 +164,17 @@ class DeepseekSparseSWAMetadata:
     prefill_seq_lens: torch.Tensor | None = None
     prefill_gather_lens: torch.Tensor | None = None
 
-    # Per-layer-type FlashMLA tile-scheduler metadata. One FlashMLASchedMeta
-    # per present DeepseekV4 layer type, shared across all ~60 layers of that type
-    # within a decode step. The first forward call of a given type triggers
-    # the in-kernel planner (which also allocates tile_scheduler_metadata and
-    # num_splits via PyTorch's graph-aware allocator); subsequent same-type
-    # calls skip planning and reuse the plan. Fresh instance per build(), so
-    # have_initialized is always False at the start of a step and the plan
-    # is re-derived from current seq_lens / topk_length on replay.
-    # None for layer types the model does not use (or when num_decode_tokens
-    # is zero).
+    # Per-layer-type FlashMLA tile-scheduler metadata. Decode and direct
+    # prefill use separate FlashMLASchedMeta objects because their batch shapes
+    # differ, but same-type layers share the object within a step. The first
+    # forward call of a given type triggers the in-kernel planner; subsequent
+    # same-type calls reuse the populated plan.
     tile_sched_swaonly: "FlashMLASchedMeta | None" = None
     tile_sched_c4a: "FlashMLASchedMeta | None" = None
     tile_sched_c128a: "FlashMLASchedMeta | None" = None
+    prefill_tile_sched_swaonly: "FlashMLASchedMeta | None" = None
+    prefill_tile_sched_c4a: "FlashMLASchedMeta | None" = None
+    prefill_tile_sched_c128a: "FlashMLASchedMeta | None" = None
 
 
 class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
@@ -226,6 +226,10 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         self._layer_types: set[str] = set()
         for ratio in compress_ratios:
             self._layer_types.add(_layer_type_for(int(ratio)))
+        attention_config = self.vllm_config.attention_config
+        self.use_flashmla_direct_kvcache_prefill = (
+            attention_config.use_deepseek_v4_flashmla_direct_kvcache_prefill
+        )
 
         max_tokens = self.vllm_config.scheduler_config.max_num_batched_tokens
         self.token_to_req_indices = torch.zeros(
@@ -289,9 +293,13 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         is_valid_token = self.is_valid_token[: slot_mapping.shape[0]]
         is_valid_token.copy_(slot_mapping >= 0)
 
-        if num_decode_tokens > 0:
-            self.decode_swa_lens[num_decode_tokens:] = 0
-            _compute_swa_indices_and_lens_kernel[(num_decode_tokens,)](
+        num_swa_tokens = num_decode_tokens
+        if self.use_flashmla_direct_kvcache_prefill:
+            num_swa_tokens += num_prefill_tokens
+
+        if num_swa_tokens > 0:
+            self.decode_swa_lens[num_swa_tokens:] = 0
+            _compute_swa_indices_and_lens_kernel[(num_swa_tokens,)](
                 self.decode_swa_indices,
                 self.decode_swa_indices.stride(0),
                 self.decode_swa_lens,
@@ -306,6 +314,13 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
                 TRITON_BLOCK_SIZE=1024,
             )
 
+        prefill_swa_indices = None
+        prefill_swa_lens = None
+        if self.use_flashmla_direct_kvcache_prefill and num_prefill_tokens > 0:
+            prefill_end = num_decode_tokens + num_prefill_tokens
+            prefill_swa_indices = self.decode_swa_indices[num_decode_tokens:prefill_end]
+            prefill_swa_lens = self.decode_swa_lens[num_decode_tokens:prefill_end]
+
         # Pre-compute DeepseekV4 prefill metadata shared across all attention layers.
         deepseek_v4_fields = self._build_deepseek_v4_metadata(
             num_decodes,
@@ -319,6 +334,9 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
         # each type triggers the planner and all same-type layers reuse the
         # resulting plan for the rest of the step.
         tile_sched = self.build_tile_scheduler(num_decode_tokens)
+        prefill_tile_sched = self.build_tile_scheduler(
+            num_prefill_tokens if self.use_flashmla_direct_kvcache_prefill else 0
+        )
 
         return DeepseekSparseSWAMetadata(
             seq_lens=seq_lens,
@@ -330,6 +348,8 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
             token_to_req_indices=token_to_req_indices,
             decode_swa_indices=self.decode_swa_indices[:num_decode_tokens],
             decode_swa_lens=self.decode_swa_lens[:num_decode_tokens],
+            prefill_swa_indices=prefill_swa_indices,
+            prefill_swa_lens=prefill_swa_lens,
             block_size=self.block_size,
             num_decodes=num_decodes,
             num_prefills=num_prefills,
@@ -338,29 +358,32 @@ class DeepseekSparseSWAMetadataBuilder(AttentionMetadataBuilder):
             tile_sched_swaonly=tile_sched[_LAYER_TYPE_SWAONLY],
             tile_sched_c4a=tile_sched[_LAYER_TYPE_C4A],
             tile_sched_c128a=tile_sched[_LAYER_TYPE_C128A],
+            prefill_tile_sched_swaonly=prefill_tile_sched[_LAYER_TYPE_SWAONLY],
+            prefill_tile_sched_c4a=prefill_tile_sched[_LAYER_TYPE_C4A],
+            prefill_tile_sched_c128a=prefill_tile_sched[_LAYER_TYPE_C128A],
             **deepseek_v4_fields,
         )
 
     def build_tile_scheduler(
-        self, num_decode_tokens: int
+        self, num_tokens: int
     ) -> dict[str, FlashMLASchedMeta | None]:
         """Allocate one empty ``FlashMLASchedMeta`` per present DeepseekV4 layer type.
 
         Returned instances have ``tile_scheduler_metadata`` / ``num_splits``
-        set to ``None``; the FlashMLA C++ decode path will allocate them and
-        run the tile-scheduler planner on the first ``flash_mla_with_kvcache``
-        call of each type. Subsequent same-type calls reuse the plan because
-        the tensors (and ``have_initialized``) are populated on the struct.
+        set to ``None``; the FlashMLA C++ path will allocate them and run the
+        tile-scheduler planner on the first ``flash_mla_with_kvcache`` call of
+        each type. Subsequent same-type calls reuse the plan because the
+        tensors (and ``have_initialized``) are populated on the struct.
 
-        Returns all-``None`` when there are no decode tokens this step, so
-        ``_forward_decode`` sees a clean sentinel.
+        Returns all-``None`` when there are no tokens for that phase, so callers
+        see a clean sentinel.
         """
         out: dict[str, FlashMLASchedMeta | None] = {
             _LAYER_TYPE_SWAONLY: None,
             _LAYER_TYPE_C4A: None,
             _LAYER_TYPE_C128A: None,
         }
-        if num_decode_tokens == 0:
+        if num_tokens == 0:
             return out
         for layer_type in self._layer_types:
             # get_mla_metadata() is the official FlashMLA entry point that
@@ -454,6 +477,13 @@ def _compute_swa_indices_and_lens_kernel(
     is_valid = tl.load(is_valid_token_ptr + token_idx)
     if not is_valid:
         tl.store(swa_lens_ptr + token_idx, 0)
+        for i in range(0, window_size, TRITON_BLOCK_SIZE):
+            offset = i + tl.arange(0, TRITON_BLOCK_SIZE)
+            tl.store(
+                swa_indices_ptr + token_idx * swa_indices_stride + offset,
+                -1,
+                mask=offset < window_size,
+            )
         return
 
     req_idx = tl.load(token_to_req_indices_ptr + token_idx)

--- a/vllm/v1/attention/ops/deepseek_v4_ops/cache_utils.py
+++ b/vllm/v1/attention/ops/deepseek_v4_ops/cache_utils.py
@@ -400,6 +400,19 @@ def _compute_global_topk_indices_and_lens_kernel(
 ):
     token_idx = tl.program_id(0)
     is_valid_token = tl.load(is_valid_token_ptr + token_idx)
+    if not is_valid_token:
+        tl.store(topk_lens_ptr + token_idx, 0)
+        for i in range(0, topk, TRITON_BLOCK_SIZE):
+            offset = i + tl.arange(0, TRITON_BLOCK_SIZE)
+            tl.store(
+                global_topk_indices_ptr
+                + token_idx * global_topk_indices_stride
+                + offset,
+                -1,
+                mask=offset < topk,
+            )
+        return
+
     req_idx = tl.load(token_to_req_indices_ptr + token_idx)
 
     count = tl.zeros((), dtype=tl.int32)


### PR DESCRIPTION
## Summary
- Add `AttentionConfig.use_deepseek_v4_flashmla_direct_kvcache_prefill`, defaulting to `false`.
- When enabled, DeepSeek V4 prefill tokens use the FlashMLA direct KV-cache path instead of the bf16 gather/dequantize workspace path.
- Handle mixed prefill/decode batches in one FlashMLA call by keeping per-token C4/C128/SWA metadata aligned with the token order.

## Validation
DeepSeek-V4-Flash on 4x GB200, fp8 KV cache, chunked prefill, prefix caching, max model length 4096, `max_num_seqs=4`, `max_num_batched_tokens=8192`.

| Run | Result |
| --- | ---: |
| GSM8K full, direct FlashMLA KV-cache prefill | 1246/1319, 0 invalid |
| GSM8K full, bf16 prefill fallback | 1247/1319, 0 invalid |
| Previous bad single-call direct prefill run | 1182/1319, 3 invalid |

Earlier task checks also passed for MMLU zero-shot and GPQA diamond zero-shot with direct prefill enabled.

## Reproduction
GSM8K was run with a local `vllm.LLM` engine. The equivalent server shape is:

```bash
MODEL=/lustre/fsw/portfolios/coreai/projects/coreai_comparch_trtllm/common/DeepSeek-V4-Flash
vllm serve "$MODEL"   --tokenizer "$MODEL"   --tokenizer-mode deepseek_v4   --trust-remote-code   --dtype bfloat16   --kv-cache-dtype fp8   --tensor-parallel-size 4   --block-size 256   --max-model-len 4096   --max-num-batched-tokens 8192   --max-num-seqs 4   --gpu-memory-utilization 0.90   --enable-chunked-prefill   --enable-prefix-caching   --attention-config.use_deepseek_v4_flashmla_direct_kvcache_prefill true
```

The full GSM8K command was:

```bash
PYTHONPATH=/lustre/fs1/portfolios/coreai/projects/coreai_comparch_trtllm/users/perkzz/dpsv4/vllm /lustre/fs1/portfolios/coreai/projects/coreai_comparch_trtllm/users/perkzz/dpsv4/.venv-vllm-gb200/bin/python   /lustre/fs1/portfolios/coreai/projects/coreai_comparch_trtllm/users/perkzz/dpsv4/diagnose_gsm8k_outputs.py   --num-questions 1319   --num-shots 5   --max-tokens 256   --max-num-seqs 4   --max-num-batched-tokens 8192   --use-cuda-graph   --label gsm8k_rebased_one_flashmla_call_full1319   --output /tmp/gsm8k_rebased_one_flashmla_call_full1319.json
```

## Tests
- `pre-commit run --files tests/engine/test_arg_utils.py vllm/config/attention.py vllm/model_executor/layers/deepseek_v4_attention.py vllm/v1/attention/backends/mla/flashmla_sparse.py vllm/v1/attention/backends/mla/sparse_swa.py vllm/v1/attention/ops/deepseek_v4_ops/cache_utils.py`
- `python -m py_compile` on the changed Python files
- `pytest tests/engine/test_arg_utils.py::test_attention_config -q`
- `pytest tests/kernels/attention/test_flashmla_sparse.py -q`
