### PR TITLE
[CompressedTensors] DeepSeek4 CT Quantization Support

### DIFF
--- a/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
+++ b/vllm/models/deepseek_v4/nvidia/ops/o_proj.py
@@ -60,10 +60,13 @@ def deep_gemm_fp8_o_proj(
         device=o.device,
         dtype=torch.bfloat16,
     )
+    weight_scale = (
+        wo_a.weight_scale if hasattr(wo_a, "weight_scale") else wo_a.weight_scale_inv
+    )
     fp8_einsum(
         "bhr,hdr->bhd",
         (o_fp8, o_scale),
-        (wo_a.weight, wo_a.weight_scale_inv),
+        (wo_a.weight, weight_scale),
         z,
         recipe=einsum_recipe,
     )


### PR DESCRIPTION
<h1 style="display: flex; align-items: center; gap: 10px; margin: 0;">
DeepSeek-V4-Flash-NVFP4-FP8
</h1>

## Model Optimizations

This model was obtained by using the following branch with LLM Compressor: https://github.com/vllm-project/llm-compressor/pull/2647

## Deployment

```bash
vllm serve RedHatAI/DeepSeek-V4-Flash-NVFP4-FP8 --tensor-parallel-size 4 --port 8089 --kv_cache_dtype="fp8"
```

## Accuracy Evaluation
| Benchmark | `deepseek-ai/DeepSeek-V4-Pro-Base` | `deepseek-ai/DeepSeek-V4-Pro` | `RedHatAI/DeepSeek-V4-Pro-NVFP4-FP8` |
| - | - | -| - |
| GPQA | | 90.1 | 0.93 (330/792 samples) |
| GSM8K | 91.1 | 92.6 | 91.0 |

## Performance Evaluation
8xB200
```
Avg prompt throughput: 155.5 tokens/s, Avg generation throughput: 3258.4 tokens/s, Running: 102 reqs, Waiting: 0 reqs, GPU KV cache usage: 15.1%, Prefix cache hit rate: 2.4%
```

For more details on how this model was created and run in LLM Compressor, please contact Kyle Sayers on the vLLM Slack: https://communityinviter.com/apps/vllm-dev/join-vllm-developers-slack