### PR TITLE
[Core] Add support for `traverse_draft_trees` for structured outputs + specdec

### DIFF
--- a/tests/v1/structured_output/test_backend_xgrammar.py
+++ b/tests/v1/structured_output/test_backend_xgrammar.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+from types import SimpleNamespace
+
 import torch
 from transformers import AutoTokenizer
 
@@ -62,6 +64,24 @@ def test_xgrammar_draft_tree_branch_token_indices():
         (1, 4),
         (1, 5),
     ]
+
+
+def test_xgrammar_backend_builds_chain_when_speculative_tree_absent():
+    tokenizer = AutoTokenizer.from_pretrained(TOKENIZER)
+    backend = XgrammarBackend(
+        vllm_config=SimpleNamespace(
+            structured_outputs_config=StructuredOutputsConfig(backend="xgrammar"),
+            speculative_config=SimpleNamespace(
+                num_speculative_tokens=3,
+                speculative_token_tree=None,
+            ),
+        ),
+        tokenizer=tokenizer,
+        vocab_size=tokenizer.vocab_size,
+    )
+
+    assert backend.draft_tree is not None
+    assert backend.draft_tree.tree_choices == ((0,), (0, 0), (0, 0, 0))
 
 
 def test_xgrammar_speculative_bitmask_chain_matches_linear_walk():

--- a/tests/v1/structured_output/test_backend_xgrammar.py
+++ b/tests/v1/structured_output/test_backend_xgrammar.py
@@ -1,0 +1,224 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+from transformers import AutoTokenizer
+
+from vllm.config import StructuredOutputsConfig, VllmConfig
+from vllm.v1.structured_output.backend_types import StructuredOutputOptions
+from vllm.v1.structured_output.backend_xgrammar import (
+    XgrammarBackend,
+    XgrammarGrammar,
+    _XgrammarDraftTree,
+)
+
+TOKENIZER = "gpt2"
+
+
+def test_xgrammar_draft_tree_topology_chain():
+    draft_tree = _XgrammarDraftTree(
+        tree_choices=((0,), (0, 0), (0, 0, 0)),
+    )
+
+    retrieve_next_token, retrieve_next_sibling = draft_tree.topology(prefix_len=3)
+
+    assert retrieve_next_token.tolist() == [1, 2, 3, -1]
+    assert retrieve_next_sibling.tolist() == [-1, -1, -1, -1]
+
+
+def test_xgrammar_draft_tree_topology_branching():
+    draft_tree = _XgrammarDraftTree(
+        tree_choices=((0,), (1,), (0, 0), (0, 1), (1, 0), (1, 1)),
+    )
+
+    retrieve_next_token, retrieve_next_sibling = draft_tree.topology(prefix_len=6)
+
+    assert retrieve_next_token.tolist() == [1, 3, 5, -1, -1, -1, -1]
+    assert retrieve_next_sibling.tolist() == [-1, 2, -1, 4, -1, 6, -1]
+
+
+def test_xgrammar_draft_tree_topology_truncated_prefix():
+    draft_tree = _XgrammarDraftTree(
+        tree_choices=((0,), (1,), (0, 0), (0, 1), (1, 0), (1, 1)),
+    )
+
+    retrieve_next_token, retrieve_next_sibling = draft_tree.topology(prefix_len=4)
+
+    assert retrieve_next_token.tolist() == [1, 3, -1, -1, -1]
+    assert retrieve_next_sibling.tolist() == [-1, 2, -1, 4, -1]
+
+
+def test_xgrammar_draft_tree_branch_token_indices():
+    draft_tree = _XgrammarDraftTree(
+        tree_choices=((0,), (1,), (0, 0), (0, 1), (1, 0), (1, 1)),
+    )
+
+    assert draft_tree.branch_token_indices(prefix_len=6) == [
+        (),
+        (0,),
+        (1,),
+        (0, 2),
+        (0, 3),
+        (1, 4),
+        (1, 5),
+    ]
+
+
+def test_xgrammar_speculative_bitmask_chain_matches_linear_walk():
+    tokenizer, backend, actual_grammar = _compile_regex_grammar(
+        "[ab][cd][ef]",
+        tree_choices=((0,), (0, 0), (0, 0, 0)),
+    )
+    _, _, expected_grammar = _compile_regex_grammar(
+        "[ab][cd][ef]",
+        tree_choices=((0,), (0, 0), (0, 0, 0)),
+    )
+    tokens = [
+        _token_id(tokenizer, "a"),
+        _token_id(tokenizer, "c"),
+        _token_id(tokenizer, "e"),
+    ]
+    actual = backend.allocate_token_bitmask(len(tokens) + 1)
+    expected = backend.allocate_token_bitmask(len(tokens) + 1)
+
+    assert actual_grammar.fill_speculative_bitmask(
+        actual, batch_index=0, tokens=tokens, apply_bitmask=True
+    )
+    _fill_linear_speculative_bitmask(expected_grammar, tokens, expected)
+
+    assert torch.equal(actual, expected)
+
+
+def test_xgrammar_speculative_bitmask_branching_matches_forked_walk():
+    tokenizer, backend, actual_grammar = _compile_regex_grammar(
+        "[ab][cd]",
+        tree_choices=((0,), (1,), (0, 0), (0, 1), (1, 0), (1, 1)),
+    )
+    _, _, expected_grammar = _compile_regex_grammar(
+        "[ab][cd]",
+        tree_choices=((0,), (1,), (0, 0), (0, 1), (1, 0), (1, 1)),
+    )
+    tokens = [
+        _token_id(tokenizer, "a"),
+        _token_id(tokenizer, "b"),
+        _token_id(tokenizer, "c"),
+        _token_id(tokenizer, "d"),
+        _token_id(tokenizer, "c"),
+        _token_id(tokenizer, "d"),
+    ]
+    actual = backend.allocate_token_bitmask(len(tokens) + 1)
+    expected = backend.allocate_token_bitmask(len(tokens) + 1)
+
+    assert actual_grammar.fill_speculative_bitmask(
+        actual, batch_index=0, tokens=tokens, apply_bitmask=True
+    )
+    _fill_branch_speculative_bitmask(expected_grammar, tokens, expected)
+
+    assert torch.equal(actual, expected)
+
+
+def test_xgrammar_speculative_bitmask_invalid_draft_does_not_advance():
+    tokenizer, backend, grammar = _compile_regex_grammar(
+        "a",
+        tree_choices=((0,),),
+    )
+    valid_token = _token_id(tokenizer, "a")
+    invalid_token = _token_id(tokenizer, "b")
+    bitmask = backend.allocate_token_bitmask(2)
+    accepted_before = grammar.validate_tokens([valid_token])
+
+    assert grammar.fill_speculative_bitmask(
+        bitmask,
+        batch_index=0,
+        tokens=[invalid_token],
+        apply_bitmask=True,
+    )
+
+    assert accepted_before == [valid_token]
+    assert grammar.validate_tokens([valid_token]) == accepted_before
+    assert not _bitmask_allows(bitmask, row=0, token_id=invalid_token)
+
+
+def test_xgrammar_speculative_bitmask_pads_unknown_suffix():
+    tokenizer, backend, grammar = _compile_regex_grammar(
+        "[ab][cd][ef]",
+        tree_choices=((0,), (0, 0), (0, 0, 0)),
+    )
+    tokens = [_token_id(tokenizer, "a"), -1, -1]
+    bitmask = backend.allocate_token_bitmask(len(tokens) + 1)
+
+    assert grammar.fill_speculative_bitmask(
+        bitmask, batch_index=0, tokens=tokens, apply_bitmask=True
+    )
+
+    assert not torch.equal(bitmask[0], torch.full_like(bitmask[0], -1))
+    assert not torch.equal(bitmask[1], torch.full_like(bitmask[1], -1))
+    assert torch.equal(bitmask[2], torch.full_like(bitmask[2], -1))
+    assert torch.equal(bitmask[3], torch.full_like(bitmask[3], -1))
+
+
+def _compile_regex_grammar(
+    regex: str,
+    tree_choices: tuple[tuple[int, ...], ...],
+) -> tuple[AutoTokenizer, XgrammarBackend, XgrammarGrammar]:
+    tokenizer = AutoTokenizer.from_pretrained(TOKENIZER)
+    backend = XgrammarBackend(
+        vllm_config=VllmConfig(
+            structured_outputs_config=StructuredOutputsConfig(backend="xgrammar"),
+        ),
+        tokenizer=tokenizer,
+        vocab_size=tokenizer.vocab_size,
+    )
+    grammar = backend.compile_grammar(StructuredOutputOptions.REGEX, regex)
+    assert isinstance(grammar, XgrammarGrammar)
+    grammar.draft_tree = _XgrammarDraftTree(tree_choices=tree_choices)
+    return tokenizer, backend, grammar
+
+
+def _token_id(tokenizer: AutoTokenizer, text: str) -> int:
+    tokens = tokenizer.encode(text, add_special_tokens=False)
+    assert len(tokens) == 1
+    return tokens[0]
+
+
+def _fill_linear_speculative_bitmask(
+    grammar: XgrammarGrammar,
+    tokens: list[int],
+    bitmask: torch.Tensor,
+) -> None:
+    state_advancements = 0
+    for idx, token in enumerate([*tokens, -1]):
+        grammar.fill_bitmask(bitmask, idx)
+        if token == -1:
+            continue
+        assert grammar.accept_tokens("req", [token])
+        state_advancements += 1
+    grammar.rollback(state_advancements)
+
+
+def _fill_branch_speculative_bitmask(
+    grammar: XgrammarGrammar,
+    tokens: list[int],
+    bitmask: torch.Tensor,
+) -> None:
+    assert grammar.draft_tree is not None
+    grammar.matcher.fill_next_token_bitmask(bitmask, 0)
+    branch_token_indices = grammar.draft_tree.branch_token_indices(len(tokens))
+    for node_idx in range(1, len(tokens) + 1):
+        token_indices = branch_token_indices[node_idx]
+        assert token_indices is not None
+        matcher = grammar.matcher.fork()
+        accepted = True
+        for token_idx in token_indices:
+            if not matcher.accept_token(tokens[token_idx]):
+                accepted = False
+                break
+        if accepted:
+            matcher.fill_next_token_bitmask(bitmask, node_idx)
+        else:
+            bitmask[node_idx].fill_(-1)
+
+
+def _bitmask_allows(bitmask: torch.Tensor, row: int, token_id: int) -> bool:
+    word = int(bitmask[row, token_id // 32].item())
+    return bool(word & (1 << (token_id % 32)))

--- a/vllm/v1/structured_output/__init__.py
+++ b/vllm/v1/structured_output/__init__.py
@@ -276,6 +276,15 @@ class StructuredOutputManager:
 
                 state_advancements = 0
                 req_tokens = scheduled_spec_decode_tokens.get(req_id, ())
+                if req_tokens and grammar.fill_speculative_bitmask(
+                    self._grammar_bitmask,
+                    cumulative_index,
+                    req_tokens,
+                    apply_bitmask,
+                ):
+                    cumulative_index += 1 + len(req_tokens)
+                    continue
+
                 for token in itertools.chain(req_tokens, (-1,)):
                     self._fill_bitmasks(((grammar, cumulative_index, apply_bitmask),))
                     if token == -1:

--- a/vllm/v1/structured_output/backend_types.py
+++ b/vllm/v1/structured_output/backend_types.py
@@ -79,6 +79,27 @@ class StructuredOutputGrammar(ABC):
             batch_index (int): The index in the bitmask to fill
         """
 
+    def fill_speculative_bitmask(
+        self,
+        bitmask: "torch.Tensor",
+        batch_index: int,
+        tokens: list[int],
+        apply_bitmask: bool,
+    ) -> bool:
+        """
+        Optionally fills bitmasks for speculative decoding.
+
+        Args:
+            bitmask (torch.Tensor): The bitmask to fill.
+            batch_index (int): The first index in the bitmask to fill.
+            tokens (list[int]): The speculative token ids in scheduler order.
+            apply_bitmask (bool): Whether grammar constraints should be applied.
+
+        Returns:
+            bool: True if this backend handled all speculative bitmask rows.
+        """
+        return False
+
     @abstractmethod
     def is_terminated(self) -> bool:
         """

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -1,7 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-import ast
 import json
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -41,25 +40,6 @@ class _XgrammarDraftTree:
     _branch_indices_cache: dict[int, list[tuple[int, ...] | None]] = field(
         default_factory=dict, init=False, repr=False
     )
-
-    @classmethod
-    def from_speculative_config(
-        cls, speculative_config: Any | None, num_speculative_tokens: int
-    ) -> "_XgrammarDraftTree | None":
-        if num_speculative_tokens <= 0:
-            return None
-
-        speculative_token_tree = None
-        if speculative_config is not None:
-            speculative_token_tree = speculative_config.speculative_token_tree
-
-        if speculative_token_tree is None:
-            tree_choices = tuple((0,) * (i + 1) for i in range(num_speculative_tokens))
-        else:
-            tree_choices = tuple(
-                tuple(path) for path in ast.literal_eval(speculative_token_tree)
-            )
-        return cls(tree_choices=tree_choices)
 
     @property
     def num_draft_tokens(self) -> int:
@@ -161,9 +141,8 @@ class XgrammarBackend(StructuredOutputBackend):
             self.num_speculative_tokens = (
                 self.vllm_config.speculative_config.num_speculative_tokens or 0
             )
-        self.draft_tree = _XgrammarDraftTree.from_speculative_config(
-            self.vllm_config.speculative_config,
-            self.num_speculative_tokens,
+        self.draft_tree = _XgrammarDraftTree(
+            tree_choices=self.vllm_config.speculative_config.speculative_token_tree
         )
 
     def compile_grammar(

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import ast
 import json
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -29,6 +30,93 @@ else:
     xgr = LazyLoader("xgr", globals(), "xgrammar")
 
 logger = init_logger(__name__)
+
+
+@dataclass
+class _XgrammarDraftTree:
+    tree_choices: tuple[tuple[int, ...], ...]
+    _topology_cache: dict[int, tuple[torch.Tensor, torch.Tensor]] = field(
+        default_factory=dict, init=False, repr=False
+    )
+    _branch_indices_cache: dict[int, list[tuple[int, ...] | None]] = field(
+        default_factory=dict, init=False, repr=False
+    )
+
+    @classmethod
+    def from_speculative_config(
+        cls, speculative_config: Any | None, num_speculative_tokens: int
+    ) -> "_XgrammarDraftTree | None":
+        if num_speculative_tokens <= 0:
+            return None
+
+        speculative_token_tree = None
+        if speculative_config is not None:
+            speculative_token_tree = speculative_config.speculative_token_tree
+
+        if speculative_token_tree is None:
+            tree_choices = tuple((0,) * (i + 1) for i in range(num_speculative_tokens))
+        else:
+            tree_choices = tuple(
+                tuple(path) for path in ast.literal_eval(speculative_token_tree)
+            )
+        return cls(tree_choices=tree_choices)
+
+    @property
+    def num_draft_tokens(self) -> int:
+        return len(self.tree_choices)
+
+    def topology(self, prefix_len: int) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return xgrammar child/sibling topology for the requested prefix."""
+        if prefix_len not in self._topology_cache:
+            num_nodes = prefix_len + 1
+            retrieve_next_token = [-1] * num_nodes
+            retrieve_next_sibling = [-1] * num_nodes
+            path_to_node = self._path_to_node(prefix_len)
+            children_by_parent: dict[int, list[int]] = {}
+
+            for node_idx, path in enumerate(self.tree_choices[:prefix_len], start=1):
+                parent_path = path[:-1]
+                if parent_path:
+                    parent_idx = path_to_node.get(parent_path)
+                    if parent_idx is None:
+                        continue
+                else:
+                    parent_idx = 0
+                children_by_parent.setdefault(parent_idx, []).append(node_idx)
+
+            for parent_idx, children in children_by_parent.items():
+                retrieve_next_token[parent_idx] = children[0]
+                for left, right in zip(children, children[1:]):
+                    retrieve_next_sibling[left] = right
+            self._topology_cache[prefix_len] = (
+                torch.tensor(retrieve_next_token, dtype=torch.int64),
+                torch.tensor(retrieve_next_sibling, dtype=torch.int64),
+            )
+        return self._topology_cache[prefix_len]
+
+    def branch_token_indices(self, prefix_len: int) -> list[tuple[int, ...] | None]:
+        """Return draft-token indices needed to reach each node."""
+        if prefix_len not in self._branch_indices_cache:
+            branch_indices: list[tuple[int, ...] | None] = [()] + [None] * prefix_len
+            path_to_node = self._path_to_node(prefix_len)
+            for node_idx, path in enumerate(self.tree_choices[:prefix_len], start=1):
+                indices: list[int] = []
+                for depth in range(1, len(path) + 1):
+                    ancestor_idx = path_to_node.get(path[:depth])
+                    if ancestor_idx is None:
+                        indices = []
+                        break
+                    indices.append(ancestor_idx - 1)
+                else:
+                    branch_indices[node_idx] = tuple(indices)
+            self._branch_indices_cache[prefix_len] = branch_indices
+        return self._branch_indices_cache[prefix_len]
+
+    def _path_to_node(self, prefix_len: int) -> dict[tuple[int, ...], int]:
+        return {
+            path: idx
+            for idx, path in enumerate(self.tree_choices[:prefix_len], start=1)
+        }
 
 
 @dataclass
@@ -71,8 +159,12 @@ class XgrammarBackend(StructuredOutputBackend):
         self.num_speculative_tokens = 0
         if self.vllm_config.speculative_config is not None:
             self.num_speculative_tokens = (
-                self.vllm_config.speculative_config.num_speculative_tokens
+                self.vllm_config.speculative_config.num_speculative_tokens or 0
             )
+        self.draft_tree = _XgrammarDraftTree.from_speculative_config(
+            self.vllm_config.speculative_config,
+            self.num_speculative_tokens,
+        )
 
     def compile_grammar(
         self, request_type: StructuredOutputOptions, grammar_spec: str
@@ -119,6 +211,7 @@ class XgrammarBackend(StructuredOutputBackend):
             ),
             vocab_size=self.vocab_size,
             ctx=ctx,
+            draft_tree=self.draft_tree,
         )
 
     def allocate_token_bitmask(self, max_num_seqs: int):
@@ -140,6 +233,7 @@ class XgrammarGrammar(StructuredOutputGrammar):
     vocab_size: int
     matcher: xgr.GrammarMatcher = field(hash=False)
     ctx: xgr.CompiledGrammar = field(hash=False)
+    draft_tree: _XgrammarDraftTree | None = field(default=None, repr=False, hash=False)
     num_processed_tokens: int = field(
         default_factory=lambda: 0, repr=False, hash=False, init=False
     )
@@ -188,8 +282,84 @@ class XgrammarGrammar(StructuredOutputGrammar):
         self.num_processed_tokens -= num_tokens
         self._is_terminated = self.matcher.is_terminated()
 
-    def fill_bitmask(self, bitmask: torch.Tensor, idx: int) -> None:
-        self.matcher.fill_next_token_bitmask(bitmask, idx)
+    def fill_bitmask(self, bitmask: torch.Tensor, batch_index: int) -> None:
+        self.matcher.fill_next_token_bitmask(bitmask, batch_index)
+
+    def fill_speculative_bitmask(
+        self,
+        bitmask: torch.Tensor,
+        batch_index: int,
+        tokens: list[int],
+        apply_bitmask: bool,
+    ) -> bool:
+        if self.draft_tree is None:
+            return False
+        if len(tokens) > self.draft_tree.num_draft_tokens:
+            return False
+
+        known_len = _get_speculative_prefix_len(tokens)
+        num_rows = len(tokens) + 1
+        rows = bitmask[batch_index : batch_index + num_rows]
+        rows.fill_(-1)
+        if not apply_bitmask or self.is_terminated():
+            return True
+
+        if known_len == 0:
+            self.matcher.fill_next_token_bitmask(bitmask, batch_index)
+            return True
+
+        token_bitmask = bitmask[batch_index : batch_index + known_len + 1]
+        draft_tokens = torch.empty(known_len + 1, dtype=torch.int64)
+        draft_tokens[0] = 0
+        draft_tokens[1:] = torch.tensor(tokens[:known_len], dtype=torch.int64)
+
+        retrieve_next_token, retrieve_next_sibling = self.draft_tree.topology(known_len)
+        try:
+            traverse_completed = self.matcher.fork().traverse_draft_tree(
+                retrieve_next_token,
+                retrieve_next_sibling,
+                draft_tokens,
+                token_bitmask,
+                -1.0,
+            )
+        except RuntimeError:
+            traverse_completed = False
+        if traverse_completed:
+            return True
+
+        self._fill_speculative_bitmask_with_forks(
+            token_bitmask,
+            tokens[:known_len],
+            known_len,
+        )
+        return True
+
+    def _fill_speculative_bitmask_with_forks(
+        self,
+        bitmask: torch.Tensor,
+        tokens: list[int],
+        prefix_len: int,
+    ) -> None:
+        assert self.draft_tree is not None
+        self.matcher.fill_next_token_bitmask(bitmask, 0)
+        branch_token_indices = self.draft_tree.branch_token_indices(prefix_len)
+        for node_idx in range(1, prefix_len + 1):
+            token_indices = branch_token_indices[node_idx]
+            if token_indices is None:
+                bitmask[node_idx].fill_(-1)
+                continue
+
+            matcher = self.matcher.fork()
+            accepted = True
+            for token_idx in token_indices:
+                if not matcher.accept_token(tokens[token_idx]):
+                    accepted = False
+                    break
+
+            if accepted:
+                matcher.fill_next_token_bitmask(bitmask, node_idx)
+            else:
+                bitmask[node_idx].fill_(-1)
 
     def is_terminated(self) -> bool:
         return self._is_terminated
@@ -197,6 +367,13 @@ class XgrammarGrammar(StructuredOutputGrammar):
     def reset(self):
         self.num_processed_tokens = 0
         self.matcher.reset()
+
+
+def _get_speculative_prefix_len(tokens: list[int]) -> int:
+    for idx, token in enumerate(tokens):
+        if token == -1:
+            return idx
+    return len(tokens)
 
 
 # cf https://github.com/mlc-ai/xgrammar/blob/a32ac892676d2eedc0327416105b9b06edfb94b2/cpp/json_schema_converter.cc

--- a/vllm/v1/structured_output/backend_xgrammar.py
+++ b/vllm/v1/structured_output/backend_xgrammar.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import ast
 import json
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
@@ -34,69 +35,60 @@ logger = init_logger(__name__)
 @dataclass
 class _XgrammarDraftTree:
     tree_choices: tuple[tuple[int, ...], ...]
+    _parent_nodes: tuple[int, ...] = field(init=False, repr=False)
     _topology_cache: dict[int, tuple[torch.Tensor, torch.Tensor]] = field(
         default_factory=dict, init=False, repr=False
     )
-    _branch_indices_cache: dict[int, list[tuple[int, ...] | None]] = field(
+    _branch_indices_cache: dict[int, list[tuple[int, ...]]] = field(
         default_factory=dict, init=False, repr=False
     )
+
+    def __post_init__(self) -> None:
+        path_to_node: dict[tuple[int, ...], int] = {}
+        parent_nodes: list[int] = []
+        for node_idx, path in enumerate(self.tree_choices, start=1):
+            parent_nodes.append(0 if len(path) == 1 else path_to_node[path[:-1]])
+            path_to_node[path] = node_idx
+        self._parent_nodes = tuple(parent_nodes)
 
     @property
     def num_draft_tokens(self) -> int:
         return len(self.tree_choices)
 
     def topology(self, prefix_len: int) -> tuple[torch.Tensor, torch.Tensor]:
-        """Return xgrammar child/sibling topology for the requested prefix."""
+        # Return xgrammar child/sibling topology for the requested prefix.
         if prefix_len not in self._topology_cache:
             num_nodes = prefix_len + 1
             retrieve_next_token = [-1] * num_nodes
             retrieve_next_sibling = [-1] * num_nodes
-            path_to_node = self._path_to_node(prefix_len)
-            children_by_parent: dict[int, list[int]] = {}
-
-            for node_idx, path in enumerate(self.tree_choices[:prefix_len], start=1):
-                parent_path = path[:-1]
-                if parent_path:
-                    parent_idx = path_to_node.get(parent_path)
-                    if parent_idx is None:
-                        continue
+            last_child = [-1] * num_nodes
+            for node_idx, parent_idx in enumerate(
+                self._parent_nodes[:prefix_len], start=1
+            ):
+                prev_sibling = last_child[parent_idx]
+                if prev_sibling == -1:
+                    retrieve_next_token[parent_idx] = node_idx
                 else:
-                    parent_idx = 0
-                children_by_parent.setdefault(parent_idx, []).append(node_idx)
-
-            for parent_idx, children in children_by_parent.items():
-                retrieve_next_token[parent_idx] = children[0]
-                for left, right in zip(children, children[1:]):
-                    retrieve_next_sibling[left] = right
+                    retrieve_next_sibling[prev_sibling] = node_idx
+                last_child[parent_idx] = node_idx
             self._topology_cache[prefix_len] = (
                 torch.tensor(retrieve_next_token, dtype=torch.int64),
                 torch.tensor(retrieve_next_sibling, dtype=torch.int64),
             )
         return self._topology_cache[prefix_len]
 
-    def branch_token_indices(self, prefix_len: int) -> list[tuple[int, ...] | None]:
-        """Return draft-token indices needed to reach each node."""
+    def branch_token_indices(self, prefix_len: int) -> list[tuple[int, ...]]:
         if prefix_len not in self._branch_indices_cache:
-            branch_indices: list[tuple[int, ...] | None] = [()] + [None] * prefix_len
-            path_to_node = self._path_to_node(prefix_len)
-            for node_idx, path in enumerate(self.tree_choices[:prefix_len], start=1):
-                indices: list[int] = []
-                for depth in range(1, len(path) + 1):
-                    ancestor_idx = path_to_node.get(path[:depth])
-                    if ancestor_idx is None:
-                        indices = []
-                        break
-                    indices.append(ancestor_idx - 1)
-                else:
-                    branch_indices[node_idx] = tuple(indices)
+            branch_indices: list[tuple[int, ...]] = [()] * (prefix_len + 1)
+            for node_idx, parent_idx in enumerate(
+                self._parent_nodes[:prefix_len], start=1
+            ):
+                branch_indices[node_idx] = (
+                    *branch_indices[parent_idx],
+                    node_idx - 1,
+                )
             self._branch_indices_cache[prefix_len] = branch_indices
         return self._branch_indices_cache[prefix_len]
-
-    def _path_to_node(self, prefix_len: int) -> dict[tuple[int, ...], int]:
-        return {
-            path: idx
-            for idx, path in enumerate(self.tree_choices[:prefix_len], start=1)
-        }
 
 
 @dataclass
@@ -137,13 +129,23 @@ class XgrammarBackend(StructuredOutputBackend):
         )
 
         self.num_speculative_tokens = 0
-        if self.vllm_config.speculative_config is not None:
-            self.num_speculative_tokens = (
-                self.vllm_config.speculative_config.num_speculative_tokens or 0
-            )
-        self.draft_tree = _XgrammarDraftTree(
-            tree_choices=self.vllm_config.speculative_config.speculative_token_tree
-        )
+        self.draft_tree = None
+        speculative_config = self.vllm_config.speculative_config
+        if speculative_config is not None:
+            self.num_speculative_tokens = speculative_config.num_speculative_tokens or 0
+            if self.num_speculative_tokens > 0:
+                # in cases of [ngram], we override speculative_token_tree to None,
+                # but for xgrammar, we would then need to construct it.
+                speculative_token_tree = speculative_config.speculative_token_tree
+                if speculative_token_tree is None:
+                    tree_choices = [
+                        (0,) * (i + 1) for i in range(self.num_speculative_tokens)
+                    ]
+                else:
+                    tree_choices = ast.literal_eval(speculative_token_tree)
+                self.draft_tree = _XgrammarDraftTree(
+                    tree_choices=tuple(tuple(path) for path in tree_choices)
+                )
 
     def compile_grammar(
         self, request_type: StructuredOutputOptions, grammar_spec: str
@@ -276,10 +278,11 @@ class XgrammarGrammar(StructuredOutputGrammar):
         if len(tokens) > self.draft_tree.num_draft_tokens:
             return False
 
-        known_len = _get_speculative_prefix_len(tokens)
-        num_rows = len(tokens) + 1
-        rows = bitmask[batch_index : batch_index + num_rows]
-        rows.fill_(-1)
+        known_len = next(
+            (idx for idx, token in enumerate(tokens) if token == -1),
+            len(tokens),
+        )
+        bitmask[batch_index : batch_index + len(tokens) + 1].fill_(-1)
         if not apply_bitmask or self.is_terminated():
             return True
 
@@ -288,22 +291,16 @@ class XgrammarGrammar(StructuredOutputGrammar):
             return True
 
         token_bitmask = bitmask[batch_index : batch_index + known_len + 1]
-        draft_tokens = torch.empty(known_len + 1, dtype=torch.int64)
-        draft_tokens[0] = 0
-        draft_tokens[1:] = torch.tensor(tokens[:known_len], dtype=torch.int64)
+        draft_tokens = torch.tensor([0, *tokens[:known_len]], dtype=torch.int64)
 
         retrieve_next_token, retrieve_next_sibling = self.draft_tree.topology(known_len)
-        try:
-            traverse_completed = self.matcher.fork().traverse_draft_tree(
-                retrieve_next_token,
-                retrieve_next_sibling,
-                draft_tokens,
-                token_bitmask,
-                -1.0,
-            )
-        except RuntimeError:
-            traverse_completed = False
-        if traverse_completed:
+        if self.matcher.fork().traverse_draft_tree(
+            retrieve_next_token,
+            retrieve_next_sibling,
+            draft_tokens,
+            token_bitmask,
+            -1.0,
+        ):
             return True
 
         self._fill_speculative_bitmask_with_forks(
@@ -323,14 +320,9 @@ class XgrammarGrammar(StructuredOutputGrammar):
         self.matcher.fill_next_token_bitmask(bitmask, 0)
         branch_token_indices = self.draft_tree.branch_token_indices(prefix_len)
         for node_idx in range(1, prefix_len + 1):
-            token_indices = branch_token_indices[node_idx]
-            if token_indices is None:
-                bitmask[node_idx].fill_(-1)
-                continue
-
             matcher = self.matcher.fork()
             accepted = True
-            for token_idx in token_indices:
+            for token_idx in branch_token_indices[node_idx]:
                 if not matcher.accept_token(tokens[token_idx]):
                     accepted = False
                     break
@@ -346,13 +338,6 @@ class XgrammarGrammar(StructuredOutputGrammar):
     def reset(self):
         self.num_processed_tokens = 0
         self.matcher.reset()
-
-
-def _get_speculative_prefix_len(tokens: list[int]) -> int:
-    for idx, token in enumerate(tokens):
-        if token == -1:
-            return idx
-    return len(tokens)
 
 
 # cf https://github.com/mlc-ai/xgrammar/blob/a32ac892676d2eedc0327416105b9b06edfb94b2/cpp/json_schema_converter.cc


### PR DESCRIPTION
Signed-off-by: Aaron Pham <contact@aarnphm.xyz>

This PR adds experimental support for XGrammar's [traverse_draft_trees](https://xgrammar.mlc.ai/docs/api/python/grammar_matcher.html#xgrammar.GrammarMatcher.traverse_draft_tree) in support for both structured outputs and specdec.

I asked Codex to setup a benchmark with numbers comparing main versus this branch implementation, and here's the results

---

## Spec-decode A/B: `kimi_spec_main_95582868e` vs `kimi_spec_feat_traverse_draft_trees_c180f4ded`

- **A** — branch `main` @ `95582868e`
- **B** — branch `feat/traverse_draft_trees` @ `c180f4ded`
- **metrics**: output_throughput, median_itl_ms, median_ttft_ms
- models: moonshotai/Kimi-K2.6, Qwen/Qwen3.6-35B-A3B (for mtp)
- eagle3: lightseekorg/kimi-k2.6-eagle3-mla
- spec: 8xB200

### metric: output_throughput

| method | dataset | qps | A | B | Δ |
| :--- | ---: | ---: | ---: | ---: | ---: |
| eagle3 | json | 1.0 | 247.19 | 239.53 |   -3.1%↓ |
| eagle3 | json | 4.0 | 969.96 | 876.37 |   -9.6%↓ |
| eagle3 | json | 8.0 | 1790.25 | 1641.37 |   -8.3%↓ |
| eagle3 | xgrammar_bench | 1.0 | 295.61 | 296.28 |   +0.2%↑ |
| eagle3 | xgrammar_bench | 4.0 | 1147.96 | 1147.57 |   -0.0%↓ |
| eagle3 | xgrammar_bench | 8.0 | 2123.42 | 2103.89 |   -0.9%↓ |
| mtp | json | 1.0 | 123.37 | 123.36 |   -0.0%↓ |
| mtp | json | 4.0 | 494.72 | 494.78 |   +0.0%↑ |
| mtp | json | 8.0 | 1013.82 | 1013.34 |   -0.0%↓ |
| mtp | xgrammar_bench | 1.0 | 301.51 | 301.49 |   -0.0%↓ |
| mtp | xgrammar_bench | 4.0 | 1191.61 | 1193.04 |   +0.1%↑ |
| mtp | xgrammar_bench | 8.0 | 2332.09 | 2334.35 |   +0.1%↑ |
| ngram | json | 1.0 | 215.02 | 213.61 |   -0.7%↓ |
| ngram | json | 4.0 | 599.20 | 605.17 |   +1.0%↑ |
| ngram | json | 8.0 | 587.80 | 605.60 |   +3.0%↑ |
| ngram | xgrammar_bench | 1.0 | 261.90 | 262.32 |   +0.2%↑ |
| ngram | xgrammar_bench | 4.0 | 408.51 | 419.33 |   +2.6%↑ |
| ngram | xgrammar_bench | 8.0 | 449.65 | 452.06 |   +0.5%↑ |
| ngram_gpu | json | 1.0 | 265.72 | 266.52 |   +0.3%↑ |
| ngram_gpu | json | 4.0 | 969.59 | 959.18 |   -1.1%↓ |
| ngram_gpu | json | 8.0 | 1440.89 | 1433.81 |   -0.5%↓ |
| ngram_gpu | xgrammar_bench | 1.0 | 261.36 | 262.07 |   +0.3%↑ |
| ngram_gpu | xgrammar_bench | 4.0 | 883.85 | 865.76 |   -2.0%↓ |
| ngram_gpu | xgrammar_bench | 8.0 | 1302.49 | 1289.51 |   -1.0%↓ |

### metric: median_itl_ms

| method | dataset | qps | A | B | Δ |
| :--- | ---: | ---: | ---: | ---: | ---: |
| eagle3 | json | 1.0 | 12.74 | 12.71 |   -0.2%↓ |
| eagle3 | json | 4.0 | 18.33 | 17.95 |   -2.1%↓ |
| eagle3 | json | 8.0 | 39.84 | 32.49 |  -18.5%↓ |
| eagle3 | xgrammar_bench | 1.0 | 12.98 | 12.99 |   +0.1%↑ |
| eagle3 | xgrammar_bench | 4.0 | 19.11 | 18.57 |   -2.8%↓ |
| eagle3 | xgrammar_bench | 8.0 | 41.78 | 41.71 |   -0.2%↓ |
| mtp | json | 1.0 | 6.89 | 6.72 |   -2.5%↓ |
| mtp | json | 4.0 | 7.09 | 6.90 |   -2.7%↓ |
| mtp | json | 8.0 | 7.52 | 7.33 |   -2.5%↓ |
| mtp | xgrammar_bench | 1.0 | 6.92 | 6.81 |   -1.6%↓ |
| mtp | xgrammar_bench | 4.0 | 7.35 | 7.17 |   -2.4%↓ |
| mtp | xgrammar_bench | 8.0 | 8.05 | 7.81 |   -2.9%↓ |
| ngram | json | 1.0 | 112.45 | 112.36 |   -0.1%↓ |
| ngram | json | 4.0 | 129.03 | 131.11 |   +1.6%↑ |
| ngram | json | 8.0 | 163.09 | 168.36 |   +3.2%↑ |
| ngram | xgrammar_bench | 1.0 | 113.59 | 113.66 |   +0.1%↑ |
| ngram | xgrammar_bench | 4.0 | 445.37 | 442.97 |   -0.5%↓ |
| ngram | xgrammar_bench | 8.0 | 465.73 | 461.93 |   -0.8%↓ |
| ngram_gpu | json | 1.0 | 41.99 | 42.41 |   +1.0%↑ |
| ngram_gpu | json | 4.0 | 43.80 | 43.87 |   +0.1%↑ |
| ngram_gpu | json | 8.0 | 67.94 | 68.66 |   +1.1%↑ |
| ngram_gpu | xgrammar_bench | 1.0 | 41.77 | 42.66 |   +2.1%↑ |
| ngram_gpu | xgrammar_bench | 4.0 | 44.22 | 43.93 |   -0.6%↓ |
| ngram_gpu | xgrammar_bench | 8.0 | 78.23 | 73.85 |   -5.6%↓ |

### metric: median_ttft_ms

| method | dataset | qps | A | B | Δ |
| :--- | ---: | ---: | ---: | ---: | ---: |
| eagle3 | json | 1.0 | 62.67 | 62.27 |   -0.6%↓ |
| eagle3 | json | 4.0 | 71.62 | 71.65 |   +0.0%↑ |
| eagle3 | json | 8.0 | 135.65 | 109.89 |  -19.0%↓ |
| eagle3 | xgrammar_bench | 1.0 | 77.89 | 77.73 |   -0.2%↓ |
| eagle3 | xgrammar_bench | 4.0 | 78.90 | 74.80 |   -5.2%↓ |
| eagle3 | xgrammar_bench | 8.0 | 139.02 | 129.73 |   -6.7%↓ |
| mtp | json | 1.0 | 43.49 | 42.45 |   -2.4%↓ |
| mtp | json | 4.0 | 67.25 | 65.41 |   -2.7%↓ |
| mtp | json | 8.0 | 76.00 | 74.62 |   -1.8%↓ |
| mtp | xgrammar_bench | 1.0 | 69.24 | 68.77 |   -0.7%↓ |
| mtp | xgrammar_bench | 4.0 | 69.35 | 67.79 |   -2.2%↓ |
| mtp | xgrammar_bench | 8.0 | 105.20 | 95.41 |   -9.3%↓ |
| ngram | json | 1.0 | 169.28 | 167.09 |   -1.3%↓ |
| ngram | json | 4.0 | 221.55 | 217.86 |   -1.7%↓ |
| ngram | json | 8.0 | 245.74 | 235.15 |   -4.3%↓ |
| ngram | xgrammar_bench | 1.0 | 202.45 | 212.84 |   +5.1%↑ |
| ngram | xgrammar_bench | 4.0 | 508.20 | 467.41 |   -8.0%↓ |
| ngram | xgrammar_bench | 8.0 | 336.99 | 354.27 |   +5.1%↑ |
| ngram_gpu | json | 1.0 | 105.15 | 108.64 |   +3.3%↑ |
| ngram_gpu | json | 4.0 | 115.67 | 119.36 |   +3.2%↑ |
| ngram_gpu | json | 8.0 | 175.93 | 183.06 |   +4.0%↑ |
| ngram_gpu | xgrammar_bench | 1.0 | 128.23 | 133.63 |   +4.2%↑ |
| ngram_gpu | xgrammar_bench | 4.0 | 121.75 | 122.78 |   +0.8%↑ |
| ngram_gpu | xgrammar_bench | 8.0 | 194.40 | 177.72 |   -8.6%↓ |

### correct_rate (A → B, pp delta)

| method | dataset | qps | A | B | Δ |
| :--- | ---: | ---: | ---: | ---: | ---: |
| eagle3 | json | 1.0 | 86.5% | 90.0% | +3.5pp↑ |
| eagle3 | json | 4.0 | 89.5% | 90.5% | +1.0pp↑ |
| eagle3 | json | 8.0 | 90.0% | 93.5% | +3.5pp↑ |
| eagle3 | xgrammar_bench | 1.0 | 48.0% | 43.5% | -4.5pp↓ |
| eagle3 | xgrammar_bench | 4.0 | 44.0% | 46.5% | +2.5pp↑ |
| eagle3 | xgrammar_bench | 8.0 | 43.5% | 39.5% | -4.0pp↓ |
| mtp | json | 1.0 | 100.0% | 100.0% | +0.0pp· |
| mtp | json | 4.0 | 99.5% | 99.5% | +0.0pp· |
| mtp | json | 8.0 | 97.0% | 97.0% | +0.0pp· |
| mtp | xgrammar_bench | 1.0 | 20.5% | 20.5% | +0.0pp· |
| mtp | xgrammar_bench | 4.0 | 23.0% | 22.5% | -0.5pp· |
| mtp | xgrammar_bench | 8.0 | 17.5% | 16.0% | -1.5pp↓ |
| ngram | json | 1.0 | 78.0% | 83.5% | +5.5pp↑ |
| ngram | json | 4.0 | 80.0% | 79.5% | -0.5pp· |
| ngram | json | 8.0 | 87.0% | 86.0% | -1.0pp↓ |
| ngram | xgrammar_bench | 1.0 | 43.5% | 40.5% | -3.0pp↓ |
| ngram | xgrammar_bench | 4.0 | 50.0% | 48.5% | -1.5pp↓ |
| ngram | xgrammar_bench | 8.0 | 45.5% | 41.5% | -4.0pp↓ |
| ngram_gpu | json | 1.0 | 75.0% | 74.0% | -1.0pp↓ |
| ngram_gpu | json | 4.0 | 88.0% | 88.0% | +0.0pp· |
| ngram_gpu | json | 8.0 | 88.5% | 89.0% | +0.5pp· |
| ngram_gpu | xgrammar_bench | 1.0 | 46.0% | 38.0% | -8.0pp↓ |
| ngram_gpu | xgrammar_bench | 4.0 | 40.5% | 36.0% | -4.5pp↓ |
| ngram_gpu | xgrammar_bench | 8.0 | 38.5% | 40.0% | +1.5pp↑ |

> JSON-parse correctness regressions (>0.5pp drop)
>
> - eagle3 / xgrammar_bench / qps=1.0: 48.0% → 43.5%
> - eagle3 / xgrammar_bench / qps=8.0: 43.5% → 39.5%
> - mtp / xgrammar_bench / qps=8.0: 17.5% → 16.0%
> - ngram / json / qps=8.0: 87.0% → 86.0%
> - ngram / xgrammar_bench / qps=1.0: 43.5% → 40.5%
> - ngram / xgrammar_bench / qps=4.0: 50.0% → 48.5%
> - ngram / xgrammar_bench / qps=8.0: 45.5% → 41.5%
> - ngram_gpu / json / qps=1.0: 75.0% → 74.0%
> - ngram_gpu / xgrammar_bench / qps=1.0: 46.0% → 38.0%
> - ngram_gpu / xgrammar_bench / qps=4.0: 40.5% → 36.0%

based on this number, goodput does seem to increase
