### PR TITLE
[Bugfix] DelegatingParser: strip buffered end-token text in phase B (follow-up to #41068)

### DIFF
--- a/tests/reasoning/test_kimi_k2_reasoning_parser.py
+++ b/tests/reasoning/test_kimi_k2_reasoning_parser.py
@@ -458,3 +458,52 @@ def test_delegating_parser_recovers_partial_end_token_in_boundary_chunk(
     assert "</think>" not in content, (
         f"partial end-token leaked into content: {content!r}"
     )
+
+
+def test_delegating_parser_recovers_reasoning_prefix_buffered_with_partial_end_token(
+    wrapped_kimi_parser, kimi_k2_tokenizer
+):
+    """Reasoning text in the boundary chunk preceding a partial `</think>`
+    must not be silently discarded.
+
+    When delta_text is `"final_thought</th"` plus the end-token id, the
+    Kimi parser returns None (literal not yet visible) and the whole
+    `"final_thought</th"` lands in the skip buffer. Without recovery the
+    pre-literal `"final_thought"` is dropped on resolve; downstream sees
+    reasoning that ends one chunk too early."""
+    request = ChatCompletionRequest(
+        model="test-model", messages=[], temperature=1.0, stream=True
+    )
+    start_id = wrapped_kimi_parser._reasoning_parser._start_token_id
+    end_id = wrapped_kimi_parser._reasoning_parser._end_token_id
+
+    def encode(s: str) -> int:
+        return kimi_k2_tokenizer.encode(s, add_special_tokens=False)[0]
+
+    # Boundary chunk: meaningful reasoning text + partial `</th` + end id.
+    timeline = [
+        Chunk("<think>", [start_id]),
+        Chunk("earlier_reasoning", [encode("earlier_reasoning")]),
+        Chunk("final_thought</th", [encode("final_thought"), end_id]),
+        Chunk("ink>", []),
+        Chunk(" answer", [encode("answer")]),
+    ]
+
+    reasoning, content = _drive(wrapped_kimi_parser, timeline, request)
+
+    assert "final_thought" in reasoning, (
+        f"pre-literal reasoning text dropped on skip resolve: {reasoning!r}"
+    )
+    assert "earlier_reasoning" in reasoning, (
+        f"earlier reasoning unexpectedly missing: {reasoning!r}"
+    )
+    assert "answer" in content, f"post-boundary content lost: {content!r}"
+    assert "</think>" not in content, (
+        f"partial end-token leaked into content: {content!r}"
+    )
+    assert "</think>" not in reasoning, (
+        f"end-token leaked into reasoning: {reasoning!r}"
+    )
+    assert "final_thought" not in content, (
+        f"pre-literal reasoning leaked into content: {content!r}"
+    )

--- a/tests/reasoning/test_kimi_k2_reasoning_parser.py
+++ b/tests/reasoning/test_kimi_k2_reasoning_parser.py
@@ -1,15 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from dataclasses import dataclass
 from unittest.mock import MagicMock
 
 import pytest
 
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
 from vllm.entrypoints.openai.engine.protocol import DeltaMessage
+from vllm.parser.abstract_parser import _WrappedParser
 from vllm.reasoning.identity_reasoning_parser import IdentityReasoningParser
 from vllm.reasoning.kimi_k2_reasoning_parser import KimiK2ReasoningParser
 from vllm.tokenizers import get_tokenizer
+from vllm.tool_parsers.kimi_k2_tool_parser import KimiK2ToolParser
 
 REASONING_MODEL_NAME = "moonshotai/Kimi-K2.5"
 
@@ -216,3 +219,242 @@ def test_streaming_tool_section_id_buffered(mock_kimi_k2_tokenizer):
         delta_token_ids=[tool_begin_id, 999],
     )
     assert result is None
+
+
+# DelegatingParser-level tests for the post-boundary skip that strips the
+# buffered </think> text from phase B (see DelegatingParser.parse_delta).
+
+
+@dataclass
+class Chunk:
+    """One streamed delta as the engine would produce it."""
+
+    delta_text: str
+    token_ids: list[int]
+
+
+@pytest.fixture
+def wrapped_kimi_parser(kimi_k2_tokenizer):
+    class _KimiK2WrappedParser(_WrappedParser):
+        reasoning_parser_cls = KimiK2ReasoningParser
+        tool_parser_cls = KimiK2ToolParser
+
+    return _KimiK2WrappedParser(kimi_k2_tokenizer, tools=[])
+
+
+def _drive(parser, timeline, request):
+    """Feed a chunk timeline through parse_delta and concatenate the deltas."""
+    reasoning_parts: list[str] = []
+    content_parts: list[str] = []
+    for chunk in timeline:
+        msg = parser.parse_delta(
+            delta_text=chunk.delta_text,
+            delta_token_ids=chunk.token_ids,
+            request=request,
+        )
+        if msg is None:
+            continue
+        if msg.reasoning:
+            reasoning_parts.append(msg.reasoning)
+        if msg.content:
+            content_parts.append(msg.content)
+    return "".join(reasoning_parts), "".join(content_parts)
+
+
+def _buffered_flush_timeline(parser, kimi_k2_tokenizer):
+    """Boundary chunk carries the </think> id but only an unrelated byte in
+    text; the buffered </think> then flushes in two later chunks."""
+    start_id = parser._reasoning_parser._start_token_id
+    end_id = parser._reasoning_parser._end_token_id
+
+    def encode(s: str) -> int:
+        return kimi_k2_tokenizer.encode(s, add_special_tokens=False)[0]
+
+    return [
+        Chunk("<think>", [start_id]),
+        Chunk("reasoning text", [encode("reasoning text")]),
+        Chunk("T", [encode("T"), end_id]),
+        Chunk("</", []),
+        Chunk("think>", []),
+        Chunk(" answer", [encode("answer")]),
+    ]
+
+
+def test_delegating_parser_strips_buffered_end_token(
+    wrapped_kimi_parser, kimi_k2_tokenizer
+):
+    """Phase B must not emit the literal </think> when its text is buffered.
+
+    Exercises the end-to-end flow through DelegatingParser.parse_delta on
+    the same scenario as test_streaming_end_token_id_buffered.
+    """
+    request = ChatCompletionRequest(
+        model="test-model", messages=[], temperature=1.0, stream=True
+    )
+    timeline = _buffered_flush_timeline(wrapped_kimi_parser, kimi_k2_tokenizer)
+
+    reasoning, content = _drive(wrapped_kimi_parser, timeline, request)
+
+    assert "</think>" not in content, f"end-token leaked into content: {content!r}"
+    assert "</think>" not in reasoning, (
+        f"end-token leaked into reasoning: {reasoning!r}"
+    )
+    assert "answer" in content, f"post-boundary content lost: {content!r}"
+
+
+def test_delegating_parser_skip_disarmed_when_parser_splits_in_one_chunk(
+    wrapped_kimi_parser, kimi_k2_tokenizer
+):
+    """No buffered tail follows when </think> id and text arrive together;
+    the skip must stay disarmed or it would over-truncate post-boundary
+    content."""
+    request = ChatCompletionRequest(
+        model="test-model", messages=[], temperature=1.0, stream=True
+    )
+    start_id = wrapped_kimi_parser._reasoning_parser._start_token_id
+    end_id = wrapped_kimi_parser._reasoning_parser._end_token_id
+
+    def encode(s: str) -> int:
+        return kimi_k2_tokenizer.encode(s, add_special_tokens=False)[0]
+
+    timeline = [
+        Chunk("<think>", [start_id]),
+        Chunk("thinking", [encode("thinking")]),
+        Chunk("</think>answer", [end_id, encode("answer")]),
+    ]
+
+    _, content = _drive(wrapped_kimi_parser, timeline, request)
+
+    assert "answer" in content, f"post-boundary content swallowed by skip: {content!r}"
+    assert not wrapped_kimi_parser._stream_state.end_token_skip_armed
+    assert not wrapped_kimi_parser._stream_state.end_token_skip_done
+
+
+def test_delegating_parser_boundary_at_end_of_delta_text(
+    wrapped_kimi_parser, kimi_k2_tokenizer
+):
+    """When </think> lands at the very end of delta_text with no content
+    after, the parser returns DeltaMessage(reasoning=..., content=None).
+    The skip must still stay disarmed: the boundary text was already
+    visible, so no buffered tail follows. Otherwise the skip would wait
+    for </think> to appear again on subsequent chunks (it won't) and
+    suppress all post-boundary content."""
+    request = ChatCompletionRequest(
+        model="test-model", messages=[], temperature=1.0, stream=True
+    )
+    start_id = wrapped_kimi_parser._reasoning_parser._start_token_id
+    end_id = wrapped_kimi_parser._reasoning_parser._end_token_id
+
+    def encode(s: str) -> int:
+        return kimi_k2_tokenizer.encode(s, add_special_tokens=False)[0]
+
+    timeline = [
+        Chunk("<think>", [start_id]),
+        Chunk("thinking", [encode("thinking")]),
+        # Boundary chunk: </think> at end, nothing after it.
+        Chunk("</think>", [end_id]),
+        # Real content arrives in the next chunk.
+        Chunk("answer", [encode("answer")]),
+    ]
+
+    _, content = _drive(wrapped_kimi_parser, timeline, request)
+
+    assert "answer" in content, (
+        f"post-boundary content suppressed when boundary lands at end of "
+        f"delta_text: {content!r}"
+    )
+    assert "</think>" not in content
+
+
+def test_delegating_parser_handles_buffered_tool_section_end(
+    wrapped_kimi_parser, kimi_k2_tokenizer
+):
+    """Kimi K2 ends reasoning implicitly via <|tool_calls_section_begin|>.
+    Under stop-sequence buffering the section-start id arrives ahead of
+    its rendered text, so the skip must wait for the section literal to
+    appear (not </think>, which never arrives in this flow). The literal
+    must be preserved in the cleaned text passed to the tool parser:
+    KimiK2ToolParser uses it to identify the section boundary, and
+    without it the post-section payload leaks as raw content (matching
+    the immediate-text path in KimiK2ReasoningParser, which keeps the
+    literal via `content = delta_text[tool_index:]`)."""
+    request = ChatCompletionRequest(
+        model="test-model", messages=[], temperature=1.0, stream=True
+    )
+    start_id = wrapped_kimi_parser._reasoning_parser._start_token_id
+    tool_section_id = wrapped_kimi_parser._reasoning_parser._tool_section_start_token_id
+
+    def encode(s: str) -> int:
+        return kimi_k2_tokenizer.encode(s, add_special_tokens=False)[0]
+
+    # Boundary chunk: tool-section id arrives but its rendered text
+    # (<|tool_calls_section_begin|>) is still buffered. The buffered text
+    # then flushes across two later chunks; the in-section payload
+    # follows.
+    timeline = [
+        Chunk("<think>", [start_id]),
+        Chunk("reasoning", [encode("reasoning")]),
+        Chunk("X", [encode("X"), tool_section_id]),
+        Chunk("<|tool_calls_section", []),
+        Chunk("_begin|>", []),
+        Chunk("payload", [encode("payload")]),
+    ]
+
+    _, content = _drive(wrapped_kimi_parser, timeline, request)
+
+    # The in-section payload must NOT leak as raw content: with the
+    # tool-section literal preserved, KimiK2ToolParser handles everything
+    # past the literal as tool-call territory rather than free content.
+    # If the skip stripped the literal, the tool parser wouldn't see the
+    # section start and "payload" would leak as raw content.
+    assert "payload" not in content, (
+        f"in-section payload leaked as content because the skip stripped "
+        f"the tool-section literal: {content!r}"
+    )
+    # Marker must still be visible to the tool parser, i.e. retained in
+    # the cumulative state. Without it the tool parser can't identify
+    # tool calls.
+    assert (
+        "<|tool_calls_section_begin|>"
+        in wrapped_kimi_parser._stream_state.previous_text
+    ), "tool-section marker not preserved for downstream tool parser"
+
+
+def test_delegating_parser_recovers_partial_end_token_in_boundary_chunk(
+    wrapped_kimi_parser, kimi_k2_tokenizer
+):
+    """The boundary chunk's delta_text can end mid-`</think>` (e.g. the
+    output_text_buffer flushed `"reasoning</th"` on the chunk where the
+    end-token id arrives). With the buffer initialized to `""` on arm,
+    the `</th` prefix is lost and the next chunk's `"ink>..."` never
+    matches `</think>` — the skip suppresses every subsequent chunk
+    forever and the response truncates at the boundary."""
+    request = ChatCompletionRequest(
+        model="test-model", messages=[], temperature=1.0, stream=True
+    )
+    start_id = wrapped_kimi_parser._reasoning_parser._start_token_id
+    end_id = wrapped_kimi_parser._reasoning_parser._end_token_id
+
+    def encode(s: str) -> int:
+        return kimi_k2_tokenizer.encode(s, add_special_tokens=False)[0]
+
+    # Boundary chunk carries `</th` (partial prefix of `</think>`) plus
+    # the end-token id. Subsequent chunks finish flushing `</think>` then
+    # emit content.
+    timeline = [
+        Chunk("<think>", [start_id]),
+        Chunk("reasoning", [encode("reasoning")]),
+        Chunk("</th", [end_id]),
+        Chunk("ink>", []),
+        Chunk(" answer", [encode("answer")]),
+    ]
+
+    _, content = _drive(wrapped_kimi_parser, timeline, request)
+
+    assert "answer" in content, (
+        f"post-boundary content suppressed when </think> spans the "
+        f"boundary chunk: {content!r}"
+    )
+    assert "</think>" not in content, (
+        f"partial end-token leaked into content: {content!r}"
+    )

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -743,8 +743,11 @@ class DelegatingParser(Parser):
                     state.end_token_skip_literal = literal
                     boundary_just_handed_off = True
 
-        # Strip the buffered end-token text from the start of phase B,
-        # otherwise the tool branch below leaks it as delta.content.
+        # Strip buffered end-token text so the tool branch doesn't leak
+        # it as delta.content. Reasoning text buffered alongside a
+        # partial literal (e.g. "thinking_tail</th") is recovered and
+        # merged into delta.reasoning after the tool branch runs.
+        recovered_reasoning_prefix = ""
         if state.end_token_skip_armed and not state.end_token_skip_done:
             end_str = state.end_token_skip_literal
             if not boundary_just_handed_off:
@@ -760,6 +763,9 @@ class DelegatingParser(Parser):
                     None,
                 )
                 literal_pos = state.end_token_skip_buffer.find(end_str)
+                # Pre-literal text is reasoning content; preserve it
+                # for the merge below.
+                recovered_reasoning_prefix = state.end_token_skip_buffer[:literal_pos]
                 content_start = literal_pos + (
                     0 if end_str == tool_section else len(end_str)
                 )
@@ -799,6 +805,14 @@ class DelegatingParser(Parser):
         # No parsers: pass through as content
         if self._reasoning_parser is None and self._tool_parser is None:
             delta_message = DeltaMessage(content=delta_text)
+
+        # Merge reasoning text recovered from the skip buffer (see above).
+        if recovered_reasoning_prefix:
+            if delta_message is None:
+                delta_message = DeltaMessage()
+            delta_message.reasoning = (
+                delta_message.reasoning or ""
+            ) + recovered_reasoning_prefix
 
         state.previous_text = current_text
         state.previous_token_ids = current_token_ids

--- a/vllm/parser/abstract_parser.py
+++ b/vllm/parser/abstract_parser.py
@@ -62,6 +62,15 @@ class StreamState:
     # only used for "required" and "named tool" choices,
     # tracks whether function name has been fully returned in the stream yet
     function_name_returned: bool = False
+    # Suppresses buffered end-token text that flushes during phase B; see
+    # DelegatingParser.parse_delta.
+    end_token_skip_buffer: str = ""
+    end_token_skip_armed: bool = False
+    end_token_skip_done: bool = False
+    # Literal that the post-boundary skip is waiting for (`</think>` for the
+    # explicit reasoning end, or e.g. `<|tool_calls_section_begin|>` when
+    # reasoning ended implicitly via the tool-section start token).
+    end_token_skip_literal: str = ""
 
 
 class Parser:
@@ -324,6 +333,43 @@ class Parser:
         """Parse a single streaming delta, orchestrating reasoning then
         tool call extraction via internal stream state.
         """
+
+
+def _pending_end_token_literal(
+    reasoning_parser: "ReasoningParser | None",
+    delta_text: str,
+    delta_token_ids: list[int],
+) -> str | None:
+    """Return the reasoning-end literal whose rendered text is still buffered.
+
+    Looks at both the explicit ``</think>`` end token and (for parsers that
+    expose it) the implicit tool-section start token. Returns the literal
+    whose id is in ``delta_token_ids`` but whose text has not yet flushed
+    into ``delta_text``, or ``None`` if the boundary text was fully visible.
+    """
+    if reasoning_parser is None:
+        return None
+    end_id = getattr(reasoning_parser, "_end_token_id", None)
+    end_str = reasoning_parser.reasoning_end_str
+    if (
+        end_id is not None
+        and end_id in delta_token_ids
+        and end_str
+        and end_str not in delta_text
+    ):
+        return end_str
+    # Kimi K2 also ends reasoning implicitly via the tool-section start token.
+    # Other parsers don't expose this attribute, so this branch is opt-in.
+    tool_section_id = getattr(reasoning_parser, "_tool_section_start_token_id", None)
+    tool_section_str = getattr(reasoning_parser, "_tool_section_start_token", None)
+    if (
+        tool_section_id is not None
+        and tool_section_id in delta_token_ids
+        and tool_section_str
+        and tool_section_str not in delta_text
+    ):
+        return tool_section_str
+    return None
 
 
 class DelegatingParser(Parser):
@@ -665,6 +711,7 @@ class DelegatingParser(Parser):
         delta_message: DeltaMessage | None = None
 
         # Reasoning extraction
+        boundary_just_handed_off = False
         if self._in_reasoning_phase(state):
             delta_message = self.extract_reasoning_streaming(
                 previous_text=state.previous_text,
@@ -683,6 +730,47 @@ class DelegatingParser(Parser):
                     delta_message.content = None
                 else:
                     current_text = ""
+                # Arm the skip if either terminator's text is still buffered.
+                # Seed the buffer with this chunk's delta_text so a partial
+                # prefix of the literal that already flushed (e.g. `</th` on
+                # the boundary chunk, `ink>` on the next) isn't lost.
+                literal = _pending_end_token_literal(
+                    self._reasoning_parser, delta_text, delta_token_ids
+                )
+                if literal is not None:
+                    state.end_token_skip_buffer = delta_text
+                    state.end_token_skip_armed = True
+                    state.end_token_skip_literal = literal
+                    boundary_just_handed_off = True
+
+        # Strip the buffered end-token text from the start of phase B,
+        # otherwise the tool branch below leaks it as delta.content.
+        if state.end_token_skip_armed and not state.end_token_skip_done:
+            end_str = state.end_token_skip_literal
+            if not boundary_just_handed_off:
+                state.end_token_skip_buffer += delta_text
+            if end_str and end_str in state.end_token_skip_buffer:
+                # The </think> literal is consumed (downstream content starts
+                # after it); the tool-section literal stays in content so
+                # downstream tool parsers can still find it (mirrors the
+                # immediate-text path in the reasoning parser).
+                tool_section = getattr(
+                    self._reasoning_parser,
+                    "_tool_section_start_token",
+                    None,
+                )
+                literal_pos = state.end_token_skip_buffer.find(end_str)
+                content_start = literal_pos + (
+                    0 if end_str == tool_section else len(end_str)
+                )
+                cleaned = state.end_token_skip_buffer[content_start:]
+                state.end_token_skip_buffer = ""
+                state.end_token_skip_done = True
+                delta_text = cleaned
+                current_text = cleaned
+            else:
+                # End-token text not yet visible; suppress the chunk.
+                return delta_message
 
         # Tool call extraction
         if self._in_tool_call_phase(state):


### PR DESCRIPTION
## Purpose

Follow-up to #41068 (now merged). #41068 fixes the parser-side off-by-one in `KimiK2ReasoningParser.extract_reasoning_streaming` when the `</think>` token id arrives in `delta_token_ids` ahead of its rendered text in `delta_text`. A second leak in the same code path survives downstream and is the subject of this PR.

After the parser returns `None` on the boundary chunk (per #41068's fix), `DelegatingParser.parse_delta` sets `state.reasoning_ended = True` and routes the next 1–N chunks through the tool branch — which has no awareness of the still-buffered end-token text and emits it verbatim as `delta.content`.

With `--reasoning-parser kimi_k2` and a non-empty `stop` list (which sets `output_text_buffer_length > 0`), per-delta capture from a real request shows:

```
delta[N]:   reasoning='T'        (last reasoning delta; parser returns None per #41068)
delta[N+1]: content=' '
delta[N+2]: content='</thin'     <- buffered </think> flushing
delta[N+3]: content='k> '
delta[N+4]: content='I will...'
```

End-users see `</think>` (or fragments of it) prefixed to the assistant's response. Resolves the leak class described in #41067.

## Approach

Add four `StreamState` fields plus a small post-boundary skip block in `DelegatingParser.parse_delta`:

- `end_token_skip_buffer` (str): rolling buffer of phase-B text since `reasoning_ended` flipped True.
- `end_token_skip_armed` (bool): True from the chunk after reasoning ends; reset once the literal is consumed.
- `end_token_skip_done` (bool): True after the literal has been seen and stripped; the skip becomes a no-op thereafter.
- `end_token_skip_literal` (str): the specific literal we're looking for (`</think>` or `<|tool_calls_section_begin|>`).

A helper `_pending_end_token_literal` checks both `</think>` and (for parsers that expose it) `<|tool_calls_section_begin|>`, returning whichever literal's token id is in `delta_token_ids` but whose text has not yet flushed. On boundary handoff the skip arms with that literal stored in state and the boundary chunk's `delta_text` seeded into the buffer (so a partial prefix of the literal that already flushed isn't lost).

While armed, subsequent chunks accumulate `delta_text` into the buffer. When the stored literal becomes visible, the buffer is split:

- For `</think>`, the literal is consumed (downstream content begins after it).
- For `<|tool_calls_section_begin|>`, the literal is **preserved** in the cleaned text — `KimiK2ToolParser` uses it to identify the section boundary, matching the immediate-text path in `KimiK2ReasoningParser.extract_reasoning_streaming` where `content = delta_text[tool_index:]` keeps the literal.

The tool-section branch is opt-in via `getattr` so it stays a no-op for parsers that don't expose those attributes (DeepSeek-R1, Step3p5, Ernie45, etc. still benefit from the `</think>` half).

## Test Plan

Five new tests in `tests/reasoning/test_kimi_k2_reasoning_parser.py`, each exercising a specific scenario end-to-end through `DelegatingParser.parse_delta`:

- `test_delegating_parser_strips_buffered_end_token` — primary scenario.
- `test_delegating_parser_skip_disarmed_when_parser_splits_in_one_chunk` — when `</think>` id and text arrive together, the skip stays disarmed; otherwise it would over-truncate post-boundary content.
- `test_delegating_parser_boundary_at_end_of_delta_text` — when `</think>` lands at the very end of `delta_text` with no content after, the skip stays disarmed (no buffered tail will appear).
- `test_delegating_parser_handles_buffered_tool_section_end` — when reasoning ends implicitly via `<|tool_calls_section_begin|>` under buffering, the skip waits for the section literal (not `</think>`), preserves it in cleaned text, and routes the in-section payload to the tool parser.
- `test_delegating_parser_recovers_partial_end_token_in_boundary_chunk` — boundary chunk's `delta_text` ends mid-literal (`</th` on chunk N, `ink>` on chunk N+1). Buffer must be seeded with the boundary chunk's `delta_text` so the partial prefix isn't lost.

\`\`\`bash
pytest tests/reasoning/test_kimi_k2_reasoning_parser.py -v
\`\`\`

## Test Result

15 tests pass (10 pre-existing + 5 new from this PR):

\`\`\`
============================== 15 passed in 6.07s ==============================
\`\`\`

Reverting \`vllm/parser/abstract_parser.py\` to upstream HEAD and rerunning the new tests:

\`\`\`
============================== 5 failed ==============================
\`\`\`

Each new test fails on either the literal leaking into \`content\` or the post-boundary content being suppressed.

**Production verification**: 8/8 leaks pre-fix → 0/25 leaks post-fix on a Kimi K2.5 deployment running v0.20.0 + #41068's parser change.

## AI use disclosure

Authored end-to-end by Claude under human direction; the submitter has reviewed every changed line and confirms the analysis, the diff, and the test results above.

Resolves part of #41067.