### PR TITLE
[Perf] Prefetch torch_key and triton_key at worker startup

### DIFF
--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -811,6 +811,18 @@ class WorkerProc:
         signal.signal(signal.SIGTERM, signal_handler)
         signal.signal(signal.SIGINT, signal_handler)
 
+        try:
+            from vllm.utils.torch_utils import is_torch_equal_or_newer
+
+            if is_torch_equal_or_newer("2.13.0.dev"):
+                from torch._inductor.codecache import torch_key, triton_key
+
+                torch_key.prefetch()
+                triton_key.prefetch()
+                # TODO: also prefetch cutlass_key if it turns out to be needed.
+        except Exception:
+            logger.debug("Failed to prefetch torch/triton keys", exc_info=True)
+
         worker = None
         ready_writer = kwargs.pop("ready_pipe")
         death_pipe = kwargs.pop("death_pipe", None)


### PR DESCRIPTION
## Purpose
Call .prefetch() on torch_key and triton_key at the top of worker_main
so their file hashing runs on background threads while the worker
continues initialization. By the time compilation calls
get_inductor_factors(), the results are already cached.

Guarded by is_torch_equal_or_newer("2.13.0.dev") since the .prefetch()
API is being added in PyTorch 2.13. Wrapped in try/except so failures
in these internal APIs never crash the worker. Placed after signal
handler setup so the worker is responsive to termination signals
throughout.

## Test Plan
Ran meta-llama/Meta-Llama-3-8B-Instruct end-to-end.

## Test Result
Model loads and runs successfully with prefetch enabled.

---
This PR was developed with AI assistance (Claude).