### PR TITLE
[ROCm][CI] Fix GPT-OSS Quark MXFP4+FP8 MoE startup

### DIFF
--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -1484,6 +1484,31 @@ class QuarkOCP_MX_MoEMethod_OSS(QuarkOCP_MX_MoEMethod):
     ):
         super().__init__(weight_config, input_config, moe)
 
+    def maybe_roundup_sizes(
+        self,
+        hidden_size: int,
+        intermediate_size_per_partition: int,
+        act_dtype: torch.dtype,
+        moe_parallel_config: FusedMoEParallelConfig,
+    ) -> tuple[int, int]:
+        # This path still swizzles MXFP4 weights/scales with Triton kernels,
+        # even though the base OCP-MX method classifies w_mxfp4_a_fp8 as
+        # emulation. Apply the Triton/CDNA4 padding before weights are created.
+        hidden_size, intermediate_size_per_partition = (
+            FusedMoEMethodBase.maybe_roundup_sizes(
+                self,
+                hidden_size=hidden_size,
+                intermediate_size_per_partition=intermediate_size_per_partition,
+                act_dtype=act_dtype,
+                moe_parallel_config=moe_parallel_config,
+            )
+        )
+        return mxfp4_round_up_hidden_size_and_intermediate_size(
+            Mxfp4MoeBackend.TRITON,
+            hidden_size,
+            intermediate_size_per_partition,
+        )
+
     def process_weights_after_loading(self, layer):
         from triton_kernels.matmul_ogs import FlexCtx, PrecisionConfig
 


### PR DESCRIPTION
Fix GPT-OSS Quark MXFP4+FP8 MoE startup on ROCm/gfx950 by applying the padding required by the Triton/CDNA4 MXFP4 scale layout, and align the GPT-OSS Quark monolithic MoE method with the current `MoERunner` call signature. The GPQA ROCm config for `amd/gpt-oss-20b-MoE-Quant-W-MXFP4-A-FP8-KV-FP8` failed during model startup while processing MoE weights:

```text
RuntimeError: shape '[-1, 90, 2, 16, 11, 2, 4, 1]' is invalid for input of size 8294400
```

The failing path is `QuarkOCP_MX_MoEMethod_OSS`, used for GPT-OSS Quark weights with MXFP4 weights and static FP8 activations. This subclass still swizzles MXFP4 weights and scales through Triton kernels in `process_weights_after_loading()`.

However, the base `QuarkOCP_MX_MoEMethod` treats `w_mxfp4_a_fp8` as an emulation path for sizing purposes, so it does not apply the MXFP4 backend padding. On ROCm/CDNA4, Triton scale swizzling requires aligned dimensions. For the 20B TP=2 case, the unpadded dimensions produce scale shapes based on `hidden_size=2880` and `intermediate_size_per_partition=1440`; `hidden_size / 32 = 90`, which is not compatible with the CDNA4 scale swizzle layout.

## Testing

Ran the focused padded MoE test file:

```text
pytest -s -v evals/gpt_oss/test_gpqa_correctness.py --config-list-file=configs/models-gfx950.txt
```

cc @kenroche 