### PR TITLE
[DP] External DP LB compatibility with all GPU visibility

### DIFF
--- a/docs/serving/data_parallel_deployment.md
+++ b/docs/serving/data_parallel_deployment.md
@@ -113,6 +113,14 @@ CUDA_VISIBLE_DEVICES=1 vllm serve $MODEL --data-parallel-size 2 --data-parallel-
                                          --port 8001
 ```
 
+Alternatively, each rank can be launched with all DP-world GPUs visible and vLLM will select this rank's GPU(s) automatically (matching internal LB behavior). This requires `device_count() >= (data-parallel-rank + 1) * tensor-parallel-size * pipeline-parallel-size`:
+
+```bash
+# Both ranks see all GPUs; rank 0 picks cuda:0, rank 1 picks cuda:1.
+vllm serve $MODEL --data-parallel-size 2 --data-parallel-rank 0 --port 8000
+vllm serve $MODEL --data-parallel-size 2 --data-parallel-rank 1 --port 8001
+```
+
 For multi-node cases, the address/port of rank 0 must also be specified:
 
 ```bash

--- a/docs/serving/data_parallel_deployment.md
+++ b/docs/serving/data_parallel_deployment.md
@@ -113,12 +113,14 @@ CUDA_VISIBLE_DEVICES=1 vllm serve $MODEL --data-parallel-size 2 --data-parallel-
                                          --port 8001
 ```
 
-Alternatively, each rank can be launched with all DP-world GPUs visible and vLLM will select this rank's GPU(s) automatically (matching internal LB behavior). This requires `device_count() >= (data-parallel-rank + 1) * tensor-parallel-size * pipeline-parallel-size`:
+Alternatively, each rank can be launched with all GPUs on its node visible (no `CUDA_VISIBLE_DEVICES` narrowing) by passing `--data-parallel-rank-local` to tell each rank which GPU slot on its node to use:
 
 ```bash
 # Both ranks see all GPUs; rank 0 picks cuda:0, rank 1 picks cuda:1.
-vllm serve $MODEL --data-parallel-size 2 --data-parallel-rank 0 --port 8000
-vllm serve $MODEL --data-parallel-size 2 --data-parallel-rank 1 --port 8001
+vllm serve $MODEL --data-parallel-size 2 --data-parallel-rank 0 --data-parallel-rank-local 0 \
+                  --port 8000
+vllm serve $MODEL --data-parallel-size 2 --data-parallel-rank 1 --data-parallel-rank-local 1 \
+                  --port 8001
 ```
 
 For multi-node cases, the address/port of rank 0 must also be specified:
@@ -129,6 +131,21 @@ vllm serve $MODEL --data-parallel-size 2 --data-parallel-rank 0 \
                   --data-parallel-address 10.99.48.128 --data-parallel-rpc-port 13345
 # Rank 1
 vllm serve $MODEL --data-parallel-size 2 --data-parallel-rank 1 \
+                  --data-parallel-address 10.99.48.128 --data-parallel-rpc-port 13345
+```
+
+`--data-parallel-rank-local` extends naturally to multi-node — each rank's value is its position on its own node:
+
+```bash
+# Node A (10.99.48.128), 2 GPUs visible to both processes
+vllm serve $MODEL --data-parallel-size 4 --data-parallel-rank 0 --data-parallel-rank-local 0 \
+                  --data-parallel-address 10.99.48.128 --data-parallel-rpc-port 13345
+vllm serve $MODEL --data-parallel-size 4 --data-parallel-rank 1 --data-parallel-rank-local 1 \
+                  --data-parallel-address 10.99.48.128 --data-parallel-rpc-port 13345
+# Node B, 2 GPUs visible to both processes
+vllm serve $MODEL --data-parallel-size 4 --data-parallel-rank 2 --data-parallel-rank-local 0 \
+                  --data-parallel-address 10.99.48.128 --data-parallel-rpc-port 13345
+vllm serve $MODEL --data-parallel-size 4 --data-parallel-rank 3 --data-parallel-rank-local 1 \
                   --data-parallel-address 10.99.48.128 --data-parallel-rpc-port 13345
 ```
 

--- a/tests/v1/distributed/test_external_lb_dp.py
+++ b/tests/v1/distributed/test_external_lb_dp.py
@@ -24,7 +24,14 @@ TP_SIZE = int(os.getenv("TP_SIZE", "1"))
 
 class ExternalLBServerManager:
     """Manages data parallel vLLM server instances for external
-    load balancer testing."""
+    load balancer testing.
+
+    device_mode controls how each rank's GPU is selected:
+      - "narrow_cvd": legacy — per-rank CUDA_VISIBLE_DEVICES narrowed to that
+        rank's GPU(s).
+      - "explicit_local_rank": all DP-world GPUs visible to every rank, with
+        --data-parallel-rank-local naming this rank's GPU slot.
+    """
 
     def __init__(
         self,
@@ -33,14 +40,15 @@ class ExternalLBServerManager:
         api_server_count: int,
         base_server_args: list,
         tp_size: int = TP_SIZE,
-        narrow_visible_devices: bool = True,
+        device_mode: str = "narrow_cvd",
     ):
+        assert device_mode in ("narrow_cvd", "explicit_local_rank")
         self.model_name = model_name
         self.dp_size = dp_size
         self.tp_size = tp_size
         self.api_server_count = api_server_count
         self.base_server_args = base_server_args
-        self.narrow_visible_devices = narrow_visible_devices
+        self.device_mode = device_mode
         self.servers: list[tuple[RemoteOpenAIServer, list[str]]] = []
         self.server_threads: list[threading.Thread] = []
 
@@ -75,13 +83,15 @@ class ExternalLBServerManager:
                 ]
             )
 
-            if self.narrow_visible_devices:
+            if self.device_mode == "narrow_cvd":
                 visible_devices = ",".join(
                     str(current_platform.device_id_to_physical_device_id(i))
                     for i in range(rank * self.tp_size, (rank + 1) * self.tp_size)
                 )
             else:
+                # explicit_local_rank
                 visible_devices = full_visible_devices
+                server_args.extend(["--data-parallel-rank-local", str(rank)])
 
             # Use a thread to start each server to allow parallel initialization
             def start_server(r: int, sargs: list[str], cvd: str):
@@ -151,20 +161,20 @@ def default_server_args():
 @pytest.fixture(
     scope="module",
     params=[
-        pytest.param((1, True), id="api_count=1-narrow_cvd"),
-        pytest.param((4, True), id="api_count=4-narrow_cvd"),
-        pytest.param((1, False), id="api_count=1-full_cvd"),
-        pytest.param((4, False), id="api_count=4-full_cvd"),
+        pytest.param((1, "narrow_cvd"), id="api_count=1-narrow_cvd"),
+        pytest.param((4, "narrow_cvd"), id="api_count=4-narrow_cvd"),
+        pytest.param((1, "explicit_local_rank"), id="api_count=1-explicit_local_rank"),
+        pytest.param((4, "explicit_local_rank"), id="api_count=4-explicit_local_rank"),
     ],
 )
 def server_manager(request, default_server_args):
-    api_server_count, narrow_visible_devices = request.param
+    api_server_count, device_mode = request.param
     server_manager = ExternalLBServerManager(
         MODEL_NAME,
         DP_SIZE,
         api_server_count,
         default_server_args,
-        narrow_visible_devices=narrow_visible_devices,
+        device_mode=device_mode,
     )
 
     with server_manager:

--- a/tests/v1/distributed/test_external_lb_dp.py
+++ b/tests/v1/distributed/test_external_lb_dp.py
@@ -33,17 +33,26 @@ class ExternalLBServerManager:
         api_server_count: int,
         base_server_args: list,
         tp_size: int = TP_SIZE,
+        narrow_visible_devices: bool = True,
     ):
         self.model_name = model_name
         self.dp_size = dp_size
         self.tp_size = tp_size
         self.api_server_count = api_server_count
         self.base_server_args = base_server_args
+        self.narrow_visible_devices = narrow_visible_devices
         self.servers: list[tuple[RemoteOpenAIServer, list[str]]] = []
         self.server_threads: list[threading.Thread] = []
 
     def __enter__(self) -> list[tuple[RemoteOpenAIServer, list[str]]]:
         """Start all server instances for external LB mode."""
+        # When not narrowing, every rank sees the full DP-world device set.
+        # vLLM should select the right device based on --data-parallel-rank.
+        full_visible_devices = ",".join(
+            str(current_platform.device_id_to_physical_device_id(i))
+            for i in range(self.dp_size * self.tp_size)
+        )
+
         for rank in range(self.dp_size):
             # Create server args for this specific rank
             server_args = self.base_server_args.copy()
@@ -66,8 +75,16 @@ class ExternalLBServerManager:
                 ]
             )
 
+            if self.narrow_visible_devices:
+                visible_devices = ",".join(
+                    str(current_platform.device_id_to_physical_device_id(i))
+                    for i in range(rank * self.tp_size, (rank + 1) * self.tp_size)
+                )
+            else:
+                visible_devices = full_visible_devices
+
             # Use a thread to start each server to allow parallel initialization
-            def start_server(r: int, sargs: list[str]):
+            def start_server(r: int, sargs: list[str], cvd: str):
                 try:
                     # Start the server
                     server = RemoteOpenAIServer(
@@ -76,10 +93,7 @@ class ExternalLBServerManager:
                         auto_port=False,
                         env_dict={
                             "VLLM_SERVER_DEV_MODE": "1",
-                            current_platform.device_control_env_var: ",".join(
-                                str(current_platform.device_id_to_physical_device_id(i))
-                                for i in range(r * TP_SIZE, (r + 1) * TP_SIZE)
-                            ),
+                            current_platform.device_control_env_var: cvd,
                         },
                     )
                     server.__enter__()
@@ -92,7 +106,9 @@ class ExternalLBServerManager:
                     print(f"Failed to start server rank {r}: {e}")
                     raise
 
-            thread = threading.Thread(target=start_server, args=(rank, server_args))
+            thread = threading.Thread(
+                target=start_server, args=(rank, server_args, visible_devices)
+            )
             thread.start()
 
             self.server_threads.append(thread)
@@ -132,11 +148,23 @@ def default_server_args():
     ]
 
 
-@pytest.fixture(scope="module", params=[1, 4])
+@pytest.fixture(
+    scope="module",
+    params=[
+        pytest.param((1, True), id="api_count=1-narrow_cvd"),
+        pytest.param((4, True), id="api_count=4-narrow_cvd"),
+        pytest.param((1, False), id="api_count=1-full_cvd"),
+        pytest.param((4, False), id="api_count=4-full_cvd"),
+    ],
+)
 def server_manager(request, default_server_args):
-    api_server_count = request.param
+    api_server_count, narrow_visible_devices = request.param
     server_manager = ExternalLBServerManager(
-        MODEL_NAME, DP_SIZE, api_server_count, default_server_args
+        MODEL_NAME,
+        DP_SIZE,
+        api_server_count,
+        default_server_args,
+        narrow_visible_devices=narrow_visible_devices,
     )
 
     with server_manager:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -456,6 +456,7 @@ class EngineArgs:
     cp_kv_cache_interleave_size: int = ParallelConfig.cp_kv_cache_interleave_size
     data_parallel_size: int = ParallelConfig.data_parallel_size
     data_parallel_rank: int | None = None
+    data_parallel_rank_local: int | None = None
     data_parallel_start_rank: int | None = None
     data_parallel_size_local: int | None = None
     data_parallel_address: str | None = None
@@ -963,6 +964,15 @@ class EngineArgs:
             type=int,
             help="Data parallel rank of this instance. "
             "When set, enables external load balancer mode.",
+        )
+        parallel_group.add_argument(
+            "--data-parallel-rank-local",
+            type=int,
+            help="Local data parallel rank of this instance, within the set "
+            "of GPUs visible to this process. Only applies in external load "
+            "balancer mode. If unset, defaults to 0, in which case the user "
+            "must narrow CUDA_VISIBLE_DEVICES (or equivalent) per rank so "
+            "that each rank sees only its own GPU(s).",
         )
         parallel_group.add_argument(
             "--data-parallel-start-rank",
@@ -1803,9 +1813,19 @@ class EngineArgs:
                 "data_parallel_size_local must be 1 or None when data_parallel_rank "
                 "is set"
             )
+            if self.data_parallel_rank_local is not None:
+                assert 0 <= self.data_parallel_rank_local <= self.data_parallel_rank, (
+                    f"data_parallel_rank_local ({self.data_parallel_rank_local}) "
+                    f"must be in [0, data_parallel_rank ({self.data_parallel_rank})]."
+                )
             data_parallel_size_local = 1
             # Use full external lb if we have local_size of 1.
             self.data_parallel_hybrid_lb = False
+        elif self.data_parallel_rank_local is not None:
+            raise ValueError(
+                "--data-parallel-rank-local is only valid in external LB mode "
+                "(set via --data-parallel-rank or --data-parallel-external-lb)."
+            )
         elif self.data_parallel_size_local is not None:
             data_parallel_size_local = self.data_parallel_size_local
 
@@ -1889,6 +1909,7 @@ class EngineArgs:
             prefill_context_parallel_size=self.prefill_context_parallel_size,
             data_parallel_size=self.data_parallel_size,
             data_parallel_rank=self.data_parallel_rank or 0,
+            data_parallel_rank_local=self.data_parallel_rank_local,
             data_parallel_external_lb=data_parallel_external_lb,
             data_parallel_size_local=data_parallel_size_local,
             master_addr=self.master_addr,

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -558,7 +558,10 @@ class MPClient(EngineCoreClient):
             dp_size = parallel_config.data_parallel_size
             dp_rank = parallel_config.data_parallel_index
             dp_local_size = parallel_config.data_parallel_size_local
-            offline_mode = parallel_config.data_parallel_rank_local is not None
+            offline_mode = (
+                parallel_config.data_parallel_rank_local is not None
+                and not parallel_config.data_parallel_external_lb
+            )
             # Client manages local+remote EngineCores in pure internal LB case.
             # Client manages local EngineCores in hybrid and external LB case.
             num_ranks = dp_local_size if parallel_config.local_engines_only else dp_size

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1093,6 +1093,24 @@ def launch_core_engines(
         local_handshake_address = handshake_address
         client_handshake_address = None
 
+    # In external-LB mode, each rank is a separate `vllm serve` process and
+    # data_parallel_rank_local is unset. Historically this means the engine
+    # subprocess always selects cuda:0 of whatever the user made visible, so
+    # users had to narrow CUDA_VISIBLE_DEVICES per rank. If instead the user
+    # has all DP-world GPUs for this rank visible, derive the local index from
+    # the global DP rank — matching how internal/hybrid LB shifts the device
+    # in the engine subprocess.
+    spawn_local_start_index = local_start_index
+    if (
+        spawn_local_start_index is None
+        and parallel_config.data_parallel_external_lb
+        and dp_rank > 0
+        and current_platform.is_cuda_alike()
+        and (dp_rank + 1) * parallel_config.world_size
+        <= current_platform.device_count()
+    ):
+        spawn_local_start_index = dp_rank
+
     with zmq_socket_ctx(
         local_handshake_address, zmq.ROUTER, bind=True
     ) as handshake_socket:
@@ -1107,7 +1125,7 @@ def launch_core_engines(
                 local_client=True,
                 local_engine_count=local_engine_count,
                 start_index=dp_rank,
-                local_start_index=local_start_index or 0,
+                local_start_index=spawn_local_start_index or 0,
                 tensor_queue=tensor_queue,
             )
         else:

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -953,7 +953,11 @@ def get_engine_zmq_addresses(
     # In offline mode there is an LLM instance per DP rank and
     # one core engine per LLM, see
     # examples/features/data_parallel/data_parallel_offline.py.
-    offline_mode = local_start_index is not None
+    # External LB also sets data_parallel_rank_local (when the user passes
+    # --data-parallel-rank-local), but that's not offline mode.
+    offline_mode = (
+        local_start_index is not None and not parallel_config.data_parallel_external_lb
+    )
 
     # client_local_only = True for cases where this front-end
     # sends requests only to colocated engines.
@@ -1001,7 +1005,11 @@ def launch_core_engines(
     host = parallel_config.data_parallel_master_ip
     local_engines_only = parallel_config.local_engines_only
 
-    offline_mode = local_start_index is not None
+    # External LB also sets data_parallel_rank_local (when the user passes
+    # --data-parallel-rank-local), but that's not offline mode.
+    offline_mode = (
+        local_start_index is not None and not parallel_config.data_parallel_external_lb
+    )
 
     # Create a single tensor IPC queue for sharing multimodal tensors between
     # API servers and engine core. Returns a single queue since we only support
@@ -1093,24 +1101,6 @@ def launch_core_engines(
         local_handshake_address = handshake_address
         client_handshake_address = None
 
-    # In external-LB mode, each rank is a separate `vllm serve` process and
-    # data_parallel_rank_local is unset. Historically this means the engine
-    # subprocess always selects cuda:0 of whatever the user made visible, so
-    # users had to narrow CUDA_VISIBLE_DEVICES per rank. If instead the user
-    # has all DP-world GPUs for this rank visible, derive the local index from
-    # the global DP rank — matching how internal/hybrid LB shifts the device
-    # in the engine subprocess.
-    spawn_local_start_index = local_start_index
-    if (
-        spawn_local_start_index is None
-        and parallel_config.data_parallel_external_lb
-        and dp_rank > 0
-        and current_platform.is_cuda_alike()
-        and (dp_rank + 1) * parallel_config.world_size
-        <= current_platform.device_count()
-    ):
-        spawn_local_start_index = dp_rank
-
     with zmq_socket_ctx(
         local_handshake_address, zmq.ROUTER, bind=True
     ) as handshake_socket:
@@ -1125,7 +1115,7 @@ def launch_core_engines(
                 local_client=True,
                 local_engine_count=local_engine_count,
                 start_index=dp_rank,
-                local_start_index=spawn_local_start_index or 0,
+                local_start_index=local_start_index or 0,
                 tensor_queue=tensor_queue,
             )
         else:


### PR DESCRIPTION
Currently deploying DP in external LB mode requires `CUDA_VISIBLE_DEVICES` to be set for each launched engine to just the GPU(s) corresponding to that engine's dp rank.

However CUDA symmetric memory (used with DS MegaMoE kernel) requires visibility to all GPUs so we want this to also work for `CUDA_VISIBLE_DEVICES` covering all local GPUs. This is already the case for internal/hybrid modes, where `torch.cuda.set_device` is used.

This PR adds a new `local_data_parallel_rank` arg that can be used in external dp lb mode along with a larger set of visible GPUs to specify the corresponding engine's local DP rank within that set. BC with all existing behavior/options is preserved.