### PR TITLE
[Bugfix] Fix FusedMoEWithLoRA has no attribute `runner`

### DIFF
--- a/vllm/lora/layers/fused_moe.py
+++ b/vllm/lora/layers/fused_moe.py
@@ -336,6 +336,10 @@ class FusedMoEWithLoRA(BaseLayerWithLoRA):
         return self.base_layer.quant_method
 
     @property
+    def runner(self):
+        return self.base_layer.runner
+
+    @property
     def is_internal_router(self) -> bool:
         return self.base_layer.is_internal_router
 


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
When testing qwen3moe+LoRA, I encounter the following error:
```bash
AttributeError: FusedMoEWithLoRA has no attribute `runner`
```


## Test Plan

````bash
pytest test_qwen3moe_tp.py -v -s 
````

## Test Result

All test in `test_qwen3moe_tp.py` can pass correctly in my local device

```shell

tests/lora/test_qwen3moe_tp.py::test_qwen3moe_lora
  /usr/lib/python3.12/multiprocessing/popen_fork.py:66: DeprecationWarning: This process (pid=3851829) is multi-threaded, use of fork() may lead to deadlocks in the child.
    self.pid = os.fork()

tests/lora/test_qwen3moe_tp.py::test_qwen3moe_lora_tp2
tests/lora/test_qwen3moe_tp.py::test_qwen3moe_lora_tp4
/vllm_main/vllm/tests/utils.py:1427: DeprecationWarning: This process (pid=3851829) is multi-threaded, use of fork() may lead to deadlocks in the child.
    pid = os.fork()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================================== 3 passed, 19 warnings in 290.25s (0:04:50) ==============================================================================================================
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
