### PR TITLE
[Model] Use AutoWeightsLoader for Plamo2

### DIFF
--- a/vllm/model_executor/models/plamo2.py
+++ b/vllm/model_executor/models/plamo2.py
@@ -797,6 +797,83 @@ class Plamo2Model(torch.nn.Module):
         hidden_states, _ = self.norm(hidden_states, residual)
         return hidden_states
 
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        params_dict = dict(self.named_parameters())
+        loaded_params: set[str] = set()
+        for name, loaded_weight in weights:
+            # Update the weight names to be compatible with the vllm version
+            # of the model.
+            # Do not change the order of the replacements.
+            replacements = {
+                # Rename incompatible weight names.
+                ".A_log": ".A",
+                ".B_norm_weight": ".B_norm.weight",
+                ".C_norm_weight": ".C_norm.weight",
+                ".dt_norm_weight": ".dt_norm.weight",
+                ".q_weight": ".q_norm.weight",
+                ".k_weight": ".k_norm.weight",
+            }
+            # Apply replacements based on the defined mappings
+            for old, new in replacements.items():
+                if old in name:
+                    name = name.replace(old, new)
+
+            # Reshape the in_proj weights to match the shape expected
+            # by MergedColumnParallelLinear.
+            # This works both for unquantized weights and
+            # for quantized weights.
+            # In the quantized case, the weights are already transposed.
+            # Also, in addition to the quantized weights,
+            # the zero points and scales have to be reshaped as well.
+            # Packing should not be affected by this.
+            if (
+                ".mixer.in_proj.weight" in name
+                or "mixer.in_proj.qweight" in name
+                or "mixer.in_proj.scales" in name
+                or "mixer.in_proj.qzeros" in name
+            ):
+                if "mixer.in_proj.weight" in name:
+                    loaded_weight = loaded_weight.transpose(0, 1)
+                # for weight:
+                # loaded_weight.shape[0] == self.config.hidden_size
+                # for qweight:
+                # loaded_weight.shape[0] == self.config.hidden_size // param.pack_factor  # noqa
+                # for scales and qzeros:
+                # loaded_weight.shape[0] == self.config.hidden_size // self.vllm_config.quant_config.group_size  # noqa
+                loaded_weight = loaded_weight.reshape(
+                    loaded_weight.shape[0], self.config.mamba_num_heads, -1
+                )
+                gate_weight, hidden_states_weight = loaded_weight.chunk(2, dim=-1)
+                gate_weight = gate_weight.reshape(loaded_weight.shape[0], -1)
+                hidden_states_weight = hidden_states_weight.reshape(
+                    loaded_weight.shape[0], -1
+                )
+                loaded_weight = torch.cat([gate_weight, hidden_states_weight], dim=-1)
+                if "mixer.in_proj.weight" in name:
+                    loaded_weight = loaded_weight.transpose(0, 1)
+
+            # Offset parameter with vllm's RMSNorm haven't been supported yet.
+            if ".pre_mixer_norm" in name:
+                loaded_weight += 1.0
+            elif ".post_mixer_norm" in name:
+                loaded_weight += 1.0 / 5
+            elif ".pre_mlp_norm" in name:
+                loaded_weight += 1.0
+            elif ".post_mlp_norm" in name:
+                loaded_weight += 1.0 / (5**1.5)
+            elif name == "norm.weight":
+                loaded_weight += 1.0
+
+            # Skip layers on other devices.
+            if is_pp_missing_parameter(name, self):
+                continue
+
+            param = params_dict[name]
+            weight_loader = getattr(param, "weight_loader", default_weight_loader)
+            weight_loader(param, loaded_weight)
+            loaded_params.add(name)
+        return loaded_params
+
 
 class Plamo2ForCausalLM(
     torch.nn.Module, HasInnerState, SupportsLoRA, SupportsPP, IsHybrid
@@ -906,88 +983,9 @@ class Plamo2ForCausalLM(
         logits = self.logits_processor(self.lm_head, hidden_states)
         return logits
 
-    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]):
-        params_dict = dict(self.named_parameters())
-        for name, loaded_weight in weights:
-            # Both tie_word_embeddings=True and lm_head.weight in the safetensor
-            # at the same time causes dict key access error.
-            if name == "lm_head.weight" and self.config.tie_word_embeddings:
-                assert "lm_head.weight" not in params_dict
-                continue
-            # Same workaround as AutoWeightsLoader for GPTQModel
-            if any(
-                substr in name
-                for substr in AutoWeightsLoader.ROTARY_EMBEDS_UNUSED_WEIGHTS
-            ):
-                continue
-
-            # Update the weight names to be compatible with the vllm version
-            # of the model.
-            # Do not change the order of the replacements.
-            replacements = {
-                # Rename incompatible weight names.
-                ".A_log": ".A",
-                ".B_norm_weight": ".B_norm.weight",
-                ".C_norm_weight": ".C_norm.weight",
-                ".dt_norm_weight": ".dt_norm.weight",
-                ".q_weight": ".q_norm.weight",
-                ".k_weight": ".k_norm.weight",
-            }
-            # Apply replacements based on the defined mappings
-            for old, new in replacements.items():
-                if old in name:
-                    name = name.replace(old, new)
-
-            # Reshape the in_proj weights to match the shape expected
-            # by MergedColumnParallelLinear.
-            # This works both for unquantized weights and
-            # for quantized weights.
-            # In the quantized case, the weights are already transposed.
-            # Also, in addition to the quantized weights,
-            # the zero points and scales have to be reshaped as well.
-            # Packing should not be affected by this.
-            if (
-                ".mixer.in_proj.weight" in name
-                or "mixer.in_proj.qweight" in name
-                or "mixer.in_proj.scales" in name
-                or "mixer.in_proj.qzeros" in name
-            ):
-                if "mixer.in_proj.weight" in name:
-                    loaded_weight = loaded_weight.transpose(0, 1)
-                # for weight:
-                # loaded_weight.shape[0] == self.config.hidden_size
-                # for qweight:
-                # loaded_weight.shape[0] == self.config.hidden_size // param.pack_factor  # noqa
-                # for scales and qzeros:
-                # loaded_weight.shape[0] == self.config.hidden_size // self.vllm_config.quant_config.group_size  # noqa
-                loaded_weight = loaded_weight.reshape(
-                    loaded_weight.shape[0], self.config.mamba_num_heads, -1
-                )
-                gate_weight, hidden_states_weight = loaded_weight.chunk(2, dim=-1)
-                gate_weight = gate_weight.reshape(loaded_weight.shape[0], -1)
-                hidden_states_weight = hidden_states_weight.reshape(
-                    loaded_weight.shape[0], -1
-                )
-                loaded_weight = torch.cat([gate_weight, hidden_states_weight], dim=-1)
-                if "mixer.in_proj.weight" in name:
-                    loaded_weight = loaded_weight.transpose(0, 1)
-
-            # Offset parameter with vllm's RMSNorm haven't been supported yet.
-            if ".pre_mixer_norm" in name:
-                loaded_weight += 1.0
-            elif ".post_mixer_norm" in name:
-                loaded_weight += 1.0 / 5
-            elif ".pre_mlp_norm" in name:
-                loaded_weight += 1.0
-            elif ".post_mlp_norm" in name:
-                loaded_weight += 1.0 / (5**1.5)
-            elif "model.norm.weight" in name:
-                loaded_weight += 1.0
-
-            # Skip layers on other devices.
-            if is_pp_missing_parameter(name, self):
-                continue
-
-            param = params_dict[name]
-            weight_loader = getattr(param, "weight_loader", default_weight_loader)
-            weight_loader(param, loaded_weight)
+    def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
+        loader = AutoWeightsLoader(
+            self,
+            skip_prefixes=(["lm_head."] if self.config.tie_word_embeddings else None),
+        )
+        return loader.load_weights(weights)


### PR DESCRIPTION
## Purpose

Part of #15697.

This PR refactors `Plamo2ForCausalLM` to use `AutoWeightsLoader`. Mirrors the pattern used by `qwen2.py` and the recently merged #41492 (Step3Text), #41448 (LongCat Flash), #38955 (Arctic), and #41690 (CohereMoe).

The PLaMo2 weight-loading logic is moved verbatim from `Plamo2ForCausalLM` to the reusable `Plamo2Model` backbone — name remappings, `mixer.in_proj` reshape, and RMSNorm offsets all preserved. `Plamo2ForCausalLM.load_weights` now delegates through `AutoWeightsLoader`, matching the standardized loading pattern used by other language models.

This is a refactor only and does not change model architecture or inference behavior.

### Adjustments inside the moved body

Three small textual edits, each required because `AutoWeightsLoader` strips the `model.` prefix when it recurses into `self.model`:

1. Removed the inline `if name == "lm_head.weight" and self.config.tie_word_embeddings: continue` block — handled at the `*ForCausalLM` level by `skip_prefixes=["lm_head."]` when embeddings are tied.
2. Removed the inline rotary-substr skip — `AutoWeightsLoader` applies its built-in `ROTARY_EMBEDS_UNUSED_WEIGHTS` list automatically (`vllm/model_executor/models/utils.py:159`).
3. Changed `elif "model.norm.weight" in name:` to `elif name == "norm.weight":`. Once the `model.` prefix is stripped, the original substring would also match unrelated inner norms (e.g., `layers.X.mixer.q_norm.weight`); exact equality is precise.

Also added `loaded_params: set[str]` tracking and a `-> set[str]` return type to satisfy the `AutoWeightsLoader` contract (the original returned `None`).

Net diff: **+83 / −85 lines** in `vllm/model_executor/models/plamo2.py`.

## Test Plan

Local validation:
- `python -m py_compile vllm/model_executor/models/plamo2.py`
- import `Plamo2ForCausalLM` through `ModelRegistry`
- verify `load_weights` is implemented on both `Plamo2Model` and `Plamo2ForCausalLM`
- verify the outer delegation uses `AutoWeightsLoader`
- `ruff check` / `ruff format --check`

Correctness verification (lm-eval against `pfnet/plamo-2-1b`):

```bash
lm_eval --model vllm \
  --model_args pretrained=pfnet/plamo-2-1b,trust_remote_code=True,dtype=auto,max_model_len=4096 \
  --tasks gsm8k --num_fewshot 5 --batch_size auto --limit 250
```

CI is also expected to run the GPU initialization test:

```bash
CUDA_VISIBLE_DEVICES=0 python -m pytest \
  tests/models/test_initialization.py::test_can_initialize_large_subset \
  -q -k Plamo2ForCausalLM -s --tb=short
```

## Test Result

Passed:
```bash
python -m py_compile vllm/model_executor/models/plamo2.py
```

Passed:
```bash
python - <<'PY'
from vllm.model_executor.models.registry import ModelRegistry
cls = ModelRegistry._try_load_model_cls("Plamo2ForCausalLM")
print(cls)
assert cls is not None
PY
```

Output:
```text
<class 'vllm.model_executor.models.plamo2.Plamo2ForCausalLM'>
```

Passed:
```bash
python - <<'PY'
from vllm.model_executor.models.plamo2 import Plamo2Model, Plamo2ForCausalLM
print("Plamo2Model.load_weights:", Plamo2Model.load_weights.__qualname__)
print("Plamo2ForCausalLM.load_weights:", Plamo2ForCausalLM.load_weights.__qualname__)
import inspect
src = inspect.getsource(Plamo2ForCausalLM.load_weights)
print("Outer delegates via AutoWeightsLoader:", "AutoWeightsLoader" in src)
PY
```

Output:
```text
Plamo2Model.load_weights: Plamo2Model.load_weights
Plamo2ForCausalLM.load_weights: Plamo2ForCausalLM.load_weights
Outer delegates via AutoWeightsLoader: True
```

Passed:
```bash
ruff check vllm/model_executor/models/plamo2.py
ruff format --check vllm/model_executor/models/plamo2.py
```

Output:
```text
All checks passed!
1 file already formatted
```

### lm-eval correctness (Colab T4, identical command and seed)

**main** (`0c620d2e0`, parent of this PR):

| Tasks | Filter | n-shot | Metric | Value | Stderr |
|---|---|---|---|---|---|
| gsm8k | flexible-extract | 5 | exact_match | 0.02 | ±0.0089 |
|       | strict-match     | 5 | exact_match | 0.04 | ±0.0124 |

**This PR** (`d440cd990`):

| Tasks | Filter | n-shot | Metric | Value | Stderr |
|---|---|---|---|---|---|
| gsm8k | flexible-extract | 5 | exact_match | 0.02 | ±0.0089 |
|       | strict-match     | 5 | exact_match | 0.04 | ±0.0124 |

Numerically identical (Δ = 0.000 on both filters) — the refactor preserves load semantics. Absolute scores are low because `pfnet/plamo-2-1b` is a 1B *base* model (no instruction tuning); the goal here is parity with `main`, not gsm8k capability.

## AI assistance

This change was AI-assisted (Claude Code). The submitter reviewed every changed line, traced the `AutoWeightsLoader` recursion against the original FCM path (`lm_head` skip, rotary skip, `model.norm.weight` exact-match, PP-missing handling, return contract), and validated correctness with the lm-eval comparison above.
