### PR TITLE
[codex] Guard Qwen-VL fp8_e5m2 default KV scales

### DIFF
--- a/tests/quantization/test_fp8.py
+++ b/tests/quantization/test_fp8.py
@@ -6,6 +6,7 @@ Run `pytest tests/quantization/test_fp8.py --forked`.
 """
 
 import logging
+from types import SimpleNamespace
 
 import pytest
 import regex as re
@@ -19,6 +20,8 @@ from vllm.model_executor.kernels.linear.scaled_mm import (
 )
 from vllm.model_executor.layers.attention.attention import (
     Attention,
+    _is_qwen_vl_model_config,
+    _validate_qwen_vl_fp8_e5m2_kv_cache_scales,
     set_default_quant_scales,
 )
 from vllm.model_executor.layers.fused_moe import FusedMoE
@@ -46,6 +49,154 @@ MODELS = [
         marks=pytest.mark.skip(reason="Checkpoint removed from HF."),
     ),
 ]
+
+
+def _attention_layer_for_kv_cache_scale_validation() -> Attention:
+    layer = object.__new__(Attention)
+    layer.impl = SimpleNamespace(process_weights_after_loading=lambda _dtype: None)
+    layer.quant_config = None
+    layer.layer_name = "language_model.model.layers.0.self_attn.attn"
+    layer._is_qwen_vl_model = True
+    layer.kv_cache_dtype = "fp8_e5m2"
+    layer.calculate_kv_scales = False
+    layer._k_scale = torch.tensor(0.0, dtype=torch.float32)
+    layer._v_scale = torch.tensor(0.0, dtype=torch.float32)
+    layer._q_scale = torch.tensor(0.0, dtype=torch.float32)
+    layer._prob_scale = torch.tensor(0.0, dtype=torch.float32)
+    return layer
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    "model_config",
+    [
+        SimpleNamespace(architecture="Qwen2VLForConditionalGeneration"),
+        SimpleNamespace(architecture="Qwen2_5_VLForConditionalGeneration"),
+        SimpleNamespace(
+            architecture="Qwen2ForCausalLM",
+            hf_config=SimpleNamespace(
+                model_type="qwen2_vl",
+                architectures=["Qwen2ForCausalLM"],
+            ),
+        ),
+        {"model_type": "QWEN2_VL"},
+        SimpleNamespace(
+            architecture="Qwen2ForCausalLM",
+            hf_text_config={"architectures": ["Qwen2_5_VLForConditionalGeneration"]},
+        ),
+        SimpleNamespace(
+            architecture="Qwen2ForCausalLM",
+            model_arch_config=SimpleNamespace(
+                architecture="Qwen2VLForConditionalGeneration"
+            ),
+        ),
+        SimpleNamespace(
+            architecture="Qwen2ForCausalLM",
+            hf_config=SimpleNamespace(
+                model_type="qwen2_5_vl",
+                architectures=["Qwen2ForCausalLM"],
+            ),
+        ),
+    ],
+)
+def test_qwen_vl_model_config_detected_for_kv_cache_guard(model_config):
+    assert _is_qwen_vl_model_config(model_config)
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    "model_config",
+    [
+        None,
+        SimpleNamespace(architecture="Qwen2ForCausalLM"),
+        SimpleNamespace(architecture="Qwen2ForCausalLM", hf_config=None),
+        {"model_type": "qwen2", "text_config": {"model_type": "qwen2"}},
+        SimpleNamespace(
+            architecture="Qwen2ForCausalLM",
+            hf_config=SimpleNamespace(
+                model_type="qwen2",
+                architectures=["Qwen2ForCausalLM"],
+            ),
+        ),
+    ],
+)
+def test_non_qwen_vl_model_config_is_not_qwen_vl_for_kv_cache_guard(
+    model_config,
+):
+    assert not _is_qwen_vl_model_config(model_config)
+
+
+@pytest.mark.skip_global_cleanup
+def test_qwen_vl_rejects_fp8_e5m2_default_kv_cache_scales_after_loading():
+    layer = _attention_layer_for_kv_cache_scale_validation()
+
+    with pytest.raises(ValueError, match="fp8_e5m2.*default KV cache scales"):
+        layer.process_weights_after_loading(torch.float16)
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    (
+        "is_qwen_vl_model",
+        "kv_cache_dtype",
+        "calculate_kv_scales",
+        "k_scale",
+        "v_scale",
+    ),
+    [
+        (False, "fp8_e5m2", False, 1.0, 1.0),
+        (True, "fp8_e4m3", False, 1.0, 1.0),
+        (True, "fp8_e5m2", True, 1.0, 1.0),
+        (True, "fp8_e5m2", False, 0.5, 0.5),
+        (True, "fp8_e5m2", False, torch.tensor(0.5), torch.tensor(0.75)),
+    ],
+)
+def test_qwen_vl_fp8_e5m2_kv_cache_guard_allows_safe_states(
+    is_qwen_vl_model: bool,
+    kv_cache_dtype: str,
+    calculate_kv_scales: bool,
+    k_scale,
+    v_scale,
+):
+    layer = SimpleNamespace(
+        _is_qwen_vl_model=is_qwen_vl_model,
+        kv_cache_dtype=kv_cache_dtype,
+        calculate_kv_scales=calculate_kv_scales,
+        _k_scale_float=k_scale,
+        _v_scale_float=v_scale,
+    )
+
+    _validate_qwen_vl_fp8_e5m2_kv_cache_scales(layer)
+
+
+@pytest.mark.skip_global_cleanup
+@pytest.mark.parametrize(
+    ("k_scale", "v_scale"),
+    [
+        (None, 0.5),
+        (0.5, None),
+        (0.0, 0.5),
+        (-0.5, 0.5),
+        (float("nan"), 0.5),
+        (0.5, float("inf")),
+        (torch.tensor([0.5, 0.75]), 0.5),
+        (True, 0.5),
+    ],
+)
+def test_qwen_vl_fp8_e5m2_kv_cache_guard_rejects_unfinalized_scales(
+    k_scale,
+    v_scale,
+):
+    layer = SimpleNamespace(
+        _is_qwen_vl_model=True,
+        kv_cache_dtype="fp8_e5m2",
+        calculate_kv_scales=False,
+        _k_scale_float=k_scale,
+        _v_scale_float=v_scale,
+    )
+
+    with pytest.raises(ValueError, match="finalized, positive, finite"):
+        _validate_qwen_vl_fp8_e5m2_kv_cache_scales(layer)
 
 
 @pytest.mark.skipif(

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import math
+from collections.abc import Mapping, Sequence
+from numbers import Real
 from typing import TYPE_CHECKING, Any, cast
 
 import torch
@@ -50,6 +53,19 @@ if TYPE_CHECKING:
     from vllm.model_executor.layers.attention import MLAAttention
 
 logger = init_logger(__name__)
+
+_QWEN_VL_FP8_E5M2_UNSAFE_ARCHITECTURES = frozenset(
+    {
+        "Qwen2VLForConditionalGeneration",
+        "Qwen2_5_VLForConditionalGeneration",
+    }
+)
+_QWEN_VL_FP8_E5M2_UNSAFE_MODEL_TYPES = frozenset(
+    {
+        "qwen2_vl",
+        "qwen2_5_vl",
+    }
+)
 
 
 def validate_kv_sharing_target(
@@ -119,6 +135,92 @@ def _largest_kernel_block_within(
         return smallest
     fitting = [b for b in candidates if b * per_token_bytes <= page_budget]
     return max(fitting) if fitting else smallest
+
+
+def _config_value(config: Any, name: str) -> Any:
+    if isinstance(config, Mapping):
+        return config.get(name)
+    return getattr(config, name, None)
+
+
+def _config_architectures(config: Any) -> tuple[str, ...]:
+    architecture = _config_value(config, "architecture")
+    architectures = _config_value(config, "architectures")
+    result = (architecture,) if isinstance(architecture, str) else ()
+    if isinstance(architectures, str):
+        return (*result, architectures)
+    if isinstance(architectures, Sequence):
+        return (*result, *(arch for arch in architectures if isinstance(arch, str)))
+    return result
+
+
+def _is_qwen_vl_model_config(model_config: Any | None) -> bool:
+    """Recognize Qwen-VL across ModelConfig and nested HF config forms."""
+    pending = [model_config]
+    seen: set[int] = set()
+    while pending:
+        config = pending.pop()
+        if config is None or id(config) in seen:
+            continue
+        seen.add(id(config))
+
+        if any(
+            arch in _QWEN_VL_FP8_E5M2_UNSAFE_ARCHITECTURES
+            for arch in _config_architectures(config)
+        ):
+            return True
+
+        model_type = _config_value(config, "model_type")
+        if (
+            isinstance(model_type, str)
+            and model_type.lower() in _QWEN_VL_FP8_E5M2_UNSAFE_MODEL_TYPES
+        ):
+            return True
+
+        # ModelConfig exposes both the outer multimodal HF config and its
+        # inner text config. Dict-backed remote configs use the same names.
+        for name in ("hf_config", "hf_text_config", "model_arch_config", "text_config"):
+            nested = _config_value(config, name)
+            if nested is not None:
+                pending.append(nested)
+
+    return False
+
+
+def _positive_finite_scalar(scale: Any) -> float | None:
+    if isinstance(scale, torch.Tensor):
+        if scale.numel() != 1:
+            return None
+        scale = scale.detach().item()
+    if isinstance(scale, bool) or not isinstance(scale, Real):
+        return None
+    value = float(scale)
+    return value if value > 0.0 and math.isfinite(value) else None
+
+
+def _validate_qwen_vl_fp8_e5m2_kv_cache_scales(layer: nn.Module) -> None:
+    if not getattr(layer, "_is_qwen_vl_model", False):
+        return
+
+    if layer.kv_cache_dtype != "fp8_e5m2" or layer.calculate_kv_scales:
+        return
+
+    k_scale = _positive_finite_scalar(getattr(layer, "_k_scale_float", None))
+    v_scale = _positive_finite_scalar(getattr(layer, "_v_scale_float", None))
+    if k_scale is None or v_scale is None:
+        raise ValueError(
+            'kv_cache_dtype="fp8_e5m2" requires finalized, positive, finite '
+            "per-tensor k_scale and v_scale values for Qwen2-VL and Qwen2.5-VL "
+            "models when calculate_kv_scales=False."
+        )
+    if k_scale == 1.0 and v_scale == 1.0:
+        raise ValueError(
+            'kv_cache_dtype="fp8_e5m2" with default KV cache scales '
+            "(k_scale=v_scale=1.0) is known to produce incorrect outputs "
+            "for Qwen2-VL and Qwen2.5-VL models. Use "
+            'kv_cache_dtype="fp8_e4m3", set calculate_kv_scales=True, '
+            "or provide calibrated k_scale/v_scale values in the checkpoint."
+        )
 
 
 def set_default_quant_scales(layer: nn.Module, register_buffer: bool = False) -> None:
@@ -342,6 +444,7 @@ class Attention(nn.Module, AttentionLayerBase):
 
         # NOTE: model_config may be None during certain tests
         model_config = vllm_config.model_config
+        self._is_qwen_vl_model = _is_qwen_vl_model_config(model_config)
         self.use_mm_prefix = model_config is not None and model_config.is_mm_prefix_lm
 
         # During model initialization, the default dtype is set as the model
@@ -614,6 +717,7 @@ class Attention(nn.Module, AttentionLayerBase):
         )
         if not should_load_quant_weights(quant_method):
             set_default_quant_scales(self, register_buffer=False)
+        _validate_qwen_vl_fp8_e5m2_kv_cache_scales(self)
 
     def get_attn_backend(self) -> type[AttentionBackend]:
         return self.attn_backend


### PR DESCRIPTION
Mitigates one unsafe path reported in #41343 by adding a fail-fast guard.

## What changed

- Adds a post-load attention guard for Qwen2-VL and Qwen2.5-VL when `kv_cache_dtype="fp8_e5m2"` would run with default KV cache scales (`k_scale=v_scale=1.0`) and `calculate_kv_scales=False`.
- Detects Qwen-VL across object- and dict-backed outer/nested HF config forms and architecture names, so the guard still applies when the inner language model presents as `Qwen2ForCausalLM`.
- Requires finalized KV scales to be positive, finite per-tensor scalars before treating a non-default checkpoint scale as calibrated.
- Keeps non-Qwen-VL models, `fp8_e4m3`, runtime scale calculation, and calibrated non-default checkpoint scales on the existing path.
- Adds focused tests for Qwen-VL detection, fail-fast behavior, and safe states.

## Scope

The issue reports silent incorrect output for Qwen-VL models using fp8_e5m2 KV cache with default scales. This PR does not prove output correctness for fp8_e5m2 with default scales and does not load calibrated scale data. It prevents the known unsafe default-scale execution path and leaves the documented safe paths available.

Safe wording for this PR: “Adds a fail-fast guard for known unsafe Qwen-VL fp8_e5m2 default-scale state; does not prove output correctness.”

## Before / after proof

A deterministic attention post-load smoke on `origin/main` (`b4806c8`) constructed a Qwen-VL attention layer with `kv_cache_dtype="fp8_e5m2"`, `calculate_kv_scales=False`, and default scale tensors. The unsafe state proceeded with `k_scale=1.0, v_scale=1.0`.

On this PR branch, the same state fails fast with:

```text
ValueError: kv_cache_dtype="fp8_e5m2" with default KV cache scales (k_scale=v_scale=1.0) is known to produce incorrect outputs for Qwen2-VL and Qwen2.5-VL models. Use kv_cache_dtype="fp8_e4m3", set calculate_kv_scales=True, or provide calibrated k_scale/v_scale values in the checkpoint.
```

## A100 validation update (2026-05-06)

Validated on GCP `a2-highgpu-1g`, 1x NVIDIA A100-SXM4-40GB, driver `580.126.20`, CUDA `13.0`, Ubuntu 24.04, Python `3.12.3`, torch `2.11.0+cu130`, transformers `5.7.0`.

Runtime smoke model: `Qwen/Qwen2-VL-2B-Instruct`, `dtype="float16"`, `enforce_eager=True`, `max_model_len=2048`, `limit_mm_per_prompt={"image": 1}`, uniform gray image prompt.

A100 before/after:

- base `b4806c8ee12d5c5bbfebd6070b389e2f4daad1fd`: `fp8_e5m2`, `calculate_kv_scales=False`, default scales completed instead of failing fast.
- PR head `ec69fb3521ae08c0579457f70d926cdd94372424`: same unsafe case raised during load with the intended guard.
- PR head safe controls completed:
  - `kv_cache_dtype="fp8_e4m3"`, `calculate_kv_scales=False`
  - `kv_cache_dtype="fp8_e5m2"`, `calculate_kv_scales=True`

Original reporter hardware was L40S, so the A100 runtime result validates the guard behavior but is not original-hardware output-correctness validation.

## Current rebase and validation (2026-07-12)

Rebased onto upstream `main` at `27c3e579f0e5f345a86e512e26e1231d3689931f`. The current follow-up broadens config recognition and closes malformed-scale escape paths: missing, non-scalar, non-positive, NaN, and infinite finalized scales now fail instead of bypassing the guard. Non-Qwen-VL models, other KV dtypes, runtime scale calculation, and positive finite calibrated scales retain their existing paths.

## Testing

- `ruff format --check vllm/model_executor/layers/attention/attention.py tests/quantization/test_fp8.py`
- `ruff check vllm/model_executor/layers/attention/attention.py tests/quantization/test_fp8.py`
- `python -m py_compile vllm/model_executor/layers/attention/attention.py tests/quantization/test_fp8.py`
- `pytest -q tests/quantization/test_fp8.py -k "qwen_vl" --confcutdir=tests/quantization` on CPU -> `26 passed, 13 deselected`
- `git diff --check`

The A100 runtime smoke above was performed on the earlier guard head. The current follow-up changes config/scale validation and was exercised by the focused CPU suite; it does not add a new GPU output-correctness claim.

## AI assistance

This change was developed with AI assistance and reviewed locally before submission.