### PR TITLE
[Perf] Optimize Allpool forward, 96% faster for method level benchmark

### DIFF
--- a/vllm/model_executor/layers/pooler/tokwise/methods.py
+++ b/vllm/model_executor/layers/pooler/tokwise/methods.py
@@ -52,8 +52,8 @@ class AllPool(TokenPoolingMethod):
             # DispatchPooler passes the full hidden_states tensor.
             # slice out the subgroup once, then split it by
             # per-request token counts
-            group_start = int(pooling_cursor.first_token_indices_gpu[0].item())
-            group_end = int(pooling_cursor.last_token_indices_gpu[-1].item()) + 1
+            group_start = int(pooling_cursor.first_token_indices_cpu[0])
+            group_end = group_start + sum(split_sizes)
             hidden_states_group = hidden_states[group_start:group_end]
             hidden_states_lst = list(hidden_states_group.split(split_sizes))
         else:

--- a/vllm/v1/pool/metadata.py
+++ b/vllm/v1/pool/metadata.py
@@ -16,6 +16,7 @@ pin_memory = is_pin_memory_available()
 class PoolingCursor:
     first_token_indices_gpu: torch.Tensor
     last_token_indices_gpu: torch.Tensor
+    first_token_indices_cpu: torch.Tensor
     prompt_lens_cpu: torch.Tensor
     seq_lens_cpu: torch.Tensor
     num_scheduled_tokens_cpu: torch.Tensor
@@ -24,6 +25,7 @@ class PoolingCursor:
         return PoolingCursor(
             first_token_indices_gpu=self.first_token_indices_gpu[indices],
             last_token_indices_gpu=self.last_token_indices_gpu[indices],
+            first_token_indices_cpu=self.first_token_indices_cpu[indices],
             prompt_lens_cpu=self.prompt_lens_cpu[indices],
             seq_lens_cpu=self.seq_lens_cpu[indices],
             num_scheduled_tokens_cpu=self.num_scheduled_tokens_cpu[indices],
@@ -117,12 +119,13 @@ class PoolingMetadata:
         assert len(prompt_lens) == n_seq
 
         num_scheduled_tokens_cpu = torch.from_numpy(num_scheduled_tokens_np)
+        cumsum_cpu = torch.zeros(
+            n_seq + 1, dtype=torch.int64, pin_memory=pin_memory, device="cpu"
+        )
+        torch.cumsum(num_scheduled_tokens_cpu, dim=0, out=cumsum_cpu[1:])
+
         if query_start_loc_gpu is None:
-            cumsum = torch.zeros(
-                n_seq + 1, dtype=torch.int64, pin_memory=pin_memory, device="cpu"
-            )
-            torch.cumsum(num_scheduled_tokens_cpu, dim=0, out=cumsum[1:])
-            cumsum = cumsum.to(device, non_blocking=True)
+            cumsum_gpu = cumsum_cpu.to(device, non_blocking=True)
         else:
             if query_start_loc_gpu.shape[0] != n_seq + 1:
                 raise ValueError(
@@ -135,10 +138,11 @@ class PoolingMetadata:
                     "query_start_loc_gpu must be on the same device as the "
                     f"hidden states: {query_start_loc_gpu.device} != {device}."
                 )
-            cumsum = query_start_loc_gpu
+            cumsum_gpu = query_start_loc_gpu
         self.pooling_cursor = PoolingCursor(
-            first_token_indices_gpu=cumsum[:n_seq],
-            last_token_indices_gpu=cumsum[1:] - 1,
+            first_token_indices_gpu=cumsum_gpu[:n_seq],
+            last_token_indices_gpu=cumsum_gpu[1:] - 1,
+            first_token_indices_cpu=cumsum_cpu[:n_seq],
             prompt_lens_cpu=prompt_lens,
             seq_lens_cpu=seq_lens_cpu,
             num_scheduled_tokens_cpu=num_scheduled_tokens_cpu,


### PR DESCRIPTION
## Purpose

Part of https://github.com/vllm-project/vllm/issues/35631

Optimize Allpool forward by removing `item()` blocker

## Test

### Acc

Covered in mteb unit tests

### Perf

```py
import json
import time
from statistics import fmean, median
from types import SimpleNamespace
from unittest.mock import patch

import torch
import torch.nn.functional as F

from vllm.model_executor.layers.pooler.tokwise import methods as tokwise_methods

DEVICE = "cuda:0"
DTYPE = torch.float16
DTYPE_NAME = "half"
NUM_REQS = 64
TOKENS_PER_REQ = 8
HIDDEN_SIZE = 2048
MODE = "pending"
WARMUP = 50
ITERS = 300
GROUP_START = 512
EXTRA_TOKENS = 128


device = torch.device(DEVICE)
torch.backends.cuda.matmul.allow_tf32 = True

with patch.object(
    tokwise_methods,
    "get_current_vllm_config",
    lambda: SimpleNamespace(
        scheduler_config=SimpleNamespace(enable_chunked_prefill=False)
    ),
):
    pooler = tokwise_methods.AllPool()

total_tokens = GROUP_START + NUM_REQS * TOKENS_PER_REQ + EXTRA_TOKENS
ready_hidden_states = torch.randn(
    total_tokens, HIDDEN_SIZE, device=device, dtype=DTYPE
)
producer_input = torch.randn_like(ready_hidden_states)
producer_weight = torch.randn(
    HIDDEN_SIZE, HIDDEN_SIZE, device=device, dtype=DTYPE
)

split_sizes = torch.full((NUM_REQS,), TOKENS_PER_REQ, dtype=torch.int64)
prefix_cpu = GROUP_START + torch.arange(NUM_REQS, dtype=torch.int64) * TOKENS_PER_REQ
prefix_gpu = prefix_cpu.to(device, non_blocking=True)
cursor = SimpleNamespace(
    num_scheduled_tokens_cpu=split_sizes,
    first_token_indices_cpu=prefix_cpu,
    first_token_indices_gpu=prefix_gpu,
    last_token_indices_gpu=prefix_gpu + TOKENS_PER_REQ - 1,
)
metadata = SimpleNamespace(get_pooling_cursor=lambda: cursor)

def run_once():
    start = time.perf_counter()
    hidden_states = ready_hidden_states
    if MODE.startswith("pending"):
        hidden_states = F.gelu(F.linear(producer_input, producer_weight))

    out = pooler.forward(hidden_states, metadata)
    if out:
        _ = out[0].shape[0]

    if MODE.endswith("sync"):
        torch.cuda.synchronize()
        end = time.perf_counter()
    else:
        end = time.perf_counter()
        torch.cuda.synchronize()
    return (end - start) * 1e6

for _ in range(WARMUP):
    run_once()
torch.cuda.synchronize()

samples = [run_once() for _ in range(ITERS)]
print(
    json.dumps(
        {
            "device": torch.cuda.get_device_name(device),
            "dtype": DTYPE_NAME,
            "mode": MODE,
            "scenario": {
                "num_reqs": NUM_REQS,
                "tokens_per_req": TOKENS_PER_REQ,
                "hidden_size": HIDDEN_SIZE,
                "warmup": WARMUP,
                "iters": ITERS,
            },
            "median_us": median(samples),
            "mean_us": fmean(samples),
            "min_us": min(samples),
            "max_us": max(samples),
        },
        indent=2,
    )
)
```

Now

```bash
{
  "device": "NVIDIA H200",
  "dtype": "half",
  "mode": "pending",
  "scenario": {
    "num_reqs": 64,
    "tokens_per_req": 8,
    "hidden_size": 2048,
    "warmup": 50,
    "iters": 300
  },
  "median_us": 37.12065517902374,
  "mean_us": 37.39439882338047,
  "min_us": 33.591873943805695,
  "max_us": 62.18813359737396
}
```

Main

```bash
{
  "device": "NVIDIA H200",
  "dtype": "half",
  "mode": "pending",
  "scenario": {
    "num_reqs": 64,
    "tokens_per_req": 8,
    "hidden_size": 2048,
    "warmup": 50,
    "iters": 300
  },
  "median_us": 72.11137562990189,
  "mean_us": 72.88243311146896,
  "min_us": 64.9942085146904,
  "max_us": 153.78929674625397
}
```

CC @noooop 