### PR TITLE
[Feature] Keep HMA enabled for supported KV connectors

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -9,7 +9,7 @@ import pytest
 import torch
 
 import vllm.v1.core.kv_cache_utils as kv_cache_utils
-from vllm.config import ModelConfig, SchedulerConfig, VllmConfig
+from vllm.config import KVTransferConfig, ModelConfig, SchedulerConfig, VllmConfig
 from vllm.config.kv_events import KVEventsConfig
 from vllm.lora.request import LoRARequest
 from vllm.multimodal.inputs import (
@@ -2165,3 +2165,29 @@ def test_hma_not_disabled_when_kv_events_enabled():
     assert vllm_config.scheduler_config.disable_hybrid_kv_cache_manager is False, (
         "kv_events_config must not force-disable the hybrid KV cache manager."
     )
+
+
+def test_hma_not_disabled_for_supported_kv_connector():
+    kv_transfer_config = KVTransferConfig(
+        kv_connector="NixlConnector",
+        kv_role="kv_both",
+    )
+
+    vllm_config = VllmConfig(
+        kv_transfer_config=kv_transfer_config,
+    )
+
+    assert vllm_config.scheduler_config.disable_hybrid_kv_cache_manager is False
+
+
+def test_hma_disabled_for_unsupported_kv_connector():
+    kv_transfer_config = KVTransferConfig(
+        kv_connector="ExampleConnector",
+        kv_role="kv_both",
+    )
+
+    vllm_config = VllmConfig(
+        kv_transfer_config=kv_transfer_config,
+    )
+
+    assert vllm_config.scheduler_config.disable_hybrid_kv_cache_manager is True

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1288,18 +1288,40 @@ class VllmConfig:
         if self.scheduler_config.disable_hybrid_kv_cache_manager is None:
             # Default to disable HMA, but only if the user didn't express a preference.
             if self.kv_transfer_config is not None:
-                # NOTE(Kuntai): turn HMA off for connector unless specifically enabled.
-                need_disable_hybrid_kv_cache_manager = True
-                logger.warning(
-                    "Turning off hybrid kv cache manager because "
-                    "`--kv-transfer-config` is set. This will reduce the "
-                    "performance of vLLM on LLMs with sliding window attention "
-                    "or Mamba attention. If you are a developer of kv connector"
-                    ", please consider supporting hybrid kv cache manager for "
-                    "your connector by making sure your connector is a subclass"
-                    " of `SupportsHMA` defined in kv_connector/v1/base.py and"
-                    " use --no-disable-hybrid-kv-cache-manager to start vLLM."
-                )
+                # NOTE(Kuntai): turn HMA off for connector unless it explicitly
+                # advertises support.
+                try:
+                    # Lazy import to avoid circular dependencies.
+                    from vllm.distributed.kv_transfer.kv_connector.factory import (
+                        KVConnectorFactory,
+                    )
+                    from vllm.distributed.kv_transfer.kv_connector.v1 import (
+                        supports_hma,
+                    )
+
+                    connector_cls = KVConnectorFactory.get_connector_class(
+                        self.kv_transfer_config
+                    )
+                    connector_supports_hma = supports_hma(connector_cls)
+                except Exception:
+                    logger.debug(
+                        "Failed to check whether KV connector supports HMA.",
+                        exc_info=True,
+                    )
+                    connector_supports_hma = False
+
+                if not connector_supports_hma:
+                    need_disable_hybrid_kv_cache_manager = True
+                    logger.warning(
+                        "Turning off hybrid kv cache manager because "
+                        "`--kv-transfer-config` is set. This will reduce the "
+                        "performance of vLLM on LLMs with sliding window attention "
+                        "or Mamba attention. If you are a developer of kv connector"
+                        ", please consider supporting hybrid kv cache manager for "
+                        "your connector by making sure your connector is a subclass"
+                        " of `SupportsHMA` defined in kv_connector/v1/base.py and"
+                        " use --no-disable-hybrid-kv-cache-manager to start vLLM."
+                    )
             self.scheduler_config.disable_hybrid_kv_cache_manager = (
                 need_disable_hybrid_kv_cache_manager
             )


### PR DESCRIPTION
## Motivation
vLLM currently disables the hybrid KV cache manager by default whenever `kv_transfer_config` is set, unless the user explicitly passes `--no-disable-hybrid-kv-cache-manager`. That is conservative for connectors that do not support HMA, but it also disables HMA for connectors like `NixlConnector` that already advertise `SupportsHMA`.

This change preserves the conservative default for unsupported connectors while allowing HMA to stay enabled by default when the selected connector explicitly supports it.

## Test Results

Hardware: 4xGB200

This PR is only part of the fixes that you need to be able to run Qwen3.5 in disagg mode.

Firstly, you need to apply these 3 patches:
* https://github.com/vllm-project/vllm/pull/41628
* https://github.com/vllm-project/vllm/pull/41635
* https://github.com/vllm-project/vllm/pull/41644 (**this PR**)

Secondly, you need to run prefill and decode nodes with the following extra options:
* `VLLM_SSM_CONV_STATE_LAYOUT=DS`
* `--kv-cache-dtype bfloat16` (see this issue for details https://github.com/vllm-project/vllm/issues/42179)
* `--no-async-scheduling` (see this issue for details https://github.com/vllm-project/vllm/issues/42182)

### Functional
`python -m pytest tests/v1/core/test_kv_cache_utils.py::test_hma_not_disabled_for_supported_kv_connector tests/v1/core/test_kv_cache_utils.py::test_hma_disabled_for_unsupported_kv_connector -v` — passed.

### Performance
Not measured. This only changes the default HMA decision for KV connectors that already declare HMA support.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>