### PR TITLE
[Doc] Fix RTD build: pytorch.org/docs/stable/objects.inv returns 404

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -105,6 +105,7 @@ plugins:
           - https://docs.aiohttp.org/en/stable/objects.inv
           - https://pillow.readthedocs.io/en/stable/objects.inv
           - https://numpy.org/doc/stable/objects.inv
+          # TODO revert to stable once https://github.com/pytorch/pytorch/issues/182007 is fixed
           - https://pytorch.org/docs/2.11/objects.inv
   - redirects:
       redirect_maps:

--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -105,7 +105,7 @@ plugins:
           - https://docs.aiohttp.org/en/stable/objects.inv
           - https://pillow.readthedocs.io/en/stable/objects.inv
           - https://numpy.org/doc/stable/objects.inv
-          - https://pytorch.org/docs/stable/objects.inv
+          - https://pytorch.org/docs/2.11/objects.inv
   - redirects:
       redirect_maps:
         features/spec_decode/README.md: features/speculative_decoding/README.md


### PR DESCRIPTION
`pytorch.org/docs/stable/objects.inv` started returning 404 because pytorch/docs PR [#84](https://github.com/pytorch/docs/pull/84) (merged 2026-04-29 23:09 UTC) replaced the symlinks under `stable/` with per-page HTML redirect stubs and did not stub or copy over non-HTML build artifacts (`objects.inv`, `searchindex.js`, `_static/version_switcher.json`). Every RTD build of `main` since ~2026-04-29 23:59 UTC aborts with `mkdocstrings: Couldn't load inventory ... HTTP Error 404`.

Temporary fix: point at `pytorch.org/docs/2.11/objects.inv`, which is what `/stable/` currently aliases to (`docs.pytorch.org/docs/stable/index.html` is a JS redirect to `../2.11/index.html`, and 2.11 is the latest PyTorch release on PyPI). Will need a one-line bump on the next stable release. Revert to `/stable/` once the upstream stub script is fixed to carry non-HTML assets through.

RTD on this PR builds green (initial run on the v1 of this PR using `/main/`: [build 32481211](https://app.readthedocs.org/projects/vllm/builds/32481211/); a new build will run on the force-push to `/2.11/`).

No open PR addresses this. AI-assisted.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
