### PR TITLE
[Build] Make bundled DeepGEMM wheel portable across Python versions

### DIFF
--- a/cmake/external_projects/deepgemm.cmake
+++ b/cmake/external_projects/deepgemm.cmake
@@ -74,7 +74,11 @@ if(DEEPGEMM_ARCHS)
   endif()
 
   # The pybind11 module name must be _C to match DeepGEMM's Python imports.
-  set_target_properties(_deep_gemm_C PROPERTIES OUTPUT_NAME "_C")
+  # Place the build artifact in a subdir so it doesn't collide with vLLM's own
+  # `_C.abi3.so` in the build tree (the install destination still differs).
+  set_target_properties(_deep_gemm_C PROPERTIES
+    OUTPUT_NAME "_C"
+    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/deep_gemm")
 
   target_compile_definitions(_deep_gemm_C PRIVATE
     "-DTORCH_EXTENSION_NAME=_C")

--- a/cmake/external_projects/deepgemm.cmake
+++ b/cmake/external_projects/deepgemm.cmake
@@ -59,8 +59,20 @@ if(DEEPGEMM_ARCHS)
   # Build the _C pybind11 extension from DeepGEMM's C++ source.
   # This is a CXX-only module — CUDA kernels are JIT-compiled at runtime.
   #
-  Python_add_library(_deep_gemm_C MODULE WITH_SOABI
-    "${deepgemm_SOURCE_DIR}/csrc/python_api.cpp")
+  # Tag the resulting .so with the stable ABI suffix (`.abi3.so`) so it loads
+  # on any supported CPython, mirroring vLLM's other native extensions
+  # (see `_C` in CMakeLists.txt and `_flashmla_C` in flashmla.cmake).
+  # Free-threaded Python doesn't yet support the stable ABI, so skip it there.
+  run_python(IS_FREETHREADED_PYTHON
+    "import sysconfig; print(1 if sysconfig.get_config_var(\"Py_GIL_DISABLED\") else 0)"
+    "Failed to determine whether interpreter is free-threaded")
+  if (NOT IS_FREETHREADED_PYTHON)
+    Python_add_library(_deep_gemm_C MODULE WITH_SOABI USE_SABI 3
+      "${deepgemm_SOURCE_DIR}/csrc/python_api.cpp")
+  else()
+    Python_add_library(_deep_gemm_C MODULE WITH_SOABI
+      "${deepgemm_SOURCE_DIR}/csrc/python_api.cpp")
+  endif()
 
   # The pybind11 module name must be _C to match DeepGEMM's Python imports.
   set_target_properties(_deep_gemm_C PROPERTIES OUTPUT_NAME "_C")
@@ -75,11 +87,16 @@ if(DEEPGEMM_ARCHS)
     "${deepgemm_SOURCE_DIR}/third-party/cutlass/tools/util/include"
     "${deepgemm_SOURCE_DIR}/third-party/fmt/include")
 
+  # Keep the stable ABI suffix on the module, but *not* on the C++ sources:
+  # pybind11's `PYBIND11_MODULE` and torch_python's tensor casters use Python
+  # C API symbols outside the strict limited subset, so compile against the
+  # full API. This matches the pattern used by `_flashmla_C`.
   target_compile_options(_deep_gemm_C PRIVATE
     $<$<COMPILE_LANGUAGE:CXX>:-std=c++17>
     $<$<COMPILE_LANGUAGE:CXX>:-O3>
     $<$<COMPILE_LANGUAGE:CXX>:-Wno-psabi>
-    $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>)
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>
+    $<$<COMPILE_LANGUAGE:CXX>:-UPy_LIMITED_API>)
 
   # torch_python is required because DeepGEMM uses pybind11 type casters
   # for at::Tensor (via PYBIND11_MODULE), unlike vLLM's own extensions which

--- a/cmake/external_projects/deepgemm.cmake
+++ b/cmake/external_projects/deepgemm.cmake
@@ -59,10 +59,9 @@ if(DEEPGEMM_ARCHS)
   # Build the _C pybind11 extension from DeepGEMM's C++ source.
   # This is a CXX-only module — CUDA kernels are JIT-compiled at runtime.
   #
-  # Tag the resulting .so with the stable ABI suffix (`.abi3.so`) so it loads
-  # on any supported CPython, mirroring vLLM's other native extensions
-  # (see `_C` in CMakeLists.txt and `_flashmla_C` in flashmla.cmake).
-  # Free-threaded Python doesn't yet support the stable ABI, so skip it there.
+  # Free-threaded Python doesn't yet support the stable ABI, so skip USE_SABI
+  # there. (The other vLLM extensions get this guard for free via
+  # define_extension_target; this target uses raw Python_add_library.)
   run_python(IS_FREETHREADED_PYTHON
     "import sysconfig; print(1 if sysconfig.get_config_var(\"Py_GIL_DISABLED\") else 0)"
     "Failed to determine whether interpreter is free-threaded")
@@ -87,15 +86,14 @@ if(DEEPGEMM_ARCHS)
     "${deepgemm_SOURCE_DIR}/third-party/cutlass/tools/util/include"
     "${deepgemm_SOURCE_DIR}/third-party/fmt/include")
 
-  # Keep the stable ABI suffix on the module, but *not* on the C++ sources:
-  # pybind11's `PYBIND11_MODULE` and torch_python's tensor casters use Python
-  # C API symbols outside the strict limited subset, so compile against the
-  # full API. This matches the pattern used by `_flashmla_C`.
+  # Keep Stable ABI for the module, but *not* for CUDA/C++ files.
+  # This prevents Py_LIMITED_API from affecting nvcc and C++ compiles.
   target_compile_options(_deep_gemm_C PRIVATE
     $<$<COMPILE_LANGUAGE:CXX>:-std=c++17>
     $<$<COMPILE_LANGUAGE:CXX>:-O3>
     $<$<COMPILE_LANGUAGE:CXX>:-Wno-psabi>
     $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>
+    $<$<COMPILE_LANGUAGE:CUDA>:-UPy_LIMITED_API>
     $<$<COMPILE_LANGUAGE:CXX>:-UPy_LIMITED_API>)
 
   # torch_python is required because DeepGEMM uses pybind11 type casters


### PR DESCRIPTION



## Purpose

The bundled `_deep_gemm_C` is built with `WITH_SOABI` only, producing `_C.cpython-312-x86_64-linux-gnu.so` (since the wheel-build container is Python 3.12). That `.so` won't load on any other CPython, so users on Python 3.10/3.11/3.13 install vLLM and silently fall through to `DeepGEMM backend is not available` in `vllm/utils/deep_gemm.py`, unless they manually run `tools/install_deepgemm.sh`.

Mirrors the pattern used in `cmake/external_projects/flashmla.cmake`.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

