### PR TITLE
[ROCm][Perf] Enable gluon preshuffle path for DeepSeek-V3.2 sparse MLA (block_size=64)

### DIFF
--- a/vllm/v1/attention/backends/mla/indexer.py
+++ b/vllm/v1/attention/backends/mla/indexer.py
@@ -122,7 +122,10 @@ class DeepseekV32IndexerBackend(AttentionBackend):
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
-        return [1, 64] if current_platform.is_rocm() else [64]
+        # Must not advertise 1 on ROCm: select_common_block_size picks
+        # min([1, 64]) = 1, which keeps block_size=1 and leaves the gluon
+        # preshuffle path (added in #41217) permanently disabled.
+        return [64]
 
     @classmethod
     def get_supported_head_sizes(cls) -> list[int]:

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla_sparse.py
@@ -273,7 +273,7 @@ class ROCMAiterMLASparseBackend(AttentionBackend):
 
     @staticmethod
     def get_supported_kernel_block_sizes() -> list[int | MultipleOf]:
-        return [1, 64]
+        return [64]
 
     @staticmethod
     def get_name() -> str:


### PR DESCRIPTION
## Summary

`DeepseekV32IndexerBackend` and `ROCMAiterMLASparseBackend` both advertise `[1, 64]` from `get_supported_kernel_block_sizes()` (added by #41217). `select_common_block_size` picks the minimum, so the KV cache is always built with `block_size=1` on ROCm.

With `block_size=1` the gluon preshuffle path introduced in #41217 is never activated:
- `Preshuffle=block_size==64` evaluates to `False`
- Indexer Triton kernels use NHD layout instead of SHUFFLE
- Decode falls back to the slower `stage1+reduce_sum` two-kernel pipeline

**Fix:** return `[64]` only (matching CUDA behaviour). This makes `select_common_block_size` pick 64 and activates the full #41217 optimisation:
- `deepgemm_fp8_paged_mqa_logits` with `Preshuffle=True`, `KVBlockSize=64`
- SHUFFLE layout in `indexer_k_quant_and_cache` / `cp_gather_indexer`
- Pre-built `paged_kv_indptr` (ragged metadata built once in `build()`)

## Test plan

- DeepSeek-V3.2 TP4 bf16 with HIP graphs — GSM8K 5-shot flexible-extract **0.9371** (baseline 0.9424 ± 0.0065)
- Server benchmark: 32 requests, 0 failures, no MAF
- Depends on: #41760 (correctness fix for DSv3.2 TP4 HIP graphs) and #41810 (preshuffle logits +256 padding, required when block_size=64)
