### PR TITLE
fix(weight_loader): support scalar-to-array conversion for PerTensorScaleParameter

### DIFF
--- a/vllm/model_executor/parameter.py
+++ b/vllm/model_executor/parameter.py
@@ -271,9 +271,7 @@ class PerTensorScaleParameter(BasevLLMParameter):
     process_weights_after_loading
     """
 
-    def __init__(self, **kwargs):
-        super().__init__(**kwargs)
-        self.needs_scalar_to_array = True
+    needs_scalar_to_array: bool = True
 
     # For row parallel layers, no sharding needed
     # load weight into parameter as is
@@ -606,8 +604,8 @@ def _adjust_shard_indexes_for_marlin(shard_size, shard_offset, marlin_tile_size)
 def _adjust_shard_indexes_for_packing(
     shard_size, shard_offset, packed_factor, marlin_tile_size
 ):
-    shard_size = round(shard_size // packed_factor)
-    shard_offset = round(shard_offset // packed_factor)
+    shard_size = shard_size // packed_factor
+    shard_offset = shard_offset // packed_factor
     if marlin_tile_size is not None:
         return _adjust_shard_indexes_for_marlin(
             shard_size=shard_size,

--- a/vllm/model_executor/parameter.py
+++ b/vllm/model_executor/parameter.py
@@ -273,6 +273,9 @@ class PerTensorScaleParameter(BasevLLMParameter):
 
     needs_scalar_to_array: bool = True
 
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
     # For row parallel layers, no sharding needed
     # load weight into parameter as is
     def load_row_parallel_weight(self, *args, **kwargs):
@@ -604,8 +607,8 @@ def _adjust_shard_indexes_for_marlin(shard_size, shard_offset, marlin_tile_size)
 def _adjust_shard_indexes_for_packing(
     shard_size, shard_offset, packed_factor, marlin_tile_size
 ):
-    shard_size = shard_size // packed_factor
-    shard_offset = shard_offset // packed_factor
+    shard_size = round(shard_size // packed_factor)
+    shard_offset = round(shard_offset // packed_factor)
     if marlin_tile_size is not None:
         return _adjust_shard_indexes_for_marlin(
             shard_size=shard_size,

--- a/vllm/model_executor/parameter.py
+++ b/vllm/model_executor/parameter.py
@@ -273,6 +273,7 @@ class PerTensorScaleParameter(BasevLLMParameter):
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
+        self.needs_scalar_to_array = True
 
     # For row parallel layers, no sharding needed
     # load weight into parameter as is


### PR DESCRIPTION


## Purpose

Enables `needs_scalar_to_array` for `PerTensorScaleParameter` to allow the weight loader to correctly handle scalar scales in checkpoints (shape `()`) when the model expects an array (shape `(1,)` or fused). This ensures compatibility with models like Mistral Small 4 119B across all backends, particularly those with strict shape requirements.

In many quantized checkpoints (e.g., Mistral Small 4 119B FP8), per-tensor scales are stored as scalars. However, vLLM typically initializes these parameters as arrays to support potential fusion or sharding. Without this flag, the `default_weight_loader` hits a shape mismatch assertion when trying to load a scalar into a 1-element tensor.

## Test Plan

https://github.com/vllm-project/tpu-inference/pull/2437

## Test Result

https://github.com/vllm-project/tpu-inference/pull/2437

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

