### PR TITLE
[ROCm] Add VLLM_SKIP_MM_PROFILING env var as alternative to --skip-mm-profiling

### DIFF
--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -552,7 +552,7 @@ class EngineArgs:
     )
     io_processor_plugin: str | None = None
     renderer_num_workers: int = 1
-    skip_mm_profiling: bool = MultiModalConfig.skip_mm_profiling
+    skip_mm_profiling: bool = envs.VLLM_SKIP_MM_PROFILING
     video_pruning_rate: float | None = MultiModalConfig.video_pruning_rate
     mm_tensor_ipc: MMTensorIPC = MultiModalConfig.mm_tensor_ipc
     # LoRA fields

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -104,6 +104,7 @@ if TYPE_CHECKING:
     VLLM_USE_TRITON_AWQ: bool = False
     VLLM_ALLOW_RUNTIME_LORA_UPDATING: bool = False
     VLLM_SKIP_P2P_CHECK: bool = False
+    VLLM_SKIP_MM_PROFILING: bool = False
     VLLM_DISABLED_KERNELS: list[str] = []
     VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE: bool = True
     VLLM_DISABLE_PYNCCL: bool = False
@@ -971,6 +972,14 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # so that vLLM can verify if p2p is actually working.
     # See https://github.com/vllm-project/vllm/blob/a9b15c606fea67a072416ea0ea115261a2756058/vllm/distributed/device_communicators/custom_all_reduce_utils.py#L101-L108 for details. # noqa
     "VLLM_SKIP_P2P_CHECK": lambda: os.getenv("VLLM_SKIP_P2P_CHECK", "1") == "1",
+    # Skip multimodal (vision encoder) memory profiling at engine startup.
+    # Useful for ROCm containers where MIOpen solver DB is absent (e.g.
+    # gfx1151 / Strix Halo) and the profiling pass hangs indefinitely.
+    # Equivalent to passing --skip-mm-profiling on the CLI.
+    # See https://github.com/vllm-project/vllm/issues/37472
+    "VLLM_SKIP_MM_PROFILING": lambda: (
+        os.getenv("VLLM_SKIP_MM_PROFILING", "0").lower() in ("1", "true")
+    ),
     # List of quantization kernels that should be disabled, used for testing
     # and performance comparisons. Currently only affects MPLinearKernel
     # selection


### PR DESCRIPTION
## Problem

On ROCm containers targeting **gfx1151 (Strix Halo / Ryzen AI MAX+)** and similar hardware where the MIOpen solver database is absent, the multimodal memory profiling pass hangs indefinitely at engine startup. The existing workaround is to pass `--skip-mm-profiling` on the CLI.

However, in Kubernetes and Docker deployments it is more natural — and often the *only* option — to configure behaviour via `ENV` directives in the `Dockerfile` or via `env:` fields in the pod spec. There is currently no environment-variable equivalent for `--skip-mm-profiling`.

Fixes: #37472

## Changes

| File | Change |
|---|---|
| `vllm/envs.py` | Add `VLLM_SKIP_MM_PROFILING` (TYPE_CHECKING decl + runtime lambda) |
| `vllm/engine/arg_utils.py` | Change `EngineArgs.skip_mm_profiling` default from `MultiModalConfig.skip_mm_profiling` (always `False`) to `envs.VLLM_SKIP_MM_PROFILING` |

When `VLLM_SKIP_MM_PROFILING=1` (or `true`) is set in the container environment, the engine behaves exactly as if `--skip-mm-profiling` was passed on the command line. Passing `--skip-mm-profiling` explicitly still overrides the env var (standard argparse precedence).

## Example usage

```dockerfile
# In a ROCm container for gfx1151 / Strix Halo hardware
ENV VLLM_SKIP_MM_PROFILING=1
```

```yaml
# Kubernetes pod spec
env:
  - name: VLLM_SKIP_MM_PROFILING
    value: "1"
```

## Test plan

- [ ] Unit: verify `envs.VLLM_SKIP_MM_PROFILING` resolves `False` by default and `True` when env var is `"1"` or `"true"`
- [ ] Integration: launch vLLM with a multimodal model, set `VLLM_SKIP_MM_PROFILING=1`, confirm no vision encoder profiling occurs (same behaviour as `--skip-mm-profiling`)
- [ ] Confirm `--skip-mm-profiling` CLI flag still works and overrides the env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)