### PR TITLE
[Bugfix] Reject unsupported FlexAttention head sizes

### DIFF
--- a/vllm/v1/attention/backends/flex_attention.py
+++ b/vllm/v1/attention/backends/flex_attention.py
@@ -135,6 +135,10 @@ class FlexAttentionBackend(AttentionBackend):
     def get_supported_head_sizes(cls) -> list[int]:
         return []
 
+    @classmethod
+    def supports_head_size(cls, head_size: int) -> bool:
+        return head_size % 8 == 0
+
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
         return [MultipleOf(16)]


### PR DESCRIPTION
## DOC

### Summary

Reject FlexAttention for head sizes that are not divisible by 8, so models
such as `inferno-project/vllm-mixtral-2` with `head_size=46` fall back to a
supported attention backend instead of crashing with a CUDA misaligned address.

### Root Cause

`FlexAttentionBackend.get_supported_head_sizes()` returned an empty list, which
the base `AttentionBackend` treats as "all head sizes are supported." That let
`head_size=46` select FlexAttention.

FlexAttention's Triton kernels use vectorized 128-bit loads and require the
row stride to be 16-byte aligned. For bf16, this means:

```text
head_size * 2 % 16 == 0
head_size % 8 == 0
```

With `head_size=46`, the row stride is 92 bytes, which is not 16-byte aligned
and can trigger a CUDA misaligned-address failure.

### User-Visible Behavior

- `head_size=46` is rejected by FlexAttention and can fall back to another
  backend such as `TRITON_ATTN`.
- Common supported head sizes such as 32, 64, 80, 96, 128, and 256 remain
  accepted.
- Public APIs and backend registration behavior are unchanged.

### Files Changed

- `vllm/v1/attention/backends/flex_attention.py`
  - Added `FlexAttentionBackend.supports_head_size()`.
  - The method returns `head_size % 8 == 0`.

### Why This Is Minimal

- Only adds the backend-specific capability check.
- Matches the same safe-rejection pattern already used by FlashAttention for
  unsupported head sizes.
- Does not change signatures, public APIs, or `get_supported_head_sizes()`.
- Relies on existing vLLM backend fallback logic for unsupported head sizes.

### Tests Run

Validation was run in WSL using a `uv`-created `.venv`.

| Test | Result |
| --- | --- |
| Python syntax (`py_compile`) | PASS |
| Ruff lint (`ruff check`) | PASS |
| Logic test: `head_size=46` rejected | PASS |
| Logic test: standard sizes 32, 64, 80, 96, 128, 256 accepted | PASS |
| Logic test: edge cases accepted/rejected correctly | PASS |

`pre-commit` was attempted twice during commit, but it could not finish because
the hook environment failed to fetch `https://github.com/crate-ci/typos/` from
GitHub (`Failed to connect to github.com port 443 after 21056 ms`).

Full GPU integration tests were not run because this environment does not have
CUDA plus a compiled `vllm._C` extension available.

### Remaining Risks

Low risk. If a non-8-divisible head size happened to work with a future
FlexAttention kernel, this change would still reject it and allow vLLM to fall
back to another backend rather than crash. That is the safer behavior for the
reported failure mode.

## Contribution Checks

- Duplicate PR check:
  - `gh issue view 41257 --repo vllm-project/vllm --comments`
  - `gh pr list --repo vllm-project/vllm --state open --search "41257 in:body"`
  - `gh pr list --repo vllm-project/vllm --state open --search "FlexAttention misaligned address head_size 46"`
- Result: no open PR was found that already addresses this issue.
- Scope: this is a targeted bug fix for a reproducible crash, not a
  formatting-only or low-value cleanup PR.
- AI assistance was used to help investigate, implement, test, and write this
  PR description.
