### PR TITLE
[ROCm] Fix circular import in GCN arch detection

### DIFF
--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -170,11 +170,17 @@ def _get_gcn_arch() -> str:
         return _query_gcn_arch_from_amdsmi()
     except Exception as e:
         logger.debug("Failed to get GCN arch via amdsmi: %s", e)
-        logger.warning_once(
-            "Failed to get GCN arch via amdsmi, falling back to torch.cuda. "
-            "This will initialize CUDA and may cause "
-            "issues if CUDA_VISIBLE_DEVICES is not set yet."
-        )
+        
+    arch_env = os.environ.get("PYTORCH_ROCM_ARCH", "")
+    if arch_env:
+        logger.info("Using PYTORCH_ROCM_ARCH=%s for GCN arch", arch_env)
+        return arch_env
+
+    logger.warning(
+        "Failed to get GCN arch via amdsmi, falling back to torch.cuda. "
+        "This will initialize CUDA and may cause "
+        "issues if CUDA_VISIBLE_DEVICES is not set yet."
+    )
     # Ultimate fallback: use torch.cuda (will initialize CUDA)
     return torch.cuda.get_device_properties("cuda").gcnArchName
 


### PR DESCRIPTION
- Problem: When `amdsmi` fails during platform initialization, `logger.warning_once` creates a circular import loop inside `vllm/platforms/rocm.py` preventing vLLM from starting in containers.
- Changes: Avoid `warning_once`, use `warning` instead, and fallback to `PYTORCH_ROCM_ARCH` environment variable.
- Fixes part of #40081.

### AI Assistance Statement
This PR was created with AI assistance. It addresses a specific bug and circular import issue rather than being a trivial change. It does not duplicate existing PRs as it targets the specific circular import bug identified in #40081.

### Testing
No automated tests run due to hardware unavailability, but code logic directly bypasses the circular import.