### PR TITLE
[Bugfix]: synchronize CUDA streams after model warmup to prevent kernel overlap

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -687,6 +687,8 @@ class Worker(WorkerBase):
             else:
                 self.model_runner._dummy_sampler_run(hidden_states=last_hidden_states)
 
+        torch.accelerator.synchronize()
+
         # Reset the seed to ensure that the random state is not affected by
         # the model initialization and profiling.
         set_random_seed(self.model_config.seed)


### PR DESCRIPTION
Fix a hang during elastic EP scale-down with CUDA graphs enabled and in-flight requests.

During elastic reconfiguration, `compile_or_warm_up_model()` launches GPU work on the worker's
execution stream. However, inference is executed via the Ray compiled DAG on a separate CUDA
stream within the same process.

Without an explicit synchronization point at the end of warmup, kernels from the warmup phase
may still be in-flight when the first post-reconfiguration inference step begins on the DAG
stream. This results in concurrent execution over shared device-global state.

For backends like NIXL-EP, which rely on cooperative kernels and persistent device-side buffers,
this overlap violates execution assumptions and leads to state corruption and deadlocks.

Add `torch.accelerator.synchronize()` at the end of `compile_or_warm_up_model()` to enforce
completion of all warmup GPU work before any subsequent execution on a different stream. This
guarantees a clean and consistent device state prior to inference.