### PR TITLE
[CI] De-flake the step failure "Elastic EP Scaling Test"

### DIFF
--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -2005,6 +2005,22 @@ class EngineCoreActorMixin:
         """
         pass
 
+    def wait_for_dag_ready(self):
+        """
+        Build the Ray Compiled-DAG eagerly so it is not built lazily on the
+        first user request. Called by the elastic-EP scale-up driver
+        sequentially across newly spawned actors before run(), to avoid a
+        Ray MutableObjectManager race when multiple actors register writer
+        channels concurrently. No-op for non-Ray executors.
+        """
+        warm = getattr(
+            self.model_executor,  # type: ignore[attr-defined]
+            "warm_up_compiled_dag",
+            None,
+        )
+        if warm is not None:
+            warm()
+
     def run(self):
         """
         Run the engine core busy loop.

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -847,6 +847,13 @@ class CoreEngineActorManager:
             else []
         ) + self.remote_engine_actors[-(len(placement_groups) - new_local_engines) :]
 
+        # Serialize first-time Compiled-DAG compile across new actors. Ray's
+        # MutableObjectManager::OpenSemaphores aborts when multiple actors
+        # race through experimental_channel_register_writer concurrently;
+        # warming each actor's DAG one-at-a-time avoids that race entirely.
+        for actor in actors:
+            ray.get(actor.wait_for_dag_ready.remote())
+
         for actor in actors:
             ref = actor.run.remote()
             self.run_refs.append(ref)

--- a/vllm/v1/executor/ray_executor.py
+++ b/vllm/v1/executor/ray_executor.py
@@ -484,6 +484,22 @@ class RayDistributedExecutor(Executor):
         # Return a future that will aggregate outputs from all workers
         return FutureWrapper(refs, self.kv_output_aggregator)
 
+    def warm_up_compiled_dag(self) -> None:
+        # The Ray race we are avoiding fires inside experimental_compile()'s
+        # writer-channel registration (MutableObjectManager::OpenSemaphores
+        # asserts `RAY_PREDICT_TRUE(_left_ != _right_)`), so building the DAG
+        # is sufficient — no execute round-trip is needed, which also keeps
+        # this safe for KV/EC connector deployments that expect connector
+        # metadata to be set on any SchedulerOutput passed to execute().
+        # The Elastic-EP scale-up driver serializes calls to this method.
+        if self.forward_dag is None:
+            self.forward_dag = self._compiled_ray_dag(enable_asyncio=False)
+        logger.info(
+            "[Elastic EP] Compiled DAG ready (dp_size=%d, world_size=%d)",
+            self.parallel_config.data_parallel_size,
+            self.parallel_config.world_size,
+        )
+
     def collective_rpc(  # type: ignore[override]
         self,
         method: str | Callable,


### PR DESCRIPTION
## Purpose

Related to the [CI Step Failure: Elastic EP Scaling Test
](https://buildkite.com/vllm/ci/builds/63544/canvas?sid=019dd8b6-9f23-4085-8497-195dafc15fc1&tab=output)

Fix an Elastic-EP scale-up crash where new `DPMoEEngineCoreActor`s lazy-built `forward_dag` on the first user request and raced through Ray's `experimental_channel_register_writer`, aborting with `MutableObjectManager::OpenSemaphores Check failed: RAY_PREDICT_TRUE(_left_ != _right_)`. Add `RayDistributedExecutor.warm_up_compiled_dag` (compile-only) and a `wait_for_dag_ready` actor RPC, called sequentially per new actor in `scale_up_elastic_ep` before `run()`. Non-elastic startup is unchanged.

## Test Plan

## Test Result