### PR TITLE
Allow non-3 number of target hidden layers for Eagle-3 models

### DIFF
--- a/vllm/model_executor/models/deepseek_eagle3.py
+++ b/vllm/model_executor/models/deepseek_eagle3.py
@@ -199,9 +199,9 @@ class DeepseekV2Eagle3Model(nn.Module):
             ]
         )
 
-        num_aux_layers = len(
-            getattr(self.config, "eagle_aux_hidden_state_layer_ids", [])
-        ) or 3
+        num_aux_layers = (
+            len(getattr(self.config, "eagle_aux_hidden_state_layer_ids", [])) or 3
+        )
         if hasattr(self.config, "target_hidden_size"):
             fc_input_size = self.config.target_hidden_size * num_aux_layers
         else:

--- a/vllm/model_executor/models/deepseek_eagle3.py
+++ b/vllm/model_executor/models/deepseek_eagle3.py
@@ -199,11 +199,13 @@ class DeepseekV2Eagle3Model(nn.Module):
             ]
         )
 
-        # fc layer for combining auxiliary hidden states (3x hidden size input)
+        num_aux_layers = len(
+            getattr(self.config, "eagle_aux_hidden_state_layer_ids", [])
+        ) or 3
         if hasattr(self.config, "target_hidden_size"):
-            fc_input_size = self.config.target_hidden_size * 3
+            fc_input_size = self.config.target_hidden_size * num_aux_layers
         else:
-            fc_input_size = self.config.hidden_size * 3
+            fc_input_size = self.config.hidden_size * num_aux_layers
 
         self.fc = ReplicatedLinear(
             input_size=fc_input_size,

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -172,9 +172,9 @@ class LlamaModel(nn.Module):
             ]
         )
         if self.use_aux_hidden_state:
-            num_aux_layers = len(
-                getattr(self.config, "eagle_aux_hidden_state_layer_ids", [])
-            ) or 3
+            num_aux_layers = (
+                len(getattr(self.config, "eagle_aux_hidden_state_layer_ids", [])) or 3
+            )
             if hasattr(self.config, "target_hidden_size"):
                 fc_input_size = self.config.target_hidden_size * num_aux_layers
             else:
@@ -311,12 +311,18 @@ class Eagle3LlamaForCausalLM(LlamaForCausalLM):
         self.use_parallel_drafting = vllm_config.speculative_config.parallel_drafting
 
         if self.use_parallel_drafting:
+            if self.model.use_aux_hidden_state:
+                num_aux_layers = (
+                    len(getattr(self.config, "eagle_aux_hidden_state_layer_ids", []))
+                    or 3
+                )
+            else:
+                num_aux_layers = 1
             self.register_buffer(
                 "mask_hidden",
                 torch.zeros(
                     1,
-                    (3 if self.model.use_aux_hidden_state else 1)
-                    * self.config.hidden_size,
+                    num_aux_layers * self.config.hidden_size,
                 ),
                 persistent=False,
             )

--- a/vllm/model_executor/models/llama_eagle3.py
+++ b/vllm/model_executor/models/llama_eagle3.py
@@ -172,10 +172,13 @@ class LlamaModel(nn.Module):
             ]
         )
         if self.use_aux_hidden_state:
+            num_aux_layers = len(
+                getattr(self.config, "eagle_aux_hidden_state_layer_ids", [])
+            ) or 3
             if hasattr(self.config, "target_hidden_size"):
-                fc_input_size = self.config.target_hidden_size * 3
+                fc_input_size = self.config.target_hidden_size * num_aux_layers
             else:
-                fc_input_size = self.config.hidden_size * 3
+                fc_input_size = self.config.hidden_size * num_aux_layers
             if self.norm_before_fc:
                 self.input_norm = RMSNorm(
                     fc_input_size,


### PR DESCRIPTION



## Purpose
Currently Eagle-3 models are required to use 3 target hidden states as input. Although there is already support for specify non-default layer ids, the requirement that there are 3 layers is hardcoded into the FC layer initialization.

This pr allows Eagle-3 models with other numbers of target hidden states to be served by vLLM.

## Test Plan

I've tested this locally with a Eagle-3 model with 4 layers. 

## Test Result

The model successfully loads and serves on vLLM, and handles requests without crashing. 

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

