### PR TITLE
fix-grpc-spawn

### DIFF
--- a/vllm/entrypoints/grpc_server.py
+++ b/vllm/entrypoints/grpc_server.py
@@ -43,7 +43,7 @@ import uvloop
 
 from vllm import envs
 from vllm.engine.arg_utils import AsyncEngineArgs
-from vllm.entrypoints.utils import log_version_and_model
+from vllm.entrypoints.utils import cli_env_setup, log_version_and_model
 from vllm.logger import init_logger
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils.argparse_utils import FlexibleArgumentParser
@@ -167,6 +167,7 @@ async def serve_grpc(args: argparse.Namespace):
 
 def main():
     """Main entry point for python -m vllm.entrypoints.grpc_server."""
+    cli_env_setup()
     parser = FlexibleArgumentParser(
         description="vLLM gRPC Server",
     )


### PR DESCRIPTION
## Purpose

`vllm.entrypoints.grpc_server` does not call `cli_env_setup()`, so `VLLM_WORKER_MULTIPROC_METHOD` defaults to `fork`. Fork is incompatible with CUDA-initialized worker processes and crashes on launch in tensor-parallel deployments.

The HTTP entry point (`vllm/entrypoints/openai/api_server.py:710`) and the generic CLI (`vllm/entrypoints/cli/main.py:36`) both call `cli_env_setup()` at the start of `main()`. The gRPC entry point should mirror this — `cli_env_setup` was always intended to run from every CLI entry point per its own docstring (`vllm/entrypoints/utils.py:154-172`).

## Change

```diff
-from vllm.entrypoints.utils import log_version_and_model
+from vllm.entrypoints.utils import cli_env_setup, log_version_and_model

 def main():
     """Main entry point for python -m vllm.entrypoints.grpc_server."""
+    cli_env_setup()
     parser = FlexibleArgumentParser(...)
```

## Test plan

- `python -m vllm.entrypoints.grpc_server --model <model>` now sets `VLLM_WORKER_MULTIPROC_METHOD=spawn` automatically, matching `python -m vllm.entrypoints.openai.api_server` behavior.
- Users who explicitly set `VLLM_WORKER_MULTIPROC_METHOD` are unaffected — `cli_env_setup()` is a no-op when the env var is already present.