### PR TITLE
[UX] Enable PyTorch `expandable_segments` by default

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -254,6 +254,13 @@ class Worker(WorkerBase):
             self.device = torch.device(f"cuda:{self.local_rank}")
             torch.accelerator.set_device_index(self.device)
 
+            if (
+                current_platform.is_cuda()
+                and "expandable_segments"
+                not in os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
+            ):
+                torch.cuda.memory._set_allocator_settings("expandable_segments:True")
+
             current_platform.check_if_supports_dtype(self.model_config.dtype)
 
             # Initialize the distributed environment BEFORE taking


### PR DESCRIPTION


## Purpose
The upgrade from PyTorch 2.9 to 2.10 seems to have substantially increased memory fragmentation during startup and cudagraph capture, leading to OOMs during startup for some models at default `--gpu-memory-utilization` (e.g. GPT-OSS 120B TP2 on 2xH100). Setting `PYTORCH_ALLOC_CONF=expandable_segments:True` addresses this and enables successful startup.

This PR enables this option by default.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

