### PR TITLE
[KV Offload] Expose SimpleCPU offload metrics

### DIFF
--- a/docs/usage/metrics.md
+++ b/docs/usage/metrics.md
@@ -45,6 +45,28 @@ The following metrics are exposed:
 
 --8<-- "docs/generated/metrics/nixl_connector.inc.md"
 
+## SimpleCPU KV Offload Metrics
+
+When `SimpleCPUOffloadConnector` is enabled, vLLM exposes KV transfer metrics
+through the existing `vllm:kv_offload_*` metric family with
+`transfer_type="GPU_to_CPU"` for stores into CPU memory and
+`transfer_type="CPU_to_GPU"` for loads back into GPU memory.
+
+The connector also reports CPU pool state:
+
+| Metric Name | Type | Description |
+|-------------|------|-------------|
+| `vllm:simple_cpu_offload_total_blocks` | Gauge | Total usable CPU KV cache blocks managed by `SimpleCPUOffloadConnector`. |
+| `vllm:simple_cpu_offload_free_blocks` | Gauge | Free usable CPU KV cache blocks managed by `SimpleCPUOffloadConnector`. |
+| `vllm:simple_cpu_offload_used_blocks` | Gauge | Used usable CPU KV cache blocks managed by `SimpleCPUOffloadConnector`. |
+| `vllm:simple_cpu_offload_usage_perc` | Gauge | CPU KV cache usage for `SimpleCPUOffloadConnector`; `1` means 100 percent usage. |
+| `vllm:simple_cpu_offload_pending_loads` | Gauge | Requests with pending CPU-to-GPU loads. |
+| `vllm:simple_cpu_offload_pending_stores` | Gauge | Store events pending worker completion. |
+
+`CPU_to_GPU` transfer samples appear only when the workload forces replay after
+GPU cache eviction. If the GPU KV cache can hold the workload, only
+`GPU_to_CPU` stores may be observed.
+
 ## Model Flops Utilization (MFU) Performance Metrics
 
 These metrics are available via `--enable-mfu-metrics`:

--- a/tests/v1/simple_kv_offload/test_metrics.py
+++ b/tests/v1/simple_kv_offload/test_metrics.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for SimpleCPUOffloadConnector metrics."""
+
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
+    OffloadingConnectorStats,
+    OffloadingOperationMetrics,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.simple_cpu_offload_connector import (
+    SimpleCPUOffloadConnector,
+    SimpleCPUOffloadConnectorStats,
+)
+from vllm.v1.simple_kv_offload.worker import SimpleCPUOffloadWorker
+
+
+def test_build_kv_connector_stats_with_none():
+    stats = SimpleCPUOffloadConnector.build_kv_connector_stats(data=None)
+
+    assert stats is not None
+    assert isinstance(stats, SimpleCPUOffloadConnectorStats)
+    assert stats.is_empty()
+
+
+def test_build_kv_connector_stats_reconstructs_serialized_payload():
+    serialized_data = {
+        "CPU_to_GPU": [
+            {"op_size": 16, "op_time": 1.0},
+            {"op_size": 8, "op_time": 0.5},
+        ],
+        "GPU_to_CPU": [{"op_size": 4, "op_time": 0.25}],
+    }
+
+    stats = SimpleCPUOffloadConnector.build_kv_connector_stats(data=serialized_data)
+
+    assert isinstance(stats, SimpleCPUOffloadConnectorStats)
+    assert stats.data == serialized_data
+
+
+def test_simple_cpu_offload_stats_aggregate_and_reduce_transfers_and_pool():
+    stats1 = SimpleCPUOffloadConnectorStats(
+        data={
+            "CPU_to_GPU": [{"op_size": 16, "op_time": 1.0}],
+            "GPU_to_CPU": [{"op_size": 4, "op_time": 0.25}],
+            "cpu_pool_total_blocks": 8,
+            "cpu_pool_free_blocks": 6,
+            "cpu_pool_used_blocks": 2,
+            "cpu_pool_usage_perc": 0.25,
+        }
+    )
+    stats2 = SimpleCPUOffloadConnectorStats(
+        data={
+            "CPU_to_GPU": [{"op_size": 8, "op_time": 0.5}],
+            "GPU_to_CPU": [{"op_size": 12, "op_time": 0.75}],
+            "cpu_pool_total_blocks": 8,
+            "cpu_pool_free_blocks": 4,
+            "cpu_pool_used_blocks": 4,
+            "cpu_pool_usage_perc": 0.5,
+        }
+    )
+
+    stats1.aggregate(stats2)
+    reduced = stats1.reduce()
+
+    assert reduced["CPU_to_GPU_total_bytes"] == 24
+    assert reduced["CPU_to_GPU_total_time"] == 1.5
+    assert reduced["GPU_to_CPU_total_bytes"] == 16
+    assert reduced["GPU_to_CPU_total_time"] == 1.0
+    assert reduced["cpu_pool_total_blocks"] == 8
+    assert reduced["cpu_pool_free_blocks"] == 4
+    assert reduced["cpu_pool_used_blocks"] == 4
+    assert reduced["cpu_pool_usage_perc"] == 0.5
+
+
+def test_worker_get_kv_connector_stats_returns_once_then_resets():
+    worker = SimpleCPUOffloadWorker(
+        vllm_config=None,  # type: ignore[arg-type]
+        kv_cache_config=None,
+        cpu_capacity_bytes=1024,
+    )
+    worker.kv_connector_stats.record_transfer(16, 1.0, ("CPU", "GPU"))
+
+    stats = worker.get_kv_connector_stats()
+    assert isinstance(stats, OffloadingConnectorStats)
+    assert stats.data == {
+        "CPU_to_GPU": [OffloadingOperationMetrics(op_size=16, op_time=1.0)]
+    }
+
+    assert worker.get_kv_connector_stats() is None

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -15,6 +15,16 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorRole,
     SupportsHMA,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    KVConnectorPromMetrics,
+    KVConnectorStats,
+    PromMetric,
+    PromMetricT,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
+    OffloadingConnectorStats,
+    OffloadPromMetrics,
+)
 from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.outputs import KVConnectorOutput
@@ -40,6 +50,122 @@ logger = init_logger(__name__)
 
 # Default CPU capacity: 8 GB
 DEFAULT_CPU_CAPACITY_BYTES = 8 * (1024**3)
+
+
+class SimpleCPUOffloadConnectorStats(OffloadingConnectorStats):
+    """Transfer and CPU-pool stats for SimpleCPUOffloadConnector."""
+
+    CPU_POOL_KEYS = {
+        "cpu_pool_total_blocks",
+        "cpu_pool_free_blocks",
+        "cpu_pool_used_blocks",
+        "cpu_pool_usage_perc",
+        "pending_loads",
+        "pending_stores",
+    }
+
+    def aggregate(self, other: KVConnectorStats) -> KVConnectorStats:
+        if other.is_empty():
+            return self
+        for key, value in other.data.items():
+            if key in self.CPU_POOL_KEYS:
+                self.data[key] = value
+                continue
+            if key not in self.data:
+                self.data[key] = value
+            else:
+                accumulator = self.data[key]
+                assert isinstance(accumulator, list)
+                assert isinstance(value, list)
+                accumulator.extend(value)
+        return self
+
+    def reduce(self) -> dict[str, int | float]:
+        transfer_data = {
+            key: value
+            for key, value in self.data.items()
+            if key not in self.CPU_POOL_KEYS
+        }
+        reduced = OffloadingConnectorStats(data=transfer_data).reduce()
+        reduced.update(
+            {
+                key: value
+                for key, value in self.data.items()
+                if key in self.CPU_POOL_KEYS
+            }
+        )
+        return reduced
+
+
+class SimpleCPUOffloadPromMetrics(OffloadPromMetrics):
+    """Prometheus metrics for SimpleCPUOffloadConnector."""
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        metric_types: dict[type[PromMetric], type[PromMetricT]],
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[object]],
+    ):
+        super().__init__(vllm_config, metric_types, labelnames, per_engine_labelvalues)
+
+        self.gauges: dict[str, dict[int, PromMetricT]] = {}
+        for name, documentation in {
+            "vllm:simple_cpu_offload_total_blocks": (
+                "Total usable CPU KV cache blocks managed by "
+                "SimpleCPUOffloadConnector."
+            ),
+            "vllm:simple_cpu_offload_free_blocks": (
+                "Free usable CPU KV cache blocks managed by "
+                "SimpleCPUOffloadConnector."
+            ),
+            "vllm:simple_cpu_offload_used_blocks": (
+                "Used usable CPU KV cache blocks managed by "
+                "SimpleCPUOffloadConnector."
+            ),
+            "vllm:simple_cpu_offload_usage_perc": (
+                "CPU KV cache usage for SimpleCPUOffloadConnector. "
+                "1 means 100 percent usage."
+            ),
+            "vllm:simple_cpu_offload_pending_loads": (
+                "Requests with pending CPU-to-GPU loads in "
+                "SimpleCPUOffloadConnector."
+            ),
+            "vllm:simple_cpu_offload_pending_stores": (
+                "Store events pending worker completion in "
+                "SimpleCPUOffloadConnector."
+            ),
+        }.items():
+            gauge = self._gauge_cls(
+                name=name,
+                documentation=documentation,
+                multiprocess_mode="mostrecent",
+                labelnames=labelnames,
+            )
+            self.gauges[name] = {
+                idx: gauge.labels(*per_engine_labelvalues[idx])
+                for idx in per_engine_labelvalues
+            }
+
+    def observe(self, transfer_stats_data: dict[str, Any], engine_idx: int = 0):
+        mapping = {
+            "cpu_pool_total_blocks": "vllm:simple_cpu_offload_total_blocks",
+            "cpu_pool_free_blocks": "vllm:simple_cpu_offload_free_blocks",
+            "cpu_pool_used_blocks": "vllm:simple_cpu_offload_used_blocks",
+            "cpu_pool_usage_perc": "vllm:simple_cpu_offload_usage_perc",
+            "pending_loads": "vllm:simple_cpu_offload_pending_loads",
+            "pending_stores": "vllm:simple_cpu_offload_pending_stores",
+        }
+        transfer_data = {
+            key: value
+            for key, value in transfer_stats_data.items()
+            if key not in mapping
+        }
+        if transfer_data:
+            super().observe(transfer_data, engine_idx)
+        for data_key, metric_name in mapping.items():
+            if data_key in transfer_stats_data:
+                self.gauges[metric_name][engine_idx].set(transfer_stats_data[data_key])
 
 
 class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
@@ -237,6 +363,31 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
         if self.scheduler_manager is not None:
             return self.scheduler_manager.take_events()
         return []
+
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        if self.worker_handler is not None:
+            return self.worker_handler.get_kv_connector_stats()
+        if self.scheduler_manager is not None:
+            return self.scheduler_manager.get_kv_connector_stats()
+        return None
+
+    @classmethod
+    def build_kv_connector_stats(
+        cls, data: dict[str, Any] | None = None
+    ) -> KVConnectorStats | None:
+        return SimpleCPUOffloadConnectorStats(data=data or {})
+
+    @classmethod
+    def build_prom_metrics(
+        cls,
+        vllm_config: VllmConfig,
+        metric_types: dict[type[PromMetric], type[PromMetricT]],
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[object]],
+    ) -> KVConnectorPromMetrics:
+        return SimpleCPUOffloadPromMetrics(
+            vllm_config, metric_types, labelnames, per_engine_labelvalues
+        )
 
     def reset_cache(self) -> bool | None:
         raise NotImplementedError(

--- a/vllm/v1/simple_kv_offload/copy_backend.py
+++ b/vllm/v1/simple_kv_offload/copy_backend.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import queue
 import threading
+from dataclasses import dataclass
 
 import torch
 
@@ -18,6 +19,15 @@ from vllm.v1.simple_kv_offload.cuda_mem_ops import (
 )
 
 logger = init_logger(__name__)
+
+
+@dataclass
+class DmaCopyEvent:
+    event_idx: int
+    start_event: torch.Event
+    end_event: torch.Event
+    num_bytes: int
+    is_store: bool
 
 
 class DmaCopyBackend:
@@ -60,12 +70,21 @@ class DmaCopyBackend:
         dst_blocks: list[int],
         is_store: bool,
         event_idx: int,
-        events_list: list[tuple[int, torch.Event]],
+        events_list: list[DmaCopyEvent],
     ) -> None:
         params = self._store_params if is_store else self._load_params
         assert params is not None and self._queue is not None
+        num_bytes = int(len(src_blocks) * sum(params.bpb))
         self._queue.put(
-            (src_blocks, dst_blocks, params, is_store, event_idx, events_list)
+            (
+                src_blocks,
+                dst_blocks,
+                params,
+                is_store,
+                event_idx,
+                events_list,
+                num_bytes,
+            )
         )
 
     def shutdown(self) -> None:
@@ -89,9 +108,27 @@ class DmaCopyBackend:
             item = q.get()
             if item is None:
                 return
-            src_blocks, dst_blocks, params, is_store, event_idx, events_list = item
-            copy_blocks(src_blocks, dst_blocks, params)
+            (
+                src_blocks,
+                dst_blocks,
+                params,
+                is_store,
+                event_idx,
+                events_list,
+                num_bytes,
+            ) = item
             stream = store_stream if is_store else load_stream
-            event = torch.Event()
-            event.record(stream)
-            events_list.append((event_idx, event))
+            start_event = torch.Event(enable_timing=True)
+            end_event = torch.Event(enable_timing=True)
+            start_event.record(stream)
+            copy_blocks(src_blocks, dst_blocks, params)
+            end_event.record(stream)
+            events_list.append(
+                DmaCopyEvent(
+                    event_idx=event_idx,
+                    start_event=start_event,
+                    end_event=end_event,
+                    num_bytes=num_bytes,
+                    is_store=is_store,
+                )
+            )

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from vllm.config import VllmConfig
 from vllm.distributed.kv_events import KVCacheEvent
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
 from vllm.distributed.kv_transfer.kv_connector.utils import yield_req_data
 from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
@@ -740,3 +741,23 @@ class SimpleCPUOffloadScheduler:
 
     def take_events(self) -> Iterable[KVCacheEvent]:
         return self.cpu_block_pool.take_events()
+
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        from vllm.distributed.kv_transfer.kv_connector.v1.simple_cpu_offload_connector import (  # noqa: E501
+            SimpleCPUOffloadConnectorStats,
+        )
+
+        total_blocks = max(0, self.cpu_block_pool.num_gpu_blocks - 1)
+        free_blocks = self.cpu_block_pool.get_num_free_blocks()
+        used_blocks = max(0, total_blocks - free_blocks)
+        usage = used_blocks / total_blocks if total_blocks else 0.0
+        return SimpleCPUOffloadConnectorStats(
+            data={
+                "cpu_pool_total_blocks": total_blocks,
+                "cpu_pool_free_blocks": free_blocks,
+                "cpu_pool_used_blocks": used_blocks,
+                "cpu_pool_usage_perc": usage,
+                "pending_loads": len(self._reqs_to_load),
+                "pending_stores": len(self._store_event_to_blocks),
+            }
+        )

--- a/vllm/v1/simple_kv_offload/worker.py
+++ b/vllm/v1/simple_kv_offload/worker.py
@@ -7,9 +7,14 @@ from typing import TYPE_CHECKING
 import torch
 
 from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import KVConnectorStats
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
+    OffloadingConnectorStats,
+)
 from vllm.logger import init_logger
 from vllm.utils.platform_utils import is_pin_memory_available
-from vllm.v1.simple_kv_offload.copy_backend import DmaCopyBackend
+from vllm.v1.kv_offload.worker.worker import TransferType
+from vllm.v1.simple_kv_offload.copy_backend import DmaCopyBackend, DmaCopyEvent
 from vllm.v1.simple_kv_offload.cuda_mem_ops import pin_tensor
 from vllm.v1.simple_kv_offload.metadata import (
     SimpleCPUOffloadMetadata,
@@ -46,9 +51,10 @@ class SimpleCPUOffloadWorker:
 
         self._backend = DmaCopyBackend()
 
-        # Ordered (event_idx, Event). Events pre-allocated on main thread.
-        self._load_events: list[tuple[int, torch.Event]] = []
-        self._store_events: list[tuple[int, torch.Event]] = []
+        # Ordered completed-copy events. Events are pre-allocated in the copy
+        # thread and polled here from the worker path.
+        self._load_events: list[DmaCopyEvent] = []
+        self._store_events: list[DmaCopyEvent] = []
         # High-water marks: highest event_idx completed per stream.
         # When the event list is empty, the hwm covers all prior events.
         self._load_hwm: int = -1
@@ -62,6 +68,7 @@ class SimpleCPUOffloadWorker:
         self._pending_store_event_indices: set[int] = set()
         # Completed store events to report via build_connector_worker_meta
         self._completed_store_events: dict[int, int] = {}
+        self.kv_connector_stats = OffloadingConnectorStats()
 
     def register_kv_caches(
         self,
@@ -268,6 +275,13 @@ class SimpleCPUOffloadWorker:
         self._completed_store_events = {}
         return meta
 
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        if self.kv_connector_stats.is_empty():
+            return None
+        kv_connector_stats = self.kv_connector_stats
+        self.kv_connector_stats = OffloadingConnectorStats()
+        return kv_connector_stats
+
     def handle_preemptions(
         self, kv_connector_metadata: SimpleCPUOffloadMetadata
     ) -> None:
@@ -278,14 +292,16 @@ class SimpleCPUOffloadWorker:
 
     def _flush_and_sync_all(self) -> None:
         """Synchronize all in-flight transfer events."""
-        for event_idx, event in self._load_events:
-            event.synchronize()
-            self._load_hwm = event_idx
+        for copy_event in self._load_events:
+            copy_event.end_event.synchronize()
+            self._record_copy_event(copy_event)
+            self._load_hwm = copy_event.event_idx
         self._load_events.clear()
 
-        for event_idx, event in self._store_events:
-            event.synchronize()
-            self._store_hwm = event_idx
+        for copy_event in self._store_events:
+            copy_event.end_event.synchronize()
+            self._record_copy_event(copy_event)
+            self._store_hwm = copy_event.event_idx
         self._store_events.clear()
 
     def _poll_stream_events(self, is_store: bool) -> int:
@@ -293,13 +309,25 @@ class SimpleCPUOffloadWorker:
         events = self._store_events if is_store else self._load_events
         hwm = self._store_hwm if is_store else self._load_hwm
         while events:
-            event_idx, event = events[0]
-            if not event.query():
+            copy_event = events[0]
+            if not copy_event.end_event.query():
                 break
-            hwm = event_idx
+            self._record_copy_event(copy_event)
+            hwm = copy_event.event_idx
             events.pop(0)
         if is_store:
             self._store_hwm = hwm
         else:
             self._load_hwm = hwm
         return hwm
+
+    def _record_copy_event(self, copy_event: DmaCopyEvent) -> None:
+        transfer_type: TransferType = (
+            ("GPU", "CPU") if copy_event.is_store else ("CPU", "GPU")
+        )
+        transfer_time = (
+            copy_event.start_event.elapsed_time(copy_event.end_event) * 1e-3
+        )
+        self.kv_connector_stats.record_transfer(
+            copy_event.num_bytes, transfer_time, transfer_type
+        )


### PR DESCRIPTION
## What changed
Expose Prometheus metrics for `SimpleCPUOffloadConnector` CPU KV offload.

The connector now reports:
- transfer bytes/time/size through existing `vllm:kv_offload_*` metrics
- `transfer_type="GPU_to_CPU"` and `transfer_type="CPU_to_GPU"`
- SimpleCPU pool total/free/used blocks
- SimpleCPU pool usage percentage
- pending load/store counts

## Why
`SimpleCPUOffloadConnector` already moves KV blocks between GPU and pinned CPU memory, but operators cannot observe transfer direction, bytes, timing, CPU pool usage, or pending load/store state.

This keeps the metrics in the existing KV connector metrics path rather than adding a separate runtime-specific telemetry path.

Refs #33689.

## Validation
- `git diff --check`: passed
- `py_compile` on changed Python files: passed
- `tests/v1/simple_kv_offload/test_metrics.py`: 4 passed in the CUDA validation environment
- T4 CUDA server smoke test:
  - Run A exact params: `GPU_to_CPU = 18.3 MB`; `CPU_to_GPU` absent because workload did not force reload
  - Run B eviction pressure: `GPU_to_CPU = 1.85 GB`, `CPU_to_GPU = 1.32 GB`, all 90 requests returned 200
- Metrics verified through `/metrics`
- Runtime path used `cuMemcpyBatchAsync` resolved through `cuGetProcAddress`

## Known limitations
- T4 validates CUDA correctness and server-path metrics wiring, not Hopper/Blackwell production performance.
- `CPU_to_GPU` appears only when the workload forces replay after GPU eviction.
- This PR does not claim ROCm or XPU support for the CUDA-specific SimpleCPU copy path.