### PR TITLE
[On hold] feat(kernels): Migrate mm_encoder_attn to vLLM IR

### DIFF
--- a/tests/kernels/ir/test_mm_encoder_attn.py
+++ b/tests/kernels/ir/test_mm_encoder_attn.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import pytest
+import torch
+
+import vllm.kernels  # noqa: F401
+from tests.ir.ir_test_utils import assert_close, clone_args, supported_providers
+from vllm import ir
+from vllm.platforms import current_platform
+
+mm_encoder_attn_native = ir.ops.mm_encoder_attn.impls["native"].impl_fn
+
+
+def ref_attention(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    query, key, value = (x.transpose(1, 2) for x in (query, key, value))
+    attn_weights = scale * torch.matmul(query, key.transpose(2, 3))
+    attn_weights = torch.softmax(attn_weights, dim=-1).to(value.dtype)
+    out = torch.matmul(attn_weights, value).transpose(1, 2)
+    return out
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike() and not current_platform.is_xpu(),
+    reason="Currently only kernels on CUDA, ROCm and XPU",
+)
+def test_mm_encoder_attn_registration():
+    expected = {
+        "native": True,
+        "flash_attn": current_platform.is_cuda_alike() or current_platform.is_xpu(),
+        "triton": current_platform.is_cuda_alike() or current_platform.is_xpu(),
+    }
+
+    actual = {
+        provider: impl.supported
+        for provider, impl in ir.ops.mm_encoder_attn.impls.items()
+    }
+
+    assert actual == expected
+
+
+BATCH_SIZES = [1, 4]
+SEQ_LENS = [1, 16]
+NUM_HEADS = [1, 16]
+NUM_KV_HEADS = [1]
+HEAD_SIZES = [64, 80]
+DTYPES = [torch.float16, torch.bfloat16]
+
+
+@pytest.mark.parametrize("dtype", DTYPES + [torch.float32])
+@pytest.mark.parametrize("batch_size", BATCH_SIZES)
+@pytest.mark.parametrize("seq_len", SEQ_LENS)
+@pytest.mark.parametrize("num_heads", [4])
+@pytest.mark.parametrize("head_size", [64])
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike() and not current_platform.is_xpu(),
+    reason="Currently only kernels on CUDA, ROCm and XPU",
+)
+class TestMMEncoderAttnNative:
+    @classmethod
+    def setup_class(cls, **kwargs):
+        torch.set_default_device(current_platform.device_type)
+
+    def test_native_semantics(self, dtype, batch_size, seq_len, num_heads, head_size):
+        scale = 1.0 / (head_size**0.5)
+        q, k, v, s = ir.ops.mm_encoder_attn.generate_inputs(
+            batch_size=batch_size,
+            seq_len=seq_len,
+            num_heads=num_heads,
+            num_kv_heads=num_heads,
+            head_size=head_size,
+            dtype=dtype,
+            scale=scale,
+        )
+        out = mm_encoder_attn_native(q, k, v, s)
+
+        assert out.shape == q.shape
+        assert out.dtype == q.dtype
+        assert out.device == q.device
+
+        ref_out = ref_attention(q, k, v, scale)
+        torch.testing.assert_close(out, ref_out, atol=1e-2, rtol=1e-2)
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("batch_size", BATCH_SIZES)
+@pytest.mark.parametrize("seq_len", SEQ_LENS)
+@pytest.mark.parametrize("num_heads", NUM_HEADS)
+@pytest.mark.parametrize("num_kv_heads", NUM_KV_HEADS)
+@pytest.mark.parametrize("head_size", HEAD_SIZES)
+@pytest.mark.skipif(
+    not current_platform.is_cuda_alike() and not current_platform.is_xpu(),
+    reason="Currently only kernels on CUDA, ROCm and XPU",
+)
+class TestMMEncoderAttn:
+    @classmethod
+    def setup_class(cls, **kwargs):
+        torch.set_default_device(current_platform.device_type)
+
+    @pytest.mark.parametrize("provider", supported_providers(ir.ops.mm_encoder_attn))
+    def test_impls(
+        self, dtype, batch_size, seq_len, num_heads, num_kv_heads, head_size, provider
+    ):
+        impl = ir.ops.mm_encoder_attn.impls[provider]
+        scale = 1.0 / (head_size**0.5)
+        q, k, v, s = ir.ops.mm_encoder_attn.generate_inputs(
+            batch_size=batch_size,
+            seq_len=seq_len,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_size=head_size,
+            dtype=dtype,
+            scale=scale,
+        )
+        args = (q, k, v, s)
+
+        if not impl.supports_args(*args):
+            pytest.skip(f"{provider} does not support args")
+
+        ref_output = mm_encoder_attn_native(*clone_args(args))
+        output = impl.impl_fn(*clone_args(args))
+        assert_close(ir.ops.mm_encoder_attn, output, ref_output)
+
+        with ir.ops.mm_encoder_attn.set_priority([provider, "native"]):
+            out_dispatched = ir.ops.mm_encoder_attn(*args)
+        out_direct = impl.impl_fn(*args)
+        torch.testing.assert_close(out_dispatched, out_direct, rtol=0.0, atol=0.0)
+
+    @pytest.mark.parametrize("provider", supported_providers(ir.ops.mm_encoder_attn))
+    def test_varlen(
+        self, dtype, batch_size, seq_len, num_heads, num_kv_heads, head_size, provider
+    ):
+        impl = ir.ops.mm_encoder_attn.impls[provider]
+        scale = 1.0 / (head_size**0.5)
+        var_seq_lens = [seq_len, seq_len + 1]
+        total_len = sum(var_seq_lens)
+        q = torch.randn(1, total_len, num_heads, head_size, dtype=dtype)
+        k = torch.randn(1, total_len, num_kv_heads, head_size, dtype=dtype)
+        v = torch.randn(1, total_len, num_kv_heads, head_size, dtype=dtype)
+        cu_seqlens = torch.tensor([0, var_seq_lens[0], total_len], dtype=torch.int32)
+        max_seqlen = max(var_seq_lens)
+        args = (q, k, v, scale, cu_seqlens, max_seqlen)
+
+        if not impl.supports_args(*args):
+            pytest.skip(f"{provider} does not support args")
+
+        ref_output = mm_encoder_attn_native(*clone_args(args))
+        output = impl.impl_fn(*clone_args(args))
+        assert_close(ir.ops.mm_encoder_attn, output, ref_output)
+
+    @pytest.mark.parametrize(
+        "provider", supported_providers(ir.ops.mm_encoder_attn) + ["native"]
+    )
+    def test_torch_opcheck(
+        self, dtype, batch_size, seq_len, num_heads, num_kv_heads, head_size, provider
+    ):
+        if not ir.ops.mm_encoder_attn.impls[provider].supported:
+            pytest.skip(f"{provider} impl not supported on this platform")
+
+        args = ir.ops.mm_encoder_attn.generate_inputs(
+            batch_size=batch_size,
+            seq_len=seq_len,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            head_size=head_size,
+            dtype=dtype,
+        )
+
+        with ir.ops.mm_encoder_attn.set_priority([provider, "native"]):
+            torch.library.opcheck(torch.ops.vllm_ir.mm_encoder_attn, args)

--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -34,6 +34,9 @@ class IrOpPriorityConfig:
     fused_add_rms_norm: list[str] = Field(default_factory=list)
     """Priority list for vllm.ir.ops.fused_add_rms_norm"""
 
+    mm_encoder_attn: list[str] = Field(default_factory=list)
+    """Priority list for vllm.ir.ops.mm_encoder_attn"""
+
     def compute_hash(self) -> str:
         """
         Produces a hash unique to the pass configuration.

--- a/vllm/ir/ops/__init__.py
+++ b/vllm/ir/ops/__init__.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from .attention import mm_encoder_attn
 from .layernorm import fused_add_rms_norm, rms_norm
 
-__all__ = ["rms_norm", "fused_add_rms_norm"]
+__all__ = ["rms_norm", "fused_add_rms_norm", "mm_encoder_attn"]

--- a/vllm/ir/ops/attention.py
+++ b/vllm/ir/ops/attention.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from ..op import register_op
+
+
+@register_op
+def mm_encoder_attn(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    scale: float,
+    cu_seqlens: Tensor | None = None,
+    max_seqlen: int | None = None,
+) -> Tensor:
+    """Multi-head encoder attention without KV cache (for multimodal encoders).
+
+    Inputs are 4D: (batch_size, seq_len, num_heads, head_size).
+    """
+    enable_gqa = query.size(2) != key.size(2)
+    q = query.transpose(1, 2)
+    k = key.transpose(1, 2)
+    v = value.transpose(1, 2)
+
+    if cu_seqlens is not None:
+        outputs = []
+        lens = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+        for q_i, k_i, v_i in zip(
+            torch.split(q, lens, dim=2),
+            torch.split(k, lens, dim=2),
+            torch.split(v, lens, dim=2),
+        ):
+            out_i = F.scaled_dot_product_attention(
+                q_i, k_i, v_i, dropout_p=0.0, scale=scale, enable_gqa=enable_gqa
+            )
+            outputs.append(out_i)
+        output = torch.cat(outputs, dim=2)
+    else:
+        output = F.scaled_dot_product_attention(
+            q, k, v, dropout_p=0.0, scale=scale, enable_gqa=enable_gqa
+        )
+
+    return output.transpose(1, 2)
+
+
+@mm_encoder_attn.register_fake
+def _mm_encoder_attn_fake(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    scale: float,
+    cu_seqlens: Tensor | None = None,
+    max_seqlen: int | None = None,
+) -> Tensor:
+    return torch.empty_like(query)
+
+
+@mm_encoder_attn.register_input_generator
+def _mm_encoder_attn_input_generator(
+    batch_size: int,
+    seq_len: int,
+    num_heads: int,
+    num_kv_heads: int,
+    head_size: int,
+    dtype: torch.dtype,
+    scale: float | None = None,
+) -> tuple:
+    if scale is None:
+        scale = 1.0 / (head_size**0.5)
+    query = torch.randn(batch_size, seq_len, num_heads, head_size, dtype=dtype)
+    key = torch.randn(batch_size, seq_len, num_kv_heads, head_size, dtype=dtype)
+    value = torch.randn(batch_size, seq_len, num_kv_heads, head_size, dtype=dtype)
+    return query, key, value, scale
+
+
+mm_encoder_attn.override_tolerance(torch.float16, atol=1e-2, rtol=1e-2)
+mm_encoder_attn.override_tolerance(torch.bfloat16, atol=1e-2, rtol=1e-2)

--- a/vllm/kernels/__init__.py
+++ b/vllm/kernels/__init__.py
@@ -2,6 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """Kernel implementations for vLLM."""
 
-from . import aiter_ops, oink_ops, vllm_c, xpu_ops
+from . import aiter_ops, attention_ops, oink_ops, vllm_c, xpu_ops
 
-__all__ = ["vllm_c", "aiter_ops", "oink_ops", "xpu_ops"]
+__all__ = ["vllm_c", "aiter_ops", "oink_ops", "xpu_ops", "attention_ops"]

--- a/vllm/kernels/attention_ops.py
+++ b/vllm/kernels/attention_ops.py
@@ -1,0 +1,144 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+from torch import Tensor
+
+from vllm import ir
+from vllm.platforms import current_platform
+
+
+def _is_flash_attn_available() -> bool:
+    if current_platform.is_rocm():
+        try:
+            from aiter import flash_attn_varlen_func  # noqa: F401
+
+            return True
+        except ImportError:
+            return False
+    if current_platform.is_xpu():
+        try:
+            from vllm.v1.attention.backends.fa_utils import (
+                flash_attn_varlen_func,  # noqa: F401
+            )
+
+            return True
+        except ImportError:
+            return False
+    try:
+        from vllm.vllm_flash_attn.flash_attn_interface import (
+            is_fa_version_supported,  # noqa: F401
+        )
+
+        return True
+    except ImportError:
+        return False
+
+
+def _is_triton_available() -> bool:
+    try:
+        import triton  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+FLASH_ATTN_AVAILABLE = _is_flash_attn_available()
+TRITON_AVAILABLE = _is_triton_available()
+
+FLASH_ATTN_SUPPORTED = FLASH_ATTN_AVAILABLE and (
+    current_platform.is_cuda_alike() or current_platform.is_xpu()
+)
+TRITON_SUPPORTED = TRITON_AVAILABLE and (
+    current_platform.is_cuda_alike() or current_platform.is_xpu()
+)
+
+
+def _fa_supports_args(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    scale: float,
+    cu_seqlens: Tensor | None = None,
+    max_seqlen: int | None = None,
+) -> bool:
+    if query.dtype == torch.float32:
+        return False
+    head_size = query.size(-1)
+    return head_size % 8 == 0 and head_size <= 256
+
+
+@ir.ops.mm_encoder_attn.register_impl(
+    "flash_attn", supports_args=_fa_supports_args, supported=FLASH_ATTN_SUPPORTED
+)
+def flash_attn_impl(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    scale: float,
+    cu_seqlens: Tensor | None = None,
+    max_seqlen: int | None = None,
+) -> Tensor:
+    from vllm.v1.attention.backends.fa_utils import get_flash_attn_version
+    from vllm.v1.attention.ops.vit_attn_wrappers import vit_flash_attn_wrapper
+
+    bsz = query.size(0)
+    head_size = query.size(-1)
+    fa_version = get_flash_attn_version(head_size=head_size)
+    max_seqlen_t = (
+        torch.tensor(max_seqlen, device=query.device)
+        if max_seqlen is not None
+        else None
+    )
+    return vit_flash_attn_wrapper(
+        q=query,
+        k=key,
+        v=value,
+        batch_size=bsz,
+        is_rocm_aiter=current_platform.is_rocm(),
+        fa_version=fa_version,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        max_seqlen=max_seqlen_t,
+    )
+
+
+def _triton_supports_args(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    scale: float,
+    cu_seqlens: Tensor | None = None,
+    max_seqlen: int | None = None,
+) -> bool:
+    return query.size(2) == key.size(2)
+
+
+@ir.ops.mm_encoder_attn.register_impl(
+    "triton", supports_args=_triton_supports_args, supported=TRITON_SUPPORTED
+)
+def triton_impl(
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    scale: float,
+    cu_seqlens: Tensor | None = None,
+    max_seqlen: int | None = None,
+) -> Tensor:
+    from vllm.v1.attention.ops.vit_attn_wrappers import vit_triton_attn_wrapper
+
+    bsz = query.size(0)
+    max_seqlen_t = (
+        torch.tensor(max_seqlen, device=query.device)
+        if max_seqlen is not None
+        else None
+    )
+    return vit_triton_attn_wrapper(
+        q=query,
+        k=key,
+        v=value,
+        batch_size=bsz,
+        scale=scale,
+        cu_seqlens=cu_seqlens,
+        max_seqlen=max_seqlen_t,
+    )

--- a/vllm/kernels/attention_ops.py
+++ b/vllm/kernels/attention_ops.py
@@ -85,11 +85,7 @@ def flash_attn_impl(
     bsz = query.size(0)
     head_size = query.size(-1)
     fa_version = get_flash_attn_version(head_size=head_size)
-    max_seqlen_t = (
-        torch.tensor(max_seqlen, device=query.device)
-        if max_seqlen is not None
-        else None
-    )
+    max_seqlen_t = torch.tensor(max_seqlen) if max_seqlen is not None else None
     return vit_flash_attn_wrapper(
         q=query,
         k=key,
@@ -128,11 +124,7 @@ def triton_impl(
     from vllm.v1.attention.ops.vit_attn_wrappers import vit_triton_attn_wrapper
 
     bsz = query.size(0)
-    max_seqlen_t = (
-        torch.tensor(max_seqlen, device=query.device)
-        if max_seqlen is not None
-        else None
-    )
+    max_seqlen_t = torch.tensor(max_seqlen) if max_seqlen is not None else None
     return vit_triton_attn_wrapper(
         q=query,
         k=key,

--- a/vllm/model_executor/layers/attention/mm_encoder_attention.py
+++ b/vllm/model_executor/layers/attention/mm_encoder_attention.py
@@ -7,6 +7,8 @@ import json
 import numpy as np
 import torch
 
+import vllm.kernels  # noqa: F401
+from vllm import ir
 from vllm.config import MultiModalConfig
 from vllm.kernels.triton.qkv_padded_fp8_quant import (
     quantize_fp8_maybe_pad_head_dim,
@@ -28,13 +30,9 @@ from vllm.utils.flashinfer import (
     is_flashinfer_cudnn_fp8_prefill_attn_supported,
 )
 from vllm.utils.math_utils import round_up
-from vllm.v1.attention.backends.fa_utils import get_flash_attn_version
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.ops.vit_attn_wrappers import (
-    vit_flash_attn_wrapper,
     vit_flashinfer_wrapper,
-    vit_torch_sdpa_wrapper,
-    vit_triton_attn_wrapper,
 )
 
 logger = init_logger(__name__)
@@ -360,12 +358,6 @@ class MMEncoderAttention(CustomOp):
             AttentionBackendEnum.ROCM_AITER_FA,
         }
 
-        self._fa_version = (
-            get_flash_attn_version(head_size=head_size)
-            if self.is_flash_attn_backend
-            else None
-        )
-
         if self.attn_backend == AttentionBackendEnum.FLASHINFER:
             _get_flashinfer_workspace_buffer()
 
@@ -482,31 +474,13 @@ class MMEncoderAttention(CustomOp):
     def enabled(cls) -> bool:
         return True
 
-    def view_qkv_to_4d(
-        self,
-        query: torch.Tensor,
-        key: torch.Tensor,
-        value: torch.Tensor,
-        bsz: int,
-        q_len: int,
-        kv_len: int,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        """
-        Reshape query, key, value to 4D tensors:
-        (batch_size, seq_len, num_heads, head_size)
-        """
-        query = query.view(bsz, q_len, self.num_heads, self.head_size)
-        key = key.view(bsz, kv_len, self.num_kv_heads, self.head_size)
-        value = value.view(bsz, kv_len, self.num_kv_heads, self.head_size)
-
-        return query, key, value
-
-    def _forward_sdpa(
+    def _call_ir_op(
         self,
         query: torch.Tensor,
         key: torch.Tensor,
         value: torch.Tensor,
         cu_seqlens: torch.Tensor | None = None,
+        max_seqlen: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """Input shape:
         (batch_size x seq_len x hidden_size) or
@@ -516,88 +490,18 @@ class MMEncoderAttention(CustomOp):
         kv_len = key.size(1)
         is_reshaped = query.dim() != 4
 
-        query, key, value = self.view_qkv_to_4d(query, key, value, bsz, q_len, kv_len)
-
-        output = vit_torch_sdpa_wrapper(
-            q=query,
-            k=key,
-            v=value,
-            scale=self.scale,
-            cu_seqlens=cu_seqlens,
-            enable_gqa=self.num_heads > self.num_kv_heads,
-        )
         if is_reshaped:
-            output = output.reshape(bsz, q_len, -1)
-        return output
+            query = query.view(bsz, q_len, self.num_heads, self.head_size)
+            key = key.view(bsz, kv_len, self.num_kv_heads, self.head_size)
+            value = value.view(bsz, kv_len, self.num_kv_heads, self.head_size)
 
-    def _forward_fa(
-        self,
-        query: torch.Tensor,
-        key: torch.Tensor,
-        value: torch.Tensor,
-        cu_seqlens: torch.Tensor | None = None,
-        max_seqlen: torch.Tensor | None = None,  # Only used for Flash Attention
-    ) -> torch.Tensor:
-        """Input shape:
-        (batch_size x seq_len x hidden_size) or
-        (batch_size x seq_len x num_heads x head_size)
-        """
-        assert (cu_seqlens is not None and max_seqlen is not None) or (
-            cu_seqlens is None and max_seqlen is None
-        ), "cu_seqlens and max_seqlen should be both set or both None."
-
-        bsz, q_len = query.size()[:2]
-        kv_len = key.size(1)
-        is_reshaped = query.dim() != 4
-
-        query, key, value = self.view_qkv_to_4d(query, key, value, bsz, q_len, kv_len)
-
-        output = vit_flash_attn_wrapper(
-            q=query,
-            k=key,
-            v=value,
-            batch_size=bsz,
-            is_rocm_aiter=(self.attn_backend == AttentionBackendEnum.ROCM_AITER_FA),
-            fa_version=self._fa_version,
-            scale=self.scale,
-            cu_seqlens=cu_seqlens,
-            max_seqlen=max_seqlen,
+        max_seqlen_int = (
+            max_seqlen.item() if isinstance(max_seqlen, torch.Tensor) else max_seqlen
         )
-        if is_reshaped:
-            output = output.reshape(bsz, q_len, -1)
-        return output
-
-    def _forward_triton(
-        self,
-        query: torch.Tensor,
-        key: torch.Tensor,
-        value: torch.Tensor,
-        cu_seqlens: torch.Tensor | None = None,
-        max_seqlen: torch.Tensor | None = None,  # Only used for Flash Attention
-    ) -> torch.Tensor:
-        """Input shape:
-        (batch_size x seq_len x hidden_size) or
-        (batch_size x seq_len x num_heads x head_size)
-        """
-        assert (cu_seqlens is not None and max_seqlen is not None) or (
-            cu_seqlens is None and max_seqlen is None
-        ), "cu_seqlens and max_seqlen should be both set or both None."
-
-        bsz, q_len = query.size()[:2]
-        kv_len = key.size(1)
-        is_reshaped = query.dim() != 4
-
-        query, key, value = self.view_qkv_to_4d(query, key, value, bsz, q_len, kv_len)
-
-        output = vit_triton_attn_wrapper(
-            q=query,
-            k=key,
-            v=value,
-            batch_size=bsz,
-            scale=self.scale,
-            cu_seqlens=cu_seqlens,
-            max_seqlen=max_seqlen,
+        output = ir.ops.mm_encoder_attn(
+            query, key, value, self.scale, cu_seqlens, max_seqlen_int
         )
+
         if is_reshaped:
             output = output.reshape(bsz, q_len, -1)
         return output
@@ -701,11 +605,11 @@ class MMEncoderAttention(CustomOp):
         key: torch.Tensor,
         value: torch.Tensor,
         cu_seqlens: torch.Tensor | None = None,
-        max_seqlen: torch.Tensor | None = None,  # Only used for Flash Attention
+        max_seqlen: torch.Tensor | None = None,  # Used by FlashAttention and Triton
         sequence_lengths: torch.Tensor
-        | None = None,  # Only used for FlashInfer CuDNN backend
+        | None = None,  # Kept for API compatibility; routes only to FlashInfer
     ) -> torch.Tensor:
-        return self._forward_sdpa(query, key, value, cu_seqlens)
+        return self._call_ir_op(query, key, value, cu_seqlens, max_seqlen)
 
     def forward_cuda(
         self,
@@ -713,25 +617,15 @@ class MMEncoderAttention(CustomOp):
         key: torch.Tensor,
         value: torch.Tensor,
         cu_seqlens: torch.Tensor | None = None,
-        max_seqlen: torch.Tensor | None = None,  # Only used for Flash Attention
+        max_seqlen: torch.Tensor | None = None,  # Used by FlashAttention and Triton
         sequence_lengths: torch.Tensor
-        | None = None,  # Only used for FlashInfer CuDNN backend
+        | None = None,  # Kept for API compatibility; routes only to FlashInfer
     ) -> torch.Tensor:
-        if self.is_flash_attn_backend:
-            return self._forward_fa(query, key, value, cu_seqlens, max_seqlen)
-        elif self.attn_backend == AttentionBackendEnum.TRITON_ATTN:
-            return self._forward_triton(query, key, value, cu_seqlens, max_seqlen)
-        elif self.attn_backend == AttentionBackendEnum.FLASHINFER:
+        if self.attn_backend == AttentionBackendEnum.FLASHINFER:
             return self._forward_flashinfer(
                 query, key, value, cu_seqlens, max_seqlen, sequence_lengths
             )
-        elif self.attn_backend == AttentionBackendEnum.TORCH_SDPA:
-            return self._forward_sdpa(query, key, value, cu_seqlens)
-        else:
-            raise ValueError(
-                f"Unsupported multi-modal encoder attention backend for CUDA: "
-                f"{self.attn_backend}."
-            )
+        return self._call_ir_op(query, key, value, cu_seqlens, max_seqlen)
 
     def forward_cpu(
         self,
@@ -739,11 +633,11 @@ class MMEncoderAttention(CustomOp):
         key: torch.Tensor,
         value: torch.Tensor,
         cu_seqlens: torch.Tensor | None = None,
-        max_seqlen: torch.Tensor | None = None,  # Only used for Flash Attention
+        max_seqlen: torch.Tensor | None = None,  # Used by FlashAttention and Triton
         sequence_lengths: torch.Tensor
-        | None = None,  # Only used for FlashInfer CuDNN backend
+        | None = None,  # Kept for API compatibility; routes only to FlashInfer
     ) -> torch.Tensor:
-        return self._forward_sdpa(query, key, value, cu_seqlens)
+        return self._call_ir_op(query, key, value, cu_seqlens, max_seqlen)
 
     def forward_xpu(
         self,
@@ -751,18 +645,8 @@ class MMEncoderAttention(CustomOp):
         key: torch.Tensor,
         value: torch.Tensor,
         cu_seqlens: torch.Tensor | None = None,
-        max_seqlen: torch.Tensor | None = None,  # Only used for Flash Attention
+        max_seqlen: torch.Tensor | None = None,  # Used by FlashAttention and Triton
         sequence_lengths: torch.Tensor
-        | None = None,  # Only used for FlashInfer CuDNN backend
+        | None = None,  # Kept for API compatibility; routes only to FlashInfer
     ) -> torch.Tensor:
-        if self.attn_backend == AttentionBackendEnum.FLASH_ATTN:
-            return self._forward_fa(query, key, value, cu_seqlens, max_seqlen)
-        elif self.attn_backend == AttentionBackendEnum.TRITON_ATTN:
-            return self._forward_triton(query, key, value, cu_seqlens, max_seqlen)
-        elif self.attn_backend == AttentionBackendEnum.TORCH_SDPA:
-            return self._forward_sdpa(query, key, value, cu_seqlens)
-        else:
-            raise ValueError(
-                f"Unsupported multi-modal encoder attention backend for XPU: "
-                f"{self.attn_backend}."
-            )
+        return self._call_ir_op(query, key, value, cu_seqlens, max_seqlen)

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -578,8 +578,13 @@ class CudaPlatformBase(Platform):
         if envs.VLLM_USE_OINK_OPS:
             rms_norm = ["oink"] + default
 
+        mm_encoder_attn = ["flash_attn", "triton", "native"]
+
         return IrOpPriorityConfig.with_default(
-            default, rms_norm=rms_norm, fused_add_rms_norm=rms_norm
+            default,
+            rms_norm=rms_norm,
+            fused_add_rms_norm=rms_norm,
+            mm_encoder_attn=mm_encoder_attn,
         )
 
 

--- a/vllm/platforms/rocm.py
+++ b/vllm/platforms/rocm.py
@@ -950,8 +950,13 @@ class RocmPlatform(Platform):
         else:
             rms_norm = default
 
+        mm_encoder_attn = ["flash_attn", "native"]
+
         return IrOpPriorityConfig.with_default(
-            default, rms_norm=rms_norm, fused_add_rms_norm=rms_norm
+            default,
+            rms_norm=rms_norm,
+            fused_add_rms_norm=rms_norm,
+            mm_encoder_attn=mm_encoder_attn,
         )
 
     @classmethod

--- a/vllm/platforms/xpu.py
+++ b/vllm/platforms/xpu.py
@@ -360,7 +360,9 @@ class XPUPlatform(Platform):
         using_inductor = cc.backend == "inductor" and cc.mode != CompilationMode.NONE
         default = ["native"] if using_inductor else ["xpu_kernels", "native"]
 
-        return IrOpPriorityConfig.with_default(default)
+        mm_encoder_attn = ["flash_attn", "triton", "native"]
+
+        return IrOpPriorityConfig.with_default(default, mm_encoder_attn=mm_encoder_attn)
 
     @classmethod
     def device_count(cls) -> int:


### PR DESCRIPTION
### Status

**On hold** on IR workspace support (per [maintainer feedback](https://github.com/vllm-project/vllm/pull/41613#issuecomment-4373747410)). Will rebase and complete once that lands.

### Purpose

→ This PR migrates the multimodal encoder attention (`MMEncoderAttention`) to the new vLLM IR framework, as discussed in https://github.com/vllm-project/vllm/issues/32676
→ Followed existing IR ops implementation patterns and the spec detailed in https://github.com/vllm-project/vllm/issues/32358
→ Added a test file following the IR pattern, and tested inference in `native`, `triton`, and default `flash_attn` modes. Moved all hardware-specific routing in `MMEncoderAttention` into `_call_ir_op` and preserved the `FlashInfer` path to handle FP8 caching.

### Test Plan
<ins>**A > Existing MHA Tests (Regression)**</ins>
→ The following test harness was executed to check that no regressions were introduced in the existing MHA and FlashInfer paths:
`tests/kernels/attention/test_mha_attn.py`
<ins>**B > New IR Kernel Tests (Added)**</ins>
→ The following test harness was added in this PR and executed to check the functional robustness of the new IR op across various data types (FP16, BF16), batch sizes, and sequence lengths:
`tests/kernels/ir/test_mm_encoder_attn.py`
<ins>**C > IR Meta-Tests (Integration)**</ins>
→ The following test harness was added in this PR and executed to check that the new op is correctly registered in the IR framework:
`tests/kernels/ir/test_ir_ops.py`
<ins>**D > E2E Sanity (Inference)**</ins>
→ Wrote a sanity check script and executed inference to check for E2E sanity across all modes:
https://gist.github.com/harshaljanjani/432d9fb7aa0bfdc550a63774872ea073

### Test Results

<ins>**A, B and C:**</ins><br>
<img alt="Untitled design (3)" src="https://github.com/user-attachments/assets/985b7e78-5a92-4549-99af-c4b1bcb172ad" />

<ins>**D:**</ins><br>
→ <ins>Backend: flash_attn</ins><br>
<img alt="2-1" src="https://github.com/user-attachments/assets/853e7879-2b65-4aea-ba5d-c37662191594" />

→ <ins>Backend: triton</ins><br>
<img alt="2-2" src="https://github.com/user-attachments/assets/57951cb1-2646-48dc-bc2c-1c3858e94d6f" />

→ <ins>Backend: native</ins><br>
<img alt="2-3" src="https://github.com/user-attachments/assets/1171fbf7-bdfd-4f33-a43b-9e7fea868118" />

### Before submitting
- [ ] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).
- [x] Was this discussed/approved via a Github issue?
- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results