### PR TITLE
[XPU] Fallback when torch.xpu mem_get_info is unsupported on integrated Intel GPU

### DIFF
--- a/tests/utils_/test_mem_utils.py
+++ b/tests/utils_/test_mem_utils.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from unittest.mock import MagicMock, patch
 
+import pytest
 import torch
 from vllm_test_utils.monitor import monitor
 
@@ -122,3 +123,54 @@ def test_memory_snapshot_uses_cuda_on_discrete_gpu():
         assert snapshot.free_memory == mock_cuda_free
         assert snapshot.total_memory == mock_cuda_total
         mock_psutil.virtual_memory.assert_not_called()
+
+
+def test_memory_snapshot_xpu_unsupported_mem_query_fallback():
+    """On XPU, unsupported mem_get_info should fallback to host memory."""
+    mock_total_memory = 16 * 1024**3
+    mock_psutil_available = 12 * 1024**3
+
+    with (
+        patch("vllm.utils.mem_utils.current_platform") as mock_platform,
+        patch("vllm.utils.mem_utils.psutil") as mock_psutil,
+    ):
+        mock_platform.mem_get_info.side_effect = RuntimeError(
+            "doesn't support querying the available free memory"
+        )
+        mock_platform.get_device_total_memory.return_value = mock_total_memory
+        mock_platform.is_integrated_gpu.return_value = False
+        mock_platform.memory_stats.return_value = {
+            "allocated_bytes.all.peak": 0,
+        }
+        mock_platform.memory_reserved.return_value = 0
+        mock_platform.current_device = lambda: "xpu:0"
+        mock_platform.device_type = "xpu"
+
+        mock_vmem = MagicMock()
+        mock_vmem.available = mock_psutil_available
+        mock_psutil.virtual_memory.return_value = mock_vmem
+
+        snapshot = MemorySnapshot(device="xpu:0")
+
+        assert snapshot.total_memory == mock_total_memory
+        assert snapshot.free_memory == mock_psutil_available
+
+
+def test_memory_snapshot_non_xpu_runtime_error_reraises():
+    """Non-XPU mem_get_info RuntimeError should not be swallowed."""
+    with (
+        patch("vllm.utils.mem_utils.current_platform") as mock_platform,
+        patch("vllm.utils.mem_utils.psutil"),
+    ):
+        mock_platform.mem_get_info.side_effect = RuntimeError("boom")
+        mock_platform.is_integrated_gpu.return_value = False
+        mock_platform.memory_stats.return_value = {
+            "allocated_bytes.all.peak": 0,
+        }
+        mock_platform.current_device = lambda: "cuda:0"
+        mock_platform.device_type = "cuda"
+
+        with patch("torch.accelerator.memory_reserved", return_value=0):
+            with patch("torch.accelerator.memory_stats", return_value={}):
+                with pytest.raises(RuntimeError, match="boom"):
+                    MemorySnapshot(device="cuda:0")

--- a/vllm/utils/mem_utils.py
+++ b/vllm/utils/mem_utils.py
@@ -122,7 +122,7 @@ class MemorySnapshot:
             self.total_memory = current_platform.get_device_total_memory(device.index)
             self.free_memory = min(psutil.virtual_memory().available,
                                    self.total_memory)
-            logger.warning(
+            logger.warning_once(
                 "XPU free-memory query is unsupported on this device; "
                 "falling back to host available memory estimate."
             )

--- a/vllm/utils/mem_utils.py
+++ b/vllm/utils/mem_utils.py
@@ -114,9 +114,8 @@ class MemorySnapshot:
             # Some Intel integrated GPUs do not implement free-memory query
             # in torch.xpu yet; use total device memory and host available
             # memory as a conservative fallback so initialization can proceed.
-            is_xpu = getattr(current_platform, "device_type", None) == "xpu"
-            unsupported_mem_query = "doesn't support querying the available free memory" in str(
-                e)
+            is_xpu = current_platform.is_xpu()
+            unsupported_mem_query = "doesn't support querying the available free memory" in str(e)
             if not (is_xpu and unsupported_mem_query):
                 raise
 

--- a/vllm/utils/mem_utils.py
+++ b/vllm/utils/mem_utils.py
@@ -11,9 +11,12 @@ import psutil
 import torch
 import torch.types
 
+from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
 from .mem_constants import GiB_bytes, KiB_bytes, MiB_bytes
+
+logger = init_logger(__name__)
 
 
 def format_kib(b: int) -> str:
@@ -105,7 +108,26 @@ class MemorySnapshot:
             "allocated_bytes.all.peak", 0
         )
 
-        self.free_memory, self.total_memory = current_platform.mem_get_info(device)
+        try:
+            self.free_memory, self.total_memory = current_platform.mem_get_info(device)
+        except RuntimeError as e:
+            # Some Intel integrated GPUs do not implement free-memory query
+            # in torch.xpu yet; use total device memory and host available
+            # memory as a conservative fallback so initialization can proceed.
+            is_xpu = getattr(current_platform, "device_type", None) == "xpu"
+            unsupported_mem_query = "doesn't support querying the available free memory" in str(
+                e)
+            if not (is_xpu and unsupported_mem_query):
+                raise
+
+            self.total_memory = current_platform.get_device_total_memory(device.index)
+            self.free_memory = min(psutil.virtual_memory().available,
+                                   self.total_memory)
+            logger.warning(
+                "XPU free-memory query is unsupported on this device; "
+                "falling back to host available memory estimate."
+            )
+
         if current_platform.is_integrated_gpu(device.index):
             # On UMA (Unified Memory Architecture) platforms where CPU and
             # GPU share physical memory (e.g. GH200, DGX Spark, Jetson Orin),
@@ -115,7 +137,7 @@ class MemorySnapshot:
             # https://docs.nvidia.com/cuda/cuda-for-tegra-appnote/#estimating-total-allocatable-device-memory-on-an-integrated-gpu-device
             self.free_memory = psutil.virtual_memory().available
 
-        self.cuda_memory = self.total_memory - self.free_memory
+        self.cuda_memory = max(0, self.total_memory - self.free_memory)
 
         # torch.accelerator.memory_reserved() is how many bytes
         # PyTorch gets from cuda (by calling cudaMalloc, etc.)


### PR DESCRIPTION
Title: [XPU] Fallback when torch.xpu mem_get_info is unsupported on integrated Intel GPU

## Why this is not a duplicate
I checked open PRs before preparing this change:

- `gh pr list --repo vllm-project/vllm --state open --search "xpu mem_get_info"`
  - Found #36005: fix(xpu): handle mem_get_info failure on XPU simulator (testing only)
- `gh pr list --repo vllm-project/vllm --state open --search "xpu_getMemoryInfo"`
  - No matches
- `gh pr list --repo vllm-project/vllm --state open --search "MemorySnapshot XPU"`
  - Found #40295 (broad XPU workstream)

This PR is materially different from #36005:
- #36005 is simulator-focused and uses hardcoded tiny fallback values.
- This change targets real Intel integrated GPU runtime behavior and uses dynamic fallback values:
  - total memory from platform device properties
  - free memory from host available memory via psutil

## Summary
On some Intel integrated GPUs, `torch.xpu.mem_get_info()` is not implemented and raises at startup. This crashes `MemorySnapshot.measure()` during engine initialization.

This PR adds a guarded fallback path in `vllm/utils/mem_utils.py` for XPU-only unsupported-memory-query errors so startup can proceed.

## What changed
- `vllm/utils/mem_utils.py`
  - Wrap `current_platform.mem_get_info(device)` in `try/except RuntimeError`.
  - If current platform is XPU and the RuntimeError indicates unsupported free-memory query:
    - set `total_memory` from `current_platform.get_device_total_memory(device.index)`
    - set `free_memory` to `min(psutil.virtual_memory().available, total_memory)`
    - emit a warning log once per snapshot measurement path
  - Keep non-XPU and other RuntimeErrors unchanged (re-raised).
  - Clamp `cuda_memory` to non-negative.

- `tests/utils_/test_mem_utils.py`
  - Added test for XPU unsupported mem query fallback.
  - Added test to verify non-XPU RuntimeError is still re-raised.

## Motivation
This unblocks vLLM startup on Intel integrated GPU environments where XPU memory free-info is currently unsupported by PyTorch runtime, while preserving existing behavior for all other platforms/error types.

## Test plan
Run:

- `uv run -m pytest tests/utils_/test_mem_utils.py -q`

Optional runtime validation (XPU environment):

- start XPU server and verify it passes MemorySnapshot initialization where it previously crashed.

## Test results
- Local runtime validation on Intel iGPU environment: PASS (startup proceeds beyond `MemorySnapshot` crash point).
- Unit tests: not executed in this shell because `uv` is unavailable in the current environment.

## AI assistance
This PR was prepared with AI assistance. All changes were reviewed and validated by the author.
