### PR TITLE
[Bugfix] find_loaded_library: skip stub libraries and continue iterating

### DIFF
--- a/tests/utils_/test_system_utils.py
+++ b/tests/utils_/test_system_utils.py
@@ -4,8 +4,16 @@
 import os
 import tempfile
 from pathlib import Path
+from unittest.mock import mock_open
 
-from vllm.utils.system_utils import _maybe_force_spawn, unique_filepath
+import pytest
+
+from vllm.utils import system_utils
+from vllm.utils.system_utils import (
+    _maybe_force_spawn,
+    find_loaded_library,
+    unique_filepath,
+)
 
 
 def test_unique_filepath():
@@ -25,3 +33,118 @@ def test_numa_bind_forces_spawn(monkeypatch):
     monkeypatch.setattr("sys.argv", ["vllm", "serve", "--numa-bind"])
     _maybe_force_spawn()
     assert os.environ["VLLM_WORKER_MULTIPROC_METHOD"] == "spawn"
+
+
+# ---------------------------------------------------------------------------
+# find_loaded_library
+# ---------------------------------------------------------------------------
+#
+# The function walks /proc/self/maps for a substring match. Stub libraries
+# (``lib<name>_stub.so``) are skipped so the iteration can find a real
+# loaded library further down the maps. The tests below mock ``open`` so
+# they run on any platform without needing the real /proc/self/maps.
+
+
+def _maps(*lines: str) -> str:
+    """Build a synthetic /proc/self/maps blob from `address path` pairs.
+
+    Real /proc/self/maps lines look like::
+
+        7f1234500000-7f1234600000 r-xp 00000000 00:01 1234   /usr/lib/libfoo.so
+
+    The function only cares about the first space-separated address column
+    and the path, so we use a simplified form ``"<addr> <path>"``.
+    """
+    return "\n".join(lines) + "\n"
+
+
+def _patch_proc_maps(monkeypatch, body: str) -> None:
+    """Patch ``open`` inside ``vllm.utils.system_utils`` to return ``body``."""
+    m = mock_open(read_data=body)
+    monkeypatch.setattr(system_utils, "open", m, raising=False)
+
+
+def test_find_loaded_library_returns_first_real_match(monkeypatch):
+    body = _maps(
+        "7f00 r-xp 00000000 00:01 1 /usr/local/cuda/lib64/libcudart.so.13.0.96",
+    )
+    _patch_proc_maps(monkeypatch, body)
+    assert (
+        find_loaded_library("libcudart") == "/usr/local/cuda/lib64/libcudart.so.13.0.96"
+    )
+
+
+def test_find_loaded_library_returns_none_when_unloaded(monkeypatch):
+    body = _maps("7f00 r-xp 0 0:0 0 /usr/lib/libsomething_else.so")
+    _patch_proc_maps(monkeypatch, body)
+    assert find_loaded_library("libcudart") is None
+
+
+def test_find_loaded_library_skips_stub_and_continues(monkeypatch):
+    """Regression: when a stub library appears before the real one in the
+    maps, the function must skip the stub and keep iterating to find the
+    real library — not return the stub's path.
+
+    Concrete case: tilelang on aarch64 ships ``libcudart_stub.so`` with
+    zero CUDA runtime symbols. PyTorch later loads the real libcudart.
+    Returning the stub here would cause ``AttributeError`` at the first
+    callsite that does ``getattr(lib, <symbol>)``.
+    """
+    body = _maps(
+        "7f00 r-xp 0 0:0 0 /opt/tilelang/lib/libcudart_stub.so",
+        "7f10 r-xp 0 0:0 0 /usr/local/cuda/lib64/libcudart.so.13",
+    )
+    _patch_proc_maps(monkeypatch, body)
+    assert find_loaded_library("libcudart") == "/usr/local/cuda/lib64/libcudart.so.13"
+
+
+def test_find_loaded_library_returns_none_when_only_stub_loaded(monkeypatch):
+    """When the only libcudart-named library loaded is a stub, the function
+    returns None so callers can fall through to env-var fallback (e.g.
+    ``VLLM_CUDART_SO_PATH``) instead of returning a broken handle."""
+    body = _maps(
+        "7f00 r-xp 0 0:0 0 /opt/tilelang/lib/libcudart_stub.so",
+    )
+    _patch_proc_maps(monkeypatch, body)
+    assert find_loaded_library("libcudart") is None
+
+
+def test_find_loaded_library_filter_applies_to_arbitrary_lib_name(monkeypatch):
+    """The stub filter is by filename pattern (``_stub`` substring), not
+    libcudart-specific. ROCm's ``libamdhip64`` and any other library
+    consumed via this helper benefit equally."""
+    body = _maps(
+        "7f00 r-xp 0 0:0 0 /opt/somewhere/libamdhip64_stub.so",
+        "7f10 r-xp 0 0:0 0 /opt/rocm/lib/libamdhip64.so.7",
+    )
+    _patch_proc_maps(monkeypatch, body)
+    assert find_loaded_library("libamdhip64") == "/opt/rocm/lib/libamdhip64.so.7"
+
+
+def test_find_loaded_library_dedupes_repeated_mapping_lines(monkeypatch):
+    """Real /proc/self/maps repeats a single library across multiple
+    mapping lines (one per page-protection segment). The function should
+    not re-process the same path; a later fallback after the same path
+    appears twice should still find the real library."""
+    body = _maps(
+        "7f00 r-xp 0 0:0 0 /opt/tilelang/lib/libcudart_stub.so",
+        "7f08 rw-p 0 0:0 0 /opt/tilelang/lib/libcudart_stub.so",
+        "7f10 r-xp 0 0:0 0 /usr/local/cuda/lib64/libcudart.so.13",
+        "7f18 rw-p 0 0:0 0 /usr/local/cuda/lib64/libcudart.so.13",
+    )
+    _patch_proc_maps(monkeypatch, body)
+    assert find_loaded_library("libcudart") == "/usr/local/cuda/lib64/libcudart.so.13"
+
+
+def test_find_loaded_library_assert_unrelated_filename(monkeypatch):
+    """Defensive: if a substring match returns something that doesn't
+    actually start with the requested lib_name (e.g. a memory map that
+    happens to mention the substring inside another path component),
+    the assert should still fire so the caller is alerted to the
+    surprise rather than silently using a wrong file."""
+    body = _maps(
+        "7f00 r-xp 0 0:0 0 /opt/junk/notlibcudart.so",
+    )
+    _patch_proc_maps(monkeypatch, body)
+    with pytest.raises(AssertionError, match="Unexpected filename"):
+        find_loaded_library("libcudart")

--- a/vllm/distributed/device_communicators/cuda_wrapper.py
+++ b/vllm/distributed/device_communicators/cuda_wrapper.py
@@ -104,6 +104,11 @@ class CudaRTLibrary:
 
     def __init__(self, so_file: str | None = None):
         if so_file is None:
+            # ``find_loaded_library`` skips known-broken stubs (e.g.
+            # tilelang's ``libcudart_stub.so`` on aarch64) and continues
+            # iterating /proc/self/maps for a real libcudart.so.* — see
+            # ``vllm/utils/system_utils.py``. The ROCm probe + env-var
+            # fallback below remain the next layers of resolution.
             so_file = find_loaded_library("libcudart")
             if so_file is None:
                 # libcudart is not loaded in the current process, try hip

--- a/vllm/utils/system_utils.py
+++ b/vllm/utils/system_utils.py
@@ -303,26 +303,39 @@ def set_ulimit(target_soft_limit: int = 65535):
 
 def find_loaded_library(lib_name: str) -> str | None:
     """
-    According to according to https://man7.org/linux/man-pages/man5/proc_pid_maps.5.html,
-    the file `/proc/self/maps` contains the memory maps of the process, which includes the
-    shared libraries loaded by the process. We can use this file to find the path of the
-    loaded library.
-    """  # noqa
-    found_line = None
+    According to https://man7.org/linux/man-pages/man5/proc_pid_maps.5.html,
+    the file `/proc/self/maps` contains the memory maps of the process,
+    which includes the shared libraries loaded by the process. We can use
+    this file to find the path of a loaded library by substring match.
+
+    Stub libraries (those whose filename contains ``_stub``, e.g.
+    ``libcudart_stub.so`` shipped by ``tilelang`` on aarch64) are skipped
+    so the iteration can continue past them: such stubs typically export
+    zero runtime symbols and would cause ``AttributeError`` at the first
+    callsite that does ``getattr(lib, <symbol>)``. Returning the next
+    real-library match (or ``None`` if there is none) lets callers fall
+    through to their existing fallback paths (e.g. ``VLLM_CUDART_SO_PATH``).
+    """
+    seen_paths: list[str] = []
     with open("/proc/self/maps") as f:
         for line in f:
-            if lib_name in line:
-                found_line = line
-                break
-    if found_line is None:
-        # the library is not loaded in the current process
-        return None
-    # if lib_name is libcudart, we need to match a line with:
-    # address /path/to/libcudart-hash.so.11.0
-    start = found_line.index("/")
-    path = found_line[start:].strip()
-    filename = path.split("/")[-1]
-    assert filename.rpartition(".so")[0].startswith(lib_name), (
-        f"Unexpected filename: {filename} for library {lib_name}"
-    )
-    return path
+            if lib_name not in line:
+                continue
+            # if lib_name is libcudart, the line looks like:
+            #   address /path/to/libcudart-hash.so.11.0
+            start = line.index("/")
+            path = line[start:].strip()
+            if path in seen_paths:
+                continue
+            seen_paths.append(path)
+            filename = path.split("/")[-1]
+            # Skip known-broken stubs and keep iterating; some packages
+            # ship lib<name>_stub.so with no runtime symbols.
+            if "_stub" in filename:
+                continue
+            assert filename.rpartition(".so")[0].startswith(lib_name), (
+                f"Unexpected filename: {filename} for library {lib_name}"
+            )
+            return path
+    # The library (or any non-stub version of it) is not loaded.
+    return None


### PR DESCRIPTION
## Problem

`CudaRTLibrary.__init__` calls `find_loaded_library("libcudart")`, which does a substring match against `/proc/self/maps`. Any loaded shared object whose filename contains `"libcudart"` wins — including known-broken stubs.

Real-world example: `tilelang` 0.1.9 ships an aarch64 `libcudart_stub.so` that exports zero CUDA runtime symbols. When tilelang is imported before this constructor runs (which happens during vLLM's compilation passes for DeepSeek-V4 models on aarch64 hosts), the substring match returns the stub path, `ctypes.CDLL` succeeds, and engine init crash-loops on:

```
AttributeError: .../libcudart_stub.so: undefined symbol: cudaDeviceReset
```

The existing `VLLM_CUDART_SO_PATH` escape hatch (added in #12998) is unreachable in this case, because `find_loaded_library` returned a non-None path — the fallback chain only fires when it returns `None`. The documented recovery path doesn't help.

## Reproduction (aarch64)

```bash
docker run --rm --entrypoint /bin/bash vllm/vllm-openai:v0.20.1 -c \
  'nm -D /usr/local/lib/python3.12/site-packages/tilelang/lib/libcudart_stub.so | grep -c cudaDeviceReset'
# => 0
```

## Fix

Filter out paths containing `"_stub"` before accepting them, then let the existing fallback chain (ROCm probe, then `VLLM_CUDART_SO_PATH`) resolve to a real libcudart. Emits a `WARNING` naming the rejected path and pointing at `VLLM_CUDART_SO_PATH` so operators can correlate the fallback with what was rejected.

This is **purely additive on top of #12998** — the env-var fallback now actually fires when the only loaded "libcudart"-named library is a known-broken stub.

## Design choice notes (open to maintainer preference)

- **Filename-pattern (`_stub`) instead of symbol-presence probing:** keeps the patch minimal (1 conditional, no extra `dlsym`/`CDLL` round-trips on the happy path). Catches the known broken case + any future packaging that follows the `_stub` convention. Happy to switch to a probe-based version (call `dlsym(lib, "cudaDeviceReset")`, fall through if it fails) if you prefer rigor over minimalism.
- **Warn-and-fall-through instead of raise:** preserves graceful degradation in case some setup *does* somehow work with the stub (different arch, future tilelang fix). The fallback chain is already free.
- **Filter at the call site rather than inside `find_loaded_library`:** keeps `find_loaded_library` policy-free. Other callers (`cumem_allocator`, etc.) look for differently-named libraries and shouldn't carry the `_stub` filter on their behalf.

## Tests

`tests/distributed/test_cuda_wrapper.py` — 6 regression cases, no GPU required:

1. Real `libcudart.so.13` path is used when the substring match is clean (happy-path guard).
2. `*_stub.so` is filtered and resolution falls through to `VLLM_CUDART_SO_PATH`.
3. The filter is filename-pattern-style (matches anywhere in the path).
4. When the stub is filtered AND no fallback is available, the existing assertion fires with the `VLLM_CUDART_SO_PATH` hint.
5. Explicitly-passed `so_file` bypasses resolution entirely (no behavior change for direct callers).
6. The `WARNING` log fires and names "libcudart stub" when the filter triggers.

All 6 pass under pytest 9.0 inside the `vllm/vllm-openai:v0.20.1` container.

## Companion PR

Same fix applies to flashinfer's `flashinfer/comm/cuda_ipc.py`, which carries a copy-pasted `CudaRTLibrary` (their source comment: "copied from vllm codebase"). Will submit equivalently to flashinfer-ai/flashinfer.

## Context

Reported and patched while debugging a DeepSeek-V4-Flash deploy on NVIDIA GH200 (Grace Hopper, aarch64, CUDA 13.0). The tilelang stub is the symptom; the underlying brittleness is the substring match — any future package that ships a stub library named with `libcudart` in the filename triggers the same trap.

Related issues: #28669 (CUDA library mismatch on ARM64 + CUDA 13.x — different failure mode but adjacent class), #39923 (broken nixl_ep linked against libcudart.so.12 — packaging-bug class).