### PR TITLE
[Bugfix][CI][Hardware][AMD] Fix various e4m3fn -> e4m3fnuz normalization issues

### DIFF
--- a/tests/kernels/moe/test_ocp_mx_moe.py
+++ b/tests/kernels/moe/test_ocp_mx_moe.py
@@ -83,7 +83,6 @@ def enable_pickle(monkeypatch):
     [
         ModelCase("fxmarty/qwen_1.5-moe-a2.7b-mxfp4", tp=2),
         ModelCase("fxmarty/deepseek_r1_3_layers_mxfp4", tp=8),
-        ModelCase("fxmarty/Llama-4-Scout-17B-16E-Instruct-2-layers-mxfp4", tp=1),
         ModelCase("fxmarty/Llama-3.1-70B-Instruct-2-layers-mxfp6", tp=1),
         ModelCase("fxmarty/Llama-3.1-70B-Instruct-2-layers-mxfp6", tp=4),
     ],

--- a/tests/quantization/test_modelopt.py
+++ b/tests/quantization/test_modelopt.py
@@ -13,6 +13,7 @@ import torch
 
 from tests.quantization.utils import is_quant_method_supported
 from vllm.config.model import ModelConfig
+from vllm.platforms import current_platform
 
 
 @pytest.fixture(scope="function", autouse=True)
@@ -85,10 +86,10 @@ def test_modelopt_fp8_checkpoint_setup(default_vllm_config, vllm_runner):
             assert isinstance(down_proj.quant_method, ModelOptFp8LinearMethod)
 
             # Check weight dtype is FP8
-            assert qkv_proj.weight.dtype == torch.float8_e4m3fn
-            assert o_proj.weight.dtype == torch.float8_e4m3fn
-            assert gate_up_proj.weight.dtype == torch.float8_e4m3fn
-            assert down_proj.weight.dtype == torch.float8_e4m3fn
+            assert qkv_proj.weight.dtype == current_platform.fp8_dtype()
+            assert o_proj.weight.dtype == current_platform.fp8_dtype()
+            assert gate_up_proj.weight.dtype == current_platform.fp8_dtype()
+            assert down_proj.weight.dtype == current_platform.fp8_dtype()
 
             # Check scales are present and have correct dtype
             assert hasattr(qkv_proj, "weight_scale")
@@ -149,10 +150,10 @@ def test_modelopt_fp8_pc_pt_checkpoint_setup(default_vllm_config, vllm_runner):
             assert isinstance(gate_up_proj.quant_method, ModelOptFp8PcPtLinearMethod)
             assert isinstance(down_proj.quant_method, ModelOptFp8PcPtLinearMethod)
 
-            assert qkv_proj.weight.dtype == torch.float8_e4m3fn
-            assert o_proj.weight.dtype == torch.float8_e4m3fn
-            assert gate_up_proj.weight.dtype == torch.float8_e4m3fn
-            assert down_proj.weight.dtype == torch.float8_e4m3fn
+            assert qkv_proj.weight.dtype == current_platform.fp8_dtype()
+            assert o_proj.weight.dtype == current_platform.fp8_dtype()
+            assert gate_up_proj.weight.dtype == current_platform.fp8_dtype()
+            assert down_proj.weight.dtype == current_platform.fp8_dtype()
 
             # Per-channel scales; activations are dynamically scaled per token.
             assert hasattr(qkv_proj, "weight_scale")
@@ -212,10 +213,10 @@ def test_modelopt_fp8_pb_wo_checkpoint_setup(default_vllm_config, vllm_runner):
             assert isinstance(gate_up_proj.quant_method, ModelOptFp8PbWoLinearMethod)
             assert isinstance(down_proj.quant_method, ModelOptFp8PbWoLinearMethod)
 
-            assert qkv_proj.weight.dtype == torch.float8_e4m3fn
-            assert o_proj.weight.dtype == torch.float8_e4m3fn
-            assert gate_up_proj.weight.dtype == torch.float8_e4m3fn
-            assert down_proj.weight.dtype == torch.float8_e4m3fn
+            assert qkv_proj.weight.dtype == current_platform.fp8_dtype()
+            assert o_proj.weight.dtype == current_platform.fp8_dtype()
+            assert gate_up_proj.weight.dtype == current_platform.fp8_dtype()
+            assert down_proj.weight.dtype == current_platform.fp8_dtype()
 
             # Block scales; should be materialized as a 2D [out_blk, in_blk] tensor.
             assert hasattr(qkv_proj, "weight_scale")

--- a/vllm/model_executor/kernels/linear/scaled_mm/pytorch.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/pytorch.py
@@ -6,6 +6,10 @@ import math
 import torch
 
 from vllm.config import CompilationMode, get_current_vllm_config
+from vllm.model_executor.layers.quantization.utils.w8a8_utils import (
+    normalize_e4m3fn_to_e4m3fnuz,
+)
+from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
 
 from .ScaledMMLinearKernel import (
@@ -39,6 +43,16 @@ class TorchFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
             return False, "requires compute capability 89 and above."
 
         return True, None
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        w, w_s, x_s, _ = self._get_layer_params(layer)
+        if current_platform.is_fp8_fnuz() and w.dtype == torch.float8_e4m3fn:
+            w, w_s, x_s = normalize_e4m3fn_to_e4m3fnuz(w, w_s, x_s)
+            w_name, w_s_name, x_s_name, _ = self.layer_param_names
+            replace_parameter(layer, w_name, w)
+            replace_parameter(layer, w_s_name, w_s)
+            if x_s is not None:
+                replace_parameter(layer, x_s_name, x_s)
 
     def get_output_padding(self) -> int | None:
         # Note: we pad the input because torch._scaled_mm is more performant

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -728,8 +728,7 @@ class ModelOptFp8PbWoLinearMethod(LinearMethodBase):
 
         layer.weight_scale = Parameter(scale.contiguous(), requires_grad=False)
 
-        if hasattr(self, "fp8_linear"):
-            self.fp8_linear.process_weights_after_loading(layer)
+        self.w8a8_block_fp8_linear.process_weights_after_loading(layer)
 
     def apply(
         self,

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -1245,7 +1245,7 @@ def process_fp8_weight_tensor_strategy(
         requantize_with_max_scale,
     )
 
-    if current_platform.is_fp8_fnuz():
+    if current_platform.is_fp8_fnuz() and weight.dtype == torch.float8_e4m3fn:
         weight, weight_scale, input_scale = normalize_e4m3fn_to_e4m3fnuz(
             weight=weight, weight_scale=weight_scale, input_scale=input_scale
         )
@@ -1271,7 +1271,7 @@ def process_fp8_weight_channel_strategy(
         normalize_e4m3fn_to_e4m3fnuz,
     )
 
-    if current_platform.is_fp8_fnuz():
+    if current_platform.is_fp8_fnuz() and weight.dtype == torch.float8_e4m3fn:
         weight, weight_scale, input_scale = normalize_e4m3fn_to_e4m3fnuz(
             weight=weight, weight_scale=weight_scale, input_scale=input_scale
         )
@@ -1288,7 +1288,7 @@ def process_fp8_weight_block_strategy(
         normalize_e4m3fn_to_e4m3fnuz,
     )
 
-    if current_platform.is_fp8_fnuz():
+    if current_platform.is_fp8_fnuz() and weight.dtype == torch.float8_e4m3fn:
         weight, weight_scale, _ = normalize_e4m3fn_to_e4m3fnuz(
             weight=weight, weight_scale=weight_scale
         )


### PR DESCRIPTION
## Purpose
This PR fixes various issues in e4m3fnuz handling encountered by various quantization code paths (ModelOpt, online). In particular, on `e4m3fnuz` platforms, `normalize_e4m3fn_to_e4m3fnuz` should be called exactly once on a given FP8 linear layer after weights are loaded.
However,
- Some PyTorch linear kernel-based code paths used during ModelOpt quantization were not calling this function.
- Some code paths used in online quantization methods were trying to call this function twice, once in the linear layer and once more in the linear layer's kernel implementation.

The end result is that the Quantization test group should now be passing on ROCm.

This PR also removes a Quark mxfp4 model that was causing failures in the Kernels MoE test group because it is incompatible with HF Transformers v5.
## Test Plan
`VLLM_TEST_FORCE_LOAD_FORMAT=auto pytest -v -s quantization/ --ignore quantization/test_blackwell_moe.py`
`pytest -v -s kernels/moe --ignore=kernels/moe/test_modular_oai_triton_moe.py`
These tests should be run as part of the Quantization and Kernels MoE test groups in vLLM AMD CI.

## Test Result
The above test groups pass, and there are no regressions.

cc @kenroche and @AndreasKaratzas

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>