### PR TITLE
[Frontend] Validate Cohere embed request inputs

### DIFF
--- a/tests/entrypoints/pooling/embed/test_protocol.py
+++ b/tests/entrypoints/pooling/embed/test_protocol.py
@@ -8,8 +8,12 @@ import struct
 import numpy as np
 import pybase64 as base64
 import pytest
+from pydantic import ValidationError
 
 from vllm.entrypoints.pooling.embed.protocol import (
+    CohereEmbedContent,
+    CohereEmbedInput,
+    CohereEmbedRequest,
     build_typed_embeddings,
 )
 
@@ -127,3 +131,64 @@ class TestBuildTypedEmbeddingsMultiple:
     def test_unknown_type_ignored(self, sample_embeddings: list[list[float]]):
         result = build_typed_embeddings(sample_embeddings, ["float", "unknown_type"])
         assert result.float is not None
+
+
+def _cohere_mixed_text_input(text: str = "hello") -> CohereEmbedInput:
+    return CohereEmbedInput(content=[CohereEmbedContent(type="text", text=text)])
+
+
+class TestCohereEmbedRequestValidation:
+    """Unit tests for CohereEmbedRequest input-field validation."""
+
+    def test_texts_input_is_accepted(self):
+        request = CohereEmbedRequest(model="test", texts=["hello"])
+
+        assert request.texts == ["hello"]
+        assert request.images is None
+        assert request.inputs is None
+
+    def test_images_input_is_accepted(self):
+        request = CohereEmbedRequest(model="test", images=["data:image/png;base64,..."])
+
+        assert request.images == ["data:image/png;base64,..."]
+        assert request.texts is None
+        assert request.inputs is None
+
+    def test_inputs_input_is_accepted(self):
+        input_item = _cohere_mixed_text_input()
+
+        request = CohereEmbedRequest(model="test", inputs=[input_item])
+
+        assert request.inputs == [input_item]
+        assert request.texts is None
+        assert request.images is None
+
+    @pytest.mark.parametrize(
+        "request_kwargs",
+        [
+            {},
+            {"texts": []},
+            {"images": []},
+            {"inputs": []},
+            {"texts": ["hello"], "images": ["data:image/png;base64,..."]},
+            {"texts": ["hello"], "inputs": [_cohere_mixed_text_input("world")]},
+            {
+                "images": ["data:image/png;base64,..."],
+                "inputs": [_cohere_mixed_text_input("world")],
+            },
+            {
+                "texts": ["hello"],
+                "images": ["data:image/png;base64,..."],
+                "inputs": [_cohere_mixed_text_input("world")],
+            },
+        ],
+    )
+    def test_exactly_one_non_empty_input_field_is_required(self, request_kwargs):
+        with pytest.raises(
+            ValidationError,
+            match=(
+                "Exactly one of texts, images, or inputs must be provided "
+                "and non-empty"
+            ),
+        ):
+            CohereEmbedRequest(model="test", **request_kwargs)

--- a/vllm/entrypoints/pooling/embed/protocol.py
+++ b/vllm/entrypoints/pooling/embed/protocol.py
@@ -13,7 +13,7 @@ from collections.abc import Sequence
 from typing import Literal, TypeAlias
 
 import pybase64 as base64
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from vllm import PoolingParams
 from vllm.config import ModelConfig
@@ -173,6 +173,20 @@ class CohereEmbedRequest(BaseModel):
     truncate: CohereTruncate = "END"
     max_tokens: int | None = None
     priority: int = 0
+
+    @model_validator(mode="after")
+    def validate_single_input_field(self):
+        provided_fields = [
+            field
+            for field in ("texts", "images", "inputs")
+            if getattr(self, field)
+        ]
+        if len(provided_fields) != 1:
+            raise ValueError(
+                "Exactly one of texts, images, or inputs must be provided "
+                "and non-empty"
+            )
+        return self
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Purpose

Validate Cohere-compatible `/v2/embed` requests so exactly one of `texts`, `images`, or `inputs` is provided and non-empty.

Before this change, requests with multiple input fields could be accepted and processed using implicit precedence (`images` over `inputs` over `texts`), silently ignoring other provided fields.

## Test Plan

```bash
python3 -m py_compile   vllm/entrypoints/pooling/embed/protocol.py   tests/entrypoints/pooling/embed/test_protocol.py
```

Added unit coverage for valid `texts`, `images`, and `inputs` requests, plus invalid empty or ambiguous input combinations.

Note: targeted pytest was not run locally because the current environment is missing `torch`, which is imported by vLLM's shared test conftest.
