### PR TITLE
[Bugfix] Fix RoutedExpertsCapturer for Gemma 4 MoE (top_k_experts)

### DIFF
--- a/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
@@ -24,6 +24,24 @@ from vllm.platforms import current_platform
 
 logger = logging.getLogger(__name__)
 
+
+def _get_num_experts_per_tok(hf_config) -> int:
+    """Resolve the per-token expert count from the HF config.
+
+    Different model families store this under different attribute names
+    (e.g. ``num_experts_per_tok`` for DeepSeek, ``top_k_experts`` for Gemma 4).
+    """
+    val = getattr(hf_config, "num_experts_per_tok", None)
+    if val is None:
+        val = getattr(hf_config, "top_k_experts", None)
+    if val is None:
+        raise ValueError(
+            "Cannot determine num_experts_per_tok: HF config has neither "
+            "'num_experts_per_tok' nor 'top_k_experts'"
+        )
+    return val
+
+
 # Constants
 _TMP_DIR = tempfile.gettempdir()
 _LOCK_FILE_PREFIX = os.path.join(_TMP_DIR, "vllm_routed_experts")
@@ -127,7 +145,7 @@ class RoutedExpertsCapturer:
 
         hf_config = vllm_config.model_config.hf_text_config
         num_layers = hf_config.num_hidden_layers
-        num_experts_per_tok = hf_config.num_experts_per_tok
+        num_experts_per_tok = _get_num_experts_per_tok(hf_config)
 
         # Initialize device buffer
         self._device_buffer = torch.zeros(
@@ -300,7 +318,7 @@ class RoutedExpertsReader:
         shape = (
             max_num_kv_tokens,
             hf_config.num_hidden_layers,
-            hf_config.num_experts_per_tok,
+            _get_num_experts_per_tok(hf_config),
         )
 
         self.dp_rank = vllm_config.parallel_config.data_parallel_rank


### PR DESCRIPTION
## Summary

`RoutedExpertsCapturer` and `RoutedExpertsReader` hard-code `hf_config.num_experts_per_tok` when sizing the shared-memory capture buffers. Gemma 4 (`Gemma4TextConfig`) stores this value under `top_k_experts` instead, causing an `AttributeError` when `--enable-return-routed-experts` is set.

- Add a `_get_num_experts_per_tok(hf_config)` helper that resolves the attribute with fallback: `num_experts_per_tok` → `top_k_experts`
- Replace the three bare `hf_config.num_experts_per_tok` accesses (two in `RoutedExpertsCapturer.init_buffer`, one in `RoutedExpertsReader.attach_buffer`)

## Context

- Related issue: #39066 (same root cause — Gemma 4 uses `top_k_experts` instead of `num_experts_per_tok`)
- PR #39067 fixes the same attribute mismatch in `moe.py` (model loading path) but does **not** cover `routed_experts_capturer.py`
- Verified locally with `google/gemma-4-26B-A4B-it` + `--enable-return-routed-experts`

## Test plan

- [x] Local verification: started vLLM server with Gemma 4 26B-A4B-it and `--enable-return-routed-experts`, confirmed `routed_experts` returned in API response without `AttributeError`
- [ ] Models using `num_experts_per_tok` (DeepSeek, Qwen MoE, etc.) should be unaffected — the helper checks that attribute first

Made with [Cursor](https://cursor.com)