### PR TITLE
[CI][Bugfix][MoE] Skip trtllm_fp4_block_scale_moe during FlashInfer autotune

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
@@ -200,39 +200,44 @@ class TrtLlmMxfp4ExpertsMonolithic(
 
         output = torch.empty_like(hidden_states)
 
-        from vllm.utils.flashinfer import _is_fi_autotuning, autotune
+        # Skip the kernel during FlashInfer warmup: its autotuner profile
+        # loop faults in the FP4 BMM cubin on SM100/SM103
+        # (flashinfer-ai/flashinfer#3168).
+        from vllm.utils.flashinfer import _is_fi_autotuning
 
-        with autotune(_is_fi_autotuning):
-            trtllm_fp4_block_scale_moe(
-                routing_logits=router_logits.to(torch.bfloat16),
-                routing_bias=None,
-                hidden_states=x_quant,
-                hidden_states_scale=x_scale,
-                gemm1_weights=w1,
-                gemm1_weights_scale=self.w1_scale,
-                gemm1_bias=self.w1_bias,
-                gemm1_alpha=self.gemm1_alpha,
-                gemm1_beta=self.gemm1_beta,
-                gemm1_clamp_limit=self.gemm1_clamp_limit,
-                gemm2_weights=w2,
-                gemm2_weights_scale=self.w2_scale,
-                gemm2_bias=self.w2_bias,
-                output1_scale_scalar=None,
-                output1_scale_gate_scalar=None,
-                output2_scale_scalar=None,
-                num_experts=global_num_experts,
-                top_k=self.topk,
-                n_group=None,
-                topk_group=None,
-                intermediate_size=self.intermediate_size_per_partition,
-                local_expert_offset=self.ep_rank * self.local_num_experts,
-                local_num_experts=self.local_num_experts,
-                routed_scaling_factor=None,
-                routing_method_type=self.routing_method_type,
-                do_finalize=True,
-                tune_max_num_tokens=max(self.max_capture_size, 1),
-                output=output,
-            )
+        if _is_fi_autotuning:
+            return output
+
+        trtllm_fp4_block_scale_moe(
+            routing_logits=router_logits.to(torch.bfloat16),
+            routing_bias=None,
+            hidden_states=x_quant,
+            hidden_states_scale=x_scale,
+            gemm1_weights=w1,
+            gemm1_weights_scale=self.w1_scale,
+            gemm1_bias=self.w1_bias,
+            gemm1_alpha=self.gemm1_alpha,
+            gemm1_beta=self.gemm1_beta,
+            gemm1_clamp_limit=self.gemm1_clamp_limit,
+            gemm2_weights=w2,
+            gemm2_weights_scale=self.w2_scale,
+            gemm2_bias=self.w2_bias,
+            output1_scale_scalar=None,
+            output1_scale_gate_scalar=None,
+            output2_scale_scalar=None,
+            num_experts=global_num_experts,
+            top_k=self.topk,
+            n_group=None,
+            topk_group=None,
+            intermediate_size=self.intermediate_size_per_partition,
+            local_expert_offset=self.ep_rank * self.local_num_experts,
+            local_num_experts=self.local_num_experts,
+            routed_scaling_factor=None,
+            routing_method_type=self.routing_method_type,
+            do_finalize=True,
+            tune_max_num_tokens=max(self.max_capture_size, 1),
+            output=output,
+        )
 
         return output
 

--- a/vllm/model_executor/warmup/kernel_warmup.py
+++ b/vllm/model_executor/warmup/kernel_warmup.py
@@ -91,19 +91,19 @@ def flashinfer_autotune(runner: "GPUModelRunner") -> None:
     import vllm.utils.flashinfer as fi_utils
 
     with torch.inference_mode(), fi_utils.autotune():
-        # Certain FlashInfer kernels (e.g. nvfp4 routed moe) are
-        # incompatible with autotuning. This state is used to skip
-        # those kernels during the autotuning process.
+        # Certain FlashInfer kernels (e.g. trtllm_fp4_block_scale_moe) are
+        # incompatible with autotuning and check this flag to skip themselves
+        # during the autotuning dummy run.
         fi_utils._is_fi_autotuning = True
-
-        # We skip EPLB here since we don't want to record dummy metrics
-        # When autotuning with number of tokens m, flashinfer will autotune
-        # operations for all number of tokens up to m.
-        # So we only need to run with the max number of tokens.
-        runner._dummy_run(
-            runner.scheduler_config.max_num_batched_tokens,
-            skip_eplb=True,
-            is_profile=True,
-        )
-
-        fi_utils._is_fi_autotuning = False
+        try:
+            # We skip EPLB here since we don't want to record dummy metrics
+            # When autotuning with number of tokens m, flashinfer will autotune
+            # operations for all number of tokens up to m.
+            # So we only need to run with the max number of tokens.
+            runner._dummy_run(
+                runner.scheduler_config.max_num_batched_tokens,
+                skip_eplb=True,
+                is_profile=True,
+            )
+        finally:
+            fi_utils._is_fi_autotuning = False


### PR DESCRIPTION
## Purpose

`gpt-oss-20b` MXFP4-BF16 startup on Blackwell (TP > 1, `--enforce-eager`) crashes with `WARP_ILLEGAL_ADDRESS` when FlashInfer's autotuner profiles a tactic for `trtllm_fp4_block_scale_moe` — the FP4 BMM cubin faults on SM100/SM103. Tracked upstream as flashinfer-ai/flashinfer#3168. This breaks the `test_gpqa_correctness[gpt-oss-20b-flashinfer-mxfp4-bf16]` B200 CI step ([build #63685](https://buildkite.com/vllm/ci/builds/63685/canvas?sid=019ddb0c-4771-42f8-b6d6-d04be6d70a21&tab=output)) and any production server in this configuration.

Skip the kernel call in `TrtLlmMxfp4ExpertsMonolithic.apply` during warmup by checking `vllm.utils.flashinfer._is_fi_autotuning`. Input quantization and dtype validation still run; production calls are unchanged. Also wrap the warmup `_dummy_run` in `try/finally` so the flag always resets.

The modular sibling (`trtllm_fp4_block_scale_routed_moe`) is unaffected — its autotune is fine because flashinfer-ai/flashinfer#2023 is already fixed.

## Test Plan

## Test Result