### PR TITLE
[Bugfix] Apply ruff-format to hyperclovax.py

### DIFF
--- a/vllm/transformers_utils/configs/hyperclovax.py
+++ b/vllm/transformers_utils/configs/hyperclovax.py
@@ -327,8 +327,7 @@ class HCXVisionConfig(PretrainedConfig):
 
         self.vision_config = None
         if vision_config is not None:
-            _vision_config = AutoConfig.for_model(
-                vision_config["model_type"])
+            _vision_config = AutoConfig.for_model(vision_config["model_type"])
             self.vision_config = _vision_config.from_dict(vision_config)
 
         self.use_nth_layer = use_nth_layer


### PR DESCRIPTION
`ruff-format` flags two lines in `vllm/transformers_utils/configs/hyperclovax.py` (vendored in #38447). Collapses the `AutoConfig.for_model(...)` call to one line.

Verified: `pre-commit run ruff-format --files vllm/transformers_utils/configs/hyperclovax.py`.

Signed-off-by: Stefano Castagnetta <scastagnetta@nvidia.com>