### PR TITLE
[Spec Decode][V1][V2] Warm spec-decode helper kernels at startup

### DIFF
--- a/tests/v1/spec_decode/test_helper_kernel_warmup.py
+++ b/tests/v1/spec_decode/test_helper_kernel_warmup.py
@@ -96,7 +96,9 @@ def test_warmup_shapes_copy_expand_eagle(
     num_query_per_req = 1 + net_slots
     total_input = num_reqs * num_query_per_req
     total_output = num_reqs * (num_query_per_req + extra_slots)
-    block_size_tokens = min(256, next_power_of_2(total_output))
+    # Match production: BLOCK_SIZE keyed off max_query_len + net_new_slots
+    # (which equals num_query_per_req for a first-decode request).
+    block_size_tokens = min(256, next_power_of_2(num_query_per_req))
 
     target_token_ids = torch.zeros(total_input, dtype=torch.int32, device=DEVICE)
     target_positions = torch.zeros(total_input, dtype=torch.int64, device=DEVICE)
@@ -178,7 +180,9 @@ def test_warmup_shapes_copy_expand_dflash(
     block_size = 16
     max_model_len = 4096
     num_query_per_req = 1 + num_speculative_tokens
-    num_context = num_query_per_req
+    # Match production sizing: ``max_ctx_per_req == 1`` for the first request
+    # after server start (no prior context).
+    num_context = 1
     max_tokens_per_req = num_context + num_query_per_req
     block_size_kernel = min(256, next_power_of_2(max_tokens_per_req))
     num_blocks_grid = (max_tokens_per_req + block_size_kernel - 1) // block_size_kernel

--- a/tests/v1/spec_decode/test_helper_kernel_warmup.py
+++ b/tests/v1/spec_decode/test_helper_kernel_warmup.py
@@ -1,0 +1,252 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Smoke tests for the synthetic shapes used by ``dry_run_helper_kernels``.
+
+These tests pin the input shapes our spec-decode warmup uses against the
+actual Triton kernels in ``vllm/v1/spec_decode/utils.py``, so a future
+kernel-signature change that breaks our warmup will fail here rather than
+silently regressing TTFT (vllm-project/vllm#39790).
+"""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.v1.spec_decode.utils import (
+    copy_and_expand_dflash_inputs_kernel,
+    copy_and_expand_eagle_inputs_kernel,
+    eagle_prepare_inputs_padded_kernel,
+    eagle_prepare_next_token_padded_kernel,
+    eagle_step_update_slot_mapping_and_metadata,
+    next_power_of_2,
+    update_num_computed_tokens_for_batch_change,
+)
+
+pytest.importorskip("triton")
+if not current_platform.is_cuda_alike() and not current_platform.is_xpu():
+    pytest.skip(
+        "CUDA/XPU required for spec-decode warmup smoke tests",
+        allow_module_level=True,
+    )
+
+DEVICE = torch.device(current_platform.device_type)
+
+
+@pytest.mark.parametrize("num_speculative_tokens", [1, 4, 8])
+def test_warmup_shapes_eagle_prepare_kernels(num_speculative_tokens: int) -> None:
+    """The two padded-batch kernels warmed by the base proposer must accept
+    the synthetic shapes ``SpecDecodeBaseProposer.dry_run_helper_kernels``
+    builds.
+    """
+    num_reqs = 1
+    num_sampled_per_req = num_speculative_tokens + 1
+    block_size_tokens = next_power_of_2(num_sampled_per_req)
+
+    sampled_token_ids = torch.zeros(
+        (num_reqs, num_sampled_per_req), dtype=torch.int64, device=DEVICE
+    )
+    discard_mask = torch.zeros(num_reqs, dtype=torch.bool, device=DEVICE)
+    backup_tokens = torch.zeros(num_reqs, dtype=torch.int32, device=DEVICE)
+    next_token_ids = torch.empty(num_reqs, dtype=torch.int32, device=DEVICE)
+    valid_count_out = torch.empty(num_reqs, dtype=torch.int32, device=DEVICE)
+    eagle_prepare_next_token_padded_kernel[(num_reqs,)](
+        sampled_token_ids,
+        discard_mask,
+        backup_tokens,
+        next_token_ids,
+        valid_count_out,
+        128,
+        num_sampled_per_req,
+        num_reqs,
+        sampled_token_ids.stride(0),
+        BLOCK_SIZE_TOKENS=block_size_tokens,
+    )
+
+    cu_num_draft_tokens = torch.zeros(num_reqs, dtype=torch.int32, device=DEVICE)
+    valid_sampled_count = torch.zeros(num_reqs, dtype=torch.int32, device=DEVICE)
+    query_start_loc = torch.zeros(num_reqs + 1, dtype=torch.int32, device=DEVICE)
+    token_indices_to_sample = torch.empty(num_reqs, dtype=torch.int32, device=DEVICE)
+    num_rejected_tokens_gpu = torch.empty(num_reqs, dtype=torch.int32, device=DEVICE)
+    eagle_prepare_inputs_padded_kernel[(num_reqs,)](
+        cu_num_draft_tokens,
+        valid_sampled_count,
+        query_start_loc,
+        token_indices_to_sample,
+        num_rejected_tokens_gpu,
+        num_reqs,
+    )
+    torch.accelerator.synchronize()
+
+
+@pytest.mark.parametrize("num_speculative_tokens", [2, 4])
+@pytest.mark.parametrize("shift_input_ids", [True, False])
+def test_warmup_shapes_copy_expand_eagle(
+    num_speculative_tokens: int, shift_input_ids: bool
+) -> None:
+    """``copy_and_expand_eagle_inputs_kernel`` must accept the shapes the
+    base proposer warmup builds for ``needs_extra_input_slots=True``
+    configs (parallel-drafting Eagle / DraftModel)."""
+    num_reqs = 1
+    # Mirror ``needs_extra_input_slots=True`` math: extra slots == k for
+    # parallel drafting; net slots = k - (1 if shift else 0).
+    extra_slots = num_speculative_tokens
+    net_slots = extra_slots - (1 if shift_input_ids else 0)
+    if net_slots <= 0:
+        pytest.skip("config does not allocate extra slots")
+    num_query_per_req = 1 + net_slots
+    total_input = num_reqs * num_query_per_req
+    total_output = num_reqs * (num_query_per_req + extra_slots)
+    block_size_tokens = min(256, next_power_of_2(total_output))
+
+    target_token_ids = torch.zeros(total_input, dtype=torch.int32, device=DEVICE)
+    target_positions = torch.zeros(total_input, dtype=torch.int64, device=DEVICE)
+    next_token_ids = torch.zeros(num_reqs, dtype=torch.int32, device=DEVICE)
+    out_input_ids = torch.zeros(total_output, dtype=torch.int32, device=DEVICE)
+    out_positions = torch.zeros(total_output, dtype=torch.int64, device=DEVICE)
+    out_is_rejected = torch.zeros(total_output, dtype=torch.bool, device=DEVICE)
+    out_is_masked = torch.zeros(total_output, dtype=torch.bool, device=DEVICE)
+    out_token_indices = torch.empty(
+        num_reqs * extra_slots, dtype=torch.int32, device=DEVICE
+    )
+    out_hidden_state_mapping = torch.empty(
+        total_input, dtype=torch.int32, device=DEVICE
+    )
+    qsl = (
+        torch.arange(num_reqs + 1, dtype=torch.int32, device=DEVICE) * num_query_per_req
+    )
+    qel = qsl[1:] - 1
+
+    num_blocks = (total_output + block_size_tokens - 1) // block_size_tokens
+    copy_and_expand_eagle_inputs_kernel[(num_reqs, num_blocks)](
+        target_token_ids_ptr=target_token_ids,
+        target_positions_ptr=target_positions,
+        next_token_ids_ptr=next_token_ids,
+        out_input_ids_ptr=out_input_ids,
+        out_positions_ptr=out_positions,
+        out_is_rejected_token_mask_ptr=out_is_rejected,
+        out_is_masked_token_mask_ptr=out_is_masked,
+        out_new_token_indices_ptr=out_token_indices,
+        out_hidden_state_mapping_ptr=out_hidden_state_mapping,
+        query_start_loc_ptr=qsl,
+        query_end_loc_ptr=qel,
+        padding_token_id=0,
+        parallel_drafting_token_id=0,
+        total_input_tokens=total_input,
+        num_padding_slots_per_request=extra_slots,
+        shift_input_ids=shift_input_ids,
+        BLOCK_SIZE_TOKENS=block_size_tokens,
+    )
+    torch.accelerator.synchronize()
+
+
+def test_warmup_shapes_eagle_step_slot_mapping() -> None:
+    """The Eagle per-step slot-mapping wrapper must accept the shapes
+    ``EagleProposer.dry_run_helper_kernels`` builds for sequential Eagle
+    with k>=2."""
+    num_reqs = 1
+    block_size = 16
+    max_model_len = 4096
+    n_blocks_per_req = (max_model_len + block_size - 1) // block_size
+
+    positions_1d = torch.zeros(num_reqs, dtype=torch.int64, device=DEVICE)
+    block_table = torch.zeros(
+        (num_reqs, n_blocks_per_req), dtype=torch.int32, device=DEVICE
+    )
+    seq_lens = torch.ones(num_reqs, dtype=torch.int32, device=DEVICE)
+    out_clamped_positions = torch.empty(num_reqs, dtype=torch.int64, device=DEVICE)
+    out_slot_mapping = torch.empty(num_reqs, dtype=torch.int64, device=DEVICE)
+    eagle_step_update_slot_mapping_and_metadata(
+        positions_1d=positions_1d,
+        block_table_tensor=block_table,
+        seq_lens=seq_lens,
+        block_size=block_size,
+        max_model_len=max_model_len,
+        out_clamped_positions=out_clamped_positions,
+        out_slot_mapping=out_slot_mapping,
+    )
+
+
+@pytest.mark.parametrize("num_speculative_tokens", [2, 4])
+@pytest.mark.parametrize("has_rejected", [False, True])
+def test_warmup_shapes_copy_expand_dflash(
+    num_speculative_tokens: int, has_rejected: bool
+) -> None:
+    """The DFlash fused kernel must accept the shapes
+    ``DFlashProposer.dry_run_helper_kernels`` builds, including the
+    ``HAS_NUM_REJECTED`` constexpr toggled either way."""
+    num_reqs = 1
+    block_size = 16
+    max_model_len = 4096
+    num_query_per_req = 1 + num_speculative_tokens
+    num_context = num_query_per_req
+    max_tokens_per_req = num_context + num_query_per_req
+    block_size_kernel = min(256, next_power_of_2(max_tokens_per_req))
+    num_blocks_grid = (max_tokens_per_req + block_size_kernel - 1) // block_size_kernel
+    n_blocks_per_req = (max_model_len + block_size - 1) // block_size
+
+    next_token_ids = torch.zeros(num_reqs, dtype=torch.int32, device=DEVICE)
+    target_positions = torch.zeros(num_context, dtype=torch.int64, device=DEVICE)
+    out_input_ids = torch.zeros(num_query_per_req, dtype=torch.int32, device=DEVICE)
+    out_context_positions = torch.zeros(num_context, dtype=torch.int64, device=DEVICE)
+    out_query_positions = torch.zeros(
+        num_query_per_req, dtype=torch.int64, device=DEVICE
+    )
+    out_context_slot = torch.zeros(num_context, dtype=torch.int64, device=DEVICE)
+    out_query_slot = torch.zeros(num_query_per_req, dtype=torch.int64, device=DEVICE)
+    out_token_indices = torch.empty(
+        num_reqs * num_speculative_tokens, dtype=torch.int32, device=DEVICE
+    )
+    block_table = torch.zeros(
+        (num_reqs, n_blocks_per_req), dtype=torch.int32, device=DEVICE
+    )
+    qsl = torch.zeros(num_reqs + 1, dtype=torch.int32, device=DEVICE)
+    qsl[1] = num_context
+    num_rejected = torch.zeros(num_reqs, dtype=torch.int32, device=DEVICE)
+
+    copy_and_expand_dflash_inputs_kernel[(num_reqs, num_blocks_grid)](
+        next_token_ids_ptr=next_token_ids,
+        target_positions_ptr=target_positions,
+        out_input_ids_ptr=out_input_ids,
+        out_context_positions_ptr=out_context_positions,
+        out_query_positions_ptr=out_query_positions,
+        out_context_slot_mapping_ptr=out_context_slot,
+        out_query_slot_mapping_ptr=out_query_slot,
+        out_token_indices_ptr=out_token_indices,
+        block_table_ptr=block_table,
+        block_table_stride=block_table.stride(0),
+        query_start_loc_ptr=qsl,
+        num_rejected_tokens_ptr=num_rejected if has_rejected else 0,
+        parallel_drafting_token_id=0,
+        block_size=block_size,
+        num_query_per_req=num_query_per_req,
+        num_speculative_tokens=num_speculative_tokens,
+        total_input_tokens=num_context,
+        BLOCK_SIZE=block_size_kernel,
+        HAS_NUM_REJECTED=has_rejected,
+    )
+    torch.accelerator.synchronize()
+
+
+def test_warmup_shapes_update_num_computed_tokens() -> None:
+    """The async-spec-decode ``@torch.compile`` correction must accept the
+    shapes ``Worker._warmup_spec_decode_helpers`` builds (V1 path)."""
+    max_num_reqs = 8
+    num_computed_tokens = torch.zeros(max_num_reqs, dtype=torch.int32, device=DEVICE)
+    num_accepted_tokens = torch.zeros(max_num_reqs, dtype=torch.int32, device=DEVICE)
+    prev_positions = torch.zeros(max_num_reqs, dtype=torch.int64, device=DEVICE)
+    valid_sampled_token_count = torch.zeros(
+        max_num_reqs, dtype=torch.int32, device=DEVICE
+    )
+    prev_num_draft_tokens = torch.zeros(max_num_reqs, dtype=torch.int32, device=DEVICE)
+    cpu_num_computed_tokens = torch.zeros(
+        max_num_reqs, dtype=torch.int32, device=DEVICE
+    )
+    update_num_computed_tokens_for_batch_change(
+        num_computed_tokens,
+        num_accepted_tokens,
+        prev_positions,
+        valid_sampled_token_count,
+        prev_num_draft_tokens,
+        cpu_num_computed_tokens,
+    )
+    torch.accelerator.synchronize()

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -310,8 +310,8 @@ class DFlashProposer(SpecDecodeBaseProposer):
         super().dry_run_helper_kernels()
 
         # ``self.block_size`` is set by ``initialize_attn_backend`` which
-        # runs before ``warmup_kernels``; guard for completeness in case
-        # this is invoked from a code path that skipped backend init.
+        # runs before ``_warmup_spec_decode_helpers``; guard for completeness
+        # in case this is invoked from a code path that skipped backend init.
         if self.block_size <= 0:
             return
 

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -318,10 +318,12 @@ class DFlashProposer(SpecDecodeBaseProposer):
         device = self.device
         num_reqs = 1
         num_query_per_req = 1 + self.num_speculative_tokens
-        # Match the production sizing in ``set_inputs_first_pass``: a single
-        # token of context + the query per request keeps the synthetic call
-        # minimal while exercising both the context and query branches.
-        num_context = num_query_per_req
+        # Match the production sizing in ``set_inputs_first_pass`` (line 124):
+        # ``max_ctx_per_req = cad.max_query_len`` is 1 for the first request
+        # after server start (no prior context). Using a larger value here
+        # would pick a different ``next_power_of_2`` bucket for ``BLOCK_SIZE``
+        # and miss the production JIT cache entry.
+        num_context = 1
         max_tokens_per_req = num_context + num_query_per_req
         # ``min(256, ...)`` mirrors the cap in production so we land on the
         # same JIT cache entry as the first real request.

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -13,7 +13,10 @@ from vllm.logger import init_logger
 from vllm.triton_utils import triton
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
-from vllm.v1.spec_decode.utils import copy_and_expand_dflash_inputs_kernel
+from vllm.v1.spec_decode.utils import (
+    copy_and_expand_dflash_inputs_kernel,
+    next_power_of_2,
+)
 
 logger = init_logger(__name__)
 
@@ -300,3 +303,71 @@ class DFlashProposer(SpecDecodeBaseProposer):
     @property
     def dflash_config(self):
         return getattr(self.draft_model_config.hf_config, "dflash_config", None) or {}
+
+    @override
+    def dry_run_helper_kernels(self) -> None:
+        # Base warms the two padded-batch helper kernels shared with Eagle.
+        super().dry_run_helper_kernels()
+
+        # ``self.block_size`` is set by ``initialize_attn_backend`` which
+        # runs before ``warmup_kernels``; guard for completeness in case
+        # this is invoked from a code path that skipped backend init.
+        if self.block_size <= 0:
+            return
+
+        device = self.device
+        num_reqs = 1
+        num_query_per_req = 1 + self.num_speculative_tokens
+        # Match the production sizing in ``set_inputs_first_pass``: a single
+        # token of context + the query per request keeps the synthetic call
+        # minimal while exercising both the context and query branches.
+        num_context = num_query_per_req
+        max_tokens_per_req = num_context + num_query_per_req
+        # ``min(256, ...)`` mirrors the cap in production so we land on the
+        # same JIT cache entry as the first real request.
+        block_size_kernel = min(256, next_power_of_2(max_tokens_per_req))
+        num_blocks_grid = (
+            max_tokens_per_req + block_size_kernel - 1
+        ) // block_size_kernel
+        grid = (num_reqs, num_blocks_grid)
+
+        n_blocks_per_req = (self.max_model_len + self.block_size - 1) // self.block_size
+
+        next_token_ids = torch.zeros(num_reqs, dtype=torch.int32, device=device)
+        target_positions = torch.zeros(num_context, dtype=torch.int64, device=device)
+        token_indices = torch.empty(
+            num_reqs * self.num_speculative_tokens, dtype=torch.int32, device=device
+        )
+        block_table = torch.zeros(
+            (num_reqs, n_blocks_per_req), dtype=torch.int32, device=device
+        )
+        query_start_loc = torch.zeros(num_reqs + 1, dtype=torch.int32, device=device)
+        query_start_loc[1] = num_context
+        num_rejected = torch.zeros(num_reqs, dtype=torch.int32, device=device)
+
+        # ``HAS_NUM_REJECTED`` is the second ``tl.constexpr`` arg, so we
+        # JIT both variants here -- the first prefill request typically
+        # uses False (no prior step), but the first decode-after-rejection
+        # would otherwise hit a fresh JIT.
+        for has_rejected in (False, True):
+            copy_and_expand_dflash_inputs_kernel[grid](
+                next_token_ids_ptr=next_token_ids,
+                target_positions_ptr=target_positions,
+                out_input_ids_ptr=self.input_ids,
+                out_context_positions_ptr=self._context_positions_buffer,
+                out_query_positions_ptr=self.positions,
+                out_context_slot_mapping_ptr=self._context_slot_mapping_buffer,
+                out_query_slot_mapping_ptr=self._slot_mapping_buffer,
+                out_token_indices_ptr=token_indices,
+                block_table_ptr=block_table,
+                block_table_stride=block_table.stride(0),
+                query_start_loc_ptr=query_start_loc,
+                num_rejected_tokens_ptr=num_rejected if has_rejected else 0,
+                parallel_drafting_token_id=self.parallel_drafting_token_id,
+                block_size=self.block_size,
+                num_query_per_req=num_query_per_req,
+                num_speculative_tokens=self.num_speculative_tokens,
+                total_input_tokens=num_context,
+                BLOCK_SIZE=block_size_kernel,
+                HAS_NUM_REJECTED=has_rejected,
+            )

--- a/vllm/v1/spec_decode/eagle.py
+++ b/vllm/v1/spec_decode/eagle.py
@@ -5,6 +5,7 @@ import torch
 
 from vllm.config import VllmConfig
 from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
+from vllm.v1.spec_decode.utils import eagle_step_update_slot_mapping_and_metadata
 
 
 class EagleProposer(SpecDecodeBaseProposer):
@@ -19,4 +20,42 @@ class EagleProposer(SpecDecodeBaseProposer):
             device,
             pass_hidden_states_to_model=True,
             runner=runner,
+        )
+
+    def dry_run_helper_kernels(self) -> None:
+        # Base warms shared per-padded-batch kernels and the
+        # copy_and_expand_eagle_inputs_kernel (when allocated).
+        super().dry_run_helper_kernels()
+
+        # ``eagle_step_update_slot_mapping_and_metadata`` fires inside the
+        # per-step inner loop of ``propose()`` only for sequential Eagle
+        # with ``num_speculative_tokens > 1``. DFlash short-circuits the
+        # loop via ``parallel_drafting`` and single-token Eagle never
+        # enters it.
+        if self.num_speculative_tokens <= 1 or self.parallel_drafting:
+            return
+        if self.block_size <= 0:
+            return
+
+        device = self.device
+        num_reqs = 1
+        block_size = self.block_size
+        max_model_len = self.max_model_len
+        n_blocks_per_req = (max_model_len + block_size - 1) // block_size
+
+        positions_1d = torch.zeros(num_reqs, dtype=torch.int64, device=device)
+        block_table = torch.zeros(
+            (num_reqs, n_blocks_per_req), dtype=torch.int32, device=device
+        )
+        seq_lens = torch.ones(num_reqs, dtype=torch.int32, device=device)
+        out_clamped_positions = torch.empty(num_reqs, dtype=torch.int64, device=device)
+        out_slot_mapping = torch.empty(num_reqs, dtype=torch.int64, device=device)
+        eagle_step_update_slot_mapping_and_metadata(
+            positions_1d=positions_1d,
+            block_table_tensor=block_table,
+            seq_lens=seq_lens,
+            block_size=block_size,
+            max_model_len=max_model_len,
+            out_clamped_positions=out_clamped_positions,
+            out_slot_mapping=out_slot_mapping,
         )

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1619,9 +1619,13 @@ class SpecDecodeBaseProposer:
             total_output_tokens = num_reqs * (
                 num_query_per_req + num_padding_slots_per_request
             )
-            # ``min(256, ...)`` mirrors the production cap so we hit the
-            # same JIT cache entry as the first real request.
-            block_size_tokens = min(256, next_power_of_2(total_output_tokens))
+            # Match production sizing in ``set_inputs_first_pass`` (line 700-703):
+            # ``BLOCK_SIZE_TOKENS = min(256, next_power_of_2(max_query_len +
+            # net_num_new_slots_per_request))``. For a first-decode request
+            # ``max_query_len == 1`` so ``num_query_per_req`` is the right key;
+            # using ``total_output_tokens`` here would pick a larger constexpr
+            # bucket and miss the production JIT cache entry.
+            block_size_tokens = min(256, next_power_of_2(num_query_per_req))
 
             target_token_ids = torch.zeros(
                 total_input_tokens, dtype=torch.int32, device=device

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1542,9 +1542,12 @@ class SpecDecodeBaseProposer:
         per-step slot-mapping kernel and copy/expand kernel; DFlashProposer's
         fused first-pass kernel).
 
-        Called once from ``warmup_kernels()`` in
-        ``vllm/v1/worker/gpu/warmup.py`` after the existing prefill+decode
-        warmup steps complete.
+        Called once from ``Worker._warmup_spec_decode_helpers()`` in
+        ``vllm/v1/worker/gpu_worker.py`` after the V1 ``_dummy_run`` +
+        ``_dummy_sampler_run`` steps complete. V2 (``VLLM_USE_V2_MODEL_RUNNER=1``)
+        does not call this: its ``warmup_kernels()`` runs a real
+        ``execute_model`` step which naturally JIT-compiles V2's separate
+        spec-decode kernels in ``vllm/v1/worker/gpu/spec_decode/``.
         """
         device = self.device
         num_reqs = 1

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -1524,6 +1524,154 @@ class SpecDecodeBaseProposer:
             use_aux_hidden_state = eagle_config.get("use_aux_hidden_state", True)
         return use_aux_hidden_state
 
+    def dry_run_helper_kernels(self) -> None:
+        """JIT-compile per-step helper kernels using synthetic inputs.
+
+        ``dummy_run()`` warms the draft model forward pass but does NOT
+        exercise the Triton helper kernels (and one ``@torch.compile``
+        function) that run inside ``propose()`` and the model_runner's
+        padded-batch path. As a result the first real request after server
+        start pays the full JIT cost, causing TTFT to spike (see
+        vllm-project/vllm#39790: ~25x first-request regression on H100 +
+        Qwen3-8B + Eagle3 in the original report).
+
+        This base implementation warms the two padded-batch helper kernels
+        that fire from base-class methods used by both Eagle and DFlash.
+        Subclasses extend this via ``super().dry_run_helper_kernels()`` to
+        also warm their method-specific kernels (e.g. EagleProposer's
+        per-step slot-mapping kernel and copy/expand kernel; DFlashProposer's
+        fused first-pass kernel).
+
+        Called once from ``warmup_kernels()`` in
+        ``vllm/v1/worker/gpu/warmup.py`` after the existing prefill+decode
+        warmup steps complete.
+        """
+        device = self.device
+        num_reqs = 1
+        num_sampled_per_req = self.num_speculative_tokens + 1
+        # ``BLOCK_SIZE_TOKENS`` is the only ``tl.constexpr`` that varies
+        # at call time for these two kernels, so warming with this exact
+        # value matches the first-request JIT cache key.
+        block_size_tokens = next_power_of_2(num_sampled_per_req)
+
+        # ---- eagle_prepare_next_token_padded_kernel ----
+        # Called by base ``prepare_next_token_ids_padded`` from the
+        # padded-batch path in gpu_model_runner.
+        sampled_token_ids = torch.zeros(
+            (num_reqs, num_sampled_per_req), dtype=torch.int64, device=device
+        )
+        discard_mask = torch.zeros(num_reqs, dtype=torch.bool, device=device)
+        backup_tokens = torch.zeros(num_reqs, dtype=torch.int32, device=device)
+        next_token_ids = torch.empty(num_reqs, dtype=torch.int32, device=device)
+        valid_count_out = torch.empty(num_reqs, dtype=torch.int32, device=device)
+        # ``vocab_size`` is a runtime int (used for bounds-checking via
+        # ``tl.where``) and not part of the constexpr cache key, so any
+        # in-range placeholder works.
+        eagle_prepare_next_token_padded_kernel[(num_reqs,)](
+            sampled_token_ids,
+            discard_mask,
+            backup_tokens,
+            next_token_ids,
+            valid_count_out,
+            128,
+            num_sampled_per_req,
+            num_reqs,
+            sampled_token_ids.stride(0),
+            BLOCK_SIZE_TOKENS=block_size_tokens,
+        )
+
+        # ---- eagle_prepare_inputs_padded_kernel ----
+        # Called by base ``prepare_inputs_padded`` from the padded-batch
+        # path. No constexpr params -- grid dimension is the only variable
+        # and is not part of the JIT cache key.
+        cu_num_draft_tokens = torch.zeros(num_reqs, dtype=torch.int32, device=device)
+        valid_sampled_count = torch.zeros(num_reqs, dtype=torch.int32, device=device)
+        query_start_loc = torch.zeros(num_reqs + 1, dtype=torch.int32, device=device)
+        token_indices_to_sample = torch.empty(
+            num_reqs, dtype=torch.int32, device=device
+        )
+        num_rejected_tokens_gpu = torch.empty(
+            num_reqs, dtype=torch.int32, device=device
+        )
+        eagle_prepare_inputs_padded_kernel[(num_reqs,)](
+            cu_num_draft_tokens,
+            valid_sampled_count,
+            query_start_loc,
+            token_indices_to_sample,
+            num_rejected_tokens_gpu,
+            num_reqs,
+        )
+
+        # ---- copy_and_expand_eagle_inputs_kernel ----
+        # Called from base ``set_inputs_first_pass`` when
+        # ``needs_extra_input_slots`` is True (parallel-drafting Eagle and
+        # any DraftModelProposer config that allocates extra slots).
+        # DFlash takes a different path (its own kernel 5) and never
+        # touches this one, so skip it there.
+        if (
+            self.method != "dflash"
+            and self.is_rejected_token_mask is not None
+            and self.is_masked_token_mask is not None
+        ):
+            num_padding_slots_per_request = self.extra_slots_per_request
+            num_query_per_req = 1 + self.net_num_new_slots_per_request
+            total_input_tokens = num_reqs * num_query_per_req
+            total_output_tokens = num_reqs * (
+                num_query_per_req + num_padding_slots_per_request
+            )
+            # ``min(256, ...)`` mirrors the production cap so we hit the
+            # same JIT cache entry as the first real request.
+            block_size_tokens = min(256, next_power_of_2(total_output_tokens))
+
+            target_token_ids = torch.zeros(
+                total_input_tokens, dtype=torch.int32, device=device
+            )
+            target_positions = torch.zeros(
+                total_input_tokens, dtype=torch.int64, device=device
+            )
+            next_token_ids_buf = torch.zeros(num_reqs, dtype=torch.int32, device=device)
+            qsl = (
+                torch.arange(num_reqs + 1, dtype=torch.int32, device=device)
+                * num_query_per_req
+            )
+            qel = qsl[1:] - 1
+            tts_buf = torch.empty(
+                num_reqs * num_padding_slots_per_request,
+                dtype=torch.int32,
+                device=device,
+            )
+            ohsm_buf = torch.empty(total_input_tokens, dtype=torch.int32, device=device)
+
+            num_blocks = (
+                total_output_tokens + block_size_tokens - 1
+            ) // block_size_tokens
+            copy_and_expand_eagle_inputs_kernel[(num_reqs, num_blocks)](
+                target_token_ids_ptr=target_token_ids,
+                target_positions_ptr=target_positions,
+                next_token_ids_ptr=next_token_ids_buf,
+                out_input_ids_ptr=self.input_ids,
+                out_positions_ptr=self.positions,
+                out_is_rejected_token_mask_ptr=self.is_rejected_token_mask,
+                out_is_masked_token_mask_ptr=self.is_masked_token_mask,
+                out_new_token_indices_ptr=tts_buf,
+                out_hidden_state_mapping_ptr=ohsm_buf,
+                query_start_loc_ptr=qsl,
+                query_end_loc_ptr=qel,
+                padding_token_id=0,
+                parallel_drafting_token_id=self.parallel_drafting_token_id,
+                total_input_tokens=total_input_tokens,
+                num_padding_slots_per_request=num_padding_slots_per_request,
+                shift_input_ids=self.pass_hidden_states_to_model,
+                BLOCK_SIZE_TOKENS=block_size_tokens,
+            )
+
+            # The bool masks are read-only at first-real-request time on
+            # rows the first request will not overwrite, so reset them
+            # to the zero state ``__init__`` established to avoid leaking
+            # warmup writes.
+            self.is_rejected_token_mask.zero_()
+            self.is_masked_token_mask.zero_()
+
     def validate_same_kv_cache_group(self, kv_cache_config: KVCacheConfig) -> None:
         """
         Validate that all drafting layers belong to the same KVCacheGroup.

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -145,18 +145,6 @@ def warmup_kernels(
         worker_execute_model(decode_output)
         worker_sample_tokens(None)
 
-    # Warm spec-decode helper kernels that ``execute_model`` (above) does NOT
-    # exercise: the per-step Triton kernels in ``vllm/v1/spec_decode/utils.py``
-    # only run inside ``drafter.propose()``, which is skipped here because
-    # ``scheduled_spec_decode_tokens`` only simulates the verification side.
-    # Without this, the first real request pays the full JIT cost
-    # (vllm-project/vllm#39790). ``update_num_computed_tokens_for_batch_change``
-    # is V1-only, so it is warmed in ``Worker._warmup_spec_decode_helpers``
-    # rather than here.
-    drafter = getattr(model_runner, "drafter", None)
-    if drafter is not None and hasattr(drafter, "dry_run_helper_kernels"):
-        drafter.dry_run_helper_kernels()
-
     # Clean up - process finish_req_ids.
     cleanup_output = SchedulerOutput.make_empty()
     cleanup_output.finished_req_ids = set(req_ids)

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -145,6 +145,18 @@ def warmup_kernels(
         worker_execute_model(decode_output)
         worker_sample_tokens(None)
 
+    # Warm spec-decode helper kernels that ``execute_model`` (above) does NOT
+    # exercise: the per-step Triton kernels in ``vllm/v1/spec_decode/utils.py``
+    # only run inside ``drafter.propose()``, which is skipped here because
+    # ``scheduled_spec_decode_tokens`` only simulates the verification side.
+    # Without this, the first real request pays the full JIT cost
+    # (vllm-project/vllm#39790). ``update_num_computed_tokens_for_batch_change``
+    # is V1-only, so it is warmed in ``Worker._warmup_spec_decode_helpers``
+    # rather than here.
+    drafter = getattr(model_runner, "drafter", None)
+    if drafter is not None and hasattr(drafter, "dry_run_helper_kernels"):
+        drafter.dry_run_helper_kernels()
+
     # Clean up - process finish_req_ids.
     cleanup_output = SchedulerOutput.make_empty()
     cleanup_output.finished_req_ids = set(req_ids)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -720,6 +720,15 @@ class Worker(WorkerBase):
             else:
                 self.model_runner._dummy_sampler_run(hidden_states=last_hidden_states)
 
+            # Warm spec-decode helper kernels (vllm-project/vllm#39790).
+            # ``_dummy_run`` exercises the draft model forward but skips
+            # ``drafter.propose()``, so the per-step Triton kernels and the
+            # async-spec ``@torch.compile`` correction in
+            # ``vllm/v1/spec_decode/utils.py`` (and the
+            # ``update_num_computed_tokens_for_batch_change`` call in this
+            # runner) JIT on the first real request, spiking TTFT.
+            self._warmup_spec_decode_helpers()
+
         # Reset the seed to ensure that the random state is not affected by
         # the model initialization and profiling.
         set_random_seed(self.model_config.seed)
@@ -741,6 +750,52 @@ class Worker(WorkerBase):
             language_model=self.compilation_config.compilation_time,
             encoder=self.compilation_config.encoder_compilation_time,
         )
+
+    def _warmup_spec_decode_helpers(self) -> None:
+        """JIT-compile spec-decode helper kernels at warmup, not first request.
+
+        See ``vllm/v1/spec_decode/llm_base_proposer.py::dry_run_helper_kernels``
+        for the kernel inventory and rationale (vllm-project/vllm#39790).
+        """
+        drafter = getattr(self.model_runner, "drafter", None)
+        if drafter is None:
+            return
+        if hasattr(drafter, "dry_run_helper_kernels"):
+            drafter.dry_run_helper_kernels()
+
+        # Also warm the async-spec ``@torch.compile`` correction owned by
+        # the model runner (V1 only -- V2 does not call it).
+        if not getattr(self.model_runner, "use_async_spec_decode", False):
+            return
+        from vllm.v1.spec_decode.utils import (
+            update_num_computed_tokens_for_batch_change,
+        )
+
+        max_num_reqs = self.model_runner.max_num_reqs
+        device = self.device
+        prev_positions = torch.zeros(max_num_reqs, dtype=torch.int64, device=device)
+        valid_sampled_token_count = torch.zeros(
+            max_num_reqs, dtype=torch.int32, device=device
+        )
+        prev_num_draft_tokens = torch.zeros(
+            max_num_reqs, dtype=torch.int32, device=device
+        )
+        cpu_num_computed_tokens = torch.zeros(
+            max_num_reqs, dtype=torch.int32, device=device
+        )
+        update_num_computed_tokens_for_batch_change(
+            self.model_runner.num_computed_tokens,
+            self.model_runner.num_accepted_tokens.gpu[:max_num_reqs],
+            prev_positions,
+            valid_sampled_token_count,
+            prev_num_draft_tokens,
+            cpu_num_computed_tokens,
+        )
+        # Reset state we wrote so warmup does not leak into the first
+        # real request.
+        self.model_runner.num_computed_tokens.zero_()
+        self.model_runner.num_accepted_tokens.gpu.zero_()
+        torch.accelerator.synchronize()
 
     def reset_mm_cache(self) -> None:
         self.model_runner.reset_mm_cache()


### PR DESCRIPTION


## Summary

Fixes #39790. The spec-decode helper kernels in `vllm/v1/spec_decode/utils.py`
(5 `@triton.jit` kernels + 1 `@torch.compile` function) are not exercised by
the existing `_dummy_run` / `warmup_kernels` warmup paths because they only
run inside `drafter.propose()` and the model_runner's padded-batch input
prep — both of which the warmup never reaches. The first real request after
server start therefore pays the full JIT cost.

This PR adds a `dry_run_helper_kernels()` strategy method on
`SpecDecodeBaseProposer` that subclasses extend for their per-method
kernels, and wires it into both the V1 and V2 worker warmup paths. A V1-
only warmup of the async-spec `@torch.compile` correction
(`update_num_computed_tokens_for_batch_change`) is added in
`Worker._warmup_spec_decode_helpers`.

## Scope and honest framing

The original report enumerates 4 first-call cost sources; this PR addresses
**1 of the 4** (the `utils.py` kernels). Remaining sources called out by
@ccs668899 — FlashAttention drafter-shape autotune, drafter CUDA module
loading (~188 ms), lazy drafter KV/hidden-state allocation — are not
touched here and are good follow-up candidates.

## Files changed

- `vllm/v1/spec_decode/llm_base_proposer.py` — `dry_run_helper_kernels()`
  base implementation warms `eagle_prepare_next_token_padded_kernel`,
  `eagle_prepare_inputs_padded_kernel` (used by both Eagle and DFlash via
  base-class methods), and `copy_and_expand_eagle_inputs_kernel` when
  `needs_extra_input_slots=True` (parallel-drafting Eagle and
  `DraftModelProposer`).
- `vllm/v1/spec_decode/eagle.py` — `EagleProposer` override adds
  `eagle_step_update_slot_mapping_and_metadata` warmup, gated on
  `num_speculative_tokens > 1 and not parallel_drafting` so it only runs
  when sequential Eagle's inner draft loop will actually execute.
- `vllm/v1/spec_decode/dflash.py` — `DFlashProposer` override adds
  `copy_and_expand_dflash_inputs_kernel` warmup with both
  `HAS_NUM_REJECTED=True` and `False` constexpr variants.
- `vllm/v1/worker/gpu/warmup.py` — V2 path: invoke
  `drafter.dry_run_helper_kernels()` after the existing prefill+decode
  warmup.
- `vllm/v1/worker/gpu_worker.py` — V1 path: new
  `_warmup_spec_decode_helpers()` invoked after the post-`capture_model`
  `_dummy_run`. Also warms
  `update_num_computed_tokens_for_batch_change` (V1-only — V2 does not
  call it).
- `tests/v1/spec_decode/test_helper_kernel_warmup.py` — smoke tests pin
  the synthetic shapes against each kernel signature so future kernel
  changes break the test instead of silently regressing TTFT.

## Why this is not duplicating an existing PR

- #38326 (Ngram-proposer JIT warmup) — different proposer, different
  kernel set.
- #39483 (Triton stream-capture error in GDN+MTP cudagraph) — different
  bug class.
- #36634 (`warm_up_spec_before_capture` for GDN+MTP) — addresses a
  startup crash for a different decode method, not a TTFT regression.
- #39822 (Mamba2 SSD kernel warmup) — same conceptual pattern (pre-JIT
  warmup) but a disjoint kernel.

No open PR addresses #39790 (`gh pr list --search "39790 in:body"` and
`gh search prs --author ccs668899 --author KlyzhenkoVadim` came up
empty as of the PR open date). @ccs668899 publicly handed off the
investigation in an earlier comment.

## Test commands run

```bash
# Lint
.venv/bin/python -m pre_commit run --files \
  vllm/v1/spec_decode/llm_base_proposer.py \
  vllm/v1/spec_decode/eagle.py \
  vllm/v1/spec_decode/dflash.py \
  vllm/v1/worker/gpu/warmup.py \
  vllm/v1/worker/gpu_worker.py \
  tests/v1/spec_decode/test_helper_kernel_warmup.py

# Unit smoke tests on the synthetic shapes
.venv/bin/python -m pytest tests/v1/spec_decode/test_helper_kernel_warmup.py -v

# Existing eagle tests should remain green
.venv/bin/python -m pytest tests/v1/spec_decode/test_eagle.py -v
.venv/bin/python -m pytest tests/v1/spec_decode/test_eagle_step_kernel.py -v
```

## Benchmark (Qwen3-8B + Eagle3, 50 distinct synthetic prompts)

Cold cache (`/root/.cache/vllm/torch_compile_cache` cleared between runs).
Each row from `python bench_ttft.py --num-prompts 50 --max-output-tokens 8`,
`max_num_seqs=1`, `num_speculative_tokens=4`. Both runs on the same pod;
the only difference between rows is the 5 modified files reverted to
`HEAD~1` for the baseline row.

| Metric | Baseline (main @ c3868bbbe) | With this PR |
|---|---|---|
| TTFT prompt 1 (ms) | 2306.8 | 1372.7 |
| TTFT median prompts 2–50 (ms) | 270.8 | 271.8 |
| First/steady ratio | 8.52× | 5.05× |

Net effect: **TTFT for the first request after server start drops by
~934 ms (-40.5%)**, and the JIT spike-ratio drops from 8.52× to 5.05×.
Steady-state TTFT is unchanged (within noise).

The remaining 5.05× ratio is dominated by the 3 cost sources this PR
does not address (FlashAttention drafter-shape autotune, drafter CUDA
module loading, lazy drafter KV/hidden-state allocation), per
ccs668899's profiling in the issue thread.

Hardware: 1× RTX A6000 (driver 570.195, CUDA 13.0), torch 2.11+cu129,
vLLM @ `c3868bbbe` precompiled wheel.

## AI assistance disclosure

This change was developed with AI assistance (Claude). The submitting
author reviewed every changed line and ran the test commands above; the
non-obvious decisions (kernel ownership in base vs. subclass; cache-key
analysis to choose synthetic shapes; bool-mask reset to avoid leaking
warmup state into the first real request) are documented inline.