### PR TITLE
[Model] Use AutoWeightsLoader for MiMo

### DIFF
--- a/vllm/model_executor/models/mimo.py
+++ b/vllm/model_executor/models/mimo.py
@@ -38,14 +38,10 @@ from vllm.distributed import get_pp_group
 from vllm.logger import init_logger
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.vocab_parallel_embedding import ParallelLMHead
-from vllm.model_executor.model_loader.weight_utils import (
-    default_weight_loader,
-    maybe_remap_kv_scale_name,
-)
 from vllm.model_executor.models.qwen2 import Qwen2ForCausalLM, Qwen2Model
 from vllm.sequence import IntermediateTensors
 
-from .utils import PPMissingLayer, is_pp_missing_parameter, maybe_prefix
+from .utils import AutoWeightsLoader, PPMissingLayer, maybe_prefix
 
 logger = init_logger(__name__)
 
@@ -89,62 +85,6 @@ class MiMoModel(Qwen2Model):
         hidden_states = hidden_states + residual
         return hidden_states
 
-    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
-        stacked_params_mapping = [
-            ("qkv_proj", "q_proj", "q"),
-            ("qkv_proj", "k_proj", "k"),
-            ("qkv_proj", "v_proj", "v"),
-            ("gate_up_proj", "gate_proj", 0),
-            ("gate_up_proj", "up_proj", 1),
-        ]
-        params_dict = dict(self.named_parameters(remove_duplicate=False))
-        loaded_params: set[str] = set()
-        for name, loaded_weight in weights:
-            if "mtp_layers" in name:
-                continue
-            if "rotary_emb.inv_freq" in name:
-                continue
-            if self.quant_config is not None and (
-                scale_name := self.quant_config.get_cache_scale(name)
-            ):
-                # Loading kv cache quantization scales
-                param = params_dict[scale_name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                loaded_weight = (
-                    loaded_weight if loaded_weight.dim() == 0 else loaded_weight[0]
-                )
-                weight_loader(param, loaded_weight)
-                loaded_params.add(scale_name)
-                continue
-            for param_name, weight_name, shard_id in stacked_params_mapping:
-                if weight_name not in name:
-                    continue
-                name = name.replace(weight_name, param_name)
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-                if is_pp_missing_parameter(name, self):
-                    continue
-                param = params_dict[name]
-                weight_loader = param.weight_loader
-                weight_loader(param, loaded_weight, shard_id)
-                break
-            else:
-                # Skip loading extra bias for GPTQ models.
-                if name.endswith(".bias") and name not in params_dict:
-                    continue
-                # Remapping the name of FP8 kv-scale.
-                name = maybe_remap_kv_scale_name(name, params_dict)
-                if name is None:
-                    continue
-                if is_pp_missing_parameter(name, self):
-                    continue
-                param = params_dict[name]
-                weight_loader = getattr(param, "weight_loader", default_weight_loader)
-                weight_loader(param, loaded_weight)
-            loaded_params.add(name)
-        return loaded_params
-
 
 class MiMoForCausalLM(Qwen2ForCausalLM, nn.Module):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = ""):
@@ -186,3 +126,12 @@ class MiMoForCausalLM(Qwen2ForCausalLM, nn.Module):
         hidden_states = self.model.norm(hidden_states)
         logits = self.logits_processor(self.lm_head, hidden_states)
         return logits
+
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        skip_prefixes = ["lm_head."] if self.config.tie_word_embeddings else None
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=skip_prefixes,
+            skip_substrs=["mtp_layers"],
+        )
+        return loader.load_weights(weights)


### PR DESCRIPTION
## Purpose

Part of #15697.

This PR refactors `MiMoForCausalLM` to use `AutoWeightsLoader`. Mirrors the pattern used by `qwen2.py` and the recently merged #41492 (Step3Text) / #41448 (LongCat Flash).

Previously `MiMoModel.load_weights` was a near-duplicate of [`Qwen2Model.load_weights`](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/qwen2.py) with one extra branch (`if "mtp_layers" in name: continue`) to keep MTP-only weights out of the main model. That override is now removed — `MiMoModel` inherits `Qwen2Model.load_weights` directly — and `MiMoForCausalLM.load_weights` delegates through `AutoWeightsLoader` with `skip_substrs=["mtp_layers"]`, matching the pattern used in [`deepseek_v4.py`](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/deepseek_v4.py#L1578) (`AutoWeightsLoader(self, skip_substrs=["mtp."])`).

The standard `skip_prefixes=["lm_head."]` is applied when `config.tie_word_embeddings` is set, matching `Qwen2ForCausalLM`.

This is a refactor only and does not change model architecture or inference behavior. The MTP draft path (`MiMoMTP` in `mimo_mtp.py`) is unaffected — it has its own loader and continues to consume the `model.mtp_layers.*` weights that this loader skips.

Net diff: **+10 / -61 lines** in `vllm/model_executor/models/mimo.py`.

## Test Plan

Local validation:
- `python -m py_compile vllm/model_executor/models/mimo.py`
- import `MiMoForCausalLM` through `ModelRegistry`
- verify `load_weights` on `MiMoModel` is inherited from `Qwen2Model` and `MiMoForCausalLM.load_weights` delegates via `AutoWeightsLoader` with the `mtp_layers` skip
- `ruff check` / `ruff format --check`

CI is expected to run the GPU initialization test:

```bash
CUDA_VISIBLE_DEVICES=0 python -m pytest \
  tests/models/test_initialization.py::test_can_initialize_large_subset \
  -q -k MiMoForCausalLM -s --tb=short
```

## Test Result

Passed:
```bash
python -m py_compile vllm/model_executor/models/mimo.py
```

Passed:
```bash
python - <<'PY'
from vllm.model_executor.models.registry import ModelRegistry
cls = ModelRegistry._try_load_model_cls("MiMoForCausalLM")
print(cls)
assert cls is not None
PY
```

Output:
```text
<class 'vllm.model_executor.models.mimo.MiMoForCausalLM'>
```

Passed:
```bash
python - <<'PY'
from vllm.model_executor.models.mimo import MiMoModel, MiMoForCausalLM
print("MiMoModel.load_weights:", MiMoModel.load_weights.__qualname__)
print("MiMoForCausalLM.load_weights:", MiMoForCausalLM.load_weights.__qualname__)
import inspect
src = inspect.getsource(MiMoForCausalLM.load_weights)
print("Outer delegates via AutoWeightsLoader:", "AutoWeightsLoader" in src)
print("Skips mtp_layers:", "mtp_layers" in src)
PY
```

Output:
```text
MiMoModel.load_weights: Qwen2Model.load_weights
MiMoForCausalLM.load_weights: MiMoForCausalLM.load_weights
Outer delegates via AutoWeightsLoader: True
Skips mtp_layers: True
```

Passed:
```bash
ruff check vllm/model_executor/models/mimo.py
ruff format --check vllm/model_executor/models/mimo.py
```

Output:
```text
All checks passed!
1 file already formatted
```

GPU initialization test deferred to CI — submitter has no local CUDA device. The change is Python-only and does not touch any C++ kernels.

## AI assistance

This change was AI-assisted (Claude Code). The submitter reviewed every changed line, walked through the `AutoWeightsLoader` semantics (including how `skip_substrs` filters at the prefix-grouping level), and validated the structural changes locally.
