### PR TITLE
[DSv4] Enable paged indexer for prefill

### DIFF
--- a/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
+++ b/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
@@ -7,6 +7,11 @@ import torch
 from torch import Tensor
 
 from vllm import _custom_ops as ops
+from vllm.model_executor.layers.sparse_attn_indexer import kv_cache_as_quant_view
+from vllm.third_party.deep_gemm import (
+    fp8_fp4_paged_mqa_logits,
+    get_paged_mqa_logits_metadata,
+)
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.utils.deep_gemm import fp8_fp4_mqa_logits
 from vllm.utils.math_utils import cdiv
@@ -30,115 +35,188 @@ def make_random_fp4(*prefix_shape: int) -> tuple[Tensor, Tensor]:
     return fp4, scales
 
 
-def deepgemm_prepare(
-    block_table: Tensor,
-    query_lens_cpu: Tensor,
-    seq_lens_cpu: Tensor,
-    compressed_seq_lens_cpu: Tensor,
-    query_start_loc_cpu: Tensor,
-    compress_ratio: int,
-    use_fp4: bool,
-):
-    chunk_specs = split_indexer_prefill_chunks(
-        compressed_seq_lens_cpu,
-        query_lens_cpu,
-        DEEPGEMM_WORKSPACE_SIZE,
-        DEEPGEMM_MAX_LOGITS_MB * 1024 * 1024,
-    )
-    chunks = []
-    for req_slice, query_slice in chunk_specs:
-        metadata = build_prefill_chunk_metadata(
-            req_slice.start,
-            req_slice.stop,
-            query_start_loc_cpu.cuda(),
-            query_start_loc_cpu,
-            seq_lens_cpu.cuda(),
-            compressed_seq_lens_cpu.cuda(),
+class DeepGemmFlat:
+    def __init__(
+        self,
+        block_table: Tensor,
+        query_lens_cpu: Tensor,
+        seq_lens_cpu: Tensor,
+        compressed_seq_lens_cpu: Tensor,
+        query_start_loc_cpu: Tensor,
+        compress_ratio: int,
+        use_fp4: bool,
+    ) -> None:
+        chunk_specs = split_indexer_prefill_chunks(
             compressed_seq_lens_cpu,
-            block_table,
-            compress_ratio,
-            query_slice=query_slice,
-            skip_kv_gather=query_slice.start > 0,
+            query_lens_cpu,
+            DEEPGEMM_WORKSPACE_SIZE,
+            DEEPGEMM_MAX_LOGITS_MB * 1024 * 1024,
         )
-        if metadata is not None:
-            chunks.append(metadata)
-    if not chunks:
-        raise RuntimeError("generated requests produced no prefill chunks")
+        self.chunks = []
+        for req_slice, query_slice in chunk_specs:
+            metadata = build_prefill_chunk_metadata(
+                req_slice.start,
+                req_slice.stop,
+                query_start_loc_cpu.cuda(),
+                query_start_loc_cpu,
+                seq_lens_cpu.cuda(),
+                compressed_seq_lens_cpu.cuda(),
+                compressed_seq_lens_cpu,
+                block_table,
+                compress_ratio,
+                query_slice=query_slice,
+                skip_kv_gather=query_slice.start > 0,
+            )
+            if metadata is not None:
+                self.chunks.append(metadata)
+        if not self.chunks:
+            raise RuntimeError("generated requests produced no prefill chunks")
 
-    workspace_tokens = max(chunk.total_seq_lens for chunk in chunks)
-    if use_fp4:
-        k_quant_shape = (workspace_tokens, HEAD_DIM // 2)
-        k_scale_shape = (workspace_tokens, HEAD_DIM // MXFP4_BLOCK_SIZE)
-        k_quant_dtype = k_scale_dtype = torch.uint8
-    else:
-        k_quant_shape = (workspace_tokens, HEAD_DIM)
-        k_scale_shape = (workspace_tokens, 4)
-        k_quant_dtype = torch.float8_e4m3fn
-        k_scale_dtype = torch.uint8
+        workspace_tokens = max(chunk.total_seq_lens for chunk in self.chunks)
+        if use_fp4:
+            k_quant_shape = (workspace_tokens, HEAD_DIM // 2)
+            k_scale_shape = (workspace_tokens, HEAD_DIM // MXFP4_BLOCK_SIZE)
+            k_quant_dtype = k_scale_dtype = torch.uint8
+        else:
+            k_quant_shape = (workspace_tokens, HEAD_DIM)
+            k_scale_shape = (workspace_tokens, 4)
+            k_quant_dtype = torch.float8_e4m3fn
+            k_scale_dtype = torch.uint8
 
-    device = block_table.device
-    k_quant_full = torch.empty(k_quant_shape, dtype=k_quant_dtype, device=device)
-    k_scale_full = torch.empty(k_scale_shape, dtype=k_scale_dtype, device=device)
-    return chunks, k_quant_full, k_scale_full
+        self.k_quant_full = torch.empty(
+            k_quant_shape, dtype=k_quant_dtype, device=block_table.device
+        )
+        self.k_scale_full = torch.empty(
+            k_scale_shape, dtype=k_scale_dtype, device=block_table.device
+        )
 
+    def run(
+        self,
+        q_quant: Tensor,
+        q_scale: Tensor | None,
+        kv_cache: Tensor,
+        weights: Tensor,
+        topk_indices_buffer: Tensor,
+    ) -> None:
+        use_fp4 = q_scale is not None
+        _, topk = topk_indices_buffer.shape
 
-def deepgemm_run(
-    q_quant: Tensor,
-    q_scale: Tensor | None,
-    kv_cache: Tensor,
-    weights: Tensor,
-    topk_indices_buffer: Tensor,
-    metadata,
-) -> None:
-    use_fp4 = q_scale is not None
-    chunks, k_quant_full, k_scale_full = metadata
-    _, topk = topk_indices_buffer.shape
+        for chunk in self.chunks:
+            k_quant = self.k_quant_full[: chunk.total_seq_lens]
+            k_scale = self.k_scale_full[: chunk.total_seq_lens]
 
-    for chunk in chunks:
-        k_quant = k_quant_full[: chunk.total_seq_lens]
-        k_scale = k_scale_full[: chunk.total_seq_lens]
+            # This mirrors SparseAttentionIndexer: query sub-chunks from the same
+            # request can reuse the previously gathered K workspace.
+            if not chunk.skip_kv_gather:
+                ops.cp_gather_indexer_k_quant_cache(
+                    kv_cache,
+                    k_quant,
+                    k_scale,
+                    chunk.block_table,
+                    chunk.cu_seq_lens,
+                )
 
-        # This mirrors SparseAttentionIndexer: query sub-chunks from the same
-        # request can reuse the previously gathered K workspace.
-        if not chunk.skip_kv_gather:
-            ops.cp_gather_indexer_k_quant_cache(
-                kv_cache,
-                k_quant,
-                k_scale,
-                chunk.block_table,
-                chunk.cu_seq_lens,
+            token_slice = slice(chunk.token_start, chunk.token_end)
+            q_slice = q_quant[token_slice]
+
+            if use_fp4:
+                q_slice = q_slice.view(torch.int8)
+                q_scale_slice = q_scale[token_slice]
+                k_quant = k_quant.view(torch.int8)
+                k_scale = k_scale.view(torch.int32).squeeze(-1)
+            else:
+                q_scale_slice = None
+                k_scale = k_scale.view(torch.float32).squeeze(-1)
+
+            logits = fp8_fp4_mqa_logits(
+                (q_slice, q_scale_slice),
+                (k_quant, k_scale),
+                weights[token_slice],
+                chunk.cu_seqlen_ks,
+                chunk.cu_seqlen_ke,
+                clean_logits=False,
+            )
+            torch.ops._C.top_k_per_row_prefill(
+                logits,
+                chunk.cu_seqlen_ks,
+                chunk.cu_seqlen_ke,
+                topk_indices_buffer[token_slice],
+                logits.shape[0],
+                logits.stride(0),
+                logits.stride(1),
+                topk,
             )
 
-        token_slice = slice(chunk.token_start, chunk.token_end)
-        q_slice = q_quant[token_slice]
 
-        if use_fp4:
-            q_slice = q_slice.view(torch.int8)
-            q_scale_slice = q_scale[token_slice]
-            k_quant = k_quant.view(torch.int8)
-            k_scale = k_scale.view(torch.int32).squeeze(-1)
-        else:
-            q_scale_slice = None
-            k_scale = k_scale.view(torch.float32).squeeze(-1)
+class DeepGemmPaged:
+    def __init__(
+        self,
+        block_table: Tensor,
+        query_lens: list[int],
+        seq_lens: list[int],
+        compressed_seq_lens: list[int],
+        compress_ratio: int,
+        block_size: int,
+    ) -> None:
+        query_to_req: list[int] = []
+        context_lens: list[int] = []
+        for req_idx, query_len in enumerate(query_lens):
+            context_len = seq_lens[req_idx] - query_len
+            for offset in range(query_len):
+                query_to_req.append(req_idx)
+                context_lens.append((context_len + offset + 1) // compress_ratio)
+        if not context_lens or max(compressed_seq_lens) == 0:
+            raise RuntimeError("generated requests produced no prefill KV tokens")
 
-        logits = fp8_fp4_mqa_logits(
-            (q_slice, q_scale_slice),
-            (k_quant, k_scale),
-            weights[token_slice],
-            chunk.cu_seqlen_ks,
-            chunk.cu_seqlen_ke,
-            clean_logits=False,
+        device = block_table.device
+        self.indices = torch.tensor(query_to_req, dtype=torch.int32, device=device)
+        self.context_lens = torch.tensor(
+            context_lens, dtype=torch.int32, device=device
+        ).view(-1, 1)
+        self.block_table = block_table.index_select(0, self.indices.to(torch.long))
+        self.max_context_len = max(compressed_seq_lens)
+
+        num_sms = torch.cuda.get_device_properties(
+            torch.cuda.current_device()
+        ).multi_processor_count
+        self.schedule_metadata = get_paged_mqa_logits_metadata(
+            self.context_lens, block_size, num_sms, indices=self.indices
         )
-        topk_indices = topk_indices_buffer[token_slice]
-        torch.ops._C.top_k_per_row_prefill(
+
+    def run(
+        self,
+        q_quant: Tensor,
+        q_scale: Tensor | None,
+        kv_cache: Tensor,
+        weights: Tensor,
+        topk_indices_buffer: Tensor,
+    ) -> None:
+        num_tokens = self.context_lens.shape[0]
+        q_values = q_quant.view(num_tokens, 1, *q_quant.shape[1:])
+        if q_scale is not None:
+            q_values = q_values.view(torch.int8)
+            q_scale = q_scale.view(num_tokens, 1, *q_scale.shape[1:])
+
+        logits = fp8_fp4_paged_mqa_logits(
+            (q_values, q_scale),
+            kv_cache_as_quant_view(kv_cache, HEAD_DIM, q_scale is not None),
+            weights,
+            self.context_lens,
+            self.block_table,
+            self.schedule_metadata,
+            self.max_context_len,
+            False,
+            indices=self.indices,
+        )
+        torch.ops._C.top_k_per_row_decode(
             logits,
-            chunk.cu_seqlen_ks,
-            chunk.cu_seqlen_ke,
-            topk_indices,
+            1,
+            self.context_lens,
+            topk_indices_buffer,
             logits.shape[0],
             logits.stride(0),
             logits.stride(1),
-            topk,
+            topk_indices_buffer.shape[1],
         )
 
 
@@ -146,13 +224,18 @@ def parse_args():
     parser = FlexibleArgumentParser(
         description="Run the DeepGEMM prefill sparse-indexer path."
     )
+    parser.add_argument(
+        "--impl",
+        choices=["deepgemm_flat", "deepgemm_paged"],
+        default="deepgemm_flat",
+    )
     parser.add_argument("--dtype", choices=["fp4", "fp8"], required=True)
     parser.add_argument("--num-requests", type=int, default=8)
     parser.add_argument("--min-query-len", type=int, default=16)
     parser.add_argument("--max-query-len", type=int, default=128)
     parser.add_argument("--min-context-len", type=int, default=0)
     parser.add_argument("--max-context-len", type=int, default=1024)
-    parser.add_argument("--block-size", type=int, default=256)
+    parser.add_argument("--block-size", type=int, default=64)
     parser.add_argument("--compress-ratio", type=int, default=4)
     parser.add_argument("--topk", type=int, default=2048)
     parser.add_argument("--seed", type=int, default=42)
@@ -169,6 +252,9 @@ def main() -> None:
 
     # Prepare request lengths.
     use_fp4 = args.dtype == "fp4"
+    if args.impl == "deepgemm_paged" and args.block_size not in (32, 64):
+        raise ValueError("deepgemm_paged requires --block-size 32 or 64")
+
     query_lens: list[int] = []
     seq_lens: list[int] = []
     compressed_seq_lens: list[int] = []
@@ -255,16 +341,26 @@ def main() -> None:
     block_table = block_table_cpu.cuda()
     topk_indices_buffer = torch.empty((total_query_len, args.topk), dtype=torch.int32)
 
-    metadata = deepgemm_prepare(
-        block_table,
-        query_lens_cpu,
-        seq_lens_cpu,
-        compressed_seq_lens_cpu,
-        query_start_loc_cpu,
-        args.compress_ratio,
-        use_fp4,
-    )
-    deepgemm_run(q_quant, q_scale, kv_cache, weights, topk_indices_buffer, metadata)
+    if args.impl == "deepgemm_flat":
+        impl = DeepGemmFlat(
+            block_table,
+            query_lens_cpu,
+            seq_lens_cpu,
+            compressed_seq_lens_cpu,
+            query_start_loc_cpu,
+            args.compress_ratio,
+            use_fp4,
+        )
+    else:
+        impl = DeepGemmPaged(
+            block_table,
+            query_lens,
+            seq_lens,
+            compressed_seq_lens,
+            args.compress_ratio,
+            block_size,
+        )
+    impl.run(q_quant, q_scale, kv_cache, weights, topk_indices_buffer)
 
 
 if __name__ == "__main__":

--- a/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
+++ b/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import argparse
+import gc
 import random
 
 import torch
@@ -348,14 +349,15 @@ class DeepGemmPaged:
         return self.topk_indices_buffer
 
 
+IMPLEMENTATIONS = (
+    ("deepgemm_flat", DeepGemmFlat),
+    ("deepgemm_paged", DeepGemmPaged),
+)
+
+
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="Run the DeepGEMM prefill sparse-indexer path."
-    )
-    parser.add_argument(
-        "--impl",
-        choices=["deepgemm_flat", "deepgemm_paged"],
-        default="deepgemm_flat",
+        description="Run all DeepGEMM prefill sparse-indexer paths."
     )
     parser.add_argument("--dtype", choices=["fp4", "fp8"], required=True)
     parser.add_argument("--num-requests", type=int, default=8)
@@ -370,17 +372,24 @@ def parse_args():
     return parser.parse_args()
 
 
-def check_topk(
+def print_topk_result(
+    impl_name: str,
     actual: Tensor,
     expected: Tensor,
     query_lens: list[int],
     seq_lens: list[int],
     compress_ratio: int,
     topk: int,
+    peak_memory_mib: float,
 ) -> None:
     actual_cpu = actual.cpu()
     expected_cpu = expected.cpu()
     row_idx = 0
+    compared_rows = 0
+    wrong_rows = 0
+    compared_entries = 0
+    wrong_entries = 0
+
     for query_len, seq_len in zip(query_lens, seq_lens):
         context_len = seq_len - query_len
         for offset in range(query_len):
@@ -389,18 +398,29 @@ def check_topk(
             if k > 0:
                 actual_row = actual_cpu[row_idx, :k].sort().values
                 expected_row = expected_cpu[row_idx, :k].sort().values
-                if not torch.equal(actual_row, expected_row):
-                    raise AssertionError(
-                        f"top-k mismatch at row {row_idx}: "
-                        f"actual={actual_cpu[row_idx, :k].tolist()}, "
-                        f"expected={expected_cpu[row_idx, :k].tolist()}"
-                    )
+                row_mismatches = int(
+                    (~torch.isin(actual_row, expected_row)).sum().item()
+                )
+                compared_rows += 1
+                compared_entries += k
+                if row_mismatches > 0:
+                    wrong_rows += 1
+                    wrong_entries += row_mismatches
             row_idx += 1
 
+    correctness = "passed" if wrong_entries == 0 else "failed"
+    print(
+        f"{impl_name}: correctness={correctness}, "
+        f"wrong_entries={wrong_entries}/{compared_entries}, "
+        f"wrong_rows={wrong_rows}/{compared_rows}, "
+        f"peak_memory={peak_memory_mib:.2f} MiB"
+    )
 
-def main() -> Tensor:
+
+def main() -> None:
     args = parse_args()
     print(args)
+    print("implementations:", ", ".join(name for name, _ in IMPLEMENTATIONS))
 
     torch.set_default_device("cuda")
     torch.manual_seed(args.seed)
@@ -492,23 +512,6 @@ def main() -> Tensor:
             kv_cache[block_id, scale_off : scale_off + block_ks.numel()] = block_ks
 
     kv_cache = kv_cache.view(-1, block_size, cache_dim)
-    impl_cls = {
-        "deepgemm_flat": DeepGemmFlat,
-        "deepgemm_paged": DeepGemmPaged,
-    }[args.impl]
-    impl = impl_cls(
-        block_table_cpu,
-        query_lens_cpu,
-        seq_lens_cpu,
-        compressed_seq_lens_cpu,
-        query_start_loc_cpu,
-        args.compress_ratio,
-        block_size,
-        use_fp4,
-        args.topk,
-    )
-    topk_indices = impl.run(q_quant, q_scale, kv_cache, weights)
-
     reference = Reference(
         block_table_cpu,
         query_lens_cpu,
@@ -521,17 +524,39 @@ def main() -> Tensor:
         args.topk,
     )
     expected_topk = reference.run(q_quant, q_scale, kv_cache, weights)
-    check_topk(
-        topk_indices,
-        expected_topk,
-        query_lens,
-        seq_lens,
-        args.compress_ratio,
-        args.topk,
-    )
-    print("correctness check passed")
 
-    return topk_indices
+    for impl_name, impl_cls in IMPLEMENTATIONS:
+        impl = None
+        topk_indices = None
+        gc.collect()
+        torch.cuda.empty_cache()
+        torch.cuda.synchronize()
+        torch.cuda.reset_peak_memory_stats()
+
+        impl = impl_cls(
+            block_table_cpu,
+            query_lens_cpu,
+            seq_lens_cpu,
+            compressed_seq_lens_cpu,
+            query_start_loc_cpu,
+            args.compress_ratio,
+            block_size,
+            use_fp4,
+            args.topk,
+        )
+        topk_indices = impl.run(q_quant, q_scale, kv_cache, weights)
+        torch.cuda.synchronize()
+        peak_memory_mib = torch.cuda.max_memory_allocated() / 1024 / 1024
+        print_topk_result(
+            impl_name,
+            topk_indices,
+            expected_topk,
+            query_lens,
+            seq_lens,
+            args.compress_ratio,
+            args.topk,
+            peak_memory_mib,
+        )
 
 
 if __name__ == "__main__":

--- a/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
+++ b/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
@@ -5,6 +5,7 @@ import argparse
 import gc
 import random
 from dataclasses import dataclass
+from functools import partial
 
 import pandas as pd
 import torch
@@ -160,7 +161,7 @@ class Reference:
         return topk_indices_buffer
 
 
-class DeepGemmFlatChunk:
+class DeepGemmFlat:
     def __init__(
         self,
         block_table_cpu: Tensor,
@@ -172,6 +173,7 @@ class DeepGemmFlatChunk:
         block_size: int,
         use_fp4: bool,
         topk: int,
+        do_chunk: bool = False,
     ) -> None:
         total_query_len = int(query_start_loc_cpu[-1].item())
         block_table = block_table_cpu.cuda()
@@ -182,12 +184,18 @@ class DeepGemmFlatChunk:
             (total_query_len, topk), dtype=torch.int32, device="cuda"
         )
 
-        chunk_specs = split_indexer_prefill_chunks(
-            compressed_seq_lens_cpu,
-            query_lens_cpu,
-            DEEPGEMM_WORKSPACE_SIZE,
-            DEEPGEMM_MAX_LOGITS_BYTES,
-        )
+        if do_chunk:
+            chunk_specs = split_indexer_prefill_chunks(
+                compressed_seq_lens_cpu,
+                query_lens_cpu,
+                DEEPGEMM_WORKSPACE_SIZE,
+                DEEPGEMM_MAX_LOGITS_BYTES,
+            )
+        else:
+            chunk_specs = [
+                (slice(0, query_lens_cpu.numel()), slice(0, total_query_len))
+            ]
+
         self.chunks = []
         for req_slice, query_slice in chunk_specs:
             metadata = build_prefill_chunk_metadata(
@@ -282,80 +290,6 @@ class DeepGemmFlatChunk:
 
 
 class DeepGemmPaged:
-    def __init__(
-        self,
-        block_table_cpu: Tensor,
-        query_lens_cpu: Tensor,
-        seq_lens_cpu: Tensor,
-        compressed_seq_lens_cpu: Tensor,
-        query_start_loc_cpu: Tensor,
-        compress_ratio: int,
-        block_size: int,
-        use_fp4: bool,
-        topk: int,
-    ) -> None:
-        total_query_len = int(query_start_loc_cpu[-1].item())
-        if total_query_len == 0 or int(compressed_seq_lens_cpu.max().item()) == 0:
-            raise RuntimeError("generated requests produced no prefill KV tokens")
-        self.topk_indices_buffer = torch.empty(
-            (total_query_len, topk), dtype=torch.int32, device="cuda"
-        )
-
-        req_ids = torch.arange(query_lens_cpu.numel(), device="cpu")
-        req_idx = torch.repeat_interleave(
-            req_ids, query_lens_cpu, output_size=total_query_len
-        )
-        token_idx = torch.arange(total_query_len, dtype=torch.int32, device="cpu")
-        query_offsets = token_idx - query_start_loc_cpu[req_idx]
-        context_lens = (
-            seq_lens_cpu[req_idx] - query_lens_cpu[req_idx] + query_offsets + 1
-        ) // compress_ratio
-
-        req_idx = req_idx.cuda()
-        self.indices = req_idx.to(torch.int32)
-        self.context_lens = context_lens.cuda().view(-1, 1)
-        self.block_table = block_table_cpu.cuda()[req_idx]
-        self.max_context_len = int(compressed_seq_lens_cpu.max().item())
-
-        self.schedule_metadata = get_paged_mqa_logits_metadata(
-            self.context_lens, block_size, NUM_SMS, indices=self.indices
-        )
-        self.num_chunks = 1
-
-    def run(
-        self, q_quant: Tensor, q_scale: Tensor | None, kv_cache: Tensor, weights: Tensor
-    ) -> Tensor:
-        num_tokens = self.context_lens.shape[0]
-        q_values = q_quant.view(num_tokens, 1, *q_quant.shape[1:])
-        if q_scale is not None:
-            q_values = q_values.view(torch.int8)
-            q_scale = q_scale.view(num_tokens, 1, *q_scale.shape[1:])
-
-        logits = fp8_fp4_paged_mqa_logits(
-            (q_values, q_scale),
-            kv_cache_as_quant_view(kv_cache, HEAD_DIM, q_scale is not None),
-            weights,
-            self.context_lens,
-            self.block_table,
-            self.schedule_metadata,
-            self.max_context_len,
-            False,
-            indices=self.indices,
-        )
-        torch.ops._C.top_k_per_row_decode(
-            logits,
-            1,
-            self.context_lens,
-            self.topk_indices_buffer,
-            logits.shape[0],
-            logits.stride(0),
-            logits.stride(1),
-            self.topk_indices_buffer.shape[1],
-        )
-        return self.topk_indices_buffer
-
-
-class DeepGemmPagedChunk:
     @dataclass
     class Metadata:
         token_start: int
@@ -377,6 +311,7 @@ class DeepGemmPagedChunk:
         block_size: int,
         use_fp4: bool,
         topk: int,
+        do_chunk: bool = False,
     ) -> None:
         total_query_len = int(query_start_loc_cpu[-1].item())
         self.topk_indices_buffer = torch.empty(
@@ -394,17 +329,22 @@ class DeepGemmPagedChunk:
         ) // compress_ratio
 
         block_table = block_table_cpu.cuda()
-        # The paged path reads K directly from the KV cache, so it does not
-        # need the flat path's gathered-K workspace bound.
-        paged_chunk_workspace_size = int(compressed_seq_lens_cpu.sum().item())
-        chunk_specs = split_indexer_prefill_chunks(
-            compressed_seq_lens_cpu,
-            query_lens_cpu,
-            paged_chunk_workspace_size,
-            DEEPGEMM_MAX_LOGITS_BYTES,
-        )
+        if do_chunk:
+            # The paged path reads K directly from the KV cache, so it does not
+            # need the flat path's gathered-K workspace bound.
+            paged_chunk_workspace_size = int(compressed_seq_lens_cpu.sum().item())
+            chunk_specs = split_indexer_prefill_chunks(
+                compressed_seq_lens_cpu,
+                query_lens_cpu,
+                paged_chunk_workspace_size,
+                DEEPGEMM_MAX_LOGITS_BYTES,
+            )
+        else:
+            chunk_specs = [
+                (slice(0, query_lens_cpu.numel()), slice(0, total_query_len))
+            ]
 
-        self.chunks: list[DeepGemmPagedChunk.Metadata] = []
+        self.chunks: list[DeepGemmPaged.Metadata] = []
         for req_slice, query_slice in chunk_specs:
             if int(compressed_seq_lens_cpu[req_slice].sum().item()) == 0:
                 continue
@@ -420,7 +360,7 @@ class DeepGemmPagedChunk:
             schedule_metadata = get_paged_mqa_logits_metadata(
                 context_lens, block_size, NUM_SMS, indices=indices
             )
-            chunk = DeepGemmPagedChunk.Metadata(
+            chunk = DeepGemmPaged.Metadata(
                 token_start,
                 token_end,
                 indices,
@@ -479,9 +419,10 @@ class DeepGemmPagedChunk:
 
 
 IMPLEMENTATIONS = (
-    ("deepgemm_flat_chunk", DeepGemmFlatChunk),
+    ("deepgemm_flat", DeepGemmFlat),
+    ("deepgemm_flat_chunk", partial(DeepGemmFlat, do_chunk=True)),
     ("deepgemm_paged", DeepGemmPaged),
-    ("deepgemm_paged_chunk", DeepGemmPagedChunk),
+    ("deepgemm_paged_chunk", partial(DeepGemmPaged, do_chunk=True)),
 )
 
 

--- a/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
+++ b/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
@@ -38,14 +38,20 @@ def make_random_fp4(*prefix_shape: int) -> tuple[Tensor, Tensor]:
 class DeepGemmFlat:
     def __init__(
         self,
-        block_table: Tensor,
+        block_table_cpu: Tensor,
         query_lens_cpu: Tensor,
         seq_lens_cpu: Tensor,
         compressed_seq_lens_cpu: Tensor,
         query_start_loc_cpu: Tensor,
         compress_ratio: int,
+        block_size: int,
         use_fp4: bool,
     ) -> None:
+        block_table = block_table_cpu.cuda()
+        query_start_loc = query_start_loc_cpu.cuda()
+        seq_lens = seq_lens_cpu.cuda()
+        compressed_seq_lens = compressed_seq_lens_cpu.cuda()
+
         chunk_specs = split_indexer_prefill_chunks(
             compressed_seq_lens_cpu,
             query_lens_cpu,
@@ -57,10 +63,10 @@ class DeepGemmFlat:
             metadata = build_prefill_chunk_metadata(
                 req_slice.start,
                 req_slice.stop,
-                query_start_loc_cpu.cuda(),
+                query_start_loc,
                 query_start_loc_cpu,
-                seq_lens_cpu.cuda(),
-                compressed_seq_lens_cpu.cuda(),
+                seq_lens,
+                compressed_seq_lens,
                 compressed_seq_lens_cpu,
                 block_table,
                 compress_ratio,
@@ -97,7 +103,7 @@ class DeepGemmFlat:
         kv_cache: Tensor,
         weights: Tensor,
         topk_indices_buffer: Tensor,
-    ) -> None:
+    ) -> Tensor:
         use_fp4 = q_scale is not None
         _, topk = topk_indices_buffer.shape
 
@@ -146,35 +152,40 @@ class DeepGemmFlat:
                 logits.stride(1),
                 topk,
             )
+        return topk_indices_buffer
 
 
 class DeepGemmPaged:
     def __init__(
         self,
-        block_table: Tensor,
-        query_lens: list[int],
-        seq_lens: list[int],
-        compressed_seq_lens: list[int],
+        block_table_cpu: Tensor,
+        query_lens_cpu: Tensor,
+        seq_lens_cpu: Tensor,
+        compressed_seq_lens_cpu: Tensor,
+        query_start_loc_cpu: Tensor,
         compress_ratio: int,
         block_size: int,
+        use_fp4: bool,
     ) -> None:
-        query_to_req: list[int] = []
-        context_lens: list[int] = []
-        for req_idx, query_len in enumerate(query_lens):
-            context_len = seq_lens[req_idx] - query_len
-            for offset in range(query_len):
-                query_to_req.append(req_idx)
-                context_lens.append((context_len + offset + 1) // compress_ratio)
-        if not context_lens or max(compressed_seq_lens) == 0:
+        total_query_len = int(query_start_loc_cpu[-1].item())
+        if total_query_len == 0 or int(compressed_seq_lens_cpu.max().item()) == 0:
             raise RuntimeError("generated requests produced no prefill KV tokens")
 
-        device = block_table.device
-        self.indices = torch.tensor(query_to_req, dtype=torch.int32, device=device)
-        self.context_lens = torch.tensor(
-            context_lens, dtype=torch.int32, device=device
-        ).view(-1, 1)
-        self.block_table = block_table.index_select(0, self.indices.to(torch.long))
-        self.max_context_len = max(compressed_seq_lens)
+        req_ids = torch.arange(query_lens_cpu.numel(), device="cpu")
+        req_idx = torch.repeat_interleave(
+            req_ids, query_lens_cpu, output_size=total_query_len
+        )
+        token_idx = torch.arange(total_query_len, dtype=torch.int32, device="cpu")
+        query_offsets = token_idx - query_start_loc_cpu[req_idx]
+        context_lens = (
+            seq_lens_cpu[req_idx] - query_lens_cpu[req_idx] + query_offsets + 1
+        ) // compress_ratio
+
+        req_idx = req_idx.cuda()
+        self.indices = req_idx.to(torch.int32)
+        self.context_lens = context_lens.cuda().view(-1, 1)
+        self.block_table = block_table_cpu.cuda().index_select(0, req_idx)
+        self.max_context_len = int(compressed_seq_lens_cpu.max().item())
 
         num_sms = torch.cuda.get_device_properties(
             torch.cuda.current_device()
@@ -190,7 +201,7 @@ class DeepGemmPaged:
         kv_cache: Tensor,
         weights: Tensor,
         topk_indices_buffer: Tensor,
-    ) -> None:
+    ) -> Tensor:
         num_tokens = self.context_lens.shape[0]
         q_values = q_quant.view(num_tokens, 1, *q_quant.shape[1:])
         if q_scale is not None:
@@ -218,6 +229,7 @@ class DeepGemmPaged:
             logits.stride(1),
             topk_indices_buffer.shape[1],
         )
+        return topk_indices_buffer
 
 
 def parse_args():
@@ -242,7 +254,7 @@ def parse_args():
     return parser.parse_args()
 
 
-def main() -> None:
+def main() -> Tensor:
     args = parse_args()
     print(args)
 
@@ -338,29 +350,23 @@ def main() -> None:
             kv_cache[block_id, scale_off : scale_off + block_ks.numel()] = block_ks
 
     kv_cache = kv_cache.view(-1, block_size, cache_dim)
-    block_table = block_table_cpu.cuda()
     topk_indices_buffer = torch.empty((total_query_len, args.topk), dtype=torch.int32)
 
-    if args.impl == "deepgemm_flat":
-        impl = DeepGemmFlat(
-            block_table,
-            query_lens_cpu,
-            seq_lens_cpu,
-            compressed_seq_lens_cpu,
-            query_start_loc_cpu,
-            args.compress_ratio,
-            use_fp4,
-        )
-    else:
-        impl = DeepGemmPaged(
-            block_table,
-            query_lens,
-            seq_lens,
-            compressed_seq_lens,
-            args.compress_ratio,
-            block_size,
-        )
-    impl.run(q_quant, q_scale, kv_cache, weights, topk_indices_buffer)
+    impl_cls = {
+        "deepgemm_flat": DeepGemmFlat,
+        "deepgemm_paged": DeepGemmPaged,
+    }[args.impl]
+    impl = impl_cls(
+        block_table_cpu,
+        query_lens_cpu,
+        seq_lens_cpu,
+        compressed_seq_lens_cpu,
+        query_start_loc_cpu,
+        args.compress_ratio,
+        block_size,
+        use_fp4,
+    )
+    return impl.run(q_quant, q_scale, kv_cache, weights, topk_indices_buffer)
 
 
 if __name__ == "__main__":

--- a/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
+++ b/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
@@ -29,6 +29,7 @@ HEAD_DIM = 128
 MXFP4_BLOCK_SIZE = 32
 DEEPGEMM_WORKSPACE_SIZE = 4096
 DEEPGEMM_MAX_LOGITS_MB = 16
+DEEPGEMM_MAX_LOGITS_BYTES = DEEPGEMM_MAX_LOGITS_MB * 1024 * 1024
 NUM_SMS = torch.cuda.get_device_properties(
     torch.cuda.current_device()
 ).multi_processor_count
@@ -185,7 +186,7 @@ class DeepGemmFlatChunk:
             compressed_seq_lens_cpu,
             query_lens_cpu,
             DEEPGEMM_WORKSPACE_SIZE,
-            DEEPGEMM_MAX_LOGITS_MB * 1024 * 1024,
+            DEEPGEMM_MAX_LOGITS_BYTES,
         )
         self.chunks = []
         for req_slice, query_slice in chunk_specs:
@@ -391,11 +392,14 @@ class DeepGemmPagedChunk:
         ) // compress_ratio
 
         block_table = block_table_cpu.cuda()
+        # The paged path reads K directly from the KV cache, so it does not
+        # need the flat path's gathered-K workspace bound.
+        paged_chunk_workspace_size = int(compressed_seq_lens_cpu.sum().item())
         chunk_specs = split_indexer_prefill_chunks(
             compressed_seq_lens_cpu,
             query_lens_cpu,
-            DEEPGEMM_WORKSPACE_SIZE,
-            DEEPGEMM_MAX_LOGITS_MB * 1024 * 1024,
+            paged_chunk_workspace_size,
+            DEEPGEMM_MAX_LOGITS_BYTES,
         )
 
         self.chunks: list[DeepGemmPagedChunk.Metadata] = []
@@ -546,17 +550,6 @@ def export_sweep_graph(
     results_df: pd.DataFrame, output_path: str, log_axis: bool
 ) -> None:
     import matplotlib.pyplot as plt
-    from matplotlib.ticker import LogFormatterSciNotation, LogLocator
-
-    def label_log_y_subticks(ax) -> None:
-        ax.yaxis.set_minor_locator(LogLocator(base=10, subs=(5,)))
-        ax.yaxis.set_minor_formatter(
-            LogFormatterSciNotation(
-                base=10,
-                labelOnlyBase=False,
-                minor_thresholds=(float("inf"), float("inf")),
-            )
-        )
 
     fig, (latency_ax, memory_ax) = plt.subplots(2, 1, figsize=(9, 7), sharex=True)
 
@@ -577,8 +570,6 @@ def export_sweep_graph(
     latency_ax.tick_params(axis="x", labelbottom=True)
     if log_axis:
         latency_ax.set_xscale("log", base=10)
-        latency_ax.set_yscale("log")
-        label_log_y_subticks(latency_ax)
     latency_ax.grid(True, axis="y", alpha=0.25)
     latency_ax.legend()
 
@@ -587,8 +578,6 @@ def export_sweep_graph(
     memory_ax.set_ylabel("MiB")
     if log_axis:
         memory_ax.set_xscale("log", base=10)
-        memory_ax.set_yscale("log")
-        label_log_y_subticks(memory_ax)
     memory_ax.grid(True, axis="y", alpha=0.25)
     memory_ax.legend()
 

--- a/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
+++ b/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
@@ -4,7 +4,6 @@
 import argparse
 import gc
 import random
-from dataclasses import dataclass
 from functools import partial
 
 import pandas as pd
@@ -16,12 +15,13 @@ from vllm.model_executor.layers.sparse_attn_indexer import kv_cache_as_quant_vie
 from vllm.third_party.deep_gemm import (
     fp8_fp4_mqa_logits,
     fp8_fp4_paged_mqa_logits,
-    get_paged_mqa_logits_metadata,
 )
 from vllm.triton_utils import triton
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.mla.indexer import (
+    build_paged_prefill_metadata,
     build_prefill_chunk_metadata,
+    split_indexer_paged_prefill_chunks,
     split_indexer_prefill_chunks,
 )
 
@@ -288,16 +288,6 @@ class DeepGemmFlat:
 
 
 class DeepGemmPaged:
-    @dataclass
-    class Metadata:
-        token_start: int
-        token_end: int
-        indices: Tensor
-        context_lens: Tensor
-        block_table: Tensor
-        schedule_metadata: Tensor
-        max_context_len: int
-
     def __init__(
         self,
         block_table_cpu: Tensor,
@@ -316,25 +306,11 @@ class DeepGemmPaged:
             (total_query_len, topk), dtype=torch.int32, device="cuda"
         )
 
-        req_ids = torch.arange(query_lens_cpu.numel(), device="cpu")
-        all_req_idx = torch.repeat_interleave(
-            req_ids, query_lens_cpu, output_size=total_query_len
-        )
-        token_idx = torch.arange(total_query_len, dtype=torch.int32, device="cpu")
-        query_offsets = token_idx - query_start_loc_cpu[all_req_idx]
-        all_context_lens = (
-            seq_lens_cpu[all_req_idx] - query_lens_cpu[all_req_idx] + query_offsets + 1
-        ) // compress_ratio
-
         block_table = block_table_cpu.cuda()
         if do_chunk:
-            # The paged path reads K directly from the KV cache, so it does not
-            # need the flat path's gathered-K workspace bound.
-            paged_chunk_workspace_size = int(compressed_seq_lens_cpu.sum().item())
-            chunk_specs = split_indexer_prefill_chunks(
+            chunk_specs = split_indexer_paged_prefill_chunks(
                 compressed_seq_lens_cpu,
                 query_lens_cpu,
-                paged_chunk_workspace_size,
                 DEEPGEMM_MAX_LOGITS_BYTES,
             )
         else:
@@ -342,32 +318,22 @@ class DeepGemmPaged:
                 (slice(0, query_lens_cpu.numel()), slice(0, total_query_len))
             ]
 
-        self.chunks: list[DeepGemmPaged.Metadata] = []
+        self.chunks = []
         for req_slice, query_slice in chunk_specs:
-            if int(compressed_seq_lens_cpu[req_slice].sum().item()) == 0:
-                continue
-
-            token_start = int(query_start_loc_cpu[req_slice.start].item())
-            token_end = token_start + query_slice.stop
-            token_start += query_slice.start
-            token_slice = slice(token_start, token_end)
-
-            req_idx = all_req_idx[token_slice].cuda()
-            indices = req_idx.to(torch.int32)
-            context_lens = all_context_lens[token_slice].cuda().view(-1, 1)
-            schedule_metadata = get_paged_mqa_logits_metadata(
-                context_lens, block_size, NUM_SMS, indices=indices
+            metadata = build_paged_prefill_metadata(
+                req_slice.start,
+                req_slice.stop,
+                query_start_loc_cpu,
+                seq_lens_cpu,
+                compressed_seq_lens_cpu,
+                block_table,
+                compress_ratio,
+                block_size,
+                NUM_SMS,
+                query_slice=query_slice,
             )
-            chunk = DeepGemmPaged.Metadata(
-                token_start,
-                token_end,
-                indices,
-                context_lens,
-                block_table[req_idx],
-                schedule_metadata,
-                int(compressed_seq_lens_cpu[req_slice].max().item()),
-            )
-            self.chunks.append(chunk)
+            if metadata is not None:
+                self.chunks.append(metadata)
 
         self.num_chunks = len(self.chunks)
         if not self.chunks:

--- a/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
+++ b/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
@@ -1,0 +1,271 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import random
+
+import torch
+from torch import Tensor
+
+from vllm import _custom_ops as ops
+from vllm.utils.argparse_utils import FlexibleArgumentParser
+from vllm.utils.deep_gemm import fp8_fp4_mqa_logits
+from vllm.utils.math_utils import cdiv
+from vllm.v1.attention.backends.mla.indexer import (
+    build_prefill_chunk_metadata,
+    split_indexer_prefill_chunks,
+)
+
+NUM_HEADS = 64
+HEAD_DIM = 128
+MXFP4_BLOCK_SIZE = 32
+DEEPGEMM_WORKSPACE_SIZE = 4096
+DEEPGEMM_MAX_LOGITS_MB = 16
+
+
+def make_random_fp4(*prefix_shape: int) -> tuple[Tensor, Tensor]:
+    fp4_shape = (*prefix_shape, HEAD_DIM // 2)
+    scales_shape = (*prefix_shape, HEAD_DIM // MXFP4_BLOCK_SIZE)
+    fp4 = torch.randint(0, 256, fp4_shape, dtype=torch.uint8)
+    scales = torch.randint(124, 131, scales_shape, dtype=torch.uint8)
+    return fp4, scales
+
+
+def deepgemm_prepare(
+    block_table: Tensor,
+    query_lens_cpu: Tensor,
+    seq_lens_cpu: Tensor,
+    compressed_seq_lens_cpu: Tensor,
+    query_start_loc_cpu: Tensor,
+    compress_ratio: int,
+    use_fp4: bool,
+):
+    chunk_specs = split_indexer_prefill_chunks(
+        compressed_seq_lens_cpu,
+        query_lens_cpu,
+        DEEPGEMM_WORKSPACE_SIZE,
+        DEEPGEMM_MAX_LOGITS_MB * 1024 * 1024,
+    )
+    chunks = []
+    for req_slice, query_slice in chunk_specs:
+        metadata = build_prefill_chunk_metadata(
+            req_slice.start,
+            req_slice.stop,
+            query_start_loc_cpu.cuda(),
+            query_start_loc_cpu,
+            seq_lens_cpu.cuda(),
+            compressed_seq_lens_cpu.cuda(),
+            compressed_seq_lens_cpu,
+            block_table,
+            compress_ratio,
+            query_slice=query_slice,
+            skip_kv_gather=query_slice.start > 0,
+        )
+        if metadata is not None:
+            chunks.append(metadata)
+    if not chunks:
+        raise RuntimeError("generated requests produced no prefill chunks")
+
+    workspace_tokens = max(chunk.total_seq_lens for chunk in chunks)
+    if use_fp4:
+        k_quant_shape = (workspace_tokens, HEAD_DIM // 2)
+        k_scale_shape = (workspace_tokens, HEAD_DIM // MXFP4_BLOCK_SIZE)
+        k_quant_dtype = k_scale_dtype = torch.uint8
+    else:
+        k_quant_shape = (workspace_tokens, HEAD_DIM)
+        k_scale_shape = (workspace_tokens, 4)
+        k_quant_dtype = torch.float8_e4m3fn
+        k_scale_dtype = torch.uint8
+
+    device = block_table.device
+    k_quant_full = torch.empty(k_quant_shape, dtype=k_quant_dtype, device=device)
+    k_scale_full = torch.empty(k_scale_shape, dtype=k_scale_dtype, device=device)
+    return chunks, k_quant_full, k_scale_full
+
+
+def deepgemm_run(
+    q_quant: Tensor,
+    q_scale: Tensor | None,
+    kv_cache: Tensor,
+    weights: Tensor,
+    topk_indices_buffer: Tensor,
+    metadata,
+) -> None:
+    use_fp4 = q_scale is not None
+    chunks, k_quant_full, k_scale_full = metadata
+    _, topk = topk_indices_buffer.shape
+
+    for chunk in chunks:
+        k_quant = k_quant_full[: chunk.total_seq_lens]
+        k_scale = k_scale_full[: chunk.total_seq_lens]
+
+        # This mirrors SparseAttentionIndexer: query sub-chunks from the same
+        # request can reuse the previously gathered K workspace.
+        if not chunk.skip_kv_gather:
+            ops.cp_gather_indexer_k_quant_cache(
+                kv_cache,
+                k_quant,
+                k_scale,
+                chunk.block_table,
+                chunk.cu_seq_lens,
+            )
+
+        token_slice = slice(chunk.token_start, chunk.token_end)
+        q_slice = q_quant[token_slice]
+
+        if use_fp4:
+            q_slice = q_slice.view(torch.int8)
+            q_scale_slice = q_scale[token_slice]
+            k_quant = k_quant.view(torch.int8)
+            k_scale = k_scale.view(torch.int32).squeeze(-1)
+        else:
+            q_scale_slice = None
+            k_scale = k_scale.view(torch.float32).squeeze(-1)
+
+        logits = fp8_fp4_mqa_logits(
+            (q_slice, q_scale_slice),
+            (k_quant, k_scale),
+            weights[token_slice],
+            chunk.cu_seqlen_ks,
+            chunk.cu_seqlen_ke,
+            clean_logits=False,
+        )
+        topk_indices = topk_indices_buffer[token_slice]
+        torch.ops._C.top_k_per_row_prefill(
+            logits,
+            chunk.cu_seqlen_ks,
+            chunk.cu_seqlen_ke,
+            topk_indices,
+            logits.shape[0],
+            logits.stride(0),
+            logits.stride(1),
+            topk,
+        )
+
+
+def parse_args():
+    parser = FlexibleArgumentParser(
+        description="Run the DeepGEMM prefill sparse-indexer path."
+    )
+    parser.add_argument("--dtype", choices=["fp4", "fp8"], required=True)
+    parser.add_argument("--num-requests", type=int, default=8)
+    parser.add_argument("--min-query-len", type=int, default=16)
+    parser.add_argument("--max-query-len", type=int, default=128)
+    parser.add_argument("--min-context-len", type=int, default=0)
+    parser.add_argument("--max-context-len", type=int, default=1024)
+    parser.add_argument("--block-size", type=int, default=256)
+    parser.add_argument("--compress-ratio", type=int, default=4)
+    parser.add_argument("--topk", type=int, default=2048)
+    parser.add_argument("--seed", type=int, default=42)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    print(args)
+
+    torch.set_default_device("cuda")
+    torch.manual_seed(args.seed)
+    random.seed(args.seed)
+
+    # Prepare request lengths.
+    use_fp4 = args.dtype == "fp4"
+    query_lens: list[int] = []
+    seq_lens: list[int] = []
+    compressed_seq_lens: list[int] = []
+    query_start_locs = [0]
+
+    for _ in range(args.num_requests):
+        query_len = random.randint(args.min_query_len, args.max_query_len)
+        context_len = random.randint(args.min_context_len, args.max_context_len)
+        seq_len = query_len + context_len
+
+        query_lens.append(query_len)
+        seq_lens.append(seq_len)
+        # Production uses floor division: the compressed cache only has entries
+        # for positions where (pos + 1) % compress_ratio == 0.
+        compressed_seq_lens.append(seq_len // args.compress_ratio)
+        query_start_locs.append(query_start_locs[-1] + query_len)
+
+    total_query_len = query_start_locs[-1]
+    cpu_i32 = dict(dtype=torch.int32, device="cpu")
+    query_lens_cpu = torch.tensor(query_lens, **cpu_i32)
+    seq_lens_cpu = torch.tensor(seq_lens, **cpu_i32)
+    compressed_seq_lens_cpu = torch.tensor(compressed_seq_lens, **cpu_i32)
+    query_start_loc_cpu = torch.tensor(query_start_locs, **cpu_i32)
+
+    # Prepare Q and per-token weights.
+    weights = torch.randn(total_query_len, NUM_HEADS)
+    if use_fp4:
+        q_quant, q_scale = make_random_fp4(total_query_len, NUM_HEADS)
+        q_scale = q_scale.view(torch.int32).squeeze(-1)
+    else:
+        q_bf16 = torch.randn(
+            total_query_len * NUM_HEADS, HEAD_DIM, dtype=torch.bfloat16
+        )
+        q_quant, q_fp8_scale = ops.scaled_fp8_quant(
+            q_bf16, use_per_token_if_dynamic=True
+        )
+        weights *= q_fp8_scale.view(total_query_len, NUM_HEADS)
+        q_quant = q_quant.view(total_query_len, NUM_HEADS, HEAD_DIM)
+        q_scale = None
+
+    # Prepare paged KV cache.
+    block_size = args.block_size
+    block_counts = [cdiv(seq_len, block_size) for seq_len in compressed_seq_lens]
+    max_blocks = max(1, max(block_counts))
+    valid_blocks = sum(block_counts)
+    poison_block = valid_blocks
+    kq_dim = HEAD_DIM // 2 if use_fp4 else HEAD_DIM
+    ks_dim = 4
+    cache_dim = kq_dim + ks_dim
+
+    # FP8: 0xff is an FP8 NaN payload, and 0xffffffff is a float32 NaN
+    # scale. FP4 has no true NaN representation, but 0xff is still a useful
+    # poison value for spotting unintended reads.
+    kv_cache = torch.full(
+        (valid_blocks + 1, block_size * cache_dim), 0xFF, dtype=torch.uint8
+    )
+    block_table_cpu = torch.full(
+        (len(block_counts), max_blocks), poison_block, **cpu_i32
+    )
+    physical_blocks = iter(torch.randperm(valid_blocks, device="cpu").tolist())
+
+    for req_idx, seq_len in enumerate(compressed_seq_lens):
+        if use_fp4:
+            kq, ks = make_random_fp4(seq_len)
+        else:
+            k_bf16 = torch.randn(seq_len, HEAD_DIM, dtype=torch.bfloat16)
+            kq, ks = ops.scaled_fp8_quant(k_bf16, use_per_token_if_dynamic=True)
+            ks = ks.view(torch.uint8).reshape(seq_len, 4)
+
+        for logical_block in range(block_counts[req_idx]):
+            block_id = next(physical_blocks)
+            block_table_cpu[req_idx, logical_block] = block_id
+
+            start = logical_block * block_size
+            end = min(start + block_size, seq_len)
+            block_kq = kq[start:end].view(torch.uint8).view(-1)
+            block_ks = ks[start:end].view(-1)
+
+            scale_off = block_size * kq_dim
+            kv_cache[block_id, : block_kq.numel()] = block_kq
+            kv_cache[block_id, scale_off : scale_off + block_ks.numel()] = block_ks
+
+    kv_cache = kv_cache.view(-1, block_size, cache_dim)
+    block_table = block_table_cpu.cuda()
+    topk_indices_buffer = torch.empty((total_query_len, args.topk), dtype=torch.int32)
+
+    metadata = deepgemm_prepare(
+        block_table,
+        query_lens_cpu,
+        seq_lens_cpu,
+        compressed_seq_lens_cpu,
+        query_start_loc_cpu,
+        args.compress_ratio,
+        use_fp4,
+    )
+    deepgemm_run(q_quant, q_scale, kv_cache, weights, topk_indices_buffer, metadata)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
+++ b/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
@@ -17,12 +17,12 @@ from vllm.third_party.deep_gemm import (
     fp8_fp4_paged_mqa_logits,
 )
 from vllm.triton_utils import triton
+from vllm.utils.deep_gemm import get_paged_mqa_logits_metadata
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.mla.indexer import (
+    DeepseekV32IndexerPagedPrefillMetadata,
     build_full_paged_prefill_metadata,
-    build_paged_prefill_metadata,
     build_prefill_chunk_metadata,
-    split_indexer_paged_prefill_chunks,
     split_indexer_prefill_chunks,
 )
 
@@ -65,6 +65,118 @@ def dequant(values: Tensor, scales: Tensor | None, use_fp4: bool) -> Tensor:
     scale = scales.view(torch.float8_e8m0fnu).float()
     dq = LUT[nibbles].unflatten(-1, (-1, MXFP4_BLOCK_SIZE)) * scale[..., None]
     return dq.flatten(-2)
+
+
+def split_indexer_paged_prefill_chunks(
+    compressed_seq_lens_cpu: Tensor,
+    query_lens_cpu: Tensor,
+    max_logits_bytes: int,
+    request_offset: int = 0,
+) -> list[tuple[slice, slice]]:
+    chunks: list[tuple[slice, slice]] = []
+    n = len(query_lens_cpu)
+    max_logits_elems = max_logits_bytes // 4
+    end = 0
+
+    while end < n:
+        start, chunk_m, chunk_max_context_len = end, 0, 0
+
+        while end < n:
+            q = query_lens_cpu[end].item()
+            max_context_len = compressed_seq_lens_cpu[end].item()
+            new_m = chunk_m + q
+            new_max_context_len = max(chunk_max_context_len, max_context_len)
+            if new_m <= 2048 and new_m * new_max_context_len <= max_logits_elems:
+                chunk_m = new_m
+                chunk_max_context_len = new_max_context_len
+                end += 1
+            else:
+                break
+
+        if end == start:
+            chunk_m = query_lens_cpu[end].item()
+            chunk_max_context_len = compressed_seq_lens_cpu[end].item()
+            end += 1
+
+        req_slice = slice(start + request_offset, end + request_offset)
+        max_q_by_logits = (
+            max(1, max_logits_elems // chunk_max_context_len)
+            if chunk_max_context_len > 0
+            else chunk_m
+        )
+        max_q = max(1, min(2048, max_q_by_logits))
+        for q_off in range(0, chunk_m, max_q):
+            sub_m = min(max_q, chunk_m - q_off)
+            chunks.append((req_slice, slice(q_off, q_off + sub_m)))
+
+    return chunks
+
+
+def build_paged_prefill_metadata(
+    start_idx: int,
+    end_idx: int,
+    query_start_loc: Tensor,
+    query_start_loc_cpu: Tensor,
+    seq_lens: Tensor,
+    compressed_seq_lens_cpu: Tensor,
+    block_table: Tensor,
+    compress_ratio: int,
+    block_size: int,
+    num_sms: int,
+    query_slice: slice | None = None,
+) -> DeepseekV32IndexerPagedPrefillMetadata | None:
+    total_query_len = (
+        query_start_loc_cpu[end_idx].item() - query_start_loc_cpu[start_idx].item()
+    )
+    if query_slice is not None:
+        qs_start = query_slice.start
+        qs_stop = query_slice.stop
+    else:
+        qs_start = 0
+        qs_stop = total_query_len
+    assert qs_start is not None
+    assert qs_stop is not None
+    output_query_len = qs_stop - qs_start
+    if output_query_len <= 0:
+        return None
+
+    device = seq_lens.device
+    req_ids = torch.arange(start_idx, end_idx, dtype=torch.long, device=device)
+    query_lens = query_start_loc[start_idx : end_idx + 1].diff()
+    req_idx = torch.repeat_interleave(req_ids, query_lens, output_size=total_query_len)[
+        qs_start:qs_stop
+    ]
+    max_context_len = int(compressed_seq_lens_cpu[start_idx:end_idx].max().item())
+    if max_context_len == 0:
+        return None
+
+    token_idx = torch.arange(qs_start, qs_stop, dtype=torch.long, device=device)
+    query_offsets = token_idx - (query_start_loc[req_idx] - query_start_loc[start_idx])
+    req_query_lens = query_start_loc[req_idx + 1] - query_start_loc[req_idx]
+    context_lens = (
+        seq_lens[req_idx] - req_query_lens + query_offsets + 1
+    ) // compress_ratio
+
+    indices = req_idx.to(torch.int32)
+    context_lens = context_lens.to(torch.int32).view(-1, 1)
+    schedule_metadata = get_paged_mqa_logits_metadata(
+        context_lens,
+        block_size,
+        num_sms,
+        indices=indices,
+    )
+    token_start = int(query_start_loc_cpu[start_idx].item()) + qs_start
+    token_end = token_start + output_query_len
+
+    return DeepseekV32IndexerPagedPrefillMetadata(
+        token_start=token_start,
+        token_end=token_end,
+        context_lens=context_lens,
+        indices=indices,
+        block_table=block_table[req_idx],
+        schedule_metadata=schedule_metadata,
+        max_context_len=max_context_len,
+    )
 
 
 class Reference:

--- a/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
+++ b/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
@@ -31,9 +31,7 @@ MXFP4_BLOCK_SIZE = 32
 DEEPGEMM_WORKSPACE_SIZE = 4096
 DEEPGEMM_MAX_LOGITS_MB = 16
 DEEPGEMM_MAX_LOGITS_BYTES = DEEPGEMM_MAX_LOGITS_MB * 1024 * 1024
-NUM_SMS = torch.cuda.get_device_properties(
-    torch.cuda.current_device()
-).multi_processor_count
+NUM_SMS = torch.cuda.get_device_properties().multi_processor_count
 
 
 def make_random_fp4(*prefix_shape: int) -> tuple[Tensor, Tensor]:
@@ -636,9 +634,9 @@ def run_benchmark_batch(
         impl = None
         topk_indices = None
         gc.collect()
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
-        torch.cuda.reset_peak_memory_stats()
+        torch.accelerator.empty_cache()
+        torch.accelerator.synchronize()
+        torch.accelerator.reset_peak_memory_stats()
 
         impl = impl_cls(
             block_table_cpu,
@@ -652,8 +650,8 @@ def run_benchmark_batch(
             args.topk,
         )
         topk_indices = impl.run(q_quant, q_scale, kv_cache, weights)
-        torch.cuda.synchronize()
-        peak_memory_mib = torch.cuda.max_memory_allocated() / 1024 / 1024
+        torch.accelerator.synchronize()
+        peak_memory_mib = torch.accelerator.max_memory_allocated() / 1024 / 1024
         wrong_entries, compared_entries = check_topk_result(
             topk_indices,
             expected_topk,

--- a/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
+++ b/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
@@ -19,6 +19,7 @@ from vllm.third_party.deep_gemm import (
 from vllm.triton_utils import triton
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.mla.indexer import (
+    build_full_paged_prefill_metadata,
     build_paged_prefill_metadata,
     build_prefill_chunk_metadata,
     split_indexer_paged_prefill_chunks,
@@ -315,16 +316,27 @@ class DeepGemmPaged:
                 query_lens_cpu,
                 DEEPGEMM_MAX_LOGITS_BYTES,
             )
+            self.chunks = []
+            for req_slice, query_slice in chunk_specs:
+                metadata = build_paged_prefill_metadata(
+                    req_slice.start,
+                    req_slice.stop,
+                    query_start_loc,
+                    query_start_loc_cpu,
+                    seq_lens,
+                    compressed_seq_lens_cpu,
+                    block_table,
+                    compress_ratio,
+                    block_size,
+                    NUM_SMS,
+                    query_slice=query_slice,
+                )
+                if metadata is not None:
+                    self.chunks.append(metadata)
         else:
-            chunk_specs = [
-                (slice(0, query_lens_cpu.numel()), slice(0, total_query_len))
-            ]
-
-        self.chunks = []
-        for req_slice, query_slice in chunk_specs:
-            metadata = build_paged_prefill_metadata(
-                req_slice.start,
-                req_slice.stop,
+            metadata = build_full_paged_prefill_metadata(
+                0,
+                query_lens_cpu.numel(),
                 query_start_loc,
                 query_start_loc_cpu,
                 seq_lens,
@@ -333,10 +345,8 @@ class DeepGemmPaged:
                 compress_ratio,
                 block_size,
                 NUM_SMS,
-                query_slice=query_slice,
             )
-            if metadata is not None:
-                self.chunks.append(metadata)
+            self.chunks = [] if metadata is None else [metadata]
 
         self.num_chunks = len(self.chunks)
         if not self.chunks:

--- a/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
+++ b/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import argparse
 import random
 
 import torch
@@ -9,11 +10,10 @@ from torch import Tensor
 from vllm import _custom_ops as ops
 from vllm.model_executor.layers.sparse_attn_indexer import kv_cache_as_quant_view
 from vllm.third_party.deep_gemm import (
+    fp8_fp4_mqa_logits,
     fp8_fp4_paged_mqa_logits,
     get_paged_mqa_logits_metadata,
 )
-from vllm.utils.argparse_utils import FlexibleArgumentParser
-from vllm.utils.deep_gemm import fp8_fp4_mqa_logits
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.mla.indexer import (
     build_prefill_chunk_metadata,
@@ -35,6 +35,123 @@ def make_random_fp4(*prefix_shape: int) -> tuple[Tensor, Tensor]:
     return fp4, scales
 
 
+def dequant(values: Tensor, scales: Tensor | None, use_fp4: bool) -> Tensor:
+    # FP8: values are e4m3, and K has one float32 scale per token.
+    if not use_fp4:
+        values = values.view(torch.float8_e4m3fn).float()
+        if scales is not None:
+            values *= scales.view(torch.float32)
+        return values
+
+    # FP4: each byte stores two e2m1 values, scaled per 32-value group.
+    assert scales is not None
+    values = values.to(torch.int64)
+    nibbles = torch.stack((values & 0xF, (values >> 4) & 0xF), dim=-1).flatten(-2)
+    # fmt: off
+    FP4_VALUES = [
+        0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0,
+        -0.0, -0.5, -1.0, -1.5, -2.0, -3.0, -4.0, -6.0,
+    ]
+    # fmt: on
+    LUT = torch.tensor(FP4_VALUES, device=values.device)
+    scale = scales.view(torch.float8_e8m0fnu).float()
+    dq = LUT[nibbles].unflatten(-1, (-1, MXFP4_BLOCK_SIZE)) * scale[..., None]
+    return dq.flatten(-2)
+
+
+class Reference:
+    def __init__(
+        self,
+        block_table_cpu: Tensor,
+        query_lens_cpu: Tensor,
+        seq_lens_cpu: Tensor,
+        compressed_seq_lens_cpu: Tensor,
+        query_start_loc_cpu: Tensor,
+        compress_ratio: int,
+        block_size: int,
+        use_fp4: bool,
+        topk: int,
+    ) -> None:
+        self.block_size = block_size
+        self.block_table = block_table_cpu.tolist()
+        self.query_lens = query_lens_cpu.tolist()
+        self.seq_lens = seq_lens_cpu.tolist()
+        self.compressed_seq_lens = compressed_seq_lens_cpu.tolist()
+        self.query_start_locs = query_start_loc_cpu.tolist()
+        self.compress_ratio = compress_ratio
+        self.use_fp4 = use_fp4
+        self.topk = topk
+
+    def run(
+        self, q_quant: Tensor, q_scale: Tensor | None, kv_cache: Tensor, weights: Tensor
+    ) -> Tensor:
+        total_query_len = self.query_start_locs[-1]
+        topk_indices_buffer = torch.empty(
+            (total_query_len, self.topk), dtype=torch.int32, device="cuda"
+        )
+        kq_dim = HEAD_DIM // 2 if self.use_fp4 else HEAD_DIM
+
+        # Walk requests exactly as the logical prefill batch is defined.
+        for req_idx, query_len in enumerate(self.query_lens):
+            query_start = self.query_start_locs[req_idx]
+            context_len = self.seq_lens[req_idx] - query_len
+            compressed_seq_len = self.compressed_seq_lens[req_idx]
+            token_slice = slice(query_start, query_start + query_len)
+
+            if compressed_seq_len == 0:
+                continue
+
+            k_values = torch.empty(
+                compressed_seq_len, kq_dim, dtype=torch.uint8, device="cuda"
+            )
+            k_scales = torch.empty(
+                compressed_seq_len,
+                MXFP4_BLOCK_SIZE // 8,
+                dtype=torch.uint8,
+                device="cuda",
+            )
+
+            # Gather this request's compressed K from paged cache blocks.
+            for block_idx in range(cdiv(compressed_seq_len, self.block_size)):
+                block_id = self.block_table[req_idx][block_idx]
+                token_start = block_idx * self.block_size
+                token_end = min(token_start + self.block_size, compressed_seq_len)
+                block_tokens = token_end - token_start
+
+                cache_page = kv_cache[block_id].view(-1)
+                value_count = block_tokens * kq_dim
+                scale_offset = self.block_size * kq_dim
+                scale_count = block_tokens * (MXFP4_BLOCK_SIZE // 8)
+                k_values[token_start:token_end] = cache_page[:value_count].view(
+                    block_tokens, kq_dim
+                )
+                k_scales[token_start:token_end] = cache_page[
+                    scale_offset : scale_offset + scale_count
+                ].view(block_tokens, MXFP4_BLOCK_SIZE // 8)
+
+            # Dequantize K and Q into plain float tensors.
+            k = dequant(k_values, k_scales, self.use_fp4)
+
+            if self.use_fp4:
+                q_scales = q_scale[token_slice].view(torch.uint8)
+                q_scales = q_scales.reshape(query_len, NUM_HEADS, -1)
+            else:
+                q_scales = None
+            q = dequant(q_quant[token_slice], q_scales, self.use_fp4)
+
+            # Reference logits and top-k for each causal row.
+            scores = torch.einsum("mhd,nd->hmn", q, k)
+            logits = (scores.relu() * weights[token_slice].T.unsqueeze(-1)).sum(dim=0)
+            for offset in range(query_len):
+                row_len = (context_len + offset + 1) // self.compress_ratio
+                k_top = min(self.topk, row_len)
+                if k_top > 0:
+                    topk_indices_buffer[query_start + offset, :k_top] = (
+                        logits[offset, :row_len].topk(k_top).indices.to(torch.int32)
+                    )
+        return topk_indices_buffer
+
+
 class DeepGemmFlat:
     def __init__(
         self,
@@ -46,11 +163,16 @@ class DeepGemmFlat:
         compress_ratio: int,
         block_size: int,
         use_fp4: bool,
+        topk: int,
     ) -> None:
+        total_query_len = int(query_start_loc_cpu[-1].item())
         block_table = block_table_cpu.cuda()
         query_start_loc = query_start_loc_cpu.cuda()
         seq_lens = seq_lens_cpu.cuda()
         compressed_seq_lens = compressed_seq_lens_cpu.cuda()
+        self.topk_indices_buffer = torch.empty(
+            (total_query_len, topk), dtype=torch.int32, device="cuda"
+        )
 
         chunk_specs = split_indexer_prefill_chunks(
             compressed_seq_lens_cpu,
@@ -97,15 +219,10 @@ class DeepGemmFlat:
         )
 
     def run(
-        self,
-        q_quant: Tensor,
-        q_scale: Tensor | None,
-        kv_cache: Tensor,
-        weights: Tensor,
-        topk_indices_buffer: Tensor,
+        self, q_quant: Tensor, q_scale: Tensor | None, kv_cache: Tensor, weights: Tensor
     ) -> Tensor:
         use_fp4 = q_scale is not None
-        _, topk = topk_indices_buffer.shape
+        _, topk = self.topk_indices_buffer.shape
 
         for chunk in self.chunks:
             k_quant = self.k_quant_full[: chunk.total_seq_lens]
@@ -146,13 +263,13 @@ class DeepGemmFlat:
                 logits,
                 chunk.cu_seqlen_ks,
                 chunk.cu_seqlen_ke,
-                topk_indices_buffer[token_slice],
+                self.topk_indices_buffer[token_slice],
                 logits.shape[0],
                 logits.stride(0),
                 logits.stride(1),
                 topk,
             )
-        return topk_indices_buffer
+        return self.topk_indices_buffer
 
 
 class DeepGemmPaged:
@@ -166,10 +283,14 @@ class DeepGemmPaged:
         compress_ratio: int,
         block_size: int,
         use_fp4: bool,
+        topk: int,
     ) -> None:
         total_query_len = int(query_start_loc_cpu[-1].item())
         if total_query_len == 0 or int(compressed_seq_lens_cpu.max().item()) == 0:
             raise RuntimeError("generated requests produced no prefill KV tokens")
+        self.topk_indices_buffer = torch.empty(
+            (total_query_len, topk), dtype=torch.int32, device="cuda"
+        )
 
         req_ids = torch.arange(query_lens_cpu.numel(), device="cpu")
         req_idx = torch.repeat_interleave(
@@ -195,12 +316,7 @@ class DeepGemmPaged:
         )
 
     def run(
-        self,
-        q_quant: Tensor,
-        q_scale: Tensor | None,
-        kv_cache: Tensor,
-        weights: Tensor,
-        topk_indices_buffer: Tensor,
+        self, q_quant: Tensor, q_scale: Tensor | None, kv_cache: Tensor, weights: Tensor
     ) -> Tensor:
         num_tokens = self.context_lens.shape[0]
         q_values = q_quant.view(num_tokens, 1, *q_quant.shape[1:])
@@ -223,17 +339,17 @@ class DeepGemmPaged:
             logits,
             1,
             self.context_lens,
-            topk_indices_buffer,
+            self.topk_indices_buffer,
             logits.shape[0],
             logits.stride(0),
             logits.stride(1),
-            topk_indices_buffer.shape[1],
+            self.topk_indices_buffer.shape[1],
         )
-        return topk_indices_buffer
+        return self.topk_indices_buffer
 
 
 def parse_args():
-    parser = FlexibleArgumentParser(
+    parser = argparse.ArgumentParser(
         description="Run the DeepGEMM prefill sparse-indexer path."
     )
     parser.add_argument(
@@ -254,6 +370,34 @@ def parse_args():
     return parser.parse_args()
 
 
+def check_topk(
+    actual: Tensor,
+    expected: Tensor,
+    query_lens: list[int],
+    seq_lens: list[int],
+    compress_ratio: int,
+    topk: int,
+) -> None:
+    actual_cpu = actual.cpu()
+    expected_cpu = expected.cpu()
+    row_idx = 0
+    for query_len, seq_len in zip(query_lens, seq_lens):
+        context_len = seq_len - query_len
+        for offset in range(query_len):
+            row_len = (context_len + offset + 1) // compress_ratio
+            k = min(topk, row_len)
+            if k > 0:
+                actual_row = actual_cpu[row_idx, :k].sort().values
+                expected_row = expected_cpu[row_idx, :k].sort().values
+                if not torch.equal(actual_row, expected_row):
+                    raise AssertionError(
+                        f"top-k mismatch at row {row_idx}: "
+                        f"actual={actual_cpu[row_idx, :k].tolist()}, "
+                        f"expected={expected_cpu[row_idx, :k].tolist()}"
+                    )
+            row_idx += 1
+
+
 def main() -> Tensor:
     args = parse_args()
     print(args)
@@ -264,8 +408,6 @@ def main() -> Tensor:
 
     # Prepare request lengths.
     use_fp4 = args.dtype == "fp4"
-    if args.impl == "deepgemm_paged" and args.block_size not in (32, 64):
-        raise ValueError("deepgemm_paged requires --block-size 32 or 64")
 
     query_lens: list[int] = []
     seq_lens: list[int] = []
@@ -350,8 +492,6 @@ def main() -> Tensor:
             kv_cache[block_id, scale_off : scale_off + block_ks.numel()] = block_ks
 
     kv_cache = kv_cache.view(-1, block_size, cache_dim)
-    topk_indices_buffer = torch.empty((total_query_len, args.topk), dtype=torch.int32)
-
     impl_cls = {
         "deepgemm_flat": DeepGemmFlat,
         "deepgemm_paged": DeepGemmPaged,
@@ -365,8 +505,33 @@ def main() -> Tensor:
         args.compress_ratio,
         block_size,
         use_fp4,
+        args.topk,
     )
-    return impl.run(q_quant, q_scale, kv_cache, weights, topk_indices_buffer)
+    topk_indices = impl.run(q_quant, q_scale, kv_cache, weights)
+
+    reference = Reference(
+        block_table_cpu,
+        query_lens_cpu,
+        seq_lens_cpu,
+        compressed_seq_lens_cpu,
+        query_start_loc_cpu,
+        args.compress_ratio,
+        block_size,
+        use_fp4,
+        args.topk,
+    )
+    expected_topk = reference.run(q_quant, q_scale, kv_cache, weights)
+    check_topk(
+        topk_indices,
+        expected_topk,
+        query_lens,
+        seq_lens,
+        args.compress_ratio,
+        args.topk,
+    )
+    print("correctness check passed")
+
+    return topk_indices
 
 
 if __name__ == "__main__":

--- a/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
+++ b/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
@@ -4,6 +4,7 @@
 import argparse
 import gc
 import random
+from dataclasses import dataclass
 
 import pandas as pd
 import torch
@@ -28,6 +29,9 @@ HEAD_DIM = 128
 MXFP4_BLOCK_SIZE = 32
 DEEPGEMM_WORKSPACE_SIZE = 4096
 DEEPGEMM_MAX_LOGITS_MB = 16
+NUM_SMS = torch.cuda.get_device_properties(
+    torch.cuda.current_device()
+).multi_processor_count
 
 
 def make_random_fp4(*prefix_shape: int) -> tuple[Tensor, Tensor]:
@@ -155,7 +159,7 @@ class Reference:
         return topk_indices_buffer
 
 
-class DeepGemmFlat:
+class DeepGemmFlatChunk:
     def __init__(
         self,
         block_table_cpu: Tensor,
@@ -308,14 +312,11 @@ class DeepGemmPaged:
         req_idx = req_idx.cuda()
         self.indices = req_idx.to(torch.int32)
         self.context_lens = context_lens.cuda().view(-1, 1)
-        self.block_table = block_table_cpu.cuda().index_select(0, req_idx)
+        self.block_table = block_table_cpu.cuda()[req_idx]
         self.max_context_len = int(compressed_seq_lens_cpu.max().item())
 
-        num_sms = torch.cuda.get_device_properties(
-            torch.cuda.current_device()
-        ).multi_processor_count
         self.schedule_metadata = get_paged_mqa_logits_metadata(
-            self.context_lens, block_size, num_sms, indices=self.indices
+            self.context_lens, block_size, NUM_SMS, indices=self.indices
         )
 
     def run(
@@ -351,9 +352,129 @@ class DeepGemmPaged:
         return self.topk_indices_buffer
 
 
+class DeepGemmPagedChunk:
+    @dataclass
+    class Metadata:
+        token_start: int
+        token_end: int
+        indices: Tensor
+        context_lens: Tensor
+        block_table: Tensor
+        schedule_metadata: Tensor
+        max_context_len: int
+
+    def __init__(
+        self,
+        block_table_cpu: Tensor,
+        query_lens_cpu: Tensor,
+        seq_lens_cpu: Tensor,
+        compressed_seq_lens_cpu: Tensor,
+        query_start_loc_cpu: Tensor,
+        compress_ratio: int,
+        block_size: int,
+        use_fp4: bool,
+        topk: int,
+    ) -> None:
+        total_query_len = int(query_start_loc_cpu[-1].item())
+        self.topk_indices_buffer = torch.empty(
+            (total_query_len, topk), dtype=torch.int32, device="cuda"
+        )
+
+        req_ids = torch.arange(query_lens_cpu.numel(), device="cpu")
+        all_req_idx = torch.repeat_interleave(
+            req_ids, query_lens_cpu, output_size=total_query_len
+        )
+        token_idx = torch.arange(total_query_len, dtype=torch.int32, device="cpu")
+        query_offsets = token_idx - query_start_loc_cpu[all_req_idx]
+        all_context_lens = (
+            seq_lens_cpu[all_req_idx] - query_lens_cpu[all_req_idx] + query_offsets + 1
+        ) // compress_ratio
+
+        block_table = block_table_cpu.cuda()
+        chunk_specs = split_indexer_prefill_chunks(
+            compressed_seq_lens_cpu,
+            query_lens_cpu,
+            DEEPGEMM_WORKSPACE_SIZE,
+            DEEPGEMM_MAX_LOGITS_MB * 1024 * 1024,
+        )
+
+        self.chunks: list[DeepGemmPagedChunk.Metadata] = []
+        for req_slice, query_slice in chunk_specs:
+            if int(compressed_seq_lens_cpu[req_slice].sum().item()) == 0:
+                continue
+
+            token_start = int(query_start_loc_cpu[req_slice.start].item())
+            token_end = token_start + query_slice.stop
+            token_start += query_slice.start
+            token_slice = slice(token_start, token_end)
+
+            req_idx = all_req_idx[token_slice].cuda()
+            indices = req_idx.to(torch.int32)
+            context_lens = all_context_lens[token_slice].cuda().view(-1, 1)
+            schedule_metadata = get_paged_mqa_logits_metadata(
+                context_lens, block_size, NUM_SMS, indices=indices
+            )
+            chunk = DeepGemmPagedChunk.Metadata(
+                token_start,
+                token_end,
+                indices,
+                context_lens,
+                block_table[req_idx],
+                schedule_metadata,
+                int(compressed_seq_lens_cpu[req_slice].max().item()),
+            )
+            self.chunks.append(chunk)
+
+        if not self.chunks:
+            raise RuntimeError("generated requests produced no prefill chunks")
+
+    def run(
+        self, q_quant: Tensor, q_scale: Tensor | None, kv_cache: Tensor, weights: Tensor
+    ) -> Tensor:
+        use_fp4 = q_scale is not None
+        kv_cache = kv_cache_as_quant_view(kv_cache, HEAD_DIM, use_fp4)
+
+        for chunk in self.chunks:
+            token_slice = slice(chunk.token_start, chunk.token_end)
+            num_tokens = chunk.context_lens.shape[0]
+
+            q_values = q_quant[token_slice].view(num_tokens, 1, *q_quant.shape[1:])
+            if q_scale is not None:
+                q_values = q_values.view(torch.int8)
+                q_scale_slice = q_scale[token_slice].view(
+                    num_tokens, 1, *q_scale.shape[1:]
+                )
+            else:
+                q_scale_slice = None
+
+            logits = fp8_fp4_paged_mqa_logits(
+                (q_values, q_scale_slice),
+                kv_cache,
+                weights[token_slice],
+                chunk.context_lens,
+                chunk.block_table,
+                chunk.schedule_metadata,
+                chunk.max_context_len,
+                False,
+                indices=chunk.indices,
+            )
+            torch.ops._C.top_k_per_row_decode(
+                logits,
+                1,
+                chunk.context_lens,
+                self.topk_indices_buffer[token_slice],
+                logits.shape[0],
+                logits.stride(0),
+                logits.stride(1),
+                self.topk_indices_buffer.shape[1],
+            )
+        return self.topk_indices_buffer
+
+
 IMPLEMENTATIONS = (
-    ("deepgemm_flat", DeepGemmFlat),
+    ("deepgemm_flat_chunk", DeepGemmFlatChunk),
     ("deepgemm_paged", DeepGemmPaged),
+    ("deepgemm_paged_chunk", DeepGemmPagedChunk),
 )
 
 

--- a/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
+++ b/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
@@ -5,6 +5,7 @@ import argparse
 import gc
 import random
 
+import pandas as pd
 import torch
 from torch import Tensor
 
@@ -15,6 +16,7 @@ from vllm.third_party.deep_gemm import (
     fp8_fp4_paged_mqa_logits,
     get_paged_mqa_logits_metadata,
 )
+from vllm.triton_utils import triton
 from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backends.mla.indexer import (
     build_prefill_chunk_metadata,
@@ -372,21 +374,17 @@ def parse_args():
     return parser.parse_args()
 
 
-def print_topk_result(
-    impl_name: str,
+def check_topk_result(
     actual: Tensor,
     expected: Tensor,
     query_lens: list[int],
     seq_lens: list[int],
     compress_ratio: int,
     topk: int,
-    peak_memory_mib: float,
-) -> None:
+) -> tuple[int, int]:
     actual_cpu = actual.cpu()
     expected_cpu = expected.cpu()
     row_idx = 0
-    compared_rows = 0
-    wrong_rows = 0
     compared_entries = 0
     wrong_entries = 0
 
@@ -401,20 +399,11 @@ def print_topk_result(
                 row_mismatches = int(
                     (~torch.isin(actual_row, expected_row)).sum().item()
                 )
-                compared_rows += 1
                 compared_entries += k
-                if row_mismatches > 0:
-                    wrong_rows += 1
-                    wrong_entries += row_mismatches
+                wrong_entries += row_mismatches
             row_idx += 1
 
-    correctness = "passed" if wrong_entries == 0 else "failed"
-    print(
-        f"{impl_name}: correctness={correctness}, "
-        f"wrong_entries={wrong_entries}/{compared_entries}, "
-        f"wrong_rows={wrong_rows}/{compared_rows}, "
-        f"peak_memory={peak_memory_mib:.2f} MiB"
-    )
+    return wrong_entries, compared_entries
 
 
 def main() -> None:
@@ -525,6 +514,7 @@ def main() -> None:
     )
     expected_topk = reference.run(q_quant, q_scale, kv_cache, weights)
 
+    results: list[dict[str, object]] = []
     for impl_name, impl_cls in IMPLEMENTATIONS:
         impl = None
         topk_indices = None
@@ -547,16 +537,43 @@ def main() -> None:
         topk_indices = impl.run(q_quant, q_scale, kv_cache, weights)
         torch.cuda.synchronize()
         peak_memory_mib = torch.cuda.max_memory_allocated() / 1024 / 1024
-        print_topk_result(
-            impl_name,
+        wrong_entries, compared_entries = check_topk_result(
             topk_indices,
             expected_topk,
             query_lens,
             seq_lens,
             args.compress_ratio,
             args.topk,
-            peak_memory_mib,
         )
+        latency_ms, p20_ms, p80_ms = triton.testing.do_bench(
+            lambda: impl.run(q_quant, q_scale, kv_cache, weights),
+            warmup=25,
+            rep=100,
+            quantiles=[0.5, 0.2, 0.8],
+        )
+        results.append(
+            {
+                "implementation": impl_name,
+                "wrong_entries": f"{wrong_entries}/{compared_entries}",
+                "peak_memory_mib": peak_memory_mib,
+                "latency_us": latency_ms * 1000,
+                "p20_us": p20_ms * 1000,
+                "p80_us": p80_ms * 1000,
+            }
+        )
+
+    results_df = pd.DataFrame(results)
+    print(
+        results_df.to_string(
+            index=False,
+            formatters={
+                "peak_memory_mib": "{:.2f}".format,
+                "latency_us": "{:.2f}".format,
+                "p20_us": "{:.2f}".format,
+                "p80_us": "{:.2f}".format,
+            },
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
+++ b/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
@@ -205,6 +205,7 @@ class DeepGemmFlatChunk:
             )
             if metadata is not None:
                 self.chunks.append(metadata)
+        self.num_chunks = len(self.chunks)
         if not self.chunks:
             raise RuntimeError("generated requests produced no prefill chunks")
 
@@ -319,6 +320,7 @@ class DeepGemmPaged:
         self.schedule_metadata = get_paged_mqa_logits_metadata(
             self.context_lens, block_size, NUM_SMS, indices=self.indices
         )
+        self.num_chunks = 1
 
     def run(
         self, q_quant: Tensor, q_scale: Tensor | None, kv_cache: Tensor, weights: Tensor
@@ -429,6 +431,7 @@ class DeepGemmPagedChunk:
             )
             self.chunks.append(chunk)
 
+        self.num_chunks = len(self.chunks)
         if not self.chunks:
             raise RuntimeError("generated requests produced no prefill chunks")
 
@@ -494,7 +497,7 @@ def parse_args():
     parser.add_argument("--max_context_len", type=int, nargs="+", default=[1024])
     parser.add_argument("--block_size", type=int, default=64)
     parser.add_argument("--compress_ratio", type=int, default=4)
-    parser.add_argument("--topk", type=int, default=2048)
+    parser.add_argument("--topk", type=int, default=1024)
     parser.add_argument("--seed", type=int, default=42)
     parser.add_argument("--log_axis", action="store_true")
     parser.add_argument("--graph_path")
@@ -551,7 +554,9 @@ def export_sweep_graph(
 ) -> None:
     import matplotlib.pyplot as plt
 
-    fig, (latency_ax, memory_ax) = plt.subplots(2, 1, figsize=(9, 7), sharex=True)
+    fig, (latency_ax, memory_ax, chunks_ax) = plt.subplots(
+        3, 1, figsize=(9, 9), sharex=True
+    )
 
     for impl_name, impl_results in results_df.groupby("implementation", sort=False):
         impl_results = impl_results.sort_values("max_context_len")
@@ -560,26 +565,38 @@ def export_sweep_graph(
         p20_us = impl_results["p20_us"].to_numpy()
         p80_us = impl_results["p80_us"].to_numpy()
         peak_memory_mib = impl_results["peak_memory_mib"].to_numpy()
+        num_chunks = impl_results["num_chunks"].to_numpy()
 
         latency_ax.plot(x_values, latency_us, marker="o", label=impl_name)
         latency_ax.fill_between(x_values, p20_us, p80_us, alpha=0.15)
         memory_ax.plot(x_values, peak_memory_mib, marker="o", label=impl_name)
+        chunks_ax.plot(x_values, num_chunks, marker="o", label=impl_name)
 
     latency_ax.set_title("Latency")
     latency_ax.set_ylabel("us")
     latency_ax.tick_params(axis="x", labelbottom=True)
     if log_axis:
         latency_ax.set_xscale("log", base=10)
+    latency_ax.set_ylim(bottom=0)
     latency_ax.grid(True, axis="y", alpha=0.25)
     latency_ax.legend()
 
-    memory_ax.set_xlabel("max_context_len")
     memory_ax.set_title("Peak memory")
     memory_ax.set_ylabel("MiB")
     if log_axis:
         memory_ax.set_xscale("log", base=10)
+    memory_ax.set_ylim(bottom=0)
     memory_ax.grid(True, axis="y", alpha=0.25)
     memory_ax.legend()
+
+    chunks_ax.set_xlabel("max_context_len")
+    chunks_ax.set_title("Chunks")
+    chunks_ax.set_ylabel("count")
+    if log_axis:
+        chunks_ax.set_xscale("log", base=10)
+    chunks_ax.set_ylim(bottom=0)
+    chunks_ax.grid(True, axis="y", alpha=0.25)
+    chunks_ax.legend()
 
     fig.tight_layout()
     fig.savefig(output_path, dpi=150)
@@ -714,6 +731,7 @@ def run_benchmark_batch(
             {
                 "max_context_len": max_context_len,
                 "implementation": impl_name,
+                "num_chunks": impl.num_chunks,
                 "wrong_entries": f"{wrong_entries}/{compared_entries}",
                 "peak_memory_mib": peak_memory_mib,
                 "latency_us": latency_ms * 1000,

--- a/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
+++ b/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
@@ -483,15 +483,17 @@ def parse_args():
         description="Run all DeepGEMM prefill sparse-indexer paths."
     )
     parser.add_argument("--dtype", choices=["fp4", "fp8"], required=True)
-    parser.add_argument("--num-requests", type=int, default=8)
-    parser.add_argument("--min-query-len", type=int, default=16)
-    parser.add_argument("--max-query-len", type=int, default=128)
-    parser.add_argument("--min-context-len", type=int, default=0)
-    parser.add_argument("--max-context-len", type=int, default=1024)
-    parser.add_argument("--block-size", type=int, default=64)
-    parser.add_argument("--compress-ratio", type=int, default=4)
+    parser.add_argument("--num_requests", type=int, default=8)
+    parser.add_argument("--min_query_len", type=int, default=16)
+    parser.add_argument("--max_query_len", type=int, default=128)
+    parser.add_argument("--min_context_len", type=int, default=0)
+    parser.add_argument("--max_context_len", type=int, nargs="+", default=[1024])
+    parser.add_argument("--block_size", type=int, default=64)
+    parser.add_argument("--compress_ratio", type=int, default=4)
     parser.add_argument("--topk", type=int, default=2048)
     parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--log_axis", action="store_true")
+    parser.add_argument("--graph_path")
     return parser.parse_args()
 
 
@@ -527,57 +529,104 @@ def check_topk_result(
     return wrong_entries, compared_entries
 
 
-def main() -> None:
-    args = parse_args()
-    print(args)
-    print("implementations:", ", ".join(name for name, _ in IMPLEMENTATIONS))
+def make_context_lens(
+    min_context_len: int, max_context_len: int, num_requests: int
+) -> list[int]:
+    if num_requests == 1:
+        return [max_context_len]
 
-    torch.set_default_device("cuda")
-    torch.manual_seed(args.seed)
-    random.seed(args.seed)
+    span = max_context_len - min_context_len
+    return [
+        min_context_len + span * req_idx // (num_requests - 1)
+        for req_idx in range(num_requests)
+    ]
 
-    # Prepare request lengths.
-    use_fp4 = args.dtype == "fp4"
 
-    query_lens: list[int] = []
+def export_sweep_graph(
+    results_df: pd.DataFrame, output_path: str, log_axis: bool
+) -> None:
+    import matplotlib.pyplot as plt
+    from matplotlib.ticker import LogFormatterSciNotation, LogLocator
+
+    def label_log_y_subticks(ax) -> None:
+        ax.yaxis.set_minor_locator(LogLocator(base=10, subs=(5,)))
+        ax.yaxis.set_minor_formatter(
+            LogFormatterSciNotation(
+                base=10,
+                labelOnlyBase=False,
+                minor_thresholds=(float("inf"), float("inf")),
+            )
+        )
+
+    fig, (latency_ax, memory_ax) = plt.subplots(2, 1, figsize=(9, 7), sharex=True)
+
+    for impl_name, impl_results in results_df.groupby("implementation", sort=False):
+        impl_results = impl_results.sort_values("max_context_len")
+        x_values = impl_results["max_context_len"].to_numpy()
+        latency_us = impl_results["latency_us"].to_numpy()
+        p20_us = impl_results["p20_us"].to_numpy()
+        p80_us = impl_results["p80_us"].to_numpy()
+        peak_memory_mib = impl_results["peak_memory_mib"].to_numpy()
+
+        latency_ax.plot(x_values, latency_us, marker="o", label=impl_name)
+        latency_ax.fill_between(x_values, p20_us, p80_us, alpha=0.15)
+        memory_ax.plot(x_values, peak_memory_mib, marker="o", label=impl_name)
+
+    latency_ax.set_title("Latency")
+    latency_ax.set_ylabel("us")
+    latency_ax.tick_params(axis="x", labelbottom=True)
+    if log_axis:
+        latency_ax.set_xscale("log", base=10)
+        latency_ax.set_yscale("log")
+        label_log_y_subticks(latency_ax)
+    latency_ax.grid(True, axis="y", alpha=0.25)
+    latency_ax.legend()
+
+    memory_ax.set_xlabel("max_context_len")
+    memory_ax.set_title("Peak memory")
+    memory_ax.set_ylabel("MiB")
+    if log_axis:
+        memory_ax.set_xscale("log", base=10)
+        memory_ax.set_yscale("log")
+        label_log_y_subticks(memory_ax)
+    memory_ax.grid(True, axis="y", alpha=0.25)
+    memory_ax.legend()
+
+    fig.tight_layout()
+    fig.savefig(output_path, dpi=150)
+    plt.close(fig)
+
+
+def run_benchmark_batch(
+    args: argparse.Namespace,
+    max_context_len: int,
+    query_lens: list[int],
+    q_quant: Tensor,
+    q_scale: Tensor | None,
+    weights: Tensor,
+    use_fp4: bool,
+) -> list[dict[str, object]]:
+    context_lens = make_context_lens(
+        args.min_context_len, max_context_len, args.num_requests
+    )
     seq_lens: list[int] = []
     compressed_seq_lens: list[int] = []
     query_start_locs = [0]
 
-    for _ in range(args.num_requests):
-        query_len = random.randint(args.min_query_len, args.max_query_len)
-        context_len = random.randint(args.min_context_len, args.max_context_len)
+    for query_len, context_len in zip(query_lens, context_lens):
         seq_len = query_len + context_len
 
-        query_lens.append(query_len)
         seq_lens.append(seq_len)
         # Production uses floor division: the compressed cache only has entries
         # for positions where (pos + 1) % compress_ratio == 0.
         compressed_seq_lens.append(seq_len // args.compress_ratio)
         query_start_locs.append(query_start_locs[-1] + query_len)
 
-    total_query_len = query_start_locs[-1]
     cpu_i32 = dict(dtype=torch.int32, device="cpu")
     query_lens_cpu = torch.tensor(query_lens, **cpu_i32)
     seq_lens_cpu = torch.tensor(seq_lens, **cpu_i32)
     compressed_seq_lens_cpu = torch.tensor(compressed_seq_lens, **cpu_i32)
     query_start_loc_cpu = torch.tensor(query_start_locs, **cpu_i32)
-
-    # Prepare Q and per-token weights.
-    weights = torch.randn(total_query_len, NUM_HEADS)
-    if use_fp4:
-        q_quant, q_scale = make_random_fp4(total_query_len, NUM_HEADS)
-        q_scale = q_scale.view(torch.int32).squeeze(-1)
-    else:
-        q_bf16 = torch.randn(
-            total_query_len * NUM_HEADS, HEAD_DIM, dtype=torch.bfloat16
-        )
-        q_quant, q_fp8_scale = ops.scaled_fp8_quant(
-            q_bf16, use_per_token_if_dynamic=True
-        )
-        weights *= q_fp8_scale.view(total_query_len, NUM_HEADS)
-        q_quant = q_quant.view(total_query_len, NUM_HEADS, HEAD_DIM)
-        q_scale = None
 
     # Prepare paged KV cache.
     block_size = args.block_size
@@ -667,13 +716,14 @@ def main() -> None:
             args.topk,
         )
         latency_ms, p20_ms, p80_ms = triton.testing.do_bench(
-            lambda: impl.run(q_quant, q_scale, kv_cache, weights),
+            lambda impl=impl: impl.run(q_quant, q_scale, kv_cache, weights),
             warmup=25,
             rep=100,
             quantiles=[0.5, 0.2, 0.8],
         )
         results.append(
             {
+                "max_context_len": max_context_len,
                 "implementation": impl_name,
                 "wrong_entries": f"{wrong_entries}/{compared_entries}",
                 "peak_memory_mib": peak_memory_mib,
@@ -682,6 +732,55 @@ def main() -> None:
                 "p80_us": p80_ms * 1000,
             }
         )
+
+    return results
+
+
+def main() -> None:
+    args = parse_args()
+    print(args)
+    print("implementations:", ", ".join(name for name, _ in IMPLEMENTATIONS))
+
+    torch.set_default_device("cuda")
+    torch.manual_seed(args.seed)
+    random.seed(args.seed)
+
+    use_fp4 = args.dtype == "fp4"
+    query_lens = [
+        random.randint(args.min_query_len, args.max_query_len)
+        for _ in range(args.num_requests)
+    ]
+    total_query_len = sum(query_lens)
+
+    # Prepare Q and per-token weights once so each sweep point uses the same
+    # query-side inputs.
+    weights = torch.randn(total_query_len, NUM_HEADS)
+    if use_fp4:
+        q_quant, q_scale = make_random_fp4(total_query_len, NUM_HEADS)
+        q_scale = q_scale.view(torch.int32).squeeze(-1)
+    else:
+        q_bf16 = torch.randn(
+            total_query_len * NUM_HEADS, HEAD_DIM, dtype=torch.bfloat16
+        )
+        q_quant, q_fp8_scale = ops.scaled_fp8_quant(
+            q_bf16, use_per_token_if_dynamic=True
+        )
+        weights *= q_fp8_scale.view(total_query_len, NUM_HEADS)
+        q_quant = q_quant.view(total_query_len, NUM_HEADS, HEAD_DIM)
+        q_scale = None
+
+    results: list[dict[str, object]] = []
+    for max_context_len in args.max_context_len:
+        batch_results = run_benchmark_batch(
+            args,
+            max_context_len,
+            query_lens,
+            q_quant,
+            q_scale,
+            weights,
+            use_fp4,
+        )
+        results.extend(batch_results)
 
     results_df = pd.DataFrame(results)
     print(
@@ -695,6 +794,9 @@ def main() -> None:
             },
         )
     )
+    if args.graph_path:
+        export_sweep_graph(results_df, args.graph_path, args.log_axis)
+        print(f"wrote {args.graph_path}")
 
 
 if __name__ == "__main__":

--- a/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
+++ b/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
@@ -583,6 +583,21 @@ def export_sweep_graph(
     results_df: pd.DataFrame, output_path: str, log_axis: bool
 ) -> None:
     import matplotlib.pyplot as plt
+    from matplotlib.ticker import LogFormatterSciNotation, LogLocator
+
+    def label_log_y_subticks(ax) -> None:
+        ax.yaxis.set_minor_locator(LogLocator(base=10, subs=(5,)))
+        ax.yaxis.set_minor_formatter(
+            LogFormatterSciNotation(
+                base=10,
+                labelOnlyBase=False,
+                minor_thresholds=(float("inf"), float("inf")),
+            )
+        )
+
+    def show_y_grid(ax) -> None:
+        ax.grid(True, axis="y", which="major", alpha=0.25)
+        ax.grid(True, axis="y", which="minor", alpha=0.12)
 
     fig, (latency_ax, memory_ax, chunks_ax) = plt.subplots(
         3, 1, figsize=(9, 9), sharex=True
@@ -607,16 +622,20 @@ def export_sweep_graph(
     latency_ax.tick_params(axis="x", labelbottom=True)
     if log_axis:
         latency_ax.set_xscale("log", base=10)
+        latency_ax.set_yscale("log")
+        label_log_y_subticks(latency_ax)
     latency_ax.set_ylim(bottom=0)
-    latency_ax.grid(True, axis="y", alpha=0.25)
+    show_y_grid(latency_ax)
     latency_ax.legend()
 
     memory_ax.set_title("Peak memory")
     memory_ax.set_ylabel("MiB")
     if log_axis:
         memory_ax.set_xscale("log", base=10)
+        memory_ax.set_yscale("log")
+        label_log_y_subticks(memory_ax)
     memory_ax.set_ylim(bottom=0)
-    memory_ax.grid(True, axis="y", alpha=0.25)
+    show_y_grid(memory_ax)
     memory_ax.legend()
 
     chunks_ax.set_xlabel("max_context_len")
@@ -624,8 +643,10 @@ def export_sweep_graph(
     chunks_ax.set_ylabel("count")
     if log_axis:
         chunks_ax.set_xscale("log", base=10)
+        chunks_ax.set_yscale("log")
+        label_log_y_subticks(chunks_ax)
     chunks_ax.set_ylim(bottom=0)
-    chunks_ax.grid(True, axis="y", alpha=0.25)
+    show_y_grid(chunks_ax)
     chunks_ax.legend()
 
     fig.tight_layout()

--- a/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
+++ b/benchmarks/kernels/benchmark_prefill_sparse_indexer.py
@@ -307,6 +307,8 @@ class DeepGemmPaged:
         )
 
         block_table = block_table_cpu.cuda()
+        query_start_loc = query_start_loc_cpu.cuda()
+        seq_lens = seq_lens_cpu.cuda()
         if do_chunk:
             chunk_specs = split_indexer_paged_prefill_chunks(
                 compressed_seq_lens_cpu,
@@ -323,8 +325,9 @@ class DeepGemmPaged:
             metadata = build_paged_prefill_metadata(
                 req_slice.start,
                 req_slice.stop,
+                query_start_loc,
                 query_start_loc_cpu,
-                seq_lens_cpu,
+                seq_lens,
                 compressed_seq_lens_cpu,
                 block_table,
                 compress_ratio,

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -307,6 +307,7 @@ def test_attention_config():
     assert args is not None
     engine_args = EngineArgs.from_cli_args(args)
     assert engine_args.attention_config == AttentionConfig()
+    assert engine_args.attention_config.enable_sparse_indexer_paged_prefill is False
 
     # set backend via dot notation
     args = parser.parse_args(["--attention-config.backend", "FLASH_ATTN"])
@@ -343,6 +344,8 @@ def test_attention_config():
             "true",
             "--attention-config.disable_flashinfer_q_quantization",
             "true",
+            "--attention-config.enable_sparse_indexer_paged_prefill",
+            "true",
         ]
     )
     assert args is not None
@@ -357,6 +360,7 @@ def test_attention_config():
     assert engine_args.attention_config.use_trtllm_attention is True
     assert engine_args.attention_config.disable_flashinfer_prefill is True
     assert engine_args.attention_config.disable_flashinfer_q_quantization is True
+    assert engine_args.attention_config.enable_sparse_indexer_paged_prefill is True
 
     # set to string form of a dict with all fields
     args = parser.parse_args(
@@ -369,7 +373,8 @@ def test_attention_config():
             '"use_trtllm_ragged_deepseek_prefill": false, '
             '"use_trtllm_attention": false, '
             '"disable_flashinfer_prefill": false, '
-            '"disable_flashinfer_q_quantization": false}',
+            '"disable_flashinfer_q_quantization": false, '
+            '"enable_sparse_indexer_paged_prefill": true}',
         ]
     )
     assert args is not None
@@ -384,6 +389,7 @@ def test_attention_config():
     assert engine_args.attention_config.use_trtllm_attention is False
     assert engine_args.attention_config.disable_flashinfer_prefill is False
     assert engine_args.attention_config.disable_flashinfer_q_quantization is False
+    assert engine_args.attention_config.enable_sparse_indexer_paged_prefill is True
 
     # test --attention-backend flows into VllmConfig.attention_config
     args = parser.parse_args(
@@ -412,6 +418,21 @@ def test_attention_config():
     engine_args = EngineArgs.from_cli_args(args)
     vllm_config = engine_args.create_engine_config()
     assert vllm_config.attention_config.backend == AttentionBackendEnum.FLASHINFER
+
+    # test --enable-sparse-indexer-paged-prefill flows into
+    # VllmConfig.attention_config
+    args = parser.parse_args(
+        [
+            "--model",
+            "facebook/opt-125m",
+            "--enable-sparse-indexer-paged-prefill",
+        ]
+    )
+    assert args is not None
+    engine_args = EngineArgs.from_cli_args(args)
+    assert engine_args.enable_sparse_indexer_paged_prefill is True
+    vllm_config = engine_args.create_engine_config()
+    assert vllm_config.attention_config.enable_sparse_indexer_paged_prefill is True
 
     # test --attention-backend and --attention-config.backend are mutually exclusive
     args = parser.parse_args(

--- a/vllm/config/attention.py
+++ b/vllm/config/attention.py
@@ -54,6 +54,9 @@ class AttentionConfig:
     use_fp4_indexer_cache: bool = False
     """If set, use fp4 indexer cache for dsv32 family model (not support yet)"""
 
+    enable_sparse_indexer_paged_prefill: bool = False
+    """Whether to use the experimental sparse-indexer paged prefill path."""
+
     use_non_causal: bool = False
     """Whether to use non-causal (bidirectional) attention."""
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -639,6 +639,7 @@ class EngineArgs:
     model_impl: str = ModelConfig.model_impl
     override_attention_dtype: str | None = ModelConfig.override_attention_dtype
     attention_backend: AttentionBackendEnum | None = AttentionConfig.backend
+    enable_sparse_indexer_paged_prefill: bool | None = None
 
     calculate_kv_scales: bool = CacheConfig.calculate_kv_scales
     kv_cache_dtype_skip_layers: list[str] = get_field(
@@ -865,6 +866,15 @@ class EngineArgs:
         )
         attention_group.add_argument(
             "--attention-backend", **attention_kwargs["backend"]
+        )
+        attention_group.add_argument(
+            "--enable-sparse-indexer-paged-prefill",
+            action="store_true",
+            default=None,
+            help=(
+                "Enable the experimental sparse-indexer paged prefill path "
+                "on supported CUDA SM100 platforms with DeepGEMM."
+            ),
         )
 
         # Mamba arguments
@@ -2026,6 +2036,10 @@ class EngineArgs:
             # Reuse the validator to handle "auto" and string-to-enum conversion
             attention_config.backend = AttentionConfig.validate_backend_before(
                 self.attention_backend
+            )
+        if self.enable_sparse_indexer_paged_prefill is not None:
+            attention_config.enable_sparse_indexer_paged_prefill = (
+                self.enable_sparse_indexer_paged_prefill
             )
 
         # TurboQuant requires FlashAttention 2 — FA3 boundary layers assert

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -57,7 +57,6 @@ if TYPE_CHECKING:
     VLLM_XLA_CACHE_PATH: str = os.path.join(VLLM_CACHE_ROOT, "xla_cache")
     VLLM_XLA_CHECK_RECOMPILATION: bool = False
     VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: int = 512
-    VLLM_SPARSE_INDEXER_DISABLE_PAGED_PREFILL_CHUNKING: bool = False
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: Literal["auto", "nccl", "shm"] = "auto"
     VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM: bool = False
     VLLM_USE_RAY_WRAPPED_PP_COMM: bool = True
@@ -895,12 +894,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Default: 512 MB
     "VLLM_SPARSE_INDEXER_MAX_LOGITS_MB": lambda: int(
         os.getenv("VLLM_SPARSE_INDEXER_MAX_LOGITS_MB", "512")
-    ),
-    # If set, SM100 sparse-indexer paged prefill uses one unchunked DeepGEMM
-    # metadata batch with a PyTorch-built schedule. This is only for
-    # experiments because materialized paged-prefill logits can be very large.
-    "VLLM_SPARSE_INDEXER_DISABLE_PAGED_PREFILL_CHUNKING": lambda: bool(
-        int(os.getenv("VLLM_SPARSE_INDEXER_DISABLE_PAGED_PREFILL_CHUNKING", "0"))
     ),
     # If set, the OpenAI API server will stay alive even after the underlying
     # AsyncLLMEngine errors and stops serving requests

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -57,6 +57,7 @@ if TYPE_CHECKING:
     VLLM_XLA_CACHE_PATH: str = os.path.join(VLLM_CACHE_ROOT, "xla_cache")
     VLLM_XLA_CHECK_RECOMPILATION: bool = False
     VLLM_SPARSE_INDEXER_MAX_LOGITS_MB: int = 512
+    VLLM_SPARSE_INDEXER_DISABLE_PAGED_PREFILL_CHUNKING: bool = False
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: Literal["auto", "nccl", "shm"] = "auto"
     VLLM_USE_RAY_COMPILED_DAG_OVERLAP_COMM: bool = False
     VLLM_USE_RAY_WRAPPED_PP_COMM: bool = True
@@ -894,6 +895,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Default: 512 MB
     "VLLM_SPARSE_INDEXER_MAX_LOGITS_MB": lambda: int(
         os.getenv("VLLM_SPARSE_INDEXER_MAX_LOGITS_MB", "512")
+    ),
+    # If set, SM100 sparse-indexer paged prefill uses one unchunked DeepGEMM
+    # metadata batch with a PyTorch-built schedule. This is only for
+    # experiments because materialized paged-prefill logits can be very large.
+    "VLLM_SPARSE_INDEXER_DISABLE_PAGED_PREFILL_CHUNKING": lambda: bool(
+        int(os.getenv("VLLM_SPARSE_INDEXER_DISABLE_PAGED_PREFILL_CHUNKING", "0"))
     ),
     # If set, the OpenAI API server will stay alive even after the underlying
     # AsyncLLMEngine errors and stops serving requests

--- a/vllm/forward_context.py
+++ b/vllm/forward_context.py
@@ -306,6 +306,9 @@ def set_forward_context(
         batch_descriptor=batch_descriptor,
         ubatch_slices=ubatch_slices,
     )
+    additional_kwargs["enable_sparse_indexer_paged_prefill"] = (
+        vllm_config.attention_config.enable_sparse_indexer_paged_prefill
+    )
 
     forward_context = create_forward_context(
         attn_metadata,

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -127,10 +127,10 @@ def sparse_attn_indexer(
             )
 
         # Dummy byte allocation to simulate peak materialized logits memory.
-        # Flat prefill is capped by chunking; paged prefill is unchunked and can
-        # materialize [max_num_batched_tokens, max_context_len] fp32 logits.
+        # Materialized paged-prefill logits are still large, but chunking bounds
+        # them by the paged chunk size.
         if use_paged_prefill:
-            max_logits_bytes = hidden_states.shape[0] * max_model_len * 4
+            max_logits_bytes = min(hidden_states.shape[0], 2048) * max_model_len * 4
         else:
             max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
         _ = torch.empty(
@@ -193,47 +193,50 @@ def sparse_attn_indexer(
         prefill_metadata = attn_metadata_narrowed.prefill
         assert prefill_metadata is not None
 
-        paged_metadata = prefill_metadata.paged_metadata
-        if paged_metadata is not None:
+        if prefill_metadata.paged_chunks:
             # Paged prefill has already expanded each query token into its own
             # varlen row, so it uses the decode-shaped DeepGEMM/top-k kernels.
             paged_kv_cache = kv_cache_as_quant_view(kv_cache, head_dim, use_fp4_cache)
-            num_tokens = paged_metadata.context_lens.shape[0]
-            token_slice = slice(paged_metadata.token_start, paged_metadata.token_end)
-            q_slice = q_quant[token_slice].view(num_tokens, 1, *q_quant.shape[1:])
-            if use_fp4_cache:
-                q_slice = q_slice.view(torch.int8)
-                assert q_scale is not None
-                q_scale_slice = q_scale[token_slice].view(
-                    num_tokens, 1, *q_scale.shape[1:]
+            for paged_metadata in prefill_metadata.paged_chunks:
+                num_tokens = paged_metadata.context_lens.shape[0]
+                token_slice = slice(
+                    paged_metadata.token_start, paged_metadata.token_end
                 )
-            else:
-                q_scale_slice = None
+                q_slice = q_quant[token_slice].view(num_tokens, 1, *q_quant.shape[1:])
+                if use_fp4_cache:
+                    q_slice = q_slice.view(torch.int8)
+                    assert q_scale is not None
+                    q_scale_slice = q_scale[token_slice].view(
+                        num_tokens, 1, *q_scale.shape[1:]
+                    )
+                else:
+                    q_scale_slice = None
 
-            logits = fp8_fp4_paged_mqa_logits(
-                (q_slice, q_scale_slice),
-                paged_kv_cache,
-                weights[token_slice],
-                paged_metadata.context_lens,
-                paged_metadata.block_table,
-                paged_metadata.schedule_metadata,
-                max_model_len=paged_metadata.max_context_len,
-                clean_logits=False,
-                indices=paged_metadata.indices,
-            )
-            topk_indices = topk_indices_buffer[
-                paged_metadata.token_start : paged_metadata.token_end, :topk_tokens
-            ]
-            torch.ops._C.top_k_per_row_decode(
-                logits,
-                1,
-                paged_metadata.context_lens,
-                topk_indices,
-                logits.shape[0],
-                logits.stride(0),
-                logits.stride(1),
-                topk_tokens,
-            )
+                logits = fp8_fp4_paged_mqa_logits(
+                    (q_slice, q_scale_slice),
+                    paged_kv_cache,
+                    weights[token_slice],
+                    paged_metadata.context_lens,
+                    paged_metadata.block_table,
+                    paged_metadata.schedule_metadata,
+                    max_model_len=paged_metadata.max_context_len,
+                    clean_logits=False,
+                    indices=paged_metadata.indices,
+                )
+                topk_indices = topk_indices_buffer[
+                    paged_metadata.token_start : paged_metadata.token_end,
+                    :topk_tokens,
+                ]
+                torch.ops._C.top_k_per_row_decode(
+                    logits,
+                    1,
+                    paged_metadata.context_lens,
+                    topk_indices,
+                    logits.shape[0],
+                    logits.stride(0),
+                    logits.stride(1),
+                    topk_tokens,
+                )
 
         if prefill_metadata.chunks:
             # Get the full shared workspace buffers once (will allocate on first use).

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -107,14 +107,24 @@ def sparse_attn_indexer(
     # assert isinstance(attn_metadata, dict)
     if not isinstance(attn_metadata, dict):
         # Reserve workspace for indexer during profiling run
-        values_spec, scales_spec = _gather_workspace_shapes(
-            total_seq_lens, head_dim, fp8_dtype, use_fp4_cache
+        use_paged_prefill = (
+            current_platform.is_cuda()
+            and current_platform.is_device_capability_family(100)
+            and has_deep_gemm()
         )
-        current_workspace_manager().get_simultaneous(
-            values_spec,
-            scales_spec,
-            ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
-        )
+        if use_paged_prefill:
+            current_workspace_manager().get_simultaneous(
+                ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
+            )
+        else:
+            values_spec, scales_spec = _gather_workspace_shapes(
+                total_seq_lens, head_dim, fp8_dtype, use_fp4_cache
+            )
+            current_workspace_manager().get_simultaneous(
+                values_spec,
+                scales_spec,
+                ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
+            )
 
         # Dummy allocation to simulate for peak logits tensor memory during inference.
         # FP8 elements so elements == bytes
@@ -179,83 +189,126 @@ def sparse_attn_indexer(
         prefill_metadata = attn_metadata_narrowed.prefill
         assert prefill_metadata is not None
 
-        # Get the full shared workspace buffers once (will allocate on first use).
-        # Layout switches between FP8 (head_dim bytes + 4-byte fp32 scale) and
-        # MXFP4 (head_dim/2 bytes packed + head_dim/MXFP4_BLOCK_SIZE ue8m0
-        # scales) based on use_fp4_cache.
-        workspace_manager = current_workspace_manager()
-        values_spec, scales_spec = _gather_workspace_shapes(
-            total_seq_lens, head_dim, fp8_dtype, use_fp4_cache
-        )
-        k_quant_full, k_scale_full = workspace_manager.get_simultaneous(
-            values_spec,
-            scales_spec,
-        )
-        for chunk in prefill_metadata.chunks:
-            k_quant = k_quant_full[: chunk.total_seq_lens]
-            k_scale = k_scale_full[: chunk.total_seq_lens]
-
-            if not chunk.skip_kv_gather:
-                ops.cp_gather_indexer_k_quant_cache(
-                    kv_cache,
-                    k_quant,
-                    k_scale,
-                    chunk.block_table,
-                    chunk.cu_seq_lens,
-                )
-
-            q_slice = q_quant[chunk.token_start : chunk.token_end]
-            q_scale_slice = (
-                q_scale[chunk.token_start : chunk.token_end]
-                if q_scale is not None
-                else None
-            )
-            # DeepGEMM scalar-type tags (zero-copy): MXFP4 values → int8
-            # (kPackedFP4), scales → int32 squeezed to 1-D kv_sf / 2-D q_sf.
+        paged_metadata = prefill_metadata.paged_metadata
+        if paged_metadata is not None:
+            # Paged prefill has already expanded each query token into its own
+            # varlen row, so it uses the decode-shaped DeepGEMM/top-k kernels.
+            paged_kv_cache = kv_cache_as_quant_view(kv_cache, head_dim, use_fp4_cache)
+            num_tokens = paged_metadata.context_lens.shape[0]
+            token_slice = slice(paged_metadata.token_start, paged_metadata.token_end)
+            q_slice = q_quant[token_slice].view(num_tokens, 1, *q_quant.shape[1:])
             if use_fp4_cache:
-                q_slice_cast = q_slice.view(torch.int8)
-                k_quant_cast = k_quant.view(torch.int8)
-                k_scale_cast = k_scale.view(torch.int32).squeeze(-1)
+                q_slice = q_slice.view(torch.int8)
+                assert q_scale is not None
+                q_scale_slice = q_scale[token_slice].view(
+                    num_tokens, 1, *q_scale.shape[1:]
+                )
             else:
-                q_slice_cast = q_slice
-                k_quant_cast = k_quant
-                k_scale_cast = k_scale.view(torch.float32).squeeze(-1)
-            logits = fp8_fp4_mqa_logits(
-                (q_slice_cast, q_scale_slice),
-                (k_quant_cast, k_scale_cast),
-                weights[chunk.token_start : chunk.token_end],
-                chunk.cu_seqlen_ks,
-                chunk.cu_seqlen_ke,
+                q_scale_slice = None
+
+            logits = fp8_fp4_paged_mqa_logits(
+                (q_slice, q_scale_slice),
+                paged_kv_cache,
+                weights[token_slice],
+                paged_metadata.context_lens,
+                paged_metadata.block_table,
+                paged_metadata.schedule_metadata,
+                max_model_len=paged_metadata.max_context_len,
                 clean_logits=False,
+                indices=paged_metadata.indices,
             )
-            num_rows = logits.shape[0]
-
             topk_indices = topk_indices_buffer[
-                chunk.token_start : chunk.token_end, :topk_tokens
+                paged_metadata.token_start : paged_metadata.token_end, :topk_tokens
             ]
+            torch.ops._C.top_k_per_row_decode(
+                logits,
+                1,
+                paged_metadata.context_lens,
+                topk_indices,
+                logits.shape[0],
+                logits.stride(0),
+                logits.stride(1),
+                topk_tokens,
+            )
 
-            if current_platform.is_xpu():
-                xpu_ops.top_k_per_row_prefill(  # type: ignore[attr-defined]
-                    logits,
+        if prefill_metadata.chunks:
+            # Get the full shared workspace buffers once (will allocate on first use).
+            # Layout switches between FP8 (head_dim bytes + 4-byte fp32 scale) and
+            # MXFP4 (head_dim/2 bytes packed + head_dim/MXFP4_BLOCK_SIZE ue8m0
+            # scales) based on use_fp4_cache.
+            workspace_manager = current_workspace_manager()
+            values_spec, scales_spec = _gather_workspace_shapes(
+                total_seq_lens, head_dim, fp8_dtype, use_fp4_cache
+            )
+            k_quant_full, k_scale_full = workspace_manager.get_simultaneous(
+                values_spec,
+                scales_spec,
+            )
+            for chunk in prefill_metadata.chunks:
+                k_quant = k_quant_full[: chunk.total_seq_lens]
+                k_scale = k_scale_full[: chunk.total_seq_lens]
+
+                if not chunk.skip_kv_gather:
+                    ops.cp_gather_indexer_k_quant_cache(
+                        kv_cache,
+                        k_quant,
+                        k_scale,
+                        chunk.block_table,
+                        chunk.cu_seq_lens,
+                    )
+
+                q_slice = q_quant[chunk.token_start : chunk.token_end]
+                q_scale_slice = (
+                    q_scale[chunk.token_start : chunk.token_end]
+                    if q_scale is not None
+                    else None
+                )
+                # DeepGEMM scalar-type tags (zero-copy): MXFP4 values → int8
+                # (kPackedFP4), scales → int32 squeezed to 1-D kv_sf / 2-D q_sf.
+                if use_fp4_cache:
+                    q_slice_cast = q_slice.view(torch.int8)
+                    k_quant_cast = k_quant.view(torch.int8)
+                    k_scale_cast = k_scale.view(torch.int32).squeeze(-1)
+                else:
+                    q_slice_cast = q_slice
+                    k_quant_cast = k_quant
+                    k_scale_cast = k_scale.view(torch.float32).squeeze(-1)
+                logits = fp8_fp4_mqa_logits(
+                    (q_slice_cast, q_scale_slice),
+                    (k_quant_cast, k_scale_cast),
+                    weights[chunk.token_start : chunk.token_end],
                     chunk.cu_seqlen_ks,
                     chunk.cu_seqlen_ke,
-                    topk_indices,
-                    num_rows,
-                    logits.stride(0),
-                    logits.stride(1),
-                    topk_tokens,
+                    clean_logits=False,
                 )
-            else:
-                torch.ops._C.top_k_per_row_prefill(
-                    logits,
-                    chunk.cu_seqlen_ks,
-                    chunk.cu_seqlen_ke,
-                    topk_indices,
-                    num_rows,
-                    logits.stride(0),
-                    logits.stride(1),
-                    topk_tokens,
-                )
+                num_rows = logits.shape[0]
+
+                topk_indices = topk_indices_buffer[
+                    chunk.token_start : chunk.token_end, :topk_tokens
+                ]
+
+                if current_platform.is_xpu():
+                    xpu_ops.top_k_per_row_prefill(  # type: ignore[attr-defined]
+                        logits,
+                        chunk.cu_seqlen_ks,
+                        chunk.cu_seqlen_ke,
+                        topk_indices,
+                        num_rows,
+                        logits.stride(0),
+                        logits.stride(1),
+                        topk_tokens,
+                    )
+                else:
+                    torch.ops._C.top_k_per_row_prefill(
+                        logits,
+                        chunk.cu_seqlen_ks,
+                        chunk.cu_seqlen_ke,
+                        topk_indices,
+                        num_rows,
+                        logits.stride(0),
+                        logits.stride(1),
+                        topk_tokens,
+                    )
 
     if has_decode:
         decode_metadata = attn_metadata_narrowed.decode

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -23,6 +23,7 @@ from vllm.utils.torch_utils import (
 )
 from vllm.v1.attention.backends.mla.indexer import (
     DeepseekV32IndexerMetadata,
+    sparse_indexer_paged_prefill_supported,
 )
 from vllm.v1.attention.ops.common import pack_seq_triton, unpack_seq_triton
 from vllm.v1.worker.workspace import current_workspace_manager
@@ -100,7 +101,8 @@ def sparse_attn_indexer(
     use_fp4_cache: bool = False,
 ) -> torch.Tensor:
     # careful! this will be None in dummy run
-    attn_metadata = get_forward_context().attn_metadata
+    forward_context = get_forward_context()
+    attn_metadata = forward_context.attn_metadata
     fp8_dtype = current_platform.fp8_dtype()
     k_cache_prefix = _resolve_layer_name(k_cache_prefix)
 
@@ -108,9 +110,10 @@ def sparse_attn_indexer(
     if not isinstance(attn_metadata, dict):
         # Reserve workspace for indexer during profiling run
         use_paged_prefill = (
-            current_platform.is_cuda()
-            and current_platform.is_device_capability_family(100)
-            and has_deep_gemm()
+            forward_context.additional_kwargs.get(
+                "enable_sparse_indexer_paged_prefill", False
+            )
+            and sparse_indexer_paged_prefill_supported()
         )
         if use_paged_prefill:
             current_workspace_manager().get_simultaneous(
@@ -127,22 +130,12 @@ def sparse_attn_indexer(
             )
 
         if use_paged_prefill:
-            if envs.VLLM_SPARSE_INDEXER_DISABLE_PAGED_PREFILL_CHUNKING:
-                # The experimental full-paged path materializes one logits
-                # tensor for all query tokens. max_model_len is already the
-                # indexer context length after any KV compression.
-                # Example: 8192 prefill tokens at 1M context with compression
-                # ratio 4 gives 8192 * (1048576 / 4) * 4 bytes = 8 GiB.
-                max_logits_bytes = hidden_states.shape[0] * max_model_len * 4
-            else:
-                # Chunked paged prefill is bounded by both the metadata safety
-                # chunk size and the configured materialized logits cap.
-                paged_chunk_bytes = min(hidden_states.shape[0], 2048)
-                paged_chunk_bytes *= max_model_len * 4
-                max_logits_bytes = min(
-                    paged_chunk_bytes,
-                    envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024,
-                )
+            # The experimental full-paged path materializes one logits tensor
+            # for all query tokens. max_model_len is already the indexer context
+            # length after any KV compression.
+            # Example: 8192 prefill tokens at 1M context with compression ratio
+            # 4 gives 8192 * (1048576 / 4) * 4 bytes = 8 GiB.
+            max_logits_bytes = hidden_states.shape[0] * max_model_len * 4
         else:
             max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
         # Dummy byte allocation to simulate peak materialized logits memory.
@@ -206,8 +199,8 @@ def sparse_attn_indexer(
         prefill_metadata = attn_metadata_narrowed.prefill
         assert prefill_metadata is not None
 
-        if prefill_metadata.full_paged_metadata is not None:
-            paged_metadata = prefill_metadata.full_paged_metadata
+        if prefill_metadata.paged_metadata is not None:
+            paged_metadata = prefill_metadata.paged_metadata
             paged_kv_cache = kv_cache_as_quant_view(kv_cache, head_dim, use_fp4_cache)
             num_tokens = paged_metadata.context_lens.shape[0]
             token_slice = slice(paged_metadata.token_start, paged_metadata.token_end)
@@ -248,51 +241,6 @@ def sparse_attn_indexer(
                 logits.stride(1),
                 topk_tokens,
             )
-
-        if prefill_metadata.paged_chunks:
-            # Paged prefill has already expanded each query token into its own
-            # varlen row, so it uses the decode-shaped DeepGEMM/top-k kernels.
-            paged_kv_cache = kv_cache_as_quant_view(kv_cache, head_dim, use_fp4_cache)
-            for paged_metadata in prefill_metadata.paged_chunks:
-                num_tokens = paged_metadata.context_lens.shape[0]
-                token_slice = slice(
-                    paged_metadata.token_start, paged_metadata.token_end
-                )
-                q_slice = q_quant[token_slice].view(num_tokens, 1, *q_quant.shape[1:])
-                if use_fp4_cache:
-                    q_slice = q_slice.view(torch.int8)
-                    assert q_scale is not None
-                    q_scale_slice = q_scale[token_slice].view(
-                        num_tokens, 1, *q_scale.shape[1:]
-                    )
-                else:
-                    q_scale_slice = None
-
-                logits = fp8_fp4_paged_mqa_logits(
-                    (q_slice, q_scale_slice),
-                    paged_kv_cache,
-                    weights[token_slice],
-                    paged_metadata.context_lens,
-                    paged_metadata.block_table,
-                    paged_metadata.schedule_metadata,
-                    max_model_len=paged_metadata.max_context_len,
-                    clean_logits=False,
-                    indices=paged_metadata.indices,
-                )
-                topk_indices = topk_indices_buffer[
-                    paged_metadata.token_start : paged_metadata.token_end,
-                    :topk_tokens,
-                ]
-                torch.ops._C.top_k_per_row_decode(
-                    logits,
-                    1,
-                    paged_metadata.context_lens,
-                    topk_indices,
-                    logits.shape[0],
-                    logits.stride(0),
-                    logits.stride(1),
-                    topk_tokens,
-                )
 
         if prefill_metadata.chunks:
             # Get the full shared workspace buffers once (will allocate on first use).

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -129,7 +129,10 @@ def sparse_attn_indexer(
         if use_paged_prefill:
             if envs.VLLM_SPARSE_INDEXER_DISABLE_PAGED_PREFILL_CHUNKING:
                 # The experimental full-paged path materializes one logits
-                # tensor for all query tokens.
+                # tensor for all query tokens. max_model_len is already the
+                # indexer context length after any KV compression.
+                # Example: 8192 prefill tokens at 1M context with compression
+                # ratio 4 gives 8192 * (1048576 / 4) * 4 bytes = 8 GiB.
                 max_logits_bytes = hidden_states.shape[0] * max_model_len * 4
             else:
                 # Chunked paged prefill is bounded by both the metadata safety
@@ -218,6 +221,8 @@ def sparse_attn_indexer(
             else:
                 q_scale_slice = None
 
+            # Example: 8192 prefill tokens at 1M context with compression
+            # ratio 4 gives 8192 * (1048576 / 4) * 4 bytes = 8 GiB.
             logits = fp8_fp4_paged_mqa_logits(
                 (q_slice, q_scale_slice),
                 paged_kv_cache,

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -126,11 +126,15 @@ def sparse_attn_indexer(
                 ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
             )
 
-        # Dummy allocation to simulate for peak logits tensor memory during inference.
-        # FP8 elements so elements == bytes
-        max_logits_elems = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
+        # Dummy byte allocation to simulate peak materialized logits memory.
+        # Flat prefill is capped by chunking; paged prefill is unchunked and can
+        # materialize [max_num_batched_tokens, max_context_len] fp32 logits.
+        if use_paged_prefill:
+            max_logits_bytes = hidden_states.shape[0] * max_model_len * 4
+        else:
+            max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
         _ = torch.empty(
-            max_logits_elems, dtype=torch.uint8, device=hidden_states.device
+            max_logits_bytes, dtype=torch.uint8, device=hidden_states.device
         )
 
         return sparse_attn_indexer_fake(

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -126,13 +126,23 @@ def sparse_attn_indexer(
                 ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),
             )
 
-        # Dummy byte allocation to simulate peak materialized logits memory.
-        # Materialized paged-prefill logits are still large, but chunking bounds
-        # them by the paged chunk size.
         if use_paged_prefill:
-            max_logits_bytes = min(hidden_states.shape[0], 2048) * max_model_len * 4
+            if envs.VLLM_SPARSE_INDEXER_DISABLE_PAGED_PREFILL_CHUNKING:
+                # The experimental full-paged path materializes one logits
+                # tensor for all query tokens.
+                max_logits_bytes = hidden_states.shape[0] * max_model_len * 4
+            else:
+                # Chunked paged prefill is bounded by both the metadata safety
+                # chunk size and the configured materialized logits cap.
+                paged_chunk_bytes = min(hidden_states.shape[0], 2048)
+                paged_chunk_bytes *= max_model_len * 4
+                max_logits_bytes = min(
+                    paged_chunk_bytes,
+                    envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024,
+                )
         else:
             max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
+        # Dummy byte allocation to simulate peak materialized logits memory.
         _ = torch.empty(
             max_logits_bytes, dtype=torch.uint8, device=hidden_states.device
         )
@@ -192,6 +202,47 @@ def sparse_attn_indexer(
     if has_prefill:
         prefill_metadata = attn_metadata_narrowed.prefill
         assert prefill_metadata is not None
+
+        if prefill_metadata.full_paged_metadata is not None:
+            paged_metadata = prefill_metadata.full_paged_metadata
+            paged_kv_cache = kv_cache_as_quant_view(kv_cache, head_dim, use_fp4_cache)
+            num_tokens = paged_metadata.context_lens.shape[0]
+            token_slice = slice(paged_metadata.token_start, paged_metadata.token_end)
+            q_slice = q_quant[token_slice].view(num_tokens, 1, *q_quant.shape[1:])
+            if use_fp4_cache:
+                q_slice = q_slice.view(torch.int8)
+                assert q_scale is not None
+                q_scale_slice = q_scale[token_slice].view(
+                    num_tokens, 1, *q_scale.shape[1:]
+                )
+            else:
+                q_scale_slice = None
+
+            logits = fp8_fp4_paged_mqa_logits(
+                (q_slice, q_scale_slice),
+                paged_kv_cache,
+                weights[token_slice],
+                paged_metadata.context_lens,
+                paged_metadata.block_table,
+                paged_metadata.schedule_metadata,
+                max_model_len=paged_metadata.max_context_len,
+                clean_logits=False,
+                indices=paged_metadata.indices,
+            )
+            topk_indices = topk_indices_buffer[
+                paged_metadata.token_start : paged_metadata.token_end,
+                :topk_tokens,
+            ]
+            torch.ops._C.top_k_per_row_decode(
+                logits,
+                1,
+                paged_metadata.context_lens,
+                topk_indices,
+                logits.shape[0],
+                logits.stride(0),
+                logits.stride(1),
+                topk_tokens,
+            )
 
         if prefill_metadata.paged_chunks:
             # Paged prefill has already expanded each query token into its own

--- a/vllm/utils/deep_gemm.py
+++ b/vllm/utils/deep_gemm.py
@@ -384,15 +384,19 @@ def fp8_fp4_mqa_logits(
 
 
 def get_paged_mqa_logits_metadata(
-    context_lens: torch.Tensor, block_size: int, num_sms: int
+    context_lens: torch.Tensor,
+    block_size: int,
+    num_sms: int,
+    indices: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Build scheduling metadata for paged MQA logits.
 
     Args:
-        context_lens: Tensor of shape [B], dtype int32; effective context length
-            per batch element.
+        context_lens: Tensor of shape [B] or [B, next_n], dtype int32;
+            effective context length per batch element or token.
         block_size: KV-cache block size in tokens (e.g., 64).
         num_sms: Number of SMs available. 132 for Hopper
+        indices: Optional request index per varlen token, dtype int32.
 
     Returns:
         Backend-specific tensor consumed by `fp8_fp4_paged_mqa_logits` to
@@ -401,7 +405,12 @@ def get_paged_mqa_logits_metadata(
     _lazy_init()
     if _get_paged_mqa_logits_metadata_impl is None:
         return _missing()
-    return _get_paged_mqa_logits_metadata_impl(context_lens, block_size, num_sms)
+    return _get_paged_mqa_logits_metadata_impl(
+        context_lens,
+        block_size,
+        num_sms,
+        indices=indices,
+    )
 
 
 def fp8_fp4_paged_mqa_logits(
@@ -413,6 +422,7 @@ def fp8_fp4_paged_mqa_logits(
     schedule_metadata: torch.Tensor,
     max_model_len: int,
     clean_logits: bool,
+    indices: torch.Tensor | None = None,
 ) -> torch.Tensor:
     """Compute MQA logits using a paged KV-cache.
 
@@ -429,14 +439,15 @@ def fp8_fp4_paged_mqa_logits(
             D+4], dtype `torch.uint8`, with the last 4 bytes per (block, pos)
             storing the float dequant scale.
         weights: Tensor of shape [B * next_n, H], dtype `torch.float32`.
-        context_lens: Tensor of shape [B], dtype int32; effective context length
-            for each batch element.
+        context_lens: Tensor of shape [B] or [B, next_n], dtype int32;
+            effective context length for each batch element or token.
         block_tables: Tensor of shape [B, max_blocks], dtype int32; maps logical
             block indices to physical blocks in the paged cache.
         schedule_metadata: Returned by `get_paged_mqa_logits_metadata`;
             used to distribute work across SMs.
         max_model_len: Maximum sequence length used to size the logits output.
         clean_logits: Whether to clean the unfilled logits into `-inf`.
+        indices: Optional request index per varlen token, dtype int32.
 
     Returns:
         Logits tensor of shape [B * next_n, max_model_len], dtype
@@ -454,6 +465,7 @@ def fp8_fp4_paged_mqa_logits(
         schedule_metadata,
         max_model_len,
         clean_logits=clean_logits,
+        indices=indices,
     )
 
 

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -887,24 +887,29 @@ def build_paged_prefill_metadata(
         device=device,
     )
 
-    _build_paged_prefill_metadata_kernel[
-        (cdiv(output_query_len * block_table_cols, 1024),)
-    ](
+    _build_paged_prefill_row_metadata_kernel[(cdiv(output_query_len, 1024),)](
         query_start_loc,
         seq_lens,
-        block_table,
         context_lens,
         indices,
-        expanded_block_table,
         token_start,
         output_query_len,
         start_idx,
         end_idx,
-        BLOCK_TABLE_STRIDE=block_table.stride(0),
-        BLOCK_TABLE_COLS=block_table_cols,
         BLOCK_SIZE=1024,
         REQ_SEARCH_STEPS=(end_idx - start_idx).bit_length(),
         COMPRESS_RATIO=compress_ratio,
+    )
+    _expand_paged_prefill_block_table_kernel[
+        (cdiv(output_query_len * block_table_cols, 1024),)
+    ](
+        block_table,
+        indices,
+        expanded_block_table,
+        output_query_len,
+        BLOCK_TABLE_STRIDE=block_table.stride(0),
+        BLOCK_TABLE_COLS=block_table_cols,
+        BLOCK_SIZE=1024,
     )
     schedule_metadata = get_paged_mqa_logits_metadata(
         context_lens,
@@ -960,24 +965,29 @@ def build_full_paged_prefill_metadata(
     )
     schedule_metadata = torch.empty((num_sms + 1, 2), dtype=torch.int32, device=device)
 
-    _build_paged_prefill_metadata_kernel[
-        (cdiv(total_query_len * block_table_cols, 1024),)
-    ](
+    _build_paged_prefill_row_metadata_kernel[(cdiv(total_query_len, 1024),)](
         query_start_loc,
         seq_lens,
-        block_table,
         context_lens,
         indices,
-        expanded_block_table,
         token_start,
         total_query_len,
         start_idx,
         end_idx,
-        BLOCK_TABLE_STRIDE=block_table.stride(0),
-        BLOCK_TABLE_COLS=block_table_cols,
         BLOCK_SIZE=1024,
         REQ_SEARCH_STEPS=(end_idx - start_idx).bit_length(),
         COMPRESS_RATIO=compress_ratio,
+    )
+    _expand_paged_prefill_block_table_kernel[
+        (cdiv(total_query_len * block_table_cols, 1024),)
+    ](
+        block_table,
+        indices,
+        expanded_block_table,
+        total_query_len,
+        BLOCK_TABLE_STRIDE=block_table.stride(0),
+        BLOCK_TABLE_COLS=block_table_cols,
+        BLOCK_SIZE=1024,
     )
     # Build the varlen schedule directly from request/query metadata so the
     # full path does not materialize per-atom PyTorch temporaries.
@@ -1006,31 +1016,24 @@ def build_full_paged_prefill_metadata(
 
 
 @triton.jit
-def _build_paged_prefill_metadata_kernel(
+def _build_paged_prefill_row_metadata_kernel(
     # Inputs
     query_start_loc_ptr,
     seq_lens_ptr,
-    block_table_ptr,
     # Outputs
     context_lens_ptr,
     indices_ptr,
-    expanded_block_table_ptr,
     token_start,
     output_query_len,
     start_idx,
     end_idx,
-    BLOCK_TABLE_STRIDE: tl.constexpr,
-    BLOCK_TABLE_COLS: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
     REQ_SEARCH_STEPS: tl.constexpr,
     COMPRESS_RATIO: tl.constexpr,
 ):
-    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    num_items = output_query_len * BLOCK_TABLE_COLS
-    mask = offsets < num_items
-
-    out_rows = offsets // BLOCK_TABLE_COLS
-    block_cols = offsets - out_rows * BLOCK_TABLE_COLS
+    out_rows = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = out_rows < output_query_len
+    out_rows = tl.minimum(out_rows, output_query_len - 1)
     query_pos = token_start + out_rows
 
     lo = tl.full((BLOCK_SIZE,), 0, tl.int64) + start_idx
@@ -1048,21 +1051,35 @@ def _build_paged_prefill_metadata_kernel(
     query_len = query_end - query_start
     query_offsets = query_pos - query_start
 
+    seq_len = tl.load(seq_lens_ptr + req_idx)
+    context_lens = (seq_len - query_len + query_offsets + 1) // COMPRESS_RATIO
+    tl.store(context_lens_ptr + out_rows, context_lens, mask=mask)
+    tl.store(indices_ptr + out_rows, req_idx, mask=mask)
+
+
+@triton.jit
+def _expand_paged_prefill_block_table_kernel(
+    block_table_ptr,
+    indices_ptr,
+    expanded_block_table_ptr,
+    output_query_len,
+    BLOCK_TABLE_STRIDE: tl.constexpr,
+    BLOCK_TABLE_COLS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    num_items = output_query_len * BLOCK_TABLE_COLS
+    mask = offsets < num_items
+
+    raw_rows = offsets // BLOCK_TABLE_COLS
+    out_rows = tl.minimum(raw_rows, output_query_len - 1)
+    block_cols = offsets - raw_rows * BLOCK_TABLE_COLS
+    req_idx = tl.load(indices_ptr + out_rows).to(tl.int64)
     block_values = tl.load(
         block_table_ptr + req_idx * BLOCK_TABLE_STRIDE + block_cols,
         mask=mask,
     )
-    tl.store(
-        expanded_block_table_ptr + out_rows * BLOCK_TABLE_COLS + block_cols,
-        block_values,
-        mask=mask,
-    )
-
-    row_mask = mask & (block_cols == 0)
-    seq_len = tl.load(seq_lens_ptr + req_idx)
-    context_lens = (seq_len - query_len + query_offsets + 1) // COMPRESS_RATIO
-    tl.store(context_lens_ptr + out_rows, context_lens, mask=row_mask)
-    tl.store(indices_ptr + out_rows, req_idx, mask=row_mask)
+    tl.store(expanded_block_table_ptr + offsets, block_values, mask=mask)
 
 
 @triton.jit

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -180,8 +180,22 @@ class DeepseekV32IndexerPrefillChunkMetadata:
 
 
 @dataclass
+class DeepseekV32IndexerPagedPrefillMetadata:
+    token_start: int
+    token_end: int
+    context_lens: torch.Tensor
+    indices: torch.Tensor
+    block_table: torch.Tensor
+    schedule_metadata: torch.Tensor
+    max_context_len: int
+
+
+@dataclass
 class DeepseekV32IndexerPrefillMetadata:
+    # Flat prefill uses one or more gathered-K chunks. SM100 paged prefill uses
+    # one full-span metadata object and reads K directly from the paged KV cache.
     chunks: list[DeepseekV32IndexerPrefillChunkMetadata]
+    paged_metadata: DeepseekV32IndexerPagedPrefillMetadata | None = None
 
 
 @dataclass
@@ -276,6 +290,11 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             self.use_fp4_indexer_cache
             or not current_platform.is_device_capability_family(100)
         ) and next_n not in self.natively_supported_next_n_fp4
+        self.use_paged_prefill = (
+            current_platform.is_cuda()
+            and current_platform.is_device_capability_family(100)
+            and has_deep_gemm()
+        )
 
         sm_count = num_compute_units(self.device.index)
         self.num_sms = sm_count
@@ -517,41 +536,56 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 if self.compress_ratio > 1
                 else seq_lens_cpu
             )
-            prefill_query_lens_cpu = torch.diff(
-                query_start_loc_cpu[num_decodes : num_decodes + num_prefills + 1]
-            )
-            max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
-            # Upper bound is exact for prefill rows (the `[num_decodes:]`
-            # slice below).
-            assert common_attn_metadata.seq_lens_cpu_upper_bound is not None
-            seq_lens_cpu = common_attn_metadata.seq_lens_cpu_upper_bound
-            chunk_specs = split_indexer_prefill_chunks(
-                compressed_seq_lens_cpu[num_decodes:],
-                prefill_query_lens_cpu,
-                self.max_prefill_buffer_size,
-                max_logits_bytes,
-                request_offset=num_decodes,
-            )
-
             chunks = []
-            for req_slice, query_slice in chunk_specs:
-                metadata = build_prefill_chunk_metadata(
-                    req_slice.start,
-                    req_slice.stop,
-                    query_start_loc,
+            paged_metadata = None
+            if self.use_paged_prefill:
+                # Paged prefill avoids the gathered-K workspace, so keep it as
+                # one full prefill span instead of applying flat chunk limits.
+                paged_metadata = build_paged_prefill_metadata(
+                    num_decodes,
+                    num_decodes + num_prefills,
                     query_start_loc_cpu,
-                    seq_lens,
-                    compressed_seq_lens,
+                    seq_lens_cpu,
                     compressed_seq_lens_cpu,
                     common_attn_metadata.block_table_tensor,
                     self.compress_ratio,
-                    query_slice=query_slice,
-                    skip_kv_gather=query_slice.start > 0,
+                    self.kv_cache_spec.storage_block_size,
+                    self.num_sms,
                 )
-                # Skip when total_seq_lens is 0 (i.e., no compressed token).
-                if metadata is not None:
-                    chunks.append(metadata)
-            prefill_metadata = DeepseekV32IndexerPrefillMetadata(chunks)
+            else:
+                prefill_query_lens_cpu = torch.diff(
+                    query_start_loc_cpu[num_decodes : num_decodes + num_prefills + 1]
+                )
+                max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
+                chunk_specs = split_indexer_prefill_chunks(
+                    compressed_seq_lens_cpu[num_decodes:],
+                    prefill_query_lens_cpu,
+                    self.max_prefill_buffer_size,
+                    max_logits_bytes,
+                    request_offset=num_decodes,
+                )
+
+                for req_slice, query_slice in chunk_specs:
+                    metadata = build_prefill_chunk_metadata(
+                        req_slice.start,
+                        req_slice.stop,
+                        query_start_loc,
+                        query_start_loc_cpu,
+                        seq_lens,
+                        compressed_seq_lens,
+                        compressed_seq_lens_cpu,
+                        common_attn_metadata.block_table_tensor,
+                        self.compress_ratio,
+                        query_slice=query_slice,
+                        skip_kv_gather=query_slice.start > 0,
+                    )
+                    # Skip when total_seq_lens is 0 (i.e., no compressed token).
+                    if metadata is not None:
+                        chunks.append(metadata)
+            prefill_metadata = DeepseekV32IndexerPrefillMetadata(
+                chunks=chunks,
+                paged_metadata=paged_metadata,
+            )
 
         decode_metadata = None
         if num_decodes > 0:
@@ -717,6 +751,63 @@ def build_prefill_chunk_metadata(
         token_end=token_end,
         num_reqs=num_reqs,
         skip_kv_gather=skip_kv_gather,
+    )
+
+
+def build_paged_prefill_metadata(
+    start_idx: int,
+    end_idx: int,
+    query_start_loc_cpu: torch.Tensor,
+    seq_lens_cpu: torch.Tensor,
+    compressed_seq_lens_cpu: torch.Tensor,
+    block_table: torch.Tensor,
+    compress_ratio: int,
+    block_size: int,
+    num_sms: int,
+) -> DeepseekV32IndexerPagedPrefillMetadata | None:
+    if int(compressed_seq_lens_cpu[start_idx:end_idx].sum().item()) == 0:
+        return None
+
+    # DeepGEMM varlen paged logits consumes per-query-token request ids and
+    # context lengths, unlike flat prefill which consumes per-row K offsets.
+    query_start_locs = query_start_loc_cpu[start_idx : end_idx + 1].to(torch.long)
+    total_query_len = int((query_start_locs[-1] - query_start_locs[0]).item())
+
+    req_ids = torch.arange(start_idx, end_idx, dtype=torch.long, device="cpu")
+    query_lens = torch.diff(query_start_locs)
+    req_idx = torch.repeat_interleave(req_ids, query_lens, output_size=total_query_len)
+    token_idx = torch.arange(total_query_len, dtype=torch.long, device="cpu")
+    query_offsets = token_idx - (
+        query_start_loc_cpu[req_idx].to(torch.long) - query_start_locs[0]
+    )
+    req_query_lens = (
+        query_start_loc_cpu[req_idx + 1] - query_start_loc_cpu[req_idx]
+    ).to(torch.long)
+    context_lens = (
+        seq_lens_cpu[req_idx].to(torch.long) - req_query_lens + query_offsets + 1
+    ) // compress_ratio
+
+    device = block_table.device
+    req_idx_device = req_idx.to(device=device)
+    indices = req_idx_device.to(torch.int32)
+    context_lens = context_lens.to(device=device, dtype=torch.int32).view(-1, 1)
+    schedule_metadata = get_paged_mqa_logits_metadata(
+        context_lens,
+        block_size,
+        num_sms,
+        indices=indices,
+    )
+    token_start = int(query_start_loc_cpu[start_idx].item())
+    token_end = token_start + total_query_len
+
+    return DeepseekV32IndexerPagedPrefillMetadata(
+        token_start=token_start,
+        token_end=token_end,
+        context_lens=context_lens,
+        indices=indices,
+        block_table=block_table[req_idx_device],
+        schedule_metadata=schedule_metadata,
+        max_context_len=int(compressed_seq_lens_cpu[start_idx:end_idx].max().item()),
     )
 
 

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -115,6 +115,62 @@ def split_indexer_prefill_chunks(
     return chunks
 
 
+def split_indexer_paged_prefill_chunks(
+    compressed_seq_lens_cpu: torch.Tensor,
+    query_lens_cpu: torch.Tensor,
+    max_logits_bytes: int,
+    request_offset: int = 0,
+) -> list[tuple[slice, slice]]:
+    """
+    Split paged prefill requests into chunks for the sparse indexer, respecting:
+    - DeepGEMM metadata constraint: total query tokens <= 2048
+    - Logits constraint: M * max_context_len * 4 <= max_logits_bytes
+
+    Returns list of (req_slice, query_slice) tuples.
+    """
+    chunks: list[tuple[slice, slice]] = []
+    n = len(query_lens_cpu)
+    max_logits_elems = max_logits_bytes // 4
+    end = 0
+
+    while end < n:
+        start, chunk_m, chunk_max_context_len = end, 0, 0
+
+        while end < n:
+            q = query_lens_cpu[end].item()
+            max_context_len = compressed_seq_lens_cpu[end].item()
+            new_m = chunk_m + q
+            new_max_context_len = max(chunk_max_context_len, max_context_len)
+            if new_m <= 2048 and new_m * new_max_context_len <= max_logits_elems:
+                chunk_m = new_m
+                chunk_max_context_len = new_max_context_len
+                end += 1
+            else:
+                break
+
+        # A single request can exceed either the metadata bound or the logits
+        # budget, requiring sub-chunking on the query dimension.
+        if end == start:
+            chunk_m = query_lens_cpu[end].item()
+            chunk_max_context_len = compressed_seq_lens_cpu[end].item()
+            end += 1
+
+        req_slice = slice(start + request_offset, end + request_offset)
+        max_q_by_logits = (
+            max(1, max_logits_elems // chunk_max_context_len)
+            if chunk_max_context_len > 0
+            else chunk_m
+        )
+        # DeepGEMM's paged metadata JIT kernel uses static shared memory
+        # proportional to the metadata batch size, so bound query rows per call.
+        max_q = max(1, min(2048, max_q_by_logits))
+        for q_off in range(0, chunk_m, max_q):
+            sub_m = min(max_q, chunk_m - q_off)
+            chunks.append((req_slice, slice(q_off, q_off + sub_m)))
+
+    return chunks
+
+
 class DeepseekV32IndexerBackend(AttentionBackend):
     @staticmethod
     def get_name() -> str:
@@ -192,10 +248,8 @@ class DeepseekV32IndexerPagedPrefillMetadata:
 
 @dataclass
 class DeepseekV32IndexerPrefillMetadata:
-    # Flat prefill uses one or more gathered-K chunks. SM100 paged prefill uses
-    # one full-span metadata object and reads K directly from the paged KV cache.
     chunks: list[DeepseekV32IndexerPrefillChunkMetadata]
-    paged_metadata: DeepseekV32IndexerPagedPrefillMetadata | None = None
+    paged_chunks: list[DeepseekV32IndexerPagedPrefillMetadata]
 
 
 @dataclass
@@ -537,27 +591,38 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 else seq_lens_cpu
             )
             chunks = []
-            paged_metadata = None
+            paged_chunks = []
+            prefill_query_lens_cpu = torch.diff(
+                query_start_loc_cpu[num_decodes : num_decodes + num_prefills + 1]
+            )
+            max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
             if self.use_paged_prefill:
-                # Paged prefill avoids the gathered-K workspace, so keep it as
-                # one full prefill span instead of applying flat chunk limits.
-                # The materialized logits are still O(tokens * context).
-                paged_metadata = build_paged_prefill_metadata(
-                    num_decodes,
-                    num_decodes + num_prefills,
-                    query_start_loc_cpu,
-                    seq_lens_cpu,
-                    compressed_seq_lens_cpu,
-                    common_attn_metadata.block_table_tensor,
-                    self.compress_ratio,
-                    self.kv_cache_spec.storage_block_size,
-                    self.num_sms,
+                # This is a DeepGEMM metadata-kernel safety bound, not a
+                # gathered-K workspace bound.
+                chunk_specs = split_indexer_paged_prefill_chunks(
+                    compressed_seq_lens_cpu[num_decodes:],
+                    prefill_query_lens_cpu,
+                    max_logits_bytes,
+                    request_offset=num_decodes,
                 )
+
+                for req_slice, query_slice in chunk_specs:
+                    paged_metadata = build_paged_prefill_metadata(
+                        req_slice.start,
+                        req_slice.stop,
+                        query_start_loc_cpu,
+                        seq_lens_cpu,
+                        compressed_seq_lens_cpu,
+                        common_attn_metadata.block_table_tensor,
+                        self.compress_ratio,
+                        self.kv_cache_spec.storage_block_size,
+                        self.num_sms,
+                        query_slice=query_slice,
+                    )
+                    # Skip when the chunk has no compressed KV tokens.
+                    if paged_metadata is not None:
+                        paged_chunks.append(paged_metadata)
             else:
-                prefill_query_lens_cpu = torch.diff(
-                    query_start_loc_cpu[num_decodes : num_decodes + num_prefills + 1]
-                )
-                max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
                 chunk_specs = split_indexer_prefill_chunks(
                     compressed_seq_lens_cpu[num_decodes:],
                     prefill_query_lens_cpu,
@@ -585,7 +650,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                         chunks.append(metadata)
             prefill_metadata = DeepseekV32IndexerPrefillMetadata(
                 chunks=chunks,
-                paged_metadata=paged_metadata,
+                paged_chunks=paged_chunks,
             )
 
         decode_metadata = None
@@ -765,19 +830,35 @@ def build_paged_prefill_metadata(
     compress_ratio: int,
     block_size: int,
     num_sms: int,
+    query_slice: slice | None = None,
 ) -> DeepseekV32IndexerPagedPrefillMetadata | None:
-    if int(compressed_seq_lens_cpu[start_idx:end_idx].sum().item()) == 0:
-        return None
-
     # DeepGEMM varlen paged logits consumes per-query-token request ids and
     # context lengths, unlike flat prefill which consumes per-row K offsets.
     query_start_locs = query_start_loc_cpu[start_idx : end_idx + 1].to(torch.long)
     total_query_len = int((query_start_locs[-1] - query_start_locs[0]).item())
+    if query_slice is not None:
+        qs_start = query_slice.start
+        qs_stop = query_slice.stop
+    else:
+        qs_start = 0
+        qs_stop = total_query_len
+    assert qs_start is not None
+    assert qs_stop is not None
+    output_query_len = qs_stop - qs_start
+    if output_query_len <= 0:
+        return None
 
     req_ids = torch.arange(start_idx, end_idx, dtype=torch.long, device="cpu")
     query_lens = torch.diff(query_start_locs)
-    req_idx = torch.repeat_interleave(req_ids, query_lens, output_size=total_query_len)
-    token_idx = torch.arange(total_query_len, dtype=torch.long, device="cpu")
+    req_idx = torch.repeat_interleave(req_ids, query_lens, output_size=total_query_len)[
+        qs_start:qs_stop
+    ]
+    selected_compressed_seq_lens = compressed_seq_lens_cpu[req_idx]
+    max_context_len = int(selected_compressed_seq_lens.max().item())
+    if max_context_len == 0:
+        return None
+
+    token_idx = torch.arange(qs_start, qs_stop, dtype=torch.long, device="cpu")
     query_offsets = token_idx - (
         query_start_loc_cpu[req_idx].to(torch.long) - query_start_locs[0]
     )
@@ -798,8 +879,8 @@ def build_paged_prefill_metadata(
         num_sms,
         indices=indices,
     )
-    token_start = int(query_start_loc_cpu[start_idx].item())
-    token_end = token_start + total_query_len
+    token_start = int(query_start_loc_cpu[start_idx].item()) + qs_start
+    token_end = token_start + output_query_len
 
     return DeepseekV32IndexerPagedPrefillMetadata(
         token_start=token_start,
@@ -808,7 +889,7 @@ def build_paged_prefill_metadata(
         indices=indices,
         block_table=block_table[req_idx_device],
         schedule_metadata=schedule_metadata,
-        max_context_len=int(compressed_seq_lens_cpu[start_idx:end_idx].max().item()),
+        max_context_len=max_context_len,
     )
 
 

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -32,6 +32,14 @@ from vllm.v1.worker.cp_utils import get_total_cp_world_size
 logger = init_logger(__name__)
 
 
+def sparse_indexer_paged_prefill_supported() -> bool:
+    return (
+        current_platform.is_cuda()
+        and current_platform.is_device_capability_family(100)
+        and has_deep_gemm()
+    )
+
+
 @triton.jit
 def _prepare_uniform_decode_kernel(
     seq_lens_ptr,
@@ -108,62 +116,6 @@ def split_indexer_prefill_chunks(
 
         req_slice = slice(start + request_offset, end + request_offset)
         max_q = max(1, max_logits_elems // chunk_n) if chunk_n > 0 else chunk_m
-        for q_off in range(0, chunk_m, max_q):
-            sub_m = min(max_q, chunk_m - q_off)
-            chunks.append((req_slice, slice(q_off, q_off + sub_m)))
-
-    return chunks
-
-
-def split_indexer_paged_prefill_chunks(
-    compressed_seq_lens_cpu: torch.Tensor,
-    query_lens_cpu: torch.Tensor,
-    max_logits_bytes: int,
-    request_offset: int = 0,
-) -> list[tuple[slice, slice]]:
-    """
-    Split paged prefill requests into chunks for the sparse indexer, respecting:
-    - DeepGEMM metadata constraint: total query tokens <= 2048
-    - Logits constraint: M * max_context_len * 4 <= max_logits_bytes
-
-    Returns list of (req_slice, query_slice) tuples.
-    """
-    chunks: list[tuple[slice, slice]] = []
-    n = len(query_lens_cpu)
-    max_logits_elems = max_logits_bytes // 4
-    end = 0
-
-    while end < n:
-        start, chunk_m, chunk_max_context_len = end, 0, 0
-
-        while end < n:
-            q = query_lens_cpu[end].item()
-            max_context_len = compressed_seq_lens_cpu[end].item()
-            new_m = chunk_m + q
-            new_max_context_len = max(chunk_max_context_len, max_context_len)
-            if new_m <= 2048 and new_m * new_max_context_len <= max_logits_elems:
-                chunk_m = new_m
-                chunk_max_context_len = new_max_context_len
-                end += 1
-            else:
-                break
-
-        # A single request can exceed either the metadata bound or the logits
-        # budget, requiring sub-chunking on the query dimension.
-        if end == start:
-            chunk_m = query_lens_cpu[end].item()
-            chunk_max_context_len = compressed_seq_lens_cpu[end].item()
-            end += 1
-
-        req_slice = slice(start + request_offset, end + request_offset)
-        max_q_by_logits = (
-            max(1, max_logits_elems // chunk_max_context_len)
-            if chunk_max_context_len > 0
-            else chunk_m
-        )
-        # DeepGEMM's paged metadata JIT kernel uses static shared memory
-        # proportional to the metadata batch size, so bound query rows per call.
-        max_q = max(1, min(2048, max_q_by_logits))
         for q_off in range(0, chunk_m, max_q):
             sub_m = min(max_q, chunk_m - q_off)
             chunks.append((req_slice, slice(q_off, q_off + sub_m)))
@@ -249,8 +201,7 @@ class DeepseekV32IndexerPagedPrefillMetadata:
 @dataclass
 class DeepseekV32IndexerPrefillMetadata:
     chunks: list[DeepseekV32IndexerPrefillChunkMetadata]
-    paged_chunks: list[DeepseekV32IndexerPagedPrefillMetadata]
-    full_paged_metadata: DeepseekV32IndexerPagedPrefillMetadata | None = None
+    paged_metadata: DeepseekV32IndexerPagedPrefillMetadata | None = None
 
 
 @dataclass
@@ -346,10 +297,16 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             or not current_platform.is_device_capability_family(100)
         ) and next_n not in self.natively_supported_next_n_fp4
         self.use_paged_prefill = (
-            current_platform.is_cuda()
-            and current_platform.is_device_capability_family(100)
-            and has_deep_gemm()
+            self.vllm_config.attention_config.enable_sparse_indexer_paged_prefill
+            and sparse_indexer_paged_prefill_supported()
         )
+        if self.use_paged_prefill:
+            logger.warning_once(
+                "Sparse-indexer paged prefill is enabled. "
+                "VLLM_SPARSE_INDEXER_MAX_LOGITS_MB is not respected by this "
+                "path because it materializes logits for the full paged "
+                "prefill batch."
+            )
 
         sm_count = num_compute_units(self.device.index)
         self.num_sms = sm_count
@@ -592,57 +549,32 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                 else seq_lens_cpu
             )
             chunks = []
-            paged_chunks = []
-            full_paged_metadata = None
+            paged_metadata = None
             prefill_query_lens_cpu = torch.diff(
                 query_start_loc_cpu[num_decodes : num_decodes + num_prefills + 1]
             )
-            max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
             if self.use_paged_prefill:
-                if envs.VLLM_SPARSE_INDEXER_DISABLE_PAGED_PREFILL_CHUNKING:
-                    # Experimental path: build the full DeepGEMM schedule in
-                    # PyTorch so large metadata batches do not JIT a
-                    # shared-memory-heavy metadata kernel.
-                    full_paged_metadata = build_full_paged_prefill_metadata(
-                        num_decodes,
-                        num_decodes + num_prefills,
-                        query_start_loc,
-                        query_start_loc_cpu,
-                        seq_lens,
-                        compressed_seq_lens_cpu,
-                        common_attn_metadata.block_table_tensor,
-                        self.compress_ratio,
-                        self.kv_cache_spec.storage_block_size,
-                        self.num_sms,
-                    )
-                else:
-                    # This is a DeepGEMM metadata-kernel safety bound, not a
-                    # gathered-K workspace bound.
-                    chunk_specs = split_indexer_paged_prefill_chunks(
-                        compressed_seq_lens_cpu[num_decodes:],
-                        prefill_query_lens_cpu,
-                        max_logits_bytes,
-                        request_offset=num_decodes,
-                    )
-
-                    for req_slice, query_slice in chunk_specs:
-                        paged_metadata = build_paged_prefill_metadata(
-                            req_slice.start,
-                            req_slice.stop,
-                            query_start_loc,
-                            query_start_loc_cpu,
-                            seq_lens,
-                            compressed_seq_lens_cpu,
-                            common_attn_metadata.block_table_tensor,
-                            self.compress_ratio,
-                            self.kv_cache_spec.storage_block_size,
-                            self.num_sms,
-                            query_slice=query_slice,
-                        )
-                        # Skip when the chunk has no compressed KV tokens.
-                        if paged_metadata is not None:
-                            paged_chunks.append(paged_metadata)
+                # Experimental path: build the full DeepGEMM schedule in
+                # PyTorch so large metadata batches do not JIT a
+                # shared-memory-heavy metadata kernel. This custom metadata
+                # construction bypasses DeepGEMM's metadata kernel and must be
+                # kept in sync with DeepGEMM scheduler metadata layout or atom
+                # assignment changes. See:
+                # https://github.com/deepseek-ai/DeepGEMM/issues/322
+                paged_metadata = build_full_paged_prefill_metadata(
+                    num_decodes,
+                    num_decodes + num_prefills,
+                    query_start_loc,
+                    query_start_loc_cpu,
+                    seq_lens,
+                    compressed_seq_lens_cpu,
+                    common_attn_metadata.block_table_tensor,
+                    self.compress_ratio,
+                    self.kv_cache_spec.storage_block_size,
+                    self.num_sms,
+                )
             else:
+                max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
                 chunk_specs = split_indexer_prefill_chunks(
                     compressed_seq_lens_cpu[num_decodes:],
                     prefill_query_lens_cpu,
@@ -670,8 +602,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                         chunks.append(metadata)
             prefill_metadata = DeepseekV32IndexerPrefillMetadata(
                 chunks=chunks,
-                paged_chunks=paged_chunks,
-                full_paged_metadata=full_paged_metadata,
+                paged_metadata=paged_metadata,
             )
 
         decode_metadata = None
@@ -838,75 +769,6 @@ def build_prefill_chunk_metadata(
         token_end=token_end,
         num_reqs=num_reqs,
         skip_kv_gather=skip_kv_gather,
-    )
-
-
-def build_paged_prefill_metadata(
-    start_idx: int,
-    end_idx: int,
-    query_start_loc: torch.Tensor,
-    query_start_loc_cpu: torch.Tensor,
-    seq_lens: torch.Tensor,
-    compressed_seq_lens_cpu: torch.Tensor,
-    block_table: torch.Tensor,
-    compress_ratio: int,
-    block_size: int,
-    num_sms: int,
-    query_slice: slice | None = None,
-) -> DeepseekV32IndexerPagedPrefillMetadata | None:
-    # DeepGEMM varlen paged logits consumes per-query-token request ids and
-    # context lengths, unlike flat prefill which consumes per-row K offsets.
-    total_query_len = (
-        query_start_loc_cpu[end_idx].item() - query_start_loc_cpu[start_idx].item()
-    )
-    if query_slice is not None:
-        qs_start = query_slice.start
-        qs_stop = query_slice.stop
-    else:
-        qs_start = 0
-        qs_stop = total_query_len
-    assert qs_start is not None
-    assert qs_stop is not None
-    output_query_len = qs_stop - qs_start
-    if output_query_len <= 0:
-        return None
-
-    device = seq_lens.device
-    req_ids = torch.arange(start_idx, end_idx, dtype=torch.long, device=device)
-    query_lens = query_start_loc[start_idx : end_idx + 1].diff()
-    req_idx = torch.repeat_interleave(req_ids, query_lens, output_size=total_query_len)[
-        qs_start:qs_stop
-    ]
-    max_context_len = int(compressed_seq_lens_cpu[start_idx:end_idx].max().item())
-    if max_context_len == 0:
-        return None
-
-    token_idx = torch.arange(qs_start, qs_stop, dtype=torch.long, device=device)
-    query_offsets = token_idx - (query_start_loc[req_idx] - query_start_loc[start_idx])
-    req_query_lens = query_start_loc[req_idx + 1] - query_start_loc[req_idx]
-    context_lens = (
-        seq_lens[req_idx] - req_query_lens + query_offsets + 1
-    ) // compress_ratio
-
-    indices = req_idx.to(torch.int32)
-    context_lens = context_lens.to(torch.int32).view(-1, 1)
-    schedule_metadata = get_paged_mqa_logits_metadata(
-        context_lens,
-        block_size,
-        num_sms,
-        indices=indices,
-    )
-    token_start = int(query_start_loc_cpu[start_idx].item()) + qs_start
-    token_end = token_start + output_query_len
-
-    return DeepseekV32IndexerPagedPrefillMetadata(
-        token_start=token_start,
-        token_end=token_end,
-        context_lens=context_lens,
-        indices=indices,
-        block_table=block_table[req_idx],
-        schedule_metadata=schedule_metadata,
-        max_context_len=max_context_len,
     )
 
 

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -871,40 +871,54 @@ def build_paged_prefill_metadata(
     if output_query_len <= 0:
         return None
 
-    device = seq_lens.device
-    req_ids = torch.arange(start_idx, end_idx, dtype=torch.long, device=device)
-    query_lens = query_start_loc[start_idx : end_idx + 1].diff()
-    req_idx = torch.repeat_interleave(req_ids, query_lens, output_size=total_query_len)[
-        qs_start:qs_stop
-    ]
-    max_context_len = compressed_seq_lens_cpu[start_idx:end_idx].max().item()
+    max_context_len = int(compressed_seq_lens_cpu[start_idx:end_idx].max().item())
     if max_context_len == 0:
         return None
 
-    token_idx = torch.arange(qs_start, qs_stop, dtype=torch.long, device=device)
-    query_offsets = token_idx - (query_start_loc[req_idx] - query_start_loc[start_idx])
-    req_query_lens = query_start_loc[req_idx + 1] - query_start_loc[req_idx]
-    context_lens = (
-        seq_lens[req_idx] - req_query_lens + query_offsets + 1
-    ) // compress_ratio
+    token_start = int(query_start_loc_cpu[start_idx].item()) + qs_start
+    token_end = token_start + output_query_len
+    device = seq_lens.device
+    block_table_cols = block_table.shape[1]
+    context_lens = torch.empty((output_query_len, 1), dtype=torch.int32, device=device)
+    indices = torch.empty(output_query_len, dtype=torch.int32, device=device)
+    expanded_block_table = torch.empty(
+        (output_query_len, block_table_cols),
+        dtype=block_table.dtype,
+        device=device,
+    )
 
-    indices = req_idx.to(torch.int32)
-    context_lens = context_lens.to(torch.int32).view(-1, 1)
+    _build_paged_prefill_metadata_kernel[
+        (cdiv(output_query_len * block_table_cols, 1024),)
+    ](
+        query_start_loc,
+        seq_lens,
+        block_table,
+        context_lens,
+        indices,
+        expanded_block_table,
+        token_start,
+        output_query_len,
+        start_idx,
+        end_idx,
+        BLOCK_TABLE_STRIDE=block_table.stride(0),
+        BLOCK_TABLE_COLS=block_table_cols,
+        BLOCK_SIZE=1024,
+        REQ_SEARCH_STEPS=(end_idx - start_idx).bit_length(),
+        COMPRESS_RATIO=compress_ratio,
+    )
     schedule_metadata = get_paged_mqa_logits_metadata(
         context_lens,
         block_size,
         num_sms,
         indices=indices,
     )
-    token_start = query_start_loc_cpu[start_idx].item() + qs_start
-    token_end = token_start + output_query_len
 
     return DeepseekV32IndexerPagedPrefillMetadata(
         token_start=token_start,
         token_end=token_end,
         context_lens=context_lens,
         indices=indices,
-        block_table=block_table[req_idx],
+        block_table=expanded_block_table,
         schedule_metadata=schedule_metadata,
         max_context_len=max_context_len,
     )
@@ -934,91 +948,185 @@ def build_full_paged_prefill_metadata(
 
     token_start = int(query_start_loc_cpu[start_idx].item())
     token_end = int(query_start_loc_cpu[end_idx].item())
-    query_lens_cpu = torch.diff(query_start_loc_cpu[start_idx : end_idx + 1])
-    total_atoms = int(((query_lens_cpu + 1) // 2).sum().item())
 
     device = seq_lens.device
-    req_ids = torch.arange(start_idx, end_idx, dtype=torch.long, device=device)
-    query_lens = query_start_loc[start_idx : end_idx + 1].diff()
-    req_idx = torch.repeat_interleave(req_ids, query_lens, output_size=total_query_len)
-    token_idx = torch.arange(total_query_len, dtype=torch.long, device=device)
-    query_offsets = token_idx - (query_start_loc[req_idx] - token_start)
-    req_query_lens = query_start_loc[req_idx + 1] - query_start_loc[req_idx]
-    context_lens = (
-        seq_lens[req_idx] - req_query_lens + query_offsets + 1
-    ) // compress_ratio
-
-    indices = req_idx.to(torch.int32)
-    split_kv = 256
-    context_lens = context_lens.to(torch.int32).view(-1, 1)
-    batch_size = context_lens.shape[0]
-
-    # Varlen paged logits groups adjacent tokens from the same request into
-    # one scheduler atom. Full prefill preserves those request runs, so build
-    # atom starts from query_lens instead of scanning the per-token indices.
-    atoms_per_req = torch.div(query_lens + 1, 2, rounding_mode="floor")
-    atom_req_idx = torch.repeat_interleave(
-        req_ids,
-        atoms_per_req,
-        output_size=total_atoms,
-    )
-
-    atom_start_locs = torch.empty(
-        end_idx - start_idx + 1,
-        dtype=torch.long,
+    block_table_cols = block_table.shape[1]
+    context_lens = torch.empty((total_query_len, 1), dtype=torch.int32, device=device)
+    indices = torch.empty(total_query_len, dtype=torch.int32, device=device)
+    expanded_block_table = torch.empty(
+        (total_query_len, block_table_cols),
+        dtype=block_table.dtype,
         device=device,
     )
-    atom_start_locs[:1] = 0
-    atom_start_locs[1:] = torch.cumsum(atoms_per_req.to(torch.long), dim=0)
+    schedule_metadata = torch.empty((num_sms + 1, 2), dtype=torch.int32, device=device)
 
-    atom_local_req_idx = atom_req_idx - start_idx
-    atom_positions = torch.arange(total_atoms, dtype=torch.long, device=device)
-    atom_offsets = (atom_positions - atom_start_locs[atom_local_req_idx]) * 2
-    atom_req_query_lens = query_lens[atom_local_req_idx].to(torch.long)
-    atom_context_offsets = torch.minimum(
-        atom_offsets + 1,
-        atom_req_query_lens - 1,
+    _build_paged_prefill_metadata_kernel[
+        (cdiv(total_query_len * block_table_cols, 1024),)
+    ](
+        query_start_loc,
+        seq_lens,
+        block_table,
+        context_lens,
+        indices,
+        expanded_block_table,
+        token_start,
+        total_query_len,
+        start_idx,
+        end_idx,
+        BLOCK_TABLE_STRIDE=block_table.stride(0),
+        BLOCK_TABLE_COLS=block_table_cols,
+        BLOCK_SIZE=1024,
+        REQ_SEARCH_STEPS=(end_idx - start_idx).bit_length(),
+        COMPRESS_RATIO=compress_ratio,
     )
-    atom_context_lens = (
-        seq_lens[atom_req_idx].to(torch.long)
-        - atom_req_query_lens
-        + atom_context_offsets
-        + 1
-    ) // compress_ratio
-    atom_starts = query_start_loc[atom_req_idx].to(torch.long) - token_start
-    atom_starts = atom_starts + atom_offsets
-
-    num_segs = torch.div(
-        atom_context_lens + split_kv - 1, split_kv, rounding_mode="floor"
+    # Build the varlen schedule directly from request/query metadata so the
+    # full path does not materialize per-atom PyTorch temporaries.
+    _build_full_paged_prefill_schedule_metadata_kernel[(num_sms + 1,)](
+        query_start_loc,
+        seq_lens,
+        schedule_metadata,
+        token_start,
+        start_idx,
+        end_idx,
+        total_query_len,
+        NUM_SMS=num_sms,
+        COMPRESS_RATIO=compress_ratio,
+        SPLIT_KV=256,
     )
-    prefix_sum = torch.cumsum(num_segs, dim=0)
-    prefix_sum_with_zero = torch.cat((prefix_sum[:1] * 0, prefix_sum))
-
-    total = prefix_sum[-1]
-    sm_indices = torch.arange(num_sms + 1, dtype=torch.int64, device=device)
-    q = total // num_sms
-    r = total % num_sms
-    seg_starts = sm_indices * q + torch.minimum(sm_indices, r)
-
-    atom_idx = torch.searchsorted(prefix_sum, seg_starts, right=True)
-    kv_split_idx = seg_starts - prefix_sum_with_zero[atom_idx]
-    clamped_atom_idx = atom_idx.clamp(max=atom_starts.shape[0] - 1)
-    q_atom_idx = torch.where(
-        atom_idx < atom_starts.shape[0],
-        atom_starts[clamped_atom_idx],
-        torch.full_like(atom_idx, batch_size),
-    )
-    schedule_metadata = torch.stack((q_atom_idx, kv_split_idx), dim=1).to(torch.int32)
 
     return DeepseekV32IndexerPagedPrefillMetadata(
         token_start=token_start,
         token_end=token_end,
         context_lens=context_lens,
         indices=indices,
-        block_table=block_table[req_idx],
+        block_table=expanded_block_table,
         schedule_metadata=schedule_metadata,
         max_context_len=max_context_len,
     )
+
+
+@triton.jit
+def _build_paged_prefill_metadata_kernel(
+    # Inputs
+    query_start_loc_ptr,
+    seq_lens_ptr,
+    block_table_ptr,
+    # Outputs
+    context_lens_ptr,
+    indices_ptr,
+    expanded_block_table_ptr,
+    token_start,
+    output_query_len,
+    start_idx,
+    end_idx,
+    BLOCK_TABLE_STRIDE: tl.constexpr,
+    BLOCK_TABLE_COLS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    REQ_SEARCH_STEPS: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    num_items = output_query_len * BLOCK_TABLE_COLS
+    mask = offsets < num_items
+
+    out_rows = offsets // BLOCK_TABLE_COLS
+    block_cols = offsets - out_rows * BLOCK_TABLE_COLS
+    query_pos = token_start + out_rows
+
+    lo = tl.full((BLOCK_SIZE,), 0, tl.int64) + start_idx
+    hi = tl.full((BLOCK_SIZE,), 0, tl.int64) + end_idx
+    for _ in tl.static_range(0, REQ_SEARCH_STEPS):
+        mid = (lo + hi) // 2
+        mid_start = tl.load(query_start_loc_ptr + mid)
+        pred = mid_start <= query_pos
+        lo = tl.where(pred, mid, lo)
+        hi = tl.where(pred, hi, mid)
+    req_idx = lo
+
+    query_start = tl.load(query_start_loc_ptr + req_idx)
+    query_end = tl.load(query_start_loc_ptr + req_idx + 1)
+    query_len = query_end - query_start
+    query_offsets = query_pos - query_start
+
+    block_values = tl.load(
+        block_table_ptr + req_idx * BLOCK_TABLE_STRIDE + block_cols,
+        mask=mask,
+    )
+    tl.store(
+        expanded_block_table_ptr + out_rows * BLOCK_TABLE_COLS + block_cols,
+        block_values,
+        mask=mask,
+    )
+
+    row_mask = mask & (block_cols == 0)
+    seq_len = tl.load(seq_lens_ptr + req_idx)
+    context_lens = (seq_len - query_len + query_offsets + 1) // COMPRESS_RATIO
+    tl.store(context_lens_ptr + out_rows, context_lens, mask=row_mask)
+    tl.store(indices_ptr + out_rows, req_idx, mask=row_mask)
+
+
+@triton.jit
+def _build_full_paged_prefill_schedule_metadata_kernel(
+    query_start_loc_ptr,
+    seq_lens_ptr,
+    schedule_metadata_ptr,
+    token_start,
+    start_idx,
+    end_idx,
+    total_query_len,
+    NUM_SMS: tl.constexpr,
+    COMPRESS_RATIO: tl.constexpr,
+    SPLIT_KV: tl.constexpr,
+):
+    sm_idx = tl.program_id(0).to(tl.int64)
+
+    total = tl.full((), 0, tl.int64)
+    req_idx = start_idx
+    while req_idx < end_idx:
+        query_start = tl.load(query_start_loc_ptr + req_idx)
+        query_end = tl.load(query_start_loc_ptr + req_idx + 1)
+        query_len = query_end - query_start
+        seq_len = tl.load(seq_lens_ptr + req_idx)
+
+        query_offset = tl.full((), 0, tl.int64)
+        while query_offset < query_len:
+            context_offset = tl.minimum(query_offset + 1, query_len - 1)
+            context_len = (seq_len - query_len + context_offset + 1) // COMPRESS_RATIO
+            total += (context_len + SPLIT_KV - 1) // SPLIT_KV
+            query_offset += 2
+        req_idx += 1
+
+    segs_per_sm = total // NUM_SMS
+    extra = total - segs_per_sm * NUM_SMS
+    seg_start = sm_idx * segs_per_sm + tl.minimum(sm_idx, extra)
+
+    prefix = tl.full((), 0, tl.int64)
+    out_q = tl.full((), 0, tl.int64) + total_query_len
+    out_kv = tl.full((), 0, tl.int64)
+    found = tl.full((), False, tl.int1)
+
+    req_idx = start_idx
+    while req_idx < end_idx:
+        query_start = tl.load(query_start_loc_ptr + req_idx)
+        query_end = tl.load(query_start_loc_ptr + req_idx + 1)
+        query_len = query_end - query_start
+        seq_len = tl.load(seq_lens_ptr + req_idx)
+
+        query_offset = tl.full((), 0, tl.int64)
+        while query_offset < query_len:
+            context_offset = tl.minimum(query_offset + 1, query_len - 1)
+            context_len = (seq_len - query_len + context_offset + 1) // COMPRESS_RATIO
+            num_segs = (context_len + SPLIT_KV - 1) // SPLIT_KV
+            is_target = (~found) & (prefix + num_segs > seg_start)
+            out_q = tl.where(is_target, query_start - token_start + query_offset, out_q)
+            out_kv = tl.where(is_target, seg_start - prefix, out_kv)
+            found = found | is_target
+            prefix += num_segs
+            query_offset += 2
+        req_idx += 1
+
+    tl.store(schedule_metadata_ptr + sm_idx * 2, out_q)
+    tl.store(schedule_metadata_ptr + sm_idx * 2 + 1, out_kv)
 
 
 @triton.jit

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -610,8 +610,9 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                     paged_metadata = build_paged_prefill_metadata(
                         req_slice.start,
                         req_slice.stop,
+                        query_start_loc,
                         query_start_loc_cpu,
-                        seq_lens_cpu,
+                        seq_lens,
                         compressed_seq_lens_cpu,
                         common_attn_metadata.block_table_tensor,
                         self.compress_ratio,
@@ -823,8 +824,9 @@ def build_prefill_chunk_metadata(
 def build_paged_prefill_metadata(
     start_idx: int,
     end_idx: int,
+    query_start_loc: torch.Tensor,
     query_start_loc_cpu: torch.Tensor,
-    seq_lens_cpu: torch.Tensor,
+    seq_lens: torch.Tensor,
     compressed_seq_lens_cpu: torch.Tensor,
     block_table: torch.Tensor,
     compress_ratio: int,
@@ -834,8 +836,9 @@ def build_paged_prefill_metadata(
 ) -> DeepseekV32IndexerPagedPrefillMetadata | None:
     # DeepGEMM varlen paged logits consumes per-query-token request ids and
     # context lengths, unlike flat prefill which consumes per-row K offsets.
-    query_start_locs = query_start_loc_cpu[start_idx : end_idx + 1].to(torch.long)
-    total_query_len = int((query_start_locs[-1] - query_start_locs[0]).item())
+    total_query_len = (
+        query_start_loc_cpu[end_idx].item() - query_start_loc_cpu[start_idx].item()
+    )
     if query_slice is not None:
         qs_start = query_slice.start
         qs_stop = query_slice.stop
@@ -848,38 +851,32 @@ def build_paged_prefill_metadata(
     if output_query_len <= 0:
         return None
 
-    req_ids = torch.arange(start_idx, end_idx, dtype=torch.long, device="cpu")
-    query_lens = torch.diff(query_start_locs)
+    device = seq_lens.device
+    req_ids = torch.arange(start_idx, end_idx, dtype=torch.long, device=device)
+    query_lens = query_start_loc[start_idx : end_idx + 1].diff()
     req_idx = torch.repeat_interleave(req_ids, query_lens, output_size=total_query_len)[
         qs_start:qs_stop
     ]
-    selected_compressed_seq_lens = compressed_seq_lens_cpu[req_idx]
-    max_context_len = int(selected_compressed_seq_lens.max().item())
+    max_context_len = compressed_seq_lens_cpu[start_idx:end_idx].max().item()
     if max_context_len == 0:
         return None
 
-    token_idx = torch.arange(qs_start, qs_stop, dtype=torch.long, device="cpu")
-    query_offsets = token_idx - (
-        query_start_loc_cpu[req_idx].to(torch.long) - query_start_locs[0]
-    )
-    req_query_lens = (
-        query_start_loc_cpu[req_idx + 1] - query_start_loc_cpu[req_idx]
-    ).to(torch.long)
+    token_idx = torch.arange(qs_start, qs_stop, dtype=torch.long, device=device)
+    query_offsets = token_idx - (query_start_loc[req_idx] - query_start_loc[start_idx])
+    req_query_lens = query_start_loc[req_idx + 1] - query_start_loc[req_idx]
     context_lens = (
-        seq_lens_cpu[req_idx].to(torch.long) - req_query_lens + query_offsets + 1
+        seq_lens[req_idx] - req_query_lens + query_offsets + 1
     ) // compress_ratio
 
-    device = block_table.device
-    req_idx_device = req_idx.to(device=device)
-    indices = req_idx_device.to(torch.int32)
-    context_lens = context_lens.to(device=device, dtype=torch.int32).view(-1, 1)
+    indices = req_idx.to(torch.int32)
+    context_lens = context_lens.to(torch.int32).view(-1, 1)
     schedule_metadata = get_paged_mqa_logits_metadata(
         context_lens,
         block_size,
         num_sms,
         indices=indices,
     )
-    token_start = int(query_start_loc_cpu[start_idx].item()) + qs_start
+    token_start = query_start_loc_cpu[start_idx].item() + qs_start
     token_end = token_start + output_query_len
 
     return DeepseekV32IndexerPagedPrefillMetadata(
@@ -887,7 +884,7 @@ def build_paged_prefill_metadata(
         token_end=token_end,
         context_lens=context_lens,
         indices=indices,
-        block_table=block_table[req_idx_device],
+        block_table=block_table[req_idx],
         schedule_metadata=schedule_metadata,
         max_context_len=max_context_len,
     )

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -871,59 +871,40 @@ def build_paged_prefill_metadata(
     if output_query_len <= 0:
         return None
 
+    device = seq_lens.device
+    req_ids = torch.arange(start_idx, end_idx, dtype=torch.long, device=device)
+    query_lens = query_start_loc[start_idx : end_idx + 1].diff()
+    req_idx = torch.repeat_interleave(req_ids, query_lens, output_size=total_query_len)[
+        qs_start:qs_stop
+    ]
     max_context_len = int(compressed_seq_lens_cpu[start_idx:end_idx].max().item())
     if max_context_len == 0:
         return None
 
-    token_start = int(query_start_loc_cpu[start_idx].item()) + qs_start
-    token_end = token_start + output_query_len
-    device = seq_lens.device
-    block_table_cols = block_table.shape[1]
-    context_lens = torch.empty((output_query_len, 1), dtype=torch.int32, device=device)
-    indices = torch.empty(output_query_len, dtype=torch.int32, device=device)
-    expanded_block_table = torch.empty(
-        (output_query_len, block_table_cols),
-        dtype=block_table.dtype,
-        device=device,
-    )
+    token_idx = torch.arange(qs_start, qs_stop, dtype=torch.long, device=device)
+    query_offsets = token_idx - (query_start_loc[req_idx] - query_start_loc[start_idx])
+    req_query_lens = query_start_loc[req_idx + 1] - query_start_loc[req_idx]
+    context_lens = (
+        seq_lens[req_idx] - req_query_lens + query_offsets + 1
+    ) // compress_ratio
 
-    _build_paged_prefill_row_metadata_kernel[(cdiv(output_query_len, 1024),)](
-        query_start_loc,
-        seq_lens,
-        context_lens,
-        indices,
-        token_start,
-        output_query_len,
-        start_idx,
-        end_idx,
-        BLOCK_SIZE=1024,
-        REQ_SEARCH_STEPS=(end_idx - start_idx).bit_length(),
-        COMPRESS_RATIO=compress_ratio,
-    )
-    _expand_paged_prefill_block_table_kernel[
-        (cdiv(output_query_len * block_table_cols, 1024),)
-    ](
-        block_table,
-        indices,
-        expanded_block_table,
-        output_query_len,
-        BLOCK_TABLE_STRIDE=block_table.stride(0),
-        BLOCK_TABLE_COLS=block_table_cols,
-        BLOCK_SIZE=1024,
-    )
+    indices = req_idx.to(torch.int32)
+    context_lens = context_lens.to(torch.int32).view(-1, 1)
     schedule_metadata = get_paged_mqa_logits_metadata(
         context_lens,
         block_size,
         num_sms,
         indices=indices,
     )
+    token_start = int(query_start_loc_cpu[start_idx].item()) + qs_start
+    token_end = token_start + output_query_len
 
     return DeepseekV32IndexerPagedPrefillMetadata(
         token_start=token_start,
         token_end=token_end,
         context_lens=context_lens,
         indices=indices,
-        block_table=expanded_block_table,
+        block_table=block_table[req_idx],
         schedule_metadata=schedule_metadata,
         max_context_len=max_context_len,
     )
@@ -953,197 +934,91 @@ def build_full_paged_prefill_metadata(
 
     token_start = int(query_start_loc_cpu[start_idx].item())
     token_end = int(query_start_loc_cpu[end_idx].item())
+    query_lens_cpu = torch.diff(query_start_loc_cpu[start_idx : end_idx + 1])
+    total_atoms = int(((query_lens_cpu + 1) // 2).sum().item())
 
     device = seq_lens.device
-    block_table_cols = block_table.shape[1]
-    context_lens = torch.empty((total_query_len, 1), dtype=torch.int32, device=device)
-    indices = torch.empty(total_query_len, dtype=torch.int32, device=device)
-    expanded_block_table = torch.empty(
-        (total_query_len, block_table_cols),
-        dtype=block_table.dtype,
+    req_ids = torch.arange(start_idx, end_idx, dtype=torch.long, device=device)
+    query_lens = query_start_loc[start_idx : end_idx + 1].diff()
+    req_idx = torch.repeat_interleave(req_ids, query_lens, output_size=total_query_len)
+    token_idx = torch.arange(total_query_len, dtype=torch.long, device=device)
+    query_offsets = token_idx - (query_start_loc[req_idx] - token_start)
+    req_query_lens = query_start_loc[req_idx + 1] - query_start_loc[req_idx]
+    context_lens = (
+        seq_lens[req_idx] - req_query_lens + query_offsets + 1
+    ) // compress_ratio
+
+    indices = req_idx.to(torch.int32)
+    split_kv = 256
+    context_lens = context_lens.to(torch.int32).view(-1, 1)
+    batch_size = context_lens.shape[0]
+
+    # Varlen paged logits groups adjacent tokens from the same request into
+    # one scheduler atom. Full prefill preserves those request runs, so build
+    # atom starts from query_lens instead of scanning the per-token indices.
+    atoms_per_req = torch.div(query_lens + 1, 2, rounding_mode="floor")
+    atom_req_idx = torch.repeat_interleave(
+        req_ids,
+        atoms_per_req,
+        output_size=total_atoms,
+    )
+
+    atom_start_locs = torch.empty(
+        end_idx - start_idx + 1,
+        dtype=torch.long,
         device=device,
     )
-    schedule_metadata = torch.empty((num_sms + 1, 2), dtype=torch.int32, device=device)
+    atom_start_locs[:1] = 0
+    atom_start_locs[1:] = torch.cumsum(atoms_per_req.to(torch.long), dim=0)
 
-    _build_paged_prefill_row_metadata_kernel[(cdiv(total_query_len, 1024),)](
-        query_start_loc,
-        seq_lens,
-        context_lens,
-        indices,
-        token_start,
-        total_query_len,
-        start_idx,
-        end_idx,
-        BLOCK_SIZE=1024,
-        REQ_SEARCH_STEPS=(end_idx - start_idx).bit_length(),
-        COMPRESS_RATIO=compress_ratio,
+    atom_local_req_idx = atom_req_idx - start_idx
+    atom_positions = torch.arange(total_atoms, dtype=torch.long, device=device)
+    atom_offsets = (atom_positions - atom_start_locs[atom_local_req_idx]) * 2
+    atom_req_query_lens = query_lens[atom_local_req_idx].to(torch.long)
+    atom_context_offsets = torch.minimum(
+        atom_offsets + 1,
+        atom_req_query_lens - 1,
     )
-    _expand_paged_prefill_block_table_kernel[
-        (cdiv(total_query_len * block_table_cols, 1024),)
-    ](
-        block_table,
-        indices,
-        expanded_block_table,
-        total_query_len,
-        BLOCK_TABLE_STRIDE=block_table.stride(0),
-        BLOCK_TABLE_COLS=block_table_cols,
-        BLOCK_SIZE=1024,
+    atom_context_lens = (
+        seq_lens[atom_req_idx].to(torch.long)
+        - atom_req_query_lens
+        + atom_context_offsets
+        + 1
+    ) // compress_ratio
+    atom_starts = query_start_loc[atom_req_idx].to(torch.long) - token_start
+    atom_starts = atom_starts + atom_offsets
+
+    num_segs = torch.div(
+        atom_context_lens + split_kv - 1, split_kv, rounding_mode="floor"
     )
-    # Build the varlen schedule directly from request/query metadata so the
-    # full path does not materialize per-atom PyTorch temporaries.
-    _build_full_paged_prefill_schedule_metadata_kernel[(num_sms + 1,)](
-        query_start_loc,
-        seq_lens,
-        schedule_metadata,
-        token_start,
-        start_idx,
-        end_idx,
-        total_query_len,
-        NUM_SMS=num_sms,
-        COMPRESS_RATIO=compress_ratio,
-        SPLIT_KV=256,
+    prefix_sum = torch.cumsum(num_segs, dim=0)
+    prefix_sum_with_zero = torch.cat((prefix_sum[:1] * 0, prefix_sum))
+
+    total = prefix_sum[-1]
+    sm_indices = torch.arange(num_sms + 1, dtype=torch.int64, device=device)
+    q = total // num_sms
+    r = total % num_sms
+    seg_starts = sm_indices * q + torch.minimum(sm_indices, r)
+
+    atom_idx = torch.searchsorted(prefix_sum, seg_starts, right=True)
+    kv_split_idx = seg_starts - prefix_sum_with_zero[atom_idx]
+    clamped_atom_idx = atom_idx.clamp(max=atom_starts.shape[0] - 1)
+    q_atom_idx = torch.where(
+        atom_idx < atom_starts.shape[0],
+        atom_starts[clamped_atom_idx],
+        torch.full_like(atom_idx, batch_size),
     )
+    schedule_metadata = torch.stack((q_atom_idx, kv_split_idx), dim=1).to(torch.int32)
 
     return DeepseekV32IndexerPagedPrefillMetadata(
         token_start=token_start,
         token_end=token_end,
         context_lens=context_lens,
         indices=indices,
-        block_table=expanded_block_table,
+        block_table=block_table[req_idx],
         schedule_metadata=schedule_metadata,
         max_context_len=max_context_len,
     )
-
-
-@triton.jit
-def _build_paged_prefill_row_metadata_kernel(
-    # Inputs
-    query_start_loc_ptr,
-    seq_lens_ptr,
-    # Outputs
-    context_lens_ptr,
-    indices_ptr,
-    token_start,
-    output_query_len,
-    start_idx,
-    end_idx,
-    BLOCK_SIZE: tl.constexpr,
-    REQ_SEARCH_STEPS: tl.constexpr,
-    COMPRESS_RATIO: tl.constexpr,
-):
-    out_rows = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask = out_rows < output_query_len
-    out_rows = tl.minimum(out_rows, output_query_len - 1)
-    query_pos = token_start + out_rows
-
-    lo = tl.full((BLOCK_SIZE,), 0, tl.int64) + start_idx
-    hi = tl.full((BLOCK_SIZE,), 0, tl.int64) + end_idx
-    for _ in tl.static_range(0, REQ_SEARCH_STEPS):
-        mid = (lo + hi) // 2
-        mid_start = tl.load(query_start_loc_ptr + mid)
-        pred = mid_start <= query_pos
-        lo = tl.where(pred, mid, lo)
-        hi = tl.where(pred, hi, mid)
-    req_idx = lo
-
-    query_start = tl.load(query_start_loc_ptr + req_idx)
-    query_end = tl.load(query_start_loc_ptr + req_idx + 1)
-    query_len = query_end - query_start
-    query_offsets = query_pos - query_start
-
-    seq_len = tl.load(seq_lens_ptr + req_idx)
-    context_lens = (seq_len - query_len + query_offsets + 1) // COMPRESS_RATIO
-    tl.store(context_lens_ptr + out_rows, context_lens, mask=mask)
-    tl.store(indices_ptr + out_rows, req_idx, mask=mask)
-
-
-@triton.jit
-def _expand_paged_prefill_block_table_kernel(
-    block_table_ptr,
-    indices_ptr,
-    expanded_block_table_ptr,
-    output_query_len,
-    BLOCK_TABLE_STRIDE: tl.constexpr,
-    BLOCK_TABLE_COLS: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-):
-    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    num_items = output_query_len * BLOCK_TABLE_COLS
-    mask = offsets < num_items
-
-    raw_rows = offsets // BLOCK_TABLE_COLS
-    out_rows = tl.minimum(raw_rows, output_query_len - 1)
-    block_cols = offsets - raw_rows * BLOCK_TABLE_COLS
-    req_idx = tl.load(indices_ptr + out_rows).to(tl.int64)
-    block_values = tl.load(
-        block_table_ptr + req_idx * BLOCK_TABLE_STRIDE + block_cols,
-        mask=mask,
-    )
-    tl.store(expanded_block_table_ptr + offsets, block_values, mask=mask)
-
-
-@triton.jit
-def _build_full_paged_prefill_schedule_metadata_kernel(
-    query_start_loc_ptr,
-    seq_lens_ptr,
-    schedule_metadata_ptr,
-    token_start,
-    start_idx,
-    end_idx,
-    total_query_len,
-    NUM_SMS: tl.constexpr,
-    COMPRESS_RATIO: tl.constexpr,
-    SPLIT_KV: tl.constexpr,
-):
-    sm_idx = tl.program_id(0).to(tl.int64)
-
-    total = tl.full((), 0, tl.int64)
-    req_idx = start_idx
-    while req_idx < end_idx:
-        query_start = tl.load(query_start_loc_ptr + req_idx)
-        query_end = tl.load(query_start_loc_ptr + req_idx + 1)
-        query_len = query_end - query_start
-        seq_len = tl.load(seq_lens_ptr + req_idx)
-
-        query_offset = tl.full((), 0, tl.int64)
-        while query_offset < query_len:
-            context_offset = tl.minimum(query_offset + 1, query_len - 1)
-            context_len = (seq_len - query_len + context_offset + 1) // COMPRESS_RATIO
-            total += (context_len + SPLIT_KV - 1) // SPLIT_KV
-            query_offset += 2
-        req_idx += 1
-
-    segs_per_sm = total // NUM_SMS
-    extra = total - segs_per_sm * NUM_SMS
-    seg_start = sm_idx * segs_per_sm + tl.minimum(sm_idx, extra)
-
-    prefix = tl.full((), 0, tl.int64)
-    out_q = tl.full((), 0, tl.int64) + total_query_len
-    out_kv = tl.full((), 0, tl.int64)
-    found = tl.full((), False, tl.int1)
-
-    req_idx = start_idx
-    while req_idx < end_idx:
-        query_start = tl.load(query_start_loc_ptr + req_idx)
-        query_end = tl.load(query_start_loc_ptr + req_idx + 1)
-        query_len = query_end - query_start
-        seq_len = tl.load(seq_lens_ptr + req_idx)
-
-        query_offset = tl.full((), 0, tl.int64)
-        while query_offset < query_len:
-            context_offset = tl.minimum(query_offset + 1, query_len - 1)
-            context_len = (seq_len - query_len + context_offset + 1) // COMPRESS_RATIO
-            num_segs = (context_len + SPLIT_KV - 1) // SPLIT_KV
-            is_target = (~found) & (prefix + num_segs > seg_start)
-            out_q = tl.where(is_target, query_start - token_start + query_offset, out_q)
-            out_kv = tl.where(is_target, seg_start - prefix, out_kv)
-            found = found | is_target
-            prefix += num_segs
-            query_offset += 2
-        req_idx += 1
-
-    tl.store(schedule_metadata_ptr + sm_idx * 2, out_q)
-    tl.store(schedule_metadata_ptr + sm_idx * 2 + 1, out_kv)
 
 
 @triton.jit

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -250,6 +250,7 @@ class DeepseekV32IndexerPagedPrefillMetadata:
 class DeepseekV32IndexerPrefillMetadata:
     chunks: list[DeepseekV32IndexerPrefillChunkMetadata]
     paged_chunks: list[DeepseekV32IndexerPagedPrefillMetadata]
+    full_paged_metadata: DeepseekV32IndexerPagedPrefillMetadata | None = None
 
 
 @dataclass
@@ -592,24 +593,19 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             )
             chunks = []
             paged_chunks = []
+            full_paged_metadata = None
             prefill_query_lens_cpu = torch.diff(
                 query_start_loc_cpu[num_decodes : num_decodes + num_prefills + 1]
             )
             max_logits_bytes = envs.VLLM_SPARSE_INDEXER_MAX_LOGITS_MB * 1024 * 1024
             if self.use_paged_prefill:
-                # This is a DeepGEMM metadata-kernel safety bound, not a
-                # gathered-K workspace bound.
-                chunk_specs = split_indexer_paged_prefill_chunks(
-                    compressed_seq_lens_cpu[num_decodes:],
-                    prefill_query_lens_cpu,
-                    max_logits_bytes,
-                    request_offset=num_decodes,
-                )
-
-                for req_slice, query_slice in chunk_specs:
-                    paged_metadata = build_paged_prefill_metadata(
-                        req_slice.start,
-                        req_slice.stop,
+                if envs.VLLM_SPARSE_INDEXER_DISABLE_PAGED_PREFILL_CHUNKING:
+                    # Experimental path: build the full DeepGEMM schedule in
+                    # PyTorch so large metadata batches do not JIT a
+                    # shared-memory-heavy metadata kernel.
+                    full_paged_metadata = build_full_paged_prefill_metadata(
+                        num_decodes,
+                        num_decodes + num_prefills,
                         query_start_loc,
                         query_start_loc_cpu,
                         seq_lens,
@@ -618,11 +614,34 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
                         self.compress_ratio,
                         self.kv_cache_spec.storage_block_size,
                         self.num_sms,
-                        query_slice=query_slice,
                     )
-                    # Skip when the chunk has no compressed KV tokens.
-                    if paged_metadata is not None:
-                        paged_chunks.append(paged_metadata)
+                else:
+                    # This is a DeepGEMM metadata-kernel safety bound, not a
+                    # gathered-K workspace bound.
+                    chunk_specs = split_indexer_paged_prefill_chunks(
+                        compressed_seq_lens_cpu[num_decodes:],
+                        prefill_query_lens_cpu,
+                        max_logits_bytes,
+                        request_offset=num_decodes,
+                    )
+
+                    for req_slice, query_slice in chunk_specs:
+                        paged_metadata = build_paged_prefill_metadata(
+                            req_slice.start,
+                            req_slice.stop,
+                            query_start_loc,
+                            query_start_loc_cpu,
+                            seq_lens,
+                            compressed_seq_lens_cpu,
+                            common_attn_metadata.block_table_tensor,
+                            self.compress_ratio,
+                            self.kv_cache_spec.storage_block_size,
+                            self.num_sms,
+                            query_slice=query_slice,
+                        )
+                        # Skip when the chunk has no compressed KV tokens.
+                        if paged_metadata is not None:
+                            paged_chunks.append(paged_metadata)
             else:
                 chunk_specs = split_indexer_prefill_chunks(
                     compressed_seq_lens_cpu[num_decodes:],
@@ -652,6 +671,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             prefill_metadata = DeepseekV32IndexerPrefillMetadata(
                 chunks=chunks,
                 paged_chunks=paged_chunks,
+                full_paged_metadata=full_paged_metadata,
             )
 
         decode_metadata = None
@@ -878,6 +898,117 @@ def build_paged_prefill_metadata(
     )
     token_start = query_start_loc_cpu[start_idx].item() + qs_start
     token_end = token_start + output_query_len
+
+    return DeepseekV32IndexerPagedPrefillMetadata(
+        token_start=token_start,
+        token_end=token_end,
+        context_lens=context_lens,
+        indices=indices,
+        block_table=block_table[req_idx],
+        schedule_metadata=schedule_metadata,
+        max_context_len=max_context_len,
+    )
+
+
+def build_full_paged_prefill_metadata(
+    start_idx: int,
+    end_idx: int,
+    query_start_loc: torch.Tensor,
+    query_start_loc_cpu: torch.Tensor,
+    seq_lens: torch.Tensor,
+    compressed_seq_lens_cpu: torch.Tensor,
+    block_table: torch.Tensor,
+    compress_ratio: int,
+    block_size: int,
+    num_sms: int,
+) -> DeepseekV32IndexerPagedPrefillMetadata | None:
+    total_query_len = int(
+        (query_start_loc_cpu[end_idx] - query_start_loc_cpu[start_idx]).item()
+    )
+    if total_query_len <= 0:
+        return None
+
+    max_context_len = int(compressed_seq_lens_cpu[start_idx:end_idx].max().item())
+    if max_context_len == 0:
+        return None
+
+    token_start = int(query_start_loc_cpu[start_idx].item())
+    token_end = int(query_start_loc_cpu[end_idx].item())
+    query_lens_cpu = torch.diff(query_start_loc_cpu[start_idx : end_idx + 1])
+    total_atoms = int(((query_lens_cpu + 1) // 2).sum().item())
+
+    device = seq_lens.device
+    req_ids = torch.arange(start_idx, end_idx, dtype=torch.long, device=device)
+    query_lens = query_start_loc[start_idx : end_idx + 1].diff()
+    req_idx = torch.repeat_interleave(req_ids, query_lens, output_size=total_query_len)
+    token_idx = torch.arange(total_query_len, dtype=torch.long, device=device)
+    query_offsets = token_idx - (query_start_loc[req_idx] - token_start)
+    req_query_lens = query_start_loc[req_idx + 1] - query_start_loc[req_idx]
+    context_lens = (
+        seq_lens[req_idx] - req_query_lens + query_offsets + 1
+    ) // compress_ratio
+
+    indices = req_idx.to(torch.int32)
+    split_kv = 256
+    context_lens = context_lens.to(torch.int32).view(-1, 1)
+    batch_size = context_lens.shape[0]
+
+    # Varlen paged logits groups adjacent tokens from the same request into
+    # one scheduler atom. Full prefill preserves those request runs, so build
+    # atom starts from query_lens instead of scanning the per-token indices.
+    atoms_per_req = torch.div(query_lens + 1, 2, rounding_mode="floor")
+    atom_req_idx = torch.repeat_interleave(
+        req_ids,
+        atoms_per_req,
+        output_size=total_atoms,
+    )
+
+    atom_start_locs = torch.empty(
+        end_idx - start_idx + 1,
+        dtype=torch.long,
+        device=device,
+    )
+    atom_start_locs[:1] = 0
+    atom_start_locs[1:] = torch.cumsum(atoms_per_req.to(torch.long), dim=0)
+
+    atom_local_req_idx = atom_req_idx - start_idx
+    atom_positions = torch.arange(total_atoms, dtype=torch.long, device=device)
+    atom_offsets = (atom_positions - atom_start_locs[atom_local_req_idx]) * 2
+    atom_req_query_lens = query_lens[atom_local_req_idx].to(torch.long)
+    atom_context_offsets = torch.minimum(
+        atom_offsets + 1,
+        atom_req_query_lens - 1,
+    )
+    atom_context_lens = (
+        seq_lens[atom_req_idx].to(torch.long)
+        - atom_req_query_lens
+        + atom_context_offsets
+        + 1
+    ) // compress_ratio
+    atom_starts = query_start_loc[atom_req_idx].to(torch.long) - token_start
+    atom_starts = atom_starts + atom_offsets
+
+    num_segs = torch.div(
+        atom_context_lens + split_kv - 1, split_kv, rounding_mode="floor"
+    )
+    prefix_sum = torch.cumsum(num_segs, dim=0)
+    prefix_sum_with_zero = torch.cat((prefix_sum[:1] * 0, prefix_sum))
+
+    total = prefix_sum[-1]
+    sm_indices = torch.arange(num_sms + 1, dtype=torch.int64, device=device)
+    q = total // num_sms
+    r = total % num_sms
+    seg_starts = sm_indices * q + torch.minimum(sm_indices, r)
+
+    atom_idx = torch.searchsorted(prefix_sum, seg_starts, right=True)
+    kv_split_idx = seg_starts - prefix_sum_with_zero[atom_idx]
+    clamped_atom_idx = atom_idx.clamp(max=atom_starts.shape[0] - 1)
+    q_atom_idx = torch.where(
+        atom_idx < atom_starts.shape[0],
+        atom_starts[clamped_atom_idx],
+        torch.full_like(atom_idx, batch_size),
+    )
+    schedule_metadata = torch.stack((q_atom_idx, kv_split_idx), dim=1).to(torch.int32)
 
     return DeepseekV32IndexerPagedPrefillMetadata(
         token_start=token_start,

--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -541,6 +541,7 @@ class DeepseekV32IndexerMetadataBuilder(AttentionMetadataBuilder):
             if self.use_paged_prefill:
                 # Paged prefill avoids the gathered-K workspace, so keep it as
                 # one full prefill span instead of applying flat chunk limits.
+                # The materialized logits are still O(tokens * context).
                 paged_metadata = build_paged_prefill_metadata(
                     num_decodes,
                     num_decodes + num_prefills,


### PR DESCRIPTION
## Purpose

This PR enables paged indexer path prefill i.e. use DeepGEMM's `fp8_fp4_paged_mqa_logits` instead of `fp8_fp4_mqa_logits` for prefill. This is only available for SM100. It skips gather K kernel (`cp_gather_indexer_k_quant_cache`) -> faster.

However, it materializes the full `Q @ K.T` logits, which has the size of `max_prefill_tokens x max_compressed_model_len`. Using 8192 tokens, 1M context, and compress ratio 4, the logits take `8192 * (1048576 / 4) * 4 bytes = 8 GiB`. Due to this reason, initially I also implemented a chunk version of paged indexer (still available in `benchmarks/kernels/benchmark_prefill_sparse_indexer.py`). But in e2e benchmark, full paged indexer (no chunking) actually has **lower** peak memory usage. I'm not sure why this is the case... Hence, I only keep full paged prefill in this PR (chunking logic is still in the git history and the benchmark script, so we can still revisit it if needed).

This feature will be gated behind the flag `--enable-sparse-indexer-paged-prefill` so that it doesn't change the default behavior.

## Microbenchmarks

This includes time for topk kernel as well. For the current "flat" kernels (`fp8_fp4_mqa_logits`), the timing also includes K gather op.

### FP8

```
python benchmarks/kernels/benchmark_prefill_sparse_indexer.py --dtype fp8 --max_query_len 4096 --max_context_len 1000 3000 10000 30000 100000 300000 1000000 --log_axis --graph_path fp8_large.png
```

<img width="500" alt="fp8_large" src="https://github.com/user-attachments/assets/c2b45dd2-196c-4e7b-a0da-7b8abc3c0453" />


### FP4

```
python benchmarks/kernels/benchmark_prefill_sparse_indexer.py --dtype fp4 --max_query_len 4096 --max_context_len 1000 3000 10000 30000 100000 300000 1000000 --log_axis --graph_path fp4_large.png
```

<img width="500" alt="fp4_large" src="https://github.com/user-attachments/assets/9996da0d-a65d-4b33-8942-ae0527965a4a" />

## E2E benchmarks

## Accuracy evals

Eval | W/o paged prefill indexer | W/ paged prefill indexer
---|---|---
GSM8K (strict-match) | 0.9462 | 0.9560
AIME25 | 0.9437 | 0.9583

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

