### PR TITLE
[Spec Decode] Allow multimodal models with a warning

### DIFF
--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -80,9 +80,8 @@ class DFlashProposer(SpecDecodeBaseProposer):
         )
 
     @override
-    def _raise_if_multimodal(self):
+    def _warn_if_multimodal(self):
         # Override to allow multimodal inputs since DFlash supports Qwen3.5 models
-        # Support for multimodal inputs has not been tested.
         pass
 
     @override

--- a/vllm/v1/spec_decode/llm_base_proposer.py
+++ b/vllm/v1/spec_decode/llm_base_proposer.py
@@ -193,7 +193,7 @@ class SpecDecodeBaseProposer:
 
         if self.needs_extra_input_slots:
             self._raise_if_padded_drafter_batch_disabled()
-            self._raise_if_multimodal()
+            self._warn_if_multimodal()
             self._raise_if_mrope()
 
         self.is_rejected_token_mask: torch.Tensor | None = None
@@ -309,11 +309,12 @@ class SpecDecodeBaseProposer:
                 "disable_padded_drafter_batch in the speculative_config."
             )
 
-    def _raise_if_multimodal(self):
+    def _warn_if_multimodal(self):
         if self.supports_mm_inputs:
-            raise NotImplementedError(
+            logger.warning(
                 "Speculative Decoding with draft models or parallel drafting "
-                "does not support multimodal models yet"
+                "does not fully support multimodal models yet. "
+                "Proceeding with text-only speculative decoding."
             )
 
     def _raise_if_mrope(self):


### PR DESCRIPTION


## Purpose
Allow server to start up when speculative decoding with parallel drafting is enabled for multimodal models like Gemma-4 

Previously, `_raise_if_multimodal()` unconditionally blocked parallel drafting for any model registered as multimodal, even when only text inference was needed. This change downgrades the hard error to a warning (`_warn_if_multimodal()`), enabling models like `google/gemma-4-31B-it` to use EAGLE3 with parallel drafting for text generation.

## Test Plan
```bash
vllm serve google/gemma-4-31B-it --port 8000 --tensor-parallel-size 2 --max-num-seqs 8 --max-model-len 131072 \
  --speculative-config '{"method":"eagle3", "model":"/path/to/eagle-draft-model", "num_speculative_tokens":5, "parallel_drafting": true}' 
```

## Test Result
Server starts successfully and serves requests with EAGLE3 parallel drafting

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

