### PR TITLE
[CI] Skip FLASH_ATTN+DeepSeek eagle test on Blackwell

### DIFF
--- a/tests/v1/e2e/spec_decode/test_spec_decode.py
+++ b/tests/v1/e2e/spec_decode/test_spec_decode.py
@@ -390,6 +390,17 @@ def _run_eagle_correctness(
             "TREE_ATTN is flaky in the test disable for now until it can be "
             "resolved (see https://github.com/vllm-project/vllm/issues/22922)"
         )
+    if (
+        attn_backend == "FLASH_ATTN"
+        and "deepseek" in model_setup[1].lower()
+        and current_platform.is_cuda()
+        and current_platform.is_device_capability_family(100)
+    ):
+        pytest.skip(
+            "FLASH_ATTN on Blackwell rejects the non-MLA DeepSeek shape "
+            "(192, 192); FA4 cute only supports (192, 128). "
+            "Use FLASH_ATTN_MLA for DeepSeek on SM100+."
+        )
     if model_impl == "transformers":
         import transformers
         from packaging.version import Version


### PR DESCRIPTION
## Purpose

Spec Decode Eagle Nightly B200 ([#63724](https://buildkite.com/vllm/ci/builds/63724/canvas?sid=019ddbbd-89e7-4d4e-a779-ab4d5ff4f06b&tab=output)) fails on `test_eagle_correctness_*[FLASH_ATTN-deepseek_eagle]`. The test forces `VLLM_MLA_DISABLE=1` + `FLASH_ATTN`, so DeepSeek-V3 (`qk_head_dim=192`, `v_head_dim=128`) hits FA4 cute with V padded to 192. On SM100+ the cute kernel only accepts `(192, 128)` and rejects `(192, 192)`. Skip this combination on Blackwell, mirroring the existing `TREE_ATTN` / `TRITON_ATTN` skips.

## Test Plan

## Test Result