### PR TITLE
[ROCm] Fix LDS bank conflicts in vecMatMul reduction_smem layout

### DIFF
--- a/csrc/rocm/ops.h
+++ b/csrc/rocm/ops.h
@@ -2,8 +2,8 @@
 
 #include <torch/all.h>
 
-torch::Tensor LLMM1(at::Tensor& in_a, at::Tensor& in_b,
-                    const int64_t rows_per_block);
+torch::Tensor vecMatMul(at::Tensor& mat, at::Tensor& vec,
+                        const int64_t rows_per_block);
 
 torch::Tensor wvSplitK(const at::Tensor& in_a, const at::Tensor& in_b,
                        const std::optional<at::Tensor>& in_bias,

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -330,11 +330,17 @@ torch::Tensor vecMatMul(at::Tensor& mat, at::Tensor& vec,
   TORCH_CHECK(mat.dtype() == vec.dtype());
   TORCH_CHECK(vec.dtype() == torch::kFloat16 ||
               vec.dtype() == torch::kBFloat16);
-  TORCH_CHECK(rows_per_block <= WARP_SIZE,
-              "rows_per_block must not exceed WARP_SIZE (", WARP_SIZE, ").");
+  TORCH_CHECK(rows_per_block == 2 || rows_per_block == 4 ||
+                  rows_per_block == 8 || rows_per_block == 16,
+              "rows_per_block must be 2, 4, 8, or 16.");
 
   auto M = mat.size(0);
   auto K = mat.size(1);
+
+  TORCH_CHECK(M % rows_per_block == 0, "M (", M,
+              ") must be a multiple of rows_per_block (", rows_per_block, ").");
+  TORCH_CHECK(K % 8 == 0, "K (", K, ") must be a multiple of 8.");
+  TORCH_CHECK(K <= 8192, "K (", K, ") must not exceed 8192.");
 
   auto out = torch::empty(
       {1, M}, torch::TensorOptions().dtype(vec.dtype()).device(vec.device()));
@@ -376,9 +382,7 @@ torch::Tensor vecMatMul(at::Tensor& mat, at::Tensor& vec,
             mat_ptr, vec_ptr, out_ptr, K);
         break;
       default:
-        NUM_BLOCKS = M / 4;
-        vecMatMul_kernel<scalar_t, 4><<<NUM_BLOCKS, NUM_THREADS, 0, stream>>>(
-            mat_ptr, vec_ptr, out_ptr, K);
+        TORCH_CHECK(false, "Unsupported rows_per_block: ", rows_per_block);
         break;
     }
   });

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -160,151 +160,230 @@ __device__ __forceinline__ float4 load_ntmprl(const float4* addr) {
   return make_float4(dat0, dat1, dat2, dat3);
 }
 
-// TBlock fetches entire rows of A, and entire col of B (K dimension); assume
-// N=1 for time being grid is M/A_NUM_ROWS blocks
-template <typename scalar_t, int NUM_A_ROWS_PER_BLOCK>
-__global__ void LLGemm1_kernel(const scalar_t* in_a, const scalar_t* in_b,
-                               scalar_t* out_c, const int K) {
-  using scalar2_t = typename scalar2<scalar_t>::type;
-  auto af4 = reinterpret_cast<const float4*>(in_a);
-  auto bf4 = reinterpret_cast<const scalar2_t*>(in_b);
-  auto c = reinterpret_cast<scalar2_t*>(out_c);
-  __shared__ float red_smem[NUM_A_ROWS_PER_BLOCK][WARP_SIZE];
-  const int row_addr = blockIdx.x * NUM_A_ROWS_PER_BLOCK * K / 8;
-  const int threadid = threadIdx.x;
-  const int warp = threadIdx.x / WARP_SIZE;
-  const int lane = threadIdx.x % WARP_SIZE;
-  const int num_warps = blockDim.x / WARP_SIZE;
-  const int qwarpid = threadid / 16;
-  const int qthreadid = threadid % 16;
-  float4 rowA_elem4[NUM_A_ROWS_PER_BLOCK];
-  scalar2_t colB_elem4x, colB_elem4y, colB_elem4z, colB_elem4w;
-  float acc[NUM_A_ROWS_PER_BLOCK];
-  scalar2_t acch2;
-  scalar2_t oval;
-
-  // As we later use warp shuffle operations, we may have more threads in the
-  // block than the actual available data, hence the if guard here.
-  if (threadid * 8 < K) {
+template <typename scalar_t, typename scalar2_t, int ROWS_PER_BLOCK>
+__device__ __forceinline__ void load_tile(
+    const float4* mat_f4, const scalar2_t* vec_h2, int thread_id,
+    int block_base_addr, int K, float4 mat_chunk[ROWS_PER_BLOCK],
+    scalar2_t& vec_h2x, scalar2_t& vec_h2y, scalar2_t& vec_h2z,
+    scalar2_t& vec_h2w) {
+  constexpr int ELEMS_PER_FLOAT4 = sizeof(float4) / sizeof(scalar_t);
+  constexpr int PAIRS_PER_FLOAT4 = sizeof(float4) / sizeof(scalar2_t);
+  if (thread_id * ELEMS_PER_FLOAT4 < K) {
 #pragma unroll
-    for (int i = 0; i < NUM_A_ROWS_PER_BLOCK; i++) {
-      // rowA_elem4[i] holds 8 * half numbers seen as a single float4.
-      rowA_elem4[i] = load_ntmprl(&af4[row_addr + threadid + K / 8 * i]);
+    for (int i = 0; i < ROWS_PER_BLOCK; i++) {
+      // block_base_addr: first float4 of row 0 for this block
+      // thread_id: this thread's column chunk within a row
+      // K / ELEMS_PER_FLOAT4 * i: row stride to row i
+      mat_chunk[i] = load_ntmprl(
+          &mat_f4[block_base_addr + thread_id + K / ELEMS_PER_FLOAT4 * i]);
     }
-    colB_elem4x = bf4[threadid * 4 + 0];
-    colB_elem4y = bf4[threadid * 4 + 1];
-    colB_elem4z = bf4[threadid * 4 + 2];
-    colB_elem4w = bf4[threadid * 4 + 3];
+    vec_h2x = vec_h2[thread_id * PAIRS_PER_FLOAT4 + 0];
+    vec_h2y = vec_h2[thread_id * PAIRS_PER_FLOAT4 + 1];
+    vec_h2z = vec_h2[thread_id * PAIRS_PER_FLOAT4 + 2];
+    vec_h2w = vec_h2[thread_id * PAIRS_PER_FLOAT4 + 3];
   }
+}
 
-  scalar2_t Af2;
-  float2 S;
+template <typename scalar2_t>
+__device__ __forceinline__ float dot_row(scalar2_t* mat_row_ptr,
+                                         scalar2_t vec_h2x, scalar2_t vec_h2y,
+                                         scalar2_t vec_h2z, scalar2_t vec_h2w) {
+  scalar2_t acc_h2 = __hmul2(*mat_row_ptr, vec_h2x);
+  acc_h2 = __hfma2(*(mat_row_ptr + 1), vec_h2y, acc_h2);
+  acc_h2 = __hfma2(*(mat_row_ptr + 2), vec_h2z, acc_h2);
+  acc_h2 = __hfma2(*(mat_row_ptr + 3), vec_h2w, acc_h2);
+  float2 sum = __s22float2(acc_h2);
+  return sum.x + sum.y;
+}
 
-  auto Ah2ptr = reinterpret_cast<scalar2_t*>(&rowA_elem4);
-  scalar2_t* ah2lptr;
-
-#pragma unroll
-  for (int i = 0; i < NUM_A_ROWS_PER_BLOCK; i++) {
-    // Multiply-add on 8 scalar_t.
-    ah2lptr = Ah2ptr + i * 4;
-    Af2 = *(ah2lptr);
-    acch2 = __hmul2(Af2, colB_elem4x);
-    Af2 = *(ah2lptr + 1);
-    acch2 = __hfma2(Af2, colB_elem4y, acch2);
-    Af2 = *(ah2lptr + 2);
-    acch2 = __hfma2(Af2, colB_elem4z, acch2);
-    Af2 = *(ah2lptr + 3);
-    acch2 = __hfma2(Af2, colB_elem4w, acch2);
-    S = __s22float2(acch2);
-
-    // See comment above concerning the if guard.
-    acc[i] = (threadid * 8 < K ? S.x + S.y : 0.f);
-  }
-
-// all reduce across warp.
+template <int ROWS_PER_BLOCK>
+__device__ __forceinline__ void warp_reduce(float acc[ROWS_PER_BLOCK]) {
 #pragma unroll
   for (int mask = WARP_SIZE / 2; mask >= 1; mask /= 2) {
 #pragma unroll
-    for (int i = 0; i < NUM_A_ROWS_PER_BLOCK; i++) {
+    for (int i = 0; i < ROWS_PER_BLOCK; i++) {
       acc[i] += __shfl_xor(acc[i], mask);
-    }
-  }
-
-  // Warp leaders store the data to shared memory.
-  if (lane < NUM_A_ROWS_PER_BLOCK) {
-    red_smem[lane][warp] = acc[lane];
-  }
-
-  // Make sure the data is in shared memory.
-  __syncthreads();
-
-  if (qwarpid < NUM_A_ROWS_PER_BLOCK) {
-    acc[qwarpid] = qthreadid < num_warps ? red_smem[qwarpid][qthreadid] : 0.f;
-#pragma unroll
-    for (int mask = 16 / 2; mask >= 1; mask /= 2) {
-      acc[qwarpid] += __shfl_xor(acc[qwarpid], mask);
-    }
-    float oval2 = __shfl_xor(acc[qwarpid], 16);
-
-    if (lane % 32 == 0) {
-      oval = __float22s2_rn<scalar2_t>(make_float2(acc[qwarpid], oval2));
-      c[blockIdx.x * NUM_A_ROWS_PER_BLOCK / 2 + qwarpid / 2] = oval;
     }
   }
 }
 
-torch::Tensor LLMM1(at::Tensor& in_a, at::Tensor& in_b,
-                    const int64_t rows_per_block) {
-  auto M = in_a.size(0);
-  auto K = in_a.size(1);
-  auto N = in_b.size(0);
+// Computes mat (M x K) * vec (1 x K) -> out (1 x M): one dot product per row of
+// mat. Grid: (M / ROWS_PER_BLOCK) blocks; each block owns ROWS_PER_BLOCK
+// consecutive rows.
+//
+// Four stages:
+//   Stage 1 — partial dot products: each thread loads one float4 per row
+//   (ROWS_PER_BLOCK rows
+//             total) from mat and one float4 from vec, accumulating partial dot
+//             products into acc[].
+//   Stage 2 — intra-warp butterfly: warp_reduce gives all lanes the same acc[];
+//   lanes
+//             0..ROWS_PER_BLOCK-1 each write their row's partial sum to smem in
+//             parallel.
+//   Stage 3 — cross-warp reduction: ROWS_PER_BLOCK row groups each stride smem
+//   columns
+//             (one per warp) then butterfly-reduce so all threads in the group
+//             hold the same scalar for that row.
+//   Stage 4 — output write: adjacent row groups exchange scalars via shfl_xor;
+//   the group
+//             leader packs the pair into a half2 and writes to out.
+template <typename scalar_t, int ROWS_PER_BLOCK>
+__global__ void vecMatMul_kernel(const scalar_t* mat, const scalar_t* vec,
+                                 scalar_t* out, const int K) {
+  using scalar2_t = typename scalar2<scalar_t>::type;
+  // Packing constants: data is stored as packed halves loaded via float4.
+  constexpr int ELEMS_PER_FLOAT4 =
+      sizeof(float4) / sizeof(scalar_t);  // 8 halves per float4
+  constexpr int PAIRS_PER_FLOAT4 =
+      sizeof(float4) / sizeof(scalar2_t);  // 4 half2 pairs per float4
+  // Threads per row group: one group per output row in the second-stage
+  // reduction.
+  constexpr int THREADS_PER_ROW_GROUP = WARP_SIZE / ROWS_PER_BLOCK;
+  auto mat_f4 = reinterpret_cast<const float4*>(mat);
+  auto vec_h2 = reinterpret_cast<const scalar2_t*>(vec);
+  auto out_h2 = reinterpret_cast<scalar2_t*>(out);
+  __shared__ float reduction_smem[ROWS_PER_BLOCK][WARP_SIZE];
+  // Base offset into mat_f4 for the first float4 of the first row this block
+  // owns.
+  const int block_base_addr =
+      blockIdx.x * ROWS_PER_BLOCK * K / ELEMS_PER_FLOAT4;
+  const int thread_id = threadIdx.x;
+  const int warp_id = thread_id / WARP_SIZE;
+  const int lane = thread_id % WARP_SIZE;
+  // Which output row group this thread belongs to (shared by all threads in the
+  // group).
+  const int row_group_id = thread_id / THREADS_PER_ROW_GROUP;
+  // This thread's position within its row group; determines which smem columns
+  // it reads.
+  const int row_group_thread_id = thread_id % THREADS_PER_ROW_GROUP;
+  scalar2_t vec_h2x, vec_h2y, vec_h2z, vec_h2w;
+  float acc[ROWS_PER_BLOCK];
+  float4 mat_chunk[ROWS_PER_BLOCK];
+  scalar2_t out_val;
 
-  TORCH_CHECK(N == 1, "Row number of activation tensor must be 1.");
-  TORCH_CHECK(in_a.dtype() == in_b.dtype());
-  TORCH_CHECK(in_b.dtype() == torch::kFloat16 ||
-              in_b.dtype() == torch::kBFloat16);
+  // Stage 1: each thread loads one float4 per row (ROWS_PER_BLOCK rows total)
+  // from mat and one float4 from vec, then computes a partial dot product per
+  // row into acc[].
+  //
+  // Threads beyond K/8 diverge in load_tile's if guard (skipping the load) and
+  // are zeroed by the ternary below; their dot_row result is discarded.
+  load_tile<scalar_t, scalar2_t, ROWS_PER_BLOCK>(
+      mat_f4, vec_h2, thread_id, block_base_addr, K, mat_chunk, vec_h2x,
+      vec_h2y, vec_h2z, vec_h2w);
 
-  auto out_c = torch::empty(
-      {N, M}, torch::TensorOptions().dtype(in_b.dtype()).device(in_b.device()));
+  auto mat_h2_ptr = reinterpret_cast<scalar2_t*>(&mat_chunk);
 
-  // NUM_TREADS need to be a multiple of WARP_SIZE, as we are using warp shuffle
-  // operations.
+#pragma unroll
+  for (int i = 0; i < ROWS_PER_BLOCK; i++) {
+    float val = dot_row(mat_h2_ptr + i * PAIRS_PER_FLOAT4, vec_h2x, vec_h2y,
+                        vec_h2z, vec_h2w);
+    acc[i] = (thread_id * ELEMS_PER_FLOAT4 < K ? val : 0.f);
+  }
+
+  // Stage 2: intra-warp butterfly — reduces each acc[i] across all lanes in the
+  // warp.
+  warp_reduce<ROWS_PER_BLOCK>(acc);
+
+  // All lanes hold the same acc[] after the butterfly; lanes
+  // 0..ROWS_PER_BLOCK-1 each write their row's partial sum to smem in parallel
+  // (lane i writes row i).
+  if (lane < ROWS_PER_BLOCK) {
+    reduction_smem[lane][warp_id] = acc[lane];
+  }
+  __syncthreads();
+
+  // Stage 3: cross-warp reduction.
+  // Threads are divided into ROWS_PER_BLOCK row groups of THREADS_PER_ROW_GROUP
+  // threads. Each group strides smem columns (one per warp) accumulating
+  // partial sums for its row, then butterfly-reduces within the group so all
+  // threads hold the same scalar. Striding handles the case where num_warps >
+  // THREADS_PER_ROW_GROUP (e.g. large K on WARP_SIZE=32 GPUs).
+  const int num_warps = blockDim.x / WARP_SIZE;
+  if (row_group_id < ROWS_PER_BLOCK) {
+    float partial = 0.f;
+    for (int w = row_group_thread_id; w < num_warps;
+         w += THREADS_PER_ROW_GROUP) {
+      partial += reduction_smem[row_group_id][w];
+    }
+#pragma unroll
+    for (int mask = THREADS_PER_ROW_GROUP / 2; mask >= 1; mask /= 2) {
+      partial += __shfl_xor(partial, mask);
+    }
+
+    // Stage 4: adjacent row groups (row i, row i+1) exchange their scalars so
+    // the group leader can pack both into a single half2 write.
+    float out_val2 = __shfl_xor(partial, THREADS_PER_ROW_GROUP);
+    if (lane % (2 * THREADS_PER_ROW_GROUP) == 0) {
+      out_val = __float22s2_rn<scalar2_t>(make_float2(partial, out_val2));
+      out_h2[blockIdx.x * ROWS_PER_BLOCK / 2 + row_group_id / 2] = out_val;
+    }
+  }
+}
+
+// Computes mat (M x K) * vec (1 x K) -> out (1 x M): one dot product per row of
+// mat against the single vec vector. Optimized for the N=1 (single token) case.
+torch::Tensor vecMatMul(at::Tensor& mat, at::Tensor& vec,
+                        const int64_t rows_per_block) {
+  TORCH_CHECK(vec.size(0) == 1, "Row number of activation tensor must be 1.");
+  TORCH_CHECK(mat.size(1) == vec.size(1),
+              "K dimension mismatch between mat and vec.");
+  TORCH_CHECK(mat.dtype() == vec.dtype());
+  TORCH_CHECK(vec.dtype() == torch::kFloat16 ||
+              vec.dtype() == torch::kBFloat16);
+  TORCH_CHECK(rows_per_block <= WARP_SIZE,
+              "rows_per_block must not exceed WARP_SIZE (", WARP_SIZE, ").");
+
+  auto M = mat.size(0);
+  auto K = mat.size(1);
+
+  auto out = torch::empty(
+      {1, M}, torch::TensorOptions().dtype(vec.dtype()).device(vec.device()));
+
+  // NUM_THREADS needs to be a multiple of WARP_SIZE, as we are using warp
+  // shuffle operations.
   const int NUM_THREADS =
-      max(rows_per_block * 16,
-          K * 2 / 16 % WARP_SIZE == 0
-              ? K * 2 / 16
-              : K * 2 / 16 + (WARP_SIZE - K * 2 / 16 % WARP_SIZE));
+      max(rows_per_block * (int)sizeof(float4),
+          K * 2 / (int)sizeof(float4) % WARP_SIZE == 0
+              ? K * 2 / (int)sizeof(float4)
+              : K * 2 / (int)sizeof(float4) +
+                    (WARP_SIZE - K * 2 / (int)sizeof(float4) % WARP_SIZE));
 
   int NUM_BLOCKS = M / rows_per_block;
 
-  const at::cuda::OptionalCUDAGuard device_guard(device_of(in_b));
+  const at::cuda::OptionalCUDAGuard device_guard(device_of(vec));
   const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  // call the kernel function...
-  AT_DISPATCH_REDUCED_FLOATING_TYPES(in_b.scalar_type(), "LLGemm1", [&] {
-    auto a_ptr = in_a.data_ptr<scalar_t>();
-    auto b_ptr = in_b.data_ptr<scalar_t>();
-    auto c_ptr = out_c.data_ptr<scalar_t>();
-    if (rows_per_block == 2) {
-      LLGemm1_kernel<scalar_t, 2>
-          <<<NUM_BLOCKS, NUM_THREADS, 0, stream>>>(a_ptr, b_ptr, c_ptr, K);
-    } else if (rows_per_block == 4) {
-      LLGemm1_kernel<scalar_t, 4>
-          <<<NUM_BLOCKS, NUM_THREADS, 0, stream>>>(a_ptr, b_ptr, c_ptr, K);
-    } else if (rows_per_block == 8) {
-      LLGemm1_kernel<scalar_t, 8>
-          <<<NUM_BLOCKS, NUM_THREADS, 0, stream>>>(a_ptr, b_ptr, c_ptr, K);
-    } else if (rows_per_block == 16) {
-      LLGemm1_kernel<scalar_t, 16>
-          <<<NUM_BLOCKS, NUM_THREADS, 0, stream>>>(a_ptr, b_ptr, c_ptr, K);
-    } else {
-      NUM_BLOCKS = M / 4;
-      LLGemm1_kernel<scalar_t, 4>
-          <<<NUM_BLOCKS, NUM_THREADS, 0, stream>>>(a_ptr, b_ptr, c_ptr, K);
+  AT_DISPATCH_REDUCED_FLOATING_TYPES(vec.scalar_type(), "vecMatMul", [&] {
+    auto mat_ptr = mat.data_ptr<scalar_t>();
+    auto vec_ptr = vec.data_ptr<scalar_t>();
+    auto out_ptr = out.data_ptr<scalar_t>();
+
+    switch (rows_per_block) {
+      case 2:
+        vecMatMul_kernel<scalar_t, 2><<<NUM_BLOCKS, NUM_THREADS, 0, stream>>>(
+            mat_ptr, vec_ptr, out_ptr, K);
+        break;
+      case 4:
+        vecMatMul_kernel<scalar_t, 4><<<NUM_BLOCKS, NUM_THREADS, 0, stream>>>(
+            mat_ptr, vec_ptr, out_ptr, K);
+        break;
+      case 8:
+        vecMatMul_kernel<scalar_t, 8><<<NUM_BLOCKS, NUM_THREADS, 0, stream>>>(
+            mat_ptr, vec_ptr, out_ptr, K);
+        break;
+      case 16:
+        vecMatMul_kernel<scalar_t, 16><<<NUM_BLOCKS, NUM_THREADS, 0, stream>>>(
+            mat_ptr, vec_ptr, out_ptr, K);
+        break;
+      default:
+        NUM_BLOCKS = M / 4;
+        vecMatMul_kernel<scalar_t, 4><<<NUM_BLOCKS, NUM_THREADS, 0, stream>>>(
+            mat_ptr, vec_ptr, out_ptr, K);
+        break;
     }
   });
 
-  return out_c;
+  return out;
 }
 
 #if defined(__HIP__GFX9__) && !defined(__HIP__GFX1X__)

--- a/csrc/rocm/skinny_gemms.cu
+++ b/csrc/rocm/skinny_gemms.cu
@@ -242,7 +242,10 @@ __global__ void vecMatMul_kernel(const scalar_t* mat, const scalar_t* vec,
   auto mat_f4 = reinterpret_cast<const float4*>(mat);
   auto vec_h2 = reinterpret_cast<const scalar2_t*>(vec);
   auto out_h2 = reinterpret_cast<scalar2_t*>(out);
-  __shared__ float reduction_smem[ROWS_PER_BLOCK][WARP_SIZE];
+  // [WARP_SIZE][ROWS_PER_BLOCK]: row stride (ROWS_PER_BLOCK × 4 B) does not
+  // align with the 32-bank LDS period, so Stage 2 writes land on distinct
+  // banks.
+  __shared__ float reduction_smem[WARP_SIZE][ROWS_PER_BLOCK];
   // Base offset into mat_f4 for the first float4 of the first row this block
   // owns.
   const int block_base_addr =
@@ -288,7 +291,7 @@ __global__ void vecMatMul_kernel(const scalar_t* mat, const scalar_t* vec,
   // 0..ROWS_PER_BLOCK-1 each write their row's partial sum to smem in parallel
   // (lane i writes row i).
   if (lane < ROWS_PER_BLOCK) {
-    reduction_smem[lane][warp_id] = acc[lane];
+    reduction_smem[warp_id][lane] = acc[lane];
   }
   __syncthreads();
 
@@ -301,9 +304,9 @@ __global__ void vecMatMul_kernel(const scalar_t* mat, const scalar_t* vec,
   const int num_warps = blockDim.x / WARP_SIZE;
   if (row_group_id < ROWS_PER_BLOCK) {
     float partial = 0.f;
-    for (int w = row_group_thread_id; w < num_warps;
-         w += THREADS_PER_ROW_GROUP) {
-      partial += reduction_smem[row_group_id][w];
+    for (int warp_idx = row_group_thread_id; warp_idx < num_warps;
+         warp_idx += THREADS_PER_ROW_GROUP) {
+      partial += reduction_smem[warp_idx][row_group_id];
     }
 #pragma unroll
     for (int mask = THREADS_PER_ROW_GROUP / 2; mask >= 1; mask /= 2) {

--- a/csrc/rocm/torch_bindings.cpp
+++ b/csrc/rocm/torch_bindings.cpp
@@ -16,9 +16,9 @@ TORCH_LIBRARY_EXPAND(TORCH_EXTENSION_NAME, rocm_ops) {
 
   // Custom gemm op for matrix-vector multiplication
   rocm_ops.def(
-      "LLMM1(Tensor in_a, Tensor in_b, int rows_per_block) -> "
+      "vecMatMul(Tensor mat, Tensor vec, int rows_per_block) -> "
       "Tensor");
-  rocm_ops.impl("LLMM1", torch::kCUDA, &LLMM1);
+  rocm_ops.impl("vecMatMul", torch::kCUDA, &vecMatMul);
 
   // Custom gemm op for skinny matrix-matrix multiplication
   rocm_ops.def(

--- a/tests/kernels/quantization/test_rocm_skinny_gemms.py
+++ b/tests/kernels/quantization/test_rocm_skinny_gemms.py
@@ -14,7 +14,7 @@ from vllm.utils.platform_utils import num_compute_units
 DTYPES = [torch.bfloat16, torch.float16]
 BIAS_MODES = [0, 1, 2]
 # Specific (N, K, M) combinations for targeted testing
-NKM_FACTORS_LLMM1 = [
+NKM_FACTORS_VEC_MAT_MUL = [
     # Small, medium, large cases
     (1, 8, 16),
     (1, 32, 64),
@@ -172,24 +172,22 @@ def test_rocm_wvsplitkrc_kernel(xnorm, n, k, m, dtype, seed, padded_a, bias_mode
         torch.testing.assert_close(out, ref_out, atol=1e-3, rtol=1e-2)
 
 
-@pytest.mark.parametrize("n,k,m", NKM_FACTORS_LLMM1)
+@pytest.mark.parametrize("n,k,m", NKM_FACTORS_VEC_MAT_MUL)
 @pytest.mark.parametrize("dtype", DTYPES)
 @pytest.mark.parametrize("rows_per_block", [2, 4, 8, 16])
 @pytest.mark.parametrize("seed", SEEDS)
 @pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
 @torch.inference_mode()
-def test_rocm_llmm1_kernel(n, k, m, dtype, rows_per_block, seed):
+def test_rocm_vec_mat_mul_kernel(n, k, m, dtype, rows_per_block, seed):
     torch.manual_seed(seed)
-    # TODO: Zero-centering the inputs causes errors for LLMM1!
-    #      Without that the numbers quickly saturate, and may
-    #      be giving false matches.
-    A = torch.rand(n, k, dtype=dtype, device="cuda")
-    B = torch.rand(m, k, dtype=dtype, device="cuda")
+    A = torch.randn(n, k, dtype=dtype, device="cuda")
+    B = torch.randn(m, k, dtype=dtype, device="cuda")
 
     ref_out = torch.matmul(A, B.t())
-    out = ops.LLMM1(B, A, rows_per_block)
+    out = ops.vecMatMul(B, A, rows_per_block)
 
-    torch.testing.assert_close(out, ref_out, atol=1e-8, rtol=1e-2)
+    atol = torch.finfo(dtype).eps * math.sqrt(k)
+    torch.testing.assert_close(out, ref_out, atol=atol, rtol=1e-2)
 
 
 @pytest.mark.parametrize("xnorm", [False, True])

--- a/tests/kernels/quantization/test_rocm_skinny_gemms.py
+++ b/tests/kernels/quantization/test_rocm_skinny_gemms.py
@@ -190,6 +190,78 @@ def test_rocm_vec_mat_mul_kernel(n, k, m, dtype, rows_per_block, seed):
     torch.testing.assert_close(out, ref_out, atol=atol, rtol=1e-2)
 
 
+@pytest.mark.parametrize("rows_per_block", [4, 8, 16])
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
+@torch.inference_mode()
+def test_rocm_vec_mat_mul_rdna4_row_write_regression(rows_per_block, dtype):
+    # Regression for RDNA4 (WARP_SIZE=32): output rows 2+ were silently skipped.
+    # The pre-fix kernel used `lane % 32 == 0` to select the group leader thread
+    # for each packed half2 write. THREADS_PER_ROW_GROUP is WARP_SIZE/ROWS_PER_BLOCK,
+    # so on WARP_SIZE=32 with rows_per_block=4 it is 8, and the second pair's leader
+    # sits at lane 16, which fails `lane % 32 == 0` and never writes.
+    # Fix: `lane % (2 * THREADS_PER_ROW_GROUP)`.
+    # Requires rows_per_block >= 4 to have a second pair; rows_per_block=2 is
+    # unaffected. On CDNA (WARP_SIZE=64), lane % 32 == 0 is correct either way.
+    torch.manual_seed(0)
+    m = rows_per_block * 4  # multiple blocks, all row slots exercised
+    k = 128  # small K to isolate from the cross-warp reduction bug
+    A = torch.randn(1, k, dtype=dtype, device="cuda")
+    B = torch.randn(m, k, dtype=dtype, device="cuda")
+
+    ref_out = torch.matmul(A, B.t())
+    out = ops.vecMatMul(B, A, rows_per_block)
+
+    atol = torch.finfo(dtype).eps * math.sqrt(k)
+    torch.testing.assert_close(out, ref_out, atol=atol, rtol=1e-2)
+
+
+@pytest.mark.parametrize("k", [4096, 8192])
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
+@torch.inference_mode()
+def test_rocm_vec_mat_mul_rdna4_reduction_regression(k, dtype):
+    # Regression for RDNA4 (WARP_SIZE=32): cross-warp reduction silently dropped
+    # partial sums when num_warps > THREADS_PER_ROW_GROUP. On WARP_SIZE=32 with
+    # rows_per_block=2, THREADS_PER_ROW_GROUP=16, and num_warps exceeds 16 when
+    # K > 4096. The pre-fix loop only accumulated warps 0..THREADS_PER_ROW_GROUP-1,
+    # losing contributions from warps 16+ and producing results that are too small.
+    # Fix: stride the loop by THREADS_PER_ROW_GROUP across all num_warps. On CDNA
+    # (WARP_SIZE=64), THREADS_PER_ROW_GROUP=32 and the test K values don't exceed
+    # the threshold.
+    torch.manual_seed(0)
+    rows_per_block = (
+        2  # isolate from the row-write bug (which needs rows_per_block >= 4)
+    )
+    m = rows_per_block * 4
+    A = torch.randn(1, k, dtype=dtype, device="cuda")
+    B = torch.randn(m, k, dtype=dtype, device="cuda")
+
+    ref_out = torch.matmul(A, B.t())
+    out = ops.vecMatMul(B, A, rows_per_block)
+
+    atol = torch.finfo(dtype).eps * math.sqrt(k)
+    torch.testing.assert_close(out, ref_out, atol=atol, rtol=1e-2)
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
+@torch.inference_mode()
+def test_rocm_vec_mat_mul_checks_n_equals_1():
+    A = torch.rand(2, 64, dtype=torch.float16, device="cuda")
+    B = torch.rand(128, 64, dtype=torch.float16, device="cuda")
+    with pytest.raises(RuntimeError, match="Row number of activation tensor must be 1"):
+        ops.vecMatMul(B, A, 4)
+
+
+@pytest.mark.skipif(not current_platform.is_rocm(), reason="only test for rocm")
+@torch.inference_mode()
+def test_rocm_vec_mat_mul_checks_k_mismatch():
+    A = torch.rand(1, 64, dtype=torch.float16, device="cuda")
+    B = torch.rand(128, 32, dtype=torch.float16, device="cuda")
+    with pytest.raises(RuntimeError, match="K dimension mismatch"):
+        ops.vecMatMul(B, A, 4)
+
+
 @pytest.mark.parametrize("xnorm", [False, True])
 @pytest.mark.parametrize("n,k,m", NKM_FACTORS_WVSPLITK)
 @pytest.mark.parametrize("dtype", DTYPES)

--- a/tests/model_executor/layers/test_rocm_unquantized_gemm.py
+++ b/tests/model_executor/layers/test_rocm_unquantized_gemm.py
@@ -31,7 +31,7 @@ def test_rocm_unquantized_gemm_gfx1x_wvsplitk_path(monkeypatch):
     wvsplitk_mock = MagicMock(side_effect=lambda w, x_view, _, __: x_view @ w.t())
     monkeypatch.setattr(utils.ops, "wvSplitK", wvsplitk_mock)
     llmm1_mock = MagicMock(side_effect=lambda w, x_view, _: x_view @ w.t())
-    monkeypatch.setattr(utils.ops, "LLMM1", llmm1_mock)
+    monkeypatch.setattr(utils.ops, "vecMatMul", llmm1_mock)
 
     out = utils.rocm_unquantized_gemm_impl(x, weight, None)
     ref = torch.nn.functional.linear(x, weight, None)
@@ -55,7 +55,7 @@ def test_rocm_unquantized_gemm_gfx1x_n_gt_4_falls_back(monkeypatch):
     wvsplitk_mock = MagicMock(side_effect=lambda w, x_view, _, __: x_view @ w.t())
     monkeypatch.setattr(utils.ops, "wvSplitK", wvsplitk_mock)
     llmm1_mock = MagicMock(side_effect=lambda w, x_view, _: x_view @ w.t())
-    monkeypatch.setattr(utils.ops, "LLMM1", llmm1_mock)
+    monkeypatch.setattr(utils.ops, "vecMatMul", llmm1_mock)
 
     out = utils.rocm_unquantized_gemm_impl(x, weight, None)
     ref = torch.nn.functional.linear(x, weight, None)

--- a/vllm/_custom_ops.py
+++ b/vllm/_custom_ops.py
@@ -2306,8 +2306,10 @@ def selective_scan_fwd(
 
 
 # ROCm skinny gemms
-def LLMM1(a: torch.Tensor, b: torch.Tensor, rows_per_block: int) -> torch.Tensor:
-    return torch.ops._rocm_C.LLMM1(a, b, rows_per_block)
+def vecMatMul(
+    mat: torch.Tensor, vec: torch.Tensor, rows_per_block: int
+) -> torch.Tensor:
+    return torch.ops._rocm_C.vecMatMul(mat, vec, rows_per_block)
 
 
 def wvSplitK(

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -182,7 +182,7 @@ def rocm_unquantized_gemm_impl(
             out = ops.wvSplitK(weight, x_view, cu_count, bias)
             return out.reshape(*x.shape[:-1], weight.shape[0])
         elif m % 4 == 0 and n == 1 and k <= 8192 and bias is None:
-            out = ops.LLMM1(weight, x_view, 4)
+            out = ops.vecMatMul(weight, x_view, 4)
             return out.reshape(*x.shape[:-1], weight.shape[0])
 
     if rocm_aiter_ops.is_tgemm_enabled():


### PR DESCRIPTION
> **Note:** This PR stacks on #40827 (`wjabbour:rocm/vecmatmul-rename-and-rdna4-fixes`) and should be reviewed/merged after it. The diff shown against `main` includes those commits; the net change from this PR alone is the three-line smem layout fix below.

## Purpose

`vecMatMul_kernel` declares its cross-warp reduction buffer as:

```c
__shared__ float reduction_smem[ROWS_PER_BLOCK][WARP_SIZE];
```

With `WARP_SIZE = 32`, the row stride is 32 floats × 4 B = 128 B, which equals the 32-bank LDS period exactly. As a result, `reduction_smem[0][warp_id]`, `reduction_smem[1][warp_id]`, ..., `reduction_smem[ROWS_PER_BLOCK-1][warp_id]` all map to the same bank. The Stage 2 write — where lanes `0..ROWS_PER_BLOCK-1` each write their row's partial sum — is therefore a `ROWS_PER_BLOCK`-way bank conflict, serialising those writes.

This PR transposes the layout to `[WARP_SIZE][ROWS_PER_BLOCK]`. The row stride is now `ROWS_PER_BLOCK × 4 B`, which does not align with the bank period, so each lane's write lands on a distinct bank.

No performance improvement is claimed — the bank conflict affects only `ROWS_PER_BLOCK` writes per warp per block and is unlikely to be the bottleneck. This is a correctness-of-memory-access-pattern fix.

## Changes

- `reduction_smem[ROWS_PER_BLOCK][WARP_SIZE]` → `reduction_smem[WARP_SIZE][ROWS_PER_BLOCK]`
- Write: `reduction_smem[lane][warp_id]` → `reduction_smem[warp_id][lane]`
- Read: `reduction_smem[row_group_id][w]` → `reduction_smem[warp_idx][row_group_id]` (also renamed loop variable `w` → `warp_idx`)

## Why this is not a duplicate

Checked open PRs against `vllm-project/vllm` — no existing PR addresses this.

## Test Plan

```
.venv/bin/python -m pytest tests/kernels/quantization/test_rocm_skinny_gemms.py -v
```

## Test Result

All tests passed on gfx1201 (RDNA4 / Radeon 9070XT).

> AI assistance was used in identifying and implementing this fix.