### PR TITLE
Add padding to support TP with Marlin linear kernel (NVFP4 on H100)

### DIFF
--- a/vllm/model_executor/kernels/linear/nvfp4/marlin.py
+++ b/vllm/model_executor/kernels/linear/nvfp4/marlin.py
@@ -54,4 +54,5 @@ class MarlinNvFp4LinearKernel(NvFp4LinearKernel):
             size_n=layer.output_size_per_partition,
             size_k=layer.input_size_per_partition,
             bias=bias,
+            padded_size_n=getattr(layer, "marlin_padded_size_n", None),
         )

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_mxfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_mxfp4.py
@@ -103,4 +103,5 @@ class CompressedTensorsW4A16Mxfp4(CompressedTensorsScheme):
             size_n=layer.output_size_per_partition,
             size_k=layer.input_size_per_partition,
             bias=bias,
+            padded_size_n=getattr(layer, "marlin_padded_size_n", None),
         )

--- a/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/schemes/compressed_tensors_w4a16_nvfp4.py
@@ -106,4 +106,5 @@ class CompressedTensorsW4A16Fp4(CompressedTensorsScheme):
             size_n=layer.output_size_per_partition,
             size_k=layer.input_size_per_partition,
             bias=bias,
+            padded_size_n=getattr(layer, "marlin_padded_size_n", None),
         )

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -30,9 +30,7 @@ def _pad_tensor_dim(
     dim: int,
     padded_size: int,
 ) -> torch.Tensor:
-    """No using torch.nn.functional.pad.
-    Allocating same-dtype zero block and concatenating along the target dim is clearer.
-    """
+    """Pad tensor along a specific dimension to a given size."""
     pad_size = padded_size - tensor.size(dim)
     if pad_size == 0:
         return tensor
@@ -41,6 +39,8 @@ def _pad_tensor_dim(
             f"Cannot pad dim {dim} from {tensor.size(dim)} to {padded_size}."
         )
 
+    # No using torch.nn.functional.pad.
+    # Allocating zero block and concatenating along the target dim is more clear.
     pad_shape = list(tensor.shape)
     pad_shape[dim] = pad_size
     pad = tensor.new_zeros(pad_shape)

--- a/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
+++ b/vllm/model_executor/layers/quantization/utils/marlin_utils_fp4.py
@@ -17,10 +17,34 @@ from vllm.model_executor.layers.quantization.utils.marlin_utils import (
 )
 from vllm.platforms import current_platform
 from vllm.scalar_type import scalar_types
+from vllm.utils.math_utils import round_up
 
 FP4_MARLIN_SUPPORTED_GROUP_SIZES = [16]
+FP4_MARLIN_TILE_N_SIZE = 64
 
 logger = init_logger(__name__)
+
+
+def _pad_tensor_dim(
+    tensor: torch.Tensor,
+    dim: int,
+    padded_size: int,
+) -> torch.Tensor:
+    """No using torch.nn.functional.pad.
+    Allocating same-dtype zero block and concatenating along the target dim is clearer.
+    """
+    pad_size = padded_size - tensor.size(dim)
+    if pad_size == 0:
+        return tensor
+    if pad_size < 0:
+        raise ValueError(
+            f"Cannot pad dim {dim} from {tensor.size(dim)} to {padded_size}."
+        )
+
+    pad_shape = list(tensor.shape)
+    pad_shape[dim] = pad_size
+    pad = tensor.new_zeros(pad_shape)
+    return torch.cat((tensor, pad), dim=dim)
 
 
 def is_fp4_marlin_supported():
@@ -157,15 +181,22 @@ def apply_fp4_marlin_linear(
     bias: torch.Tensor | None = None,
     input_dtype: torch.dtype | None = None,
     use_fp32_reduce: bool = USE_FP32_REDUCE_DEFAULT,
+    padded_size_n: int | None = None,
 ) -> torch.Tensor:
     # For GPUs that lack FP4 hardware support, we can leverage the
     # Marlin kernel for fast weight-only FP4 quantization
 
     reshaped_x = input.reshape(-1, input.shape[-1])
-    out_shape = input.shape[:-1] + (size_n,)
+    original_size_n = size_n
+    padded_size_n = padded_size_n if padded_size_n is not None else size_n
+    out_shape = input.shape[:-1] + (original_size_n,)
 
     use_atomic_add = should_use_atomic_add_reduce(
-        m=reshaped_x.size(0), n=size_n, k=size_k, device=input.device, dtype=input.dtype
+        m=reshaped_x.size(0),
+        n=padded_size_n,
+        k=size_k,
+        device=input.device,
+        dtype=input.dtype,
     )
 
     inputs = reshaped_x
@@ -193,11 +224,14 @@ def apply_fp4_marlin_linear(
         workspace=workspace,
         b_q_type=scalar_types.float4_e2m1f,
         size_m=reshaped_x.size(0),
-        size_n=size_n,
+        size_n=padded_size_n,
         size_k=size_k,
         use_atomic_add=use_atomic_add,
         use_fp32_reduce=use_fp32_reduce,
     )
+
+    if padded_size_n != original_size_n:
+        output = output[:, :original_size_n]
 
     return output.reshape(out_shape)
 
@@ -214,9 +248,27 @@ def prepare_fp4_layer_for_marlin(
 
     group_size = 16 if is_nvfp4 else 32
 
-    part_size_n = layer.output_size_per_partition
+    unpadded_part_size_n = layer.output_size_per_partition
+    part_size_n = round_up(unpadded_part_size_n, FP4_MARLIN_TILE_N_SIZE)
+    padding_n_required = unpadded_part_size_n != part_size_n
+
     part_size_k = layer.input_size_per_partition
     param_dtype = layer.params_dtype
+
+    if padding_n_required:
+        # Marlin FP4 kernels require the output/N dimension to be tile-aligned.
+        # Without this, repack fails with:
+        # RuntimeError: size_n = ... is not divisible by tile_n_size = 64.
+        logger.warning_once("Padding is required for Marlin FP4 linear kernel.")
+        layer.weight = torch.nn.Parameter(
+            _pad_tensor_dim(layer.weight.data, dim=0, padded_size=part_size_n),
+            requires_grad=False,
+        )
+        if hasattr(layer, "bias") and layer.bias is not None:
+            layer.bias = torch.nn.Parameter(
+                _pad_tensor_dim(layer.bias.data, dim=0, padded_size=part_size_n),
+                requires_grad=False,
+            )
 
     assert layer.weight.shape == (part_size_n, part_size_k // 2)
 
@@ -240,6 +292,7 @@ def prepare_fp4_layer_for_marlin(
         is_a_8bit=is_a_8bit,
     )
     layer.weight = torch.nn.Parameter(marlin_qweight, requires_grad=False)
+    layer.marlin_padded_size_n = part_size_n
 
     # WEIGHT SCALES
     # Permute scales
@@ -249,6 +302,13 @@ def prepare_fp4_layer_for_marlin(
         weight_scale = weight_scale.view(torch.float8_e8m0fnu)
 
     weight_scale = weight_scale.to(param_dtype)
+    if padding_n_required:
+        # Padding is required
+        weight_scale = _pad_tensor_dim(
+            weight_scale,
+            dim=1,
+            padded_size=part_size_n,
+        )
     weight_scale = marlin_permute_scales(
         s=weight_scale,
         size_k=part_size_k,


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose

When running **NVFP4** models on **H100** GPUs, certain models fail if the N dim is not divisible by 64:

```python
RuntimeError: size_n = ... is not divisible by tile_n_size = 64
```

This error is raised from function `prepare_fp4_layer_for_marlin`.

This PR adds padding for Marlin linear kernel to support TP for these models (future Nemotron models).

## Test Plan

NVFP4 models should still work on H100 (`MarlinNvFp4LinearKernel` will be auto selected in this case).

## Test Result

Eval (GSM8K):

```bash
export MODEL_PATH="/my_home/hf_models/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4/"
export MODEL_PATH="/my_home/hf_models/RedHatAI/Qwen3.5-122B-A10B-NVFP4/"
export MODEL_PATH="/my_home/hf_models/RedHatAI/Qwen3-Coder-Next-NVFP4/"

lm_eval \
  --model vllm \
  --trust_remote_code \
  --model_args pretrained=$MODEL_PATH,max_model_len=4096,enforce_eager=True,tensor_parallel_size=4,enable_expert_parallel=True \
  --tasks gsm8k \
  --batch_size auto
```

Results (same as main branch - no regression):

```
Using MarlinNvFp4LinearKernel for NVFP4 GEMM
Using 'MARLIN' NvFp4 MoE backend out of potential backends: ...

# nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-NVFP4

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9356|±  |0.0068|
|     |       |strict-match    |     5|exact_match|↑  |0.9265|±  |0.0072|

# RedHatAI/Qwen3.5-122B-A10B-NVFP4

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8514|±  |0.0098|
|     |       |strict-match    |     5|exact_match|↑  |0.8309|±  |0.0103|

# RedHatAI/Qwen3-Coder-Next-NVFP4

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9105|±  |0.0079|
|     |       |strict-match    |     5|exact_match|↑  |0.9098|±  |0.0079|
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
