### PR TITLE
Fix multiturn think leakage when tool parser is composed with reasoning parser

### DIFF
--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -648,21 +648,37 @@ class DelegatingParser(Parser):
         return state.reasoning_ended
 
     def _expect_streamed_thinking_blocks(self) -> bool:
-        """True when chat template kwargs say the model emits thinking in outputs.
+        """True when chat template kwargs say the model emits thinking in
+        outputs (``thinking=True`` or ``enable_thinking=True``).  When
+        kwargs are missing, falls back to the reasoning parser: any
+        ``reasoning_start_str`` implies streamed thinking blocks
+        (DeepSeek / R1 / Qwen3-thinking, but *not* Identity).
 
-        Mirrors ``DeepSeekV3ReasoningParser`` so multi-turn DeepSeek keeps streaming
-        reasoning extraction while Qwen-style ``thinking=false`` + tools can still
-        use ``is_reasoning_end(prompt)`` to skip empty prefilled think spans.
+        An explicit ``thinking=False`` / ``enable_thinking=False``
+        overrides the fallback so Qwen3-thinking-disabled + tools can
+        still use ``is_reasoning_end(prompt)``.
         """
-        kwargs = getattr(self, "_chat_template_kwargs", None)
-        if kwargs is None:
-            return False
-        # Be defensive: some custom parser construction paths may pass the full
-        # ``kwargs`` dict, where chat template options are nested one level deeper.
+        # 1. Respect explicit kwargs (handle both flat and nested shapes).
+        kwargs = getattr(self, "_chat_template_kwargs", None) or {}
         chat_kwargs = kwargs.get("chat_template_kwargs", kwargs)
-        return bool(chat_kwargs.get("thinking")) or bool(
-            chat_kwargs.get("enable_thinking")
-        )
+        if isinstance(chat_kwargs, dict):
+            if bool(chat_kwargs.get("thinking")) or bool(
+                chat_kwargs.get("enable_thinking")
+            ):
+                return True
+            if (
+                chat_kwargs.get("thinking") is False
+                or chat_kwargs.get("enable_thinking") is False
+            ):
+                return False
+        # 2. Fallback: a reasoning parser with a start token implies streaming
+        #    think blocks (DeepSeek/R1/Qwen3-thinking). IdentityReasoningParser
+        #    has reasoning_start_str=None and correctly falls through to False.
+        if self._reasoning_parser is not None:
+            return (
+                getattr(self._reasoning_parser, "reasoning_start_str", None) is not None
+            )
+        return False
 
     def _should_prefill_reasoning_ended_from_prompt(self) -> bool:
         """Whether to apply ``is_reasoning_end`` on ``prompt_token_ids``."""

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -657,7 +657,7 @@ class DelegatingParser(Parser):
 
         if not state.prompt_reasoning_checked and prompt_token_ids is not None:
             state.prompt_reasoning_checked = True
-            if self.is_reasoning_end(prompt_token_ids):
+            if self._tool_parser is None and self.is_reasoning_end(prompt_token_ids):
                 state.reasoning_ended = True
 
         current_text = state.previous_text + delta_text

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -7,6 +7,7 @@ from abc import abstractmethod
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from functools import cached_property
+from typing import Any
 
 from openai.types.responses import (
     ResponseFunctionToolCall,
@@ -54,6 +55,7 @@ class StreamState:
 
     reasoning_ended: bool = False
     tool_call_text_started: bool = False
+    prompt_reasoning_checked: bool = False
     previous_text: str = ""
     previous_token_ids: list[int] = field(default_factory=list)
     history_tool_call_cnt: int = 0
@@ -645,6 +647,24 @@ class DelegatingParser(Parser):
             return True
         return state.reasoning_ended
 
+    def _expect_streamed_thinking_blocks(self) -> bool:
+        """True when chat template kwargs say the model emits thinking in outputs.
+
+        Mirrors ``DeepSeekV3ReasoningParser`` so multi-turn DeepSeek keeps streaming
+        reasoning extraction while Qwen-style ``thinking=false`` + tools can still
+        use ``is_reasoning_end(prompt)`` to skip empty prefilled think spans.
+        """
+        kwargs = getattr(self, "_chat_template_kwargs", None)
+        if kwargs is None:
+            return False
+        return bool(kwargs.get("thinking")) or bool(kwargs.get("enable_thinking"))
+
+    def _should_prefill_reasoning_ended_from_prompt(self) -> bool:
+        """Whether to apply ``is_reasoning_end`` on ``prompt_token_ids``."""
+        if self._tool_parser is None:
+            return True
+        return not self._expect_streamed_thinking_blocks()
+
     def parse_delta(
         self,
         delta_text: str,
@@ -653,6 +673,19 @@ class DelegatingParser(Parser):
         prompt_token_ids: list[int] | None = None,
     ) -> DeltaMessage | None:
         state = self._stream_state
+
+        # GitHub #40801: ``is_reasoning_end(full_prompt)`` sees prior turns'
+        # ``</think>`` and must not pre-mark reasoning ended when the
+        # model still emits thinking (merged ``thinking`` / ``enable_thinking``).
+        # When thinking is off + tools (e.g. Qwen), keep the prompt shortcut so the
+        # first tokens route to content/tool parsing instead of ``reasoning=``.
+        if not state.prompt_reasoning_checked and prompt_token_ids is not None:
+            state.prompt_reasoning_checked = True
+            if (
+                self._should_prefill_reasoning_ended_from_prompt()
+                and self.is_reasoning_end(prompt_token_ids)
+            ):
+                state.reasoning_ended = True
 
         current_text = state.previous_text + delta_text
         current_token_ids = state.previous_token_ids + delta_token_ids
@@ -733,6 +766,11 @@ class _WrappedParser(DelegatingParser):
         self, tokenizer: TokenizerLike, tools: list[Tool] | None = None, **kwargs
     ):
         super().__init__(tokenizer)
+        # Merged request + server defaults (see OpenAIServingChat); used to gate
+        # prompt-level reasoning_ended (direction-A fix for #40801 vs Qwen tools).
+        self._chat_template_kwargs: dict[str, Any] | None = kwargs.get(
+            "chat_template_kwargs"
+        )
         # Instantiate the underlying parsers from class attributes
         if self.__class__.reasoning_parser_cls is not None:
             self._reasoning_parser = self.__class__.reasoning_parser_cls(

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -657,7 +657,12 @@ class DelegatingParser(Parser):
         kwargs = getattr(self, "_chat_template_kwargs", None)
         if kwargs is None:
             return False
-        return bool(kwargs.get("thinking")) or bool(kwargs.get("enable_thinking"))
+        # Be defensive: some custom parser construction paths may pass the full
+        # ``kwargs`` dict, where chat template options are nested one level deeper.
+        chat_kwargs = kwargs.get("chat_template_kwargs", kwargs)
+        return bool(chat_kwargs.get("thinking")) or bool(
+            chat_kwargs.get("enable_thinking")
+        )
 
     def _should_prefill_reasoning_ended_from_prompt(self) -> bool:
         """Whether to apply ``is_reasoning_end`` on ``prompt_token_ids``."""

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -54,7 +54,6 @@ class StreamState:
 
     reasoning_ended: bool = False
     tool_call_text_started: bool = False
-    prompt_reasoning_checked: bool = False
     previous_text: str = ""
     previous_token_ids: list[int] = field(default_factory=list)
     history_tool_call_cnt: int = 0
@@ -654,11 +653,6 @@ class DelegatingParser(Parser):
         prompt_token_ids: list[int] | None = None,
     ) -> DeltaMessage | None:
         state = self._stream_state
-
-        if not state.prompt_reasoning_checked and prompt_token_ids is not None:
-            state.prompt_reasoning_checked = True
-            if self._tool_parser is None and self.is_reasoning_end(prompt_token_ids):
-                state.reasoning_ended = True
 
         current_text = state.previous_text + delta_text
         current_token_ids = state.previous_token_ids + delta_token_ids

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -648,15 +648,29 @@ class DelegatingParser(Parser):
         return state.reasoning_ended
 
     def _expect_streamed_thinking_blocks(self) -> bool:
-        """True when chat template kwargs say the model emits thinking in
-        outputs (``thinking=True`` or ``enable_thinking=True``).  When
-        kwargs are missing, falls back to the reasoning parser: any
-        ``reasoning_start_str`` implies streamed thinking blocks
-        (DeepSeek / R1 / Qwen3-thinking, but *not* Identity).
+        """Return True when the model is expected to emit thinking tokens.
 
-        An explicit ``thinking=False`` / ``enable_thinking=False``
-        overrides the fallback so Qwen3-thinking-disabled + tools can
-        still use ``is_reasoning_end(prompt)``.
+        Decision matrix::
+
+            thinking=True  / enable_thinking=True  -> True
+            thinking=False / enable_thinking=False -> False  (explicit, beats fallback)
+            key absent, reasoning_parser has reasoning_start_str  -> True
+                (DeepSeek / R1 / Qwen3-thinking)
+            key absent, IdentityReasoningParser (reasoning_start_str=None) -> False
+            no reasoning_parser                                    -> False
+
+        Two-stage logic:
+
+        1. **Explicit kwargs** – ``_chat_template_kwargs`` may be flat
+           ``{"thinking": True}`` or nested ``{"chat_template_kwargs": {...}}``;
+           both shapes are handled.  An explicit ``False`` overrides the
+           fallback, so Qwen3-thinking-disabled + tools keeps the
+           ``is_reasoning_end(prompt)`` shortcut.
+
+        2. **Reasoning-parser fallback** – when kwargs are absent or the key
+           is not present, the presence of ``reasoning_start_str`` (e.g.
+           ``"<think>"``) is a reliable signal that the model was configured
+           to emit streamed thinking blocks.
         """
         # 1. Respect explicit kwargs (handle both flat and nested shapes).
         kwargs = getattr(self, "_chat_template_kwargs", None) or {}


### PR DESCRIPTION
## Purpose

- Fixes: #40801
- relevant  #40806 


### NOTE : Co-Author by  AI



### Problem

Multi-turn DeepSeek conversations leak raw `<think>...</think>` tags
into the user-visible `content` field.

### Root Cause

`parse_delta()` calls `is_reasoning_end()` on the full prompt token IDs.
Multi-turn chat prompts contain `</think>` from prior assistant turns (injected by the chat template). 
The backward scan hits that old token, sets `reasoning_ended=True` before the first generated token, and bypasses reasoning extraction entirely. 
The model's new `<think>...</think>` output lands in `DeepSeekV32ToolParser._extract_content()`, which ships
it verbatim as content.

### Fix

Instead of a blanket removal, condition the prompt-level check on whether the model is expected to emit thinking blocks in its own output:

- `_expect_streamed_thinking_blocks()` mirrors the existing   `DeepSeekV3ReasoningParser` logic: it reads `chat_template_kwargs`   for `thinking` / `enable_thinking`.
- `_should_prefill_reasoning_ended_from_prompt()` returns `False` when   a tool parser is present **and** the model will generate its own   `<think>` tags — so DeepSeek multi-turn skips the prompt shortcut   and lets the streaming reasoning parser handle the turn correctly.
- When `_tool_parser is None`, or when the model does **not** generate  its own thinking blocks (e.g. Qwen3 `enable_thinking=False`), the  prompt-level check is preserved.

### Behavior Matrix

| Scenario | `_expect_thinking` | `_tool_parser` | Prompt check | Result |
|---|---|---|---|---|
| DeepSeek V3.2/V4 thinking + tools | True | present | skipped | streaming reasoning parser strips `<think>` ✅ |
| Qwen3 thinking=false + tools | False | present | executed | prompt `</think>` ends reasoning immediately ✅ |
| Any model, no tools | — | None | executed | original behavior preserved ✅ |
| DeepSeek single-turn | True | present | skipped | single-turn prompt has no `</think>`, no impact ✅ |



## Test Plan

using script to reproduce (generated by AI)
```
#!/usr/bin/env python3

"""Minimal repro: multiturn prompt ends with </think> -> think leaks to content.

Bug: ``DelegatingParser.parse_delta`` used ``is_reasoning_end(full_prompt_token_ids)``
even when a tool parser is composed; full chat prompts contain *prior* assistants'
closing think tokens, so ``reasoning_ended`` becomes True before the new assistant
stream → reasoning strip is skipped → ``DeepSeekV32ToolParser`` emits think tags
as normal ``content``.

Exit 0 if fixed (no ``<think>`` in streamed client ``content``).
Exit 1 if unfixed (leak reproduced).
"""

from __future__ import annotations

import sys
from unittest.mock import MagicMock

from vllm.parser.abstract_parser import _WrappedParser
from vllm.reasoning.deepseek_r1_reasoning_parser import DeepSeekR1ReasoningParser
from vllm.tool_parsers.deepseekv32_tool_parser import DeepSeekV32ToolParser

# Match DeepSeek tokenizer special ids used in repro traces (mock vocab only).
_START_ID = 128821
_END_ID = 128822


def _mock_tokenizer():
    tok = MagicMock()
    tok.get_vocab.return_value = {
        "<think>": _START_ID,
        "</think>": _END_ID,
    }
    tok.tokenize.return_value = []
    return tok


def _tiny_fc() -> str:
    return (
        "<｜DSML｜function_calls>\n"
        '<｜DSML｜invoke name="fn">\n'
        "</｜DSML｜invoke>\n"
        "</｜DSML｜function_calls>"
    )


class _P(_WrappedParser):
    reasoning_parser_cls = DeepSeekR1ReasoningParser
    tool_parser_cls = DeepSeekV32ToolParser


def main() -> int:
    assistant = "<think>secret plan</think>\n\n" + _tiny_fc()
    # Synthetic multiturn prompt: history closed a think span (ids walk backward hits END).
    multiturn_prompt_ids = [_START_ID, 100, _END_ID]

    req = MagicMock()
    req.tools = []
    req.tool_choice = "auto"

    tok = _mock_tokenizer()
    parser = _P(tok, tools=None)

    # One-shot stream chunk; delta_token_ids must contain think start/end so reasoning
    # parser can strip when the bug is fixed.
    delta_ids = [_START_ID, 100, 100, _END_ID, 1, 2, 3, 4]

    msg = parser.parse_delta(
        assistant,
        list(delta_ids),
        req,
        prompt_token_ids=list(multiturn_prompt_ids),
    )

    visible = msg.content if msg is not None else None
    leaked = visible is not None and (
        "<think>" in visible or "</think>" in visible
    )

    if leaked:
        print("BUG (unfixed): think tags in client-visible content:", repr(visible))
        return 1

    print("OK (fixed): no think tags in content delta:", repr(visible))
    return 0


if __name__ == "__main__":
    sys.exit(main())

```

## Test Result


```
kubectl -n public exec -it deepseek-v4-pro-llm-d-modelservice-decode-0 -- bash

python3 /tmp/test_dsml_mini.py
OK (fixed): no think tags in content delta: '\n\n'
```

Before:

```
python3 /tmp/test_dsml_mini.py
BUG (unfixed): think tags in client-visible content: '<think>secret plan</think>\n\n'
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

