### PR TITLE
[Core] Add is_eagle in AttentionSpec

### DIFF
--- a/vllm/model_executor/layers/deepseek_v4_attention.py
+++ b/vllm/model_executor/layers/deepseek_v4_attention.py
@@ -141,6 +141,7 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
+        is_eagle: bool = False,
     ) -> None:
         super().__init__()
         self.hidden_size = hidden_size
@@ -235,6 +236,7 @@ class DeepseekV4MultiHeadLatentAttentionWrapper(PluggableLayer):
             dtype=torch.uint8,
             prefix=f"{prefix}.swa_cache",
             cache_config=cache_config,
+            is_eagle=is_eagle,
         )
 
         self.mla_attn = DeepseekV4MLAAttention(

--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -953,8 +953,10 @@ class DeepseekV4Attention(nn.Module):
         # in the compress ratio list
         if layer_id < config.num_hidden_layers:
             self.compress_ratio = max(1, config.compress_ratios[layer_id])
+            self.is_eagle_layer = False
         else:
             self.compress_ratio = 1
+            self.is_eagle_layer = True
         self.eps = config.rms_norm_eps
         self.max_position_embeddings = config.max_position_embeddings
 
@@ -1077,6 +1079,7 @@ class DeepseekV4Attention(nn.Module):
             cache_config=vllm_config.cache_config,
             quant_config=quant_config,
             prefix=prefix,
+            is_eagle=self.is_eagle_layer,
         )
 
     def forward(

--- a/vllm/v1/attention/backends/mla/sparse_swa.py
+++ b/vllm/v1/attention/backends/mla/sparse_swa.py
@@ -53,6 +53,7 @@ class DeepseekV4SWACache(torch.nn.Module, AttentionLayerBase):
         dtype: torch.dtype,
         prefix: str,
         cache_config: CacheConfig,
+        is_eagle: bool = False,
     ):
         super().__init__()
         self.kv_cache = torch.tensor([])
@@ -61,6 +62,7 @@ class DeepseekV4SWACache(torch.nn.Module, AttentionLayerBase):
         self.prefix = prefix
         self.cache_config = cache_config
         self.dtype = dtype
+        self.is_eagle = is_eagle
         compilation_config = get_current_vllm_config().compilation_config
         if prefix in compilation_config.static_forward_context:
             raise ValueError(f"Duplicate layer name: {prefix}")
@@ -84,6 +86,7 @@ class DeepseekV4SWACache(torch.nn.Module, AttentionLayerBase):
             cache_dtype_str=self.cache_config.cache_dtype,
             alignment=576,  # NOTE: FlashMLA requires 576B alignment
             model_version="deepseek_v4",
+            is_eagle=self.is_eagle,
         )
 
     def forward(self): ...

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -1586,28 +1586,30 @@ def _get_kv_cache_groups_uniform_groups(
     return [full_mla_group, *swa_mla_groups]
 
 
-def _annotate_eagle_groups_deepseek_v4(
+def _annotate_eagle_groups(
     vllm_config: VllmConfig,
     kv_cache_spec: dict[str, KVCacheSpec],
     kv_cache_groups: list[KVCacheGroupSpec],
 ) -> None:
+    """Mark KV cache groups that contain EAGLE/MTP draft attention layers.
+
+    Each attention layer that is part of an EAGLE or MTP draft head sets
+    ``AttentionSpec.is_eagle`` to ``True`` in its ``get_kv_cache_spec()``.
+    This function propagates that signal to the containing group so that
+    ``KVCacheCoordinator`` can apply the EAGLE last-block drop to exactly
+    the right groups without model-specific heuristics.
+    """
     spec_config = vllm_config.speculative_config
     if spec_config is None or not spec_config.use_eagle():
         return
-    # Detection uses the merged MLA spec's model_version.
-    if not any(
-        getattr(spec, "model_version", None) == "deepseek_v4"
-        for spec in kv_cache_spec.values()
-    ):
+    eagle_layers = {
+        name for name, spec in kv_cache_spec.items() if getattr(spec, "is_eagle", False)
+    }
+    if not eagle_layers:
         return
-    # DeepseekV4's MTP attention layer is always the last layer, and we flag whichever
-    # group contains it.
-    # FIXME(yifan): avoid/generalize this hacky check.
-    last_layer = next(reversed(kv_cache_spec))
     for group in kv_cache_groups:
-        if last_layer in group.layer_names:
+        if eagle_layers & set(group.layer_names):
             group.is_eagle_group = True
-            break
 
 
 def get_kv_cache_groups(
@@ -1635,30 +1637,33 @@ def get_kv_cache_groups(
         # KV cache of all layers are the same, which is true for
         # most models. Allocate the same amount of memory for
         # each layer.
-        return _get_kv_cache_groups_uniform_spec(kv_cache_spec)
+        kv_cache_groups = _get_kv_cache_groups_uniform_spec(kv_cache_spec)
     elif uniform_spec := UniformTypeKVCacheSpecs.from_specs(kv_cache_spec):
         # All layers need the same number of token slots (e.g., all layers are
         # full attention, or all layers are sliding window attention with the
         # same window size). Put all layers into one group.
-        return _get_kv_cache_groups_uniform_type(uniform_spec)
+        kv_cache_groups = _get_kv_cache_groups_uniform_type(uniform_spec)
     elif grouped_specs := group_and_unify_kv_cache_specs(kv_cache_spec):
         # DeepseekV4 case: All layers need the same number of token slots,
         # yet some layers are full attention while others are sliding window
         # attention in different sizes. Need to group layers into multiple
         # UniformTypeKVCacheSpecs.
         kv_cache_groups = _get_kv_cache_groups_uniform_groups(grouped_specs)
-        _annotate_eagle_groups_deepseek_v4(vllm_config, kv_cache_spec, kv_cache_groups)
-        return kv_cache_groups
+    else:
+        # As KVCacheManager can only allocate memory of one size, we need to unify
+        # the page size of the layers. For cases cannot be unified, this function
+        # will raise an error.
+        kv_cache_spec = unify_kv_cache_spec_page_size(kv_cache_spec)
+        # Model contains multiple attention types, but KV cache of all layers
+        # have the same physical memory per block per layer. Split the layers
+        # into groups with the same number of layers, and thus same total page
+        # size.
+        kv_cache_groups = _get_kv_cache_groups_uniform_page_size(kv_cache_spec)
 
-    # As KVCacheManager can only allocate memory of one size, we need to unify
-    # the page size of the layers. For cases cannot be unified, this function
-    # will raise an error.
-    kv_cache_spec = unify_kv_cache_spec_page_size(kv_cache_spec)
-    # Model contains multiple attention types, but KV cache of all layers
-    # have the same physical memory per block per layer. Split the layers
-    # into groups with the same number of layers, and thus same total page
-    # size.
-    return _get_kv_cache_groups_uniform_page_size(kv_cache_spec)
+    # Propagate AttentionSpec.is_eagle to KVCacheGroupSpec.is_eagle_group for
+    # any model that marks its draft attention layers explicitly.
+    _annotate_eagle_groups(vllm_config, kv_cache_spec, kv_cache_groups)
+    return kv_cache_groups
 
 
 def generate_scheduler_kv_cache_config(

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -815,7 +815,9 @@ def check_enough_kv_cache_memory(
 
 
 def create_kv_cache_group_specs(
-    kv_cache_spec: dict[str, KVCacheSpec], grouped_layer_names: list[list[str]]
+    kv_cache_spec: dict[str, KVCacheSpec],
+    grouped_layer_names: list[list[str]],
+    eagle_layer_names: set[str] | None = None,
 ) -> list[KVCacheGroupSpec]:
     """
     Create KVCacheGroupSpec object for each kv cache group layer.
@@ -829,6 +831,9 @@ def create_kv_cache_group_specs(
             A list of kv cache groups, where each element is a list of layer
             names that belong to the same group and should share the same
             KVCacheSpec.
+        eagle_layer_names:
+            Set of layer names that are EAGLE/MTP draft attention layers.
+            Used to set is_eagle_group at construction time.
     Returns:
         A list of KVCacheGroupSpec objects, one for each group.
     """
@@ -838,8 +843,15 @@ def create_kv_cache_group_specs(
             kv_cache_spec[layer_name] for layer_name in layer_names_one_group
         ]
         merged_layer_spec = layer_specs[0].merge(layer_specs)
+        is_eagle_group = bool(
+            eagle_layer_names and eagle_layer_names & set(layer_names_one_group)
+        )
         kv_cache_groups.append(
-            KVCacheGroupSpec(layer_names_one_group, merged_layer_spec)
+            KVCacheGroupSpec(
+                layer_names_one_group,
+                merged_layer_spec,
+                is_eagle_group=is_eagle_group,
+            )
         )
     return kv_cache_groups
 
@@ -958,6 +970,7 @@ def get_uniform_page_size(kv_cache_specs: Iterable[KVCacheSpec]) -> int:
 
 def _get_kv_cache_groups_uniform_spec(
     kv_cache_specs: dict[str, KVCacheSpec],
+    eagle_layer_names: set[str] | None = None,
 ) -> list[KVCacheGroupSpec]:
     """
     Generates the KV cache configuration for a model with the same KV cache
@@ -965,16 +978,20 @@ def _get_kv_cache_groups_uniform_spec(
 
     Args:
         kv_cache_specs: The kv cache spec of each attention layer in the model
+        eagle_layer_names: Set of eagle draft layer names for annotation.
 
     Returns:
         The generated KVCacheGroupSpecs
     """
 
-    return create_kv_cache_group_specs(kv_cache_specs, [list(kv_cache_specs.keys())])
+    return create_kv_cache_group_specs(
+        kv_cache_specs, [list(kv_cache_specs.keys())], eagle_layer_names
+    )
 
 
 def _get_kv_cache_groups_uniform_type(
     spec: UniformTypeKVCacheSpecs,
+    eagle_layer_names: set[str] | None = None,
 ) -> list[KVCacheGroupSpec]:
     """
     Generates the KV cache configuration for a model with one type of KV cache
@@ -982,12 +999,14 @@ def _get_kv_cache_groups_uniform_type(
 
     Args:
         spec: The UniformTypeKVCacheSpecs of the model
+        eagle_layer_names: Set of eagle draft layer names for annotation.
 
     Returns:
         The generated KVCacheGroupSpecs
     """
-
-    return [KVCacheGroupSpec(list(spec.kv_cache_specs.keys()), spec)]
+    layer_names = list(spec.kv_cache_specs.keys())
+    is_eagle_group = bool(eagle_layer_names and eagle_layer_names & set(layer_names))
+    return [KVCacheGroupSpec(layer_names, spec, is_eagle_group=is_eagle_group)]
 
 
 def is_kv_cache_page_size_uniform(kv_cache_spec: dict[str, KVCacheSpec]) -> bool:
@@ -1051,6 +1070,7 @@ def is_kv_cache_type_attention_free(kv_cache_spec: dict[str, KVCacheSpec]) -> bo
 
 def _get_kv_cache_groups_uniform_page_size(
     kv_cache_spec: dict[str, KVCacheSpec],
+    eagle_layer_names: set[str] | None = None,
 ) -> list[KVCacheGroupSpec]:
     """
     Generates the KV cache groups for hybrid models with multiple
@@ -1168,7 +1188,7 @@ def _get_kv_cache_groups_uniform_page_size(
         # instead of layers[i * group_size: (i + 1) * group_size]
         for i in range(num_groups):
             grouped_layers.append(layers[i::num_groups])
-    return create_kv_cache_group_specs(kv_cache_spec, grouped_layers)
+    return create_kv_cache_group_specs(kv_cache_spec, grouped_layers, eagle_layer_names)
 
 
 def _get_kv_cache_config_deepseek_v4(
@@ -1487,6 +1507,7 @@ def _approximate_gcd(values: Sequence[int], *, lower_bound: int | None = None) -
 
 def _get_kv_cache_groups_uniform_groups(
     grouped_specs: list[UniformTypeKVCacheSpecs],
+    eagle_layer_names: set[str] | None = None,
 ) -> list[KVCacheGroupSpec]:
     """
     Generate the KV cache groups from the grouped specs.
@@ -1504,6 +1525,10 @@ def _get_kv_cache_groups_uniform_groups(
     full_mla_group = KVCacheGroupSpec(
         layer_names=list(full_mla_spec.kv_cache_specs.keys()),
         kv_cache_spec=full_mla_spec,
+        is_eagle_group=bool(
+            eagle_layer_names
+            and eagle_layer_names & set(full_mla_spec.kv_cache_specs.keys())
+        ),
     )
 
     # We define a layer tuple as a group of layers with different page sizes, and
@@ -1580,36 +1605,13 @@ def _get_kv_cache_groups_uniform_groups(
                 KVCacheGroupSpec(
                     layer_names=group_layer_names,
                     kv_cache_spec=sub_sm_spec,
+                    is_eagle_group=bool(
+                        eagle_layer_names and eagle_layer_names & set(group_layer_names)
+                    ),
                 )
             )
 
     return [full_mla_group, *swa_mla_groups]
-
-
-def _annotate_eagle_groups(
-    vllm_config: VllmConfig,
-    kv_cache_spec: dict[str, KVCacheSpec],
-    kv_cache_groups: list[KVCacheGroupSpec],
-) -> None:
-    """Mark KV cache groups that contain EAGLE/MTP draft attention layers.
-
-    Each attention layer that is part of an EAGLE or MTP draft head sets
-    ``AttentionSpec.is_eagle`` to ``True`` in its ``get_kv_cache_spec()``.
-    This function propagates that signal to the containing group so that
-    ``KVCacheCoordinator`` can apply the EAGLE last-block drop to exactly
-    the right groups without model-specific heuristics.
-    """
-    spec_config = vllm_config.speculative_config
-    if spec_config is None or not spec_config.use_eagle():
-        return
-    eagle_layers = {
-        name for name, spec in kv_cache_spec.items() if getattr(spec, "is_eagle", False)
-    }
-    if not eagle_layers:
-        return
-    for group in kv_cache_groups:
-        if eagle_layers & set(group.layer_names):
-            group.is_eagle_group = True
 
 
 def get_kv_cache_groups(
@@ -1633,22 +1635,37 @@ def get_kv_cache_groups(
         # attention free models.
         return []
 
+    # Collect layer names whose KVCacheSpec.is_eagle is True so that each
+    # KVCacheGroupSpec can be annotated with is_eagle_group at construction
+    # time instead of through a separate post-hoc pass.
+    spec_config = vllm_config.speculative_config
+    if spec_config is not None and spec_config.use_eagle():
+        eagle_layer_names = {n for n, s in kv_cache_spec.items() if s.is_eagle}
+    else:
+        eagle_layer_names = None
+
     if is_kv_cache_spec_uniform(kv_cache_spec):
         # KV cache of all layers are the same, which is true for
         # most models. Allocate the same amount of memory for
         # each layer.
-        kv_cache_groups = _get_kv_cache_groups_uniform_spec(kv_cache_spec)
+        kv_cache_groups = _get_kv_cache_groups_uniform_spec(
+            kv_cache_spec, eagle_layer_names
+        )
     elif uniform_spec := UniformTypeKVCacheSpecs.from_specs(kv_cache_spec):
         # All layers need the same number of token slots (e.g., all layers are
         # full attention, or all layers are sliding window attention with the
         # same window size). Put all layers into one group.
-        kv_cache_groups = _get_kv_cache_groups_uniform_type(uniform_spec)
+        kv_cache_groups = _get_kv_cache_groups_uniform_type(
+            uniform_spec, eagle_layer_names
+        )
     elif grouped_specs := group_and_unify_kv_cache_specs(kv_cache_spec):
         # DeepseekV4 case: All layers need the same number of token slots,
         # yet some layers are full attention while others are sliding window
         # attention in different sizes. Need to group layers into multiple
         # UniformTypeKVCacheSpecs.
-        kv_cache_groups = _get_kv_cache_groups_uniform_groups(grouped_specs)
+        kv_cache_groups = _get_kv_cache_groups_uniform_groups(
+            grouped_specs, eagle_layer_names
+        )
     else:
         # As KVCacheManager can only allocate memory of one size, we need to unify
         # the page size of the layers. For cases cannot be unified, this function
@@ -1658,11 +1675,10 @@ def get_kv_cache_groups(
         # have the same physical memory per block per layer. Split the layers
         # into groups with the same number of layers, and thus same total page
         # size.
-        kv_cache_groups = _get_kv_cache_groups_uniform_page_size(kv_cache_spec)
+        kv_cache_groups = _get_kv_cache_groups_uniform_page_size(
+            kv_cache_spec, eagle_layer_names
+        )
 
-    # Propagate AttentionSpec.is_eagle to KVCacheGroupSpec.is_eagle_group for
-    # any model that marks its draft attention layers explicitly.
-    _annotate_eagle_groups(vllm_config, kv_cache_spec, kv_cache_groups)
     return kv_cache_groups
 
 

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -133,6 +133,10 @@ class AttentionSpec(KVCacheSpec):
     dtype: torch.dtype
     kv_quant_mode: KVQuantMode = KVQuantMode.NONE
     page_size_padded: int | None = None
+    # True when this layer is an EAGLE/MTP draft attention layer. Used by
+    # get_kv_cache_groups() to set KVCacheGroupSpec.is_eagle_group without
+    # relying on model-specific positional heuristics.
+    is_eagle: bool = False
 
     @property
     def page_size_bytes(self) -> int:
@@ -379,6 +383,7 @@ class MLAAttentionSpec(FullAttentionSpec):
             cache_dtype_str=cache_dtype_str_set.pop(),
             compress_ratio=compress_ratio_set.pop(),
             model_version=model_version_set.pop(),
+            is_eagle=any(s.is_eagle for s in specs),
         )
 
 
@@ -524,6 +529,7 @@ class SlidingWindowMLASpec(SlidingWindowSpec):
             cache_dtype_str=cache_dtype_str_set.pop(),
             compress_ratio=compress_ratio_set.pop(),
             model_version=model_version_set.pop(),
+            is_eagle=any(s.is_eagle for s in specs),
         )
 
 

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import copy
 from collections import Counter
-from dataclasses import dataclass, fields, replace
+from dataclasses import dataclass, field, fields, replace
 from enum import IntEnum
 from math import prod
 from typing import TYPE_CHECKING
@@ -85,6 +85,10 @@ class KVCacheSpec:
 
     # number of tokens in a block
     block_size: int
+    # True when this layer is an EAGLE/MTP draft attention layer. Used by
+    # get_kv_cache_groups() to set KVCacheGroupSpec.is_eagle_group without
+    # relying on model-specific positional heuristics.
+    is_eagle: bool = field(default=False, kw_only=True)
 
     @property
     def page_size_bytes(self) -> int:
@@ -133,10 +137,6 @@ class AttentionSpec(KVCacheSpec):
     dtype: torch.dtype
     kv_quant_mode: KVQuantMode = KVQuantMode.NONE
     page_size_padded: int | None = None
-    # True when this layer is an EAGLE/MTP draft attention layer. Used by
-    # get_kv_cache_groups() to set KVCacheGroupSpec.is_eagle_group without
-    # relying on model-specific positional heuristics.
-    is_eagle: bool = False
 
     @property
     def page_size_bytes(self) -> int:


### PR DESCRIPTION



## Purpose

Follow #39690.

Currently, `_annotate_eagle_groups_deepseek_v4` is model-specific method. Other models would all go into the fallback logic inside. This PR is introducing `is_eagle` in AttentionSpec to make `_annotate_eagle_groups` general for all models.

## Test Plan

### Gemma4

```
vllm serve google/gemma-4-31b-it \
  --tensor-parallel-size 2 \
  --speculative-config '{
    "model": "RedHatAI/gemma-4-31B-it-speculator.eagle3",
    "num_speculative_tokens": 3,
    "method": "eagle3"
  }' \
  --max-num-seqs 64 \
  --enable-prefix-caching
```

```
vllm bench serve \
  --host 127.0.0.1 --port 8000 \
  --model google/gemma-4-31b-it \
  --dataset-name prefix_repetition \
  --prefix-repetition-prefix-len 512 \
  --prefix-repetition-suffix-len 256 \
  --prefix-repetition-num-prefixes 8 \
  --prefix-repetition-output-len 128 \
  --request-rate 8 \
  --num-prompts 256 \
  --save-result \
  --result-dir ./bench_results_with_prefix_cache \
  --result-filename result.json
```

## Test Result

```bash
(APIServer pid=1447322) INFO:     127.0.0.1:58752 - "POST /v1/completions HTTP/1.1" 200 OK
(APIServer pid=1447322) INFO:     127.0.0.1:58754 - "POST /v1/completions HTTP/1.1" 200 OK
(APIServer pid=1447322) INFO 05-04 15:29:49 [loggers.py:271] Engine 000: Avg prompt throughput: 2975.4 tokens/s, Avg generation throughput: 867.4 tokens/s, Running: 64 reqs, Waiting: 79 reqs, GPU KV cache usage: 35.1%, Prefix cache hit rate: 53.1%
(APIServer pid=1447322) INFO 05-04 15:29:49 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 1.30, Accepted throughput: 196.87 tokens/s, Drafted throughput: 1994.65 tokens/s, Accepted: 1969 tokens, Drafted: 19950 tokens, Per-position acceptance rate: 0.136, 0.089, 0.071, Avg Draft acceptance rate: 9.9%

...

(APIServer pid=1447322) INFO 05-04 15:29:59 [loggers.py:271] Engine 000: Avg prompt throughput: 2306.9 tokens/s, Avg generation throughput: 709.2 tokens/s, Running: 64 reqs, Waiting: 79 reqs, GPU KV cache usage: 32.4%, Prefix cache hit rate: 55.4%
(APIServer pid=1447322) INFO 05-04 15:29:59 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 1.33, Accepted throughput: 175.37 tokens/s, Drafted throughput: 1588.24 tokens/s, Accepted: 1754 tokens, Drafted: 15885 tokens, Per-position acceptance rate: 0.147, 0.102, 0.083, Avg Draft acceptance rate: 11.0%
(APIServer pid=1447322) INFO:     127.0.0.1:58620 - "POST /v1/completions HTTP/1.1" 200 OK
(APIServer pid=1447322) INFO:     127.0.0.1:58448 - "POST /v1/completions HTTP/1.1" 200 OK
(APIServer pid=1447322) INFO:     127.0.0.1:58622 - "POST /v1/completions HTTP/1.1" 200 OK
(APIServer pid=1447322) INFO:     127.0.0.1:58626 - "POST /v1/completions HTTP/1.1" 200 OK
(APIServer pid=1447322) INFO:     127.0.0.1:58724 - "POST /v1/completions HTTP/1.1" 200 OK
(APIServer pid=1447322) INFO:     127.0.0.1:58632 - "POST /v1/completions HTTP/1.1" 200 OK
(APIServer pid=1447322) INFO 05-04 15:30:09 [loggers.py:271] Engine 000: Avg prompt throughput: 1631.7 tokens/s, Avg generation throughput: 763.2 tokens/s, Running: 64 reqs, Waiting: 43 reqs, GPU KV cache usage: 33.6%, Prefix cache hit rate: 56.1%
(APIServer pid=1447322) INFO 05-04 15:30:09 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 1.22, Accepted throughput: 136.88 tokens/s, Drafted throughput: 1869.95 tokens/s, Accepted: 1369 tokens, Drafted: 18702 tokens, Per-position acceptance rate: 0.104, 0.066, 0.050, Avg Draft acceptance rate: 7.3%
(APIServer pid=1447322) INFO 05-04 15:30:19 [loggers.py:271] Engine 000: Avg prompt throughput: 1407.2 tokens/s, Avg generation throughput: 745.9 tokens/s, Running: 41 reqs, Waiting: 0 reqs, GPU KV cache usage: 23.7%, Prefix cache hit rate: 56.5%
(APIServer pid=1447322) INFO 05-04 15:30:19 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 1.16, Accepted throughput: 103.45 tokens/s, Drafted throughput: 1921.20 tokens/s, Accepted: 1035 tokens, Drafted: 19221 tokens, Per-position acceptance rate: 0.084, 0.044, 0.033, Avg Draft acceptance rate: 5.4%
(APIServer pid=1447322) INFO:     127.0.0.1:58768 - "GET /metrics HTTP/1.1" 200 OK
(APIServer pid=1447322) INFO 05-04 15:30:29 [loggers.py:271] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 180.5 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 56.5%
(APIServer pid=1447322) INFO 05-04 15:30:29 [metrics.py:101] SpecDecoding metrics: Mean acceptance length: 1.06, Accepted throughput: 9.50 tokens/s, Drafted throughput: 514.42 tokens/s, Accepted: 95 tokens, Drafted: 5145 tokens, Per-position acceptance rate: 0.029, 0.015, 0.011, Avg Draft acceptance rate: 1.8%
```

```
 python -m pytest tests/v1/core/test_prefix_caching.py
========================================================== test session starts ==========================================================
platform linux -- Python 3.12.3, pytest-9.0.3, pluggy-1.6.0
rootdir: /root/vllm-workspace/vllm
configfile: pyproject.toml
plugins: anyio-4.13.0
collected 58 items

tests/v1/core/test_prefix_caching.py ..........................................................                                   [100%]

=========================================================== warnings summary ============================================================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

tests/v1/core/test_prefix_caching.py: 14 warnings
  /root/vllm-workspace/.venv/lib/python3.12/site-packages/torch/jit/_script.py:365: DeprecationWarning: `torch.jit.script_method` is deprecated. Please switch to `torch.compile` or `torch.export`.
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=================================================== 58 passed, 16 warnings in 11.26s ====================================================
sys:1: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

