### PR TITLE
Fix Granite Speech audio placeholder sizing

### DIFF
--- a/tests/models/multimodal/test_granite_speech_processor.py
+++ b/tests/models/multimodal/test_granite_speech_processor.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import numpy as np
+import torch
+
+from vllm.model_executor.models.granite_speech import (
+    GraniteSpeechMultiModalProcessor,
+)
+from vllm.multimodal.processing import BaseMultiModalProcessor
+
+
+class _FakeAudioProcessor:
+    def _get_num_audio_features(self, audio_lengths: list[int]) -> list[int]:
+        return [length // 100 for length in audio_lengths]
+
+
+class _FakeProcessor:
+    audio_processor = _FakeAudioProcessor()
+
+
+class _FakeInfo:
+    def get_hf_processor(self, **kwargs):
+        return _FakeProcessor()
+
+
+def test_granite_speech_uses_audio_lengths_for_embed_sizes(monkeypatch):
+    def fake_call_hf_processor(self, prompt, mm_data, mm_kwargs, tok_kwargs):
+        return {"input_ids": torch.tensor([[1, 2, 100352, 3]])}
+
+    monkeypatch.setattr(
+        BaseMultiModalProcessor,
+        "_call_hf_processor",
+        fake_call_hf_processor,
+    )
+
+    processor = GraniteSpeechMultiModalProcessor.__new__(
+        GraniteSpeechMultiModalProcessor
+    )
+    processor.info = _FakeInfo()
+
+    outputs = processor._call_hf_processor(
+        prompt="<|audio|>transcribe",
+        mm_data={"audios": [np.zeros(32000), np.zeros(48000)]},
+        mm_kwargs={},
+        tok_kwargs={},
+    )
+
+    assert outputs["audio_embed_sizes"].tolist() == [320, 480]
+
+
+def test_granite_speech_lets_vllm_apply_prompt_updates():
+    processor = GraniteSpeechMultiModalProcessor.__new__(
+        GraniteSpeechMultiModalProcessor
+    )
+
+    assert not processor._hf_processor_applies_updates(
+        prompt_text="<|audio|>transcribe",
+        mm_items=SimpleNamespace(),
+        hf_processor_mm_kwargs={},
+        tokenization_kwargs={},
+    )

--- a/vllm/model_executor/models/granite_speech.py
+++ b/vllm/model_executor/models/granite_speech.py
@@ -200,14 +200,31 @@ class GraniteSpeechMultiModalProcessor(
         )
 
         if "audio" in mm_data:
-            # Calculate the number of audio tokens per entry in the batch;
-            # This is used to split the batch back out after padding.
-            audio_token_index = self.info.get_hf_config().audio_token_index
-            processed_outputs["audio_embed_sizes"] = (
-                processed_outputs["input_ids"] == audio_token_index
-            ).sum(-1)
+            # GraniteSpeechProcessor leaves a single audio marker in the text.
+            # vLLM expands it later via PromptReplacement, so derive the
+            # embedding sizes from the audio instead of counting prompt tokens.
+            feature_extractor = self.info.get_hf_processor(
+                **mm_kwargs
+            ).audio_processor
+            audio_lengths = [audio.shape[-1] for audio in audios]
+            processed_outputs["audio_embed_sizes"] = torch.tensor(
+                feature_extractor._get_num_audio_features(audio_lengths),
+                dtype=torch.long,
+            )
 
         return processed_outputs
+
+    def _hf_processor_applies_updates(
+        self,
+        prompt_text: str,
+        mm_items: MultiModalDataItems,
+        hf_processor_mm_kwargs: Mapping[str, object],
+        tokenization_kwargs: Mapping[str, object],
+    ) -> bool:
+        # GraniteSpeechProcessor tokenizes the audio marker but does not expand
+        # it to match the number of projected audio embeddings. Let vLLM apply
+        # the PromptReplacement declared in _get_prompt_updates.
+        return False
 
 
 class GraniteSpeechDummyInputsBuilder(


### PR DESCRIPTION
Fixes Granite Speech audio placeholder sizing by deriving audio embedding counts from waveform lengths and letting vLLM apply prompt replacement.

Tested:
- python -m py_compile vllm\model_executor\models\granite_speech.py tests\models\multimodal\test_granite_speech_processor.py

https://github.com/vllm-project/vllm/issues/41284