### PR TITLE
[Bugfix] Respect ignore_eos for GPT-OSS Harmony stop tokens

### DIFF
--- a/tests/entrypoints/openai/parser/test_harmony_utils.py
+++ b/tests/entrypoints/openai/parser/test_harmony_utils.py
@@ -6,7 +6,10 @@ from openai.types.responses import FunctionTool
 from openai_harmony import DeveloperContent, Message, Role
 
 from tests.entrypoints.openai.utils import verify_harmony_messages
-from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionToolsParam
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+    ChatCompletionToolsParam,
+)
 from vllm.entrypoints.openai.parser import harmony_utils
 from vllm.entrypoints.openai.parser.harmony_utils import (
     auto_drop_analysis_messages,
@@ -24,6 +27,7 @@ from vllm.entrypoints.openai.responses.harmony import (
     response_input_to_harmony,
     response_previous_input_to_harmony,
 )
+from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 
 _TOOL_PARAMETERS = {
     "type": "object",
@@ -292,6 +296,44 @@ def test_harmony_default_stop_tokens_added_when_eos_is_active(monkeypatch):
     assert request_defaults is not default_sampling_params
     assert request_defaults["stop_token_ids"] == [123, 200002, 200012]
     assert default_sampling_params["stop_token_ids"] == [123, 200002]
+
+
+def test_chat_completion_uses_harmony_default_stop_tokens(monkeypatch):
+    def get_stop_tokens():
+        return [200002, 200012]
+
+    monkeypatch.setattr(
+        harmony_utils, "get_stop_tokens_for_assistant_actions", get_stop_tokens
+    )
+    request_defaults = get_harmony_request_default_sampling_params(
+        {"temperature": 0.0}, ignore_eos=False
+    )
+    request = ChatCompletionRequest(messages=[], model="test")
+
+    sampling_params = request.to_sampling_params(
+        max_tokens=16, default_sampling_params=request_defaults
+    )
+
+    assert sampling_params.stop_token_ids == [200002, 200012]
+
+
+def test_responses_uses_harmony_default_stop_tokens(monkeypatch):
+    def get_stop_tokens():
+        return [200002, 200012]
+
+    monkeypatch.setattr(
+        harmony_utils, "get_stop_tokens_for_assistant_actions", get_stop_tokens
+    )
+    request_defaults = get_harmony_request_default_sampling_params(
+        {"temperature": 0.0}, ignore_eos=False
+    )
+    request = ResponsesRequest(input="hello", model="test")
+
+    sampling_params = request.to_sampling_params(
+        default_max_tokens=16, default_sampling_params=request_defaults
+    )
+
+    assert sampling_params.stop_token_ids == [200002, 200012]
 
 
 class TestCommonParseInputToHarmonyMessage:

--- a/tests/entrypoints/openai/parser/test_harmony_utils.py
+++ b/tests/entrypoints/openai/parser/test_harmony_utils.py
@@ -7,11 +7,13 @@ from openai_harmony import DeveloperContent, Message, Role
 
 from tests.entrypoints.openai.utils import verify_harmony_messages
 from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionToolsParam
+from vllm.entrypoints.openai.parser import harmony_utils
 from vllm.entrypoints.openai.parser.harmony_utils import (
     auto_drop_analysis_messages,
     create_tool_definition,
     extract_function_from_recipient,
     get_encoding,
+    get_harmony_request_default_sampling_params,
     get_system_message,
     has_custom_tools,
     is_function_recipient,
@@ -250,6 +252,46 @@ class TestExtractFunctionFromRecipient:
     )
     def test_dotted_function_name_extraction(self, recipient, expected):
         assert extract_function_from_recipient(recipient) == expected
+
+
+def test_harmony_default_stop_tokens_respect_ignore_eos(monkeypatch):
+    def get_stop_tokens():
+        return [200002, 200012]
+
+    monkeypatch.setattr(
+        harmony_utils, "get_stop_tokens_for_assistant_actions", get_stop_tokens
+    )
+    default_sampling_params = {"temperature": 0.0, "stop_token_ids": [123]}
+
+    request_defaults = get_harmony_request_default_sampling_params(
+        default_sampling_params, ignore_eos=True
+    )
+
+    # Harmony action tokens are EOS-like. If EOS is ignored, adding them as
+    # request stop tokens would make ignore_eos ineffective for GPT-OSS.
+    assert request_defaults is default_sampling_params
+    assert request_defaults["stop_token_ids"] == [123]
+
+
+def test_harmony_default_stop_tokens_added_when_eos_is_active(monkeypatch):
+    def get_stop_tokens():
+        return [200002, 200012]
+
+    monkeypatch.setattr(
+        harmony_utils, "get_stop_tokens_for_assistant_actions", get_stop_tokens
+    )
+    default_sampling_params = {"temperature": 0.0, "stop_token_ids": [123, 200002]}
+
+    request_defaults = get_harmony_request_default_sampling_params(
+        default_sampling_params, ignore_eos=False
+    )
+
+    # Normal GPT-OSS requests should still stop on Harmony assistant actions.
+    # The helper returns request-local defaults so shared server defaults are
+    # not mutated across requests with different ignore_eos values.
+    assert request_defaults is not default_sampling_params
+    assert request_defaults["stop_token_ids"] == [123, 200002, 200012]
+    assert default_sampling_params["stop_token_ids"] == [123, 200002]
 
 
 class TestCommonParseInputToHarmonyMessage:

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -614,6 +614,8 @@ class ChatCompletionRequest(OpenAIBaseModel):
         if self.kv_transfer_params:
             # Pass in kv_transfer_params via extra_args
             extra_args["kv_transfer_params"] = self.kv_transfer_params
+        stop_token_ids = list(default_sampling_params.get("stop_token_ids") or ())
+        stop_token_ids.extend(self.stop_token_ids or ())
         return SamplingParams.from_optional(
             n=self.n,
             presence_penalty=self.presence_penalty,
@@ -625,7 +627,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             min_p=min_p,
             seed=self.seed,
             stop=self.stop,
-            stop_token_ids=self.stop_token_ids,
+            stop_token_ids=list(dict.fromkeys(stop_token_ids)),
             logprobs=self.top_logprobs if self.logprobs else None,
             prompt_logprobs=prompt_logprobs,
             ignore_eos=self.ignore_eos,

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -53,6 +53,7 @@ from vllm.entrypoints.openai.engine.serving import (
 )
 from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.openai.parser.harmony_utils import (
+    get_harmony_request_default_sampling_params,
     get_streamable_parser_for_assistant,
     parse_chat_output,
 )
@@ -156,6 +157,7 @@ class OpenAIServingChat(OpenAIServing):
             else getattr(mc, "override_generation_config", {}).get("max_new_tokens")
         )
         self.use_harmony = self.model_config.hf_config.model_type == "gpt_oss"
+
         self.tool_call_id_type = get_tool_call_id_type(self.model_config)
 
         # NOTE(woosuk): While OpenAI's chat completion API supports browsing
@@ -279,6 +281,11 @@ class OpenAIServingChat(OpenAIServing):
             sub_request_id = (
                 request_id if len(engine_inputs) == 1 else f"{request_id}_{i}"
             )
+            default_sampling_params = self.default_sampling_params
+            if self.use_harmony:
+                default_sampling_params = get_harmony_request_default_sampling_params(
+                    self.default_sampling_params, request.ignore_eos
+                )
 
             max_tokens = get_max_tokens(
                 max_model_len,
@@ -286,7 +293,7 @@ class OpenAIServingChat(OpenAIServing):
                 if request.max_completion_tokens is not None
                 else request.max_tokens,
                 self._extract_prompt_len(engine_input),
-                self.default_sampling_params,
+                default_sampling_params,
                 self.override_max_tokens,
                 truncate_prompt_tokens=request.truncate_prompt_tokens,
             )
@@ -294,12 +301,12 @@ class OpenAIServingChat(OpenAIServing):
             sampling_params: SamplingParams | BeamSearchParams
             if request.use_beam_search:
                 sampling_params = request.to_beam_search_params(
-                    max_tokens, self.default_sampling_params
+                    max_tokens, default_sampling_params
                 )
             else:
                 sampling_params = request.to_sampling_params(
                     max_tokens,
-                    self.default_sampling_params,
+                    default_sampling_params,
                 )
 
             self._log_inputs(

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -273,6 +273,11 @@ class OpenAIServingChat(OpenAIServing):
         # Schedule the request and get the result generator.
         max_model_len = self.model_config.max_model_len
         generators: list[AsyncGenerator[RequestOutput, None]] = []
+        default_sampling_params = self.default_sampling_params
+        if self.use_harmony:
+            default_sampling_params = get_harmony_request_default_sampling_params(
+                self.default_sampling_params, request.ignore_eos
+            )
         for i, engine_input in enumerate(engine_inputs):
             prompt_token_ids = self._extract_prompt_components(engine_input).token_ids
 
@@ -281,11 +286,6 @@ class OpenAIServingChat(OpenAIServing):
             sub_request_id = (
                 request_id if len(engine_inputs) == 1 else f"{request_id}_{i}"
             )
-            default_sampling_params = self.default_sampling_params
-            if self.use_harmony:
-                default_sampling_params = get_harmony_request_default_sampling_params(
-                    self.default_sampling_params, request.ignore_eos
-                )
 
             max_tokens = get_max_tokens(
                 max_model_len,

--- a/vllm/entrypoints/openai/parser/harmony_utils.py
+++ b/vllm/entrypoints/openai/parser/harmony_utils.py
@@ -454,6 +454,30 @@ def render_for_completion(messages: list[Message]) -> list[int]:
     return token_ids
 
 
+def get_stop_tokens_for_assistant_actions() -> list[int]:
+    return get_encoding().stop_tokens_for_assistant_actions()
+
+
+def get_harmony_request_default_sampling_params(
+    default_sampling_params: dict[str, Any],
+    ignore_eos: bool,
+) -> dict[str, Any]:
+    """Add Harmony EOS-like stop tokens only when EOS stopping is enabled."""
+    if ignore_eos:
+        return default_sampling_params
+
+    request_default_sampling_params = dict(default_sampling_params)
+    stop_token_ids = list(request_default_sampling_params.get("stop_token_ids") or ())
+    # Harmony assistant action tokens are alternate EOS tokens for GPT-OSS.
+    # They should follow the same rule as generation-config EOS IDs: ignore_eos
+    # means these EOS-like tokens do not stop generation.
+    stop_token_ids.extend(get_stop_tokens_for_assistant_actions())
+    request_default_sampling_params["stop_token_ids"] = list(
+        dict.fromkeys(stop_token_ids)
+    )
+    return request_default_sampling_params
+
+
 def get_streamable_parser_for_assistant() -> StreamableParser:
     return StreamableParser(get_encoding(), role=Role.ASSISTANT)
 

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -401,6 +401,7 @@ class ResponsesRequest(OpenAIBaseModel):
         if self.kv_transfer_params:
             extra_args["kv_transfer_params"] = self.kv_transfer_params
 
+        stop_token_ids = list(default_sampling_params.get("stop_token_ids") or ())
         return SamplingParams.from_optional(
             temperature=temperature,
             top_p=top_p,
@@ -408,6 +409,7 @@ class ResponsesRequest(OpenAIBaseModel):
             max_tokens=max_tokens,
             logprobs=self.top_logprobs if self.is_include_output_logprobs() else None,
             stop=stop,
+            stop_token_ids=stop_token_ids,
             frequency_penalty=frequency_penalty,
             presence_penalty=presence_penalty,
             repetition_penalty=repetition_penalty,

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -417,16 +417,15 @@ class OpenAIServingResponses(OpenAIServing):
             available_tools = []
         tokenizer = self.renderer.get_tokenizer()
 
+        default_sampling_params = self.default_sampling_params
+        if self.use_harmony:
+            default_sampling_params = get_harmony_request_default_sampling_params(
+                self.default_sampling_params, request.ignore_eos
+            )
         for engine_input in engine_inputs:
             maybe_error = self._validate_generator_input(engine_input)
             if maybe_error is not None:
                 return maybe_error
-
-            default_sampling_params = self.default_sampling_params
-            if self.use_harmony:
-                default_sampling_params = get_harmony_request_default_sampling_params(
-                    self.default_sampling_params, request.ignore_eos
-                )
 
             default_max_tokens = get_max_tokens(
                 max_model_len,

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -46,6 +46,7 @@ from vllm.entrypoints.openai.models.serving import OpenAIServingModels
 from vllm.entrypoints.openai.parser.harmony_utils import (
     build_harmony_preamble,
     extract_instructions_from_messages,
+    get_harmony_request_default_sampling_params,
     get_user_message,
     has_custom_tools,
     render_for_completion,
@@ -421,11 +422,17 @@ class OpenAIServingResponses(OpenAIServing):
             if maybe_error is not None:
                 return maybe_error
 
+            default_sampling_params = self.default_sampling_params
+            if self.use_harmony:
+                default_sampling_params = get_harmony_request_default_sampling_params(
+                    self.default_sampling_params, request.ignore_eos
+                )
+
             default_max_tokens = get_max_tokens(
                 max_model_len,
                 request.max_output_tokens,
                 self._extract_prompt_len(engine_input),
-                self.default_sampling_params,
+                default_sampling_params,
                 self.override_max_tokens,
                 truncate_prompt_tokens=(
                     -1 if request.truncation != "disabled" else None
@@ -433,7 +440,7 @@ class OpenAIServingResponses(OpenAIServing):
             )
 
             sampling_params = request.to_sampling_params(
-                default_max_tokens, self.default_sampling_params
+                default_max_tokens, default_sampling_params
             )
 
             trace_headers = (


### PR DESCRIPTION



## Purpose

GPT-OSS adds Harmony assistant action tokens (`<|return|>` and `<|call|>`) as EOS-like stop tokens for Chat Completions and Responses. Those tokens were previously inserted into shared `default_sampling_params`, so requests with `ignore_eos=True` could still stop early on the Harmony stop IDs.

This PR moves Harmony stop-token injection to per-request default sampling params and skips those EOS-like stop IDs when `ignore_eos=True`. Normal GPT-OSS requests still stop on Harmony assistant actions, and explicit user-provided `stop_token_ids` keep their existing behavior.

`ignore_eos=True` is used by benchmark and generation workflows that need to continue until `max_tokens`. vLLM already treats generation-config EOS IDs this way: EOS-like defaults should not become active stop tokens when EOS is ignored. Harmony assistant action tokens are the GPT-OSS equivalent of alternate EOS tokens, so they should follow the same rule.

## Test Plan

- Add unit coverage for GPT-OSS Harmony default stop-token handling when `ignore_eos=True`.
- Add unit coverage that Harmony assistant action stop tokens are still added for normal requests.
- Run the focused Harmony parser utility tests.

## Test Result

```
python -m pytest \
  tests/entrypoints/openai/parser/test_harmony_utils.py::test_harmony_default_stop_tokens_respect_ignore_eos \
  tests/entrypoints/openai/parser/test_harmony_utils.py::test_harmony_default_stop_tokens_added_when_eos_is_active \
  -q

(...)

2 passed
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

