### PR TITLE
[ROCm][Bugfix] Fix DeepSeek-V3.2 TP4 sparse MLA with HIP graphs

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -927,23 +927,6 @@ class VllmBackend:
         return standalone_compile_artifacts, sym_shape_indices_map, returns_tuple_map
 
     def configure_post_pass(self) -> None:
-        # TODO proper PassManager?
-        pre_grad_pass_key = "pre_grad_custom_pass"
-        assert self.pass_key != pre_grad_pass_key
-        assert pre_grad_pass_key not in self.inductor_config
-        self.inductor_config[pre_grad_pass_key] = VllmIRInplaceFunctionalizationPass(
-            self.vllm_config
-        )
-
-        # Make sure pre_grad_custom_pass is not pickled
-        # as part of AOTAutograd built-in cache key
-        # TODO(luka) is there a cleaner way to do this
-        import torch._inductor.config as inductor_config
-
-        ignore = inductor_config._cache_config_ignore_prefix + [pre_grad_pass_key]
-        assert "_cache_config_ignore_prefix" not in self.inductor_config
-        self.inductor_config["_cache_config_ignore_prefix"] = ignore
-
         # Configure the (nominally post-grad) pass manager
         self.pass_manager.configure(self.vllm_config)
 

--- a/vllm/compilation/passes/pass_manager.py
+++ b/vllm/compilation/passes/pass_manager.py
@@ -20,6 +20,7 @@ from .vllm_inductor_pass import VllmInductorPass, VllmPatternMatcherPass
 
 if rocm_aiter_ops.is_enabled():
     from .fusion.allreduce_rms_fusion import (
+        AllReduceFusionPass,
         RocmAiterAllReduceFusionPass,
     )
     from .fusion.rocm_aiter_fusion import (
@@ -116,8 +117,6 @@ class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
         # DCE handles mutating ops correctly as well.
         self.ir_lowering(graph)
         VllmInductorPass.dump_prefix += 1
-        self.clone_elimination(graph)
-        VllmInductorPass.dump_prefix += 1
 
         # clean up after lowering again
         self.post_cleanup(graph)
@@ -143,10 +142,9 @@ class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
                     self.passes += [AsyncTPPass(config)]
 
             if self.pass_config.fuse_allreduce_rms:
-                if rocm_aiter_ops.is_enabled():
-                    self.passes += [RocmAiterAllReduceFusionPass(config)]
-                else:
-                    self.passes += [AllReduceFusionPass(config)]
+                # RocmAiterAllReduceFusionPass is disabled: it corrupts HIP
+                # graph replay when sparse MLA attention (nhead=32) is active.
+                self.passes += [AllReduceFusionPass(config)]
 
             if self.pass_config.fuse_minimax_qk_norm:
                 self.passes += [MiniMaxQKNormPass(config)]

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -472,7 +472,6 @@ class GroupCoordinator:
         # only cuda uses this function,
         # so we don't abstract it into the base class
         maybe_ca_context = nullcontext()
-        maybe_aiter_context = nullcontext()
         from vllm.distributed.device_communicators.cuda_communicator import (
             CudaCommunicator,
         )
@@ -483,20 +482,13 @@ class GroupCoordinator:
             if ca_comm is not None:
                 maybe_ca_context = ca_comm.capture()  # type: ignore
 
-            from vllm._aiter_ops import rocm_aiter_ops
-
-            if rocm_aiter_ops.is_enabled():
-                aiter_ar = rocm_aiter_ops.get_aiter_allreduce()
-                if aiter_ar is not None:
-                    maybe_aiter_context = aiter_ar.capture()  # type: ignore
-
         # ensure all initialization operations complete before attempting to
         # capture the graph on another stream
         curr_stream = torch.cuda.current_stream()
         if curr_stream != stream:
             stream.wait_stream(curr_stream)
 
-        with torch.cuda.stream(stream), maybe_ca_context, maybe_aiter_context:
+        with torch.cuda.stream(stream), maybe_ca_context:
             yield graph_capture_context
 
     def all_reduce(self, input_: torch.Tensor) -> torch.Tensor:

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -351,9 +351,8 @@ class DeepseekV2MoE(nn.Module):
             self.is_rocm_aiter_moe_enabled
             and self.gate.e_score_correction_bias is not None
         ):
-            gate_out_dtype = self.gate.out_dtype or self.gate.weight.dtype
             self.gate.e_score_correction_bias.data = (
-                self.gate.e_score_correction_bias.data.to(gate_out_dtype)
+                self.gate.e_score_correction_bias.data.to(self.gate.out_dtype)
             )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -396,7 +396,7 @@ class AiterMLAHelper:
     """
 
     _AITER_MIN_MLA_HEADS: Final = 16
-    _AITER_UNSUPPORTED_HEADS = [32]
+    _AITER_UNSUPPORTED_HEADS: list[int] = []
 
     @staticmethod
     def check_num_heads_validity(num_heads: int):


### PR DESCRIPTION
## Summary

DeepSeek-V3.2 at TP4 (nhead=32) produces garbage output when HIP graphs are enabled. This is caused by the interaction of four issues introduced across #41217, #37646, #36823, and #41405:

1. **`_AITER_UNSUPPORTED_HEADS=[32]`** incorrectly blocks nhead=32 from the AITER MLA decode path. AITER [PR #2983 v2](https://github.com/ROCm/aiter/pull/2983) added proper kernel support for this configuration.

2. **`RocmAiterAllReduceFusionPass`** and its `aiter_ar.capture()` context corrupt HIP graph replay for the sparse MLA attention path. Switch to the standard `AllReduceFusionPass`.

3. **`UnsafeCloneEliminationPass`** and **`VllmIRInplaceFunctionalizationPass`** introduce subtle numerical corruption under graph capture, causing wrong MoE expert routing (manifests as bilingual/incoherent output).

4. **#41405** `gate_out_dtype` fallback casts `e_score_correction_bias` to bf16 when `gate.out_dtype` is None, causing precision loss in AITER `biased_grouped_topk`. Revert to `.to(self.gate.out_dtype)` which is a no-op when `out_dtype` is unset.

## Changes

- `rocm_aiter_mla.py`: Clear `_AITER_UNSUPPORTED_HEADS` (1 line)
- `pass_manager.py`: Use `AllReduceFusionPass` instead of `RocmAiterAllReduceFusionPass`; skip `clone_elimination` call
- `parallel_state.py`: Remove `aiter_ar.capture()` from graph capture context
- `backends.py`: Skip `VllmIRInplaceFunctionalizationPass` registration
- `deepseek_v2.py`: Revert #41405 gate dtype fallback

## GSM8K (5-shot, 1319 prompts)


| Filter             | Metric        | Value      | Stderr     |
| ------------------ | ------------- | ---------- | ---------- |
| `flexible-extract` | `exact_match` | **0.9318** | ± 0.0069   |
| `strict-match`     | `exact_match` | **0.9113** | ± 0.0078   |

## Test plan

- [x] DeepSeek-V3.2 TP4 bf16 with HIP graphs — correct, coherent output
- [x] Same config with `--enforce-eager` — also correct (confirms compute logic unchanged)
- [ ] DeepSeek-V3.2 TP8 — verify no regression
- [ ] Non-MLA models on ROCm — verify allreduce fusion still works via standard pass

## Related

- Fixes regression from #41217 (nhead=32 block + sparse MLA rewrite)
- Fixes regression from #37646 (AITER fused allreduce graph capture)
- Fixes regression from #36823 (clone elimination + inplace functionalization)
- Fixes incomplete fix in #41405 (gate bias dtype)
