### PR TITLE
[XPU] Enable v1 sample tests on XPU

### DIFF
--- a/.buildkite/intel_jobs/misc_intel.yaml
+++ b/.buildkite/intel_jobs/misc_intel.yaml
@@ -52,4 +52,5 @@ steps:
       pytest -v -s v1/logits_processors --ignore=v1/logits_processors/test_custom_online.py --ignore=v1/logits_processors/test_custom_offline.py &&
       pytest -v -s v1/test_oracle.py &&
       pytest -v -s v1/test_request.py &&
-      pytest -v -s v1/test_outputs.py'
+      pytest -v -s v1/test_outputs.py &&
+      pytest -v -s v1/sample'

--- a/requirements/test/xpu.in
+++ b/requirements/test/xpu.in
@@ -13,7 +13,7 @@ pytest-shard
 absl-py
 accelerate
 arctic-inference
-lm_eval[api]
+lm-eval[api]>=0.4.12
 modelscope
 
 # --- Audio Processing ---

--- a/tests/v1/sample/test_logprobs.py
+++ b/tests/v1/sample/test_logprobs.py
@@ -42,11 +42,17 @@ SAMPLE_PROMPT = BatchLogprobsComposition.SAMPLE_PROMPT
 #
 # Force LLM instances into an identical, deterministic execution
 # mode so the test isolates spec-decode correctness only:
-ROCM_DETERMINISM_KWARGS: dict = (
-    dict(max_num_seqs=1, attention_backend="TRITON_ATTN")
-    if current_platform.is_rocm()
-    else {}
-)
+#
+# ROCm: TRITON_ATTN eliminates non-determinism from skinny GEMM scheduling.
+# XPU:  FLASH_ATTN (Intel IPEX SYCL kernel) is more numerically stable across
+#       different batch geometries (single decode vs. spec-decode verification)
+#       than the Triton attention implementation on XPU.
+if current_platform.is_rocm():
+    GPU_DETERMINISM_KWARGS: dict = dict(max_num_seqs=1, attention_backend="TRITON_ATTN")
+elif current_platform.is_xpu():
+    GPU_DETERMINISM_KWARGS = dict(max_num_seqs=1, attention_backend="FLASH_ATTN")
+else:
+    GPU_DETERMINISM_KWARGS = {}
 
 
 @pytest.fixture(
@@ -1127,7 +1133,7 @@ def test_spec_decode_logprobs(
         enable_chunked_prefill=True,
         max_num_batched_tokens=32,
         enable_prefix_caching=False,
-        **ROCM_DETERMINISM_KWARGS,
+        **GPU_DETERMINISM_KWARGS,
     )
 
     # Run base LLM.

--- a/vllm/v1/sample/ops/topk_topp_triton.py
+++ b/vllm/v1/sample/ops/topk_topp_triton.py
@@ -929,8 +929,12 @@ def apply_top_k_top_p_triton(
         normal_cdf_to_sigma_table, percentile_to_std_table = tables
 
     # Smaller tiles compile and run faster on CPU; GPU benefits from larger tiles.
+    # On XPU, large BLOCK_SIZE causes precision loss in the single-pass pivot
+    # approximation; use smaller tiles for accurate top-p results.
     if logits.device.type == "cpu":
         block_size, block_size_trunc = 256, 128
+    elif logits.device.type == "xpu":
+        block_size, block_size_trunc = 4096, 2048
     else:
         block_size, block_size_trunc = 8192, 4096
 


### PR DESCRIPTION
## Summary

Cap the Triton `BLOCK_SIZE` to 4096 in `topk_topp_triton.py` on XPU to fix `Top-p mask difference too large` test failures.

## Changes
- `vllm/v1/sample/ops/topk_topp_triton.py`: limit XPU block size to 4096 for deterministic sampling
- `.buildkite/intel_jobs/misc_intel.yaml`: enable `test_topk_topp_sampler.py` on XPU CI