### PR TITLE
Re-enable allreduce rms fusion for DP / PP

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -129,12 +129,6 @@ def enable_allreduce_rms_fusion(cfg: "VllmConfig") -> bool:
             current_platform.is_device_capability_family(100)
             or current_platform.is_device_capability(90)
         )
-        # tp-dp combination broken:
-        # https://github.com/vllm-project/vllm/issues/34458
-        and cfg.parallel_config.data_parallel_size == 1
-        # tp-pp combination broken:
-        # https://github.com/vllm-project/vllm/issues/35426
-        and cfg.parallel_config.pipeline_parallel_size == 1
     )
 
 


### PR DESCRIPTION
## Purpose

Re-enable allreduce + rms fusion for PP & DP.

Previous issues:
- PP: https://github.com/vllm-project/vllm/issues/35426
- DP: https://github.com/vllm-project/vllm/issues/34458

Both issues have been fixed by https://github.com/flashinfer-ai/flashinfer/pull/2662 that was included in flashinfer 0.6.7. We are currently on 0.6.8 so this can be re-enabled. 

## Test Plan

Tested manually the reproducers. Turning the config on by default also means we will get a lot more coverage in the CI, such as `tests/compile/fullgraph/test_basic_correctness.py`

## Test Result

It works.

Evals:
```
lm-eval --model vllm --model_args "pretrained=Qwen/Qwen3.5-35B-A3B,tensor_parallel_size=2,pipeline_parallel_size=2" --tasks gsm8k --num_fewshot 5 --batch_size 32
```

Before:
```
vllm ({'pretrained': 'Qwen/Qwen3.5-35B-A3B', 'tensor_parallel_size': 2, 'pipeline_parallel_size': 2}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: 32
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8597|±  |0.0096|
|     |       |strict-match    |     5|exact_match|↑  |0.8400|±  |0.0101|
```

After:
```
(EngineCore pid=1513286) INFO 05-01 17:35:18 [compilation.py:303] Enabled custom fusions: allreduce_rms
[...]
vllm ({'pretrained': 'Qwen/Qwen3.5-35B-A3B', 'tensor_parallel_size': 2, 'pipeline_parallel_size': 2}), gen_kwargs: ({}), limit: None, num_fewshot: 5, batch_size: 32
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8537|±  |0.0097|
|     |       |strict-match    |     5|exact_match|↑  |0.8347|±  |0.0102|
```
