### PR TITLE
[ROCm] Fix TurboQuant shape mismatch on non-power-of-2 head_dim

### DIFF
--- a/vllm/v1/attention/backends/turboquant_attn.py
+++ b/vllm/v1/attention/backends/turboquant_attn.py
@@ -84,7 +84,12 @@ def _build_hadamard_cached(d: int, device_str: str) -> torch.Tensor:
     H = torch.tensor([[1.0]])
     while H.shape[0] < d:
         H = torch.cat([torch.cat([H, H], 1), torch.cat([H, -H], 1)], 0)
-    return (H / math.sqrt(d)).to(torch.device(device_str))
+    # H is now next_power_of_2(d) x next_power_of_2(d)
+    # Correct normalization for orthonormal Hadamard is 1/sqrt(N)
+    N = H.shape[0]
+    H = H / math.sqrt(N)
+    # Slice to dxd to match head_dim
+    return H[:d, :d].to(torch.device(device_str))
 
 
 class TurboQuantAttentionBackend(AttentionBackend):


### PR DESCRIPTION
- Problem: _build_hadamard_cached failed to produce a correctly sized matrix for models with non-power-of-2 head_dim (like Phi-2 with d=80), leading to RuntimeError: mat1 and mat2 shapes cannot be multiplied.
- Changes: Corrected Hadamard normalization to use 
ext_power_of_2(d) and sliced the resulting matrix to d x d.
- Fixes #41413.

### AI Assistance Statement
This PR was created with AI assistance to fix a shape mismatch bug in the platform-independent rotation path of TurboQuant, which was identified and reproduced on ROCm MI300X.

### Testing
Logic verified: for d=80, H becomes 128x128, normalized by sqrt(128), and sliced to 80x80.