### PR TITLE
[ROCm] Add QuickReduce min-size override and codec threshold

### DIFF
--- a/tests/distributed/test_quick_all_reduce.py
+++ b/tests/distributed/test_quick_all_reduce.py
@@ -11,7 +11,14 @@ import torch.distributed as dist
 
 from vllm import _custom_ops as ops
 from vllm.distributed.communication_op import tensor_model_parallel_all_reduce  # noqa
+from vllm.distributed.device_communicators.quick_all_reduce import (
+    KB,
+    MB,
+    QuickAllReduce,
+    QuickReduceRegime,
+)
 from vllm.distributed.parallel_state import get_tp_group, graph_capture
+from vllm.envs import disable_envs_cache
 from vllm.platforms import current_platform
 
 from ..utils import (
@@ -26,6 +33,177 @@ random.seed(44)
 test_sizes = [random.randint(8 * 1024 * 1024, 10 * 1024 * 1024) for _ in range(8)]
 for i, v in enumerate(test_sizes):
     test_sizes[i] -= v % 8
+
+
+@pytest.fixture
+def envs_cache_disabled():
+    disable_envs_cache()
+    yield
+    disable_envs_cache()
+
+
+def _make_quick_allreduce_for_test(
+    min_size_mb: int | None = None,
+    quantization_min_size: int | None = None,
+) -> QuickAllReduce:
+    quick_reduce = QuickAllReduce.__new__(QuickAllReduce)
+    quick_reduce.disabled = False
+    quick_reduce.qr_max_size = 16 * MB
+    quick_reduce.qr_min_size = min_size_mb * MB if min_size_mb is not None else None
+    quick_reduce.qr_quant_level = QuickReduceRegime.INT4
+    quick_reduce.qr_quantization_min_size = quantization_min_size
+    quick_reduce.use_fp16_kernels = False
+    quick_reduce.world_size = 2
+    return quick_reduce
+
+
+def test_should_quick_allreduce_uses_builtin_min_size_when_unset():
+    quick_reduce = _make_quick_allreduce_for_test(min_size_mb=None)
+
+    below_builtin_min = torch.empty(MB // 4, dtype=torch.float16)
+    at_builtin_min = torch.empty(MB // 2, dtype=torch.float16)
+
+    assert not quick_reduce.should_quick_allreduce(below_builtin_min)
+    assert quick_reduce.should_quick_allreduce(at_builtin_min)
+
+
+def test_should_quick_allreduce_uses_min_size_override():
+    quick_reduce = _make_quick_allreduce_for_test(min_size_mb=0)
+
+    below_builtin_min = torch.empty(8, dtype=torch.float16)
+
+    assert quick_reduce.should_quick_allreduce(below_builtin_min)
+
+
+def test_quick_allreduce_min_size_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+    envs_cache_disabled,
+):
+    monkeypatch.delenv("VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB", raising=False)
+
+    assert QuickAllReduce._get_qr_min_size(qr_max_size=16 * MB) is None
+
+
+def test_quick_allreduce_min_size_env_converts_mb_to_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+    envs_cache_disabled,
+):
+    monkeypatch.setenv("VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB", "4")
+
+    assert QuickAllReduce._get_qr_min_size(qr_max_size=16 * MB) == 4 * MB
+
+
+def test_quick_allreduce_min_size_env_rejects_negative(
+    monkeypatch: pytest.MonkeyPatch,
+    envs_cache_disabled,
+):
+    monkeypatch.setenv("VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB", "-1")
+
+    with pytest.raises(ValueError, match="must be non-negative"):
+        QuickAllReduce._get_qr_min_size(qr_max_size=16 * MB)
+
+
+def test_quick_allreduce_min_size_env_allows_equal_to_max(
+    monkeypatch: pytest.MonkeyPatch,
+    envs_cache_disabled,
+):
+    monkeypatch.setenv("VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB", "16")
+
+    assert QuickAllReduce._get_qr_min_size(qr_max_size=16 * MB) == 16 * MB
+
+
+def test_quick_allreduce_min_size_env_rejects_larger_than_max(
+    monkeypatch: pytest.MonkeyPatch,
+    envs_cache_disabled,
+):
+    monkeypatch.setenv("VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB", "17")
+
+    with pytest.raises(ValueError, match="effective QuickReduce max size"):
+        QuickAllReduce._get_qr_min_size(qr_max_size=16 * MB)
+
+
+def test_quick_allreduce_quantization_min_size_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+    envs_cache_disabled,
+):
+    monkeypatch.delenv("VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB", raising=False)
+
+    assert QuickAllReduce._get_qr_quantization_min_size() is None
+
+
+def test_quick_allreduce_quantization_min_size_env_converts_kb_to_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+    envs_cache_disabled,
+):
+    monkeypatch.setenv("VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB", "2048")
+
+    assert QuickAllReduce._get_qr_quantization_min_size() == 2048 * KB
+
+
+def test_quick_allreduce_quantization_min_size_env_rejects_negative(
+    monkeypatch: pytest.MonkeyPatch,
+    envs_cache_disabled,
+):
+    monkeypatch.setenv("VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB", "-1")
+
+    with pytest.raises(ValueError, match="must be non-negative"):
+        QuickAllReduce._get_qr_quantization_min_size()
+
+
+def test_quick_allreduce_quantization_min_size_unset_uses_configured_codec():
+    quick_reduce = _make_quick_allreduce_for_test(quantization_min_size=None)
+    inp = torch.empty(8, dtype=torch.float16)
+
+    assert quick_reduce._get_qr_quant_level(inp) == QuickReduceRegime.INT4.value
+
+
+def test_quick_allreduce_quantization_min_size_uses_fp_below_threshold():
+    quick_reduce = _make_quick_allreduce_for_test(quantization_min_size=2048)
+    inp = torch.empty(1024 // 2, dtype=torch.float16)
+
+    assert quick_reduce._get_qr_quant_level(inp) == QuickReduceRegime.FP.value
+
+
+def test_quick_allreduce_quantization_min_size_uses_configured_codec_at_threshold():
+    quick_reduce = _make_quick_allreduce_for_test(quantization_min_size=2048)
+    inp = torch.empty(2048 // 2, dtype=torch.float16)
+
+    assert quick_reduce._get_qr_quant_level(inp) == QuickReduceRegime.INT4.value
+
+
+def test_quick_allreduce_quantization_min_size_does_not_change_eligibility():
+    quick_reduce = _make_quick_allreduce_for_test(quantization_min_size=2 * MB)
+
+    below_builtin_min = torch.empty(MB // 4, dtype=torch.float16)
+    at_builtin_min = torch.empty(MB // 2, dtype=torch.float16)
+
+    assert not quick_reduce.should_quick_allreduce(below_builtin_min)
+    assert quick_reduce.should_quick_allreduce(at_builtin_min)
+
+
+def test_quick_allreduce_passes_dynamic_quant_level(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    quick_reduce = _make_quick_allreduce_for_test(quantization_min_size=2 * KB)
+    quick_reduce._ptr = object()
+    inp = torch.empty(KB // 2, dtype=torch.float16)
+    called_quant_level = None
+
+    def fake_qr_all_reduce(
+        fa,
+        inp,
+        out,
+        quant_level,
+        cast_bf2half,
+    ):
+        nonlocal called_quant_level
+        called_quant_level = quant_level
+
+    monkeypatch.setattr(ops, "qr_all_reduce", fake_qr_all_reduce)
+
+    quick_reduce.quick_all_reduce(inp)
+
+    assert called_quant_level == QuickReduceRegime.FP.value
 
 
 @ray.remote(num_gpus=1, max_calls=1)

--- a/vllm/distributed/device_communicators/quick_all_reduce.py
+++ b/vllm/distributed/device_communicators/quick_all_reduce.py
@@ -39,7 +39,8 @@ class QuickReduceRegime(Enum):
     NONE = 4
 
 
-MB = 1024 * 1024
+KB = 1024
+MB = 1024 * KB
 
 
 class QuickAllReduce:
@@ -183,6 +184,7 @@ class QuickAllReduce:
             )
             return
         self.qr_quant_level = QuickReduceRegime[regime_str]
+        self.qr_quantization_min_size = self._get_qr_quantization_min_size()
         vllm_config = get_current_vllm_config_or_none()
         if (
             vllm_config is not None
@@ -215,10 +217,55 @@ class QuickAllReduce:
                     "lead to error or degradation to custom allreduce or rccl."
                 )
             qr_max_size = qr_max_size * MB
+        effective_qr_max_size = (
+            qr_max_size if qr_max_size is not None else ops.qr_max_size()
+        )
+        qr_min_size = self._get_qr_min_size(effective_qr_max_size)
         self._ptr = ops.init_custom_qr(self.rank, self.world_size, qr_max_size)
-        self.qr_max_size = qr_max_size if qr_max_size is not None else ops.qr_max_size()
+        self.qr_max_size = effective_qr_max_size
+        self.qr_min_size = qr_min_size
+        if qr_min_size is not None:
+            logger.info(
+                "Custom quick allreduce: min size override = %d MB",
+                qr_min_size // MB,
+            )
+        if self.qr_quantization_min_size is not None:
+            logger.info(
+                "Custom quick allreduce: quantization codec threshold = %d KB",
+                self.qr_quantization_min_size // KB,
+            )
         self.create_shared_buffer()
         self.disabled = False
+
+    @staticmethod
+    def _get_qr_min_size(qr_max_size: int | None) -> int | None:
+        qr_min_size = envs.VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB
+        if qr_min_size is None:
+            return None
+        if qr_min_size < 0:
+            raise ValueError(
+                "VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB must be non-negative, "
+                f"got {qr_min_size}"
+            )
+        qr_min_size *= MB
+        if qr_max_size is not None and qr_min_size > qr_max_size:
+            raise ValueError(
+                "VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB must be less than or "
+                "equal to the effective QuickReduce max size"
+            )
+        return qr_min_size
+
+    @staticmethod
+    def _get_qr_quantization_min_size() -> int | None:
+        quantization_min_size = envs.VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB
+        if quantization_min_size is None:
+            return None
+        if quantization_min_size < 0:
+            raise ValueError(
+                "VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB must be "
+                f"non-negative, got {quantization_min_size}"
+            )
+        return quantization_min_size * KB
 
     def _rocm_arch_available(self):
         if not current_platform.is_rocm():
@@ -261,11 +308,12 @@ class QuickAllReduce:
         dtype = inp.dtype
         if self.use_fp16_kernels:
             dtype = torch.float16
-        return (
-            inp_size <= self.qr_max_size
-            and inp_size
-            >= self._QR_MIN_SIZE[(dtype, self.world_size)][self.qr_quant_level.value]
-        )
+        min_size = self.qr_min_size
+        if min_size is None:
+            min_size = self._QR_MIN_SIZE[(dtype, self.world_size)][
+                self.qr_quant_level.value
+            ]
+        return inp_size <= self.qr_max_size and inp_size >= min_size
 
     def quick_all_reduce(self, inp: torch.Tensor, *, out: torch.Tensor = None):
         """Performs an out-of-place custom quick all reduce."""
@@ -274,9 +322,18 @@ class QuickAllReduce:
         if out is None:
             out = torch.empty_like(inp)
         ops.qr_all_reduce(
-            self._ptr, inp, out, self.qr_quant_level.value, self.use_fp16_kernels
+            self._ptr, inp, out, self._get_qr_quant_level(inp), self.use_fp16_kernels
         )
         return out
+
+    def _get_qr_quant_level(self, inp: torch.Tensor) -> int:
+        quantization_min_size = self.qr_quantization_min_size
+        if (
+            quantization_min_size is not None
+            and inp.numel() * inp.element_size() < quantization_min_size
+        ):
+            return QuickReduceRegime.FP.value
+        return self.qr_quant_level.value
 
     def close(self):
         if not self.disabled and getattr(self, "_ptr", None):

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -209,6 +209,8 @@ if TYPE_CHECKING:
     ] = "NONE"
     VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16: bool = True
     VLLM_ROCM_QUICK_REDUCE_MAX_SIZE_BYTES_MB: int | None = None
+    VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB: int | None = None
+    VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB: int | None = None
     VLLM_MORIIO_CONNECTOR_READ_MODE: bool = False
     VLLM_MORIIO_QP_PER_TRANSFER: int = 1
     VLLM_MORIIO_POST_BATCH_SIZE: int = -1
@@ -1121,6 +1123,19 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # communication.
     "VLLM_ROCM_QUICK_REDUCE_MAX_SIZE_BYTES_MB": lambda: maybe_convert_int(
         os.environ.get("VLLM_ROCM_QUICK_REDUCE_MAX_SIZE_BYTES_MB", None)
+    ),
+    # Custom quick allreduce kernel for MI3* cards.
+    # Controls the minimum allowed number of data bytes(MB) required to use
+    # custom quick allreduce communication.
+    # If unset, use the built-in threshold table.
+    "VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB": lambda: maybe_convert_int(
+        os.environ.get("VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB", None)
+    ),
+    # Controls the minimum tensor size (KB, where 1 KB = 1024 bytes) required
+    # to use the configured QuickReduce codec. Smaller tensors use FP
+    # QuickReduce. This does not affect QuickReduce eligibility.
+    "VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB": lambda: maybe_convert_int(
+        os.environ.get("VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB", None)
     ),
     # Divisor for dynamic query scale factor calculation for FP8 KV Cache
     "Q_SCALE_CONSTANT": lambda: int(os.getenv("Q_SCALE_CONSTANT", "200")),


### PR DESCRIPTION
## Summary

- Add `VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB` to override the ROCm QuickReduce minimum tensor-size threshold.
- Add `VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB` to control when QuickReduce uses the configured codec vs FP QuickReduce.
- Preserve existing behavior when either env var is unset.

ROCm QuickReduce currently relies on a static minimum-size threshold table to decide when a tensor is large enough to use the custom QuickReduce path, and always uses the configured codec (e.g. INT4) once a tensor is eligible. These two env vars add controlled tuning knobs:

1. **`MIN_SIZE_BYTES_MB`** overrides the eligibility floor — set to 0 to force all tensors through QR, or to a specific MB value to lower/raise the threshold vs the built-in table.
2. **`QUANTIZATION_MIN_SIZE_KB`** selects the codec after eligibility — tensors below this size use FP QuickReduce (avoiding quantization overhead on small messages), tensors at or above use the configured codec.

Default behavior is unchanged when neither variable is set.

## Benchmark Data

**Model:** MiniMaxAI/MiniMax-M2.5 (hidden_size=3072, 62 layers, 256 experts/8 active, FP8 weights, BF16 activations)  
**Hardware:** 4× MI355X (XGMI), vLLM 0.18.0  
**Server:** `--max-num-seqs 512 --max-num-batched-tokens 32768 --compilation-config mode=3`  
**Base env:** `VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4`, `VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16=True`

### Configurations

| | Baseline | Case 1 | Case 2 |
|---|---|---|---|
| `VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB` | unset (default table) | **0** | **0** |
| `VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB` | unset | unset | **2048** |

### Results: Median TPOT (ms)

| Sweep | Baseline | Case 1 | Δ vs base | Case 2 | Δ vs base |
|---|---|---|---|---|---|
| 1000/100 c16 | 13.40 | 15.83 | +18.1% | 13.94 | +4.0% |
| 1000/100 c256 | 41.63 | 40.39 | -3.0% | 38.97 | **-6.4%** |
| 1000/100 c512 | 75.74 | 77.31 | +2.1% | 66.11 | **-12.7%** |
| 5000/500 c16 | 14.61 | 17.05 | +16.7% | 15.19 | +4.0% |
| 5000/500 c256 | 63.12 | 63.75 | +1.0% | 63.01 | -0.2% |
| 5000/500 c512 | 119.92 | 120.28 | +0.3% | 120.99 | +0.9% |
| **Geomean** | **40.89** | **43.16** | **+5.55%** | **40.10** | **-1.92%** |

### Results: Output Token Throughput (tok/s)

| Sweep | Baseline | Case 1 | Δ vs base | Case 2 | Δ vs base |
|---|---|---|---|---|---|
| 1000/100 c16 | 962.01 | 819.96 | -14.8% | 947.03 | -1.6% |
| 1000/100 c256 | 4480.71 | 4365.73 | -2.6% | 4355.36 | -2.8% |
| 1000/100 c512 | 5382.48 | 5291.22 | -1.7% | 5357.56 | -0.5% |
| 5000/500 c16 | 996.60 | 863.11 | -13.4% | 951.27 | -4.5% |
| 5000/500 c256 | 3719.52 | 3681.91 | -1.0% | 3673.44 | -1.2% |
| 5000/500 c512 | 4052.87 | 4047.98 | -0.1% | 4054.44 | +0.0% |
| **Geomean** | **2652.85** | **2499.18** | **-5.79%** | **2605.82** | **-1.77%** |

### Analysis

- **Case 1** (`MIN_SIZE_BYTES_MB=0` only): Forces all tensors through QR INT4 regardless of size. The INT4 codec pack/unpack overhead dominates on small tensors (96 KB at c16), causing **+5.6% geomean TPOT regression** and **-5.8% throughput loss**. This demonstrates that lowering the QuickReduce eligibility floor without a codec threshold is harmful.

- **Case 2** (`MIN_SIZE_BYTES_MB=0` + `QUANTIZATION_MIN_SIZE_KB=2048`): Uses FP QuickReduce below 2048 KB and INT4 above. This avoids the INT4 codec overhead on small tensors while still enabling QuickReduce for medium tensors that benefit from it. Result: **-1.9% geomean TPOT improvement** with up to **-12.7% TPOT at high concurrency** (1000/100 c512).

`QUANTIZATION_MIN_SIZE_KB` is essential when using `MIN_SIZE_BYTES_MB` to lower the QR floor. Without it, the codec overhead makes the override counterproductive. Together, they enable targeted TPOT improvements at medium-to-high concurrency decode workloads.

## TODO

- [x] Add benchmark data from representative workloads showing when overriding the default QuickReduce minimum-size threshold is beneficial.
- [x] Run the focused QuickReduce unit tests