### PR TITLE
[Frontend] Forward prompt extras in cross-encoder scoring

### DIFF
--- a/tests/entrypoints/pooling/scoring/test_io_processor.py
+++ b/tests/entrypoints/pooling/scoring/test_io_processor.py
@@ -1,0 +1,58 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+from vllm.entrypoints.pooling.scoring.io_processor import CrossEncoderIOProcessor
+from vllm.entrypoints.pooling.scoring.typing import ScoringData
+from vllm.pooling_params import PoolingParams
+
+
+class DummyTokenizeParams:
+    def get_encode_kwargs(self):
+        return {}
+
+    def apply_post_tokenization(self, tokenizer, engine_prompt):
+        pass
+
+
+class DummyRenderer:
+    def __init__(self):
+        self.prompts = []
+
+    def process_for_engine(self, prompt, arrival_time):
+        self.prompts.append(prompt.copy())
+        engine_input = {
+            "prompt_token_ids": prompt["prompt_token_ids"],
+            "arrival_time": arrival_time,
+        }
+        if cache_salt := prompt.get("cache_salt"):
+            engine_input["cache_salt"] = cache_salt
+        return engine_input
+
+
+def test_cross_encoder_prompt_extras_are_applied_before_engine_processing():
+    processor = object.__new__(CrossEncoderIOProcessor)
+    processor.model_config = SimpleNamespace(is_encoder_decoder=False)
+    processor.tokenizer = object()
+    processor.renderer = DummyRenderer()
+
+    def get_score_prompt(**kwargs):
+        return None, {
+            "prompt_token_ids": [1, 2, 3],
+            "token_type_ids": [0, 0, 1],
+        }
+
+    processor.get_score_prompt = get_score_prompt
+
+    pooling_params = PoolingParams(task="classify")
+    engine_inputs, pooling_params_list = processor._pre_process(
+        ScoringData(data_1=["query"], data_2=["document"]),
+        DummyTokenizeParams(),
+        pooling_params,
+        prompt_extras={"cache_salt": "test-salt"},
+    )
+
+    assert engine_inputs[0]["cache_salt"] == "test-salt"
+    assert processor.renderer.prompts[0]["cache_salt"] == "test-salt"
+    assert "compressed_token_type_ids" in pooling_params_list[0].extra_kwargs

--- a/vllm/entrypoints/pooling/scoring/io_processor.py
+++ b/vllm/entrypoints/pooling/scoring/io_processor.py
@@ -10,6 +10,7 @@ from vllm import PoolingParams, PoolingRequestOutput, TokensPrompt
 from vllm.inputs import EngineInput
 from vllm.renderers import TokenizeParams
 from vllm.renderers.hf import safe_apply_chat_template
+from vllm.renderers.inputs.preprocess import extract_target_prompt
 from vllm.tasks import PoolingTask
 from vllm.utils.mistral import is_mistral_tokenizer
 
@@ -431,7 +432,6 @@ class CrossEncoderIOProcessor(ScoringIOProcessor):
         max_tokens_per_doc: int = 0,
         prompt_extras: dict[str, Any] | None = None,
     ) -> tuple[Sequence[EngineInput], list[PoolingParams]]:
-        # todo: support prompt_extras
         arrival_time = time.time()
 
         data_1 = scoring_data.data_1
@@ -464,6 +464,9 @@ class CrossEncoderIOProcessor(ScoringIOProcessor):
                 pooling_params_list.append(pooling_params)
 
             tok_params.apply_post_tokenization(self.tokenizer, engine_prompt)
+            if prompt_extras:
+                target_prompt = extract_target_prompt(self.model_config, engine_prompt)
+                target_prompt.update(prompt_extras)
             engine_inputs.append(
                 self.renderer.process_for_engine(engine_prompt, arrival_time)
             )


### PR DESCRIPTION
## Purpose

Forward request-level prompt extras through the cross-encoder scoring path.

Pooling requests expose `cache_salt` and `mm_processor_kwargs`, and `CrossEncoderIOProcessor.pre_process_online()` already collects those values into `prompt_extras`. However, `CrossEncoderIOProcessor._pre_process()` did not apply `prompt_extras` before converting the tokenized prompt into an engine input, so valid request fields such as `cache_salt` were dropped for cross-encoder `/score` and `/rerank` requests.

This change applies the extras to the target tokenized prompt before `process_for_engine()`, matching the existing renderer behavior used by the other pooling preprocessing paths.

## Duplicate Check

Checked for existing open PRs before opening this PR:

```bash
repo:vllm-project/vllm is:pr is:open "prompt_extras" "scoring"
repo:vllm-project/vllm is:pr is:open "cache_salt" "scoring"
repo:vllm-project/vllm is:pr is:open "CrossEncoderIOProcessor" "cache_salt"
repo:vllm-project/vllm is:pr is:open "mm_processor_kwargs" "CrossEncoderIOProcessor"
```

All four searches returned 0 open PRs.

## AI Assistance

AI assistance was used to identify the missing prompt-extras path and prepare this focused patch. I reviewed the touched code path and kept the change limited to cross-encoder scoring preprocessing plus a regression test.

## Test Plan

```bash
git diff --check
python3 -m py_compile   vllm/entrypoints/pooling/scoring/io_processor.py   tests/entrypoints/pooling/scoring/test_io_processor.py
```

Added unit coverage that verifies `cache_salt` is applied before engine-input processing while preserving the cross-encoder `token_type_ids` pooling-params path.

Note: targeted pytest was not run locally because the current environment is missing dependencies imported by vLLM's shared test conftest (`tblib`).
