### PR TITLE
Improve offline embedding throughput for pooling models

### DIFF
--- a/tests/renderers/test_completions.py
+++ b/tests/renderers/test_completions.py
@@ -65,14 +65,17 @@ class DummyTokenizer:
     def __post_init__(self) -> None:
         self._captured_encode_kwargs: dict = {}
         self._captured_text_len: int = 0
+        self._captured_encode_texts: list[str] = []
+        self._captured_batch_texts: list[str] = []
+        self._encode_calls = 0
+        self._batch_encode_calls = 0
+        self._call_encode_calls = 0
 
     def decode(self, tokens: list[int]):
         return str(tokens)
 
-    def encode(self, text: str, **kwargs):
-        self._captured_encode_kwargs = kwargs
-        self._captured_text_len = len(text)
-
+    @staticmethod
+    def _encode_text(text: str, **kwargs):
         in_length = len(text)
         truncation = kwargs.get("truncation")
         max_length = kwargs.get("max_length")
@@ -81,10 +84,29 @@ class DummyTokenizer:
 
         return list(range(in_length))
 
-    def __call__(self, text: str, **kwargs):
-        # BaseRenderer._tokenize_prompt calls the tokenizer via __call__ (to
-        # unify the output type), so mirror a real tokenizer's BatchEncoding.
-        return {"input_ids": self.encode(text, **kwargs)}
+    def encode(self, text: str, **kwargs):
+        self._encode_calls += 1
+        self._captured_encode_kwargs = kwargs
+        self._captured_text_len = len(text)
+        self._captured_encode_texts.append(text)
+        return self._encode_text(text, **kwargs)
+
+    def batch_encode_plus(self, texts: list[str], **kwargs):
+        self._batch_encode_calls += 1
+        self._captured_encode_kwargs = kwargs
+        self._captured_batch_texts = list(texts)
+        return {"input_ids": [self._encode_text(text, **kwargs) for text in texts]}
+
+    def __call__(self, texts: str | list[str], **kwargs):
+        if isinstance(texts, str):
+            # BaseRenderer._tokenize_prompt calls the tokenizer via __call__
+            # for single-prompt fallback, so mirror a real BatchEncoding.
+            return {"input_ids": self.encode(texts, **kwargs)}
+
+        self._call_encode_calls += 1
+        self._captured_encode_kwargs = kwargs
+        self._captured_batch_texts = list(texts)
+        return {"input_ids": [self._encode_text(text, **kwargs) for text in texts]}
 
 
 def _build_renderer(
@@ -201,6 +223,112 @@ class TestRenderPrompt:
         assert len(results) == 3
         for text_input, result in zip(text_list_input, results):
             assert len(result["prompt_token_ids"]) == len(text_input)
+        assert renderer.tokenizer._batch_encode_calls == 1
+        assert renderer.tokenizer._encode_calls == 0
+
+    def test_text_list_input_uses_callable_batch_tokenizer(self):
+        renderer = _build_renderer(MockModelConfig())
+        renderer.tokenizer.batch_encode_plus = None
+
+        text_list_input = ["x" * 10, "x" * 12, "x" * 14]
+        prompts = renderer.render_prompts(
+            _preprocess_prompt(renderer.model_config, text_list_input)
+        )
+        results = renderer.tokenize_prompts(
+            prompts,
+            TokenizeParams(max_total_tokens=100),
+        )
+
+        assert len(results) == 3
+        for text_input, result in zip(text_list_input, results):
+            assert len(result["prompt_token_ids"]) == len(text_input)
+        assert renderer.tokenizer._call_encode_calls == 1
+        assert renderer.tokenizer._encode_calls == 0
+
+    def test_text_list_batch_tokenize_failure_does_not_mutate_fallback(self):
+        class PrefixTokenizeParams(TokenizeParams):
+            pre_calls = 0
+            post_calls = 0
+
+            def apply_pre_tokenization(self, tokenizer, prompt):
+                self.pre_calls += 1
+                prompt["prompt"] = "prefix:" + prompt["prompt"]
+                return prompt
+
+            def apply_post_tokenization(self, tokenizer, prompt):
+                self.post_calls += 1
+                return super().apply_post_tokenization(tokenizer, prompt)
+
+        renderer = _build_renderer(MockModelConfig())
+
+        def broken_batch_encode_plus(texts: list[str], **kwargs):
+            renderer.tokenizer._batch_encode_calls += 1
+            renderer.tokenizer._captured_batch_texts = list(texts)
+            return {"input_ids": []}
+
+        renderer.tokenizer.batch_encode_plus = broken_batch_encode_plus
+        text_list_input = ["abc", "def"]
+        prompts = renderer.render_prompts(
+            _preprocess_prompt(renderer.model_config, text_list_input)
+        )
+        params = PrefixTokenizeParams(max_total_tokens=100)
+        results = renderer.tokenize_prompts(prompts, params)
+
+        assert len(results) == 2
+        assert renderer.tokenizer._batch_encode_calls == 1
+        assert renderer.tokenizer._encode_calls == 2
+        assert renderer.tokenizer._captured_batch_texts == [
+            "prefix:abc",
+            "prefix:def",
+        ]
+        assert renderer.tokenizer._captured_encode_texts == [
+            "prefix:abc",
+            "prefix:def",
+        ]
+        assert [prompt["prompt"] for prompt in prompts] == ["abc", "def"]
+        assert params.pre_calls == 2
+        assert params.post_calls == 2
+
+    def test_text_list_malformed_nested_batch_result_uses_fallback(self):
+        renderer = _build_renderer(MockModelConfig())
+
+        def malformed_batch_encode_plus(texts: list[str], **kwargs):
+            return {"input_ids": [[1, 2], 3]}
+
+        renderer.tokenizer.batch_encode_plus = malformed_batch_encode_plus
+        prompts = renderer.render_prompts(
+            _preprocess_prompt(renderer.model_config, ["abc", "def"])
+        )
+
+        results = renderer.tokenize_prompts(
+            prompts,
+            TokenizeParams(max_total_tokens=100),
+        )
+
+        assert [result["prompt_token_ids"] for result in results] == [
+            [0, 1, 2],
+            [0, 1, 2],
+        ]
+        assert renderer.tokenizer._encode_calls == 2
+
+    def test_text_list_batch_tokenizer_type_error_is_not_hidden(self):
+        renderer = _build_renderer(MockModelConfig())
+
+        def buggy_batch_encode_plus(texts: list[str], **kwargs):
+            raise TypeError("unexpected tokenizer implementation bug")
+
+        renderer.tokenizer.batch_encode_plus = buggy_batch_encode_plus
+        prompts = renderer.render_prompts(
+            _preprocess_prompt(renderer.model_config, ["abc", "def"])
+        )
+
+        with pytest.raises(TypeError, match="unexpected tokenizer implementation bug"):
+            renderer.tokenize_prompts(
+                prompts,
+                TokenizeParams(max_total_tokens=100),
+            )
+
+        assert renderer.tokenizer._encode_calls == 0
 
     def test_zero_truncation(self):
         renderer = _build_renderer(MockModelConfig())

--- a/tests/renderers/test_token_offsets.py
+++ b/tests/renderers/test_token_offsets.py
@@ -15,10 +15,27 @@ from vllm.renderers.params import TokenizeParams
 
 @pytest.fixture
 def fast_tokenizer():
-    """gpt2 ships a Fast tokenizer; use it to test the offsets happy path."""
-    from transformers import AutoTokenizer
+    """Build a local fast tokenizer so offset tests never need the network."""
+    from tokenizers import Tokenizer
+    from tokenizers.models import WordLevel
+    from tokenizers.pre_tokenizers import Whitespace
+    from transformers import PreTrainedTokenizerFast
 
-    return AutoTokenizer.from_pretrained("openai-community/gpt2", use_fast=True)
+    backend = Tokenizer(
+        WordLevel(
+            vocab={
+                "[UNK]": 0,
+                "Hello": 1,
+                "world": 2,
+                "Goodbye": 3,
+                ",": 4,
+                ".": 5,
+            },
+            unk_token="[UNK]",
+        )
+    )
+    backend.pre_tokenizer = Whitespace()
+    return PreTrainedTokenizerFast(tokenizer_object=backend, unk_token="[UNK]")
 
 
 def _make_base_renderer_with(tokenizer):
@@ -70,6 +87,53 @@ class TestTokenizePromptOffsets:
         for s, e in offsets:
             assert isinstance(s, int) and isinstance(e, int)
             assert 0 <= s <= e <= text_len
+
+    def test_batch_text_prompts_with_flag_return_offsets(self, fast_tokenizer):
+        renderer = _make_base_renderer_with(fast_tokenizer)
+        params = TokenizeParams(max_total_tokens=None, return_token_offsets=True)
+        prompts = [{"prompt": "Hello, world."}, {"prompt": "Goodbye."}]
+
+        results = renderer.tokenize_prompts(prompts, params)
+
+        assert len(results) == len(prompts)
+        for result, prompt in zip(results, prompts):
+            assert "prompt_token_ids" in result
+            offsets = result["prompt_token_offsets"]
+            assert offsets is not None
+            assert len(offsets) == len(result["prompt_token_ids"])
+            text_len = len(prompt["prompt"])
+            for s, e in offsets:
+                assert isinstance(s, int) and isinstance(e, int)
+                assert 0 <= s <= e <= text_len
+
+    def test_malformed_batch_offsets_fall_back_per_prompt(
+        self, fast_tokenizer, monkeypatch
+    ):
+        renderer = _make_base_renderer_with(fast_tokenizer)
+        params = TokenizeParams(max_total_tokens=None, return_token_offsets=True)
+        prompts = [{"prompt": "Hello, world."}, {"prompt": "Goodbye."}]
+
+        def malformed_batch_encode_plus(texts, **kwargs):
+            return {
+                "input_ids": [[1, 2], [3]],
+                # The first row does not contain one offset per token.
+                "offset_mapping": [[(0, 1)], [(0, 1)]],
+            }
+
+        monkeypatch.setattr(
+            fast_tokenizer,
+            "batch_encode_plus",
+            malformed_batch_encode_plus,
+            raising=False,
+        )
+
+        results = renderer.tokenize_prompts(prompts, params)
+
+        assert len(results) == len(prompts)
+        for result in results:
+            assert len(result["prompt_token_offsets"]) == len(
+                result["prompt_token_ids"]
+            )
 
     def test_base_renderer_without_override_yields_no_offsets(self, fast_tokenizer):
         """A renderer that does not override ``_can_produce_offsets`` never

--- a/vllm/renderers/base.py
+++ b/vllm/renderers/base.py
@@ -6,6 +6,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from concurrent.futures import Executor, ThreadPoolExecutor
 from functools import cached_property
+from numbers import Integral
 from typing import TYPE_CHECKING, Any, Generic, overload
 
 from typing_extensions import TypeVar
@@ -625,7 +626,158 @@ class BaseRenderer(ABC, Generic[_T]):
         prompts: Sequence[DictPrompt],
         params: TokenizeParams,
     ) -> list[TokPrompt]:
+        batch_result = self._batch_tokenize_text_prompts(prompts, params)
+        if batch_result is not None:
+            return batch_result
+
         return [self.tokenize_prompt(prompt, params) for prompt in prompts]
+
+    def _batch_tokenize_text_prompts(
+        self,
+        prompts: Sequence[DictPrompt],
+        params: TokenizeParams,
+    ) -> list[TokPrompt] | None:
+        """Batch-tokenize simple text prompts when the tokenizer supports it."""
+        if params.needs_detokenization:
+            return None
+
+        tokenizer = self.tokenizer
+        if tokenizer is None:
+            return None
+
+        batch_tokenize = getattr(tokenizer, "batch_encode_plus", None)
+        if not callable(batch_tokenize) and callable(tokenizer):
+            batch_tokenize = tokenizer
+        if not callable(batch_tokenize):
+            return None
+
+        text_prompts: list[TextPrompt] = []
+        for prompt in prompts:
+            if "encoder_prompt" in prompt:
+                return None
+            if "prompt_token_ids" in prompt or "prompt_embeds" in prompt:
+                return None
+            if not isinstance(prompt.get("prompt"), str):
+                return None
+            text_prompts.append(prompt)  # type: ignore[arg-type]
+
+        if not text_prompts:
+            return []
+
+        processed_prompts: list[TextPrompt] = []
+        prompt_texts: list[str] = []
+        wants_offsets: list[bool] = []
+        for prompt in text_prompts:
+            prompt = prompt.copy()
+            prompt = params.apply_pre_tokenization(tokenizer, prompt)
+            if not isinstance(prompt.get("prompt"), str):
+                raise TypeError(
+                    "TokenizeParams.apply_pre_tokenization must return a text prompt"
+                )
+            processed_prompts.append(prompt)
+            prompt_texts.append(prompt["prompt"])
+            wants_offsets.append(self._wants_offsets(prompt, params))
+
+        def tokenize_individually() -> list[TokPrompt]:
+            # Pre-tokenization hooks have already run on private prompt copies.
+            # Falling back through tokenize_prompt() would run them twice.
+            return [
+                params.apply_post_tokenization(
+                    tokenizer,
+                    self._tokenize_prompt(prompt, params),
+                )
+                for prompt in processed_prompts
+            ]
+
+        kwargs = params.get_encode_kwargs()
+        if any(wants_offsets):
+            kwargs = {**kwargs, "return_offsets_mapping": True}
+        try:
+            encoded = batch_tokenize(prompt_texts, **kwargs)
+        except NotImplementedError:
+            return tokenize_individually()
+
+        input_ids = (
+            encoded.get("input_ids")
+            if isinstance(encoded, Mapping)
+            else getattr(encoded, "input_ids", None)
+        )
+        if not self._valid_batch_token_ids(input_ids, len(processed_prompts)):
+            return tokenize_individually()
+
+        offset_mappings = None
+        if any(wants_offsets):
+            offset_mappings = (
+                encoded.get("offset_mapping")
+                if isinstance(encoded, Mapping)
+                else getattr(encoded, "offset_mapping", None)
+            )
+            if not self._valid_batch_offsets(offset_mappings, input_ids):
+                return tokenize_individually()
+
+        return [
+            params.apply_post_tokenization(
+                tokenizer,
+                self._build_tokens_prompt(
+                    prompt_token_ids,
+                    prompt,
+                    offset_mapping=(
+                        offset_mappings[i]
+                        if offset_mappings is not None and wants_offsets[i]
+                        else None
+                    ),
+                ),
+            )
+            for i, (prompt, prompt_token_ids) in enumerate(
+                zip(processed_prompts, input_ids)
+            )
+        ]
+
+    @staticmethod
+    def _valid_batch_token_ids(input_ids: Any, batch_size: int) -> bool:
+        if (
+            not isinstance(input_ids, Sequence)
+            or isinstance(input_ids, (str, bytes))
+            or len(input_ids) != batch_size
+        ):
+            return False
+        return all(
+            isinstance(row, Sequence)
+            and not isinstance(row, (str, bytes))
+            and all(
+                isinstance(token_id, Integral) and not isinstance(token_id, bool)
+                for token_id in row
+            )
+            for row in input_ids
+        )
+
+    @staticmethod
+    def _valid_batch_offsets(offsets: Any, input_ids: Sequence[Sequence[int]]) -> bool:
+        if (
+            not isinstance(offsets, Sequence)
+            or isinstance(offsets, (str, bytes))
+            or len(offsets) != len(input_ids)
+        ):
+            return False
+        for row_offsets, row_input_ids in zip(offsets, input_ids):
+            if (
+                not isinstance(row_offsets, Sequence)
+                or isinstance(row_offsets, (str, bytes))
+                or len(row_offsets) != len(row_input_ids)
+            ):
+                return False
+            for span in row_offsets:
+                if (
+                    not isinstance(span, Sequence)
+                    or isinstance(span, (str, bytes))
+                    or len(span) != 2
+                    or any(
+                        not isinstance(position, Integral) or isinstance(position, bool)
+                        for position in span
+                    )
+                ):
+                    return False
+        return True
 
     async def tokenize_prompt_async(
         self,


### PR DESCRIPTION
TARGETED renderer/tokenization overhead improvement discovered while investigating #41390.

## Problem

For short batched offline embedding workloads, `LLM.embed` can spend avoidable time in renderer-side tokenization before requests reach the engine. In the Nemotron embedding repro from #41390, `BaseRenderer.tokenize_prompts` tokenized each simple text prompt with one `tokenizer.encode(...)` call even when the tokenizer supported list/batch tokenization.

This does not explain the entire vLLM vs. Transformers gap. It is a localized vLLM-side overhead in the steady-state renderer/tokenization path for batched text embedding requests.

## Root Cause

The synchronous renderer path always fell back to:

```python
[self.tokenize_prompt(prompt, params) for prompt in prompts]
```

For plain text prompt lists this misses the tokenizer batch fast path. The Nemotron tokenizer used in the issue does not expose `batch_encode_plus`, but it does support being called with `list[str]`.

## Solution

Add a conservative batch-tokenization fast path for simple text prompt lists:

- use `batch_encode_plus` when available;
- otherwise use the tokenizer callable when it accepts `list[str]`;
- preserve `TokenizeParams` pre-tokenization hooks, encode kwargs, and post-tokenization hooks;
- fall back to the existing per-prompt path for token IDs, prompt embeddings, encoder-decoder inputs, detokenization, unsupported tokenizer APIs, or unexpected return shapes.

The change is general to offline renderer tokenization and does not special-case Nemotron.

## A100 validation update (2026-05-06)

Validated on GCP `a2-highgpu-1g`, 1x NVIDIA A100-SXM4-40GB, driver `580.126.20`, CUDA `13.0`, Ubuntu 24.04, Python `3.12.3`, torch `2.11.0+cu130`, transformers `5.7.0`.

Issue model/workload:

- model: `nvidia/llama-nemotron-embed-1b-v2`
- revision: `cefc2394cc541737b7867df197984cf23f05367f`
- prompts: 5,000 deterministic 32-word query-style prompts with `query: ` prefix
- HF baseline: Transformers `AutoTokenizer` + `AutoModel`, attention-mask mean pooling, `F.normalize`
- vLLM path: offline `LLM.embed`, pooling runner, `FLASH_ATTN`, `max_model_len=8192`

Original issue hardware was 3x A100 80GB PCIe, so this is targeted A100 side-effect validation rather than a full original-environment reproduction.

Correctness on 32 prompts:

- shape: `[32, 2048]`
- HF/vLLM row cosine min/mean/max: `0.999825 / 0.999884 / 0.999911`
- HF norm mean: `1.0`
- vLLM norm mean: `1.0`

Side-effect checks on PR head:

- batch path vs forced old per-prompt fallback: cosine min/mean/max `0.999928 / 0.999998 / 1.000000`, max abs diff `0.001110`;
- direct tokenizer check confirmed batch and per-prompt token IDs are identical for the correctness prompts, so the small embedding delta is runtime numeric variance, not tokenization divergence;
- batch sizes `1/8/32/64/128` returned expected output counts;
- `TokensPrompt` matched text input under the same default special-token semantics;
- mixed `[str, TokensPrompt, str]` inputs worked;
- GPU memory stayed flat after warmup: `4139 MiB` repeated across six samples.

Performance on same A100 and same model revision, count `5000`:

| batch | HF baseline s | vLLM base s | vLLM PR head s | vLLM delta |
| ---: | ---: | ---: | ---: | ---: |
| 1 | 81.150 | 27.597 | 27.601 | 0.0% |
| 8 | 10.814 | 8.910 | 8.781 | 1.5% |
| 32 | 3.106 | 4.775 | 4.258 | 10.8% |
| 64 | 2.776 | 4.139 | 3.629 | 12.3% |
| 128 | 2.620 | 3.913 | 3.375 | 13.7% |

Batch-32 internal profile:

| stage | base ms | PR head ms |
| --- | ---: | ---: |
| `pre_process_offline` | 5.155 | 1.547 |
| `render_and_add_requests` | 2.308 | 3.679 |
| `run_engine` | 23.445 | 23.584 |
| `post_process_offline` | 0.011 | 0.011 |
| total | 32.322 | 30.304 |

The PR improves the local renderer/tokenization overhead and large-batch vLLM wall time, but vLLM remains slower than the HF baseline at larger batches on this single-A100 run. This should be treated as `TARGETED`, not as a full fix for #41390.

## Review follow-up addressed (2026-07-12)

Rebased onto upstream `main` at `27c3e579f0e5f345a86e512e26e1231d3689931f`.

- Checks for a missing tokenizer before capability access.
- Runs pre- and post-tokenization hooks exactly once, including malformed-result and unsupported-API fallback.
- Applies hooks to private prompt copies so fallback does not mutate or double-process the originals.
- Falls back only for an explicit `NotImplementedError` or a structurally invalid batch result; unexpected tokenizer `TypeError` and other implementation failures remain visible.
- Validates the full nested token-ID batch shape and every per-token offset row before accepting the fast path.
- Uses a local fast-tokenizer fixture for hermetic offset tests.

## Tests

- `ruff format --check vllm/renderers/base.py tests/renderers/test_completions.py tests/renderers/test_token_offsets.py`
- `ruff check vllm/renderers/base.py tests/renderers/test_completions.py tests/renderers/test_token_offsets.py`
- `python -m py_compile vllm/renderers/base.py tests/renderers/test_completions.py tests/renderers/test_token_offsets.py`
- `HF_HUB_OFFLINE=1 pytest -q tests/renderers/test_completions.py tests/renderers/test_token_offsets.py --confcutdir=tests/renderers` on CPU -> `42 passed`
- `git diff --check`

The A100 performance/correctness measurements above were made on the earlier fast-path head. This follow-up is safety and compatibility hardening; it does not expand the performance claim.

## AI assistance

This change was developed with AI assistance and reviewed locally before submission.