### PR TITLE
[Bugfix] Fix Qwen3Coder prev_tool_call_arr double-emission on parse failure

### DIFF
--- a/vllm/tool_parsers/qwen3coder_tool_parser.py
+++ b/vllm/tool_parsers/qwen3coder_tool_parser.py
@@ -639,6 +639,7 @@ class Qwen3CoderToolParser(ToolParser):
                 func_content_end = tool_text.find(self.function_end_token, func_start)
                 if func_content_end != -1:
                     func_content = tool_text[func_start:func_content_end]
+                    parse_succeeded = False
                     try:
                         parsed_tool = self._parse_xml_function_call(
                             func_content,
@@ -649,12 +650,36 @@ class Qwen3CoderToolParser(ToolParser):
                             self.prev_tool_call_arr[self.current_tool_index][
                                 "arguments"
                             ] = parsed_tool.function.arguments
+                            parse_succeeded = True
                     except Exception:
                         logger.debug(
                             "Failed to parse tool call during streaming: %s",
                             tool_text,
                             exc_info=True,
                         )
+                    # When _parse_xml_function_call fails (returns None
+                    # or throws), prev_tool_call_arr still has the "{}"
+                    # placeholder from the header-sent step.  Fall back
+                    # to the arguments that were incrementally streamed so
+                    # the serving layer's remaining-args check produces
+                    # correct output instead of double-emitting "{}".
+                    # Only trigger when parsing actually failed — a successful
+                    # parse with empty parameters produces "{}" legitimately.
+                    if (
+                        not parse_succeeded
+                        and self.current_tool_index < len(self.prev_tool_call_arr)
+                        and self.current_tool_index
+                        < len(self.streamed_args_for_tool)
+                    ):
+                        # Append closing brace so prev_tool_call_arr
+                        # matches streamed_args_for_tool after the "+="
+                        # "}" below — otherwise the serving layer's
+                        # remainder check loses the closing brace.
+                        self.prev_tool_call_arr[self.current_tool_index][
+                            "arguments"
+                        ] = self.streamed_args_for_tool[
+                            self.current_tool_index
+                        ] + "}"
 
                 if self.current_tool_index < len(self.streamed_args_for_tool):
                     self.streamed_args_for_tool[self.current_tool_index] += "}"


### PR DESCRIPTION
## Summary

When `_parse_xml_function_call` fails during streaming (returns `None` or throws), `prev_tool_call_arr` still holds the `"{}"` placeholder from the header-sent step. The serving layer's remaining-args check then sees `"{}"` as the expected argument and computes a wrong remainder, causing `{"arguments": "{}"}` to be emitted twice.

## Context

We run Qwen3.6-27B-FP8 with MTP=3 in production and observed a suite of tool-calling issues with speculative decoding. After applying several open PRs together, tool call reliability improved dramatically:

- #40783 — fragmented `<think/>` tag handling in reasoning parser
- #40861 — structural parsing fixes in Qwen3Coder tool parser
- #39055 — embedded tool call recovery from reasoning
- #36138 — grammar ignored when reasoning ends within speculated tokens
- #39598 — Pydantic null serialization in streaming tool call deltas

We also opened two other sibling draft PRs in an attempt to perfectly fix the issue:

- #41467 — Detect MTP truncation at reasoning-to-tool-call boundary
- #41493 — Suppress EOS at draft positions in rejection sampler

This PR addresses a remaining edge case where XML parsing fails mid-stream and the placeholder `"{}"` leaks through to the client.

## Root Cause Analysis

During streaming tool call parsing, the `Qwen3CoderToolParser` sends a tool call header with `"{}"` as the placeholder arguments in `prev_tool_call_arr`. After the header is sent, incremental text is parsed via `_parse_xml_function_call` to extract the actual arguments.

When `_parse_xml_function_call` fails (returns `None` or throws an exception), `prev_tool_call_arr` still contains the `"{}"` placeholder. The serving layer's `_should_check_for_unstreamed_tool_arg_tokens` check then sees `"{}"` as the expected arguments and computes a remainder of zero — but the incremental `streamed_args_for_tool` contains the actual streamed text. This mismatch causes `{"arguments": "{}"}` to be emitted as a delta, double-emitting the empty arguments.

## Changes

- Adds a `parse_succeeded` flag to track whether `_parse_xml_function_call` returned a valid result
- After the `try/except` block, if parsing failed, copies the incrementally streamed arguments from `streamed_args_for_tool` into `prev_tool_call_arr` plus the closing `}` (appended because line 1335 adds `}` to `streamed_args_for_tool` *after* the fallback runs — without it the serving layer's remainder check loses the brace and produces broken JSON)
- Uses an explicit flag to avoid false positives where `"{}"` is a legitimate empty-parameter result

## Why This Is Safe

- Only activates on the failure path (`_parse_xml_function_call` returns `None` or throws)
- The success path (normal parsing) is completely unchanged
- The fallback produces the same result as a successful parse would have — the streamed arguments are copied directly
- Bounds checks on `current_tool_index` prevent index out of range

## Reproduction

Stream a tool-calling request with the `qwen3_coder` parser where the model's XML output is malformed enough to cause `_parse_xml_function_call` to fail. The double-emission of `"{}"` appears in the streamed deltas.

## Test Plan

- [x] Verify streaming tool calls with `qwen3_coder` parser still work normally when parsing succeeds
- [x] Verify that when `_parse_xml_function_call` fails, the streamed arguments are used as fallback instead of `"{}"`
- [ ] Run `pytest tests/tool_parsers/test_qwen3coder_tool_parser.py`
