### PR TITLE
docs: clarify NIXL KV transfer metrics aggregation

### DIFF
--- a/docs/usage/metrics.md
+++ b/docs/usage/metrics.md
@@ -45,6 +45,30 @@ The following metrics are exposed:
 
 --8<-- "docs/generated/metrics/nixl_connector.inc.md"
 
+When NixlConnector logs a line such as `KV Transfer metrics: Num successful
+transfers=4, Avg xfer time (ms)=1.381, ...`, the summary is computed from the
+combined pool of rank-level transfer observations collected during the logging
+interval. In tensor-parallel deployments, each TP rank records its own NIXL
+transfer telemetry and the observations from all ranks are concatenated before
+averages, percentiles, and throughput are computed.
+
+Interpret the log fields as follows:
+
+- `Num successful transfers` is the total count of successful rank-level
+  transfers across all ranks.
+- `Avg xfer time (ms)`, `P90 xfer time (ms)`, `Avg post time (ms)`, and
+  `P90 post time (ms)` are computed over the combined distribution of
+  rank-level timings.
+- `Avg MB per transfer` is the average transferred size of an individual
+  rank-level transfer, not the total bytes moved by one engine-level KV cache
+  operation.
+- `Throughput (MB/s)` is total transferred MB divided by the sum of transfer
+  durations across the combined rank-level observations. This is an average
+  rank-level transfer rate, not aggregate system throughput over wall-clock
+  time.
+- `Avg number of descriptors` is averaged over individual rank-level
+  transfers.
+
 ## Model Flops Utilization (MFU) Performance Metrics
 
 These metrics are available via `--enable-mfu-metrics`:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -22,6 +22,19 @@ class KVConnectorStats:
     metrics or otherwise important telemetry from the connector.
     All sub-classes need to be serializable as stats are sent from worker to
     logger process.
+
+    The logging pipeline is:
+
+    * workers record connector-specific observations;
+    * scheduler/logging code passes those observations to
+      :meth:`KVConnectorLogging.observe`;
+    * observations from multiple calls are accumulated with :meth:`aggregate`;
+    * :meth:`reduce` summarizes the accumulated pool for the log line.
+
+    Depending on the connector and runtime topology, the stats object passed to
+    the logger can already contain observations aggregated across workers, such
+    as all tensor-parallel ranks. Connector implementations should document the
+    scope represented by their observations before they are reduced.
     """
 
     data: dict[str, Any] = field(default_factory=dict)
@@ -33,6 +46,9 @@ class KVConnectorStats:
     def aggregate(self, other: "KVConnectorStats") -> "KVConnectorStats":
         """
         Aggregate stats with another `KVConnectorStats` object.
+
+        Implementations usually concatenate observation series so a later
+        :meth:`reduce` call summarizes the combined observation pool.
         """
         raise NotImplementedError
 
@@ -51,6 +67,15 @@ class KVConnectorStats:
 
 
 class KVConnectorLogging:
+    """
+    Accumulates KV connector observations and emits periodic log summaries.
+
+    `observe()` may receive stats that have already been aggregated by the
+    connector across workers. The logger keeps accumulating those observations
+    with the connector's `aggregate()` implementation until `log()` calls
+    `reduce()` and emits a single "KV Transfer metrics" line for the interval.
+    """
+
     def __init__(self, kv_transfer_config: KVTransferConfig | None):
         # Instantiate the connector's stats class.
         if kv_transfer_config and kv_transfer_config.kv_connector:

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
@@ -21,7 +21,22 @@ from vllm.v1.metrics.utils import create_metric_per_engine
 
 @dataclass
 class NixlKVConnectorStats(KVConnectorStats):
-    """Container for transfer performance metrics"""
+    """
+    Container for NIXL transfer performance metrics.
+
+    Each tensor-parallel rank records rank-local transfer telemetry with
+    :meth:`record_transfer`. During logging, stats from all ranks are aggregated
+    into one combined observation pool before :meth:`reduce` computes summary
+    values. As a result, "Num successful transfers" is the total rank-level
+    transfer count across all ranks, averages and percentiles are computed over
+    individual rank-level transfers, and "Avg MB per transfer" is not the total
+    bytes moved by one engine-level KV cache operation.
+
+    "Throughput (MB/s)" is computed as total transferred MB across the combined
+    rank-level observations divided by the sum of their transfer durations. This
+    is an average over rank-level transfer observations, not aggregate system
+    throughput over wall-clock time.
+    """
 
     def __post_init__(self):
         if not self.data:
@@ -78,11 +93,14 @@ class NixlKVConnectorStats(KVConnectorStats):
             for k, v in other.data.items():
                 accumulator = self.data[k]
                 assert isinstance(accumulator, list)
+                # Concatenate rank/worker-local observations. Summary stats are
+                # computed later over this combined pool, not per rank.
                 accumulator.extend(v)
         return self
 
     def reduce(self) -> dict[str, int | float]:
-        # Compute compact representative stats suitable for CLI logging
+        # Compute compact representative stats suitable for CLI logging. In TP
+        # deployments, this operates on observations aggregated from all ranks.
         if self.num_successful_transfers == 0:
             # CLI logging only reports successful transfers stats. If all requests in
             # the interval were unsuccessful, Prom will report failures stats instead.
@@ -106,9 +124,14 @@ class NixlKVConnectorStats(KVConnectorStats):
         assert n == self.num_successful_transfers
 
         total_mb = mb.sum()
+        # Average bytes per rank-level transfer in the combined observation
+        # pool, not bytes per engine-level KV cache operation.
         avg_mb = total_mb / n
 
         total_time_seconds = xfer_time.sum()
+        # This is total MB divided by summed rank-level transfer time, so it is
+        # an average per-rank transfer rate rather than wall-clock aggregate
+        # system throughput.
         throughput_mb_s = total_mb / total_time_seconds
 
         return {


### PR DESCRIPTION
## Purpose

Fixes #41230.

This PR documents the aggregation semantics for NIXL KV connector transfer metrics. In TP > 1 deployments, NIXL transfer observations are recorded per rank and then aggregated before summary stats are computed. The updated docs and docstrings clarify that:

- `Num successful transfers` is the total count across rank-level transfers.
- averages and P90 values are computed over the combined rank-level observation pool.
- `Avg MB per transfer` is per rank-level transfer, not per engine-level KV operation.
- `Throughput (MB/s)` is total MB divided by summed rank-level transfer time, not aggregate system throughput over wall-clock time.

I checked for duplicate open PRs using GitHub search and did not find an existing PR addressing #41230.

AI assistance was used to draft and apply this documentation update. I reviewed the changed files.

## Test Plan

```bash
pre-commit run ruff-check --files vllm/distributed/kv_transfer/kv_connector/v1/metrics.py vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
pre-commit run markdownlint-cli2 --files docs/usage/metrics.md
