### PR TITLE
[ROCm][DeepSeek] Enable V3.2 TP4 AITER MLA

### DIFF
--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -299,6 +299,15 @@ class DeepseekV2MoE(nn.Module):
         self.is_fusion_moe_shared_experts_enabled = (
             rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
         )
+        if (
+            self.is_rocm_aiter_moe_enabled
+            and self.gate.e_score_correction_bias is not None
+        ):
+            # AITER biased_grouped_topk requires the correction bias dtype to
+            # match the router logits. Keep DeepSeek's correction bias in fp32
+            # by requesting fp32 router logits for this routing path.
+            self.gate.set_out_dtype(torch.float32)
+
         if config.n_shared_experts is None or self.is_fusion_moe_shared_experts_enabled:
             self.shared_experts = None
         else:
@@ -338,22 +347,15 @@ class DeepseekV2MoE(nn.Module):
             n_shared_experts=config.n_shared_experts
             if self.is_fusion_moe_shared_experts_enabled
             else None,
+            router_logits_dtype=self.gate.out_dtype,
         )
 
-        # Pre-cast the bias to match the gate output dtype so the
-        # conversion is not repeated on every forward pass.  All
-        # downstream references (FusedMoE, router) share the same
-        # nn.Parameter object, so mutating .data propagates everywhere.
-        # Weight loading uses copy_(), which handles the dtype conversion.
-        # Only needed on ROCm where the aiter biased_grouped_topk kernel
-        # requires the bias dtype to match the gating output dtype.
         if (
             self.is_rocm_aiter_moe_enabled
             and self.gate.e_score_correction_bias is not None
         ):
-            gate_out_dtype = self.gate.out_dtype or self.gate.weight.dtype
             self.gate.e_score_correction_bias.data = (
-                self.gate.e_score_correction_bias.data.to(gate_out_dtype)
+                self.gate.e_score_correction_bias.data.to(self.gate.out_dtype)
             )
 
     def forward(self, hidden_states: torch.Tensor) -> torch.Tensor:

--- a/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
+++ b/vllm/v1/attention/backends/mla/rocm_aiter_mla.py
@@ -396,7 +396,7 @@ class AiterMLAHelper:
     """
 
     _AITER_MIN_MLA_HEADS: Final = 16
-    _AITER_UNSUPPORTED_HEADS = [32]
+    _AITER_UNSUPPORTED_HEADS: ClassVar[tuple[int, ...]] = ()
 
     @staticmethod
     def check_num_heads_validity(num_heads: int):


### PR DESCRIPTION
## Purpose

This PR enables the remaining DeepSeek-V3.2 TP4-specific pieces needed for ROCm AITER MLA serving.

DeepSeek-V3.2 TP4 reaches local MLA `num_heads=32`. Current ROCm AITER MLA rejects that head count through `_AITER_UNSUPPORTED_HEADS = [32]`, so the model can fail before reaching the HIP graph accuracy path with `unsupported head_num: 32`. This PR removes that stale block now that the AITER-side MLA kernel support for this shape exists.

This PR also preserves DeepSeek's fp32 MoE correction bias when `GateLinear.out_dtype` is unset. The previous fallback cast `e_score_correction_bias` to the gate weight dtype, which can lose routing precision for DeepSeek's biased grouped top-k path and contribute to wrong expert routing or incoherent output.

This is the DeepSeek-specific split from Frida Andersson's original draft PR #41760. The shared ROCm AITER HIP graph replay fixes were split separately into #41816. This PR intentionally does not duplicate those graph replay changes. The full DeepSeek-V3.2 TP4 HIP-graphs fix is expected to require this PR plus #41816, along with an AITER build that includes `num_heads=32` MLA kernel support.

Special thanks to Frida for the original investigation, patch direction, and DeepSeek-V3.2 validation. This PR is a minimal split of her DeepSeek-specific work so it can be reviewed independently from the cross-model graph replay fix.

Co-authored-by: Frida Andersson <fanderss@amd.com>

## Test Plan

ROCm runtime validation still needed:

- Launch DeepSeek-V3.2 TP4 with ROCm AITER MLA enabled.
- Confirm the model no longer fails with `unsupported head_num: 32`.
- Confirm the runtime image includes AITER MLA kernel support for local `num_heads=32`.
- Validate with HIP graphs enabled using this PR plus #41816.
- Run GSM8K 5-shot or equivalent accuracy validation.
- Run serving benchmark before/after if reviewers want DS TP4 perf data.


Suggested validation matrix:

| Configuration | Expected result |
|---|---|
| Baseline `main` | DSv3.2 TP4 AITER MLA can fail with `unsupported head_num: 32`. |
| This PR only | `num_heads=32` is no longer blocked, but full HIP graph accuracy may still require #41816. |
| This PR + #41816 | DSv3.2 TP4 HIP-graphs path should launch and produce coherent output. |

## Test Result

Runtime result from Frida's original full draft fix stack in #41760 showed DeepSeek-V3.2 TP4 GSM8K 5-shot recovered to:

| Filter | Metric | Value | Stderr |
|---|---|---:|---:|
| flexible-extract | exact_match | 0.9318 | ± 0.0069 |
| strict-match | exact_match | 0.9113 | ± 0.0078 |

Those numbers were produced with the full #41760 fix stack before splitting. After the split, complete runtime validation should be rerun with this PR plus #41816 applied together.

