### PR TITLE
Revert "Re-enable allreduce rms fusion for DP / PP" (#41458)

### DIFF
--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -136,6 +136,12 @@ def enable_allreduce_rms_fusion(cfg: "VllmConfig") -> bool:
             current_platform.is_device_capability_family(100)
             or current_platform.is_device_capability(90)
         )
+        # tp-dp combination broken:
+        # https://github.com/vllm-project/vllm/issues/34458
+        and cfg.parallel_config.data_parallel_size == 1
+        # tp-pp combination broken:
+        # https://github.com/vllm-project/vllm/issues/35426
+        and cfg.parallel_config.pipeline_parallel_size == 1
     )
 
 


### PR DESCRIPTION
## Revert of #41458

This reverts the merge commit 5737770c6c346d918fdfb13e9378f9514f616186 from PR https://github.com/vllm-project/vllm/pull/41458.

**Reason:** This PR is linked to 1 new CI failure in build [#64141](https://buildkite.com/vllm/ci/builds/64141):
- Sequence Parallel Correctness Tests (2xH100)

The PR re-enabled allreduce rms fusion for DP/PP, which affects the compile/fusion pipeline used by sequence parallelism. The failing test `test_tp_sp_generation` uses ray backend with inductor graph partitioning and fusion.

---
*Auto-generated by CI failure analyzer*