### PR TITLE
fix: handle detached HEAD in precompiled wheel commit resolution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -787,13 +787,13 @@ class precompiled_wheel_utils:
                     ["git", "fetch", "https://github.com/vllm-project/vllm", "main"]
                 )
 
-            # Then get the commit hash of the current branch that is the same as
-            # the upstream main commit.
+            # Get the current branch name, or "HEAD" for detached HEAD
+            # (e.g. git submodules, `git checkout <hash>`).
             current_branch = (
                 subprocess.check_output(["git", "branch", "--show-current"])
                 .decode("utf-8")
                 .strip()
-            )
+            ) or "HEAD"
 
             base_commit = (
                 subprocess.check_output(


### PR DESCRIPTION
When running in detached HEAD state (e.g. git submodules or `git checkout <hash>`), `git branch --show-current` returns an empty string, causing `git merge-base` to fail. This silently falls back to the nightly wheel, which is likely to be built against a different torch version, leading to ABI incompatibility (undefined symbol errors at import time).

Fall back to "HEAD" when no branch name is available, which is a valid ref for `git merge-base`.

## Purpose

Fix precompiled wheel commit resolution when running in detached HEAD state.

Currently, `get_base_commit_in_main_branch()` in `setup.py` uses `git branch --show-current` to get the current branch name. In detached HEAD state (common with git submodules or direct commit checkouts), this returns an empty string, causing `git merge-base <upstream> ""` to fail. The code then falls back to the `"nightly"` wheel, which may be built against a different torch version (e.g. torch 2.11 vs 2.10), resulting in `ImportError: undefined symbol` at runtime.

The fix adds `or "HEAD"` so that `git merge-base` receives a valid ref in all cases.

## Test Plan

```bash
# In a detached HEAD state (e.g. git submodule):
git checkout 58262dec6e8190f321edd088e937d9b51f7ed064

# Before fix: falls back to nightly, may cause ABI mismatch
VLLM_USE_PRECOMPILED=1 pip install -e . --no-build-isolation
python -c "import vllm"  # ImportError: undefined symbol

# After fix: correctly resolves merge-base using HEAD
VLLM_USE_PRECOMPILED=1 pip install -e . --no-build-isolation
python -c "import vllm"  # Success
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

