### PR TITLE
Limit concurrency on `test_transcription_api_correctness.py`

### DIFF
--- a/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
+++ b/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
@@ -184,7 +184,7 @@ def test_wer_correctness(
     server_args = [
         "--enforce-eager",
         f"--tokenizer_mode={model_info.tokenizer_mode}",
-        f"--max_num_seqs=32", # avoid OOM on small GPUs
+        "--max_num_seqs=32",  # avoid OOM on small GPUs
     ]
     if model_info.trust_remote_code:
         server_args.append("--trust-remote-code")

--- a/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
+++ b/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
@@ -184,6 +184,7 @@ def test_wer_correctness(
     server_args = [
         "--enforce-eager",
         f"--tokenizer_mode={model_info.tokenizer_mode}",
+        f"--max_num_seqs=32", # avoid OOM on small GPUs
     ]
     if model_info.trust_remote_code:
         server_args.append("--trust-remote-code")

--- a/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
+++ b/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
@@ -26,6 +26,9 @@ from vllm.tokenizers import get_tokenizer
 from ....models.registry import HF_EXAMPLE_MODELS
 from ....utils import RemoteOpenAIServer
 
+# Tuned to prevent OOM on 18GB GPUs in transcription correctness tests.
+MAX_SEQS_FOR_TRANSCRIPTION_TEST = 32
+
 
 def to_bytes(y, sr):
     buffer = io.BytesIO()
@@ -184,7 +187,7 @@ def test_wer_correctness(
     server_args = [
         "--enforce-eager",
         f"--tokenizer_mode={model_info.tokenizer_mode}",
-        "--max_num_seqs=32",  # avoid OOM on small GPUs
+        f"--max_num_seqs={MAX_SEQS_FOR_TRANSCRIPTION_TEST}",
     ]
     if model_info.trust_remote_code:
         server_args.append("--trust-remote-code")


### PR DESCRIPTION
CohereASR was added alongside Whisper to `tests/entrypoints/openai/correctness/test_transcription_api_correctness.py` in https://github.com/vllm-project/vllm/pull/40582. The motivation was to have a model in CI which tests the codepath of running with variable length seq len in the encoder and not rely on padding it to 30s as done in Whisper. 

The CI passed in the PR which introduced this test https://github.com/vllm-project/vllm/pull/40582. However, later it was observed to fail in some other CI run with a `RuntimeError: NVML_SUCCESS == r INTERNAL ASSERT FAILED` crash in `cohere_asr.py` during the `CohereASR` transcription test (model_config1). The error occurs in `cohere_asr.py:491` -> `conv.forward` -> `torch.nn.modules.conv.py` -> CUDA caching allocator assertion failure.

The logs indicate that:
1. The test used effectively unbounded concurrency for this dataset.
2. The engine then tried to process a large batch of concurrent audio encoder requests.
3. PyTorch died inside the CUDA caching allocator / NVML path.
4. Instead of throwing OOM it raised `[RemoteOpenAIServer] Could not query GPU memory: Insufficient Permissions` because the CI is running on a MIG and not full H200 so NVML doesnt have the permission to query in this CI setup.

The root cause looks very likely memory-pressure-induced allocator failure under excessive concurrency in encoder using convolution operation. The PR limits the concurrency so it does not fail for this workload on 18GB of H200 MIG which doesn't impact the correctness test. 