### PR TITLE
Refactor Step3Text loading to use AutoWeightsLoader

### DIFF
--- a/vllm/model_executor/models/step3_text.py
+++ b/vllm/model_executor/models/step3_text.py
@@ -41,6 +41,7 @@ from vllm.transformers_utils.configs.step3_vl import Step3TextConfig
 
 from .interfaces import SupportsPP
 from .utils import (
+    AutoWeightsLoader,
     PPMissingLayer,
     is_pp_missing_parameter,
     make_empty_intermediate_tensors_factory,
@@ -382,55 +383,6 @@ class Step3TextModel(nn.Module):
         hidden_states, _ = self.norm(hidden_states, residual)
         return hidden_states
 
-
-class Step3TextForCausalLM(nn.Module, SupportsPP):
-    def __init__(
-        self,
-        *,
-        vllm_config: VllmConfig,
-        prefix: str = "",
-    ):
-        super().__init__()
-        config = vllm_config.model_config.hf_config
-
-        self.config = config
-        self.vllm_config = vllm_config
-
-        self.model = Step3TextModel(vllm_config=vllm_config, prefix=prefix)
-
-        if get_pp_group().is_last_rank:
-            self.lm_head = ParallelLMHead(
-                config.vocab_size,
-                config.hidden_size,
-                prefix=maybe_prefix(prefix, "lm_head"),
-            )
-            self.logits_processor = LogitsProcessor(config.vocab_size)
-        else:
-            self.lm_head = PPMissingLayer()
-
-        self.make_empty_intermediate_tensors = (
-            self.model.make_empty_intermediate_tensors
-        )
-
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.model.embed_input_ids(input_ids)
-
-    def forward(
-        self,
-        input_ids: torch.Tensor | None,
-        positions: torch.Tensor,
-        intermediate_tensors: IntermediateTensors | None = None,
-        inputs_embeds: torch.Tensor | None = None,
-    ):
-        hidden_states = self.model(
-            input_ids, positions, intermediate_tensors, inputs_embeds
-        )
-        return hidden_states
-
-    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
-        logits = self.logits_processor(self.lm_head, hidden_states)
-        return logits
-
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         qkv_params_mapping = [
             # (param_name, shard_name, relative_start_idx, relative_end_idx)
@@ -553,3 +505,56 @@ class Step3TextForCausalLM(nn.Module, SupportsPP):
                         weight_loader(param, loaded_weight)
                         loaded_params.add(name)
         return loaded_params
+
+
+class Step3TextForCausalLM(nn.Module, SupportsPP):
+    def __init__(
+        self,
+        *,
+        vllm_config: VllmConfig,
+        prefix: str = "",
+    ):
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+
+        self.config = config
+        self.vllm_config = vllm_config
+
+        self.model = Step3TextModel(vllm_config=vllm_config, prefix=prefix)
+
+        if get_pp_group().is_last_rank:
+            self.lm_head = ParallelLMHead(
+                config.vocab_size,
+                config.hidden_size,
+                prefix=maybe_prefix(prefix, "lm_head"),
+            )
+            self.logits_processor = LogitsProcessor(config.vocab_size)
+        else:
+            self.lm_head = PPMissingLayer()
+
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.embed_input_ids(input_ids)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor | None,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+    ):
+        hidden_states = self.model(
+            input_ids, positions, intermediate_tensors, inputs_embeds
+        )
+        return hidden_states
+
+    def compute_logits(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        logits = self.logits_processor(self.lm_head, hidden_states)
+        return logits
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(self)
+        return loader.load_weights(weights)


### PR DESCRIPTION
## Purpose

Part of #15697.

This PR refactors `Step3TextForCausalLM` to use `AutoWeightsLoader`. Mirrors the pattern used by `qwen2.py` and the recently merged #41448 for `LongcatFlashForCausalLM`.

The Step3Text weight-loading logic is moved from `Step3TextForCausalLM` to the reusable `Step3TextModel` backbone. `Step3TextForCausalLM.load_weights` now delegates through `AutoWeightsLoader`, matching the standardized loading pattern used by other language models.

This is a refactor only and does not change model architecture or inference behavior. The body of the moved method is unchanged; PP-missing handling for `lm_head` is delegated to `AutoWeightsLoader`, which already handles `PPMissingLayer` (`vllm/model_executor/models/utils.py:267`).

No `skip_prefixes` is needed — `Step3TextForCausalLM` always instantiates a real `ParallelLMHead` on the last PP rank (no `tie_word_embeddings` branch), so `lm_head.*` weights must be loaded from the checkpoint when present.

## Test Plan

Local validation (macOS arm64, can't run CUDA tests locally):

- `python -m py_compile vllm/model_executor/models/step3_text.py`
- Import `Step3TextForCausalLM` through `ModelRegistry`
- Verify `load_weights` is implemented on both `Step3TextModel` and `Step3TextForCausalLM`
- Verify the outer delegation uses `AutoWeightsLoader`

CI is expected to run the GPU initialization test:

```bash
CUDA_VISIBLE_DEVICES=0 python -m pytest \
  tests/models/test_initialization.py::test_can_initialize_large_subset \
  -q -k Step3TextForCausalLM -s --tb=short
```

## Test Result

Passed:
```bash
python -m py_compile vllm/model_executor/models/step3_text.py
```

Passed:
```bash
python - <<'PY'
from vllm.model_executor.models.registry import ModelRegistry
cls = ModelRegistry._try_load_model_cls("Step3TextForCausalLM")
print(cls)
assert cls is not None
PY
```

Passed:
```bash
python - <<'PY'
from vllm.model_executor.models.step3_text import Step3TextModel, Step3TextForCausalLM
print("Step3TextModel.load_weights:", Step3TextModel.load_weights.__qualname__)
print("Step3TextForCausalLM.load_weights:", Step3TextForCausalLM.load_weights.__qualname__)
import inspect
fcm_src = inspect.getsource(Step3TextForCausalLM.load_weights)
print("Outer delegates via AutoWeightsLoader:", "AutoWeightsLoader" in fcm_src)
PY
```

GPU initialization test deferred to CI — submitter is on macOS arm64 (no CUDA, plus the test runner spawns a subprocess that hits the known macOS objc/fork crash before any model code runs, so this doesn't indicate a problem with the change). macOS arm64 build is also currently broken on `main` by an unrelated upstream regression (#41437, fix in flight at #41387); the change in this PR is Python-only and does not touch any C++ kernels.

## AI assistance

This change was AI-assisted (Claude Code). The submitter reviewed every changed line, walked through the AutoWeightsLoader semantics including PP-missing handling, and validated the structural changes locally.
