### PR TITLE
[Bugfix] Workaround for DeepSeek V4 MTP=1 hang issue

### DIFF
--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -164,6 +164,10 @@ class DeepseekV4IndexerBackend(DeepseekV32IndexerBackend):
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
         return [256]
 
+    @staticmethod
+    def get_builder_cls() -> type["DeepseekV32IndexerMetadataBuilder"]:
+        return DeepseekV4IndexerMetadataBuilder
+
 
 @dataclass
 class DeepseekV32IndexerPrefillChunkMetadata:
@@ -636,6 +640,10 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
         )
 
         return attn_metadata
+
+
+class DeepseekV4IndexerMetadataBuilder(DeepseekV32IndexerMetadataBuilder):
+    natively_supported_next_n_fp4: list[int] = [1]
 
 
 def build_prefill_chunk_metadata(


### PR DESCRIPTION
## Purpose
Currently running DeepSeek V4 MTP=1 will hang. Reproduction:
```
VLLM_ENGINE_READY_TIMEOUT_S=3600 python3 \
    -m vllm.entrypoints.cli.main \
    serve deepseek-ai/DeepSeek-V4-Pro \
    --trust-remote-code \
    --max-num-batched-tokens 2048 \
    --max-model-len 2048 \
    --max-cudagraph-capture-size 2048 \
    --no-enable-prefix-caching \
    --tensor-parallel-size 8 \
    --enable-expert-parallel \
    --attention_config.use_fp4_indexer_cache=True \
    --kv-cache-dtype fp8 \
    --compilation-config '{"cudagraph_mode":"FULL_AND_PIECEWISE", "custom_ops":["all"]}' \
    --speculative-config '{"method": "mtp", "num_speculative_tokens": 1}' \
    --block-size 256 \
    --enable-auto-tool-choice \
    --tokenizer-mode deepseek_v4 \
    --tool-call-parser deepseek_v4 \
    --no-enable-flashinfer-autotune \
    --reasoning-parser deepseek_v4

python3 InferenceX/utils/bench_serving/benchmark_serving.py --model deepseek-ai/DeepSeek-V4-Pro --backend vllm --base-url [http://0.0.0.0:](http://0.0.0.0:8888/)8000 --dataset-name random --random-input-len 1024 --random-output-len 1024 --random-range-ratio 0.8 --num-prompts 80 --max-concurrency 8 --request-rate inf --ignore-eos --save-result --num-warmups 8 --percentile-metrics ttft,tpot,itl,e2el --trust-remote-code --use-chat-template --dsv4
```

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

