### PR TITLE
Add multimodal embed task-prefix docs and tests

### DIFF
--- a/docs/models/pooling_models/embed.md
+++ b/docs/models/pooling_models/embed.md
@@ -450,15 +450,27 @@ The `truncate` parameter controls how inputs exceeding the model's maximum seque
 
 #### Input type and prompt prefixes
 
-The `input_type` field selects a prompt prefix to prepend to each text input. The available values
-depend on the model:
+The `input_type` field selects a model-specific prompt prefix. The available values depend on
+the model:
 
 - **Models with `task_instructions` in `config.json`**: The keys from the `task_instructions` dict are
-  the valid `input_type` values and the corresponding value is prepended to each text.
+  the valid `input_type` values.
 - **Models with `config_sentence_transformers.json` prompts**: The keys from the `prompts` dict are
   the valid `input_type` values. For example, `Snowflake/snowflake-arctic-embed-xs` defines `"query"`,
   so setting `input_type: "query"` prepends `"Represent this sentence for searching relevant passages: "`.
 - **Other models**: `input_type` is not accepted and will raise a validation error if passed.
+
+For text-only requests without a chat template, vLLM prepends the selected prompt prefix to each
+text before tokenization. When a chat template is used, including for multimodal embedding models,
+vLLM passes the selected prompt prefix as a `system` message and keeps the embedding input in one
+`user` message. A multimodal embedding chat template that supports `/v2/embed` with `input_type`
+should therefore accept an optional leading `system` message for the task prefix and exactly one
+non-system payload message containing the text and image parts to embed.
+
+This is the same message shape callers can use directly with `/v1/embeddings` `messages`: a
+`system` task-prefix message followed by one `user` payload message. For example, `/v2/embed` with
+`input_type: "query"` should render equivalently to a `/v1/embeddings` request whose first message
+contains the model's query prefix.
 
 ## More examples
 

--- a/tests/entrypoints/pooling/embed/test_io_processor.py
+++ b/tests/entrypoints/pooling/embed/test_io_processor.py
@@ -112,6 +112,58 @@ class TestApplyStPrompt:
         assert handler._apply_task_instruction(texts, "passage") is texts
 
 
+class TestMixedInputToMessages:
+    """Unit tests for EmbedIOProcessor._mixed_input_to_messages."""
+
+    def test_task_prefix_uses_system_message(self):
+        messages = EmbedIOProcessor._mixed_input_to_messages(
+            CohereEmbedInput(content=[CohereEmbedContent(type="text", text="hello")]),
+            task_prefix="query: ",
+        )
+
+        assert messages == [
+            {
+                "role": "system",
+                "content": [{"type": "text", "text": "query: "}],
+            },
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "hello"}],
+            },
+        ]
+
+    def test_task_prefix_keeps_mixed_payload_in_user_message(self):
+        messages = EmbedIOProcessor._mixed_input_to_messages(
+            CohereEmbedInput(
+                content=[
+                    CohereEmbedContent(type="text", text="describe this"),
+                    CohereEmbedContent(
+                        type="image_url",
+                        image_url={"url": "data:image/png;base64,AAA"},
+                    ),
+                ]
+            ),
+            task_prefix="query: ",
+        )
+
+        assert messages == [
+            {
+                "role": "system",
+                "content": [{"type": "text", "text": "query: "}],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe this"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,AAA"},
+                    },
+                ],
+            },
+        ]
+
+
 class TestLoadTaskInstructions:
     """Unit tests for EmbedIOProcessor._load_task_instructions."""
 
@@ -316,6 +368,62 @@ class TestPreProcessCohereOnline:
                             CohereEmbedInput(
                                 content=[CohereEmbedContent(type="text", text="hello")]
                             ),
+                            task_prefix="query: ",
+                        )
+                    ],
+                    "truncate_prompt_tokens": -1,
+                    "truncation_side": None,
+                },
+            )
+        ]
+
+    def test_mixed_inputs_with_task_prefix_use_system_message(self):
+        handler = self._make_handler()
+        mixed_input = CohereEmbedInput(
+            content=[
+                CohereEmbedContent(type="text", text="describe this"),
+                CohereEmbedContent(
+                    type="image_url",
+                    image_url={"url": "data:image/png;base64,AAA"},
+                ),
+            ]
+        )
+        ctx = self._make_context(inputs=[mixed_input], input_type="query")
+        calls: list[tuple[str, object]] = []
+
+        def batch_render_chat(
+            request,
+            all_messages,
+            truncate_prompt_tokens,
+            truncation_side,
+        ):
+            calls.append(
+                (
+                    "chat",
+                    {
+                        "request": request,
+                        "all_messages": all_messages,
+                        "truncate_prompt_tokens": truncate_prompt_tokens,
+                        "truncation_side": truncation_side,
+                    },
+                )
+            )
+            return ["chat"]
+
+        handler._get_task_instruction_prefix = lambda _input_type: "query: "
+        handler._batch_render_chat = batch_render_chat
+
+        handler._pre_process_cohere_online(ctx)
+
+        assert ctx.engine_inputs == ["chat"]
+        assert calls == [
+            (
+                "chat",
+                {
+                    "request": ctx.request,
+                    "all_messages": [
+                        handler._mixed_input_to_messages(
+                            mixed_input,
                             task_prefix="query: ",
                         )
                     ],


### PR DESCRIPTION
## Purpose

Refs #40616

Add vLLM-side regression coverage and documentation for the multimodal embedding chat-template contract used with Cohere `/v2/embed` `input_type` task prefixes.

The checkpoint-side fix for `nvidia/llama-nemotron-embed-vl-1b-v2` is being handled in https://huggingface.co/nvidia/llama-nemotron-embed-vl-1b-v2/discussions/8. With that model-side change, vLLM can keep its existing behavior: resolve `input_type` through `task_instructions`, pass the resolved prefix as a `system` message when rendering a chat template, and keep the text/image payload in one non-system user message.

This PR does not reintroduce the inline-prefix heuristic from the closed PR #40866. It only documents the expected template behavior and adds focused tests for the current message shape.

## Duplicate checks

- `gh issue view 40616 --repo vllm-project/vllm --json number,title,state,assignees,comments,url`
  - Issue is open.
- `gh pr list --repo vllm-project/vllm --state open --search "40616 in:body"`
  - No open PRs found.
- `gh pr list --repo vllm-project/vllm --state open --search "multimodal embedding chat template"`
  - Returned unrelated open PRs; none cover this issue's vLLM-side tests/docs follow-up.

## Test Plan

- Run focused unit tests for the embedding IO processor.
- Run ruff check and format hooks on the modified files.
- Manually validate the local patched Nemotron Embed VL checkpoint using the checkpoint-side template/config change from the Hugging Face discussion.

## Test Results

`.venv/bin/python -m pytest tests/entrypoints/pooling/embed/test_io_processor.py -v`

Result: `31 passed, 2 warnings in 6.49s`

`pre-commit run ruff-check --files tests/entrypoints/pooling/embed/test_io_processor.py docs/models/pooling_models/embed.md`

Result: `ruff check Passed`

`pre-commit run ruff-format --files tests/entrypoints/pooling/embed/test_io_processor.py docs/models/pooling_models/embed.md`

Result: `ruff format Passed`

Commit-time pre-commit hooks also passed on the staged files.

Manual validation:

- Served local patched `nvidia/llama-nemotron-embed-vl-1b-v2` checkpoint without passing `--chat-template`.
- Verified `/v1/embeddings` with top-level `messages` containing a `system` task-prefix message followed by one `user` payload message returns embeddings.
- Verified the local patched model config/template matches the checkpoint-side direction in the Hugging Face discussion.
<img width="2439" height="1329" alt="31594e63-8333-402e-8f2a-4231d4fa8310" src="https://github.com/user-attachments/assets/48b2147e-fef1-4444-9b0a-70a40cf45f67" />
<img width="2097" height="1296" alt="fdf91a9e-1dcd-43dd-bacf-ea1584768095" src="https://github.com/user-attachments/assets/76200dee-9993-4af7-9cd5-1b0bc26657c7" />

AI assistance was used.