### PR TITLE
Abort removed-rank requests during Elastic EP scale-down

### DIFF
--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -1000,7 +1000,10 @@ class AsyncLLM(EngineClient):
 
         set_scaling_elastic_ep(True)
         try:
-            await self.engine_core.scale_elastic_ep(new_data_parallel_size)
+            await self.engine_core.scale_elastic_ep(
+                new_data_parallel_size,
+                on_removed_requests=self.output_processor.abort_requests_for_removed_engines,
+            )
             self.vllm_config.parallel_config.data_parallel_size = new_data_parallel_size
         finally:
             set_scaling_elastic_ep(False)

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -204,7 +204,11 @@ class EngineCoreClient(ABC):
         running state."""
         raise NotImplementedError
 
-    async def scale_elastic_ep(self, new_data_parallel_size: int) -> None:
+    async def scale_elastic_ep(
+        self,
+        new_data_parallel_size: int,
+        on_removed_requests: Callable[[list[str]], list[str]] | None = None,
+    ) -> None:
         raise NotImplementedError
 
     async def get_output_async(self) -> EngineCoreOutputs:
@@ -1479,7 +1483,28 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
     ) -> None:
         await self._send_input(EngineCoreRequestType.ABORT, request_ids, engine)
 
-    async def scale_elastic_ep(self, new_data_parallel_size: int) -> None:
+    def _pop_requests_on_removed_engines(
+        self, new_data_parallel_size: int
+    ) -> list[str]:
+        """Remove and return request IDs assigned to removed DP engines."""
+        removed_engines = set(self.core_engines[new_data_parallel_size:])
+
+        removed_req_ids = [
+            req_id
+            for req_id, engine in self.reqs_in_flight.items()
+            if engine in removed_engines
+        ]
+
+        for req_id in removed_req_ids:
+            self.reqs_in_flight.pop(req_id, None)
+
+        return removed_req_ids
+
+    async def scale_elastic_ep(
+        self,
+        new_data_parallel_size: int,
+        on_removed_requests: Callable[[list[str]], list[str]] | None = None,
+    ) -> None:
         """Scale elastic EP data parallel size"""
         cur_data_parallel_size = len(self.core_engines)
 
@@ -1499,8 +1524,12 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
                 cur_data_parallel_size, new_data_parallel_size
             )
         else:
+            if on_removed_requests is None:
+                raise ValueError("on_removed_requests is required when scaling down Elastic EP")
             await self._scale_down_elastic_ep(
-                cur_data_parallel_size, new_data_parallel_size
+                cur_data_parallel_size,
+                new_data_parallel_size,
+                on_removed_requests,
             )
 
     async def _eep_wait_for_setup_switch_complete(self) -> None:
@@ -1633,7 +1662,10 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
         )
 
     async def _scale_down_elastic_ep(
-        self, cur_data_parallel_size: int, new_data_parallel_size: int
+        self,
+        cur_data_parallel_size: int,
+        new_data_parallel_size: int,
+        on_removed_requests: Callable[[list[str]], list[str]],
     ) -> None:
         """Scale down the data parallel size by shutting down and
         reconfiguring existing engine cores."""
@@ -1650,6 +1682,12 @@ class DPLBAsyncMPClient(DPAsyncMPClient):
 
         removed_dp_size = cur_data_parallel_size - new_data_parallel_size
         assert isinstance(self.resources.engine_manager, CoreEngineActorManager)
+
+        removed_req_ids = self._pop_requests_on_removed_engines(new_data_parallel_size)
+        if removed_req_ids:
+            # The callback may expand removed child IDs to siblings on remaining ranks.
+            await self.abort_requests_async(on_removed_requests(removed_req_ids))
+
         self.resources.engine_manager.remove_run_refs_for_scale_down(removed_dp_size)
         reconfig_futures = []
         for cur_dp_rank, engine in enumerate(self.core_engines):

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -443,6 +443,33 @@ class OutputProcessor:
             assert state.queue is not None
             state.queue.put(e)
 
+    def abort_requests_for_removed_engines(
+        self, request_ids: Iterable[str]
+    ) -> list[str]:
+        """Abort removed-engine requests, coalescing parallel-sampling children.
+        
+        Returns internal request IDs that should still be aborted in EngineCore,
+        e.g. surviving siblings of parallel-sampling requests.
+        """
+        target_ids: list[str] = []
+        seen_target_ids: set[str] = set()
+
+        for request_id in request_ids:
+            target_id = request_id
+            if req_state := self.request_states.get(request_id):
+                if req_state.parent_req is not None:
+                    target_id = req_state.parent_req.request_id
+
+            if target_id in seen_target_ids:
+                continue
+            seen_target_ids.add(target_id)
+            target_ids.append(target_id)
+
+        if not target_ids:
+            return []
+
+        return self.abort_requests(target_ids, internal=True)
+
     def abort_requests(self, request_ids: Iterable[str], internal: bool) -> list[str]:
         """Abort a list of requests.
 


### PR DESCRIPTION
This PR fixes Elastic EP scale-down handling for in-flight requests that were already routed to DP ranks being removed.

During scale-down, requests assigned to removed ranks cannot complete normally. The core client now identifies those internal request IDs from `reqs_in_flight`, removes their routing entries, and asks the `OutputProcessor` to abort the corresponding frontend request state.

The important case is parallel sampling (`n > 1`): a removed child request may belong to a parent request with sibling children still running on remaining ranks. The `OutputProcessor` now coalesces removed child IDs to the parent request, performs frontend abort cleanup, and returns the internal child IDs that should still be aborted in EngineCore. Removed-rank IDs have already been popped from `reqs_in_flight`, so `abort_requests_async()` only forwards aborts for siblings still routed to remaining ranks.

The change keeps ownership split by layer:
- `core_client.py`: owns DP engine routing and removed-rank request detection.
- `output_processor.py`: owns parent/child request state and frontend abort semantics.
- `async_llm.py`: wires the two together during Elastic EP scale-down.