### PR TITLE
[feature][WIP] Enable KV Offload for DeepSeek V4 model

### DIFF
--- a/tests/v1/kv_connector/unit/offloading_connector/test_connector.py
+++ b/tests/v1/kv_connector/unit/offloading_connector/test_connector.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from unittest.mock import MagicMock
+
+from vllm.distributed.kv_transfer.kv_connector.v1.base import SupportsHMA
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading_connector import (
+    OffloadingConnector,
+)
+
+
+def test_offloading_connector_supports_hma() -> None:
+    assert issubclass(OffloadingConnector, SupportsHMA)
+
+
+def test_request_finished_all_groups_delegates_to_scheduler() -> None:
+    connector = object.__new__(OffloadingConnector)
+    connector.connector_scheduler = MagicMock()
+    request = MagicMock()
+    block_ids = ([1, 2], [3, 4])
+
+    connector.connector_scheduler.request_finished.return_value = (False, None)
+
+    assert connector.request_finished_all_groups(request, block_ids) == (False, None)
+    connector.connector_scheduler.request_finished.assert_called_once_with(
+        request, block_ids
+    )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/scheduler.py
@@ -647,7 +647,7 @@ class OffloadingConnectorScheduler:
     def request_finished(
         self,
         request: Request,
-        block_ids: list[int],
+        block_ids: list[int] | tuple[list[int], ...],
     ) -> tuple[bool, dict[str, Any] | None]:
         """
         Called when a request has finished, before its blocks are freed.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading_connector.py
@@ -10,6 +10,7 @@ from vllm.distributed.kv_events import KVCacheEvent
 from vllm.distributed.kv_transfer.kv_connector.v1 import (
     KVConnectorBase_V1,
     KVConnectorRole,
+    SupportsHMA,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorMetadata
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
@@ -42,7 +43,7 @@ from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
 
 
-class OffloadingConnector(KVConnectorBase_V1):
+class OffloadingConnector(KVConnectorBase_V1, SupportsHMA):
     @property
     def prefer_cross_layer_blocks(self) -> bool:
         return True
@@ -147,6 +148,14 @@ class OffloadingConnector(KVConnectorBase_V1):
         self,
         request: "Request",
         block_ids: list[int],
+    ) -> tuple[bool, dict[str, Any] | None]:
+        assert self.connector_scheduler is not None
+        return self.connector_scheduler.request_finished(request, block_ids)
+
+    def request_finished_all_groups(
+        self,
+        request: "Request",
+        block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict[str, Any] | None]:
         assert self.connector_scheduler is not None
         return self.connector_scheduler.request_finished(request, block_ids)


### PR DESCRIPTION
##  [feature][WIP] Enable KV Offload for DeepSeek V4 model

## Summary

This PR makes the v1 `OffloadingConnector` advertise `SupportsHMA` and handle
the scheduler's all-KV-group request-finish callback. This is the remaining
connector facade needed for grouped KV offload support when the scheduler passes
`tuple[list[int], ...]` block IDs for multiple KV cache groups.

The implementation is backend-neutral. It does not add Ascend imports,
`torch_npu`, DSv4-specific branches, or `VLLM_ASCEND_*` gates.

## Existing generic grouped-KV pieces in this branch

- `SupportsHMA` is already defined in
  `vllm/distributed/kv_transfer/kv_connector/v1/base.py`.
- `GPULoadStoreSpec` already has typed `group_sizes` and `block_indices` fields.
- `offloading/scheduler.py` already tracks `RequestOffloadState` per KV group.
- The offloading scheduler already uses `make_offload_key(..., group_idx)` for
  group-aware offload keys.
- Load/store metadata already carries grouped GPU block IDs through
  `group_sizes` and `block_indices`.

## Changes

- Make `OffloadingConnector` inherit `SupportsHMA`.
- Add `OffloadingConnector.request_finished_all_groups(...)` and delegate to the
  existing scheduler finish path.
- Widen the offloading scheduler finish type annotation so the connector can pass
  either the legacy single-group list or the HMA all-group tuple.
- Add unit coverage for the connector facade so the class is recognized as
  HMA-capable and forwards all-group block IDs unchanged.

## Validation

Intended focused tests:

```bash
pytest -q tests/v1/kv_connector/unit/offloading_connector/test_connector.py
pytest -q tests/v1/kv_connector/unit/offloading_connector/test_scheduler.py
```

In this local environment, pytest collection currently requires missing optional
test/runtime dependencies (`tblib`, then `gguf` on direct import). Syntax-level
checks were used locally until the full vLLM test environment is available.

## Follow-up

The hardware backend remains out of scope for this PR. DSv4 compressed KV
registration, NPU-visible host memory, and A3 launch/runtime validation belong
in the paired `vllm-ascend` change.