### PR TITLE
Support bf16 for mamba ssm cache

### DIFF
--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -32,7 +32,7 @@ CacheDType = Literal[
     "fp8_per_token_head",
     "nvfp4",
 ]
-MambaDType = Literal["auto", "float32", "float16"]
+MambaDType = Literal["auto", "float32", "float16", "bfloat16"]
 MambaCacheMode = Literal["all", "align", "none"]
 PrefixCachingHashAlgo = Literal["sha256", "sha256_cbor", "xxhash", "xxhash_cbor"]
 KVOffloadingBackend = Literal["native", "lmcache"]


### PR DESCRIPTION
Will be used in tpu-inference

## Purpose
Adding the option to choose bf16 for mamba ssm cache. This will be consumed by tpu-inference and other use cases.

## Test Plan
Validate in tpu-inference.

## Test Result
Validated in tpu-inference
