### PR TITLE
Fix NIXL Mamba prefix-cache block trimming

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -3,6 +3,8 @@
 """Unit tests for NixlConnectorScheduler with HMA and Mamba N-1 prefill."""
 
 import gc
+from collections import defaultdict
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -377,6 +379,114 @@ def test_get_block_descs_ids_kernel_block_mismatch():
     #   region2: [1001, 1002], region3: [1101, 1102]
     expected = [3, 7, 403, 407, 801, 802, 901, 902, 1001, 1002, 1101, 1102]
     assert list(result) == expected, f"Expected {expected}, got {list(result)}"
+
+
+def _make_fake_read_blocks_worker():
+    from vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker import (
+        NixlConnectorWorker,
+    )
+
+    class FakeNixlWrapper:
+        def __init__(self):
+            self.local_descs = None
+            self.remote_descs = None
+
+        def make_prepped_xfer(
+            self,
+            xfer_type,
+            local_xfer_side_handle,
+            local_block_descs_ids,
+            remote_xfer_side_handle,
+            remote_block_descs_ids,
+            notif_msg=None,
+        ):
+            self.local_descs = local_block_descs_ids
+            self.remote_descs = remote_block_descs_ids
+            return 1
+
+        def transfer(self, handle):
+            return "PROC"
+
+    class FakeTransferTopo:
+        def get_engine_info(self, engine_id):
+            return SimpleNamespace(remote_block_size=16)
+
+        def block_size_ratio(self, remote_block_size):
+            return 1
+
+    worker = object.__new__(NixlConnectorWorker)
+    worker.transfer_topo = FakeTransferTopo()
+    worker.kv_cache_config = make_kv_cache_config(block_size=16, mamba_enabled=True)
+    worker.engine_id = "local-engine"
+    worker.world_size = 1
+    worker.num_regions = 2
+    worker.dst_num_blocks = {"local-engine": 100, "remote-engine": 100}
+    worker._has_mamba = True
+    worker._is_mamba_group = [False, True]
+    worker._physical_blocks_per_logical = {
+        "local-engine": 1,
+        "remote-engine": 1,
+    }
+    worker.block_len_per_layer = [100]
+    worker.nixl_wrapper = FakeNixlWrapper()
+    worker._recving_transfers = defaultdict(list)
+    return worker
+
+
+@pytest.mark.cpu_test
+def test_read_blocks_trims_mamba_remote_prefix_padding():
+    """Hybrid prefix hits can leave leading null blocks in remote Mamba groups.
+
+    The transfer descriptor lists must still have the same length after trimming
+    remote groups down to the local transfer slots.
+    """
+    worker = _make_fake_read_blocks_worker()
+    worker._read_blocks(
+        local_block_ids=([16], [17]),
+        remote_block_ids=([0, 18], [0, 19]),
+        dst_engine_id="remote-engine",
+        request_id="decode-req",
+        remote_request_id="prefill-req",
+        remote_rank=0,
+        local_xfer_side_handle=10,
+        remote_xfer_side_handle=20,
+    )
+
+    assert list(worker.nixl_wrapper.local_descs) == [
+        16,
+        116,
+        217,
+        317,
+        417,
+        517,
+    ]
+    assert list(worker.nixl_wrapper.remote_descs) == [
+        18,
+        118,
+        219,
+        319,
+        419,
+        519,
+    ]
+
+
+@pytest.mark.cpu_test
+def test_read_blocks_drops_remote_group_when_no_local_slots():
+    """Avoid keeping a remote group accidentally via Python's ``[-0:]``."""
+    worker = _make_fake_read_blocks_worker()
+    worker._read_blocks(
+        local_block_ids=([16], []),
+        remote_block_ids=([0, 18], [0]),
+        dst_engine_id="remote-engine",
+        request_id="decode-req",
+        remote_request_id="prefill-req",
+        remote_rank=0,
+        local_xfer_side_handle=10,
+        remote_xfer_side_handle=20,
+    )
+
+    assert list(worker.nixl_wrapper.local_descs) == [16, 116]
+    assert list(worker.nixl_wrapper.remote_descs) == [18, 118]
 
 
 @pytest.mark.cpu_test

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -2065,13 +2065,15 @@ class NixlConnectorWorker:
         for i, remote_group in enumerate(remote_block_ids):
             num_remote_blocks = len(remote_group)
             num_local_blocks = len(local_block_ids[i])
-            if not self._is_mamba_group[i]:
-                assert num_local_blocks <= num_remote_blocks
-            # Partial prefix cache hit: just read uncomputed blocks.
-            # Skip mamba groups — their blocks represent full state (conv+ssm),
-            # not per-token data, so trimming would corrupt the transfer.
-            if num_local_blocks < num_remote_blocks and not self._is_mamba_group[i]:
-                remote_block_ids[i] = remote_group[-num_local_blocks:]
+            assert num_local_blocks <= num_remote_blocks
+            # Partial prefix cache hit: just read uncomputed blocks. With HMA,
+            # remote groups can include leading null/prefix-cached blocks while
+            # local groups contain only newly allocated transfer slots. This also
+            # applies to Mamba align-mode state blocks.
+            if num_local_blocks < num_remote_blocks:
+                remote_block_ids[i] = (
+                    remote_group[-num_local_blocks:] if num_local_blocks else []
+                )
 
         # NOTE (nicolo) With homogeneous TP, each TP worker loads KV from
         # corresponding rank. With heterogeneous TP, fixing D>P, the D tp

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -2068,8 +2068,7 @@ class NixlConnectorWorker:
             assert num_local_blocks <= num_remote_blocks
             # Partial prefix cache hit: just read uncomputed blocks. With HMA,
             # remote groups can include leading null/prefix-cached blocks while
-            # local groups contain only newly allocated transfer slots. This also
-            # applies to Mamba align-mode state blocks.
+            # local groups contain only newly allocated transfer slots.
             if num_local_blocks < num_remote_blocks:
                 remote_block_ids[i] = (
                     remote_group[-num_local_blocks:] if num_local_blocks else []


### PR DESCRIPTION
<!-- markdownlint-disable -->
Trim remote Mamba block groups to the decode worker's local receive slots before descriptor expansion. This keeps local and remote NIXL descriptor counts aligned for partial prefix-cache hits on hybrid SSM/Mamba models.

## Purpose

This fixes a decode-side NIXL assertion when prefix caching is enabled for hybrid SSM/Mamba models under disaggregated prefill/decode:

```text
vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
assert len(local_block_descs_ids) == len(remote_block_descs_ids)
```

In the failing case, the decode worker can already have some prefix state in its local prefix cache, while the prefill worker's remote metadata still includes block IDs from the beginning of the prefetched prompt. That means the remote side can have leading prefix/null/alignment entries that do not have corresponding local receive slots:

```python
local_block_ids  = [[16], [17], [18], [19], [20, 21]]
remote_block_ids = [[0, 17], [0, 19], [0, 21], [0, 23], [24, 25]]
```

The existing NIXL path already trimmed remote attention groups to the local suffix length for partial prefix-cache hits. A previous Mamba/HMA change skipped that trimming for Mamba groups because Mamba blocks represent full conv+SSM state rather than per-token KV. That concern is valid for slicing inside a single Mamba state, but this PR only drops unmatched leading whole Mamba block IDs before descriptor expansion. Each retained Mamba block still expands into the complete transfer unit, including x/B/C conv regions and SSM state.

The fix applies the same cardinality invariant to Mamba groups:

- each local receive slot must have one corresponding remote block;
- remote may be longer because of prefix-cache hits, so we keep the remote tail;
- if there are zero local receive slots, the remote group must become empty instead of accidentally preserving the full group via Python's `[-0:]` slice behavior.

Duplicate-work check: searched open PRs for `nixl mamba prefix cache` and `NixlConnector Mamba prefix caching`. The only nearby open PR was #40826, which handles heterogeneous split K/V policy support and does not address Mamba prefix-cache block trimming or this descriptor-count assertion.

This PR was prepared with AI assistance; I reviewed the changed lines and validated the repro/test results below.

## Test Plan

Unit coverage:

```bash
python -m pytest tests/v1/kv_connector/unit/test_nixl_connector_hma.py -m cpu_test -q
```

Manual repro validation:

- model: `nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8`
- setup: Dynamo disaggregated prefill/decode, one H100 for prefill and one H100 for decode
- connector: `{"kv_connector":"NixlConnector","kv_role":"kv_both"}`
- important env: `VLLM_SSM_CONV_STATE_LAYOUT=DS`
- prefix caching enabled
- loadgen:
  - 8 shared-prefix chat-completion requests with a long BrowseComp-style prompt
  - AIPerf chat profile with one shared 768-token prefix, concurrency 2, 1 warmup + 8 profiled requests, forced 2048 output tokens with `min_tokens:2048` and `ignore_eos:true`

## Test Result

Unit/lint:

```text
21 passed, 1 deselected
ruff-check passed
ruff-format passed
```

Manual repro:

- simple shared-prefix driver completed 8/8 requests with HTTP 200
- AIPerf completed 8/8 profiled requests with 0 errors and 0 cancellations
- AIPerf run details:
  - average input length: 848.9 tokens
  - output length: 2048 tokens for every profiled request
  - average TTFT: ~209 ms
  - average request latency: ~18.0 s
- searched decode/prefill/frontend logs for `AssertionError`, `local_block_ids`, `remote.block_ids`, `connector_prefix_cache_stats`, `Traceback`, `ERROR`, and `read_blocks`; no NIXL assertion or block-group mismatch appeared
- `/v1/models` continued returning 200 after the run, confirming the disaggregated endpoints survived the workload

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
