### PR TITLE
Add metadata support to latency and throughput benchmarks

### DIFF
--- a/tests/benchmarks/test_latency_cli.py
+++ b/tests/benchmarks/test_latency_cli.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
 import subprocess
+import sys
 
 import pytest
 
@@ -8,9 +10,12 @@ MODEL_NAME = "meta-llama/Llama-3.2-1B-Instruct"
 
 
 @pytest.mark.benchmark
-def test_bench_latency():
+def test_bench_latency(tmp_path):
+    output_json = tmp_path / "latency.json"
     command = [
-        "vllm",
+        sys.executable,
+        "-m",
+        "vllm.entrypoints.cli.main",
         "bench",
         "latency",
         "--model",
@@ -19,12 +24,25 @@ def test_bench_latency():
         "32",
         "--output-len",
         "1",
+        "--num-iters-warmup",
+        "1",
+        "--num-iters",
+        "1",
         "--enforce-eager",
         "--load-format",
         "dummy",
+        "--output-json",
+        str(output_json),
+        "--metadata",
+        "test_key=test_value",
+        "source=pytest",
     ]
     result = subprocess.run(command, capture_output=True, text=True)
     print(result.stdout)
     print(result.stderr)
 
     assert result.returncode == 0, f"Benchmark failed: {result.stderr}"
+    results = json.loads(output_json.read_text())
+    assert results["test_key"] == "test_value"
+    assert results["source"] == "pytest"
+    assert "avg_latency" in results

--- a/tests/benchmarks/test_throughput_cli.py
+++ b/tests/benchmarks/test_throughput_cli.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
 import subprocess
+import sys
 
 import pytest
 
@@ -8,9 +10,12 @@ MODEL_NAME = "meta-llama/Llama-3.2-1B-Instruct"
 
 
 @pytest.mark.benchmark
-def test_bench_throughput():
+def test_bench_throughput(tmp_path):
+    output_json = tmp_path / "throughput.json"
     command = [
-        "vllm",
+        sys.executable,
+        "-m",
+        "vllm.entrypoints.cli.main",
         "bench",
         "throughput",
         "--model",
@@ -19,12 +24,23 @@ def test_bench_throughput():
         "32",
         "--output-len",
         "1",
+        "--num-prompts",
+        "2",
         "--enforce-eager",
         "--load-format",
         "dummy",
+        "--output-json",
+        str(output_json),
+        "--metadata",
+        "test_key=test_value",
+        "source=pytest",
     ]
     result = subprocess.run(command, capture_output=True, text=True)
     print(result.stdout)
     print(result.stderr)
 
     assert result.returncode == 0, f"Benchmark failed: {result.stderr}"
+    results = json.loads(output_json.read_text())
+    assert "requests_per_second" in results
+    assert results["test_key"] == "test_value"
+    assert results["source"] == "pytest"

--- a/vllm/benchmarks/latency.py
+++ b/vllm/benchmarks/latency.py
@@ -11,7 +11,11 @@ from typing import Any
 import numpy as np
 from tqdm import tqdm
 
-from vllm.benchmarks.lib.utils import convert_to_pytorch_benchmark_format, write_to_json
+from vllm.benchmarks.lib.utils import (
+    convert_to_pytorch_benchmark_format,
+    parse_metadata,
+    write_to_json,
+)
 from vllm.engine.arg_utils import EngineArgs
 from vllm.inputs import PromptType
 from vllm.sampling_params import BeamSearchParams
@@ -23,7 +27,11 @@ def save_to_pytorch_benchmark_format(
     pt_records = convert_to_pytorch_benchmark_format(
         args=args,
         metrics={"latency": results["latencies"]},
-        extra_info={k: results[k] for k in ["avg_latency", "percentiles"]},
+        extra_info={
+            k: v
+            for k, v in results.items()
+            if k not in {"latencies"}
+        },
     )
     if pt_records:
         pt_file = f"{os.path.splitext(args.output_json)[0]}.pytorch.json"
@@ -62,6 +70,14 @@ def add_cli_args(parser: argparse.ArgumentParser):
         help="Path to save the latency results in JSON format.",
     )
     parser.add_argument(
+        "--metadata",
+        metavar="KEY=VALUE",
+        nargs="*",
+        help="Key-value pairs (e.g, --metadata version=0.3.3 tp=1) "
+        "for metadata of this run to be saved in the result JSON file "
+        "for record keeping purposes.",
+    )
+    parser.add_argument(
         "--disable-detokenize",
         action="store_true",
         help=(
@@ -77,6 +93,7 @@ def add_cli_args(parser: argparse.ArgumentParser):
 
 
 def main(args: argparse.Namespace):
+    metadata = parse_metadata(args.metadata)
     engine_args = EngineArgs.from_cli_args(args)
 
     # Lazy import to avoid importing LLM when the bench command is not selected.
@@ -161,11 +178,16 @@ def main(args: argparse.Namespace):
 
     # Output JSON results if specified
     if args.output_json:
-        results = {
-            "avg_latency": np.mean(latencies),
-            "latencies": latencies.tolist(),
-            "percentiles": dict(zip(percentages, percentiles.tolist())),
-        }
+        results: dict[str, Any] = metadata.copy()
+        results.update(
+            {
+                "avg_latency": np.mean(latencies),
+                "latencies": latencies.tolist(),
+                "percentiles": dict(zip(percentages, percentiles.tolist())),
+            }
+        )
+
         with open(args.output_json, "w") as f:
             json.dump(results, f, indent=4)
+
         save_to_pytorch_benchmark_format(args, results)

--- a/vllm/benchmarks/lib/utils.py
+++ b/vllm/benchmarks/lib/utils.py
@@ -9,6 +9,20 @@ from contextlib import contextmanager
 from typing import Any
 
 
+def parse_metadata(metadata: list[str] | None) -> dict[str, str]:
+    """Parse KEY=VALUE metadata CLI arguments into a result JSON mapping."""
+    result: dict[str, str] = {}
+    if not metadata:
+        return result
+
+    for item in metadata:
+        if "=" not in item:
+            raise ValueError("Invalid metadata format. Please use KEY=VALUE format.")
+        key, value = item.split("=", 1)
+        result[key.strip()] = value.strip()
+    return result
+
+
 def extract_field(
     args: argparse.Namespace, extra_info: dict[str, Any], field_name: str
 ) -> str:

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -50,7 +50,11 @@ from vllm.benchmarks.lib.endpoint_request_func import (
     RequestFuncOutput,
 )
 from vllm.benchmarks.lib.ready_checker import wait_for_endpoint
-from vllm.benchmarks.lib.utils import convert_to_pytorch_benchmark_format, write_to_json
+from vllm.benchmarks.lib.utils import (
+    convert_to_pytorch_benchmark_format,
+    parse_metadata,
+    write_to_json,
+)
 from vllm.tokenizers import TokenizerLike, get_tokenizer
 from vllm.utils.gc_utils import freeze_gc_heap
 from vllm.utils.network_utils import join_host_port
@@ -1632,6 +1636,7 @@ def main(args: argparse.Namespace) -> dict[str, Any]:
 
 async def main_async(args: argparse.Namespace) -> dict[str, Any]:
     print(args)
+    metadata = parse_metadata(args.metadata)
     random.seed(args.seed)
     np.random.seed(args.seed)
 
@@ -1858,15 +1863,7 @@ async def main_async(args: argparse.Namespace) -> dict[str, Any]:
     result_json["num_prompts"] = args.num_prompts
 
     # Metadata
-    if args.metadata:
-        for item in args.metadata:
-            if "=" in item:
-                kvstring = item.split("=", 1)
-                result_json[kvstring[0].strip()] = kvstring[1].strip()
-            else:
-                raise ValueError(
-                    "Invalid metadata format. Please use KEY=VALUE format."
-                )
+    result_json.update({k: v for k, v in metadata.items() if k not in result_json})
 
     # Traffic
     result_json["request_rate"] = (

--- a/vllm/benchmarks/throughput.py
+++ b/vllm/benchmarks/throughput.py
@@ -33,7 +33,11 @@ from vllm.benchmarks.datasets import (
     add_random_dataset_base_args,
     add_random_multimodal_dataset_args,
 )
-from vllm.benchmarks.lib.utils import convert_to_pytorch_benchmark_format, write_to_json
+from vllm.benchmarks.lib.utils import (
+    convert_to_pytorch_benchmark_format,
+    parse_metadata,
+    write_to_json,
+)
 from vllm.engine.arg_utils import AsyncEngineArgs, EngineArgs
 from vllm.inputs import TextPrompt, TokensPrompt
 from vllm.lora.request import LoRARequest
@@ -329,7 +333,9 @@ def save_to_pytorch_benchmark_format(
             "tokens_per_second": [results["tokens_per_second"]],
         },
         extra_info={
-            k: results[k] for k in ["elapsed_time", "num_requests", "total_num_tokens"]
+            k: v
+            for k, v in results.items()
+            if k not in {"requests_per_second", "tokens_per_second"}
         },
     )
     if pt_records:
@@ -784,6 +790,14 @@ def add_cli_args(parser: argparse.ArgumentParser):
         help="Path to save the throughput results in JSON format.",
     )
     parser.add_argument(
+        "--metadata",
+        metavar="KEY=VALUE",
+        nargs="*",
+        help="Key-value pairs (e.g, --metadata version=0.3.3 tp=1) "
+        "for metadata of this run to be saved in the result JSON file "
+        "for record keeping purposes.",
+    )
+    parser.add_argument(
         "--async-engine",
         action="store_true",
         default=False,
@@ -905,6 +919,7 @@ def add_cli_args(parser: argparse.ArgumentParser):
 
 
 def main(args: argparse.Namespace):
+    metadata = parse_metadata(args.metadata)
     validate_args(args)
     if args.seed is None:
         args.seed = 0
@@ -1007,13 +1022,18 @@ def main(args: argparse.Namespace):
 
     # Output JSON results if specified
     if args.output_json:
-        results = {
-            "elapsed_time": elapsed_time,
-            "num_requests": len(requests),
-            "total_num_tokens": total_num_tokens,
-            "requests_per_second": len(requests) / elapsed_time,
-            "tokens_per_second": total_num_tokens / elapsed_time,
-        }
+        results: dict[str, Any] = metadata.copy()
+        results.update(
+            {
+                "elapsed_time": elapsed_time,
+                "num_requests": len(requests),
+                "total_num_tokens": total_num_tokens,
+                "requests_per_second": len(requests) / elapsed_time,
+                "tokens_per_second": total_num_tokens / elapsed_time,
+            }
+        )
+
         with open(args.output_json, "w") as f:
             json.dump(results, f, indent=4)
+
         save_to_pytorch_benchmark_format(args, results)


### PR DESCRIPTION
## Purpose

Adds `--metadata KEY=VALUE` support to the latency and throughput benchmark CLIs, matching the existing metadata behavior in `bench serve`.

Metadata key-value pairs are written as top-level fields in the benchmark JSON output. This also moves the existing serve metadata parsing logic into `vllm/benchmarks/lib/utils.py` so serve, latency, and throughput use the same parser.

## Test Plan

- Run latency and throughput benchmarks with `--metadata experiment=metadata_test run_id=1`.
- Confirm the metadata fields appear in the output JSON.
- Confirm `vllm bench serve` still preserves its existing top-level metadata behavior.

Run latency benchmark with metadata:

```bash
vllm bench latency \
  --model Qwen/Qwen2.5-0.5B-Instruct \
  --input-len 8 \
  --output-len 1 \
  --num-iters-warmup 1 \
  --num-iters 1 \
  --enforce-eager \
  --load-format dummy \
  --gpu-memory-utilization 0.50 \
  --output-json latency_output.json \
  --metadata experiment=metadata_test run_id=1
```

Run throughput benchmark with metadata:

```bash
vllm bench throughput \
  --model Qwen/Qwen2.5-0.5B-Instruct \
  --random-input-len 8 \
  --random-output-len 1 \
  --random-prefix-len 0 \
  --num-prompts 1 \
  --max-model-len 128 \
  --enforce-eager \
  --load-format dummy \
  --gpu-memory-utilization 0.50 \
  --output-json throughput_output.json \
  --metadata experiment=metadata_test run_id=1
```

## Test Result

Latency output contained:

```json
{
  "experiment": "metadata_test",
  "run_id": "1",
  "avg_latency": 0.14875651400006973
}
```

Throughput output contained:

```json
{
  "experiment": "metadata_test",
  "run_id": "1",
  "requests_per_second": 4.565215454059947,
  "tokens_per_second": 41.08693908653952
}
```

Also manually verified `vllm bench serve` still preserves existing top-level metadata behavior.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>