### PR TITLE
[Scheduler] Fix sync speculative decode rollback on empty output

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -889,8 +889,9 @@ def test_spec_decoding_stats_empty_output():
     """Test that spec decoding stats handle empty output tokens gracefully.
 
     This is a regression test for a bug where empty sampled_token_ids
-    would cause num_accepted = len([]) - 1 = -1, leading to a
-    ValueError when incrementing a Prometheus counter with a negative value.
+    would both skip sync-spec rollback and make num_accepted negative.
+    The rollback bug parked the request on the next draft update, while
+    the negative num_accepted value crashed the Prometheus stats path.
     """
     num_spec_tokens = 3
     scheduler = create_scheduler(num_speculative_tokens=num_spec_tokens)
@@ -943,6 +944,19 @@ def test_spec_decoding_stats_empty_output():
         engine_core_outputs[0].scheduler_stats if engine_core_outputs else None
     )
     assert scheduler_stats is None or scheduler_stats.spec_decoding_stats is None
+
+    running_req = scheduler.running[0]
+    assert running_req.num_computed_tokens == running_req.num_tokens - 1
+
+    # A fresh draft update should restore the normal sync-spec gap instead of
+    # parking the request with zero schedulable tokens.
+    scheduler.update_draft_token_ids(DraftTokenIds([req_id], [[4, 5, 6]]))
+    running_req = scheduler.running[0]
+    assert running_req.num_tokens_with_spec - running_req.num_computed_tokens == 4
+
+    output = scheduler.schedule()
+    assert output.num_scheduled_tokens[req_id] == 4
+    assert output.scheduled_spec_decode_tokens[req_id] == [4, 5, 6]
 
 
 def test_no_spec_tokens_scheduled_for_prefill_chunks():

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1367,28 +1367,43 @@ class Scheduler(SchedulerInterface):
             scheduled_spec_token_ids = (
                 scheduler_output.scheduled_spec_decode_tokens.get(req_id)
             )
-            if scheduled_spec_token_ids and generated_token_ids:
+            if scheduled_spec_token_ids and (
+                generated_token_ids or request.num_output_placeholders == 0
+            ):
                 num_draft_tokens = len(scheduled_spec_token_ids)
-                num_accepted = len(generated_token_ids) - 1
-                num_rejected = num_draft_tokens - num_accepted
+                num_generated_tokens = len(generated_token_ids)
+                num_accepted = max(num_generated_tokens - 1, 0)
+                if request.num_output_placeholders == 0:
+                    # Sync spec decode advances num_computed_tokens optimistically
+                    # before we know how many scheduled tokens survive. If the worker
+                    # returns no materialized tokens, roll back the full optimistic
+                    # advance here so the next draft update keeps the usual decode gap.
+                    num_rejected = max(
+                        scheduler_output.num_scheduled_tokens.get(req_id, 0)
+                        - num_generated_tokens,
+                        0,
+                    )
+                else:
+                    num_rejected = num_draft_tokens - num_accepted
                 # num_computed_tokens represents the number of tokens
                 # processed in the current step, considering scheduled
                 # tokens and rejections. If some tokens are rejected,
                 # num_computed_tokens is decreased by the number of rejected
                 # tokens.
-                if request.num_computed_tokens > 0:
+                if num_rejected > 0 and request.num_computed_tokens > 0:
                     request.num_computed_tokens -= num_rejected
                 # If async scheduling, num_output_placeholders also includes
                 # the scheduled spec tokens count and so is similarly adjusted.
-                if request.num_output_placeholders > 0:
+                if num_rejected > 0 and request.num_output_placeholders > 0:
                     request.num_output_placeholders -= num_rejected
-                spec_decoding_stats = self.make_spec_decoding_stats(
-                    spec_decoding_stats,
-                    num_draft_tokens=num_draft_tokens,
-                    num_accepted_tokens=num_accepted,
-                    num_invalid_spec_tokens=scheduler_output.num_invalid_spec_tokens,
-                    request_id=req_id,
-                )
+                if generated_token_ids:
+                    spec_decoding_stats = self.make_spec_decoding_stats(
+                        spec_decoding_stats,
+                        num_draft_tokens=num_draft_tokens,
+                        num_accepted_tokens=num_accepted,
+                        num_invalid_spec_tokens=scheduler_output.num_invalid_spec_tokens,
+                        request_id=req_id,
+                    )
 
             # Free encoder inputs only after the step has actually executed.
             if request.has_encoder_inputs:


### PR DESCRIPTION
## Summary
- roll back the optimistic sync speculative decode advance when a worker step returns no materialized tokens
- keep the next draft update on the normal schedulable path instead of parking the request with zero work
- extend the scheduler regression test to cover the empty-output rollback case

## Test plan
- pre-commit hooks run during `git commit`
- `python3 -m pytest tests/v1/core/test_scheduler.py -k test_spec_decoding_stats_empty_output` was not run in this worktree because the host Python environment does not have `pytest`
- DeepSeek V3.2 MTP repro and fix validation were run separately during issue investigation

AI assistance was used for this PR.