### PR TITLE
[ROCm] Disable AITER allreduce fusion for HIP graph replay

### DIFF
--- a/vllm/compilation/backends.py
+++ b/vllm/compilation/backends.py
@@ -23,6 +23,7 @@ from torch._logging._internal import trace_structured
 from torch.fx._lazy_graph_module import _use_lazy_graph_module
 
 import vllm.envs as envs
+from vllm._aiter_ops import rocm_aiter_ops
 from vllm.compilation.codegen import (
     compile_execution_fn,
     generate_execution_code,
@@ -929,20 +930,23 @@ class VllmBackend:
     def configure_post_pass(self) -> None:
         # TODO proper PassManager?
         pre_grad_pass_key = "pre_grad_custom_pass"
-        assert self.pass_key != pre_grad_pass_key
-        assert pre_grad_pass_key not in self.inductor_config
-        self.inductor_config[pre_grad_pass_key] = VllmIRInplaceFunctionalizationPass(
-            self.vllm_config
-        )
+        # Keep the regular pre-grad pass pipeline for other backends. ROCm
+        # AITER skips this pass to avoid HIP graph replay corruption.
+        if not rocm_aiter_ops.is_enabled():
+            assert self.pass_key != pre_grad_pass_key
+            assert pre_grad_pass_key not in self.inductor_config
+            self.inductor_config[pre_grad_pass_key] = VllmIRInplaceFunctionalizationPass(
+                self.vllm_config
+            )
 
-        # Make sure pre_grad_custom_pass is not pickled
-        # as part of AOTAutograd built-in cache key
-        # TODO(luka) is there a cleaner way to do this
-        import torch._inductor.config as inductor_config
+            # Make sure pre_grad_custom_pass is not pickled
+            # as part of AOTAutograd built-in cache key
+            # TODO(luka) is there a cleaner way to do this
+            import torch._inductor.config as inductor_config
 
-        ignore = inductor_config._cache_config_ignore_prefix + [pre_grad_pass_key]
-        assert "_cache_config_ignore_prefix" not in self.inductor_config
-        self.inductor_config["_cache_config_ignore_prefix"] = ignore
+            ignore = inductor_config._cache_config_ignore_prefix + [pre_grad_pass_key]
+            assert "_cache_config_ignore_prefix" not in self.inductor_config
+            self.inductor_config["_cache_config_ignore_prefix"] = ignore
 
         # Configure the (nominally post-grad) pass manager
         self.pass_manager.configure(self.vllm_config)

--- a/vllm/compilation/passes/pass_manager.py
+++ b/vllm/compilation/passes/pass_manager.py
@@ -18,10 +18,10 @@ from .ir.clone_elimination import UnsafeCloneEliminationPass
 from .ir.lowering_pass import VllmIRLoweringPass
 from .vllm_inductor_pass import VllmInductorPass, VllmPatternMatcherPass
 
+if rocm_aiter_ops.is_enabled() or current_platform.is_cuda():
+    from .fusion.allreduce_rms_fusion import AllReduceFusionPass
+
 if rocm_aiter_ops.is_enabled():
-    from .fusion.allreduce_rms_fusion import (
-        RocmAiterAllReduceFusionPass,
-    )
     from .fusion.rocm_aiter_fusion import (
         MLADualRMSNormFusionPass,
         RocmAiterRMSNormQuantFusionPass,
@@ -41,7 +41,6 @@ if current_platform.is_cuda_alike():
     from .utility.split_coalescing import SplitCoalescingPass
 
 if current_platform.is_cuda():
-    from .fusion.allreduce_rms_fusion import AllReduceFusionPass
     from .fusion.collective_fusion import AsyncTPPass
     from .fusion.minimax_qk_norm_fusion import MiniMaxQKNormPass
 
@@ -116,8 +115,11 @@ class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
         # DCE handles mutating ops correctly as well.
         self.ir_lowering(graph)
         VllmInductorPass.dump_prefix += 1
-        self.clone_elimination(graph)
-        VllmInductorPass.dump_prefix += 1
+        # ROCm AITER relies on HIP graph replay; this unsafe pass can alter
+        # aliases in ways that corrupt replayed decode graphs.
+        if not rocm_aiter_ops.is_enabled():
+            self.clone_elimination(graph)
+            VllmInductorPass.dump_prefix += 1
 
         # clean up after lowering again
         self.post_cleanup(graph)
@@ -143,10 +145,9 @@ class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
                     self.passes += [AsyncTPPass(config)]
 
             if self.pass_config.fuse_allreduce_rms:
-                if rocm_aiter_ops.is_enabled():
-                    self.passes += [RocmAiterAllReduceFusionPass(config)]
-                else:
-                    self.passes += [AllReduceFusionPass(config)]
+                # The ROCm AITER allreduce fusion path can corrupt HIP graph
+                # replay; use the standard pass when AITER is enabled.
+                self.passes += [AllReduceFusionPass(config)]
 
             if self.pass_config.fuse_minimax_qk_norm:
                 self.passes += [MiniMaxQKNormPass(config)]
@@ -205,7 +206,8 @@ class PostGradPassManager(CustomGraphPass):  # type: ignore[misc]
 
         passes.append(self.post_cleanup.uuid())
         passes.append(self.ir_lowering.uuid())
-        passes.append(self.clone_elimination.uuid())
+        if not rocm_aiter_ops.is_enabled():
+            passes.append(self.clone_elimination.uuid())
         passes.append(self.post_cleanup.uuid())
         passes.append(self.fix_functionalization.uuid())
 

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -472,7 +472,6 @@ class GroupCoordinator:
         # only cuda uses this function,
         # so we don't abstract it into the base class
         maybe_ca_context = nullcontext()
-        maybe_aiter_context = nullcontext()
         from vllm.distributed.device_communicators.cuda_communicator import (
             CudaCommunicator,
         )
@@ -483,20 +482,13 @@ class GroupCoordinator:
             if ca_comm is not None:
                 maybe_ca_context = ca_comm.capture()  # type: ignore
 
-            from vllm._aiter_ops import rocm_aiter_ops
-
-            if rocm_aiter_ops.is_enabled():
-                aiter_ar = rocm_aiter_ops.get_aiter_allreduce()
-                if aiter_ar is not None:
-                    maybe_aiter_context = aiter_ar.capture()  # type: ignore
-
         # ensure all initialization operations complete before attempting to
         # capture the graph on another stream
         curr_stream = torch.cuda.current_stream()
         if curr_stream != stream:
             stream.wait_stream(curr_stream)
 
-        with torch.cuda.stream(stream), maybe_ca_context, maybe_aiter_context:
+        with torch.cuda.stream(stream), maybe_ca_context:
             yield graph_capture_context
 
     def all_reduce(self, input_: torch.Tensor) -> torch.Tensor:


### PR DESCRIPTION
## Purpose

This PR is a minimal split from draft PR #41760, which originally reported DeepSeek accuracy/output corruption under ROCm AITER HIP graph replay.

The same shared failure mode also affects non-DeepSeek ROCm AITER serving. In MiniMax/Kimi-K2.5-style workloads, HIP graph replay produces decode-time output corruption and severe accuracy loss. The common issue is not DeepSeek MLA logic itself, but the ROCm AITER allreduce fusion / graph capture / compiler pass interaction.

This PR keeps only the shared ROCm AITER graph replay fixes:

- Use standard `AllReduceFusionPass` instead of `RocmAiterAllReduceFusionPass` when ROCm AITER is enabled.
- Remove AITER allreduce graph capture via `aiter_ar.capture()`.
- Skip `UnsafeCloneEliminationPass` only when ROCm AITER is enabled.
- Skip `VllmIRInplaceFunctionalizationPass` only when ROCm AITER is enabled.

The DeepSeek-specific fixes from draft PR #41760 are intentionally excluded. Those changes involve model-specific MLA head support and DeepSeek MoE bias dtype handling. Keeping them separate lets this PR focus on the shared ROCm AITER HIP graph replay corruption path, while DeepSeek-specific behavior can be validated and reviewed independently.

Care was taken to avoid changing CUDA and non-AITER behavior. The broad compile-pass changes from the draft PR are scoped here to ROCm AITER only, so other backends keep their existing compilation pipeline.

## Test Plan

- Run fresh before/after accuracy validation for the affected DeepSeek workload.
- Run fresh before/after accuracy validation for MiniMax/Kimi-K2.5-style ROCm AITER workload.
- Run fresh before/after performance validation to check for regressions.
- Run or request CUDA smoke validation to confirm CUDA behavior is unchanged.

## Test Result
Validated on MiniMax serving with ROCm AITER enabled, using TP=2.
Serving configuration:
- Model: `MiniMaxAI/MiniMax-M2.5`
- Env vars: `VLLM_ROCM_USE_AITER=1`, `VLLM_ROCM_USE_AITER_MHA=0`, `VLLM_ROCM_USE_AITER_UNIFIED_ATTENTION=1`, `VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4`
- Serve args: `--tensor-parallel-size 2`, `--attention-backend ROCM_AITER_UNIFIED_ATTN`, `--max-model-len 12288`, `--block-size 64`, `--max-num-seqs 512`, `--max-num-batched-tokens 32768`, `--gpu-memory-utilization 0.95`, `--performance-mode balanced`, `--async-scheduling`, `--no-enable-prefix-caching`, `--kv-cache-dtype auto`, `--compilation-config '{"mode":3}'`
Accuracy was measured with `lm-eval` on GSM8K 5-shot using `local-completions`, `num_concurrent=32`, `max_gen_toks=1024`, `max_length=12288`, `--apply_chat_template`, and `temperature=0`.
### Accuracy
| Task | Filter | Metric | Before PR | After PR | Delta |
|---|---|---:|---:|---:|---:|
| gsm8k | flexible-extract | exact_match | 0.0136 ± 0.0032 | 0.9553 ± 0.0057 | +94.17 pp |
| gsm8k | strict-match | exact_match | 0.0000 ± 0.0000 | 0.9424 ± 0.0064 | +94.24 pp |
### Serving Benchmark
Serving performance was measured with `vllm bench serve` using random prompts, ISL=1000, OSL=100, 512 requests, `request-rate=inf`, and 0 failed requests.
| Max concurrency | Output tok/s before | Output tok/s after | Change | Median TPOT before | Median TPOT after | Change | Median TTFT before | Median TTFT after | Change |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 8 | 499.91 | 491.73 | -1.6% | 12.23 ms | 13.82 ms | +13.0% | 351.27 ms | 257.10 ms | -26.8% |
| 64 | 1852.30 | 1499.50 | -19.0% | 23.75 ms | 32.97 ms | +38.8% | 1234.30 ms | 956.39 ms | -22.5% |


Overall, this PR restores MiniMax ROCm AITER accuracy from near-zero GSM8K exact match to expected accuracy levels. The measured serving cost is small at concurrency 8, with output throughput down 1.6%, but more visible at concurrency 64, with output throughput down 19.0% and median TPOT up 38.8%.

Co-authored-by: frida-andersson <fanderss@amd.com>