### PR TITLE
[ROCm] Fix platform detection failures in unprivileged containers

### DIFF
--- a/vllm/platforms/__init__.py
+++ b/vllm/platforms/__init__.py
@@ -108,6 +108,34 @@ def cuda_platform_plugin() -> str | None:
     return "vllm.platforms.cuda.CudaPlatform" if is_cuda else None
 
 
+def _rocm_detect_via_hip() -> bool:
+    """Fallback ROCm detection using ctypes HIP when amdsmi is unavailable.
+
+    amdsmi requires sysfs/hwmon paths that may not be exposed inside
+    unprivileged containers even when the GPU is accessible via /dev/kfd and
+    /dev/dri.  hipGetDeviceCount() succeeds as long as those device nodes are
+    mounted, making it a reliable fallback for containerised deployments.
+
+    See: https://github.com/ROCm/amdsmi/issues/75 and
+    https://github.com/ROCm/ROCm/issues/5000
+    """
+    try:
+        import ctypes
+
+        hip = ctypes.CDLL("libamdhip64.so")
+        count = ctypes.c_int(0)
+        if hip.hipGetDeviceCount(ctypes.byref(count)) == 0 and count.value > 0:
+            logger.debug(
+                "Confirmed ROCm platform via HIP ctypes fallback "
+                "(%d device(s)).",
+                count.value,
+            )
+            return True
+    except Exception as e:
+        logger.debug("HIP ctypes fallback also failed: %s", e)
+    return False
+
+
 def rocm_platform_plugin() -> str | None:
     is_rocm = False
     logger.debug("Checking if ROCm platform is available.")
@@ -124,7 +152,10 @@ def rocm_platform_plugin() -> str | None:
         finally:
             amdsmi.amdsmi_shut_down()
     except Exception as e:
-        logger.debug("ROCm platform is not available because: %s", str(e))
+        logger.debug(
+            "amdsmi unavailable (%s); trying HIP ctypes fallback.", str(e)
+        )
+        is_rocm = _rocm_detect_via_hip()
 
     return "vllm.platforms.rocm.RocmPlatform" if is_rocm else None
 

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -163,18 +163,34 @@ def _query_gcn_arch_from_amdsmi() -> str:
 
 def _get_gcn_arch() -> str:
     """
-    Get GCN arch via amdsmi (no CUDA init), fallback to torch.cuda.
-    Called once at module level; result stored in _GCN_ARCH.
+    Get GCN arch via amdsmi (no CUDA init), fallback to env var, then
+    torch.cuda.  Called once at module level; result stored in _GCN_ARCH.
+
+    The env-var fallback is intentionally checked *before* calling any logging
+    helper that might trigger an import of vllm.distributed during module
+    initialisation (which would cause a circular-import error in container
+    environments where amdsmi fails).
     """
     try:
         return _query_gcn_arch_from_amdsmi()
     except Exception as e:
         logger.debug("Failed to get GCN arch via amdsmi: %s", e)
-        logger.warning_once(
-            "Failed to get GCN arch via amdsmi, falling back to torch.cuda. "
-            "This will initialize CUDA and may cause "
-            "issues if CUDA_VISIBLE_DEVICES is not set yet."
-        )
+
+    # Check env var before falling back to torch.cuda to (a) avoid
+    # unnecessary CUDA initialisation and (b) prevent a potential circular
+    # import triggered by logger.warning_once() during module init when the
+    # call chain goes through vllm.distributed.parallel_state.
+    arch_env = os.environ.get("PYTORCH_ROCM_ARCH", "").split(":")[0].strip()
+    if arch_env:
+        logger.debug("Using PYTORCH_ROCM_ARCH=%r for GCN arch.", arch_env)
+        return arch_env
+
+    logger.warning(
+        "Failed to get GCN arch via amdsmi, falling back to torch.cuda. "
+        "This will initialize CUDA and may cause "
+        "issues if CUDA_VISIBLE_DEVICES is not set yet. "
+        "Set PYTORCH_ROCM_ARCH (e.g. 'gfx942') to avoid this."
+    )
     # Ultimate fallback: use torch.cuda (will initialize CUDA)
     return torch.cuda.get_device_properties("cuda").gcnArchName
 


### PR DESCRIPTION
## Summary

Fixes vLLM startup failures on AMD GPUs inside containers where `amdsmi`
cannot access sysfs/hwmon paths even though the GPU is fully functional.

Closes #40081 (Bug 1 + Bug 2)

### Root cause

`rocm_platform_plugin()` relies solely on `amdsmi` to detect ROCm.
`amdsmi` requires `/sys/bus/pci/drivers/amdgpu`, hwmon, and DRM sysfs
nodes that are typically absent in unprivileged containers, even when
the GPU is reachable via `/dev/kfd` + `/dev/dri`.  When `amdsmi` fails,
the function returns `None` and vLLM aborts with "Failed to infer device
type."

A secondary issue in `_get_gcn_arch()`: after amdsmi fails the code
calls `logger.warning_once()`, whose import chain (`vllm.distributed →
vllm.utils.system_utils → vllm.platforms`) creates a circular import
during module initialisation.

### Changes

**`vllm/platforms/__init__.py`** — add `_rocm_detect_via_hip()`

When `amdsmi` raises, fall back to `ctypes.CDLL("libamdhip64.so")` and
call `hipGetDeviceCount()`.  HIP only needs the device nodes already
mounted by container runtimes, so it succeeds where amdsmi does not.

```python
hip = ctypes.CDLL("libamdhip64.so")
count = ctypes.c_int(0)
if hip.hipGetDeviceCount(ctypes.byref(count)) == 0 and count.value > 0:
    return True  # ROCm confirmed
```

**`vllm/platforms/rocm.py`** — env-var fallback in `_get_gcn_arch()`

Check `PYTORCH_ROCM_ARCH` env var before touching `logger.warning_once()`
to break the circular-import path.  Also adds a clear hint to the warning
message so users know how to suppress it.

## Test plan

- [ ] Verify `vllm serve` starts on an RDNA 4 (gfx1201) container without
      `--privileged` (uses HIP fallback)
- [ ] Verify `vllm serve` starts on MI300X with `amdsmi` available
      (existing path, unchanged)
- [ ] Confirm no regression on CUDA (CUDA detection path is untouched)
- [ ] Set `PYTORCH_ROCM_ARCH=gfx942` and confirm no warning is emitted
      when amdsmi fails

Related issues: #40081, #24576, #34573, #39378

🤖 Generated with [Claude Code](https://claude.ai/code)