### PR TITLE
[UX][Bugfix] Fix OOM by setting PyTorch `max_split_size_mb` during model loading

### DIFF
--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -5,12 +5,13 @@
 import gc
 import os
 from collections.abc import Callable
-from contextlib import AbstractContextManager, nullcontext
+from contextlib import AbstractContextManager, contextmanager, nullcontext
 from datetime import timedelta
 from types import NoneType
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+import regex as re
 import torch
 import torch.nn as nn
 
@@ -208,6 +209,28 @@ class Worker(WorkerBase):
             )
         return allocator.use_memory_pool(tag=tag)
 
+    @contextmanager
+    def _scoped_allocator_max_split(self, max_split_size_mb: int):
+        """Temporarily set max_split_size_mb to reduce allocator fragmentation at the
+        cost of more cudaMalloc calls (negligible in practice). Restores the original
+        value on exit."""
+        if not current_platform.is_cuda():
+            yield
+            return
+
+        conf = os.environ.get("PYTORCH_CUDA_ALLOC_CONF", "")
+        match = re.search(r"max_split_size_mb:(\d+)", conf)
+        original_value = match.group(1) if match else None
+
+        torch._C._accelerator_setAllocatorSettings(
+            f"max_split_size_mb:{max_split_size_mb}"
+        )
+        try:
+            yield
+        finally:
+            restore = original_value if original_value else "99999999"
+            torch._C._accelerator_setAllocatorSettings(f"max_split_size_mb:{restore}")
+
     @instrument(span_name="Init device")
     def init_device(self):
         if self.device_config.device_type == "cuda":
@@ -312,6 +335,8 @@ class Worker(WorkerBase):
         with (
             self._maybe_get_memory_pool_context(tag="weights"),
             set_current_vllm_config(self.vllm_config),
+            # 20 MiB is the minimum PyTorch allows for max_split_size_mb.
+            self._scoped_allocator_max_split(max_split_size_mb=20),
         ):
             self.model_runner.load_model(load_dummy_weights=load_dummy_weights)
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -228,7 +228,9 @@ class Worker(WorkerBase):
         try:
             yield
         finally:
-            restore = original_value if original_value else "99999999"
+            # PyTorch defaults to SIZE_MAX (no limit).
+            _SIZE_MAX_MB = (2**64 - 1) // (1024 * 1024)
+            restore = original_value if original_value else str(_SIZE_MAX_MB)
             torch._C._accelerator_setAllocatorSettings(f"max_split_size_mb:{restore}")
 
     @instrument(span_name="Init device")


### PR DESCRIPTION


## Purpose
Alternative to https://github.com/vllm-project/vllm/pull/41158 because `expandable_segments` is not compatible with sleep mode and NIXLConnector.

The upgrade from PyTorch 2.9 to 2.10 seems to have substantially increased memory fragmentation during startup and cudagraph capture, leading to OOMs during startup for some models at default --gpu-memory-utilization (e.g. GPT-OSS 120B TP2 on 2xH100).

In the case of GPT-OSS 120B, this is caused by mxfp4 weight post-processing. The w13 (gate+up) and w2 (down) MoE weights are processed separately via `convert_layout`, producing 530 MiB and 270 MiB allocations respectively. When PyTorch processes the 270 MiB w2 weights, it finds cached 530 MiB segments left over from w13 processing and places the 270 MiB tensor inside. Because 530 - 270 = 260 > 20 MiB (minimum split size), PyTorch splits the block, creating a 260 MiB free remainder within the segment. This remainder is too small for another 530 MiB or 270 MiB allocation, and cannot be freed because the 270 MiB weight pins the segment.

By setting `max_split_size_mb=20` (the minimum allowed value) during model loading, when PyTorch searches for a place to write the 270 MiB tensor, the 530 MiB block is not allowed to be split, so PyTorch creates a new 270 MiB allocation.

The empty 530 MiB segments are freed as necessary for new allocations.

This is a representative example, and it is possible that other models encounter similar situations.

The reason this happened between 2.9->2.10 is actually not PyTorch itself, but because this upgrade bumped `triton-kernels` from 3.5.0 to 3.6.0. In this upgrade, the `swizzle_data` kernel added a pre-padding step, which changed the allocation sizes.

## Test Plan

On H100,
```
vllm serve openai/gpt-oss-120b -tp 2 --trust-remote-code --max-model-len 10000
```

## Test Result

| `max_split_size_mb` | Load time | Result |
|---------------------|-----------|--------|
| _SIZE_MAX (no limit, default) | 23.76s | OOM |
| 128 | 24.10s | PASS |
| 20 (minimum allowed) | 24.58s | PASS |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
