### PR TITLE
[Config] Auto-upgrade compilation mode when cudagraph_mode requires VLLM_COMPILE

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -942,6 +942,27 @@ class VllmConfig:
             else:
                 self.compilation_config.mode = CompilationMode.NONE
 
+        # If the user explicitly set a cudagraph_mode that requires piecewise
+        # compilation but a lower compilation mode, upgrade `mode` to
+        # VLLM_COMPILE rather than silently turning the cudagraph off.
+        # Only honoured when the user explicitly set cudagraph_mode (not None);
+        # default values come from the optimization level and are still subject
+        # to the platform-side fallbacks in `resolve_cudagraph_mode_and_sizes`.
+        if (
+            self.compilation_config.cudagraph_mode is not None
+            and self.compilation_config.cudagraph_mode
+                .requires_piecewise_compilation()
+            and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
+        ):
+            logger.warning(
+                "cudagraph_mode=%s requires CompilationMode.VLLM_COMPILE; "
+                "upgrading from mode=%s. Pass cudagraph_mode=NONE to keep "
+                "the eager mode.",
+                self.compilation_config.cudagraph_mode,
+                self.compilation_config.mode,
+            )
+            self.compilation_config.mode = CompilationMode.VLLM_COMPILE
+
         # By default, enable torch wrapping only when using custom Inductor lowering
         if self.compilation_config.ir_enable_torch_wrap is None:
             self.compilation_config.ir_enable_torch_wrap = (
@@ -970,18 +991,6 @@ class VllmConfig:
                 "KernelConfig.enable_flashinfer_autotune must be set after applying "
                 "optimization level defaults."
             )
-
-        if (
-            self.compilation_config.cudagraph_mode.requires_piecewise_compilation()
-            and self.compilation_config.mode != CompilationMode.VLLM_COMPILE
-        ):
-            logger.info(
-                "Cudagraph mode %s is not compatible with compilation mode %s."
-                "Overriding to NONE.",
-                self.compilation_config.cudagraph_mode,
-                self.compilation_config.mode,
-            )
-            self.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
 
         # async tp is built on top of sequence parallelism and requires it.
         pass_config = self.compilation_config.pass_config


### PR DESCRIPTION
## What

When a user explicitly sets `cudagraph_mode=PIECEWISE` (or `FULL_AND_PIECEWISE`) together with `mode=NONE`, vLLM currently silently disables CUDA graphs (INFO log) and the explicit graph setting is lost. This PR upgrades `mode` to `VLLM_COMPILE` instead — but only when the user **explicitly** set `cudagraph_mode`. Default values from the optimization level are unchanged.

Also fixes a string-concat typo in the original log message (`"...mode 0.Overriding..."`).

## Behaviour

| `mode` | `cudagraph_mode` | before | after |
|---|---|---|---|
| NONE | PIECEWISE / FULL_AND_PIECEWISE (explicit) | cudagraph silently → NONE | mode → VLLM_COMPILE, cudagraph kept |
| NONE | None (uses O-level default) | unchanged | unchanged |
| NONE | NONE | unchanged | unchanged |
| VLLM_COMPILE | * | unchanged | unchanged |

## Why now

The `mode=0 + cudagraph_mode=PIECEWISE` combination is in circulation as a workaround for an older inductor crash (since fixed by #41135), so users hit this silent regression.

## Numbers (DeepSeek-V4-Flash-FP8, TP=4, 4×H20, greedy decode)

| scenario | conc | mode=0 (silent NONE) | mode=3 + FULL_AND_PIECEWISE | speedup |
|---|---|---|---|---|
| 1024 in / 1024 out | 1 | 10.3 | 69.6 | 6.8× |
| 1024 in / 1024 out | 8 | 84.6 | 525.5 | 6.2× |
| 1024 in / 1024 out | 64 | 581 | 1538 | 2.6× |
| 16k in / 128 out | 1 | 9.0 | 31.6 | 3.5× |
| 16k in / 128 out | 8 | 40.0 | 46.3 | 1.16× |

Speedup tapers as prefill (compute-bound, not in graph) takes a larger share, as expected.

## Acc check

30-question MATH/factual mini-suite, greedy + identical seeds: BASE vs PATCH is **30/30 string-identical**.
