### PR TITLE
Fix Gemma4 TritonAttention buffer mismatch for heterogeneous head_dim (#41656)

### DIFF
--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -142,7 +142,7 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
             vllm_config.parallel_config
         )
         self.num_heads_kv = model_config.get_num_kv_heads(vllm_config.parallel_config)
-        self.headdim = model_config.get_head_size()
+        self.headdim = kv_cache_spec.head_size
 
         # Check if CUDA Graphs are enabled for decode
         self.decode_cudagraph_enabled = (


### PR DESCRIPTION
Summary:

Fix TritonAttentionMetadataBuilder to use `kv_cache_spec.head_size` instead of `model_config.get_head_size()` when allocating intermediate softmax buffers. For models with heterogeneous head dimensions (Gemma4 26B-A4B: head_dim=256 for sliding attention, global_head_dim=512 for full attention), vLLM V1 creates separate AttentionGroups per head_size, each with the correct kv_cache_spec. But the builder was ignoring the spec and using the model-level value, causing buffers to be too small for the full-attention group, leading to out-of-bounds CUDA memory access during decode. This matches FlashInferMetadataBuilder which already uses `kv_cache_spec.head_size`.

Test Plan:
Verified with google/gemma-4-26B-A4B-it (heterogeneous head_dim model) — decode runs correctly without CUDA OOB errors after fix.

```
VLLM_USE_V1=1 VLLM_ATTENTION_BACKEND=TRITON_ATTN \
vllm serve google/gemma-4-26B-A4B-it \
  --max-model-len 32768 \
  --max-num-seqs 128 \
  --max-num-batched-tokens 16384 \
  --gpu-memory-utilization 0.95
```

Reviewed By: houseroad

Differential Revision: D103467235


