### PR TITLE
[Feature] Add rolling-hash repetition detection algorithm

### DIFF
--- a/benchmarks/benchmark_repetition_detection.py
+++ b/benchmarks/benchmark_repetition_detection.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Microbenchmark: per-step latency of repetition detection algorithms.
+
+Three configurations are compared on a simulated decode loop where one
+output token is appended per step and ``check_sequence_repetition`` is
+invoked:
+
+  * naive (current in-tree)        — bounded ``max_pattern_size`` only
+  * rolling_hash (no state)        — recomputes prefix hashes per step
+  * rolling_hash + state           — incremental, prefix hashes amortized
+
+Two scenarios are exercised:
+
+  * "random"  — pseudo-random tokens (no detection should fire)
+  * "loop"    — random prefix then a repeating tail (detection fires)
+
+Run::
+
+    .venv/bin/python benchmarks/benchmark_repetition_detection.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import sys
+import time
+import types
+
+# The local CUDA build can fail to import vllm._C on hosts that lack the
+# matching driver symbols. The detection logic is pure-Python, so stub
+# the C extension before any vllm import.
+sys.modules.setdefault("vllm._C", types.ModuleType("vllm._C"))
+
+from vllm.sampling_params import RepetitionDetectionParams  # noqa: E402
+from vllm.v1.core.sched.utils import (  # noqa: E402
+    RollingHashState,
+    check_sequence_repetition,
+)
+
+
+def _gen_stream(n: int, vocab: int, scenario: str, seed: int) -> list[int]:
+    rng = random.Random(seed)
+    if scenario == "random":
+        return [rng.randrange(vocab) for _ in range(n)]
+    if scenario == "loop":
+        prefix_len = max(0, n // 2)
+        prefix = [rng.randrange(vocab) for _ in range(prefix_len)]
+        # 64-token pattern repeated until total length n.
+        pattern = [rng.randrange(vocab) for _ in range(64)]
+        tail_len = n - prefix_len
+        tail = (pattern * ((tail_len // len(pattern)) + 1))[:tail_len]
+        return prefix + tail
+    raise ValueError(f"unknown scenario: {scenario}")
+
+
+def _bench_one(
+    label: str,
+    stream: list[int],
+    params: RepetitionDetectionParams,
+    use_state: bool,
+) -> tuple[float, int]:
+    """Simulate per-step ``check_sequence_repetition`` over the stream.
+
+    Returns ``(total_seconds, last_step_with_hit_or_n)``.
+    """
+    state: RollingHashState | None = RollingHashState() if use_state else None
+    token_ids: list[int] = []
+    hit_step = -1
+    t0 = time.perf_counter()
+    for tok in stream:
+        token_ids.append(tok)
+        # Mirror check_stop's call signature.
+        if check_sequence_repetition(token_ids, params, state=state):
+            hit_step = len(token_ids)
+            break
+    t1 = time.perf_counter()
+    return (t1 - t0, hit_step if hit_step >= 0 else len(token_ids))
+
+
+def _fmt_us(seconds: float, steps: int) -> str:
+    if steps == 0:
+        return "       n/a"
+    return f"{(seconds / steps) * 1e6:8.2f} us"
+
+
+def main() -> None:
+    p = argparse.ArgumentParser()
+    p.add_argument("--n", type=int, default=8192, help="stream length")
+    p.add_argument("--vocab", type=int, default=1000, help="effective vocab")
+    p.add_argument("--seed", type=int, default=0xC0FFEE)
+    p.add_argument(
+        "--max-pattern-size",
+        type=int,
+        default=128,
+        help=(
+            "bounded mode cap. Only used by configs that respect it. The "
+            "rolling_hash unbounded config ignores this and uses 0."
+        ),
+    )
+    p.add_argument("--min-count", type=int, default=3)
+    args = p.parse_args()
+
+    print(
+        f"# stream length n={args.n}  vocab={args.vocab}  "
+        f"min_count={args.min_count}  max_pattern_size={args.max_pattern_size}"
+    )
+    print()
+    header = (
+        f"{'scenario':<10}  {'config':<32}  {'wall':>9}  "
+        f"{'per-step':>10}  {'steps':>7}  {'hit?':>5}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    for scenario in ("random", "loop"):
+        stream = _gen_stream(args.n, args.vocab, scenario, args.seed)
+
+        configs = [
+            (
+                "naive (bounded)",
+                RepetitionDetectionParams(
+                    max_pattern_size=args.max_pattern_size,
+                    min_pattern_size=2,
+                    min_count=args.min_count,
+                    algorithm="naive",
+                ),
+                False,
+            ),
+            (
+                "rolling_hash (bounded, no state)",
+                RepetitionDetectionParams(
+                    max_pattern_size=args.max_pattern_size,
+                    min_pattern_size=2,
+                    min_count=args.min_count,
+                    algorithm="rolling_hash",
+                ),
+                False,
+            ),
+            (
+                "rolling_hash (bounded, +state)",
+                RepetitionDetectionParams(
+                    max_pattern_size=args.max_pattern_size,
+                    min_pattern_size=2,
+                    min_count=args.min_count,
+                    algorithm="rolling_hash",
+                ),
+                True,
+            ),
+            (
+                "rolling_hash (unbounded, no state)",
+                RepetitionDetectionParams(
+                    max_pattern_size=0,
+                    min_pattern_size=2,
+                    min_count=args.min_count,
+                    algorithm="rolling_hash",
+                ),
+                False,
+            ),
+            (
+                "rolling_hash (unbounded, +state)",
+                RepetitionDetectionParams(
+                    max_pattern_size=0,
+                    min_pattern_size=2,
+                    min_count=args.min_count,
+                    algorithm="rolling_hash",
+                ),
+                True,
+            ),
+        ]
+
+        for label, params, use_state in configs:
+            wall, hit_step = _bench_one(label, stream, params, use_state)
+            steps = hit_step  # number of decode steps actually executed
+            hit = "yes" if hit_step < len(stream) else "no"
+            print(
+                f"{scenario:<10}  {label:<32}  "
+                f"{wall:>7.3f}s  {_fmt_us(wall, steps):>10}  "
+                f"{steps:>7d}  {hit:>5}"
+            )
+        print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/v1/core/test_repetition_detection.py
+++ b/tests/v1/core/test_repetition_detection.py
@@ -1,122 +1,411 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import random
+
 import pytest
 
 from vllm.sampling_params import RepetitionDetectionParams, SamplingParams
-from vllm.v1.core.sched.utils import check_sequence_repetition, check_stop
+from vllm.v1.core.sched.utils import (
+    RollingHashState,
+    check_sequence_repetition,
+    check_stop,
+)
 from vllm.v1.request import Request, RequestStatus
 
 pytestmark = pytest.mark.cpu_test
 
+ALGORITHMS = ["naive", "rolling_hash"]
+
 # ============================================================================
-# UNIT TESTS - check_sequence_repetition function
+# UNIT TESTS - check_sequence_repetition function (run for both algorithms)
 # ============================================================================
 
 
+@pytest.mark.parametrize("algorithm", ALGORITHMS)
 class TestCheckSequenceRepetition:
     """Unit tests for the check_sequence_repetition function"""
 
-    def test_simple_repetition_detected(self):
+    def test_simple_repetition_detected(self, algorithm):
         """Test detection of simple repetitive patterns"""
         token_ids = [1, 2, 3, 1, 2, 3, 1, 2, 3]
         params = RepetitionDetectionParams(
             max_pattern_size=3,
             min_pattern_size=2,
             min_count=3,
+            algorithm=algorithm,
         )
         assert check_sequence_repetition(token_ids, params)
 
-    def test_repetition_below_min_count(self):
+    def test_repetition_below_min_count(self, algorithm):
         """Test that pattern below min_count is not detected"""
         token_ids = [1, 2, 3, 1, 2, 3]
         params = RepetitionDetectionParams(
             max_pattern_size=3,
             min_pattern_size=2,
             min_count=3,
+            algorithm=algorithm,
         )
         assert not check_sequence_repetition(token_ids, params)
 
-    def test_two_token_pattern(self):
+    def test_two_token_pattern(self, algorithm):
         """Test detection of 2-token patterns"""
         token_ids = [1, 2, 1, 2, 1, 2, 1, 2]
         params = RepetitionDetectionParams(
             max_pattern_size=5,
             min_pattern_size=2,
             min_count=4,
+            algorithm=algorithm,
         )
         assert check_sequence_repetition(token_ids, params)
 
-    def test_no_repetition_varied_sequence(self):
+    def test_no_repetition_varied_sequence(self, algorithm):
         """Test that non-repetitive sequences are not flagged"""
         token_ids = [1, 2, 3, 4, 5, 6, 7, 8, 9]
         params = RepetitionDetectionParams(
             max_pattern_size=5,
             min_pattern_size=2,
             min_count=2,
+            algorithm=algorithm,
         )
         assert not check_sequence_repetition(token_ids, params)
 
-    def test_partial_repetition_not_detected(self):
+    def test_partial_repetition_not_detected(self, algorithm):
         """Test that incomplete repetitions are not detected"""
         token_ids = [1, 2, 3, 1, 2, 3, 1, 2, 4]
         params = RepetitionDetectionParams(
             max_pattern_size=3,
             min_pattern_size=2,
             min_count=3,
+            algorithm=algorithm,
         )
         assert not check_sequence_repetition(token_ids, params)
 
-    def test_empty_token_list(self):
+    def test_empty_token_list(self, algorithm):
         """Test with empty token list"""
         params = RepetitionDetectionParams(
             max_pattern_size=3,
             min_pattern_size=2,
             min_count=2,
+            algorithm=algorithm,
         )
         assert not check_sequence_repetition([], params)
 
-    def test_detection_disabled_max_size_zero(self):
-        """Test that zero max_pattern_size disables detection"""
+    def test_detection_disabled_default_params(self, algorithm):
+        """Default parameters disable detection regardless of algorithm.
+
+        For 'naive' this is enforced via max_pattern_size=0; for
+        'rolling_hash' via min_count=0 (the "active" gate).
+        """
         token_ids = [1, 2, 1, 2, 1, 2]
-        params = RepetitionDetectionParams()
+        params = RepetitionDetectionParams(algorithm=algorithm)
         assert not check_sequence_repetition(token_ids, params)
 
-    def test_invalid_min_count(self):
+    def test_invalid_min_count(self, algorithm):
         """Test that min_count < 2 returns False"""
         token_ids = [1, 2, 1, 2]
-        params = RepetitionDetectionParams()
+        params = RepetitionDetectionParams(algorithm=algorithm)
         assert not check_sequence_repetition(token_ids, params)
 
-    def test_repetition_at_end_of_sequence(self):
+    def test_repetition_at_end_of_sequence(self, algorithm):
         """Test detection when repetition occurs at the end"""
         token_ids = [1, 2, 3, 4, 5, 6, 5, 6, 5, 6]
         params = RepetitionDetectionParams(
             max_pattern_size=3,
             min_pattern_size=2,
             min_count=3,
+            algorithm=algorithm,
         )
         assert check_sequence_repetition(token_ids, params)
 
-    def test_large_pattern_many_repetitions(self):
+    def test_large_pattern_many_repetitions(self, algorithm):
         """Test large pattern repeated many times"""
         token_ids = [1, 2, 3, 4, 5, 6, 7, 8] * 5
         params = RepetitionDetectionParams(
             max_pattern_size=10,
             min_pattern_size=2,
             min_count=3,
+            algorithm=algorithm,
         )
         assert check_sequence_repetition(token_ids, params)
 
 
 # ============================================================================
-# INTEGRATION TESTS - check_stop with repetition detection
+# ROLLING-HASH SPECIFIC TESTS - unbounded pattern length & equivalence
 # ============================================================================
 
 
+class TestRollingHashSpecific:
+    """Tests that exercise rolling_hash-only behavior."""
+
+    def test_rolling_hash_unbounded_detects_long_pattern(self):
+        """A pattern longer than any reasonable max_pattern_size is detected."""
+        pattern = list(range(50))  # length 50, well beyond default caps
+        token_ids = pattern * 4
+        params = RepetitionDetectionParams(
+            max_pattern_size=0,  # unbounded
+            min_pattern_size=2,
+            min_count=3,
+            algorithm="rolling_hash",
+        )
+        assert check_sequence_repetition(token_ids, params)
+
+    def test_rolling_hash_unbounded_no_false_positive(self):
+        """Unbounded mode should not flag a non-repetitive sequence."""
+        token_ids = list(range(200))
+        params = RepetitionDetectionParams(
+            max_pattern_size=0,
+            min_pattern_size=2,
+            min_count=3,
+            algorithm="rolling_hash",
+        )
+        assert not check_sequence_repetition(token_ids, params)
+
+    def test_naive_max_size_zero_still_disables(self):
+        """Backward compat: naive with max_pattern_size=0 stays disabled."""
+        pattern = list(range(50))
+        token_ids = pattern * 4
+        params = RepetitionDetectionParams(
+            max_pattern_size=0,
+            min_pattern_size=2,
+            min_count=3,
+            algorithm="naive",
+        )
+        # naive validates min_count<2 against max_pattern_size>0 only, so
+        # min_count=3 is allowed here even with max_pattern_size=0; the
+        # function must still treat it as disabled.
+        assert not check_sequence_repetition(token_ids, params)
+
+    def test_rolling_hash_capped_by_max_pattern_size(self):
+        """When set, max_pattern_size still caps rolling_hash search."""
+        # 50-length pattern, but we cap search at 10 → must NOT be detected.
+        pattern = list(range(50))
+        token_ids = pattern * 3
+        params = RepetitionDetectionParams(
+            max_pattern_size=10,
+            min_pattern_size=2,
+            min_count=3,
+            algorithm="rolling_hash",
+        )
+        assert not check_sequence_repetition(token_ids, params)
+
+    def test_invalid_algorithm_raises(self):
+        with pytest.raises(ValueError, match="algorithm"):
+            RepetitionDetectionParams(
+                max_pattern_size=3,
+                min_pattern_size=2,
+                min_count=2,
+                algorithm="bogus",
+            )
+
+
+# ============================================================================
+# EQUIVALENCE TEST - naive == rolling_hash on shared parameter ranges
+# ============================================================================
+
+
+class TestAlgorithmEquivalence:
+    """Verify rolling_hash agrees with naive whenever both are enabled."""
+
+    @pytest.mark.parametrize(
+        "token_ids,max_size,min_size,min_count",
+        [
+            ([1, 2, 3, 1, 2, 3, 1, 2, 3], 5, 1, 3),
+            ([1, 2, 3, 1, 2, 3], 5, 1, 3),
+            ([1, 2] * 10, 5, 1, 4),
+            ([1, 2, 3, 4, 5, 6, 7, 8, 9], 5, 2, 2),
+            ([1, 2, 3, 1, 2, 3, 1, 2, 4], 5, 2, 3),
+            ([1, 2, 3, 4, 5, 6, 5, 6, 5, 6], 5, 2, 3),
+            ([1, 2, 3, 4, 5, 6, 7, 8] * 5, 10, 2, 3),
+            ([10, 20, 30, 10, 20, 30], 3, 3, 2),  # boundary
+            ([7] * 20, 5, 1, 5),  # all-same
+            ([7, 7, 7, 7, 8, 9], 5, 1, 3),  # repetition broken at tail
+            (list(range(30)) + [1, 2, 1, 2, 1, 2, 1, 2], 5, 2, 4),
+        ],
+    )
+    def test_table(self, token_ids, max_size, min_size, min_count):
+        naive_params = RepetitionDetectionParams(
+            max_pattern_size=max_size,
+            min_pattern_size=min_size,
+            min_count=min_count,
+            algorithm="naive",
+        )
+        rh_params = RepetitionDetectionParams(
+            max_pattern_size=max_size,
+            min_pattern_size=min_size,
+            min_count=min_count,
+            algorithm="rolling_hash",
+        )
+        assert check_sequence_repetition(
+            token_ids, naive_params
+        ) == check_sequence_repetition(token_ids, rh_params), (
+            f"disagreement for {token_ids=} {max_size=} {min_size=} {min_count=}"
+        )
+
+    def test_random_equivalence(self):
+        """Fuzz: rolling_hash must match naive across many random inputs."""
+        rng = random.Random(0xC0FFEE)
+        for _ in range(2000):
+            length = rng.randint(0, 60)
+            vocab = rng.randint(2, 6)
+            token_ids = [rng.randrange(vocab) for _ in range(length)]
+            max_size = rng.randint(1, 10)
+            min_size = rng.randint(1, max_size)
+            min_count = rng.randint(2, 5)
+            naive = RepetitionDetectionParams(
+                max_pattern_size=max_size,
+                min_pattern_size=min_size,
+                min_count=min_count,
+                algorithm="naive",
+            )
+            rh = RepetitionDetectionParams(
+                max_pattern_size=max_size,
+                min_pattern_size=min_size,
+                min_count=min_count,
+                algorithm="rolling_hash",
+            )
+            naive_out = check_sequence_repetition(token_ids, naive)
+            rh_out = check_sequence_repetition(token_ids, rh)
+            assert naive_out == rh_out, (
+                f"disagreement: {token_ids=} max={max_size} "
+                f"min={min_size} count={min_count} "
+                f"naive={naive_out} rh={rh_out}"
+            )
+
+
+# ============================================================================
+# INCREMENTAL STATE TESTS - rolling-hash state survives across calls
+# ============================================================================
+
+
+class TestRollingHashIncrementalState:
+    """Verify the incremental ``RollingHashState`` produces the same
+    detection result as a one-shot recomputation, and that the state
+    grows append-only as decoding progresses."""
+
+    def test_state_grows_append_only(self):
+        rng = random.Random(0xBEEF)
+        token_ids: list[int] = []
+        params = RepetitionDetectionParams(
+            max_pattern_size=0,  # unbounded
+            min_pattern_size=2,
+            min_count=3,
+            algorithm="rolling_hash",
+        )
+        state = RollingHashState()
+
+        # Stream 200 random tokens, then a 12-token repeating pattern
+        # 4 times — detection must fire late, never before.
+        steps_until_detect = []
+        flagged_step = None
+        pattern = [rng.randrange(50) for _ in range(12)]
+        for step in range(1, 201):
+            token_ids.append(rng.randrange(50))
+            assert state.n == step - 1, "state must lag tokens by one"
+            hit = check_sequence_repetition(token_ids, params, state=state)
+            assert state.n == step
+            if hit and flagged_step is None:
+                flagged_step = step
+        # Random stream: very unlikely to flag (with 50-vocab there is a
+        # tiny chance, but with this seed it shouldn't).
+        steps_until_detect.append(flagged_step)
+
+        for rep in range(4):
+            for tok in pattern:
+                token_ids.append(tok)
+                hit = check_sequence_repetition(token_ids, params, state=state)
+                if hit:
+                    # Once detected, state is still consistent.
+                    assert state.n == len(token_ids)
+                    break
+            if hit:
+                break
+        assert hit, "12-token pattern repeated 3+ times must trigger"
+
+    def test_state_matches_recompute(self):
+        """For the same token stream, incremental == recompute, step by step."""
+        rng = random.Random(123)
+        token_ids: list[int] = []
+        params = RepetitionDetectionParams(
+            max_pattern_size=0,
+            min_pattern_size=1,
+            min_count=3,
+            algorithm="rolling_hash",
+        )
+        state = RollingHashState()
+        # Build a stream that will hit detection partway through.
+        prefix = [rng.randrange(20) for _ in range(40)]
+        tail = [4, 7, 9] * 5
+        stream = prefix + tail
+
+        for tok in stream:
+            token_ids.append(tok)
+            inc = check_sequence_repetition(token_ids, params, state=state)
+            recomp = check_sequence_repetition(token_ids, params)
+            assert inc == recomp, (
+                f"step {len(token_ids)}: incremental={inc} recompute={recomp}"
+            )
+
+    def test_check_stop_persists_state_on_request(self):
+        """``check_stop`` lazily attaches RollingHashState to the request and
+        reuses it across consecutive calls."""
+        params = SamplingParams(
+            max_tokens=200,
+            repetition_detection=RepetitionDetectionParams(
+                max_pattern_size=0,
+                min_pattern_size=2,
+                min_count=3,
+                algorithm="rolling_hash",
+            ),
+        )
+        request = Request(
+            request_id="test",
+            prompt_token_ids=[1, 2, 3],
+            sampling_params=params,
+            pooling_params=None,
+        )
+        # No state until the first check_stop call.
+        assert request.repetition_hash_state is None
+        request.append_output_token_ids([10, 11, 12, 13, 14])
+        assert not check_stop(request, max_model_len=2048)
+        first_state = request.repetition_hash_state
+        assert isinstance(first_state, RollingHashState)
+        assert first_state.n == 5
+        # Subsequent decode steps reuse the same state object and grow it.
+        request.append_output_token_ids([15])
+        assert not check_stop(request, max_model_len=2048)
+        assert request.repetition_hash_state is first_state
+        assert first_state.n == 6
+        # Naive algorithm path must not allocate state.
+        params2 = SamplingParams(
+            max_tokens=200,
+            repetition_detection=RepetitionDetectionParams(
+                max_pattern_size=4,
+                min_pattern_size=2,
+                min_count=3,
+                algorithm="naive",
+            ),
+        )
+        req2 = Request(
+            request_id="test2",
+            prompt_token_ids=[1],
+            sampling_params=params2,
+            pooling_params=None,
+        )
+        req2.append_output_token_ids([5, 6, 7])
+        assert not check_stop(req2, max_model_len=2048)
+        assert req2.repetition_hash_state is None
+
+
+# ============================================================================
+# INTEGRATION TESTS - check_stop with repetition detection (both algorithms)
+# ============================================================================
+
+
+@pytest.mark.parametrize("algorithm", ALGORITHMS)
 class TestRepetitionDetectionIntegration:
     """Integration tests for repetition detection in check_stop"""
 
-    def test_basic_repetition_stops_generation(self):
+    def test_basic_repetition_stops_generation(self, algorithm):
         """Test that repetition is detected and stops generation"""
         params = SamplingParams(
             max_tokens=100,
@@ -124,6 +413,7 @@ class TestRepetitionDetectionIntegration:
                 max_pattern_size=5,
                 min_pattern_size=2,
                 min_count=3,
+                algorithm=algorithm,
             ),
         )
         request = Request(
@@ -137,7 +427,7 @@ class TestRepetitionDetectionIntegration:
         assert request.status == RequestStatus.FINISHED_REPETITION
         assert request.stop_reason == "repetition_detected"
 
-    def test_detection_disabled_no_stop(self):
+    def test_detection_disabled_no_stop(self, algorithm):
         """Test that disabled detection doesn't stop generation"""
         params = SamplingParams(
             max_tokens=100,
@@ -151,7 +441,7 @@ class TestRepetitionDetectionIntegration:
         request.append_output_token_ids([10, 20, 10, 20, 10, 20])
         assert not check_stop(request, max_model_len=1024)
 
-    def test_repetition_respects_min_tokens(self):
+    def test_repetition_respects_min_tokens(self, algorithm):
         """Test that repetition detection respects min_tokens"""
         params = SamplingParams(
             min_tokens=10,
@@ -160,6 +450,7 @@ class TestRepetitionDetectionIntegration:
                 max_pattern_size=5,
                 min_pattern_size=2,
                 min_count=3,
+                algorithm=algorithm,
             ),
         )
         request = Request(
@@ -171,7 +462,7 @@ class TestRepetitionDetectionIntegration:
         request.append_output_token_ids([10, 20, 10, 20, 10, 20])
         assert not check_stop(request, max_model_len=1024)
 
-    def test_no_repetition_continues_generation(self):
+    def test_no_repetition_continues_generation(self, algorithm):
         """Test that non-repetitive tokens don't stop generation"""
         params = SamplingParams(
             max_tokens=100,
@@ -179,6 +470,7 @@ class TestRepetitionDetectionIntegration:
                 max_pattern_size=5,
                 min_pattern_size=2,
                 min_count=3,
+                algorithm=algorithm,
             ),
         )
         request = Request(
@@ -190,7 +482,7 @@ class TestRepetitionDetectionIntegration:
         request.append_output_token_ids([10, 20, 30, 40, 50, 60])
         assert not check_stop(request, max_model_len=1024)
 
-    def test_pattern_at_size_boundary(self):
+    def test_pattern_at_size_boundary(self, algorithm):
         """Test detection at exact pattern size boundary"""
         params = SamplingParams(
             max_tokens=100,
@@ -198,6 +490,7 @@ class TestRepetitionDetectionIntegration:
                 max_pattern_size=3,
                 min_pattern_size=3,
                 min_count=2,
+                algorithm=algorithm,
             ),
         )
         request = Request(
@@ -210,7 +503,7 @@ class TestRepetitionDetectionIntegration:
         assert check_stop(request, max_model_len=1024)
         assert request.status == RequestStatus.FINISHED_REPETITION
 
-    def test_multiple_pattern_sizes_checked(self):
+    def test_multiple_pattern_sizes_checked(self, algorithm):
         """Test that function checks pattern sizes in range"""
         params = SamplingParams(
             max_tokens=100,
@@ -218,6 +511,7 @@ class TestRepetitionDetectionIntegration:
                 max_pattern_size=5,
                 min_pattern_size=2,
                 min_count=3,
+                algorithm=algorithm,
             ),
         )
         request = Request(
@@ -230,7 +524,7 @@ class TestRepetitionDetectionIntegration:
         assert check_stop(request, max_model_len=1024)
         assert request.status == RequestStatus.FINISHED_REPETITION
 
-    def test_eos_takes_precedence_over_repetition(self):
+    def test_eos_takes_precedence_over_repetition(self, algorithm):
         """Test that EOS token stops before repetition check"""
         params = SamplingParams(
             max_tokens=100,
@@ -239,6 +533,7 @@ class TestRepetitionDetectionIntegration:
                 max_pattern_size=5,
                 min_pattern_size=2,
                 min_count=3,
+                algorithm=algorithm,
             ),
         )
         request = Request(
@@ -251,7 +546,7 @@ class TestRepetitionDetectionIntegration:
         assert check_stop(request, max_model_len=1024)
         assert request.status == RequestStatus.FINISHED_STOPPED
 
-    def test_min_pattern_size_filters_small_patterns(self):
+    def test_min_pattern_size_filters_small_patterns(self, algorithm):
         """Test that min_pattern_size filters out smaller patterns"""
         params = SamplingParams(
             max_tokens=100,
@@ -259,6 +554,7 @@ class TestRepetitionDetectionIntegration:
                 max_pattern_size=5,
                 min_pattern_size=3,
                 min_count=3,
+                algorithm=algorithm,
             ),
         )
         request = Request(
@@ -270,7 +566,7 @@ class TestRepetitionDetectionIntegration:
         request.append_output_token_ids([10, 20, 10, 20, 10, 20])
         assert not check_stop(request, max_model_len=1024)
 
-    def test_high_repetition_threshold(self):
+    def test_high_repetition_threshold(self, algorithm):
         """Test that high min_count requires many repetitions"""
         params = SamplingParams(
             max_tokens=100,
@@ -278,6 +574,7 @@ class TestRepetitionDetectionIntegration:
                 max_pattern_size=5,
                 min_pattern_size=2,
                 min_count=5,
+                algorithm=algorithm,
             ),
         )
         request = Request(

--- a/tests/v1/core/test_repetition_detection.py
+++ b/tests/v1/core/test_repetition_detection.py
@@ -345,6 +345,51 @@ class TestRollingHashIncrementalState:
                 f"step {len(token_ids)}: incremental={inc} recompute={recomp}"
             )
 
+    def test_state_handles_truncation(self):
+        """Speculative-decode rollback: when ``token_ids`` shrinks, the
+        state must drop trailing hashes so subsequent appends compute
+        from the surviving prefix, not the rolled-back tail.
+        """
+        params = RepetitionDetectionParams(
+            max_pattern_size=0,
+            min_pattern_size=2,
+            min_count=3,
+            algorithm="rolling_hash",
+        )
+        state = RollingHashState()
+
+        # Hash a 10-token sequence (simulating speculative tokens that
+        # initially looked accepted but get rolled back).
+        initial = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        check_sequence_repetition(initial, params, state=state)
+        assert state.n == len(initial)
+
+        # Roll back to 6 tokens (4 speculative tokens rejected).
+        truncated = initial[:6]
+        check_sequence_repetition(truncated, params, state=state)
+        assert state.n == 6
+        # The kept prefix hashes must equal what a fresh state would
+        # produce for the same prefix — verify by comparing against a
+        # one-shot recompute on the truncated sequence.
+        recompute_truncated = check_sequence_repetition(truncated, params)
+        incremental_truncated = check_sequence_repetition(
+            truncated, params, state=RollingHashState()
+        )
+        assert recompute_truncated == incremental_truncated
+
+        # Re-extend with a *different* tail (would produce wrong hashes
+        # if truncation hadn't dropped the rejected tokens).
+        replayed = truncated + [99, 99, 99, 99, 99, 99]
+        inc = check_sequence_repetition(replayed, params, state=state)
+        assert state.n == len(replayed)
+        recomp = check_sequence_repetition(replayed, params)
+        assert inc == recomp, (
+            f"truncation path diverged: incremental={inc} recompute={recomp}"
+        )
+        # The all-99 tail should trigger detection (5 reps of length-1
+        # pattern).
+        assert inc
+
     def test_check_stop_persists_state_on_request(self):
         """``check_stop`` lazily attaches RollingHashState to the request and
         reuses it across consecutive calls."""

--- a/tests/v1/core/test_repetition_detection.py
+++ b/tests/v1/core/test_repetition_detection.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import random
-
 import pytest
 
 from vllm.sampling_params import RepetitionDetectionParams, SamplingParams
@@ -14,317 +12,152 @@ from vllm.v1.request import Request, RequestStatus
 
 pytestmark = pytest.mark.cpu_test
 
-ALGORITHMS = ["naive", "rolling_hash"]
-
 # ============================================================================
-# UNIT TESTS - check_sequence_repetition function (run for both algorithms)
+# UNIT TESTS - check_sequence_repetition function
 # ============================================================================
 
 
-@pytest.mark.parametrize("algorithm", ALGORITHMS)
 class TestCheckSequenceRepetition:
     """Unit tests for the check_sequence_repetition function"""
 
-    def test_simple_repetition_detected(self, algorithm):
+    def test_simple_repetition_detected(self):
         """Test detection of simple repetitive patterns"""
         token_ids = [1, 2, 3, 1, 2, 3, 1, 2, 3]
         params = RepetitionDetectionParams(
             max_pattern_size=3,
             min_pattern_size=2,
             min_count=3,
-            algorithm=algorithm,
         )
         assert check_sequence_repetition(token_ids, params)
 
-    def test_repetition_below_min_count(self, algorithm):
+    def test_repetition_below_min_count(self):
         """Test that pattern below min_count is not detected"""
         token_ids = [1, 2, 3, 1, 2, 3]
         params = RepetitionDetectionParams(
             max_pattern_size=3,
             min_pattern_size=2,
             min_count=3,
-            algorithm=algorithm,
         )
         assert not check_sequence_repetition(token_ids, params)
 
-    def test_two_token_pattern(self, algorithm):
+    def test_two_token_pattern(self):
         """Test detection of 2-token patterns"""
         token_ids = [1, 2, 1, 2, 1, 2, 1, 2]
         params = RepetitionDetectionParams(
             max_pattern_size=5,
             min_pattern_size=2,
             min_count=4,
-            algorithm=algorithm,
         )
         assert check_sequence_repetition(token_ids, params)
 
-    def test_no_repetition_varied_sequence(self, algorithm):
+    def test_no_repetition_varied_sequence(self):
         """Test that non-repetitive sequences are not flagged"""
         token_ids = [1, 2, 3, 4, 5, 6, 7, 8, 9]
         params = RepetitionDetectionParams(
             max_pattern_size=5,
             min_pattern_size=2,
             min_count=2,
-            algorithm=algorithm,
         )
         assert not check_sequence_repetition(token_ids, params)
 
-    def test_partial_repetition_not_detected(self, algorithm):
+    def test_partial_repetition_not_detected(self):
         """Test that incomplete repetitions are not detected"""
         token_ids = [1, 2, 3, 1, 2, 3, 1, 2, 4]
         params = RepetitionDetectionParams(
             max_pattern_size=3,
             min_pattern_size=2,
             min_count=3,
-            algorithm=algorithm,
         )
         assert not check_sequence_repetition(token_ids, params)
 
-    def test_empty_token_list(self, algorithm):
+    def test_empty_token_list(self):
         """Test with empty token list"""
         params = RepetitionDetectionParams(
             max_pattern_size=3,
             min_pattern_size=2,
             min_count=2,
-            algorithm=algorithm,
         )
         assert not check_sequence_repetition([], params)
 
-    def test_detection_disabled_default_params(self, algorithm):
-        """Default parameters disable detection regardless of algorithm.
-
-        For 'naive' this is enforced via max_pattern_size=0; for
-        'rolling_hash' via min_count=0 (the "active" gate).
-        """
+    def test_detection_disabled_max_size_zero(self):
+        """Test that zero max_pattern_size disables detection"""
         token_ids = [1, 2, 1, 2, 1, 2]
-        params = RepetitionDetectionParams(algorithm=algorithm)
+        params = RepetitionDetectionParams()
         assert not check_sequence_repetition(token_ids, params)
 
-    def test_invalid_min_count(self, algorithm):
+    def test_invalid_min_count(self):
         """Test that min_count < 2 returns False"""
         token_ids = [1, 2, 1, 2]
-        params = RepetitionDetectionParams(algorithm=algorithm)
+        params = RepetitionDetectionParams()
         assert not check_sequence_repetition(token_ids, params)
 
-    def test_repetition_at_end_of_sequence(self, algorithm):
+    def test_repetition_at_end_of_sequence(self):
         """Test detection when repetition occurs at the end"""
         token_ids = [1, 2, 3, 4, 5, 6, 5, 6, 5, 6]
         params = RepetitionDetectionParams(
             max_pattern_size=3,
             min_pattern_size=2,
             min_count=3,
-            algorithm=algorithm,
         )
         assert check_sequence_repetition(token_ids, params)
 
-    def test_large_pattern_many_repetitions(self, algorithm):
+    def test_large_pattern_many_repetitions(self):
         """Test large pattern repeated many times"""
         token_ids = [1, 2, 3, 4, 5, 6, 7, 8] * 5
         params = RepetitionDetectionParams(
             max_pattern_size=10,
             min_pattern_size=2,
             min_count=3,
-            algorithm=algorithm,
         )
         assert check_sequence_repetition(token_ids, params)
 
 
 # ============================================================================
-# ROLLING-HASH SPECIFIC TESTS - unbounded pattern length & equivalence
+# ROLLING-HASH ALGORITHM
 # ============================================================================
 
 
-class TestRollingHashSpecific:
-    """Tests that exercise rolling_hash-only behavior."""
+class TestRollingHash:
+    """Tests for the rolling_hash algorithm and its incremental state."""
 
-    def test_rolling_hash_unbounded_detects_long_pattern(self):
-        """A pattern longer than any reasonable max_pattern_size is detected."""
-        pattern = list(range(50))  # length 50, well beyond default caps
-        token_ids = pattern * 4
-        params = RepetitionDetectionParams(
-            max_pattern_size=0,  # unbounded
-            min_pattern_size=2,
-            min_count=3,
-            algorithm="rolling_hash",
-        )
-        assert check_sequence_repetition(token_ids, params)
-
-    def test_rolling_hash_unbounded_no_false_positive(self):
-        """Unbounded mode should not flag a non-repetitive sequence."""
-        token_ids = list(range(200))
-        params = RepetitionDetectionParams(
-            max_pattern_size=0,
-            min_pattern_size=2,
-            min_count=3,
-            algorithm="rolling_hash",
-        )
-        assert not check_sequence_repetition(token_ids, params)
-
-    def test_naive_max_size_zero_still_disables(self):
-        """Backward compat: naive with max_pattern_size=0 stays disabled."""
-        pattern = list(range(50))
-        token_ids = pattern * 4
-        params = RepetitionDetectionParams(
-            max_pattern_size=0,
-            min_pattern_size=2,
-            min_count=3,
-            algorithm="naive",
-        )
-        # naive validates min_count<2 against max_pattern_size>0 only, so
-        # min_count=3 is allowed here even with max_pattern_size=0; the
-        # function must still treat it as disabled.
-        assert not check_sequence_repetition(token_ids, params)
-
-    def test_rolling_hash_capped_by_max_pattern_size(self):
-        """When set, max_pattern_size still caps rolling_hash search."""
-        # 50-length pattern, but we cap search at 10 → must NOT be detected.
-        pattern = list(range(50))
-        token_ids = pattern * 3
-        params = RepetitionDetectionParams(
-            max_pattern_size=10,
-            min_pattern_size=2,
-            min_count=3,
-            algorithm="rolling_hash",
-        )
-        assert not check_sequence_repetition(token_ids, params)
-
-    def test_invalid_algorithm_raises(self):
-        with pytest.raises(ValueError, match="algorithm"):
-            RepetitionDetectionParams(
-                max_pattern_size=3,
-                min_pattern_size=2,
-                min_count=2,
-                algorithm="bogus",
-            )
-
-
-# ============================================================================
-# EQUIVALENCE TEST - naive == rolling_hash on shared parameter ranges
-# ============================================================================
-
-
-class TestAlgorithmEquivalence:
-    """Verify rolling_hash agrees with naive whenever both are enabled."""
-
-    @pytest.mark.parametrize(
-        "token_ids,max_size,min_size,min_count",
-        [
-            ([1, 2, 3, 1, 2, 3, 1, 2, 3], 5, 1, 3),
-            ([1, 2, 3, 1, 2, 3], 5, 1, 3),
-            ([1, 2] * 10, 5, 1, 4),
-            ([1, 2, 3, 4, 5, 6, 7, 8, 9], 5, 2, 2),
-            ([1, 2, 3, 1, 2, 3, 1, 2, 4], 5, 2, 3),
-            ([1, 2, 3, 4, 5, 6, 5, 6, 5, 6], 5, 2, 3),
-            ([1, 2, 3, 4, 5, 6, 7, 8] * 5, 10, 2, 3),
-            ([10, 20, 30, 10, 20, 30], 3, 3, 2),  # boundary
-            ([7] * 20, 5, 1, 5),  # all-same
-            ([7, 7, 7, 7, 8, 9], 5, 1, 3),  # repetition broken at tail
-            (list(range(30)) + [1, 2, 1, 2, 1, 2, 1, 2], 5, 2, 4),
-        ],
-    )
-    def test_table(self, token_ids, max_size, min_size, min_count):
-        naive_params = RepetitionDetectionParams(
-            max_pattern_size=max_size,
-            min_pattern_size=min_size,
-            min_count=min_count,
-            algorithm="naive",
-        )
-        rh_params = RepetitionDetectionParams(
-            max_pattern_size=max_size,
-            min_pattern_size=min_size,
-            min_count=min_count,
-            algorithm="rolling_hash",
-        )
-        assert check_sequence_repetition(
-            token_ids, naive_params
-        ) == check_sequence_repetition(token_ids, rh_params), (
-            f"disagreement for {token_ids=} {max_size=} {min_size=} {min_count=}"
-        )
-
-    def test_random_equivalence(self):
-        """Fuzz: rolling_hash must match naive across many random inputs."""
-        rng = random.Random(0xC0FFEE)
-        for _ in range(2000):
-            length = rng.randint(0, 60)
-            vocab = rng.randint(2, 6)
-            token_ids = [rng.randrange(vocab) for _ in range(length)]
-            max_size = rng.randint(1, 10)
-            min_size = rng.randint(1, max_size)
-            min_count = rng.randint(2, 5)
+    def test_matches_naive_on_shared_inputs(self):
+        """rolling_hash and naive must agree whenever both are enabled."""
+        cases = [
+            ([1, 2, 3, 1, 2, 3, 1, 2, 3], 5, 1, 3, True),
+            ([1, 2, 3, 1, 2, 3], 5, 1, 3, False),
+            ([1, 2] * 10, 5, 1, 4, True),
+            ([1, 2, 3, 4, 5, 6, 7, 8, 9], 5, 2, 2, False),
+            ([7] * 20, 5, 1, 5, True),
+        ]
+        for tokens, mx, mn, k, expected in cases:
             naive = RepetitionDetectionParams(
-                max_pattern_size=max_size,
-                min_pattern_size=min_size,
-                min_count=min_count,
-                algorithm="naive",
+                max_pattern_size=mx, min_pattern_size=mn, min_count=k
             )
             rh = RepetitionDetectionParams(
-                max_pattern_size=max_size,
-                min_pattern_size=min_size,
-                min_count=min_count,
+                max_pattern_size=mx,
+                min_pattern_size=mn,
+                min_count=k,
                 algorithm="rolling_hash",
             )
-            naive_out = check_sequence_repetition(token_ids, naive)
-            rh_out = check_sequence_repetition(token_ids, rh)
-            assert naive_out == rh_out, (
-                f"disagreement: {token_ids=} max={max_size} "
-                f"min={min_size} count={min_count} "
-                f"naive={naive_out} rh={rh_out}"
-            )
+            assert check_sequence_repetition(tokens, naive) is expected
+            assert check_sequence_repetition(tokens, rh) is expected
 
-
-# ============================================================================
-# INCREMENTAL STATE TESTS - rolling-hash state survives across calls
-# ============================================================================
-
-
-class TestRollingHashIncrementalState:
-    """Verify the incremental ``RollingHashState`` produces the same
-    detection result as a one-shot recomputation, and that the state
-    grows append-only as decoding progresses."""
-
-    def test_state_grows_append_only(self):
-        rng = random.Random(0xBEEF)
-        token_ids: list[int] = []
+    def test_unbounded_detects_long_pattern(self):
+        """max_pattern_size=0 in rolling_hash mode catches long patterns
+        that the bounded naive scan would miss."""
+        pattern = list(range(50))  # length 50, beyond a typical naive cap
+        token_ids = pattern * 4
         params = RepetitionDetectionParams(
-            max_pattern_size=0,  # unbounded
+            max_pattern_size=0,
             min_pattern_size=2,
             min_count=3,
             algorithm="rolling_hash",
         )
-        state = RollingHashState()
-
-        # Stream 200 random tokens, then a 12-token repeating pattern
-        # 4 times — detection must fire late, never before.
-        steps_until_detect = []
-        flagged_step = None
-        pattern = [rng.randrange(50) for _ in range(12)]
-        for step in range(1, 201):
-            token_ids.append(rng.randrange(50))
-            assert state.n == step - 1, "state must lag tokens by one"
-            hit = check_sequence_repetition(token_ids, params, state=state)
-            assert state.n == step
-            if hit and flagged_step is None:
-                flagged_step = step
-        # Random stream: very unlikely to flag (with 50-vocab there is a
-        # tiny chance, but with this seed it shouldn't).
-        steps_until_detect.append(flagged_step)
-
-        for rep in range(4):
-            for tok in pattern:
-                token_ids.append(tok)
-                hit = check_sequence_repetition(token_ids, params, state=state)
-                if hit:
-                    # Once detected, state is still consistent.
-                    assert state.n == len(token_ids)
-                    break
-            if hit:
-                break
-        assert hit, "12-token pattern repeated 3+ times must trigger"
+        assert check_sequence_repetition(token_ids, params)
 
     def test_state_matches_recompute(self):
-        """For the same token stream, incremental == recompute, step by step."""
-        rng = random.Random(123)
-        token_ids: list[int] = []
+        """Incremental state must produce the same result as a one-shot
+        recompute, step by step."""
         params = RepetitionDetectionParams(
             max_pattern_size=0,
             min_pattern_size=1,
@@ -332,24 +165,17 @@ class TestRollingHashIncrementalState:
             algorithm="rolling_hash",
         )
         state = RollingHashState()
-        # Build a stream that will hit detection partway through.
-        prefix = [rng.randrange(20) for _ in range(40)]
-        tail = [4, 7, 9] * 5
-        stream = prefix + tail
-
-        for tok in stream:
+        token_ids: list[int] = []
+        for tok in [1, 5, 9, 2, 7, 3, 4, 7, 3, 4, 7, 3, 4]:
             token_ids.append(tok)
             inc = check_sequence_repetition(token_ids, params, state=state)
             recomp = check_sequence_repetition(token_ids, params)
-            assert inc == recomp, (
-                f"step {len(token_ids)}: incremental={inc} recompute={recomp}"
-            )
+            assert inc == recomp
+            assert state.n == len(token_ids)
 
     def test_state_handles_truncation(self):
-        """Speculative-decode rollback: when ``token_ids`` shrinks, the
-        state must drop trailing hashes so subsequent appends compute
-        from the surviving prefix, not the rolled-back tail.
-        """
+        """Speculative-decode rollback: when token_ids shrinks, state
+        drops trailing hashes so the next append is correct."""
         params = RepetitionDetectionParams(
             max_pattern_size=0,
             min_pattern_size=2,
@@ -357,43 +183,21 @@ class TestRollingHashIncrementalState:
             algorithm="rolling_hash",
         )
         state = RollingHashState()
-
-        # Hash a 10-token sequence (simulating speculative tokens that
-        # initially looked accepted but get rolled back).
-        initial = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
-        check_sequence_repetition(initial, params, state=state)
-        assert state.n == len(initial)
-
-        # Roll back to 6 tokens (4 speculative tokens rejected).
-        truncated = initial[:6]
-        check_sequence_repetition(truncated, params, state=state)
+        check_sequence_repetition([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], params, state=state)
+        assert state.n == 10
+        # Roll back 4 tokens then re-extend with a different tail.
+        replayed = [1, 2, 3, 4, 5, 6, 99, 99, 99, 99, 99, 99]
+        check_sequence_repetition(replayed[:6], params, state=state)
         assert state.n == 6
-        # The kept prefix hashes must equal what a fresh state would
-        # produce for the same prefix — verify by comparing against a
-        # one-shot recompute on the truncated sequence.
-        recompute_truncated = check_sequence_repetition(truncated, params)
-        incremental_truncated = check_sequence_repetition(
-            truncated, params, state=RollingHashState()
-        )
-        assert recompute_truncated == incremental_truncated
-
-        # Re-extend with a *different* tail (would produce wrong hashes
-        # if truncation hadn't dropped the rejected tokens).
-        replayed = truncated + [99, 99, 99, 99, 99, 99]
         inc = check_sequence_repetition(replayed, params, state=state)
-        assert state.n == len(replayed)
         recomp = check_sequence_repetition(replayed, params)
-        assert inc == recomp, (
-            f"truncation path diverged: incremental={inc} recompute={recomp}"
-        )
-        # The all-99 tail should trigger detection (5 reps of length-1
-        # pattern).
-        assert inc
+        assert inc == recomp
+        assert inc  # all-99 tail triggers detection
 
-    def test_check_stop_persists_state_on_request(self):
-        """``check_stop`` lazily attaches RollingHashState to the request and
-        reuses it across consecutive calls."""
-        params = SamplingParams(
+    def test_check_stop_attaches_state(self):
+        """check_stop lazily allocates RollingHashState on first call,
+        only for algorithm='rolling_hash'."""
+        rh_params = SamplingParams(
             max_tokens=200,
             repetition_detection=RepetitionDetectionParams(
                 max_pattern_size=0,
@@ -402,55 +206,43 @@ class TestRollingHashIncrementalState:
                 algorithm="rolling_hash",
             ),
         )
-        request = Request(
-            request_id="test",
+        rh_request = Request(
+            request_id="rh",
             prompt_token_ids=[1, 2, 3],
-            sampling_params=params,
+            sampling_params=rh_params,
             pooling_params=None,
         )
-        # No state until the first check_stop call.
-        assert request.repetition_hash_state is None
-        request.append_output_token_ids([10, 11, 12, 13, 14])
-        assert not check_stop(request, max_model_len=2048)
-        first_state = request.repetition_hash_state
-        assert isinstance(first_state, RollingHashState)
-        assert first_state.n == 5
-        # Subsequent decode steps reuse the same state object and grow it.
-        request.append_output_token_ids([15])
-        assert not check_stop(request, max_model_len=2048)
-        assert request.repetition_hash_state is first_state
-        assert first_state.n == 6
-        # Naive algorithm path must not allocate state.
-        params2 = SamplingParams(
+        assert rh_request.repetition_hash_state is None
+        rh_request.append_output_token_ids([10, 11, 12])
+        assert not check_stop(rh_request, max_model_len=2048)
+        assert isinstance(rh_request.repetition_hash_state, RollingHashState)
+
+        naive_params = SamplingParams(
             max_tokens=200,
             repetition_detection=RepetitionDetectionParams(
-                max_pattern_size=4,
-                min_pattern_size=2,
-                min_count=3,
-                algorithm="naive",
+                max_pattern_size=4, min_pattern_size=2, min_count=3
             ),
         )
-        req2 = Request(
-            request_id="test2",
+        naive_request = Request(
+            request_id="naive",
             prompt_token_ids=[1],
-            sampling_params=params2,
+            sampling_params=naive_params,
             pooling_params=None,
         )
-        req2.append_output_token_ids([5, 6, 7])
-        assert not check_stop(req2, max_model_len=2048)
-        assert req2.repetition_hash_state is None
+        naive_request.append_output_token_ids([5, 6, 7])
+        assert not check_stop(naive_request, max_model_len=2048)
+        assert naive_request.repetition_hash_state is None
 
 
 # ============================================================================
-# INTEGRATION TESTS - check_stop with repetition detection (both algorithms)
+# INTEGRATION TESTS - check_stop with repetition detection
 # ============================================================================
 
 
-@pytest.mark.parametrize("algorithm", ALGORITHMS)
 class TestRepetitionDetectionIntegration:
     """Integration tests for repetition detection in check_stop"""
 
-    def test_basic_repetition_stops_generation(self, algorithm):
+    def test_basic_repetition_stops_generation(self):
         """Test that repetition is detected and stops generation"""
         params = SamplingParams(
             max_tokens=100,
@@ -458,7 +250,6 @@ class TestRepetitionDetectionIntegration:
                 max_pattern_size=5,
                 min_pattern_size=2,
                 min_count=3,
-                algorithm=algorithm,
             ),
         )
         request = Request(
@@ -472,7 +263,7 @@ class TestRepetitionDetectionIntegration:
         assert request.status == RequestStatus.FINISHED_REPETITION
         assert request.stop_reason == "repetition_detected"
 
-    def test_detection_disabled_no_stop(self, algorithm):
+    def test_detection_disabled_no_stop(self):
         """Test that disabled detection doesn't stop generation"""
         params = SamplingParams(
             max_tokens=100,
@@ -486,7 +277,7 @@ class TestRepetitionDetectionIntegration:
         request.append_output_token_ids([10, 20, 10, 20, 10, 20])
         assert not check_stop(request, max_model_len=1024)
 
-    def test_repetition_respects_min_tokens(self, algorithm):
+    def test_repetition_respects_min_tokens(self):
         """Test that repetition detection respects min_tokens"""
         params = SamplingParams(
             min_tokens=10,
@@ -495,7 +286,6 @@ class TestRepetitionDetectionIntegration:
                 max_pattern_size=5,
                 min_pattern_size=2,
                 min_count=3,
-                algorithm=algorithm,
             ),
         )
         request = Request(
@@ -507,7 +297,7 @@ class TestRepetitionDetectionIntegration:
         request.append_output_token_ids([10, 20, 10, 20, 10, 20])
         assert not check_stop(request, max_model_len=1024)
 
-    def test_no_repetition_continues_generation(self, algorithm):
+    def test_no_repetition_continues_generation(self):
         """Test that non-repetitive tokens don't stop generation"""
         params = SamplingParams(
             max_tokens=100,
@@ -515,7 +305,6 @@ class TestRepetitionDetectionIntegration:
                 max_pattern_size=5,
                 min_pattern_size=2,
                 min_count=3,
-                algorithm=algorithm,
             ),
         )
         request = Request(
@@ -527,7 +316,7 @@ class TestRepetitionDetectionIntegration:
         request.append_output_token_ids([10, 20, 30, 40, 50, 60])
         assert not check_stop(request, max_model_len=1024)
 
-    def test_pattern_at_size_boundary(self, algorithm):
+    def test_pattern_at_size_boundary(self):
         """Test detection at exact pattern size boundary"""
         params = SamplingParams(
             max_tokens=100,
@@ -535,7 +324,6 @@ class TestRepetitionDetectionIntegration:
                 max_pattern_size=3,
                 min_pattern_size=3,
                 min_count=2,
-                algorithm=algorithm,
             ),
         )
         request = Request(
@@ -548,7 +336,7 @@ class TestRepetitionDetectionIntegration:
         assert check_stop(request, max_model_len=1024)
         assert request.status == RequestStatus.FINISHED_REPETITION
 
-    def test_multiple_pattern_sizes_checked(self, algorithm):
+    def test_multiple_pattern_sizes_checked(self):
         """Test that function checks pattern sizes in range"""
         params = SamplingParams(
             max_tokens=100,
@@ -556,7 +344,6 @@ class TestRepetitionDetectionIntegration:
                 max_pattern_size=5,
                 min_pattern_size=2,
                 min_count=3,
-                algorithm=algorithm,
             ),
         )
         request = Request(
@@ -569,7 +356,7 @@ class TestRepetitionDetectionIntegration:
         assert check_stop(request, max_model_len=1024)
         assert request.status == RequestStatus.FINISHED_REPETITION
 
-    def test_eos_takes_precedence_over_repetition(self, algorithm):
+    def test_eos_takes_precedence_over_repetition(self):
         """Test that EOS token stops before repetition check"""
         params = SamplingParams(
             max_tokens=100,
@@ -578,7 +365,6 @@ class TestRepetitionDetectionIntegration:
                 max_pattern_size=5,
                 min_pattern_size=2,
                 min_count=3,
-                algorithm=algorithm,
             ),
         )
         request = Request(
@@ -591,7 +377,7 @@ class TestRepetitionDetectionIntegration:
         assert check_stop(request, max_model_len=1024)
         assert request.status == RequestStatus.FINISHED_STOPPED
 
-    def test_min_pattern_size_filters_small_patterns(self, algorithm):
+    def test_min_pattern_size_filters_small_patterns(self):
         """Test that min_pattern_size filters out smaller patterns"""
         params = SamplingParams(
             max_tokens=100,
@@ -599,7 +385,6 @@ class TestRepetitionDetectionIntegration:
                 max_pattern_size=5,
                 min_pattern_size=3,
                 min_count=3,
-                algorithm=algorithm,
             ),
         )
         request = Request(
@@ -611,7 +396,7 @@ class TestRepetitionDetectionIntegration:
         request.append_output_token_ids([10, 20, 10, 20, 10, 20])
         assert not check_stop(request, max_model_len=1024)
 
-    def test_high_repetition_threshold(self, algorithm):
+    def test_high_repetition_threshold(self):
         """Test that high min_count requires many repetitions"""
         params = SamplingParams(
             max_tokens=100,
@@ -619,7 +404,6 @@ class TestRepetitionDetectionIntegration:
                 max_pattern_size=5,
                 min_pattern_size=2,
                 min_count=5,
-                algorithm=algorithm,
             ),
         )
         request = Request(

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -117,30 +117,51 @@ class RepetitionDetectionParams:
 
     max_pattern_size: int = 0
     """Maximum size of N-gram pattern to detect for sequence repetition.
-    Set to 0 to disable. Must be used together with min_count."""
+    For ``algorithm="naive"`` (default), set to 0 to disable detection.
+    For ``algorithm="rolling_hash"``, set to 0 to remove the upper bound
+    (the effective cap becomes ``len(token_ids) // min_count``).
+    Must be used together with min_count."""
 
     min_pattern_size: int = 0
     """Minimum N-gram pattern size to check for sequence repetition.
     If set to 0, it defaults to 1.
-    Must be <= max_pattern_size."""
+    Must be <= max_pattern_size when max_pattern_size > 0."""
 
     min_count: int = 0
     """Minimum number of times an N-gram pattern must repeat to trigger
     detection. Must be >= 2. Example: 3 for detecting a phrase repeated
-    3 times. Must be used together with max_pattern_size."""
+    3 times. Detection is disabled when min_count < 2."""
+
+    algorithm: str = "naive"
+    """Detection algorithm. One of:
+
+    - ``"naive"``: per-step iterates pattern lengths in
+      ``[min_pattern_size, max_pattern_size]`` with O(L*K) literal compares
+      per L. ``max_pattern_size=0`` disables detection.
+    - ``"rolling_hash"``: double polynomial rolling hash with two-stage
+      filtering. ``max_pattern_size=0`` removes the upper bound (capped only
+      by ``len(token_ids) // min_count``). Useful when long-range
+      repetitions need to be caught."""
 
     def __post_init__(self):
-        if (
-            self.max_pattern_size < 0
-            or self.min_pattern_size < 0
-            or self.min_pattern_size > self.max_pattern_size
-        ):
+        if self.algorithm not in ("naive", "rolling_hash"):
             raise ValueError(
-                "max_pattern_size, min_pattern_size must be >=0, "
-                "with min_pattern_size <= max_pattern_size. "
-                "Set both to 0 to disable repetitive pattern detection."
+                f"algorithm must be 'naive' or 'rolling_hash', got {self.algorithm!r}."
             )
-        if self.max_pattern_size > 0 and self.min_count < 2:
+        if self.max_pattern_size < 0 or self.min_pattern_size < 0 or self.min_count < 0:
+            raise ValueError(
+                "max_pattern_size, min_pattern_size, min_count must be >= 0."
+            )
+        if self.max_pattern_size > 0 and self.min_pattern_size > self.max_pattern_size:
+            raise ValueError(
+                "min_pattern_size must be <= max_pattern_size when "
+                "max_pattern_size > 0."
+            )
+        if (
+            self.algorithm == "naive"
+            and self.max_pattern_size > 0
+            and self.min_count < 2
+        ):
             raise ValueError(
                 "min_count must be >= 2 to detect repetitive patterns "
                 "in engine output. If you do not wish to detect repetitive "

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -7,7 +7,7 @@ import json as json_mod
 from dataclasses import field
 from enum import Enum, IntEnum
 from functools import cached_property
-from typing import Any
+from typing import Any, Literal
 
 import msgspec
 from pydantic.dataclasses import dataclass
@@ -132,7 +132,7 @@ class RepetitionDetectionParams:
     detection. Must be >= 2. Example: 3 for detecting a phrase repeated
     3 times. Detection is disabled when min_count < 2."""
 
-    algorithm: str = "naive"
+    algorithm: Literal["naive", "rolling_hash"] = "naive"
     """Detection algorithm. One of:
 
     - ``"naive"``: per-step iterates pattern lengths in
@@ -144,10 +144,6 @@ class RepetitionDetectionParams:
       repetitions need to be caught."""
 
     def __post_init__(self):
-        if self.algorithm not in ("naive", "rolling_hash"):
-            raise ValueError(
-                f"algorithm must be 'naive' or 'rolling_hash', got {self.algorithm!r}."
-            )
         if self.max_pattern_size < 0 or self.min_pattern_size < 0 or self.min_count < 0:
             raise ValueError(
                 "max_pattern_size, min_pattern_size, min_count must be >= 0."

--- a/vllm/v1/core/sched/utils.py
+++ b/vllm/v1/core/sched/utils.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import contextlib
+from array import array
 from collections.abc import Sequence
 
 from vllm.sampling_params import RepetitionDetectionParams
@@ -25,17 +26,183 @@ def _has_repeating_pattern(
     return True
 
 
+# Double polynomial rolling hash parameters. MOD1 is the Mersenne prime 2^61-1
+# and MOD2 is 2^31-1; collision probability per pair is < 2^-90, negligible
+# for repetition detection at LLM-output scales.
+_RH_MOD1 = (1 << 61) - 1
+_RH_MOD2 = (1 << 31) - 1
+_RH_BASE1 = 131
+_RH_BASE2 = 137
+
+
+class RollingHashState:
+    """Incremental double-rolling-hash state for repetition detection.
+
+    Owned by a single ``Request`` for the duration of its decode; updated
+    in O(1) per output token via :meth:`extend`. Range-hash queries over
+    any sub-interval ``[l, r)`` are O(1).
+
+    Storage: four ``array.array("q")`` buffers (signed int64, 8 bytes each
+    plus amortized growth slack), so the memory cost is roughly
+    ``4 * 8 * num_output_tokens`` bytes — about 7x smaller than the
+    equivalent Python ``list[int]`` because raw int64 elements are not
+    boxed as Python objects.
+    """
+
+    __slots__ = ("h1", "h2", "p1", "p2", "n")
+
+    def __init__(self) -> None:
+        # h*[i] = hash of token_ids[0..i); p*[i] = base^i mod _RH_MOD*.
+        self.h1: array = array("q", [0])
+        self.h2: array = array("q", [0])
+        self.p1: array = array("q", [1])
+        self.p2: array = array("q", [1])
+        self.n: int = 0
+
+    def extend(self, token_ids: Sequence[int], up_to: int) -> None:
+        """Extend internal hashes to cover ``token_ids[:up_to]``.
+
+        Idempotent and append-only: callers may pass the entire output
+        sequence each step; only tokens beyond ``self.n`` are processed.
+        """
+        if up_to <= self.n:
+            return
+        h1, h2, p1, p2 = self.h1, self.h2, self.p1, self.p2
+        last_h1 = h1[-1]
+        last_h2 = h2[-1]
+        last_p1 = p1[-1]
+        last_p2 = p2[-1]
+        for i in range(self.n, up_to):
+            # +1 so token id 0 contributes a non-zero term.
+            t = token_ids[i] + 1
+            last_h1 = (last_h1 * _RH_BASE1 + t) % _RH_MOD1
+            last_h2 = (last_h2 * _RH_BASE2 + t) % _RH_MOD2
+            last_p1 = last_p1 * _RH_BASE1 % _RH_MOD1
+            last_p2 = last_p2 * _RH_BASE2 % _RH_MOD2
+            h1.append(last_h1)
+            h2.append(last_h2)
+            p1.append(last_p1)
+            p2.append(last_p2)
+        self.n = up_to
+
+
+def _has_repeating_pattern_rolling_hash(
+    token_ids: Sequence[int],
+    max_pattern_size: int,
+    min_pattern_size: int,
+    min_count: int,
+    state: RollingHashState | None = None,
+) -> bool:
+    """Detect tail repetition via double polynomial rolling hashes.
+
+    For each candidate period L in ``[min_pattern_size, upper_l]``, checks
+    whether the last ``min_count * L`` tokens are exactly ``min_count``
+    copies of an L-block. A cheap single-token compare (Stage 1) prunes
+    most L values; the hash equality (Stage 2) confirms full block match
+    in O(min_count) per L using O(1) range hashes.
+
+    ``max_pattern_size <= 0`` removes the upper bound (capped only by
+    ``len(token_ids) // min_count``). Otherwise capped by
+    ``min(max_pattern_size, len(token_ids) // min_count)``.
+
+    When ``state`` is provided, prefix hashes are reused across calls and
+    extended incrementally — total cost is O(1) per token plus O(L_max)
+    scan per step. When ``state`` is ``None`` (e.g. direct invocations
+    from tests), prefix hashes are recomputed locally.
+    """
+    n = len(token_ids)
+    # Keep the request-attached state consistent with the latest output
+    # tokens regardless of whether we end up scanning. The per-token
+    # cost is amortized O(1), and downstream callers (and tests) can
+    # assume ``state.n == len(token_ids)`` after this function returns.
+    if state is not None and n > state.n:
+        state.extend(token_ids, n)
+
+    if n == 0 or min_count < 2:
+        return False
+
+    if min_pattern_size <= 0:
+        min_pattern_size = 1
+
+    upper_l = n // min_count
+    if max_pattern_size > 0:
+        upper_l = min(upper_l, max_pattern_size)
+
+    if upper_l < min_pattern_size:
+        return False
+
+    if state is not None:
+        h1, h2, p1, p2 = state.h1, state.h2, state.p1, state.p2
+    else:
+        h1 = [0] * (n + 1)
+        h2 = [0] * (n + 1)
+        p1 = [1] * (n + 1)
+        p2 = [1] * (n + 1)
+        for i in range(n):
+            t = token_ids[i] + 1
+            h1[i + 1] = (h1[i] * _RH_BASE1 + t) % _RH_MOD1
+            h2[i + 1] = (h2[i] * _RH_BASE2 + t) % _RH_MOD2
+            p1[i + 1] = p1[i] * _RH_BASE1 % _RH_MOD1
+            p2[i + 1] = p2[i] * _RH_BASE2 % _RH_MOD2
+
+    # Hot loop: read into locals to avoid attribute lookups.
+    mod1 = _RH_MOD1
+    mod2 = _RH_MOD2
+    last_token = token_ids[-1]
+    h1_n = h1[n]
+    h2_n = h2[n]
+
+    for length in range(min_pattern_size, upper_l + 1):
+        # Stage 1: single-token prune. Eliminates most L cheaply.
+        if token_ids[n - 1 - length] != last_token:
+            continue
+        # Stage 2: hash equality across all min_count blocks.
+        p1_l = p1[length]
+        p2_l = p2[length]
+        ref1 = (h1_n - h1[n - length] * p1_l) % mod1
+        ref2 = (h2_n - h2[n - length] * p2_l) % mod2
+        match = True
+        for k in range(1, min_count):
+            r = n - length * k
+            l_ = r - length
+            if (h1[r] - h1[l_] * p1_l) % mod1 != ref1 or (
+                h2[r] - h2[l_] * p2_l
+            ) % mod2 != ref2:
+                match = False
+                break
+        if match:
+            return True
+    return False
+
+
 def check_sequence_repetition(
     token_ids: Sequence[int],
     params: RepetitionDetectionParams,
+    state: RollingHashState | None = None,
 ) -> bool:
     """Check if a sequence of token IDs has a repetition pattern.
+
     Args:
-        token_ids: List of token IDs
+        token_ids: List of token IDs.
         params: Repetition detection parameters.
+        state: Optional incremental rolling-hash state. Only consulted
+            when ``params.algorithm == "rolling_hash"``. The ``check_stop``
+            scheduler entry passes a per-request state for amortized O(1)
+            per-token updates; direct callers may omit it.
+
     Returns:
         True if a repetition pattern is found, False otherwise.
     """
+    if params.algorithm == "rolling_hash":
+        return _has_repeating_pattern_rolling_hash(
+            token_ids,
+            params.max_pattern_size,
+            params.min_pattern_size,
+            params.min_count,
+            state=state,
+        )
+
+    # naive (default)
     max_pattern_size = params.max_pattern_size
     min_pattern_size = params.min_pattern_size
     min_count = params.min_count
@@ -117,14 +284,20 @@ def check_stop(request: Request, max_model_len: int) -> bool:
         return True
 
     repetition_detection = sampling_params.repetition_detection
-    if repetition_detection is not None and (
-        check_sequence_repetition(
+    if repetition_detection is not None:
+        state: RollingHashState | None = None
+        if repetition_detection.algorithm == "rolling_hash":
+            state = request.repetition_hash_state
+            if state is None:
+                state = RollingHashState()
+                request.repetition_hash_state = state
+        if check_sequence_repetition(
             request.output_token_ids,
             repetition_detection,
-        )
-    ):
-        request.status = RequestStatus.FINISHED_REPETITION
-        request.stop_reason = "repetition_detected"
-        return True
+            state=state,
+        ):
+            request.status = RequestStatus.FINISHED_REPETITION
+            request.stop_reason = "repetition_detected"
+            return True
 
     return False

--- a/vllm/v1/core/sched/utils.py
+++ b/vllm/v1/core/sched/utils.py
@@ -60,12 +60,32 @@ class RollingHashState:
         self.n: int = 0
 
     def extend(self, token_ids: Sequence[int], up_to: int) -> None:
-        """Extend internal hashes to cover ``token_ids[:up_to]``.
+        """Sync internal hashes to cover ``token_ids[:up_to]``.
 
-        Idempotent and append-only: callers may pass the entire output
-        sequence each step; only tokens beyond ``self.n`` are processed.
+        Idempotent. Two paths:
+
+        * ``up_to > self.n`` — append-only growth (the steady-state
+          decode case).
+        * ``up_to < self.n`` — truncation (rollback). Drop hash entries
+          past ``up_to`` so subsequent extends rebuild from the
+          surviving prefix. This is required for correctness under
+          speculative decoding: when speculative tokens are rejected,
+          ``request.output_token_ids`` shrinks, and we must not keep
+          hashes for those rolled-back tokens.
+
+        The surviving prefix is assumed unchanged — vLLM v1 commits
+        output tokens once, so positions ``[0, up_to)`` are stable.
         """
-        if up_to <= self.n:
+        if up_to == self.n:
+            return
+        if up_to < self.n:
+            # Truncation path. ``del a[k:]`` is O(n - k) on array.array.
+            keep = up_to + 1
+            del self.h1[keep:]
+            del self.h2[keep:]
+            del self.p1[keep:]
+            del self.p2[keep:]
+            self.n = up_to
             return
         h1, h2, p1, p2 = self.h1, self.h2, self.p1, self.p2
         last_h1 = h1[-1]
@@ -112,10 +132,10 @@ def _has_repeating_pattern_rolling_hash(
     """
     n = len(token_ids)
     # Keep the request-attached state consistent with the latest output
-    # tokens regardless of whether we end up scanning. The per-token
-    # cost is amortized O(1), and downstream callers (and tests) can
-    # assume ``state.n == len(token_ids)`` after this function returns.
-    if state is not None and n > state.n:
+    # tokens regardless of whether we end up scanning. ``n != state.n``
+    # also covers truncation (e.g. speculative-decode rejection); see
+    # ``RollingHashState.extend``.
+    if state is not None and n != state.n:
         state.extend(token_ids, n)
 
     if n == 0 or min_count < 2:

--- a/vllm/v1/core/sched/utils.py
+++ b/vllm/v1/core/sched/utils.py
@@ -60,26 +60,16 @@ class RollingHashState:
         self.n: int = 0
 
     def extend(self, token_ids: Sequence[int], up_to: int) -> None:
-        """Sync internal hashes to cover ``token_ids[:up_to]``.
+        """Sync internal hashes to cover ``token_ids[:up_to]`` (idempotent).
 
-        Idempotent. Two paths:
-
-        * ``up_to > self.n`` — append-only growth (the steady-state
-          decode case).
-        * ``up_to < self.n`` — truncation (rollback). Drop hash entries
-          past ``up_to`` so subsequent extends rebuild from the
-          surviving prefix. This is required for correctness under
-          speculative decoding: when speculative tokens are rejected,
-          ``request.output_token_ids`` shrinks, and we must not keep
-          hashes for those rolled-back tokens.
-
-        The surviving prefix is assumed unchanged — vLLM v1 commits
-        output tokens once, so positions ``[0, up_to)`` are stable.
+        Handles both growth and truncation. Truncation is needed for
+        speculative-decode rollback: when speculative tokens are rejected
+        ``request.output_token_ids`` shrinks, so stale hashes past
+        ``up_to`` must be dropped before the next append.
         """
         if up_to == self.n:
             return
         if up_to < self.n:
-            # Truncation path. ``del a[k:]`` is O(n - k) on array.array.
             keep = up_to + 1
             del self.h1[keep:]
             del self.h2[keep:]
@@ -125,18 +115,14 @@ def _has_repeating_pattern_rolling_hash(
     ``len(token_ids) // min_count``). Otherwise capped by
     ``min(max_pattern_size, len(token_ids) // min_count)``.
 
-    When ``state`` is provided, prefix hashes are reused across calls and
-    extended incrementally — total cost is O(1) per token plus O(L_max)
-    scan per step. When ``state`` is ``None`` (e.g. direct invocations
-    from tests), prefix hashes are recomputed locally.
+    A per-request ``state`` reuses prefix hashes across decode steps
+    (O(1) per new token). Direct test callers may omit it; in that case
+    a temporary state is built once locally.
     """
     n = len(token_ids)
-    # Keep the request-attached state consistent with the latest output
-    # tokens regardless of whether we end up scanning. ``n != state.n``
-    # also covers truncation (e.g. speculative-decode rejection); see
-    # ``RollingHashState.extend``.
-    if state is not None and n != state.n:
-        state.extend(token_ids, n)
+    if state is None:
+        state = RollingHashState()
+    state.extend(token_ids, n)
 
     if n == 0 or min_count < 2:
         return False
@@ -151,21 +137,8 @@ def _has_repeating_pattern_rolling_hash(
     if upper_l < min_pattern_size:
         return False
 
-    if state is not None:
-        h1, h2, p1, p2 = state.h1, state.h2, state.p1, state.p2
-    else:
-        h1 = [0] * (n + 1)
-        h2 = [0] * (n + 1)
-        p1 = [1] * (n + 1)
-        p2 = [1] * (n + 1)
-        for i in range(n):
-            t = token_ids[i] + 1
-            h1[i + 1] = (h1[i] * _RH_BASE1 + t) % _RH_MOD1
-            h2[i + 1] = (h2[i] * _RH_BASE2 + t) % _RH_MOD2
-            p1[i + 1] = p1[i] * _RH_BASE1 % _RH_MOD1
-            p2[i + 1] = p2[i] * _RH_BASE2 % _RH_MOD2
+    h1, h2, p1, p2 = state.h1, state.h2, state.p1, state.p2
 
-    # Hot loop: read into locals to avoid attribute lookups.
     mod1 = _RH_MOD1
     mod2 = _RH_MOD2
     last_token = token_ids[-1]
@@ -173,10 +146,8 @@ def _has_repeating_pattern_rolling_hash(
     h2_n = h2[n]
 
     for length in range(min_pattern_size, upper_l + 1):
-        # Stage 1: single-token prune. Eliminates most L cheaply.
         if token_ids[n - 1 - length] != last_token:
             continue
-        # Stage 2: hash equality across all min_count blocks.
         p1_l = p1[length]
         p2_l = p2[length]
         ref1 = (h1_n - h1[n - length] * p1_l) % mod1

--- a/vllm/v1/core/sched/utils.py
+++ b/vllm/v1/core/sched/utils.py
@@ -35,6 +35,14 @@ _RH_BASE1 = 131
 _RH_BASE2 = 137
 
 
+def _build_powers(count: int, base: int, mod: int) -> array:
+    powers = array("q", [0]) * count
+    powers[0] = 1
+    for i in range(1, count):
+        powers[i] = powers[i - 1] * base % mod
+    return powers
+
+
 class RollingHashState:
     """Incremental double-rolling-hash state for repetition detection.
 
@@ -42,58 +50,100 @@ class RollingHashState:
     in O(1) per output token via :meth:`extend`. Range-hash queries over
     any sub-interval ``[l, r)`` are O(1).
 
-    Storage: four ``array.array("q")`` buffers (signed int64, 8 bytes each
-    plus amortized growth slack), so the memory cost is roughly
-    ``4 * 8 * num_output_tokens`` bytes — about 7x smaller than the
-    equivalent Python ``list[int]`` because raw int64 elements are not
-    boxed as Python objects.
+    In **bounded** mode (``max_pattern_size > 0``) the search only ever
+    queries hashes spanning the last ``W = max_pattern_size * min_count``
+    tokens, and powers up to length ``max_pattern_size``. Two memory
+    optimizations follow:
+
+    * ``p1`` / ``p2`` are pre-filled to ``max_pattern_size + 1`` entries
+      and never grow.
+    * ``h1`` / ``h2`` slide: when the stored prefix exceeds ``2W + 1``
+      entries, the leading ``W`` are dropped and ``self.start`` is
+      advanced by ``W``. Indexing becomes ``h*[abs_pos - self.start]``.
+
+    In **unbounded** mode (``max_pattern_size <= 0``) the prefix arrays
+    grow per token (current behaviour).
+
+    Storage uses ``array.array("q")`` (signed int64) — about 7x smaller
+    than ``list[int]`` since raw int64 elements are not boxed.
     """
 
-    __slots__ = ("h1", "h2", "p1", "p2", "n")
+    __slots__ = ("h1", "h2", "p1", "p2", "n", "start", "_window")
 
-    def __init__(self) -> None:
-        # h*[i] = hash of token_ids[0..i); p*[i] = base^i mod _RH_MOD*.
+    def __init__(self, max_pattern_size: int = 0, min_count: int = 0) -> None:
         self.h1: array = array("q", [0])
         self.h2: array = array("q", [0])
-        self.p1: array = array("q", [1])
-        self.p2: array = array("q", [1])
         self.n: int = 0
+        # Absolute index of ``h*[0]``. Advances on window slides.
+        self.start: int = 0
+        if max_pattern_size > 0 and min_count >= 2:
+            # Bounded mode: cap powers and enable sliding window.
+            self._window: int = max_pattern_size * min_count
+            self.p1: array = _build_powers(max_pattern_size + 1, _RH_BASE1, _RH_MOD1)
+            self.p2: array = _build_powers(max_pattern_size + 1, _RH_BASE2, _RH_MOD2)
+        else:
+            self._window = 0
+            self.p1 = array("q", [1])
+            self.p2 = array("q", [1])
 
     def extend(self, token_ids: Sequence[int], up_to: int) -> None:
         """Sync internal hashes to cover ``token_ids[:up_to]`` (idempotent).
 
-        Handles both growth and truncation. Truncation is needed for
-        speculative-decode rollback: when speculative tokens are rejected
-        ``request.output_token_ids`` shrinks, so stale hashes past
-        ``up_to`` must be dropped before the next append.
+        Handles growth, truncation (speculative-decode rollback shrinks
+        ``request.output_token_ids``), and — in bounded mode — periodic
+        sliding to bound memory.
         """
         if up_to == self.n:
             return
         if up_to < self.n:
-            keep = up_to + 1
-            del self.h1[keep:]
-            del self.h2[keep:]
-            del self.p1[keep:]
-            del self.p2[keep:]
-            self.n = up_to
-            return
-        h1, h2, p1, p2 = self.h1, self.h2, self.p1, self.p2
+            if up_to < self.start:
+                # Rollback exceeds the kept window; reset and rebuild.
+                self.h1 = array("q", [0])
+                self.h2 = array("q", [0])
+                self.start = 0
+                self.n = 0
+            else:
+                keep = up_to - self.start + 1
+                del self.h1[keep:]
+                del self.h2[keep:]
+                self.n = up_to
+                return
+        # Growth path.
+        h1, h2 = self.h1, self.h2
         last_h1 = h1[-1]
         last_h2 = h2[-1]
-        last_p1 = p1[-1]
-        last_p2 = p2[-1]
         for i in range(self.n, up_to):
             # +1 so token id 0 contributes a non-zero term.
             t = token_ids[i] + 1
             last_h1 = (last_h1 * _RH_BASE1 + t) % _RH_MOD1
             last_h2 = (last_h2 * _RH_BASE2 + t) % _RH_MOD2
-            last_p1 = last_p1 * _RH_BASE1 % _RH_MOD1
-            last_p2 = last_p2 * _RH_BASE2 % _RH_MOD2
             h1.append(last_h1)
             h2.append(last_h2)
-            p1.append(last_p1)
-            p2.append(last_p2)
         self.n = up_to
+        # Bounded mode: slide head off when buffer exceeds 2W + 1.
+        window = self._window
+        if window > 0:
+            stored = up_to - self.start + 1
+            if stored > 2 * window + 1:
+                drop = window
+                del self.h1[:drop]
+                del self.h2[:drop]
+                self.start += drop
+        else:
+            # Unbounded mode: grow powers lazily to cover any L the
+            # search may query (capped by ``up_to // 2`` since
+            # ``min_count >= 2``).
+            target = up_to // 2
+            cur = len(self.p1) - 1
+            if target > cur:
+                p1, p2 = self.p1, self.p2
+                last_p1 = p1[-1]
+                last_p2 = p2[-1]
+                for _ in range(cur, target):
+                    last_p1 = last_p1 * _RH_BASE1 % _RH_MOD1
+                    last_p2 = last_p2 * _RH_BASE2 % _RH_MOD2
+                    p1.append(last_p1)
+                    p2.append(last_p2)
 
 
 def _has_repeating_pattern_rolling_hash(
@@ -121,7 +171,7 @@ def _has_repeating_pattern_rolling_hash(
     """
     n = len(token_ids)
     if state is None:
-        state = RollingHashState()
+        state = RollingHashState(max_pattern_size, min_count)
     state.extend(token_ids, n)
 
     if n == 0 or min_count < 2:
@@ -138,23 +188,24 @@ def _has_repeating_pattern_rolling_hash(
         return False
 
     h1, h2, p1, p2 = state.h1, state.h2, state.p1, state.p2
+    start = state.start
 
     mod1 = _RH_MOD1
     mod2 = _RH_MOD2
     last_token = token_ids[-1]
-    h1_n = h1[n]
-    h2_n = h2[n]
+    h1_n = h1[n - start]
+    h2_n = h2[n - start]
 
     for length in range(min_pattern_size, upper_l + 1):
         if token_ids[n - 1 - length] != last_token:
             continue
         p1_l = p1[length]
         p2_l = p2[length]
-        ref1 = (h1_n - h1[n - length] * p1_l) % mod1
-        ref2 = (h2_n - h2[n - length] * p2_l) % mod2
+        ref1 = (h1_n - h1[n - length - start] * p1_l) % mod1
+        ref2 = (h2_n - h2[n - length - start] * p2_l) % mod2
         match = True
         for k in range(1, min_count):
-            r = n - length * k
+            r = n - length * k - start
             l_ = r - length
             if (h1[r] - h1[l_] * p1_l) % mod1 != ref1 or (
                 h2[r] - h2[l_] * p2_l
@@ -280,7 +331,10 @@ def check_stop(request: Request, max_model_len: int) -> bool:
         if repetition_detection.algorithm == "rolling_hash":
             state = request.repetition_hash_state
             if state is None:
-                state = RollingHashState()
+                state = RollingHashState(
+                    repetition_detection.max_pattern_size,
+                    repetition_detection.min_count,
+                )
                 request.repetition_hash_state = state
         if check_sequence_repetition(
             request.output_token_ids,

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -182,6 +182,14 @@ class Request:
         # None entry in the queue means finished.
         self.streaming_queue: deque[StreamingUpdate | None] | None = None
 
+        # Lazy-init incremental rolling-hash state for repetition
+        # detection. Only populated when
+        # ``sampling_params.repetition_detection.algorithm ==
+        # "rolling_hash"``. Typed as ``Any`` to avoid importing the
+        # scheduler-side state class here (and the resulting circular
+        # import with ``vllm.v1.core.sched.utils``).
+        self.repetition_hash_state: Any | None = None
+
     @classmethod
     def from_engine_core_request(
         cls,

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -27,6 +27,7 @@ from vllm.v1.utils import ConstantList
 if TYPE_CHECKING:
     from vllm.lora.request import LoRARequest
     from vllm.v1.core.kv_cache_utils import BlockHash
+    from vllm.v1.core.sched.utils import RollingHashState
 
 
 @dataclass
@@ -182,13 +183,9 @@ class Request:
         # None entry in the queue means finished.
         self.streaming_queue: deque[StreamingUpdate | None] | None = None
 
-        # Lazy-init incremental rolling-hash state for repetition
-        # detection. Only populated when
-        # ``sampling_params.repetition_detection.algorithm ==
-        # "rolling_hash"``. Typed as ``Any`` to avoid importing the
-        # scheduler-side state class here (and the resulting circular
-        # import with ``vllm.v1.core.sched.utils``).
-        self.repetition_hash_state: Any | None = None
+        # Lazy-initialized by check_stop when repetition_detection uses
+        # algorithm="rolling_hash"; remains None otherwise.
+        self.repetition_hash_state: RollingHashState | None = None
 
     @classmethod
     def from_engine_core_request(


### PR DESCRIPTION
Adds an opt-in `algorithm="rolling_hash"` option to `RepetitionDetectionParams` (added in #35451). The default stays `"naive"` so nothing changes for existing users.

The naive scan has two practical issues:

1. Patterns longer than `max_pattern_size` go undetected, so the paragraph- or JSON-block-sized loops that motivate this feature in the first place often slip through unless the cap is cranked up.
2. Cranking the cap up costs O(L²·K) per step.

The rolling-hash detector uses a double polynomial hash (Mersenne 2^61-1 + 2^31-1, collision probability < 2^-90) with a two-stage filter — a single-token prune on the candidate period L (Stage 1) followed by O(K) range-hash equality on the few survivors (Stage 2). Setting `max_pattern_size=0` removes the upper bound: patterns up to `len(token_ids) // min_count` become reachable.

To keep per-step cost reasonable, a `RollingHashState` is lazily attached to the `Request` and updated O(1) per output token from `check_stop`. Storage uses `array.array("q")` (signed int64), which is roughly 7x more memory-efficient than `list[int]`.

## Microbenchmark

`benchmarks/benchmark_repetition_detection.py --n 16384`:

| config | per-step | vs naive |
| --- | ---: | ---: |
| naive (max=128) | 39.4 us | 1.0x |
| rolling_hash (max=128, +state) | 9.6 us | 4.1x faster |
| rolling_hash (unbounded, +state) | 186 us | unbounded coverage |

Without the incremental state, rolling_hash recomputes prefix hashes every call and ends up ~180x slower than naive — so the state isn't optional, it's part of the design. The benchmark includes that config as a cautionary baseline.