### PR TITLE
[Bugfix] V1 Ray: sync `global_rank` in `adjust_rank` for PP > 1

### DIFF
--- a/tests/v1/executor/test_ray_utils.py
+++ b/tests/v1/executor/test_ray_utils.py
@@ -3,7 +3,10 @@
 
 import numpy as np
 
-from vllm.v1.executor.ray_utils import detach_zero_copy_from_model_runner_output
+from vllm.v1.executor.ray_utils import (
+    RayWorkerWrapper,
+    detach_zero_copy_from_model_runner_output,
+)
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors, ModelRunnerOutput
 
 
@@ -52,3 +55,21 @@ def test_detach_zero_copy_from_model_runner_output_copies_only_numpy_views():
     assert detached_logprobs.sampled_token_ranks.flags.writeable
     assert detached_logprobs.cu_num_generated_tokens is cu_num_generated_tokens
     assert output.prompt_logprobs_dict["req-0"] is prompt_logprobs
+
+
+def test_adjust_rank_keeps_global_rank_in_sync():
+    wrapper = RayWorkerWrapper(rpc_rank=0)
+    assert wrapper.rpc_rank == 0
+    assert wrapper.global_rank == 0
+
+    # Re-rank from 0 -> 2
+    # (emulating RayDistributedExecutor reordering workers by node placement).
+    wrapper.adjust_rank({0: 2})
+    assert wrapper.rpc_rank == 2
+    assert wrapper.global_rank == 2
+
+    # When the worker's current `rpc_rank` (of 2) is not a key in the `rank_mapping`
+    # argument below ({5: 9}), `adjust_rank` must leave both ranks untouched
+    wrapper.adjust_rank({5: 9})
+    assert wrapper.rpc_rank == 2
+    assert wrapper.global_rank == 2

--- a/vllm/v1/executor/ray_utils.py
+++ b/vllm/v1/executor/ray_utils.py
@@ -74,6 +74,9 @@ try:
             """
             if self.rpc_rank in rank_mapping:
                 self.rpc_rank = rank_mapping[self.rpc_rank]
+                # `global_rank` defaults to `rpc_rank` at construction;
+                # keep that invariant when `rpc_rank` is reassigned
+                self.global_rank = self.rpc_rank
 
         def execute_method(self, method: str | bytes, *args, **kwargs):
             try:


### PR DESCRIPTION
## Purpose

Fixes https://github.com/vllm-project/vllm/issues/41287.

This bugfix PR keeps `rpc_rank` and `global_rank` in-sync in `RayWorkerWrapper`.

## Test Plan

Newly-added test `test_adjust_rank_keeps_global_rank_in_sync` passes:

```none
pytest tests/v1/executor/test_ray_utils.py
```

## Test Result

Passing tests