### PR TITLE
[Bugfix] Guard against buffered token IDs in BaseThinkingReasoningParser streaming

### DIFF
--- a/tests/reasoning/test_base_thinking_reasoning_parser.py
+++ b/tests/reasoning/test_base_thinking_reasoning_parser.py
@@ -436,3 +436,39 @@ class TestBaseThinkingReasoningParserEdgeCases:
         # Should treat as regular content since tokens don't match exactly
         assert reasoning == ("<test:thinking>Not a real token</test:thinking>Content")
         assert content is None
+
+
+class TestBaseThinkingStreamingBuffered:
+    """Test streaming with buffered token IDs (stream_interval > 1)."""
+
+    def test_end_token_id_buffered_with_start_in_previous(self, test_tokenizer):
+        """end_token_id in delta but end_token text not yet flushed."""
+        parser = TestThinkingReasoningParser(test_tokenizer)
+        start_id = parser.start_token_id
+        end_id = parser.end_token_id
+
+        result = parser.extract_reasoning_streaming(
+            previous_text="some reasoning",
+            current_text="some reasoning more",
+            delta_text="more",  # end_token text NOT present
+            previous_token_ids=[start_id],
+            current_token_ids=[start_id, end_id, 999],
+            delta_token_ids=[end_id, 999],
+        )
+        assert result is None
+
+    def test_both_tokens_buffered_in_delta(self, test_tokenizer):
+        """start and end token IDs in delta but text not yet flushed."""
+        parser = TestThinkingReasoningParser(test_tokenizer)
+        start_id = parser.start_token_id
+        end_id = parser.end_token_id
+
+        result = parser.extract_reasoning_streaming(
+            previous_text="",
+            current_text="prefix",
+            delta_text="prefix",  # neither token text present
+            previous_token_ids=[],
+            current_token_ids=[start_id, end_id, 999],
+            delta_token_ids=[start_id, end_id, 999],
+        )
+        assert result is None

--- a/vllm/reasoning/basic_parsers.py
+++ b/vllm/reasoning/basic_parsers.py
@@ -121,6 +121,10 @@ class BaseThinkingReasoningParser(ReasoningParser):
             if self.end_token_id in delta_token_ids:
                 # start token in previous, end token in delta,
                 # extract reasoning content
+                if self.end_token not in delta_text:
+                    # Token ID arrived before text was flushed
+                    # (stop-sequence buffering). Wait for next delta.
+                    return None
                 end_index = delta_text.find(self.end_token)
                 reasoning = delta_text[:end_index]
                 content = delta_text[end_index + len(self.end_token) :]
@@ -139,6 +143,13 @@ class BaseThinkingReasoningParser(ReasoningParser):
             if self.end_token_id in delta_token_ids:
                 # start token in delta, end token in delta,
                 # extract reasoning content
+                if (
+                    self.start_token not in delta_text
+                    or self.end_token not in delta_text
+                ):
+                    # Token IDs arrived before text was flushed.
+                    # Wait for next delta.
+                    return None
                 start_index = delta_text.find(self.start_token)
                 end_index = delta_text.find(self.end_token)
                 reasoning = delta_text[start_index + len(self.start_token) : end_index]


### PR DESCRIPTION
## Purpose

Fix streaming token truncation when `--stream-interval > 1` with reasoning parsers (e.g. `--reasoning-parser gemma4`).

When `stream_interval > 1`, token IDs can arrive in `delta_token_ids` before their text is flushed to `delta_text` (stop-sequence buffering). `find()` then returns `-1`, causing `delta_text[:-1]` which silently drops the last character of reasoning output.

This adds text-presence guards before `find()` calls in `BaseThinkingReasoningParser.extract_reasoning_streaming()`, matching the pattern already applied in KimiK2 (#41068), Hermes, GLM, DeepSeekV3.2, and MiniMax M2 parsers.

Fixes #41691

## Test Plan

```bash
pytest tests/reasoning/test_base_thinking_reasoning_parser.py -xvs
```

## Test Result

```
26 passed, 18 warnings in 11.84s
```

- All existing tests pass (no regression)
- New `TestBaseThinkingStreamingBuffered` tests verify both buffering scenarios:
  - `end_token_id` in delta with start in previous, text not yet flushed
  - Both `start_token_id` and `end_token_id` in delta, text not yet flushed


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

