### PR TITLE
Add return type annotations to 20 methods across vllm

### DIFF
--- a/vllm/beam_search.py
+++ b/vllm/beam_search.py
@@ -34,7 +34,7 @@ class BeamSearchSequence:
     finish_reason: str | None = None
     stop_reason: int | str | None = None
 
-    def get_prompt(self):
+    def get_prompt(self) -> DecoderOnlyEngineInput | EncoderDecoderInput:
         prompt = self.orig_prompt
 
         if prompt["type"] == "enc_dec":

--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -946,7 +946,7 @@ class VllmBackend:
                 )
         self.inductor_config[self.pass_key] = self.pass_manager
 
-    def _log_compilation_config(self):
+    def _log_compilation_config(self) -> None:
         """Log vLLM compilation config for TORCH_TRACE/tlparse."""
         cc = self.compilation_config
         pass_cfg = cc.pass_config

--- a/vllm/compilation/passes/fusion/act_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/act_quant_fusion.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import itertools
-from typing import Any
+from typing import Any, Callable
 
 import torch
 from torch._higher_order_ops.auto_functionalize import auto_functionalized
@@ -91,7 +91,7 @@ class SiluMulFp8StaticQuantPattern(ActivationQuantPattern):
         ]
 
     @property
-    def pattern(self):
+    def pattern(self) -> Callable[..., torch.Tensor]:
         def _pattern(
             input: torch.Tensor,
             scale: torch.Tensor,
@@ -103,7 +103,7 @@ class SiluMulFp8StaticQuantPattern(ActivationQuantPattern):
         return _pattern
 
     @property
-    def replacement(self):
+    def replacement(self) -> Callable[..., torch.Tensor]:
         def _replacement(
             input: torch.Tensor,
             scale: torch.Tensor,
@@ -137,7 +137,7 @@ class SiluMulNvfp4QuantPattern(ActivationQuantPattern):
         return [result, output_scale, input_, scale]
 
     @property
-    def pattern(self):
+    def pattern(self) -> Callable[..., tuple[torch.Tensor, torch.Tensor]]:
         def _pattern(
             result: torch.Tensor,
             output_scale: torch.Tensor,
@@ -158,7 +158,7 @@ class SiluMulNvfp4QuantPattern(ActivationQuantPattern):
         return _pattern
 
     @property
-    def replacement(self):
+    def replacement(self) -> Callable[..., tuple[torch.Tensor, torch.Tensor]]:
         def _replacement(
             result: torch.Tensor,
             output_scale: torch.Tensor,
@@ -208,7 +208,7 @@ class SiluMulBlockQuantPattern(ActivationQuantPattern):
         return self.silu_and_mul_matcher.inputs() + [scale]
 
     @property
-    def pattern(self):
+    def pattern(self) -> Callable[..., tuple[torch.Tensor, torch.Tensor]]:
         def _pattern(
             input: torch.Tensor,
             scale: torch.Tensor,
@@ -239,7 +239,7 @@ class SiluMulBlockQuantPattern(ActivationQuantPattern):
         return _pattern
 
     @property
-    def replacement(self):
+    def replacement(self) -> Callable[..., tuple[torch.Tensor, torch.Tensor]]:
         def _replacement(
             input: torch.Tensor,
             scale: torch.Tensor,

--- a/vllm/compilation/passes/fusion/attn_quant_fusion.py
+++ b/vllm/compilation/passes/fusion/attn_quant_fusion.py
@@ -152,7 +152,7 @@ class AttnFp8StaticQuantPattern(VllmPatternReplacement[..., torch.Tensor]):
 
         return _replacement
 
-    def get_inputs(self):
+    def get_inputs(self) -> list[torch.Tensor]:
         dtype = self._dtype
         num_heads = self._num_heads
         head_size = self._head_size

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -212,7 +212,7 @@ class CacheConfig:
         factors = get_hash_factors(self, ignored_factors)
         return hash_factors(factors)
 
-    def metrics_info(self):
+    def metrics_info(self) -> dict[str, str]:
         # convert cache_config to dict(key: str, value: str) for prometheus
         # metrics info
         return {key: str(value) for key, value in self.__dict__.items()}

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -1186,7 +1186,7 @@ class CompilationConfig:
             )
             self.cudagraph_mode = CUDAGraphMode.NONE
 
-    def set_splitting_ops_for_attn_fusion(self):
+    def set_splitting_ops_for_attn_fusion(self) -> None:
         assert self.pass_config.fuse_attn_quant
         if self.splitting_ops is None:
             self.splitting_ops = []
@@ -1245,7 +1245,7 @@ class CompilationConfig:
         # Inductor partition case
         return self.backend == "inductor" and self.mode != CompilationMode.NONE
 
-    def custom_op_log_check(self):
+    def custom_op_log_check(self) -> None:
         """
         This method logs the enabled/disabled custom ops and checks that the
         passed custom_ops field only contains relevant ops.

--- a/vllm/config/device.py
+++ b/vllm/config/device.py
@@ -46,7 +46,7 @@ class DeviceConfig:
         hash_str = safe_hash(str(factors).encode(), usedforsecurity=False).hexdigest()
         return hash_str
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.device == "auto":
             # Automated device type detection
             from vllm.platforms import current_platform

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import contextlib
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from dataclasses import asdict, fields
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -65,7 +65,7 @@ class IrOpPriorityConfig:
         return value
 
     @contextlib.contextmanager
-    def set_priority(self):
+    def set_priority(self) -> Generator[None, None, None]:
         """
         Context manager to set the IR op priority for all op members.
         It also imports IR kernel implementations for the current platform

--- a/vllm/config/kv_events.py
+++ b/vllm/config/kv_events.py
@@ -47,6 +47,6 @@ class KVEventsConfig:
     this topic to receive events.
     """
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.publisher is None:
             self.publisher = "zmq" if self.enable_kv_cache_events else "null"

--- a/vllm/config/mamba.py
+++ b/vllm/config/mamba.py
@@ -53,7 +53,7 @@ class MambaConfig:
             return MambaBackendEnum[value.upper()]
         return value
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.enable_stochastic_rounding:
             from vllm.platforms import current_platform
 

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -779,7 +779,7 @@ class ModelConfig:
         return used_cls == transformers_backend_cls
 
     @property
-    def registry(self):
+    def registry(self) -> "me_models._ModelRegistry":
         return me_models.ModelRegistry
 
     @property
@@ -1088,7 +1088,7 @@ class ModelConfig:
                 "when expert parallelism is enabled."
             )
 
-    def _try_verify_and_update_model_config(self):
+    def _try_verify_and_update_model_config(self) -> None:
         # Avoid running try_verify_and_update_config multiple times
         if getattr(self, "config_updated", False):
             return

--- a/vllm/connections.py
+++ b/vllm/connections.py
@@ -222,7 +222,7 @@ class HTTPConnection:
 
         return self._async_client
 
-    def _validate_http_url(self, url: str):
+    def _validate_http_url(self, url: str) -> None:
         parsed_url = parse_url(url)
 
         if parsed_url.scheme not in ("http", "https"):

--- a/vllm/logging_utils/formatter.py
+++ b/vllm/logging_utils/formatter.py
@@ -10,14 +10,14 @@ from vllm import envs
 class NewLineFormatter(logging.Formatter):
     """Adds logging prefix to newlines to align multi-line messages."""
 
-    def __init__(self, fmt, datefmt=None, style="%"):
+    def __init__(self, fmt: str, datefmt: str | None = None, style: str = "%") -> None:
         super().__init__(fmt, datefmt, style)
 
         self.use_relpath = envs.VLLM_LOGGING_LEVEL == "DEBUG"
         if self.use_relpath:
             self.root_dir = Path(__file__).resolve().parent.parent.parent
 
-    def format(self, record):
+    def format(self, record: logging.LogRecord) -> str:
         def shrink_path(relpath: Path) -> str:
             """
             Shortens a file path for logging display:


### PR DESCRIPTION
## Summary

Add missing return type annotations to improve code quality and IDE support.

## Changes

- :  -> 
- :  -> 
- :  -> 
- :  -> 
- :  -> 
- :  and  with full type hints
- :  property -> 
- :  -> 
- :  -> 
- :  -> 
- :  -> 
- :  -> 
- : / properties
- :  -> 
- :  -> 

## Test Plan

- [ ] Run pre-commit hooks: 
- [ ] Run type checking: 
- [ ] Verify no regressions in existing tests