### PR TITLE
[Installation] Make bitsandbytes, runai-model-streamer, and mamba-ssm optional for macOS

### DIFF
--- a/requirements/test.in
+++ b/requirements/test.in
@@ -26,7 +26,7 @@ torch==2.7.0
 torchaudio==2.7.0
 torchvision==0.22.0
 transformers_stream_generator # required for qwen-vl test
-mamba_ssm # required for plamo2 test
+mamba_ssm; platform_system != "Darwin" # required for plamo2 test
 matplotlib # required for qwen-vl test
 mistral_common[opencv] >= 1.5.4 # required for pixtral test
 num2words # required for smolvlm test
@@ -39,7 +39,7 @@ tokenizers==0.21.1
 huggingface-hub[hf_xet]>=0.30.0  # Required for Xet downloads.
 schemathesis>=3.39.15 # Required for openai schema test.
 # quantization
-bitsandbytes>=0.45.3
+bitsandbytes>=0.45.3; platform_system != "Darwin"
 buildkite-test-collector==0.1.9
 
 genai_perf==0.0.8
@@ -48,7 +48,7 @@ tritonclient==2.51.0
 numba == 0.60.0; python_version == '3.9' # v0.61 doesn't support Python 3.9. Required for N-gram speculative decoding
 numba == 0.61.2; python_version > '3.9'
 numpy
-runai-model-streamer==0.11.0
-runai-model-streamer-s3==0.11.0
+runai-model-streamer==0.11.0; platform_system != "Darwin"
+runai-model-streamer-s3==0.11.0; platform_system != "Darwin"
 fastsafetensors>=0.1.10
 pydantic>=2.10 # 2.9 leads to error on python 3.10

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -45,7 +45,7 @@ backoff==2.2.1
     # via
     #   -r requirements/test.in
     #   schemathesis
-bitsandbytes==0.45.3
+bitsandbytes==0.45.3; platform_system != "Darwin"
     # via -r requirements/test.in
 black==24.10.0
     # via datamodel-code-generator
@@ -286,7 +286,7 @@ lxml==5.3.0
     # via
     #   blobfile
     #   sacrebleu
-mamba-ssm==2.2.4
+mamba-ssm==2.2.4; platform_system != "Darwin"
     # via -r requirements/test.in
 markdown-it-py==3.0.0
     # via rich
@@ -644,9 +644,9 @@ rpds-py==0.20.1
     #   referencing
 rsa==4.9.1
     # via google-auth
-runai-model-streamer==0.11.0
+runai-model-streamer==0.11.0; platform_system != "Darwin"
     # via -r requirements/test.in
-runai-model-streamer-s3==0.11.0
+runai-model-streamer-s3==0.11.0; platform_system != "Darwin"
     # via -r requirements/test.in
 s3transfer==0.10.3
     # via boto3


### PR DESCRIPTION
## Summary

This PR makes `bitsandbytes`, `runai-model-streamer`, and `mamba-ssm` optional for macOS installations. These packages do not have macOS wheels and cause installation failures on Apple Silicon.

## Changes

- Modified `requirements/test.in` to add `platform_system != "Darwin"` conditions for:
  - `bitsandbytes>=0.45.3`
  - `runai-model-streamer==0.11.0`
  - `runai-model-streamer-s3==0.11.0`
  - `mamba_ssm`
- Updated `requirements/test.txt` with corresponding platform conditions

## Testing

- Successfully installed dependencies on macOS with these changes
- vLLM imports and initializes properly
- No functionality is lost for Linux users

## Related Issues

Fixes #34351

## Additional Notes

- `bitsandbytes` is only used for quantization features
- `runai-model-streamer` is only available for Linux x86_64
- `mamba-ssm` requires CUDA (nvcc) which is not available on macOS
- All three packages are optional for development/testing on macOS