### PR TITLE
fix: convert LogprobsLists to lists for cross node Ray transport (#38602)

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -55,7 +55,12 @@ from vllm.v1.engine import EngineCoreEventType, EngineCoreOutput, EngineCoreOutp
 from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheConfig
 from vllm.v1.metrics.perf import ModelMetrics, PerfStats
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
-from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
+from vllm.v1.outputs import (
+    DraftTokenIds,
+    KVConnectorOutput,
+    LogprobsLists,
+    ModelRunnerOutput,
+)
 from vllm.v1.request import Request, RequestStatus, StreamingUpdate
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.structured_output import StructuredOutputManager
@@ -1307,6 +1312,20 @@ class Scheduler(SchedulerInterface):
     ) -> dict[int, EngineCoreOutputs]:
         sampled_token_ids = model_runner_output.sampled_token_ids
         logprobs = model_runner_output.logprobs
+        # FIX (vllm-project/vllm#38602): Multi-node Ray compiled-DAG channel
+        # cannot transmit numpy ndarrays inside LogprobsLists, so the worker
+        # serialized them as Python lists before crossing the channel. The
+        # downstream msgspec schema for EngineCoreOutput.new_logprobs requires
+        # ndarrays, so reconstruct them here on the driver side.
+        if logprobs is not None and not isinstance(
+            logprobs.logprob_token_ids, np.ndarray
+        ):
+            logprobs = LogprobsLists(
+                np.asarray(logprobs.logprob_token_ids, dtype=np.int32),
+                np.asarray(logprobs.logprobs, dtype=np.float32),
+                np.asarray(logprobs.sampled_token_ranks, dtype=np.int32),
+                logprobs.cu_num_generated_tokens,
+            )
         prompt_logprobs_dict = model_runner_output.prompt_logprobs_dict
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
         pooler_outputs = model_runner_output.pooler_output

--- a/vllm/v1/outputs.py
+++ b/vllm/v1/outputs.py
@@ -59,10 +59,14 @@ class LogprobsTensors(NamedTuple):
     cu_num_generated_tokens: list[int] | None = None
 
     def tolists(self, cu_num_generated_tokens: list[int] | None = None):
+        # FIX: Convert to plain Python lists (not numpy ndarrays) to avoid
+        # Ray compiled-DAG cross-node serialization hang
+        # (vllm-project/vllm#38602). The Ray channel chokes on ndarrays
+        # nested in NamedTuples cross-node.
         return LogprobsLists(
-            self.logprob_token_ids.cpu().numpy(),
-            self.logprobs.cpu().numpy(),
-            self.selected_token_ranks.cpu().numpy(),
+            self.logprob_token_ids.cpu().tolist(),
+            self.logprobs.cpu().tolist(),
+            self.selected_token_ranks.cpu().tolist(),
             cu_num_generated_tokens
             if cu_num_generated_tokens is not None
             else self.cu_num_generated_tokens,


### PR DESCRIPTION
Closes #38602.

## What's broken

Production deployment of GLM 5.1 FP8 on TP=8 + PP=2 across two nodes hangs deterministically the moment any request includes `logprobs:true`. The same prompt without logprobs returns in seconds. GPUs sit at 0% for the entire duration of the hang. No traceback is ever logged, no NCCL warning, no kernel event. After roughly 900 seconds the engine finally crashes with `ray.exceptions.RayChannelTimeoutError` on the cross node compiled DAG return channel and the deployment goes unhealthy.

This reproduces with `distributed_executor_backend=ray` and the V1 engine on any two node Ray cluster where the model has TP > 1 and PP > 1. Any client that sets logprobs (LangChain probability aware chains, eval harnesses, RAG re rankers, agentic frameworks doing token level confidence scoring) silently bricks the deployment.

## Where the hang is

I traced this with line level instrumentation along the logprobs path:

```
WORKER NODE (8 RayWorkerWrappers, last PP stage):
  M1..M5  sampler.forward fires through gather_logprobs        x 8
  M5a..e  bookkeeping, tolists() returned                      x 8
  M5f..g  _get_prompt_logprobs_dict ok                         x 8
  M5h..k  eplb_step, ModelRunnerOutput constructed, returned   x 8

DRIVER (head, EngineCore):
  M13     FutureWrapper.result: ray.get starting               x 1
  M14     FutureWrapper.result: ray.get returned               x 0   <-- HANG
```

The worker fully constructs and returns `ModelRunnerOutput`. The driver's `ray.get` on the compiled DAG return ref never resolves.

To prove the hang is in transport, not compute, I set `model_runner_output.logprobs = None` after the worker computed it. Result: HTTP 200 in 1.8 seconds, M14 fires. That isolates the wedge to transmission of `LogprobsLists` (a `NamedTuple` containing three numpy ndarrays) across the cross node Ray channel.

Full bisect trace and the nullification experiment are in the issue thread.

## The fix

Two changes, 2 files, 23 insertions and 4 deletions.

`vllm/v1/outputs.py`: `LogprobsTensors.tolists()` now returns plain Python lists rather than numpy ndarrays. The method is named `tolists` so returning lists matches the contract. Lists pickle cleanly across the Ray channel; ndarrays in NamedTuples do not.

`vllm/v1/core/sched/scheduler.py`: `Scheduler.update_from_output` reconstructs ndarrays from the lists right after they cross the Ray channel, because the downstream msgspec schema for `EngineCoreOutput.new_logprobs` validates against ndarrays. The reconstruction is gated on an `isinstance` check so call sites that already pass ndarrays (single node setups that never hit the Ray hop) are untouched.

## Validation

Ran on a live two node H100 cluster (8 GPUs per node, vLLM 0.19.1, Ray 2.55.1, GLM 5.1 FP8, `distributed_executor_backend=ray`):

| Request | Before | After |
|---|---|---|
| Plain max_tokens=16 | 200 in 1.3s | 200 in 0.37s |
| Plain max_tokens=256 | 200 in 3.1s | 200 in 3.1s |
| Logprobs top_logprobs=1, max_tokens=8 | 504 (300s hang) | 200 in 1.55s |
| Logprobs top_logprobs=5, max_tokens=32 | 504 (300s hang) | 200 in 1.77s |
| Logprobs top_logprobs=5, max_tokens=256 | 504 (300s hang) | 200 in 3.35s |
| Logprobs top_logprobs=20, max_tokens=16 | 504 (300s hang) | 200 in 0.38s |
| 4x concurrent logprobs | all 504 | all 200 in ~1.3s |

Response shape on the success cases matches the OpenAI logprobs schema (`token`, `logprob`, `bytes`, `top_logprobs`).

## Things I did not do

I did not add a regression test under `tests/distributed/`. I'm not sure which CI fixture pattern covers two node TP+PP setups, since most distributed tests in this directory run on a single host. Happy to add a test if a maintainer can point me at the right pattern, or leave that for a follow up if `tests/distributed/` does not have a multi node harness today.

I did not run the full vLLM test suite locally. My environment is a production cluster, so I only validated against the bug surface and a small set of regression scenarios. CI will exercise the rest.

I did not change anything in the V0 engine path or the async scheduling path beyond what naturally flows through the same `update_from_output` reconstruction.

## Duplicate work check

Per `AGENTS.md` I checked open issues and PRs first:

- #36237 (Generation hangs until `RAY_CGRAPH_get_timeout`): same crash class, different surface (TP only). The `RAY_CGRAPH_buffer_size_bytes` workaround suggested in that thread does not fix this case. I tested it before going further.
- #29373, #37001: related multi node Ray crashes, different code paths.
- #38602: the issue this closes. Bisect data and the experiment that confirms transport vs compute are in the comments.
- No open PRs touching `tolists()` or `Scheduler.update_from_output` overlap with this change.

The strategic fix is the RayExecutorV2 migration tracked in #35848 (cc @kouroshHakha @jeffreywang-anyscale). I cannot use V2 on my model class today because of a separate `deepseek_v2.py` loader regression in 0.20.0 against GLM 5.1 FP8 (KeyError on `model.layers.0.self_attn.indexer.wk_weights_proj.weight`). This PR is interim relief for users still on the Compiled DAG path while V2 stabilizes.

## Open question for reviewers

The proximate cause is on the Ray side: compiled DAG channels can't transmit ndarrays inside a `NamedTuple` cross node. I worked around it at the vLLM layer (lists across the channel, reconstruct on the driver side). A cleaner fix might be at the Ray channel layer or by registering a custom `LogprobsLists` serializer. Happy to take direction on which layer the upstream fix should target.

## Disclosure

I used Claude as an assistant during the investigation and the patch drafting. I reviewed every changed line and tested the result on the cluster myself. The `Co-authored-by` trailer is in the commit.
