### PR TITLE
[Perf] Batch Weight Prefetching via cuMemcpyBatchAsync to Reduce Latency

### DIFF
--- a/vllm/model_executor/offloader/prefetch.py
+++ b/vllm/model_executor/offloader/prefetch.py
@@ -22,6 +22,7 @@ import vllm.model_executor.offloader.prefetch_ops  # noqa: F401
 from vllm.logger import init_logger
 from vllm.model_executor.offloader.base import BaseOffloader, should_pin_memory
 from vllm.utils.torch_utils import get_dtype_size
+from vllm import _custom_ops as ops
 
 logger = init_logger(__name__)
 
@@ -390,6 +391,10 @@ class _ModuleOffloader:
         # Used for per-layer synchronization (both eager and capture modes).
         self._copy_done_event = torch.cuda.Event()
 
+        # Fork: record event on compute stream, copy_stream waits on it.
+        # This joins copy_stream to any active CUDA graph capture.
+        self._fork_event = torch.cuda.Event()
+
         # Track whether _copy_done_event is valid for eager-mode wait_event.
         # False when: (1) never recorded, or (2) last recorded during a
         # cudagraph capture (events become invalid after capture ends).
@@ -408,6 +413,12 @@ class _ModuleOffloader:
         # Buffer pool and slot (assigned in assign_buffer_slot)
         self._buffer_pool: StaticBufferPool | None = None
         self._buffer_slot_idx: int = 0
+
+        # Buffer pointers
+        # Grouped pointers enable batch copy from cuMemcpyBatchAsync.
+        self._buffer_src_ptrs: torch.Tensor | None = None
+        self._buffer_dst_ptrs: torch.Tensor | None = None
+        self._buffer_sizes: torch.Tensor | None = None
 
         param_dict = dict(self.module.named_parameters())
         assert all(name in param_dict for name in whitelist_param_names), (
@@ -486,6 +497,12 @@ class _ModuleOffloader:
         self._buffer_pool = pool
         self._buffer_slot_idx = slot_idx
 
+        pin_memory = should_pin_memory()
+
+        src_ptrs: list[int] = []
+        dst_ptrs: list[int] = []
+        sizes: list[int] = []
+
         # Assign static buffers to parameters
         # Use CPU storage shape/stride/dtype since param.data is now empty
         for name, offloader in self._param_offloaders.items():
@@ -499,6 +516,37 @@ class _ModuleOffloader:
                 slot_idx=slot_idx,
             )
             offloader.assign_static_buffer(buffer)
+
+            # IMPORTANT: Update pointer.
+            cpu_storage = offloader._cpu_storage
+            assert cpu_storage is not None, "CPU storage not initialized"
+            assert not pin_memory or cpu_storage.is_pinned(), (
+                f"CPU storage for {name} is not pinned, but pin_memory is "
+                "enabled. The batched H2D prefetch path requires pinned "
+                "source memory; otherwise cuMemcpyBatchAsync degrades to a "
+                "synchronous copy and breaks event-based fork "
+                "synchronization with the compute stream."
+            )
+
+            src_ptrs.append(cpu_storage.data_ptr())
+            dst_ptrs.append(buffer.data_ptr())
+            sizes.append(cpu_storage.numel() * cpu_storage.element_size())
+
+        # Group buffer's pointer.
+        if not src_ptrs:
+            self._buffer_src_ptrs = None
+            self._buffer_dst_ptrs = None
+            self._buffer_sizes = None
+        else:
+            self._buffer_src_ptrs = torch.tensor(
+                src_ptrs, dtype=torch.int64, pin_memory=pin_memory
+            )
+            self._buffer_dst_ptrs = torch.tensor(
+                dst_ptrs, dtype=torch.int64, pin_memory=pin_memory
+            )
+            self._buffer_sizes = torch.tensor(
+                sizes, dtype=torch.int64, pin_memory=pin_memory
+            )
 
     def start_onload_to_static(self):
         """Start async copy from CPU storage to GPU buffer.
@@ -517,24 +565,39 @@ class _ModuleOffloader:
         self._prefetch_in_capture = torch.cuda.is_current_stream_capturing()
 
         # Fork: record event on compute stream, copy_stream waits on it
-        # This joins copy_stream to any active CUDA graph capture
-        fork_event = torch.cuda.Event()
-        torch.cuda.current_stream().record_event(fork_event)
-        self.copy_stream.wait_event(fork_event)
+        # This joins copy_stream to any active CUDA graph capture.
+        torch.cuda.current_stream().record_event(self._fork_event)
+        self.copy_stream.wait_event(self._fork_event)
 
         with torch.cuda.stream(self.copy_stream):
-            for name, offloader in self._param_offloaders.items():
-                cpu_storage = offloader._cpu_storage
-                gpu_buffer = offloader._gpu_buffer
-                assert cpu_storage is not None, "CPU storage not initialized"
-                assert gpu_buffer is not None, "GPU buffer not assigned"
-                assert not should_pin_memory() or cpu_storage.is_pinned(), (
-                    f"CPU storage for {name} is not pinned! "
-                    "non_blocking=True H2D copy from non-pinned memory "
-                    "causes stream synchronization that breaks "
-                    "event-based fork synchronization."
+            if not torch.cuda.is_current_stream_capturing() and (
+                self._buffer_src_ptrs is not None
+                and self._buffer_dst_ptrs is not None
+                and self._buffer_sizes is not None
+            ):
+                # Batch API path: batched copy using custom op (single cuMemcpyBatchAsync call on CUDA 12.8+)      
+                # cuMemcpyBatchAsync can have less driver-call overhead and better performance.
+                # swap_blocks_batch() will fallback to internal cudaMemcpyAsync loop if cuMemcpyBatchAsync is not available.
+                # IMPORTANT: cuMemcpyBatchAsync is not capture-safe.
+                ops.swap_blocks_batch(
+                    src_ptrs=self._buffer_src_ptrs,
+                    dst_ptrs=self._buffer_dst_ptrs,
+                    sizes=self._buffer_sizes
                 )
-                gpu_buffer.copy_(cpu_storage, non_blocking=True)
+            else:
+                # Graph path: Fallbacks to per-param copy_() so they can get recorded into the graph.
+                for name, offloader in self._param_offloaders.items():
+                    cpu_storage = offloader._cpu_storage
+                    gpu_buffer = offloader._gpu_buffer
+                    assert cpu_storage is not None, "CPU storage not initialized"
+                    assert gpu_buffer is not None, "GPU buffer not assigned"
+                    assert not should_pin_memory() or cpu_storage.is_pinned(), (
+                        f"CPU storage for {name} is not pinned! "
+                        "non_blocking=True H2D copy from non-pinned memory "
+                        "causes stream synchronization that breaks "
+                        "event-based fork synchronization."
+                    )
+                    gpu_buffer.copy_(cpu_storage, non_blocking=True)
 
         # Record completion event for _wait_for_layer to use
         self._copy_done_event.record(self.copy_stream)


### PR DESCRIPTION



## Purpose

Current implementation of weight prefetching requires launching `cuMemcpyAsync` multiple times, which creates driver-call overhead. This overhead accumulates and hurts inference performance because prefetching is hooked up near the end of each layer `forward`.

Replace per-layer weight prefetching with `swap_blocks_batch`. `swap_blocks_batch` utilizes `cuMemcpyBatchAsync` since CUDA 12.8+. According to the implementation, `swap_blocks_batch` will fallback to `cuMemcpyAsync` loop when the feature is not available.

In addition, objects related to CUDA stream synchronization have been optimized to further reduce the overhead.

As a result, it yields **>50%** latency decrease in triggering prefetching and reduces both TTFT and TPOT/ITL (See the test result below).

### Original Trace
<img width="1428" height="560" alt="Origin_CUDA_Graph_Trace" src="https://github.com/user-attachments/assets/a81ed736-8729-4a8c-adfb-128a851431c6" />

### Trace after This PR
<img width="1428" height="638" alt="PR_CUDA_Graph_Trace" src="https://github.com/user-attachments/assets/32e35e35-fbe0-4e69-a6f9-04645ea70f89" />

## Test Plan
### Hardware
**GPU**: 1xA100-40GB 40GB, CUDA 12.8/12.9
**CPU**: 2× Intel Xeon Gold 5318Y @ 2.10 GHz (24 cores/socket, 2 threads/core → 96 logical CPUs, 48 physical cores), max turbo 3.4 GHz, 2 NUMA nodes.
**GPU ↔ CPU**: PCIe Gen4 x16 (30GB/s R/W theoretical, 25GB/s actual)
**Memory**:  ~690 GiB usable (724 GB raw); DDR4-3200 ECC, running at 2933 MT/s

### vLLM
**Version**:
- `vllm==0.19.1rc1.dev750+ga3ec4a35f.precompiled`
- `VLLM_USE_PRECOMPILED=1 VLLM_PRECOMPILED_WHEEL_COMMIT=3527229517f01a5f2406fa6fbf35ff9223c65ed5 uv pip install --editable . --torch
-backend=cu129`.
- Last Git Commit: `a3ec4a35f5943c250974d504706d22297d423468 [Bugfix][Metrics] Fix RayPrometheusMetric.labels() returning shared labeled child (#40840)`

**Configuration**:
- Model: Qwen3-8B/Qwen3-32B
- Max model length: 24k
- TP: 1
- GPU util: 90%
- Offload backend: `prefetch`
- Offload groups:
  - Qwen3-8B (Dense, 36 layers): `50%` offload; 18 groups, 2 layers each, 1 layer offloaded, ratio: `2:1`; Prefetch steps: 2
  - Qwen3-32B (Dense, 64 layers): `75%` offload; 16 groups, 4 layers each, 3 layers offloaded, ratio: `4:3`; Prefetch steps: 2

vLLM Instance:
```
vllm serve Qwen/Qwen3-8B \
      --port 8000 \
      --tensor-parallel-size 1 \
      --gpu-memory-utilization 0.9 \
      --max-model-len 24000 \
      --offload-backend prefetch \
      --offload-group-size 2 \
      --offload-num-in-group 1 \
      --offload-prefetch-step 2
```

**Dataset & Benchmark**:
Dataset: LongBench-NarrativeQA (Shuffled): [Link](https://huggingface.co/datasets/zai-org/LongBench#:~:text=200-,NarrativeQA,-Single%2Ddoc%20QA)
QPS: 1
Prompts: 10

Benchmark & Torch Profiling:
```
vllm bench serve \
  --backend vllm \
  --model Qwen/Qwen3-8B \
  --dataset-name custom \
  --dataset-path /workspace/projects/datasets/narrativeqa_shuffled.jsonl \
  --skip-chat-template \
  --disable-shuffle \
  --num-prompts 10 \
  --request-rate 1 \
  --profile \
  --result-dir [PLACEHOLDER] \
  --result-filename [PLACEHOLDER] \
  --save-result
```

## Test Result

### Qwen3-8B
#### (Major Improvement) Per-prefetch-call Host-side Latency
Mode | Variant | Calls | Mean (μs) | Median (μs) | P99 (μs) | Total host (ms)
-- | -- | -- | -- | -- | -- | --
CUDA Graph Enabled | Original | 864 | 353.4 | 348.2 | 432.8 | 305.3
CUDA Graph Enabled | PR | 864 | 159.4 | 151.9 | 181.5 | 137.7
  |   |   | -54.9% | -56.4% | -58.1% | -54.9%
Eager | Original | 5,472 | 342.8 | 334.4 | 478.9 | 1876.1
Eager | PR | 5,472 | 149.8 | 148.4 | 177.3 | 819.6
  |   |   | -56.3% | -55.6% | -63.0% | -56.3%
#### End-to-end Throughput & Latency
##### CUDA Graph Enabled
Torch Profile (Original): [Link](https://huggingface.co/datasets/xiaobao520123/pasa-exp/blob/main/torch/profile/weight_prefetch_qwen3-8B_longbench_all/origin/cuda_graph/weight_prefetch_shuffled_1qps/rank0.1777648073798165136.pt.trace.json.gz)
Torch Profile (cuMemcpyBatchAsync): [Link](https://huggingface.co/datasets/xiaobao520123/pasa-exp/blob/main/torch/profile/weight_prefetch_qwen3-8B_longbench_all/fixed/cuda_graph/weight_prefetch_shuffled_1qps/rank0.1777632985348306463.pt.trace.json.gz)
Metric | Unit | Original | This PR | Δ
-- | -- | -- | -- | --
Output tokens | — | 2 560 | 2 560 | 0
Request throughput | req/s | 0.1161 | 0.1161 | -0.03%
Output throughput | tok/s | 29.72 | 29.71 | -0.03%
Total token throughput | tok/s | 1567.5 | 1567.0 | -0.03%
Duration | s | 86.14 | 86.17 | +0.03%
Mean TTFT | ms | 4927.3 | 4912.2 | -0.31%
Median TTFT | ms | 5405.0 | 5380.3 | -0.46%
P99 TTFT | ms | 8412.0 | 8392.1 | -0.24%
Mean TPOT | ms | 279.59 | 279.74 | +0.05%
Mean ITL | ms | 279.59 | 279.74 | +0.05%
##### Eager
Torch Profile (Original): [Link](https://huggingface.co/datasets/xiaobao520123/pasa-exp/blob/main/torch/profile/weight_prefetch_qwen3-8B_longbench_all/origin/eager/weight_prefetch_shuffled_1qps/rank0.1777648371496668212.pt.trace.json.gz)
Torch Profile (cuMemcpyBatchAsync): [Link](https://huggingface.co/datasets/xiaobao520123/pasa-exp/blob/main/torch/profile/weight_prefetch_qwen3-8B_longbench_all/fixed/eager/weight_prefetch_shuffled_1qps/rank0.1777633270305561051.pt.trace.json.gz)
Metric | Unit | Original | This PR | Δ
-- | -- | -- | -- | --
Output tokens | — | 2 560 | 2 560 | 0
Request throughput | req/s | 0.1154 | 0.1161 | +0.59%
Output throughput | tok/s | 29.54 | 29.72 | +0.59%
Total token throughput | tok/s | 1558.2 | 1567.4 | +0.59%
Duration | s | 86.65 | 86.14 | -0.59%
Mean TTFT | ms | 5712.3 | 5446.2 | -4.66%
Median TTFT | ms | 6185.1 | 5903.3 | -4.56%
P99 TTFT | ms | 9214.3 | 8938.7 | -2.99%
Mean TPOT | ms | 278.63 | 277.75 | -0.32%
Mean ITL | ms | 278.63 | 277.75 | -0.32%

### Qwen3-32B (Profiling disabled)
* Qwen3-32B is too large to fit the hardware, and weight offloading/prefetching pushes significant pressure on memory & bandwidth. Therefore, performace gain is realtively small.
#### End-to-end Throughput & Latency
##### CUDA Graph Enabled
Metric | Unit | Original | This PR | Δ
-- | -- | -- | -- | --
Output tokens | — | 2 498 | 2 150 | **-14%**
Request throughput (normalized) | req/s | 0.01022 | 0.01022 | +0.005%
Output throughput (normalized) | tok/s | 2.5520 | 2.5521 | +0.005%
Total token throughput (normalized) | tok/s | 137.88 | 137.89 | +0.005%
Duration (normalized to 2 498 tok) | s | 978.86 | 978.81 | -0.005%
Mean TTFT | ms | 251 829 | 234 892 | -6.7%
Median TTFT | ms | 244 395 | 98 586 | -60%
P99 TTFT | ms | 498 065 | 527 317 | +5.9%
Mean TPOT | ms | 1 859.03 | 1 858.99 | -0.002%
Mean ITL | ms | 1 859.05 | 1 858.73 | -0.017%

##### Eager
Metric | Unit | Original | This PR | Δ
-- | -- | -- | -- | --
Output tokens | — | 2 192 | 2 192 | 0
Request throughput | req/s | 0.009942 | 0.009944 | +0.02%
Output throughput | tok/s | 2.1794 | 2.1798 | +0.02%
Total token throughput | tok/s | 133.880 | 133.905 | +0.02%
Duration | s | 1005.80 | 1005.61 | -0.02%
Mean TTFT | ms | 228 152.3 | 228 059.9 | -0.04%
Median TTFT | ms | 57 661.4 | 57 594.2 | -0.12%
P99 TTFT | ms | 526 514.9 | 526 376.7 | -0.03%
Mean TPOT | ms | 1863.00 | 1862.74 | -0.014%
Mean ITL | ms | 1863.27 | 1863.01 | -0.014%

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

