### PR TITLE
[Bugfix] Fix XPU/ROCm compatibility in spawn_new_process_for_each_test

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,7 +19,7 @@ import threading
 import time
 import warnings
 from collections.abc import Callable, Iterable, Sequence
-from contextlib import ExitStack, contextmanager, suppress
+from contextlib import ExitStack, contextmanager
 from multiprocessing import Process
 from pathlib import Path
 from typing import Any, Literal
@@ -1511,7 +1511,6 @@ def fork_new_process_for_each_test(func: Callable[_P, None]) -> Callable[_P, Non
     return wrapper
 
 
-<<<<<<< HEAD
 def spawn_new_process_for_each_test(f: Callable[_P, None]) -> Callable[_P, None]:
     """Decorator to spawn a new process for each test function.
 
@@ -1519,10 +1518,6 @@ def spawn_new_process_for_each_test(f: Callable[_P, None]) -> Callable[_P, None]
     propagates exceptions back to the parent, so test failures are never
     silently swallowed (fixes https://github.com/vllm-project/vllm/issues/41415).
     """
-=======
-
-    """Decorator to spawn a new process for each test function."""
->>>>>>> 2c4dc247b ([Bugfix] Fix spawn_new_process_for_each_test silently swallowing failures)
 
     @functools.wraps(f)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> None:
@@ -1545,64 +1540,6 @@ def spawn_new_process_for_each_test(f: Callable[_P, None]) -> Callable[_P, None]
                 "    f(*args, **kwargs)\n"
                 "except Skipped:\n"
                 "    sys.exit(0)\n"
-                "except BaseException:\n"
-                "    open(tb_file, 'w').write(traceback.format_exc())\n"
-                "    sys.exit(1)\n"
-            )
-
-            repo_root = str(VLLM_PATH.resolve())
-            env = os.environ.copy()
-            env["PYTHONPATH"] = repo_root + os.pathsep + env.get("PYTHONPATH", "")
-
-            result = subprocess.run(
-                [sys.executable, "-c", child_script],
-                input=payload,
-                capture_output=True,
-                env=env,
-            )
-
-            if result.returncode != 0:
-                # Read traceback written by child, fall back to stderr
-                tb = ""
-                if os.path.exists(tb_file) and os.path.getsize(tb_file) > 0:
-                    with open(tb_file) as fp:
-                        tb = fp.read()
-                else:
-                    tb = result.stderr.decode()
-                raise RuntimeError(
-                    f"Test subprocess '{f.__name__}' failed "
-                    f"(exit code {result.returncode}):\n{tb}"
-                )
-        finally:
-            with contextlib.suppress(OSError):
-                os.remove(tb_file)
-
-    return wrapper
-
-def spawn_new_process_for_each_test(f: Callable[_P, None]) -> Callable[_P, None]:
-    """Decorator to spawn a new process for each test function.
-
-    Uses subprocess with cloudpickle to serialize the test function and
-    propagates exceptions back to the parent, so test failures are never
-    silently swallowed (fixes https://github.com/vllm-project/vllm/issues/41415).
-    """
-
-    @functools.wraps(f)
-    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> None:
-        with tempfile.NamedTemporaryFile(
-            delete=False, suffix=".tb", mode="wb"
-        ) as tmp:
-            tb_file = tmp.name
-
-        try:
-            # Serialize the function + args with cloudpickle so closures work
-            payload = cloudpickle.dumps((f, args, kwargs, tb_file))
-
-            child_script = (
-                "import sys, cloudpickle, traceback\n"
-                "f, args, kwargs, tb_file = cloudpickle.loads(sys.stdin.buffer.read())\n"
-                "try:\n"
-                "    f(*args, **kwargs)\n"
                 "except BaseException:\n"
                 "    open(tb_file, 'w').write(traceback.format_exc())\n"
                 "    sys.exit(1)\n"

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,7 +19,7 @@ import threading
 import time
 import warnings
 from collections.abc import Callable, Iterable, Sequence
-from contextlib import ExitStack, contextmanager
+from contextlib import ExitStack, contextmanager, suppress
 from multiprocessing import Process
 from pathlib import Path
 from typing import Any, Literal
@@ -1511,6 +1511,7 @@ def fork_new_process_for_each_test(func: Callable[_P, None]) -> Callable[_P, Non
     return wrapper
 
 
+<<<<<<< HEAD
 def spawn_new_process_for_each_test(f: Callable[_P, None]) -> Callable[_P, None]:
     """Decorator to spawn a new process for each test function.
 
@@ -1518,6 +1519,10 @@ def spawn_new_process_for_each_test(f: Callable[_P, None]) -> Callable[_P, None]
     propagates exceptions back to the parent, so test failures are never
     silently swallowed (fixes https://github.com/vllm-project/vllm/issues/41415).
     """
+=======
+
+    """Decorator to spawn a new process for each test function."""
+>>>>>>> 2c4dc247b ([Bugfix] Fix spawn_new_process_for_each_test silently swallowing failures)
 
     @functools.wraps(f)
     def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> None:
@@ -1540,6 +1545,64 @@ def spawn_new_process_for_each_test(f: Callable[_P, None]) -> Callable[_P, None]
                 "    f(*args, **kwargs)\n"
                 "except Skipped:\n"
                 "    sys.exit(0)\n"
+                "except BaseException:\n"
+                "    open(tb_file, 'w').write(traceback.format_exc())\n"
+                "    sys.exit(1)\n"
+            )
+
+            repo_root = str(VLLM_PATH.resolve())
+            env = os.environ.copy()
+            env["PYTHONPATH"] = repo_root + os.pathsep + env.get("PYTHONPATH", "")
+
+            result = subprocess.run(
+                [sys.executable, "-c", child_script],
+                input=payload,
+                capture_output=True,
+                env=env,
+            )
+
+            if result.returncode != 0:
+                # Read traceback written by child, fall back to stderr
+                tb = ""
+                if os.path.exists(tb_file) and os.path.getsize(tb_file) > 0:
+                    with open(tb_file) as fp:
+                        tb = fp.read()
+                else:
+                    tb = result.stderr.decode()
+                raise RuntimeError(
+                    f"Test subprocess '{f.__name__}' failed "
+                    f"(exit code {result.returncode}):\n{tb}"
+                )
+        finally:
+            with contextlib.suppress(OSError):
+                os.remove(tb_file)
+
+    return wrapper
+
+def spawn_new_process_for_each_test(f: Callable[_P, None]) -> Callable[_P, None]:
+    """Decorator to spawn a new process for each test function.
+
+    Uses subprocess with cloudpickle to serialize the test function and
+    propagates exceptions back to the parent, so test failures are never
+    silently swallowed (fixes https://github.com/vllm-project/vllm/issues/41415).
+    """
+
+    @functools.wraps(f)
+    def wrapper(*args: _P.args, **kwargs: _P.kwargs) -> None:
+        with tempfile.NamedTemporaryFile(
+            delete=False, suffix=".tb", mode="wb"
+        ) as tmp:
+            tb_file = tmp.name
+
+        try:
+            # Serialize the function + args with cloudpickle so closures work
+            payload = cloudpickle.dumps((f, args, kwargs, tb_file))
+
+            child_script = (
+                "import sys, cloudpickle, traceback\n"
+                "f, args, kwargs, tb_file = cloudpickle.loads(sys.stdin.buffer.read())\n"
+                "try:\n"
+                "    f(*args, **kwargs)\n"
                 "except BaseException:\n"
                 "    open(tb_file, 'w').write(traceback.format_exc())\n"
                 "    sys.exit(1)\n"

--- a/tests/v1/logits_processors/test_custom_online.py
+++ b/tests/v1/logits_processors/test_custom_online.py
@@ -10,7 +10,7 @@ import openai
 import pytest
 import pytest_asyncio
 
-from tests.utils import RemoteOpenAIServerCustom, create_new_process_for_each_test
+from tests.utils import RemoteOpenAIServerCustom
 from tests.v1.logits_processors.utils import (
     DUMMY_LOGITPROC_ARG,
     DUMMY_LOGITPROC_FQCN,
@@ -119,7 +119,7 @@ api_keyword_args = {
 }
 
 
-@create_new_process_for_each_test()
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "model_name",
     [MODEL_NAME],


### PR DESCRIPTION
## Purpose

Follow-up to #41423.

`mp.set_start_method("spawn")` was inadvertently removed when the decorator was rewritten to use `subprocess.run`. While the decorator itself doesn't need it (since `subprocess.run` launches a fresh interpreter regardless), other parts of the test session — specifically XPU/ROCm engine workers that use `mp.Process` directly — depend on this global mp start method being set to spawn.

Without it, those workers default back to `fork` on Linux, causing:
`RuntimeError: Cannot re-initialize XPU in forked subprocess`

This restore has no effect on the failure-propagation fix from #41423.

cc @jikunshang @ProExpertProg @AndreasKaratzas 