### PR TITLE
[Attention][MLA] Add Triton-fused TurboQuant decode backend

### DIFF
--- a/benchmarks/kernels/benchmark_mla_turboquant_decode.py
+++ b/benchmarks/kernels/benchmark_mla_turboquant_decode.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Kernel microbench: fused MLA TurboQuant decode vs bf16 grouped MLA decode.
+
+Times stage1 (+ stage2 reduce) for both paths over a small (batch, ctx_len)
+grid at fixed num_q_heads/L/R, and prints a markdown table. Run on a single
+GPU; intended for inclusion in PR #41803 evidence section.
+
+Usage:
+    .venv/bin/python benchmarks/kernels/benchmark_mla_turboquant_decode.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+
+import torch
+
+# Reuse synth helpers from the equivalence test (same package layout).
+from tests.kernels.attention.test_mla_turboquant_dequant import (  # noqa: E402
+    make_synth_cache,
+    torch_ref_dequant,
+)
+from vllm.model_executor.layers.quantization.turboquant.centroids import (
+    get_centroids,
+)
+from vllm.v1.attention.backends.turboquant_attn import _build_hadamard
+from vllm.v1.attention.ops.triton_decode_attention import (
+    _decode_softmax_reducev_fwd,
+    decode_attention_fwd_grouped,
+)
+from vllm.v1.attention.ops.triton_turboquant_mla_decode import (
+    fused_mla_tq_decode_stage1,
+)
+
+
+def _time_ms(fn, warmup=10, trials=30):
+    for _ in range(warmup):
+        fn()
+    torch.accelerator.synchronize()
+    start = torch.Event(enable_timing=True)
+    end = torch.Event(enable_timing=True)
+    start.record()
+    for _ in range(trials):
+        fn()
+    end.record()
+    torch.accelerator.synchronize()
+    return start.elapsed_time(end) / trials
+
+
+def bench_one(B, ctx_len, H_q, L, R, mse_bits, page_size, num_kv_splits, device):
+    num_pages_per_seq = ctx_len // page_size
+    n_active = B * num_pages_per_seq
+    sm_scale = 1.0 / math.sqrt(L + R)
+
+    mse_bytes = math.ceil(L * mse_bits / 8)
+    kv_c_bytes = mse_bytes + 2
+    kpe_bytes = 2 * R
+    packed_bytes = kv_c_bytes + kpe_bytes
+
+    cache, _, _, _ = make_synth_cache(
+        n_active=n_active,
+        block_size=page_size,
+        L=L,
+        R=R,
+        mse_bits=mse_bits,
+        mse_bytes=mse_bytes,
+        kv_c_bytes=kv_c_bytes,
+        packed_bytes=packed_bytes,
+        device=device,
+        kpe_fp8=False,
+    )
+    centroids = get_centroids(L, mse_bits).to(device=device, dtype=torch.bfloat16)
+    Pi = _build_hadamard(L, str(device)).to(torch.bfloat16)
+
+    req_to_tokens = torch.arange(n_active, device=device, dtype=torch.int32).view(
+        B, num_pages_per_seq
+    )
+    b_seqlen = torch.full((B,), ctx_len, device=device, dtype=torch.int32)
+
+    torch.manual_seed(0)
+    q = torch.randn(B, H_q, L + R, device=device, dtype=torch.bfloat16)
+    q_rot = q.clone()
+    q_rot[..., :L] = (q[..., :L].reshape(-1, L) @ Pi).view(B, H_q, L)
+
+    # Materialize bf16 cache once for the baseline (cost not counted —
+    # baseline pretends an `auto` dtype that already stores bf16).
+    kv_full = torch_ref_dequant(
+        cache,
+        centroids,
+        Pi,
+        L=L,
+        R=R,
+        mse_bits=mse_bits,
+        mse_bytes=mse_bytes,
+        kv_c_bytes=kv_c_bytes,
+        norm_correction=True,
+        kpe_fp8=False,
+    )  # (n_active, page_size, L+R) bf16
+
+    # ----- TurboQuant fused path -----
+    attn_logits = torch.empty(
+        B, H_q, num_kv_splits, L + 1, device=device, dtype=torch.float32
+    )
+    o_fused_rot = torch.empty(B, H_q, L, device=device, dtype=torch.bfloat16)
+    lse_fused = torch.empty(B, H_q, device=device, dtype=torch.bfloat16)
+    v_holder = torch.empty((1, L), device=device, dtype=torch.bfloat16)
+
+    def run_tq():
+        fused_mla_tq_decode_stage1(
+            q_rot,
+            cache,
+            centroids,
+            attn_logits,
+            req_to_tokens,
+            b_seqlen,
+            sm_scale=sm_scale,
+            page_size=page_size,
+            L=L,
+            R=R,
+            mse_bits=mse_bits,
+            mse_bytes=mse_bytes,
+            kv_c_bytes=kv_c_bytes,
+            norm_correction=True,
+            kpe_fp8=False,
+            num_kv_splits=num_kv_splits,
+        )
+        _decode_softmax_reducev_fwd(
+            attn_logits,
+            q_rot,
+            o_fused_rot,
+            lse_fused,
+            v_holder,
+            b_seqlen,
+            num_kv_splits,
+        )
+
+    # ----- bf16 baseline (decode_attention_fwd_grouped over bf16 cache) -----
+    # kv_full: (n_active, page_size, L+R) → add KV-head dim of 1 for MLA layout.
+    k_buffer = kv_full.unsqueeze(2)  # (n_active, page_size, 1, L+R)
+    v_buffer = k_buffer[..., :L]
+    o_ref = torch.empty(B, H_q, L, device=device, dtype=torch.bfloat16)
+    lse_ref = torch.empty(B, H_q, device=device, dtype=torch.bfloat16)
+    attn_logits_ref = torch.empty(
+        B, H_q, num_kv_splits, L + 1, device=device, dtype=torch.float32
+    )
+    one_scale = torch.ones(1, device=device, dtype=torch.float32)
+
+    def run_bf16():
+        decode_attention_fwd_grouped(
+            q_rot,
+            k_buffer,
+            v_buffer,
+            o_ref,
+            lse_ref,
+            req_to_tokens,
+            b_seqlen,
+            attn_logits_ref,
+            num_kv_splits,
+            sm_scale,
+            page_size,
+            k_scale=one_scale,
+            v_scale=one_scale,
+            is_mla=True,
+        )
+
+    # Sanity warmup (also surfaces any signature mismatch up front).
+    run_tq()
+    run_bf16()
+    torch.accelerator.synchronize()
+
+    t_tq = _time_ms(run_tq)
+    t_bf = _time_ms(run_bf16)
+    return t_bf, t_tq
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--L", type=int, default=512)
+    p.add_argument("--R", type=int, default=64)
+    p.add_argument("--H-q", type=int, default=128)
+    p.add_argument("--page-size", type=int, default=64)
+    p.add_argument("--num-kv-splits", type=int, default=4)
+    p.add_argument("--bits", type=int, nargs="+", default=[3, 4])
+    p.add_argument("--batches", type=int, nargs="+", default=[1, 4, 16])
+    p.add_argument("--ctx-lens", type=int, nargs="+", default=[1024, 4096, 16384])
+    args = p.parse_args()
+
+    assert torch.cuda.is_available(), "needs CUDA"
+    device = torch.device("cuda")
+
+    rows = []
+    for bits in args.bits:
+        for B in args.batches:
+            for ctx in args.ctx_lens:
+                t_bf, t_tq = bench_one(
+                    B=B,
+                    ctx_len=ctx,
+                    H_q=args.H_q,
+                    L=args.L,
+                    R=args.R,
+                    mse_bits=bits,
+                    page_size=args.page_size,
+                    num_kv_splits=args.num_kv_splits,
+                    device=device,
+                )
+                speedup = t_bf / t_tq
+                rows.append((bits, B, ctx, t_bf, t_tq, speedup))
+                print(
+                    f"bits={bits} B={B:>2} ctx={ctx:>5} | "
+                    f"bf16={t_bf:7.3f}ms  tq={t_tq:7.3f}ms  "
+                    f"speedup={speedup:5.2f}x"
+                )
+
+    print("\n## Results (markdown)\n")
+    print("| bits | B | ctx_len | bf16 ms | TQ ms | TQ vs bf16 |")
+    print("|---:|---:|---:|---:|---:|---:|")
+    for bits, B, ctx, t_bf, t_tq, sp in rows:
+        print(f"| {bits} | {B} | {ctx} | {t_bf:.3f} | {t_tq:.3f} | {sp:.2f}× |")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/kernels/benchmark_mla_turboquant_decode_fp8.py
+++ b/benchmarks/kernels/benchmark_mla_turboquant_decode_fp8.py
@@ -1,0 +1,238 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""K3 baseline microbench — FP8 (turboquant_k8v4) decode workspace path.
+
+Times the current FP8 decode flow:
+    cache_fp8 -> dequant to bf16 workspace (kv_c) + write k_pe ->
+    decode_attention_fwd_grouped over bf16 workspace.
+
+This is the path that `_forward_mqa_fp8_workspace` runs today. Once K3 has
+a fused FP8 kernel, time it against these numbers (same B/ctx grid).
+
+Usage:
+    .venv/bin/python benchmarks/kernels/benchmark_mla_turboquant_decode_fp8.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import math
+
+import torch
+
+from vllm.v1.attention.ops.triton_decode_attention import (
+    _decode_softmax_reducev_fwd,
+    decode_attention_fwd_grouped,
+)
+from vllm.v1.attention.ops.triton_turboquant_mla_decode import (
+    fused_mla_tq_decode_stage1,
+)
+
+_FP8 = torch.float8_e4m3fn
+_BF16 = torch.bfloat16
+
+
+def _time_ms(fn, warmup=10, trials=30):
+    for _ in range(warmup):
+        fn()
+    torch.accelerator.synchronize()
+    start = torch.Event(enable_timing=True)
+    end = torch.Event(enable_timing=True)
+    start.record()
+    for _ in range(trials):
+        fn()
+    end.record()
+    torch.accelerator.synchronize()
+    return start.elapsed_time(end) / trials
+
+
+def _make_fp8_cache(n_active, page_size, L, R, device):
+    """FP8 layout: [L bytes fp8 kv_c | 2*R bytes bf16 k_pe]."""
+    kv_c_f = torch.randn(n_active, page_size, L, device=device, dtype=torch.float32)
+    kv_c_f = kv_c_f.clamp(-448.0, 448.0).to(_FP8)
+    k_pe = torch.randn(n_active, page_size, R, device=device, dtype=_BF16)
+    packed = L + 2 * R
+    cache = torch.empty(n_active, page_size, packed, device=device, dtype=torch.uint8)
+    cache[..., :L] = kv_c_f.view(torch.uint8)
+    cache[..., L:] = k_pe.view(torch.uint8).reshape(n_active, page_size, 2 * R)
+    k_scale = torch.tensor([1.0], device=device, dtype=torch.float32)
+    return cache, k_scale
+
+
+def bench_one(B, ctx_len, H_q, L, R, page_size, num_kv_splits, device):
+    num_pages_per_seq = ctx_len // page_size
+    n_active = B * num_pages_per_seq
+    sm_scale = 1.0 / math.sqrt(L + R)
+
+    cache, k_scale = _make_fp8_cache(n_active, page_size, L, R, device)
+    req_to_tokens = torch.arange(n_active, device=device, dtype=torch.int32).view(
+        B, num_pages_per_seq
+    )
+    b_seqlen = torch.full((B,), ctx_len, device=device, dtype=torch.int32)
+
+    torch.manual_seed(0)
+    q = torch.randn(B, H_q, L + R, device=device, dtype=_BF16)
+
+    workspace = torch.empty(n_active, page_size, L + R, device=device, dtype=_BF16)
+    o = torch.empty(B, H_q, L, device=device, dtype=_BF16)
+    lse = torch.empty(B, H_q, device=device, dtype=_BF16)
+    attn_logits = torch.empty(
+        B, H_q, num_kv_splits, L + 1, device=device, dtype=torch.float32
+    )
+
+    one_scale = torch.ones(1, device=device, dtype=torch.float32)
+
+    def run_baseline():
+        # Stage A: dequant fp8 → bf16 kv_c into workspace[..., :L]
+        kv_c_fp8 = cache[..., :L].contiguous().view(_FP8)
+        workspace[..., :L] = (kv_c_fp8.to(torch.float32) * k_scale).to(_BF16)
+        # Stage B: copy k_pe (bf16 reinterpret) into workspace[..., L:]
+        kpe = cache[..., L:].contiguous().view(_BF16).reshape(n_active, page_size, R)
+        workspace[..., L:] = kpe
+        # Stage C: bf16 grouped decode over workspace
+        k_buffer = workspace.unsqueeze(2)  # (n_active, page_size, 1, L+R)
+        v_buffer = k_buffer[..., :L]
+        decode_attention_fwd_grouped(
+            q,
+            k_buffer,
+            v_buffer,
+            o,
+            lse,
+            req_to_tokens,
+            b_seqlen,
+            attn_logits,
+            num_kv_splits,
+            sm_scale,
+            page_size,
+            k_scale=one_scale,
+            v_scale=one_scale,
+            is_mla=True,
+        )
+
+    def run_staging():
+        kv_c_fp8 = cache[..., :L].contiguous().view(_FP8)
+        workspace[..., :L] = (kv_c_fp8.to(torch.float32) * k_scale).to(_BF16)
+        kpe = cache[..., L:].contiguous().view(_BF16).reshape(n_active, page_size, R)
+        workspace[..., L:] = kpe
+
+    def run_decode_only():
+        k_buffer = workspace.unsqueeze(2)
+        v_buffer = k_buffer[..., :L]
+        decode_attention_fwd_grouped(
+            q,
+            k_buffer,
+            v_buffer,
+            o,
+            lse,
+            req_to_tokens,
+            b_seqlen,
+            attn_logits,
+            num_kv_splits,
+            sm_scale,
+            page_size,
+            k_scale=one_scale,
+            v_scale=one_scale,
+            is_mla=True,
+        )
+
+    # K3 fused FP8 path: stage1 reads fp8 cache directly, no staging.
+    centroids_unused = torch.empty(0, device=device, dtype=_BF16)
+    o_fused = torch.empty(B, H_q, L, device=device, dtype=_BF16)
+    lse_fused = torch.empty(B, H_q, device=device, dtype=_BF16)
+    v_holder = torch.empty((1, L), device=device, dtype=_BF16)
+    attn_logits_f = torch.empty(
+        B, H_q, num_kv_splits, L + 1, device=device, dtype=torch.float32
+    )
+
+    def run_fused():
+        fused_mla_tq_decode_stage1(
+            q,
+            cache,
+            centroids_unused,
+            attn_logits_f,
+            req_to_tokens,
+            b_seqlen,
+            sm_scale=sm_scale,
+            page_size=page_size,
+            L=L,
+            R=R,
+            mse_bits=0,
+            mse_bytes=0,
+            kv_c_bytes=L,
+            norm_correction=False,
+            kpe_fp8=False,
+            key_fp8=True,
+            k_scale=float(k_scale.item()),
+            num_kv_splits=num_kv_splits,
+        )
+        _decode_softmax_reducev_fwd(
+            attn_logits_f,
+            q,
+            o_fused,
+            lse_fused,
+            v_holder,
+            b_seqlen,
+            num_kv_splits,
+        )
+
+    run_baseline()
+    run_staging()
+    run_decode_only()
+    run_fused()
+    torch.accelerator.synchronize()
+    return (
+        _time_ms(run_baseline),
+        _time_ms(run_staging),
+        _time_ms(run_decode_only),
+        _time_ms(run_fused),
+    )
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--L", type=int, default=512)
+    p.add_argument("--R", type=int, default=64)
+    p.add_argument("--H-q", type=int, default=128)
+    p.add_argument("--page-size", type=int, default=64)
+    p.add_argument("--num-kv-splits", type=int, default=4)
+    p.add_argument("--batches", type=int, nargs="+", default=[1, 4, 16])
+    p.add_argument("--ctx-lens", type=int, nargs="+", default=[1024, 4096, 16384])
+    args = p.parse_args()
+
+    assert torch.cuda.is_available(), "needs CUDA"
+    device = torch.device("cuda")
+
+    rows = []
+    for B in args.batches:
+        for ctx in args.ctx_lens:
+            t_total, t_stage, t_dec, t_fused = bench_one(
+                B=B,
+                ctx_len=ctx,
+                H_q=args.H_q,
+                L=args.L,
+                R=args.R,
+                page_size=args.page_size,
+                num_kv_splits=args.num_kv_splits,
+                device=device,
+            )
+            speedup = t_total / t_fused if t_fused > 0 else 0.0
+            rows.append((B, ctx, t_total, t_stage, t_dec, t_fused, speedup))
+            print(
+                f"FP8  B={B:>2} ctx={ctx:>5} | "
+                f"total={t_total:7.3f}ms  staging={t_stage:7.3f}ms  "
+                f"decode={t_dec:7.3f}ms  fused={t_fused:7.3f}ms  "
+                f"speedup={speedup:.2f}x"
+            )
+
+    print("\n## Results (markdown)\n")
+    print("| B | ctx_len | baseline ms | staging ms | decode ms | fused ms | speedup |")
+    print("|---:|---:|---:|---:|---:|---:|---:|")
+    for B, ctx, t_total, t_stage, t_dec, t_fused, sp in rows:
+        print(
+            f"| {B} | {ctx} | {t_total:.3f} | {t_stage:.3f} | "
+            f"{t_dec:.3f} | {t_fused:.3f} | {sp:.2f}× |"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/design/attention_backends.md
+++ b/docs/design/attention_backends.md
@@ -136,11 +136,12 @@ Priority is **1 = highest** (tried first).
 
 | Priority | Backend |
 | -------- | ------- |
-| 1 | `FLASH_ATTN_MLA` |
-| 2 | `FLASHMLA` |
-| 3 | `FLASHINFER_MLA` |
-| 4 | `TRITON_MLA` |
-| 5 | `FLASHMLA_SPARSE` |
+| 1 | `TRITON_MLA_TURBOQUANT` |
+| 2 | `FLASH_ATTN_MLA` |
+| 3 | `FLASHMLA` |
+| 4 | `FLASHINFER_MLA` |
+| 5 | `TRITON_MLA` |
+| 6 | `FLASHMLA_SPARSE` |
 
 > **\*** For sparse MLA, FP8 KV cache always prefers `FLASHINFER_MLA_SPARSE`. With BF16 KV cache, `FLASHINFER_MLA_SPARSE` is preferred for low query-head counts (<= 16), while `FLASHMLA_SPARSE` is preferred otherwise.
 >
@@ -224,4 +225,5 @@ MLA decode backends are selected using the standard
 | `ROCM_AITER_MLA_SPARSE` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | 1, 64 | Any | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | N/A |
 | `ROCM_AITER_TRITON_MLA` | fp16, bf16 | `auto` | Any | Any | ❌ | ❌ | ❌ | ❌ | ❌ | Decoder | N/A |
 | `TRITON_MLA` | fp16, bf16 | `auto`, `float16`, `bfloat16`, `fp8`, `fp8_e4m3` | %16 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | Any |
+| `TRITON_MLA_TURBOQUANT` | bf16 | `turboquant_k8v4`, `turboquant_4bit_nc`, `turboquant_k3v4_nc`, `turboquant_3bit_nc` | %16 | Any | ❌ | ❌ | ❌ | ❌ | ✅ | Decoder | Any |
 | `XPU_MLA_SPARSE` | fp16, bf16 | `auto`, `float16`, `bfloat16` | Any | 576 | ❌ | ❌ | ✅ | ❌ | ❌ | Decoder | Any |

--- a/tests/kernels/attention/test_mla_turboquant_dequant.py
+++ b/tests/kernels/attention/test_mla_turboquant_dequant.py
@@ -1,0 +1,1122 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# Adapted from tools/test_mla_tq_fused_dequant.py
+"""Numerical equivalence sweep for fused MLA TurboQuant decode.
+
+Compares ``fused_mla_tq_decode_stage1 + _decode_softmax_reducev_fwd`` against
+a pure PyTorch oracle (``torch_ref_dequant`` materializing a bf16 KV cache,
+then ``decode_attention_fwd_grouped`` over it) across a 48-case parameter
+sweep.
+"""
+
+import math
+from collections import namedtuple
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.turboquant.centroids import (
+    get_centroids,
+)
+from vllm.v1.attention.backends.mla.triton_mla_tq import (
+    _pack_bits_rows,
+    _unpack_bits_rows,
+)
+from vllm.v1.attention.backends.turboquant_attn import _build_hadamard
+from vllm.v1.attention.ops.triton_decode_attention import (
+    _decode_softmax_reducev_fwd,
+)
+from vllm.v1.attention.ops.triton_turboquant_mla_decode import (
+    fused_mla_tq_decode_stage1,
+)
+
+
+def make_synth_cache(
+    n_active,
+    block_size,
+    L,
+    R,
+    mse_bits,
+    mse_bytes,
+    kv_c_bytes,
+    packed_bytes,
+    device,
+    kpe_fp8=False,
+):
+    """Construct a quantized cache with random indices/norms/k_pe.
+
+    When kpe_fp8=True, the k_pe segment uses [R fp8 bytes | 2-byte fp16 scale]
+    layout instead of 2*R bf16 bytes.
+    """
+    torch.manual_seed(0)
+    _FP8_DTYPE = torch.float8_e4m3fn
+    _FP8_MAX = 448.0
+    idx = torch.randint(
+        0, 1 << mse_bits, (n_active * block_size, L), device=device, dtype=torch.int64
+    )
+    packed_idx = _pack_bits_rows(idx, bits=mse_bits)
+    norms_fp16 = (0.5 + 1.5 * torch.rand(n_active * block_size, device=device)).to(
+        torch.float16
+    )
+    norms_bytes = norms_fp16.view(torch.uint8).view(-1, 2)
+    kpe_bf = torch.randn(n_active * block_size, R, device=device, dtype=torch.bfloat16)
+    if kpe_fp8:
+        kpe_f32 = kpe_bf.to(torch.float32)
+        max_abs = kpe_f32.abs().amax(dim=-1, keepdim=True).clamp(min=1e-8)
+        scale = max_abs / _FP8_MAX
+        x = (kpe_f32 / scale).clamp(-_FP8_MAX, _FP8_MAX).to(_FP8_DTYPE)
+        kpe_data_bytes = x.view(torch.uint8).view(-1, R)
+        scale_fp16 = scale.squeeze(-1).to(torch.float16)
+        scale_bytes = scale_fp16.view(torch.uint8).view(-1, 2)
+        kpe_bytes = torch.cat([kpe_data_bytes, scale_bytes], dim=-1)
+        kpe_dec = (x.to(torch.float32) * scale).to(torch.bfloat16)
+        kpe_ref = kpe_dec
+    else:
+        kpe_bytes = kpe_bf.view(torch.uint8).view(-1, 2 * R)
+        kpe_ref = kpe_bf
+    row = torch.cat([packed_idx, norms_bytes, kpe_bytes], dim=-1)
+    assert row.shape[-1] == packed_bytes, (row.shape, packed_bytes)
+    return (
+        row.view(n_active, block_size, packed_bytes).contiguous(),
+        idx,
+        norms_fp16,
+        kpe_ref,
+    )
+
+
+def torch_ref_dequant(
+    cache,
+    centroids_bf16,
+    Pi_bf16,
+    L,
+    R,
+    mse_bits,
+    mse_bytes,
+    kv_c_bytes,
+    norm_correction,
+    kpe_fp8=False,
+):
+    """Pure PyTorch reference dequant.
+
+    Returns a bf16 ``(nb, bs, L+R)`` tensor whose ``[..., :L]`` slice is
+    already ``@ Pi``-rotated (i.e. in the rotated frame the fused kernel
+    operates in on the q-side).  This matches the contract used by the
+    fused-path oracle: q is pre-rotated with ``Pi`` and the K cache used by
+    the oracle attention call is also pre-rotated, so the bilinear form
+    ``q^T k`` produces the same scores as the fused kernel.
+    """
+    _FP8_DTYPE = torch.float8_e4m3fn
+    nb, bs, _ = cache.shape
+    idx_bytes = cache[..., :mse_bytes].contiguous()
+    norms_bytes = cache[..., mse_bytes : mse_bytes + 2].contiguous()
+
+    idx = _unpack_bits_rows(idx_bytes, bits=mse_bits, D=L).to(torch.int32)
+    y_hat = centroids_bf16[idx.to(torch.int64)]
+    if norm_correction:
+        y32 = y_hat.to(torch.float32)
+        c_norm = y32.norm(dim=-1, keepdim=True).clamp(min=1e-8)
+        y_hat = (y32 / c_norm).to(torch.bfloat16)
+    vec_norm = norms_bytes.view(torch.float16).to(torch.bfloat16)
+    kv_c_pre_rot = y_hat * vec_norm
+    kv_c = kv_c_pre_rot.view(nb * bs, L) @ Pi_bf16
+    out = torch.empty(nb, bs, L + R, dtype=torch.bfloat16, device=cache.device)
+    out[..., :L] = kv_c.view(nb, bs, L)
+    if kpe_fp8:
+        kpe_fp8_bytes = cache[..., kv_c_bytes : kv_c_bytes + R].contiguous()
+        kpe_fp8_t = kpe_fp8_bytes.view(_FP8_DTYPE)
+        scale_bytes = cache[..., kv_c_bytes + R : kv_c_bytes + R + 2].contiguous()
+        scale_fp16 = scale_bytes.view(torch.float16)
+        scale_bf = scale_fp16.to(torch.bfloat16)
+        out[..., L:] = kpe_fp8_t.to(torch.bfloat16) * scale_bf
+    else:
+        out[..., L:] = cache[..., kv_c_bytes:].contiguous().view(torch.bfloat16)
+    return out
+
+
+Tol = namedtuple("Tol", "atol rtol min_cos")
+
+
+def _tolerance_for(mse_bits, norm_correction, kpe_fp8):
+    base_atol = 5e-3 if mse_bits == 4 else 8e-3
+    if kpe_fp8:
+        base_atol += 2e-3
+    min_cos = 0.999 if mse_bits == 4 else 0.997
+    return Tol(atol=base_atol, rtol=5e-3, min_cos=min_cos)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA only")
+@pytest.mark.parametrize("L", [128, 256, 512])
+@pytest.mark.parametrize("R", [32, 64])
+@pytest.mark.parametrize("mse_bits", [3, 4])
+@pytest.mark.parametrize("kpe_fp8", [False, True])
+@pytest.mark.parametrize("norm_correction", [False, True])
+@torch.inference_mode()
+def test_fused_mla_tq_decode_matches_torch_oracle(
+    L,
+    R,
+    mse_bits,
+    kpe_fp8,
+    norm_correction,
+):
+    device = torch.device("cuda")
+    B = 2
+    H_q = 16
+    num_kv_splits = 4
+    page_size = 64
+    num_pages_per_seq = 4
+    seqlen = page_size * num_pages_per_seq
+    n_active = B * num_pages_per_seq
+    sm_scale = 1.0 / math.sqrt(L + R)
+
+    mse_bytes = math.ceil(L * mse_bits / 8)
+    kv_c_bytes = mse_bytes + 2
+    kpe_bytes = (R + 2) if kpe_fp8 else 2 * R
+    packed_bytes = kv_c_bytes + kpe_bytes
+
+    cache, _, _, _ = make_synth_cache(
+        n_active=n_active,
+        block_size=page_size,
+        L=L,
+        R=R,
+        mse_bits=mse_bits,
+        mse_bytes=mse_bytes,
+        kv_c_bytes=kv_c_bytes,
+        packed_bytes=packed_bytes,
+        device=device,
+        kpe_fp8=kpe_fp8,
+    )
+
+    centroids = get_centroids(L, mse_bits).to(device=device, dtype=torch.bfloat16)
+    Pi = _build_hadamard(L, str(device)).to(torch.bfloat16)
+
+    req_to_tokens = torch.arange(n_active, device=device, dtype=torch.int32).view(
+        B, num_pages_per_seq
+    )
+    b_seqlen = torch.full((B,), seqlen, device=device, dtype=torch.int32)
+
+    torch.manual_seed(1)
+    q = torch.randn(B, H_q, L + R, device=device, dtype=torch.bfloat16)
+    q_rot = q.clone()
+    q_rot[..., :L] = (q[..., :L].reshape(-1, L) @ Pi).view(B, H_q, L)
+
+    attn_logits = torch.empty(
+        B, H_q, num_kv_splits, L + 1, device=device, dtype=torch.float32
+    )
+    fused_mla_tq_decode_stage1(
+        q_rot,
+        cache,
+        centroids,
+        attn_logits,
+        req_to_tokens,
+        b_seqlen,
+        sm_scale=sm_scale,
+        page_size=page_size,
+        L=L,
+        R=R,
+        mse_bits=mse_bits,
+        mse_bytes=mse_bytes,
+        kv_c_bytes=kv_c_bytes,
+        norm_correction=norm_correction,
+        kpe_fp8=kpe_fp8,
+        num_kv_splits=num_kv_splits,
+    )
+    o_fused_rot = torch.empty(B, H_q, L, device=device, dtype=torch.bfloat16)
+    lse_fused = torch.empty(B, H_q, device=device, dtype=torch.bfloat16)
+    v_shape_holder = torch.empty((1, L), device=device, dtype=torch.bfloat16)
+    _decode_softmax_reducev_fwd(
+        attn_logits,
+        q_rot,
+        o_fused_rot,
+        lse_fused,
+        v_shape_holder,
+        b_seqlen,
+        num_kv_splits,
+    )
+    o_fused = (o_fused_rot.reshape(-1, L) @ Pi).view(B, H_q, L).contiguous()
+
+    kv_full = torch_ref_dequant(
+        cache,
+        centroids,
+        Pi,
+        L=L,
+        R=R,
+        mse_bits=mse_bits,
+        mse_bytes=mse_bytes,
+        kv_c_bytes=kv_c_bytes,
+        norm_correction=norm_correction,
+        kpe_fp8=kpe_fp8,
+    )
+    # PyTorch attention oracle.  ``kv_full[..., :L]`` is the original-frame
+    # ``kv_c`` (i.e. (y_hat*vec_norm) @ Pi); ``kv_full[..., L:]`` is k_pe.
+    # The fused kernel computes scores as (q@Pi)·(y*vn) and reduces V over
+    # the same un-rotated (y*vn), then the caller un-rotates with @ Pi.  To
+    # match that, the oracle uses the *original* q against the
+    # original-frame kv cache: score = q · kv_c_orig = (q@Pi) · (y*vn),
+    # and o_ref = sum_s p_s · kv_c_orig (already un-rotated, no @ Pi needed).
+    kv_seq = kv_full.view(B, seqlen, L + R)
+    k_seq = kv_seq
+    v_seq = kv_seq[..., :L]
+    q_f32 = q.to(torch.float32)
+    k_f32 = k_seq.to(torch.float32)
+    v_f32 = v_seq.to(torch.float32)
+    scores = torch.einsum("bhd,bsd->bhs", q_f32, k_f32) * sm_scale
+    p = torch.softmax(scores, dim=-1)
+    o_ref = torch.einsum("bhs,bsd->bhd", p, v_f32).to(torch.bfloat16).contiguous()
+
+    tol = _tolerance_for(mse_bits, norm_correction, kpe_fp8)
+    torch.testing.assert_close(o_fused, o_ref, atol=tol.atol, rtol=tol.rtol)
+    cos = torch.nn.functional.cosine_similarity(
+        o_fused.flatten().float(),
+        o_ref.flatten().float(),
+        dim=0,
+    ).item()
+    assert cos >= tol.min_cos, f"cosine={cos} < {tol.min_cos}"
+
+
+# ---------------------------------------------------------------------------
+# FP8 key path (turboquant_k8v4)
+# ---------------------------------------------------------------------------
+
+_FP8_DTYPE = torch.float8_e4m3fn
+_FP8_MAX = 448.0
+
+
+def make_synth_cache_fp8(
+    n_active,
+    block_size,
+    L,
+    R,
+    k_pe_bytes,
+    packed_bytes,
+    device,
+    kpe_fp8=False,
+):
+    """Construct an FP8 key cache with random kv_c / k_pe.
+
+    Returns (cache_uint8, k_scale_tensor, kpe_ref_bf16).
+    """
+    torch.manual_seed(42)
+    kv_c_bf = torch.randn(n_active * block_size, L, device=device, dtype=torch.bfloat16)
+    # Per-tensor k_scale (layer-global).
+    max_abs = kv_c_bf.abs().amax().clamp(min=1e-8)
+    k_scale = max_abs / _FP8_MAX
+    kv_c_fp8 = (
+        (kv_c_bf.to(torch.float32) / k_scale).clamp(-_FP8_MAX, _FP8_MAX).to(_FP8_DTYPE)
+    )
+    kv_c_bytes = kv_c_fp8.view(torch.uint8).view(n_active * block_size, L)
+
+    kpe_bf = torch.randn(n_active * block_size, R, device=device, dtype=torch.bfloat16)
+    if kpe_fp8:
+        kpe_f32 = kpe_bf.to(torch.float32)
+        kpe_max = kpe_f32.abs().amax(dim=-1, keepdim=True).clamp(min=1e-8)
+        scale = kpe_max / _FP8_MAX
+        x = (kpe_f32 / scale).clamp(-_FP8_MAX, _FP8_MAX).to(_FP8_DTYPE)
+        kpe_data = x.view(torch.uint8).view(n_active * block_size, R)
+        scale_fp16 = scale.squeeze(-1).to(torch.float16)
+        scale_bytes = scale_fp16.view(torch.uint8).view(n_active * block_size, 2)
+        kpe_row = torch.cat([kpe_data, scale_bytes], dim=-1)
+        kpe_ref = (x.to(torch.float32) * scale).to(torch.bfloat16)
+    else:
+        kpe_row = kpe_bf.view(torch.uint8).view(n_active * block_size, 2 * R)
+        kpe_ref = kpe_bf
+
+    row = torch.cat([kv_c_bytes, kpe_row], dim=-1)
+    assert row.shape[-1] == packed_bytes, (row.shape, packed_bytes)
+    return (
+        row.view(n_active, block_size, packed_bytes).contiguous(),
+        k_scale,
+        kpe_ref,
+    )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA only")
+@pytest.mark.parametrize("L", [128, 256, 512])
+@pytest.mark.parametrize("R", [32, 64])
+@pytest.mark.parametrize("kpe_fp8", [False, True])
+@torch.inference_mode()
+def test_fused_mla_tq_decode_fp8_keys(L, R, kpe_fp8):
+    """FP8 key path (turboquant_k8v4): fused decode must match PyTorch oracle."""
+    device = torch.device("cuda")
+    B = 2
+    H_q = 16
+    num_kv_splits = 4
+    page_size = 64
+    num_pages_per_seq = 4
+    seqlen = page_size * num_pages_per_seq
+    n_active = B * num_pages_per_seq
+    sm_scale = 1.0 / math.sqrt(L + R)
+
+    kv_c_bytes = L  # 1 byte per fp8 element
+    kpe_bytes_count = (R + 2) if kpe_fp8 else 2 * R
+    packed_bytes = kv_c_bytes + kpe_bytes_count
+
+    cache, k_scale, kpe_ref = make_synth_cache_fp8(
+        n_active=n_active,
+        block_size=page_size,
+        L=L,
+        R=R,
+        k_pe_bytes=kpe_bytes_count,
+        packed_bytes=packed_bytes,
+        device=device,
+        kpe_fp8=kpe_fp8,
+    )
+
+    # k_scale as device scalar tensor (matching production code).
+    k_scale_tensor = k_scale.to(torch.float32).reshape(())
+
+    req_to_tokens = torch.arange(n_active, device=device, dtype=torch.int32).view(
+        B, num_pages_per_seq
+    )
+    b_seqlen = torch.full((B,), seqlen, device=device, dtype=torch.int32)
+
+    torch.manual_seed(1)
+    q = torch.randn(B, H_q, L + R, device=device, dtype=torch.bfloat16)
+
+    # FP8 path: no Hadamard rotation on q.
+    attn_logits = torch.empty(
+        B, H_q, num_kv_splits, L + 1, device=device, dtype=torch.float32
+    )
+    # centroids unused in FP8 mode — pass empty placeholder.
+    centroids_placeholder = torch.empty(0, device=device, dtype=torch.bfloat16)
+    fused_mla_tq_decode_stage1(
+        q,
+        cache,
+        centroids_placeholder,
+        attn_logits,
+        req_to_tokens,
+        b_seqlen,
+        sm_scale=sm_scale,
+        page_size=page_size,
+        L=L,
+        R=R,
+        mse_bits=0,
+        mse_bytes=0,
+        kv_c_bytes=kv_c_bytes,
+        norm_correction=False,
+        kpe_fp8=kpe_fp8,
+        key_fp8=True,
+        k_scale=k_scale_tensor,
+        num_kv_splits=num_kv_splits,
+    )
+    o_fused = torch.empty(B, H_q, L, device=device, dtype=torch.bfloat16)
+    lse_fused = torch.empty(B, H_q, device=device, dtype=torch.bfloat16)
+    v_shape_holder = torch.empty((1, L), device=device, dtype=torch.bfloat16)
+    _decode_softmax_reducev_fwd(
+        attn_logits,
+        q,
+        o_fused,
+        lse_fused,
+        v_shape_holder,
+        b_seqlen,
+        num_kv_splits,
+    )
+
+    # PyTorch oracle: dequant fp8 → bf16, then standard attention.
+    kv_c_fp8_view = cache[..., :L].contiguous().view(_FP8_DTYPE)
+    kv_c_deq = (kv_c_fp8_view.to(torch.float32) * k_scale_tensor.to(torch.float32)).to(
+        torch.bfloat16
+    )
+    if kpe_fp8:
+        kpe_fp8_view = (
+            cache[..., kv_c_bytes : kv_c_bytes + R].contiguous().view(_FP8_DTYPE)
+        )
+        scale_bytes = cache[..., kv_c_bytes + R : kv_c_bytes + R + 2].contiguous()
+        scale_fp16 = scale_bytes.view(torch.float16).to(torch.bfloat16)
+        kpe_deq = kpe_fp8_view.to(torch.bfloat16) * scale_fp16
+    else:
+        kpe_deq = cache[..., kv_c_bytes:].contiguous().view(torch.bfloat16)
+
+    kv_full = torch.cat(
+        [kv_c_deq.view(n_active, page_size, L), kpe_deq.view(n_active, page_size, R)],
+        dim=-1,
+    )
+    kv_seq = kv_full.view(B, seqlen, L + R)
+    # In MLA: K == V for the kv_c slice.
+    k_seq = kv_seq
+    v_seq = kv_seq[..., :L]
+    q_f32 = q.to(torch.float32)
+    k_f32 = k_seq.to(torch.float32)
+    v_f32 = v_seq.to(torch.float32)
+    scores = torch.einsum("bhd,bsd->bhs", q_f32, k_f32) * sm_scale
+    p = torch.softmax(scores, dim=-1)
+    o_ref = torch.einsum("bhs,bsd->bhd", p, v_f32).to(torch.bfloat16).contiguous()
+
+    torch.testing.assert_close(o_fused, o_ref, atol=5e-3, rtol=5e-3)
+    cos = torch.nn.functional.cosine_similarity(
+        o_fused.flatten().float(), o_ref.flatten().float(), dim=0
+    ).item()
+    assert cos >= 0.999, f"cosine={cos}"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end MSE roundtrip: quantize → packed cache → fused decode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA only")
+@pytest.mark.parametrize("L", [128, 512])
+@pytest.mark.parametrize("mse_bits", [3, 4])
+@pytest.mark.parametrize("norm_correction", [False, True])
+@torch.inference_mode()
+def test_mse_quant_store_decode_roundtrip(L, mse_bits, norm_correction):
+    """End-to-end: quantize real kv_c → pack into uint8 cache → fused
+    decode must match bf16 oracle that uses the original un-quantized kv_c.
+
+    This tests the full pipeline (Hadamard rotation, Lloyd-Max bucketize,
+    bit-pack, fused bit-unpack + centroid gather + vec_norm) against a
+    ground truth built from the *original* bf16 kv_c, not from synthetic
+    random indices.
+    """
+    R = 64
+    B = 2
+    H_q = 16
+    page_size = 64
+    num_pages_per_seq = 4
+    seqlen = page_size * num_pages_per_seq
+    n_active = B * num_pages_per_seq
+    num_kv_splits = 4
+    sm_scale = 1.0 / math.sqrt(L + R)
+    device = torch.device("cuda")
+
+    torch.manual_seed(99)
+    # Generate latent kv_c (what the model would produce).
+    n_tokens = n_active * page_size
+    kv_c_orig = torch.randn(n_tokens, L, device=device, dtype=torch.bfloat16)
+    k_pe_orig = torch.randn(n_tokens, R, device=device, dtype=torch.bfloat16)
+
+    # Build the packed TQ cache.
+    Pi = _build_hadamard(L, str(device))
+    Pi_bf16 = Pi.to(torch.bfloat16)
+    centroids = get_centroids(L, mse_bits).to(device=device, dtype=torch.bfloat16)
+
+    # Quantize: same logic as TritonMLATurboQuantImpl._quantize_kv_c_mse.
+    kv_c_f = kv_c_orig.to(torch.float32)
+    norms = kv_c_f.norm(dim=1, keepdim=True).clamp(min=1e-8)
+    x_hat = kv_c_f / norms
+    y = x_hat @ Pi.to(torch.float32)  # Pi is symmetric
+    c_sorted, _ = centroids.to(torch.float32).sort()
+    midpoints = (c_sorted[:-1] + c_sorted[1:]) / 2
+    idx = torch.bucketize(y.contiguous(), midpoints).clamp(max=(1 << mse_bits) - 1)
+    packed_idx = _pack_bits_rows(idx, bits=mse_bits)
+    norms_fp16 = norms.squeeze(1).to(torch.float16)
+    norms_bytes = norms_fp16.view(torch.uint8).view(-1, 2)
+    k_pe_bytes = k_pe_orig.view(torch.uint8).view(-1, 2 * R)
+    row = torch.cat([packed_idx, norms_bytes, k_pe_bytes], dim=-1)
+
+    mse_bytes = math.ceil(L * mse_bits / 8)
+    kv_c_bytes = mse_bytes + 2
+    packed_bytes = kv_c_bytes + 2 * R
+    assert row.shape[-1] == packed_bytes, (row.shape, packed_bytes)
+
+    cache = row.view(n_active, page_size, packed_bytes).contiguous()
+
+    # Build q (already rotated by Pi).
+    q = torch.randn(B, H_q, L + R, device=device, dtype=torch.bfloat16)
+    q_rot = q.clone()
+    q_rot[..., :L] = (q[..., :L].reshape(-1, L) @ Pi_bf16).view(B, H_q, L)
+
+    req_to_tokens = torch.arange(n_active, device=device, dtype=torch.int32).view(
+        B, num_pages_per_seq
+    )
+    b_seqlen = torch.full((B,), seqlen, device=device, dtype=torch.int32)
+
+    # Fused decode.
+    attn_logits = torch.empty(
+        B, H_q, num_kv_splits, L + 1, device=device, dtype=torch.float32
+    )
+    fused_mla_tq_decode_stage1(
+        q_rot,
+        cache,
+        centroids,
+        attn_logits,
+        req_to_tokens,
+        b_seqlen,
+        sm_scale=sm_scale,
+        page_size=page_size,
+        L=L,
+        R=R,
+        mse_bits=mse_bits,
+        mse_bytes=mse_bytes,
+        kv_c_bytes=kv_c_bytes,
+        norm_correction=norm_correction,
+        kpe_fp8=False,
+        num_kv_splits=num_kv_splits,
+    )
+    o_fused_rot = torch.empty(B, H_q, L, device=device, dtype=torch.bfloat16)
+    lse_fused = torch.empty(B, H_q, device=device, dtype=torch.bfloat16)
+    v_shape_holder = torch.empty((1, L), device=device, dtype=torch.bfloat16)
+    _decode_softmax_reducev_fwd(
+        attn_logits,
+        q_rot,
+        o_fused_rot,
+        lse_fused,
+        v_shape_holder,
+        b_seqlen,
+        num_kv_splits,
+    )
+    o_fused = (o_fused_rot.reshape(-1, L) @ Pi_bf16).view(B, H_q, L).contiguous()
+
+    # Oracle: bf16 attention over the original kv_c + k_pe.
+    kv_full = torch.cat([kv_c_orig, k_pe_orig], dim=-1)
+    kv_seq = kv_full.view(B, seqlen, L + R)
+    q_f32 = q.to(torch.float32)
+    k_f32 = kv_seq.to(torch.float32)
+    v_f32 = kv_seq[..., :L].to(torch.float32)
+    scores = torch.einsum("bhd,bsd->bhs", q_f32, k_f32) * sm_scale
+    p = torch.softmax(scores, dim=-1)
+    o_ref = torch.einsum("bhs,bsd->bhd", p, v_f32).to(torch.bfloat16).contiguous()
+
+    # Relaxed tolerance since quantization introduces systematic error.
+    # 3-bit has higher quantization distortion; cosine similarity is the
+    # primary quality metric.
+    base_atol = 0.15 if mse_bits == 4 else 0.3
+    tol = Tol(atol=base_atol, rtol=0.15, min_cos=0.93 if mse_bits == 3 else 0.96)
+    torch.testing.assert_close(o_fused, o_ref, atol=tol.atol, rtol=tol.rtol)
+    cos = torch.nn.functional.cosine_similarity(
+        o_fused.flatten().float(), o_ref.flatten().float(), dim=0
+    ).item()
+    assert cos >= tol.min_cos, f"cosine={cos}"
+
+
+# ---------------------------------------------------------------------------
+# Store kernel tests: _mla_fused_store_fp8 and _mla_fused_store_mse
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA only")
+@pytest.mark.parametrize("L", [128, 512])
+@pytest.mark.parametrize("R", [32, 64])
+@pytest.mark.parametrize("kpe_fp8", [False, True])
+@torch.inference_mode()
+def test_mla_fused_store_fp8(L, R, kpe_fp8):
+    """Verify _mla_fused_store_fp8 writes correct FP8 kv_c + k_pe bytes."""
+    from vllm.v1.attention.ops.triton_turboquant_store import _mla_fused_store_fp8
+
+    _FP8_DTYPE = torch.float8_e4m3fn
+    _FP8_MAX = 448.0
+    device = torch.device("cuda")
+
+    N = 8
+    block_size = 16
+    num_blocks = 2
+    k_pe_bytes = R + 2 if kpe_fp8 else 2 * R
+    packed_bytes = L + k_pe_bytes
+
+    torch.manual_seed(42)
+    kv_c = torch.randn(N, L, device=device, dtype=torch.bfloat16)
+    k_pe = torch.randn(N, R, device=device, dtype=torch.bfloat16)
+    k_scale = torch.tensor(1.5, device=device, dtype=torch.float32)
+
+    # slot_mapping: map each of N tokens to a slot in the cache.
+    slot_mapping = torch.arange(N, device=device, dtype=torch.int64)
+
+    kv_cache = torch.zeros(
+        num_blocks, block_size, packed_bytes, device=device, dtype=torch.uint8
+    )
+
+    _mla_fused_store_fp8(
+        kv_c,
+        k_pe,
+        kv_cache,
+        slot_mapping,
+        k_scale,
+        kv_lora_rank=L,
+        qk_rope_head_dim=R,
+        k_pe_fp8=kpe_fp8,
+    )
+
+    # Verify kv_c bytes: kv_c / k_scale → clamp → fp8 → uint8.
+    inv_scale = 1.0 / k_scale.item()
+    kv_c_f32 = kv_c.to(torch.float32) * inv_scale
+    kv_c_clamped = kv_c_f32.clamp(-_FP8_MAX, _FP8_MAX)
+    kv_c_fp8_ref = kv_c_clamped.to(_FP8_DTYPE)
+    kv_c_bytes_ref = kv_c_fp8_ref.view(torch.uint8)
+
+    flat_cache = kv_cache.view(-1, packed_bytes)
+    torch.testing.assert_close(flat_cache[:N, :L], kv_c_bytes_ref)
+
+    # Verify k_pe bytes.
+    if not kpe_fp8:
+        # bf16 path: k_pe stored as 2*R bytes.
+        k_pe_bf16_ref = k_pe.to(torch.bfloat16)
+        k_pe_bytes_ref = k_pe_bf16_ref.view(torch.uint8)
+        torch.testing.assert_close(flat_cache[:N, L:], k_pe_bytes_ref)
+    else:
+        # fp8 path: k_pe stored as R fp8 bytes + 2-byte fp16 scale.
+        kpe_f32 = k_pe.to(torch.float32)
+        absmax = kpe_f32.abs().amax(dim=-1, keepdim=True).clamp(min=1e-8)
+        scale = absmax / _FP8_MAX
+        kpe_scaled = kpe_f32 / scale
+        kpe_clamped = kpe_scaled.clamp(-_FP8_MAX, _FP8_MAX)
+        kpe_fp8_ref = kpe_clamped.to(_FP8_DTYPE)
+        kpe_data_ref = kpe_fp8_ref.view(torch.uint8)
+        scale_fp16_ref = scale.squeeze(-1).to(torch.float16)
+        scale_bytes_ref = scale_fp16_ref.view(torch.uint8).view(-1, 2)
+
+        torch.testing.assert_close(flat_cache[:N, L : L + R], kpe_data_ref)
+        torch.testing.assert_close(flat_cache[:N, L + R : L + R + 2], scale_bytes_ref)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA only")
+@pytest.mark.parametrize("L", [128, 512])
+@pytest.mark.parametrize("R", [32, 64])
+@pytest.mark.parametrize("mse_bits", [3, 4])
+@pytest.mark.parametrize("kpe_fp8", [False, True])
+@torch.inference_mode()
+def test_mla_fused_store_mse(L, R, mse_bits, kpe_fp8):
+    """Verify _mla_fused_store_mse writes correct packed MSE indices + norm
+    + k_pe bytes. Compares against a pure-Python reference implementation.
+    """
+    from vllm.model_executor.layers.quantization.turboquant.centroids import (
+        get_centroids,
+    )
+    from vllm.v1.attention.backends.turboquant_attn import _build_hadamard
+    from vllm.v1.attention.ops.triton_turboquant_store import _mla_fused_store_mse
+
+    _FP8_DTYPE = torch.float8_e4m3fn
+    _FP8_MAX = 448.0
+    device = torch.device("cuda")
+
+    N = 8
+    block_size = 16
+    num_blocks = 2
+    mse_bytes = math.ceil(L * mse_bits / 8)
+    kv_c_bytes = mse_bytes + 2
+    k_pe_bytes = R + 2 if kpe_fp8 else 2 * R
+    packed_bytes = kv_c_bytes + k_pe_bytes
+
+    torch.manual_seed(123)
+    kv_c = torch.randn(N, L, device=device, dtype=torch.bfloat16)
+    k_pe = torch.randn(N, R, device=device, dtype=torch.bfloat16)
+
+    Pi = _build_hadamard(L, str(device))
+    PiT = Pi.to(torch.float32)
+    cents = get_centroids(L, mse_bits).to(device=device, dtype=torch.float32)
+    c_sorted, _ = cents.sort()
+    midpoints = (c_sorted[:-1] + c_sorted[1:]) / 2
+
+    slot_mapping = torch.arange(N, device=device, dtype=torch.int64)
+    kv_cache = torch.zeros(
+        num_blocks, block_size, packed_bytes, device=device, dtype=torch.uint8
+    )
+
+    _mla_fused_store_mse(
+        kv_c,
+        k_pe,
+        kv_cache,
+        slot_mapping,
+        PiT,
+        midpoints,
+        mse_bits=mse_bits,
+        kv_lora_rank=L,
+        qk_rope_head_dim=R,
+        k_pe_fp8=kpe_fp8,
+    )
+
+    # Python reference: normalize + rotate + bucketize + pack.
+    kv_c_f = kv_c.to(torch.float32)
+    norms = kv_c_f.norm(dim=1)  # (N,)
+    x_hat = kv_c_f / (norms.unsqueeze(1) + 1e-8)
+    y = x_hat @ PiT  # (N, L) rotated
+    idx = torch.bucketize(y.contiguous(), midpoints).clamp(max=(1 << mse_bits) - 1)
+    packed_idx_ref = _pack_bits_rows(idx, bits=mse_bits)
+    norms_fp16_ref = norms.to(torch.float16)
+    norms_bytes_ref = norms_fp16_ref.view(torch.uint8).view(-1, 2)
+
+    flat_cache = kv_cache.view(-1, packed_bytes)
+
+    # Check MSE packed indices.
+    torch.testing.assert_close(flat_cache[:N, :mse_bytes], packed_idx_ref)
+
+    # Check vec_norm bytes.
+    torch.testing.assert_close(
+        flat_cache[:N, mse_bytes : mse_bytes + 2], norms_bytes_ref
+    )
+
+    # Check k_pe bytes.
+    kpe_offset = kv_c_bytes
+    if not kpe_fp8:
+        k_pe_bf16_ref = k_pe.to(torch.bfloat16)
+        k_pe_bytes_ref = k_pe_bf16_ref.view(torch.uint8)
+        torch.testing.assert_close(flat_cache[:N, kpe_offset:], k_pe_bytes_ref)
+    else:
+        kpe_f32 = k_pe.to(torch.float32)
+        absmax = kpe_f32.abs().amax(dim=-1, keepdim=True).clamp(min=1e-8)
+        scale = absmax / _FP8_MAX
+        kpe_scaled = kpe_f32 / scale
+        kpe_clamped = kpe_scaled.clamp(-_FP8_MAX, _FP8_MAX)
+        kpe_fp8_ref = kpe_clamped.to(_FP8_DTYPE)
+        kpe_data_ref = kpe_fp8_ref.view(torch.uint8)
+        scale_fp16_ref = scale.squeeze(-1).to(torch.float16)
+        scale_bytes_ref = scale_fp16_ref.view(torch.uint8).view(-1, 2)
+
+        torch.testing.assert_close(
+            flat_cache[:N, kpe_offset : kpe_offset + R], kpe_data_ref
+        )
+        torch.testing.assert_close(
+            flat_cache[:N, kpe_offset + R : kpe_offset + R + 2],
+            scale_bytes_ref,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Boundary condition tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA only")
+@pytest.mark.parametrize("mse_bits", [3, 4])
+@torch.inference_mode()
+def test_dequant_L1024(mse_bits):
+    """L=1024 stress test: maximum shared-memory pressure on the kernel."""
+    L = 1024
+    R = 64
+    kpe_fp8 = False
+    norm_correction = True
+    device = torch.device("cuda")
+    B = 2
+    H_q = 16
+    page_size = 64
+    num_pages_per_seq = 4
+    seqlen = page_size * num_pages_per_seq
+    n_active = B * num_pages_per_seq
+    num_kv_splits = 4
+    sm_scale = 1.0 / math.sqrt(L + R)
+
+    mse_bytes = math.ceil(L * mse_bits / 8)
+    kv_c_bytes = mse_bytes + 2
+    kpe_bytes = 2 * R
+    packed_bytes = kv_c_bytes + kpe_bytes
+
+    cache, _, _, _ = make_synth_cache(
+        n_active=n_active,
+        block_size=page_size,
+        L=L,
+        R=R,
+        mse_bits=mse_bits,
+        mse_bytes=mse_bytes,
+        kv_c_bytes=kv_c_bytes,
+        packed_bytes=packed_bytes,
+        device=device,
+        kpe_fp8=kpe_fp8,
+    )
+
+    centroids = get_centroids(L, mse_bits).to(device=device, dtype=torch.bfloat16)
+    Pi = _build_hadamard(L, str(device)).to(torch.bfloat16)
+
+    req_to_tokens = torch.arange(n_active, device=device, dtype=torch.int32).view(
+        B, num_pages_per_seq
+    )
+    b_seqlen = torch.full((B,), seqlen, device=device, dtype=torch.int32)
+
+    torch.manual_seed(1)
+    q = torch.randn(B, H_q, L + R, device=device, dtype=torch.bfloat16)
+    q_rot = q.clone()
+    q_rot[..., :L] = (q[..., :L].reshape(-1, L) @ Pi).view(B, H_q, L)
+
+    attn_logits = torch.empty(
+        B, H_q, num_kv_splits, L + 1, device=device, dtype=torch.float32
+    )
+    fused_mla_tq_decode_stage1(
+        q_rot,
+        cache,
+        centroids,
+        attn_logits,
+        req_to_tokens,
+        b_seqlen,
+        sm_scale=sm_scale,
+        page_size=page_size,
+        L=L,
+        R=R,
+        mse_bits=mse_bits,
+        mse_bytes=mse_bytes,
+        kv_c_bytes=kv_c_bytes,
+        norm_correction=norm_correction,
+        kpe_fp8=kpe_fp8,
+        num_kv_splits=num_kv_splits,
+    )
+
+    o_fused_rot = torch.empty(B, H_q, L, device=device, dtype=torch.bfloat16)
+    lse_fused = torch.empty(B, H_q, device=device, dtype=torch.bfloat16)
+    v_shape_holder = torch.empty((1, L), device=device, dtype=torch.bfloat16)
+    _decode_softmax_reducev_fwd(
+        attn_logits,
+        q_rot,
+        o_fused_rot,
+        lse_fused,
+        v_shape_holder,
+        b_seqlen,
+        num_kv_splits,
+    )
+    o_fused = (o_fused_rot.reshape(-1, L) @ Pi).view(B, H_q, L).contiguous()
+
+    kv_full = torch_ref_dequant(
+        cache,
+        centroids,
+        Pi,
+        L=L,
+        R=R,
+        mse_bits=mse_bits,
+        mse_bytes=mse_bytes,
+        kv_c_bytes=kv_c_bytes,
+        norm_correction=norm_correction,
+        kpe_fp8=kpe_fp8,
+    )
+    kv_seq = kv_full.view(B, seqlen, L + R)
+    kv_seq_f32 = kv_seq.to(torch.float32)
+    q_f32 = q.to(torch.float32)
+    scores = torch.einsum("bhd,bsd->bhs", q_f32, kv_seq_f32) * sm_scale
+    p = torch.softmax(scores, dim=-1)
+    o_ref = (
+        torch.einsum("bhs,bsd->bhd", p, kv_seq_f32[..., :L])
+        .to(torch.bfloat16)
+        .contiguous()
+    )
+
+    tol = _tolerance_for(mse_bits, norm_correction, kpe_fp8)
+    torch.testing.assert_close(o_fused, o_ref, atol=tol.atol, rtol=tol.rtol)
+    cos = torch.nn.functional.cosine_similarity(
+        o_fused.flatten().float(), o_ref.flatten().float(), dim=0
+    ).item()
+    assert cos >= tol.min_cos, f"cosine={cos}"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA only")
+@pytest.mark.parametrize("page_size", [16, 32])
+@torch.inference_mode()
+def test_dequant_small_page_sizes(page_size):
+    """Test minimum (16) and small (32) page sizes to verify addressing."""
+    L = 128
+    R = 32
+    mse_bits = 4
+    kpe_fp8 = False
+    norm_correction = False
+    device = torch.device("cuda")
+    B = 2
+    H_q = 8
+    num_pages_per_seq = 8
+    seqlen = page_size * num_pages_per_seq
+    n_active = B * num_pages_per_seq
+    num_kv_splits = 4
+    sm_scale = 1.0 / math.sqrt(L + R)
+
+    mse_bytes = math.ceil(L * mse_bits / 8)
+    kv_c_bytes = mse_bytes + 2
+    kpe_bytes = 2 * R
+    packed_bytes = kv_c_bytes + kpe_bytes
+
+    cache, _, _, _ = make_synth_cache(
+        n_active=n_active,
+        block_size=page_size,
+        L=L,
+        R=R,
+        mse_bits=mse_bits,
+        mse_bytes=mse_bytes,
+        kv_c_bytes=kv_c_bytes,
+        packed_bytes=packed_bytes,
+        device=device,
+        kpe_fp8=kpe_fp8,
+    )
+
+    centroids = get_centroids(L, mse_bits).to(device=device, dtype=torch.bfloat16)
+    Pi = _build_hadamard(L, str(device)).to(torch.bfloat16)
+
+    req_to_tokens = torch.arange(n_active, device=device, dtype=torch.int32).view(
+        B, num_pages_per_seq
+    )
+    b_seqlen = torch.full((B,), seqlen, device=device, dtype=torch.int32)
+
+    torch.manual_seed(7)
+    q = torch.randn(B, H_q, L + R, device=device, dtype=torch.bfloat16)
+    q_rot = q.clone()
+    q_rot[..., :L] = (q[..., :L].reshape(-1, L) @ Pi).view(B, H_q, L)
+
+    attn_logits = torch.empty(
+        B, H_q, num_kv_splits, L + 1, device=device, dtype=torch.float32
+    )
+    fused_mla_tq_decode_stage1(
+        q_rot,
+        cache,
+        centroids,
+        attn_logits,
+        req_to_tokens,
+        b_seqlen,
+        sm_scale=sm_scale,
+        page_size=page_size,
+        L=L,
+        R=R,
+        mse_bits=mse_bits,
+        mse_bytes=mse_bytes,
+        kv_c_bytes=kv_c_bytes,
+        norm_correction=norm_correction,
+        kpe_fp8=kpe_fp8,
+        num_kv_splits=num_kv_splits,
+    )
+
+    o_fused_rot = torch.empty(B, H_q, L, device=device, dtype=torch.bfloat16)
+    lse_fused = torch.empty(B, H_q, device=device, dtype=torch.bfloat16)
+    v_shape_holder = torch.empty((1, L), device=device, dtype=torch.bfloat16)
+    _decode_softmax_reducev_fwd(
+        attn_logits,
+        q_rot,
+        o_fused_rot,
+        lse_fused,
+        v_shape_holder,
+        b_seqlen,
+        num_kv_splits,
+    )
+    o_fused = (o_fused_rot.reshape(-1, L) @ Pi).view(B, H_q, L).contiguous()
+
+    kv_full = torch_ref_dequant(
+        cache,
+        centroids,
+        Pi,
+        L=L,
+        R=R,
+        mse_bits=mse_bits,
+        mse_bytes=mse_bytes,
+        kv_c_bytes=kv_c_bytes,
+        norm_correction=norm_correction,
+        kpe_fp8=kpe_fp8,
+    )
+    kv_seq = kv_full.view(B, seqlen, L + R)
+    kv_seq_f32 = kv_seq.to(torch.float32)
+    q_f32 = q.to(torch.float32)
+    scores = torch.einsum("bhd,bsd->bhs", q_f32, kv_seq_f32) * sm_scale
+    p = torch.softmax(scores, dim=-1)
+    o_ref = (
+        torch.einsum("bhs,bsd->bhd", p, kv_seq_f32[..., :L])
+        .to(torch.bfloat16)
+        .contiguous()
+    )
+
+    tol = _tolerance_for(mse_bits, norm_correction, kpe_fp8)
+    torch.testing.assert_close(o_fused, o_ref, atol=tol.atol, rtol=tol.rtol)
+    cos = torch.nn.functional.cosine_similarity(
+        o_fused.flatten().float(), o_ref.flatten().float(), dim=0
+    ).item()
+    assert cos >= tol.min_cos, f"cosine={cos}"
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA only")
+@torch.inference_mode()
+def test_dequant_scattered_page_table():
+    """Non-contiguous page table: pages are allocated in random order,
+    which is the realistic scenario during serving.
+    """
+    L = 256
+    R = 64
+    mse_bits = 4
+    kpe_fp8 = False
+    norm_correction = True
+    device = torch.device("cuda")
+    B = 2
+    H_q = 8
+    page_size = 16
+    num_pages_per_seq = 4
+    seqlen = page_size * num_pages_per_seq
+    n_active = B * num_pages_per_seq
+    num_kv_splits = 4
+    sm_scale = 1.0 / math.sqrt(L + R)
+
+    mse_bytes = math.ceil(L * mse_bits / 8)
+    kv_c_bytes = mse_bytes + 2
+    kpe_bytes = 2 * R
+    packed_bytes = kv_c_bytes + kpe_bytes
+
+    # Build cache with extra "decoy" blocks to scatter into.
+    total_blocks = n_active + 10
+    cache, _, _, _ = make_synth_cache(
+        n_active=total_blocks,
+        block_size=page_size,
+        L=L,
+        R=R,
+        mse_bits=mse_bits,
+        mse_bytes=mse_bytes,
+        kv_c_bytes=kv_c_bytes,
+        packed_bytes=packed_bytes,
+        device=device,
+        kpe_fp8=kpe_fp8,
+    )
+
+    centroids = get_centroids(L, mse_bits).to(device=device, dtype=torch.bfloat16)
+    Pi = _build_hadamard(L, str(device)).to(torch.bfloat16)
+
+    # Scattered page table: random permutation of block indices.
+    torch.manual_seed(55)
+    perm = torch.randperm(total_blocks, device=device, dtype=torch.int32)
+    req_to_tokens = perm[:n_active].view(B, num_pages_per_seq)
+    b_seqlen = torch.full((B,), seqlen, device=device, dtype=torch.int32)
+
+    q = torch.randn(B, H_q, L + R, device=device, dtype=torch.bfloat16)
+    q_rot = q.clone()
+    q_rot[..., :L] = (q[..., :L].reshape(-1, L) @ Pi).view(B, H_q, L)
+
+    attn_logits = torch.empty(
+        B, H_q, num_kv_splits, L + 1, device=device, dtype=torch.float32
+    )
+    fused_mla_tq_decode_stage1(
+        q_rot,
+        cache,
+        centroids,
+        attn_logits,
+        req_to_tokens,
+        b_seqlen,
+        sm_scale=sm_scale,
+        page_size=page_size,
+        L=L,
+        R=R,
+        mse_bits=mse_bits,
+        mse_bytes=mse_bytes,
+        kv_c_bytes=kv_c_bytes,
+        norm_correction=norm_correction,
+        kpe_fp8=kpe_fp8,
+        num_kv_splits=num_kv_splits,
+    )
+
+    o_fused_rot = torch.empty(B, H_q, L, device=device, dtype=torch.bfloat16)
+    lse_fused = torch.empty(B, H_q, device=device, dtype=torch.bfloat16)
+    v_shape_holder = torch.empty((1, L), device=device, dtype=torch.bfloat16)
+    _decode_softmax_reducev_fwd(
+        attn_logits,
+        q_rot,
+        o_fused_rot,
+        lse_fused,
+        v_shape_holder,
+        b_seqlen,
+        num_kv_splits,
+    )
+    o_fused = (o_fused_rot.reshape(-1, L) @ Pi).view(B, H_q, L).contiguous()
+
+    # Build oracle from the scattered cache pages.
+    kv_full = torch_ref_dequant(
+        cache,
+        centroids,
+        Pi,
+        L=L,
+        R=R,
+        mse_bits=mse_bits,
+        mse_bytes=mse_bytes,
+        kv_c_bytes=kv_c_bytes,
+        norm_correction=norm_correction,
+        kpe_fp8=kpe_fp8,
+    )
+    # Gather pages in scattered order.
+    gathered_pages = kv_full[req_to_tokens.long()]  # (B, P, bs, L+R)
+    kv_seq = gathered_pages.reshape(B, seqlen, L + R)
+    kv_seq_f32 = kv_seq.to(torch.float32)
+    q_f32 = q.to(torch.float32)
+    scores = torch.einsum("bhd,bsd->bhs", q_f32, kv_seq_f32) * sm_scale
+    p = torch.softmax(scores, dim=-1)
+    o_ref = (
+        torch.einsum("bhs,bsd->bhd", p, kv_seq_f32[..., :L])
+        .to(torch.bfloat16)
+        .contiguous()
+    )
+
+    tol = _tolerance_for(mse_bits, norm_correction, kpe_fp8)
+    torch.testing.assert_close(o_fused, o_ref, atol=tol.atol, rtol=tol.rtol)
+    cos = torch.nn.functional.cosine_similarity(
+        o_fused.flatten().float(), o_ref.flatten().float(), dim=0
+    ).item()
+    assert cos >= tol.min_cos, f"cosine={cos}"

--- a/tests/kernels/attention/test_mla_turboquant_qside_rotation.py
+++ b/tests/kernels/attention/test_mla_turboquant_qside_rotation.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Equivalence oracle for the q-side Hadamard rotation trick used by the
+TurboQuant MLA backend.
+
+Math
+----
+Store path produces packed indices for ``y = x_hat @ Pi^T`` (Pi is a
+Walsh-Hadamard rotation, symmetric self-inverse). Decode reconstructs
+``kv_c ≈ (y_hat @ Pi) * vec_norm``. The attention score for a query ``q`` is
+therefore::
+
+    score = q · kv_c = q · ((y_hat @ Pi) * vec_norm)
+                     = ((q @ Pi) · y_hat) * vec_norm
+
+The right-hand form lets us rotate ``q`` once per forward and feed the raw
+``y_hat * vec_norm`` directly into the fused decode kernel (no per-token
+K-side GEMM). This test pins that equivalence under the same bf16 tolerance
+the MLA backend already uses, before we cut over production code.
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+
+from vllm.model_executor.layers.quantization.turboquant.centroids import (
+    get_centroids,
+)
+from vllm.v1.attention.backends.turboquant_attn import _build_hadamard
+
+
+def _quantize_to_indices(x: torch.Tensor, centroids: torch.Tensor) -> torch.Tensor:
+    # Nearest-centroid lookup (Lloyd-Max); shape preserves x.
+    diff = (x.unsqueeze(-1) - centroids.view(1, 1, -1)).abs()
+    return diff.argmin(dim=-1)
+
+
+@pytest.mark.parametrize("L", [128, 256, 512, 1024])
+@pytest.mark.parametrize("bits", [3, 4])
+@pytest.mark.parametrize("norm_correction", [False, True])
+def test_q_side_rotation_equivalence(L: int, bits: int, norm_correction: bool) -> None:
+    """``q · ((y_hat @ Pi) * vn) == ((q @ Pi) · y_hat) * vn`` in bf16."""
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+
+    T = 64  # tokens
+    H = 8  # heads (q only — kv_c is shared across heads in MLA)
+
+    Pi = _build_hadamard(L, str(device)).to(torch.float32)
+    centroids = get_centroids(L, bits).to(device=device, dtype=torch.float32)
+
+    # Synthetic latent kv_c of shape (T, L), gaussian.
+    kv_c = torch.randn(T, L, device=device, dtype=torch.float32)
+
+    # Store-side: rotate, optionally norm-correct, then quantize.
+    y = kv_c @ Pi  # Pi is symmetric, so Pi == Pi^T
+    if norm_correction:
+        vec_norm = y.norm(dim=-1, keepdim=True).clamp_min(1e-6)
+        y_unit = y / vec_norm
+    else:
+        vec_norm = torch.ones(T, 1, device=device, dtype=torch.float32)
+        y_unit = y
+
+    idx = _quantize_to_indices(y_unit, centroids)
+    y_hat = centroids[idx]  # (T, L)
+
+    # Random query.
+    q = torch.randn(H, L, device=device, dtype=torch.float32)
+
+    # k-side reference: dequant, rotate, then dot with q.
+    k_recovered = (y_hat @ Pi) * vec_norm  # (T, L)
+    score_kside = (q @ k_recovered.T).to(torch.bfloat16).to(torch.float32)
+
+    # q-side fused: rotate q once, dot with raw y_hat, scale by vec_norm.
+    q_rot = q @ Pi
+    score_qside = ((q_rot @ y_hat.T) * vec_norm.T).to(torch.bfloat16).to(torch.float32)
+
+    torch.testing.assert_close(score_qside, score_kside, atol=5e-3, rtol=5e-3)
+    cos = torch.nn.functional.cosine_similarity(
+        score_qside.flatten(), score_kside.flatten(), dim=0
+    )
+    assert cos.item() >= 0.999, f"cosine={cos.item():.6f}"

--- a/tests/v1/attention/test_mla_turboquant_backend.py
+++ b/tests/v1/attention/test_mla_turboquant_backend.py
@@ -1,0 +1,216 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Backend-level tests for the Triton-fused TurboQuant MLA backend.
+
+These tests exercise the static surface of `TritonMLATurboQuantBackend`
+(class registration, supported dtypes / head sizes / CG mode, packed-cache
+shape) and the bit-pack helpers used by the write path. They do **not**
+launch a vLLM engine — numerical equivalence of the fused decode kernel
+is covered by `tests/kernels/attention/test_mla_turboquant_dequant.py`.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+import torch
+
+from vllm.v1.attention.backend import AttentionCGSupport
+from vllm.v1.attention.backends.mla.triton_mla_tq import (
+    TritonMLATurboQuantBackend,
+    TritonMLATurboQuantImpl,
+    TritonMLATurboQuantMetadataBuilder,
+    _enumerate_packed_sizes,
+    _pack_bits_rows,
+    _unpack_bits_rows,
+)
+from vllm.v1.attention.backends.registry import AttentionBackendEnum
+
+TQ_DTYPES = [
+    "turboquant_k8v4",
+    "turboquant_4bit_nc",
+    "turboquant_k3v4_nc",
+    "turboquant_3bit_nc",
+]
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — Backend registration & static surface
+# ---------------------------------------------------------------------------
+
+
+def test_registry_resolves_to_turboquant_backend():
+    """The enum entry must import and resolve to the right class."""
+    cls = AttentionBackendEnum.TRITON_MLA_TURBOQUANT.get_class()
+    assert cls is TritonMLATurboQuantBackend
+    assert cls.get_name() == "TRITON_MLA_TURBOQUANT"
+    assert cls.get_impl_cls() is TritonMLATurboQuantImpl
+    assert cls.get_builder_cls() is TritonMLATurboQuantMetadataBuilder
+
+
+@pytest.mark.parametrize("dtype_str", TQ_DTYPES)
+def test_supports_kv_cache_dtype(dtype_str):
+    """All four advertised TurboQuant cache dtypes must be claimed."""
+    assert TritonMLATurboQuantBackend.supports_kv_cache_dtype(dtype_str)
+
+
+def test_does_not_claim_foreign_kv_cache_dtypes():
+    """Backend must not silently accept non-TQ dtypes — that would steal the
+    selection from FP8 / bf16 backends in `current_platform.get_attn_backend`.
+    """
+    for foreign in ("auto", "fp8", "fp8_e4m3", "fp8_ds_mla"):
+        assert not TritonMLATurboQuantBackend.supports_kv_cache_dtype(foreign)
+
+
+def test_builder_advertises_uniform_batch_cudagraph():
+    """Loss of `UNIFORM_BATCH` would silently disable CUDA graph capture for
+    the TurboQuant decode path — a major perf regression.
+    """
+    assert (
+        TritonMLATurboQuantMetadataBuilder._cudagraph_support
+        is AttentionCGSupport.UNIFORM_BATCH
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — Packed cache shape & supported head sizes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("dtype_str", TQ_DTYPES)
+def test_kv_cache_shape_is_uint8_packed(dtype_str):
+    """`get_kv_cache_shape` returns `(num_blocks, block_size, head_size)`
+    — head_size is the packed-bytes-per-slot, not a logical dim."""
+    shape = TritonMLATurboQuantBackend.get_kv_cache_shape(
+        num_blocks=8,
+        block_size=16,
+        num_kv_heads=1,
+        head_size=576,
+        cache_dtype_str=dtype_str,
+    )
+    assert shape == (8, 16, 576)
+
+
+def test_supported_head_sizes_cover_all_presets():
+    """The `get_supported_head_sizes()` enumeration must include the packed
+    sizes for every (L, R, preset, kpe_fp8) combination — otherwise vLLM's
+    startup head-size validation rejects the backend.
+    """
+    sizes = set(TritonMLATurboQuantBackend.get_supported_head_sizes())
+    # Exact set is enumerated in _enumerate_packed_sizes; mirror a few
+    # high-value cells to catch regressions in either direction.
+    L, R = 512, 64
+    for kv_c in (
+        L,  # k8v4 fp8 keys
+        math.ceil(L * 4 / 8) + 2,  # 4bit MSE + vec_norm
+        math.ceil(L * 3 / 8) + 2,  # 3bit MSE + vec_norm
+    ):
+        for k_pe in (2 * R, R + 2):  # bf16 vs fp8 kpe layout
+            assert kv_c + k_pe in sizes, f"missing packed size {kv_c + k_pe}"
+
+    # _enumerate_packed_sizes is the single source of truth — make sure
+    # the public method returns exactly that set, sorted.
+    assert sorted(sizes) == _enumerate_packed_sizes()
+
+
+def test_supported_dtypes_bf16_only():
+    """The fused Triton kernel only supports bf16 — fp16 must not be claimed."""
+    assert torch.bfloat16 in TritonMLATurboQuantBackend.supported_dtypes
+    assert torch.float16 not in TritonMLATurboQuantBackend.supported_dtypes
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — Bit-pack roundtrip (foundation of the MSE write path)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA")
+@pytest.mark.parametrize("bits", [3, 4])
+@pytest.mark.parametrize("D", [128, 256, 512])
+@pytest.mark.parametrize("N", [1, 17, 64])
+def test_pack_unpack_roundtrip(bits, D, N):
+    """`_unpack_bits_rows(_pack_bits_rows(x)) == x` for all (bits, N, D)
+    relevant to MLA decode. Catches off-by-one byte-spill bugs in the
+    packer that would silently corrupt every quantized cache write.
+    """
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    idx = torch.randint(0, 1 << bits, (N, D), dtype=torch.int64, device=device)
+
+    packed = _pack_bits_rows(idx, bits)
+    expected_bytes = math.ceil(D * bits / 8)
+    assert packed.shape == (N, expected_bytes)
+    assert packed.dtype == torch.uint8
+
+    out = _unpack_bits_rows(packed, bits, D)
+    assert out.shape == (N, D)
+    assert torch.equal(out, idx)
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — TurboQuantConfig single source of truth for k_pe_bytes
+# ---------------------------------------------------------------------------
+
+
+def test_tq_config_k_pe_bytes_matches_env_var():
+    """TurboQuantConfig.k_pe_bytes must be the single source of truth for
+    both mla_attention.get_kv_cache_spec and the TQ MLA backend __init__.
+    """
+    from vllm.model_executor.layers.quantization.turboquant.config import (
+        TurboQuantConfig,
+    )
+
+    for rope_dim in [32, 64, 128]:
+        # bf16 layout: 2 * rope_dim
+        cfg = TurboQuantConfig(
+            head_dim=512,
+            key_quant_bits=4,
+            value_quant_bits=4,
+            rope_head_dim=rope_dim,
+            k_pe_fp8=False,
+        )
+        assert cfg.k_pe_bytes == 2 * rope_dim
+        assert cfg.mla_packed_bytes == cfg.key_packed_size + 2 * rope_dim
+
+        # fp8 layout: rope_dim + 2
+        cfg_fp8 = TurboQuantConfig(
+            head_dim=512,
+            key_quant_bits=4,
+            value_quant_bits=4,
+            rope_head_dim=rope_dim,
+            k_pe_fp8=True,
+        )
+        assert cfg_fp8.k_pe_bytes == rope_dim + 2
+        assert cfg_fp8.mla_packed_bytes == cfg_fp8.key_packed_size + rope_dim + 2
+
+
+def test_from_cache_dtype_forwards_mla_params():
+    """TurboQuantConfig.from_cache_dtype must forward rope_head_dim and
+    k_pe_fp8 so that the config carries the single source of truth."""
+    from vllm.model_executor.layers.quantization.turboquant.config import (
+        TurboQuantConfig,
+    )
+
+    cfg = TurboQuantConfig.from_cache_dtype(
+        "turboquant_k3v4_nc",
+        head_dim=512,
+        rope_head_dim=64,
+        k_pe_fp8=True,
+    )
+    assert cfg.rope_head_dim == 64
+    assert cfg.k_pe_fp8 is True
+    assert cfg.k_pe_bytes == 66  # 64 fp8 + 2 scale
+    assert cfg.mla_packed_bytes == cfg.key_packed_size + 66
+
+
+def test_from_cache_dtype_defaults_rope_dim_zero():
+    """Non-MLA call (no rope_head_dim) should default to 0 — k_pe_bytes
+    must not be called in that case."""
+    from vllm.model_executor.layers.quantization.turboquant.config import (
+        TurboQuantConfig,
+    )
+
+    cfg = TurboQuantConfig.from_cache_dtype("turboquant_k3v4_nc", head_dim=128)
+    assert cfg.rope_head_dim == 0
+    assert cfg.k_pe_fp8 is False

--- a/tools/bench_mla_tq_decode.py
+++ b/tools/bench_mla_tq_decode.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""P1 baseline benchmark for MLA + TurboQuant decode throughput.
+
+Measures TTFT, decode tok/s, and peak HBM across kv_cache_dtype x batch.
+
+Usage:
+    conda run -n vllm-mla-tq python tools/bench_mla_tq_decode.py \
+        --dtypes auto turboquant_k8v4 turboquant_4bit_nc \
+                 turboquant_k3v4_nc turboquant_3bit_nc \
+        --batches 1 4 16 --prompt-len 512 --gen-len 256
+
+Output:
+    tools/reports/p1_baseline.md (markdown table, appended)
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import os
+import time
+from pathlib import Path
+
+os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+
+import torch  # noqa: E402
+
+REPORT_PATH = Path(
+    os.environ.get(
+        "REPORT",
+        str(Path(__file__).resolve().parent / "reports" / "p1_baseline.md"),
+    )
+)
+MODEL_PATH = os.environ.get("MODEL", "/path/to/DeepSeek-V2-Lite")
+
+
+def make_prompt(prompt_len: int, tokenizer) -> str:
+    # Pick a deterministic, prose-like prompt so token count is stable.
+    base = (
+        "The history of artificial intelligence began in antiquity with myths "
+        "and stories of artificial beings endowed with intelligence. "
+    )
+    text = base * 200
+    ids = tokenizer.encode(text)[:prompt_len]
+    return tokenizer.decode(ids)
+
+
+def bench_one(
+    dtype: str,
+    batch: int,
+    prompt_len: int,
+    gen_len: int,
+    tp: int,
+    max_model_len: int,
+    gpu_memory_utilization: float = 0.8,
+    enforce_eager: bool = True,
+    chunked_prefill: bool = False,
+    prefix_caching: bool = False,
+) -> dict:
+    from vllm import LLM, SamplingParams
+
+    torch.accelerator.empty_cache()
+    torch.accelerator.reset_peak_memory_stats()
+
+    llm = LLM(
+        model=MODEL_PATH,
+        tensor_parallel_size=tp,
+        kv_cache_dtype=dtype,
+        enforce_eager=enforce_eager,
+        enable_prefix_caching=prefix_caching,
+        enable_chunked_prefill=chunked_prefill,
+        max_model_len=max_model_len,
+        max_num_seqs=max(batch, 1),
+        gpu_memory_utilization=gpu_memory_utilization,
+        trust_remote_code=True,
+        dtype="bfloat16",
+    )
+
+    tok = llm.get_tokenizer()
+    prompt = make_prompt(prompt_len, tok)
+    prompts = [prompt] * batch
+
+    # ---------- TTFT pass: prompt + 1 token ----------
+    sp_ttft = SamplingParams(temperature=0.0, max_tokens=1)
+    # warmup
+    llm.generate(prompts, sp_ttft, use_tqdm=False)
+    torch.accelerator.synchronize()
+    t0 = time.perf_counter()
+    llm.generate(prompts, sp_ttft, use_tqdm=False)
+    torch.accelerator.synchronize()
+    ttft_s = time.perf_counter() - t0
+
+    # ---------- decode pass: prompt + gen_len ----------
+    sp_dec = SamplingParams(temperature=0.0, max_tokens=gen_len)
+    torch.accelerator.synchronize()
+    t0 = time.perf_counter()
+    outs = llm.generate(prompts, sp_dec, use_tqdm=False)
+    torch.accelerator.synchronize()
+    total_s = time.perf_counter() - t0
+
+    gen_tokens = sum(len(o.outputs[0].token_ids) for o in outs)
+    decode_only_s = max(total_s - ttft_s, 1e-6)
+    decode_tps = gen_tokens / decode_only_s
+    peak_gb = torch.accelerator.max_memory_allocated() / (1024**3)
+
+    res = dict(
+        dtype=dtype,
+        batch=batch,
+        ttft_ms=ttft_s * 1000.0,
+        decode_tps=decode_tps,
+        gen_tokens=gen_tokens,
+        peak_hbm_gb=peak_gb,
+    )
+
+    # release model
+    del llm
+    gc.collect()
+    torch.accelerator.empty_cache()
+    return res
+
+
+def append_report(rows: list[dict], note: str = "") -> None:
+    REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    new = not REPORT_PATH.exists()
+    with REPORT_PATH.open("a") as f:
+        if new:
+            f.write("# P1 baseline — MLA + TurboQuant decode\n\n")
+        f.write(f"\n## Run @ {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+        if note:
+            f.write(f"\n_{note}_\n")
+        f.write(
+            "\n| dtype | batch | TTFT (ms) | decode tok/s | "
+            "gen toks | peak HBM (GB) |\n"
+        )
+        f.write("|---|---|---|---|---|---|\n")
+        for r in rows:
+            f.write(
+                f"| {r['dtype']} | {r['batch']} | "
+                f"{r['ttft_ms']:.1f} | {r['decode_tps']:.2f} | "
+                f"{r['gen_tokens']} | {r['peak_hbm_gb']:.2f} |\n"
+            )
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--dtypes",
+        nargs="+",
+        default=[
+            "auto",
+            "turboquant_k8v4",
+            "turboquant_4bit_nc",
+            "turboquant_k3v4_nc",
+            "turboquant_3bit_nc",
+        ],
+    )
+    ap.add_argument("--batches", nargs="+", type=int, default=[1, 4, 16])
+    ap.add_argument("--prompt-len", type=int, default=512)
+    ap.add_argument("--gen-len", type=int, default=256)
+    ap.add_argument("--tp", type=int, default=4)
+    ap.add_argument("--gpu-memory-utilization", type=float, default=0.8)
+    ap.add_argument("--note", type=str, default="")
+    ap.add_argument(
+        "--no-enforce-eager",
+        action="store_true",
+        help="Disable enforce_eager (lets vLLM use PIECEWISE/FULL CG)",
+    )
+    ap.add_argument(
+        "--chunked-prefill", action="store_true", help="Enable chunked prefill (P3-3)"
+    )
+    ap.add_argument(
+        "--prefix-caching", action="store_true", help="Enable prefix caching (P3-3)"
+    )
+    args = ap.parse_args()
+
+    enforce_eager = not args.no_enforce_eager
+    max_model_len = args.prompt_len + args.gen_len + 16
+    rows = []
+    for dtype in args.dtypes:
+        for batch in args.batches:
+            print(f"\n>>> bench dtype={dtype} batch={batch} eager={enforce_eager}")
+            try:
+                r = bench_one(
+                    dtype,
+                    batch,
+                    args.prompt_len,
+                    args.gen_len,
+                    args.tp,
+                    max_model_len,
+                    args.gpu_memory_utilization,
+                    enforce_eager=enforce_eager,
+                    chunked_prefill=args.chunked_prefill,
+                    prefix_caching=args.prefix_caching,
+                )
+            except Exception as e:
+                print(f"  FAILED: {e!r}")
+                r = dict(
+                    dtype=dtype,
+                    batch=batch,
+                    ttft_ms=float("nan"),
+                    decode_tps=float("nan"),
+                    gen_tokens=0,
+                    peak_hbm_gb=float("nan"),
+                )
+            print(
+                f"  TTFT={r['ttft_ms']:.1f}ms  "
+                f"decode={r['decode_tps']:.2f} tok/s  "
+                f"peak={r['peak_hbm_gb']:.2f} GB"
+            )
+            rows.append(r)
+
+    append_report(rows, args.note)
+    print(f"\nReport appended → {REPORT_PATH}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/run_gsm8k.sh
+++ b/tools/run_gsm8k.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# GSM8K 5-shot via lm-eval-harness across kv_cache_dtype settings.
+set -e
+MODEL=${MODEL:-/data/modelscope/DeepSeek-V2-Lite}
+TP=${TP:-4}
+DTYPES=${DTYPES:-"auto fp8 turboquant_k8v4 turboquant_4bit_nc turboquant_3bit_nc"}
+OUT=tools/reports/p3_gsm8k
+GPU_MEM=${GPU_MEM:-0.75}
+mkdir -p $OUT
+for DT in $DTYPES; do
+  echo "=== GSM8K 5-shot: kv_cache_dtype=$DT ==="
+  VLLM_ALLOW_INSECURE_SERIALIZATION=1 \
+  PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True \
+  .venv/bin/python -m lm_eval \
+    --model vllm \
+    --model_args "pretrained=$MODEL,tensor_parallel_size=$TP,kv_cache_dtype=$DT,max_model_len=4096,trust_remote_code=True,dtype=bfloat16,gpu_memory_utilization=$GPU_MEM,max_num_seqs=64,enforce_eager=True" \
+    --tasks gsm8k \
+    --num_fewshot 5 \
+    --batch_size auto \
+    --output_path $OUT/$DT 2>&1 | tee $OUT/$DT.log | tail -20
+done

--- a/tools/scan_mla_tq_kv_capacity.py
+++ b/tools/scan_mla_tq_kv_capacity.py
@@ -1,0 +1,134 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""§3.1 KV-cache capacity scan: how many decode tokens fit per dtype.
+
+For each kv_cache_dtype, init vLLM at fixed max_model_len + gpu_mem_util,
+read the resulting GPU KV cache size (tokens) and per-token bytes from
+vllm.v1.core.kv_cache_utils, then write a markdown row.
+
+Usage:
+    VLLM_ALLOW_INSECURE_SERIALIZATION=1 \
+    MODEL=/data/modelscope/DeepSeek-V2-Lite \
+        python tools/scan_mla_tq_kv_capacity.py \
+            --dtypes auto turboquant_k8v4 turboquant_4bit_nc turboquant_3bit_nc
+"""
+
+from __future__ import annotations
+
+import argparse
+import gc
+import os
+import time
+from pathlib import Path
+
+os.environ.setdefault("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+
+REPORT = Path(
+    os.environ.get(
+        "REPORT",
+        str(Path(__file__).resolve().parent / "reports" / "p3_1_kv_capacity.md"),
+    )
+)
+MODEL_PATH = os.environ.get("MODEL", "/data/modelscope/DeepSeek-V2-Lite")
+
+
+def probe(dtype: str, tp: int, max_model_len: int, gpu_mem: float) -> dict:
+    from vllm import LLM
+
+    llm = LLM(
+        model=MODEL_PATH,
+        tensor_parallel_size=tp,
+        max_model_len=max_model_len,
+        kv_cache_dtype=dtype,
+        max_num_seqs=1,
+        gpu_memory_utilization=gpu_mem,
+        trust_remote_code=True,
+        dtype="bfloat16",
+        enforce_eager=os.environ.get("ENFORCE_EAGER", "1") == "1",
+    )
+
+    # Pull cache config from engine
+    cfg = llm.llm_engine.vllm_config
+    kv_cfg = cfg.cache_config
+    num_gpu_blocks = kv_cfg.num_gpu_blocks or 0
+    block_size = kv_cfg.block_size
+    total_tokens = num_gpu_blocks * block_size
+    res = dict(
+        dtype=dtype,
+        max_model_len=max_model_len,
+        num_gpu_blocks=num_gpu_blocks,
+        block_size=block_size,
+        total_tokens=total_tokens,
+        max_concurrency=total_tokens / max_model_len if max_model_len else 0.0,
+    )
+
+    del llm
+    gc.collect()
+    return res
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument(
+        "--dtypes",
+        nargs="+",
+        default=[
+            "auto",
+            "turboquant_k8v4",
+            "turboquant_4bit_nc",
+            "turboquant_3bit_nc",
+        ],
+    )
+    ap.add_argument("--max-model-len", type=int, default=8192)
+    ap.add_argument("--tp", type=int, default=4)
+    ap.add_argument("--gpu-memory-utilization", type=float, default=0.8)
+    ap.add_argument("--note", type=str, default="")
+    args = ap.parse_args()
+
+    rows = []
+    for dt in args.dtypes:
+        print(f">>> probe dtype={dt}")
+        try:
+            r = probe(dt, args.tp, args.max_model_len, args.gpu_memory_utilization)
+        except Exception as e:
+            print(f"  FAILED: {e!r}")
+            r = dict(
+                dtype=dt,
+                max_model_len=args.max_model_len,
+                num_gpu_blocks=0,
+                block_size=0,
+                total_tokens=0,
+                max_concurrency=0.0,
+            )
+        print(
+            f"  blocks={r['num_gpu_blocks']} bs={r['block_size']} "
+            f"toks={r['total_tokens']} conc={r['max_concurrency']:.1f}x"
+        )
+        rows.append(r)
+
+    REPORT.parent.mkdir(parents=True, exist_ok=True)
+    new = not REPORT.exists()
+    with REPORT.open("a") as f:
+        if new:
+            f.write("# §3.1 KV-cache capacity per dtype\n\n")
+        f.write(f"\n## Run @ {time.strftime('%Y-%m-%d %H:%M:%S')}\n")
+        if args.note:
+            f.write(f"\n_{args.note}_\n")
+        f.write(
+            f"\nmax_model_len={args.max_model_len}  tp={args.tp}  "
+            f"gpu_mem_util={args.gpu_memory_utilization}\n\n"
+        )
+        f.write(
+            "| dtype | gpu blocks | block_size | total tokens | max concurrency |\n"
+        )
+        f.write("|---|---|---|---|---|\n")
+        for r in rows:
+            f.write(
+                f"| {r['dtype']} | {r['num_gpu_blocks']} | {r['block_size']} | "
+                f"{r['total_tokens']} | {r['max_concurrency']:.1f}x |\n"
+            )
+    print(f"\nReport appended → {REPORT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/test_k3_fp8_fused_equiv.py
+++ b/tools/test_k3_fp8_fused_equiv.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""K3 numerical equivalence: fused FP8 stage1 vs bf16-workspace baseline.
+
+Verifies that `fused_mla_tq_decode_stage1(key_fp8=True)` produces the same
+output as the legacy path of (cache_fp8 -> bf16 workspace) +
+`decode_attention_fwd_grouped`, modulo bf16 ULP-level rounding.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from vllm.v1.attention.ops.triton_decode_attention import (
+    _decode_softmax_reducev_fwd,
+    decode_attention_fwd_grouped,
+)
+from vllm.v1.attention.ops.triton_turboquant_mla_decode import (
+    fused_mla_tq_decode_stage1,
+)
+
+_FP8 = torch.float8_e4m3fn
+_BF16 = torch.bfloat16
+
+
+def main():
+    torch.manual_seed(0)
+    device = torch.device("cuda")
+    L, R, H_q = 512, 64, 128
+    B, ctx_len, page_size = 4, 4096, 64
+    num_kv_splits = 4
+    num_pages_per_seq = ctx_len // page_size
+    n_active = B * num_pages_per_seq
+    sm_scale = 1.0 / math.sqrt(L + R)
+
+    # Build cache.
+    kv_c_f = (
+        torch.randn(n_active, page_size, L, device=device, dtype=torch.float32)
+        .clamp(-448.0, 448.0)
+        .to(_FP8)
+    )
+    k_pe = torch.randn(n_active, page_size, R, device=device, dtype=_BF16)
+    cache = torch.empty(n_active, page_size, L + 2 * R, device=device, dtype=torch.uint8)
+    cache[..., :L] = kv_c_f.view(torch.uint8)
+    cache[..., L:] = k_pe.view(torch.uint8).reshape(n_active, page_size, 2 * R)
+    import os as _os
+    k_scale_t = torch.tensor(
+        float(_os.environ.get("K_SCALE", "1.0")),
+        device=device, dtype=torch.float32,
+    )
+    k_scale = float(k_scale_t.item())
+    print(f"k_scale = {k_scale}")
+
+    req_to_tokens = torch.arange(n_active, device=device, dtype=torch.int32).view(
+        B, num_pages_per_seq
+    )
+    b_seqlen = torch.full((B,), ctx_len, device=device, dtype=torch.int32)
+    q = torch.randn(B, H_q, L + R, device=device, dtype=_BF16)
+
+    # Baseline: dequant fp8 -> bf16 workspace -> decode_attention_fwd_grouped.
+    workspace = torch.empty(n_active, page_size, L + R, device=device, dtype=_BF16)
+    workspace[..., :L] = (kv_c_f.to(torch.float32) * k_scale).to(_BF16)
+    workspace[..., L:] = k_pe
+    o_ref = torch.empty(B, H_q, L, device=device, dtype=_BF16)
+    lse_ref = torch.empty(B, H_q, device=device, dtype=_BF16)
+    attn_logits_ref = torch.empty(
+        B, H_q, num_kv_splits, L + 1, device=device, dtype=torch.float32
+    )
+    one_scale = torch.ones(1, device=device, dtype=torch.float32)
+    decode_attention_fwd_grouped(
+        q,
+        workspace.unsqueeze(2),
+        workspace.unsqueeze(2)[..., :L],
+        o_ref,
+        lse_ref,
+        req_to_tokens,
+        b_seqlen,
+        attn_logits_ref,
+        num_kv_splits,
+        sm_scale,
+        page_size,
+        k_scale=one_scale,
+        v_scale=one_scale,
+        is_mla=True,
+    )
+
+    # Fused: stage1 reads fp8 directly; k_scale applied to y_hat before cast.
+    centroids_unused = torch.empty(0, device=device, dtype=_BF16)
+    o_fused = torch.empty(B, H_q, L, device=device, dtype=_BF16)
+    lse_fused = torch.empty(B, H_q, device=device, dtype=_BF16)
+    v_holder = torch.empty((1, L), device=device, dtype=_BF16)
+    attn_logits_f = torch.empty(
+        B, H_q, num_kv_splits, L + 1, device=device, dtype=torch.float32
+    )
+    fused_mla_tq_decode_stage1(
+        q,
+        cache,
+        centroids_unused,
+        attn_logits_f,
+        req_to_tokens,
+        b_seqlen,
+        sm_scale=sm_scale,
+        page_size=page_size,
+        L=L,
+        R=R,
+        mse_bits=0,
+        mse_bytes=0,
+        kv_c_bytes=L,
+        norm_correction=False,
+        kpe_fp8=False,
+        key_fp8=True,
+        k_scale=k_scale_t,
+        num_kv_splits=num_kv_splits,
+    )
+    _decode_softmax_reducev_fwd(
+        attn_logits_f, q, o_fused, lse_fused, v_holder, b_seqlen, num_kv_splits,
+    )
+
+    diff = (o_fused.to(torch.float32) - o_ref.to(torch.float32)).abs()
+    ref_rms = o_ref.to(torch.float32).pow(2).mean().sqrt().item()
+    diff_rms = diff.pow(2).mean().sqrt().item()
+    print(f"max abs diff   = {diff.max().item():.6e}")
+    print(f"diff RMS       = {diff_rms:.6e}")
+    print(f"ref RMS        = {ref_rms:.6e}")
+    print(f"rel RMS error  = {diff_rms / max(ref_rms, 1e-9):.6e}")
+
+    # bf16 ULP tolerance: O(1e-2) absolute is fine for this scale.
+    assert diff.max().item() < 0.05, "fused FP8 vs baseline diverged > 5e-2"
+    print("OK: K3 fused FP8 matches bf16-workspace baseline within bf16 tolerance.")
+
+
+if __name__ == "__main__":
+    main()

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -162,6 +162,7 @@ if TYPE_CHECKING:
     VLLM_TPU_BUCKET_PADDING_GAP: int = 0
     VLLM_TPU_MOST_MODEL_LEN: int | None = None
     VLLM_TPU_USING_PATHWAYS: bool = False
+    VLLM_TQ_KPE_FP8: bool = False
     VLLM_USE_DEEP_GEMM: bool = True
     VLLM_MOE_USE_DEEP_GEMM: bool = True
     VLLM_USE_DEEP_GEMM_E8M0: bool = True
@@ -1261,6 +1262,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_TPU_USING_PATHWAYS": lambda: bool(
         "proxy" in os.getenv("JAX_PLATFORMS", "").lower()
     ),
+    # TurboQuant MLA: store k_pe as fp8 (R bytes + 2B fp16 scale)
+    # instead of raw bf16 (2*R bytes). Default 0 (bf16 layout).
+    "VLLM_TQ_KPE_FP8": lambda: bool(int(os.getenv("VLLM_TQ_KPE_FP8", "0"))),
     # Allow use of DeepGemm kernels for fused moe ops.
     "VLLM_USE_DEEP_GEMM": lambda: bool(int(os.getenv("VLLM_USE_DEEP_GEMM", "1"))),
     # Allow use of DeepGemm specifically for MoE fused ops (overrides only MoE).

--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -949,6 +949,36 @@ class MLAAttention(nn.Module, AttentionLayerBase):
         return self.attn_backend
 
     def get_kv_cache_spec(self, vllm_config: VllmConfig) -> KVCacheSpec:
+        # TurboQuant MLA: cache is packed bytes per slot, not bf16 elements.
+        # Per-token layout: [ kv_c_packed | k_pe (2 * qk_rope bytes, bf16) ].
+        # kv_c_packed size depends on the preset (FP8/MSE bits) and comes
+        # from TurboQuantConfig.key_packed_size. We expose head_size=
+        # packed_bytes and dtype=uint8 so that the default
+        # real_page_size_bytes formula (block * num_kv_heads * head_size *
+        # dtype_size) matches the physical byte allocation.
+        if self.kv_cache_dtype.startswith("turboquant_"):
+            from vllm.model_executor.layers.quantization.turboquant.config import (
+                TurboQuantConfig,
+            )
+
+            # Single source of truth: k_pe_fp8 flag comes from envs.VLLM_TQ_KPE_FP8
+            # (registered in vllm/envs.py). The MLA TQ backend reads it from
+            # the config object (not the env var again).
+            k_pe_fp8 = envs.VLLM_TQ_KPE_FP8
+            tq_cfg = TurboQuantConfig.from_cache_dtype(
+                self.kv_cache_dtype,
+                head_dim=self.kv_lora_rank,
+                rope_head_dim=self.qk_rope_head_dim,
+                k_pe_fp8=k_pe_fp8,
+            )
+            packed_bytes = tq_cfg.mla_packed_bytes
+            return MLAAttentionSpec(
+                block_size=vllm_config.cache_config.block_size,
+                num_kv_heads=1,
+                head_size=packed_bytes,
+                dtype=torch.uint8,
+                cache_dtype_str=self.kv_cache_dtype,
+            )
         kv_cache_dtype = kv_cache_dtype_str_to_dtype(
             self.kv_cache_dtype, vllm_config.model_config
         )

--- a/vllm/model_executor/layers/quantization/turboquant/config.py
+++ b/vllm/model_executor/layers/quantization/turboquant/config.py
@@ -84,6 +84,13 @@ class TurboQuantConfig:
     value_quant_bits: int = 4  # 3-4 = uniform quantized values
     seed: int = 42  # kept for backward compatibility; no longer used internally
     norm_correction: bool = False
+    # MLA-specific: k_pe (rope) compression. When k_pe_fp8=True, k_pe is
+    # stored as R fp8 e4m3 bytes + 2-byte fp16 per-token scale (vs the
+    # default 2*R raw bf16 bytes). This is the single source of truth for
+    # k_pe_bytes — mla_attention.py and the TQ MLA backend both read from
+    # here, avoiding divergent env-var reads.
+    rope_head_dim: int = 0  # qk_rope_head_dim for MLA models (0 = non-MLA)
+    k_pe_fp8: bool = False
 
     @property
     def key_fp8(self) -> bool:
@@ -158,6 +165,28 @@ class TurboQuantConfig:
         return self.key_packed_size + self.value_packed_size
 
     @property
+    def k_pe_bytes(self) -> int:
+        """Packed bytes for k_pe (rope positions) in MLA models.
+
+        Requires rope_head_dim > 0 (MLA models only). Two layouts:
+          - bf16 (default): 2 * rope_head_dim bytes
+          - fp8 (k_pe_fp8=True): rope_head_dim bytes + 2-byte fp16 scale
+        """
+        if self.rope_head_dim <= 0:
+            raise ValueError("k_pe_bytes requires rope_head_dim > 0")
+        if self.k_pe_fp8:
+            return self.rope_head_dim + 2  # R fp8 e4m3 + fp16 scale
+        return 2 * self.rope_head_dim  # raw bf16
+
+    @property
+    def mla_packed_bytes(self) -> int:
+        """Total packed bytes per MLA slot (kv_c + k_pe).
+
+        Layout: [kv_c_packed (key_packed_size bytes) | k_pe (k_pe_bytes)]
+        """
+        return self.key_packed_size + self.k_pe_bytes
+
+    @property
     def slot_size_aligned(self) -> int:
         """Slot size rounded up to next even number.
 
@@ -206,7 +235,12 @@ class TurboQuantConfig:
         return [str(i) for i in indices]
 
     @staticmethod
-    def from_cache_dtype(cache_dtype: str, head_dim: int) -> TurboQuantConfig:
+    def from_cache_dtype(
+        cache_dtype: str,
+        head_dim: int,
+        rope_head_dim: int = 0,
+        k_pe_fp8: bool = False,
+    ) -> TurboQuantConfig:
         """Create config from a named preset.
 
         Valid presets: turboquant_k8v4, turboquant_4bit_nc, etc.
@@ -223,6 +257,8 @@ class TurboQuantConfig:
             key_quant_bits=preset["key_quant_bits"],
             value_quant_bits=preset["value_quant_bits"],
             norm_correction=preset["norm_correction"],
+            rope_head_dim=rope_head_dim,
+            k_pe_fp8=k_pe_fp8,
         )
 
 

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -118,6 +118,7 @@ def _get_backend_priorities(
             ]
         else:
             return [
+                AttentionBackendEnum.TRITON_MLA_TURBOQUANT,
                 AttentionBackendEnum.FLASH_ATTN_MLA,
                 AttentionBackendEnum.FLASHMLA,
                 AttentionBackendEnum.FLASHINFER_MLA,

--- a/vllm/v1/attention/backends/mla/triton_mla_tq.py
+++ b/vllm/v1/attention/backends/mla/triton_mla_tq.py
@@ -1,0 +1,871 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""TurboQuant TRITON_MLA backend for DeepSeek-style MLA.
+
+Supported presets (via --kv-cache-dtype):
+    turboquant_k8v4     — FP8 kv_c (8-bit, no Hadamard rotation), SM89+ required
+    turboquant_4bit_nc  — 4-bit MSE kv_c with Hadamard + Lloyd-Max + norm_correction
+    turboquant_k3v4_nc  — 3-bit MSE kv_c with Hadamard + Lloyd-Max + norm_correction
+    turboquant_3bit_nc  — 3-bit MSE kv_c with Hadamard + Lloyd-Max + norm_correction
+                          (in MLA, k/v bits collapse onto kv_c → same as k3v4_nc)
+
+Cache layout per token (uint8, byte-packed):
+    [ kv_c_packed (key_packed_size bytes) | k_pe (k_pe_bytes) ]
+
+k_pe bytes (controlled by TurboQuantConfig.k_pe_fp8):
+  default: 2 * qk_rope_head_dim bytes, raw bf16
+  optional: qk_rope_head_dim fp8 bytes + 2-byte fp16 scale
+
+kv_c_packed:
+  FP8 path:  kv_lora_rank bytes (1 B/elem, e4m3)
+  MSE path:  ceil(kv_lora_rank * mse_bits / 8) index bytes
+             + 2 B fp16 vec_norm
+
+Implementation strategy:
+  - do_kv_cache_update: quantize latent kv_c / ctkv and scatter packed bytes
+    into the uint8 KV cache.
+  - forward_mqa:
+      * k8v4 uses the fused KEY_FP8 branch in fused_mla_tq_decode_stage1.
+      * MSE presets use the fused bit-unpack + centroid-gather + vec_norm
+        branch in fused_mla_tq_decode_stage1.
+
+Reference material:
+  - #38479 general TurboQuant infrastructure
+  - vllm/v1/attention/backends/turboquant_attn.py
+  - vllm/model_executor/layers/quantization/turboquant/{config,centroids}.py
+  - vllm/v1/attention/ops/triton_turboquant_mla_decode.py
+"""
+
+import math
+from typing import ClassVar
+
+import torch
+
+import vllm.envs as envs
+from vllm.config.cache import CacheDType
+from vllm.logger import init_logger
+from vllm.model_executor.layers.attention.mla_attention import (
+    MLACommonMetadata,
+    MLACommonMetadataBuilder,
+)
+from vllm.model_executor.layers.quantization.turboquant.centroids import (
+    get_centroids,
+)
+from vllm.model_executor.layers.quantization.turboquant.config import (
+    TurboQuantConfig,
+)
+from vllm.platforms.interface import DeviceCapability
+from vllm.triton_utils import triton
+from vllm.v1.attention.backend import (
+    AttentionCGSupport,
+    AttentionLayer,
+    MultipleOf,
+)
+from vllm.v1.attention.backends.mla.triton_mla import (
+    TritonMLABackend,
+    TritonMLAImpl,
+)
+from vllm.v1.attention.backends.turboquant_attn import _build_hadamard
+from vllm.v1.attention.ops.triton_decode_attention import (
+    _decode_softmax_reducev_fwd,
+)
+from vllm.v1.attention.ops.triton_turboquant_mla_decode import (
+    fused_mla_dequant_mse,
+    fused_mla_tq_decode_stage1,
+)
+from vllm.v1.attention.ops.triton_turboquant_store import (
+    _mla_fused_store_fp8,
+    _mla_fused_store_mse,
+)
+
+logger = init_logger(__name__)
+
+_FP8_DTYPE = torch.float8_e4m3fn
+_FP8_MAX = 448.0
+_BF16 = torch.bfloat16
+
+
+def _enumerate_packed_sizes() -> list[int]:
+    """Return all head_size (=packed_bytes per slot) values this backend
+    accepts, across (L, R, preset, kpe_fp8) combinations supported by the
+    code paths in this module.
+
+    Concrete reasoning:
+      - L (kv_lora_rank): power of 2 in {128, 256, 512, 1024}
+      - R (qk_rope_head_dim): in {32, 64, 96, 128}
+      - kv_c_bytes for preset:
+          k8v4: L              (1 B/elem fp8)
+          4bit: ceil(L*4/8)+2 = L/2 + 2
+          3bit: ceil(L*3/8)+2
+      - k_pe_bytes: 2*R (bf16) or R+2 (fp8 + fp16 scale)
+
+    We enumerate the cross product so that any vLLM `get_supported_head_sizes`
+    membership check at startup will succeed.
+    """
+    import math as _math
+
+    sizes: set[int] = set()
+    for L in (128, 256, 512, 1024):
+        # k8v4 fp8 keys (1 byte/elem):
+        kv_c_options = [L]
+        # MSE 3-bit and 4-bit keys, +2 fp16 vec_norm:
+        for bits in (3, 4):
+            kv_c_options.append(_math.ceil(L * bits / 8) + 2)
+        for R in (32, 64, 96, 128):
+            for k_pe in (2 * R, R + 2):  # bf16 vs fp8 layout
+                for kv_c in kv_c_options:
+                    sizes.add(kv_c + k_pe)
+    return sorted(sizes)
+
+
+# ----------------------------------------------------------------------
+# Bit-packing helpers (pure PyTorch, correctness-first).
+# ----------------------------------------------------------------------
+
+
+def _pack_bits_rows(idx: torch.Tensor, bits: int) -> torch.Tensor:
+    """Pack (N, D) int indices into (N, ceil(D*bits/8)) uint8 rows.
+
+    Because the `bits`-wide fields land in disjoint bit ranges within each
+    byte, we can use integer addition (scatter_add_) as a stand-in for
+    bitwise-OR and convert the int32 accumulator back to uint8 at the end.
+
+    Args:
+        idx: (N, D) integer tensor in [0, 2**bits).
+        bits: 3 or 4.
+
+    Returns:
+        (N, ceil(D*bits/8)) uint8 tensor.
+    """
+    assert bits in (3, 4), f"pack supports 3/4 bits only, got {bits}"
+    N, D = idx.shape
+    n_bytes = math.ceil(D * bits / 8)
+    device = idx.device
+
+    idx_i = idx.to(torch.int32)
+    out = torch.zeros((N, n_bytes), dtype=torch.int32, device=device)
+
+    d = torch.arange(D, device=device)
+    bit_off = d * bits
+    byte_idx = (bit_off // 8).to(torch.long)  # (D,)
+    bit_shift = (bit_off % 8).to(torch.int32)  # (D,)
+
+    # Low part: bits landing in byte_idx.
+    low = (idx_i << bit_shift.view(1, D)) & 0xFF
+    out.scatter_add_(1, byte_idx.view(1, D).expand(N, D), low)
+
+    # High part: spill bits to byte_idx+1 when bit_shift + bits > 8.
+    spans = (bit_shift + bits > 8).view(1, D).expand(N, D)
+    spill_shift = (8 - bit_shift).clamp(min=0)
+    high = (idx_i >> spill_shift.view(1, D)) & 0xFF
+    high = torch.where(spans, high, torch.zeros_like(high))
+    high_byte_idx = (byte_idx + 1).clamp(max=n_bytes - 1)
+    out.scatter_add_(1, high_byte_idx.view(1, D).expand(N, D), high)
+    return out.to(torch.uint8)
+
+
+def _unpack_bits_rows(packed: torch.Tensor, bits: int, D: int) -> torch.Tensor:
+    """Inverse of _pack_bits_rows.
+
+    Args:
+        packed: (..., n_bytes) uint8.
+        bits: 3 or 4.
+        D: expected output width.
+
+    Returns:
+        (..., D) int64 tensor of indices in [0, 2**bits).
+    """
+    assert bits in (3, 4), f"unpack supports 3/4 bits only, got {bits}"
+    device = packed.device
+    n_bytes = packed.shape[-1]
+
+    d = torch.arange(D, device=device)
+    bit_off = d * bits
+    byte_idx = (bit_off // 8).to(torch.long)
+    bit_shift = (bit_off % 8).to(torch.long)
+    mask = (1 << bits) - 1
+
+    raw0 = packed[..., byte_idx].to(torch.int32)
+    # byte_idx + 1 may equal n_bytes; pad by clamping and masking the spill.
+    safe_next = (byte_idx + 1).clamp(max=n_bytes - 1)
+    raw1 = packed[..., safe_next].to(torch.int32)
+    raw16 = raw0 | (raw1 << 8)
+    out = (raw16 >> bit_shift.view(*([1] * (packed.dim() - 1)), D)) & mask
+    return out.to(torch.int64)
+
+
+class TritonMLATurboQuantMetadataBuilder(MLACommonMetadataBuilder[MLACommonMetadata]):
+    """MLA metadata builder that advertises CUDA-graph support.
+
+    Parent MLACommonMetadataBuilder defaults to AttentionCGSupport.NEVER.
+    TurboQuant's decode path (after Step 2: no torch.unique, no host syncs)
+    is CG-safe for decode-only batches, so UNIFORM_BATCH is the correct
+    level — matching FlashMLA / FlashAttn MLA.
+
+    `build_for_cudagraph_capture` is inherited from MLACommonMetadataBuilder;
+    it asserts decode-only and calls self.build(0, m), which is fine here.
+    """
+
+    _cudagraph_support: ClassVar[AttentionCGSupport] = AttentionCGSupport.UNIFORM_BATCH
+
+
+class TritonMLATurboQuantBackend(TritonMLABackend):
+    """TurboQuant-aware MLA backend on top of TritonMLA."""
+
+    supported_dtypes: ClassVar[list[torch.dtype]] = [torch.bfloat16]
+    supported_kv_cache_dtypes: ClassVar[list[CacheDType]] = [
+        "turboquant_k8v4",
+        "turboquant_4bit_nc",
+        "turboquant_k3v4_nc",
+        "turboquant_3bit_nc",
+    ]
+
+    @staticmethod
+    def get_name() -> str:
+        return "TRITON_MLA_TURBOQUANT"
+
+    @classmethod
+    def get_supported_head_sizes(cls) -> list[int]:
+        # head_size in this backend == packed_bytes per slot (uint8 cache),
+        # so the value depends on (kv_lora_rank, qk_rope_head_dim, preset, kpe_fp8).
+        # DeepSeek-V2/V3 (L=512, R=64): bf16 k_pe → 576; fp8 k_pe → 514.
+        # Other models: see _enumerate_packed_sizes for the full set we accept.
+        return _enumerate_packed_sizes()
+
+    @staticmethod
+    def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
+        return [MultipleOf(16)]
+
+    @classmethod
+    def supports_block_size(cls, block_size: int | None) -> bool:
+        if block_size is None:
+            return True
+        return block_size % 16 == 0
+
+    @staticmethod
+    def get_kv_cache_shape(
+        num_blocks: int,
+        block_size: int,
+        num_kv_heads: int,
+        head_size: int,
+        cache_dtype_str: str = "turboquant_k8v4",
+    ) -> tuple[int, ...]:
+        # head_size is the packed byte count per token, computed by
+        # MLAAttention.get_kv_cache_spec using TurboQuantConfig.
+        return (num_blocks, block_size, head_size)
+
+    @classmethod
+    def supports_kv_cache_dtype(cls, kv_cache_dtype: CacheDType | None) -> bool:
+        return kv_cache_dtype in cls.supported_kv_cache_dtypes
+
+    @classmethod
+    def supports_compute_capability(cls, capability: DeviceCapability) -> bool:
+        # MSE path needs SM80+; FP8 path (k8v4) needs SM89+.
+        # Gate at SM80 here — the FP8 SM89+ requirement is enforced at
+        # runtime in TritonMLATurboQuantImpl.__init__ so that A100 users
+        # can still use MSE presets (4bit_nc, k3v4_nc, 3bit_nc).
+        return capability.major >= 8
+
+    @staticmethod
+    def get_impl_cls() -> type["TritonMLATurboQuantImpl"]:
+        return TritonMLATurboQuantImpl
+
+    @staticmethod
+    def get_builder_cls() -> type[TritonMLATurboQuantMetadataBuilder]:
+        return TritonMLATurboQuantMetadataBuilder
+
+
+class TritonMLATurboQuantImpl(TritonMLAImpl):
+    """TritonMLA impl with a TurboQuant byte-packed KV cache.
+
+    Supports FP8 keys (k8v4) and MSE Lloyd-Max keys (4bit_nc / k3v4_nc /
+    3bit_nc). Value compression is not applicable in MLA: V is recovered
+    from kv_c via W_UV, so there is no independent V slot to quantize.
+    """
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # P3-1: kv_lora_rank can now be any power of 2 (Sylvester Hadamard
+        # requirement). qk_rope_head_dim can be any positive int (R is just a
+        # bf16 byte slice on the cache, no Hadamard, only BLOCK_R=next_pow2(R)
+        # masking inside the kernel).
+        L = self.kv_lora_rank
+        assert L > 0 and (L & (L - 1)) == 0, (
+            f"TritonMLATurboQuant requires kv_lora_rank to be a power of 2 "
+            f"(Sylvester Hadamard); got {L}"
+        )
+        assert self.qk_rope_head_dim > 0, (
+            f"qk_rope_head_dim must be positive; got {self.qk_rope_head_dim}"
+        )
+        # Build TQ config from the kv_cache_dtype string. self.kv_cache_dtype
+        # is set by the base impl (turboquant_{k8v4,4bit_nc,k3v4_nc,3bit_nc}).
+        # k_pe_fp8 flag is read once here and stored in the config; the rest
+        # of the code reads from tq_config.k_pe_fp8 rather than re-checking
+        # the env var. This matches mla_attention.get_kv_cache_spec which
+        # also bakes the flag into the config at cache-spec time.
+        k_pe_fp8 = envs.VLLM_TQ_KPE_FP8
+        self.tq_config: TurboQuantConfig = TurboQuantConfig.from_cache_dtype(
+            self.kv_cache_dtype,
+            head_dim=self.kv_lora_rank,
+            rope_head_dim=self.qk_rope_head_dim,
+            k_pe_fp8=k_pe_fp8,
+        )
+        # FP8 preset (k8v4) requires SM89+ for native fp8e4m3 support.
+        # MSE presets (4bit_nc, k3v4_nc, 3bit_nc) only need SM80+.
+        if self.tq_config.key_fp8:
+            from vllm.platforms import current_platform
+
+            cap = current_platform.get_device_capability()
+            if cap is not None and (
+                cap.major < 8 or (cap.major == 8 and cap.minor < 9)
+            ):
+                raise RuntimeError(
+                    f"TurboQuant FP8 preset '{self.kv_cache_dtype}' requires "
+                    f"SM89+ (Hopper+), but current GPU is SM{cap.major}{cap.minor}. "
+                    f"Use an MSE preset (turboquant_4bit_nc, turboquant_k3v4_nc, "
+                    f"turboquant_3bit_nc) instead, which work on SM80+."
+                )
+        # Per-slot byte layout (parameterized on L = kv_lora_rank):
+        #   FP8  : L bytes (1 B/elem, no norm)
+        #   MSE  : ceil(L * bits / 8) + 2 bytes (indices + fp16 vec_norm)
+        # Concrete: L=512 → FP8 512B, 4bit 258B, 3bit 194B.
+        self._kv_c_bytes = self.tq_config.key_packed_size
+        # k_pe layout: single source of truth from TurboQuantConfig.
+        # The config was created in mla_attention.get_kv_cache_spec with the
+        # k_pe_fp8 flag already baked in, so we read it from the config
+        # rather than re-reading the env var.
+        self._kpe_fp8 = self.tq_config.k_pe_fp8
+        self._k_pe_bytes = self.tq_config.k_pe_bytes
+        self._packed_bytes = self.tq_config.mla_packed_bytes
+
+        # For MSE path: number of "index bytes" before the 2-byte vec_norm.
+        self._mse_index_bytes = (
+            math.ceil(self.kv_lora_rank * self.tq_config.key_mse_bits / 8)
+            if not self.tq_config.key_fp8
+            else 0
+        )
+
+        # Override: TritonMLA sets supports_quant_query_input=False when
+        # is_quantized_kv_cache is True; we want the same.
+        self.supports_quant_query_input = False
+
+    # ---------------- impl-level TQ buffers ----------------
+    # Hadamard + Lloyd-Max centroids depend only on (kv_lora_rank, device)
+    # and bit-width, not on any layer-specific state. Caching on `self`
+    # avoids threading `layer` through do_kv_cache_update (which has no
+    # layer argument in the unified dispatch path).
+    def _ensure_buffers(self, device: torch.device) -> None:
+        key = str(device)
+        if not hasattr(self, "_tq_buffers"):
+            self._tq_buffers: dict[str, dict] = {}
+        if key in self._tq_buffers:
+            return
+        D = self.kv_lora_rank  # power of 2 (e.g. 512 for DeepSeek-V2/V3)
+        H = _build_hadamard(D, str(device))  # symmetric → Pi == PiT
+        buf: dict = {"Pi": H, "PiT": H, "Pi_bf16": H.to(_BF16)}
+        if not self.tq_config.key_fp8:
+            cents = get_centroids(D, self.tq_config.key_mse_bits).to(
+                device=device, dtype=torch.float32
+            )
+            c_sorted, _ = cents.sort()
+            buf["centroids"] = cents
+            buf["centroids_bf16"] = cents.to(_BF16)
+            buf["midpoints"] = (c_sorted[:-1] + c_sorted[1:]) / 2
+        self._tq_buffers[key] = buf
+
+    def _get_buffers(self, device: torch.device) -> dict:
+        self._ensure_buffers(device)
+        return self._tq_buffers[str(device)]
+
+    def _get_decode_buffers(
+        self,
+        B: int,
+        H_q: int,
+        num_kv_splits: int,
+        L: int,
+        dtype: torch.dtype,
+        device: torch.device,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Cached decode temporaries. Reuses tensors when shapes match,
+        reducing CUDA allocator pressure in high-throughput decode."""
+        key = (B, H_q, num_kv_splits, L, dtype)
+        if not hasattr(self, "_decode_buf_cache"):
+            self._decode_buf_cache: dict = {}
+        if key in self._decode_buf_cache:
+            return self._decode_buf_cache[key]
+        attn_logits = torch.empty(
+            (B, H_q, num_kv_splits, L + 1),
+            dtype=torch.float32,
+            device=device,
+        )
+        o_unrot = torch.empty(B, H_q, L, dtype=dtype, device=device)
+        lse = torch.empty(B, H_q, dtype=dtype, device=device)
+        v_shape_holder = torch.empty((1, L), device=device, dtype=dtype)
+        bufs = (attn_logits, o_unrot, lse, v_shape_holder)
+        self._decode_buf_cache[key] = bufs
+        return bufs
+
+    def _maybe_fold_pi_into_layer(self, layer) -> None:
+        """K2: fold Pi into layer.W_UK_T and layer.W_UV once, eliminating two
+        per-forward bf16 GEMMs (q-side rotation, V un-rotation).
+
+        Mathematical identity (Pi is self-inverse symmetric Hadamard):
+          - q_rot = q[..., :L] @ Pi  →  fold W_UK_T_new = W_UK_T @ Pi
+          - o_unrot @ Pi @ W_UV = o_unrot @ W_UV_new  with W_UV_new = Pi @ W_UV
+        Done in fp32 then cast back to weight dtype for precision; net effect
+        is *more* accurate than the runtime bf16 rotations.
+        """
+        if getattr(layer, "_tq_pi_folded", False):
+            return
+        if not (hasattr(layer, "W_UK_T") and hasattr(layer, "W_UV")):
+            return  # Backend supports only the absorbed-MLA decode path.
+        Pi = self._get_buffers(layer.W_UK_T.device)["Pi_bf16"]
+        Pi_f32 = Pi.to(torch.float32)
+        # W_UK_T: (N, P, L). Fold along last dim.
+        wuk = layer.W_UK_T
+        wuk_new = (wuk.to(torch.float32) @ Pi_f32).to(wuk.dtype)
+        layer.W_UK_T = wuk_new
+        # W_UV: (N, L, V). Fold along middle (L) dim: W_UV_new = Pi @ W_UV.
+        wuv = layer.W_UV
+        wuv_new = (Pi_f32 @ wuv.to(torch.float32)).to(wuv.dtype)
+        layer.W_UV = wuv_new
+        layer._tq_pi_folded = True
+
+    # ---------------- store ----------------
+    def do_kv_cache_update(
+        self,
+        kv_c_normed: torch.Tensor,  # (N, kv_lora_rank)
+        k_pe: torch.Tensor,  # (N, 1, qk_rope_head_dim) or (N, qk_rope_head_dim)
+        kv_cache: torch.Tensor,  # (num_blocks, block_size, packed_bytes) uint8
+        slot_mapping: torch.Tensor,
+        kv_cache_dtype: str,
+        k_scale: torch.Tensor,  # float scalar tensor
+    ) -> None:
+        torch.cuda.nvtx.range_push("tq_store")
+        if kv_cache.numel() == 0:
+            torch.cuda.nvtx.range_pop()
+            return
+        N = slot_mapping.shape[0]
+        if N <= 0:
+            torch.cuda.nvtx.range_pop()
+            return
+
+        k_pe_ = k_pe.squeeze(1) if k_pe.dim() == 3 else k_pe
+        kv_c_ = kv_c_normed[:N]
+        k_pe_ = k_pe_[:N]
+
+        # Cache k_scale as fp32 to avoid .to() call (CUDA graph safe)
+        if not hasattr(self, "_tq_k_scale_f32"):
+            self._tq_k_scale_f32 = k_scale.to(torch.float32).contiguous()
+
+        if self.tq_config.key_fp8:
+            # Fused FP8 store: quantize kv_c + k_pe and scatter in one kernel
+            _mla_fused_store_fp8(
+                kv_c_,
+                k_pe_,
+                kv_cache,
+                slot_mapping,
+                self._tq_k_scale_f32,
+                self.kv_lora_rank,
+                self.qk_rope_head_dim,
+                self._kpe_fp8,
+            )
+        else:
+            # Fused MSE store: normalize + rotate + bucketize + pack + scatter
+            device = kv_cache.device
+            buf = self._get_buffers(device)
+            _mla_fused_store_mse(
+                kv_c_,
+                k_pe_,
+                kv_cache,
+                slot_mapping,
+                buf["PiT"],
+                buf["midpoints"],
+                self.tq_config.key_mse_bits,
+                self.kv_lora_rank,
+                self.qk_rope_head_dim,
+                self._kpe_fp8,
+            )
+
+        torch.cuda.nvtx.range_pop()
+
+    # ---------------- prefix-caching prefill ----------------
+    # P3-3b: upstream's `ops.gather_and_maybe_dequant_cache` (C++) only knows
+    # {auto, fp8*} dtypes and raises a TORCH_CHECK on `turboquant_*`. Override the
+    # context-gather step so chunked_prefill + enable_prefix_caching works.
+    #
+    # Strategy: reproduce the C++ kernel's (token_id → block_id, slot_id)
+    # mapping in Python, gather packed rows from the uint8 cache, then reuse
+    # our fused dequant kernel (same one forward_mqa uses).
+    def _compute_prefill_context(
+        self,
+        q: torch.Tensor,
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata,
+        k_scale: torch.Tensor,
+    ):
+        from vllm.model_executor.layers.attention.mla_attention import (
+            merge_attn_states,
+        )
+        from vllm.platforms import current_platform
+
+        assert attn_metadata.prefill is not None
+        prefill_metadata = attn_metadata.prefill
+        assert prefill_metadata.chunked_context is not None
+
+        use_fp8_prefill = prefill_metadata.q_data_type == current_platform.fp8_dtype()
+        if use_fp8_prefill:
+            q = q.to(prefill_metadata.q_data_type)
+
+        device = kv_c_and_k_pe_cache.device
+        buf = self._get_buffers(device)
+        L = self.kv_lora_rank
+        R = self.qk_rope_head_dim
+        num_blocks, block_size, packed_bytes = kv_c_and_k_pe_cache.shape
+        assert packed_bytes == self._packed_bytes
+
+        cache_flat = kv_c_and_k_pe_cache.view(num_blocks * block_size, packed_bytes)
+
+        output = None
+        output_lse = None
+        iters = len(prefill_metadata.chunked_context.seq_tot)
+        workspace = prefill_metadata.chunked_context.workspace
+
+        for i in range(iters):
+            toks = prefill_metadata.chunked_context.seq_tot[i]
+            if toks <= 0:
+                continue
+
+            # Replicate C++ kernel address math:
+            #   batch_id      = token_to_seq[token_id]
+            #   batch_start   = cu_seq_lens[batch_id]
+            #   batch_offset  = token_id - batch_start + seq_starts[batch_id]
+            #   block_id      = block_table[batch_id, batch_offset // block_size]
+            #   slot_id       = batch_offset % block_size
+            num_tokens = int(prefill_metadata.chunked_context.chunk_total_token[i])
+            token_to_seq = prefill_metadata.chunked_context.token_to_seq[i][
+                :num_tokens
+            ].to(torch.int64)
+            cu_seq_lens = prefill_metadata.chunked_context.cu_seq_lens[i].to(
+                torch.int64
+            )
+            seq_starts_t = prefill_metadata.chunked_context.starts[i]
+            block_table = prefill_metadata.block_table.to(torch.int64)
+
+            # All shape-dependent gather math stays on-device (CG-compatible).
+            batch_ids = token_to_seq  # (num_tokens,)
+            batch_starts = cu_seq_lens.index_select(0, batch_ids)
+            tok_ids = torch.arange(num_tokens, device=device, dtype=torch.int64)
+            batch_offsets = tok_ids - batch_starts
+            if seq_starts_t is not None:
+                seq_starts_i = seq_starts_t.to(torch.int64).index_select(0, batch_ids)
+                batch_offsets = batch_offsets + seq_starts_i
+            block_table_ids = batch_offsets // block_size
+            slot_ids = batch_offsets % block_size
+            bt_stride = block_table.stride(0)
+            bt_flat_idx = batch_ids * bt_stride + block_table_ids
+            block_ids = block_table.view(-1).index_select(0, bt_flat_idx)
+            row_ids = block_ids * block_size + slot_ids  # (num_tokens,)
+
+            # Gather packed bytes → (num_tokens, packed_bytes) uint8.
+            gathered = cache_flat.index_select(0, row_ids).contiguous()
+
+            # Shape to what fused_mla_dequant_mse expects:
+            #   cache_view: (nb=toks, bs=1, packed_bytes)
+            #   out_view:   (nb=toks, bs=1, L+R) bf16
+            cache_view = gathered.view(num_tokens, 1, packed_bytes)
+            out_view = workspace[:num_tokens].view(num_tokens, 1, L + R)
+
+            if self.tq_config.key_fp8:
+                # FP8 kv_c: reinterpret bytes as fp8_e4m3 → bf16 * k_scale.
+                kv_c_fp8 = (
+                    cache_view[..., : self._kv_c_bytes].contiguous().view(_FP8_DTYPE)
+                )
+                scale_f32 = k_scale.to(torch.float32)
+                out_view[..., :L] = (kv_c_fp8.to(torch.float32) * scale_f32).to(_BF16)
+                self._write_kpe_into_workspace(cache_view, out_view, L, R)
+            else:
+                # MSE path: fused kernel writes (y*vec_norm) + k_pe, then
+                # we apply inverse Hadamard as the final bf16 GEMM.
+                fused_mla_dequant_mse(
+                    cache_view,
+                    buf["centroids_bf16"],
+                    out_view,
+                    L=L,
+                    R=R,
+                    mse_bits=self.tq_config.key_mse_bits,
+                    mse_bytes=self._mse_index_bytes,
+                    kv_c_bytes=self._kv_c_bytes,
+                    norm_correction=bool(self.tq_config.norm_correction),
+                    kpe_fp8=self._kpe_fp8,
+                )
+                kvc = out_view[..., :L].view(num_tokens, L)
+                out_view[..., :L] = (kvc @ buf["Pi_bf16"]).view(num_tokens, 1, L)
+
+            # Extract kv_c_normed / k_pe from workspace (shape matches base).
+            kv_c_normed = workspace[:toks][..., :L]
+            _kv_b_proj_w_dtype = (
+                self.kv_b_proj.weight.dtype
+                if hasattr(self.kv_b_proj, "weight")
+                else self.kv_b_proj.params_dtype
+            )
+            if (
+                use_fp8_prefill or _kv_b_proj_w_dtype != current_platform.fp8_dtype()
+            ) and _kv_b_proj_w_dtype != torch.uint8:
+                kv_c_normed = kv_c_normed.to(_kv_b_proj_w_dtype)
+
+            k_pe = workspace[:toks][..., L:].unsqueeze(1)
+            kv_nope = self.kv_b_proj(kv_c_normed)[0].view(
+                -1, self.num_heads, self.qk_nope_head_dim + self.v_head_dim
+            )
+            if use_fp8_prefill:
+                kv_nope = kv_nope.to(prefill_metadata.q_data_type)
+                k_pe = k_pe.to(prefill_metadata.q_data_type)
+            k_nope, v = kv_nope.split([self.qk_nope_head_dim, self.v_head_dim], dim=-1)
+            k = self._concat_k_nope_k_pe(k_nope, k_pe)
+
+            attn_output, attn_softmax_lse = (
+                prefill_metadata.prefill_backend.run_prefill_context_chunk(
+                    chunk_idx=i,
+                    q=q,
+                    k=k,
+                    v=v,
+                )
+            )
+            if output is None:
+                output = attn_output
+                output_lse = attn_softmax_lse
+            else:
+                output_tmp = torch.empty_like(output)
+                output_lse_tmp = torch.empty_like(output_lse)
+                merge_attn_states(
+                    output=output_tmp,
+                    output_lse=output_lse_tmp,
+                    prefix_output=output,
+                    prefix_lse=output_lse,
+                    suffix_output=attn_output,
+                    suffix_lse=attn_softmax_lse,
+                )
+                output = output_tmp
+                output_lse = output_lse_tmp
+
+        return output, output_lse
+
+    # ---------------- decode ----------------
+    def forward_mqa(
+        self,
+        q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        # (num_blocks, block_size, packed_bytes) uint8
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata: MLACommonMetadata,
+        layer: AttentionLayer,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        torch.cuda.nvtx.range_push("tq_decode")
+        assert kv_c_and_k_pe_cache.numel() > 0
+        assert attn_metadata.decode is not None
+
+        # FP8 path: K3 fused FP8 decode kernel (no bf16 staging). FP8 has
+        # no Hadamard rotation so the K2 weight fold must NOT run on this
+        # path.
+        if self.tq_config.key_fp8:
+            result = self._forward_mqa_fp8_fused(
+                q, kv_c_and_k_pe_cache, attn_metadata, layer
+            )
+            torch.cuda.nvtx.range_pop()
+            return result
+
+        # K2: one-shot fold of Pi into layer.W_UK_T and layer.W_UV (MSE only).
+        self._maybe_fold_pi_into_layer(layer)
+
+        # ----- MSE (3/4-bit) fused path -----
+        if isinstance(q, tuple):
+            q = torch.cat(q, dim=-1)
+        assert isinstance(q, torch.Tensor)
+
+        device = kv_c_and_k_pe_cache.device
+        buf = self._get_buffers(device)
+        L = self.kv_lora_rank
+        R = self.qk_rope_head_dim
+        B = q.shape[0]
+        H_q = q.shape[1]
+
+        # K2-a: q is already in rotated space because Pi has been folded into
+        # layer.W_UK_T (the projection that produced q[..., :L]). Skip runtime
+        # rotation.
+        q_rot = q
+
+        # 2) Allocate stage1 output (logits + LSE) and final output buffers.
+        decode_md = attn_metadata.decode
+        if envs.VLLM_BATCH_INVARIANT:
+            num_kv_splits = 1
+        else:
+            ideal_splits = max(1, attn_metadata.max_seq_len // 512)
+            ideal_splits = triton.next_power_of_2(ideal_splits)
+            num_kv_splits = min(ideal_splits, self._sm_count * 2)
+
+        attn_logits, o_unrot, lse, v_shape_holder = self._get_decode_buffers(
+            B,
+            H_q,
+            num_kv_splits,
+            L,
+            q.dtype,
+            device,
+        )
+
+        # 3) Fused stage1 directly on packed uint8 cache.
+        fused_mla_tq_decode_stage1(
+            q_rot,
+            kv_c_and_k_pe_cache,
+            buf["centroids_bf16"],
+            attn_logits,
+            decode_md.block_table,
+            decode_md.seq_lens,
+            sm_scale=self.scale,
+            page_size=kv_c_and_k_pe_cache.shape[1],
+            L=L,
+            R=R,
+            mse_bits=self.tq_config.key_mse_bits,
+            mse_bytes=self._mse_index_bytes,
+            kv_c_bytes=self._kv_c_bytes,
+            norm_correction=bool(self.tq_config.norm_correction),
+            kpe_fp8=self._kpe_fp8,
+            num_kv_splits=num_kv_splits,
+            logit_cap=0.0,
+        )
+
+        # 4) Stage2 reduce. v_buffer is only read for its last-dim size (Lv);
+        #    pass a minimal placeholder with last_dim=L (1*L bf16 elements).
+        _decode_softmax_reducev_fwd(
+            attn_logits,
+            q_rot,
+            o_unrot,
+            lse,
+            v_shape_holder,
+            decode_md.seq_lens,
+            num_kv_splits,
+        )
+
+        # K2-b: leave o in rotated kv_c space; Pi has been folded into
+        # layer.W_UV so the downstream BMM (`x @ W_UV`) un-rotates implicitly.
+        o = o_unrot.view(B, H_q, L)
+
+        torch.cuda.nvtx.range_pop()
+        return o, lse
+
+    def _forward_mqa_fp8_fused(
+        self,
+        q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+        kv_c_and_k_pe_cache: torch.Tensor,
+        attn_metadata: MLACommonMetadata,
+        layer: AttentionLayer,
+    ) -> tuple[torch.Tensor, torch.Tensor | None]:
+        """K3: FP8 fused decode — `fused_mla_tq_decode_stage1(key_fp8=True)`
+        reads the fp8 cache directly inside the inner KV loop, eliminating
+        the bf16 workspace materialization that `_forward_mqa_fp8_workspace`
+        used to do. The layer's k_scale is passed as a kernel constexpr.
+        """
+        assert attn_metadata.decode is not None
+        if isinstance(q, tuple):
+            q = torch.cat(q, dim=-1)
+        assert isinstance(q, torch.Tensor)
+
+        device = kv_c_and_k_pe_cache.device
+        L = self.kv_lora_rank
+        R = self.qk_rope_head_dim
+        B = q.shape[0]
+        H_q = q.shape[1]
+
+        decode_md = attn_metadata.decode
+        if envs.VLLM_BATCH_INVARIANT:
+            num_kv_splits = 1
+        else:
+            ideal_splits = max(1, attn_metadata.max_seq_len // 512)
+            ideal_splits = triton.next_power_of_2(ideal_splits)
+            num_kv_splits = min(ideal_splits, self._sm_count * 2)
+
+        attn_logits, o_unrot, lse, v_shape_holder = self._get_decode_buffers(
+            B,
+            H_q,
+            num_kv_splits,
+            L,
+            q.dtype,
+            device,
+        )
+
+        # Empty centroid placeholder — KEY_FP8 branch never reads it; Triton
+        # still requires a bf16 1-D tensor argument.
+        buf = self._get_buffers(device)
+        centroids_unused = buf.get(
+            "_fp8_centroid_placeholder",
+            torch.empty(0, device=device, dtype=_BF16),
+        )
+        buf["_fp8_centroid_placeholder"] = centroids_unused
+
+        # CUDA-graph-safe k_scale access: cache the fp32 copy on the layer
+        # to avoid a .to() call (which is a CUDA op) during graph capture.
+        if not hasattr(layer, "_tq_k_scale_f32"):
+            layer._tq_k_scale_f32 = (
+                layer._k_scale.to(torch.float32).contiguous()
+                if hasattr(layer, "_k_scale")
+                else torch.tensor(1.0, dtype=torch.float32, device=device)
+            )
+        k_scale = layer._tq_k_scale_f32
+
+        fused_mla_tq_decode_stage1(
+            q,
+            kv_c_and_k_pe_cache,
+            centroids_unused,
+            attn_logits,
+            decode_md.block_table,
+            decode_md.seq_lens,
+            sm_scale=self.scale,
+            page_size=kv_c_and_k_pe_cache.shape[1],
+            L=L,
+            R=R,
+            mse_bits=0,
+            mse_bytes=0,
+            kv_c_bytes=L,
+            norm_correction=False,
+            kpe_fp8=self._kpe_fp8,
+            key_fp8=True,
+            k_scale=k_scale,
+            num_kv_splits=num_kv_splits,
+            logit_cap=0.0,
+        )
+
+        _decode_softmax_reducev_fwd(
+            attn_logits,
+            q,
+            o_unrot,
+            lse,
+            v_shape_holder,
+            decode_md.seq_lens,
+            num_kv_splits,
+        )
+        o = o_unrot.view(B, H_q, L)
+        return o, lse
+
+    # ------------------------------------------------------------------
+    # k_pe writer (handles both bf16 and fp8 layouts).
+    # P3-2: when VLLM_TQ_KPE_FP8=1, k_pe is stored as R fp8 e4m3 bytes
+    # followed by 2 bytes per-token fp16 scale; otherwise raw bf16 (2*R bytes).
+    # ------------------------------------------------------------------
+    def _write_kpe_into_workspace(self, cache, workspace, L, R) -> None:
+        if self._kpe_fp8:
+            # cache layout: [..., kv_c_bytes : kv_c_bytes + R] = fp8 data
+            #               [kv_c_bytes + R : kv_c_bytes + R + 2] = fp16 scale
+            kpe_fp8 = (
+                cache[..., self._kv_c_bytes : self._kv_c_bytes + R]
+                .contiguous()
+                .view(_FP8_DTYPE)
+            )
+            # (..., 2) bytes → (..., 1) fp16 → (..., 1) bf16 broadcast scalar
+            scale_fp16 = (
+                cache[..., self._kv_c_bytes + R : self._kv_c_bytes + R + 2]
+                .contiguous()
+                .view(torch.float16)
+            )
+            scale_bf = scale_fp16.to(_BF16)  # (..., 1)
+            workspace[..., L:] = kpe_fp8.to(_BF16) * scale_bf
+        else:
+            workspace[..., L:] = cache[..., self._kv_c_bytes :].contiguous().view(_BF16)

--- a/vllm/v1/attention/backends/registry.py
+++ b/vllm/v1/attention/backends/registry.py
@@ -68,6 +68,9 @@ class AttentionBackendEnum(Enum, metaclass=_AttentionBackendEnumMeta):
         "FlashInferMLASparseBackend"
     )
     TRITON_MLA = "vllm.v1.attention.backends.mla.triton_mla.TritonMLABackend"
+    TRITON_MLA_TURBOQUANT = (
+        "vllm.v1.attention.backends.mla.triton_mla_tq.TritonMLATurboQuantBackend"
+    )
     CUTLASS_MLA = "vllm.v1.attention.backends.mla.cutlass_mla.CutlassMLABackend"
     FLASHMLA = "vllm.v1.attention.backends.mla.flashmla.FlashMLABackend"
     FLASHMLA_SPARSE = (

--- a/vllm/v1/attention/ops/triton_turboquant_mla_decode.py
+++ b/vllm/v1/attention/ops/triton_turboquant_mla_decode.py
@@ -1,0 +1,590 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Fused TurboQuant MSE dequant for MLA decode.
+
+This module provides a single Triton kernel `_tq_mla_dequant_mse` that
+collapses the per-layer hot path:
+    {bit-unpack → centroid gather → optional norm-correction → vec_norm mul}
+into one launch, writing the un-rotated reconstruction (`y_hat * vec_norm`)
+plus the k_pe bf16 slice into a dense workspace.
+
+The final inverse-Hadamard rotation `y_normed @ Pi` is left as a single
+cuBLAS bf16 GEMM in Python — that one is already a single fast kernel
+and would only complicate the Triton kernel.
+
+Reference for the unpack + centroid gather pattern:
+    `vllm/v1/attention/ops/triton_turboquant_decode.py::_tq_full_dequant_kv`
+(non-MLA backend; we mirror its K-dequant branch).
+
+Numerical equivalence with `_dequant_kv_c_mse` (PyTorch reference in
+`triton_mla_tq.py`) is bit-for-bit at fp32 round-trip; bf16 ULP-level
+deviations are allowed.
+"""
+
+import torch
+
+from vllm.triton_utils import tl, triton
+
+_BF16 = torch.bfloat16
+
+
+@triton.jit
+def _tq_mla_dequant_mse(
+    Cache_ptr,  # uint8: (n_active, block_size, packed_bytes)
+    Centroids_ptr,  # bf16: (2**bits,) sorted Lloyd-Max codebook
+    Out_ptr,  # bf16: (n_active, block_size, L+R)
+    # Strides (in elements; cache stride in bytes since uint8)
+    stride_cache_n,
+    stride_cache_p,
+    stride_out_n,
+    stride_out_p,
+    # Compile-time constants
+    L: tl.constexpr,  # kv_lora_rank, e.g. 512
+    R: tl.constexpr,  # qk_rope_head_dim, e.g. 64
+    BLOCK_SIZE: tl.constexpr,  # cache block_size (page count)
+    BLOCK_D: tl.constexpr,  # next_pow2(L)
+    BLOCK_R: tl.constexpr,  # next_pow2(R)
+    MSE_BITS: tl.constexpr,  # 3 or 4
+    MSE_BYTES: tl.constexpr,  # ceil(L * MSE_BITS / 8)
+    KV_C_BYTES: tl.constexpr,  # MSE_BYTES + 2 (vec_norm fp16)
+    NORM_CORRECTION: tl.constexpr,  # 0/1
+    KPE_FP8: tl.constexpr,  # 0=bf16, 1=fp8 e4m3 + per-token fp16 scale
+):
+    """One program = one (active_block, page).
+
+    Writes to Out_ptr[active_idx, page, :L+R]:
+      out[:L] = y_hat_normed * vec_norm   (un-rotated; caller applies @ Pi)
+      out[L:] = k_pe (bf16 reinterpret of cache[..., KV_C_BYTES:])
+    """
+    n_idx = tl.program_id(0)  # active block index
+    p_idx = tl.program_id(1)  # page within block
+
+    d_offs = tl.arange(0, BLOCK_D)
+    d_mask = d_offs < L
+
+    # ----- Address of this slot's packed bytes in the cache -----
+    slot_base = n_idx * stride_cache_n + p_idx * stride_cache_p
+
+    # ----- Bit-unpack indices (mirrors _unpack_bits_rows) -----
+    bit_off = d_offs * MSE_BITS
+    byte_idx = bit_off // 8
+    bit_shift = bit_off % 8
+    umask = (1 << MSE_BITS) - 1
+
+    raw0 = tl.load(Cache_ptr + slot_base + byte_idx, mask=d_mask, other=0).to(tl.int32)
+    raw1 = tl.load(Cache_ptr + slot_base + byte_idx + 1, mask=d_mask, other=0).to(
+        tl.int32
+    )
+    raw16 = raw0 | (raw1 << 8)
+    idx = (raw16 >> bit_shift) & umask
+
+    # ----- Centroid gather (bf16) -----
+    # Cast to fp32 immediately for stable norm computation.
+    # .ca hint: codebook is tiny (8/16 bf16); cache at all levels.
+    y_hat_bf = tl.load(
+        Centroids_ptr + idx, mask=d_mask, other=0.0, cache_modifier=".ca"
+    )
+    y_hat = y_hat_bf.to(tl.float32)
+
+    # ----- Optional norm correction: re-normalize y_hat to unit norm -----
+    if NORM_CORRECTION:
+        sq = tl.where(d_mask, y_hat * y_hat, 0.0)
+        c_norm_sq = tl.sum(sq, axis=0)
+        inv_norm = 1.0 / tl.sqrt(c_norm_sq + 1e-8)
+        y_hat = y_hat * inv_norm
+
+    # ----- Recover per-token vec_norm from the 2 fp16 bytes -----
+    n_lo = tl.load(Cache_ptr + slot_base + MSE_BYTES).to(tl.uint16)
+    n_hi = tl.load(Cache_ptr + slot_base + MSE_BYTES + 1).to(tl.uint16)
+    vec_norm_u16 = n_lo | (n_hi << 8)
+    vec_norm_f32 = vec_norm_u16.to(tl.float16, bitcast=True).to(tl.float32)
+
+    # ----- Final scalar multiply, cast back to bf16 -----
+    out_kvc = (y_hat * vec_norm_f32).to(tl.bfloat16)
+
+    # ----- Store y_hat * vec_norm into Out[..., :L] -----
+    out_base = n_idx * stride_out_n + p_idx * stride_out_p
+    tl.store(Out_ptr + out_base + d_offs, out_kvc, mask=d_mask)
+
+    # ----- Inline copy k_pe -----
+    # bf16 layout: cache[KV_C_BYTES : KV_C_BYTES + 2*R] = R bf16 elems.
+    # fp8 layout:  cache[KV_C_BYTES : KV_C_BYTES + R]   = R fp8 e4m3 elems,
+    #              cache[KV_C_BYTES + R : KV_C_BYTES + R + 2] = fp16 scale.
+    r_offs = tl.arange(0, BLOCK_R)
+    r_mask = r_offs < R
+    if KPE_FP8:
+        # Reload fp8 byte and bitcast to fp8e4m3 → fp32 → bf16.
+        # Then multiply per-token scale.
+        fp8_byte = tl.load(
+            Cache_ptr + slot_base + KV_C_BYTES + r_offs,
+            mask=r_mask,
+            other=0,
+        ).to(tl.uint8)
+        # bitcast uint8 → fp8 e4m3
+        kpe_fp8 = fp8_byte.to(tl.float8e4nv, bitcast=True)
+        kpe_f32 = kpe_fp8.to(tl.float32)
+        # Per-token fp16 scale at cache[KV_C_BYTES + R : KV_C_BYTES + R + 2]
+        s_lo = tl.load(Cache_ptr + slot_base + KV_C_BYTES + R).to(tl.uint16)
+        s_hi = tl.load(Cache_ptr + slot_base + KV_C_BYTES + R + 1).to(tl.uint16)
+        scale_u16 = s_lo | (s_hi << 8)
+        scale_f32 = scale_u16.to(tl.float16, bitcast=True).to(tl.float32)
+        kpe_bf = (kpe_f32 * scale_f32).to(tl.bfloat16)
+    else:
+        # bf16 path: reinterpret 2 consecutive uint8 as one bf16.
+        kpe_lo = tl.load(
+            Cache_ptr + slot_base + KV_C_BYTES + r_offs * 2,
+            mask=r_mask,
+            other=0,
+        ).to(tl.uint16)
+        kpe_hi = tl.load(
+            Cache_ptr + slot_base + KV_C_BYTES + r_offs * 2 + 1,
+            mask=r_mask,
+            other=0,
+        ).to(tl.uint16)
+        kpe_u16 = kpe_lo | (kpe_hi << 8)
+        kpe_bf = kpe_u16.to(tl.bfloat16, bitcast=True)
+    tl.store(Out_ptr + out_base + L + r_offs, kpe_bf, mask=r_mask)
+
+
+def fused_mla_dequant_mse(
+    cache: torch.Tensor,  # (n_active, block_size, packed_bytes) uint8
+    centroids_bf16: torch.Tensor,  # (2**bits,) bf16
+    out: torch.Tensor,  # (n_active, block_size, L+R) bf16 (un-rotated)
+    *,
+    L: int,
+    R: int,
+    mse_bits: int,
+    mse_bytes: int,
+    kv_c_bytes: int,
+    norm_correction: bool,
+    kpe_fp8: bool = False,
+) -> None:
+    """Launch the fused MSE dequant kernel.
+
+    `out[..., :L]` receives `y_hat_normed * vec_norm` — the caller must
+    apply `out[..., :L] @ Pi` (cuBLAS bf16 GEMM) to finish the inverse
+    Hadamard rotation. `out[..., L:]` receives `k_pe`.
+    """
+    assert cache.dtype == torch.uint8
+    assert out.dtype == _BF16
+    assert centroids_bf16.dtype == _BF16
+    n_active, block_size, _packed = cache.shape
+    assert out.shape == (n_active, block_size, L + R), (
+        f"out shape mismatch: {out.shape} vs ({n_active}, {block_size}, {L + R})"
+    )
+    if n_active == 0:
+        return
+
+    BLOCK_D = triton.next_power_of_2(L)
+    BLOCK_R = triton.next_power_of_2(R)
+    grid = (n_active, block_size)
+    _tq_mla_dequant_mse[grid](
+        cache,
+        centroids_bf16,
+        out,
+        cache.stride(0),
+        cache.stride(1),
+        out.stride(0),
+        out.stride(1),
+        L=L,
+        R=R,
+        BLOCK_SIZE=block_size,
+        BLOCK_D=BLOCK_D,
+        BLOCK_R=BLOCK_R,
+        MSE_BITS=mse_bits,
+        MSE_BYTES=mse_bytes,
+        KV_C_BYTES=kv_c_bytes,
+        NORM_CORRECTION=1 if norm_correction else 0,
+        KPE_FP8=1 if kpe_fp8 else 0,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+# =============================================================================
+# Fused decode stage1: dequant + grouped attention in a single kernel.
+#
+# Mirrors `_fwd_grouped_kernel_stage1` in
+# `vllm/v1/attention/ops/triton_decode_attention.py` (L261-443) but consumes
+# a packed-uint8 paged TurboQuant cache directly. At each K-load site we
+# inline {bit-unpack → centroid gather → vec_norm scale} instead of reading
+# bf16, eliminating the per-layer bf16 dequant workspace. The query is
+# expected to be pre-rotated (Πq) on the caller side — see
+# `tests/kernels/attention/test_mla_turboquant_qside_rotation.py` for the
+# math identity.
+#
+# Cache slot layout (per token in `(num_blocks, block_size, packed_bytes)`):
+#     bytes [0 ... MSE_BYTES)              packed kv_c indices (MSE_BITS each)
+#     bytes [MSE_BYTES ... KV_C_BYTES)     fp16 vec_norm  (MSE_BYTES + 2)
+#     bytes [KV_C_BYTES ... )              k_pe (bf16) or k_pe (fp8 + fp16 scale)
+# =============================================================================
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_N": 16}, num_warps=4, num_stages=2, maxnreg=192),
+        triton.Config({"BLOCK_N": 32}, num_warps=4, num_stages=2, maxnreg=192),
+        triton.Config({"BLOCK_N": 64}, num_warps=4, num_stages=3, maxnreg=192),
+        triton.Config({"BLOCK_N": 32}, num_warps=8, num_stages=2, maxnreg=192),
+        triton.Config({"BLOCK_N": 64}, num_warps=8, num_stages=3, maxnreg=192),
+    ],
+    key=["L", "R", "MSE_BITS", "KEY_FP8", "PAGE_SIZE"],
+)
+@triton.jit
+def _fwd_grouped_kernel_stage1_tq(
+    Q,  # bf16: (batch, q_head_num, Lk) Lk=L+R; q is Π-rotated on the L slice
+    K_Cache,  # uint8: (num_blocks, block_size, packed_bytes)
+    Centroids_ptr,  # bf16: (2**MSE_BITS,) Lloyd-Max codebook
+    sm_scale,
+    Req_to_tokens,  # int32: (batch, max_kv_pages) -> page index
+    B_Seqlen,
+    Att_Out,
+    stride_req_to_tokens_b,
+    stride_qbs,
+    stride_qh,
+    stride_cache_n,  # bytes per page block (block_size * packed_bytes)
+    stride_cache_p,  # bytes per token slot (packed_bytes)
+    stride_mid_ob,
+    stride_mid_oh,
+    stride_mid_os,
+    q_head_num: tl.constexpr,
+    BLOCK_DMODEL: tl.constexpr,  # next_pow2(L)
+    BLOCK_DPE: tl.constexpr,  # next_pow2(R)
+    BLOCK_DV: tl.constexpr,  # = BLOCK_DMODEL (MLA: V is L slice of kv_c)
+    BLOCK_N: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    NUM_KV_SPLITS: tl.constexpr,
+    PAGE_SIZE: tl.constexpr,
+    logit_cap: tl.constexpr,
+    L: tl.constexpr,  # kv_lora_rank
+    R: tl.constexpr,  # qk_rope_head_dim
+    MSE_BITS: tl.constexpr,
+    MSE_BYTES: tl.constexpr,
+    KV_C_BYTES: tl.constexpr,
+    NORM_CORRECTION: tl.constexpr,
+    KPE_FP8: tl.constexpr,
+    KEY_FP8: tl.constexpr,
+    K_SCALE_ptr,  # fp32 device scalar: layer-global k_scale
+):
+    """One program = (batch, head_block, kv_split). Heads are grouped via BLOCK_H
+    just like the upstream stage1; KV is reduced one BLOCK_N tile at a time.
+
+    KEY_FP8=1: kv_c bytes are L fp8 e4m3 elems (no Hadamard, no vec_norm,
+    no centroid). The layer-global K_SCALE compile-time constant is multiplied
+    into the bf16 K tile (and therefore into V via the MLA K==V identity)
+    so output magnitude matches the bf16-workspace baseline that pre-scales
+    the cache.
+    """
+    cur_batch = tl.program_id(0)
+    cur_head_id = tl.program_id(1)
+    split_kv_id = tl.program_id(2)
+
+    # MLA: kv_group_num == q_head_num (single shared kv_c).
+    cur_head = cur_head_id * BLOCK_H + tl.arange(0, BLOCK_H)
+    mask_h = cur_head < q_head_num
+
+    offs_d = tl.arange(0, BLOCK_DMODEL)
+    mask_d = offs_d < L
+    offs_dpe = L + tl.arange(0, BLOCK_DPE)
+    mask_dpe = offs_dpe < (L + R)
+
+    cur_batch_seq_len = tl.load(B_Seqlen + cur_batch)
+
+    # Load the (already Π-rotated) query.
+    offs_q = cur_batch * stride_qbs + cur_head[:, None] * stride_qh + offs_d[None, :]
+    q = tl.load(
+        Q + offs_q,
+        mask=mask_h[:, None] & mask_d[None, :],
+        other=0.0,
+        cache_modifier=".ca",
+    )
+    off_qpe = cur_batch * stride_qbs + cur_head[:, None] * stride_qh + offs_dpe[None, :]
+    qpe = tl.load(
+        Q + off_qpe,
+        mask=mask_h[:, None] & mask_dpe[None, :],
+        other=0.0,
+        cache_modifier=".ca",
+    )
+
+    kv_len_per_split = tl.cdiv(cur_batch_seq_len, NUM_KV_SPLITS)
+    split_kv_start = kv_len_per_split * split_kv_id
+    split_kv_end = tl.minimum(split_kv_start + kv_len_per_split, cur_batch_seq_len)
+
+    e_max = tl.zeros([BLOCK_H], dtype=tl.float32) - float("inf")
+    e_sum = tl.zeros([BLOCK_H], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_H, BLOCK_DV], dtype=tl.float32)
+
+    # Bit-unpack constants.
+    bit_off = offs_d * MSE_BITS  # (BLOCK_DMODEL,)
+    byte_idx = bit_off // 8
+    bit_shift = bit_off % 8
+    umask = (1 << MSE_BITS) - 1
+
+    if split_kv_end > split_kv_start:
+        for start_n in tl.range(split_kv_start, split_kv_end, BLOCK_N):
+            offs_n = start_n + tl.arange(0, BLOCK_N)
+            n_mask = offs_n < split_kv_end
+
+            kv_page = tl.load(
+                Req_to_tokens
+                + stride_req_to_tokens_b * cur_batch
+                + offs_n // PAGE_SIZE,
+                mask=n_mask,
+                other=0,
+                cache_modifier=".ca",
+            )
+            kv_in_page = offs_n % PAGE_SIZE
+            slot_base = kv_page * stride_cache_n + kv_in_page * stride_cache_p
+            # slot_base shape (BLOCK_N,); we need (BLOCK_DMODEL, BLOCK_N).
+            sb = slot_base[None, :]
+            bi = byte_idx[:, None]
+            bs = bit_shift[:, None]
+            d_full_mask = mask_d[:, None] & n_mask[None, :]
+
+            if KEY_FP8:
+                # K3: FP8 keys — load fp8 byte, bitcast to fp8e4nv,
+                # cast directly to bf16 (skip fp32 intermediate), multiply
+                # k_scale in bf16. Saves one F2FP conversion step.
+                k_scale = tl.load(K_SCALE_ptr).to(tl.bfloat16)
+                fp8_k = tl.load(
+                    K_Cache + sb + offs_d[:, None],
+                    mask=d_full_mask,
+                    other=0,
+                    cache_modifier=".cg",
+                ).to(tl.uint8)
+                k_fp8 = fp8_k.to(tl.float8e4nv, bitcast=True)
+                k = k_fp8.to(tl.bfloat16) * k_scale
+                qk = tl.dot(q, k)
+            else:
+                # ----- Bit-unpack across (BLOCK_DMODEL, BLOCK_N) -----
+                raw0 = tl.load(
+                    K_Cache + sb + bi,
+                    mask=d_full_mask,
+                    other=0,
+                    cache_modifier=".cg",
+                ).to(tl.int32)
+                raw1 = tl.load(
+                    K_Cache + sb + bi + 1,
+                    mask=d_full_mask,
+                    other=0,
+                    cache_modifier=".cg",
+                ).to(tl.int32)
+                raw16 = raw0 | (raw1 << 8)
+                idx = (raw16 >> bs) & umask
+
+                # ----- Centroid gather (bf16 → fp32 for stable downstream) -----
+                # .ca hint: codebook is tiny (8/16 bf16 values); cache at all
+                # levels so subsequent tiles hit L1 instead of global memory.
+                y_hat = tl.load(
+                    Centroids_ptr + idx,
+                    mask=d_full_mask,
+                    other=0.0,
+                    cache_modifier=".ca",
+                ).to(tl.float32)
+
+                if NORM_CORRECTION:
+                    sq = tl.where(d_full_mask, y_hat * y_hat, 0.0)
+                    c_norm_sq = tl.sum(sq, axis=0)  # (BLOCK_N,)
+                    inv_norm = 1.0 / tl.sqrt(c_norm_sq + 1e-8)
+                    y_hat = y_hat * inv_norm[None, :]
+
+                # ----- Per-token vec_norm (fp16, 2 bytes) -----
+                vn_lo = tl.load(
+                    K_Cache + slot_base + MSE_BYTES, mask=n_mask, other=0
+                ).to(tl.uint16)
+                vn_hi = tl.load(
+                    K_Cache + slot_base + MSE_BYTES + 1, mask=n_mask, other=0
+                ).to(tl.uint16)
+                vn_u16 = vn_lo | (vn_hi << 8)
+                vec_norm = vn_u16.to(tl.float16, bitcast=True).to(tl.float32)
+
+                # K1-a: scale qk by per-token vec_norm AFTER the dot, instead of
+                # scaling the [BLOCK_DMODEL, BLOCK_N] k tile before the cast. This
+                # avoids materializing a separately-scaled bf16 K tile.
+                k = y_hat.to(q.dtype)
+
+                qk = tl.dot(q, k)
+                qk = qk * vec_norm[None, :]
+
+            # ----- k_pe path -----
+            r_offs = tl.arange(0, BLOCK_DPE)
+            r_mask = r_offs < R
+            r_full_mask = r_mask[:, None] & n_mask[None, :]
+            if KPE_FP8:
+                fp8_byte = tl.load(
+                    K_Cache + sb + KV_C_BYTES + r_offs[:, None],
+                    mask=r_full_mask,
+                    other=0,
+                    cache_modifier=".cg",
+                ).to(tl.uint8)
+                kpe_f32 = fp8_byte.to(tl.float8e4nv, bitcast=True).to(tl.float32)
+                s_lo = tl.load(
+                    K_Cache + slot_base + KV_C_BYTES + R, mask=n_mask, other=0
+                ).to(tl.uint16)
+                s_hi = tl.load(
+                    K_Cache + slot_base + KV_C_BYTES + R + 1, mask=n_mask, other=0
+                ).to(tl.uint16)
+                scale = (s_lo | (s_hi << 8)).to(tl.float16, bitcast=True).to(tl.float32)
+                kpe = (kpe_f32 * scale[None, :]).to(qpe.dtype)
+            else:
+                kpe_lo = tl.load(
+                    K_Cache + sb + KV_C_BYTES + r_offs[:, None] * 2,
+                    mask=r_full_mask,
+                    other=0,
+                    cache_modifier=".cg",
+                ).to(tl.uint16)
+                kpe_hi = tl.load(
+                    K_Cache + sb + KV_C_BYTES + r_offs[:, None] * 2 + 1,
+                    mask=r_full_mask,
+                    other=0,
+                    cache_modifier=".cg",
+                ).to(tl.uint16)
+                kpe_u16 = kpe_lo | (kpe_hi << 8)
+                kpe = kpe_u16.to(tl.bfloat16, bitcast=True).to(qpe.dtype)
+
+            qk += tl.dot(qpe, kpe)
+            qk *= sm_scale
+
+            if logit_cap > 0:
+                qk = logit_cap * tl.math.tanh(qk / logit_cap)
+
+            qk = tl.where(mask_h[:, None] & n_mask[None, :], qk, float("-inf"))
+
+            # MLA reuses k as v (transposed).
+            v = tl.trans(k)
+
+            n_e_max = tl.maximum(tl.max(qk, 1), e_max)
+            re_scale = tl.exp(e_max - n_e_max)
+            p = tl.exp(qk - n_e_max[:, None])
+            acc *= re_scale[:, None]
+            # K1-a value-path correction: in the MSE branch K is stored as
+            # un-scaled centroid `y_hat` (vec_norm is folded into qk *after*
+            # the dot to save a (BLOCK_DMODEL, BLOCK_N) multiply). Since
+            # `v = trans(k) = trans(y_hat)` is also missing vec_norm, the
+            # accumulator must apply vec_norm here — mathematically:
+            #   sum_n p_n * (y_hat_n * vn_n) = sum_n (p_n * vn_n) * y_hat_n
+            # so we scale p (shape (BLOCK_H, BLOCK_N), small) instead of v.
+            # KEY_FP8 path bakes K_SCALE into y_hat before the cast, so v
+            # already carries the correct scale and no correction is needed.
+            p_for_v = p.to(v.dtype) if KEY_FP8 else (p * vec_norm[None, :]).to(v.dtype)
+            acc += tl.dot(p_for_v, v)
+            e_sum = e_sum * re_scale + tl.sum(p, 1)
+            e_max = n_e_max
+
+        offs_mid_o = (
+            cur_batch * stride_mid_ob
+            + cur_head[:, None] * stride_mid_oh
+            + split_kv_id * stride_mid_os
+            + offs_d[None, :]
+        )
+        tl.store(
+            Att_Out + offs_mid_o,
+            acc / e_sum[:, None],
+            mask=mask_h[:, None] & mask_d[None, :],
+        )
+        offs_lse = (
+            cur_batch * stride_mid_ob
+            + cur_head * stride_mid_oh
+            + split_kv_id * stride_mid_os
+            + L
+        )
+        tl.store(Att_Out + offs_lse, e_max + tl.log(e_sum), mask=mask_h)
+
+
+def fused_mla_tq_decode_stage1(
+    q: torch.Tensor,  # bf16: (batch, q_head_num, L+R), Π-rotated on [:L]
+    cache: torch.Tensor,  # uint8: (num_blocks, block_size, packed_bytes)
+    centroids_bf16: torch.Tensor,  # bf16: (2**MSE_BITS,) or empty when key_fp8
+    att_out: torch.Tensor,  # fp32: (batch, q_head_num, NUM_KV_SPLITS, L+1)
+    req_to_tokens: torch.Tensor,  # int32: (batch, max_kv_pages)
+    b_seqlen: torch.Tensor,  # int32: (batch,)
+    *,
+    sm_scale: float,
+    page_size: int,
+    L: int,
+    R: int,
+    mse_bits: int,
+    mse_bytes: int,
+    kv_c_bytes: int,
+    norm_correction: bool,
+    kpe_fp8: bool,
+    key_fp8: bool = False,
+    k_scale: torch.Tensor | None = None,  # fp32 scalar on device
+    num_kv_splits: int = 4,
+    logit_cap: float = 0.0,
+) -> None:
+    """Launch the fused TurboQuant MLA decode stage1.
+
+    MSE keys (default): `q` must be the standard MLA decode query with the
+    Hadamard rotation applied to its first L (kv_lora_rank) elements; the
+    kernel does no rotation internally.
+
+    FP8 keys (`key_fp8=True`): cache layout is `[L bytes fp8 e4m3 | k_pe...]`.
+    No Hadamard rotation; q is consumed as-is. The layer-global `k_scale`
+    is passed as a device scalar and multiplied into the bf16 K tile
+    inside the kernel (so V = trans(K) inherits the same scale, preserving
+    MLA K==V semantics). centroids_bf16 is unused in this mode (pass any
+    bf16 1-D tensor; e.g. an empty one).
+    """
+    assert cache.dtype == torch.uint8
+    assert q.dtype == torch.bfloat16
+    assert centroids_bf16.dtype == torch.bfloat16
+    batch, q_head_num, head_dim = q.shape
+    assert head_dim == L + R, f"q head_dim {head_dim} != L+R {L + R}"
+
+    BLOCK_DMODEL = triton.next_power_of_2(L)
+    BLOCK_DPE = triton.next_power_of_2(R)
+    BLOCK_DV = BLOCK_DMODEL
+    BLOCK_H = 16
+
+    grid = (
+        batch,
+        triton.cdiv(q_head_num, BLOCK_H),
+        num_kv_splits,
+    )
+    # k_scale is a device scalar (fp32, shape ()). For the MSE path the
+    # kernel never reads it; pass a placeholder that satisfies Triton's
+    # signature requirements.
+    if k_scale is None:
+        k_scale_tensor = torch.tensor(1.0, dtype=torch.float32, device=q.device)
+    else:
+        assert k_scale.dim() == 0 and k_scale.dtype == torch.float32, (
+            f"k_scale must be a scalar fp32 tensor, got shape={k_scale.shape} "
+            f"dtype={k_scale.dtype}"
+        )
+        k_scale_tensor = k_scale
+
+    _fwd_grouped_kernel_stage1_tq[grid](
+        q,
+        cache,
+        centroids_bf16,
+        sm_scale,
+        req_to_tokens,
+        b_seqlen,
+        att_out,
+        req_to_tokens.stride(0),
+        q.stride(0),
+        q.stride(1),
+        cache.stride(0),
+        cache.stride(1),
+        att_out.stride(0),
+        att_out.stride(1),
+        att_out.stride(2),
+        q_head_num=q_head_num,
+        BLOCK_DMODEL=BLOCK_DMODEL,
+        BLOCK_DPE=BLOCK_DPE,
+        BLOCK_DV=BLOCK_DV,
+        BLOCK_H=BLOCK_H,
+        NUM_KV_SPLITS=num_kv_splits,
+        PAGE_SIZE=page_size,
+        logit_cap=logit_cap,
+        L=L,
+        R=R,
+        MSE_BITS=mse_bits,
+        MSE_BYTES=mse_bytes,
+        KV_C_BYTES=kv_c_bytes,
+        NORM_CORRECTION=1 if norm_correction else 0,
+        KPE_FP8=1 if kpe_fp8 else 0,
+        KEY_FP8=1 if key_fp8 else 0,
+        K_SCALE_ptr=k_scale_tensor,
+    )

--- a/vllm/v1/attention/ops/triton_turboquant_store.py
+++ b/vllm/v1/attention/ops/triton_turboquant_store.py
@@ -347,6 +347,302 @@ def _tq_fused_store_mse(
 # ═══════════════════════════════════════════════════════════════════════
 
 
+# ═══════════════════════════════════════════════════════════════════════
+# MLA fused store kernels (no head dimension, MLA-specific layout)
+# ═══════════════════════════════════════════════════════════════════════
+
+
+@triton.jit
+def _tq_mla_fused_store_fp8_kernel(
+    kv_c_ptr,  # [N, L] bf16/fp32
+    k_pe_ptr,  # [N, R] bf16/fp32
+    kv_cache_ptr,  # [total_slots * packed_bytes] uint8
+    slot_mapping_ptr,  # [N] int64
+    k_scale_ptr,  # [1] fp32
+    L: tl.constexpr,
+    R: tl.constexpr,
+    PACKED_BYTES: tl.constexpr,
+    K_PE_BYTES: tl.constexpr,
+    K_PE_FP8: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    BLOCK_L: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+):
+    """MLA FP8 fused store: quantize kv_c to fp8 + handle k_pe + scatter."""
+    token_idx = tl.program_id(0)
+    slot = tl.load(slot_mapping_ptr + token_idx)
+    if slot < 0:
+        return
+
+    slot_i64 = slot.to(tl.int64)
+    cache_offset = slot_i64 * PACKED_BYTES
+
+    # Load k_scale (scalar)
+    k_scale = tl.load(k_scale_ptr)
+    inv_scale = tl.where(k_scale > 0, 1.0 / k_scale, 1.0)
+
+    # ── FP8 kv_c: cast to fp8 and store ──────────────────────────
+    l_offs = tl.arange(0, BLOCK_L)
+    l_mask = l_offs < L
+    kv_c_vals = tl.load(kv_c_ptr + token_idx * L + l_offs, mask=l_mask, other=0.0)
+    kv_c_scaled = kv_c_vals.to(tl.float32) * inv_scale
+    kv_c_clamped = tl.minimum(tl.maximum(kv_c_scaled, -FP8_MAX), FP8_MAX)
+    kv_c_fp8 = kv_c_clamped.to(tl.float8e4nv)
+    kv_c_bytes = kv_c_fp8.to(tl.uint8, bitcast=True)
+    tl.store(kv_cache_ptr + cache_offset + l_offs, kv_c_bytes, mask=l_mask)
+
+    # ── k_pe ──────────────────────────────────────────────────────
+    r_offs = tl.arange(0, BLOCK_R)
+    r_mask = r_offs < R
+    k_pe_vals = tl.load(k_pe_ptr + token_idx * R + r_offs, mask=r_mask, other=0.0)
+    k_pe_offset = cache_offset + L
+
+    if K_PE_FP8:
+        # Per-token absmax quantization
+        k_pe_f32 = k_pe_vals.to(tl.float32)
+        k_pe_absmax = tl.max(tl.abs(tl.where(r_mask, k_pe_f32, 0.0)), axis=0)
+        k_pe_scale = k_pe_absmax / FP8_MAX
+        k_pe_scale = tl.where(k_pe_scale > 1e-8, k_pe_scale, 1e-8)
+        k_pe_inv = 1.0 / k_pe_scale
+        kpe_scaled = k_pe_f32 * k_pe_inv
+        kpe_clamped = tl.minimum(tl.maximum(kpe_scaled, -FP8_MAX), FP8_MAX)
+        k_pe_fp8 = kpe_clamped.to(tl.float8e4nv)
+        k_pe_u8 = k_pe_fp8.to(tl.uint8, bitcast=True)
+        tl.store(kv_cache_ptr + k_pe_offset + r_offs, k_pe_u8, mask=r_mask)
+        # Store scale as fp16 (2 bytes)
+        sc_f16 = k_pe_scale.to(tl.float16)
+        sc_u16 = sc_f16.to(tl.uint16, bitcast=True)
+        tl.store(kv_cache_ptr + k_pe_offset + R, (sc_u16 & 0xFF).to(tl.uint8))
+        tl.store(
+            kv_cache_ptr + k_pe_offset + R + 1, ((sc_u16 >> 8) & 0xFF).to(tl.uint8)
+        )
+    else:
+        # Store k_pe as bf16 (2*R bytes)
+        k_pe_bf16 = k_pe_vals.to(tl.bfloat16)
+        k_pe_u16 = k_pe_bf16.to(tl.uint16, bitcast=True)
+        tl.store(
+            kv_cache_ptr + k_pe_offset + r_offs * 2,
+            (k_pe_u16 & 0xFF).to(tl.uint8),
+            mask=r_mask,
+        )
+        tl.store(
+            kv_cache_ptr + k_pe_offset + r_offs * 2 + 1,
+            ((k_pe_u16 >> 8) & 0xFF).to(tl.uint8),
+            mask=r_mask,
+        )
+
+
+@triton.jit
+def _tq_mla_fused_store_mse_kernel(
+    Y_ptr,  # [N, L] fp32 — rotated normalized keys (x_hat @ PiT)
+    Norms_ptr,  # [N] fp32 — key vector norms
+    k_pe_ptr,  # [N, R] bf16/fp32
+    Midpoints_ptr,  # [n_centroids-1] fp32
+    kv_cache_ptr,  # [total_slots * packed_bytes] uint8
+    slot_mapping_ptr,  # [N] int64
+    L: tl.constexpr,
+    R: tl.constexpr,
+    PACKED_BYTES: tl.constexpr,
+    MSE_BYTES: tl.constexpr,
+    K_PE_BYTES: tl.constexpr,
+    K_PE_FP8: tl.constexpr,
+    MSE_BITS: tl.constexpr,
+    N_CENTROIDS: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    BLOCK_L: tl.constexpr,
+    BLOCK_R: tl.constexpr,
+):
+    """MLA MSE fused store: bucketize + pack + norm store + k_pe store."""
+    token_idx = tl.program_id(0)
+    slot = tl.load(slot_mapping_ptr + token_idx)
+    if slot < 0:
+        return
+
+    slot_i64 = slot.to(tl.int64)
+    cache_offset = slot_i64 * PACKED_BYTES
+
+    l_offs = tl.arange(0, BLOCK_L)
+    l_mask = l_offs < L
+
+    # ── 1. Load rotated keys and binary search bucketize ──────────
+    y_vec = tl.load(Y_ptr + token_idx * L + l_offs, mask=l_mask, other=0.0)
+    lo = tl.zeros([BLOCK_L], dtype=tl.int32)
+    hi = tl.full([BLOCK_L], N_CENTROIDS - 1, dtype=tl.int32)
+    for _ in range(MSE_BITS):
+        mid = (lo + hi) >> 1
+        safe_mid = tl.minimum(mid, N_CENTROIDS - 2)
+        mid_val = tl.load(Midpoints_ptr + safe_mid, mask=l_mask, other=0.0)
+        lo = tl.where(y_vec >= mid_val, mid + 1, lo)
+        hi = tl.where(y_vec >= mid_val, hi, mid)
+    idx = tl.minimum(lo, N_CENTROIDS - 1)
+
+    # ── 2. Pack MSE indices ──────────────────────────────────────
+    if MSE_BITS == 4:
+        idx_pairs = tl.reshape(idx, [BLOCK_L // 2, 2])
+        shifts_4 = tl.arange(0, 2) * 4
+        packed = tl.sum((idx_pairs & 0xF) << shifts_4[None, :], axis=1).to(tl.uint8)
+        mse_offs = tl.arange(0, BLOCK_L // 2)
+        mse_mask = mse_offs < MSE_BYTES
+        tl.store(kv_cache_ptr + cache_offset + mse_offs, packed, mask=mse_mask)
+    else:  # MSE_BITS == 3
+        BLOCK_GRP: tl.constexpr = triton.next_power_of_2(L // 8)
+        grp_offs = tl.arange(0, BLOCK_GRP)
+        grp_mask = grp_offs < (L // 8)
+        idx_grp = tl.reshape(idx, [BLOCK_GRP, 8])
+        shifts_3 = tl.arange(0, 8) * 3
+        packed_24 = tl.sum((idx_grp & 0x7) << shifts_3[None, :], axis=1)
+        b0 = (packed_24 & 0xFF).to(tl.uint8)
+        b1 = ((packed_24 >> 8) & 0xFF).to(tl.uint8)
+        b2 = ((packed_24 >> 16) & 0xFF).to(tl.uint8)
+        tl.store(kv_cache_ptr + cache_offset + grp_offs * 3, b0, mask=grp_mask)
+        tl.store(kv_cache_ptr + cache_offset + grp_offs * 3 + 1, b1, mask=grp_mask)
+        tl.store(kv_cache_ptr + cache_offset + grp_offs * 3 + 2, b2, mask=grp_mask)
+
+    # ── 3. Store vec_norm (fp16, 2 bytes) ─────────────────────────
+    norm_offset = cache_offset + MSE_BYTES
+    vn_f16 = tl.load(Norms_ptr + token_idx).to(tl.float16)
+    vn_u16 = vn_f16.to(tl.uint16, bitcast=True)
+    tl.store(kv_cache_ptr + norm_offset, (vn_u16 & 0xFF).to(tl.uint8))
+    tl.store(kv_cache_ptr + norm_offset + 1, ((vn_u16 >> 8) & 0xFF).to(tl.uint8))
+
+    # ── 4. k_pe ──────────────────────────────────────────────────
+    r_offs = tl.arange(0, BLOCK_R)
+    r_mask = r_offs < R
+    k_pe_vals = tl.load(k_pe_ptr + token_idx * R + r_offs, mask=r_mask, other=0.0)
+    k_pe_offset = cache_offset + MSE_BYTES + 2
+
+    if K_PE_FP8:
+        k_pe_f32 = k_pe_vals.to(tl.float32)
+        k_pe_absmax = tl.max(tl.abs(tl.where(r_mask, k_pe_f32, 0.0)), axis=0)
+        k_pe_scale = k_pe_absmax / FP8_MAX
+        k_pe_scale = tl.where(k_pe_scale > 1e-8, k_pe_scale, 1e-8)
+        kpe_scaled = k_pe_f32 / k_pe_scale
+        kpe_clamped = tl.minimum(tl.maximum(kpe_scaled, -FP8_MAX), FP8_MAX)
+        k_pe_fp8 = kpe_clamped.to(tl.float8e4nv)
+        k_pe_u8 = k_pe_fp8.to(tl.uint8, bitcast=True)
+        tl.store(kv_cache_ptr + k_pe_offset + r_offs, k_pe_u8, mask=r_mask)
+        sc_f16 = k_pe_scale.to(tl.float16)
+        sc_u16 = sc_f16.to(tl.uint16, bitcast=True)
+        tl.store(kv_cache_ptr + k_pe_offset + R, (sc_u16 & 0xFF).to(tl.uint8))
+        tl.store(
+            kv_cache_ptr + k_pe_offset + R + 1, ((sc_u16 >> 8) & 0xFF).to(tl.uint8)
+        )
+    else:
+        k_pe_bf16 = k_pe_vals.to(tl.bfloat16)
+        k_pe_u16 = k_pe_bf16.to(tl.uint16, bitcast=True)
+        tl.store(
+            kv_cache_ptr + k_pe_offset + r_offs * 2,
+            (k_pe_u16 & 0xFF).to(tl.uint8),
+            mask=r_mask,
+        )
+        tl.store(
+            kv_cache_ptr + k_pe_offset + r_offs * 2 + 1,
+            ((k_pe_u16 >> 8) & 0xFF).to(tl.uint8),
+            mask=r_mask,
+        )
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# MLA store launchers
+# ═══════════════════════════════════════════════════════════════════════
+
+
+def _mla_fused_store_fp8(
+    kv_c: torch.Tensor,  # [N, L] bf16/fp32
+    k_pe: torch.Tensor,  # [N, R] bf16/fp32
+    kv_cache: torch.Tensor,  # [num_blocks, block_size, packed_bytes] uint8
+    slot_mapping: torch.Tensor,  # [N] int64
+    k_scale: torch.Tensor,  # scalar fp32
+    kv_lora_rank: int,
+    qk_rope_head_dim: int,
+    k_pe_fp8: bool,
+):
+    """Launch MLA FP8 fused store kernel."""
+    N = kv_c.shape[0]
+    L = kv_lora_rank
+    R = qk_rope_head_dim
+    BLOCK_L = triton.next_power_of_2(L)
+    BLOCK_R = triton.next_power_of_2(R)
+    k_pe_bytes = R + 2 if k_pe_fp8 else 2 * R
+    packed_bytes = L + k_pe_bytes
+
+    grid = (N,)
+    _tq_mla_fused_store_fp8_kernel[grid](
+        kv_c,
+        k_pe,
+        kv_cache.view(-1),
+        slot_mapping.to(torch.int64),
+        k_scale,
+        L=L,
+        R=R,
+        PACKED_BYTES=packed_bytes,
+        K_PE_BYTES=k_pe_bytes,
+        K_PE_FP8=k_pe_fp8,
+        FP8_MAX=448.0,
+        BLOCK_L=BLOCK_L,
+        BLOCK_R=BLOCK_R,
+        num_warps=4,
+        num_stages=1,
+    )
+
+
+def _mla_fused_store_mse(
+    kv_c: torch.Tensor,  # [N, L] bf16/fp32
+    k_pe: torch.Tensor,  # [N, R] bf16/fp32
+    kv_cache: torch.Tensor,  # [num_blocks, block_size, packed_bytes] uint8
+    slot_mapping: torch.Tensor,  # [N] int64
+    PiT: torch.Tensor,  # [L, L] fp32 — Hadamard rotation matrix
+    midpoints: torch.Tensor,  # [n_centroids-1] fp32
+    mse_bits: int,
+    kv_lora_rank: int,
+    qk_rope_head_dim: int,
+    k_pe_fp8: bool,
+):
+    """Launch MLA MSE fused store kernel.
+
+    External GEMM handles normalize + rotation (cuBLAS is faster than in-kernel).
+    The kernel does: bucketize + MSE index pack + norm store + k_pe store.
+    """
+    N = kv_c.shape[0]
+    L = kv_lora_rank
+    R = qk_rope_head_dim
+    BLOCK_L = triton.next_power_of_2(L)
+    BLOCK_R = triton.next_power_of_2(R)
+    mse_bytes = math.ceil(L * mse_bits / 8)
+    n_centroids = 2**mse_bits
+    k_pe_bytes = R + 2 if k_pe_fp8 else 2 * R
+    packed_bytes = mse_bytes + 2 + k_pe_bytes
+
+    # External GEMM: normalize + rotation
+    kv_c_f = kv_c.to(torch.float32)
+    norms = kv_c_f.norm(dim=1)  # (N,)
+    x_hat = kv_c_f / (norms.unsqueeze(1) + 1e-8)
+    y = x_hat @ PiT  # (N, L) — rotated
+
+    grid = (N,)
+    _tq_mla_fused_store_mse_kernel[grid](
+        y,
+        norms,
+        k_pe,
+        midpoints,
+        kv_cache.view(-1),
+        slot_mapping.to(torch.int64),
+        L=L,
+        R=R,
+        PACKED_BYTES=packed_bytes,
+        MSE_BYTES=mse_bytes,
+        K_PE_BYTES=k_pe_bytes,
+        K_PE_FP8=k_pe_fp8,
+        MSE_BITS=mse_bits,
+        N_CENTROIDS=n_centroids,
+        FP8_MAX=448.0,
+        BLOCK_L=BLOCK_L,
+        BLOCK_R=BLOCK_R,
+        num_warps=4,
+        num_stages=1,
+    )
+
+
 def triton_turboquant_store(
     key: torch.Tensor,  # [N, H, D] — raw keys (post-RoPE)
     value: torch.Tensor,  # [N, H, D] — raw values


### PR DESCRIPTION
# Summary

- Builds on **#38479** (general TurboQuant) by adding a DeepSeek-style MLA-specific Triton-fused TurboQuant decode backend.
- Addresses the MLA support follow-up tracked in **#40069**.
- Keeps the compressed latent KV cache packed as `uint8` through decode — the default fused decode path avoids bf16 K-cache materialization; the legacy workspace path is kept only as an opt-in regression anchor.
- Fuses TurboQuant dequant (bit-unpack + centroid gather + vec_norm for MSE, or fp8→q.dtype cast for k8v4) into the MLA decode stage1 kernel.
- Scope: **CUDA + DeepSeek-style MLA first**. `TRITON_MLA_TURBOQUANT` backend, four presets: `turboquant_k8v4`, `turboquant_4bit_nc`, `turboquant_k3v4_nc`, `turboquant_3bit_nc`.

---

# Scope

## In scope

- CUDA-only
- DeepSeek-style MLA (latent `kv_c` / `ctkv` path)
- `TRITON_MLA_TURBOQUANT` backend
- `turboquant_k8v4`, `turboquant_4bit_nc`, `turboquant_k3v4_nc`, `turboquant_3bit_nc`
- Local correctness tests + local validation on DeepSeek-V2-Lite (4×RTX 4090) and DeepSeek-R1 (8×H20-3e)

## Out of scope

- General TurboQuant redesign (#38479 handles the non-MLA path)
- End-to-end MTP/spec-decode support
- KV connector / disaggregated serving
- CUTLASS/CUDA replacement kernels
- Broad H100/A100 certification

---

# What changed

| Area | Files | Purpose |
|------|-------|---------|
| MLA TQ backend | `vllm/v1/attention/backends/mla/triton_mla_tq.py` | `forward_mqa` rewritten: `*_nc` → fused MSE branch; `k8v4` → fused KEY_FP8 branch; lazy one-shot Π fold into `W_UK_T`/`W_UV` on the MSE decode path; metadata builder |
| Fused Triton decode kernel | `vllm/v1/attention/ops/triton_turboquant_mla_decode.py` | `_fwd_grouped_kernel_stage1_tq` + `fused_mla_tq_decode_stage1` launcher; KEY_FP8 / KPE_FP8 / NORM_CORRECTION `constexpr` branches; vec_norm post-multiply |
| Backend selection | `vllm/v1/attention/backends/registry.py`, `vllm/platforms/cuda.py` | Register `TritonMLATurboQuantBackend`; select for supported MLA + TQ dtype |
| MLA KV cache spec | `vllm/model_executor/layers/attention/mla_attention.py` | Returns packed-uint8 MLAAttentionSpec for turboquant_* MLA cache dtypes |
| Correctness tests | `tests/kernels/attention/test_mla_turboquant_dequant.py`, `test_mla_turboquant_qside_rotation.py`, `tests/v1/attention/test_mla_turboquant_backend.py` | 48 + 16 + 30 cases |
| Bench / repro | `benchmarks/kernels/benchmark_mla_turboquant_decode*.py`, `tools/scan_mla_tq_kv_capacity.py`, `tools/bench_mla_tq_decode.py`, `tools/run_gsm8k.sh`, others | Local validation and reproducibility |
| Docs | `docs/design/attention_backends.md` | Backend registry documentation |

---

# Design

**Central identity** — q-side Hadamard rotation that avoids materializing bf16 K cache:

```
q · ((y_hat * vn) @ Π) ≡ ((q @ Π) · y_hat) * vn
```

- MSE presets keep packed codebook indices + vec_norm in `uint8` cache. The kernel inlines bit-unpack → centroid gather → vec_norm scale → dot at every K-load site.
- k8v4 reads FP8 keys directly from `uint8` cache via `KEY_FP8` branch: bitcast to `tl.float8e4nv`, scale by `K_SCALE`, cast to `q.dtype`, feed `tl.dot`.
- Q-side rotation avoids materializing full bf16 K cache. The Hadamard rotation is folded into `W_UK_T` / `W_UV` via lazy one-shot Π fold on the MSE decode path, eliminating per-forward rotation calls.
- `K_SCALE` is applied inside the FP8 K tile (`y_hat *= K_SCALE` before cast) rather than folded into `sm_scale`, because MLA reuses K as V — both `qk` and `acc @ v` must see the same scale. Folding into `sm_scale` corrects qk magnitude but leaves V unscaled, producing ~42% rel RMS error at non-unit k_scale.

---

# Correctness

Local tests (all pass):

| Test | Cases | What it validates |
|------|-------|-------------------|
| `test_mla_turboquant_dequant.py` | 48 | Fused kernel vs PyTorch oracle: `{L ∈ {128,256,512}} × {R ∈ {32,64}} × {mse_bits ∈ {3,4}} × {kpe_fp8, norm_correction}`. 4-bit: atol=5e-3, cosine ≥ 0.999. 3-bit: atol=8e-3, cosine ≥ 0.997. |
| `test_mla_turboquant_qside_rotation.py` | 16 | Q-side rotation identity: `{L ∈ {128,256,512,1024}} × {bits ∈ {3,4}} × {norm_correction}` |
| `test_mla_turboquant_backend.py` | 30 | Backend surface: registry resolution, dtype claim discipline, CG mode, packed-uint8 cache shape, `_pack_bits_rows`/`_unpack_bits_rows` round-trip |
| `tools/test_k3_fp8_fused_equiv.py` | 3 | KEY_FP8 branch vs workspace reference at `k_scale ∈ {0.7, 1.0, 2.5}`. Rel RMS ~1e-4 |

```bash
pytest tests/kernels/attention/test_mla_turboquant_dequant.py -q          # 48 passed
pytest tests/kernels/attention/test_mla_turboquant_qside_rotation.py -q    # 16 passed
pytest tests/v1/attention/test_mla_turboquant_backend.py -q                # 30 passed
python tools/test_k3_fp8_fused_equiv.py
```

---

# Validation summary

## DeepSeek-V2-Lite / 4×RTX 4090 (SM89), TP=4

| Preset | Capacity vs auto | b=16 decode tok/s | b=16 vs auto | GSM8K Δ vs auto |
|--------|-----------------|-------------------|--------------|-----------------|
| `turboquant_k8v4` | 1.80× | 898 | 1.16× | −0.53 pp (within stderr) |
| `turboquant_4bit_nc` | 2.98× | 591 | 0.76× | −0.76 pp (within stderr) |
| `turboquant_3bit_nc` | 3.58× | 623 | 0.80× | −1.82 pp (~1.4σ) |

k8v4 is throughput-positive on V2-Lite (1.16–1.96× across switch combos). `*_nc` presets are capacity-positive; kernel-level speed is 0.20–0.81× of bf16. GSM8K quality is within stderr for k8v4 and 4bit_nc; 3bit_nc is the most aggressive preset and shows a small ~1.4σ drop.

## DeepSeek-R1 / 8×H20-3e (SM90), TP=8

| Preset | Capacity vs auto | b=16 decode tok/s | b=16 vs auto | 64K context |
|--------|-----------------|-------------------|--------------|-------------|
| `turboquant_k8v4` | 1.89× | 112 | 0.86× | Validated |
| `turboquant_4bit_nc` | 3.14× | 97 | 0.75× | Validated |
| `turboquant_3bit_nc` | 3.76× | 96 | 0.75× | Validated |

R1 is MoE/GEMM-bound. TurboQuant improves KV capacity, while throughput is operating-point-dependent and not claimed as a general speedup.

---

# Limitations

- `*_nc` MSE branch is capacity-first, not raw kernel-speed-first. Kernel-level decode is 0.20–0.81× of bf16. Tensor-core unpack→mma fusion is the natural follow-up.
- R1 / large MoE decode is GEMM-bound; TurboQuant capacity gains may not translate to throughput improvement at small batch.
- H100/A100 numbers not collected.
- End-to-end MTP/spec-decode support is not claimed in this PR.
- H20/R1 validation is additive stress coverage, not a universal production certification.
- `fp8` KV-cache dtype regresses vs `auto` on FP8-native R1 (0.53× capacity) — on FP8-native MoE checkpoints, the TurboQuant presets are the right knob, not the explicit `fp8` mode.

---

# Relationship to existing work

- **Builds on #38479** (general TurboQuant, merged). This PR adds the MLA-specific fused decode kernel and backend wiring; #38479 covers the general (non-MLA) attention path only.
- **Addresses the MLA support item** from #40069 (tracking issue for TurboQuant/HIGGS follow-ups).
- **Complementary to #39931** (hybrid model support): #39931 enables hybrid/full-attention coverage for general TurboQuant; this PR adds the DeepSeek-style MLA-specific decode backend.
- Not a duplicate of any open PR. No other PR fuses TurboQuant dequant into the MLA decode kernel.

---

# Test plan

- [x] Local unit tests: `test_mla_turboquant_dequant.py` (48), `test_mla_turboquant_qside_rotation.py` (16), `test_mla_turboquant_backend.py` (30)
- [x] Local DeepSeek-V2-Lite validation on 4×RTX 4090: capacity, throughput, GSM8K
- [x] Local DeepSeek-R1 stress validation on 8×H20-3e: capacity, throughput, 64K context, large-batch
- [ ] Full upstream CI (pending)

---

# AI assistance / DCO

This PR was prepared with Claude assistance (commit trailers `Co-authored-by: Claude`). Every changed line was reviewed and validated by the human submitter. DCO signed-off.

<details>
<summary>Validation details (click to expand)</summary>

## V2-Lite detail — KV-cache capacity (mml=8192, gmu=0.80)

| dtype | total cache tokens | × vs auto | max concurrency |
|-------|-------------------|-----------|-----------------|
| auto (bf16) | 366,960 | 1.00× | 44.8× |
| fp8 | 725,648 | 1.98× | 88.6× |
| turboquant_k8v4 | 660,544 | 1.80× | 80.6× |
| turboquant_4bit_nc | 1,095,200 | 2.98× | 133.7× |
| turboquant_3bit_nc | 1,312,880 | 3.58× | 160.3× |

## V2-Lite detail — k8v4 kernel microbench (K3 fused vs staging+decode)

| B | ctx | baseline ms | fused ms | speedup |
|---|-----|------------|---------|---------|
| 16 | 16384 | 5.511 | 1.661 | 3.32× |

K3 fused time matches decode-alone within noise — inline fp8→bf16 cast costs ~zero on top of attention math.

## R1 detail — KV-cache capacity (mml=8192, gmu=0.85)

| dtype | total cache tokens | × vs auto | max concurrency |
|-------|-------------------|-----------|-----------------|
| auto (R1 FP8) | 517,616 | 1.00× | 63.2× |
| turboquant_k8v4 | 979,040 | 1.89× | 119.5× |
| turboquant_4bit_nc | 1,623,280 | 3.14× | 198.2× |
| turboquant_3bit_nc | 1,945,920 | 3.76× | 237.5× |

## R1 detail — long context (batch=1, gen=256)

| dtype | 32K tok/s | 64K tok/s |
|-------|-----------|-----------|
| auto | 9.06 | 8.85 |
| turboquant_k8v4 | 6.99 | 7.28 |
| turboquant_4bit_nc | 6.06 | 6.35 |

32K and 64K validated on all dtypes. No "131K unlock" claim — 131K OOMs on all dtypes at gmu=0.85.

The V2-Lite fp8 GSM8K row blocked on SM89 was collected on H20: flexible 38.13%, strict 37.91%.

## Reproducibility commands

```bash
# V2-Lite capacity scan
VLLM_ALLOW_INSECURE_SERIALIZATION=1 MODEL=/path/to/DeepSeek-V2-Lite \
    python tools/scan_mla_tq_kv_capacity.py \
        --dtypes auto fp8 turboquant_k8v4 turboquant_4bit_nc turboquant_3bit_nc \
        --max-model-len 8192 --tp 4

# V2-Lite decode throughput
VLLM_ALLOW_INSECURE_SERIALIZATION=1 MODEL=/path/to/DeepSeek-V2-Lite \
    python tools/bench_mla_tq_decode.py \
        --dtypes auto turboquant_k8v4 turboquant_4bit_nc turboquant_3bit_nc \
        --batches 1 4 16 --prompt-len 512 --gen-len 256 --tp 4 --no-enforce-eager

# GSM8K 5-shot
bash tools/run_gsm8k.sh

# Kernel microbench
PYTHONPATH=. python benchmarks/kernels/benchmark_mla_turboquant_decode.py
PYTHONPATH=. python benchmarks/kernels/benchmark_mla_turboquant_decode_fp8.py
```

## Follow-up

Further local experiments around SM90 tuning, spec-decode validation, and long-context serving capacity are intentionally kept out of this PR and may be proposed separately.

</details>
