### PR TITLE
[Bugfix] Fix persistent_topk inter-CTA init race on RadixRowState

### DIFF
--- a/csrc/persistent_topk.cuh
+++ b/csrc/persistent_topk.cuh
@@ -887,26 +887,13 @@ __global__ void __launch_bounds__(kThreadsPerBlock, 2)
   uint32_t* shared_ordered =
       reinterpret_cast<uint32_t*>(smem_raw + kFixedSmemLarge);
 
-  // RadixRowState for multi-CTA cooperative radix
+  // RadixRowState for multi-CTA cooperative radix.
+  // Zero-initialization is done host-side via cudaMemsetAsync in topk.cu
+  // before launch — that gives a stream-ordered happens-before edge for all
+  // CTAs, which the previous in-kernel init (CTA-0 only + intra-CTA
+  // __syncthreads) did not provide and which manifested as a race against
+  // CTA-1+'s first red_release on arrival_counter.
   RadixRowState* state = &params.row_states[group_id];
-
-  // -- Initialize RadixRowState (only needed if large rows exist) --
-  if (params.max_seq_len > RADIX_THRESHOLD) {
-    if (cta_in_group == 0) {
-      for (uint32_t buf = 0; buf < 3; buf++) {
-        for (uint32_t i = tx; i < RADIX; i += kThreadsPerBlock) {
-          state->histogram[buf][i] = 0;
-        }
-      }
-      if (tx == 0) {
-        state->remaining_k = 0;
-        state->prefix = 0;
-        state->arrival_counter = 0;
-        state->output_counter = 0;
-      }
-    }
-    __syncthreads();
-  }
 
   int barrier_phase = 0;
   const uint32_t total_iters = (params.num_rows + num_groups - 1) / num_groups;

--- a/csrc/topk.cu
+++ b/csrc/topk.cu
@@ -153,6 +153,21 @@ void launch_persistent_topk(const torch::Tensor& logits,
     TORCH_CHECK(workspace.size(0) >= static_cast<int64_t>(state_bytes),
                 "workspace too small, need ", state_bytes, " bytes");
 
+    // Zero the per-group RadixRowState region before launch. Two reasons:
+    //   1. arrival_counter accumulates within a launch and is never reset,
+    //      so a prior call leaves it at a large positive value. Without this
+    //      reset, the very first wait_ge in the next call sees counter >>
+    //      target and returns instantly, breaking the barrier.
+    //   2. The in-kernel init at persistent_topk.cuh:894-909 only runs in
+    //      CTA-0 with intra-CTA __syncthreads(), so it has no happens-before
+    //      edge to CTA-1+'s first red_release. cudaMemsetAsync is
+    //      stream-ordered: the zero is globally visible before any CTA runs.
+    // Cost: ~30 * 3088 = 92KB at the persistent path, negligible.
+    cudaError_t mz_err =
+        cudaMemsetAsync(workspace.data_ptr<uint8_t>(), 0, state_bytes, stream);
+    TORCH_CHECK(mz_err == cudaSuccess,
+                "row_states memset failed: ", cudaGetErrorString(mz_err));
+
     P::PersistentTopKParams params;
     params.input = logits.data_ptr<float>();
     params.output = output.data_ptr<int32_t>();

--- a/csrc/topk.cu
+++ b/csrc/topk.cu
@@ -153,20 +153,28 @@ void launch_persistent_topk(const torch::Tensor& logits,
     TORCH_CHECK(workspace.size(0) >= static_cast<int64_t>(state_bytes),
                 "workspace too small, need ", state_bytes, " bytes");
 
-    // Zero the per-group RadixRowState region before launch. Two reasons:
+    // Zero the per-group RadixRowState region before launch — only when the
+    // radix path will actually run (max_seq_len > RADIX_THRESHOLD). The
+    // RadixRowState fields (arrival_counter, histograms) are only touched by
+    // radix_topk; the decode/medium paths inside the persistent kernel
+    // operate purely in shared memory and never read these globals, so a
+    // stale workspace is harmless for them.
+    //
+    // Why we need the memset (when needs_cooperative is true):
     //   1. arrival_counter accumulates within a launch and is never reset,
     //      so a prior call leaves it at a large positive value. Without this
     //      reset, the very first wait_ge in the next call sees counter >>
     //      target and returns instantly, breaking the barrier.
-    //   2. The in-kernel init at persistent_topk.cuh:894-909 only runs in
-    //      CTA-0 with intra-CTA __syncthreads(), so it has no happens-before
-    //      edge to CTA-1+'s first red_release. cudaMemsetAsync is
-    //      stream-ordered: the zero is globally visible before any CTA runs.
-    // Cost: ~30 * 3088 = 92KB at the persistent path, negligible.
-    cudaError_t mz_err =
-        cudaMemsetAsync(workspace.data_ptr<uint8_t>(), 0, state_bytes, stream);
-    TORCH_CHECK(mz_err == cudaSuccess,
-                "row_states memset failed: ", cudaGetErrorString(mz_err));
+    //   2. The previous in-kernel init only ran in CTA-0 with intra-CTA
+    //      __syncthreads(), so it had no happens-before edge to CTA-1+'s
+    //      first red_release. cudaMemsetAsync is stream-ordered: the zero
+    //      is globally visible before any CTA runs.
+    if (needs_cooperative) {
+      cudaError_t mz_err = cudaMemsetAsync(workspace.data_ptr<uint8_t>(), 0,
+                                           state_bytes, stream);
+      TORCH_CHECK(mz_err == cudaSuccess,
+                  "row_states memset failed: ", cudaGetErrorString(mz_err));
+    }
 
     P::PersistentTopKParams params;
     params.input = logits.data_ptr<float>();


### PR DESCRIPTION
The `RadixRowState` per-group state (in `topk_workspace`) was initialized inside the kernel by CTA-0 only, with a plain global store followed by an intra-CTA `__syncthreads()`. CTA-1+ skipped the init entirely. There was no inter-CTA synchronization between CTA-0's init writes and CTA-1+'s first `red_release(&state->arrival_counter, 1)` in `radix_topk`, so two distinct races existed:

1) **Within a single launch.** CTA-1+'s atomicAdd could fire before
   CTA-0's plain ST of `arrival_counter = 0` reached L2. CTA-1+ would
   read whatever was in `arrival_counter` from the prior kernel call,
   add 1 atomically, then CTA-0's plain store would *overwrite* the
   incremented value with 0. The barrier counter would no longer reflect
   the true number of arrivals, so subsequent `wait_ge` calls could
   either return too early or hang. Empirically the chunk-load loop in
   Stage 1 of `radix_topk` (~10^4 cycles) gives CTA-0's init enough time
   to commit, masking the race in non-cooperative launches — but the
   bug is real on paper and would fire under tighter scheduling.

2) **Across launches.** `arrival_counter` is monotonically incremented
   throughout a launch and never reset. After a call, it ends at
   `total_phases * ctas_per_group`, a large positive value. The
   `topk_workspace` returned by the workspace manager is reused across
   calls without zero-init (`torch.empty`), so the *next* call's first
   `wait_ge(counter, ctas_per_group)` sees the stale large value and
   returns immediately on every CTA. Histograms have the same problem
   — they accumulate atomicAdds onto whatever the prior call left
   behind. This was the more impactful failure mode: every kernel
   invocation after the first one was effectively skipping the
   cooperative barrier and producing undefined results, hidden only
   because CTA-0's in-kernel init sometimes overwrote the stale state
   in time.

**Fix.** Replace the in-kernel init with a host-side `cudaMemsetAsync(workspace, 0, num_groups * sizeof(RadixRowState))` issued on the launch stream before the kernel runs. This:

- Provides a stream-ordered happens-before edge for *all* CTAs (memset completes before the kernel begins), removing the inter-CTA race without needing `st.release.gpu` + acquire-flag handshakes.
- Resets `arrival_counter` and `histogram` to zero between launches, fixing the cross-launch state leak.
- Removes the CTA-0-only init branch from the kernel entirely (`persistent_topk.cuh:894-909`), simplifying the prologue.

Cost: ~30 * 3088 = 92KB memset on the persistent path, dominated by the radix kernel itself (which spends most of its time in chunk loads and atomic histogram updates). Negligible.

This only affects the persistent-kernel path
(`num_rows <= 32` on devices with `max_smem >= 128KB`); the `FilteredTopK` paths are unchanged.




## Purpose

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

