### PR TITLE
Limit gpu utils and lower max BS on test_transcription_api_correctness.py

### DIFF
--- a/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
+++ b/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
@@ -27,7 +27,8 @@ from ....models.registry import HF_EXAMPLE_MODELS
 from ....utils import RemoteOpenAIServer
 
 # Tuned to prevent OOM on 18GB GPUs in transcription correctness tests.
-MAX_SEQS_FOR_TRANSCRIPTION_TEST = 32
+MAX_SEQS_FOR_TRANSCRIPTION_TEST = 8
+GPU_UTIL_FOR_TRANSCRIPTION_TEST = 0.5
 
 
 def to_bytes(y, sr):
@@ -188,6 +189,7 @@ def test_wer_correctness(
         "--enforce-eager",
         f"--tokenizer_mode={model_info.tokenizer_mode}",
         f"--max_num_seqs={MAX_SEQS_FOR_TRANSCRIPTION_TEST}",
+        f"--gpu_memory_utilization={GPU_UTIL_FOR_TRANSCRIPTION_TEST}"
     ]
     if model_info.trust_remote_code:
         server_args.append("--trust-remote-code")

--- a/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
+++ b/tests/entrypoints/openai/correctness/test_transcription_api_correctness.py
@@ -189,7 +189,7 @@ def test_wer_correctness(
         "--enforce-eager",
         f"--tokenizer_mode={model_info.tokenizer_mode}",
         f"--max_num_seqs={MAX_SEQS_FOR_TRANSCRIPTION_TEST}",
-        f"--gpu_memory_utilization={GPU_UTIL_FOR_TRANSCRIPTION_TEST}"
+        f"--gpu_memory_utilization={GPU_UTIL_FOR_TRANSCRIPTION_TEST}",
     ]
     if model_info.trust_remote_code:
         server_args.append("--trust-remote-code")


### PR DESCRIPTION
 https://github.com/vllm-project/vllm/pull/41478 added a fix to lower BS in the test. The CI passed in that PR but failed later on in https://buildkite.com/vllm/ci/builds/64258/canvas?sid=019df193-a942-4d4b-aeb0-15f160336dfa&tab=output. This PR adds more aggressive limit on max memory size since the CI machine is a 18GB MIG H200.