### PR TITLE
Keep first/last n token in high precision for nvfp4 kv cache

### DIFF
--- a/docs/features/quantization/quantized_kvcache.md
+++ b/docs/features/quantization/quantized_kvcache.md
@@ -49,6 +49,32 @@ You can configure how the quantization scales are computed in vLLM using three d
 - `kv_cache_dtype="fp8_e4m3"`: Supported on CUDA 11.8+ and ROCm (AMD GPUs)
 - `kv_cache_dtype="fp8_e5m2"`: Supported on CUDA 11.8+
 
+### Skipping Specific Layers from KV-Cache Quantization
+
+Some attention layer types (e.g. sliding-window) are more sensitive to KV-cache quantization. The `--kv-cache-dtype-skip-layers` flag leaves the specified layers at the model's native dtype while keeping the rest of the layers under the chosen quantized dtype. The flag accepts either layer indices or layer-type names:
+
+```bash
+# Skip every sliding-window attention layer.
+vllm serve <model> \
+  --kv-cache-dtype fp8 \
+  --kv-cache-dtype-skip-layers sliding_window
+
+# Skip specific layer indices.
+vllm serve <model> \
+  --kv-cache-dtype fp8 \
+  --kv-cache-dtype-skip-layers 0 1 23
+```
+
+Programmatic usage:
+
+```python
+llm = LLM(
+    model="meta-llama/Llama-3.1-8B-Instruct",
+    kv_cache_dtype="fp8",
+    kv_cache_dtype_skip_layers=["sliding_window"],
+)
+```
+
 ---
 
 ## Examples

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2270,6 +2270,50 @@ def test_check_enough_kv_cache_memory_respects_num_gpu_blocks_override():
         get_kv_cache_configs(vllm_config, [kv_cache_specs], [large_available_memory])
 
 
+def test_unify_kv_cache_spec_page_size_scales_attention_block_size():
+    small_spec = new_kv_cache_spec(
+        block_size=16, num_kv_heads=1, head_size=8, dtype=torch.float32
+    )
+    large_spec = new_kv_cache_spec(
+        block_size=16, num_kv_heads=1, head_size=16, dtype=torch.float32
+    )
+
+    unified = kv_cache_utils.unify_kv_cache_spec_page_size(
+        {
+            "small": small_spec,
+            "large": large_spec,
+        }
+    )
+
+    assert unified["small"].page_size_bytes == large_spec.page_size_bytes
+    assert unified["small"].block_size == small_spec.block_size * 2
+    assert unified["large"] == large_spec
+
+
+def test_unify_kv_cache_spec_page_size_pads_mamba_spec():
+    mamba_spec = new_mamba_spec(
+        block_size=32,
+        shapes=((64,),),
+        dtypes=(torch.float32,),
+        page_size_padded=None,
+    )
+    attention_spec = new_kv_cache_spec(
+        block_size=16, num_kv_heads=1, head_size=16, dtype=torch.float32
+    )
+
+    unified = kv_cache_utils.unify_kv_cache_spec_page_size(
+        {
+            "mamba": mamba_spec,
+            "attention": attention_spec,
+        }
+    )
+
+    assert unified["mamba"].page_size_bytes == attention_spec.page_size_bytes
+    assert unified["mamba"].block_size == mamba_spec.block_size
+    assert unified["mamba"].page_size_padded == attention_spec.page_size_bytes
+    assert unified["attention"] == attention_spec
+
+
 def test_unify_hybrid_kv_cache_specs():
     # 1. has_full_attention and has_sliding_window
     before_spec_1 = new_kv_cache_spec()

--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -2290,6 +2290,42 @@ def test_unify_kv_cache_spec_page_size_scales_attention_block_size():
     assert unified["large"] == large_spec
 
 
+def test_unify_kv_cache_spec_page_size_pads_padded_attention_spec():
+    # A padded attention spec (e.g. mixed-precision sibling) co-existing with a
+    # larger non-padded attention spec must bump ONLY its ``page_size_padded``
+    # to the unified target while keeping ``block_size`` intact. Scaling
+    # ``block_size`` here would break the kernel-block view in the model
+    # runner: the runner stamps ``page_size_padded`` as the per-row stride
+    # over kernel-blocks, so scaling both would make that stride
+    # ``ratio``× too large and overshoot the actual storage.
+    natural_page = (
+        2 * 16 * 1 * 8 * 4
+    )  # 1024 bytes (K+V * block_size * heads * head_size * dtype)
+    padded_spec = new_kv_cache_spec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=8,
+        dtype=torch.float32,
+        page_size_padded=natural_page,
+    )
+    large_spec = new_kv_cache_spec(
+        block_size=16, num_kv_heads=1, head_size=32, dtype=torch.float32
+    )
+
+    unified = kv_cache_utils.unify_kv_cache_spec_page_size(
+        {
+            "padded": padded_spec,
+            "large": large_spec,
+        }
+    )
+
+    # large_spec.page_size_bytes = 2*16*1*32*4 = 4096.
+    assert unified["padded"].page_size_bytes == large_spec.page_size_bytes
+    assert unified["padded"].block_size == padded_spec.block_size
+    assert unified["padded"].page_size_padded == large_spec.page_size_bytes
+    assert unified["large"] == large_spec
+
+
 def test_unify_kv_cache_spec_page_size_pads_mamba_spec():
     mamba_spec = new_mamba_spec(
         block_size=32,

--- a/vllm/config/attention.py
+++ b/vllm/config/attention.py
@@ -74,6 +74,20 @@ class AttentionConfig:
     If None, uses the default (kv_cache_block_size on PyTorch >= 2.9,
     128 otherwise)."""
 
+    mixed_kv_n_tokens: int = 0
+    """Mixed-precision KV cache: number of tokens kept in a higher-precision sibling
+    cache, while the bulk history stays in the primary (e.g. NVFP4) KV cache. Set to 0
+    (default) to disable. Currently supported only with nvfp4 kv cache on the FlashInfer
+    TRTLLM-gen backend."""
+
+    mixed_kv_dtype: Literal["fp8", "bf16"] = "fp8"
+    """Dtype of the mixed-precision sibling cache."""
+
+    mixed_kv_location: Literal["first", "last"] = "last"
+    """Position of the high-precision tier within each sequence:
+    - `last`: the most-recent N tokens.
+    - `first`: pin the first N tokens."""
+
     def compute_hash(self) -> str:
         """
         Provide a hash that uniquely identifies all the configs

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -2105,6 +2105,19 @@ class VllmConfig:
         return self
 
     @model_validator(mode="after")
+    def validate_mixed_kv_cache_with_dcp(self) -> "VllmConfig":
+        if (
+            self.attention_config.mixed_kv_n_tokens > 0
+            and self.parallel_config.decode_context_parallel_size > 1
+        ):
+            raise ValueError(
+                "Mixed-precision KV cache is not supported with decode context "
+                "parallelism. Set mixed_kv_n_tokens=0 or use "
+                "decode_context_parallel_size=1."
+            )
+        return self
+
+    @model_validator(mode="after")
     def validate_mamba_block_size(self) -> "VllmConfig":
         if self.model_config is None:
             return self

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -91,6 +91,22 @@ def should_load_quant_weights(quant_method: QuantizeMethodBase | None) -> bool:
     )
 
 
+def _smallest_kernel_block(
+    attn_backend: "type[AttentionBackend]", fallback: int
+) -> int:
+    """Smallest int kernel block size the backend supports."""
+    from vllm.v1.attention.backend import MultipleOf
+
+    sizes = attn_backend.get_supported_kernel_block_sizes()
+    ints = [s for s in sizes if isinstance(s, int)]
+    if ints:
+        return min(ints)
+    multiples = [s.base for s in sizes if isinstance(s, MultipleOf)]
+    if multiples:
+        return min(multiples)
+    return fallback
+
+
 def set_default_quant_scales(layer: nn.Module, register_buffer: bool = False) -> None:
     """Sets default quantization scales for the layer."""
     if register_buffer:
@@ -564,18 +580,29 @@ class Attention(nn.Module, AttentionLayerBase):
         # Should not be called for enc-dec or encoder-only attention.
         assert self.attn_type == AttentionType.DECODER
         quant_mode = get_kv_quant_mode(self.kv_cache_dtype)
+        # Backend's supported kernel block sizes — carry on the spec so the
+        # page-size unification pass can read it without needing to look the
+        # layer up in ``static_forward_context`` (which doesn't exist in the
+        # engine-core process when running under MultiprocExecutor).
+        kernel_blocks = tuple(self.attn_backend.get_supported_kernel_block_sizes())
         if self.sliding_window is not None:
             assert not vllm_config.model_config.use_mla, (
                 "MLA is not supported for slidingwindow"
             )
+            # SW chooses its own block_size (starts at the backend's smallest
+            # kernel-supported size) so the user's ``--block-size`` only
+            # constrains primary attention. ``unify_kv_cache_spec_page_size``
+            # decides the final value via clean-scale or padding.
+            sw_block_size = _smallest_kernel_block(self.attn_backend, block_size)
             return SlidingWindowSpec(
-                block_size=block_size,
+                block_size=sw_block_size,
                 num_kv_heads=self.num_kv_heads,
                 head_size=self.head_size,
                 head_size_v=self.head_size_v,
                 dtype=self.kv_cache_torch_dtype,
                 kv_quant_mode=quant_mode,
                 sliding_window=self.sliding_window,
+                supported_kernel_block_sizes=kernel_blocks,
             )
         elif self.kv_cache_dtype.startswith("turboquant_"):
             from vllm.model_executor.layers.quantization.turboquant.config import (
@@ -593,6 +620,7 @@ class Attention(nn.Module, AttentionLayerBase):
                 head_size_v=self.head_size,
                 dtype=self.kv_cache_torch_dtype,
                 tq_slot_size=tq_config.slot_size_aligned,
+                supported_kernel_block_sizes=kernel_blocks,
             )
         else:
             return FullAttentionSpec(
@@ -602,6 +630,7 @@ class Attention(nn.Module, AttentionLayerBase):
                 head_size_v=self.head_size_v,
                 dtype=self.kv_cache_torch_dtype,
                 kv_quant_mode=quant_mode,
+                supported_kernel_block_sizes=kernel_blocks,
             )
 
 

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -36,6 +36,10 @@ from vllm.v1.attention.backend import (
     AttentionMetadata,
     AttentionType,
 )
+from vllm.v1.attention.backends.mixed_precision_kv import (
+    MixedPrecisionKVCache,
+    mixed_kv_layer_prefix,
+)
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.selector import get_attn_backend
 from vllm.v1.kv_cache_interface import (
@@ -380,20 +384,76 @@ class Attention(nn.Module, AttentionLayerBase):
             if block_n is not None:
                 extra_impl_args.setdefault("block_n", block_n)
 
-        impl_cls = self.attn_backend.get_impl_cls()
-        self.impl = impl_cls(  # type: ignore[assignment]  # impl_cls always returns an AttentionImpl subclass
-            num_heads,
-            head_size,
-            scale,
-            num_kv_heads,
-            alibi_slopes,
-            sliding_window,
-            kv_cache_dtype,
-            logits_soft_cap,
-            attn_type,
-            kv_sharing_target_layer_name,
-            **extra_impl_args,
+        # Mixed-precision KV cache: NVFP4 bulk + higher-precision sibling for
+        # the first-N or last-N tokens. When enabled we construct
+        # ``MixedPrecisionFlashInferImpl`` (subclass of ``FlashInferImpl``)
+        # so the dual-kernel decode path is selected via the impl's type
+        # rather than monkey-patched attributes.
+        attn_cfg = vllm_config.attention_config
+        mixed_kv_n_tokens = attn_cfg.mixed_kv_n_tokens
+        # Mixed-KV is for full-attention layers only.
+        mixed_kv_enabled = (
+            mixed_kv_n_tokens > 0
+            and kv_cache_dtype == "nvfp4"
+            and kv_sharing_target_layer_name is None
+            and self.attn_backend.get_name() == "FLASHINFER"
+            and sliding_window is None
         )
+
+        impl_cls = self.attn_backend.get_impl_cls()
+        self.mixed_kv_cache: MixedPrecisionKVCache | None = None
+        if mixed_kv_enabled:
+            assert cache_config is not None, (
+                "Mixed-precision KV cache requires a CacheConfig."
+            )
+            sibling_prefix = mixed_kv_layer_prefix(prefix)
+            # Import locally to avoid pulling FlashInfer at module load on
+            # platforms where it isn't installed (this branch only fires
+            # when the FlashInfer backend was selected above).
+            from vllm.v1.attention.backends.flashinfer import (
+                MixedPrecisionFlashInferImpl,
+            )
+
+            self.impl = MixedPrecisionFlashInferImpl(  # type: ignore[assignment]
+                num_heads,
+                head_size,
+                scale,
+                num_kv_heads,
+                alibi_slopes,
+                sliding_window,
+                kv_cache_dtype,
+                logits_soft_cap,
+                attn_type,
+                kv_sharing_target_layer_name,
+                **extra_impl_args,
+                mixed_kv_cache_prefix=sibling_prefix,
+                mixed_kv_n_tokens=mixed_kv_n_tokens,
+                mixed_kv_location=attn_cfg.mixed_kv_location,
+                mixed_kv_dtype=attn_cfg.mixed_kv_dtype,
+            )
+            self.mixed_kv_cache = MixedPrecisionKVCache(
+                head_size=head_size,
+                num_kv_heads=num_kv_heads,
+                n_tokens=mixed_kv_n_tokens,
+                dtype=attn_cfg.mixed_kv_dtype,
+                location=attn_cfg.mixed_kv_location,
+                prefix=sibling_prefix,
+                cache_config=cache_config,
+            )
+        else:
+            self.impl = impl_cls(  # type: ignore[assignment]  # impl_cls always returns an AttentionImpl subclass
+                num_heads,
+                head_size,
+                scale,
+                num_kv_heads,
+                alibi_slopes,
+                sliding_window,
+                kv_cache_dtype,
+                logits_soft_cap,
+                attn_type,
+                kv_sharing_target_layer_name,
+                **extra_impl_args,
+            )
         self.backend = AttentionBackendEnum[self.attn_backend.get_name()]
         self.dtype = dtype
 
@@ -444,6 +504,13 @@ class Attention(nn.Module, AttentionLayerBase):
                 if is_per_head
                 else GroupShape.PER_TENSOR,
             )
+
+        # BF16 sibling reads the query unquantized — skip the outer
+        # auto-quantize. We still want ``self.query_quant`` *built* above so
+        # the impl can inline-quantize Q for the NVFP4 call; the flip has to
+        # happen *after* that build, hence the post-construction patch.
+        if self.mixed_kv_cache is not None and attn_cfg.mixed_kv_dtype == "bf16":
+            self.impl.supports_quant_query_input = False
 
     def forward(
         self,

--- a/vllm/v1/attention/backend.py
+++ b/vllm/v1/attention/backend.py
@@ -45,11 +45,15 @@ class AttentionType(str, Enum):
     """Attention between dec. Q and enc. K/V for encoder-decoder."""
 
 
+@dataclass(frozen=True)
 class MultipleOf:
-    base: int
+    """Marker for a kernel block size that must be any positive multiple of
+    ``base``. Frozen so two instances with the same ``base`` compare equal and
+    hash to the same value — needed for spec equality across layers in the
+    same KV cache group.
+    """
 
-    def __init__(self, base: int):
-        self.base = base
+    base: int
 
 
 class AttentionBackend(ABC):

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -4,7 +4,7 @@
 
 from dataclasses import dataclass
 from functools import partial
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 import numpy as np
 import torch
@@ -80,6 +80,9 @@ FLASHINFER_WORKSPACE_BUFFER_SIZE_BATCH_INVARIANT = 2048 * 1024 * 1024
 
 FP8_DTYPE = current_platform.fp8_dtype()
 FP4_DTYPE = torch.uint8
+
+# trtllm-gen FMHA writes LSE in base 2; merge_attn_states uses expf (base e).
+_LN2 = 0.6931471805599453
 
 logger = init_logger(__name__)
 
@@ -1268,8 +1271,8 @@ class FlashInferImpl(AttentionImpl):
         sliding_window: int | None,
         kv_cache_dtype: str,
         logits_soft_cap: float | None = None,
-        attn_type: AttentionType = AttentionType.DECODER,
-        kv_sharing_target_layer_name: int | None = None,
+        attn_type: str = AttentionType.DECODER,
+        kv_sharing_target_layer_name: str | None = None,
         sinks: torch.Tensor | None = None,
     ) -> None:
         self.num_heads = num_heads
@@ -1850,6 +1853,502 @@ class FlashInferImpl(AttentionImpl):
                 layer._k_scale,
                 layer._v_scale,
             )
+
+
+class MixedPrecisionFlashInferImpl(FlashInferImpl):
+    """FlashInferImpl variant for NVFP4 primary + higher-precision sibling KV.
+
+    Owns:
+    - The four ``mixed_kv_*`` config attributes, set explicitly in
+      ``__init__`` (no monkey-patching from ``Attention.__init__``).
+    - Pre-allocated decode scratch (``_mixed_out_a/b``, ``_mixed_lse_a/b``)
+      sized for cuda-graph capture/replay.
+    - Override ``forward`` to run the dual-kernel decode (NVFP4 + sibling)
+      merged via LSE, with NVFP4-only prefill.
+    - Override ``do_kv_cache_update`` to also write the sibling cache.
+    - Override ``fused_output_quant_supported`` to advertise FP8 only.
+    """
+
+    def __init__(
+        self,
+        num_heads: int,
+        head_size: int,
+        scale: float,
+        num_kv_heads: int,
+        alibi_slopes: list[float] | None,
+        sliding_window: int | None,
+        kv_cache_dtype: str,
+        logits_soft_cap: float | None = None,
+        attn_type: str = AttentionType.DECODER,
+        kv_sharing_target_layer_name: str | None = None,
+        sinks: torch.Tensor | None = None,
+        *,
+        mixed_kv_cache_prefix: str,
+        mixed_kv_n_tokens: int,
+        mixed_kv_location: Literal["first", "last"],
+        mixed_kv_dtype: Literal["fp8", "bf16"],
+    ) -> None:
+        assert kv_cache_dtype == "nvfp4", (
+            "MixedPrecisionFlashInferImpl requires NVFP4 primary cache; "
+            f"got kv_cache_dtype={kv_cache_dtype!r}."
+        )
+        assert kv_sharing_target_layer_name is None, (
+            "Mixed-precision KV does not support cross-layer KV sharing."
+        )
+        super().__init__(
+            num_heads=num_heads,
+            head_size=head_size,
+            scale=scale,
+            num_kv_heads=num_kv_heads,
+            alibi_slopes=alibi_slopes,
+            sliding_window=sliding_window,
+            kv_cache_dtype=kv_cache_dtype,
+            logits_soft_cap=logits_soft_cap,
+            attn_type=attn_type,
+            kv_sharing_target_layer_name=kv_sharing_target_layer_name,
+            sinks=sinks,
+        )
+        self.mixed_kv_cache_prefix = mixed_kv_cache_prefix
+        self.mixed_kv_n_tokens = mixed_kv_n_tokens
+        self.mixed_kv_location = mixed_kv_location
+        self.mixed_kv_dtype = mixed_kv_dtype
+
+        # Pre-allocated dual-kernel decode scratch. Stable addresses so
+        # cuda-graph capture/replay sees the same buffers on every run.
+        # Zero-init: when the NVFP4 pass is skipped (every request fits in
+        # the high-precision window) we deselect partial A via
+        # ``lse_a = -inf`` and rely on ``0 * out_a = 0`` in the LSE merge.
+        # Bytes 0x7F/0xFF in FP8-E4M3FN decode to NaN -- without zero-init,
+        # ``0 * NaN = NaN`` would propagate into the output.
+        vllm_config = get_current_vllm_config_or_none()
+        assert vllm_config is not None, (
+            "MixedPrecisionFlashInferImpl needs a vllm_config to size "
+            "the decode scratch buffers."
+        )
+        max_num_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+        self._mixed_out_a = torch.zeros(
+            (max_num_tokens, num_heads, head_size),
+            dtype=FP8_DTYPE,
+            device="cuda",
+        )
+        # Sibling output dtype follows the sibling cache: FP8 for FP8
+        # sibling (trtllm-gen forces FP8 output when KV is FP8), or the
+        # model dtype (typically BF16) for BF16 sibling.
+        sibling_out_dtype = (
+            FP8_DTYPE if mixed_kv_dtype == "fp8" else vllm_config.model_config.dtype
+        )
+        self._mixed_out_b = torch.zeros(
+            (max_num_tokens, num_heads, head_size),
+            dtype=sibling_out_dtype,
+            device="cuda",
+        )
+        self._mixed_lse_a = torch.zeros(
+            (max_num_tokens, num_heads),
+            dtype=torch.float32,
+            device="cuda",
+        )
+        self._mixed_lse_b = torch.zeros_like(self._mixed_lse_a)
+
+    def fused_output_quant_supported(self, quant_key: QuantKey):
+        # NVFP4 output quant is unsupported on the mixed path (the merge
+        # step is FP8 / model-dtype). Restrict to FP8 only.
+        return (
+            self.support_trtllm_attn
+            and is_quantized_kv_cache(self.kv_cache_dtype)
+            and quant_key == kFp8StaticTensorSym
+        )
+
+    def forward(
+        self,
+        layer: torch.nn.Module,
+        query: torch.Tensor,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        attn_metadata: FlashInferMetadata,
+        output: torch.Tensor,
+        output_scale: torch.Tensor | None = None,
+        output_block_scale: torch.Tensor | None = None,
+    ) -> torch.Tensor:
+        """Mixed-precision attention: NVFP4 primary + sibling cache.
+
+        DECODE: dual-kernel path. The trtllm-gen decode kernel is invoked twice per
+        layer:
+
+        * Once on the sibling cache with ``seq_lens`` clipped to ``min(seq_len,
+          n_tokens)``. The sibling owns the first or last N tokens per
+          ``mixed_kv_location``; its block_table comes from the FirstNManager
+          (location='first') or sliding-window manager (location='last') and naturally
+          points at those tokens.
+        * Once on the NVFP4 cache with ``seq_lens`` clipped to ``max(0, seq_len -
+          n_tokens)`` (NVFP4 covers the complement). For ``location='first'`` the NVFP4
+          block_table is additionally sliced to drop the first ``n_tokens / block_size``
+          blocks so the kernel reads positions ``[n_tokens, seq_len)``.
+
+        Each call returns its partial attention output and per-token LSE. The two are
+        recombined via ``merge_attn_states`` (log-sum-exp recombination) so each token
+        is attended exactly once across the pair — no double-counting.
+
+        PREFILL: NVFP4-only. Prefill reads from NVFP4 only (which holds the entire
+        history). The sibling cache is still WRITTEN during prefill, so decode
+        immediately benefits.
+
+        Limitations:
+          * Fused output quant supports FP8 only (no NVFP4 output quant).
+          * No cascade attention.
+          * No DCP.
+          * ``mixed_kv_dtype`` ∈ {'fp8', 'bf16'}. BF16 sibling reads/ writes
+            unquantized; we leave the query unquantized at the outer layer (by flipping
+            ``supports_quant_query_input`` to False) and inline-quantize Q only for the
+            NVFP4 call here.
+        """
+        from vllm.model_executor.layers.attention.attention import (
+            get_attention_context,
+        )
+        from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
+
+        if attn_metadata is None:
+            return output.fill_(0)
+        # ---------- guards ----------
+        if attn_metadata.use_cascade:
+            raise NotImplementedError(
+                "Mixed-precision KV (NVFP4 primary + sibling) does not support "
+                "cascade attention."
+            )
+        if self.dcp_world_size > 1:
+            raise NotImplementedError(
+                "Mixed-precision KV (NVFP4 primary + sibling) does not yet support "
+                "decode context parallelism."
+            )
+        if output_scale is None:
+            assert output_block_scale is None, (
+                "output_block_scale is not supported when fusion has not happened"
+            )
+        else:
+            if output.dtype != FP8_DTYPE:
+                raise NotImplementedError(
+                    "Mixed-precision KV only supports fused FP8 output "
+                    "quantization. NVFP4 output quantization is not supported."
+                )
+            assert output_block_scale is None, (
+                "output_block_scale should not be provided for fp8 output"
+            )
+            if layer._o_scale_float is None:
+                layer._o_scale_float = output_scale.cpu().item()
+
+        # ---------- per-step setup (mirrors existing forward) ----------
+        # NVFP4 cache always sees an FP8 query, so its bmm scales include
+        # the q/k/v quantization factors. The sibling cache scales depend
+        # on its dtype: FP8 sibling = same as NVFP4 (Q is FP8, KV is FP8);
+        # BF16 sibling = pure sm_scale (Q is BF16, KV is BF16, no
+        # quantization scales involved).
+        if self.bmm1_scale is None:
+            self.bmm1_scale = self.scale * layer._q_scale_float * layer._k_scale_float
+        if self.bmm2_scale is None:
+            self.bmm2_scale = layer._v_scale_float
+        if self.mixed_kv_dtype == "fp8":
+            sibling_bmm1_scale = self.bmm1_scale
+            sibling_bmm2_scale = self.bmm2_scale
+        else:  # bf16
+            sibling_bmm1_scale = self.scale
+            sibling_bmm2_scale = 1.0
+
+        # ---------- look up sibling cache + metadata ----------
+        n_tokens = self.mixed_kv_n_tokens
+        sibling_meta, _sibling_layer, sibling_kv_cache, _ = get_attention_context(
+            self.mixed_kv_cache_prefix
+        )
+        assert sibling_meta is not None, (
+            "Mixed-KV metadata missing — sibling cache layer must be "
+            "registered with the KVCacheManager."
+        )
+
+        num_actual_tokens = attn_metadata.num_actual_tokens
+        num_decode_tokens = attn_metadata.num_decode_tokens
+        num_prefill_tokens = attn_metadata.num_prefill_tokens
+        num_decodes = attn_metadata.num_decodes
+        num_prefills = attn_metadata.num_prefills
+
+        # First-N alignment gate. ``location='first'`` truncates the primary
+        # block_table by ``skip_blocks = n_tokens // nvfp4_block_size``;
+        # ``n_tokens`` must be an exact multiple of the *post-unify* primary
+        # block_size or decode either double-counts the prefix or silently
+        # widens the sibling window. ``kv_cache.shape[2]`` is the actual
+        # value after platform bumping and ``unify_kv_cache_spec_page_size``.
+        nvfp4_block_size = kv_cache.shape[2]
+        if self.mixed_kv_location == "first" and n_tokens % nvfp4_block_size != 0:
+            raise ValueError(
+                f"mixed_kv_n_tokens={n_tokens} must be a multiple of the "
+                f"post-unify NVFP4 primary block_size={nvfp4_block_size} "
+                f"for mixed_kv_location='first'. Use a multiple of "
+                f"{nvfp4_block_size}, or use mixed_kv_location='last' "
+                "(no alignment constraint)."
+            )
+        kv_cache_fp = kv_cache.view(
+            FlashInferBackend.get_dtype_for_flashinfer(self.kv_cache_dtype)
+        )
+        stride_order = FlashInferBackend.get_kv_cache_stride_order()
+        kv_cache_permute = kv_cache_fp.permute(*stride_order)
+        nvfp4_data, nvfp4_scales = nvfp4_kv_cache_split_views(kv_cache_permute)
+
+        # For FP8 the underlying storage is uint8 and we view-cast to E4M3; for BF16 the
+        # storage is already bfloat16 so no cast is needed.
+        if self.mixed_kv_dtype == "fp8":
+            sibling_view = sibling_kv_cache.view(FP8_DTYPE)
+        else:  # bf16 — cache tensor is already bfloat16
+            sibling_view = sibling_kv_cache
+        # Permute to the FlashInfer stride order.
+        sibling_kv_cache_permute = sibling_view.permute(*stride_order)
+
+        # ---------- query setup ----------
+        # FP8 sibling: outer ``Attention.forward`` auto-quantized Q to FP8
+        # (``supports_quant_query_input`` left at True), so NVFP4 and
+        # sibling kernels both consume the same FP8 tensor. BF16 sibling:
+        # ``Attention.__init__`` flips ``supports_quant_query_input`` to
+        # False *after* building ``layer.query_quant`` — outer auto-quantize
+        # is skipped but the inline op is still available for the NVFP4
+        # call below.
+        query = query[:num_actual_tokens]
+        if self.mixed_kv_dtype == "fp8":
+            assert attn_metadata.q_data_type == FP8_DTYPE, (
+                "FP8 sibling requires FP8 query (set "
+                "disable_flashinfer_q_quantization=False)."
+            )
+            nvfp4_query = query
+            sibling_query = query
+        else:  # bf16
+            assert query.dtype != FP8_DTYPE, (
+                "BF16 sibling expects an unquantized query; got FP8 — "
+                "``Attention.__init__`` should have flipped "
+                "``supports_quant_query_input`` to False after building "
+                "``query_quant``."
+            )
+            # query_quant (scaled_fp8_quant) expects a 2D (num_tokens, hidden) tensor,
+            # but by the time we're inside the impl the outer `Attention.forward` has
+            # reshaped to (num_tokens, num_heads, head_size). Flatten for the quant op,
+            # then restore the original shape so the kernel call signature matches the
+            # FP8-sibling path.
+            orig_shape = query.shape
+            q_flat = query.reshape(orig_shape[0], -1)
+            nvfp4_query_flat, _ = layer.query_quant(q_flat, layer._q_scale)
+            nvfp4_query = nvfp4_query_flat.view(orig_shape)
+            sibling_query = query
+
+        # Pre-allocated scratch (``_mixed_out_a/b`` / ``_mixed_lse_a/b``)
+        # spans ``max_num_batched_tokens``; we slice into it below. Decode
+        # tokens are at ``[0:num_decode_tokens]`` per the standard vLLM
+        # batch ordering.
+        workspace_buffer = _get_trtllm_gen_workspace_buffer()
+
+        # ---------- DECODE branch ----------
+        if num_decode_tokens > 0:
+            assert isinstance(attn_metadata.decode, TRTLLMDecode), (
+                "Mixed-precision KV requires the trtllm-gen decode path."
+            )
+            nvfp4_decode_query = nvfp4_query[:num_decode_tokens]
+            sibling_decode_query = sibling_query[:num_decode_tokens]
+
+            out_a_d = self._mixed_out_a[:num_decode_tokens]
+            out_b_d = self._mixed_out_b[:num_decode_tokens]
+            lse_a_d = self._mixed_lse_a[:num_decode_tokens]
+            lse_b_d = self._mixed_lse_b[:num_decode_tokens]
+
+            seq_lens_d = attn_metadata.decode.seq_lens
+            seq_lens_nvfp4_d = torch.clamp(seq_lens_d - n_tokens, min=0)
+            seq_lens_sib_d = torch.clamp(seq_lens_d, max=n_tokens)
+            max_seq_len_d = attn_metadata.decode.max_seq_len
+            max_seq_len_nvfp4_d = max(0, max_seq_len_d - n_tokens)
+            max_seq_len_sib_d = min(max_seq_len_d, n_tokens)
+
+            block_tables_sib_d = sibling_meta.block_table[:num_decodes]
+            if self.mixed_kv_location == "first":
+                # NVFP4 should attend to [n_tokens, seq_len), so drop the first
+                # ``n_tokens / nvfp4_block_size`` rows of its block_table. The
+                # alignment check above guarantees this divides exactly.
+                # ``.contiguous()`` is required: the trtllm-gen kernel reads
+                # block_tables as a flat ``int*`` and ignores stride; a column
+                # slice keeps the original row stride, so without the copy the
+                # kernel would read the wrong row for req > 0.
+                skip_blocks = n_tokens // nvfp4_block_size
+                block_tables_nvfp4_d = attn_metadata.decode.block_tables[
+                    :, skip_blocks:
+                ].contiguous()
+            else:
+                block_tables_nvfp4_d = attn_metadata.decode.block_tables
+
+            if num_decode_tokens % num_decodes != 0:
+                q_len_per_req = 1
+            else:
+                q_len_per_req = num_decode_tokens // num_decodes
+
+            # Pass A: NVFP4 cache. Run unconditionally (not wasteful — a Python
+            # ``if`` would only capture one branch into cuda graph and the
+            # replay would diverge from the actual per-step seq lens); then
+            # mask ``lse_a = -inf`` per-request for ``seq_lens_nvfp4 == 0`` so
+            # the merge gives those entries weight 0. sinks=None — they live
+            # on the sibling partial so the merge accounts for them once.
+            trtllm_batch_decode_with_kv_cache(
+                query=nvfp4_decode_query,
+                kv_cache=nvfp4_data,
+                workspace_buffer=workspace_buffer,
+                block_tables=block_tables_nvfp4_d,
+                seq_lens=seq_lens_nvfp4_d,
+                max_seq_len=max(1, max_seq_len_nvfp4_d),
+                bmm1_scale=self.bmm1_scale,
+                bmm2_scale=self.bmm2_scale,
+                window_left=self.window_left,
+                sinks=None,
+                o_sf_scale=self.o_sf_scale,
+                out=out_a_d,
+                q_len_per_req=q_len_per_req,
+                kv_cache_sf=nvfp4_scales,
+                return_lse=True,
+                lse=lse_a_d,
+            )
+            empty_req_mask = (
+                (seq_lens_nvfp4_d == 0).repeat_interleave(q_len_per_req).view(-1, 1)
+            )
+            lse_a_d[:num_decode_tokens].masked_fill_(empty_req_mask, float("-inf"))
+
+            # Pass B: sibling cache (FP8 or BF16).
+            # For ``location='last'``: SlidingWindowManager evicts old blocks
+            # → sibling block_table has NULL leading entries. With clipped
+            # ``seq_lens`` the kernel would read the NULL prefix instead of
+            # the recent N tokens. Use full ``seq_lens`` + ``window_left=n-1``
+            # so the kernel attends to the last N keys (mirroring how
+            # standard SWA uses this kernel). For ``location='first'``,
+            # FirstNManager doesn't evict so block_table is clean and the
+            # natural ``seq_lens=n`` read works.
+            if self.mixed_kv_location == "last":
+                sib_seq_lens = seq_lens_d
+                sib_max_seq_len = max_seq_len_d
+                sib_window_left = n_tokens - 1
+            else:  # first
+                sib_seq_lens = seq_lens_sib_d
+                sib_max_seq_len = max_seq_len_sib_d
+                sib_window_left = self.window_left
+            trtllm_batch_decode_with_kv_cache(
+                query=sibling_decode_query,
+                kv_cache=sibling_kv_cache_permute,
+                workspace_buffer=workspace_buffer,
+                block_tables=block_tables_sib_d,
+                seq_lens=sib_seq_lens,
+                max_seq_len=sib_max_seq_len,
+                bmm1_scale=sibling_bmm1_scale,
+                bmm2_scale=sibling_bmm2_scale,
+                window_left=sib_window_left,
+                sinks=self.sinks,
+                o_sf_scale=self.o_sf_scale,
+                out=out_b_d,
+                q_len_per_req=q_len_per_req,
+                kv_cache_sf=None,
+                return_lse=True,
+                lse=lse_b_d,
+            )
+
+            # Merge. trtllm-gen FMHA writes LSE in base 2; merge_attn_states
+            # uses expf (base e), so multiply by ln(2) to convert. trtllm LSE
+            # shape is (num_tokens, num_heads); the merge wants
+            # (num_heads, num_tokens), so transpose.
+            merge_input_dtype = (
+                layer.dtype if output_scale is not None else output.dtype
+            )
+            merge_attn_states(
+                output=output[:num_decode_tokens],
+                prefix_output=out_a_d.to(merge_input_dtype),
+                prefix_lse=lse_a_d.transpose(0, 1).contiguous().mul_(_LN2),
+                suffix_output=out_b_d.to(merge_input_dtype),
+                suffix_lse=lse_b_d.transpose(0, 1).contiguous().mul_(_LN2),
+                output_scale=output_scale,
+            )
+
+        # ---------- PREFILL branch (NVFP4-only) ----------
+        # We do NOT split the prefill compute across the two caches.
+        if num_prefill_tokens > 0:
+            assert isinstance(attn_metadata.prefill, TRTLLMPrefill), (
+                "Mixed-precision KV requires the trtllm-gen prefill path."
+            )
+            # NVFP4 prefill needs FP8 Q. With BF16 sibling, `nvfp4_query`
+            # is the inline-quantized version; with FP8 sibling, it is the
+            # already-FP8 query passed in.
+            prefill_query = nvfp4_query[num_decode_tokens:]
+            prefill_end = num_decode_tokens + num_prefill_tokens
+
+            # NVFP4 trtllm prefill emits FP8. For fused FP8 output quant,
+            # write directly to the final output with the output scale folded
+            # into bmm2_scale. Otherwise, use scratch and dequantize below.
+            if output_scale is not None:
+                assert self.bmm2_scale is not None
+                assert layer._o_scale_float is not None
+                out_p = output[num_decode_tokens:prefill_end]
+                prefill_bmm2_scale = self.bmm2_scale / layer._o_scale_float
+            else:
+                out_p = self._mixed_out_a[num_decode_tokens:prefill_end]
+                prefill_bmm2_scale = self.bmm2_scale
+            trtllm_batch_context_with_kv_cache(
+                query=prefill_query,
+                kv_cache=nvfp4_data,
+                workspace_buffer=workspace_buffer,
+                block_tables=attn_metadata.prefill.block_tables,
+                seq_lens=attn_metadata.prefill.seq_lens,
+                max_q_len=attn_metadata.prefill.max_q_len,
+                max_kv_len=attn_metadata.prefill.max_seq_len,
+                bmm1_scale=self.bmm1_scale,
+                bmm2_scale=prefill_bmm2_scale,
+                batch_size=num_prefills,
+                cum_seq_lens_q=attn_metadata.prefill.cum_seq_lens_q,
+                cum_seq_lens_kv=attn_metadata.prefill.cum_seq_lens_kv,
+                window_left=self.window_left,
+                sinks=self.sinks,
+                o_sf_scale=self.o_sf_scale,
+                out=out_p,
+                kv_cache_sf=nvfp4_scales,
+            )
+            if output_scale is None:
+                output[num_decode_tokens:prefill_end].copy_(out_p.to(output.dtype))
+
+        return output
+
+    def do_kv_cache_update(
+        self,
+        layer: torch.nn.Module,
+        key: torch.Tensor,
+        value: torch.Tensor,
+        kv_cache: torch.Tensor,
+        slot_mapping: torch.Tensor,
+    ) -> None:
+        # Primary (NVFP4) write -- delegate to FlashInferImpl.
+        super().do_kv_cache_update(layer, key, value, kv_cache, slot_mapping)
+        if self.kv_sharing_target_layer_name is not None:
+            return
+        # Sibling write. Read slot_mapping from MixedKVMetadata, NOT from
+        # forward_context.slot_mapping: the first-N -1 mask only lives in
+        # the former. Without it, past-N positions write to wrong slots.
+        from vllm.model_executor.layers.attention.attention import (
+            get_attention_context,
+        )
+
+        sibling_meta, _sibling_layer, sibling_kv_cache, _ = get_attention_context(
+            self.mixed_kv_cache_prefix
+        )
+        if sibling_meta is None or sibling_kv_cache.numel() == 0:
+            return
+        # Cache shape is already at natural num_kv_heads (inter-block
+        # padding handled by page_size_padded). FP8 sibling: pass "fp8"
+        # so the kernel quantizes bf16 inputs to E4M3 with ``_k_scale`` /
+        # ``_v_scale``. BF16 sibling: pass "auto" so the kernel writes
+        # bf16 inputs through unchanged (scales unused).
+        sibling_cache_dtype_str = "fp8" if self.mixed_kv_dtype == "fp8" else "auto"
+        torch.ops._C_cache_ops.reshape_and_cache_flash(
+            key,
+            value,
+            sibling_kv_cache[:, 0],
+            sibling_kv_cache[:, 1],
+            sibling_meta.slot_mapping,
+            sibling_cache_dtype_str,
+            layer._k_scale,
+            layer._v_scale,
+        )
 
 
 def fast_plan_decode(

--- a/vllm/v1/attention/backends/mixed_precision_kv.py
+++ b/vllm/v1/attention/backends/mixed_precision_kv.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Sibling KV-cache layer for the mixed-precision path.
+
+This module owns the higher-precision (FP8 or BF16) sibling cache that holds N tokens
+per sequence alongside the primary cache (NVFP4 today). It exposes:
+
+- ``MixedPrecisionKVCache``: the sibling cache layer.
+- ``MixedKVCacheBackend`` and ``MixedKVMetadataBuilder``: spec / metadata plumbing for
+  the standard ``KVCacheManager``.
+- ``MixedKVMetadata``: per-step metadata shared across layers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import ClassVar, Literal
+
+import torch
+import torch.nn as nn
+
+from vllm.config import CacheConfig, VllmConfig, get_current_vllm_config
+from vllm.model_executor.layers.attention_layer_base import AttentionLayerBase
+from vllm.v1.attention.backend import (
+    AttentionBackend,
+    AttentionCGSupport,
+    AttentionMetadataBuilder,
+    CommonAttentionMetadata,
+)
+from vllm.v1.attention.backends.flashinfer import FlashInferBackend
+from vllm.v1.kv_cache_interface import FirstNSpec, KVCacheSpec, SlidingWindowSpec
+
+# Sentinel suffix appended to the parent attention layer prefix when
+# constructing the sibling cache. Used by FlashInferImpl to look the
+# sibling up via the static_forward_context.
+MIXED_KV_SUFFIX = ".mixed_kv"
+
+
+def mixed_kv_layer_prefix(parent_prefix: str) -> str:
+    return f"{parent_prefix}{MIXED_KV_SUFFIX}"
+
+
+@dataclass
+class MixedKVMetadata:
+    """Per-step metadata for the sibling cache.
+
+    block_table is read by the dual-kernel decode in FlashInferImpl;
+    slot_mapping carries the first-N -1 mask through to do_kv_cache_update
+    (the runner's per-layer slot_mapping is built before our mask is
+    applied, so we route the masked version via attn_metadata instead).
+    block_size is a constant the impl uses to compute skip_blocks for the
+    primary cache's read."""
+
+    block_table: torch.Tensor
+    slot_mapping: torch.Tensor
+    block_size: int
+
+
+class MixedKVCacheBackend(FlashInferBackend):
+    """Backend that piggybacks on the FlashInfer page layout. We do not
+    plan/execute attention through this backend directly; FlashInferImpl
+    handles the kernel call. This class exists so the KVCacheManager has
+    a backend to query for shape / stride info. Inherits supported kernel
+    block sizes, stride order, and supported head sizes from
+    ``FlashInferBackend``; overrides ``get_kv_cache_shape`` (natural shape
+    without NVFP4 head padding) and ``get_builder_cls``.
+    """
+
+    @staticmethod
+    def get_name() -> str:
+        return "MIXED_KV_SIBLING"
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "auto",
+    ) -> tuple[int, ...]:
+        # Return the NATURAL shape (no head-padding). Inter-block padding
+        # is handled by ``page_size_padded`` on the spec via
+        # ``model_runner.py``'s ``torch.as_strided`` path, which adds extra
+        # bytes BETWEEN blocks while keeping each block internally
+        # contiguous. Padding the head dim into the shape (as we used to)
+        # made the kernel's slice [..., :natural_h, :] non-contiguous and
+        # corrupted strides for downstream dims.
+        return (num_blocks, 2, block_size, num_kv_heads, head_size)
+
+    @staticmethod
+    def get_builder_cls() -> type[MixedKVMetadataBuilder]:  # type: ignore[override]
+        return MixedKVMetadataBuilder
+
+
+class MixedPrecisionKVCache(nn.Module, AttentionLayerBase):
+    """Sibling KV-cache layer paired with a primary (NVFP4) Attention layer.
+
+    Holds ``n_tokens`` per sequence at higher precision. Allocation,
+    slot-mapping, and block-table management are performed by the
+    standard vLLM KVCacheManager via the spec returned from
+    ``get_kv_cache_spec``. Reads happen inside FlashInferImpl, not here;
+    this module just owns the tensor handle.
+    """
+
+    def __init__(
+        self,
+        head_size: int,
+        num_kv_heads: int,
+        n_tokens: int,
+        dtype: Literal["fp8", "bf16"],
+        location: Literal["first", "last"],
+        prefix: str,
+        cache_config: CacheConfig,
+    ) -> None:
+        super().__init__()
+        # Sibling chooses its own block_size (smallest kernel-supported
+        # size); unify_kv_cache_spec_page_size grows it as needed so the
+        # sibling's --block-size is decoupled from the user's
+        # --block-size (which only constrains primary attention).
+        supported = MixedKVCacheBackend.get_supported_kernel_block_sizes()
+        self.block_size = min(s for s in supported if isinstance(s, int))
+        self.head_size = head_size
+        self.num_kv_heads = num_kv_heads
+        self.n_tokens = n_tokens
+        self.mixed_kv_dtype = dtype
+        self.location = location
+        self.prefix = prefix
+        self.cache_config = cache_config
+        # Storage dtype: uint8 for FP8 (the kernel writes raw E4M3 bytes via
+        # `reshape_and_cache_flash` with kv_cache_dtype="fp8" so the tensor
+        # type doesn't need to be FP8 itself); bfloat16 for BF16 (the kernel
+        # uses kv_cache_dtype="auto" and writes through unchanged).
+        self.dtype = torch.uint8 if dtype == "fp8" else torch.bfloat16
+        # Will be filled by bind_kv_cache.
+        self.kv_cache = torch.tensor([])
+
+        compilation_config = get_current_vllm_config().compilation_config
+        if prefix in compilation_config.static_forward_context:
+            raise ValueError(f"Duplicate layer name: {prefix}")
+        compilation_config.static_forward_context[prefix] = self
+
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        # For ``location='last'``, sliding-window auto-eviction matches our
+        # semantics (only the most recent N tokens stay resident).
+        # For ``location='first'``, FirstNSpec caps allocation at the first
+        # ``ceil(N/block_size)`` blocks and disables eviction (anchor mode).
+        # The sibling page is rounded up to match the primary NVFP4 page
+        # by ``unify_kv_cache_spec_page_size`` (which has visibility into
+        # all specs and can pick a single ``target`` that satisfies the
+        # shared block pool's same-page requirement).
+        spec_cls = FirstNSpec if self.location == "first" else SlidingWindowSpec
+        return spec_cls(
+            block_size=self.block_size,
+            num_kv_heads=self.num_kv_heads,
+            head_size=self.head_size,
+            head_size_v=self.head_size,
+            dtype=self.dtype,
+            sliding_window=self.n_tokens,
+            supported_kernel_block_sizes=tuple(
+                MixedKVCacheBackend.get_supported_kernel_block_sizes()
+            ),
+        )
+
+    def get_attn_backend(self) -> type[AttentionBackend]:
+        return MixedKVCacheBackend
+
+
+class MixedKVMetadataBuilder(AttentionMetadataBuilder):
+    """Builds MixedKVMetadata once per step (shared across layers).
+
+    The standard KVCacheManager produces the sibling's block_table and
+    slot_mapping; for first-N we additionally mask slot_mapping to -1 at
+    positions >= N (the kernel that computes slot_mapping reads past the
+    capped block_table rows and produces garbage slots otherwise).
+    """
+
+    reorder_batch_threshold: int = 1
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        assert isinstance(self.kv_cache_spec, SlidingWindowSpec), (
+            "MixedKVMetadataBuilder expects a SlidingWindowSpec or "
+            f"FirstNSpec; got {type(self.kv_cache_spec).__name__}."
+        )
+        self.n_tokens = int(self.kv_cache_spec.sliding_window)
+        self.block_size = self.kv_cache_spec.block_size
+        # FirstNSpec is a SlidingWindowSpec subclass; only it needs the
+        # past-N slot_mapping mask.
+        self.is_first_n = isinstance(self.kv_cache_spec, FirstNSpec)
+        # Persistent buffer for the masked slot_mapping. The runner's
+        # ``common_attn_metadata.slot_mapping`` is itself a stable buffer,
+        # but the masked version needs separate storage. A fresh
+        # ``slot_mapping.clone()`` per ``build()`` would be captured at a
+        # stale address under cuda-graph capture/replay and produce
+        # garbled writes to the sibling cache (mismatched slots →
+        # corrupted K/V for the first-N positions → token output
+        # degenerates after a few decode steps). Allocate once here so the
+        # cuda-graph captures a stable pointer on its very first build()
+        # call, including the warm-up before capture starts.
+        if self.is_first_n:
+            max_num_tokens = self.vllm_config.scheduler_config.max_num_batched_tokens
+            self._masked_slot_mapping = torch.empty(
+                max_num_tokens, dtype=torch.int64, device=self.device
+            )
+        else:
+            self._masked_slot_mapping = None
+
+    def build(
+        self,
+        common_prefix_len: int,
+        common_attn_metadata: CommonAttentionMetadata,
+        fast_build: bool = False,
+    ) -> MixedKVMetadata:
+        block_table = common_attn_metadata.block_table_tensor
+        slot_mapping = common_attn_metadata.slot_mapping
+
+        # First-N: FirstNManager allocates only ceil(N/block_size) blocks per request,
+        # so positions >= N index past the end of the block_table row and the
+        # slot-mapping kernel produces garbage slots there. Mask them to -1 so
+        # reshape_and_cache_flash skips those writes. positions is sized
+        # `num_actual_tokens` while slot_mapping may be padded for cuda-graph FULL mode;
+        # the padding region is already -1 from the runner so we only touch the
+        # actual-tokens prefix.
+        if self.is_first_n:
+            positions = common_attn_metadata.positions
+            assert positions is not None, (
+                "first_n mixed-precision KV requires CommonAttentionMetadata."
+                "positions to be populated; the model runner sets this on "
+                "all standard call sites."
+            )
+            n_actual = positions.shape[0]
+            # Reuse the persistent buffer allocated in ``__init__`` so
+            # cuda-graph capture sees a stable input pointer for the
+            # sibling write kernel. See ``__init__`` for why this matters.
+            assert self._masked_slot_mapping is not None
+            assert self._masked_slot_mapping.dtype == slot_mapping.dtype, (
+                f"masked slot_mapping dtype mismatch: buf="
+                f"{self._masked_slot_mapping.dtype} vs "
+                f"runner={slot_mapping.dtype}"
+            )
+            buf = self._masked_slot_mapping[: slot_mapping.shape[0]]
+            buf.copy_(slot_mapping)
+            buf[:n_actual] = torch.where(
+                positions < self.n_tokens,
+                slot_mapping[:n_actual],
+                torch.full_like(positions, -1, dtype=slot_mapping.dtype),
+            )
+            slot_mapping = buf
+
+        return MixedKVMetadata(
+            block_table=block_table,
+            slot_mapping=slot_mapping,
+            block_size=self.block_size,
+        )

--- a/vllm/v1/attention/backends/mixed_precision_kv.py
+++ b/vllm/v1/attention/backends/mixed_precision_kv.py
@@ -28,12 +28,40 @@ from vllm.v1.attention.backend import (
     CommonAttentionMetadata,
 )
 from vllm.v1.attention.backends.flashinfer import FlashInferBackend
+from vllm.v1.core.single_type_kv_cache_manager import (
+    FirstNManager,
+    SlidingWindowManager,
+    spec_manager_map,
+)
 from vllm.v1.kv_cache_interface import FirstNSpec, KVCacheSpec, SlidingWindowSpec
 
 # Sentinel suffix appended to the parent attention layer prefix when
 # constructing the sibling cache. Used by FlashInferImpl to look the
 # sibling up via the static_forward_context.
 MIXED_KV_SUFFIX = ".mixed_kv"
+
+
+# Sibling-cache specs that opt into zero-init for newly-allocated blocks.
+# The trtllm-gen FMHA kernel can load partial blocks where unfilled slots
+# would carry FP NaN bit patterns from a previously-freed block; ``0 * NaN
+# = NaN`` then propagates through the softmax-weighted output. Zeroing on
+# allocation breaks that path. Both subclasses are pure markers — they
+# inherit storage and behavior from their parents and just flip the
+# ``requires_zeroing`` ClassVar.
+@dataclass(frozen=True, kw_only=True)
+class MixedKVSlidingWindowSpec(SlidingWindowSpec):
+    requires_zeroing: ClassVar[bool] = True
+
+
+@dataclass(frozen=True, kw_only=True)
+class MixedKVFirstNSpec(FirstNSpec):
+    requires_zeroing: ClassVar[bool] = True
+
+
+# ``spec_manager_map`` is keyed by exact ``type``; the subclasses above need
+# explicit entries so the manager lookup picks the parent's manager class.
+spec_manager_map[MixedKVSlidingWindowSpec] = SlidingWindowManager
+spec_manager_map[MixedKVFirstNSpec] = FirstNManager
 
 
 def mixed_kv_layer_prefix(parent_prefix: str) -> str:
@@ -147,8 +175,13 @@ class MixedPrecisionKVCache(nn.Module, AttentionLayerBase):
         # The sibling page is rounded up to match the primary NVFP4 page
         # by ``unify_kv_cache_spec_page_size`` (which has visibility into
         # all specs and can pick a single ``target`` that satisfies the
-        # shared block pool's same-page requirement).
-        spec_cls = FirstNSpec if self.location == "first" else SlidingWindowSpec
+        # shared block pool's same-page requirement). Use the
+        # ``MixedKV*Spec`` subclasses so the allocator zero-inits new blocks
+        # (``requires_zeroing=True``) — guards against the trtllm-gen FMHA
+        # kernel loading FP NaN bit patterns from a previously-freed block.
+        spec_cls = (
+            MixedKVFirstNSpec if self.location == "first" else MixedKVSlidingWindowSpec
+        )
         return spec_cls(
             block_size=self.block_size,
             num_kv_heads=self.num_kv_heads,

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -12,6 +12,8 @@ from dataclasses import dataclass, replace
 from functools import partial
 from typing import Any, NewType, TypeAlias, cast, overload
 
+import torch
+
 from vllm import envs
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
@@ -19,7 +21,9 @@ from vllm.utils.hashing import sha256_cbor, xxhash_cbor
 from vllm.utils.math_utils import cdiv, round_up
 from vllm.utils.mem_utils import format_gib
 from vllm.utils.torch_utils import get_dtype_size
+from vllm.v1.attention.backend import MultipleOf
 from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
     ChunkedLocalAttentionSpec,
     FullAttentionSpec,
     HiddenStateCacheSpec,
@@ -1006,43 +1010,168 @@ def is_kv_cache_page_size_uniform(kv_cache_spec: dict[str, KVCacheSpec]) -> bool
     return len(page_sizes) == 1
 
 
+def _bytes_per_token(spec: AttentionSpec) -> int:
+    """Bytes per token for an AttentionSpec."""
+    full = spec.real_page_size_bytes
+    if spec.kv_quant_mode.is_per_token_head:
+        full += 2 * spec.block_size * spec.num_kv_heads * get_dtype_size(torch.float32)
+    assert full % spec.block_size == 0
+    return full // spec.block_size
+
+
+def _kernel_blocks_from_specs(
+    kv_cache_spec: dict[str, KVCacheSpec],
+) -> tuple[int | MultipleOf, ...]:
+    """Single kernel-block-size tuple for the whole model.
+
+    vLLM picks one attention backend per process, so every ``AttentionSpec``
+    has the same ``supported_kernel_block_sizes`` (populated at spec-creation
+    time by the layer that knows its backend). Pull it from any attention
+    spec that has it set; the answer is identical across layers.
+    """
+    for spec in kv_cache_spec.values():
+        if isinstance(spec, AttentionSpec) and spec.supported_kernel_block_sizes:
+            return spec.supported_kernel_block_sizes
+    return ()
+
+
+def _kernel_block_size_supported(
+    supported_size: int | MultipleOf,
+    block_size: int,
+) -> bool:
+    if isinstance(supported_size, int):
+        return block_size == supported_size
+    if isinstance(supported_size, MultipleOf):
+        return block_size % supported_size.base == 0
+    raise ValueError(f"Unknown supported kernel block size: {supported_size}")
+
+
+def _largest_supported_kernel_block_that_fits(
+    supported_sizes: tuple[int | MultipleOf, ...],
+    max_block_size: int,
+) -> int | None:
+    candidates: list[int] = []
+    for supported_size in supported_sizes:
+        if isinstance(supported_size, int):
+            candidate = supported_size
+        elif isinstance(supported_size, MultipleOf):
+            candidate = (max_block_size // supported_size.base) * supported_size.base
+        else:
+            raise ValueError(f"Unknown supported kernel block size: {supported_size}")
+        if candidate > 0 and candidate <= max_block_size:
+            candidates.append(candidate)
+    return max(candidates, default=None)
+
+
+def _minimal_page_bytes_for(
+    spec: KVCacheSpec, kernel_blocks: tuple[int | MultipleOf, ...]
+) -> int:
+    """Smallest page (bytes) the spec can produce.
+
+    AttentionSpec: smallest int kernel block × per_token.
+    MambaSpec: its unpadded page.
+    """
+    if isinstance(spec, AttentionSpec):
+        min_block = min(s if isinstance(s, int) else s.base for s in kernel_blocks)
+        return _bytes_per_token(spec) * min_block
+    if isinstance(spec, MambaSpec):
+        return sum(
+            math.prod(shape) * get_dtype_size(dtype)
+            for shape, dtype in zip(spec.shapes, spec.dtypes)
+        )
+    return spec.page_size_bytes
+
+
 def unify_kv_cache_spec_page_size(
     kv_cache_spec: dict[str, KVCacheSpec],
 ) -> dict[str, KVCacheSpec]:
-    """
-    Unify the page size of the given KVCacheSpec. If the page size of all layers
-    are the same, return the original KVCacheSpec. If not same, unify the page
-    size by increasing the block size of layers with smaller page size. Raise
-    NotImplementedError if failed to unify the page size.
+    """Pad / scale each spec so they share one page_size_bytes target.
 
-    Args:
-        kv_cache_spec: The KVCacheSpec of each attention layer in the model
-
-    Returns:
-        The updated KVCacheSpec with the same page_size_bytes.
+    Target = ``max(max(spec.page_size_bytes), max(spec.minimal_page_bytes))``.
+    The minimal-page floor lets every spec stay at a kernel-supported
+    block_size — if all current pages are smaller than some spec's
+    smallest realizable page, primary scales up so the target reaches it.
+    AttentionSpecs scale via block_size or fall back to padding via
+    ``page_size_padded``; MambaSpec is pad-only.
     """
     page_sizes = {layer.page_size_bytes for layer in kv_cache_spec.values()}
     if len(page_sizes) <= 1:
-        # All layers have the same page size, no need to unify.
         return kv_cache_spec
 
-    max_page_size = max(page_sizes)
-    new_kv_cache_spec = {}
+    # All attention layers in a vLLM model share one backend, so the supported
+    # kernel block sizes are the same for every ``AttentionSpec``. Pull the
+    # tuple once from any populated spec and reuse for every layer below.
+    kernel_blocks = _kernel_blocks_from_specs(kv_cache_spec)
+
+    max_page_bytes = max(s.page_size_bytes for s in kv_cache_spec.values())
+    minimal_page_bytes_required = max(
+        _minimal_page_bytes_for(s, kernel_blocks) for s in kv_cache_spec.values()
+    )
+    floor = max(max_page_bytes, minimal_page_bytes_required)
+
+    # Round up to a multiple of primary.natural_page_bytes so primary
+    # always clean-scales (block_size grows to target/per_token) instead
+    # of falling to padding. Padding primary wastes memory — primary
+    # is the densest spec and dominates the total KV footprint.
+    scalable = [s for s in kv_cache_spec.values() if isinstance(s, AttentionSpec)]
+    if scalable:
+        primary = min(scalable, key=_bytes_per_token)
+        primary_natural = _bytes_per_token(primary) * primary.block_size
+        target = ((floor + primary_natural - 1) // primary_natural) * primary_natural
+    else:
+        target = floor
+
+    new_kv_cache_spec: dict[str, KVCacheSpec] = {}
     for layer_name, layer_spec in kv_cache_spec.items():
-        if layer_spec.page_size_bytes == max_page_size:
-            new_kv_cache_spec[layer_name] = layer_spec
-        else:
-            layer_page_size = layer_spec.page_size_bytes
-            if max_page_size % layer_page_size != 0:
-                raise NotImplementedError(
-                    "The page size of the layer is not divisible by the "
-                    "maximum page size. Cannot unify by adjusting block_size."
-                )
-            ratio = max_page_size // layer_page_size
-            new_block_size = layer_spec.block_size * ratio
-            new_spec = replace(layer_spec, block_size=new_block_size)
-            assert new_spec.page_size_bytes == max_page_size
+        if isinstance(layer_spec, AttentionSpec):
+            per_token = _bytes_per_token(layer_spec)
+            # Try clean block_size scaling first; preserve original block_size
+            # as a divisor.
+            if target % per_token == 0:
+                new_block = target // per_token
+                if new_block % layer_spec.block_size == 0:
+                    new_spec = replace(
+                        layer_spec,
+                        block_size=new_block,
+                        page_size_padded=None,
+                    )
+                    assert new_spec.page_size_bytes == target
+                    new_kv_cache_spec[layer_name] = new_spec
+                    continue
+            # Padding fallback. block_size must remain kernel-supported,
+            # else the runner's strided view + kernel split is out of bounds.
+            assert kernel_blocks, (
+                f"{layer_name}: no supported_kernel_block_sizes available for "
+                "page-size unification padding fallback"
+            )
+            assert any(
+                _kernel_block_size_supported(s, layer_spec.block_size)
+                for s in kernel_blocks
+            ), f"{layer_name}: block_size={layer_spec.block_size} unsupported by kernel"
+            pad_block = layer_spec.block_size
+            largest_supported_block = _largest_supported_kernel_block_that_fits(
+                kernel_blocks,
+                target // per_token,
+            )
+            if largest_supported_block is not None:
+                pad_block = max(pad_block, largest_supported_block)
+            new_spec = replace(
+                layer_spec, block_size=pad_block, page_size_padded=target
+            )
+            assert new_spec.page_size_bytes == target
             new_kv_cache_spec[layer_name] = new_spec
+        elif isinstance(layer_spec, MambaSpec):
+            if layer_spec.page_size_bytes == target:
+                new_kv_cache_spec[layer_name] = layer_spec
+            else:
+                padded_mamba = replace(layer_spec, page_size_padded=target)
+                assert padded_mamba.page_size_bytes == target
+                new_kv_cache_spec[layer_name] = padded_mamba
+        else:
+            raise NotImplementedError(
+                f"Cannot unify spec_type={type(layer_spec).__name__} "
+                f"for layer {layer_name!r}"
+            )
     return new_kv_cache_spec
 
 
@@ -1393,6 +1522,7 @@ def unify_hybrid_kv_cache_specs(kv_cache_spec: dict[str, KVCacheSpec]):
                     kv_quant_mode=spec.kv_quant_mode,
                     sliding_window=spec.sliding_window,
                     page_size_padded=spec.page_size_padded,
+                    supported_kernel_block_sizes=spec.supported_kernel_block_sizes,
                 )
             elif isinstance(spec, ChunkedLocalAttentionSpec):
                 kv_cache_spec[layer_name] = FullAttentionSpec(
@@ -1402,6 +1532,7 @@ def unify_hybrid_kv_cache_specs(kv_cache_spec: dict[str, KVCacheSpec]):
                     dtype=spec.dtype,
                     attention_chunk_size=spec.attention_chunk_size,
                     page_size_padded=spec.page_size_padded,
+                    supported_kernel_block_sizes=spec.supported_kernel_block_sizes,
                 )
 
     if not (

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -15,6 +15,7 @@ from vllm.v1.core.kv_cache_utils import (
 from vllm.v1.kv_cache_interface import (
     ChunkedLocalAttentionSpec,
     CrossAttentionSpec,
+    FirstNSpec,
     FullAttentionSpec,
     HiddenStateCacheSpec,
     KVCacheSpec,
@@ -445,6 +446,52 @@ class SingleTypeKVCacheManager(ABC):
 
 
 class FullAttentionManager(SingleTypeKVCacheManager):
+    @staticmethod
+    def _match_prefix_blocks(
+        block_hashes: BlockHashList,
+        max_num_blocks: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        """Scan ``block_hashes`` left-to-right, returning the longest run of
+        contiguous cached blocks (up to ``max_num_blocks``). Shared by
+        ``FullAttentionManager`` and ``FirstNManager``."""
+        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
+            [] for _ in range(len(kv_cache_group_ids))
+        )
+        for block_hash in itertools.islice(block_hashes, max_num_blocks):
+            # block_hashes is a chain of block hashes. If a block hash is not
+            # in the cached_block_hash_to_id, the following block hashes are
+            # not computed yet for sure.
+            if cached_block := block_pool.get_cached_block(
+                block_hash, kv_cache_group_ids
+            ):
+                for computed, cached in zip(computed_blocks, cached_block):
+                    computed.append(cached)
+            else:
+                break
+        return computed_blocks
+
+    @staticmethod
+    def _trim_for_eagle_and_align(
+        computed_blocks: tuple[list[KVCacheBlock], ...],
+        block_size: int,
+        alignment_tokens: int,
+        use_eagle: bool,
+    ) -> None:
+        """Apply the eagle drop + alignment trim post-processing in place.
+        Shared by ``FullAttentionManager`` and ``FirstNManager``."""
+        if use_eagle and computed_blocks[0]:
+            for computed in computed_blocks:
+                computed.pop()
+        while (
+            block_size != alignment_tokens
+            and computed_blocks[0]
+            and len(computed_blocks[0]) * block_size % alignment_tokens != 0
+        ):
+            for computed in computed_blocks:
+                computed.pop()
+
     @classmethod
     def find_longest_cache_hit(
         cls,
@@ -464,34 +511,16 @@ class FullAttentionManager(SingleTypeKVCacheManager):
             "FullAttentionManager can only be used for full attention "
             "and chunked local attention groups"
         )
-        computed_blocks: tuple[list[KVCacheBlock], ...] = tuple(
-            [] for _ in range(len(kv_cache_group_ids))
-        )
         block_size = kv_cache_spec.block_size
         if dcp_world_size * pcp_world_size > 1:
             block_size *= dcp_world_size * pcp_world_size
         max_num_blocks = max_length // block_size
-        for block_hash in itertools.islice(block_hashes, max_num_blocks):
-            # block_hashes is a chain of block hashes. If a block hash is not
-            # in the cached_block_hash_to_id, the following block hashes are
-            # not computed yet for sure.
-            if cached_block := block_pool.get_cached_block(
-                block_hash, kv_cache_group_ids
-            ):
-                for computed, cached in zip(computed_blocks, cached_block):
-                    computed.append(cached)
-            else:
-                break
-        if use_eagle and computed_blocks[0]:
-            # Need to drop the last matched block if eagle is enabled.
-            for computed in computed_blocks:
-                computed.pop()
-        while (
-            block_size != alignment_tokens  # Faster for common case.
-            and len(computed_blocks[0]) * block_size % alignment_tokens != 0
-        ):
-            for computed in computed_blocks:
-                computed.pop()
+        computed_blocks = cls._match_prefix_blocks(
+            block_hashes, max_num_blocks, kv_cache_group_ids, block_pool
+        )
+        cls._trim_for_eagle_and_align(
+            computed_blocks, block_size, alignment_tokens, use_eagle
+        )
         return computed_blocks
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
@@ -640,6 +669,101 @@ class SlidingWindowManager(SingleTypeKVCacheManager):
         window in the future.
         """
         return 0
+
+
+class FirstNManager(SlidingWindowManager):
+    """KV cache manager that pins the FIRST N tokens of every request.
+
+    Allocation is capped at ``ceil(N / block_size)`` blocks per request and
+    no eviction ever happens — the first N tokens stay resident for the
+    full lifetime of the request. Used by the mixed-precision KV cache's
+    ``location='first'`` mode.
+
+    Inherits from SlidingWindowManager so the page-size unification logic
+    that pairs the sibling cache with NVFP4 keeps working unchanged.
+    """
+
+    @classmethod
+    def find_longest_cache_hit(
+        cls,
+        block_hashes: BlockHashList,
+        max_length: int,
+        kv_cache_group_ids: list[int],
+        block_pool: BlockPool,
+        kv_cache_spec: KVCacheSpec,
+        use_eagle: bool,
+        alignment_tokens: int,
+        dcp_world_size: int = 1,
+        pcp_world_size: int = 1,
+    ) -> tuple[list[KVCacheBlock], ...]:
+        # Match real cached blocks for the first ``ceil(N/block_size)`` positions, then
+        # append null-block fillers up to ``max_length``. The padding past N matters:
+        # without it, FirstN's hit length caps at N and the coordinator's fixed-point
+        # clamps the primary (full-attention) group's longer prefix-cache hit to N too.
+        # The nulls are safe because the sibling kernel reads only ``seq_lens_sib <= N``
+        # keys and writes past N are masked to slot=-1 in
+        # ``MixedKVMetadataBuilder.build``.
+        assert isinstance(kv_cache_spec, FirstNSpec), (
+            "FirstNManager can only be used for FirstNSpec groups"
+        )
+        block_size = kv_cache_spec.block_size
+        if dcp_world_size * pcp_world_size > 1:
+            block_size *= dcp_world_size * pcp_world_size
+        max_num_blocks = max_length // block_size
+        max_first_n_blocks = (
+            kv_cache_spec.sliding_window + block_size - 1
+        ) // block_size
+        real_match_blocks = min(max_num_blocks, max_first_n_blocks)
+
+        computed_blocks = FullAttentionManager._match_prefix_blocks(
+            block_hashes, real_match_blocks, kv_cache_group_ids, block_pool
+        )
+        # Pad with null blocks past N — but only if we matched the full first-N range
+        # (otherwise the primary group will reduce the hit length below N anyway, and
+        # extra padding here is wasted work).
+        if len(computed_blocks[0]) == max_first_n_blocks:
+            for _ in range(max_first_n_blocks, max_num_blocks):
+                for computed in computed_blocks:
+                    computed.append(block_pool.null_block)
+        FullAttentionManager._trim_for_eagle_and_align(
+            computed_blocks, block_size, alignment_tokens, use_eagle
+        )
+        return computed_blocks
+
+    def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
+        # No eviction: every token in [0, N) of every request stays resident.
+        return 0
+
+    def allocate_new_blocks(
+        self, request_id: str, num_tokens: int, num_tokens_main_model: int
+    ) -> list[KVCacheBlock]:
+        # Stop allocating once we have the first N tokens worth of blocks.
+        # Any chunk whose tokens fall past position N adds zero new blocks
+        # (its slot_mapping entries are masked to -1 by the metadata
+        # builder, so reshape_and_cache_flash skips them).
+        capped = min(num_tokens, self.sliding_window)
+        capped_main = min(num_tokens_main_model, self.sliding_window)
+        return super().allocate_new_blocks(request_id, capped, capped_main)
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: Sequence[KVCacheBlock],
+        total_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> int:
+        # Same cap as allocate_new_blocks so admission accounting stays
+        # consistent with the runtime allocator.
+        return super().get_num_blocks_to_allocate(
+            request_id,
+            min(num_tokens, self.sliding_window),
+            new_computed_blocks,
+            total_computed_tokens,
+            min(num_tokens_main_model, self.sliding_window),
+            apply_admission_cap=apply_admission_cap,
+        )
 
 
 class ChunkedLocalAttentionManager(SingleTypeKVCacheManager):
@@ -1147,6 +1271,7 @@ spec_manager_map: dict[type[KVCacheSpec], type[SingleTypeKVCacheManager]] = {
     HiddenStateCacheSpec: FullAttentionManager,
     SlidingWindowSpec: SlidingWindowManager,
     SlidingWindowMLASpec: SlidingWindowManager,
+    FirstNSpec: FirstNManager,
     ChunkedLocalAttentionSpec: ChunkedLocalAttentionManager,
     MambaSpec: MambaManager,
     CrossAttentionSpec: CrossAttentionManager,

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -13,6 +13,7 @@ from vllm.v1.core.kv_cache_utils import (
     KVCacheBlock,
 )
 from vllm.v1.kv_cache_interface import (
+    AttentionSpec,
     ChunkedLocalAttentionSpec,
     CrossAttentionSpec,
     FirstNSpec,
@@ -238,7 +239,13 @@ class SingleTypeKVCacheManager(ABC):
                 cdiv(num_total_computed_tokens, self.block_size) - len(req_blocks)
             )
             req_blocks.extend(allocated_blocks)
-            if type(self.kv_cache_spec) in (FullAttentionSpec, TQFullAttentionSpec):
+            if type(self.kv_cache_spec) in (
+                FullAttentionSpec,
+                TQFullAttentionSpec,
+            ) or (
+                isinstance(self.kv_cache_spec, AttentionSpec)
+                and self.kv_cache_spec.requires_zeroing
+            ):
                 self.new_block_ids.extend(b.block_id for b in allocated_blocks)
 
     def allocate_new_blocks(
@@ -266,7 +273,13 @@ class SingleTypeKVCacheManager(ABC):
         else:
             new_blocks = self.block_pool.get_new_blocks(num_new_blocks)
             req_blocks.extend(new_blocks)
-            if type(self.kv_cache_spec) in (FullAttentionSpec, TQFullAttentionSpec):
+            if type(self.kv_cache_spec) in (
+                FullAttentionSpec,
+                TQFullAttentionSpec,
+            ) or (
+                isinstance(self.kv_cache_spec, AttentionSpec)
+                and self.kv_cache_spec.requires_zeroing
+            ):
                 self.new_block_ids.extend(b.block_id for b in new_blocks)
             return new_blocks
 

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -147,6 +147,12 @@ class AttentionSpec(KVCacheSpec):
     dtype: torch.dtype
     kv_quant_mode: KVQuantMode = KVQuantMode.NONE
     page_size_padded: int | None = None
+    # The kernel block sizes the layer's attention backend supports. Carried
+    # on the spec so page-size unification doesn't need to look up the layer
+    # in ``static_forward_context`` — which doesn't exist in the engine-core
+    # process under multi-process executors. Tuples for hashability; empty
+    # tuple means "not populated" (legacy callers that pre-date this field).
+    supported_kernel_block_sizes: tuple = ()
 
     @property
     def page_size_bytes(self) -> int:
@@ -260,6 +266,7 @@ class FullAttentionSpec(AttentionSpec):
             page_size_padded=specs[0].page_size_padded,
             sliding_window=cls.merge_window_sizes(sliding_window),
             attention_chunk_size=cls.merge_window_sizes(attention_chunk_size),
+            supported_kernel_block_sizes=specs[0].supported_kernel_block_sizes,
         )
         for spec in specs:
             for f in fields(AttentionSpec):
@@ -393,6 +400,7 @@ class MLAAttentionSpec(FullAttentionSpec):
             cache_dtype_str=cache_dtype_str_set.pop(),
             compress_ratio=compress_ratio_set.pop(),
             model_version=model_version_set.pop(),
+            supported_kernel_block_sizes=specs[0].supported_kernel_block_sizes,
         )
 
 

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -503,6 +503,25 @@ class SlidingWindowSpec(AttentionSpec):
 
 
 @dataclass(frozen=True, kw_only=True)
+class FirstNSpec(SlidingWindowSpec):
+    """Like SlidingWindowSpec but pins the FIRST N tokens (no eviction).
+
+    Allocation is capped at ``ceil(N/block_size)`` blocks per request and old blocks are
+    never evicted. Used by the mixed-precision KV cache's ``location='first'`` mode,
+    where the sibling cache holds positions ``[0, N)`` indefinitely.
+
+    Reuses ``sliding_window``."""
+
+    def max_admission_blocks_per_request(
+        self, max_num_batched_tokens: int, max_model_len: int
+    ) -> int:
+        # Per-request peak holdings = ceil(N / block_size), regardless of
+        # batched-token / max-model-len: we stop allocating once the first
+        # N tokens are stored, and we never evict.
+        return cdiv(self.sliding_window, self.block_size)
+
+
+@dataclass(frozen=True, kw_only=True)
 class SlidingWindowMLASpec(SlidingWindowSpec):
     """Sliding window attention with MLA cache format."""
 

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -8,7 +8,7 @@ from collections import Counter
 from dataclasses import dataclass, fields, replace
 from enum import Enum, IntEnum
 from math import prod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import torch
 from typing_extensions import Self
@@ -153,6 +153,12 @@ class AttentionSpec(KVCacheSpec):
     # process under multi-process executors. Tuples for hashability; empty
     # tuple means "not populated" (legacy callers that pre-date this field).
     supported_kernel_block_sizes: tuple = ()
+
+    # If True, newly-allocated blocks for this spec are zero-initialized
+    # before first use. Needed when the attention kernel may load partial
+    # blocks where unfilled slots could land on FP NaN bit patterns and
+    # propagate via ``0 * NaN = NaN`` in the softmax-weighted sum.
+    requires_zeroing: ClassVar[bool] = False
 
     @property
     def page_size_bytes(self) -> int:
@@ -884,4 +890,8 @@ class KVCacheConfig:
 
     @property
     def needs_kv_cache_zeroing(self) -> bool:
-        return self.has_mamba_layers
+        return self.has_mamba_layers or any(
+            isinstance(g.kv_cache_spec, AttentionSpec)
+            and g.kv_cache_spec.requires_zeroing
+            for g in self.kv_cache_groups
+        )

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -426,6 +426,30 @@ class GPUModelRunner(LoRAModelRunnerMixin):
         )
         self.kv_connector = get_kv_connector(self.vllm_config, kv_caches_dict)
 
+    def _init_kv_zero_meta(self) -> None:
+        """Initialize the KV block zeroer for specs with ``requires_zeroing``.
+        Called from gpu_worker.py after KV caches are allocated. Without
+        this, freshly allocated blocks (e.g. for the mixed-precision KV
+        sibling) retain stale data from prior warmup/dummy runs, which
+        corrupts attention output.
+        """
+        from vllm.utils.platform_utils import is_pin_memory_available
+        from vllm.v1.worker.utils import KVBlockZeroer
+
+        self._kv_block_zeroer = KVBlockZeroer(self.device, is_pin_memory_available())
+        # V2 builds metadata with ``kernel_block_size=None`` so the kernel
+        # block size equals each spec's own ``block_size``.
+        kernel_block_sizes = [
+            g.kv_cache_spec.block_size for g in self.kv_cache_config.kv_cache_groups
+        ]
+        self._kv_block_zeroer.init_meta(
+            attn_groups_iter=(g for groups in self.attn_groups for g in groups),
+            kernel_block_sizes=kernel_block_sizes,
+            cache_dtype=self.cache_config.cache_dtype,
+            runner_only_attn_layers=set(),
+            static_forward_context=self.compilation_config.static_forward_context,
+        )
+
     @torch.inference_mode()
     @step_eplb_after(is_dummy=True)
     def _dummy_run(
@@ -999,6 +1023,16 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             self.add_requests(scheduler_output)
             self.update_requests(scheduler_output)
             self.block_tables.apply_staged_writes()
+            # Zero GPU memory for freshly allocated cache blocks (specs with
+            # ``requires_zeroing=True``, e.g. mixed-precision KV sibling) to
+            # prevent stale data — including from earlier warmup/dummy runs —
+            # from corrupting attention computation when the block is reused.
+            if scheduler_output.new_block_ids_to_zero and hasattr(
+                self, "_kv_block_zeroer"
+            ):
+                self._kv_block_zeroer.zero_block_ids(
+                    scheduler_output.new_block_ids_to_zero
+                )
             if scheduler_output.total_num_scheduled_tokens == 0:
                 # No need to run the model.
                 empty_output = self.kv_connector.no_forward(scheduler_output)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -143,6 +143,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheConfig,
     KVCacheGroupSpec,
     KVCacheSpec,
+    KVQuantMode,
     MambaSpec,
     SlidingWindowSpec,
     UniformTypeKVCacheSpecs,
@@ -6843,12 +6844,19 @@ class GPUModelRunner(
                     else:
                         shape_block_size = kernel_block_size
 
+                    # Skipped layers (--kv-cache-dtype-skip-layers) need
+                    # the unquantized shape.
+                    layer_cache_dtype_str = (
+                        "auto"
+                        if kv_cache_spec.kv_quant_mode == KVQuantMode.NONE
+                        else self.cache_config.cache_dtype
+                    )
                     kv_cache_shape = attn_backend.get_kv_cache_shape(
                         kernel_num_blocks,
                         shape_block_size,
                         kv_cache_spec.num_kv_heads,
                         kv_cache_spec.head_size,
-                        cache_dtype_str=self.cache_config.cache_dtype,
+                        cache_dtype_str=layer_cache_dtype_str,
                     )
                     dtype = kv_cache_spec.dtype
                     try:

--- a/vllm/v1/worker/utils.py
+++ b/vllm/v1/worker/utils.py
@@ -120,7 +120,9 @@ class KVBlockZeroer:
 
         for group in attn_groups_iter:
             spec = group.kv_cache_spec
-            if not isinstance(spec, FullAttentionSpec):
+            if not isinstance(spec, FullAttentionSpec) and not (
+                isinstance(spec, AttentionSpec) and spec.requires_zeroing
+            ):
                 continue
             if group.kv_cache_group_id >= len(kernel_block_sizes):
                 continue


### PR DESCRIPTION
To make NVFP4 kv cache more accurate, we keep the first/last n tokens in higher precision (FP8/BF16).
  - Add MixedPrecisionKVCache as a sibling KV cache for NVFP4 primary attention, keeping selected first/last N tokens in higher precision.
  - Use SlidingWindowSpec/sliding-window manager for last-N mixed KV, and add FirstNSpec/FirstNManager for anchored first-N mixed KV.
  - Extend FlashInfer mixed-KV decode to run primary NVFP4 and sibling high-precision attention, then combine partial outputs with LSE merge.
  - Add page-size padding/unification support so mixed KV and Mamba/attention hybrid cache specs can share allocator pages.



## Purpose
Make nvfp4 kv cache more accurate without losing too much speed.

## Test Plan
E2E accuracy and speed test

## Test Result
Running.
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

