### PR TITLE
[Performance][MiniMax-M2.5] Migrate gate to GateLinear bf16->fp32 gives 1.1x OTPS/gpu

### DIFF
--- a/vllm/model_executor/models/minimax_m2.py
+++ b/vllm/model_executor/models/minimax_m2.py
@@ -41,12 +41,12 @@ from vllm.distributed import (
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import (
     FusedMoE,
+    GateLinear,
     fused_moe_make_expert_params_mapping,
 )
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (
     QKVParallelLinear,
-    ReplicatedLinear,
     RowParallelLinear,
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
@@ -110,15 +110,13 @@ class MiniMaxM2MoE(nn.Module):
             renormalize=True,
             quant_config=quant_config,
             prefix=f"{prefix}.experts",
-            router_logits_dtype=torch.float32,
         )
 
-        self.gate = ReplicatedLinear(
+        self.gate = GateLinear(
             config.hidden_size,
             config.num_local_experts,
-            bias=False,
-            params_dtype=torch.float32,
-            quant_config=None,
+            out_dtype=torch.float32,
+            force_fp32_compute=True,
             prefix=f"{prefix}.gate",
         )
 
@@ -132,7 +130,7 @@ class MiniMaxM2MoE(nn.Module):
         hidden_states = hidden_states.view(-1, hidden_dim)
 
         # router_logits: (num_tokens, n_experts)
-        router_logits, _ = self.gate(hidden_states.to(torch.float32))
+        router_logits, _ = self.gate(hidden_states)
         final_hidden_states = self.experts(
             hidden_states=hidden_states, router_logits=router_logits
         )


### PR DESCRIPTION
**No Need**
BF16 will have accuracy issue. The solution on B200 is to use `VLLM_FLOAT32_MATMUL_PRECISION=high` and bring ~5% otps.



## Purpose

PR #35121 (Cublas Bf16 Gate with Fp32 Output) introduced `GateLinear`, a 3-tier dispatcher that keeps FP32 routing logits but moves the matmul to BF16 on Hopper Tensor Cores via the new `router_gemm_bf16_fp32` cuBLAS wrapper. That PR migrated DeepSeek-V2 and Nemotron-H. **MiniMax-M2 was added in #27535 (Oct 2025), 4 months before #35121 landed (Feb 2026), and was missed.

The MiniMax-M2 / M2.5 MoE gate currently runs as a pure FP32xFP32 GEMM:

| Phase | Kernel that fires | Hardware path |
|-------|---|---|
| Prefill (large M)    | `sm80_xmma_gemm_f32f32_f32f32_f32_tn_n_tilesize128x128x8`  | Ampere FP32 TC (compat mode) |
| Decode  (small M)    | `cutlass::Kernel2<cutlass_80_simt_sgemm_64x64_8x5_tn_align1>` | **CUDA cores (SIMT)**, no TC |

## Test Plan

- [x] **Accuracy: GSM8K 5-shot via lm_eval** against the served endpoint (num_concurrent=32, batch_size=32, max_length=32768, tokenized_requests=False).
- [x] **End-to-end serving on B200 TP=1 NVFP4**, sglang sweep concurrency 1 -> 512 at ISL=1600 OSL=600 REPEAT=5. Run twice on the same node back-to-back to control for cross-machine variation: once with the patch reverted ("Before, same node") and once with the patch applied ("After").
- [x] **vllm bench serve at conc=512** with random workload (num-prompts=1024) for the headline single-config result, before vs after on the same node and same container.

## Test Result

### 1. Serve script (B200 NVFP4 TP=1)

```bash
vllm serve /scratch_omniml_data_3/models/MiniMax-M2.5-NVFP4 \
    --tensor-parallel-size 1 \
    --max-num-seqs 512 \
    --max-num-batched-tokens 8192 \
    --max-model-len 4096 \
    --gpu-memory-utilization 0.90 \
    --trust-remote-code \
    --async-scheduling \
    --no-enable-prefix-caching \
    --compilation-config '{"compile_sizes":[1,2,4,8,16,32,64,128,256,512],"cudagraph_capture_sizes":[1,2,4,8,16,32,64,128,256,512]}' \
    --host 0.0.0.0 --port 8003
```

### 2. Single-config headline (vllm bench serve, conc=512, ISL=1600 OSL=600, num_prompts=1024, ignore_eos)

```bash
vllm bench serve \
    --backend openai-chat \
    --base-url http://localhost:8003 \
    --model /scratch_omniml_data_3/models/MiniMax-M2.5-NVFP4 \
    --endpoint /v1/chat/completions \
    --dataset-name random \
    --random-input-len 1600 \
    --random-output-len 600 \
    --num-prompts 1024 \
    --max-concurrency 512 \
    --request-rate inf --ignore-eos --seed 1746
```

**Before**

```
============ Serving Benchmark Result ============
Successful requests:                     1024
Failed requests:                         0
Maximum request concurrency:             512
Benchmark duration (s):                  175.78
Total input tokens:                      1677312
Total generated tokens:                  614400
Request throughput (req/s):              5.83
Output token throughput (tok/s):         3495.31
Peak output token throughput (tok/s):    5252.00
Peak concurrent requests:                547.00
Total token throughput (tok/s):          13037.49
---------------Time to First Token----------------
Mean TTFT (ms):                          47416.55
Median TTFT (ms):                        51472.15
P99 TTFT (ms):                           75694.15
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          38.30
Median TPOT (ms):                        35.78
P99 TPOT (ms):                           65.54
---------------Inter-token Latency----------------
Mean ITL (ms):                           38.23
Median ITL (ms):                         29.71
P99 ITL (ms):                            155.11
==================================================
```

**After** — finishes ~17 s faster, **+10.7 %** total token throughput, **+12.4 %** peak OTPS, **-10.6 %** mean TTFT, **-7.1 %** median TPOT.

```
============ Serving Benchmark Result ============
Successful requests:                     1024
Failed requests:                         0
Maximum request concurrency:             512
Benchmark duration (s):                  158.81
Total input tokens:                      1677312
Total generated tokens:                  614400
Request throughput (req/s):              6.45
Output token throughput (tok/s):         3868.67
Peak output token throughput (tok/s):    5904.00
Peak concurrent requests:                552.00
Total token throughput (tok/s):          14430.15
---------------Time to First Token----------------
Mean TTFT (ms):                          42368.59
Median TTFT (ms):                        44829.83
P99 TTFT (ms):                           69457.55
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          35.50
Median TPOT (ms):                        33.23
P99 TPOT (ms):                           60.38
---------------Inter-token Latency----------------
Mean ITL (ms):                           35.44
Median ITL (ms):                         27.30
P99 ITL (ms):                            136.77
==================================================
```

### 3. Accuracy: GSM8K 5-shot, lm_eval, BS=32 max_len=4096 (conc=32 against the served endpoint)

**MAX_LEN=4096 (short-context):**

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| flexible-extract exact_match | 0.9287 +/- 0.0071 | 0.9272 +/- 0.0072 | **-0.0015 (within stderr)** |
| strict-match exact_match     | 0.9265 +/- 0.0072 | 0.9257 +/- 0.0072 | **-0.0008 (within stderr)** |

**MAX_LEN=32768 (long-context, separate paired re-run with --max-model-len 32768):**

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| flexible-extract exact_match | 0.9234 +/- 0.0073 | 0.9181 +/- 0.0076 | **-0.0053 (within stderr)** |
| strict-match exact_match     | 0.9227 +/- 0.0074 | 0.9151 +/- 0.0077 | **-0.0076 (right at +/-stderr edge)** |

### 4. Full concurrency sweep, OTPS / GPU (sglang sweep, ISL=1600 OSL=600, REPEAT=5, same node)

| Conc | Before (FP32 gate) | After (GateLinear) | Delta |
|---|---:|---:|---:|
| 1   | 250.0  | 239.7  | -4.1 % (5 prompts, noisy) |
| 2   | 330.4  | 361.0  | **+9.3 %** |
| 4   | 558.6  | 606.1  | **+8.5 %** |
| 8   | 883.8  | 941.7  | **+6.6 %** |
| 16  | 1326.3 | 1374.7 | +3.7 % |
| 32  | 1795.6 | 1951.9 | **+8.7 %** |
| 64  | 2582.4 | 2834.3 | **+9.8 %** |
| 128 | 3890.5 | 4156.1 | **+6.8 %** |
| 256 | 3761.6 | 4163.9 | **+10.7 %** |
| 512 | 3788.1 | 4223.4 | **+11.5 %** |

### 5. nsys on B200
Before
<img width="987" height="536" alt="image (17)" src="https://github.com/user-attachments/assets/2540b8b1-0788-4e73-ac3d-6901262a1098" />

After
<img width="913" height="562" alt="image (18)" src="https://github.com/user-attachments/assets/27311b5a-f12a-4a7e-9ae4-aca5c12df9e8" />

### 5b. Alternative considered: `VLLM_FLOAT32_MATMUL_PRECISION=high` (TF32 path)

A simpler alternative to this PR is to keep the FP32 gate weights but set `VLLM_FLOAT32_MATMUL_PRECISION=high`, which makes PyTorch / cuBLAS promote FP32xFP32 matmul to use the Blackwell sm100 Tensor Cores in TF32 mode. This avoids the slow SIMT fallback without changing the model code. To compare, both the no-flag and `=high` configurations were measured on the same B200 / same container / same workload (sglang sweep, ISL=1600, OSL=600, REPEAT=5):

| Conc | Before, no flag | Before, `=high` (TF32) | TF32 / noflag |
|---|---:|---:|---:|
| 1   | 253.9  | 244.2  | -3.8 % |
| 2   | 330.3  | 348.8  | **+5.6 %** |
| 4   | 575.5  | 602.6  | **+4.7 %** |
| 8   | 899.6  | 934.2  | **+3.8 %** |
| 16  | 1332.7 | 1372.3 | **+3.0 %** |
| 32  | 1809.0 | 1929.7 | **+6.7 %** |
| 64  | 2645.2 | 2827.1 | **+6.9 %** |
| 128 | 3963.4 | 4186.2 | **+5.6 %** |

**TF32 alone gives ~+5 % avg** vs no-flag baseline (vs ~+8 % avg / +11 % peak from this PR's GateLinear migration in the prior section).

**Kernel-level evidence — paired NSYS, B200, conc=16, OSL=20**:

| Configuration | Gate kernel observed | Math units |
|---|---|---|
| Before, no flag | `cutlass::Kernel2<cutlass_80_simt_sgemm_64x64_8x5_tn_align1>` | **CUDA cores (SIMT)** — no TC |
| Before, `=high` (TF32) | `cutlass3x_sm100_tensorop_s128x128x8tf32gemm_f32_f32_f32_f32_f32_128x128x32_0_tnn_align4_2sm_epi_tma_bias_f32_relu` (+ `cublasLt::splitKreduce_kernel<__nv_bfloat16, float>`) | **Blackwell sm100 Tensor Cores in TF32 mode** |
| After (this PR, GateLinear) | `cublasLt::splitKreduce_kernel<__nv_bfloat16, float>` + `nvjet_sm100_tss_32x64_64x16_4x1_v_bz_splitK_TNN` | **Blackwell sm100 Tensor Cores in BF16 mode** |



## Note
### Comparison with the HuggingFace reference implementation

`MiniMaxAI/MiniMax-M2.5/modeling_minimax_m2.py` (the author's reference):
```python
# Gate — no dtype override:
self.gate = nn.Linear(config.hidden_size, config.num_local_experts, bias=False)

# Forward — no .to(torch.float32) cast:
router_logits = self.gate(hidden_states)

# FP32 upcast happens only AFTER the matmul, before the sigmoid+topk:
def route_tokens_to_experts(self, router_logits):
    routing_weights = torch.nn.functional.sigmoid(router_logits.float())
```

The author's design is **BF16 gate matmul + FP32 sigmoid/topk** — the matmul runs in the model's native dtype and only the routing-decision step is upcast to FP32 for numerical stability of the sigmoid. The vLLM port currently does **FP32 matmul + FP32 sigmoid/topk**, which is stricter than the author intended; this PR's `GateLinear` Tier 2 (`router_gemm_bf16_fp32`: BF16 inputs/weights, FP32 accumulator output) restores the author's intended semantics — BF16 matmul on Tensor Cores, FP32 logits feeding into sigmoid+topk.** This PR mirrors the Nemotron-H migration (commit 38c498b8e) so MiniMax-M2 gets the same fast path.

The change is 5 insertions / 7 deletions in `vllm/model_executor/models/minimax_m2.py`. Routing logits remain in FP32 (precision unchanged); only the matmul moves off the SIMT FP32 path onto Hopper / Blackwell Tensor Cores.


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

