### PR TITLE
[Installation] Make bitsandbytes and runai-model-streamer optional for macOS

### DIFF
--- a/requirements/test/cuda.in
+++ b/requirements/test/cuda.in
@@ -42,7 +42,7 @@ transformers==5.5.3
 tokenizers==0.22.2
 schemathesis>=3.39.15 # Required for openai schema test.
 # quantization
-bitsandbytes==0.49.2
+bitsandbytes==0.49.2; platform_system != "Darwin"
 buildkite-test-collector==0.1.9
 
 
@@ -56,7 +56,7 @@ grpcio-reflection==1.78.0
 arctic-inference == 0.1.1 # Required for suffix decoding test
 numba == 0.65.0 # Required for N-gram speculative decoding
 numpy
-runai-model-streamer[s3,gcs,azure]==0.15.7
+runai-model-streamer[s3,gcs,azure]==0.15.7; platform_system == "Linux" and platform_machine == "x86_64"
 fastsafetensors>=0.2.2 # 0.2.2 contains important fixes for multi-GPU mem usage
 instanttensor>=0.1.5
 pydantic>=2.12 # 2.11 leads to error on python 3.13

--- a/requirements/test/cuda.txt
+++ b/requirements/test/cuda.txt
@@ -77,7 +77,7 @@ backoff==2.2.1
     # via
     #   -r requirements/test/cuda.in
     #   schemathesis
-bitsandbytes==0.49.2
+bitsandbytes==0.49.2; platform_system != "Darwin"
     # via
     #   -r requirements/test/cuda.in
     #   lightning
@@ -1039,13 +1039,13 @@ rsa==4.9.1
     # via google-auth
 rtree==1.4.0
     # via torchgeo
-runai-model-streamer==0.15.7
+runai-model-streamer==0.15.7; platform_system == "Linux" and platform_machine == "x86_64"
     # via -r requirements/test/cuda.in
-runai-model-streamer-azure==0.15.7
+runai-model-streamer-azure==0.15.7; platform_system == "Linux" and platform_machine == "x86_64"
     # via runai-model-streamer
-runai-model-streamer-gcs==0.15.7
+runai-model-streamer-gcs==0.15.7; platform_system == "Linux" and platform_machine == "x86_64"
     # via runai-model-streamer
-runai-model-streamer-s3==0.15.7
+runai-model-streamer-s3==0.15.7; platform_system == "Linux" and platform_machine == "x86_64"
     # via runai-model-streamer
 s3transfer==0.10.3
     # via boto3


### PR DESCRIPTION
## Summary

This PR makes `bitsandbytes` and `runai-model-streamer` optional for macOS installations. These packages do not have macOS wheels and cause installation failures on Apple Silicon.

## Changes

Modified `requirements/test/cuda.in` and `requirements/test/cuda.txt` to add platform conditions:

- `bitsandbytes==0.49.2; platform_system != "Darwin"`
  - Reason: No macOS wheels available
  
- `runai-model-streamer[s3,gcs,azure]==0.15.7; platform_system == "Linux" and platform_machine == "x86_64"`
  - Reason: Only supports Linux x86_64

## Testing

- Successfully installed dependencies on macOS with these changes
- vLLM imports and initializes properly
- No functionality is lost for Linux users

## Related Issues

Fixes #34351

## Additional Notes

- Uses precise platform conditions as suggested by Gemini Code Review
- `bitsandbytes` is only used for quantization features
- `runai-model-streamer` is only available for Linux x86_64
- Both packages are optional for development/testing on macOS