### PR TITLE
support case of DSML｜_tool_calls

### DIFF
--- a/tests/tool_parsers/test_deepseekv32_tool_parser.py
+++ b/tests/tool_parsers/test_deepseekv32_tool_parser.py
@@ -51,6 +51,8 @@ def make_request(tools=None) -> MagicMock:
 # Shorthand for the DSML tokens used throughout
 FC_START = "<｜DSML｜function_calls>"
 FC_END = "</｜DSML｜function_calls>"
+UTC_START = "<｜DSML｜_tool_calls>"
+UTC_END = "</｜DSML｜_tool_calls>"
 INV_START = '<｜DSML｜invoke name="'
 INV_END = "</｜DSML｜invoke>"
 PARAM_START = '<｜DSML｜parameter name="'
@@ -63,6 +65,16 @@ def build_tool_call(func_name: str, params: dict[str, str]) -> str:
         f'{PARAM_START}{k}" string="true">{v}{PARAM_END}' for k, v in params.items()
     )
     return f'{FC_START}\n{INV_START}{func_name}">\n{param_strs}\n{INV_END}\n{FC_END}'
+
+
+def build_tool_call_with_wrapper(
+    start_tag: str, end_tag: str, func_name: str, params: dict[str, str]
+) -> str:
+    """Build a complete tool call with explicit wrapper tags."""
+    param_strs = "".join(
+        f'{PARAM_START}{k}" string="true">{v}{PARAM_END}' for k, v in params.items()
+    )
+    return f'{start_tag}\n{INV_START}{func_name}">\n{param_strs}\n{INV_END}\n{end_tag}'
 
 
 # ---------------------------------------------------------------------------
@@ -211,6 +223,22 @@ class TestExtractToolCalls:
         assert args == {"enabled": True, "count": 42}
         assert isinstance(args["enabled"], bool)
         assert isinstance(args["count"], int)
+
+    def test_alias_wrapper_non_streaming(self, parser):
+        """Alias wrappers like ``_tool_calls`` should be parsed as tools."""
+        model_output = build_tool_call_with_wrapper(
+            UTC_START,
+            UTC_END,
+            "read",
+            {"path": "/app/skills/weather/SKILL.md"},
+        )
+        result = parser.extract_tool_calls(model_output, None)
+        assert result.tools_called
+        assert len(result.tool_calls) == 1
+        assert result.tool_calls[0].function.name == "read"
+        assert json.loads(result.tool_calls[0].function.arguments) == {
+            "path": "/app/skills/weather/SKILL.md"
+        }
 
 
 # ---------------------------------------------------------------------------
@@ -559,6 +587,24 @@ class TestExtractToolCallsStreaming:
         deltas = self._stream_chunked(parser, full_text, chunk_size=3)
         content = "".join(d.content for d in deltas if d.content is not None)
         assert content == full_text
+
+    def test_alias_wrapper_streaming_no_dsml_leak(self, parser):
+        """Alias wrapper should emit tool_calls, not DSML fragments in content."""
+        full_text = (
+            "让我先加载 weather 技能，然后帮你查！\n\n"
+            + build_tool_call_with_wrapper(
+                UTC_START,
+                UTC_END,
+                "read",
+                {"path": "/app/skills/weather/SKILL.md"},
+            )
+        )
+        deltas = self._stream_chunked(parser, full_text, chunk_size=4)
+        content = "".join(d.content for d in deltas if d.content is not None)
+        assert content == "让我先加载 weather 技能，然后帮你查！\n\n"
+        assert "DSML" not in content
+        args_str = self._reconstruct_args(deltas)
+        assert json.loads(args_str) == {"path": "/app/skills/weather/SKILL.md"}
 
 
 class TestDelimiterPreservation:

--- a/vllm/tool_parsers/deepseekv32_tool_parser.py
+++ b/vllm/tool_parsers/deepseekv32_tool_parser.py
@@ -48,6 +48,11 @@ class DeepSeekV32ToolParser(ToolParser):
 
     tool_call_start_token: str = "<｜DSML｜function_calls>"
     tool_call_end_token: str = "</｜DSML｜function_calls>"
+    _fallback_tool_call_start_tokens: tuple[str, ...] = (
+        "<｜DSML｜tool_calls>",
+        "<｜DSML｜_tool_calls>",
+        "<｜DSML｜function_calls>",
+    )
 
     def __init__(self, tokenizer: TokenizerLike, tools: list[Tool] | None = None):
         super().__init__(tokenizer, tools)
@@ -58,11 +63,12 @@ class DeepSeekV32ToolParser(ToolParser):
         self.current_tool_index: int = 0
         self._sent_content_idx: int = 0
 
-        # Regex patterns for complete parsing
+        # Regex patterns for complete parsing. Accept both legacy and alias
+        # wrappers because some deployments emit ``_tool_calls`` variants.
+        self._tool_call_start_tokens = self._build_tool_call_start_tokens()
         self.tool_call_complete_regex = re.compile(
-            re.escape(self.tool_call_start_token)
-            + r"(.*?)"
-            + re.escape(self.tool_call_end_token),
+            r"<｜DSML｜(?:function_calls|_?tool_calls)>(.*?)"
+            r"</\s*｜DSML｜(?:function_calls|_?tool_calls)>",
             re.DOTALL,
         )
         self.invoke_complete_regex = re.compile(
@@ -100,6 +106,26 @@ class DeepSeekV32ToolParser(ToolParser):
     def _generate_tool_call_id(self) -> str:
         """Generate a unique tool call ID."""
         return f"call_{uuid.uuid4().hex[:24]}"
+
+    def _build_tool_call_start_tokens(self) -> tuple[str, ...]:
+        """Start-tag variants to detect in streaming/non-streaming text."""
+        candidates = [
+            self.tool_call_start_token,
+            *self._fallback_tool_call_start_tokens,
+        ]
+        ordered_unique: list[str] = []
+        for token in candidates:
+            if token not in ordered_unique:
+                ordered_unique.append(token)
+        return tuple(ordered_unique)
+
+    def _find_first_tool_call_start(self, text: str) -> int:
+        """Return the left-most DSML tool-call wrapper start index."""
+        positions = [text.find(token) for token in self._tool_call_start_tokens]
+        valid_positions = [pos for pos in positions if pos >= 0]
+        if not valid_positions:
+            return -1
+        return min(valid_positions)
 
     def _parse_invoke_params(self, invoke_str: str) -> dict:
         param_dict = dict()
@@ -175,8 +201,8 @@ class DeepSeekV32ToolParser(ToolParser):
         request: ChatCompletionRequest,
     ) -> ExtractedToolCallInformation:
         """Extract tool calls from complete model output (non-streaming)."""
-        # Quick check
-        if self.tool_call_start_token not in model_output:
+        first_tool_idx = self._find_first_tool_call_start(model_output)
+        if first_tool_idx == -1:
             return ExtractedToolCallInformation(
                 tools_called=False, tool_calls=[], content=model_output
             )
@@ -208,7 +234,6 @@ class DeepSeekV32ToolParser(ToolParser):
                 )
 
             # Extract content before first tool call
-            first_tool_idx = model_output.find(self.tool_call_start_token)
             content = model_output[:first_tool_idx] if first_tool_idx > 0 else None
 
             return ExtractedToolCallInformation(
@@ -275,11 +300,17 @@ class DeepSeekV32ToolParser(ToolParser):
         Holds back any suffix that could be a partial start marker
         so that split markers are never leaked as content.
         """
-        if self.tool_call_start_token not in current_text:
-            overlap = partial_tag_overlap(current_text, self.tool_call_start_token)
+        first_tool_idx = self._find_first_tool_call_start(current_text)
+        if first_tool_idx == -1:
+            overlap = max(
+                partial_tag_overlap(current_text, start_token)
+                for start_token in self._tool_call_start_tokens
+            )
+            # Keep back generic DSML prefix to avoid leaking unknown wrappers.
+            overlap = max(overlap, partial_tag_overlap(current_text, "<｜DSML｜"))
             sendable_idx = len(current_text) - overlap
         else:
-            sendable_idx = current_text.index(self.tool_call_start_token)
+            sendable_idx = first_tool_idx
 
         if sendable_idx > self._sent_content_idx:
             content = current_text[self._sent_content_idx : sendable_idx]


### PR DESCRIPTION



## Purpose

in openclaw chat

we sometimes see DSML leak as below
```
<｜DSML｜_tool_calls>
Could not find file /openclaw/data/openclaw-peter-clawos/workspace/skills/weather/[SKILL.md](http://skill.md/).
</｜DSML｜_tool_calls>
<tool_calls>
<tool_coke name="read" path="/app/skills/weather/[SKILL.md](http://skill.md/)">
</tool_coke>
</tool_calls>
<｜DSML｜_tool_calls>
Could not find file /app/skills/weather/[SKILL.md](http://skill.md/).
</｜DSML｜_tool_calls>
<tool_calls>
<tool_coke name="exec" path="/openclaw/data/openclaw-peter-clawos/workspace" workdir="/openclaw/data/opencl-peter-clawos/workspace" command="find . -name 'weather*' -type f 2>/dev/null; find /app/skills -name 'weather*' -type f 2>/dev/null; ls /app/skills/weather/ 2>/dev/null || echo 'not found'" >
</tool_coke>
</tool_calls>
<｜DSML｜_tool_calls>
The given path /openclaw/data/openclaw-peter-clawos/workspace is not a valid directory.
</｜DSML｜_tool_calls>
</
```

Is it possible that there's another DSML FC keyword than `｜DSML｜function_calls` which is `DSML｜_tool_calls`


may Fixes: https://github.com/vllm-project/vllm/issues/40801
relevant https://github.com/vllm-project/vllm/pull/40806




## Test Plan

NOT TEST YEAH!


## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

