### PR TITLE
[Bugfix] Use NVFP4 packed layout for SlidingWindowSpec.real_page_size_bytes

### DIFF
--- a/tests/v1/core/test_kv_cache_utils.py
+++ b/tests/v1/core/test_kv_cache_utils.py
@@ -20,6 +20,7 @@ from vllm.multimodal.inputs import (
 from vllm.sampling_params import SamplingParams
 from vllm.utils.hashing import sha256, sha256_cbor
 from vllm.utils.mem_constants import GiB_bytes
+from vllm.utils.torch_utils import nvfp4_kv_cache_full_dim
 from vllm.v1.core.kv_cache_manager import KVCacheManager
 from vllm.v1.core.kv_cache_utils import (
     BlockHash,
@@ -44,6 +45,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheGroupSpec,
     KVCacheSpec,
     KVCacheTensor,
+    KVQuantMode,
     MambaSpec,
     MLAAttentionSpec,
     SlidingWindowSpec,
@@ -1265,6 +1267,54 @@ def test_merge_kv_cache_spec():
         same_sliding_window_layer_spec_with_none
     )
     assert merged_layer_spec.sliding_window == 1
+
+
+def test_sliding_window_spec_real_page_size_bytes_nvfp4():
+    """SlidingWindowSpec.real_page_size_bytes must use NVFP4 packed layout
+    when kv_quant_mode is NVFP4. Without this branch, hybrid models such as
+    Gemma 4 (full attention + sliding window layers) compute the wrong page
+    size for the sliding-window layers under NVFP4 KV cache, causing a
+    mismatch with the bytes actually written by the cache writer.
+    """
+    block_size = 16
+    num_kv_heads = 8
+    head_size = 256
+    head_size_v = 128
+
+    # NVFP4 page bytes: K and V each contribute (head_size // 2 fp4 data
+    # + head_size // 16 fp8e4m3 scale) bytes per head, summed over
+    # block_size * num_kv_heads. The bf16 path returns
+    # (head_size + head_size_v) * dtype_size, which would be a different
+    # number of bytes - that mismatch is the bug this guards against.
+    spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+        head_size=head_size,
+        head_size_v=head_size_v,
+        dtype=torch.uint8,
+        sliding_window=1024,
+        kv_quant_mode=KVQuantMode.NVFP4,
+    )
+
+    expected = (
+        block_size
+        * num_kv_heads
+        * (nvfp4_kv_cache_full_dim(head_size) + nvfp4_kv_cache_full_dim(head_size_v))
+    )
+    assert spec.real_page_size_bytes == expected
+
+    # bf16 (no kv_quant_mode) path should still match the original formula.
+    bf16_spec = SlidingWindowSpec(
+        block_size=block_size,
+        num_kv_heads=num_kv_heads,
+        head_size=head_size,
+        head_size_v=head_size_v,
+        dtype=torch.bfloat16,
+        sliding_window=1024,
+    )
+    assert bf16_spec.real_page_size_bytes == (
+        block_size * num_kv_heads * (head_size + head_size_v) * 2
+    )
 
 
 def test_is_kv_cache_spec_uniform():

--- a/vllm/v1/kv_cache_interface.py
+++ b/vllm/v1/kv_cache_interface.py
@@ -421,6 +421,16 @@ class SlidingWindowSpec(AttentionSpec):
 
     @property
     def real_page_size_bytes(self) -> int:
+        if self.kv_quant_mode.is_nvfp4:
+            last_dim = nvfp4_kv_cache_full_dim(
+                self.head_size
+            ) + nvfp4_kv_cache_full_dim(self.head_size_v)
+            return (
+                self.block_size
+                * self.num_kv_heads
+                * last_dim
+                * get_dtype_size(self.dtype)
+            )
         return (
             self.block_size
             * self.num_kv_heads


### PR DESCRIPTION
## Purpose

`SlidingWindowSpec.real_page_size_bytes` returns the bf16-style formula
`block_size * num_kv_heads * (head_size + head_size_v) * dtype_size`
even when `kv_quant_mode` is `KVQuantMode.NVFP4`. `AttentionSpec` and
`FullAttentionSpec` both include an NVFP4 branch using
`nvfp4_kv_cache_full_dim` (fp4 data + fp8 block scales packed into
uint8); `SlidingWindowSpec` overrides the property because it tracks
`head_size` and `head_size_v` separately, but the override was missing
the NVFP4 case.

### Reachability

`Attention.get_kv_cache_spec` constructs `SlidingWindowSpec` with
`kv_quant_mode=quant_mode` whenever the layer has a sliding window:

https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/layers/attention/attention.py#L544-L556

So a model with both sliding window layers and `--kv-cache-dtype nvfp4`
hits this path directly.

### Consequences

`page_size_bytes` (which delegates to `real_page_size_bytes`) is read by
many critical sites: the startup assertion
`raw_tensor.numel() % kv_cache_spec.page_size_bytes == 0` in
`gpu_model_runner.py`, the `num_blocks` computation, and the
`page_stride` used for strided KV tensor views. With the wrong page
size, the startup assertion may fire (the bytes the cache writer
actually allocates do not divide evenly by the bf16-formula page size),
or block bookkeeping mismatches the bytes actually written.

Sibling specs (`AttentionSpec`, `FullAttentionSpec`) carry the NVFP4
branch already, so the contract for `kv_quant_mode=NVFP4` is "the
spec returns the packed page size." This PR brings `SlidingWindowSpec`
in line with that contract; the new branch mirrors
`FullAttentionSpec.real_page_size_bytes` verbatim. No public API
changes.

## Test Plan

Added `test_sliding_window_spec_real_page_size_bytes_nvfp4` in
`tests/v1/core/test_kv_cache_utils.py`. It builds a `SlidingWindowSpec`
with `head_size=256`, `head_size_v=128`, `dtype=torch.uint8`,
`KVQuantMode.NVFP4`, and asserts `real_page_size_bytes` equals
`block_size * num_kv_heads * (nvfp4_kv_cache_full_dim(head_size) + nvfp4_kv_cache_full_dim(head_size_v))`.
A second assertion covers the bf16 path to guard against regressions in
the existing formula.

```bash
pytest tests/v1/core/test_kv_cache_utils.py::test_sliding_window_spec_real_page_size_bytes_nvfp4 -v
```

## Test Result

- With the fix: `1 passed`
- Without the fix (sanity check, fix temporarily reverted): `1 failed` —
  the bf16 formula returns `49,152` bytes vs the expected `27,648` NVFP4
  bytes for the test shapes
- `pre-commit run --files vllm/v1/kv_cache_interface.py tests/v1/core/test_kv_cache_utils.py` passes (ruff-check, ruff-format, typos, mypy, SPDX, root-lazy-imports, ...)

---

Prepared with AI assistance (Claude). Diff and test reviewed by the human author before submission.
