### PR TITLE
[KV Offload] Expose SimpleCPU offload metrics

### DIFF
--- a/docs/usage/metrics.md
+++ b/docs/usage/metrics.md
@@ -92,7 +92,7 @@ The deprecated `vllm:kv_offload_total_bytes`/`vllm:kv_offload_total_time`/`vllm:
 | `vllm:simple_cpu_offload_free_blocks` | Free CPU KV cache blocks. |
 | `vllm:simple_cpu_offload_used_blocks` | Used CPU KV cache blocks. |
 | `vllm:simple_cpu_offload_usage_perc` | Fraction of CPU KV cache blocks in use, between `0.0` and `1.0` (`1.0` = 100% used). |
-| `vllm:simple_cpu_offload_pending_loads` | Requests with an outstanding CPU-to-GPU load. |
+| `vllm:simple_cpu_offload_pending_loads` | Requests with an outstanding CPU-to-GPU load, including abandoned loads still draining after a cache reset. |
 | `vllm:simple_cpu_offload_pending_stores` | In-flight GPU-to-CPU store events, including abandoned ones still draining. |
 
 These metrics are observability only; they do not change offload behavior or improve performance on their own. The copy path (`cuMemcpyBatchAsync`/`hipMemcpyBatchAsync`) is supported on both CUDA and ROCm.

--- a/docs/usage/metrics.md
+++ b/docs/usage/metrics.md
@@ -51,6 +51,52 @@ These metrics are available via `--enable-mfu-metrics`:
 
 --8<-- "docs/generated/metrics/perf.inc.md"
 
+## SimpleCPU Offload Metrics
+
+These metrics are available when `--kv-transfer-config` selects `SimpleCPUOffloadConnector`, e.g.:
+
+```bash
+vllm serve <model> \
+  --kv-transfer-config '{
+    "kv_connector": "SimpleCPUOffloadConnector",
+    "kv_role": "kv_both",
+    "kv_connector_extra_config": {
+      "cpu_bytes_to_use": 1000000000
+    }
+  }'
+```
+
+### Transfer Metrics
+
+SimpleCPU offload emits the same flat transfer metrics as the generic `OffloadingConnector`. Direction is CPU pinned memory → GPU HBM for load, GPU HBM → CPU pinned memory for store.
+
+| Metric | Type | Description |
+| --- | --- | --- |
+| `vllm:kv_offload_load_bytes` | Counter | Total bytes loaded from CPU to GPU. |
+| `vllm:kv_offload_load_time` | Counter | Total load time, in seconds. DMA execution time only; excludes host preparation and the GPU compute barrier wait. |
+| `vllm:kv_offload_load_size` | Histogram | Size of each load operation, in bytes. |
+| `vllm:kv_offload_store_bytes` | Counter | Total bytes stored from GPU to CPU. |
+| `vllm:kv_offload_store_time` | Counter | Total store time, in seconds. DMA execution time only; excludes host preparation and the GPU compute barrier wait. |
+| `vllm:kv_offload_store_size` | Histogram | Size of each store operation, in bytes. |
+
+The deprecated `vllm:kv_offload_total_bytes`/`vllm:kv_offload_total_time`/`vllm:kv_offload_size` series (labeled with `transfer_type="CPU_to_GPU"` for load and `"GPU_to_CPU"` for store) are still mirrored during the migration to the flat names above. The flat names are canonical; the labeled series is compatibility-only.
+
+!!! note
+    `CPU_to_GPU`/load samples only appear once previously-stored KV blocks are actually reloaded (a GPU eviction followed by a request that hits the same prefix). Their absence under a light workload is expected, not a bug.
+
+### Pool and Pending-Work Gauges
+
+| Metric | Description |
+| --- | --- |
+| `vllm:simple_cpu_offload_total_blocks` | Total usable CPU KV cache blocks (excludes the null block). |
+| `vllm:simple_cpu_offload_free_blocks` | Free CPU KV cache blocks. |
+| `vllm:simple_cpu_offload_used_blocks` | Used CPU KV cache blocks. |
+| `vllm:simple_cpu_offload_usage_perc` | Fraction of CPU KV cache blocks in use, between `0.0` and `1.0` (`1.0` = 100% used). |
+| `vllm:simple_cpu_offload_pending_loads` | Requests with an outstanding CPU-to-GPU load. |
+| `vllm:simple_cpu_offload_pending_stores` | In-flight GPU-to-CPU store events, including abandoned ones still draining. |
+
+These metrics are observability only; they do not change offload behavior or improve performance on their own. The copy path (`cuMemcpyBatchAsync`/`hipMemcpyBatchAsync`) is supported on both CUDA and ROCm.
+
 ## Deprecation Policy
 
 Note: when metrics are deprecated in version `X.Y`, they are hidden in version `X.Y+1`

--- a/tests/v1/simple_kv_offload/test_copy_backend.py
+++ b/tests/v1/simple_kv_offload/test_copy_backend.py
@@ -15,6 +15,7 @@ import ctypes
 import queue
 import time
 from typing import Any
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -141,9 +142,14 @@ def _run_copy_loop_once(
     )
     q.put(None)
     fake_stream = _FakeStream(getattr(event_pool, "_calls", []))
-    DmaCopyBackend._copy_loop(
-        q, torch.device("cpu"), fake_stream, fake_stream, event_pool
-    )
+    # These tests drive the loop with fake streams/events on any host; on a
+    # CUDA machine current_platform.set_device would reject the cpu device,
+    # so stub it out -- device binding is irrelevant to the ordering under
+    # test.
+    with mock.patch.object(copy_backend_mod.current_platform, "set_device"):
+        DmaCopyBackend._copy_loop(
+            q, torch.device("cpu"), fake_stream, fake_stream, event_pool
+        )
 
 
 def _patch_prepare_submit(

--- a/tests/v1/simple_kv_offload/test_copy_backend.py
+++ b/tests/v1/simple_kv_offload/test_copy_backend.py
@@ -1,0 +1,408 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""CPU-only unit tests for the DMA copy backend: host-side address/size
+staging (``prepare_copy_blocks``), the DMA-only timing bracket in
+``DmaCopyBackend._copy_loop``, and the ``_EventPairPool`` allocator.
+
+None of these tests touch a real CUDA/ROCm device: ``prepare_copy_blocks``
+is pure NumPy, and ``_copy_loop`` is driven with fake streams/events so the
+call ordering can be asserted without wall-clock timing or GPU hardware.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import queue
+import time
+from typing import Any
+
+import numpy as np
+import pytest
+
+from vllm.v1.simple_kv_offload import copy_backend as copy_backend_mod
+from vllm.v1.simple_kv_offload.copy_backend import (
+    _EVENT_POOL_INITIAL_SIZE,
+    DmaCopyBackend,
+    DmaCopyEvent,
+    _EventPairPool,
+)
+from vllm.v1.simple_kv_offload.cuda_mem_ops import (
+    BatchMemcpyParams,
+    PreparedBatchCopy,
+    _CUmemcpyAttributes,
+    prepare_copy_blocks,
+)
+from vllm.v1.simple_kv_offload.worker import SimpleCPUOffloadWorker
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_batch_params(
+    src_bases: list[int],
+    dst_bases: list[int],
+    bpb: list[int],
+) -> BatchMemcpyParams:
+    """Build a ``BatchMemcpyParams`` directly (no ``build_params()``, which
+    unconditionally resolves the CUDA/ROCm batch-memcpy symbol and would fail
+    on a machine with no accelerator). ``prepare_copy_blocks`` only reads the
+    NumPy fields (``src_bases``/``dst_bases``/``bpb``/``num_layers``); the
+    ctypes fields below are never touched by it, so dummy values are fine.
+    """
+    return BatchMemcpyParams(
+        src_bases=np.array(src_bases, dtype=np.uint64),
+        dst_bases=np.array(dst_bases, dtype=np.uint64),
+        bpb=np.array(bpb, dtype=np.uint64),
+        num_layers=len(src_bases),
+        attrs=_CUmemcpyAttributes(srcAccessOrder=1),
+        attrs_idx=ctypes.c_size_t(0),
+        fail_idx=ctypes.c_size_t(0),
+        stream_handle=0,
+    )
+
+
+class _FakeStream:
+    """Records ``wait_event`` calls without touching any real device."""
+
+    def __init__(self, calls: list[str]) -> None:
+        self._calls = calls
+
+    def wait_event(self, event: Any) -> None:
+        self._calls.append("wait_event")
+
+
+class _FakeEvent:
+    """Records ``record`` calls; ``elapsed_time`` returns a fixed value."""
+
+    def __init__(self, tag: str, calls: list[str], elapsed_ms: float = 0.0) -> None:
+        self.tag = tag
+        self._calls = calls
+        self._elapsed_ms = elapsed_ms
+
+    def record(self, stream: Any) -> None:
+        self._calls.append(f"{self.tag}.record")
+
+    def query(self) -> bool:
+        return True
+
+    def synchronize(self) -> None:
+        pass
+
+    def elapsed_time(self, other: _FakeEvent) -> float:
+        return self._elapsed_ms
+
+
+class _FakeEventPool:
+    """Fake ``_EventPairPool``: ``acquire()`` returns fresh fake events,
+    ``release()`` is a no-op (release is only invoked later by worker code,
+    never from within ``_copy_loop`` itself)."""
+
+    def __init__(self, calls: list[str], elapsed_ms: float = 0.0) -> None:
+        self._calls = calls
+        self._elapsed_ms = elapsed_ms
+
+    def acquire(self) -> tuple[_FakeEvent, _FakeEvent]:
+        return (
+            _FakeEvent("start", self._calls, self._elapsed_ms),
+            _FakeEvent("end", self._calls, self._elapsed_ms),
+        )
+
+    def release(self, pair: Any) -> None:
+        pass
+
+
+def _run_copy_loop_once(
+    *,
+    src_blocks: list[int],
+    dst_blocks: list[int],
+    is_store: bool,
+    event_idx: int,
+    events_list: list[DmaCopyEvent],
+    wait_event: Any,
+    event_pool: Any,
+) -> None:
+    """Feed a single work item through ``DmaCopyBackend._copy_loop`` and let
+    it drain (terminates on the ``None`` sentinel), all on CPU."""
+    import torch
+
+    q: queue.SimpleQueue = queue.SimpleQueue()
+    q.put(
+        (
+            src_blocks,
+            dst_blocks,
+            object(),  # params: opaque, only forwarded to the (monkeypatched)
+            # prepare/submit functions in these tests.
+            is_store,
+            event_idx,
+            events_list,
+            wait_event,
+        )
+    )
+    q.put(None)
+    fake_stream = _FakeStream(getattr(event_pool, "_calls", []))
+    DmaCopyBackend._copy_loop(
+        q, torch.device("cpu"), fake_stream, fake_stream, event_pool
+    )
+
+
+def _patch_prepare_submit(
+    monkeypatch, calls: list[str], prepared, *, sleep_s: float = 0.0
+):
+    def fake_prepare(src, dst, params):
+        calls.append("prepare")
+        if sleep_s:
+            time.sleep(sleep_s)
+        return prepared
+
+    def fake_submit(prepared_arg, params):
+        calls.append("submit")
+
+    monkeypatch.setattr(copy_backend_mod, "prepare_copy_blocks", fake_prepare)
+    monkeypatch.setattr(copy_backend_mod, "submit_prepared_copy", fake_submit)
+
+
+_SAMPLE_PREPARED = PreparedBatchCopy(
+    src_all=np.array([1], dtype=np.uint64),
+    dst_all=np.array([2], dtype=np.uint64),
+    sz_all=np.array([8], dtype=np.uint64),
+    total_transfers=1,
+    total_bytes=8,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. prepare_copy_blocks correctness
+# ---------------------------------------------------------------------------
+
+
+def test_prepare_copy_blocks_address_math():
+    """addresses = base + id*bpb per layer; sz_all repeats per layer;
+    total_transfers = n*num_layers; total_bytes is an exact Python int."""
+    params = _make_batch_params(
+        src_bases=[100, 1_000_000], dst_bases=[5_000, 9_000_000], bpb=[16, 32]
+    )
+    src_ids = [0, 1, 2]
+    dst_ids = [3, 4, 5]
+
+    prepared = prepare_copy_blocks(src_ids, dst_ids, params)
+
+    assert prepared is not None
+    n = len(src_ids)
+    expected_src = []
+    expected_dst = []
+    expected_sz = []
+    for layer in range(params.num_layers):
+        base_s = int(params.src_bases[layer])
+        base_d = int(params.dst_bases[layer])
+        b = int(params.bpb[layer])
+        for s_id, d_id in zip(src_ids, dst_ids):
+            expected_src.append(base_s + s_id * b)
+            expected_dst.append(base_d + d_id * b)
+            expected_sz.append(b)
+
+    np.testing.assert_array_equal(
+        prepared.src_all, np.array(expected_src, dtype=np.uint64)
+    )
+    np.testing.assert_array_equal(
+        prepared.dst_all, np.array(expected_dst, dtype=np.uint64)
+    )
+    np.testing.assert_array_equal(
+        prepared.sz_all, np.array(expected_sz, dtype=np.uint64)
+    )
+    assert prepared.total_transfers == n * params.num_layers
+    assert prepared.total_bytes == sum(expected_sz)
+    assert isinstance(prepared.total_bytes, int)
+
+
+def test_prepare_copy_blocks_empty_returns_none():
+    params = _make_batch_params(src_bases=[0], dst_bases=[0], bpb=[16])
+    assert prepare_copy_blocks([], [], params) is None
+
+
+# ---------------------------------------------------------------------------
+# 2. REQUIRED-ORDER: prepare -> [wait_event] -> start.record -> submit ->
+#    end.record. Proves host prep and the compute barrier sit outside the
+#    timed bracket, without relying on wall-clock timing.
+# ---------------------------------------------------------------------------
+
+
+def test_copy_loop_required_order_with_wait_event(monkeypatch):
+    calls: list[str] = []
+    _patch_prepare_submit(monkeypatch, calls, _SAMPLE_PREPARED)
+
+    event_pool = _FakeEventPool(calls)
+    events_list: list[DmaCopyEvent] = []
+    fake_wait_event = object()
+
+    _run_copy_loop_once(
+        src_blocks=[0],
+        dst_blocks=[0],
+        is_store=True,
+        event_idx=0,
+        events_list=events_list,
+        wait_event=fake_wait_event,
+        event_pool=event_pool,
+    )
+
+    assert calls == ["prepare", "wait_event", "start.record", "submit", "end.record"]
+    assert len(events_list) == 1
+    assert events_list[0].num_bytes == 8
+    assert events_list[0].is_store is True
+
+
+def test_copy_loop_no_wait_event_skips_stream_wait(monkeypatch):
+    """Loads pass wait_event=None; the stream.wait_event call must be
+    skipped entirely (not just a no-op call)."""
+    calls: list[str] = []
+    _patch_prepare_submit(monkeypatch, calls, _SAMPLE_PREPARED)
+
+    event_pool = _FakeEventPool(calls)
+    events_list: list[DmaCopyEvent] = []
+
+    _run_copy_loop_once(
+        src_blocks=[0],
+        dst_blocks=[0],
+        is_store=False,
+        event_idx=0,
+        events_list=events_list,
+        wait_event=None,
+        event_pool=event_pool,
+    )
+
+    assert calls == ["prepare", "start.record", "submit", "end.record"]
+    assert "wait_event" not in calls
+
+
+# ---------------------------------------------------------------------------
+# 3. DMA-only timing excludes host prep, even when prep is artificially slow.
+# ---------------------------------------------------------------------------
+
+
+def test_dma_time_excludes_prep_delay(monkeypatch):
+    calls: list[str] = []
+    # Inject an artificial delay into prepare; the *mocked* elapsed_time is
+    # what determines the recorded seconds, so if the recorded value equals
+    # elapsed_ms/1000 regardless of this delay, timing is provably decoupled
+    # from prep cost (no reliance on comparing against wall-clock prep time).
+    _patch_prepare_submit(monkeypatch, calls, _SAMPLE_PREPARED, sleep_s=0.05)
+
+    mock_elapsed_ms = 3.5
+    event_pool = _FakeEventPool(calls, elapsed_ms=mock_elapsed_ms)
+    events_list: list[DmaCopyEvent] = []
+
+    _run_copy_loop_once(
+        src_blocks=[0],
+        dst_blocks=[0],
+        is_store=False,
+        event_idx=0,
+        events_list=events_list,
+        wait_event=None,
+        event_pool=event_pool,
+    )
+
+    worker = SimpleCPUOffloadWorker(
+        vllm_config=None, kv_cache_config=None, cpu_capacity_bytes=0
+    )
+    worker._record_copy_event(events_list[0])
+
+    assert worker._transfer_stats.load.time == pytest.approx(mock_elapsed_ms / 1000.0)
+    assert worker._transfer_stats.load.bytes == _SAMPLE_PREPARED.total_bytes
+
+
+# ---------------------------------------------------------------------------
+# 4. Empty batch: prepare returns None -> submit must not run, but a
+#    DmaCopyEvent(num_bytes=0) is still appended for event_idx accounting.
+# ---------------------------------------------------------------------------
+
+
+def test_copy_loop_empty_batch_still_appends_event(monkeypatch):
+    calls: list[str] = []
+
+    def fake_prepare(src, dst, params):
+        calls.append("prepare")
+        return None
+
+    def fake_submit(prepared, params):
+        pytest.fail("submit_prepared_copy must not be called for an empty batch")
+
+    monkeypatch.setattr(copy_backend_mod, "prepare_copy_blocks", fake_prepare)
+    monkeypatch.setattr(copy_backend_mod, "submit_prepared_copy", fake_submit)
+
+    event_pool = _FakeEventPool(calls)
+    events_list: list[DmaCopyEvent] = []
+
+    _run_copy_loop_once(
+        src_blocks=[],
+        dst_blocks=[],
+        is_store=False,
+        event_idx=7,
+        events_list=events_list,
+        wait_event=None,
+        event_pool=event_pool,
+    )
+
+    assert calls == ["prepare", "start.record", "end.record"]
+    assert len(events_list) == 1
+    assert events_list[0].event_idx == 7
+    assert events_list[0].num_bytes == 0
+
+
+# ---------------------------------------------------------------------------
+# 5. _EventPairPool: preallocation, reuse, growth, release.
+# ---------------------------------------------------------------------------
+
+
+class _CountingEvent:
+    """Stand-in for torch.Event that just counts construction calls."""
+
+    _instances = 0
+
+    def __init__(self, **kwargs: Any) -> None:
+        type(self)._instances += 1
+
+
+def test_event_pool_preallocates_exact_size(monkeypatch):
+    _CountingEvent._instances = 0
+    monkeypatch.setattr(copy_backend_mod.torch, "Event", _CountingEvent)
+
+    pool = _EventPairPool()
+
+    assert _CountingEvent._instances == 2 * _EVENT_POOL_INITIAL_SIZE
+    assert len(pool._pairs) == _EVENT_POOL_INITIAL_SIZE
+
+
+def test_event_pool_acquire_release_reuse_no_new_allocation():
+    pool = _EventPairPool()
+    initial_size = len(pool._pairs)
+
+    for _ in range(50):
+        pair = pool.acquire()
+        pool.release(pair)
+
+    assert len(pool._pairs) == initial_size
+
+
+def test_event_pool_exhaustion_allocates_exactly_one_new_pair(monkeypatch):
+    pool = _EventPairPool()
+    acquired = [pool.acquire() for _ in range(_EVENT_POOL_INITIAL_SIZE)]
+    assert len(pool._pairs) == 0
+
+    _CountingEvent._instances = 0
+    monkeypatch.setattr(copy_backend_mod.torch, "Event", _CountingEvent)
+
+    extra_pair = pool.acquire()
+
+    assert _CountingEvent._instances == 2
+    assert extra_pair not in acquired
+
+
+def test_event_pool_release_returns_pair():
+    pool = _EventPairPool()
+    initial_size = len(pool._pairs)
+
+    pair = pool.acquire()
+    assert len(pool._pairs) == initial_size - 1
+
+    pool.release(pair)
+    assert len(pool._pairs) == initial_size

--- a/tests/v1/simple_kv_offload/test_metrics.py
+++ b/tests/v1/simple_kv_offload/test_metrics.py
@@ -44,6 +44,7 @@ from .test_scheduler import (
     make_request,
     make_scheduler,
     make_scheduler_output,
+    simulate_load_completion,
     simulate_store_completion,
 )
 
@@ -336,6 +337,81 @@ def test_scheduler_gauges_reflect_pending_store_and_load():
 
     values_load = sched.get_stats().data[_StatsKey.DATA]
     assert values_load[SimpleCPUMetricName.PENDING_LOADS][()] == 1
+
+
+def test_pending_loads_gauge_survives_reset_while_load_drains():
+    """Regression test: reset() moves an in-flight load (load_event already
+    assigned) from _reqs_to_load into _abandoned_reqs_to_load, but its DMA is
+    still physically draining -- pending_loads must not drop to 0 until the
+    worker actually reports completion."""
+    fix = make_scheduler(num_cpu_blocks=8, num_gpu_blocks=16, lazy=False)
+    sched = fix.scheduler
+    gpu_pool = fix.gpu_block_pool
+
+    num_blocks = 2
+
+    # Store blocks to CPU so a later request can hit them.
+    req = make_request(num_blocks=num_blocks)
+    kv_blocks = _alloc_and_register(fix, req, num_blocks)
+    sched.update_state_after_alloc(req, kv_blocks, num_external_tokens=0)
+    block_ids = kv_blocks.get_block_ids()
+    sched_out = make_scheduler_output(
+        {req.request_id: num_blocks * BLOCK_SIZE},
+        new_reqs={req.request_id: block_ids},
+    )
+    meta = sched.build_connector_meta(sched_out)
+    simulate_store_completion(sched, meta.store_event)
+
+    # Dispatch a load -- CPU cache hit for req2.
+    req2 = Request(
+        request_id="req-pending-loads-reset",
+        prompt_token_ids=req.prompt_token_ids,
+        sampling_params=req.sampling_params,
+        pooling_params=None,
+        mm_features=None,
+        block_hasher=req._block_hasher,
+    )
+    hit_tokens, is_async = sched.get_num_new_matched_tokens(req2, num_computed_tokens=0)
+    assert hit_tokens > 0
+    assert is_async is True
+
+    gpu_blocks2 = gpu_pool.get_new_blocks(num_blocks)
+    kv_blocks2 = KVCacheBlocks(blocks=(gpu_blocks2,))
+    sched.update_state_after_alloc(req2, kv_blocks2, num_external_tokens=hit_tokens)
+    block_ids2 = kv_blocks2.get_block_ids()
+    sched_out2 = make_scheduler_output(
+        {req2.request_id: 1},
+        new_reqs={req2.request_id: block_ids2},
+    )
+    meta2 = sched.build_connector_meta(sched_out2)
+    assert meta2.load_event >= 0, "Expected a load event to be assigned"
+
+    values = sched.get_stats().data[_StatsKey.DATA]
+    assert values[SimpleCPUMetricName.PENDING_LOADS][()] == 1
+    pending_stores_before = values[SimpleCPUMetricName.PENDING_STORES][()]
+
+    # reset() abandons the in-flight load (DMA still draining) rather than
+    # dropping it: it must return False and move the request into
+    # _abandoned_reqs_to_load, not silently discard it.
+    assert sched.reset() is False
+    assert len(sched._reqs_to_load) == 0
+    assert req2.request_id in sched._abandoned_reqs_to_load
+
+    values_during_reset = sched.get_stats().data[_StatsKey.DATA]
+    # Regression: pre-fix this read 0 because pending_loads only counted
+    # _reqs_to_load, which reset() had just emptied.
+    assert values_during_reset[SimpleCPUMetricName.PENDING_LOADS][()] == 1
+    assert (
+        values_during_reset[SimpleCPUMetricName.PENDING_STORES][()]
+        == pending_stores_before
+    )
+
+    # Worker reports the drained load finished -> gauge drops to 0, no
+    # negative or stale values.
+    simulate_load_completion(sched, {req2.request_id})
+    values_after = sched.get_stats().data[_StatsKey.DATA]
+    assert values_after[SimpleCPUMetricName.PENDING_LOADS][()] == 0
+    assert values_after[SimpleCPUMetricName.PENDING_STORES][()] == pending_stores_before
 
 
 # ---------------------------------------------------------------------------

--- a/tests/v1/simple_kv_offload/test_metrics.py
+++ b/tests/v1/simple_kv_offload/test_metrics.py
@@ -1,0 +1,548 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for SimpleCPUOffloadConnector metrics: stats payload
+construction/aggregation, worker poll-and-reset, scheduler gauges,
+worker+scheduler aggregation, IPC (msgpack) round trip, and Prometheus
+observation. All CPU-only.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from prometheus_client import Counter, Gauge, Histogram
+
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
+    TransferStats,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
+    OffloadingConnectorStats,
+    _MetricType,
+    _StatsKey,
+    _TransferMetricName,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.simple_cpu_offload_connector import (
+    SimpleCPUOffloadConnector,
+    SimpleCPUOffloadPromMetrics,
+)
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks
+from vllm.v1.kv_offload.factory import OffloadingSpecFactory
+from vllm.v1.metrics.stats import SchedulerStats
+from vllm.v1.outputs import KVConnectorOutput
+from vllm.v1.request import Request
+from vllm.v1.serial_utils import MsgpackDecoder, MsgpackEncoder
+from vllm.v1.simple_kv_offload.copy_backend import DmaCopyEvent
+from vllm.v1.simple_kv_offload.metadata import SimpleCPUOffloadWorkerMetadata
+from vllm.v1.simple_kv_offload.metrics import SimpleCPUMetricName
+from vllm.v1.simple_kv_offload.worker import SimpleCPUOffloadWorker
+
+from .test_scheduler import (
+    BLOCK_SIZE,
+    _alloc_and_register,
+    make_request,
+    make_scheduler,
+    make_scheduler_output,
+    simulate_store_completion,
+)
+
+# ---------------------------------------------------------------------------
+# 6. build_kv_connector_stats
+# ---------------------------------------------------------------------------
+
+
+def test_build_kv_connector_stats_none_returns_empty():
+    stats = SimpleCPUOffloadConnector.build_kv_connector_stats(data=None)
+
+    assert isinstance(stats, OffloadingConnectorStats)
+    assert stats.is_empty()
+
+
+def test_build_kv_connector_stats_rehydrates_from_payload():
+    payload = {
+        _StatsKey.TYPES: {
+            _TransferMetricName.LOAD_BYTES: _MetricType.COUNTER,
+            SimpleCPUMetricName.TOTAL_BLOCKS: _MetricType.GAUGE,
+        },
+        _StatsKey.DATA: {
+            _TransferMetricName.LOAD_BYTES: {(): 128},
+            SimpleCPUMetricName.TOTAL_BLOCKS: {(): 64},
+        },
+    }
+
+    stats = SimpleCPUOffloadConnector.build_kv_connector_stats(data=payload)
+
+    assert isinstance(stats, OffloadingConnectorStats)
+    values = stats.data[_StatsKey.DATA]
+    assert values[_TransferMetricName.LOAD_BYTES][()] == 128
+    assert values[SimpleCPUMetricName.TOTAL_BLOCKS][()] == 64
+
+
+# ---------------------------------------------------------------------------
+# 7. Aggregation semantics via the SimpleCPU payload: counters sum, gauges
+#    last-write-wins, histograms extend, labelvalues survive.
+# ---------------------------------------------------------------------------
+
+
+def test_aggregation_counters_sum_gauges_latest_histograms_extend():
+    stats1 = OffloadingConnectorStats()
+    stats1.increase_counter(_TransferMetricName.LOAD_BYTES, 100)
+    stats1.observe_histogram(_TransferMetricName.LOAD_SIZE, 100)
+    stats1.set_gauge(SimpleCPUMetricName.PENDING_LOADS, 3)
+    stats1.increase_counter("labeled_counter", 5, ("gpu0",))
+
+    stats2 = OffloadingConnectorStats()
+    stats2.increase_counter(_TransferMetricName.LOAD_BYTES, 50)
+    stats2.observe_histogram(_TransferMetricName.LOAD_SIZE, 50)
+    stats2.set_gauge(SimpleCPUMetricName.PENDING_LOADS, 7)
+    stats2.increase_counter("labeled_counter", 2, ("gpu0",))
+    stats2.increase_counter("labeled_counter", 9, ("gpu1",))
+
+    stats1.aggregate(stats2)
+
+    values = stats1.data[_StatsKey.DATA]
+    assert values[_TransferMetricName.LOAD_BYTES][()] == 150  # counter: sum
+    assert values[_TransferMetricName.LOAD_SIZE][()] == [100, 50]  # histogram: extend
+    assert values[SimpleCPUMetricName.PENDING_LOADS][()] == 7  # gauge: last write wins
+    assert values["labeled_counter"][("gpu0",)] == 7  # labelvalues preserved
+    assert values["labeled_counter"][("gpu1",)] == 9
+
+
+# ---------------------------------------------------------------------------
+# 8. Serialized (IPC) stats path: round-trip through the real MsgpackEncoder/
+#    Decoder used to send SchedulerStats.kv_connector_stats to the frontend.
+# ---------------------------------------------------------------------------
+
+
+def _sample_stats() -> OffloadingConnectorStats:
+    stats = OffloadingConnectorStats()
+    stats.increase_counter(_TransferMetricName.LOAD_BYTES, 4096)
+    stats.increase_counter(_TransferMetricName.LOAD_TIME, 0.02)
+    stats.observe_histogram(_TransferMetricName.LOAD_SIZE, 4096)
+    stats.increase_counter(_TransferMetricName.STORE_BYTES, 8192)
+    stats.increase_counter(_TransferMetricName.STORE_TIME, 0.04)
+    stats.observe_histogram(_TransferMetricName.STORE_SIZE, 8192)
+    stats.set_gauge(SimpleCPUMetricName.TOTAL_BLOCKS, 100)
+    stats.set_gauge(SimpleCPUMetricName.FREE_BLOCKS, 40)
+    stats.set_gauge(SimpleCPUMetricName.USED_BLOCKS, 60)
+    stats.set_gauge(SimpleCPUMetricName.USAGE_PERC, 0.6)
+    stats.set_gauge(SimpleCPUMetricName.PENDING_LOADS, 2)
+    stats.set_gauge(SimpleCPUMetricName.PENDING_STORES, 1)
+    # A labeled key exercises the tuple-labelvalues-as-dict-key shape that
+    # the self-describing {types, data} payload relies on.
+    stats.increase_counter("some_labeled_metric", 3, ("engine0", "gpu"))
+    return stats
+
+
+def test_stats_data_survives_msgpack_round_trip():
+    """Round-trip the raw ``.data`` dict exactly as it travels: scheduler.py
+    ``make_stats()`` sets ``SchedulerStats.kv_connector_stats = stats.data``
+    (see vllm/v1/core/sched/scheduler.py), and that dict is what gets
+    msgpack-encoded for IPC to the frontend process."""
+    stats = _sample_stats()
+
+    encoder = MsgpackEncoder()
+    decoder = MsgpackDecoder()
+    encoded = encoder.encode(stats.data)
+    decoded = decoder.decode(encoded)
+
+    assert decoded == stats.data
+
+    # Tuple labelvalue keys must survive as tuples (used as dict keys
+    # throughout OffloadingConnectorStats), not silently become lists.
+    for metric_name, label_map in decoded[_StatsKey.DATA].items():
+        for labelvalues in label_map:
+            assert isinstance(labelvalues, tuple), (
+                f"{metric_name} labelvalues {labelvalues!r} did not survive "
+                "msgpack round trip as a tuple"
+            )
+
+    rehydrated = SimpleCPUOffloadConnector.build_kv_connector_stats(data=decoded)
+    assert isinstance(rehydrated, OffloadingConnectorStats)
+    assert rehydrated.data == stats.data
+
+
+def test_stats_survive_msgpack_round_trip_via_scheduler_stats():
+    """End-to-end variant: wrap in the real SchedulerStats dataclass (as
+    produced by Scheduler.make_stats()) to prove the field-level path, not
+    just the bare dict, round-trips."""
+    stats = _sample_stats()
+    sched_stats = SchedulerStats(kv_connector_stats=stats.data)
+
+    encoder = MsgpackEncoder()
+    decoder = MsgpackDecoder()
+    encoded = encoder.encode(sched_stats)
+    decoded = decoder.decode(encoded)
+
+    assert decoded["kv_connector_stats"] == stats.data
+    rehydrated = SimpleCPUOffloadConnector.build_kv_connector_stats(
+        data=decoded["kv_connector_stats"]
+    )
+    assert rehydrated.data == stats.data
+
+
+# ---------------------------------------------------------------------------
+# 5 (worker half). Empty-batch events (num_bytes=0) must not affect stats.
+# ---------------------------------------------------------------------------
+
+
+def test_record_copy_event_skips_stats_for_zero_bytes():
+    worker = SimpleCPUOffloadWorker(
+        vllm_config=None, kv_cache_config=None, cpu_capacity_bytes=0
+    )
+    ev = DmaCopyEvent(
+        event_idx=3,
+        start_event=Mock(elapsed_time=Mock(return_value=999.0)),
+        end_event=Mock(),
+        num_bytes=0,
+        is_store=False,
+        release=lambda: None,
+    )
+
+    worker._record_copy_event(ev)
+
+    assert worker._transfer_stats.is_empty()
+    assert worker._transfer_stats.load.bytes == 0
+    assert worker._transfer_stats.load.time == 0.0
+    # An empty batch has nothing to time; elapsed_time must not even be
+    # consulted (the method returns before reaching it).
+    ev.start_event.elapsed_time.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# 9. Worker poll-and-reset via build_connector_worker_meta().
+# ---------------------------------------------------------------------------
+
+
+def _make_dma_event(
+    event_idx: int, num_bytes: int, is_store: bool, elapsed_ms: float
+) -> DmaCopyEvent:
+    return DmaCopyEvent(
+        event_idx=event_idx,
+        start_event=Mock(elapsed_time=Mock(return_value=elapsed_ms)),
+        end_event=Mock(),
+        num_bytes=num_bytes,
+        is_store=is_store,
+        release=lambda: None,
+    )
+
+
+def test_worker_meta_poll_and_reset():
+    worker = SimpleCPUOffloadWorker(
+        vllm_config=None, kv_cache_config=None, cpu_capacity_bytes=0
+    )
+
+    load_ev = _make_dma_event(0, num_bytes=1024, is_store=False, elapsed_ms=10.0)
+    worker._record_copy_event(load_ev)
+
+    meta = worker.build_connector_worker_meta()
+
+    assert meta is not None
+    assert not meta.transfer_stats.is_empty()
+    assert meta.transfer_stats.load.bytes == 1024
+    assert meta.transfer_stats.load.time == pytest.approx(0.01)
+
+    # poll-and-reset: nothing new since the last call -> None.
+    assert worker.build_connector_worker_meta() is None
+
+
+def test_worker_meta_built_with_only_transfer_stats_no_store_events():
+    """meta must be returned even when completed_store_events is empty but
+    transfer_stats has data (build_connector_worker_meta's early-return must
+    check both, not just completed_store_events)."""
+    worker = SimpleCPUOffloadWorker(
+        vllm_config=None, kv_cache_config=None, cpu_capacity_bytes=0
+    )
+    assert worker._completed_store_events == {}
+
+    store_ev = _make_dma_event(1, num_bytes=2048, is_store=True, elapsed_ms=5.0)
+    worker._record_copy_event(store_ev)
+    assert worker._completed_store_events == {}
+
+    meta = worker.build_connector_worker_meta()
+
+    assert meta is not None
+    assert meta.completed_store_events == {}
+    assert meta.transfer_stats.store.bytes == 2048
+    assert meta.transfer_stats.store.time == pytest.approx(0.005)
+
+
+# ---------------------------------------------------------------------------
+# 10. Scheduler-only gauges (no worker input).
+# ---------------------------------------------------------------------------
+
+
+def test_scheduler_only_gauges_no_worker_activity():
+    fix = make_scheduler(num_cpu_blocks=8, num_gpu_blocks=16, lazy=False)
+    sched = fix.scheduler
+
+    stats = sched.get_stats()
+
+    assert stats is not None
+    values = stats.data[_StatsKey.DATA]
+    total_blocks = sched.cpu_block_pool.num_gpu_blocks - 1
+    assert values[SimpleCPUMetricName.TOTAL_BLOCKS][()] == total_blocks
+    assert values[SimpleCPUMetricName.FREE_BLOCKS][()] == total_blocks
+    assert values[SimpleCPUMetricName.USED_BLOCKS][()] == 0
+    usage = values[SimpleCPUMetricName.USAGE_PERC][()]
+    assert 0.0 <= usage <= 1.0
+    assert usage == 0.0
+    assert values[SimpleCPUMetricName.PENDING_LOADS][()] == 0
+    assert values[SimpleCPUMetricName.PENDING_STORES][()] == 0
+    # No transfer counters absent any worker-reported activity.
+    assert _TransferMetricName.LOAD_BYTES not in values
+
+
+def test_scheduler_gauges_reflect_pending_store_and_load():
+    fix = make_scheduler(num_cpu_blocks=8, num_gpu_blocks=16, lazy=False)
+    sched = fix.scheduler
+
+    num_blocks = 2
+    req = make_request(num_blocks=num_blocks)
+    kv_blocks = _alloc_and_register(fix, req, num_blocks)
+    sched.update_state_after_alloc(req, kv_blocks, num_external_tokens=0)
+    sched_out = make_scheduler_output(
+        {req.request_id: num_blocks * BLOCK_SIZE},
+        new_reqs={req.request_id: kv_blocks.get_block_ids()},
+    )
+    meta = sched.build_connector_meta(sched_out)
+    assert meta.store_event >= 0
+
+    values = sched.get_stats().data[_StatsKey.DATA]
+    assert values[SimpleCPUMetricName.PENDING_STORES][()] == 1
+
+    simulate_store_completion(sched, meta.store_event)
+
+    values_after = sched.get_stats().data[_StatsKey.DATA]
+    assert values_after[SimpleCPUMetricName.PENDING_STORES][()] == 0
+
+    # --- Pending load: new request hits the now-cached CPU blocks. ---
+    req2 = Request(
+        request_id="req-metrics-load",
+        prompt_token_ids=req.prompt_token_ids,
+        sampling_params=req.sampling_params,
+        pooling_params=None,
+        mm_features=None,
+        block_hasher=req._block_hasher,
+    )
+    hit_tokens, is_async = sched.get_num_new_matched_tokens(req2, num_computed_tokens=0)
+    assert hit_tokens > 0
+    assert is_async is True
+
+    gpu_blocks2 = fix.gpu_block_pool.get_new_blocks(num_blocks)
+    kv_blocks2 = KVCacheBlocks(blocks=(gpu_blocks2,))
+    sched.update_state_after_alloc(req2, kv_blocks2, num_external_tokens=hit_tokens)
+
+    values_load = sched.get_stats().data[_StatsKey.DATA]
+    assert values_load[SimpleCPUMetricName.PENDING_LOADS][()] == 1
+
+
+# ---------------------------------------------------------------------------
+# 11. Worker+scheduler aggregation: counters popped after get_stats(),
+#     gauges always re-emitted; TP/PP metadata.aggregate() sums stats.
+# ---------------------------------------------------------------------------
+
+
+def test_worker_scheduler_aggregation_counters_popped_gauges_persist():
+    fix = make_scheduler(num_cpu_blocks=8, num_gpu_blocks=16, lazy=False)
+    sched = fix.scheduler
+
+    transfer_stats = TransferStats()
+    transfer_stats.load.record(1024, 0.01)
+    transfer_stats.store.record(2048, 0.02)
+
+    output = KVConnectorOutput(
+        finished_recving=set(),
+        kv_connector_worker_meta=SimpleCPUOffloadWorkerMetadata(
+            completed_store_events={},
+            transfer_stats=transfer_stats,
+        ),
+    )
+    sched.update_connector_output(output)
+
+    values = sched.get_stats().data[_StatsKey.DATA]
+    assert values[_TransferMetricName.LOAD_BYTES][()] == 1024
+    assert values[_TransferMetricName.LOAD_TIME][()] == pytest.approx(0.01)
+    assert values[_TransferMetricName.LOAD_SIZE][()] == [1024]
+    assert values[_TransferMetricName.STORE_BYTES][()] == 2048
+    assert values[_TransferMetricName.STORE_TIME][()] == pytest.approx(0.02)
+    assert values[_TransferMetricName.STORE_SIZE][()] == [2048]
+    assert SimpleCPUMetricName.TOTAL_BLOCKS in values  # gauges present too
+
+    values_second = sched.get_stats().data[_StatsKey.DATA]
+    assert _TransferMetricName.LOAD_BYTES not in values_second  # counters popped
+    assert SimpleCPUMetricName.TOTAL_BLOCKS in values_second  # gauges persist
+
+
+def test_worker_metadata_aggregate_sums_across_workers():
+    stats_a = TransferStats()
+    stats_a.load.record(100, 0.001)
+    stats_b = TransferStats()
+    stats_b.load.record(200, 0.002)
+
+    meta_a = SimpleCPUOffloadWorkerMetadata(
+        completed_store_events={1: 1}, transfer_stats=stats_a
+    )
+    meta_b = SimpleCPUOffloadWorkerMetadata(
+        completed_store_events={1: 1, 2: 1}, transfer_stats=stats_b
+    )
+
+    merged = meta_a.aggregate(meta_b)
+
+    assert merged.completed_store_events == {1: 2, 2: 1}
+    assert merged.transfer_stats.load.bytes == 300
+    assert merged.transfer_stats.load.time == pytest.approx(0.003)
+    assert merged.transfer_stats.load.sizes == [100, 200]
+
+
+# ---------------------------------------------------------------------------
+# 12. Prometheus observe(): SimpleCPUOffloadPromMetrics wiring.
+# ---------------------------------------------------------------------------
+
+
+class _FakeMetric:
+    """Stand-in for a prometheus_client Counter/Gauge/Histogram, mirroring
+    tests/v1/kv_connector/unit/offloading_connector/test_metrics.py."""
+
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.children: list[_FakeMetric] = []
+        self.observed: list[float] = []
+        self.increments: list[float] = []
+        self.set_values: list[float] = []
+        self.labelvalues: tuple[object, ...] = ()
+
+    def labels(self, *labelvalues):
+        child = _FakeMetric(**self.kwargs)
+        child.labelvalues = labelvalues
+        self.children.append(child)
+        return child
+
+    def observe(self, value):
+        self.observed.append(value)
+
+    def inc(self, value):
+        self.increments.append(value)
+
+    def set(self, value):
+        self.set_values.append(value)
+
+
+class _FakeVllmConfig:
+    def __init__(self):
+        self.kv_transfer_config = SimpleNamespace(kv_connector_extra_config={})
+
+
+def _make_prom_metrics(per_engine_labelvalues=None) -> SimpleCPUOffloadPromMetrics:
+    return SimpleCPUOffloadPromMetrics(
+        vllm_config=_FakeVllmConfig(),  # type: ignore[arg-type]
+        metric_types={
+            Gauge: _FakeMetric,
+            Counter: _FakeMetric,
+            Histogram: _FakeMetric,
+        },
+        labelnames=["model_name", "engine"],
+        per_engine_labelvalues=per_engine_labelvalues or {0: ["model", "0"]},
+    )
+
+
+_ALL_SIMPLE_CPU_GAUGES = (
+    (SimpleCPUMetricName.TOTAL_BLOCKS, 100),
+    (SimpleCPUMetricName.FREE_BLOCKS, 40),
+    (SimpleCPUMetricName.USED_BLOCKS, 60),
+    (SimpleCPUMetricName.USAGE_PERC, 0.6),
+    (SimpleCPUMetricName.PENDING_LOADS, 2),
+    (SimpleCPUMetricName.PENDING_STORES, 1),
+)
+
+
+def test_simple_cpu_prom_metrics_observes_transfer_and_gauges():
+    prom = _make_prom_metrics()
+
+    types = {
+        _TransferMetricName.LOAD_BYTES: _MetricType.COUNTER,
+        _TransferMetricName.LOAD_TIME: _MetricType.COUNTER,
+        _TransferMetricName.LOAD_SIZE: _MetricType.HISTOGRAM,
+        _TransferMetricName.STORE_BYTES: _MetricType.COUNTER,
+        _TransferMetricName.STORE_TIME: _MetricType.COUNTER,
+        _TransferMetricName.STORE_SIZE: _MetricType.HISTOGRAM,
+        **{name: _MetricType.GAUGE for name, _ in _ALL_SIMPLE_CPU_GAUGES},
+    }
+    data = {
+        _TransferMetricName.LOAD_BYTES: {(): 4096},
+        _TransferMetricName.LOAD_TIME: {(): 0.01},
+        _TransferMetricName.LOAD_SIZE: {(): [4096]},
+        _TransferMetricName.STORE_BYTES: {(): 8192},
+        _TransferMetricName.STORE_TIME: {(): 0.02},
+        _TransferMetricName.STORE_SIZE: {(): [8192]},
+        **{name: {(): value} for name, value in _ALL_SIMPLE_CPU_GAUGES},
+    }
+
+    prom.observe({_StatsKey.TYPES: types, _StatsKey.DATA: data})
+
+    def flat(name):
+        return prom.offloading_metrics[(0, name, ())]
+
+    assert flat(_TransferMetricName.LOAD_BYTES).increments == [4096]
+    assert flat(_TransferMetricName.LOAD_TIME).increments == [0.01]
+    assert flat(_TransferMetricName.LOAD_SIZE).observed == [4096]
+    assert flat(_TransferMetricName.STORE_BYTES).increments == [8192]
+    assert flat(_TransferMetricName.STORE_TIME).increments == [0.02]
+    assert flat(_TransferMetricName.STORE_SIZE).observed == [8192]
+
+    for name, expected in _ALL_SIMPLE_CPU_GAUGES:
+        gauge = flat(name)
+        assert gauge.set_values == [expected]
+        assert gauge.labelvalues == ("model", "0")  # engine labels applied
+
+    # Deprecated transfer_type-labeled mirrors (CPU_to_GPU=load,
+    # GPU_to_CPU=store) must also fire, since SimpleCPU always sets
+    # _should_observe_deprecated_metrics=True.
+    assert prom.counter_kv_bytes[(0, "CPU_to_GPU")].increments == [4096]
+    assert prom.counter_kv_transfer_time[(0, "CPU_to_GPU")].increments == [0.01]
+    assert prom.histogram_transfer_size[(0, "CPU_to_GPU")].observed == [4096]
+    assert prom.counter_kv_bytes[(0, "GPU_to_CPU")].increments == [8192]
+    assert prom.counter_kv_transfer_time[(0, "GPU_to_CPU")].increments == [0.02]
+    assert prom.histogram_transfer_size[(0, "GPU_to_CPU")].observed == [8192]
+
+    # No double observation of the flat (non-deprecated) metrics: exactly
+    # one call recorded per metric despite the deprecated mirror also firing.
+    assert len(flat(_TransferMetricName.LOAD_BYTES).increments) == 1
+    assert len(flat(_TransferMetricName.LOAD_SIZE).observed) == 1
+    assert len(flat(_TransferMetricName.STORE_BYTES).increments) == 1
+
+
+def test_simple_cpu_prom_metrics_engine_labels_applied_per_engine():
+    prom = _make_prom_metrics(
+        per_engine_labelvalues={0: ["model", "0"], 1: ["model", "1"]}
+    )
+
+    prom.observe(
+        {
+            _StatsKey.TYPES: {SimpleCPUMetricName.TOTAL_BLOCKS: _MetricType.GAUGE},
+            _StatsKey.DATA: {SimpleCPUMetricName.TOTAL_BLOCKS: {(): 42}},
+        },
+        engine_idx=1,
+    )
+
+    assert (0, SimpleCPUMetricName.TOTAL_BLOCKS, ()) not in prom.offloading_metrics
+    engine1 = prom.offloading_metrics[(1, SimpleCPUMetricName.TOTAL_BLOCKS, ())]
+    assert engine1.set_values == [42]
+    assert engine1.labelvalues == ("model", "1")
+
+
+def test_simple_cpu_prom_metrics_does_not_depend_on_spec_factory():
+    """SimpleCPU has no OffloadingSpec; its metric metadata must come from
+    the flat transfer defs + SimpleCPU gauge defs only, never the spec
+    factory (unlike the generic OffloadPromMetrics default)."""
+    with patch.object(
+        OffloadingSpecFactory,
+        "get_spec_cls",
+        side_effect=AssertionError("spec factory should not be consulted"),
+    ):
+        prom = _make_prom_metrics()
+
+    assert _TransferMetricName.LOAD_BYTES in prom._offloading_metric_metadata
+    assert SimpleCPUMetricName.TOTAL_BLOCKS in prom._offloading_metric_metadata
+    assert prom._observe_deprecated_metrics is True

--- a/tests/v1/simple_kv_offload/test_worker.py
+++ b/tests/v1/simple_kv_offload/test_worker.py
@@ -19,7 +19,7 @@ from vllm.platforms import current_platform
 if not current_platform.is_cuda_alike():
     pytest.skip("Requires CUDA or ROCm", allow_module_level=True)
 
-from vllm.v1.simple_kv_offload.copy_backend import DmaCopyBackend
+from vllm.v1.simple_kv_offload.copy_backend import DmaCopyBackend, DmaCopyEvent
 from vllm.v1.simple_kv_offload.cuda_mem_ops import (
     CU_MEMCPY_SRC_ACCESS_ORDER_ANY,
     CU_MEMCPY_SRC_ACCESS_ORDER_STREAM,
@@ -82,7 +82,7 @@ def _drive_store(
             wait_event = torch.Event()
             wait_event.record(compute_stream)
 
-        store_events: list[tuple[int, torch.Event]] = []
+        store_events: list[DmaCopyEvent] = []
         backend.launch_copy(
             block_ids,
             block_ids,
@@ -96,7 +96,7 @@ def _drive_store(
         while not store_events and time.time() < deadline:
             time.sleep(0.0005)
         assert store_events, "background copy was never enqueued"
-        store_events[0][1].synchronize()
+        store_events[0].end_event.synchronize()
 
         if int((cpu[:, 0].to(torch.int32) != val).sum().item()):
             corrupt += 1

--- a/vllm/distributed/kv_transfer/kv_connector/v1/offloading/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/offloading/metrics.py
@@ -60,7 +60,8 @@ TRANSFER_SIZE_BUCKETS = (
 )
 
 
-def get_connector_metric_definitions() -> dict[str, OffloadingMetricMetadata]:
+def get_transfer_metric_definitions() -> dict[str, OffloadingMetricMetadata]:
+    """Flat transfer metric definitions, shared by all offloading connectors."""
     return {
         _TransferMetricName.LOAD_BYTES: OffloadingCounterMetadata(
             documentation="Total bytes loaded from offload storage to GPU.",
@@ -82,6 +83,12 @@ def get_connector_metric_definitions() -> dict[str, OffloadingMetricMetadata]:
             documentation="Histogram of KV offload store operation size, in bytes.",
             buckets=TRANSFER_SIZE_BUCKETS,
         ),
+    }
+
+
+def get_connector_metric_definitions() -> dict[str, OffloadingMetricMetadata]:
+    return {
+        **get_transfer_metric_definitions(),
         _ConnectorMetricName.LOOKUP_SYNC_DELAY: OffloadingHistogramMetadata(
             documentation=(
                 "Histogram of the time spent in a single offload lookup call, "
@@ -321,17 +328,12 @@ class OffloadPromMetrics(KVConnectorPromMetrics):
         self.histogram_transfer_size: dict[tuple[int, str], PromMetricT] = {}
         self.counter_kv_bytes: dict[tuple[int, str], PromMetricT] = {}
         self.counter_kv_transfer_time: dict[tuple[int, str], PromMetricT] = {}
-        spec_cls = OffloadingSpecFactory.get_spec_cls(vllm_config)
-        kv_transfer_config = vllm_config.kv_transfer_config
-        assert kv_transfer_config is not None
-        extra_config = kv_transfer_config.kv_connector_extra_config
-        self._offloading_metric_metadata: dict[str, OffloadingMetricMetadata] = {
-            **spec_cls.build_metric_definitions(extra_config),
-            **get_connector_metric_definitions(),
-        }
-        from vllm.v1.kv_offload.cpu.spec import CPUOffloadingSpec
-
-        self._observe_deprecated_metrics = issubclass(spec_cls, CPUOffloadingSpec)
+        self._offloading_metric_metadata: dict[str, OffloadingMetricMetadata] = (
+            self._build_metric_metadata(vllm_config)
+        )
+        self._observe_deprecated_metrics = self._should_observe_deprecated_metrics(
+            vllm_config
+        )
         self._offloading_metric_defs: dict[str, PromMetricT] = {}
         # (engine_idx, metric_name, labelvalues) -> metric with bound labels
         self.offloading_metrics: dict[
@@ -382,6 +384,31 @@ class OffloadPromMetrics(KVConnectorPromMetrics):
             self._offloading_metric_defs[metric_name] = self._create_metric(
                 metric_name, metadata
             )
+
+    def _build_metric_metadata(
+        self, vllm_config: VllmConfig
+    ) -> dict[str, OffloadingMetricMetadata]:
+        """Metric definitions to register, keyed by flat metric name.
+
+        Subclasses that emit a fixed, spec-independent set of metrics (e.g.
+        SimpleCPUOffloadConnector) should override this instead of relying on
+        an ``OffloadingSpec``.
+        """
+        spec_cls = OffloadingSpecFactory.get_spec_cls(vllm_config)
+        kv_transfer_config = vllm_config.kv_transfer_config
+        assert kv_transfer_config is not None
+        extra_config = kv_transfer_config.kv_connector_extra_config
+        return {
+            **spec_cls.build_metric_definitions(extra_config),
+            **get_connector_metric_definitions(),
+        }
+
+    def _should_observe_deprecated_metrics(self, vllm_config: VllmConfig) -> bool:
+        """Whether to mirror the legacy ``transfer_type``-labeled metrics."""
+        spec_cls = OffloadingSpecFactory.get_spec_cls(vllm_config)
+        from vllm.v1.kv_offload.cpu.spec import CPUOffloadingSpec
+
+        return issubclass(spec_cls, CPUOffloadingSpec)
 
     def _create_metric(
         self, metric_name: str, metadata: OffloadingMetricMetadata

--- a/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/simple_cpu_offload_connector.py
@@ -15,8 +15,20 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorRole,
     SupportsHMA,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
+    KVConnectorPromMetrics,
+    KVConnectorStats,
+    PromMetric,
+    PromMetricT,
+)
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
+    OffloadingConnectorStats,
+    OffloadPromMetrics,
+    get_transfer_metric_definitions,
+)
 from vllm.logger import init_logger
 from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.kv_offload.base import OffloadingMetricMetadata
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.simple_kv_offload.manager import (
     SimpleCPUOffloadScheduler,
@@ -24,6 +36,7 @@ from vllm.v1.simple_kv_offload.manager import (
 from vllm.v1.simple_kv_offload.metadata import (
     SimpleCPUOffloadMetadata,
 )
+from vllm.v1.simple_kv_offload.metrics import get_simple_cpu_metric_definitions
 from vllm.v1.simple_kv_offload.worker import (
     SimpleCPUOffloadWorker,
 )
@@ -40,6 +53,28 @@ logger = init_logger(__name__)
 
 # Default CPU capacity: 8 GB
 DEFAULT_CPU_CAPACITY_BYTES = 8 * (1024**3)
+
+
+class SimpleCPUOffloadPromMetrics(OffloadPromMetrics):
+    """Prometheus metrics for SimpleCPUOffloadConnector.
+
+    SimpleCPU has no OffloadingSpec and no lookup/allocation-failure metrics,
+    so it overrides metric discovery instead of relying on the generic
+    spec-factory-driven defaults.
+    """
+
+    def _build_metric_metadata(
+        self, vllm_config: VllmConfig
+    ) -> dict[str, OffloadingMetricMetadata]:
+        return {
+            **get_transfer_metric_definitions(),
+            **get_simple_cpu_metric_definitions(),
+        }
+
+    def _should_observe_deprecated_metrics(self, vllm_config: VllmConfig) -> bool:
+        # SimpleCPU is a CPU offload connector; keep the legacy
+        # transfer_type-labeled series alive during the flat-name migration.
+        return True
 
 
 class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
@@ -252,3 +287,32 @@ class SimpleCPUOffloadConnector(KVConnectorBase_V1, SupportsHMA):
         if self.scheduler_manager is not None:
             return self.scheduler_manager.reset()
         return None
+
+    def get_kv_connector_stats(self) -> KVConnectorStats | None:
+        # Worker-side stats travel via build_connector_worker_meta() instead
+        # of this hook; only the scheduler side emits stats here.
+        if self.scheduler_manager is not None:
+            return self.scheduler_manager.get_stats()
+        return None
+
+    @classmethod
+    def build_kv_connector_stats(
+        cls, data: dict[str, Any] | None = None
+    ) -> KVConnectorStats | None:
+        return (
+            OffloadingConnectorStats(data=data)
+            if data is not None
+            else OffloadingConnectorStats()
+        )
+
+    @classmethod
+    def build_prom_metrics(
+        cls,
+        vllm_config: VllmConfig,
+        metric_types: dict[type[PromMetric], type[PromMetricT]],
+        labelnames: list[str],
+        per_engine_labelvalues: dict[int, list[object]],
+    ) -> KVConnectorPromMetrics:
+        return SimpleCPUOffloadPromMetrics(
+            vllm_config, metric_types, labelnames, per_engine_labelvalues
+        )

--- a/vllm/v1/simple_kv_offload/copy_backend.py
+++ b/vllm/v1/simple_kv_offload/copy_backend.py
@@ -4,8 +4,11 @@
 
 from __future__ import annotations
 
+import functools
 import queue
 import threading
+from collections.abc import Callable
+from dataclasses import dataclass
 
 import torch
 
@@ -16,10 +19,58 @@ from vllm.v1.simple_kv_offload.cuda_mem_ops import (
     CU_MEMCPY_SRC_ACCESS_ORDER_STREAM,
     BatchMemcpyParams,
     build_params,
-    copy_blocks,
+    prepare_copy_blocks,
+    submit_prepared_copy,
 )
 
 logger = init_logger(__name__)
+
+# Number of (start, end) event pairs preallocated by _EventPairPool.
+_EVENT_POOL_INITIAL_SIZE = 16
+
+
+@dataclass
+class DmaCopyEvent:
+    """A single queued copy op's timing/completion events.
+
+    ``end_event`` doubles as the completion event: both events are recorded
+    on the same stream, so FIFO stream order means ``end_event.query()``
+    becoming true implies the op (and everything queued before it on that
+    stream) has completed. A separate completion event would be redundant.
+    """
+
+    event_idx: int
+    start_event: torch.Event
+    end_event: torch.Event
+    num_bytes: int
+    is_store: bool
+    release: Callable[[], None]
+
+
+class _EventPairPool:
+    """Reusable pool of (start, end) timing-event pairs.
+
+    Preallocates `_EVENT_POOL_INITIAL_SIZE` pairs up front so the hot copy
+    loop never calls `torch.Event(enable_timing=True)` per-op: timing events
+    hold CUDA driver resources, and per-op creation/GC of them pressures the
+    driver when many small transfers are launched. Grows on demand if
+    exhausted by a burst of in-flight ops; growth is bounded by however many
+    ops are concurrently in flight, not per-op.
+    """
+
+    def __init__(self, size: int = _EVENT_POOL_INITIAL_SIZE) -> None:
+        self._pairs: list[tuple[torch.Event, torch.Event]] = [
+            (torch.Event(enable_timing=True), torch.Event(enable_timing=True))
+            for _ in range(size)
+        ]
+
+    def acquire(self) -> tuple[torch.Event, torch.Event]:
+        if self._pairs:
+            return self._pairs.pop()
+        return (torch.Event(enable_timing=True), torch.Event(enable_timing=True))
+
+    def release(self, pair: tuple[torch.Event, torch.Event]) -> None:
+        self._pairs.append(pair)
 
 
 class DmaCopyBackend:
@@ -33,6 +84,7 @@ class DmaCopyBackend:
         self._queue: queue.SimpleQueue | None = None
         self._thread: threading.Thread | None = None
         self._shutdown: bool = False
+        self._event_pool: _EventPairPool | None = None
 
     def init(
         self,
@@ -44,6 +96,7 @@ class DmaCopyBackend:
     ) -> None:
         self._load_stream = load_stream
         self._store_stream = store_stream
+        self._event_pool = _EventPairPool()
 
         # Stores read the live KV cache -> STREAM (paired with the compute-done
         # wait in get_finished); loads read stable pinned host memory -> ANY.
@@ -63,7 +116,7 @@ class DmaCopyBackend:
         self._queue = queue.SimpleQueue()
         self._thread = threading.Thread(
             target=self._copy_loop,
-            args=(self._queue, device, load_stream, store_stream),
+            args=(self._queue, device, load_stream, store_stream, self._event_pool),
             daemon=True,
         )
         self._thread.start()
@@ -74,7 +127,7 @@ class DmaCopyBackend:
         dst_blocks: list[int],
         is_store: bool,
         event_idx: int,
-        events_list: list[tuple[int, torch.Event]],
+        events_list: list[DmaCopyEvent],
         wait_event: torch.Event | None = None,
     ) -> None:
         params = self._store_params if is_store else self._load_params
@@ -106,6 +159,7 @@ class DmaCopyBackend:
         device: torch.device,
         load_stream: torch.cuda.Stream,
         store_stream: torch.cuda.Stream,
+        event_pool: _EventPairPool,
     ) -> None:
         current_platform.set_device(device)
         while True:
@@ -122,9 +176,26 @@ class DmaCopyBackend:
                 wait_event,
             ) = item
             stream = store_stream if is_store else load_stream
+            # Host prep (pure NumPy) happens first, outside the timed region,
+            # so DMA timing below excludes it.
+            prepared = prepare_copy_blocks(src_blocks, dst_blocks, params)
+            start_event, end_event = event_pool.acquire()
+            release = functools.partial(event_pool.release, (start_event, end_event))
             if wait_event is not None:
+                # #46278: stream-order the copy after compute-done, before
+                # start_event is recorded, so timing excludes the wait.
                 stream.wait_event(wait_event)
-            copy_blocks(src_blocks, dst_blocks, params)
-            event = torch.Event()
-            event.record(stream)
-            events_list.append((event_idx, event))
+            start_event.record(stream)
+            if prepared is not None:
+                submit_prepared_copy(prepared, params)
+            end_event.record(stream)
+            events_list.append(
+                DmaCopyEvent(
+                    event_idx=event_idx,
+                    start_event=start_event,
+                    end_event=end_event,
+                    num_bytes=prepared.total_bytes if prepared is not None else 0,
+                    is_store=is_store,
+                    release=release,
+                )
+            )

--- a/vllm/v1/simple_kv_offload/cuda_mem_ops.py
+++ b/vllm/v1/simple_kv_offload/cuda_mem_ops.py
@@ -158,15 +158,33 @@ def build_params(
     )
 
 
-def copy_blocks(
+class PreparedBatchCopy(NamedTuple):
+    """Host-side (pure NumPy) staging for a batch memcpy call.
+
+    Kept separate from submission so callers can time the DMA submit alone,
+    excluding this NumPy prep, while still keeping the arrays alive for the
+    lifetime of the in-flight `cuMemcpyBatchAsync` call (the driver reads
+    them synchronously at submit time, so no extra lifetime management is
+    needed beyond holding a reference to this tuple until submit returns).
+    """
+
+    src_all: np.ndarray
+    dst_all: np.ndarray
+    sz_all: np.ndarray
+    total_transfers: int
+    total_bytes: int
+
+
+def prepare_copy_blocks(
     src_block_ids: list[int],
     dst_block_ids: list[int],
     params: BatchMemcpyParams,
-) -> None:
-    """Copy blocks via cuMemcpyBatchAsync / hipMemcpyBatchAsync."""
+) -> PreparedBatchCopy | None:
+    """Compute per-transfer src/dst addresses and sizes. Returns None iff
+    there are zero transfers (nothing to submit)."""
     n = len(src_block_ids)
     if n == 0:
-        return
+        return None
 
     src_ids = np.array(src_block_ids, dtype=np.uint64)
     dst_ids = np.array(dst_block_ids, dtype=np.uint64)
@@ -180,16 +198,30 @@ def copy_blocks(
     sz_all = np.repeat(params.bpb, n)
     total = n * params.num_layers
 
+    return PreparedBatchCopy(
+        src_all=src_all,
+        dst_all=dst_all,
+        sz_all=sz_all,
+        total_transfers=total,
+        total_bytes=int(sz_all.sum()),
+    )
+
+
+def submit_prepared_copy(
+    prepared: PreparedBatchCopy,
+    params: BatchMemcpyParams,
+) -> None:
+    """Submit a prepared batch to cuMemcpyBatchAsync / hipMemcpyBatchAsync."""
     # ROCm 7.2.1/7.2.2 rejects any call with numAttrs>0 (hipMemcpyBatchAsync
     # hipamd/src/hip_memory.cpp:2819-2822); CUDA uses one attrs entry so
     # srcAccessOrder is honored. attrs / attrsIdxs are ignored when
     # numAttrs==0, so we pass the same values from both paths.
     num_attrs = 0 if current_platform.is_rocm() else 1
     err = _batch_memcpy_fn(
-        dst_all.ctypes.data,
-        src_all.ctypes.data,
-        sz_all.ctypes.data,
-        total,
+        prepared.dst_all.ctypes.data,
+        prepared.src_all.ctypes.data,
+        prepared.sz_all.ctypes.data,
+        prepared.total_transfers,
         ctypes.addressof(params.attrs),
         ctypes.byref(params.attrs_idx),
         num_attrs,
@@ -200,3 +232,20 @@ def copy_blocks(
         raise RuntimeError(
             f"batch memcpy failed: err={err} failIdx={params.fail_idx.value}"
         )
+
+
+def copy_blocks(
+    src_block_ids: list[int],
+    dst_block_ids: list[int],
+    params: BatchMemcpyParams,
+) -> None:
+    """Copy blocks via cuMemcpyBatchAsync / hipMemcpyBatchAsync.
+
+    Thin prepare+submit wrapper kept for compatibility; callers that need
+    DMA-only timing should call `prepare_copy_blocks`/`submit_prepared_copy`
+    directly so host-side NumPy prep is excluded from the timed region.
+    """
+    prepared = prepare_copy_blocks(src_block_ids, dst_block_ids, params)
+    if prepared is None:
+        return
+    submit_prepared_copy(prepared, params)

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -10,6 +10,10 @@ from typing import TYPE_CHECKING, Any
 from vllm.config import VllmConfig
 from vllm.distributed.kv_events import KVCacheEvent
 from vllm.distributed.kv_transfer.kv_connector.utils import yield_req_data
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.metrics import (
+    OffloadingConnectorStats,
+    _TransferMetricName,
+)
 from vllm.logger import init_logger
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
@@ -28,6 +32,7 @@ from vllm.v1.simple_kv_offload.metadata import (
     SimpleCPUOffloadMetadata,
     SimpleCPUOffloadWorkerMetadata,
 )
+from vllm.v1.simple_kv_offload.metrics import SimpleCPUMetricName
 
 if TYPE_CHECKING:
     from vllm.v1.core.kv_cache_manager import KVCacheBlocks
@@ -176,6 +181,10 @@ class SimpleCPUOffloadScheduler:
         # Events must be reported by all world_size workers before considered complete.
         self._expected_worker_count = vllm_config.parallel_config.world_size
         self._store_event_pending_counts: dict[int, int] = {}
+
+        # Accumulates transfer counters/histograms reported via worker meta
+        # since the last get_stats() call.
+        self._connector_stats = OffloadingConnectorStats()
 
     @staticmethod
     def _derive_cpu_config(
@@ -689,6 +698,35 @@ class SimpleCPUOffloadScheduler:
             else:
                 self._store_event_pending_counts[event_idx] = total
 
+        # --- Transfer stats ---
+        # `meta` here is already the TP/PP-aggregated worker metadata for this
+        # step (see vllm/distributed/kv_transfer/kv_connector/utils.py, which
+        # calls KVConnectorWorkerMetadata.aggregate() across workers before
+        # the scheduler ever sees a KVConnectorOutput), so folding it in once
+        # per call does not double-count per-rank transfer bytes/time.
+        transfer_stats = meta.transfer_stats
+        if not transfer_stats.is_empty():
+            new_stats = OffloadingConnectorStats()
+            if not transfer_stats.load.is_empty():
+                new_stats.increase_counter(
+                    _TransferMetricName.LOAD_BYTES, transfer_stats.load.bytes
+                )
+                new_stats.increase_counter(
+                    _TransferMetricName.LOAD_TIME, transfer_stats.load.time
+                )
+                for size in transfer_stats.load.sizes:
+                    new_stats.observe_histogram(_TransferMetricName.LOAD_SIZE, size)
+            if not transfer_stats.store.is_empty():
+                new_stats.increase_counter(
+                    _TransferMetricName.STORE_BYTES, transfer_stats.store.bytes
+                )
+                new_stats.increase_counter(
+                    _TransferMetricName.STORE_TIME, transfer_stats.store.time
+                )
+                for size in transfer_stats.store.sizes:
+                    new_stats.observe_histogram(_TransferMetricName.STORE_SIZE, size)
+            self._connector_stats.aggregate(new_stats)
+
     def _process_store_event(self, event_idx: int) -> None:
         """Process a fully-completed store event."""
         transfer = self._store_event_to_blocks.pop(event_idx, None)
@@ -760,6 +798,42 @@ class SimpleCPUOffloadScheduler:
         return bool(
             self._store_event_to_blocks or self._abandoned_store_event_to_blocks
         )
+
+    def get_stats(self) -> OffloadingConnectorStats | None:
+        """Pop accumulated transfer stats and merge in the current pool/pending
+        gauges. Gauges are always emitted (scheduler-only emission is
+        guaranteed even absent any worker-reported transfer activity)."""
+        stats: OffloadingConnectorStats | None = None
+        if not self._connector_stats.is_empty():
+            stats = self._connector_stats
+            self._connector_stats = OffloadingConnectorStats()
+        else:
+            stats = OffloadingConnectorStats()
+
+        # Usable blocks, matching BlockPool.get_usage()'s convention of
+        # excluding the null block from the total.
+        total = self.cpu_block_pool.num_gpu_blocks - 1
+        free = self.cpu_block_pool.get_num_free_blocks()
+        used = max(0, total - free)
+        usage = self.cpu_block_pool.get_usage()
+        stats.set_gauge(SimpleCPUMetricName.TOTAL_BLOCKS, total)
+        stats.set_gauge(SimpleCPUMetricName.FREE_BLOCKS, free)
+        stats.set_gauge(SimpleCPUMetricName.USED_BLOCKS, used)
+        stats.set_gauge(SimpleCPUMetricName.USAGE_PERC, usage)
+        # _load_event_to_reqs is a subset view (only requests whose load has
+        # already been dispatched to the worker) of _reqs_to_load -- counting
+        # it separately would double-count the same outstanding loads.
+        stats.set_gauge(SimpleCPUMetricName.PENDING_LOADS, len(self._reqs_to_load))
+        # Event-level count, matching has_pending_stores(): the eager-mode
+        # _reqs_to_store/_store_event_to_reqs/_in_flight_store_gpu_blocks maps
+        # are per-request views of the same in-flight store events, so they
+        # are excluded here to avoid double counting.
+        stats.set_gauge(
+            SimpleCPUMetricName.PENDING_STORES,
+            len(self._store_event_to_blocks)
+            + len(self._abandoned_store_event_to_blocks),
+        )
+        return stats
 
     def request_finished(
         self,

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -823,7 +823,16 @@ class SimpleCPUOffloadScheduler:
         # _load_event_to_reqs is a subset view (only requests whose load has
         # already been dispatched to the worker) of _reqs_to_load -- counting
         # it separately would double-count the same outstanding loads.
-        stats.set_gauge(SimpleCPUMetricName.PENDING_LOADS, len(self._reqs_to_load))
+        # _abandoned_reqs_to_load holds in-flight loads that reset() moved out
+        # of _reqs_to_load while their DMA is still draining (see reset());
+        # _reqs_to_load and _abandoned_reqs_to_load are disjoint (reset() pops
+        # a request from the former before inserting it into the latter, and
+        # _cleanup_load_request() pops from whichever one currently holds it),
+        # so summing them counts each outstanding load exactly once.
+        stats.set_gauge(
+            SimpleCPUMetricName.PENDING_LOADS,
+            len(self._reqs_to_load) + len(self._abandoned_reqs_to_load),
+        )
         # Event-level count, matching has_pending_stores(): the eager-mode
         # _reqs_to_store/_store_event_to_reqs/_in_flight_store_gpu_blocks maps
         # are per-request views of the same in-flight store events, so they

--- a/vllm/v1/simple_kv_offload/metadata.py
+++ b/vllm/v1/simple_kv_offload/metadata.py
@@ -8,6 +8,9 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorMetadata,
     KVConnectorWorkerMetadata,
 )
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
+    TransferStats,
+)
 
 INVALID_JOB_ID = -1
 
@@ -46,9 +49,14 @@ class SimpleCPUOffloadWorkerMetadata(KVConnectorWorkerMetadata):
     ``aggregate()`` sums counts across workers within a step.
     The scheduler-side manager accumulates across steps and processes
     a store completion only when count reaches ``world_size``.
+
+    ``transfer_stats`` carries completed-transfer byte/time samples since the
+    worker's last report (poll-and-reset); ``aggregate()`` sums across
+    workers (TP/PP) the same way ``completed_store_events`` does.
     """
 
     completed_store_events: dict[int, int]
+    transfer_stats: TransferStats = field(default_factory=TransferStats)
 
     def aggregate(
         self, other: "KVConnectorWorkerMetadata"
@@ -57,4 +65,7 @@ class SimpleCPUOffloadWorkerMetadata(KVConnectorWorkerMetadata):
         merged = dict(self.completed_store_events)
         for k, v in other.completed_store_events.items():
             merged[k] = merged.get(k, 0) + v
-        return SimpleCPUOffloadWorkerMetadata(completed_store_events=merged)
+        return SimpleCPUOffloadWorkerMetadata(
+            completed_store_events=merged,
+            transfer_stats=self.transfer_stats.aggregate(other.transfer_stats),
+        )

--- a/vllm/v1/simple_kv_offload/metrics.py
+++ b/vllm/v1/simple_kv_offload/metrics.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Scheduler-side gauge metric definitions for SimpleCPUOffloadConnector."""
+
+from vllm.v1.kv_offload.base import OffloadingGaugeMetadata, OffloadingMetricMetadata
+
+
+class SimpleCPUMetricName:
+    """Flat gauge metric names for the SimpleCPU offload block pool."""
+
+    TOTAL_BLOCKS = "vllm:simple_cpu_offload_total_blocks"
+    FREE_BLOCKS = "vllm:simple_cpu_offload_free_blocks"
+    USED_BLOCKS = "vllm:simple_cpu_offload_used_blocks"
+    USAGE_PERC = "vllm:simple_cpu_offload_usage_perc"
+    PENDING_LOADS = "vllm:simple_cpu_offload_pending_loads"
+    PENDING_STORES = "vllm:simple_cpu_offload_pending_stores"
+
+
+def get_simple_cpu_metric_definitions() -> dict[str, OffloadingMetricMetadata]:
+    return {
+        SimpleCPUMetricName.TOTAL_BLOCKS: OffloadingGaugeMetadata(
+            documentation="Total number of usable CPU KV cache blocks "
+            "(excludes the null block).",
+        ),
+        SimpleCPUMetricName.FREE_BLOCKS: OffloadingGaugeMetadata(
+            documentation="Number of free CPU KV cache blocks.",
+        ),
+        SimpleCPUMetricName.USED_BLOCKS: OffloadingGaugeMetadata(
+            documentation="Number of used CPU KV cache blocks.",
+        ),
+        SimpleCPUMetricName.USAGE_PERC: OffloadingGaugeMetadata(
+            documentation="Fraction of CPU KV cache blocks in use, between "
+            "0.0 and 1.0 (1.0 = 100% used).",
+        ),
+        SimpleCPUMetricName.PENDING_LOADS: OffloadingGaugeMetadata(
+            documentation="Number of requests with an outstanding CPU-to-GPU load.",
+        ),
+        SimpleCPUMetricName.PENDING_STORES: OffloadingGaugeMetadata(
+            documentation="Number of in-flight GPU-to-CPU store events, "
+            "including abandoned ones still draining.",
+        ),
+    }

--- a/vllm/v1/simple_kv_offload/metrics.py
+++ b/vllm/v1/simple_kv_offload/metrics.py
@@ -33,7 +33,9 @@ def get_simple_cpu_metric_definitions() -> dict[str, OffloadingMetricMetadata]:
             "0.0 and 1.0 (1.0 = 100% used).",
         ),
         SimpleCPUMetricName.PENDING_LOADS: OffloadingGaugeMetadata(
-            documentation="Number of requests with an outstanding CPU-to-GPU load.",
+            documentation="Number of requests with an outstanding CPU-to-GPU "
+            "load, including abandoned loads still draining after a cache "
+            "reset.",
         ),
         SimpleCPUMetricName.PENDING_STORES: OffloadingGaugeMetadata(
             documentation="Number of in-flight GPU-to-CPU store events, "

--- a/vllm/v1/simple_kv_offload/worker.py
+++ b/vllm/v1/simple_kv_offload/worker.py
@@ -7,9 +7,12 @@ from typing import TYPE_CHECKING
 import torch
 
 from vllm.config import VllmConfig
+from vllm.distributed.kv_transfer.kv_connector.v1.offloading.common import (
+    TransferStats,
+)
 from vllm.logger import init_logger
 from vllm.utils.torch_utils import PIN_MEMORY
-from vllm.v1.simple_kv_offload.copy_backend import DmaCopyBackend
+from vllm.v1.simple_kv_offload.copy_backend import DmaCopyBackend, DmaCopyEvent
 from vllm.v1.simple_kv_offload.cuda_mem_ops import pin_tensor
 from vllm.v1.simple_kv_offload.metadata import (
     SimpleCPUOffloadMetadata,
@@ -46,9 +49,9 @@ class SimpleCPUOffloadWorker:
 
         self._backend = DmaCopyBackend()
 
-        # Ordered (event_idx, Event). Events pre-allocated on main thread.
-        self._load_events: list[tuple[int, torch.Event]] = []
-        self._store_events: list[tuple[int, torch.Event]] = []
+        # Ordered per-op timing/completion events.
+        self._load_events: list[DmaCopyEvent] = []
+        self._store_events: list[DmaCopyEvent] = []
         # High-water marks: highest event_idx completed per stream.
         # When the event list is empty, the hwm covers all prior events.
         self._load_hwm: int = -1
@@ -66,6 +69,9 @@ class SimpleCPUOffloadWorker:
         self._pending_store_event_indices: set[int] = set()
         # Completed store events to report via build_connector_worker_meta
         self._completed_store_events: dict[int, int] = {}
+        # DMA transfer byte/time stats since the last build_connector_worker_meta
+        # call (poll-and-reset, see build_connector_worker_meta).
+        self._transfer_stats = TransferStats()
 
     def register_kv_caches(
         self,
@@ -267,13 +273,15 @@ class SimpleCPUOffloadWorker:
         return None, finished_recving or None
 
     def build_connector_worker_meta(self) -> SimpleCPUOffloadWorkerMetadata | None:
-        """Return completed store events since the last call."""
-        if not self._completed_store_events:
+        """Return completed store events and transfer stats since the last call."""
+        if not self._completed_store_events and self._transfer_stats.is_empty():
             return None
         meta = SimpleCPUOffloadWorkerMetadata(
             completed_store_events=self._completed_store_events,
+            transfer_stats=self._transfer_stats,
         )
         self._completed_store_events = {}
+        self._transfer_stats = TransferStats()
         return meta
 
     def handle_preemptions(
@@ -284,16 +292,36 @@ class SimpleCPUOffloadWorker:
             return
         self._flush_and_sync_all()
 
+    def _record_copy_event(self, ev: DmaCopyEvent) -> None:
+        """Record a completed op's DMA-only elapsed time into transfer stats.
+
+        `start_event` is recorded after the store-stream wait (see
+        `_copy_loop`), so the elapsed time here covers only the submitted
+        DMA itself, excluding both host NumPy prep and any compute-done
+        barrier wait.
+        """
+        if ev.num_bytes == 0:
+            # Empty batch: an event was still recorded to keep event_idx
+            # accounting contiguous, but there was no DMA to report.
+            return
+        seconds = ev.start_event.elapsed_time(ev.end_event) / 1000.0
+        stats = self._transfer_stats.store if ev.is_store else self._transfer_stats.load
+        stats.record(ev.num_bytes, seconds)
+
     def _flush_and_sync_all(self) -> None:
         """Synchronize all in-flight transfer events."""
-        for event_idx, event in self._load_events:
-            event.synchronize()
-            self._load_hwm = event_idx
+        for ev in self._load_events:
+            ev.end_event.synchronize()
+            self._record_copy_event(ev)
+            ev.release()
+            self._load_hwm = ev.event_idx
         self._load_events.clear()
 
-        for event_idx, event in self._store_events:
-            event.synchronize()
-            self._store_hwm = event_idx
+        for ev in self._store_events:
+            ev.end_event.synchronize()
+            self._record_copy_event(ev)
+            ev.release()
+            self._store_hwm = ev.event_idx
         self._store_events.clear()
 
     def _poll_stream_events(self, is_store: bool) -> int:
@@ -301,10 +329,12 @@ class SimpleCPUOffloadWorker:
         events = self._store_events if is_store else self._load_events
         hwm = self._store_hwm if is_store else self._load_hwm
         while events:
-            event_idx, event = events[0]
-            if not event.query():
+            ev = events[0]
+            if not ev.end_event.query():
                 break
-            hwm = event_idx
+            hwm = ev.event_idx
+            self._record_copy_event(ev)
+            ev.release()
             events.pop(0)
         if is_store:
             self._store_hwm = hwm


### PR DESCRIPTION
## What changed

Exposes production observability for `SimpleCPUOffloadConnector` (GPU HBM ↔ pinned-CPU KV block movement), rebuilt on top of the current offloading metrics architecture. This head is a fresh integration on `main` @ `550218b13670fd6708916a645d8f538d773409c3` (2026-07-13) — a real metrics-path migration as requested in review, not a conflict-resolve of the old head.

Commits:

1. `[KV Offload] Measure DMA-only SimpleCPU transfer timing with pooled events` — copy-path split + timing-event pool + worker transfer stats
2. `[KV Offload] Expose SimpleCPU offload metrics via generic offloading stats` — scheduler aggregation, pool/pending gauges, Prometheus wiring
3. `[KV Offload] Add SimpleCPU metrics integration tests`
4. `[Doc] Document SimpleCPU offload metrics`

## Why

SimpleCPU moves KV blocks between GPU HBM and pinned CPU memory, but operators previously could not see transfer direction, bytes, DMA timing, transfer-size distribution, CPU-pool utilization, or pending work. #33689. @Change72 also needs these for Simple-vs-Native measurements.

## Current architecture

SimpleCPU-specific metric definitions; generic offloading stats transport and observation.

- **Worker side**: the DMA copy loop brackets only the submitted copy with pooled `torch.Event(enable_timing=True)` pairs. `copy_blocks()` is split into `prepare_copy_blocks()` (host-side NumPy address/size staging) and `submit_prepared_copy()` (the `cuMemcpyBatchAsync`/`hipMemcpyBatchAsync` call); the start event is recorded after the store stream's compute-done wait (#46278), so measured time is DMA execution only — host prep and the compute barrier are excluded. The end timing event doubles as the existing completion event, preserving high-water-mark polling. Completed bytes/seconds/sizes accumulate into `TransferStats` on `SimpleCPUOffloadWorkerMetadata` (poll-and-reset via `build_connector_worker_meta()`, summed across TP/PP ranks by `aggregate()`).
- **Scheduler side**: `SimpleCPUOffloadScheduler.update_connector_output()` folds worker-reported `TransferStats` into an `OffloadingConnectorStats` accumulator (the self-describing `{types, data}` payload from #45957), mirroring `OffloadingConnectorScheduler`. `get_stats()` pops accumulated transfer stats and always merges in the pool/pending gauges, so scheduler-only emission works with zero transfer activity. Collection ordering follows #43877 (`update_connector_output()` before scheduler stats collection).
- **Prometheus**: `OffloadPromMetrics` gains two template methods (`_build_metric_metadata`, `_should_observe_deprecated_metrics`) with the generic spec-factory behavior unchanged; `SimpleCPUOffloadPromMetrics` is a thin subclass overriding only those two, reusing the generic lazy-child observation machinery. No duplicated observer, no bespoke serialization format.

```
worker DMA events ── TransferStats on worker meta (TP/PP aggregate)
        │
KVConnectorOutput.kv_connector_worker_meta
        │
scheduler update_connector_output() ──► OffloadingConnectorStats accumulator
        │                                        │
        └── (#43877 ordering) get_kv_connector_stats() = transfers + pool/pending gauges
                                                 │
                       SchedulerStats.kv_connector_stats (msgpack IPC)
                                                 │
                       KVConnectorProm.observe() ──► SimpleCPUOffloadPromMetrics ──► /metrics
```

## Metrics

Transfer metrics (flat names, shared with the generic `OffloadingConnector`; load = CPU→GPU, store = GPU→CPU):

| Metric | Type | Notes |
| --- | --- | --- |
| `vllm:kv_offload_load_bytes` / `vllm:kv_offload_store_bytes` | Counter | exact completed bytes |
| `vllm:kv_offload_load_time` / `vllm:kv_offload_store_time` | Counter | seconds, DMA execution only |
| `vllm:kv_offload_load_size` / `vllm:kv_offload_store_size` | Histogram | bytes per completed operation |

The deprecated `vllm:kv_offload_total_bytes`/`_total_time`/`_size` series (`transfer_type="CPU_to_GPU"`/`"GPU_to_CPU"`) remain mirrored during the migration, matching the framework's behavior for CPU offload specs.

SimpleCPU gauges (scheduler-side):

| Gauge | Meaning |
| --- | --- |
| `vllm:simple_cpu_offload_total_blocks` | usable CPU pool blocks (excludes null block) |
| `vllm:simple_cpu_offload_free_blocks` / `_used_blocks` | pool occupancy |
| `vllm:simple_cpu_offload_usage_perc` | fraction 0.0–1.0 (1.0 = 100% used) |
| `vllm:simple_cpu_offload_pending_loads` | requests with an outstanding CPU→GPU load |
| `vllm:simple_cpu_offload_pending_stores` | in-flight GPU→CPU store events, incl. abandoned ones still draining |

Pending definitions deliberately avoid double counting: `_load_event_to_reqs` and the eager-mode store maps are per-request views of the same work and are excluded (documented in code).

## Correctness guarantees preserved

- #46278: stores still wait on the compute-done event before DMA; `CU_MEMCPY_SRC_ACCESS_ORDER_STREAM` for stores, `ANY` for loads; ROCm `numAttrs=0` path untouched. The timing start event is recorded *after* the wait in stream order, so timing never includes the compute barrier.
- #43877: worker-only, scheduler-only, and combined stats all aggregate; scheduler stats are collected after `update_connector_output()`.
- #45957: labeled `{types, data}` payload; counters sum, gauges last-write-win, histograms append; survives msgpack IPC (tuple labelvalues verified in tests).
- #42289 TOCTOU fix and the existing store-race regression test are untouched and green.
- Production copy path is still real `cuMemcpyBatchAsync` — no synthetic metric simulator.

## Test coverage

`tests/v1/simple_kv_offload/` — 25 new tests (75 passed, CUDA-only module skips on non-GPU host):

- copy-loop call-order proof: `prepare → wait_event → start.record → submit → end.record` (and no wait for loads) — host prep and barrier provably outside the timed bracket, no wall-clock flakiness
- prep delay does not affect recorded DMA seconds (mocked elapsed time)
- event pool: exact preallocation, reuse without new allocations, bounded growth, release/return
- empty batches keep event-index accounting but emit no stats
- `build_kv_connector_stats(None)` + payload rehydration; counter/gauge/histogram aggregation with labels
- serialized stats path: real `MsgpackEncoder`/`MsgpackDecoder` round-trip, bare and via `SchedulerStats`
- worker poll-and-reset via `build_connector_worker_meta()` (incl. transfer-stats-only steps)
- scheduler-only gauge emission; worker+scheduler aggregation (counters popped, gauges persist); TP/PP meta aggregation
- Prometheus `observe()`: counter inc / gauge set / per-sample histogram observe, engine labels, deprecated `transfer_type` mirrors, no double observation, no `OffloadingSpecFactory` dependency

Validation on this head (macOS arm64 dev box, CPU-only):

```
pytest tests/v1/simple_kv_offload/ tests/v1/kv_connector/unit/offloading_connector/test_metrics.py
→ 75 passed, 2 skipped (CUDA-only)
pre-commit run --files <all changed files>
→ all hooks pass (ruff check/format, mypy 3.10, typos, markdownlint, SPDX, ...)
```

GPU-dependent tests (`test_worker.py` store-race test, `test_integration.py`) were not run on this machine; they are unmodified except adapting the store-race test to the new event dataclass shape (assertions unchanged).

## Hardware validation

Historical receipts from the previous head (same feature semantics, pre-migration code — **not rerun** on this head):

- **T4** (eviction-pressure run): GPU→CPU 1.85 GB, CPU→GPU 1.32 GB, 90/90 HTTP success. Default-style run showed GPU→CPU only, CPU→GPU absent without eviction (expected).
- **H100 80GB HBM3** (CUDA 13.0, PyTorch 2.11.0+cu130): GPU→CPU 13.87 GB, CPU→GPU 4.77 GB, 320/320 HTTP success. Required `VLLM_USE_DEEP_GEMM=0` for an unrelated DeepGEMM warmup issue in that image, hit before the SimpleCPU path.
- **Blackwell-class RTX PRO 6000 Server (sm120)** (CUDA 13.0, PyTorch 2.11.0+cu130): GPU→CPU 11.23 GB, CPU→GPU 4.77 GB, 320/320 HTTP success. Required `VLLM_USE_FLASHINFER_SAMPLER=0` (bundled FlashInfer wheel rejected sm120 JIT), hit before the SimpleCPU path. This was sm120 Blackwell-class validation — **not** B200/GB200.

Fresh GPU validation of this rebased head is pending; @Change72's offer to validate Simple-vs-Native on the updated head is very welcome.

## Known limitations

- CPU→GPU (load) metrics stay at zero unless stored KV is actually evicted from GPU and reloaded by a same-prefix request — expected behavior, documented.
- On ROCm the driver ignores `srcAccessOrder` (`numAttrs=0` workaround for ROCm 7.2.x) — pre-existing behavior, unchanged by this PR.
- Metrics are observability only; no scheduling/offload behavior changes.

## Related upstream work

- #35669 — generic offloading manager stats (payload/transport this PR migrates onto)
- #43877 — scheduler-side stats collection ordering (preserved; tested)
- #45957 — labeled, self-describing stats payloads (adopted)
- #46278 — GPU→CPU store synchronization + source access ordering (preserved; timing recorded after the barrier)

---

AI assistance was used for this change (rebase, migration, tests); every changed line has been reviewed by the submitting human, and the test commands above were run locally as stated. Not a duplicate: no other open PR implements SimpleCPU offload metrics — #42466 (generic cache-usage gauge) closed unmerged, and this PR predates and supersedes the offered takeover in the thread below.
