### PR TITLE
[Bugfix][Model] Fix DeepSeek V4 scale_fmt default for non-canonical quant configs

### DIFF
--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -1004,7 +1004,7 @@ class DeepseekV4Attention(nn.Module):
             prefix=f"{prefix}.wo_b",
         )
         self.softmax_scale = self.head_dim**-0.5
-        self.scale_fmt = config.quantization_config["scale_fmt"]
+        self.scale_fmt = config.quantization_config.get("scale_fmt", "ue8m0")
 
         self.rope_parameters = config.rope_scaling
 


### PR DESCRIPTION
## Purpose

Fixes #41604.

DeepSeek V4 attention currently reads `quantization_config["scale_fmt"]` directly. Non-canonical DeepSeek V4 quantization configs may omit this DeepSeek-specific field and fail during model initialization with `KeyError: 'scale_fmt'`.

This PR falls back to the existing canonical default `ue8m0`, matching the default used by the DeepSeek V4 attention layer implementation.

## Test Plan

Run local lint/static checks. Request the issue reporter to validate the GPU reproduction on their Ampere SM86 setup.

## Test Result

```text
pre-commit run ruff-check --files vllm/model_executor/models/deepseek_v4.py
# Passed

pre-commit run ruff-format --files vllm/model_executor/models/deepseek_v4.py
# Passed

python -m py_compile vllm/model_executor/models/deepseek_v4.py
# Passed

python -c "from vllm.model_executor.models.deepseek_v4 import DeepseekV4Attention; print(DeepseekV4Attention)"
# Passed
# Output:
# <class 'vllm.model_executor.models.deepseek_v4.DeepseekV4Attention'>
```