### PR TITLE
Revert "[Doc] Fix RTD build: pytorch.org/docs/stable/objects.inv returns 404"

### DIFF
--- a/mkdocs.yaml
+++ b/mkdocs.yaml
@@ -105,8 +105,7 @@ plugins:
           - https://docs.aiohttp.org/en/stable/objects.inv
           - https://pillow.readthedocs.io/en/stable/objects.inv
           - https://numpy.org/doc/stable/objects.inv
-          # TODO revert to stable once https://github.com/pytorch/pytorch/issues/182007 is fixed
-          - https://pytorch.org/docs/2.11/objects.inv
+          - https://pytorch.org/docs/stable/objects.inv
   - redirects:
       redirect_maps:
         features/spec_decode/README.md: features/speculative_decoding/README.md


### PR DESCRIPTION
Fixed upstream by pytorch/docs#85. `pytorch.org/docs/stable/objects.inv` is back, byte-identical to the `/docs/2.11/` pin.

Reverts vllm-project/vllm#41353