### PR TITLE
Add ROCm QuickReduce quantization min size override

### DIFF
--- a/tests/distributed/test_quick_all_reduce.py
+++ b/tests/distributed/test_quick_all_reduce.py
@@ -11,7 +11,14 @@ import torch.distributed as dist
 
 from vllm import _custom_ops as ops
 from vllm.distributed.communication_op import tensor_model_parallel_all_reduce  # noqa
+from vllm.distributed.device_communicators.quick_all_reduce import (
+    KB,
+    MB,
+    QuickAllReduce,
+    QuickReduceRegime,
+)
 from vllm.distributed.parallel_state import get_tp_group, graph_capture
+from vllm.envs import disable_envs_cache
 from vllm.platforms import current_platform
 
 from ..utils import (
@@ -26,6 +33,112 @@ random.seed(44)
 test_sizes = [random.randint(8 * 1024 * 1024, 10 * 1024 * 1024) for _ in range(8)]
 for i, v in enumerate(test_sizes):
     test_sizes[i] -= v % 8
+
+
+@pytest.fixture
+def envs_cache_disabled():
+    disable_envs_cache()
+    yield
+    disable_envs_cache()
+
+
+def _make_quick_allreduce_for_test(
+    quantization_min_size: int | None,
+) -> QuickAllReduce:
+    quick_reduce = QuickAllReduce.__new__(QuickAllReduce)
+    quick_reduce.disabled = False
+    quick_reduce.qr_max_size = 16 * MB
+    quick_reduce.qr_quant_level = QuickReduceRegime.INT4
+    quick_reduce.qr_quantization_min_size = quantization_min_size
+    quick_reduce.use_fp16_kernels = False
+    quick_reduce.world_size = 2
+    return quick_reduce
+
+
+def test_quick_allreduce_quantization_min_size_env_unset(
+    monkeypatch: pytest.MonkeyPatch,
+    envs_cache_disabled,
+):
+    monkeypatch.delenv(
+        "VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB", raising=False
+    )
+
+    assert QuickAllReduce._get_qr_quantization_min_size() is None
+
+
+def test_quick_allreduce_quantization_min_size_env_converts_kb_to_bytes(
+    monkeypatch: pytest.MonkeyPatch,
+    envs_cache_disabled,
+):
+    monkeypatch.setenv("VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB", "2048")
+
+    assert QuickAllReduce._get_qr_quantization_min_size() == 2048 * KB
+
+
+def test_quick_allreduce_quantization_min_size_env_rejects_negative(
+    monkeypatch: pytest.MonkeyPatch,
+    envs_cache_disabled,
+):
+    monkeypatch.setenv("VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB", "-1")
+
+    with pytest.raises(ValueError, match="must be non-negative"):
+        QuickAllReduce._get_qr_quantization_min_size()
+
+
+def test_quick_allreduce_quantization_min_size_unset_uses_configured_codec():
+    quick_reduce = _make_quick_allreduce_for_test(quantization_min_size=None)
+    inp = torch.empty(8, dtype=torch.float16)
+
+    assert quick_reduce._get_qr_quant_level(inp) == QuickReduceRegime.INT4.value
+
+
+def test_quick_allreduce_quantization_min_size_uses_fp_below_threshold():
+    quick_reduce = _make_quick_allreduce_for_test(quantization_min_size=2048)
+    inp = torch.empty(1024 // 2, dtype=torch.float16)
+
+    assert quick_reduce._get_qr_quant_level(inp) == QuickReduceRegime.FP.value
+
+
+def test_quick_allreduce_quantization_min_size_uses_configured_codec_at_threshold():
+    quick_reduce = _make_quick_allreduce_for_test(quantization_min_size=2048)
+    inp = torch.empty(2048 // 2, dtype=torch.float16)
+
+    assert quick_reduce._get_qr_quant_level(inp) == QuickReduceRegime.INT4.value
+
+
+def test_quick_allreduce_quantization_min_size_does_not_change_eligibility():
+    quick_reduce = _make_quick_allreduce_for_test(quantization_min_size=2 * MB)
+
+    below_builtin_min = torch.empty(MB // 4, dtype=torch.float16)
+    at_builtin_min = torch.empty(MB // 2, dtype=torch.float16)
+
+    assert not quick_reduce.should_quick_allreduce(below_builtin_min)
+    assert quick_reduce.should_quick_allreduce(at_builtin_min)
+
+
+def test_quick_allreduce_passes_dynamic_quant_level(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    quick_reduce = _make_quick_allreduce_for_test(quantization_min_size=2 * KB)
+    quick_reduce._ptr = object()
+    inp = torch.empty(KB // 2, dtype=torch.float16)
+    called_quant_level = None
+
+    def fake_qr_all_reduce(
+        fa,
+        inp,
+        out,
+        quant_level,
+        cast_bf2half,
+    ):
+        nonlocal called_quant_level
+        called_quant_level = quant_level
+
+    monkeypatch.setattr(ops, "qr_all_reduce", fake_qr_all_reduce)
+
+    quick_reduce.quick_all_reduce(inp)
+
+    assert called_quant_level == QuickReduceRegime.FP.value
 
 
 @ray.remote(num_gpus=1, max_calls=1)

--- a/vllm/distributed/device_communicators/quick_all_reduce.py
+++ b/vllm/distributed/device_communicators/quick_all_reduce.py
@@ -39,7 +39,8 @@ class QuickReduceRegime(Enum):
     NONE = 4
 
 
-MB = 1024 * 1024
+KB = 1024
+MB = 1024 * KB
 
 
 class QuickAllReduce:
@@ -175,6 +176,7 @@ class QuickAllReduce:
             )
             return
 
+        self.qr_quantization_min_size = self._get_qr_quantization_min_size()
         if regime_str == "NONE":
             logger.debug(
                 "Custom quick allreduce is disabled based "
@@ -219,6 +221,18 @@ class QuickAllReduce:
         self.qr_max_size = qr_max_size if qr_max_size is not None else ops.qr_max_size()
         self.create_shared_buffer()
         self.disabled = False
+
+    @staticmethod
+    def _get_qr_quantization_min_size() -> int | None:
+        quantization_min_size = envs.VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB
+        if quantization_min_size is None:
+            return None
+        if quantization_min_size < 0:
+            raise ValueError(
+                "VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB must be "
+                f"non-negative, got {quantization_min_size}"
+            )
+        return quantization_min_size * KB
 
     def _rocm_arch_available(self):
         if not current_platform.is_rocm():
@@ -274,9 +288,18 @@ class QuickAllReduce:
         if out is None:
             out = torch.empty_like(inp)
         ops.qr_all_reduce(
-            self._ptr, inp, out, self.qr_quant_level.value, self.use_fp16_kernels
+            self._ptr, inp, out, self._get_qr_quant_level(inp), self.use_fp16_kernels
         )
         return out
+
+    def _get_qr_quant_level(self, inp: torch.Tensor) -> int:
+        quantization_min_size = self.qr_quantization_min_size
+        if (
+            quantization_min_size is not None
+            and inp.numel() * inp.element_size() < quantization_min_size
+        ):
+            return QuickReduceRegime.FP.value
+        return self.qr_quant_level.value
 
     def close(self):
         if not self.disabled and getattr(self, "_ptr", None):

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -202,6 +202,7 @@ if TYPE_CHECKING:
     ] = "NONE"
     VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16: bool = True
     VLLM_ROCM_QUICK_REDUCE_MAX_SIZE_BYTES_MB: int | None = None
+    VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB: int | None = None
     VLLM_NIXL_ABORT_REQUEST_TIMEOUT: int = 480
     VLLM_MORIIO_CONNECTOR_READ_MODE: bool = False
     VLLM_MORIIO_QP_PER_TRANSFER: int = 1
@@ -1101,6 +1102,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # communication.
     "VLLM_ROCM_QUICK_REDUCE_MAX_SIZE_BYTES_MB": lambda: maybe_convert_int(
         os.environ.get("VLLM_ROCM_QUICK_REDUCE_MAX_SIZE_BYTES_MB", None)
+    ),
+    # Custom quick allreduce kernel for MI3* cards.
+    # Controls the minimum tensor size (KB, where 1 KB = 1024 bytes) required
+    # to use the configured QuickReduce codec. Smaller tensors use FP
+    # QuickReduce. This does not affect QuickReduce eligibility.
+    "VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB": lambda: maybe_convert_int(
+        os.environ.get("VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB", None)
     ),
     # Divisor for dynamic query scale factor calculation for FP8 KV Cache
     "Q_SCALE_CONSTANT": lambda: int(os.getenv("Q_SCALE_CONSTANT", "200")),


### PR DESCRIPTION
## Summary

- Add `VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB` to control when QuickReduce uses the configured codec.
- Preserve existing behavior when the env var is unset.
- Use FP QuickReduce below the configured threshold, and the configured QuickReduce codec at or above the threshold.

This PR is intended to compose with #41675. That PR controls when a tensor is eligible for QuickReduce; this PR only selects the codec after QuickReduce has already been selected. QuickReduce eligibility still follows the existing `_QR_MIN_SIZE` table, or the effective min-size override from #41675 when configured.

The motivation is that quantized QuickReduce has fixed codec overhead from packing and unpacking. For small tensors, that overhead can outweigh the bandwidth savings from quantization. This env var lets users keep FP QuickReduce for smaller messages while using the configured quantized codec, such as `INT4`, for larger messages.


## Benchmark Data
**Model:** MiniMaxAI/MiniMax-M2.5 (hidden_size=3072, 62 layers, 256 experts/8 active, FP8 weights, BF16 activations)  
**Hardware:** 4× MI355X (XGMI), vLLM 0.18.0  
**Server:** `--max-num-seqs 512 --max-num-batched-tokens 32768 --compilation-config mode=3`  
**Base env:** `VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4`, `VLLM_ROCM_QUICK_REDUCE_CAST_BF16_TO_FP16=True`
### Configurations
| | Baseline | Case 1 | Case 2 |
|---|---|---|---|
| `VLLM_ROCM_QUICK_REDUCE_MIN_SIZE_BYTES_MB` | unset (default table) | **0** | **0** |
| `VLLM_ROCM_QUICK_REDUCE_QUANTIZATION_MIN_SIZE_KB` | unset | unset | **2048** |


### Results: Median TPOT (ms)
| Sweep | Baseline | Case 1 | Δ vs base | Case 2 | Δ vs base |
|---|---|---|---|---|---|
| 1000/100 c16 | 13.40 | 15.83 | +18.1% | 13.94 | +4.0% |
| 1000/100 c256 | 41.63 | 40.39 | -3.0% | 38.97 | **-6.4%** |
| 1000/100 c512 | 75.74 | 77.31 | +2.1% | 66.11 | **-12.7%** |
| 5000/500 c16 | 14.61 | 17.05 | +16.7% | 15.19 | +4.0% |
| 5000/500 c256 | 63.12 | 63.75 | +1.0% | 63.01 | -0.2% |
| 5000/500 c512 | 119.92 | 120.28 | +0.3% | 120.99 | +0.9% |
| **Geomean** | **40.89** | **43.16** | **+5.55%** | **40.10** | **-1.92%** |


### Results: Output Token Throughput (tok/s)
| Sweep | Baseline | Case 1 | Δ vs base | Case 2 | Δ vs base |
|---|---|---|---|---|---|
| 1000/100 c16 | 962.01 | 819.96 | -14.8% | 947.03 | -1.6% |
| 1000/100 c256 | 4480.71 | 4365.73 | -2.6% | 4355.36 | -2.8% |
| 1000/100 c512 | 5382.48 | 5291.22 | -1.7% | 5357.56 | -0.5% |
| 5000/500 c16 | 996.60 | 863.11 | -13.4% | 951.27 | -4.5% |
| 5000/500 c256 | 3719.52 | 3681.91 | -1.0% | 3673.44 | -1.2% |
| 5000/500 c512 | 4052.87 | 4047.98 | -0.1% | 4054.44 | +0.0% |
| **Geomean** | **2652.85** | **2499.18** | **-5.79%** | **2605.82** | **-1.77%** |


### Analysis

- **Case 1** (`MIN_SIZE_BYTES_MB=0` only): Forces all tensors through QR INT4 regardless of size. The INT4 codec pack/unpack overhead dominates on small tensors (96 KB at c16), causing **+5.6% geomean TPOT regression** and **-5.8% throughput loss**. This demonstrates that lowering the QuickReduce eligibility floor without a codec threshold is harmful.

- **Case 2** (`MIN_SIZE_BYTES_MB=0` + `QUANTIZATION_MIN_SIZE_KB=2048`): Uses FP QuickReduce below 2048 KB and INT4 above. This avoids the INT4 codec overhead on small tensors while still enabling QuickReduce for medium tensors that benefit from it. Result: **-1.9% geomean TPOT improvement** with up to **-12.7% TPOT at high concurrency** (1000/100 c512).

`QUANTIZATION_MIN_SIZE_KB` (#41679) is essential when using `MIN_SIZE_BYTES_MB` (#41675) to lower the QR floor. Without it, the codec overhead makes the override counterproductive. Together, they enable targeted TPOT improvements at medium-to-high concurrency decode workloads.
