### PR TITLE
Enable DBO with elastic EP on NIXL EP

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1451,12 +1451,15 @@ class VllmConfig:
             assert a2a_backend in [
                 "deepep_low_latency",
                 "deepep_high_throughput",
+                "nixl_ep",
             ], (
-                "Microbatching currently only supports the deepep_low_latency and "
-                f"deepep_high_throughput all2all backend. {a2a_backend} is not "
-                "supported. To fix use --all2all-backend=deepep_low_latency or "
-                "--all2all-backend=deepep_high_throughput and install the DeepEP"
-                " kernels."
+                "Microbatching currently only supports the deepep_low_latency, "
+                "deepep_high_throughput, and nixl_ep all2all backends. "
+                f"{a2a_backend} is not supported. "
+                "To fix use --all2all-backend=deepep_low_latency, "
+                "--all2all-backend=deepep_high_throughput, or "
+                "--all2all-backend=nixl_ep and install the corresponding backend "
+                "kernels."
             )
 
             if not self.model_config.disable_cascade_attn:

--- a/vllm/distributed/device_communicators/all2all.py
+++ b/vllm/distributed/device_communicators/all2all.py
@@ -373,6 +373,7 @@ class NixlEPAll2AllManager(All2AllManagerBase):
         )
         buffer = Buffer(
             rank=self.rank,
+            disable_ll_nvlink=True,
             tcp_store_group=self.tcp_store_group.store,
         )
         buffer.update_memory_buffers(

--- a/vllm/distributed/elastic_ep/elastic_execute.py
+++ b/vllm/distributed/elastic_ep/elastic_execute.py
@@ -47,6 +47,7 @@ from vllm.utils import is_moe_layer
 from vllm.v1.engine import ReconfigureDistributedRequest, ReconfigureRankType
 from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
 from vllm.v1.worker.workspace import lock_workspace, unlock_workspace
+from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
 
@@ -328,13 +329,22 @@ class ElasticEPScalingExecutor:
             staged_quant_method.moe_kernel.prepare_finalize.on_commit()
         self._staged_moe_quant_methods.clear()
 
+    def _refresh_dbo_graph_pool(self, wrapper: UBatchWrapper) -> None:
+        # DBO captures multi-stream FULL CUDA graphs. After those graphs are
+        # destroyed, reusing the same pool can trip CUDACachingAllocator's
+        # "use_count > 0" assert; start re-capture from a fresh pool.
+        new_pool = current_platform.graph_pool_handle()
+        current_platform.__class__._global_graph_pool = new_pool
+        if wrapper.cudagraph_wrapper is not None:
+            wrapper.cudagraph_wrapper.graph_pool = new_pool
+
     def _release_cuda_graphs(self) -> None:
-        if isinstance(self.worker.model_runner.model, CUDAGraphWrapper):
-            wrapper = self.worker.model_runner.model
+        wrapper = self.worker.model_runner.model
+        if isinstance(wrapper, CUDAGraphWrapper):
             wrapper.concrete_cudagraph_entries = {}
 
-        elif isinstance(self.worker.model_runner.model, UBatchWrapper):
-            raise RuntimeError("DBO is not yet supported in elastic EP")
+        elif isinstance(wrapper, UBatchWrapper):
+            wrapper.clear_graphs()
 
         torch.compiler.reset()
         with set_current_vllm_config(self.worker.vllm_config):
@@ -343,6 +353,9 @@ class ElasticEPScalingExecutor:
         gc.collect()
         torch.accelerator.synchronize()
         torch.accelerator.empty_cache()
+
+        if isinstance(wrapper, UBatchWrapper):
+            self._refresh_dbo_graph_pool(wrapper)
 
     def switch_and_remove(self) -> None:
         self._release_cuda_graphs()

--- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
+++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
@@ -353,6 +353,7 @@ def maybe_make_prepare_finalize(
             max_tokens_per_rank=moe.max_num_tokens,
             num_dispatchers=all2all_manager.world_size,
             use_fp8_dispatch=use_fp8_dispatch,
+            moe_backend=moe.moe_backend,
             global_to_physical=global_to_physical,
             physical_to_global=physical_to_global,
             local_expert_global_ids=local_expert_global_ids,

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/nixl_ep.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/nixl_ep.py
@@ -6,7 +6,6 @@ import nixl_ep
 import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
-from vllm.config import get_current_vllm_config
 from vllm.distributed import get_ep_group
 from vllm.distributed.device_communicators.all2all import NixlEPAll2AllManager
 from vllm.logger import init_logger
@@ -79,6 +78,7 @@ class NixlEPPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         max_tokens_per_rank: int,
         num_dispatchers: int,
         use_fp8_dispatch: bool = False,
+        moe_backend: str = "auto",
         global_to_physical: torch.Tensor | None = None,
         physical_to_global: torch.Tensor | None = None,
         local_expert_global_ids: torch.Tensor | None = None,
@@ -88,6 +88,7 @@ class NixlEPPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         self.buffer = buffer
         self.max_tokens_per_rank = max_tokens_per_rank
         self.use_fp8_dispatch = use_fp8_dispatch
+        self.moe_backend = moe_backend
         # The dispatch function returns a handle that the combine function
         # requires. We store the handle here so it is available to the
         # combine function.
@@ -192,8 +193,7 @@ class NixlEPPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         x = x.view((-1, hidden_dim))
         q_dtype = quant_config.quant_dtype
 
-        moe_backend = get_current_vllm_config().kernel_config.moe_backend
-        if moe_backend == "flashinfer_cutedsl":
+        if self.moe_backend == "flashinfer_cutedsl":
             logger.info_once(
                 "Skip quantization when using FlashInfer CUTEDSL "
                 "(--moe-backend flashinfer_cutedsl) for ModelOptNvFp4FusedMoE."


### PR DESCRIPTION
This PR enables two related configurations:
1. Allow DBO/microbatching with the `nixl_ep` all2all backend.
2. Allow DBO together with elastic EP.

## Test Result
`lm_eval` GSM8K, 5-shot, 256 examples.

Dense model with DBO enabled and `nixl_ep` selected as the all2all backend:

vllm serve Qwen/Qwen2-1.5B-Instruct \
  --trust-remote-code \
  --max-model-len 4096 \
  --max-num-seqs 64 \
  --enable-dbo \
  --dbo-decode-token-threshold 16 \
  --dbo-prefill-token-threshold 256 \
  --all2all-backend nixl_ep

lm_eval \
  --model local-completions \
  --model_args "model=Qwen/Qwen2-1.5B-Instruct,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=64,tokenized_requests=False" \
  --tasks gsm8k \
  --num_fewshot 5 \
  --limit 256

Result:
- flexible-extract/exact_match: 0.5820 ± 0.0309
- strict-match/exact_match: 0.5781 ± 0.0309

MoE model with nixl_ep, elastic EP, and DBO enabled:

vllm serve deepseek-ai/DeepSeek-V2-Lite-Chat \
  --trust-remote-code \
  --max-model-len 4096 \
  --max-num-seqs 64 \
  --data-parallel-size 2 \
  --enable-expert-parallel \
  --enable-elastic-ep \
  --enable-dbo \
  --dbo-decode-token-threshold 16 \
  --dbo-prefill-token-threshold 256 \
  --all2all-backend nixl_ep

lm_eval \
  --model local-completions \
  --model_args "model=deepseek-ai/DeepSeek-V2-Lite-Chat,base_url=http://127.0.0.1:8000/v1/completions,num_concurrent=64,tokenized_requests=False" \
  --tasks gsm8k \
  --num_fewshot 5 \
  --limit 256

Result:
- flexible-extract/exact_match: 0.6562 ± 0.0297
- strict-match/exact_match: 0.6523 ± 0.0298
