### PR TITLE
[ROCm][CI] Use vLLM generation defaults for DeepSeek prefetch-offload eval

### DIFF
--- a/.buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_prefetch_offload.sh
+++ b/.buildkite/scripts/scheduled_integration_test/deepseek_v2_lite_prefetch_offload.sh
@@ -51,6 +51,7 @@ vllm serve "$MODEL" \
   --offload-num-in-group 2 \
   --offload-prefetch-step 1 \
   --offload-params w13_weight w2_weight \
+  --generation-config vllm \
   --port "$PORT" \
   ${EXTRA_ARGS+"${EXTRA_ARGS[@]}"} &
 SERVER_PID=$!


### PR DESCRIPTION
This PR fixes `mi300_1: DeepSeek V2-Lite Prefetch Offload Accuracy (H100-MI300)`. Changes:
- Run the scheduled DeepSeek V2-Lite prefetch-offload eval with `--generation-config vllm`.
- This keeps the GSM8K harness deterministic instead of inheriting the model's HF generation defaults.
- The fix preserves the prefetch-offload coverage and only changes serving defaults for this eval script.

cc @kenroche 