### PR TITLE
[Bugfix][Compile] Fix gc.collect/empty_cache patch arity in CUDAGraphWrapper

### DIFF
--- a/vllm/compilation/cuda_graph.py
+++ b/vllm/compilation/cuda_graph.py
@@ -290,9 +290,14 @@ class CUDAGraphWrapper:
                     # across layers will make the cudagraph capture very slow.
                     # therefore, we only run gc for the first graph,
                     # and disable gc for the rest of the graphs.
-                    stack.enter_context(patch("gc.collect", lambda: None))
                     stack.enter_context(
-                        patch("torch.accelerator.empty_cache", lambda: None)
+                        patch("gc.collect", lambda *args, **kwargs: None)
+                    )
+                    stack.enter_context(
+                        patch(
+                            "torch.accelerator.empty_cache",
+                            lambda *args, **kwargs: None,
+                        )
                     )
 
                 if self.graph_pool is not None:


### PR DESCRIPTION



## Purpose

`CUDAGraphWrapper.__call__` patches `gc.collect` and `torch.accelerator.empty_cache` with no-arg lambdas to suppress them during piecewise cudagraph capture. At least the first function is sometimes called with positional arguments — `gc.collect(generation)` in particular is invoked from `torch._dynamo.convert_frame._compile` whenever dynamo recompiles a nested `@torch.compile` callable inside the capture region. The 0-arg lambda then raises `TypeError: <lambda>() takes 0 positional arguments but 1 was given` and the worker dies.

This happened to me consistently on a GB200 node, using vLLM's nightly docker image.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

