### PR TITLE
[CVE Backport] Handle `trust_remote_code` for transformers backend (releases/v0.12.0)

### DIFF
--- a/vllm/model_executor/models/registry.py
+++ b/vllm/model_executor/models/registry.py
@@ -854,6 +854,7 @@ class _ModelRegistry:
                         module,
                         model_config.model,
                         revision=model_config.revision,
+                        trust_remote_code=model_config.trust_remote_code,
                         warn_on_fail=False,
                     )
 
@@ -866,6 +867,7 @@ class _ModelRegistry:
                         module,
                         model_config.model,
                         revision=model_config.revision,
+                        trust_remote_code=model_config.trust_remote_code,
                         warn_on_fail=True,
                     )
                     if model_module is not None:

--- a/vllm/transformers_utils/dynamic_module.py
+++ b/vllm/transformers_utils/dynamic_module.py
@@ -2,7 +2,10 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import os
 
-from transformers.dynamic_module_utils import get_class_from_dynamic_module
+from transformers.dynamic_module_utils import (
+    get_class_from_dynamic_module,
+    resolve_trust_remote_code,
+)
 
 import vllm.envs as envs
 from vllm.logger import init_logger
@@ -13,6 +16,7 @@ logger = init_logger(__name__)
 def try_get_class_from_dynamic_module(
     class_reference: str,
     pretrained_model_name_or_path: str,
+    trust_remote_code: bool,
     cache_dir: str | os.PathLike | None = None,
     force_download: bool = False,
     resume_download: bool | None = None,
@@ -30,6 +34,13 @@ def try_get_class_from_dynamic_module(
     but ignoring any errors.
     """
     try:
+        resolve_trust_remote_code(
+            trust_remote_code,
+            pretrained_model_name_or_path,
+            has_local_code=False,
+            has_remote_code=True,
+        )
+
         return get_class_from_dynamic_module(
             class_reference,
             pretrained_model_name_or_path,


### PR DESCRIPTION
## Summary

Backport of #32194 (commit `78d13ea9`, "[Model] Handle `trust_remote_code` for transformers backend") to `releases/v0.12.0`. The upstream change closes **CVE-2026-22807**: the transformers-backend custom-code path could load remote `*.py` definitions without honoring the `--trust-remote-code` gate.

Tracking issue: #41275 (vulgraph reported the same gap on every release branch in support — #41157 v0.11.0, #41271 v0.11.1, #41273 v0.11.2, #41275 v0.12.0). This PR addresses v0.12.0; if accepted I'll send the same patch to the other three.

## What changes

Verbatim cherry-pick of `78d13ea9`. Two files, +14/-1:

- `vllm/transformers_utils/dynamic_module.py` — adds a `trust_remote_code: bool` parameter to `try_get_class_from_dynamic_module` and calls `transformers.dynamic_module_utils.resolve_trust_remote_code(...)` before forwarding to `get_class_from_dynamic_module`. Imports `resolve_trust_remote_code`.
- `vllm/model_executor/models/registry.py` — both call sites in `_try_resolve_transformers` (the `warn_on_fail=False` and `warn_on_fail=True` arms) now thread `trust_remote_code=model_config.trust_remote_code` through.

`resolve_trust_remote_code` is a long-standing helper in `transformers.dynamic_module_utils`; this branch already pins `transformers >= 4.56.0, < 5`, so the import is safe.

## Why it isn't a duplicate

`gh pr list --repo vllm-project/vllm --base releases/v0.12.0 --state open` and searches for `32194 in:body` and `78d13ea9 in:body` (state: all) returned no existing PR against any release branch. The reporter offered the cherry-pick on each issue but hasn't sent one yet.

## Tests run

- `git cherry-pick -x 78d13ea9` — applied cleanly, no conflicts.
- `ruff check` on both touched files — clean.
- `ruff format --check` on both touched files — already formatted.
- `mypy --python-version 3.10 --ignore-missing-imports vllm/transformers_utils/dynamic_module.py` — `Success: no issues found in 1 source file`.
- `typos` on both touched files — clean.
- `python -c "import ast; ast.parse(...)"` on both files — OK.
- `grep -rn try_get_class_from_dynamic_module` across the branch — only two callers exist (both in `registry.py`); both pass the new kwarg.

The upstream commit shipped without a regression test and there's no existing test that exercises `try_get_class_from_dynamic_module`, so I haven't added one here either — the goal of this PR is byte-identical behavior with `main`.

## AI assistance disclosure

Claude (Anthropic) assisted with: locating the upstream commit, reading the four CVE issues, running the duplicate-PR checks, executing the cherry-pick and the lint/mypy/typos commands, and drafting this PR body. Every changed line is the upstream maintainer's; I (Demian Havdun) reviewed the diff and signed off as committer per DCO. Co-author trailer added per AGENTS.md.
