### PR TITLE
[Bugfix] [Weight Loader] Add Fp8OnlineLinearMethod to WEIGHT_LOADER_V2_SUPPORTED

### DIFF
--- a/vllm/model_executor/layers/linear.py
+++ b/vllm/model_executor/layers/linear.py
@@ -50,6 +50,7 @@ WEIGHT_LOADER_V2_SUPPORTED = [
     "AWQLinearMethod",
     "GPTQMarlinLinearMethod",
     "Fp8LinearMethod",
+    "Fp8OnlineLinearMethod",
     "MarlinLinearMethod",
     "GPTQMarlin24LinearMethod",
     "TPUInt8LinearMethod",


### PR DESCRIPTION
Purpose
---------
Fixes `Qwen3.5/Qwen3-Next` failing to load with online FP8 quantization (`--quantization=fp8` from a bf16 checkpoint), which crashes at model load with:

  `NotImplementedError`: Shard id with multiple indices is not supported
  in `weight_loader`, please use `weight_loader_v2` instead.

Bug chain
---------
PR #34697 ("[Bugfix] Redo Qwen3.5/Qwen3-Next GDN projector fusion") fused the GDN in_proj_qkv and in_proj_z projections into a single in_proj_qkvz parameter with output_sizes=[key_dim, key_dim, value_dim, value_dim]. The checkpoint still ships the qkv portion pre-fused, so load_weights now passes a tuple shard_id (0, 1, 2) to map the checkpoint's in_proj_qkv into slots 0..2 of the model's 4-slot in_proj_qkvz parameter.

The same PR moved tuple shard_id handling from weight_loader (v1) to weight_loader_v2 only: v1 now explicitly raises NotImplementedError when it sees a tuple, and v2 was extended to handle them.

Whether v1 or v2 is selected is decided in ColumnParallelLinear by a string match against WEIGHT_LOADER_V2_SUPPORTED:

    weight_loader=(
        self.weight_loader_v2
        if self.quant_method.__class__.__name__ in WEIGHT_LOADER_V2_SUPPORTED
        else self.weight_loader
    )

Fp8LinearMethod is in the allowlist. Fp8OnlineLinearMethod (which subclasses Fp8LinearMethod and is used when the checkpoint is bf16 and --quantization=fp8 is requested, quantizing weights at load time) is not. Because the check uses __class__.__name__, the subclass relationship does not help -- the concrete class name "Fp8OnlineLinearMethod" must appear in the list.

Result: Qwen3.5 + online FP8 routes through v1, hits the tuple shard_id, and crashes at model load.

Why CI did not catch it
-----------------------
PR #34697's test plan exercised correctness of the fusion (gsm8k on the unquantized model, plus offline FP8 with Fp8LinearMethod which IS in the allowlist). Online FP8 (bf16 weights quantized at load time via Fp8OnlineLinearMethod) is a separate, more production-oriented code path that is not covered by the standard CI matrix for Qwen3.5/Qwen3-Next.

Fix
---
Add "Fp8OnlineLinearMethod" to WEIGHT_LOADER_V2_SUPPORTED so the v2 loader is selected for it. Fp8OnlineLinearMethod's create_weights wraps whatever weight_loader it receives in a patched_weight_loader for FP8-on-load quantization and then delegates to the original loader -- it is agnostic to the v1/v2 distinction, so v2 flows through correctly and the tuple shard_id is handled.

Test
----
```
vllm serve Qwen/Qwen3.5-27B \
  --port 8000 \
  --tensor-parallel-size 4 \
  --max-model-len 262144 \
  --reasoning-parser qwen3 \
  --quantization=fp8
```

Before: model load aborts with NotImplementedError raised from
        MergedColumnParallelLinear.weight_loader on the GDN
        in_proj_qkvz parameter.
After:  model loads cleanly; serve starts; no NotImplementedError.




---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

