### PR TITLE
Revert "[MoE] Make MoERunnerInterface a PluggableLayer for OOT support" (#35178)

### DIFF
--- a/docs/mkdocs/hooks/generate_argparse.py
+++ b/docs/mkdocs/hooks/generate_argparse.py
@@ -38,20 +38,8 @@ class MockCustomOp:
         return decorator
 
 
-class MockPluggableLayer:
-    @staticmethod
-    def register(name):
-        def decorator(cls):
-            return cls
-
-        return decorator
-
-
 mock_if_no_torch("vllm._C", MagicMock())
-mock_if_no_torch(
-    "vllm.model_executor.custom_op",
-    MagicMock(CustomOp=MockCustomOp, PluggableLayer=MockPluggableLayer),
-)
+mock_if_no_torch("vllm.model_executor.custom_op", MagicMock(CustomOp=MockCustomOp))
 mock_if_no_torch(
     "vllm.utils.torch_utils", MagicMock(direct_register_custom_op=lambda *a, **k: None)
 )

--- a/vllm/model_executor/layers/fused_moe/layer.py
+++ b/vllm/model_executor/layers/fused_moe/layer.py
@@ -1487,19 +1487,15 @@ class FusedMoE(PluggableLayer):
             "w2_input_scale",
         }
 
-        # Parameters of non-expert submodules that live inside runner (MoERunner).
-        # These must be excluded from EPLB weight rearrangement.
-        NON_EXPERT_PREFIXES = (
-            "runner._shared_experts.",
-            "runner.gate.",
-            "runner.routed_input_transform.",
-            "runner.routed_output_transform.",
-        )
-
         assert all(
             weight.is_contiguous()
             for name, weight in weights
-            if not name.startswith(NON_EXPERT_PREFIXES)
+            if not (
+                name.startswith("_shared_experts.")
+                or name.startswith("_gate.")
+                or name.startswith("_routed_input_transform.")
+                or name.startswith("_routed_output_transform.")
+            )
             and name not in NON_EXPERT_WEIGHTS
         )
 
@@ -1508,7 +1504,12 @@ class FusedMoE(PluggableLayer):
             for name, weight in weights
             if name not in NON_EXPERT_WEIGHTS
             and weight.shape != torch.Size([])
-            and not name.startswith(NON_EXPERT_PREFIXES)
+            and not name.startswith("_shared_experts.")
+            # exclude parameters from non-expert submodules,
+            # e.g. gate/shared/transforms.
+            and not name.startswith("_gate.")
+            and not name.startswith("_routed_input_transform.")
+            and not name.startswith("_routed_output_transform.")
         ]
 
     def set_eplb_state(

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner.py
@@ -220,7 +220,7 @@ class MoERunner(MoERunnerInterface):
         self.routed_output_transform = routed_output_transform
         self.routed_scaling_factor = routed_scaling_factor
         self.gate = gate
-        self._quant_method = quant_method
+        self.quant_method = quant_method
         self.enable_dbo = enable_dbo
 
         self._shared_experts: SharedExperts | None = None
@@ -263,7 +263,7 @@ class MoERunner(MoERunnerInterface):
     def _replace_quant_method(self, quant_method: FusedMoEMethodBase):
         if self._shared_experts is not None:
             self._shared_experts._quant_method = quant_method
-        self._quant_method = quant_method
+        self.quant_method = quant_method
 
     def is_internal_router(self) -> bool:
         return self.gate is not None
@@ -330,8 +330,8 @@ class MoERunner(MoERunnerInterface):
     @property
     def _fused_output_is_reduced(self) -> bool:
         return (
-            self._quant_method.moe_kernel is not None
-            and self._quant_method.moe_kernel.output_is_reduced()
+            self.quant_method.moe_kernel is not None
+            and self.quant_method.moe_kernel.output_is_reduced()
         )
 
     def _maybe_reduce_shared_expert_output(
@@ -407,7 +407,7 @@ class MoERunner(MoERunnerInterface):
         )
         transformed_hidden_dim = hidden_states.shape[-1]
         if (
-            not self._quant_method.skip_forward_padding
+            not self.quant_method.skip_forward_padding
             and self.moe_config.hidden_dim != transformed_hidden_dim
         ):
             hidden_states = F.pad(
@@ -451,8 +451,8 @@ class MoERunner(MoERunnerInterface):
             shared_experts_input, SharedExpertsOrder.NO_OVERLAP
         )
 
-        if self._quant_method.is_monolithic:
-            fused_out = self._quant_method.apply_monolithic(
+        if self.quant_method.is_monolithic:
+            fused_out = self.quant_method.apply_monolithic(
                 layer=layer,
                 x=hidden_states,
                 router_logits=router_logits,
@@ -467,7 +467,7 @@ class MoERunner(MoERunnerInterface):
 
             # Passing shared_experts_input in case SharedExpertsOrder is
             # MK_INTERNAL_OVERLAPPED.
-            fused_out = self._quant_method.apply(
+            fused_out = self.quant_method.apply(
                 layer=layer,
                 x=hidden_states,
                 topk_weights=topk_weights,
@@ -618,7 +618,7 @@ class MoERunner(MoERunnerInterface):
     @property
     def do_naive_dispatch_combine(self) -> bool:
         return (
-            self.moe_config.dp_size > 1 and not self._quant_method.supports_internal_mk
+            self.moe_config.dp_size > 1 and not self.quant_method.supports_internal_mk
         )
 
     def _maybe_dispatch(

--- a/vllm/model_executor/layers/fused_moe/runner/moe_runner_interface.py
+++ b/vllm/model_executor/layers/fused_moe/runner/moe_runner_interface.py
@@ -4,7 +4,6 @@ from abc import ABC, abstractmethod
 
 import torch
 
-from vllm.model_executor.custom_op import PluggableLayer
 from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
     FusedMoEMethodBase,
 )
@@ -13,7 +12,7 @@ from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
 )
 
 
-class MoERunnerInterface(PluggableLayer, ABC):
+class MoERunnerInterface(ABC):
     """
     Abstract base class for Mixture of Experts (MoE) runners.
 


### PR DESCRIPTION
## Revert of #35178

This reverts the merge commit b55b26520c088eeed791cbe4648c73ea015f3613.

**Reason:** CI failures in nightly build [#63914](https://buildkite.com/vllm/ci/builds/63914).

Two tests failed after this PR was merged, both involving MoE models:

1. **Distributed Tests (2 GPUs)(H100):** `test_dbo_dp_ep_gsm8k[deepep_high_throughput]` failed with accuracy 0.594 < 0.620 threshold. The PR changed `fused_moe/layer.py` and MoE runner files which are in the code path for DBO+DP+EP with MoE models.

2. **Quantization:** `test_cpu_offload_compressed_tensors` failed with seeded sampling mismatch for `nm-testing/Qwen1.5-MoE-A2.7B-Chat-quantized.w4a16` model when using `--cpu-offload-gb 1`. Different text generated vs reference, indicating MoE layer changes affected quantized MoE model behavior during CPU offloading.

**Linked failures (2):**
- Distributed Tests (2 GPUs)(H100)
- Quantization

---
*Auto-generated by CI failure analyzer. Build [#63914](https://buildkite.com/vllm/ci/builds/63914), commit efb4cdf.*