### PR TITLE
Fix sharded_state load for FP8 models with aliased scale keys

### DIFF
--- a/tests/model_executor/model_loader/test_sharded_state_loader.py
+++ b/tests/model_executor/model_loader/test_sharded_state_loader.py
@@ -13,6 +13,9 @@ from huggingface_hub import snapshot_download
 
 from vllm import LLM, SamplingParams
 from vllm.model_executor.model_loader import ShardedStateLoader
+from vllm.model_executor.model_loader.sharded_state_loader import (
+    _has_loaded_alias,
+)
 from vllm.platforms import current_platform
 
 prompts = [
@@ -48,6 +51,28 @@ def test_filter_subtensors():
     for key, tensor in filtered_state_dict.items():
         # NOTE: don't use `equal` here, as the tensor might contain NaNs
         assert tensor is state_dict[key]
+
+
+class TestHasLoadedAlias:
+    """Tests for _has_loaded_alias, which bridges save/load asymmetry
+    for buffer/parameter pairs like _q_scale and q_scale (#41174)."""
+
+    def test_underscore_alias_detected(self):
+        loaded = {"layer.attn._q_scale", "layer.attn._k_scale"}
+        assert _has_loaded_alias("layer.attn.q_scale", loaded)
+        assert _has_loaded_alias("layer.attn.k_scale", loaded)
+
+    def test_no_alias_when_underscore_version_not_loaded(self):
+        loaded = {"layer.attn.weight", "layer.attn.bias"}
+        assert not _has_loaded_alias("layer.attn.q_scale", loaded)
+
+    def test_already_underscore_prefixed_key_not_aliased(self):
+        loaded = {"layer.attn.__q_scale"}
+        assert not _has_loaded_alias("layer.attn._q_scale", loaded)
+
+    def test_top_level_key_no_alias(self):
+        loaded = {"_weight"}
+        assert not _has_loaded_alias("weight", loaded)
 
 
 @pytest.fixture(scope="module")

--- a/vllm/model_executor/model_loader/sharded_state_loader.py
+++ b/vllm/model_executor/model_loader/sharded_state_loader.py
@@ -26,6 +26,26 @@ from vllm.transformers_utils.utils import is_s3
 logger = init_logger(__name__)
 
 
+def _has_loaded_alias(key: str, loaded_keys: set[str]) -> bool:
+    """Check if *key* is an alias of a key that was already loaded.
+
+    During save, ``_filter_subtensors`` keeps only one key from a group of
+    tensors that share the same underlying storage.  For buffer/parameter
+    pairs that follow the ``_name`` / ``name`` convention (e.g.
+    ``_q_scale`` buffer vs ``q_scale`` parameter), the underscore-prefixed
+    version wins because it sorts first.  On a fresh model at load time
+    these tensors no longer share storage, so the loader cannot detect
+    the alias automatically.  This function bridges the gap by checking
+    whether the underscore-prefixed counterpart of *key* was loaded.
+    """
+    parts = key.rsplit(".", 1)
+    if len(parts) == 2:
+        parent, name = parts
+        if not name.startswith("_"):
+            return f"{parent}._{name}" in loaded_keys
+    return False
+
+
 class ShardedStateLoader(BaseModelLoader):
     """
     Model loader that directly loads each worker's model state dict, which
@@ -135,6 +155,7 @@ class ShardedStateLoader(BaseModelLoader):
             )
         state_dict = self._filter_subtensors(model.state_dict())
         counter_before_loading_weights = time.perf_counter()
+        loaded_keys: set[str] = set()
         for key, tensor in self.iterate_over_files(filepaths):
             # If loading with LoRA enabled, additional padding may
             # be added to certain parameters. We only load into a
@@ -153,13 +174,28 @@ class ShardedStateLoader(BaseModelLoader):
                 )
             param_data.copy_(tensor)
             state_dict.pop(key)
+            loaded_keys.add(key)
         counter_after_loading_weights = time.perf_counter()
         logger.info_once(
             "Loading weights took %.2f seconds",
             counter_after_loading_weights - counter_before_loading_weights,
         )
         if state_dict:
-            raise ValueError(f"Missing keys {tuple(state_dict)} in loaded state!")
+            # During save, _filter_subtensors deduplicates tensors that
+            # share storage (e.g. buffer _q_scale and parameter q_scale).
+            # The checkpoint keeps only the canonical (underscore-prefixed)
+            # key. On a fresh model these tensors have separate storage, so
+            # _filter_subtensors cannot deduplicate them at load time.
+            # Skip keys whose underscore-prefixed counterpart was loaded.
+            missing = {
+                k: v
+                for k, v in state_dict.items()
+                if not _has_loaded_alias(k, loaded_keys)
+            }
+            if missing:
+                raise ValueError(
+                    f"Missing keys {tuple(missing)} in loaded state!"
+                )
 
     def iterate_over_files(
         self, paths


### PR DESCRIPTION
## Summary

Fixes #41174

- `_filter_subtensors` deduplicates tensors sharing storage during save (e.g. `_q_scale` buffer and `q_scale` parameter keep only `_q_scale`). On a fresh model at load time, these tensors have separate storage and cannot be deduplicated, so both keys remain in the expected state dict but only the underscore-prefixed version exists in the checkpoint — causing `ValueError: Missing keys`.
- Added `_has_loaded_alias()` helper that checks whether an unloaded key's underscore-prefixed counterpart was already loaded from the checkpoint. Remaining keys that pass this check are skipped instead of triggering the error.
- Added unit tests for the alias detection logic.

### Why this is not duplicating an existing PR

No open PRs address issue #41174. Verified via:
```
gh pr list --repo vllm-project/vllm --state open --search "41174 in:body"
gh pr list --repo vllm-project/vllm --state open --search "_filter_subtensors"
```

### AI assistance disclosure

This PR was developed with AI assistance (Claude). All changes have been reviewed and understood by the submitter.

## Test plan

- [x] Unit tests for `_has_loaded_alias` covering alias detection, non-alias keys, already-prefixed keys, and top-level keys
- [x] Existing `test_filter_subtensors` still passes (no change to dedup logic)
- [ ] Manual verification with FP8 model + sharded_state save/load (requires GPU — CI will cover this via existing `test_sharded_state_loader`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)