### PR TITLE
Temporary disable persistent topk for Hopper

### DIFF
--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -320,7 +320,7 @@ def sparse_attn_indexer(
         num_rows = logits.shape[0]
         topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
 
-        if current_platform.is_cuda() and topk_tokens in (512, 1024, 2048):
+        if current_platform.is_cuda() and topk_tokens in (512, 2048):
             workspace_manager = current_workspace_manager()
             (topk_workspace,) = workspace_manager.get_simultaneous(
                 ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),

--- a/vllm/model_executor/layers/sparse_attn_indexer.py
+++ b/vllm/model_executor/layers/sparse_attn_indexer.py
@@ -320,7 +320,12 @@ def sparse_attn_indexer(
         num_rows = logits.shape[0]
         topk_indices = topk_indices_buffer[:num_padded_tokens, :topk_tokens]
 
-        if current_platform.is_cuda() and topk_tokens in (512, 2048):
+        allowed_topk = (
+            (512, 1024, 2048)
+            if current_platform.is_device_capability_family(100)
+            else (512, 2048)
+        )
+        if current_platform.is_cuda() and topk_tokens in allowed_topk:
             workspace_manager = current_workspace_manager()
             (topk_workspace,) = workspace_manager.get_simultaneous(
                 ((RADIX_TOPK_WORKSPACE_SIZE,), torch.uint8),


### PR DESCRIPTION
## Summary
- Reverts commit a4debbd5bd0608999314ad68e6463fb1d76f5d4e on `releases/v0.20.1`, which had reverted #41442 ("Temporary disable persistent topk").
- Restores the `topk_tokens in (512, 1024, 2048)` gate in `vllm/model_executor/layers/sparse_attn_indexer.py` so the persistent topk path is re-disabled for `topk_tokens == 1024` on this release branch.

## Test plan
- Verified MTP=1 no longer hangs on hopper for deepseek v4 pro and gsm8k score as expected
> ✓ task=gsm8k | flexible-extract=0.9522 | strict-match=0.9530 

---
AI assistance was used to prepare this revert PR (Claude Code). The change is a pure revert of a single-line gate; the submitter has reviewed every changed line.

Co-authored-by: Claude <noreply@anthropic.com>