### PR TITLE
[Security] Add CORS wildcard warning, CODEOWNERS for workflows, block pool ref_cnt guard

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -198,3 +198,6 @@ mkdocs.yaml @hmellor
 /docs/usage/security.md @russellb
 /SECURITY.md @russellb
 /docs/contributing/vulnerability_management.md @russellb
+
+# CI/CD pipeline files require security review
+/.github/workflows/ @russellb

--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -253,6 +253,13 @@ def build_app(
         register_pooling_api_routers(app, supported_tasks, model_config)
 
     app.root_path = args.root_path
+    if args.allowed_origins == ["*"]:
+        logger.warning(
+            "CORS is using wildcard origins (allowed_origins=['*']). "
+            "Any website can make cross-origin requests to this server. "
+            "For internet-exposed deployments, set --allowed-origins to "
+            "specific trusted origins."
+        )
     app.add_middleware(
         CORSMiddleware,
         allow_origins=args.allowed_origins,

--- a/vllm/entrypoints/openai/cli_args.py
+++ b/vllm/entrypoints/openai/cli_args.py
@@ -246,11 +246,14 @@ class FrontendArgs(BaseFrontendArgs):
     allow_credentials: bool = False
     """Allow credentials."""
     allowed_origins: list[str] = field(default_factory=lambda: ["*"])
-    """Allowed origins."""
+    """Allowed origins for CORS. Defaults to wildcard, which allows any
+    origin to make cross-origin requests. For internet-exposed servers,
+    set this to specific origins to prevent cross-origin request forgery
+    (OWASP A05)."""
     allowed_methods: list[str] = field(default_factory=lambda: ["*"])
-    """Allowed methods."""
+    """Allowed methods for CORS."""
     allowed_headers: list[str] = field(default_factory=lambda: ["*"])
-    """Allowed headers."""
+    """Allowed headers for CORS."""
     api_key: list[str] | None = None
     """If provided, the server will require one of these keys to be presented in
     the header."""

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -417,6 +417,11 @@ class BlockPool:
         blocks_list = list(ordered_blocks)
         for block in blocks_list:
             block.ref_cnt -= 1
+            assert block.ref_cnt >= 0, (
+                f"Block {block.block_id} ref_cnt went negative "
+                f"({block.ref_cnt}). This indicates a double-free bug in "
+                f"the KV cache block management."
+            )
         self.free_block_queue.append_n(
             [block for block in blocks_list if block.ref_cnt == 0 and not block.is_null]
         )


### PR DESCRIPTION
## Summary

Three security and correctness hardening changes from an adversarial code review of the vllm codebase:

1. **CORS wildcard origin warning** (`cli_args.py`, `api_server.py`): Add a startup warning when CORS is configured with the default wildcard `allowed_origins=['*']`. The warning alerts operators that any website can make cross-origin requests to internet-exposed servers (OWASP A05: Security Misconfiguration). The default behavior is unchanged — this is non-breaking.

2. **CODEOWNERS for CI/CD workflows** (`.github/CODEOWNERS`): Add `/.github/workflows/ @russellb` to require security-conscious review on all CI/CD pipeline changes. Without this, any repo collaborator can modify workflow files without security review, enabling supply chain attacks (exfiltrating secrets, modifying releases).

3. **Block pool ref_cnt negative guard** (`block_pool.py`): Add assertion in `BlockPool.free_blocks()` that catches double-free bugs where `ref_cnt` would go negative. Negative `ref_cnt` indicates a block is freed more times than it was allocated, which can lead to silent KV cache memory corruption.

### Adversarial review context

These changes were identified during a multi-agent adversarial code review that produced 28 findings (5 P0, 12 P1, 3 P2, 8 security audit). This PR addresses the highest-priority items with bounded, non-breaking fixes. Deeper issues (pickle deserialization in distributed, KV transfer use-after-free, elastic EP barrier deadlock) require design discussions and are better suited for dedicated issues.

### Duplicate PR check

- CORS wildcard: no open PRs found
- CODEOWNERS for workflows: no open PRs found
- Dockerfile USER directive: already covered by #40275 (not included here)
- SHA-pin setup-uv: already covered by #39310, #38500, #38290 (not included here)
- Block pool ref_cnt: no open PRs found

## Test plan

- [x] Verified `block_id` attribute exists on `KVCacheBlock` dataclass (`kv_cache_utils.py:118`)
- [x] Verified project convention uses `assert` for invariants in `block_pool.py` (9 existing assertions)
- [x] Verified no existing tests reference `allowed_origins` or `CORSConfig` (no test breakage)
- [x] Verified Starlette CORSMiddleware behavior is unchanged (default `["*"]` preserved)
- [x] Adversarial self-review: confirmed all three changes are non-breaking and backward-compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

AI assistance disclosure: This PR was generated with AI assistance (Claude). The changes were reviewed line-by-line, and an adversarial self-review was performed before submission to catch breaking changes and regressions.