### PR TITLE
Fix: merge default stop_token_ids with request stop_token_ids in to_sampling_params

### DIFF
--- a/tests/entrypoints/openai/test_stop_token_ids.py
+++ b/tests/entrypoints/openai/test_stop_token_ids.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionRequest
+from vllm.entrypoints.openai.completion.protocol import CompletionRequest
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+def _make_chat_request(stop_token_ids: list[int] | None = None):
+    return ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "Hello"}],
+        stop_token_ids=stop_token_ids,
+    )
+
+
+def _make_completion_request(stop_token_ids: list[int] | None = None):
+    return CompletionRequest(
+        model="test-model",
+        prompt="Hello",
+        stop_token_ids=stop_token_ids,
+    )
+
+
+@pytest.mark.parametrize(
+    "request_factory",
+    [_make_chat_request, _make_completion_request],
+)
+def test_default_stop_token_ids_are_preserved(request_factory):
+    request = request_factory()
+
+    sampling_params = request.to_sampling_params(
+        max_tokens=16,
+        default_sampling_params={"stop_token_ids": [101, 102]},
+    )
+
+    assert sampling_params.stop_token_ids == [101, 102]
+
+
+@pytest.mark.parametrize(
+    "request_factory",
+    [_make_chat_request, _make_completion_request],
+)
+def test_request_stop_token_ids_are_preserved_without_defaults(request_factory):
+    request = request_factory(stop_token_ids=[201, 202])
+
+    sampling_params = request.to_sampling_params(
+        max_tokens=16,
+        default_sampling_params={},
+    )
+
+    assert sampling_params.stop_token_ids == [201, 202]
+
+
+@pytest.mark.parametrize(
+    "request_factory",
+    [_make_chat_request, _make_completion_request],
+)
+def test_default_and_request_stop_token_ids_are_merged(request_factory):
+    request = request_factory(stop_token_ids=[202, 301])
+    default_sampling_params = {"stop_token_ids": [101, 202]}
+
+    sampling_params = request.to_sampling_params(
+        max_tokens=16,
+        default_sampling_params=default_sampling_params,
+    )
+
+    assert sampling_params.stop_token_ids == [101, 202, 301]
+    assert default_sampling_params == {"stop_token_ids": [101, 202]}

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -31,6 +31,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     ToolCall,
     UsageInfo,
 )
+from vllm.entrypoints.openai.sampling_params import merge_default_stop_token_ids
 from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.logprobs import Logprob
@@ -523,6 +524,10 @@ class ChatCompletionRequest(OpenAIBaseModel):
                 "min_p", self._DEFAULT_SAMPLING_PARAMS["min_p"]
             )
 
+        stop_token_ids = merge_default_stop_token_ids(
+            self.stop_token_ids, default_sampling_params
+        )
+
         prompt_logprobs = self.prompt_logprobs
         if prompt_logprobs is None and self.echo:
             prompt_logprobs = self.top_logprobs
@@ -574,7 +579,7 @@ class ChatCompletionRequest(OpenAIBaseModel):
             min_p=min_p,
             seed=self.seed,
             stop=self.stop,
-            stop_token_ids=self.stop_token_ids,
+            stop_token_ids=stop_token_ids,
             logprobs=self.top_logprobs if self.logprobs else None,
             prompt_logprobs=prompt_logprobs,
             ignore_eos=self.ignore_eos,

--- a/vllm/entrypoints/openai/completion/protocol.py
+++ b/vllm/entrypoints/openai/completion/protocol.py
@@ -19,6 +19,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     StructuralTagResponseFormat,
     UsageInfo,
 )
+from vllm.entrypoints.openai.sampling_params import merge_default_stop_token_ids
 from vllm.exceptions import VLLMValidationError
 from vllm.logger import init_logger
 from vllm.logprobs import Logprob
@@ -251,6 +252,10 @@ class CompletionRequest(OpenAIBaseModel):
                 "min_p", self._DEFAULT_SAMPLING_PARAMS["min_p"]
             )
 
+        stop_token_ids = merge_default_stop_token_ids(
+            self.stop_token_ids, default_sampling_params
+        )
+
         prompt_logprobs = self.prompt_logprobs
         if prompt_logprobs is None and self.echo:
             prompt_logprobs = self.logprobs
@@ -304,7 +309,7 @@ class CompletionRequest(OpenAIBaseModel):
             min_p=min_p,
             seed=self.seed,
             stop=self.stop,
-            stop_token_ids=self.stop_token_ids,
+            stop_token_ids=stop_token_ids,
             logprobs=self.logprobs,
             ignore_eos=self.ignore_eos,
             max_tokens=max_tokens if not echo_without_generation else 1,

--- a/vllm/entrypoints/openai/sampling_params.py
+++ b/vllm/entrypoints/openai/sampling_params.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+
+def merge_default_stop_token_ids(
+    request_stop_token_ids: list[int] | None,
+    default_sampling_params: dict | None,
+) -> list[int] | None:
+    """Merge server-default and request stop token ids deterministically."""
+    default_stop_token_ids = (default_sampling_params or {}).get("stop_token_ids") or ()
+    if not default_stop_token_ids:
+        return request_stop_token_ids
+
+    # Default stop token ids are model/server requirements, so request stop ids
+    # should extend them rather than replace them.
+    stop_token_ids = list(default_stop_token_ids)
+    seen_token_ids = set(stop_token_ids)
+    for token_id in request_stop_token_ids or ():
+        if token_id not in seen_token_ids:
+            stop_token_ids.append(token_id)
+            seen_token_ids.add(token_id)
+
+    return stop_token_ids


### PR DESCRIPTION



## Purpose

Server-configured stop_token_ids (via `--default-sampling-params` or model-specific setup) were silently dropped when a request specified its own `stop_token_ids`. This fixes the merge so both sets are honored, with deduplication preserving insertion order.

## Test Plan

New tests added to `tests/entrypoints/openai/test_stop_token_ids.py`

## Test Result

All pass.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

