### PR TITLE
[Bugfix][Attention][TurboQuant] Pad head_dim to power-of-2 for WHT

### DIFF
--- a/tests/quantization/test_turboquant.py
+++ b/tests/quantization/test_turboquant.py
@@ -197,6 +197,43 @@ class TestTurboQuantConfig:
         layers = TurboQuantConfig.get_boundary_skip_layers(8, 10)
         assert len(layers) == 8
 
+    # ---- Non-power-of-2 head_dim padding ----
+
+    @pytest.mark.parametrize("head_dim", [64, 128, 256])
+    def test_padded_head_dim_pow2_passthrough(self, head_dim):
+        """Power-of-2 head_dim is unchanged: padded_head_dim == head_dim."""
+        cfg = TurboQuantConfig.from_cache_dtype("turboquant_4bit_nc", head_dim=head_dim)
+        assert cfg.padded_head_dim == head_dim
+        assert cfg.needs_padding is False
+
+    @pytest.mark.parametrize(
+        "head_dim,expected_padded",
+        [(80, 128), (96, 128), (192, 256), (40, 64)],
+    )
+    def test_padded_head_dim_non_pow2(self, head_dim, expected_padded):
+        """Non-power-of-2 head_dim rounds up to the next power of 2."""
+        cfg = TurboQuantConfig.from_cache_dtype("turboquant_4bit_nc", head_dim=head_dim)
+        assert cfg.padded_head_dim == expected_padded
+        assert cfg.needs_padding is True
+
+    def test_mse_key_packed_size_uses_padded(self):
+        """MSE keys live in WHT space, so byte count tracks padded_head_dim."""
+        cfg = TurboQuantConfig.from_cache_dtype("turboquant_4bit_nc", head_dim=80)
+        assert cfg.padded_head_dim == 128
+        # 4-bit MSE: ceil(128 * 4 / 8) + 2 (vec_norm fp16) = 66
+        assert cfg.key_packed_size == 66
+        # 4-bit V on MSE-K path uses padded too: ceil(128 * 4 / 8) + 4 = 68
+        assert cfg.value_packed_size == 68
+
+    def test_fp8_key_packed_size_stays_at_head_dim(self):
+        """FP8 keys are not rotated, so byte count tracks head_dim directly."""
+        cfg = TurboQuantConfig.from_cache_dtype("turboquant_k8v4", head_dim=80)
+        assert cfg.padded_head_dim == 128
+        assert cfg.key_packed_size == 80  # 1 byte per element, no rotation
+        # FP8 K + uniform V: V also stays at head_dim (kernel reads raw)
+        # ceil(80 * 4 / 8) + 4 = 44
+        assert cfg.value_packed_size == 44
+
 
 # ============================================================================
 # Centroids tests (CPU-only)
@@ -398,11 +435,18 @@ class TestRotationMatrix:
 
 
 def _build_hadamard(d: int, device: str = "cpu") -> torch.Tensor:
-    """Reproduce the serving-path Hadamard construction."""
+    """Reproduce the serving-path Hadamard construction.
+
+    For non-power-of-2 d, the Sylvester construction overshoots and
+    produces a matrix at next_power_of_2(d). Normalize by sqrt of the
+    matrix size so the result is orthonormal at that size; the serving
+    path uses padded_head_dim throughout for the same reason.
+    """
+    target = next_power_of_2(d)
     H = torch.tensor([[1.0]])
-    while H.shape[0] < d:
+    while H.shape[0] < target:
         H = torch.cat([torch.cat([H, H], 1), torch.cat([H, -H], 1)], 0)
-    return (H / math.sqrt(d)).to(torch.device(device))
+    return (H / math.sqrt(target)).to(torch.device(device))
 
 
 @pytest.mark.skipif(not GPGPU_AVAILABLE, reason="GPGPU not available")
@@ -544,4 +588,117 @@ class TestStoreDecodeRoundTrip:
             threshold = 0.95 if cfg.key_fp8 else 0.85
             assert cos_sim > threshold, (
                 f"Preset {preset} head {h}: cosine_sim={cos_sim:.4f} < {threshold}"
+            )
+
+    @pytest.mark.parametrize(
+        "preset,head_dim",
+        [
+            ("turboquant_k8v4", 80),
+            ("turboquant_4bit_nc", 80),
+            ("turboquant_k8v4", 96),
+            ("turboquant_4bit_nc", 96),
+        ],
+    )
+    def test_non_pow2_head_dim_roundtrip(self, preset, head_dim):
+        """Store + decode at non-power-of-2 head_dim (Qwen3-4B = 80)."""
+        from vllm.model_executor.layers.quantization.turboquant.centroids import (
+            solve_lloyd_max,
+        )
+        from vllm.v1.attention.ops.triton_turboquant_decode import (
+            triton_turboquant_decode_attention,
+        )
+        from vllm.v1.attention.ops.triton_turboquant_store import (
+            triton_turboquant_store,
+        )
+
+        cfg = TurboQuantConfig.from_cache_dtype(preset, head_dim=head_dim)
+        D = head_dim
+        D_pad = cfg.padded_head_dim
+        assert cfg.needs_padding, f"head_dim={head_dim} should need padding"
+
+        Hk = 4
+        Hq = 4
+        B = 1
+        block_size = 16
+        num_blocks = 1
+
+        device = torch.device(DEVICE_TYPE)
+
+        # Hadamard at padded dim — this is what the serving path does.
+        H = _build_hadamard(D_pad, DEVICE_TYPE)
+        PiT = H
+        Pi = H
+
+        centroids, _ = solve_lloyd_max(D_pad, cfg.centroid_bits)
+        centroids = centroids.float().to(device)
+        c_sorted, _ = centroids.sort()
+        midpoints = ((c_sorted[:-1] + c_sorted[1:]) / 2).to(device)
+
+        torch.manual_seed(123)
+        key = torch.randn(B, Hk, D, device=device, dtype=torch.float16)
+        value = torch.randn(B, Hk, D, device=device, dtype=torch.float16)
+
+        padded_slot = cfg.slot_size_aligned
+        kv_cache = torch.zeros(
+            num_blocks,
+            block_size,
+            Hk,
+            padded_slot,
+            device=device,
+            dtype=torch.uint8,
+        )
+        slot_mapping = torch.tensor([0], device=device, dtype=torch.int32)
+
+        triton_turboquant_store(
+            key,
+            value,
+            kv_cache,
+            slot_mapping,
+            PiT,
+            midpoints,
+            mse_bits=cfg.key_mse_bits,
+            key_packed_size=cfg.key_packed_size,
+            value_quant_bits=cfg.effective_value_quant_bits,
+            key_fp8=cfg.key_fp8,
+            padded_head_dim=cfg.padded_head_dim,
+        )
+
+        query = key.expand(B, Hq, D).contiguous().to(torch.float16)
+        block_table = torch.tensor([[0]], device=device, dtype=torch.int32)
+        seq_lens = torch.tensor([1], device=device, dtype=torch.int32)
+
+        output = triton_turboquant_decode_attention(
+            query=query,
+            kv_cache=kv_cache,
+            block_table=block_table,
+            seq_lens=seq_lens,
+            Pi=Pi,
+            centroids=centroids,
+            scale=1.0 / math.sqrt(D),
+            mse_bits=cfg.key_mse_bits,
+            key_packed_size=cfg.key_packed_size,
+            value_quant_bits=cfg.effective_value_quant_bits,
+            key_fp8=cfg.key_fp8,
+            norm_correction=cfg.norm_correction,
+            PiT=PiT,
+            max_num_kv_splits=4,
+            padded_head_dim=cfg.padded_head_dim,
+        )
+
+        # Output is sliced back to head_dim by the launcher.
+        assert output.shape == (B, Hq, D), (
+            f"Expected output shape {(B, Hq, D)}, got {tuple(output.shape)}"
+        )
+
+        out_fp32 = output.float()
+        val_fp32 = value.expand(B, Hq, D).float()
+        for h in range(Hq):
+            cos_sim = torch.nn.functional.cosine_similarity(
+                out_fp32[0, h].unsqueeze(0),
+                val_fp32[0, h].unsqueeze(0),
+            ).item()
+            threshold = 0.95 if cfg.key_fp8 else 0.85
+            assert cos_sim > threshold, (
+                f"Preset {preset} d={head_dim} head {h}: "
+                f"cosine_sim={cos_sim:.4f} < {threshold}"
             )

--- a/vllm/model_executor/layers/quantization/turboquant/config.py
+++ b/vllm/model_executor/layers/quantization/turboquant/config.py
@@ -5,6 +5,8 @@
 import math
 from dataclasses import dataclass
 
+from vllm.utils.math_utils import next_power_of_2
+
 # Named TQ presets: each maps to frozen config parameters.
 # key_quant_bits: 8 = FP8 keys, 3-4 = MSE (Lloyd-Max) quantized keys.
 # value_quant_bits: 3-4 = uniform quantized values.
@@ -82,6 +84,22 @@ class TurboQuantConfig:
         return self.key_quant_bits == 8
 
     @property
+    def padded_head_dim(self) -> int:
+        """Head dimension used for the WHT rotation.
+
+        Sylvester Hadamard construction requires a power-of-2 dimension.
+        Models with non-power-of-2 head_dim (e.g. Qwen3-4B at 80) are padded
+        to the next power of 2 for the WHT and sliced back at the I/O
+        boundary. Pow-2 head_dims pass through unchanged.
+        """
+        return next_power_of_2(self.head_dim)
+
+    @property
+    def needs_padding(self) -> bool:
+        """Whether head_dim requires zero-padding for the WHT."""
+        return self.padded_head_dim != self.head_dim
+
+    @property
     def mse_bits(self) -> int:
         """MSE quantizer bit-width (determines centroid count: 2^mse_bits).
 
@@ -114,15 +132,19 @@ class TurboQuantConfig:
         """Packed bytes for a single KEY vector.
 
         FP8 mode (key_quant_bits=8):
-          head_dim bytes (1 byte per element, no overhead).
+          head_dim bytes (1 byte per element, no overhead). FP8 keys are not
+          rotated, so storage tracks the model's real head_dim.
 
-        TQ mode:
-          - MSE indices: ceil(head_dim * key_mse_bits / 8) bytes
+        TQ mode (MSE keys with WHT rotation):
+          - MSE indices: ceil(padded_head_dim * key_mse_bits / 8) bytes
           - vec_norm:     2 bytes (float16)
+
+          MSE indices live in WHT space, so the byte count is sized to the
+          padded dimension when head_dim is not a power of 2.
         """
         if self.key_fp8:
-            return self.head_dim  # 1 byte per element
-        mse_bytes = math.ceil(self.head_dim * self.key_mse_bits / 8)
+            return self.head_dim  # 1 byte per element, no rotation
+        mse_bytes = math.ceil(self.padded_head_dim * self.key_mse_bits / 8)
         norm_bytes = 2  # vec_norm fp16
         return mse_bytes + norm_bytes
 
@@ -135,9 +157,17 @@ class TurboQuantConfig:
     def value_packed_size(self) -> int:
         """Packed bytes for a single VALUE vector.
 
-        Uniform quantization: ceil(head_dim * bits / 8) + 4 bytes (scale + zero fp16).
+        Uniform quantization: ceil(D * bits / 8) + 4 bytes (scale + zero fp16).
+
+        On the FP8 K path the kernel operates on raw head_dim (no WHT), so
+        D = head_dim. On the MSE K path the kernel iterates a unified D for
+        both K and V; when head_dim is not a power of 2 the K-side requires
+        padded_head_dim for the WHT, so V is sized to padded_head_dim too
+        (zero-padded at store time, sliced at decode time). Pow-2 head_dims
+        pass through unchanged.
         """
-        data_bytes = math.ceil(self.head_dim * self.value_quant_bits / 8)
+        d = self.head_dim if self.key_fp8 else self.padded_head_dim
+        data_bytes = math.ceil(d * self.value_quant_bits / 8)
         return data_bytes + 4  # +2 scale(fp16) +2 zero(fp16)
 
     @property

--- a/vllm/v1/attention/backends/turboquant_attn.py
+++ b/vllm/v1/attention/backends/turboquant_attn.py
@@ -269,14 +269,17 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
 
         self.tq_config = TurboQuantConfig.from_cache_dtype(kv_cache_dtype, head_size)
 
-        # Pre-compute kernel constants from config (avoid repeated arithmetic)
+        # Pre-compute kernel constants from config (avoid repeated arithmetic).
+        # MSE keys live in WHT space at padded_head_dim (next pow-2). FP8
+        # keys are not rotated, so byte counts use head_size directly.
         cfg = self.tq_config
         self._mse_bytes = (
-            math.ceil(head_size * cfg.key_mse_bits / 8)
+            math.ceil(cfg.padded_head_dim * cfg.key_mse_bits / 8)
             if not cfg.key_fp8
             else head_size
         )
-        self._val_data_bytes = math.ceil(head_size * cfg.effective_value_quant_bits / 8)
+        d_for_v = head_size if cfg.key_fp8 else cfg.padded_head_dim
+        self._val_data_bytes = math.ceil(d_for_v * cfg.effective_value_quant_bits / 8)
         self._n_centroids = cfg.n_centroids if not cfg.key_fp8 else 1
 
         # Detect flash-attn version (FA2/3/4) for prefill paths.
@@ -333,9 +336,13 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
         flips do not improve Lloyd-Max quantization quality because the
         quantizer is symmetric around zero (sign-flipping a coordinate
         maps it to the mirror centroid with identical distortion).
+
+        For non-power-of-2 head_dim (e.g. 80) the WHT, centroid table, and
+        cached PiT live at padded_head_dim. Padding/slicing of K and Q is
+        handled at the kernel-launch boundary in store/decode.
         """
         if not hasattr(layer, "_tq_cached"):
-            D = self.head_size
+            D = self.tq_config.padded_head_dim
 
             # Pure Hadamard: orthonormal + symmetric (H = H^T), enabling
             # in-kernel butterfly fusion and trivial inverse for continuation.
@@ -345,7 +352,7 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
             # fp16 copy for rotation in continuation prefill path
             layer._tq_Pi_half = H.to(torch.float16)
 
-            # Centroids for Lloyd-Max quantization.
+            # Centroids for Lloyd-Max quantization (in padded WHT space).
             layer._tq_centroids = get_centroids(D, self.tq_config.centroid_bits).to(
                 device=device, dtype=torch.float32
             )
@@ -534,6 +541,7 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
             key_packed_size=self.tq_config.key_packed_size,
             value_quant_bits=self.tq_config.effective_value_quant_bits,
             key_fp8=self.tq_config.key_fp8,
+            padded_head_dim=self.tq_config.padded_head_dim,
         )
 
     # ------------------------------------------------------------------ #
@@ -662,6 +670,7 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
                         key_fp8=self.tq_config.key_fp8,
                         norm_correction=self.tq_config.norm_correction,
                         PiT=PiT,
+                        padded_head_dim=self.tq_config.padded_head_dim,
                     )
                 else:
                     # Large continuation: dequant cached K/V and use
@@ -704,7 +713,13 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
         Hk = key_chunk.shape[1]
         device = query.device
         block_size = kv_cache.shape[1]
-        BLOCK_D = triton.next_power_of_2(D)
+        # Cached K/V live at padded_head_dim on the MSE path (zero-padded
+        # at store time). FP8 path stays at head_dim because keys are not
+        # rotated. D_pad == D for pow-2 head_dim regardless.
+        D_pad = (
+            self.tq_config.padded_head_dim if not self.tq_config.key_fp8 else D
+        )
+        BLOCK_D = triton.next_power_of_2(D_pad)
 
         mse_bytes = self._mse_bytes
         val_data_bytes = self._val_data_bytes
@@ -713,7 +728,7 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
         # Allocate slightly over to align to block_size for the grid.
         # Reuse cached buffers to avoid per-call allocation (~16MB at 8K).
         alloc_len = math.ceil(cached_len / block_size) * block_size
-        buf_shape = (1, Hk, alloc_len, D)
+        buf_shape = (1, Hk, alloc_len, D_pad)
         # Use WorkspaceManager for dequant buffers.
         # Shared across all layers — saves 60× memory at long context.
         # Required for CUDA Graph capture (per-layer growth incompatible with CG).
@@ -743,7 +758,7 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
             kv_cache.stride(1),
             kv_cache.stride(2),
             block_table.stride(0),
-            HEAD_DIM=D,
+            HEAD_DIM=D_pad,
             BLOCK_SIZE=block_size,
             NUM_KV_HEADS=Hk,
             MSE_BYTES=mse_bytes,
@@ -762,11 +777,14 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
         if not self.tq_config.key_fp8:
             # fp16 matmul for rotation (2× less bandwidth, uses fp16 tensor cores)
             Pi_half = layer._tq_Pi_half
-            k_flat = k_cached[0, :, :cached_len, :].reshape(-1, D)
+            k_flat = k_cached[0, :, :cached_len, :].reshape(-1, D_pad)
             k_flat = k_flat @ Pi_half
-            k_cached_trim = k_flat.reshape(Hk, cached_len, D).transpose(
+            k_cached_trim = k_flat.reshape(Hk, cached_len, D_pad).transpose(
                 0, 1
-            )  # (cached_len, Hk, D) — already fp16
+            )  # (cached_len, Hk, D_pad) — already fp16
+            # Slice padded dimensions back to head_dim before flash_attn.
+            if D_pad > D:
+                k_cached_trim = k_cached_trim[:, :, :D]
         else:
             k_cached_trim = k_cached[0, :, :cached_len, :].transpose(
                 0, 1
@@ -774,6 +792,8 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
 
         # Skip .contiguous() — the copy into k_full/v_full handles layout
         v_cached_trim = v_cached[0, :, :cached_len, :].transpose(0, 1)
+        if D_pad > D:
+            v_cached_trim = v_cached_trim[:, :, :D]
 
         # Concatenate cached + current chunk K/V (match query dtype)
         # Pre-allocate full K/V buffer, copy into slices (no cat alloc)
@@ -874,5 +894,6 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
             lse_buf=lse_buf,
             buf_holder=layer,
             max_num_kv_splits=self.max_num_kv_splits,
+            padded_head_dim=self.tq_config.padded_head_dim,
         )
         return result

--- a/vllm/v1/attention/backends/turboquant_attn.py
+++ b/vllm/v1/attention/backends/turboquant_attn.py
@@ -860,8 +860,14 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
         # Acquire shared decode scratch buffers from WorkspaceManager.
         # Layers execute sequentially so one set of buffers is sufficient.
         # Falls back to kernel-internal allocation if workspace unavailable.
+        # On the MSE-K path with non-pow-2 head_dim, mid_o and output operate
+        # in WHT space at padded_head_dim; sizing the workspace to head_dim
+        # would fail the buffer-fits checks in the launcher every decode and
+        # trigger a fresh torch.empty() per call. Use padded_head_dim except
+        # on the FP8-K path, which never enters WHT space.
         B = query.shape[0]
         D = self.head_size
+        D_buf = D if self.tq_config.key_fp8 else self.tq_config.padded_head_dim
         S = self.max_num_kv_splits
         Hq = self.num_heads
         mid_o_buf = output_buf = lse_buf = None
@@ -869,8 +875,8 @@ class TurboQuantAttentionImpl(AttentionImpl["TurboQuantMetadata"]):
             # output_buf in query dtype — matches the in-kernel fp16 cast in stage2.
             mid_o_buf, output_buf, lse_buf = (
                 current_workspace_manager().get_simultaneous(
-                    ((B, Hq, S, D + 1), torch.float32),
-                    ((B, Hq, D), query.dtype),
+                    ((B, Hq, S, D_buf + 1), torch.float32),
+                    ((B, Hq, D_buf), query.dtype),
                     ((B, Hq), torch.float32),
                 )
             )

--- a/vllm/v1/attention/ops/triton_turboquant_decode.py
+++ b/vllm/v1/attention/ops/triton_turboquant_decode.py
@@ -503,10 +503,18 @@ def triton_turboquant_decode_attention(
     lse_buf: torch.Tensor | None = None,
     buf_holder: Any = None,
     max_num_kv_splits: int = 32,  # fixed split count (must be constant for cudagraph)
+    padded_head_dim: int = 0,
 ) -> torch.Tensor:
     """Launch fused TQ decode attention (Triton stage1 + stage2).
 
     Returns: output tensor [B, Hq, D] in query's dtype.
+
+    For non-power-of-2 head_dim on the MSE path, the K cache and V cache are
+    stored at padded_head_dim (see triton_turboquant_store). This launcher
+    pads Q for the rotation, runs the kernels at padded width, and slices
+    the output back to head_dim before returning. The FP8 K path is
+    unaffected: keys are stored raw at head_dim and kernels mask non-pow-2
+    loads directly.
     """
     B, Hq, D = query.shape
     Hk = kv_cache.shape[2]
@@ -514,7 +522,10 @@ def triton_turboquant_decode_attention(
     kv_group_size = Hq // Hk
     device = query.device
 
-    cfg = _get_layout(D, mse_bits, value_quant_bits, key_packed_size)
+    # On the MSE path we run kernels in WHT space at padded_head_dim. FP8
+    # path stays at head_dim because keys are not rotated.
+    D_pad = padded_head_dim if (padded_head_dim > D and not key_fp8) else D
+    cfg = _get_layout(D_pad, mse_bits, value_quant_bits, key_packed_size)
 
     # Compute q_rot = q @ Pi.T (rotated query for MSE key scoring)
     # FP8 path: pass query directly (float16); kernel casts inline.
@@ -523,6 +534,8 @@ def triton_turboquant_decode_attention(
         q_rot = query.contiguous()
     else:
         q_float = query.float()
+        if D_pad > D:
+            q_float = torch.nn.functional.pad(q_float, (0, D_pad - D))
         if PiT is None:
             PiT = Pi.T.contiguous()
         q_rot = (q_float @ PiT).contiguous()
@@ -533,14 +546,15 @@ def triton_turboquant_decode_attention(
         mid_o_buf is not None
         and mid_o_buf.shape[0] >= B
         and mid_o_buf.shape[2] >= NUM_KV_SPLITS
+        and mid_o_buf.shape[3] >= D_pad + 1
     ):
-        mid_o = mid_o_buf[:B, :Hq, :NUM_KV_SPLITS, :]
+        mid_o = mid_o_buf[:B, :Hq, :NUM_KV_SPLITS, : D_pad + 1]
     else:
         mid_o = torch.empty(
             B,
             Hq,
             NUM_KV_SPLITS,
-            D + 1,
+            D_pad + 1,
             dtype=torch.float32,
             device=device,
         )
@@ -568,7 +582,7 @@ def triton_turboquant_decode_attention(
         mid_o.stride(1),
         mid_o.stride(2),
         NUM_KV_HEADS=Hk,
-        HEAD_DIM=D,
+        HEAD_DIM=D_pad,
         BLOCK_SIZE=block_size,
         NUM_KV_SPLITS=NUM_KV_SPLITS,
         KV_GROUP_SIZE=kv_group_size,
@@ -588,16 +602,21 @@ def triton_turboquant_decode_attention(
     )
 
     # Stage 2: Reduce across KV splits
-    # Output in query dtype — eliminates float16_copy kernel after stage2
+    # Output in query dtype — eliminates float16_copy kernel after stage2.
+    # On the MSE path with non-pow-2 head_dim we reduce in padded space and
+    # slice to head_dim before returning. The padded V columns hold zeros
+    # by construction (see triton_turboquant_store) so they contribute
+    # nothing to the reduction.
     out_dtype = query.dtype
     if (
         output_buf is not None
         and output_buf.shape[0] >= B
+        and output_buf.shape[2] >= D_pad
         and output_buf.dtype == out_dtype
     ):
-        output = output_buf[:B, :Hq, :D]
+        output = output_buf[:B, :Hq, :D_pad]
     else:
-        output = torch.empty(B, Hq, D, dtype=out_dtype, device=device)
+        output = torch.empty(B, Hq, D_pad, dtype=out_dtype, device=device)
         if buf_holder is not None:
             buf_holder._tq_output_buf = output
     if lse_buf is not None and lse_buf.shape[0] >= B:
@@ -621,10 +640,12 @@ def triton_turboquant_decode_attention(
         lse.stride(0),
         NUM_KV_SPLITS=NUM_KV_SPLITS,
         BLOCK_DV=cfg["BLOCK_D"],
-        Lv=D,
+        Lv=D_pad,
         OUTPUT_FP16=1 if out_dtype == torch.float16 else 0,
         num_warps=4,
         num_stages=2,
     )
 
+    if D_pad > D:
+        return output[:, :, :D].contiguous()
     return output  # already in query dtype

--- a/vllm/v1/attention/ops/triton_turboquant_store.py
+++ b/vllm/v1/attention/ops/triton_turboquant_store.py
@@ -352,34 +352,44 @@ def triton_turboquant_store(
     value: torch.Tensor,  # [N, H, D] — raw values
     kv_cache: torch.Tensor,  # [num_blocks, block_size, Hk, padded_slot] uint8
     slot_mapping: torch.Tensor,  # [N] int32
-    PiT: torch.Tensor,  # [D, D] float32
+    PiT: torch.Tensor,  # [D, D] float32 (D = padded_head_dim on MSE path)
     midpoints: torch.Tensor,  # [n_centroids-1] float32
     mse_bits: int,
     key_packed_size: int,
     value_quant_bits: int,
     key_fp8: bool = False,
+    padded_head_dim: int = 0,
 ):
-    """Launch TQ store kernel (FP8 or MSE path)."""
+    """Launch TQ store kernel (FP8 or MSE path).
+
+    For non-power-of-2 head_dim on the MSE path, K is padded with zeros to
+    padded_head_dim before the WHT. V is zero-padded to the same width so
+    the unified-D fused kernel can iterate K and V together; the unused V
+    bytes carry zero quantization indices and are sliced off at decode.
+    The FP8 K path is unaffected — it reads raw head_dim values directly.
+    """
     N, H, D = key.shape
     NH = N * H
     block_size = kv_cache.shape[1]
-    BLOCK_D = triton.next_power_of_2(D)
-    mse_bytes = math.ceil(D * mse_bits / 8)
+    # WHT requires a power-of-2 dimension. For pow-2 head_dim, D_pad == D
+    # and all paths reduce to the original behavior.
+    D_pad = padded_head_dim if padded_head_dim > D else D
+    BLOCK_D = triton.next_power_of_2(D_pad)
     n_centroids = 2**mse_bits
-
-    val_data_bytes = math.ceil(D * value_quant_bits / 8)
-
-    BLOCK_VAL = triton.next_power_of_2(val_data_bytes)
 
     # Cache strides (element_size=1 for uint8, so stride in bytes = stride())
     stride_block = kv_cache.stride(0)
     stride_pos = kv_cache.stride(1)
     stride_head = kv_cache.stride(2)
 
-    block_grp = triton.next_power_of_2(D // 8) if D >= 8 else 1
-
     # ── FP8 PATH: in-kernel FP8 cast + scatter via fp8 kernel ──
+    # FP8 keys are not rotated, so non-pow-2 head_dim works directly with
+    # masked loads. No padding needed on this path.
     if key_fp8:
+        mse_bytes = math.ceil(D * mse_bits / 8)
+        val_data_bytes = math.ceil(D * value_quant_bits / 8)
+        BLOCK_VAL = triton.next_power_of_2(val_data_bytes)
+        block_grp = triton.next_power_of_2(D // 8) if D >= 8 else 1
         k_flat = key.reshape(NH, D).contiguous()
         v_flat = value.reshape(NH, D).contiguous()
 
@@ -410,13 +420,25 @@ def triton_turboquant_store(
         return
 
     # ── MSE PATH: external GEMM + fused bucketize/pack kernel ──
+    # MSE keys live in WHT space, which requires a power-of-2 dimension.
+    # Pad K to D_pad with zeros before the rotation GEMM; pad V to the
+    # same width so the unified-D fused kernel can iterate.
+    mse_bytes = math.ceil(D_pad * mse_bits / 8)
+    val_data_bytes = math.ceil(D_pad * value_quant_bits / 8)
+    BLOCK_VAL = triton.next_power_of_2(val_data_bytes)
+    block_grp = triton.next_power_of_2(D_pad // 8) if D_pad >= 8 else 1
+
     # Normalize + rotation GEMM externally (cuBLAS is faster than in-kernel)
     k_flat = key.float().reshape(NH, D)
     norms = k_flat.norm(dim=1, keepdim=True)
     x_hat = k_flat / (norms + 1e-8)
-    y = x_hat @ PiT
+    if D_pad > D:
+        x_hat = torch.nn.functional.pad(x_hat, (0, D_pad - D))
+    y = x_hat @ PiT  # [NH, D_pad]
 
     v_flat = value.float().reshape(NH, D)
+    if D_pad > D:
+        v_flat = torch.nn.functional.pad(v_flat, (0, D_pad - D))
 
     # Fused kernel: bucketize + MSE index pack + norm store + value pack
     grid = (NH,)
@@ -430,7 +452,7 @@ def triton_turboquant_store(
         stride_cache_block=stride_block,
         stride_cache_pos=stride_pos,
         stride_cache_head=stride_head,
-        D=D,
+        D=D_pad,
         H=H,
         BLOCK_SIZE=block_size,
         BLOCK_D=BLOCK_D,


### PR DESCRIPTION
## Purpose

Fix a latent correctness bug in the TurboQuant rotation path for models with non-power-of-2 `head_dim`. Reproduced on `microsoft/phi-2` (`head_dim=80`) with `turboquant_4bit_nc`:

```
File "vllm/v1/attention/backends/turboquant_attn.py", line 380, in do_kv_cache_update
    y = x_hat @ PiT
RuntimeError: mat1 and mat2 shapes cannot be multiplied (16384x80 and 128x128)
```

## Root cause

`_build_hadamard_cached(d)` constructs the Sylvester Hadamard by doubling `H` until `H.shape[0] >= d`, then normalizes by `sqrt(d)`:

```python
H = torch.tensor([[1.0]])
while H.shape[0] < d:
    H = torch.cat([torch.cat([H, H], 1), torch.cat([H, -H], 1)], 0)
return (H / math.sqrt(d)).to(...)
```

For `d=80` the loop overshoots to 128×128 and the result is normalized by `1/sqrt(80)` — the matrix is the wrong size *and* not orthonormal at the constructed size. `_ensure_on_device` stores this 128×128 tensor as `layer._tq_PiT`; the MSE-K decode/store kernels then attempt `q @ PiT` with `q` at width 80 and `PiT` at 128×128.

The bug is path-specific:
- **MSE-K presets** (`turboquant_4bit_nc`, `turboquant_3bit_nc`, `turboquant_k3v4_nc`) call the rotation GEMM and crash at engine init.
- **FP8-K** (`turboquant_k8v4`) bypasses the WHT entirely (in-kernel FP8 cast, no rotation), so the broken matrix is built but never multiplied — the model loads but wastes VRAM on the unused buffer.

## Summary of changes

- Add `padded_head_dim = next_power_of_2(head_dim)` and `needs_padding` to `TurboQuantConfig`. Pow-2 `head_dim` is identity.
- On the MSE-K path, run the WHT in `padded_head_dim` space throughout: zero-pad K and V at the kernel-launch boundary, run store/decode/continuation kernels with `D=padded_head_dim`, and slice the decode output back to `head_dim` before returning. Padded V columns hold zero quantization indices and contribute nothing to the reduction.
- FP8-K path is untouched (raw `head_dim`, no rotation, kernel masks non-pow-2 loads directly).
- For pow-2 `head_dim` (the common case: 64, 128, 256 — every current Qwen3, Llama, Mistral target), `padded_head_dim == head_dim` and every code path reduces to the prior behavior. Byte-counts in `key_packed_size` / `value_packed_size` are bitwise-identical.

## Duplicate-work check

Searched open PRs and issues touching TurboQuant + `head_dim` / Hadamard / Phi-2 / non-power-of-2 before opening this PR. The closest references are:

- Tracking issue #40069 (TurboQuant follow-ups) — does not list `head_dim` padding.
- PR #39890 (erhan1209) adds new "official" 3-bit/4-bit grouped TQ presets but does not change `_build_hadamard_cached` or address non-pow-2 dim.
- PR #40792 (hoseung2) optimizes k8v4 decode with GQA head grouping — orthogonal kernel optimization, unaffected by this fix.

No open PR addresses the rotation-shape mismatch on non-pow-2 `head_dim`. Issue #41413 was filed alongside this PR.

## Test Plan / Results

Tested on AMD MI300X (`gfx942`), ROCm 7.2, vLLM ROCm 7.2.1 wheels.

**Bug reproduction (Phi-2 `d=80` + `turboquant_4bit_nc`):**

Command (control + treatment):
```bash
python3 -c "
import os; os.environ['VLLM_ROCM_USE_AITER_FP4BMM']='0'
from vllm import LLM, SamplingParams
llm = LLM(model='microsoft/phi-2', dtype='bfloat16',
          kv_cache_dtype='turboquant_4bit_nc', max_model_len=2048,
          gpu_memory_utilization=0.40)
print(llm.generate(['The capital of France is'],
                   SamplingParams(max_tokens=32, temperature=0.0))[0].outputs[0].text)
"
```

| Branch | Result |
|---|---|
| upstream main `c2fb01331` | `RuntimeError: mat1 and mat2 shapes cannot be multiplied (16384x80 and 128x128)` |
| this PR | ` Paris.` ✓ |

**No regression — Qwen3-8B (`d=128`) 3-chunk PPL on `wikitext-2-raw/wiki.test.raw` @ 8K:**

Command:
```bash
python3 -c "
import os, math
os.environ['VLLM_ROCM_USE_AITER_FP4BMM']='0'
from vllm import LLM, SamplingParams
llm = LLM(model='Qwen/Qwen3-8B', dtype='bfloat16', max_model_len=8192,
          kv_cache_dtype='<preset>', gpu_memory_utilization=0.40,
          enable_prefix_caching=False, max_num_batched_tokens=512)
tok = llm.get_tokenizer()
ids = tok.encode(open('wiki.test.raw').read(), add_special_tokens=False)
chunks = [ids[i:i+8191] for i in range(0, len(ids)-8191, 8191)][:3]
total_lp, total_tok = 0.0, 0
sp = SamplingParams(max_tokens=1, temperature=0.0, prompt_logprobs=1)
for ch in chunks:
    o = llm.generate({'prompt_token_ids': ch}, sp, use_tqdm=False)[0]
    for i, lp_dict in enumerate(o.prompt_logprobs[1:]):
        if lp_dict and ch[i+1] in lp_dict:
            total_lp += lp_dict[ch[i+1]].logprob
            total_tok += 1
print(math.exp(-total_lp/total_tok))
"
```

| Preset | upstream main | this PR | Δ |
|---|---|---|---|
| `turboquant_k8v4` | 7.8630 | 7.8630 | 0 |
| `turboquant_4bit_nc` | 7.9041 | 7.9041 | 0 |

Both PPLs are byte-identical, same token count (24570).

**Unit tests on this PR:**
```bash
python3 -m pytest tests/quantization/test_turboquant.py -v
```
→ **130/130 passed** in 28.34s.

Includes 14 new tests for the non-pow-2 `head_dim` path:
- `padded_head_dim` is identity for pow-2 `head_dim` (64, 128, 256)
- non-pow-2 `head_dim` rounds up correctly (80→128, 96→128, 192→256, 40→64)
- MSE preset at `head_dim=80`: `key_packed_size=66`, `value_packed_size=68` (sized to padded 128)
- FP8 preset at `head_dim=80`: `key_packed_size=80`, `value_packed_size=44` (head_dim-sized, FP8 path)
- Store + decode round-trip across `{turboquant_k8v4, turboquant_4bit_nc} × {80, 96}`: cosine similarity vs the stored V passes the same thresholds as the pow-2 case (>0.95 FP8, >0.85 MSE) and the returned tensor is sliced back to `head_dim`

## AI assistance

This PR was prepared with AI assistance (Anthropic Claude). Each line of the diff was reviewed by the human submitter, the bug reproduction was run on the human's hardware (AMD MI300X dev cloud), and the no-regression PPL numbers are from runs the human supervised. Commits carry a `Co-authored-by: Claude` trailer per AGENTS.md.

Fixes #41413.

cc @vibhavagarwal5
