### PR TITLE
[Bugfix] Fix B200 batch determinism in fused_moe logic

### DIFF
--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1568,21 +1568,36 @@ def _prepare_expert_assignment(
     # SPARSITY_FACTOR is a heuristic margin ensuring tokens_in_chunk * top_k
     # activates only a small fraction of total experts
     # Skips moe_align_block_size and activates the `sorted_token_ids is None`
-    # path of the fused_moe_kernel kernel
-    naive_block_assignment = (
-        expert_map is None
-        and num_tokens * top_k_num * 4 <= global_num_experts
-        and not (
-            (use_int8_w8a16 or use_int4_w4a16)
-            and block_shape is not None
-            and block_shape[1] > 0
-        )
+    # path of the fused_moe_kernel kernel.
+    # Under VLLM_BATCH_INVARIANT, force the naive path for block-quantized
+    # w8a8 matmuls (FP8/INT8 with block_shape). The aligned path packs up to
+    # BLOCK_SIZE_M tokens routed to the same expert into one M-tile, and the
+    # needle's row position within that tile depends on which other tokens
+    # share the expert. FP8/INT8 wgmma on Hopper/Blackwell is row-position
+    # sensitive enough to flip greedy-sampled tokens. BF16 and per-tensor
+    # paths (block_shape is None) appear row-invariant in aligned mode, so
+    # they keep the heuristic and the aligned-path throughput.
+    force_naive_for_invariance = envs.VLLM_BATCH_INVARIANT and block_shape is not None
+    naive_block_assignment = not (
+        (use_int8_w8a16 or use_int4_w4a16)
+        and block_shape is not None
+        and block_shape[1] > 0
+    ) and (
+        force_naive_for_invariance
+        or (expert_map is None and num_tokens * top_k_num * 4 <= global_num_experts)
     )
 
     if naive_block_assignment:
+        # Under EP, topk_ids holds global expert ids but the kernel indexes
+        # into local weights. Map global -> local; non-local experts become
+        # -1 and the kernel writes zeros for those blocks (their contribution
+        # comes from another rank).
+        flat_expert_ids = topk_ids.view(-1)
+        if expert_map is not None:
+            flat_expert_ids = expert_map[flat_expert_ids]
         return (
             None,
-            topk_ids.view(-1),
+            flat_expert_ids,
             torch.full(
                 (1,),
                 topk_ids.numel() * config["BLOCK_SIZE_M"],


### PR DESCRIPTION
Fixes https://github.com/pytorch/pytorch/issues/181248

## Purpose
We notice on torch 2.12 upgrade that batch invariance test is broken in vLLM - this PR fixes that inconsistency, enforcing the same path taken in batch invariance mode

Both bs=1 and bs=N decode now hit the same kernel branch with the needle token at the same row position, eliminating FP8-MMA tile-content sensitivity that broke determinism.            

As a tradeoff, this is much less performant, regresing from 3.7s -> 33.7s so we should follow up with an efficency fix           
                                                     
## Test Plan
```bash
export VLLM_TEST_MODEL=Qwen/Qwen3-30B-A3B-Thinking-2507-FP8
pytest -v -s 'tests/v1/determinism/test_batch_invariance.py::test_v1_generation_is_deterministic_across_batch_sizes_with_needle[FLASH_ATTN]
```

## Test Result
** Before **
```
E               Failed: Nondeterministic outputs detected: 4 failed out of 5 trials (max_batch_size=128).
```

** After **
```
1 passed
```


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

