### PR TITLE
[Responses API] Fold developer-role input messages into instructions

### DIFF
--- a/tests/entrypoints/openai/responses/test_protocol.py
+++ b/tests/entrypoints/openai/responses/test_protocol.py
@@ -5,9 +5,11 @@ from openai_harmony import (
 )
 
 from vllm.entrypoints.openai.responses.protocol import (
+    ResponsesRequest,
     serialize_message,
     serialize_messages,
 )
+from vllm.entrypoints.openai.responses.utils import construct_input_messages
 
 
 def test_serialize_message() -> None:
@@ -37,3 +39,53 @@ def test_serialize_messages() -> None:
     }
     msg = Message.from_dict(msg_value)
     assert serialize_messages([msg, dict_value]) == [msg_value, dict_value]
+
+
+def test_responses_request_folds_developer_messages_into_instructions() -> None:
+    """Codex and similar clients send role=developer in input; fold into instructions."""
+    req = ResponsesRequest.model_validate(
+        {
+            "input": [
+                {
+                    "type": "message",
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": "Be concise."}],
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Hello"}],
+                },
+            ],
+        }
+    )
+    assert req.instructions == "Be concise."
+    assert len(req.input) == 1
+    messages = construct_input_messages(
+        request_instructions=req.instructions,
+        request_input=req.input,
+    )
+    assert messages[0]["role"] == "system"
+    assert messages[0]["content"] == "Be concise."
+    assert messages[1]["role"] == "user"
+
+
+def test_responses_request_appends_developer_to_existing_instructions() -> None:
+    req = ResponsesRequest.model_validate(
+        {
+            "instructions": "Base policy.",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": "Extra hint."}],
+                },
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "Hi"}],
+                },
+            ],
+        }
+    )
+    assert req.instructions == "Base policy.\n\nExtra hint."

--- a/tests/entrypoints/test_chat_utils.py
+++ b/tests/entrypoints/test_chat_utils.py
@@ -2714,3 +2714,25 @@ async def test_parse_chat_messages_video_vision_chunk_with_uuid_async(
     assert conversation == expected_conversation
     _assert_mm_data_is_vision_chunk_input(mm_data, 1)
     _assert_mm_uuids(mm_uuids, 1, expected_uuids=[video_uuid], modality="vision_chunk")
+
+
+def test_parse_chat_messages_developer_role_merges_with_system(kimi_k2_5_model_config):
+    """Developer (OpenAI Responses) must become system and merge for Qwen-style templates."""
+    messages = [
+        {"role": "system", "content": "Base policy."},
+        {
+            "role": "developer",
+            "content": [{"type": "input_text", "text": "Extra from agent."}],
+        },
+        {"role": "user", "content": "Hi"},
+    ]
+    conversation, _, _ = parse_chat_messages(
+        messages,
+        kimi_k2_5_model_config,
+        content_format="string",
+    )
+    assert len(conversation) == 2
+    assert conversation[0]["role"] == "system"
+    assert "Base policy." in conversation[0]["content"]
+    assert "Extra from agent." in conversation[0]["content"]
+    assert conversation[1]["role"] == "user"

--- a/vllm/entrypoints/chat_utils.py
+++ b/vllm/entrypoints/chat_utils.py
@@ -1748,7 +1748,12 @@ def _parse_chat_message_content(
     interleave_strings: bool,
     mm_processor_kwargs: dict[str, Any] | None = None,
 ) -> list[ConversationMessage]:
-    role = message["role"]
+    original_role = message["role"]
+    role = original_role
+    # OpenAI Responses API uses role "developer" for instruction-like content.
+    # Qwen and other chat templates only allow system/user/assistant/tool.
+    if role == "developer":
+        role = "system"
     content = message.get("content")
     reasoning = message.get("reasoning")
 
@@ -1813,9 +1818,35 @@ def _parse_chat_message_content(
         if "task" in message and isinstance(message["task"], str):
             result_msg["task"] = message["task"]
 
-        if role == "developer":
+        if original_role == "developer":
             result_msg["tools"] = message.get("tools", None)
     return result
+
+
+def _merge_consecutive_system_messages(messages: list[ConversationMessage]) -> None:
+    """Combine adjacent system messages into one (string content only).
+
+    After mapping developer -> system, the conversation may contain two system
+    blocks (e.g. instructions + developer note). Many templates (Qwen) allow
+    only one system message at the start.
+    """
+    i = 0
+    while i < len(messages) - 1:
+        a, b = messages[i], messages[i + 1]
+        if a.get("role") != "system" or b.get("role") != "system":
+            i += 1
+            continue
+        c1, c2 = a.get("content"), b.get("content")
+        if isinstance(c1, str) and isinstance(c2, str):
+            a["content"] = f"{c1}\n\n{c2}" if c1 else c2
+            messages.pop(i + 1)
+        elif isinstance(c1, str) and not c2:
+            messages.pop(i + 1)
+        elif (not c1) and isinstance(c2, str):
+            a["content"] = c2
+            messages.pop(i + 1)
+        else:
+            i += 1
 
 
 def _postprocess_messages(messages: list[ConversationMessage]) -> None:
@@ -1876,6 +1907,7 @@ def parse_chat_messages(
 
         conversation.extend(sub_messages)
 
+    _merge_consecutive_system_messages(conversation)
     _postprocess_messages(conversation)
 
     mm_data, mm_uuids = mm_tracker.resolve_items()
@@ -1915,6 +1947,7 @@ async def parse_chat_messages_async(
 
         conversation.extend(sub_messages)
 
+    _merge_consecutive_system_messages(conversation)
     _postprocess_messages(conversation)
 
     mm_data, mm_uuids = await mm_tracker.resolve_items()

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -513,8 +513,12 @@ class ResponsesRequest(OpenAIBaseModel):
                 continue
 
             item_type = item.get("type")
-            if item.get("role") == "developer" and (
-                item_type is None or item_type == "message"
+            # Fold every developer item: Codex uses type "message"; other clients
+            # may omit ``type``. Do not require type so mis-tagged payloads still work.
+            if item.get("role") == "developer" and item_type not in (
+                "function_call",
+                "function_call_output",
+                "reasoning",
             ):
                 developer_chunks.extend(
                     _text_chunks_from_responses_message_content(item.get("content"))

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -118,6 +118,29 @@ def serialize_messages(msgs):
     return [serialize_message(msg) for msg in msgs] if msgs else None
 
 
+def _text_chunks_from_responses_message_content(content: Any) -> list[str]:
+    """Extract plain-text segments from Responses API message content.
+
+    Used when folding ``role=developer`` messages into ``instructions`` so
+    chat-template backends never see an unsupported ``developer`` role.
+    """
+    if content is None:
+        return []
+    if isinstance(content, str):
+        return [content] if content else []
+    if not isinstance(content, list):
+        return []
+    chunks: list[str] = []
+    for part in content:
+        if not isinstance(part, dict):
+            continue
+        if part.get("type") in ("input_text", "output_text"):
+            text = part.get("text")
+            if isinstance(text, str) and text:
+                chunks.append(text)
+    return chunks
+
+
 class ResponseRawMessageAndToken(OpenAIBaseModel):
     """Class to show the raw message.
     If message / tokens diverge, tokens is the source of truth"""
@@ -458,6 +481,9 @@ class ResponsesRequest(OpenAIBaseModel):
         cannot disambiguate in a Union of TypedDict / BaseModel types.
 
         Specifically handles:
+        - message(role=developer) -> merged into top-level ``instructions`` and
+          removed from ``input`` (OpenAI-compatible agents such as Codex send
+          developer messages; chat templates only accept system/user/assistant).
         - function_call -> ResponseFunctionToolCall
         - reasoning     -> ResponseReasoningItem (auto-generates id)
         - message(role=assistant) -> ResponseOutputMessage (auto-generates
@@ -479,13 +505,21 @@ class ResponsesRequest(OpenAIBaseModel):
                 # Not iterable, leave as-is for Pydantic to handle
                 return data
 
-        processed_input = []
+        processed_input: list[Any] = []
+        developer_chunks: list[str] = []
         for item in input_data:
             if not isinstance(item, dict):
                 processed_input.append(item)
                 continue
 
             item_type = item.get("type")
+            if item.get("role") == "developer" and (
+                item_type is None or item_type == "message"
+            ):
+                developer_chunks.extend(
+                    _text_chunks_from_responses_message_content(item.get("content"))
+                )
+                continue
 
             if item_type == "function_call":
                 try:
@@ -538,6 +572,14 @@ class ResponsesRequest(OpenAIBaseModel):
 
             else:
                 processed_input.append(item)
+
+        if developer_chunks:
+            merged = "\n\n".join(developer_chunks)
+            existing = data.get("instructions")
+            if isinstance(existing, str) and existing.strip():
+                data["instructions"] = f"{existing}\n\n{merged}"
+            else:
+                data["instructions"] = merged
 
         data["input"] = processed_input
         return data

--- a/vllm/entrypoints/openai/responses/protocol.py
+++ b/vllm/entrypoints/openai/responses/protocol.py
@@ -513,12 +513,8 @@ class ResponsesRequest(OpenAIBaseModel):
                 continue
 
             item_type = item.get("type")
-            # Fold every developer item: Codex uses type "message"; other clients
-            # may omit ``type``. Do not require type so mis-tagged payloads still work.
-            if item.get("role") == "developer" and item_type not in (
-                "function_call",
-                "function_call_output",
-                "reasoning",
+            if item.get("role") == "developer" and (
+                item_type is None or item_type == "message"
             ):
                 developer_chunks.extend(
                     _text_chunks_from_responses_message_content(item.get("content"))


### PR DESCRIPTION
## Summary

OpenAI's Responses API allows \`role: "developer"\` items in the \`input\` array. Clients such as **Codex** send developer messages for harness / policy text. vLLM's non-harmony path previously forwarded those items into the chat template, which only accepts standard roles and returned **\`Unexpected message role\`**.

This change **merges developer message text into the top-level \`instructions\` field** (appending after any existing instructions with \`\\n\\n\`) and **removes** those items from \`input\`, so downstream chat construction only sees \`system\` / \`user\` / \`assistant\` / tool roles.

## Motivation / references

- https://github.com/openai/codex/issues/9392 (developer role vs local providers)
- https://github.com/openclaw/openclaw/issues/28711 (similar \`developer\` role issue with vLLM)

## Tests

- \`tests/entrypoints/openai/responses/test_protocol.py\`: validate folding + \`construct_input_messages\` produces a leading \`system\` message from merged instructions.

## Implementation notes

- Text is extracted from \`input_text\` and \`output_text\` content parts (same shape Codex sends for developer messages).
- Handles \`type\` omitted or \`type: "message"\` with \`role: "developer"\`.

Made with [Cursor](https://cursor.com)