### PR TITLE
[Spec Decode] Fix Gemma4 DFlash batched verification

### DIFF
--- a/tests/v1/core/test_kv_sharing.py
+++ b/tests/v1/core/test_kv_sharing.py
@@ -1,9 +1,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import pytest
 import torch
 
+from vllm.v1.core.kv_cache_utils import get_kv_cache_config_from_groups
 from vllm.v1.kv_cache_interface import FullAttentionSpec, KVCacheGroupSpec
 from vllm.v1.worker.utils import add_kv_sharing_layers_to_kv_cache_groups
 
@@ -103,3 +106,28 @@ def test_initialize_kv_cache_for_kv_sharing_no_attn_groups():
     assert len(kv_cache_groups) == 2
     assert kv_cache_groups[0].layer_names == ["model.layers.0", "model.layers.2"]
     assert kv_cache_groups[1].layer_names == ["model.layers.1", "model.layers.3"]
+
+
+def test_dflash_draft_kv_groups_keep_hybrid_tensor_sharing():
+    spec = new_kv_cache_spec()
+    num_blocks = 8
+    vllm_config = SimpleNamespace(
+        speculative_config=SimpleNamespace(method="dflash"),
+        cache_config=SimpleNamespace(num_gpu_blocks_override=None),
+    )
+    kv_cache_groups = [
+        KVCacheGroupSpec(["model.layers.0", "model.layers.1"], spec),
+        KVCacheGroupSpec(["model.layers.2", "model.layers.3"], spec),
+    ]
+
+    kv_cache_config = get_kv_cache_config_from_groups(
+        vllm_config=vllm_config,
+        kv_cache_groups=kv_cache_groups,
+        available_memory=spec.page_size_bytes * 2 * num_blocks,
+    )
+
+    assert kv_cache_config.num_blocks == num_blocks
+    assert [tensor.shared_by for tensor in kv_cache_config.kv_cache_tensors] == [
+        ["model.layers.0", "model.layers.2"],
+        ["model.layers.1", "model.layers.3"],
+    ]

--- a/tests/v1/spec_decode/test_dflash_swa.py
+++ b/tests/v1/spec_decode/test_dflash_swa.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import torch
 
+from vllm.config import SpeculativeConfig
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.models.qwen3_dflash import DFlashAttention
 from vllm.transformers_utils.configs.speculators import SpeculatorsConfig
@@ -86,6 +87,28 @@ def test_dflash_speculators_preserves_swa_config():
     assert hf_config["max_window_layers"] == len(layer_types)
     assert hf_config["eagle_aux_hidden_state_layer_ids"] == [1, 2, 3]
     assert hf_config["dflash_config"]["target_layer_ids"] == [0, 1, 2]
+
+
+def _compute_dflash_hash(hf_config: SimpleNamespace) -> str:
+    config = object.__new__(SpeculativeConfig)
+    config.method = "dflash"
+    config.draft_model_config = SimpleNamespace(hf_config=hf_config)
+    return config.compute_hash()
+
+
+def test_dflash_compile_hash_uses_checkpoint_layer_id_semantics():
+    dflash_hash = _compute_dflash_hash(
+        SimpleNamespace(dflash_config={"target_layer_ids": [0, 2]})
+    )
+    shifted_aux_hash = _compute_dflash_hash(
+        SimpleNamespace(eagle_aux_hidden_state_layer_ids=[1, 3])
+    )
+    different_hash = _compute_dflash_hash(
+        SimpleNamespace(dflash_config={"target_layer_ids": [0, 3]})
+    )
+
+    assert dflash_hash == shifted_aux_hash
+    assert dflash_hash != different_hash
 
 
 def test_dflash_swa_layers_use_full_kv_cache_spec(monkeypatch):

--- a/tests/v1/spec_decode/test_dflash_swa.py
+++ b/tests/v1/spec_decode/test_dflash_swa.py
@@ -5,14 +5,14 @@ from types import SimpleNamespace
 
 import torch
 
+from vllm.model_executor.layers.attention import Attention
+from vllm.model_executor.models.qwen3_dflash import DFlashAttention
 from vllm.transformers_utils.configs.speculators import SpeculatorsConfig
 from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
-    KVCacheConfig,
-    KVCacheGroupSpec,
+    SlidingWindowSpec,
 )
-from vllm.v1.spec_decode import dflash as dflash_module
 from vllm.v1.spec_decode.dflash import DFlashProposer
 
 
@@ -25,21 +25,6 @@ class _FakeBuilder:
 
     def build_for_drafting(self, common_attn_metadata, draft_index):
         return SimpleNamespace(causal=common_attn_metadata.causal)
-
-
-class _FakeBackend:
-    @classmethod
-    def full_cls_name(cls):
-        return "fake.backend"
-
-    @classmethod
-    def get_builder_cls(cls):
-        return _FakeBuilder
-
-
-class _FakeLayer:
-    def get_attn_backend(self):
-        return _FakeBackend
 
 
 class _FakeAttentionGroup:
@@ -81,13 +66,35 @@ def test_dflash_speculators_preserves_swa_config():
     assert hf_config["max_window_layers"] == len(layer_types)
 
 
+def test_dflash_swa_layers_use_full_kv_cache_spec(monkeypatch):
+    sliding_spec = SlidingWindowSpec(
+        block_size=16,
+        num_kv_heads=1,
+        head_size=8,
+        dtype=torch.float16,
+        sliding_window=4,
+    )
+    monkeypatch.setattr(
+        Attention,
+        "get_kv_cache_spec",
+        lambda self, vllm_config: sliding_spec,
+    )
+
+    spec = DFlashAttention.get_kv_cache_spec(
+        object.__new__(DFlashAttention), SimpleNamespace()
+    )
+
+    assert isinstance(spec, FullAttentionSpec)
+    assert spec.block_size == sliding_spec.block_size
+    assert spec.num_kv_heads == sliding_spec.num_kv_heads
+    assert spec.head_size == sliding_spec.head_size
+    assert spec.sliding_window is None
+
+
 def test_dflash_swa_layers_use_causal_metadata():
     proposer = object.__new__(DFlashProposer)
     proposer.model = SimpleNamespace(sliding_attention_layer_names={"layer.sw"})
-    proposer.draft_attn_groups = [
-        _FakeAttentionGroup(["layer.sw"]),
-        _FakeAttentionGroup(["layer.full"]),
-    ]
+    proposer.draft_attn_groups = [_FakeAttentionGroup(["layer.sw", "layer.full"])]
     cad = CommonAttentionMetadata(
         query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
         query_start_loc_cpu=torch.tensor([0, 2], dtype=torch.int32),
@@ -105,59 +112,6 @@ def test_dflash_swa_layers_use_causal_metadata():
         proposer, cad
     )
 
-    assert per_group[0].causal is True
-    assert per_group[1].causal is False
+    assert per_group[0].causal is False
     assert per_layer["layer.sw"].causal is True
     assert per_layer["layer.full"].causal is False
-
-
-def test_dflash_initializes_split_swa_draft_groups(monkeypatch):
-    proposer = object.__new__(DFlashProposer)
-    proposer.vllm_config = SimpleNamespace()
-    proposer.device = torch.device("cpu")
-    proposer.model = SimpleNamespace(sliding_attention_layer_names={"layer.sw"})
-    proposer._draft_attn_layer_names = {"layer.sw", "layer.full"}
-
-    monkeypatch.setattr(
-        dflash_module,
-        "get_layers_from_vllm_config",
-        lambda *args, **kwargs: {
-            "layer.sw": _FakeLayer(),
-            "layer.full": _FakeLayer(),
-        },
-    )
-
-    kv_cache_config = KVCacheConfig(
-        num_blocks=1,
-        kv_cache_tensors=[],
-        kv_cache_groups=[
-            KVCacheGroupSpec(
-                ["layer.sw"],
-                FullAttentionSpec(
-                    block_size=16,
-                    num_kv_heads=1,
-                    head_size=8,
-                    dtype=torch.float16,
-                    sliding_window=4,
-                ),
-            ),
-            KVCacheGroupSpec(
-                ["layer.full"],
-                FullAttentionSpec(
-                    block_size=16,
-                    num_kv_heads=1,
-                    head_size=8,
-                    dtype=torch.float16,
-                ),
-            ),
-        ],
-    )
-
-    DFlashProposer.initialize_attn_backend(proposer, kv_cache_config, [16, 16])
-
-    assert len(proposer.draft_attn_groups) == 2
-    assert {group.kv_cache_group_id for group in proposer.draft_attn_groups} == {0, 1}
-    assert {tuple(group.layer_names) for group in proposer.draft_attn_groups} == {
-        ("layer.sw",),
-        ("layer.full",),
-    }

--- a/tests/v1/spec_decode/test_dflash_swa.py
+++ b/tests/v1/spec_decode/test_dflash_swa.py
@@ -24,12 +24,17 @@ class _FakeBuilder:
         self.layer_names = layer_names
 
     def build_for_drafting(self, common_attn_metadata, draft_index):
-        return SimpleNamespace(causal=common_attn_metadata.causal)
+        return SimpleNamespace(
+            causal=common_attn_metadata.causal,
+            block_table_tensor=common_attn_metadata.block_table_tensor,
+            slot_mapping=common_attn_metadata.slot_mapping,
+        )
 
 
 class _FakeAttentionGroup:
-    def __init__(self, layer_names):
+    def __init__(self, layer_names, kv_cache_group_id=0):
         self.layer_names = layer_names
+        self.kv_cache_group_id = kv_cache_group_id
         self._builder = _FakeBuilder()
 
     def get_metadata_builder(self):
@@ -95,6 +100,13 @@ def test_dflash_swa_layers_use_causal_metadata():
     proposer = object.__new__(DFlashProposer)
     proposer.model = SimpleNamespace(sliding_attention_layer_names={"layer.sw"})
     proposer.draft_attn_groups = [_FakeAttentionGroup(["layer.sw", "layer.full"])]
+    proposer.kv_cache_gid = 0
+    proposer._draft_kv_cache_group_ids = [0]
+    proposer._draft_layer_to_kv_cache_gid = {
+        "layer.sw": 0,
+        "layer.full": 0,
+    }
+    proposer._draft_block_tables = {}
     cad = CommonAttentionMetadata(
         query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
         query_start_loc_cpu=torch.tensor([0, 2], dtype=torch.int32),
@@ -107,6 +119,7 @@ def test_dflash_swa_layers_use_causal_metadata():
         slot_mapping=torch.empty(2, dtype=torch.int64),
         causal=False,
     )
+    proposer._slot_mapping_buffers_by_gid = {0: (cad.slot_mapping, cad.slot_mapping)}
 
     per_group, per_layer = DFlashProposer.build_per_group_and_layer_attn_metadata(
         proposer, cad
@@ -115,3 +128,55 @@ def test_dflash_swa_layers_use_causal_metadata():
     assert per_group[0].causal is False
     assert per_layer["layer.sw"].causal is True
     assert per_layer["layer.full"].causal is False
+
+
+def test_dflash_metadata_uses_per_kv_group_slot_mapping():
+    proposer = object.__new__(DFlashProposer)
+    proposer.model = SimpleNamespace(sliding_attention_layer_names={"layer.sw"})
+    proposer.draft_attn_groups = [
+        _FakeAttentionGroup(["layer.full"], kv_cache_group_id=1),
+        _FakeAttentionGroup(["layer.sw"], kv_cache_group_id=2),
+    ]
+    proposer.kv_cache_gid = 1
+    proposer._draft_kv_cache_group_ids = [1, 2]
+    proposer._draft_layer_to_kv_cache_gid = {
+        "layer.full": 1,
+        "layer.sw": 2,
+    }
+
+    full_block_table = torch.tensor([[11, 12]], dtype=torch.int32)
+    sw_block_table = torch.tensor([[21, 22]], dtype=torch.int32)
+    full_slots = torch.tensor([111, 112], dtype=torch.int64)
+    sw_slots = torch.tensor([211, 212], dtype=torch.int64)
+
+    base_cad = CommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 2], dtype=torch.int32),
+        seq_lens=torch.tensor([2], dtype=torch.int32),
+        num_reqs=1,
+        num_actual_tokens=2,
+        max_query_len=2,
+        max_seq_len=2,
+        block_table_tensor=full_block_table,
+        slot_mapping=full_slots,
+        causal=False,
+    )
+    proposer._draft_block_tables = {
+        1: full_block_table,
+        2: sw_block_table,
+    }
+    proposer._slot_mapping_buffers_by_gid = {
+        1: (full_slots, full_slots),
+        2: (sw_slots, sw_slots),
+    }
+
+    _, per_layer = DFlashProposer.build_per_group_and_layer_attn_metadata(
+        proposer, base_cad
+    )
+
+    assert per_layer["layer.full"].block_table_tensor is full_block_table
+    torch.testing.assert_close(per_layer["layer.full"].slot_mapping, full_slots)
+    assert per_layer["layer.full"].causal is False
+    assert per_layer["layer.sw"].block_table_tensor is sw_block_table
+    torch.testing.assert_close(per_layer["layer.sw"].slot_mapping, sw_slots)
+    assert per_layer["layer.sw"].causal is True

--- a/tests/v1/spec_decode/test_dflash_swa.py
+++ b/tests/v1/spec_decode/test_dflash_swa.py
@@ -1,0 +1,163 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.transformers_utils.configs.speculators import SpeculatorsConfig
+from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheConfig,
+    KVCacheGroupSpec,
+)
+from vllm.v1.spec_decode import dflash as dflash_module
+from vllm.v1.spec_decode.dflash import DFlashProposer
+
+
+class _FakeBuilder:
+    def __init__(
+        self, kv_cache_spec=None, layer_names=None, vllm_config=None, device=None
+    ):
+        self.kv_cache_spec = kv_cache_spec
+        self.layer_names = layer_names
+
+    def build_for_drafting(self, common_attn_metadata, draft_index):
+        return SimpleNamespace(causal=common_attn_metadata.causal)
+
+
+class _FakeBackend:
+    @classmethod
+    def full_cls_name(cls):
+        return "fake.backend"
+
+    @classmethod
+    def get_builder_cls(cls):
+        return _FakeBuilder
+
+
+class _FakeLayer:
+    def get_attn_backend(self):
+        return _FakeBackend
+
+
+class _FakeAttentionGroup:
+    def __init__(self, layer_names):
+        self.layer_names = layer_names
+        self._builder = _FakeBuilder()
+
+    def get_metadata_builder(self):
+        return self._builder
+
+
+def test_dflash_speculators_preserves_swa_config():
+    layer_types = [
+        "sliding_attention",
+        "sliding_attention",
+        "full_attention",
+    ]
+    config = {
+        "speculators_model_type": "dflash",
+        "transformer_layer_config": {
+            "num_hidden_layers": len(layer_types),
+            "sliding_window": None,
+        },
+        "draft_vocab_size": 100,
+        "target_hidden_size": 64,
+        "aux_hidden_state_layer_ids": [0, 1, 2],
+        "mask_token_id": 99,
+        "layer_types": layer_types,
+        "use_sliding_window": True,
+        "sliding_window": 2048,
+        "max_window_layers": len(layer_types),
+    }
+
+    hf_config = SpeculatorsConfig.extract_transformers_pre_trained_config(config)
+
+    assert hf_config["layer_types"] == layer_types
+    assert hf_config["use_sliding_window"] is True
+    assert hf_config["sliding_window"] == 2048
+    assert hf_config["max_window_layers"] == len(layer_types)
+
+
+def test_dflash_swa_layers_use_causal_metadata():
+    proposer = object.__new__(DFlashProposer)
+    proposer.model = SimpleNamespace(sliding_attention_layer_names={"layer.sw"})
+    proposer.draft_attn_groups = [
+        _FakeAttentionGroup(["layer.sw"]),
+        _FakeAttentionGroup(["layer.full"]),
+    ]
+    cad = CommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 2], dtype=torch.int32),
+        seq_lens=torch.tensor([2], dtype=torch.int32),
+        num_reqs=1,
+        num_actual_tokens=2,
+        max_query_len=2,
+        max_seq_len=2,
+        block_table_tensor=torch.empty(1, 1, dtype=torch.int32),
+        slot_mapping=torch.empty(2, dtype=torch.int64),
+        causal=False,
+    )
+
+    per_group, per_layer = DFlashProposer.build_per_group_and_layer_attn_metadata(
+        proposer, cad
+    )
+
+    assert per_group[0].causal is True
+    assert per_group[1].causal is False
+    assert per_layer["layer.sw"].causal is True
+    assert per_layer["layer.full"].causal is False
+
+
+def test_dflash_initializes_split_swa_draft_groups(monkeypatch):
+    proposer = object.__new__(DFlashProposer)
+    proposer.vllm_config = SimpleNamespace()
+    proposer.device = torch.device("cpu")
+    proposer.model = SimpleNamespace(sliding_attention_layer_names={"layer.sw"})
+    proposer._draft_attn_layer_names = {"layer.sw", "layer.full"}
+
+    monkeypatch.setattr(
+        dflash_module,
+        "get_layers_from_vllm_config",
+        lambda *args, **kwargs: {
+            "layer.sw": _FakeLayer(),
+            "layer.full": _FakeLayer(),
+        },
+    )
+
+    kv_cache_config = KVCacheConfig(
+        num_blocks=1,
+        kv_cache_tensors=[],
+        kv_cache_groups=[
+            KVCacheGroupSpec(
+                ["layer.sw"],
+                FullAttentionSpec(
+                    block_size=16,
+                    num_kv_heads=1,
+                    head_size=8,
+                    dtype=torch.float16,
+                    sliding_window=4,
+                ),
+            ),
+            KVCacheGroupSpec(
+                ["layer.full"],
+                FullAttentionSpec(
+                    block_size=16,
+                    num_kv_heads=1,
+                    head_size=8,
+                    dtype=torch.float16,
+                ),
+            ),
+        ],
+    )
+
+    DFlashProposer.initialize_attn_backend(proposer, kv_cache_config, [16, 16])
+
+    assert len(proposer.draft_attn_groups) == 2
+    assert {group.kv_cache_group_id for group in proposer.draft_attn_groups} == {0, 1}
+    assert {tuple(group.layer_names) for group in proposer.draft_attn_groups} == {
+        ("layer.sw",),
+        ("layer.full",),
+    }

--- a/tests/v1/spec_decode/test_dflash_swa.py
+++ b/tests/v1/spec_decode/test_dflash_swa.py
@@ -69,6 +69,8 @@ def test_dflash_speculators_preserves_swa_config():
     assert hf_config["use_sliding_window"] is True
     assert hf_config["sliding_window"] == 2048
     assert hf_config["max_window_layers"] == len(layer_types)
+    assert hf_config["eagle_aux_hidden_state_layer_ids"] == [1, 2, 3]
+    assert hf_config["dflash_config"]["target_layer_ids"] == [0, 1, 2]
 
 
 def test_dflash_swa_layers_use_full_kv_cache_spec(monkeypatch):

--- a/tests/v1/spec_decode/test_dflash_swa.py
+++ b/tests/v1/spec_decode/test_dflash_swa.py
@@ -41,6 +41,21 @@ class _FakeAttentionGroup:
         return self._builder
 
 
+def _make_cad(block_table, slot_mapping) -> CommonAttentionMetadata:
+    return CommonAttentionMetadata(
+        query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
+        query_start_loc_cpu=torch.tensor([0, 2], dtype=torch.int32),
+        seq_lens=torch.tensor([2], dtype=torch.int32),
+        num_reqs=1,
+        num_actual_tokens=2,
+        max_query_len=2,
+        max_seq_len=2,
+        block_table_tensor=block_table,
+        slot_mapping=slot_mapping,
+        causal=False,
+    )
+
+
 def test_dflash_speculators_preserves_swa_config():
     layer_types = [
         "sliding_attention",
@@ -109,17 +124,9 @@ def test_dflash_swa_layers_use_causal_metadata():
         "layer.full": 0,
     }
     proposer._draft_block_tables = {}
-    cad = CommonAttentionMetadata(
-        query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
-        query_start_loc_cpu=torch.tensor([0, 2], dtype=torch.int32),
-        seq_lens=torch.tensor([2], dtype=torch.int32),
-        num_reqs=1,
-        num_actual_tokens=2,
-        max_query_len=2,
-        max_seq_len=2,
-        block_table_tensor=torch.empty(1, 1, dtype=torch.int32),
-        slot_mapping=torch.empty(2, dtype=torch.int64),
-        causal=False,
+    cad = _make_cad(
+        torch.empty(1, 1, dtype=torch.int32),
+        torch.empty(2, dtype=torch.int64),
     )
     proposer._slot_mapping_buffers_by_gid = {0: (cad.slot_mapping, cad.slot_mapping)}
 
@@ -151,18 +158,7 @@ def test_dflash_metadata_uses_per_kv_group_slot_mapping():
     full_slots = torch.tensor([111, 112], dtype=torch.int64)
     sw_slots = torch.tensor([211, 212], dtype=torch.int64)
 
-    base_cad = CommonAttentionMetadata(
-        query_start_loc=torch.tensor([0, 2], dtype=torch.int32),
-        query_start_loc_cpu=torch.tensor([0, 2], dtype=torch.int32),
-        seq_lens=torch.tensor([2], dtype=torch.int32),
-        num_reqs=1,
-        num_actual_tokens=2,
-        max_query_len=2,
-        max_seq_len=2,
-        block_table_tensor=full_block_table,
-        slot_mapping=full_slots,
-        causal=False,
-    )
+    base_cad = _make_cad(full_block_table, full_slots)
     proposer._draft_block_tables = {
         1: full_block_table,
         2: sw_block_table,

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -716,6 +716,41 @@ def test_kv_cache_stride_order(monkeypatch, model_runner):
             assert all(not kv.is_contiguous() for kv in model_runner.kv_caches)
 
 
+@pytest.mark.parametrize(
+    "physical_order",
+    [
+        ("block", "kv", "token", "head", "dim"),
+        ("block", "kv", "head", "token", "dim"),
+    ],
+)
+def test_kv_major_cache_can_share_block_major_raw_tensor(physical_order):
+    kv_cache_shape = (2, 3, 4, 2, 8)
+    _, num_blocks, block_size, num_kv_heads, head_size = kv_cache_shape
+    block_elems = block_size * num_kv_heads * head_size
+    raw_tensor = torch.arange(2 * num_blocks * block_elems)
+    public_order = ("kv", "block", "token", "head", "dim")
+    dim_sizes = dict(zip(public_order, kv_cache_shape))
+    expected_strides = {}
+    stride = 1
+    for dim in reversed(physical_order):
+        expected_strides[dim] = stride
+        stride *= dim_sizes[dim]
+
+    kv_cache = GPUModelRunner._view_kv_cache_with_physical_order(
+        raw_tensor,
+        kv_cache_shape,
+        public_order,
+        physical_order,
+    )
+
+    assert kv_cache.shape == kv_cache_shape
+    assert kv_cache.stride() == tuple(expected_strides[dim] for dim in public_order)
+    assert kv_cache[0, 0, 0, 0, 0] == raw_tensor[0]
+    assert kv_cache[1, 0, 0, 0, 0] == raw_tensor[block_elems]
+    assert kv_cache[0, 1, 0, 0, 0] == raw_tensor[2 * block_elems]
+    assert kv_cache[1, 1, 0, 0, 0] == raw_tensor[3 * block_elems]
+
+
 def test_update_config(model_runner):
     # Simple update
     model_runner.update_config({"load_config": {"load_format": "dummy"}})

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -1047,6 +1047,10 @@ class SpeculativeConfig:
     def use_eagle(self) -> bool:
         return self.method in ("eagle", "eagle3", "mtp", "dflash")
 
+    def requires_eagle_cache_drop(self) -> bool:
+        """Whether prefix cache hits must drop one block for hidden states."""
+        return self.use_eagle() and not self.use_dflash()
+
     def use_dflash(self) -> bool:
         return self.method == "dflash"
 

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -289,6 +289,14 @@ class SpeculativeConfig:
                 "eagle_aux_hidden_state_layer_ids",
                 None,
             )
+            if not layer_ids:
+                dflash_config = getattr(
+                    self.draft_model_config.hf_config, "dflash_config", None
+                )
+                if dflash_config and isinstance(dflash_config, dict):
+                    layer_ids = [
+                        i + 1 for i in dflash_config.get("target_layer_ids", [])
+                    ]
             if layer_ids is not None:
                 # Convert to tuple to make it hashable
                 factors.append(tuple(layer_ids))

--- a/vllm/model_executor/layers/attention/attention.py
+++ b/vllm/model_executor/layers/attention/attention.py
@@ -203,6 +203,7 @@ class Attention(nn.Module, AttentionLayerBase):
         kv_sharing_target_layer_name: str | None = None,
         attn_backend: type[AttentionBackend] | None = None,
         head_size_v: int | None = None,
+        use_mm_prefix: bool | None = None,
         **extra_impl_args,
     ) -> None:
         """
@@ -290,7 +291,11 @@ class Attention(nn.Module, AttentionLayerBase):
 
         # NOTE: model_config may be None during certain tests
         model_config = vllm_config.model_config
-        self.use_mm_prefix = model_config is not None and model_config.is_mm_prefix_lm
+        self.use_mm_prefix = (
+            model_config is not None and model_config.is_mm_prefix_lm
+            if use_mm_prefix is None
+            else use_mm_prefix
+        )
 
         # During model initialization, the default dtype is set as the model
         # weight and activation dtype.

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from collections.abc import Iterable
+from collections.abc import Iterable, Mapping
 
 import torch
 import torch.nn.functional as F
@@ -410,7 +410,7 @@ class DFlashQwen3Model(nn.Module):
         self,
         context_states: torch.Tensor,
         context_positions: torch.Tensor,
-        context_slot_mapping: torch.Tensor | None = None,
+        context_slot_mapping: torch.Tensor | Mapping[str, torch.Tensor] | None = None,
     ) -> None:
         """Precompute K/V for context states write them into each layer's KV cache.
 
@@ -491,13 +491,18 @@ class DFlashQwen3Model(nn.Module):
         all_k_final = all_k_flat.view(L, num_ctx, nkv, hd)
         for i in range(L):
             attn = self._attn_layers[i]
+            layer_slot_mapping = (
+                context_slot_mapping[attn.layer_name]
+                if isinstance(context_slot_mapping, Mapping)
+                else context_slot_mapping
+            )
             kv_cache = attn.kv_cache
             attn.impl.do_kv_cache_update(
                 attn,
                 all_k_final[i],
                 all_v[i],
                 kv_cache,
-                context_slot_mapping,
+                layer_slot_mapping,
             )
 
     def forward(
@@ -637,7 +642,7 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         self,
         context_states: torch.Tensor,
         context_positions: torch.Tensor,
-        context_slot_mapping: torch.Tensor | None = None,
+        context_slot_mapping: torch.Tensor | Mapping[str, torch.Tensor] | None = None,
     ) -> None:
         """Precompute projected + RoPE'd K/V and write to cache."""
         self.model.precompute_and_store_context_kv(

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -84,6 +84,12 @@ class DFlashAttention(Attention):
     before drafting and cannot evict old context blocks from draft layers.
     """
 
+    def __init__(self, *args, **kwargs) -> None:
+        # DFlash draft attention runs over text/query tokens with prewritten K/V.
+        # Do not inherit a multimodal-prefix mask requirement from the target.
+        kwargs.setdefault("use_mm_prefix", False)
+        super().__init__(*args, **kwargs)
+
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec | None:
         spec = super().get_kv_cache_spec(vllm_config)
         if isinstance(spec, SlidingWindowSpec):

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -80,6 +80,9 @@ class DFlashAttention(Attention):
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec | None:
         spec = super().get_kv_cache_spec(vllm_config)
         if isinstance(spec, SlidingWindowSpec):
+            # DFlash pre-populates context KV for every draft layer, so the
+            # cache must retain the full context even when the layer computes
+            # with a sliding attention window.
             return FullAttentionSpec(
                 block_size=spec.block_size,
                 num_kv_heads=spec.num_kv_heads,
@@ -88,7 +91,6 @@ class DFlashAttention(Attention):
                 dtype=spec.dtype,
                 kv_quant_mode=spec.kv_quant_mode,
                 page_size_padded=spec.page_size_padded,
-                sliding_window=spec.sliding_window,
             )
         return spec
 

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -77,12 +77,16 @@ def _get_dflash_layer_types(config: Qwen3Config) -> tuple[str, ...]:
 
 
 class DFlashAttention(Attention):
+    """Attention with DFlash-specific KV allocation semantics.
+
+    The compute path keeps the layer's configured sliding window. The KV cache
+    spec is widened to full attention because DFlash writes every context KV
+    before drafting and cannot evict old context blocks from draft layers.
+    """
+
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec | None:
         spec = super().get_kv_cache_spec(vllm_config)
         if isinstance(spec, SlidingWindowSpec):
-            # DFlash pre-populates context KV for every draft layer, so the
-            # cache must retain the full context even when the layer computes
-            # with a sliding attention window.
             return FullAttentionSpec(
                 block_size=spec.block_size,
                 num_kv_heads=spec.num_kv_heads,

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -302,6 +302,12 @@ class DFlashQwen3Model(nn.Module):
             self.config.hidden_size,
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
+        target_config = vllm_config.model_config.hf_text_config
+        self.embed_normalizer: float | None = None
+        if str(getattr(target_config, "model_type", "")).startswith("gemma4"):
+            # Gemma4 scales token embeddings by sqrt(hidden_size). DFlash
+            # shares the target embeddings, so the draft path must match.
+            self.embed_normalizer = target_config.hidden_size**0.5
 
         self.layer_types = _get_dflash_layer_types(self.config)
         self.layers = nn.ModuleList(
@@ -349,7 +355,8 @@ class DFlashQwen3Model(nn.Module):
         )
 
     def embed_input_ids(self, input_ids: torch.Tensor) -> torch.Tensor:
-        return self.embed_tokens(input_ids)
+        embeds = self.embed_tokens(input_ids)
+        return embeds * self.embed_normalizer if self.embed_normalizer else embeds
 
     def _build_fused_kv_buffers(self) -> None:
         """Build fused weight buffers for precompute_and_store_context_kv.
@@ -595,6 +602,7 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         self.logits_processor = LogitsProcessor(
             self.config.draft_vocab_size,
             scale=logit_scale,
+            soft_cap=getattr(self.config, "final_logit_softcapping", None),
         )
         target_vocab_size = vllm_config.model_config.get_vocab_size()
         if self.config.draft_vocab_size != target_vocab_size:

--- a/vllm/model_executor/models/qwen3_dflash.py
+++ b/vllm/model_executor/models/qwen3_dflash.py
@@ -34,6 +34,11 @@ from vllm.model_executor.model_loader.weight_utils import (
 from vllm.multimodal.inputs import NestedTensors
 from vllm.transformers_utils.config import set_default_rope_theta
 from vllm.v1.attention.backend import AttentionType
+from vllm.v1.kv_cache_interface import (
+    FullAttentionSpec,
+    KVCacheSpec,
+    SlidingWindowSpec,
+)
 
 from .qwen2 import Qwen2MLP as Qwen3MLP
 from .qwen3 import Qwen3ForCausalLM
@@ -45,6 +50,47 @@ from .utils import (
 )
 
 logger = init_logger(__name__)
+
+
+_DFLASH_VALID_LAYER_TYPES = frozenset({"full_attention", "sliding_attention"})
+
+
+def _get_dflash_layer_types(config: Qwen3Config) -> tuple[str, ...]:
+    layer_types = getattr(config, "layer_types", None)
+    if layer_types is None:
+        return ("full_attention",) * config.num_hidden_layers
+    if len(layer_types) != config.num_hidden_layers:
+        raise ValueError(
+            f"DFlash layer_types length {len(layer_types)} does not match "
+            f"num_hidden_layers {config.num_hidden_layers}."
+        )
+    invalid = set(layer_types) - _DFLASH_VALID_LAYER_TYPES
+    if invalid:
+        raise ValueError(f"Invalid DFlash layer_type(s): {sorted(invalid)}.")
+    if "sliding_attention" in layer_types and not getattr(
+        config, "sliding_window", None
+    ):
+        raise ValueError(
+            "DFlash sliding_attention layers require `sliding_window` in config."
+        )
+    return tuple(layer_types)
+
+
+class DFlashAttention(Attention):
+    def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec | None:
+        spec = super().get_kv_cache_spec(vllm_config)
+        if isinstance(spec, SlidingWindowSpec):
+            return FullAttentionSpec(
+                block_size=spec.block_size,
+                num_kv_heads=spec.num_kv_heads,
+                head_size=spec.head_size,
+                head_size_v=getattr(spec, "head_size_v", spec.head_size),
+                dtype=spec.dtype,
+                kv_quant_mode=spec.kv_quant_mode,
+                page_size_padded=spec.page_size_padded,
+                sliding_window=spec.sliding_window,
+            )
+        return spec
 
 
 class DFlashQwen3Attention(nn.Module):
@@ -66,6 +112,7 @@ class DFlashQwen3Attention(nn.Module):
         attention_bias: bool = False,
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
+        sliding_window: int | None = None,
         prefix: str = "",
         attn_type: str = AttentionType.DECODER,
     ) -> None:
@@ -109,13 +156,14 @@ class DFlashQwen3Attention(nn.Module):
             max_position=max_position,
             rope_parameters=rope_parameters,
         )
-        self.attn = Attention(
+        self.attn = DFlashAttention(
             self.num_heads,
             self.head_dim,
             self.scaling,
             num_kv_heads=self.num_kv_heads,
             cache_config=cache_config,
             quant_config=quant_config,
+            per_layer_sliding_window=sliding_window,
             prefix=f"{prefix}.attn",
             attn_type=attn_type,
         )
@@ -158,12 +206,17 @@ class DFlashQwen3DecoderLayer(nn.Module):
         config: Qwen3Config,
         cache_config: CacheConfig | None = None,
         quant_config: QuantizationConfig | None = None,
+        layer_type: str = "full_attention",
         prefix: str = "",
     ) -> None:
         super().__init__()
         self.hidden_size = config.hidden_size
+        self.layer_type = layer_type
         set_default_rope_theta(config, default_theta=1000000)
         attn_type = AttentionType.DECODER
+        sliding_window = (
+            config.sliding_window if layer_type == "sliding_attention" else None
+        )
 
         self.self_attn = DFlashQwen3Attention(
             hidden_size=self.hidden_size,
@@ -175,6 +228,7 @@ class DFlashQwen3DecoderLayer(nn.Module):
             head_dim=getattr(config, "head_dim", None),
             cache_config=cache_config,
             quant_config=quant_config,
+            sliding_window=sliding_window,
             rope_parameters=config.rope_parameters,
             prefix=f"{prefix}.self_attn",
             attn_type=attn_type,
@@ -243,16 +297,23 @@ class DFlashQwen3Model(nn.Module):
             prefix=maybe_prefix(prefix, "embed_tokens"),
         )
 
+        self.layer_types = _get_dflash_layer_types(self.config)
         self.layers = nn.ModuleList(
             [
                 DFlashQwen3DecoderLayer(
                     current_vllm_config,
                     prefix=maybe_prefix(prefix, f"layers.{layer_idx + start_layer_id}"),
                     config=self.config,
+                    layer_type=self.layer_types[layer_idx],
                 )
                 for layer_idx in range(self.config.num_hidden_layers)
             ]
         )
+        self.sliding_attention_layer_names = {
+            layer.self_attn.attn.layer_name
+            for layer in self.layers
+            if layer.layer_type == "sliding_attention"
+        }
         if self.use_aux_hidden_state:
             num_features_to_use = self.config.num_hidden_layers
             if "target_layer_ids" in drafter_config:
@@ -521,7 +582,8 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
             prefix=maybe_prefix(prefix, "lm_head"),
         )
         self.logits_processor = LogitsProcessor(
-            self.config.draft_vocab_size, scale=logit_scale
+            self.config.draft_vocab_size,
+            scale=logit_scale,
         )
         target_vocab_size = vllm_config.model_config.get_vocab_size()
         if self.config.draft_vocab_size != target_vocab_size:
@@ -575,6 +637,10 @@ class DFlashQwen3ForCausalLM(Qwen3ForCausalLM):
         self.model.precompute_and_store_context_kv(
             context_states, context_positions, context_slot_mapping
         )
+
+    @property
+    def sliding_attention_layer_names(self) -> set[str]:
+        return self.model.sliding_attention_layer_names
 
     def combine_hidden_states(
         self,

--- a/vllm/transformers_utils/configs/speculators/algos.py
+++ b/vllm/transformers_utils/configs/speculators/algos.py
@@ -64,6 +64,14 @@ def update_dflash(config_dict: dict, pre_trained_config: dict) -> None:
     pre_trained_config["draft_vocab_size"] = config_dict.get("draft_vocab_size")
     if config_dict.get("target_hidden_size") is not None:
         pre_trained_config["target_hidden_size"] = config_dict["target_hidden_size"]
+    for key in (
+        "layer_types",
+        "use_sliding_window",
+        "sliding_window",
+        "max_window_layers",
+    ):
+        if key in config_dict:
+            pre_trained_config[key] = config_dict[key]
 
     # TODO: does this need to be shifted by 1 like in gpu_model_runner?
     aux_layer_ids = config_dict["aux_hidden_state_layer_ids"]

--- a/vllm/transformers_utils/configs/speculators/algos.py
+++ b/vllm/transformers_utils/configs/speculators/algos.py
@@ -54,11 +54,11 @@ def update_dflash(config_dict: dict, pre_trained_config: dict) -> None:
     - target_hidden_size: Hidden size of the target model
     - mask_token_id (required): Token ID used for parallel drafting mask
         placeholders
-    - aux_hidden_state_layer_ids (required): Layer indices from the target
-        model whose intermediate hidden states are used as context for the
-        DFlash drafter. Mapped to both eagle_aux_hidden_state_layer_ids
-        (for gpu_model_runner) and dflash_config.target_layer_ids (for the
-        DFlash model).
+    - aux_hidden_state_layer_ids (required): DFlash target layer indices whose
+        intermediate hidden states are used as context for the DFlash drafter.
+        Mapped to dflash_config.target_layer_ids for the DFlash model. The
+        runner-facing eagle_aux_hidden_state_layer_ids are shifted by one to
+        match vLLM's hidden-state extraction semantics.
     """
     pre_trained_config["architectures"] = ["DFlashDraftModel"]
     pre_trained_config["draft_vocab_size"] = config_dict.get("draft_vocab_size")
@@ -73,9 +73,10 @@ def update_dflash(config_dict: dict, pre_trained_config: dict) -> None:
         if key in config_dict:
             pre_trained_config[key] = config_dict[key]
 
-    # TODO: does this need to be shifted by 1 like in gpu_model_runner?
     aux_layer_ids = config_dict["aux_hidden_state_layer_ids"]
-    pre_trained_config["eagle_aux_hidden_state_layer_ids"] = aux_layer_ids
+    pre_trained_config["eagle_aux_hidden_state_layer_ids"] = [
+        i + 1 for i in aux_layer_ids
+    ]
 
     pre_trained_config["dflash_config"] = {
         "mask_token_id": config_dict["mask_token_id"],

--- a/vllm/transformers_utils/configs/speculators/algos.py
+++ b/vllm/transformers_utils/configs/speculators/algos.py
@@ -65,6 +65,7 @@ def update_dflash(config_dict: dict, pre_trained_config: dict) -> None:
     if config_dict.get("target_hidden_size") is not None:
         pre_trained_config["target_hidden_size"] = config_dict["target_hidden_size"]
 
+    # TODO: does this need to be shifted by 1 like in gpu_model_runner?
     aux_layer_ids = config_dict["aux_hidden_state_layer_ids"]
     pre_trained_config["eagle_aux_hidden_state_layer_ids"] = aux_layer_ids
 

--- a/vllm/v1/attention/backends/triton_attn.py
+++ b/vllm/v1/attention/backends/triton_attn.py
@@ -140,8 +140,11 @@ class TritonAttentionMetadataBuilder(AttentionMetadataBuilder[TritonAttentionMet
         self.num_heads_q = model_config.get_num_attention_heads(
             vllm_config.parallel_config
         )
-        self.num_heads_kv = model_config.get_num_kv_heads(vllm_config.parallel_config)
-        self.headdim = model_config.get_head_size()
+        # Some models (e.g. Gemma4) use different KV/head geometry for
+        # different attention layer groups, so size decode metadata from the
+        # actual KV cache spec instead of the model-wide defaults.
+        self.num_heads_kv = kv_cache_spec.num_kv_heads
+        self.headdim = kv_cache_spec.head_size
 
         # Check if CUDA Graphs are enabled for decode
         self.decode_cudagraph_enabled = (

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -6,6 +6,7 @@ import copy
 import hashlib
 import math
 import os
+import re
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass, replace
@@ -79,6 +80,7 @@ def maybe_convert_block_hash(hash_bytes: BlockHash) -> ExternalBlockHash:
 
 
 logger = init_logger(__name__)
+_LAYER_INDEX_RE = re.compile(r"(?:^|\.)layers\.(\d+)(?:\.|$)")
 
 # The hash seed for the first block of any prefix block sequence.
 #
@@ -900,7 +902,10 @@ def may_override_num_blocks(vllm_config: VllmConfig, num_blocks: int) -> int:
     return num_blocks
 
 
-def _pool_bytes_per_block(kv_cache_groups: list[KVCacheGroupSpec]) -> int:
+def _pool_bytes_per_block(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> int:
     """
     Bytes consumed by one block in the worker's shared KV cache pool, mirroring
     the divisor used by `get_kv_cache_config_from_groups` to convert
@@ -922,7 +927,7 @@ def _pool_bytes_per_block(kv_cache_groups: list[KVCacheGroupSpec]) -> int:
             for g in kv_cache_groups
         )
         return layer_tuple_page_bytes * num_layer_tuples
-    group_size = max(len(g.layer_names) for g in kv_cache_groups)
+    group_size = _get_kv_tensor_group_size(vllm_config, kv_cache_groups)
     page_size = get_uniform_page_size([g.kv_cache_spec for g in kv_cache_groups])
     return page_size * group_size
 
@@ -954,6 +959,69 @@ def get_uniform_page_size(kv_cache_specs: Iterable[KVCacheSpec]) -> int:
     page_sizes = {layer.page_size_bytes for layer in kv_cache_specs}
     assert len(page_sizes) == 1
     return page_sizes.pop()
+
+
+def _get_dflash_isolated_group_ids(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> set[int]:
+    spec_config = vllm_config.speculative_config
+    if spec_config is None or spec_config.method != "dflash":
+        return set()
+
+    try:
+        target_num_layers = vllm_config.model_config.get_num_layers(
+            vllm_config.parallel_config
+        )
+    except Exception:
+        return set()
+
+    group_ids: set[int] = set()
+    for group_id, group in enumerate(kv_cache_groups):
+        layer_indices: list[int] = []
+        for layer_name in group.layer_names:
+            match = _LAYER_INDEX_RE.search(layer_name)
+            if match is None:
+                layer_indices = []
+                break
+            layer_indices.append(int(match.group(1)))
+        if layer_indices and all(idx >= target_num_layers for idx in layer_indices):
+            group_ids.add(group_id)
+    return group_ids
+
+
+def _split_dflash_isolated_groups(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> tuple[list[KVCacheGroupSpec], list[str]]:
+    isolated_group_ids = _get_dflash_isolated_group_ids(vllm_config, kv_cache_groups)
+    if not isolated_group_ids:
+        return kv_cache_groups, []
+    return (
+        [
+            group
+            for group_id, group in enumerate(kv_cache_groups)
+            if group_id not in isolated_group_ids
+        ],
+        [
+            layer_name
+            for group_id in sorted(isolated_group_ids)
+            for layer_name in kv_cache_groups[group_id].layer_names
+        ],
+    )
+
+
+def _get_kv_tensor_group_size(
+    vllm_config: VllmConfig,
+    kv_cache_groups: list[KVCacheGroupSpec],
+) -> int:
+    shared_groups, isolated_layer_names = _split_dflash_isolated_groups(
+        vllm_config, kv_cache_groups
+    )
+    shared_group_size = (
+        max(len(group.layer_names) for group in shared_groups) if shared_groups else 0
+    )
+    return shared_group_size + len(isolated_layer_names)
 
 
 def _get_kv_cache_groups_uniform_spec(
@@ -1290,7 +1358,18 @@ def get_kv_cache_config_from_groups(
         # (sw.1, padding) will be: (group_size = 2)
         # full.0, sw.0, sw.1: share a Tensor with size=available_memory//2
         # full.1, sw.2: share another Tensor with size=available_memory//2
-        group_size = max(len(group.layer_names) for group in kv_cache_groups)
+        # DFlash precomputes draft context K/V directly into cache. Keep
+        # draft-only KV groups on their own raw tensors; the logical KV groups
+        # and per-group block tables remain unchanged.
+        shared_groups, isolated_layer_names = _split_dflash_isolated_groups(
+            vllm_config, kv_cache_groups
+        )
+        shared_group_size = (
+            max(len(group.layer_names) for group in shared_groups)
+            if shared_groups
+            else 0
+        )
+        group_size = shared_group_size + len(isolated_layer_names)
 
         page_size = get_uniform_page_size(
             [group.kv_cache_spec for group in kv_cache_groups]
@@ -1300,13 +1379,17 @@ def get_kv_cache_config_from_groups(
             vllm_config, group_size, available_memory, page_size
         )
         kv_cache_tensors = []
-        for i in range(group_size):
+        for i in range(shared_group_size):
             shared_by = []
-            for j in range(len(kv_cache_groups)):
-                if i < len(kv_cache_groups[j].layer_names):
-                    shared_by.append(kv_cache_groups[j].layer_names[i])
+            for group in shared_groups:
+                if i < len(group.layer_names):
+                    shared_by.append(group.layer_names[i])
             kv_cache_tensors.append(
                 KVCacheTensor(size=page_size * num_blocks, shared_by=shared_by)
+            )
+        for layer_name in isolated_layer_names:
+            kv_cache_tensors.append(
+                KVCacheTensor(size=page_size * num_blocks, shared_by=[layer_name])
             )
 
     return KVCacheConfig(
@@ -1994,7 +2077,7 @@ def get_kv_cache_configs(
             if not groups:
                 adjusted_memory.append(avail_mem)
                 continue
-            bytes_per_block = _pool_bytes_per_block(groups)
+            bytes_per_block = _pool_bytes_per_block(vllm_config, groups)
             logger.info(
                 "Overriding num_gpu_blocks=%d with num_gpu_blocks_override=%d",
                 avail_mem // bytes_per_block,

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -6,7 +6,6 @@ import copy
 import hashlib
 import math
 import os
-import re
 from collections import defaultdict
 from collections.abc import Callable, Iterable, Iterator, Sequence
 from dataclasses import dataclass, replace
@@ -80,7 +79,6 @@ def maybe_convert_block_hash(hash_bytes: BlockHash) -> ExternalBlockHash:
 
 
 logger = init_logger(__name__)
-_LAYER_INDEX_RE = re.compile(r"(?:^|\.)layers\.(\d+)(?:\.|$)")
 
 # The hash seed for the first block of any prefix block sequence.
 #
@@ -902,10 +900,7 @@ def may_override_num_blocks(vllm_config: VllmConfig, num_blocks: int) -> int:
     return num_blocks
 
 
-def _pool_bytes_per_block(
-    vllm_config: VllmConfig,
-    kv_cache_groups: list[KVCacheGroupSpec],
-) -> int:
+def _pool_bytes_per_block(kv_cache_groups: list[KVCacheGroupSpec]) -> int:
     """
     Bytes consumed by one block in the worker's shared KV cache pool, mirroring
     the divisor used by `get_kv_cache_config_from_groups` to convert
@@ -927,7 +922,7 @@ def _pool_bytes_per_block(
             for g in kv_cache_groups
         )
         return layer_tuple_page_bytes * num_layer_tuples
-    group_size = _get_kv_tensor_group_size(vllm_config, kv_cache_groups)
+    group_size = max(len(g.layer_names) for g in kv_cache_groups)
     page_size = get_uniform_page_size([g.kv_cache_spec for g in kv_cache_groups])
     return page_size * group_size
 
@@ -959,69 +954,6 @@ def get_uniform_page_size(kv_cache_specs: Iterable[KVCacheSpec]) -> int:
     page_sizes = {layer.page_size_bytes for layer in kv_cache_specs}
     assert len(page_sizes) == 1
     return page_sizes.pop()
-
-
-def _get_dflash_isolated_group_ids(
-    vllm_config: VllmConfig,
-    kv_cache_groups: list[KVCacheGroupSpec],
-) -> set[int]:
-    spec_config = vllm_config.speculative_config
-    if spec_config is None or spec_config.method != "dflash":
-        return set()
-
-    try:
-        target_num_layers = vllm_config.model_config.get_num_layers(
-            vllm_config.parallel_config
-        )
-    except Exception:
-        return set()
-
-    group_ids: set[int] = set()
-    for group_id, group in enumerate(kv_cache_groups):
-        layer_indices: list[int] = []
-        for layer_name in group.layer_names:
-            match = _LAYER_INDEX_RE.search(layer_name)
-            if match is None:
-                layer_indices = []
-                break
-            layer_indices.append(int(match.group(1)))
-        if layer_indices and all(idx >= target_num_layers for idx in layer_indices):
-            group_ids.add(group_id)
-    return group_ids
-
-
-def _split_dflash_isolated_groups(
-    vllm_config: VllmConfig,
-    kv_cache_groups: list[KVCacheGroupSpec],
-) -> tuple[list[KVCacheGroupSpec], list[str]]:
-    isolated_group_ids = _get_dflash_isolated_group_ids(vllm_config, kv_cache_groups)
-    if not isolated_group_ids:
-        return kv_cache_groups, []
-    return (
-        [
-            group
-            for group_id, group in enumerate(kv_cache_groups)
-            if group_id not in isolated_group_ids
-        ],
-        [
-            layer_name
-            for group_id in sorted(isolated_group_ids)
-            for layer_name in kv_cache_groups[group_id].layer_names
-        ],
-    )
-
-
-def _get_kv_tensor_group_size(
-    vllm_config: VllmConfig,
-    kv_cache_groups: list[KVCacheGroupSpec],
-) -> int:
-    shared_groups, isolated_layer_names = _split_dflash_isolated_groups(
-        vllm_config, kv_cache_groups
-    )
-    shared_group_size = (
-        max(len(group.layer_names) for group in shared_groups) if shared_groups else 0
-    )
-    return shared_group_size + len(isolated_layer_names)
 
 
 def _get_kv_cache_groups_uniform_spec(
@@ -1358,18 +1290,7 @@ def get_kv_cache_config_from_groups(
         # (sw.1, padding) will be: (group_size = 2)
         # full.0, sw.0, sw.1: share a Tensor with size=available_memory//2
         # full.1, sw.2: share another Tensor with size=available_memory//2
-        # DFlash precomputes draft context K/V directly into cache. Keep
-        # draft-only KV groups on their own raw tensors; the logical KV groups
-        # and per-group block tables remain unchanged.
-        shared_groups, isolated_layer_names = _split_dflash_isolated_groups(
-            vllm_config, kv_cache_groups
-        )
-        shared_group_size = (
-            max(len(group.layer_names) for group in shared_groups)
-            if shared_groups
-            else 0
-        )
-        group_size = shared_group_size + len(isolated_layer_names)
+        group_size = max(len(group.layer_names) for group in kv_cache_groups)
 
         page_size = get_uniform_page_size(
             [group.kv_cache_spec for group in kv_cache_groups]
@@ -1379,17 +1300,13 @@ def get_kv_cache_config_from_groups(
             vllm_config, group_size, available_memory, page_size
         )
         kv_cache_tensors = []
-        for i in range(shared_group_size):
+        for i in range(group_size):
             shared_by = []
-            for group in shared_groups:
+            for group in kv_cache_groups:
                 if i < len(group.layer_names):
                     shared_by.append(group.layer_names[i])
             kv_cache_tensors.append(
                 KVCacheTensor(size=page_size * num_blocks, shared_by=shared_by)
-            )
-        for layer_name in isolated_layer_names:
-            kv_cache_tensors.append(
-                KVCacheTensor(size=page_size * num_blocks, shared_by=[layer_name])
             )
 
     return KVCacheConfig(
@@ -2077,7 +1994,7 @@ def get_kv_cache_configs(
             if not groups:
                 adjusted_memory.append(avail_mem)
                 continue
-            bytes_per_block = _pool_bytes_per_block(vllm_config, groups)
+            bytes_per_block = _pool_bytes_per_block(groups)
             logger.info(
                 "Overriding num_gpu_blocks=%d with num_gpu_blocks_override=%d",
                 avail_mem // bytes_per_block,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -208,11 +208,15 @@ class Scheduler(SchedulerInterface):
 
         speculative_config = vllm_config.speculative_config
         self.use_eagle = False
+        self.requires_eagle_cache_drop = False
         self.num_spec_tokens = self.num_lookahead_tokens = 0
         if speculative_config:
             self.num_spec_tokens = speculative_config.num_speculative_tokens
             if speculative_config.use_eagle():
                 self.use_eagle = True
+                self.requires_eagle_cache_drop = (
+                    speculative_config.requires_eagle_cache_drop()
+                )
                 self.num_lookahead_tokens = self.num_spec_tokens
             if speculative_config.uses_draft_model():
                 self.num_lookahead_tokens = self.num_spec_tokens
@@ -225,7 +229,7 @@ class Scheduler(SchedulerInterface):
             max_model_len=self.max_model_len,
             max_num_batched_tokens=self.scheduler_config.max_num_batched_tokens,
             enable_caching=self.cache_config.enable_prefix_caching,
-            use_eagle=self.use_eagle,
+            use_eagle=self.requires_eagle_cache_drop,
             log_stats=self.log_stats,
             enable_kv_cache_events=self.enable_kv_cache_events,
             dcp_world_size=self.dcp_world_size,
@@ -283,13 +287,13 @@ class Scheduler(SchedulerInterface):
             # must be a multiple of `block_size`.
             # As an exception, if `num_new_tokens` is less than `block_size`, the
             # state is simply not cached, requiring no special handling.
-            # Additionally, when Eagle mode is enabled, FullAttn prunes the last
-            # matching block. To prevent this from causing a Mamba cache miss, the
-            # last chunk must be not smaller than `block_size`.
+            # Additionally, when Eagle-style cache drop is enabled, FullAttn
+            # prunes the last matching block. To prevent this from causing a
+            # Mamba cache miss, the last chunk must be not smaller than
+            # `block_size`.
             block_size = self.cache_config.block_size
             last_cache_position = request.num_tokens - request.num_tokens % block_size
-            # eagle prune
-            if self.use_eagle:
+            if self.requires_eagle_cache_drop:
                 last_cache_position = max(last_cache_position - block_size, 0)
             num_computed_tokens_after_sched = num_computed_tokens + num_new_tokens
             if num_computed_tokens_after_sched < last_cache_position:
@@ -393,7 +397,7 @@ class Scheduler(SchedulerInterface):
                     request.num_computed_tokens,
                     num_new_tokens,
                     encoder_compute_budget,
-                    shift_computed_tokens=1 if self.use_eagle else 0,
+                    shift_computed_tokens=1 if self.requires_eagle_cache_drop else 0,
                 )
 
             if self.need_mamba_block_aligned_split:
@@ -662,7 +666,9 @@ class Scheduler(SchedulerInterface):
                             num_computed_tokens,
                             num_new_tokens,
                             encoder_compute_budget,
-                            shift_computed_tokens=1 if self.use_eagle else 0,
+                            shift_computed_tokens=1
+                            if self.requires_eagle_cache_drop
+                            else 0,
                         )
                         if num_new_tokens == 0:
                             # The request cannot be scheduled.

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -275,9 +275,9 @@ class DFlashProposer(SpecDecodeBaseProposer):
             )
 
         primary_kv_cache_gid = draft_kv_group_ids[0]
-        query_slot_mapping = self._slot_mapping_buffers_by_gid[primary_kv_cache_gid][
-            1
-        ][:num_query_total]
+        query_slot_mapping = self._slot_mapping_buffers_by_gid[primary_kv_cache_gid][1][
+            :num_query_total
+        ]
         new_query_start_loc = self.arange[: batch_size + 1] * num_query_per_req
 
         # In padded mode, cad.seq_lens includes rejected tokens. Subtract

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -1,17 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from dataclasses import replace
 from typing import Any
 
 import torch
 from typing_extensions import override
 
-from vllm.config import VllmConfig
+from vllm.config import VllmConfig, replace
 from vllm.forward_context import set_forward_context
 from vllm.logger import init_logger
 from vllm.triton_utils import triton
 from vllm.v1.attention.backend import CommonAttentionMetadata
+from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.spec_decode.llm_base_proposer import SpecDecodeBaseProposer
 from vllm.v1.spec_decode.utils import copy_and_expand_dflash_inputs_kernel
 
@@ -30,6 +30,7 @@ class DFlashProposer(SpecDecodeBaseProposer):
         super().__init__(
             vllm_config=vllm_config,
             device=device,
+            # Request aux hidden states; DFlash turns them into context K/V.
             pass_hidden_states_to_model=True,
             runner=runner,
         )
@@ -50,6 +51,11 @@ class DFlashProposer(SpecDecodeBaseProposer):
             dtype=torch.int64,
             device=device,
         )
+        self._slot_mapping_buffers_by_gid: dict[
+            int, tuple[torch.Tensor, torch.Tensor]
+        ] = {}
+        self._draft_block_size_by_gid: dict[int, int] = {}
+        self._draft_block_tables: dict[int, torch.Tensor] = {}
         self._context_positions_buffer = torch.zeros(
             self.max_num_tokens,
             dtype=torch.int64,
@@ -65,8 +71,40 @@ class DFlashProposer(SpecDecodeBaseProposer):
             self.max_positions + 1, device=device, dtype=torch.int32
         )
 
-        # For DFlash we use the input embeddings to embed the mask token
+        # DFlash embeds mask tokens directly.
         self.parallel_drafting_hidden_state_tensor = None
+
+    @override
+    def allow_multiple_draft_kv_cache_groups(self) -> bool:
+        return True
+
+    @override
+    def initialize_attn_backend(
+        self,
+        kv_cache_config: KVCacheConfig,
+        kernel_block_sizes: list[int] | None = None,
+    ) -> None:
+        super().initialize_attn_backend(kv_cache_config, kernel_block_sizes)
+        self._draft_block_size_by_gid.clear()
+        for attn_group in self.draft_attn_groups:
+            gid = attn_group.kv_cache_group_id
+            self._draft_block_size_by_gid[gid] = (
+                kernel_block_sizes[gid]
+                if kernel_block_sizes is not None and gid < len(kernel_block_sizes)
+                else attn_group.get_metadata_builder().kv_cache_spec.block_size
+            )
+        self._ensure_slot_mapping_buffers()
+
+    def clear_draft_block_tables(self) -> None:
+        self._draft_block_tables.clear()
+
+    def set_draft_block_table(
+        self,
+        kv_cache_gid: int,
+        block_table: torch.Tensor,
+    ) -> None:
+        if kv_cache_gid in self._draft_kv_cache_group_ids:
+            self._draft_block_tables[kv_cache_gid] = block_table
 
     @override
     def _create_draft_vllm_config(self) -> VllmConfig:
@@ -82,7 +120,84 @@ class DFlashProposer(SpecDecodeBaseProposer):
     @override
     def _warn_if_multimodal(self):
         # Override to allow multimodal inputs since DFlash supports Qwen3.5 models
+        # Support for multimodal inputs has not been tested.
         pass
+
+    def _ensure_slot_mapping_buffers(self) -> None:
+        gids = self._draft_kv_gids()
+
+        first_gid = gids[0]
+        for gid in gids:
+            if gid in self._slot_mapping_buffers_by_gid:
+                continue
+            if gid == first_gid:
+                self._slot_mapping_buffers_by_gid[gid] = (
+                    self._context_slot_mapping_buffer,
+                    self._slot_mapping_buffer,
+                )
+            else:
+                self._slot_mapping_buffers_by_gid[gid] = (
+                    torch.zeros(
+                        self.max_num_tokens,
+                        dtype=torch.int64,
+                        device=self.device,
+                    ),
+                    torch.zeros(
+                        self.max_query_tokens,
+                        dtype=torch.int64,
+                        device=self.device,
+                    ),
+                )
+
+    def _draft_kv_gids(self) -> list[int]:
+        return self._draft_kv_cache_group_ids or [
+            self.kv_cache_gid if self.kv_cache_gid >= 0 else 0
+        ]
+
+    def _get_dflash_block_table(
+        self,
+        kv_cache_gid: int,
+        cad: CommonAttentionMetadata,
+    ) -> torch.Tensor:
+        block_table = self._draft_block_tables.get(kv_cache_gid)
+        if block_table is not None:
+            return block_table
+        if kv_cache_gid == self.kv_cache_gid or self.kv_cache_gid < 0:
+            return cad.block_table_tensor
+        raise RuntimeError(
+            "Missing DFlash KV metadata for draft KV cache group "
+            f"{kv_cache_gid}. This is required when DFlash draft layers span "
+            "multiple KV cache groups."
+        )
+
+    def _get_dflash_context_slot_mapping(
+        self,
+        num_context: int,
+    ) -> torch.Tensor | dict[str, torch.Tensor]:
+        if not self._draft_layer_to_kv_cache_gid:
+            return self._context_slot_mapping_buffer[:num_context]
+        return {
+            layer_name: self._slot_mapping_buffers_by_gid[
+                self._draft_layer_to_kv_cache_gid[layer_name]
+            ][0][:num_context]
+            for layer_name in self._draft_attn_layer_names
+        }
+
+    @override
+    def _get_slot_mapping(
+        self,
+        num_tokens: int,
+        slot_mapping: torch.Tensor | None = None,
+    ) -> dict[str, torch.Tensor]:
+        self._ensure_slot_mapping_buffers()
+        if self._draft_layer_to_kv_cache_gid:
+            return {
+                layer_name: self._slot_mapping_buffers_by_gid[
+                    self._draft_layer_to_kv_cache_gid[layer_name]
+                ][1][:num_tokens]
+                for layer_name in self._draft_attn_layer_names
+            }
+        return super()._get_slot_mapping(num_tokens, slot_mapping)
 
     @override
     def set_inputs_first_pass(
@@ -102,11 +217,9 @@ class DFlashProposer(SpecDecodeBaseProposer):
         num_query_per_req = 1 + self.num_speculative_tokens
         num_query_total = batch_size * num_query_per_req
 
-        # Store for build_model_inputs_first_pass to use
         self._dflash_num_context = num_context
 
-        # We don't need to copy into a buffer here since the context preprocessing
-        # does not run in a CUDA graph
+        # Context preprocessing does not run in a CUDA graph.
         self._dflash_hidden_states = target_hidden_states
 
         token_indices_to_sample = torch.empty(
@@ -115,8 +228,7 @@ class DFlashProposer(SpecDecodeBaseProposer):
             device=self.device,
         )
 
-        # Launch fused triton kernel for input_ids, positions, slot_mapping,
-        # and token_indices_to_sample
+        # Fill query inputs and per-KV-group slot mappings.
         max_ctx_per_req = cad.max_query_len
         max_tokens_per_req = max_ctx_per_req + num_query_per_req
         BLOCK_SIZE = min(256, triton.next_power_of_2(max_tokens_per_req))
@@ -124,36 +236,48 @@ class DFlashProposer(SpecDecodeBaseProposer):
         grid = (batch_size, num_blocks)
 
         has_num_rejected = num_rejected_tokens_gpu is not None
-        copy_and_expand_dflash_inputs_kernel[grid](
-            # Inputs
-            next_token_ids_ptr=next_token_ids,
-            target_positions_ptr=target_positions,
-            # Outputs
-            out_input_ids_ptr=self.input_ids,
-            out_context_positions_ptr=self._context_positions_buffer,
-            out_query_positions_ptr=self.positions,
-            out_context_slot_mapping_ptr=self._context_slot_mapping_buffer,
-            out_query_slot_mapping_ptr=self._slot_mapping_buffer,
-            out_token_indices_ptr=token_indices_to_sample,
-            # Block table
-            block_table_ptr=cad.block_table_tensor,
-            block_table_stride=cad.block_table_tensor.stride(0),
-            # Metadata
-            query_start_loc_ptr=cad.query_start_loc,
-            num_rejected_tokens_ptr=(
-                num_rejected_tokens_gpu if has_num_rejected else 0
-            ),
-            # Scalars
-            parallel_drafting_token_id=self.parallel_drafting_token_id,
-            block_size=self.block_size,
-            num_query_per_req=num_query_per_req,
-            num_speculative_tokens=self.num_speculative_tokens,
-            total_input_tokens=num_context,
-            BLOCK_SIZE=BLOCK_SIZE,
-            HAS_NUM_REJECTED=has_num_rejected,
-        )
+        self._ensure_slot_mapping_buffers()
+        draft_kv_group_ids = self._draft_kv_gids()
+        for kv_cache_gid in draft_kv_group_ids:
+            context_slot_mapping_buffer, query_slot_mapping_buffer = (
+                self._slot_mapping_buffers_by_gid[kv_cache_gid]
+            )
+            block_table = self._get_dflash_block_table(kv_cache_gid, cad)
+            copy_and_expand_dflash_inputs_kernel[grid](
+                # Inputs
+                next_token_ids_ptr=next_token_ids,
+                target_positions_ptr=target_positions,
+                # Outputs
+                out_input_ids_ptr=self.input_ids,
+                out_context_positions_ptr=self._context_positions_buffer,
+                out_query_positions_ptr=self.positions,
+                out_context_slot_mapping_ptr=context_slot_mapping_buffer,
+                out_query_slot_mapping_ptr=query_slot_mapping_buffer,
+                out_token_indices_ptr=token_indices_to_sample,
+                # Block table
+                block_table_ptr=block_table,
+                block_table_stride=block_table.stride(0),
+                # Metadata
+                query_start_loc_ptr=cad.query_start_loc,
+                num_rejected_tokens_ptr=(
+                    num_rejected_tokens_gpu if has_num_rejected else 0
+                ),
+                # Scalars
+                parallel_drafting_token_id=self.parallel_drafting_token_id,
+                block_size=self._draft_block_size_by_gid.get(
+                    kv_cache_gid, self.block_size
+                ),
+                num_query_per_req=num_query_per_req,
+                num_speculative_tokens=self.num_speculative_tokens,
+                total_input_tokens=num_context,
+                BLOCK_SIZE=BLOCK_SIZE,
+                HAS_NUM_REJECTED=has_num_rejected,
+            )
 
-        query_slot_mapping = self._slot_mapping_buffer[:num_query_total]
+        primary_kv_cache_gid = draft_kv_group_ids[0]
+        query_slot_mapping = self._slot_mapping_buffers_by_gid[primary_kv_cache_gid][
+            1
+        ][:num_query_total]
         new_query_start_loc = self.arange[: batch_size + 1] * num_query_per_req
 
         # In padded mode, cad.seq_lens includes rejected tokens. Subtract
@@ -162,12 +286,6 @@ class DFlashProposer(SpecDecodeBaseProposer):
         if has_num_rejected:
             effective_seq_lens = effective_seq_lens - num_rejected_tokens_gpu
 
-        # Skip num_rejected_tokens (GPU-only); overestimating is fine here.
-        new_seq_lens_cpu_upper_bound = (
-            cad.seq_lens_cpu_upper_bound + num_query_per_req
-            if cad.seq_lens_cpu_upper_bound is not None
-            else None
-        )
         new_cad = CommonAttentionMetadata(
             query_start_loc=new_query_start_loc,
             seq_lens=effective_seq_lens + num_query_per_req,
@@ -177,12 +295,11 @@ class DFlashProposer(SpecDecodeBaseProposer):
             ),
             _seq_lens_cpu=None,
             _num_computed_tokens_cpu=None,
-            seq_lens_cpu_upper_bound=new_seq_lens_cpu_upper_bound,
             num_reqs=cad.num_reqs,
             num_actual_tokens=num_query_total,
             max_query_len=num_query_per_req,
             max_seq_len=cad.max_seq_len + num_query_per_req,
-            block_table_tensor=cad.block_table_tensor,
+            block_table_tensor=self._get_dflash_block_table(primary_kv_cache_gid, cad),
             slot_mapping=query_slot_mapping,
             causal=False,  # Non-causal attention is required for DFlash
         )
@@ -255,15 +372,13 @@ class DFlashProposer(SpecDecodeBaseProposer):
         num_input_tokens: int,
         mm_embed_inputs: tuple[list[torch.Tensor], torch.Tensor] | None,
     ) -> tuple[dict[str, Any], int]:
-        # Context and query positions/slots were written to separate
-        # buffers by the kernel — no copy needed.
+        # Context and query positions/slots were written by the kernel.
         num_context = self._dflash_num_context
 
-        # Pre-insert context KVs directly into cache
         self.model.precompute_and_store_context_kv(
             self._dflash_hidden_states,  # Shape is already [num_context, hidden_size]
             self._context_positions_buffer[:num_context],
-            self._context_slot_mapping_buffer[:num_context],
+            self._get_dflash_context_slot_mapping(num_context),
         )
         return (
             dict(
@@ -278,10 +393,52 @@ class DFlashProposer(SpecDecodeBaseProposer):
     def build_per_group_and_layer_attn_metadata(
         self, cad: CommonAttentionMetadata, draft_index: int = 0
     ) -> tuple[list[object], dict[str, object]]:
-        per_group, per_layer = super().build_per_group_and_layer_attn_metadata(
-            cad, draft_index
+        self._ensure_slot_mapping_buffers()
+        sliding_layer_names: set[str] = getattr(
+            self.model, "sliding_attention_layer_names", set()
         )
+
+        per_group: list[object] = []
+        per_layer: dict[str, object] = {}
+        for attn_group in self.draft_attn_groups:
+            kv_cache_gid = attn_group.kv_cache_group_id
+            group_cad = cad.replace(
+                block_table_tensor=self._get_dflash_block_table(kv_cache_gid, cad),
+                slot_mapping=self._slot_mapping_buffers_by_gid[kv_cache_gid][1][
+                    : cad.num_actual_tokens
+                ],
+                causal=False,
+            )
+            attn_metadata = attn_group.get_metadata_builder().build_for_drafting(
+                common_attn_metadata=group_cad,
+                draft_index=draft_index,
+            )
+            per_group.append(attn_metadata)
+            for layer_name in attn_group.layer_names:
+                per_layer[layer_name] = attn_metadata
+
+            # DFlash layers consume attention metadata through the per-layer
+            # forward context. Keep the non-causal group metadata for
+            # group-level spec decode checks, and specialize only the SWA
+            # layers that need a causal sliding-window mask.
+            causal_layers = sliding_layer_names & set(attn_group.layer_names)
+            if causal_layers:
+                causal_attn_metadata = (
+                    attn_group.get_metadata_builder().build_for_drafting(
+                        common_attn_metadata=group_cad.replace(causal=True),
+                        draft_index=draft_index,
+                    )
+                )
+                for layer_name in causal_layers:
+                    per_layer[layer_name] = causal_attn_metadata
+
         for layer_name, attn_metadata in per_layer.items():
+            if layer_name in sliding_layer_names:
+                assert getattr(attn_metadata, "causal", None) is True, (
+                    f"Attention metadata for sliding layer {layer_name} does not have"
+                    " causal support, which is required for DFlash SWA."
+                )
+                continue
             assert getattr(attn_metadata, "causal", None) is False, (
                 f"Attention metadata for layer {layer_name} does not have"
                 " non-causal support, which is required for DFlash."

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -30,7 +30,11 @@ from vllm.v1.attention.backend import CommonAttentionMetadata
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 from vllm.v1.attention.backends.triton_attn import TritonAttentionMetadata
 from vllm.v1.cudagraph_dispatcher import CudagraphDispatcher
-from vllm.v1.kv_cache_interface import KVCacheConfig, UniformTypeKVCacheSpecs
+from vllm.v1.kv_cache_interface import (
+    KVCacheConfig,
+    KVCacheSpec,
+    UniformTypeKVCacheSpecs,
+)
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.sampler import _SAMPLING_EPS
 from vllm.v1.spec_decode.metadata import SpecDecodeMetadata
@@ -1526,7 +1530,9 @@ class SpecDecodeBaseProposer:
             )
         self.kv_cache_gid = self._draft_kv_cache_group_ids[0]
 
-        attention_groups: dict[tuple[int, str, Any], AttentionGroup] = {}
+        attention_groups: dict[
+            tuple[int, tuple[str, str], KVCacheSpec], AttentionGroup
+        ] = {}
         for layer_name in self._draft_attn_layer_names:
             gid = self._draft_layer_to_kv_cache_gid[layer_name]
             kv_cache_spec = kv_cache_config.kv_cache_groups[gid].kv_cache_spec

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -130,6 +130,8 @@ class SpecDecodeBaseProposer:
 
         self.draft_attn_groups: list[AttentionGroup] = []
         self.kv_cache_gid: int = -1
+        self._draft_layer_to_kv_cache_gid: dict[str, int] = {}
+        self._draft_kv_cache_group_ids: list[int] = []
         self.eagle3_use_aux_hidden_state: bool = (
             self._get_eagle3_use_aux_hidden_state_from_config()
         )
@@ -1485,6 +1487,9 @@ class SpecDecodeBaseProposer:
             == 1
         ), "All drafting layers should belong to the same kv cache group"
 
+    def allow_multiple_draft_kv_cache_groups(self) -> bool:
+        return False
+
     def initialize_attn_backend(
         self,
         kv_cache_config: KVCacheConfig,
@@ -1499,47 +1504,59 @@ class SpecDecodeBaseProposer:
             AttentionLayerBase,  # type: ignore[type-abstract]
         )
 
-        # Find which kv_cache_group the draft layers belong to
-        self.validate_same_kv_cache_group(kv_cache_config)
-        kv_cache_spec = None
-        for gid, group in enumerate(kv_cache_config.kv_cache_groups):
-            if self._draft_attn_layer_names & set(group.layer_names):
-                self.kv_cache_gid = gid
-                kv_cache_spec = group.kv_cache_spec
-                break
+        self._draft_layer_to_kv_cache_gid = {
+            layer_name: gid
+            for gid, group in enumerate(kv_cache_config.kv_cache_groups)
+            for layer_name in group.layer_names
+            if layer_name in self._draft_attn_layer_names
+        }
+        missing_layers = self._draft_attn_layer_names - set(
+            self._draft_layer_to_kv_cache_gid
+        )
+        assert not missing_layers, (
+            "Draft attention layers are missing from KV cache groups: "
+            f"{sorted(missing_layers)}"
+        )
+        self._draft_kv_cache_group_ids = sorted(
+            set(self._draft_layer_to_kv_cache_gid.values())
+        )
+        if not self.allow_multiple_draft_kv_cache_groups():
+            assert len(self._draft_kv_cache_group_ids) == 1, (
+                "All drafting layers should belong to the same kv cache group"
+            )
+        self.kv_cache_gid = self._draft_kv_cache_group_ids[0]
 
-        attention_groups: dict[tuple[str, str], AttentionGroup] = {}
-        if kv_cache_spec is not None:
-            for layer_name in self._draft_attn_layer_names:
-                attn_backend = all_attn_layers[layer_name].get_attn_backend()
-                backend_key = attn_backend.full_cls_name()
-                if backend_key not in attention_groups:
-                    layer_kv_cache_spec = kv_cache_spec
-                    if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
-                        layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[
-                            layer_name
-                        ]
+        attention_groups: dict[tuple[int, str, Any], AttentionGroup] = {}
+        for layer_name in self._draft_attn_layer_names:
+            gid = self._draft_layer_to_kv_cache_gid[layer_name]
+            kv_cache_spec = kv_cache_config.kv_cache_groups[gid].kv_cache_spec
+            layer_kv_cache_spec = kv_cache_spec
+            if isinstance(layer_kv_cache_spec, UniformTypeKVCacheSpecs):
+                layer_kv_cache_spec = layer_kv_cache_spec.kv_cache_specs[layer_name]
 
-                    kernel_block_size = (
-                        kernel_block_sizes[self.kv_cache_gid]
-                        if kernel_block_sizes is not None
-                        and self.kv_cache_gid < len(kernel_block_sizes)
-                        else None
-                    )
-                    attn_group = AttentionGroup(
-                        backend=attn_backend,
-                        layer_names=[layer_name],
-                        kv_cache_spec=layer_kv_cache_spec,
-                        kv_cache_group_id=self.kv_cache_gid,
-                    )
-                    attn_group.create_metadata_builders(
-                        self.vllm_config,
-                        self.device,
-                        kernel_block_size=kernel_block_size,
-                    )
-                    attention_groups[backend_key] = attn_group
-                else:
-                    attention_groups[backend_key].layer_names.append(layer_name)
+            attn_backend = all_attn_layers[layer_name].get_attn_backend()
+            backend_key = attn_backend.full_cls_name()
+            group_key = (gid, backend_key, layer_kv_cache_spec)
+            if group_key not in attention_groups:
+                kernel_block_size = (
+                    kernel_block_sizes[gid]
+                    if kernel_block_sizes is not None and gid < len(kernel_block_sizes)
+                    else None
+                )
+                attn_group = AttentionGroup(
+                    backend=attn_backend,
+                    layer_names=[layer_name],
+                    kv_cache_spec=layer_kv_cache_spec,
+                    kv_cache_group_id=gid,
+                )
+                attn_group.create_metadata_builders(
+                    self.vllm_config,
+                    self.device,
+                    kernel_block_size=kernel_block_size,
+                )
+                attention_groups[group_key] = attn_group
+            else:
+                attention_groups[group_key].layer_names.append(layer_name)
 
         self.draft_attn_groups = list(attention_groups.values())
         self.block_size = (

--- a/vllm/v1/spec_decode/utils.py
+++ b/vllm/v1/spec_decode/utils.py
@@ -502,20 +502,13 @@ def copy_and_expand_dflash_inputs_kernel(
     ctx_start = tl.load(query_start_loc_ptr + req_idx)
     ctx_end = tl.load(query_start_loc_ptr + req_idx + 1)
     num_ctx = ctx_end - ctx_start
-    total_tokens = num_ctx + num_query_per_req
 
     j = block_idx * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    in_bounds = j < total_tokens
+    in_bounds = j < (num_ctx + num_query_per_req)
     is_ctx = j < num_ctx
     is_query = (~is_ctx) & in_bounds
     query_off = j - num_ctx  # offset within query portion (0-indexed)
 
-    # --- Positions ---
-    # Context: load from target_positions
-    ctx_pos_idx = tl.minimum(ctx_start + j, total_input_tokens - 1)
-    ctx_pos = tl.load(target_positions_ptr + ctx_pos_idx, mask=is_ctx, other=0)
-
-    # Query: last_valid_pos + 1 + query_off
     # In padded mode, ctx_end includes rejected tokens; use valid_ctx_end
     # to find the last accepted context position.
     if HAS_NUM_REJECTED:
@@ -523,14 +516,37 @@ def copy_and_expand_dflash_inputs_kernel(
         valid_ctx_end = ctx_end - num_rejected
     else:
         valid_ctx_end = ctx_end
-    last_pos = tl.load(target_positions_ptr + valid_ctx_end - 1)
+
+    valid_num_ctx = valid_ctx_end - ctx_start
+    is_valid_ctx = j < valid_num_ctx
+
+    # --- Positions ---
+    # Context: load from target_positions. Rejected context positions are
+    # don't-care because their slot mappings are masked out below.
+    ctx_pos_idx = tl.minimum(ctx_start + j, total_input_tokens - 1)
+    ctx_pos = tl.load(target_positions_ptr + ctx_pos_idx, mask=is_ctx, other=0)
+
+    # Query: last_valid_pos + 1 + query_off. If the previous sampled output
+    # was discarded, there may be no valid context token from that target pass;
+    # start from the first scheduled position in that case.
+    fallback_last_pos = tl.load(target_positions_ptr + ctx_start) - 1
+    last_valid_pos_idx = tl.maximum(valid_ctx_end - 1, ctx_start)
+    last_pos = tl.load(
+        target_positions_ptr + last_valid_pos_idx,
+        mask=valid_num_ctx > 0,
+        other=fallback_last_pos,
+    )
     query_pos = last_pos + 1 + query_off
 
     positions = tl.where(is_ctx, ctx_pos, query_pos)
 
     # Context and query positions go to separate buffers.
     ctx_pos_out = ctx_start + j
-    tl.store(out_context_positions_ptr + ctx_pos_out, ctx_pos, mask=is_ctx)
+    tl.store(
+        out_context_positions_ptr + ctx_pos_out,
+        tl.where(is_valid_ctx, ctx_pos, 0),
+        mask=is_ctx,
+    )
     query_out = req_idx * num_query_per_req + query_off
     tl.store(out_query_positions_ptr + query_out, query_pos, mask=is_query)
 
@@ -544,7 +560,11 @@ def copy_and_expand_dflash_inputs_kernel(
         other=0,
     ).to(tl.int64)
     slot = block_id * block_size + (positions % block_size)
-    tl.store(out_context_slot_mapping_ptr + ctx_pos_out, slot, mask=is_ctx)
+    tl.store(
+        out_context_slot_mapping_ptr + ctx_pos_out,
+        tl.where(is_valid_ctx, slot, -1),
+        mask=is_ctx,
+    )
     tl.store(out_query_slot_mapping_ptr + query_out, slot, mask=is_query)
 
     # --- Input IDs (query tokens only) ---

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5042,7 +5042,8 @@ class GPUModelRunner(
         if not layer_ids:
             dflash_config = getattr(hf_config, "dflash_config", None)
             if dflash_config and isinstance(dflash_config, dict):
-                layer_ids = dflash_config.get("target_layer_ids")
+                # Add 1 to convert DFlash's aux layer id semantics
+                layer_ids = [i + 1 for i in dflash_config.get("target_layer_ids", [])]
 
         if layer_ids and isinstance(layer_ids, (list, tuple)):
             return tuple(layer_ids)

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -2318,6 +2318,14 @@ class GPUModelRunner(
         # Prepare the attention metadata for each KV cache group and make layers
         # in the same group share the same metadata.
         spec_decode_common_attn_metadata = None
+        dflash_drafter = (
+            self.drafter
+            if self.speculative_config and isinstance(self.drafter, DFlashProposer)
+            else None
+        )
+        if dflash_drafter is not None:
+            dflash_drafter.clear_draft_block_tables()
+
         for kv_cache_gid, kv_cache_group in enumerate(kv_cache_groups):
             cm = copy(cm_base)  # shallow copy
 
@@ -2332,6 +2340,11 @@ class GPUModelRunner(
             if kv_cache_gid > 0:
                 cm.block_table_tensor = _get_block_table(kv_cache_gid)
                 cm.slot_mapping = slot_mappings[kv_cache_gid]
+
+            if dflash_drafter is not None:
+                dflash_drafter.set_draft_block_table(
+                    kv_cache_gid, cm.block_table_tensor
+                )
 
             if self.speculative_config and spec_decode_common_attn_metadata is None:
                 if isinstance(
@@ -5042,7 +5055,7 @@ class GPUModelRunner(
         if not layer_ids:
             dflash_config = getattr(hf_config, "dflash_config", None)
             if dflash_config and isinstance(dflash_config, dict):
-                # Add 1 to convert DFlash's aux layer id semantics
+                # Add 1 to convert DFlash's aux layer id semantics.
                 layer_ids = [i + 1 for i in dflash_config.get("target_layer_ids", [])]
 
         if layer_ids and isinstance(layer_ids, (list, tuple)):

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6689,6 +6689,119 @@ class GPUModelRunner(
         for attn_groups in self.attn_groups:
             yield from attn_groups
 
+    @staticmethod
+    def _get_kv_cache_stride_order(
+        attn_backend: type[AttentionBackend],
+        kv_cache_shape: tuple[int, ...],
+    ) -> tuple[int, ...]:
+        try:
+            kv_cache_stride_order = attn_backend.get_kv_cache_stride_order()
+            assert len(kv_cache_stride_order) == len(kv_cache_shape)
+            return kv_cache_stride_order
+        except (AttributeError, NotImplementedError):
+            return tuple(range(len(kv_cache_shape)))
+
+    @classmethod
+    def _get_standard_kv_cache_orders(
+        cls,
+        attn_backend: type[AttentionBackend],
+        kv_cache_shape: tuple[int, ...],
+        num_blocks: int,
+    ) -> tuple[tuple[int, ...], tuple[str, ...] | None, tuple[str, ...] | None]:
+        stride_order = cls._get_kv_cache_stride_order(attn_backend, kv_cache_shape)
+        if len(kv_cache_shape) != 5:
+            return stride_order, None, None
+        if kv_cache_shape[:2] == (2, num_blocks):
+            public_order = ("kv", "block", "token", "head", "dim")
+        elif kv_cache_shape[:2] == (num_blocks, 2):
+            public_order = ("block", "kv", "token", "head", "dim")
+        else:
+            return stride_order, None, None
+        return stride_order, public_order, tuple(public_order[i] for i in stride_order)
+
+    @staticmethod
+    def _view_kv_cache_with_physical_order(
+        raw_tensor: torch.Tensor,
+        kv_cache_shape: tuple[int, ...],
+        public_order: tuple[str, ...],
+        physical_order: tuple[str, ...],
+    ) -> torch.Tensor:
+        # Backends can expose the same standard KV cache with different public
+        # shapes or physical orders. When they share one raw tensor, keep each
+        # backend's public shape but map it to the shared physical layout.
+        dim_sizes = dict(zip(public_order, kv_cache_shape))
+        physical_strides: dict[str, int] = {}
+        stride = 1
+        for dim in reversed(physical_order):
+            physical_strides[dim] = stride
+            stride *= dim_sizes[dim]
+        public_strides = tuple(physical_strides[dim] for dim in public_order)
+        return torch.as_strided(
+            raw_tensor,
+            size=kv_cache_shape,
+            stride=public_strides,
+        )
+
+    @staticmethod
+    def _get_attention_kv_cache_shape(
+        attn_backend: type[AttentionBackend],
+        kv_cache_spec: AttentionSpec,
+        num_blocks: int,
+        kernel_block_size: int,
+        cache_dtype_str: str,
+    ) -> tuple[int, ...]:
+        # For MLA with compression, storage_block_size != block_size.
+        if kv_cache_spec.storage_block_size != kv_cache_spec.block_size:
+            shape_block_size = kv_cache_spec.storage_block_size
+        else:
+            shape_block_size = kernel_block_size
+        return attn_backend.get_kv_cache_shape(
+            num_blocks,
+            shape_block_size,
+            kv_cache_spec.num_kv_heads,
+            kv_cache_spec.head_size,
+            cache_dtype_str=cache_dtype_str,
+        )
+
+    def _get_raw_tensor_physical_orders(
+        self,
+        kv_cache_raw_tensors: dict[str, torch.Tensor],
+        kernel_block_sizes: list[int],
+    ) -> dict[int, set[tuple[str, ...]]]:
+        raw_tensor_physical_orders: dict[int, set[tuple[str, ...]]] = defaultdict(set)
+        for group in self._kv_cache_spec_attn_group_iterator():
+            kv_cache_spec = group.kv_cache_spec
+            if (
+                group.kv_cache_group_id == len(kernel_block_sizes)
+                or not isinstance(kv_cache_spec, AttentionSpec)
+            ):
+                continue
+            kernel_block_size = kernel_block_sizes[group.kv_cache_group_id]
+            for layer_name in group.layer_names:
+                if (
+                    layer_name in self.runner_only_attn_layers
+                    or layer_name not in kv_cache_raw_tensors
+                ):
+                    continue
+                raw_tensor = kv_cache_raw_tensors[layer_name]
+                num_blocks = raw_tensor.numel() // kv_cache_spec.page_size_bytes
+                num_blocks *= kv_cache_spec.block_size // kernel_block_size
+                kv_cache_shape = self._get_attention_kv_cache_shape(
+                    group.backend,
+                    kv_cache_spec,
+                    num_blocks,
+                    kernel_block_size,
+                    self.cache_config.cache_dtype,
+                )
+                _, _, physical_order = self._get_standard_kv_cache_orders(
+                    group.backend,
+                    kv_cache_shape,
+                    num_blocks,
+                )
+                if physical_order is not None:
+                    raw_tensor_physical_orders[id(raw_tensor)].add(physical_order)
+        return raw_tensor_physical_orders
+
     def _reshape_kv_cache_tensors(
         self,
         kv_cache_raw_tensors: dict[str, torch.Tensor],
@@ -6707,6 +6820,10 @@ class GPUModelRunner(
         """
         kv_caches: dict[str, torch.Tensor] = {}
         has_attn, has_mamba = False, False
+        raw_tensor_physical_orders = self._get_raw_tensor_physical_orders(
+            kv_cache_raw_tensors, kernel_block_sizes
+        )
+
         for group in self._kv_cache_spec_attn_group_iterator():
             kv_cache_spec = group.kv_cache_spec
             attn_backend = group.backend
@@ -6727,25 +6844,47 @@ class GPUModelRunner(
                     )
                     kernel_num_blocks = num_blocks * num_blocks_per_kv_block
 
-                    # For MLA with compression, storage_block_size != block_size
-                    if kv_cache_spec.storage_block_size != kv_cache_spec.block_size:
-                        shape_block_size = kv_cache_spec.storage_block_size
-                    else:
-                        shape_block_size = kernel_block_size
-
-                    kv_cache_shape = attn_backend.get_kv_cache_shape(
+                    kv_cache_shape = self._get_attention_kv_cache_shape(
+                        attn_backend,
+                        kv_cache_spec,
                         kernel_num_blocks,
-                        shape_block_size,
-                        kv_cache_spec.num_kv_heads,
-                        kv_cache_spec.head_size,
-                        cache_dtype_str=self.cache_config.cache_dtype,
+                        kernel_block_size,
+                        self.cache_config.cache_dtype,
+                    )
+                    (
+                        kv_cache_stride_order,
+                        public_order,
+                        physical_order,
+                    ) = self._get_standard_kv_cache_orders(
+                        attn_backend,
+                        kv_cache_shape,
+                        kernel_num_blocks,
                     )
                     dtype = kv_cache_spec.dtype
-                    try:
-                        kv_cache_stride_order = attn_backend.get_kv_cache_stride_order()
-                        assert len(kv_cache_stride_order) == len(kv_cache_shape)
-                    except (AttributeError, NotImplementedError):
-                        kv_cache_stride_order = tuple(range(len(kv_cache_shape)))
+                    shared_orders = raw_tensor_physical_orders[id(raw_tensor)]
+                    block_major_orders = (
+                        order for order in shared_orders if order[:2] == ("block", "kv")
+                    )
+                    shared_physical_order = next(
+                        iter(sorted(block_major_orders)), None
+                    ) or next(iter(sorted(shared_orders)), None)
+                    raw_tensor = raw_tensor.view(dtype)
+                    if (
+                        public_order is not None
+                        and physical_order != shared_physical_order
+                        and shared_physical_order is not None
+                        and kv_cache_spec.page_size_padded is None
+                    ):
+                        kv_caches[layer_name] = (
+                            self._view_kv_cache_with_physical_order(
+                                raw_tensor,
+                                kv_cache_shape,
+                                public_order,
+                                shared_physical_order,
+                            )
+                        )
+                        continue
+
                     # The allocation respects the backend-defined stride order
                     # to ensure the semantic remains consistent for each
                     # backend. We first obtain the generic kv cache shape and
@@ -6760,16 +6899,15 @@ class GPUModelRunner(
                         for i in range(len(kv_cache_stride_order))
                     ]
 
-                    raw_tensor = kv_cache_raw_tensors[layer_name].view(dtype)
                     if kv_cache_spec.page_size_padded is not None:
                         # Use strided view to handle page_size_bytes that
-                        # include padding. This follows
-                        # the same pattern as MambaSpec handling below.
+                        # include padding. This follows the same pattern as
+                        # MambaSpec handling below.
                         # NOTE: This assumes kv_cache_shape[0] == num_blocks
                         # (i.e. the first physical dimension is the block
                         # index), which holds for MLA backends but NOT for
-                        # standard attention backends whose shape starts with
-                        # a K/V dimension of size 2.
+                        # standard attention backends whose shape starts
+                        # with a K/V dimension of size 2.
                         dtype_size = get_dtype_size(dtype)
                         page_stride = kv_cache_spec.page_size_bytes // dtype_size
                         strides = list(torch.empty(kv_cache_shape).stride())

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6771,9 +6771,8 @@ class GPUModelRunner(
         raw_tensor_physical_orders: dict[int, set[tuple[str, ...]]] = defaultdict(set)
         for group in self._kv_cache_spec_attn_group_iterator():
             kv_cache_spec = group.kv_cache_spec
-            if (
-                group.kv_cache_group_id == len(kernel_block_sizes)
-                or not isinstance(kv_cache_spec, AttentionSpec)
+            if group.kv_cache_group_id == len(kernel_block_sizes) or not isinstance(
+                kv_cache_spec, AttentionSpec
             ):
                 continue
             kernel_block_size = kernel_block_sizes[group.kv_cache_group_id]
@@ -6875,13 +6874,11 @@ class GPUModelRunner(
                         and shared_physical_order is not None
                         and kv_cache_spec.page_size_padded is None
                     ):
-                        kv_caches[layer_name] = (
-                            self._view_kv_cache_with_physical_order(
-                                raw_tensor,
-                                kv_cache_shape,
-                                public_order,
-                                shared_physical_order,
-                            )
+                        kv_caches[layer_name] = self._view_kv_cache_with_physical_order(
+                            raw_tensor,
+                            kv_cache_shape,
+                            public_order,
+                            shared_physical_order,
                         )
                         continue
 


### PR DESCRIPTION
## Purpose

Fix the remaining Gemma4-specific DFlash issues on top of the generic DFlash SWA/shared-KV work in #40898.

This PR is stacked in git history on #40898. The Gemma4-only review delta against the SWA branch is intentionally small: 4 files, 57 insertions, 15 deletions.

Review delta: https://github.com/jianc99/vllm/compare/dflash-swa-support...dflash-gemma4-fix

## Changes

1. **Gemma4-compatible DFlash draft embeddings and logits**

   DFlash shares target embeddings. For Gemma4 targets, the draft path now applies the target embedding normalization (`sqrt(hidden_size)`) and passes `final_logit_softcapping` into `LogitsProcessor`.

2. **Triton metadata uses concrete KV cache geometry**

   Triton decode metadata now sizes KV heads and head dimension from the actual `kv_cache_spec`, which avoids assuming all attention groups share the model-wide KV geometry.

3. **Rejected-token handling for DFlash batch verification**

   `copy_and_expand_dflash_inputs_kernel` now masks rejected context slots, avoids writing invalid context slots into draft KV cache, and computes query positions from the last valid accepted context token.

4. **Text-only DFlash draft attention with Gemma4 target**

   DFlash draft attention runs over text/query tokens with prewritten K/V, so it should not inherit the Gemma4 target's multimodal-prefix backend restriction. The draft attention layer now opts out of `use_mm_prefix`, allowing the requested `attention_backend=flash_attn` drafter path.

## DFlash vs Gemma4 MTP Comparison

Benchmarked on B200 with `google/gemma-4-26B-A4B-it`, `num_speculative_tokens=15`, `max_concurrency=32`, `--max-num-batched-tokens 32768`, and `--num-warmups 32`.

### HumanEval

| Method | Output tok/s | Mean TPOT | Median TPOT | Mean TTFT | Median TTFT | Acceptance length | Acceptance rate |
|---|---:|---:|---:|---:|---:|---:|---:|
| DFlash | 6820.79 | 3.34 ms | 3.17 ms | 108.35 ms | 79.33 ms | 7.73 | 44.88% |
| Gemma4 MTP | 6372.44 | 4.31 ms | 4.28 ms | 130.93 ms | 110.95 ms | 7.95 | 46.35% |

### MT-Bench

| Method | Output tok/s | Mean TPOT | Median TPOT | Mean TTFT | Median TTFT | Acceptance length | Acceptance rate |
|---|---:|---:|---:|---:|---:|---:|---:|
| DFlash | 5250.12 | 5.15 ms | 5.14 ms | 94.88 ms | 76.60 ms | 4.25 | 21.68% |
| Gemma4 MTP | 4216.70 | 6.52 ms | 6.35 ms | 142.34 ms | 105.05 ms | 4.83 | 25.56% |

DFlash is faster on both warmed workloads, despite Gemma4 MTP having slightly higher acceptance.

### Latest exact HumanEval regression run

Command matched the PR repro command without benchmark warmups, using `/home/zlab/workspace/jianc/repo/dflash/cache/humaneval.vllm.jsonl`:

| Method | Output tok/s | Mean TPOT | Median TPOT | Mean TTFT | Median TTFT | Acceptance length | Acceptance rate | Failed |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| DFlash | 6122.98 | 2.97 ms | 2.80 ms | 2760.48 ms | 69.53 ms | 7.70 | 44.69% | 0 |

This matches the previous reference acceptance profile (`44.59%`, acceptance length `7.69`) while keeping the shared target/draft raw KV tensor path from #40898.

### DFlash target-layer offset check

The checkpoint-native `dflash_config.target_layer_ids` path was also checked against a temporary no-shift run. The shifted path matches HF DFlash semantics and gives the expected acceptance profile.

| Aux layer semantics | Aux layers used | Output tok/s | Acceptance length | Acceptance rate | Failed |
|---|---:|---:|---:|---:|---:|
| Shifted `+1` | `(2, 7, 12, 18, 23, 28)` | 6122.98 | 7.70 | 44.69% | 0 |
| No shift | `(1, 6, 11, 17, 22, 27)` | 5270.36 | 6.60 | 37.30% | 0 |

## Test Plan

Unit tests:

```bash
PATH=/home/zlab/miniconda3/envs/vllm-dflash/bin:$PATH python -m pytest \
  tests/v1/spec_decode/test_eagle.py \
  tests/v1/spec_decode/test_dflash_swa.py \
  tests/v1/core/test_kv_sharing.py -q
```

Syntax/whitespace hygiene:

```bash
PATH=/home/zlab/miniconda3/envs/vllm-dflash/bin:$PATH python -m py_compile \
  vllm/model_executor/layers/attention/attention.py \
  vllm/model_executor/models/qwen3_dflash.py \
  vllm/v1/attention/backends/triton_attn.py \
  vllm/v1/spec_decode/utils.py

git diff --check refs/remotes/jianc99/dflash-swa-support...HEAD
git diff --check origin/main...HEAD
```

Manual HumanEval validation:

```bash
vllm serve google/gemma-4-26B-A4B-it \
  --speculative-config '{"method": "dflash", "model": "z-lab/gemma-4-26B-A4B-it-DFlash", "num_speculative_tokens": 15, "attention_backend": "flash_attn"}' \
  --attention-backend triton_attn \
  --max-num-batched-tokens 32768

vllm bench serve \
  --backend openai-chat \
  --base-url http://127.0.0.1:8000 \
  --endpoint /v1/chat/completions \
  --dataset-name custom \
  --dataset-path /home/zlab/workspace/jianc/repo/dflash/cache/humaneval.vllm.jsonl \
  --custom-output-len 4096 \
  --num-prompts 164 \
  --max-concurrency 32 \
  --model google/gemma-4-26B-A4B-it \
  --temperature 0.0 \
  --skip-chat-template \
  --extra-body '{"chat_template_kwargs":{"enable_thinking":true}}'
```

## Test Result

- Pushed head: `8cb2db16072cebbb944564f84f21045a90151ad1`; includes #40898 head `23002d3f368a5a24641301bc71e4ae15dae89a24`.
- Re-stacked branch on #40898 head: Gemma4-only delta is 4 files, 57 insertions, 15 deletions.
- Focused checks: `54 passed, 6 skipped, 20 warnings` for `test_eagle.py`, `test_dflash_swa.py`, and `test_kv_sharing.py`.
- `pre-commit run --files` passed for the Gemma4 delta files, including mypy.
- Syntax checks passed with `py_compile` for the Gemma4 delta files.
- `git diff --check refs/remotes/jianc99/dflash-swa-support...HEAD` and `git diff --check origin/main...HEAD` passed.
- Manual HumanEval serving benchmark completed with 0 failed requests; see the exact regression table above.
- Earlier warmed HumanEval and MT-Bench serving benchmarks both completed with 0 failed requests; see comparison tables above.



