### PR TITLE
fix(tokenizer): guard reasoning_effort for Mistral tokenizer

### DIFF
--- a/tests/tokenizers_/test_mistral.py
+++ b/tests/tokenizers_/test_mistral.py
@@ -1192,6 +1192,22 @@ class TestMistralTokenizer:
                 continue_final_message=False,
             )
 
+    @pytest.mark.parametrize("reasoning_effort", [None, "none", "high"])
+    def test_apply_chat_template_reasoning_effort(
+        self,
+        mistral_tokenizer: MistralTokenizer,
+        reasoning_effort: str | None,
+    ):
+        messages = [{"role": "user", "content": "Hello world !"}]
+        result = mistral_tokenizer.apply_chat_template(
+            messages,
+            tools=[],
+            add_generation_prompt=True,
+            reasoning_effort=reasoning_effort,
+        )
+        assert isinstance(result, list)
+        assert all(isinstance(t, int) for t in result)
+
     @pytest.mark.parametrize(
         "skip_special_tokens,expected_tokens",
         (

--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -447,7 +447,9 @@ class MistralTokenizer(TokenizerLike):
         # NOTE: This is for backward compatibility.
         # Transformers should be passed arguments it knows.
         if self.version >= 15:
-            version_kwargs["reasoning_effort"] = kwargs.get("reasoning_effort")
+            _reasoning_effort = kwargs.get("reasoning_effort")
+            if _reasoning_effort is not None:
+                version_kwargs["reasoning_effort"] = _reasoning_effort
 
         messages, tools = _prepare_apply_chat_template_tools_and_messages(
             messages, tools, continue_final_message, add_generation_prompt

--- a/vllm/tokenizers/mistral.py
+++ b/vllm/tokenizers/mistral.py
@@ -448,7 +448,7 @@ class MistralTokenizer(TokenizerLike):
         # Transformers should be passed arguments it knows.
         if self.version >= 15:
             _reasoning_effort = kwargs.get("reasoning_effort")
-            if _reasoning_effort is not None:
+            if _reasoning_effort is not None and _reasoning_effort != "none":
                 version_kwargs["reasoning_effort"] = _reasoning_effort
 
         messages, tools = _prepare_apply_chat_template_tools_and_messages(


### PR DESCRIPTION
## Summary

Builds on #38448 by @marioiseli89 (cherry-picked) and adds a guard for the `reasoning_effort="none"` case.

- Cherry-picks @marioiseli89's fix from #38448: skip `reasoning_effort` when it is `None`
- Adds guard for `reasoning_effort="none"` — a valid `ReasoningEffort` enum value meaning "no reasoning effort" — which also must not be passed to `transformers`' `apply_chat_template` (it doesn't support the kwarg)
- Adds a parametrized test covering `None`, `"none"`, and `"high"` values

Without this fix, chat completions crash on Mistral models with tokenizer version >= 15 (e.g., Mistral-Small-4) whenever `reasoning_effort` is omitted or set to `"none"`.

Ref: #38560

## Test plan

- [x] `pre-commit run --all-files` passes on changed files
- [x] `pytest tests/tokenizers_/test_mistral.py::TestMistralTokenizer::test_apply_chat_template_reasoning_effort` — tests `None`, `"none"`, and `"high"` values against both `Mistral-7B-Instruct-v0.3` (version < 15) and `Magistral-Small-2509` (version >= 15, tekken)
- [ ] Buildkite CI (to be triggered)

## AI Assistance Disclosure

This PR was prepared with AI assistance (Claude). All changes reviewed and submitted by a human contributor.