### PR TITLE
Revert "[Build] Make bundled DeepGEMM wheel portable across Python versions"

### DIFF
--- a/cmake/external_projects/deepgemm.cmake
+++ b/cmake/external_projects/deepgemm.cmake
@@ -59,26 +59,11 @@ if(DEEPGEMM_ARCHS)
   # Build the _C pybind11 extension from DeepGEMM's C++ source.
   # This is a CXX-only module — CUDA kernels are JIT-compiled at runtime.
   #
-  # Free-threaded Python doesn't yet support the stable ABI, so skip USE_SABI
-  # there. (The other vLLM extensions get this guard for free via
-  # define_extension_target; this target uses raw Python_add_library.)
-  run_python(IS_FREETHREADED_PYTHON
-    "import sysconfig; print(1 if sysconfig.get_config_var(\"Py_GIL_DISABLED\") else 0)"
-    "Failed to determine whether interpreter is free-threaded")
-  if (NOT IS_FREETHREADED_PYTHON)
-    Python_add_library(_deep_gemm_C MODULE WITH_SOABI USE_SABI 3
-      "${deepgemm_SOURCE_DIR}/csrc/python_api.cpp")
-  else()
-    Python_add_library(_deep_gemm_C MODULE WITH_SOABI
-      "${deepgemm_SOURCE_DIR}/csrc/python_api.cpp")
-  endif()
+  Python_add_library(_deep_gemm_C MODULE WITH_SOABI
+    "${deepgemm_SOURCE_DIR}/csrc/python_api.cpp")
 
   # The pybind11 module name must be _C to match DeepGEMM's Python imports.
-  # Place the build artifact in a subdir so it doesn't collide with vLLM's own
-  # `_C.abi3.so` in the build tree (the install destination still differs).
-  set_target_properties(_deep_gemm_C PROPERTIES
-    OUTPUT_NAME "_C"
-    LIBRARY_OUTPUT_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/deep_gemm")
+  set_target_properties(_deep_gemm_C PROPERTIES OUTPUT_NAME "_C")
 
   target_compile_definitions(_deep_gemm_C PRIVATE
     "-DTORCH_EXTENSION_NAME=_C")
@@ -90,15 +75,11 @@ if(DEEPGEMM_ARCHS)
     "${deepgemm_SOURCE_DIR}/third-party/cutlass/tools/util/include"
     "${deepgemm_SOURCE_DIR}/third-party/fmt/include")
 
-  # Keep Stable ABI for the module, but *not* for CUDA/C++ files.
-  # This prevents Py_LIMITED_API from affecting nvcc and C++ compiles.
   target_compile_options(_deep_gemm_C PRIVATE
     $<$<COMPILE_LANGUAGE:CXX>:-std=c++17>
     $<$<COMPILE_LANGUAGE:CXX>:-O3>
     $<$<COMPILE_LANGUAGE:CXX>:-Wno-psabi>
-    $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>
-    $<$<COMPILE_LANGUAGE:CUDA>:-UPy_LIMITED_API>
-    $<$<COMPILE_LANGUAGE:CXX>:-UPy_LIMITED_API>)
+    $<$<COMPILE_LANGUAGE:CXX>:-Wno-deprecated-declarations>)
 
   # torch_python is required because DeepGEMM uses pybind11 type casters
   # for at::Tensor (via PYBIND11_MODULE), unlike vLLM's own extensions which


### PR DESCRIPTION
Reverts vllm-project/vllm#41476 as the approach is not actually viable for pybind11-based bindings