### PR TITLE
Stop mergify labelling from skipping pre-commit

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -16,11 +16,7 @@ permissions:
 
 jobs:
   pre-run-check:
-    if: >-
-      github.event_name == 'pull_request' &&
-      (github.event.action != 'labeled' ||
-       github.event.label.name == 'ready' ||
-       github.event.label.name == 'verified')
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
     - name: Check PR label and author merge count
@@ -49,12 +45,7 @@ jobs:
 
   pre-commit:
     needs: pre-run-check
-    if: >-
-      always() &&
-      (github.event.action != 'labeled' ||
-       github.event.label.name == 'ready' ||
-       github.event.label.name == 'verified') &&
-      (needs.pre-run-check.result == 'success' || needs.pre-run-check.result == 'skipped')
+    if: always() && (needs.pre-run-check.result == 'success' || needs.pre-run-check.result == 'skipped')
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'labeled' }}
 
 permissions:
   contents: read

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -8,7 +8,7 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'labeled' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Commit 2d80cf9 ("Fix pre-commit labeled trigger system", #39523) made two changes to `.github/workflows/pre-commit.yml`:

1. Added `types: [opened, synchronize, reopened, labeled]` to the pull_request trigger so adding a label could trigger pre-commit.
2. Added label-name filters to the if of both `pre-run-check` and `pre-commit` so the jobs only execute for the ready / verified labels.

(2) is the source of the bug. Mergify auto-applies a long list of domain labels (documentation, ci/build, frontend, bug, …) shortly after PR creation. Each label fires a `labeled` event, which:

- cancels the in-progress opened run via the workflow-level concurrency group, then
- starts a new run whose jobs immediately skip because the just-applied label isn't ready / verified.

End result: the PR has no pre-commit run at all.

This PR reverts (2) because (1) is enough to trigger pre-commit when labels are added, then the script inside `pre-run-check` decides if `pre-commit` should run.