### PR TITLE
Fix DeepSeek V4 reasoning before tool calls

### DIFF
--- a/tests/reasoning/test_deepseekv3_reasoning_parser.py
+++ b/tests/reasoning/test_deepseekv3_reasoning_parser.py
@@ -9,6 +9,7 @@ from vllm.entrypoints.openai.engine.protocol import DeltaMessage
 from vllm.reasoning import ReasoningParserManager
 from vllm.reasoning.deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
 from vllm.reasoning.deepseek_v3_reasoning_parser import DeepSeekV3ReasoningParser
+from vllm.reasoning.deepseek_v4_reasoning_parser import DeepSeekV4ReasoningParser
 from vllm.reasoning.identity_reasoning_parser import IdentityReasoningParser
 
 REASONING_MODEL_NAME = "deepseek-ai/DeepSeek-V3.1"
@@ -37,7 +38,7 @@ def test_parser_selection(tokenizer, thinking, expected_parser_type):
 def test_deepseek_v4_reasoning_parser_alias():
     parser_cls = ReasoningParserManager.get_reasoning_parser("deepseek_v4")
 
-    assert parser_cls is DeepSeekV3ReasoningParser
+    assert parser_cls is DeepSeekV4ReasoningParser
 
 
 def test_identity_reasoning_parser_basic(tokenizer):

--- a/tests/reasoning/test_deepseekv4_reasoning_parser.py
+++ b/tests/reasoning/test_deepseekv4_reasoning_parser.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import json
+from unittest.mock import MagicMock
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.reasoning.deepseek_v4_reasoning_parser import DeepSeekV4ReasoningParser
+from vllm.tool_parsers.deepseekv4_tool_parser import DeepSeekV4ToolParser
+
+TC_START = "<｜DSML｜tool_calls>"
+TC_END = "</｜DSML｜tool_calls>"
+DSML_TOOL_CALL = (
+    f"{TC_START}\n"
+    '<｜DSML｜invoke name="read_file">\n'
+    '<｜DSML｜parameter name="path" string="true">/tmp/example.lean'
+    "</｜DSML｜parameter>\n"
+    "</｜DSML｜invoke>\n"
+    f"{TC_END}"
+)
+
+
+class FakeDeepSeekV4Tokenizer:
+    vocab = {"<think>": 1, "</think>": 2}
+
+    def get_vocab(self) -> dict[str, int]:
+        return self.vocab
+
+
+def _request() -> ChatCompletionRequest:
+    return ChatCompletionRequest(model="test-model", messages=[])
+
+
+def _parser() -> DeepSeekV4ReasoningParser:
+    return DeepSeekV4ReasoningParser(
+        FakeDeepSeekV4Tokenizer(),
+        chat_template_kwargs={"thinking": True},
+    )
+
+
+def test_tool_call_start_implicitly_ends_reasoning() -> None:
+    reasoning, content = _parser().extract_reasoning(
+        f"Let me search.\n\n{DSML_TOOL_CALL}",
+        _request(),
+    )
+
+    assert reasoning == "Let me search.\n\n"
+    assert content == DSML_TOOL_CALL
+
+
+def test_implicit_content_is_parseable_as_tool_call() -> None:
+    tool_parser = DeepSeekV4ToolParser(MagicMock(), tools=None)
+    _, content = _parser().extract_reasoning(
+        f"Let me search.\n\n{DSML_TOOL_CALL}",
+        _request(),
+    )
+
+    result = tool_parser.extract_tool_calls(content or "", MagicMock())
+
+    assert result.tools_called
+    assert len(result.tool_calls) == 1
+    parsed_tool_call = result.tool_calls[0]
+    assert parsed_tool_call.function.name == "read_file"
+    assert json.loads(parsed_tool_call.function.arguments) == {
+        "path": "/tmp/example.lean",
+    }

--- a/vllm/reasoning/__init__.py
+++ b/vllm/reasoning/__init__.py
@@ -29,8 +29,8 @@ _REASONING_PARSERS_TO_REGISTER = {
         "DeepSeekV3ReasoningParser",
     ),
     "deepseek_v4": (
-        "deepseek_v3_reasoning_parser",
-        "DeepSeekV3ReasoningParser",
+        "deepseek_v4_reasoning_parser",
+        "DeepSeekV4ReasoningParser",
     ),
     "poolside_v1": (
         "poolside_v1_reasoning_parser",

--- a/vllm/reasoning/deepseek_v4_reasoning_parser.py
+++ b/vllm/reasoning/deepseek_v4_reasoning_parser.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from typing import TYPE_CHECKING
+
+from vllm.reasoning.deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
+from vllm.reasoning.deepseek_v3_reasoning_parser import DeepSeekV3ReasoningParser
+
+if TYPE_CHECKING:
+    from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+    from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
+
+
+class DeepSeekV4ReasoningParser(DeepSeekV3ReasoningParser):
+    """
+    DeepSeek V4 reasoning parser.
+
+    DeepSeek V4 can start DSML tool calls directly after reasoning. Treating the
+    tool-call block as content lets the DeepSeek V4 tool parser handle it.
+    """
+
+    tool_call_start_token = "<｜DSML｜tool_calls>"
+
+    def _r1_parser(self) -> DeepSeekR1ReasoningParser | None:
+        if isinstance(self._parser, DeepSeekR1ReasoningParser):
+            return self._parser
+        return None
+
+    def extract_reasoning(
+        self,
+        model_output: str,
+        request: "ChatCompletionRequest | ResponsesRequest",
+    ) -> tuple[str | None, str | None]:
+        r1_parser = self._r1_parser()
+        if r1_parser is None:
+            return self._parser.extract_reasoning(model_output, request)
+
+        reasoning, content = r1_parser.extract_reasoning(model_output, request)
+        if reasoning is None or self.tool_call_start_token not in reasoning:
+            return reasoning, content
+
+        reasoning, _, tool_content = reasoning.partition(self.tool_call_start_token)
+        content = self.tool_call_start_token + tool_content + (content or "")
+        return reasoning, content


### PR DESCRIPTION
## Summary

DeepSeek V4 uses DSML tool-call blocks (`<｜DSML｜tool_calls>...`) with the `deepseek_v4` tool parser. The `deepseek_v4` reasoning parser was previously an alias for the DeepSeek V3 parser, which delegates to the R1 `<think>...</think>` parser when thinking is enabled.

If a model starts a DSML tool-call block before emitting `</think>`, the R1 parser classifies the whole output as reasoning and returns no content. Non-streaming chat completion only runs tool parsing on the post-reasoning content, so the tool call is never parsed.

This adds a small DeepSeek V4 reasoning parser subclass. It preserves the existing DeepSeek V3 parser selection behavior, but after R1 reasoning extraction it moves any DSML tool-call block found in the reasoning suffix into `content`, where the existing DeepSeek V4 tool parser can parse it.

## Tests

- `ruff check vllm/reasoning/deepseek_v4_reasoning_parser.py tests/reasoning/test_deepseekv4_reasoning_parser.py tests/reasoning/test_deepseekv3_reasoning_parser.py`
- `PYTHONPATH=/tmp/vllm-main python -m pytest --confcutdir=tests/reasoning tests/reasoning/test_deepseekv4_reasoning_parser.py tests/reasoning/test_deepseekv3_reasoning_parser.py::test_deepseek_v4_reasoning_parser_alias -q`
- `PYTHONPATH=/tmp/vllm-main python -m pytest --confcutdir=tests/tool_parsers tests/tool_parsers/test_deepseekv4_tool_parser.py -q`
