### PR TITLE
[Performance][MLA] Lift decode Q-prep (q-absorb + cat + FP8 quant) out of forward_impl

### DIFF
--- a/tests/kernels/core/test_mla_q_quant_separation.py
+++ b/tests/kernels/core/test_mla_q_quant_separation.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Bit-exact parity test for the q-quant-separation refactor in MLAAttention.
+
+The refactor lifts the decode q-prep (q-absorb BMM + head-dim cat + per-tensor
+FP8 quant) out of ``MLAAttention.forward_impl`` and into
+``MLAAttention.forward()`` so each step appears as a discrete FX node. This
+test pins the math: the lifted sequence
+``QAbsorb(q_nope) -> cat -> reshape -> static FP8 quant`` must produce exactly
+the same ``mqa_q`` tensor as the legacy in-place path
+``BMM(q_nope, W_UK_T) -> _DecodeConcatQuantFP8(ql_nope, q_pe, q_scale)``.
+
+Two cases are exercised: ``seq_len=1`` (the production decode hot path) and
+``seq_len=7`` (a small multi-row batch that catches off-by-one shape bugs).
+Both run at the canonical Kimi-K2.5 / DeepSeek-V3 dimensions.
+"""
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.attention.mla_attention import (
+    _DecodeConcatQuantFP8,
+)
+from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
+from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import set_random_seed
+
+# Kimi-K2.5 / DeepSeek-V3 production shapes.
+_QK_NOPE_HEAD_DIM = 128
+_QK_ROPE_HEAD_DIM = 64
+_KV_LORA_RANK = 512
+_NUM_HEADS = 128
+_DTYPE = torch.bfloat16
+
+
+def _legacy_inplace_mqa_q(
+    q_nope: torch.Tensor,
+    q_pe: torch.Tensor,
+    W_UK_T: torch.Tensor,
+    q_scale: torch.Tensor,
+    decode_concat_quant: _DecodeConcatQuantFP8,
+) -> torch.Tensor:
+    """Reproduce the BMM + cat + FP8-quant block from forward_impl exactly."""
+    # forward_impl: (B, N, P) -> (N, B, P)
+    q_nope_nb = q_nope.transpose(0, 1)
+    N, B, _ = q_nope_nb.shape
+    _, _, L = W_UK_T.shape
+    ql_nope_nb = q_nope_nb.new_empty((N, B, L))
+    torch.bmm(q_nope_nb, W_UK_T, out=ql_nope_nb)
+    # (N, B, L) -> (B, N, L)
+    ql_nope = ql_nope_nb.transpose(0, 1)
+    return decode_concat_quant(ql_nope, q_pe, q_scale)
+
+
+def _lifted_mqa_q(
+    q_nope: torch.Tensor,
+    q_pe: torch.Tensor,
+    W_UK_T: torch.Tensor,
+    q_scale: torch.Tensor,
+    quant_fp8: QuantFP8,
+) -> torch.Tensor:
+    """Reproduce the lifted q-prep that ``forward()`` emits as discrete FX nodes."""
+    # Discrete FX node #1: q-absorb BMM, BF16 output, (B, N, L).
+    q_nope_nb = q_nope.transpose(0, 1)
+    N, B, _ = q_nope_nb.shape
+    _, _, L = W_UK_T.shape
+    ql_nope_nb = q_nope_nb.new_empty((N, B, L))
+    torch.bmm(q_nope_nb, W_UK_T, out=ql_nope_nb)
+    ql_nope = ql_nope_nb.transpose(0, 1)
+    # Discrete FX node #2: head-dim concat.
+    q_full = torch.cat((ql_nope, q_pe), dim=-1)
+    # Discrete FX node #3: static per-tensor FP8 quant.
+    q_flat = q_full.reshape(q_full.shape[0], -1)
+    mqa_q_flat, _ = quant_fp8(q_flat, q_scale)
+    return mqa_q_flat.view(q_full.shape)
+
+
+@pytest.mark.skipif(not current_platform.is_cuda_alike(), reason="requires GPU")
+@pytest.mark.parametrize("seq_len", [1, 7])
+@torch.inference_mode()
+def test_lifted_q_prep_matches_inplace_decode_concat_quant(
+    default_vllm_config,
+    seq_len: int,
+) -> None:
+    device = "cuda:0"
+    set_random_seed(0)
+    torch.set_default_device(device)
+
+    q_nope = torch.randn(
+        seq_len, _NUM_HEADS, _QK_NOPE_HEAD_DIM, dtype=_DTYPE, device=device
+    )
+    q_pe = torch.randn(
+        seq_len, _NUM_HEADS, _QK_ROPE_HEAD_DIM, dtype=_DTYPE, device=device
+    )
+    # forward_impl uses W_UK_T with layout (N, P, L); same dtype as activations.
+    W_UK_T = torch.randn(
+        _NUM_HEADS, _QK_NOPE_HEAD_DIM, _KV_LORA_RANK, dtype=_DTYPE, device=device
+    )
+    q_scale = torch.tensor(0.125, dtype=torch.float32, device=device)
+
+    # The two CustomOp instances need to share the exact same quant kernel
+    # dispatch so we don't introduce a spurious mismatch.
+    decode_concat_quant = _DecodeConcatQuantFP8(
+        static=True,
+        group_shape=GroupShape.PER_TENSOR,
+        compile_native=True,
+    )
+    quant_fp8 = QuantFP8(
+        static=True,
+        group_shape=GroupShape.PER_TENSOR,
+        compile_native=True,
+    )
+
+    inplace = _legacy_inplace_mqa_q(q_nope, q_pe, W_UK_T, q_scale, decode_concat_quant)
+    lifted = _lifted_mqa_q(q_nope, q_pe, W_UK_T, q_scale, quant_fp8)
+
+    # The lift is supposed to be a pure reordering of the same ops, so the
+    # two FP8 tensors must be bit-exact.
+    assert inplace.dtype == lifted.dtype
+    assert inplace.shape == lifted.shape
+    torch.testing.assert_close(
+        inplace.to(torch.float32),
+        lifted.to(torch.float32),
+        atol=0.0,
+        rtol=0.0,
+    )

--- a/tests/kernels/core/test_mla_q_quant_separation_fx.py
+++ b/tests/kernels/core/test_mla_q_quant_separation_fx.py
@@ -10,13 +10,25 @@ AITER fused kernel.
 
 We compile ``_maybe_prepare_decode_mqa_q`` end-to-end with vLLM's
 ``TestBackend`` and assert that the post-Dynamo / pre-pass graph contains
-the four lifted ops as separate ``call_function`` nodes, in the right
-order:
+the lifted ops as separate ``call_function`` nodes, in the right order:
 
-* ``vllm::mla_decode_q_take``  (slices q to ``num_decode_tokens`` rows)
-* ``vllm::unified_mla_q_absorb``
-* ``aten::cat``
-* the static FP8 quant op
+* ``vllm::mla_split_batch``  — the only new vLLM custom op; returns
+  ``num_decode_tokens`` as an unbacked SymInt and keeps the metadata
+  read invisible to torch.compile (matches the convention from PR
+  #39346 where the same name is used).
+* ``aten::narrow`` (or its decomposed ``aten::slice`` form) — slices
+  ``q`` to the SymInt-many decode rows. The unbacked SymInt flows
+  through as the leading dim of every downstream tensor.
+* ``aten::bmm`` (when no AITER FP4/FP8 BMM kernel is available) or the
+  ``aten::triton_*`` kernel call — the q-absorb BMM, inlined (no
+  custom op wrapper, per upstream review on PR #41568).
+* ``aten::cat`` — head-dim concat.
+* The static FP8 quant op (either
+  ``vllm._C.static_scaled_fp8_quant`` or the decomposed
+  ``prims.convert_element_type → fp8_dtype`` chain).
+
+The chain after Dynamo therefore looks like
+``mla_split_batch → narrow → split → bmm/aiter_bmm → cat → fp8_quant``.
 
 ``vllm::unified_mla_attention_with_output`` is *not* exercised here (we
 test the prep in isolation), but its ``prepared_mqa_q`` kwarg is
@@ -28,6 +40,9 @@ pattern matcher will have nothing to match against.
 """
 
 from __future__ import annotations
+
+import os
+import pathlib
 
 import pytest
 import torch
@@ -55,6 +70,8 @@ _LAYER_NAME = "fxtest_layer.0"
 def _make_stub_layer(
     device: torch.device, dtype: torch.dtype, *, lift: bool
 ) -> MLAAttention:
+    import types
+
     layer: MLAAttention = object.__new__(MLAAttention)
     torch.nn.Module.__init__(layer)
     layer.qk_nope_head_dim = _QK_NOPE
@@ -74,6 +91,11 @@ def _make_stub_layer(
     layer._decode_concat_quant_fp8_op = _DecodeConcatQuantFP8(
         static=True, group_shape=GroupShape.PER_TENSOR, compile_native=True
     )
+    # Shared ``_run_decode_q_prep_kernels`` reads
+    # ``self.impl.supports_quant_query_input`` to decide whether to take
+    # the FP8-mqa_q-tensor return path. Stub it as a SimpleNamespace
+    # since we don't need a real attention impl for this trace test.
+    layer.impl = types.SimpleNamespace(supports_quant_query_input=True)
     return layer
 
 
@@ -93,9 +115,13 @@ class _LiftedQPrep(torch.nn.Module):
 
 
 def _make_forward_context(layer: MLAAttention, num_decode_tokens: int):
-    """Build a forward context with a stub attn_metadata that only carries
-    ``num_decode_tokens``. The lifted slice op (``mla_decode_q_take``) is
-    the only thing in this test that reads from attn_metadata.
+    """Build a forward context with a stub attn_metadata that carries
+    ``num_decode_tokens``.
+
+    ``vllm::mla_split_batch`` reads from this metadata at execution
+    time. ``no_compile_layers`` resolves the layer name back to the
+    layer object so the lifted helper can pick up ``W_UK_T``,
+    ``W_K`` / ``W_K_scale`` for the BMM.
     """
     import types
 
@@ -114,8 +140,8 @@ def _make_forward_context(layer: MLAAttention, num_decode_tokens: int):
 @pytest.mark.skipif(not current_platform.is_cuda_alike(), reason="requires GPU")
 @torch.inference_mode()
 def test_lifted_prep_emits_discrete_fx_nodes(default_vllm_config) -> None:
-    """The lifted prep, after Dynamo trace, must show the decode-rows
-    slice op, the q-absorb BMM op, the cat, and the FP8 quant op as
+    """The lifted prep, after Dynamo trace, must show the SymInt split
+    op, the slice, the q-absorb BMM, the cat, and the FP8 quant as
     separate ``call_function`` nodes.
     """
     device = torch.device("cuda:0")
@@ -133,8 +159,9 @@ def test_lifted_prep_emits_discrete_fx_nodes(default_vllm_config) -> None:
         _SEQ_LEN, _NUM_HEADS, _QK_NOPE + _QK_ROPE, dtype=dtype, device=device
     )
 
-    # Tell the slice op to keep all rows so the rest of the prep runs on a
-    # non-empty tensor; the FX-node assertions are independent of this size.
+    # Tell the SymInt op to keep all rows so the rest of the prep runs
+    # on a non-empty tensor; the FX-node assertions are independent of
+    # this size.
     fctx = _make_forward_context(layer, num_decode_tokens=_SEQ_LEN)
     with override_forward_context(fctx):
         out = compiled(q)
@@ -148,24 +175,38 @@ def test_lifted_prep_emits_discrete_fx_nodes(default_vllm_config) -> None:
     graph = backend.graph_pre_pass
 
     # --- The discrete ops we expect to see as separate FX nodes ---
-    q_take = torch.ops.vllm.mla_decode_q_take
-    q_absorb = torch.ops.vllm.unified_mla_q_absorb
+    split_batch = torch.ops.vllm.mla_split_batch
     high_level_fp8_quant = torch.ops._C.static_scaled_fp8_quant
     fp8_dtype = current_platform.fp8_dtype()
 
-    q_take_nodes = list(find_op_nodes(q_take, graph))
-    assert len(q_take_nodes) >= 1, (
-        "vllm::mla_decode_q_take is missing from the post-Dynamo graph. "
-        "The decode-rows slice collapsed back into the opaque attention "
+    split_batch_nodes = list(find_op_nodes(split_batch, graph))
+    assert len(split_batch_nodes) >= 1, (
+        "vllm::mla_split_batch is missing from the post-Dynamo graph. "
+        "The SymInt split point collapsed back into the opaque attention "
         "op or was inlined by Dynamo, which would re-introduce the "
-        "prefill-rows BMM waste. Graph dump:\n"
+        "metadata graph break. Graph dump:\n"
         f"{graph}"
     )
 
-    q_absorb_nodes = list(find_op_nodes(q_absorb, graph))
-    assert len(q_absorb_nodes) >= 1, (
-        "vllm::unified_mla_q_absorb is missing from the post-Dynamo graph. "
-        "The lift collapsed back into something else; Phase 2's pattern "
+    # ``q.narrow(0, 0, num_decode)`` should follow the SymInt op and
+    # feed the rest of the chain. Both ``aten.narrow`` and its
+    # decomposed form ``aten.slice`` are accepted (Dynamo / decomp
+    # tables vary).
+    narrow_nodes = list(find_op_nodes(torch.ops.aten.narrow, graph)) + list(
+        find_op_nodes(torch.ops.aten.slice, graph)
+    )
+    assert len(narrow_nodes) >= 1, (
+        "Expected an aten.narrow / aten.slice node consuming the SymInt "
+        f"from mla_split_batch. Graph dump:\n{graph}"
+    )
+
+    # The q-absorb BMM is now inlined (no custom op wrapper, per
+    # upstream review). The platform-neutral test stub uses
+    # ``torch.bmm``, so we look for ``aten.bmm`` here.
+    bmm_nodes = list(find_op_nodes(torch.ops.aten.bmm, graph))
+    assert len(bmm_nodes) >= 1, (
+        "aten.bmm is missing from the post-Dynamo graph. The q-absorb "
+        "BMM has been folded into something else; Phase 2's pattern "
         "matcher will have nothing to match. Graph dump:\n"
         f"{graph}"
     )
@@ -183,8 +224,8 @@ def test_lifted_prep_emits_discrete_fx_nodes(default_vllm_config) -> None:
     # 2. As a chain ending in ``prims.convert_element_type`` to the
     #    platform's FP8 dtype (preceded by ``clamp_min`` / ``clamp_max``).
     #
-    # Either way it must NOT be folded into ``unified_mla_q_absorb`` or
-    # any other opaque op — it has to be matchable by the Phase 2 pass.
+    # Either way it must NOT be folded into the BMM or any other opaque
+    # op — it has to be matchable by the Phase 2 pass.
     high_level_quant_nodes = list(find_op_nodes(high_level_fp8_quant, graph))
     fp8_cast_nodes = [
         n
@@ -202,24 +243,53 @@ def test_lifted_prep_emits_discrete_fx_nodes(default_vllm_config) -> None:
         f"{graph}"
     )
 
-    # Topology: mla_decode_q_take ->  q_absorb -> cat -> FP8 quant.
+    # Topology: mla_split_batch -> narrow -> bmm -> cat -> FP8 quant.
     # The pattern matcher in Phase 2 will rely on this ordering.
     quant_nodes = high_level_quant_nodes or fp8_cast_nodes
     indexed = list(graph.nodes)
-    q_take_idx = min(indexed.index(n) for n in q_take_nodes)
-    q_absorb_idx = min(indexed.index(n) for n in q_absorb_nodes)
+    split_batch_idx = min(indexed.index(n) for n in split_batch_nodes)
+    narrow_idx = min(indexed.index(n) for n in narrow_nodes)
+    bmm_idx = min(indexed.index(n) for n in bmm_nodes)
     cat_idx = min(indexed.index(n) for n in cat_nodes)
     quant_idx = min(indexed.index(n) for n in quant_nodes)
 
-    assert q_take_idx < q_absorb_idx, (
-        "Expected mla_decode_q_take to appear before unified_mla_q_absorb "
-        f"in the FX node ordering. Graph dump:\n{graph}"
+    assert split_batch_idx < narrow_idx, (
+        "Expected mla_split_batch to appear before aten.narrow in "
+        f"the FX node ordering. Graph dump:\n{graph}"
     )
-    assert q_absorb_idx < cat_idx, (
-        f"Expected unified_mla_q_absorb to appear before aten.cat:\n{graph}"
+    assert narrow_idx < bmm_idx, (
+        "Expected aten.narrow to appear before aten.bmm in the FX "
+        f"node ordering. Graph dump:\n{graph}"
     )
-    assert q_absorb_idx < quant_idx, (
-        "Expected unified_mla_q_absorb to appear before the FP8 quant in "
-        "the FX node ordering, but they are reversed. Graph dump:\n"
-        f"{graph}"
+    assert bmm_idx < cat_idx, (
+        f"Expected aten.bmm to appear before aten.cat:\n{graph}"
     )
+    assert bmm_idx < quant_idx, (
+        "Expected aten.bmm to appear before the FP8 quant in the FX "
+        f"node ordering, but they are reversed. Graph dump:\n{graph}"
+    )
+
+    # When invoked with ``MLA_FX_DUMP=<path>`` (or via the dump-to-cwd
+    # marker ``MLA_FX_DUMP=1``), persist the captured FX graph so the
+    # author can attach it to the PR as reviewer-facing evidence that
+    # the lifted chain is what Phase 2's pattern matcher will see. No
+    # behavioural change to the test itself; the dump is purely
+    # informational and only fires when the env var is set.
+    dump_target = os.environ.get("MLA_FX_DUMP")
+    if dump_target:
+        if dump_target == "1":
+            dump_target = "phase1_lifted_fx_graph.txt"
+        dump_path = pathlib.Path(dump_target).resolve()
+        dump_path.parent.mkdir(parents=True, exist_ok=True)
+        dump_path.write_text(
+            "Phase 1 — lifted MLA decode q-prep, post-Dynamo / pre-pass FX graph.\n"
+            "Captured by tests/kernels/core/test_mla_q_quant_separation_fx.py\n"
+            "Layer config: "
+            f"qk_nope={_QK_NOPE} qk_rope={_QK_ROPE} kv_lora={_KV_LORA} "
+            f"num_heads={_NUM_HEADS} seq_len={_SEQ_LEN}\n"
+            "Required FX nodes (asserted above):\n"
+            "  vllm::mla_split_batch (SymInt) -> aten::narrow / aten::slice "
+            "-> aten::bmm -> aten::cat -> static FP8 quant\n"
+            "----------------------------------------------------------------\n"
+            f"{graph}\n"
+        )

--- a/tests/kernels/core/test_mla_q_quant_separation_fx.py
+++ b/tests/kernels/core/test_mla_q_quant_separation_fx.py
@@ -10,14 +10,17 @@ AITER fused kernel.
 
 We compile ``_maybe_prepare_decode_mqa_q`` end-to-end with vLLM's
 ``TestBackend`` and assert that the post-Dynamo / pre-pass graph contains
-the four ops we care about as separate ``call_function`` nodes:
+the four lifted ops as separate ``call_function`` nodes, in the right
+order:
 
+* ``vllm::mla_decode_q_take``  (slices q to ``num_decode_tokens`` rows)
 * ``vllm::unified_mla_q_absorb``
 * ``aten::cat``
 * the static FP8 quant op
-* ``vllm::unified_mla_attention_with_output`` is *not* exercised here
-  (we test the prep in isolation), but its ``prepared_mqa_q`` kwarg is
-  validated separately by the wiring test.
+
+``vllm::unified_mla_attention_with_output`` is *not* exercised here (we
+test the prep in isolation), but its ``prepared_mqa_q`` kwarg is
+validated separately by the wiring test.
 
 If this test ever starts failing, **stop**: it means the lift has
 collapsed back into the opaque attention custom op and Phase 2's

--- a/tests/kernels/core/test_mla_q_quant_separation_fx.py
+++ b/tests/kernels/core/test_mla_q_quant_separation_fx.py
@@ -1,0 +1,196 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+FX-graph-shape test for the q-quant-separation refactor.
+
+This is the test that pins the **whole point** of Phase 1: the lifted
+decode q-prep must appear as discrete nodes in the FX graph so a
+downstream pattern matcher (Phase 2) can rewrite the chain into the
+AITER fused kernel.
+
+We compile ``_maybe_prepare_decode_mqa_q`` end-to-end with vLLM's
+``TestBackend`` and assert that the post-Dynamo / pre-pass graph contains
+the four ops we care about as separate ``call_function`` nodes:
+
+* ``vllm::unified_mla_q_absorb``
+* ``aten::cat``
+* the static FP8 quant op
+* ``vllm::unified_mla_attention_with_output`` is *not* exercised here
+  (we test the prep in isolation), but its ``prepared_mqa_q`` kwarg is
+  validated separately by the wiring test.
+
+If this test ever starts failing, **stop**: it means the lift has
+collapsed back into the opaque attention custom op and Phase 2's
+pattern matcher will have nothing to match against.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from tests.compile.backend import TestBackend
+from vllm.compilation.passes.fx_utils import find_op_nodes
+from vllm.forward_context import override_forward_context
+from vllm.model_executor.layers.attention.mla_attention import (
+    MLAAttention,
+    _DecodeConcatQuantFP8,
+)
+from vllm.model_executor.layers.quantization.input_quant_fp8 import QuantFP8
+from vllm.model_executor.layers.quantization.utils.quant_utils import GroupShape
+from vllm.platforms import current_platform
+from vllm.utils.torch_utils import LayerNameType, _encode_layer_name, set_random_seed
+
+_QK_NOPE = 128
+_QK_ROPE = 64
+_KV_LORA = 512
+_NUM_HEADS = 16
+_SEQ_LEN = 4
+_LAYER_NAME = "fxtest_layer.0"
+
+
+def _make_stub_layer(
+    device: torch.device, dtype: torch.dtype, *, lift: bool
+) -> MLAAttention:
+    layer: MLAAttention = object.__new__(MLAAttention)
+    torch.nn.Module.__init__(layer)
+    layer.qk_nope_head_dim = _QK_NOPE
+    layer.qk_rope_head_dim = _QK_ROPE
+    layer.kv_lora_rank = _KV_LORA
+    layer._lift_q_decode_quant = lift
+    layer.layer_name = _LAYER_NAME
+    layer.is_aiter_triton_fp4_bmm_enabled = False
+    layer.is_aiter_triton_fp8_bmm_enabled = False
+    layer.W_UK_T = torch.randn(
+        _NUM_HEADS, _QK_NOPE, _KV_LORA, dtype=dtype, device=device
+    )
+    layer._q_scale = torch.tensor(0.125, dtype=torch.float32, device=device)
+    layer._quant_fp8_op = QuantFP8(
+        static=True, group_shape=GroupShape.PER_TENSOR, compile_native=True
+    )
+    layer._decode_concat_quant_fp8_op = _DecodeConcatQuantFP8(
+        static=True, group_shape=GroupShape.PER_TENSOR, compile_native=True
+    )
+    return layer
+
+
+class _LiftedQPrep(torch.nn.Module):
+    """Thin wrapper around ``MLAAttention._maybe_prepare_decode_mqa_q`` so
+    we can ``torch.compile`` it in isolation."""
+
+    def __init__(self, layer: MLAAttention, encoded: LayerNameType) -> None:
+        super().__init__()
+        self.layer = layer
+        self.encoded = encoded
+
+    def forward(self, q: torch.Tensor) -> torch.Tensor:
+        out = self.layer._maybe_prepare_decode_mqa_q(q, self.encoded)
+        assert out is not None
+        return out
+
+
+def _make_forward_context(layer: MLAAttention):
+    from vllm.forward_context import ForwardContext
+
+    return ForwardContext(
+        no_compile_layers={layer.layer_name: layer},
+        all_moe_layers=None,
+        attn_metadata=None,
+        slot_mapping={},
+        dp_metadata=None,
+    )
+
+
+@pytest.mark.skipif(not current_platform.is_cuda_alike(), reason="requires GPU")
+@torch.inference_mode()
+def test_lifted_prep_emits_discrete_fx_nodes(default_vllm_config) -> None:
+    """The lifted prep, after Dynamo trace, must show the q-absorb BMM op,
+    the cat, and the FP8 quant op as separate ``call_function`` nodes.
+    """
+    device = torch.device("cuda:0")
+    dtype = torch.bfloat16
+    set_random_seed(0)
+
+    layer = _make_stub_layer(device, dtype, lift=True)
+    encoded = _encode_layer_name(_LAYER_NAME)
+    module = _LiftedQPrep(layer, encoded).eval()
+
+    backend = TestBackend()  # no custom passes; we only want the captured graph
+    compiled = torch.compile(module, backend=backend, fullgraph=True)
+
+    q = torch.randn(
+        _SEQ_LEN, _NUM_HEADS, _QK_NOPE + _QK_ROPE, dtype=dtype, device=device
+    )
+
+    with override_forward_context(_make_forward_context(layer)):
+        out = compiled(q)
+
+    assert out is not None and out.dtype == current_platform.fp8_dtype()
+    assert backend.graph_pre_pass is not None, (
+        "TestBackend never captured a graph; torch.compile may have fallen "
+        "through without invoking the post_grad pass hook."
+    )
+    graph = backend.graph_pre_pass
+
+    # --- The discrete ops we expect to see as separate FX nodes ---
+    q_absorb = torch.ops.vllm.unified_mla_q_absorb
+    high_level_fp8_quant = torch.ops._C.static_scaled_fp8_quant
+    fp8_dtype = current_platform.fp8_dtype()
+
+    q_absorb_nodes = list(find_op_nodes(q_absorb, graph))
+    assert len(q_absorb_nodes) >= 1, (
+        "vllm::unified_mla_q_absorb is missing from the post-Dynamo graph. "
+        "The lift collapsed back into something else; Phase 2's pattern "
+        "matcher will have nothing to match. Graph dump:\n"
+        f"{graph}"
+    )
+
+    cat_nodes = list(find_op_nodes(torch.ops.aten.cat, graph))
+    assert len(cat_nodes) >= 1, (
+        f"aten::cat is missing from the post-Dynamo graph:\n{graph}"
+    )
+
+    # The FP8 quant is visible in the graph in one of two shapes,
+    # depending on whether QuantFP8 lowered to its high-level op or got
+    # decomposed by ``compile_native=True``:
+    #
+    # 1. As a single ``vllm._C.static_scaled_fp8_quant`` call, or
+    # 2. As a chain ending in ``prims.convert_element_type`` to the
+    #    platform's FP8 dtype (preceded by ``clamp_min`` / ``clamp_max``).
+    #
+    # Either way it must NOT be folded into ``unified_mla_q_absorb`` or
+    # any other opaque op — it has to be matchable by the Phase 2 pass.
+    high_level_quant_nodes = list(find_op_nodes(high_level_fp8_quant, graph))
+    fp8_cast_nodes = [
+        n
+        for n in graph.find_nodes(
+            op="call_function",
+            target=torch.ops.prims.convert_element_type.default,
+        )
+        if len(n.args) >= 2 and n.args[1] == fp8_dtype
+    ]
+    assert high_level_quant_nodes or fp8_cast_nodes, (
+        "Neither static_scaled_fp8_quant nor a prims.convert_element_type "
+        f"to {fp8_dtype} is present in the post-Dynamo graph. The lifted "
+        "FP8 quant has been fused away or eliminated, which would defeat "
+        "the purpose of the lift.\n"
+        f"{graph}"
+    )
+
+    # Topology: q_absorb must appear strictly before the (decomposed or
+    # high-level) FP8 quant. Order by graph node index.
+    quant_nodes = high_level_quant_nodes or fp8_cast_nodes
+    indexed = list(graph.nodes)
+    q_absorb_idx = min(indexed.index(n) for n in q_absorb_nodes)
+    quant_idx = min(indexed.index(n) for n in quant_nodes)
+    assert q_absorb_idx < quant_idx, (
+        "Expected unified_mla_q_absorb to appear before the FP8 quant in "
+        "the FX node ordering, but they are reversed. Graph dump:\n"
+        f"{graph}"
+    )
+
+    # And q_absorb must appear before the cat (cat consumes its output).
+    cat_idx = min(indexed.index(n) for n in cat_nodes)
+    assert q_absorb_idx < cat_idx, (
+        f"Expected unified_mla_q_absorb to appear before aten.cat:\n{graph}"
+    )

--- a/tests/kernels/core/test_mla_q_quant_separation_fx.py
+++ b/tests/kernels/core/test_mla_q_quant_separation_fx.py
@@ -89,13 +89,20 @@ class _LiftedQPrep(torch.nn.Module):
         return out
 
 
-def _make_forward_context(layer: MLAAttention):
+def _make_forward_context(layer: MLAAttention, num_decode_tokens: int):
+    """Build a forward context with a stub attn_metadata that only carries
+    ``num_decode_tokens``. The lifted slice op (``mla_decode_q_take``) is
+    the only thing in this test that reads from attn_metadata.
+    """
+    import types
+
     from vllm.forward_context import ForwardContext
 
+    fake_attn_meta = types.SimpleNamespace(num_decode_tokens=num_decode_tokens)
     return ForwardContext(
         no_compile_layers={layer.layer_name: layer},
         all_moe_layers=None,
-        attn_metadata=None,
+        attn_metadata={layer.layer_name: fake_attn_meta},
         slot_mapping={},
         dp_metadata=None,
     )
@@ -104,8 +111,9 @@ def _make_forward_context(layer: MLAAttention):
 @pytest.mark.skipif(not current_platform.is_cuda_alike(), reason="requires GPU")
 @torch.inference_mode()
 def test_lifted_prep_emits_discrete_fx_nodes(default_vllm_config) -> None:
-    """The lifted prep, after Dynamo trace, must show the q-absorb BMM op,
-    the cat, and the FP8 quant op as separate ``call_function`` nodes.
+    """The lifted prep, after Dynamo trace, must show the decode-rows
+    slice op, the q-absorb BMM op, the cat, and the FP8 quant op as
+    separate ``call_function`` nodes.
     """
     device = torch.device("cuda:0")
     dtype = torch.bfloat16
@@ -122,10 +130,14 @@ def test_lifted_prep_emits_discrete_fx_nodes(default_vllm_config) -> None:
         _SEQ_LEN, _NUM_HEADS, _QK_NOPE + _QK_ROPE, dtype=dtype, device=device
     )
 
-    with override_forward_context(_make_forward_context(layer)):
+    # Tell the slice op to keep all rows so the rest of the prep runs on a
+    # non-empty tensor; the FX-node assertions are independent of this size.
+    fctx = _make_forward_context(layer, num_decode_tokens=_SEQ_LEN)
+    with override_forward_context(fctx):
         out = compiled(q)
 
     assert out is not None and out.dtype == current_platform.fp8_dtype()
+    assert out.shape == (_SEQ_LEN, _NUM_HEADS, _KV_LORA + _QK_ROPE), out.shape
     assert backend.graph_pre_pass is not None, (
         "TestBackend never captured a graph; torch.compile may have fallen "
         "through without invoking the post_grad pass hook."
@@ -133,9 +145,19 @@ def test_lifted_prep_emits_discrete_fx_nodes(default_vllm_config) -> None:
     graph = backend.graph_pre_pass
 
     # --- The discrete ops we expect to see as separate FX nodes ---
+    q_take = torch.ops.vllm.mla_decode_q_take
     q_absorb = torch.ops.vllm.unified_mla_q_absorb
     high_level_fp8_quant = torch.ops._C.static_scaled_fp8_quant
     fp8_dtype = current_platform.fp8_dtype()
+
+    q_take_nodes = list(find_op_nodes(q_take, graph))
+    assert len(q_take_nodes) >= 1, (
+        "vllm::mla_decode_q_take is missing from the post-Dynamo graph. "
+        "The decode-rows slice collapsed back into the opaque attention "
+        "op or was inlined by Dynamo, which would re-introduce the "
+        "prefill-rows BMM waste. Graph dump:\n"
+        f"{graph}"
+    )
 
     q_absorb_nodes = list(find_op_nodes(q_absorb, graph))
     assert len(q_absorb_nodes) >= 1, (
@@ -177,20 +199,24 @@ def test_lifted_prep_emits_discrete_fx_nodes(default_vllm_config) -> None:
         f"{graph}"
     )
 
-    # Topology: q_absorb must appear strictly before the (decomposed or
-    # high-level) FP8 quant. Order by graph node index.
+    # Topology: mla_decode_q_take ->  q_absorb -> cat -> FP8 quant.
+    # The pattern matcher in Phase 2 will rely on this ordering.
     quant_nodes = high_level_quant_nodes or fp8_cast_nodes
     indexed = list(graph.nodes)
+    q_take_idx = min(indexed.index(n) for n in q_take_nodes)
     q_absorb_idx = min(indexed.index(n) for n in q_absorb_nodes)
+    cat_idx = min(indexed.index(n) for n in cat_nodes)
     quant_idx = min(indexed.index(n) for n in quant_nodes)
+
+    assert q_take_idx < q_absorb_idx, (
+        "Expected mla_decode_q_take to appear before unified_mla_q_absorb "
+        f"in the FX node ordering. Graph dump:\n{graph}"
+    )
+    assert q_absorb_idx < cat_idx, (
+        f"Expected unified_mla_q_absorb to appear before aten.cat:\n{graph}"
+    )
     assert q_absorb_idx < quant_idx, (
         "Expected unified_mla_q_absorb to appear before the FP8 quant in "
         "the FX node ordering, but they are reversed. Graph dump:\n"
         f"{graph}"
-    )
-
-    # And q_absorb must appear before the cat (cat consumes its output).
-    cat_idx = min(indexed.index(n) for n in cat_nodes)
-    assert q_absorb_idx < cat_idx, (
-        f"Expected unified_mla_q_absorb to appear before aten.cat:\n{graph}"
     )

--- a/vllm/config/compilation.py
+++ b/vllm/config/compilation.py
@@ -152,6 +152,16 @@ class PassConfig:
     Larger batch sizes e.g. during prefill will use the unfused kernels.
     """
 
+    lift_mla_decode_q_prep: bool = False
+    """Lift the MLA decode q-prep chain (split + q-absorb BMM + cat +
+    static FP8 quant) out of ``MLAAttention.forward_impl`` into
+    ``forward()`` so torch.compile sees it as discrete FX nodes that a
+    Phase 2 pattern matcher can rewrite into the AITER fused kernel.
+
+    Off by default. Requires ``cc.use_inductor_graph_partition=True`` to
+    avoid the cudagraph capture/replay SymInt freeze on the lifted
+    decode rows. Only applies on the FP8 decode path."""
+
     fi_allreduce_fusion_max_size_mb: float | None = None
     """The threshold of the communicated tensor sizes under which
     vllm should use flashinfer fused allreduce. Specified as a

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1135,7 +1135,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     # If set, vLLM will disable the MLA attention optimizations.
     "VLLM_MLA_DISABLE": lambda: bool(int(os.getenv("VLLM_MLA_DISABLE", "0"))),
-    # If set, vLLM will pick up the provided Flash Attention MLA
     # Number of GPUs per worker in Ray, if it is set to be a fraction,
     # it allows ray to schedule multiple actors on a single GPU,
     # so that users can colocate other actors on the same GPUs as vLLM.

--- a/vllm/model_executor/custom_op.py
+++ b/vllm/model_executor/custom_op.py
@@ -247,6 +247,13 @@ class CustomOp(nn.Module):
 
             @functools.wraps(fn)
             def wrapper(*args, **kwargs):
+                # If this wrapper is reached while tracing an enclosing
+                # torch.compile graph, calling mark_dynamic is forbidden.
+                # In that case, run the eager-native function directly and
+                # let the outer trace capture it.
+                if torch.compiler.is_compiling():
+                    return fn(*args, **kwargs)
+
                 bound = sig.bind(*args, **kwargs)
                 bound.apply_defaults()
                 for name, dims in dynamic_arg_dims.items():

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -516,17 +516,36 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         #
         # We only lift on the FP8 decode path that today goes through
         # ``_DecodeConcatQuantFP8``. All conditions below are layer-init
-        # constants, so this is safe to bake in at trace time.
+        # constants, so this is safe to bake in at trace time. The lifted
+        # path stays off unless
+        # ``cc.pass_config.lift_mla_decode_q_prep=True`` (see
+        # ``_compute_lift_q_decode_quant``).
         decode_context_parallel_size = (
             vllm_config.parallel_config.decode_context_parallel_size
             if vllm_config is not None
             else 1
+        )
+        compilation_config = (
+            vllm_config.compilation_config if vllm_config is not None else None
+        )
+        pass_config = (
+            compilation_config.pass_config if compilation_config is not None else None
         )
         self._lift_q_decode_quant = self._compute_lift_q_decode_quant(
             kv_cache_dtype=self.kv_cache_dtype,
             impl=self.impl,
             q_pad_num_heads=self.q_pad_num_heads,
             decode_context_parallel_size=decode_context_parallel_size,
+            use_inductor_graph_partition=(
+                compilation_config.use_inductor_graph_partition
+                if compilation_config is not None
+                else False
+            ),
+            lift_decode_q_prep=(
+                bool(getattr(pass_config, "lift_mla_decode_q_prep", False))
+                if pass_config is not None
+                else False
+            ),
         )
 
     @staticmethod
@@ -535,13 +554,19 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         impl: "MLAAttentionImpl",
         q_pad_num_heads: int | None,
         decode_context_parallel_size: int,
+        use_inductor_graph_partition: bool,
+        lift_decode_q_prep: bool,
     ) -> bool:
         """Pure predicate for the decode q-prep lift gate.
 
         Extracted from ``__init__`` so the truth table is unit-testable
-        without standing up a full ``MLAAttention`` instance. See the
-        Q_QUANT_SEPARATION_HANDOFF.md, §3.3 for the rationale of each
-        condition.
+        without standing up a full ``MLAAttention`` instance.
+
+        The lifted path is gated by
+        ``cc.pass_config.lift_mla_decode_q_prep`` and additionally
+        requires ``cc.use_inductor_graph_partition``: without graph
+        partitioning, piecewise/full cudagraph capture can freeze the
+        decode SymInt at capture time and replay it incorrectly.
         """
         return (
             is_quantized_kv_cache(kv_cache_dtype)
@@ -550,6 +575,8 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             and not isinstance(impl, SparseMLAAttentionImpl)
             and q_pad_num_heads is None
             and decode_context_parallel_size <= 1
+            and use_inductor_graph_partition
+            and lift_decode_q_prep
         )
 
     @property
@@ -569,14 +596,39 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         k_pe: torch.Tensor,
         output_shape: torch.Size | None = None,
     ) -> torch.Tensor:
-        if self.calculate_kv_scales:
-            torch.ops.vllm.maybe_calc_kv_scales(
-                q,
-                kv_c_normed,
-                k_pe,
-                _encode_layer_name(self.layer_name),
-            )
+        encoded = _encode_layer_name(self.layer_name)
 
+        if self.calculate_kv_scales:
+            torch.ops.vllm.maybe_calc_kv_scales(q, kv_c_normed, k_pe, encoded)
+
+        # ProExpertProg-style outer/inner-forward split (see PR #39346
+        # discussion): one place picks between the lifted (FX-visible
+        # decode q-prep) path and the opaque single-op path. Everything
+        # else stays identical between the two so reviewers can read
+        # the policy at one site.
+        if self._lift_q_decode_quant:
+            return self._lifted_inner_forward(
+                q, kv_c_normed, k_pe, output_shape, encoded
+            )
+        return self._opaque_forward(q, kv_c_normed, k_pe, output_shape, encoded)
+
+    def _opaque_forward(
+        self,
+        q: torch.Tensor,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        output_shape: torch.Size | None,
+        encoded: LayerNameType,
+    ) -> torch.Tensor:
+        """Default path: MLA attention is one opaque custom op.
+
+        This is the historical path; ``torch.compile`` sees a single
+        ``vllm::unified_mla_attention_with_output`` node and never
+        traces into the q-absorb BMM / cat / FP8 quant / attention
+        kernels. No FX-visible q-prep, so Phase 2 has nothing to bind
+        to; that's fine — Phase 2 only fires when the lifted path is
+        active.
+        """
         if self.use_direct_call:
             forward_context: ForwardContext = get_forward_context()
             attn_metadata_raw = forward_context.attn_metadata
@@ -604,9 +656,96 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 self._k_scale,
             )
             output = torch.empty(output_shape, dtype=q.dtype, device=q.device)
-            prepared_mqa_q = self._maybe_prepare_decode_mqa_q(
-                q, _encode_layer_name(self.layer_name)
+            self.forward_impl(
+                q,
+                kv_c_normed,
+                k_pe,
+                self_kv_cache,
+                attn_metadata,
+                output=output,
             )
+            return output
+
+        kv_cache_dummy_dep = torch.ops.vllm.unified_mla_kv_cache_update(
+            kv_c_normed,
+            k_pe,
+            encoded,
+            self.kv_cache_dtype,
+            self._k_scale,
+        )
+        output = torch.empty(output_shape, dtype=q.dtype, device=q.device)
+        torch.ops.vllm.unified_mla_attention_with_output(
+            q,
+            kv_c_normed,
+            k_pe,
+            output,
+            encoded,
+            kv_cache_dummy_dep=kv_cache_dummy_dep,
+        )
+        return output
+
+    def _lifted_inner_forward(
+        self,
+        q: torch.Tensor,
+        kv_c_normed: torch.Tensor,
+        k_pe: torch.Tensor,
+        output_shape: torch.Size | None,
+        encoded: LayerNameType,
+    ) -> torch.Tensor:
+        """Lifted (decomposed) path: decode q-prep happens here as
+        plain torch ops so torch.compile / FX see them.
+
+        Layout mirrors PR #39346's ``inner_forward`` sketch from
+        ProExpertProg's review:
+
+        * The ``vllm::mla_split_batch`` SymInt op + ``aten.narrow`` +
+          BMM + cat + static FP8 quant are emitted as discrete FX
+          nodes here, ready for a Phase 2
+          ``VllmFusionPatternMatcherPass`` to rewrite.
+        * The actual attention kernel call stays opaque (still one
+          ``vllm::unified_mla_attention_with_output`` op), so the
+          backend remains responsible for its own correctness and
+          perf — we are only exposing the *prep* chain, not the
+          attention itself.
+
+        Strict by design: when the gate is on we never silently
+        recompute prep in ``forward_impl``. If the row count of
+        ``prepared_mqa_q`` does not match ``num_decode_tokens`` at
+        kernel-launch time, ``forward_impl`` asserts and the run
+        stops, so any capture/replay shape drift is loud.
+        """
+        prepared_mqa_q = self._maybe_prepare_decode_mqa_q(q, encoded)
+        assert prepared_mqa_q is not None, (
+            "_lift_q_decode_quant=True but _maybe_prepare_decode_mqa_q "
+            "returned None; the gate predicate is out of sync with "
+            "the prep helper."
+        )
+
+        if self.use_direct_call:
+            forward_context: ForwardContext = get_forward_context()
+            attn_metadata_raw = forward_context.attn_metadata
+            attn_metadata: MLACommonMetadata
+            if isinstance(attn_metadata_raw, dict):
+                attn_metadata = attn_metadata_raw[self.layer_name]  # type: ignore[assignment]
+            elif isinstance(attn_metadata_raw, list):
+                attn_metadata = attn_metadata_raw[0][self.layer_name]  # type: ignore[assignment]
+            else:
+                attn_metadata = attn_metadata_raw
+            self_kv_cache = self.kv_cache
+            slot_mapping = forward_context.slot_mapping
+
+            assert isinstance(slot_mapping, dict), (
+                f"Expected slot_mapping to be a dict, got {type(slot_mapping)}. "
+            )
+            self.impl.do_kv_cache_update(  # type: ignore[attr-defined]
+                kv_c_normed,
+                k_pe,
+                self_kv_cache,
+                slot_mapping.get(self.layer_name),
+                self.kv_cache_dtype,
+                self._k_scale,
+            )
+            output = torch.empty(output_shape, dtype=q.dtype, device=q.device)
             self.forward_impl(
                 q,
                 kv_c_normed,
@@ -617,27 +756,108 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 prepared_mqa_q=prepared_mqa_q,
             )
             return output
+
+        kv_cache_dummy_dep = torch.ops.vllm.unified_mla_kv_cache_update(
+            kv_c_normed,
+            k_pe,
+            encoded,
+            self.kv_cache_dtype,
+            self._k_scale,
+        )
+        output = torch.empty(output_shape, dtype=q.dtype, device=q.device)
+        torch.ops.vllm.unified_mla_attention_with_output(
+            q,
+            kv_c_normed,
+            k_pe,
+            output,
+            encoded,
+            kv_cache_dummy_dep=kv_cache_dummy_dep,
+            prepared_mqa_q=prepared_mqa_q,
+        )
+        return output
+
+    def _run_decode_q_prep_kernels(
+        self,
+        mqa_q_nope: torch.Tensor,
+        mqa_q_pe: torch.Tensor,
+        fp8_attention: bool,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        """Q-absorb BMM + (optional) head-dim concat + per-tensor FP8 quant.
+
+        Shared between ``_maybe_prepare_decode_mqa_q`` (the lifted path
+        in ``forward()`` that exposes the chain to torch.compile as
+        discrete FX nodes) and the legacy in-place branch in
+        ``forward_impl`` (eager). Same code, same kernels, same math —
+        bit-exact between the two callers, which keeps the parity test
+        ``tests/kernels/core/test_mla_q_quant_separation.py`` honest.
+
+        Excludes the ``q_pad_num_heads is not None`` branch: that path
+        intermixes head-padding with kernel-specific allocation and is
+        kept inline in ``forward_impl``. The lift gate disables the
+        lifted path whenever padding is active, so this branch is never
+        reached from ``_maybe_prepare_decode_mqa_q``.
+
+        Args:
+            mqa_q_nope: ``(B, N, qk_nope_head_dim)`` no-PE part.
+            mqa_q_pe:   ``(B, N, qk_rope_head_dim)`` PE part.
+            fp8_attention: ``is_quantized_kv_cache(kv_cache_dtype)`` —
+                when true and the impl supports FP8 query input, the
+                helper returns the FP8 ``mqa_q`` tensor; otherwise
+                returns the ``(ql_nope, mqa_q_pe)`` tuple that the DCP
+                / non-FP8 paths consume.
+
+        We force ``y_scale=None`` on the AITER FP4/FP8 BMM kernels so
+        the BMM output stays in BF16 and the subsequent cat + per-tensor
+        quant remain visible as separate ops. Phase 2's pattern matcher
+        binds to those ops, so collapsing them into the kernel's fused
+        ``y_scale`` path would defeat the lift. The legacy in-place path
+        previously used the fused path; the resulting extra per-tensor
+        quant kernel launch is bounded (one launch per layer per decode
+        forward) and is recovered entirely once Phase 2 replaces the
+        whole chain with the AITER fused kernel.
+        """
+        # (B, N, P) -> (N, B, P) for the BMM kernels.
+        q_nope_nb = mqa_q_nope.transpose(0, 1)
+
+        if self.is_aiter_triton_fp4_bmm_enabled:
+            from aiter.ops.triton.batched_gemm_a16wfp4 import batched_gemm_a16wfp4
+
+            ql_nope = batched_gemm_a16wfp4(
+                q_nope_nb,
+                self.W_K,
+                self.W_K_scale,
+                transpose_bm=True,
+                prequant=True,
+                # Force BF16 output here so cat + FP8-quant stay visible
+                # as discrete graph nodes downstream (see docstring).
+                y_scale=None,
+            )
+        elif self.is_aiter_triton_fp8_bmm_enabled:
+            ql_nope = rocm_aiter_ops.triton_fp8_bmm(
+                q_nope_nb,
+                self.W_K,
+                self.W_K_scale,
+                group_size=128,
+                transpose_bm=True,
+            )
         else:
-            encoded = _encode_layer_name(self.layer_name)
-            kv_cache_dummy_dep = torch.ops.vllm.unified_mla_kv_cache_update(
-                kv_c_normed,
-                k_pe,
-                encoded,
-                self.kv_cache_dtype,
-                self._k_scale,
+            # Plain BMM path. We deliberately *do not* preallocate
+            # ``out=`` here: when ``q_nope_nb`` carries an unbacked
+            # SymInt batch dim from ``vllm::mla_split_batch`` (the
+            # lifted decode path), constructing a ``new_empty`` with
+            # that SymInt and feeding it as ``out=`` introduces a
+            # data-dependent shape-equality guard that Dynamo cannot
+            # discharge (``GuardOnDataDependentSymNode: u0``). Letting
+            # ``torch.bmm`` infer the output shape avoids the guard
+            # and is bit-equivalent.
+            ql_nope_nb = torch.bmm(q_nope_nb, self.W_UK_T)
+            ql_nope = ql_nope_nb.transpose(0, 1)
+
+        if fp8_attention and self.impl.supports_quant_query_input:
+            return self._decode_concat_quant_fp8_op(
+                ql_nope, mqa_q_pe, self._q_scale
             )
-            output = torch.empty(output_shape, dtype=q.dtype, device=q.device)
-            prepared_mqa_q = self._maybe_prepare_decode_mqa_q(q, encoded)
-            torch.ops.vllm.unified_mla_attention_with_output(
-                q,
-                kv_c_normed,
-                k_pe,
-                output,
-                encoded,
-                kv_cache_dummy_dep=kv_cache_dummy_dep,
-                prepared_mqa_q=prepared_mqa_q,
-            )
-            return output
+        return (ql_nope, mqa_q_pe)
 
     def _maybe_prepare_decode_mqa_q(
         self,
@@ -647,38 +867,65 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         """Run the lifted decode q-prep (slice + q-absorb + cat + FP8 quant).
 
         Returns the FP8-quantized ``mqa_q`` (shape ``(num_decode_tokens,
-        num_heads, kv_lora_rank + qk_rope_head_dim)``) when the trace-time
-        gate is enabled, otherwise ``None`` and ``forward_impl`` runs the
-        legacy in-place path.
+        num_heads, kv_lora_rank + qk_rope_head_dim)``) when the
+        trace-time gate is enabled, otherwise ``None`` and
+        ``forward_impl`` runs the legacy in-place path.
 
-        The first FX node is ``vllm::mla_decode_q_take``, which trims ``q``
-        to the decode rows (``q[:num_decode_tokens]``) by reading
-        ``attn_metadata`` from the forward context at execution time. The
-        BMM, cat and FP8 quant therefore operate on decode-only tokens —
-        prefill rows and cudagraph padding never enter the lifted prep.
+        Design note (mirrors PR #39346 / @morrison-turnansky's
+        ``mla_split_batch`` pattern):
+
+        - ``vllm::mla_split_batch`` is a SymInt-returning custom op;
+          its impl reads ``attn_metadata.num_decode_tokens`` at runtime
+          and its fake returns ``ctx.new_dynamic_size()``. Wrapping
+          this metadata read in a custom op is what keeps it invisible
+          to ``torch.compile``, so the surrounding ops stay traceable
+          without graph-breaking on the metadata access.
+        - The slice (``q.narrow(0, 0, num_decode)``), q-absorb BMM,
+          cat, and FP8 quant are deliberately **not** wrapped in
+          custom ops — they are plain aten / kernel calls that
+          torch.compile sees as discrete FX nodes, ready for Phase 2's
+          pattern matcher to bind to.
+
+        Known caveat: under vLLM's *piecewise* CUDA-graph capture, the
+        decode SymInt resolves at capture time and is baked into the
+        captured graph's tensor sizes / kernel grids. At replay with a
+        runtime ``num_decode_tokens`` different from the capture-time
+        value, the captured chain still operates at the captured size,
+        producing incorrect output. PR #39346 sidesteps this by using
+        ``cudagraph_mode=FULL_AND_PIECEWISE`` plus
+        ``use_inductor_graph_partition=true`` (commit ``0aa9492``:
+        "stable cuda graph piece replay addresses").
+
+        The lift gate (``cc.pass_config.lift_mla_decode_q_prep``) is
+        therefore additionally **and**-ed with
+        ``cc.use_inductor_graph_partition`` in
+        ``_compute_lift_q_decode_quant``, and ``forward_impl``
+        asserts on row mismatch instead of silently recomputing —
+        any residual capture/replay drift is loud, not silent.
         """
         if not self._lift_q_decode_quant:
             return None
 
-        # Discrete FX node #1: take only the decode rows.
-        q_decode = torch.ops.vllm.mla_decode_q_take(q, layer_name_encoded)
+        # Discrete FX node #1: SymInt split point.
+        #
+        # We intentionally avoid torch._check/_check_is_size hints here.
+        # On our current stack, those hints lower through a path that
+        # reaches ``torch._dynamo.mark_dynamic`` during fullgraph capture,
+        # which Dynamo rejects with:
+        #   AssertionError: Attempt to trace forbidden callable mark_dynamic
+        # The bound is still enforced by ``aten.narrow`` at runtime.
+        num_decode = torch.ops.vllm.mla_split_batch(q, layer_name_encoded)
 
-        q_nope, q_pe = q_decode.split(
+        # Discrete FX node #2: slice q to decode rows.
+        q_decode = q.narrow(0, 0, num_decode)
+        mqa_q_nope, mqa_q_pe = q_decode.split(
             [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
         )
-
-        # Discrete FX node #2: q-absorption BMM (BF16 output).
-        ql_nope = torch.ops.vllm.unified_mla_q_absorb(q_nope, layer_name_encoded)
-
-        # Discrete FX node #3: concat along head_dim.
-        q_full = torch.cat((ql_nope, q_pe), dim=-1)
-
-        # Discrete FX node #4: static per-tensor FP8 quantization.
-        # Reshape mirrors ``_DecodeConcatQuantFP8.forward`` so QuantFP8 sees
-        # the same 2-D shape it has always been called with.
-        q_flat = q_full.reshape(q_full.shape[0], -1)
-        mqa_q_flat, _ = self._quant_fp8_op(q_flat, self._q_scale)
-        return mqa_q_flat.view(q_full.shape)
+        # The shared helper emits FX nodes #3 (BMM), #4 (cat), and
+        # #5 (FP8 quant). The lift gate guarantees ``fp8_attention``
+        # is true and ``supports_quant_query_input`` is true, so the
+        # helper takes the FP8-mqa_q-tensor return path.
+        return self._run_decode_q_prep_kernels(mqa_q_nope, mqa_q_pe, fp8_attention=True)
 
     def forward_impl(
         self,
@@ -749,9 +996,10 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         q = q[:num_actual_toks, ...]
         k_c_normed = k_c_normed[:num_actual_toks, ...]
         k_pe = k_pe[:num_actual_toks, ...]
-        # ``prepared_mqa_q`` arrives sized to ``num_decode_tokens`` (sliced
-        # by ``vllm::mla_decode_q_take`` inside ``_maybe_prepare_decode_mqa_q``),
-        # which is ``<= num_actual_toks``, so no cudagraph-padding trim is
+        # ``prepared_mqa_q`` arrives sized to ``num_decode_tokens``
+        # (sliced by ``q.narrow(0, 0, vllm::mla_split_batch(...))``
+        # inside ``_maybe_prepare_decode_mqa_q``), which is
+        # ``<= num_actual_toks``, so no cudagraph-padding trim is
         # needed here. The decode-row slice below also becomes a no-op.
 
         if fp8_attention and self.kv_cache_dtype != "fp8_ds_mla":
@@ -787,17 +1035,35 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             mqa_output_slice = output[:num_mqa_tokens]
 
             if prepared_mqa_q is not None:
-                # Lifted decode q-prep path: caller has already produced a
-                # quantized ``mqa_q`` via ``forward()`` so the slice,
-                # q-absorb BMM, head_dim concat, and FP8 quant are visible
-                # as discrete FX nodes. The lift sizes ``prepared_mqa_q``
-                # to ``num_decode_tokens == num_mqa_tokens``, so we can
-                # consume it directly.
+                # Lifted decode q-prep path: ``_lifted_inner_forward``
+                # already sliced to decode rows and ran the q-absorb
+                # BMM + cat + FP8 quant via
+                # ``_maybe_prepare_decode_mqa_q``. The SymInt split
+                # point in that helper makes the slice visible to
+                # torch.compile, so ``prepared_mqa_q`` must be sized to
+                # ``num_decode_tokens == num_mqa_tokens`` at kernel
+                # launch.
+                #
+                # Strict by design: a row mismatch here means the
+                # cudagraph capture/replay froze the SymInt at a
+                # different decode size, which silently corrupts
+                # outputs. Fail loudly instead of recomputing — the
+                # gate (``cc.pass_config.lift_mla_decode_q_prep``)
+                # ships default-off precisely because Phase 1 alone
+                # cannot guarantee this won't happen on every stack;
+                # the freeze is dodged either by PR #39346's
+                # "stable cuda graph piece replay" work or by Phase 2
+                # collapsing the chain into one fused op (#41839).
                 assert prepared_mqa_q.shape[0] == num_mqa_tokens, (
-                    f"prepared_mqa_q has {prepared_mqa_q.shape[0]} rows "
-                    f"but expected {num_mqa_tokens} (num_decode_tokens). "
-                    "The lift in MLAAttention.forward() should have already "
-                    "trimmed to the decode slice via mla_decode_q_take."
+                    f"prepared_mqa_q row mismatch ({prepared_mqa_q.shape[0]} "
+                    f"vs {num_mqa_tokens} decode rows). The lifted "
+                    "decode q-prep produced a tensor with the wrong "
+                    "leading dim; this is a cudagraph capture/replay "
+                    "SymInt freeze on the lifted chain. Phase 1 of the "
+                    "decode q-prep lift cannot make this safe by "
+                    "itself. For now, set "
+                    "cc.pass_config.lift_mla_decode_q_prep=False "
+                    "(default) to fall back to the in-impl prep."
                 )
                 mqa_q = prepared_mqa_q
             else:
@@ -806,63 +1072,67 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                     [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
                 )
 
-                # Convert from (B, N, P) to (N, B, P)
-                mqa_q_nope = mqa_q_nope.transpose(0, 1)
-
                 if self.q_pad_num_heads is not None:
+                    # Padded path: kept inline because the head padding
+                    # is intermixed with kernel-specific allocation.
+                    # ``_run_decode_q_prep_kernels`` deliberately doesn't
+                    # cover this branch (the lift gate disables the lift
+                    # whenever padding is active, so the lifted path
+                    # never reaches it).
+                    mqa_q_nope = mqa_q_nope.transpose(0, 1)
+
                     B, N, L = mqa_q_pe.shape
                     mqa_pe_padded = mqa_q_pe.new_empty((B, self.q_pad_num_heads, L))
                     mqa_pe_padded.resize_((B, N, L))
                     mqa_pe_padded.copy_(mqa_q_pe)
                     mqa_q_pe = mqa_pe_padded
 
-                if self.is_aiter_triton_fp4_bmm_enabled:
-                    from aiter.ops.triton.batched_gemm_a16wfp4 import (
-                        batched_gemm_a16wfp4,
-                    )
+                    if self.is_aiter_triton_fp4_bmm_enabled:
+                        from aiter.ops.triton.batched_gemm_a16wfp4 import (
+                            batched_gemm_a16wfp4,
+                        )
 
-                    mqa_ql_nope = batched_gemm_a16wfp4(
-                        mqa_q_nope,
-                        self.W_K,
-                        self.W_K_scale,
-                        transpose_bm=True,
-                        prequant=True,
-                        y_scale=self._q_scale if fp8_attention else None,
-                    )
-                elif self.is_aiter_triton_fp8_bmm_enabled:
-                    # Multiply+Transpose (N, B, P)x(N, P, L)->(N, B, L)->(B, N, L)
-                    mqa_ql_nope = rocm_aiter_ops.triton_fp8_bmm(
-                        mqa_q_nope,
-                        self.W_K,
-                        self.W_K_scale,
-                        group_size=128,
-                        transpose_bm=True,
-                    )
-                else:
-                    # Pads the head_dim if necessary (for the underlying kernel)
-                    N, B, P = mqa_q_nope.shape
-                    _, _, L = self.W_UK_T.shape
-
-                    if self.q_pad_num_heads is not None:
-                        mqa_ql_nope = mqa_q_nope.new_empty((self.q_pad_num_heads, B, L))
-                        mqa_ql_nope.resize_((N, B, L))
+                        mqa_ql_nope = batched_gemm_a16wfp4(
+                            mqa_q_nope,
+                            self.W_K,
+                            self.W_K_scale,
+                            transpose_bm=True,
+                            prequant=True,
+                            y_scale=self._q_scale if fp8_attention else None,
+                        )
+                    elif self.is_aiter_triton_fp8_bmm_enabled:
+                        mqa_ql_nope = rocm_aiter_ops.triton_fp8_bmm(
+                            mqa_q_nope,
+                            self.W_K,
+                            self.W_K_scale,
+                            group_size=128,
+                            transpose_bm=True,
+                        )
                     else:
-                        mqa_ql_nope = mqa_q_nope.new_empty((N, B, L))
+                        N, B, P = mqa_q_nope.shape
+                        _, _, L = self.W_UK_T.shape
+                        mqa_ql_nope = mqa_q_nope.new_empty(
+                            (self.q_pad_num_heads, B, L)
+                        )
+                        mqa_ql_nope.resize_((N, B, L))
+                        torch.bmm(mqa_q_nope, self.W_UK_T, out=mqa_ql_nope)
+                        mqa_ql_nope = mqa_ql_nope.transpose(0, 1)
 
-                    # Multiply (N, B, P) x (N, P, L) -> (N, B, L)
-                    torch.bmm(mqa_q_nope, self.W_UK_T, out=mqa_ql_nope)
-
-                    # Convert from (N, B, L) to (B, N, L)
-                    mqa_ql_nope = mqa_ql_nope.transpose(0, 1)
-
-                if fp8_attention and self.impl.supports_quant_query_input:
-                    assert mqa_ql_nope.shape[0] == mqa_q_pe.shape[0]
-                    assert mqa_ql_nope.shape[1] == mqa_q_pe.shape[1]
-                    mqa_q = self._decode_concat_quant_fp8_op(
-                        mqa_ql_nope, mqa_q_pe, self._q_scale
-                    )
+                    if fp8_attention and self.impl.supports_quant_query_input:
+                        assert mqa_ql_nope.shape[0] == mqa_q_pe.shape[0]
+                        assert mqa_ql_nope.shape[1] == mqa_q_pe.shape[1]
+                        mqa_q = self._decode_concat_quant_fp8_op(
+                            mqa_ql_nope, mqa_q_pe, self._q_scale
+                        )
+                    else:
+                        mqa_q = (mqa_ql_nope, mqa_q_pe)
                 else:
-                    mqa_q = (mqa_ql_nope, mqa_q_pe)
+                    # No padding: same kernels as the lifted path,
+                    # via the shared helper. Bit-exact between the two
+                    # callers (verified by the parity test).
+                    mqa_q = self._run_decode_q_prep_kernels(
+                        mqa_q_nope, mqa_q_pe, fp8_attention=fp8_attention
+                    )
             if self.impl.dcp_world_size > 1:
                 assert not fp8_attention, "DCP not support fp8 kvcache now."
                 # concatenate mqa_ql_nope and mqa_q_pe -> (B, N, L + P)
@@ -1164,114 +1434,42 @@ direct_register_custom_op(
 )
 
 
-def unified_mla_q_absorb(
-    q_nope: torch.Tensor,
-    layer_name: LayerNameType,
-) -> torch.Tensor:
-    """Run the MLA Q-absorption BMM on the no-PE part of the query.
-
-    Hoists the q_nope @ W_UK_T computation (a.k.a. "Q absorption") out of
-    ``MLAAttention.forward_impl`` and exposes it as a standalone custom op so
-    it shows up as a discrete node in the FX graph. This is a prerequisite
-    for FX-pass-based fusion of (q-absorb, cat, q-quant) with the upstream
-    KV-cache write.
-
-    Always returns ``ql_nope`` in BF16/FP16 layout ``(B, N, L)``; the FP8
-    quantization is intentionally split off into a downstream node.
-
-    Args:
-        q_nope: ``(B, N, qk_nope_head_dim)`` no-PE part of the query.
-        layer_name: Encoded layer name used to look up the owning
-            ``MLAAttention`` from the forward context.
-
-    Returns:
-        ``ql_nope`` of shape ``(B, N, kv_lora_rank)`` with the same dtype as
-        the input, regardless of whether the FP4/FP8 BMM kernel could itself
-        produce FP8 output.
-    """
-    layer_name = _resolve_layer_name(layer_name)
-    forward_context = get_forward_context()
-    attn_layer = forward_context.no_compile_layers[layer_name]
-
-    # Convert (B, N, P) -> (N, B, P) for the BMM kernels, mirroring the
-    # in-place path in ``forward_impl``.
-    q_nope_nb = q_nope.transpose(0, 1)
-
-    if attn_layer.is_aiter_triton_fp4_bmm_enabled:
-        from aiter.ops.triton.batched_gemm_a16wfp4 import batched_gemm_a16wfp4
-
-        ql_nope = batched_gemm_a16wfp4(
-            q_nope_nb,
-            attn_layer.W_K,
-            attn_layer.W_K_scale,
-            transpose_bm=True,
-            prequant=True,
-            # Force BF16 output here so cat + FP8-quant stay visible as
-            # discrete graph nodes downstream.
-            y_scale=None,
-        )
-        return ql_nope
-
-    if attn_layer.is_aiter_triton_fp8_bmm_enabled:
-        ql_nope = rocm_aiter_ops.triton_fp8_bmm(
-            q_nope_nb,
-            attn_layer.W_K,
-            attn_layer.W_K_scale,
-            group_size=128,
-            transpose_bm=True,
-        )
-        return ql_nope
-
-    N, B, _P = q_nope_nb.shape
-    _, _, L = attn_layer.W_UK_T.shape
-    ql_nope_nb = q_nope_nb.new_empty((N, B, L))
-    torch.bmm(q_nope_nb, attn_layer.W_UK_T, out=ql_nope_nb)
-    return ql_nope_nb.transpose(0, 1)
-
-
-def unified_mla_q_absorb_fake(
-    q_nope: torch.Tensor,
-    layer_name: LayerNameType,
-) -> torch.Tensor:
-    layer_name = _resolve_layer_name(layer_name)
-    forward_context = get_forward_context()
-    attn_layer = forward_context.no_compile_layers[layer_name]
-    return q_nope.new_empty((q_nope.shape[0], q_nope.shape[1], attn_layer.kv_lora_rank))
-
-
-direct_register_custom_op(
-    op_name="unified_mla_q_absorb",
-    op_func=unified_mla_q_absorb,
-    fake_impl=unified_mla_q_absorb_fake,
+torch.library.define(
+    "vllm::mla_split_batch",
+    "(Tensor q, str layer_name) -> SymInt",
+    tags=torch.Tag.pt2_compliant_tag,
 )
 
 
-def mla_decode_q_take(
-    q: torch.Tensor,
-    layer_name: LayerNameType,
-) -> torch.Tensor:
-    """Slice ``q`` to the decode rows (``q[:num_decode_tokens]``).
+@torch.library.impl("vllm::mla_split_batch", "CompositeExplicitAutograd")
+def mla_split_batch_impl(q: torch.Tensor, layer_name: str) -> int:
+    """Read ``num_decode_tokens`` from forward context as a runtime int.
 
-    Reads ``num_decode_tokens`` from ``forward_context.attn_metadata`` at
-    graph-execution time so the lifted q-prep operates only on the decode
-    portion of the batch, not on prefill rows or cudagraph padding. The op
-    is opaque to Dynamo (the slice index isn't a graph input) but appears
-    as a discrete FX node so a downstream pattern matcher can bind to it.
+    Wrapping this metadata read in a custom op (with a SymInt-returning
+    fake) is what keeps it invisible to ``torch.compile``: the
+    surrounding lifted ops (``q.narrow``, the q-absorb BMM, cat, FP8
+    quant) stay fully traceable, with the SymInt as their leading dim,
+    instead of graph-breaking on the ``attn_metadata`` access.
 
-    Returns a zero-row slice when ``attn_metadata`` is unavailable (profile
-    runs) or when ``num_decode_tokens`` isn't populated; ``forward_impl``'s
-    own ``attn_metadata is None`` early-return handles the empty case.
+    Same role as ``vllm::mla_split_batch`` in PR #39346
+    ([Refactor][MLA]: Expose mla to torch.compile), under the same
+    name to match the upstream convention.
 
-    We deliberately reach into ``forward_context.attn_metadata`` directly
-    rather than going through ``get_attention_context``: the slice only
-    needs the metadata field, not ``attn_layer`` / ``kv_cache`` / slot
-    mapping, and avoiding that lookup keeps the op cheap.
+    Returns 0 when ``attn_metadata`` is unavailable (profile runs) or
+    when ``num_decode_tokens`` isn't populated. Downstream callers
+    handle the 0-row case via ``forward_impl``'s
+    ``num_mqa_tokens > 0`` guard.
+
+    We deliberately reach into ``forward_context.attn_metadata``
+    directly rather than going through ``get_attention_context``: we
+    only need the metadata field, not ``attn_layer`` / ``kv_cache`` /
+    slot mapping, and avoiding that lookup keeps the op cheap.
     """
     layer_name = _resolve_layer_name(layer_name)
     forward_context = get_forward_context()
     attn_metadata_raw = forward_context.attn_metadata
     if attn_metadata_raw is None:
-        return q[:0]
+        return 0
     # Mirror the dispatch get_attention_context() does: per-layer dict,
     # list-of-dicts (speculative decoding), or a single attn_metadata.
     if isinstance(attn_metadata_raw, dict):
@@ -1281,33 +1479,21 @@ def mla_decode_q_take(
     else:
         attn_metadata = attn_metadata_raw
     if attn_metadata is None:
-        return q[:0]
+        return 0
     num_decode = getattr(attn_metadata, "num_decode_tokens", None)
-    if num_decode is None:
-        return q[:0]
-    return q[:num_decode]
+    return int(num_decode) if num_decode else 0
 
 
-def mla_decode_q_take_fake(
-    q: torch.Tensor,
-    layer_name: LayerNameType,
-) -> torch.Tensor:
-    # Declare the symbolic shape as the input's shape (an upper bound):
-    # the runtime slice always has ``num_decode_tokens <= q.shape[0]``
-    # rows. Using a backed SymInt (``q.shape[0]``) instead of an unbacked
-    # one keeps downstream ops (``QuantFP8.forward_native``'s
-    # ``group_broadcast``, etc.) free of data-dependent guard failures.
-    # At graph-execution time the real op returns a smaller tensor and
-    # downstream FX nodes operate on its actual runtime shape — same
-    # pattern as ``unified_mla_q_absorb_fake``.
-    return q.new_empty((q.shape[0], q.shape[1], q.shape[2]))
-
-
-direct_register_custom_op(
-    op_name="mla_decode_q_take",
-    op_func=mla_decode_q_take,
-    fake_impl=mla_decode_q_take_fake,
-)
+@torch.library.register_fake("vllm::mla_split_batch")
+def mla_split_batch_fake(q: torch.Tensor, layer_name: str) -> int:
+    # Return a fresh unbacked SymInt at trace time. Inductor then tracks
+    # ``num_decode_tokens`` as its own dynamic dimension, independent of
+    # the input batch size ``q.shape[0]``. Downstream ops
+    # (``q.narrow(0, 0, num_decode)``, the inline BMM, cat, FP8 quant)
+    # carry this unbacked SymInt as their leading dim, so symbolic
+    # shapes match runtime shapes exactly — no fake-impl shape lie.
+    ctx = torch.library.get_ctx()
+    return ctx.new_dynamic_size()
 
 
 @maybe_transfer_kv_layer

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -510,6 +510,48 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             compile_native=True,
         )
 
+        # Trace-time gate that controls whether the decode q-prep
+        # (q-absorb BMM + cat + FP8 quant) is lifted out of ``forward_impl``
+        # into ``forward()`` so it appears as discrete FX graph nodes.
+        #
+        # We only lift on the FP8 decode path that today goes through
+        # ``_DecodeConcatQuantFP8``. All conditions below are layer-init
+        # constants, so this is safe to bake in at trace time.
+        decode_context_parallel_size = (
+            vllm_config.parallel_config.decode_context_parallel_size
+            if vllm_config is not None
+            else 1
+        )
+        self._lift_q_decode_quant = self._compute_lift_q_decode_quant(
+            kv_cache_dtype=self.kv_cache_dtype,
+            impl=self.impl,
+            q_pad_num_heads=self.q_pad_num_heads,
+            decode_context_parallel_size=decode_context_parallel_size,
+        )
+
+    @staticmethod
+    def _compute_lift_q_decode_quant(
+        kv_cache_dtype: str,
+        impl: "MLAAttentionImpl",
+        q_pad_num_heads: int | None,
+        decode_context_parallel_size: int,
+    ) -> bool:
+        """Pure predicate for the decode q-prep lift gate.
+
+        Extracted from ``__init__`` so the truth table is unit-testable
+        without standing up a full ``MLAAttention`` instance. See the
+        Q_QUANT_SEPARATION_HANDOFF.md, §3.3 for the rationale of each
+        condition.
+        """
+        return (
+            is_quantized_kv_cache(kv_cache_dtype)
+            and kv_cache_dtype != "fp8_ds_mla"
+            and getattr(impl, "supports_quant_query_input", False)
+            and not isinstance(impl, SparseMLAAttentionImpl)
+            and q_pad_num_heads is None
+            and decode_context_parallel_size <= 1
+        )
+
     @property
     def chunked_prefill_workspace_size(self) -> int:
         if self._chunked_prefill_workspace_size is None:
@@ -562,6 +604,9 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 self._k_scale,
             )
             output = torch.empty(output_shape, dtype=q.dtype, device=q.device)
+            prepared_mqa_q = self._maybe_prepare_decode_mqa_q(
+                q, _encode_layer_name(self.layer_name)
+            )
             self.forward_impl(
                 q,
                 kv_c_normed,
@@ -569,6 +614,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 self_kv_cache,
                 attn_metadata,
                 output=output,
+                prepared_mqa_q=prepared_mqa_q,
             )
             return output
         else:
@@ -581,6 +627,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 self._k_scale,
             )
             output = torch.empty(output_shape, dtype=q.dtype, device=q.device)
+            prepared_mqa_q = self._maybe_prepare_decode_mqa_q(q, encoded)
             torch.ops.vllm.unified_mla_attention_with_output(
                 q,
                 kv_c_normed,
@@ -588,8 +635,45 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 output,
                 encoded,
                 kv_cache_dummy_dep=kv_cache_dummy_dep,
+                prepared_mqa_q=prepared_mqa_q,
             )
             return output
+
+    def _maybe_prepare_decode_mqa_q(
+        self,
+        q: torch.Tensor,
+        layer_name_encoded: LayerNameType,
+    ) -> torch.Tensor | None:
+        """Run the lifted decode q-prep (q-absorb + cat + FP8 quant).
+
+        Returns the FP8-quantized ``mqa_q`` (shape ``(B, N, kv_lora_rank +
+        qk_rope_head_dim)``) when the trace-time gate is enabled, otherwise
+        ``None`` and ``forward_impl`` runs the legacy in-place path.
+
+        We compute the prep over the full input ``q`` (decode + prefill).
+        ``forward_impl`` slices it to ``[:num_mqa_tokens]`` for the decode
+        kernel; prefill rows continue to flow through ``forward_mha`` with
+        the original BF16 ``q``. This wastes a small amount of compute on
+        mixed/pure-prefill batches but keeps the prep trace-time-constant
+        and graph-visible, which is the whole point.
+        """
+        if not self._lift_q_decode_quant:
+            return None
+
+        q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+
+        # Discrete FX node #1: q-absorption BMM (BF16 output).
+        ql_nope = torch.ops.vllm.unified_mla_q_absorb(q_nope, layer_name_encoded)
+
+        # Discrete FX node #2: concat along head_dim.
+        q_full = torch.cat((ql_nope, q_pe), dim=-1)
+
+        # Discrete FX node #3: static per-tensor FP8 quantization.
+        # Reshape mirrors ``_DecodeConcatQuantFP8.forward`` so QuantFP8 sees
+        # the same 2-D shape it has always been called with.
+        q_flat = q_full.reshape(q_full.shape[0], -1)
+        mqa_q_flat, _ = self._quant_fp8_op(q_flat, self._q_scale)
+        return mqa_q_flat.view(q_full.shape)
 
     def forward_impl(
         self,
@@ -605,6 +689,7 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         quant_scale_ue8m0: bool | None = None,
         quant_col_major: bool | None = None,
         quant_tma_aligned: bool | None = None,
+        prepared_mqa_q: torch.Tensor | None = None,
     ) -> torch.Tensor:
         assert output is not None, "Output tensor must be provided."
 
@@ -659,6 +744,8 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         q = q[:num_actual_toks, ...]
         k_c_normed = k_c_normed[:num_actual_toks, ...]
         k_pe = k_pe[:num_actual_toks, ...]
+        if prepared_mqa_q is not None:
+            prepared_mqa_q = prepared_mqa_q[:num_actual_toks, ...]
 
         if fp8_attention and self.kv_cache_dtype != "fp8_ds_mla":
             kv_cache = kv_cache.view(current_platform.fp8_dtype())
@@ -690,68 +777,78 @@ class MLAAttention(nn.Module, AttentionLayerBase):
             )
 
         if num_mqa_tokens > 0:
-            mqa_q = q[:num_mqa_tokens]
             mqa_output_slice = output[:num_mqa_tokens]
 
-            mqa_q_nope, mqa_q_pe = mqa_q.split(
-                [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
-            )
-
-            # Convert from (B, N, P) to (N, B, P)
-            mqa_q_nope = mqa_q_nope.transpose(0, 1)
-
-            if self.q_pad_num_heads is not None:
-                B, N, L = mqa_q_pe.shape
-                mqa_pe_padded = mqa_q_pe.new_empty((B, self.q_pad_num_heads, L))
-                mqa_pe_padded.resize_((B, N, L))
-                mqa_pe_padded.copy_(mqa_q_pe)
-                mqa_q_pe = mqa_pe_padded
-
-            if self.is_aiter_triton_fp4_bmm_enabled:
-                from aiter.ops.triton.batched_gemm_a16wfp4 import batched_gemm_a16wfp4
-
-                mqa_ql_nope = batched_gemm_a16wfp4(
-                    mqa_q_nope,
-                    self.W_K,
-                    self.W_K_scale,
-                    transpose_bm=True,
-                    prequant=True,
-                    y_scale=self._q_scale if fp8_attention else None,
-                )
-            elif self.is_aiter_triton_fp8_bmm_enabled:
-                # Multiply+Transpose (N, B, P)x(N, P, L)->(N, B, L)->(B, N, L)
-                mqa_ql_nope = rocm_aiter_ops.triton_fp8_bmm(
-                    mqa_q_nope,
-                    self.W_K,
-                    self.W_K_scale,
-                    group_size=128,
-                    transpose_bm=True,
-                )
+            if prepared_mqa_q is not None:
+                # Lifted decode q-prep path: caller has already produced a
+                # quantized ``mqa_q`` via ``forward()`` so the q-absorb BMM,
+                # head_dim concat, and FP8 quant are visible as discrete FX
+                # nodes. The lifted prep was computed for the full token
+                # extent, so trim it to the decode slice here.
+                mqa_q = prepared_mqa_q[:num_mqa_tokens]
             else:
-                # Pads the head_dim if necessary (for the underlying kernel)
-                N, B, P = mqa_q_nope.shape
-                _, _, L = self.W_UK_T.shape
+                mqa_q = q[:num_mqa_tokens]
+                mqa_q_nope, mqa_q_pe = mqa_q.split(
+                    [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
+                )
+
+                # Convert from (B, N, P) to (N, B, P)
+                mqa_q_nope = mqa_q_nope.transpose(0, 1)
 
                 if self.q_pad_num_heads is not None:
-                    mqa_ql_nope = mqa_q_nope.new_empty((self.q_pad_num_heads, B, L))
-                    mqa_ql_nope.resize_((N, B, L))
+                    B, N, L = mqa_q_pe.shape
+                    mqa_pe_padded = mqa_q_pe.new_empty((B, self.q_pad_num_heads, L))
+                    mqa_pe_padded.resize_((B, N, L))
+                    mqa_pe_padded.copy_(mqa_q_pe)
+                    mqa_q_pe = mqa_pe_padded
+
+                if self.is_aiter_triton_fp4_bmm_enabled:
+                    from aiter.ops.triton.batched_gemm_a16wfp4 import (
+                        batched_gemm_a16wfp4,
+                    )
+
+                    mqa_ql_nope = batched_gemm_a16wfp4(
+                        mqa_q_nope,
+                        self.W_K,
+                        self.W_K_scale,
+                        transpose_bm=True,
+                        prequant=True,
+                        y_scale=self._q_scale if fp8_attention else None,
+                    )
+                elif self.is_aiter_triton_fp8_bmm_enabled:
+                    # Multiply+Transpose (N, B, P)x(N, P, L)->(N, B, L)->(B, N, L)
+                    mqa_ql_nope = rocm_aiter_ops.triton_fp8_bmm(
+                        mqa_q_nope,
+                        self.W_K,
+                        self.W_K_scale,
+                        group_size=128,
+                        transpose_bm=True,
+                    )
                 else:
-                    mqa_ql_nope = mqa_q_nope.new_empty((N, B, L))
+                    # Pads the head_dim if necessary (for the underlying kernel)
+                    N, B, P = mqa_q_nope.shape
+                    _, _, L = self.W_UK_T.shape
 
-                # Multiply (N, B, P) x (N, P, L) -> (N, B, L)
-                torch.bmm(mqa_q_nope, self.W_UK_T, out=mqa_ql_nope)
+                    if self.q_pad_num_heads is not None:
+                        mqa_ql_nope = mqa_q_nope.new_empty((self.q_pad_num_heads, B, L))
+                        mqa_ql_nope.resize_((N, B, L))
+                    else:
+                        mqa_ql_nope = mqa_q_nope.new_empty((N, B, L))
 
-                # Convert from (N, B, L) to (B, N, L)
-                mqa_ql_nope = mqa_ql_nope.transpose(0, 1)
+                    # Multiply (N, B, P) x (N, P, L) -> (N, B, L)
+                    torch.bmm(mqa_q_nope, self.W_UK_T, out=mqa_ql_nope)
 
-            if fp8_attention and self.impl.supports_quant_query_input:
-                assert mqa_ql_nope.shape[0] == mqa_q_pe.shape[0]
-                assert mqa_ql_nope.shape[1] == mqa_q_pe.shape[1]
-                mqa_q = self._decode_concat_quant_fp8_op(
-                    mqa_ql_nope, mqa_q_pe, self._q_scale
-                )
-            else:
-                mqa_q = (mqa_ql_nope, mqa_q_pe)
+                    # Convert from (N, B, L) to (B, N, L)
+                    mqa_ql_nope = mqa_ql_nope.transpose(0, 1)
+
+                if fp8_attention and self.impl.supports_quant_query_input:
+                    assert mqa_ql_nope.shape[0] == mqa_q_pe.shape[0]
+                    assert mqa_ql_nope.shape[1] == mqa_q_pe.shape[1]
+                    mqa_q = self._decode_concat_quant_fp8_op(
+                        mqa_ql_nope, mqa_q_pe, self._q_scale
+                    )
+                else:
+                    mqa_q = (mqa_ql_nope, mqa_q_pe)
             if self.impl.dcp_world_size > 1:
                 assert not fp8_attention, "DCP not support fp8 kvcache now."
                 # concatenate mqa_ql_nope and mqa_q_pe -> (B, N, L + P)
@@ -1053,6 +1150,88 @@ direct_register_custom_op(
 )
 
 
+def unified_mla_q_absorb(
+    q_nope: torch.Tensor,
+    layer_name: LayerNameType,
+) -> torch.Tensor:
+    """Run the MLA Q-absorption BMM on the no-PE part of the query.
+
+    Hoists the q_nope @ W_UK_T computation (a.k.a. "Q absorption") out of
+    ``MLAAttention.forward_impl`` and exposes it as a standalone custom op so
+    it shows up as a discrete node in the FX graph. This is a prerequisite
+    for FX-pass-based fusion of (q-absorb, cat, q-quant) with the upstream
+    KV-cache write.
+
+    Always returns ``ql_nope`` in BF16/FP16 layout ``(B, N, L)``; the FP8
+    quantization is intentionally split off into a downstream node.
+
+    Args:
+        q_nope: ``(B, N, qk_nope_head_dim)`` no-PE part of the query.
+        layer_name: Encoded layer name used to look up the owning
+            ``MLAAttention`` from the forward context.
+
+    Returns:
+        ``ql_nope`` of shape ``(B, N, kv_lora_rank)`` with the same dtype as
+        the input, regardless of whether the FP4/FP8 BMM kernel could itself
+        produce FP8 output.
+    """
+    layer_name = _resolve_layer_name(layer_name)
+    forward_context = get_forward_context()
+    attn_layer = forward_context.no_compile_layers[layer_name]
+
+    # Convert (B, N, P) -> (N, B, P) for the BMM kernels, mirroring the
+    # in-place path in ``forward_impl``.
+    q_nope_nb = q_nope.transpose(0, 1)
+
+    if attn_layer.is_aiter_triton_fp4_bmm_enabled:
+        from aiter.ops.triton.batched_gemm_a16wfp4 import batched_gemm_a16wfp4
+
+        ql_nope = batched_gemm_a16wfp4(
+            q_nope_nb,
+            attn_layer.W_K,
+            attn_layer.W_K_scale,
+            transpose_bm=True,
+            prequant=True,
+            # Force BF16 output here so cat + FP8-quant stay visible as
+            # discrete graph nodes downstream.
+            y_scale=None,
+        )
+        return ql_nope
+
+    if attn_layer.is_aiter_triton_fp8_bmm_enabled:
+        ql_nope = rocm_aiter_ops.triton_fp8_bmm(
+            q_nope_nb,
+            attn_layer.W_K,
+            attn_layer.W_K_scale,
+            group_size=128,
+            transpose_bm=True,
+        )
+        return ql_nope
+
+    N, B, _P = q_nope_nb.shape
+    _, _, L = attn_layer.W_UK_T.shape
+    ql_nope_nb = q_nope_nb.new_empty((N, B, L))
+    torch.bmm(q_nope_nb, attn_layer.W_UK_T, out=ql_nope_nb)
+    return ql_nope_nb.transpose(0, 1)
+
+
+def unified_mla_q_absorb_fake(
+    q_nope: torch.Tensor,
+    layer_name: LayerNameType,
+) -> torch.Tensor:
+    layer_name = _resolve_layer_name(layer_name)
+    forward_context = get_forward_context()
+    attn_layer = forward_context.no_compile_layers[layer_name]
+    return q_nope.new_empty((q_nope.shape[0], q_nope.shape[1], attn_layer.kv_lora_rank))
+
+
+direct_register_custom_op(
+    op_name="unified_mla_q_absorb",
+    op_func=unified_mla_q_absorb,
+    fake_impl=unified_mla_q_absorb_fake,
+)
+
+
 @maybe_transfer_kv_layer
 def unified_mla_attention_with_output(
     q: torch.Tensor,
@@ -1067,6 +1246,7 @@ def unified_mla_attention_with_output(
     quant_scale_ue8m0: bool | None = None,
     quant_col_major: bool | None = None,
     quant_tma_aligned: bool | None = None,
+    prepared_mqa_q: torch.Tensor | None = None,
 ) -> None:
     # kv_cache_dummy_dep is not used but accepting it creates a data dependency
     # that ensures torch.compile preserves ordering between KV cache update and
@@ -1087,6 +1267,7 @@ def unified_mla_attention_with_output(
         quant_scale_ue8m0=quant_scale_ue8m0,
         quant_col_major=quant_col_major,
         quant_tma_aligned=quant_tma_aligned,
+        prepared_mqa_q=prepared_mqa_q,
     )
 
 
@@ -1103,6 +1284,7 @@ def unified_mla_attention_with_output_fake(
     quant_scale_ue8m0: bool | None = None,
     quant_col_major: bool | None = None,
     quant_tma_aligned: bool | None = None,
+    prepared_mqa_q: torch.Tensor | None = None,
 ) -> None:
     return
 

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -644,31 +644,36 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         q: torch.Tensor,
         layer_name_encoded: LayerNameType,
     ) -> torch.Tensor | None:
-        """Run the lifted decode q-prep (q-absorb + cat + FP8 quant).
+        """Run the lifted decode q-prep (slice + q-absorb + cat + FP8 quant).
 
-        Returns the FP8-quantized ``mqa_q`` (shape ``(B, N, kv_lora_rank +
-        qk_rope_head_dim)``) when the trace-time gate is enabled, otherwise
-        ``None`` and ``forward_impl`` runs the legacy in-place path.
+        Returns the FP8-quantized ``mqa_q`` (shape ``(num_decode_tokens,
+        num_heads, kv_lora_rank + qk_rope_head_dim)``) when the trace-time
+        gate is enabled, otherwise ``None`` and ``forward_impl`` runs the
+        legacy in-place path.
 
-        We compute the prep over the full input ``q`` (decode + prefill).
-        ``forward_impl`` slices it to ``[:num_mqa_tokens]`` for the decode
-        kernel; prefill rows continue to flow through ``forward_mha`` with
-        the original BF16 ``q``. This wastes a small amount of compute on
-        mixed/pure-prefill batches but keeps the prep trace-time-constant
-        and graph-visible, which is the whole point.
+        The first FX node is ``vllm::mla_decode_q_take``, which trims ``q``
+        to the decode rows (``q[:num_decode_tokens]``) by reading
+        ``attn_metadata`` from the forward context at execution time. The
+        BMM, cat and FP8 quant therefore operate on decode-only tokens —
+        prefill rows and cudagraph padding never enter the lifted prep.
         """
         if not self._lift_q_decode_quant:
             return None
 
-        q_nope, q_pe = q.split([self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1)
+        # Discrete FX node #1: take only the decode rows.
+        q_decode = torch.ops.vllm.mla_decode_q_take(q, layer_name_encoded)
 
-        # Discrete FX node #1: q-absorption BMM (BF16 output).
+        q_nope, q_pe = q_decode.split(
+            [self.qk_nope_head_dim, self.qk_rope_head_dim], dim=-1
+        )
+
+        # Discrete FX node #2: q-absorption BMM (BF16 output).
         ql_nope = torch.ops.vllm.unified_mla_q_absorb(q_nope, layer_name_encoded)
 
-        # Discrete FX node #2: concat along head_dim.
+        # Discrete FX node #3: concat along head_dim.
         q_full = torch.cat((ql_nope, q_pe), dim=-1)
 
-        # Discrete FX node #3: static per-tensor FP8 quantization.
+        # Discrete FX node #4: static per-tensor FP8 quantization.
         # Reshape mirrors ``_DecodeConcatQuantFP8.forward`` so QuantFP8 sees
         # the same 2-D shape it has always been called with.
         q_flat = q_full.reshape(q_full.shape[0], -1)
@@ -744,8 +749,10 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         q = q[:num_actual_toks, ...]
         k_c_normed = k_c_normed[:num_actual_toks, ...]
         k_pe = k_pe[:num_actual_toks, ...]
-        if prepared_mqa_q is not None:
-            prepared_mqa_q = prepared_mqa_q[:num_actual_toks, ...]
+        # ``prepared_mqa_q`` arrives sized to ``num_decode_tokens`` (sliced
+        # by ``vllm::mla_decode_q_take`` inside ``_maybe_prepare_decode_mqa_q``),
+        # which is ``<= num_actual_toks``, so no cudagraph-padding trim is
+        # needed here. The decode-row slice below also becomes a no-op.
 
         if fp8_attention and self.kv_cache_dtype != "fp8_ds_mla":
             kv_cache = kv_cache.view(current_platform.fp8_dtype())
@@ -781,11 +788,18 @@ class MLAAttention(nn.Module, AttentionLayerBase):
 
             if prepared_mqa_q is not None:
                 # Lifted decode q-prep path: caller has already produced a
-                # quantized ``mqa_q`` via ``forward()`` so the q-absorb BMM,
-                # head_dim concat, and FP8 quant are visible as discrete FX
-                # nodes. The lifted prep was computed for the full token
-                # extent, so trim it to the decode slice here.
-                mqa_q = prepared_mqa_q[:num_mqa_tokens]
+                # quantized ``mqa_q`` via ``forward()`` so the slice,
+                # q-absorb BMM, head_dim concat, and FP8 quant are visible
+                # as discrete FX nodes. The lift sizes ``prepared_mqa_q``
+                # to ``num_decode_tokens == num_mqa_tokens``, so we can
+                # consume it directly.
+                assert prepared_mqa_q.shape[0] == num_mqa_tokens, (
+                    f"prepared_mqa_q has {prepared_mqa_q.shape[0]} rows "
+                    f"but expected {num_mqa_tokens} (num_decode_tokens). "
+                    "The lift in MLAAttention.forward() should have already "
+                    "trimmed to the decode slice via mla_decode_q_take."
+                )
+                mqa_q = prepared_mqa_q
             else:
                 mqa_q = q[:num_mqa_tokens]
                 mqa_q_nope, mqa_q_pe = mqa_q.split(
@@ -1229,6 +1243,70 @@ direct_register_custom_op(
     op_name="unified_mla_q_absorb",
     op_func=unified_mla_q_absorb,
     fake_impl=unified_mla_q_absorb_fake,
+)
+
+
+def mla_decode_q_take(
+    q: torch.Tensor,
+    layer_name: LayerNameType,
+) -> torch.Tensor:
+    """Slice ``q`` to the decode rows (``q[:num_decode_tokens]``).
+
+    Reads ``num_decode_tokens`` from ``forward_context.attn_metadata`` at
+    graph-execution time so the lifted q-prep operates only on the decode
+    portion of the batch, not on prefill rows or cudagraph padding. The op
+    is opaque to Dynamo (the slice index isn't a graph input) but appears
+    as a discrete FX node so a downstream pattern matcher can bind to it.
+
+    Returns a zero-row slice when ``attn_metadata`` is unavailable (profile
+    runs) or when ``num_decode_tokens`` isn't populated; ``forward_impl``'s
+    own ``attn_metadata is None`` early-return handles the empty case.
+
+    We deliberately reach into ``forward_context.attn_metadata`` directly
+    rather than going through ``get_attention_context``: the slice only
+    needs the metadata field, not ``attn_layer`` / ``kv_cache`` / slot
+    mapping, and avoiding that lookup keeps the op cheap.
+    """
+    layer_name = _resolve_layer_name(layer_name)
+    forward_context = get_forward_context()
+    attn_metadata_raw = forward_context.attn_metadata
+    if attn_metadata_raw is None:
+        return q[:0]
+    # Mirror the dispatch get_attention_context() does: per-layer dict,
+    # list-of-dicts (speculative decoding), or a single attn_metadata.
+    if isinstance(attn_metadata_raw, dict):
+        attn_metadata = attn_metadata_raw.get(layer_name)
+    elif isinstance(attn_metadata_raw, list):
+        attn_metadata = attn_metadata_raw[0].get(layer_name)
+    else:
+        attn_metadata = attn_metadata_raw
+    if attn_metadata is None:
+        return q[:0]
+    num_decode = getattr(attn_metadata, "num_decode_tokens", None)
+    if num_decode is None:
+        return q[:0]
+    return q[:num_decode]
+
+
+def mla_decode_q_take_fake(
+    q: torch.Tensor,
+    layer_name: LayerNameType,
+) -> torch.Tensor:
+    # Declare the symbolic shape as the input's shape (an upper bound):
+    # the runtime slice always has ``num_decode_tokens <= q.shape[0]``
+    # rows. Using a backed SymInt (``q.shape[0]``) instead of an unbacked
+    # one keeps downstream ops (``QuantFP8.forward_native``'s
+    # ``group_broadcast``, etc.) free of data-dependent guard failures.
+    # At graph-execution time the real op returns a smaller tensor and
+    # downstream FX nodes operate on its actual runtime shape — same
+    # pattern as ``unified_mla_q_absorb_fake``.
+    return q.new_empty((q.shape[0], q.shape[1], q.shape[2]))
+
+
+direct_register_custom_op(
+    op_name="mla_decode_q_take",
+    op_func=mla_decode_q_take,
+    fake_impl=mla_decode_q_take_fake,
 )
 
 

--- a/vllm/model_executor/layers/quantization/utils/quant_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/quant_utils.py
@@ -220,7 +220,7 @@ def group_broadcast(t, shape):
         # If tensor has fewer dimensions than target shape, treat missing
         # dimensions as size 1 (standard PyTorch broadcasting behavior)
         t_dim_size = t.shape[i] if i < t.ndim else 1
-        if t_dim_size != s and t_dim_size != 1:
+        if t_dim_size != 1 and t_dim_size != s:
             assert s % t_dim_size == 0
             t = (
                 t.unsqueeze(i + 1)


### PR DESCRIPTION
## Purpose

Phase 1 of a two-phase plan to enable end-to-end fusion of the MLA decode
q-prep chain on AITER. This PR is a **pure refactor** — it does not change
math, kernels, or the user-visible default path. It lifts the decode q-prep
chain (q-absorb BMM, q_nope/q_pe head-dim concat, static FP8 quant) out of
`MLAAttention.forward_impl` and into `MLAAttention.forward()` so
`torch.compile` sees each step as a discrete FX node instead of an opaque
custom-op body.

```
q ──► vllm::mla_split_batch(q, layer_name) ──► num_decode (SymInt u0)
q ──► aten.narrow(0, 0, u0) ──► aten.split([nope, rope], -1) ──► q_nope, q_pe
q_nope ──► aten.bmm(W_UK_T) ──► ql_nope          (BF16, no `out=`)
ql_nope, q_pe ──► aten.cat(dim=-1) ──► q_full
q_full ──► (÷scale, clamp ±448, cast e4m3fn) ──► mqa_q  (FP8)
…
vllm::unified_mla_attention_with_output(..., prepared_mqa_q=mqa_q)
```

This is the FX shape that **Phase 2** will pattern-match into the AITER `fused_qk_rope_concat_and_cache_mla`
kernel. Phase 1 ships only the visibility refactor; no kernel work, no
expected perf change against the opaque path.

Borrows ideas from [#39346](https://github.com/vllm-project/vllm/pull/39346)
(@morrison-turnansky — "Expose MLA to torch.compile") — same
`vllm::mla_split_batch` SymInt op convention, same outer/inner-forward
split idea — and follows the same `cc.pass_config.<flag>` shape that
[#40392](https://github.com/vllm-project/vllm/pull/40392) (@Rohan138 —
`MLARoPEKVCacheCatFusionPass`) settled on for MLA-side toggles.

## Design

### Outer/inner forward split

`MLAAttention.forward()` now picks between two paths in one place — exactly
the `wrap_if_exposed` / `inner_forward` shape ProExpertProg sketched in the
[#39346 review thread](https://github.com/vllm-project/vllm/pull/39346):

- `_opaque_forward()` — historical path. One
  `vllm::unified_mla_attention_with_output` op, no FX-visible q-prep.
  This is the **user-visible default**.
- `_lifted_inner_forward()` — runs the prep inline as plain torch ops:
  `vllm::mla_split_batch` (SymInt) → `aten.narrow` → split → q-absorb BMM
  → cat → static FP8 quant. The attention kernel call stays opaque (still
  one `vllm::unified_mla_attention_with_output` op), so the backend
  retains its own correctness/perf boundary; only the *prep* chain is
  exposed to the FX graph.

Single policy site, both branches share the same downstream code, so the
diff a reviewer has to read is one `if`/`else` in `forward()`.

### Gating

A new `cc.pass_config.lift_mla_decode_q_prep: bool = False` flag (mirrors
the shape of `cc.pass_config.fuse_rope_kvcache_cat_mla` from #40392)
controls the lift. The full predicate, computed once at layer-init time
(`_compute_lift_q_decode_quant`), is:

```python
return (
    is_quantized_kv_cache(kv_cache_dtype)
    and kv_cache_dtype != "fp8_ds_mla"
    and impl.supports_quant_query_input
    and not isinstance(impl, SparseMLAAttentionImpl)
    and q_pad_num_heads is None
    and decode_context_parallel_size <= 1
    and use_inductor_graph_partition          # cudagraph SymInt safety
    and lift_decode_q_prep                    # opt-in pass_config flag
)
```

The `use_inductor_graph_partition` requirement matches #39346's recipe for
making the unbacked SymInt safe under piecewise/full cudagraph capture.
The lift is **off by default**, so the PR has zero impact on users who do
not opt in.

### `vllm::mla_split_batch` (SymInt op)

A thin custom op (same name as in #39346 for forward compatibility) reads
`forward_context.attn_metadata.num_decode_tokens` at execution time and
returns it. Its fake impl returns `ctx.new_dynamic_size()`, so downstream
ops (`q.narrow(0, 0, num_decode)`, the inline BMM, cat, FP8 quant) carry
this unbacked SymInt as their leading dim. Wrapping the metadata read in a
custom op keeps it invisible to `torch.compile` — surrounding ops stay
fully traceable instead of graph-breaking on the metadata access.

### Strict mode (no silent fallback)

Earlier revisions of this branch had a row-mismatch warning + recompute
fallback in `forward_impl`. That is gone: when the lift gate is on,
`forward_impl` **asserts** `prepared_mqa_q.shape[0] == num_mqa_tokens`
with an actionable message that names the suspected cause (cudagraph
capture/replay SymInt freeze on the lifted chain) and tells the user how
to fall back (`cc.pass_config.lift_mla_decode_q_prep=False`). Rationale
matches the @morrison-turnansky / @ProExpertProg "fail fast" stance in
#39346 on size-0 cases: a silent recompute hides cudagraph freeze and
produces wrong outputs that look right; an assert surfaces them on the
first decode step.

### Schema / wire compatibility

`unified_mla_attention_with_output` keeps its existing `prepared_mqa_q`
trailing optional kwarg (default `None`). The Inductor pattern matcher
(`torch._inductor.pattern_matcher._TargetArgsExpr._match`) normalises
target-side kwargs through `torch.fx.operator_schemas.normalize_function`
and filters them down to the keys each pattern lists, so existing
`MLAAttnQuantFusionPass` patterns (`MLAAttnFp8StaticQuantPattern`,
`MLAAttnNvfp4QuantPattern`, `MLAAttnFp8GroupQuantPattern`) continue to
match without modification.

## Files changed

| File | Purpose |
| --- | --- |
| `vllm/config/compilation.py` | Adds `PassConfig.lift_mla_decode_q_prep: bool = False`. |
| `vllm/model_executor/layers/attention/mla_attention.py` | Outer/inner forward split, lifted q-prep helper, `vllm::mla_split_batch` op, strict assert in `forward_impl`, `_run_decode_q_prep_kernels` shared between lifted and legacy paths. |
| `tests/kernels/core/test_mla_q_quant_separation_fx.py` | FX-shape test; pins that the lifted chain emits the discrete FX nodes Phase 2 will bind to. Adds `MLA_FX_DUMP=<path>` env to dump the captured pre-pass graph for offline review. |
| `tests/kernels/core/test_mla_q_quant_separation.py` | Bit-exact parity (`atol=0`) between the lifted Python sequence and the legacy in-place block on the same inputs. |
| `vllm/model_executor/custom_op.py` | One-line guard: when a `dynamic_arg_dims` wrapper is reached while `torch.compiler.is_compiling()`, skip `mark_dynamic` (Dynamo forbids it during fullgraph trace) and call the eager-native function directly so the outer trace captures it. Required for the lifted path's static FP8 quant to compile cleanly. |
| `vllm/model_executor/layers/quantization/utils/quant_utils.py` | One-line reorder in `group_broadcast`: short-circuit on the extent-1 case (`t_dim_size != 1`) before the SymInt equality (`t_dim_size != s`). The lifted FP8 quant chain runs through `QuantFP8.forward_native → group_broadcast` with a target shape carrying the unbacked SymInt from `vllm::mla_split_batch`; the original ordering forced `int != SymInt` first and raised `GuardOnDataDependentSymNode` under fullgraph capture. Bit-equivalent for eager; required for `test_mla_q_quant_separation_fx.py` to compile. |

## Test plan

```bash
# Phase 1 FX-shape unit test (runs in CI; ~8 s on CPU).
# Optional MLA_FX_DUMP=<path> writes the captured pre-pass FX graph to
# disk so reviewers can audit the chain Phase 2 will bind to.
pytest tests/kernels/core/test_mla_q_quant_separation_fx.py -v
MLA_FX_DUMP=/tmp/phase1_lifted_fx_graph.txt \
    pytest tests/kernels/core/test_mla_q_quant_separation_fx.py -v

# Bit-exact parity unit test (lifted vs. legacy in-place block, atol=0).
pytest tests/kernels/core/test_mla_q_quant_separation.py -v

```

E2E server tests and gsm8k 5-shot tests done as well.

## Test results

### Phase 1 FX-shape test — captured graph

`pytest tests/kernels/core/test_mla_q_quant_separation_fx.py -v` → **1 passed**.

With `MLA_FX_DUMP=…` set, the pre-pass FX graph is the contract Phase 2's
matcher binds to:

```
graph():
    %arg0_1 : [num_users=2] = placeholder[target=arg0_1]
    %arg1_1 : [num_users=1] = placeholder[target=arg1_1]
    %arg2_1 : [num_users=1] = placeholder[target=arg2_1]
    %mla_split_batch : [num_users=5] = call_function[target=torch.ops.vllm.mla_split_batch.default](args = (%arg0_1, fxtest_layer.0), kwargs = {})
    %ge_1 : [num_users=1] = call_function[target=operator.ge](args = (%mla_split_batch, 0), kwargs = {})
    %_assert_scalar : [num_users=0] = call_function[target=torch.ops.aten._assert_scalar.default](args = (%ge_1, Runtime assertion failed for expression u0 >= 0 on node 'ge'), kwargs = {})
    %le : [num_users=1] = call_function[target=operator.le](args = (%mla_split_batch, 4), kwargs = {})
    %_assert_scalar_1 : [num_users=0] = call_function[target=torch.ops.aten._assert_scalar.default](args = (%le, Runtime assertion failed for expression u0 <= 4 on node 'le'), kwargs = {})
    %eq : [num_users=1] = call_function[target=operator.eq](args = (%mla_split_batch, 0), kwargs = {})
    %sym_not : [num_users=1] = call_function[target=torch.sym_not](args = (%eq,), kwargs = {})
    %_assert_scalar_2 : [num_users=0] = call_function[target=torch.ops.aten._assert_scalar.default](args = (%sym_not, Runtime assertion failed for expression Ne(u0, 0) on node 'sym_not'), kwargs = {})
    %add : [num_users=1] = call_function[target=operator.add](args = (0, %mla_split_batch), kwargs = {})
    %slice_1 : [num_users=2] = call_function[target=torch.ops.aten.slice.Tensor](args = (%arg0_1, 0, 0, %add), kwargs = {})
    %split_with_sizes : [num_users=2] = call_function[target=torch.ops.aten.split_with_sizes.default](args = (%slice_1, [128, 64], -1), kwargs = {})
    %getitem : [num_users=1] = call_function[target=operator.getitem](args = (%split_with_sizes, 0), kwargs = {})
    %getitem_1 : [num_users=1] = call_function[target=operator.getitem](args = (%split_with_sizes, 1), kwargs = {})
    %permute : [num_users=1] = call_function[target=torch.ops.aten.permute.default](args = (%getitem, [1, 0, 2]), kwargs = {})
    %bmm : [num_users=1] = call_function[target=torch.ops.aten.bmm.default](args = (%permute, %arg1_1), kwargs = {})
    %permute_1 : [num_users=1] = call_function[target=torch.ops.aten.permute.default](args = (%bmm, [1, 0, 2]), kwargs = {})
    %cat : [num_users=1] = call_function[target=torch.ops.aten.cat.default](args = ([%permute_1, %getitem_1], -1), kwargs = {})
    %view : [num_users=1] = call_function[target=torch.ops.aten.reshape.default](args = (%cat, [%mla_split_batch, -1]), kwargs = {})
    %convert_element_type_2 : [num_users=1] = call_function[target=torch.ops.prims.convert_element_type.default](args = (%view, torch.float32), kwargs = {})
    %reciprocal : [num_users=1] = call_function[target=torch.ops.aten.reciprocal.default](args = (%arg2_1,), kwargs = {})
    %mul_24 : [num_users=1] = call_function[target=torch.ops.aten.mul.Tensor](args = (%convert_element_type_2, %reciprocal), kwargs = {})
    %clamp_min : [num_users=1] = call_function[target=torch.ops.aten.clamp_min.default](args = (%mul_24, -448.0), kwargs = {})
    %clamp_max : [num_users=1] = call_function[target=torch.ops.aten.clamp_max.default](args = (%clamp_min, 448.0), kwargs = {})
    %convert_element_type_3 : [num_users=1] = call_function[target=torch.ops.prims.convert_element_type.default](args = (%clamp_max, torch.float8_e4m3fn), kwargs = {})
    %sym_size_int : [num_users=1] = call_function[target=torch.ops.aten.sym_size.int](args = (%slice_1, 0), kwargs = {})
    %view_1 : [num_users=1] = call_function[target=torch.ops.aten.reshape.default](args = (%convert_element_type_3, [%sym_size_int, 16, 576]), kwargs = {})
    return (view_1,)
```

The required topology (`vllm::mla_split_batch` (SymInt) → `aten.slice` →
split → `aten.bmm` → `aten.cat` → static FP8 quant chain → reshape on
`u0`) is asserted by the unit test; the dump above is just the human-
readable version of the same contract.

### Bit-exact parity unit test

`pytest tests/kernels/core/test_mla_q_quant_separation.py -v` → **2/2 pass**,
`atol=0`. The lifted Python sequence is bit-identical to the legacy
in-place `BMM + _DecodeConcatQuantFP8` block on the same inputs, at
`seq_len=1` and `seq_len=7`, with canonical Kimi-K2.5 / DeepSeek-V3 dims
(`qk_nope_head_dim=128`, `qk_rope_head_dim=64`, `kv_lora_rank=512`,
`num_heads=128`, `bf16`).

### E2E accuracy (`amd/Kimi-K2-Thinking-MXFP4`, ROCm AITER, FP8 KV, TP=4)

GSM8K 5-shot, same compiled binary, three configurations:

| run | `lift_mla_decode_q_prep` | `use_inductor_graph_partition` | gsm8k 5-shot |
| --- | --- | --- | --- |
| baseline (clean upstream) | False | False | **0.93** |
| partition only (no lift) | False | True | **0.93** |
| lift on, strict assert | True | True | hits the strict assert during cudagraph capture (`prepared_mqa_q row mismatch (16 vs 512 decode rows)`) — see "Known limitation" |

The opaque path (rows 1 and 2) is bit-exact with clean upstream, so the PR
has zero impact on users who do not opt in.

## Known limitation: cudagraph SymInt freeze on the lifted chain

Row 3 above is the **expected** Phase 1 outcome on a stack that does not
yet include #39346's "stable cuda graph piece replay" work (commit
`0aa9492`). Under piecewise/full cudagraph capture, the unbacked SymInt
returned by `vllm::mla_split_batch` is resolved to the *capture-time*
decode count and baked into the captured graph's tensor sizes / kernel
grids. At replay with a different runtime `num_decode_tokens`, the
captured chain still operates at the captured size — the lifted
`prepared_mqa_q` arrives with the wrong leading dim and the strict
assert in `forward_impl` fires.

This is the cudagraph capture/replay SymInt freeze that PR #39346
sidesteps with `cudagraph_mode=FULL_AND_PIECEWISE` +
`use_inductor_graph_partition=true`, and that Phase 2 makes
moot by collapsing the entire chain into a single fused op that reads
the runtime decode size *inside* the op — at which point the boundary-
crossing tensor that the freeze acts on simply does not exist.

The PR therefore intentionally:

* keeps the gate **default-off** (opaque path is the user-visible
  behaviour, bit-exact with clean upstream);
* makes the gate-on path **strict** (asserts loudly on the freeze
  instead of silently recomputing the prep, which earlier revisions
  did and which masked the issue);
* lands the FX-shape unit test, which exercises the lifted chain in
  isolation (no cudagraph) and is independent of the freeze.

End users with stacks that include #39346 — or, eventually, anyone
running with Phase 2 — get the lift; everyone else stays on the opaque
path.

## Notes for reviewers

- **Custom-op surface**: one new SymInt op, `vllm::mla_split_batch`,
  same name and signature as in #39346.
  `unified_mla_attention_with_output` keeps its existing
  `prepared_mqa_q` trailing optional kwarg (default `None`); existing
  positional callers and FX patterns are unaffected.
- **`_run_decode_q_prep_kernels`** is the shared helper between the
  lifted path and the legacy in-impl path — same kernels, same math,
  so the lifted path is bit-exact when the gate is on. The plain-bmm
  fallback in this helper deliberately *does not* preallocate `out=`:
  with `q_nope_nb` carrying an unbacked SymInt batch dim, an
  `out=` buffer constructed via `q_nope_nb.new_empty((N, B, L))` adds
  a data-dependent shape-equality guard that Dynamo cannot discharge
  (`GuardOnDataDependentSymNode: u0`). Letting `torch.bmm` infer the
  output shape avoids the guard and is bit-equivalent.
- **`forward_impl`** keeps the `q_pad_num_heads` and DCP branches
  inline. The lift gate disables itself for both, so the lifted
  helper never reaches them.
- **`custom_op.py` `mark_dynamic` guard** is a small one-liner that
  fixes a fullgraph-trace error on the lifted path. When a
  `dynamic_arg_dims`-wrapped op (here, `QuantFP8`) is reached while
  Dynamo is already tracing an enclosing graph,
  `torch._dynamo.mark_dynamic` raises `Attempt to trace forbidden
  callable mark_dynamic`. The wrapper now short-circuits to the
  eager-native function under `torch.compiler.is_compiling()`, letting
  the outer trace capture it normally. Bounded scope, no behaviour
  change outside fullgraph capture.
- **`group_broadcast` short-circuit** in `vllm/model_executor/layers/quantization/utils/quant_utils.py`
  is a one-line reorder of the two equality checks. The lifted FP8
  quant chain runs through `QuantFP8.forward_native → group_broadcast`
  with a target shape carrying the unbacked SymInt from
  `vllm::mla_split_batch`. The original ordering
  `t_dim_size != s and t_dim_size != 1` evaluates the `int != SymInt`
  comparison first and trips `GuardOnDataDependentSymNode` under
  fullgraph capture, even though the very next branch is the standard
  PyTorch extent-1 broadcasting case. Swapping to
  `t_dim_size != 1 and t_dim_size != s` short-circuits on the static-1
  case before any SymInt comparison happens. Bit-equivalent for eager;
  required for `test_mla_q_quant_separation_fx.py` to compile.

## Risks & follow-ups

- **No correctness risk** when the gate is off (opaque path is bit-
  exact with clean upstream).
- **Strict assert when on**: the assert in `forward_impl` is the
  *only* way the gate-on path can produce wrong output, and it does
  not — it stops the run with an actionable message.
- **Phase 2** will consume the FX shape this PR establishes and
  is the path to actual perf wins. Phase 1 by itself is performance-
  neutral by construction (same kernels, same math, only the FX
  visibility changes).
- **#39346 alignment**: this PR uses the same `vllm::mla_split_batch`
  op name, the same outer/inner-forward split shape, and the same
  `use_inductor_graph_partition` pre-condition; once #39346 lands, its
  decode branch can call `_maybe_prepare_decode_mqa_q` directly
  without any additional refactor.

cc @ProExpertProg @LucasWilkinson @MatthewBonanni @morrison-turnansky

## AI assistance disclosure

This change was prepared with AI assistance (Cursor / Claude). I
(Xavier Aguilar) reviewed every changed line, ran every test command
listed above on local hardware, and stand behind the implementation
end-to-end. Duplicate-work checks against #39346 and #40392 were
performed; this PR is materially different — it is a pure refactor of
the *decode q-prep chain only*, not the prefill/decode split (#39346's
scope) and not the RoPE/KV-cache fusion (#40392's scope). Phase 2
will consume the FX shape this PR establishes.

---