### PR TITLE
WIP: Add opt-in BF16 linear compile path

### DIFF
--- a/tests/model_executor/test_compile_bf16_linear_dispatch.py
+++ b/tests/model_executor/test_compile_bf16_linear_dispatch.py
@@ -1,0 +1,264 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for the opt-in BF16 unquantized linear torch.compile path."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from vllm.model_executor.layers import utils
+from vllm.platforms import current_platform
+
+
+@pytest.fixture(autouse=True)
+def _reset_compile_state(monkeypatch):
+    utils._unquant_bf16_linear_cache.clear()
+    utils._unquant_bf16_linear_capture_safe_keys.clear()
+    monkeypatch.setattr(utils, "_unquant_bf16_linear_torch_compile_configured", False)
+    monkeypatch.setattr(utils, "_unquant_bf16_linear_torch_compile_disabled", False)
+    monkeypatch.setattr(utils, "_inductor_max_autotune_gemm_forced", True)
+    monkeypatch.setattr(utils, "_dynamo_compile_caches_forced", True)
+    yield
+    utils._unquant_bf16_linear_cache.clear()
+    utils._unquant_bf16_linear_capture_safe_keys.clear()
+
+
+class _Tensorish:
+    def __init__(
+        self,
+        *,
+        dtype: torch.dtype = torch.bfloat16,
+        is_cuda: bool = True,
+        contiguous: bool = True,
+    ):
+        self.dtype = dtype
+        self.is_cuda = is_cuda
+        self._contiguous = contiguous
+
+    def is_contiguous(self):
+        return self._contiguous
+
+
+def test_dispatch_env_on_cuda_returns_compile(monkeypatch):
+    monkeypatch.setenv("VLLM_ENABLE_UNQUANT_BF16_LINEAR_TORCH_COMPILE", "1")
+    monkeypatch.setattr(current_platform, "is_rocm", lambda: False)
+    monkeypatch.setattr(current_platform, "is_cpu", lambda: False)
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+
+    assert (
+        utils.dispatch_unquantized_gemm() is utils._torch_compile_bf16_unquantized_gemm
+    )
+
+
+def test_dispatch_env_off_returns_default(monkeypatch):
+    monkeypatch.setenv("VLLM_ENABLE_UNQUANT_BF16_LINEAR_TORCH_COMPILE", "0")
+    monkeypatch.setattr(current_platform, "is_rocm", lambda: False)
+    monkeypatch.setattr(current_platform, "is_cpu", lambda: False)
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: True)
+
+    assert utils.dispatch_unquantized_gemm() is utils.default_unquantized_gemm
+
+
+def test_dispatch_non_cuda_does_not_select_compile(monkeypatch):
+    monkeypatch.setenv("VLLM_ENABLE_UNQUANT_BF16_LINEAR_TORCH_COMPILE", "1")
+    monkeypatch.setattr(current_platform, "is_rocm", lambda: False)
+    monkeypatch.setattr(current_platform, "is_cpu", lambda: True)
+    monkeypatch.setattr(current_platform, "is_cuda", lambda: False)
+
+    assert utils.dispatch_unquantized_gemm() is not (
+        utils._torch_compile_bf16_unquantized_gemm
+    )
+
+
+def test_predicate_rejects_cpu_tensor():
+    x = _Tensorish(is_cuda=False)
+    w = _Tensorish()
+
+    assert not utils._should_use_unquant_bf16_linear_torch_compile(x, w, None)
+
+
+def test_predicate_rejects_non_bf16_dtype():
+    x = _Tensorish(dtype=torch.float16)
+    w = _Tensorish()
+
+    assert not utils._should_use_unquant_bf16_linear_torch_compile(x, w, None)
+
+
+def test_predicate_rejects_bias_dtype_mismatch():
+    x = _Tensorish()
+    w = _Tensorish()
+    bias = _Tensorish(dtype=torch.float32)
+
+    assert not utils._should_use_unquant_bf16_linear_torch_compile(x, w, bias)
+
+
+def test_predicate_rejects_non_contiguous_input():
+    x = _Tensorish(contiguous=False)
+    w = _Tensorish()
+
+    assert not utils._should_use_unquant_bf16_linear_torch_compile(x, w, None)
+
+
+def test_predicate_rejects_while_dynamo_is_compiling(monkeypatch):
+    x = _Tensorish()
+    w = _Tensorish()
+    monkeypatch.setattr(torch._dynamo, "is_compiling", lambda: True)
+
+    assert not utils._should_use_unquant_bf16_linear_torch_compile(x, w, None)
+
+
+def test_cache_key_is_static_shape_specific():
+    x_a = torch.zeros(4, 8)
+    x_b = torch.zeros(64, 8)
+    w = torch.zeros(16, 8)
+
+    assert utils._unquant_bf16_linear_cache_key(
+        x_a, w, None
+    ) != utils._unquant_bf16_linear_cache_key(x_b, w, None)
+
+
+def test_compile_gemm_falls_back_to_f_linear_when_ineligible():
+    x = torch.randn(4, 8, dtype=torch.bfloat16)
+    w = torch.randn(16, 8, dtype=torch.bfloat16)
+
+    out = utils._torch_compile_bf16_unquantized_gemm(None, x, w, None)
+
+    torch.testing.assert_close(
+        out, torch.nn.functional.linear(x, w, None), atol=0.0, rtol=0.0
+    )
+
+
+def test_capture_skips_uncompiled_shape(monkeypatch):
+    x = torch.randn(4, 8, dtype=torch.bfloat16)
+    w = torch.randn(16, 8, dtype=torch.bfloat16)
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+
+    assert utils._apply_unquant_bf16_linear_torch_compile(x, w, None) is None
+
+
+def test_capture_reuses_warmed_shape(monkeypatch):
+    x = torch.randn(4, 8, dtype=torch.bfloat16)
+    w = torch.randn(16, 8, dtype=torch.bfloat16)
+    key = utils._unquant_bf16_linear_cache_key(x, w, None)
+    cached = MagicMock(return_value=torch.nn.functional.linear(x, w, None))
+    utils._unquant_bf16_linear_cache[key] = cached
+    utils._unquant_bf16_linear_capture_safe_keys.add(key)
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: True)
+
+    utils._apply_unquant_bf16_linear_torch_compile(x, w, None)
+
+    cached.assert_called_once_with(x, w)
+
+
+def test_compile_failure_disables_fast_path(monkeypatch):
+    x = torch.randn(4, 8, dtype=torch.bfloat16)
+    w = torch.randn(16, 8, dtype=torch.bfloat16)
+
+    monkeypatch.setattr(torch.cuda, "is_current_stream_capturing", lambda: False)
+    monkeypatch.setattr(
+        utils,
+        "_get_or_create_unquant_bf16_linear_kernel",
+        lambda x, weight, bias, allow_new_compile: MagicMock(
+            side_effect=RuntimeError("inductor boom")
+        ),
+    )
+
+    assert utils._apply_unquant_bf16_linear_torch_compile(x, w, None) is None
+    assert utils._unquant_bf16_linear_torch_compile_disabled is True
+
+
+@pytest.fixture
+def _restore_inductor_state():
+    pytest.importorskip("torch._inductor.utils")
+    pytest.importorskip("torch._inductor.config")
+    pytest.importorskip("torch._inductor.codegen.cuda")
+    import torch._dynamo.config as dynamo_config
+    import torch._inductor.config as inductor_config
+    import torch._inductor.utils as inductor_utils
+    from torch._inductor.codegen.cuda import cuda_env
+
+    originals = {
+        "is_big_gpu": inductor_utils.is_big_gpu,
+        "is_datacenter_blackwell_arch": cuda_env.is_datacenter_blackwell_arch,
+        "max_autotune": inductor_config.max_autotune,
+        "max_autotune_gemm": inductor_config.max_autotune_gemm,
+        "max_autotune_gemm_backends": inductor_config.max_autotune_gemm_backends,
+        "coordinate_descent_tuning": inductor_config.coordinate_descent_tuning,
+        "cache_size_limit": getattr(dynamo_config, "cache_size_limit", None),
+        "accumulated_cache_size_limit": getattr(
+            dynamo_config, "accumulated_cache_size_limit", None
+        ),
+    }
+    yield inductor_utils, cuda_env, inductor_config, dynamo_config
+    inductor_utils.is_big_gpu = originals["is_big_gpu"]
+    cuda_env.is_datacenter_blackwell_arch = originals["is_datacenter_blackwell_arch"]
+    inductor_config.max_autotune = originals["max_autotune"]
+    inductor_config.max_autotune_gemm = originals["max_autotune_gemm"]
+    inductor_config.max_autotune_gemm_backends = originals["max_autotune_gemm_backends"]
+    inductor_config.coordinate_descent_tuning = originals["coordinate_descent_tuning"]
+    if originals["cache_size_limit"] is not None:
+        dynamo_config.cache_size_limit = originals["cache_size_limit"]
+    if originals["accumulated_cache_size_limit"] is not None:
+        dynamo_config.accumulated_cache_size_limit = originals[
+            "accumulated_cache_size_limit"
+        ]
+
+
+def test_force_autotune_patches_inductor(monkeypatch, _restore_inductor_state):
+    inductor_utils, _, inductor_config, _ = _restore_inductor_state
+    monkeypatch.setattr(utils, "_inductor_max_autotune_gemm_forced", False)
+
+    utils.force_inductor_max_autotune_gemm_on_small_gpus()
+
+    assert inductor_utils.is_big_gpu() is True
+    assert getattr(inductor_utils.is_big_gpu, "__vllm_big_gpu_override__", False)
+    assert inductor_config.max_autotune is True
+    assert inductor_config.max_autotune_gemm is True
+    assert inductor_config.max_autotune_gemm_backends == "ATEN,TRITON"
+    assert inductor_config.coordinate_descent_tuning is True
+
+
+def test_force_large_dynamo_caches_raises_limits(monkeypatch, _restore_inductor_state):
+    _, _, _, dynamo_config = _restore_inductor_state
+    monkeypatch.setattr(utils, "_dynamo_compile_caches_forced", False)
+    if hasattr(dynamo_config, "cache_size_limit"):
+        dynamo_config.cache_size_limit = 1
+    dynamo_config.accumulated_cache_size_limit = 1
+
+    utils.force_large_dynamo_compile_caches()
+
+    if hasattr(dynamo_config, "cache_size_limit"):
+        assert dynamo_config.cache_size_limit >= utils._DYNAMO_CACHE_SIZE_LIMIT
+    assert (
+        dynamo_config.accumulated_cache_size_limit
+        >= utils._DYNAMO_ACCUMULATED_CACHE_SIZE_LIMIT
+    )
+
+
+_cuda_bf16_ok = torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 8
+
+
+@pytest.mark.skipif(not _cuda_bf16_ok, reason="CUDA BF16 required")
+@pytest.mark.parametrize("has_bias", [False, True])
+def test_compile_path_matches_f_linear_cuda(has_bias, monkeypatch):
+    torch.manual_seed(0)
+    x = torch.randn(4, 64, dtype=torch.bfloat16, device="cuda")
+    w = torch.randn(128, 64, dtype=torch.bfloat16, device="cuda")
+    bias = torch.randn(128, dtype=torch.bfloat16, device="cuda") if has_bias else None
+    monkeypatch.setattr(
+        utils,
+        "_should_use_unquant_bf16_linear_torch_compile",
+        lambda x, w, b: True,
+    )
+
+    out = utils._torch_compile_bf16_unquantized_gemm(None, x, w, bias)
+
+    torch.testing.assert_close(
+        out,
+        torch.nn.functional.linear(x, w, bias),
+        atol=2e-2,
+        rtol=2e-2,
+    )

--- a/tests/model_executor/test_compile_bf16_linear_dispatch.py
+++ b/tests/model_executor/test_compile_bf16_linear_dispatch.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -170,6 +171,39 @@ def test_compile_failure_disables_fast_path(monkeypatch):
     assert utils._unquant_bf16_linear_torch_compile_disabled is True
 
 
+def test_set_inductor_cutlass_dir_uses_existing_dir(monkeypatch, tmp_path):
+    configured_dir = tmp_path / "configured-cutlass"
+    fallback_dir = tmp_path / "fallback-cutlass"
+    configured_dir.mkdir()
+    fallback_dir.mkdir()
+    inductor_config = SimpleNamespace(
+        cuda=SimpleNamespace(cutlass_dir=str(configured_dir)),
+        cutlass=SimpleNamespace(cutlass_dir="unchanged"),
+    )
+    monkeypatch.setattr(utils, "_INDUCTOR_CUTLASS_DIR_FALLBACKS", (fallback_dir,))
+
+    utils._set_inductor_cutlass_dir_if_needed(inductor_config)
+
+    assert inductor_config.cuda.cutlass_dir == str(configured_dir)
+    assert inductor_config.cutlass.cutlass_dir == "unchanged"
+
+
+def test_set_inductor_cutlass_dir_falls_back(monkeypatch, tmp_path):
+    fallback_dir = tmp_path / "cutlass-src"
+    fallback_dir.mkdir()
+    inductor_config = SimpleNamespace(
+        cuda=SimpleNamespace(cutlass_dir=str(tmp_path / "missing")),
+        cutlass=SimpleNamespace(cutlass_dir=str(tmp_path / "missing")),
+    )
+    monkeypatch.setattr(utils, "_INDUCTOR_CUTLASS_DIR_FALLBACKS", (fallback_dir,))
+
+    utils._set_inductor_cutlass_dir_if_needed(inductor_config)
+
+    resolved_fallback = str(fallback_dir.resolve())
+    assert inductor_config.cuda.cutlass_dir == resolved_fallback
+    assert inductor_config.cutlass.cutlass_dir == resolved_fallback
+
+
 @pytest.fixture
 def _restore_inductor_state():
     pytest.importorskip("torch._inductor.utils")
@@ -180,6 +214,9 @@ def _restore_inductor_state():
     import torch._inductor.utils as inductor_utils
     from torch._inductor.codegen.cuda import cuda_env
 
+    missing = object()
+    cuda_config = getattr(inductor_config, "cuda", None)
+    cutlass_config = getattr(inductor_config, "cutlass", None)
     originals = {
         "is_big_gpu": inductor_utils.is_big_gpu,
         "is_datacenter_blackwell_arch": cuda_env.is_datacenter_blackwell_arch,
@@ -187,6 +224,8 @@ def _restore_inductor_state():
         "max_autotune_gemm": inductor_config.max_autotune_gemm,
         "max_autotune_gemm_backends": inductor_config.max_autotune_gemm_backends,
         "coordinate_descent_tuning": inductor_config.coordinate_descent_tuning,
+        "cuda_cutlass_dir": getattr(cuda_config, "cutlass_dir", missing),
+        "cutlass_cutlass_dir": getattr(cutlass_config, "cutlass_dir", missing),
         "cache_size_limit": getattr(dynamo_config, "cache_size_limit", None),
         "accumulated_cache_size_limit": getattr(
             dynamo_config, "accumulated_cache_size_limit", None
@@ -199,6 +238,10 @@ def _restore_inductor_state():
     inductor_config.max_autotune_gemm = originals["max_autotune_gemm"]
     inductor_config.max_autotune_gemm_backends = originals["max_autotune_gemm_backends"]
     inductor_config.coordinate_descent_tuning = originals["coordinate_descent_tuning"]
+    if originals["cuda_cutlass_dir"] is not missing:
+        inductor_config.cuda.cutlass_dir = originals["cuda_cutlass_dir"]
+    if originals["cutlass_cutlass_dir"] is not missing:
+        inductor_config.cutlass.cutlass_dir = originals["cutlass_cutlass_dir"]
     if originals["cache_size_limit"] is not None:
         dynamo_config.cache_size_limit = originals["cache_size_limit"]
     if originals["accumulated_cache_size_limit"] is not None:

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -129,6 +129,7 @@ if TYPE_CHECKING:
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = True
     VLLM_LOG_BATCHSIZE_INTERVAL: float = -1
     VLLM_DISABLE_COMPILE_CACHE: bool = False
+    VLLM_ENABLE_UNQUANT_BF16_LINEAR_TORCH_COMPILE: bool = False
     VLLM_USE_LAYERNAME: bool = True
     Q_SCALE_CONSTANT: int = 200
     K_SCALE_CONSTANT: int = 200
@@ -1106,6 +1107,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
         os.getenv("VLLM_LOG_BATCHSIZE_INTERVAL", "-1")
     ),
     "VLLM_DISABLE_COMPILE_CACHE": disable_compile_cache,
+    # If set, route CUDA BF16 unquantized linear layers through a local
+    # torch.compile wrapper with max-autotune enabled for each exact shape.
+    "VLLM_ENABLE_UNQUANT_BF16_LINEAR_TORCH_COMPILE": lambda: bool(
+        int(os.getenv("VLLM_ENABLE_UNQUANT_BF16_LINEAR_TORCH_COMPILE", "0"))
+    ),
     # If set to "0", disable LayerName opaque type for layer_name
     # parameters in custom ops.  Defaults to enabled on torch >= 2.11.
     "VLLM_USE_LAYERNAME": lambda: bool(int(os.getenv("VLLM_USE_LAYERNAME", "1"))),

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Utility methods for model layers."""
 
+import contextlib
+import itertools
 from collections.abc import Callable
 
 import torch
@@ -87,6 +89,292 @@ def apply_penalties(
     logits -= frequency_penalties.unsqueeze(dim=1) * output_bin_counts
     logits -= presence_penalties.unsqueeze(dim=1) * output_mask
     return logits
+
+
+_DYNAMO_CACHE_SIZE_LIMIT = 65536
+_DYNAMO_ACCUMULATED_CACHE_SIZE_LIMIT = 1048576
+
+_inductor_max_autotune_gemm_forced = False
+_dynamo_compile_caches_forced = False
+_unquant_bf16_linear_cache: dict[tuple, Callable] = {}
+_unquant_bf16_linear_id_gen = itertools.count()
+_unquant_bf16_linear_capture_safe_keys: set[tuple] = set()
+_unquant_bf16_linear_torch_compile_configured = False
+_unquant_bf16_linear_torch_compile_disabled = False
+
+
+def force_large_dynamo_compile_caches() -> None:
+    """Raise Dynamo cache limits for many per-shape compiled linear kernels."""
+    global _dynamo_compile_caches_forced
+    if _dynamo_compile_caches_forced:
+        return
+    _dynamo_compile_caches_forced = True
+
+    try:
+        import torch._dynamo.config as dynamo_config
+    except Exception:
+        logger.warning(
+            "torch._dynamo.config could not be imported; "
+            "leaving Dynamo cache limits untouched.",
+            exc_info=True,
+        )
+        return
+
+    if hasattr(dynamo_config, "cache_size_limit"):
+        dynamo_config.cache_size_limit = max(
+            dynamo_config.cache_size_limit,
+            _DYNAMO_CACHE_SIZE_LIMIT,
+        )
+    dynamo_config.accumulated_cache_size_limit = max(
+        getattr(dynamo_config, "accumulated_cache_size_limit", 0),
+        _DYNAMO_ACCUMULATED_CACHE_SIZE_LIMIT,
+    )
+    if hasattr(dynamo_config, "recompile_limit"):
+        dynamo_config.recompile_limit = max(
+            dynamo_config.recompile_limit,
+            _DYNAMO_CACHE_SIZE_LIMIT,
+        )
+    if hasattr(dynamo_config, "accumulated_recompile_limit"):
+        dynamo_config.accumulated_recompile_limit = max(
+            dynamo_config.accumulated_recompile_limit,
+            _DYNAMO_ACCUMULATED_CACHE_SIZE_LIMIT,
+        )
+    if hasattr(dynamo_config, "fail_on_recompile_limit_hit"):
+        dynamo_config.fail_on_recompile_limit_hit = False
+    if hasattr(dynamo_config, "fail_on_cache_limit_hit"):
+        dynamo_config.fail_on_cache_limit_hit = False
+
+
+def force_inductor_max_autotune_gemm_on_small_gpus() -> None:
+    """Enable inductor GEMM autotuning for the BF16 linear compile path."""
+    global _inductor_max_autotune_gemm_forced
+    if _inductor_max_autotune_gemm_forced:
+        return
+    _inductor_max_autotune_gemm_forced = True
+
+    force_large_dynamo_compile_caches()
+
+    try:
+        import torch._inductor.config as inductor_config
+        import torch._inductor.utils as inductor_utils
+    except Exception:
+        logger.warning(
+            "torch._inductor could not be imported; leaving inductor config untouched.",
+            exc_info=True,
+        )
+        return
+
+    original_big_gpu = getattr(inductor_utils, "is_big_gpu", None)
+    if original_big_gpu is not None and not getattr(
+        original_big_gpu, "__vllm_big_gpu_override__", False
+    ):
+
+        def _forced_big_gpu(*args, **kwargs) -> bool:
+            return True
+
+        _forced_big_gpu.__vllm_big_gpu_override__ = True
+        inductor_utils.is_big_gpu = _forced_big_gpu
+        cache_clear = getattr(original_big_gpu, "cache_clear", None)
+        if callable(cache_clear):
+            with contextlib.suppress(Exception):
+                cache_clear()
+
+    try:
+        from torch._inductor.codegen.cuda import cuda_env
+
+        original_blackwell = getattr(cuda_env, "is_datacenter_blackwell_arch", None)
+        if original_blackwell is not None and not getattr(
+            original_blackwell, "__vllm_blackwell_family_override__", False
+        ):
+
+            def _forced_blackwell_family_arch() -> bool:
+                if original_blackwell():
+                    return True
+                if torch.cuda.is_available():
+                    major, _ = torch.cuda.get_device_capability()
+                    return major >= 10
+                return False
+
+            _forced_blackwell_family_arch.__vllm_blackwell_family_override__ = True
+            cuda_env.is_datacenter_blackwell_arch = _forced_blackwell_family_arch
+            cache_clear = getattr(original_blackwell, "cache_clear", None)
+            if callable(cache_clear):
+                with contextlib.suppress(Exception):
+                    cache_clear()
+    except Exception:
+        logger.debug("Could not patch inductor Blackwell architecture helper.")
+
+    inductor_config.max_autotune = True
+    inductor_config.max_autotune_gemm = True
+    inductor_config.max_autotune_gemm_backends = "ATEN,TRITON"
+    inductor_config.coordinate_descent_tuning = True
+    if hasattr(inductor_config, "triton"):
+        inductor_config.triton.unique_kernel_names = True
+        if hasattr(inductor_config.triton, "enable_persistent_tma_matmul"):
+            inductor_config.triton.enable_persistent_tma_matmul = True
+    if hasattr(inductor_config, "fx_graph_cache"):
+        inductor_config.fx_graph_cache = True
+
+    if torch.cuda.is_available():
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+        torch.set_float32_matmul_precision("high")
+
+
+def _configure_unquant_bf16_linear_torch_compile_once() -> None:
+    global _unquant_bf16_linear_torch_compile_configured
+    if _unquant_bf16_linear_torch_compile_configured:
+        return
+
+    force_inductor_max_autotune_gemm_on_small_gpus()
+    _unquant_bf16_linear_torch_compile_configured = True
+
+
+def _unquant_bf16_linear_cache_key(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+) -> tuple:
+    return (
+        tuple(x.shape),
+        tuple(x.stride()),
+        x.dtype,
+        tuple(weight.shape),
+        tuple(weight.stride()),
+        weight.dtype,
+        None if bias is None else tuple(bias.shape),
+        None if bias is None else tuple(bias.stride()),
+        None if bias is None else bias.dtype,
+        x.device.type,
+        x.device.index,
+    )
+
+
+def _compile_unquant_bf16_linear_kernel(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+) -> Callable:
+    _configure_unquant_bf16_linear_torch_compile_once()
+    compile_id = next(_unquant_bf16_linear_id_gen)
+    name_suffix = f"_{compile_id}"
+
+    if bias is None:
+
+        def _linear_no_bias(x: torch.Tensor, weight: torch.Tensor) -> torch.Tensor:
+            return torch.nn.functional.linear(x, weight, None)
+
+        _linear_no_bias.__name__ += name_suffix
+        compiled = torch.compile(
+            _linear_no_bias,
+            fullgraph=True,
+            dynamic=False,
+            mode="max-autotune-no-cudagraphs",
+        )
+        compiled(x, weight)
+        return compiled
+
+    def _linear_with_bias(
+        x: torch.Tensor, weight: torch.Tensor, bias: torch.Tensor
+    ) -> torch.Tensor:
+        return torch.nn.functional.linear(x, weight, bias)
+
+    _linear_with_bias.__name__ += name_suffix
+    compiled = torch.compile(
+        _linear_with_bias,
+        fullgraph=True,
+        dynamic=False,
+        mode="max-autotune-no-cudagraphs",
+    )
+    compiled(x, weight, bias)
+    return compiled
+
+
+def _get_or_create_unquant_bf16_linear_kernel(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+    allow_new_compile: bool,
+) -> Callable | None:
+    key = _unquant_bf16_linear_cache_key(x, weight, bias)
+    compiled = _unquant_bf16_linear_cache.get(key)
+    if compiled is not None:
+        return compiled
+    if not allow_new_compile:
+        return None
+
+    compiled = _compile_unquant_bf16_linear_kernel(x, weight, bias)
+    _unquant_bf16_linear_cache[key] = compiled
+    return compiled
+
+
+def _should_use_unquant_bf16_linear_torch_compile(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+) -> bool:
+    if _unquant_bf16_linear_torch_compile_disabled:
+        return False
+    if torch._dynamo.is_compiling():
+        return False
+    if not x.is_cuda:
+        return False
+    if x.dtype != torch.bfloat16 or weight.dtype != torch.bfloat16:
+        return False
+    if bias is not None and bias.dtype != torch.bfloat16:
+        return False
+    return x.is_contiguous()
+
+
+def _apply_unquant_bf16_linear_torch_compile(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None,
+) -> torch.Tensor | None:
+    global _unquant_bf16_linear_torch_compile_disabled
+
+    key = _unquant_bf16_linear_cache_key(x, weight, bias)
+    is_capturing = torch.cuda.is_current_stream_capturing()
+    if is_capturing and key not in _unquant_bf16_linear_capture_safe_keys:
+        return None
+
+    compiled = _get_or_create_unquant_bf16_linear_kernel(
+        x,
+        weight,
+        bias,
+        allow_new_compile=not is_capturing,
+    )
+    if compiled is None:
+        return None
+
+    try:
+        output = compiled(x, weight) if bias is None else compiled(x, weight, bias)
+    except Exception:
+        if is_capturing:
+            return None
+        logger.warning(
+            "Disabling compiled BF16 linear fast path after torch.compile failure.",
+            exc_info=True,
+        )
+        _unquant_bf16_linear_torch_compile_disabled = True
+        return None
+
+    if not is_capturing:
+        _unquant_bf16_linear_capture_safe_keys.add(key)
+    return output
+
+
+def _torch_compile_bf16_unquantized_gemm(
+    layer: torch.nn.Module,
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    bias: torch.Tensor | None = None,
+):
+    if _should_use_unquant_bf16_linear_torch_compile(x, weight, bias):
+        output = _apply_unquant_bf16_linear_torch_compile(x, weight, bias)
+        if output is not None:
+            return output
+    return torch.nn.functional.linear(x, weight, bias)
 
 
 def default_unquantized_gemm(
@@ -311,5 +599,10 @@ def dispatch_unquantized_gemm() -> Callable[..., torch.Tensor]:
         return rocm_unquantized_gemm
     elif current_platform.is_cpu():
         return cpu_unquantized_gemm
+    elif (
+        envs.VLLM_ENABLE_UNQUANT_BF16_LINEAR_TORCH_COMPILE
+        and current_platform.is_cuda()
+    ):
+        return _torch_compile_bf16_unquantized_gemm
     else:
         return default_unquantized_gemm

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -98,6 +98,7 @@ _DYNAMO_ACCUMULATED_CACHE_SIZE_LIMIT = 1048576
 _inductor_max_autotune_gemm_forced = False
 _dynamo_compile_caches_forced = False
 _unquant_bf16_linear_cache: dict[tuple, Callable] = {}
+_unquant_bf16_linear_lock = threading.Lock()
 _unquant_bf16_linear_id_gen = itertools.count()
 _unquant_bf16_linear_capture_safe_keys: set[tuple] = set()
 _unquant_bf16_linear_torch_compile_configured = False

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -4,6 +4,7 @@
 
 import contextlib
 import itertools
+import threading
 from collections.abc import Callable
 
 import torch

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -6,6 +6,7 @@ import contextlib
 import itertools
 import threading
 from collections.abc import Callable
+from pathlib import Path
 
 import torch
 
@@ -94,6 +95,10 @@ def apply_penalties(
 
 _DYNAMO_CACHE_SIZE_LIMIT = 65536
 _DYNAMO_ACCUMULATED_CACHE_SIZE_LIMIT = 1048576
+_VLLM_ROOT = Path(__file__).resolve().parents[3]
+_INDUCTOR_CUTLASS_DIR_FALLBACKS = (
+    _VLLM_ROOT.parent / "pytorch" / "third_party" / "cutlass",
+)
 
 _inductor_max_autotune_gemm_forced = False
 _dynamo_compile_caches_forced = False
@@ -103,6 +108,30 @@ _unquant_bf16_linear_id_gen = itertools.count()
 _unquant_bf16_linear_capture_safe_keys: set[tuple] = set()
 _unquant_bf16_linear_torch_compile_configured = False
 _unquant_bf16_linear_torch_compile_disabled = False
+
+
+def _set_inductor_cutlass_dir_if_needed(inductor_config) -> None:
+    cuda_config = getattr(inductor_config, "cuda", None)
+    if cuda_config is None or not hasattr(cuda_config, "cutlass_dir"):
+        return
+
+    configured_cutlass_dir = getattr(cuda_config, "cutlass_dir", None)
+    if configured_cutlass_dir:
+        with contextlib.suppress(TypeError, OSError):
+            if Path(configured_cutlass_dir).exists():
+                return
+
+    for fallback in _INDUCTOR_CUTLASS_DIR_FALLBACKS:
+        if fallback.exists():
+            resolved_fallback = str(fallback.resolve())
+            cuda_config.cutlass_dir = resolved_fallback
+            cutlass_config = getattr(inductor_config, "cutlass", None)
+            if cutlass_config is not None and hasattr(cutlass_config, "cutlass_dir"):
+                cutlass_config.cutlass_dir = resolved_fallback
+            logger.info(
+                "Set inductor CUTLASS source directory to %s", resolved_fallback
+            )
+            return
 
 
 def force_large_dynamo_compile_caches() -> None:
@@ -221,6 +250,11 @@ def force_inductor_max_autotune_gemm_on_small_gpus() -> None:
         torch.backends.cuda.matmul.allow_tf32 = True
         torch.backends.cudnn.allow_tf32 = True
         torch.set_float32_matmul_precision("high")
+
+    # Ensure CUTLASS source dir is set so the inductor backend can find it.
+    # The default points to ../third_party/cutlass/ (developer source tree),
+    # which does not exist in pip-installed or container environments.
+    _set_inductor_cutlass_dir_if_needed(inductor_config)
 
 
 def _configure_unquant_bf16_linear_torch_compile_once() -> None:

--- a/vllm/model_executor/layers/utils.py
+++ b/vllm/model_executor/layers/utils.py
@@ -361,7 +361,8 @@ def _apply_unquant_bf16_linear_torch_compile(
         return None
 
     if not is_capturing:
-        _unquant_bf16_linear_capture_safe_keys.add(key)
+        with _unquant_bf16_linear_lock:
+            _unquant_bf16_linear_capture_safe_keys.add(key)
     return output
 
 


### PR DESCRIPTION
## Summary

Adds an opt-in BF16 unquantized linear fast path that wraps CUDA BF16 `F.linear` calls in a per-shape `torch.compile(..., mode="max-autotune-no-cudagraphs")` kernel.

The path is disabled by default and enabled with:

```bash
VLLM_ENABLE_UNQUANT_BF16_LINEAR_TORCH_COMPILE=1
```
Key changes:

- Add VLLM_ENABLE_UNQUANT_BF16_LINEAR_TORCH_COMPILE
- Route eligible CUDA BF16 unquantized linears through a local torch.compile wrapper
- Cache compiled kernels by exact tensor shape/stride/dtype/device
- Avoid compiling during CUDA graph capture; only reuse previously warmed shapes
- Patch relevant Inductor/Dynamo autotune and cache knobs lazily when the path is first used
- Add focused dispatch, predicate, cache, fallback, and config tests