### PR TITLE
[Core] Make encoder budget args configurable via CLI

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -9,7 +9,13 @@ from typing import Annotated, Literal
 import pytest
 from pydantic import Field
 
-from vllm.config import AttentionConfig, CompilationConfig, ModelConfig, config
+from vllm.config import (
+    AttentionConfig,
+    CompilationConfig,
+    ModelConfig,
+    SchedulerConfig,
+    config,
+)
 from vllm.engine.arg_utils import (
     EngineArgs,
     _expand_json_human_readable_numbers,
@@ -634,6 +640,47 @@ def test_human_readable_other_args():
     assert args.max_num_batched_tokens == 2_000
     args = parser.parse_args(["--max-num-batched-tokens", "4K"])
     assert args.max_num_batched_tokens == 2**10 * 4
+
+    args = parser.parse_args(
+        [
+            "--max-num-encoder-input-tokens",
+            "64K",
+            "--encoder-cache-size",
+            "1m",
+        ]
+    )
+    assert args.max_num_encoder_input_tokens == 2**16
+    assert args.encoder_cache_size == 1_000_000
+
+
+def test_encoder_budget_args_propagate_to_scheduler_config():
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(
+        [
+            "--model",
+            "facebook/opt-125m",
+            "--max-num-batched-tokens",
+            "2K",
+            "--max-num-encoder-input-tokens",
+            "64K",
+            "--encoder-cache-size",
+            "128K",
+        ]
+    )
+
+    scheduler_config = (
+        EngineArgs.from_cli_args(args=args).create_engine_config().scheduler_config
+    )
+
+    assert scheduler_config.max_num_encoder_input_tokens == 2**16
+    assert scheduler_config.encoder_cache_size == 2**17
+
+
+def test_encoder_budget_args_default_to_max_num_batched_tokens():
+    scheduler_config = SchedulerConfig.default_factory(max_num_batched_tokens=4096)
+
+    assert scheduler_config.max_num_encoder_input_tokens == 4096
+    assert scheduler_config.encoder_cache_size == 4096
 
 
 def test_numa_bind_args():

--- a/tests/engine/test_encoder_budget_args.py
+++ b/tests/engine/test_encoder_budget_args.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.engine.arg_utils import EngineArgs
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+
+
+def test_encoder_budget_defaults_to_max_num_batched_tokens():
+    """When not set, both encoder fields default to max_num_batched_tokens."""
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args([])
+    engine_args = EngineArgs.from_cli_args(args)
+    vllm_config = engine_args.create_engine_config()
+    sc = vllm_config.scheduler_config
+    assert sc.max_num_encoder_input_tokens == sc.max_num_batched_tokens
+    assert sc.encoder_cache_size == sc.max_num_batched_tokens
+
+
+@pytest.mark.parametrize(
+    ("encoder_input_tokens", "cache_size"),
+    [
+        (100000, 200000),
+        (500000, 600000),
+    ],
+)
+def test_encoder_budget_cli_args_and_config(encoder_input_tokens, cache_size):
+    """CLI args propagate to EngineArgs and flow through to SchedulerConfig."""
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(
+        [
+            "--max-num-encoder-input-tokens",
+            str(encoder_input_tokens),
+            "--encoder-cache-size",
+            str(cache_size),
+        ]
+    )
+    engine_args = EngineArgs.from_cli_args(args)
+    assert engine_args.max_num_encoder_input_tokens == encoder_input_tokens
+    assert engine_args.encoder_cache_size == cache_size
+
+    vllm_config = engine_args.create_engine_config()
+    sc = vllm_config.scheduler_config
+    assert sc.max_num_encoder_input_tokens == encoder_input_tokens
+    assert sc.encoder_cache_size == cache_size
+
+
+def test_encoder_budget_partial_override():
+    """Setting only one field leaves the other at default."""
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(["--max-num-encoder-input-tokens", "100000"])
+    engine_args = EngineArgs.from_cli_args(args)
+    vllm_config = engine_args.create_engine_config()
+    sc = vllm_config.scheduler_config
+    assert sc.max_num_encoder_input_tokens == 100000
+    assert sc.encoder_cache_size == sc.max_num_batched_tokens
+
+
+def test_encoder_budget_not_in_default_args():
+    """Default CLI parse produces None for both encoder fields."""
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args([])
+    engine_args = EngineArgs.from_cli_args(args)
+    assert engine_args.max_num_encoder_input_tokens is None
+    assert engine_args.encoder_cache_size is None

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -339,6 +339,42 @@ def test_schedule_partial_requests():
     assert requests[2].request_id not in output.num_scheduled_tokens
 
 
+@pytest.mark.parametrize(
+    ("encoder_budget", "expected_encoder_inputs"),
+    [
+        (None, [0]),
+        (1200, [0, 1]),
+    ],
+)
+def test_encoder_budget_controls_concurrent_mm_residency(
+    encoder_budget: int | None,
+    expected_encoder_inputs: list[int],
+):
+    scheduler = create_scheduler(
+        model="llava-hf/llava-1.5-7b-hf",
+        max_num_batched_tokens=1024,
+        max_num_encoder_input_tokens=encoder_budget,
+        encoder_cache_size=encoder_budget,
+    )
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=1300,
+        mm_positions=[
+            [
+                PlaceholderRange(offset=0, length=600),
+                PlaceholderRange(offset=601, length=600),
+            ]
+        ],
+    )
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+
+    assert output.scheduled_encoder_inputs[request.request_id] == (
+        expected_encoder_inputs
+    )
+
+
 @pytest.mark.parametrize("has_running", [True, False])
 def test_schedule_prefills_gating(has_running: bool):
     """DP prefill-balancing gate: when `throttle_prefills` is True, a new

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -52,6 +52,8 @@ def create_scheduler(
     model: str = "facebook/opt-125m",
     max_num_seqs: int = 16,
     max_num_batched_tokens: int = 8192,
+    max_num_encoder_input_tokens: int | None = None,
+    encoder_cache_size: int | None = None,
     enable_chunked_prefill: bool = True,
     enable_prefix_caching: bool = False,
     long_prefill_token_threshold: int = 0,
@@ -102,6 +104,13 @@ def create_scheduler(
         model_config.multimodal_config = MultiModalConfig()
     if max_model_len is None:
         max_model_len = max_num_batched_tokens
+    encoder_scheduler_kwargs = {}
+    if max_num_encoder_input_tokens is not None:
+        encoder_scheduler_kwargs["max_num_encoder_input_tokens"] = (
+            max_num_encoder_input_tokens
+        )
+    if encoder_cache_size is not None:
+        encoder_scheduler_kwargs["encoder_cache_size"] = encoder_cache_size
     scheduler_config = SchedulerConfig(
         max_num_seqs=max_num_seqs,
         max_num_batched_tokens=max_num_batched_tokens,
@@ -113,6 +122,7 @@ def create_scheduler(
         is_encoder_decoder=model_config.is_encoder_decoder,
         # Ensure admission/preemption mechanics are deterministic
         watermark=0.0,
+        **encoder_scheduler_kwargs,
     )
     # Cache config, optionally force APC
     cache_config = CacheConfig(

--- a/tests/v1/worker/test_encoder_runner.py
+++ b/tests/v1/worker/test_encoder_runner.py
@@ -25,10 +25,25 @@ from vllm.multimodal.inputs import (
 from vllm.v1.worker.gpu.mm.encoder_cache import EncoderCache
 from vllm.v1.worker.gpu.mm.encoder_runner import EncoderRunner
 from vllm.v1.worker.gpu.model_states.interface import ModelState
+from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 
 pytestmark = pytest.mark.cpu_test
 
 HIDDEN = 4
+
+
+def test_v1_profile_reserves_full_encoder_cache():
+    runner = object.__new__(GPUModelRunner)
+    runner.encoder_cache = {}
+    runner.inputs_embeds_size = HIDDEN
+    runner.dtype = torch.float32
+    runner.device = torch.device("cpu")
+
+    runner._reserve_encoder_cache_for_profile(cache_size=7)
+
+    reservation = runner.encoder_cache["tmp_profile_reservation"]
+    assert reservation.shape == (7, HIDDEN)
+    assert reservation.dtype == torch.float32
 
 
 def _model_state(cache: EncoderCache) -> MagicMock:

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -92,19 +92,19 @@ class SchedulerConfig:
     is_multimodal_model: bool = False
     """True if the model is multimodal."""
 
-    # TODO (ywang96): Make this configurable.
-    max_num_encoder_input_tokens: int = Field(init=False)
+    max_num_encoder_input_tokens: int | None = Field(default=None, ge=1)
     """Multimodal encoder compute budget, only used in V1.
 
-    NOTE: This is not currently configurable. It will be overridden by
-    max_num_batched_tokens in case max multimodal embedding size is larger."""
+    If not set, defaults to max_num_batched_tokens. The actual budget
+    used by the scheduler may be larger if the model reports a higher
+    per-item multimodal token count."""
 
-    # TODO (ywang96): Make this configurable.
-    encoder_cache_size: int = Field(init=False)
+    encoder_cache_size: int | None = Field(default=None, ge=1)
     """Multimodal encoder cache size, only used in V1.
 
-    NOTE: This is not currently configurable. It will be overridden by
-    max_num_batched_tokens in case max multimodal embedding size is larger."""
+    If not set, defaults to max_num_batched_tokens. The actual cache
+    size used by the scheduler may be larger if the model reports a
+    higher per-item multimodal token count."""
 
     policy: SchedulerPolicy = "fcfs"
     """The scheduling policy to use:
@@ -232,8 +232,10 @@ class SchedulerConfig:
                 " prefix caching; disabling both."
             )
 
-        self.max_num_encoder_input_tokens = self.max_num_batched_tokens
-        self.encoder_cache_size = self.max_num_batched_tokens
+        if self.max_num_encoder_input_tokens is None:
+            self.max_num_encoder_input_tokens = self.max_num_batched_tokens
+        if self.encoder_cache_size is None:
+            self.encoder_cache_size = self.max_num_batched_tokens
 
         if self.enable_chunked_prefill:
             logger.info_once(

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -124,19 +124,18 @@ class SchedulerConfig:
     is_multimodal_model: bool = False
     """True if the model is multimodal."""
 
-    # TODO (ywang96): Make this configurable.
-    max_num_encoder_input_tokens: int = Field(init=False)
+    max_num_encoder_input_tokens: int = Field(default=None, ge=1)  # type: ignore[assignment]
     """Multimodal encoder compute budget, only used in V1.
 
-    NOTE: This is not currently configurable. It will be overridden by
-    max_num_batched_tokens in case max multimodal embedding size is larger."""
+    If not set, defaults to `max_num_batched_tokens`. The effective budget
+    may be increased to fit the model's largest multimodal item."""
 
-    # TODO (ywang96): Make this configurable.
-    encoder_cache_size: int = Field(init=False)
+    encoder_cache_size: int = Field(default=None, ge=1)  # type: ignore[assignment]
     """Multimodal encoder cache size, only used in V1.
 
-    NOTE: This is not currently configurable. It will be overridden by
-    max_num_batched_tokens in case max multimodal embedding size is larger."""
+    If not set, defaults to `max_num_batched_tokens`. The effective cache size
+    may be increased to fit the model's largest multimodal item. Increasing
+    this value allows more encoder outputs to remain resident concurrently."""
 
     policy: SchedulerPolicy = "fcfs"
     """The scheduling policy to use:
@@ -281,8 +280,10 @@ class SchedulerConfig:
                 " prefix caching; disabling both."
             )
 
-        self.max_num_encoder_input_tokens = self.max_num_batched_tokens
-        self.encoder_cache_size = self.max_num_batched_tokens
+        if self.max_num_encoder_input_tokens is None:
+            self.max_num_encoder_input_tokens = self.max_num_batched_tokens
+        if self.encoder_cache_size is None:
+            self.encoder_cache_size = self.max_num_batched_tokens
 
         if self.enable_chunked_prefill:
             logger.info_once(

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -350,7 +350,12 @@ def _compute_kwargs(cls: ConfigType) -> dict[str, dict[str, Any]]:
             if name == "max_model_len":
                 kwargs[name]["type"] = human_readable_int_or_auto
                 kwargs[name]["help"] += f"\n\n{human_readable_int_or_auto.__doc__}"
-            elif name in ("max_num_batched_tokens", "kv_cache_memory_bytes"):
+            elif name in (
+                "max_num_batched_tokens",
+                "kv_cache_memory_bytes",
+                "max_num_encoder_input_tokens",
+                "encoder_cache_size",
+            ):
                 kwargs[name]["type"] = human_readable_int
                 kwargs[name]["help"] += f"\n\n{human_readable_int.__doc__}"
             else:
@@ -611,6 +616,10 @@ class EngineArgs:
     enable_mm_processor_stats: bool = ObservabilityConfig.enable_mm_processor_stats
     scheduling_policy: SchedulerPolicy = SchedulerConfig.policy
     scheduler_cls: str | type[object] | None = SchedulerConfig.scheduler_cls
+    max_num_encoder_input_tokens: int | None = (
+        SchedulerConfig.max_num_encoder_input_tokens
+    )
+    encoder_cache_size: int | None = SchedulerConfig.encoder_cache_size
 
     pooler_config: PoolerConfig | None = ModelConfig.pooler_config
     compilation_config: CompilationConfig = get_field(VllmConfig, "compilation_config")
@@ -1361,6 +1370,14 @@ class EngineArgs:
         scheduler_group.add_argument(
             "--stream-interval", **scheduler_kwargs["stream_interval"]
         )
+        scheduler_group.add_argument(
+            "--max-num-encoder-input-tokens",
+            **scheduler_kwargs["max_num_encoder_input_tokens"],
+        )
+        scheduler_group.add_argument(
+            "--encoder-cache-size",
+            **scheduler_kwargs["encoder_cache_size"],
+        )
 
         # Compilation arguments
         compilation_kwargs = get_kwargs(CompilationConfig)
@@ -1971,6 +1988,8 @@ class EngineArgs:
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
             stream_interval=self.stream_interval,
+            max_num_encoder_input_tokens=self.max_num_encoder_input_tokens,
+            encoder_cache_size=self.encoder_cache_size,
         )
 
         if not model_config.is_multimodal_model and self.default_mm_loras:

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -365,6 +365,8 @@ def _compute_kwargs(cls: ConfigType) -> dict[str, dict[str, Any]]:
             human_readable_int_args = {
                 "max_num_batched_tokens",
                 "max_num_scheduled_tokens",
+                "max_num_encoder_input_tokens",
+                "encoder_cache_size",
                 "kv_cache_memory_bytes",
                 "safetensors_prefetch_block_size",
                 "max_num_queued_tokens",
@@ -684,6 +686,10 @@ class EngineArgs:
     enable_mm_processor_stats: bool = ObservabilityConfig.enable_mm_processor_stats
     scheduling_policy: SchedulerPolicy = SchedulerConfig.policy
     scheduler_cls: str | type[object] | None = SchedulerConfig.scheduler_cls
+    max_num_encoder_input_tokens: int | None = (
+        SchedulerConfig.max_num_encoder_input_tokens
+    )
+    encoder_cache_size: int | None = SchedulerConfig.encoder_cache_size
 
     pooler_config: PoolerConfig | None = ModelConfig.pooler_config
     compilation_config: CompilationConfig = get_field(VllmConfig, "compilation_config")
@@ -1615,6 +1621,14 @@ class EngineArgs:
         scheduler_group.add_argument(
             "--stream-interval", **scheduler_kwargs["stream_interval"]
         )
+        scheduler_group.add_argument(
+            "--max-num-encoder-input-tokens",
+            **scheduler_kwargs["max_num_encoder_input_tokens"],
+        )
+        scheduler_group.add_argument(
+            "--encoder-cache-size",
+            **scheduler_kwargs["encoder_cache_size"],
+        )
 
         # Compilation arguments
         compilation_kwargs = get_kwargs(CompilationConfig)
@@ -2363,6 +2377,13 @@ class EngineArgs:
         assert model_config.max_model_len is not None, (
             "max_model_len must be set by this point"
         )
+        encoder_scheduler_kwargs: dict[str, Any] = {}
+        if self.max_num_encoder_input_tokens is not None:
+            encoder_scheduler_kwargs["max_num_encoder_input_tokens"] = (
+                self.max_num_encoder_input_tokens
+            )
+        if self.encoder_cache_size is not None:
+            encoder_scheduler_kwargs["encoder_cache_size"] = self.encoder_cache_size
         scheduler_config = SchedulerConfig(
             runner_type=model_config.runner_type,
             max_num_batched_tokens=self.max_num_batched_tokens,
@@ -2384,6 +2405,7 @@ class EngineArgs:
             disable_hybrid_kv_cache_manager=self.disable_hybrid_kv_cache_manager,
             async_scheduling=self.async_scheduling,
             stream_interval=self.stream_interval,
+            **encoder_scheduler_kwargs,
         )
 
         if not model_config.is_multimodal_model and self.default_mm_loras:

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6549,6 +6549,11 @@ class GPUModelRunner(
                 mm_budget = self.mm_budget
                 assert mm_budget is not None
 
+                if mm_budget.encoder_cache_size > 0:
+                    self._reserve_encoder_cache_for_profile(
+                        mm_budget.encoder_cache_size
+                    )
+
                 if (encoder_budget := mm_budget.get_encoder_budget()) > 0:
                     if not mm_budget.mm_max_toks_per_item:
                         # All modality limits are 0 — embedding-only mode.
@@ -6610,6 +6615,13 @@ class GPUModelRunner(
         del hidden_states, output
         self.encoder_cache.clear()
         gc.collect()
+
+    def _reserve_encoder_cache_for_profile(self, cache_size: int) -> None:
+        self.encoder_cache["tmp_profile_reservation"] = torch.empty(
+            (cache_size, self.inputs_embeds_size),
+            dtype=self.dtype,
+            device=self.device,
+        )
 
     def _init_minimal_kv_cache_for_profiling(self) -> None:
         from vllm.v1.core.kv_cache_utils import (


### PR DESCRIPTION
## Purpose
  Make `max_num_encoder_input_tokens` and `encoder_cache_size` configurable
  via `--max-num-encoder-input-tokens` and `--encoder-cache-size` CLI args.

  Previously these were hardcoded to `max_num_batched_tokens` in
  `SchedulerConfig.__post_init__`. They now accept user-specified values
  with `None` defaulting to the prior behavior, resolving the TODO items
  from @ywang96.

  ## Test Plan
  Added `tests/engine/test_encoder_budget_args.py` covering:
  - Default behavior (None → max_num_batched_tokens)
  - CLI arg parsing with parametrized values
  - End-to-end config propagation
  - Partial override (one field set, other defaults)
  - None verification on default parse

  ## Test Result

  pytest tests/engine/testencoderbudget_args.py -v

  ## AI Disclosure
  This PR was developed with AI assistance (Kiro).