### PR TITLE
Revert "[CPU][RISC-V] Auto-bind OMP threads and harden nobind path" (#40569)

### DIFF
--- a/vllm/utils/ompmultiprocessing.py
+++ b/vllm/utils/ompmultiprocessing.py
@@ -40,13 +40,12 @@ class OMPProcessManager:
 
         assert not (self.use_iomp and self.use_gomp)
 
-        # at least reserve 1/local_world_size(for ARM/RISC-V) core for scheduler
+        # at least reserve 1/local_world_size(for ARM) core for scheduler
         # proc as always use MP executor
         # TODO: make scheduler proc sleep when idle
         self.reserve_cpu_num = (
             self.local_world_size
-            if current_platform.get_cpu_architecture()
-            in (CpuArchEnum.ARM, CpuArchEnum.RISCV)
+            if current_platform.get_cpu_architecture() == CpuArchEnum.ARM
             else 1
         )
         # reserve at one more core for nixl_connector under p/d case
@@ -141,8 +140,8 @@ class OMPProcessManager:
                 cpu_list, reserve_list = self._get_autobind_cpu_ids(
                     lambda cpus: cpus[-1:]
                 )
-            elif cpu_arch in (CpuArchEnum.ARM, CpuArchEnum.RISCV):
-                # For AArch64 / RISC-V, no SMT, use all logical CPUs
+            elif cpu_arch == CpuArchEnum.ARM:
+                # For AArch64, no SMT, use all logical CPU
                 cpu_list, reserve_list = self._get_autobind_cpu_ids(lambda cpus: cpus)
             else:
                 cpu_list, reserve_list = [], []
@@ -174,15 +173,9 @@ class OMPProcessManager:
             # skip
             self.cpu_lists = []
 
-        msg = (
-            "OpenMP thread binding info: \n"
-            f"\tVLLM_CPU_OMP_THREADS_BIND={vllm_mask!r}, "
-            f"auto_setup={self.auto_setup}, skip_setup={self.skip_setup}\n"
-            f"\tlocal_world_size={self.local_world_size}, "
-            f"reserve_cpu_num={self.reserve_cpu_num}\n"
-        )
-        for i, cpus in enumerate(self.cpu_lists):
-            msg += f"\tlocal_rank={i}, core ids={cpus}\n"
+        msg = "OpenMP thread binding info: \n"
+        for i in range(self.local_world_size):
+            msg += f"\tlocal_rank={i}, core ids={self.cpu_lists[i]}\n"
         msg += f"\treserved_cpus={self.reserved_cpu_list}"
         logger.info(msg)
 


### PR DESCRIPTION
## Auto-Revert

This reverts https://github.com/vllm-project/vllm/pull/40569 (merge commit 5d0fd87038b123a11dd9c85a05ce2d258e27ce7b).

**Reason:** This PR is linked to 1 new CI failure in build [#64792](https://buildkite.com/vllm/ci/builds/64792):
- Arm CPU Test

The OMP thread binding changes in `ompmultiprocessing.py` appear to cause a hang during model loading on ARM CPU, with `get_mempolicy: Operation not permitted` and `set_mempolicy: Operation not permitted` errors. The test container was killed during model loading with zero test results produced.

> **Note:** Auto-generated by CI failure analyzer. Please review carefully before merging.