### PR TITLE
[Attention] Remove unused slot mapping from FlashAttention metadata

### DIFF
--- a/tests/compile/passes/test_rope_kvcache_fusion.py
+++ b/tests/compile/passes/test_rope_kvcache_fusion.py
@@ -31,6 +31,7 @@ from vllm.platforms import current_platform
 from vllm.utils.torch_utils import _encode_layer_name
 from vllm.v1.attention.backend import (
     AttentionBackend,
+    AttentionMetadata,
     CommonAttentionMetadata,
 )
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
@@ -114,7 +115,9 @@ class QKRoPEKVCacheTestModel(torch.nn.Module):
             device=device,
         )
 
-    def build_attn_metadata(self, batch_size: int) -> CommonAttentionMetadata:
+    def build_attn_metadata(
+        self, batch_size: int
+    ) -> tuple[AttentionMetadata, torch.Tensor]:
         """Initialize attention metadata."""
         # Create common attn metadata
         batch_spec = BatchSpec(seq_lens=[1] * batch_size, query_lens=[1] * batch_size)
@@ -156,7 +159,7 @@ class QKRoPEKVCacheTestModel(torch.nn.Module):
             common_prefix_len=0, common_attn_metadata=common_attn_metadata
         )
 
-        return attn_metadata
+        return attn_metadata, common_attn_metadata.slot_mapping
 
     def forward(
         self, qkv: torch.Tensor, positions: torch.Tensor
@@ -290,10 +293,8 @@ def test_rope_kvcache_fusion(
 
         with set_forward_context(None, vllm_config):
             forward_context = get_forward_context()
-            attn_metadata = model.build_attn_metadata(T)
-            forward_context.slot_mapping = {
-                model.layer_name: attn_metadata.slot_mapping
-            }
+            _, slot_mapping = model.build_attn_metadata(T)
+            forward_context.slot_mapping = {model.layer_name: slot_mapping}
             q_unfused, k_unfused, v_unfused, dummy = model(qkv_unfused, pos_unfused)
             attn_layer = forward_context.no_compile_layers[model.layer_name]
             kv_cache_unfused = attn_layer.kv_cache
@@ -304,10 +305,8 @@ def test_rope_kvcache_fusion(
         with set_forward_context(None, vllm_config):
             model_fused = torch.compile(model, backend=backend)
             forward_context = get_forward_context()
-            attn_metadata = model_fused.build_attn_metadata(T)
-            forward_context.slot_mapping = {
-                model.layer_name: attn_metadata.slot_mapping
-            }
+            _, slot_mapping = model_fused.build_attn_metadata(T)
+            forward_context.slot_mapping = {model.layer_name: slot_mapping}
             q_fused, k_fused, v_fused, dummy = model_fused(qkv, pos)
             attn_layer = forward_context.no_compile_layers[model.layer_name]
             kv_cache_fused = attn_layer.kv_cache

--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -300,7 +300,11 @@ def run_attention_backend(
     # in the calling test function.
     if not try_backend_includes_kv_cache_update(actual_backend):
         impl.do_kv_cache_update(
-            mock_layer, key, value, kv_cache, attn_metadata.slot_mapping
+            mock_layer,
+            key,
+            value,
+            kv_cache,
+            common_attn_metadata.slot_mapping,
         )
     output = impl.forward(
         mock_layer, query, key, value, kv_cache, attn_metadata, output=output

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -235,7 +235,6 @@ class FlashAttentionMetadata:
     max_seq_len: int
     seq_lens: torch.Tensor
     block_table: torch.Tensor
-    slot_mapping: torch.Tensor
 
     # For cascade attention.
     use_cascade: bool
@@ -402,7 +401,6 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
         query_start_loc = common_attn_metadata.query_start_loc
         seq_lens = common_attn_metadata.seq_lens
         block_table_tensor = common_attn_metadata.block_table_tensor
-        slot_mapping = common_attn_metadata.slot_mapping
         causal = common_attn_metadata.causal
 
         # Disable AOT schedule for spec-decode proposer (not worth the overhead)
@@ -561,7 +559,6 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
             max_seq_len=max_seq_len,
             seq_lens=seq_lens,
             block_table=block_table_tensor,
-            slot_mapping=slot_mapping,
             max_dcp_context_kv_len=max_dcp_context_kv_len,
             dcp_context_kv_lens=dcp_context_kv_lens,
             use_cascade=use_cascade,
@@ -584,7 +581,6 @@ class FlashAttentionMetadataBuilder(AttentionMetadataBuilder[FlashAttentionMetad
     ) -> FlashAttentionMetadata:
         new_metadata = copy.copy(metadata)
         new_metadata.block_table = blk_table
-        new_metadata.slot_mapping = slot_mapping
         return new_metadata
 
     def use_cascade_attention(self, *args, **kwargs) -> bool:


### PR DESCRIPTION

## Purpose

Related to #32335.

Remove unused `slot_mapping` from `FlashAttentionMetadata`.

FlashAttention KV cache updates already receive slot mapping through the separate `do_kv_cache_update` path, so keeping another copy in backend metadata is unnecessary. Tests that previously used metadata as a convenient slot mapping source now use `CommonAttentionMetadata.slot_mapping` directly.

Tested:
- pytest tests/v1/attention/test_attention_backends.py
- pytest tests/compile/passes/test_rope_kvcache_fusion.py

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
