### PR TITLE
[Bugfix][Gemma 4] Allow loading fine-tuned E2B/E4B checkpoints

### DIFF
--- a/vllm/model_executor/models/gemma4.py
+++ b/vllm/model_executor/models/gemma4.py
@@ -1497,6 +1497,14 @@ class Gemma4Model(nn.Module, EagleModelMixin):
                     weight_loader(param, loaded_weight)
             loaded_params.add(name)
 
+        # KV-shared layers (last `num_kv_shared_layers` in Gemma 4 E2B/E4B)
+        # never run k_norm in forward; mark their k_norm.weight as loaded so
+        # fine-tuned checkpoints (which omit the unused tensor) don't trip the
+        # default_loader missing-weights check.
+        for i in range(self.start_layer, self.end_layer):
+            if getattr(self.layers[i].self_attn, "is_kv_shared_layer", False):
+                loaded_params.add(f"layers.{i}.self_attn.k_norm.weight")
+
         return loaded_params
 
 


### PR DESCRIPTION
## Summary

Fine-tuned Gemma 4 E2B/E4B checkpoints saved by HF transformers'
`save_pretrained` omit `k_norm.weight` for KV-shared layers (the last
`num_kv_shared_layers` layers reuse K/V from earlier layers and never run
`k_norm` in forward, so transformers prunes the unused parameter).
vLLM's `default_loader` then raises a `Following weights were not
initialized from checkpoint` error.

Original Google E2B/E4B checkpoints happen to ship redundant `k_norm`
tensors for shared layers, which is why the issue only surfaces after
fine-tuning.

## Reproduction

```python
# Fine-tune Gemma 4 E4B with HF Trainer / axolotl / TRL (any tool that
# uses transformers' save_pretrained), then load with vLLM:
from vllm import LLM
LLM(model="path/to/finetuned-gemma-4-e4b")
```

Fails with:

```
ValueError: Following weights were not initialized from checkpoint:
{'language_model.model.layers.41.self_attn.k_norm.weight',
 'language_model.model.layers.40.self_attn.k_norm.weight',
 ... (one entry per KV-shared layer)}
```

## Root cause

- `transformers/models/gemma4/modeling_gemma4.py` only creates `k_norm`
  on non-KV-shared layers (`if not self.is_kv_shared_layer:`), and registers
  the unused keys in `_keys_to_ignore_on_load_unexpected`.
- vLLM's `Gemma4Attention.__init__` creates `k_norm` unconditionally on
  every layer. Forward correctly skips them on shared layers via the
  `if not self.is_kv_shared_layer` guard, so behavior is correct — but
  the always-present params still need to be loaded.
- Original Google checkpoints ship redundant `k_norm` tensors for shared
  layers and load fine. After fine-tuning, `save_pretrained` drops the
  pruned parameters, so vLLM's `default_loader` finds 18 (E4B) or 20 (E2B)
  unloaded `k_norm.weight` params and raises.

## Fix

In `Gemma4Model.load_weights`, after the iteration over checkpoint
weights, mark KV-shared layers' `k_norm.weight` as loaded so the
`default_loader` missing-weights check ignores them. This mirrors how
the same check already tolerates online quantization scales
(default_loader.py:414-425).

```python
# Gemma4Model.load_weights, just before `return loaded_params`:
for i in range(self.start_layer, self.end_layer):
    if getattr(self.layers[i].self_attn, "is_kv_shared_layer", False):
        loaded_params.add(f"layers.{i}.self_attn.k_norm.weight")
```

### Why this approach over modifying `__init__`

- `Gemma4Attention` module topology is identical to `main`; no
  architectural change.
- Original Google checkpoints' redundant `k_norm` tensors continue to
  load into the always-existing params and remain no-ops in forward
  (the `is_kv_shared_layer` guard already prevents their use).
- Pipeline-parallel safe: iterates only `[start_layer, end_layer)`.
- 8 added lines, zero deletions.

## Affected models

| Model              | `num_kv_shared_layers` | Affected by bug? |
| ------------------ | ---------------------- | ---------------- |
| Gemma 4 26B-A4B-it | 0                      | No               |
| Gemma 4 31B-it     | 0                      | No               |
| Gemma 4 E2B-it     | 20                     | **Yes**          |
| Gemma 4 E4B-it     | 18                     | **Yes**          |

For models with `num_kv_shared_layers == 0`, no layer has
`is_kv_shared_layer = True`, so the new loop is a no-op — behavior is
identical.

## Test plan

- [x] Load original `google/gemma-4-e4b-it` (Gemma4ForConditionalGeneration)
      — still loads identically to `main`.
- [x] Load a fine-tuned Gemma 4 E4B checkpoint
      (Gemma4ForCausalLM, 42 layers, `num_kv_shared_layers=18`)
      saved by HF transformers — previously failed, now succeeds.
- [x] Smoke generation on Gemma 4 26B-A4B / 31B — `num_kv_shared_layers=0`
      so no behavior change expected.