### PR TITLE
[XPU] enable fp8 with torch._scaled_mm

### DIFF
--- a/vllm/model_executor/kernels/linear/__init__.py
+++ b/vllm/model_executor/kernels/linear/__init__.py
@@ -140,6 +140,7 @@ from vllm.model_executor.kernels.linear.scaled_mm.triton import (
     TritonInt8ScaledMMLinearKernel,
 )
 from vllm.model_executor.kernels.linear.scaled_mm.xpu import (
+    XPUFp8BlockScaledMMKernel,
     XPUFP8ScaledMMLinearKernel,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
@@ -198,6 +199,9 @@ _POSSIBLE_FP8_BLOCK_KERNELS: dict[
     PlatformEnum.ROCM: [
         AiterFp8BlockScaledMMKernel,
         TritonFp8BlockScaledMMKernel,
+    ],
+    PlatformEnum.XPU: [
+        XPUFp8BlockScaledMMKernel,
     ],
 }
 

--- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
@@ -16,6 +16,8 @@ from vllm.model_executor.layers.quantization.utils.quant_utils import (
 from vllm.model_executor.utils import replace_parameter
 from vllm.platforms import current_platform
 
+from .BlockScaledMMLinearKernel import Fp8BlockScaledMMLinearKernel
+
 
 class XPUFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
     @classmethod
@@ -69,4 +71,43 @@ class XPUFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
         bias: torch.Tensor | None,
         output_shape: list,
     ) -> torch.Tensor:
-        pass
+        m = A.shape[0]
+        A_2d = A.reshape(m, A.shape[-1])
+        out = torch._scaled_mm(
+            A_2d,
+            B,
+            scale_a=As,
+            scale_b=Bs,
+            bias=bias,
+            out_dtype=out_dtype,
+        )
+        if type(out) is tuple and len(out) == 2:
+            out = out[0]
+        return out.reshape(*output_shape, out.shape[-1])
+
+
+class XPUFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
+    @classmethod
+    def is_supported(cls, compute_capability=None):
+        if not current_platform.is_xpu():
+            return False, "XPUFp8BlockScaledMM only support on XPU"
+        return True, None
+
+    def apply_block_scaled_mm(
+        self,
+        A: torch.Tensor,
+        B: torch.Tensor,
+        As: torch.Tensor,
+        Bs: torch.Tensor,
+    ) -> torch.Tensor:
+        out_dtype = self.config.out_dtype
+        out = torch._scaled_mm(
+            A,
+            B.t().contiguous(),
+            scale_a=As,
+            scale_b=Bs.t().contiguous(),
+            out_dtype=out_dtype,
+        )
+        if type(out) is tuple and len(out) == 2:
+            out = out[0]
+        return out

--- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
@@ -73,18 +73,7 @@ class XPUFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
         bias: torch.Tensor | None,
         output_shape: list,
     ) -> torch.Tensor:
-        A_2d = A.reshape(-1, A.shape[-1])
-        out = torch._scaled_mm(
-            A_2d,
-            B,
-            scale_a=As,
-            scale_b=Bs,
-            bias=bias,
-            out_dtype=out_dtype,
-        )
-        if type(out) is tuple and len(out) == 2:
-            out = out[0]
-        return out.reshape(*output_shape, out.shape[-1])
+        pass
 
 
 class XPUFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
@@ -96,6 +85,26 @@ class XPUFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
             return False, "XPUFp8BlockScaledMM requires PyTorch >= 2.12"
         return True, None
 
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        super().process_weights_after_loading(layer)
+
+        params = self._get_layer_params(layer)
+        weight = params.weight
+        weight_scale = (
+            params.weight_scale
+            if params.weight_scale_inv is None
+            else params.weight_scale_inv
+        )
+        scale_attr_name = (
+            params.WEIGHT_SCALE
+            if params.weight_scale_inv is None
+            else params.WEIGHT_SCALE_INV
+        )
+
+        # Pre-transpose weight and scales to avoid per-forward-pass transpose
+        replace_parameter(layer, params.WEIGHT, weight.data.t().contiguous())
+        replace_parameter(layer, scale_attr_name, weight_scale.data.t().contiguous())
+
     def apply_block_scaled_mm(
         self,
         A: torch.Tensor,
@@ -103,14 +112,6 @@ class XPUFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
         As: torch.Tensor,
         Bs: torch.Tensor,
     ) -> torch.Tensor:
+        # B and Bs are already transposed in process_weights_after_loading
         out_dtype = self.config.out_dtype
-        out = torch._scaled_mm(
-            A,
-            B.t().contiguous(),
-            scale_a=As,
-            scale_b=Bs.t().contiguous(),
-            out_dtype=out_dtype,
-        )
-        if type(out) is tuple and len(out) == 2:
-            out = out[0]
-        return out
+        return torch._scaled_mm(A, B, scale_a=As, scale_b=Bs, out_dtype=out_dtype)

--- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
@@ -18,6 +18,8 @@ from vllm.platforms import current_platform
 
 from .BlockScaledMMLinearKernel import Fp8BlockScaledMMLinearKernel
 
+_TORCH_HAS_BLOCK_SCALED_MM = torch.__version__ >= "2.12" or "dev" in torch.__version__
+
 
 class XPUFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
     @classmethod
@@ -91,6 +93,8 @@ class XPUFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
     def is_supported(cls, compute_capability=None):
         if not current_platform.is_xpu():
             return False, "XPUFp8BlockScaledMM only support on XPU"
+        if not _TORCH_HAS_BLOCK_SCALED_MM:
+            return False, "XPUFp8BlockScaledMM requires PyTorch >= 2.12"
         return True, None
 
     def apply_block_scaled_mm(

--- a/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/xpu.py
@@ -73,8 +73,7 @@ class XPUFP8ScaledMMLinearKernel(FP8ScaledMMLinearKernel):
         bias: torch.Tensor | None,
         output_shape: list,
     ) -> torch.Tensor:
-        m = A.shape[0]
-        A_2d = A.reshape(m, A.shape[-1])
+        A_2d = A.reshape(-1, A.shape[-1])
         out = torch._scaled_mm(
             A_2d,
             B,


### PR DESCRIPTION

## Purpose

enable fp8 with torch.scaled_mm

https://github.com/pytorch/pytorch/pull/173630

## Test Plan

per-channel fp8
```
lm_eval --model vllm --model_args pretrained=RedHatAI/Qwen3-8B-FP8-dynamic,enforce_eager=True --tasks gsm8k --batch_size auto
```

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8772|±  |0.0090|
|     |       |strict-match    |     5|exact_match|↑  |0.8749|±  |0.0091|

block fp8

```
lm_eval --model vllm --model_args pretrained=Qwen/Qwen3-8B-FP8,enforce_eager=True
--tasks gsm8k --batch_size auto
```

xpu caled_mm not support block fp8 in 2.11 yet

```
(EngineCore pid=35405)   File "/workspace/vllm/vllm/model_executor/kernels/linear/scaled_mm/xpu.py", line 104, in apply_block_scaled_mm
(EngineCore pid=35405)     out = torch._scaled_mm(
(EngineCore pid=35405)           ^^^^^^^^^^^^^^^^^
(EngineCore pid=35405) RuntimeError: Invalid scaling configuration.
(EngineCore pid=35405) - For TensorWise scaling, a and b should be float8, scales should be float and singletons.
(EngineCore pid=35405) - For RowWise scaling, a and b should be float8, scales should be float, scale_a should be (8192, 1) and scale_b should be (1, 6144), and both should be contiguous.
(EngineCore pid=35405) Got a.dtype()=Float8_e4m3fn, scale_a.dtype()=Float, scale_a.size()=[8192, 32], scale_a.stride()=[32, 1], b.dtype()=Float8_e4m3fn, scale_b.dtype()=Float, scale_b.size()=[32, 48] and scale_b.stride()=[48, 1]
```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

