### PR TITLE
Skip Mamba splitting during async KV load

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -1211,6 +1211,47 @@ def _step_until_kv_transfer_finished(scheduler: Scheduler, req_ids: list[str]):
     return initial_ecos
 
 
+def test_mamba_block_aligned_split_accepts_external_kv_tokens():
+    scheduler = create_scheduler(block_size=16)
+    (request,) = create_requests(num_requests=1, num_tokens=64, block_size=16)
+
+    num_new_tokens = scheduler._mamba_block_aligned_split(
+        request,
+        num_new_tokens=0,
+        num_external_computed_tokens=64,
+    )
+
+    assert num_new_tokens == 0
+
+
+def test_async_kv_load_skips_mamba_block_aligned_split():
+    block_size = 16
+    num_external_tokens = block_size * 2
+    scheduler = create_scheduler(
+        enable_prefix_caching=True,
+        use_kv_connector=mock_kv(
+            matched_tokens=num_external_tokens,
+            is_async=True,
+        ),
+        block_size=block_size,
+    )
+    scheduler.need_mamba_block_aligned_split = True
+    scheduler._mamba_block_aligned_split = Mock(  # type: ignore[method-assign]
+        side_effect=AssertionError("mamba split should be skipped")
+    )
+
+    (request,) = create_requests(num_requests=1, num_tokens=block_size * 4)
+    scheduler.add_request(request)
+
+    scheduler_output = scheduler.schedule()
+
+    assert scheduler._mamba_block_aligned_split.call_count == 0
+    assert request.status == RequestStatus.WAITING_FOR_REMOTE_KVS
+    assert request.num_computed_tokens == num_external_tokens
+    assert len(scheduler.skipped_waiting) == 1
+    assert len(scheduler_output.scheduled_new_reqs) == 0
+
+
 @pytest.mark.parametrize("is_async", [False, True])
 def test_kv_connector_basic(is_async: bool):
     """

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -302,9 +302,6 @@ class Scheduler(SchedulerInterface):
         num_new_local_computed_tokens: int = 0,
         num_external_computed_tokens: int = 0,
     ) -> int:
-        assert num_external_computed_tokens == 0, (
-            "External KV connector is not verified yet"
-        )
         num_computed_tokens = (
             request.num_computed_tokens
             + num_new_local_computed_tokens
@@ -706,7 +703,9 @@ class Scheduler(SchedulerInterface):
                             # The request cannot be scheduled.
                             break
 
-                if self.need_mamba_block_aligned_split:
+                # Async KV load uses num_new_tokens=0; skip splitting so the
+                # delayed allocation below reaches the connector.
+                if self.need_mamba_block_aligned_split and not load_kv_async:
                     num_new_tokens = self._mamba_block_aligned_split(
                         request,
                         num_new_tokens,


### PR DESCRIPTION
## Motivation
During disaggregated serving, decode workers can receive prompt KV from an external connector. The scheduler already accounts for `num_external_computed_tokens`, but `_mamba_block_aligned_split()` rejected that path with an assertion.

For async KV load, `num_new_tokens` is intentionally zero. The scheduler still needs to allocate delayed cache blocks so the connector can issue the remote read in `update_state_after_alloc()`, so Mamba block-aligned splitting must be skipped on that path.

## Test Results

Hardware: 4xGB200

This PR is only part of the fixes that you need to be able to run Qwen3.5 in disagg mode.

Firstly, you need to apply these 3 patches:
* https://github.com/vllm-project/vllm/pull/41628
* https://github.com/vllm-project/vllm/pull/41635 (**this PR**)
* https://github.com/vllm-project/vllm/pull/41644

Secondly, you need to run prefill and decode nodes with the following extra options:
* `VLLM_SSM_CONV_STATE_LAYOUT=DS`
* `--kv-cache-dtype bfloat16` (see this issue for details https://github.com/vllm-project/vllm/issues/42179)
* `--no-async-scheduling` (see this issue for details https://github.com/vllm-project/vllm/issues/42182)

### Functional
`python -m pytest tests/v1/core/test_scheduler.py::test_mamba_block_aligned_split_accepts_external_kv_tokens tests/v1/core/test_scheduler.py::test_async_kv_load_skips_mamba_block_aligned_split -v` — passed.

### Performance
Not applicable; this only fixes scheduler control flow for async KV transfer and does not change kernels.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>