### PR TITLE
[DSV4] Add knob to enable pre-attn gemm 

### DIFF
--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -245,7 +245,7 @@ if TYPE_CHECKING:
     VLLM_DEBUG_WORKSPACE: bool = False
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
     VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD: int = 256
-    VLLM_ENABLE_MULTI_STREAM_GEMM: bool = False
+    VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD: int = 4096
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
     VLLM_USE_V2_MODEL_RUNNER: bool = False
     VLLM_LOG_MODEL_INSPECTION: bool = False
@@ -1670,12 +1670,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD": lambda: int(
         int(os.getenv("VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD", 256))
     ),
-    # Enables multi-stream overlap of the attention input GEMM with auxiliary
-    # GEMMs (e.g. fused_wqa_wkv overlapped with indexer weights / kv-score
-    # projections in DeepSeek-V4). When unset, those callables run
-    # sequentially on the current stream even if aux streams are provided.
-    "VLLM_ENABLE_MULTI_STREAM_GEMM": lambda: bool(
-        int(os.getenv("VLLM_ENABLE_MULTI_STREAM_GEMM", "0"))
+    # Token-count cutoff for multi-stream overlap of the attention input
+    # GEMM with auxiliary GEMMs (e.g. fused_wqa_wkv overlapped with indexer
+    # weights / kv-score projections in DeepSeek-V4). At or below this many
+    # tokens the FP8 main GEMM has idle SMs to share with the bf16 aux GEMMs
+    # and overlap is a 5-45% win; above it the FP8 GEMM saturates the device
+    # and the cross-stream sync becomes pure overhead. Set to 0 to disable
+    # the multi-stream path entirely. Empirical crossover on B300 (148 SMs)
+    # is ~4096; B200 (132 SMs) is expected ~3072.
+    "VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD": lambda: int(
+        os.getenv("VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD", "4096")
     ),
     # Format for saving torch.compile cache artifacts
     # - "binary": saves as binary file

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -245,6 +245,7 @@ if TYPE_CHECKING:
     VLLM_DEBUG_WORKSPACE: bool = False
     VLLM_DISABLE_SHARED_EXPERTS_STREAM: bool = False
     VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD: int = 256
+    VLLM_ENABLE_MULTI_STREAM_GEMM: bool = False
     VLLM_COMPILE_CACHE_SAVE_FORMAT: Literal["binary", "unpacked"] = "binary"
     VLLM_USE_V2_MODEL_RUNNER: bool = False
     VLLM_LOG_MODEL_INSPECTION: bool = False
@@ -1668,6 +1669,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # TODO(alexm-redhat): Tune to be more dynamic based on GPU type
     "VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD": lambda: int(
         int(os.getenv("VLLM_SHARED_EXPERTS_STREAM_TOKEN_THRESHOLD", 256))
+    ),
+    # Enables multi-stream overlap of the attention input GEMM with auxiliary
+    # GEMMs (e.g. fused_wqa_wkv overlapped with indexer weights / kv-score
+    # projections in DeepSeek-V4). When unset, those callables run
+    # sequentially on the current stream even if aux streams are provided.
+    "VLLM_ENABLE_MULTI_STREAM_GEMM": lambda: bool(
+        int(os.getenv("VLLM_ENABLE_MULTI_STREAM_GEMM", "0"))
     ),
     # Format for saving torch.compile cache artifacts
     # - "binary": saves as binary file

--- a/vllm/model_executor/layers/deepseek_v4_attention.py
+++ b/vllm/model_executor/layers/deepseek_v4_attention.py
@@ -13,6 +13,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 from transformers import DeepseekV2Config, DeepseekV3Config
 
+import vllm.envs as envs
 from vllm.model_executor.layers.linear import (
     ReplicatedLinear,
 )
@@ -385,6 +386,7 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
             self.ln_events[0],
             self.ln_events[1:4],
             self.aux_stream_list[:3],
+            enable=envs.VLLM_ENABLE_MULTI_STREAM_GEMM,
         )
 
         return qr_kv, kv_score, indexer_kv_score, indexer_weights

--- a/vllm/model_executor/layers/deepseek_v4_attention.py
+++ b/vllm/model_executor/layers/deepseek_v4_attention.py
@@ -386,7 +386,8 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
             self.ln_events[0],
             self.ln_events[1:4],
             self.aux_stream_list[:3],
-            enable=envs.VLLM_ENABLE_MULTI_STREAM_GEMM,
+            enable=hidden_states.shape[0]
+            <= envs.VLLM_MULTI_STREAM_GEMM_TOKEN_THRESHOLD,
         )
 
         return qr_kv, kv_score, indexer_kv_score, indexer_weights

--- a/vllm/utils/multi_stream_utils.py
+++ b/vllm/utils/multi_stream_utils.py
@@ -64,6 +64,7 @@ def execute_in_parallel(
     start_event: torch.cuda.Event,
     done_events: list[torch.cuda.Event],
     aux_streams: list[torch.cuda.Stream] | None = None,
+    enable: bool = False,
 ) -> tuple[Any, list[Any]]:
     """Run default_fn on the current stream and aux_fns concurrently on
     aux_streams.
@@ -74,8 +75,9 @@ def execute_in_parallel(
 
     start_event fans out from the current stream to every launched aux stream;
     done_events[i] is recorded after aux_fns[i] so the current stream joins
-    before returning. When aux_streams is None, all aux_fns run sequentially
-    on the current stream.
+    before returning. Falls back to sequential execution on the current stream
+    when aux_streams is None or enable is False; in that case default_fn runs
+    first, then aux_fns in order.
 
     Args:
         default_fn: Callable for the default (current) stream.
@@ -86,13 +88,17 @@ def execute_in_parallel(
             corresponding aux_fn. Length must match aux_fns.
         aux_streams: Per-aux CUDA streams. Length must match aux_fns.
             Multi-stream is disabled when None.
+        enable: Opt-in switch for the multi-stream path. Defaults to False,
+            so callers that pass aux_streams must also pass enable=True
+            (typically gated by an env var) to actually overlap. When False,
+            execution falls back to sequential on the current stream.
 
     Returns:
         Tuple of (default_result, aux_results) where aux_results[i] is the
         result of aux_fns[i] (or None when skipped).
     """
     aux_results: list[Any]
-    if aux_streams is None:
+    if aux_streams is None or not enable:
         default_result = default_fn()
         aux_results = [fn() if fn is not None else None for fn in aux_fns]
         return default_result, aux_results


### PR DESCRIPTION



## Purpose
When running large batch forward, multi-stream GEMM will degrade performance. So change to optionally add env var to gate it.

## Test Plan
V4-Flash gsm8k

## Test Result
no envar
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9507|±  | 0.006|
|     |       |strict-match    |     5|exact_match|↑  |0.9507|±  | 0.006|
```

with envvar
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9538|±  |0.0058|
|     |       |strict-match    |     5|exact_match|↑  |0.9545|±  |0.0057|
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

