### PR TITLE
[Don't merge] Compare torch vs torch stable vs tvm-ffi

### DIFF
--- a/ffi_bench/bench.py
+++ b/ffi_bench/bench.py
@@ -1,0 +1,171 @@
+"""Microbenchmark dispatch overhead for the same trivial CUDA kernel exposed
+through three different binding mechanisms:
+
+    unstable  -> TORCH_LIBRARY (classic vLLM csrc, unboxed dispatcher)
+    stable    -> STABLE_TORCH_LIBRARY (vLLM's libtorch_stable migration target,
+                                       boxed dispatcher)
+    tvmffi    -> TVM_FFI_DLL_EXPORT_TYPED_FUNC (no torch dispatcher at all)
+
+We use a 1-element float32 tensor so kernel compute time is negligible and
+per-call latency is dominated by Python -> binding -> launch overhead.
+"""
+import os
+import statistics
+import sys
+import time
+
+import torch
+import tvm_ffi
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+BUILD = os.path.join(HERE, "build")
+
+# Load the three .so files.
+torch.ops.load_library(os.path.join(BUILD, "unstable.so"))
+torch.ops.load_library(os.path.join(BUILD, "stable.so"))
+tvmffi_mod = tvm_ffi.load_module(os.path.join(BUILD, "tvmffi.so"))
+
+device = torch.device("cuda:0")
+dtype = torch.float32
+
+N = 1  # 1-element so compute is ~free
+in_t = torch.randn(N, device=device, dtype=dtype)
+out_t = torch.empty_like(in_t)
+factor = 2.0
+
+
+def correctness():
+    expected = in_t * factor
+    for name, fn in [
+        ("unstable", lambda: torch.ops.bench_unstable.scale(out_t, in_t, factor)),
+        ("stable",   lambda: torch.ops.bench_stable.scale(out_t, in_t, factor)),
+        ("tvmffi",   lambda: tvmffi_mod.scale(out_t, in_t, factor)),
+    ]:
+        out_t.zero_()
+        fn()
+        torch.cuda.synchronize()
+        ok = torch.allclose(out_t, expected)
+        print(f"  {name}: out={out_t.item():.4f} expected={expected.item():.4f} ok={ok}")
+
+
+def time_calls(fn, iters):
+    # Time `iters` calls; sync once at the end. Per-call latency = total / iters.
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        fn()
+    torch.cuda.synchronize()
+    t1 = time.perf_counter()
+    return (t1 - t0) / iters * 1e6  # microseconds per call
+
+
+def bench_eager(iters=20000, repeats=7):
+    print(f"\n=== eager mode (iters={iters} per repeat, {repeats} repeats) ===")
+    print("                  median_us    min_us    stdev_us")
+    cases = {
+        "unstable_TORCH_LIBRARY":         lambda: torch.ops.bench_unstable.scale(out_t, in_t, factor),
+        "stable_STABLE_TORCH_LIBRARY":    lambda: torch.ops.bench_stable.scale(out_t, in_t, factor),
+        "tvmffi_direct":                  lambda: tvmffi_mod.scale(out_t, in_t, factor),
+    }
+    for name, fn in cases.items():
+        # warmup
+        for _ in range(2000):
+            fn()
+        torch.cuda.synchronize()
+        # repeats
+        samples = [time_calls(fn, iters) for _ in range(repeats)]
+        med = statistics.median(samples)
+        mn = min(samples)
+        sd = statistics.stdev(samples) if len(samples) > 1 else 0.0
+        print(f"  {name:<35s} {med:8.3f}  {mn:8.3f}  {sd:8.3f}")
+
+
+def bench_cuda_graph(graph_iters=512, replays=10000, repeats=7):
+    """Capture `graph_iters` calls into a CUDA graph; time `replays` replays."""
+    print(f"\n=== CUDA graph (capture {graph_iters} calls per graph, "
+          f"replay {replays} times, {repeats} repeats) ===")
+    print("                  median_us_per_replay   per_op_ns   stdev_us")
+
+    cases = {
+        "unstable_TORCH_LIBRARY":         lambda: torch.ops.bench_unstable.scale(out_t, in_t, factor),
+        "stable_STABLE_TORCH_LIBRARY":    lambda: torch.ops.bench_stable.scale(out_t, in_t, factor),
+        "tvmffi_direct":                  lambda: tvmffi_mod.scale(out_t, in_t, factor),
+    }
+
+    for name, fn in cases.items():
+        # warmup with a side stream so capture has a clean state
+        s = torch.cuda.Stream()
+        s.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(s):
+            for _ in range(50):
+                fn()
+        torch.cuda.current_stream().wait_stream(s)
+        torch.cuda.synchronize()
+
+        # Try to capture
+        graph = torch.cuda.CUDAGraph()
+        try:
+            with torch.cuda.graph(graph):
+                for _ in range(graph_iters):
+                    fn()
+        except Exception as e:
+            print(f"  {name:<35s} CAPTURE FAILED: {type(e).__name__}: {e}")
+            continue
+
+        # Time replays
+        torch.cuda.synchronize()
+        samples = []
+        for _ in range(repeats):
+            t0 = time.perf_counter()
+            for _ in range(replays):
+                graph.replay()
+            torch.cuda.synchronize()
+            t1 = time.perf_counter()
+            samples.append((t1 - t0) / replays * 1e6)  # us per replay
+        med = statistics.median(samples)
+        per_op_ns = med / graph_iters * 1000.0
+        sd = statistics.stdev(samples) if len(samples) > 1 else 0.0
+        print(f"  {name:<35s} {med:18.3f}     {per_op_ns:7.1f}   {sd:8.3f}")
+
+
+def bench_capture_time(graph_iters=4096, repeats=5):
+    """How long does *capturing* the graph take? This is dispatch overhead at
+    record time — relevant if you build/rebuild graphs frequently."""
+    print(f"\n=== CUDA graph capture cost (record {graph_iters} calls) ===")
+    print("                  median_capture_ms   per_op_us")
+    cases = {
+        "unstable_TORCH_LIBRARY":         lambda: torch.ops.bench_unstable.scale(out_t, in_t, factor),
+        "stable_STABLE_TORCH_LIBRARY":    lambda: torch.ops.bench_stable.scale(out_t, in_t, factor),
+        "tvmffi_direct":                  lambda: tvmffi_mod.scale(out_t, in_t, factor),
+    }
+    for name, fn in cases.items():
+        samples = []
+        for _ in range(repeats):
+            # warmup on side stream before capture
+            s = torch.cuda.Stream()
+            s.wait_stream(torch.cuda.current_stream())
+            with torch.cuda.stream(s):
+                for _ in range(50):
+                    fn()
+            torch.cuda.current_stream().wait_stream(s)
+            torch.cuda.synchronize()
+
+            graph = torch.cuda.CUDAGraph()
+            t0 = time.perf_counter()
+            with torch.cuda.graph(graph):
+                for _ in range(graph_iters):
+                    fn()
+            t1 = time.perf_counter()
+            samples.append((t1 - t0) * 1e3)  # ms
+            del graph
+        med = statistics.median(samples)
+        per_op_us = med * 1000.0 / graph_iters
+        print(f"  {name:<35s} {med:18.3f}   {per_op_us:8.3f}")
+
+
+if __name__ == "__main__":
+    print("=== correctness ===")
+    correctness()
+    bench_eager()
+    bench_capture_time()
+    bench_cuda_graph()

--- a/ffi_bench/binding_stable.cu
+++ b/ffi_bench/binding_stable.cu
@@ -1,0 +1,43 @@
+// Variant 2: STABLE_TORCH_LIBRARY (PyTorch >= 2.10 stable ABI). Goes through
+// the boxed dispatcher path via TORCH_BOX. This is the path vLLM is migrating
+// to in csrc/libtorch_stable/.
+#include <torch/csrc/stable/library.h>
+#include <torch/csrc/stable/tensor.h>
+#include <torch/csrc/stable/accelerator.h>
+#include <torch/headeronly/core/ScalarType.h>
+#include <torch/csrc/inductor/aoti_torch/c/shim.h>
+
+#include "scale_kernel.cuh"
+
+static inline cudaStream_t stable_current_stream(int32_t dev) {
+  void* stream_ptr = nullptr;
+  TORCH_ERROR_CODE_CHECK(
+      aoti_torch_get_current_cuda_stream(dev, &stream_ptr));
+  return static_cast<cudaStream_t>(stream_ptr);
+}
+
+namespace bench_stable {
+
+void scale(torch::stable::Tensor& out, torch::stable::Tensor const& in,
+           double factor) {
+  STD_TORCH_CHECK(
+      out.scalar_type() == torch::headeronly::ScalarType::Float &&
+          in.scalar_type() == torch::headeronly::ScalarType::Float,
+      "float32 only");
+  const int32_t dev = in.get_device_index();
+  const torch::stable::accelerator::DeviceGuard guard(dev);
+  cudaStream_t stream = stable_current_stream(dev);
+  launch_scale_f32(static_cast<float*>(out.mutable_data_ptr()),
+                   static_cast<const float*>(in.const_data_ptr()),
+                   static_cast<float>(factor), in.numel(), stream);
+}
+
+}  // namespace bench_stable
+
+STABLE_TORCH_LIBRARY(bench_stable, m) {
+  m.def("scale(Tensor(a!) out, Tensor src, float factor) -> ()");
+}
+
+STABLE_TORCH_LIBRARY_IMPL(bench_stable, CUDA, m) {
+  m.impl("scale", TORCH_BOX(&bench_stable::scale));
+}

--- a/ffi_bench/binding_tvmffi.cu
+++ b/ffi_bench/binding_tvmffi.cu
@@ -1,0 +1,25 @@
+// Variant 3: apache-tvm-ffi. Direct C ABI, no torch dispatcher involved. The
+// .so does not link against libtorch at all; it only links against libtvm_ffi.
+#include <tvm/ffi/extra/c_env_api.h>
+#include <tvm/ffi/function.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include "scale_kernel.cuh"
+
+namespace bench_tvmffi {
+
+inline cudaStream_t get_stream(DLDevice device) {
+  return static_cast<cudaStream_t>(
+      TVMFFIEnvGetStream(device.device_type, device.device_id));
+}
+
+void scale(tvm::ffi::TensorView out, tvm::ffi::TensorView in, double factor) {
+  cudaStream_t stream = get_stream(in.device());
+  launch_scale_f32(static_cast<float*>(out.data_ptr()),
+                   static_cast<const float*>(in.data_ptr()),
+                   static_cast<float>(factor), in.numel(), stream);
+}
+
+}  // namespace bench_tvmffi
+
+TVM_FFI_DLL_EXPORT_TYPED_FUNC(scale, bench_tvmffi::scale);

--- a/ffi_bench/binding_unstable.cu
+++ b/ffi_bench/binding_unstable.cu
@@ -1,0 +1,27 @@
+// Baseline: classic TORCH_LIBRARY registration with at::Tensor (unboxed
+// dispatch path). This is what most of vLLM's csrc still uses today.
+#include <torch/library.h>
+#include <ATen/ATen.h>
+#include <c10/cuda/CUDAStream.h>
+
+#include "scale_kernel.cuh"
+
+namespace bench_unstable {
+
+void scale(at::Tensor& out, at::Tensor const& in, double factor) {
+  TORCH_CHECK(out.is_cuda() && in.is_cuda(), "tensors must be CUDA");
+  TORCH_CHECK(out.scalar_type() == at::kFloat, "float32 only");
+  auto stream = c10::cuda::getCurrentCUDAStream(in.device().index()).stream();
+  launch_scale_f32(out.data_ptr<float>(), in.data_ptr<float>(),
+                   static_cast<float>(factor), in.numel(), stream);
+}
+
+}  // namespace bench_unstable
+
+TORCH_LIBRARY(bench_unstable, m) {
+  m.def("scale(Tensor(a!) out, Tensor src, float factor) -> ()");
+}
+
+TORCH_LIBRARY_IMPL(bench_unstable, CUDA, m) {
+  m.impl("scale", &bench_unstable::scale);
+}

--- a/ffi_bench/build.sh
+++ b/ffi_bench/build.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Build all three binding variants and report build time + .so size.
+# Run from the ffi_bench directory.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+cd "$HERE"
+
+PY="$HERE/../.venv/bin/python"
+NVCC=/usr/local/cuda-13.0/bin/nvcc
+ARCH=sm_103
+
+TORCH_INC=$($PY -c "import torch.utils.cpp_extension as ce; print(' '.join(f'-I{p}' for p in ce.include_paths()))")
+TORCH_LIB=$($PY -c "import torch.utils.cpp_extension as ce; print(' '.join(f'-L{p}' for p in ce.library_paths()))")
+TORCH_ABI_FLAG="-D_GLIBCXX_USE_CXX11_ABI=1"
+
+TVMFFI_CXX=$($HERE/../.venv/bin/tvm-ffi-config --cxxflags)
+TVMFFI_LD=$($HERE/../.venv/bin/tvm-ffi-config --ldflags)
+TVMFFI_LIBS=$($HERE/../.venv/bin/tvm-ffi-config --libs)
+
+COMMON="-O3 -shared -Xcompiler -fPIC -arch=$ARCH -std=c++17 $TORCH_ABI_FLAG -DUSE_CUDA"
+
+mkdir -p build
+
+build_one() {
+  local src=$1
+  local out=$2
+  shift 2
+  echo ">>> Building $out"
+  /usr/bin/time -f "  build_time_sec=%e  rss_mb=%M" \
+    $NVCC $COMMON "$src" -o "build/$out" "$@" 2>&1 | tail -3
+  ls -la "build/$out" | awk '{printf "  size_bytes=%s\n", $5}'
+}
+
+TORCH_LIBDIR=$($PY -c "import torch.utils.cpp_extension as ce; print(ce.library_paths()[0])")
+TVMFFI_LIBDIR=$($HERE/../.venv/bin/tvm-ffi-config --libdir)
+
+build_one binding_unstable.cu unstable.so \
+  $TORCH_INC $TORCH_LIB \
+  -lc10 -ltorch -ltorch_cpu -lc10_cuda -ltorch_cuda \
+  -Xlinker -rpath -Xlinker "$TORCH_LIBDIR"
+
+build_one binding_stable.cu stable.so \
+  $TORCH_INC $TORCH_LIB \
+  -lc10 -ltorch -ltorch_cpu -lc10_cuda -ltorch_cuda \
+  -Xlinker -rpath -Xlinker "$TORCH_LIBDIR"
+
+build_one binding_tvmffi.cu tvmffi.so \
+  $TVMFFI_CXX $TVMFFI_LD $TVMFFI_LIBS \
+  -Xlinker -rpath -Xlinker "$TVMFFI_LIBDIR"
+
+echo
+echo "=== summary ==="
+ls -la build/

--- a/ffi_bench/scale_kernel.cuh
+++ b/ffi_bench/scale_kernel.cuh
@@ -1,0 +1,19 @@
+// Trivial CUDA kernel shared by all three binding variants. Computing
+// `out[i] = in[i] * factor` is essentially free; with a 1-element tensor the
+// per-call latency is dominated by host-side dispatch + kernel launch overhead.
+#pragma once
+#include <cuda_runtime.h>
+
+template <typename T>
+__global__ void scale_kernel(T* __restrict__ out, const T* __restrict__ in,
+                             T factor, int64_t n) {
+  int64_t i = blockIdx.x * blockDim.x + threadIdx.x;
+  if (i < n) out[i] = in[i] * factor;
+}
+
+inline void launch_scale_f32(float* out, const float* in, float factor,
+                             int64_t n, cudaStream_t stream) {
+  int threads = 256;
+  int blocks = (n + threads - 1) / threads;
+  scale_kernel<float><<<blocks, threads, 0, stream>>>(out, in, factor, n);
+}


### PR DESCRIPTION



Made with claude to experiment, here is the summary. Just wanted to test some important details to me after seeing https://github.com/vllm-project/vllm/issues/26946

## Setup

- B300 (sm_103), torch 2.11.0+cu13.0, tvm-ffi 0.1.9
- Same kernel (`out[i] = in[i] * factor`), 1-element float32 tensor so kernel compute ≈ 0
- Three bindings in `/home/mgoin/code/vllm/ffi_bench/`:
  - `binding_unstable.cu` — `TORCH_LIBRARY` (vLLM's current default, unboxed dispatch)
  - `binding_stable.cu` — `STABLE_TORCH_LIBRARY` + `TORCH_BOX` (vLLM's `csrc/libtorch_stable/` target)
  - `binding_tvmffi.cu` — `TVM_FFI_DLL_EXPORT_TYPED_FUNC` (no torch dispatcher)

## Build

| Variant | Build time | .so size | Runtime deps (`ldd`) |
|---|---:|---:|---|
| TORCH_LIBRARY | **12.1 s** | 1071 KB | libc10, libtorch_cpu, libc10_cuda, libcudart |
| STABLE_TORCH_LIBRARY | **2.4 s** | 1026 KB | libc10, libtorch_cpu, libtorch_cuda, libtorch_nvshmem, libc10_cuda, libcusparse, libcufft, libcufile, libcudart |
| tvm-ffi | **1.7 s** | 1031 KB | **libtvm_ffi only** (no torch) |

The compile-time difference is real and large (5–7×). Both `unstable` and `stable` still link libtorch — `stable` actually drags in *more* libs because the AOTI shim section pulls libtorch_cuda. tvm-ffi's .so is genuinely torch-free; this is the entire portability story in one `ldd`.

## Eager dispatch (host-side latency per call)

```
  unstable_TORCH_LIBRARY                 3.412 µs   (baseline)
  stable_STABLE_TORCH_LIBRARY            3.513 µs   (+0.10 µs, +3%)
  tvmffi_direct                          2.711 µs   (-0.70 µs, -21%)
```

So the article's "torch stable has greater launch overhead" claim is **directionally correct but small**: ~100 ns penalty for the boxed dispatcher path vs the unboxed one. The real gap is between *any* torch dispatcher (~3.4 µs) and *no* torch dispatcher (~2.7 µs) — about 700 ns.

## CUDA graph capture (dispatch happens once at record time)

```
  unstable    9.26 ms / 4096 ops = 2.26 µs/op
  stable     10.48 ms / 4096 ops = 2.56 µs/op   (+13%)
  tvmffi      7.20 ms / 4096 ops = 1.76 µs/op   (-22%)
```

Same shape as eager — capture-time dispatch overhead tracks eager-time overhead.

## CUDA graph replay (the steady-state vLLM path)

```
  unstable_TORCH_LIBRARY      1142 ns/op
  stable_STABLE_TORCH_LIBRARY 1144 ns/op
  tvmffi_direct               1146 ns/op
```

**Indistinguishable.** Once captured, the graph is just a list of `cudaLaunchKernel` calls — the binding mechanism is gone. For vLLM's hot path (decode through CUDA graphs), the binding choice is irrelevant for steady-state perf.

All three captured cleanly into `torch.cuda.CUDAGraph()`, including tvm-ffi — so the "does it work with CUDA graphs" question is settled for the simple kernel case (the kernel uses the current torch stream via `TVMFFIEnvGetStream`, which graph capture sees as expected).

## What this means for vLLM

Your ranking of priorities — *portability over dispatcher integration, no autograd, no torch.compile fusion in the op itself* — actually maps cleanly onto these numbers:

1. **Eager µs gaps don't matter** for the decode hot path because you're in CUDA graphs and the gap collapses to noise.
2. **Build time and dependencies are where tvm-ffi wins big.** 7× faster compile, and the .so has *zero* libtorch dependency — that's a real "ship one wheel against any torch ≥ 2.x" story, whereas stable-ABI's wheel still loads libtorch_cuda at runtime (the symbols *promise* to stay stable, but you still need libtorch present).
3. **Capture overhead favors tvm-ffi** by ~22%, which matters if you frequently re-capture graphs (piecewise compilation, dynamic shapes triggering recapture).
4. **Stable ABI's downside vs tvm-ffi here is real but modest** at the call site (~100 ns boxed vs unboxed). The bigger downside is the runtime libtorch coupling.

The honest read: if portability + low-friction integration of new kernels is the goal and you're not relying on dispatcher integration, **tvm-ffi has a defensible advantage** for *new* vLLM C++ ops. Its big risks are organizational — pre-release pinning churn ([vLLM #27476](https://github.com/vllm-project/vllm/issues/27476)) and the ABI itself still being 0.1.x — not technical.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

