### PR TITLE
Add generic multi-pool KV cache allocation

### DIFF
--- a/tests/v1/core/test_block_pool.py
+++ b/tests/v1/core/test_block_pool.py
@@ -1,0 +1,172 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.v1.core.block_pool import BlockPool, CompactBlockPool
+
+pytestmark = pytest.mark.cpu_test
+
+
+def test_block_pool_reserves_zero_as_null_block():
+    block_pool = BlockPool(
+        num_gpu_blocks=4,
+        enable_caching=False,
+        hash_block_size=16,
+    )
+
+    assert block_pool.null_block.block_id == 0
+    assert block_pool.null_block.is_null
+    assert block_pool.get_num_free_blocks() == 3
+    assert block_pool.get_usage() == 0
+
+
+def test_block_pool_allocation_never_returns_null_block():
+    block_pool = BlockPool(
+        num_gpu_blocks=4,
+        enable_caching=False,
+        hash_block_size=16,
+    )
+
+    blocks = block_pool.get_new_blocks(3)
+
+    assert {block.block_id for block in blocks} == {1, 2, 3}
+    assert all(not block.is_null for block in blocks)
+    assert block_pool.get_num_free_blocks() == 0
+    assert block_pool.get_usage() == 1
+
+
+def test_block_pool_exhaustion_raises_without_allocating_null_block():
+    block_pool = BlockPool(
+        num_gpu_blocks=2,
+        enable_caching=False,
+        hash_block_size=16,
+    )
+
+    with pytest.raises(ValueError, match="Cannot get 2 free blocks"):
+        block_pool.get_new_blocks(2)
+
+    block = block_pool.get_new_blocks(1)[0]
+    assert block.block_id == 1
+    assert block_pool.null_block.block_id == 0
+
+
+def test_block_pool_free_returns_blocks_but_not_null_block():
+    block_pool = BlockPool(
+        num_gpu_blocks=3,
+        enable_caching=False,
+        hash_block_size=16,
+    )
+    blocks = block_pool.get_new_blocks(2)
+
+    block_pool.free_blocks(reversed(blocks))
+
+    assert block_pool.get_num_free_blocks() == 2
+    assert block_pool.get_usage() == 0
+    reallocated = block_pool.get_new_blocks(2)
+    assert {block.block_id for block in reallocated} == {1, 2}
+
+
+@pytest.mark.parametrize(
+    "pool",
+    [
+        BlockPool(num_gpu_blocks=4, enable_caching=False, hash_block_size=16),
+        CompactBlockPool(num_allocatable=3),
+    ],
+)
+def test_block_pool_protocol_conformance(pool):
+    assert pool.num_gpu_blocks == 4
+    assert pool.null_block.block_id == 0
+    assert pool.null_block.is_null
+
+    blocks = pool.get_new_blocks(1)
+
+    assert len(blocks) == 1
+    assert blocks[0].block_id != 0
+    assert not blocks[0].is_null
+    pool.free_blocks(blocks)
+
+
+def test_compact_block_pool_reserves_zero_as_null_block():
+    block_pool = CompactBlockPool(num_allocatable=3)
+
+    assert block_pool.num_gpu_blocks == 4
+    assert block_pool.null_block.block_id == 0
+    assert block_pool.null_block.is_null
+    assert block_pool.get_num_free_blocks() == 3
+    assert block_pool.get_usage() == 0
+
+
+def test_compact_block_pool_allocation_never_returns_null_block():
+    block_pool = CompactBlockPool(num_allocatable=3)
+
+    blocks = block_pool.get_new_blocks(3)
+
+    assert {block.block_id for block in blocks} == {1, 2, 3}
+    assert all(not block.is_null for block in blocks)
+    assert all(block.ref_cnt == 1 for block in blocks)
+    assert block_pool.get_num_free_blocks() == 0
+    assert block_pool.get_usage() == 1
+
+
+def test_compact_block_pool_zero_arg_operations_are_noops():
+    block_pool = CompactBlockPool(num_allocatable=1)
+
+    assert block_pool.get_new_blocks(0) == []
+    block_pool.free_blocks([])
+
+    assert block_pool.get_num_free_blocks() == 1
+    assert block_pool.get_usage() == 0
+
+
+def test_compact_block_pool_exhaustion_matches_shared_pool_error_type():
+    block_pool = CompactBlockPool(num_allocatable=1)
+
+    with pytest.raises(ValueError, match="Cannot get 2 free blocks"):
+        block_pool.get_new_blocks(2)
+
+    block = block_pool.get_new_blocks(1)[0]
+    assert block.block_id == 1
+    assert block_pool.null_block.block_id == 0
+
+
+def test_compact_block_pool_free_returns_blocks_to_pool():
+    block_pool = CompactBlockPool(num_allocatable=2)
+    blocks = block_pool.get_new_blocks(2)
+
+    block_pool.free_blocks(reversed(blocks))
+
+    assert all(block.ref_cnt == 0 for block in blocks)
+    assert block_pool.get_num_free_blocks() == 2
+    assert block_pool.get_usage() == 0
+    reallocated = block_pool.get_new_blocks(2)
+    assert {block.block_id for block in reallocated} == {1, 2}
+    assert all(block.ref_cnt == 1 for block in reallocated)
+
+
+def test_compact_block_pool_rejects_freeing_null_block():
+    block_pool = CompactBlockPool(num_allocatable=1)
+
+    with pytest.raises(AssertionError, match="null block must never be freed"):
+        block_pool.free_blocks([block_pool.null_block])
+
+
+def test_compact_block_pool_rejects_freeing_unallocated_block():
+    block_pool = CompactBlockPool(num_allocatable=1)
+    block = block_pool.get_new_blocks(1)[0]
+    block_pool.free_blocks([block])
+
+    with pytest.raises(AssertionError, match="binary ref_cnt semantics"):
+        block_pool.free_blocks([block])
+
+
+def test_compact_block_pool_allows_zero_allocatable_blocks():
+    block_pool = CompactBlockPool(num_allocatable=0)
+
+    assert block_pool.num_gpu_blocks == 1
+    assert block_pool.null_block.block_id == 0
+    assert block_pool.get_num_free_blocks() == 0
+    assert block_pool.get_usage() == 0
+    assert block_pool.get_new_blocks(0) == []
+    with pytest.raises(ValueError, match="Cannot get 1 free blocks"):
+        block_pool.get_new_blocks(1)

--- a/tests/v1/core/test_kv_cache_coordinator.py
+++ b/tests/v1/core/test_kv_cache_coordinator.py
@@ -1,0 +1,380 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.core.block_pool import BlockPool, CompactBlockPool
+from vllm.v1.core.kv_cache_coordinator import get_kv_cache_coordinator
+from vllm.v1.core.kv_cache_manager import KVCacheManager
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+    KVCachePoolConfig,
+    KVCacheTensor,
+    MambaSpec,
+    MemoryModel,
+    SlidingWindowSpec,
+)
+from vllm.v1.request import Request
+
+pytestmark = pytest.mark.cpu_test
+
+
+def make_full_attention_spec(block_size: int = 16) -> FullAttentionSpec:
+    return FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=2,
+        head_size=64,
+        dtype=torch.float32,
+    )
+
+
+def make_sliding_window_spec(block_size: int = 16) -> SlidingWindowSpec:
+    return SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=2,
+        head_size=64,
+        dtype=torch.float32,
+        sliding_window=128,
+    )
+
+
+def make_mamba_spec(block_size: int = 16) -> MambaSpec:
+    return MambaSpec(
+        block_size=block_size,
+        shapes=((1,),),
+        dtypes=(torch.float32,),
+    )
+
+
+def make_coordinator(config: KVCacheConfig, enable_caching: bool = False):
+    return get_kv_cache_coordinator(
+        kv_cache_config=config,
+        max_model_len=128,
+        max_num_batched_tokens=128,
+        use_eagle=False,
+        enable_caching=enable_caching,
+        enable_kv_cache_events=False,
+        dcp_world_size=1,
+        pcp_world_size=1,
+        scheduler_block_size=16,
+        hash_block_size=16,
+    )
+
+
+def make_kv_cache_manager_config(
+    block_size: int = 4, num_blocks: int = 3
+) -> KVCacheConfig:
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["layer"], make_full_attention_spec(block_size))
+        ],
+    )
+
+
+def make_multi_pool_kv_cache_manager_config() -> KVCacheConfig:
+    block_size = 4
+    full_spec = make_full_attention_spec(block_size)
+    mamba_spec = make_mamba_spec(block_size)
+    return KVCacheConfig(
+        num_blocks=3,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["attention_layer"], full_spec),
+            KVCacheGroupSpec(["mamba_layer"], mamba_spec),
+        ],
+        pool_configs=(
+            KVCachePoolConfig(
+                pool_id=0,
+                memory_model=MemoryModel.TOKEN_PROPORTIONAL,
+                group_ids=(0,),
+                num_blocks=3,
+                accounting_page_size_bytes=full_spec.accounting_page_size_bytes,
+                physical_page_size_bytes=full_spec.physical_page_size_bytes,
+            ),
+            KVCachePoolConfig(
+                pool_id=1,
+                memory_model=MemoryModel.REQUEST_CONSTANT,
+                group_ids=(1,),
+                num_blocks=2,
+                accounting_page_size_bytes=mamba_spec.accounting_page_size_bytes,
+                physical_page_size_bytes=mamba_spec.physical_page_size_bytes,
+            ),
+        ),
+        group_to_pool_id=(0, 1),
+    )
+
+
+def make_request(request_id: str = "request", num_tokens: int = 4) -> Request:
+    return Request(
+        request_id=request_id,
+        prompt_token_ids=[0] * num_tokens,
+        sampling_params=SamplingParams(max_tokens=1),
+        pooling_params=None,
+    )
+
+
+def test_attention_free_config_keeps_legacy_shared_pool_alias():
+    coordinator = make_coordinator(
+        KVCacheConfig(num_blocks=1, kv_cache_tensors=[], kv_cache_groups=[])
+    )
+
+    assert coordinator.block_pool is coordinator._block_pools[0]
+    assert coordinator._group_to_pool == ()
+    assert coordinator.single_type_managers == ()
+    assert coordinator.get_num_free_blocks_by_pool() == ()
+    # The legacy coordinator still owns one shared BlockPool, but
+    # attention-free configs have no KV cache pool metadata and no managers.
+    assert (
+        coordinator.get_num_blocks_to_allocate_by_pool(
+            request_id="request",
+            num_tokens=32,
+            new_computed_blocks=(),
+            num_encoder_tokens=0,
+            total_computed_tokens=0,
+            num_tokens_main_model=32,
+        )
+        == ()
+    )
+    assert (
+        coordinator.get_num_blocks_to_allocate(
+            request_id="request",
+            num_tokens=32,
+            new_computed_blocks=(),
+            num_encoder_tokens=0,
+            total_computed_tokens=0,
+            num_tokens_main_model=32,
+        )
+        == 0
+    )
+
+
+def test_single_group_config_maps_manager_to_legacy_pool_alias():
+    config = KVCacheConfig(
+        num_blocks=10,
+        kv_cache_tensors=[KVCacheTensor(size=100, shared_by=["layer_0"])],
+        kv_cache_groups=[KVCacheGroupSpec(["layer_0"], make_full_attention_spec())],
+    )
+
+    coordinator = make_coordinator(config, enable_caching=True)
+
+    assert coordinator.block_pool is coordinator._block_pools[0]
+    assert coordinator._group_to_pool == (coordinator.block_pool,)
+    assert coordinator.single_type_managers[0].block_pool is coordinator.block_pool
+    assert coordinator.get_num_free_blocks_by_pool() == (9,)
+    assert coordinator.get_num_blocks_to_allocate_by_pool(
+        request_id="request",
+        num_tokens=32,
+        new_computed_blocks=((),),
+        num_encoder_tokens=0,
+        total_computed_tokens=0,
+        num_tokens_main_model=32,
+    ) == (2,)
+    assert (
+        coordinator.get_num_blocks_to_allocate(
+            request_id="request",
+            num_tokens=32,
+            new_computed_blocks=((),),
+            num_encoder_tokens=0,
+            total_computed_tokens=0,
+            num_tokens_main_model=32,
+        )
+        == 2
+    )
+
+
+def test_multi_group_single_pool_config_maps_all_managers_to_legacy_pool_alias():
+    config = KVCacheConfig(
+        num_blocks=10,
+        kv_cache_tensors=[
+            KVCacheTensor(size=100, shared_by=["layer_0"]),
+            KVCacheTensor(size=100, shared_by=["layer_1"]),
+        ],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["layer_0"], make_full_attention_spec()),
+            KVCacheGroupSpec(["layer_1"], make_sliding_window_spec()),
+        ],
+    )
+
+    coordinator = make_coordinator(config)
+
+    assert coordinator.block_pool is coordinator._block_pools[0]
+    assert coordinator._group_to_pool == (
+        coordinator.block_pool,
+        coordinator.block_pool,
+    )
+    assert all(
+        manager.block_pool is coordinator.block_pool
+        for manager in coordinator.single_type_managers
+    )
+    assert coordinator.get_num_free_blocks_by_pool() == (9,)
+    assert coordinator.get_num_blocks_to_allocate_by_pool(
+        request_id="request",
+        num_tokens=32,
+        new_computed_blocks=((), ()),
+        num_encoder_tokens=0,
+        total_computed_tokens=0,
+        num_tokens_main_model=32,
+    ) == (4,)
+    assert (
+        coordinator.get_num_blocks_to_allocate(
+            request_id="request",
+            num_tokens=32,
+            new_computed_blocks=((), ()),
+            num_encoder_tokens=0,
+            total_computed_tokens=0,
+            num_tokens_main_model=32,
+        )
+        == 4
+    )
+
+
+def test_multi_pool_config_without_prefix_cache_builds_configured_pools():
+    full_spec = make_full_attention_spec()
+    mamba_spec = make_mamba_spec()
+    config = KVCacheConfig(
+        num_blocks=10,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["layer_0"], full_spec),
+            KVCacheGroupSpec(["layer_1"], mamba_spec),
+        ],
+        pool_configs=(
+            KVCachePoolConfig(
+                pool_id=0,
+                memory_model=MemoryModel.TOKEN_PROPORTIONAL,
+                group_ids=(0,),
+                num_blocks=10,
+                accounting_page_size_bytes=full_spec.accounting_page_size_bytes,
+                physical_page_size_bytes=full_spec.physical_page_size_bytes,
+            ),
+            KVCachePoolConfig(
+                pool_id=1,
+                memory_model=MemoryModel.REQUEST_CONSTANT,
+                group_ids=(1,),
+                num_blocks=3,
+                accounting_page_size_bytes=mamba_spec.accounting_page_size_bytes,
+                physical_page_size_bytes=mamba_spec.physical_page_size_bytes,
+            ),
+        ),
+        group_to_pool_id=(0, 1),
+    )
+
+    coordinator = make_coordinator(config, enable_caching=False)
+
+    assert isinstance(coordinator._block_pools[0], BlockPool)
+    assert isinstance(coordinator._block_pools[1], CompactBlockPool)
+    assert coordinator.block_pool is coordinator._block_pools[0]
+    assert coordinator._group_to_pool == coordinator._block_pools
+    assert coordinator.get_num_free_blocks_by_pool() == (9, 2)
+    # Full attention remains token-proportional: 32 tokens / block_size 16 = 2.
+    # Request-constant Mamba uses one compact state block per request.
+    assert coordinator.get_num_blocks_to_allocate_by_pool(
+        request_id="request",
+        num_tokens=32,
+        new_computed_blocks=((), ()),
+        num_encoder_tokens=0,
+        total_computed_tokens=0,
+        num_tokens_main_model=32,
+    ) == (2, 1)
+
+
+def test_has_enough_free_blocks_by_pool_uses_pool_tuple():
+    manager = KVCacheManager(
+        kv_cache_config=make_kv_cache_manager_config(num_blocks=3),
+        max_model_len=16,
+        scheduler_block_size=4,
+        hash_block_size=4,
+        enable_caching=False,
+    )
+
+    # num_blocks=3 includes the null sentinel, leaving two allocatable blocks.
+    assert manager.coordinator.get_num_free_blocks_by_pool() == (2,)
+    assert manager._has_enough_free_blocks_by_pool((2,))
+    assert not manager._has_enough_free_blocks_by_pool((3,))
+
+
+def test_allocate_slots_uses_pool_aware_accounting_path():
+    manager = KVCacheManager(
+        kv_cache_config=make_kv_cache_manager_config(num_blocks=3),
+        max_model_len=16,
+        scheduler_block_size=4,
+        hash_block_size=4,
+        enable_caching=False,
+    )
+    request = make_request(num_tokens=4)
+    manager.coordinator.get_num_blocks_to_allocate = Mock(
+        side_effect=AssertionError("legacy scalar accounting should not be used")
+    )
+    get_num_blocks_to_allocate_by_pool = Mock(
+        wraps=manager.coordinator.get_num_blocks_to_allocate_by_pool
+    )
+    manager.coordinator.get_num_blocks_to_allocate_by_pool = (
+        get_num_blocks_to_allocate_by_pool
+    )
+
+    blocks = manager.allocate_slots(request, num_new_tokens=4)
+
+    assert blocks is not None
+    assert blocks.get_block_ids() == ([1],)
+    manager.coordinator.get_num_blocks_to_allocate.assert_not_called()
+    get_num_blocks_to_allocate_by_pool.assert_called_once()
+
+
+def test_allocate_slots_checks_each_pool_independently():
+    manager = KVCacheManager(
+        kv_cache_config=make_multi_pool_kv_cache_manager_config(),
+        max_model_len=16,
+        scheduler_block_size=4,
+        hash_block_size=4,
+        enable_caching=False,
+    )
+
+    blocks = manager.allocate_slots(make_request("first", num_tokens=4), 4)
+
+    assert blocks is not None
+    assert blocks.get_block_ids() == ([1], [1])
+    assert manager.coordinator.get_num_free_blocks_by_pool() == (1, 0)
+    assert manager.allocate_slots(make_request("second", num_tokens=4), 4) is None
+
+
+def test_multi_pool_config_with_prefix_cache_is_rejected_until_pool_aware():
+    full_spec = make_full_attention_spec()
+    sliding_spec = make_sliding_window_spec()
+    config = KVCacheConfig(
+        num_blocks=10,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["layer_0"], full_spec),
+            KVCacheGroupSpec(["layer_1"], sliding_spec),
+        ],
+        pool_configs=(
+            KVCachePoolConfig(
+                pool_id=0,
+                memory_model=MemoryModel.TOKEN_PROPORTIONAL,
+                group_ids=(0,),
+                num_blocks=10,
+                accounting_page_size_bytes=full_spec.accounting_page_size_bytes,
+                physical_page_size_bytes=full_spec.physical_page_size_bytes,
+            ),
+            KVCachePoolConfig(
+                pool_id=1,
+                memory_model=MemoryModel.TOKEN_PROPORTIONAL,
+                group_ids=(1,),
+                num_blocks=10,
+                accounting_page_size_bytes=sliding_spec.accounting_page_size_bytes,
+                physical_page_size_bytes=sliding_spec.physical_page_size_bytes,
+            ),
+        ),
+        group_to_pool_id=(0, 1),
+    )
+
+    with pytest.raises(NotImplementedError, match="prefix caching is disabled"):
+        make_coordinator(config, enable_caching=True)

--- a/tests/v1/core/test_kv_cache_invariants.py
+++ b/tests/v1/core/test_kv_cache_invariants.py
@@ -1,0 +1,188 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Callable
+
+import pytest
+import torch
+
+from vllm.utils.torch_utils import get_dtype_size
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    CrossAttentionSpec,
+    EncoderOnlyAttentionSpec,
+    FullAttentionSpec,
+    KVCacheSpec,
+    MambaSpec,
+    MemoryModel,
+    MLAAttentionSpec,
+    SinkFullAttentionSpec,
+    SlidingWindowSpec,
+    UniformTypeKVCacheSpecs,
+)
+
+pytestmark = pytest.mark.cpu_test
+
+
+def _full_attention_spec() -> FullAttentionSpec:
+    return FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=64,
+        dtype=torch.float16,
+    )
+
+
+def _mla_attention_spec() -> MLAAttentionSpec:
+    return MLAAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=64,
+        dtype=torch.float16,
+    )
+
+
+def _chunked_local_attention_spec() -> ChunkedLocalAttentionSpec:
+    return ChunkedLocalAttentionSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=64,
+        dtype=torch.float16,
+        attention_chunk_size=128,
+    )
+
+
+def _sliding_window_spec() -> SlidingWindowSpec:
+    return SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=64,
+        dtype=torch.float16,
+        sliding_window=128,
+    )
+
+
+def _mamba_spec() -> MambaSpec:
+    return MambaSpec(
+        block_size=16,
+        shapes=((4, 8), (2, 8)),
+        dtypes=(torch.float16, torch.float32),
+    )
+
+
+def _encoder_only_attention_spec() -> EncoderOnlyAttentionSpec:
+    return EncoderOnlyAttentionSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=64,
+        dtype=torch.float16,
+    )
+
+
+def _cross_attention_spec() -> CrossAttentionSpec:
+    return CrossAttentionSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=64,
+        dtype=torch.float16,
+    )
+
+
+def _sink_full_attention_spec() -> SinkFullAttentionSpec:
+    return SinkFullAttentionSpec(
+        block_size=16,
+        num_kv_heads=2,
+        head_size=64,
+        dtype=torch.float16,
+        sink_len=4,
+    )
+
+
+def _uniform_type_kv_cache_specs() -> UniformTypeKVCacheSpecs:
+    return UniformTypeKVCacheSpecs(
+        block_size=16,
+        kv_cache_specs={
+            "layer.0": _full_attention_spec(),
+            "layer.1": _full_attention_spec(),
+        },
+    )
+
+
+TOKEN_PROPORTIONAL_SPEC_FACTORIES: list[tuple[str, Callable[[], KVCacheSpec]]] = [
+    ("FullAttentionSpec", _full_attention_spec),
+    ("MLAAttentionSpec", _mla_attention_spec),
+    ("ChunkedLocalAttentionSpec", _chunked_local_attention_spec),
+    ("SlidingWindowSpec", _sliding_window_spec),
+    ("EncoderOnlyAttentionSpec", _encoder_only_attention_spec),
+    ("CrossAttentionSpec", _cross_attention_spec),
+    ("SinkFullAttentionSpec", _sink_full_attention_spec),
+    ("UniformTypeKVCacheSpecs", _uniform_type_kv_cache_specs),
+]
+
+
+@pytest.mark.parametrize(
+    ("spec_name", "make_spec"),
+    TOKEN_PROPORTIONAL_SPEC_FACTORIES,
+    ids=[name for name, _ in TOKEN_PROPORTIONAL_SPEC_FACTORIES],
+)
+def test_default_memory_model_is_token_proportional(
+    spec_name: str, make_spec: Callable[[], KVCacheSpec]
+) -> None:
+    spec = make_spec()
+
+    assert spec.memory_model == MemoryModel.TOKEN_PROPORTIONAL, spec_name
+    assert spec.accounting_page_size_bytes == spec.page_size_bytes, spec_name
+    assert spec.requires_block_zeroing_on_alloc is True, spec_name
+
+
+@pytest.mark.parametrize("mamba_cache_mode", ["none", "align", "all"])
+def test_mamba_zeroing_metadata_matches_current_zeroer(
+    mamba_cache_mode: str,
+) -> None:
+    spec = MambaSpec(
+        block_size=16,
+        shapes=((4, 8), (2, 8)),
+        dtypes=(torch.float16, torch.float32),
+        mamba_cache_mode=mamba_cache_mode,
+    )
+
+    expected_memory_model = (
+        MemoryModel.TOKEN_PROPORTIONAL
+        if mamba_cache_mode == "all"
+        else MemoryModel.REQUEST_CONSTANT
+    )
+    assert spec.memory_model == expected_memory_model
+    assert spec.accounting_page_size_bytes == spec.page_size_bytes
+    assert spec.requires_block_zeroing_on_alloc is False
+
+
+def test_mamba_physical_page_size_excludes_accounting_padding() -> None:
+    spec = MambaSpec(
+        block_size=16,
+        shapes=((4, 8), (2, 8)),
+        dtypes=(torch.float16, torch.float32),
+        page_size_padded=1024,
+    )
+    expected_physical = (4 * 8 * get_dtype_size(torch.float16)) + (
+        2 * 8 * get_dtype_size(torch.float32)
+    )
+
+    assert spec.physical_page_size_bytes == expected_physical
+    assert spec.page_size_bytes == 1024
+    assert spec.accounting_page_size_bytes == 1024
+
+
+def test_uniform_type_physical_page_size_sums_children() -> None:
+    full_spec = _full_attention_spec()
+    mla_spec = _mla_attention_spec()
+    uniform_spec = UniformTypeKVCacheSpecs(
+        block_size=16,
+        kv_cache_specs={
+            "full": full_spec,
+            "mla": mla_spec,
+        },
+    )
+
+    assert uniform_spec.physical_page_size_bytes == (
+        full_spec.physical_page_size_bytes + mla_spec.physical_page_size_bytes
+    )

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -3,6 +3,7 @@
 import hashlib
 import importlib
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 import pytest
@@ -10,6 +11,7 @@ import torch
 
 import vllm.v1.core.kv_cache_utils as kv_cache_utils
 from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
+from vllm.config.compilation import CompilationConfig, CUDAGraphMode
 from vllm.config.kv_events import KVEventsConfig
 from vllm.lora.request import LoRARequest
 from vllm.multimodal.inputs import (
@@ -20,6 +22,7 @@ from vllm.multimodal.inputs import (
 from vllm.sampling_params import SamplingParams
 from vllm.utils.hashing import sha256, sha256_cbor
 from vllm.utils.mem_constants import GiB_bytes
+from vllm.v1.attention.backend import AttentionCGSupport
 from vllm.v1.core.kv_cache_manager import KVCacheManager
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
@@ -31,6 +34,7 @@ from vllm.v1.core.kv_cache_utils import (
     get_kv_cache_configs,
     get_max_concurrency_for_kv_cache_config,
     get_request_block_hasher,
+    get_token_proportional_kv_cache_capacity_tokens,
     hash_block_tokens,
     init_none_hash,
     is_kv_cache_spec_uniform,
@@ -42,10 +46,12 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    KVCachePoolConfig,
     KVCacheSpec,
     KVCacheSpecKind,
     KVCacheTensor,
     MambaSpec,
+    MemoryModel,
     MLAAttentionSpec,
     SinkFullAttentionSpec,
     SlidingWindowMLASpec,
@@ -179,6 +185,151 @@ def new_mamba_spec(
         page_size_padded=page_size_padded,
         mamba_cache_mode=mamba_cache_mode,
         num_speculative_blocks=num_speculative_blocks,
+    )
+
+
+@dataclass(frozen=True)
+class _DummyRequestConstantSpec(MambaSpec):
+    """Test-only spec for generated request-constant config paths."""
+
+    @property
+    def memory_model(self) -> MemoryModel:
+        return MemoryModel.REQUEST_CONSTANT
+
+    @property
+    def blocks_per_request(self) -> int:
+        return 1 + self.num_speculative_blocks
+
+
+def new_request_constant_spec(
+    block_size=16,
+    shapes=((2,),),
+    dtypes=(torch.float32,),
+    num_speculative_blocks=0,
+    page_size_padded=None,
+):
+    return _DummyRequestConstantSpec(
+        block_size=block_size,
+        shapes=shapes,
+        dtypes=dtypes,
+        num_speculative_blocks=num_speculative_blocks,
+        page_size_padded=page_size_padded,
+    )
+
+
+def assert_legacy_single_pool_metadata(config: KVCacheConfig) -> None:
+    if len(config.kv_cache_groups) == 0:
+        assert config.pool_configs == ()
+        assert config.group_to_pool_id == ()
+        assert config.num_blocks == 1
+        return
+
+    assert len(config.pool_configs) == 1
+    pool_config = config.pool_configs[0]
+    assert pool_config.pool_id == 0
+    assert pool_config.memory_model == MemoryModel.TOKEN_PROPORTIONAL
+    assert pool_config.group_ids == tuple(range(len(config.kv_cache_groups)))
+    assert config.group_to_pool_id == tuple(0 for _ in config.kv_cache_groups)
+    assert pool_config.num_blocks == config.num_blocks
+    assert config.num_blocks == sum(pool.num_blocks for pool in config.pool_configs)
+
+    accounting_page_sizes = {
+        group.kv_cache_spec.accounting_page_size_bytes
+        for group in config.kv_cache_groups
+    }
+    physical_page_sizes = {
+        group.kv_cache_spec.physical_page_size_bytes for group in config.kv_cache_groups
+    }
+    assert len(accounting_page_sizes) == 1
+    accounting_page_size = accounting_page_sizes.pop()
+    assert pool_config.accounting_page_size_bytes == accounting_page_size
+    if len(physical_page_sizes) == 1:
+        assert pool_config.physical_page_size_bytes == physical_page_sizes.pop()
+    else:
+        assert pool_config.physical_page_size_bytes == accounting_page_size
+
+
+def test_legacy_pool_metadata_keeps_mixed_memory_models_shared():
+    attention_spec = new_kv_cache_spec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    mamba_spec = new_mamba_spec(
+        block_size=4,
+        shapes=((4,),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="none",
+    )
+
+    config = KVCacheConfig(
+        num_blocks=7,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["attn"], attention_spec),
+            KVCacheGroupSpec(["mamba"], mamba_spec),
+        ],
+    )
+
+    assert config.group_to_pool_id == (0, 0)
+    assert config.pool_configs == (
+        KVCachePoolConfig(
+            pool_id=0,
+            memory_model=MemoryModel.TOKEN_PROPORTIONAL,
+            group_ids=(0, 1),
+            num_blocks=7,
+            accounting_page_size_bytes=max(
+                attention_spec.accounting_page_size_bytes,
+                mamba_spec.accounting_page_size_bytes,
+            ),
+            physical_page_size_bytes=max(
+                attention_spec.accounting_page_size_bytes,
+                mamba_spec.accounting_page_size_bytes,
+            ),
+        ),
+    )
+
+
+def test_legacy_pool_metadata_keeps_different_page_sizes_shared():
+    small_spec = FullAttentionSpec(
+        block_size=12,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    large_spec = FullAttentionSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+
+    config = KVCacheConfig(
+        num_blocks=11,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["small"], small_spec),
+            KVCacheGroupSpec(["large"], large_spec),
+        ],
+    )
+
+    assert config.group_to_pool_id == (0, 0)
+    assert config.pool_configs == (
+        KVCachePoolConfig(
+            pool_id=0,
+            memory_model=MemoryModel.TOKEN_PROPORTIONAL,
+            group_ids=(0, 1),
+            num_blocks=11,
+            accounting_page_size_bytes=max(
+                small_spec.accounting_page_size_bytes,
+                large_spec.accounting_page_size_bytes,
+            ),
+            physical_page_size_bytes=max(
+                small_spec.accounting_page_size_bytes,
+                large_spec.accounting_page_size_bytes,
+            ),
+        ),
     )
 
 
@@ -1793,6 +1944,579 @@ def test_get_kv_cache_configs_attention_free():
             kv_cache_groups=[],
         )
     ]
+    assert_legacy_single_pool_metadata(kv_cache_configs[0])
+
+
+def test_kv_cache_config_legacy_pool_metadata_single_group():
+    spec = new_kv_cache_spec()
+    config = KVCacheConfig(
+        num_blocks=10,
+        kv_cache_tensors=[
+            KVCacheTensor(size=spec.page_size_bytes * 10, shared_by=["layer_1"]),
+            KVCacheTensor(size=spec.page_size_bytes * 10, shared_by=["layer_2"]),
+        ],
+        kv_cache_groups=[KVCacheGroupSpec(["layer_1", "layer_2"], spec)],
+    )
+
+    assert_legacy_single_pool_metadata(config)
+
+
+def test_kv_cache_config_legacy_pool_metadata_multi_group():
+    model_config = ModelConfig(max_model_len=16)
+    vllm_config = VllmConfig(model_config=model_config)
+    mem_per_block_per_layer = 16 * 2 * 64 * 4 * 2
+    kv_cache_specs = {
+        "layer_1": new_kv_cache_spec(),
+        "layer_2": new_sliding_window_spec(),
+    }
+
+    config = get_kv_cache_configs(
+        vllm_config, [kv_cache_specs], [mem_per_block_per_layer * 2 * 32]
+    )[0]
+
+    assert len(config.kv_cache_groups) == 2
+    assert_legacy_single_pool_metadata(config)
+
+
+def test_kv_cache_config_legacy_pool_metadata_mixed_physical_page_sizes():
+    unpadded_mamba_spec = new_mamba_spec(mamba_cache_mode="all")
+    unified_page_size = unpadded_mamba_spec.physical_page_size_bytes + 1024
+    attention_spec = new_kv_cache_spec(page_size_padded=unified_page_size)
+    mamba_spec = new_mamba_spec(
+        page_size_padded=unified_page_size,
+        mamba_cache_mode="all",
+    )
+    assert (
+        attention_spec.physical_page_size_bytes != mamba_spec.physical_page_size_bytes
+    )
+
+    config = KVCacheConfig(
+        num_blocks=10,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["layer_1"], attention_spec),
+            KVCacheGroupSpec(["layer_2"], mamba_spec),
+        ],
+    )
+
+    assert_legacy_single_pool_metadata(config)
+
+
+def test_kv_cache_config_pool_metadata_tracks_worker_min_blocks():
+    model_config = ModelConfig(max_model_len=16)
+    vllm_config = VllmConfig(model_config=model_config)
+    spec = new_kv_cache_spec()
+    kv_cache_specs = [
+        {
+            "layer1": new_kv_cache_spec(),
+            "layer2": new_kv_cache_spec(),
+        },
+        {
+            "layer1": new_kv_cache_spec(),
+            "layer2": new_kv_cache_spec(),
+        },
+    ]
+
+    kv_cache_configs = get_kv_cache_configs(
+        vllm_config,
+        kv_cache_specs,
+        [
+            spec.page_size_bytes * 2 * 10,
+            spec.page_size_bytes * 2 * 20,
+        ],
+    )
+
+    for config in kv_cache_configs:
+        assert config.num_blocks == 10
+        assert_legacy_single_pool_metadata(config)
+
+
+def make_request_constant_vllm_config(
+    max_model_len: int = 16,
+    max_num_seqs: int = 4,
+) -> VllmConfig:
+    model_config = ModelConfig(max_model_len=max_model_len)
+    scheduler_config = SchedulerConfig(
+        max_num_seqs=max_num_seqs,
+        max_model_len=model_config.max_model_len,
+        is_encoder_decoder=model_config.is_encoder_decoder,
+    )
+    vllm_config = VllmConfig(
+        model_config=model_config,
+        scheduler_config=scheduler_config,
+    )
+    vllm_config.cache_config.enable_prefix_caching = False
+    return vllm_config
+
+
+def test_real_mamba_spec_none_mode_is_request_constant():
+    spec = new_mamba_spec(
+        mamba_cache_mode="none",
+        num_speculative_blocks=2,
+    )
+
+    assert spec.memory_model == MemoryModel.REQUEST_CONSTANT
+    assert spec.blocks_per_request == 3
+    assert spec.physical_page_size_bytes == spec.page_size_bytes
+
+
+def test_real_mamba_spec_align_mode_blocks_per_request():
+    spec = new_mamba_spec(
+        mamba_cache_mode="align",
+        num_speculative_blocks=2,
+    )
+
+    assert spec.memory_model == MemoryModel.REQUEST_CONSTANT
+    assert spec.blocks_per_request == 4
+
+
+def test_real_mamba_spec_all_mode_is_token_proportional():
+    spec = new_mamba_spec(
+        mamba_cache_mode="all",
+        num_speculative_blocks=2,
+    )
+
+    assert spec.memory_model == MemoryModel.TOKEN_PROPORTIONAL
+    assert spec.blocks_per_request == 3
+
+
+def test_hybrid_qwen_like_config_generates_multi_pool():
+    vllm_config = make_request_constant_vllm_config(max_num_seqs=4)
+    attention_spec = new_kv_cache_spec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    mamba_spec = new_mamba_spec(
+        block_size=4,
+        shapes=((4,),),
+        dtypes=(torch.float32,),
+        num_speculative_blocks=0,
+        mamba_cache_mode="none",
+        page_size_padded=attention_spec.page_size_bytes,
+    )
+    mamba_num_blocks = 4 * mamba_spec.blocks_per_request + 1
+    mamba_reserved_bytes = mamba_num_blocks * mamba_spec.physical_page_size_bytes
+    available_memory = mamba_reserved_bytes + attention_spec.page_size_bytes * 20
+
+    config = get_kv_cache_configs(
+        vllm_config,
+        [{"attn": attention_spec, "mamba": mamba_spec}],
+        [available_memory],
+    )[0]
+
+    assert config.kv_cache_groups == [
+        KVCacheGroupSpec(["attn"], attention_spec),
+        KVCacheGroupSpec(["mamba"], mamba_spec),
+    ]
+    assert config.group_to_pool_id == (0, 1)
+    assert config.pool_configs[0].memory_model == MemoryModel.TOKEN_PROPORTIONAL
+    assert config.pool_configs[0].num_blocks == 20
+    assert config.pool_configs[1].memory_model == MemoryModel.REQUEST_CONSTANT
+    assert config.pool_configs[1].num_blocks == mamba_num_blocks
+    assert config.kv_cache_tensors == [
+        KVCacheTensor(size=attention_spec.page_size_bytes * 20, shared_by=["attn"]),
+        KVCacheTensor(size=mamba_reserved_bytes, shared_by=["mamba"]),
+    ]
+
+
+@pytest.mark.parametrize("enable_prefix_caching", [True, False])
+def test_real_mamba_spec_all_mode_keeps_shared_pool(enable_prefix_caching):
+    vllm_config = make_request_constant_vllm_config(max_num_seqs=4)
+    vllm_config.cache_config.enable_prefix_caching = enable_prefix_caching
+    attention_spec = new_kv_cache_spec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        page_size_padded=64,
+    )
+    mamba_spec = new_mamba_spec(
+        block_size=4,
+        shapes=((4,),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="all",
+        page_size_padded=64,
+    )
+
+    config = get_kv_cache_configs(
+        vllm_config,
+        [{"attn": attention_spec, "mamba": mamba_spec}],
+        [64 * 10],
+    )[0]
+
+    assert config.group_to_pool_id == (0, 0)
+    assert len(config.pool_configs) == 1
+    assert config.pool_configs[0].memory_model == MemoryModel.TOKEN_PROPORTIONAL
+
+
+def test_token_proportional_capacity_ignores_request_constant_pool():
+    vllm_config = make_request_constant_vllm_config(
+        max_model_len=16,
+        max_num_seqs=4,
+    )
+    attention_spec = new_kv_cache_spec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    mamba_spec = new_mamba_spec(
+        block_size=4,
+        shapes=((4,),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="none",
+        page_size_padded=attention_spec.page_size_bytes,
+    )
+    mamba_num_blocks = 4 * mamba_spec.blocks_per_request + 1
+    mamba_reserved_bytes = mamba_num_blocks * mamba_spec.physical_page_size_bytes
+
+    config = get_kv_cache_configs(
+        vllm_config,
+        [{"attn": attention_spec, "mamba": mamba_spec}],
+        [mamba_reserved_bytes + attention_spec.page_size_bytes * 16],
+    )[0]
+
+    assert get_token_proportional_kv_cache_capacity_tokens(config) == 64
+    assert get_max_concurrency_for_kv_cache_config(vllm_config, config) == 4
+
+
+def _make_request_constant_mamba_cudagraph_config(
+    max_num_seqs: int = 4,
+    mamba_cache_mode: str = "none",
+    num_speculative_blocks: int = 2,
+) -> KVCacheConfig:
+    vllm_config = make_request_constant_vllm_config(max_num_seqs=max_num_seqs)
+    attention_spec = new_kv_cache_spec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    mamba_spec = new_mamba_spec(
+        block_size=4,
+        shapes=((4,),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode=mamba_cache_mode,
+        num_speculative_blocks=num_speculative_blocks,
+        page_size_padded=attention_spec.page_size_bytes,
+    )
+    mamba_num_blocks = max_num_seqs * mamba_spec.blocks_per_request + 1
+    mamba_reserved_bytes = mamba_num_blocks * mamba_spec.physical_page_size_bytes
+    return get_kv_cache_configs(
+        vllm_config,
+        [{"attn": attention_spec, "mamba": mamba_spec}],
+        [mamba_reserved_bytes + attention_spec.page_size_bytes * 16],
+    )[0]
+
+
+def test_request_constant_mamba_full_cudagraph_uses_pool_capacity():
+    kv_cache_config = _make_request_constant_mamba_cudagraph_config()
+    compilation_config = CompilationConfig(cudagraph_mode=CUDAGraphMode.FULL)
+
+    cudagraph_mode = compilation_config.resolve_cudagraph_mode_and_sizes(
+        min_cg_support=AttentionCGSupport.ALWAYS,
+        min_cg_attn_backend="test",
+        kv_cache_config=kv_cache_config,
+        max_num_reqs=4,
+    )
+
+    assert cudagraph_mode == CUDAGraphMode.FULL
+
+
+def test_request_constant_mamba_full_cudagraph_rejects_small_pool():
+    kv_cache_config = _make_request_constant_mamba_cudagraph_config()
+    compilation_config = CompilationConfig(cudagraph_mode=CUDAGraphMode.FULL)
+
+    with pytest.raises(
+        ValueError,
+        match="REQUEST_CONSTANT KV cache blocks",
+    ):
+        compilation_config.resolve_cudagraph_mode_and_sizes(
+            min_cg_support=AttentionCGSupport.ALWAYS,
+            min_cg_attn_backend="test",
+            kv_cache_config=kv_cache_config,
+            max_num_reqs=5,
+        )
+
+
+def test_request_constant_mamba_full_cudagraph_align_uses_blocks_per_request():
+    kv_cache_config = _make_request_constant_mamba_cudagraph_config(
+        mamba_cache_mode="align",
+        num_speculative_blocks=1,
+    )
+    compilation_config = CompilationConfig(cudagraph_mode=CUDAGraphMode.FULL)
+
+    cudagraph_mode = compilation_config.resolve_cudagraph_mode_and_sizes(
+        min_cg_support=AttentionCGSupport.ALWAYS,
+        min_cg_attn_backend="test",
+        kv_cache_config=kv_cache_config,
+        max_num_reqs=4,
+    )
+
+    assert cudagraph_mode == CUDAGraphMode.FULL
+
+
+def test_request_constant_mamba_full_cudagraph_skips_profiling_capacity():
+    kv_cache_config = _make_request_constant_mamba_cudagraph_config()
+    compilation_config = CompilationConfig(cudagraph_mode=CUDAGraphMode.FULL)
+
+    cudagraph_mode = compilation_config.resolve_cudagraph_mode_and_sizes(
+        min_cg_support=AttentionCGSupport.ALWAYS,
+        min_cg_attn_backend="test",
+        kv_cache_config=kv_cache_config,
+        max_num_reqs=5,
+        is_profiling=True,
+    )
+
+    assert cudagraph_mode == CUDAGraphMode.FULL
+
+
+def test_request_constant_mamba_full_cudagraph_requires_max_num_reqs():
+    kv_cache_config = _make_request_constant_mamba_cudagraph_config()
+    compilation_config = CompilationConfig(cudagraph_mode=CUDAGraphMode.FULL)
+
+    with pytest.raises(
+        ValueError,
+        match="requires max_num_seqs for capacity validation",
+    ):
+        compilation_config.resolve_cudagraph_mode_and_sizes(
+            min_cg_support=AttentionCGSupport.ALWAYS,
+            min_cg_attn_backend="test",
+            kv_cache_config=kv_cache_config,
+            max_num_reqs=None,
+        )
+
+
+def test_mixed_memory_model_config_reserves_request_constant_pool():
+    vllm_config = make_request_constant_vllm_config(max_num_seqs=4)
+    attention_spec = new_kv_cache_spec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    request_constant_spec = new_request_constant_spec(
+        num_speculative_blocks=1,
+        page_size_padded=16,
+    )
+    request_constant_num_blocks = 4 * request_constant_spec.blocks_per_request + 1
+    reserved_bytes = (
+        request_constant_num_blocks * request_constant_spec.physical_page_size_bytes
+    )
+    available_memory = reserved_bytes + attention_spec.page_size_bytes * 10
+
+    config = get_kv_cache_configs(
+        vllm_config,
+        [{"attn": attention_spec, "state": request_constant_spec}],
+        [available_memory],
+    )[0]
+
+    assert config.num_blocks == 10
+    assert config.kv_cache_groups == [
+        KVCacheGroupSpec(["attn"], attention_spec),
+        KVCacheGroupSpec(["state"], request_constant_spec),
+    ]
+    assert config.kv_cache_tensors == [
+        KVCacheTensor(size=attention_spec.page_size_bytes * 10, shared_by=["attn"]),
+        KVCacheTensor(size=reserved_bytes, shared_by=["state"]),
+    ]
+    assert config.group_to_pool_id == (0, 1)
+    assert config.pool_configs == (
+        KVCachePoolConfig(
+            pool_id=0,
+            memory_model=MemoryModel.TOKEN_PROPORTIONAL,
+            group_ids=(0,),
+            num_blocks=10,
+            accounting_page_size_bytes=attention_spec.accounting_page_size_bytes,
+            physical_page_size_bytes=attention_spec.physical_page_size_bytes,
+        ),
+        KVCachePoolConfig(
+            pool_id=1,
+            memory_model=MemoryModel.REQUEST_CONSTANT,
+            group_ids=(1,),
+            num_blocks=request_constant_num_blocks,
+            accounting_page_size_bytes=(
+                request_constant_spec.accounting_page_size_bytes
+            ),
+            physical_page_size_bytes=request_constant_spec.physical_page_size_bytes,
+        ),
+    )
+
+
+def test_multi_pool_config_deterministic_across_workers():
+    vllm_config = make_request_constant_vllm_config(max_num_seqs=4)
+    attention_spec = new_kv_cache_spec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    request_constant_spec = new_request_constant_spec(
+        num_speculative_blocks=1,
+        page_size_padded=16,
+    )
+    request_constant_num_blocks = 4 * request_constant_spec.blocks_per_request + 1
+    reserved_bytes = (
+        request_constant_num_blocks * request_constant_spec.physical_page_size_bytes
+    )
+
+    kv_cache_configs = get_kv_cache_configs(
+        vllm_config,
+        [
+            {"attn": attention_spec, "state": request_constant_spec},
+            {"attn": attention_spec, "state": request_constant_spec},
+        ],
+        [
+            reserved_bytes + attention_spec.page_size_bytes * 10,
+            reserved_bytes + attention_spec.page_size_bytes * 20,
+        ],
+    )
+
+    for config in kv_cache_configs:
+        assert config.num_blocks == 10
+        assert config.pool_configs[0].num_blocks == 10
+        assert config.pool_configs[1].num_blocks == request_constant_num_blocks
+        assert config.kv_cache_tensors == [
+            KVCacheTensor(size=attention_spec.page_size_bytes * 10, shared_by=["attn"]),
+            KVCacheTensor(size=reserved_bytes, shared_by=["state"]),
+        ]
+
+    scheduler_config = generate_scheduler_kv_cache_config(kv_cache_configs)
+    assert scheduler_config.pool_configs == kv_cache_configs[0].pool_configs
+    assert scheduler_config.group_to_pool_id == (0, 1)
+
+
+def test_request_constant_prefix_caching_fails_early():
+    vllm_config = make_request_constant_vllm_config()
+    vllm_config.cache_config.enable_prefix_caching = True
+    attention_spec = new_kv_cache_spec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    request_constant_spec = new_request_constant_spec()
+    reserved_bytes = (
+        vllm_config.scheduler_config.max_num_seqs
+        * request_constant_spec.blocks_per_request
+        + 1
+    ) * request_constant_spec.physical_page_size_bytes
+
+    with pytest.raises(
+        NotImplementedError,
+        match="Prefix caching with REQUEST_CONSTANT groups",
+    ):
+        get_kv_cache_configs(
+            vllm_config,
+            [{"attn": attention_spec, "state": request_constant_spec}],
+            [reserved_bytes + attention_spec.page_size_bytes * 10],
+        )
+
+
+def test_request_constant_reservation_fails_closed_when_memory_exhausted():
+    vllm_config = make_request_constant_vllm_config(max_num_seqs=4)
+    attention_spec = new_kv_cache_spec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    request_constant_spec = new_request_constant_spec(
+        num_speculative_blocks=1,
+        page_size_padded=16,
+    )
+    request_constant_num_blocks = 4 * request_constant_spec.blocks_per_request + 1
+    reserved_bytes = (
+        request_constant_num_blocks * request_constant_spec.physical_page_size_bytes
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="REQUEST_CONSTANT KV cache reservation",
+    ):
+        kv_cache_utils.get_kv_cache_config_from_groups(
+            vllm_config,
+            [
+                KVCacheGroupSpec(["attn"], attention_spec),
+                KVCacheGroupSpec(["state"], request_constant_spec),
+            ],
+            available_memory=reserved_bytes,
+        )
+
+
+def test_request_constant_num_blocks_override_allows_minimal_config():
+    vllm_config = make_request_constant_vllm_config(max_num_seqs=4)
+    vllm_config.cache_config.num_gpu_blocks_override = 1
+    attention_spec = new_kv_cache_spec(
+        block_size=4,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    request_constant_spec = new_request_constant_spec(
+        num_speculative_blocks=1,
+        page_size_padded=16,
+    )
+    request_constant_num_blocks = 4 * request_constant_spec.blocks_per_request + 1
+    reserved_bytes = (
+        request_constant_num_blocks * request_constant_spec.physical_page_size_bytes
+    )
+
+    config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config,
+        [
+            KVCacheGroupSpec(["attn"], attention_spec),
+            KVCacheGroupSpec(["state"], request_constant_spec),
+        ],
+        available_memory=0,
+    )
+
+    assert config.num_blocks == 1
+    assert config.pool_configs[0].num_blocks == 1
+    assert config.pool_configs[1].num_blocks == request_constant_num_blocks
+    assert config.kv_cache_tensors == [
+        KVCacheTensor(size=attention_spec.page_size_bytes, shared_by=["attn"]),
+        KVCacheTensor(size=reserved_bytes, shared_by=["state"]),
+    ]
+
+
+def test_request_constant_only_num_blocks_override_allows_minimal_config():
+    vllm_config = make_request_constant_vllm_config(max_num_seqs=4)
+    vllm_config.cache_config.num_gpu_blocks_override = 1
+    request_constant_spec = new_request_constant_spec(
+        num_speculative_blocks=1,
+        page_size_padded=16,
+    )
+    request_constant_num_blocks = 4 * request_constant_spec.blocks_per_request + 1
+    reserved_bytes = (
+        request_constant_num_blocks * request_constant_spec.physical_page_size_bytes
+    )
+
+    config = kv_cache_utils.get_kv_cache_config_from_groups(
+        vllm_config,
+        [KVCacheGroupSpec(["state"], request_constant_spec)],
+        available_memory=0,
+    )
+
+    assert config.num_blocks == request_constant_num_blocks
+    assert config.group_to_pool_id == (0,)
+    assert config.pool_configs == (
+        KVCachePoolConfig(
+            pool_id=0,
+            memory_model=MemoryModel.REQUEST_CONSTANT,
+            group_ids=(0,),
+            num_blocks=request_constant_num_blocks,
+            accounting_page_size_bytes=(
+                request_constant_spec.accounting_page_size_bytes
+            ),
+            physical_page_size_bytes=request_constant_spec.physical_page_size_bytes,
+        ),
+    )
+    assert config.kv_cache_tensors == [
+        KVCacheTensor(size=reserved_bytes, shared_by=["state"]),
+    ]
 
 
 def test_generate_uniform_type_kv_cache_specs():
@@ -1866,6 +2590,36 @@ def test_generate_scheduler_kv_cache_config():
         kv_cache_tensors=[],
         kv_cache_groups=[KVCacheGroupSpec(["layer_1", "layer_2"], new_kv_cache_spec())],
     )
+
+
+def test_generate_scheduler_kv_cache_config_rejects_mismatched_pool_schema():
+    spec = new_kv_cache_spec()
+    kv_cache_config = KVCacheConfig(
+        num_blocks=10,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["layer_1"], spec)],
+    )
+    mismatched_kv_cache_config = KVCacheConfig(
+        num_blocks=10,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["layer_1"], spec)],
+        pool_configs=(
+            KVCachePoolConfig(
+                pool_id=0,
+                memory_model=MemoryModel.TOKEN_PROPORTIONAL,
+                group_ids=(0,),
+                num_blocks=10,
+                accounting_page_size_bytes=spec.accounting_page_size_bytes + 1,
+                physical_page_size_bytes=spec.physical_page_size_bytes,
+            ),
+        ),
+        group_to_pool_id=(0,),
+    )
+
+    with pytest.raises(AssertionError):
+        generate_scheduler_kv_cache_config(
+            [kv_cache_config, mismatched_kv_cache_config]
+        )
 
 
 def new_mla_spec(cache_dtype_str=None):
@@ -2196,7 +2950,16 @@ def test_auto_fit_max_model_len_with_hybrid():
     model_config = ModelConfig(max_model_len=8192)
     # Simulate the user passing -1 by setting original_max_model_len
     model_config.original_max_model_len = -1
-    vllm_config = VllmConfig(model_config=model_config)
+    scheduler_config = SchedulerConfig(
+        max_num_seqs=1,
+        max_model_len=model_config.max_model_len,
+        is_encoder_decoder=model_config.is_encoder_decoder,
+    )
+    vllm_config = VllmConfig(
+        model_config=model_config,
+        scheduler_config=scheduler_config,
+    )
+    vllm_config.cache_config.enable_prefix_caching = False
 
     mem_per_block_per_layer = 16 * 2 * 64 * 4 * 2  # 16KB per block per layer
     gamma = 2
@@ -2205,7 +2968,9 @@ def test_auto_fit_max_model_len_with_hybrid():
         "layer_2": new_kv_cache_spec(),
     }
 
-    available_memory = mem_per_block_per_layer * (1024 // 16 + 1 + gamma)
+    # 64 attention blocks for 1024 tokens plus 3 compact Mamba blocks for the
+    # single request and 1 compact-pool null block.
+    available_memory = mem_per_block_per_layer * (1024 // 16 + 1 + gamma + 1)
     _kv_cache_configs = get_kv_cache_configs(
         vllm_config, [kv_cache_specs], [available_memory]
     )

--- a/tests/v1/core/test_prefix_caching.py
+++ b/tests/v1/core/test_prefix_caching.py
@@ -37,8 +37,10 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    KVCachePoolConfig,
     KVCacheSpecKind,
     MambaSpec,
+    MemoryModel,
     SlidingWindowSpec,
 )
 
@@ -140,8 +142,9 @@ def make_kv_cache_config_hybrid_model(
     elif second_spec_type == "mamba":
         second_spec = MambaSpec(
             block_size=block_size,
-            shapes=(1, 1),
+            shapes=((1, 1),),
             dtypes=(torch.float32,),
+            page_size_padded=8 * block_size,
         )
 
     return KVCacheConfig(
@@ -175,8 +178,12 @@ def make_kv_cache_config_three_types(
     if third_spec_type == "mamba":
         third_spec = MambaSpec(
             block_size=block_size,
-            shapes=(1, 1),
+            shapes=((1, 1),),
             dtypes=(torch.float32,),
+            page_size_padded=8 * block_size,
+            # This helper is used by prefix-caching event tests. Request-constant
+            # Mamba modes intentionally reject prefix caching.
+            mamba_cache_mode="all",
         )
     elif third_spec_type == "sliding_window":
         third_spec = SlidingWindowSpec(
@@ -755,13 +762,19 @@ def _make_hybrid_kv_cache_config(
         ),
         "mamba": lambda: MambaSpec(
             block_size=block_size,
-            shapes=(1, 1),
+            shapes=((1, 1),),
             dtypes=(torch.float32,),
+            page_size_padded=8 * block_size,
+            # Prefix-caching tests exercise the legacy shared-pool Mamba path.
+            # Non-"all" Mamba modes are REQUEST_CONSTANT and intentionally
+            # fail-closed with prefix caching.
+            mamba_cache_mode="all",
         ),
         "mamba_align": lambda: MambaSpec(
             block_size=block_size,
-            shapes=(1, 1),
+            shapes=((1, 1),),
             dtypes=(torch.float32,),
+            page_size_padded=8 * block_size,
             mamba_cache_mode="align",
         ),
     }
@@ -982,44 +995,62 @@ def test_prefill_hybrid_model_combinations_eagle(
     manager.free(req1)
 
 
-def test_prefill_hybrid_model_mamba_align():
-    """Test that MambaManager.cache_blocks() handles null blocks in align mode.
-
-    Regression test for https://github.com/vllm-project/vllm/issues/34361.
-    In mamba_cache_mode="align", allocate_new_blocks() pads req_to_blocks with
-    null blocks. cache_full_blocks() correctly skips them, but
-    MambaManager.cache_blocks() must also skip null blocks when tracking
-    cached_blocks_this_step.
-    """
+def test_prefill_hybrid_model_mamba_align_prefix_caching_rejected():
+    """mamba_cache_mode="align" is REQUEST_CONSTANT and not prefix-cacheable."""
     block_size = 16
     num_blocks = 30
-
-    kv_cache_config = _make_hybrid_kv_cache_config(
-        block_size, num_blocks, ["full", "mamba_align"]
+    full_spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
     )
-    manager = make_kv_cache_manager(
-        kv_cache_config,
-        max_model_len=8192,
-        enable_caching=True,
-        hash_block_size=block_size,
+    mamba_spec = MambaSpec(
+        block_size=block_size,
+        shapes=((1, 1),),
+        dtypes=(torch.float32,),
+        page_size_padded=8 * block_size,
+        mamba_cache_mode="align",
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["layer0"], full_spec),
+            KVCacheGroupSpec(["layer1"], mamba_spec),
+        ],
+        pool_configs=(
+            KVCachePoolConfig(
+                pool_id=0,
+                memory_model=MemoryModel.TOKEN_PROPORTIONAL,
+                group_ids=(0,),
+                num_blocks=num_blocks,
+                accounting_page_size_bytes=full_spec.accounting_page_size_bytes,
+                physical_page_size_bytes=full_spec.physical_page_size_bytes,
+            ),
+            KVCachePoolConfig(
+                pool_id=1,
+                memory_model=MemoryModel.REQUEST_CONSTANT,
+                group_ids=(1,),
+                num_blocks=3,
+                accounting_page_size_bytes=mamba_spec.accounting_page_size_bytes,
+                physical_page_size_bytes=mamba_spec.physical_page_size_bytes,
+            ),
+        ),
+        group_to_pool_id=(0, 1),
     )
 
-    hash_fn = sha256
-
-    # 3 full blocks (48 tokens) + 7 partial tokens = 55 tokens total
-    all_token_ids = [i for i in range(3) for _ in range(block_size)] + [3] * 7
-
-    # First request: allocate_slots should not crash with the assertion error
-    # in MambaManager.cache_blocks() when null blocks are present.
-    req0 = make_request("0", all_token_ids, block_size, hash_fn)
-    computed_blocks, num_computed_tokens = manager.get_computed_blocks(req0)
-    assert num_computed_tokens == 0
-
-    blocks = manager.allocate_slots(req0, 55, num_computed_tokens, computed_blocks)
-    assert blocks is not None
-    assert len(blocks.get_block_ids()) == 2  # full_attn + mamba groups
-
-    manager.free(req0)
+    with pytest.raises(
+        NotImplementedError,
+        match="multi-pool configs only when prefix caching is disabled",
+    ):
+        KVCacheManager(
+            kv_cache_config,
+            max_model_len=8192,
+            enable_caching=True,
+            scheduler_block_size=block_size,
+            hash_block_size=block_size,
+        )
 
 
 def test_prefill_plp():
@@ -1980,6 +2011,43 @@ def test_kv_cache_events(blocks_to_cache: int):
 
     assert isinstance(events[-1], AllBlocksCleared)
     assert len(manager.block_pool.cached_block_hash_to_block) == 0
+
+
+def test_request_constant_only_kv_cache_events_noop():
+    block_size = 4
+    mamba_spec = MambaSpec(
+        block_size=block_size,
+        shapes=((1,),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="none",
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=3,
+        kv_cache_tensors=[],
+        kv_cache_groups=[KVCacheGroupSpec(["mamba"], mamba_spec)],
+        pool_configs=(
+            KVCachePoolConfig(
+                pool_id=0,
+                memory_model=MemoryModel.REQUEST_CONSTANT,
+                group_ids=(0,),
+                num_blocks=3,
+                accounting_page_size_bytes=mamba_spec.accounting_page_size_bytes,
+                physical_page_size_bytes=mamba_spec.physical_page_size_bytes,
+            ),
+        ),
+        group_to_pool_id=(0,),
+    )
+
+    manager = KVCacheManager(
+        kv_cache_config,
+        max_model_len=8192,
+        enable_caching=False,
+        enable_kv_cache_events=True,
+        scheduler_block_size=block_size,
+        hash_block_size=block_size,
+    )
+
+    assert manager.take_events() == []
 
 
 def test_null_parent_block_hash():

--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -31,6 +31,9 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    KVCachePoolConfig,
+    MambaSpec,
+    MemoryModel,
 )
 from vllm.v1.outputs import DraftTokenIds, KVConnectorOutput, ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
@@ -72,6 +75,162 @@ def test_get_num_unfinished_requests():
     for i, request in enumerate(requests):
         scheduler.finish_requests(request.request_id, RequestStatus.FINISHED_STOPPED)
         assert scheduler.get_num_unfinished_requests() == len(requests) - i - 1
+
+
+def test_routed_experts_capacity_uses_token_proportional_pool():
+    block_size = 16
+    num_attention_blocks = 8
+    model_config = ModelConfig(
+        model="facebook/opt-125m",
+        trust_remote_code=True,
+        dtype="float16",
+        seed=42,
+        skip_tokenizer_init=True,
+    )
+    model_config.enable_return_routed_experts = True
+    model_config.hf_text_config.num_experts = 4
+    model_config.hf_text_config.num_experts_per_tok = 2
+    scheduler_config = SchedulerConfig(
+        max_num_seqs=1,
+        max_num_batched_tokens=128,
+        max_model_len=128,
+        is_encoder_decoder=model_config.is_encoder_decoder,
+    )
+    cache_config = CacheConfig(
+        block_size=block_size,
+        gpu_memory_utilization=0.9,
+        cache_dtype="auto",
+        enable_prefix_caching=False,
+    )
+    vllm_config = VllmConfig(
+        scheduler_config=scheduler_config,
+        model_config=model_config,
+        cache_config=cache_config,
+    )
+    attention_spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    mamba_spec = MambaSpec(
+        block_size=block_size,
+        shapes=((4,),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="none",
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=num_attention_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["attn"], attention_spec),
+            KVCacheGroupSpec(["mamba"], mamba_spec),
+        ],
+        pool_configs=(
+            KVCachePoolConfig(
+                pool_id=0,
+                memory_model=MemoryModel.TOKEN_PROPORTIONAL,
+                group_ids=(0,),
+                num_blocks=num_attention_blocks,
+                accounting_page_size_bytes=attention_spec.page_size_bytes,
+                physical_page_size_bytes=attention_spec.physical_page_size_bytes,
+            ),
+            KVCachePoolConfig(
+                pool_id=1,
+                memory_model=MemoryModel.REQUEST_CONSTANT,
+                group_ids=(1,),
+                num_blocks=2,
+                accounting_page_size_bytes=mamba_spec.page_size_bytes,
+                physical_page_size_bytes=mamba_spec.physical_page_size_bytes,
+            ),
+        ),
+        group_to_pool_id=(0, 1),
+    )
+    cache_config.num_gpu_blocks = num_attention_blocks
+
+    scheduler = Scheduler(
+        vllm_config=vllm_config,
+        kv_cache_config=kv_cache_config,
+        block_size=block_size,
+        structured_output_manager=StructuredOutputManager(vllm_config),
+    )
+
+    expected_max_num_kv_tokens = num_attention_blocks * block_size
+    assert scheduler.routed_experts_mgr.attn_gid == 0
+    assert (
+        scheduler.routed_experts_mgr.routed_experts_by_slot.shape[0]
+        == expected_max_num_kv_tokens
+    )
+
+
+def test_kv_connector_rejects_request_constant_block_pool():
+    block_size = 16
+    model_config = ModelConfig(
+        model="facebook/opt-125m",
+        trust_remote_code=True,
+        dtype="float16",
+        seed=42,
+        skip_tokenizer_init=True,
+    )
+    scheduler_config = SchedulerConfig(
+        max_num_seqs=1,
+        max_num_batched_tokens=128,
+        max_model_len=128,
+        is_encoder_decoder=model_config.is_encoder_decoder,
+    )
+    cache_config = CacheConfig(
+        block_size=block_size,
+        gpu_memory_utilization=0.9,
+        cache_dtype="auto",
+        enable_prefix_caching=False,
+    )
+    kv_transfer_config = KVTransferConfig(
+        kv_connector="MockKVConnector",
+        kv_role="kv_both",
+        kv_connector_extra_config={
+            "matched_tokens": 0,
+            "is_async": False,
+        },
+    )
+    vllm_config = VllmConfig(
+        scheduler_config=scheduler_config,
+        model_config=model_config,
+        cache_config=cache_config,
+        kv_transfer_config=kv_transfer_config,
+    )
+    mamba_spec = MambaSpec(
+        block_size=block_size,
+        shapes=((4,),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="none",
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=2,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["mamba"], mamba_spec),
+        ],
+        pool_configs=(
+            KVCachePoolConfig(
+                pool_id=0,
+                memory_model=MemoryModel.REQUEST_CONSTANT,
+                group_ids=(0,),
+                num_blocks=2,
+                accounting_page_size_bytes=mamba_spec.page_size_bytes,
+                physical_page_size_bytes=mamba_spec.physical_page_size_bytes,
+            ),
+        ),
+        group_to_pool_id=(0,),
+    )
+    cache_config.num_gpu_blocks = 2
+
+    with pytest.raises(NotImplementedError, match="KV connector requires"):
+        Scheduler(
+            vllm_config=vllm_config,
+            kv_cache_config=kv_cache_config,
+            block_size=block_size,
+            structured_output_manager=StructuredOutputManager(vllm_config),
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -6,7 +6,7 @@ import random
 import pytest
 import torch
 
-from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.block_pool import BlockPool, CompactBlockPool
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
     KVCacheBlock,
@@ -14,9 +14,16 @@ from vllm.v1.core.kv_cache_utils import (
 )
 from vllm.v1.core.single_type_kv_cache_manager import (
     ChunkedLocalAttentionManager,
+    FullAttentionManager,
+    MambaManager,
     SlidingWindowManager,
 )
-from vllm.v1.kv_cache_interface import ChunkedLocalAttentionSpec, SlidingWindowSpec
+from vllm.v1.kv_cache_interface import (
+    ChunkedLocalAttentionSpec,
+    FullAttentionSpec,
+    MambaSpec,
+    SlidingWindowSpec,
+)
 
 pytestmark = pytest.mark.cpu_test
 
@@ -44,6 +51,198 @@ def get_chunked_local_attention_manager(
         scheduler_block_size=chunked_local_attention_spec.block_size,
         max_admission_blocks_per_request=10**9,
     )
+
+
+@pytest.mark.parametrize(
+    ("kv_cache_spec", "manager_cls", "should_record"),
+    [
+        (
+            FullAttentionSpec(
+                block_size=2,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+            ),
+            FullAttentionManager,
+            True,
+        ),
+        (
+            SlidingWindowSpec(
+                block_size=2,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+                sliding_window=4,
+            ),
+            SlidingWindowManager,
+            False,
+        ),
+        (
+            ChunkedLocalAttentionSpec(
+                block_size=2,
+                num_kv_heads=1,
+                head_size=1,
+                dtype=torch.float32,
+                attention_chunk_size=4,
+            ),
+            ChunkedLocalAttentionManager,
+            False,
+        ),
+        (
+            MambaSpec(
+                block_size=2,
+                shapes=((1,),),
+                dtypes=(torch.float32,),
+            ),
+            MambaManager,
+            False,
+        ),
+    ],
+)
+def test_legacy_new_block_ids_for_zeroing_behavior(
+    kv_cache_spec, manager_cls, should_record
+):
+    block_pool = BlockPool(
+        num_gpu_blocks=10,
+        enable_caching=False,
+        hash_block_size=kv_cache_spec.block_size,
+    )
+    manager = manager_cls(
+        kv_cache_spec,
+        block_pool=block_pool,
+        enable_caching=False,
+        kv_cache_group_id=0,
+        scheduler_block_size=kv_cache_spec.block_size,
+    )
+
+    new_blocks = manager.allocate_new_blocks(
+        request_id="request",
+        num_tokens=4,
+        num_tokens_main_model=4,
+    )
+
+    if should_record:
+        assert manager.take_new_block_ids() == [b.block_id for b in new_blocks]
+    else:
+        assert manager.take_new_block_ids() == []
+    assert manager.take_new_block_ids() == []
+
+
+def test_mamba_manager_accepts_allocation_only_pool_when_caching_disabled():
+    kv_cache_spec = MambaSpec(
+        block_size=2,
+        shapes=((1,),),
+        dtypes=(torch.float32,),
+    )
+    block_pool = CompactBlockPool(num_allocatable=2)
+    manager = MambaManager(
+        kv_cache_spec,
+        block_pool=block_pool,
+        enable_caching=False,
+        kv_cache_group_id=0,
+        scheduler_block_size=kv_cache_spec.block_size,
+    )
+
+    new_blocks = manager.allocate_new_blocks(
+        request_id="request",
+        num_tokens=4,
+        num_tokens_main_model=4,
+    )
+
+    assert [block.block_id for block in new_blocks] == [2]
+    assert block_pool.get_num_free_blocks() == 1
+    manager.free("request")
+    assert block_pool.get_num_free_blocks() == 2
+
+
+def test_mamba_manager_request_constant_none_allocates_once():
+    kv_cache_spec = MambaSpec(
+        block_size=2,
+        shapes=((1,),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="none",
+        num_speculative_blocks=1,
+    )
+    block_pool = CompactBlockPool(num_allocatable=4)
+    manager = MambaManager(
+        kv_cache_spec,
+        block_pool=block_pool,
+        enable_caching=False,
+        kv_cache_group_id=0,
+        scheduler_block_size=kv_cache_spec.block_size,
+    )
+
+    assert (
+        manager.get_num_blocks_to_allocate(
+            "request",
+            num_tokens=100,
+            new_computed_blocks=[],
+            total_computed_tokens=0,
+            num_tokens_main_model=100,
+        )
+        == kv_cache_spec.blocks_per_request
+    )
+    new_blocks = manager.allocate_new_blocks(
+        request_id="request",
+        num_tokens=100,
+        num_tokens_main_model=100,
+    )
+
+    assert len(new_blocks) == kv_cache_spec.blocks_per_request
+    assert all(block.block_id != 0 for block in new_blocks)
+    assert block_pool.get_num_free_blocks() == 2
+    assert (
+        manager.get_num_blocks_to_allocate(
+            "request",
+            num_tokens=200,
+            new_computed_blocks=[],
+            total_computed_tokens=100,
+            num_tokens_main_model=200,
+        )
+        == 0
+    )
+    assert (
+        manager.allocate_new_blocks(
+            request_id="request",
+            num_tokens=200,
+            num_tokens_main_model=200,
+        )
+        == []
+    )
+
+    manager.remove_skipped_blocks("request", num_computed_tokens=100)
+    assert block_pool.get_num_free_blocks() == 2
+    manager.free("request")
+    assert block_pool.get_num_free_blocks() == 4
+
+
+def test_mamba_manager_request_constant_align_free_filters_null_blocks():
+    kv_cache_spec = MambaSpec(
+        block_size=2,
+        shapes=((1,),),
+        dtypes=(torch.float32,),
+        mamba_cache_mode="align",
+    )
+    block_pool = CompactBlockPool(num_allocatable=4)
+    manager = MambaManager(
+        kv_cache_spec,
+        block_pool=block_pool,
+        enable_caching=False,
+        kv_cache_group_id=0,
+        scheduler_block_size=kv_cache_spec.block_size,
+    )
+
+    new_blocks = manager.allocate_new_blocks(
+        request_id="request",
+        num_tokens=6,
+        num_tokens_main_model=6,
+    )
+
+    assert len(new_blocks) == 3
+    assert sum(not block.is_null for block in manager.req_to_blocks["request"]) == 1
+    assert block_pool.get_num_free_blocks() == 3
+    manager.free("request")
+    assert block_pool.get_num_free_blocks() == 4
 
 
 def test_chunked_local_attention_possible_cached_prefix():

--- a/tests/v1/kv_connector/unit/utils.py
+++ b/tests/v1/kv_connector/unit/utils.py
@@ -477,6 +477,9 @@ def make_kv_cache_config(
                     block_size=block_size,
                     shapes=((16,), (16,)),
                     dtypes=(torch.float16,),
+                    # These connector tests exercise the legacy shared-pool
+                    # prefix-cache path, not request-constant Mamba allocation.
+                    mamba_cache_mode="all",
                 ),
             )
         )

--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+import pytest
 import torch
 
 from vllm import SamplingParams
@@ -34,7 +35,10 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    KVCachePoolConfig,
     KVCacheTensor,
+    MambaSpec,
+    MemoryModel,
 )
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import Request
@@ -91,6 +95,59 @@ def _make_kv_cache_config(
         num_blocks=num_blocks,
         kv_cache_tensors=tensors,
         kv_cache_groups=groups,
+    )
+
+
+def _make_request_constant_kv_cache_config(num_blocks: int = 8) -> KVCacheConfig:
+    attention_spec = FullAttentionSpec(
+        block_size=BLOCK_SIZE,
+        num_kv_heads=NUM_KV_HEADS,
+        head_size=HEAD_SIZE,
+        dtype=DTYPE,
+    )
+    mamba_spec = MambaSpec(
+        block_size=BLOCK_SIZE,
+        shapes=((1,),),
+        dtypes=(DTYPE,),
+        mamba_cache_mode="none",
+        page_size_padded=attention_spec.page_size_bytes,
+    )
+    mamba_num_blocks = 3
+    return KVCacheConfig(
+        num_blocks=num_blocks,
+        kv_cache_tensors=[
+            KVCacheTensor(
+                size=attention_spec.page_size_bytes * num_blocks,
+                shared_by=["attn"],
+            ),
+            KVCacheTensor(
+                size=mamba_spec.physical_page_size_bytes * mamba_num_blocks,
+                shared_by=["mamba"],
+            ),
+        ],
+        kv_cache_groups=[
+            KVCacheGroupSpec(["attn"], attention_spec),
+            KVCacheGroupSpec(["mamba"], mamba_spec),
+        ],
+        pool_configs=(
+            KVCachePoolConfig(
+                pool_id=0,
+                memory_model=MemoryModel.TOKEN_PROPORTIONAL,
+                group_ids=(0,),
+                num_blocks=num_blocks,
+                accounting_page_size_bytes=attention_spec.accounting_page_size_bytes,
+                physical_page_size_bytes=attention_spec.physical_page_size_bytes,
+            ),
+            KVCachePoolConfig(
+                pool_id=1,
+                memory_model=MemoryModel.REQUEST_CONSTANT,
+                group_ids=(1,),
+                num_blocks=mamba_num_blocks,
+                accounting_page_size_bytes=mamba_spec.accounting_page_size_bytes,
+                physical_page_size_bytes=mamba_spec.physical_page_size_bytes,
+            ),
+        ),
+        group_to_pool_id=(0, 1),
     )
 
 
@@ -173,6 +230,19 @@ def make_scheduler(
         kv_cache_config=kv_cache_config,
         num_groups=num_groups,
     )
+
+
+def test_cpu_offload_rejects_request_constant_kv_cache():
+    kv_cache_config = _make_request_constant_kv_cache_config()
+
+    with pytest.raises(
+        NotImplementedError,
+        match="CPU KV cache offload with REQUEST_CONSTANT specs",
+    ):
+        SimpleCPUOffloadScheduler._derive_cpu_config(
+            kv_cache_config,
+            cpu_capacity_bytes=_BYTES_PER_BLOCK,
+        )
 
 
 _req_counter = 0

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -26,7 +27,9 @@ from vllm.distributed.parallel_state import (
 from vllm.distributed.weight_transfer.base import SparseWeightPatch
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.mamba.mamba_mixer2 import MambaMixer2
+from vllm.model_executor.models import ModelRegistry
 from vllm.platforms import current_platform
+from vllm.platforms.interface import Platform
 from vllm.sampling_params import SamplingParams
 from vllm.utils.mem_constants import GiB_bytes
 from vllm.utils.system_utils import update_environment_variables
@@ -36,21 +39,162 @@ from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.core.kv_cache_utils import estimate_max_model_len, get_kv_cache_configs
 from vllm.v1.core.sched.output import CachedRequestData, NewRequestData, SchedulerOutput
 from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheTensor,
+    MambaSpec,
+    MemoryModel,
 )
 from vllm.v1.outputs import EMPTY_MODEL_RUNNER_OUTPUT
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
 from vllm.v1.worker.gpu_input_batch import InputBatch
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
-from vllm.v1.worker.utils import select_common_block_size
+from vllm.v1.worker.kv_connector_model_runner_mixin import (
+    KVConnectorModelRunnerMixin,
+)
+from vllm.v1.worker.utils import AttentionGroup, select_common_block_size
 
 BLOCK_SIZE = 16
 NUM_BLOCKS = 10
 DEVICE_TYPE = current_platform.device_type
+
+
+@dataclass(frozen=True)
+class _RequestConstantMambaSpec(MambaSpec):
+    """Test-only Mamba-like request-constant spec for worker reshape paths."""
+
+    @property
+    def memory_model(self) -> MemoryModel:
+        return MemoryModel.REQUEST_CONSTANT
+
+
+@dataclass(frozen=True, kw_only=True)
+class _RequestConstantFullAttentionSpec(FullAttentionSpec):
+    """Test-only invalid attention spec used to verify fail-closed guards."""
+
+    @property
+    def memory_model(self) -> MemoryModel:
+        return MemoryModel.REQUEST_CONSTANT
+
+
+class _TestAttentionBackend:
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, int, int, int, int]:
+        return (2, num_blocks, block_size, num_kv_heads, head_size)
+
+    @staticmethod
+    def get_kv_cache_stride_order():
+        return tuple(range(5))
+
+    @classmethod
+    def get_kv_cache_block_dim(
+        cls,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> int:
+        shape = cls.get_kv_cache_shape(
+            1234567,
+            block_size,
+            num_kv_heads,
+            head_size,
+            cache_dtype_str=cache_dtype_str,
+        )
+        return shape.index(1234567)
+
+
+class _HybridBlockSizeTestBackend:
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int]:
+        return [16, 32, 64]
+
+    @staticmethod
+    def get_name() -> str:
+        return "HYBRID_BLOCK_SIZE_TEST"
+
+
+class _HybridBlockSizeTestModel:
+    @staticmethod
+    def get_mamba_state_shape_from_config(vllm_config):
+        return ((130,),)
+
+    @staticmethod
+    def get_mamba_state_dtype_from_config(vllm_config):
+        return (torch.float32,)
+
+
+class _HybridBlockSizeTestModelConfig:
+    dtype = torch.float16
+    use_mla = False
+    architecture = "HybridBlockSizeTestModel"
+
+    def get_num_kv_heads(self, parallel_config):
+        return 1
+
+    def get_head_size(self):
+        return 1
+
+    def get_mamba_chunk_size(self):
+        return 16
+
+
+def _make_hybrid_block_size_test_config(
+    *,
+    mamba_cache_mode: str,
+    block_size: int = 16,
+    mamba_page_size_padded: int | None = None,
+):
+    cache_config = CacheConfig(
+        block_size=block_size,
+        cache_dtype="auto",
+        mamba_cache_mode=mamba_cache_mode,
+    )
+    cache_config.mamba_page_size_padded = mamba_page_size_padded
+    return SimpleNamespace(
+        cache_config=cache_config,
+        model_config=_HybridBlockSizeTestModelConfig(),
+        parallel_config=ParallelConfig(),
+    )
+
+
+def _patch_hybrid_block_size_test_model(monkeypatch):
+    def resolve_model_cls(*args, **kwargs):
+        return _HybridBlockSizeTestModel, None
+
+    monkeypatch.setattr(ModelRegistry, "resolve_model_cls", resolve_model_cls)
+
+
+def _reshape_kv_cache_tensor_for_test(
+    kv_cache_spec,
+    raw_tensor: torch.Tensor,
+    layer_name: str = "layer.0",
+):
+    group = AttentionGroup(
+        _TestAttentionBackend,
+        [layer_name],
+        kv_cache_spec,
+        0,
+    )
+    runner_stub = SimpleNamespace(
+        runner_only_attn_layers=set(),
+        cache_config=SimpleNamespace(cache_dtype="auto"),
+        _kv_cache_spec_attn_group_iterator=lambda: iter([group]),
+    )
+    return GPUModelRunner._reshape_kv_cache_tensors(
+        runner_stub,
+        {layer_name: raw_tensor},
+        [kv_cache_spec.block_size],
+    )
 
 
 def initialize_kv_cache(runner: GPUModelRunner):
@@ -105,6 +249,7 @@ def get_vllm_config():
         block_size=BLOCK_SIZE,
         gpu_memory_utilization=0.9,
         cache_dtype="auto",
+        mamba_cache_mode="all",
     )
     parallel_config = ParallelConfig()
     vllm_config = VllmConfig(
@@ -1264,6 +1409,206 @@ def test_hybrid_attention_mamba_tensor_shapes():
             expected_ssm = ssm_blocks_constant[i]
             assert torch.equal(actual_conv, expected_conv)
             assert torch.equal(actual_ssm, expected_ssm)
+
+
+def test_update_hybrid_attention_mamba_layout_with_num_block_2_rewrites_stride():
+    ambiguous_cache = torch.empty((2, 2, BLOCK_SIZE, 1, 8), dtype=torch.float16)
+    """Ambiguous, because both dims[0=kv_dim] and dims[1=num_blocks] == 2"""
+    hidden_size = ambiguous_cache.shape[2:].numel()
+    assert ambiguous_cache.stride()[:2] == (2 * hidden_size, hidden_size)
+
+    attention_spec = AttentionSpec(
+        block_size=BLOCK_SIZE, num_kv_heads=1, head_size=8, dtype=torch.float16
+    )
+    runner_stub = SimpleNamespace(
+        cache_config=SimpleNamespace(cache_dtype="auto"),
+        _kv_cache_spec_attn_group_iterator=lambda: iter(
+            [AttentionGroup(_TestAttentionBackend, ["attn"], attention_spec, 0)]
+        ),
+    )
+    GPUModelRunner._update_hybrid_attention_mamba_layout(
+        runner_stub, {"attn": ambiguous_cache}, [BLOCK_SIZE]
+    )
+
+    assert ambiguous_cache.stride()[:2] == (hidden_size, 2 * hidden_size), """\
+        We expect _update_hybrid_attention_mamba_layout to re-stride the cache from:
+        (2, num_blocks) -> (num_blocks, 2), even when num_blocks==2,
+        which was ambiguous before get_kv_cache_block_dim was used"""
+
+
+@pytest.mark.parametrize(
+    (
+        "mamba_cache_mode",
+        "initial_mamba_block_size",
+        "initial_page_size_padded",
+        "expected_block_size",
+        "expected_mamba_block_size",
+        "expected_page_size_padded",
+    ),
+    [
+        ("none", None, 999, 16, None, None),
+        ("align", 2048, 999, 16, 16, None),
+        ("all", None, None, 144, 144, 576),
+    ],
+    ids=["request_constant_none", "request_constant_align", "token_proportional_all"],
+)
+def test_request_constant_mamba_and_token_proportional_mamba_all_platform_padding(
+    monkeypatch,
+    mamba_cache_mode,
+    initial_mamba_block_size,
+    initial_page_size_padded,
+    expected_block_size,
+    expected_mamba_block_size,
+    expected_page_size_padded,
+):
+    _patch_hybrid_block_size_test_model(monkeypatch)
+    vllm_config = _make_hybrid_block_size_test_config(
+        mamba_cache_mode=mamba_cache_mode,
+        mamba_page_size_padded=initial_page_size_padded,
+    )
+    vllm_config.cache_config.mamba_block_size = initial_mamba_block_size
+
+    Platform._align_hybrid_block_size(vllm_config, _HybridBlockSizeTestBackend)
+
+    assert vllm_config.cache_config.block_size == expected_block_size
+    assert vllm_config.cache_config.mamba_block_size == expected_mamba_block_size
+    assert vllm_config.cache_config.mamba_page_size_padded == expected_page_size_padded
+
+
+def test_reshape_request_constant_mamba_uses_physical_page():
+    spec = _RequestConstantMambaSpec(
+        block_size=1,
+        shapes=((2,),),
+        dtypes=(torch.float32,),
+        page_size_padded=16,
+    )
+    num_blocks = 3
+    raw_tensor = torch.empty(
+        spec.physical_page_size_bytes * num_blocks,
+        dtype=torch.int8,
+    )
+
+    kv_caches = _reshape_kv_cache_tensor_for_test(spec, raw_tensor, "state")
+
+    assert kv_caches["state"][0].shape == (num_blocks, 2)
+
+
+def test_reshape_request_constant_mamba_stride_matches_physical():
+    dtype = torch.float32
+    spec = _RequestConstantMambaSpec(
+        block_size=1,
+        shapes=((2,),),
+        dtypes=(dtype,),
+        page_size_padded=16,
+    )
+    raw_tensor = torch.empty(
+        spec.physical_page_size_bytes * 3,
+        dtype=torch.int8,
+    )
+
+    kv_caches = _reshape_kv_cache_tensor_for_test(spec, raw_tensor, "state")
+    state_tensor = kv_caches["state"][0]
+    dtype_size = torch.empty((), dtype=dtype).element_size()
+
+    assert state_tensor.stride()[0] == spec.physical_page_size_bytes // dtype_size
+    assert state_tensor.stride()[0] != spec.page_size_bytes // dtype_size
+
+
+def test_reshape_token_proportional_mamba_uses_padded_page():
+    dtype = torch.float32
+    spec = MambaSpec(
+        block_size=1,
+        shapes=((2,),),
+        dtypes=(dtype,),
+        page_size_padded=16,
+        mamba_cache_mode="all",
+    )
+    num_blocks = 3
+    raw_tensor = torch.empty(
+        spec.page_size_bytes * num_blocks,
+        dtype=torch.int8,
+    )
+
+    kv_caches = _reshape_kv_cache_tensor_for_test(spec, raw_tensor, "state")
+    state_tensor = kv_caches["state"][0]
+    dtype_size = torch.empty((), dtype=dtype).element_size()
+
+    assert state_tensor.shape == (num_blocks, 2)
+    assert state_tensor.stride()[0] == spec.page_size_bytes // dtype_size
+
+
+def test_reshape_token_proportional_attention_unchanged():
+    spec = FullAttentionSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+        page_size_padded=32,
+    )
+    num_blocks = 2
+    raw_tensor = torch.empty(
+        spec.page_size_bytes * num_blocks,
+        dtype=torch.int8,
+    )
+
+    kv_caches = _reshape_kv_cache_tensor_for_test(spec, raw_tensor, "attn")
+    kv_cache = kv_caches["attn"]
+
+    assert kv_cache.shape[1] == num_blocks
+    assert (
+        kv_cache.numel()
+        == spec.real_page_size_bytes
+        * num_blocks
+        // torch.empty((), dtype=spec.dtype).element_size()
+    )
+
+
+def test_reshape_attention_request_constant_rejected():
+    spec = _RequestConstantFullAttentionSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    raw_tensor = torch.empty(spec.page_size_bytes, dtype=torch.int8)
+
+    with pytest.raises(NotImplementedError, match="REQUEST_CONSTANT AttentionSpec"):
+        _reshape_kv_cache_tensor_for_test(spec, raw_tensor, "attn")
+
+
+def test_reshape_connector_request_constant_rejected():
+    spec = _RequestConstantFullAttentionSpec(
+        block_size=2,
+        num_kv_heads=1,
+        head_size=1,
+        dtype=torch.float32,
+    )
+    kv_cache_config = KVCacheConfig(
+        num_blocks=1,
+        kv_cache_tensors=[
+            KVCacheTensor(size=spec.page_size_bytes, shared_by=["attn"]),
+        ],
+        kv_cache_groups=[KVCacheGroupSpec(layer_names=["attn"], kv_cache_spec=spec)],
+    )
+    attn_groups = [
+        [
+            AttentionGroup(
+                _TestAttentionBackend,
+                ["attn"],
+                spec,
+                0,
+            )
+        ]
+    ]
+
+    with pytest.raises(NotImplementedError, match="Cross-layer KV connector"):
+        KVConnectorModelRunnerMixin.allocate_uniform_kv_caches(
+            kv_cache_config,
+            attn_groups,
+            "auto",
+            torch.device("cpu"),
+            [spec.block_size],
+        )
 
 
 def test_hybrid_block_table_initialization():

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -1324,6 +1324,43 @@ class CompilationConfig:
         assert "none" in self.custom_ops
         return f"+{op}" in self.custom_ops
 
+    @staticmethod
+    def _has_request_constant_kv_pools(kv_cache_config: "KVCacheConfig") -> bool:
+        from vllm.v1.kv_cache_interface import MemoryModel
+
+        return any(
+            pool.memory_model == MemoryModel.REQUEST_CONSTANT
+            for pool in kv_cache_config.pool_configs
+        )
+
+    @staticmethod
+    def _validate_request_constant_cudagraph_capacity(
+        kv_cache_config: "KVCacheConfig",
+        max_num_reqs: int,
+    ) -> None:
+        from vllm.v1.kv_cache_interface import MemoryModel
+
+        for pool in kv_cache_config.pool_configs:
+            if pool.memory_model != MemoryModel.REQUEST_CONSTANT:
+                continue
+
+            blocks_per_request = 0
+            for group_id in pool.group_ids:
+                spec = kv_cache_config.kv_cache_groups[group_id].kv_cache_spec
+                blocks_per_request += spec.blocks_per_request
+            required_blocks = max_num_reqs * blocks_per_request
+            usable_blocks = pool.num_blocks - 1
+            if required_blocks <= usable_blocks:
+                continue
+
+            raise ValueError(
+                f"max_num_seqs ({max_num_reqs}) requires "
+                f"{required_blocks} REQUEST_CONSTANT KV cache blocks for "
+                f"pool {pool.pool_id}, but only {usable_blocks} are available. "
+                "Full CUDA graph capture cannot proceed. Please lower "
+                "max_num_seqs or increase gpu_memory_utilization."
+            )
+
     def resolve_cudagraph_mode_and_sizes(
         self,
         min_cg_support: "AttentionCGSupport",
@@ -1443,6 +1480,26 @@ class CompilationConfig:
                 tensor_parallel_size,
             )
 
+        has_request_constant_pools = (
+            kv_cache_config is not None
+            and self._has_request_constant_kv_pools(kv_cache_config)
+        )
+
+        if (
+            kv_cache_config is not None
+            and cudagraph_mode.has_full_cudagraphs()
+            and not is_profiling
+            and has_request_constant_pools
+        ):
+            if max_num_reqs is None:
+                raise ValueError(
+                    "Full CUDA graph capture with REQUEST_CONSTANT KV cache "
+                    "requires max_num_seqs for capacity validation."
+                )
+            self._validate_request_constant_cudagraph_capacity(
+                kv_cache_config, max_num_reqs
+            )
+
         # For Mamba models with FULL decode cudagraphs, each decode
         # sequence needs one Mamba cache block. The decode cudagraph
         # dispatcher already caps batch sizes at max_num_seqs, so we just
@@ -1456,6 +1513,7 @@ class CompilationConfig:
             and cudagraph_mode.has_full_cudagraphs()
             and not is_profiling
             and kv_cache_config.has_mamba_layers
+            and not has_request_constant_pools
             and max_num_reqs > kv_cache_config.num_blocks
         ):
             raise ValueError(

--- a/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
+++ b/vllm/model_executor/layers/fused_moe/routed_experts_capturer.py
@@ -14,6 +14,9 @@ from vllm.config import VllmConfig
 from vllm.distributed.parallel_state import get_tp_group
 from vllm.forward_context import get_forward_context
 from vllm.platforms import current_platform
+from vllm.v1.core.kv_cache_utils import (
+    get_token_proportional_kv_cache_capacity_tokens,
+)
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheConfig
 
 logger = logging.getLogger(__name__)
@@ -240,9 +243,9 @@ class RoutedExpertsManager:
          calls :meth:`get` with the request's block IDs to recover
          the full per-token routing.
 
-    Memory: ``routed_experts_by_slot`` is sized for the whole block
-    pool (``num_blocks * block_size`` slots). For large block pools
-    this can reach multiple GB; see the init log for the exact size.
+    Memory: ``routed_experts_by_slot`` is sized for the token-proportional
+    attention KV-cache capacity. For large block pools this can reach
+    multiple GB; see the init log for the exact size.
     """
 
     def __init__(
@@ -264,14 +267,13 @@ class RoutedExpertsManager:
         attn_group = kv_cache_config.kv_cache_groups[self.attn_gid]
         self.block_size = attn_group.kv_cache_spec.block_size
 
-        # All kv_cache_groups share the same physical block pool, so
-        # block IDs span [0, num_blocks) regardless of how many groups
-        # exist. Sizing to the full pool avoids index-out-of-range
-        # when different groups happen to land on the same block.
+        # Slot mappings are derived from the attention KV-cache group. Hybrid
+        # models may split request-constant Mamba state into a separate compact
+        # pool, so size this buffer from TOKEN_PROPORTIONAL capacity only.
         hf_config = vllm_config.model_config.hf_text_config
         num_experts = get_num_experts(hf_config)
         num_experts_per_tok = _get_num_experts_per_tok(hf_config)
-        max_num_slots = kv_cache_config.num_blocks * self.block_size
+        max_num_slots = get_token_proportional_kv_cache_capacity_tokens(kv_cache_config)
         # Expert IDs are 0..num_experts-1; uint8 fits 256 distinct
         # values so the boundary is ``<= 256`` (NOT ``< 256``). Keeping
         # this narrow matters because the slot buffer is sized for the

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -628,6 +628,16 @@ class Platform:
             else None
         )
 
+        if cache_config.mamba_cache_mode != "all":
+            # REQUEST_CONSTANT Mamba modes use a separate compact pool sized by
+            # the physical Mamba state page. They no longer require attention
+            # pages to be inflated to match Mamba pages, nor Mamba pages to be
+            # padded to the attention page size.
+            if cache_config.mamba_cache_mode == "align":
+                cache_config.mamba_block_size = cache_config.block_size
+            cache_config.mamba_page_size_padded = None
+            return
+
         # Get kernel block alignment from the backend's supported sizes
         with set_current_vllm_config(vllm_config):
             kernel_block_alignment_size = max(

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -278,14 +278,23 @@ class XPUPlatform(Platform):
                 new_block_size * attn_page_size_1_token
             )
         cache_config.block_size = new_block_size
-        logger.info(
-            "[XPU]Setting attention block size to %d tokens to ensure multiple of %d, "
-            "set mamba_page_size_padded to %d bytes accordingly, before was %d bytes.",
-            new_block_size,
-            kernel_block_size,
-            cache_config.mamba_page_size_padded,
-            original_mamba_page_size_padded,
-        )
+        if original_mamba_page_size_padded is None:
+            logger.info(
+                "[XPU]Setting attention block size to %d tokens to ensure "
+                "multiple of %d; mamba_page_size_padded remains unset.",
+                new_block_size,
+                kernel_block_size,
+            )
+        else:
+            logger.info(
+                "[XPU]Setting attention block size to %d tokens to ensure "
+                "multiple of %d, set mamba_page_size_padded to %d bytes "
+                "accordingly, before was %d bytes.",
+                new_block_size,
+                kernel_block_size,
+                cache_config.mamba_page_size_padded,
+                original_mamba_page_size_padded,
+            )
 
     @classmethod
     def support_hybrid_kv_cache(cls) -> bool:

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from collections.abc import Iterable, Sequence
-from typing import Any
+from typing import Any, Protocol
 
 from vllm.distributed.kv_events import (
     MEDIUM_GPU,
@@ -29,6 +29,120 @@ from vllm.v1.core.kv_cache_utils import (
 from vllm.v1.request import Request
 
 logger = init_logger(__name__)
+
+
+class BlockPoolProtocol(Protocol):
+    """Basic allocation contract shared by all KV cache block pools.
+
+    Implementations must reserve ``block_id=0`` as the null sentinel. Allocation
+    methods must never return the null block, and backing tensors must be sized
+    so that block index 0 is always valid.
+    """
+
+    num_gpu_blocks: int
+    null_block: KVCacheBlock
+
+    def get_new_blocks(self, num_blocks: int) -> list[KVCacheBlock]: ...
+
+    def free_blocks(self, ordered_blocks: Iterable[KVCacheBlock]) -> None: ...
+
+    def get_num_free_blocks(self) -> int: ...
+
+    def get_usage(self) -> float: ...
+
+    def take_events(self) -> list[KVCacheEvent]: ...
+
+
+class CacheableBlockPoolProtocol(BlockPoolProtocol, Protocol):
+    """Block-pool contract for pools that also support prefix caching."""
+
+    def get_cached_block(
+        self, block_hash: BlockHash, kv_cache_group_ids: list[int]
+    ) -> list[KVCacheBlock] | None: ...
+
+    def cache_full_blocks(
+        self,
+        request: Request,
+        blocks: list[KVCacheBlock],
+        num_cached_blocks: int,
+        num_full_blocks: int,
+        block_size: int,
+        kv_cache_group_id: int,
+        block_mask: list[bool] | None = None,
+    ) -> None: ...
+
+    def touch(self, blocks: Sequence[KVCacheBlock]) -> None: ...
+
+    def evict_blocks(self, block_ids: set[int]) -> None: ...
+
+    def reset_prefix_cache(self) -> bool: ...
+
+
+class CompactBlockPool:
+    """Compact allocation-only pool for request-constant KV-cache specs.
+
+    Invariants enforced by this pool:
+      (1) ``block_id=0`` is reserved as the null sentinel.
+      (2) Backing tensors must be sized for ``num_allocatable + 1`` blocks.
+      (3) Allocation never returns the null block.
+      (4) ``ref_cnt`` is binary: 0 when free, 1 when allocated.
+      (5) ``get_new_blocks(0)`` returns ``[]`` and ``free_blocks([])`` is a no-op.
+      (6) Freeing a null block or a non-allocated block is rejected.
+
+    This pool deliberately does not implement prefix-caching APIs such as
+    ``touch``, ``get_cached_block``, or ``cache_full_blocks``.
+    """
+
+    def __init__(self, num_allocatable: int) -> None:
+        assert isinstance(num_allocatable, int) and num_allocatable >= 0
+        self._num_allocatable = num_allocatable
+        self.num_gpu_blocks = num_allocatable + 1
+        self.null_block = KVCacheBlock(block_id=0)
+        self.null_block.is_null = True
+        self._free: list[KVCacheBlock] = [
+            KVCacheBlock(block_id=i) for i in range(1, num_allocatable + 1)
+        ]
+
+    def get_new_blocks(self, num_blocks: int) -> list[KVCacheBlock]:
+        if num_blocks == 0:
+            return []
+        if num_blocks > self.get_num_free_blocks():
+            raise ValueError(f"Cannot get {num_blocks} free blocks from the pool")
+
+        blocks = [self._free.pop() for _ in range(num_blocks)]
+        for block in blocks:
+            assert block.block_id != 0
+            assert not block.is_null
+            assert block.ref_cnt == 0
+            block.ref_cnt += 1
+            assert block.ref_cnt == 1
+        return blocks
+
+    def free_blocks(self, ordered_blocks: Iterable[KVCacheBlock]) -> None:
+        blocks = list(ordered_blocks)
+        if not blocks:
+            return
+        for block in blocks:
+            assert block.block_id != 0, "null block must never be freed"
+            assert not block.is_null, "null block must never be freed"
+            assert block.ref_cnt == 1, (
+                "CompactBlockPool expects binary ref_cnt semantics"
+            )
+            block.ref_cnt -= 1
+            assert block.ref_cnt == 0
+        self._free.extend(blocks)
+
+    def get_num_free_blocks(self) -> int:
+        return len(self._free)
+
+    def get_usage(self) -> float:
+        if self._num_allocatable == 0:
+            return 0
+        return 1.0 - (self.get_num_free_blocks() / self._num_allocatable)
+
+    def take_events(self) -> list[KVCacheEvent]:
+        """Compact pools do not emit prefix-cache events."""
+        return []
 
 
 class BlockHashToBlockMap:

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -2,9 +2,14 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
-from typing import NamedTuple
+from typing import NamedTuple, cast
 
-from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.block_pool import (
+    BlockPool,
+    BlockPoolProtocol,
+    CacheableBlockPoolProtocol,
+    CompactBlockPool,
+)
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
@@ -20,7 +25,9 @@ from vllm.v1.core.single_type_kv_cache_manager import (
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
+    KVCachePoolConfig,
     KVCacheSpec,
+    MemoryModel,
 )
 from vllm.v1.request import Request
 
@@ -55,12 +62,17 @@ class KVCacheCoordinator(ABC):
         )
         self.scheduler_block_size = scheduler_block_size
 
-        self.block_pool = BlockPool(
-            num_gpu_blocks=kv_cache_config.num_blocks,
-            enable_caching=enable_caching,
-            hash_block_size=hash_block_size,
-            enable_kv_cache_events=enable_kv_cache_events,
-            metrics_collector=metrics_collector,
+        self._check_pool_config_supported()
+        self._block_pools = self._make_block_pools(
+            enable_kv_cache_events,
+            hash_block_size,
+            metrics_collector,
+        )
+        # Public legacy alias. Existing consumers assume a single shared pool.
+        self.block_pool = self._block_pools[0]
+        self._group_to_pool = tuple(
+            self._block_pools[pool_id]
+            for pool_id in self.kv_cache_config.group_to_pool_id
         )
 
         # KV cache group indices that get the EAGLE last-block drop.
@@ -76,7 +88,7 @@ class KVCacheCoordinator(ABC):
                 kv_cache_spec=kv_cache_group.kv_cache_spec,
                 max_num_batched_tokens=max_num_batched_tokens,
                 max_model_len=max_model_len,
-                block_pool=self.block_pool,
+                block_pool=self._group_to_pool[i],
                 enable_caching=enable_caching,
                 kv_cache_group_id=i,
                 dcp_world_size=dcp_world_size,
@@ -85,6 +97,68 @@ class KVCacheCoordinator(ABC):
             )
             for i, kv_cache_group in enumerate(self.kv_cache_config.kv_cache_groups)
         )
+
+    def _check_pool_config_supported(self) -> None:
+        """Reject unsupported multi-pool prefix-cache configs."""
+        pool_ids = set(self.kv_cache_config.group_to_pool_id)
+        num_distinct_pools = max(
+            len(self.kv_cache_config.pool_configs),
+            len(pool_ids),
+        )
+        if num_distinct_pools > 1 and self.enable_caching:
+            raise NotImplementedError(
+                "KVCacheCoordinator currently supports multi-pool configs only "
+                "when prefix caching is disabled. Got "
+                f"{num_distinct_pools} distinct pools in kv_cache_config. "
+                "Pool-aware prefix-cache dispatch is not implemented yet."
+            )
+
+    def _make_block_pools(
+        self,
+        enable_kv_cache_events: bool,
+        hash_block_size: int,
+        metrics_collector: KVCacheMetricsCollector | None,
+    ) -> tuple[BlockPoolProtocol, ...]:
+        if not self.kv_cache_config.pool_configs:
+            return (
+                BlockPool(
+                    self.kv_cache_config.num_blocks,
+                    self.enable_caching,
+                    hash_block_size,
+                    enable_kv_cache_events,
+                    metrics_collector,
+                ),
+            )
+
+        return tuple(
+            self._make_block_pool(
+                pool_config,
+                enable_kv_cache_events,
+                hash_block_size,
+                metrics_collector,
+            )
+            for pool_config in self.kv_cache_config.pool_configs
+        )
+
+    def _make_block_pool(
+        self,
+        pool_config: KVCachePoolConfig,
+        enable_kv_cache_events: bool,
+        hash_block_size: int,
+        metrics_collector: KVCacheMetricsCollector | None,
+    ) -> BlockPoolProtocol:
+        if pool_config.memory_model == MemoryModel.TOKEN_PROPORTIONAL:
+            return BlockPool(
+                pool_config.num_blocks,
+                self.enable_caching,
+                hash_block_size,
+                enable_kv_cache_events,
+                metrics_collector,
+            )
+        if pool_config.memory_model == MemoryModel.REQUEST_CONSTANT:
+            assert not self.enable_caching
+            return CompactBlockPool(num_allocatable=pool_config.num_blocks - 1)
+        raise AssertionError(f"Unsupported KV cache memory model: {pool_config}")
 
     def get_num_blocks_to_allocate(
         self,
@@ -119,12 +193,35 @@ class KVCacheCoordinator(ABC):
         Returns:
             The number of blocks to allocate.
         """
-        num_blocks_to_allocate = 0
+        return sum(
+            self.get_num_blocks_to_allocate_by_pool(
+                request_id,
+                num_tokens,
+                new_computed_blocks,
+                num_encoder_tokens,
+                total_computed_tokens,
+                num_tokens_main_model,
+                apply_admission_cap=apply_admission_cap,
+            )
+        )
+
+    def get_num_blocks_to_allocate_by_pool(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: tuple[Sequence[KVCacheBlock], ...],
+        num_encoder_tokens: int,
+        total_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> tuple[int, ...]:
+        """Get the number of blocks needed from each KV cache pool."""
+        num_blocks_to_allocate = [0] * len(self.kv_cache_config.pool_configs)
         for i, manager in enumerate(self.single_type_managers):
             if isinstance(manager, CrossAttentionManager):
                 # For cross-attention, we issue a single static allocation
                 # of blocks based on the number of encoder input tokens.
-                num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
+                required_blocks = manager.get_num_blocks_to_allocate(
                     request_id,
                     num_encoder_tokens,
                     [],
@@ -133,7 +230,7 @@ class KVCacheCoordinator(ABC):
                     apply_admission_cap=apply_admission_cap,
                 )
             else:
-                num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
+                required_blocks = manager.get_num_blocks_to_allocate(
                     request_id,
                     num_tokens,
                     new_computed_blocks[i],
@@ -141,7 +238,16 @@ class KVCacheCoordinator(ABC):
                     num_tokens_main_model,
                     apply_admission_cap=apply_admission_cap,
                 )
-        return num_blocks_to_allocate
+            pool_id = self.kv_cache_config.group_to_pool_id[i]
+            num_blocks_to_allocate[pool_id] += required_blocks
+        return tuple(num_blocks_to_allocate)
+
+    def get_num_free_blocks_by_pool(self) -> tuple[int, ...]:
+        """Get the number of currently free blocks in each KV cache pool."""
+        return tuple(
+            self._block_pools[pool_id].get_num_free_blocks()
+            for pool_id in range(len(self.kv_cache_config.pool_configs))
+        )
 
     def allocate_new_computed_blocks(
         self,
@@ -390,11 +496,12 @@ class UnitaryKVCacheCoordinator(KVCacheCoordinator):
         block_hashes: list[BlockHash],
         max_cache_hit_length: int,
     ) -> tuple[tuple[list[KVCacheBlock], ...], int]:
+        block_pool = cast(CacheableBlockPoolProtocol, self.block_pool)
         hit_blocks = self.single_type_managers[0].find_longest_cache_hit(
             block_hashes=block_hashes,
             max_length=max_cache_hit_length,
             kv_cache_group_ids=[0],
-            block_pool=self.block_pool,
+            block_pool=block_pool,
             kv_cache_spec=self.kv_cache_spec,
             drop_eagle_block=0 in self.eagle_group_ids,
             alignment_tokens=self.block_size,
@@ -598,11 +705,12 @@ class HybridKVCacheCoordinator(KVCacheCoordinator):
                     _max_length = min(
                         curr_hit_length + spec.block_size, max_cache_hit_length
                     )
+                block_pool = cast(CacheableBlockPoolProtocol, self.block_pool)
                 hit_blocks = manager_cls.find_longest_cache_hit(
                     block_hashes=_get_block_hashes(spec),
                     max_length=_max_length,
                     kv_cache_group_ids=group_ids,
-                    block_pool=self.block_pool,
+                    block_pool=block_pool,
                     kv_cache_spec=spec,
                     drop_eagle_block=drop_eagle_block,
                     alignment_tokens=self.scheduler_block_size,

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -4,10 +4,11 @@
 import itertools
 from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Literal, overload
+from typing import Literal, cast, overload
 
 from vllm.distributed.kv_events import BlockStored, KVCacheEvent
 from vllm.logger import init_logger
+from vllm.v1.core.block_pool import CacheableBlockPoolProtocol
 from vllm.v1.core.kv_cache_coordinator import get_kv_cache_coordinator
 from vllm.v1.core.kv_cache_metrics import KVCacheMetricsCollector
 from vllm.v1.core.kv_cache_utils import KVCacheBlock
@@ -181,6 +182,10 @@ class KVCacheManager:
         """
         return self.block_pool.get_usage()
 
+    def _cacheable_block_pool(self) -> CacheableBlockPoolProtocol:
+        """Return the legacy shared pool as a prefix-cache-capable pool."""
+        return cast(CacheableBlockPoolProtocol, self.block_pool)
+
     def make_prefix_cache_stats(self) -> PrefixCacheStats | None:
         """Get (and reset) the prefix cache stats.
 
@@ -192,6 +197,38 @@ class KVCacheManager:
         stats = self.prefix_cache_stats
         self.prefix_cache_stats = PrefixCacheStats()
         return stats
+
+    def _has_enough_free_blocks_by_pool(
+        self, num_blocks_to_allocate_by_pool: tuple[int, ...]
+    ) -> bool:
+        num_free_blocks_by_pool = self.coordinator.get_num_free_blocks_by_pool()
+        assert len(num_blocks_to_allocate_by_pool) == len(num_free_blocks_by_pool)
+        return all(
+            num_blocks_to_allocate <= num_free_blocks
+            for num_blocks_to_allocate, num_free_blocks in zip(
+                num_blocks_to_allocate_by_pool, num_free_blocks_by_pool
+            )
+        )
+
+    def _get_num_blocks_to_allocate_by_pool(
+        self,
+        request: Request,
+        num_tokens: int,
+        new_computed_block_list: tuple[Sequence[KVCacheBlock], ...],
+        num_encoder_tokens: int,
+        total_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> tuple[int, ...]:
+        return self.coordinator.get_num_blocks_to_allocate_by_pool(
+            request_id=request.request_id,
+            num_tokens=num_tokens,
+            new_computed_blocks=new_computed_block_list,
+            num_encoder_tokens=num_encoder_tokens,
+            total_computed_tokens=total_computed_tokens,
+            num_tokens_main_model=num_tokens_main_model,
+            apply_admission_cap=apply_admission_cap,
+        )
 
     def get_computed_blocks(self, request: Request) -> tuple[KVCacheBlocks, int]:
         """Get the computed (cached) blocks for the request.
@@ -349,16 +386,16 @@ class KVCacheManager:
             # First check and fail if the full request sequence won't fit.
             full_num_tokens = min(request.num_tokens, self.max_model_len)
 
-            num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
-                request_id=request.request_id,
+            num_blocks_to_allocate_by_pool = self._get_num_blocks_to_allocate_by_pool(
+                request,
                 num_tokens=full_num_tokens,
-                new_computed_blocks=new_computed_block_list,
+                new_computed_block_list=new_computed_block_list,
                 num_encoder_tokens=num_encoder_tokens,
                 total_computed_tokens=total_computed_tokens,
                 num_tokens_main_model=full_num_tokens,
                 apply_admission_cap=True,
             )
-            if num_blocks_to_allocate > self.block_pool.get_num_free_blocks():
+            if not self._has_enough_free_blocks_by_pool(num_blocks_to_allocate_by_pool):
                 return None
 
         num_tokens_main_model = total_computed_tokens + num_new_tokens
@@ -376,17 +413,17 @@ class KVCacheManager:
             request.request_id, total_computed_tokens
         )
 
-        num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
-            request_id=request.request_id,
+        num_blocks_to_allocate_by_pool = self._get_num_blocks_to_allocate_by_pool(
+            request,
             num_tokens=num_tokens_need_slot,
-            new_computed_blocks=new_computed_block_list,
+            new_computed_block_list=new_computed_block_list,
             num_encoder_tokens=num_encoder_tokens,
             total_computed_tokens=num_local_computed_tokens
             + num_external_computed_tokens,
             num_tokens_main_model=num_tokens_main_model,
         )
 
-        if num_blocks_to_allocate > self.block_pool.get_num_free_blocks():
+        if not self._has_enough_free_blocks_by_pool(num_blocks_to_allocate_by_pool):
             # Cannot allocate new blocks
             return None
 
@@ -457,7 +494,7 @@ class KVCacheManager:
         Args:
             block_ids: Set of block IDs to evict from cache.
         """
-        self.block_pool.evict_blocks(block_ids)
+        self._cacheable_block_pool().evict_blocks(block_ids)
 
     def reset_prefix_cache(self) -> bool:
         """Reset prefix cache. This function may be used in RLHF
@@ -468,7 +505,7 @@ class KVCacheManager:
             bool: True if the prefix cache is successfully reset,
             False otherwise.
         """
-        if not self.block_pool.reset_prefix_cache():
+        if not self._cacheable_block_pool().reset_prefix_cache():
             return False
         if self.log_stats:
             assert self.prefix_cache_stats is not None
@@ -515,7 +552,7 @@ class KVCacheManager:
         Returns:
             A list of KV cache events.
         """
-        events = self.block_pool.take_events()
+        events = self._cacheable_block_pool().take_events()
         for event in events:
             if not isinstance(event, BlockStored):
                 continue

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -25,9 +25,11 @@ from vllm.v1.kv_cache_interface import (
     HiddenStateCacheSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    KVCachePoolConfig,
     KVCacheSpec,
     KVCacheTensor,
     MambaSpec,
+    MemoryModel,
     MLAAttentionSpec,
     SlidingWindowMLASpec,
     SlidingWindowSpec,
@@ -880,19 +882,94 @@ def get_max_concurrency_for_kv_cache_config(
     """
     Get the maximum concurrency for the given KV cache configuration.
     """
-    num_layer_per_group = max(
-        len(group.layer_names) for group in kv_cache_config.kv_cache_groups
-    )
+    if _has_request_constant_pools(kv_cache_config):
+        group_ids = [
+            group_id
+            for group_id, group in enumerate(kv_cache_config.kv_cache_groups)
+            if group.kv_cache_spec.memory_model == MemoryModel.TOKEN_PROPORTIONAL
+        ]
+        if not group_ids:
+            return _get_request_constant_max_concurrency(kv_cache_config)
+        groups = [kv_cache_config.kv_cache_groups[group_id] for group_id in group_ids]
+        num_blocks = _get_num_blocks_for_group_ids(kv_cache_config, group_ids)
+    else:
+        groups = kv_cache_config.kv_cache_groups
+        num_blocks = kv_cache_config.num_blocks
+
+    num_layer_per_group = max(len(group.layer_names) for group in groups)
     max_memory_usage_per_request = num_layer_per_group * max_memory_usage_bytes(
-        vllm_config, (group.kv_cache_spec for group in kv_cache_config.kv_cache_groups)
+        vllm_config, (group.kv_cache_spec for group in groups)
     )
-    memory_per_block = (
-        kv_cache_config.kv_cache_groups[0].kv_cache_spec.page_size_bytes
-        * num_layer_per_group
-    )
+    memory_per_block = groups[0].kv_cache_spec.page_size_bytes * num_layer_per_group
     num_block_per_request = cdiv(max_memory_usage_per_request, memory_per_block)
-    max_concurrency = kv_cache_config.num_blocks / num_block_per_request
+    max_concurrency = num_blocks / num_block_per_request
     return max_concurrency
+
+
+def _has_request_constant_pools(kv_cache_config: KVCacheConfig) -> bool:
+    return any(
+        pool.memory_model == MemoryModel.REQUEST_CONSTANT
+        for pool in kv_cache_config.pool_configs
+    )
+
+
+def _get_request_constant_max_concurrency(
+    kv_cache_config: KVCacheConfig,
+) -> float:
+    pool_by_id = {pool.pool_id: pool for pool in kv_cache_config.pool_configs}
+    per_group_capacity = []
+    for group_id, group in enumerate(kv_cache_config.kv_cache_groups):
+        if group.kv_cache_spec.memory_model != MemoryModel.REQUEST_CONSTANT:
+            continue
+        pool_id = kv_cache_config.group_to_pool_id[group_id]
+        pool = pool_by_id[pool_id]
+        per_group_capacity.append(
+            (pool.num_blocks - 1) / group.kv_cache_spec.blocks_per_request
+        )
+    if not per_group_capacity:
+        return 0
+    return min(per_group_capacity)
+
+
+def _get_token_proportional_group_ids(
+    kv_cache_config: KVCacheConfig,
+) -> list[int]:
+    group_ids = [
+        group_id
+        for group_id, group in enumerate(kv_cache_config.kv_cache_groups)
+        if group.kv_cache_spec.memory_model == MemoryModel.TOKEN_PROPORTIONAL
+    ]
+    if not group_ids:
+        raise NotImplementedError(
+            "KV cache capacity reporting requires at least one "
+            "TOKEN_PROPORTIONAL group."
+        )
+    return group_ids
+
+
+def _get_num_blocks_for_group_ids(
+    kv_cache_config: KVCacheConfig,
+    group_ids: list[int],
+) -> int:
+    pool_ids = {kv_cache_config.group_to_pool_id[group_id] for group_id in group_ids}
+    return sum(
+        pool.num_blocks
+        for pool in kv_cache_config.pool_configs
+        if pool.pool_id in pool_ids
+    )
+
+
+def get_token_proportional_kv_cache_capacity_tokens(
+    kv_cache_config: KVCacheConfig,
+) -> int:
+    """Return token capacity represented by TOKEN_PROPORTIONAL pools only."""
+    token_group_ids = _get_token_proportional_group_ids(kv_cache_config)
+    min_block_size = min(
+        kv_cache_config.kv_cache_groups[group_id].kv_cache_spec.block_size
+        for group_id in token_group_ids
+    )
+    num_blocks = _get_num_blocks_for_group_ids(kv_cache_config, token_group_ids)
+    return num_blocks // len(token_group_ids) * min_block_size
 
 
 def may_override_num_blocks(vllm_config: VllmConfig, num_blocks: int) -> int:
@@ -1052,6 +1129,13 @@ def unify_kv_cache_spec_page_size(
 def is_kv_cache_type_attention_free(kv_cache_spec: dict[str, KVCacheSpec]) -> bool:
     # kv_cache_spec is an empty dict for attention free models
     return not kv_cache_spec
+
+
+def _has_request_constant_specs(kv_cache_spec: dict[str, KVCacheSpec]) -> bool:
+    return any(
+        spec.memory_model == MemoryModel.REQUEST_CONSTANT
+        for spec in kv_cache_spec.values()
+    )
 
 
 def _get_kv_cache_groups_uniform_page_size(
@@ -1233,6 +1317,163 @@ def _get_kv_cache_config_deepseek_v4(
     return num_blocks, kv_cache_tensors
 
 
+def _has_request_constant_groups(
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> bool:
+    return any(
+        group.kv_cache_spec.memory_model == MemoryModel.REQUEST_CONSTANT
+        for group in kv_cache_groups
+    )
+
+
+def _get_request_constant_num_blocks(
+    vllm_config: VllmConfig, kv_cache_spec: KVCacheSpec
+) -> int:
+    blocks_per_request = kv_cache_spec.blocks_per_request
+    assert blocks_per_request > 0
+    max_num_seqs = vllm_config.scheduler_config.max_num_seqs
+    assert max_num_seqs > 0
+    return max_num_seqs * blocks_per_request + 1
+
+
+def _get_request_constant_reserved_bytes(
+    vllm_config: VllmConfig, kv_cache_groups: list[KVCacheGroupSpec]
+) -> int:
+    return sum(
+        _get_request_constant_num_blocks(vllm_config, group.kv_cache_spec)
+        * group.kv_cache_spec.physical_page_size_bytes
+        * len(group.layer_names)
+        for group in kv_cache_groups
+        if group.kv_cache_spec.memory_model == MemoryModel.REQUEST_CONSTANT
+    )
+
+
+def _get_legacy_num_blocks_from_pool_configs(
+    pool_configs: tuple[KVCachePoolConfig, ...],
+) -> int:
+    assert pool_configs
+    for pool in pool_configs:
+        if pool.memory_model == MemoryModel.TOKEN_PROPORTIONAL:
+            return pool.num_blocks
+    return pool_configs[0].num_blocks
+
+
+def _get_kv_cache_config_mixed_memory_model(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+    available_memory: int,
+) -> KVCacheConfig:
+    token_group_ids = [
+        group_id
+        for group_id, group in enumerate(kv_cache_groups)
+        if group.kv_cache_spec.memory_model == MemoryModel.TOKEN_PROPORTIONAL
+    ]
+    request_constant_group_ids = [
+        group_id
+        for group_id, group in enumerate(kv_cache_groups)
+        if group.kv_cache_spec.memory_model == MemoryModel.REQUEST_CONSTANT
+    ]
+
+    kv_cache_tensors: list[KVCacheTensor] = []
+    pool_configs: list[KVCachePoolConfig] = []
+    group_to_pool_id = [-1] * len(kv_cache_groups)
+
+    request_constant_pool_specs: list[tuple[int, KVCachePoolConfig]] = []
+    reserved_bytes = _get_request_constant_reserved_bytes(vllm_config, kv_cache_groups)
+
+    # CUDA graph memory profiling temporarily sets num_gpu_blocks_override and
+    # asks for a minimal KV cache with available_memory=0.  The single-pool
+    # TOKEN_PROPORTIONAL path already honors that override after deriving an
+    # initial block count from available_memory.  Mirror that behavior here so
+    # mixed-memory configs do not fail before the token pool gets a chance to
+    # apply the override.  REQUEST_CONSTANT pool sizes remain deterministic.
+    override = vllm_config.cache_config.num_gpu_blocks_override
+    if override is not None:
+        if token_group_ids:
+            token_groups = [kv_cache_groups[group_id] for group_id in token_group_ids]
+            available_memory = max(
+                available_memory,
+                reserved_bytes + override * _pool_bytes_per_block(token_groups),
+            )
+        else:
+            available_memory = max(available_memory, reserved_bytes)
+
+    next_pool_id = 1 if token_group_ids else 0
+    for group_id in request_constant_group_ids:
+        group = kv_cache_groups[group_id]
+        spec = group.kv_cache_spec
+        num_blocks = _get_request_constant_num_blocks(vllm_config, spec)
+        pool_config = KVCachePoolConfig(
+            pool_id=next_pool_id,
+            memory_model=MemoryModel.REQUEST_CONSTANT,
+            group_ids=(group_id,),
+            num_blocks=num_blocks,
+            accounting_page_size_bytes=spec.accounting_page_size_bytes,
+            physical_page_size_bytes=spec.physical_page_size_bytes,
+        )
+        request_constant_pool_specs.append((group_id, pool_config))
+        next_pool_id += 1
+
+    reservation_exhausts_memory = (
+        reserved_bytes >= available_memory
+        if token_group_ids
+        else reserved_bytes > available_memory
+    )
+    if reservation_exhausts_memory:
+        raise ValueError(
+            "REQUEST_CONSTANT KV cache reservation "
+            f"({format_gib(reserved_bytes)} GiB) is not smaller than the "
+            f"available KV cache memory ({format_gib(available_memory)} GiB). "
+            "Try increasing `gpu_memory_utilization` or decreasing "
+            "`max_num_seqs`."
+        )
+
+    if token_group_ids:
+        token_groups = [kv_cache_groups[group_id] for group_id in token_group_ids]
+        token_kv_cache_config = get_kv_cache_config_from_groups(
+            vllm_config, token_groups, available_memory - reserved_bytes
+        )
+        if token_kv_cache_config.num_blocks <= 0:
+            raise ValueError(
+                "No available memory remains for TOKEN_PROPORTIONAL KV cache "
+                "blocks after REQUEST_CONSTANT KV cache reservation."
+            )
+        token_pool_config = token_kv_cache_config.pool_configs[0]
+        pool_configs.append(
+            replace(
+                token_pool_config,
+                pool_id=0,
+                group_ids=tuple(token_group_ids),
+            )
+        )
+        for group_id in token_group_ids:
+            group_to_pool_id[group_id] = 0
+        kv_cache_tensors.extend(token_kv_cache_config.kv_cache_tensors)
+
+    for group_id, pool_config in request_constant_pool_specs:
+        group = kv_cache_groups[group_id]
+        spec = group.kv_cache_spec
+        group_to_pool_id[group_id] = pool_config.pool_id
+        pool_configs.append(pool_config)
+        for layer_name in group.layer_names:
+            kv_cache_tensors.append(
+                KVCacheTensor(
+                    size=pool_config.num_blocks * spec.physical_page_size_bytes,
+                    shared_by=[layer_name],
+                )
+            )
+
+    assert all(pool_id >= 0 for pool_id in group_to_pool_id)
+    pool_config_tuple = tuple(pool_configs)
+    return KVCacheConfig(
+        num_blocks=_get_legacy_num_blocks_from_pool_configs(pool_config_tuple),
+        kv_cache_tensors=kv_cache_tensors,
+        kv_cache_groups=kv_cache_groups,
+        pool_configs=pool_config_tuple,
+        group_to_pool_id=tuple(group_to_pool_id),
+    )
+
+
 def get_kv_cache_config_from_groups(
     vllm_config: VllmConfig,
     kv_cache_groups: list[KVCacheGroupSpec],
@@ -1256,6 +1497,17 @@ def get_kv_cache_config_from_groups(
             num_blocks=1,
             kv_cache_tensors=[],
             kv_cache_groups=kv_cache_groups,
+        )
+
+    if _has_request_constant_groups(kv_cache_groups):
+        if vllm_config.cache_config.enable_prefix_caching:
+            raise NotImplementedError(
+                "Prefix caching with REQUEST_CONSTANT groups is not yet "
+                "supported. Either disable prefix caching or use only "
+                "TOKEN_PROPORTIONAL specs."
+            )
+        return _get_kv_cache_config_mixed_memory_model(
+            vllm_config, kv_cache_groups, available_memory
         )
 
     # Determine how model runners should initialize the KV cache tensors.
@@ -1615,19 +1867,9 @@ def _annotate_eagle_groups_deepseek_v4(
             break
 
 
-def get_kv_cache_groups(
+def _get_token_proportional_kv_cache_groups(
     vllm_config: VllmConfig, kv_cache_spec: dict[str, KVCacheSpec]
 ) -> list[KVCacheGroupSpec]:
-    """
-    Split the layers in the model into groups with the same KV cache spec.
-
-    Args:
-        vllm_config: The global VllmConfig
-        kv_cache_spec: The kv cache spec of each attention layer in the model
-
-    Returns:
-        The generated KVCacheGroups
-    """
     if vllm_config.scheduler_config.disable_hybrid_kv_cache_manager:
         unify_hybrid_kv_cache_specs(kv_cache_spec)
 
@@ -1684,6 +1926,68 @@ def get_kv_cache_groups(
     return groups
 
 
+def _get_request_constant_kv_cache_groups(
+    kv_cache_spec: dict[str, KVCacheSpec],
+) -> list[KVCacheGroupSpec]:
+    """Group request-constant specs without page-size unification."""
+    same_spec_layers: dict[KVCacheSpec, list[str]] = defaultdict(list)
+    for layer_name, layer_spec in kv_cache_spec.items():
+        same_spec_layers[layer_spec].append(layer_name)
+    return create_kv_cache_group_specs(kv_cache_spec, list(same_spec_layers.values()))
+
+
+def _get_memory_model_aware_kv_cache_groups(
+    vllm_config: VllmConfig, kv_cache_spec: dict[str, KVCacheSpec]
+) -> list[KVCacheGroupSpec]:
+    token_proportional_specs = {
+        layer_name: spec
+        for layer_name, spec in kv_cache_spec.items()
+        if spec.memory_model == MemoryModel.TOKEN_PROPORTIONAL
+    }
+    request_constant_specs = {
+        layer_name: spec
+        for layer_name, spec in kv_cache_spec.items()
+        if spec.memory_model == MemoryModel.REQUEST_CONSTANT
+    }
+
+    kv_cache_groups: list[KVCacheGroupSpec] = []
+    if token_proportional_specs:
+        kv_cache_groups.extend(
+            _get_token_proportional_kv_cache_groups(
+                vllm_config, token_proportional_specs
+            )
+        )
+    if request_constant_specs:
+        kv_cache_groups.extend(
+            _get_request_constant_kv_cache_groups(request_constant_specs)
+        )
+    return kv_cache_groups
+
+
+def get_kv_cache_groups(
+    vllm_config: VllmConfig, kv_cache_spec: dict[str, KVCacheSpec]
+) -> list[KVCacheGroupSpec]:
+    """
+    Split the layers in the model into groups with the same KV cache spec.
+
+    Args:
+        vllm_config: The global VllmConfig
+        kv_cache_spec: The kv cache spec of each attention layer in the model
+
+    Returns:
+        The generated KVCacheGroups
+    """
+    if is_kv_cache_type_attention_free(kv_cache_spec):
+        # This returns an empty list to allow for the KVCacheManager to handle
+        # attention free models.
+        return []
+
+    if _has_request_constant_specs(kv_cache_spec):
+        return _get_memory_model_aware_kv_cache_groups(vllm_config, kv_cache_spec)
+
+    return _get_token_proportional_kv_cache_groups(vllm_config, kv_cache_spec)
+
+
 def generate_scheduler_kv_cache_config(
     kv_cache_configs: list[KVCacheConfig],
 ) -> KVCacheConfig:
@@ -1692,6 +1996,26 @@ def generate_scheduler_kv_cache_config(
     """
     assert all(
         [cfg.num_blocks == kv_cache_configs[0].num_blocks for cfg in kv_cache_configs]
+    )
+    assert all(
+        [
+            cfg.group_to_pool_id == kv_cache_configs[0].group_to_pool_id
+            for cfg in kv_cache_configs
+        ]
+    )
+    assert all(
+        [
+            _get_pool_config_structure(cfg)
+            == _get_pool_config_structure(kv_cache_configs[0])
+            for cfg in kv_cache_configs
+        ]
+    )
+    assert all(
+        [
+            tuple(pool.num_blocks for pool in cfg.pool_configs)
+            == tuple(pool.num_blocks for pool in kv_cache_configs[0].pool_configs)
+            for cfg in kv_cache_configs
+        ]
     )
     # All workers have the same kv_cache_config except layer names, so use
     # an arbitrary one to initialize the scheduler.
@@ -1703,7 +2027,21 @@ def generate_scheduler_kv_cache_config(
             group.kv_cache_spec = next(
                 iter(group.kv_cache_spec.kv_cache_specs.values())
             )
+    cfg.refresh_legacy_pool_metadata()
     return cfg
+
+
+def _get_pool_config_structure(kv_cache_config: KVCacheConfig):
+    return tuple(
+        (
+            pool.pool_id,
+            pool.memory_model,
+            pool.group_ids,
+            pool.accounting_page_size_bytes,
+            pool.physical_page_size_bytes,
+        )
+        for pool in kv_cache_config.pool_configs
+    )
 
 
 def _report_kv_cache_config(
@@ -1751,6 +2089,22 @@ def _max_memory_usage_bytes_from_groups(
     """
     if not kv_cache_groups:
         return 0
+
+    if _has_request_constant_groups(kv_cache_groups):
+        request_constant_memory = _get_request_constant_reserved_bytes(
+            vllm_config, kv_cache_groups
+        )
+        token_proportional_groups = [
+            group
+            for group in kv_cache_groups
+            if group.kv_cache_spec.memory_model == MemoryModel.TOKEN_PROPORTIONAL
+        ]
+        token_proportional_memory = (
+            _max_memory_usage_bytes_from_groups(vllm_config, token_proportional_groups)
+            if token_proportional_groups
+            else 0
+        )
+        return request_constant_memory + token_proportional_memory
 
     if len(kv_cache_groups) == 1 and isinstance(
         kv_cache_groups[0].kv_cache_spec, UniformTypeKVCacheSpecs
@@ -1942,6 +2296,81 @@ def _project_kv_cache_groups_to_worker(
     return projected_groups
 
 
+def _get_tensor_pool_id(
+    kv_cache_config: KVCacheConfig,
+    tensor: KVCacheTensor,
+) -> int:
+    layer_to_group_id = {
+        layer_name: group_id
+        for group_id, group in enumerate(kv_cache_config.kv_cache_groups)
+        for layer_name in group.layer_names
+    }
+    pool_ids = {
+        kv_cache_config.group_to_pool_id[layer_to_group_id[layer_name]]
+        for layer_name in tensor.shared_by
+    }
+    assert len(pool_ids) == 1
+    return pool_ids.pop()
+
+
+def _normalize_kv_cache_config_num_blocks(
+    kv_cache_configs: list[KVCacheConfig],
+) -> None:
+    if not kv_cache_configs:
+        return
+    if not kv_cache_configs[0].pool_configs:
+        min_num_blocks = min(
+            kv_cache_config.num_blocks for kv_cache_config in kv_cache_configs
+        )
+        for kv_cache_config in kv_cache_configs:
+            kv_cache_config.num_blocks = min_num_blocks
+            kv_cache_config.refresh_legacy_pool_metadata()
+        return
+
+    num_pools = len(kv_cache_configs[0].pool_configs)
+    assert all(len(config.pool_configs) == num_pools for config in kv_cache_configs)
+
+    normalized_pool_num_blocks: list[int] = []
+    for pool_id in range(num_pools):
+        memory_model = kv_cache_configs[0].pool_configs[pool_id].memory_model
+        assert all(
+            config.pool_configs[pool_id].memory_model == memory_model
+            for config in kv_cache_configs
+        )
+        pool_num_blocks = [
+            config.pool_configs[pool_id].num_blocks for config in kv_cache_configs
+        ]
+        if memory_model == MemoryModel.TOKEN_PROPORTIONAL:
+            normalized_pool_num_blocks.append(min(pool_num_blocks))
+        else:
+            assert len(set(pool_num_blocks)) == 1
+            normalized_pool_num_blocks.append(pool_num_blocks[0])
+
+    for kv_cache_config in kv_cache_configs:
+        old_pool_num_blocks = tuple(
+            pool.num_blocks for pool in kv_cache_config.pool_configs
+        )
+        kv_cache_config.pool_configs = tuple(
+            replace(pool, num_blocks=normalized_pool_num_blocks[pool.pool_id])
+            for pool in kv_cache_config.pool_configs
+        )
+        kv_cache_config.num_blocks = _get_legacy_num_blocks_from_pool_configs(
+            kv_cache_config.pool_configs
+        )
+
+        for tensor in kv_cache_config.kv_cache_tensors:
+            pool_id = _get_tensor_pool_id(kv_cache_config, tensor)
+            old_num_blocks = old_pool_num_blocks[pool_id]
+            new_num_blocks = normalized_pool_num_blocks[pool_id]
+            assert old_num_blocks > 0, (
+                "KV cache pool num_blocks includes the null block and must be positive."
+            )
+            if old_num_blocks == new_num_blocks:
+                continue
+            assert tensor.size % old_num_blocks == 0
+            tensor.size = tensor.size // old_num_blocks * new_num_blocks
+
+
 def get_kv_cache_configs(
     vllm_config: VllmConfig,
     kv_cache_specs: list[dict[str, KVCacheSpec]],
@@ -2017,13 +2446,29 @@ def get_kv_cache_configs(
             if not groups:
                 adjusted_memory.append(avail_mem)
                 continue
-            bytes_per_block = _pool_bytes_per_block(groups)
+            if _has_request_constant_groups(groups):
+                token_groups = [
+                    group
+                    for group in groups
+                    if group.kv_cache_spec.memory_model
+                    == MemoryModel.TOKEN_PROPORTIONAL
+                ]
+                request_constant_bytes = _get_request_constant_reserved_bytes(
+                    vllm_config, groups
+                )
+                bytes_per_block = (
+                    _pool_bytes_per_block(token_groups) if token_groups else 0
+                )
+            else:
+                request_constant_bytes = 0
+                bytes_per_block = _pool_bytes_per_block(groups)
+            profiled_blocks = avail_mem // bytes_per_block if bytes_per_block else 0
             logger.info(
                 "Overriding num_gpu_blocks=%d with num_gpu_blocks_override=%d",
-                avail_mem // bytes_per_block,
+                profiled_blocks,
                 override,
             )
-            adjusted_memory.append(override * bytes_per_block)
+            adjusted_memory.append(request_constant_bytes + override * bytes_per_block)
         available_memory = adjusted_memory
 
     if vllm_config.model_config.original_max_model_len == -1:
@@ -2055,21 +2500,11 @@ def get_kv_cache_configs(
             )
         )
 
-    # Change the num_blocks of each rank to the smallest among all ranks.
-    # We also need to shrink the tensor size proportionally to avoid
-    # allocating unused memory.
-    min_num_blocks = min(
-        kv_cache_config.num_blocks for kv_cache_config in kv_cache_configs
-    )
+    # Change token-proportional num_blocks of each rank to the smallest among
+    # all ranks. Request-constant pool sizes are deterministic from
+    # max_num_seqs and are asserted equal rather than normalized.
+    _normalize_kv_cache_config_num_blocks(kv_cache_configs)
     for kv_cache_config in kv_cache_configs:
-        num_blocks_old = kv_cache_config.num_blocks
-        kv_cache_config.num_blocks = min_num_blocks
-
-        # Shrink tensor size proportionally
-        for tensor in kv_cache_config.kv_cache_tensors:
-            assert tensor.size % num_blocks_old == 0
-            tensor.size = tensor.size // num_blocks_old * min_num_blocks
-
         if len(kv_cache_config.kv_cache_groups) > 0:
             _report_kv_cache_config(vllm_config, kv_cache_config)
 

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -29,6 +29,7 @@ from vllm.model_executor.layers.fused_moe.routed_experts_capturer import (
 )
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
 from vllm.multimodal.encoder_budget import MultiModalBudget
+from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.encoder_cache_manager import (
     EncoderCacheManager,
     EncoderDecoderCacheManager,
@@ -244,7 +245,14 @@ class Scheduler(SchedulerInterface):
         # Bind GPU block pool to the KV connector. This must happen after
         # kv_cache_manager is constructed so block_pool is available.
         if self.connector is not None:
-            self.connector.bind_gpu_block_pool(self.kv_cache_manager.block_pool)
+            block_pool = self.kv_cache_manager.block_pool
+            if not isinstance(block_pool, BlockPool):
+                raise NotImplementedError(
+                    "KV connector requires the token-proportional BlockPool. "
+                    "REQUEST_CONSTANT KV cache pools are not supported with "
+                    "KV connector yet."
+                )
+            self.connector.bind_gpu_block_pool(block_pool)
 
         self.use_pp = self.parallel_config.pipeline_parallel_size > 1
         self.use_v2_model_runner = vllm_config.use_v2_model_runner

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -4,9 +4,14 @@ import itertools
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Sequence
+from typing import cast
 
 from vllm.utils.math_utils import cdiv
-from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.block_pool import (
+    BlockPool,
+    BlockPoolProtocol,
+    CacheableBlockPoolProtocol,
+)
 from vllm.v1.core.kv_cache_utils import (
     BlockHashList,
     BlockHashWithGroupId,
@@ -19,6 +24,7 @@ from vllm.v1.kv_cache_interface import (
     HiddenStateCacheSpec,
     KVCacheSpec,
     MambaSpec,
+    MemoryModel,
     MLAAttentionSpec,
     SinkFullAttentionSpec,
     SlidingWindowMLASpec,
@@ -37,7 +43,7 @@ class SingleTypeKVCacheManager(ABC):
     def __init__(
         self,
         kv_cache_spec: KVCacheSpec,
-        block_pool: BlockPool,
+        block_pool: BlockPoolProtocol,
         enable_caching: bool,
         kv_cache_group_id: int,
         scheduler_block_size: int,
@@ -91,6 +97,27 @@ class SingleTypeKVCacheManager(ABC):
         # aligned segment (SWA). Initialized lazily by the coordinator after
         # determining the attention groups.
         self.use_eagle = False
+
+    def _should_record_new_block_ids_for_zeroing(self) -> bool:
+        """Return whether newly allocated blocks should be zeroed.
+
+        This preserves the legacy behavior exactly: only full-attention style
+        KV blocks are zeroed by the GPU worker. Sink attention uses a custom
+        manager and is excluded from this generic full-attention path.
+        """
+        return isinstance(self.kv_cache_spec, FullAttentionSpec) and not isinstance(
+            self.kv_cache_spec, SinkFullAttentionSpec
+        )
+
+    def _cacheable_block_pool(self) -> CacheableBlockPoolProtocol:
+        """Return the block pool as a prefix-cache-capable pool.
+
+        Compact/request-constant pools only implement the allocation protocol.
+        Prefix-cache paths are guarded by ``enable_caching`` and must only run
+        with a cacheable pool.
+        """
+        assert self.enable_caching
+        return cast(CacheableBlockPoolProtocol, self.block_pool)
 
     @classmethod
     def _get_num_evictable_blocks(cls, blocks: Sequence[KVCacheBlock]):
@@ -226,7 +253,7 @@ class SingleTypeKVCacheManager(ABC):
 
         # Touch the computed blocks to make sure they won't be evicted.
         if self.enable_caching:
-            self.block_pool.touch(new_computed_blocks)
+            self._cacheable_block_pool().touch(new_computed_blocks)
         else:
             assert not any(new_computed_blocks), (
                 "Computed blocks should be empty when prefix caching is disabled"
@@ -247,11 +274,7 @@ class SingleTypeKVCacheManager(ABC):
                 cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
             )
             req_blocks.extend(allocated_blocks)
-            if type(self.kv_cache_spec) in (
-                FullAttentionSpec,
-                TQFullAttentionSpec,
-                MLAAttentionSpec,
-            ):
+            if self._should_record_new_block_ids_for_zeroing():
                 self.new_block_ids.extend(b.block_id for b in allocated_blocks)
 
     def allocate_new_blocks(
@@ -279,11 +302,7 @@ class SingleTypeKVCacheManager(ABC):
         else:
             new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
             req_blocks.extend(new_blocks)
-            if type(self.kv_cache_spec) in (
-                FullAttentionSpec,
-                TQFullAttentionSpec,
-                MLAAttentionSpec,
-            ):
+            if self._should_record_new_block_ids_for_zeroing():
                 self.new_block_ids.extend(b.block_id for b in new_blocks)
             return new_blocks
 
@@ -330,7 +349,7 @@ class SingleTypeKVCacheManager(ABC):
                 self.kv_cache_spec,
                 self.use_eagle,
             )
-        self.block_pool.cache_full_blocks(
+        self._cacheable_block_pool().cache_full_blocks(
             request=request,
             blocks=self.req_to_blocks[request.request_id],
             num_cached_blocks=num_cached_blocks,
@@ -400,7 +419,7 @@ class SingleTypeKVCacheManager(ABC):
         block_hashes: BlockHashList,
         max_length: int,
         kv_cache_group_ids: list[int],
-        block_pool: BlockPool,
+        block_pool: CacheableBlockPoolProtocol,
         kv_cache_spec: KVCacheSpec,
         drop_eagle_block: bool,
         alignment_tokens: int,
@@ -513,7 +532,7 @@ class FullAttentionManager(SingleTypeKVCacheManager):
         block_hashes: BlockHashList,
         max_length: int,
         kv_cache_group_ids: list[int],
-        block_pool: BlockPool,
+        block_pool: CacheableBlockPoolProtocol,
         kv_cache_spec: KVCacheSpec,
         drop_eagle_block: bool,
         alignment_tokens: int,
@@ -591,7 +610,7 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         block_hashes: BlockHashList,
         max_length: int,
         kv_cache_group_ids: list[int],
-        block_pool: BlockPool,
+        block_pool: CacheableBlockPoolProtocol,
         kv_cache_spec: KVCacheSpec,
         drop_eagle_block: bool,
         alignment_tokens: int,
@@ -750,7 +769,7 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
         block_hashes: BlockHashList,
         max_length: int,
         kv_cache_group_ids: list[int],
-        block_pool: BlockPool,
+        block_pool: CacheableBlockPoolProtocol,
         kv_cache_spec: KVCacheSpec,
         drop_eagle_block: bool,
         alignment_tokens: int,
@@ -891,12 +910,17 @@ class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
 
 class MambaManager(SingleTypeKVCacheManager):
     def __init__(
-        self, kv_cache_spec: MambaSpec, block_pool: BlockPool, **kwargs
+        self, kv_cache_spec: MambaSpec, block_pool: BlockPoolProtocol, **kwargs
     ) -> None:
         super().__init__(kv_cache_spec, block_pool, **kwargs)
         self.cached_blocks_this_step: set[BlockHashWithGroupId] = set()
         self.mamba_cache_mode = kv_cache_spec.mamba_cache_mode
         self.num_speculative_blocks: int = kv_cache_spec.num_speculative_blocks
+        self.is_request_constant = (
+            kv_cache_spec.memory_model == MemoryModel.REQUEST_CONSTANT
+        )
+        if self.is_request_constant:
+            assert not self.enable_caching
         if self.mamba_cache_mode == "align":
             # Mapping from request ID to the index of the block
             # allocated in the previous step
@@ -910,7 +934,7 @@ class MambaManager(SingleTypeKVCacheManager):
         block_hashes: BlockHashList,
         max_length: int,
         kv_cache_group_ids: list[int],
-        block_pool: BlockPool,
+        block_pool: CacheableBlockPoolProtocol,
         kv_cache_spec: KVCacheSpec,
         drop_eagle_block: bool,
         alignment_tokens: int,
@@ -962,6 +986,13 @@ class MambaManager(SingleTypeKVCacheManager):
         # that we might actually need.
         num_computed_tokens = max(0, num_computed_tokens - self.num_speculative_blocks)
 
+        if self.is_request_constant and self.mamba_cache_mode != "align":
+            # Non-align compact Mamba keeps exactly one current state block
+            # plus optional speculative state blocks per request. Token-window
+            # based skipped-block eviction would incorrectly free that compact
+            # state because its block table is not token-proportional.
+            return
+
         super().remove_skipped_blocks(request_id, num_computed_tokens)
         if self.mamba_cache_mode == "align":
             # `last_state_block_idx` refers to the block index allocated two steps ago.
@@ -988,6 +1019,13 @@ class MambaManager(SingleTypeKVCacheManager):
         """
         return 0
 
+    def _get_request_constant_num_blocks_to_allocate(self, request_id: str) -> int:
+        assert isinstance(self.kv_cache_spec, MambaSpec)
+        held_blocks = sum(
+            not block.is_null for block in self.req_to_blocks.get(request_id, ())
+        )
+        return max(self.kv_cache_spec.blocks_per_request - held_blocks, 0)
+
     def get_num_blocks_to_allocate(
         self,
         request_id: str,
@@ -1007,6 +1045,9 @@ class MambaManager(SingleTypeKVCacheManager):
             # that kv_cache_manager will think there is no enough blocks to allocate now
             # and don't schedule it in the current step.
             return self.block_pool.num_gpu_blocks + 1
+        if self.is_request_constant and self.mamba_cache_mode != "align":
+            assert len(new_computed_blocks) == 0
+            return self._get_request_constant_num_blocks_to_allocate(request_id)
         if self.mamba_cache_mode != "align":
             # Allocate extra `num_speculative_blocks` blocks for
             # speculative decoding (MTP/EAGLE) with linear attention.
@@ -1059,6 +1100,16 @@ class MambaManager(SingleTypeKVCacheManager):
         self, request_id: str, num_tokens: int, num_tokens_main_model: int
     ) -> list[KVCacheBlock]:
         assert isinstance(self.kv_cache_spec, MambaSpec)
+        if self.is_request_constant and self.mamba_cache_mode != "align":
+            compact_req_blocks: list[KVCacheBlock] = self.req_to_blocks[request_id]
+            num_new_blocks = self._get_request_constant_num_blocks_to_allocate(
+                request_id
+            )
+            if num_new_blocks <= 0:
+                return []
+            new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
+            compact_req_blocks.extend(new_blocks)
+            return new_blocks
         if self.mamba_cache_mode != "align":
             # Allocate extra `num_speculative_blocks` blocks for
             # speculative decoding (MTP/EAGLE) with linear attention.
@@ -1137,6 +1188,16 @@ class MambaManager(SingleTypeKVCacheManager):
         if self.mamba_cache_mode == "align":
             self._allocated_block_reqs.discard(request_id)
             self.last_state_block_idx.pop(request_id, None)
+        if self.is_request_constant:
+            # CompactBlockPool rejects freeing the null sentinel. Align-mode
+            # request block tables can contain null padding, so filter them
+            # before returning real compact blocks to the pool.
+            req_blocks = self.req_to_blocks.pop(request_id, [])
+            self.block_pool.free_blocks(
+                block for block in reversed(req_blocks) if not block.is_null
+            )
+            self.num_cached_block.pop(request_id, None)
+            return
         super().free(request_id)
 
     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
@@ -1204,7 +1265,7 @@ class CrossAttentionManager(SingleTypeKVCacheManager):
         block_hashes: BlockHashList,
         max_length: int,
         kv_cache_group_ids: list[int],
-        block_pool: BlockPool,
+        block_pool: CacheableBlockPoolProtocol,
         kv_cache_spec: KVCacheSpec,
         drop_eagle_block: bool,
         alignment_tokens: int,
@@ -1244,7 +1305,7 @@ class SinkFullAttentionManager(FullAttentionManager):
         sink_len = kv_cache_spec.sink_len
         assert sink_len is not None and sink_len > 0 and sink_len % self.block_size == 0
         num_sink_block = sink_len // self.block_size
-        self.sink_blocks = self.block_pool.free_block_queue.popleft_n(num_sink_block)
+        self.sink_blocks = block_pool.free_block_queue.popleft_n(num_sink_block)
 
 
 spec_manager_map: dict[type[KVCacheSpec], type[SingleTypeKVCacheManager]] = {

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -91,6 +91,13 @@ class KVCacheSpecKind(str, Enum):
     UNKNOWN = "unknown"
 
 
+class MemoryModel(Enum):
+    """How a KV cache spec's memory scales with request properties."""
+
+    TOKEN_PROPORTIONAL = "token_proportional"
+    REQUEST_CONSTANT = "request_constant"
+
+
 @dataclass(frozen=True)
 class KVCacheSpec:
     """
@@ -113,6 +120,34 @@ class KVCacheSpec:
     @property
     def storage_block_size(self) -> int:
         return self.block_size
+
+    @property
+    def memory_model(self) -> MemoryModel:
+        """How memory usage scales for this KV cache spec."""
+        return MemoryModel.TOKEN_PROPORTIONAL
+
+    @property
+    def blocks_per_request(self) -> int:
+        """Maximum compact-pool blocks held by one request.
+
+        This is only meaningful for ``REQUEST_CONSTANT`` specs.
+        """
+        return 1
+
+    @property
+    def accounting_page_size_bytes(self) -> int:
+        """Bytes used for allocator accounting."""
+        return self.page_size_bytes
+
+    @property
+    def physical_page_size_bytes(self) -> int:
+        """Bytes the backing cache tensor physically stores per page."""
+        return self.page_size_bytes
+
+    @property
+    def requires_block_zeroing_on_alloc(self) -> bool:
+        """Whether reused blocks must be zeroed before re-allocation."""
+        return True
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         """
@@ -570,22 +605,50 @@ class MambaSpec(KVCacheSpec):
 
     @property
     def page_size_bytes(self) -> int:
-        page_size = sum(
-            prod(shape) * get_dtype_size(dtype)
-            for (shape, dtype) in zip(self.shapes, self.dtypes)
-        )
+        page_size = self.physical_page_size_bytes
         if self.page_size_padded is not None:
             assert self.page_size_padded >= page_size
             return self.page_size_padded
         return page_size
 
+    @property
+    def physical_page_size_bytes(self) -> int:
+        return sum(
+            prod(shape) * get_dtype_size(dtype)
+            for (shape, dtype) in zip(self.shapes, self.dtypes)
+        )
+
+    @property
+    def memory_model(self) -> MemoryModel:
+        # "all" mode preserves the legacy token-proportional shared-pool path,
+        # including prefix-caching compatibility. Other modes store compact
+        # O(1)-per-request state.
+        if self.mamba_cache_mode == "all":
+            return MemoryModel.TOKEN_PROPORTIONAL
+        return MemoryModel.REQUEST_CONSTANT
+
+    @property
+    def blocks_per_request(self) -> int:
+        # "align" may transiently hold previous + current state blocks during a
+        # state-block transition. "none" holds exactly one state block.
+        # Speculative decoding adds one compact slot per speculative block.
+        if self.mamba_cache_mode == "align":
+            return 2 + self.num_speculative_blocks
+        return 1 + self.num_speculative_blocks
+
+    @property
+    def requires_block_zeroing_on_alloc(self) -> bool:
+        # The current KVBlockZeroer skips Mamba tensors in all modes. Mamba
+        # state isolation is handled by the kernel/state-copy path instead.
+        return False
+
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
-        if vllm_config.cache_config.mamba_cache_mode == "all":
+        if self.mamba_cache_mode == "all":
             max_model_len = vllm_config.model_config.max_model_len
             return (
                 cdiv(max_model_len, self.block_size) + self.num_speculative_blocks
             ) * self.page_size_bytes
-        elif vllm_config.cache_config.mamba_cache_mode == "align":
+        elif self.mamba_cache_mode == "align":
             return self.page_size_bytes * (2 + self.num_speculative_blocks)
         else:
             return self.page_size_bytes * (1 + self.num_speculative_blocks)
@@ -677,6 +740,12 @@ class UniformTypeKVCacheSpecs(KVCacheSpec):
     @property
     def page_size_bytes(self) -> int:
         return sum(spec.page_size_bytes for spec in self.kv_cache_specs.values())
+
+    @property
+    def physical_page_size_bytes(self) -> int:
+        return sum(
+            spec.physical_page_size_bytes for spec in self.kv_cache_specs.values()
+        )
 
     def max_memory_usage_bytes(self, vllm_config: VllmConfig) -> int:
         max_num_pages = max(
@@ -834,6 +903,22 @@ class KVCacheGroupSpec:
     is_eagle_group: bool = False
 
 
+@dataclass(frozen=True)
+class KVCachePoolConfig:
+    """Metadata for one KV cache block-pool namespace.
+
+    ``num_blocks`` includes the reserved null sentinel block. Therefore the
+    number of allocatable blocks in the pool is ``num_blocks - 1``.
+    """
+
+    pool_id: int
+    memory_model: MemoryModel
+    group_ids: tuple[int, ...]
+    num_blocks: int
+    accounting_page_size_bytes: int
+    physical_page_size_bytes: int
+
+
 @dataclass
 class KVCacheConfig:
     """
@@ -852,6 +937,127 @@ class KVCacheConfig:
     For models with multiple types of attention, there will be multiple groups,
     see `_get_kv_cache_config_uniform_page_size` for more details.
     """
+    pool_configs: tuple[KVCachePoolConfig, ...] = ()
+    """Metadata for KV cache block-pool namespaces."""
+    group_to_pool_id: tuple[int, ...] = ()
+    """Mapping from KV cache group id to pool id."""
+
+    def __post_init__(self) -> None:
+        if len(self.kv_cache_groups) == 0:
+            assert self.pool_configs == ()
+            assert self.group_to_pool_id == ()
+            return
+
+        if not self.pool_configs and not self.group_to_pool_id:
+            pool_configs, group_to_pool_id = self._make_legacy_pool_metadata()
+            self.pool_configs = pool_configs
+            self.group_to_pool_id = group_to_pool_id
+            return
+
+        assert len(self.group_to_pool_id) == len(self.kv_cache_groups)
+        pool_ids = {pool.pool_id for pool in self.pool_configs}
+        assert pool_ids == set(range(len(self.pool_configs)))
+        assert set(self.group_to_pool_id).issubset(pool_ids)
+
+    def _make_legacy_pool_metadata(
+        self,
+        num_blocks: int | None = None,
+    ) -> tuple[tuple[KVCachePoolConfig, ...], tuple[int, ...]]:
+        """Derive pool metadata for legacy direct ``KVCacheConfig`` callers.
+
+        Production multi-pool configs should pass explicit pool metadata. This
+        fallback keeps the old single shared block-pool behavior. It cannot
+        compute request-constant compact capacity because it has no scheduler
+        context.
+        """
+        specs = [group.kv_cache_spec for group in self.kv_cache_groups]
+        accounting_page_size = max(spec.accounting_page_size_bytes for spec in specs)
+        physical_page_sizes = {spec.physical_page_size_bytes for spec in specs}
+        if len(physical_page_sizes) == 1:
+            pool_physical_page_size_bytes = physical_page_sizes.pop()
+        else:
+            pool_physical_page_size_bytes = accounting_page_size
+
+        pool_config = KVCachePoolConfig(
+            pool_id=0,
+            memory_model=MemoryModel.TOKEN_PROPORTIONAL,
+            group_ids=tuple(range(len(self.kv_cache_groups))),
+            num_blocks=self.num_blocks if num_blocks is None else num_blocks,
+            accounting_page_size_bytes=accounting_page_size,
+            physical_page_size_bytes=pool_physical_page_size_bytes,
+        )
+        return (pool_config,), tuple(0 for _ in self.kv_cache_groups)
+
+    def _legacy_num_blocks_pool_id(self) -> int | None:
+        """Return the pool represented by the legacy ``num_blocks`` field."""
+        if not self.pool_configs:
+            return None
+        for pool in self.pool_configs:
+            if pool.memory_model == MemoryModel.TOKEN_PROPORTIONAL:
+                return pool.pool_id
+        return self.pool_configs[0].pool_id
+
+    def _refresh_multi_pool_metadata(self) -> None:
+        """Refresh explicit pool metadata without collapsing it to one pool."""
+        assert self.pool_configs
+        assert len(self.group_to_pool_id) == len(self.kv_cache_groups)
+
+        group_ids_by_pool: dict[int, list[int]] = {
+            pool.pool_id: [] for pool in self.pool_configs
+        }
+        for group_id, pool_id in enumerate(self.group_to_pool_id):
+            group_ids_by_pool[pool_id].append(group_id)
+
+        legacy_pool_id = self._legacy_num_blocks_pool_id()
+        refreshed_pool_configs: list[KVCachePoolConfig] = []
+        for pool in self.pool_configs:
+            group_ids = tuple(group_ids_by_pool[pool.pool_id])
+            assert group_ids
+            specs = [
+                self.kv_cache_groups[group_id].kv_cache_spec for group_id in group_ids
+            ]
+            memory_models = {spec.memory_model for spec in specs}
+            assert memory_models == {pool.memory_model}
+
+            accounting_page_sizes = {spec.accounting_page_size_bytes for spec in specs}
+            assert len(accounting_page_sizes) == 1
+            physical_page_sizes = {spec.physical_page_size_bytes for spec in specs}
+            if len(physical_page_sizes) == 1:
+                physical_page_size_bytes = physical_page_sizes.pop()
+            else:
+                physical_page_size_bytes = next(iter(accounting_page_sizes))
+
+            refreshed_pool_configs.append(
+                replace(
+                    pool,
+                    group_ids=group_ids,
+                    num_blocks=(
+                        self.num_blocks
+                        if pool.pool_id == legacy_pool_id
+                        else pool.num_blocks
+                    ),
+                    accounting_page_size_bytes=accounting_page_sizes.pop(),
+                    physical_page_size_bytes=physical_page_size_bytes,
+                )
+            )
+
+        self.pool_configs = tuple(refreshed_pool_configs)
+
+    def refresh_legacy_pool_metadata(self) -> None:
+        """Regenerate pool metadata after mutating config fields."""
+        if len(self.kv_cache_groups) == 0:
+            self.pool_configs = ()
+            self.group_to_pool_id = ()
+            return
+        if len(self.pool_configs) > 1 or any(
+            pool.memory_model == MemoryModel.REQUEST_CONSTANT
+            for pool in self.pool_configs
+        ):
+            self._refresh_multi_pool_metadata()
+            return
+        pool_configs, group_to_pool_id = self._make_legacy_pool_metadata()
+        self.pool_configs = pool_configs
+        self.group_to_pool_id = group_to_pool_id
 
     @property
     def has_mamba_layers(self) -> bool:
@@ -859,4 +1065,11 @@ class KVCacheConfig:
 
     @property
     def needs_kv_cache_zeroing(self) -> bool:
+        """Whether the GPU worker should initialize the attention KV zeroer.
+
+        Despite the broad name, this gate currently controls the attention-only
+        ``KVBlockZeroer`` in hybrid models. The zeroer skips Mamba tensors, and
+        ``SingleTypeKVCacheManager`` only records full-attention block IDs for
+        zeroing.
+        """
         return self.has_mamba_layers

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -5,7 +5,7 @@
 import contextlib
 from collections.abc import Iterable
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from vllm.config import VllmConfig
 from vllm.distributed.kv_events import KVCacheEvent
@@ -21,6 +21,7 @@ from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     MambaSpec,
+    MemoryModel,
     SlidingWindowSpec,
 )
 from vllm.v1.outputs import KVConnectorOutput
@@ -130,7 +131,7 @@ class SimpleCPUOffloadScheduler:
             scheduler_block_size=self.block_size,
             hash_block_size=self.hash_block_size,
         )
-        self.cpu_block_pool: BlockPool = self.cpu_coordinator.block_pool
+        self.cpu_block_pool = cast(BlockPool, self.cpu_coordinator.block_pool)
 
         # GPU block pool reference - bound after scheduler builds kv_cache_manager
         self._gpu_block_pool: BlockPool | None = None
@@ -184,6 +185,15 @@ class SimpleCPUOffloadScheduler:
         from vllm.v1.kv_cache_interface import KVCacheTensor
 
         assert len(gpu_config.kv_cache_tensors) > 0
+        if any(
+            pool.memory_model == MemoryModel.REQUEST_CONSTANT
+            for pool in gpu_config.pool_configs
+        ):
+            raise NotImplementedError(
+                "CPU KV cache offload with REQUEST_CONSTANT specs "
+                "(Mamba in 'none' or 'align' mode) is not supported. Set "
+                "mamba_cache_mode='all' or disable offload."
+            )
 
         gpu_total_bytes = sum(t.size for t in gpu_config.kv_cache_tensors)
         num_gpu_blocks = gpu_config.num_blocks

--- a/vllm/v1/worker/gpu/attn_utils.py
+++ b/vllm/v1/worker/gpu/attn_utils.py
@@ -19,6 +19,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheSpec,
     MambaSpec,
+    MemoryModel,
     UniformTypeKVCacheSpecs,
 )
 from vllm.v1.worker.gpu.model_states.interface import ModelSpecificAttnMetadata
@@ -34,6 +35,13 @@ from vllm.v1.worker.utils import (
 class AttentionCGSupportInfo:
     min_cg_support: AttentionCGSupport = AttentionCGSupport.ALWAYS
     min_cg_attn_backend: str | None = None
+
+
+def get_block_layout_page_size_bytes(spec: KVCacheSpec) -> int:
+    """Page size used for block-count and stride math during reshape."""
+    if spec.memory_model == MemoryModel.REQUEST_CONSTANT:
+        return spec.physical_page_size_bytes
+    return spec.page_size_bytes
 
 
 def get_kv_cache_spec(vllm_config: VllmConfig) -> dict[str, KVCacheSpec]:
@@ -194,10 +202,16 @@ def _reshape_kv_cache(
                 continue
 
             kv_raw_tensor = kv_cache_raw_tensors[layer_name]
-            assert kv_raw_tensor.numel() % kv_cache_spec.page_size_bytes == 0
-            num_blocks = kv_raw_tensor.numel() // kv_cache_spec.page_size_bytes
+            block_layout_page_size = get_block_layout_page_size_bytes(kv_cache_spec)
+            assert kv_raw_tensor.numel() % block_layout_page_size == 0
+            num_blocks = kv_raw_tensor.numel() // block_layout_page_size
 
             if isinstance(kv_cache_spec, AttentionSpec):
+                if kv_cache_spec.memory_model == MemoryModel.REQUEST_CONSTANT:
+                    raise NotImplementedError(
+                        "REQUEST_CONSTANT AttentionSpec is not supported. "
+                        "Attention KV cache is token-proportional."
+                    )
                 has_attn = True
                 # Use storage_block_size: it equals block_size for uncompressed
                 # specs but is smaller for compressed ones (DeepSeek V4), which
@@ -238,7 +252,7 @@ def _reshape_kv_cache(
                     # index), which holds for all current backends
                     # (MLA, FlashAttention, TritonAttention, etc.).
                     dtype_size = get_dtype_size(dtype)
-                    page_stride = kv_cache_spec.page_size_bytes // dtype_size
+                    page_stride = block_layout_page_size // dtype_size
                     strides = list(torch.empty(kv_cache_shape).stride())
                     strides[inv_order[0]] = page_stride
                     kv_cache = torch.as_strided(
@@ -257,7 +271,7 @@ def _reshape_kv_cache(
                 storage_offset_bytes = 0
                 for shape, dtype in zip(kv_cache_spec.shapes, kv_cache_spec.dtypes):
                     dtype_size = get_dtype_size(dtype)
-                    num_element_per_page = kv_cache_spec.page_size_bytes // dtype_size
+                    num_element_per_page = block_layout_page_size // dtype_size
                     target_shape = (num_blocks, *shape)
                     stride = torch.empty(target_shape).stride()
                     target_stride = (num_element_per_page, *stride[1:])

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -149,6 +149,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheSpec,
     MambaSpec,
+    MemoryModel,
     SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
 )
@@ -199,6 +200,7 @@ from vllm.v1.worker.cp_utils import (
 )
 from vllm.v1.worker.dp_utils import coordinate_batch_across_dp
 from vllm.v1.worker.ec_connector_model_runner_mixin import ECConnectorModelRunnerMixin
+from vllm.v1.worker.gpu.attn_utils import get_block_layout_page_size_bytes
 from vllm.v1.worker.gpu.pool.late_interaction_runner import LateInteractionRunner
 from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.gpu_ubatch_wrapper import UBatchWrapper
@@ -7048,9 +7050,15 @@ class GPUModelRunner(
                 if layer_name in self.runner_only_attn_layers:
                     continue
                 raw_tensor = kv_cache_raw_tensors[layer_name]
-                assert raw_tensor.numel() % kv_cache_spec.page_size_bytes == 0
-                num_blocks = raw_tensor.numel() // kv_cache_spec.page_size_bytes
+                block_layout_page_size = get_block_layout_page_size_bytes(kv_cache_spec)
+                assert raw_tensor.numel() % block_layout_page_size == 0
+                num_blocks = raw_tensor.numel() // block_layout_page_size
                 if isinstance(kv_cache_spec, AttentionSpec):
+                    if kv_cache_spec.memory_model == MemoryModel.REQUEST_CONSTANT:
+                        raise NotImplementedError(
+                            "REQUEST_CONSTANT AttentionSpec is not supported. "
+                            "Attention KV cache is token-proportional."
+                        )
                     has_attn = True
                     num_blocks_per_kv_block = (
                         kv_cache_spec.block_size // kernel_block_size
@@ -7101,7 +7109,7 @@ class GPUModelRunner(
                         # standard attention backends whose shape starts with
                         # a K/V dimension of size 2.
                         dtype_size = get_dtype_size(dtype)
-                        page_stride = kv_cache_spec.page_size_bytes // dtype_size
+                        page_stride = block_layout_page_size // dtype_size
                         strides = list(torch.empty(kv_cache_shape).stride())
                         strides[inv_order[0]] = page_stride
                         kv_cache = torch.as_strided(
@@ -7121,9 +7129,7 @@ class GPUModelRunner(
                     storage_offset_bytes = 0
                     for shape, dtype in zip(kv_cache_spec.shapes, kv_cache_spec.dtypes):
                         dtype_size = get_dtype_size(dtype)
-                        num_element_per_page = (
-                            kv_cache_spec.page_size_bytes // dtype_size
-                        )
+                        num_element_per_page = block_layout_page_size // dtype_size
                         target_shape = (num_blocks, *shape)
                         stride = torch.empty(target_shape).stride()
                         target_stride = (num_element_per_page, *stride[1:])

--- a/vllm/v1/worker/kv_connector_model_runner_mixin.py
+++ b/vllm/v1/worker/kv_connector_model_runner_mixin.py
@@ -17,11 +17,12 @@ from vllm.distributed.kv_transfer.kv_connector.base import KVConnectorBase
 from vllm.forward_context import get_forward_context, set_forward_context
 from vllm.logger import init_logger
 from vllm.v1.attention.backend import AttentionBackend
-from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheConfig
+from vllm.v1.kv_cache_interface import AttentionSpec, KVCacheConfig, MemoryModel
 from vllm.v1.outputs import (
     KVConnectorOutput,
     ModelRunnerOutput,
 )
+from vllm.v1.worker.gpu.attn_utils import get_block_layout_page_size_bytes
 from vllm.v1.worker.utils import AttentionGroup
 
 if TYPE_CHECKING:
@@ -212,6 +213,15 @@ class KVConnectorModelRunnerMixin:
         attn_group = attn_groups[0][0]
         kv_cache_spec = attn_group.kv_cache_spec
         assert isinstance(kv_cache_spec, AttentionSpec)
+        if any(
+            group.kv_cache_spec.memory_model == MemoryModel.REQUEST_CONSTANT
+            for groups in attn_groups
+            for group in groups
+        ):
+            raise NotImplementedError(
+                "Cross-layer KV connector does not support REQUEST_CONSTANT "
+                "specs. Multi-pool connector support is out of scope."
+            )
 
         tensor_sizes = set(
             kv_cache_tensor.size for kv_cache_tensor in kv_cache_config.kv_cache_tensors
@@ -219,7 +229,7 @@ class KVConnectorModelRunnerMixin:
         assert len(tensor_sizes) == 1
         tensor_size = tensor_sizes.pop()
 
-        page_size = kv_cache_spec.page_size_bytes
+        page_size = get_block_layout_page_size_bytes(kv_cache_spec)
         assert tensor_size % page_size == 0
         num_blocks = tensor_size // page_size
         num_layers = len(kv_cache_config.kv_cache_tensors)


### PR DESCRIPTION
## Purpose

Hybrid models like Qwen3.5/3.6 mix attention KV (grows with sequence length) with fixed-size state cache (Mamba/GDN/linear-attention). This PR separates their accounting so that reported token KV capacity is accurate.

Without this, request-constant state is counted as token KV, inflating the reported capacity and potentially causing OOM at high `max_num_seqs`.

## Summary

This PR adds explicit memory model metadata for KV cache specs:

- `TOKEN_PROPORTIONAL`: normal attention KV, grows with sequence length
- `REQUEST_CONSTANT`: fixed-size state, allocated per request

Request-constant specs use a compact allocation-only pool. Token KV capacity is reported from the token-proportional pool only.

## What changed

- Add `MemoryModel` to `KVCacheSpec`.
- Add compact block pool for request-constant KV cache specs.
- Add per-pool accounting in KV cache coordinator / manager.
- Keep the legacy single-pool path for attention-only models.
- Fail closed for unsupported combinations such as prefix caching, CPU KV offload, and KV connector with request-constant pools.

## Scope

This PR does not change token-proportional attention KV allocation behavior for normal attention-only models.

Unsupported integrations are intentionally rejected instead of silently sharing the wrong pool type.

## Duplicate check

I checked related open PRs and did not find another PR that separates token-proportional KV blocks from request-constant state with scheduler/coordinator accounting.

## Test plan

Targeted tests:

```bash
pytest tests/v1/core/test_kv_cache_utils.py -q
pytest tests/v1/core/test_block_pool.py -q
pytest tests/v1/core/test_kv_cache_coordinator.py -q
pytest tests/v1/core/test_kv_cache_invariants.py -q
pytest tests/v1/core/test_prefix_caching.py -q
pytest tests/v1/core/test_single_type_kv_cache_manager.py -q
pytest tests/v1/simple_kv_offload/test_scheduler.py -q
```

Additional checks for the connector/scheduler integration:

```bash
pytest tests/v1/core/test_scheduler.py -q -k 'kv_connector or connector'
pytest tests/v1/core/test_kv_cache_coordinator.py tests/v1/core/test_kv_cache_utils.py -q
pre-commit run mypy-3.10 --all-files --hook-stage manual
pre-commit run ruff-check --files vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py
pre-commit run ruff-format --files vllm/v1/core/sched/scheduler.py tests/v1/core/test_scheduler.py
```

## Test result

- KV cache targeted suite: `210 passed, 16 warnings`
- Connector scheduler regression: `39 passed, 64 deselected`
- Simple KV offload scheduler: `16 passed`
- KV cache coordinator + utils regression: `90 passed`
- `ruff-check`, `ruff-format`, and `mypy-3.10`: passed

AI assistance: Codex, Claude, Gemini.