### PR TITLE
[BugFix][MyPy]:  Module has no attribute "sched_getaffinity" [attr-defined]

### DIFF
--- a/vllm/utils/cpu_resource_utils.py
+++ b/vllm/utils/cpu_resource_utils.py
@@ -3,7 +3,6 @@
 
 import json
 import os
-import platform
 import subprocess
 import sys
 from dataclasses import dataclass
@@ -79,7 +78,7 @@ def parse_id_list(raw_str: str) -> list[int]:
 
 
 def get_memory_node_info(node_id: int = 0) -> MemoryNodeInfo:
-    if platform.system() == "Darwin":
+    if sys.platform == "darwin":
         # MacOS has no memory node
         return MemoryNodeInfo(
             total_memory=psutil.virtual_memory().total,
@@ -130,7 +129,7 @@ def get_allowed_cpu_list() -> list[LogicalCPUInfo]:
 
 
 def get_visible_memory_node() -> list[int]:
-    if platform.system() == "Darwin":
+    if sys.platform == "darwin":
         return [0]
 
     allowed_memory_node_list = get_memory_affinity()
@@ -161,7 +160,7 @@ def _synthesize_cpu_list() -> list[LogicalCPUInfo]:
 
 
 def _get_cpu_list() -> list[LogicalCPUInfo]:
-    if platform.system() == "Darwin":
+    if sys.platform == "darwin":
         # For MacOS, no user-level CPU affinity and SMT, return all CPUs
         return _synthesize_cpu_list()
 

--- a/vllm/utils/cpu_resource_utils.py
+++ b/vllm/utils/cpu_resource_utils.py
@@ -5,6 +5,7 @@ import json
 import os
 import platform
 import subprocess
+import sys
 from dataclasses import dataclass
 from functools import cache
 
@@ -122,13 +123,10 @@ def get_memory_node_info(node_id: int = 0) -> MemoryNodeInfo:
 
 def get_allowed_cpu_list() -> list[LogicalCPUInfo]:
     cpu_list = _get_cpu_list()
-    if platform.system() == "Darwin":
-        return cpu_list
-
-    global_allowed_cpu_id_list = os.sched_getaffinity(0)  # type: ignore[attr-defined]
-    logical_cpu_list = [x for x in cpu_list if x.id in global_allowed_cpu_id_list]
-
-    return logical_cpu_list
+    if sys.platform == "linux":
+        allowed = os.sched_getaffinity(0)
+        return [x for x in cpu_list if x.id in allowed]
+    return cpu_list
 
 
 def get_visible_memory_node() -> list[int]:


### PR DESCRIPTION
Error when MyPy run locally:

```bash
$ pre-commit run -a --hook-stage manual mypy-3.10

Run mypy for Python 3.10.................................................Failed
- hook id: mypy-3.10
- exit code: 1

$ mypy --python-version 3.10 
vllm/utils/cpu_resource_utils.py:128: error: Module has no attribute "sched_getaffinity"  [attr-defined]
Found 1 error in 1 file (checked 1025 source files)
```

The solution uses `sys.platform` instead of `platform.system()` because MyPy only understands `sys.platform` for OS checks and not `platform.system()` as it can’t safely narrow types with `platform`. Updated the file in 61617d0ac09b9647c3b9ea89a6b780af425966e8 to use `sys.platform` for consistency.
