### PR TITLE
Fix: EngineCore Crash in Mamba Align-Mode Prefix Caching with Speculative Decoding

### DIFF
--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -2,6 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from unittest.mock import MagicMock, patch
 
+import torch
+
+from vllm.model_executor.layers.mamba.mamba_utils import get_temporal_copy_spec
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.worker.mamba_utils import preprocess_mamba
 
@@ -67,3 +70,18 @@ def test_resumed_req_ids_cleared_from_mamba_state_idx():
         )
 
     assert mamba_state_idx == {"keep": 99}
+
+
+def test_get_temporal_copy_spec_clamps_out_of_range_block_index():
+    state = torch.arange(12, dtype=torch.float32).view(3, 4)
+    block_ids = [0, 2]
+
+    copy_spec = get_temporal_copy_spec(
+        state,
+        block_ids,
+        cur_block_idx=1,
+        num_accepted_tokens=2,
+    )
+
+    assert copy_spec.start_addr == state[block_ids[-1]].data_ptr()
+    assert copy_spec.num_elements == state[block_ids[-1]].numel()

--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -2,9 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 from unittest.mock import MagicMock, patch
 
-import torch
-
-from vllm.model_executor.layers.mamba.mamba_utils import get_temporal_copy_spec
 from vllm.v1.core.sched.output import CachedRequestData, SchedulerOutput
 from vllm.v1.worker.mamba_utils import preprocess_mamba
 
@@ -70,18 +67,3 @@ def test_resumed_req_ids_cleared_from_mamba_state_idx():
         )
 
     assert mamba_state_idx == {"keep": 99}
-
-
-def test_get_temporal_copy_spec_clamps_out_of_range_block_index():
-    state = torch.arange(12, dtype=torch.float32).view(3, 4)
-    block_ids = [0, 2]
-
-    copy_spec = get_temporal_copy_spec(
-        state,
-        block_ids,
-        cur_block_idx=1,
-        num_accepted_tokens=2,
-    )
-
-    assert copy_spec.start_addr == state[block_ids[-1]].data_ptr()
-    assert copy_spec.num_elements == state[block_ids[-1]].numel()

--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -335,10 +335,9 @@ def get_temporal_copy_spec(
     num_accepted_tokens: int,
 ) -> MambaCopySpec:
     """Return a MambaCopySpec for copying a temporal state slice."""
-    target_block_idx = cur_block_idx + num_accepted_tokens - 1
-    # In align mode, lookahead tokens may not have backing blocks yet.
-    effective_block_idx = min(target_block_idx, len(block_ids) - 1)
-    src_block_id = block_ids[effective_block_idx]
+    # In align mode we allocate one speculative state block per speculative
+    # token, so advancing by the accepted-token count is intentional here.
+    src_block_id = block_ids[cur_block_idx + num_accepted_tokens - 1]
     src_state = state[src_block_id]
     return MambaCopySpec(
         start_addr=src_state.data_ptr(), num_elements=src_state.numel()

--- a/vllm/model_executor/layers/mamba/mamba_utils.py
+++ b/vllm/model_executor/layers/mamba/mamba_utils.py
@@ -335,7 +335,10 @@ def get_temporal_copy_spec(
     num_accepted_tokens: int,
 ) -> MambaCopySpec:
     """Return a MambaCopySpec for copying a temporal state slice."""
-    src_block_id = block_ids[cur_block_idx + num_accepted_tokens - 1]
+    target_block_idx = cur_block_idx + num_accepted_tokens - 1
+    # In align mode, lookahead tokens may not have backing blocks yet.
+    effective_block_idx = min(target_block_idx, len(block_ids) - 1)
+    src_block_id = block_ids[effective_block_idx]
     src_state = state[src_block_id]
     return MambaCopySpec(
         start_addr=src_state.data_ptr(), num_elements=src_state.numel()


### PR DESCRIPTION
 
## Purpose

Fix EngineCore Crash in Mamba Align-Mode Prefix Caching with Speculative Decoding
issue: https://github.com/vllm-project/vllm/issues/41884


### Scenario

The issue is triggered when all of the following are true:
  - A Mamba / linear-attention model is used
  - Prefix caching is enabled
  - mamba_cache_mode="align" is active
  - Speculative decoding is enabled
  - A decode step accepts enough tokens that temporal-state lookup advances past the currently allocated backing blocks

  This is most likely to happen in align mode because lookahead tokens may not have backing blocks allocated yet.
  During inference, EngineCore crashes with:
         IndexError: list index out of range

  The crash happens in get_temporal_copy_spec() when evaluating:

  block_ids[cur_block_idx + num_accepted_tokens - 1]

  Operationally, this can propagate upward as an EngineCore failure and may bring down the API server process.

  If speculative decoding requires a temporal-state block index beyond the currently available block_ids, the code should handle it defensively and degrade  gracefully instead of throwing an exception and terminating inference.

###  Root Cause

  get_temporal_copy_spec() assumed that:

  cur_block_idx + num_accepted_tokens - 1

  always points to a valid entry in block_ids.

  That assumption is not always valid in mamba_cache_mode="align" with speculative decoding, because align mode intentionally does not guarantee backing blocks for lookahead tokens. As a result, temporal-state copy can request a block index beyond the actual length of block_ids, causing an out-of-range  access.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

