### PR TITLE
Fix EP precision for Qwen3 MoE shared expert under sequence-parallel MoE

### DIFF
--- a/tests/models/test_qwen3_moe.py
+++ b/tests/models/test_qwen3_moe.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from vllm.model_executor.models.qwen3_moe import Qwen3MoeMLP
+
+
+def test_qwen3_moe_mlp_threads_is_sequence_parallel_to_disable_tp() -> None:
+    mlp = Qwen3MoeMLP(
+        hidden_size=128,  # Arbitrary; only wiring is checked
+        intermediate_size=256,  # Arbitrary; only wiring is checked
+        hidden_act="silu",  # Placeholder; only value the ctor accepts
+        # With `reduce_results` left at its default of `True`, the `down_proj` layer
+        # would all-reduce and misses the bug we're covering here (that an un-reduced
+        # partial-sum output is the input to the offending all_gather)
+        reduce_results=False,
+        # This test covers that this SP flag propagates to disable TP on both
+        # of the MLP's linear layers (`gate_up_proj` and `down_proj`)
+        is_sequence_parallel=True,
+    )
+
+    assert mlp.gate_up_proj.disable_tp, (
+        "gate_up_proj is still tensor-parallel under is_sequence_parallel: "
+        "weights would be column-sharded across TP and the shared-expert "
+        "output for each SP chunk would be wrong. With TP disabled on the "
+        "layer, each rank instead holds the full replicated weights and "
+        "processes its sequence-parallel chunk independently."
+    )
+    assert mlp.down_proj.disable_tp, (
+        "down_proj is still tensor-parallel under is_sequence_parallel: "
+        "weights would be row-sharded and, with reduce_results=False, each "
+        "rank would emit a 1/TP partial sum. With TP disabled on the layer, "
+        "each rank instead holds the full replicated weights and processes "
+        "its sequence-parallel chunk independently."
+    )

--- a/vllm/model_executor/models/qwen3_moe.py
+++ b/vllm/model_executor/models/qwen3_moe.py
@@ -98,6 +98,7 @@ class Qwen3MoeMLP(nn.Module):
         quant_config: QuantizationConfig | None = None,
         reduce_results: bool = True,
         expert_gate: torch.nn.Linear | None = None,
+        is_sequence_parallel: bool = False,
         prefix: str = "",
     ) -> None:
         super().__init__()
@@ -106,6 +107,7 @@ class Qwen3MoeMLP(nn.Module):
             [intermediate_size] * 2,
             bias=False,
             quant_config=quant_config,
+            disable_tp=is_sequence_parallel,
             prefix=f"{prefix}.gate_up_proj",
         )
         self.down_proj = RowParallelLinear(
@@ -114,6 +116,7 @@ class Qwen3MoeMLP(nn.Module):
             bias=False,
             quant_config=quant_config,
             reduce_results=reduce_results,
+            disable_tp=is_sequence_parallel,
             prefix=f"{prefix}.down_proj",
         )
         if hidden_act != "silu":
@@ -202,6 +205,7 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
                 quant_config=quant_config,
                 reduce_results=False,
                 expert_gate=self.shared_expert_gate,
+                is_sequence_parallel=self.is_sequence_parallel,
                 prefix=f"{prefix}.shared_expert",
             )
         else:


### PR DESCRIPTION
Closes #37856.

## Purpose

https://github.com/vllm-project/vllm/pull/39181 fixed Qwen3-Next and Qwen2MoeMLP. This PR extends the same `is_sequence_parallel` → `disable_tp` wiring to `Qwen3MoeMLP` / `Qwen3MoeSparseMoeBlock`

The result is any `Qwen3MoeForCausalLM` config with `shared_expert_intermediate_size > 0` stops emitting `1/TP`-scaled shared-expert outputs under `EP + TP>1 + DP>1`.

## Test Plan

Created `tests/models/test_qwen3_moe.py` to confirm `is_sequence_parallel` propagation to `disable_tp`.

## Test Result

Test passes