### PR TITLE
[Parser][0/N] Add unified Mistral parser entrypoint

### DIFF
--- a/tests/parser/test_parser_manager.py
+++ b/tests/parser/test_parser_manager.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.parser.abstract_parser import _WrappedParser
+from vllm.parser.minimax_m2_parser import MiniMaxM2Parser
+from vllm.parser.mistral_parser import MistralParser
+from vllm.parser.parser_manager import ParserManager
+from vllm.reasoning.minimax_m2_reasoning_parser import MiniMaxM2ReasoningParser
+from vllm.reasoning.mistral_reasoning_parser import MistralReasoningParser
+from vllm.reasoning.qwen3_reasoning_parser import Qwen3ReasoningParser
+from vllm.tool_parsers.minimax_m2_tool_parser import MinimaxM2ToolParser
+from vllm.tool_parsers.mistral_tool_parser import MistralToolParser
+
+
+@pytest.fixture(autouse=True)
+def reset_parser_classes():
+    MistralParser.reasoning_parser_cls = None
+    _WrappedParser.reasoning_parser_cls = None
+    _WrappedParser.tool_parser_cls = None
+
+
+@pytest.mark.parametrize(
+    (
+        "reasoning_parser_name",
+        "tool_parser_name",
+        "expected_parser_cls",
+        "expected_reasoning_parser_cls",
+        "expected_tool_parser_cls",
+    ),
+    [
+        pytest.param(
+            "minimax_m2",
+            "minimax_m2",
+            MiniMaxM2Parser,
+            MiniMaxM2ReasoningParser,
+            MinimaxM2ToolParser,
+            id="minimax_m2_parser",
+        ),
+        pytest.param(
+            "mistral",
+            "mistral",
+            MistralParser,
+            MistralReasoningParser,
+            MistralToolParser,
+            id="mistral_parser_with_mistral_reasoning",
+        ),
+        pytest.param(
+            "qwen3",
+            "mistral",
+            MistralParser,
+            Qwen3ReasoningParser,
+            MistralToolParser,
+            id="mistral_parser_with_other_reasoning",
+        ),
+        pytest.param(
+            "mistral",
+            "minimax_m2",
+            _WrappedParser,
+            MistralReasoningParser,
+            MinimaxM2ToolParser,
+            id="wrapped_parser_fallback",
+        ),
+    ],
+)
+def test_get_parser(
+    reasoning_parser_name: str,
+    tool_parser_name: str,
+    expected_parser_cls: type,
+    expected_reasoning_parser_cls: type,
+    expected_tool_parser_cls: type,
+):
+    parser_cls = ParserManager.get_parser(
+        tool_parser_name=tool_parser_name,
+        reasoning_parser_name=reasoning_parser_name,
+        enable_auto_tools=True,
+        model_name="test-model",
+    )
+
+    assert parser_cls is expected_parser_cls
+    assert parser_cls.reasoning_parser_cls is expected_reasoning_parser_cls
+    assert parser_cls.tool_parser_cls is expected_tool_parser_cls

--- a/tests/parser/test_parser_manager.py
+++ b/tests/parser/test_parser_manager.py
@@ -3,22 +3,10 @@
 
 import pytest
 
-from vllm.parser.abstract_parser import _WrappedParser
+from vllm.parser.abstract_parser import DelegatingParser
 from vllm.parser.minimax_m2_parser import MiniMaxM2Parser
 from vllm.parser.mistral_parser import MistralParser
 from vllm.parser.parser_manager import ParserManager
-from vllm.reasoning.minimax_m2_reasoning_parser import MiniMaxM2ReasoningParser
-from vllm.reasoning.mistral_reasoning_parser import MistralReasoningParser
-from vllm.reasoning.qwen3_reasoning_parser import Qwen3ReasoningParser
-from vllm.tool_parsers.minimax_m2_tool_parser import MinimaxM2ToolParser
-from vllm.tool_parsers.mistral_tool_parser import MistralToolParser
-
-
-@pytest.fixture(autouse=True)
-def reset_parser_classes():
-    MistralParser.reasoning_parser_cls = None
-    _WrappedParser.reasoning_parser_cls = None
-    _WrappedParser.tool_parser_cls = None
 
 
 @pytest.mark.parametrize(
@@ -26,58 +14,90 @@ def reset_parser_classes():
         "reasoning_parser_name",
         "tool_parser_name",
         "expected_parser_cls",
-        "expected_reasoning_parser_cls",
-        "expected_tool_parser_cls",
+        "enable_auto_tools",
     ),
     [
         pytest.param(
             "minimax_m2",
             "minimax_m2",
             MiniMaxM2Parser,
-            MiniMaxM2ReasoningParser,
-            MinimaxM2ToolParser,
+            True,
             id="minimax_m2_parser",
         ),
         pytest.param(
             "mistral",
             "mistral",
             MistralParser,
-            MistralReasoningParser,
-            MistralToolParser,
+            True,
             id="mistral_parser_with_mistral_reasoning",
         ),
         pytest.param(
             "qwen3",
             "mistral",
             MistralParser,
-            Qwen3ReasoningParser,
-            MistralToolParser,
+            True,
             id="mistral_parser_with_other_reasoning",
         ),
         pytest.param(
             "mistral",
             "minimax_m2",
-            _WrappedParser,
-            MistralReasoningParser,
-            MinimaxM2ToolParser,
-            id="wrapped_parser_fallback",
+            DelegatingParser,
+            True,
+            id="delegating_parser_fallback",
+        ),
+        pytest.param(
+            None,
+            "minimax_m2",
+            DelegatingParser,
+            True,
+            id="delegating_parser_fallback_no_reasoning",
+        ),
+        pytest.param(
+            None,
+            "mistral",
+            MistralParser,
+            True,
+            id="mistral_parser_no_reasoning",
+        ),
+        pytest.param(
+            "mistral",
+            "mistral",
+            DelegatingParser,
+            False,
+            id="mistral_parser_fallback_no_auto_tools",
         ),
     ],
 )
 def test_get_parser(
-    reasoning_parser_name: str,
-    tool_parser_name: str,
+    reasoning_parser_name: str | None,
+    tool_parser_name: str | None,
     expected_parser_cls: type,
-    expected_reasoning_parser_cls: type,
-    expected_tool_parser_cls: type,
+    enable_auto_tools: bool,
 ):
     parser_cls = ParserManager.get_parser(
         tool_parser_name=tool_parser_name,
         reasoning_parser_name=reasoning_parser_name,
-        enable_auto_tools=True,
+        enable_auto_tools=enable_auto_tools,
         model_name="test-model",
     )
 
-    assert parser_cls is expected_parser_cls
-    assert parser_cls.reasoning_parser_cls is expected_reasoning_parser_cls
-    assert parser_cls.tool_parser_cls is expected_tool_parser_cls
+    assert issubclass(parser_cls, expected_parser_cls)
+
+    expected_reasoning_parser_cls = ParserManager.get_reasoning_parser(
+        reasoning_parser_name
+    )
+    if expected_reasoning_parser_cls is not None:
+        assert issubclass(
+            parser_cls.reasoning_parser_cls, expected_reasoning_parser_cls
+        )
+    else:
+        assert parser_cls.reasoning_parser_cls is None
+
+    expected_tool_parser_cls = ParserManager.get_tool_parser(
+        tool_parser_name=tool_parser_name,
+        enable_auto_tools=enable_auto_tools,
+    )
+    if expected_tool_parser_cls is not None:
+        assert issubclass(parser_cls.tool_parser_cls, expected_tool_parser_cls)
+    else:
+        assert parser_cls.tool_parser_cls is None

--- a/vllm/parser/__init__.py
+++ b/vllm/parser/__init__.py
@@ -20,6 +20,10 @@ _PARSERS_TO_REGISTER = {
         "minimax_m2_parser",  # filename
         "MiniMaxM2Parser",  # class_name
     ),
+    "mistral": (
+        "mistral_parser",
+        "MistralParser",
+    ),
 }
 
 

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -7,6 +7,7 @@ from abc import abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from functools import cached_property
+from typing import Any
 
 from openai.types.responses import (
     ResponseFunctionToolCall,
@@ -89,6 +90,22 @@ class Parser:
     # Subclasses should override these if they use specific parser classes
     reasoning_parser_cls: type[ReasoningParser] | None = None
     tool_parser_cls: type[ToolParser] | None = None
+
+    @classmethod
+    @abstractmethod
+    def specialize(
+        cls,
+        reasoning_parser_cls: type[ReasoningParser] | None,
+        tool_parser_cls: type[ToolParser] | None,
+        **kwargs: Any,
+    ) -> tuple[bool, dict[str, Any]]:
+        """
+        Specialize the parser to use specific reasoning and tool parsers.
+        Returns:
+            A tuple of (success, kwargs) where success is a boolean indicating
+            whether the specialization was successful and kwargs is a dictionary
+            of keyword arguments to pass to the parser's __init__ method.
+        """
 
     def __init__(self, tokenizer: TokenizerLike, *args, **kwargs):
         """
@@ -326,6 +343,12 @@ class Parser:
         """
 
 
+def issubclass_or_both_none(sub: type | None, parent: type | None) -> bool:
+    if parent is None:
+        return sub is None
+    return sub is not None and issubclass(sub, parent)
+
+
 class DelegatingParser(Parser):
     """
     A Parser implementation that delegates to separate ReasoningParser and
@@ -339,6 +362,20 @@ class DelegatingParser(Parser):
     If either parser is None, the corresponding methods will return default
     values (no reasoning extraction, no tool calls).
     """
+
+    @classmethod
+    def specialize(
+        cls,
+        reasoning_parser_cls: type[ReasoningParser] | None,
+        tool_parser_cls: type[ToolParser] | None,
+        **kwargs: Any,
+    ) -> tuple[bool, dict[str, Any]]:
+        # Check the provided parser classes match the overridden class attributes
+        if issubclass_or_both_none(
+            reasoning_parser_cls, cls.reasoning_parser_cls
+        ) and issubclass_or_both_none(tool_parser_cls, cls.tool_parser_cls):
+            return True, {}
+        return False, {}
 
     def extract_reasoning(
         self,
@@ -733,8 +770,17 @@ class _WrappedParser(DelegatingParser):
         parser = _WrappedParser(tokenizer)
     """
 
-    reasoning_parser_cls: type[ReasoningParser] | None = None
-    tool_parser_cls: type[ToolParser] | None = None
+    @classmethod
+    def specialize(
+        cls,
+        reasoning_parser_cls: type[ReasoningParser] | None,
+        tool_parser_cls: type[ToolParser] | None,
+        **kwargs: Any,
+    ) -> tuple[bool, dict[str, Any]]:
+        return True, {
+            "reasoning_parser_cls": reasoning_parser_cls,
+            "tool_parser_cls": tool_parser_cls,
+        }
 
     def __init__(
         self, tokenizer: TokenizerLike, tools: list[Tool] | None = None, **kwargs

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -104,7 +104,7 @@ class Parser:
         Returns:
             A tuple of (success, kwargs) where success is a boolean indicating
             whether the specialization was successful and kwargs is a dictionary
-            of keyword arguments to pass to the parser's __init__ method.
+            of class-level attributes to set on the parser class.
         """
 
     def __init__(self, tokenizer: TokenizerLike, *args, **kwargs):

--- a/vllm/parser/mistral_parser.py
+++ b/vllm/parser/mistral_parser.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+"""
+Mistral Parser - A unified parser for Mistral models.
+
+This parser combines MistralReasoningParser and MistralToolParser into a
+single unified interface.  Unlike ``_WrappedParser``, it **always**
+instantiates ``MistralToolParser`` even when no tools are provided, because
+the Mistral grammar path (``_grammar_from_tool_parser``) requires a live
+tool-parser instance for streaming extraction.
+"""
+
+from vllm.logger import init_logger
+from vllm.parser.abstract_parser import DelegatingParser
+from vllm.reasoning import ReasoningParser
+from vllm.tokenizers import TokenizerLike
+from vllm.tool_parsers.abstract_tool_parser import Tool
+from vllm.tool_parsers.mistral_tool_parser import MistralToolParser
+
+logger = init_logger(__name__)
+
+
+class MistralParser(DelegatingParser):
+    """
+    Unified parser for Mistral models that handles both reasoning
+    extraction and tool call parsing.
+
+    This parser delegates to the existing implementations:
+    - Any reasoning parser for reasoning extraction
+    - MistralToolParser for tool call parsing
+
+    The tool parser is always instantiated (even without tools) so the
+    Mistral grammar streaming path has the parser instance it requires.
+    """
+
+    # Any reasoning parser is supported.
+    reasoning_parser_cls: type[ReasoningParser] | None = None
+    tool_parser_cls: type[MistralToolParser] = MistralToolParser
+
+    def __init__(
+        self,
+        tokenizer: TokenizerLike,
+        tools: list[Tool] | None = None,
+        *args,
+        **kwargs,
+    ):
+        super().__init__(tokenizer, *args, **kwargs)
+
+        cls = type(self)
+        if cls.reasoning_parser_cls:
+            self._reasoning_parser = cls.reasoning_parser_cls(tokenizer, **kwargs)
+
+        self._tool_parser = cls.tool_parser_cls(tokenizer, tools)
+
+        logger.debug("vLLM Successfully initialized parser %s!", cls)

--- a/vllm/parser/mistral_parser.py
+++ b/vllm/parser/mistral_parser.py
@@ -1,21 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-"""
-Mistral Parser - A unified parser for Mistral models.
-
-This parser combines MistralReasoningParser and MistralToolParser into a
-single unified interface.  Unlike ``_WrappedParser``, it **always**
-instantiates ``MistralToolParser`` even when no tools are provided, because
-the Mistral grammar path (``_grammar_from_tool_parser``) requires a live
-tool-parser instance for streaming extraction.
-"""
+from typing import Any
 
 from vllm.logger import init_logger
 from vllm.parser.abstract_parser import DelegatingParser
 from vllm.reasoning import ReasoningParser
 from vllm.tokenizers import TokenizerLike
-from vllm.tool_parsers.abstract_tool_parser import Tool
+from vllm.tool_parsers.abstract_tool_parser import Tool, ToolParser
 from vllm.tool_parsers.mistral_tool_parser import MistralToolParser
 
 logger = init_logger(__name__)
@@ -35,8 +27,23 @@ class MistralParser(DelegatingParser):
     """
 
     # Any reasoning parser is supported.
-    reasoning_parser_cls: type[ReasoningParser] | None = None
-    tool_parser_cls: type[MistralToolParser] = MistralToolParser
+    tool_parser_cls = MistralToolParser
+
+    @classmethod
+    def specialize(
+        cls,
+        reasoning_parser_cls: type[ReasoningParser] | None,
+        tool_parser_cls: type[ToolParser] | None,
+        **kwargs: Any,
+    ) -> tuple[bool, dict[str, Any]]:
+        # Requires MistralToolParser but flexible reasoning parser
+        if tool_parser_cls is None or not issubclass(
+            tool_parser_cls, MistralToolParser
+        ):
+            return False, {}
+        return True, {
+            "reasoning_parser_cls": reasoning_parser_cls,
+        }
 
     def __init__(
         self,

--- a/vllm/parser/parser_manager.py
+++ b/vllm/parser/parser_manager.py
@@ -159,7 +159,7 @@ class ParserManager:
             if isinstance(name, str):
                 names = [name]
             elif is_list_of(name, str):
-                names = name
+                names = name  # type: ignore
             else:
                 names = [class_name]
 
@@ -262,46 +262,71 @@ class ParserManager:
         Returns:
             A Parser class, or None if neither parser is specified.
         """
-        from vllm.parser.abstract_parser import _WrappedParser
-
-        if not tool_parser_name and not reasoning_parser_name:
-            return None
-
-        # Strategy 1: If both names match, check for a unified parser with that name
-        if tool_parser_name and tool_parser_name == reasoning_parser_name:
-            try:
-                parser = cls.get_parser_internal(tool_parser_name)
-                logger.info(
-                    "Using unified parser '%s' for both reasoning and tool parsing.",
-                    tool_parser_name,
-                )
-                return parser
-            except KeyError:
-                pass  # No unified parser with this name
-
-        # Strategy 2: Check for parser with either name
-        for name in [tool_parser_name, reasoning_parser_name]:
-            if name:
-                try:
-                    parser = cls.get_parser_internal(name)
-                    logger.info(
-                        "Using unified parser '%s' for reasoning and tool parsing.",
-                        name,
-                    )
-                    return parser
-                except KeyError:
-                    pass
-
-        # Strategy 3: Create a DelegatingParser with the individual parser classes
         reasoning_parser_cls = cls.get_reasoning_parser(reasoning_parser_name)
         tool_parser_cls = cls.get_tool_parser(
             tool_parser_name, enable_auto_tools, model_name
         )
-
         if reasoning_parser_cls is None and tool_parser_cls is None:
             return None
 
+        # Try specializing a specific reasoning and tool parsers.
+        for name in [tool_parser_name, reasoning_parser_name]:
+            if not name:
+                continue
+
+            try:
+                parser = cls.get_parser_internal(name)
+            except KeyError:
+                continue
+
+            if (
+                parser.reasoning_parser_cls is not None
+                and parser.reasoning_parser_cls != reasoning_parser_cls
+            ):
+                logger.warning(
+                    "Unified parser '%s' isn't used due to unsupported "
+                    "reasoning parser: expected %s but got %s",
+                    name,
+                    parser.reasoning_parser_cls,
+                    reasoning_parser_cls,
+                )
+                continue
+
+            if (
+                parser.tool_parser_cls is not None
+                and parser.tool_parser_cls != tool_parser_cls
+            ):
+                logger.warning(
+                    "Unified parser '%s' isn't used due to unsupported "
+                    "tool parser: expected %s but got %s",
+                    name,
+                    parser.tool_parser_cls,
+                    tool_parser_cls,
+                )
+                continue
+
+            if parser.reasoning_parser_cls is None:
+                logger.info(
+                    "Specializing unified parser '%s''s reasoning parser to %s",
+                    name,
+                    reasoning_parser_cls,
+                )
+                parser.reasoning_parser_cls = reasoning_parser_cls
+
+            if parser.tool_parser_cls is None:
+                logger.info(
+                    "Specializing unified parser '%s''s tool parser to %s",
+                    name,
+                    tool_parser_cls,
+                )
+                parser.tool_parser_cls = tool_parser_cls
+
+            return parser
+
+        # Fallback: Create a DelegatingParser with the individual parser classes
         # Set the class-level attributes on the imported _WrappedParser
+        from vllm.parser.abstract_parser import _WrappedParser
+
         _WrappedParser.reasoning_parser_cls = reasoning_parser_cls
         _WrappedParser.tool_parser_cls = tool_parser_cls
 

--- a/vllm/parser/parser_manager.py
+++ b/vllm/parser/parser_manager.py
@@ -307,8 +307,12 @@ def specialize_parser(
     specialized_name = parser_cls.__name__
     if reasoning_parser_cls is not None:
         specialized_name += f"_{reasoning_parser_cls.__name__}"
+    else:
+        specialized_name += "_NoReasoning"
     if tool_parser_cls is not None:
         specialized_name += f"_{tool_parser_cls.__name__}"
+    else:
+        specialized_name += "_NoTool"
 
     return type(
         specialized_name,

--- a/vllm/parser/parser_manager.py
+++ b/vllm/parser/parser_manager.py
@@ -279,29 +279,39 @@ class ParserManager:
             except KeyError:
                 continue
 
-            success, kwargs = parser_cls.specialize(
-                reasoning_parser_cls, tool_parser_cls
+            specialized_parser = specialize_parser(
+                parser_cls, reasoning_parser_cls, tool_parser_cls
             )
-            if not success:
-                continue
-
-            # Dynamically create subclass with specialized class variables
-            # Set the class-level attributes on the specialized parser class
-            return type(
-                f"{parser_cls}_{reasoning_parser_cls}_{tool_parser_cls}",
-                (parser_cls,),
-                kwargs,
-            )
+            if specialized_parser is not None:
+                return specialized_parser
 
         # Fallback: Specialize a _WrappedParser with the individual parser classes
         from vllm.parser.abstract_parser import _WrappedParser
 
-        success, kwargs = _WrappedParser.specialize(
-            reasoning_parser_cls, tool_parser_cls
+        specialized_parser = specialize_parser(
+            _WrappedParser, reasoning_parser_cls, tool_parser_cls
         )
-        assert success
-        return type(
-            f"_WrappedParser_{reasoning_parser_cls}_{tool_parser_cls}",
-            (_WrappedParser,),
-            kwargs,
-        )
+        assert specialized_parser is not None
+        return specialized_parser
+
+
+def specialize_parser(
+    parser_cls: type[Parser],
+    reasoning_parser_cls: type[ReasoningParser] | None,
+    tool_parser_cls: type[ToolParser] | None,
+) -> type[Parser] | None:
+    success, kwargs = parser_cls.specialize(reasoning_parser_cls, tool_parser_cls)
+    if not success:
+        return None
+
+    specialized_name = parser_cls.__name__
+    if reasoning_parser_cls is not None:
+        specialized_name += f"_{reasoning_parser_cls.__name__}"
+    if tool_parser_cls is not None:
+        specialized_name += f"_{tool_parser_cls.__name__}"
+
+    return type(
+        specialized_name,
+        (parser_cls,),
+        kwargs,
+    )

--- a/vllm/parser/parser_manager.py
+++ b/vllm/parser/parser_manager.py
@@ -269,65 +269,39 @@ class ParserManager:
         if reasoning_parser_cls is None and tool_parser_cls is None:
             return None
 
-        # Try specializing a specific reasoning and tool parsers.
+        # Try specializing a unified parser.
         for name in [tool_parser_name, reasoning_parser_name]:
             if not name:
                 continue
 
             try:
-                parser = cls.get_parser_internal(name)
+                parser_cls = cls.get_parser_internal(name)
             except KeyError:
                 continue
 
-            if (
-                parser.reasoning_parser_cls is not None
-                and parser.reasoning_parser_cls != reasoning_parser_cls
-            ):
-                logger.warning(
-                    "Unified parser '%s' isn't used due to unsupported "
-                    "reasoning parser: expected %s but got %s",
-                    name,
-                    parser.reasoning_parser_cls,
-                    reasoning_parser_cls,
-                )
+            success, kwargs = parser_cls.specialize(
+                reasoning_parser_cls, tool_parser_cls
+            )
+            if not success:
                 continue
 
-            if (
-                parser.tool_parser_cls is not None
-                and parser.tool_parser_cls != tool_parser_cls
-            ):
-                logger.warning(
-                    "Unified parser '%s' isn't used due to unsupported "
-                    "tool parser: expected %s but got %s",
-                    name,
-                    parser.tool_parser_cls,
-                    tool_parser_cls,
-                )
-                continue
+            # Dynamically create subclass with specialized class variables
+            # Set the class-level attributes on the specialized parser class
+            return type(
+                f"{parser_cls}_{reasoning_parser_cls}_{tool_parser_cls}",
+                (parser_cls,),
+                kwargs,
+            )
 
-            if parser.reasoning_parser_cls is None:
-                logger.info(
-                    "Specializing unified parser '%s''s reasoning parser to %s",
-                    name,
-                    reasoning_parser_cls,
-                )
-                parser.reasoning_parser_cls = reasoning_parser_cls
-
-            if parser.tool_parser_cls is None:
-                logger.info(
-                    "Specializing unified parser '%s''s tool parser to %s",
-                    name,
-                    tool_parser_cls,
-                )
-                parser.tool_parser_cls = tool_parser_cls
-
-            return parser
-
-        # Fallback: Create a DelegatingParser with the individual parser classes
-        # Set the class-level attributes on the imported _WrappedParser
+        # Fallback: Specialize a _WrappedParser with the individual parser classes
         from vllm.parser.abstract_parser import _WrappedParser
 
-        _WrappedParser.reasoning_parser_cls = reasoning_parser_cls
-        _WrappedParser.tool_parser_cls = tool_parser_cls
-
-        return _WrappedParser
+        success, kwargs = _WrappedParser.specialize(
+            reasoning_parser_cls, tool_parser_cls
+        )
+        assert success
+        return type(
+            f"_WrappedParser_{reasoning_parser_cls}_{tool_parser_cls}",
+            (_WrappedParser,),
+            kwargs,
+        )


### PR DESCRIPTION


## Purpose

This is the first step toward a unified Mistral parser and support for the Responses API.

Mistral's reasoning, tool, and grammar-driven streaming paths are tightly coupled. A unified parser is a better abstraction and allow some hacks we currently use to be removed. It also allows easier integration with Responses API.

<details>
<summary> Why unified parser is a better abstraction </summary>

Mistral is special because
1. its tool parser uses grammar for constrained decoding
2. it may not emit `[THINK]` tokens even in thinking mode

As a result:
- The tool parser needs reasoning-aware setup (`MistralToolParser.model_can_reason`), which is [specially handled in Chat Completions serving](https://github.com/vllm-project/vllm/blob/1e9500410a21782847ae86561b4de7f3aa69f0bc/vllm/entrypoints/openai/chat_completion/serving.py#L142-L148)
- `adjust_request()` coordinates with parsing via a [private request-level attribute `ChatCompletionRequest._grammar_from_tool_parser`](https://github.com/vllm-project/vllm/blob/1e9500410a21782847ae86561b4de7f3aa69f0bc/vllm/entrypoints/openai/chat_completion/protocol.py#L430-L431)
- In streaming, [MistralToolParser.extract_maybe_reasoning_and_tool_streaming()](https://github.com/yzong-rh/vllm/blob/f6b9935f7aff1b01d4f608957ef10e27af3bc2eb/vllm/entrypoints/openai/chat_completion/serving.py#L706-L726) is used instead of the standard `parse_delta()` to handle optional reasoning.

A unified `MistralParser` would:
- Remove server-side special handling of `MistralToolParser.model_can_reason`.
- Move grammar coordination from the request level into the parser.
- Move `MistralToolParser.extract_maybe_reasoning_and_tool_streaming()` into Mistral-specific `MistralParser.parse_delta()`.
- Most importantly, allow Mistral parser to work in Responses API without copying over the "hacks" from Chat Completions.

</details>

This PR:
- Create a unified parser entrypoint for Mistral by adding `MistralParser`.
- Update `ParserManager.get_parser()` logic to support "specializing" a unified parser with specific reasoning / tool parsers.
  - This is needed by `MistralParser` because it supports an optional and arbitrary reasoning parser (any reasoning parser or None). We we can't hardcode one like we did for `MiniMaxM2`.
  - Previous logic can also cause the unified `parser_cls`'s `reasoning_parser_cls` and `tool_parser_cls` attributes to be different than what would be returned from direct calls to `get_reasoning_parser` and `get_tool_parser`. This mismatch should no longer occur.
- The "specializing" logic creates a new subclass with correct class-level attributes (`reasoning_parser_cls` and `tool_parser_cls`). No more direct mutation on class attributes.
- Add test coverage for parser manager and the specialization logic.

Future PRs will
1. Migrate `adjust_request` from `MistralToolParser` to the unified `MistralParser` and ensure the unified parser's `adjust_request` is called (currently we call reasoning parser and tool parser's `adjust_request` separately, we don't use the unified parser's `adjust_request`)
2. Ensure the same parser instance used to `adjust_request` is also used for parsing, allowing per-request parsing state to be stored in a unified parser instance instead of at the request level (which we do now with `_grammar_from_tool_parser`)
3. Wire up Mistral grammar for responses.

## Test Plan

- `python -m pytest tests/parser/test_parser_manager.py`

```
BFCL_MODEL='mistralai/Mistral-Small-4-119B-2603-NVFP4' \
BFCL_API_TYPE='chat_completions' \
BFCL_TP_SIZE=2 \
BFCL_TOOL_CALL_PARSER='mistral' \
BFCL_REASONING_PARSER='mistral' \
BFCL_EXTRA_ARGS='--default-chat-template-kwargs {"reasoning_effort":"high"}' \
BFCL_MAX_MODEL_LEN='16384' \
BFCL_TEST_CATEGORY='multi_turn_base' \
BFCL_OUTPUT_DIR='results' \
bash .buildkite/scripts/tool_call/run-bfcl-eval.sh
```

## Test Result

Unit test pass

BFCL:
| Before | After |
|--------|------|
| 0.465 | 0.48 |

No change expected. Likely run-to-run variance.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

