### PR TITLE
[ROCm] Add missing type hints to rocm_attn backend

### DIFF
--- a/vllm/v1/attention/backends/rocm_attn.py
+++ b/vllm/v1/attention/backends/rocm_attn.py
@@ -509,7 +509,7 @@ class RocmAttentionImpl(AttentionImpl):
         is_neox: bool,
         kv_cache: torch.Tensor,
         layer_slot_mapping: torch.Tensor,
-    ):
+    ) -> None:
         if self.attn_type in (AttentionType.ENCODER_ONLY, AttentionType.ENCODER):
             return
         key_cache, value_cache = PagedAttention.split_kv_cache(


### PR DESCRIPTION
- Problem: Several ROCm attention backend methods lacked return type hints, causing mypy/lint warnings.
- Changes: Added -> bool and -> None to functions in llm/v1/attention/backends/rocm_attn.py.
- Test plan: Purely typing change, no logic modified.