### PR TITLE
[Misc] Delay EPLB Nixl import until needed 

### DIFF
--- a/vllm/distributed/eplb/eplb_communicator.py
+++ b/vllm/distributed/eplb/eplb_communicator.py
@@ -23,10 +23,6 @@ from vllm.distributed.device_communicators.pynccl import PyNcclCommunicator
 from vllm.distributed.device_communicators.pynccl_wrapper import (
     ncclDataTypeEnum,
 )
-from vllm.distributed.nixl_utils import (
-    NixlWrapper,
-    nixl_agent_config,
-)
 from vllm.distributed.parallel_state import (
     GroupCoordinator,
     get_pp_group,
@@ -41,6 +37,8 @@ logger = init_logger(__name__)
 
 def has_nixl() -> bool:
     """Whether the optional NIXL / RIXL package is available."""
+    from vllm.distributed.nixl_utils import NixlWrapper
+
     return NixlWrapper is not None
 
 
@@ -235,6 +233,8 @@ class NixlEplbCommunicator(EplbCommunicator):
         expert_weights: Sequence[torch.Tensor],
         cuda_stream: torch.cuda.Stream | None = None,
     ) -> None:
+        from vllm.distributed.nixl_utils import NixlWrapper, nixl_agent_config
+
         assert expert_weights, "NixlEplbCommunicator requires non-empty expert_weights."
         if NixlWrapper is None:
             raise RuntimeError("NIXL/ RIXL is unavailable.")


### PR DESCRIPTION
Starting a simple colocated vllm instance with a dense model (ep obv disabled) still brings up this unrelated logs that show up when importing nixl
```
> vllm serve mistralai/Mistral-Medium-3.5-128B -tp 4 --port 8004 --max-model-len 32k
(APIServer pid=377662) INFO 05-06 09:34:02 [utils.py:299]
(APIServer pid=377662) INFO 05-06 09:34:02 [utils.py:299]        █     █     █▄   ▄█
(APIServer pid=377662) INFO 05-06 09:34:02 [utils.py:299]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.20.2rc1.dev69+g66d1cc0c7
(APIServer pid=377662) INFO 05-06 09:34:02 [utils.py:299]   █▄█▀ █     █     █     █  model   mistralai/Mistral-Medium-3.5-128B
(APIServer pid=377662) INFO 05-06 09:34:02 [utils.py:299]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀
(APIServer pid=377662) INFO 05-06 09:34:02 [utils.py:299]
 [ . . . ]
==>(APIServer pid=377662) INFO 05-06 09:34:04 [nixl_utils.py:20] Setting UCX_RCACHE_MAX_UNRELEASED to '1024' to avoid a rare memory leak in UCX when using NIXL.
==>(APIServer pid=377662) INFO 05-06 09:34:04 [nixl_utils.py:32] NIXL is available

(APIServer pid=377662) INFO 05-06 09:34:04 [scheduler.py:239] Chunked prefill is enabled with max_num_batched_tokens=8192.
```

This PR simply delays importing nixl until needed, that is when eplb with nixl backend has been requested by the user
```
> vllm serve mistralai/Mistral-Medium-3.5-128B -tp 4 --port 8004 --max-model-len 32k

(APIServer pid=388945) INFO 05-06 09:55:28 [utils.py:299]
(APIServer pid=388945) INFO 05-06 09:55:28 [utils.py:299]        █     █     █▄   ▄█
(APIServer pid=388945) INFO 05-06 09:55:28 [utils.py:299]  ▄▄ ▄█ █     █     █ ▀▄▀ █  version 0.20.2rc1.dev69+g66d1cc0c7
(APIServer pid=388945) INFO 05-06 09:55:28 [utils.py:299]   █▄█▀ █     █     █     █  model   mistralai/Mistral-Medium-3.5-128B
(APIServer pid=388945) INFO 05-06 09:55:28 [utils.py:299]    ▀▀  ▀▀▀▀▀ ▀▀▀▀▀ ▀     ▀
(APIServer pid=388945) INFO 05-06 09:55:28 [utils.py:299]
[ . . .]
(APIServer pid=388945) INFO 05-06 09:55:30 [model.py:563] Resolved architecture: PixtralForConditionalGeneration
(APIServer pid=388945) INFO 05-06 09:55:30 [model.py:1692] Using max model len 32000
(APIServer pid=388945) INFO 05-06 09:55:31 [scheduler.py:239] Chunked prefill is enabled with max_num_batched_tokens=8192.
(APIServer pid=388945) INFO 05-06 09:55:31 [vllm.py:844] Asynchronous scheduling is enabled.
(APIServer pid=388945) INFO 05-06 09:55:31 [kernel.py:212] Final IR op priority after setting platform defaults: IrOpPriorityConfig(rms_norm=['native'], fused_add_rms_norm=['native'])
```

cc @ilmarkov 