### PR TITLE
[Bugfix] Flush final KV block when SimpleCPUOffload request finishes in same step as its last full block

### DIFF
--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -1135,3 +1135,79 @@ def test_partial_gpu_prefix_plus_cpu_load() -> None:
         assert bid in ext_block_ids, (
             f"Load GPU block {bid} should be an ext_comp block, not a comp or new block"
         )
+
+
+# ---------------------------------------------------------------------------
+# Test 11: Flush final block on finish (eager mode)
+# ---------------------------------------------------------------------------
+def test_eager_flush_final_block_on_finish() -> None:
+    """Eager mode: the last full block computed in the same step a request
+    finishes must still be offloaded to CPU (flush-on-finish).
+
+    Root cause: build_connector_meta runs BEFORE _update_after_schedule, so
+    the current step's newly confirmed block is invisible to
+    _prepare_eager_store_specs.  When the request then finishes in that same
+    step, request_finished must flush it rather than silently drop it.
+
+    Sequence simulated:
+    1. Allocate 2 GPU blocks; confirm only block 0 before the first
+       build_connector_meta call — matching the real scheduler ordering.
+    2. build_connector_meta stores block 0.
+    3. _update_after_schedule advances num_computed_tokens to cover block 1.
+    4. request_finished is called — flush-on-finish queues block 1.
+    5. Next build_connector_meta merges the pending flush into a store event.
+    6. After store completes, block 1's hash is in the CPU cache.
+    """
+    fix = make_scheduler(num_cpu_blocks=8, num_gpu_blocks=16, lazy=False)
+    sched = fix.scheduler
+
+    req = make_request(num_blocks=2)
+
+    # Allocate both GPU blocks but only confirm block 0 initially.
+    kv_blocks = _alloc_and_register(fix, req, 2, confirmed=False)
+    req.num_computed_tokens = BLOCK_SIZE  # block 0 confirmed
+    block_ids = kv_blocks.get_block_ids()
+    sched.update_state_after_alloc(req, kv_blocks, num_external_tokens=0)
+
+    # Step 1: build_connector_meta sees only block 0 confirmed → stores block 0.
+    sched_out1 = make_scheduler_output(
+        {req.request_id: BLOCK_SIZE},
+        new_reqs={req.request_id: block_ids},
+    )
+    meta1 = sched.build_connector_meta(sched_out1)
+    assert meta1.store_event >= 0, "Block 0 should be scheduled for store"
+    assert len(meta1.store_gpu_blocks) == 1, "Only block 0 should be stored"
+    simulate_store_completion(sched, meta1.store_event)
+
+    # Step 2: simulate _update_after_schedule advancing num_computed_tokens.
+    req.num_computed_tokens = 2 * BLOCK_SIZE  # block 1 now confirmed
+
+    # Step 3: request finishes — flush-on-finish should queue block 1.
+    sched.request_finished(req, block_ids=[])
+    assert len(sched._pending_flush_gpu_blocks) == 1, (
+        "Block 1 should be queued in _pending_flush_gpu_blocks after request_finished"
+    )
+    # State must be kept alive (finished=True, not yet cleaned up).
+    assert req.request_id in sched._reqs_to_store
+    assert sched._reqs_to_store[req.request_id].finished is True
+
+    # Step 4: next build_connector_meta consumes the pending flush.
+    sched_out2 = make_scheduler_output({})
+    meta2 = sched.build_connector_meta(sched_out2)
+    assert meta2.store_event >= 0, "Flush should produce a store event"
+    assert len(meta2.store_gpu_blocks) == 1, "Exactly block 1 should be flushed"
+    assert len(sched._pending_flush_gpu_blocks) == 0, "Pending flush must be cleared"
+
+    simulate_store_completion(sched, meta2.store_event)
+
+    # State cleaned up after the flush store event completes.
+    assert req.request_id not in sched._reqs_to_store
+
+    # Block 1's hash must now be discoverable in the CPU cache.
+    bhash1_with_group = make_block_hash_with_group_id(req.block_hashes[1], 0)
+    cached = sched.cpu_block_pool.cached_block_hash_to_block.get_one_block(
+        bhash1_with_group
+    )
+    assert cached is not None, (
+        "Block 1 should be in CPU cache after flush-on-finish store completes"
+    )

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -151,6 +151,14 @@ class SimpleCPUOffloadScheduler:
         self._load_event_counter: int = 0
         self._store_event_counter: int = 0
 
+        # Flush-on-finish (eager mode only): blocks queued by request_finished
+        # that were confirmed this step (after _update_after_schedule) but
+        # missed by build_connector_meta (which ran before _update_after_schedule).
+        # Consumed and merged into the next build_connector_meta store event.
+        self._pending_flush_gpu_blocks: list[int] = []
+        self._pending_flush_cpu_blocks: list[int] = []
+        self._pending_flush_req_ids: list[str] = []
+
         # For TP/PP: track partial store completions across steps.
         # Events must be reported by all world_size workers before considered complete.
         self._expected_worker_count = vllm_config.parallel_config.world_size
@@ -322,6 +330,19 @@ class SimpleCPUOffloadScheduler:
         # --- Stores ---
         store_event = -1
         store_gpu, store_cpu, store_req_ids = self.prepare_store_specs(scheduler_output)
+
+        # Merge any blocks queued by _flush_final_blocks_on_finish (eager mode).
+        # These are blocks whose KV data was confirmed after build_connector_meta
+        # ran in the previous step (because _update_after_schedule fires after
+        # build_connector_meta), so they couldn't be included then.
+        if not self._lazy_mode and self._pending_flush_gpu_blocks:
+            store_gpu = store_gpu + self._pending_flush_gpu_blocks
+            store_cpu = store_cpu + self._pending_flush_cpu_blocks
+            store_req_ids = store_req_ids + self._pending_flush_req_ids
+            self._pending_flush_gpu_blocks = []
+            self._pending_flush_cpu_blocks = []
+            self._pending_flush_req_ids = []
+
         if store_gpu:
             store_event = self._store_event_counter
             self._store_event_counter += 1
@@ -654,6 +675,94 @@ class SimpleCPUOffloadScheduler:
         """Return True if there are in-flight store transfers."""
         return bool(self._store_event_to_blocks)
 
+    def _flush_final_blocks_on_finish(self, request: "Request") -> bool:
+        """Queue any final confirmed blocks for the next store event.
+
+        Called from request_finished() before the cleanup check. At that
+        point _update_after_schedule() has already advanced
+        request.num_computed_tokens, so the last full block computed during
+        this step is now confirmed and eligible for offload — but it was
+        invisible to build_connector_meta(), which ran before
+        _update_after_schedule().
+
+        Returns True if any blocks were queued, False otherwise.
+        """
+        req_id = request.request_id
+        state = self._reqs_to_store.get(req_id)
+        if state is None or state.finished:
+            return False
+
+        gpu_block_pool = self._gpu_block_pool
+        if gpu_block_pool is None:
+            return False
+
+        cpu_block_pool = self.cpu_block_pool
+        kv_cache_groups = self.cpu_kv_cache_config.kv_cache_groups
+        num_groups = len(kv_cache_groups)
+        num_free = cpu_block_pool.get_num_free_blocks()
+
+        confirmed_tokens = request.num_computed_tokens - request.num_output_placeholders
+
+        gpu_block_ids: list[int] = []
+        block_hashes_to_store: list[bytes] = []
+        out_of_space = False
+
+        for g in range(num_groups):
+            if out_of_space:
+                break
+            already_stored_g = state.num_stored_blocks[g]
+            group_gpu_ids = state.block_ids[g]
+            g_block_size = kv_cache_groups[g].kv_cache_spec.block_size
+            ready_blocks_g = confirmed_tokens // g_block_size
+            scannable = group_gpu_ids[already_stored_g:ready_blocks_g]
+
+            advanced = 0
+            for gpu_block_id in scannable:
+                gpu_block = gpu_block_pool.blocks[gpu_block_id]
+                if gpu_block.is_null:
+                    advanced += 1
+                    continue
+                bhash_with_group = gpu_block.block_hash
+                if bhash_with_group is None:
+                    break
+                if (
+                    cpu_block_pool.cached_block_hash_to_block.get_one_block(
+                        bhash_with_group
+                    )
+                    is not None
+                ):
+                    advanced += 1
+                    continue
+                if num_free <= 0:
+                    out_of_space = True
+                    break
+                num_free -= 1
+                gpu_block_ids.append(gpu_block_id)
+                block_hashes_to_store.append(bhash_with_group)
+                advanced += 1
+            state.num_stored_blocks[g] += advanced
+
+        if not gpu_block_ids:
+            return False
+
+        cpu_blocks_alloc = cpu_block_pool.get_new_blocks(len(gpu_block_ids))
+        cpu_block_ids = [blk.block_id for blk in cpu_blocks_alloc]
+        for cpu_blk, bhash in zip(cpu_blocks_alloc, block_hashes_to_store):
+            cpu_blk._block_hash = bhash  # type: ignore[assignment]
+
+        gpu_block_pool.touch([gpu_block_pool.blocks[bid] for bid in gpu_block_ids])
+
+        self._pending_flush_gpu_blocks.extend(gpu_block_ids)
+        self._pending_flush_cpu_blocks.extend(cpu_block_ids)
+        self._pending_flush_req_ids.append(req_id)
+
+        logger.debug(
+            "Flush on finish: Request %s queued %d final block(s) for CPU offload",
+            req_id,
+            len(cpu_block_ids),
+        )
+        return True
+
     def request_finished(
         self,
         request: "Request",
@@ -671,12 +780,13 @@ class SimpleCPUOffloadScheduler:
             else:
                 self._cleanup_load_request(req_id)
 
-        # Handle store (eager mode only): defer cleanup if stores in-flight
+        # Handle store (eager mode only): flush final block then defer or cleanup
         if not self._lazy_mode:
+            has_pending_flush = self._flush_final_blocks_on_finish(request)
             store_state = self._reqs_to_store.get(req_id)
             if store_state is not None:
-                if store_state.store_events:
-                    store_state.finished = True  # Defer: stores in-flight
+                if store_state.store_events or has_pending_flush:
+                    store_state.finished = True
                 else:
                     self._cleanup_store_request(req_id)
 

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -472,7 +472,8 @@ class SimpleCPUOffloadScheduler:
         Only considers blocks whose KV data has been **confirmed computed** by
         the GPU. This means blocks from the current step are NOT stored until the
         next step. If a request finishes in the same step as its last full block,
-        that block may be missed. (TODO: flush on finish.)
+        ``_flush_final_blocks_on_finish`` handles the offload via the pending
+        flush path in ``build_connector_meta``.
 
         Returns:
             (gpu_block_ids, cpu_block_ids, req_ids) for the store event.


### PR DESCRIPTION
## Summary

Fixes #41704.

In eager mode, `SimpleCPUOffloadScheduler` silently drops the last full KV block of a request when that block is computed in the **same scheduler step** that the request finishes.

**Root cause:** `build_connector_meta` → `_prepare_eager_store_specs` runs *before* `_update_after_schedule` advances `request.num_computed_tokens`. The newly-confirmed block from the current step is therefore invisible to the store planner. When the request then finishes in that same step, `request_finished` previously only deferred cleanup for already in-flight stores and never flushed the newly confirmed block. The next `build_connector_meta` call never sees the request again (it's being cleaned up), so the block is permanently dropped.

## Changes

**`vllm/v1/simple_kv_offload/manager.py`**

- Add `_pending_flush_{gpu,cpu,req}_*` lists to buffer blocks queued by `_flush_final_blocks_on_finish`.
- Add `_flush_final_blocks_on_finish(request)`: called from `request_finished` (eager mode only) after `_update_after_schedule` has already advanced `num_computed_tokens`. Scans for any unconfirmed-but-now-complete full blocks using the updated token count, allocates CPU blocks, `touch()`-es the GPU blocks to prevent early eviction, and enqueues the pairs in `_pending_flush_*`.
- `request_finished`: call `_flush_final_blocks_on_finish` before the cleanup check; defer `_cleanup_store_request` if a flush was queued (`has_pending_flush`), so the state stays alive until the flush store event completes.
- `build_connector_meta`: after `prepare_store_specs`, merge any `_pending_flush_*` blocks into the regular store lists before creating the store event. The existing `store_req_ids` → `store_state.store_events` tracking then handles deferred cleanup correctly.

**`tests/v1/simple_kv_offload/test_scheduler.py`**

- Add `test_eager_flush_final_block_on_finish` (Test 11): reproduces the exact scheduler ordering (build_connector_meta before _update_after_schedule), verifies that `_pending_flush_gpu_blocks` is populated after `request_finished`, that the next `build_connector_meta` emits a store event for the flush, and that block 1's hash is discoverable in the CPU cache after the store completes.

## Test plan

- [ ] `pytest tests/v1/simple_kv_offload/test_scheduler.py -v` — all 11 tests pass
- [ ] Existing tests `test_eager_store_and_load_roundtrip`, `test_eager_store_preemption_cleanup`, `test_inflight_finish_deferred_cleanup` continue to pass (deferred-cleanup paths unchanged)