### PR TITLE
[CI/Build] Skip Prithvi/Terratorch model-registry tests when terratorch is missing

### DIFF
--- a/tests/models/multimodal/pooling/test_prithvi_mae.py
+++ b/tests/models/multimodal/pooling/test_prithvi_mae.py
@@ -1,13 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import importlib.util
+
 import pytest
 import torch
 
 from ....conftest import VllmRunner
 
-pytest.importorskip(
-    "terratorch",
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("terratorch") is None,
     reason="terratorch unavailable while PyPI has `lightning` quarantined; see #41376",
 )
 

--- a/tests/models/test_initialization.py
+++ b/tests/models/test_initialization.py
@@ -109,6 +109,16 @@ def can_initialize(
             "which is not configured in test environment"
         )
 
+    if model_arch in ("PrithviGeoSpatialMAE", "Terratorch"):
+        import importlib.util
+
+        if importlib.util.find_spec("terratorch") is None:
+            pytest.skip(
+                "terratorch is not installed; "
+                "temporarily skipped while PyPI has `lightning` quarantined "
+                "(see #41376)"
+            )
+
     if model_arch in ["DeepseekV32ForCausalLM", "GlmMoeDsaForCausalLM"]:
         from vllm.platforms import current_platform
 

--- a/tests/models/test_registry.py
+++ b/tests/models/test_registry.py
@@ -36,6 +36,17 @@ def test_registry_imports(model_arch):
         check_max_version=False,
         check_version_reason="vllm",
     )
+
+    if model_arch in ("PrithviGeoSpatialMAE", "Terratorch"):
+        import importlib.util
+
+        if importlib.util.find_spec("terratorch") is None:
+            pytest.skip(
+                "terratorch is not installed; "
+                "temporarily skipped while PyPI has `lightning` quarantined "
+                "(see #41376)"
+            )
+
     # Ensure all model classes can be imported successfully
     model_cls = ModelRegistry._try_load_model_cls(model_arch)
     assert model_cls is not None

--- a/tests/models/test_terratorch.py
+++ b/tests/models/test_terratorch.py
@@ -1,14 +1,16 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import importlib.util
+
 import pytest
 import torch
 
 from tests.conftest import VllmRunner
 from tests.utils import create_new_process_for_each_test
 
-pytest.importorskip(
-    "terratorch",
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("terratorch") is None,
     reason="terratorch unavailable while PyPI has `lightning` quarantined; see #41376",
 )
 

--- a/tests/plugins_tests/test_terratorch_io_processor_plugins.py
+++ b/tests/plugins_tests/test_terratorch_io_processor_plugins.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import importlib.util
 import io
 
 import imagehash
@@ -11,8 +12,8 @@ from PIL import Image
 from tests.utils import RemoteOpenAIServer
 from vllm.entrypoints.pooling.pooling.protocol import IOProcessorResponse
 
-pytest.importorskip(
-    "terratorch",
+pytestmark = pytest.mark.skipif(
+    importlib.util.find_spec("terratorch") is None,
     reason="terratorch unavailable while PyPI has `lightning` quarantined; see #41376",
 )
 


### PR DESCRIPTION
Follow-up to #41377. After dropping terratorch from the test deps, two model-registry parametrize tests started failing on every PR that re-ran those jobs against current main:

- `tests/models/test_initialization.py::test_can_initialize_small_subset[PrithviGeoSpatialMAE]`
- `tests/models/test_registry.py::test_registry_imports[PrithviGeoSpatialMAE]`
- `tests/models/test_registry.py::test_registry_imports[Terratorch]`

Both tests reach Prithvi via the model-registry parametrize indirection, so they were not covered by the per-file `pytest.importorskip` guards added in #41377. Add inline skips matching the existing precedent in `test_initialization.py` (`if model_arch == "MoonshotKimiaForCausalLM": pytest.skip(...)`), gated on `importlib.util.find_spec("terratorch")`. The skips no-op once terratorch is restored to the lockfiles.

Audited every other parametrize site in `test_registry.py` (`test_registry_model_property`, `test_registry_is_pp`, `test_hf_registry_coverage`) — they use hardcoded narrow model lists that don't include Terratorch/Prithvi, so they need no change.

---
<details>
<summary>Essential Elements of an Effective PR Description Checklist</summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results.
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
