### PR TITLE
[Core][Multimodal] Test + doc direct multimodal engine inputs

### DIFF
--- a/docs/features/multimodal_inputs.md
+++ b/docs/features/multimodal_inputs.md
@@ -482,6 +482,99 @@ You can pass pre-computed audio embeddings similar to image embeddings:
         print(generated_text)
     ```
 
+### Preprocessed Multimodal Inputs (Direct Engine Contract)
+
+For RL frameworks and other clients that already run the HuggingFace processor outside vLLM,
+you can pass a fully-rendered `MultiModalInput` directly to the engine via the `mm_input`
+factory (`from vllm.inputs import mm_input`). This bypasses vLLM's own MM processor entirely —
+useful when you need exact tensor reuse across train and rollout, or want to avoid
+retokenization drift in token-in-token-out workflows.
+
+!!! warning
+    This is an advanced API. The caller owns the model-specific contract: `prompt_token_ids`
+    must already include the placeholder positions, `mm_kwargs` must match what the model
+    expects, and `mm_hashes` must be stable strings (non-string hashes are rejected).
+    Mismatches surface as silent prompt corruption, not loud errors.
+
+??? code
+
+    ```python
+    import asyncio
+    import torch
+    from vllm import SamplingParams
+    from vllm.engine.arg_utils import AsyncEngineArgs
+    from vllm.inputs import mm_input
+    from vllm.multimodal.inputs import (
+        MultiModalFieldConfig,
+        MultiModalKwargsItems,
+        PlaceholderRange,
+    )
+    from vllm.v1.engine.async_llm import AsyncLLM
+
+    engine = AsyncLLM.from_engine_args(
+        AsyncEngineArgs(model="Qwen/Qwen2.5-VL-3B-Instruct")
+    )
+
+    # 1) Run the HF processor (or your own preprocessing) outside vLLM to obtain
+    #    prompt_token_ids (with placeholder tokens already inserted) and the modality
+    #    tensors that vLLM's model would otherwise compute internally.
+    inputs = ...  # dict[str, torch.Tensor] from HF processor: pixel_values, image_grid_thw, ...
+    prompt_token_ids = ...  # list[int]
+
+    # 2) Wrap the HF outputs in MultiModalKwargsItems with a per-field config.
+    mm_kwargs = MultiModalKwargsItems.from_hf_inputs(
+        inputs,
+        {
+            "pixel_values": MultiModalFieldConfig.flat_from_sizes(
+                "image", inputs["image_grid_thw"].prod(-1)
+            ),
+            "image_grid_thw": MultiModalFieldConfig.batched("image", keep_on_cpu=True),
+        },
+    )
+
+    # 3) Build the MultiModalInput payload. Placeholder offsets/lengths must match the
+    #    placeholder token runs the model expects in prompt_token_ids; is_embed marks the
+    #    positions that consume vision-encoder embeddings (vs. surrounding text tokens).
+    payload = mm_input(
+        prompt_token_ids=prompt_token_ids,
+        mm_kwargs=mm_kwargs,
+        mm_hashes={"image": ["sha256-or-uuid-1"]},  # stable string per item
+        mm_placeholders={
+            "image": [PlaceholderRange(offset=10, length=64)],
+        },
+        cache_salt="optional-prefix-cache-key",
+    )
+
+    # 4) AsyncLLM.generate accepts the payload directly. `vllm.LLM` (sync) does not yet
+    #    expose MultiModalInput in its PromptType union, so use AsyncLLM today.
+    async def run():
+        async for out in engine.generate(
+            prompt=payload,
+            sampling_params=SamplingParams(temperature=0.0, max_tokens=64, seed=0),
+            request_id="req-1",
+        ):
+            if out.finished:
+                return out
+    outputs = asyncio.run(run())
+    ```
+
+For a production reference, see verl's `build_vllm_preprocessed_multimodal_input` in
+[verl-project/verl#6203][verl-pr] — it constructs Qwen2.5-VL image / video and Qwen3-VL
+timestamp-aware video payloads against this contract.
+
+[verl-pr]: https://github.com/verl-project/verl/pull/6203
+
+!!! note "Online Serving status"
+    The direct `MultiModalInput` contract is currently exposed **only through the Python
+    SDK** (`vllm.LLM` / `vllm.v1.engine.async_llm.AsyncLLM`). The OpenAI-compatible HTTP
+    endpoints (`/v1/chat/completions`, `/v1/completions`) do not yet provide a way to pass
+    a fully-rendered preprocessed payload — server-side requests still go through vLLM's
+    MM processor. For the OpenAI-compatible side, only pre-computed embeddings have a
+    bypass today (see the **Image Embedding Inputs** subsection under Online Serving below,
+    which uses `tensor2base64`-encoded `image_embeds` and requires `enable_mm_embeds=True`).
+    A general OpenAI-compatible bypass for raw pixel/tensor payloads is tracked in
+    [vllm-project/vllm#33311](https://github.com/vllm-project/vllm/issues/33311).
+
 ### Cached Inputs
 
 When using multi-modal inputs, vLLM normally hashes each media item by content to enable caching across requests. You can optionally pass `multi_modal_uuids` to provide your own stable IDs for each item so caching can reuse work across requests without rehashing the raw content.

--- a/docs/features/multimodal_inputs.md
+++ b/docs/features/multimodal_inputs.md
@@ -564,16 +564,34 @@ timestamp-aware video payloads against this contract.
 
 [verl-pr]: https://github.com/verl-project/verl/pull/6203
 
-!!! note "Online Serving status"
-    The direct `MultiModalInput` contract is currently exposed **only through the Python
-    SDK** (`vllm.LLM` / `vllm.v1.engine.async_llm.AsyncLLM`). The OpenAI-compatible HTTP
-    endpoints (`/v1/chat/completions`, `/v1/completions`) do not yet provide a way to pass
-    a fully-rendered preprocessed payload — server-side requests still go through vLLM's
-    MM processor. For the OpenAI-compatible side, only pre-computed embeddings have a
-    bypass today (see the **Image Embedding Inputs** subsection under Online Serving below,
-    which uses `tensor2base64`-encoded `image_embeds` and requires `enable_mm_embeds=True`).
-    A general OpenAI-compatible bypass for raw pixel/tensor payloads is tracked in
+!!! note "Online Serving (HTTP) equivalent"
+    The same direct contract is exposed over HTTP through vLLM's **disaggregated serving**
+    endpoint pair (rather than `/v1/chat/completions`):
+
+    - `POST /v1/chat/completions/render` — runs the chat template + HF processor and returns
+      `{token_ids, features: {mm_hashes, mm_placeholders, kwargs_data}, ...}`. `kwargs_data`
+      is base64-encoded `MultiModalKwargsItem` per modality item, so the response is an
+      already-rendered preprocessed payload.
+    - `POST /inference/v1/generate` — accepts that payload directly (the `GenerateRequest`
+      schema in [`vllm/entrypoints/serve/disagg/protocol.py`](https://github.com/vllm-project/vllm/blob/main/vllm/entrypoints/serve/disagg/protocol.py))
+      and runs token-in-token-out generation, bypassing the MM processor.
+
+    A worked example is in
+    [`examples/online_serving/disaggregated_serving/example_mm_serve.py`](https://github.com/vllm-project/vllm/blob/main/examples/online_serving/disaggregated_serving/example_mm_serve.py).
+    Callers that preprocessed outside vLLM (e.g. RL frameworks reusing HF processor outputs
+    from training) can also post directly to `/inference/v1/generate` without going through
+    `/render`.
+
+    Caveat: `PlaceholderRangeInfo` in the disagg protocol does not yet carry `is_embed`
+    (see the TODO at `protocol.py:27-29`), so Qwen3-VL sparse video placeholder masks
+    cannot be transported over the HTTP side end-to-end yet — for that case the SDK path
+    above is the only complete option. General `is_embed` support and a wider OpenAI-
+    standard-endpoint bypass are tracked in
     [vllm-project/vllm#33311](https://github.com/vllm-project/vllm/issues/33311).
+
+    Pre-computed embeddings (the narrower `image_embeds`-via-`tensor2base64` path) over the
+    standard `/v1/chat/completions` endpoint is a separate older feature, documented in the
+    **Image Embedding Inputs** subsection further below.
 
 ### Cached Inputs
 

--- a/tests/v1/engine/test_direct_multimodal_input.py
+++ b/tests/v1/engine/test_direct_multimodal_input.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+
+import vllm.platforms as vllm_platforms
+from vllm.platforms.interface import UnspecifiedPlatform
+
+
+@pytest.fixture()
+def direct_input_contract(monkeypatch: pytest.MonkeyPatch):
+    original_platform = vllm_platforms._current_platform
+    test_platform = UnspecifiedPlatform()
+    vllm_platforms._current_platform = test_platform
+
+    try:
+        from vllm.inputs import mm_input
+        from vllm.multimodal.inputs import (
+            MultiModalFieldElem,
+            MultiModalKwargsItem,
+            MultiModalKwargsItems,
+            MultiModalSharedField,
+            PlaceholderRange,
+        )
+        from vllm.sampling_params import SamplingParams
+        from vllm.v1.engine import input_processor as input_processor_module
+        from vllm.v1.engine.input_processor import InputProcessor
+
+        monkeypatch.setattr(input_processor_module, "current_platform", test_platform)
+        monkeypatch.setattr(
+            test_platform, "validate_request", lambda *args, **kwargs: None
+        )
+
+        yield SimpleNamespace(
+            InputProcessor=InputProcessor,
+            MultiModalFieldElem=MultiModalFieldElem,
+            MultiModalKwargsItem=MultiModalKwargsItem,
+            MultiModalKwargsItems=MultiModalKwargsItems,
+            MultiModalSharedField=MultiModalSharedField,
+            PlaceholderRange=PlaceholderRange,
+            SamplingParams=SamplingParams,
+            mm_input=mm_input,
+        )
+    finally:
+        vllm_platforms._current_platform = original_platform
+
+
+class _Renderer:
+    tokenizer = None
+
+    @staticmethod
+    def get_eos_token_id():
+        return None
+
+
+class _FailingPreprocessor:
+    def preprocess(self, *args, **kwargs):
+        raise AssertionError("Direct EngineInput must not be preprocessed")
+
+
+def _build_input_processor(input_processor_cls: type[Any]):
+    processor = input_processor_cls.__new__(input_processor_cls)
+    processor.vllm_config = SimpleNamespace(
+        parallel_config=SimpleNamespace(
+            data_parallel_size=1,
+            data_parallel_size_local=1,
+            local_engines_only=False,
+        ),
+    )
+    processor.model_config = SimpleNamespace(
+        max_model_len=128,
+        runner_type="generate",
+    )
+    processor.lora_config = None
+    processor.generation_config_fields = {}
+    processor.renderer = _Renderer()
+    processor.supports_mm_inputs = True
+    processor.mm_encoder_cache_size = 16
+    processor.skip_prompt_length_check = False
+    processor.input_preprocessor = _FailingPreprocessor()
+    processor._validate_params = lambda *args, **kwargs: None
+    processor._validate_lora = lambda *args, **kwargs: None
+    return processor
+
+
+def _mm_item(mm: Any, name: str, value: torch.Tensor):
+    return mm.MultiModalKwargsItem(
+        {
+            name: mm.MultiModalFieldElem(
+                data=value,
+                field=mm.MultiModalSharedField(batch_size=1),
+            )
+        }
+    )
+
+
+def test_direct_multimodal_input_builds_mm_features(direct_input_contract: Any):
+    mm = direct_input_contract
+    processor = _build_input_processor(mm.InputProcessor)
+    image_item = _mm_item(mm, "pixel_values", torch.arange(4))
+    video_item = _mm_item(mm, "pixel_values_videos", torch.arange(8))
+    is_embed = torch.tensor([True, False, True])
+    image_position = mm.PlaceholderRange(offset=4, length=3, is_embed=is_embed)
+    video_position = mm.PlaceholderRange(offset=1, length=2)
+
+    engine_input = mm.mm_input(
+        prompt_token_ids=[10, 11, 12, 13, 14, 15, 16],
+        mm_kwargs=mm.MultiModalKwargsItems(
+            {
+                "image": [image_item],
+                "video": [video_item],
+            }
+        ),
+        mm_hashes={
+            "image": ["image-hash"],
+            "video": ["video-hash"],
+        },
+        mm_placeholders={
+            "image": [image_position],
+            "video": [video_position],
+        },
+        cache_salt="salt",
+    )
+
+    request = processor.process_inputs(
+        request_id="request-id",
+        prompt=engine_input,
+        params=mm.SamplingParams(max_tokens=1),
+        supported_tasks=("generate",),
+        arrival_time=123.0,
+    )
+
+    assert request.prompt_token_ids == engine_input["prompt_token_ids"]
+    assert request.prompt_embeds is None
+    assert request.cache_salt == "salt"
+    assert request.arrival_time == 123.0
+    assert request.mm_features is not None
+
+    # Features are flattened and sorted by their placeholder position.
+    assert [feature.modality for feature in request.mm_features] == ["video", "image"]
+    video_feature, image_feature = request.mm_features
+
+    assert video_feature.data is video_item
+    assert video_feature.identifier == "video-hash"
+    assert video_feature.mm_hash == "video-hash"
+    assert video_feature.mm_position == video_position
+
+    assert image_feature.data is image_item
+    assert image_feature.identifier == "image-hash"
+    assert image_feature.mm_hash == "image-hash"
+    assert image_feature.mm_position.offset == image_position.offset
+    assert image_feature.mm_position.length == image_position.length
+    assert image_feature.mm_position.is_embed is not None
+    torch.testing.assert_close(image_feature.mm_position.is_embed, is_embed)
+
+
+def test_direct_multimodal_input_rejects_non_string_hashes(direct_input_contract: Any):
+    mm = direct_input_contract
+    processor = _build_input_processor(mm.InputProcessor)
+    engine_input = mm.mm_input(
+        prompt_token_ids=[10, 11, 12],
+        mm_kwargs=mm.MultiModalKwargsItems(
+            {"image": [_mm_item(mm, "pixel_values", torch.arange(4))]}
+        ),
+        mm_hashes={"image": [123]},  # type: ignore[list-item]
+        mm_placeholders={"image": [mm.PlaceholderRange(offset=1, length=1)]},
+    )
+
+    with pytest.raises(ValueError, match="mm_hashes must contain only strings"):
+        processor.process_inputs(
+            request_id="request-id",
+            prompt=engine_input,
+            params=mm.SamplingParams(max_tokens=1),
+            supported_tasks=("generate",),
+        )


### PR DESCRIPTION
## Summary

Adds a focused unit test + documentation for vLLM's direct `MultiModalInput` engine contract — the path that lets external callers (RL frameworks, custom servers) bypass the in-engine MM processor when they have already preprocessed their multimodal tensors with the HuggingFace processor.

The test in `tests/v1/engine/test_direct_multimodal_input.py`:

- verifies a direct `mm_input(...)` payload is consumed without invoking the prompt/MM preprocessor (a `_FailingPreprocessor` in the fixture asserts it never runs)
- verifies `mm_kwargs` / `mm_hashes` / `mm_placeholders` are flattened into `request.mm_features` in placeholder-offset order
- verifies `PlaceholderRange.is_embed` survives end-to-end through `InputProcessor`
- verifies non-string `mm_hashes` are rejected (`ValueError("mm_hashes must contain only strings")`)

The doc in `docs/features/multimodal_inputs.md` adds a "Preprocessed Multimodal Inputs (Direct Engine Contract)" subsection that walks through the `mm_input` factory + `MultiModalKwargsItems.from_hf_inputs` + `PlaceholderRange` build flow, links the verl reference implementation, and points users at the `/v1/chat/completions/render` + `/inference/v1/generate` HTTP-side equivalent (the disagg serving endpoints already accept this contract — see `vllm/entrypoints/serve/disagg/protocol.py`'s `GenerateRequest` schema and the `examples/online_serving/disaggregated_serving/example_mm_serve.py` worked example).

## Why this is not duplicating an existing PR

`gh pr list --repo vllm-project/vllm --state open --search "MultiModalInput direct"` and `--search "preprocessed multimodal"` searches return no other open PR addressing this surface. The earlier copy of this PR (`#41196`) was closed when its author account was banned; this is a re-submission from the new account `aoshen02` against the same upstream branches. The patch content is identical to the last reviewed state of `#41196` (which already addressed @DarkLight1337's feedback on the `mm_input(...)` schema location and his correction on the `/inference/v1/generate` HTTP path).

Related to vllm-project/vllm#33311.

## Scope checklist

**SDK contract — covered here**

- [x] Direct `MultiModalInput` payload accepted by the v1 `InputProcessor` (test in `tests/v1/engine/test_direct_multimodal_input.py`)
- [x] MM processor is bypassed when the caller passes a rendered `MultiModalInput` (test asserts `_FailingPreprocessor.preprocess` is never called)
- [x] `mm_kwargs` / `mm_hashes` / `mm_placeholders` flatten into `request.mm_features` in placeholder order (test asserts `[modality for f in features] == ["video", "image"]` for offsets 1 / 4)
- [x] `PlaceholderRange.is_embed` preserved through the engine (test asserts torch-equal of the `is_embed` mask)
- [x] Non-string `mm_hashes` rejected with `ValueError("mm_hashes must contain only strings")`
- [x] `AsyncLLM.generate(prompt=mm_input(...))` validated end-to-end against a downstream consumer (verl rollout) — see verl-project/verl#6245
- [x] Documentation in `docs/features/multimodal_inputs.md` (new "Preprocessed Multimodal Inputs (Direct Engine Contract)" subsection under Offline Inference, with a callout describing the disagg HTTP endpoints)

**HTTP serving — already exists via the disagg endpoint pair**

- [x] `POST /v1/chat/completions/render` returns a fully-rendered preprocessed payload (`token_ids` + `features.{mm_hashes, mm_placeholders, kwargs_data}` where `kwargs_data` is base64-encoded `MultiModalKwargsItem`)
- [x] `POST /inference/v1/generate` consumes that payload and runs token-in-token-out generation, bypassing the MM processor (schema in `vllm/entrypoints/serve/disagg/protocol.py`; example in `examples/online_serving/disaggregated_serving/example_mm_serve.py`)
- [x] Pre-computed embeddings via base64 over the standard `/v1/chat/completions` (older narrower feature: `enable_mm_embeds=True` + `tensor2base64(image_embeds)`; documented in the existing "Image Embedding Inputs" subsection under Online Serving)
- [ ] `PlaceholderRangeInfo` in the disagg protocol carries `is_embed` (real gap for Qwen3-VL sparse video placeholder masks; today HTTP path only works for dense placeholders, see TODO at `vllm/entrypoints/serve/disagg/protocol.py:27-29`)
- [ ] The OpenAI **standard** endpoints (`/v1/chat/completions`, `/v1/completions`) themselves admit a direct preprocessed payload (today they always re-run the MM processor server-side; users who want HTTP-side bypass route through the disagg endpoints instead)
- [ ] General design for raw-pixel / tensor schema over OpenAI-standard endpoints — tracked in [#33311](https://github.com/vllm-project/vllm/issues/33311)

**Per-model builder reference — handled downstream, not in this PR**

- [x] verl Qwen2.5-VL image / video builder (token-run placeholders + `second_per_grid_ts`) — companion verl PR
- [x] verl Qwen3 / Qwen3.5-VL timestamp-aware video builder (`is_embed` mask + `<seconds>` text interleave) — companion verl PR
- [ ] Built-in factory inside vLLM that converts HF processor outputs into `MultiModalInput` (today the caller wires `MultiModalKwargsItems.from_hf_inputs` themselves; could move into `vllm/multimodal/` if a second consumer needs it)

**Other deferred items**

- [ ] vLLM provides a stable `mm_uuid` channel callers can use instead of content hashes (today verl computes SHA-256 over tensors per request; a stable-id path would skip the hash work)
- [ ] `vllm.LLM` (sync wrapper) admits `MultiModalInput` in its `PromptType` union (today only `AsyncLLM.generate` accepts it; `LLM.generate` requires `TokensPrompt(... multi_modal_data=...)`)

## Non-goals

- This PR does not add processor-output dict support such as `multi_modal_data={"video": {"pixel_values_videos": ...}}`.
- This PR does not change Qwen / Qwen3 / Qwen3.5 model parser code.
- This PR does not extend the OpenAI **standard** endpoints (`/v1/chat/completions`, `/v1/completions`) to admit a fully-rendered preprocessed payload — that gap is separate from the disagg `/inference/v1/generate` route which already accepts it.
- Per-model verl builders are tracked in the companion verl PR: verl-project/verl#6245.

## Validation

- `RUFF_CACHE_DIR=/tmp/vllm-ruff-cache uvx ruff check tests/v1/engine/test_direct_multimodal_input.py` — passed
- `RUFF_CACHE_DIR=/tmp/vllm-ruff-cache uvx ruff format --check tests/v1/engine/test_direct_multimodal_input.py` — passed
- `UV_TORCH_BACKEND=cpu uvx --from pytest --with pytest --with torch --with-requirements requirements/common.txt pytest --noconftest tests/v1/engine/test_direct_multimodal_input.py -q` — `2 passed` locally (warnings from local uncompiled/test cache environment)
- Downstream end-to-end via verl: bit-identical 64-token output between the direct `mm_input(...)` payload and the legacy `TokensPrompt(prompt_token_ids=..., multi_modal_data={"image": [...]})` path on real vllm 0.19.1 (single-process `AsyncLLM`, temperature=0, seed=42) for both `Qwen/Qwen2.5-VL-3B-Instruct` and `Qwen/Qwen3-VL-4B-Instruct`.

## AI assistance

This PR includes AI-assisted code changes (Codex-authored test + doc; review and validation done with Claude opus-4-7). The human submitter has reviewed every changed line and is responsible for defending the behavior end-to-end.

Co-authored-by: Codex <codex@openai.com>
Co-authored-by: Claude <noreply@anthropic.com>