### PR TITLE
Fix: unsafe GDN auto backend selection for TP>1

### DIFF
--- a/tests/model_executor/test_gdn_linear_attn.py
+++ b/tests/model_executor/test_gdn_linear_attn.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from unittest.mock import Mock
+
+import pytest
+
+from vllm.config import VllmConfig, set_current_vllm_config
+from vllm.model_executor.layers.mamba.gdn_linear_attn import ChunkGatedDeltaRule
+
+
+def _make_gdn_op(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    backend: str | None,
+    tp_size: int,
+    is_cuda: bool = True,
+    has_sm90: bool = True,
+) -> tuple[ChunkGatedDeltaRule, Mock]:
+    logger = Mock()
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.mamba.gdn_linear_attn.logger", logger
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.mamba.gdn_linear_attn."
+        "get_tensor_model_parallel_world_size",
+        lambda: tp_size,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.mamba.gdn_linear_attn.current_platform.is_cuda",
+        lambda: is_cuda,
+    )
+    monkeypatch.setattr(
+        "vllm.model_executor.layers.mamba.gdn_linear_attn."
+        "current_platform.is_device_capability",
+        lambda capability: has_sm90 and capability == 90,
+    )
+
+    additional_config = {}
+    if backend is not None:
+        additional_config["gdn_prefill_backend"] = backend
+    vllm_config = VllmConfig(additional_config=additional_config)
+
+    with set_current_vllm_config(vllm_config):
+        return ChunkGatedDeltaRule(), logger
+
+
+def test_gdn_auto_uses_flashinfer_for_single_tp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    op, logger = _make_gdn_op(monkeypatch, backend=None, tp_size=1)
+
+    assert op._forward_method.__name__ == "forward_cuda"
+    logger.warning_once.assert_not_called()
+
+
+def test_gdn_auto_falls_back_to_triton_for_multi_tp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    op, logger = _make_gdn_op(monkeypatch, backend=None, tp_size=8)
+
+    assert op._forward_method.__name__ == "forward_native"
+    logger.warning_once.assert_called_once()
+    warning_args = logger.warning_once.call_args[0]
+    assert "GDN prefill backend 'auto' is falling back to Triton/FLA" in warning_args[
+        0
+    ]
+    assert warning_args[1] == 8
+
+
+def test_gdn_flashinfer_override_keeps_flashinfer_for_multi_tp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    op, logger = _make_gdn_op(monkeypatch, backend="flashinfer", tp_size=8)
+
+    assert op._forward_method.__name__ == "forward_cuda"
+    logger.warning_once.assert_not_called()
+
+
+def test_gdn_triton_override_keeps_triton(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    op, logger = _make_gdn_op(monkeypatch, backend="triton", tp_size=1)
+
+    assert op._forward_method.__name__ == "forward_native"
+    logger.warning_once.assert_not_called()
+
+
+def test_gdn_flashinfer_falls_back_when_platform_unsupported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    op, logger = _make_gdn_op(
+        monkeypatch,
+        backend="flashinfer",
+        tp_size=1,
+        is_cuda=False,
+        has_sm90=False,
+    )
+
+    assert op._forward_method.__name__ == "forward_native"
+    logger.warning_once.assert_called_once()
+    assert "cannot use this kernel on the current platform" in (
+        logger.warning_once.call_args[0][0]
+    )

--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -124,6 +124,7 @@ class ChunkGatedDeltaRule(CustomOp):
         assert isinstance(additional_config, dict)
         backend_cfg = additional_config.get("gdn_prefill_backend", "auto")
         backend = str(backend_cfg).strip().lower()
+        tp_size = get_tensor_model_parallel_world_size()
 
         supports_flashinfer = (
             current_platform.is_cuda() and current_platform.is_device_capability(90)
@@ -140,7 +141,14 @@ class ChunkGatedDeltaRule(CustomOp):
         elif backend == "triton":
             use_flashinfer = False
         else:
-            use_flashinfer = supports_flashinfer
+            use_flashinfer = supports_flashinfer and tp_size == 1
+            if supports_flashinfer and tp_size > 1:
+                logger.warning_once(
+                    "GDN prefill backend 'auto' is falling back to Triton/FLA "
+                    "when tensor parallel size is %d. Set "
+                    "`--gdn-prefill-backend flashinfer` to force FlashInfer.",
+                    tp_size,
+                )
 
         if use_flashinfer:
             logger.info_once("Using FlashInfer GDN prefill kernel")


### PR DESCRIPTION
 
  Fix unsafe GDN auto backend selection for TP>1 by falling back to Triton
  
  fix issue https://github.com/vllm-project/vllm/issues/41865
  
## Purpose

### scenario

  The issue is triggered when serving GDN-based models such as Qwen3.5 / Qwen3-Next on a CUDA SM90+ platform where GDN prefill auto selects FlashInfer by  default, and tensor_parallel_size > 1. In that setup, multiple TP workers enter the V1 profile/warmup path at startup and concurrently hit the FlashInfer  GDN prefill JIT/warmup path.

  During startup, one worker may complete a long compile or warmup step while the remaining workers make no forward progress. The engine then appears hung  and repeatedly logs messages such as No available shared memory broadcast block found in 60 seconds. In practice, service initialization stalls and the  model does not become ready.

###   Root cause

  The root cause is that the GDN backend auto-selection logic only considered platform capability and not TP topology. On supported CUDA hardware, auto  selected FlashInfer even when TP>1, which allowed multiple TP workers to enter the FlashInfer GDN prefill JIT/warmup path concurrently during V1 profile  run. That path is unstable under multi-worker initialization and can lead to worker stalls or startup hangs. More precisely, the code and issue evidence  show that FlashInfer GDN auto-selection is unsafe for the reported multi-TP startup path; the exact lower-level cause inside FlashInfer/JIT is still not  fully proven in this repo.
  
## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

