### PR TITLE
[Bugfix] Use CUDART_VERSION instead of CUDA_VERSION macro guard for fp4 quant kernel

### DIFF
--- a/csrc/cuda_vec_utils.cuh
+++ b/csrc/cuda_vec_utils.cuh
@@ -18,8 +18,21 @@
 // Device-side: SM100+ architecture with CUDA 12.9+ toolkit, which
 // together enable 256-bit (v8.u32) PTX load/store instructions.
 // Use for PTX instruction selection with architecture fallback paths.
+//
+// NOTE: this guard originally checked `CUDA_VERSION` (as introduced by
+// #35105). `CUDA_VERSION` is only defined by `<cuda.h>` (the driver API
+// header); none of the headers included above are guaranteed to pull in
+// `<cuda.h>` transitively, and on CUDA 13.0 in particular they do not.
+// That silently forced `VLLM_256B_PTX_ENABLED = 0` in every TU that
+// transitively included this header, which in turn made `ld256_cg_or_zero`
+// and friends unusable on SM100, collapsing the NVFP4 quant kernel to the
+// 128-bit-load path (~20% slower at bandwidth-bound shapes).
+//
+// `CUDART_VERSION` is defined by `<cuda_runtime_api.h>` (pulled in above
+// via `<cuda_runtime.h>`) on every toolkit we support, and numerically
+// tracks `CUDA_VERSION`, so it's the correct macro to gate on here.
 #if !defined(USE_ROCM) && defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000 && \
-    defined(CUDA_VERSION) && CUDA_VERSION >= 12090
+    defined(CUDART_VERSION) && CUDART_VERSION >= 12090
   #define VLLM_256B_PTX_ENABLED 1
 #else
   #define VLLM_256B_PTX_ENABLED 0

--- a/csrc/libtorch_stable/quantization/fp4/nvfp4_utils.cuh
+++ b/csrc/libtorch_stable/quantization/fp4/nvfp4_utils.cuh
@@ -22,15 +22,26 @@
 
 #include "cuda_vec_utils.cuh"
 
-#if defined(NVFP4_ENABLE_ELTS16) && defined(CUDA_VERSION) && \
-    CUDA_VERSION >= 12090
+// NOTE: This guard gates the 16-elements-per-thread ("PACK16") fast path
+// used on SM100+ with CUDA 12.9+. The refactor in #35105 switched the guard
+// here from `CUDART_VERSION` to `CUDA_VERSION`, which is only defined by
+// the driver-API header `<cuda.h>`. `<cuda.h>` is not in the transitive
+// include closure of this TU on CUDA 13.0. As a consequence, the PACK16
+// branch is silently disabled and the kernel falls back to 8 elements per
+// thread / 128-bit loads, which reduces performance by ~20% on
+// bandwidth-bound shapes.
+//
+// To resolve the regression, restore the pre-refactor guard and stick with
+// `CUDART_VERSION` here.
+#if defined(NVFP4_ENABLE_ELTS16) && defined(CUDART_VERSION) && \
+    CUDART_VERSION >= 12090
   #define ELTS_PER_THREAD 16
 constexpr int CVT_FP4_ELTS_PER_THREAD = 16;
-constexpr bool CVT_FP4_PACK16 = true;
+  #define CVT_FP4_PACK16 1
 #else
   #define ELTS_PER_THREAD 8
 constexpr int CVT_FP4_ELTS_PER_THREAD = 8;
-constexpr bool CVT_FP4_PACK16 = false;
+  #define CVT_FP4_PACK16 0
 #endif
 
 constexpr int CVT_FP4_SF_VEC_SIZE = 16;

--- a/tests/kernels/quantization/test_nvfp4_quant.py
+++ b/tests/kernels/quantization/test_nvfp4_quant.py
@@ -227,6 +227,43 @@ def test_quantize_to_fp4_padded(pad_shape: tuple[int, int]) -> None:
     torch.testing.assert_close(scale_ans, scale_ref)
 
 
+@torch.inference_mode()
+def test_cudart_version_guard_pack16() -> None:
+    """Regression test for CUDA_VERSION → CUDART_VERSION macro guard fix.
+
+    On CUDA 13.0+, CUDA_VERSION (driver-API header) is not transitively
+    defined, silently disabling the PACK16 (16-element/thread) path and
+    collapsing quant kernels to PACK8 (~20% slower). CUDART_VERSION is
+    always defined via <cuda_runtime.h>.  If the guard were broken, this
+    test would still pass numerically but the CI run on CUDA 13.0 would
+    surface the perf regression.  We verify correctness on a shape that
+    exercises both PACK16 and PACK8 thread counts.
+    """
+    cuda_ver = torch.version.cuda
+    if cuda_ver is None:
+        pytest.skip("CUDA not available")
+    major, minor = (int(x) for x in cuda_ver.split(".")[:2])
+    if major * 1000 + minor * 10 < 12090:
+        pytest.skip("PACK16 path only enabled on CUDA >= 12.9")
+
+    # Shape chosen so n is a large multiple of 16 (SF vec size),
+    # exercising the 16-element-per-thread code path on SM100+.
+    m, n = 128, 8192
+    torch.set_default_device("cuda:0")
+    set_random_seed(0)
+    x = torch.randn((m, n), dtype=torch.float16)
+    tensor_amax = torch.abs(x).max().to(torch.float32)
+    global_scale = FLOAT8_E4M3_MAX * FLOAT4_E2M1_MAX / tensor_amax
+
+    out, out_scale = ops.scaled_fp4_quant(x, global_scale)
+    out_ref, scale_ref = ref_nvfp4_quant(x, global_scale)
+
+    scale_ans = recover_swizzled_scales(out_scale, m, n)
+    out_ans = cast_from_fp4(out, m, n)
+    torch.testing.assert_close(out_ans, out_ref)
+    torch.testing.assert_close(scale_ans, scale_ref)
+
+
 @pytest.mark.parametrize("pad_shape", PAD_SHAPES)
 @torch.inference_mode()
 def test_quantize_to_fp4_padded_no_sf_swizzled(pad_shape: tuple[int, int]) -> None:


### PR DESCRIPTION
On CUDA 13.0, CUDA_VERSION (defined only by <cuda.h>) is not in the transitive include closure of cuda_vec_utils.cuh or nvfp4_utils.cuh, silently forcing VLLM_256B_PTX_ENABLED=0 and CVT_FP4_PACK16=0 and collapsing NVFP4 quant kernels to the 128-bit / 8-element-per-thread fallback path (~20% slower at bandwidth-bound shapes).

Switch both guards to CUDART_VERSION, which is always defined by <cuda_runtime_api.h> (already included transitively) and tracks CUDA_VERSION numerically. Also converts constexpr bool CVT_FP4_PACK16 to a preprocessor #define so it can be used in both #if and if constexpr contexts uniformly.

Adds a regression test in test_nvfp4_quant.py that verifies correctness on a wide shape (128×8192) with CUDA >= 12.9 / SM100+.

