### PR TITLE
Adding reasoning for responses API V1

### DIFF
--- a/tests/entrypoints/openai/responses/test_protocol.py
+++ b/tests/entrypoints/openai/responses/test_protocol.py
@@ -5,6 +5,7 @@ from openai_harmony import (
 )
 
 from vllm.entrypoints.openai.responses.protocol import (
+    ResponsesRequest,
     serialize_message,
     serialize_messages,
 )
@@ -37,3 +38,19 @@ def test_serialize_messages() -> None:
     }
     msg = Message.from_dict(msg_value)
     assert serialize_messages([msg, dict_value]) == [msg_value, dict_value]
+
+
+def test_responses_request_accepts_chat_template_kwargs() -> None:
+    request = ResponsesRequest(
+        input="test input",
+        reasoning={"effort": "none"},
+        chat_template_kwargs={"enable_thinking": False},
+    )
+
+    chat_params = request.build_chat_params(
+        default_template=None,
+        default_template_content_format="auto",
+    )
+
+    assert chat_params.chat_template_kwargs["enable_thinking"] is False
+    assert chat_params.chat_template_kwargs["reasoning_effort"] == "none"

--- a/tests/entrypoints/openai/responses/test_protocol.py
+++ b/tests/entrypoints/openai/responses/test_protocol.py
@@ -54,3 +54,21 @@ def test_responses_request_accepts_chat_template_kwargs() -> None:
 
     assert chat_params.chat_template_kwargs["enable_thinking"] is False
     assert chat_params.chat_template_kwargs["reasoning_effort"] == "none"
+
+
+def test_responses_internal_chat_template_kwargs_take_precedence() -> None:
+    request = ResponsesRequest(
+        input="test input",
+        chat_template_kwargs={
+            "add_generation_prompt": False,
+            "continue_final_message": True,
+        },
+    )
+
+    chat_params = request.build_chat_params(
+        default_template=None,
+        default_template_content_format="auto",
+    )
+
+    assert chat_params.chat_template_kwargs["add_generation_prompt"] is True
+    assert chat_params.chat_template_kwargs["continue_final_message"] is False

--- a/tests/entrypoints/openai/responses/test_sampling_params.py
+++ b/tests/entrypoints/openai/responses/test_sampling_params.py
@@ -47,6 +47,7 @@ class TestResponsesRequestSamplingParams:
             seed=42,
             stop=["END", "STOP"],
             ignore_eos=True,
+            thinking_token_budget=128,
             vllm_xargs={"custom": "value"},
         )
 
@@ -56,6 +57,7 @@ class TestResponsesRequestSamplingParams:
         assert sampling_params.seed == 42
         assert sampling_params.stop == ["END", "STOP"]
         assert sampling_params.ignore_eos is True
+        assert sampling_params.thinking_token_budget == 128
         assert sampling_params.extra_args == {"custom": "value"}
 
     def test_stop_string_conversion(self):

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -263,6 +263,18 @@ class ResponsesRequest(OpenAIBaseModel):
     seed: int | None = Field(None, ge=_INT64_MIN, le=_INT64_MAX)
     stop: str | list[str] | None = []
     ignore_eos: bool = False
+    chat_template_kwargs: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Additional keyword arguments passed to the chat template renderer. "
+            "Useful for model-specific controls such as enable_thinking."
+        ),
+    )
+    thinking_token_budget: int | None = Field(
+        default=None,
+        ge=0,
+        description="Maximum number of tokens allowed for thinking operations.",
+    )
     vllm_xargs: dict[str, str | int | float | list[str | int | float]] | None = Field(
         default=None,
         description=(
@@ -294,7 +306,7 @@ class ResponsesRequest(OpenAIBaseModel):
             chat_template=default_template,
             chat_template_content_format=default_template_content_format,
             chat_template_kwargs=merge_kwargs(  # To remove unset values
-                {},
+                self.chat_template_kwargs,
                 dict(
                     add_generation_prompt=not continue_final,
                     continue_final_message=continue_final,
@@ -394,6 +406,7 @@ class ResponsesRequest(OpenAIBaseModel):
             frequency_penalty=frequency_penalty,
             presence_penalty=presence_penalty,
             repetition_penalty=repetition_penalty,
+            thinking_token_budget=self.thinking_token_budget,
             seed=self.seed,
             ignore_eos=self.ignore_eos,
             output_kind=(

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -267,7 +267,11 @@ class ResponsesRequest(OpenAIBaseModel):
         default=None,
         description=(
             "Additional keyword arguments passed to the chat template renderer. "
-            "Useful for model-specific controls such as enable_thinking."
+            "Useful for model-specific controls such as enable_thinking. "
+            "These are merged before internally derived response controls, so "
+            "the Responses API's computed values take precedence for "
+            "overlapping keys such as add_generation_prompt and "
+            "continue_final_message."
         ),
     )
     thinking_token_budget: int | None = Field(
@@ -305,7 +309,9 @@ class ResponsesRequest(OpenAIBaseModel):
         return ChatParams(
             chat_template=default_template,
             chat_template_content_format=default_template_content_format,
-            chat_template_kwargs=merge_kwargs(  # To remove unset values
+            # Merge request-provided kwargs first so internally derived
+            # Responses API controls take precedence on overlapping keys.
+            chat_template_kwargs=merge_kwargs(
                 self.chat_template_kwargs,
                 dict(
                     add_generation_prompt=not continue_final,


### PR DESCRIPTION
## Purpose
Working with Qwen3.6 27B and the /v1/responses API it was not allowing me to set reasoning effort this fixes that.

## Test Plan

```bash
python -m pytest tests/entrypoints/openai/responses/test_protocol.py tests/entrypoints/openai/responses/test_sampling_params.py   -v
```

## Test Result

 10 passed, 17 warnings in 1.89s

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.