### PR TITLE
[Bugfix][MoRIIO] Proxy robustness and write-task deferral for async KV transfer

### DIFF
--- a/examples/online_serving/disaggregated_serving/moriio_toy_proxy_server.py
+++ b/examples/online_serving/disaggregated_serving/moriio_toy_proxy_server.py
@@ -259,7 +259,14 @@ async def handle_request(api: str, request: Request):
         )
         ip, port = extract_ip_port_fast(prefill_request_url)
 
-        req_data["max_tokens"] -= 1
+        # OpenAI Chat Completions: when both fields are present,
+        # max_completion_tokens takes precedence, so decrement that one
+        # to keep the per-request budget consistent with what the
+        # backend will enforce. Fall back to max_tokens otherwise.
+        if "max_completion_tokens" in req_data:
+            req_data["max_completion_tokens"] -= 1
+        elif "max_tokens" in req_data:
+            req_data["max_tokens"] -= 1
 
         req_data["kv_transfer_params"] = {
             "do_remote_decode": False,
@@ -309,6 +316,17 @@ async def handle_request(api: str, request: Request):
                 500,
             )
         )
+
+
+@app.route("/health", methods=["GET"])
+async def health_check():
+    with _list_lock:
+        return {
+            "status": "ok",
+            "prefill_instances": len(prefill_instances),
+            "decode_instances": len(decode_instances),
+            "transfer_type": TRANSFER_TYPE,
+        }
 
 
 if __name__ == "__main__":

--- a/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/moriio/moriio_engine.py
@@ -154,7 +154,13 @@ class MoRIIOWriter:
         self._deferred_tasks = still_deferred
 
     def _is_remote_ready(self, task: WriteTask) -> bool:
-        """Check if remote blocks are allocated for this task.
+        """Check if remote blocks are allocated and populated for this task.
+
+        Returns True only when the remote allocation entry exists *and*
+        carries a non-None ``block_ids`` mapping. The latter check ensures
+        that ``_execute_write_task`` is never invoked for a task whose
+        remote ``block_ids`` are still being filled in by the scheduler;
+        without it we would either drop the task or busy-loop on it.
 
         Args:
             task: The write task
@@ -162,9 +168,10 @@ class MoRIIOWriter:
         Returns:
             True if remote blocks are ready
         """
-        return (
-            task.transfer_id in self.worker.moriio_wrapper.done_remote_allocate_req_dict
+        info = self.worker.moriio_wrapper.done_remote_allocate_req_dict.get(
+            task.transfer_id
         )
+        return info is not None and info.block_ids is not None
 
     def _get_remote_alloc_info(self, transfer_id: str) -> RemoteAllocInfo:
         """Get remote allocation info for a request.
@@ -188,20 +195,16 @@ class MoRIIOWriter:
     def _execute_write_task(self, task: WriteTask) -> None:
         """Execute a single write task.
 
+        Callers must ensure ``_is_remote_ready(task)`` returned ``True``
+        before invoking this method; ``_is_remote_ready`` guarantees that
+        ``request_info.block_ids`` is non-None and the entry exists.
+
         Args:
             task: The write task to execute
 
         """
         # Get remote allocation info
         request_info = self._get_remote_alloc_info(task.transfer_id)
-
-        if request_info.block_ids is None:
-            logger.debug(
-                "Request remote block IDs not ready:request_id = %s, transfer_id = %s",
-                task.request_id,
-                task.transfer_id,
-            )
-            return
 
         # Wait for CUDA event
         # The attention computation of the current layer cannot


### PR DESCRIPTION
## Purpose

This PR bundles three independent fixes for the MoRIIO-based P/D disaggregation path (no overlap with open PRs #40344, 39276, #32630, #39835).

1. **Proxy: handle `max_completion_tokens` for chat completions API.**
The OpenAI Chat Completions API uses `max_completion_tokens`; the toy proxy was only decrementing `max_tokens`, dropping the field on forward and causing the backend to use its default. Decrement whichever field the client sent.

2. **Proxy: add `/health` endpoint.**
Benchmark harnesses (e.g. `vllm bench serve`) perform health probes against the proxy before sending traffic. Without this endpoint the probe fails and the benchmark aborts. Add a minimal 200-OK responder that also reports the current instance counts.

3. **Engine: defer write task when remote `block_ids` is `None`.**
When a prefill-side write task arrives before the scheduler has populated the remote `block_ids` (async handshake race), the current code silently drops the task. Instead, append it to the existing `self._deferred_tasks` queue so it is retried once the mapping becomes available, preventing lost KV transfers.

All three are narrow, independent fixes. They do not modify the scheduler's hot path or introduce new control flow. Verified to apply cleanly on upstream/main as of 2026-04-22.

## Test Plan

These fixes were developed and verified on:
- A 2-node cluster, each node equipped with 8x MI300X and 8x Broadcom Thor2 400G NICs (`bnxt_re`)
- A 10-node cluster, also each node equipped with 8x MI300X and 8x Broadcom Thor2 400G NICs (`bnxt_re`)

We use these as a precondition for our vLLM P/D disaggregated serving stack with the MoRI-IO connector. Without these fixes, MoRI-IO failed at startup.

## Test Result

- vLLM 1P1D (TP=8) disaggregated serving comes up and runs end-to-end with MoRI-IO over Thor2 with these fixes applied.
- Various xPyD setups succeeded in bring-up including 1P3D, 1P4D, etc.

This change was developed with AI assistance; the author has reviewed and tested each hunk and is accountable for the behavior.


Signed-off-by: Chaemin Lim <chaemin.lim@mangoboost.io>

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

