### PR TITLE
[Bugfix] Fix KeyError in NixlConnector when handshake fails

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -2603,3 +2603,76 @@ def test_handshake_decode_errors(default_vllm_config, dist_init, error_scenario)
                 f"got {notif!r} (expected {expected_notif!r}, "
                 f"buggy form would be {bad_notif!r})"
             )
+
+
+@patch(
+    "vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker.NixlWrapper",
+    FakeNixlWrapper,
+)
+def test_handshake_zmq_failure_no_keyerror(default_vllm_config, dist_init):
+    """Regression test: KeyError when handshake fails before _block_size is set.
+
+    In production, when _nixl_handshake fails at the zmq level (e.g. timeout),
+    _block_size[engine_id] is never populated. The request ends up in
+    _failed_recv_reqs and then get_finished() must not crash with KeyError
+    when trying to call block_size_ratio_from_engine_id().
+
+    This differs from test_handshake_failure_returns_finished which fails
+    inside add_remote_agent (after _block_size is already set).
+    """
+    from zmq.error import Again
+
+    vllm_config = create_vllm_config()
+
+    connector = NixlConnector(vllm_config, KVConnectorRole.WORKER)
+    connector.connector_worker = FakeNixlConnectorWorker(
+        vllm_config, connector.engine_id, hand_shake_latency=0.0
+    )
+
+    # Patch _nixl_handshake to raise zmq.Again (simulating sock.recv timeout)
+    # This ensures _block_size[engine_id] is NEVER populated.
+    def failing_handshake(*args, **kwargs):
+        raise Again("Resource temporarily unavailable")
+
+    connector.connector_worker._nixl_handshake = failing_handshake
+
+    request_id = "test_zmq_timeout"
+    metadata = NixlConnectorMetadata()
+    metadata.add_new_req_to_recv(
+        request_id=request_id,
+        local_block_ids=[10, 11, 12],
+        kv_transfer_params={
+            "remote_block_ids": [20, 21, 22],
+            "remote_engine_id": FakeNixlConnectorWorker.REMOTE_ENGINE_ID,
+            "remote_request_id": f"prefill-{request_id}",
+            "remote_host": "localhost",
+            "remote_port": 1234,
+            "remote_tp_size": 1,
+        },
+    )
+    connector.bind_connector_metadata(metadata)
+
+    dummy_ctx = ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        virtual_engine=0,
+        slot_mapping={},
+    )
+    connector.start_load_kv(dummy_ctx)
+
+    # Wait for handshake to fail
+    time.sleep(0.2)
+
+    # Verify _block_size was NOT populated (reproducing the real bug condition)
+    worker = connector.connector_worker
+    assert FakeNixlConnectorWorker.REMOTE_ENGINE_ID not in worker._block_size
+
+    # This must NOT raise KeyError
+    _, done_recving = connector.get_finished(finished_req_ids=set())
+    assert request_id in done_recving
+
+    # Blocks should be marked invalid
+    invalid_blocks = connector.get_block_ids_with_load_errors()
+    assert invalid_blocks == {10, 11, 12}
+
+

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -1644,9 +1644,10 @@ class NixlConnectorWorker:
         done_sending = self._get_new_notifs()
         done_recving = self._pop_done_transfers(self._recving_transfers)
 
-        # add requests that skipped transfer to done_recving
-        done_recving.update(self._failed_recv_reqs)
-        self._failed_recv_reqs.clear()
+        # Atomic swap to avoid race with background handshake thread
+        failed_req_ids = self._failed_recv_reqs
+        self._failed_recv_reqs = set()
+        done_recving.update(failed_req_ids)
 
         if len(done_sending) > 0 or len(done_recving) > 0:
             logger.debug(
@@ -1664,6 +1665,11 @@ class NixlConnectorWorker:
             meta = self._recving_metadata.pop(req_id, None)
             assert meta is not None, f"{req_id} not found in recving_metadata list"
             assert meta.remote is not None
+
+            # Skip post-processing for failed requests (no data transferred)
+            if req_id in failed_req_ids:
+                continue
+
             if self.use_host_buffer:
                 self.sync_recved_kv_to_device(req_id, meta)
 


### PR DESCRIPTION
We saw errors like the following on multiple decode workers, when a prefill worker crashed due to an unrelated reason:
```
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263] NIXL transfer failure: handshake_setup_failed | Context: {'failure_type': 'handshake_setup_failed', 'request_id': None, 'engine_id': 'c92321f8-5be9-4722-9cc1-648335f9c072', 'remote_engine_id': 'b6b76ae8-5a6c-4104-bb1d-4966a7cb9e8c'}
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263] Traceback (most recent call last):
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py", line 1261, in done_callback
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]     self._remote_agents[eid] = f.result()
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]                                ^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 449, in result
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]     return self.__get_result()
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]            ^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]     raise self._exception
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]   File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]     result = self.fn(*self.args, **self.kwargs)
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py", line 1067, in _nixl_handshake
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]     handshake_bytes = sock.recv()
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]                       ^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]   File "_zmq.py", line 1147, in zmq.backend.cython._zmq.Socket.recv
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]   File "_zmq.py", line 1182, in zmq.backend.cython._zmq.Socket.recv
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]   File "_zmq.py", line 1342, in zmq.backend.cython._zmq._recv_copy
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]   File "_zmq.py", line 1337, in zmq.backend.cython._zmq._recv_copy
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263]   File "_zmq.py", line 176, in zmq.backend.cython._zmq._check_rc
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1263] zmq.error.Again: Resource temporarily unavailable
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280] NIXL transfer failure: handshake_failed | Context: {'failure_type': 'handshake_failed', 'request_id': '6340b78f-f53a-4ca2-9a05-836ead4a31fc-8d876717', 'engine_id': 'c92321f8-5be9-4722-9cc1-648335f9c072', 'remote_engine_id': 'b6b76ae8-5a6c-4104-bb1d-4966a7cb9e8c', 'remote_request_id': '6340b78f-f53a-4ca2-9a05-836ead4a31fc-93fbc251', 'remote_host': '21.0.1.85', 'remote_port': 5600, 'num_local_blocks': 24, 'num_remote_blocks': 62, 'local_block_ids_sample': [21177, 21178, 21179, 34148, 34147, 34146, 34145, 34144, 34143, 34142]}
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280] Traceback (most recent call last):
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py", line 1276, in request_ready
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]     f.result()
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 449, in result
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]     return self.__get_result()
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]            ^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]     raise self._exception
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py", line 1261, in done_callback
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]     self._remote_agents[eid] = f.result()
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]                                ^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 449, in result
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]     return self.__get_result()
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]            ^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]   File "/usr/lib/python3.12/concurrent/futures/_base.py", line 401, in __get_result
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]     raise self._exception
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]   File "/usr/lib/python3.12/concurrent/futures/thread.py", line 58, in run
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]     result = self.fn(*self.args, **self.kwargs)
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py", line 1067, in _nixl_handshake
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]     handshake_bytes = sock.recv()
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]                       ^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]   File "_zmq.py", line 1147, in zmq.backend.cython._zmq.Socket.recv
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]   File "_zmq.py", line 1182, in zmq.backend.cython._zmq.Socket.recv
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]   File "_zmq.py", line 1342, in zmq.backend.cython._zmq._recv_copy
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]   File "_zmq.py", line 1337, in zmq.backend.cython._zmq._recv_copy
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280]   File "_zmq.py", line 176, in zmq.backend.cython._zmq._check_rc
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [nixl_connector.py:1280] zmq.error.Again: Resource temporarily unavailable
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863] WorkerProc hit an exception.
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863] Traceback (most recent call last):
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/v1/executor/multiproc_executor.py", line 858, in worker_busy_loop
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     output = func(*args, **kwargs)
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]              ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/v1/worker/worker_base.py", line 361, in execute_model
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     return self.worker.execute_model(scheduler_output)
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     return func(*args, **kwargs)
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/v1/worker/gpu_worker.py", line 652, in execute_model
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     output = self.model_runner.execute_model(
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     return func(*args, **kwargs)
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/v1/worker/gpu_model_runner.py", line 3523, in execute_model
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     with (
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/usr/lib/python3.12/contextlib.py", line 144, in __exit__
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     next(self.gen)
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/v1/worker/kv_connector_model_runner_mixin.py", line 104, in _get_kv_connector_output
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     kv_connector.get_finished(scheduler_output.finished_req_ids)
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py", line 436, in get_finished
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     return self.connector_worker.get_finished()
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py", line 1952, in get_finished
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     block_size_ratio = self.kv_topo.block_size_ratio_from_engine_id(
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_connector/utils.py", line 442, in block_size_ratio_from_engine_id
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     remote_block_size = self.remote_block_size[remote_engine_id]
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]                         ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863] KeyError: 'b6b76ae8-5a6c-4104-bb1d-4966a7cb9e8c'
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863] Traceback (most recent call last):
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/v1/executor/multiproc_executor.py", line 858, in worker_busy_loop
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     output = func(*args, **kwargs)
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]              ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/v1/worker/worker_base.py", line 361, in execute_model
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     return self.worker.execute_model(scheduler_output)
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     return func(*args, **kwargs)
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/v1/worker/gpu_worker.py", line 652, in execute_model
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     output = self.model_runner.execute_model(
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/torch/utils/_contextlib.py", line 120, in decorate_context
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     return func(*args, **kwargs)
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]            ^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/v1/worker/gpu_model_runner.py", line 3523, in execute_model
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     with (
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/usr/lib/python3.12/contextlib.py", line 144, in __exit__
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     next(self.gen)
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/v1/worker/kv_connector_model_runner_mixin.py", line 104, in _get_kv_connector_output
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     kv_connector.get_finished(scheduler_output.finished_req_ids)
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py", line 436, in get_finished
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     return self.connector_worker.get_finished()
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_connector/v1/nixl_connector.py", line 1952, in get_finished
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     block_size_ratio = self.kv_topo.block_size_ratio_from_engine_id(
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]   File "/opt/dynamo/venv/lib/python3.12/site-packages/vllm/distributed/kv_transfer/kv_connector/utils.py", line 442, in block_size_ratio_from_engine_id
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]     remote_block_size = self.remote_block_size[remote_engine_id]
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863]                         ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863] KeyError: 'b6b76ae8-5a6c-4104-bb1d-4966a7cb9e8c'
(Worker_TP0_EP0 pid=865) ERROR 05-01 15:00:23 [multiproc_executor.py:863] 
```

Which caused decode worker to crash.  
It looks like `remote_block_size[id]` isn't populated for failed reqs, so the fetch at the end fails with a key error that causes the crash. This PR fixes the crash by skipping post-processing for failed reqs.

---
This PR includes AI-assisted code (Claude).