### PR TITLE
Fix FP8 KV wake-up for nested KV cache containers

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -300,6 +300,29 @@ def test_sample_tokens_skips_pp_group_lookup_without_async_scheduling(
     assert GPUModelRunner.sample_tokens(runner, None) is None
 
 
+def test_init_fp8_kv_scales_zeroes_nested_kv_cache_tensors():
+    runner = GPUModelRunner.__new__(GPUModelRunner)
+    runner.cache_config = SimpleNamespace(cache_dtype="fp8_e4m3")
+    runner.compilation_config = SimpleNamespace(static_forward_context={})
+
+    attn_cache = torch.ones(2)
+    mamba_conv_cache = torch.ones(3)
+    mamba_ssm_cache = torch.ones(4)
+    shared_cache = torch.ones(5)
+    runner.kv_caches = [
+        attn_cache,
+        [mamba_conv_cache, None, (mamba_ssm_cache,)],
+        {"shared": shared_cache},
+    ]
+
+    GPUModelRunner.init_fp8_kv_scales(runner)
+
+    assert torch.equal(attn_cache, torch.zeros_like(attn_cache))
+    assert torch.equal(mamba_conv_cache, torch.zeros_like(mamba_conv_cache))
+    assert torch.equal(mamba_ssm_cache, torch.zeros_like(mamba_ssm_cache))
+    assert torch.equal(shared_cache, torch.zeros_like(shared_cache))
+
+
 def test_select_common_block_size_no_valid_option():
     backend_a = _make_mock_backend_for_kernel_block_size([64])
     backend_b = _make_mock_backend_for_kernel_block_size([MultipleOf(16)])

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -7,7 +7,7 @@ import itertools
 import threading
 import time
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Iterator, Sequence
+from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
 from contextlib import contextmanager
 from copy import copy, deepcopy
 from dataclasses import dataclass, replace
@@ -218,6 +218,24 @@ if TYPE_CHECKING:
     from vllm.v1.worker.encoder_cudagraph import EncoderCudaGraphManager
 
 logger = init_logger(__name__)
+
+
+def _iter_kv_cache_tensors(kv_caches: Iterable[Any]) -> Iterator[torch.Tensor]:
+    for cache in kv_caches:
+        if cache is None:
+            continue
+        if isinstance(cache, torch.Tensor):
+            yield cache
+        elif isinstance(cache, Mapping):
+            yield from _iter_kv_cache_tensors(cache.values())
+        elif isinstance(cache, (list, tuple)):
+            yield from _iter_kv_cache_tensors(cache)
+        else:
+            raise TypeError(
+                "Expected KV cache entries to be tensors or nested containers "
+                f"of tensors, got {type(cache)!r}."
+            )
+
 
 AttnMetadataDict: TypeAlias = dict[str, AttentionMetadata]
 # list when ubatching is enabled
@@ -904,9 +922,8 @@ class GPUModelRunner(
             return
 
         kv_caches = getattr(self, "kv_caches", [])
-        for cache_tensor in kv_caches:
-            if cache_tensor is not None:
-                cache_tensor.zero_()
+        for cache_tensor in _iter_kv_cache_tensors(kv_caches):
+            cache_tensor.zero_()
 
         k_attr_names = ("_k_scale", "k_scale")
         v_attr_names = ("_v_scale", "v_scale")


### PR DESCRIPTION
Summary:
- Walk nested KV cache containers when zeroing quantized KV caches during wake-up.
- Covers hybrid attention/Mamba runners where `self.kv_caches` can contain lists of tensors instead of only tensors.
- Add a CPU unit test for nested attention/Mamba-style KV cache entries.

Testing:
- `python3 -m py_compile vllm/v1/worker/gpu_model_runner.py tests/v1/worker/test_gpu_model_runner.py`
- `git diff --check`
- Not run: `python3 -m pytest tests/v1/worker/test_gpu_model_runner.py -k nested_kv_cache_tensors` because pytest is not installed in my local environment.

Context:
- This fixes an FP8 KV wake-up path that can fail after sleep/restore when hybrid cache entries are nested containers rather than flat tensors.