### PR TITLE
docs: document NIXL KV connector metrics aggregation semantics

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/metrics.py
@@ -51,6 +51,38 @@ class KVConnectorStats:
 
 
 class KVConnectorLogging:
+    """Manages the observe → aggregate → reduce → log pipeline for KV transfer metrics.
+
+    **Data flow**
+
+    1. **observe()**: Called periodically when the KV connector syncs with the
+       scheduler. Receives ``transfer_stats_data`` that has **already been
+       aggregated across all TP ranks** by the scheduler. Builds a
+       ``KVConnectorStats`` object and accumulates it into
+       ``transfer_stats_accumulator``.
+
+    2. **aggregate()**: Stats from consecutive ``observe()`` calls are merged
+       into the accumulator. This pools all individual
+       transfer observations across ranks and time intervals.
+
+    3. **reduce()**: Called by :meth:`log()` to compute summary statistics
+       (averages, percentiles, throughput) over the combined observation pool.
+       See :class:`~vllm.distributed.kv_transfer.kv_connector.v1.nixl.stats.NixlKVConnectorStats`
+       for multi-rank aggregation semantics.
+
+    4. **log()**: Formats the reduced metrics into a single log line:
+
+       .. code-block:: text
+
+           KV Transfer metrics: Num successful transfers=4, Avg xfer time (ms)=1.381, ...
+
+       Then resets the accumulator for the next interval.
+
+    **Important**: The ``transfer_stats_data`` received by ``observe()`` is
+    pre-aggregated across workers by the scheduler. It only sees the combined pool of observations. This is a deliberate
+    fire-and-forget design to avoid coordination overhead.
+    """
+
     def __init__(self, kv_transfer_config: KVTransferConfig | None):
         # Instantiate the connector's stats class.
         if kv_transfer_config and kv_transfer_config.kv_connector:
@@ -63,12 +95,19 @@ class KVConnectorLogging:
         self.transfer_stats_accumulator: KVConnectorStats | None = None
 
     def observe(self, transfer_stats_data: dict[str, Any]):
+        """Accumulate transfer stats from a connector sync cycle.
+
+        Args:
+            transfer_stats_data: Stats pre-aggregated across all TP ranks
+                by the scheduler. Contains lists of per-transfer
+                observations (transfer_duration, post_duration, bytes, etc.).
+        """
         # Should not be called when a KVConnector is not configured.
         assert self.connector_cls is not None
         # Called periodically when connector syncs with the scheduler.
         # Note that this is not the same as the logging interval.
-        # We expect transfer_stats_data to be aggregated across all workers and
-        # consist of observations from a single connector or a MultiConnector.
+        # transfer_stats_data is already aggregated across all TP ranks by the scheduler;
+        # we pool all observations together for later reduction.
         transfer_stats = self.connector_cls.build_kv_connector_stats(
             transfer_stats_data
         )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/stats.py
@@ -21,7 +21,42 @@ from vllm.v1.metrics.utils import create_metric_per_engine
 
 @dataclass
 class NixlKVConnectorStats(KVConnectorStats):
-    """Container for transfer performance metrics"""
+    """Container for NIXL KV cache transfer performance metrics.
+
+    **Multi-rank (TP > 1) aggregation semantics**
+
+    In tensor-parallel deployments (TP > 1), each TP rank independently records
+    per-transfer telemetry via :meth:`record_transfer`. Stats from all ranks are
+    then concatenated via :meth:`aggregate` (``list.extend()``), and summary
+    statistics are computed over the **combined pool** of observations in
+    :meth:`reduce`.
+
+    This means:
+
+    - **Num successful transfers**: total count across all TP ranks, not per-rank.
+    - **Avg MB per transfer**: average over all individual rank-level transfers,
+      not the total bytes moved for a single KV cache transfer operation.
+    - **Throughput (MB/s)**: ``total_MB_all_ranks / total_time_all_ranks``.
+      This is an average per-rank throughput, **not** the aggregate system
+      throughput. For example, with 2 ranks each transferring 100 MB/s, the
+      reported throughput will be ~100 MB/s (the average), not 200 MB/s.
+    - **P90 percentiles**: computed over the combined distribution of all ranks'
+      transfer times, not per-rank percentiles.
+
+    This design is deliberate: workers report stats fire-and-forget to the
+    scheduler, which then aggregates. Per-rank reporting would require
+    additional coordination.
+
+    Each metric field records:
+
+    - ``transfer_duration``: time spent on the actual data transfer (seconds).
+    - ``post_duration``: time spent posting the transfer request (seconds).
+    - ``bytes_transferred``: total bytes transferred per operation.
+    - ``num_descriptors``: number of NIXL descriptors per transfer.
+    - ``num_failed_transfers``: count of failed transfer operations.
+    - ``num_failed_notifications``: count of failed notification sends.
+    - ``num_kv_expired_reqs``: count of requests whose KV blocks expired.
+    """
 
     def __post_init__(self):
         if not self.data:
@@ -105,9 +140,16 @@ class NixlKVConnectorStats(KVConnectorStats):
         n = len(descs)
         assert n == self.num_successful_transfers
 
+        # total_mb is the sum of bytes across ALL ranks (not per-rank total).
         total_mb = mb.sum()
+        # avg_mb is the average bytes per individual transfer operation
+        # (each entry in the combined pool is one rank's transfer).
         avg_mb = total_mb / n
 
+        # total_time_seconds is the sum of all transfer durations across all ranks.
+        # throughput_mb_s = total_MB_all_ranks / total_time_all_ranks.
+        # This represents the average per-rank throughput, NOT aggregate system
+        # throughput. With N ranks each at X MB/s, the reported value is ~X MB/s.
         total_time_seconds = xfer_time.sum()
         throughput_mb_s = total_mb / total_time_seconds
 


### PR DESCRIPTION
## Summary

Document how NIXL KV connector metrics are aggregated across TP ranks in
multi-rank deployments. This has caused confusion among users who expect
metrics to reflect per-engine totals or aggregate system throughput.

## Changes

### 

- Added comprehensive class docstring to  explaining:
  - Multi-rank (TP > 1) aggregation semantics
  - What each metric represents in the context of combined observations
  - Clarification that throughput is average per-rank, not aggregate system throughput
  - List of all metric fields and their meanings

- Added inline comments in  clarifying:
  -  is sum across ALL ranks
  -  is average per individual transfer operation
  -  is average per-rank throughput, not aggregate

### 

- Added class docstring to  explaining the full pipeline:
  -  →  →  → 
  - Data is pre-aggregated across workers before reaching the scheduler
  - Fire-and-forget design rationale

- Added docstring to  clarifying the pre-aggregated data flow

## Context

See issue #41230 for the original discussion. This is a documentation-only
change — no behavior is modified.

## Testing

- No code changes, documentation only
- Verified docstrings render correctly with Sphinx-style formatting