### PR TITLE
Allow video_files in custom_mm

### DIFF
--- a/tests/benchmarks/test_custom_mm_dataset.py
+++ b/tests/benchmarks/test_custom_mm_dataset.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for CustomMMDataset."""
+
+import json
+from pathlib import Path
+
+import pytest
+from transformers import AutoTokenizer, PreTrainedTokenizerBase
+
+from vllm.benchmarks.datasets import CustomMMDataset
+
+
+@pytest.fixture(scope="session")
+def tokenizer() -> PreTrainedTokenizerBase:
+    return AutoTokenizer.from_pretrained("gpt2")
+
+
+def _dataset(tmp_path: Path, rows: list[dict]) -> CustomMMDataset:
+    jsonl = tmp_path / "data.jsonl"
+    jsonl.write_text("\n".join(json.dumps(r) for r in rows))
+    return CustomMMDataset(dataset_path=str(jsonl), random_seed=0)
+
+
+@pytest.mark.benchmark
+def test_video_files_produces_video_url(
+    tokenizer: PreTrainedTokenizerBase, tmp_path: Path
+):
+    vid = tmp_path / "clip.mp4"
+    vid.write_bytes(b"")
+    ds = _dataset(tmp_path, [{"prompt": "p", "video_files": [str(vid)]}])
+    [sample] = ds.sample(tokenizer=tokenizer, num_requests=1, output_len=32)
+    assert sample.multi_modal_data["type"] == "video_url"
+    assert sample.multi_modal_data["video_url"]["url"] == f"file://{vid}"
+
+
+@pytest.mark.benchmark
+def test_image_files_produces_image_url(
+    tokenizer: PreTrainedTokenizerBase, tmp_path: Path
+):
+    img = tmp_path / "frame.jpg"
+    img.write_bytes(b"")
+    ds = _dataset(tmp_path, [{"prompt": "p", "image_files": [str(img)]}])
+    [sample] = ds.sample(tokenizer=tokenizer, num_requests=1, output_len=32)
+    assert sample.multi_modal_data["type"] == "image_url"
+    assert sample.multi_modal_data["image_url"]["url"] == f"file://{img}"
+
+
+@pytest.mark.benchmark
+def test_image_files_takes_priority_over_video_files(
+    tokenizer: PreTrainedTokenizerBase, tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
+    """When both keys are present image_files wins and a warning is emitted."""
+    vid, img = tmp_path / "clip.mp4", tmp_path / "frame.jpg"
+    vid.write_bytes(b"")
+    img.write_bytes(b"")
+    ds = _dataset(
+        tmp_path,
+        [{"prompt": "p", "video_files": [str(vid)], "image_files": [str(img)]}],
+    )
+    with caplog.at_level("WARNING"):
+        [sample] = ds.sample(tokenizer=tokenizer, num_requests=1, output_len=32)
+    assert any("Only images will be used" in r.message for r in caplog.records)
+    assert sample.multi_modal_data["type"] == "image_url"
+
+
+@pytest.mark.benchmark
+def test_multiple_files_warns_and_uses_first(
+    tokenizer: PreTrainedTokenizerBase, tmp_path: Path, caplog: pytest.LogCaptureFixture
+):
+    """Multiple files in a list: warning emitted and only the first is used."""
+    vid1, vid2 = tmp_path / "a.mp4", tmp_path / "b.mp4"
+    vid1.write_bytes(b"")
+    vid2.write_bytes(b"")
+    ds = _dataset(tmp_path, [{"prompt": "p", "video_files": [str(vid1), str(vid2)]}])
+    with caplog.at_level("WARNING"):
+        [sample] = ds.sample(tokenizer=tokenizer, num_requests=1, output_len=32)
+    assert any("Only the first will be used" in r.message for r in caplog.records)
+    assert sample.multi_modal_data["video_url"]["url"] == f"file://{vid1}"

--- a/vllm/benchmarks/datasets/datasets.py
+++ b/vllm/benchmarks/datasets/datasets.py
@@ -2298,14 +2298,24 @@ class CustomMMDataset(CustomDataset):
             prompt = item["prompt"]
 
             prompt_len = len(tokenizer(prompt).input_ids)
-            images = item["image_files"]
-            if len(images) > 1:
-                logger.warning(
-                    "Multiple image files found for sample %d. "
-                    "Only the first image will be used.",
-                    i,
-                )
-            mm_content = process_image(images[0])
+            if "video_files" in item:
+                videos = item["video_files"]
+                if len(videos) > 1:
+                    logger.warning(
+                        "Multiple video files found for sample %d. "
+                        "Only the first video will be used.",
+                        i,
+                    )
+                mm_content = process_video(videos[0])
+            else:
+                images = item["image_files"]
+                if len(images) > 1:
+                    logger.warning(
+                        "Multiple image files found for sample %d. "
+                        "Only the first image will be used.",
+                        i,
+                    )
+                mm_content = process_image(images[0])
             if enable_multimodal_chat:
                 # Note: when chat is enabled the request prompt_len is no longer
                 # accurate and we will be using request output to count the

--- a/vllm/benchmarks/datasets/datasets.py
+++ b/vllm/benchmarks/datasets/datasets.py
@@ -2259,12 +2259,15 @@ class CustomMMDataset(CustomDataset):
         "image_files": ["path/to/image1.png", "path/to/image2.png"],
     }
     {
-        "prompt": "Which country has the most pokemons based on the given graphs?",
-        "image_files": ["path/to/image.png"],
+        "prompt": "Describe the video and the accompanying image.",
+        "video_files": ["path/to/clip.mp4"],
+        "image_files": ["path/to/frame.png"],
     }
     ```
 
-    NOTE: Only the first image file in "image_files" is used for each sample request.
+    Each item must contain "image_files", "video_files", or both.
+    If both are present, "image_files" takes precedence.
+    Only the first file in each list is used.
 
     This is used to benchmark multimodal LLMs on arbitrary datasets.
     """
@@ -2298,24 +2301,27 @@ class CustomMMDataset(CustomDataset):
             prompt = item["prompt"]
 
             prompt_len = len(tokenizer(prompt).input_ids)
-            if "video_files" in item:
-                videos = item["video_files"]
-                if len(videos) > 1:
-                    logger.warning(
-                        "Multiple video files found for sample %d. "
-                        "Only the first video will be used.",
-                        i,
-                    )
-                mm_content = process_video(videos[0])
+            image_files = item.get("image_files", [])
+            video_files = item.get("video_files", [])
+            if image_files and video_files:
+                logger.warning(
+                    "Both 'image_files' and 'video_files' found for sample %d. "
+                    "Only images will be used.",
+                    i,
+                )
+                video_files = []
+            if video_files:
+                files, process_fn, modality = video_files, process_video, "video"
             else:
-                images = item["image_files"]
-                if len(images) > 1:
-                    logger.warning(
-                        "Multiple image files found for sample %d. "
-                        "Only the first image will be used.",
-                        i,
-                    )
-                mm_content = process_image(images[0])
+                files, process_fn, modality = image_files, process_image, "image"
+            if len(files) > 1:
+                logger.warning(
+                    "Multiple %s files found for sample %d. "
+                    "Only the first will be used.",
+                    modality,
+                    i,
+                )
+            mm_content = process_fn(files[0])
             if enable_multimodal_chat:
                 # Note: when chat is enabled the request prompt_len is no longer
                 # accurate and we will be using request output to count the


### PR DESCRIPTION



## Purpose
Adds video support to custom_mm dataset

## Test Plan

[tests/benchmarks/test_custom_mm_dataset.py](https://github.com/evezhier/vllm/blob/8d6884782b411ca3ba749b66d86e7214c63a232b/tests/benchmarks/test_custom_mm_dataset.py)

## Test Result
custom_mm dataset now accepts "video_files" and vllm bench throws no error

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

