### PR TITLE
[Bugfix] Improve error messages for LoRA+speculative and attention_backend config conflicts

### DIFF
--- a/tests/engine/test_arg_utils.py
+++ b/tests/engine/test_arg_utils.py
@@ -5,6 +5,7 @@ import json
 from argparse import ArgumentError
 from contextlib import AbstractContextManager, nullcontext
 from typing import Annotated, Literal
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import Field
@@ -427,6 +428,35 @@ def test_attention_config():
     assert args is not None
     engine_args = EngineArgs.from_cli_args(args)
     with pytest.raises(ValueError, match="mutually exclusive"):
+        engine_args.create_engine_config()
+
+
+def test_lora_speculative_batched_tokens_error():
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    # max_num_seqs=4, num_speculative_tokens=3 → min_batched_tokens = 4*(3+1)=16
+    # --max-num-batched-tokens=8 < 16, so the ValueError should fire.
+    # create_speculative_config is mocked because it requires a draft model
+    # download; we only want to test the scheduler constraint check.
+    args = parser.parse_args(
+        [
+            "--model",
+            "facebook/opt-125m",
+            "--enable-lora",
+            "--max-num-seqs",
+            "4",
+            "--max-num-batched-tokens",
+            "8",
+        ]
+    )
+    engine_args = EngineArgs.from_cli_args(args)
+    mock_spec_config = MagicMock()
+    mock_spec_config.num_speculative_tokens = 3
+    with (
+        patch.object(
+            engine_args, "create_speculative_config", return_value=mock_spec_config
+        ),
+        pytest.raises(ValueError, match="LoRA and speculative decoding"),
+    ):
         engine_args.create_engine_config()
 
 

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -2006,9 +2006,18 @@ class EngineArgs:
                 * (speculative_config.num_speculative_tokens + 1)
             )
         ):
+            min_batched_tokens = scheduler_config.max_num_seqs * (
+                speculative_config.num_speculative_tokens + 1
+            )
             raise ValueError(
-                "Consider increasing max_num_batched_tokens or "
-                "decreasing num_speculative_tokens"
+                f"When LoRA and speculative decoding are both enabled, "
+                f"max_num_batched_tokens ({scheduler_config.max_num_batched_tokens}) "
+                f"must be >= max_num_seqs * (num_speculative_tokens + 1) = "
+                f"{scheduler_config.max_num_seqs} * "
+                f"({speculative_config.num_speculative_tokens} + 1) = "
+                f"{min_batched_tokens}. "
+                f"Consider increasing --max-num-batched-tokens to at least "
+                f"{min_batched_tokens}, or decreasing --num-speculative-tokens."
             )
 
         # bitsandbytes pre-quantized model need a specific model loader
@@ -2020,8 +2029,10 @@ class EngineArgs:
         if self.attention_backend is not None:
             if attention_config.backend is not None:
                 raise ValueError(
-                    "attention_backend and attention_config.backend "
-                    "are mutually exclusive"
+                    f"--attention-backend ({self.attention_backend}) and "
+                    f"attention_config.backend ({attention_config.backend}) "
+                    f"are mutually exclusive. Use only --attention-backend, "
+                    f"or remove the backend field from --attention-config."
                 )
             # Reuse the validator to handle "auto" and string-to-enum conversion
             attention_config.backend = AttentionConfig.validate_backend_before(


### PR DESCRIPTION
## Improve error messaging for LoRA/Speculative decoding and backend config conflicts

## Purpose

Two error messages in `EngineArgs.create_engine_config()` were missing the actual values that caused the failure, making them difficult to diagnose:

*   **LoRA + Speculative Decoding Constraint (`arg_utils.py`):** The old message suggested increasing `max_num_batched_tokens` or decreasing `num_speculative_tokens` without context. The updated message now includes:
    *   Actual `max_num_batched_tokens`
    *   `max_num_seqs`
    *   `num_speculative_tokens`
    *   The full constraint formula and the minimum required value.
*   **Attention Backend Conflict (`arg_utils.py`):** The old message stated `attention_backend` and `attention_config.backend` were mutually exclusive. The updated message explicitly shows both conflicting values and directs the user on which flag to remove.

## Test Plan

Ran the following pytest commands to validate the new error logic and existing backend checks:

```bash
.venv/bin/python -m pytest \
  tests/engine/test_arg_utils.py::test_attention_config \
  tests/engine/test_arg_utils.py::test_lora_speculative_batched_tokens_error -v
```

*   **Note:** Added a new test `test_lora_speculative_batched_tokens_error`. 
*   **Mocking:** `create_speculative_config` is mocked as the test specifically targets the scheduler constraint validation rather than draft model loading.

## Test Result

```text
tests/engine/test_arg_utils.py::test_attention_config PASSED
tests/engine/test_arg_utils.py::test_lora_speculative_batched_tokens_error PASSED

=========================== 2 passed in 4.51s ===========================
```

*   Verified no open PRs address these specific error messages (searched "error message attention_backend" and "speculative lora batched tokens").

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
