### PR TITLE
[Feature] TRITON_ATTN add INT8 per-tensor KV cache quantization

### DIFF
--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -179,7 +179,7 @@ Priority is **1 = highest** (tried first).
 | `ROCM_AITER_UNIFIED_ATTN` | | fp16, bf16 | `auto` | %16 | Any | ✅ | ✅ | ❌ | All | N/A |
 | `ROCM_ATTN` | | fp16, bf16, fp32 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2` | %16 | 32, 64, 80, 96, 128, 160, 192, 224, 256 | ❌ | ✅ | ❌ | Decoder, Encoder, Encoder Only | N/A |
 | `TREE_ATTN` | | fp16, bf16 | `auto`, `float16`, `bfloat16` | %16 | 32, 64, 96, 128, 160, 192, 224, 256 | ❌ | ❌ | ❌ | Decoder | Any |
-| `TRITON_ATTN` | | fp16, bf16, fp32 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2`, `int8_per_token_head`, `fp8_per_token_head` | %16 | Any | ✅ | ✅ | ❌ | All | Any |
+| `TRITON_ATTN` | | fp16, bf16, fp32 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3`, `fp8_e5m2`, `int8_per_tensor`, `int8_per_token_head`, `fp8_per_token_head` | %16 | Any | ✅ | ✅ | ❌ | All | Any |
 | `TURBOQUANT` | | fp16, bf16 | `turboquant_k8v4`, `turboquant_4bit_nc`, `turboquant_k3v4_nc`, `turboquant_3bit_nc` | 16, 32, 64, 128 | Any | ❌ | ❌ | ❌ | Decoder | Any |
 
 > **†** FlashInfer uses TRTLLM attention on Blackwell (SM100), which supports sinks. Disable via `--attention-config.use_trtllm_attention=0`.

--- a/tests/v1/attention/test_int8_per_tensor_kvcache.py
+++ b/tests/v1/attention/test_int8_per_tensor_kvcache.py
@@ -1,0 +1,322 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for INT8 per-tensor KV cache quantization."""
+
+import pytest
+import torch
+
+from vllm.platforms import current_platform
+from vllm.utils.math_utils import next_power_of_2
+from vllm.utils.torch_utils import set_random_seed
+from vllm.v1.attention.ops.triton_unified_attention import unified_attention
+from vllm.v1.kv_cache_interface import KVQuantMode, get_kv_quant_mode
+
+DEVICE_TYPE = current_platform.device_type
+
+NUM_HEADS = [(4, 4), (8, 2)]
+HEAD_SIZES = [64, 128]
+BLOCK_SIZES = [16]
+SEQ_THRESHOLD_3D_VALUES = [0, 8]
+
+
+def ref_paged_attn(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    query_lens: list[int],
+    kv_lens: list[int],
+    block_tables: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Reference paged attention in pure PyTorch."""
+    num_seqs = len(query_lens)
+    block_tables = block_tables.cpu().numpy()
+    _, block_size, num_kv_heads, head_size = key_cache.shape
+
+    outputs: list[torch.Tensor] = []
+    start_idx = 0
+    for i in range(num_seqs):
+        query_len = query_lens[i]
+        kv_len = kv_lens[i]
+        q = query[start_idx : start_idx + query_len]
+        q = q * scale
+
+        num_kv_blocks = (kv_len + block_size - 1) // block_size
+        block_indices = block_tables[i, :num_kv_blocks]
+
+        k = key_cache[block_indices].view(-1, num_kv_heads, head_size)[:kv_len]
+        v = value_cache[block_indices].view(-1, num_kv_heads, head_size)[:kv_len]
+
+        if q.shape[1] != k.shape[1]:
+            k = torch.repeat_interleave(k, q.shape[1] // k.shape[1], dim=1)
+            v = torch.repeat_interleave(v, q.shape[1] // v.shape[1], dim=1)
+
+        attn = torch.einsum("qhd,khd->hqk", q, k).float()
+        mask = torch.triu(
+            torch.ones(query_len, kv_len), diagonal=kv_len - query_len + 1
+        ).bool()
+        attn.masked_fill_(mask, float("-inf"))
+        attn = torch.softmax(attn, dim=-1).to(v.dtype)
+        out = torch.einsum("hqk,khd->qhd", attn, v)
+        outputs.append(out)
+        start_idx += query_len
+
+    return torch.cat(outputs, dim=0)
+
+
+class TestKVQuantModeMapping:
+    def test_int8_per_tensor_mapping(self):
+        mode = get_kv_quant_mode("int8_per_tensor")
+        assert mode == KVQuantMode.INT8_PER_TENSOR
+        assert mode.value == 5
+
+    def test_int8_per_tensor_not_per_token_head(self):
+        mode = get_kv_quant_mode("int8_per_tensor")
+        assert not mode.is_per_token_head
+
+    def test_int8_per_tensor_value(self):
+        assert KVQuantMode.INT8_PER_TENSOR.value == 5
+
+
+class TestInt8ReshapeAndCache:
+    @pytest.mark.parametrize("head_size", HEAD_SIZES)
+    @pytest.mark.parametrize("num_heads", [4, 8])
+    @torch.inference_mode()
+    def test_quantize_dequantize_roundtrip(self, head_size, num_heads):
+        """Verify quantize -> dequantize error is within 1 LSB."""
+        from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
+            triton_reshape_and_cache_flash,
+        )
+
+        torch.set_default_device(DEVICE_TYPE)
+        set_random_seed(0)
+
+        num_tokens = 16
+        block_size = 16
+        num_blocks = 4
+
+        key = torch.randn(num_tokens, num_heads, head_size, dtype=torch.float16) * 2.0
+        value = torch.randn(num_tokens, num_heads, head_size, dtype=torch.float16) * 2.0
+
+        key_cache = torch.zeros(
+            num_blocks, block_size, num_heads, head_size, dtype=torch.int8
+        )
+        value_cache = torch.zeros(
+            num_blocks, block_size, num_heads, head_size, dtype=torch.int8
+        )
+
+        k_scale_val = key.abs().max().float() / 127.0
+        v_scale_val = value.abs().max().float() / 127.0
+        k_scale = torch.tensor([k_scale_val], dtype=torch.float32)
+        v_scale = torch.tensor([v_scale_val], dtype=torch.float32)
+
+        slot_mapping = torch.arange(num_tokens, dtype=torch.long)
+
+        triton_reshape_and_cache_flash(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            "int8_per_tensor",
+            k_scale,
+            v_scale,
+        )
+
+        # Dequantize and check error
+        key_dequant = key_cache[:1, :num_tokens].float() * k_scale_val
+        value_dequant = value_cache[:1, :num_tokens].float() * v_scale_val
+
+        key_err = (key_dequant - key.float()).abs().max()
+        value_err = (value_dequant - value.float()).abs().max()
+
+        # Max error <= 0.5 * scale (half a quantization step)
+        assert key_err <= k_scale_val * 0.6, (
+            f"Key error {key_err:.6f} > threshold {k_scale_val * 0.6:.6f}"
+        )
+        assert value_err <= v_scale_val * 0.6, (
+            f"Value error {value_err:.6f} > threshold {v_scale_val * 0.6:.6f}"
+        )
+
+    @torch.inference_mode()
+    def test_scale_one_lossless(self):
+        """With scale=1.0 and integer values in [-127,127], quant is lossless."""
+        from vllm.v1.attention.ops.triton_reshape_and_cache_flash import (
+            triton_reshape_and_cache_flash,
+        )
+
+        torch.set_default_device(DEVICE_TYPE)
+
+        num_tokens, num_heads, head_size = 8, 4, 64
+        block_size, num_blocks = 16, 2
+
+        key = torch.randint(
+            -50, 50, (num_tokens, num_heads, head_size), dtype=torch.float16
+        )
+        value = torch.randint(
+            -50, 50, (num_tokens, num_heads, head_size), dtype=torch.float16
+        )
+
+        key_cache = torch.zeros(
+            num_blocks, block_size, num_heads, head_size, dtype=torch.int8
+        )
+        value_cache = torch.zeros(
+            num_blocks, block_size, num_heads, head_size, dtype=torch.int8
+        )
+
+        k_scale = torch.tensor([1.0], dtype=torch.float32)
+        v_scale = torch.tensor([1.0], dtype=torch.float32)
+        slot_mapping = torch.arange(num_tokens, dtype=torch.long)
+
+        triton_reshape_and_cache_flash(
+            key,
+            value,
+            key_cache,
+            value_cache,
+            slot_mapping,
+            "int8_per_tensor",
+            k_scale,
+            v_scale,
+        )
+
+        key_back = key_cache[0, :num_tokens].to(torch.float16)
+        assert torch.equal(key_back, key), (
+            "INT8 with scale=1.0 should be lossless for integer values"
+        )
+
+
+@pytest.mark.parametrize("seq_lens", [[(1, 1328), (5, 18)], [(1, 523), (1, 2011)]])
+@pytest.mark.parametrize("num_heads", NUM_HEADS)
+@pytest.mark.parametrize("head_size", HEAD_SIZES)
+@pytest.mark.parametrize("block_size", BLOCK_SIZES)
+@pytest.mark.parametrize("seq_threshold_3D", SEQ_THRESHOLD_3D_VALUES)
+@torch.inference_mode()
+def test_int8_per_tensor_attention(
+    seq_lens: list[tuple[int, int]],
+    num_heads: tuple[int, int],
+    head_size: int,
+    block_size: int,
+    seq_threshold_3D: int,
+) -> None:
+    """Test INT8 per-tensor attention against reference implementation.
+
+    Follows the same pattern as test_triton_unified_attn for FP8.
+    """
+    torch.set_default_device(DEVICE_TYPE)
+    set_random_seed(0)
+
+    num_seqs = len(seq_lens)
+    query_lens = [x[0] for x in seq_lens]
+    kv_lens = [x[1] for x in seq_lens]
+    num_query_heads = num_heads[0]
+    num_kv_heads = num_heads[1]
+    assert num_query_heads % num_kv_heads == 0
+    max_query_len = max(query_lens)
+    max_kv_len = max(kv_lens)
+    scale = head_size**-0.5
+    num_blocks = 32768
+
+    # Generate FP16 reference data
+    query = torch.randn(
+        sum(query_lens), num_query_heads, head_size, dtype=torch.bfloat16
+    )
+    key_cache_fp16 = torch.randn(
+        num_blocks, block_size, num_kv_heads, head_size, dtype=torch.bfloat16
+    )
+    value_cache_fp16 = torch.randn_like(key_cache_fp16)
+
+    # Quantize KV cache to INT8 with proper scaling
+    k_scale_val = key_cache_fp16.abs().max().float().item() / 127.0
+    v_scale_val = value_cache_fp16.abs().max().float().item() / 127.0
+
+    key_cache_int8 = torch.clamp(
+        torch.round(key_cache_fp16.float() / k_scale_val), -128, 127
+    ).to(torch.int8)
+    value_cache_int8 = torch.clamp(
+        torch.round(value_cache_fp16.float() / v_scale_val), -128, 127
+    ).to(torch.int8)
+
+    # Dequantized version for reference (what INT8 effectively represents)
+    key_cache_dequant = key_cache_int8.to(torch.bfloat16) * k_scale_val
+    value_cache_dequant = value_cache_int8.to(torch.bfloat16) * v_scale_val
+
+    k_descale = torch.full((num_seqs, num_kv_heads), k_scale_val, dtype=torch.float32)
+    v_descale = torch.full((num_seqs, num_kv_heads), v_scale_val, dtype=torch.float32)
+
+    cu_query_lens = torch.tensor([0] + query_lens, dtype=torch.int32).cumsum(
+        dim=0, dtype=torch.int32
+    )
+    kv_lens_tensor = torch.tensor(kv_lens, dtype=torch.int32)
+
+    max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
+    block_tables = torch.randint(
+        0, num_blocks, (num_seqs, max_num_blocks_per_seq), dtype=torch.int32
+    )
+
+    # Buffers for 3D kernel
+    num_par_softmax_segments = 16
+    head_size_padded = next_power_of_2(head_size)
+    softmax_segm_output = torch.empty(
+        (seq_threshold_3D, num_query_heads, num_par_softmax_segments, head_size_padded),
+        dtype=torch.float32,
+    )
+    softmax_segm_max = torch.empty(
+        (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+        dtype=torch.float32,
+    )
+    softmax_segm_expsum = torch.empty(
+        (seq_threshold_3D, num_query_heads, num_par_softmax_segments),
+        dtype=torch.float32,
+    )
+
+    # Run INT8 attention via Triton kernel
+    output_int8 = torch.empty_like(query)
+    unified_attention(
+        q=query,
+        k=key_cache_int8,
+        v=value_cache_int8,
+        out=output_int8,
+        cu_seqlens_q=cu_query_lens,
+        seqused_k=kv_lens_tensor,
+        max_seqlen_q=max_query_len,
+        max_seqlen_k=max_kv_len,
+        softmax_scale=scale,
+        causal=True,
+        window_size=(-1, -1),
+        block_table=block_tables,
+        softcap=0,
+        q_descale=None,
+        k_descale=k_descale,
+        v_descale=v_descale,
+        seq_threshold_3D=seq_threshold_3D,
+        num_par_softmax_segments=num_par_softmax_segments,
+        softmax_segm_output=softmax_segm_output,
+        softmax_segm_max=softmax_segm_max,
+        softmax_segm_expsum=softmax_segm_expsum,
+        kv_quant_mode=KVQuantMode.INT8_PER_TENSOR,
+    )
+
+    # Reference: run attention on the dequantized cache (pure PyTorch)
+    ref_output = ref_paged_attn(
+        query=query,
+        key_cache=key_cache_dequant,
+        value_cache=value_cache_dequant,
+        query_lens=query_lens,
+        kv_lens=kv_lens,
+        block_tables=block_tables,
+        scale=scale,
+    )
+
+    # Tolerance: INT8 quantization introduces rounding error that propagates
+    # through softmax. Use same tolerance as FP8 test.
+    atol, rtol = 1.5e-1, 1.5e-1
+    torch.testing.assert_close(output_int8, ref_output, atol=atol, rtol=rtol)
+
+
+class TestTritonAttentionBackend:
+    def test_int8_per_tensor_in_supported_dtypes(self):
+        from vllm.v1.attention.backends.triton_attn import (
+            TritonAttentionBackend,
+        )
+
+        assert "int8_per_tensor" in TritonAttentionBackend.supported_kv_cache_dtypes

--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -28,6 +28,7 @@ CacheDType = Literal[
     "turboquant_4bit_nc",
     "turboquant_k3v4_nc",
     "turboquant_3bit_nc",
+    "int8_per_tensor",
     "int8_per_token_head",
     "fp8_per_token_head",
     "nvfp4",
@@ -256,6 +257,13 @@ class CacheConfig:
                 "memory footprint and boosts the performance. "
                 "Dynamic per-token-head scales will be computed at runtime.",
                 str(cache_dtype),
+            )
+        elif cache_dtype == "int8_per_tensor":
+            logger.info(
+                "Using int8_per_tensor data type to store kv cache. "
+                "It reduces the GPU memory footprint and boosts the "
+                "performance. Meanwhile, it may cause accuracy drop "
+                "without a proper scaling factor",
             )
         elif is_quantized_kv_cache(cache_dtype):
             logger.info(

--- a/vllm/utils/torch_utils.py
+++ b/vllm/utils/torch_utils.py
@@ -38,6 +38,7 @@ STR_DTYPE_TO_TORCH_DTYPE = {
     "fp8_e4m3": torch.uint8,
     "fp8_e5m2": torch.uint8,
     "int8": torch.int8,
+    "int8_per_tensor": torch.int8,
     "int8_per_token_head": torch.int8,
     "fp8_per_token_head": torch.uint8,
     "fp8_inc": torch.float8_e4m3fn,
@@ -70,6 +71,7 @@ T = TypeVar("T")
 def is_quantized_kv_cache(kv_cache_dtype: str) -> bool:
     return (
         kv_cache_dtype.startswith("fp8")
+        or kv_cache_dtype.startswith("int8")
         or kv_cache_dtype.endswith("per_token_head")
         or kv_cache_dtype == "nvfp4"
     )

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -276,6 +276,7 @@ class TritonAttentionBackend(AttentionBackend):
         "fp8",
         "fp8_e4m3",
         "fp8_e5m2",
+        "int8_per_tensor",
         "int8_per_token_head",
         "fp8_per_token_head",
     ]
@@ -574,10 +575,13 @@ class TritonAttentionImpl(AttentionImpl):
             v_descale = None
             k_scale_cache = self._k_scale_cache
             v_scale_cache = self._v_scale_cache
-        # FP8 per-tensor / auto path (original flow).
+        # FP8 per-tensor / INT8 per-tensor / auto path (original flow).
         else:
             key_cache, value_cache = kv_cache.unbind(1)
-            if is_quantized_kv_cache(self.kv_cache_dtype):
+            if (
+                is_quantized_kv_cache(self.kv_cache_dtype)
+                and self.kv_cache_dtype != "int8_per_tensor"
+            ):
                 if key_cache.dtype != self.fp8_dtype:
                     key_cache = key_cache.view(self.fp8_dtype)
                     value_cache = value_cache.view(self.fp8_dtype)
@@ -719,7 +723,10 @@ class TritonAttentionImpl(AttentionImpl):
             return
         # For decoder and cross-attention, use KV cache as before.
         key_cache, value_cache = kv_cache.unbind(1)
-        if is_quantized_kv_cache(self.kv_cache_dtype):
+        if (
+            is_quantized_kv_cache(self.kv_cache_dtype)
+            and self.kv_cache_dtype != "int8_per_tensor"
+        ):
             key_cache = key_cache.view(self.fp8_dtype)
             value_cache = value_cache.view(self.fp8_dtype)
         triton_reshape_and_cache_flash(

--- a/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
+++ b/vllm/v1/attention/ops/triton_reshape_and_cache_flash.py
@@ -38,6 +38,11 @@ def reshape_and_cache_kernel_flash(
     USE_HEAD_MAJOR_LAYOUT: tl.constexpr,
     # FP8 flags
     FP8_KV_CACHE: tl.constexpr,
+    # INT8 per-tensor flag
+    INT8_KV_CACHE: tl.constexpr,
+    # Platform
+    IS_ROCM: tl.constexpr,
+    IS_CUDA: tl.constexpr,
     # tune parameters
     TILE_SIZE: tl.constexpr,
 ):
@@ -90,7 +95,18 @@ def reshape_and_cache_kernel_flash(
     key_load = tl.load(
         key_ptr + src_key_idx + tile_pos, mask=tile_pos < (num_heads * head_size)
     )
-    if FP8_KV_CACHE:
+    if INT8_KV_CACHE:
+        # INT8 per-tensor: quantize to [-128, 127]
+        k_scale_val = tl.load(k_scale)
+        k_scaled = key_load.to(tl.float32) / k_scale_val
+        if IS_ROCM:
+            k_rounded = tl.extra.hip.libdevice.nearbyint(k_scaled)
+        elif IS_CUDA:
+            k_rounded = tl.extra.cuda.libdevice.rint(k_scaled)
+        else:
+            k_rounded = tl.floor(k_scaled + 0.5)
+        key_tile = tl.clamp(k_rounded, -128.0, 127.0).to(tl.int8)
+    elif FP8_KV_CACHE:
         # tl.store will do the correct implicit cast to fp8,
         # based on the key_cache_ptr.dtype.element_ty
         key_tile = key_load if key_load.dtype.is_fp8() else key_load / tl.load(k_scale)
@@ -101,7 +117,18 @@ def reshape_and_cache_kernel_flash(
     value_load = tl.load(
         value_ptr + src_value_idx + tile_pos, mask=tile_pos < (num_heads * head_size)
     )
-    if FP8_KV_CACHE:
+    if INT8_KV_CACHE:
+        # INT8 per-tensor: quantize to [-128, 127]
+        v_scale_val = tl.load(v_scale)
+        v_scaled = value_load.to(tl.float32) / v_scale_val
+        if IS_ROCM:
+            v_rounded = tl.extra.hip.libdevice.nearbyint(v_scaled)
+        elif IS_CUDA:
+            v_rounded = tl.extra.cuda.libdevice.rint(v_scaled)
+        else:
+            v_rounded = tl.floor(v_scaled + 0.5)
+        value_tile = tl.clamp(v_rounded, -128.0, 127.0).to(tl.int8)
+    elif FP8_KV_CACHE:
         if value_load.dtype.is_fp8():
             value_tile = value_load
         else:
@@ -353,25 +380,28 @@ def triton_reshape_and_cache_flash(
     assert kv_cache_dtype == "auto" or is_quantized_kv_cache(kv_cache_dtype), (
         f"unsupported kv_cache_dtype (str), got {kv_cache_dtype}."
     )
-    kv_cache_torch_dtype = (
-        current_platform.fp8_dtype()
-        if is_quantized_kv_cache(kv_cache_dtype)
-        else key_cache.dtype
-    )
+    is_int8_per_tensor = kv_cache_dtype == "int8_per_tensor"
+    is_int8 = kv_cache_dtype.startswith("int8")
+    if is_int8:
+        kv_cache_torch_dtype = torch.int8
+    elif is_quantized_kv_cache(kv_cache_dtype):
+        kv_cache_torch_dtype = current_platform.fp8_dtype()
+    else:
+        kv_cache_torch_dtype = key_cache.dtype
 
-    if key_cache.dtype != kv_cache_torch_dtype and is_quantized_kv_cache(
-        kv_cache_dtype
+    if (
+        not is_int8
+        and key_cache.dtype != kv_cache_torch_dtype
+        and is_quantized_kv_cache(kv_cache_dtype)
     ):
         # to avoid erounous implicit cast in triton kernel (tl.store to uint8)
         # (e.g. explicit cast to fp8e4m3fnuz is not supported in triton 3.4)
         key_cache = key_cache.view(kv_cache_torch_dtype)
         value_cache = value_cache.view(kv_cache_torch_dtype)
-    assert kv_cache_dtype != torch.uint8, (
-        "explicit fp8 cast and store to "
-        "uint8 is not supported by triton reshape_and_cache_flash"
-    )
 
-    FP8_KV_CACHE = is_quantized_kv_cache(kv_cache_dtype)
+    FP8_KV_CACHE = is_quantized_kv_cache(kv_cache_dtype) and not is_int8
+    INT8_KV_CACHE = is_int8_per_tensor
+
     assert (not FP8_KV_CACHE) or kv_cache_torch_dtype in [
         torch.float8_e4m3fn,
         torch.float8_e5m2,
@@ -379,8 +409,8 @@ def triton_reshape_and_cache_flash(
         torch.float8_e4m3fnuz,
     ], (
         "unsupported dtype of KV cache tensor, got "
-        "{kv_cache_torch_dtype}. Supported kv cache dtypes: fp8e4m3fn, "
-        "fp8e5m2, uint8, bfloat16, float16, float32, fp8e4m3fnuz."
+        f"{kv_cache_torch_dtype}. Supported kv cache dtypes: fp8e4m3fn, "
+        "fp8e5m2, uint8, bfloat16, float16, float32, fp8e4m3fnuz, int8."
     )
 
     # heuristics instead of autotuning
@@ -423,6 +453,9 @@ def triton_reshape_and_cache_flash(
         x=x,
         USE_HEAD_MAJOR_LAYOUT=use_head_major_layout,
         FP8_KV_CACHE=FP8_KV_CACHE,
+        INT8_KV_CACHE=INT8_KV_CACHE,
+        IS_ROCM=current_platform.is_rocm(),
+        IS_CUDA=current_platform.is_cuda(),
         # autotune parameters
         TILE_SIZE=TILE_SIZE,
         num_warps=num_warps,

--- a/vllm/v1/attention/ops/triton_unified_attention.py
+++ b/vllm/v1/attention/ops/triton_unified_attention.py
@@ -46,11 +46,16 @@ def _cast_kv_tile(data, Q, tensor_scale, KV_QUANT_MODE: tl.constexpr):
       their scales separately on S/P inside the loop.
     - ``KV_QUANT_MODE == 1`` (FP8 per-tensor): dequantize using the
       tensor-wide scale.
+    - ``KV_QUANT_MODE == 5`` (INT8 per-tensor): plain cast.
+      Scale applied post-matmul via folding into softmax_scale / acc.
     """
     if KV_QUANT_MODE == 1:
         if Q.dtype.is_fp8():
             return data.to(Q.dtype)
         return (data.to(tl.float32) * tl.load(tensor_scale)).to(Q.dtype)
+    if KV_QUANT_MODE == 5:
+        # INT8 per-tensor: plain cast, scale folded into S and acc post-matmul
+        return data.to(Q.dtype)
     return data.to(Q.dtype)
 
 
@@ -131,7 +136,7 @@ def kernel_unified_attention(
     IS_3D: tl.constexpr,
     # KV cache quantization mode handled inside this kernel via constexpr
     # branches: NONE (0), FP8_PER_TENSOR (1), INT8_PER_TOKEN_HEAD (2),
-    # FP8_PER_TOKEN_HEAD (3).
+    # FP8_PER_TOKEN_HEAD (3), INT8_PER_TENSOR (5).
     KV_QUANT_MODE: tl.constexpr = 0,
     FP8_MIN: tl.constexpr = float8_info.min,
     FP8_MAX: tl.constexpr = float8_info.max,
@@ -141,7 +146,9 @@ def kernel_unified_attention(
     CHUNK_LOOKBACK: tl.constexpr = -1,
     CHUNK_SIZE: tl.constexpr = -1,
 ):
-    USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = KV_QUANT_MODE >= 2
+    USE_PER_TOKEN_HEAD_SCALES: tl.constexpr = (KV_QUANT_MODE == 2) or (
+        KV_QUANT_MODE == 3
+    )
 
     q_block_global_idx = tl.program_id(0)
     kv_head_idx = tl.program_id(1)
@@ -227,6 +234,12 @@ def kernel_unified_attention(
         CHUNK_LOOKBACK,
         CHUNK_SIZE,
     )
+
+    # INT8 per-tensor: fold k_scale into softmax scale, apply v_scale post-loop
+    if KV_QUANT_MODE == 5:
+        int8_k_scale_val = tl.load(k_scale)
+        int8_v_scale_val = tl.load(v_scale)
+        scale = scale * int8_k_scale_val
 
     # iterate through tiles (now limited to the sliding window range)
     for j in range(loop_lo, loop_hi):
@@ -338,6 +351,10 @@ def kernel_unified_attention(
             acc += tl.dot(P_v, V)
         else:
             acc += tl.dot(P.to(V.dtype), V)
+
+    # INT8 per-tensor: apply v_scale once on accumulated output
+    if KV_QUANT_MODE == 5:
+        acc = acc * int8_v_scale_val
 
     # ---- Epilogue ---------------------------------------------------------
     if IS_3D:

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -40,6 +40,7 @@ class KVQuantMode(IntEnum):
     INT8_PER_TOKEN_HEAD = 2  # per-token-head dynamic scales for int8
     FP8_PER_TOKEN_HEAD = 3  # per-token-head dynamic scales for fp8
     NVFP4 = 4  # packed fp4 data + fp8 block scales
+    INT8_PER_TENSOR = 5  # per-tensor scales with int8 storage
 
     @property
     def is_per_token_head(self) -> bool:
@@ -61,6 +62,8 @@ def get_kv_quant_mode(kv_cache_dtype: str) -> KVQuantMode:
         return KVQuantMode.INT8_PER_TOKEN_HEAD
     if kv_cache_dtype == "fp8_per_token_head":
         return KVQuantMode.FP8_PER_TOKEN_HEAD
+    if kv_cache_dtype == "int8_per_tensor":
+        return KVQuantMode.INT8_PER_TENSOR
     if kv_cache_dtype == "nvfp4":
         return KVQuantMode.NVFP4
     if isinstance(kv_cache_dtype, str) and kv_cache_dtype.startswith("fp8"):


### PR DESCRIPTION
# Add INT8 per-tensor KV cache quantization

## Summary

- Add `--kv-cache-dtype int8_per_tensor` option for symmetric INT8 KV cache quantization
- Uses native int-to-float hardware conversion (single instruction on all modern GPUs), with scale folded post-matmul for zero overhead in the attention inner loop
- Quantization on cache write uses platform-native round-to-nearest-even (ROCm `nearbyint`, CUDA `rint`, fallback `floor+0.5`)

## Motivation

FP8 per-tensor KV cache relies on software-emulated type conversions on GPUs without native FP8 hardware. This includes AMD RDNA3 (RX 7900 series) and NVIDIA Ampere (A100/A10). INT8 per-tensor avoids this by using native int-to-float conversion, which is a single hardware instruction on all modern GPUs regardless of generation. The scale is folded into the softmax scale (for K) and applied once on the accumulated output (for V), resulting in zero extra arithmetic in the attention inner loop.

## Changes

- `vllm/v1/kv_cache_interface.py`: Add `KVQuantMode.INT8_PER_TENSOR = 5`
- `vllm/v1/attention/ops/triton_unified_attention.py`: Mode 5 dequant (plain cast) + `k_scale` folded into `softmax_scale` + `v_scale` applied once post-loop
- `vllm/v1/attention/ops/triton_reshape_and_cache_flash.py`: INT8 quantization kernel with platform-native RNE rounding
- `vllm/v1/attention/backends/triton_attn.py`: Register dtype, skip fp8 view for int8 cache
- `vllm/config/cache.py`, `vllm/utils/torch_utils.py`: Wire up `int8_per_tensor`

## Benchmarks

**Hardware:** 2× AMD RX 7900 XTX (gfx1100), ROCm 7.2
**Model:** Qwen3.6-27B-GPTQ-W4A16-G32, TP2, `enforce-eager`

### Prefill throughput (attention-bound scaling)

| Context length | FP16 (auto) | INT8 per-tensor | FP8 per-tensor | FP8 penalty      |
| -------------- | ----------- | --------------- | -------------- | ---------------- |
| 2.8K tokens    | 790 tok/s   | 787 tok/s       | 790 tok/s      | ±0% (GEMM-bound) |
| 16K tokens     | 730 tok/s   | 723 tok/s       | 660 tok/s      | -10%             |
| 32K tokens     | 640 tok/s   | 640 tok/s       | 558 tok/s      | -13%             |

The FP8 penalty grows with context length because attention becomes the bottleneck at longer sequences — each KV tile load pays the conversion overhead. INT8 remains at parity with FP16 regardless of context length.

### Decode throughput (single request, 200 tokens)

| FP16       | INT8 per-tensor  |
| ---------- | ---------------- |
| 33.7 tok/s | 32.7 tok/s (-3%) |

### KV cache capacity (same VRAM budget, 0.92 utilization)

| KV dtype | Available KV memory | Max tokens | Context multiplier |
| -------- | ------------------- | ---------- | ------------------ |
| FP16     | 11.34 GiB           | ~157K      | 1×                 |
| INT8     | 11.06 GiB           | ~315K      | 2×                 |

## Quality (greedy decoding, temperature=0)

Tested across code generation, translation, factual QA, and mathematical reasoning prompts. Outputs are byte-identical between INT8 and FP16 for all test cases, confirming lossless quantization when activation values fall within the INT8 range.

## ISA verification (Triton codegen on gfx1100)

Confirmed via `TRITON_CACHE_DIR` dump that Triton compiles `data.to(tl.float16)` on int8 input to:

```asm
v_bfe_i32 v2, v2, 0, 8           ; sign-extend byte
v_cvt_f16_i16_e32 v2, v2         ; native 1-cycle conversion
```

vs FP8 `data.to(tl.float32)` which compiles to ~20 VALU instructions + 3 divergent branches (full software emulation via `__hip_cvt_fp8_to_halfraw`).

## Usage

```bash
vllm serve <model> --kv-cache-dtype int8_per_tensor
```

> **Note:** Requires models with pre-calibrated `k_scale` / `v_scale` values (e.g., GPTQ W4A16 quantized models). Models without calibrated scales default to `scale=1.0`, which works correctly only if KV activation values fall within `[-128, 127]`. For uncalibrated models, use `--kv-cache-dtype auto` instead.