### PR TITLE
[codex] Fix ModelScope remote GGUF quant loading

### DIFF
--- a/tests/models/test_gguf_download.py
+++ b/tests/models/test_gguf_download.py
@@ -35,9 +35,13 @@ class TestGGUFDownload:
                 cache_dir=None,
                 allow_patterns=[
                     "*-IQ1_S.gguf",
+                    "*.IQ1_S.gguf",
                     "*-IQ1_S-*.gguf",
+                    "*.IQ1_S-*.gguf",
                     "*/*-IQ1_S.gguf",
+                    "*/*.IQ1_S.gguf",
                     "*/*-IQ1_S-*.gguf",
+                    "*/*.IQ1_S-*.gguf",
                 ],
                 revision=None,
                 ignore_patterns=None,
@@ -45,6 +49,68 @@ class TestGGUFDownload:
 
             # Verify result is the file path, not folder
             assert result == f"{mock_folder}/model-IQ1_S.gguf"
+
+    @patch("vllm.model_executor.model_loader.weight_utils.download_weights_from_hf")
+    def test_download_gguf_dot_quant_suffix(self, mock_download):
+        """Test GGUF repos whose quant suffix is separated by a dot."""
+        mock_folder = "/tmp/mock_cache"
+        mock_download.return_value = mock_folder
+
+        with patch("glob.glob") as mock_glob:
+            mock_glob.side_effect = lambda pattern, **kwargs: (
+                [f"{mock_folder}/model.Q4_K_M.gguf"] if ".Q4_K_M" in pattern else []
+            )
+
+            result = download_gguf("hesamation/model-GGUF", "Q4_K_M")
+
+            assert result == f"{mock_folder}/model.Q4_K_M.gguf"
+
+    @patch("vllm.model_executor.model_loader.weight_utils.download_weights_from_hf")
+    @patch(
+        "vllm.model_executor.model_loader.weight_utils.maybe_download_from_modelscope"
+    )
+    def test_download_gguf_modelscope_uses_selected_patterns(
+        self,
+        mock_modelscope_download,
+        mock_hf_download,
+        monkeypatch,
+    ):
+        """Test ModelScope downloads only the selected GGUF quant files."""
+        monkeypatch.setenv("VLLM_USE_MODELSCOPE", "True")
+        mock_folder = "/tmp/mock_cache"
+        mock_modelscope_download.return_value = mock_folder
+
+        with patch("glob.glob") as mock_glob:
+            mock_glob.side_effect = lambda pattern, **kwargs: (
+                [f"{mock_folder}/model.Q4_K_M.gguf"] if ".Q4_K_M" in pattern else []
+            )
+
+            result = download_gguf(
+                "hesamation/model-GGUF",
+                "Q4_K_M",
+                cache_dir="/cache",
+                revision="master",
+                ignore_patterns=["original/**/*"],
+            )
+
+            assert result == f"{mock_folder}/model.Q4_K_M.gguf"
+            mock_modelscope_download.assert_called_once_with(
+                model="hesamation/model-GGUF",
+                revision="master",
+                download_dir="/cache",
+                ignore_patterns=["original/**/*"],
+                allow_patterns=[
+                    "*-Q4_K_M.gguf",
+                    "*.Q4_K_M.gguf",
+                    "*-Q4_K_M-*.gguf",
+                    "*.Q4_K_M-*.gguf",
+                    "*/*-Q4_K_M.gguf",
+                    "*/*.Q4_K_M.gguf",
+                    "*/*-Q4_K_M-*.gguf",
+                    "*/*.Q4_K_M-*.gguf",
+                ],
+            )
+            mock_hf_download.assert_not_called()
 
     @patch("vllm.model_executor.model_loader.weight_utils.download_weights_from_hf")
     def test_download_gguf_sharded_files(self, mock_download):

--- a/tests/models/test_gguf_download.py
+++ b/tests/models/test_gguf_download.py
@@ -1,14 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
 
 from vllm.config import ModelConfig
 from vllm.config.load import LoadConfig
 from vllm.model_executor.model_loader.gguf_loader import GGUFModelLoader
 from vllm.model_executor.model_loader.weight_utils import download_gguf
+from vllm.model_executor.models.qwen3_5 import (
+    _load_gguf_tuple_shard,
+    _maybe_unsqueeze_single_output_weight,
+)
 
 
 class TestGGUFDownload:
@@ -164,6 +170,264 @@ class TestGGUFDownload:
 
 class TestGGUFModelLoader:
     """Test GGUFModelLoader class methods."""
+
+    @patch("vllm.model_executor.model_loader.gguf_loader.AutoModelForImageTextToText")
+    def test_qwen35_moe_gguf_mapping(self, mock_auto_model):
+        """Test Qwen3.5-MoE maps GGUF names to loadable expert tensors."""
+
+        class DummyTensorNameMap:
+            def get_name(self, name: str):
+                if name == "model.norm":
+                    return "output_norm"
+                return None
+
+        class DummyModel:
+            _checkpoint_conversion_mapping = None
+
+            def state_dict(self):
+                return {
+                    "model.language_model.layers.0.linear_attn.dt_bias": torch.empty(
+                        32,
+                        device="meta",
+                    ),
+                    "model.language_model.layers.0.mlp.experts.gate_up_proj": (
+                        torch.empty(256, 1024, 2048, device="meta")
+                    ),
+                }
+
+        mock_auto_model.from_config.return_value = DummyModel()
+
+        hf_config = MagicMock()
+        hf_config.model_type = "qwen3_5_moe"
+        hf_config.vision_config = SimpleNamespace(num_hidden_layers=0)
+        hf_config.get_text_config.return_value = SimpleNamespace(num_hidden_layers=1)
+
+        model_config = MagicMock()
+        model_config.hf_config = hf_config
+        model_config.trust_remote_code = False
+        model_config.multimodal_config = SimpleNamespace(language_model_only=False)
+
+        load_config = LoadConfig(load_format="gguf")
+        loader = GGUFModelLoader(load_config)
+
+        with patch(
+            "vllm.model_executor.model_loader.gguf_loader.gguf.get_tensor_name_map",
+            return_value=DummyTensorNameMap(),
+        ):
+            mapping = loader._get_gguf_weights_map(model_config)
+
+        assert mapping["blk.0.ffn_gate_exps.weight"] == (
+            "model.language_model.layers.0.mlp.experts.0.gate_proj.weight"
+        )
+        assert mapping["blk.0.ffn_up_exps.weight"] == (
+            "model.language_model.layers.0.mlp.experts.0.up_proj.weight"
+        )
+        assert mapping["blk.0.ffn_down_exps.weight"] == (
+            "model.language_model.layers.0.mlp.experts.0.down_proj.weight"
+        )
+        assert mapping["blk.0.ssm_dt.bias"] == (
+            "model.language_model.layers.0.linear_attn.dt_bias"
+        )
+
+    @patch("vllm.model_executor.model_loader.gguf_loader.AutoModelForCausalLM")
+    def test_qwen35_moe_gguf_language_model_only_mapping(self, mock_auto_model):
+        """Test Qwen3.5-MoE text-only GGUF names avoid multimodal prefixes."""
+
+        class DummyTensorNameMap:
+            def get_name(self, name: str):
+                if name == "model.norm":
+                    return "output_norm"
+                return None
+
+        class DummyModel:
+            _checkpoint_conversion_mapping = None
+
+            def state_dict(self):
+                return {
+                    "model.layers.0.linear_attn.dt_bias": torch.empty(
+                        32,
+                        device="meta",
+                    ),
+                    "model.layers.0.mlp.experts.gate_up_proj": torch.empty(
+                        256,
+                        1024,
+                        2048,
+                        device="meta",
+                    ),
+                    "model.norm.weight": torch.empty(2048, device="meta"),
+                }
+
+        mock_auto_model.from_config.return_value = DummyModel()
+
+        hf_config = MagicMock()
+        hf_config.model_type = "qwen3_5_moe"
+        hf_config.vision_config = SimpleNamespace(depth=27)
+        hf_config.get_text_config.return_value = SimpleNamespace(num_hidden_layers=1)
+
+        model_config = MagicMock()
+        model_config.hf_config = hf_config
+        model_config.trust_remote_code = False
+        model_config.multimodal_config = SimpleNamespace(language_model_only=True)
+
+        load_config = LoadConfig(load_format="gguf")
+        loader = GGUFModelLoader(load_config)
+
+        with patch(
+            "vllm.model_executor.model_loader.gguf_loader.gguf.get_tensor_name_map",
+            return_value=DummyTensorNameMap(),
+        ):
+            mapping = loader._get_gguf_weights_map(model_config)
+
+        assert mapping["blk.0.ffn_gate_exps.weight"] == (
+            "model.language_model.layers.0.mlp.experts.0.gate_proj.weight"
+        )
+        assert mapping["blk.0.ssm_dt.bias"] == (
+            "model.language_model.layers.0.linear_attn.dt_bias"
+        )
+        assert mapping["output_norm.weight"] == "model.language_model.norm.weight"
+
+    @patch("vllm.model_executor.model_loader.gguf_loader.detect_gguf_multimodal")
+    @patch(
+        "vllm.model_executor.model_loader.gguf_loader.get_gguf_weight_type_map",
+        return_value={"model.layers.0.mlp.experts.0.gate_proj.weight": "Q4_K"},
+    )
+    def test_language_model_only_weight_types_skip_mmproj(
+        self, mock_get_weight_type_map, mock_detect_mm
+    ):
+        """Test text-only multimodal configs do not require an mm_proj file."""
+
+        hf_config = MagicMock()
+        hf_config.vision_config = SimpleNamespace(depth=27)
+
+        model_config = MagicMock()
+        model_config.hf_config = hf_config
+        model_config.multimodal_config = SimpleNamespace(language_model_only=True)
+
+        load_config = LoadConfig(load_format="gguf")
+        loader = GGUFModelLoader(load_config)
+
+        weight_type_map = loader._get_gguf_weight_type(
+            model_config,
+            "/tmp/model.gguf",
+            {
+                "blk.0.ffn_gate_exps.weight": (
+                    "model.layers.0.mlp.experts.0.gate_proj.weight"
+                )
+            },
+        )
+
+        assert weight_type_map == {
+            "model.layers.0.mlp.experts.0.gate_proj.weight": "Q4_K"
+        }
+        mock_get_weight_type_map.assert_called_once()
+        mock_detect_mm.assert_not_called()
+
+    @patch("vllm.model_executor.model_loader.gguf_loader.detect_gguf_multimodal")
+    @patch(
+        "vllm.model_executor.model_loader.gguf_loader.gguf_quant_weights_iterator",
+        return_value=iter([("model.layers.0.linear_attn.dt_bias", torch.empty(1))]),
+    )
+    def test_language_model_only_weights_iterator_skips_mmproj(
+        self, mock_weight_iter, mock_detect_mm
+    ):
+        """Test text-only multimodal configs load only the main GGUF file."""
+
+        hf_config = MagicMock()
+        hf_config.vision_config = SimpleNamespace(depth=27)
+
+        model_config = MagicMock()
+        model_config.hf_config = hf_config
+        model_config.multimodal_config = SimpleNamespace(language_model_only=True)
+
+        load_config = LoadConfig(load_format="gguf")
+        loader = GGUFModelLoader(load_config)
+
+        weights = list(
+            loader._get_weights_iterator(
+                model_config,
+                "/tmp/model.gguf",
+                {"blk.0.ssm_dt.bias": "model.layers.0.linear_attn.dt_bias"},
+            )
+        )
+
+        assert weights[0][0] == "model.layers.0.linear_attn.dt_bias"
+        mock_weight_iter.assert_called_once()
+        mock_detect_mm.assert_not_called()
+
+    def test_qwen35_gguf_tuple_shard_weight_splits(self):
+        """Test Qwen3.5 GGUF qkv tuple shards are loaded one shard at a time."""
+
+        calls = []
+
+        class DummyLoader:
+            output_sizes = [2, 3, 4]
+
+            def weight_loader(self, param, loaded_weight, shard_id):
+                calls.append((loaded_weight.clone(), shard_id))
+
+        param = torch.nn.Parameter(torch.empty(0), requires_grad=False)
+        param.is_gguf_weight = True
+        param.output_dim = 0
+        loaded_weight = torch.arange(18).view(9, 2)
+
+        handled = _load_gguf_tuple_shard(
+            param,
+            loaded_weight,
+            (0, 1, 2),
+            DummyLoader().weight_loader,
+        )
+
+        assert handled
+        assert [shard_id for _, shard_id in calls] == [0, 1, 2]
+        assert [weight.shape[0] for weight, _ in calls] == [2, 3, 4]
+        assert torch.equal(calls[1][0], loaded_weight[2:5])
+
+    def test_qwen35_gguf_tuple_shard_weight_type_reuses_scalar(self):
+        """Test tuple qweight_type shards reuse the same GGUF type scalar."""
+
+        calls = []
+
+        class DummyLoader:
+            output_sizes = [2, 3, 4]
+
+            def weight_loader(self, param, loaded_weight, shard_id):
+                calls.append((loaded_weight, shard_id))
+
+        param = torch.nn.Parameter(torch.empty(0), requires_grad=False)
+        param.is_gguf_weight_type = True
+        loaded_weight = torch.tensor(12)
+
+        handled = _load_gguf_tuple_shard(
+            param,
+            loaded_weight,
+            (0, 1, 2),
+            DummyLoader().weight_loader,
+        )
+
+        assert handled
+        assert calls == [(loaded_weight, 0), (loaded_weight, 1), (loaded_weight, 2)]
+
+    def test_qwen35_gguf_single_output_weight_unsqueeze(self):
+        """Test single-output GGUF tensors match vLLM's 2D gate params."""
+
+        param = torch.nn.Parameter(torch.empty(1, 2048), requires_grad=False)
+        loaded_weight = torch.empty(2048)
+
+        reshaped = _maybe_unsqueeze_single_output_weight(param, loaded_weight)
+
+        assert reshaped.shape == torch.Size([1, 2048])
+        assert reshaped.data_ptr() == loaded_weight.data_ptr()
+
+    def test_qwen35_gguf_conv_weight_unsqueeze(self):
+        """Test GGUF conv tensors match vLLM's singleton channel dim."""
+
+        param = torch.nn.Parameter(torch.empty(2048, 1, 4), requires_grad=False)
+        loaded_weight = torch.empty(2048, 4)
+
+        reshaped = _maybe_unsqueeze_single_output_weight(param, loaded_weight)
+
+        assert reshaped.shape == torch.Size([2048, 1, 4])
+        assert reshaped.data_ptr() == loaded_weight.data_ptr()
 
     @patch("os.path.isfile", return_value=True)
     def test_prepare_weights_local_file(self, mock_isfile):

--- a/tests/tokenizers_/test_registry.py
+++ b/tests/tokenizers_/test_registry.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import sys
+import types
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -75,3 +78,47 @@ def test_customized_tokenizer():
     assert tokenizer.bos_token_id == 0
     assert tokenizer.eos_token_id == 1
     assert tokenizer.pad_token_id == 2
+
+
+def test_modelscope_remote_gguf_tokenizer_preserves_quant_selector(monkeypatch):
+    calls = []
+
+    def fake_snapshot_download(**kwargs):
+        calls.append(kwargs)
+        return "/tmp/modelscope/repo"
+
+    snapshot_module = types.ModuleType("modelscope.hub.snapshot_download")
+    snapshot_module.snapshot_download = fake_snapshot_download
+    hub_module = types.ModuleType("modelscope.hub")
+    hub_module.snapshot_download = snapshot_module
+    modelscope_module = types.ModuleType("modelscope")
+    modelscope_module.hub = hub_module
+
+    with monkeypatch.context() as m:
+        m.setenv("VLLM_USE_MODELSCOPE", "True")
+        m.setitem(sys.modules, "modelscope", modelscope_module)
+        m.setitem(sys.modules, "modelscope.hub", hub_module)
+        m.setitem(sys.modules, "modelscope.hub.snapshot_download", snapshot_module)
+
+        with patch(
+            "vllm.tokenizers.registry.get_gguf_file_path_from_hf",
+            return_value="model.Q4_K_M.gguf",
+        ):
+            _, tokenizer_name, _, kwargs = resolve_tokenizer_args(
+                "owner/repo-GGUF:Q4_K_M",
+                revision="main",
+                download_dir="/tmp/cache",
+            )
+
+    assert tokenizer_name == "/tmp/modelscope/repo"
+    assert kwargs["gguf_file"] == "model.Q4_K_M.gguf"
+    assert calls == [
+        {
+            "model_id": "owner/repo-GGUF",
+            "cache_dir": "/tmp/cache",
+            "revision": "main",
+            "local_files_only": False,
+            "ignore_file_pattern": None,
+            "allow_patterns": "model.Q4_K_M.gguf",
+        }
+    ]

--- a/tests/transformers_utils/test_config.py
+++ b/tests/transformers_utils/test_config.py
@@ -6,8 +6,17 @@ only get the `eos_token_id` from the tokenizer as defined by
 `BaseRenderer.get_eos_token_id`.
 """
 
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import vllm.transformers_utils.config as config_module
 from vllm.tokenizers import get_tokenizer
-from vllm.transformers_utils.config import try_get_generation_config
+from vllm.transformers_utils.config import (
+    maybe_override_with_speculators,
+    try_get_generation_config,
+)
 
 
 def test_get_llama3_eos_token():
@@ -30,3 +39,39 @@ def test_get_blip2_eos_token():
     generation_config = try_get_generation_config(model_name, trust_remote_code=False)
     assert generation_config is not None
     assert generation_config.eos_token_id == 50118
+
+
+def test_maybe_override_with_speculators_gguf_quant_modelscope_no_path_replace_crash(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    model = "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF:Q4_K_M"
+    calls: list[Any] = []
+
+    def fake_get_config_dict(model_arg: Any, **kwargs: Any):
+        if isinstance(model_arg, Path):
+            raise TypeError(
+                "Path.replace() takes 2 positional arguments but 3 were given"
+            )
+        calls.append(model_arg)
+        return {}, None
+
+    monkeypatch.setattr(
+        config_module.PretrainedConfig,
+        "get_config_dict",
+        staticmethod(fake_get_config_dict),
+    )
+
+    resolved_model, resolved_tokenizer, speculative_config = (
+        maybe_override_with_speculators(
+            model=model,
+            tokenizer=None,
+            trust_remote_code=False,
+        )
+    )
+
+    assert calls == [
+        "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF"
+    ]
+    assert resolved_model == model
+    assert resolved_tokenizer is None
+    assert speculative_config is None

--- a/tests/transformers_utils/test_config.py
+++ b/tests/transformers_utils/test_config.py
@@ -6,6 +6,8 @@ only get the `eos_token_id` from the tokenizer as defined by
 `BaseRenderer.get_eos_token_id`.
 """
 
+import sys
+import types
 from pathlib import Path
 from typing import Any
 
@@ -45,16 +47,17 @@ def test_maybe_override_with_speculators_gguf_quant_modelscope_no_path_replace_c
     monkeypatch: pytest.MonkeyPatch,
 ):
     model = "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF:Q4_K_M"
-    calls: list[Any] = []
+    calls: list[tuple[Any, dict[str, Any]]] = []
 
     def fake_get_config_dict(model_arg: Any, **kwargs: Any):
         if isinstance(model_arg, Path):
             raise TypeError(
                 "Path.replace() takes 2 positional arguments but 3 were given"
             )
-        calls.append(model_arg)
+        calls.append((model_arg, kwargs))
         return {}, None
 
+    monkeypatch.setenv("VLLM_USE_MODELSCOPE", "True")
     monkeypatch.setattr(
         config_module.PretrainedConfig,
         "get_config_dict",
@@ -69,9 +72,71 @@ def test_maybe_override_with_speculators_gguf_quant_modelscope_no_path_replace_c
         )
     )
 
-    assert calls == [
+    assert len(calls) == 1
+    model_arg, kwargs = calls[0]
+    assert model_arg == (
         "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF"
-    ]
+    )
+    assert "*.gguf" in kwargs["ignore_file_pattern"]
     assert resolved_model == model
     assert resolved_tokenizer is None
     assert speculative_config is None
+
+
+def test_modelscope_remote_gguf_config_downloads_selected_file(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    model = "hesamation/model-GGUF:Q4_K_M"
+    kwargs: dict[str, Any] = {}
+    calls: list[dict[str, Any]] = []
+
+    def fake_get_gguf_file_path_from_hf(
+        repo_id: str,
+        quant_type: str,
+        *,
+        revision: str | None = None,
+    ):
+        assert repo_id == "hesamation/model-GGUF"
+        assert quant_type == "Q4_K_M"
+        assert revision == "master"
+        return "model.Q4_K_M.gguf"
+
+    def fake_snapshot_download(**snapshot_kwargs: Any):
+        calls.append(snapshot_kwargs)
+        return "/cache/model-GGUF"
+
+    modelscope_module = types.ModuleType("modelscope")
+    hub_module = types.ModuleType("modelscope.hub")
+    snapshot_module = types.ModuleType("modelscope.hub.snapshot_download")
+    snapshot_module.snapshot_download = fake_snapshot_download
+    hub_module.snapshot_download = snapshot_module
+    modelscope_module.hub = hub_module
+    monkeypatch.setitem(sys.modules, "modelscope", modelscope_module)
+    monkeypatch.setitem(sys.modules, "modelscope.hub", hub_module)
+    monkeypatch.setitem(
+        sys.modules,
+        "modelscope.hub.snapshot_download",
+        snapshot_module,
+    )
+    monkeypatch.setattr(
+        config_module,
+        "get_gguf_file_path_from_hf",
+        fake_get_gguf_file_path_from_hf,
+    )
+
+    resolved = config_module._localize_modelscope_remote_gguf_for_config(
+        model,
+        "master",
+        kwargs,
+    )
+
+    assert resolved == "/cache/model-GGUF"
+    assert kwargs["gguf_file"] == "model.Q4_K_M.gguf"
+    assert calls == [
+        {
+            "model_id": "hesamation/model-GGUF",
+            "revision": "master",
+            "local_files_only": False,
+            "allow_patterns": "model.Q4_K_M.gguf",
+        }
+    ]

--- a/tests/transformers_utils/test_config.py
+++ b/tests/transformers_utils/test_config.py
@@ -140,3 +140,104 @@ def test_modelscope_remote_gguf_config_downloads_selected_file(
             "allow_patterns": "model.Q4_K_M.gguf",
         }
     ]
+
+
+def test_ensure_transformers_can_check_gguf_version(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from transformers.utils import import_utils
+
+    calls: list[str] = []
+
+    class DummyIsGGUFAvailable:
+        def cache_clear(self):
+            calls.append("cache_clear")
+
+    monkeypatch.delitem(
+        import_utils.PACKAGE_DISTRIBUTION_MAPPING,
+        "gguf",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        import_utils,
+        "is_gguf_available",
+        DummyIsGGUFAvailable(),
+    )
+
+    config_module._ensure_transformers_can_check_gguf_version()
+
+    assert import_utils.PACKAGE_DISTRIBUTION_MAPPING["gguf"] == ["gguf"]
+    assert calls == ["cache_clear"]
+
+
+def test_get_gguf_base_model_id_for_config(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    gguf_file = tmp_path / "model.Q4_K_M.gguf"
+    gguf_file.touch()
+
+    monkeypatch.setattr(
+        config_module,
+        "get_gguf_base_model_id",
+        lambda path: "Qwen/Qwen3.6-35B-A3B",
+    )
+
+    assert (
+        config_module._get_gguf_base_model_id_for_config(
+            tmp_path,
+            {"gguf_file": gguf_file.name},
+        )
+        == "Qwen/Qwen3.6-35B-A3B"
+    )
+
+
+def test_get_config_falls_back_to_gguf_base_model(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    from transformers import PretrainedConfig
+
+    gguf_file = tmp_path / "model.Q4_K_M.gguf"
+    gguf_file.touch()
+    calls: list[Any] = []
+
+    class DummyParser:
+        def parse(self, model: Any, **kwargs: Any):
+            calls.append((model, kwargs))
+            if kwargs.get("gguf_file") == gguf_file.name:
+                raise ValueError(
+                    "GGUF model with architecture qwen35moe is not supported yet."
+                )
+            return {"model_type": "qwen3_5_moe"}, PretrainedConfig(
+                model_type="qwen3_5_moe",
+            )
+
+    monkeypatch.setattr(
+        config_module,
+        "check_gguf_file",
+        lambda model: str(model).endswith(".gguf"),
+    )
+    monkeypatch.setattr(
+        config_module,
+        "is_gguf",
+        lambda model: str(model).endswith(".gguf"),
+    )
+    monkeypatch.setattr(config_module, "is_remote_gguf", lambda model: False)
+    monkeypatch.setattr(config_module, "get_config_parser", lambda _: DummyParser())
+    monkeypatch.setattr(
+        config_module,
+        "_get_gguf_base_model_id_for_config",
+        lambda model, kwargs: "Qwen/Qwen3.6-35B-A3B",
+    )
+
+    config = config_module.get_config(
+        gguf_file,
+        trust_remote_code=False,
+        config_format="hf",
+    )
+
+    assert config._vllm_gguf_base_model_id == "Qwen/Qwen3.6-35B-A3B"
+    assert calls[0][0] == tmp_path
+    assert calls[1][0] == "Qwen/Qwen3.6-35B-A3B"
+    assert "gguf_file" not in calls[1][1]

--- a/tests/transformers_utils/test_utils.py
+++ b/tests/transformers_utils/test_utils.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from vllm.transformers_utils.gguf_utils import (
+    get_gguf_file_path_from_hf,
     is_gguf,
     is_remote_gguf,
     split_remote_gguf,
@@ -193,6 +194,35 @@ class TestSplitRemoteGGUF:
         # Cloud storage - is_remote_gguf returns False
         with pytest.raises(ValueError, match="Wrong GGUF model"):
             split_remote_gguf("s3://bucket/repo/model:Q2_K")
+
+
+class TestGetGGUFFilePathFromHF:
+    @patch("vllm.transformers_utils.gguf_utils.list_filtered_repo_files")
+    def test_get_gguf_file_path_matches_dot_quant_suffix(self, mock_list_files):
+        mock_list_files.return_value = [
+            "Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled.Q4_K_M.gguf"
+        ]
+
+        result = get_gguf_file_path_from_hf(
+            "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
+            "Q4_K_M",
+        )
+
+        assert result.endswith(".Q4_K_M.gguf")
+        mock_list_files.assert_called_once_with(
+            "hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF",
+            allow_patterns=[
+                "*-Q4_K_M.gguf",
+                "*.Q4_K_M.gguf",
+                "*-Q4_K_M-*.gguf",
+                "*.Q4_K_M-*.gguf",
+                "*/*-Q4_K_M.gguf",
+                "*/*.Q4_K_M.gguf",
+                "*/*-Q4_K_M-*.gguf",
+                "*/*.Q4_K_M-*.gguf",
+            ],
+            revision=None,
+        )
 
 
 class TestIsGGUF:

--- a/vllm/config/model.py
+++ b/vllm/config/model.py
@@ -466,6 +466,7 @@ class ModelConfig:
         )
         self.model = maybe_model_redirect(self.model)
         # The tokenizer is consistent with the model by default.
+        tokenizer_was_default = self.tokenizer is None
         if self.tokenizer is None:
             self.tokenizer = self.model
         if self.tokenizer_revision is None:
@@ -516,6 +517,14 @@ class ModelConfig:
             self.model,
             hf_config,
         )
+        gguf_base_model_id = getattr(hf_config, "_vllm_gguf_base_model_id", None)
+        if (
+            tokenizer_was_default
+            and language_model_only
+            and isinstance(gguf_base_model_id, str)
+            and is_gguf(self.tokenizer)
+        ):
+            self.tokenizer = maybe_model_redirect(gguf_base_model_id)
 
         self.hf_config = hf_config
         if dict_overrides:

--- a/vllm/model_executor/model_loader/gguf_loader.py
+++ b/vllm/model_executor/model_loader/gguf_loader.py
@@ -100,6 +100,17 @@ class GGUFModelLoader(BaseModelLoader):
             logger.info("Discovered %d GGUF shard files", len(files))
         return files if files else [model_path]
 
+    @staticmethod
+    def _is_multimodal_model_config(model_config: ModelConfig) -> bool:
+        hf_config = model_config.hf_config
+        mm_config = getattr(model_config, "multimodal_config", None)
+        language_model_only = getattr(mm_config, "language_model_only", False)
+        return (
+            hasattr(hf_config, "vision_config")
+            and hf_config.vision_config is not None
+            and not language_model_only
+        )
+
     def _get_gguf_weights_map(self, model_config: ModelConfig):
         """
         GGUF uses this naming convention for their tensors from HF checkpoint:
@@ -116,9 +127,10 @@ class GGUFModelLoader(BaseModelLoader):
         # models, this returns config itself.
         text_config = config.get_text_config()
         model_type = config.model_type
-        is_multimodal = (
+        has_multimodal_wrapper = (
             hasattr(config, "vision_config") and config.vision_config is not None
         )
+        is_multimodal = self._is_multimodal_model_config(model_config)
         gguf_to_hf_name_map = {}
         sideload_params: list[re.Pattern] = []
         # hack: ggufs have a different name than transformers
@@ -149,6 +161,37 @@ class GGUFModelLoader(BaseModelLoader):
                     re.compile(
                         f"model\\.layers\\.{idx}"
                         r"\.mlp\.experts\.[0-9]+\.(gate|up|down)_proj\.weight"
+                    )
+                )
+        if model_type == "qwen3_5_moe":
+            model_type = "qwen35moe"
+            # GGUF stores Qwen3.5-MoE expert gate/up weights as separate
+            # tensors, while the HF dummy model exposes a packed expert
+            # parameter. Map the GGUF tensors to per-expert HF names so the
+            # FusedMoE loader can place w1/w3 into the merged vLLM parameter.
+            hf_layer_prefix = (
+                "model.language_model.layers"
+                if has_multimodal_wrapper
+                else "model.layers"
+            )
+            for idx in range(text_config.num_hidden_layers):
+                hf_expert_prefix = f"{hf_layer_prefix}.{idx}.mlp.experts.0"
+                gguf_to_hf_name_map[f"blk.{idx}.ffn_down_exps.weight"] = (
+                    f"{hf_expert_prefix}.down_proj.weight"
+                )
+                gguf_to_hf_name_map[f"blk.{idx}.ffn_gate_exps.weight"] = (
+                    f"{hf_expert_prefix}.gate_proj.weight"
+                )
+                gguf_to_hf_name_map[f"blk.{idx}.ffn_up_exps.weight"] = (
+                    f"{hf_expert_prefix}.up_proj.weight"
+                )
+                gguf_to_hf_name_map[f"blk.{idx}.ssm_dt.bias"] = (
+                    f"{hf_layer_prefix}.{idx}.linear_attn.dt_bias"
+                )
+                sideload_params.append(
+                    re.compile(
+                        re.escape(f"{hf_layer_prefix}.{idx}")
+                        + r"\.mlp\.experts\.(gate_up_proj|down_proj)"
                     )
                 )
         if model_type in ("qwen2_moe", "qwen3_moe"):
@@ -207,7 +250,9 @@ class GGUFModelLoader(BaseModelLoader):
 
         if is_multimodal:
             mm_proj_arch = gguf.MODEL_ARCH.MMPROJ
-            vision_num_layers = config.vision_config.num_hidden_layers
+            vision_num_layers = getattr(config.vision_config, "num_hidden_layers", None)
+            if vision_num_layers is None:
+                vision_num_layers = config.vision_config.depth
             vision_name_map = gguf.get_tensor_name_map(mm_proj_arch, vision_num_layers)
         else:
             vision_name_map = None
@@ -219,9 +264,10 @@ class GGUFModelLoader(BaseModelLoader):
         auto_cls = (
             AutoModelForImageTextToText if is_multimodal else AutoModelForCausalLM
         )
+        dummy_config = config if is_multimodal else text_config
         with torch.device("meta"):
             dummy_model = auto_cls.from_config(
-                config, trust_remote_code=model_config.trust_remote_code
+                dummy_config, trust_remote_code=model_config.trust_remote_code
             )
 
         state_dict = dummy_model.state_dict()
@@ -313,14 +359,21 @@ class GGUFModelLoader(BaseModelLoader):
         unmapped_params = []
         for hf_name in state_dict:
             gguf_name_with_suffix = find_hf_name_in_tensor_map(hf_name)
+            target_hf_name = hf_name
+            if (
+                has_multimodal_wrapper
+                and not is_multimodal
+                and hf_name.startswith("model.")
+            ):
+                target_hf_name = "model.language_model." + hf_name[6:]
 
             # Track mapping success
             if gguf_name_with_suffix is not None:
-                gguf_to_hf_name_map[gguf_name_with_suffix] = hf_name
+                gguf_to_hf_name_map[gguf_name_with_suffix] = target_hf_name
                 logger.debug("Mapped GGUF %s → HF %s", gguf_name_with_suffix, hf_name)
-            elif hf_name not in gguf_to_hf_name_map.values():
+            elif target_hf_name not in gguf_to_hf_name_map.values():
                 # Parameter not in manual overrides either
-                unmapped_params.append(hf_name)
+                unmapped_params.append(target_hf_name)
 
         # All parameters (except those initialized by other means) must be mapped:
         # both vision/projector and backbone
@@ -349,7 +402,7 @@ class GGUFModelLoader(BaseModelLoader):
         weight_type_map = {}
         for f in gguf_files:
             weight_type_map.update(get_gguf_weight_type_map(f, gguf_to_hf_name_map))
-        is_multimodal = hasattr(model_config.hf_config, "vision_config")
+        is_multimodal = self._is_multimodal_model_config(model_config)
         if is_multimodal:
             mmproj_file = detect_gguf_multimodal(model_name_or_path)
             assert mmproj_file is not None, (
@@ -379,8 +432,7 @@ class GGUFModelLoader(BaseModelLoader):
         Yields:
             Tuples of (parameter_name, tensor) for all model weights
         """
-        hf_config = model_config.hf_config
-        is_multimodal = hasattr(hf_config, "vision_config")
+        is_multimodal = self._is_multimodal_model_config(model_config)
 
         if is_multimodal:
             # Load mm_proj (mm_encoder + projector) for multimodal weights

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -476,24 +476,41 @@ def download_gguf(
     # Use patterns that snapshot_download can handle directly
     # Patterns to match:
     # - *-{quant_type}.gguf (root)
+    # - *.{quant_type}.gguf (root)
     # - *-{quant_type}-*.gguf (root sharded)
+    # - *.{quant_type}-*.gguf (root sharded)
     # - */*-{quant_type}.gguf (subdir)
+    # - */*.{quant_type}.gguf (subdir)
     # - */*-{quant_type}-*.gguf (subdir sharded)
+    # - */*.{quant_type}-*.gguf (subdir sharded)
     allow_patterns = [
         f"*-{quant_type}.gguf",
+        f"*.{quant_type}.gguf",
         f"*-{quant_type}-*.gguf",
+        f"*.{quant_type}-*.gguf",
         f"*/*-{quant_type}.gguf",
+        f"*/*.{quant_type}.gguf",
         f"*/*-{quant_type}-*.gguf",
+        f"*/*.{quant_type}-*.gguf",
     ]
 
-    # Use download_weights_from_hf which handles caching and downloading
-    folder = download_weights_from_hf(
-        model_name_or_path=repo_id,
-        cache_dir=cache_dir,
-        allow_patterns=allow_patterns,
-        revision=revision,
-        ignore_patterns=ignore_patterns,
-    )
+    if envs.VLLM_USE_MODELSCOPE:
+        folder = maybe_download_from_modelscope(
+            model=repo_id,
+            revision=revision,
+            download_dir=cache_dir,
+            ignore_patterns=ignore_patterns,
+            allow_patterns=allow_patterns,
+        )
+        assert folder is not None
+    else:
+        folder = download_weights_from_hf(
+            model_name_or_path=repo_id,
+            cache_dir=cache_dir,
+            allow_patterns=allow_patterns,
+            revision=revision,
+            ignore_patterns=ignore_patterns,
+        )
 
     # Find the downloaded file(s) in the folder
     local_files = []

--- a/vllm/model_executor/models/qwen3_5.py
+++ b/vllm/model_executor/models/qwen3_5.py
@@ -105,6 +105,53 @@ from .utils import (
 logger = init_logger(__name__)
 
 
+def _load_gguf_tuple_shard(
+    param: torch.nn.Parameter,
+    loaded_weight: torch.Tensor,
+    shard_id: tuple[int, ...],
+    weight_loader: Callable[..., None],
+) -> bool:
+    is_gguf_weight = getattr(param, "is_gguf_weight", False)
+    is_gguf_weight_type = getattr(param, "is_gguf_weight_type", False)
+    if not (is_gguf_weight or is_gguf_weight_type):
+        return False
+
+    if is_gguf_weight_type:
+        for shard in shard_id:
+            weight_loader(param, loaded_weight, shard)
+        return True
+
+    output_dim = getattr(param, "output_dim", None)
+    output_sizes = weight_loader.__self__.output_sizes
+    offset = 0
+    for shard in shard_id:
+        shard_size = output_sizes[shard]
+        shard_weight = loaded_weight.narrow(output_dim, offset, shard_size)
+        weight_loader(param, shard_weight, shard)
+        offset += shard_size
+    return True
+
+
+def _maybe_unsqueeze_single_output_weight(
+    param: torch.nn.Parameter, loaded_weight: torch.Tensor
+) -> torch.Tensor:
+    if (
+        param.ndim == 2
+        and param.shape[0] == 1
+        and loaded_weight.ndim == 1
+        and loaded_weight.shape[0] == param.shape[1]
+    ):
+        return loaded_weight.unsqueeze(0)
+    if (
+        param.ndim == 3
+        and param.shape[1] == 1
+        and loaded_weight.ndim == 2
+        and loaded_weight.shape == (param.shape[0], param.shape[2])
+    ):
+        return loaded_weight.unsqueeze(1)
+    return loaded_weight
+
+
 class Qwen3_5ProcessingInfo(Qwen3VLProcessingInfo):
     def get_hf_config(self):
         return self.ctx.get_hf_config(Qwen3_5Config)
@@ -212,6 +259,7 @@ class Qwen3_5Model(Qwen3NextModel):
             vllm_config.model_config.hf_text_config
         )
         parallel_config = vllm_config.parallel_config
+        quant_config = vllm_config.quant_config
 
         eplb_config = parallel_config.eplb_config
         self.num_redundant_experts = eplb_config.num_redundant_experts
@@ -224,6 +272,8 @@ class Qwen3_5Model(Qwen3NextModel):
         self.embed_tokens = VocabParallelEmbedding(
             self.vocab_size,
             config.hidden_size,
+            quant_config=quant_config,
+            prefix=maybe_prefix(prefix, "embed_tokens"),
         )
 
         def get_layer(prefix: str):
@@ -354,6 +404,10 @@ class Qwen3_5Model(Qwen3NextModel):
                 weight_loader = param.weight_loader
                 if param_name == "in_proj_z" and self.enable_lora:
                     weight_loader(param, loaded_weight)
+                elif isinstance(shard_id, tuple) and _load_gguf_tuple_shard(
+                    param, loaded_weight, shard_id, weight_loader
+                ):
+                    pass
                 else:
                     weight_loader(param, loaded_weight, shard_id)
                 break
@@ -440,6 +494,9 @@ class Qwen3_5Model(Qwen3NextModel):
                     weight_loader = getattr(
                         param, "weight_loader", default_weight_loader
                     )
+                    loaded_weight = _maybe_unsqueeze_single_output_weight(
+                        param, loaded_weight
+                    )
                     weight_loader(param, loaded_weight)
             loaded_params.add(name)
         return loaded_params
@@ -501,6 +558,7 @@ class Qwen3_5ForCausalLMBase(
                 self.lm_head = ParallelLMHead(
                     config.vocab_size,
                     config.hidden_size,
+                    quant_config=self.quant_config,
                     prefix=maybe_prefix(prefix, "lm_head"),
                 )
         else:

--- a/vllm/tokenizers/registry.py
+++ b/vllm/tokenizers/registry.py
@@ -101,6 +101,17 @@ def resolve_tokenizer_args(
 ):
     revision: str | None = kwargs.get("revision")
     download_dir: str | None = kwargs.get("download_dir")
+    remote_gguf_tokenizer_name: str | None = None
+    remote_gguf_file: str | None = None
+
+    if is_remote_gguf(tokenizer_name):
+        remote_gguf_tokenizer_name, quant_type = split_remote_gguf(tokenizer_name)
+        remote_gguf_file = get_gguf_file_path_from_hf(
+            remote_gguf_tokenizer_name,
+            quant_type,
+            revision=revision,
+        )
+        kwargs["gguf_file"] = remote_gguf_file
 
     if envs.VLLM_USE_MODELSCOPE:
         # download model from ModelScope hub,
@@ -111,17 +122,21 @@ def resolve_tokenizer_args(
         from vllm.model_executor.model_loader.weight_utils import get_lock
 
         # Only set the tokenizer here, model will be downloaded on the workers.
-        if not Path(tokenizer_name).exists():
+        modelscope_tokenizer_name = remote_gguf_tokenizer_name or tokenizer_name
+        if not Path(modelscope_tokenizer_name).exists():
             # Use file lock to prevent multiple processes from
             # downloading the same file at the same time.
-            with get_lock(tokenizer_name, download_dir):
+            with get_lock(str(modelscope_tokenizer_name), download_dir):
                 tokenizer_path = snapshot_download(
-                    model_id=str(tokenizer_name),
+                    model_id=str(modelscope_tokenizer_name),
                     cache_dir=download_dir,
                     revision=revision,
                     local_files_only=huggingface_hub.constants.HF_HUB_OFFLINE,
                     # Ignore weights - we only need the tokenizer.
-                    ignore_file_pattern=[".*.pt", ".*.safetensors", ".*.bin"],
+                    ignore_file_pattern=None
+                    if remote_gguf_file is not None
+                    else [".*.pt", ".*.safetensors", ".*.bin"],
+                    allow_patterns=remote_gguf_file,
                 )
                 tokenizer_name = tokenizer_path
 
@@ -130,7 +145,7 @@ def resolve_tokenizer_args(
         if check_gguf_file(tokenizer_name):
             kwargs["gguf_file"] = Path(tokenizer_name).name
             tokenizer_name = Path(tokenizer_name).parent
-        elif is_remote_gguf(tokenizer_name):
+        elif remote_gguf_file is None and is_remote_gguf(tokenizer_name):
             tokenizer_name, quant_type = split_remote_gguf(tokenizer_name)
             # Get the HuggingFace Hub path for the GGUF file
             gguf_file = get_gguf_file_path_from_hf(

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -36,6 +36,7 @@ from vllm.utils.torch_utils import common_broadcastable_dtype
 from .config_parser_base import ConfigParserBase
 from .gguf_utils import (
     check_gguf_file,
+    get_gguf_base_model_id,
     get_gguf_file_path_from_hf,
     is_gguf,
     is_remote_gguf,
@@ -119,6 +120,45 @@ def _localize_modelscope_remote_gguf_for_config(
         local_files_only=huggingface_hub.constants.HF_HUB_OFFLINE,
         allow_patterns=gguf_file,
     )
+
+
+def _ensure_transformers_can_check_gguf_version() -> None:
+    try:
+        from transformers.utils import import_utils as transformers_import_utils
+
+        package_mapping = getattr(
+            transformers_import_utils,
+            "PACKAGE_DISTRIBUTION_MAPPING",
+            None,
+        )
+        if isinstance(package_mapping, dict):
+            package_mapping.setdefault("gguf", ["gguf"])
+
+        is_gguf_available = getattr(
+            transformers_import_utils,
+            "is_gguf_available",
+            None,
+        )
+        if hasattr(is_gguf_available, "cache_clear"):
+            is_gguf_available.cache_clear()
+    except Exception:
+        logger.debug(
+            "Failed to patch Transformers GGUF version detection.",
+            exc_info=True,
+        )
+
+
+def _get_gguf_base_model_id_for_config(
+    model: str | Path,
+    kwargs: dict[str, Any],
+) -> str | None:
+    gguf_file = kwargs.get("gguf_file")
+    if gguf_file is None:
+        return None
+    gguf_path = Path(model) / str(gguf_file)
+    if not gguf_path.is_file():
+        return None
+    return get_gguf_base_model_id(gguf_path)
 
 
 if Version(version("transformers")) < Version("5.0.0"):
@@ -232,6 +272,8 @@ class HFConfigParser(ConfigParserBase):
         **kwargs,
     ) -> tuple[dict, PretrainedConfig]:
         kwargs["local_files_only"] = huggingface_hub.constants.HF_HUB_OFFLINE
+        if kwargs.get("gguf_file") is not None:
+            _ensure_transformers_can_check_gguf_version()
         trust_remote_code |= kwargs.get("trust_remote_code", False)
         kwargs = without_trust_remote_code(kwargs)
         config_dict, _ = PretrainedConfig.get_config_dict(
@@ -793,14 +835,39 @@ def get_config(
             raise ValueError(error_message) from e
 
     config_parser = get_config_parser(config_format)
-    config_dict, config = config_parser.parse(
-        model,
-        trust_remote_code=trust_remote_code,
-        revision=revision,
-        code_revision=code_revision,
-        hf_overrides=hf_overrides_kw or hf_overrides_fn,
-        **kwargs,
-    )
+    try:
+        config_dict, config = config_parser.parse(
+            model,
+            trust_remote_code=trust_remote_code,
+            revision=revision,
+            code_revision=code_revision,
+            hf_overrides=hf_overrides_kw or hf_overrides_fn,
+            **kwargs,
+        )
+    except ValueError as e:
+        is_unsupported_gguf_arch = "GGUF model with architecture" in str(e)
+        base_model = (
+            _get_gguf_base_model_id_for_config(model, kwargs)
+            if _is_gguf and is_unsupported_gguf_arch
+            else None
+        )
+        if base_model is None:
+            raise
+        logger.info(
+            "Falling back to base model config %s for GGUF model %s.",
+            base_model,
+            model,
+        )
+        base_kwargs = {k: v for k, v in kwargs.items() if k != "gguf_file"}
+        config_dict, config = config_parser.parse(
+            base_model,
+            trust_remote_code=trust_remote_code,
+            revision=revision,
+            code_revision=code_revision,
+            hf_overrides=hf_overrides_kw or hf_overrides_fn,
+            **base_kwargs,
+        )
+        config._vllm_gguf_base_model_id = base_model
 
     # Patching defaults for GGUF models
     if _is_gguf:

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -611,7 +611,7 @@ def maybe_override_with_speculators(
         gguf_model_repo = Path(model).parent
     elif is_remote_gguf(model):
         repo_id, _ = split_remote_gguf(model)
-        gguf_model_repo = Path(repo_id)
+        gguf_model_repo = repo_id
     else:
         gguf_model_repo = None
     kwargs["local_files_only"] = huggingface_hub.constants.HF_HUB_OFFLINE

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -36,6 +36,7 @@ from vllm.utils.torch_utils import common_broadcastable_dtype
 from .config_parser_base import ConfigParserBase
 from .gguf_utils import (
     check_gguf_file,
+    get_gguf_file_path_from_hf,
     is_gguf,
     is_remote_gguf,
     split_remote_gguf,
@@ -65,6 +66,60 @@ else:
 MISTRAL_CONFIG_NAME = "params.json"
 
 logger = init_logger(__name__)
+
+_MODELSCOPE_CONFIG_PROBE_IGNORE_PATTERNS = [
+    "*.bin",
+    "*.safetensors",
+    "*.pth",
+    "*.pt",
+    "*.h5",
+    "*.ckpt",
+    "*.zip",
+    "*.onnx",
+    "*.tar",
+    "*.gz",
+    "*.gguf",
+]
+
+
+def _ignore_gguf_files_for_modelscope_config_probe(
+    ignore_file_pattern: str | list[str] | None,
+) -> list[str]:
+    if ignore_file_pattern is None:
+        return list(_MODELSCOPE_CONFIG_PROBE_IGNORE_PATTERNS)
+
+    if isinstance(ignore_file_pattern, str):
+        patterns = [ignore_file_pattern]
+    else:
+        patterns = list(ignore_file_pattern)
+
+    if "*.gguf" not in patterns:
+        patterns.append("*.gguf")
+    return patterns
+
+
+def _localize_modelscope_remote_gguf_for_config(
+    model: str | Path,
+    revision: str | None,
+    kwargs: dict[str, Any],
+) -> str:
+    repo_id, quant_type = split_remote_gguf(model)
+    gguf_file = get_gguf_file_path_from_hf(
+        repo_id,
+        quant_type,
+        revision=revision,
+    )
+    kwargs["gguf_file"] = gguf_file
+
+    from modelscope.hub.snapshot_download import snapshot_download
+
+    return snapshot_download(
+        model_id=repo_id,
+        revision=revision,
+        local_files_only=huggingface_hub.constants.HF_HUB_OFFLINE,
+        allow_patterns=gguf_file,
+    )
+
 
 if Version(version("transformers")) < Version("5.0.0"):
     logger.warning(
@@ -612,6 +667,12 @@ def maybe_override_with_speculators(
     elif is_remote_gguf(model):
         repo_id, _ = split_remote_gguf(model)
         gguf_model_repo = repo_id
+        if envs.VLLM_USE_MODELSCOPE:
+            kwargs["ignore_file_pattern"] = (
+                _ignore_gguf_files_for_modelscope_config_probe(
+                    kwargs.get("ignore_file_pattern")
+                )
+            )
     else:
         gguf_model_repo = None
     kwargs["local_files_only"] = huggingface_hub.constants.HF_HUB_OFFLINE
@@ -665,9 +726,16 @@ def get_config(
             model = Path(model).parent
         elif _is_remote_gguf:
             # Remote GGUF - extract repo_id from repo_id:quant_type format
-            # The actual GGUF file will be downloaded later by GGUFModelLoader
-            # Keep model as repo_id:quant_type for download, but use repo_id for config
-            model, _ = split_remote_gguf(model)
+            # Use repo_id for HF config lookup. ModelScope GGUF repos may not
+            # provide config.json, so localize the selected file for parsing.
+            if envs.VLLM_USE_MODELSCOPE:
+                model = _localize_modelscope_remote_gguf_for_config(
+                    model,
+                    revision,
+                    kwargs,
+                )
+            else:
+                model, _ = split_remote_gguf(model)
 
     if config_format == "auto":
         try:
@@ -679,8 +747,10 @@ def get_config(
                 model=model, config_name=MISTRAL_CONFIG_NAME, revision=revision
             ):
                 config_format = "mistral"
-            elif (_is_gguf and not _is_remote_gguf) or file_or_path_exists(
-                model, HF_CONFIG_NAME, revision=revision
+            elif (
+                (_is_gguf and not _is_remote_gguf)
+                or (_is_remote_gguf and kwargs.get("gguf_file") is not None)
+                or file_or_path_exists(model, HF_CONFIG_NAME, revision=revision)
             ):
                 config_format = "hf"
             # Remote GGUF models must have config.json in repo,

--- a/vllm/transformers_utils/gguf_utils.py
+++ b/vllm/transformers_utils/gguf_utils.py
@@ -38,6 +38,44 @@ def check_gguf_file(model: str | PathLike) -> bool:
         return False
 
 
+def _read_gguf_string_field(reader: gguf.GGUFReader, key: str) -> str | None:
+    field = reader.fields.get(key)
+    if field is None:
+        return None
+    try:
+        value = field.parts[field.data[0]]
+        return bytes(value).decode("utf-8")
+    except Exception:
+        logger.debug("Failed to read GGUF string field %s", key, exc_info=True)
+        return None
+
+
+@cache
+def get_gguf_base_model_id(gguf_file: str | PathLike) -> str | None:
+    """Return the HF-style base model id embedded in GGUF metadata, if present."""
+    try:
+        reader = gguf.GGUFReader(gguf_file)
+    except Exception:
+        logger.debug("Failed to read GGUF file %s", gguf_file, exc_info=True)
+        return None
+
+    repo_url = _read_gguf_string_field(reader, "general.base_model.0.repo_url")
+    if repo_url is not None:
+        prefix = "https://huggingface.co/"
+        if repo_url.startswith(prefix):
+            return repo_url.removeprefix(prefix).strip("/")
+
+    organization = _read_gguf_string_field(
+        reader,
+        "general.base_model.0.organization",
+    )
+    name = _read_gguf_string_field(reader, "general.base_model.0.name")
+    if organization is not None and name is not None:
+        return f"{organization}/{name.replace(' ', '-')}"
+
+    return None
+
+
 @cache
 def is_remote_gguf(model: str | Path) -> bool:
     """Check if the model is a remote GGUF model.

--- a/vllm/transformers_utils/gguf_utils.py
+++ b/vllm/transformers_utils/gguf_utils.py
@@ -313,9 +313,13 @@ def get_gguf_file_path_from_hf(
     repo_id = str(repo_id)
     gguf_patterns = [
         f"*-{quant_type}.gguf",
+        f"*.{quant_type}.gguf",
         f"*-{quant_type}-*.gguf",
+        f"*.{quant_type}-*.gguf",
         f"*/*-{quant_type}.gguf",
+        f"*/*.{quant_type}.gguf",
         f"*/*-{quant_type}-*.gguf",
+        f"*/*.{quant_type}-*.gguf",
     ]
     matching_files = list_filtered_repo_files(
         repo_id,


### PR DESCRIPTION
Fixes #41475.

## Purpose

Fix ModelScope handling for remote GGUF selectors such as `repo:Q4_K_M` under `VLLM_USE_MODELSCOPE=True`.

The reported command crashed before model loading because speculator config probing passed a `Path` object into the ModelScope-patched `PretrainedConfig.get_config_dict(...)` path. A100 validation then found two additional same-command blockers after the initial `Path.replace` fix: vLLM selected the repo broadly enough to download every GGUF quant variant, and the selected Qwen3.5-MoE GGUF still failed during language-model-only startup.

## Fix

- Keep remote GGUF repo ids as strings during speculator config probing.
- During ModelScope speculator probing, add `*.gguf` to `ignore_file_pattern` so metadata probing does not download GGUF weights.
- Preserve the selected GGUF quant suffix through config, tokenizer, and weight-download paths.
- Support dotted GGUF quant filenames such as `model.Q4_K_M.gguf` in selector matching.
- For ModelScope remote GGUF config loading, resolve and localize only the selected `repo:quant` file when the repo lacks `config.json`.
- Route `download_gguf()` through ModelScope when `VLLM_USE_MODELSCOPE=True`, preserving selected quant patterns.
- Infer the base HF model id from GGUF metadata when the selected GGUF architecture is not directly supported by Transformers config loading.
- Use the inferred base tokenizer for default-tokenizer `--language-model-only` remote GGUF runs.
- Treat multimodal-wrapper GGUFs as text-only under `--language-model-only`, skipping `mm_proj` while mapping text weights into the wrapped language model.
- Add Qwen3.5-MoE GGUF mapping/load support needed by the reported model, including tuple-shard handling and singleton output/conv reshape handling.

## A100 validation update (2026-05-07)

Validated on GCP `vllm-35922-a100`, `a2-highgpu-1g`, 1x NVIDIA A100-SXM4-40GB, driver `580.126.20`, CUDA reported by `nvidia-smi` as `13.0`, Ubuntu 22.04.5, Python `3.10.12`. Dependency versions: torch `2.11.0+cu130`, transformers `5.8.0`, modelscope `1.36.3`, huggingface-hub `1.14.0`, pytest `9.0.3`, gguf import available. Initial validation was run from the PR checkout in a venv on the A100 host. Docker parity validation was also added by overlaying the PR Python files into the installed package.

Reporter-style command tested:

```text
VLLM_USE_MODELSCOPE=True python -m vllm.entrypoints.cli.main serve \
  --model hesamation/Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled-GGUF:Q4_K_M \
  --max-model-len 102400 \
  --kv-cache-dtype fp8 \
  --gpu-memory-utilization 0.9 \
  --max-num-seqs 24 \
  --max-num-batched-tokens 8192 \
  --language-model-only \
  --enable-prefix-caching \
  --default-chat-template-kwargs '{"enable_thinking":false}'
```

Before/after:

- base `5737770c6c346d918fdfb13e9378f9514f616186`: reproduced the original config-probing crash before model loading: `TypeError: Path.replace() takes 2 positional arguments but 3 were given`.
- original PR head `a9713d224bc53de7b92ebb59a1a94c6caa88e310` (pre-signoff; same tree as signed-off `5e0f99307`): no `Path.replace` crash, but the same command still selected/downloaded multiple GGUF variants (`Q4_K_M`, `Q5_K_M`, `Q6_K`, `Q8_0`) and did not validate full server startup.
- fixed head `1adea4bd315d319ce27f56bf84348dfcd369f71c` (same tree as A100-validated pre-signoff `725312340813c2295626d028c863f941b0d97325`): completed selected `Q4_K_M` download only, then the exact command reached server startup. Runtime log showed model loading at `19.87 GiB` and `64.726065 seconds`, profiling/warmup completion, `GPU KV cache size: 1,366,337 tokens`, and `Application startup complete`. The clean validation log had no missing-parameter, `skip loading`, traceback, `KeyError`, `ValueError`, `AssertionError`, or `RuntimeError` signatures.

Selected-download validation also completed the full 19.7 GB Q4 download and confirmed the cache contained `Qwen3.6-35B-A3B-Claude-4.6-Opus-Reasoning-Distilled.Q4_K_M.gguf` while `Q5_K_M`, `Q6_K`, and `Q8_0` were absent.

## Tests

On the A100 VM:

```text
python -m ruff check \
  vllm/transformers_utils/config.py \
  vllm/transformers_utils/gguf_utils.py \
  vllm/config/model.py \
  vllm/model_executor/model_loader/gguf_loader.py \
  vllm/model_executor/models/qwen3_5.py \
  tests/transformers_utils/test_config.py \
  tests/models/test_gguf_download.py
python -m ruff format --check \
  vllm/transformers_utils/config.py \
  vllm/transformers_utils/gguf_utils.py \
  vllm/config/model.py \
  vllm/model_executor/model_loader/gguf_loader.py \
  vllm/model_executor/models/qwen3_5.py \
  tests/transformers_utils/test_config.py \
  tests/models/test_gguf_download.py
python -m pytest \
  tests/transformers_utils/test_config.py::test_ensure_transformers_can_check_gguf_version \
  tests/transformers_utils/test_config.py::test_get_gguf_base_model_id_for_config \
  tests/transformers_utils/test_config.py::test_get_config_falls_back_to_gguf_base_model \
  tests/transformers_utils/test_config.py::test_modelscope_remote_gguf_config_downloads_selected_file \
  tests/transformers_utils/test_config.py::test_maybe_override_with_speculators_gguf_quant_modelscope_no_path_replace_crash \
  tests/models/test_gguf_download.py::TestGGUFModelLoader::test_qwen35_moe_gguf_mapping \
  tests/models/test_gguf_download.py::TestGGUFModelLoader::test_qwen35_moe_gguf_language_model_only_mapping \
  tests/models/test_gguf_download.py::TestGGUFModelLoader::test_language_model_only_weight_types_skip_mmproj \
  tests/models/test_gguf_download.py::TestGGUFModelLoader::test_language_model_only_weights_iterator_skips_mmproj \
  tests/models/test_gguf_download.py::TestGGUFModelLoader::test_qwen35_gguf_tuple_shard_weight_splits \
  tests/models/test_gguf_download.py::TestGGUFModelLoader::test_qwen35_gguf_tuple_shard_weight_type_reuses_scalar \
  tests/models/test_gguf_download.py::TestGGUFModelLoader::test_qwen35_gguf_single_output_weight_unsqueeze \
  tests/models/test_gguf_download.py::TestGGUFModelLoader::test_qwen35_gguf_conv_weight_unsqueeze \
  -q --confcutdir=tests
```

Result: `13 passed`.

## Safe claim

This is validated as a full startup fix for the reported ModelScope remote GGUF `repo:quant` command on the A100 host. It does not claim generation-quality validation or exact reporter Docker image parity.


## Docker parity validation update (2026-05-07)

Also checked the reporter-style Docker setup on the same A100 VM after installing Docker `29.1.3` and NVIDIA container runtime. Image used: `vllm/vllm-openai:v0.20.0` at digest `sha256:04563c302537a91aa49ebdfbceda96111c5712275999b7e8804fa598f0b5641d`.

This was not a full rebuilt PR Docker image. To isolate container parity without a multi-hour image build, I mounted the PR checkout and overlaid the changed Python files into the installed vLLM package inside the reporter image before running `vllm serve`.

Docker before/after:

- unmodified `vllm/vllm-openai:v0.20.0`: reproduced the original Docker crash: `TypeError: Path.replace() takes 2 positional arguments but 3 were given`.
- patched overlay, standard `--gpus all`: passed the original ModelScope/GGUF path, downloaded only the selected `Q4_K_M` GGUF, resolved `Qwen3_5MoeForCausalLM`, then failed before model load with Docker GPU visibility in the vLLM EngineCore child: `DP adjusted local rank 0 is out of bounds`. A direct parent/child torch preflight in the same image saw CUDA, so this was treated as a container runtime/capability issue, not a PR path failure.
- patched overlay with explicit `--runtime=nvidia --gpus all --privileged`: reached server startup. Preflight printed CUDA visible as `True 1 1`; EngineCore initialized NCCL with `world_size=1`; model loading took `19.85 GiB` and `72.970768 seconds`; KV cache size was `364,480` tokens; max concurrency for 102,400-token requests was `13.35x`; log reached `Application startup complete`.

The successful Docker log had no `Path.replace`, `skip loading`, missing-parameter, traceback, `KeyError`, `ValueError`, `AssertionError`, or `RuntimeError` signatures.