### PR TITLE
[Bugfix][V1][P/D] Fix reset_prefix_cache failing on prefiller after PD-disagg prefill

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -182,6 +182,13 @@ class Scheduler(SchedulerInterface):
         # KV Connector: requests in process of async KV loading or recving
         self.finished_recving_kv_req_ids: set[str] = set()
         self.failed_recving_kv_req_ids: set[str] = set()
+        # KV Connector: requests whose blocks are held pending the connector
+        # finishing an outbound KV transfer (e.g. PD-disagg prefiller waiting
+        # for the decode peer to acknowledge the pull). These keep
+        # `has_requests()` true so that the engine continues to poll
+        # `connector.get_finished()` until the transfer completes (or times
+        # out) and the blocks can be freed.
+        self.delayed_free_req_ids: set[str] = set()
 
         # Encoder-related.
         # Calculate encoder cache size if applicable
@@ -1838,12 +1845,18 @@ class Scheduler(SchedulerInterface):
         delay_free_blocks |= connector_delay_free_blocks
         if not delay_free_blocks:
             self._free_blocks(request)
+        else:
+            # The connector is holding the blocks for an async transfer.
+            # Track the request id so the engine stays awake polling
+            # `connector.get_finished()` until the transfer completes.
+            self.delayed_free_req_ids.add(request_id)
 
         return kv_xfer_params
 
     def _free_blocks(self, request: Request):
         assert request.is_finished()
         self.kv_cache_manager.free(request)
+        self.delayed_free_req_ids.discard(request.request_id)
         del self.requests[request.request_id]
 
     @property
@@ -1867,6 +1880,25 @@ class Scheduler(SchedulerInterface):
 
     def has_finished_requests(self) -> bool:
         return len(self.finished_req_ids) > 0
+
+    def has_delayed_free_requests(self) -> bool:
+        """Returns True if any request still holds blocks pending the KV
+        connector finishing an async outbound transfer."""
+        return len(self.delayed_free_req_ids) > 0
+
+    def has_requests(self) -> bool:
+        """Override `SchedulerInterface.has_requests` to also stay alive while
+        any request is waiting for the KV connector to complete an async
+        outbound transfer. Without this, the engine can sleep on the input
+        queue right after a prefill (PD-disagg prefiller), never polling
+        `connector.get_finished()` to receive the decode-side acknowledgement,
+        and the held blocks become unreclaimable until the connector's own
+        timeout fires."""
+        return (
+            self.has_unfinished_requests()
+            or self.has_finished_requests()
+            or self.has_delayed_free_requests()
+        )
 
     def reset_prefix_cache(
         self, reset_running_requests: bool = False, reset_connector: bool = False

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -1214,10 +1214,15 @@ class EngineCoreProc(EngineCore):
         self.post_step(model_executed)
 
         # If no model execution happened but there are waiting requests
-        # (e.g., WAITING_FOR_REMOTE_KVS), yield the GIL briefly to allow
-        # background threads (like NIXL handshake) to make progress.
+        # (e.g., WAITING_FOR_REMOTE_KVS) or requests holding blocks pending
+        # an outbound KV connector transfer (PD-disagg prefiller waiting for
+        # decode-side ack), yield the GIL briefly to allow background threads
+        # (like NIXL handshake) to make progress.
         # Without this, the tight polling loop can starve background threads.
-        if not model_executed and self.scheduler.has_unfinished_requests():
+        if not model_executed and (
+            self.scheduler.has_unfinished_requests()
+            or self.scheduler.has_delayed_free_requests()
+        ):
             time.sleep(0.001)
 
         return model_executed


### PR DESCRIPTION


## Purpose

Restore the symmetric "stay alive while a remote KV transfer is in flight" invariant on the **prefiller** side of V1 P/D disaggregation.

**Symptom (1P1D, NIXL):** after a PD-disagg prefill, hitting the prefiller's `/reset_prefix_cache` returns failure — `kv_cache_manager.reset_prefix_cache()` is False because the request's blocks are still held by the connector.

**Why:** the receiver already has this invariant — a request waiting for inbound KV stays in `waiting` with `WAITING_FOR_REMOTE_KVS`, so `has_unfinished_requests()` keeps the engine stepping until `_update_from_kv_xfer_finished` consumes `finished_recving`. The sender does not. After prefill, `_free_request` sees `connector_delay_free_blocks=True`, the request is removed from `running`/`waiting` and only lives in `finished_req_ids`, which is cleared on the next `schedule()`. From there `has_requests()` is False, the engine sleeps on the input queue, `connector.get_finished()` is never driven, and the worker-side `finished_sending` (decoder's pull ack) never reaches `_free_blocks`.

**Fix:** add a sender-side equivalent of `finished_recving_kv_req_ids`.

- New `Scheduler.delayed_free_req_ids: set[str]`. Filled in `_free_request` when blocks are delayed; drained in `_free_blocks`.
- Override `Scheduler.has_requests()` to include `has_delayed_free_requests()`, mirroring how the receiver stays alive via the `waiting` queue.
- Extend the existing `WAITING_FOR_REMOTE_KVS` GIL-yield in `EngineCoreProc._process_engine_step` to also cover delayed-free requests, so the NIXL background thread can make progress instead of tight-spinning.

Scope: scheduler + engine core only. No connector-side changes.

**Duplicate-work check:** searched vllm-project/vllm for `delayed_free_req_ids`, `has_requests` + `get_finished`, `reset_prefix_cache` + PD-disagg. Closest is #19223 (block stranding on D-side abort) — orthogonal: that's the abort path, this is normal completion.

**AI assistance disclosure:** developed with AI assistance (Claude); every changed line reviewed and tested by the human submitter.

## Test Plan

MI300X × 8, NIXL 1P1D PD-disagg.

1. Launch P and D with NIXL, fronted by the toy proxy server (`tests/v1/kv_connector/nixl_integration/toy_proxy_server.py`).
2. Send a PD-disagg request to the proxy so the prefix cache is loaded on P.
3. Call P's `/reset_prefix_cache`.

Pass: P keeps scheduling until the decoder's pull-finished notif arrives; held blocks are then released via `_update_from_kv_xfer_finished → _free_blocks`; `/reset_prefix_cache` succeeds.

### Launch Script
```bash
# Environment
export UCX_IB_PCI_RELAXED_ORDERING=on
export UCX_ROCM_COPY_DMABUF=try
export UCX_TLS=rocm_copy,rocm_ipc,self,sm,rc_x
export VLLM_LOGGING_LEVEL=DEBUG
export VLLM_NIXL_SIDE_CHANNEL_HOST=<host_addr>
export VLLM_SERVER_DEV_MODE=1

# vllm serve (prefiller / decoder both)
# --block-size 1 makes one token == one block so the failure surfaces deterministically.
vllm serve <model_path> \
  --served-model-name <model_name> \
  --port <port> \
  --trust-remote-code \
  --block-size 1 \
  --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}'

# Toy proxy in front of P and D (see tests/v1/kv_connector/nixl_integration/run_accuracy_test.sh)
python3 tests/v1/kv_connector/nixl_integration/toy_proxy_server.py \
  --port <proxy_port> \
  --prefiller-hosts <p_host> --prefiller-ports <p_port> \
  --decoder-hosts   <d_host> --decoder-ports   <d_port>
```

### Load Prefix Cache, Then Reset
```bash
# 1) Send a request through the proxy so P loads the prefix cache.
curl -X POST http://<proxy_host>:<proxy_port>/v1/completions \
  -H 'Content-Type: application/json' \
  -d '{"model": "<model_name>", "prompt": "<long prompt>", "max_tokens": 16}'

# 2) Hit the prefiller's reset endpoint directly.
curl -X POST http://<prefiller_host>:<port>/reset_prefix_cache
```


## Test Result

MI300X × 8, NIXL 1P1D manual e2e:

- **Before:** prefiller engine goes idle right after prefill; `connector.get_finished()` is not driven; `/reset_prefix_cache` fails.
```text
Failed to reset prefix cache because some blocks (<token_num>) are not freed yet
```

- **After:** prefiller keeps scheduling until the decoder notif arrives; blocks are freed via the existing path; `/reset_prefix_cache` succeeds.
```text
Successfully reset prefix cache
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>