### PR TITLE
[NVFP4][fix] Fix `layer.weight` -> `w13` typo in NVFP4 MOE emulation kernel preparation

### DIFF
--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -381,7 +381,7 @@ def convert_to_nvfp4_moe_kernel_format(
     elif nvfp4_backend == NvFp4MoeBackend.EMULATION:
         # Move the E2M1 lookup table to the device now, because
         # `.to(device)` is not allowed during CUDA graph capture.
-        kE2M1ToFloat_handle.val = kE2M1ToFloat_handle.val.to(layer.weight.device)
+        kE2M1ToFloat_handle.val = kE2M1ToFloat_handle.val.to(layer.w13_weight.device)
 
         if a13_scale is None or a2_scale is None:
             raise ValueError(

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -381,7 +381,7 @@ def convert_to_nvfp4_moe_kernel_format(
     elif nvfp4_backend == NvFp4MoeBackend.EMULATION:
         # Move the E2M1 lookup table to the device now, because
         # `.to(device)` is not allowed during CUDA graph capture.
-        kE2M1ToFloat_handle.val = kE2M1ToFloat_handle.val.to(layer.w13_weight.device)
+        kE2M1ToFloat_handle.val = kE2M1ToFloat_handle.val.to(w13.device)
 
         if a13_scale is None or a2_scale is None:
             raise ValueError(


### PR DESCRIPTION
## Purpose

A bug slipped in https://github.com/vllm-project/vllm/pull/40033, using `layer.weight.device` instead of `layer.w13_weight.device` for MOE kernel preparation in the emulation case, resulting in

```
(EngineCore pid=7349)   File "/felmarty/repos/vllm/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py", line 384, in convert_to_nvfp4_moe_kernel_format
(EngineCore pid=7349)     kE2M1ToFloat_handle.val = kE2M1ToFloat_handle.val.to(layer.weight.device)
(EngineCore pid=7349)                                                          ^^^^^^^^^^^^
(EngineCore pid=7349)   File "/usr/local/lib/python3.12/dist-packages/torch/nn/modules/module.py", line 1965, in __getattr__
(EngineCore pid=7349)     raise AttributeError(
(EngineCore pid=7349) AttributeError: 'FusedMoE' object has no attribute 'weight'
```

## Test Plan

`pytest tests/models/quantization/test_nvfp4.py -s -vvvvv -k "test_nvfp4_moe"`

at https://github.com/vllm-project/vllm/blob/62ba7516e87a18c9d3407c1bb526384a7474cf44/tests/models/quantization/test_nvfp4.py#L125-L145