### PR TITLE
Avoid redundant AITER MoE output copies

### DIFF
--- a/tests/kernels/moe/test_modular_kernel_direct_output.py
+++ b/tests/kernels/moe/test_modular_kernel_direct_output.py
@@ -1,0 +1,334 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+import vllm.model_executor.layers.fused_moe.modular_kernel as mk
+from vllm.model_executor.layers.fused_moe.activation import MoEActivation
+from vllm.model_executor.layers.fused_moe.config import (
+    FUSED_MOE_UNQUANTIZED_CONFIG,
+    FusedMoEConfig,
+    FusedMoEParallelConfig,
+    RoutingMethodType,
+)
+from vllm.model_executor.layers.fused_moe.prepare_finalize.no_dp_ep import (
+    MoEPrepareAndFinalizeNoDPEPModular,
+)
+from vllm.model_executor.layers.fused_moe.topk_weight_and_reduce import (
+    TopKWeightAndReduceNoOP,
+)
+from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
+
+
+def _make_moe_config() -> FusedMoEConfig:
+    return FusedMoEConfig(
+        num_experts=1,
+        experts_per_token=1,
+        hidden_dim=3,
+        intermediate_size_per_partition=4,
+        num_local_experts=1,
+        num_logical_experts=1,
+        moe_parallel_config=FusedMoEParallelConfig.make_no_parallel(),
+        activation=MoEActivation.SILU,
+        in_dtype=torch.float32,
+        device="cpu",
+        routing_method=RoutingMethodType.TopK,
+        max_num_tokens=8,
+    )
+
+
+class _DirectOutputExperts(mk.FusedMoEExpertsModular):
+    def __init__(
+        self,
+        direct_output: torch.Tensor,
+        weight_and_reduce_impl: mk.TopKWeightAndReduce | None = None,
+    ) -> None:
+        super().__init__(
+            moe_config=_make_moe_config(),
+            quant_config=FUSED_MOE_UNQUANTIZED_CONFIG,
+        )
+        self.direct_output = direct_output
+        self.weight_and_reduce_impl = (
+            weight_and_reduce_impl or TopKWeightAndReduceNoOP()
+        )
+        self.output_arg: torch.Tensor | None = None
+
+    @staticmethod
+    def activation_format() -> mk.FusedMoEActivationFormat:
+        return mk.FusedMoEActivationFormat.Standard
+
+    @staticmethod
+    def _supports_current_device() -> bool:
+        return True
+
+    @staticmethod
+    def _supports_no_act_and_mul() -> bool:
+        return True
+
+    @staticmethod
+    def _supports_quant_scheme(
+        weight_key: QuantKey | None,
+        activation_key: QuantKey | None,
+    ) -> bool:
+        return True
+
+    @staticmethod
+    def _supports_activation(activation: MoEActivation) -> bool:
+        return True
+
+    @staticmethod
+    def _supports_parallel_config(
+        moe_parallel_config: FusedMoEParallelConfig,
+    ) -> bool:
+        return True
+
+    def supports_expert_map(self) -> bool:
+        return True
+
+    def finalize_weight_and_reduce_impl(self) -> mk.TopKWeightAndReduce:
+        return self.weight_and_reduce_impl
+
+    def workspace_shapes(
+        self,
+        M: int,
+        N: int,
+        K: int,
+        topk: int,
+        global_num_experts: int,
+        local_num_experts: int,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        activation: MoEActivation,
+    ) -> tuple[tuple[int, ...], tuple[int, ...], tuple[int, ...]]:
+        return (1,), (1,), (M, K)
+
+    def apply(
+        self,
+        output: torch.Tensor,
+        hidden_states: torch.Tensor,
+        w1: torch.Tensor,
+        w2: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        activation: MoEActivation,
+        global_num_experts: int,
+        expert_map: torch.Tensor | None,
+        a1q_scale: torch.Tensor | None,
+        a2_scale: torch.Tensor | None,
+        workspace13: torch.Tensor,
+        workspace2: torch.Tensor,
+        expert_tokens_meta: mk.ExpertTokensMetadata | None,
+        apply_router_weight_on_input: bool,
+    ) -> torch.Tensor | None:
+        self.output_arg = output
+        return self.direct_output
+
+
+class _TrackingNoDPEP(MoEPrepareAndFinalizeNoDPEPModular):
+    def __init__(self) -> None:
+        self.finalize_calls = 0
+
+    def finalize(
+        self,
+        output: torch.Tensor,
+        fused_expert_output: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        apply_router_weight_on_input: bool,
+        weight_and_reduce_impl: mk.TopKWeightAndReduce,
+    ) -> None:
+        self.finalize_calls += 1
+        super().finalize(
+            output,
+            fused_expert_output,
+            topk_weights,
+            topk_ids,
+            apply_router_weight_on_input,
+            weight_and_reduce_impl,
+        )
+
+
+def _make_impl(
+    direct_output: torch.Tensor,
+    prepare_finalize: MoEPrepareAndFinalizeNoDPEPModular | None = None,
+    inplace: bool = False,
+) -> tuple[mk.FusedMoEKernelModularImpl, _DirectOutputExperts]:
+    experts = _DirectOutputExperts(direct_output)
+    impl = mk.FusedMoEKernelModularImpl(
+        prepare_finalize or MoEPrepareAndFinalizeNoDPEPModular(),
+        experts,
+        shared_experts=None,
+        inplace=inplace,
+    )
+    return impl, experts
+
+
+def _patch_apply_inputs(
+    monkeypatch,
+    impl: mk.FusedMoEKernelModularImpl,
+    fused_out: torch.Tensor,
+    fused_out_is_direct: bool,
+) -> None:
+    def fake_prepare(
+        hidden_states,
+        topk_weights,
+        topk_ids,
+        global_num_experts,
+        expert_map,
+        apply_router_weight_on_input,
+    ):
+        return hidden_states, None, None, topk_ids, topk_weights
+
+    def fake_fused_experts(**kwargs):
+        return fused_out, fused_out_is_direct
+
+    monkeypatch.setattr(impl, "_prepare", fake_prepare)
+    monkeypatch.setattr(impl, "_fused_experts", fake_fused_experts)
+
+
+def _apply_test_moe(
+    impl: mk.FusedMoEKernelModularImpl,
+    hidden_states: torch.Tensor,
+    shared_experts_input: torch.Tensor | None = None,
+) -> torch.Tensor:
+    w1 = torch.empty(1, 4, 3)
+    w2 = torch.empty(1, 3, 4)
+    topk_weights = torch.ones(2, 1)
+    topk_ids = torch.zeros(2, 1, dtype=torch.int64)
+    return impl.apply(
+        hidden_states=hidden_states,
+        w1=w1,
+        w2=w2,
+        topk_ids=topk_ids,
+        topk_weights=topk_weights,
+        shared_experts_input=shared_experts_input,
+    )
+
+
+def test_fused_experts_can_return_direct_output(monkeypatch):
+    direct_output = torch.full((2, 3), 7.0)
+    fallback_output = torch.empty_like(direct_output)
+    impl, experts = _make_impl(direct_output)
+
+    def fake_allocate_buffers(*args, **kwargs):
+        return torch.empty(1), torch.empty(1), fallback_output
+
+    monkeypatch.setattr(impl, "_allocate_buffers", fake_allocate_buffers)
+
+    hidden_states = torch.empty(2, 3)
+    w1 = torch.empty(1, 4, 3)
+    w2 = torch.empty(1, 3, 4)
+    topk_weights = torch.ones(2, 1)
+    topk_ids = torch.zeros(2, 1, dtype=torch.int64)
+
+    output, output_is_direct = impl._fused_experts(
+        in_dtype=hidden_states.dtype,
+        a1q=hidden_states,
+        a1q_scale=None,
+        w1=w1,
+        w2=w2,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=MoEActivation.SILU,
+        global_num_experts=1,
+        local_num_experts=1,
+        expert_map=None,
+        apply_router_weight_on_input=False,
+        expert_tokens_meta=None,
+    )
+
+    assert output is direct_output
+    assert output_is_direct
+    assert experts.output_arg is fallback_output
+
+
+def test_fused_experts_marks_returned_workspace_not_direct(monkeypatch):
+    fallback_output = torch.full((2, 3), 7.0)
+    workspace_alias = fallback_output.view_as(fallback_output)
+    impl, experts = _make_impl(workspace_alias)
+
+    def fake_allocate_buffers(*args, **kwargs):
+        return torch.empty(1), torch.empty(1), fallback_output
+
+    monkeypatch.setattr(impl, "_allocate_buffers", fake_allocate_buffers)
+
+    hidden_states = torch.empty(2, 3)
+    w1 = torch.empty(1, 4, 3)
+    w2 = torch.empty(1, 3, 4)
+    topk_weights = torch.ones(2, 1)
+    topk_ids = torch.zeros(2, 1, dtype=torch.int64)
+
+    output, output_is_direct = impl._fused_experts(
+        in_dtype=hidden_states.dtype,
+        a1q=hidden_states,
+        a1q_scale=None,
+        w1=w1,
+        w2=w2,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        activation=MoEActivation.SILU,
+        global_num_experts=1,
+        local_num_experts=1,
+        expert_map=None,
+        apply_router_weight_on_input=False,
+        expert_tokens_meta=None,
+    )
+
+    assert output is workspace_alias
+    assert not output_is_direct
+    assert experts.output_arg is fallback_output
+
+
+def test_apply_skips_noop_copy_for_direct_output(monkeypatch):
+    prepare_finalize = _TrackingNoDPEP()
+    fused_out = torch.full((2, 3), 5.0)
+    impl, _ = _make_impl(fused_out, prepare_finalize)
+    _patch_apply_inputs(monkeypatch, impl, fused_out, fused_out_is_direct=True)
+
+    output = _apply_test_moe(impl, torch.zeros_like(fused_out))
+
+    assert output is fused_out
+    assert prepare_finalize.finalize_calls == 0
+
+
+def test_apply_copies_workspace_output_before_returning(monkeypatch):
+    prepare_finalize = _TrackingNoDPEP()
+    fused_out = torch.full((2, 3), 5.0)
+    impl, _ = _make_impl(fused_out, prepare_finalize)
+    _patch_apply_inputs(monkeypatch, impl, fused_out, fused_out_is_direct=False)
+
+    output = _apply_test_moe(impl, torch.zeros_like(fused_out))
+
+    assert output is not fused_out
+    assert prepare_finalize.finalize_calls == 1
+    torch.testing.assert_close(output, fused_out)
+
+
+def test_apply_uses_generic_path_for_inplace_output(monkeypatch):
+    prepare_finalize = _TrackingNoDPEP()
+    fused_out = torch.full((2, 3), 5.0)
+    hidden_states = torch.zeros_like(fused_out)
+    impl, _ = _make_impl(fused_out, prepare_finalize, inplace=True)
+    _patch_apply_inputs(monkeypatch, impl, fused_out, fused_out_is_direct=True)
+
+    output = _apply_test_moe(impl, hidden_states)
+
+    assert output is hidden_states
+    assert prepare_finalize.finalize_calls == 1
+    torch.testing.assert_close(hidden_states, fused_out)
+
+
+def test_apply_uses_generic_path_with_shared_experts_input(monkeypatch):
+    prepare_finalize = _TrackingNoDPEP()
+    fused_out = torch.full((2, 3), 5.0)
+    impl, _ = _make_impl(fused_out, prepare_finalize)
+    _patch_apply_inputs(monkeypatch, impl, fused_out, fused_out_is_direct=True)
+
+    output = _apply_test_moe(
+        impl,
+        torch.zeros_like(fused_out),
+        shared_experts_input=torch.empty_like(fused_out),
+    )
+
+    assert output is not fused_out
+    assert prepare_finalize.finalize_calls == 1
+    torch.testing.assert_close(output, fused_out)

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -120,6 +120,13 @@ class TopKWeightAndReduce(ABC):
     An abstract base class for weight application and reduction implementations.
     """
 
+    def is_noop(self) -> bool:
+        """
+        Whether this implementation leaves an already weighted/reduced fused
+        expert output unchanged when no output buffer is provided.
+        """
+        return False
+
     @abstractmethod
     def apply(
         self,
@@ -410,6 +417,16 @@ class FusedMoEPrepareAndFinalizeModular(FusedMoEPrepareAndFinalize):
         obj.finalize(output, ...)
         """
         raise NotImplementedError
+
+    def can_skip_finalize_copy(
+        self,
+        weight_and_reduce_impl: TopKWeightAndReduce,
+    ) -> bool:
+        """
+        Return true when finalize would only copy an already-final fused expert
+        output into the provided output buffer.
+        """
+        return False
 
 
 class FusedMoEPrepareAndFinalizeMonolithic(FusedMoEPrepareAndFinalize):
@@ -896,7 +913,7 @@ class FusedMoEExpertsModular(FusedMoEExperts):
         workspace2: torch.Tensor,
         expert_tokens_meta: ExpertTokensMetadata | None,
         apply_router_weight_on_input: bool,
-    ) -> None:
+    ) -> torch.Tensor | None:
         """
         This function computes the intermediate result of a Mixture of Experts
         (MoE) layer using two sets of weights, w1 and w2.
@@ -931,6 +948,12 @@ class FusedMoEExpertsModular(FusedMoEExperts):
         - apply_router_weight_on_input: True if router weights are already
           applied on the input. This is relevant if the implementation
           chooses to do weight application.
+
+        Returns:
+        - None if the result was written into output.
+        - A direct output tensor when the implementation already produced the
+          final fused expert output and the caller should use it instead of
+          output.
         """
         raise NotImplementedError
 
@@ -1204,7 +1227,7 @@ class FusedMoEKernelModularImpl:
         expert_map: torch.Tensor | None,
         apply_router_weight_on_input: bool,
         expert_tokens_meta: ExpertTokensMetadata | None,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, bool]:
         _, M_full, N, K, top_k = self.fused_experts.moe_problem_size(
             a1q, w1, w2, topk_ids
         )
@@ -1216,7 +1239,7 @@ class FusedMoEKernelModularImpl:
         # low-latency kernels are always batched and can never run into
         # the tensor.numel() == 0 case.
         if M_full == 0:
-            return torch.empty_like(a1q, dtype=in_dtype)
+            return torch.empty_like(a1q, dtype=in_dtype), False
 
         workspace13, workspace2, fused_out = self._allocate_buffers(
             in_dtype,
@@ -1232,7 +1255,7 @@ class FusedMoEKernelModularImpl:
             activation,
         )
 
-        self.fused_experts.apply(
+        direct_fused_out = self.fused_experts.apply(
             output=fused_out,
             hidden_states=a1q,
             w1=w1,
@@ -1249,8 +1272,31 @@ class FusedMoEKernelModularImpl:
             expert_tokens_meta=expert_tokens_meta,
             apply_router_weight_on_input=apply_router_weight_on_input,
         )
+        if direct_fused_out is not None:
+            return direct_fused_out, not self._shares_storage(
+                direct_fused_out, fused_out
+            )
 
-        return fused_out
+        return fused_out, False
+
+    @staticmethod
+    def _shares_storage(lhs: torch.Tensor, rhs: torch.Tensor) -> bool:
+        return lhs.untyped_storage().data_ptr() == rhs.untyped_storage().data_ptr()
+
+    def _can_skip_finalize_copy(
+        self,
+        weight_and_reduce_impl: TopKWeightAndReduce,
+        shared_experts_input: torch.Tensor | None,
+        fused_out_is_direct: bool,
+    ) -> bool:
+        return (
+            fused_out_is_direct
+            and not self.inplace
+            and not self.prepare_finalize.supports_async()
+            and self.shared_experts is None
+            and shared_experts_input is None
+            and self.prepare_finalize.can_skip_finalize_copy(weight_and_reduce_impl)
+        )
 
     def _finalize(
         self,
@@ -1261,6 +1307,7 @@ class FusedMoEKernelModularImpl:
         topk_ids: torch.Tensor,
         apply_router_weight_on_input: bool,
         shared_experts_input: torch.Tensor | None,
+        weight_and_reduce_impl: TopKWeightAndReduce,
     ) -> torch.Tensor:
         """
         The _finalize method is a wrapper around self.prepare_finalize.finalize
@@ -1282,7 +1329,7 @@ class FusedMoEKernelModularImpl:
                 topk_weights,
                 topk_ids,
                 apply_router_weight_on_input,
-                self.fused_experts.finalize_weight_and_reduce_impl(),
+                weight_and_reduce_impl,
             )
         else:
             finalize_ret = self.prepare_finalize.finalize_async(
@@ -1291,7 +1338,7 @@ class FusedMoEKernelModularImpl:
                 topk_weights,
                 topk_ids,
                 apply_router_weight_on_input,
-                self.fused_experts.finalize_weight_and_reduce_impl(),
+                weight_and_reduce_impl,
             )
             self._maybe_apply_shared_experts(shared_experts_input)
 
@@ -1361,9 +1408,6 @@ class FusedMoEKernelModularImpl:
         if self.inplace:
             assert self.shared_experts is None
             assert not disable_inplace()
-            output = hidden_states
-        else:
-            output = torch.empty_like(hidden_states)
 
         local_num_experts = w1.shape[0]
         if global_num_experts == -1:
@@ -1378,7 +1422,7 @@ class FusedMoEKernelModularImpl:
             apply_router_weight_on_input,
         )
 
-        fused_out = self._fused_experts(
+        fused_out, fused_out_is_direct = self._fused_experts(
             in_dtype=hidden_states.dtype,
             a1q=a1q,
             a1q_scale=a1q_scale,
@@ -1394,6 +1438,23 @@ class FusedMoEKernelModularImpl:
             expert_tokens_meta=expert_tokens_meta,
         )
 
+        weight_and_reduce_impl = self.fused_experts.finalize_weight_and_reduce_impl()
+        if self._can_skip_finalize_copy(
+            weight_and_reduce_impl,
+            shared_experts_input,
+            fused_out_is_direct,
+        ):
+            assert not dbo_enabled()
+            return weight_and_reduce_impl.apply(
+                output=None,
+                fused_expert_output=fused_out,
+                topk_weights=topk_weights,
+                topk_ids=topk_ids,
+                apply_router_weight_on_input=apply_router_weight_on_input,
+            )
+
+        output = hidden_states if self.inplace else torch.empty_like(hidden_states)
+
         return self._finalize(
             output,
             fused_out,
@@ -1402,6 +1463,7 @@ class FusedMoEKernelModularImpl:
             topk_ids,
             apply_router_weight_on_input,
             shared_experts_input=shared_experts_input,
+            weight_and_reduce_impl=weight_and_reduce_impl,
         )
 
 

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/no_dp_ep.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/no_dp_ep.py
@@ -53,6 +53,12 @@ class MoEPrepareAndFinalizeNoDPEPModular(mk.FusedMoEPrepareAndFinalizeModular):
     def output_is_reduced(self) -> bool:
         return False
 
+    def can_skip_finalize_copy(
+        self,
+        weight_and_reduce_impl: mk.TopKWeightAndReduce,
+    ) -> bool:
+        return weight_and_reduce_impl.is_noop()
+
     def prepare(
         self,
         a1: torch.Tensor,

--- a/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py
@@ -412,7 +412,7 @@ class AiterExperts(mk.FusedMoEExpertsModular):
         workspace2: torch.Tensor,
         expert_tokens_meta: mk.ExpertTokensMetadata | None,
         apply_router_weight_on_input: bool,
-    ):
+    ) -> torch.Tensor:
         # TODO(rob): rocm_aiter_fused_experts uses self.quant_config's
         # a_scales for static quantization. Update this to fit better
         # with the interface once all quant integrations are complete.
@@ -422,7 +422,7 @@ class AiterExperts(mk.FusedMoEExpertsModular):
         else:
             num_local_tokens = None
 
-        result = rocm_aiter_fused_experts(
+        return rocm_aiter_fused_experts(
             hidden_states=hidden_states,
             w1=w1,
             w2=w2,
@@ -437,4 +437,3 @@ class AiterExperts(mk.FusedMoEExpertsModular):
             num_local_tokens=num_local_tokens,
             output_dtype=output.dtype,
         )
-        output.copy_(result)

--- a/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
+++ b/vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py
@@ -50,6 +50,9 @@ class TopKWeightAndReduceNoOP(mk.TopKWeightAndReduce):
     def __eq__(self, other):
         return isinstance(other, TopKWeightAndReduceNoOP)
 
+    def is_noop(self) -> bool:
+        return True
+
     def apply(
         self,
         output: torch.Tensor | None,


### PR DESCRIPTION
## Summary
- allow modular fused experts to return a direct fused output tensor
- make ROCm AITER MoE return the AITER kernel output directly instead of copying into `fused_out`
- skip NoDPEP `fused_out -> output` finalize copy when `TopKWeightAndReduceNoOP` is used and no shared experts are present
- add focused modular-kernel tests for direct output and copy-skip behavior

## Testing
- `python3 -m py_compile vllm/model_executor/layers/fused_moe/modular_kernel.py vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py vllm/model_executor/layers/fused_moe/prepare_finalize/no_dp_ep.py vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py tests/kernels/moe/test_modular_kernel_direct_output.py`
- `uv run --no-project --with ruff ruff check vllm/model_executor/layers/fused_moe/modular_kernel.py vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py vllm/model_executor/layers/fused_moe/prepare_finalize/no_dp_ep.py vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py tests/kernels/moe/test_modular_kernel_direct_output.py`
- `uv run --no-project --with ruff ruff format --check vllm/model_executor/layers/fused_moe/modular_kernel.py vllm/model_executor/layers/fused_moe/topk_weight_and_reduce.py vllm/model_executor/layers/fused_moe/prepare_finalize/no_dp_ep.py vllm/model_executor/layers/fused_moe/rocm_aiter_fused_moe.py tests/kernels/moe/test_modular_kernel_direct_output.py`

## Benchmark
ROCm MI355X TP4, `MiniMaxAI/MiniMax-M2.5`, random 1024 ISL / 1024 OSL, `--gpu-memory-utilization 0.95 --kv-cache-dtype fp8 --block-size=32 --no-enable-prefix-caching --attention-backend ROCM_AITER_FA --trust-remote-code`.

Higher total throughput is better. Fresh paired sweep rerun on 2026-05-02; all rows completed with 0 failed requests.

| Max concurrency | Baseline total tok/s | Patched total tok/s | Delta | Delta % | Baseline tok/GPU/s | Patched tok/GPU/s |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 4 | 633.40 | 654.90 | +21.50 | +3.39% | 158.35 | 163.72 |
| 8 | 1256.79 | 1284.35 | +27.57 | +2.19% | 314.20 | 321.09 |
| 16 | 2210.05 | 2282.57 | +72.52 | +3.28% | 552.51 | 570.64 |
| 32 | 3832.75 | 3942.30 | +109.55 | +2.86% | 958.19 | 985.57 |
| 64 | 4970.13 | 5120.49 | +150.36 | +3.03% | 1242.53 | 1280.12 |
| 128 | 7977.71 | 8273.93 | +296.22 | +3.71% | 1994.43 | 2068.48 |
