### PR TITLE
[Spec Decode] Don't compile `update_num_computed_tokens_for_batch_change`

### DIFF
--- a/vllm/v1/spec_decode/utils.py
+++ b/vllm/v1/spec_decode/utils.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import torch
 
-from vllm.platforms import current_platform
 from vllm.triton_utils import tl, triton
 from vllm.v1.attention.backends.utils import (
     CommonAttentionMetadata,
@@ -563,7 +562,6 @@ def copy_and_expand_dflash_inputs_kernel(
     )
 
 
-@torch.compile(dynamic=True, backend=current_platform.simple_compile_backend)
 def update_num_computed_tokens_for_batch_change(
     num_computed_tokens: torch.Tensor,
     num_accepted_tokens: torch.Tensor,


### PR DESCRIPTION


Fix #39940

## Purpose
It seems that `update_num_computed_tokens_for_batch_change` is such a brief op that the per-call overhead of torch compile (dynamo guard checks, dispatch) outweighs the benefit. Eliminating this compilation is sufficient to eliminate the TPOT regression from #32951 described in #39940 

Note that this is NOT sufficient to restore current TOT performance to v0.18.0 levels for this benchmark.

## Test Plan

```
vllm serve meta-llama/Llama-3.1-8B-Instruct \
	-tp 4 \
	--max-model-len 8192 \
	--speculative-config '{"method":"eagle3","model":"RedHatAI/Llama-3.1-8B-Instruct-speculator.eagle3","num_speculative_tokens":3,"draft_tensor_parallel_size":1}'
```
with
```
vllm bench serve \
    --dataset-name sonnet \
    --dataset-path sonnet.txt \
    --sonnet-input-len 4096 \
    --sonnet-output-len 512 \
    --sonnet-prefix-len 0 \
    --num-prompts 100 \
    --request-rate 1
```

## Test Result
| | Mean TPOT (ms) | Median TPOT (ms) | P99 TPOT (ms) |
|---|---|---|---|
| Before PR (`fafe76b4a^`) | 2.62 | 2.59 | 3.24 |
| After PR (`fafe76b4a`) | 2.82 | 2.79 | 3.67 |
| **After PR + fix** | **2.63** | **2.62** | **2.89** |
| Main baseline | 2.74 | 2.75 | 3.00 |
| Main + fix | 2.75 | 2.76 | 3.21 |

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

