### PR TITLE
[Bugfix][DeepSeek V4] Enable cross-node TP=16 FP8 serving

### DIFF
--- a/tests/models/test_deepseek_v4_padding.py
+++ b/tests/models/test_deepseek_v4_padding.py
@@ -1,0 +1,571 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.quantization.fp8 import Fp8Config
+from vllm.model_executor.layers.quantization.mxfp4 import Mxfp4Config
+from vllm.model_executor.models import deepseek_v4, deepseek_v4_mtp
+from vllm.model_executor.models.deepseek_v4 import (
+    DeepseekV4FP8Config,
+    DeepseekV4MLP,
+    DeepseekV4Model,
+    DeepseekV4MoE,
+    _balanced_tp_block_indices,
+    _pad_deepseek_v4_tensor,
+    _pad_deepseek_v4_tensor_by_tp_blocks,
+    _padded_moe_intermediate_size,
+)
+from vllm.model_executor.models.deepseek_v4_mtp import DeepSeekV4MTP
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def _fp8_block_config() -> Fp8Config:
+    return Fp8Config(
+        is_checkpoint_fp8_serialized=True,
+        activation_scheme="dynamic",
+        weight_block_size=[128, 128],
+    )
+
+
+def _empty_deepseek_v4_model() -> DeepseekV4Model:
+    model = object.__new__(DeepseekV4Model)
+    model.config = SimpleNamespace(moe_intermediate_size=3072, n_shared_experts=1)
+    model.quant_config = _fp8_block_config()
+    return model
+
+
+def _empty_deepseek_v4_mtp_model() -> DeepSeekV4MTP:
+    model = object.__new__(DeepSeekV4MTP)
+    model.config = SimpleNamespace(moe_intermediate_size=3072, n_shared_experts=1)
+    model.quant_config = _fp8_block_config()
+    return model
+
+
+def _deepseek_v4_moe_config(*, expert_dtype: str = "fp4") -> SimpleNamespace:
+    return SimpleNamespace(
+        hidden_size=7168,
+        n_routed_experts=16,
+        num_experts_per_tok=4,
+        moe_intermediate_size=3072,
+        n_shared_experts=1,
+        swiglu_limit=None,
+        norm_topk_prob=True,
+        scoring_func="sqrtsoftplus",
+        num_hash_layers=0,
+        hidden_act="silu",
+        topk_method="noaux_tc",
+        expert_dtype=expert_dtype,
+    )
+
+
+def _assert_tp_balanced_padding(
+    padded: torch.Tensor,
+    original: torch.Tensor,
+    *,
+    dim: int,
+    block_size: int,
+    fill_value: int | float,
+    tp_size: int = 16,
+) -> None:
+    original_blocks = original.shape[dim] // block_size
+    padded_blocks = padded.shape[dim] // block_size
+    block_indices = _balanced_tp_block_indices(
+        original_blocks,
+        padded_blocks,
+        tp_size,
+    )
+
+    src_slices = [slice(None)] * original.ndim
+    dst_slices = [slice(None)] * padded.ndim
+    for src_block, dst_block in enumerate(block_indices):
+        src_slices[dim] = slice(
+            src_block * block_size,
+            (src_block + 1) * block_size,
+        )
+        dst_slices[dim] = slice(
+            dst_block * block_size,
+            (dst_block + 1) * block_size,
+        )
+        assert torch.equal(padded[tuple(dst_slices)], original[tuple(src_slices)])
+
+    padded_block_set = set(range(padded_blocks))
+    original_block_set = set(block_indices)
+    for dst_block in padded_block_set - original_block_set:
+        dst_slices[dim] = slice(
+            dst_block * block_size,
+            (dst_block + 1) * block_size,
+        )
+        assert torch.all(padded[tuple(dst_slices)] == fill_value)
+
+
+def test_padded_moe_intermediate_size_only_pads_misaligned_fp8_tp():
+    quant_config = _fp8_block_config()
+
+    assert _padded_moe_intermediate_size(3072, quant_config, 1) == 3072
+    assert _padded_moe_intermediate_size(3072, quant_config, 8) == 3072
+    assert _padded_moe_intermediate_size(3072, quant_config, 16) == 4096
+    assert _padded_moe_intermediate_size(4096, quant_config, 16) == 4096
+    assert _padded_moe_intermediate_size(3072, Mxfp4Config(), 16) == 3072
+    assert _padded_moe_intermediate_size(3072, None, 16) == 3072
+
+
+def test_pad_deepseek_v4_tensor_preserves_values_and_fills_padding():
+    weight = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+
+    padded = _pad_deepseek_v4_tensor(weight, dim=1, target_size=5, fill_value=1.5)
+
+    assert padded.shape == (2, 5)
+    torch.testing.assert_close(padded[:, :3], weight)
+    torch.testing.assert_close(padded[:, 3:], torch.full((2, 2), 1.5))
+
+
+def test_pad_deepseek_v4_tensor_rejects_truncation():
+    weight = torch.empty((2, 3))
+
+    with pytest.raises(ValueError, match="Cannot pad DeepSeek V4 tensor"):
+        _pad_deepseek_v4_tensor(weight, dim=1, target_size=2)
+
+
+def test_balanced_tp_block_padding_spreads_zero_blocks_across_ranks():
+    assert _balanced_tp_block_indices(24, 32, 16) == [
+        0,
+        1,
+        2,
+        4,
+        5,
+        6,
+        8,
+        9,
+        10,
+        12,
+        13,
+        14,
+        16,
+        17,
+        18,
+        20,
+        21,
+        22,
+        24,
+        25,
+        26,
+        28,
+        29,
+        30,
+    ]
+
+    weight = torch.arange(24, dtype=torch.float32).reshape(24, 1)
+    padded = _pad_deepseek_v4_tensor_by_tp_blocks(
+        weight,
+        dim=0,
+        target_size=32,
+        block_size=1,
+        tp_size=16,
+        fill_value=-1.0,
+    )
+
+    _assert_tp_balanced_padding(
+        padded,
+        weight,
+        dim=0,
+        block_size=1,
+        fill_value=-1.0,
+    )
+
+
+def test_balanced_tp_block_padding_preserves_linear_round_trip():
+    hidden_size = 5
+    original_intermediate_size = 3
+    padded_intermediate_size = 4
+
+    hidden_states = torch.randn(2, hidden_size)
+    gate_up_weight = torch.randn(original_intermediate_size, hidden_size)
+    down_weight = torch.randn(hidden_size, original_intermediate_size)
+
+    original_output = hidden_states.matmul(gate_up_weight.t()).matmul(down_weight.t())
+
+    padded_gate_up_weight = _pad_deepseek_v4_tensor_by_tp_blocks(
+        gate_up_weight,
+        dim=0,
+        target_size=padded_intermediate_size,
+        block_size=1,
+        tp_size=2,
+    )
+    padded_down_weight = _pad_deepseek_v4_tensor_by_tp_blocks(
+        down_weight,
+        dim=1,
+        target_size=padded_intermediate_size,
+        block_size=1,
+        tp_size=2,
+    )
+    padded_output = hidden_states.matmul(padded_gate_up_weight.t()).matmul(
+        padded_down_weight.t()
+    )
+
+    torch.testing.assert_close(padded_output, original_output)
+
+
+def test_shared_experts_loader_padding_for_gate_up_and_down(monkeypatch):
+    if not hasattr(torch, "float8_e4m3fn"):
+        pytest.skip("torch build does not expose float8_e4m3fn")
+
+    monkeypatch.setattr(deepseek_v4, "get_tensor_model_parallel_world_size", lambda: 16)
+    model = _empty_deepseek_v4_model()
+
+    gate_up = torch.ones((3072, 7168), dtype=torch.float8_e4m3fn)
+    padded_gate_up = model._maybe_pad_shared_experts_weight(
+        "model.layers.0.ffn.shared_experts.gate_up_proj.weight",
+        gate_up,
+    )
+    assert padded_gate_up.shape == (4096, 7168)
+    _assert_tp_balanced_padding(
+        padded_gate_up.view(torch.uint8),
+        gate_up.view(torch.uint8),
+        dim=0,
+        block_size=128,
+        fill_value=0,
+    )
+
+    down = torch.ones((7168, 3072), dtype=torch.float8_e4m3fn)
+    padded_down = model._maybe_pad_shared_experts_weight(
+        "model.layers.0.ffn.shared_experts.down_proj.weight",
+        down,
+    )
+    assert padded_down.shape == (7168, 4096)
+    _assert_tp_balanced_padding(
+        padded_down.view(torch.uint8),
+        down.view(torch.uint8),
+        dim=1,
+        block_size=128,
+        fill_value=0,
+    )
+
+
+def test_shared_experts_scale_loader_padding_uses_e8m0_identity(monkeypatch):
+    if not hasattr(torch, "float8_e8m0fnu"):
+        pytest.skip("torch build does not expose float8_e8m0fnu")
+
+    monkeypatch.setattr(deepseek_v4, "get_tensor_model_parallel_world_size", lambda: 16)
+    model = _empty_deepseek_v4_model()
+
+    gate_up_scale = torch.ones((24, 56), dtype=torch.float8_e8m0fnu)
+    padded_gate_up_scale = model._maybe_pad_shared_experts_weight(
+        "model.layers.0.ffn.shared_experts.gate_up_proj.weight_scale_inv",
+        gate_up_scale,
+    )
+    assert padded_gate_up_scale.shape == (32, 56)
+    _assert_tp_balanced_padding(
+        padded_gate_up_scale.view(torch.uint8),
+        gate_up_scale.view(torch.uint8),
+        dim=0,
+        block_size=1,
+        fill_value=127,
+    )
+
+    down_scale = torch.ones((56, 24), dtype=torch.float8_e8m0fnu)
+    padded_down_scale = model._maybe_pad_shared_experts_weight(
+        "model.layers.0.ffn.shared_experts.down_proj.weight_scale_inv",
+        down_scale,
+    )
+    assert padded_down_scale.shape == (56, 32)
+    _assert_tp_balanced_padding(
+        padded_down_scale.view(torch.uint8),
+        down_scale.view(torch.uint8),
+        dim=1,
+        block_size=1,
+        fill_value=127,
+    )
+
+
+def test_routed_fp8_experts_loader_padding_for_gate_up_and_down(monkeypatch):
+    if not hasattr(torch, "float8_e4m3fn"):
+        pytest.skip("torch build does not expose float8_e4m3fn")
+
+    monkeypatch.setattr(deepseek_v4, "get_tensor_model_parallel_world_size", lambda: 16)
+    model = _empty_deepseek_v4_model()
+    model.config.expert_dtype = "fp8"
+
+    w1 = torch.ones((3072, 7168), dtype=torch.float8_e4m3fn)
+    padded_w1 = model._maybe_pad_routed_experts_weight(
+        "model.layers.0.ffn.experts.0.w1.weight",
+        w1,
+    )
+    assert padded_w1.shape == (4096, 7168)
+    _assert_tp_balanced_padding(
+        padded_w1.view(torch.uint8),
+        w1.view(torch.uint8),
+        dim=0,
+        block_size=128,
+        fill_value=0,
+    )
+
+    w2 = torch.ones((7168, 3072), dtype=torch.float8_e4m3fn)
+    padded_w2 = model._maybe_pad_routed_experts_weight(
+        "model.layers.0.ffn.experts.0.w2.weight",
+        w2,
+    )
+    assert padded_w2.shape == (7168, 4096)
+    _assert_tp_balanced_padding(
+        padded_w2.view(torch.uint8),
+        w2.view(torch.uint8),
+        dim=1,
+        block_size=128,
+        fill_value=0,
+    )
+
+
+def test_routed_fp8_experts_scale_padding_uses_float_identity(monkeypatch):
+    monkeypatch.setattr(deepseek_v4, "get_tensor_model_parallel_world_size", lambda: 16)
+    model = _empty_deepseek_v4_model()
+    model.config.expert_dtype = "fp8"
+
+    w1_scale = torch.ones((24, 56), dtype=torch.float32)
+    padded_w1_scale = model._maybe_pad_routed_experts_weight(
+        "model.layers.0.ffn.experts.0.w1.weight_scale_inv",
+        w1_scale,
+    )
+    assert padded_w1_scale.shape == (32, 56)
+    _assert_tp_balanced_padding(
+        padded_w1_scale,
+        w1_scale,
+        dim=0,
+        block_size=1,
+        fill_value=1.0,
+    )
+
+    w2_scale = torch.ones((56, 24), dtype=torch.float32)
+    padded_w2_scale = model._maybe_pad_routed_experts_weight(
+        "model.layers.0.ffn.experts.0.w2.weight_scale_inv",
+        w2_scale,
+    )
+    assert padded_w2_scale.shape == (56, 32)
+    _assert_tp_balanced_padding(
+        padded_w2_scale,
+        w2_scale,
+        dim=1,
+        block_size=1,
+        fill_value=1.0,
+    )
+
+
+def test_mtp_shared_experts_loader_reuses_tp16_padding(monkeypatch):
+    if not hasattr(torch, "float8_e4m3fn"):
+        pytest.skip("torch build does not expose float8_e4m3fn")
+
+    monkeypatch.setattr(
+        deepseek_v4_mtp, "get_tensor_model_parallel_world_size", lambda: 16
+    )
+    model = _empty_deepseek_v4_mtp_model()
+
+    gate_up = torch.ones((3072, 7168), dtype=torch.float8_e4m3fn)
+    padded_gate_up = model._maybe_pad_shared_experts_weight(
+        "model.layers.61.mtp_block.ffn.shared_experts.gate_up_proj.weight",
+        gate_up,
+    )
+    assert padded_gate_up.shape == (4096, 7168)
+    _assert_tp_balanced_padding(
+        padded_gate_up.view(torch.uint8),
+        gate_up.view(torch.uint8),
+        dim=0,
+        block_size=128,
+        fill_value=0,
+    )
+
+    down = torch.ones((7168, 3072), dtype=torch.float8_e4m3fn)
+    padded_down = model._maybe_pad_shared_experts_weight(
+        "model.layers.61.mtp_block.ffn.shared_experts.down_proj.weight",
+        down,
+    )
+    assert padded_down.shape == (7168, 4096)
+    _assert_tp_balanced_padding(
+        padded_down.view(torch.uint8),
+        down.view(torch.uint8),
+        dim=1,
+        block_size=128,
+        fill_value=0,
+    )
+
+
+def test_mtp_shared_experts_scale_padding_uses_e8m0_identity(monkeypatch):
+    if not hasattr(torch, "float8_e8m0fnu"):
+        pytest.skip("torch build does not expose float8_e8m0fnu")
+
+    monkeypatch.setattr(
+        deepseek_v4_mtp, "get_tensor_model_parallel_world_size", lambda: 16
+    )
+    model = _empty_deepseek_v4_mtp_model()
+
+    down_scale = torch.ones((56, 24), dtype=torch.float8_e8m0fnu)
+    padded_down_scale = model._maybe_pad_shared_experts_weight(
+        "model.layers.61.mtp_block.ffn.shared_experts.down_proj.weight_scale_inv",
+        down_scale,
+    )
+
+    assert padded_down_scale.shape == (56, 32)
+    _assert_tp_balanced_padding(
+        padded_down_scale.view(torch.uint8),
+        down_scale.view(torch.uint8),
+        dim=1,
+        block_size=1,
+        fill_value=127,
+    )
+
+
+def test_tp16_fp8_shared_experts_mlp_requires_padded_intermediate(monkeypatch):
+    import vllm.distributed as distributed
+    import vllm.model_executor.layers.linear as linear
+    import vllm.model_executor.layers.quantization.fp8 as fp8
+    import vllm.model_executor.parameter as parameter
+
+    for module in (distributed, linear, parameter):
+        monkeypatch.setattr(module, "get_tensor_model_parallel_world_size", lambda: 16)
+        monkeypatch.setattr(module, "get_tensor_model_parallel_rank", lambda: 0)
+
+    monkeypatch.setattr(fp8, "init_fp8_linear_kernel", lambda **kwargs: object())
+
+    vllm_config = VllmConfig()
+    vllm_config.model_config = SimpleNamespace(dtype=torch.bfloat16)
+    quant_config = _fp8_block_config()
+
+    with set_current_vllm_config(vllm_config):
+        with pytest.raises(ValueError, match="input_size_per_partition = 192"):
+            DeepseekV4MLP(
+                hidden_size=7168,
+                intermediate_size=3072,
+                hidden_act="silu",
+                quant_config=quant_config,
+                prefix="model.layers.0.ffn.shared_experts",
+            )
+
+        padded_size = _padded_moe_intermediate_size(3072, quant_config, 16)
+        mlp = DeepseekV4MLP(
+            hidden_size=7168,
+            intermediate_size=padded_size,
+            hidden_act="silu",
+            quant_config=quant_config,
+            prefix="model.layers.0.ffn.shared_experts",
+        )
+
+    assert padded_size == 4096
+    assert mlp.down_proj.input_size_per_partition == 256
+    assert mlp.gate_up_proj.output_partition_sizes == [256, 256]
+
+
+@pytest.mark.parametrize(
+    ("expert_dtype", "expected_routed_size", "expected_shared_size"),
+    [
+        ("fp4", 3072, 4096),
+        ("fp8", 4096, 4096),
+    ],
+)
+def test_tp16_moe_construction_preserves_expert_dtype_padding_contract(
+    expert_dtype: str,
+    expected_routed_size: int,
+    expected_shared_size: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    class FakeGate(torch.nn.Module):
+        def __init__(self, *args: object, **kwargs: object):
+            super().__init__()
+            self.e_score_correction_bias = None
+            self.tid2eid = None
+
+    class FakeMLP(torch.nn.Module):
+        calls: list[dict[str, object]] = []
+
+        def __init__(self, **kwargs: object):
+            super().__init__()
+            self.kwargs = kwargs
+            FakeMLP.calls.append(kwargs)
+
+    class FakeFusedMoE(torch.nn.Module):
+        calls: list[dict[str, object]] = []
+
+        def __init__(self, **kwargs: object):
+            super().__init__()
+            self.kwargs = kwargs
+            FakeFusedMoE.calls.append(kwargs)
+
+    monkeypatch.setattr(deepseek_v4, "get_tensor_model_parallel_world_size", lambda: 16)
+    monkeypatch.setattr(deepseek_v4, "get_tensor_model_parallel_rank", lambda: 0)
+    monkeypatch.setattr(deepseek_v4, "GateLinear", FakeGate)
+    monkeypatch.setattr(deepseek_v4, "DeepseekV4MLP", FakeMLP)
+    monkeypatch.setattr(deepseek_v4, "FusedMoE", FakeFusedMoE)
+
+    config = _deepseek_v4_moe_config(expert_dtype=expert_dtype)
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(hf_config=config),
+        quant_config=_fp8_block_config(),
+        parallel_config=SimpleNamespace(enable_expert_parallel=False),
+        kernel_config=SimpleNamespace(moe_backend=None),
+    )
+
+    moe = DeepseekV4MoE(vllm_config, prefix="model.layers.0.ffn")
+
+    assert moe.shared_experts_intermediate_size == expected_shared_size
+    assert FakeMLP.calls[0]["intermediate_size"] == expected_shared_size
+    assert FakeFusedMoE.calls[0]["intermediate_size"] == expected_routed_size
+
+
+def test_deepseek_v4_fp8_config_preserves_expert_dtype_dispatch(monkeypatch):
+    import vllm.config as vllm_config_module
+    from vllm.model_executor.layers.fused_moe import FusedMoE
+    from vllm.model_executor.layers.fused_moe.layer import UnquantizedFusedMoEMethod
+    from vllm.model_executor.layers.quantization.fp8 import Fp8MoEMethod
+    from vllm.model_executor.layers.quantization.mxfp4 import Mxfp4MoEMethod
+
+    vllm_config = VllmConfig()
+    vllm_config.model_config = SimpleNamespace(dtype=torch.bfloat16)
+    fake_layer = object.__new__(FusedMoE)
+    fake_layer.moe_config = SimpleNamespace()
+    fake_layer.local_num_experts = 1
+
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.mxfp4.select_mxfp4_moe_backend",
+        lambda moe: (None, None),
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.quantization.fp8.select_fp8_moe_backend",
+        lambda **kwargs: (None, None),
+    )
+    quant_config = DeepseekV4FP8Config(
+        is_checkpoint_fp8_serialized=True,
+        activation_scheme="dynamic",
+        weight_block_size=[128, 128],
+    )
+
+    vllm_config.model_config.hf_config = SimpleNamespace(expert_dtype="fp4")
+    monkeypatch.setattr(
+        vllm_config_module, "get_current_vllm_config", lambda: vllm_config
+    )
+    with set_current_vllm_config(vllm_config):
+        assert isinstance(
+            quant_config.get_quant_method(fake_layer, "model.layers.0.ffn.experts"),
+            Mxfp4MoEMethod,
+        )
+    assert quant_config.is_mxfp4_quant("model.layers.0.ffn.experts", fake_layer)
+    assert quant_config.is_scale_e8m0
+
+    quant_config._resolved_expert_dtype = None
+    vllm_config.model_config.hf_config = SimpleNamespace(expert_dtype="fp8")
+    monkeypatch.setattr(
+        vllm_config_module, "get_current_vllm_config", lambda: vllm_config
+    )
+    with set_current_vllm_config(vllm_config):
+        method = quant_config.get_quant_method(fake_layer, "model.layers.0.ffn.experts")
+    assert isinstance(method, Fp8MoEMethod)
+    assert not isinstance(method, Mxfp4MoEMethod | UnquantizedFusedMoEMethod)
+    assert not quant_config.is_mxfp4_quant("model.layers.0.ffn.experts", fake_layer)
+    assert not quant_config.is_scale_e8m0
+
+
+def test_routed_mxfp4_experts_keep_checkpoint_intermediate_size():
+    # The default DeepSeek V4 Flash route keeps routed experts on MXFP4, while
+    # only FP8 linear/shared expert paths require TP16 block-shape padding.
+    assert _padded_moe_intermediate_size(3072, Mxfp4Config(), 16) == 3072

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -162,6 +162,7 @@ if TYPE_CHECKING:
     VLLM_TPU_BUCKET_PADDING_GAP: int = 0
     VLLM_TPU_MOST_MODEL_LEN: int | None = None
     VLLM_TPU_USING_PATHWAYS: bool = False
+    VLLM_DETERMINISTIC_AUX_STREAM: bool = False
     VLLM_USE_DEEP_GEMM: bool = True
     VLLM_MOE_USE_DEEP_GEMM: bool = True
     VLLM_USE_DEEP_GEMM_E8M0: bool = True
@@ -1250,6 +1251,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Whether using Pathways
     "VLLM_TPU_USING_PATHWAYS": lambda: bool(
         "proxy" in os.getenv("JAX_PLATFORMS", "").lower()
+    ),
+    # When set to 1, force `multi_stream_utils.maybe_execute_in_parallel` and
+    # `execute_in_parallel` to run on a single stream. Removes a non-determinism
+    # source observed under cross-node TP (e.g. DeepSeek V4 attn_gemm parallel
+    # path on multi-node TP=16) at a small concurrent-throughput cost.
+    "VLLM_DETERMINISTIC_AUX_STREAM": lambda: bool(
+        int(os.getenv("VLLM_DETERMINISTIC_AUX_STREAM", "0"))
     ),
     # Allow use of DeepGemm kernels for fused moe ops.
     "VLLM_USE_DEEP_GEMM": lambda: bool(int(os.getenv("VLLM_USE_DEEP_GEMM", "1"))),

--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -3,6 +3,7 @@
 import typing
 from collections.abc import Callable, Iterable
 from itertools import islice
+from math import lcm
 
 import regex as re
 import torch
@@ -65,6 +66,301 @@ from .utils import (
 )
 
 _DEEPSEEK_V4_EXPERT_DTYPES = ("fp4", "fp8")
+
+
+def _ceil_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def _padded_moe_intermediate_size(
+    intermediate_size: int,
+    quant_config: QuantizationConfig | None,
+    tp_size: int,
+) -> int:
+    if not isinstance(quant_config, Fp8Config):
+        return intermediate_size
+    weight_block_size = getattr(quant_config, "weight_block_size", None)
+    if weight_block_size is None or len(weight_block_size) < 2:
+        return intermediate_size
+    block_n, block_k = int(weight_block_size[0]), int(weight_block_size[1])
+    if tp_size <= 0 or block_n <= 0 or block_k <= 0:
+        return intermediate_size
+
+    # Row-parallel down projection requires the intermediate-dimension shard
+    # to align with block_k, while merged gate/up column-parallel scales are
+    # sharded at block_n granularity. Padding to TP * lcm(block_n, block_k)
+    # satisfies both without mutating the HF config object.
+    alignment = tp_size * lcm(block_n, block_k)
+    return _ceil_div(intermediate_size, alignment) * alignment
+
+
+def _pad_deepseek_v4_tensor(
+    loaded_weight: torch.Tensor,
+    dim: int,
+    target_size: int,
+    *,
+    fill_value: float = 0.0,
+    fill_e8m0_identity: bool = False,
+) -> torch.Tensor:
+    if dim >= loaded_weight.ndim:
+        return loaded_weight
+    if loaded_weight.shape[dim] == target_size:
+        return loaded_weight
+    if loaded_weight.shape[dim] > target_size:
+        raise ValueError(
+            f"Cannot pad DeepSeek V4 tensor dimension {dim} from "
+            f"{loaded_weight.shape[dim]} down to {target_size}."
+        )
+
+    padded_shape = list(loaded_weight.shape)
+    padded_shape[dim] = target_size
+    padded = loaded_weight.new_empty(padded_shape)
+    if fill_e8m0_identity:
+        padded.view(torch.uint8).fill_(127)
+    else:
+        padded.fill_(fill_value)
+
+    slices = [slice(None)] * loaded_weight.ndim
+    slices[dim] = slice(0, loaded_weight.shape[dim])
+    padded[tuple(slices)].copy_(loaded_weight)
+    return padded
+
+
+def _balanced_tp_block_indices(
+    original_blocks: int,
+    padded_blocks: int,
+    tp_size: int,
+) -> list[int]:
+    if (
+        original_blocks <= 0
+        or padded_blocks <= 0
+        or original_blocks > padded_blocks
+        or tp_size <= 0
+        or padded_blocks % tp_size != 0
+    ):
+        return list(range(original_blocks))
+
+    blocks_per_partition = padded_blocks // tp_size
+    if blocks_per_partition <= 0:
+        return list(range(original_blocks))
+
+    base_blocks_per_partition = original_blocks // tp_size
+    extra_partitions = original_blocks % tp_size
+    if base_blocks_per_partition > blocks_per_partition:
+        return list(range(original_blocks))
+
+    # Spread the partitions that receive one extra checkpoint block across
+    # tensor-parallel ranks instead of appending all padding to the final ranks.
+    # For DeepSeek V4 Pro at TP=16 this maps 24 original FP8 blocks into
+    # 32 padded blocks as:
+    #   [0, 1], [2, pad], [3, 4], [5, pad], ...
+    # This preserves the checkpoint block order while avoiding four ranks
+    # with a completely zero shared-expert shard on 2-node TP=16 runs.
+    extra_partition_indices = (
+        {(i * tp_size) // extra_partitions for i in range(extra_partitions)}
+        if extra_partitions
+        else set()
+    )
+
+    block_indices: list[int] = []
+    for partition in range(tp_size):
+        partition_blocks = base_blocks_per_partition
+        if partition in extra_partition_indices:
+            partition_blocks += 1
+        if partition_blocks > blocks_per_partition:
+            return list(range(original_blocks))
+        start = partition * blocks_per_partition
+        block_indices.extend(start + offset for offset in range(partition_blocks))
+
+    if len(block_indices) != original_blocks:
+        return list(range(original_blocks))
+    return block_indices
+
+
+def _pad_deepseek_v4_tensor_by_tp_blocks(
+    loaded_weight: torch.Tensor,
+    dim: int,
+    target_size: int,
+    *,
+    block_size: int,
+    tp_size: int,
+    fill_value: float = 0.0,
+    fill_e8m0_identity: bool = False,
+) -> torch.Tensor:
+    if (
+        dim >= loaded_weight.ndim
+        or block_size <= 0
+        or loaded_weight.shape[dim] == target_size
+    ):
+        return _pad_deepseek_v4_tensor(
+            loaded_weight,
+            dim,
+            target_size,
+            fill_value=fill_value,
+            fill_e8m0_identity=fill_e8m0_identity,
+        )
+    if loaded_weight.shape[dim] > target_size:
+        raise ValueError(
+            f"Cannot pad DeepSeek V4 tensor dimension {dim} from "
+            f"{loaded_weight.shape[dim]} down to {target_size}."
+        )
+    if loaded_weight.shape[dim] % block_size != 0 or target_size % block_size != 0:
+        return _pad_deepseek_v4_tensor(
+            loaded_weight,
+            dim,
+            target_size,
+            fill_value=fill_value,
+            fill_e8m0_identity=fill_e8m0_identity,
+        )
+
+    original_blocks = loaded_weight.shape[dim] // block_size
+    padded_blocks = target_size // block_size
+    block_indices = _balanced_tp_block_indices(
+        original_blocks,
+        padded_blocks,
+        tp_size,
+    )
+    if block_indices == list(range(original_blocks)):
+        return _pad_deepseek_v4_tensor(
+            loaded_weight,
+            dim,
+            target_size,
+            fill_value=fill_value,
+            fill_e8m0_identity=fill_e8m0_identity,
+        )
+
+    padded_shape = list(loaded_weight.shape)
+    padded_shape[dim] = target_size
+    padded = loaded_weight.new_empty(padded_shape)
+    if fill_e8m0_identity:
+        padded.view(torch.uint8).fill_(127)
+    else:
+        padded.fill_(fill_value)
+
+    src_slices = [slice(None)] * loaded_weight.ndim
+    dst_slices = [slice(None)] * loaded_weight.ndim
+    for src_block, dst_block in enumerate(block_indices):
+        src_slices[dim] = slice(
+            src_block * block_size,
+            (src_block + 1) * block_size,
+        )
+        dst_slices[dim] = slice(
+            dst_block * block_size,
+            (dst_block + 1) * block_size,
+        )
+        padded[tuple(dst_slices)].copy_(loaded_weight[tuple(src_slices)])
+
+    return padded
+
+
+def _maybe_pad_deepseek_v4_intermediate_tensor(
+    *,
+    original_size: int,
+    padded_size: int,
+    weight_block_size: list[int] | tuple[int, ...] | None,
+    name: str,
+    loaded_weight: torch.Tensor,
+    gate_up_markers: tuple[str, ...],
+    down_markers: tuple[str, ...],
+    tp_size: int,
+) -> torch.Tensor:
+    if loaded_weight.ndim < 2 or original_size == padded_size:
+        return loaded_weight
+    if weight_block_size is None or len(weight_block_size) < 2:
+        return loaded_weight
+    block_n, block_k = int(weight_block_size[0]), int(weight_block_size[1])
+    if block_n <= 0 or block_k <= 0:
+        return loaded_weight
+
+    is_weight_scale = ".weight_scale" in name or name.endswith(".scale")
+
+    if any(marker in name for marker in gate_up_markers):
+        dim = loaded_weight.ndim - 2
+        block_size = block_n
+    elif any(marker in name for marker in down_markers):
+        dim = loaded_weight.ndim - 1
+        block_size = block_k
+    else:
+        return loaded_weight
+
+    expected_size = (
+        _ceil_div(original_size, block_size) if is_weight_scale else original_size
+    )
+    if loaded_weight.shape[dim] != expected_size:
+        return loaded_weight
+
+    if is_weight_scale:
+        target_size = _ceil_div(padded_size, block_size)
+        tensor_block_size = 1
+    else:
+        target_size = padded_size
+        tensor_block_size = block_size
+
+    return _pad_deepseek_v4_tensor_by_tp_blocks(
+        loaded_weight,
+        dim,
+        target_size,
+        block_size=tensor_block_size,
+        tp_size=tp_size,
+        fill_value=1.0 if is_weight_scale else 0.0,
+        fill_e8m0_identity=is_weight_scale
+        and loaded_weight.dtype == torch.float8_e8m0fnu,
+    )
+
+
+def _maybe_pad_deepseek_v4_shared_experts_weight(
+    config: typing.Any,
+    quant_config: QuantizationConfig | None,
+    name: str,
+    loaded_weight: torch.Tensor,
+    tp_size: int,
+) -> torch.Tensor:
+    if ".shared_experts." not in name:
+        return loaded_weight
+
+    n_shared_experts = getattr(config, "n_shared_experts", None)
+    if n_shared_experts is None:
+        return loaded_weight
+    original_size = config.moe_intermediate_size * n_shared_experts
+    padded_size = _padded_moe_intermediate_size(original_size, quant_config, tp_size)
+
+    return _maybe_pad_deepseek_v4_intermediate_tensor(
+        original_size=original_size,
+        padded_size=padded_size,
+        weight_block_size=getattr(quant_config, "weight_block_size", None),
+        name=name,
+        loaded_weight=loaded_weight,
+        gate_up_markers=(".shared_experts.gate_up_proj.",),
+        down_markers=(".shared_experts.down_proj.",),
+        tp_size=tp_size,
+    )
+
+
+def _maybe_pad_deepseek_v4_routed_experts_weight(
+    config: typing.Any,
+    quant_config: QuantizationConfig | None,
+    name: str,
+    loaded_weight: torch.Tensor,
+    tp_size: int,
+) -> torch.Tensor:
+    if ".experts." not in name:
+        return loaded_weight
+    if getattr(config, "expert_dtype", "fp4") != "fp8":
+        return loaded_weight
+
+    original_size = config.moe_intermediate_size
+    padded_size = _padded_moe_intermediate_size(original_size, quant_config, tp_size)
+
+    return _maybe_pad_deepseek_v4_intermediate_tensor(
+        original_size=original_size,
+        padded_size=padded_size,
+        weight_block_size=getattr(quant_config, "weight_block_size", None),
+        name=name,
+        loaded_weight=loaded_weight,
+        gate_up_markers=(".w1.", ".w3."),
+        down_markers=(".w2.",),
+        tp_size=tp_size,
+    )
 
 
 class DeepseekV4MLP(nn.Module):
@@ -729,6 +1025,8 @@ class DeepseekV4MoE(nn.Module):
         self.n_routed_experts = config.n_routed_experts
         self.n_activated_experts = config.num_experts_per_tok
         self.moe_intermediate_size = config.moe_intermediate_size
+        self.routed_experts_intermediate_size = config.moe_intermediate_size
+        self.shared_experts_intermediate_size: int | None = None
         self.swiglu_limit = config.swiglu_limit
         self.renormalize = config.norm_topk_prob
         self.scoring_func = getattr(config, "scoring_func", "sqrtsoftplus")
@@ -778,6 +1076,10 @@ class DeepseekV4MoE(nn.Module):
             self.shared_experts = None
         else:
             intermediate_size = config.moe_intermediate_size * config.n_shared_experts
+            intermediate_size = _padded_moe_intermediate_size(
+                intermediate_size, quant_config, self.tp_size
+            )
+            self.shared_experts_intermediate_size = intermediate_size
 
             self.shared_experts = DeepseekV4MLP(
                 hidden_size=config.hidden_size,
@@ -832,6 +1134,12 @@ class DeepseekV4MoE(nn.Module):
         self.n_local_experts = config.n_routed_experts // self.tp_size
         self.experts_start_idx = self.tp_rank * self.n_local_experts
         self.experts_end_idx = self.experts_start_idx + self.n_local_experts
+        intermediate_size = config.moe_intermediate_size
+        if getattr(config, "expert_dtype", "fp4") == "fp8":
+            intermediate_size = _padded_moe_intermediate_size(
+                intermediate_size, quant_config, self.tp_size
+            )
+        self.routed_experts_intermediate_size = intermediate_size
 
         self.experts = FusedMoE(
             shared_experts=self.shared_experts,
@@ -839,7 +1147,7 @@ class DeepseekV4MoE(nn.Module):
             num_experts=config.n_routed_experts,
             top_k=config.num_experts_per_tok,
             hidden_size=config.hidden_size,
-            intermediate_size=config.moe_intermediate_size,
+            intermediate_size=intermediate_size,
             renormalize=config.norm_topk_prob,
             quant_config=quant_config,
             prefix=f"{prefix}.experts",
@@ -1225,6 +1533,7 @@ class DeepseekV4Model(nn.Module):
         config = vllm_config.model_config.hf_config
         quant_config = vllm_config.quant_config
         self.config = config
+        self.quant_config = quant_config
 
         self.vocab_size = config.vocab_size
         self.hc_eps = config.hc_eps
@@ -1297,6 +1606,28 @@ class DeepseekV4Model(nn.Module):
             device=self.device,
         )
 
+    def _maybe_pad_shared_experts_weight(
+        self, name: str, loaded_weight: torch.Tensor
+    ) -> torch.Tensor:
+        return _maybe_pad_deepseek_v4_shared_experts_weight(
+            self.config,
+            self.quant_config,
+            name,
+            loaded_weight,
+            get_tensor_model_parallel_world_size(),
+        )
+
+    def _maybe_pad_routed_experts_weight(
+        self, name: str, loaded_weight: torch.Tensor
+    ) -> torch.Tensor:
+        return _maybe_pad_deepseek_v4_routed_experts_weight(
+            self.config,
+            self.quant_config,
+            name,
+            loaded_weight,
+            get_tensor_model_parallel_world_size(),
+        )
+
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
         return self.embed_tokens(input_ids)
 
@@ -1364,6 +1695,9 @@ class DeepseekV4Model(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
+                loaded_weight = self._maybe_pad_shared_experts_weight(
+                    name, loaded_weight
+                )
 
                 param = params_dict[name]
                 weight_loader = param.weight_loader
@@ -1386,6 +1720,9 @@ class DeepseekV4Model(nn.Module):
                         if weight_name not in name:
                             continue
                         name_mapped = name.replace(weight_name, param_name)
+                        loaded_weight = self._maybe_pad_routed_experts_weight(
+                            name, loaded_weight
+                        )
                         param = params_dict[name_mapped]
                         # We should ask the weight loader to return success or not
                         # here since otherwise we may skip experts with other
@@ -1413,6 +1750,9 @@ class DeepseekV4Model(nn.Module):
                     loaded_params.add(name)
                     continue
                 else:
+                    loaded_weight = self._maybe_pad_shared_experts_weight(
+                        name, loaded_weight
+                    )
                     param = params_dict[name]
                     weight_loader = getattr(
                         param, "weight_loader", default_weight_loader

--- a/vllm/model_executor/models/deepseek_v4_mtp.py
+++ b/vllm/model_executor/models/deepseek_v4_mtp.py
@@ -40,6 +40,8 @@ from .deepseek_mtp import SharedHead
 from .deepseek_v2 import get_spec_layer_idx_from_weight_name
 from .deepseek_v4 import (
     DeepseekV4DecoderLayer,
+    _maybe_pad_deepseek_v4_routed_experts_weight,
+    _maybe_pad_deepseek_v4_shared_experts_weight,
     hc_head,
     make_deepseek_v4_expert_params_mapping,
 )
@@ -274,6 +276,28 @@ class DeepSeekV4MTP(nn.Module):
     ) -> torch.Tensor | None:
         return self.model.compute_logits(hidden_states, spec_step_idx)
 
+    def _maybe_pad_shared_experts_weight(
+        self, name: str, loaded_weight: torch.Tensor
+    ) -> torch.Tensor:
+        return _maybe_pad_deepseek_v4_shared_experts_weight(
+            self.config,
+            self.quant_config,
+            name,
+            loaded_weight,
+            get_tensor_model_parallel_world_size(),
+        )
+
+    def _maybe_pad_routed_experts_weight(
+        self, name: str, loaded_weight: torch.Tensor
+    ) -> torch.Tensor:
+        return _maybe_pad_deepseek_v4_routed_experts_weight(
+            self.config,
+            self.quant_config,
+            name,
+            loaded_weight,
+            get_tensor_model_parallel_world_size(),
+        )
+
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         # Weight name remapping for checkpoint compatibility.
         # Maps checkpoint weight paths to model parameter paths.
@@ -375,6 +399,9 @@ class DeepSeekV4MTP(nn.Module):
                 if weight_name not in name:
                     continue
                 name = name.replace(weight_name, param_name)
+                loaded_weight = self._maybe_pad_shared_experts_weight(
+                    name, loaded_weight
+                )
 
                 param = params_dict[name]
                 weight_loader = param.weight_loader
@@ -396,6 +423,9 @@ class DeepSeekV4MTP(nn.Module):
                         if weight_name not in name:
                             continue
                         name_mapped = name.replace(weight_name, param_name)
+                        loaded_weight = self._maybe_pad_routed_experts_weight(
+                            name, loaded_weight
+                        )
                         param = params_dict[name_mapped]
                         # We should ask the weight loader to return success or not
                         # here since otherwise we may skip experts with other
@@ -427,6 +457,9 @@ class DeepSeekV4MTP(nn.Module):
                         name = name.replace(
                             ".shared_experts.w2", ".shared_experts.down_proj"
                         )
+                    loaded_weight = self._maybe_pad_shared_experts_weight(
+                        name, loaded_weight
+                    )
                     if name.endswith(".ffn.gate.bias"):
                         name = name.replace(".bias", ".e_score_correction_bias")
                     param = params_dict[name]

--- a/vllm/utils/multi_stream_utils.py
+++ b/vllm/utils/multi_stream_utils.py
@@ -7,6 +7,8 @@ from typing import Any
 
 import torch
 
+import vllm.envs as envs
+
 
 class AuxStreamType(Enum):
     Attention = 1
@@ -33,6 +35,12 @@ def maybe_execute_in_parallel(
     This design follows TensorRT-LLM's maybe_execute_in_parallel pattern
     (tensorrt_llm/_torch/modules/multi_stream_utils.py).
 
+    Setting ``VLLM_DETERMINISTIC_AUX_STREAM=1`` forces sequential execution
+    even when an ``aux_stream`` is supplied. Cross-node TP runs (e.g. multi-node
+    TP=16 for DeepSeek V4) observed bit-level non-determinism caused by
+    aux-stream completion order; the env-var lets operators trade a small
+    concurrent-throughput cost for reproducible logits.
+
     Args:
         fn0: Callable for the default stream.
         fn1: Callable for the auxiliary stream.
@@ -44,6 +52,8 @@ def maybe_execute_in_parallel(
     Returns:
         Tuple of (fn0_result, fn1_result).
     """
+    if envs.VLLM_DETERMINISTIC_AUX_STREAM:
+        aux_stream = None
     if aux_stream is not None:
         event0.record()
         result0 = fn0()
@@ -87,10 +97,15 @@ def execute_in_parallel(
         aux_streams: Per-aux CUDA streams. Length must match aux_fns.
             Multi-stream is disabled when None.
 
+    Setting ``VLLM_DETERMINISTIC_AUX_STREAM=1`` forces sequential execution
+    even when ``aux_streams`` is supplied (see ``maybe_execute_in_parallel``).
+
     Returns:
         Tuple of (default_result, aux_results) where aux_results[i] is the
         result of aux_fns[i] (or None when skipped).
     """
+    if envs.VLLM_DETERMINISTIC_AUX_STREAM:
+        aux_streams = None
     aux_results: list[Any]
     if aux_streams is None:
         default_result = default_fn()


### PR DESCRIPTION
## Purpose

This PR makes **cross-node TP=16 serving of DeepSeek V4 (Pro / Flash) work end-to-end** on FP8 checkpoints. Two independent issues block it today, both addressed here. They are bundled because Fix B was discovered *because* Fix A alone wasn't enough — keeping them together preserves the full reproduction trail for reviewers.

### Issue A — FP8 weight loading fails at TP=16

DeepSeek V4 has `moe_intermediate_size = 3072` and ships with a `[128, 128]` FP8 block-quant scheme. At TP=16 the per-rank input dim becomes `3072 / 16 = 192`, which is not divisible by `block_k = 128`, so model load fails with:

```
ValueError: Weight input_size_per_partition = 192
is not divisible by weight quantization block_k = 128.
```

This is the same class of bug that #34408 fixes for EXAONE4-32B-FP8 and that #36853 reports for Qwen3-Coder-Next-FP8. TP ≤ 8 is unaffected (`3072 / 8 = 384`, divisible by 128), which is why the problem only surfaces on 2-node deployments — exactly the topology that #36836 (RayExecutorV2, merged) was designed to enable.

**Fix A — load-time intermediate-size padding.** Mirror the EXAONE4 pattern: pad `moe_intermediate_size` to the smallest multiple of `TP × lcm(block_n, block_k)` (4096 at TP=16) and zero-pad the affected `gate_proj` / `up_proj` / `down_proj` weights and their `weight_scale_inv` tensors at load time. SwiGLU preserves zero-in → zero-out, so no activation mask is needed.

Padding is **only applied** when:
- `quant_config` is `Fp8Config` with `weight_block_size` set, AND
- `tp_size × lcm(block_n, block_k)` does not already divide the original size.

So existing TP ≤ 8 deployments and non-FP8 quant configs (e.g. routed MXFP4 experts on V4 Flash) are pass-through unchanged.

A subtlety worth flagging: a naive append-only pad places all the zero blocks on the highest TP ranks, which leaves several ranks holding an entirely-zero shared-expert shard at TP=16 (24 → 32 blocks across 16 ranks ⇒ 8 ranks fully zero). We use a **balanced TP-block layout** that spreads the original 24 blocks evenly across the 16 ranks (most ranks get 1 real block + 1 zero block, the "extra" 8 real blocks distributed every other rank), so no rank ends up with a fully-zero expert shard. This is the change in commit 2.

Memory cost: ~505 MiB / GPU at TP=16, ~7.9 GiB across the model. Acceptable to unlock the deployment.

### Issue B — Cross-node TP=16 reasoning produces garbage output

Even with Fix A applied, `reasoning_effort=max` + long system prompt + `temp=1.0` produces mode-collapsed multilingual token soup with leaked `<｜begin▁of▁sentence｜>` control tokens on TP=16. Critically, the same regression reproduces at `temp=0`: 3 trials of the same prompt yield 3 different outputs, with one or two collapsing into garbage. TP=8 single-node is byte-equal stable across trials.

Root cause: `vllm/utils/multi_stream_utils.py:maybe_execute_in_parallel` dispatches `q_proj` / kv-compressor / indexer GEMMs onto a default + auxiliary CUDA stream (used by `deepseek_v4_attention.attn_gemm_parallel_execute`). Stream-completion order is non-deterministic across forward passes, perturbing FP accumulation downstream at the bit level. Short generations are robust to this jitter, but during the long thinking phase produced by `reasoning_effort=max`, the cumulative perturbation eventually swaps top-1 ↔ top-2 once and the generation diverges into out-of-distribution tokens.

**Fix B — opt-in deterministic mode.** Add `VLLM_DETERMINISTIC_AUX_STREAM` (default OFF). When set, both `maybe_execute_in_parallel` and `execute_in_parallel` force `aux_stream` / `aux_streams = None`, falling back to sequential execution.

- Default behavior is unchanged — single-node TP ≤ 8 users see no difference.
- Cross-node TP operators set `VLLM_DETERMINISTIC_AUX_STREAM=1` to trade a small concurrent-throughput cost (~5%) for reproducible logits.
- The flag lives in `vllm/utils/multi_stream_utils.py`, so every call site that goes through these helpers (not just DeepSeek V4) gets the determinism toggle for free.

### Negative results that informed Fix B

For reviewer context, here is what we tried before landing on Fix B:

- **Padding form alone is not enough.** Both v1 (append-only) and v2 (LCM-balanced TP-block spread) padding resolve the load-time `ValueError` but do not resolve the `reasoning_effort=max` regression on cross-node TP=16.
- **Switching base image is not enough either.** Building from vLLM main nightly instead of the `deepseekv4-cu130` image does not fix the regression, and additionally introduces an unrelated `ScalarType 44` (FP8 e8m0fnu) crash for cross-node TP=16 + UE8M0, so nightly is not a viable workaround at the moment.
- **`temp=0` self-inconsistency** at TP=16 (with multi-stream ON) was the conclusive signal that the regression is a numerical-determinism issue, not a sampling or padding issue.

### Related work

- #34408 — EXAONE4 padding fix (same class as Fix A, open)
- #36853 — Qwen3-Coder-Next-FP8 TP=8 error (related class, open)
- #36836 — RayExecutorV2 (merged, enables the 2-node topology)
- #38164 — RayExecutorV2 + EEP (future work; out of scope here)

### Out of scope

- Expert Parallelism (`--enable-expert-parallel`) for DeepSeek V4 — separate workstream tracked in #38164.
- Pipeline Parallelism — DeepSeek V4 currently does not implement `SupportsPP`.
- B300 SM_120 sparse MLA — tracked in #40991; does not affect the SM_100 path used by B300 SXM6.
- CUDA-graph compilation of the 1.6T-parameter Pro variant — `torch.compile` OOMs the 1.9 TiB host RAM under current main. Left for future work; this PR validates only `--enforce-eager`.

---

## Test Plan

### Unit tests

`tests/models/test_deepseek_v4_padding.py` (new, 17 tests) covers:

- `_padded_moe_intermediate_size` — only pads on FP8 + misaligned TP, otherwise pass-through (verified at TP=1/8/16, MXFP4, `None`).
- `_pad_deepseek_v4_tensor` — value preservation, fill behavior, refuses truncation.
- `_balanced_tp_block_indices` — exact 24→32 layout at TP=16, asserts the expected `[0,1,2,4,5,6,8,9,10,...]` pattern that prevents all-zero shards.
- Round-trip linear-equivalence: padded `gate_up @ down` produces the same output as the original on the unpadded region.
- Loader-level: shared-expert and routed-expert FP8 / `weight_scale_inv` / E8M0-scale padding on both `DeepseekV4Model` and `DeepSeekV4MTP`.
- Construction contract: `DeepseekV4MLP` raises the original `192` `ValueError` on TP=16 without padding, and constructs cleanly with the padded size; `DeepseekV4MoE` preserves `expert_dtype="fp4"` (routed stays at 3072) vs `"fp8"` (routed padded to 4096) routing.
- `DeepseekV4FP8Config` dispatch correctly routes `expert_dtype="fp4"` → `Mxfp4MoEMethod` and `"fp8"` → `Fp8MoEMethod`.

```bash
pytest tests/models/test_deepseek_v4_padding.py -v
```

### End-to-end (2× B300 SXM6, RoCEv2)

Cluster: 2 nodes × 8× B300 SXM6 (16 GPUs total), CUDA 13.0, NCCL 2.28.9, Ray 2.49.0, RoCEv2 over `enp83s0f1np1`.

```bash
# Per-node ray bring-up (head + worker; standard --add-host b300-01/02 + GLOO/NCCL_SOCKET_IFNAME), then on head:
docker exec -d \
  -e VLLM_USE_RAY_V2_EXECUTOR_BACKEND=1 \
  -e VLLM_DETERMINISTIC_AUX_STREAM=1 \
  -e RAY_ADDRESS=10.1.130.11:6379 \
  -e GLOO_SOCKET_IFNAME=enp83s0f1np1 \
  -e NCCL_SOCKET_IFNAME=enp83s0f1np1 \
  ray-head bash -c 'vllm serve deepseek-ai/DeepSeek-V4-Pro \
    --trust-remote-code \
    --tensor-parallel-size 16 \
    --distributed-executor-backend ray \
    --kv-cache-dtype fp8 \
    --block-size 256 \
    --enforce-eager \
    --tokenizer-mode deepseek_v4 \
    --tool-call-parser deepseek_v4 \
    --enable-auto-tool-choice \
    --reasoning-parser deepseek_v4 \
    --port 8000'
```

Verification:
1. Health: `curl http://<head>:8000/v1/models` returns the model id.
2. Functional: chat completion `"What is 17 × 19?"` returns 323.
3. Numerical: byte-equality vs TP=8 single-node baseline at `temp=0` on 6 representative prompts.
4. Reasoning regression: original failure case `reasoning_effort=max + long system + temp=1.0`, 5 trials.

---

## Test Result

### Before this PR

```
ValueError: Weight input_size_per_partition = 192
is not divisible by weight quantization block_k = 128.
```

Model fails to load. (After local Fix A only, without Fix B: model loads, but the reasoning regression reported below is reproducible.)

### After this PR (Fix A + Fix B with `VLLM_DETERMINISTIC_AUX_STREAM=1`)

**Correctness — TP=16 vs TP=8 byte-equality at `temp=0`**

| Prompt | Bytes equal? |
|--------|:---:|
| `대한민국의 수도는?` | ✅ |
| `대한민국 헌법 제1조의 내용을 그대로 인용하세요.` | ✅ |
| `What is the capital of France?` | ✅ |
| `Compute 17 * 19.` | ✅ |
| Python one-liner sum 1..100 | ✅ |
| Bob/Alice age reasoning puzzle | ✅ |
| **Overall** | **6 / 6** |

**Self-consistency on TP=16 at `temp=0` (3 trials × 4 prompts):** all stable. Without Fix B (env var unset, default), the reasoning prompt was unstable across trials (2 hash variants per 3 trials, occasional garbage).

**Reasoning regression — `reasoning_effort=max + long system + temp=1.0`, 5 trials**

| | Result |
|---|---|
| Without Fix B | 3/3 garbage (mode-collapse, `<｜begin▁of▁sentence｜>` leak) |
| **With Fix B** | **5/5 clean responses** (correct multilingual answers + tool calls) |

**Performance — single request, 256-token completion, `--enforce-eager`**

| Setup | TTFT median | Decode tok/s |
|-------|:---:|:---:|
| TP=8 single-node | 276 ms | 4.0 |
| TP=16 (multi-stream ON) | 310 ms | 3.7 |
| **TP=16 + Fix A + Fix B** | **307 ms** | **3.7** |

**Performance — concurrent, 100 prompts, RPS=8, max_concurrency=32, `--enforce-eager`**

| Setup | Output tok/s | Total tok/s | TTFT median | TPOT median |
|-------|:---:|:---:|:---:|:---:|
| TP=8 single-node | 78.0 | 389.8 | 4625 ms | 310 ms |
| TP=16 (multi-stream ON) | 64.4 | 321.9 | 14720 ms | 335 ms |
| **TP=16 + Fix A + Fix B** | **60.9** | **304** | 15922 ms | 372 ms |

Fix B costs ~5% concurrent throughput vs the multi-stream baseline at TP=16. Cross-node TP=16 is communication-bound (RoCEv2 ~50 GB/s vs intra-node NVLink ~900 GB/s), so the value of this PR is **enabling a single endpoint that serves 16 GPUs of capacity**, not raw token-rate gain over single-node TP=8. With CUDA-graph enabled (future work — currently OOMs `torch.compile` host RAM), expect 5–10× decode throughput.

---

<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR — see "Issue A" and "Issue B" above.
- [x] The test plan — unit (`pytest tests/models/test_deepseek_v4_padding.py -v`) and 2-node B300 e2e command provided.
- [x] The test results — correctness (6/6 byte-equal vs TP=8), regression (5/5 clean with Fix B vs 3/3 garbage without), and single/concurrent performance tables.
- [x] (Optional) Documentation — `VLLM_DETERMINISTIC_AUX_STREAM` is documented inline in `vllm/envs.py` and in the docstrings of `maybe_execute_in_parallel` / `execute_in_parallel`.

</details>