### PR TITLE
[Bugfix] Handle NaN in QuantFP8 Native Forward

### DIFF
--- a/tests/kernels/quantization/test_fp8_quant.py
+++ b/tests/kernels/quantization/test_fp8_quant.py
@@ -11,7 +11,10 @@ from tests.kernels.quant_utils import (
     ref_dynamic_per_token_quant,
 )
 from tests.kernels.utils import opcheck
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    GroupShape,
     scaled_quantize,
 )
 from vllm.platforms import current_platform
@@ -219,3 +222,46 @@ def test_static_fp8_quant_1d_scale(
     torch.testing.assert_close(ref_out.float(), ops_out.float(), rtol=0.12, atol=0.0)
 
     opcheck_fp8_quant(ops_out, x, scale=scale_1d, group_shape=group_shape)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("group_shape_name", ["PER_TOKEN", "PER_TENSOR"])
+@torch.inference_mode()
+def test_fp8_quant_nan_handling(
+    dtype: torch.dtype,
+    group_shape_name: str,
+) -> None:
+    """Test that forward_native handles NaN inputs identically to forward_cuda;
+    since the CUDA kernel treats NaN as 0 and produces valid scales and quantized
+    outputs, we need to do the same in forward_native.
+    """
+    num_tokens = 32
+    hidden_size = 1024
+    group_shape_name = getattr(GroupShape, group_shape_name)
+
+    with set_current_vllm_config(VllmConfig()):
+        quant = QuantFP8(
+            static=False,
+            group_shape=group_shape_name,
+        )
+
+    x = torch.randn(num_tokens, hidden_size, dtype=dtype, device="cuda")
+
+    # Inject NaNs & run forward for both cuda and native
+    x[:, : hidden_size // 2] = float("nan")
+
+    out_cuda, scale_cuda = quant.forward_cuda(x)
+    out_native, scale_native = quant.forward_native(x)
+
+    # Neither path should produce NaN in scales or outputs
+    assert not torch.isnan(scale_cuda).any(), "CUDA scales contain NaN"
+    assert not torch.isnan(scale_native).any(), "Native scales contain NaN"
+    assert not torch.isnan(out_cuda.float()).any(), "CUDA output contains NaN"
+    assert not torch.isnan(out_native.float()).any(), "Native output contains NaN"
+
+    # Scales should match between CUDA and native
+    torch.testing.assert_close(scale_native, scale_cuda)
+
+    # Quantized outputs should match at non-NaN input positions.
+    valid = ~torch.isnan(x)
+    torch.testing.assert_close(out_native.float()[valid], out_cuda.float()[valid])

--- a/vllm/model_executor/layers/quantization/input_quant_fp8.py
+++ b/vllm/model_executor/layers/quantization/input_quant_fp8.py
@@ -194,14 +194,18 @@ class QuantFP8(CustomOp):
             and scale_ub.numel() == 1
         )
 
+        # Replace NaN with 0 to match the CUDA kernel's behavior, since the underlying
+        # CUDA kernels use fmaxf, which won't propagate NaNs if we have numeric values.
+        x_f = torch.nan_to_num(x.to(torch.float32), nan=0.0)
+
         if scale is None:
             if self.group_shape == GroupShape.PER_TOKEN:
-                x_max, _ = x.abs().max(dim=-1)
-                x_max = x_max.unsqueeze(-1).to(torch.float32)
+                x_max, _ = x_f.abs().max(dim=-1)
+                x_max = x_max.unsqueeze(-1)
                 if scale_ub is not None:
                     x_max = x_max.clamp(max=scale_ub)
             else:
-                x_max = x.abs().max().unsqueeze(-1).to(torch.float32)
+                x_max = x_f.abs().max().unsqueeze(-1)
 
             scale = (x_max / _FP8_MAX).clamp(min=_FP8_MIN_SCALING_FACTOR)
         else:
@@ -209,10 +213,7 @@ class QuantFP8(CustomOp):
 
         # Even for dynamic per-token scales,
         # reciprocal performs slightly better than division
-        out = (
-            x.to(torch.float32)
-            * group_broadcast(scale.to(torch.float32), x.shape[-2:]).reciprocal()
-        )
+        out = x_f * group_broadcast(scale.to(torch.float32), x.shape[-2:]).reciprocal()
         out = out.clamp(_FP8_MIN, _FP8_MAX).to(_FP8_DTYPE)
 
         # This currently generates an extra Triton kernel in compilation.


### PR DESCRIPTION
## Purpose
Encountered while investigating this issue in Granite Speech: https://github.com/vllm-project/vllm/issues/41284
Also related fix for the source of the NaNs: https://github.com/vllm-project/vllm/pull/41424

While digging into the the cause for FP8 outputs turning into garbage for `0.17` and `0.20`, I eventually found that the cause was due to bias values being corrupted, which was causing a bunch of NaNs. It looks like the reason this didn't become a problem until recently is that the native forward doesn't handle NaNs, but the underlying CUDA kernels do, because they use `fmaxf` etc, which implicitly handle NaNs.

This PR adds handling for NaNs to the native forward implementation and a check to ensure that it lines up with the CUDA forward.

## Test Plan
Also gives normal outputs with the broken example here https://github.com/vllm-project/vllm/pull/41424, although the other PR is the correct fix for the root cause of the NaNs, while this one is to align the behaviors between the forward implementations.

## Test Result
Test fails on main with `Native scales contain NaN` and passes on this branch.

@DarkLight1337 @robertgshaw2-redhat Could you PTAL?