### PR TITLE
Adjust the initialization order of self.k_norm to prevent vllm from failing to load models after gemma4 sft.

### DIFF
--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -426,12 +426,6 @@ class Gemma4Attention(nn.Module):
             prefix=f"{prefix}.o_proj",
         )
 
-        # Q/K norms: output = norm(x) * weight (learnable per-head scale)
-        self.q_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
-        self.k_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
-        # V norm: no learnable scale (pure normalization only)
-        self.v_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps, has_weight=False)
-
         # Determine layer type and sliding window
         layer_idx = extract_layer_index(prefix)
         layer_type = config.layer_types[layer_idx]
@@ -483,6 +477,15 @@ class Gemma4Attention(nn.Module):
                         f"{param_name_before_layers}.layers."
                         f"{kv_shared_layer_index}.self_attn.attn"
                     )
+
+        # Q/K norms: output = norm(x) * weight (learnable per-head scale)
+        self.q_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        if self.is_kv_shared_layer:
+            self.k_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps, has_weight=False)
+        else:
+            self.k_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        # V norm: no learnable scale (pure normalization only)
+        self.v_norm = RMSNorm(self.head_dim, eps=config.rms_norm_eps, has_weight=False)
 
         self.rotary_emb = get_rope(
             self.head_dim,


### PR DESCRIPTION
…o initialize `self.k_norm` to avoid VLLM failing to load checkpoints after SFT Gemma4 .




## Purpose
Adjust the initialization order of self.k_norm to prevent vllm from failing to load models after gemma4 sft.

If one layer is kv_shared_layer,  model will not use the weight of self.k_norm, the self.k_norm should be nitialized with has_weight.   After SFT for gemma4 model , the result checkpoint for kv_shared_layers will not store self_attn.k_norm.weight.  The original solution will result in a ValueError just like:


`ValueError: Following weights were not initialized from checkpoint: {'language_model.model.layers.27.self_attn.k_norm.weight', 'language_model.model.layers.40.self_attn.k_norm.weight', 'language_model.model.layers.28.self_attn.k_norm.weight', 'language_model.model.layers.36.self_attn.k_norm.weight', 'language_model.model.layers.39.self_attn.k_norm.weight', 'language_model.model.layers.24.self_attn.k_norm.weight', 'language_model.model.layers.30.self_attn.k_norm.weight', 'language_model.model.layers.34.self_attn.k_norm.weight', 'language_model.model.layers.41.self_attn.k_norm.weight', 'language_model.model.layers.38.self_attn.k_norm.weight', 'language_model.model.layers.32.self_attn.k_norm.weight', 'language_model.model.layers.37.self_attn.k_norm.weight', 'language_model.model.layers.33.self_attn.k_norm.weight', 'language_model.model.layers.25.self_attn.k_norm.weight', 'language_model.model.layers.29.self_attn.k_norm.weight', 'language_model.model.layers.35.self_attn.k_norm.weight', 'language_model.mo
del.layers.31.self_attn.k_norm.weight', 'language_model.model.layers.26.self_attn.k_norm.weight'}`
 
<img width="2558" height="753" alt="ValueError" src="https://github.com/user-attachments/assets/122441c8-99cc-4b4a-9ec5-4b71305dde44" />

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

