### PR TITLE
[Attention] Remove unused slot mapping from TreeAttention metadata

### DIFF
--- a/tests/v1/attention/test_attention_backends.py
+++ b/tests/v1/attention/test_attention_backends.py
@@ -300,7 +300,7 @@ def run_attention_backend(
     # in the calling test function.
     if not try_backend_includes_kv_cache_update(actual_backend):
         impl.do_kv_cache_update(
-            mock_layer, key, value, kv_cache, attn_metadata.slot_mapping
+            mock_layer, key, value, kv_cache, common_attn_metadata.slot_mapping
         )
     output = impl.forward(
         mock_layer, query, key, value, kv_cache, attn_metadata, output=output

--- a/tests/v1/spec_decode/test_tree_attention.py
+++ b/tests/v1/spec_decode/test_tree_attention.py
@@ -294,7 +294,7 @@ def forward_attention(
                 value,
                 key_cache,
                 value_cache,
-                attn_metadata.slot_mapping,
+                common_attn_metadata.slot_mapping,
                 "auto",
                 layer._k_scale,
                 layer._v_scale,
@@ -305,7 +305,7 @@ def forward_attention(
                 key=key,
                 value=value,
                 kv_cache=adapted_kv_cache,
-                slot_mapping=attn_metadata.slot_mapping,
+                slot_mapping=common_attn_metadata.slot_mapping,
             )
     return instance.forward(
         layer=layer,

--- a/vllm/v1/attention/backends/tree_attn.py
+++ b/vllm/v1/attention/backends/tree_attn.py
@@ -83,7 +83,6 @@ class TreeAttentionMetadata:
     max_seq_len: int
     seq_lens: torch.Tensor
     block_table: torch.Tensor
-    slot_mapping: torch.Tensor
 
     num_prefill_tokens: int = 0
     num_decode_tokens: int = 0
@@ -117,7 +116,6 @@ class TreeAttentionMetadata:
             max_seq_len=int(kv_seqlens.max().item()),
             seq_lens=kv_seqlens,
             block_table=self.block_table[self.num_decodes :],
-            slot_mapping=self.slot_mapping[self.num_decode_tokens :],
         )
         return self._cached_prefill_metadata
 
@@ -142,7 +140,6 @@ class TreeAttentionMetadata:
             max_seq_len=int(kv_seqlens.max().item()),
             seq_lens=kv_seqlens,
             block_table=self.block_table[: self.num_decodes],
-            slot_mapping=self.slot_mapping[: self.num_decode_tokens],
             tree_attn_bias=self.tree_attn_bias,
         )
         return self._cached_decode_metadata
@@ -197,7 +194,6 @@ class TreeAttentionMetadataBuilder(AttentionMetadataBuilder[TreeAttentionMetadat
         kv_seqlens = common_attn_metadata.seq_lens
         max_seq_len = common_attn_metadata.max_seq_len
         block_table = common_attn_metadata.block_table_tensor
-        slot_mapping = common_attn_metadata.slot_mapping
 
         return TreeAttentionMetadata(
             num_actual_tokens=num_actual_tokens,
@@ -210,7 +206,6 @@ class TreeAttentionMetadataBuilder(AttentionMetadataBuilder[TreeAttentionMetadat
             max_seq_len=max_seq_len,
             seq_lens=kv_seqlens,
             block_table=block_table,
-            slot_mapping=slot_mapping,
             tree_attn_bias=self.tree_attn_bias,
         )
 


### PR DESCRIPTION

## Purpose

Related to #32335.

Remove unused `slot_mapping` from `TreeAttentionMetadata`.

TreeAttention KV cache updates already receive slot mapping through the separate update path. Forward only needs query, sequence, and block-table metadata, so storing slot mapping in TreeAttention metadata is redundant.

Tested:
- pytest tests/v1/spec_decode/test_tree_attention.py

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
