### PR TITLE
Fix assistant thinking block normalization

### DIFF
--- a/tests/entrypoints/test_chat_utils.py
+++ b/tests/entrypoints/test_chat_utils.py
@@ -16,6 +16,7 @@ from vllm.entrypoints.chat_utils import (
     parse_chat_messages,
     parse_chat_messages_async,
 )
+from vllm.exceptions import VLLMValidationError
 from vllm.inputs import MultiModalDataDict, MultiModalUUIDDict
 from vllm.multimodal.utils import (
     encode_audio_url,
@@ -2086,6 +2087,7 @@ def test_parse_chat_messages_multiple_images_interleave_with_placeholders(
         )
 
 
+@pytest.mark.skip_global_cleanup
 def test_parse_chat_messages_include_thinking_chunk(mistral_model_config):
     messages = [
         {
@@ -2138,13 +2140,34 @@ def test_parse_chat_messages_include_thinking_chunk(mistral_model_config):
             "role": "assistant",
             "content": [
                 {"type": "text", "text": "Let me think about it."},
-                {"type": "text", "text": "2+2 = 4"},
                 {"type": "text", "text": "The answer is 4."},
             ],
+            "reasoning": "2+2 = 4",
+            "reasoning_content": "2+2 = 4",
         },
     ]
 
     assert conversation_with_thinking == expected_conversation
+
+
+@pytest.mark.skip_global_cleanup
+def test_parse_chat_messages_rejects_duplicate_assistant_reasoning(
+    mistral_model_config,
+):
+    messages = [
+        {
+            "role": "assistant",
+            "content": [{"type": "thinking", "thinking": "from content"}],
+            "reasoning": "from reasoning",
+        }
+    ]
+
+    with pytest.raises(VLLMValidationError, match="both top-level `reasoning`"):
+        parse_chat_messages(
+            messages,
+            mistral_model_config,
+            content_format="string",
+        )
 
 
 def test_parse_chat_messages_single_empty_audio_with_uuid(

--- a/tests/tokenizers_/test_deepseek_v4.py
+++ b/tests/tokenizers_/test_deepseek_v4.py
@@ -183,6 +183,35 @@ def test_deepseek_v4_renders_parsed_history_tool_arguments():
     assert 'parameter name="arguments"' not in prompt
 
 
+@pytest.mark.skip_global_cleanup
+def test_deepseek_v4_renders_assistant_thinking_content_as_reasoning():
+    messages = [
+        {"role": "user", "content": "u"},
+        {
+            "role": "assistant",
+            "content": [{"type": "thinking", "thinking": "REASON"}],
+        },
+        {"role": "user", "content": "v"},
+    ]
+    conversation, _, _ = parse_chat_messages(
+        messages,
+        _model_config(),
+        content_format="string",
+    )
+
+    prompt = _tokenizer().apply_chat_template(
+        conversation=conversation,
+        messages=messages,
+        tokenize=False,
+        thinking=True,
+        drop_thinking=False,
+        reasoning_effort="high",
+    )
+
+    assert "<｜User｜>u<｜Assistant｜><think>REASON</think>" in prompt
+    assert "<think></think>REASON" not in prompt
+
+
 @pytest.mark.parametrize("reasoning_effort", ["minimal", "low", "medium", "high"])
 def test_deepseek_v4_accepts_openai_reasoning_effort_values(reasoning_effort):
     prompt = _tokenizer().apply_chat_template(

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1736,6 +1736,23 @@ def _parse_chat_message_content_part(
     return MODALITY_PLACEHOLDERS_MAP[modality] if interleave_strings else None
 
 
+def _extract_assistant_thinking_parts(
+    parts: list[ChatCompletionContentPartParam],
+) -> tuple[list[ChatCompletionContentPartParam], str | None]:
+    visible_parts: list[ChatCompletionContentPartParam] = []
+    reasoning_parts: list[str] = []
+
+    for part in parts:
+        if isinstance(part, dict) and part.get("type") == "thinking":
+            thinking = part.get("thinking")
+            if thinking is not None:
+                reasoning_parts.append(cast(str, thinking))
+            continue
+        visible_parts.append(part)
+
+    return visible_parts, "".join(reasoning_parts) or None
+
+
 # No need to validate using Pydantic again
 _AssistantParser = partial(cast, ChatCompletionAssistantMessageParam)
 _ToolParser = partial(cast, ChatCompletionToolMessageParam)
@@ -1756,6 +1773,20 @@ def _parse_chat_message_content(
         content = []
     elif isinstance(content, str):
         content = [ChatCompletionContentPartTextParam(type="text", text=content)]
+
+    if role == "assistant":
+        content, reasoning_from_content = _extract_assistant_thinking_parts(content)
+        if reasoning is not None and reasoning_from_content is not None:
+            raise VLLMValidationError(
+                "Assistant messages must not contain both top-level "
+                "`reasoning` and content parts of type `thinking`. Please "
+                "use only one representation for assistant reasoning.",
+                parameter="messages",
+                value=message,
+            )
+        if reasoning_from_content is not None:
+            reasoning = reasoning_from_content
+
     result = _parse_chat_message_content_parts(
         role,
         content,  # type: ignore


### PR DESCRIPTION
### Summary
- route assistant content parts of type `thinking` into the normalized `reasoning` / `reasoning_content` fields instead of visible `content`
- reject assistant messages that provide both top-level `reasoning` and typed `thinking` content blocks, since those are duplicate reasoning representations
- add CPU-friendly regression coverage for generic chat message normalization and DeepSeek V4 prompt rendering

This fixes a DeepSeek V4 history-rendering issue where prior assistant messages shaped like `{"content": [{"type": "thinking", "thinking": "..."}]}` rendered as `<think></think>...` instead of `<think>...</think>`.

### Tests
- `git diff --check`
- `CUDA_VISIBLE_DEVICES='' .venv/bin/python -m pytest tests/entrypoints/test_chat_utils.py::test_parse_chat_messages_include_thinking_chunk tests/entrypoints/test_chat_utils.py::test_parse_chat_messages_rejects_duplicate_assistant_reasoning tests/tokenizers_/test_deepseek_v4.py::test_deepseek_v4_renders_assistant_thinking_content_as_reasoning -q`
  - Note: after reverting the minimal test config per reviewer preference, the two `test_chat_utils.py` targets require the existing `mistral_model_config` fixture and may need optional vision deps in local environments.

### AI assistance
AI assistance was used to prepare this patch. The submitting human should review every changed line and CI result before merge.
