### PR TITLE
Revert "Fix Cohere ASR after HF upgrade" (#40582)

### DIFF
--- a/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
+++ b/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
@@ -167,8 +167,9 @@ def run_evaluation(
     "model_config",
     [
         ("openai/whisper-large-v3", 12.744980),
+        # TODO (ekagra): turn on after asr release
         # CohereASR is used to test the variable encoder length code paths
-        ("CohereLabs/cohere-transcribe-03-2026", 11.92),
+        # ("CohereLabs/cohere-transcribe-03-2026", 11.92),
     ],
 )
 # Original dataset is 20GB+ in size, hence we use a pre-filtered slice.

--- a/tests/models/multimodal/processing/test_common.py
+++ b/tests/models/multimodal/processing/test_common.py
@@ -311,9 +311,6 @@ def _test_processing_correctness(
             baseline_processor,
             cached_processor,
             batch_idx,
-            hit_rate,
-            num_batches,
-            simplify_rate,
         )
 
 
@@ -323,9 +320,6 @@ def _test_processing_correctness_one(
     baseline_processor: BaseMultiModalProcessor,
     cached_processor: BaseMultiModalProcessor,
     batch_idx: int,
-    hit_rate: float,
-    num_batches: int,
-    simplify_rate: float,
 ):
     model_type = model_config.hf_config.model_type
 
@@ -349,11 +343,7 @@ def _test_processing_correctness_one(
         baseline_tokenized_result,
         cached_tokenized_result,
         ignore_mm_keys=ignore_mm_keys,
-        msg=(
-            f"Failed ({batch_idx=}, {hit_rate=}, "
-            f"{num_batches=}, {simplify_rate=}, "
-            f"{text_prompt=}, {token_prompt=}, {mm_data=})"
-        ),
+        msg=f"Failed ({batch_idx=}, {token_prompt=}, {mm_data=})",
     )
 
     if text_prompt is not None:
@@ -372,33 +362,21 @@ def _test_processing_correctness_one(
             baseline_text_result,
             cached_text_result,
             ignore_mm_keys=ignore_mm_keys,
-            msg=(
-                f"Failed ({batch_idx=}, {hit_rate=}, "
-                f"{num_batches=}, {simplify_rate=}, "
-                f"{text_prompt=}, {token_prompt=}, {mm_data=})"
-            ),
+            msg=f"Failed ({batch_idx=}, {text_prompt=}, {mm_data=})",
         )
 
         _assert_inputs_equal(
             baseline_text_result,
             baseline_tokenized_result,
             ignore_mm_keys=ignore_mm_keys,
-            msg=(
-                f"Failed ({batch_idx=}, {hit_rate=}, "
-                f"{num_batches=}, {simplify_rate=}, "
-                f"{text_prompt=}, {token_prompt=}, {mm_data=})"
-            ),
+            msg=f"Failed ({batch_idx=}, {text_prompt=}, {token_prompt=}, {mm_data=})",
         )
 
         _assert_inputs_equal(
             cached_text_result,
             cached_tokenized_result,
             ignore_mm_keys=ignore_mm_keys,
-            msg=(
-                f"Failed ({batch_idx=}, {hit_rate=}, "
-                f"{num_batches=}, {simplify_rate=}, "
-                f"{text_prompt=}, {token_prompt=}, {mm_data=})"
-            ),
+            msg=f"Failed ({batch_idx=}, {text_prompt=}, {token_prompt=}, {mm_data=})",
         )
 
 
@@ -430,8 +408,6 @@ def test_processing_correctness(
             "correctness test as is. Let's revisit adapting this "
             "test once more realtime models exist."
         )
-    if model_id == "CohereLabs/cohere-transcribe-03-2026":
-        pytest.skip("Fix later")
 
     _test_processing_correctness(
         model_id,

--- a/tests/models/registry.py
+++ b/tests/models/registry.py
@@ -1396,7 +1396,9 @@ _MULTIMODAL_EXAMPLE_MODELS = {
     ),
     # [Encoder-decoder]
     "CohereAsrForConditionalGeneration": _HfExamplesInfo(
-        "CohereLabs/cohere-transcribe-03-2026", trust_remote_code=True
+        "CohereLabs/cohere-transcribe-03-2026",
+        trust_remote_code=True,
+        is_available_online=False,  # TODO (ekagra): revert after asr release
     ),
     "NemotronParseForConditionalGeneration": _HfExamplesInfo(
         "nvidia/NVIDIA-Nemotron-Parse-v1.1", trust_remote_code=True

--- a/vllm/model_executor/models/cohere_asr.py
+++ b/vllm/model_executor/models/cohere_asr.py
@@ -3,7 +3,6 @@
 
 import math
 from collections.abc import Iterable, Mapping, Sequence
-from typing import Any, ClassVar
 
 import torch
 import torch.nn.functional as F
@@ -15,7 +14,7 @@ from vllm.config import CacheConfig, ModelConfig, SpeechToTextConfig, VllmConfig
 from vllm.config.multimodal import BaseDummyOptions
 from vllm.config.speech_to_text import SpeechToTextParams
 from vllm.distributed import get_tensor_model_parallel_world_size
-from vllm.inputs import MultiModalDataDict, PromptType, TokensPrompt
+from vllm.inputs import MultiModalDataDict, PromptType, TextPrompt
 from vllm.logger import init_logger
 from vllm.model_executor.layers.activation import get_act_fn
 from vllm.model_executor.layers.attention import (
@@ -49,7 +48,6 @@ from vllm.multimodal.processing import (
     PromptUpdate,
 )
 from vllm.renderers import TokenizeParams
-from vllm.tokenizers import cached_tokenizer_from_config
 from vllm.transformers_utils.processors.cohere_asr import (
     INF_VAL,
     CohereASRFeatureExtractor,
@@ -2010,9 +2008,6 @@ class CohereAsrForConditionalGeneration(
     supported_languages = ISO639_1_SUPPORTED_LANGS
     skip_warmup_audio_preprocessing = True
     no_space_languages = {"ja", "zh"}
-    _default_prompt_token_ids_cache: ClassVar[
-        dict[tuple[str | None, str | None, str], tuple[int, ...]]
-    ] = {}
 
     @classmethod
     def validate_language(cls, language: str | None) -> str | None:
@@ -2030,80 +2025,29 @@ class CohereAsrForConditionalGeneration(
         audio = stt_params.audio
         stt_config = stt_params.stt_config
         language = stt_params.language
-        model_config = stt_params.model_config
+        request_prompt = stt_params.request_prompt
 
         if language is None:
             raise ValueError(
                 "Language must be specified when creating the CohereASR prompt"
             )
 
-        tokenizer = cached_tokenizer_from_config(model_config)
-
-        # prompt_text is None because CoherASR uses fast implementation of
-        # sentencepiece tokenizer which needs "▁" as the first token
-        # (which is different from "_") and encode("▁ABC") ignores the first token
-        # so the prompt_text is unreliable. However, prompt_token_ids can be used
-        # to get prompt_text but it wont have the first token "▁".
-        prompt_text = None
-        prompt_token_ids = cls._get_default_prompt_token_ids(
-            tokenizer,
-            model_config,
-            language,
+        # NOTE: this function is used only by online inference and not offline inference
+        # CohereASR doesnt have encoder prompt
+        language_tag = f"<|{language}|><|{language}|>"
+        pnc = True  # TODO(ekagra): make this configurable later
+        pnc_tag = "<|pnc|>" if pnc else "<|nopnc|>"
+        default_prompt = (
+            f"<|startofcontext|><|startoftranscript|>"
+            f"<|emo:undefined|>{language_tag}{pnc_tag}"
+            f"<|noitn|><|notimestamp|><|nodiarize|>"
         )
+        prompt_text = request_prompt if request_prompt else default_prompt
 
-        return TokensPrompt(
+        return TextPrompt(
             prompt=prompt_text,
-            prompt_token_ids=prompt_token_ids,
             multi_modal_data={"audio": (audio, stt_config.sample_rate)},
         )
-
-    @classmethod
-    def _get_default_prompt_tokens(cls, language: str) -> tuple[str, ...]:
-        # Use token-level control tags so fast tokenizers do not have to parse
-        # the raw string form of the decoder prefix.
-        return (
-            "▁",
-            "<|startofcontext|>",
-            "<|startoftranscript|>",
-            "<|emo:undefined|>",
-            f"<|{language}|>",
-            f"<|{language}|>",
-            "<|pnc|>",
-            "<|noitn|>",
-            "<|notimestamp|>",
-            "<|nodiarize|>",
-        )
-
-    @classmethod
-    def _get_default_prompt_token_ids(
-        cls,
-        tokenizer: Any,
-        model_config: ModelConfig,
-        language: str,
-    ) -> list[int]:
-        cache_key = (
-            getattr(model_config, "tokenizer", None),
-            getattr(model_config, "tokenizer_revision", None),
-            language,
-        )
-        prompt_token_ids = cls._default_prompt_token_ids_cache.get(cache_key)
-        if prompt_token_ids is None:
-            prompt_tokens = list(cls._get_default_prompt_tokens(language))
-            token_ids = tokenizer.convert_tokens_to_ids(prompt_tokens)
-            if not isinstance(token_ids, list):
-                token_ids = [token_ids]
-            unk_token_id = getattr(tokenizer, "unk_token_id", None)
-            if unk_token_id is not None and any(
-                token_id == unk_token_id for token_id in token_ids
-            ):
-                raise ValueError(
-                    "Failed to resolve the CohereASR decoder control tokens "
-                    "with the configured tokenizer."
-                )
-            prompt_token_ids = tuple(int(token_id) for token_id in token_ids)
-            cls._default_prompt_token_ids_cache[cache_key] = prompt_token_ids
-
-        return list(prompt_token_ids)
 
     @classmethod
     def get_placeholder_str(cls, modality: str, i: int) -> str | None:

--- a/vllm/transformers_utils/model_arch_config_convertor.py
+++ b/vllm/transformers_utils/model_arch_config_convertor.py
@@ -351,9 +351,6 @@ class CohereAsrModelArchConfigConvertor(ModelArchConfigConvertorBase):
         )
         return enc_num_kv_heads
 
-    def is_mm_prefix_lm(self) -> bool:
-        return False
-
 
 class MambaModelArchConfigConvertor(ModelArchConfigConvertorBase):
     def get_head_size(self) -> int:


### PR DESCRIPTION
## Revert of #40582

This reverts the merge commit a04e0cf3b8cd7bf6b643eacab15033025f462166.

**Reason:** CI failure in nightly build [#63914](https://buildkite.com/vllm/ci/builds/63914).

The `OpenAI API Correctness` test failed with a `RuntimeError: NVML_SUCCESS == r INTERNAL ASSERT FAILED` crash in `cohere_asr.py` during the CohereASR transcription test (`model_config1`). The error occurs in `cohere_asr.py:491` -> `conv.forward` -> `torch.nn.modules.conv.py` -> CUDA caching allocator assertion failure.

**Linked failures (1):**
- OpenAI API Correctness

---
*Auto-generated by CI failure analyzer. Build [#63914](https://buildkite.com/vllm/ci/builds/63914), commit efb4cdf.*