### PR TITLE
[style] Remove redundant None default in dict.get() (ruff SIM910)

### DIFF
--- a/vllm/model_executor/models/config.py
+++ b/vllm/model_executor/models/config.py
@@ -292,7 +292,7 @@ class LlamaBidirectionalConfig(VerifyAndUpdateConfig):
             "last": "LAST",
         }
 
-        pooling_type = pooling_type_map.get(hf_config.pooling, None)
+        pooling_type = pooling_type_map.get(hf_config.pooling)
         if pooling_type is None:
             raise ValueError(f"pool_type {hf_config.pooling!r} not supported")
 


### PR DESCRIPTION
## Summary

Fixes the sole `SIM910` ruff violation reported when running `ruff check vllm/` with the project's own ruff configuration (`v0.14.0`, `SIM` rule group selected in `pyproject.toml`):

```
SIM910 [*] dict-get-with-none-default
vllm/model_executor/models/config.py:295
```

`dict.get(key)` already returns `None` when the key is absent, so explicitly passing `None` as the default is redundant. Removing it makes the call more idiomatic Python.

**Before:**
```python
pooling_type = pooling_type_map.get(hf_config.pooling, None)
```

**After:**
```python
pooling_type = pooling_type_map.get(hf_config.pooling)
```

## Test plan

- [x] `ruff check vllm/` passes with zero violations after this change
- No functional change — behaviour is identical since `dict.get(key)` and `dict.get(key, None)` are semantically equivalent

https://claude.ai/code/session_01VcM9vytB4Bo4ukHfx2xd5A