### PR TITLE
expose flex block size for batch invariant mode

### DIFF
--- a/tests/v1/determinism/test_batch_invariance.py
+++ b/tests/v1/determinism/test_batch_invariance.py
@@ -18,24 +18,6 @@ import vllm.envs as envs
 from vllm import LLM, SamplingParams
 
 
-@pytest.mark.parametrize(
-    "block_m,block_n",
-    [(0, 16), (8, 16), (16, 7), (15, 16), (48, 16), (16, 0)],
-)
-def test_batch_invariant_block_size_validation(
-    block_m,
-    block_n,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    from vllm.v1.attention.backends.flex_attention import get_kernel_options
-
-    monkeypatch.setattr(envs, "VLLM_BATCH_INVARIANT", True)
-
-    dummy_query = torch.empty(1, 1, 64, dtype=torch.float16)
-    with pytest.raises(ValueError):
-        get_kernel_options(dummy_query, block_m, block_n, False)
-
-
 @skip_unsupported
 @pytest.mark.timeout(1000)
 @pytest.mark.parametrize(
@@ -167,7 +149,7 @@ def test_v1_generation_is_deterministic_across_batch_sizes_with_needle(
 )
 @pytest.mark.parametrize(
     "block_m,block_n",
-    [(16, 16), (32, 32), (16, 32)],
+    [(16, 16), (8, 16)],
 )
 def test_logprobs_bitwise_batch_invariance_bs1_vs_bsN(
     backend,
@@ -198,8 +180,8 @@ def test_logprobs_bitwise_batch_invariance_bs1_vs_bsN(
         gpu_memory_utilization=0.9,
         attention_config={
             "backend": backend,
-            "flex_batch_invariant_block_m": block_m,
-            "flex_batch_invariant_block_n": block_n,
+            "flex_attn_block_m": block_m,
+            "flex_attn_block_n": block_n,
         },
     )
 

--- a/tests/v1/determinism/test_batch_invariance.py
+++ b/tests/v1/determinism/test_batch_invariance.py
@@ -18,6 +18,24 @@ import vllm.envs as envs
 from vllm import LLM, SamplingParams
 
 
+@pytest.mark.parametrize(
+    "block_m,block_n",
+    [(0, 16), (8, 16), (16, 7), (15, 16), (48, 16), (16, 0)],
+)
+def test_batch_invariant_block_size_validation(
+    block_m,
+    block_n,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from vllm.v1.attention.backends.flex_attention import get_kernel_options
+
+    monkeypatch.setattr(envs, "VLLM_BATCH_INVARIANT", True)
+
+    dummy_query = torch.empty(1, 1, 64, dtype=torch.float16)
+    with pytest.raises(ValueError):
+        get_kernel_options(dummy_query, block_m, block_n, False)
+
+
 @skip_unsupported
 @pytest.mark.timeout(1000)
 @pytest.mark.parametrize(
@@ -147,8 +165,14 @@ def test_v1_generation_is_deterministic_across_batch_sizes_with_needle(
     "backend",
     BACKENDS,
 )
+@pytest.mark.parametrize(
+    "block_m,block_n",
+    [(16, 16), (32, 32), (16, 32)],
+)
 def test_logprobs_bitwise_batch_invariance_bs1_vs_bsN(
     backend,
+    block_m,
+    block_n,
 ):
     seed = int(os.getenv("VLLM_TEST_SEED", "12345"))
     random.seed(seed)
@@ -172,7 +196,11 @@ def test_logprobs_bitwise_batch_invariance_bs1_vs_bsN(
         max_model_len=8192,
         dtype="auto",  # not everything is supported
         gpu_memory_utilization=0.9,
-        attention_config={"backend": backend},
+        attention_config={
+            "backend": backend,
+            "flex_batch_invariant_block_m": block_m,
+            "flex_batch_invariant_block_n": block_n,
+        },
     )
 
     # Use more realistic prompts for better token generation

--- a/vllm/config/attention.py
+++ b/vllm/config/attention.py
@@ -67,13 +67,26 @@ class AttentionConfig:
     use_non_causal: bool = False
     """Whether to use non-causal (bidirectional) attention."""
 
-    flex_batch_invariant_block_m: int = 16
-    """BLOCK_M tile size for flex attention in batch-invariant mode.
-    Must be a power of 2 >= 16."""
+    flex_attn_block_m: int | None = None
+    """Triton kernel BLOCK_M tile size for flex attention.
+    Must be a power of 2 >= 16. If None and VLLM_BATCH_INVARIANT=1,
+    defaults to 16."""
 
-    flex_batch_invariant_block_n: int = 16
-    """BLOCK_N tile size for flex attention in batch-invariant mode.
-    Must be a power of 2 >= 16."""
+    flex_attn_block_n: int | None = None
+    """Triton kernel BLOCK_N tile size for flex attention.
+    Must be a power of 2 >= 16. If None and VLLM_BATCH_INVARIANT=1,
+    defaults to 16."""
+
+    flex_attn_q_block_size: int | None = None
+    """Logical Q block size for the flex attention block mask.
+    Must be a power of 2 and divisible by flex_attn_block_m.
+    If None, uses the default (16 on PyTorch >= 2.9, 128 otherwise)."""
+
+    flex_attn_kv_block_size: int | None = None
+    """Logical KV block size for the flex attention block mask.
+    Must be a power of 2 and divisible by flex_attn_block_n.
+    If None, uses the default (kv_cache_block_size on PyTorch >= 2.9,
+    128 otherwise)."""
 
     def compute_hash(self) -> str:
         """

--- a/vllm/config/attention.py
+++ b/vllm/config/attention.py
@@ -67,6 +67,14 @@ class AttentionConfig:
     use_non_causal: bool = False
     """Whether to use non-causal (bidirectional) attention."""
 
+    flex_batch_invariant_block_m: int = 16
+    """BLOCK_M tile size for flex attention in batch-invariant mode.
+    Must be a power of 2 >= 16."""
+
+    flex_batch_invariant_block_n: int = 16
+    """BLOCK_N tile size for flex attention in batch-invariant mode.
+    Must be a power of 2 >= 16."""
+
     def compute_hash(self) -> str:
         """
         Provide a hash that uniquely identifies all the configs

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -341,6 +341,29 @@ class Attention(nn.Module, AttentionLayerBase):
                 f"but got {self.attn_backend.get_name()}."
             )
 
+        if self.attn_backend.get_name() == "FLEX_ATTENTION":
+            block_m = vllm_config.attention_config.flex_attn_block_m
+            block_n = vllm_config.attention_config.flex_attn_block_n
+
+            if envs.VLLM_BATCH_INVARIANT and cache_config is not None:
+                if block_m is not None and block_m > cache_config.block_size:
+                    raise ValueError(
+                        f"flex_attn_block_m ({block_m}) must be "
+                        f"<= cache block size ({cache_config.block_size}) for "
+                        f"batch invariance"
+                    )
+                if block_n is not None and block_n > cache_config.block_size:
+                    raise ValueError(
+                        f"flex_attn_block_n ({block_n}) must be "
+                        f"<= cache block size ({cache_config.block_size}) for "
+                        f"batch invariance"
+                    )
+
+            if block_m is not None:
+                extra_impl_args.setdefault("block_m", block_m)
+            if block_n is not None:
+                extra_impl_args.setdefault("block_n", block_n)
+
         impl_cls = self.attn_backend.get_impl_cls()
         self.impl = impl_cls(  # type: ignore[assignment]  # impl_cls always returns an AttentionImpl subclass
             num_heads,

--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -24,7 +24,6 @@ from torch.nn.attention.flex_attention import (
 import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
-from vllm.config.vllm import get_current_vllm_config_or_none
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.math_utils import cdiv
@@ -770,8 +769,15 @@ class FlexAttentionMetadataBuilder(AttentionMetadataBuilder[FlexAttentionMetadat
         self.kv_cache_spec = kv_cache_spec
         supports_small_blocks = is_torch_equal_or_newer("2.9.0.dev0")
         self.direct_build: bool = supports_small_blocks
-        self.q_block_size: int = 16 if supports_small_blocks else 128
-        self.kv_block_size: int = self.block_size if supports_small_blocks else 128
+
+        self.q_block_size, self.kv_block_size = self._get_block_sizes(
+            vllm_config.attention_config,
+            supports_small_blocks,
+            self.block_size,
+        )
+
+        if self.direct_build and self.kv_block_size != self.block_size:
+            self.direct_build = False
 
         self.max_model_len = self.model_config.max_model_len
         max_num_seqs = vllm_config.scheduler_config.max_num_seqs
@@ -792,6 +798,39 @@ class FlexAttentionMetadataBuilder(AttentionMetadataBuilder[FlexAttentionMetadat
         # initialize later when we can access block_table
         self.persistent_physical_to_logical = None
         self.persistent_kv_indices = None
+
+    @staticmethod
+    def _get_block_sizes(
+        attn_cfg,
+        supports_small_blocks: bool,
+        cache_block_size: int,
+    ) -> tuple[int, int]:
+        q_block_size = 16 if supports_small_blocks else 128
+        kv_block_size = cache_block_size if supports_small_blocks else 128
+
+        q_block_size = attn_cfg.flex_attn_q_block_size or q_block_size
+        if (q_block_size & (q_block_size - 1)) != 0 or (
+            attn_cfg.flex_attn_block_m is not None
+            and q_block_size % attn_cfg.flex_attn_block_m != 0
+        ):
+            raise ValueError(
+                f"flex_attn_q_block_size must be a power of 2 "
+                f"and divisible by flex_attn_block_m, got "
+                f"{q_block_size}, {attn_cfg.flex_attn_block_m}"
+            )
+
+        kv_block_size = attn_cfg.flex_attn_kv_block_size or kv_block_size
+        if (kv_block_size & (kv_block_size - 1)) != 0 or (
+            attn_cfg.flex_attn_block_n is not None
+            and kv_block_size % attn_cfg.flex_attn_block_n != 0
+        ):
+            raise ValueError(
+                f"flex_attn_kv_block_size must be a power of 2 "
+                f"and divisible by flex_attn_block_n, got "
+                f"{kv_block_size}, {attn_cfg.flex_attn_block_n}"
+            )
+
+        return q_block_size, kv_block_size
 
     def build_for_cudagraph_capture(
         self, common_attn_metadata: CommonAttentionMetadata
@@ -947,6 +986,8 @@ class FlexAttentionImpl(AttentionImpl):
         logits_soft_cap: float | None = None,
         attn_type: AttentionType = AttentionType.DECODER,
         kv_sharing_target_layer_name: str | None = None,
+        block_m: int | None = None,
+        block_n: int | None = None,
         **kwargs,
     ) -> None:
         self.num_heads = num_heads
@@ -987,14 +1028,13 @@ class FlexAttentionImpl(AttentionImpl):
                 "FlexAttention does not support quantized kv-cache. Yet"
             )
 
-        vllm_config = get_current_vllm_config_or_none()
-        if vllm_config is not None:
-            attn_cfg = vllm_config.attention_config
-            self.batch_invariant_block_m = attn_cfg.flex_batch_invariant_block_m
-            self.batch_invariant_block_n = attn_cfg.flex_batch_invariant_block_n
-        else:
-            self.batch_invariant_block_m = 16
-            self.batch_invariant_block_n = 16
+        self.block_m = 16 if envs.VLLM_BATCH_INVARIANT else None
+        self.block_n = 16 if envs.VLLM_BATCH_INVARIANT else None
+
+        if block_m is not None:
+            self.block_m = block_m
+        if block_n is not None:
+            self.block_n = block_n
 
     @staticmethod
     def view_as_4d(tensor: torch.Tensor) -> torch.Tensor:
@@ -1138,16 +1178,16 @@ class FlexAttentionImpl(AttentionImpl):
         assert attn_metadata.block_mask is not None
         block_m, block_n = attn_metadata.block_mask.BLOCK_SIZE
 
-        if envs.VLLM_BATCH_INVARIANT:
-            block_m = self.batch_invariant_block_m
-            block_n = self.batch_invariant_block_n
-
         kernel_options = get_kernel_options(
-            query,
-            block_m,
-            block_n,
-            attn_metadata.direct_build,
+            query, block_m, block_n, attn_metadata.direct_build
         )
+
+        if self.block_m is not None:
+            kernel_options["BLOCK_M"] = self.block_m
+        if self.block_n is not None:
+            kernel_options["BLOCK_N"] = self.block_n
+        if envs.VLLM_BATCH_INVARIANT:
+            kernel_options["IS_DIVISIBLE"] = False
         out = flex_attention_compiled(
             query,
             key_tensor,
@@ -1187,22 +1227,6 @@ def get_kernel_options(
             return block_size
         return candidate
 
-    if envs.VLLM_BATCH_INVARIANT:
-        if (
-            block_m < 16
-            or (block_m & (block_m - 1)) != 0
-            or block_n < 16
-            or (block_n & (block_n - 1)) != 0
-        ):
-            raise ValueError(
-                "flex_batch_invariant_block_m and "
-                "flex_batch_invariant_block_n must be a power of 2 >= 16, "
-                f"got {block_m}, {block_n}"
-            )
-        kernel_options["BLOCK_M"] = block_m
-        kernel_options["BLOCK_N"] = block_n
-        kernel_options["IS_DIVISIBLE"] = False
-        return kernel_options
     if use_direct_build:
         kernel_options["BLOCK_M"] = block_m
         kernel_options["BLOCK_N"] = block_n

--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -24,6 +24,7 @@ from torch.nn.attention.flex_attention import (
 import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.config.cache import CacheDType
+from vllm.config.vllm import get_current_vllm_config_or_none
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.math_utils import cdiv
@@ -986,6 +987,15 @@ class FlexAttentionImpl(AttentionImpl):
                 "FlexAttention does not support quantized kv-cache. Yet"
             )
 
+        vllm_config = get_current_vllm_config_or_none()
+        if vllm_config is not None:
+            attn_cfg = vllm_config.attention_config
+            self.batch_invariant_block_m = attn_cfg.flex_batch_invariant_block_m
+            self.batch_invariant_block_n = attn_cfg.flex_batch_invariant_block_n
+        else:
+            self.batch_invariant_block_m = 16
+            self.batch_invariant_block_n = 16
+
     @staticmethod
     def view_as_4d(tensor: torch.Tensor) -> torch.Tensor:
         """View a 3d tensor as 4D."""
@@ -1128,8 +1138,15 @@ class FlexAttentionImpl(AttentionImpl):
         assert attn_metadata.block_mask is not None
         block_m, block_n = attn_metadata.block_mask.BLOCK_SIZE
 
+        if envs.VLLM_BATCH_INVARIANT:
+            block_m = self.batch_invariant_block_m
+            block_n = self.batch_invariant_block_n
+
         kernel_options = get_kernel_options(
-            query, block_m, block_n, attn_metadata.direct_build
+            query,
+            block_m,
+            block_n,
+            attn_metadata.direct_build,
         )
         out = flex_attention_compiled(
             query,
@@ -1171,8 +1188,19 @@ def get_kernel_options(
         return candidate
 
     if envs.VLLM_BATCH_INVARIANT:
-        kernel_options["BLOCK_M"] = 16
-        kernel_options["BLOCK_N"] = 16
+        if (
+            block_m < 16
+            or (block_m & (block_m - 1)) != 0
+            or block_n < 16
+            or (block_n & (block_n - 1)) != 0
+        ):
+            raise ValueError(
+                "flex_batch_invariant_block_m and "
+                "flex_batch_invariant_block_n must be a power of 2 >= 16, "
+                f"got {block_m}, {block_n}"
+            )
+        kernel_options["BLOCK_M"] = block_m
+        kernel_options["BLOCK_N"] = block_n
         kernel_options["IS_DIVISIBLE"] = False
         return kernel_options
     if use_direct_build:


### PR DESCRIPTION
under VLLM_BATCH_INVARIANT_MODE, expose Flex Attention block sizes through additional env vars so that the user can set them. previously this was hardcoded to 16 (default with this PR is still 16).

testing: 
parametrized block size N/M in batch invariant test and also added test for invalid numbers (ie not powers of 2).