### PR TITLE
[Misc] Fix typos and grammar in speculative decoding and KV cache com…

### DIFF
--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -29,7 +29,7 @@ class KVCacheBlocks:
     blocks: tuple[Sequence[KVCacheBlock], ...]
     """
     `blocks[i][j]` refers to the i-th kv_cache_group
-    and the j-th block of tokens.We don't use block of
+    and the j-th block of tokens. We don't use block of
     tokens as the outer dimension because it assumes all
     kv_cache_groups have the same number of blocks, which is true for now but
     will be broken if we want to give different block_size to different
@@ -282,7 +282,7 @@ class KVCacheManager:
         ----------------------------------------------------------------------
         ```
 
-        Abbrivations:
+        Abbreviations:
 
         ```
         comp      = request.num_computed_tokens

--- a/vllm/v1/spec_decode/ngram_proposer.py
+++ b/vllm/v1/spec_decode/ngram_proposer.py
@@ -19,8 +19,8 @@ class NgramProposer:
         self.min_n = vllm_config.speculative_config.prompt_lookup_min
         # Maximum length of the n-gram to match.
         self.max_n = vllm_config.speculative_config.prompt_lookup_max
-        # Number of tokens follow the match. If there are less than k
-        # tokens follow the match, we will return the maximum amount of
+        # Number of tokens following the match. If there are fewer than k
+        # tokens following the match, we will return the maximum amount of
         # tokens until the end.
         self.k = vllm_config.speculative_config.num_speculative_tokens
         # Maximum length of the model.
@@ -209,7 +209,7 @@ def _find_longest_matched_ngram_and_propose_tokens(
 
     If found, we will extract k right after the matched ngram.
     """
-    # Do not generate draft tokens is context is shorter than minimum n-gram
+    # Do not generate draft tokens if context is shorter than minimum n-gram
     total_token = origin_tokens.shape[0]
     if total_token < min_ngram:
         return np.empty((0,), dtype=origin_tokens.dtype)


### PR DESCRIPTION
## Purpose

Fix several minor typos and grammar issues in comments and docstrings within the V1 speculative decoding and KV cache manager modules.

### Changes

**`vllm/v1/spec_decode/ngram_proposer.py`**
- Fix grammar: `"tokens follow"` → `"tokens following"` (line 22-23)
- Fix grammar: `"less than k"` → `"fewer than k"` (countable noun, line 22)
- Fix typo: `"Do not generate draft tokens is context is"` → `"Do not generate draft tokens if context is"` (line 212)

**`vllm/v1/core/kv_cache_manager.py`**
- Fix formatting: `"tokens.We"` → `"tokens. We"` (missing space after period, line 32)
- Fix typo: `"Abbrivations"` → `"Abbreviations"` (line 285)

These are comment-only changes with **zero impact on runtime behavior**.

## Test Plan

No tests required — changes are limited to comments and docstrings with no functional code modifications.

## Test Result

N/A (no code logic changed)

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
