### PR TITLE
[Bugfix][Gemma4] Fix k_eq_v full-attention projection layout

### DIFF
--- a/tests/model_executor/models/test_gemma4.py
+++ b/tests/model_executor/models/test_gemma4.py
@@ -1,0 +1,130 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+
+from vllm.model_executor.models import gemma4 as gemma4_mod
+
+
+class _FakeColumnParallelLinear(nn.Module):
+
+    def __init__(
+        self,
+        _hidden_size: int,
+        output_size: int,
+        **_kwargs,
+    ) -> None:
+        super().__init__()
+        self.output_size = output_size
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, None]:
+        shape = (*x.shape[:-1], self.output_size)
+        return torch.zeros(shape, dtype=x.dtype, device=x.device), None
+
+
+class _FakeQKVParallelLinear(nn.Module):
+    forward_calls = 0
+
+    def __init__(
+        self,
+        _hidden_size: int,
+        head_size: int,
+        total_num_heads: int,
+        total_num_kv_heads: int,
+        **_kwargs,
+    ) -> None:
+        super().__init__()
+        self.output_size = (
+            total_num_heads * head_size
+            + 2 * total_num_kv_heads * head_size
+        )
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, None]:
+        type(self).forward_calls += 1
+        shape = (*x.shape[:-1], self.output_size)
+        return torch.zeros(shape, dtype=x.dtype, device=x.device), None
+
+
+class _FakeRowParallelLinear(nn.Module):
+
+    def __init__(self, _input_size: int, _output_size: int, **_kwargs) -> None:
+        super().__init__()
+
+    def forward(self, x: torch.Tensor) -> tuple[torch.Tensor, None]:
+        return x, None
+
+
+class _FakeAttention(nn.Module):
+
+    def __init__(self, *_args, **_kwargs) -> None:
+        super().__init__()
+        self.last_shapes: tuple[torch.Size, torch.Size, torch.Size] | None = None
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+    ) -> torch.Tensor:
+        self.last_shapes = (q.shape, k.shape, v.shape)
+        return q
+
+
+def test_gemma4_k_eq_v_uses_separate_qk_proj(monkeypatch):
+    monkeypatch.setattr(gemma4_mod, "ColumnParallelLinear", _FakeColumnParallelLinear)
+    monkeypatch.setattr(gemma4_mod, "QKVParallelLinear", _FakeQKVParallelLinear)
+    monkeypatch.setattr(gemma4_mod, "RowParallelLinear", _FakeRowParallelLinear)
+    monkeypatch.setattr(gemma4_mod, "Attention", _FakeAttention)
+    monkeypatch.setattr(
+        gemma4_mod,
+        "get_rope",
+        lambda *args, **kwargs: (lambda positions, q, k: (q, k)),
+    )
+    monkeypatch.setattr(gemma4_mod, "extract_layer_index", lambda _prefix: 5)
+
+    config = SimpleNamespace(
+        attention_bias=False,
+        rms_norm_eps=1e-6,
+        layer_types=["sliding_attention"] * 5 + ["full_attention"],
+        sliding_window=1024,
+        rope_parameters={
+            "full_attention": {
+                "rope_type": "proportional",
+                "partial_rotary_factor": 0.25,
+                "rope_theta": 1_000_000.0,
+            },
+        },
+        num_hidden_layers=6,
+        num_kv_shared_layers=0,
+    )
+
+    _FakeQKVParallelLinear.forward_calls = 0
+    attn = gemma4_mod.Gemma4Attention(
+        config=config,
+        hidden_size=32,
+        num_heads=4,
+        num_kv_heads=1,
+        head_dim=16,
+        max_position_embeddings=128,
+        use_k_eq_v=True,
+        prefix="model.layers.5.self_attn",
+    )
+
+    assert attn.qkv_proj is None
+    assert hasattr(attn, "q_proj")
+    assert hasattr(attn, "k_proj")
+
+    positions = torch.arange(3)
+    hidden_states = torch.zeros(3, 32)
+    output = attn(positions, hidden_states)
+
+    assert _FakeQKVParallelLinear.forward_calls == 0
+    assert output.shape == (3, 64)
+    assert attn.attn.last_shapes == (
+        torch.Size([3, 64]),
+        torch.Size([3, 16]),
+        torch.Size([3, 16]),
+    )

--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -402,18 +402,37 @@ class Gemma4Attention(nn.Module):
         # Q/K norms with learnable weights handle scaling implicitly.
         self.scaling = 1.0
 
-        # QKVParallelLinear handles GQA correctly for all layer types.
-        # k_eq_v layers load K weights into both K and V slots via
-        # _weight_iterator remapping — no structural difference needed.
-        self.qkv_proj = QKVParallelLinear(
-            hidden_size,
-            self.head_dim,
-            self.total_num_heads,
-            self.total_num_kv_heads,
-            bias=config.attention_bias,
-            quant_config=quant_config,
-            prefix=f"{prefix}.qkv_proj",
-        )
+        # Gemma 4 full-attention k_eq_v layers omit v_proj on disk. Keep
+        # them as separate q_proj/k_proj modules so the checkpoint layout
+        # matches the module structure and we can reuse K as V directly.
+        if self.use_k_eq_v:
+            self.q_proj = ColumnParallelLinear(
+                hidden_size,
+                self.total_num_heads * self.head_dim,
+                bias=config.attention_bias,
+                gather_output=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.q_proj",
+            )
+            self.k_proj = ColumnParallelLinear(
+                hidden_size,
+                self.total_num_kv_heads * self.head_dim,
+                bias=config.attention_bias,
+                gather_output=False,
+                quant_config=quant_config,
+                prefix=f"{prefix}.k_proj",
+            )
+            self.qkv_proj = None
+        else:
+            self.qkv_proj = QKVParallelLinear(
+                hidden_size,
+                self.head_dim,
+                self.total_num_heads,
+                self.total_num_kv_heads,
+                bias=config.attention_bias,
+                quant_config=quant_config,
+                prefix=f"{prefix}.qkv_proj",
+            )
         self.o_proj = RowParallelLinear(
             self.total_num_heads * self.head_dim,
             hidden_size,
@@ -506,11 +525,13 @@ class Gemma4Attention(nn.Module):
         hidden_states: torch.Tensor,
         **kwargs,
     ) -> torch.Tensor:
-        # Unified QKV path (works for both k_eq_v and standard layers).
-        # For k_eq_v, K weights are loaded into both K and V slots of
-        # qkv_proj, so V == K automatically.
-        qkv, _ = self.qkv_proj(hidden_states)
-        q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
+        if self.use_k_eq_v:
+            q, _ = self.q_proj(hidden_states)
+            k, _ = self.k_proj(hidden_states)
+            v = k
+        else:
+            qkv, _ = self.qkv_proj(hidden_states)
+            q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
 
         # Q norm (always applied)
         q = q.unflatten(-1, (self.num_heads, self.head_dim))
@@ -1613,16 +1634,6 @@ class Gemma4ForCausalLM(
         # Gemma4ForConditionalGeneration wrapper). Strip it to map to our
         # model tree which is just "model.*".
         def _weight_iterator():
-            use_k_eq_v = getattr(self.config, "attention_k_eq_v", False)
-            # Build set of k_eq_v layer indices (full_attention layers
-            # when attention_k_eq_v is enabled). These layers have k_proj
-            # but no v_proj in checkpoint — we duplicate k_proj as v_proj.
-            k_eq_v_layer_indices: set[int] = set()
-            if use_k_eq_v:
-                for idx, lt in enumerate(self.config.layer_types):
-                    if lt == "full_attention":
-                        k_eq_v_layer_indices.add(idx)
-
             for name, weight in weights:
                 # Remap "language_model." → "" to match our model tree.
                 # Checkpoint: model.language_model.layers.X.*
@@ -1684,18 +1695,6 @@ class Gemma4ForCausalLM(
                         expert_name = name.replace("moe.", f"moe.experts.{expert_id}.")
                         yield expert_name, weight[expert_id]
                     continue
-
-                # k_eq_v layers: checkpoint has k_proj but no v_proj.
-                # QKVParallelLinear expects both, so duplicate k_proj
-                # as v_proj so V gets identical weights to K.
-                # ONLY for full_attention layers — sliding layers have
-                # their own real v_proj weights.
-                if "self_attn.k_proj" in name and k_eq_v_layer_indices:
-                    m = re.search(r"layers\.(\d+)\.", name)
-                    if m and int(m.group(1)) in k_eq_v_layer_indices:
-                        yield name, weight
-                        yield name.replace("k_proj", "v_proj"), weight.clone()
-                        continue
 
                 yield name, weight
 


### PR DESCRIPTION
## Summary

Fix Gemma 4 `attention_k_eq_v` full-attention layers to use separate `q_proj` and `k_proj` modules instead of forcing them through packed `qkv_proj`.

## Root cause

For `google/gemma-4-31b-it`, the public checkpoint metadata shows that full-attention `k_eq_v` layers omit `v_proj` on disk, but still use full-width K projections:

- `q_proj`: `[16384, 5376]`
- `k_proj`: `[2048, 5376]`
- `k_norm`: `[512]`
- no `v_proj` tensor

vLLM currently models these layers with a packed `qkv_proj` path and synthesizes `v_proj` by duplicating `k_proj` during weight loading. That leads to an invalid packed layout for `k_eq_v` full-attention layers and crashes during engine init.

## Changes

- keep `k_eq_v` full-attention layers as separate `q_proj` and `k_proj` modules
- reuse K as V in forward for those layers
- remove synthetic `k_proj -> v_proj` duplication in the weight iterator
- add a regression test covering the `k_eq_v` full-attention path

## Validation

- `python -m compileall vllm/model_executor/models/gemma4.py tests/model_executor/models/test_gemma4.py`