### PR TITLE
[Frontend] Validate rerank top_n parameter

### DIFF
--- a/tests/entrypoints/pooling/scoring/test_protocol.py
+++ b/tests/entrypoints/pooling/scoring/test_protocol.py
@@ -1,0 +1,32 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+from pydantic import ValidationError
+
+from vllm.entrypoints.pooling.scoring.protocol import RerankRequest
+
+
+class TestRerankRequestValidation:
+    def test_top_n_defaults_to_zero(self):
+        request = RerankRequest(query="capital of France", documents=["Paris"])
+
+        assert request.top_n == 0
+
+    @pytest.mark.parametrize("top_n", [0, 1, 2])
+    def test_non_negative_top_n_is_accepted(self, top_n: int):
+        request = RerankRequest(
+            query="capital of France",
+            documents=["Paris", "Berlin"],
+            top_n=top_n,
+        )
+
+        assert request.top_n == top_n
+
+    def test_negative_top_n_is_rejected(self):
+        with pytest.raises(ValidationError):
+            RerankRequest(
+                query="capital of France",
+                documents=["Paris", "Berlin"],
+                top_n=-1,
+            )

--- a/vllm/entrypoints/pooling/scoring/protocol.py
+++ b/vllm/entrypoints/pooling/scoring/protocol.py
@@ -114,7 +114,7 @@ class RerankRequest(ScoringRequestMixin):
     # --8<-- [start:rerank-request-params]
     query: ScoreInput
     documents: ScoreInput | list[ScoreInput]
-    top_n: int = Field(default_factory=lambda: 0)
+    top_n: int = Field(default=0, ge=0)
     # --8<-- [end:rerank-request-params]
 
 


### PR DESCRIPTION
## Purpose

Validate that rerank `top_n` is non-negative.

Before this change, negative `top_n` values were accepted by the request model. Since the serving path treats non-positive `top_n` as the default full result set, values such as `top_n=-1` were silently accepted instead of being rejected as invalid input.

This keeps the existing valid behavior unchanged:

- omitted `top_n` defaults to `0`
- `top_n=0` keeps the existing "return all results" behavior
- positive `top_n` values continue to limit the returned results
- negative `top_n` values are rejected during request validation

## Duplicate Check

Checked for existing open work before opening this PR:

```bash
repo:vllm-project/vllm is:pr is:open rerank top_n
repo:vllm-project/vllm is:pr is:open "top_n"
repo:vllm-project/vllm is:issue is:open rerank top_n
```

Only this PR was found for the open PR searches, and no open issue was found for `rerank top_n`.

## AI Assistance

AI assistance was used to prepare this change. The change is intentionally scoped to request validation and focused unit coverage so it can be reviewed end-to-end.

## Test Plan

```bash
git diff --check
python3 -m py_compile   vllm/entrypoints/pooling/scoring/protocol.py   tests/entrypoints/pooling/scoring/test_protocol.py
```

Added unit coverage for the default `top_n=0`, accepted non-negative values, and rejected negative values.

Note: targeted pytest was not run locally because the current environment is missing test dependencies imported by vLLM's shared test conftest (`tblib`/`torch`).
