### PR TITLE
Hoist DCP scratch tensors to top-level allocation

### DIFF
--- a/vllm/model_executor/layers/attention/mla_attention.py
+++ b/vllm/model_executor/layers/attention/mla_attention.py
@@ -272,9 +272,13 @@ from vllm.v1.attention.backends.utils import (
 from vllm.v1.attention.ops.common import (
     cp_all_gather_heads,
     cp_lse_ag_out_rs,
+    cp_lse_ag_out_rs_workspace_shapes,
     reserve_cp_collective_workspace,
 )
-from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
+from vllm.v1.attention.ops.dcp_alltoall import (
+    dcp_a2a_lse_reduce,
+    dcp_a2a_lse_reduce_workspace_shapes,
+)
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.attention.selector import get_attn_backend
 from vllm.v1.kv_cache_interface import (
@@ -486,14 +490,27 @@ class MLAAttention(nn.Module, AttentionLayerBase):
                 if speculative_config is not None
                 else 0
             )
+            max_tokens = scheduler_config.max_num_seqs * (1 + num_spec_tokens)
+            total_heads = self.num_heads * dcp_world_size
+            ws_shapes_fn = (
+                dcp_a2a_lse_reduce_workspace_shapes
+                if parallel_config.dcp_comm_backend == "a2a"
+                else cp_lse_ag_out_rs_workspace_shapes
+            )
             reserve_cp_collective_workspace(
-                max_num_tokens=scheduler_config.max_num_seqs * (1 + num_spec_tokens),
-                total_heads=self.num_heads * dcp_world_size,
+                max_num_tokens=max_tokens,
+                total_heads=total_heads,
                 gather_head_dim=self.kv_lora_rank + self.qk_rope_head_dim,
                 reduce_scatter_head_dim=self.kv_lora_rank,
                 cp_world_size=dcp_world_size,
                 dtype=model_config.dtype,
-                reserve_a2a=(parallel_config.dcp_comm_backend == "a2a"),
+                combine_workspace_shapes=ws_shapes_fn(
+                    num_tokens=max_tokens,
+                    total_heads=total_heads,
+                    head_dim=self.kv_lora_rank,
+                    cp_world_size=dcp_world_size,
+                    dtype=model_config.dtype,
+                ),
             )
         self.dcp_a2a = (
             dcp_world_size > 1

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -691,14 +691,27 @@ class FlashAttentionImpl(AttentionImpl):
         self._dcp_dtype: torch.dtype | None = None
         if vllm_config is not None and self.dcp_world_size > 1:
             self._dcp_dtype = vllm_config.model_config.dtype
+            max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+            total_heads = self.num_heads * self.dcp_world_size
             reserve_cp_collective_workspace(
-                max_num_tokens=vllm_config.scheduler_config.max_num_batched_tokens,
-                total_heads=self.num_heads * self.dcp_world_size,
+                max_num_tokens=max_tokens,
+                total_heads=total_heads,
                 gather_head_dim=self.head_size,
                 reduce_scatter_head_dim=self.head_size,
                 cp_world_size=self.dcp_world_size,
                 dtype=self._dcp_dtype,
-                combine_workspace_shapes_fn=self.dcp_combine_workspace_shapes,
+                reserve_a2a=dcp_a2a,
+            )
+            current_workspace_manager().get_simultaneous(
+                ((max_tokens, total_heads, self.head_size), self._dcp_dtype),
+                ((max_tokens, self.num_heads, self.head_size), self._dcp_dtype),
+                *self.dcp_combine_workspace_shapes(
+                    num_tokens=max_tokens,
+                    total_heads=total_heads,
+                    head_dim=self.head_size,
+                    cp_world_size=self.dcp_world_size,
+                    dtype=self._dcp_dtype,
+                ),
             )
 
     def forward(

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -698,7 +698,7 @@ class FlashAttentionImpl(AttentionImpl):
                 reduce_scatter_head_dim=self.head_size,
                 cp_world_size=self.dcp_world_size,
                 dtype=self._dcp_dtype,
-                reserve_a2a=dcp_a2a,
+                combine_workspace_shapes_fn=self.dcp_combine_workspace_shapes,
             )
 
     def forward(
@@ -935,10 +935,7 @@ class FlashAttentionImpl(AttentionImpl):
         dcp_context_out, dcp_query_out, *combine_workspaces = (
             current_workspace_manager().get_simultaneous(
                 ((n, total_heads, self.head_size), self._dcp_dtype),
-                (
-                    (query.shape[0], self.num_heads, self.head_size),
-                    self._dcp_dtype,
-                ),
+                ((n, self.num_heads, self.head_size), self._dcp_dtype),
                 *self.dcp_combine_workspace_shapes(
                     num_tokens=n,
                     total_heads=total_heads,

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -28,11 +28,14 @@ from vllm.v1.attention.backends.fa_utils import (
 from vllm.v1.attention.backends.utils import get_dcp_local_seq_lens
 from vllm.v1.attention.ops.common import (
     cp_all_gather_heads,
-    cp_collective_scratch_bytes,
     cp_lse_ag_out_rs,
+    cp_lse_ag_out_rs_workspace_shapes,
     reserve_cp_collective_workspace,
 )
-from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
+from vllm.v1.attention.ops.dcp_alltoall import (
+    dcp_a2a_lse_reduce,
+    dcp_a2a_lse_reduce_workspace_shapes,
+)
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.worker.workspace import current_workspace_manager
 
@@ -678,7 +681,12 @@ class FlashAttentionImpl(AttentionImpl):
             and vllm_config.parallel_config.decode_context_parallel_size > 1
             and vllm_config.parallel_config.dcp_comm_backend == "a2a"
         )
-        self.dcp_combine = dcp_a2a_lse_reduce if dcp_a2a else cp_lse_ag_out_rs
+        if dcp_a2a:
+            self.dcp_combine = dcp_a2a_lse_reduce
+            self.dcp_combine_workspace_shapes = dcp_a2a_lse_reduce_workspace_shapes
+        else:
+            self.dcp_combine = cp_lse_ag_out_rs
+            self.dcp_combine_workspace_shapes = cp_lse_ag_out_rs_workspace_shapes
 
         self._dcp_dtype: torch.dtype | None = None
         if vllm_config is not None and self.dcp_world_size > 1:
@@ -692,36 +700,6 @@ class FlashAttentionImpl(AttentionImpl):
                 dtype=self._dcp_dtype,
                 reserve_a2a=dcp_a2a,
             )
-
-    def _get_dcp_combine_workspace_bytes(self, num_tokens: int) -> int:
-        assert self._dcp_dtype is not None
-        ws, n, h, hd, d = (
-            self.dcp_world_size,
-            num_tokens,
-            self.num_heads,
-            self.head_size,
-            self._dcp_dtype,
-        )
-        if self.dcp_combine is dcp_a2a_lse_reduce:
-            t = (ws, n, h, hd)
-            return cp_collective_scratch_bytes(
-                (t, d),  # send_output
-                (t, d),  # recv_output
-                ((ws, n, h), torch.float32),  # send_lse
-                ((ws, n, h), torch.float32),  # recv_lse
-            )
-        return max(
-            # buffer for all_gather_into_tensor
-            # [ws * n, total_heads]
-            cp_collective_scratch_bytes(
-                ((ws * n, h * ws), torch.float32),
-            ),
-            # output buffer for reduce scatter
-            cp_collective_scratch_bytes(
-                (((h * ws), n, hd), d),
-                ((h, n, hd), d),
-            ),
-        )
 
     def forward(
         self,
@@ -952,15 +930,25 @@ class FlashAttentionImpl(AttentionImpl):
             list(self.sliding_window) if self.sliding_window is not None else None
         )
         n = query_across_dcp.shape[0]
-        dcp_context_out, dcp_combine_workspace = (
+        total_heads = self.num_heads * self.dcp_world_size
+
+        dcp_context_out, dcp_query_out, *combine_workspaces = (
             current_workspace_manager().get_simultaneous(
+                ((n, total_heads, self.head_size), self._dcp_dtype),
                 (
-                    (n, self.num_heads * self.dcp_world_size, self.head_size),
+                    (query.shape[0], self.num_heads, self.head_size),
                     self._dcp_dtype,
                 ),
-                ((self._get_dcp_combine_workspace_bytes(n),), torch.uint8),
+                *self.dcp_combine_workspace_shapes(
+                    num_tokens=n,
+                    total_heads=total_heads,
+                    head_dim=self.head_size,
+                    cp_world_size=self.dcp_world_size,
+                    dtype=self._dcp_dtype,
+                ),
             )
         )
+
         context_attn_out, context_lse = flash_attn_varlen_func(
             q=query_across_dcp,
             k=key_cache,
@@ -990,13 +978,9 @@ class FlashAttentionImpl(AttentionImpl):
             context_lse.transpose(0, 1),
             get_dcp_group(),
             return_lse=True,
-            scratch_workspace=dcp_combine_workspace,
+            workspaces=combine_workspaces,
         )
         context_lse_cor = context_lse_cor.transpose(0, 1).contiguous()
-
-        (dcp_query_out,) = current_workspace_manager().get_simultaneous(
-            ((query.shape[0], self.num_heads, self.head_size), self._dcp_dtype),
-        )
         query_attn_out, query_lse = flash_attn_varlen_func(
             q=query,
             k=key,

--- a/vllm/v1/attention/backends/flash_attn.py
+++ b/vllm/v1/attention/backends/flash_attn.py
@@ -700,12 +700,7 @@ class FlashAttentionImpl(AttentionImpl):
                 reduce_scatter_head_dim=self.head_size,
                 cp_world_size=self.dcp_world_size,
                 dtype=self._dcp_dtype,
-                reserve_a2a=dcp_a2a,
-            )
-            current_workspace_manager().get_simultaneous(
-                ((max_tokens, total_heads, self.head_size), self._dcp_dtype),
-                ((max_tokens, self.num_heads, self.head_size), self._dcp_dtype),
-                *self.dcp_combine_workspace_shapes(
+                combine_workspace_shapes=self.dcp_combine_workspace_shapes(
                     num_tokens=max_tokens,
                     total_heads=total_heads,
                     head_dim=self.head_size,

--- a/vllm/v1/attention/backends/flashinfer.py
+++ b/vllm/v1/attention/backends/flashinfer.py
@@ -68,9 +68,13 @@ from vllm.v1.attention.backends.utils import (
 from vllm.v1.attention.ops.common import (
     cp_all_gather_heads,
     cp_lse_ag_out_rs,
+    cp_lse_ag_out_rs_workspace_shapes,
     reserve_cp_collective_workspace,
 )
-from vllm.v1.attention.ops.dcp_alltoall import dcp_a2a_lse_reduce
+from vllm.v1.attention.ops.dcp_alltoall import (
+    dcp_a2a_lse_reduce,
+    dcp_a2a_lse_reduce_workspace_shapes,
+)
 from vllm.v1.attention.ops.merge_attn_states import merge_attn_states
 from vllm.v1.kv_cache_interface import (
     AttentionSpec,
@@ -1349,14 +1353,27 @@ class FlashInferImpl(AttentionImpl):
             self.dcp_combine = partial(cp_lse_ag_out_rs, is_lse_base_on_e=False)
 
         if vllm_config is not None and self.dcp_world_size > 1:
+            max_tokens = vllm_config.scheduler_config.max_num_batched_tokens
+            total_heads = self.num_heads * self.dcp_world_size
+            ws_shapes_fn = (
+                dcp_a2a_lse_reduce_workspace_shapes
+                if dcp_a2a
+                else cp_lse_ag_out_rs_workspace_shapes
+            )
             reserve_cp_collective_workspace(
-                max_num_tokens=vllm_config.scheduler_config.max_num_batched_tokens,
-                total_heads=self.num_heads * self.dcp_world_size,
+                max_num_tokens=max_tokens,
+                total_heads=total_heads,
                 gather_head_dim=self.head_size,
                 reduce_scatter_head_dim=self.head_size,
                 cp_world_size=self.dcp_world_size,
                 dtype=vllm_config.model_config.dtype,
-                reserve_a2a=dcp_a2a,
+                combine_workspace_shapes=ws_shapes_fn(
+                    num_tokens=max_tokens,
+                    total_heads=total_heads,
+                    head_dim=self.head_size,
+                    cp_world_size=self.dcp_world_size,
+                    dtype=vllm_config.model_config.dtype,
+                ),
             )
 
     def fused_output_quant_supported(self, quant_key: QuantKey):

--- a/vllm/v1/attention/ops/common.py
+++ b/vllm/v1/attention/ops/common.py
@@ -1,7 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from collections.abc import Callable
-
 import torch
 
 from vllm.distributed.parallel_state import GroupCoordinator
@@ -121,9 +119,7 @@ def reserve_cp_collective_workspace(
     cp_world_size: int,
     dtype: torch.dtype,
     lse_dtype: torch.dtype = torch.float32,
-    combine_workspace_shapes_fn: (
-        Callable[..., list[tuple[tuple[int, ...], torch.dtype]]] | None
-    ) = None,
+    reserve_a2a: bool = False,
 ) -> None:
     if (
         cp_world_size <= 1
@@ -135,29 +131,29 @@ def reserve_cp_collective_workspace(
     assert total_heads % cp_world_size == 0
     local_heads = total_heads // cp_world_size
     workspace_manager = current_workspace_manager()
-
-    # Reserve for cp_all_gather_heads (separate get_simultaneous call)
     workspace_manager.get_simultaneous(
         ((max_num_tokens * cp_world_size, local_heads, gather_head_dim), dtype),
     )
-
-    # Reserve for the single get_simultaneous in _forward_with_dcp:
-    # context FA output + query FA output + combine workspaces
-    combine_shapes: list[tuple[tuple[int, ...], torch.dtype]] = []
-    if combine_workspace_shapes_fn is not None:
-        combine_shapes = combine_workspace_shapes_fn(
-            num_tokens=max_num_tokens,
-            total_heads=total_heads,
-            head_dim=reduce_scatter_head_dim,
-            cp_world_size=cp_world_size,
-            dtype=dtype,
-            lse_dtype=lse_dtype,
-        )
     workspace_manager.get_simultaneous(
-        ((max_num_tokens, total_heads, gather_head_dim), dtype),
-        ((max_num_tokens, local_heads, reduce_scatter_head_dim), dtype),
-        *combine_shapes,
+        ((total_heads, max_num_tokens, reduce_scatter_head_dim), dtype),
+        ((local_heads, max_num_tokens, reduce_scatter_head_dim), dtype),
     )
+    workspace_manager.get_simultaneous(
+        ((cp_world_size * max_num_tokens, total_heads), lse_dtype),
+    )
+    if reserve_a2a:
+        workspace_manager.get_simultaneous(
+            (
+                (cp_world_size, max_num_tokens, local_heads, reduce_scatter_head_dim),
+                dtype,
+            ),
+            (
+                (cp_world_size, max_num_tokens, local_heads, reduce_scatter_head_dim),
+                dtype,
+            ),
+            ((cp_world_size, max_num_tokens, local_heads), lse_dtype),
+            ((cp_world_size, max_num_tokens, local_heads), lse_dtype),
+        )
 
 
 def cp_all_gather_heads(

--- a/vllm/v1/attention/ops/common.py
+++ b/vllm/v1/attention/ops/common.py
@@ -118,8 +118,7 @@ def reserve_cp_collective_workspace(
     reduce_scatter_head_dim: int,
     cp_world_size: int,
     dtype: torch.dtype,
-    lse_dtype: torch.dtype = torch.float32,
-    reserve_a2a: bool = False,
+    combine_workspace_shapes: (list[tuple[tuple[int, ...], torch.dtype]] | None) = None,
 ) -> None:
     if (
         cp_world_size <= 1
@@ -135,25 +134,10 @@ def reserve_cp_collective_workspace(
         ((max_num_tokens * cp_world_size, local_heads, gather_head_dim), dtype),
     )
     workspace_manager.get_simultaneous(
-        ((total_heads, max_num_tokens, reduce_scatter_head_dim), dtype),
-        ((local_heads, max_num_tokens, reduce_scatter_head_dim), dtype),
+        ((max_num_tokens, total_heads, gather_head_dim), dtype),
+        ((max_num_tokens, local_heads, reduce_scatter_head_dim), dtype),
+        *(combine_workspace_shapes or []),
     )
-    workspace_manager.get_simultaneous(
-        ((cp_world_size * max_num_tokens, total_heads), lse_dtype),
-    )
-    if reserve_a2a:
-        workspace_manager.get_simultaneous(
-            (
-                (cp_world_size, max_num_tokens, local_heads, reduce_scatter_head_dim),
-                dtype,
-            ),
-            (
-                (cp_world_size, max_num_tokens, local_heads, reduce_scatter_head_dim),
-                dtype,
-            ),
-            ((cp_world_size, max_num_tokens, local_heads), lse_dtype),
-            ((cp_world_size, max_num_tokens, local_heads), lse_dtype),
-        )
 
 
 def cp_all_gather_heads(

--- a/vllm/v1/attention/ops/common.py
+++ b/vllm/v1/attention/ops/common.py
@@ -152,9 +152,13 @@ def cp_all_gather_heads(
     batch_size, local_heads, head_dim = cp_attn_in.shape
     world_size = cp_group.world_size
 
-    (gathered,) = current_workspace_manager().get_simultaneous(
-        ((batch_size * world_size, local_heads, head_dim), cp_attn_in.dtype),
-    )
+    shape = (batch_size * world_size, local_heads, head_dim)
+    if is_workspace_manager_initialized():
+        (gathered,) = current_workspace_manager().get_simultaneous(
+            (shape, cp_attn_in.dtype),
+        )
+    else:
+        gathered = torch.empty(shape, dtype=cp_attn_in.dtype, device=cp_attn_in.device)
     cp_group.all_gather_into_tensor(gathered, cp_attn_in)
 
     out = torch.empty(
@@ -333,16 +337,20 @@ def cp_lse_ag_out_rs(
     cp_attn_lse: [ B, H ]
     """
     if workspaces is None:
-        workspaces = current_workspace_manager().get_simultaneous(
-            *cp_lse_ag_out_rs_workspace_shapes(
-                num_tokens=cp_attn_out.shape[0],
-                total_heads=cp_attn_out.shape[1],
-                head_dim=cp_attn_out.shape[2],
-                cp_world_size=cp_group.world_size,
-                dtype=cp_attn_out.dtype,
-                lse_dtype=cp_attn_lse.dtype,
-            )
+        shapes = cp_lse_ag_out_rs_workspace_shapes(
+            num_tokens=cp_attn_out.shape[0],
+            total_heads=cp_attn_out.shape[1],
+            head_dim=cp_attn_out.shape[2],
+            cp_world_size=cp_group.world_size,
+            dtype=cp_attn_out.dtype,
+            lse_dtype=cp_attn_lse.dtype,
         )
+        if is_workspace_manager_initialized():
+            workspaces = current_workspace_manager().get_simultaneous(*shapes)
+        else:
+            workspaces = [
+                torch.empty(s, dtype=d, device=cp_attn_out.device) for s, d in shapes
+            ]
     lse_buffer, rs_input, rs_output = workspaces
 
     out, lse = _cp_lse_common(

--- a/vllm/v1/attention/ops/common.py
+++ b/vllm/v1/attention/ops/common.py
@@ -1,5 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from collections.abc import Callable
+
 import torch
 
 from vllm.distributed.parallel_state import GroupCoordinator
@@ -119,9 +121,10 @@ def reserve_cp_collective_workspace(
     cp_world_size: int,
     dtype: torch.dtype,
     lse_dtype: torch.dtype = torch.float32,
-    reserve_a2a: bool = False,
+    combine_workspace_shapes_fn: (
+        Callable[..., list[tuple[tuple[int, ...], torch.dtype]]] | None
+    ) = None,
 ) -> None:
-    # reserve workspace from workspace manager, call before allgather/reduce_scatter
     if (
         cp_world_size <= 1
         or max_num_tokens <= 0
@@ -132,29 +135,29 @@ def reserve_cp_collective_workspace(
     assert total_heads % cp_world_size == 0
     local_heads = total_heads // cp_world_size
     workspace_manager = current_workspace_manager()
+
+    # Reserve for cp_all_gather_heads (separate get_simultaneous call)
     workspace_manager.get_simultaneous(
         ((max_num_tokens * cp_world_size, local_heads, gather_head_dim), dtype),
     )
-    workspace_manager.get_simultaneous(
-        ((total_heads, max_num_tokens, reduce_scatter_head_dim), dtype),
-        ((local_heads, max_num_tokens, reduce_scatter_head_dim), dtype),
-    )
-    workspace_manager.get_simultaneous(
-        ((cp_world_size * max_num_tokens, total_heads), lse_dtype),
-    )
-    if reserve_a2a:
-        workspace_manager.get_simultaneous(
-            (
-                (cp_world_size, max_num_tokens, local_heads, reduce_scatter_head_dim),
-                dtype,
-            ),
-            (
-                (cp_world_size, max_num_tokens, local_heads, reduce_scatter_head_dim),
-                dtype,
-            ),
-            ((cp_world_size, max_num_tokens, local_heads), lse_dtype),
-            ((cp_world_size, max_num_tokens, local_heads), lse_dtype),
+
+    # Reserve for the single get_simultaneous in _forward_with_dcp:
+    # context FA output + query FA output + combine workspaces
+    combine_shapes: list[tuple[tuple[int, ...], torch.dtype]] = []
+    if combine_workspace_shapes_fn is not None:
+        combine_shapes = combine_workspace_shapes_fn(
+            num_tokens=max_num_tokens,
+            total_heads=total_heads,
+            head_dim=reduce_scatter_head_dim,
+            cp_world_size=cp_world_size,
+            dtype=dtype,
+            lse_dtype=lse_dtype,
         )
+    workspace_manager.get_simultaneous(
+        ((max_num_tokens, total_heads, gather_head_dim), dtype),
+        ((max_num_tokens, local_heads, reduce_scatter_head_dim), dtype),
+        *combine_shapes,
+    )
 
 
 def cp_all_gather_heads(

--- a/vllm/v1/attention/ops/common.py
+++ b/vllm/v1/attention/ops/common.py
@@ -1,12 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-from math import prod
-
 import torch
 
 from vllm.distributed.parallel_state import GroupCoordinator
 from vllm.triton_utils import tl, triton
-from vllm.utils.math_utils import round_up
 from vllm.v1.worker.workspace import (
     current_workspace_manager,
     is_workspace_manager_initialized,
@@ -114,47 +111,6 @@ class CPTritonContext:
             self.inner_kernel[grid](*regular_args)
 
 
-def cp_collective_scratch_bytes(
-    *shapes_and_dtypes: tuple[tuple[int, ...], torch.dtype],
-) -> int:
-    return sum(
-        round_up(prod(shape) * dtype.itemsize, 256)
-        for shape, dtype in shapes_and_dtypes
-    )
-
-
-def get_cp_collective_scratch_tensors(
-    device: torch.device,
-    *shapes_and_dtypes: tuple[tuple[int, ...], torch.dtype],
-    scratch_workspace: torch.Tensor | None = None,
-) -> list[torch.Tensor]:
-    if scratch_workspace is not None:
-        offset = 0
-        tensors: list[torch.Tensor] = []
-        for shape, dtype in shapes_and_dtypes:
-            actual_bytes = prod(shape) * dtype.itemsize
-            aligned_bytes = round_up(actual_bytes, 256)
-            tensors.append(
-                scratch_workspace[offset : offset + actual_bytes]
-                .view(dtype)
-                .reshape(shape)
-            )
-            offset += aligned_bytes
-        return tensors
-    # get workspace from workspace manager
-    if is_workspace_manager_initialized():
-        workspace_manager = current_workspace_manager()
-        try:
-            return workspace_manager.get_simultaneous(*shapes_and_dtypes)
-        except AssertionError:
-            if not workspace_manager.is_locked():
-                raise
-    return [
-        torch.empty(shape, dtype=dtype, device=device)
-        for shape, dtype in shapes_and_dtypes
-    ]
-
-
 def reserve_cp_collective_workspace(
     max_num_tokens: int,
     total_heads: int,
@@ -213,8 +169,7 @@ def cp_all_gather_heads(
     batch_size, local_heads, head_dim = cp_attn_in.shape
     world_size = cp_group.world_size
 
-    (gathered,) = get_cp_collective_scratch_tensors(
-        cp_attn_in.device,
+    (gathered,) = current_workspace_manager().get_simultaneous(
         ((batch_size * world_size, local_heads, head_dim), cp_attn_in.dtype),
     )
     cp_group.all_gather_into_tensor(gathered, cp_attn_in)
@@ -233,7 +188,8 @@ def cp_all_gather_heads(
 def cp_reduce_scatter_heads(
     cp_attn_out: torch.Tensor,
     cp_group: GroupCoordinator,
-    scratch_workspace: torch.Tensor | None = None,
+    rs_input: torch.Tensor,
+    rs_output: torch.Tensor,
 ) -> torch.Tensor:
     """Reduce-scatter a [B, H_total, D] tensor across ranks on the head axis."""
     if cp_group.world_size == 1:
@@ -244,12 +200,6 @@ def cp_reduce_scatter_heads(
     assert total_heads % world_size == 0
     local_heads = total_heads // world_size
 
-    rs_input, rs_output = get_cp_collective_scratch_tensors(
-        cp_attn_out.device,
-        ((total_heads, batch_size, head_dim), cp_attn_out.dtype),
-        ((local_heads, batch_size, head_dim), cp_attn_out.dtype),
-        scratch_workspace=scratch_workspace,
-    )
     rs_input.copy_(cp_attn_out.movedim(0, 1))
     cp_group.reduce_scatter_tensor(rs_output, rs_input)
 
@@ -339,7 +289,7 @@ def _cp_lse_common(
     cp_group: GroupCoordinator,
     ctx: CPTritonContext | None = None,
     is_lse_base_on_e=True,
-    scratch_workspace: torch.Tensor | None = None,
+    lse_buffer: torch.Tensor | None = None,
 ):
     """
     cp_attn_out: [ B, H, D ]
@@ -352,14 +302,14 @@ def _cp_lse_common(
         ctx = CPTritonContext()
 
     cp_attn_lse = cp_attn_lse.contiguous()
-    batch_size, num_heads = cp_attn_lse.shape
-    (lses_flat,) = get_cp_collective_scratch_tensors(
-        cp_attn_lse.device,
-        ((cp_group.world_size * batch_size, num_heads), cp_attn_lse.dtype),
-        scratch_workspace=scratch_workspace,
-    )
-    cp_group.all_gather_into_tensor(lses_flat, cp_attn_lse)
-    lses = lses_flat.view((cp_group.world_size,) + cp_attn_lse.shape)
+    if lse_buffer is None:
+        lse_buffer = torch.empty(
+            (cp_group.world_size * cp_attn_lse.shape[0], cp_attn_lse.shape[1]),
+            dtype=cp_attn_lse.dtype,
+            device=cp_attn_lse.device,
+        )
+    cp_group.all_gather_into_tensor(lse_buffer, cp_attn_lse)
+    lses = lse_buffer.view((cp_group.world_size,) + cp_attn_lse.shape)
     out, lse = correct_attn_out(
         cp_attn_out,
         lses,
@@ -370,6 +320,22 @@ def _cp_lse_common(
     return out, lse
 
 
+def cp_lse_ag_out_rs_workspace_shapes(
+    num_tokens: int,
+    total_heads: int,
+    head_dim: int,
+    cp_world_size: int,
+    dtype: torch.dtype,
+    lse_dtype: torch.dtype = torch.float32,
+) -> list[tuple[tuple[int, ...], torch.dtype]]:
+    local_heads = total_heads // cp_world_size
+    return [
+        ((cp_world_size * num_tokens, total_heads), lse_dtype),
+        ((total_heads, num_tokens, head_dim), dtype),
+        ((local_heads, num_tokens, head_dim), dtype),
+    ]
+
+
 def cp_lse_ag_out_rs(
     cp_attn_out: torch.Tensor,
     cp_attn_lse: torch.Tensor,
@@ -377,21 +343,34 @@ def cp_lse_ag_out_rs(
     ctx: CPTritonContext | None = None,
     return_lse: bool = False,
     is_lse_base_on_e=True,
-    scratch_workspace: torch.Tensor | None = None,
+    workspaces: list[torch.Tensor] | None = None,
 ):
     """
     cp_attn_out: [ B, H, D ]
     cp_attn_lse: [ B, H ]
     """
+    if workspaces is None:
+        workspaces = current_workspace_manager().get_simultaneous(
+            *cp_lse_ag_out_rs_workspace_shapes(
+                num_tokens=cp_attn_out.shape[0],
+                total_heads=cp_attn_out.shape[1],
+                head_dim=cp_attn_out.shape[2],
+                cp_world_size=cp_group.world_size,
+                dtype=cp_attn_out.dtype,
+                lse_dtype=cp_attn_lse.dtype,
+            )
+        )
+    lse_buffer, rs_input, rs_output = workspaces
+
     out, lse = _cp_lse_common(
         cp_attn_out,
         cp_attn_lse,
         cp_group,
         ctx=ctx,
         is_lse_base_on_e=is_lse_base_on_e,
-        scratch_workspace=scratch_workspace,
+        lse_buffer=lse_buffer,
     )
-    out = cp_reduce_scatter_heads(out, cp_group, scratch_workspace=scratch_workspace)
+    out = cp_reduce_scatter_heads(out, cp_group, rs_input=rs_input, rs_output=rs_output)
 
     if return_lse:
         cp_num_heads = lse.shape[1] // cp_group.world_size

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -26,7 +26,7 @@ import torch
 import torch.distributed as dist
 
 from vllm.triton_utils import tl, triton
-from vllm.v1.attention.ops.common import get_cp_collective_scratch_tensors
+from vllm.v1.worker.workspace import current_workspace_manager
 
 if TYPE_CHECKING:
     from vllm.distributed.parallel_state import GroupCoordinator
@@ -107,21 +107,6 @@ def _dcp_a2a_lse_pack_dim(output_dtype: torch.dtype) -> int:
     if bits == 32:
         return 1
     raise ValueError(f"Cannot pack fp32 LSE into output dtype {output_dtype}.")
-
-
-def _dcp_a2a_send_recv_buffers(
-    shape: tuple[int, ...],
-    device: torch.device,
-    dtype: torch.dtype,
-    scratch_workspace: torch.Tensor | None = None,
-) -> tuple[torch.Tensor, torch.Tensor]:
-    send_buffer, recv_buffer = get_cp_collective_scratch_tensors(
-        device,
-        (shape, dtype),
-        (shape, dtype),
-        scratch_workspace=scratch_workspace,
-    )
-    return send_buffer, recv_buffer
 
 
 @triton.jit
@@ -384,6 +369,23 @@ def _dcp_a2a_unpack_combine(
     return out
 
 
+def dcp_a2a_lse_reduce_workspace_shapes(
+    num_tokens: int,
+    total_heads: int,
+    head_dim: int,
+    cp_world_size: int,
+    dtype: torch.dtype,
+    lse_dtype: torch.dtype = torch.float32,
+) -> list[tuple[tuple[int, ...], torch.dtype]]:
+    local_heads = total_heads // cp_world_size
+    lse_pack_dim = _dcp_a2a_lse_pack_dim(dtype)
+    buf_shape = (cp_world_size, num_tokens, local_heads, head_dim + lse_pack_dim)
+    return [
+        (buf_shape, dtype),
+        (buf_shape, dtype),
+    ]
+
+
 def dcp_a2a_lse_reduce(
     cp_attn_out: torch.Tensor,
     cp_attn_lse: torch.Tensor,
@@ -391,7 +393,7 @@ def dcp_a2a_lse_reduce(
     ctx: CPTritonContext | None = None,
     return_lse: bool = False,
     is_lse_base_on_e: bool = True,
-    scratch_workspace: torch.Tensor | None = None,
+    workspaces: list[torch.Tensor] | None = None,
 ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
     """
     Combine partial attention outputs across DCP ranks using All-to-All.
@@ -406,6 +408,8 @@ def dcp_a2a_lse_reduce(
         ctx: CPTritonContext (unused, for signature compatibility)
         return_lse: If True, also return the combined global LSE
         is_lse_base_on_e: If True, LSE is base e; if False, base 2
+        workspaces: Pre-allocated [send_buffer, recv_buffer] from
+            dcp_a2a_lse_reduce_workspace_shapes.
 
     Returns:
         Combined output [B, H/N, D] (head-scattered)
@@ -424,12 +428,17 @@ def dcp_a2a_lse_reduce(
     H_per_rank = H // world_size
     lse_pack_dim = _dcp_a2a_lse_pack_dim(cp_attn_out.dtype)
 
-    send_buffer, recv_buffer = _dcp_a2a_send_recv_buffers(
-        (world_size, B, H_per_rank, D + lse_pack_dim),
-        device=cp_attn_out.device,
-        dtype=cp_attn_out.dtype,
-        scratch_workspace=scratch_workspace,
-    )
+    if workspaces is None:
+        workspaces = current_workspace_manager().get_simultaneous(
+            *dcp_a2a_lse_reduce_workspace_shapes(
+                num_tokens=B,
+                total_heads=H,
+                head_dim=D,
+                cp_world_size=world_size,
+                dtype=cp_attn_out.dtype,
+            )
+        )
+    send_buffer, recv_buffer = workspaces
 
     _dcp_a2a_pack_send(
         cp_attn_out,

--- a/vllm/v1/attention/ops/dcp_alltoall.py
+++ b/vllm/v1/attention/ops/dcp_alltoall.py
@@ -26,7 +26,10 @@ import torch
 import torch.distributed as dist
 
 from vllm.triton_utils import tl, triton
-from vllm.v1.worker.workspace import current_workspace_manager
+from vllm.v1.worker.workspace import (
+    current_workspace_manager,
+    is_workspace_manager_initialized,
+)
 
 if TYPE_CHECKING:
     from vllm.distributed.parallel_state import GroupCoordinator
@@ -429,15 +432,19 @@ def dcp_a2a_lse_reduce(
     lse_pack_dim = _dcp_a2a_lse_pack_dim(cp_attn_out.dtype)
 
     if workspaces is None:
-        workspaces = current_workspace_manager().get_simultaneous(
-            *dcp_a2a_lse_reduce_workspace_shapes(
-                num_tokens=B,
-                total_heads=H,
-                head_dim=D,
-                cp_world_size=world_size,
-                dtype=cp_attn_out.dtype,
-            )
+        shapes = dcp_a2a_lse_reduce_workspace_shapes(
+            num_tokens=B,
+            total_heads=H,
+            head_dim=D,
+            cp_world_size=world_size,
+            dtype=cp_attn_out.dtype,
         )
+        if is_workspace_manager_initialized():
+            workspaces = current_workspace_manager().get_simultaneous(*shapes)
+        else:
+            workspaces = [
+                torch.empty(s, dtype=d, device=cp_attn_out.device) for s, d in shapes
+            ]
     send_buffer, recv_buffer = workspaces
 
     _dcp_a2a_pack_send(


### PR DESCRIPTION
## Summary
- Replace the `scratch_workspace` byte-blob pattern with explicit named tensor allocation in `_forward_with_dcp`
- Each combine variant (AG+RS, A2A) now defines a `workspace_shapes()` function returning `(shape, dtype)` tuples, keeping layout knowledge co-located with the combine logic
- Removes `get_cp_collective_scratch_tensors`, `cp_collective_scratch_bytes`, `_get_dcp_combine_workspace_bytes`, `_dcp_a2a_send_recv_buffers`, and the `scratch_workspace` parameter threading

## Test plan
- [ ] Verify existing DCP tests pass
- [ ] Verify AG+RS and A2A combine paths work end-to-end with multi-GPU

🤖 Generated with [Claude Code](https://claude.com/claude-code)