### PR TITLE
[Model] Use AutoWeightsLoader for CohereMoe

### DIFF
--- a/vllm/model_executor/models/cohere_moe.py
+++ b/vllm/model_executor/models/cohere_moe.py
@@ -37,6 +37,7 @@ from vllm.sequence import IntermediateTensors
 from .commandr import LayerNorm
 from .interfaces import SupportsPP, SupportsQuant
 from .utils import (
+    AutoWeightsLoader,
     extract_layer_index,
     is_pp_missing_parameter,
     make_empty_intermediate_tensors_factory,
@@ -330,6 +331,7 @@ class CohereMoeModel(nn.Module):
         quant_config = vllm_config.quant_config
 
         self.config = config
+        self.quant_config = quant_config
         self.vocab_size = config.vocab_size
         self.org_vocab_size = config.vocab_size
         self.embed_tokens = VocabParallelEmbedding(
@@ -377,63 +379,6 @@ class CohereMoeModel(nn.Module):
             )
         hidden_states, _ = self.norm(hidden_states, residual)
         return hidden_states
-
-
-class CohereMoeForCausalLM(nn.Module, SupportsPP, SupportsQuant):
-    is_text_generation_model = True
-
-    packed_modules_mapping = {
-        "qkv_proj": [
-            "q_proj",
-            "k_proj",
-            "v_proj",
-        ],
-        "gate_up_proj": [
-            "gate_proj",
-            "up_proj",
-        ],
-    }
-
-    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
-        super().__init__()
-        config = vllm_config.model_config.hf_config
-        quant_config = vllm_config.quant_config
-        self.config = config
-        assert getattr(config, "tie_word_embeddings", True)
-        self.unpadded_vocab_size = config.vocab_size
-        self.quant_config = quant_config
-        self.logits_scale = config.logit_scale
-        self.logits_processor = LogitsProcessor(
-            self.unpadded_vocab_size, config.vocab_size, scale=self.logits_scale
-        )
-        self.model = CohereMoeModel(
-            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
-        )
-        self.make_empty_intermediate_tensors = (
-            self.model.make_empty_intermediate_tensors
-        )
-
-    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.model.get_input_embeddings(input_ids)
-
-    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.model.get_input_embeddings(input_ids)
-
-    @torch.no_grad()
-    def forward(
-        self,
-        input_ids: torch.Tensor,
-        positions: torch.Tensor,
-        intermediate_tensors: IntermediateTensors | None = None,
-        inputs_embeds: torch.Tensor | None = None,
-    ) -> torch.Tensor | IntermediateTensors:
-        return self.model(input_ids, positions, intermediate_tensors, inputs_embeds)
-
-    def compute_logits(
-        self,
-        hidden_states: torch.Tensor,
-    ) -> torch.Tensor | None:
-        return self.logits_processor(self.model.embed_tokens, hidden_states)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         stacked_params_mapping = [
@@ -507,8 +452,6 @@ class CohereMoeForCausalLM(nn.Module, SupportsPP, SupportsQuant):
                     )
                     break
                 else:
-                    if "lm_head.weight" in name:
-                        continue
                     if (
                         name.endswith(".bias") or name.endswith("_bias")
                     ) and name not in params_dict:
@@ -526,3 +469,64 @@ class CohereMoeForCausalLM(nn.Module, SupportsPP, SupportsQuant):
             loaded_params.add(name)
 
         return loaded_params
+
+
+class CohereMoeForCausalLM(nn.Module, SupportsPP, SupportsQuant):
+    is_text_generation_model = True
+
+    packed_modules_mapping = {
+        "qkv_proj": [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+        ],
+        "gate_up_proj": [
+            "gate_proj",
+            "up_proj",
+        ],
+    }
+
+    def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
+        super().__init__()
+        config = vllm_config.model_config.hf_config
+        quant_config = vllm_config.quant_config
+        self.config = config
+        assert getattr(config, "tie_word_embeddings", True)
+        self.unpadded_vocab_size = config.vocab_size
+        self.quant_config = quant_config
+        self.logits_scale = config.logit_scale
+        self.logits_processor = LogitsProcessor(
+            self.unpadded_vocab_size, config.vocab_size, scale=self.logits_scale
+        )
+        self.model = CohereMoeModel(
+            vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
+        )
+        self.make_empty_intermediate_tensors = (
+            self.model.make_empty_intermediate_tensors
+        )
+
+    def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.get_input_embeddings(input_ids)
+
+    def get_input_embeddings(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.model.get_input_embeddings(input_ids)
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: IntermediateTensors | None = None,
+        inputs_embeds: torch.Tensor | None = None,
+    ) -> torch.Tensor | IntermediateTensors:
+        return self.model(input_ids, positions, intermediate_tensors, inputs_embeds)
+
+    def compute_logits(
+        self,
+        hidden_states: torch.Tensor,
+    ) -> torch.Tensor | None:
+        return self.logits_processor(self.model.embed_tokens, hidden_states)
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(self, skip_prefixes=["lm_head."])
+        return loader.load_weights(weights)


### PR DESCRIPTION
## Purpose

Part of #15697.

This PR refactors `CohereMoeForCausalLM` to use `AutoWeightsLoader`. Mirrors the pattern used by `commandr.py` (#19399), `mixtral.py` (#16325), and the recently merged #41492 for `Step3TextForCausalLM`.

The CohereMoe weight-loading logic is moved from `CohereMoeForCausalLM` to the reusable `CohereMoeModel` backbone. `CohereMoeForCausalLM.load_weights` now delegates through `AutoWeightsLoader`, matching the standardized loading pattern used by other language models.

This is a refactor only and does not change model architecture or inference behavior. The body of the moved method is unchanged; the `lm_head.weight` skip previously inlined in the loop is now expressed as `skip_prefixes=["lm_head."]` on `AutoWeightsLoader` (CohereMoe asserts `tie_word_embeddings=True`, so there is no separate `lm_head` parameter to load). `rotary_emb.inv_freq` no longer needs an explicit skip because `AutoWeightsLoader` already includes it in its default `skip_substrs` (`vllm/model_executor/models/utils.py:134`).

`self.quant_config` is now stored on `CohereMoeModel.__init__` so the moved KV-scale handling continues to resolve correctly.

## Test Plan

Local validation (CPU-only dev box, no CUDA available):

- `python -m py_compile vllm/model_executor/models/cohere_moe.py`
- Import `CohereMoeForCausalLM` through `ModelRegistry`
- Verify `load_weights` is implemented on both `CohereMoeModel` and `CohereMoeForCausalLM` and that the outer delegates via `AutoWeightsLoader`
- `pre-commit`-equivalent lint: `ruff check` and `ruff format --check`
- Re-run `tests/models/test_utils.py` (covers `AutoWeightsLoader` skip_prefixes / skip_substrs semantics that this PR depends on)

CI is expected to run the GPU initialization test:

```bash
CUDA_VISIBLE_DEVICES=0 python -m pytest \
  tests/models/test_initialization.py::test_can_initialize_large_subset \
  -q -k CohereMoeForCausalLM -s --tb=short
```

## Test Result

Passed:
```bash
python -m py_compile vllm/model_executor/models/cohere_moe.py
```

Passed:
```bash
python - <<'PY'
from vllm.model_executor.models.registry import ModelRegistry
cls = ModelRegistry._try_load_model_cls("CohereMoeForCausalLM")
print(cls)
assert cls is not None
PY
```

Output:
```text
<class 'vllm.model_executor.models.cohere_moe.CohereMoeForCausalLM'>
```

Passed:
```bash
python - <<'PY'
import inspect
from vllm.model_executor.models.cohere_moe import CohereMoeModel, CohereMoeForCausalLM
print("CohereMoeModel.load_weights:", CohereMoeModel.load_weights.__qualname__)
print("CohereMoeForCausalLM.load_weights:", CohereMoeForCausalLM.load_weights.__qualname__)
src = inspect.getsource(CohereMoeForCausalLM.load_weights)
print("Outer delegates via AutoWeightsLoader:", "AutoWeightsLoader" in src)
PY
```

Output:
```text
CohereMoeModel.load_weights: CohereMoeModel.load_weights
CohereMoeForCausalLM.load_weights: CohereMoeForCausalLM.load_weights
Outer delegates via AutoWeightsLoader: True
```

Passed:
```bash
ruff check vllm/model_executor/models/cohere_moe.py
ruff format --check vllm/model_executor/models/cohere_moe.py
```

Output:
```text
All checks passed!
1 file already formatted
```

Passed:
```bash
python -m pytest tests/models/test_utils.py -v
```

Output:
```text
4 passed, 1 skipped, 16 warnings in 9.29s
```

GPU initialization test for `CohereMoeForCausalLM` is registered with `is_available_online=False` (the checkpoint is internal), so it cannot be exercised in a public dev environment; deferred to CI.

## AI assistance

This change was AI-assisted (Claude Code). The submitter reviewed every changed line, walked through the `AutoWeightsLoader` semantics including the default `rotary_emb.inv_freq` skip and the outer `skip_prefixes=["lm_head."]` handling, and validated the structural changes locally.
