### PR TITLE
fix(lightning_attn): make CBLOCK device-aware to fit Ampere SMEM

### DIFF
--- a/vllm/model_executor/layers/lightning_attn.py
+++ b/vllm/model_executor/layers/lightning_attn.py
@@ -455,7 +455,14 @@ class _attention(torch.autograd.Function):
         E_FBLOCK = e // NUM_FBLOCK
         assert e % NUM_FBLOCK == 0
 
-        CBLOCK = 64
+        # Device-aware CBLOCK: on Ampere (SM 8.x) the 64 KB fp32 kv
+        # accumulator + double-buffered k_trans/v at CBLOCK=64 yields a peak
+        # SMEM of ~131 KB per CTA, exceeding the ~99 KB hardware ceiling on
+        # consumer/prosumer Ampere GPUs (RTX A4000, 4090, A10, etc.) and
+        # causing the kernel to fail to launch with OutOfResources. Halving
+        # CBLOCK to 32 brings the peak to ~96 KB, fits the ceiling, and
+        # leaves Hopper+ unchanged.
+        CBLOCK = 64 if capability[0] >= 9 else 32
         NUM_CBLOCK = BLOCK // CBLOCK
         assert BLOCK % CBLOCK == 0, "BLOCK must be a multiple of CBLOCK"
 


### PR DESCRIPTION
## Summary

`vllm/model_executor/layers/lightning_attn.py` hardcodes `CBLOCK = 64` in `_attention.forward` (line 458 of `lightning_attn.py`). On Ampere consumer/prosumer GPUs (RTX A4000, 4090, A10, etc. — SM 8.x), the resulting Triton kernel `_fwd_kv_parallel` requests ~131 KB of shared memory per CTA, exceeding the hardware ceiling of ~99 KB. The kernel fails to launch with:

```
triton.runtime.errors.OutOfResources: out of resource: shared memory,
Required: 131584, Hardware limit: 101376.
Reducing block sizes or `num_stages` may help.
```

This blocks running any model that uses vLLM's `lightning_attn` (MiniMax-Text01, MiniMax M2.5/M2.7, Ling-2.6-flash and similar Lightning-Linear-Attention models) on Ampere consumer/prosumer hardware **regardless of TP configuration** — independent of any other constraint the model may have.

## The fix

Make `CBLOCK` device-aware: keep `64` on Hopper+ where the kernel was tuned, drop to `32` on Ampere/older where `64` doesn't fit. This affects both `_fwd_kv_parallel` and `_fwd_none_diag_kernel` (they share the same `CBLOCK` setting in `_attention.forward`).

```python
# Before
CBLOCK = 64

# After
device_cap = torch.cuda.get_device_capability()
CBLOCK = 64 if device_cap[0] >= 9 else 32  # 64 on Hopper+, 32 on Ampere/older
```

`_fwd_diag_kernel` already uses `CBLOCK = 32` and is unaffected.

## SMEM math

At CBLOCK=64 on Ampere with the typical Lightning-LA shapes (head_dim 128, double-buffered loads):

- `kv` accumulator persistent: `[128, 128]` fp32 = 64 KB
- `k_trans` (double-buffered): `[128, 64]` bf16 × 2 = 32 KB
- `v` (double-buffered): `[64, 128]` bf16 × 2 = 32 KB
- Plus pointers/decay/Triton bookkeeping ≈ 3 KB
- **Total: ~131 KB**, exceeds A4000's 99 KB ceiling

At CBLOCK=32:

- `kv` accumulator: 64 KB (unchanged)
- `k_trans` doubled: 16 KB
- `v` doubled: 16 KB
- Plus overhead
- **Total: ~96 KB**, fits

## Performance impact

`NUM_CBLOCK = BLOCK / CBLOCK` doubles from 4 to 8 when `CBLOCK` halves, so the inner loop iterates twice as many times. Total work is unchanged; per-iteration overhead grows slightly. **Hopper performance is preserved** (still uses CBLOCK=64). On Ampere, this is the difference between the kernel failing to launch and running at near-full speed.

## Validation

Tested on 8× RTX A4000 (SM 8.6) running Ling-2.6-flash (BailingMoeV2_5, INT4 AWQ MoE, 28 linear-attn layers) with vLLM 0.20.1.dev0 + the patch:

- Without the patch: kernel fails to launch at any TP configuration
- With the patch: model loads and produces coherent output across an 8-prompt test set; throughput in line with model size and hardware

The patch is also forward-compatible with Hopper (path unchanged for `cap[0] >= 9`).

## Affected user class

Anyone running Lightning-Linear-Attention models (MiniMax-Text01, MiniMax M2/M2.5/M2.7-class, Ling/Bailing-class, similar future architectures) on Ampere consumer/prosumer GPUs. This is a real model-class-wide accessibility unlock for a real hardware tier.

## Test plan

- [ ] Verify the kernel launches and produces correct output on Ampere SM 8.x with bf16
- [ ] Verify Hopper SM 9.x still uses CBLOCK=64 and produces unchanged output
- [ ] Run existing lightning_attn test suite (if any) on both arches

## Related

This PR was discovered while running a vLLM TP-flexibility framework pilot (Universal Translator RFC). The kernel SMEM ceiling was the second of five integration gates encountered when attempting to run Ling-2.6-flash on 8× A4000. This PR is the orthogonal kernel fix; framework work is being submitted separately.

---

Discovered while running a TP-flexibility framework pilot (Universal Translator). The framework RFC will be filed separately as `[RFC]:` and references this kernel fix as a separable contribution. Project home: https://github.com/MidasMining/universal-translator
