### PR TITLE
[CI] Split B200 LM Eval Small Models suite by GPU count

### DIFF
--- a/.buildkite/test_areas/lm_eval.yaml
+++ b/.buildkite/test_areas/lm_eval.yaml
@@ -48,6 +48,18 @@ steps:
   commands:
   - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-blackwell.txt
 
+- label: LM Eval Small Models (2 GPUs)(B200)
+  key: lm-eval-small-models-2-gpus-b200
+  timeout_in_minutes: 120
+  device: b200
+  optional: true
+  num_devices: 2
+  source_file_dependencies:
+  - csrc/
+  - vllm/model_executor/layers/quantization
+  commands:
+  - pytest -s -v evals/gsm8k/test_gsm8k_correctness.py --config-list-file=configs/models-blackwell-2gpu.txt
+
 - label: LM Eval Qwen3.5 Models (B200)
   key: lm-eval-qwen3-5-models-b200
   timeout_in_minutes: 120

--- a/tests/evals/gsm8k/configs/models-blackwell-2gpu.txt
+++ b/tests/evals/gsm8k/configs/models-blackwell-2gpu.txt
@@ -1,0 +1,3 @@
+Qwen3-Next-80B-A3B-NVFP4-EP2.yaml
+Qwen3-Next-FP8-EP2.yaml
+Nemotron-3-Super-120B-A12B-NVFP4.yaml

--- a/tests/evals/gsm8k/configs/models-blackwell.txt
+++ b/tests/evals/gsm8k/configs/models-blackwell.txt
@@ -3,6 +3,3 @@ Qwen2.5-VL-3B-Instruct-FP8-dynamic.yaml
 Qwen1.5-MoE-W4A16-CT.yaml
 DeepSeek-V2-Lite-Instruct-FP8.yaml
 Qwen3-30B-A3B-NVFP4.yaml
-Qwen3-Next-80B-A3B-NVFP4-EP2.yaml
-Qwen3-Next-FP8-EP2.yaml
-Nemotron-3-Super-120B-A12B-NVFP4.yaml


### PR DESCRIPTION
## Purpose

`LM Eval Small Models (B200)` does not declare `num_devices`, so the agent gets a single B200, but `models-blackwell.txt` includes three TP=2 configs. They fail at engine init with `World size (2) is larger than the number of available GPUs (1)` ([build #63724](https://buildkite.com/vllm/ci/builds/63724)).

Split by GPU count, mirroring the adjacent `lm-eval-qwen3-5-models-b200`:

- `models-blackwell.txt` keeps the 5 TP=1 entries.
- New `models-blackwell-2gpu.txt` holds the 3 TP=2 entries.
- New `LM Eval Small Models (2 GPUs)(B200)` step with `num_devices: 2`.

## Test Plan

## Test Result