### PR TITLE
[Core] block_pool: sort the list of allocated free blocks

### DIFF
--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -334,6 +334,7 @@ class BlockPool:
             raise ValueError(f"Cannot get {num_blocks} free blocks from the pool")
 
         ret: list[KVCacheBlock] = self.free_block_queue.popleft_n(num_blocks)
+        ret.sort(key=lambda block: block.block_id)
 
         # In order to only iterate the list once, we duplicated code a bit
         if self.enable_caching:


### PR DESCRIPTION
Sorting the blocks returned from the free list, increases the chance that blocks that correspond to the same request and therefore KV cache content, will also be sequential in the device memory. This helps later for offload engines that want to write out that KV cache to file with a smaller vector of scatter gather, which can increase IO size and therefore offload throughput.