### PR TITLE
add fused mhc_post_pre kernel

### DIFF
--- a/tests/kernels/test_mhc_kernels.py
+++ b/tests/kernels/test_mhc_kernels.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+
+import vllm.model_executor.layers.mhc as mhc_ops  # noqa: F401
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
+
+DEVICE = current_platform.device_type
+
+
+def sinkhorn_normalize_ref(x: torch.Tensor, repeat: int, eps: float) -> torch.Tensor:
+    x = x.softmax(-1) + eps
+    x = x / (x.sum(-2, keepdim=True) + eps)
+    for _ in range(repeat - 1):
+        x = x / (x.sum(-1, keepdim=True) + eps)
+        x = x / (x.sum(-2, keepdim=True) + eps)
+    return x
+
+
+def mhc_pre_ref(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """mHC pre reference kernel from tilelang repo: https://github.com/tile-ai/tilelang/blob/d135bd1cd2d2eee74fbb41dd0a0831a427194c86/examples/deepseek_mhc/example_mhc_pre.py#L303"""
+    hc_mult = residual.shape[-2]
+
+    residual_flat = residual.flatten(-2, -1).float()
+    sqrsum = residual_flat.square().sum(-1)
+    mixes = (
+        residual_flat @ fn.T * (sqrsum.unsqueeze(-1) / fn.shape[-1] + rms_eps).rsqrt()
+    )
+
+    hc_scale = torch.cat(
+        [
+            hc_scale[0].expand(hc_mult),
+            hc_scale[1].expand(hc_mult),
+            hc_scale[2].expand(hc_mult * hc_mult),
+        ],
+    )
+    mixes = mixes * hc_scale + hc_base
+
+    pre_mix = mixes[:, :hc_mult].sigmoid().unsqueeze(-1) + hc_pre_eps
+    post_mix = (
+        mixes[:, hc_mult : 2 * hc_mult].sigmoid() * hc_post_mult_value
+    ).unsqueeze(-1)
+    res_mix = mixes[:, 2 * hc_mult :].view(-1, hc_mult, hc_mult)
+
+    res_mix = sinkhorn_normalize_ref(
+        res_mix, repeat=sinkhorn_repeat, eps=hc_sinkhorn_eps
+    )
+
+    layer_input = (residual * pre_mix).sum(-2).bfloat16()
+
+    return post_mix, res_mix, layer_input
+
+
+def mhc_post_ref(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> torch.Tensor:
+    """mHC post reference kernel from tilelang repo: https://github.com/tile-ai/tilelang/blob/d135bd1cd2d2eee74fbb41dd0a0831a427194c86/examples/deepseek_mhc/example_mhc_post.py#L68"""
+    term2 = torch.bmm(comb_res_mix.mT, residual.float())
+    return (x.float().unsqueeze(-2) * post_layer_mix + term2).bfloat16()
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="CUDA required",
+)
+@pytest.mark.parametrize("num_tokens", [1, 4, 8, 128])
+@pytest.mark.parametrize("hidden_size", [4096, 7168])
+@pytest.mark.parametrize("hc_mult", [4])
+def test_mhc_fused_post_pre(num_tokens, hidden_size, hc_mult):
+    torch.set_default_device(DEVICE)
+    set_random_seed(0)
+
+    x = torch.randn((num_tokens, hidden_size), dtype=torch.bfloat16)
+    residual = torch.randn((num_tokens, hc_mult, hidden_size), dtype=torch.bfloat16)
+    post_layer_mix = torch.randn((num_tokens, hc_mult, 1), dtype=torch.float32)
+    comb_res_mix = torch.randn((num_tokens, hc_mult, hc_mult), dtype=torch.float32)
+
+    hc_mult2 = hc_mult * hc_mult
+    hc_mult3 = hc_mult * 2 + hc_mult2
+    fn = (
+        torch.randn((hc_mult3, hc_mult, hidden_size), dtype=torch.float)
+        * 1e-4
+        * (1 + torch.arange(hc_mult).mul(0.01).view(1, -1, 1))
+    ).flatten(1, 2)
+    hc_scale = torch.randn((3,), dtype=torch.float) * 0.1
+    hc_base = torch.randn((hc_mult3,), dtype=torch.float) * 0.1
+
+    hc_sinkhorn_eps = hc_pre_eps = rms_eps = 1e-6
+    sinkhorn_repeat = 20
+    hc_post_alpha = 1.0
+
+    def run_ref():
+        residual_ref = mhc_post_ref(x, residual, post_layer_mix, comb_res_mix)
+        post_mix_ref, res_mix_ref, layer_input_ref = mhc_pre_ref(
+            residual_ref,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_alpha,
+            sinkhorn_repeat,
+        )
+        return residual_ref, post_mix_ref, res_mix_ref, layer_input_ref
+
+    residual_ref, post_mix_ref, res_mix_ref, layer_input_ref = run_ref()
+
+    residual, post_mix, res_mix, x = torch.ops.vllm.mhc_fused_post_pre(
+        x,
+        residual,
+        post_layer_mix,
+        comb_res_mix,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_alpha,
+        sinkhorn_repeat,
+    )
+
+    torch.testing.assert_close(residual, residual_ref, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(post_mix, post_mix_ref, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(res_mix, res_mix_ref, atol=1e-2, rtol=1e-2)
+    torch.testing.assert_close(x, layer_input_ref, atol=1e-2, rtol=1e-2)

--- a/vllm/model_executor/layers/mhc.py
+++ b/vllm/model_executor/layers/mhc.py
@@ -408,6 +408,156 @@ def mhc_post_tilelang(
         T.pdl_trigger()
 
 
+@tilelang.jit(
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+        tilelang.PassConfigKey.TL_PTXAS_REGISTER_USAGE_LEVEL: 10,
+    },
+)
+def mhc_fused_tilelang(
+    comb_mix,
+    residual_in,
+    post_mix,
+    x_in,
+    weight_t,
+    yp_out,
+    rp_out,
+    residual_out,
+    hc: int,
+    hidden: int,
+    n_out: int,  # static; equals hc_mult * (2 + hc_mult) for mhc
+    n_thr: int = 256,
+    h_blk: int = 256,
+    tile_n: int = 1,
+    split_k: int = 1,
+) -> tilelang.JITKernel:
+    """Fused mhc post-mapping + pre-norm GEMM FMA"""
+    m = T.dynamic("num_tokens")
+    split_k = T.dynamic("split_k")
+    h = hidden
+    h_blk = math.gcd(hidden, h_blk)
+    h_per_split = h // split_k
+    n_tiles = n_out // tile_n
+
+    comb_mix: T.Tensor((m, hc, hc), T.float32)  # type: ignore[no-redef, valid-type]
+    residual_in: T.Tensor((m, hc, h), T.bfloat16)  # type: ignore[no-redef, valid-type]
+    post_mix: T.Tensor((m, hc), T.float32)  # type: ignore[no-redef, valid-type]
+    x_in: T.Tensor((m, h), T.bfloat16)  # type: ignore[no-redef, valid-type]
+    weight_t: T.Tensor((n_out, hc, h), T.float32)  # type: ignore[no-redef, valid-type]
+    yp_out: T.Tensor((split_k, m, n_out), T.float32)  # type: ignore[no-redef, valid-type]
+    rp_out: T.Tensor((split_k, m), T.float32)  # type: ignore[no-redef, valid-type]
+    residual_out: T.Tensor((m, hc, h), T.bfloat16)  # type: ignore[no-redef, valid-type]
+
+    # Strided h loop: each thread owns indices {h_split_start + tid, +n_thr, ...}
+    # within its k-split. Per-thread acc[tile_n] and sqr accumulate across all
+    # iterations; one final warp_reduce_sum + smem cross-warp reduce mirrors the
+    # CUDA __shfl_xor_sync butterfly + s_warp staging.
+    h_iters = h_per_split // n_thr
+    num_warps = n_thr // 32
+    _ = h_blk  # vestigial; per-thread strided loop replaces the h-block tiling.
+
+    with T.Kernel(m, n_tiles, split_k, threads=n_thr) as (i_n, i_nt, i_ks):
+        tid = T.get_thread_binding()
+        warp_id = tid // 32
+        lane = tid % 32
+
+        # Shared mem: cross-warp staging (analog of CUDA `s_warp`).
+        # Layout: [num_warps][tile_n cols + 1 sqr slot].
+        s_warp = T.alloc_shared((num_warps, tile_n + 1), T.float32)
+        # Shared mem: post_mix and comb_mix loaded once per CTA (analog of
+        # CUDA s_post / s_comb).
+        s_post = T.alloc_shared((hc,), T.float32)
+        s_comb = T.alloc_shared((hc, hc), T.float32)
+
+        # Per-thread registers (analogs of CUDA's `pm[]`, `cm[][]`, `acc[]`,
+        # `sqr`, `new_r[][]`, `rf_k[]`).
+        pm = T.alloc_local((hc,), T.float32)
+        cm = T.alloc_local((hc, hc), T.float32)
+        acc = T.alloc_local((tile_n,), T.float32)
+        sqr = T.alloc_local((1,), T.float32)
+        new_r = T.alloc_local((hc,), T.float32)
+        r_vals = T.alloc_local((hc,), T.float32)
+
+        T.pdl_sync()
+
+        # Load post_mix and comb_mix into shared via a coalesced copy, then
+        # broadcast into per-thread registers.
+        T.copy(post_mix[i_n, 0], s_post)
+        T.copy(comb_mix[i_n, 0, 0], s_comb)
+        T.sync_threads()
+        for j in T.unroll(hc):
+            pm[j] = s_post[j]
+        for j in T.unroll(hc):
+            for k in T.unroll(hc):
+                cm[k, j] = s_comb[k, j]
+
+        for n in T.unroll(tile_n):
+            acc[n] = T.float32(0.0)
+        sqr[0] = T.float32(0.0)
+
+        h_split_start = i_ks * h_per_split
+
+        # Each thread owns h_iters elements of the k-split's h slice.
+        for it in T.serial(h_iters):
+            h_idx = h_split_start + it * n_thr + tid
+
+            # ---- Load this thread's slice of x and residual ----
+            xv = x_in[i_n, h_idx]
+            for k in T.unroll(hc):
+                r_vals[k] = residual_in[i_n, k, h_idx]
+
+            # ---- Compute new_r[j] = pm[j] * x + sum_k cm[k, j] * r[k] ----
+            for j in T.unroll(hc):
+                new_r[j] = pm[j] * xv
+                for k in T.unroll(hc):
+                    new_r[j] += cm[k, j] * r_vals[k]
+
+            # ---- residual_out + sqr (only n-tile 0; per-thread, no race) ----
+            if i_nt == 0:
+                for j in T.unroll(hc):
+                    residual_out[i_n, j, h_idx] = new_r[j]  # fp32 -> bf16
+                    sqr[0] += new_r[j] * new_r[j]
+
+            # ---- Per-thread FMA into acc[n] (no smem — pure register) ----
+            for n in T.unroll(tile_n):
+                for j in T.unroll(hc):
+                    acc[n] += weight_t[i_nt * tile_n + n, j, h_idx] * new_r[j]
+
+        # ---- Butterfly warp reduce (analog of __shfl_xor_sync loop) ----
+        for n in T.unroll(tile_n):
+            acc[n] = T.warp_reduce_sum(acc[n])
+        if i_nt == 0:
+            sqr[0] = T.warp_reduce_sum(sqr[0])
+
+        # ---- Cross-warp reduce via shared mem (analog of CUDA s_warp) ----
+        if lane == 0:
+            for n in T.unroll(tile_n):
+                s_warp[warp_id, n] = acc[n]
+            if i_nt == 0:
+                s_warp[warp_id, tile_n] = sqr[0]
+        T.sync_threads()
+
+        # Warp 0 does the final cross-warp sum and writes outputs. Lane n
+        # writes column n (mirrors CUDA "if lane == 0 && warp_id < n_cols").
+        if warp_id == 0:
+            if lane < tile_n:
+                v = T.alloc_local((1,), T.float32)
+                v[0] = T.float32(0.0)
+                for w in T.unroll(num_warps):
+                    v[0] += s_warp[w, lane]
+                yp_out[i_ks, i_n, i_nt * tile_n + lane] = v[0]
+
+            if i_nt == 0 and lane == 0:
+                v2 = T.alloc_local((1,), T.float32)
+                v2[0] = T.float32(0.0)
+                for w in T.unroll(num_warps):
+                    v2[0] += s_warp[w, tile_n]
+                rp_out[i_ks, i_n] = v2[0]
+
+        T.pdl_trigger()
+
+
 def mhc_post(
     x: torch.Tensor,
     residual: torch.Tensor,
@@ -425,6 +575,218 @@ def mhc_post(
         residual.shape[-1],
     )
     return out
+
+
+def mhc_fused_post_pre(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    n_splits: int = 1,
+    tile_n: int = 1,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Run one MHC post block followed by the next MHC pre block.
+
+    Returns:
+        residual_cur: post-mapped residual, shape (..., hc_mult, hidden_size)
+        post_mix_cur: shape (..., hc_mult, 1)
+        comb_mix_cur: shape (..., hc_mult, hc_mult)
+        layer_input_cur: shape (..., hidden_size)
+    """
+
+    assert residual.dtype == torch.bfloat16
+    assert x.dtype == torch.bfloat16
+    assert post_layer_mix.dtype == torch.float32
+    assert comb_res_mix.dtype == torch.float32
+    assert fn.dtype == torch.float32
+    assert hc_scale.dtype == torch.float32
+    assert hc_base.dtype == torch.float32
+
+    hc_mult = residual.shape[-2]
+    hidden_size = residual.shape[-1]
+    hc_mult2 = hc_mult * hc_mult
+    hc_mult3 = hc_mult * 2 + hc_mult2
+    hc_hidden_size = hc_mult * hidden_size
+    outer_shape = residual.shape[:-2]
+
+    assert x.shape == (*outer_shape, hidden_size)
+    assert post_layer_mix.shape in (
+        (*outer_shape, hc_mult, 1),
+        (*outer_shape, hc_mult),
+    )
+    assert comb_res_mix.shape == (*outer_shape, hc_mult, hc_mult)
+    assert fn.shape == (hc_mult3, hc_hidden_size)
+    assert hc_scale.shape == (3,)
+    assert hc_base.shape == (hc_mult3,)
+
+    assert n_splits in (1, 2, 4, 8)
+    assert hidden_size % n_splits == 0
+
+    residual_flat = residual.view(-1, hc_mult, hidden_size)
+    num_tokens = residual_flat.shape[0]
+    x_flat = x.view(num_tokens, hidden_size)
+    post_layer_mix_flat = post_layer_mix.view(num_tokens, hc_mult)
+    comb_res_mix_flat = comb_res_mix.view(num_tokens, hc_mult, hc_mult)
+
+    fma_token_threshold = 16
+    if num_tokens <= fma_token_threshold:
+        # TODO(gnovack): investigate tuning these heuristics
+        tile_n = 2 if num_tokens <= 8 else 3
+        n_splits = 4
+    else:
+        # these number are from deepgemm kernel impl
+        block_k = 64
+        block_m = 64
+        n_splits = compute_num_split(block_k, hc_hidden_size, cdiv(num_tokens, block_m))
+
+    gemm_out_mul = torch.empty(
+        n_splits,
+        num_tokens,
+        hc_mult3,
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    gemm_out_sqrsum = torch.empty(
+        n_splits,
+        num_tokens,
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    residual_cur = torch.empty_like(residual_flat)
+    post_mix_cur = torch.empty(
+        num_tokens,
+        hc_mult,
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    comb_mix_cur = torch.empty(
+        num_tokens,
+        hc_mult2,
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    layer_input_cur = torch.empty(
+        num_tokens,
+        hidden_size,
+        dtype=torch.bfloat16,
+        device=residual.device,
+    )
+
+    if num_tokens <= fma_token_threshold:
+        mhc_fused_tilelang(
+            comb_res_mix_flat,
+            residual_flat,
+            post_layer_mix_flat,
+            x_flat,
+            fn.view(hc_mult3, hc_mult, hidden_size),
+            gemm_out_mul,
+            gemm_out_sqrsum,
+            residual_cur,
+            hc_mult,
+            hidden_size,
+            hc_mult3,
+            tile_n=tile_n,
+            n_splits=n_splits,
+        )
+    else:
+        mhc_post_tilelang(
+            comb_res_mix_flat,
+            residual_flat,
+            post_layer_mix_flat,
+            x_flat,
+            residual_cur,
+            residual.shape[-2],
+            residual.shape[-1],
+        )
+
+        from vllm.utils.deep_gemm import tf32_hc_prenorm_gemm
+
+        tf32_hc_prenorm_gemm(
+            residual_cur.view(num_tokens, hc_mult * hidden_size),
+            fn,
+            gemm_out_mul,
+            gemm_out_sqrsum,
+            n_splits,
+        )
+
+    mhc_pre_big_fuse_tilelang(
+        gemm_out_mul,
+        gemm_out_sqrsum,
+        hc_scale,
+        hc_base,
+        residual_cur,
+        post_mix_cur,
+        comb_mix_cur,
+        layer_input_cur,
+        hidden_size,
+        rms_eps,
+        hc_pre_eps,
+        hc_sinkhorn_eps,
+        hc_post_mult_value,
+        sinkhorn_repeat,
+        n_splits,
+        hc_mult,
+    )
+
+    return (
+        residual_cur.view(*outer_shape, hc_mult, hidden_size),
+        post_mix_cur.view(*outer_shape, hc_mult, 1),
+        comb_mix_cur.view(*outer_shape, hc_mult, hc_mult),
+        layer_input_cur.view(*outer_shape, hidden_size),
+    )
+
+
+def _mhc_fused_post_pre_fake(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    n_splits: int = 1,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    hc_mult = residual.shape[-2]
+    hidden_size = residual.shape[-1]
+    outer_shape = residual.shape[:-2]
+
+    residual_cur = torch.empty_like(residual)
+    post_mix_cur = torch.empty(
+        *outer_shape,
+        hc_mult,
+        1,
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    comb_mix_cur = torch.empty(
+        *outer_shape,
+        hc_mult,
+        hc_mult,
+        dtype=torch.float32,
+        device=residual.device,
+    )
+    layer_input_cur = torch.empty(
+        *outer_shape,
+        hidden_size,
+        dtype=torch.bfloat16,
+        device=residual.device,
+    )
+
+    return residual_cur, post_mix_cur, comb_mix_cur, layer_input_cur
 
 
 def _mhc_post_fake(
@@ -447,6 +809,12 @@ direct_register_custom_op(
     op_func=mhc_post,
     mutates_args=[],
     fake_impl=_mhc_post_fake,
+)
+direct_register_custom_op(
+    op_name="mhc_fused_post_pre",
+    op_func=mhc_fused_post_pre,
+    mutates_args=[],
+    fake_impl=_mhc_fused_post_pre_fake,
 )
 
 

--- a/vllm/model_executor/layers/mhc.py
+++ b/vllm/model_executor/layers/mhc.py
@@ -639,9 +639,9 @@ def mhc_fused_post_pre(
 
     fma_token_threshold = 16
     if num_tokens <= fma_token_threshold:
-        # TODO(gnovack): investigate tuning these heuristics
-        tile_n = 2 if num_tokens <= 8 else 3
-        n_splits = 4
+        # TODO(gnovack): investigate autotuning these heuristics
+        tile_n = 2 if num_tokens < 8 else 3
+        n_splits = 8 if (num_tokens < 8 and hidden_size <= 4096) else 4
     else:
         # these number are from deepgemm kernel impl
         block_k = 64

--- a/vllm/model_executor/layers/mhc.py
+++ b/vllm/model_executor/layers/mhc.py
@@ -426,7 +426,7 @@ def mhc_fused_tilelang(
     residual_out,
     hc: int,
     hidden: int,
-    n_out: int,  # static; equals hc_mult * (2 + hc_mult) for mhc
+    n_out: int,
     n_thr: int = 256,
     h_blk: int = 256,
     tile_n: int = 1,
@@ -449,88 +449,66 @@ def mhc_fused_tilelang(
     rp_out: T.Tensor((split_k, m), T.float32)  # type: ignore[no-redef, valid-type]
     residual_out: T.Tensor((m, hc, h), T.bfloat16)  # type: ignore[no-redef, valid-type]
 
-    # Strided h loop: each thread owns indices {h_split_start + tid, +n_thr, ...}
-    # within its k-split. Per-thread acc[tile_n] and sqr accumulate across all
-    # iterations; one final warp_reduce_sum + smem cross-warp reduce mirrors the
-    # CUDA __shfl_xor_sync butterfly + s_warp staging.
     h_iters = h_per_split // n_thr
     num_warps = n_thr // 32
-    _ = h_blk  # vestigial; per-thread strided loop replaces the h-block tiling.
 
     with T.Kernel(m, n_tiles, split_k, threads=n_thr) as (i_n, i_nt, i_ks):
         tid = T.get_thread_binding()
-        warp_id = tid // 32
-        lane = tid % 32
+        warp_id = T.get_warp_idx()
+        lane = T.get_lane_idx()
 
-        # Shared mem: cross-warp staging (analog of CUDA `s_warp`).
-        # Layout: [num_warps][tile_n cols + 1 sqr slot].
         s_warp = T.alloc_shared((num_warps, tile_n + 1), T.float32)
-        # Shared mem: post_mix and comb_mix loaded once per CTA (analog of
-        # CUDA s_post / s_comb).
         s_post = T.alloc_shared((hc,), T.float32)
         s_comb = T.alloc_shared((hc, hc), T.float32)
 
-        # Per-thread registers (analogs of CUDA's `pm[]`, `cm[][]`, `acc[]`,
-        # `sqr`, `new_r[][]`, `rf_k[]`).
         pm = T.alloc_local((hc,), T.float32)
         cm = T.alloc_local((hc, hc), T.float32)
         acc = T.alloc_local((tile_n,), T.float32)
         sqr = T.alloc_local((1,), T.float32)
         new_r = T.alloc_local((hc,), T.float32)
-        r_vals = T.alloc_local((hc,), T.float32)
+
+        T.clear(acc)
+        T.clear(sqr)
+        h_split_start = i_ks * h_per_split
 
         T.pdl_sync()
 
-        # Load post_mix and comb_mix into shared via a coalesced copy, then
-        # broadcast into per-thread registers.
         T.copy(post_mix[i_n, 0], s_post)
         T.copy(comb_mix[i_n, 0, 0], s_comb)
-        T.sync_threads()
+
         for j in T.unroll(hc):
             pm[j] = s_post[j]
         for j in T.unroll(hc):
             for k in T.unroll(hc):
                 cm[k, j] = s_comb[k, j]
 
-        for n in T.unroll(tile_n):
-            acc[n] = T.float32(0.0)
-        sqr[0] = T.float32(0.0)
-
-        h_split_start = i_ks * h_per_split
-
         # Each thread owns h_iters elements of the k-split's h slice.
         for it in T.serial(h_iters):
             h_idx = h_split_start + it * n_thr + tid
 
-            # ---- Load this thread's slice of x and residual ----
-            xv = x_in[i_n, h_idx]
-            for k in T.unroll(hc):
-                r_vals[k] = residual_in[i_n, k, h_idx]
-
-            # ---- Compute new_r[j] = pm[j] * x + sum_k cm[k, j] * r[k] ----
+            # Compute new residual from layer output and past residual
             for j in T.unroll(hc):
-                new_r[j] = pm[j] * xv
+                new_r[j] = pm[j] * x_in[i_n, h_idx]
                 for k in T.unroll(hc):
-                    new_r[j] += cm[k, j] * r_vals[k]
+                    new_r[j] += cm[k, j] * residual_in[i_n, k, h_idx]
 
-            # ---- residual_out + sqr (only n-tile 0; per-thread, no race) ----
+            # populate residual_out and compute sqr sum
             if i_nt == 0:
                 for j in T.unroll(hc):
-                    residual_out[i_n, j, h_idx] = new_r[j]  # fp32 -> bf16
+                    residual_out[i_n, j, h_idx] = new_r[j]
                     sqr[0] += new_r[j] * new_r[j]
 
-            # ---- Per-thread FMA into acc[n] (no smem — pure register) ----
+            # Per-thread FMA into acc[n]
             for n in T.unroll(tile_n):
                 for j in T.unroll(hc):
                     acc[n] += weight_t[i_nt * tile_n + n, j, h_idx] * new_r[j]
 
-        # ---- Butterfly warp reduce (analog of __shfl_xor_sync loop) ----
         for n in T.unroll(tile_n):
             acc[n] = T.warp_reduce_sum(acc[n])
         if i_nt == 0:
             sqr[0] = T.warp_reduce_sum(sqr[0])
 
-        # ---- Cross-warp reduce via shared mem (analog of CUDA s_warp) ----
+        # Cross-warp reduce via shared mem
         if lane == 0:
             for n in T.unroll(tile_n):
                 s_warp[warp_id, n] = acc[n]
@@ -538,22 +516,19 @@ def mhc_fused_tilelang(
                 s_warp[warp_id, tile_n] = sqr[0]
         T.sync_threads()
 
-        # Warp 0 does the final cross-warp sum and writes outputs. Lane n
-        # writes column n (mirrors CUDA "if lane == 0 && warp_id < n_cols").
+        # Warp 0 does the final cross-warp sum and writes outputs
         if warp_id == 0:
             if lane < tile_n:
-                v = T.alloc_local((1,), T.float32)
-                v[0] = T.float32(0.0)
+                v = T.alloc_var(T.float32, init=0.0)
                 for w in T.unroll(num_warps):
-                    v[0] += s_warp[w, lane]
-                yp_out[i_ks, i_n, i_nt * tile_n + lane] = v[0]
+                    v += s_warp[w, lane]
+                yp_out[i_ks, i_n, i_nt * tile_n + lane] = v
 
             if i_nt == 0 and lane == 0:
-                v2 = T.alloc_local((1,), T.float32)
-                v2[0] = T.float32(0.0)
+                v2 = T.alloc_var(T.float32, init=0.0)
                 for w in T.unroll(num_warps):
-                    v2[0] += s_warp[w, tile_n]
-                rp_out[i_ks, i_n] = v2[0]
+                    v2 += s_warp[w, tile_n]
+                rp_out[i_ks, i_n] = v2
 
         T.pdl_trigger()
 

--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -1199,23 +1199,53 @@ class DeepseekV4DecoderLayer(nn.Module):
         x: torch.Tensor,
         positions: torch.Tensor,
         input_ids: torch.Tensor | None,
+        post_mix: torch.Tensor | None,
+        res_mix: torch.Tensor | None,
+        residual: torch.Tensor | None,
     ) -> torch.Tensor:
-        residual = x
-        x, post, comb = self.hc_pre(
-            x, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base
-        )
+        if residual is None:
+            # Run standalone hc_pre on first layer
+            residual = x
+            x, post_mix, res_mix = self.hc_pre(
+                x, self.hc_attn_fn, self.hc_attn_scale, self.hc_attn_base
+            )
+        else:
+            residual, post_mix, res_mix, x = torch.ops.vllm.mhc_fused_post_pre(
+                x,
+                residual,
+                post_mix,
+                res_mix,
+                self.hc_attn_fn,
+                self.hc_attn_scale,
+                self.hc_attn_base,
+                self.rms_norm_eps,
+                self.hc_eps,
+                self.hc_eps,
+                self.hc_post_alpha,
+                self.hc_sinkhorn_iters,
+            )
+
         x = self.attn_norm(x)
         x = self.attn(positions, x, None)
-        x = self.hc_post(x, residual, post, comb)
 
-        residual = x
-        x, post, comb = self.hc_pre(
-            x, self.hc_ffn_fn, self.hc_ffn_scale, self.hc_ffn_base
+        residual, post_mix, res_mix, x = torch.ops.vllm.mhc_fused_post_pre(
+            x,
+            residual,
+            post_mix,
+            res_mix,
+            self.hc_ffn_fn,
+            self.hc_ffn_scale,
+            self.hc_ffn_base,
+            self.rms_norm_eps,
+            self.hc_eps,
+            self.hc_eps,
+            self.hc_post_alpha,
+            self.hc_sinkhorn_iters,
         )
+
         x = self.ffn_norm(x)
         x = self.ffn(x, input_ids)
-        x = self.hc_post(x, residual, post, comb)
-        return x
+        return x, residual, post_mix, res_mix
 
 
 @support_torch_compile
@@ -1320,12 +1350,19 @@ class DeepseekV4Model(nn.Module):
         hidden_states = hidden_states.unsqueeze(-2).repeat(1, self.hc_mult, 1)
         if self.use_mega_moe:
             input_ids = input_ids.to(torch.int64)
+
+        residual, post_mix, res_mix = None, None, None
         for layer in islice(self.layers, self.start_layer, self.end_layer):
-            hidden_states = layer(
+            hidden_states, residual, post_mix, res_mix = layer(
                 hidden_states,
                 positions,
                 input_ids,
+                post_mix,
+                res_mix,
+                residual,
             )
+        else:
+            hidden_states = layer.hc_post(hidden_states, residual, post_mix, res_mix)
 
         # Stash pre-hc_head residual for the MTP draft (captured copy_).
         num_tokens = hidden_states.shape[0]


### PR DESCRIPTION

## Purpose
This PR adds a new mHC kernel, which fuses the `hc_post` operation with the `prenorm_gemm` portion of `hc_pre`. The approach is adapted from TRTLLM, and performs the GEMM using FMA (rather than tensor cores), improving speed at low concurrency.

### Benchmarks
Benchmark results with deepseek-ai/DeepSeek-V4-Flash at concurrency 4.

Before this PR:
```
================= Serving Benchmark Result =================
Successful requests:                     300       
Failed requests:                         0         
Maximum request concurrency:             4         
Benchmark duration (s):                  302.63    
Total input tokens:                      307200    
Total generated tokens:                  100753    
Request throughput (req/s):              0.99      
Output token throughput (tok/s):         332.92    
Peak output token throughput (tok/s):    408.00    
Peak concurrent requests:                7.00      
Total token throughput (tok/s):          1348.00   
--------------------Time to First Token---------------------
Mean TTFT (ms):                          196.89    
Median TTFT (ms):                        192.03    
P99 TTFT (ms):                           680.64    
P90 TTFT (ms):                           206.13    
----------Time per Output Token (excl. 1st token)-----------
Mean TPOT (ms):                          11.40     
Median TPOT (ms):                        11.34     
P99 TPOT (ms):                           14.48     
P90 TPOT (ms):                           12.28
============================================================
```

With this PR:
```
================= Serving Benchmark Result =================
Successful requests:                     300       
Failed requests:                         0         
Maximum request concurrency:             4         
Benchmark duration (s):                  284.77    
Total input tokens:                      307200    
Total generated tokens:                  100436    
Request throughput (req/s):              1.05      
Output token throughput (tok/s):         352.69    
Peak output token throughput (tok/s):    432.00    
Peak concurrent requests:                7.00      
Total token throughput (tok/s):          1431.47   
--------------------Time to First Token---------------------
Mean TTFT (ms):                          185.48    
Median TTFT (ms):                        188.37    
P99 TTFT (ms):                           539.61    
P90 TTFT (ms):                           201.03    
----------Time per Output Token (excl. 1st token)-----------
Mean TPOT (ms):                          10.74     
Median TPOT (ms):                        10.69     
P99 TPOT (ms):                           12.39     
P90 TPOT (ms):                           11.59
============================================================
```

### Accuracy Evals

task | result
-- | --
gsm8k | flexible-extract=0.9492; strict-match=0.9500
aime25 | exact_match=0.9333

## Still Pending

- [x] Code cleanup
- [x] Rebase
- [x] Add unit tests
- [x] Add model quality eval results to PR
- [ ] Look into autotuning to avoid hard-coded metaparams (tile_n, split_k, etc.)