### PR TITLE
[Docs] update attribution to reflect EDEN foundation

### DIFF
--- a/vllm/model_executor/layers/quantization/turboquant/__init__.py
+++ b/vllm/model_executor/layers/quantization/turboquant/__init__.py
@@ -5,15 +5,20 @@
 Hadamard rotation + per-coordinate Lloyd-Max scalar quantization for
 keys, uniform quantization for values.
 
-The technique implemented here consists of the scalar case of the HIGGS
+The core algorithmic pattern implemented for key quantization (Hadamard
+rotation followed by deterministic scalar quantization and
+re-normalization) was originally established in DRIVE (Vargaftik et al.,
+NeurIPS 2021) and EDEN (Vargaftik et al., ICML 2022). This formulation is
+also mathematically equivalent to the scalar case of the HIGGS
 quantization method (Malinovskii et al., "Pushing the Limits of Large
 Language Model Quantization via the Linearity Theorem", NAACL 2025;
-preprint arXiv:2411.17525): rotation + optimized grid + optional
-re-normalization, applied to KV cache compression. A first application
-of this approach to KV-cache compression is in "Cache Me If You Must:
-Adaptive Key-Value Quantization for Large Language Models" (Shutova
-et al., ICML 2025; preprint arXiv:2501.19392). Both these references
-pre-date the TurboQuant paper (Zandieh et al., ICLR 2026).
+preprint arXiv:2411.17525), which subsequently generalized these concepts.
+
+A first application of this approach to KV-cache compression is in "Cache
+Me If You Must: Adaptive Key-Value Quantization for Large Language Models"
+(Shutova et al., ICML 2025; preprint arXiv:2501.19392). All of these
+foundational and application references pre-date the TurboQuant paper
+(Zandieh et al., ICLR 2026).
 """
 
 from vllm.model_executor.layers.quantization.turboquant.config import TurboQuantConfig

--- a/vllm/model_executor/layers/quantization/turboquant/config.py
+++ b/vllm/model_executor/layers/quantization/turboquant/config.py
@@ -39,19 +39,25 @@ class TurboQuantConfig:
     Applies Hadamard rotation followed by per-coordinate Lloyd-Max scalar
     quantization for keys, and uniform quantization for values.
 
-    Historical note: this is the scalar case of the HIGGS quantization
-    method (Malinovskii et al., "Pushing the Limits of Large Language Model
-    Quantization via the Linearity Theorem", NAACL 2025; preprint
-    arXiv:2411.17525): rotation + optimized grid + optional re-normalization,
-    applied to KV cache compression. A first application of this approach to
-    KV-cache compression is in "Cache Me If You Must: Adaptive Key-Value
-    Quantization for Large Language Models" (Shutova et al., ICML 2025;
-    preprint arXiv:2501.19392). Both these references pre-date the
-    TurboQuant paper.
+    Historical note: the core algorithmic pattern implemented for key
+    quantization (Hadamard rotation followed by deterministic scalar
+    quantization and re-normalization) was originally established in DRIVE
+    (Vargaftik et al., NeurIPS 2021) and EDEN (Vargaftik et al., ICML
+    2022). This formulation is also mathematically equivalent to the
+    scalar case of the HIGGS quantization method (Malinovskii et al.,
+    "Pushing the Limits of Large Language Model Quantization via the
+    Linearity Theorem", NAACL 2025; preprint arXiv:2411.17525), which
+    subsequently generalized these concepts.
 
-    QJL is intentionally omitted — community consensus (5+ independent
-    groups) found it hurts attention quality by amplifying variance through
-    softmax.
+    A first application of this approach to KV-cache compression is in
+    "Cache Me If You Must: Adaptive Key-Value Quantization for Large
+    Language Models" (Shutova et al., ICML 2025; preprint
+    arXiv:2501.19392). All of these foundational and application
+    references pre-date the TurboQuant paper (Zandieh et al., ICLR 2026).
+
+    QJL is intentionally omitted: community consensus (5+ independent
+    groups) found it hurts attention quality by amplifying variance
+    through softmax.
 
     Named presets (use via --kv-cache-dtype):
         turboquant_k8v4:   FP8 keys + 4-bit values, 2.6x, +1.17% PPL


### PR DESCRIPTION

## Purpose

The quantization implemented here is fundamentally closer to EDEN than to TurboQuant. By relying on norm preservation and dropping QJL, the technique aligns directly with established bounds of the earlier framework.

For detailed technical context, please see:

Detailed comparison: https://arxiv.org/abs/2604.18555

Overview of the comparison: https://towardsdatascience.com/how-a-2021-quantization-algorithm-quietly-outperforms-its-2026-successor/

Discussion regarding the specific scale used in vLLM: https://github.com/TheTom/turboquant_plus/issues/89#issuecomment-4374269003


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [X] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [X] The test plan, such as providing test command.
- [X] The test results, such as pasting the results comparison before and after, or e2e results
- [X] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

