### PR TITLE
[Refactor] Extract shared helpers from MXFP4 MoE backend selectors

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -241,6 +241,129 @@ def _backend_activation_key(backend: Mxfp4MoeBackend) -> QuantKey | None:
     return None
 
 
+def _activation_format_for_config(
+    config: FusedMoEConfig,
+) -> mk.FusedMoEActivationFormat:
+    """Pick the fused-MoE activation format implied by the parallel config."""
+    if config.moe_parallel_config.use_batched_activation_format:
+        return mk.FusedMoEActivationFormat.BatchedExperts
+    return mk.FusedMoEActivationFormat.Standard
+
+
+def _make_log_backend(backend: Mxfp4MoeBackend) -> str:
+    return f"Using '{backend.value}' Mxfp4 MoE backend."
+
+
+def _make_log_unsupported(backend: Mxfp4MoeBackend, reason: str | None) -> str:
+    if reason:
+        return (
+            f"Mxfp4 MoE backend '{backend.value}' does not support the "
+            f"deployment configuration since {reason}."
+        )
+    return (
+        f"Mxfp4 MoE backend '{backend.value}' does not support the "
+        "deployment configuration."
+    )
+
+
+def _try_kernel_classes(
+    backend: Mxfp4MoeBackend,
+    config: FusedMoEConfig,
+    weight_key: QuantKey | None,
+    activation_key: QuantKey | None,
+    activation_format: mk.FusedMoEActivationFormat,
+    *,
+    log_failures: bool = False,
+) -> tuple[type[mk.FusedMoEExperts] | None, str | None]:
+    """Probe every kernel class registered for ``backend``.
+
+    Returns the first kernel that reports ``is_supported_config`` as True;
+    otherwise ``(None, last_reason)``. When ``log_failures`` is True, each
+    unsupported kernel emits a deduplicated debug log — matching the original
+    priority-loop behavior, which logged once per failed kernel class.
+    """
+    reason: str | None = None
+    for k_cls in backend_to_kernel_cls(backend):
+        supported, reason = k_cls.is_supported_config(
+            k_cls, config, weight_key, activation_key, activation_format
+        )
+        if supported:
+            return k_cls, None
+        if log_failures:
+            logger.debug_once(_make_log_unsupported(backend, reason))
+    return None, reason
+
+
+def _return_or_raise(
+    backend: Mxfp4MoeBackend,
+    config: FusedMoEConfig,
+    weight_key: QuantKey | None,
+    activation_key: QuantKey | None,
+    activation_format: mk.FusedMoEActivationFormat,
+) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts]]:
+    """Resolve ``backend`` to a supported kernel class or raise ``ValueError``."""
+    k_cls, reason = _try_kernel_classes(
+        backend, config, weight_key, activation_key, activation_format
+    )
+    if k_cls is not None:
+        logger.info_once(_make_log_backend(backend))
+        return backend, k_cls
+    raise ValueError(_make_log_unsupported(backend, reason))
+
+
+def _select_explicit_runner_backend(
+    config: FusedMoEConfig,
+    activation_format: mk.FusedMoEActivationFormat,
+) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts]] | None:
+    """Honor ``config.moe_backend`` when set explicitly (not ``"auto"``).
+
+    Returns the resolved ``(backend, kernel_cls)`` or raises ``ValueError`` if
+    the requested backend cannot be satisfied. Returns ``None`` when the user
+    left ``moe_backend`` on auto, in which case the caller should fall through
+    to priority-order selection.
+    """
+    runner_backend = config.moe_backend
+    if runner_backend == "auto":
+        return None
+    requested_backend = map_mxfp4_backend(runner_backend)
+    if (
+        activation_format == mk.FusedMoEActivationFormat.BatchedExperts
+        and requested_backend == Mxfp4MoeBackend.MARLIN
+    ):
+        requested_backend = Mxfp4MoeBackend.BATCHED_MARLIN
+    return _return_or_raise(
+        requested_backend,
+        config,
+        kMxfp4Static,
+        _backend_activation_key(requested_backend),
+        activation_format,
+    )
+
+
+def _select_first_supported_backend(
+    config: FusedMoEConfig,
+    priority_backends: list[Mxfp4MoeBackend],
+    activation_format: mk.FusedMoEActivationFormat,
+) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts]] | None:
+    """Walk ``priority_backends`` in order and return the first one whose
+    kernel reports the deployment as supported. Returns ``None`` if none match.
+    """
+    for backend in priority_backends:
+        activation_key = _backend_activation_key(backend)
+        k_cls, _ = _try_kernel_classes(
+            backend,
+            config,
+            kMxfp4Static,
+            activation_key,
+            activation_format,
+            log_failures=True,
+        )
+        if k_cls is not None:
+            logger.info_once(_make_log_backend(backend))
+            return backend, k_cls
+    return None
+
+
 def select_gpt_oss_mxfp4_moe_backend(
     config: FusedMoEConfig,
 ) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts] | None]:
@@ -271,58 +394,11 @@ def select_gpt_oss_mxfp4_moe_backend(
         logger.info_once("Using Marlin backend for mxfp4 lora")
         return Mxfp4MoeBackend.MARLIN, backend_to_kernel_cls(Mxfp4MoeBackend.MARLIN)[0]
 
-    activation_format = (
-        mk.FusedMoEActivationFormat.BatchedExperts
-        if config.moe_parallel_config.use_batched_activation_format
-        else mk.FusedMoEActivationFormat.Standard
-    )
+    activation_format = _activation_format_for_config(config)
 
-    def _make_log_backend(backend: Mxfp4MoeBackend):
-        return f"Using '{backend.value}' Mxfp4 MoE backend."
-
-    def _make_log_unsupported(backend: Mxfp4MoeBackend, reason: str | None) -> str:
-        if reason:
-            return (
-                f"Mxfp4 MoE backend '{backend.value}' does not support the "
-                f"deployment configuration since {reason}."
-            )
-        return (
-            f"Mxfp4 MoE backend '{backend.value}' does not support the "
-            "deployment configuration."
-        )
-
-    def _return_or_raise(
-        backend: Mxfp4MoeBackend,
-        config: FusedMoEConfig,
-        weight_key: QuantKey | None,
-        activation_key: QuantKey | None,
-        activation_format: mk.FusedMoEActivationFormat,
-    ) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts]]:
-        reason: str | None = None
-        for k_cls in backend_to_kernel_cls(backend):
-            supported, reason = k_cls.is_supported_config(
-                k_cls, config, weight_key, activation_key, activation_format
-            )
-            if supported:
-                logger.info_once(_make_log_backend(backend))
-                return backend, k_cls
-        raise ValueError(_make_log_unsupported(backend, reason))
-
-    runner_backend = config.moe_backend
-    if runner_backend != "auto":
-        requested_backend = map_mxfp4_backend(runner_backend)
-        if (
-            activation_format == mk.FusedMoEActivationFormat.BatchedExperts
-            and requested_backend == Mxfp4MoeBackend.MARLIN
-        ):
-            requested_backend = Mxfp4MoeBackend.BATCHED_MARLIN
-        return _return_or_raise(
-            requested_backend,
-            config,
-            kMxfp4Static,
-            _backend_activation_key(requested_backend),
-            activation_format,
-        )
+    explicit = _select_explicit_runner_backend(config, activation_format)
+    if explicit is not None:
+        return explicit
 
     # Select kernels in order of backend.
     AVAILABLE_BACKENDS = _get_priority_backends_for_gpt_oss()
@@ -391,21 +467,13 @@ def select_gpt_oss_mxfp4_moe_backend(
             activation_format,
         )
 
-    for backend in AVAILABLE_BACKENDS:
-        activation_key = _backend_activation_key(backend)
-        for k_cls in backend_to_kernel_cls(backend):
-            supported, reason = k_cls.is_supported_config(
-                k_cls, config, kMxfp4Static, activation_key, activation_format
-            )
-            if supported:
-                logger.info_once(_make_log_backend(backend))
-                return backend, k_cls
-            else:
-                logger.debug_once(_make_log_unsupported(backend, reason))
+    selected = _select_first_supported_backend(
+        config, AVAILABLE_BACKENDS, activation_format
+    )
+    if selected is not None:
+        return selected
 
     if current_platform.is_xpu():
-        backend = Mxfp4MoeBackend.XPU
-        logger.info_once(_make_log_backend(backend))
         return _return_or_raise(
             Mxfp4MoeBackend.XPU,
             config,
@@ -429,73 +497,20 @@ def select_mxfp4_moe_backend(
     Select the MXFP4 MoE backend with MXFP8 activation as top priority.
     Falls back through BF16 and other backends.
     """
-    activation_format = (
-        mk.FusedMoEActivationFormat.BatchedExperts
-        if config.moe_parallel_config.use_batched_activation_format
-        else mk.FusedMoEActivationFormat.Standard
-    )
-
-    def _make_log_backend(backend: Mxfp4MoeBackend):
-        return f"Using '{backend.value}' Mxfp4 MoE backend."
-
-    def _make_log_unsupported(backend: Mxfp4MoeBackend, reason: str | None) -> str:
-        if reason:
-            return (
-                f"Mxfp4 MoE backend '{backend.value}' does not support the "
-                f"deployment configuration since {reason}."
-            )
-        return (
-            f"Mxfp4 MoE backend '{backend.value}' does not support the "
-            "deployment configuration."
-        )
-
-    def _return_or_raise(
-        backend: Mxfp4MoeBackend,
-        config: FusedMoEConfig,
-        weight_key: QuantKey | None,
-        activation_key: QuantKey | None,
-        activation_format: mk.FusedMoEActivationFormat,
-    ) -> tuple[Mxfp4MoeBackend, type[mk.FusedMoEExperts]]:
-        reason: str | None = None
-        for k_cls in backend_to_kernel_cls(backend):
-            supported, reason = k_cls.is_supported_config(
-                k_cls, config, weight_key, activation_key, activation_format
-            )
-            if supported:
-                logger.info_once(_make_log_backend(backend), scope="local")
-                return backend, k_cls
-        raise ValueError(_make_log_unsupported(backend, reason))
+    activation_format = _activation_format_for_config(config)
 
     # Honor explicit moe_backend (e.g. "marlin", "triton_unfused") before
     # falling back to the auto priority list.
-    runner_backend = config.moe_backend
-    if runner_backend != "auto":
-        requested_backend = map_mxfp4_backend(runner_backend)
-        if (
-            activation_format == mk.FusedMoEActivationFormat.BatchedExperts
-            and requested_backend == Mxfp4MoeBackend.MARLIN
-        ):
-            requested_backend = Mxfp4MoeBackend.BATCHED_MARLIN
-        return _return_or_raise(
-            requested_backend,
-            config,
-            kMxfp4Static,
-            _backend_activation_key(requested_backend),
-            activation_format,
-        )
+    explicit = _select_explicit_runner_backend(config, activation_format)
+    if explicit is not None:
+        return explicit
 
     # Iterate priority backends: TRTLLM MXFP8, then Triton.
-    for backend in _get_priority_backends():
-        activation_key = _backend_activation_key(backend)
-        for k_cls in backend_to_kernel_cls(backend):
-            supported, reason = k_cls.is_supported_config(
-                k_cls, config, kMxfp4Static, activation_key, activation_format
-            )
-            if supported:
-                logger.info_once(_make_log_backend(backend), scope="local")
-                return backend, k_cls
-            else:
-                logger.debug_once(_make_log_unsupported(backend, reason), scope="local")
+    selected = _select_first_supported_backend(
+        config, _get_priority_backends(), activation_format
+    )
+    if selected is not None:
+        return selected
 
     raise NotImplementedError(
         "No MXFP4 MoE backend supports the deployment configuration."


### PR DESCRIPTION
## Summary

Addresses #41291 by extracting the duplicated machinery shared between `select_gpt_oss_mxfp4_moe_backend` and `select_mxfp4_moe_backend` into private module-level helpers in `vllm/model_executor/layers/fused_moe/oracle/mxfp4.py`.

## What changes

Both selectors carried four nested closures each (`_make_log_backend`, `_make_log_unsupported`, `_return_or_raise`) plus near-identical copies of the priority-iteration loop and the explicit-runner-backend branch. This PR lifts those into six private module-level helpers:

- `_activation_format_for_config(config)` — pulls the `BatchedExperts` vs `Standard` decision out of both functions.
- `_make_log_backend(backend)` / `_make_log_unsupported(backend, reason)` — the two log-message templates, deduplicated.
- `_try_kernel_classes(backend, config, ..., *, log_failures=False)` — probes every kernel class registered for `backend`. The `log_failures` switch preserves the difference between the priority-loop path (which logs each unsupported kernel via `debug_once`) and the explicit-backend path (which only surfaces failures by raising).
- `_return_or_raise(backend, config, ...)` — resolves a single backend or raises `ValueError`, used by every direct-pick site (env vars, runner-backend, XPU fallback).
- `_select_explicit_runner_backend(config, activation_format)` — honors `config.moe_backend` when set, returns `None` to signal "fall through to priority list".
- `_select_first_supported_backend(config, priority_backends, activation_format)` — walks a priority list and returns the first backend whose kernel matches.

`select_gpt_oss_mxfp4_moe_backend` and `select_mxfp4_moe_backend` are now thin orchestration that compose those helpers. Both keep their public signatures and observable behavior, so the three callers in `vllm/model_executor/layers/quantization/mxfp4.py` and `vllm/model_executor/layers/quantization/quark/quark_moe.py` need no edit.

## Behavioral preservation

The refactor preserves observable behavior 1:1, with two intentional no-op cleanups bundled in:

1. Removed the redundant `logger.info_once(_make_log_backend(backend))` immediately before `_return_or_raise(Mxfp4MoeBackend.XPU, ...)` in the GPT-OSS XPU branch — `_return_or_raise` already emits the same `info_once` message on success, so the original would have logged twice and `info_once` deduplicated it.
2. Removed the explicit `scope="local"` kwargs in `select_mxfp4_moe_backend`'s log calls. `"local"` is the default for `info_once` / `debug_once` per `vllm/logger.py`, so the behavior is identical and the calls match the rest of the file.

The GPT-OSS path's behavior matrix is fully preserved:
- LoRA branch (raises on non-CUDA, picks `TRITON_UNFUSED` or `MARLIN`).
- All four env-var override branches (`VLLM_USE_FLASHINFER_MOE_MXFP4_BF16`, `VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8`, `VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8_CUTLASS`, `VLLM_MXFP4_USE_MARLIN`) — kept in `select_gpt_oss_mxfp4_moe_backend`, since they don't apply to the generic MXFP4 path.
- The `BATCHED_MARLIN` coercion when the format is `BatchedExperts`.
- The XPU fallback after the priority loop.
- The CUDA/ROCm `NotImplementedError` and the final `(NONE, None)` return.
- The per-kernel-class `debug_once` for unsupported configs in the priority loop (preserved via `log_failures=True`).

## Why this shape and not the issue's literal ask

The issue proposes "a single `select_mxfp4_moe_backend()` function … with `activation_key` parameter or quantization_config parameter". Reading both functions, the divergence is bigger than that:

| Aspect | `select_gpt_oss_mxfp4_moe_backend` | `select_mxfp4_moe_backend` |
|---|---|---|
| LoRA branch | yes | no |
| Env-var overrides | yes (4 branches) | no |
| Priority list | BF16-focused (`_get_priority_backends_for_gpt_oss`) | MXFP8/DeepGEMM (`_get_priority_backends`) |
| XPU fallback | yes | no |
| Final fallback | returns `(NONE, None)` | raises `NotImplementedError` |

A single function with a `mode='gpt_oss'` flag (or several boolean kwargs) would be harder to read than two named entry points and would lock in a shape that the larger class-hierarchy refactor in PR #37776 will rework anyway. This PR achieves the spirit of the dedup ask — eliminate the four copies of the helper closures and the duplicated priority loop — while keeping both entry points distinct.

## Why it isn't a duplicate

Searched for existing PRs:

```
gh pr list --repo vllm-project/vllm --state all --search "41291 in:body"        → no PR
gh pr list --repo vllm-project/vllm --state open --search "select_mxfp4_moe_backend"  → no overlap
gh pr list --repo vllm-project/vllm --state open --search "merge mxfp4 backend"       → no overlap
```

The closest open PR is #37776 (`[MoE] Unify MoE oracles with class structure`, `needs-rebase`), which restructures *all* MoE oracles into a class hierarchy. That PR predates the GPT-OSS split that #39604 introduced and #40860 reshaped, so it does not touch `select_gpt_oss_mxfp4_moe_backend` at all. The two PRs don't conflict; whichever lands first, the other rebases cleanly.

Tracking issue: #41291.

## Tests run

This is a Python-only refactor with no observable behavior change, so I ran the lint/typecheck commands instead of building the full vLLM wheel:

- `ruff check vllm/model_executor/layers/fused_moe/oracle/mxfp4.py` — clean.
- `ruff format --check vllm/model_executor/layers/fused_moe/oracle/mxfp4.py` — already formatted.
- `mypy --python-version 3.10 --follow-imports=skip --ignore-missing-imports vllm/model_executor/layers/fused_moe/oracle/mxfp4.py` — `Success: no issues found in 1 source file`.
- `typos vllm/model_executor/layers/fused_moe/oracle/mxfp4.py` — clean.
- `python -c "import ast; ast.parse(open(...).read())"` — OK.
- `grep -rn "select_gpt_oss_mxfp4_moe_backend\|select_mxfp4_moe_backend"` across the repo — three call sites in `quantization/mxfp4.py` and `quantization/quark/quark_moe.py`, none need editing because the public signatures are unchanged.

I did **not** run the full pytest suite or build the wheel — the PR makes no behavior changes and the helpers are private (no new public API surface). Happy to run any specific kernel/MoE test the reviewer thinks is relevant.

## AI assistance disclosure

Claude (Anthropic) assisted with: reading both selector functions and the issue thread, comparing against the in-flight PR #37776, designing the helper extraction shape, applying the edit, and running the lint/mypy/typos commands. I (Demian Havdun) reviewed every changed line, checked that the helpers preserve the original behavior path-by-path (especially the per-kernel-class debug logging and the XPU branch double-log dedup), and signed off as committer per DCO. Co-author trailer added per AGENTS.md.
