### PR TITLE
Fix prefix cache block visibility lifecycle

### DIFF
--- a/tests/lora/test_lora_prefix_cache_stress.py
+++ b/tests/lora/test_lora_prefix_cache_stress.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import gc
+
+import pytest
+import torch
+from transformers import AutoTokenizer
+
+from vllm import LLM, SamplingParams
+from vllm.lora.request import LoRARequest
+
+MODEL_PATH = "Qwen/Qwen2.5-0.5B-Instruct"
+
+
+def _repeat_to_length(token_ids: list[int], target_len: int) -> list[int]:
+    return (token_ids * ((target_len + len(token_ids) - 1) // len(token_ids)))[
+        :target_len
+    ]
+
+
+def _build_prompt_token_ids(
+    tokenizer, request_id: str, prompt_len: int, prefix_len: int
+) -> list[int]:
+    shared_unit = tokenizer.encode(
+        "Context: the stable key is blue, the checksum is seven, "
+        "and the requested output is the word seven.\n",
+        add_special_tokens=False,
+    )
+    filler_unit = tokenizer.encode(
+        f"Record {request_id}: neutral filler, no new facts. ",
+        add_special_tokens=False,
+    )
+    suffix = tokenizer.encode(
+        "\nQuestion: What single word should be returned?\nAnswer: seven",
+        add_special_tokens=False,
+    )
+    assert prompt_len >= prefix_len + len(suffix)
+    prefix = _repeat_to_length(shared_unit, prefix_len)
+    filler = _repeat_to_length(
+        filler_unit, prompt_len - prefix_len - len(suffix)
+    )
+    return prefix + filler + suffix
+
+
+def _generate_random_lora(output_dir: str, seed: int) -> str:
+    from peft import LoraConfig, TaskType, get_peft_model
+    from transformers import AutoModelForCausalLM
+
+    torch.manual_seed(seed)
+    model = AutoModelForCausalLM.from_pretrained(
+        MODEL_PATH,
+        torch_dtype=torch.float16,
+        low_cpu_mem_usage=True,
+    )
+    lora_config = LoraConfig(
+        task_type=TaskType.CAUSAL_LM,
+        r=8,
+        lora_alpha=16,
+        target_modules=["q_proj", "v_proj"],
+        lora_dropout=0.0,
+        bias="none",
+    )
+    peft_model = get_peft_model(model, lora_config)
+    for name, param in peft_model.named_parameters():
+        if "lora_B" in name:
+            torch.nn.init.normal_(param, mean=0.0, std=0.01)
+    peft_model.save_pretrained(output_dir)
+    del peft_model, model
+    gc.collect()
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
+    return output_dir
+
+
+@pytest.mark.optional
+def test_lora_alternation_prefix_cache_runtime_stress(tmp_path):
+    """Generated LoRA adapters stay deterministic under chunked prefix reuse.
+
+    This mirrors the issue #38606 traffic shape, but keeps the assertion
+    simple: repeated greedy runs of the same alternating-adapter batch must
+    produce identical text. The core block lifecycle invariant is covered by
+    tests/v1/core/test_prefix_caching.py.
+    """
+    lora_a_path = _generate_random_lora(str(tmp_path / "lora_a"), seed=1)
+    lora_b_path = _generate_random_lora(str(tmp_path / "lora_b"), seed=2)
+    lora_a = LoRARequest("lora_a", 1, lora_a_path)
+    lora_b = LoRARequest("lora_b", 2, lora_b_path)
+    tokenizer = AutoTokenizer.from_pretrained(MODEL_PATH)
+
+    llm = LLM(
+        model=MODEL_PATH,
+        enable_lora=True,
+        max_loras=2,
+        max_lora_rank=8,
+        enable_prefix_caching=True,
+        enable_chunked_prefill=True,
+        max_num_batched_tokens=64,
+        max_model_len=2048,
+        gpu_memory_utilization=0.6,
+        enforce_eager=True,
+    )
+    sampling_params = SamplingParams(
+        temperature=0,
+        top_p=1.0,
+        top_k=0,
+        repetition_penalty=1.0,
+        max_tokens=8,
+    )
+    requests = [
+        ("r1", lora_a, 700, 512),
+        ("thrash_0", lora_a, 700, 512),
+        ("thrash_1", lora_b, 700, 0),
+        ("thrash_2", lora_a, 700, 0),
+        ("thrash_3", lora_b, 700, 0),
+        ("thrash_4", lora_a, 700, 0),
+        ("thrash_5", lora_b, 700, 0),
+        ("thrash_6", lora_a, 700, 0),
+        ("r2", lora_b, 700, 512),
+    ]
+    prompts = [
+        {
+            "prompt_token_ids": _build_prompt_token_ids(
+                tokenizer, request_id, prompt_len, prefix_len
+            )
+        }
+        for request_id, _, prompt_len, prefix_len in requests
+    ]
+    lora_requests = [lora for _, lora, _, _ in requests]
+
+    def run_once() -> list[str]:
+        outputs = llm.generate(
+            prompts,
+            sampling_params,
+            lora_request=lora_requests,
+            use_tqdm=False,
+        )
+        return [output.outputs[0].text for output in outputs]
+
+    # Warm the cache once so the assertion compares repeated prefix-cache
+    # reuse, not uncached prefill against cached prefill. Those two paths can
+    # differ by bf16 tie-breaking without implying KV block corruption.
+    run_once()
+    baseline = run_once()
+    for _ in range(3):
+        assert run_once() == baseline

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -108,6 +108,12 @@ def make_kv_cache_config(block_size: int, num_blocks: int) -> KVCacheConfig:
     )
 
 
+def _finish_scheduler_step(manager: KVCacheManager) -> None:
+    """Simulate model-runner completion for direct KV manager tests."""
+    manager.mark_blocks_computed(manager.take_new_cached_blocks())
+    manager.new_step_starts()
+
+
 def make_kv_cache_config_hybrid_model(
     block_size: int,
     num_blocks: int,
@@ -247,6 +253,8 @@ def test_prefill(hash_fn):
         assert manager.block_pool.blocks[block_id].block_hash is None
         assert manager.block_pool.blocks[block_id].ref_cnt == 1
 
+    _finish_scheduler_step(manager)
+
     # Cache hit in the common prefix when the original block is still in use.
     # Incomplete 1 block (5 tokens)
     unique_token_ids = [3] * 5
@@ -280,6 +288,8 @@ def test_prefill(hash_fn):
     assert [
         b.block_id for b in manager.block_pool.free_block_queue.get_all_free_blocks()
     ] == [6, 7, 8, 9, 10, 4, 5, 3, 2, 1]
+
+    _finish_scheduler_step(manager)
 
     # Cache hit in the common prefix when the original block is already free.
     # Incomplete 1 block (6 tokens)
@@ -378,6 +388,8 @@ def test_prefill_hybrid_model():
         assert manager.block_pool.blocks[block_id].block_hash is None
         assert manager.block_pool.blocks[block_id].ref_cnt == 1
 
+    _finish_scheduler_step(manager)
+
     # Cache hit in the common prefix
     # Incomplete 1 block (5 tokens)
     unique_token_ids = [3] * 5
@@ -400,6 +412,8 @@ def test_prefill_hybrid_model():
     block_hashes = req1.block_hashes
     manager.free(req0)
     manager.free(req1)
+
+    _finish_scheduler_step(manager)
 
     # Evict the blocks outside sliding window, does not affect the hit length.
     _test_partial_request_hit(
@@ -549,6 +563,8 @@ def test_prefill_hybrid_model_eagle():
         assert manager.block_pool.blocks[partial_block_id].block_hash is None
         assert manager.block_pool.blocks[partial_block_id].ref_cnt == 1
 
+    _finish_scheduler_step(manager)
+
     # Cache hit in the common prefix
     # Incomplete 1 block (5 tokens)
     unique_token_ids = [6] * 5
@@ -579,6 +595,8 @@ def test_prefill_hybrid_model_eagle():
     block_hashes = req1.block_hashes
     manager.free(req0)
     manager.free(req1)
+
+    _finish_scheduler_step(manager)
 
     # Evict the blocks outside sliding window, does not affect the hit length.
     _test_partial_request_hit(
@@ -864,7 +882,7 @@ def test_prefill_hybrid_model_combinations(spec_types: list[str]):
     # Should have blocks for all groups
     assert len(blocks.get_block_ids()) == num_groups
 
-    manager.new_step_starts()
+    _finish_scheduler_step(manager)
 
     # Second request: should hit cached blocks for common prefix
     req1 = make_request("1", common_token_ids + [4] * 5, block_size, hash_fn)
@@ -941,6 +959,8 @@ def test_prefill_hybrid_model_combinations_eagle(
     # Should have blocks for all groups
     assert len(blocks.get_block_ids()) == num_groups
 
+    _finish_scheduler_step(manager)
+
     # Second request: should hit cached blocks for common prefix
     all_token_ids = common_token_ids + [6] * 5
     req1 = make_request("1", all_token_ids, block_size, hash_fn)
@@ -973,7 +993,7 @@ def test_prefill_hybrid_model_mamba_align():
     Regression test for https://github.com/vllm-project/vllm/issues/34361.
     In mamba_cache_mode="align", allocate_new_blocks() pads req_to_blocks with
     null blocks. cache_full_blocks() correctly skips them, but
-    MambaManager.cache_blocks() must also skip null blocks when tracking
+    cache_blocks() must also skip null blocks when tracking
     cached_blocks_this_step.
     """
     block_size = 16
@@ -1059,6 +1079,8 @@ def test_prefill_plp():
     for block_id in (4,):
         assert manager.block_pool.blocks[block_id].block_hash is None
         assert manager.block_pool.blocks[block_id].ref_cnt == 1
+
+    _finish_scheduler_step(manager)
 
     # Request #1 is a non-prompt-logprobs request:
     # Cache hit in the common prefix when the original block is still in use.
@@ -1227,6 +1249,8 @@ def test_evict():
         b.block_id for b in manager.block_pool.free_block_queue.get_all_free_blocks()
     ] == [10, 6, 5, 4, 3, 2, 1, 9, 8, 7]
 
+    _finish_scheduler_step(manager)
+
     # Touch the first 2 blocks.
     req2 = make_request("2", list(range(2 * 16 + 3)), block_size, sha256)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req2)
@@ -1321,6 +1345,8 @@ def test_computed_blocks_not_evicted():
     # Free the blocks.
     manager.free(req0)
     manager.free(req1)
+
+    _finish_scheduler_step(manager)
 
     # Now if we have a cache hit on the first block, we should evict the second
     # cached block rather than the first one.
@@ -1597,6 +1623,8 @@ def test_mm_prefix_caching():
     assert blocks.get_block_ids() == ([1, 2, 3, 4],)
     req0.num_computed_tokens = 59
 
+    _finish_scheduler_step(manager)
+
     # Append slots without allocating a new block.
     for _ in range(5):
         req0.append_output_token_ids(8)
@@ -1612,6 +1640,8 @@ def test_mm_prefix_caching():
             (("ccc", 0),),
         )
     )
+
+    _finish_scheduler_step(manager)
 
     # Cache hit.
     unique_token_ids = [-1] * 7 + [200] * 5
@@ -1672,6 +1702,8 @@ def test_cache_key_salting():
     assert blocks.get_block_ids() == ([1, 2, 3, 4],)
     req0.num_computed_tokens = 59
 
+    _finish_scheduler_step(manager)
+
     # Append slots without allocating a new block.
     for _ in range(5):
         req0.append_output_token_ids(8)
@@ -1683,6 +1715,8 @@ def test_cache_key_salting():
     assert block_hashes[3] == sha256(
         (block_hashes[2], tuple(token_ids[3 * block_size :] + [8] * 5), None)
     )
+
+    _finish_scheduler_step(manager)
 
     # Test cache hit with a new request that has the same salt.
     token_ids = common_token_ids + [4] * 11
@@ -1739,6 +1773,8 @@ def test_prefill_not_enough_free_blocks_with_computed_blocks():
         req0.request_id
     ]
 
+    _finish_scheduler_step(manager)
+
     # | Common-0 | Common-1 | Common-2 | Req1-3 | Req1-4 | Req1-5 | ... |
     req1 = make_request("1", common_token_ids * 2, block_size, sha256)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
@@ -1755,6 +1791,8 @@ def test_prefill_not_enough_free_blocks_with_computed_blocks():
     manager.free(req1)
     assert {block.ref_cnt for block in block_part1[:3]} == {1}
     assert {block.ref_cnt for block in block_part1[3:]} == {0}
+
+    _finish_scheduler_step(manager)
 
     # | Common-0 | Common-1 | Common-2 | Req1-3 (F) | Req1-4 (F) |
     # | Req1-5(F)| Req2-0   | Req2-1   | ... |
@@ -1805,6 +1843,8 @@ def test_reset_prefix_cache():
     req0 = make_request("0", all_token_ids, block_size, sha256)
     blocks = manager.allocate_slots(req0, 55)
     assert blocks is not None and blocks.get_block_ids() == ([1, 2, 3, 4],)
+
+    _finish_scheduler_step(manager)
 
     unique_token_ids = [4] * 7
     all_token_ids = full_block_token_ids + unique_token_ids
@@ -2258,6 +2298,8 @@ def test_eagle_enabled_removes_last_block():
     )
     manager.free(req)
 
+    _finish_scheduler_step(manager)
+
     # New request with same tokens + Eagle enabled
     req_eagle = make_request("eagle_divisible", token_ids, block_size, sha256)
     computed_blocks, num_tokens = manager.get_computed_blocks(req_eagle)
@@ -2289,6 +2331,8 @@ def test_eagle_with_partial_blocks():
         req, len(token_ids), len(computed_blocks.blocks[0]) * 16, computed_blocks
     )
     manager.free(req)
+
+    _finish_scheduler_step(manager)
 
     # New request with Eagle enabled
     req_eagle = make_request("partial_eagle", token_ids, block_size, sha256)
@@ -2333,6 +2377,8 @@ def test_eagle_with_sliding_window():
     block_hash_first_block = req.block_hashes[0]
     assert block_hash_first_block is not None
     manager.free(req)
+
+    _finish_scheduler_step(manager)
 
     # New request with Eagle enabled
     req_eagle = make_request("partial_eagle", token_ids, block_size, sha256)
@@ -2412,6 +2458,9 @@ def test_different_block_size():
         req0, 7 * block_size, len(computed_blocks.blocks[0]) * 16, computed_blocks
     )
     assert blocks.get_block_ids() == ([1, 2, 3, 4], [5, 6, 7, 8, 9, 10, 11])
+
+    _finish_scheduler_step(manager)
+
     req1 = make_request("1", common_token_ids[: 7 * block_size + 1], block_size, sha256)
     computed_blocks, num_computed_tokens = manager.get_computed_blocks(req1)
     assert len(computed_blocks.blocks[0]) == 3
@@ -2512,6 +2561,481 @@ def test_block_lookup_cache_multi_blocks_per_key():
     assert cache.pop(key1, 11) is block11
     assert cache.get_one_block(key1) is None
     assert cache.pop(key1, 12) is None
+
+
+def test_prefix_cache_block_not_stolen_between_get_and_alloc():
+    """Prefix hits are pinned before another request can recycle them."""
+    block_size = 4
+    manager = KVCacheManager(
+        make_kv_cache_config(block_size, 5),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    prefix_token_ids = list(range(block_size))
+    suffix_token_ids = list(range(block_size, 2 * block_size))
+    req0 = make_request(
+        "0", prefix_token_ids + suffix_token_ids, block_size, sha256
+    )
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    assert manager.allocate_slots(
+        req0, 2 * block_size, num_computed_tokens, computed_blocks
+    )
+    prefix_block = manager.block_pool.blocks[1]
+    assert prefix_block.ref_cnt == 1
+    assert prefix_block.block_hash is not None
+    manager.free(req0)
+    assert prefix_block.ref_cnt == 0
+
+    _finish_scheduler_step(manager)
+
+    req_a = make_request("A", prefix_token_ids + [42], block_size, sha256)
+    computed_blocks_a, num_computed_a = manager.get_computed_blocks(req_a)
+    assert num_computed_a == block_size
+    assert computed_blocks_a.blocks[0][0] is prefix_block
+    assert prefix_block.ref_cnt == 1
+
+    req_b = make_request(
+        "B", [10, 11, 12, 13, 20, 21, 22, 23], block_size, sha256
+    )
+    computed_blocks_b, num_computed_b = manager.get_computed_blocks(req_b)
+    assert num_computed_b == 0
+    blocks_b = manager.allocate_slots(
+        req_b, 2 * block_size, num_computed_b, computed_blocks_b
+    )
+    assert blocks_b is not None
+    req_b_block_ids = {b.block_id for b in blocks_b.blocks[0]}
+    assert prefix_block.block_id not in req_b_block_ids
+
+    blocks_a = manager.allocate_slots(
+        req_a, 1, num_computed_a, computed_blocks_a
+    )
+    assert blocks_a is not None
+    assert prefix_block in manager.coordinator.single_type_managers[
+        0
+    ].req_to_blocks[req_a.request_id]
+
+    manager.free(req_a)
+    manager.free(req_b)
+
+
+def test_no_intra_step_prefix_reuse():
+    """Blocks cached this scheduler step are not safe prefix hits yet."""
+    block_size = 16
+    manager = KVCacheManager(
+        make_kv_cache_config(block_size, 10),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    common_token_ids = [i for i in range(3) for _ in range(block_size)]
+    req0 = make_request(
+        "0", common_token_ids + [99] * 7, block_size, sha256
+    )
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    assert num_computed_tokens == 0
+    assert manager.allocate_slots(
+        req0,
+        len(req0.prompt_token_ids),
+        num_computed_tokens,
+        computed_blocks,
+    )
+
+    req1 = make_request(
+        "1", common_token_ids + [88] * 5, block_size, sha256
+    )
+    computed_blocks1, num_computed_tokens1 = manager.get_computed_blocks(req1)
+    assert num_computed_tokens1 == 3 * block_size
+
+    # req0 registered these blocks before the GPU forward pass has written KV
+    # data into them. Defer req1 until the model-runner output completes.
+    assert (
+        manager.allocate_slots(
+            req1, 5, num_computed_tokens1, computed_blocks1
+        )
+        is None
+    )
+
+    # A new scheduler step alone is not sufficient when async scheduling has an
+    # earlier batch in flight.
+    manager.new_step_starts()
+    computed_blocks1, num_computed_tokens1 = manager.get_computed_blocks(req1)
+    assert num_computed_tokens1 == 3 * block_size
+    assert (
+        manager.allocate_slots(
+            req1, 5, num_computed_tokens1, computed_blocks1
+        )
+        is None
+    )
+
+    _finish_scheduler_step(manager)
+    computed_blocks1, num_computed_tokens1 = manager.get_computed_blocks(req1)
+    assert num_computed_tokens1 == 3 * block_size
+    assert manager.allocate_slots(
+        req1, 5, num_computed_tokens1, computed_blocks1
+    )
+
+    manager.free(req0)
+    manager.free(req1)
+
+
+def test_cancelled_duplicate_hash_evicts_exact_physical_block():
+    """Cancelled work with a duplicate hash must not publish stale blocks."""
+    block_size = 4
+    manager = KVCacheManager(
+        make_kv_cache_config(block_size, 8),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    token_ids = list(range(block_size)) + [99]
+
+    req0 = make_request("0", token_ids, block_size, sha256)
+    computed_blocks0, num_computed_tokens0 = manager.get_computed_blocks(req0)
+    assert manager.allocate_slots(
+        req0, len(token_ids), num_computed_tokens0, computed_blocks0
+    )
+    req0_block = manager.get_blocks(req0.request_id).blocks[0][0]
+    shared_hash = req0_block.block_hash
+    assert shared_hash is not None
+
+    # Allocate the duplicate block directly to simulate a request that was
+    # scheduled, cached, and then removed before SchedulerOutput was built.
+    req1 = make_request("1", token_ids, block_size, sha256)
+    empty_blocks = manager.empty_kv_cache_blocks
+    assert manager.allocate_slots(req1, len(token_ids), 0, empty_blocks)
+    req1_block = manager.get_blocks(req1.request_id).blocks[0][0]
+    assert req1_block.block_hash == shared_hash
+    assert req1_block is not req0_block
+
+    scheduled_blocks = manager.take_new_cached_blocks([req0.request_id])
+    assert scheduled_blocks is not None
+    assert [block.request_id for block in scheduled_blocks] == [req0.request_id]
+    assert req0_block.block_hash == shared_hash
+    assert req1_block.block_hash is None
+    assert (
+        manager.block_pool.cached_block_hash_to_block.get_one_block(shared_hash)
+        is req0_block
+    )
+
+    req_hit = make_request("hit", token_ids, block_size, sha256)
+    computed_blocks_hit, num_computed_tokens_hit = manager.get_computed_blocks(
+        req_hit
+    )
+    assert num_computed_tokens_hit == block_size
+    assert manager.has_pending_computed_blocks(computed_blocks_hit)
+    manager.release_computed_blocks(computed_blocks_hit)
+
+    manager.mark_blocks_computed(scheduled_blocks)
+    computed_blocks_hit, num_computed_tokens_hit = manager.get_computed_blocks(
+        req_hit
+    )
+    assert num_computed_tokens_hit == block_size
+    assert not manager.has_pending_computed_blocks(computed_blocks_hit)
+    manager.release_computed_blocks(computed_blocks_hit)
+
+    manager.free(req0)
+    manager.free(req1)
+
+
+def test_no_intra_step_prefix_reuse_with_lora():
+    """LoRA cache entries obey the same current-step visibility invariant."""
+    block_size = 16
+    manager = KVCacheManager(
+        make_kv_cache_config(block_size, 10),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    lora = LoRARequest(lora_name="adapter_a", lora_int_id=1, lora_path="/a")
+    common_token_ids = [i for i in range(3) for _ in range(block_size)]
+
+    req0 = make_request(
+        "0",
+        common_token_ids + [99] * 7,
+        block_size,
+        sha256,
+        lora_request=lora,
+    )
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    assert manager.allocate_slots(
+        req0,
+        len(req0.prompt_token_ids),
+        num_computed_tokens,
+        computed_blocks,
+    )
+
+    req1 = make_request(
+        "1",
+        common_token_ids + [88] * 5,
+        block_size,
+        sha256,
+        lora_request=lora,
+    )
+    computed_blocks1, num_computed_tokens1 = manager.get_computed_blocks(req1)
+    assert num_computed_tokens1 == 3 * block_size
+    assert (
+        manager.allocate_slots(
+            req1, 5, num_computed_tokens1, computed_blocks1
+        )
+        is None
+    )
+
+    manager.new_step_starts()
+    computed_blocks1, num_computed_tokens1 = manager.get_computed_blocks(req1)
+    assert num_computed_tokens1 == 3 * block_size
+    assert (
+        manager.allocate_slots(
+            req1, 5, num_computed_tokens1, computed_blocks1
+        )
+        is None
+    )
+
+    _finish_scheduler_step(manager)
+    computed_blocks1, num_computed_tokens1 = manager.get_computed_blocks(req1)
+    assert num_computed_tokens1 == 3 * block_size
+    assert manager.allocate_slots(
+        req1, 5, num_computed_tokens1, computed_blocks1
+    )
+
+    manager.free(req0)
+    manager.free(req1)
+
+
+def test_lora_prefix_cache_namespace_and_reuse():
+    """LoRA block hashes isolate adapters while preserving same-adapter hits."""
+    block_size = 16
+    manager = KVCacheManager(
+        make_kv_cache_config(block_size, 10),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    lora_a = LoRARequest(lora_name="adapter_a", lora_int_id=1, lora_path="/a")
+    lora_b = LoRARequest(lora_name="adapter_b", lora_int_id=2, lora_path="/b")
+    # Include a trailing partial block so both full blocks are eligible for a
+    # prefix hit; exact-block prompts intentionally recompute the last block.
+    token_ids = [i for i in range(2) for _ in range(block_size)] + [7]
+
+    req_a0 = make_request(
+        "a0", token_ids, block_size, sha256, lora_request=lora_a
+    )
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req_a0)
+    assert num_computed_tokens == 0
+    assert manager.allocate_slots(
+        req_a0, len(token_ids), num_computed_tokens, computed_blocks
+    )
+    _finish_scheduler_step(manager)
+    manager.free(req_a0)
+
+    req_b = make_request("b", token_ids, block_size, sha256, lora_request=lora_b)
+    computed_blocks_b, num_computed_tokens_b = manager.get_computed_blocks(req_b)
+    assert num_computed_tokens_b == 0
+    assert not computed_blocks_b.blocks[0]
+
+    req_a1 = make_request(
+        "a1", token_ids, block_size, sha256, lora_request=lora_a
+    )
+    computed_blocks_a, num_computed_tokens_a = manager.get_computed_blocks(req_a1)
+    assert num_computed_tokens_a == 2 * block_size
+    assert len(computed_blocks_a.blocks[0]) == 2
+
+    manager.release_computed_blocks(computed_blocks_a)
+
+
+def test_inflight_blocks_not_recycled_before_gpu_completion():
+    """Async scheduling pins in-flight blocks until model-runner completion."""
+    block_size = 4
+    manager = KVCacheManager(
+        make_kv_cache_config(block_size, 8),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+
+    req0 = make_request("0", list(range(2 * block_size)), block_size, sha256)
+    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
+    assert manager.allocate_slots(
+        req0, 2 * block_size, num_computed_tokens, computed_blocks
+    )
+    req0_block_ids = manager.get_block_ids(req0.request_id)[0]
+    inflight_block_ids = manager.pin_inflight_blocks([req0.request_id])
+    assert inflight_block_ids == req0_block_ids
+
+    # Simulate preemption/abort while the GPU batch is still in flight. The
+    # request releases its ownership, but the temporary in-flight pin keeps the
+    # blocks out of the free queue.
+    manager.free(req0)
+    assert all(
+        manager.block_pool.blocks[block_id].ref_cnt == 1
+        for block_id in req0_block_ids
+    )
+
+    req1 = make_request("1", [100 + i for i in range(8)], block_size, sha256)
+    computed_blocks1, num_computed_tokens1 = manager.get_computed_blocks(req1)
+    assert manager.allocate_slots(
+        req1, 2 * block_size, num_computed_tokens1, computed_blocks1
+    )
+    req1_block_ids = manager.get_block_ids(req1.request_id)[0]
+    assert not set(req0_block_ids) & set(req1_block_ids)
+
+    manager.mark_blocks_computed(manager.take_new_cached_blocks())
+    manager.release_inflight_blocks(inflight_block_ids)
+
+    manager.free(req1)
+    assert all(
+        block.is_null or block.ref_cnt == 0 for block in manager.block_pool.blocks
+    )
+
+
+def test_lora_alternation_prefix_cache_lifecycle_stress():
+    """Rapid LoRA alternation preserves prefix-cache ownership invariants.
+
+    This exercises the LoRA alternation traffic shape discussed in issue
+    #38606, but keeps the assertion on the scheduler/KV-cache invariant:
+    blocks must not be visible for unsafe cross-request reuse before the
+    model-runner batch that writes them has completed.
+    """
+    block_size = 8
+    num_prefix_blocks = 6
+    manager = KVCacheManager(
+        make_kv_cache_config(block_size, 40),
+        max_model_len=8192,
+        enable_caching=True,
+        hash_block_size=block_size,
+    )
+    loras = (
+        LoRARequest(lora_name="adapter_a", lora_int_id=1, lora_path="/a"),
+        LoRARequest(lora_name="adapter_b", lora_int_id=2, lora_path="/b"),
+    )
+    long_prefix = [
+        token for token in range(num_prefix_blocks) for _ in range(block_size)
+    ]
+
+    anchor_reqs = []
+    anchor_prefix_block_ids = []
+    anchor_prefix_blocks = []
+    for idx, lora in enumerate(loras):
+        req = make_request(
+            f"anchor_{idx}",
+            long_prefix + [100 + idx],
+            block_size,
+            sha256,
+            lora_request=lora,
+        )
+        computed_blocks, num_computed_tokens = manager.get_computed_blocks(req)
+        assert num_computed_tokens == 0
+        assert manager.allocate_slots(
+            req,
+            len(req.prompt_token_ids),
+            num_computed_tokens,
+            computed_blocks,
+        )
+        blocks = manager.get_blocks(req.request_id).blocks[0]
+        anchor_reqs.append(req)
+        anchor_prefix_blocks.append(blocks[:num_prefix_blocks])
+        anchor_prefix_block_ids.append(
+            [block.block_id for block in blocks[:num_prefix_blocks]]
+        )
+
+    # Identical tokens under different LoRA adapters must hash to different
+    # prefix-cache namespaces.
+    assert anchor_reqs[0].block_hashes[:num_prefix_blocks] != anchor_reqs[
+        1
+    ].block_hashes[:num_prefix_blocks]
+
+    # Requests arriving while the anchor batches are in flight can see the newly
+    # registered prefix blocks, but must not consume them until the model runner
+    # has written the KV data. The failed allocation must also undo the
+    # pre-touch.
+    for idx, lora in enumerate(loras):
+        req = make_request(
+            f"same_step_consumer_{idx}",
+            long_prefix + [200 + idx],
+            block_size,
+            sha256,
+            lora_request=lora,
+        )
+        computed_blocks, num_computed_tokens = manager.get_computed_blocks(req)
+        assert num_computed_tokens == num_prefix_blocks * block_size
+        assert computed_blocks.get_block_ids() == (
+            anchor_prefix_block_ids[idx],
+        )
+        assert all(block.ref_cnt == 2 for block in anchor_prefix_blocks[idx])
+        assert (
+            manager.allocate_slots(
+                req,
+                len(req.prompt_token_ids) - num_computed_tokens,
+                num_computed_tokens,
+                computed_blocks,
+            )
+            is None
+        )
+        assert all(block.ref_cnt == 1 for block in anchor_prefix_blocks[idx])
+
+    manager.new_step_starts()
+    for idx, lora in enumerate(loras):
+        req = make_request(
+            f"next_step_consumer_{idx}",
+            long_prefix + [250 + idx],
+            block_size,
+            sha256,
+            lora_request=lora,
+        )
+        computed_blocks, num_computed_tokens = manager.get_computed_blocks(req)
+        assert num_computed_tokens == num_prefix_blocks * block_size
+        assert (
+            manager.allocate_slots(
+                req,
+                len(req.prompt_token_ids) - num_computed_tokens,
+                num_computed_tokens,
+                computed_blocks,
+            )
+            is None
+        )
+        assert all(block.ref_cnt == 1 for block in anchor_prefix_blocks[idx])
+
+    _finish_scheduler_step(manager)
+
+    # After the model-runner output completes, same-adapter prefix reuse is valid.
+    # Alternate adapters repeatedly to make sure block ownership stays inside
+    # each adapter namespace and the ref counts return to the anchor-only state.
+    consumer_reqs = []
+    for idx in range(8):
+        adapter_idx = idx % 2
+        req = make_request(
+            f"consumer_{idx}",
+            long_prefix + [300 + idx],
+            block_size,
+            sha256,
+            lora_request=loras[adapter_idx],
+        )
+        computed_blocks, num_computed_tokens = manager.get_computed_blocks(req)
+        assert num_computed_tokens == num_prefix_blocks * block_size
+        assert computed_blocks.get_block_ids() == (
+            anchor_prefix_block_ids[adapter_idx],
+        )
+        assert manager.allocate_slots(
+            req,
+            len(req.prompt_token_ids) - num_computed_tokens,
+            num_computed_tokens,
+            computed_blocks,
+        )
+        consumer_reqs.append(req)
+
+    for req in consumer_reqs:
+        manager.free(req)
+    for idx in range(2):
+        assert all(block.ref_cnt == 1 for block in anchor_prefix_blocks[idx])
+
+    for req in anchor_reqs:
+        manager.free(req)
+    assert all(
+        block.is_null or block.ref_cnt == 0 for block in manager.block_pool.blocks
+    )
 
 
 def test_can_fit_full_sequence_swa_cap_admits_long_prompt():

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -106,6 +106,58 @@ def test_schedule(enable_prefix_caching: bool, prompt_logprobs: int | None):
         assert scheduler.running[i] == request
 
 
+def test_pending_prefix_hit_does_not_block_later_waiting_request():
+    """A pending prefix hit skips only that request, not the waiting queue."""
+    block_size = 4
+    scheduler = create_scheduler(
+        async_scheduling=True,
+        enable_prefix_caching=True,
+        max_num_seqs=4,
+        max_num_batched_tokens=64,
+        block_size=block_size,
+        num_blocks=16,
+    )
+
+    anchor = create_requests(
+        num_requests=1,
+        num_tokens=9,
+        same_prompt=True,
+        block_size=block_size,
+        req_ids=["anchor"],
+    )[0]
+    scheduler.add_request(anchor)
+    first_output = scheduler.schedule()
+    assert first_output.num_scheduled_tokens[anchor.request_id] == 9
+    assert first_output.new_cached_blocks
+
+    pending_hit = create_requests(
+        num_requests=1,
+        num_tokens=9,
+        same_prompt=True,
+        block_size=block_size,
+        req_ids=["pending_hit"],
+    )[0]
+    _, independent = create_requests(
+        num_requests=2,
+        num_tokens=9,
+        same_prompt=False,
+        block_size=block_size,
+        req_ids=["dummy", "independent"],
+    )
+    scheduler.add_request(pending_hit)
+    scheduler.add_request(independent)
+
+    second_output = scheduler.schedule()
+    scheduled_new_req_ids = {
+        req_data.req_id for req_data in second_output.scheduled_new_reqs
+    }
+    assert "pending_hit" not in scheduled_new_req_ids
+    assert "independent" in scheduled_new_req_ids
+    assert pending_hit.request_id in {
+        request.request_id for request in scheduler.skipped_waiting
+    }
+
+
 def test_schedule_multimodal_requests():
     scheduler = create_scheduler(model="llava-hf/llava-1.5-7b-hf")
     mm_positions = [[PlaceholderRange(offset=i, length=100)] for i in range(10)]

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -17,6 +17,7 @@ from vllm.v1.core.kv_cache_utils import (
     BlockHashList,
     BlockHashListWithBlockSize,
     BlockHashWithGroupId,
+    CachedBlockEntry,
     ExternalBlockHash,
     FreeKVCacheBlockQueue,
     KVCacheBlock,
@@ -216,7 +217,7 @@ class BlockPool:
         num_full_blocks: int,
         block_size: int,
         kv_cache_group_id: int,
-    ) -> None:
+    ) -> list[CachedBlockEntry]:
         """Cache a list of full blocks for prefix caching.
         This function takes a list of blocks that will have their block hash
         metadata to be updated and cached. Given a request, it updates the
@@ -233,9 +234,12 @@ class BlockPool:
                 be cached after this function.
             block_size: Number of tokens in each block.
             kv_cache_group_id: The id of the KV cache group.
+
+        Returns:
+            The physical block entries newly inserted into the prefix cache.
         """
         if num_cached_blocks >= num_full_blocks:
-            return
+            return []
         new_full_blocks = blocks[num_cached_blocks:num_full_blocks]
         assert len(request.block_hashes) >= num_full_blocks
         if block_size == self.hash_block_size:
@@ -255,6 +259,7 @@ class BlockPool:
         new_hashes: list[ExternalBlockHash] | None = (
             [] if self.enable_kv_cache_events else None
         )
+        new_cached_blocks: list[CachedBlockEntry] = []
         for i, blk in enumerate(new_full_blocks):
             # Some blocks may be null blocks when enabling sparse attention like
             # sliding window attention, or Mamba models with prefix-caching in
@@ -270,6 +275,13 @@ class BlockPool:
             )
             blk.block_hash = block_hash_with_group_id
             self.cached_block_hash_to_block.insert(block_hash_with_group_id, blk)
+            new_cached_blocks.append(
+                CachedBlockEntry(
+                    request_id=request.request_id,
+                    block_id=blk.block_id,
+                    block_hash=block_hash_with_group_id,
+                )
+            )
             if new_hashes is not None:
                 new_hashes.append(maybe_convert_block_hash(block_hash))
 
@@ -318,6 +330,7 @@ class BlockPool:
                     group_idx=kv_cache_group_id,
                 )
             )
+        return new_cached_blocks
 
     def get_new_blocks(self, num_blocks: int) -> list[KVCacheBlock]:
         """Get new blocks from the free block pool.
@@ -439,6 +452,15 @@ class BlockPool:
             )
             block = self.blocks[block_id]
             self._maybe_evict_cached_block(block)
+
+    def evict_cached_blocks(
+        self, cached_blocks: Iterable[CachedBlockEntry]
+    ) -> None:
+        """Evict specific cached blocks when scheduled work is cancelled."""
+        for cached_block in cached_blocks:
+            block = self.blocks[cached_block.block_id]
+            if block.block_hash == cached_block.block_hash:
+                self._maybe_evict_cached_block(block)
 
     def reset_prefix_cache(self) -> bool:
         """Reset prefix cache. This function may be used in RLHF

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -10,6 +10,7 @@ from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     BlockHashList,
     BlockHashListWithBlockSize,
+    CachedBlockEntry,
     KVCacheBlock,
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
@@ -184,7 +185,9 @@ class KVCacheCoordinator(ABC):
             for manager in self.single_type_managers
         )
 
-    def cache_blocks(self, request: Request, num_computed_tokens: int) -> None:
+    def cache_blocks(
+        self, request: Request, num_computed_tokens: int
+    ) -> list[CachedBlockEntry]:
         """
         Cache the blocks for the request.
 
@@ -194,8 +197,10 @@ class KVCacheCoordinator(ABC):
                 that need to be cached
                 (including tokens that are already cached).
         """
+        new_cached_blocks: list[CachedBlockEntry] = []
         for manager in self.single_type_managers:
-            manager.cache_blocks(request, num_computed_tokens)
+            new_cached_blocks.extend(manager.cache_blocks(request, num_computed_tokens))
+        return new_cached_blocks
 
     def free(self, request_id: str) -> None:
         """
@@ -247,6 +252,65 @@ class KVCacheCoordinator(ABC):
             manager.req_to_blocks.get(request_id) or []
             for manager in self.single_type_managers
         )
+
+    def touch_computed_blocks(
+        self, computed_blocks: tuple[Sequence[KVCacheBlock], ...]
+    ) -> None:
+        """Pin prefix-cache hits returned by find_longest_cache_hit().
+
+        get_computed_blocks() and allocate_slots() are separate scheduler
+        operations. If a hit block is currently an eviction candidate
+        (ref_cnt == 0), another request can recycle it between those calls
+        unless we pin it immediately.
+        """
+        if not self.enable_caching:
+            return
+        for group_blocks in computed_blocks:
+            blocks_to_touch = [block for block in group_blocks if not block.is_null]
+            self.block_pool.touch(blocks_to_touch)
+
+    def release_computed_blocks(
+        self, computed_blocks: tuple[Sequence[KVCacheBlock], ...]
+    ) -> None:
+        """Undo touch_computed_blocks() when a request is not scheduled."""
+        if not self.enable_caching:
+            return
+        for group_blocks in computed_blocks:
+            self.block_pool.free_blocks(
+                block for block in group_blocks if not block.is_null
+            )
+
+    def has_pending_computed_blocks(
+        self, computed_blocks: tuple[Sequence[KVCacheBlock], ...]
+    ) -> bool:
+        """Return whether a prefix hit still has in-flight GPU writes."""
+        if not self.enable_caching:
+            return False
+        return any(
+            manager.has_pending_computed_blocks(group_blocks)
+            for manager, group_blocks in zip(
+                self.single_type_managers, computed_blocks
+            )
+        )
+
+    def mark_blocks_computed(
+        self, cached_blocks: Sequence[CachedBlockEntry]
+    ) -> None:
+        """Mark pending prefix-cache entries as safe after GPU completion."""
+        if not self.enable_caching:
+            return
+        for manager in self.single_type_managers:
+            manager.mark_blocks_computed(cached_blocks)
+
+    def discard_pending_blocks(
+        self, cached_blocks: Sequence[CachedBlockEntry]
+    ) -> None:
+        """Remove pending prefix-cache entries for cancelled scheduled work."""
+        if not self.enable_caching:
+            return
+        for manager in self.single_type_managers:
+            manager.mark_blocks_computed(cached_blocks)
+        self.block_pool.evict_cached_blocks(cached_blocks)
 
     @abstractmethod
     def find_longest_cache_hit(

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -10,7 +10,7 @@ from vllm.distributed.kv_events import KVCacheEvent
 from vllm.logger import init_logger
 from vllm.v1.core.kv_cache_coordinator import get_kv_cache_coordinator
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
-from vllm.v1.core.kv_cache_utils import KVCacheBlock
+from vllm.v1.core.kv_cache_utils import CachedBlockEntry, KVCacheBlock
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.stats import PrefixCacheStats
 from vllm.v1.request import Request
@@ -158,6 +158,11 @@ class KVCacheManager:
         self.empty_kv_cache_blocks = KVCacheBlocks(
             tuple(() for _ in range(self.num_kv_cache_groups))
         )
+        # Prefix cache entries are registered during scheduling, before the
+        # model runner has written the corresponding KV data. The scheduler
+        # drains these physical block entries into SchedulerOutput and marks
+        # them ready only after that output completes.
+        self._new_cached_blocks: list[CachedBlockEntry] = []
 
     @property
     def usage(self) -> float:
@@ -211,6 +216,12 @@ class KVCacheManager:
                 request.block_hashes, max_cache_hit_length
             )
         )
+        if num_new_computed_tokens > 0:
+            # Pin prefix-cache hits immediately. A cached block with ref_cnt=0
+            # sits in the eviction queue, so waiting until allocate_slots() to
+            # touch it leaves a scheduler-window where another request can
+            # recycle the block and make this hit point at unrelated KV data.
+            self.coordinator.touch_computed_blocks(computed_blocks)
 
         if self.log_stats:
             assert self.prefix_cache_stats is not None
@@ -221,6 +232,23 @@ class KVCacheManager:
             )
 
         return self.create_kv_cache_blocks(computed_blocks), num_new_computed_tokens
+
+    def release_computed_blocks(self, computed_blocks: KVCacheBlocks) -> None:
+        """Release prefix-cache hits pinned by get_computed_blocks().
+
+        This must be called whenever a request with prefix-cache hits will not
+        call allocate_slots() in the same scheduler pass. Otherwise the
+        pre-touch would leak a reference and keep eviction candidates pinned.
+        """
+        if computed_blocks is self.empty_kv_cache_blocks:
+            return
+        self.coordinator.release_computed_blocks(computed_blocks.blocks)
+
+    def has_pending_computed_blocks(self, computed_blocks: KVCacheBlocks) -> bool:
+        """Return whether any prefix hit is not safe to consume yet."""
+        if computed_blocks is self.empty_kv_cache_blocks:
+            return False
+        return self.coordinator.has_pending_computed_blocks(computed_blocks.blocks)
 
     def can_fit_full_sequence(
         self,
@@ -240,6 +268,12 @@ class KVCacheManager:
             new_computed_block_list = new_computed_blocks.blocks
         else:
             new_computed_block_list = self.empty_kv_cache_blocks.blocks
+
+        if (
+            new_computed_blocks is not None
+            and self.has_pending_computed_blocks(new_computed_blocks)
+        ):
+            return False
 
         num_local_computed_tokens = (
             request.num_computed_tokens + num_new_computed_tokens
@@ -356,6 +390,17 @@ class KVCacheManager:
         else:
             new_computed_block_list = self.empty_kv_cache_blocks.blocks
 
+        if (
+            new_computed_blocks is not None
+            and self.has_pending_computed_blocks(new_computed_blocks)
+        ):
+            # A prefix hit can be found in the cache hash table before the GPU
+            # batch that writes its KV data completes. Do not let direct callers
+            # consume it; the scheduler has a precheck that skips this request
+            # and continues with later waiting requests.
+            self.coordinator.release_computed_blocks(new_computed_block_list)
+            return None
+
         # The number of computed tokens is the number of computed tokens plus
         # the new prefix caching hits
         num_local_computed_tokens = (
@@ -392,7 +437,10 @@ class KVCacheManager:
         )
 
         if num_blocks_to_allocate > self.block_pool.get_num_free_blocks():
-            # Cannot allocate new blocks
+            # Cannot allocate new blocks. Release any prefix-cache hits that
+            # were pre-touched by get_computed_blocks() for this request.
+            if new_computed_block_list is not self.empty_kv_cache_blocks.blocks:
+                self.coordinator.release_computed_blocks(new_computed_block_list)
             return None
 
         if (
@@ -429,7 +477,7 @@ class KVCacheManager:
             total_computed_tokens + num_new_tokens,
             request.num_tokens,
         )
-        self.coordinator.cache_blocks(request, num_tokens_to_cache)
+        self.cache_blocks(request, num_tokens_to_cache)
 
         return self.create_kv_cache_blocks(new_blocks)
 
@@ -539,7 +587,74 @@ class KVCacheManager:
                 that are already cached and tokens to be cached.
         """
         if self.enable_caching:
-            self.coordinator.cache_blocks(request, num_computed_tokens)
+            self._new_cached_blocks.extend(
+                self.coordinator.cache_blocks(request, num_computed_tokens)
+            )
+
+    def take_new_cached_blocks(
+        self, scheduled_request_ids: Sequence[str] | None = None
+    ) -> list[CachedBlockEntry] | None:
+        """Drain cache entries published by cache_blocks() since the last call.
+
+        If scheduled_request_ids is provided, hashes from work cancelled before
+        the SchedulerOutput is built are discarded instead of later being marked
+        ready without a corresponding GPU write.
+        """
+        if not self._new_cached_blocks:
+            return None
+        cached_blocks = self._new_cached_blocks
+        self._new_cached_blocks = []
+        if scheduled_request_ids is not None:
+            scheduled_request_id_set = set(scheduled_request_ids)
+            cancelled_blocks = [
+                cached_block
+                for cached_block in cached_blocks
+                if cached_block.request_id not in scheduled_request_id_set
+            ]
+            if cancelled_blocks:
+                self.coordinator.discard_pending_blocks(cancelled_blocks)
+            cached_blocks = [
+                cached_block
+                for cached_block in cached_blocks
+                if cached_block.request_id in scheduled_request_id_set
+            ]
+        return cached_blocks
+
+    def mark_blocks_computed(
+        self, cached_blocks: Sequence[CachedBlockEntry] | None
+    ) -> None:
+        """Make pending prefix-cache entries visible after GPU completion."""
+        if cached_blocks:
+            self.coordinator.mark_blocks_computed(cached_blocks)
+
+    def pin_inflight_blocks(self, request_ids: Sequence[str]) -> list[int] | None:
+        """Pin blocks used by an in-flight model runner batch.
+
+        Async scheduling can schedule or preempt another batch before the
+        current GPU work completes. These temporary pins prevent blocks that
+        the model runner may still read or write from being recycled.
+        """
+        block_ids: list[int] = []
+        blocks_to_pin: list[KVCacheBlock] = []
+        for request_id in request_ids:
+            for group_blocks in self.coordinator.get_blocks(request_id):
+                for block in group_blocks:
+                    if block.is_null:
+                        continue
+                    blocks_to_pin.append(block)
+                    block_ids.append(block.block_id)
+        if not blocks_to_pin:
+            return None
+        self.block_pool.touch(blocks_to_pin)
+        return block_ids
+
+    def release_inflight_blocks(self, block_ids: Sequence[int] | None) -> None:
+        """Release temporary pins from pin_inflight_blocks()."""
+        if not block_ids:
+            return
+        self.block_pool.free_blocks(
+            self.block_pool.blocks[block_id] for block_id in block_ids
+        )
 
     def create_kv_cache_blocks(
         self, blocks: tuple[list[KVCacheBlock], ...]

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -44,6 +44,16 @@ BlockHash = NewType("BlockHash", bytes)
 # functions below pack/unpack the `BlockHash` and group id into/from the key.
 BlockHashWithGroupId = NewType("BlockHashWithGroupId", bytes)
 
+
+@dataclass(frozen=True, slots=True)
+class CachedBlockEntry:
+    """A physical block registered in the prefix-cache hash table."""
+
+    request_id: str
+    block_id: int
+    block_hash: BlockHashWithGroupId
+
+
 # ExternalBlockHash is used for reproducible prefix-cache block hashing.
 # It's a union of `bytes` and `int` to keep backward compatibility
 # after we default block hashing to use sha256 bytes.

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from vllm.multimodal.inputs import MultiModalFeatureSpec
     from vllm.pooling_params import PoolingParams
     from vllm.sampling_params import SamplingParams
+    from vllm.v1.core.kv_cache_utils import CachedBlockEntry
     from vllm.v1.request import Request
 else:
     ECConnectorMetadata = object
@@ -25,6 +26,7 @@ else:
     PoolingParams = object
     SamplingParams = object
     Request = object
+    CachedBlockEntry = object
 
 
 @dataclass
@@ -237,6 +239,15 @@ class SchedulerOutput:
     # The worker zeros the corresponding GPU memory before the blocks are used,
     # preventing stale NaN/data from corrupting attention or SSM computation.
     new_block_ids_to_zero: list[int] | None = None
+
+    # Physical blocks registered in the prefix cache by this scheduling step.
+    # They are not valid prefix hits until this SchedulerOutput has completed.
+    new_cached_blocks: list[CachedBlockEntry] | None = None
+
+    # Blocks touched by this scheduling step's model-runner batch. These pins
+    # prevent async scheduling/preemption from recycling blocks before the GPU
+    # has finished reading or writing them.
+    inflight_pinned_block_ids: list[int] | None = None
 
     @classmethod
     def make_empty(cls) -> "SchedulerOutput":

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -616,6 +616,18 @@ class Scheduler(SchedulerInterface):
                     new_computed_blocks, num_new_local_computed_tokens = (
                         self.kv_cache_manager.get_computed_blocks(request)
                     )
+                    if self.kv_cache_manager.has_pending_computed_blocks(
+                        new_computed_blocks
+                    ):
+                        # The prefix lookup found blocks registered by an
+                        # in-flight model-runner batch. Skip only this request
+                        # so later waiting requests can still use this step.
+                        self.kv_cache_manager.release_computed_blocks(
+                            new_computed_blocks
+                        )
+                        request_queue.pop_request()
+                        step_skipped_waiting.prepend_request(request)
+                        continue
 
                     # Get externally-cached tokens if using a KVConnector.
                     if self.connector is not None:
@@ -629,6 +641,9 @@ class Scheduler(SchedulerInterface):
                             # The request cannot be scheduled because
                             # the KVConnector couldn't determine
                             # the number of matched tokens.
+                            self.kv_cache_manager.release_computed_blocks(
+                                new_computed_blocks
+                            )
                             request_queue.pop_request()
                             step_skipped_waiting.prepend_request(request)
                             continue
@@ -687,6 +702,9 @@ class Scheduler(SchedulerInterface):
                     ):
                         # If chunked_prefill is disabled,
                         # we can stop the scheduling here.
+                        self.kv_cache_manager.release_computed_blocks(
+                            new_computed_blocks
+                        )
                         break
 
                     num_new_tokens = min(num_new_tokens, token_budget)
@@ -708,6 +726,9 @@ class Scheduler(SchedulerInterface):
                         )
                         if num_new_tokens == 0:
                             # The request cannot be scheduled.
+                            self.kv_cache_manager.release_computed_blocks(
+                                new_computed_blocks
+                            )
                             break
 
                 if self.need_mamba_block_aligned_split:
@@ -718,6 +739,9 @@ class Scheduler(SchedulerInterface):
                         num_external_computed_tokens,
                     )
                     if num_new_tokens == 0:
+                        self.kv_cache_manager.release_computed_blocks(
+                            new_computed_blocks
+                        )
                         break
 
                 # Handles an edge case when P/D Disaggregation
@@ -753,6 +777,9 @@ class Scheduler(SchedulerInterface):
                 ):
                     if request.has_encoder_inputs:
                         self.encoder_cache_manager.free(request)
+                    self.kv_cache_manager.release_computed_blocks(
+                        new_computed_blocks
+                    )
                     break
 
                 new_blocks = self.kv_cache_manager.allocate_slots(
@@ -919,6 +946,13 @@ class Scheduler(SchedulerInterface):
             if self.needs_kv_cache_zeroing
             else None
         )
+        scheduled_request_ids = tuple(num_scheduled_tokens)
+        new_cached_blocks = self.kv_cache_manager.take_new_cached_blocks(
+            scheduled_request_ids
+        )
+        inflight_pinned_block_ids = self.kv_cache_manager.pin_inflight_blocks(
+            scheduled_request_ids
+        )
 
         scheduler_output = SchedulerOutput(
             scheduled_new_reqs=new_reqs_data,
@@ -936,6 +970,8 @@ class Scheduler(SchedulerInterface):
             finished_req_ids=self.finished_req_ids,
             free_encoder_mm_hashes=self.encoder_cache_manager.get_freed_mm_hashes(),
             new_block_ids_to_zero=new_block_ids_to_zero,
+            new_cached_blocks=new_cached_blocks,
+            inflight_pinned_block_ids=inflight_pinned_block_ids,
         )
 
         # NOTE(Kuntai): this function is designed for multiple purposes:
@@ -1305,6 +1341,16 @@ class Scheduler(SchedulerInterface):
         scheduler_output: SchedulerOutput,
         model_runner_output: ModelRunnerOutput,
     ) -> dict[int, EngineCoreOutputs]:
+        # Prefix-cache blocks are registered during scheduling, before the GPU
+        # writes their KV data. They become safe to reuse only after the
+        # corresponding model-runner output has completed.
+        self.kv_cache_manager.mark_blocks_computed(
+            scheduler_output.new_cached_blocks
+        )
+        self.kv_cache_manager.release_inflight_blocks(
+            scheduler_output.inflight_pinned_block_ids
+        )
+
         sampled_token_ids = model_runner_output.sampled_token_ids
         logprobs = model_runner_output.logprobs
         prompt_logprobs_dict = model_runner_output.prompt_logprobs_dict

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -85,7 +85,7 @@ class SingleTypeKVCacheManager(ABC):
         # whose GPU forward pass has not completed yet. These blocks must not
         # be consumed as prefix hits: their block hashes are visible before the
         # model runner has written the corresponding KV data.
-        self.cached_blocks_pending_write: dict[BlockHashWithGroupId, int] = {}
+        self.cached_blocks_pending_write: set[tuple[BlockHashWithGroupId, int]] = set()
 
     @classmethod
     def _get_num_evictable_blocks(cls, blocks: Sequence[KVCacheBlock]):
@@ -314,9 +314,8 @@ class SingleTypeKVCacheManager(ABC):
         self.num_cached_block[request.request_id] = num_full_blocks
         if self.enable_caching:
             for cached_block in new_cached_blocks:
-                self.cached_blocks_pending_write[cached_block.block_hash] = (
-                    self.cached_blocks_pending_write.get(cached_block.block_hash, 0)
-                    + 1
+                self.cached_blocks_pending_write.add(
+                    (cached_block.block_hash, cached_block.block_id)
                 )
         return new_cached_blocks
 
@@ -471,7 +470,7 @@ class SingleTypeKVCacheManager(ABC):
         return any(
             not block.is_null
             and block.block_hash is not None
-            and block.block_hash in self.cached_blocks_pending_write
+            and (block.block_hash, block.block_id) in self.cached_blocks_pending_write
             for block in computed_blocks
         )
 
@@ -479,14 +478,9 @@ class SingleTypeKVCacheManager(ABC):
         self, cached_blocks: Sequence[CachedBlockEntry]
     ) -> None:
         for cached_block in cached_blocks:
-            block_hash = cached_block.block_hash
-            pending_count = self.cached_blocks_pending_write.get(block_hash)
-            if pending_count is None:
-                continue
-            if pending_count == 1:
-                del self.cached_blocks_pending_write[block_hash]
-            else:
-                self.cached_blocks_pending_write[block_hash] = pending_count - 1
+            self.cached_blocks_pending_write.discard(
+                (cached_block.block_hash, cached_block.block_id)
+            )
 
 
 class FullAttentionManager(SingleTypeKVCacheManager):

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -10,6 +10,7 @@ from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_utils import (
     BlockHashList,
     BlockHashWithGroupId,
+    CachedBlockEntry,
     KVCacheBlock,
 )
 from vllm.v1.kv_cache_interface import (
@@ -80,6 +81,11 @@ class SingleTypeKVCacheManager(ABC):
 
         self.kv_cache_group_id = kv_cache_group_id
         self._null_block = block_pool.null_block
+        # Blocks registered in the prefix cache by scheduler allocation, but
+        # whose GPU forward pass has not completed yet. These blocks must not
+        # be consumed as prefix hits: their block hashes are visible before the
+        # model runner has written the corresponding KV data.
+        self.cached_blocks_pending_write: dict[BlockHashWithGroupId, int] = {}
 
     @classmethod
     def _get_num_evictable_blocks(cls, blocks: Sequence[KVCacheBlock]):
@@ -200,6 +206,15 @@ class SingleTypeKVCacheManager(ABC):
         num_skipped_tokens = self.get_num_skipped_tokens(num_total_computed_tokens)
         num_skipped_blocks = num_skipped_tokens // self.block_size
         if num_skipped_blocks > 0:
+            # Prefix-cache hits were pre-touched by get_computed_blocks().
+            # Release any skipped hits that will not be tracked in req_to_blocks.
+            if self.enable_caching:
+                num_to_release = min(num_skipped_blocks, len(new_computed_blocks))
+                self.block_pool.free_blocks(
+                    block
+                    for block in new_computed_blocks[:num_to_release]
+                    if not block.is_null
+                )
             # It is possible that all new computed blocks are skipped when
             # num_skipped_blocks > len(new_computed_blocks).
             new_computed_blocks = new_computed_blocks[num_skipped_blocks:]
@@ -209,10 +224,10 @@ class SingleTypeKVCacheManager(ABC):
                 num_external_computed_tokens,
             )
 
-        # Touch the computed blocks to make sure they won't be evicted.
-        if self.enable_caching:
-            self.block_pool.touch(new_computed_blocks)
-        else:
+        # Prefix-cache hits are pinned by get_computed_blocks(), before another
+        # scheduler allocation can recycle their blocks. Touching again here
+        # would double-count the reference.
+        if not self.enable_caching:
             assert not any(new_computed_blocks), (
                 "Computed blocks should be empty when prefix caching is disabled"
             )
@@ -270,7 +285,9 @@ class SingleTypeKVCacheManager(ABC):
         self.new_block_ids = []
         return ids
 
-    def cache_blocks(self, request: Request, num_tokens: int) -> None:
+    def cache_blocks(
+        self, request: Request, num_tokens: int
+    ) -> list[CachedBlockEntry]:
         """
         Cache the blocks for the request.
 
@@ -283,9 +300,9 @@ class SingleTypeKVCacheManager(ABC):
         num_full_blocks = num_tokens // self.block_size
 
         if num_cached_blocks >= num_full_blocks:
-            return
+            return []
 
-        self.block_pool.cache_full_blocks(
+        new_cached_blocks = self.block_pool.cache_full_blocks(
             request=request,
             blocks=self.req_to_blocks[request.request_id],
             num_cached_blocks=num_cached_blocks,
@@ -295,6 +312,13 @@ class SingleTypeKVCacheManager(ABC):
         )
 
         self.num_cached_block[request.request_id] = num_full_blocks
+        if self.enable_caching:
+            for cached_block in new_cached_blocks:
+                self.cached_blocks_pending_write[cached_block.block_hash] = (
+                    self.cached_blocks_pending_write.get(cached_block.block_hash, 0)
+                    + 1
+                )
+        return new_cached_blocks
 
     def free(self, request_id: str) -> None:
         """
@@ -435,8 +459,34 @@ class SingleTypeKVCacheManager(ABC):
         return 0
 
     def new_step_starts(self) -> None:
-        # do nothing by default
+        # Prefix-cache entries are made visible by scheduler allocation, but
+        # remain unsafe until the corresponding model-runner output is returned.
+        # Therefore there is no per-scheduler-step state to clear here.
         return None
+
+    def has_pending_computed_blocks(
+        self, computed_blocks: Sequence[KVCacheBlock]
+    ) -> bool:
+        """Return whether any prefix-hit block is still pending GPU writes."""
+        return any(
+            not block.is_null
+            and block.block_hash is not None
+            and block.block_hash in self.cached_blocks_pending_write
+            for block in computed_blocks
+        )
+
+    def mark_blocks_computed(
+        self, cached_blocks: Sequence[CachedBlockEntry]
+    ) -> None:
+        for cached_block in cached_blocks:
+            block_hash = cached_block.block_hash
+            pending_count = self.cached_blocks_pending_write.get(block_hash)
+            if pending_count is None:
+                continue
+            if pending_count == 1:
+                del self.cached_blocks_pending_write[block_hash]
+            else:
+                self.cached_blocks_pending_write[block_hash] = pending_count - 1
 
 
 class FullAttentionManager(SingleTypeKVCacheManager):
@@ -792,7 +842,6 @@ class MambaManager(SingleTypeKVCacheManager):
         self, kv_cache_spec: MambaSpec, block_pool: BlockPool, **kwargs
     ) -> None:
         super().__init__(kv_cache_spec, block_pool, **kwargs)
-        self.cached_blocks_this_step: set[BlockHashWithGroupId] = set()
         self.mamba_cache_mode = kv_cache_spec.mamba_cache_mode
         self.num_speculative_blocks: int = kv_cache_spec.num_speculative_blocks
         if self.mamba_cache_mode == "align":
@@ -850,7 +899,9 @@ class MambaManager(SingleTypeKVCacheManager):
 
         return computed_blocks
 
-    def remove_skipped_blocks(self, request_id: str, num_computed_tokens: int) -> None:
+    def remove_skipped_blocks(
+        self, request_id: str, total_computed_tokens: int
+    ) -> None:
         assert isinstance(self.kv_cache_spec, MambaSpec)
 
         # NOTE (tdoublep) with async scheduling, the num_computed_tokens can contain
@@ -858,7 +909,9 @@ class MambaManager(SingleTypeKVCacheManager):
         # This can make us think we are further ahead in the sequence than we actually
         # are, so let's assume that all tokens are rejected so we don't free blocks
         # that we might actually need.
-        num_computed_tokens = max(0, num_computed_tokens - self.num_speculative_blocks)
+        num_computed_tokens = max(
+            0, total_computed_tokens - self.num_speculative_blocks
+        )
 
         super().remove_skipped_blocks(request_id, num_computed_tokens)
         if self.mamba_cache_mode == "align":
@@ -895,15 +948,6 @@ class MambaManager(SingleTypeKVCacheManager):
         num_tokens_main_model: int,
     ) -> int:
         assert isinstance(self.kv_cache_spec, MambaSpec)
-        if (
-            len(new_computed_blocks) > 0
-            and new_computed_blocks[-1].block_hash in self.cached_blocks_this_step
-        ):
-            # Mamba can't rely on blocks generated by other requests in the current step
-            # To put it in the next step, we return num_gpu_blocks + 1 so
-            # that kv_cache_manager will think there is no enough blocks to allocate now
-            # and don't schedule it in the current step.
-            return self.block_pool.num_gpu_blocks + 1
         if self.mamba_cache_mode != "align":
             # Allocate extra `num_speculative_blocks` blocks for
             # speculative decoding (MTP/EAGLE) with linear attention.
@@ -1043,21 +1087,12 @@ class MambaManager(SingleTypeKVCacheManager):
         """
         return num_computed_tokens - 1
 
-    def cache_blocks(self, request: Request, num_tokens: int) -> None:
-        num_cached_blocks_before = self.num_cached_block.get(request.request_id, 0)
-        super().cache_blocks(request, num_tokens)
-        num_cached_blocks_after = self.num_cached_block.get(request.request_id, 0)
-        if num_cached_blocks_after > num_cached_blocks_before:
-            for block in self.req_to_blocks[request.request_id][
-                num_cached_blocks_before:num_cached_blocks_after
-            ]:
-                if block.is_null:
-                    continue
-                assert block.block_hash is not None
-                self.cached_blocks_this_step.add(block.block_hash)
-
-    def new_step_starts(self) -> None:
-        self.cached_blocks_this_step.clear()
+    def cache_blocks(
+        self, request: Request, num_tokens: int
+    ) -> list[CachedBlockEntry]:
+        # Tracking newly-cached blocks in cached_blocks_pending_write is handled
+        # by the base cache_blocks implementation.
+        return super().cache_blocks(request, num_tokens)
 
 
 class CrossAttentionManager(SingleTypeKVCacheManager):
@@ -1074,7 +1109,9 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         # requests, so  `new_computed_blocks` should always be empty.
         assert len(new_computed_blocks) == 0
 
-    def cache_blocks(self, request: Request, num_tokens: int) -> None:
+    def cache_blocks(
+        self, request: Request, num_tokens: int
+    ) -> list[CachedBlockEntry]:
         # We do not cache blocks for cross-attention to be shared between
         # requests, so this method is not relevant.
         raise ValueError("Should not be called as prefix caching is disabled.")


### PR DESCRIPTION
## Summary

This PR tightens the scheduler/KV-cache lifecycle around prefix-cache visibility:

- pins prefix-cache hits as soon as lookup returns them, so an evictable hit cannot be recycled before `allocate_slots()`;
- tracks newly registered physical prefix-cache blocks as pending until the model-runner batch that writes their KV data completes;
- defers reuse of pending prefix-cache entries, including LoRA-prefixed entries, until completion;
- evicts exact physical blocks, not only hashes, when scheduled work is cancelled before the model-runner batch is built;
- skips only the request that hit pending KV blocks so other waiting requests can still be scheduled;
- temporarily pins blocks touched by an in-flight async model-runner batch so abort/preemption paths cannot recycle them early;
- releases the new pins on scheduler deferral paths to avoid leaking references.

The intended invariant is narrow: a block may be registered in the prefix-cache hash table during scheduling, but it must not become a valid cross-request prefix hit until the GPU work that writes the corresponding KV data has completed.

## Context on #38606

I investigated the reporter's Qwen/Qwen2.5-0.5B-Instruct repro for #38606 and reproduced the nondeterministic text symptom. I do not think the repro script, by itself, cleanly proves KV block corruption:

- before this fix: the exact reporter repro reported divergent greedy output;
- after this fix: the exact reporter repro still reports divergent greedy output;
- corrected controls also diverged with `--no-enable-prefix-caching --no-enable-chunked-prefill --enable-lora`;
- the same controls still diverged with `--enforce-eager`, with `--max-num-seqs 1`, and with `--max-loras 2`;
- a modified base-model-only run also diverged with no LoRA, no prefix caching, and no chunked prefill;
- a sequential base-model check of the same request was stable.

So this PR does not claim that every nondeterministic output observed by that script is fixed here. The text-diff oracle appears to include a broader concurrent greedy-generation signal. This patch instead fixes the scheduler/KV lifecycle hazard that the investigation exposed and adds deterministic tests for that invariant.

## Regression proof

The before/after evidence is intentionally split by signal:

- Reporter repro: before this patch, the exact Qwen/Qwen2.5-0.5B-Instruct repro diverged; after this patch, that same text-diff repro still diverged. This is why the PR does not claim to close #38606 by using the reporter script as the oracle.
- Targeted scheduler/KV invariant: the new deterministic tests encode the pre-fix failure modes directly and pass after this patch:
  - `test_no_intra_step_prefix_reuse` and `test_no_intra_step_prefix_reuse_with_lora` assert that a request cannot consume prefix-cache blocks registered earlier in the same scheduler/model-runner step; pre-fix behavior made those blocks visible immediately, while the fixed behavior defers reuse until `mark_blocks_computed()`.
  - `test_cancelled_duplicate_hash_evicts_exact_physical_block` covers the duplicate-hash cancellation case: cancelled scheduled work must evict its exact physical block instead of using hash-only filtering that can leave an unwritten duplicate visible.
  - `test_inflight_blocks_not_recycled_before_gpu_completion` covers async/preemption reuse: blocks touched by an in-flight model-runner batch remain pinned until the corresponding output is processed.
  - `test_lora_alternation_prefix_cache_lifecycle_stress` exercises rapid alternating LoRA adapter requests while preserving same-adapter reuse and cross-adapter namespace separation.
- Runtime stress: `tests/lora/test_lora_prefix_cache_stress.py --optional` generates two LoRA adapters and repeats an alternating-adapter greedy batch; it passed after the fix on the GCP L4 validation VM.

## Tests

- `python -m pytest tests/v1/core/test_prefix_caching.py -q`
  - `65 passed` on the GCP L4 validation VM after the Code Assist follow-up
- `python -m pytest tests/lora/test_lora_utils.py tests/lora/test_resolver.py -q`
  - `19 passed` on the GCP L4 validation VM
- `python -m pytest tests/lora/test_lora_prefix_cache_stress.py --optional -q`
  - `1 passed` on the GCP L4 validation VM after the Code Assist follow-up
- `ruff check ...` for the touched scheduler/KV/test files
- `python -m py_compile ...` for the touched scheduler/KV/test files
- `git diff --check`

## Notes

I kept legitimate same-adapter prefix-cache reuse intact. The LoRA test coverage checks both namespace separation across adapters and reuse within the same adapter.

Duplicate-work check: I searched open PRs for `#38606`, `prefix cache LoRA chunked prefill KV block corruption`, and related scheduler/KV lifecycle terms; I found only this PR addressing this change.

AI assistance was used to investigate, implement, and validate this PR. The submitter should review and be able to defend the full diff before requesting final review.