### PR TITLE
[CI] Add ci-fetch-log.sh helper for Buildkite job logs

### DIFF
--- a/.buildkite/scripts/ci-fetch-log.sh
+++ b/.buildkite/scripts/ci-fetch-log.sh
@@ -25,7 +25,7 @@ if [ $# -lt 1 ]; then usage; fi
 
 if [[ "$1" == https://* ]]; then
     BUILD=$(echo "$1" | sed -nE 's#.*/builds/([0-9]+).*#\1#p')
-    JOB=$(echo "$1" | sed -nE 's/.*[#?&]([0-9a-f]{8}-[0-9a-f-]+).*/\1/p')
+    JOB=$(echo "$1" | grep -oE '[0-9a-f]{8}-[0-9a-f-]+' | head -n 1)
     OUT="${2:-ci-${BUILD}-${JOB:0:8}.log}"
 else
     if [ $# -lt 2 ]; then usage; fi

--- a/.buildkite/scripts/ci-fetch-log.sh
+++ b/.buildkite/scripts/ci-fetch-log.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Usage: ./ci-fetch-log.sh <buildkite_job_url> [output_file]
+#        ./ci-fetch-log.sh <build_number> <job_uuid> [output_file]
+#
+# Downloads the raw log for a Buildkite job from the public, unauthenticated
+# /organizations/<org>/pipelines/<pipeline>/builds/<n>/jobs/<uuid>/download
+# endpoint, then strips ANSI/timestamps via ci-clean-log.sh.
+#
+# Find <build_number> and <job_uuid> via:
+#   gh pr checks <PR> --repo vllm-project/vllm
+# Each failing row's URL is .../builds/<build_number>#<job_uuid>.
+
+set -euo pipefail
+
+ORG="vllm"
+PIPELINE="ci"
+
+usage() {
+    echo "Usage: $0 <buildkite_job_url> [output_file]"
+    echo "       $0 <build_number> <job_uuid> [output_file]"
+    exit 1
+}
+
+if [ $# -lt 1 ]; then usage; fi
+
+if [[ "$1" == https://* ]]; then
+    BUILD=$(echo "$1" | sed -nE 's#.*/builds/([0-9]+).*#\1#p')
+    JOB=$(echo "$1" | sed -nE 's/.*[#?&]([0-9a-f]{8}-[0-9a-f-]+).*/\1/p')
+    OUT="${2:-ci-${BUILD}-${JOB:0:8}.log}"
+else
+    if [ $# -lt 2 ]; then usage; fi
+    BUILD="$1"
+    JOB="$2"
+    OUT="${3:-ci-${BUILD}-${JOB:0:8}.log}"
+fi
+
+if [ -z "$BUILD" ] || [ -z "$JOB" ]; then
+    echo "Could not parse build number or job UUID from: $1" >&2
+    usage
+fi
+
+COOKIES=$(mktemp)
+trap 'rm -f "$COOKIES"' EXIT
+
+# Buildkite issues a session cookie on first hit; subsequent /download needs it.
+curl -fsSL -c "$COOKIES" -A "vllm-ci-fetch-log" \
+    "https://buildkite.com/${ORG}/${PIPELINE}/builds/${BUILD}" -o /dev/null
+
+curl -fsSL -b "$COOKIES" -A "vllm-ci-fetch-log" \
+    "https://buildkite.com/organizations/${ORG}/pipelines/${PIPELINE}/builds/${BUILD}/jobs/${JOB}/download" \
+    -o "$OUT"
+
+bash "$(dirname "$0")/ci-clean-log.sh" "$OUT"
+
+echo "$OUT"

--- a/docs/contributing/ci/failures.md
+++ b/docs/contributing/ci/failures.md
@@ -60,9 +60,19 @@ the failure?
 
 ## Logs Wrangling
 
-Download the full log file from Buildkite locally.
+Download a job's log (no Buildkite login required):
 
-Strip timestamps and colorization:
+[.buildkite/scripts/ci-fetch-log.sh](../../../.buildkite/scripts/ci-fetch-log.sh)
+
+```bash
+# Find the failing job. Each row's URL is .../builds/<N>#<job_uuid>:
+gh pr checks <PR> --repo vllm-project/vllm
+
+# Download + strip timestamps/ANSI in one step:
+.buildkite/scripts/ci-fetch-log.sh "https://buildkite.com/vllm/ci/builds/<N>#<job_uuid>"
+```
+
+To clean an already-downloaded log:
 
 [.buildkite/scripts/ci-clean-log.sh](../../../.buildkite/scripts/ci-clean-log.sh)
 


### PR DESCRIPTION
## Summary

- New `.buildkite/scripts/ci-fetch-log.sh`: downloads a Buildkite job log from the public `/organizations/<org>/pipelines/<pipeline>/builds/<n>/jobs/<uuid>/download` endpoint, then runs `ci-clean-log.sh`. The user-facing `/<org>/<pipeline>/...` URLs return 404 for log routes, which is why the existing docs only said "download the log file from Buildkite locally" without giving a method. This is very useful for agents debugging ci failures.
- Update `docs/contributing/ci/failures.md` "Logs Wrangling" with the concrete `gh pr checks` → `ci-fetch-log.sh "<URL>"` recipe.

## Duplicate check

`gh pr list --repo vllm-project/vllm --state open --search "ci-fetch-log OR buildkite log fetch OR ci-clean-log"` returned no matches.

## Test plan

- [x] `pre-commit run --files .buildkite/scripts/ci-fetch-log.sh docs/contributing/ci/failures.md` passes (shellcheck, markdownlint, typos).
- [x] End-to-end against PR #41516's failing job: `bash .buildkite/scripts/ci-fetch-log.sh "https://buildkite.com/vllm/ci/builds/64166#019dea78-da59-411e-ae47-e2b08e2126dc"` produces a 2.6 MB cleaned log.

AI assistance (Claude Code) was used; submitter reviewed all changes.