### PR TITLE
[DSV4] Attention accumulation in model dtype

### DIFF
--- a/vllm/model_executor/layers/deepseek_v4_attention.py
+++ b/vllm/model_executor/layers/deepseek_v4_attention.py
@@ -352,7 +352,6 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
                 return torch.mm(
                     hidden_states,
                     compressor.fused_wkv_wgate.weight.T,
-                    out_dtype=torch.bfloat16,
                 )
 
             aux_fns[0] = compressor_kv_score
@@ -369,7 +368,6 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
                 return torch.mm(
                     hidden_states,
                     indexer.compressor.fused_wkv_wgate.weight.T,
-                    out_dtype=torch.bfloat16,
                 )
 
             aux_fns[1] = indexer_weights_proj

--- a/vllm/model_executor/layers/deepseek_v4_attention.py
+++ b/vllm/model_executor/layers/deepseek_v4_attention.py
@@ -352,7 +352,7 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
                 return torch.mm(
                     hidden_states,
                     compressor.fused_wkv_wgate.weight.T,
-                    out_dtype=torch.float32,
+                    out_dtype=torch.bfloat16,
                 )
 
             aux_fns[0] = compressor_kv_score
@@ -369,7 +369,7 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
                 return torch.mm(
                     hidden_states,
                     indexer.compressor.fused_wkv_wgate.weight.T,
-                    out_dtype=torch.float32,
+                    out_dtype=torch.bfloat16,
                 )
 
             aux_fns[1] = indexer_weights_proj


### PR DESCRIPTION
## Purpose ##
* Rerequisite for https://github.com/vllm-project/vllm/pull/41276
  * NVFP4 kernels do not have a pathway to specify output dtype, they instead follow the dtype of the activations (typically bf16)
* Minor throughput/ latency improvement for no accuracy loss (slight accuracy improvement)

## Changes ##
* Replace `out_dtype` argument of compressor and indexer operations with `bfloat16` 

## Testing ##
```bash
vllm serve deepseek-ai/DeepSeek-V4-Flash --tensor-parallel-size 4 --port 8089 --kv_cache_dtype="fp8"`
lm_eval
   --model local-completions
   --model_args model=deepseek-ai/DeepSeek-V4Flash,base_url=http://localhost:8089/v1/completions,tokenized_requests=False,trust_remote_code=True
   --tasks longbench_summarization
   --output_path ./
```
| Metric | `out_dtype=float32` | `out_dtype=bfloat16` |
| - | - | - |
MMLU | 0.677 | 0.680 |
GSM8K | 0.938 | 0.945 |
LongBenchV2_Summarization | 0.2007 | 0.2029 |
Tok/s (mmlu) | 163.546 | 165.546 |
