### PR TITLE
[security] Change VLLM_MEDIA_URL_ALLOW_REDIRECTS default to False

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -72,7 +72,7 @@ if TYPE_CHECKING:
     VLLM_MEDIA_CACHE_MAX_SIZE_MB: int = 5120
     VLLM_MEDIA_CACHE_TTL_HOURS: float = 24
     VLLM_MEDIA_FETCH_MAX_RETRIES: int = 3
-    VLLM_MEDIA_URL_ALLOW_REDIRECTS: bool = True
+    VLLM_MEDIA_URL_ALLOW_REDIRECTS: bool = False
     VLLM_MEDIA_LOADING_THREAD_COUNT: int = 8
     VLLM_MAX_AUDIO_CLIP_FILESIZE_MB: int = 25
     VLLM_VIDEO_LOADER_BACKEND: str = "opencv"
@@ -826,9 +826,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("VLLM_MEDIA_FETCH_MAX_RETRIES", "3")
     ),
     # Whether to allow HTTP redirects when fetching from media URLs.
-    # Default to True
+    # Default to False
     "VLLM_MEDIA_URL_ALLOW_REDIRECTS": lambda: bool(
-        int(os.getenv("VLLM_MEDIA_URL_ALLOW_REDIRECTS", "1"))
+        int(os.getenv("VLLM_MEDIA_URL_ALLOW_REDIRECTS", "0"))
     ),
     # Max number of workers for the thread pool handling
     # media bytes loading. Set to 1 to disable parallel processing.


### PR DESCRIPTION
## Summary
Change the default value of `VLLM_MEDIA_URL_ALLOW_REDIRECTS` from `True` to `False`.

## Problem
The security documentation (`docs/usage/security.md`) explicitly warns: *"consider setting VLLM_MEDIA_URL_ALLOW_REDIRECTS=0 to prevent HTTP redirects from being followed to bypass domain restrictions."* This indicates the default `True` conflicts with the project's own security guidance.

## Solution
Set the default to `False`, aligning the default behavior with the documented secure configuration.

## Note
Operators who rely on redirect following for legitimate use cases (e.g., CDN redirects) can explicitly set `VLLM_MEDIA_URL_ALLOW_REDIRECTS=1` to restore the previous behavior.

## Testing
- Verified the redirect bypass vulnerability end-to-end (target received requests after redirect)
- The fix is a single-line change in `vllm/envs.py`