### PR TITLE
Add comments before logs used for benchmarking.

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -599,6 +599,7 @@ async def build_and_serve(
     app = build_app(args, supported_tasks, model_config)
     await init_app_state(engine_client, app.state, args, supported_tasks)
 
+    # This log line is used for benchmarking. Please maintain the format
     logger.info("Starting vLLM server on %s", listen_address)
 
     return await serve_http(
@@ -644,6 +645,7 @@ async def build_and_serve_renderer(
     app = build_app(args, ("render",))
     await init_render_app_state(vllm_config, app.state, args)
 
+    # This log line is used for benchmarking. Please maintain the format
     logger.info("Starting vLLM server on %s", listen_address)
 
     return await serve_http(

--- a/vllm/model_executor/model_loader/default_loader.py
+++ b/vllm/model_executor/model_loader/default_loader.py
@@ -388,6 +388,7 @@ class DefaultModelLoader(BaseModelLoader):
         loaded_weights = model.load_weights(self.get_all_weights(model_config, model))
 
         self.counter_after_loading_weights = time.perf_counter()
+        # This log line is used for benchmarking. Please maintain the format
         logger.info_once(
             "Loading weights took %.2f seconds",
             self.counter_after_loading_weights - self.counter_before_loading_weights,

--- a/vllm/model_executor/model_loader/sharded_state_loader.py
+++ b/vllm/model_executor/model_loader/sharded_state_loader.py
@@ -154,6 +154,7 @@ class ShardedStateLoader(BaseModelLoader):
             param_data.copy_(tensor)
             state_dict.pop(key)
         counter_after_loading_weights = time.perf_counter()
+        # This log line is used for benchmarking. Please maintain the format
         logger.info_once(
             "Loading weights took %.2f seconds",
             counter_after_loading_weights - counter_before_loading_weights,

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -612,8 +612,7 @@ def download_weights_from_hf(
                 break
         time_taken = time.perf_counter() - start_time
         if time_taken > 0.5:
-            # This log line is used for benchmarking
-            # Please maintain the format.
+            # This log line is used for benchmarking. Please maintain the format
             logger.info(
                 "Time spent downloading weights for %s: %.6f seconds",
                 model_name_or_path,

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -1063,7 +1063,7 @@ def runai_safetensors_weights_iterator(
         tensor_iter = tqdm(
             streamer.get_tensors(),
             total=total_tensors,
-            # This line is used for benchmarking. Please maintain the format:
+            # This line is used for benchmarking. Please maintain the format
             desc="Loading safetensors using Runai Model Streamer",
             bar_format=_BAR_FORMAT,
             disable=not enable_tqdm(use_tqdm_on_load),

--- a/vllm/model_executor/model_loader/weight_utils.py
+++ b/vllm/model_executor/model_loader/weight_utils.py
@@ -612,6 +612,8 @@ def download_weights_from_hf(
                 break
         time_taken = time.perf_counter() - start_time
         if time_taken > 0.5:
+            # This log line is used for benchmarking
+            # Please maintain the format.
             logger.info(
                 "Time spent downloading weights for %s: %.6f seconds",
                 model_name_or_path,
@@ -1062,6 +1064,7 @@ def runai_safetensors_weights_iterator(
         tensor_iter = tqdm(
             streamer.get_tensors(),
             total=total_tensors,
+            # This line is used for benchmarking. Please maintain the format:
             desc="Loading safetensors using Runai Model Streamer",
             bar_format=_BAR_FORMAT,
             disable=not enable_tqdm(use_tqdm_on_load),


### PR DESCRIPTION
Add comments before logs used for benchmarking.

## Purpose

This PR adds comments to clarify that the specific format of the log message is relied upon by external benchmarking tools. The comments aim to prevent accidental modifications to this log format, which could break these tools.

## Test Plan
Since this change only adds comments to the codebase, the test plan is to ensure that the code still builds and runs without any new errors or regressions. Standard project tests should be sufficient.

## Test Result
N/A

