### PR TITLE
fix: support MIG UUIDs in CUDA_VISIBLE_DEVICES

### DIFF
--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -589,12 +589,19 @@ class CudaPlatformBase(Platform):
 # the major benefit of using NVML is that it will not initialize CUDA
 class NvmlCudaPlatform(CudaPlatformBase):
     @classmethod
+    def _get_nvml_handle(cls, device_id: int = 0):
+        """Get NVML device handle, supporting both integer indices and MIG UUIDs."""
+        physical_device_id = cls.device_id_to_physical_device_id(device_id)
+        if isinstance(physical_device_id, str):
+            return pynvml.nvmlDeviceGetHandleByUUID(physical_device_id)
+        return pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)
+
+    @classmethod
     @cache
     @with_nvml_context
     def get_device_capability(cls, device_id: int = 0) -> DeviceCapability | None:
         try:
-            physical_device_id = cls.device_id_to_physical_device_id(device_id)
-            handle = pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)
+            handle = cls._get_nvml_handle(device_id)
             major, minor = pynvml.nvmlDeviceGetCudaComputeCapability(handle)
             return DeviceCapability(major=major, minor=minor)
         except RuntimeError:
@@ -615,21 +622,19 @@ class NvmlCudaPlatform(CudaPlatformBase):
     @classmethod
     @with_nvml_context
     def get_device_name(cls, device_id: int = 0) -> str:
-        physical_device_id = cls.device_id_to_physical_device_id(device_id)
-        return cls._get_physical_device_name(physical_device_id)
+        handle = cls._get_nvml_handle(device_id)
+        return pynvml.nvmlDeviceGetName(handle)
 
     @classmethod
     @with_nvml_context
     def get_device_uuid(cls, device_id: int = 0) -> str:
-        physical_device_id = cls.device_id_to_physical_device_id(device_id)
-        handle = pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)
+        handle = cls._get_nvml_handle(device_id)
         return pynvml.nvmlDeviceGetUUID(handle)
 
     @classmethod
     @with_nvml_context
     def get_device_total_memory(cls, device_id: int = 0) -> int:
-        physical_device_id = cls.device_id_to_physical_device_id(device_id)
-        handle = pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)
+        handle = cls._get_nvml_handle(device_id)
         return int(pynvml.nvmlDeviceGetMemoryInfo(handle).total)
 
     @classmethod
@@ -638,7 +643,12 @@ class NvmlCudaPlatform(CudaPlatformBase):
         """
         query if the set of gpus are fully connected by nvlink (1 hop)
         """
-        handles = [pynvml.nvmlDeviceGetHandleByIndex(i) for i in physical_device_ids]
+        handles = [
+            pynvml.nvmlDeviceGetHandleByUUID(i)
+            if isinstance(i, str)
+            else pynvml.nvmlDeviceGetHandleByIndex(i)
+            for i in physical_device_ids
+        ]
         for i, handle in enumerate(handles):
             for j, peer_handle in enumerate(handles):
                 if i < j:
@@ -667,8 +677,7 @@ class NvmlCudaPlatform(CudaPlatformBase):
     @with_nvml_context
     def get_device_numa_node(cls, device_id: int = 0) -> int | None:
         """Get the NUMA node ID for a GPU device."""
-        physical_device_id = cls.device_id_to_physical_device_id(device_id)
-        handle = pynvml.nvmlDeviceGetHandleByIndex(physical_device_id)
+        handle = cls._get_nvml_handle(device_id)
 
         try:
             numa_node = pynvml.nvmlDeviceGetNumaNodeId(handle)

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -220,7 +220,7 @@ class Platform:
         import vllm.kernels  # noqa: F401
 
     @classmethod
-    def device_id_to_physical_device_id(cls, device_id: int):
+    def device_id_to_physical_device_id(cls, device_id: int) -> "int | str":
         # Treat empty device control env var as unset. This is a valid
         # configuration in Ray setups where the engine is launched in
         # a CPU-only placement group located on a GPU node.
@@ -230,7 +230,12 @@ class Platform:
         ):
             device_ids = os.environ[cls.device_control_env_var].split(",")
             physical_device_id = device_ids[device_id]
-            return int(physical_device_id)
+            try:
+                return int(physical_device_id)
+            except ValueError:
+                # MIG UUIDs (e.g. "MIG-xxxx-...") are not integers.
+                # Return the raw string so callers can resolve via UUID.
+                return physical_device_id
         else:
             return device_id
 


### PR DESCRIPTION
## Summary

When `CUDA_VISIBLE_DEVICES` is set to a NVIDIA MIG UUID (e.g. `MIG-fe59bfcd-3946-5d58-a00e-183ee397373b`), vLLM crashes on startup with:

```
ValueError: invalid literal for int() with base 10: 'MIG-fe59bfcd-3946-5d58-a00e-183ee397373b'
```

**Root cause:** `Platform.device_id_to_physical_device_id()` unconditionally calls `int()` on `CUDA_VISIBLE_DEVICES` entries. MIG UUIDs are strings, not integers.

**Secondary issue:** Even if the crash is worked around, all NVML callers in `NvmlCudaPlatform` pass the physical device ID to `nvmlDeviceGetHandleByIndex()`, which returns the **parent GPU** handle. For example, on an A100 40GB split into 2×3g.20gb MIG instances, `get_device_total_memory()` reports 40GB instead of the MIG slice's actual 20GB.

## Changes

### `vllm/platforms/interface.py`
- `device_id_to_physical_device_id()` now catches `ValueError` and returns the raw UUID string when the device ID is not an integer (e.g. MIG UUIDs)
- Return type updated to `int | str`

### `vllm/platforms/cuda.py`
- Added `NvmlCudaPlatform._get_nvml_handle()` helper that uses `nvmlDeviceGetHandleByUUID()` for string device IDs (MIG UUIDs) and `nvmlDeviceGetHandleByIndex()` for integer device IDs
- Updated all NVML callers (`get_device_capability`, `get_device_name`, `get_device_uuid`, `get_device_total_memory`, `get_device_numa_node`) to use the new helper

## Reproduction

```bash
# On an A100 with MIG enabled (2x 3g.20gb instances)
nvidia-smi -L
# GPU 0: NVIDIA A100-SXM4-40GB (UUID: GPU-...)
#   MIG 3g.20gb Device 0: (UUID: MIG-fe59bfcd-...)
#   MIG 3g.20gb Device 1: (UUID: MIG-f570b9ec-...)

# This crashes without the fix:
CUDA_VISIBLE_DEVICES=MIG-fe59bfcd-3946-5d58-a00e-183ee397373b \
  python -m vllm.entrypoints.openai.api_server --model google/gemma-4-E4B-it ...
```

## Verification

Tested on bare-metal A100 40GB with 2×3g.20gb MIG instances:

| Query | Before fix | After fix |
|-------|-----------|-----------|
| Startup | `ValueError` crash | Works |
| `get_device_name()` | N/A (crash) | `NVIDIA A100-SXM4-40GB MIG 3g.20gb` |
| `get_device_total_memory()` | N/A (crash) | 19.6 GB (correct MIG slice) |

Note: MIG works inside Docker containers (via NVIDIA Container Toolkit) because the toolkit maps the MIG instance as `cuda:0` inside the container. This fix enables **bare-metal** MIG usage with vLLM.