### PR TITLE
[EPD-Disaggregation] Add CPU-GPU encoding transfers in new EC connector.

### DIFF
--- a/tests/v1/ec_connector/unit/test_ec_cpu_connector.py
+++ b/tests/v1/ec_connector/unit/test_ec_cpu_connector.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Unit tests for ECCPUConnector.
+"""
+
+from unittest.mock import Mock, patch
+
+import pytest
+import torch
+
+from vllm.config import VllmConfig
+from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorRole
+from vllm.distributed.ec_transfer.ec_connector.cpu_connector import (
+    ECCPUConnector,
+    ECCPUConnectorMetadata,
+)
+from vllm.v1.core.sched.output import SchedulerOutput
+
+NUM_BLOCKS = 16
+BLOCK_SIZE = 128
+
+
+def _make_mock_config(
+    num_ec_blocks: int = NUM_BLOCKS,
+    ec_hidden_dim: int = BLOCK_SIZE,
+    world_size: int = 1,
+    rank: int = 0,
+) -> Mock:
+    config = Mock(spec=VllmConfig)
+    config.ec_transfer_config = Mock()
+    config.ec_transfer_config.is_ec_producer = False
+    config.ec_transfer_config.is_ec_consumer = True
+    config.ec_transfer_config.engine_id = "test-engine-id"
+    config.ec_transfer_config.get_from_extra_config = lambda key, default: {
+        "num_ec_blocks": num_ec_blocks,
+        "ec_hidden_dim": ec_hidden_dim,
+    }.get(key, default)
+    config.parallel_config = Mock()
+    config.parallel_config.world_size = world_size
+    config.parallel_config.rank = rank
+    return config
+
+
+def _make_worker_connector(
+    num_ec_blocks: int = NUM_BLOCKS,
+    ec_hidden_dim: int = BLOCK_SIZE,
+) -> ECCPUConnector:
+    """Create a worker connector with ECSharedRegion patched out."""
+    config = _make_mock_config(num_ec_blocks=num_ec_blocks, ec_hidden_dim=ec_hidden_dim)
+    with patch(
+        "vllm.distributed.ec_transfer.ec_connector.cpu_connector.ECSharedRegion"
+    ) as mock_region_cls:
+        # The mock region returns a real tensor as .blocks
+        cpu_blocks = torch.arange(
+            num_ec_blocks * ec_hidden_dim,
+            dtype=torch.float32,
+        ).reshape(num_ec_blocks, ec_hidden_dim)
+        mock_region_cls.return_value.blocks = cpu_blocks
+
+        connector = ECCPUConnector(
+            vllm_config=config,
+            role=ECConnectorRole.WORKER,
+        )
+    return connector
+
+
+@pytest.fixture
+def scheduler_connector():
+    config = _make_mock_config()
+    return ECCPUConnector(
+        vllm_config=config,
+        role=ECConnectorRole.SCHEDULER,
+    )
+
+
+@pytest.fixture
+def worker_connector():
+    return _make_worker_connector()
+
+
+class TestBuildConnectorMeta:
+    def test_returns_metadata_with_encoding_map(self, scheduler_connector):
+        scheduler_connector._encoding_map = {
+            "hash_a": [0, 1, 2],
+            "hash_b": [3, 4],
+        }
+        scheduler_output = Mock(spec=SchedulerOutput)
+
+        meta = scheduler_connector.build_connector_meta(scheduler_output)
+
+        assert isinstance(meta, ECCPUConnectorMetadata)
+        assert meta.mm_hash_to_cpu_blocks == {
+            "hash_a": [0, 1, 2],
+            "hash_b": [3, 4],
+        }
+
+    def test_resets_encoding_map_after_build(self, scheduler_connector):
+        scheduler_connector._encoding_map = {
+            "hash_a": [0, 1],
+            "hash_b": [2, 3],
+        }
+        scheduler_output = Mock(spec=SchedulerOutput)
+
+        scheduler_connector.build_connector_meta(scheduler_output)
+
+        assert scheduler_connector._encoding_map == {}
+
+    def test_consecutive_builds_are_independent(self, scheduler_connector):
+        scheduler_output = Mock(spec=SchedulerOutput)
+
+        scheduler_connector._encoding_map = {"hash_a": [0, 1]}
+        meta1 = scheduler_connector.build_connector_meta(scheduler_output)
+
+        scheduler_connector._encoding_map = {"hash_b": [5, 6]}
+        meta2 = scheduler_connector.build_connector_meta(scheduler_output)
+
+        assert meta1.mm_hash_to_cpu_blocks == {"hash_a": [0, 1]}
+        assert meta2.mm_hash_to_cpu_blocks == {"hash_b": [5, 6]}
+
+    def test_empty_encoding_map(self, scheduler_connector):
+        scheduler_output = Mock(spec=SchedulerOutput)
+
+        meta = scheduler_connector.build_connector_meta(scheduler_output)
+
+        assert isinstance(meta, ECCPUConnectorMetadata)
+        assert meta.mm_hash_to_cpu_blocks == {}
+
+
+class TestStartLoadCaches:
+    @patch("vllm.distributed.ec_transfer.ec_connector.cpu_connector.current_platform")
+    def test_gathers_correct_blocks(self, mock_platform, worker_connector):
+        mock_platform.device_type = "cpu"
+
+        metadata = ECCPUConnectorMetadata(mm_hash_to_cpu_blocks={"hash_a": [2, 5]})
+        worker_connector.bind_connector_metadata(metadata)
+
+        encoder_cache: dict[str, torch.Tensor] = {}
+        worker_connector.start_load_caches(encoder_cache=encoder_cache)
+
+        assert "hash_a" in encoder_cache
+        expected = worker_connector._cpu_blocks[[2, 5]]
+        assert torch.equal(encoder_cache["hash_a"], expected)
+
+    @patch("vllm.distributed.ec_transfer.ec_connector.cpu_connector.current_platform")
+    def test_skips_existing_hash_in_encoder_cache(
+        self, mock_platform, worker_connector
+    ):
+        mock_platform.device_type = "cpu"
+
+        existing_tensor = torch.zeros(2, BLOCK_SIZE)
+        encoder_cache: dict[str, torch.Tensor] = {"hash_a": existing_tensor}
+
+        metadata = ECCPUConnectorMetadata(mm_hash_to_cpu_blocks={"hash_a": [0, 1]})
+        worker_connector.bind_connector_metadata(metadata)
+        worker_connector.start_load_caches(encoder_cache=encoder_cache)
+
+        assert torch.equal(encoder_cache["hash_a"], existing_tensor)
+
+    def test_empty_metadata(self, worker_connector):
+        metadata = ECCPUConnectorMetadata(mm_hash_to_cpu_blocks={})
+        worker_connector.bind_connector_metadata(metadata)
+
+        encoder_cache: dict[str, torch.Tensor] = {}
+        worker_connector.start_load_caches(encoder_cache=encoder_cache)
+
+        assert len(encoder_cache) == 0
+
+    @patch("vllm.distributed.ec_transfer.ec_connector.cpu_connector.current_platform")
+    def test_loads_multiple_encodings(self, mock_platform, worker_connector):
+        mock_platform.device_type = "cpu"
+
+        metadata = ECCPUConnectorMetadata(
+            mm_hash_to_cpu_blocks={
+                "hash_a": [0, 1],
+                "hash_b": [4, 5, 6],
+                "hash_c": [10],
+            }
+        )
+        worker_connector.bind_connector_metadata(metadata)
+
+        encoder_cache: dict[str, torch.Tensor] = {}
+        worker_connector.start_load_caches(encoder_cache=encoder_cache)
+
+        assert len(encoder_cache) == 3
+        assert torch.equal(
+            encoder_cache["hash_a"],
+            worker_connector._cpu_blocks[[0, 1]],
+        )
+        assert torch.equal(
+            encoder_cache["hash_b"],
+            worker_connector._cpu_blocks[[4, 5, 6]],
+        )
+        assert torch.equal(
+            encoder_cache["hash_c"],
+            worker_connector._cpu_blocks[[10]],
+        )
+
+
+class TestMetadataLifecycle:
+    def test_bind_and_retrieve(self, worker_connector):
+        metadata = ECCPUConnectorMetadata(mm_hash_to_cpu_blocks={"h": [0, 1]})
+        worker_connector.bind_connector_metadata(metadata)
+
+        assert worker_connector._get_connector_metadata() is metadata
+
+    def test_clear(self, worker_connector):
+        metadata = ECCPUConnectorMetadata(mm_hash_to_cpu_blocks={})
+        worker_connector.bind_connector_metadata(metadata)
+        worker_connector.clear_connector_metadata()
+
+        assert worker_connector._connector_metadata is None
+
+    def test_get_without_bind_raises(self, worker_connector):
+        with pytest.raises(AssertionError):
+            worker_connector._get_connector_metadata()

--- a/tests/v1/ec_connector/unit/test_ec_cpu_connector.py
+++ b/tests/v1/ec_connector/unit/test_ec_cpu_connector.py
@@ -26,8 +26,6 @@ BLOCK_SIZE_BYTES = HIDDEN_DIM * ELEMENT_SIZE
 
 def _make_mock_config(
     num_ec_blocks: int = NUM_BLOCKS,
-    world_size: int = 1,
-    rank: int = 0,
 ) -> Mock:
     config = Mock(spec=VllmConfig)
     config.ec_transfer_config = Mock()
@@ -38,8 +36,7 @@ def _make_mock_config(
         "num_ec_blocks": num_ec_blocks,
     }.get(key, default)
     config.parallel_config = Mock()
-    config.parallel_config.world_size = world_size
-    config.parallel_config.rank = rank
+    config.parallel_config.rank = 0
     config.model_config = Mock()
     config.model_config.get_inputs_embeds_size.return_value = HIDDEN_DIM
     config.model_config.dtype = DTYPE

--- a/tests/v1/ec_connector/unit/test_ec_cpu_connector.py
+++ b/tests/v1/ec_connector/unit/test_ec_cpu_connector.py
@@ -10,7 +10,10 @@ import pytest
 import torch
 
 from vllm.config import VllmConfig
-from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorRole
+from vllm.distributed.ec_transfer.ec_connector.base import (
+    ECConnectorRole,
+    EncoderConfig,
+)
 from vllm.distributed.ec_transfer.ec_connector.cpu_connector import (
     ECCPUConnector,
     ECCPUConnectorMetadata,
@@ -18,12 +21,17 @@ from vllm.distributed.ec_transfer.ec_connector.cpu_connector import (
 from vllm.v1.core.sched.output import SchedulerOutput
 
 NUM_BLOCKS = 16
-BLOCK_SIZE = 128
+HIDDEN_DIM = 32
+DTYPE = torch.float32
+ELEMENT_SIZE = 4  # float32
+
+ENCODER_CONFIG = EncoderConfig(
+    hidden_dim=HIDDEN_DIM, dtype=DTYPE, element_size=ELEMENT_SIZE
+)
 
 
 def _make_mock_config(
     num_ec_blocks: int = NUM_BLOCKS,
-    ec_hidden_dim: int = BLOCK_SIZE,
     world_size: int = 1,
     rank: int = 0,
 ) -> Mock:
@@ -34,7 +42,6 @@ def _make_mock_config(
     config.ec_transfer_config.engine_id = "test-engine-id"
     config.ec_transfer_config.get_from_extra_config = lambda key, default: {
         "num_ec_blocks": num_ec_blocks,
-        "ec_hidden_dim": ec_hidden_dim,
     }.get(key, default)
     config.parallel_config = Mock()
     config.parallel_config.world_size = world_size
@@ -44,24 +51,25 @@ def _make_mock_config(
 
 def _make_worker_connector(
     num_ec_blocks: int = NUM_BLOCKS,
-    ec_hidden_dim: int = BLOCK_SIZE,
 ) -> ECCPUConnector:
     """Create a worker connector with ECSharedRegion patched out."""
-    config = _make_mock_config(num_ec_blocks=num_ec_blocks, ec_hidden_dim=ec_hidden_dim)
+    config = _make_mock_config(num_ec_blocks=num_ec_blocks)
+    connector = ECCPUConnector(
+        vllm_config=config,
+        role=ECConnectorRole.WORKER,
+    )
+
+    block_size_bytes = ENCODER_CONFIG.block_size_bytes
     with patch(
         "vllm.distributed.ec_transfer.ec_connector.cpu_connector.ECSharedRegion"
     ) as mock_region_cls:
-        # The mock region returns a real tensor as .blocks
         cpu_blocks = torch.arange(
-            num_ec_blocks * ec_hidden_dim,
-            dtype=torch.float32,
-        ).reshape(num_ec_blocks, ec_hidden_dim)
+            num_ec_blocks * block_size_bytes,
+            dtype=torch.uint8,
+        ).reshape(num_ec_blocks, block_size_bytes)
         mock_region_cls.return_value.blocks = cpu_blocks
 
-        connector = ECCPUConnector(
-            vllm_config=config,
-            role=ECConnectorRole.WORKER,
-        )
+        connector.register_caches(ENCODER_CONFIG)
     return connector
 
 
@@ -148,7 +156,7 @@ class TestStartLoadCaches:
     ):
         mock_platform.device_type = "cpu"
 
-        existing_tensor = torch.zeros(2, BLOCK_SIZE)
+        existing_tensor = torch.zeros(2, ENCODER_CONFIG.block_size_bytes)
         encoder_cache: dict[str, torch.Tensor] = {"hash_a": existing_tensor}
 
         metadata = ECCPUConnectorMetadata(mm_hash_to_cpu_blocks={"hash_a": [0, 1]})

--- a/tests/v1/ec_connector/unit/test_ec_cpu_connector.py
+++ b/tests/v1/ec_connector/unit/test_ec_cpu_connector.py
@@ -10,10 +10,7 @@ import pytest
 import torch
 
 from vllm.config import VllmConfig
-from vllm.distributed.ec_transfer.ec_connector.base import (
-    ECConnectorRole,
-    EncoderConfig,
-)
+from vllm.distributed.ec_transfer.ec_connector.base import ECConnectorRole
 from vllm.distributed.ec_transfer.ec_connector.cpu_connector import (
     ECCPUConnector,
     ECCPUConnectorMetadata,
@@ -24,10 +21,7 @@ NUM_BLOCKS = 16
 HIDDEN_DIM = 32
 DTYPE = torch.float32
 ELEMENT_SIZE = 4  # float32
-
-ENCODER_CONFIG = EncoderConfig(
-    hidden_dim=HIDDEN_DIM, dtype=DTYPE, element_size=ELEMENT_SIZE
-)
+BLOCK_SIZE_BYTES = HIDDEN_DIM * ELEMENT_SIZE
 
 
 def _make_mock_config(
@@ -46,6 +40,9 @@ def _make_mock_config(
     config.parallel_config = Mock()
     config.parallel_config.world_size = world_size
     config.parallel_config.rank = rank
+    config.model_config = Mock()
+    config.model_config.get_inputs_embeds_size.return_value = HIDDEN_DIM
+    config.model_config.dtype = DTYPE
     return config
 
 
@@ -54,22 +51,20 @@ def _make_worker_connector(
 ) -> ECCPUConnector:
     """Create a worker connector with ECSharedRegion patched out."""
     config = _make_mock_config(num_ec_blocks=num_ec_blocks)
-    connector = ECCPUConnector(
-        vllm_config=config,
-        role=ECConnectorRole.WORKER,
-    )
 
-    block_size_bytes = ENCODER_CONFIG.block_size_bytes
+    cpu_blocks = torch.arange(
+        num_ec_blocks * BLOCK_SIZE_BYTES,
+        dtype=torch.uint8,
+    ).reshape(num_ec_blocks, BLOCK_SIZE_BYTES)
+
     with patch(
         "vllm.distributed.ec_transfer.ec_connector.cpu_connector.ECSharedRegion"
     ) as mock_region_cls:
-        cpu_blocks = torch.arange(
-            num_ec_blocks * block_size_bytes,
-            dtype=torch.uint8,
-        ).reshape(num_ec_blocks, block_size_bytes)
         mock_region_cls.return_value.blocks = cpu_blocks
-
-        connector.register_caches(ENCODER_CONFIG)
+        connector = ECCPUConnector(
+            vllm_config=config,
+            role=ECConnectorRole.WORKER,
+        )
     return connector
 
 
@@ -156,7 +151,7 @@ class TestStartLoadCaches:
     ):
         mock_platform.device_type = "cpu"
 
-        existing_tensor = torch.zeros(2, ENCODER_CONFIG.block_size_bytes)
+        existing_tensor = torch.zeros(2, BLOCK_SIZE_BYTES)
         encoder_cache: dict[str, torch.Tensor] = {"hash_a": existing_tensor}
 
         metadata = ECCPUConnectorMetadata(mm_hash_to_cpu_blocks={"hash_a": [0, 1]})

--- a/vllm/distributed/ec_transfer/ec_connector/base.py
+++ b/vllm/distributed/ec_transfer/ec_connector/base.py
@@ -24,6 +24,7 @@ The class provides the following primitives:
 
 import enum
 from abc import ABC, abstractmethod
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 import torch
@@ -37,6 +38,17 @@ if TYPE_CHECKING:
     from vllm.v1.request import Request
 
 logger = init_logger(__name__)
+
+
+@dataclass(frozen=True)
+class EncoderConfig:
+    hidden_dim: int
+    dtype: torch.dtype
+    element_size: int
+
+    @property
+    def block_size_bytes(self) -> int:
+        return self.hidden_dim * self.element_size
 
 
 class ECConnectorRole(enum.Enum):

--- a/vllm/distributed/ec_transfer/ec_connector/base.py
+++ b/vllm/distributed/ec_transfer/ec_connector/base.py
@@ -190,7 +190,7 @@ class ECConnectorBase(ABC):
     def has_cache_item(
         self,
         identifier: str,
-    ) -> bool:
+    ) -> bool | None:
         """
         Check if a single encoder cache exists
 
@@ -200,6 +200,9 @@ class ECConnectorBase(ABC):
         Returns:
             A bool where value is True if cache exist for
             the media
+            If None, it means that the connector needs more time to
+            determine whether the item is actually in the cache, or
+            was computed by E node and still isn't available.
         """
         pass
 

--- a/vllm/distributed/ec_transfer/ec_connector/cpu_connector.py
+++ b/vllm/distributed/ec_transfer/ec_connector/cpu_connector.py
@@ -12,6 +12,7 @@ from vllm.distributed.ec_transfer.ec_connector.base import (
     ECConnectorRole,
 )
 from vllm.logger import init_logger
+from vllm.platforms import current_platform
 from vllm.v1.core.sched.output import SchedulerOutput
 
 if TYPE_CHECKING:
@@ -37,23 +38,30 @@ class ECCPUConnector(ECConnectorBase):
         # mm_hash -> (offset, size) in the flat CPU buffer
         self._encoding_map: dict[str, tuple[int, int]] = {}
 
+        self._cpu_buffer: torch.Tensor | None = None
+
     # ==============================
     # Worker-side methods
     # ==============================
 
     def register_caches(self, ec_caches: dict[str, torch.Tensor]):
+        """
+        This needs to be called by someone
+        Or, alternatively, create the cpu buffer in init().
+        """
+
+        if "cpu_buffer" not in ec_caches:
+            raise ValueError("ECCPUConnector requires 'cpu_buffer' in ec_caches")
         self._cpu_buffer = ec_caches["cpu_buffer"]
 
     def start_load_caches(
         self, encoder_cache: dict[str, torch.Tensor], **kwargs
     ) -> None:
-        from vllm.platforms import current_platform
-
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, ECCPUConnectorMetadata)
 
         for mm_hash, (offset, size) in metadata.mm_hash_to_cpu_loc.items():
-            if mm_hash in encoder_cache:
+            if mm_hash in encoder_cache or not self._cpu_buffer:
                 continue
             encoder_cache[mm_hash] = self._cpu_buffer[offset : offset + size].to(
                 device=current_platform.device_type, non_blocking=True

--- a/vllm/distributed/ec_transfer/ec_connector/cpu_connector.py
+++ b/vllm/distributed/ec_transfer/ec_connector/cpu_connector.py
@@ -55,17 +55,13 @@ class ECCPUConnector(ECConnectorBase):
             block_size_bytes = hidden_dim * element_size
 
             num_ec_blocks = int(ec_config.get_from_extra_config("num_ec_blocks", 256))
-            num_workers = vllm_config.parallel_config.world_size
-            rank = vllm_config.parallel_config.rank
 
             self._region = ECSharedRegion(
                 instance_id=ec_config.engine_id,
                 num_blocks=num_ec_blocks,
                 block_size_bytes=block_size_bytes,
-                num_workers=num_workers,
-                rank=rank,
             )
-            if is_pin_memory_available():
+            if is_pin_memory_available() and vllm_config.parallel_config.rank == 0:
                 self._region.pin_memory()
             self._cpu_blocks = self._region.blocks
 

--- a/vllm/distributed/ec_transfer/ec_connector/cpu_connector.py
+++ b/vllm/distributed/ec_transfer/ec_connector/cpu_connector.py
@@ -10,7 +10,6 @@ from vllm.distributed.ec_transfer.ec_connector.base import (
     ECConnectorBase,
     ECConnectorMetadata,
     ECConnectorRole,
-    EncoderConfig,
 )
 from vllm.distributed.ec_transfer.ec_connector.ec_shared_region import (
     ECSharedRegion,
@@ -49,29 +48,35 @@ class ECCPUConnector(ECConnectorBase):
             ec_config = vllm_config.ec_transfer_config
             assert ec_config is not None
 
-            self._engine_id = ec_config.engine_id
-            self._num_ec_blocks = int(
-                ec_config.get_from_extra_config("num_ec_blocks", 256)
+            hidden_dim = vllm_config.model_config.get_inputs_embeds_size()
+            element_size = torch.tensor(
+                [], dtype=vllm_config.model_config.dtype
+            ).element_size()
+            block_size_bytes = hidden_dim * element_size
+
+            num_ec_blocks = int(ec_config.get_from_extra_config("num_ec_blocks", 256))
+            num_workers = vllm_config.parallel_config.world_size
+            rank = vllm_config.parallel_config.rank
+
+            self._region = ECSharedRegion(
+                instance_id=ec_config.engine_id,
+                num_blocks=num_ec_blocks,
+                block_size_bytes=block_size_bytes,
+                num_workers=num_workers,
+                rank=rank,
             )
-            self._num_workers = vllm_config.parallel_config.world_size
-            self._rank = vllm_config.parallel_config.rank
+            if is_pin_memory_available():
+                self._region.pin_memory()
+            self._cpu_blocks = self._region.blocks
 
-            self._region: ECSharedRegion | None = None
-            self._cpu_blocks: torch.Tensor | None = None
+            self._copy_stream: torch.cuda.Stream | None = None
+            self._copy_event: torch.Event | None = None
 
-    def register_caches(  # type: ignore[override]
-        self, encoder_config: EncoderConfig
-    ) -> None:
-        self._region = ECSharedRegion(
-            instance_id=self._engine_id,
-            num_blocks=self._num_ec_blocks,
-            block_size_bytes=encoder_config.block_size_bytes,
-            num_workers=self._num_workers,
-            rank=self._rank,
-        )
-        if is_pin_memory_available():
-            self._region.pin_memory()
-        self._cpu_blocks = self._region.blocks
+    def register_caches(
+        self,
+        ec_caches: dict[str, torch.Tensor],
+    ):
+        raise NotImplementedError
 
     # ==============================
     # Worker-side methods
@@ -83,13 +88,23 @@ class ECCPUConnector(ECConnectorBase):
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, ECCPUConnectorMetadata)
 
-        assert self._cpu_blocks is not None, "register_caches() not called"
-        for mm_hash, block_indices in metadata.mm_hash_to_cpu_blocks.items():
-            if mm_hash in encoder_cache:
-                continue
-            encoder_cache[mm_hash] = self._cpu_blocks[block_indices].to(
-                device=current_platform.device_type, non_blocking=True
-            )
+        assert self._cpu_blocks is not None
+
+        if self._copy_stream is None:
+            self._copy_stream = torch.cuda.Stream()
+            self._copy_event = torch.Event()
+        assert self._copy_event is not None
+
+        with torch.cuda.stream(self._copy_stream):
+            for mm_hash, block_indices in metadata.mm_hash_to_cpu_blocks.items():
+                if mm_hash in encoder_cache:
+                    continue
+                encoder_cache[mm_hash] = self._cpu_blocks[block_indices].to(
+                    device=current_platform.device_type, non_blocking=True
+                )
+            self._copy_event.record(self._copy_stream)
+
+        torch.cuda.current_stream().wait_event(self._copy_event)
 
     def save_caches(
         self, encoder_cache: dict[str, torch.Tensor], mm_hash: str, **kwargs

--- a/vllm/distributed/ec_transfer/ec_connector/cpu_connector.py
+++ b/vllm/distributed/ec_transfer/ec_connector/cpu_connector.py
@@ -11,8 +11,12 @@ from vllm.distributed.ec_transfer.ec_connector.base import (
     ECConnectorMetadata,
     ECConnectorRole,
 )
+from vllm.distributed.ec_transfer.ec_connector.ec_shared_region import (
+    ECSharedRegion,
+)
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
+from vllm.utils.platform_utils import is_pin_memory_available
 from vllm.v1.core.sched.output import SchedulerOutput
 
 if TYPE_CHECKING:
@@ -23,8 +27,8 @@ logger = init_logger(__name__)
 
 @dataclass
 class ECCPUConnectorMetadata(ECConnectorMetadata):
-    # mm_hash -> (offset, size) in the flat CPU buffer
-    mm_hash_to_cpu_loc: dict[str, tuple[int, int]] = field(default_factory=dict)
+    # mm_hash -> list of block indices in the shared CPU region
+    mm_hash_to_cpu_blocks: dict[str, list[int]] = field(default_factory=dict)
 
 
 class ECCPUConnector(ECConnectorBase):
@@ -35,24 +39,38 @@ class ECCPUConnector(ECConnectorBase):
 
     def __init__(self, vllm_config: "VllmConfig", role: ECConnectorRole):
         super().__init__(vllm_config=vllm_config, role=role)
-        # mm_hash -> (offset, size) in the flat CPU buffer
-        self._encoding_map: dict[str, tuple[int, int]] = {}
 
-        self._cpu_buffer: torch.Tensor | None = None
+        if self.role == ECConnectorRole.SCHEDULER:
+            # mm_hash -> list of block indices in the shared CPU region
+            self._encoding_map: dict[str, list[int]] = {}
+
+        if self.role == ECConnectorRole.WORKER:
+            ec_config = vllm_config.ec_transfer_config
+            assert ec_config is not None
+
+            num_ec_blocks = ec_config.get_from_extra_config("num_ec_blocks", None)
+            ec_hidden_dim = ec_config.get_from_extra_config("ec_hidden_dim", None)
+            if num_ec_blocks is None or ec_hidden_dim is None:
+                raise ValueError(
+                    "ECCPUConnector requires 'num_ec_blocks' and "
+                    "'ec_hidden_dim' in ec_connector_extra_config"
+                )
+
+            parallel_config = vllm_config.parallel_config
+            self._region = ECSharedRegion(
+                instance_id=ec_config.engine_id,
+                num_blocks=int(num_ec_blocks),
+                block_size_bytes=int(ec_hidden_dim),
+                num_workers=parallel_config.world_size,
+                rank=parallel_config.rank,
+            )
+            if is_pin_memory_available():
+                self._region.pin_memory()
+            self._cpu_blocks = self._region.blocks
 
     # ==============================
     # Worker-side methods
     # ==============================
-
-    def register_caches(self, ec_caches: dict[str, torch.Tensor]):
-        """
-        This needs to be called by someone
-        Or, alternatively, create the cpu buffer in init().
-        """
-
-        if "cpu_buffer" not in ec_caches:
-            raise ValueError("ECCPUConnector requires 'cpu_buffer' in ec_caches")
-        self._cpu_buffer = ec_caches["cpu_buffer"]
 
     def start_load_caches(
         self, encoder_cache: dict[str, torch.Tensor], **kwargs
@@ -60,10 +78,10 @@ class ECCPUConnector(ECConnectorBase):
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, ECCPUConnectorMetadata)
 
-        for mm_hash, (offset, size) in metadata.mm_hash_to_cpu_loc.items():
-            if mm_hash in encoder_cache or not self._cpu_buffer:
+        for mm_hash, block_indices in metadata.mm_hash_to_cpu_blocks.items():
+            if mm_hash in encoder_cache:
                 continue
-            encoder_cache[mm_hash] = self._cpu_buffer[offset : offset + size].to(
+            encoder_cache[mm_hash] = self._cpu_blocks[block_indices].to(
                 device=current_platform.device_type, non_blocking=True
             )
 
@@ -89,7 +107,7 @@ class ECCPUConnector(ECConnectorBase):
         self, scheduler_output: SchedulerOutput
     ) -> ECCPUConnectorMetadata:
         meta = ECCPUConnectorMetadata(
-            mm_hash_to_cpu_loc=self._encoding_map,
+            mm_hash_to_cpu_blocks=self._encoding_map,
         )
         self._encoding_map = {}
         return meta

--- a/vllm/distributed/ec_transfer/ec_connector/cpu_connector.py
+++ b/vllm/distributed/ec_transfer/ec_connector/cpu_connector.py
@@ -10,6 +10,7 @@ from vllm.distributed.ec_transfer.ec_connector.base import (
     ECConnectorBase,
     ECConnectorMetadata,
     ECConnectorRole,
+    EncoderConfig,
 )
 from vllm.distributed.ec_transfer.ec_connector.ec_shared_region import (
     ECSharedRegion,
@@ -48,25 +49,29 @@ class ECCPUConnector(ECConnectorBase):
             ec_config = vllm_config.ec_transfer_config
             assert ec_config is not None
 
-            num_ec_blocks = ec_config.get_from_extra_config("num_ec_blocks", None)
-            ec_hidden_dim = ec_config.get_from_extra_config("ec_hidden_dim", None)
-            if num_ec_blocks is None or ec_hidden_dim is None:
-                raise ValueError(
-                    "ECCPUConnector requires 'num_ec_blocks' and "
-                    "'ec_hidden_dim' in ec_connector_extra_config"
-                )
-
-            parallel_config = vllm_config.parallel_config
-            self._region = ECSharedRegion(
-                instance_id=ec_config.engine_id,
-                num_blocks=int(num_ec_blocks),
-                block_size_bytes=int(ec_hidden_dim),
-                num_workers=parallel_config.world_size,
-                rank=parallel_config.rank,
+            self._engine_id = ec_config.engine_id
+            self._num_ec_blocks = int(
+                ec_config.get_from_extra_config("num_ec_blocks", 256)
             )
-            if is_pin_memory_available():
-                self._region.pin_memory()
-            self._cpu_blocks = self._region.blocks
+            self._num_workers = vllm_config.parallel_config.world_size
+            self._rank = vllm_config.parallel_config.rank
+
+            self._region: ECSharedRegion | None = None
+            self._cpu_blocks: torch.Tensor | None = None
+
+    def register_caches(  # type: ignore[override]
+        self, encoder_config: EncoderConfig
+    ) -> None:
+        self._region = ECSharedRegion(
+            instance_id=self._engine_id,
+            num_blocks=self._num_ec_blocks,
+            block_size_bytes=encoder_config.block_size_bytes,
+            num_workers=self._num_workers,
+            rank=self._rank,
+        )
+        if is_pin_memory_available():
+            self._region.pin_memory()
+        self._cpu_blocks = self._region.blocks
 
     # ==============================
     # Worker-side methods
@@ -78,6 +83,7 @@ class ECCPUConnector(ECConnectorBase):
         metadata = self._get_connector_metadata()
         assert isinstance(metadata, ECCPUConnectorMetadata)
 
+        assert self._cpu_blocks is not None, "register_caches() not called"
         for mm_hash, block_indices in metadata.mm_hash_to_cpu_blocks.items():
             if mm_hash in encoder_cache:
                 continue

--- a/vllm/distributed/ec_transfer/ec_connector/cpu_connector.py
+++ b/vllm/distributed/ec_transfer/ec_connector/cpu_connector.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.distributed.ec_transfer.ec_connector.base import (
+    ECConnectorBase,
+    ECConnectorMetadata,
+    ECConnectorRole,
+)
+from vllm.logger import init_logger
+from vllm.v1.core.sched.output import SchedulerOutput
+
+if TYPE_CHECKING:
+    from vllm.v1.request import Request
+
+logger = init_logger(__name__)
+
+
+@dataclass
+class ECCPUConnectorMetadata(ECConnectorMetadata):
+    # mm_hash -> (offset, size) in the flat CPU buffer
+    mm_hash_to_cpu_loc: dict[str, tuple[int, int]] = field(default_factory=dict)
+
+
+class ECCPUConnector(ECConnectorBase):
+    """EC connector for E-PD disaggregation.
+
+    Loads encodings from a remote Encoder node into a dedicated CPU cache,
+    and loads them to the GPU on demand."""
+
+    def __init__(self, vllm_config: "VllmConfig", role: ECConnectorRole):
+        super().__init__(vllm_config=vllm_config, role=role)
+        # mm_hash -> (offset, size) in the flat CPU buffer
+        self._encoding_map: dict[str, tuple[int, int]] = {}
+
+    # ==============================
+    # Worker-side methods
+    # ==============================
+
+    def register_caches(self, ec_caches: dict[str, torch.Tensor]):
+        self._cpu_buffer = ec_caches["cpu_buffer"]
+
+    def start_load_caches(
+        self, encoder_cache: dict[str, torch.Tensor], **kwargs
+    ) -> None:
+        from vllm.platforms import current_platform
+
+        metadata = self._get_connector_metadata()
+        assert isinstance(metadata, ECCPUConnectorMetadata)
+
+        for mm_hash, (offset, size) in metadata.mm_hash_to_cpu_loc.items():
+            if mm_hash in encoder_cache:
+                continue
+            encoder_cache[mm_hash] = self._cpu_buffer[offset : offset + size].to(
+                device=current_platform.device_type, non_blocking=True
+            )
+
+    def save_caches(
+        self, encoder_cache: dict[str, torch.Tensor], mm_hash: str, **kwargs
+    ) -> None:
+        raise NotImplementedError
+
+    # ==============================
+    # Scheduler-side methods
+    # ==============================
+
+    def has_cache_item(
+        self,
+        identifier: str,
+    ) -> bool | None:
+        raise NotImplementedError
+
+    def update_state_after_alloc(self, request: "Request", index: int):
+        raise NotImplementedError
+
+    def build_connector_meta(
+        self, scheduler_output: SchedulerOutput
+    ) -> ECCPUConnectorMetadata:
+        meta = ECCPUConnectorMetadata(
+            mm_hash_to_cpu_loc=self._encoding_map,
+        )
+        self._encoding_map = {}
+        return meta

--- a/vllm/distributed/ec_transfer/ec_connector/ec_shared_region.py
+++ b/vllm/distributed/ec_transfer/ec_connector/ec_shared_region.py
@@ -4,7 +4,7 @@
 Lightweight mmap-backed shared memory region for encoder cache (EC) data.
 
 Modeled after SharedOffloadRegion (vllm/v1/kv_offload/cpu/) but simplified
-for EC: single view per worker, no multi-tensor cursor, no block_size_factor.
+for EC: flat shared layout, no multi-tensor cursor, no block_size_factor.
 """
 
 import mmap
@@ -33,16 +33,11 @@ def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0):
 
 class ECSharedRegion:
     """
-    Single mmap-backed memory region shared across TP workers for
+    Flat mmap-backed memory region shared across TP workers for
     encoder cache blocks.
 
-    Layout (interleaved by worker):
-        Row for block 0: [ worker0_slot | worker1_slot | ... ]
-        Row for block 1: [ worker0_slot | worker1_slot | ... ]
-        ...
-
-    Each worker gets a strided view of shape (num_blocks, block_size_bytes)
-    that skips over other workers' slots.
+    Layout: (num_blocks, block_size_bytes) — contiguous, no per-worker
+    interleaving.  All workers map the same file and see identical data.
 
     File path: /dev/shm/vllm_ec_{instance_id}.mmap
     """
@@ -52,16 +47,11 @@ class ECSharedRegion:
         instance_id: str,
         num_blocks: int,
         block_size_bytes: int,
-        num_workers: int,
-        rank: int,
     ) -> None:
         self.num_blocks = num_blocks
         self.block_size_bytes = block_size_bytes
-        self.num_workers = num_workers
-        self.rank = rank
 
-        self._row_stride = block_size_bytes * num_workers
-        self.total_size_bytes = num_blocks * self._row_stride
+        self.total_size_bytes = num_blocks * block_size_bytes
         self.mmap_path = f"/dev/shm/vllm_ec_{instance_id}.mmap"
         self._creator = False
 
@@ -89,29 +79,16 @@ class ECSharedRegion:
             prot=mmap.PROT_READ | mmap.PROT_WRITE,
         )
 
-        # Populate this worker's pages
-        _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
-        page_size = mmap.PAGESIZE
-        worker_offset = rank * block_size_bytes
-        for block in range(num_blocks):
-            raw_offset = block * self._row_stride + worker_offset
-            aligned_offset = (raw_offset // page_size) * page_size
-            end = raw_offset + block_size_bytes
-            aligned_length = end - aligned_offset
-            self.mmap_obj.madvise(_MADV_POPULATE_WRITE, aligned_offset, aligned_length)
+        if self._creator:
+            _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
+            self.mmap_obj.madvise(_MADV_POPULATE_WRITE, 0, self.total_size_bytes)
 
         self._base: torch.Tensor | None = torch.frombuffer(
             memoryview(self.mmap_obj), dtype=torch.int8
         )
         self.is_pinned: bool = False
 
-        # Single strided view for this worker
-        self.blocks: torch.Tensor = torch.as_strided(
-            self._base,
-            size=(num_blocks, block_size_bytes),
-            stride=(self._row_stride, 1),
-            storage_offset=rank * block_size_bytes,
-        )
+        self.blocks: torch.Tensor = self._base.view(num_blocks, block_size_bytes)
 
     def pin_memory(self) -> None:
         """Register the entire mmap as CUDA pinned memory for fast DMA."""
@@ -123,15 +100,13 @@ class ECSharedRegion:
         )
         if result.value != 0:
             logger.warning(
-                "cudaHostRegister failed for rank=%d (code=%d) — "
+                "cudaHostRegister failed (code=%d) — "
                 "transfers will still work but may be slower (unpinned DMA)",
-                self.rank,
                 result,
             )
         else:
             logger.debug(
-                "cudaHostRegister rank=%d %.2f MB",
-                self.rank,
+                "cudaHostRegister %.2f MB",
                 self.total_size_bytes / 1e6,
             )
             self.is_pinned = True
@@ -142,8 +117,7 @@ class ECSharedRegion:
             result = torch.cuda.cudart().cudaHostUnregister(base_ptr)
             if result.value != 0:
                 logger.warning(
-                    "cudaHostUnregister failed for rank=%d (code=%d)",
-                    self.rank,
+                    "cudaHostUnregister failed (code=%d)",
                     result,
                 )
             self.is_pinned = False

--- a/vllm/distributed/ec_transfer/ec_connector/ec_shared_region.py
+++ b/vllm/distributed/ec_transfer/ec_connector/ec_shared_region.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Lightweight mmap-backed shared memory region for encoder cache (EC) data.
+
+Modeled after SharedOffloadRegion (vllm/v1/kv_offload/cpu/) but simplified
+for EC: single view per worker, no multi-tensor cursor, no block_size_factor.
+"""
+
+import mmap
+import os
+import time
+
+import torch
+
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def _wait_for_file_size(fd: int, expected_size: int, timeout: float = 30.0):
+    """Spin-wait until the file reaches expected_size (creator truncated it)."""
+    deadline = time.monotonic() + timeout
+    while True:
+        if os.fstat(fd).st_size >= expected_size:
+            return
+        if time.monotonic() > deadline:
+            raise TimeoutError(
+                f"Timed out waiting for EC mmap file to reach {expected_size} bytes"
+            )
+        time.sleep(0.005)
+
+
+class ECSharedRegion:
+    """
+    Single mmap-backed memory region shared across TP workers for
+    encoder cache blocks.
+
+    Layout (interleaved by worker):
+        Row for block 0: [ worker0_slot | worker1_slot | ... ]
+        Row for block 1: [ worker0_slot | worker1_slot | ... ]
+        ...
+
+    Each worker gets a strided view of shape (num_blocks, block_size_bytes)
+    that skips over other workers' slots.
+
+    File path: /dev/shm/vllm_ec_{instance_id}.mmap
+    """
+
+    def __init__(
+        self,
+        instance_id: str,
+        num_blocks: int,
+        block_size_bytes: int,
+        num_workers: int,
+        rank: int,
+    ) -> None:
+        self.num_blocks = num_blocks
+        self.block_size_bytes = block_size_bytes
+        self.num_workers = num_workers
+        self.rank = rank
+
+        self._row_stride = block_size_bytes * num_workers
+        self.total_size_bytes = num_blocks * self._row_stride
+        self.mmap_path = f"/dev/shm/vllm_ec_{instance_id}.mmap"
+        self._creator = False
+
+        # Creator/joiner race: first worker creates, others wait
+        try:
+            self.fd: int | None = os.open(
+                self.mmap_path, os.O_CREAT | os.O_EXCL | os.O_RDWR, 0o600
+            )
+            os.ftruncate(self.fd, self.total_size_bytes)
+            self._creator = True
+            logger.info(
+                "Created EC mmap file %s (%.2f MB)",
+                self.mmap_path,
+                self.total_size_bytes / 1e6,
+            )
+        except FileExistsError:
+            self.fd = os.open(self.mmap_path, os.O_RDWR)
+            _wait_for_file_size(self.fd, self.total_size_bytes)
+            logger.info("Opened existing EC mmap file %s", self.mmap_path)
+
+        self.mmap_obj: mmap.mmap | None = mmap.mmap(
+            self.fd,
+            self.total_size_bytes,
+            flags=mmap.MAP_SHARED,
+            prot=mmap.PROT_READ | mmap.PROT_WRITE,
+        )
+
+        # Populate this worker's pages
+        _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
+        page_size = mmap.PAGESIZE
+        worker_offset = rank * block_size_bytes
+        for block in range(num_blocks):
+            raw_offset = block * self._row_stride + worker_offset
+            aligned_offset = (raw_offset // page_size) * page_size
+            end = raw_offset + block_size_bytes
+            aligned_length = end - aligned_offset
+            self.mmap_obj.madvise(_MADV_POPULATE_WRITE, aligned_offset, aligned_length)
+
+        self._base: torch.Tensor | None = torch.frombuffer(
+            memoryview(self.mmap_obj), dtype=torch.int8
+        )
+        self.is_pinned: bool = False
+
+        # Single strided view for this worker
+        self.blocks: torch.Tensor = torch.as_strided(
+            self._base,
+            size=(num_blocks, block_size_bytes),
+            stride=(self._row_stride, 1),
+            storage_offset=rank * block_size_bytes,
+        )
+
+    def pin_memory(self) -> None:
+        """Register the entire mmap as CUDA pinned memory for fast DMA."""
+        if self._base is None:
+            return
+        base_ptr = self._base.data_ptr()
+        result = torch.cuda.cudart().cudaHostRegister(
+            base_ptr, self.total_size_bytes, 0
+        )
+        if result.value != 0:
+            logger.warning(
+                "cudaHostRegister failed for rank=%d (code=%d) — "
+                "transfers will still work but may be slower (unpinned DMA)",
+                self.rank,
+                result,
+            )
+        else:
+            logger.debug(
+                "cudaHostRegister rank=%d %.2f MB",
+                self.rank,
+                self.total_size_bytes / 1e6,
+            )
+            self.is_pinned = True
+
+    def cleanup(self) -> None:
+        if self.is_pinned and self._base is not None:
+            base_ptr = self._base.data_ptr()
+            result = torch.cuda.cudart().cudaHostUnregister(base_ptr)
+            if result.value != 0:
+                logger.warning(
+                    "cudaHostUnregister failed for rank=%d (code=%d)",
+                    self.rank,
+                    result,
+                )
+            self.is_pinned = False
+        self.blocks = None  # type: ignore[assignment]
+        self._base = None
+        if self.mmap_obj:
+            try:
+                self.mmap_obj.close()
+            except Exception:
+                logger.warning("Failed to close mmap_obj", exc_info=True)
+            self.mmap_obj = None
+        if self.fd is not None:
+            try:
+                os.close(self.fd)
+            except Exception:
+                logger.warning("Failed to close fd %s", self.fd, exc_info=True)
+            self.fd = None
+        if self._creator and getattr(self, "mmap_path", None):
+            try:
+                os.unlink(self.mmap_path)
+                logger.info("Removed EC mmap file %s", self.mmap_path)
+            except Exception:
+                logger.warning(
+                    "Failed to unlink path %s", self.mmap_path, exc_info=True
+                )
+            self._creator = False

--- a/vllm/distributed/ec_transfer/ec_connector/factory.py
+++ b/vllm/distributed/ec_transfer/ec_connector/factory.py
@@ -83,3 +83,9 @@ ECConnectorFactory.register_connector(
     "vllm.distributed.ec_transfer.ec_connector.example_connector",
     "ECExampleConnector",
 )
+
+ECConnectorFactory.register_connector(
+    "ECCPUConnector",
+    "vllm.distributed.ec_transfer.ec_connector.cpu_connector",
+    "ECCPUConnector",
+)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -34,7 +34,6 @@ from vllm.config import (
 )
 from vllm.config.cache import CacheConfig
 from vllm.distributed.ec_transfer import get_ec_transfer, has_ec_transfer
-from vllm.distributed.ec_transfer.ec_connector.base import EncoderConfig
 from vllm.distributed.eplb.eplb_state import EplbState
 from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group
 from vllm.distributed.kv_transfer.kv_connector.utils import copy_kv_blocks
@@ -505,7 +504,6 @@ class GPUModelRunner(
 
         # mm_hash ->  encoder_output
         self.encoder_cache: dict[str, torch.Tensor] = {}
-        self.encoder_config: EncoderConfig | None = None
         self.late_interaction_runner = LateInteractionRunner()
 
         # Encoder CUDA graph manager (initialized after model load if enabled)
@@ -5849,13 +5847,6 @@ class GPUModelRunner(
                         )
                         for i, output in enumerate(dummy_encoder_outputs):
                             self.encoder_cache[f"tmp_{i}"] = output
-
-                        last_output = dummy_encoder_outputs[-1]
-                        self.encoder_config = EncoderConfig(
-                            hidden_dim=last_output.shape[-1],
-                            dtype=last_output.dtype,
-                            element_size=last_output.element_size(),
-                        )
 
         # Add `is_profile` here to pre-allocate communication buffers
         hidden_states, last_hidden_states = self._dummy_run(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -34,6 +34,7 @@ from vllm.config import (
 )
 from vllm.config.cache import CacheConfig
 from vllm.distributed.ec_transfer import get_ec_transfer, has_ec_transfer
+from vllm.distributed.ec_transfer.ec_connector.base import EncoderConfig
 from vllm.distributed.eplb.eplb_state import EplbState
 from vllm.distributed.kv_transfer import get_kv_transfer_group, has_kv_transfer_group
 from vllm.distributed.kv_transfer.kv_connector.utils import copy_kv_blocks
@@ -504,6 +505,7 @@ class GPUModelRunner(
 
         # mm_hash ->  encoder_output
         self.encoder_cache: dict[str, torch.Tensor] = {}
+        self.encoder_config: EncoderConfig | None = None
         self.late_interaction_runner = LateInteractionRunner()
 
         # Encoder CUDA graph manager (initialized after model load if enabled)
@@ -5847,6 +5849,13 @@ class GPUModelRunner(
                         )
                         for i, output in enumerate(dummy_encoder_outputs):
                             self.encoder_cache[f"tmp_{i}"] = output
+
+                        last_output = dummy_encoder_outputs[-1]
+                        self.encoder_config = EncoderConfig(
+                            hidden_dim=last_output.shape[-1],
+                            dtype=last_output.dtype,
+                            element_size=last_output.element_size(),
+                        )
 
         # Add `is_profile` here to pre-allocate communication buffers
         hidden_states, last_hidden_states = self._dummy_run(

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -24,8 +24,6 @@ from vllm.distributed import (
 )
 from vllm.distributed.ec_transfer import (
     ensure_ec_transfer_initialized,
-    get_ec_transfer,
-    has_ec_transfer,
 )
 from vllm.distributed.eplb.eplb_utils import override_envs_for_eplb
 from vllm.distributed.kv_transfer import (
@@ -524,9 +522,6 @@ class Worker(WorkerBase):
         # because `initialize_kv_cache` will inject kv cache groups not
         # related to kv cache connector (e.g. kv cache sharing layers).
         ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
-
-        if has_ec_transfer() and self.model_runner.encoder_config is not None:
-            get_ec_transfer().register_caches(self.model_runner.encoder_config)
 
         if self.vllm_config.model_config.enable_sleep_mode:
             from vllm.device_allocator.cumem import CuMemAllocator

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -22,7 +22,11 @@ from vllm.distributed import (
     init_distributed_environment,
     set_custom_all_reduce,
 )
-from vllm.distributed.ec_transfer import ensure_ec_transfer_initialized
+from vllm.distributed.ec_transfer import (
+    ensure_ec_transfer_initialized,
+    get_ec_transfer,
+    has_ec_transfer,
+)
 from vllm.distributed.eplb.eplb_utils import override_envs_for_eplb
 from vllm.distributed.kv_transfer import (
     ensure_kv_transfer_initialized,
@@ -520,6 +524,9 @@ class Worker(WorkerBase):
         # because `initialize_kv_cache` will inject kv cache groups not
         # related to kv cache connector (e.g. kv cache sharing layers).
         ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
+
+        if has_ec_transfer() and self.model_runner.encoder_config is not None:
+            get_ec_transfer().register_caches(self.model_runner.encoder_config)
 
         if self.vllm_config.model_config.enable_sleep_mode:
             from vllm.device_allocator.cumem import CuMemAllocator


### PR DESCRIPTION


## Purpose
 Add `ECCPUConnector` for Encoder-Prefill/Decode (E-PD) disaggregation. This connector enables a PD node to load encoder outputs from a remote Encoder node via a dedicated CPU buffer, then transfer them to GPU on demand.

  This is an initial skeleton with the core scheduler→worker metadata flow implemented:
  - Scheduler accumulates `(offset, size)` locations per `mm_hash` in a flat CPU buffer
  - `build_connector_meta()` passes this mapping to the worker via `ECCPUConnectorMetadata`
  - Worker's `start_load_caches()` copies the relevant CPU buffer slices to GPU

  Also updates `ECConnectorBase.has_cache_item()` return type to `bool | None` to support connectors that need async cache availability checks.

## Test Plan
Not yet available
## Test Result

