### PR TITLE
[DSV4] Align aux stream API with DeepseekV4DecoderLayer

### DIFF
--- a/vllm/model_executor/models/deepseek_v4_mtp.py
+++ b/vllm/model_executor/models/deepseek_v4_mtp.py
@@ -167,7 +167,7 @@ class DeepSeekV4MultiTokenPredictor(nn.Module):
         )
 
         # Three aux streams shared across all MTP layers, mirroring
-        # DeepseekV4Model — see comment at deepseek_v4.py:1236-1239.
+        # DeepseekV4Model.
         aux_stream_list = [torch.cuda.Stream() for _ in range(3)]
 
         # to map the exact layer index from weights

--- a/vllm/model_executor/models/deepseek_v4_mtp.py
+++ b/vllm/model_executor/models/deepseek_v4_mtp.py
@@ -64,6 +64,7 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
         vllm_config: VllmConfig,
         topk_indices_buffer: torch.Tensor,
         prefix: str,
+        aux_stream_list: list[torch.cuda.Stream] | None = None,
     ) -> None:
         super().__init__()
 
@@ -111,7 +112,6 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
         self.shared_head = SharedHead(
             config=config, prefix=prefix, quant_config=quant_config
         )
-        aux_stream_list = [torch.cuda.Stream() for _ in range(3)]
         self.mtp_block = DeepseekV4DecoderLayer(
             vllm_config,
             prefix,
@@ -166,6 +166,10 @@ class DeepSeekV4MultiTokenPredictor(nn.Module):
             device=self.device,
         )
 
+        # Three aux streams shared across all MTP layers, mirroring
+        # DeepseekV4Model — see comment at deepseek_v4.py:1236-1239.
+        aux_stream_list = [torch.cuda.Stream() for _ in range(3)]
+
         # to map the exact layer index from weights
         self.layers = torch.nn.ModuleDict(
             {
@@ -173,6 +177,7 @@ class DeepSeekV4MultiTokenPredictor(nn.Module):
                     vllm_config,
                     self.topk_indices_buffer,
                     f"{prefix}.layers.{idx}",
+                    aux_stream_list=aux_stream_list,
                 )
                 for idx in range(
                     self.mtp_start_layer_idx,

--- a/vllm/model_executor/models/deepseek_v4_mtp.py
+++ b/vllm/model_executor/models/deepseek_v4_mtp.py
@@ -35,7 +35,6 @@ from vllm.model_executor.layers.vocab_parallel_embedding import (
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.platforms import current_platform
 from vllm.sequence import IntermediateTensors
-from vllm.utils.multi_stream_utils import AuxStreamType
 
 from .deepseek_mtp import SharedHead
 from .deepseek_v2 import get_spec_layer_idx_from_weight_name
@@ -112,14 +111,12 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
         self.shared_head = SharedHead(
             config=config, prefix=prefix, quant_config=quant_config
         )
-        self.aux_stream_dict = {
-            AuxStreamType.Attention: torch.cuda.Stream(),
-        }
+        aux_stream_list = [torch.cuda.Stream() for _ in range(3)]
         self.mtp_block = DeepseekV4DecoderLayer(
             vllm_config,
             prefix,
             topk_indices_buffer=topk_indices_buffer,
-            aux_stream_dict=self.aux_stream_dict,
+            aux_stream_list=aux_stream_list,
         )
 
     def forward(


### PR DESCRIPTION
## Summary
- PR #41061 changed `DeepseekV4DecoderLayer` to take `aux_stream_list: list[torch.cuda.Stream]` (3 streams) and dropped the old `aux_stream_dict` path, but missed `DeepSeekV4MultiTokenPredictorLayer` in `deepseek_v4_mtp.py`, which still constructed an `aux_stream_dict` keyed by `AuxStreamType.Attention` and forwarded it as `aux_stream_dict=...`.
- Construct `aux_stream_list = [torch.cuda.Stream() for _ in range(3)]` in the MTP layer and pass it through, matching the new interface used in `deepseek_v4.py` and removing the now-unused `AuxStreamType` import.

## Test plan
- [x] DeepSeek V4 + MTP startup smoke test (model loads, no `TypeError` on `DeepseekV4DecoderLayer.__init__`).
- [x] Spec-decoding correctness on DeepSeek V4 MTP (greedy + temperature).

AI assistance (Claude) was used for this change; the submitter has reviewed every line and is accountable for it. No existing open PR addresses this MTP-side interface mismatch (checked open PRs touching `deepseek_v4_mtp.py` / referencing #41061).