### PR TITLE
[vLLM IR] port activation ops (fatrelu_and_mul, relu2, gelu_and_mul_sparse, swigluoai_and_mul)

### DIFF
--- a/vllm/config/kernel.py
+++ b/vllm/config/kernel.py
@@ -34,6 +34,12 @@ class IrOpPriorityConfig:
     fused_add_rms_norm: list[str] = Field(default_factory=list)
     """Priority list for vllm.ir.ops.fused_add_rms_norm"""
 
+    fatrelu_and_mul: list[str] = Field(default_factory=list)
+    """Priority list for vllm.ir.ops.fatrelu_and_mul"""
+
+    swigluoai_and_mul: list[str] = Field(default_factory=list)
+    """Priority list for vllm.ir.ops.swigluoai_and_mul"""
+
     def compute_hash(self) -> str:
         """
         Produces a hash unique to the pass configuration.

--- a/vllm/ir/ops/__init__.py
+++ b/vllm/ir/ops/__init__.py
@@ -1,5 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from .activation import fatrelu_and_mul, gelu_and_mul_sparse, relu2, swigluoai_and_mul
 from .layernorm import fused_add_rms_norm, rms_norm
 
-__all__ = ["rms_norm", "fused_add_rms_norm"]
+__all__ = [
+    "rms_norm",
+    "fused_add_rms_norm",
+    "fatrelu_and_mul",
+    "relu2",
+    "gelu_and_mul_sparse",
+    "swigluoai_and_mul",
+]

--- a/vllm/ir/ops/activation.py
+++ b/vllm/ir/ops/activation.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from ..op import register_op
+
+
+@register_op
+def fatrelu_and_mul(x: Tensor, threshold: float = 0.0) -> Tensor:
+    """FATReLU gated activation: threshold(x[:d]) * x[d:]
+
+    Computes FATReLU(x[:d]) * x[d:] where FATReLU zeros values below threshold.
+    Used in openbmb/MiniCPM-S-1B-sft.
+
+    Shapes:
+        x: (..., 2 * d)
+        return: (..., d)
+    """
+    d = x.shape[-1] // 2
+    return F.threshold(x[..., :d], threshold, 0.0) * x[..., d:]
+
+
+@fatrelu_and_mul.register_input_generator
+def _fatrelu_and_mul_input_generator(
+    num_tokens: int, hidden_size: int, dtype: torch.dtype, threshold: float = 0.0
+) -> tuple:
+    x = torch.randn(num_tokens, hidden_size * 2, dtype=dtype)
+    return (x, threshold)
+
+
+@register_op
+def relu2(x: Tensor) -> Tensor:
+    """ReLU-squared activation: relu(x)^2
+
+    Applies the relu^2 activation introduced in https://arxiv.org/abs/2109.08668v2
+
+    Shapes:
+        x: (..., d)
+        return: (..., d)
+    """
+    return torch.square(F.relu(x))
+
+
+@relu2.register_input_generator
+def _relu2_input_generator(
+    num_tokens: int, hidden_size: int, dtype: torch.dtype
+) -> tuple:
+    x = torch.randn(num_tokens, hidden_size, dtype=dtype)
+    return (x,)
+
+
+@register_op
+def gelu_and_mul_sparse(
+    x: Tensor, std_multiplier: float, approximate: str = "none"
+) -> Tensor:
+    """Sparse GeGLU activation: gelu(gaussian_topk(x[:d])) * x[d:]
+
+    Applies a Gaussian-based top-k sparsification to the gate before GELU.
+    Used in Gemma3n models.
+
+    Args:
+        x: Input tensor with shape (..., 2 * d)
+        std_multiplier: Threshold multiplier derived from target sparsity via
+            normal distribution icdf (normal_dist.icdf(activation_sparsity)).
+        approximate: GELU approximation mode, 'none' or 'tanh'.
+
+    Shapes:
+        x: (..., 2 * d)
+        return: (..., d)
+    """
+    d = x.shape[-1] // 2
+    gate = x[..., :d]
+    mean = torch.mean(gate, dim=-1, keepdim=True)
+    std = torch.std(gate, dim=-1, keepdim=True, unbiased=False)
+    sparse_gate = F.relu(gate - (mean + std * std_multiplier))
+    return F.gelu(sparse_gate, approximate=approximate) * x[..., d:]
+
+
+@gelu_and_mul_sparse.register_input_generator
+def _gelu_and_mul_sparse_input_generator(
+    num_tokens: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    std_multiplier: float = 1.28,
+    approximate: str = "none",
+) -> tuple:
+    # std_multiplier=1.28 corresponds to ~90% sparsity (icdf(0.9) ≈ 1.28)
+    x = torch.randn(num_tokens, hidden_size * 2, dtype=dtype)
+    return (x, std_multiplier, approximate)
+
+
+@register_op
+def swigluoai_and_mul(x: Tensor, alpha: float = 1.702, limit: float = 7.0) -> Tensor:
+    """SwiGLU-OAI gated activation with clamping, interleaved input layout.
+
+    Computes (up + 1) * (gate * sigmoid(alpha * gate)) where gate/up are
+    interleaved: gate = x[..., ::2], up = x[..., 1::2], with clamping.
+    Reference: https://github.com/huggingface/transformers/blob/v4.55.0/src/
+    transformers/models/gpt_oss/modeling_gpt_oss.py#L106-L110
+
+    Shapes:
+        x: (..., 2 * d)  — interleaved gate/up layout
+        return: (..., d)
+    """
+    gate, up = x[..., ::2], x[..., 1::2]
+    gate = gate.clamp(max=limit)
+    up = up.clamp(min=-limit, max=limit)
+    return (up + 1) * (gate * torch.sigmoid(alpha * gate))
+
+
+@swigluoai_and_mul.register_input_generator
+def _swigluoai_and_mul_input_generator(
+    num_tokens: int,
+    hidden_size: int,
+    dtype: torch.dtype,
+    alpha: float = 1.702,
+    limit: float = 7.0,
+) -> tuple:
+    x = torch.randn(num_tokens, hidden_size * 2, dtype=dtype)
+    return (x, alpha, limit)

--- a/vllm/kernels/vllm_c.py
+++ b/vllm/kernels/vllm_c.py
@@ -61,3 +61,21 @@ def fused_add_rms_norm(
     assert variance_size is None
     torch.ops._C.fused_add_rms_norm(x, x_residual, weight, epsilon)
     return x, x_residual
+
+
+@ir.ops.fatrelu_and_mul.register_impl("vllm_c", supported=CUDA_ALIKE)
+def fatrelu_and_mul(x: Tensor, threshold: float = 0.0) -> Tensor:
+    d = x.shape[-1] // 2
+    output_shape = x.shape[:-1] + (d,)
+    out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+    torch.ops._C.fatrelu_and_mul(out, x, threshold)
+    return out
+
+
+@ir.ops.swigluoai_and_mul.register_impl("vllm_c", supported=CUDA_ALIKE)
+def swigluoai_and_mul(x: Tensor, alpha: float = 1.702, limit: float = 7.0) -> Tensor:
+    d = x.shape[-1] // 2
+    output_shape = x.shape[:-1] + (d,)
+    out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
+    torch.ops._C.swigluoai_and_mul(out, x, alpha, limit)
+    return out

--- a/vllm/model_executor/layers/activation.py
+++ b/vllm/model_executor/layers/activation.py
@@ -8,6 +8,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from vllm import ir
 from vllm.distributed import (
     divide,
     get_tensor_model_parallel_rank,
@@ -93,24 +94,13 @@ class FatreluAndMul(CustomOp):
     def __init__(self, threshold: float = 0.0):
         super().__init__()
         self.threshold = threshold
-        if current_platform.is_cuda_alike():
-            self.op = torch.ops._C.fatrelu_and_mul
-        elif current_platform.is_cpu():
-            self._forward_method = self.forward_native
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
-        d = x.shape[-1] // 2
-        x1 = x[..., :d]
-        x2 = x[..., d:]
-        x1 = F.threshold(x1, self.threshold, 0.0)
-        return x1 * x2
+        """PyTorch-native implementation equivalent to forward()."""
+        return ir.ops.fatrelu_and_mul(x, self.threshold)
 
     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
-        d = x.shape[-1] // 2
-        output_shape = x.shape[:-1] + (d,)
-        out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
-        self.op(out, x, self.threshold)
-        return out
+        return self.forward_native(x)
 
 
 # --8<-- [start:silu_and_mul]
@@ -280,10 +270,7 @@ class GeluAndMulSparse(CustomOp):
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
         """PyTorch-native implementation equivalent to forward()."""
-        d = x.shape[-1] // 2
-        out = self._gaussian_topk(x[..., :d])
-        out = F.gelu(out, approximate=self.approximate)
-        return out * x[..., d:]
+        return ir.ops.gelu_and_mul_sparse(x, self.std_multiplier, self.approximate)
 
     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
         return self.forward_native(x)
@@ -388,20 +375,10 @@ class SwigluOAIAndMul(CustomOp):
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
         """PyTorch-native implementation equivalent to forward()."""
-
-        gate, up = x[..., ::2], x[..., 1::2]
-        gate = gate.clamp(min=None, max=self.limit)
-        up = up.clamp(min=-self.limit, max=self.limit)
-        glu = gate * torch.sigmoid(gate * self.alpha)
-        gated_output = (up + 1) * glu
-        return gated_output
+        return ir.ops.swigluoai_and_mul(x, self.alpha, self.limit)
 
     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
-        d = x.shape[-1] // 2
-        output_shape = x.shape[:-1] + (d,)
-        out = torch.empty(output_shape, dtype=x.dtype, device=x.device)
-        torch.ops._C.swigluoai_and_mul(out, x, self.alpha, self.limit)
-        return out
+        return self.forward_native(x)
 
     def extra_repr(self) -> str:
         return f"alpha={repr(self.alpha)}, limit={repr(self.limit)}"
@@ -539,7 +516,7 @@ class ReLUSquaredActivation(CustomOp):
 
     def forward_native(self, x: torch.Tensor) -> torch.Tensor:
         """PyTorch-native implementation equivalent to forward()."""
-        return torch.square(F.relu(x))
+        return ir.ops.relu2(x)
 
     def forward_cuda(self, x: torch.Tensor) -> torch.Tensor:
         # TODO : implement cuda kernels


### PR DESCRIPTION
## Purpose
Port four activation  CustomOp implementations to the vLLM IR op framework, following the pattern established for rms_norm /fused_add_rms_norm.
## Test Plan

- Existing tests in tests/kernels/core/test_activation.pycover theCustomOplayer end-to-end (correctness + opcheck) for all four ops

- tests/kernels/ir/test_layernorm.pyandtests/kernels/ir/test_ir_ops.pyserve as the reference pattern for IR op testing; the IR op layer itself is exercised transitively through theCustomOptests above

## Test Result
All existing activation tests pass without modification.

## Related
https://github.com/vllm-project/vllm/issues/32676