### PR TITLE
[KV Offload] Return None from lookup() for in-flight blocks

### DIFF
--- a/tests/v1/kv_offload/cpu/test_manager.py
+++ b/tests/v1/kv_offload/cpu/test_manager.py
@@ -163,9 +163,9 @@ def test_cpu_manager():
         ),
     )
 
-    # lookup [1, 2] -> not ready
-    assert cpu_manager.lookup(to_key(1), _EMPTY_REQ_CTX) is False
-    assert cpu_manager.lookup(to_key(2), _EMPTY_REQ_CTX) is False
+    # lookup [1, 2] -> write in-flight, not yet ready
+    assert cpu_manager.lookup(to_key(1), _EMPTY_REQ_CTX) is None
+    assert cpu_manager.lookup(to_key(2), _EMPTY_REQ_CTX) is None
 
     # no events so far
     assert list(cpu_manager.take_events()) == []
@@ -296,9 +296,9 @@ class TestARCPolicy:
             ),
         )
 
-        # lookup [1, 2] -> not ready
-        assert cpu_manager.lookup(to_key(1), _EMPTY_REQ_CTX) is False
-        assert cpu_manager.lookup(to_key(2), _EMPTY_REQ_CTX) is False
+        # lookup [1, 2] -> write in-flight, not yet ready
+        assert cpu_manager.lookup(to_key(1), _EMPTY_REQ_CTX) is None
+        assert cpu_manager.lookup(to_key(2), _EMPTY_REQ_CTX) is None
 
         # no events so far
         assert list(cpu_manager.take_events()) == []

--- a/vllm/v1/kv_offload/cpu/manager.py
+++ b/vllm/v1/kv_offload/cpu/manager.py
@@ -86,7 +86,11 @@ class CPUOffloadingManager(OffloadingManager):
 
     def lookup(self, key: OffloadKey, req_context: ReqContext) -> bool | None:
         block = self._policy.get(key)
-        return block is not None and block.is_ready
+        if block is None:
+            return False
+        if not block.is_ready:
+            return None  # write in-flight; caller should retry
+        return True
 
     def prepare_load(
         self,


### PR DESCRIPTION



## Purpose
`CPUOffloadingManager.lookup()` was returning `False` for both absent blocks and in-flight blocks (write started but not yet complete). 
The base class defines `None` to mean "retry later" which is the right semantic for in-flight.
This makes the scheduler defer instead of treating an in-flight block as a miss.

## Test Plan
```
pytest -v -s tests/v1/kv_offload/cpu/test_manager.py
```

## Test Result
```
tests/v1/kv_offload/cpu/test_manager.py::test_already_stored_block_not_evicted_during_prepare_store[lru] PASSED
tests/v1/kv_offload/cpu/test_manager.py::test_already_stored_block_not_evicted_during_prepare_store[arc] PASSED
tests/v1/kv_offload/cpu/test_manager.py::test_cpu_manager PASSED
tests/v1/kv_offload/cpu/test_manager.py::TestARCPolicy::test_basic PASSED
tests/v1/kv_offload/cpu/test_manager.py::TestARCPolicy::test_t1_to_t2_promotion PASSED
tests/v1/kv_offload/cpu/test_manager.py::TestARCPolicy::test_eviction_with_load PASSED
tests/v1/kv_offload/cpu/test_manager.py::TestARCPolicy::test_adaptive_target PASSED
tests/v1/kv_offload/cpu/test_manager.py::TestARCPolicy::test_t1_t2_eviction_policy PASSED
tests/v1/kv_offload/cpu/test_manager.py::TestARCPolicy::test_ghost_list_bounds PASSED
tests/v1/kv_offload/cpu/test_manager.py::TestARCPolicy::test_touch_ordering PASSED
tests/v1/kv_offload/cpu/test_manager.py::TestARCPolicy::test_failed_store PASSED
tests/v1/kv_offload/cpu/test_manager.py::TestARCPolicy::test_full_scenario PASSED
tests/v1/kv_offload/cpu/test_manager.py::test_filter_reused_manager PASSED
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

