### PR TITLE
[Bugfix] Fix async scheduler token payload recovery

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -143,6 +143,41 @@ def test_async_scheduling_pp_allows_rescheduling_with_output_placeholders():
     assert req.request_id in output.num_scheduled_tokens
 
 
+def test_async_scheduling_sends_tokens_until_worker_state_confirmed():
+    scheduler = create_scheduler(async_scheduling=True)
+    (req,) = create_requests(num_requests=1, num_tokens=8)
+    scheduler.add_request(req)
+
+    first_output = scheduler.schedule()
+    assert first_output.scheduled_cached_reqs.num_reqs == 0
+
+    # The request was scheduled in the previous scheduler step, but no worker
+    # output has confirmed that it has been added to the persistent batch yet.
+    # Send token ids so the worker can rebuild state if this output arrives
+    # before the prior batch has been applied.
+    second_output = scheduler.schedule()
+    second_cached_reqs = second_output.scheduled_cached_reqs
+    assert req.request_id in second_cached_reqs.req_ids
+    assert req.request_id in second_cached_reqs.all_token_ids
+
+    model_output = ModelRunnerOutput(
+        req_ids=[req.request_id],
+        req_id_to_index={req.request_id: 0},
+        sampled_token_ids=[[100]],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+    scheduler.update_from_output(first_output, model_output)
+
+    # After a worker output reports the request in its persistent batch, the
+    # scheduler can omit the full token payload again.
+    third_output = scheduler.schedule()
+    third_cached_reqs = third_output.scheduled_cached_reqs
+    assert req.request_id in third_cached_reqs.req_ids
+    assert req.request_id not in third_cached_reqs.all_token_ids
+
+
 def test_schedule_partial_requests():
     """Test scheduling behavior with partial requests.
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -101,6 +101,10 @@ class Scheduler(SchedulerInterface):
             defaultdict(set) if include_finished_set else None
         )
         self.prev_step_scheduled_req_ids: set[str] = set()
+        # Request IDs present in the most recent worker persistent batch that
+        # produced a ModelRunnerOutput. Async scheduling can issue a later
+        # SchedulerOutput before that worker-side state is confirmed.
+        self.prev_model_runner_batch_req_ids: set[str] = set()
 
         # Scheduling constraints.
         self.max_num_running_reqs = self.scheduler_config.max_num_seqs
@@ -1090,10 +1094,18 @@ class Scheduler(SchedulerInterface):
                 ]
                 new_token_ids.append(token_ids)
             scheduled_in_prev_step = req_id in self.prev_step_scheduled_req_ids
+            if self.scheduler_config.async_scheduling:
+                has_worker_state = (
+                    scheduled_in_prev_step
+                    and req_id in self.prev_model_runner_batch_req_ids
+                )
+            else:
+                has_worker_state = scheduled_in_prev_step
             if idx >= num_running_reqs:
                 assert not scheduled_in_prev_step
                 resumed_req_ids.add(req_id)
-            if not scheduled_in_prev_step:
+                has_worker_state = False
+            if not has_worker_state:
                 all_token_ids[req_id] = req.all_token_ids.copy()
             new_block_ids.append(
                 req_to_new_blocks[req_id].get_block_ids(allow_none=True)
@@ -1313,6 +1325,7 @@ class Scheduler(SchedulerInterface):
         num_nans_in_logits = model_runner_output.num_nans_in_logits
         kv_connector_output = model_runner_output.kv_connector_output
         cudagraph_stats = model_runner_output.cudagraph_stats
+        self.prev_model_runner_batch_req_ids = set(model_runner_output.req_id_to_index)
 
         perf_stats: PerfStats | None = None
         if self.perf_metrics and self.perf_metrics.is_enabled():


### PR DESCRIPTION
## Summary
- Track request IDs confirmed by the worker's latest persistent batch output.
- In async scheduling, keep sending full token IDs for cached requests until worker state is confirmed.
- Add a regression test for a second scheduler output emitted before the first worker output is applied.

## Root cause
Async scheduling can emit another `SchedulerOutput` for a request before the scheduler has processed the worker output for the previous step. After a step is scheduled, async scheduler bookkeeping advances `num_computed_tokens` and adds `num_output_placeholders` for the token that the step is expected to produce. That lookahead lets the next scheduler step keep the decode pipeline full, but it also means scheduler-local history can get ahead of worker-confirmed persistent batch state.

The old logic only checked whether a request was scheduled in the previous scheduler step, so it could omit `all_token_ids` even though the worker still needed the payload to rebuild request state. That can surface as a `KeyError` in worker state update when re-adding a cached request.

```
worker_base.py, line 337, in execute_model
 return self.worker.execute_model(scheduler_output)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gpu_model_runner.py, line 3833, in execute_model
deferred_state_corrections_fn = self._update_states(scheduler_output)
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gpu_model_runner.py, line 1324, in _update_states
     resumed_token_ids = req_data.all_token_ids[req_id]
                        ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
KeyError: 'chatcmpl-____d567d404c6214189a02153241c7eb203-bd77a0f9'
```

## Simplified bug timeline
- `R` is one request, for example `req_42`.
- `A` is the first `SchedulerOutput` that schedules `R` on the decode side.
- `B` is the next `SchedulerOutput` for `R`, produced before the scheduler has processed `ModelRunnerOutput(A)`.

Timeline:
1. Scheduler emits `A` with `R`, and records `R` in `prev_step_scheduled_req_ids`.
2. Async scheduler immediately advances scheduler-side bookkeeping for `A`: `num_computed_tokens` is incremented and `num_output_placeholders` reserves the sampled token that `A` is expected to produce.
3. Because that placeholder represents the in-flight output token, scheduler can emit `B` for `R` before `A`'s sampled token and worker batch state are confirmed through `ModelRunnerOutput(A)`.
4. Old logic saw `R` in `prev_step_scheduled_req_ids` and assumed the worker already had `R` in its persistent batch.
5. Because of that assumption, `B` omitted `scheduled_cached_reqs.all_token_ids[R]`.
6. If the worker applies `B` while `R` is absent from that worker's `input_batch.req_id_to_index`, it needs those token IDs to rebuild/add `R`; the missing payload can cause a `KeyError` during worker state update.

The fix separates scheduler lookahead/history from worker-confirmed state. In async scheduling, token IDs are omitted only after `ModelRunnerOutput.req_id_to_index` confirms that the worker has `R` in its persistent batch.

## Duplicate-work check
No issue number was provided, so issue-specific duplicate checks were not applicable.

I checked open PRs with these searches:
- `async scheduling all_token_ids KeyError`
- `prev_step_scheduled_req_ids all_token_ids`
- `persistent batch async scheduling`

The nearest open matches were #34029 and #40610. #34029 optimizes async scheduling token copying but still keys payload elision off scheduler history, while this PR gates elision on worker-confirmed persistent batch state. #40610 fixes a speculative decoding synchronization race in `gpu_model_runner.py`, which is a different failure mode.

## Tests
- `.venv/bin/python -m compileall -q vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py`
- Direct inline regression script for the async scheduler token-payload race
- `.venv/bin/python -m pytest tests/v1/core/test_scheduler.py -k 'async_scheduling_sends_tokens_until_worker_state_confirmed or async_scheduling_pp_allows_rescheduling_with_output_placeholders' -v` (2 passed, 95 deselected)
- `git diff --check -- vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py`

## AI assistance
AI assistance was used to draft and validate this change. The human submitter must review every changed line, understand the root cause and fix, and be able to defend the change end-to-end before marking this PR ready for review.