### PR TITLE
[MM][Gemma4] Use video profiling hints in encoder budget

### DIFF
--- a/tests/models/multimodal/processing/test_gemma4.py
+++ b/tests/models/multimodal/processing/test_gemma4.py
@@ -111,6 +111,8 @@ def test_get_mm_max_tokens_per_item_respects_configured_max_soft_tokens(
         ({"video": {"num_frames": 0}}, 32 * (70 + 2 + 6)),
         ({"video": {"num_frames": -1}}, 32 * (70 + 2 + 6)),
         ({"video": {"num_frames": "32"}}, 32 * (70 + 2 + 6)),
+        ({"video": {"num_frames": True}}, 32 * (70 + 2 + 6)),
+        ({"video": {"num_frames": False}}, 32 * (70 + 2 + 6)),
     ],
 )
 @pytest.mark.parametrize("model_id", [GEMMA4_MODEL_ID])
@@ -145,6 +147,8 @@ def test_get_mm_max_tokens_per_item_respects_configured_video_num_frames(
         ({"video": {"num_frames": 0}}, 32),
         ({"video": {"num_frames": -1}}, 32),
         ({"video": {"num_frames": "32"}}, 32),
+        ({"video": {"num_frames": True}}, 32),
+        ({"video": {"num_frames": False}}, 32),
     ],
 )
 @pytest.mark.parametrize("model_id", [GEMMA4_MODEL_ID])

--- a/tests/models/multimodal/processing/test_gemma4.py
+++ b/tests/models/multimodal/processing/test_gemma4.py
@@ -102,6 +102,77 @@ def test_get_mm_max_tokens_per_item_respects_configured_max_soft_tokens(
     assert tokens["video"] == 32 * (70 + 2 + 6)
 
 
+@pytest.mark.parametrize(
+    ("media_io_kwargs", "expected_video_tokens"),
+    [
+        ({}, 32 * (70 + 2 + 6)),
+        ({"video": {"num_frames": 8}}, 8 * (70 + 2 + 6)),
+        ({"video": {"num_frames": 40}}, 40 * (70 + 2 + 6)),
+        ({"video": {"num_frames": 0}}, 32 * (70 + 2 + 6)),
+        ({"video": {"num_frames": -1}}, 32 * (70 + 2 + 6)),
+        ({"video": {"num_frames": "32"}}, 32 * (70 + 2 + 6)),
+    ],
+)
+@pytest.mark.parametrize("model_id", [GEMMA4_MODEL_ID])
+def test_get_mm_max_tokens_per_item_respects_configured_video_num_frames(
+    model_id: str,
+    media_io_kwargs: dict[str, object],
+    expected_video_tokens: int,
+):
+    ctx = build_model_context(
+        model_id,
+        model_config_kwargs={"media_io_kwargs": media_io_kwargs},
+        limit_mm_per_prompt={"video": 1},
+    )
+    processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config)
+
+    tokens = processor.info.get_mm_max_tokens_per_item(
+        seq_len=ctx.model_config.max_model_len,
+        mm_counts={"video": 1},
+    )
+
+    assert tokens is not None
+    assert tokens["image"] == 280
+    assert tokens["video"] == expected_video_tokens
+
+
+@pytest.mark.parametrize(
+    ("media_io_kwargs", "expected_num_frames"),
+    [
+        ({}, 32),
+        ({"video": {"num_frames": 8}}, 8),
+        ({"video": {"num_frames": 40}}, 40),
+        ({"video": {"num_frames": 0}}, 32),
+        ({"video": {"num_frames": -1}}, 32),
+        ({"video": {"num_frames": "32"}}, 32),
+    ],
+)
+@pytest.mark.parametrize("model_id", [GEMMA4_MODEL_ID])
+def test_dummy_video_respects_configured_video_num_frames(
+    model_id: str,
+    media_io_kwargs: dict[str, object],
+    expected_num_frames: int,
+):
+    ctx = build_model_context(
+        model_id,
+        model_config_kwargs={"media_io_kwargs": media_io_kwargs},
+        limit_mm_per_prompt={"video": 1},
+    )
+    processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config)
+
+    dummy_data = processor.dummy_inputs.get_dummy_mm_data(
+        seq_len=ctx.model_config.max_model_len,
+        mm_counts={"video": 1},
+        mm_options={},
+    )
+
+    assert "video" in dummy_data
+    assert len(dummy_data["video"]) == 1
+    video, metadata = dummy_data["video"][0]
+    assert video.shape[0] == expected_num_frames
+    assert metadata["total_num_frames"] == expected_num_frames
+
+
 @pytest.mark.parametrize("model_id", [GEMMA4_MODEL_ID])
 def test_get_prompt_updates_respects_nested_max_soft_tokens(model_id: str):
     ctx = build_model_context(

--- a/tests/models/multimodal/processing/test_gemma4.py
+++ b/tests/models/multimodal/processing/test_gemma4.py
@@ -103,28 +103,25 @@ def test_get_mm_max_tokens_per_item_respects_configured_max_soft_tokens(
 
 
 @pytest.mark.parametrize(
-    ("media_io_kwargs", "expected_video_tokens"),
+    ("limit_mm_per_prompt", "expected_video_tokens"),
     [
-        ({}, 32 * (70 + 2 + 6)),
-        ({"video": {"num_frames": 8}}, 8 * (70 + 2 + 6)),
-        ({"video": {"num_frames": 40}}, 40 * (70 + 2 + 6)),
-        ({"video": {"num_frames": 0}}, 32 * (70 + 2 + 6)),
-        ({"video": {"num_frames": -1}}, 32 * (70 + 2 + 6)),
-        ({"video": {"num_frames": "32"}}, 32 * (70 + 2 + 6)),
-        ({"video": {"num_frames": True}}, 32 * (70 + 2 + 6)),
-        ({"video": {"num_frames": False}}, 32 * (70 + 2 + 6)),
+        ({"video": 1}, 32 * (70 + 2 + 6)),
+        ({"video": {"count": 1}}, 32 * (70 + 2 + 6)),
+        ({"video": {"count": 1, "num_frames": 1}}, 1 * (70 + 2 + 6)),
+        ({"video": {"count": 1, "num_frames": 8}}, 8 * (70 + 2 + 6)),
+        ({"video": {"count": 1, "num_frames": 32}}, 32 * (70 + 2 + 6)),
+        ({"video": {"count": 1, "num_frames": 40}}, 32 * (70 + 2 + 6)),
     ],
 )
 @pytest.mark.parametrize("model_id", [GEMMA4_MODEL_ID])
 def test_get_mm_max_tokens_per_item_respects_configured_video_num_frames(
     model_id: str,
-    media_io_kwargs: dict[str, object],
+    limit_mm_per_prompt: dict[str, object],
     expected_video_tokens: int,
 ):
     ctx = build_model_context(
         model_id,
-        model_config_kwargs={"media_io_kwargs": media_io_kwargs},
-        limit_mm_per_prompt={"video": 1},
+        limit_mm_per_prompt=limit_mm_per_prompt,
     )
     processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config)
 
@@ -136,45 +133,6 @@ def test_get_mm_max_tokens_per_item_respects_configured_video_num_frames(
     assert tokens is not None
     assert tokens["image"] == 280
     assert tokens["video"] == expected_video_tokens
-
-
-@pytest.mark.parametrize(
-    ("media_io_kwargs", "expected_num_frames"),
-    [
-        ({}, 32),
-        ({"video": {"num_frames": 8}}, 8),
-        ({"video": {"num_frames": 40}}, 40),
-        ({"video": {"num_frames": 0}}, 32),
-        ({"video": {"num_frames": -1}}, 32),
-        ({"video": {"num_frames": "32"}}, 32),
-        ({"video": {"num_frames": True}}, 32),
-        ({"video": {"num_frames": False}}, 32),
-    ],
-)
-@pytest.mark.parametrize("model_id", [GEMMA4_MODEL_ID])
-def test_dummy_video_respects_configured_video_num_frames(
-    model_id: str,
-    media_io_kwargs: dict[str, object],
-    expected_num_frames: int,
-):
-    ctx = build_model_context(
-        model_id,
-        model_config_kwargs={"media_io_kwargs": media_io_kwargs},
-        limit_mm_per_prompt={"video": 1},
-    )
-    processor = MULTIMODAL_REGISTRY.create_processor(ctx.model_config)
-
-    dummy_data = processor.dummy_inputs.get_dummy_mm_data(
-        seq_len=ctx.model_config.max_model_len,
-        mm_counts={"video": 1},
-        mm_options={},
-    )
-
-    assert "video" in dummy_data
-    assert len(dummy_data["video"]) == 1
-    video, metadata = dummy_data["video"][0]
-    assert video.shape[0] == expected_num_frames
-    assert metadata["total_num_frames"] == expected_num_frames
 
 
 @pytest.mark.parametrize("model_id", [GEMMA4_MODEL_ID])

--- a/tests/models/multimodal/processing/test_gemma4.py
+++ b/tests/models/multimodal/processing/test_gemma4.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from collections.abc import Mapping
+
 import pytest
 from PIL import Image as PILImage
 
@@ -116,7 +118,7 @@ def test_get_mm_max_tokens_per_item_respects_configured_max_soft_tokens(
 @pytest.mark.parametrize("model_id", [GEMMA4_MODEL_ID])
 def test_get_mm_max_tokens_per_item_respects_configured_video_num_frames(
     model_id: str,
-    limit_mm_per_prompt: dict[str, object],
+    limit_mm_per_prompt: Mapping[str, int | Mapping[str, int]],
     expected_video_tokens: int,
 ):
     ctx = build_model_context(

--- a/tests/models/utils.py
+++ b/tests/models/utils.py
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import warnings
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
@@ -277,7 +277,7 @@ def build_model_context(
     dtype: ModelDType = "auto",
     model_config_kwargs: dict[str, Any] | None = None,
     mm_processor_kwargs: dict[str, Any] | None = None,
-    limit_mm_per_prompt: dict[str, int] | None = None,
+    limit_mm_per_prompt: Mapping[str, int | Mapping[str, int]] | None = None,
     mm_processor_cache_gb: int = 0,
 ):
     """Creates an InputProcessingContext for a given model.
@@ -300,7 +300,10 @@ def build_model_context(
     )
 
     model_config_kwargs = model_config_kwargs or {}
-    limit_mm_per_prompt = limit_mm_per_prompt or {}
+    limit_mm_per_prompt = {
+        modality: dict(limit) if isinstance(limit, Mapping) else limit
+        for modality, limit in (limit_mm_per_prompt or {}).items()
+    }
     model_config = ModelConfig(
         model_id,
         runner=runner,

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -228,6 +228,16 @@ class Gemma4ProcessingInfo(BaseProcessingInfo):
         limits["video"] = None
         return limits
 
+    def _get_configured_video_num_frames(self) -> int:
+        mm_config = self.ctx.model_config.get_multimodal_config()
+        video_kwargs = mm_config.media_io_kwargs.get("video", {})
+        if not isinstance(video_kwargs, Mapping):
+            video_kwargs = {}
+        num_frames = video_kwargs.get("num_frames", _VIDEO_MAX_FRAMES)
+        if not isinstance(num_frames, int) or num_frames <= 0:
+            return _VIDEO_MAX_FRAMES
+        return num_frames
+
     def get_mm_max_tokens_per_item(
         self, seq_len: int, mm_counts: Mapping[str, int]
     ) -> Mapping[str, int] | None:
@@ -246,7 +256,8 @@ class Gemma4ProcessingInfo(BaseProcessingInfo):
             processor = self.get_hf_processor()
             tokens["audio"] = processor.audio_seq_length
         # Video: each frame ≤ 70 soft tokens + boi + eoi + ~6 ts tokens.
-        tokens["video"] = _VIDEO_MAX_FRAMES * (_VIDEO_MAX_SOFT_TOKENS + 2 + 6)
+        num_frames = self._get_configured_video_num_frames()
+        tokens["video"] = num_frames * (_VIDEO_MAX_SOFT_TOKENS + 2 + 6)
         return tokens
 
     def get_data_parser(self) -> MultiModalDataParser:
@@ -457,7 +468,7 @@ class Gemma4DummyInputsBuilder(BaseDummyInputsBuilder[Gemma4ProcessingInfo]):
             data["video"] = self._get_dummy_videos(
                 width=img_width,
                 height=img_height,
-                num_frames=_VIDEO_MAX_FRAMES,
+                num_frames=self.info._get_configured_video_num_frames(),
                 num_videos=num_videos,
                 overrides=video_overrides,
             )

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -234,7 +234,7 @@ class Gemma4ProcessingInfo(BaseProcessingInfo):
         if not isinstance(video_kwargs, Mapping):
             video_kwargs = {}
         num_frames = video_kwargs.get("num_frames", _VIDEO_MAX_FRAMES)
-        if not isinstance(num_frames, int) or num_frames <= 0:
+        if type(num_frames) is not int or num_frames <= 0:
             return _VIDEO_MAX_FRAMES
         return num_frames
 

--- a/vllm/model_executor/models/gemma4_mm.py
+++ b/vllm/model_executor/models/gemma4_mm.py
@@ -228,16 +228,6 @@ class Gemma4ProcessingInfo(BaseProcessingInfo):
         limits["video"] = None
         return limits
 
-    def _get_configured_video_num_frames(self) -> int:
-        mm_config = self.ctx.model_config.get_multimodal_config()
-        video_kwargs = mm_config.media_io_kwargs.get("video", {})
-        if not isinstance(video_kwargs, Mapping):
-            video_kwargs = {}
-        num_frames = video_kwargs.get("num_frames", _VIDEO_MAX_FRAMES)
-        if type(num_frames) is not int or num_frames <= 0:
-            return _VIDEO_MAX_FRAMES
-        return num_frames
-
     def get_mm_max_tokens_per_item(
         self, seq_len: int, mm_counts: Mapping[str, int]
     ) -> Mapping[str, int] | None:
@@ -256,7 +246,14 @@ class Gemma4ProcessingInfo(BaseProcessingInfo):
             processor = self.get_hf_processor()
             tokens["audio"] = processor.audio_seq_length
         # Video: each frame ≤ 70 soft tokens + boi + eoi + ~6 ts tokens.
-        num_frames = self._get_configured_video_num_frames()
+        num_frames = _VIDEO_MAX_FRAMES
+        mm_config = self.ctx.model_config.get_multimodal_config()
+        video_opts = mm_config.limit_per_prompt.get("video")
+        if (
+            isinstance(video_opts, VideoDummyOptions)
+            and video_opts.num_frames is not None
+        ):
+            num_frames = min(num_frames, video_opts.num_frames)
         tokens["video"] = num_frames * (_VIDEO_MAX_SOFT_TOKENS + 2 + 6)
         return tokens
 
@@ -468,7 +465,7 @@ class Gemma4DummyInputsBuilder(BaseDummyInputsBuilder[Gemma4ProcessingInfo]):
             data["video"] = self._get_dummy_videos(
                 width=img_width,
                 height=img_height,
-                num_frames=self.info._get_configured_video_num_frames(),
+                num_frames=_VIDEO_MAX_FRAMES,
                 num_videos=num_videos,
                 overrides=video_overrides,
             )


### PR DESCRIPTION
## Purpose

Gemma4 video budget used fixed 32 frames in `get_mm_max_tokens_per_item()`.
But profiling dummy video already uses
`--limit-mm-per-prompt '{"video": {"num_frames": ...}}'`
through `VideoDummyOptions`.

I made the fast budget path read same profiling hint.
So budget and dummy profiling match now.

For values bigger than 32, stays capped at 32. Same as dummy path already does.

Runtime loading, media_io_kwargs, and image max_soft_tokens not changed.

Checked open PRs — no existing PR for Gemma4 video num_frames budget fix.

## Test Plan

```bash
pre-commit run ruff-format --files vllm/model_executor/models/gemma4_mm.py tests/models/multimodal/processing/test_gemma4.py
pre-commit run ruff-check --files vllm/model_executor/models/gemma4_mm.py tests/models/multimodal/processing/test_gemma4.py
.venv/bin/python -m pytest tests/models/multimodal/processing/test_gemma4.py -v
```

## Test Result

```text
ruff format / ruff check: passed
19 passed, 16 warnings
```

<details> <summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR
- [x] The test plan, such as providing test command.
- [x] The test results

</details>

AI assistance used (Codex, Claude, Gemini)