### PR TITLE
Auto-adjust max num seqs mamba

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1222,9 +1222,25 @@ def test_is_uniform_decode() -> None:
     current_platform.is_rocm(),
     reason="Attention backend FLASHINFER is not supported on ROCm.",
 )
-def test_mamba_cache_raises_when_max_num_seqs_exceeds_blocks():
-    """Test that a ValueError is raised when max_num_seqs exceeds the
-    available Mamba cache blocks for hybrid models with FULL cudagraphs.
+@pytest.mark.parametrize(
+    "original_max_num_seqs, expect_raise",
+    [
+        pytest.param(10, True, id="user_set_raises"),
+        pytest.param(None, False, id="default_auto_adjusts"),
+    ],
+)
+def test_mamba_cache_when_max_num_seqs_exceeds_blocks(
+    original_max_num_seqs, expect_raise
+):
+    """Verify behavior when max_num_seqs exceeds the available Mamba
+    cache blocks for hybrid models with FULL cudagraphs:
+
+    - When the user set `max_num_seqs` explicitly (`original_max_num_seqs`
+      is not None), raise `ValueError` with the actionable message.
+    - When `max_num_seqs` is the engine-determined default
+      (`original_max_num_seqs` is None), auto-adjust it down to the
+      available block count and filter cudagraph capture sizes
+      accordingly so the server can start.
 
     See: https://github.com/vllm-project/vllm/issues/34094
     """
@@ -1252,6 +1268,7 @@ def test_mamba_cache_raises_when_max_num_seqs_exceeds_blocks():
     )
     scheduler_config = SchedulerConfig(
         max_num_seqs=10,
+        original_max_num_seqs=original_max_num_seqs,
         max_num_batched_tokens=512,
         max_model_len=512,
         is_encoder_decoder=model_config.is_encoder_decoder,
@@ -1319,5 +1336,13 @@ def test_mamba_cache_raises_when_max_num_seqs_exceeds_blocks():
         # Force max_num_seqs to exceed num_blocks so the check triggers.
         runner.max_num_reqs = num_blocks + 100
 
-        with pytest.raises(ValueError, match="max_num_seqs"):
+        if expect_raise:
+            with pytest.raises(ValueError, match="max_num_seqs"):
+                runner.initialize_kv_cache(kv_cache_config)
+        else:
             runner.initialize_kv_cache(kv_cache_config)
+            assert scheduler_config.max_num_seqs == num_blocks
+            assert all(
+                s <= num_blocks
+                for s in vllm_config.compilation_config.cudagraph_capture_sizes
+            )

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -26,6 +26,7 @@ from vllm.utils.torch_utils import is_torch_equal_or_newer
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+    from vllm.config.scheduler import SchedulerConfig
     from vllm.v1.attention.backend import AttentionCGSupport
     from vllm.v1.kv_cache_interface import KVCacheConfig
 else:
@@ -1307,6 +1308,7 @@ class CompilationConfig:
         kv_cache_config: "KVCacheConfig | None" = None,
         max_num_reqs: int | None = None,
         is_profiling: bool = False,
+        scheduler_config: "SchedulerConfig | None" = None,
     ) -> CUDAGraphMode:
         from vllm.v1.attention.backend import AttentionCGSupport
 
@@ -1420,9 +1422,10 @@ class CompilationConfig:
         # For Mamba models with FULL decode cudagraphs, each decode
         # sequence needs one Mamba cache block. The decode cudagraph
         # dispatcher already caps batch sizes at max_num_seqs, so we just
-        # need to verify that enough blocks exist. Raising here instead
-        # of silently capping cudagraph_capture_sizes avoids unintended
-        # restrictions on PIECEWISE (prefill) cudagraphs.
+        # need to verify that enough blocks exist. If max_num_seqs was
+        # the engine-determined default, auto-adjust it down to fit the
+        # available blocks; if the user set it explicitly, raise so they
+        # see the actionable error.
         # See: https://github.com/vllm-project/vllm/issues/34094
         if (
             kv_cache_config is not None
@@ -1432,14 +1435,39 @@ class CompilationConfig:
             and kv_cache_config.has_mamba_layers
             and max_num_reqs > kv_cache_config.num_blocks
         ):
-            raise ValueError(
-                f"max_num_seqs ({max_num_reqs}) exceeds available Mamba cache "
-                f"blocks ({kv_cache_config.num_blocks}). Each decode sequence "
-                "requires one Mamba cache block, so CUDA graph capture cannot "
-                "proceed. Please lower max_num_seqs to at most "
-                f"{kv_cache_config.num_blocks} or increase "
-                "gpu_memory_utilization."
+            num_blocks = kv_cache_config.num_blocks
+            user_set_max_num_seqs = (
+                scheduler_config is not None
+                and scheduler_config.original_max_num_seqs is not None
             )
+            if user_set_max_num_seqs:
+                raise ValueError(
+                    f"max_num_seqs ({max_num_reqs}) exceeds available Mamba "
+                    f"cache blocks ({num_blocks}). Each decode sequence "
+                    "requires one Mamba cache block, so CUDA graph capture "
+                    "cannot proceed. Please lower max_num_seqs to at most "
+                    f"{num_blocks} or increase gpu_memory_utilization."
+                )
+            logger.warning(
+                "max_num_seqs (%d) exceeds available Mamba cache blocks "
+                "(%d); auto-adjusting max_num_seqs to %d so CUDA graph "
+                "capture can proceed. Pass --max-num-seqs explicitly or "
+                "increase --gpu-memory-utilization to override.",
+                max_num_reqs,
+                num_blocks,
+                num_blocks,
+            )
+            assert scheduler_config is not None
+            scheduler_config.max_num_seqs = num_blocks
+            if self.cudagraph_capture_sizes:
+                self.cudagraph_capture_sizes = [
+                    s for s in self.cudagraph_capture_sizes if s <= num_blocks
+                ]
+                if (
+                    self.max_cudagraph_capture_size is not None
+                    and self.max_cudagraph_capture_size > num_blocks
+                ):
+                    self.max_cudagraph_capture_size = num_blocks
 
         self.cudagraph_mode = cudagraph_mode
         return cudagraph_mode

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -1436,11 +1436,10 @@ class CompilationConfig:
             and max_num_reqs > kv_cache_config.num_blocks
         ):
             num_blocks = kv_cache_config.num_blocks
-            user_set_max_num_seqs = (
-                scheduler_config is not None
-                and scheduler_config.original_max_num_seqs is not None
-            )
-            if user_set_max_num_seqs:
+            if (
+                scheduler_config is None
+                or scheduler_config.original_max_num_seqs is not None
+            ):
                 raise ValueError(
                     f"max_num_seqs ({max_num_reqs}) exceeds available Mamba "
                     f"cache blocks ({num_blocks}). Each decode sequence "
@@ -1457,20 +1456,39 @@ class CompilationConfig:
                 num_blocks,
                 num_blocks,
             )
-            assert scheduler_config is not None
+            # TODO: this in-place mutation of scheduler_config + cudagraph
+            # sizes patches state that was already computed against the
+            # pre-clamp max_num_seqs. Long-term fix: defer cudagraph size
+            # finalization until after max_num_seqs is known
+            # (post-KV-cache-profiling) so the values are correct from
+            # the start. Until that refactor lands, any new
+            # max_num_seqs-dependent attribute on CompilationConfig must
+            # be re-clamped in `_clamp_cudagraph_sizes_to`.
             scheduler_config.max_num_seqs = num_blocks
-            if self.cudagraph_capture_sizes:
-                self.cudagraph_capture_sizes = [
-                    s for s in self.cudagraph_capture_sizes if s <= num_blocks
-                ]
-                if (
-                    self.max_cudagraph_capture_size is not None
-                    and self.max_cudagraph_capture_size > num_blocks
-                ):
-                    self.max_cudagraph_capture_size = num_blocks
+            self._clamp_cudagraph_sizes_to(num_blocks)
 
         self.cudagraph_mode = cudagraph_mode
         return cudagraph_mode
+
+    def _clamp_cudagraph_sizes_to(self, max_size: int) -> None:
+        """Clamp cudagraph capture sizes so they fit within `max_size`.
+
+        Filters `cudagraph_capture_sizes` and lowers
+        `max_cudagraph_capture_size` if either exceeds `max_size`. Used
+        when a downstream constraint (e.g. Mamba cache blocks) forces a
+        smaller batch size after the cudagraph sizes were already
+        computed in `VllmConfig`.
+        """
+        if not self.cudagraph_capture_sizes:
+            return
+        self.cudagraph_capture_sizes = [
+            s for s in self.cudagraph_capture_sizes if s <= max_size
+        ]
+        if (
+            self.max_cudagraph_capture_size is not None
+            and self.max_cudagraph_capture_size > max_size
+        ):
+            self.max_cudagraph_capture_size = max_size
 
     def adjust_cudagraph_sizes_for_spec_decode(
         self, uniform_decode_query_len: int, tensor_parallel_size: int

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -1449,10 +1449,10 @@ class CompilationConfig:
                     f"{num_blocks} or increase gpu_memory_utilization."
                 )
             logger.warning(
-                "max_num_seqs (%d) exceeds available Mamba cache blocks "
-                "(%d); auto-adjusting max_num_seqs to %d so CUDA graph "
-                "capture can proceed. Pass --max-num-seqs explicitly or "
-                "increase --gpu-memory-utilization to override.",
+                "Default max_num_seqs (%d) exceeds available Mamba cache "
+                "blocks (%d); auto-adjusting max_num_seqs to %d so CUDA "
+                "graph capture can proceed. Pass --max-num-seqs explicitly "
+                "or increase --gpu-memory-utilization to override.",
                 max_num_reqs,
                 num_blocks,
                 num_blocks,

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -67,6 +67,11 @@ class SchedulerConfig:
     In real usage, this should be set in `EngineArgs.create_engine_config`.
     """
 
+    original_max_num_seqs: int | None = None
+    """The user-supplied `max_num_seqs` before any defaulting, or `None` if
+    the user did not set it explicitly. Used to decide whether `max_num_seqs`
+    may be auto-adjusted (e.g. lowered to fit available Mamba cache blocks)."""
+
     max_num_partial_prefills: int = Field(default=1, ge=1)
     """For chunked prefill, the maximum number of sequences that can be
     partially prefilled concurrently."""

--- a/vllm/config/scheduler.py
+++ b/vllm/config/scheduler.py
@@ -69,8 +69,9 @@ class SchedulerConfig:
 
     original_max_num_seqs: int | None = None
     """The user-supplied `max_num_seqs` before any defaulting, or `None` if
-    the user did not set it explicitly. Used to decide whether `max_num_seqs`
-    may be auto-adjusted (e.g. lowered to fit available Mamba cache blocks)."""
+    the user did not set it explicitly. Set by `EngineArgs.create_engine_config`;
+    not user-configurable. Used to decide whether `max_num_seqs` may be auto-adjusted
+    (e.g. lowered to fit available Mamba cache blocks)."""
 
     max_num_partial_prefills: int = Field(default=1, ge=1)
     """For chunked prefill, the maximum number of sequences that can be

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -1935,6 +1935,7 @@ class EngineArgs:
             target_parallel_config=parallel_config,
         )
 
+        original_max_num_seqs = self.max_num_seqs
         self._set_default_max_num_seqs_and_batched_tokens_args(
             usage_context,
             model_config,
@@ -1955,6 +1956,7 @@ class EngineArgs:
             runner_type=model_config.runner_type,
             max_num_batched_tokens=self.max_num_batched_tokens,
             max_num_seqs=self.max_num_seqs,
+            original_max_num_seqs=original_max_num_seqs,
             max_model_len=model_config.max_model_len,
             enable_chunked_prefill=self.enable_chunked_prefill,
             disable_chunked_mm_input=self.disable_chunked_mm_input,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -376,7 +376,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.parallel_config.tensor_parallel_size,
             self.kv_cache_config,
             self.max_num_reqs,
-            self.scheduler_config,
+            scheduler_config=self.scheduler_config,
         )
         self.cudagraph_manager = ModelCudaGraphManager(
             self.vllm_config,

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -376,6 +376,7 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.parallel_config.tensor_parallel_size,
             self.kv_cache_config,
             self.max_num_reqs,
+            self.scheduler_config,
         )
         self.cudagraph_manager = ModelCudaGraphManager(
             self.vllm_config,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6434,6 +6434,7 @@ class GPUModelRunner(
             self.kv_cache_config,
             self.max_num_reqs,
             is_profiling=is_profiling,
+            scheduler_config=self.scheduler_config,
         )
         # Trigger cudagraph dispatching keys initialization after
         # resolved cudagraph mode.


### PR DESCRIPTION



## Purpose

Hybrid/Mamba models fail to start in tight memory configurations when the engine-determined default `max_num_seqs` exceeds the available Mamba cache blocks.
Each decode sequence needs one Mamba block, so CUDA graph capture refuses to proceed and a `ValueError` is raised at startup (introduced by #38270, which replaced an earlier silent cap with an explicit actionable error).

This PR auto-adjusts `max_num_seqs` to the available block count when the user did **not** pass `--max-num-seqs` explicitly, so the server can launch without manual tuning.
When the user *did* set it explicitly, the existing actionable `ValueError` is preserved.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

