### PR TITLE
Fix GPU memory not being released on MRV2 shutdown

### DIFF
--- a/tests/v1/worker/test_gpu_shutdown.py
+++ b/tests/v1/worker/test_gpu_shutdown.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from types import SimpleNamespace
+
+import torch
+
+from vllm.config import VllmConfig
+from vllm.v1.worker.gpu.shutdown import free_before_shutdown
+
+
+def test_free_before_shutdown_clears_layer_kv_cache_and_scale_views(
+    monkeypatch,
+):
+    vllm_config = VllmConfig()
+
+    kv_cache = torch.ones(4)
+    layer = SimpleNamespace(
+        kv_cache=kv_cache,
+        impl=SimpleNamespace(
+            _k_scale_cache=torch.ones(2),
+            _v_scale_cache=torch.ones(2),
+        ),
+    )
+    tuple_kv_layer = SimpleNamespace(kv_cache=[torch.ones(1), torch.ones(1)])
+    vllm_config.compilation_config.static_forward_context = {
+        "layer": layer,
+        "tuple_layer": tuple_kv_layer,
+    }
+    vllm_config.cache_config.num_gpu_blocks = 16
+
+    reset_calls = 0
+
+    def fake_reset_workspace_manager() -> None:
+        nonlocal reset_calls
+        reset_calls += 1
+
+    monkeypatch.setattr(
+        "vllm.v1.worker.workspace.reset_workspace_manager",
+        fake_reset_workspace_manager,
+    )
+
+    from vllm.model_executor.layers import rotary_embedding
+
+    rotary_embedding._ROPE_DICT["test"] = object()
+
+    free_before_shutdown(vllm_config)
+
+    assert torch.equal(layer.kv_cache, torch.tensor([]))
+    assert tuple_kv_layer.kv_cache == []
+    assert layer.impl._k_scale_cache is None
+    assert layer.impl._v_scale_cache is None
+    assert vllm_config.cache_config.num_gpu_blocks is None
+    assert vllm_config.compilation_config.static_forward_context == {}
+    assert rotary_embedding._ROPE_DICT == {}
+    assert reset_calls == 1

--- a/vllm/v1/worker/gpu/shutdown.py
+++ b/vllm/v1/worker/gpu/shutdown.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 
@@ -14,6 +16,17 @@ def free_before_shutdown(vllm_config: VllmConfig) -> None:
     cache_config.num_gpu_blocks = None
 
     compilation_config = vllm_config.compilation_config
+    for layer in compilation_config.static_forward_context.values():
+        if hasattr(layer, "kv_cache"):
+            kv_cache = layer.kv_cache
+            layer.kv_cache = (
+                torch.tensor([]) if isinstance(kv_cache, torch.Tensor) else []
+            )
+        if hasattr(layer, "impl"):
+            if hasattr(layer.impl, "_k_scale_cache"):
+                layer.impl._k_scale_cache = None
+            if hasattr(layer.impl, "_v_scale_cache"):
+                layer.impl._v_scale_cache = None
     compilation_config.static_forward_context.clear()
 
     _ROPE_DICT.clear()


### PR DESCRIPTION
…es before dropping static_forward_context




## Purpose

### scenario:
  In MRV2, KV caches are bound into objects stored in compilation_config.static_forward_context, where each layer may keep references such as layer.kv_cache,  layer.impl._k_scale_cache, and layer.impl._v_scale_cache. When shutdown() is called in a same-process reuse scenario, the current code clears the outer  static_forward_context map but does not explicitly clear those per-layer fields first.

  After shutdown(), GPU memory may not be released as expected. This can show up as residual memory usage after engine teardown, and in same-process reinitialization  flows it increases the risk of allocation pressure or OOM because KV-related tensors or tensor views may still remain reachable through layer-owned references.


###  Expected behavior:
  Before clearing static_forward_context, shutdown should explicitly sever KV-related references held by each layer object, so that Python GC and
  torch.accelerator.empty_cache() can actually reclaim the underlying GPU memory. MRV1 already follows this pattern.


###  Root cause:
  The MRV2 shutdown path performs only shallow container cleanup. It clears runner-side containers and then clears compilation_config.static_forward_context, but it  misses the deeper object graph where KV cache tensors are stored on the layer instances themselves. Since KV cache binding writes directly into  forward_context[layer_name].kv_cache, clearing only the outer dictionary is not sufficient.

### Fix:
  Apply the same cleanup pattern already used in MRV1. In free_before_shutdown(), iterate through compilation_config.static_forward_context.values() before calling
  clear(), and for each layer:

  - reset layer.kv_cache to an empty tensor or empty list, matching the existing MRV1 behavior
  - set layer.impl._k_scale_cache = None when present
  - set layer.impl._v_scale_cache = None when present

  Then proceed with:

  - compilation_config.static_forward_context.clear()
  - _ROPE_DICT.clear()
  - reset_workspace_manager()

  This is the smallest correct fix because it only patches the missing reference-release step and stays aligned with the existing shutdown implementation in MRV1.
  
  
## Test Plan

test case is added and it passed 

## Test Result


