### PR TITLE
[Test][ROCm] Add missing ROCm skip markers

### DIFF
--- a/tests/kernels/test_flex_attention.py
+++ b/tests/kernels/test_flex_attention.py
@@ -5,6 +5,7 @@
 import pytest
 import torch
 from packaging import version
+from vllm.platforms import current_platform
 
 from tests.utils import set_random_seed
 from tests.v1.attention.utils import (
@@ -185,7 +186,7 @@ def test_encoder_flex_attention_vs_default_backend(vllm_runner):
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or TORCH_VERSION < DIRECT_BUILD_VERSION,
+    not torch.cuda.is_available() or current_platform.is_rocm() or TORCH_VERSION < DIRECT_BUILD_VERSION,
     reason="CUDA not available or PyTorch version < 2.7",
 )
 def test_block_mask_direct_vs_slow_path():
@@ -278,7 +279,7 @@ def test_physical_to_logical_mapping_handles_reused_blocks():
 
 
 @pytest.mark.skipif(
-    not torch.cuda.is_available() or TORCH_VERSION < DIRECT_BUILD_VERSION,
+    not torch.cuda.is_available() or current_platform.is_rocm() or TORCH_VERSION < DIRECT_BUILD_VERSION,
     reason="CUDA not available or PyTorch version < 2.9",
 )
 def test_block_sparsity_hint_prunes_blocks():
@@ -328,4 +329,6 @@ def test_block_sparsity_hint_prunes_blocks():
 
 
 if __name__ == "__main__":
+    pytest.main([__file__])
+:
     pytest.main([__file__])

--- a/tests/v1/attention/test_mla_backends.py
+++ b/tests/v1/attention/test_mla_backends.py
@@ -45,7 +45,7 @@ BACKENDS_TO_TEST = [
 DEVICE_TYPE = current_platform.device_type
 
 # Remove sm100 backends from the list if not using sm100
-if not torch.cuda.is_available() or torch.cuda.get_device_properties(0).major < 10:
+if not torch.cuda.is_available() or current_platform.is_rocm() or torch.cuda.get_device_properties(0).major < 10:
     BACKENDS_TO_TEST.remove(AttentionBackendEnum.CUTLASS_MLA)
     BACKENDS_TO_TEST.remove(AttentionBackendEnum.FLASHINFER_MLA)
 


### PR DESCRIPTION
- Problem: Some tests crash on ROCm because they implicitly assume CUDA (e.g. checking get_device_properties().major for SM100, or running lex_attention which is unsupported/untested on AMD).
- Changes: Added current_platform.is_rocm() skips to 	est_mla_backends.py and 	est_flex_attention.py.
- Test plan: Run pytest on AMD GPUs.