### PR TITLE
[BugFix] Wrap TokenizersBackend fallback with cached tokenizer

### DIFF
--- a/tests/tokenizers_/test_registry.py
+++ b/tests/tokenizers_/test_registry.py
@@ -3,7 +3,10 @@
 from pathlib import Path
 
 import pytest
+from transformers import PretrainedConfig
 
+import vllm.tokenizers.registry as registry
+from vllm.renderers.params import TokenizeParams
 from vllm.tokenizers import TokenizerLike
 from vllm.tokenizers.registry import (
     TokenizerRegistry,
@@ -75,3 +78,31 @@ def test_customized_tokenizer():
     assert tokenizer.bos_token_id == 0
     assert tokenizer.eos_token_id == 1
     assert tokenizer.pad_token_id == 2
+
+
+@pytest.mark.parametrize(
+    "model_type",
+    sorted(registry._MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS),
+)
+def test_get_tokenizer_incorrect_tokenizer_class_returns_cached_tokenizer(
+    monkeypatch,
+    model_type,
+):
+    # These model types are loaded through the TokenizersBackend fallback.
+    monkeypatch.setattr(
+        registry,
+        "get_config",
+        lambda *args, **kwargs: PretrainedConfig(model_type=model_type),
+    )
+
+    # Use gpt2 as a small tokenizer fixture; the monkeypatched config
+    # forces get_tokenizer through the incorrect-tokenizer-class fallback.
+    tokenizer = registry.get_tokenizer("gpt2")
+    params = TokenizeParams(max_total_tokens=10, max_output_tokens=1)
+
+    assert tokenizer.max_chars_per_token > 0
+    assert tokenizer.max_token_id >= len(tokenizer) - 1
+    assert isinstance(tokenizer.all_special_ids, list)
+    assert isinstance(tokenizer.all_special_tokens, list)
+    assert tokenizer.get_vocab()
+    assert params._text_len_check(tokenizer, "hello") == "hello"

--- a/vllm/tokenizers/hf.py
+++ b/vllm/tokenizers/hf.py
@@ -3,7 +3,7 @@
 import contextlib
 import copy
 from pathlib import Path
-from typing import TypeAlias
+from typing import Any, TypeAlias, cast
 
 from transformers import AutoTokenizer, PreTrainedTokenizer, PreTrainedTokenizerFast
 from transformers.tokenization_utils_tokenizers import TokenizersBackend
@@ -81,7 +81,7 @@ class CachedHfTokenizer(TokenizerLike):
         revision: str | None = None,
         download_dir: str | None = None,
         **kwargs,
-    ) -> HfTokenizer:
+    ) -> TokenizerLike:
         try:
             tokenizer = AutoTokenizer.from_pretrained(
                 path_or_repo_id,
@@ -118,12 +118,12 @@ class CachedHfTokenizer(TokenizerLike):
         if isinstance(encoder_config, dict) and encoder_config.get(
             "do_lower_case", False
         ):
-            special_tokens_map = {
+            special_tokens_map: dict[str, Any] = {
                 k: v.lower() for k, v in tokenizer.special_tokens_map.items()
             }
             tokenizer.add_special_tokens(special_tokens_map)
 
-        return get_cached_tokenizer(tokenizer)
+        return cast(TokenizerLike, get_cached_tokenizer(tokenizer))
 
 
 class CachedTokenizersBackend(TokenizerLike):
@@ -136,13 +136,16 @@ class CachedTokenizersBackend(TokenizerLike):
         revision: str | None = None,
         download_dir: str | None = None,
         **kwargs,
-    ) -> HfTokenizer:
+    ) -> TokenizerLike:
+        tokenizer_kwargs = kwargs.copy()
+        if revision is not None:
+            tokenizer_kwargs["revision"] = revision
+
         tokenizer = TokenizersBackend.from_pretrained(
             path_or_repo_id,
             *args,
             trust_remote_code=trust_remote_code,
-            revision=revision,
             cache_dir=download_dir,
-            **kwargs,
+            **tokenizer_kwargs,
         )
-        return get_cached_tokenizer(tokenizer)
+        return cast(TokenizerLike, get_cached_tokenizer(tokenizer))

--- a/vllm/tokenizers/hf.py
+++ b/vllm/tokenizers/hf.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TypeAlias
 
 from transformers import AutoTokenizer, PreTrainedTokenizer, PreTrainedTokenizerFast
+from transformers.tokenization_utils_tokenizers import TokenizersBackend
 
 from vllm.transformers_utils.config import get_sentence_transformer_tokenizer_config
 
@@ -122,4 +123,26 @@ class CachedHfTokenizer(TokenizerLike):
             }
             tokenizer.add_special_tokens(special_tokens_map)
 
+        return get_cached_tokenizer(tokenizer)
+
+
+class CachedTokenizersBackend(TokenizerLike):
+    @classmethod
+    def from_pretrained(
+        cls,
+        path_or_repo_id: str | Path,
+        *args,
+        trust_remote_code: bool = False,
+        revision: str | None = None,
+        download_dir: str | None = None,
+        **kwargs,
+    ) -> HfTokenizer:
+        tokenizer = TokenizersBackend.from_pretrained(
+            path_or_repo_id,
+            *args,
+            trust_remote_code=trust_remote_code,
+            revision=revision,
+            cache_dir=download_dir,
+            **kwargs,
+        )
         return get_cached_tokenizer(tokenizer)

--- a/vllm/tokenizers/registry.py
+++ b/vllm/tokenizers/registry.py
@@ -4,7 +4,7 @@ import contextlib
 from dataclasses import dataclass, field
 from functools import lru_cache
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import huggingface_hub
 from typing_extensions import TypeVar, assert_never
@@ -231,7 +231,7 @@ def get_tokenizer(
     # Some models have an incorrect tokenizer_class on the hub.
     # For these model types, bypass AutoTokenizer and use TokenizersBackend directly.
     model_type = getattr(config, "model_type", None) if config else None
-    tokenizer_cls_: type[TokenizerLike]
+    tokenizer_cls_: type[Any]
     if model_type in _MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS:
         from .hf import CachedTokenizersBackend
 

--- a/vllm/tokenizers/registry.py
+++ b/vllm/tokenizers/registry.py
@@ -33,10 +33,13 @@ if TYPE_CHECKING:
 logger = init_logger(__name__)
 
 
-# Model types whose hub tokenizer_class is incorrect and should be overridden with
-# TokenizersBackend (the generic fast tokenizer). Adding a model type here is always a
-# temporary workaround and better long term solutions are:
-# - Add model type to MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS in transformers (better)
+# Model types whose hub tokenizer_class is incorrect and should be loaded
+# through TokenizersBackend (the generic fast tokenizer). vLLM wraps that
+# backend with get_cached_tokenizer so the result still satisfies TokenizerLike.
+# Adding a model type here is always a temporary workaround and better long term
+# solutions are:
+# - Add model type to MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS in transformers
+#   (better)
 # - Fix tokenizer_class on the hub for the affected models (best)
 _MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS: set[str] = {"step3_vl"}
 
@@ -228,14 +231,15 @@ def get_tokenizer(
     # Some models have an incorrect tokenizer_class on the hub.
     # For these model types, bypass AutoTokenizer and use TokenizersBackend directly.
     model_type = getattr(config, "model_type", None) if config else None
+    tokenizer_cls_: type[TokenizerLike]
     if model_type in _MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS:
-        from transformers.tokenization_utils_tokenizers import TokenizersBackend
+        from .hf import CachedTokenizersBackend
 
         logger.debug(
             "Overriding tokenizer_class to TokenizersBackend for model_type=%r",
             model_type,
         )
-        tokenizer_cls_ = TokenizersBackend
+        tokenizer_cls_ = CachedTokenizersBackend
     elif tokenizer_cls == TokenizerLike:
         tokenizer_cls_ = TokenizerRegistry.load_tokenizer_cls(tokenizer_mode)
     else:


### PR DESCRIPTION
## Purpose

Fix https://github.com/vllm-project/vllm/issues/41719.

Fix the incorrect-tokenizer-class fallback so it does not return a bare `TokenizersBackend` missing vLLM tokenizer properties such as `max_chars_per_token`.

The fallback now uses a cached `TokenizersBackend` loader, matching the normal HF tokenizer path.

## Test Plan

```python
from transformers import PretrainedConfig
import vllm.tokenizers.registry as registry
from vllm.renderers.params import TokenizeParams

registry.get_config = lambda *args, **kwargs: PretrainedConfig(model_type="step3_vl")

tok = registry.get_tokenizer("gpt2")
params = TokenizeParams(max_total_tokens=10, max_output_tokens=1)
print(type(tok))
print(tok.max_chars_per_token)
print(params._text_len_check(tok, "hello"))
```

## Test Result

<img width="915" height="326" alt="image" src="https://github.com/user-attachments/assets/51fbd28f-b47b-4ca5-b342-62eb8fd5e0ae" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

