### PR TITLE
[Bug] Skip KVConnector lookup when request opts out of prefix cache

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1212,6 +1212,40 @@ def _step_until_kv_transfer_finished(scheduler: Scheduler, req_ids: list[str]):
 
 
 @pytest.mark.parametrize("is_async", [False, True])
+def test_kv_connector_skip_reading_prefix_cache(is_async: bool):
+    """
+    Requests that set skip_reading_prefix_cache (e.g. prompt_logprobs) must
+    not consume external KV blocks from the connector. KVCacheManager
+    already returns 0 cached tokens for these requests, so a connector hit
+    would leave num_computed_tokens ahead of the allocated blocks and the
+    runner would read uninitialized memory for the "matched" positions.
+    """
+    BLOCK_SIZE = 16
+    MATCHED = BLOCK_SIZE * 2
+    scheduler = create_scheduler(
+        enable_prefix_caching=True,
+        use_kv_connector=mock_kv(matched_tokens=MATCHED, is_async=is_async),
+        block_size=BLOCK_SIZE,
+    )
+
+    (req,) = create_requests(
+        num_requests=1,
+        num_tokens=MATCHED * 2,
+        prompt_logprobs=1,
+        block_size=BLOCK_SIZE,
+    )
+    assert req.skip_reading_prefix_cache
+    scheduler.add_request(req)
+
+    output = scheduler.schedule()
+
+    assert req.prefill_stats is not None
+    assert req.prefill_stats.num_external_cached_tokens == 0
+    assert req.prefill_stats.num_local_cached_tokens == 0
+    assert output.num_scheduled_tokens[req.request_id] == req.num_tokens
+
+
+@pytest.mark.parametrize("is_async", [False, True])
 def test_kv_connector_basic(is_async: bool):
     """
     Test whether Scheduler with KVConnector schedules tokens, allocates

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -618,7 +618,13 @@ class Scheduler(SchedulerInterface):
                     )
 
                     # Get externally-cached tokens if using a KVConnector.
-                    if self.connector is not None:
+                    # Mirror get_computed_blocks' skip_reading_prefix_cache
+                    # behavior; otherwise prompt-logprob requests read
+                    # uninitialized memory for connector-claimed positions.
+                    if (
+                        self.connector is not None
+                        and not request.skip_reading_prefix_cache
+                    ):
                         ext_tokens, load_kv_async = (
                             self.connector.get_num_new_matched_tokens(
                                 request, num_new_local_computed_tokens


### PR DESCRIPTION
This PR seeks to address a mismatch between the regular KVCacheManager & the offloader. This bug leads to incorrect prompt logprobs when KV cache offloading is used.

In particular, `KVCacheManager.get_computed_blocks()` already returns 0 cached tokens when `request.skip_reading_prefix_cache` is True. The connector branch in the scheduler does not honor the same flag, so it claims external matched tokens while the local cache returns nothing. This means that the runner ends up reading unitialised KV memory for the connector-claimed positions.

The solution here is just to mirror the kv_cache_manager guard in the scheduler's connector branch. 




## Purpose

## Test Plan
- [x] Added `tests/v1/core/test_scheduler.py::test_kv_connector_skip_reading_prefix_cache` to cover this case.
## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

