### PR TITLE
fix: zero DP padding via torch.where to prevent NaN propagation into MoE

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -234,6 +234,7 @@ if TYPE_CHECKING:
     VLLM_DEEPEP_HIGH_THROUGHPUT_FORCE_INTRA_NODE: bool = False
     VLLM_DEEPEP_LOW_LATENCY_USE_MNNVL: bool = False
     VLLM_DBO_COMM_SMS: int = 20
+    VLLM_DP_PADDING_NAN_MASK: bool = False
     VLLM_PATTERN_MATCH_DEBUG: str | None = None
     VLLM_DEBUG_DUMP_PATH: str | None = None
     VLLM_ENABLE_INDUCTOR_MAX_AUTOTUNE: bool = True
@@ -1623,6 +1624,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # The number of SMs to allocate for communication kernels when running DBO
     # the rest of the SMs on the device will be allocated to compute
     "VLLM_DBO_COMM_SMS": lambda: int(os.getenv("VLLM_DBO_COMM_SMS", "20")),
+    # Zero out DP padding tokens before MoE to prevent NaN propagation
+    # from attention into expert routing / EP dispatch.
+    "VLLM_DP_PADDING_NAN_MASK": lambda: bool(
+        int(os.getenv("VLLM_DP_PADDING_NAN_MASK", "0"))
+    ),
     # Enable max_autotune & coordinate_descent_tuning in inductor_config
     # to compile static shapes passed from compile_sizes in compilation_config
     # If set to 1, enable max_autotune; By default, this is enabled (1)

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -352,9 +352,23 @@ class DeepseekV2MoE(nn.Module):
                 self.gate.e_score_correction_bias.data.to(self.gate.out_dtype)
             )
 
+        # DP padding mask — assigned by model runner when DP > 1.
+        # Pre-allocated buffer of shape (max_num_tokens, 1); contents
+        # updated each step (1.0 for real tokens, 0.0 for padding).
+        self._dp_padding_mask: torch.Tensor | None = None
+
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:
         num_tokens, hidden_dim = hidden_states.shape
         hidden_states = hidden_states.view(-1, hidden_dim)
+
+        # Zero out DP padding tokens so they don't contaminate real
+        # tokens through expert routing / EP all-to-all dispatch.
+        # Use torch.where instead of multiplication because NaN * 0 = NaN
+        # (IEEE 754), so padding tokens with NaN from attention would
+        # propagate into expert kernels and corrupt FP4 block scales.
+        if self._dp_padding_mask is not None:
+            mask = self._dp_padding_mask[:num_tokens].bool()
+            hidden_states = torch.where(mask, hidden_states, 0.0)
 
         # Chunk the hidden states so they aren't replicated across TP ranks.
         # This avoids duplicate computation in self.experts.

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -4952,7 +4952,10 @@ class GPUModelRunner(
                 )
 
         # Allocate DP padding mask for MoE layers when using data parallelism.
-        if self.parallel_config.data_parallel_size > 1:
+        if (
+            self.parallel_config.data_parallel_size > 1
+            and envs.VLLM_DP_PADDING_NAN_MASK
+        ):
             self._setup_dp_padding_mask()
 
         get_offloader().post_init()
@@ -4964,8 +4967,8 @@ class GPUModelRunner(
         from vllm.model_executor.models.deepseek_v2 import DeepseekV2MoE
 
         self._dp_padding_mask = torch.ones(
-            self.max_num_tokens, 1,
-            dtype=self.dtype, device=self.device)
+            self.max_num_tokens, 1, dtype=self.dtype, device=self.device
+        )
 
         assigned = 0
         for module in self.model.modules():
@@ -4974,8 +4977,7 @@ class GPUModelRunner(
                 assigned += 1
 
         if assigned > 0:
-            logger.info(
-                "DP padding mask assigned to %d MoE layers", assigned)
+            logger.info("DP padding mask assigned to %d MoE layers", assigned)
         else:
             # No DeepseekV2MoE modules found — not a DeepSeek model.
             self._dp_padding_mask = None

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -491,6 +491,11 @@ class GPUModelRunner(
         Will be lazily initialized when the model is loaded.
         """
 
+        # DP padding mask — zeros out padding tokens before MoE to prevent
+        # contamination of real tokens through expert routing / EP dispatch.
+        # Shape (max_num_tokens, 1), filled each step in execute_model.
+        self._dp_padding_mask: torch.Tensor | None = None
+
         # Lazy initializations
         # self.model: nn.Module  # Set after load_model
         # Initialize in initialize_kv_cache
@@ -4026,6 +4031,11 @@ class GPUModelRunner(
             self.model_config.is_encoder_decoder and num_encoder_reqs > 0
         )
 
+        # Update DP padding mask: 1.0 for real tokens, 0.0 for padding.
+        if self._dp_padding_mask is not None:
+            self._dp_padding_mask[:num_tokens_unpadded].fill_(1.0)
+            self._dp_padding_mask[num_tokens_unpadded:].fill_(0.0)
+
         # Run the model.
         # Use persistent buffers for CUDA graphs.
         # When spec decode is enabled, defer connector finalization
@@ -4941,7 +4951,34 @@ class GPUModelRunner(
                     self.model, self.vllm_config, CUDAGraphMode.NONE, self.device
                 )
 
+        # Allocate DP padding mask for MoE layers when using data parallelism.
+        if self.parallel_config.data_parallel_size > 1:
+            self._setup_dp_padding_mask()
+
         get_offloader().post_init()
+
+    def _setup_dp_padding_mask(self) -> None:
+        """Pre-allocate a DP padding mask and assign it to all DeepseekV2MoE
+        modules. The mask is filled each step in execute_model: 1.0 for real
+        tokens, 0.0 for DP padding tokens."""
+        from vllm.model_executor.models.deepseek_v2 import DeepseekV2MoE
+
+        self._dp_padding_mask = torch.ones(
+            self.max_num_tokens, 1,
+            dtype=self.dtype, device=self.device)
+
+        assigned = 0
+        for module in self.model.modules():
+            if isinstance(module, DeepseekV2MoE):
+                module._dp_padding_mask = self._dp_padding_mask
+                assigned += 1
+
+        if assigned > 0:
+            logger.info(
+                "DP padding mask assigned to %d MoE layers", assigned)
+        else:
+            # No DeepseekV2MoE modules found — not a DeepSeek model.
+            self._dp_padding_mask = None
 
     def _get_eagle3_aux_layers_from_config(self) -> tuple[int, ...] | None:
         """Extract Eagle3 auxiliary layer indices from speculative config.
@@ -5521,6 +5558,11 @@ class GPUModelRunner(
                 num_tokens_padded = ubatch_slices_padded[0].num_tokens
                 if num_tokens_across_dp is not None:
                     num_tokens_across_dp[:] = num_tokens_padded
+
+            # During dummy/capture runs, mark all tokens as real (no padding).
+            if self._dp_padding_mask is not None:
+                self._dp_padding_mask[:num_tokens_padded].fill_(1.0)
+                self._dp_padding_mask[num_tokens_padded:].fill_(0.0)
 
             with (
                 self.maybe_randomize_inputs(input_ids, inputs_embeds),


### PR DESCRIPTION
## Summary

- Padding tokens from DP coordination can carry NaN from attention into expert routing and EP all-to-all dispatch, contaminating real tokens. This adds a pre-allocated DP padding mask (`shape [max_num_tokens, 1]`) that is filled each step (`1.0` real, `0.0` padding) and applied in `DeepseekV2MoE` before the gate/experts.
- Uses `torch.where(mask, hidden_states, 0.0)` instead of multiplication because IEEE 754 says `NaN * 0 = NaN` — multiplication cannot zero out NaN values. `torch.where` correctly replaces NaN with `0.0` in padding positions, preventing FP4 block scale corruption in DeepEP warp-level reductions.
- Gated behind `VLLM_DP_PADDING_NAN_MASK` environment variable (default disabled) so it's opt-in.

## Test plan

- [ ] Run DeepSeek-V2/V3 inference with `DP > 1` and `VLLM_DP_PADDING_NAN_MASK=1`, verify no NaN propagation from padding tokens into MoE expert outputs
- [ ] Run without the flag (`VLLM_DP_PADDING_NAN_MASK=0` or unset), verify behavior is unchanged (no regression)
- [ ] Verify CUDA graph capture/replay works correctly with the mask (dummy runs fill mask properly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)