### PR TITLE
fix(spec decode): suppress EOS at draft positions in rejection sampler

### DIFF
--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -62,9 +62,11 @@ class RejectionSampler(nn.Module):
         sampler: Sampler,
         spec_config: SpeculativeConfig | None = None,
         device: torch.device | None = None,
+        eos_token_ids: list[int] | None = None,
     ):
         super().__init__()
         self.sampler = sampler
+        self.eos_token_ids = eos_token_ids
         logprobs_mode = self.sampler.logprobs_mode
         self.is_processed_logprobs_mode = logprobs_mode.startswith("processed")
         self.is_logits_logprobs_mode = logprobs_mode.endswith("logits")
@@ -164,6 +166,17 @@ class RejectionSampler(nn.Module):
             metadata.cu_num_draft_tokens,
             sampling_metadata,
         )
+
+        # Suppress EOS at draft positions so MTP speculative decoding
+        # doesn't prematurely terminate tool-call generation.
+        # Use scalar column indexing (select + fill_) instead of list
+        # indexing to avoid the indexSelectSmallIndex CUDA kernel which
+        # can assert with large vocab sizes.
+        if self.eos_token_ids:
+            vocab_size = target_logits.shape[-1]
+            for eid in self.eos_token_ids:
+                if 0 <= eid < vocab_size:
+                    target_logits[:, eid].fill_(float('-inf'))
 
         output_token_ids = rejection_sample(
             metadata.draft_token_ids,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -218,6 +218,25 @@ if TYPE_CHECKING:
 
 logger = init_logger(__name__)
 
+
+def _collect_eos_token_ids(model_config) -> list[int] | None:
+    ids: set[int] = set()
+    for cfg in (model_config.hf_config, model_config.hf_text_config):
+        val = getattr(cfg, 'eos_token_id', None)
+        if val is not None:
+            if isinstance(val, int):
+                ids.add(val)
+            else:
+                ids.update(val)
+    gen_config = model_config.try_get_generation_config()
+    if gen_config and (val := gen_config.get('eos_token_id')) is not None:
+        if isinstance(val, int):
+            ids.add(val)
+        else:
+            ids.update(val)
+    return sorted(ids) if ids else None
+
+
 AttnMetadataDict: TypeAlias = dict[str, AttentionMetadata]
 # list when ubatching is enabled
 PerLayerAttnMetadata: TypeAlias = list[AttnMetadataDict] | AttnMetadataDict
@@ -578,7 +597,8 @@ class GPUModelRunner(
                     f"{self.speculative_config.method}"
                 )
             self.rejection_sampler = RejectionSampler(
-                self.sampler, self.speculative_config, self.device
+                self.sampler, self.speculative_config, self.device,
+                eos_token_ids=_collect_eos_token_ids(self.model_config),
             )
 
         self.num_spec_tokens = 0


### PR DESCRIPTION
## Summary

When using MTP speculative decoding, the rejection sampler's target model can produce EOS as the argmax at a draft position. The scheduler iterates the MTP burst tokens one-by-one via `check_stop()`, which immediately sets `FINISHED_STOPPED` when it encounters EOS — discarding all remaining tokens in the burst, including the bonus token that would have continued generation.

This manifests as premature stopping at reasoning-to-tool-call boundaries: the client receives `finish_reason: "stop"` with only `reasoning_content` and no `tool_calls` or `content`.

**Observed hit rate**: ~0.25% under concurrent load with `num_speculative_tokens=3`, 0% without MTP.

## Context

We run Qwen3.6-27B-FP8 with MTP=3 in production and observed a suite of tool-calling issues with speculative decoding. After applying several open PRs together, tool call reliability improved dramatically:

- #40783 — fragmented `<think/>` tag handling in reasoning parser
- #40861 — structural parsing fixes in Qwen3Coder tool parser
- #39055 — embedded tool call recovery from reasoning
- #36138 — grammar ignored when reasoning ends within speculated tokens
- #39598 — Pydantic null serialization in streaming tool call deltas

We also opened two other sibling draft PRs in an attempt to perfectly fix the issue:

- #41466 — prev_tool_call_arr double-emission fallback
- #41467 — Detect MTP truncation at reasoning-to-tool-call boundary

## Root Cause Analysis

MTP speculative decoding produces two separate logit tensors:
- `target_logits` — covers draft positions (K tokens)
- `bonus_logits` — covers the position after the last accepted draft token

The rejection sampler compares draft tokens against `target_logits`'s argmax. When the argmax at any draft position is EOS, the scheduler's `_update_request_with_output` calls `check_stop()` which immediately sets `FINISHED_STOPPED`, discarding all remaining tokens including the bonus token.

This is particularly problematic at the reasoning-to-tool-call boundary where the model's output transitions from reasoning content to tool-call XML. The target model correctly predicts the continuation at the bonus position, but EOS at a draft position causes the scheduler to stop before reaching it.

## Changes

- `RejectionSampler.__init__` accepts `eos_token_ids` (plural) parameter — collects all EOS variants
- `RejectionSampler.forward` suppresses all EOS tokens in `target_logits` after `apply_sampling_constraints()` and before `rejection_sample()`, using scalar column indexing (`[:, eid].fill_()`) to avoid the `indexSelectSmallIndex` CUDA kernel that asserts with large vocab sizes (observed with Qwen3.6-27B: vocab=248320, eos=248044)
- `_collect_eos_token_ids` helper gathers EOS IDs from multiple config sources:
  - `model_config.hf_config.eos_token_id`
  - `model_config.hf_text_config.eos_token_id` (multimodal models like Qwen3.6-27B nest EOS here)
  - `generation_config.eos_token_id`
  - Handles both `int` and `list[int]` — for Qwen3.6-27B, collects both 248044 (text_config) and 248046 (tokenizer)
- Only the large model runner (`gpu_model_runner.py`) is patched — the small runner uses a different `RejectionSampler` from `vllm/v1/worker/gpu/model_runner.py` with a different API
- Bounds check filters EOS IDs exceeding actual vocab dimension

## Why This Is Safe

Generation is still bounded by multiple mechanisms:
- **Bonus token**: Sampled from a separate `bonus_logits` tensor — CAN still produce EOS for legitimate stops
- **max_tokens**: `check_stop()` enforces `FINISHED_LENGTH_CAPPED`
- **min_tokens**: `check_stop()` enforces minimum generation before any stop
- **Worst case**: At most K extra tokens (MTP=3 → 3 tokens) per burst before the bonus token handles the stop. At greedy temperature, the bonus token deterministically produces EOS when the model wants to stop.

## Reproduction

Using Qwen3.6-27B-FP8 with MTP=3, send tool-calling requests with reasoning enabled under concurrent load. The truncation occurs at ~0.25% hit rate. Stress testing with `--concurrent 4` or higher increases the hit rate.

## Test Plan

- [ ] Verify non-MTP generation is unaffected
- [ ] Stress test with MTP=3 tool-calling workload
- [ ] Run vLLM CI test suite
- [ ] Verify normal (non-tool-calling) generation with MTP stops correctly
