### PR TITLE
[Core] feat: add optional cap for --max-model-len auto

### DIFF
--- a/docs/configuration/conserving_memory.md
+++ b/docs/configuration/conserving_memory.md
@@ -45,6 +45,19 @@ from vllm import LLM
 llm = LLM(model="Qwen/Qwen2.5-VL-3B-Instruct", max_model_len=2048, max_num_seqs=2)
 ```
 
+When using automatic context fitting, you can cap the fitted context length so
+vLLM uses the largest length that fits in memory, but never exceeds your
+deployment limit e.g.:
+
+```bash
+vllm serve <model> --max-model-len auto --max-model-len-cap 131072
+```
+
+The effective context length is `min(auto_fit_len, max_model_len_cap)`.
+If `--max-model-len-cap` is omitted, the existing `--max-model-len auto`
+path is unchanged and no implicit cap is applied. The cap is only valid
+together with `max_model_len=-1` or `--max-model-len auto`.
+
 ## Reduce CUDA Graphs
 
 By default, we optimize model inference using CUDA graphs which take up extra memory in the GPU.

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -512,9 +512,22 @@ def test_human_readable_model_len():
 
     args = parser.parse_args([])
     assert args.max_model_len is None
+    assert args.max_model_len_cap is None
 
     args = parser.parse_args(["--max-model-len", "1024"])
     assert args.max_model_len == 1024
+    assert args.max_model_len_cap is None
+
+    args = parser.parse_args(["--max-model-len", "auto"])
+    assert args.max_model_len == -1
+    assert args.max_model_len_cap is None
+
+    args = parser.parse_args(["--max-model-len-cap", "131072"])
+    assert args.max_model_len_cap == 131072
+
+    args = parser.parse_args(["--max-model-len", "auto", "--max-model-len-cap", "128K"])
+    assert args.max_model_len == -1
+    assert args.max_model_len_cap == 128 * 2**10
 
     # Lower
     args = parser.parse_args(["--max-model-len", "1m"])

--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -535,9 +535,22 @@ def test_human_readable_model_len():
 
     args = parser.parse_args([])
     assert args.max_model_len is None
+    assert args.max_model_len_cap is None
 
     args = parser.parse_args(["--max-model-len", "1024"])
     assert args.max_model_len == 1024
+    assert args.max_model_len_cap is None
+
+    args = parser.parse_args(["--max-model-len", "auto"])
+    assert args.max_model_len == -1
+    assert args.max_model_len_cap is None
+
+    args = parser.parse_args(["--max-model-len-cap", "131072"])
+    assert args.max_model_len_cap == 131072
+
+    args = parser.parse_args(["--max-model-len", "auto", "--max-model-len-cap", "128K"])
+    assert args.max_model_len == -1
+    assert args.max_model_len_cap == 128 * 2**10
 
     # Lower
     args = parser.parse_args(["--max-model-len", "1m"])

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2646,7 +2646,10 @@ def test_auto_fit_max_model_len():
         "layer_2": new_kv_cache_spec(),
     }
 
-    # With enough memory, max_model_len stays at the derived max
+    # With enough memory and no cap, max_model_len stays at the derived max.
+    # This preserves the existing auto-fit default path when max_model_len_cap
+    # is omitted.
+    assert vllm_config.model_config.max_model_len_cap is None
     large_available_memory = mem_per_block_per_layer * 2 * 1024  # plenty of memory
     _kv_cache_configs = get_kv_cache_configs(
         vllm_config, [kv_cache_specs], [large_available_memory]
@@ -2658,7 +2661,9 @@ def test_auto_fit_max_model_len():
     model_config.original_max_model_len = -1
     vllm_config = VllmConfig(model_config=model_config)
 
-    # With limited memory, max_model_len should be reduced
+    # With limited memory and no cap, max_model_len should be reduced only by
+    # the existing auto-fit memory calculation.
+    assert vllm_config.model_config.max_model_len_cap is None
     # Need memory for at least max_model_len tokens
     # 32 blocks worth of memory for 2 layers = can fit 32*16=512 tokens
     limited_memory = mem_per_block_per_layer * 2 * 32
@@ -2668,6 +2673,55 @@ def test_auto_fit_max_model_len():
     # Should be reduced to fit in memory
     assert vllm_config.model_config.max_model_len < 1024
     assert vllm_config.model_config.max_model_len > 0
+
+
+def test_auto_fit_max_model_len_cap():
+    """Test that max_model_len_cap caps the auto-fit upper bound."""
+    model_config = ModelConfig(max_model_len=-1, max_model_len_cap=256)
+    vllm_config = VllmConfig(model_config=model_config)
+
+    mem_per_block_per_layer = 16 * 2 * 64 * 4 * 2
+    kv_cache_specs = {
+        "layer_1": new_kv_cache_spec(),
+        "layer_2": new_kv_cache_spec(),
+    }
+
+    large_available_memory = mem_per_block_per_layer * 2 * 1024
+    _kv_cache_configs = get_kv_cache_configs(
+        vllm_config, [kv_cache_specs], [large_available_memory]
+    )
+
+    assert vllm_config.model_config.original_max_model_len == -1
+    assert vllm_config.model_config.max_model_len == 256
+
+
+def test_auto_fit_max_model_len_cap_above_fit():
+    """Test that the cap does not raise an auto-fit result that is lower."""
+    model_config = ModelConfig(max_model_len=-1, max_model_len_cap=768)
+    vllm_config = VllmConfig(model_config=model_config)
+
+    mem_per_block_per_layer = 16 * 2 * 64 * 4 * 2
+    kv_cache_specs = {
+        "layer_1": new_kv_cache_spec(),
+        "layer_2": new_kv_cache_spec(),
+    }
+
+    limited_memory = mem_per_block_per_layer * 2 * 32
+    _kv_cache_configs = get_kv_cache_configs(
+        vllm_config, [kv_cache_specs], [limited_memory]
+    )
+
+    assert vllm_config.model_config.original_max_model_len == -1
+    assert vllm_config.model_config.max_model_len == 512
+
+
+def test_max_model_len_cap_requires_auto():
+    """Test that max_model_len_cap is only valid with auto max_model_len."""
+    with pytest.raises(ValueError, match="max_model_len_cap"):
+        ModelConfig(max_model_len=1024, max_model_len_cap=256)
+
+    with pytest.raises(ValueError, match="max_model_len_cap"):
+        ModelConfig(max_model_len=None, max_model_len_cap=256)
 
 
 def test_auto_fit_max_model_len_with_hybrid():

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2496,7 +2496,10 @@ def test_auto_fit_max_model_len():
         "layer_2": new_kv_cache_spec(),
     }
 
-    # With enough memory, max_model_len stays at the derived max
+    # With enough memory and no cap, max_model_len stays at the derived max.
+    # This preserves the existing auto-fit default path when max_model_len_cap
+    # is omitted.
+    assert vllm_config.model_config.max_model_len_cap is None
     large_available_memory = mem_per_block_per_layer * 2 * 1024  # plenty of memory
     _kv_cache_configs = get_kv_cache_configs(
         vllm_config, [kv_cache_specs], [large_available_memory]
@@ -2508,7 +2511,9 @@ def test_auto_fit_max_model_len():
     model_config.original_max_model_len = -1
     vllm_config = VllmConfig(model_config=model_config)
 
-    # With limited memory, max_model_len should be reduced
+    # With limited memory and no cap, max_model_len should be reduced only by
+    # the existing auto-fit memory calculation.
+    assert vllm_config.model_config.max_model_len_cap is None
     # Need memory for at least max_model_len tokens
     # 32 blocks worth of memory for 2 layers = can fit 32*16=512 tokens
     limited_memory = mem_per_block_per_layer * 2 * 32
@@ -2518,6 +2523,55 @@ def test_auto_fit_max_model_len():
     # Should be reduced to fit in memory
     assert vllm_config.model_config.max_model_len < 1024
     assert vllm_config.model_config.max_model_len > 0
+
+
+def test_auto_fit_max_model_len_cap():
+    """Test that max_model_len_cap caps the auto-fit upper bound."""
+    model_config = ModelConfig(max_model_len=-1, max_model_len_cap=256)
+    vllm_config = VllmConfig(model_config=model_config)
+
+    mem_per_block_per_layer = 16 * 2 * 64 * 4 * 2
+    kv_cache_specs = {
+        "layer_1": new_kv_cache_spec(),
+        "layer_2": new_kv_cache_spec(),
+    }
+
+    large_available_memory = mem_per_block_per_layer * 2 * 1024
+    _kv_cache_configs = get_kv_cache_configs(
+        vllm_config, [kv_cache_specs], [large_available_memory]
+    )
+
+    assert vllm_config.model_config.original_max_model_len == -1
+    assert vllm_config.model_config.max_model_len == 256
+
+
+def test_auto_fit_max_model_len_cap_above_fit():
+    """Test that the cap does not raise an auto-fit result that is lower."""
+    model_config = ModelConfig(max_model_len=-1, max_model_len_cap=768)
+    vllm_config = VllmConfig(model_config=model_config)
+
+    mem_per_block_per_layer = 16 * 2 * 64 * 4 * 2
+    kv_cache_specs = {
+        "layer_1": new_kv_cache_spec(),
+        "layer_2": new_kv_cache_spec(),
+    }
+
+    limited_memory = mem_per_block_per_layer * 2 * 32
+    _kv_cache_configs = get_kv_cache_configs(
+        vllm_config, [kv_cache_specs], [limited_memory]
+    )
+
+    assert vllm_config.model_config.original_max_model_len == -1
+    assert vllm_config.model_config.max_model_len == 512
+
+
+def test_max_model_len_cap_requires_auto():
+    """Test that max_model_len_cap is only valid with auto max_model_len."""
+    with pytest.raises(ValueError, match="max_model_len_cap"):
+        ModelConfig(max_model_len=1024, max_model_len_cap=256)
+
+    with pytest.raises(ValueError, match="max_model_len_cap"):
+        ModelConfig(max_model_len=None, max_model_len_cap=256)
 
 
 def test_auto_fit_max_model_len_with_hybrid():

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -219,6 +219,12 @@ class ModelConfig:
     - -1 or 'auto' -> Automatically choose the maximum model length that fits in
       GPU memory. This will use the model's maximum context length if it fits,
       otherwise it will find the largest length that can be accommodated."""
+    max_model_len_cap: int | None = Field(default=None, gt=0)
+    """Optional upper bound for `--max-model-len auto`. If set together with
+    `--max-model-len auto`, the effective context length is capped to
+    `min(auto_fit_len, max_model_len_cap)`. If unset, auto-fit behavior is
+    unchanged. This is only valid when `max_model_len` is `-1` or `"auto"`."""
+
     spec_target_max_model_len: int | None = None
     """Specify the maximum length for spec decoding draft models."""
     quantization: QuantizationMethods | str | None = None
@@ -420,6 +426,7 @@ class ModelConfig:
             "allowed_media_domains",
             "tokenizer_revision",
             "spec_target_max_model_len",
+            "max_model_len_cap",
             "enforce_eager",
             "return_sampling_mask",
             "logprobs_mode",
@@ -742,7 +749,24 @@ class ModelConfig:
             self.hf_text_config.sliding_window = None
 
         self.original_max_model_len = self.max_model_len
+        if self.max_model_len_cap is not None and self.original_max_model_len != -1:
+            raise ValueError(
+                "`max_model_len_cap` can only be used with "
+                "`max_model_len=-1` or `max_model_len='auto'`."
+            )
+
         self.max_model_len = self.get_and_verify_max_len(self.max_model_len)
+        if (
+            self.max_model_len_cap is not None
+            and self.max_model_len > self.max_model_len_cap
+        ):
+            logger.info(
+                "Capping auto-derived max_model_len from %d to %d "
+                "because max_model_len_cap is set.",
+                self.max_model_len,
+                self.max_model_len_cap,
+            )
+            self.max_model_len = self.max_model_len_cap
 
         if self.is_encoder_decoder:
             mm_processor_cache_gb = 0

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -214,6 +214,12 @@ class ModelConfig:
     - -1 or 'auto' -> Automatically choose the maximum model length that fits in
       GPU memory. This will use the model's maximum context length if it fits,
       otherwise it will find the largest length that can be accommodated."""
+    max_model_len_cap: int | None = Field(default=None, gt=0)
+    """Optional upper bound for `--max-model-len auto`. If set together with
+    `--max-model-len auto`, the effective context length is capped to
+    `min(auto_fit_len, max_model_len_cap)`. If unset, auto-fit behavior is
+    unchanged. This is only valid when `max_model_len` is `-1` or `"auto"`."""
+
     spec_target_max_model_len: int | None = None
     """Specify the maximum length for spec decoding draft models."""
     quantization: QuantizationMethods | str | None = None
@@ -413,6 +419,7 @@ class ModelConfig:
             "allowed_media_domains",
             "tokenizer_revision",
             "spec_target_max_model_len",
+            "max_model_len_cap",
             "enforce_eager",
             "logprobs_mode",
             "use_fp64_gumbel",
@@ -711,7 +718,24 @@ class ModelConfig:
             self.hf_text_config.sliding_window = None
 
         self.original_max_model_len = self.max_model_len
+        if self.max_model_len_cap is not None and self.original_max_model_len != -1:
+            raise ValueError(
+                "`max_model_len_cap` can only be used with "
+                "`max_model_len=-1` or `max_model_len='auto'`."
+            )
+
         self.max_model_len = self.get_and_verify_max_len(self.max_model_len)
+        if (
+            self.max_model_len_cap is not None
+            and self.max_model_len > self.max_model_len_cap
+        ):
+            logger.info(
+                "Capping auto-derived max_model_len from %d to %d "
+                "because max_model_len_cap is set.",
+                self.max_model_len,
+                self.max_model_len_cap,
+            )
+            self.max_model_len = self.max_model_len_cap
 
         if self.is_encoder_decoder:
             mm_processor_cache_gb = 0

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -365,6 +365,7 @@ def _compute_kwargs(cls: ConfigType) -> dict[str, dict[str, Any]]:
                 "max_num_scheduled_tokens",
                 "kv_cache_memory_bytes",
                 "safetensors_prefetch_block_size",
+                "max_model_len_cap",
             }
             if name == "max_model_len":
                 kwargs[name]["type"] = human_readable_int_or_auto
@@ -448,6 +449,7 @@ class EngineArgs:
     kv_cache_dtype: CacheDType = CacheConfig.cache_dtype
     seed: int = ModelConfig.seed
     max_model_len: int = ModelConfig.max_model_len
+    max_model_len_cap: int | None = ModelConfig.max_model_len_cap
     cudagraph_capture_sizes: list[int] | None = (
         CompilationConfig.cudagraph_capture_sizes
     )
@@ -852,6 +854,9 @@ class EngineArgs:
             "--tokenizer-revision", **model_kwargs["tokenizer_revision"]
         )
         model_group.add_argument("--max-model-len", **model_kwargs["max_model_len"])
+        model_group.add_argument(
+            "--max-model-len-cap", **model_kwargs["max_model_len_cap"]
+        )
         model_group.add_argument("--quantization", "-q", **model_kwargs["quantization"])
         model_group.add_argument(
             "--quantization-config", **model_kwargs["quantization_config"]
@@ -1699,6 +1704,7 @@ class EngineArgs:
             model_class_overrides=self.model_class_overrides,
             tokenizer_revision=self.tokenizer_revision,
             max_model_len=self.max_model_len,
+            max_model_len_cap=self.max_model_len_cap,
             quantization=self.quantization,
             quantization_config=self.quantization_config,
             allow_deprecated_quantization=self.allow_deprecated_quantization,

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -367,6 +367,7 @@ def _compute_kwargs(cls: ConfigType) -> dict[str, dict[str, Any]]:
                 "max_num_scheduled_tokens",
                 "kv_cache_memory_bytes",
                 "safetensors_prefetch_block_size",
+                "max_model_len_cap",
             }
             if name == "max_model_len":
                 kwargs[name]["type"] = human_readable_int_or_auto
@@ -451,6 +452,7 @@ class EngineArgs:
     kv_cache_dtype: CacheDType = CacheConfig.cache_dtype
     seed: int = ModelConfig.seed
     max_model_len: int = ModelConfig.max_model_len
+    max_model_len_cap: int | None = ModelConfig.max_model_len_cap
     cudagraph_capture_sizes: list[int] | None = (
         CompilationConfig.cudagraph_capture_sizes
     )
@@ -864,6 +866,9 @@ class EngineArgs:
             "--tokenizer-revision", **model_kwargs["tokenizer_revision"]
         )
         model_group.add_argument("--max-model-len", **model_kwargs["max_model_len"])
+        model_group.add_argument(
+            "--max-model-len-cap", **model_kwargs["max_model_len_cap"]
+        )
         model_group.add_argument("--quantization", "-q", **model_kwargs["quantization"])
         model_group.add_argument(
             "--quantization-config", **model_kwargs["quantization_config"]
@@ -1751,6 +1756,7 @@ class EngineArgs:
             model_class_overrides=self.model_class_overrides,
             tokenizer_revision=self.tokenizer_revision,
             max_model_len=self.max_model_len,
+            max_model_len_cap=self.max_model_len_cap,
             quantization=self.quantization,
             quantization_config=self.quantization_config,
             allow_deprecated_quantization=self.allow_deprecated_quantization,


### PR DESCRIPTION
## Purpose

Adds `--max-model-len-cap` as an optional upper bound for `--max-model-len auto`.

The effective maximum context length is:

```text
effective_max_model_len = min(memory_fitting_length, max_model_len_cap)
```

This is a serving-policy control rather than a GPU-memory-budget control. It limits the maximum context length exposed to individual requests while retaining the configured shared KV-cache budget for concurrency and throughput.

Use `--gpu-memory-utilization` or `--kv-cache-memory-bytes` when the goal is to reduce the total KV-cache memory allocated by the vLLM instance. The controls can be used together.

Closes #41364.

## Test Plan

- Build and install vLLM from this branch.
- Run syntax checks for the changed Python files.
- Run targeted pytest coverage for parser/config/KV-cache auto-fit behavior.
- Run single-GPU serving validation with a small model on an RTX 4090.
- Run single-GPU serving validation with a small model on an RTX 5090.
- Verify that capped auto-fit accepts normal requests and rejects oversized requests at the configured cap.
- Verify that `--max-model-len auto` without `--max-model-len-cap` still starts and serves requests successfully.
- Add minimal documentation for the new option.

## Test Result

Built and installed vLLM from this branch:

```text
Successfully installed vllm-0.1.dev16216+gfc6bc6d1e.cu131
```

Environment:

```text
vllm: 0.1.dev16216+gfc6bc6d1e
torch: 2.11.0+cu128
cuda available: True
cuda version: 12.8
GPU 0: NVIDIA GeForce RTX 4090, capability (8, 9)
GPU 1: NVIDIA GeForce RTX 5090, capability (12, 0)
```

Syntax check:

```text
python -m py_compile \
  vllm/config/model.py \
  vllm/engine/arg_utils.py \
  vllm/v1/core/kv_cache_utils.py \
  tests/v1/core/test_kv_cache_utils.py \
  tests/engine/test_arg_utils.py
```

Result: passed.

Targeted pytest coverage:

```text
python -m pytest \
  tests/engine/test_arg_utils.py \
  tests/v1/core/test_kv_cache_utils.py \
  -k "max_model_len_cap or max_model_len or auto" \
  -q
```

Result:

```text
8 passed, 113 deselected, 16 warnings in 16.39s
```

Serving validation used `Qwen/Qwen3-0.6B`.

RTX 4090 capped auto-fit:

```text
CUDA_VISIBLE_DEVICES=0 vllm serve Qwen/Qwen3-0.6B \
  --max-model-len auto \
  --max-model-len-cap 2048 \
  --gpu-memory-utilization 0.35 \
  --max-num-seqs 4 \
  --max-num-batched-tokens 2048
```

RTX 5090 capped auto-fit:

```text
CUDA_VISIBLE_DEVICES=1 vllm serve Qwen/Qwen3-0.6B \
  --max-model-len auto \
  --max-model-len-cap 2048 \
  --gpu-memory-utilization 0.35 \
  --max-num-seqs 4 \
  --max-num-batched-tokens 2048
```

Verified on both GPUs:
- short completion requests succeeded
- oversized prompts were rejected with the configured capped maximum context length:

```text
This model's maximum context length is 2048 tokens. However, you requested 16 output tokens and your prompt contains at least 2033 input tokens, for a total of at least 2049 tokens.
```

Regression check without cap:

```text
CUDA_VISIBLE_DEVICES=0 vllm serve Qwen/Qwen3-0.6B \
  --max-model-len auto \
  --gpu-memory-utilization 0.35 \
  --max-num-seqs 4 \
  --max-num-batched-tokens 2048
```

Result: server started successfully and served a completion request.

Full distributed/tensor-parallel serving tests were not run.

## Notes

This PR was prepared with AI assistance. I reviewed the changed code and tests before submission.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

