### PR TITLE
Fix CPU-only shutdown cleanup without accelerator

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -1321,3 +1321,27 @@ def test_mamba_cache_raises_when_max_num_seqs_exceeds_blocks():
 
         with pytest.raises(ValueError, match="max_num_seqs"):
             runner.initialize_kv_cache(kv_cache_config)
+
+
+def test_cleanup_profiling_kv_cache_without_accelerator(monkeypatch):
+    runner = object.__new__(GPUModelRunner)
+    runner.kv_caches = [object()]
+    runner.attn_groups = [object()]
+    runner.kv_cache_config = object()
+    runner.cache_config = SimpleNamespace(num_gpu_blocks=1)
+    runner.compilation_config = SimpleNamespace(static_forward_context={})
+
+    monkeypatch.setattr(torch.accelerator, "is_available", lambda: False)
+
+    def fail_if_called(*args, **kwargs):
+        raise AssertionError("accelerator cleanup should be skipped")
+
+    monkeypatch.setattr(torch.accelerator, "synchronize", fail_if_called)
+    monkeypatch.setattr(torch.accelerator, "empty_cache", fail_if_called)
+
+    GPUModelRunner._cleanup_profiling_kv_cache(runner)
+
+    assert runner.kv_caches == []
+    assert runner.attn_groups == []
+    assert not hasattr(runner, "kv_cache_config")
+    assert runner.cache_config.num_gpu_blocks is None

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5969,7 +5969,9 @@ class GPUModelRunner(
         reset_workspace_manager()
 
     def _cleanup_profiling_kv_cache(self) -> None:
-        torch.accelerator.synchronize()
+        accelerator_available = torch.accelerator.is_available()
+        if accelerator_available:
+            torch.accelerator.synchronize()
         if hasattr(self, "kv_caches") and self.kv_caches:
             for i in range(len(self.kv_caches)):
                 self.kv_caches[i] = None  # type: ignore
@@ -5998,7 +6000,8 @@ class GPUModelRunner(
                     layer.impl._v_scale_cache = None
 
         gc.collect()
-        torch.accelerator.empty_cache()
+        if accelerator_available:
+            torch.accelerator.empty_cache()
 
         logger.debug("Cleaned up profiling KV cache and CUDA graphs")
 


### PR DESCRIPTION
Fixes #41660.

This PR guards accelerator-specific cleanup calls in `GPUModelRunner._cleanup_profiling_kv_cache()` with `torch.accelerator.is_available()`.

In CPU-only shutdown paths, `torch.accelerator.synchronize()` can raise `RuntimeError: Cannot access accelerator device when none is available.` The Python-side cleanup of KV cache references and static forward context can still proceed, so only the accelerator synchronization and cache-clear calls need to be skipped.

Why this is not duplicating an existing PR:

- I checked open PRs referencing `#41660` and open PRs matching the short area keywords `CPUWorker shutdown accelerator unavailable`.
- I did not find another open PR addressing this shutdown cleanup path.

AI assistance:

- AI assistance was used to prepare this patch.
- I reviewed the changed lines and the targeted test output before submitting.

Test added:

```bash
PYTHONPATH=. python -m pytest   --confcutdir=tests/v1/worker   tests/v1/worker/test_gpu_model_runner.py::test_cleanup_profiling_kv_cache_without_accelerator -q
```

Result:

```text
1 passed
```
