### PR TITLE
[EC Connector] Added mm_hash_to_encoder in kv_transfer_params

### DIFF
--- a/vllm/distributed/ec_transfer/ec_connector/base.py
+++ b/vllm/distributed/ec_transfer/ec_connector/base.py
@@ -39,6 +39,34 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
+# Convention for passing per-mm_hash remote encoder node info through
+# ``Request.kv_transfer_params`` (populated from
+# ``SamplingParams.extra_args["kv_transfer_params"]``).
+#
+# A routing layer (e.g. ``disagg_epd_proxy``) selects an encoder instance per
+# multimodal item and attaches the resulting mapping so the EC consumer
+# connector on the PD instance can pull each encoder cache from the right
+# producer. The per-mm_hash inner dict uses the same flat key names as NIXL
+# P/D (``remote_engine_id`` / ``remote_host`` / ``remote_port``) so both
+# transports share a dispatch shape; like NIXL, this is a loose dict
+# convention rather than a typed schema.
+#
+# Example::
+#
+#     sampling_params.extra_args = {
+#         "kv_transfer_params": {
+#             MM_HASH_TO_ENCODER_KEY: {
+#                 "<mm_hash_1>": {
+#                     "remote_engine_id": "enc-0",
+#                     "remote_host": "10.0.0.1",
+#                     "remote_port": 5557,
+#                 },
+#             },
+#         },
+#     }
+MM_HASH_TO_ENCODER_KEY = "mm_hash_to_encoder"
+
+
 class ECConnectorRole(enum.Enum):
     # Connector running in the scheduler process
     SCHEDULER = 0

--- a/vllm/distributed/ec_transfer/ec_connector/example_connector.py
+++ b/vllm/distributed/ec_transfer/ec_connector/example_connector.py
@@ -1,13 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import os
-from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
 
 import safetensors
 
 from vllm.config import VllmConfig
 from vllm.distributed.ec_transfer.ec_connector.base import (
+    MM_HASH_TO_ENCODER_KEY,
     ECConnectorBase,
     ECConnectorMetadata,
     ECConnectorRole,
@@ -25,10 +26,18 @@ logger = init_logger(__name__)
 class MMMeta:
     mm_hash: str
     num_token: int
+    # Remote encoder node descriptor copied from
+    # ``request.kv_transfer_params[MM_HASH_TO_ENCODER_KEY][mm_hash]`` when the
+    # routing layer supplied one. ``None`` for locally-served caches.
+    encoder_node: dict[str, Any] | None = field(default=None)
 
     @staticmethod
-    def make_meta(mm_hash, num_token) -> "MMMeta":
-        return MMMeta(mm_hash=mm_hash, num_token=num_token)
+    def make_meta(
+        mm_hash: str,
+        num_token: int,
+        encoder_node: dict[str, Any] | None = None,
+    ) -> "MMMeta":
+        return MMMeta(mm_hash=mm_hash, num_token=num_token, encoder_node=encoder_node)
 
 
 @dataclass
@@ -50,6 +59,10 @@ class ECExampleConnector(ECConnectorBase):
         super().__init__(vllm_config=vllm_config, role=role)
         # req_id -> index
         self._mm_datas_need_loads: dict[str, int] = {}
+        # mm_hash -> remote encoder node descriptor (or None for local-only).
+        # Populated from ``request.kv_transfer_params[MM_HASH_TO_ENCODER_KEY]``
+        # in ``update_state_after_alloc`` and drained in ``build_connector_meta``.
+        self._mm_encoder_nodes: dict[str, dict[str, Any] | None] = {}
         transfer_config = vllm_config.ec_transfer_config
         if transfer_config is not None:
             self._storage_path = transfer_config.get_from_extra_config(
@@ -146,6 +159,10 @@ class ECExampleConnector(ECConnectorBase):
             return
         num_encoder_token = request.get_num_encoder_embeds(index)
         self._mm_datas_need_loads[mm_hash] = num_encoder_token
+        encoder_map = (request.kv_transfer_params or {}).get(MM_HASH_TO_ENCODER_KEY)
+        self._mm_encoder_nodes[mm_hash] = (
+            encoder_map.get(mm_hash) if isinstance(encoder_map, dict) else None
+        )
 
     def build_connector_meta(
         self,
@@ -161,8 +178,15 @@ class ECExampleConnector(ECConnectorBase):
         """
         meta = ECExampleConnectorMetadata()
         for mm_hash, num_encoder_token in self._mm_datas_need_loads.items():
-            meta.add_mm_data(MMMeta.make_meta(mm_hash, num_encoder_token))
+            meta.add_mm_data(
+                MMMeta.make_meta(
+                    mm_hash,
+                    num_encoder_token,
+                    encoder_node=self._mm_encoder_nodes.get(mm_hash),
+                )
+            )
         self._mm_datas_need_loads.clear()
+        self._mm_encoder_nodes.clear()
         return meta
 
     # ==============================

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -97,7 +97,12 @@ class Request:
         self.events: list[EngineCoreEvent] = []
         self.stop_reason: int | str | None = None
 
-        # P/D: Connector-specific KV transfer parameters.
+        # P/D: Connector-specific KV transfer parameters. Also carries the
+        # EC routing convention under
+        # ``vllm.distributed.ec_transfer.ec_connector.base.MM_HASH_TO_ENCODER_KEY``:
+        # a ``{mm_hash: {remote_engine_id, remote_host, remote_port}}`` mapping
+        # populated by the routing layer so the EC consumer connector knows
+        # which encoder instance holds each mm cache.
         self.kv_transfer_params: dict[str, Any] | None = None
 
         if pooling_params is not None:


### PR DESCRIPTION


## Purpose
Establishes the per-request routing convention for EC (encoder-cache) disaggregation. 
A routing layer (e.g. disagg_epd_proxy) can now attach a {mm_hash: {remote_engine_id, remote_host, remote_port}} map onto kv_transfer_params, and the EC consumer connector picks it up for each scheduled load.

- New convention: kv_transfer_params["mm_hash_to_encoder"] (constant MM_HASH_TO_ENCODER_KEY in vllm/distributed/ec_transfer/ec_connector/base.py). 
- The per-mm_hash inner dict reuses NIXL P/D's flat keys (remote_engine_id / remote_host / remote_port).
- Wired through ECExampleConnector: new optional encoder_node field on MMMeta, populated from request.kv_transfer_params and propagated via build_connector_meta. 
- Doc comment on Request.kv_transfer_params pointing readers at the convention.
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

