### PR TITLE
[Bugfix] Handle dead remote peer in NIXL connector 

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -2241,6 +2241,131 @@ def test_transfer_setup_failure_returns_finished(default_vllm_config, dist_init)
     assert request_id in done_recving
 
 
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker.NixlWrapper",
+    FailingNixlWrapper,
+)
+def test_transfer_state_failure_returns_finished_without_post_processing(
+    default_vllm_config, dist_init
+):
+    """Test that failed transfers return via get_finished without receive cleanup."""
+    vllm_config = create_vllm_config()
+
+    connector = NixlConnector(
+        vllm_config, KVConnectorRole.WORKER, make_kv_cache_config(block_size=16)
+    )
+    connector.connector_worker = FakeNixlConnectorWorker(
+        vllm_config, connector.engine_id, hand_shake_latency=0
+    )
+    worker = connector.connector_worker
+    worker.nixl_wrapper.fail_transfer_state = True
+
+    request_id = "test_transfer_state_fail"
+    metadata = NixlConnectorMetadata()
+    metadata.add_new_req_to_recv(
+        request_id=request_id,
+        local_block_ids=([7, 8, 9],),
+        kv_transfer_params={
+            "remote_block_ids": ([10, 11, 12],),
+            "remote_engine_id": FakeNixlConnectorWorker.REMOTE_ENGINE_ID,
+            "remote_request_id": f"prefill-{request_id}",
+            "remote_host": "localhost",
+            "remote_port": 1234,
+            "remote_tp_size": 1,
+        },
+    )
+    connector.bind_connector_metadata(metadata)
+
+    dummy_ctx = ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
+    )
+    connector.start_load_kv(dummy_ctx)
+
+    # Wait for handshake to complete and process ready_requests.
+    connector.bind_connector_metadata(NixlConnectorMetadata())
+    time.sleep(0.1)
+    connector.start_load_kv(dummy_ctx)
+
+    # Failed transfers have no valid KV to sync or post-process.
+    worker.use_host_buffer = True
+    with patch.object(
+        worker,
+        "sync_recved_kv_to_device",
+        side_effect=AssertionError("failed transfer should skip receive sync"),
+    ):
+        _, done_recving = connector.get_finished(finished_req_ids=set())
+
+    assert request_id in done_recving
+    assert connector.get_block_ids_with_load_errors() == {7, 8, 9}
+
+
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker.NixlWrapper",
+    FakeNixlWrapper,
+)
+def test_handshake_recv_timeout_returns_finished(default_vllm_config, dist_init):
+    """Dead remote peer (zmq.Again before add_remote_agent) must not raise from get_finished."""
+    from zmq.error import Again
+
+    class RecvTimeoutWorker(FakeNixlConnectorWorker):
+        """Simulates dead remote peer: raises zmq.Again before add_remote_agent()."""
+
+        def _nixl_handshake(
+            self,
+            host: str,
+            port: int,
+            remote_tp_size: int,
+            expected_engine_id: str,
+        ) -> dict[int, str]:
+            raise Again("Simulated recv timeout: remote peer dead")
+
+    vllm_config = create_vllm_config()
+
+    connector = NixlConnector(
+        vllm_config, KVConnectorRole.WORKER, make_kv_cache_config(block_size=16)
+    )
+    connector.connector_worker = RecvTimeoutWorker(
+        vllm_config, connector.engine_id, hand_shake_latency=0
+    )
+
+    request_id = "test_handshake_recv_timeout"
+    metadata = NixlConnectorMetadata()
+    metadata.add_new_req_to_recv(
+        request_id=request_id,
+        local_block_ids=([1, 2, 3],),
+        kv_transfer_params={
+            "remote_block_ids": ([4, 5, 6],),
+            "remote_engine_id": FakeNixlConnectorWorker.REMOTE_ENGINE_ID,
+            "remote_request_id": f"prefill-{request_id}",
+            "remote_host": "localhost",
+            "remote_port": 1234,
+            "remote_tp_size": 1,
+        },
+    )
+    connector.bind_connector_metadata(metadata)
+
+    dummy_ctx = ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
+    )
+    connector.start_load_kv(dummy_ctx)
+
+    # Wait for the handshake thread to raise Again.
+    time.sleep(0.3)
+
+    # Blocks must be marked invalid because no KV was received.
+    assert connector.get_block_ids_with_load_errors() == {1, 2, 3}
+
+    # get_finished() must return the request in done_recving without raising.
+    # Before the fix this raises KeyError: 'remote_engine' because
+    # the remote engine was never registered in TransferTopology.
+    _, done_recving = connector.get_finished(finished_req_ids=set())
+    assert request_id in done_recving
+
+
 @pytest.mark.parametrize(
     "mismatch_type,config_overrides,version_override,should_fail,enforce_handshake_compat",
     [

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -1644,9 +1644,19 @@ class NixlConnectorWorker:
         done_sending = self._get_new_notifs()
         done_recving = self._pop_done_transfers(self._recving_transfers)
 
-        # add requests that skipped transfer to done_recving
-        done_recving.update(self._failed_recv_reqs)
-        self._failed_recv_reqs.clear()
+        # Failed-recv requests (e.g. dead peer / zmq timeout) are included in
+        # done_recving so the scheduler can release them, but skip
+        # post-processing that requires successful KV transfer state. Snapshot
+        # the set because handshake callbacks can add failures concurrently.
+        # Transfer-state failures are consumed only after all active transfer
+        # handles for the request are gone.
+        failed_recving = {
+            req_id
+            for req_id in self._failed_recv_reqs
+            if req_id in done_recving or req_id not in self._recving_transfers
+        }
+        done_recving.update(failed_recving)
+        self._failed_recv_reqs.difference_update(failed_recving)
 
         if len(done_sending) > 0 or len(done_recving) > 0:
             logger.debug(
@@ -1664,6 +1674,11 @@ class NixlConnectorWorker:
             meta = self._recving_metadata.pop(req_id, None)
             assert meta is not None, f"{req_id} not found in recving_metadata list"
             assert meta.remote is not None
+
+            if req_id in failed_recving:
+                # No KV transferred; skip post-processing.
+                continue
+
             if self.use_host_buffer:
                 self.sync_recved_kv_to_device(req_id, meta)
 
@@ -1822,6 +1837,7 @@ class NixlConnectorWorker:
             self._invalid_block_ids.update(meta.local_block_ids[0])
         self.nixl_wrapper.release_xfer_handle(handle)
         self.xfer_stats.record_failed_transfer()
+        self._failed_recv_reqs.add(req_id)
 
     def start_load_kv(self, metadata: NixlConnectorMetadata):
         """


### PR DESCRIPTION
## Purpose

When a remote peer dies before the NIXL handshake completes, the handshake thread raises `zmq.Again` before `add_remote_agent()` registers the engine. The request is marked failed and its blocks invalidated, but `get_finished()` still tries to post-process the receive (host-buffer sync) and raises `KeyError` because the remote engine was never added to `TransferTopology`. This crashes the worker.

This PR makes `get_finished()` resilient to handshake / transfer failures so the scheduler can release the affected requests cleanly.

### Changes

- **`vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py`**
  - Snapshot `_failed_recv_reqs` in `get_finished()` and skip post-processing (host-buffer sync, etc.) for those requests — there is no valid KV state to act on.
  - Defer consuming transfer-state failures until all active transfer handles for the request are gone, so partial-failure cases don't drop the request prematurely.
  - On transfer-state failure, add the request id to `_failed_recv_reqs` so it is surfaced through `get_finished()`.

## Test Plan

Two new unit tests in `tests/v1/kv_connector/unit/test_nixl_connector.py`:

1. `test_transfer_state_failure_returns_finished_without_post_processing` — failed transfers are returned via `get_finished()` and `sync_recved_kv_to_device()` is **not** called (asserted via patched side effect). Blocks are marked invalid.
2. `test_handshake_recv_timeout_returns_finished` — simulates a dead remote peer by raising `zmq.Again` from `_nixl_handshake()` before `add_remote_agent()`. Verifies `get_finished()` does not raise `KeyError: 'remote_engine'`, blocks are invalidated, and the request is returned in `done_recving`.

```bash
.venv/bin/python -m pytest tests/v1/kv_connector/unit/test_nixl_connector.py \
  -k "test_transfer_state_failure_returns_finished_without_post_processing or test_handshake_recv_timeout_returns_finished" -v
```

## Test Result

Both new tests pass. Existing `test_nixl_connector.py` suite continues to pass.

AI assistance (Claude) was used to draft the fix and tests; the human submitter reviewed every line and ran the tests locally.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>
