### PR TITLE
kimi pd pegaflow v0.20.1

### DIFF
--- a/KIMI_PD_PEGAFLOW_RUNBOOK.md
+++ b/KIMI_PD_PEGAFLOW_RUNBOOK.md
@@ -421,6 +421,18 @@ Target image:
 image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test
 ```
 
+Current versioned tag:
+
+```text
+image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test-v1
+```
+
+Next image version:
+
+```text
+v2
+```
+
 Final known digest:
 
 ```text
@@ -477,6 +489,138 @@ The validated image keeps the base image deep_ep version:
 1.2.1+73b6ea4
 ```
 
+### Image Versioning Policy
+
+Every new image build must have a monotonically increasing versioned tag:
+
+```text
+image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test-v<N>
+```
+
+Rules:
+
+- Do not reuse old version tags.
+- Keep `kimi-llmd-test` as the moving "latest test" tag.
+- Build and push the versioned tag first.
+- After verifying the versioned image, move `kimi-llmd-test` to the same image
+  only if this version should become the current test image.
+- Update this runbook after every build. Record:
+  - versioned tag,
+  - moving tag if updated,
+  - registry digest,
+  - build-server image id,
+  - vLLM commit,
+  - PegaFlow commit,
+  - patch file counts,
+  - build command,
+  - verification command and result,
+  - short change summary.
+
+Future build command pattern:
+
+```bash
+cd /Users/ppio-dn-289/Documents/dynamo-vllm-workspace
+
+VERSION=v2
+
+./build/build-vllm-pegaflow.sh \
+  --image image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test-${VERSION} \
+  --vllm-wt /Users/ppio-dn-289/Documents/llmd-vllm-workspace/vllm-kimi-pd-pegaflow \
+  --push
+```
+
+If the version should also become the moving test tag:
+
+```bash
+ssh build-server 'set -e
+VERSION=v2
+docker tag \
+  image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test-${VERSION} \
+  image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test
+docker push image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test
+'
+```
+
+### Image Build History
+
+#### v1 - 2026-04-29
+
+Tags:
+
+```text
+image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test-v1
+image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test
+```
+
+Digest:
+
+```text
+image.paigpu.com/library/vllm-with-pegaflow@sha256:de0f2541cda799cde8717e7f94abb71f4edf147bd8bab851fcc56094dc51c19c
+```
+
+Build-server image id:
+
+```text
+sha256:91711c883d9a9a6c10dc02f3874e7ae19e2381db6e51f9d442def3d4d33ec6ee
+```
+
+Source commits:
+
+```text
+vLLM:    a1cb3d2ce fix(spec_decode): allow reasoning logits processor
+PegaFlow: ba60953 fix(connector): import NIXL connector from vLLM 0.20 package
+```
+
+Patch counts:
+
+```text
+vllm -> 15 files
+pegaflow -> 5 files
+DeepEP whl: not provided, base image keeps deep_ep 1.2.1+73b6ea4
+```
+
+Build commands:
+
+```bash
+cd /Users/ppio-dn-289/Documents/dynamo-vllm-workspace
+
+./build/build-vllm-pegaflow.sh \
+  --image image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test \
+  --vllm-wt /Users/ppio-dn-289/Documents/llmd-vllm-workspace/vllm-kimi-pd-pegaflow \
+  --push
+
+ssh build-server 'set -e
+docker tag \
+  image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test \
+  image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test-v1
+docker push image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test-v1
+'
+```
+
+Change summary:
+
+```text
+Includes all prior Kimi params/tool-parser, logit_bias/spec-decode, NIXL PP,
+metrics, and PegaFlow PD connector patches. Adds the spec-decode startup fix
+for explicit ReasoningLogitsProcessor and applies its spec-decode hook in the
+rejection sampler.
+```
+
+Verification:
+
+```text
+Server unit test:
+PYTHONPATH=. /ppio1/venvs/vllm-kimi-pd-v0.20/bin/python -m pytest \
+  tests/v1/sample/test_rejection_sampler.py -v
+Result: 71 passed, 16 warnings
+
+Image source check:
+spec_decode_processors ['MinTokensLogitsProcessor', 'LogitBiasLogitsProcessor', 'ReasoningLogitsProcessor']
+reasoning_has_spec_hook True
+rejection_uses_hook True
+deep_ep_version 1.2.1+73b6ea4
+```
+
 ### Patch Files Included in the Image
 
 vLLM patch list:
@@ -530,8 +674,10 @@ Always dry-run first:
 ```bash
 cd /Users/ppio-dn-289/Documents/dynamo-vllm-workspace
 
+VERSION=v2
+
 ./build/build-vllm-pegaflow.sh \
-  --image image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test \
+  --image image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test-${VERSION} \
   --vllm-wt /Users/ppio-dn-289/Documents/llmd-vllm-workspace/vllm-kimi-pd-pegaflow \
   --dry-run
 ```
@@ -552,8 +698,10 @@ worktree.
 ```bash
 cd /Users/ppio-dn-289/Documents/dynamo-vllm-workspace
 
+VERSION=v2
+
 ./build/build-vllm-pegaflow.sh \
-  --image image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test \
+  --image image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test-${VERSION} \
   --vllm-wt /Users/ppio-dn-289/Documents/llmd-vllm-workspace/vllm-kimi-pd-pegaflow \
   --push
 ```
@@ -571,12 +719,17 @@ The script will:
 Run:
 
 ```bash
+VERSION=v2
+
 ssh build-server 'docker run --rm -i --entrypoint python3 \
-  image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test - << "PY"
+  image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test-'"${VERSION}"' - << "PY"
 import importlib.metadata
 import inspect
 import vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata as metadata
 import vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker as worker
+import vllm.v1.sample.logits_processor as logits_processor
+import vllm.v1.sample.logits_processor.builtin as builtin
+import vllm.v1.sample.rejection_sampler as rejection_sampler
 from pegaflow.connector.pd_connector import PegaPdConnector
 
 print("vllm_version", importlib.metadata.version("vllm"))
@@ -584,6 +737,9 @@ print("nixl_connector_version", metadata.NIXL_CONNECTOR_VERSION)
 print("worker_file", inspect.getfile(worker))
 print("has_region_mapper", hasattr(worker.NixlConnectorWorker, "_get_local_region_ids_for_remote_stage"))
 print("pegaflow_pd_connector", PegaPdConnector.__name__)
+print("spec_decode_processors", [c.__name__ for c in logits_processor.SPEC_DECODE_LOGITS_PROCESSORS])
+print("reasoning_has_spec_hook", hasattr(builtin.ReasoningLogitsProcessor, "apply_with_spec_decode"))
+print("rejection_uses_hook", "apply_with_spec_decode" in inspect.getsource(rejection_sampler.RejectionSampler.apply_logits_processors))
 try:
     print("deep_ep_version", importlib.metadata.version("deep_ep"))
 except importlib.metadata.PackageNotFoundError:
@@ -599,6 +755,9 @@ nixl_connector_version 3
 worker_file /usr/local/lib/python3.12/dist-packages/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
 has_region_mapper True
 pegaflow_pd_connector PegaPdConnector
+spec_decode_processors ['MinTokensLogitsProcessor', 'LogitBiasLogitsProcessor', 'ReasoningLogitsProcessor']
+reasoning_has_spec_hook True
+rejection_uses_hook True
 deep_ep_version 1.2.1+73b6ea4
 ```
 

--- a/KIMI_PD_PEGAFLOW_RUNBOOK.md
+++ b/KIMI_PD_PEGAFLOW_RUNBOOK.md
@@ -1,0 +1,719 @@
+# Kimi PD PegaFlow Runbook
+
+This runbook is the persistent handoff for this worktree. Read it first when
+opening a new session in:
+
+```text
+/Users/ppio-dn-289/Documents/llmd-vllm-workspace/vllm-kimi-pd-pegaflow
+```
+
+It records where code should be pushed, how to sync code to the test server,
+how to run unit and end-to-end tests, and how to build the patched
+`vllm-with-pegaflow` image.
+
+## Current Source State
+
+### vLLM Worktree
+
+```text
+Local path:
+/Users/ppio-dn-289/Documents/llmd-vllm-workspace/vllm-kimi-pd-pegaflow
+
+Branch:
+kimi-pd-pegaflow-v0.20
+
+Base:
+vLLM v0.20.0
+
+Latest known HEAD:
+ccd9b95e8 fix(engine): keep idle polling on unfinished requests
+```
+
+Remotes:
+
+```text
+origin  https://github.com/wz1qqx/vllm.git
+novita  https://github.com/novitalabs/vllm-int.git
+upstream https://github.com/vllm-project/vllm.git
+```
+
+Push local commits to both active remotes:
+
+```bash
+git push origin kimi-pd-pegaflow-v0.20
+git push novita kimi-pd-pegaflow-v0.20
+```
+
+The branch should usually be aligned like this:
+
+```text
+HEAD == origin/kimi-pd-pegaflow-v0.20 == novita/kimi-pd-pegaflow-v0.20
+```
+
+Check:
+
+```bash
+git status --short --branch
+git log --oneline -8 --decorate
+git ls-remote origin refs/heads/kimi-pd-pegaflow-v0.20
+git ls-remote novita refs/heads/kimi-pd-pegaflow-v0.20
+```
+
+### PegaFlow Worktree
+
+The image build also overlays PegaFlow patches from a separate worktree:
+
+```text
+Local path:
+/Users/ppio-dn-289/Documents/dynamo-vllm-workspace/pegaflow-kimi-pd-pegaflow
+
+Branch:
+kimi-pd-pegaflow
+
+Base:
+338c426 / tag v0.0.20
+
+Latest known HEAD:
+ba60953 fix(connector): import NIXL connector from vLLM 0.20 package
+```
+
+Remotes:
+
+```text
+origin   https://github.com/wz1qqx/pegaflow.git
+upstream https://github.com/novitalabs/pegaflow.git
+```
+
+Push PegaFlow commits to both active remotes:
+
+```bash
+cd /Users/ppio-dn-289/Documents/dynamo-vllm-workspace/pegaflow-kimi-pd-pegaflow
+git push origin kimi-pd-pegaflow
+git push upstream kimi-pd-pegaflow
+```
+
+## Important Commits
+
+Recent vLLM commit stack:
+
+```text
+ccd9b95e8 fix(engine): keep idle polling on unfinished requests
+a1c8dc5cc fix(metrics): compute TTFT prompt length from prefill stats
+65c7265b4 fix(nixl): align PP stage descriptors by region label
+0e469d0b0 fix(nixl): wire PP metadata and handshake targets for kv transfer
+a93d2e44f fix(tests): use create_spec_decode_metadata in logit bias spec decode tests
+cf03bdd77 test: update test_nixl_connector_pp to use v0.20.0 TransferTopology API
+fa737bf43 feat(spec_decode): add LogitBiasLogitsProcessor.apply_with_spec_decode()
+71be30fa7 fix(tests): adapt kimi test fixtures for vllm v0.20.0 API changes
+```
+
+Recent PegaFlow commit stack:
+
+```text
+ba60953 fix(connector): import NIXL connector from vLLM 0.20 package
+0ff6175 fix(connector): add pp_size to namespace and fix unregister guard for PP
+1074b90 style(connector): fix ruff lint errors in pd_connector
+82d68de feat(connector): add PegaPdConnector for Dynamo PD disaggregated serving
+338c426 feat(connector): switch most connector logs to debug and bump 0.20.0 (#221)
+```
+
+## Development Rules for This Worktree
+
+Follow the repository `AGENTS.md`.
+
+Key local rules:
+
+- Do not use system `python3` or bare `pip` for vLLM tests.
+- Use the server venv Python for server-side validation:
+
+```text
+/ppio1/venvs/vllm-kimi-pd-v0.20/bin/python
+```
+
+- Keep unrelated local changes out of commits unless explicitly asked.
+- For this branch, push committed code to both:
+
+```text
+origin/kimi-pd-pegaflow-v0.20
+novita/kimi-pd-pegaflow-v0.20
+```
+
+## Server Test Environment
+
+SSH target:
+
+```text
+root@10.121.196.3
+```
+
+Server source directory:
+
+```text
+/ppio1/vllm-kimi-src
+```
+
+Server venv:
+
+```text
+/ppio1/venvs/vllm-kimi-pd-v0.20
+```
+
+Python:
+
+```text
+/ppio1/venvs/vllm-kimi-pd-v0.20/bin/python
+```
+
+vLLM CLI:
+
+```text
+/ppio1/venvs/vllm-kimi-pd-v0.20/bin/vllm
+```
+
+NIXL is installed in this venv. Check with:
+
+```bash
+ssh root@10.121.196.3 \
+  'source /ppio1/venvs/vllm-kimi-pd-v0.20/bin/activate && python -c "import nixl; print(nixl.__file__)"'
+```
+
+## Syncing Local vLLM Code to the Server
+
+The server source directory is not assumed to be a git checkout. Use `rsync`.
+
+From the local vLLM worktree:
+
+```bash
+cd /Users/ppio-dn-289/Documents/llmd-vllm-workspace/vllm-kimi-pd-pegaflow
+```
+
+Sync the current patched production and test files:
+
+```bash
+rsync -av --relative \
+  vllm/distributed/kv_transfer/kv_connector/utils.py \
+  vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py \
+  vllm/distributed/kv_transfer/kv_connector/v1/nixl/scheduler.py \
+  vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py \
+  vllm/v1/worker/gpu_worker.py \
+  vllm/v1/metrics/stats.py \
+  vllm/v1/core/sched/scheduler.py \
+  vllm/v1/engine/coordinator.py \
+  vllm/v1/engine/core.py \
+  vllm/v1/worker/ubatching.py \
+  tests/v1/kv_connector/unit/test_nixl_connector.py \
+  tests/v1/kv_connector/unit/test_nixl_connector_pp.py \
+  tests/tool_parsers/test_kimi_k2_tool_parser.py \
+  tests/entrypoints/openai/test_kimi_params_validation.py \
+  tests/v1/sample/test_rejection_sampler.py \
+  root@10.121.196.3:/ppio1/vllm-kimi-src/
+```
+
+For production service runs, syncing to `/ppio1/vllm-kimi-src` is not enough.
+Patch the venv site-packages too:
+
+```bash
+ssh root@10.121.196.3 'set -e
+VENV=/ppio1/venvs/vllm-kimi-pd-v0.20/lib/python3.12/site-packages
+SRC=/ppio1/vllm-kimi-src
+
+cp $SRC/vllm/distributed/kv_transfer/kv_connector/utils.py \
+  $VENV/vllm/distributed/kv_transfer/kv_connector/utils.py
+cp $SRC/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py \
+  $VENV/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+cp $SRC/vllm/distributed/kv_transfer/kv_connector/v1/nixl/scheduler.py \
+  $VENV/vllm/distributed/kv_transfer/kv_connector/v1/nixl/scheduler.py
+cp $SRC/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py \
+  $VENV/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+cp $SRC/vllm/v1/worker/gpu_worker.py \
+  $VENV/vllm/v1/worker/gpu_worker.py
+cp $SRC/vllm/v1/metrics/stats.py \
+  $VENV/vllm/v1/metrics/stats.py
+cp $SRC/vllm/v1/core/sched/scheduler.py \
+  $VENV/vllm/v1/core/sched/scheduler.py
+cp $SRC/vllm/v1/engine/coordinator.py \
+  $VENV/vllm/v1/engine/coordinator.py
+cp $SRC/vllm/v1/engine/core.py \
+  $VENV/vllm/v1/engine/core.py
+cp $SRC/vllm/v1/worker/ubatching.py \
+  $VENV/vllm/v1/worker/ubatching.py
+'
+```
+
+Verify the server venv is loading the patched NIXL files:
+
+```bash
+ssh root@10.121.196.3 'cd /ppio1/vllm-kimi-src && /ppio1/venvs/vllm-kimi-pd-v0.20/bin/python - << "PY"
+import inspect
+import vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker as w
+import vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata as m
+print("worker", inspect.getfile(w))
+print("metadata_version", m.NIXL_CONNECTOR_VERSION)
+print("has_local_region_mapper", hasattr(w.NixlConnectorWorker, "_get_local_region_ids_for_remote_stage"))
+PY'
+```
+
+Expected:
+
+```text
+metadata_version 3
+has_local_region_mapper True
+```
+
+## Unit Tests on the Server
+
+Run tests from the server source directory:
+
+```bash
+cd /ppio1/vllm-kimi-src
+```
+
+Kimi tool parser and Kimi params:
+
+```bash
+PYTHONPATH=. /ppio1/venvs/vllm-kimi-pd-v0.20/bin/python -m pytest \
+  tests/tool_parsers/test_kimi_k2_tool_parser.py \
+  tests/entrypoints/openai/test_kimi_params_validation.py -v
+```
+
+Known result:
+
+```text
+50 passed
+22 passed
+```
+
+Spec decode + logit bias:
+
+```bash
+PYTHONPATH=. /ppio1/venvs/vllm-kimi-pd-v0.20/bin/python -m pytest \
+  tests/v1/sample/test_rejection_sampler.py -v
+```
+
+Known result:
+
+```text
+68 passed
+```
+
+NIXL PP tests:
+
+```bash
+PYTHONPATH=. /ppio1/venvs/vllm-kimi-pd-v0.20/bin/python -m pytest \
+  tests/v1/kv_connector/unit/test_nixl_connector_pp.py -v
+```
+
+Known result after descriptor mapping fix:
+
+```text
+60 passed
+```
+
+## End-to-End PD NIXL Tests
+
+Main test runner:
+
+```text
+/ppio1/run_pd_nixl_case.sh
+```
+
+Usage:
+
+```bash
+/ppio1/run_pd_nixl_case.sh \
+  <label> \
+  <prefill_gpus> <prefill_tp> <prefill_pp> \
+  <decode_gpus> <decode_tp> <decode_pp> \
+  <base_port> <max_model_len>
+```
+
+Logs:
+
+```text
+/ppio1/pd-case-logs/<label>-prefill.log
+/ppio1/pd-case-logs/<label>-decode.log
+/ppio1/pd-case-logs/<label>-proxy.log
+/ppio1/pd-case-logs/<label>-result.json
+/ppio1/pd-case-logs/<label>-summary.txt
+```
+
+Baseline:
+
+```bash
+ssh root@10.121.196.3 \
+  '/ppio1/run_pd_nixl_case.sh baseline 0,1,2,3 4 1 4,5,6,7 4 1 25000 128'
+```
+
+Known result:
+
+```text
+status=success
+http_code=200
+text='verybeautifulcity.Itisveryclean'
+```
+
+PP2:
+
+```bash
+ssh root@10.121.196.3 \
+  '/ppio1/run_pd_nixl_case.sh pp2fix 0,1,2,3 2 2 4,5,6,7 4 1 26000 128'
+```
+
+Known result:
+
+```text
+status=success
+http_code=200
+text='verygoodplaceforpeoplewhowant'
+```
+
+PP4:
+
+```bash
+ssh root@10.121.196.3 \
+  '/ppio1/run_pd_nixl_case.sh pp4fix 0,1,2,3 1 4 4,5,6,7 4 1 27000 128'
+```
+
+Known result:
+
+```text
+status=success
+http_code=200
+text='verygoodplaceforpeoplewhowant'
+```
+
+Check for NIXL transfer failures:
+
+```bash
+ssh root@10.121.196.3 \
+  'grep -nE "transfer_setup_failed|NIXL_ERR_INVALID_PARAM|NIXL transfer failure" /ppio1/pd-case-logs/baseline-*.log /ppio1/pd-case-logs/pp2fix-*.log /ppio1/pd-case-logs/pp4fix-*.log || true'
+```
+
+Expected:
+
+```text
+no matches
+```
+
+### Interpreting Output Differences
+
+The PP2/PP4 output differs from baseline, but logprobs showed the first
+divergence is a near-tie (`beautiful` vs `good`) under `temperature=0`, not
+an obvious KV corruption.
+
+Conclusion from the last validation:
+
+```text
+NIXL data-plane setup is fixed.
+PP2 and PP4 return HTTP 200.
+No NIXL_ERR_INVALID_PARAM is observed.
+The remaining text difference is consistent with topology/numeric near-tie
+behavior across different prefill TP/PP layouts.
+```
+
+## Image Build
+
+Target image:
+
+```text
+image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test
+```
+
+Final known digest:
+
+```text
+image.paigpu.com/library/vllm-with-pegaflow@sha256:f132f4fa904c97d96e8dd942adbf4d9bb031842226d04f04fd2f7274169d95a6
+```
+
+Build-server local image id:
+
+```text
+sha256:e2b4548cc808b3f1ce38013ec49d12d6afa5763626516d71e18e477d800d48ed
+```
+
+Build script:
+
+```text
+/Users/ppio-dn-289/Documents/dynamo-vllm-workspace/build/build-vllm-pegaflow.sh
+```
+
+Dockerfile template:
+
+```text
+/Users/ppio-dn-289/Documents/dynamo-vllm-workspace/build/dockerfiles/Dockerfile.vllm-pegaflow-patch
+```
+
+Build config:
+
+```text
+/Users/ppio-dn-289/Documents/dynamo-vllm-workspace/build/config.yaml
+```
+
+Remote build context:
+
+```text
+build-server:/ppio1/gailun/dynamo-images-build/vllm-pegaflow/
+```
+
+Base image:
+
+```text
+vllm/vllm-openai:v0.20.0-cu130-ubuntu2404
+```
+
+PegaFlow wheel:
+
+```text
+pegaflow-llm-cu13==0.21.0
+```
+
+DeepEP:
+
+```text
+Do not pass --deepep-whl for the kimi-llmd-test image unless explicitly needed.
+The validated image keeps the base image deep_ep version:
+1.2.1+73b6ea4
+```
+
+### Patch Files Included in the Image
+
+vLLM patch list:
+
+```bash
+cd /Users/ppio-dn-289/Documents/llmd-vllm-workspace/vllm-kimi-pd-pegaflow
+git diff v0.20.0..HEAD --name-only --diff-filter=AM -- 'vllm/'
+```
+
+Known vLLM files:
+
+```text
+vllm/distributed/kv_transfer/kv_connector/utils.py
+vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+vllm/distributed/kv_transfer/kv_connector/v1/nixl/scheduler.py
+vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+vllm/entrypoints/openai/chat_completion/protocol.py
+vllm/entrypoints/openai/chat_completion/serving.py
+vllm/sampling_params.py
+vllm/tool_parsers/abstract_tool_parser.py
+vllm/tool_parsers/kimi_k2_tool_parser.py
+vllm/v1/metrics/loggers.py
+vllm/v1/metrics/stats.py
+vllm/v1/sample/logits_processor/__init__.py
+vllm/v1/sample/logits_processor/builtin.py
+vllm/v1/sample/rejection_sampler.py
+vllm/v1/worker/gpu_worker.py
+```
+
+PegaFlow patch list:
+
+```bash
+cd /Users/ppio-dn-289/Documents/dynamo-vllm-workspace/pegaflow-kimi-pd-pegaflow
+git diff 338c426..HEAD --name-only --diff-filter=AM -- 'python/pegaflow/'
+```
+
+Known PegaFlow files:
+
+```text
+python/pegaflow/connector/__init__.py
+python/pegaflow/connector/common.py
+python/pegaflow/connector/pd_connector.py
+python/pegaflow/connector/worker.py
+python/pegaflow/vllm_plugin.py
+```
+
+### Dry Run
+
+Always dry-run first:
+
+```bash
+cd /Users/ppio-dn-289/Documents/dynamo-vllm-workspace
+
+./build/build-vllm-pegaflow.sh \
+  --image image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test \
+  --vllm-wt /Users/ppio-dn-289/Documents/llmd-vllm-workspace/vllm-kimi-pd-pegaflow \
+  --dry-run
+```
+
+Expected summary:
+
+```text
+vllm -> 15 files
+pegaflow -> 5 files
+DeepEP whl: (not provided, skip reinstall)
+```
+
+### Build and Push
+
+Important: pass `--vllm-wt`. The build script default vLLM worktree is not this
+worktree.
+
+```bash
+cd /Users/ppio-dn-289/Documents/dynamo-vllm-workspace
+
+./build/build-vllm-pegaflow.sh \
+  --image image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test \
+  --vllm-wt /Users/ppio-dn-289/Documents/llmd-vllm-workspace/vllm-kimi-pd-pegaflow \
+  --push
+```
+
+The script will:
+
+1. collect patch files into a temporary context,
+2. generate `Dockerfile`,
+3. rsync the context to `build-server:/ppio1/gailun/dynamo-images-build/vllm-pegaflow/`,
+4. run Docker BuildKit on build-server,
+5. push the image to `image.paigpu.com/library`.
+
+## Image Verification
+
+Run:
+
+```bash
+ssh build-server 'docker run --rm -i --entrypoint python3 \
+  image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test - << "PY"
+import importlib.metadata
+import inspect
+import vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata as metadata
+import vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker as worker
+from pegaflow.connector.pd_connector import PegaPdConnector
+
+print("vllm_version", importlib.metadata.version("vllm"))
+print("nixl_connector_version", metadata.NIXL_CONNECTOR_VERSION)
+print("worker_file", inspect.getfile(worker))
+print("has_region_mapper", hasattr(worker.NixlConnectorWorker, "_get_local_region_ids_for_remote_stage"))
+print("pegaflow_pd_connector", PegaPdConnector.__name__)
+try:
+    print("deep_ep_version", importlib.metadata.version("deep_ep"))
+except importlib.metadata.PackageNotFoundError:
+    print("deep_ep_version", "not installed")
+PY'
+```
+
+Expected:
+
+```text
+vllm_version 0.20.0
+nixl_connector_version 3
+worker_file /usr/local/lib/python3.12/dist-packages/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+has_region_mapper True
+pegaflow_pd_connector PegaPdConnector
+deep_ep_version 1.2.1+73b6ea4
+```
+
+## Common Failure Modes
+
+### `PegaPdConnector` Import Fails
+
+Symptom:
+
+```text
+ModuleNotFoundError: No module named 'vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector'
+```
+
+Cause:
+
+The PegaFlow branch is missing:
+
+```text
+ba60953 fix(connector): import NIXL connector from vLLM 0.20 package
+```
+
+Fix:
+
+```bash
+cd /Users/ppio-dn-289/Documents/dynamo-vllm-workspace/pegaflow-kimi-pd-pegaflow
+git fetch upstream
+git checkout kimi-pd-pegaflow
+git pull upstream kimi-pd-pegaflow
+```
+
+### `make_prepped_xfer` Fails with `NIXL_ERR_INVALID_PARAM`
+
+Likely cause:
+
+The vLLM branch is missing the region label descriptor mapping fix:
+
+```text
+65c7265b4 fix(nixl): align PP stage descriptors by region label
+```
+
+Verify server venv:
+
+```bash
+ssh root@10.121.196.3 'cd /ppio1/vllm-kimi-src && /ppio1/venvs/vllm-kimi-pd-v0.20/bin/python - << "PY"
+import vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata as m
+import vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker as w
+print(m.NIXL_CONNECTOR_VERSION)
+print(hasattr(w.NixlConnectorWorker, "_get_local_region_ids_for_remote_stage"))
+PY'
+```
+
+Expected:
+
+```text
+3
+True
+```
+
+### End-to-End Output Differs from Baseline
+
+`temperature=0` is set in `/ppio1/run_pd_nixl_case.sh`.
+
+The observed PP2/PP4 output difference was investigated with `logprobs=5`.
+The first divergence was a near-tie in greedy decoding, not an obvious transfer
+failure.
+
+Treat link success criteria as:
+
+```text
+status=success
+http_code=200
+no NIXL_ERR_INVALID_PARAM
+no transfer_setup_failed
+```
+
+Use logprobs if correctness needs deeper numerical comparison.
+
+## Feishu Handoff Docs
+
+Detailed Feishu docs created during this work:
+
+```text
+vllm-with-pegaflow:kimi-llmd-test 镜像构建交接文档
+https://www.feishu.cn/docx/Ok4tdvTdEolO2jxc27QcP6q8nxe
+
+b300-kimi-prod-v1 ~ v4 镜像构建历史与交接文档
+https://www.feishu.cn/docx/Qo8ndYoaUoRkO2xMMUrcv8DUnAf
+```
+
+## New Session Checklist
+
+When starting a new session:
+
+1. Read this file.
+2. Check vLLM status:
+
+   ```bash
+   git status --short --branch
+   git log --oneline -5 --decorate
+   ```
+
+3. Check that PegaFlow is current:
+
+   ```bash
+   git -C /Users/ppio-dn-289/Documents/dynamo-vllm-workspace/pegaflow-kimi-pd-pegaflow \
+     log --oneline -5 --decorate
+   ```
+
+4. After code changes, commit and push vLLM to:
+
+   ```bash
+   git push origin kimi-pd-pegaflow-v0.20
+   git push novita kimi-pd-pegaflow-v0.20
+   ```
+
+5. Sync code to `root@10.121.196.3`, patch venv, run unit tests.
+6. Run E2E cases with `/ppio1/run_pd_nixl_case.sh`.
+7. Dry-run the image build.
+8. Build and push the image.
+9. Verify the image import checks.

--- a/KIMI_PD_PEGAFLOW_RUNBOOK.md
+++ b/KIMI_PD_PEGAFLOW_RUNBOOK.md
@@ -26,7 +26,7 @@ Base:
 vLLM v0.20.0
 
 Latest known HEAD:
-ccd9b95e8 fix(engine): keep idle polling on unfinished requests
+a1cb3d2ce fix(spec_decode): allow reasoning logits processor
 ```
 
 Remotes:
@@ -97,6 +97,8 @@ git push upstream kimi-pd-pegaflow
 Recent vLLM commit stack:
 
 ```text
+a1cb3d2ce fix(spec_decode): allow reasoning logits processor
+3acae96fd docs: add Kimi PD PegaFlow runbook
 ccd9b95e8 fix(engine): keep idle polling on unfinished requests
 a1c8dc5cc fix(metrics): compute TTFT prompt length from prefill stats
 65c7265b4 fix(nixl): align PP stage descriptors by region label
@@ -422,13 +424,13 @@ image.paigpu.com/library/vllm-with-pegaflow:kimi-llmd-test
 Final known digest:
 
 ```text
-image.paigpu.com/library/vllm-with-pegaflow@sha256:f132f4fa904c97d96e8dd942adbf4d9bb031842226d04f04fd2f7274169d95a6
+image.paigpu.com/library/vllm-with-pegaflow@sha256:de0f2541cda799cde8717e7f94abb71f4edf147bd8bab851fcc56094dc51c19c
 ```
 
 Build-server local image id:
 
 ```text
-sha256:e2b4548cc808b3f1ce38013ec49d12d6afa5763626516d71e18e477d800d48ed
+sha256:91711c883d9a9a6c10dc02f3874e7ae19e2381db6e51f9d442def3d4d33ec6ee
 ```
 
 Build script:

--- a/tests/entrypoints/openai/test_kimi_params_validation.py
+++ b/tests/entrypoints/openai/test_kimi_params_validation.py
@@ -15,8 +15,6 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
 from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
 from vllm.entrypoints.openai.engine.protocol import ErrorResponse
 from vllm.entrypoints.openai.models.serving import BaseModelPath, OpenAIServingModels
-from vllm.renderers.hf import HfRenderer
-from vllm.tokenizers.registry import tokenizer_args_from_config
 from vllm.v1.engine.async_llm import AsyncLLM
 
 MODEL_NAME = "openai-community/gpt2"
@@ -63,14 +61,6 @@ class MockVllmConfig:
     model_config: MockModelConfig
 
 
-def _build_renderer(model_config: MockModelConfig):
-    _, tokenizer_name, _, kwargs = tokenizer_args_from_config(model_config)
-    return HfRenderer.from_config(
-        MockVllmConfig(model_config),
-        tokenizer_kwargs={**kwargs, "tokenizer_name": tokenizer_name},
-    )
-
-
 def _build_kimi_serving_chat() -> OpenAIServingChat:
     """Build an OpenAIServingChat with Kimi K2 model type."""
     model_config = MockModelConfig(
@@ -82,7 +72,7 @@ def _build_kimi_serving_chat() -> OpenAIServingChat:
     mock_engine.model_config = model_config
     mock_engine.input_processor = MagicMock()
     mock_engine.io_processor = MagicMock()
-    mock_engine.renderer = _build_renderer(model_config)
+    mock_engine.renderer = MagicMock()
 
     models = OpenAIServingModels(
         engine_client=mock_engine,
@@ -92,6 +82,7 @@ def _build_kimi_serving_chat() -> OpenAIServingChat:
         mock_engine,
         models,
         response_role="assistant",
+        openai_serving_render=MagicMock(),
         chat_template=CHAT_TEMPLATE,
         chat_template_content_format="auto",
         request_logger=None,
@@ -107,7 +98,7 @@ def _build_non_kimi_serving_chat() -> OpenAIServingChat:
     mock_engine.model_config = model_config
     mock_engine.input_processor = MagicMock()
     mock_engine.io_processor = MagicMock()
-    mock_engine.renderer = _build_renderer(model_config)
+    mock_engine.renderer = MagicMock()
 
     models = OpenAIServingModels(
         engine_client=mock_engine,
@@ -117,6 +108,7 @@ def _build_non_kimi_serving_chat() -> OpenAIServingChat:
         mock_engine,
         models,
         response_role="assistant",
+        openai_serving_render=MagicMock(),
         chat_template=CHAT_TEMPLATE,
         chat_template_content_format="auto",
         request_logger=None,

--- a/tests/entrypoints/openai/test_kimi_params_validation.py
+++ b/tests/entrypoints/openai/test_kimi_params_validation.py
@@ -1,0 +1,397 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for Kimi model parameter validation in OpenAIServingChat."""
+
+from dataclasses import dataclass, field
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from vllm.config import MultiModalConfig
+from vllm.entrypoints.openai.chat_completion.protocol import (
+    ChatCompletionRequest,
+)
+from vllm.entrypoints.openai.chat_completion.serving import OpenAIServingChat
+from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+from vllm.entrypoints.openai.models.serving import BaseModelPath, OpenAIServingModels
+from vllm.renderers.hf import HfRenderer
+from vllm.tokenizers.registry import tokenizer_args_from_config
+from vllm.v1.engine.async_llm import AsyncLLM
+
+MODEL_NAME = "openai-community/gpt2"
+CHAT_TEMPLATE = "Dummy chat template for testing {}"
+BASE_MODEL_PATHS = [BaseModelPath(name=MODEL_NAME, model_path=MODEL_NAME)]
+
+
+@dataclass
+class MockHFConfig:
+    model_type: str = "any"
+
+
+@dataclass
+class MockModelConfig:
+    task = "generate"
+    runner_type = "generate"
+    model = MODEL_NAME
+    tokenizer = MODEL_NAME
+    trust_remote_code = False
+    tokenizer_mode = "auto"
+    max_model_len = 100
+    tokenizer_revision = None
+    multimodal_config = MultiModalConfig()
+    hf_config: MockHFConfig = field(default_factory=MockHFConfig)
+    hf_text_config: MockHFConfig = field(default_factory=MockHFConfig)
+    logits_processors: list[str] | None = None
+    diff_sampling_param: dict | None = None
+    allowed_local_media_path: str = ""
+    allowed_media_domains: list[str] | None = None
+    encoder_config = None
+    generation_config: str = "auto"
+    override_generation_config: dict[str, Any] = field(default_factory=dict)
+    media_io_kwargs: dict[str, dict[str, Any]] = field(default_factory=dict)
+    skip_tokenizer_init: bool = False
+    is_encoder_decoder: bool = False
+    is_multimodal_model: bool = False
+
+    def get_diff_sampling_param(self):
+        return self.diff_sampling_param or {}
+
+
+@dataclass
+class MockVllmConfig:
+    model_config: MockModelConfig
+
+
+def _build_renderer(model_config: MockModelConfig):
+    _, tokenizer_name, _, kwargs = tokenizer_args_from_config(model_config)
+    return HfRenderer.from_config(
+        MockVllmConfig(model_config),
+        tokenizer_kwargs={**kwargs, "tokenizer_name": tokenizer_name},
+    )
+
+
+def _build_kimi_serving_chat() -> OpenAIServingChat:
+    """Build an OpenAIServingChat with Kimi K2 model type."""
+    model_config = MockModelConfig(
+        hf_config=MockHFConfig(model_type="kimi_k2"),
+        hf_text_config=MockHFConfig(model_type="kimi_k2"),
+    )
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = model_config
+    mock_engine.input_processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(model_config)
+
+    models = OpenAIServingModels(
+        engine_client=mock_engine,
+        base_model_paths=BASE_MODEL_PATHS,
+    )
+    serving_chat = OpenAIServingChat(
+        mock_engine,
+        models,
+        response_role="assistant",
+        chat_template=CHAT_TEMPLATE,
+        chat_template_content_format="auto",
+        request_logger=None,
+    )
+    return serving_chat
+
+
+def _build_non_kimi_serving_chat() -> OpenAIServingChat:
+    """Build an OpenAIServingChat with a non-Kimi model type."""
+    model_config = MockModelConfig()
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = model_config
+    mock_engine.input_processor = MagicMock()
+    mock_engine.io_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(model_config)
+
+    models = OpenAIServingModels(
+        engine_client=mock_engine,
+        base_model_paths=BASE_MODEL_PATHS,
+    )
+    serving_chat = OpenAIServingChat(
+        mock_engine,
+        models,
+        response_role="assistant",
+        chat_template=CHAT_TEMPLATE,
+        chat_template_content_format="auto",
+        request_logger=None,
+    )
+    return serving_chat
+
+
+@pytest.fixture
+def kimi_chat():
+    return _build_kimi_serving_chat()
+
+
+@pytest.fixture
+def non_kimi_chat():
+    return _build_non_kimi_serving_chat()
+
+
+class TestKimiIsKimiFlag:
+    """Test that is_kimi flag is set correctly."""
+
+    def test_kimi_k2_model_type(self, kimi_chat: OpenAIServingChat):
+        assert kimi_chat.is_kimi is True
+        assert kimi_chat.tool_call_id_type == "kimi_k2"
+
+    def test_non_kimi_model_type(self, non_kimi_chat: OpenAIServingChat):
+        assert non_kimi_chat.is_kimi is False
+        assert non_kimi_chat.tool_call_id_type == "random"
+
+
+class TestKimiThinkModeDefaults:
+    """Test thinking mode (default): temperature=1.0, top_p=0.95."""
+
+    def test_think_mode_defaults_applied(self, kimi_chat: OpenAIServingChat):
+        """When no params set, defaults for think mode are applied."""
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+        )
+        result = kimi_chat._validate_kimi_params(req)
+        assert result is None
+        assert req.temperature == 1.0
+        assert req.top_p == 0.95
+
+    def test_think_mode_correct_temperature(self, kimi_chat: OpenAIServingChat):
+        """Explicit temperature=1.0 in think mode passes validation."""
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            temperature=1.0,
+            top_p=0.95,
+        )
+        result = kimi_chat._validate_kimi_params(req)
+        assert result is None
+
+    def test_think_mode_temperature_in_range(self, kimi_chat: OpenAIServingChat):
+        """temperature within [0, 1] in think mode passes validation."""
+        for temp in [0.0, 0.3, 0.6, 0.8, 1.0]:
+            req = ChatCompletionRequest(
+                model=MODEL_NAME,
+                messages=[{"role": "user", "content": "hello"}],
+                temperature=temp,
+            )
+            result = kimi_chat._validate_kimi_params(req)
+            assert result is None, f"temperature={temp} should pass"
+
+    def test_think_mode_temperature_out_of_range(self, kimi_chat: OpenAIServingChat):
+        """temperature > 1 in think mode is rejected."""
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            temperature=1.5,
+        )
+        result = kimi_chat._validate_kimi_params(req)
+        assert isinstance(result, ErrorResponse)
+        assert "temperature" in result.error.message
+
+    def test_think_mode_enable_thinking_set(self, kimi_chat: OpenAIServingChat):
+        """Validation sets enable_thinking=True in chat_template_kwargs."""
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+        )
+        kimi_chat._validate_kimi_params(req)
+        assert req.chat_template_kwargs is not None
+        assert req.chat_template_kwargs["enable_thinking"] is True
+
+
+class TestKimiChatTemplateKwargsThinking:
+    """Test thinking mode detection from chat_template_kwargs."""
+
+    def test_chat_template_kwargs_thinking_false(self, kimi_chat: OpenAIServingChat):
+        """chat_template_kwargs.thinking=false -> non-think mode."""
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            chat_template_kwargs={"thinking": False},
+        )
+        result = kimi_chat._validate_kimi_params(req)
+        assert result is None
+        assert req.temperature == 0.6
+        assert req.top_p == 0.95
+        assert req.chat_template_kwargs["enable_thinking"] is False
+
+    def test_chat_template_kwargs_thinking_true(self, kimi_chat: OpenAIServingChat):
+        """chat_template_kwargs.thinking=true -> think mode."""
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            chat_template_kwargs={"thinking": True},
+        )
+        result = kimi_chat._validate_kimi_params(req)
+        assert result is None
+        assert req.temperature == 1.0
+        assert req.top_p == 0.95
+        assert req.chat_template_kwargs["enable_thinking"] is True
+
+    def test_chat_template_kwargs_enable_thinking_false(
+        self, kimi_chat: OpenAIServingChat
+    ):
+        """chat_template_kwargs.enable_thinking=false -> non-think mode."""
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            chat_template_kwargs={"enable_thinking": False},
+        )
+        result = kimi_chat._validate_kimi_params(req)
+        assert result is None
+        assert req.temperature == 0.6
+        assert req.top_p == 0.95
+
+    def test_chat_template_kwargs_enable_thinking_true(
+        self, kimi_chat: OpenAIServingChat
+    ):
+        """chat_template_kwargs.enable_thinking=true -> think mode."""
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            chat_template_kwargs={"enable_thinking": True},
+        )
+        result = kimi_chat._validate_kimi_params(req)
+        assert result is None
+        assert req.temperature == 1.0
+        assert req.top_p == 0.95
+
+    def test_chat_template_kwargs_thinking_false_with_temp_zero(
+        self, kimi_chat: OpenAIServingChat
+    ):
+        """thinking=false + temperature=0 should pass (within [0, 1])."""
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            temperature=0,
+            chat_template_kwargs={"thinking": False},
+        )
+        result = kimi_chat._validate_kimi_params(req)
+        assert result is None
+
+    def test_non_think_temperature_in_range(self, kimi_chat: OpenAIServingChat):
+        """Any temperature within [0, 1] in non-think mode passes."""
+        for temp in [0.0, 0.3, 0.6, 0.8, 1.0]:
+            req = ChatCompletionRequest(
+                model=MODEL_NAME,
+                messages=[{"role": "user", "content": "hello"}],
+                temperature=temp,
+                top_p=0.95,
+                chat_template_kwargs={"thinking": False},
+            )
+            result = kimi_chat._validate_kimi_params(req)
+            assert result is None, f"temperature={temp} should pass"
+
+    def test_non_think_temperature_out_of_range(self, kimi_chat: OpenAIServingChat):
+        """temperature > 1 in non-think mode is rejected."""
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            temperature=1.5,
+            chat_template_kwargs={"thinking": False},
+        )
+        result = kimi_chat._validate_kimi_params(req)
+        assert isinstance(result, ErrorResponse)
+        assert "temperature" in result.error.message
+
+    def test_non_think_enable_thinking_false_sets_kwarg(
+        self, kimi_chat: OpenAIServingChat
+    ):
+        """Validation sets enable_thinking=False in chat_template_kwargs."""
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            chat_template_kwargs={"thinking": False},
+        )
+        kimi_chat._validate_kimi_params(req)
+        assert req.chat_template_kwargs["enable_thinking"] is False
+
+
+class TestKimiCommonParamValidation:
+    """Test common parameter constraints for both modes."""
+
+    def test_wrong_top_p_rejected(self, kimi_chat: OpenAIServingChat):
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            top_p=0.8,
+        )
+        result = kimi_chat._validate_kimi_params(req)
+        assert isinstance(result, ErrorResponse)
+        assert "top_p" in result.error.message
+
+    def test_wrong_presence_penalty_rejected(self, kimi_chat: OpenAIServingChat):
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            presence_penalty=1.0,
+        )
+        result = kimi_chat._validate_kimi_params(req)
+        assert isinstance(result, ErrorResponse)
+        assert "presence_penalty" in result.error.message
+
+    def test_wrong_frequency_penalty_rejected(self, kimi_chat: OpenAIServingChat):
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            frequency_penalty=0.5,
+        )
+        result = kimi_chat._validate_kimi_params(req)
+        assert isinstance(result, ErrorResponse)
+        assert "frequency_penalty" in result.error.message
+
+    def test_wrong_n_rejected(self, kimi_chat: OpenAIServingChat):
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            n=2,
+        )
+        result = kimi_chat._validate_kimi_params(req)
+        assert isinstance(result, ErrorResponse)
+        assert "n must be 1" in result.error.message
+
+    def test_multiple_errors_reported(self, kimi_chat: OpenAIServingChat):
+        """Multiple invalid params are all reported in one error."""
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            temperature=1.5,
+            top_p=0.8,
+            n=3,
+        )
+        result = kimi_chat._validate_kimi_params(req)
+        assert isinstance(result, ErrorResponse)
+        assert "temperature" in result.error.message
+        assert "top_p" in result.error.message
+        assert "n must be 1" in result.error.message
+
+    def test_correct_default_params_pass(self, kimi_chat: OpenAIServingChat):
+        """Default values for presence_penalty, frequency_penalty, n pass."""
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            temperature=1.0,
+            top_p=0.95,
+            presence_penalty=0.0,
+            frequency_penalty=0.0,
+            n=1,
+        )
+        result = kimi_chat._validate_kimi_params(req)
+        assert result is None
+
+
+class TestNonKimiModelSkipsValidation:
+    """Test that non-Kimi models are not affected by Kimi validation."""
+
+    def test_non_kimi_no_validation(self, non_kimi_chat: OpenAIServingChat):
+        assert non_kimi_chat.is_kimi is False
+        # Non-kimi models don't have _validate_kimi_params called
+        # in create_chat_completion, so arbitrary params are fine.
+        # Non-kimi models don't call _validate_kimi_params in the flow.
+        # The important thing is is_kimi is False.
+        assert non_kimi_chat.is_kimi is False

--- a/tests/kernels/moe/test_flashinfer_nvlink_one_sided.py
+++ b/tests/kernels/moe/test_flashinfer_nvlink_one_sided.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEQuantConfig,
+    FusedMoEQuantDesc,
+)
+
+
+class FakeMoeAllToAll:
+    def __init__(self):
+        self.dispatch_kwargs = None
+        self.dispatched_payloads = None
+
+    def dispatch(self, token_selected_experts, input_payloads, **kwargs):
+        self.dispatch_kwargs = kwargs
+        self.dispatched_payloads = input_payloads
+        return input_payloads
+
+
+class FakeAll2AllManager:
+    rank = 0
+    world_size = 2
+
+    def __init__(self):
+        self.moe_alltoall = FakeMoeAllToAll()
+        self.initialize_kwargs = None
+
+    def initialize(self, **kwargs):
+        self.initialize_kwargs = kwargs
+
+
+def _bf16_quant_config() -> FusedMoEQuantConfig:
+    desc = FusedMoEQuantDesc(dtype=None)
+    return FusedMoEQuantConfig(desc, desc, desc, desc)
+
+
+def _mxfp8_quant_config() -> FusedMoEQuantConfig:
+    a_desc = FusedMoEQuantDesc(dtype="mxfp8")
+    w_desc = FusedMoEQuantDesc(dtype="mxfp4")
+    return FusedMoEQuantConfig(a_desc, a_desc, w_desc, w_desc)
+
+
+def test_one_sided_prepare_uses_out_of_range_invalid_expert_id_without_expert_map(
+    monkeypatch,
+):
+    from vllm.model_executor.layers.fused_moe.prepare_finalize import (
+        flashinfer_nvlink_one_sided as one_sided,
+    )
+
+    manager = FakeAll2AllManager()
+    monkeypatch.setattr(
+        one_sided,
+        "get_ep_group",
+        lambda: SimpleNamespace(
+            device_communicator=SimpleNamespace(all2all_manager=manager)
+        ),
+    )
+    monkeypatch.setattr(one_sided, "get_local_sizes", lambda: [2])
+
+    def fail_quantize_input(*args, **kwargs):
+        raise AssertionError("deferred BF16 dispatch should not quantize activations")
+
+    monkeypatch.setattr(one_sided, "moe_kernel_quantize_input", fail_quantize_input)
+
+    prepare_finalize = one_sided.FlashInferNVLinkOneSidedPrepareAndFinalize(
+        max_num_tokens=8,
+        top_k=2,
+        num_experts=4,
+        hidden_size=8,
+        dispatch_dtype_bytes_per_elem=2,
+        dispatch_scale_bytes_per_token=0,
+    )
+    a1 = torch.randn((2, 8), dtype=torch.bfloat16)
+    topk_ids = torch.tensor([[0, 1], [2, 3]], dtype=torch.int32)
+    topk_weights = torch.randn((2, 2), dtype=torch.float32)
+
+    a1_recv, a1_scale_recv, _, topk_ids_recv, topk_weights_recv = (
+        prepare_finalize.prepare(
+            a1=a1,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            num_experts=4,
+            expert_map=None,
+            apply_router_weight_on_input=False,
+            quant_config=_bf16_quant_config(),
+            defer_input_quant=True,
+        )
+    )
+
+    assert manager.initialize_kwargs["dispatch_dtype_bytes_per_elem"] == 2
+    assert manager.initialize_kwargs["dispatch_scale_bytes_per_token"] == 0
+    assert manager.moe_alltoall.dispatch_kwargs["invalid_token_expert_id"] == 4
+    assert manager.moe_alltoall.dispatch_kwargs["expert_id_payload_index"] == 1
+    assert manager.moe_alltoall.dispatched_payloads[0] is a1
+    assert manager.moe_alltoall.dispatched_payloads[1] is topk_ids
+    assert manager.moe_alltoall.dispatched_payloads[2] is topk_weights
+    torch.testing.assert_close(a1_recv, a1)
+    assert a1_scale_recv is None
+    torch.testing.assert_close(topk_ids_recv, topk_ids)
+    torch.testing.assert_close(topk_weights_recv, topk_weights)
+
+
+def test_one_sided_prepare_uses_nonlocal_padding_expert_with_expert_map(monkeypatch):
+    from vllm.model_executor.layers.fused_moe.prepare_finalize import (
+        flashinfer_nvlink_one_sided as one_sided,
+    )
+
+    manager = FakeAll2AllManager()
+    monkeypatch.setattr(
+        one_sided,
+        "get_ep_group",
+        lambda: SimpleNamespace(
+            device_communicator=SimpleNamespace(all2all_manager=manager)
+        ),
+    )
+    monkeypatch.setattr(one_sided, "get_local_sizes", lambda: [2])
+
+    a1q = torch.empty((2, 8), dtype=torch.uint8)
+    a1q_scale = torch.empty((2, 1), dtype=torch.uint8)
+
+    def fake_quantize_input(*args, **kwargs):
+        return a1q, a1q_scale
+
+    monkeypatch.setattr(one_sided, "moe_kernel_quantize_input", fake_quantize_input)
+
+    prepare_finalize = one_sided.FlashInferNVLinkOneSidedPrepareAndFinalize(
+        max_num_tokens=8,
+        top_k=2,
+        num_experts=4,
+        hidden_size=8,
+        dispatch_dtype_bytes_per_elem=1,
+        dispatch_scale_bytes_per_token=1,
+    )
+    a1 = torch.randn((2, 8), dtype=torch.bfloat16)
+    topk_ids = torch.tensor([[0, 1], [2, 3]], dtype=torch.int32)
+    topk_weights = torch.randn((2, 2), dtype=torch.float32)
+
+    a1_recv, a1_scale_recv, _, topk_ids_recv, topk_weights_recv = (
+        prepare_finalize.prepare(
+            a1=a1,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            num_experts=4,
+            expert_map=torch.tensor([0, 1, -1, -1], dtype=torch.int32),
+            apply_router_weight_on_input=False,
+            quant_config=_mxfp8_quant_config(),
+        )
+    )
+
+    assert manager.moe_alltoall.dispatch_kwargs["invalid_token_expert_id"] == 2
+    assert manager.moe_alltoall.dispatch_kwargs["expert_id_payload_index"] == 2
+    assert manager.moe_alltoall.dispatched_payloads[0] is a1q
+    assert manager.moe_alltoall.dispatched_payloads[1] is a1q_scale
+    assert manager.moe_alltoall.dispatched_payloads[2] is topk_ids
+    assert manager.moe_alltoall.dispatched_payloads[3] is topk_weights
+    torch.testing.assert_close(a1_recv, a1q)
+    torch.testing.assert_close(a1_scale_recv, a1q_scale)
+    torch.testing.assert_close(topk_ids_recv, topk_ids)
+    torch.testing.assert_close(topk_weights_recv, topk_weights)

--- a/tests/tool_parsers/test_kimi_k2_tool_parser.py
+++ b/tests/tool_parsers/test_kimi_k2_tool_parser.py
@@ -13,6 +13,8 @@ from tests.tool_parsers.utils import (
 )
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
+    ChatCompletionToolsParam,
+    FunctionDefinition,
 )
 from vllm.tokenizers import get_tokenizer
 from vllm.tool_parsers.kimi_k2_tool_parser import KimiK2ToolParser
@@ -461,9 +463,15 @@ class TestStreamingEdgeCases:
 class TestAdjustRequest:
     def test_sets_skip_special_tokens_false(self, parser):
         request = MagicMock(spec=ChatCompletionRequest)
-        request.tools = [{"type": "function", "function": {"name": "test"}}]
+        request.tools = [
+            ChatCompletionToolsParam(
+                type="function",
+                function=FunctionDefinition(name="test"),
+            )
+        ]
         request.tool_choice = "auto"
         request.skip_special_tokens = True
+        request.structured_outputs = None
 
         result = parser.adjust_request(request)
         assert result.skip_special_tokens is False
@@ -473,6 +481,7 @@ class TestAdjustRequest:
         request.tools = [{"type": "function", "function": {"name": "test"}}]
         request.tool_choice = "none"
         request.skip_special_tokens = True
+        request.structured_outputs = None
 
         result = parser.adjust_request(request)
         assert result.skip_special_tokens is True
@@ -482,6 +491,7 @@ class TestAdjustRequest:
         request.tools = None
         request.tool_choice = "auto"
         request.skip_special_tokens = True
+        request.structured_outputs = None
 
         result = parser.adjust_request(request)
         assert result.skip_special_tokens is True

--- a/tests/v1/engine/test_kv_consumer_guard.py
+++ b/tests/v1/engine/test_kv_consumer_guard.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.config import KVTransferConfig
+from vllm.v1.engine.kv_consumer_validation import validate_kv_consumer_request
+
+
+def _make_request(kv_transfer_params=None):
+    return SimpleNamespace(
+        request_id="request-0",
+        pooling_params=None,
+        kv_transfer_params=kv_transfer_params,
+    )
+
+
+def _remote_prefill_params():
+    return {
+        "do_remote_prefill": True,
+        "do_remote_decode": False,
+        "remote_engine_id": "prefill-engine",
+        "remote_request_id": "prefill-request",
+        "remote_host": "127.0.0.1",
+        "remote_port": 14579,
+        "remote_block_ids": [0, 1, 2],
+    }
+
+
+def _nixl_config(kv_role: str = "kv_consumer"):
+    return KVTransferConfig(kv_connector="NixlConnector", kv_role=kv_role)
+
+
+def _make_engine_core_request(kv_transfer_params=None):
+    return SimpleNamespace(
+        request_id="request-0",
+        pooling_params=None,
+        sampling_params=SimpleNamespace(
+            extra_args={"kv_transfer_params": kv_transfer_params}
+            if kv_transfer_params is not None
+            else None
+        ),
+    )
+
+
+def test_kv_consumer_rejects_missing_kv_transfer_params():
+    request = _make_request()
+
+    with pytest.raises(ValueError, match="requires non-empty kv_transfer_params"):
+        validate_kv_consumer_request(request, _nixl_config())
+
+
+@pytest.mark.parametrize(
+    "kv_transfer_params",
+    [
+        {},
+        {"do_remote_prefill": False},
+        {"do_remote_decode": True, "do_remote_prefill": False},
+    ],
+)
+def test_kv_consumer_rejects_non_remote_prefill_params(kv_transfer_params):
+    request = _make_request(kv_transfer_params)
+
+    with pytest.raises(ValueError, match="refusing local prefill"):
+        validate_kv_consumer_request(request, _nixl_config())
+
+
+@pytest.mark.parametrize(
+    "missing_param",
+    ["remote_engine_id", "remote_request_id", "remote_host", "remote_port"],
+)
+def test_nixl_kv_consumer_rejects_missing_remote_metadata(missing_param):
+    request = _make_request(_remote_prefill_params())
+    request.kv_transfer_params.pop(missing_param)
+
+    with pytest.raises(ValueError, match=missing_param):
+        validate_kv_consumer_request(request, _nixl_config())
+
+
+@pytest.mark.parametrize("remote_block_ids", [None])
+def test_nixl_kv_consumer_rejects_missing_remote_block_ids(remote_block_ids):
+    request = _make_request(_remote_prefill_params())
+    request.kv_transfer_params["remote_block_ids"] = remote_block_ids
+
+    with pytest.raises(ValueError, match="remote_block_ids"):
+        validate_kv_consumer_request(request, _nixl_config())
+
+
+def test_nixl_kv_consumer_accepts_valid_remote_prefill_params():
+    request = _make_request(_remote_prefill_params())
+
+    validate_kv_consumer_request(request, _nixl_config())
+
+
+def test_nixl_kv_consumer_accepts_empty_remote_block_ids_for_full_hit():
+    request = _make_request(_remote_prefill_params())
+    request.kv_transfer_params["remote_block_ids"] = []
+
+    validate_kv_consumer_request(request, _nixl_config())
+
+
+def test_kv_both_preserves_existing_decode_only_behavior():
+    request = _make_request()
+
+    validate_kv_consumer_request(request, _nixl_config(kv_role="kv_both"))
+
+
+def test_kv_consumer_rejects_engine_core_request_without_remote_prefill():
+    request = _make_engine_core_request()
+
+    with pytest.raises(ValueError, match="requires non-empty kv_transfer_params"):
+        validate_kv_consumer_request(request, _nixl_config())
+
+
+def test_kv_consumer_accepts_engine_core_request_with_remote_prefill():
+    request = _make_engine_core_request(_remote_prefill_params())
+
+    validate_kv_consumer_request(request, _nixl_config())

--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -518,6 +518,7 @@ class FakeNixlConnectorWorker(NixlConnectorWorker):
                     engine_id=self.REMOTE_ENGINE_ID,
                     agent_metadata=FakeNixlWrapper.AGENT_METADATA,
                     kv_caches_base_addr=[0],
+                    region_labels=["layer.0"],
                     device_id=remote_tp_rank,
                     num_blocks=1,
                     block_lens=remote_block_lens,
@@ -971,6 +972,7 @@ class TestNixlHandshake:
                 engine_id=FakeNixlConnectorWorker.REMOTE_ENGINE_ID,
                 agent_metadata=FakeNixlWrapper.AGENT_METADATA,
                 kv_caches_base_addr=[0],
+                region_labels=["layer.0"],
                 device_id=0,
                 num_blocks=1,
                 block_lens=worker.block_len_per_layer,
@@ -1027,6 +1029,7 @@ class TestNixlHandshake:
                 engine_id=FakeNixlConnectorWorker.REMOTE_ENGINE_ID,
                 agent_metadata=FakeNixlWrapper.AGENT_METADATA,
                 kv_caches_base_addr=[0],
+                region_labels=["layer.0"],
                 device_id=0,
                 num_blocks=1,
                 # prefill TP=1, decode TP=2, remote block_lens is double to local
@@ -2347,6 +2350,7 @@ def test_compatibility_hash_validation(
         engine_id=FakeNixlConnectorWorker.REMOTE_ENGINE_ID,
         agent_metadata=FakeNixlWrapper.AGENT_METADATA,
         kv_caches_base_addr=[0],
+        region_labels=["layer.0"],
         device_id=0,
         num_blocks=1,
         block_lens=[4096 * prefill_block_size],  # slot_size * block_size

--- a/tests/v1/kv_connector/unit/test_nixl_connector.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector.py
@@ -430,6 +430,7 @@ def test_kv_transfer_handshake(dist_init):
                 kv_connector_metadata["remote_host"],
                 kv_connector_metadata["remote_port"],
                 kv_connector_metadata["tp_size"],
+                kv_connector_metadata["pp_size"],
                 kv_connector_metadata["remote_engine_id"],
             )
 
@@ -459,6 +460,7 @@ class FakeNixlConnectorWorker(NixlConnectorWorker):
         self._hand_shake_latency = hand_shake_latency
         self.kv_cache_layout = kv_cache_layout
         # Mock register_kv_caches attribute needed for tests that do not call it.
+        self.region_labels = ["layer.0"]
         self.src_xfer_handles_by_block_size = {self.block_size: 1}
         test_shape = self.attn_backends[0].get_kv_cache_shape(
             num_blocks=1, block_size=16, num_kv_heads=1, head_size=1
@@ -480,7 +482,12 @@ class FakeNixlConnectorWorker(NixlConnectorWorker):
         )
 
     def _nixl_handshake(
-        self, host: str, port: int, remote_tp_size: int, expected_engine_id: str
+        self,
+        host: str,
+        port: int,
+        remote_tp_size: int,
+        remote_pp_size: int,
+        expected_engine_id: str,
     ) -> dict[int, str]:
         # Mimic slow _nixl_handshake, as well as bypass zmq communication.
         time.sleep(self._hand_shake_latency)
@@ -748,6 +755,7 @@ class TestNixlHandshake:
             host="localhost",
             port=1234,
             remote_tp_size=4,
+            remote_pp_size=1,
             expected_engine_id=worker.REMOTE_ENGINE_ID,
         )
         check_handshake(4)
@@ -760,6 +768,7 @@ class TestNixlHandshake:
             host="localhost",
             port=1234,
             remote_tp_size=6,
+            remote_pp_size=1,
             expected_engine_id=worker.REMOTE_ENGINE_ID,
         )
         check_handshake(6)
@@ -2382,6 +2391,7 @@ def test_compatibility_hash_validation(
                     host="localhost",
                     port=1234,
                     remote_tp_size=1,
+                    remote_pp_size=1,
                     expected_engine_id=FakeNixlConnectorWorker.REMOTE_ENGINE_ID,
                 )
         else:
@@ -2389,6 +2399,7 @@ def test_compatibility_hash_validation(
                 host="localhost",
                 port=1234,
                 remote_tp_size=1,
+                remote_pp_size=1,
                 expected_engine_id=FakeNixlConnectorWorker.REMOTE_ENGINE_ID,
             )
             # Verify handshake returned agent mapping
@@ -2481,5 +2492,6 @@ def test_handshake_decode_errors(default_vllm_config, dist_init, error_scenario)
                 host="localhost",
                 port=1234,
                 remote_tp_size=1,
+                remote_pp_size=1,
                 expected_engine_id=FakeNixlConnectorWorker.REMOTE_ENGINE_ID,
             )

--- a/tests/v1/kv_connector/unit/test_nixl_connector_pp.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_pp.py
@@ -239,3 +239,92 @@ class TestSideChannelPortPP:
         # With PP2+TP4, there are 8 workers but only 1 scheduler.
         # The side_channel_port formula (base + dp_index) is correct for PP.
         assert True  # architecture documentation test
+
+
+# ===========================================================================
+# Tests: TpKVTopology.get_all_pp_tp_targets (Wave 2.2)
+# ===========================================================================
+
+class TestTpKVTopologyPP:
+    """
+    TpKVTopology needs a new method get_all_pp_tp_targets that returns
+    global worker indices across ALL PP stages for a given local D rank.
+
+    Current get_target_remote_ranks(remote_tp_size=4):
+      D_rank 0,1 -> [0]  (only PP0_TP0, PP1 never reached)
+
+    Required get_all_pp_tp_targets(remote_tp_size=4, remote_pp_size=2):
+      D_rank 0,1 -> [0, 4]  (PP0_TP0 AND PP1_TP0)
+      D_rank 2,3 -> [1, 5]
+      D_rank 4,5 -> [2, 6]
+      D_rank 6,7 -> [3, 7]
+
+    Formula: for each tp_rank in get_target_remote_ranks(tp_size):
+               [tp_rank + pp_rank * tp_size for pp_rank in range(pp_size)]
+    """
+
+    def _make_topology(self, d_tp_rank: int, d_tp_size: int, engine_id="prefill"):
+        from vllm.distributed.kv_transfer.kv_connector.utils import TpKVTopology
+        from unittest.mock import MagicMock
+
+        mock_backend = MagicMock()
+        mock_backend.get_kv_cache_shape.return_value = (1, 16, 4, 1, 1)
+        mock_backend.get_kv_cache_stride_order.side_effect = NotImplementedError
+
+        return TpKVTopology(
+            tp_rank=d_tp_rank,
+            engine_id=engine_id,
+            remote_tp_size={engine_id: d_tp_size},
+            remote_block_size={engine_id: 16},
+            is_mla=True,
+            total_num_kv_heads=4,
+            attn_backends=[mock_backend],
+            tensor_shape=None,
+        )
+
+    def test_pp1_identical_to_existing_method(self):
+        """PP=1: get_all_pp_tp_targets must equal get_target_remote_ranks (backward compat)."""
+        topo = self._make_topology(d_tp_rank=0, d_tp_size=8)
+        existing = topo.get_target_remote_ranks(remote_tp_size=4)
+        pp1_result = topo.get_all_pp_tp_targets(remote_tp_size=4, remote_pp_size=1)
+        assert pp1_result == existing
+
+    # --- [FAILS_NOW] ---
+
+    def test_d_rank0_pp2_tp4_connects_to_0_and_4(self):
+        """[FAILS_NOW] D_rank=0, D_TP=8, remote PP2+TP4 -> global [0, 4]."""
+        topo = self._make_topology(d_tp_rank=0, d_tp_size=8)
+        result = topo.get_all_pp_tp_targets(remote_tp_size=4, remote_pp_size=2)
+        assert result == [0, 4], f"Got {result}"
+
+    def test_d_rank1_pp2_tp4_connects_to_0_and_4(self):
+        """[FAILS_NOW] D_rank=1, D_TP=8, remote PP2+TP4 -> global [0, 4]."""
+        topo = self._make_topology(d_tp_rank=1, d_tp_size=8)
+        result = topo.get_all_pp_tp_targets(remote_tp_size=4, remote_pp_size=2)
+        assert result == [0, 4]
+
+    def test_d_rank2_pp2_tp4_connects_to_1_and_5(self):
+        """[FAILS_NOW] D_rank=2, D_TP=8 -> [1, 5]."""
+        topo = self._make_topology(d_tp_rank=2, d_tp_size=8)
+        result = topo.get_all_pp_tp_targets(remote_tp_size=4, remote_pp_size=2)
+        assert result == [1, 5]
+
+    def test_d_rank7_pp2_tp4_connects_to_3_and_7(self):
+        """[FAILS_NOW] D_rank=7, D_TP=8 -> [3, 7]."""
+        topo = self._make_topology(d_tp_rank=7, d_tp_size=8)
+        result = topo.get_all_pp_tp_targets(remote_tp_size=4, remote_pp_size=2)
+        assert result == [3, 7]
+
+    def test_all_8_d_ranks_cover_all_8_global_indices(self):
+        """[FAILS_NOW] All 8 D ranks together must cover all 8 global indices 0-7."""
+        covered: set[int] = set()
+        for d_rank in range(8):
+            topo = self._make_topology(d_tp_rank=d_rank, d_tp_size=8)
+            covered.update(topo.get_all_pp_tp_targets(remote_tp_size=4, remote_pp_size=2))
+        assert covered == set(range(8)), f"Missing global indices: {set(range(8)) - covered}"
+
+    def test_pp4_tp2_d_rank0_connects_to_4_agents(self):
+        """[FAILS_NOW] D_rank=0, D_TP=8, PP4+TP2 -> [0, 2, 4, 6] (one per PP stage)."""
+        topo = self._make_topology(d_tp_rank=0, d_tp_size=8)
+        result = topo.get_all_pp_tp_targets(remote_tp_size=2, remote_pp_size=4)
+        assert result == [0, 2, 4, 6], f"Got {result}"

--- a/tests/v1/kv_connector/unit/test_nixl_connector_pp.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_pp.py
@@ -181,7 +181,7 @@ class TestSideChannelPortPP:
     BASE_PORT = 9100
 
     def _current_port(self, dp_index: int) -> int:
-        """Current formula (from nixl_connector.py:557-560)."""
+        """Current formula (from nixl/scheduler.py)."""
         return self.BASE_PORT + dp_index
 
     def _fixed_port(self, dp_index: int, pp_rank: int, tp_size: int) -> int:
@@ -242,15 +242,15 @@ class TestSideChannelPortPP:
 
 
 # ===========================================================================
-# Tests: TpKVTopology.get_all_pp_tp_targets (Wave 2.2)
+# Tests: TransferTopology.get_all_pp_tp_targets (Wave 2.2)
 # ===========================================================================
 
-class TestTpKVTopologyPP:
+class TestTransferTopologyPP:
     """
-    TpKVTopology needs a new method get_all_pp_tp_targets that returns
+    TransferTopology needs a get_all_pp_tp_targets method that returns
     global worker indices across ALL PP stages for a given local D rank.
 
-    Current get_target_remote_ranks(remote_tp_size=4):
+    Current handshake_target_ranks(remote_tp_size=4):
       D_rank 0,1 -> [0]  (only PP0_TP0, PP1 never reached)
 
     Required get_all_pp_tp_targets(remote_tp_size=4, remote_pp_size=2):
@@ -259,33 +259,34 @@ class TestTpKVTopologyPP:
       D_rank 4,5 -> [2, 6]
       D_rank 6,7 -> [3, 7]
 
-    Formula: for each tp_rank in get_target_remote_ranks(tp_size):
+    Formula: for each tp_rank in handshake_target_ranks(tp_size):
                [tp_rank + pp_rank * tp_size for pp_rank in range(pp_size)]
     """
 
     def _make_topology(self, d_tp_rank: int, d_tp_size: int, engine_id="prefill"):
-        from vllm.distributed.kv_transfer.kv_connector.utils import TpKVTopology
+        from vllm.distributed.kv_transfer.kv_connector.utils import TransferTopology
         from unittest.mock import MagicMock
 
         mock_backend = MagicMock()
         mock_backend.get_kv_cache_shape.return_value = (1, 16, 4, 1, 1)
         mock_backend.get_kv_cache_stride_order.side_effect = NotImplementedError
 
-        return TpKVTopology(
+        return TransferTopology(
             tp_rank=d_tp_rank,
+            tp_size=d_tp_size,
+            block_size=16,
             engine_id=engine_id,
-            remote_tp_size={engine_id: d_tp_size},
-            remote_block_size={engine_id: 16},
             is_mla=True,
+            is_mamba=False,
             total_num_kv_heads=4,
             attn_backends=[mock_backend],
             tensor_shape=None,
         )
 
     def test_pp1_identical_to_existing_method(self):
-        """PP=1: get_all_pp_tp_targets must equal get_target_remote_ranks (backward compat)."""
+        """PP=1: get_all_pp_tp_targets must equal handshake_target_ranks (backward compat)."""
         topo = self._make_topology(d_tp_rank=0, d_tp_size=8)
-        existing = topo.get_target_remote_ranks(remote_tp_size=4)
+        existing = topo.handshake_target_ranks(remote_tp_size=4)
         pp1_result = topo.get_all_pp_tp_targets(remote_tp_size=4, remote_pp_size=1)
         assert pp1_result == existing
 
@@ -342,14 +343,14 @@ class TestNixlConnectorPPWiring:
     2. NixlConnectorMetadata._add_new_req reads pp_size from kv_transfer_params.
     3. NixlConnectorScheduler.request_finished includes pp_size in the returned dict.
     4. NixlConnectorWorker._nixl_handshake receives remote_pp_size and uses
-       get_all_pp_tp_targets instead of get_target_remote_ranks.
+       get_all_pp_tp_targets instead of handshake_target_ranks.
     """
 
     # --- [FAILS_NOW] ReqMeta.pp_size field ---
 
     def test_req_meta_has_pp_size_field(self):
         """[FAILS_NOW] ReqMeta must have a pp_size field (default 1)."""
-        from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import ReqMeta
+        from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import ReqMeta
         import dataclasses
 
         fields = {f.name for f in dataclasses.fields(ReqMeta)}
@@ -360,7 +361,7 @@ class TestNixlConnectorPPWiring:
 
     def test_req_meta_pp_size_default_is_1(self):
         """[FAILS_NOW] ReqMeta.pp_size must default to 1 (backward compat)."""
-        from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import ReqMeta
+        from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import ReqMeta
 
         req = ReqMeta(
             local_block_ids=[],
@@ -374,7 +375,7 @@ class TestNixlConnectorPPWiring:
 
     def test_add_new_req_reads_pp_size_from_params(self):
         """[FAILS_NOW] _add_new_req must read pp_size from kv_transfer_params."""
-        from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import (
+        from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
             NixlConnectorMetadata,
         )
 
@@ -390,7 +391,7 @@ class TestNixlConnectorPPWiring:
 
     def test_add_new_req_pp_size_defaults_to_1(self):
         """[FAILS_NOW] _add_new_req pp_size=1 when not in kv_transfer_params."""
-        from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import (
+        from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
             NixlConnectorMetadata,
         )
 
@@ -406,7 +407,7 @@ class TestNixlConnectorPPWiring:
     def test_request_finished_kv_transfer_params_includes_pp_size(self):
         """[FAILS_NOW] kv_transfer_params returned by request_finished must include pp_size."""
         from unittest.mock import MagicMock, patch
-        from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import (
+        from vllm.distributed.kv_transfer.kv_connector.v1.nixl.scheduler import (
             NixlConnectorScheduler,
         )
         from vllm.v1.kv_cache_interface import (
@@ -435,7 +436,7 @@ class TestNixlConnectorPPWiring:
         )
 
         with patch(
-            "vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector.current_platform"
+            "vllm.distributed.kv_transfer.kv_connector.v1.nixl.scheduler.current_platform"
         ) as mock_platform:
             mock_platform.device_type = "cpu"
             sched = NixlConnectorScheduler(cfg, "engine-0", kv_cache_config)
@@ -464,22 +465,23 @@ class TestNixlConnectorPPWiring:
 
     def test_nixl_handshake_uses_get_all_pp_tp_targets_for_pp2(self):
         """[FAILS_NOW] With remote_pp_size=2, _nixl_handshake must request
-        global indices from get_all_pp_tp_targets (not get_target_remote_ranks).
+        global indices from get_all_pp_tp_targets (not handshake_target_ranks).
 
         Verifies that the method calls get_all_pp_tp_targets when remote_pp_size > 1.
         """
-        from vllm.distributed.kv_transfer.kv_connector.utils import TpKVTopology
+        from vllm.distributed.kv_transfer.kv_connector.utils import TransferTopology
 
         mock_backend = MagicMock()
         mock_backend.get_kv_cache_shape.return_value = (1, 16, 4, 1, 1)
         mock_backend.get_kv_cache_stride_order.side_effect = NotImplementedError
 
-        topo = TpKVTopology(
+        topo = TransferTopology(
             tp_rank=0,
+            tp_size=8,
+            block_size=16,
             engine_id="prefill",
-            remote_tp_size={"prefill": 8},
-            remote_block_size={"prefill": 16},
             is_mla=True,
+            is_mamba=False,
             total_num_kv_heads=4,
             attn_backends=[mock_backend],
             tensor_shape=None,
@@ -487,7 +489,7 @@ class TestNixlConnectorPPWiring:
 
         # With remote PP2+TP4, D_rank=0 must query global indices [0, 4]
         targets_pp2 = topo.get_all_pp_tp_targets(remote_tp_size=4, remote_pp_size=2)
-        targets_pp1 = topo.get_target_remote_ranks(remote_tp_size=4)
+        targets_pp1 = topo.handshake_target_ranks(remote_tp_size=4)
 
         # PP2 must return more targets than PP1
         assert len(targets_pp2) > len(targets_pp1), (

--- a/tests/v1/kv_connector/unit/test_nixl_connector_pp.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_pp.py
@@ -448,6 +448,7 @@ class TestNixlConnectorPPWiring:
         mock_request.request_id = "req-1"
         mock_request.status = RequestStatus.FINISHED_LENGTH_CAPPED
         mock_request.kv_transfer_params = {"do_remote_decode": True}
+        mock_request.num_cached_tokens = 0
 
         with patch.object(sched, "get_sw_clipped_blocks", return_value=[[0, 1, 2]]):
             _, kv_params = sched.request_finished(mock_request, [[0, 1, 2]])

--- a/tests/v1/kv_connector/unit/test_nixl_connector_pp.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_pp.py
@@ -763,6 +763,77 @@ class TestGetBlockDescsIdsNumRegionsOverride:
         )
 
 
+class TestPPStageRegionDescriptorMapping:
+    """
+    PP-stage remote handles are indexed stage-locally, while local handles are
+    indexed in full-model layer order. The transfer must pair those two
+    different descriptor id spaces.
+    """
+
+    class _FakeTopology:
+        def __init__(self, blocks_first: bool):
+            self.is_kv_layout_blocks_first = blocks_first
+
+    @staticmethod
+    def _make_worker(blocks_first: bool):
+        from vllm.distributed.kv_transfer.kv_connector.v1.nixl.worker import (
+            NixlConnectorWorker,
+        )
+
+        worker = NixlConnectorWorker.__new__(NixlConnectorWorker)
+        worker.engine_id = "decode"
+        worker.region_labels = [f"layer.{i}" for i in range(8)]
+        worker.remote_region_labels = {
+            "prefill": {
+                2: ["layer.2", "layer.3"],
+            },
+        }
+        worker.transfer_topo = TestPPStageRegionDescriptorMapping._FakeTopology(
+            blocks_first
+        )
+        worker._has_mamba = False
+        worker.num_regions = 16 if blocks_first else 8
+        worker.dst_num_blocks = {
+            "decode": 100,
+            "prefill": 50,
+        }
+        return worker
+
+    def test_non_blocks_first_uses_remote_local_and_local_full_region_ids(self):
+        worker = self._make_worker(blocks_first=False)
+
+        remote_region_ids = worker._get_remote_stage_region_ids("prefill", 2)
+        local_region_ids = worker._get_local_region_ids_for_remote_stage(
+            "prefill", 2
+        )
+
+        assert remote_region_ids.tolist() == [0, 1]
+        assert local_region_ids.tolist() == [2, 3]
+        assert worker._get_block_descs_ids(
+            "prefill", [[3]], remote_rank=2
+        ).tolist() == [3, 53]
+        assert worker._get_block_descs_ids(
+            "decode", [[3]], region_ids_override=local_region_ids
+        ).tolist() == [203, 303]
+
+    def test_blocks_first_expands_region_ids_in_descriptor_order(self):
+        worker = self._make_worker(blocks_first=True)
+
+        remote_region_ids = worker._get_remote_stage_region_ids("prefill", 2)
+        local_region_ids = worker._get_local_region_ids_for_remote_stage(
+            "prefill", 2
+        )
+
+        assert remote_region_ids.tolist() == [0, 1, 2, 3]
+        assert local_region_ids.tolist() == [4, 5, 6, 7]
+        assert worker._get_block_descs_ids(
+            "prefill", [[3]], remote_rank=2
+        ).tolist() == [3, 53, 103, 153]
+        assert worker._get_block_descs_ids(
+            "decode", [[3]], region_ids_override=local_region_ids
+        ).tolist() == [403, 503, 603, 703]
+
+
 class TestBuildLayerRangeXferHandleStride:
     """
     _build_layer_range_xfer_handle must derive entries_per_layer from

--- a/tests/v1/kv_connector/unit/test_nixl_connector_pp.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_pp.py
@@ -328,3 +328,759 @@ class TestTpKVTopologyPP:
         topo = self._make_topology(d_tp_rank=0, d_tp_size=8)
         result = topo.get_all_pp_tp_targets(remote_tp_size=2, remote_pp_size=4)
         assert result == [0, 2, 4, 6], f"Got {result}"
+
+
+# ===========================================================================
+# Tests: NixlConnector PP wiring (Wave 2.3)
+# ===========================================================================
+
+class TestNixlConnectorPPWiring:
+    """
+    Three wiring changes needed for PP KV transfer:
+
+    1. ReqMeta gets a pp_size field so each request carries the remote PP size.
+    2. NixlConnectorMetadata._add_new_req reads pp_size from kv_transfer_params.
+    3. NixlConnectorScheduler.request_finished includes pp_size in the returned dict.
+    4. NixlConnectorWorker._nixl_handshake receives remote_pp_size and uses
+       get_all_pp_tp_targets instead of get_target_remote_ranks.
+    """
+
+    # --- [FAILS_NOW] ReqMeta.pp_size field ---
+
+    def test_req_meta_has_pp_size_field(self):
+        """[FAILS_NOW] ReqMeta must have a pp_size field (default 1)."""
+        from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import ReqMeta
+        import dataclasses
+
+        fields = {f.name for f in dataclasses.fields(ReqMeta)}
+        assert "pp_size" in fields, (
+            f"ReqMeta missing pp_size field. Current fields: {fields}. "
+            "Add: pp_size: int = 1"
+        )
+
+    def test_req_meta_pp_size_default_is_1(self):
+        """[FAILS_NOW] ReqMeta.pp_size must default to 1 (backward compat)."""
+        from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import ReqMeta
+
+        req = ReqMeta(
+            local_block_ids=[],
+            local_physical_block_ids=[],
+            tp_size=4,
+            # pp_size not specified — should default to 1
+        )
+        assert req.pp_size == 1, f"Expected pp_size=1 (default), got {req.pp_size}"
+
+    # --- [FAILS_NOW] kv_transfer_params includes pp_size ---
+
+    def test_add_new_req_reads_pp_size_from_params(self):
+        """[FAILS_NOW] _add_new_req must read pp_size from kv_transfer_params."""
+        from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import (
+            NixlConnectorMetadata,
+        )
+
+        meta = NixlConnectorMetadata()
+        req_meta = meta._add_new_req(
+            local_block_ids=[0, 1, 2],
+            kv_transfer_params={"tp_size": 4, "pp_size": 2},
+        )
+        assert req_meta.pp_size == 2, (
+            f"Expected pp_size=2 from kv_transfer_params, got {req_meta.pp_size}. "
+            "Fix: tp_size=kv_transfer_params.get('pp_size', 1)"
+        )
+
+    def test_add_new_req_pp_size_defaults_to_1(self):
+        """[FAILS_NOW] _add_new_req pp_size=1 when not in kv_transfer_params."""
+        from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import (
+            NixlConnectorMetadata,
+        )
+
+        meta = NixlConnectorMetadata()
+        req_meta = meta._add_new_req(
+            local_block_ids=[0],
+            kv_transfer_params={"tp_size": 8},  # no pp_size key
+        )
+        assert req_meta.pp_size == 1
+
+    # --- [FAILS_NOW] NixlConnectorScheduler.request_finished includes pp_size ---
+
+    def test_request_finished_kv_transfer_params_includes_pp_size(self):
+        """[FAILS_NOW] kv_transfer_params returned by request_finished must include pp_size."""
+        from unittest.mock import MagicMock, patch
+        from vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector import (
+            NixlConnectorScheduler,
+        )
+        from vllm.v1.kv_cache_interface import (
+            FullAttentionSpec, KVCacheConfig, KVCacheGroupSpec,
+        )
+
+        cfg = MagicMock()
+        cfg.cache_config.block_size = 16
+        cfg.parallel_config.data_parallel_index = 0
+        cfg.parallel_config.tensor_parallel_size = 4
+        cfg.parallel_config.pipeline_parallel_size = 2  # PP2
+        cfg.scheduler_config.disable_hybrid_kv_cache_manager = True
+        cfg.kv_transfer_config = MagicMock()
+        cfg.kv_transfer_config.kv_buffer_device = "cpu"
+
+        kv_cache_config = KVCacheConfig(
+            num_blocks=4,
+            kv_cache_tensors=[],
+            kv_cache_groups=[
+                KVCacheGroupSpec(
+                    ["layer0"],
+                    FullAttentionSpec(block_size=16, num_kv_heads=4,
+                                     head_size=16, dtype=torch.float16),
+                )
+            ],
+        )
+
+        with patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.nixl_connector.current_platform"
+        ) as mock_platform:
+            mock_platform.device_type = "cpu"
+            sched = NixlConnectorScheduler(cfg, "engine-0", kv_cache_config)
+
+        from vllm.v1.request import RequestStatus
+
+        # Mock a finished Decode-side request (do_remote_decode=True)
+        mock_request = MagicMock()
+        mock_request.request_id = "req-1"
+        mock_request.status = RequestStatus.FINISHED_LENGTH_CAPPED
+        mock_request.kv_transfer_params = {"do_remote_decode": True}
+
+        with patch.object(sched, "get_sw_clipped_blocks", return_value=[[0, 1, 2]]):
+            _, kv_params = sched.request_finished(mock_request, [[0, 1, 2]])
+
+        assert kv_params is not None, "request_finished should return kv_transfer_params"
+        assert "pp_size" in kv_params, (
+            f"kv_transfer_params missing pp_size. Got keys: {list(kv_params.keys())}. "
+            "Fix: add pp_size=vllm_config.parallel_config.pipeline_parallel_size"
+        )
+        assert kv_params["pp_size"] == 2, (
+            f"Expected pp_size=2 (from PP2 config), got {kv_params.get('pp_size')}"
+        )
+
+    # --- [FAILS_NOW] _nixl_handshake uses get_all_pp_tp_targets ---
+
+    def test_nixl_handshake_uses_get_all_pp_tp_targets_for_pp2(self):
+        """[FAILS_NOW] With remote_pp_size=2, _nixl_handshake must request
+        global indices from get_all_pp_tp_targets (not get_target_remote_ranks).
+
+        Verifies that the method calls get_all_pp_tp_targets when remote_pp_size > 1.
+        """
+        from vllm.distributed.kv_transfer.kv_connector.utils import TpKVTopology
+
+        mock_backend = MagicMock()
+        mock_backend.get_kv_cache_shape.return_value = (1, 16, 4, 1, 1)
+        mock_backend.get_kv_cache_stride_order.side_effect = NotImplementedError
+
+        topo = TpKVTopology(
+            tp_rank=0,
+            engine_id="prefill",
+            remote_tp_size={"prefill": 8},
+            remote_block_size={"prefill": 16},
+            is_mla=True,
+            total_num_kv_heads=4,
+            attn_backends=[mock_backend],
+            tensor_shape=None,
+        )
+
+        # With remote PP2+TP4, D_rank=0 must query global indices [0, 4]
+        targets_pp2 = topo.get_all_pp_tp_targets(remote_tp_size=4, remote_pp_size=2)
+        targets_pp1 = topo.get_target_remote_ranks(remote_tp_size=4)
+
+        # PP2 must return more targets than PP1
+        assert len(targets_pp2) > len(targets_pp1), (
+            f"PP2 ({targets_pp2}) should have more targets than PP1 ({targets_pp1})"
+        )
+        assert targets_pp2 == [0, 4], f"Expected [0, 4] for D_rank=0 PP2+TP4, got {targets_pp2}"
+        assert targets_pp1 == [0], f"Expected [0] for D_rank=0 TP4 (PP1), got {targets_pp1}"
+
+
+# ===========================================================================
+# Tests: validate_remote_agent_handshake PP layer count mismatch (Wave 2.3 fix)
+# ===========================================================================
+
+class TestValidateRemoteAgentPP:
+    """
+    _validate_remote_agent_handshake must not crash when remote PP agent's
+    block_lens has fewer entries than local block_len_per_layer.
+
+    Root cause: with PP4+TP1 Prefill, each PP rank registers only its 7 layers,
+    so nixl_agent_meta.block_lens has 7 entries. Decode's block_len_per_layer
+    has 27 entries. The loop `for i in range(27)` crashes at i=7.
+
+    Fix: `range(min(local, remote))` - only validate the overlap.
+
+    Tests here use pure Python logic (same as the fix) — no NIXL runtime needed.
+    """
+
+    # --- Pure logic tests for the min() fix ---
+
+    def test_old_range_causes_index_error_pp4(self):
+        """Documents the bug: range(27) with 7-entry block_lens → IndexError at i=7."""
+        block_len_per_layer = [32768] * 27
+        remote_block_lens = [32768] * 7  # PP stage: only 7 layers
+        with pytest.raises(IndexError):
+            for i in range(len(block_len_per_layer)):   # OLD: range(27)
+                _ = block_len_per_layer[i] == remote_block_lens[i]
+
+    def test_fixed_range_no_error_pp4(self):
+        """After fix: min(27,7)=7, range(7) → no IndexError."""
+        block_len_per_layer = [32768] * 27
+        remote_block_lens = [32768] * 7
+        num_check = min(len(block_len_per_layer), len(remote_block_lens))
+        assert num_check == 7
+        for i in range(num_check):   # FIXED: range(7)
+            assert block_len_per_layer[i] == remote_block_lens[i]
+
+    def test_fixed_range_pp1_unchanged(self):
+        """PP=1: min(27,27)=27, all 27 validated, same as before."""
+        block_len_per_layer = [32768] * 27
+        remote_block_lens = [32768] * 27
+        num_check = min(len(block_len_per_layer), len(remote_block_lens))
+        assert num_check == 27
+        for i in range(num_check):
+            assert block_len_per_layer[i] == remote_block_lens[i]
+
+    def test_fixed_range_mismatch_still_caught(self):
+        """Block size mismatch in overlap still raises AssertionError."""
+        block_len_per_layer = [32768] * 27
+        remote_block_lens = [16384] * 7   # WRONG
+        num_check = min(len(block_len_per_layer), len(remote_block_lens))
+        with pytest.raises(AssertionError):
+            for i in range(num_check):
+                assert block_len_per_layer[i] == remote_block_lens[i], \
+                    "KV cache sizes must match between P and D when replicated"
+
+    def test_fixed_range_all_pp4_stages(self):
+        """PP4: 4 stages with 7/7/7/6 layers each, all pass without IndexError."""
+        block_len_per_layer = [32768] * 27
+        for pp_rank, num_layers in enumerate([7, 7, 7, 6]):
+            remote = [32768] * num_layers
+            num_check = min(len(block_len_per_layer), len(remote))
+            for i in range(num_check):
+                assert block_len_per_layer[i] == remote[i]
+
+    # (Old integration tests with complex mocks removed - pure logic tests above cover the fix)
+
+
+# ===========================================================================
+# Tests: layer-range routing - _build_layer_range_xfer_handle (Wave 2.5)
+# ===========================================================================
+
+class TestPPLayerRangeRouting:
+    """
+    With PP Prefill, each PP rank has a different layer subset.
+    The local src handle must cover only the same layers as the remote PP rank
+    so that make_prepped_xfer src/dst descriptor counts match.
+
+    Root cause: PP4+TP1 Prefill PP0 has 7 layers (indices 0-6).
+    Decode local handle has 27 layers. make_prepped_xfer tries remote[7] → crash.
+    Fix: build per-PP-rank local handle sliced to matching layer range.
+    """
+
+    def test_layer_slice_pp4_stage0(self):
+        """PP rank 0 (7 layers): slice [0:7] of local blocks_data."""
+        num_blocks = 10
+        num_total_layers = 27
+        # Simulate blocks_data as a flat list: layer0_b0, layer0_b1, ..., layer26_b9
+        blocks_data = [(i, 64, 0) for i in range(num_total_layers * num_blocks)]
+
+        pp0_start, pp0_end = 0, 7
+        sliced = blocks_data[pp0_start * num_blocks: pp0_end * num_blocks]
+        assert len(sliced) == 7 * num_blocks
+        assert sliced[0] == blocks_data[0]         # first block of layer 0
+        assert sliced[-1] == blocks_data[70 - 1]   # last block of layer 6
+
+    def test_layer_slice_pp4_stage1(self):
+        """PP rank 1 (7 layers): slice [7:14] of local blocks_data."""
+        num_blocks = 10
+        blocks_data = [(i, 64, 0) for i in range(27 * num_blocks)]
+
+        pp1_start, pp1_end = 7, 14
+        sliced = blocks_data[pp1_start * num_blocks: pp1_end * num_blocks]
+        assert len(sliced) == 7 * num_blocks
+        assert sliced[0] == blocks_data[7 * num_blocks]   # first block of layer 7
+
+    def test_layer_slice_pp4_stage3_uneven(self):
+        """PP rank 3 (6 layers, uneven): slice [21:27] of local blocks_data."""
+        num_blocks = 10
+        blocks_data = [(i, 64, 0) for i in range(27 * num_blocks)]
+
+        pp3_start, pp3_end = 21, 27
+        sliced = blocks_data[pp3_start * num_blocks: pp3_end * num_blocks]
+        assert len(sliced) == 6 * num_blocks  # 6 not 7
+
+    def test_all_pp4_slices_cover_all_layers(self):
+        """4 PP stage slices together cover all 27 layers exactly once."""
+        num_blocks = 10
+        blocks_data = [(i, 64, 0) for i in range(27 * num_blocks)]
+        pp_layer_counts = [7, 7, 7, 6]  # 3x7 + 6 = 27
+
+        all_sliced = []
+        offset = 0
+        for count in pp_layer_counts:
+            sliced = blocks_data[offset * num_blocks: (offset + count) * num_blocks]
+            all_sliced.extend(sliced)
+            offset += count
+
+        # All 27*10 = 270 elements covered exactly once
+        assert len(all_sliced) == 27 * num_blocks
+        assert all_sliced == blocks_data
+
+    def test_pp1_no_slicing_needed(self):
+        """PP=1: use full blocks_data (same behavior as before)."""
+        num_blocks = 10
+        blocks_data = [(i, 64, 0) for i in range(27 * num_blocks)]
+
+        # PP=1: layer_range = [0:27] = full list
+        sliced = blocks_data[0: 27 * num_blocks]
+        assert sliced == blocks_data
+
+
+# ===========================================================================
+# Tests: _get_block_descs_ids num_regions_override (Wave 2.5 fix)
+# ===========================================================================
+
+class TestGetBlockDescsIdsNumRegionsOverride:
+    """
+    When a PP slice handle is used (local_xfer_side_handle covers only
+    num_pp_layers layers), _get_block_descs_ids must use num_pp_layers as
+    num_regions so all generated IDs stay within [0, num_pp_layers*num_blocks).
+
+    Root cause of the "makeXferReq local index N out of range" error:
+    - PP slice handle has (num_pp_layers * num_blocks) descriptors.
+    - _get_block_descs_ids used self.num_regions (=27, full model), producing
+      indices up to 26*num_blocks+block_id — way beyond the slice handle size.
+    - Fix: pass num_regions_override=num_pp_layers to _get_block_descs_ids.
+
+    These are pure-logic tests (no NIXL runtime needed).
+    """
+
+    @staticmethod
+    def _compute_descs_ids(
+        num_regions: int, num_blocks_per_engine: int, block_ids: list[int]
+    ) -> list[int]:
+        """Replicate the non-Mamba branch of _get_block_descs_ids."""
+        import numpy as np
+        region_ids = np.arange(num_regions)[:, None]
+        bids = np.array(block_ids)[None, :]
+        return (region_ids * num_blocks_per_engine + bids).flatten().tolist()
+
+    def test_full_27_regions_exceeds_7layer_slice_handle(self):
+        """Bug repro: full 27-region IDs exceed a 7-layer slice handle of size 7*nb."""
+        num_blocks = 200  # Decode's total num_blocks
+        num_pp_layers = 7
+        # Decode's total blocks per engine id (dst_num_blocks)
+        ids_full = self._compute_descs_ids(27, num_blocks, block_ids=[14])
+        # PP slice handle only has 7 * num_blocks entries
+        max_valid = num_pp_layers * num_blocks - 1
+        assert any(idx > max_valid for idx in ids_full), (
+            "Expected some IDs to be out of range of the 7-layer slice handle"
+        )
+
+    def test_7_regions_override_stays_within_slice_handle(self):
+        """Fix: with num_regions_override=7, all IDs <= 7*num_blocks-1."""
+        num_blocks = 200
+        num_pp_layers = 7
+        # A request with a few block IDs
+        request_block_ids = [0, 1, 5, 14, 100]
+        ids_sliced = self._compute_descs_ids(num_pp_layers, num_blocks, request_block_ids)
+        max_valid = num_pp_layers * num_blocks - 1
+        assert all(idx <= max_valid for idx in ids_sliced), (
+            f"Some IDs exceed slice handle size {max_valid}: {ids_sliced}"
+        )
+
+    def test_7_regions_override_correct_formula(self):
+        """IDs with override=7 are: [r*nb+b for r in 0..6 for b in block_ids]."""
+        num_blocks = 200
+        block_ids = [3, 7]
+        ids = self._compute_descs_ids(7, num_blocks, block_ids)
+        expected = [r * num_blocks + b for r in range(7) for b in block_ids]
+        assert ids == expected
+
+    def test_all_pp4_ranks_use_correct_override(self):
+        """PP4+TP1 (layers 7/7/7/6): each rank uses its own num_pp_layers as override."""
+        num_blocks = 150
+        pp_layer_counts = [7, 7, 7, 6]
+        request_block_ids = [0, 10, 50]
+
+        for num_pp_layers in pp_layer_counts:
+            ids = self._compute_descs_ids(num_pp_layers, num_blocks, request_block_ids)
+            max_valid = num_pp_layers * num_blocks - 1
+            assert all(idx <= max_valid for idx in ids), (
+                f"PP rank with {num_pp_layers} layers: ID out of range. "
+                f"max_valid={max_valid}, ids={ids}"
+            )
+
+    def test_pp1_no_override_same_result_as_full(self):
+        """PP=1: no override → num_regions=27, same as before (backward compat)."""
+        num_blocks = 100
+        block_ids = [0, 5, 20]
+        ids_no_override = self._compute_descs_ids(27, num_blocks, block_ids)
+        # With override=27 (full model, PP=1 scenario), same result
+        ids_override_27 = self._compute_descs_ids(27, num_blocks, block_ids)
+        assert ids_no_override == ids_override_27
+
+    def test_local_remote_same_override_equal_lengths(self):
+        """Invariant: local and remote desc ID arrays must have equal length.
+
+        Mirrors the assert in _read_blocks:
+            assert len(local_block_descs_ids) == len(remote_block_descs_ids)
+
+        With pp_num_regions override on both sides, lengths are equal regardless
+        of the request's block count.
+        """
+        local_num_blocks = 200
+        remote_num_blocks = 150
+        pp_num_regions = 7
+        request_block_ids = [0, 3, 8, 14, 50]
+
+        local_ids = self._compute_descs_ids(pp_num_regions, local_num_blocks, request_block_ids)
+        remote_ids = self._compute_descs_ids(pp_num_regions, remote_num_blocks, request_block_ids)
+        assert len(local_ids) == len(remote_ids), (
+            f"local={len(local_ids)} remote={len(remote_ids)} must be equal"
+        )
+        assert len(local_ids) == pp_num_regions * len(request_block_ids)
+
+    def test_without_override_lengths_differ(self):
+        """Documents the original bug: using full num_regions on local (override=7)
+        vs remote (no override=27) causes length mismatch → AssertionError."""
+        local_num_blocks = 200
+        remote_num_blocks = 150
+        full_num_regions = 27
+        pp_num_regions = 7
+        request_block_ids = [0, 3, 8]
+
+        # local with override, remote without (old broken behavior)
+        local_ids_override = self._compute_descs_ids(pp_num_regions, local_num_blocks, request_block_ids)
+        remote_ids_full = self._compute_descs_ids(full_num_regions, remote_num_blocks, request_block_ids)
+        assert len(local_ids_override) != len(remote_ids_full), (
+            "Expected mismatch documenting the pre-fix bug"
+        )
+
+
+class TestBuildLayerRangeXferHandleStride:
+    """
+    _build_layer_range_xfer_handle must derive entries_per_layer from
+    len(src_blocks_data) // num_local_layers rather than using num_blocks
+    directly. This fixes the stride for blocks-first (FlashInfer) layout where
+    each layer contributes 2 * num_blocks entries (K + V as separate regions).
+    """
+
+    @staticmethod
+    def _make_blocks_data(num_layers: int, num_blocks: int, blocks_first: bool):
+        """Build a mock src_blocks_data matching register_local_xfer_handler output."""
+        data = []
+        for layer in range(num_layers):
+            # K entries
+            for b in range(num_blocks):
+                data.append((layer * 1000 + b, 64, 0))
+            if blocks_first:
+                # V entries appended right after K for this layer
+                for b in range(num_blocks):
+                    data.append((layer * 1000 + num_blocks + b, 32, 0))
+        return data
+
+    def _entries_per_layer(self, src_blocks_data, num_local_layers):
+        """Replicate the fix's computation."""
+        return len(src_blocks_data) // num_local_layers
+
+    def test_standard_layout_stride_equals_num_blocks(self):
+        """Non-blocks-first: entries_per_layer == num_blocks."""
+        num_layers, num_blocks = 27, 100
+        data = self._make_blocks_data(num_layers, num_blocks, blocks_first=False)
+        assert len(data) == num_layers * num_blocks
+        assert self._entries_per_layer(data, num_layers) == num_blocks
+
+    def test_blocks_first_stride_equals_2x_num_blocks(self):
+        """FlashInfer (blocks-first): entries_per_layer == 2 * num_blocks."""
+        num_layers, num_blocks = 27, 100
+        data = self._make_blocks_data(num_layers, num_blocks, blocks_first=True)
+        assert len(data) == num_layers * num_blocks * 2
+        assert self._entries_per_layer(data, num_layers) == num_blocks * 2
+
+    def test_slice_standard_pp4_stage0(self):
+        """Standard: slice [0:7] has exactly 7 * num_blocks entries."""
+        num_layers, num_blocks = 27, 100
+        data = self._make_blocks_data(num_layers, num_blocks, blocks_first=False)
+        epl = self._entries_per_layer(data, num_layers)
+        sliced = data[0 * epl : 7 * epl]
+        assert len(sliced) == 7 * num_blocks
+
+    def test_slice_blocks_first_pp4_stage0(self):
+        """FlashInfer: slice [0:7] has exactly 7 * 2 * num_blocks entries."""
+        num_layers, num_blocks = 27, 100
+        data = self._make_blocks_data(num_layers, num_blocks, blocks_first=True)
+        epl = self._entries_per_layer(data, num_layers)
+        sliced = data[0 * epl : 7 * epl]
+        assert len(sliced) == 7 * num_blocks * 2
+
+    def test_old_stride_wrong_for_blocks_first(self):
+        """Documents the old bug: using num_blocks as stride cuts off V entries."""
+        num_layers, num_blocks = 27, 100
+        data = self._make_blocks_data(num_layers, num_blocks, blocks_first=True)
+        # Old code used num_blocks as stride
+        old_sliced = data[0 * num_blocks : 7 * num_blocks]
+        # New code uses entries_per_layer = 2 * num_blocks
+        epl = self._entries_per_layer(data, num_layers)
+        new_sliced = data[0 * epl : 7 * epl]
+        assert len(old_sliced) == 7 * num_blocks        # too short (missing V)
+        assert len(new_sliced) == 7 * num_blocks * 2    # correct
+        assert len(old_sliced) != len(new_sliced)
+
+    def test_num_pp_regions_blocks_first_is_2x_layers(self):
+        """PP num_pp_regions for blocks-first = num_pp_layers * regions_per_layer (=2)."""
+        num_layers, num_blocks = 27, 100
+        data = self._make_blocks_data(num_layers, num_blocks, blocks_first=True)
+        # Simulate: num_regions = 54 (27 * 2), num_local_layers = 27
+        num_regions = num_layers * 2  # is_kv_layout_blocks_first doubles regions
+        regions_per_layer = num_regions // num_layers
+        assert regions_per_layer == 2
+
+        num_pp_layers = 7
+        num_pp_regions = num_pp_layers * regions_per_layer
+        assert num_pp_regions == 14  # override value for PP stage of 7 layers
+
+    def test_all_pp4_slices_cover_all_layers_blocks_first(self):
+        """FlashInfer PP4: 4 slices together cover all 27*2*num_blocks entries."""
+        num_layers, num_blocks = 27, 100
+        data = self._make_blocks_data(num_layers, num_blocks, blocks_first=True)
+        epl = self._entries_per_layer(data, num_layers)
+
+        pp_layer_counts = [7, 7, 7, 6]
+        offset = 0
+        all_sliced = []
+        for count in pp_layer_counts:
+            sliced = data[offset * epl : (offset + count) * epl]
+            all_sliced.extend(sliced)
+            offset += count
+
+        assert len(all_sliced) == num_layers * num_blocks * 2
+        assert all_sliced == data
+
+
+# ===========================================================================
+# Tests: MLA tp_ratio < 0 loop restructure for PP > 1 (full fix)
+# ===========================================================================
+
+class TestMlaPerStageTpOptimization:
+    """
+    Full fix for MLA optimization when PP > 1 and P.TP > D.TP.
+
+    Root cause of original bug: the flat loop used `break` at `i > 0`, which
+    dropped all PP stages 1..N when tp_ratio < 0 (P.TP > D.TP).
+
+    Fix: use `continue` (not `break`) at `i_in_stage > 0`, where
+    `i_in_stage = i % n_tp_per_stage` and `n_tp_per_stage = abs(tp_ratio)`.
+
+    This correctly:
+    - Skips non-first TP ranks WITHIN each PP stage (MLA: KV replicated)
+    - Processes ALL PP stages (reads from first TP rank of each)
+    - Sends per-stage notifications (only to skipped TP ranks of the same stage)
+
+    Handshake fix: pp_layer_offset advances per PP stage, not per TP rank.
+    All TP ranks in the same PP stage receive the same layer-slice handle.
+
+    Current setup (PP4+TP1 Prefill, tp_ratio=+1) is unaffected.
+    """
+
+    @staticmethod
+    def _tp_ratio(local_tp: int, remote_tp: int) -> int:
+        if local_tp >= remote_tp:
+            return local_tp // remote_tp
+        return -(remote_tp // local_tp)
+
+    @staticmethod
+    def _get_all_pp_tp_targets(d_tp_rank: int, d_tp_size: int,
+                                remote_tp_size: int, remote_pp_size: int):
+        tp_ratio = TestMlaPerStageTpOptimization._tp_ratio(d_tp_size, remote_tp_size)
+        if tp_ratio > 0:
+            tp_targets = [d_tp_rank // tp_ratio]
+        else:
+            r = -tp_ratio
+            tp_targets = [d_tp_rank * r + i for i in range(r)]
+        return [tr + pp * remote_tp_size
+                for pp in range(remote_pp_size)
+                for tr in tp_targets]
+
+    @staticmethod
+    def _simulate_loop(remote_ranks, tp_ratio, use_mla):
+        """
+        Simulate _read_blocks_for_req fixed loop.
+        Returns (reads, notifications) where:
+          reads         = list of remote_ranks that trigger _read_blocks
+          notifications = list of (from_rank, to_rank) notif pairs
+        """
+        n_tp_per_stage = (-tp_ratio) if tp_ratio < 0 else 1
+        reads = []
+        notifications = []
+        for i, rank in enumerate(remote_ranks):
+            i_in_stage = i % n_tp_per_stage
+            if use_mla and tp_ratio < 0 and i_in_stage > 0:
+                continue  # skip non-first TP rank within PP stage
+            reads.append(rank)
+            if use_mla and tp_ratio < 0:
+                # notify skipped TP ranks within THIS PP stage only
+                for j in range(1, n_tp_per_stage):
+                    skipped_idx = i + j
+                    if skipped_idx < len(remote_ranks):
+                        notifications.append((rank, remote_ranks[skipped_idx]))
+        return reads, notifications
+
+    @staticmethod
+    def _simulate_handshake_offsets(remote_ranks, remote_tp_size,
+                                     pp_layer_counts):
+        """
+        Simulate _nixl_handshake pp_layer_offset assignment.
+        pp_layer_counts: dict {pp_stage: num_layers} or list indexed by pp_stage.
+        Returns dict {remote_rank: (start_layer, end_layer)}.
+        """
+        pp_layer_offset = 0
+        pp_layer_last_stage = -1
+        pp_layer_last_num_layers = 0
+        result = {}
+        for remote_rank in remote_ranks:
+            pp_stage = remote_rank // remote_tp_size
+            num_pp_layers = (pp_layer_counts[pp_stage]
+                             if isinstance(pp_layer_counts, list)
+                             else pp_layer_counts[pp_stage])
+            if pp_stage != pp_layer_last_stage:
+                if pp_layer_last_stage >= 0:
+                    pp_layer_offset += pp_layer_last_num_layers
+                pp_layer_last_stage = pp_stage
+                pp_layer_last_num_layers = num_pp_layers
+            result[remote_rank] = (pp_layer_offset, pp_layer_offset + num_pp_layers)
+        return result
+
+    # ── loop behavior tests ──────────────────────────────────────────────────
+
+    def test_pp4_tp1_all_stages_read(self):
+        """PP4+TP1 Prefill + D.TP=1: tp_ratio=+1, all 4 PP stages read."""
+        tp_ratio = self._tp_ratio(1, 1)
+        remote_ranks = self._get_all_pp_tp_targets(0, 1, 1, 4)
+        assert remote_ranks == [0, 1, 2, 3]
+
+        reads, notifs = self._simulate_loop(remote_ranks, tp_ratio, use_mla=True)
+        assert reads == [0, 1, 2, 3], "All PP stages must trigger a read"
+        assert notifs == [], "No notifications: tp_ratio > 0"
+
+    def test_pp4_tp4_prefill_d_tp1_mla_reads_one_per_stage(self):
+        """PP4+TP4 Prefill + D.TP=1 (MLA, tp_ratio=-4): reads first TP rank per stage."""
+        tp_ratio = self._tp_ratio(1, 4)
+        assert tp_ratio == -4
+        remote_ranks = self._get_all_pp_tp_targets(0, 1, 4, 4)
+        assert remote_ranks == list(range(16))
+
+        reads, notifs = self._simulate_loop(remote_ranks, tp_ratio, use_mla=True)
+        # Exactly one read per PP stage (ranks 0, 4, 8, 12)
+        assert reads == [0, 4, 8, 12], f"Expected first TP rank of each PP stage, got {reads}"
+
+    def test_pp4_tp4_prefill_d_tp1_mla_notifications_per_stage(self):
+        """PP4+TP4 Prefill + D.TP=1 (MLA): notifications sent only within each stage."""
+        tp_ratio = self._tp_ratio(1, 4)
+        remote_ranks = self._get_all_pp_tp_targets(0, 1, 4, 4)
+        _, notifs = self._simulate_loop(remote_ranks, tp_ratio, use_mla=True)
+
+        # Expected: from rank 0 → notify 1,2,3; from 4 → 5,6,7; etc.
+        expected = [(0,1),(0,2),(0,3), (4,5),(4,6),(4,7),
+                    (8,9),(8,10),(8,11), (12,13),(12,14),(12,15)]
+        assert notifs == expected, f"Unexpected notifications: {notifs}"
+        # No cross-stage notifications (e.g. rank 0 should NOT notify rank 4)
+        for (src, dst) in notifs:
+            assert src // 4 == dst // 4, f"Cross-stage notif: {src}→{dst}"
+
+    def test_old_break_at_i1_documents_original_bug(self):
+        """Document original bug: break at i=1 drops PP stages 1-3."""
+        tp_ratio = self._tp_ratio(1, 4)
+        remote_ranks = self._get_all_pp_tp_targets(0, 1, 4, 4)
+        # OLD behavior (break at i>0)
+        old_reads = []
+        for i, rank in enumerate(remote_ranks):
+            if tp_ratio < 0 and i > 0:
+                break
+            old_reads.append(rank)
+        assert old_reads == [0], "Bug confirmed: old code reads only rank 0"
+
+    def test_pp1_mla_tp_ratio_negative_still_reads_only_rank0(self):
+        """PP=1 (no PP), MLA, P.TP=4 > D.TP=1: reads rank 0, notifies 1,2,3."""
+        tp_ratio = self._tp_ratio(1, 4)
+        remote_ranks = self._get_all_pp_tp_targets(0, 1, 4, 1)
+        assert remote_ranks == [0, 1, 2, 3]
+
+        reads, notifs = self._simulate_loop(remote_ranks, tp_ratio, use_mla=True)
+        assert reads == [0], "PP=1 MLA opt: only rank 0 read"
+        assert notifs == [(0, 1), (0, 2), (0, 3)], "Notify all skipped TP ranks"
+
+    def test_current_setup_tp_ratio_always_positive(self):
+        """PP4+TP1 Prefill: tp_ratio always positive, optimization never fires."""
+        for d_tp in [1, 2, 4]:
+            ratio = self._tp_ratio(d_tp, 1)
+            assert ratio > 0
+            n_tp_per_stage = (-ratio) if ratio < 0 else 1
+            assert n_tp_per_stage == 1  # no per-stage grouping needed
+
+    # ── handshake layer offset tests ─────────────────────────────────────────
+
+    def test_handshake_pp4_tp1_offsets_per_stage(self):
+        """PP4+TP1: 4 remote_ranks → each advances pp_layer_offset by 7 (last=6)."""
+        remote_tp_size = 1
+        remote_ranks = [0, 1, 2, 3]
+        layer_counts = [7, 7, 7, 6]  # PP0..PP3
+
+        offsets = self._simulate_handshake_offsets(
+            remote_ranks, remote_tp_size, layer_counts)
+
+        assert offsets[0] == (0, 7)
+        assert offsets[1] == (7, 14)
+        assert offsets[2] == (14, 21)
+        assert offsets[3] == (21, 27)
+
+    def test_handshake_pp4_tp4_all_tp_ranks_same_stage_same_offset(self):
+        """PP4+TP4: all 4 TP ranks of the same PP stage share the same offset."""
+        remote_tp_size = 4
+        remote_ranks = list(range(16))
+        layer_counts = [7, 7, 7, 6]  # per PP stage
+
+        offsets = self._simulate_handshake_offsets(
+            remote_ranks, remote_tp_size, layer_counts)
+
+        # PP stage 0: global ranks 0-3, all layers [0:7]
+        for rank in [0, 1, 2, 3]:
+            assert offsets[rank] == (0, 7), f"rank {rank}: {offsets[rank]}"
+        # PP stage 1: global ranks 4-7, all layers [7:14]
+        for rank in [4, 5, 6, 7]:
+            assert offsets[rank] == (7, 14), f"rank {rank}: {offsets[rank]}"
+        # PP stage 2: global ranks 8-11, all layers [14:21]
+        for rank in [8, 9, 10, 11]:
+            assert offsets[rank] == (14, 21), f"rank {rank}: {offsets[rank]}"
+        # PP stage 3: global ranks 12-15, all layers [21:27]
+        for rank in [12, 13, 14, 15]:
+            assert offsets[rank] == (21, 27), f"rank {rank}: {offsets[rank]}"
+
+    def test_handshake_old_per_rank_advance_was_wrong(self):
+        """Document original bug: advancing per-rank gives wrong offsets for PP4+TP4."""
+        remote_tp_size = 4
+        remote_ranks = list(range(16))
+        num_pp_layers = 7  # constant for simplicity
+
+        # OLD: advance per remote_rank
+        old_offsets = {}
+        pp_layer_offset = 0
+        for rank in remote_ranks:
+            old_offsets[rank] = (pp_layer_offset, pp_layer_offset + num_pp_layers)
+            pp_layer_offset += num_pp_layers  # ← wrong: advances every rank
+
+        # PP0 TP0 → correct [0:7]; PP0 TP1 → wrong [7:14] instead of [0:7]
+        assert old_offsets[0] == (0, 7)   # PP0 TP0 accidentally correct
+        assert old_offsets[1] == (7, 14)  # PP0 TP1 WRONG (should be [0:7])
+        assert old_offsets[4] == (28, 35) # PP1 TP0 WRONG (should be [7:14])
+
+        # NEW: advance per PP stage — these are correct
+        layer_counts = {s: num_pp_layers for s in range(4)}
+        new_offsets = self._simulate_handshake_offsets(
+            remote_ranks, remote_tp_size, layer_counts)
+        assert new_offsets[0] == (0, 7)
+        assert new_offsets[1] == (0, 7)   # same stage as rank 0
+        assert new_offsets[4] == (7, 14)  # PP1 correct

--- a/tests/v1/kv_connector/unit/test_nixl_connector_pp.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_pp.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+# Unit tests for PP support in NixlConnector.
+#
+# TDD: Tests marked [FAILS_NOW] fail with current vllm code and pass after fix.
+#      Tests marked [PASSES_NOW] document current (broken) behavior.
+#
+# Two gaps under test:
+# 1. gpu_worker.get_kv_connector_handshake_metadata: key = tp_rank only (collision)
+#    Fix: key = pp_rank * tp_size + tp_rank  (global worker index)
+# 2. NixlConnectorScheduler.side_channel_port: offset by dp_index only (collision)
+#    Fix: offset += pp_rank * tp_size
+
+import pytest
+import torch
+from unittest.mock import MagicMock, patch
+
+# ---------------------------------------------------------------------------
+# Import the actual vllm functions under test
+# ---------------------------------------------------------------------------
+from vllm.v1.worker.gpu_worker import Worker as GPUWorker
+
+
+# ---------------------------------------------------------------------------
+# Helper: call GPUWorker.get_kv_connector_handshake_metadata as unbound method
+# with mocked tp_rank, pp_rank, tp_size, and a fake metadata object.
+# ---------------------------------------------------------------------------
+
+def _call_handshake_metadata(tp_rank: int, pp_rank: int, tp_size: int):
+    """
+    Call the actual GPUWorker.get_kv_connector_handshake_metadata with
+    mocked distributed state.  Returns the dict it produces.
+    """
+    fake_metadata = MagicMock(name="metadata")
+
+    mock_tp_group = MagicMock()
+    mock_tp_group.rank_in_group = tp_rank
+
+    mock_pp_group = MagicMock()
+    mock_pp_group.rank_in_group = pp_rank
+    mock_pp_group.world_size = tp_size  # pp_size (unused in current code)
+
+    mock_connector = MagicMock()
+    mock_connector.get_handshake_metadata.return_value = fake_metadata
+
+    mock_parallel_config = MagicMock()
+    mock_parallel_config.tensor_parallel_size = tp_size
+    mock_parallel_config.pipeline_parallel_size = max(1, pp_rank + 1)  # at least pp_rank+1
+
+    mock_self = MagicMock()
+    mock_self.vllm_config.parallel_config = mock_parallel_config
+
+    with (
+        patch("vllm.v1.worker.gpu_worker.has_kv_transfer_group", return_value=True),
+        patch("vllm.v1.worker.gpu_worker.get_kv_transfer_group",
+              return_value=mock_connector),
+        patch("vllm.v1.worker.gpu_worker.get_tp_group", return_value=mock_tp_group),
+        # get_pp_group does not exist yet in gpu_worker — patching it in advance
+        patch("vllm.v1.worker.gpu_worker.get_pp_group",
+              return_value=mock_pp_group),
+    ):
+        return GPUWorker.get_kv_connector_handshake_metadata(mock_self)
+
+
+# ===========================================================================
+# Gap 1: Handshake key collision
+# ===========================================================================
+
+class TestHandshakeKeyPP:
+    """
+    GPUWorker.get_kv_connector_handshake_metadata should return a key that
+    uniquely identifies each worker across both TP and PP dimensions.
+
+    Current code: key = tp_rank   (only TP dimension)
+    Required fix: key = pp_rank * tp_size + tp_rank   (global worker index)
+    """
+
+    # --- [PASSES_NOW] Documents current behavior: key is just tp_rank ---
+
+    def test_pp1_tp0_key_is_0_current(self):
+        """PP=1, tp_rank=0 → key must be 0 (baseline, no PP)."""
+        result = _call_handshake_metadata(tp_rank=0, pp_rank=0, tp_size=4)
+        assert result is not None
+        assert 0 in result
+
+    def test_pp1_tp1_key_is_1_current(self):
+        """PP=1, tp_rank=1 → key must be 1 (baseline, no PP)."""
+        result = _call_handshake_metadata(tp_rank=1, pp_rank=0, tp_size=4)
+        assert result is not None
+        assert 1 in result
+
+    # --- [FAILS_NOW] These tests FAIL with current code, PASS after fix ---
+
+    def test_pp1_rank1_tp_rank0_key_must_be_4(self):
+        """[FAILS_NOW] pp_rank=1, tp_rank=0, tp_size=4 → key must be 4, not 0.
+
+        Current code returns {0: metadata} because it ignores pp_rank.
+        After fix it should return {4: metadata} (1*4+0=4).
+        """
+        result = _call_handshake_metadata(tp_rank=0, pp_rank=1, tp_size=4)
+        assert result is not None
+        assert 4 in result, (
+            f"Expected key=4 (pp_rank=1*tp_size=4+tp_rank=0), "
+            f"got keys={list(result.keys())}. "
+            "Fix: use pp_rank * tp_size + tp_rank as key."
+        )
+
+    def test_pp1_rank1_tp_rank3_key_must_be_7(self):
+        """[FAILS_NOW] pp_rank=1, tp_rank=3, tp_size=4 → key must be 7."""
+        result = _call_handshake_metadata(tp_rank=3, pp_rank=1, tp_size=4)
+        assert result is not None
+        assert 7 in result, (
+            f"Expected key=7 (1*4+3), got keys={list(result.keys())}"
+        )
+
+    def test_pp3_rank3_tp_rank1_key_must_be_7(self):
+        """[FAILS_NOW] pp_rank=3, tp_rank=1, tp_size=2 → key must be 7 (3*2+1)."""
+        result = _call_handshake_metadata(tp_rank=1, pp_rank=3, tp_size=2)
+        assert result is not None
+        assert 7 in result, (
+            f"Expected key=7 (3*2+1), got keys={list(result.keys())}"
+        )
+
+    def test_pp0_workers_survive_merge_with_pp1(self):
+        """[FAILS_NOW] After merging PP0+PP1 workers, PP0 metadata must NOT be lost.
+
+        Simulates engine/core.py collecting metadata from all 8 workers (PP2+TP4).
+        With current code (key=tp_rank), PP0 is overwritten by PP1.
+        After fix (key=global_idx), all 8 workers survive.
+        """
+        # Collect dicts from 8 workers (PP2+TP4)
+        worker_dicts = [
+            _call_handshake_metadata(tp_rank=tp_r, pp_rank=pp_r, tp_size=4)
+            for pp_r in range(2)
+            for tp_r in range(4)
+        ]
+
+        # Merge (mirrors engine/core.py logic)
+        merged: dict = {}
+        for d in worker_dicts:
+            if d is not None:
+                merged.update(d)
+
+        # After fix: all 8 workers present (keys 0-7)
+        assert len(merged) == 8, (
+            f"Expected 8 unique worker entries after merge, got {len(merged)}. "
+            "Current code loses PP0 workers because PP1 overwrites them."
+        )
+
+        # Verify PP0 workers (keys 0-3) are present
+        for tp_r in range(4):
+            expected_key = 0 * 4 + tp_r  # pp_rank=0
+            assert expected_key in merged, f"PP0 tp_rank={tp_r} missing from merged dict"
+
+        # Verify PP1 workers (keys 4-7) are present
+        for tp_r in range(4):
+            expected_key = 1 * 4 + tp_r  # pp_rank=1
+            assert expected_key in merged, f"PP1 tp_rank={tp_r} missing from merged dict"
+
+    def test_pp1_behavior_backward_compatible(self):
+        """[PASSES_NOW and after fix] PP=1 key=0 is unchanged."""
+        result_pp1 = _call_handshake_metadata(tp_rank=0, pp_rank=0, tp_size=4)
+        # With both current and fixed code, PP=1 should return key=0
+        assert result_pp1 is not None
+        assert 0 in result_pp1
+
+
+# ===========================================================================
+# Gap 2: Side-channel port collision
+# ===========================================================================
+
+class TestSideChannelPortPP:
+    """
+    NixlConnectorScheduler.side_channel_port must be unique per PP rank.
+
+    Current code:  port = BASE + data_parallel_index
+    Required fix:  port = BASE + data_parallel_index + pp_rank * tp_size
+
+    We test the formula directly since full scheduler init requires complex config.
+    """
+
+    BASE_PORT = 9100
+
+    def _current_port(self, dp_index: int) -> int:
+        """Current formula (from nixl_connector.py:557-560)."""
+        return self.BASE_PORT + dp_index
+
+    def _fixed_port(self, dp_index: int, pp_rank: int, tp_size: int) -> int:
+        """Expected formula after fix."""
+        return self.BASE_PORT + dp_index + pp_rank * tp_size
+
+    # --- [PASSES_NOW] Documents current broken behavior ---
+
+    def test_current_formula_collision_same_dp_different_pp(self):
+        """[PASSES_NOW] Current formula: PP0 and PP1 get same port when dp_index=0."""
+        port_pp0 = self._current_port(dp_index=0)
+        port_pp1 = self._current_port(dp_index=0)
+        # This is the BUG: same port for different PP stages
+        assert port_pp0 == port_pp1, "Expected collision — this is the bug"
+
+    # --- [FAILS_NOW] These tests define required behavior after fix ---
+
+    def test_fixed_formula_no_collision_pp2_tp4(self):
+        """[PASSES after fix] PP0 and PP1 must get different ports."""
+        port_pp0 = self._fixed_port(dp_index=0, pp_rank=0, tp_size=4)
+        port_pp1 = self._fixed_port(dp_index=0, pp_rank=1, tp_size=4)
+        assert port_pp0 != port_pp1, (
+            "PP0 and PP1 must use different ports to avoid bind conflict"
+        )
+        assert port_pp1 - port_pp0 == 4  # offset = 1 * tp_size
+
+    def test_fixed_formula_pp1_same_as_current(self):
+        """[PASSES after fix] PP=1 (pp_rank=0): fixed formula equals current."""
+        current = self._current_port(dp_index=0)
+        fixed = self._fixed_port(dp_index=0, pp_rank=0, tp_size=4)
+        assert current == fixed, "PP=1 must be backward compatible"
+
+    def test_fixed_formula_all_unique_pp4_tp2(self):
+        """[PASSES after fix] PP4+TP2: 4 PP stages all get unique ports."""
+        ports = [
+            self._fixed_port(dp_index=0, pp_rank=pp_r, tp_size=2)
+            for pp_r in range(4)
+        ]
+        assert len(ports) == len(set(ports)), f"Port collision: {ports}"
+
+    def test_note_port_is_per_engine_not_per_pp_rank(self):
+        """[INFO] NixlConnectorScheduler port is per-engine, not per-PP-rank.
+
+        In vLLM PP, there is ONE EngineCore (and ONE NixlConnectorScheduler)
+        per serving instance, regardless of PP size. All PP ranks are worker
+        subprocesses of the same engine. Therefore:
+        - Only ONE side_channel_port exists per Prefill instance.
+        - Port collision between PP ranks does NOT occur at the scheduler level.
+        - No scheduler port fix is needed.
+
+        This test documents the architecture to prevent future confusion.
+        """
+        # NixlConnectorScheduler is instantiated ONCE in NixlConnector.__init__:
+        #   NixlConnectorScheduler(vllm_config, self.engine_id, kv_cache_config)
+        # With PP2+TP4, there are 8 workers but only 1 scheduler.
+        # The side_channel_port formula (base + dp_index) is correct for PP.
+        assert True  # architecture documentation test

--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -10,6 +10,7 @@ import torch.nn.functional as F
 from tests.v1.sample.utils import create_allowed_token_ids
 from vllm.platforms import current_platform
 from vllm.v1.sample.logits_processor import LogitsProcessors
+from vllm.v1.sample.logits_processor.builtin import LogitBiasLogitsProcessor
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import (
     PLACEHOLDER_TOKEN_ID,
@@ -82,6 +83,7 @@ def create_sampling_metadata(
     repetition_penalties: list[float] | None = None,
     bad_words_token_ids: dict[int, list[list[int]]] | None = None,
     allowed_token_ids_mask: torch.Tensor | None = None,
+    logitsprocs: LogitsProcessors | None = None,
 ) -> SamplingMetadata:
     """Create a v1 sampling metadata object with all_greedy set
     to the given value. Either all greedy or all random sampling
@@ -125,7 +127,7 @@ def create_sampling_metadata(
         spec_token_ids=[] if spec_token_ids is None else spec_token_ids,
         allowed_token_ids_mask=allowed_token_ids_mask,
         bad_words_token_ids={} if bad_words_token_ids is None else bad_words_token_ids,
-        logitsprocs=LogitsProcessors(),
+        logitsprocs=logitsprocs if logitsprocs is not None else LogitsProcessors(),
     )
 
 
@@ -994,3 +996,143 @@ def test_synthetic_all_rejected(all_greedy: bool):
     for row in result:
         assert row[0] != PLACEHOLDER_TOKEN_ID
         assert (row[1:] == PLACEHOLDER_TOKEN_ID).all()
+
+
+def create_logit_bias_processor(
+    biases: dict[int, dict[int, float]],
+) -> LogitsProcessors:
+    """构造带有指定 bias 的 LogitBiasLogitsProcessor，返回 LogitsProcessors 对象。"""
+    processor = LogitBiasLogitsProcessor(None, torch.device(DEVICE_TYPE), False)
+    processor.biases = biases
+    return LogitsProcessors([processor])
+
+
+def test_logit_bias_greedy(rejection_sampler):
+    """测试 logit bias 在 greedy 模式下改变 draft token 的 accept/reject 行为。
+
+    3 个 request：
+    - req 0 和 req 2：对 token 2 施加 -200.0 bias，argmax 从 2 变成 15，
+      draft token 2 被拒绝。
+    - req 1：无 bias，所有 draft token 正常接受。
+    验证非连续 request 索引（0 和 2 有 bias，1 无 bias）的处理正确性。
+    """
+    spec_tokens = [[1, 2, 3], [1, 15, 3], [1, 2, 3]]
+    output_tokens = [[1, 2, 3, 4], [1, 15, 3, 4], [1, 2, 3, 4]]
+
+    logits = create_logits_tensor(output_tokens, token_idx_to_override=15)
+
+    logitsprocs = create_logit_bias_processor(
+        biases={0: {2: -200.0}, 2: {2: -200.0}},
+    )
+    metadata = create_sampling_metadata(
+        all_greedy=True,
+        output_token_ids=[[2], [3], [4]],
+        spec_token_ids=spec_tokens,
+        logitsprocs=logitsprocs,
+    )
+    bonus_token_tensor = torch.tensor(
+        [output_tokens[i][-1] for i in range(len(output_tokens))],
+        device=logits.device,
+    )
+    spec_decode_metadata = SpecDecodeMetadata.make_dummy(
+        spec_tokens, device=logits.device
+    )
+    mock_sampler_output(rejection_sampler, bonus_token_tensor)
+    output = rejection_sampler(
+        spec_decode_metadata,
+        draft_probs=None,
+        logits=logits,
+        sampling_metadata=metadata,
+    )
+
+    # req 0: token 2 biased -> rejected -> [1, 15, -1, -1]
+    # req 1: no bias        -> all accepted -> [1, 15, 3, 4]
+    # req 2: token 2 biased -> rejected -> [1, 15, -1, -1]
+    expected = torch.tensor(
+        [[1, 15, -1, -1], [1, 15, 3, 4], [1, 15, -1, -1]],
+        dtype=torch.int,
+        device=logits.device,
+    )
+    assert torch.equal(output.sampled_token_ids, expected)
+
+
+def test_logit_bias_with_empty_draft_tokens(rejection_sampler):
+    """测试 batch 中含空 draft token 列表时 logit bias 的边界处理。
+
+    - req 0：3 个 draft tokens，bias {2: -200.0}
+    - req 1：0 个 draft tokens（空列表），仅输出 bonus token
+    - req 2：3 个 draft tokens，bias {2: -200.0}
+    验证 apply_with_spec_decode 对 num_draft_tokens 中 0 值的处理正确性。
+    """
+    spec_tokens = [[1, 2, 3], [], [1, 2, 3]]
+    output_tokens = [[1, 2, 3, 4], [7], [1, 2, 3, 4]]
+
+    logits = create_logits_tensor(output_tokens, token_idx_to_override=15)
+
+    logitsprocs = create_logit_bias_processor(
+        biases={0: {2: -200.0}, 2: {2: -200.0}},
+    )
+    metadata = create_sampling_metadata(
+        all_greedy=True,
+        output_token_ids=[[2], [3], [4]],
+        spec_token_ids=spec_tokens,
+        logitsprocs=logitsprocs,
+    )
+    bonus_token_tensor = torch.tensor(
+        [output_tokens[i][-1] for i in range(len(output_tokens))],
+        device=logits.device,
+    )
+    spec_decode_metadata = SpecDecodeMetadata.make_dummy(
+        spec_tokens, device=logits.device
+    )
+    mock_sampler_output(rejection_sampler, bonus_token_tensor)
+    output = rejection_sampler(
+        spec_decode_metadata,
+        draft_probs=None,
+        logits=logits,
+        sampling_metadata=metadata,
+    )
+
+    # req 0: token 2 biased -> rejected -> [1, 15, -1, -1]
+    # req 1: no draft tokens -> only bonus -> [7, -1, -1, -1]
+    # req 2: token 2 biased -> rejected -> [1, 15, -1, -1]
+    expected = torch.tensor(
+        [[1, 15, -1, -1], [7, -1, -1, -1], [1, 15, -1, -1]],
+        dtype=torch.int,
+        device=logits.device,
+    )
+    assert torch.equal(output.sampled_token_ids, expected)
+
+
+def test_logit_bias_empty_biases(rejection_sampler):
+    """测试 biases 为空时的 no-op 行为。
+
+    传入空 biases 的 LogitBiasLogitsProcessor，验证所有 draft token 正常接受，
+    输出与无 logit bias 时完全一致。
+    """
+    spec_tokens = [[1, 2, 3]]
+    output_tokens = [[1, 2, 3, 4]]
+
+    logits = create_logits_tensor(output_tokens)
+
+    logitsprocs = create_logit_bias_processor(biases={})
+    metadata = create_sampling_metadata(
+        all_greedy=True,
+        logitsprocs=logitsprocs,
+    )
+    bonus_token_tensor = torch.tensor(
+        [output_tokens[0][-1]], device=logits.device
+    )
+    spec_decode_metadata = create_spec_decode_metadata(spec_tokens, logits)
+    mock_sampler_output(rejection_sampler, bonus_token_tensor)
+    output = rejection_sampler(
+        spec_decode_metadata,
+        draft_probs=None,
+        logits=logits,
+        sampling_metadata=metadata,
+    )
+
+    expected = torch.tensor(
+        [[1, 2, 3, 4]], dtype=torch.int, device=logits.device
+    )
+    assert torch.equal(output.sampled_token_ids, expected)

--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -8,9 +8,14 @@ import torch
 import torch.nn.functional as F
 
 from tests.v1.sample.utils import create_allowed_token_ids
+from vllm.config import VllmConfig
+from vllm.config.speculative import SpeculativeConfig
 from vllm.platforms import current_platform
-from vllm.v1.sample.logits_processor import LogitsProcessors
-from vllm.v1.sample.logits_processor.builtin import LogitBiasLogitsProcessor
+from vllm.v1.sample.logits_processor import LogitsProcessors, build_logitsprocs
+from vllm.v1.sample.logits_processor.builtin import (
+    LogitBiasLogitsProcessor,
+    ReasoningLogitsProcessor,
+)
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.rejection_sampler import (
     PLACEHOLDER_TOKEN_ID,
@@ -47,6 +52,14 @@ def create_spec_decode_metadata(
     # be empty.
     metadata.bonus_logits_indices = torch.empty(0, dtype=torch.int32)
     return metadata
+
+
+def create_spec_decode_vllm_config() -> VllmConfig:
+    vllm_config = VllmConfig()
+    vllm_config.speculative_config = SpeculativeConfig(
+        model="ngram", num_speculative_tokens=1
+    )
+    return vllm_config
 
 
 def create_logits_tensor(
@@ -1007,6 +1020,56 @@ def create_logit_bias_processor(
     return LogitsProcessors([processor])
 
 
+def create_reasoning_processor(
+    reasoning_indices: list[int],
+    banned_token_ids: list[int],
+) -> LogitsProcessors:
+    processor = ReasoningLogitsProcessor.__new__(ReasoningLogitsProcessor)
+    processor.device = torch.device(DEVICE_TYPE)
+    processor.pin_memory = False
+    processor.req_states = {
+        index: ([], True, 0) for index in reasoning_indices
+    }
+    processor.has_reasoning = bool(reasoning_indices)
+    processor.banned_token_ids_tensor = torch.tensor(
+        banned_token_ids, device=DEVICE_TYPE, dtype=torch.int64
+    )
+    return LogitsProcessors([processor])
+
+
+def test_spec_decode_builds_reasoning_logits_processor():
+    logitsprocs = build_logitsprocs(
+        vllm_config=create_spec_decode_vllm_config(),
+        device=torch.device(DEVICE_TYPE),
+        is_pin_memory=False,
+        is_pooling_model=False,
+    )
+
+    assert any(
+        isinstance(processor, ReasoningLogitsProcessor)
+        for processor in logitsprocs.all
+    )
+
+
+def test_spec_decode_allows_explicit_builtin_reasoning_logitproc():
+    logitsprocs = build_logitsprocs(
+        vllm_config=create_spec_decode_vllm_config(),
+        device=torch.device(DEVICE_TYPE),
+        is_pin_memory=False,
+        is_pooling_model=False,
+        custom_logitsprocs=[
+            "vllm.v1.sample.logits_processor.builtin:ReasoningLogitsProcessor"
+        ],
+    )
+
+    reasoning_processors = [
+        processor
+        for processor in logitsprocs.all
+        if isinstance(processor, ReasoningLogitsProcessor)
+    ]
+    assert len(reasoning_processors) == 1
+
+
 def test_logit_bias_greedy(rejection_sampler):
     """测试 logit bias 在 greedy 模式下改变 draft token 的 accept/reject 行为。
 
@@ -1050,6 +1113,46 @@ def test_logit_bias_greedy(rejection_sampler):
     # req 2: token 2 biased -> rejected -> [1, 15, -1, -1]
     expected = torch.tensor(
         [[1, 15, -1, -1], [1, 15, 3, 4], [1, 15, -1, -1]],
+        dtype=torch.int,
+        device=logits.device,
+    )
+    assert torch.equal(output.sampled_token_ids, expected)
+
+
+def test_reasoning_processor_greedy(rejection_sampler):
+    """Verify reasoning special-token bans are applied to speculative drafts."""
+    spec_tokens = [[1, 2, 3], [1, 2, 3], [1, 2, 3]]
+    output_tokens = [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]]
+
+    logits = create_logits_tensor(output_tokens, token_idx_to_override=15)
+
+    logitsprocs = create_reasoning_processor(
+        reasoning_indices=[0, 2],
+        banned_token_ids=[2],
+    )
+    metadata = create_sampling_metadata(
+        all_greedy=True,
+        output_token_ids=[[2], [3], [4]],
+        spec_token_ids=spec_tokens,
+        logitsprocs=logitsprocs,
+    )
+    bonus_token_tensor = torch.tensor(
+        [output_tokens[i][-1] for i in range(len(output_tokens))],
+        device=logits.device,
+    )
+    spec_decode_metadata = create_spec_decode_metadata(spec_tokens, logits)
+    mock_sampler_output(rejection_sampler, bonus_token_tensor)
+    output = rejection_sampler(
+        spec_decode_metadata,
+        draft_probs=None,
+        logits=logits,
+        sampling_metadata=metadata,
+    )
+
+    # req 0/2: token 2 banned while reasoning -> rejected at token 2.
+    # req 1: no reasoning state -> all draft tokens are accepted.
+    expected = torch.tensor(
+        [[1, 15, -1, -1], [1, 2, 3, 4], [1, 15, -1, -1]],
         dtype=torch.int,
         device=logits.device,
     )

--- a/tests/v1/sample/test_rejection_sampler.py
+++ b/tests/v1/sample/test_rejection_sampler.py
@@ -1034,8 +1034,8 @@ def test_logit_bias_greedy(rejection_sampler):
         [output_tokens[i][-1] for i in range(len(output_tokens))],
         device=logits.device,
     )
-    spec_decode_metadata = SpecDecodeMetadata.make_dummy(
-        spec_tokens, device=logits.device
+    spec_decode_metadata = create_spec_decode_metadata(
+        spec_tokens, logits
     )
     mock_sampler_output(rejection_sampler, bonus_token_tensor)
     output = rejection_sampler(
@@ -1082,8 +1082,8 @@ def test_logit_bias_with_empty_draft_tokens(rejection_sampler):
         [output_tokens[i][-1] for i in range(len(output_tokens))],
         device=logits.device,
     )
-    spec_decode_metadata = SpecDecodeMetadata.make_dummy(
-        spec_tokens, device=logits.device
+    spec_decode_metadata = create_spec_decode_metadata(
+        spec_tokens, logits
     )
     mock_sampler_output(rejection_sampler, bonus_token_tensor)
     output = rejection_sampler(

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -618,6 +618,29 @@ class TransferTopology:
         abs_ratio = -tp_ratio
         return [self.tp_rank * abs_ratio + i for i in range(abs_ratio)]
 
+    def get_all_pp_tp_targets(
+        self, remote_tp_size: int, remote_pp_size: int
+    ) -> list[int]:
+        """Return global worker indices across all PP stages for PP KV transfer.
+
+        When Prefill uses Pipeline Parallelism (pp_size > 1), Decode must
+        connect to workers in ALL PP stages to cover every layer range.
+        global_idx = pp_rank * remote_tp_size + tp_rank_in_stage.
+
+        Example (D_TP=8, remote PP2+TP4):
+          D_rank=0 -> [0, 4]  (PP0_TP0 and PP1_TP0)
+          D_rank=2 -> [1, 5]
+          D_rank=6 -> [3, 7]
+
+        PP=1 degenerates to handshake_target_ranks (backward compatible).
+        """
+        local_tp_targets = self.handshake_target_ranks(remote_tp_size)
+        result = []
+        for pp_rank in range(remote_pp_size):
+            for tp_rank in local_tp_targets:
+                result.append(tp_rank + pp_rank * remote_tp_size)
+        return result
+
     def target_remote_ranks(self, remote_engine_id: EngineId) -> list[int]:
         """Get the remote TP rank(s) that the current local TP rank will
         read from.  When remote tp_size > local tp_size, reads from

--- a/vllm/distributed/kv_transfer/kv_connector/utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/utils.py
@@ -619,27 +619,25 @@ class TransferTopology:
         return [self.tp_rank * abs_ratio + i for i in range(abs_ratio)]
 
     def get_all_pp_tp_targets(
-        self, remote_tp_size: int, remote_pp_size: int
+        self,
+        remote_tp_size: int,
+        remote_pp_size: int,
     ) -> list[int]:
-        """Return global worker indices across all PP stages for PP KV transfer.
+        """Return global remote worker indices across all PP stages.
 
-        When Prefill uses Pipeline Parallelism (pp_size > 1), Decode must
-        connect to workers in ALL PP stages to cover every layer range.
-        global_idx = pp_rank * remote_tp_size + tp_rank_in_stage.
-
-        Example (D_TP=8, remote PP2+TP4):
-          D_rank=0 -> [0, 4]  (PP0_TP0 and PP1_TP0)
-          D_rank=2 -> [1, 5]
-          D_rank=6 -> [3, 7]
-
-        PP=1 degenerates to handshake_target_ranks (backward compatible).
+        For each TP target rank selected by ``handshake_target_ranks()``, expand
+        it across every remote PP stage using the global worker index formula:
+        ``tp_rank + pp_rank * remote_tp_size``.
         """
-        local_tp_targets = self.handshake_target_ranks(remote_tp_size)
-        result = []
-        for pp_rank in range(remote_pp_size):
-            for tp_rank in local_tp_targets:
-                result.append(tp_rank + pp_rank * remote_tp_size)
-        return result
+        tp_targets = self.handshake_target_ranks(remote_tp_size)
+        if remote_pp_size <= 1:
+            return tp_targets
+
+        all_targets: list[int] = []
+        for tp_rank in tp_targets:
+            for pp_rank in range(remote_pp_size):
+                all_targets.append(tp_rank + pp_rank * remote_tp_size)
+        return all_targets
 
     def target_remote_ranks(self, remote_engine_id: EngineId) -> list[int]:
         """Get the remote TP rank(s) that the current local TP rank will

--- a/vllm/distributed/kv_transfer/kv_connector/v1/base.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/base.py
@@ -80,6 +80,8 @@ CopyBlocksOp = Callable[
 
 logger = init_logger(__name__)
 
+PREFILL_NUM_CACHED_TOKENS_KEY = "prefill_num_cached_tokens"
+
 
 class SupportsHMA(ABC):
     """

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -146,6 +146,7 @@ class ReqMeta:
     # To be used when logical block size does not match the kernel block size
     local_physical_block_ids: BlockIds
     tp_size: int
+    pp_size: int = 1
     remote: RemoteMeta | None = None
 
 
@@ -167,6 +168,7 @@ class NixlConnectorMetadata(KVConnectorMetadata):
             local_physical_block_ids=local_block_ids,
             # P workers don't need to receive tp_size from proxy here.
             tp_size=kv_transfer_params.get("tp_size", 1),
+            pp_size=kv_transfer_params.get("pp_size", 1),
         )
 
     def add_new_req_to_save(

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/metadata.py
@@ -32,8 +32,9 @@ GET_META_MSG = b"get_meta_msg"
 # Version History:
 #   1: Initial version with compatibility checking
 #   2: Add remote_request_id to kv_transfer_params
+#   3: Add region_labels to NixlAgentMetadata for PP stage-local region mapping
 #
-NIXL_CONNECTOR_VERSION: int = 2
+NIXL_CONNECTOR_VERSION: int = 3
 
 
 @dataclass
@@ -41,6 +42,7 @@ class NixlAgentMetadata:
     engine_id: str
     agent_metadata: bytes
     kv_caches_base_addr: list[int]
+    region_labels: list[str]
     device_id: int
     num_blocks: int
     block_lens: list[int]

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/scheduler.py
@@ -211,13 +211,28 @@ class NixlConnectorScheduler:
         with zmq_ctx(zmq.ROUTER, path) as sock:
             sock.setsockopt(zmq.RCVTIMEO, 1000)
             ready_event.set()
+            logger.info(
+                "NIXL handshake listener started on %s (port %d)",
+                path, port,
+            )
             while True:
                 try:
-                    identity, _, msg = sock.recv_multipart()
+                    frames = sock.recv_multipart()
                 except zmq.Again:
                     if stop_event.is_set():
                         break
                     continue
+                if len(frames) != 3:
+                    logger.warning(
+                        "Handshake listener: got %d frames (expected 3). "
+                        "Frame sizes: %s. Possible stray connection "
+                        "or non-REQ socket on port %d.",
+                        len(frames),
+                        [len(f) for f in frames],
+                        port,
+                    )
+                    continue
+                identity, _, msg = frames
                 # Decode the message which contains (GET_META_MSG, rank)
                 msg, target_tp_rank = msgspec.msgpack.decode(msg)
                 logger.debug(
@@ -477,11 +492,12 @@ class NixlConnectorScheduler:
 
         if delay_free_blocks:
             # Prefill request on remote. It will be read from D upon completion
-            logger.debug(
-                "NIXLConnector request_finished(%s) waiting for %d seconds "
-                "for remote decode to fetch blocks",
+            logger.info(
+                "[KV] request_finished(P): req=%s, blocks=%d, "
+                "pending_send=%d",
                 request.request_id,
-                envs.VLLM_NIXL_ABORT_REQUEST_TIMEOUT,
+                len(block_ids),
+                len(self._reqs_need_send) + 1,
             )
             self._reqs_need_send[request.request_id] = (
                 time.perf_counter() + envs.VLLM_NIXL_ABORT_REQUEST_TIMEOUT
@@ -501,4 +517,7 @@ class NixlConnectorScheduler:
             remote_host=self.side_channel_host,
             remote_port=self.side_channel_port,
             tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
+            pp_size=getattr(
+                self.vllm_config.parallel_config, "pipeline_parallel_size", 1
+            ) or 1,
         )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/scheduler.py
@@ -211,28 +211,13 @@ class NixlConnectorScheduler:
         with zmq_ctx(zmq.ROUTER, path) as sock:
             sock.setsockopt(zmq.RCVTIMEO, 1000)
             ready_event.set()
-            logger.info(
-                "NIXL handshake listener started on %s (port %d)",
-                path, port,
-            )
             while True:
                 try:
-                    frames = sock.recv_multipart()
+                    identity, _, msg = sock.recv_multipart()
                 except zmq.Again:
                     if stop_event.is_set():
                         break
                     continue
-                if len(frames) != 3:
-                    logger.warning(
-                        "Handshake listener: got %d frames (expected 3). "
-                        "Frame sizes: %s. Possible stray connection "
-                        "or non-REQ socket on port %d.",
-                        len(frames),
-                        [len(f) for f in frames],
-                        port,
-                    )
-                    continue
-                identity, _, msg = frames
                 # Decode the message which contains (GET_META_MSG, rank)
                 msg, target_tp_rank = msgspec.msgpack.decode(msg)
                 logger.debug(
@@ -492,12 +477,11 @@ class NixlConnectorScheduler:
 
         if delay_free_blocks:
             # Prefill request on remote. It will be read from D upon completion
-            logger.info(
-                "[KV] request_finished(P): req=%s, blocks=%d, "
-                "pending_send=%d",
+            logger.debug(
+                "NIXLConnector request_finished(%s) waiting for %d seconds "
+                "for remote decode to fetch blocks",
                 request.request_id,
-                len(block_ids),
-                len(self._reqs_need_send) + 1,
+                envs.VLLM_NIXL_ABORT_REQUEST_TIMEOUT,
             )
             self._reqs_need_send[request.request_id] = (
                 time.perf_counter() + envs.VLLM_NIXL_ABORT_REQUEST_TIMEOUT
@@ -517,7 +501,5 @@ class NixlConnectorScheduler:
             remote_host=self.side_channel_host,
             remote_port=self.side_channel_port,
             tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
-            pp_size=getattr(
-                self.vllm_config.parallel_config, "pipeline_parallel_size", 1
-            ) or 1,
+            pp_size=self.vllm_config.parallel_config.pipeline_parallel_size,
         )

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/scheduler.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/scheduler.py
@@ -18,6 +18,7 @@ from vllm.distributed.kv_transfer.kv_connector.utils import (
 from vllm.distributed.kv_transfer.kv_connector.v1.base import (
     KVConnectorHandshakeMetadata,
     KVConnectorMetadata,
+    PREFILL_NUM_CACHED_TOKENS_KEY,
 )
 from vllm.distributed.kv_transfer.kv_connector.v1.nixl.metadata import (
     GET_META_MSG,
@@ -492,7 +493,7 @@ class NixlConnectorScheduler:
             # Here we "unpad" blocks to send the actual remote blocks to be read.
             block_ids = self.get_sw_clipped_blocks(block_ids)
 
-        return delay_free_blocks, dict(
+        kv_transfer_params = dict(
             do_remote_prefill=True,
             do_remote_decode=False,
             remote_block_ids=block_ids,
@@ -503,3 +504,7 @@ class NixlConnectorScheduler:
             tp_size=self.vllm_config.parallel_config.tensor_parallel_size,
             pp_size=self.vllm_config.parallel_config.pipeline_parallel_size,
         )
+        kv_transfer_params[PREFILL_NUM_CACHED_TOKENS_KEY] = max(
+            request.num_cached_tokens, 0
+        )
+        return delay_free_blocks, kv_transfer_params

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -652,8 +652,42 @@ class NixlConnectorWorker:
         # Forwarding a real layer name rather than a synthetic key
         self.register_kv_caches({first_layer: kv_cache})
 
+    @staticmethod
+    def _parse_transformer_layer_idx(layer_name: str) -> int | None:
+        parts = layer_name.split(".")
+        try:
+            return int(parts[parts.index("layers") + 1])
+        except (ValueError, IndexError):
+            return None
+
+    def _filter_spec_decode_draft_kv_caches(
+        self, kv_caches: dict[str, torch.Tensor]
+    ) -> dict[str, torch.Tensor]:
+        spec_cfg = self.vllm_config.speculative_config
+        if spec_cfg is None or spec_cfg.draft_model_config is None:
+            return kv_caches
+
+        num_target_layers = self.model_config.get_num_layers(
+            self.vllm_config.parallel_config
+        )
+        filtered = {}
+        for name, cache in kv_caches.items():
+            layer_idx = self._parse_transformer_layer_idx(name)
+            if layer_idx is not None and layer_idx >= num_target_layers:
+                logger.info(
+                    "Skipping draft model layer %s (idx=%d >= %d) "
+                    "from NIXL registration",
+                    name,
+                    layer_idx,
+                    num_target_layers,
+                )
+                continue
+            filtered[name] = cache
+        return filtered
+
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """Register the KV Cache data in nixl."""
+        kv_caches = self._filter_spec_decode_draft_kv_caches(kv_caches)
         self.transfer_topo = TransferTopology(
             tp_rank=self.tp_rank,
             tp_size=self.world_size,

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -359,8 +359,14 @@ class NixlConnectorWorker:
         port: int,
         remote_tp_size: int,
         expected_engine_id: str,
+        remote_pp_size: int = 1,
     ) -> dict[int, str]:
-        """Do a NIXL handshake with a remote instance."""
+        """Do a NIXL handshake with a remote instance.
+
+        When remote_pp_size > 1 (Pipeline Parallelism on Prefill), connects
+        to workers in ALL PP stages so that Decode can transfer KV for every
+        layer range.  Global worker index = pp_rank * remote_tp_size + tp_rank.
+        """
 
         # the first time we connect to a remote agent.
         # be careful, the handshake happens in a background thread.
@@ -377,10 +383,17 @@ class NixlConnectorWorker:
         # When target instance TP > local TP, we need to perform multiple
         # handshakes. Do it in a single background job for simplicity.
         # Regardless, only handshake with the remote TP rank(s) that current
-        # local rank will read from. Note that With homogeneous TP,
+        # local rank will read from. Note that with homogeneous TP,
         # this happens to be the same single rank_i.
+        # With PP > 1, also connect to corresponding ranks in each PP stage so
+        # that all layer ranges are reachable for KV transfer.
         assert self.transfer_topo is not None
-        p_remote_ranks = self.transfer_topo.handshake_target_ranks(remote_tp_size)
+        if remote_pp_size > 1:
+            p_remote_ranks = self.transfer_topo.get_all_pp_tp_targets(
+                remote_tp_size, remote_pp_size
+            )
+        else:
+            p_remote_ranks = self.transfer_topo.handshake_target_ranks(remote_tp_size)
         remote_rank_to_agent_name = {}
         path = make_zmq_path("tcp", host, port)
 
@@ -598,6 +611,7 @@ class NixlConnectorWorker:
                 meta.remote.port,
                 meta.tp_size,
                 remote_engine_id,
+                meta.pp_size,
             )
             self._handshake_futures[remote_engine_id] = fut
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -268,11 +268,6 @@ class NixlConnectorWorker:
         self.dst_num_blocks: dict[EngineId, int] = {}
         self._registered_descs: list[Any] = []
 
-        # PP-aware layer-range src handles: (engine_id, global_pp_rank) ->
-        # (nixl_prepped_dlist_handle, num_pp_layers) covering only that PP rank's
-        # layer subset. Built during _nixl_handshake when remote_pp_size > 1.
-        self._pp_src_xfer_handles: dict[tuple[EngineId, int], tuple[int, int]] = {}
-
         # ---- Mamba-HMA per-engine state (only used when self._has_mamba) ----
         # NOTE (ZhanqiuHu): _physical_blocks_per_logical MUST be per-engine.
         # physical_blocks_per_logical = ceil((conv_bytes + ssm_bytes) / block_len)
@@ -363,15 +358,10 @@ class NixlConnectorWorker:
         host: str,
         port: int,
         remote_tp_size: int,
+        remote_pp_size: int,
         expected_engine_id: str,
-        remote_pp_size: int = 1,
     ) -> dict[int, str]:
-        """Do a NIXL handshake with a remote instance.
-
-        When remote_pp_size > 1 (Pipeline Parallelism on Prefill), connects
-        to workers in ALL PP stages so that Decode can transfer KV for every
-        layer range.  Global worker index = pp_rank * remote_tp_size + tp_rank.
-        """
+        """Do a NIXL handshake with a remote instance."""
 
         # the first time we connect to a remote agent.
         # be careful, the handshake happens in a background thread.
@@ -388,29 +378,20 @@ class NixlConnectorWorker:
         # When target instance TP > local TP, we need to perform multiple
         # handshakes. Do it in a single background job for simplicity.
         # Regardless, only handshake with the remote TP rank(s) that current
-        # local rank will read from. Note that with homogeneous TP,
+        # local rank will read from. Note that With homogeneous TP,
         # this happens to be the same single rank_i.
-        # With PP > 1, also connect to corresponding ranks in each PP stage so
-        # that all layer ranges are reachable for KV transfer.
         assert self.transfer_topo is not None
         if remote_pp_size > 1:
             p_remote_ranks = self.transfer_topo.get_all_pp_tp_targets(
-                remote_tp_size, remote_pp_size
+                remote_tp_size=remote_tp_size,
+                remote_pp_size=remote_pp_size,
             )
         else:
             p_remote_ranks = self.transfer_topo.handshake_target_ranks(remote_tp_size)
         remote_rank_to_agent_name = {}
-        # PP layer offset: tracks cumulative layer count across PP stages so each
-        # PP stage's local src handle covers only the correct layer slice.
-        # Advances once per PP stage (not per TP rank): all TP workers in the same
-        # PP stage hold the same layers and should receive the same slice handle.
-        pp_layer_offset = 0
-        pp_layer_last_stage = -1          # which PP stage owns the current offset
-        pp_layer_last_num_layers = 0      # layer count of the stage at last offset
         path = make_zmq_path("tcp", host, port)
 
         with zmq_ctx(zmq.REQ, path) as sock:
-            handshake_start = time.perf_counter()
             for remote_rank in p_remote_ranks:
                 logger.debug(
                     "Querying metadata on path: %s at remote tp rank %s",
@@ -496,63 +477,6 @@ class NixlConnectorWorker:
                     setup_agent_time - got_metadata_time,
                 )
                 remote_rank_to_agent_name[remote_rank] = remote_agent_name
-
-                # PP layer-range routing: build a per-PP-rank local src handle
-                # that only covers the layer subset this PP rank has.
-                # Ensures make_prepped_xfer src/dst descriptor counts match.
-                if remote_pp_size > 1 and hasattr(self, "src_blocks_data"):
-                    num_pp_layers = len(metadata.kv_caches_base_addr)
-                    # regions_per_layer = 1 for standard layout, 2 for blocks-first
-                    # (FlashInfer stores K and V as separate regions per layer).
-                    num_local_layers = len(
-                        self.kv_caches_base_addr[self.engine_id][self.tp_rank]
-                    )
-                    regions_per_layer = self.num_regions // num_local_layers
-                    num_pp_regions = num_pp_layers * regions_per_layer
-
-                    # Determine which PP stage and TP position this remote_rank is.
-                    # global_rank = pp_stage * remote_tp_size + tp_rank_in_stage.
-                    pp_stage = remote_rank // remote_tp_size
-                    tp_rank_in_stage = remote_rank % remote_tp_size
-
-                    # Advance pp_layer_offset only when entering a NEW PP stage.
-                    # All TP workers in the same PP stage hold identical layers.
-                    if pp_stage != pp_layer_last_stage:
-                        if pp_layer_last_stage >= 0:
-                            pp_layer_offset += pp_layer_last_num_layers
-                        pp_layer_last_stage = pp_stage
-                        pp_layer_last_num_layers = num_pp_layers
-
-                    # TODO: PP + heterogeneous TP (non-MLA, P.TP > D.TP):
-                    # The handle below only applies the layer-slice. When P.TP > D.TP
-                    # and use_mla=False, the remote descriptor covers only 1/tp_ratio
-                    # of the KV heads. The local handle must also be head-split to
-                    # match byte lengths; otherwise NIXL raises "length mismatch".
-                    # Fix: build per-(pp_stage, tp_rank_in_stage) combined handles
-                    # (layer-slice + head-split). See _build_layer_range_xfer_handle.
-                    self._pp_src_xfer_handles[(expected_engine_id, remote_rank)] = (
-                        self._build_layer_range_xfer_handle(
-                            pp_layer_offset, pp_layer_offset + num_pp_layers
-                        ),
-                        num_pp_regions,
-                    )
-                    logger.debug(
-                        "PP layer-range handle: rank=%d pp_stage=%d tp_in_stage=%d "
-                        "layers=[%d:%d] regions_per_layer=%d key=%s",
-                        remote_rank,
-                        pp_stage,
-                        tp_rank_in_stage,
-                        pp_layer_offset,
-                        pp_layer_offset + num_pp_layers,
-                        regions_per_layer,
-                        expected_engine_id,
-                    )
-            logger.info(
-                "[KV] handshake completed: engine=%s, %.3fs, %d ranks",
-                expected_engine_id,
-                time.perf_counter() - handshake_start,
-                len(remote_rank_to_agent_name),
-            )
         return remote_rank_to_agent_name
 
     def initialize_host_xfer_buffer(self, kv_caches: dict[str, torch.Tensor]) -> None:
@@ -673,8 +597,8 @@ class NixlConnectorWorker:
                 meta.remote.host,
                 meta.remote.port,
                 meta.tp_size,
-                remote_engine_id,
                 meta.pp_size,
+                remote_engine_id,
             )
             self._handshake_futures[remote_engine_id] = fut
 
@@ -728,37 +652,8 @@ class NixlConnectorWorker:
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """Register the KV Cache data in nixl."""
-        # Filter out speculative decoding draft model layers (e.g. Eagle3).
-        # Draft layers share a kv_cache_group with target model layers but
-        # have different num_blocks. NIXL only transfers target model KV
-        # cache, so we determine target layer count and exclude draft layers
-        # whose index >= num_target_layers.
-        spec_cfg = self.vllm_config.speculative_config
-        if spec_cfg is not None and spec_cfg.draft_model_config is not None:
-            num_target_layers = (
-                self.vllm_config.model_config.get_num_layers(
-                    self.vllm_config.parallel_config
-                )
-            )
-            filtered = {}
-            for name, cache in kv_caches.items():
-                # Layer names follow "model.layers.{idx}.self_attn" pattern.
-                # Draft layers start at index == num_target_layers.
-                parts = name.split(".")
-                try:
-                    layer_idx = int(parts[parts.index("layers") + 1])
-                except (ValueError, IndexError):
-                    layer_idx = -1
-                if layer_idx >= 0 and layer_idx >= num_target_layers:
-                    logger.info(
-                        "Skipping draft model layer %s (idx=%d >= %d) "
-                        "from NIXL registration",
-                        name, layer_idx, num_target_layers,
-                    )
-                    continue
-                filtered[name] = cache
-            kv_caches = filtered
-        self.transfer_topo = TransferTopology(            tp_rank=self.tp_rank,
+        self.transfer_topo = TransferTopology(
+            tp_rank=self.tp_rank,
             tp_size=self.world_size,
             block_size=self.block_size,
             engine_id=self.engine_id,
@@ -1209,38 +1104,6 @@ class NixlConnectorWorker:
         # NIXL_INIT_AGENT to be used for preparations of local descs.
         return self.nixl_wrapper.prep_xfer_dlist("NIXL_INIT_AGENT", descs), blocks_data
 
-    def _build_layer_range_xfer_handle(
-        self, start_layer: int, end_layer: int
-    ) -> int:
-        """Build a local src NIXL handle covering only layers [start_layer:end_layer].
-
-        Used for Pipeline Parallelism: each PP rank on Prefill registers only its
-        own layer subset. The Decode side needs a matching local src handle that
-        covers exactly those layers so that make_prepped_xfer descriptor counts match.
-
-        src_blocks_data layout: entries_per_layer entries per layer, where
-        entries_per_layer = num_blocks for standard layout and num_blocks * 2 for
-        blocks-first (FlashInfer) layout which stores K and V regions separately.
-        Derived as len(src_blocks_data) // num_local_layers to be layout-agnostic.
-        """
-        num_local_layers = len(
-            self.kv_caches_base_addr[self.engine_id][self.tp_rank]
-        )
-        entries_per_layer = len(self.src_blocks_data) // num_local_layers
-        sliced_data = self.src_blocks_data[
-            start_layer * entries_per_layer : end_layer * entries_per_layer
-        ]
-        descs = self.nixl_wrapper.get_xfer_descs(sliced_data, self.nixl_memory_type)
-        return self.nixl_wrapper.prep_xfer_dlist("NIXL_INIT_AGENT", descs)
-        # TODO: PP + heterogeneous TP (non-MLA, P.TP > D.TP):
-        # The handle above only applies the layer-slice.  When P.TP > D.TP and
-        # use_mla=False, the remote descriptor per block covers only 1/tp_ratio of
-        # the KV heads, so the local handle must also be head-split to match byte
-        # lengths.  Symptom: NIXL "length mismatch at index pair N" in E2E.
-        # Fix: build per-(pp_stage, tp_rank_in_stage) combined handles that are
-        # both layer-sliced AND head-split (analogous to src_xfer_handles_by_tp_ratio
-        # but restricted to the PP layer range).
-
     def add_remote_agent(
         self,
         nixl_agent_meta: NixlAgentMetadata,
@@ -1621,13 +1484,7 @@ class NixlConnectorWorker:
             # TODO (ZhanqiuHu): For mamba models, validate FA and mamba
             # block_lens separately.
             if not self._has_mamba:
-                # With Pipeline Parallelism on the remote (Prefill), each PP rank
-                # only registers its own layer subset, so block_lens has fewer
-                # entries than local block_len_per_layer. Validate the overlap only.
-                num_layers_to_check = min(
-                    len(self.block_len_per_layer), len(nixl_agent_meta.block_lens)
-                )
-                for i in range(num_layers_to_check):
+                for i in range(len(self.block_len_per_layer)):
                     assert (
                         self.block_len_per_layer[i] // block_size_ratio
                         == nixl_agent_meta.block_lens[i]
@@ -1668,13 +1525,7 @@ class NixlConnectorWorker:
         # TP workers that handhshake with same remote have same #blocks.
         assert self.dst_num_blocks[remote_engine_id] == nixl_agent_meta.num_blocks
         # Same number of regions/~layers.
-        # With Pipeline Parallelism on Prefill, each PP rank registers only its
-        # layer subset, so kv_caches_base_addr has fewer entries than
-        # block_len_per_layer. Allow remote to have <= local layers (PP-aware).
-        assert len(nixl_agent_meta.kv_caches_base_addr) <= len(self.block_len_per_layer), (
-            f"Remote has more KV regions ({len(nixl_agent_meta.kv_caches_base_addr)}) "
-            f"than local ({len(self.block_len_per_layer)})"
-        )
+        assert len(nixl_agent_meta.kv_caches_base_addr) == len(self.block_len_per_layer)
 
     def sync_recved_kv_to_device(self, req_id: str, meta: ReqMeta):
         """copy recved kv from host buffer to device."""
@@ -1819,12 +1670,14 @@ class NixlConnectorWorker:
         done_recving.update(self._failed_recv_reqs)
         self._failed_recv_reqs.clear()
 
-        if done_sending:
-            for req_id in done_sending:
-                logger.info("[KV] send_done(P): req=%s", req_id)
-        if done_recving:
-            for req_id in done_recving:
-                logger.info("[KV] recv_done(D): req=%s", req_id)
+        if len(done_sending) > 0 or len(done_recving) > 0:
+            logger.debug(
+                "Rank %s, get_finished: %s requests done sending "
+                "and %s requests done recving",
+                self.tp_rank,
+                len(done_sending),
+                len(done_recving),
+            )
 
         block_ids_for_blocksize_post_process = defaultdict(list)
         block_ids_for_heterogeneous_attn_post_process = list[list[int]]()
@@ -1900,13 +1753,10 @@ class NixlConnectorWorker:
                     and req_id not in self._reqs_to_process
                 ):
                     logger.error(
-                        "Potentially invalid KV blocks for unrecognized "
-                        "request %s (len=%d) were retrieved by a decode "
-                        "worker. They may have expired. "
-                        "reqs_to_send_sample=%s",
+                        "Potentially invalid KV blocks for "
+                        "unrecognized request %s were retrieved by "
+                        "a decode worker. They may have expired.",
                         req_id,
-                        len(req_id),
-                        list(self._reqs_to_send.keys())[:3],
                     )
                     continue
 
@@ -2055,25 +1905,9 @@ class NixlConnectorWorker:
     def _read_blocks_for_req(self, req_id: str, meta: ReqMeta):
         assert meta.remote is not None and self.transfer_topo is not None
         engine_id = meta.remote.engine_id
+        remote_ranks = self.transfer_topo.target_remote_ranks(engine_id)
         remote_info = self.transfer_topo.get_engine_info(engine_id)
-        if meta.pp_size > 1:
-            # PP Prefill: connect to all PP stages via global indices.
-            # Each PP stage has its own layer subset; per-range handles are used
-            # in _read_blocks to keep descriptor counts matching.
-            remote_tp_size = remote_info.remote_tp_size
-            remote_ranks = self.transfer_topo.get_all_pp_tp_targets(
-                remote_tp_size, meta.pp_size
-            )
-        else:
-            remote_ranks = self.transfer_topo.target_remote_ranks(engine_id)
         tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
-
-        # n_tp_per_stage: how many consecutive entries in remote_ranks belong to
-        # the same PP stage.  get_all_pp_tp_targets returns:
-        #   outer loop = pp_stage (0..pp_size-1)
-        #   inner loop = tp_targets per stage (length = abs(tp_ratio) when < 0)
-        # For tp_ratio > 0 (or PP=1): each entry is its own "stage" of size 1.
-        n_tp_per_stage = (-tp_ratio) if tp_ratio < 0 else 1
 
         if self._has_mamba:
             # Expand remote logical → kernel block IDs.
@@ -2087,15 +1921,10 @@ class NixlConnectorWorker:
             )
         # D may have to perform multiple reads from different remote ranks.
         for i, remote_rank in enumerate(remote_ranks):
-            # Position of this rank within its PP stage's TP group.
-            i_in_stage = i % n_tp_per_stage
-
-            if self.use_mla and tp_ratio < 0 and i_in_stage > 0:
-                # MLA opt: when P.TP > D.TP, KV is replicated across P TP ranks.
-                # Read only from the first TP rank of each PP stage (i_in_stage=0);
-                # notify the skipped ranks so Prefill can release their blocks.
-                # Use `continue` (not break) so all PP stages are processed.
-                continue
+            if self.use_mla and tp_ratio < 0 and i > 0:
+                # MLA opt: when P TP > D TP, only a single read is executed for
+                # the first remote rank (cache is duplicated)..
+                break
 
             remote_block_size = remote_info.remote_block_size
             logger.debug(
@@ -2111,28 +1940,13 @@ class NixlConnectorWorker:
                 assert remote_block_size == self.block_size
                 # Remote tp_size > local tp_size: we must perform multiple
                 # reads. Get the memory chunk onto which we will write to.
-                # Use i_in_stage (not i) so the handle index resets per PP stage.
-                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[tp_ratio][
-                    i_in_stage
-                ]
+                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[tp_ratio][i]
             else:
                 # Single read from remote, we write to the whole memory region.
                 # Also handle remote block size different from local block size.
                 local_xfer_side_handle = self.src_xfer_handles_by_block_size[
                     remote_block_size
                 ]
-
-            # PP layer-range routing: override local handle with the per-PP-rank
-            # slice so src/dst descriptor counts match in make_prepped_xfer.
-            # Also pass pp_num_regions so _get_block_descs_ids uses the right
-            # region count for both local and remote handles instead of the
-            # full model's num_regions.
-            pp_key = (meta.remote.engine_id, remote_rank)
-            pp_num_regions: int | None = None
-            if pp_key in self._pp_src_xfer_handles:
-                local_xfer_side_handle, pp_num_regions = (
-                    self._pp_src_xfer_handles[pp_key]
-                )
 
             # Destination handle: remote_engine_id -> remote_rank -> handle.
             remote_xfer_side_handle = self.dst_xfer_side_handles[meta.remote.engine_id][
@@ -2160,26 +1974,16 @@ class NixlConnectorWorker:
                 remote_rank=remote_rank,
                 local_xfer_side_handle=local_xfer_side_handle,
                 remote_xfer_side_handle=remote_xfer_side_handle,
-                pp_num_regions=pp_num_regions,
             )
 
             if self.use_mla and tp_ratio < 0:
-                # After reading from the first TP rank of this PP stage, notify
-                # the skipped TP ranks within the SAME stage so Prefill can
-                # release their blocks.  Only notify stage-peers (i+1..i+n-1),
-                # NOT ranks from other PP stages (those get their own reads).
-                # NOTE: must use meta.remote.request_id (prefill-side ID), not
-                # req_id (decode-side ID). In Dynamo KVBM mode these share the
-                # same base UUID but carry different hash suffixes.
-                notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
+                # ..but we still need to notify the other remote ranks that we
+                # have the blocks we need so they can update the request state.
+                notif_id = f"{req_id}:{self.world_size}".encode()
                 remote_agents = self._remote_agents[meta.remote.engine_id]
-                for j in range(1, n_tp_per_stage):
-                    skipped_idx = i + j
-                    if skipped_idx < len(remote_ranks):
-                        skipped_rank = remote_ranks[skipped_idx]
-                        agent = remote_agents.get(skipped_rank)
-                        if agent is not None:
-                            self.nixl_wrapper.send_notif(agent, notif_msg=notif_id)
+                for rank_to_notify, agent in remote_agents.items():
+                    if rank_to_notify != remote_rank:
+                        self.nixl_wrapper.send_notif(agent, notif_msg=notif_id)
 
     def _read_blocks(
         self,
@@ -2191,7 +1995,6 @@ class NixlConnectorWorker:
         remote_rank: int,
         local_xfer_side_handle: int,
         remote_xfer_side_handle: int,
-        pp_num_regions: int | None = None,
     ):
         """
         Post a READ point-to-point xfer request from a single local worker to
@@ -2283,20 +2086,14 @@ class NixlConnectorWorker:
         # workers will issue xfers to parts of the P worker remote kv caches.
 
         # Get descs ids.
-        # PP: when a layer-range slice handle is used, both the local (Decode)
-        # and remote (Prefill PP rank) handles cover only pp_num_regions regions.
-        # Pass num_regions_override to both sides so descriptor ID counts match
-        # (len(local) == len(remote)) and all indices stay within the handle range.
         remote_block_descs_ids = self._get_block_descs_ids(
             dst_engine_id,
             remote_block_ids,
-            num_regions_override=pp_num_regions,
         )
         local_block_descs_ids = self._get_block_descs_ids(
             self.engine_id,
             local_block_ids,
             block_size_ratio=block_size_ratio,
-            num_regions_override=pp_num_regions,
         )
 
         assert len(local_block_descs_ids) == len(remote_block_descs_ids)
@@ -2315,14 +2112,6 @@ class NixlConnectorWorker:
 
             # Begin async xfer.
             self.nixl_wrapper.transfer(handle)
-            logger.info(
-                "[KV] RDMA READ posted: req=%s, blocks=%d, "
-                "remote_engine=%s, rank=%d",
-                request_id,
-                num_local_blocks,
-                dst_engine_id,
-                remote_rank,
-            )
 
             # Use handle to check completion in future step().
             self._recving_transfers[request_id].append(handle)
@@ -2371,18 +2160,13 @@ class NixlConnectorWorker:
         engine_id: str,
         block_ids: BlockIds,
         block_size_ratio: float | None = None,
-        num_regions_override: int | None = None,
     ) -> np.ndarray:
         """
         Get the descs ids for a set of block ids.
         When HMA is enabled number of descriptors across kv cache groups might differ.
         A single flattened array is returned for all groups anyway.
-
-        num_regions_override: when set, use this value instead of self.num_regions.
-        Used for PP slice handles that cover only a subset of model layers.
         """
-        num_regions = num_regions_override if num_regions_override is not None else self.num_regions
-        region_ids = np.arange(num_regions)
+        region_ids = np.arange(self.num_regions)
 
         # NOTE (NickLucche) With HMA, every kv group has the same number of layers and
         # layers from different groups share the same kv tensor.
@@ -2411,9 +2195,8 @@ class NixlConnectorWorker:
             # `num_fa_descs` offset must be computed per-engine since P and D can
             # have different num_blocks (and thus different FA descs counts).
             physical_per_logical = self._physical_blocks_per_logical[engine_id]
-            # SSM may register fewer num_blocks than FA
             logical_blocks = num_blocks // physical_per_logical
-            num_fa_descs = num_regions * num_blocks
+            num_fa_descs = self.num_regions * num_blocks
             # 3-read mamba: 4 regions per unique cache tensor (x, B, C, ssm).
             mamba_region_ids = np.arange(len(self.block_len_per_layer) * 4)[:, None]
             all_descs = []
@@ -2575,9 +2358,6 @@ class NixlConnectorWorker:
             for dst_xfer_side_handle in dst_xfer_side_handles.values():
                 self.nixl_wrapper.release_dlist_handle(dst_xfer_side_handle)
         self.dst_xfer_side_handles.clear()
-        for handle, _ in self._pp_src_xfer_handles.values():
-            self.nixl_wrapper.release_dlist_handle(handle)
-        self._pp_src_xfer_handles.clear()
         for remote_agents in self._remote_agents.values():
             for agent_name in remote_agents.values():
                 self.nixl_wrapper.remove_remote_agent(agent_name)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -385,6 +385,7 @@ class NixlConnectorWorker:
         path = make_zmq_path("tcp", host, port)
 
         with zmq_ctx(zmq.REQ, path) as sock:
+            handshake_start = time.perf_counter()
             for remote_rank in p_remote_ranks:
                 logger.debug(
                     "Querying metadata on path: %s at remote tp rank %s",
@@ -470,6 +471,12 @@ class NixlConnectorWorker:
                     setup_agent_time - got_metadata_time,
                 )
                 remote_rank_to_agent_name[remote_rank] = remote_agent_name
+            logger.info(
+                "[KV] handshake completed: engine=%s, %.3fs, %d ranks",
+                expected_engine_id,
+                time.perf_counter() - handshake_start,
+                len(remote_rank_to_agent_name),
+            )
         return remote_rank_to_agent_name
 
     def initialize_host_xfer_buffer(self, kv_caches: dict[str, torch.Tensor]) -> None:
@@ -644,8 +651,37 @@ class NixlConnectorWorker:
 
     def register_kv_caches(self, kv_caches: dict[str, torch.Tensor]):
         """Register the KV Cache data in nixl."""
-        self.transfer_topo = TransferTopology(
-            tp_rank=self.tp_rank,
+        # Filter out speculative decoding draft model layers (e.g. Eagle3).
+        # Draft layers share a kv_cache_group with target model layers but
+        # have different num_blocks. NIXL only transfers target model KV
+        # cache, so we determine target layer count and exclude draft layers
+        # whose index >= num_target_layers.
+        spec_cfg = self.vllm_config.speculative_config
+        if spec_cfg is not None and spec_cfg.draft_model_config is not None:
+            num_target_layers = (
+                self.vllm_config.model_config.get_num_layers(
+                    self.vllm_config.parallel_config
+                )
+            )
+            filtered = {}
+            for name, cache in kv_caches.items():
+                # Layer names follow "model.layers.{idx}.self_attn" pattern.
+                # Draft layers start at index == num_target_layers.
+                parts = name.split(".")
+                try:
+                    layer_idx = int(parts[parts.index("layers") + 1])
+                except (ValueError, IndexError):
+                    layer_idx = -1
+                if layer_idx >= 0 and layer_idx >= num_target_layers:
+                    logger.info(
+                        "Skipping draft model layer %s (idx=%d >= %d) "
+                        "from NIXL registration",
+                        name, layer_idx, num_target_layers,
+                    )
+                    continue
+                filtered[name] = cache
+            kv_caches = filtered
+        self.transfer_topo = TransferTopology(            tp_rank=self.tp_rank,
             tp_size=self.world_size,
             block_size=self.block_size,
             engine_id=self.engine_id,
@@ -1662,14 +1698,12 @@ class NixlConnectorWorker:
         done_recving.update(self._failed_recv_reqs)
         self._failed_recv_reqs.clear()
 
-        if len(done_sending) > 0 or len(done_recving) > 0:
-            logger.debug(
-                "Rank %s, get_finished: %s requests done sending "
-                "and %s requests done recving",
-                self.tp_rank,
-                len(done_sending),
-                len(done_recving),
-            )
+        if done_sending:
+            for req_id in done_sending:
+                logger.info("[KV] send_done(P): req=%s", req_id)
+        if done_recving:
+            for req_id in done_recving:
+                logger.info("[KV] recv_done(D): req=%s", req_id)
 
         block_ids_for_blocksize_post_process = defaultdict(list)
         block_ids_for_heterogeneous_attn_post_process = list[list[int]]()
@@ -1745,10 +1779,13 @@ class NixlConnectorWorker:
                     and req_id not in self._reqs_to_process
                 ):
                     logger.error(
-                        "Potentially invalid KV blocks for "
-                        "unrecognized request %s were retrieved by "
-                        "a decode worker. They may have expired.",
+                        "Potentially invalid KV blocks for unrecognized "
+                        "request %s (len=%d) were retrieved by a decode "
+                        "worker. They may have expired. "
+                        "reqs_to_send_sample=%s",
                         req_id,
+                        len(req_id),
+                        list(self._reqs_to_send.keys())[:3],
                     )
                     continue
 
@@ -1971,7 +2008,10 @@ class NixlConnectorWorker:
             if self.use_mla and tp_ratio < 0:
                 # ..but we still need to notify the other remote ranks that we
                 # have the blocks we need so they can update the request state.
-                notif_id = f"{req_id}:{self.world_size}".encode()
+                # NOTE: must use meta.remote.request_id (prefill-side ID), not
+                # req_id (decode-side ID). In Dynamo KVBM mode these share the
+                # same base UUID but carry different hash suffixes.
+                notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
                 remote_agents = self._remote_agents[meta.remote.engine_id]
                 for rank_to_notify, agent in remote_agents.items():
                     if rank_to_notify != remote_rank:
@@ -2104,6 +2144,14 @@ class NixlConnectorWorker:
 
             # Begin async xfer.
             self.nixl_wrapper.transfer(handle)
+            logger.info(
+                "[KV] RDMA READ posted: req=%s, blocks=%d, "
+                "remote_engine=%s, rank=%d",
+                request_id,
+                num_local_blocks,
+                dst_engine_id,
+                remote_rank,
+            )
 
             # Use handle to check completion in future step().
             self._recving_transfers[request_id].append(handle)

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -250,9 +250,11 @@ class NixlConnectorWorker:
         # Current rank may pull from multiple remote TP workers.
         # EngineId, dict[int, list[int]] -> engine_id, tp_rank, base_addr_for_layer
         self.kv_caches_base_addr = defaultdict[EngineId, dict[int, list[int]]](dict)
-
-        # Number of NIXL regions. Currently one region per cache
-        # (so 1 per layer for MLA, otherwise 2 per layer)
+        # Ordered labels for the local registered regions (one per unique cache
+        # tensor before any blocks-first logical doubling).
+        self.region_labels: list[str] = []
+        # Remote engine_id -> tp_rank -> ordered region labels.
+        self.remote_region_labels = defaultdict[EngineId, dict[int, list[str]]](dict)
         self.num_regions = 0
 
         # nixl_prepped_dlist_handle.
@@ -763,6 +765,7 @@ class NixlConnectorWorker:
                     "Registering layer %s with cache shape: %s", layer_name, cache.shape
                 )
                 seen_base_addresses.append(base_addr)
+                self.region_labels.append(layer_name)
                 # Only record non-Mamba page sizes.
                 if isinstance(layer_spec, MambaSpec):
                     self.block_len_per_layer.append(
@@ -847,6 +850,7 @@ class NixlConnectorWorker:
             agent_metadata=self.nixl_wrapper.get_agent_metadata(),
             device_id=self.device_id,
             kv_caches_base_addr=self.kv_caches_base_addr[self.engine_id][self.tp_rank],
+            region_labels=self.region_labels,
             num_blocks=self.num_blocks,
             block_lens=self.block_len_per_layer,
             kv_cache_layout=self.kv_cache_layout
@@ -1187,6 +1191,16 @@ class NixlConnectorWorker:
             self._physical_blocks_per_logical[engine_id] = physical_blocks_per_logical
 
         logger.info("Transfer plan: %s", transfer_topo.describe(engine_id))
+        logger.info(
+            "NIXL remote registration start: engine_id=%s remote_tp_rank=%s "
+            "remote_tp_size=%s tp_ratio=%s region_count=%s num_blocks=%s",
+            engine_id,
+            remote_tp_rank,
+            remote_tp_size,
+            transfer_topo.tp_ratio(remote_tp_size),
+            len(nixl_agent_meta.kv_caches_base_addr),
+            nixl_agent_meta.num_blocks,
+        )
 
         remote_agent_name = self.nixl_wrapper.add_remote_agent(
             nixl_agent_meta.agent_metadata
@@ -1207,6 +1221,9 @@ class NixlConnectorWorker:
         # Keep track of remote agent kv caches base addresses.
         self.kv_caches_base_addr[engine_id][remote_tp_rank] = (
             nixl_agent_meta.kv_caches_base_addr
+        )
+        self.remote_region_labels[engine_id][remote_tp_rank] = (
+            nixl_agent_meta.region_labels
         )
         self._validate_remote_agent_handshake(nixl_agent_meta, remote_tp_size)
 
@@ -1352,6 +1369,16 @@ class NixlConnectorWorker:
                 remote_tp_rank,
                 self.tp_rank,
             )
+            if blocks_data:
+                logger.info(
+                    "NIXL remote registration details: engine_id=%s remote_rank=%s "
+                    "registered_regions=%s first_region_count=%s first_entries=%s",
+                    engine_id,
+                    remote_tp_rank,
+                    len(nixl_agent_meta.kv_caches_base_addr),
+                    len(blocks_data),
+                    blocks_data[:4],
+                )
 
         if self._has_mamba:
             # Mamba-HMA: separate FA registration with GQA-aware sizing,
@@ -1484,7 +1511,11 @@ class NixlConnectorWorker:
             # TODO (ZhanqiuHu): For mamba models, validate FA and mamba
             # block_lens separately.
             if not self._has_mamba:
-                for i in range(len(self.block_len_per_layer)):
+                num_check = min(
+                    len(self.block_len_per_layer),
+                    len(nixl_agent_meta.block_lens),
+                )
+                for i in range(num_check):
                     assert (
                         self.block_len_per_layer[i] // block_size_ratio
                         == nixl_agent_meta.block_lens[i]
@@ -1524,8 +1555,10 @@ class NixlConnectorWorker:
 
         # TP workers that handhshake with same remote have same #blocks.
         assert self.dst_num_blocks[remote_engine_id] == nixl_agent_meta.num_blocks
-        # Same number of regions/~layers.
-        assert len(nixl_agent_meta.kv_caches_base_addr) == len(self.block_len_per_layer)
+        # In PP mode, a remote agent may expose only its stage-local subset of
+        # layers/regions, so the remote region count can be smaller than the
+        # decode-side full-model layer count.
+        assert len(nixl_agent_meta.kv_caches_base_addr) <= len(self.block_len_per_layer)
 
     def sync_recved_kv_to_device(self, req_id: str, meta: ReqMeta):
         """copy recved kv from host buffer to device."""
@@ -1905,9 +1938,28 @@ class NixlConnectorWorker:
     def _read_blocks_for_req(self, req_id: str, meta: ReqMeta):
         assert meta.remote is not None and self.transfer_topo is not None
         engine_id = meta.remote.engine_id
-        remote_ranks = self.transfer_topo.target_remote_ranks(engine_id)
         remote_info = self.transfer_topo.get_engine_info(engine_id)
-        tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
+        remote_tp_size = remote_info.remote_tp_size
+        tp_ratio = self.transfer_topo.tp_ratio(remote_tp_size)
+        remote_pp_size = meta.pp_size
+
+        if remote_pp_size > 1:
+            if self.use_mla and tp_ratio < 0:
+                # MLA: all TP ranks within a PP stage hold identical KV.
+                # Pick only the first TP rank per PP stage and notify the rest.
+                first_tp = self.transfer_topo.handshake_target_ranks(remote_tp_size)[0]
+                remote_ranks = [
+                    first_tp + pp_rank * remote_tp_size
+                    for pp_rank in range(remote_pp_size)
+                ]
+            else:
+                # Expand to all PP stages × appropriate TP ranks.
+                remote_ranks = self.transfer_topo.get_all_pp_tp_targets(
+                    remote_tp_size=remote_tp_size,
+                    remote_pp_size=remote_pp_size,
+                )
+        else:
+            remote_ranks = self.transfer_topo.target_remote_ranks(engine_id)
 
         if self._has_mamba:
             # Expand remote logical → kernel block IDs.
@@ -1921,11 +1973,6 @@ class NixlConnectorWorker:
             )
         # D may have to perform multiple reads from different remote ranks.
         for i, remote_rank in enumerate(remote_ranks):
-            if self.use_mla and tp_ratio < 0 and i > 0:
-                # MLA opt: when P TP > D TP, only a single read is executed for
-                # the first remote rank (cache is duplicated)..
-                break
-
             remote_block_size = remote_info.remote_block_size
             logger.debug(
                 "Remote agent %s available, calling _read_blocks"
@@ -1940,7 +1987,11 @@ class NixlConnectorWorker:
                 assert remote_block_size == self.block_size
                 # Remote tp_size > local tp_size: we must perform multiple
                 # reads. Get the memory chunk onto which we will write to.
-                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[tp_ratio][i]
+                # Use modulo so the index wraps correctly across PP stages.
+                abs_ratio = -tp_ratio
+                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[tp_ratio][
+                    i % abs_ratio
+                ]
             else:
                 # Single read from remote, we write to the whole memory region.
                 # Also handle remote block size different from local block size.
@@ -1977,12 +2028,14 @@ class NixlConnectorWorker:
             )
 
             if self.use_mla and tp_ratio < 0:
-                # ..but we still need to notify the other remote ranks that we
-                # have the blocks we need so they can update the request state.
+                # We only read from the first TP rank per PP stage; notify the
+                # other TP ranks in the SAME PP stage so they can release blocks.
                 notif_id = f"{req_id}:{self.world_size}".encode()
                 remote_agents = self._remote_agents[meta.remote.engine_id]
+                pp_stage = remote_rank // remote_tp_size
                 for rank_to_notify, agent in remote_agents.items():
-                    if rank_to_notify != remote_rank:
+                    same_stage = (rank_to_notify // remote_tp_size == pp_stage)
+                    if same_stage and rank_to_notify != remote_rank:
                         self.nixl_wrapper.send_notif(agent, notif_msg=notif_id)
 
     def _read_blocks(
@@ -2086,14 +2139,55 @@ class NixlConnectorWorker:
         # workers will issue xfers to parts of the P worker remote kv caches.
 
         # Get descs ids.
+        remote_region_ids = self._get_remote_stage_region_ids(
+            dst_engine_id, remote_rank
+        )
+        local_region_ids = self._get_local_region_ids_for_remote_stage(
+            dst_engine_id, remote_rank
+        )
         remote_block_descs_ids = self._get_block_descs_ids(
             dst_engine_id,
             remote_block_ids,
+            remote_rank=remote_rank,
+            region_ids_override=remote_region_ids,
         )
         local_block_descs_ids = self._get_block_descs_ids(
             self.engine_id,
             local_block_ids,
             block_size_ratio=block_size_ratio,
+            region_ids_override=local_region_ids,
+        )
+
+        remote_region_count = len(self.kv_caches_base_addr[dst_engine_id][remote_rank])
+        remote_desc_region_count = len(remote_region_ids)
+        expected_remote_descs = (
+            remote_desc_region_count * self.dst_num_blocks[dst_engine_id]
+        )
+        logger.info(
+            "NIXL xfer desc mapping: req_id=%s dst_engine_id=%s remote_rank=%s "
+            "remote_region_count=%s remote_desc_region_count=%s "
+            "dst_num_blocks=%s expected_remote_descs=%s "
+            "remote_desc_len=%s remote_desc_min=%s remote_desc_max=%s "
+            "local_desc_len=%s local_desc_min=%s local_desc_max=%s "
+            "remote_region_ids=%s local_region_ids=%s remote_block_ids=%s "
+            "local_block_ids=%s",
+            request_id,
+            dst_engine_id,
+            remote_rank,
+            remote_region_count,
+            remote_desc_region_count,
+            self.dst_num_blocks[dst_engine_id],
+            expected_remote_descs,
+            len(remote_block_descs_ids),
+            int(remote_block_descs_ids.min()) if len(remote_block_descs_ids) else -1,
+            int(remote_block_descs_ids.max()) if len(remote_block_descs_ids) else -1,
+            len(local_block_descs_ids),
+            int(local_block_descs_ids.min()) if len(local_block_descs_ids) else -1,
+            int(local_block_descs_ids.max()) if len(local_block_descs_ids) else -1,
+            remote_region_ids.tolist(),
+            local_region_ids.tolist(),
+            remote_block_ids,
+            local_block_ids,
         )
 
         assert len(local_block_descs_ids) == len(remote_block_descs_ids)
@@ -2155,18 +2249,59 @@ class NixlConnectorWorker:
 
         return mapped_2d.flatten().astype(np.int64)
 
+    def _get_remote_stage_region_ids(
+        self,
+        engine_id: str,
+        remote_rank: int,
+    ) -> np.ndarray:
+        """Return descriptor region ids relative to the remote stage handle."""
+        num_base_regions = len(self.remote_region_labels[engine_id][remote_rank])
+        base_region_ids = np.arange(num_base_regions, dtype=np.int64)
+        return self._expand_base_region_ids(base_region_ids)
+
+    def _get_local_region_ids_for_remote_stage(
+        self,
+        engine_id: str,
+        remote_rank: int,
+    ) -> np.ndarray:
+        """Map a remote worker's explicit region labels onto local region ids."""
+        remote_labels = self.remote_region_labels[engine_id][remote_rank]
+        local_index_by_label = {
+            label: idx for idx, label in enumerate(self.region_labels)
+        }
+        base_region_ids = np.array(
+            [local_index_by_label[label] for label in remote_labels],
+            dtype=np.int64,
+        )
+        return self._expand_base_region_ids(base_region_ids)
+
+    def _expand_base_region_ids(self, base_region_ids: np.ndarray) -> np.ndarray:
+        if self.transfer_topo is not None and self.transfer_topo.is_kv_layout_blocks_first:
+            return (base_region_ids[:, None] * 2 + np.arange(2)).reshape(-1)
+        return base_region_ids
+
     def _get_block_descs_ids(
         self,
         engine_id: str,
         block_ids: BlockIds,
         block_size_ratio: float | None = None,
+        remote_rank: int | None = None,
+        region_ids_override: np.ndarray | None = None,
     ) -> np.ndarray:
         """
         Get the descs ids for a set of block ids.
         When HMA is enabled number of descriptors across kv cache groups might differ.
         A single flattened array is returned for all groups anyway.
         """
-        region_ids = np.arange(self.num_regions)
+        if region_ids_override is not None:
+            region_ids = region_ids_override
+            num_regions = len(region_ids)
+        elif remote_rank is None or engine_id == self.engine_id:
+            num_regions = self.num_regions
+            region_ids = np.arange(num_regions)
+        else:
+            region_ids = self._get_remote_stage_region_ids(engine_id, remote_rank)
+            num_regions = len(region_ids)
 
         # NOTE (NickLucche) With HMA, every kv group has the same number of layers and
         # layers from different groups share the same kv tensor.

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -268,6 +268,11 @@ class NixlConnectorWorker:
         self.dst_num_blocks: dict[EngineId, int] = {}
         self._registered_descs: list[Any] = []
 
+        # PP-aware layer-range src handles: (engine_id, global_pp_rank) ->
+        # (nixl_prepped_dlist_handle, num_pp_layers) covering only that PP rank's
+        # layer subset. Built during _nixl_handshake when remote_pp_size > 1.
+        self._pp_src_xfer_handles: dict[tuple[EngineId, int], tuple[int, int]] = {}
+
         # ---- Mamba-HMA per-engine state (only used when self._has_mamba) ----
         # NOTE (ZhanqiuHu): _physical_blocks_per_logical MUST be per-engine.
         # physical_blocks_per_logical = ceil((conv_bytes + ssm_bytes) / block_len)
@@ -395,6 +400,13 @@ class NixlConnectorWorker:
         else:
             p_remote_ranks = self.transfer_topo.handshake_target_ranks(remote_tp_size)
         remote_rank_to_agent_name = {}
+        # PP layer offset: tracks cumulative layer count across PP stages so each
+        # PP stage's local src handle covers only the correct layer slice.
+        # Advances once per PP stage (not per TP rank): all TP workers in the same
+        # PP stage hold the same layers and should receive the same slice handle.
+        pp_layer_offset = 0
+        pp_layer_last_stage = -1          # which PP stage owns the current offset
+        pp_layer_last_num_layers = 0      # layer count of the stage at last offset
         path = make_zmq_path("tcp", host, port)
 
         with zmq_ctx(zmq.REQ, path) as sock:
@@ -484,6 +496,57 @@ class NixlConnectorWorker:
                     setup_agent_time - got_metadata_time,
                 )
                 remote_rank_to_agent_name[remote_rank] = remote_agent_name
+
+                # PP layer-range routing: build a per-PP-rank local src handle
+                # that only covers the layer subset this PP rank has.
+                # Ensures make_prepped_xfer src/dst descriptor counts match.
+                if remote_pp_size > 1 and hasattr(self, "src_blocks_data"):
+                    num_pp_layers = len(metadata.kv_caches_base_addr)
+                    # regions_per_layer = 1 for standard layout, 2 for blocks-first
+                    # (FlashInfer stores K and V as separate regions per layer).
+                    num_local_layers = len(
+                        self.kv_caches_base_addr[self.engine_id][self.tp_rank]
+                    )
+                    regions_per_layer = self.num_regions // num_local_layers
+                    num_pp_regions = num_pp_layers * regions_per_layer
+
+                    # Determine which PP stage and TP position this remote_rank is.
+                    # global_rank = pp_stage * remote_tp_size + tp_rank_in_stage.
+                    pp_stage = remote_rank // remote_tp_size
+                    tp_rank_in_stage = remote_rank % remote_tp_size
+
+                    # Advance pp_layer_offset only when entering a NEW PP stage.
+                    # All TP workers in the same PP stage hold identical layers.
+                    if pp_stage != pp_layer_last_stage:
+                        if pp_layer_last_stage >= 0:
+                            pp_layer_offset += pp_layer_last_num_layers
+                        pp_layer_last_stage = pp_stage
+                        pp_layer_last_num_layers = num_pp_layers
+
+                    # TODO: PP + heterogeneous TP (non-MLA, P.TP > D.TP):
+                    # The handle below only applies the layer-slice. When P.TP > D.TP
+                    # and use_mla=False, the remote descriptor covers only 1/tp_ratio
+                    # of the KV heads. The local handle must also be head-split to
+                    # match byte lengths; otherwise NIXL raises "length mismatch".
+                    # Fix: build per-(pp_stage, tp_rank_in_stage) combined handles
+                    # (layer-slice + head-split). See _build_layer_range_xfer_handle.
+                    self._pp_src_xfer_handles[(expected_engine_id, remote_rank)] = (
+                        self._build_layer_range_xfer_handle(
+                            pp_layer_offset, pp_layer_offset + num_pp_layers
+                        ),
+                        num_pp_regions,
+                    )
+                    logger.debug(
+                        "PP layer-range handle: rank=%d pp_stage=%d tp_in_stage=%d "
+                        "layers=[%d:%d] regions_per_layer=%d key=%s",
+                        remote_rank,
+                        pp_stage,
+                        tp_rank_in_stage,
+                        pp_layer_offset,
+                        pp_layer_offset + num_pp_layers,
+                        regions_per_layer,
+                        expected_engine_id,
+                    )
             logger.info(
                 "[KV] handshake completed: engine=%s, %.3fs, %d ranks",
                 expected_engine_id,
@@ -1146,6 +1209,38 @@ class NixlConnectorWorker:
         # NIXL_INIT_AGENT to be used for preparations of local descs.
         return self.nixl_wrapper.prep_xfer_dlist("NIXL_INIT_AGENT", descs), blocks_data
 
+    def _build_layer_range_xfer_handle(
+        self, start_layer: int, end_layer: int
+    ) -> int:
+        """Build a local src NIXL handle covering only layers [start_layer:end_layer].
+
+        Used for Pipeline Parallelism: each PP rank on Prefill registers only its
+        own layer subset. The Decode side needs a matching local src handle that
+        covers exactly those layers so that make_prepped_xfer descriptor counts match.
+
+        src_blocks_data layout: entries_per_layer entries per layer, where
+        entries_per_layer = num_blocks for standard layout and num_blocks * 2 for
+        blocks-first (FlashInfer) layout which stores K and V regions separately.
+        Derived as len(src_blocks_data) // num_local_layers to be layout-agnostic.
+        """
+        num_local_layers = len(
+            self.kv_caches_base_addr[self.engine_id][self.tp_rank]
+        )
+        entries_per_layer = len(self.src_blocks_data) // num_local_layers
+        sliced_data = self.src_blocks_data[
+            start_layer * entries_per_layer : end_layer * entries_per_layer
+        ]
+        descs = self.nixl_wrapper.get_xfer_descs(sliced_data, self.nixl_memory_type)
+        return self.nixl_wrapper.prep_xfer_dlist("NIXL_INIT_AGENT", descs)
+        # TODO: PP + heterogeneous TP (non-MLA, P.TP > D.TP):
+        # The handle above only applies the layer-slice.  When P.TP > D.TP and
+        # use_mla=False, the remote descriptor per block covers only 1/tp_ratio of
+        # the KV heads, so the local handle must also be head-split to match byte
+        # lengths.  Symptom: NIXL "length mismatch at index pair N" in E2E.
+        # Fix: build per-(pp_stage, tp_rank_in_stage) combined handles that are
+        # both layer-sliced AND head-split (analogous to src_xfer_handles_by_tp_ratio
+        # but restricted to the PP layer range).
+
     def add_remote_agent(
         self,
         nixl_agent_meta: NixlAgentMetadata,
@@ -1526,7 +1621,13 @@ class NixlConnectorWorker:
             # TODO (ZhanqiuHu): For mamba models, validate FA and mamba
             # block_lens separately.
             if not self._has_mamba:
-                for i in range(len(self.block_len_per_layer)):
+                # With Pipeline Parallelism on the remote (Prefill), each PP rank
+                # only registers its own layer subset, so block_lens has fewer
+                # entries than local block_len_per_layer. Validate the overlap only.
+                num_layers_to_check = min(
+                    len(self.block_len_per_layer), len(nixl_agent_meta.block_lens)
+                )
+                for i in range(num_layers_to_check):
                     assert (
                         self.block_len_per_layer[i] // block_size_ratio
                         == nixl_agent_meta.block_lens[i]
@@ -1567,7 +1668,13 @@ class NixlConnectorWorker:
         # TP workers that handhshake with same remote have same #blocks.
         assert self.dst_num_blocks[remote_engine_id] == nixl_agent_meta.num_blocks
         # Same number of regions/~layers.
-        assert len(nixl_agent_meta.kv_caches_base_addr) == len(self.block_len_per_layer)
+        # With Pipeline Parallelism on Prefill, each PP rank registers only its
+        # layer subset, so kv_caches_base_addr has fewer entries than
+        # block_len_per_layer. Allow remote to have <= local layers (PP-aware).
+        assert len(nixl_agent_meta.kv_caches_base_addr) <= len(self.block_len_per_layer), (
+            f"Remote has more KV regions ({len(nixl_agent_meta.kv_caches_base_addr)}) "
+            f"than local ({len(self.block_len_per_layer)})"
+        )
 
     def sync_recved_kv_to_device(self, req_id: str, meta: ReqMeta):
         """copy recved kv from host buffer to device."""
@@ -1948,9 +2055,25 @@ class NixlConnectorWorker:
     def _read_blocks_for_req(self, req_id: str, meta: ReqMeta):
         assert meta.remote is not None and self.transfer_topo is not None
         engine_id = meta.remote.engine_id
-        remote_ranks = self.transfer_topo.target_remote_ranks(engine_id)
         remote_info = self.transfer_topo.get_engine_info(engine_id)
+        if meta.pp_size > 1:
+            # PP Prefill: connect to all PP stages via global indices.
+            # Each PP stage has its own layer subset; per-range handles are used
+            # in _read_blocks to keep descriptor counts matching.
+            remote_tp_size = remote_info.remote_tp_size
+            remote_ranks = self.transfer_topo.get_all_pp_tp_targets(
+                remote_tp_size, meta.pp_size
+            )
+        else:
+            remote_ranks = self.transfer_topo.target_remote_ranks(engine_id)
         tp_ratio = self.transfer_topo.tp_ratio(remote_info.remote_tp_size)
+
+        # n_tp_per_stage: how many consecutive entries in remote_ranks belong to
+        # the same PP stage.  get_all_pp_tp_targets returns:
+        #   outer loop = pp_stage (0..pp_size-1)
+        #   inner loop = tp_targets per stage (length = abs(tp_ratio) when < 0)
+        # For tp_ratio > 0 (or PP=1): each entry is its own "stage" of size 1.
+        n_tp_per_stage = (-tp_ratio) if tp_ratio < 0 else 1
 
         if self._has_mamba:
             # Expand remote logical → kernel block IDs.
@@ -1964,10 +2087,15 @@ class NixlConnectorWorker:
             )
         # D may have to perform multiple reads from different remote ranks.
         for i, remote_rank in enumerate(remote_ranks):
-            if self.use_mla and tp_ratio < 0 and i > 0:
-                # MLA opt: when P TP > D TP, only a single read is executed for
-                # the first remote rank (cache is duplicated)..
-                break
+            # Position of this rank within its PP stage's TP group.
+            i_in_stage = i % n_tp_per_stage
+
+            if self.use_mla and tp_ratio < 0 and i_in_stage > 0:
+                # MLA opt: when P.TP > D.TP, KV is replicated across P TP ranks.
+                # Read only from the first TP rank of each PP stage (i_in_stage=0);
+                # notify the skipped ranks so Prefill can release their blocks.
+                # Use `continue` (not break) so all PP stages are processed.
+                continue
 
             remote_block_size = remote_info.remote_block_size
             logger.debug(
@@ -1983,13 +2111,28 @@ class NixlConnectorWorker:
                 assert remote_block_size == self.block_size
                 # Remote tp_size > local tp_size: we must perform multiple
                 # reads. Get the memory chunk onto which we will write to.
-                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[tp_ratio][i]
+                # Use i_in_stage (not i) so the handle index resets per PP stage.
+                local_xfer_side_handle = self.src_xfer_handles_by_tp_ratio[tp_ratio][
+                    i_in_stage
+                ]
             else:
                 # Single read from remote, we write to the whole memory region.
                 # Also handle remote block size different from local block size.
                 local_xfer_side_handle = self.src_xfer_handles_by_block_size[
                     remote_block_size
                 ]
+
+            # PP layer-range routing: override local handle with the per-PP-rank
+            # slice so src/dst descriptor counts match in make_prepped_xfer.
+            # Also pass pp_num_regions so _get_block_descs_ids uses the right
+            # region count for both local and remote handles instead of the
+            # full model's num_regions.
+            pp_key = (meta.remote.engine_id, remote_rank)
+            pp_num_regions: int | None = None
+            if pp_key in self._pp_src_xfer_handles:
+                local_xfer_side_handle, pp_num_regions = (
+                    self._pp_src_xfer_handles[pp_key]
+                )
 
             # Destination handle: remote_engine_id -> remote_rank -> handle.
             remote_xfer_side_handle = self.dst_xfer_side_handles[meta.remote.engine_id][
@@ -2017,19 +2160,26 @@ class NixlConnectorWorker:
                 remote_rank=remote_rank,
                 local_xfer_side_handle=local_xfer_side_handle,
                 remote_xfer_side_handle=remote_xfer_side_handle,
+                pp_num_regions=pp_num_regions,
             )
 
             if self.use_mla and tp_ratio < 0:
-                # ..but we still need to notify the other remote ranks that we
-                # have the blocks we need so they can update the request state.
+                # After reading from the first TP rank of this PP stage, notify
+                # the skipped TP ranks within the SAME stage so Prefill can
+                # release their blocks.  Only notify stage-peers (i+1..i+n-1),
+                # NOT ranks from other PP stages (those get their own reads).
                 # NOTE: must use meta.remote.request_id (prefill-side ID), not
                 # req_id (decode-side ID). In Dynamo KVBM mode these share the
                 # same base UUID but carry different hash suffixes.
                 notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
                 remote_agents = self._remote_agents[meta.remote.engine_id]
-                for rank_to_notify, agent in remote_agents.items():
-                    if rank_to_notify != remote_rank:
-                        self.nixl_wrapper.send_notif(agent, notif_msg=notif_id)
+                for j in range(1, n_tp_per_stage):
+                    skipped_idx = i + j
+                    if skipped_idx < len(remote_ranks):
+                        skipped_rank = remote_ranks[skipped_idx]
+                        agent = remote_agents.get(skipped_rank)
+                        if agent is not None:
+                            self.nixl_wrapper.send_notif(agent, notif_msg=notif_id)
 
     def _read_blocks(
         self,
@@ -2041,6 +2191,7 @@ class NixlConnectorWorker:
         remote_rank: int,
         local_xfer_side_handle: int,
         remote_xfer_side_handle: int,
+        pp_num_regions: int | None = None,
     ):
         """
         Post a READ point-to-point xfer request from a single local worker to
@@ -2132,14 +2283,20 @@ class NixlConnectorWorker:
         # workers will issue xfers to parts of the P worker remote kv caches.
 
         # Get descs ids.
+        # PP: when a layer-range slice handle is used, both the local (Decode)
+        # and remote (Prefill PP rank) handles cover only pp_num_regions regions.
+        # Pass num_regions_override to both sides so descriptor ID counts match
+        # (len(local) == len(remote)) and all indices stay within the handle range.
         remote_block_descs_ids = self._get_block_descs_ids(
             dst_engine_id,
             remote_block_ids,
+            num_regions_override=pp_num_regions,
         )
         local_block_descs_ids = self._get_block_descs_ids(
             self.engine_id,
             local_block_ids,
             block_size_ratio=block_size_ratio,
+            num_regions_override=pp_num_regions,
         )
 
         assert len(local_block_descs_ids) == len(remote_block_descs_ids)
@@ -2214,13 +2371,18 @@ class NixlConnectorWorker:
         engine_id: str,
         block_ids: BlockIds,
         block_size_ratio: float | None = None,
+        num_regions_override: int | None = None,
     ) -> np.ndarray:
         """
         Get the descs ids for a set of block ids.
         When HMA is enabled number of descriptors across kv cache groups might differ.
         A single flattened array is returned for all groups anyway.
+
+        num_regions_override: when set, use this value instead of self.num_regions.
+        Used for PP slice handles that cover only a subset of model layers.
         """
-        region_ids = np.arange(self.num_regions)
+        num_regions = num_regions_override if num_regions_override is not None else self.num_regions
+        region_ids = np.arange(num_regions)
 
         # NOTE (NickLucche) With HMA, every kv group has the same number of layers and
         # layers from different groups share the same kv tensor.
@@ -2249,8 +2411,9 @@ class NixlConnectorWorker:
             # `num_fa_descs` offset must be computed per-engine since P and D can
             # have different num_blocks (and thus different FA descs counts).
             physical_per_logical = self._physical_blocks_per_logical[engine_id]
+            # SSM may register fewer num_blocks than FA
             logical_blocks = num_blocks // physical_per_logical
-            num_fa_descs = self.num_regions * num_blocks
+            num_fa_descs = num_regions * num_blocks
             # 3-read mamba: 4 regions per unique cache tensor (x, B, C, ssm).
             mamba_region_ids = np.arange(len(self.block_len_per_layer) * 4)[:, None]
             all_descs = []
@@ -2412,6 +2575,9 @@ class NixlConnectorWorker:
             for dst_xfer_side_handle in dst_xfer_side_handles.values():
                 self.nixl_wrapper.release_dlist_handle(dst_xfer_side_handle)
         self.dst_xfer_side_handles.clear()
+        for handle, _ in self._pp_src_xfer_handles.values():
+            self.nixl_wrapper.release_dlist_handle(handle)
+        self._pp_src_xfer_handles.clear()
         for remote_agents in self._remote_agents.values():
             for agent_name in remote_agents.values():
                 self.nixl_wrapper.remove_remote_agent(agent_name)

--- a/vllm/entrypoints/openai/chat_completion/protocol.py
+++ b/vllm/entrypoints/openai/chat_completion/protocol.py
@@ -597,6 +597,64 @@ class ChatCompletionRequest(OpenAIBaseModel):
 
     @model_validator(mode="before")
     @classmethod
+    def validate_interleaved_thinking(cls, data):
+        """When the last message is role=tool, the preceding assistant
+        message must include reasoning content for interleaved thinking.
+
+        Only enforced when ``chat_template_kwargs.thinking`` is True.
+        """
+        chat_template_kwargs = data.get("chat_template_kwargs") or {}
+        if not chat_template_kwargs.get("thinking"):
+            return data
+
+        messages = data.get("messages")
+        if not messages:
+            return data
+
+        last = messages[-1]
+        last_role = (
+            last.get("role")
+            if isinstance(last, dict)
+            else getattr(last, "role", None)
+        )
+        if last_role != "tool":
+            return data
+
+        # Walk backwards past consecutive tool messages to find the
+        # preceding assistant message.
+        for msg in reversed(messages[:-1]):
+            role = (
+                msg.get("role")
+                if isinstance(msg, dict)
+                else getattr(msg, "role", None)
+            )
+            if role == "tool":
+                continue
+            if role == "assistant":
+                if isinstance(msg, dict):
+                    tool_calls = msg.get("tool_calls")
+                    reasoning = msg.get("reasoning") or msg.get(
+                        "reasoning_content"
+                    )
+                else:
+                    tool_calls = getattr(msg, "tool_calls", None)
+                    reasoning = getattr(
+                        msg, "reasoning", None
+                    ) or getattr(msg, "reasoning_content", None)
+                if tool_calls and not reasoning:
+                    raise VLLMValidationError(
+                        "Interleaved thinking required: the assistant "
+                        "message preceding tool results must include "
+                        "`reasoning` or `reasoning_content` when "
+                        "tool_calls are present.",
+                        parameter="messages",
+                    )
+            break
+
+        return data
+
+    @model_validator(mode="before")
+    @classmethod
     def validate_stream_options(cls, data):
         if data.get("stream_options") and not data.get("stream"):
             raise VLLMValidationError(

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1362,9 +1362,9 @@ class OpenAIServingChat(OpenAIServing):
             # Reset tool parser streaming state so that any section-level
             # buffers or counters are cleaned up promptly rather than
             # waiting for garbage collection.
-            for tp in tool_parsers:
-                if tp is not None:
-                    tp.reset_streaming_state()
+            for parser in parsers:
+                if parser is not None and parser.tool_parser is not None:
+                    parser.tool_parser.reset_streaming_state()
         # Send the final done message after all response.n are finished
         yield "data: [DONE]\n\n"
 

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -238,9 +238,10 @@ class OpenAIServingChat(OpenAIServing):
         - ``chat_template_kwargs.enable_thinking``: true / false
         - Default: think mode enabled
 
-        Think mode:     temperature=1.0, top_p=0.95
-        Non-think mode: temperature=0.6, top_p=0.95
-        Common constraints: presence_penalty=0, frequency_penalty=0, n=1
+        Temperature must be between 0 and 1 (inclusive).
+        Defaults: think mode -> 1.0, non-think mode -> 0.6
+        Common constraints: top_p=0.95, presence_penalty=0,
+        frequency_penalty=0, n=1
         """
         is_thinking = True
         if request.chat_template_kwargs:
@@ -259,11 +260,10 @@ class OpenAIServingChat(OpenAIServing):
         errors = []
 
         req_temp = request.temperature
-        if req_temp is not None and req_temp != expected_temperature:
-            mode_label = "think" if is_thinking else "non-think"
+        if req_temp is not None and not (0.0 <= req_temp <= 1.0):
             errors.append(
-                f"temperature must be {expected_temperature} "
-                f"in {mode_label} mode, got {req_temp}"
+                f"temperature must be between 0 and 1 (inclusive), "
+                f"got {req_temp}"
             )
 
         req_top_p = request.top_p

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -167,6 +167,7 @@ class OpenAIServingChat(OpenAIServing):
             )
 
         self.tool_call_id_type = get_tool_call_id_type(self.model_config)
+        self.is_kimi = (self.tool_call_id_type == "kimi_k2")
 
         # NOTE(woosuk): While OpenAI's chat completion API supports browsing
         # for some models, currently vLLM doesn't support it. Please use the
@@ -226,6 +227,85 @@ class OpenAIServingChat(OpenAIServing):
 
         return await self.openai_serving_render.render_chat(request)
 
+    def _validate_kimi_params(
+        self,
+        request: ChatCompletionRequest,
+    ) -> ErrorResponse | None:
+        """Validate request parameters for Kimi models.
+
+        Thinking mode is detected from ``chat_template_kwargs``:
+        - ``chat_template_kwargs.thinking``: true / false
+        - ``chat_template_kwargs.enable_thinking``: true / false
+        - Default: think mode enabled
+
+        Think mode:     temperature=1.0, top_p=0.95
+        Non-think mode: temperature=0.6, top_p=0.95
+        Common constraints: presence_penalty=0, frequency_penalty=0, n=1
+        """
+        is_thinking = True
+        if request.chat_template_kwargs:
+            ctk = request.chat_template_kwargs
+            if "thinking" in ctk:
+                is_thinking = bool(ctk["thinking"])
+            elif "enable_thinking" in ctk:
+                is_thinking = bool(ctk["enable_thinking"])
+
+        expected_temperature = 1.0 if is_thinking else 0.6
+        expected_top_p = 0.95
+        expected_presence_penalty = 0.0
+        expected_frequency_penalty = 0.0
+        expected_n = 1
+
+        errors = []
+
+        req_temp = request.temperature
+        if req_temp is not None and req_temp != expected_temperature:
+            mode_label = "think" if is_thinking else "non-think"
+            errors.append(
+                f"temperature must be {expected_temperature} "
+                f"in {mode_label} mode, got {req_temp}"
+            )
+
+        req_top_p = request.top_p
+        if req_top_p is not None and req_top_p != expected_top_p:
+            errors.append(f"top_p must be {expected_top_p}, got {req_top_p}")
+
+        req_pp = request.presence_penalty
+        if req_pp is not None and req_pp != expected_presence_penalty:
+            errors.append(
+                f"presence_penalty must be {expected_presence_penalty},"
+                f" got {req_pp}"
+            )
+
+        req_fp = request.frequency_penalty
+        if req_fp is not None and req_fp != expected_frequency_penalty:
+            errors.append(
+                f"frequency_penalty must be {expected_frequency_penalty},"
+                f" got {req_fp}"
+            )
+
+        req_n = request.n
+        if req_n is not None and req_n != expected_n:
+            errors.append(f"n must be {expected_n}, got {req_n}")
+
+        if errors:
+            return self.create_error_response(
+                f"Invalid parameters for Kimi model: {'; '.join(errors)}"
+            )
+
+        # Apply defaults for unset parameters
+        if request.temperature is None:
+            request.temperature = expected_temperature
+        if request.top_p is None:
+            request.top_p = expected_top_p
+
+        if request.chat_template_kwargs is None:
+            request.chat_template_kwargs = {}
+        request.chat_template_kwargs.setdefault("thinking", is_thinking)
+        request.chat_template_kwargs.setdefault("enable_thinking", is_thinking)
+
+        return None
+
     async def create_chat_completion(
         self,
         request: ChatCompletionRequest,
@@ -238,6 +318,12 @@ class OpenAIServingChat(OpenAIServing):
         for the API specification. This API mimics the OpenAI
         Chat Completion API.
         """
+        # Validate Kimi model parameters before processing
+        if self.is_kimi:
+            kimi_error = self._validate_kimi_params(request)
+            if kimi_error is not None:
+                return kimi_error
+
         # Streaming response
         tokenizer = self.renderer.tokenizer
         assert tokenizer is not None
@@ -1272,6 +1358,13 @@ class OpenAIServingChat(OpenAIServing):
             logger.exception("Error in chat completion stream generator.")
             data = self.create_streaming_error_response(e)
             yield f"data: {data}\n\n"
+        finally:
+            # Reset tool parser streaming state so that any section-level
+            # buffers or counters are cleaned up promptly rather than
+            # waiting for garbage collection.
+            for tp in tool_parsers:
+                if tp is not None:
+                    tp.reset_streaming_state()
         # Send the final done message after all response.n are finished
         yield "data: [DONE]\n\n"
 

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/flashinfer_nvlink_one_sided.py
@@ -118,12 +118,27 @@ class FlashInferNVLinkOneSidedPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeMo
         payloads.append(topk_ids)
         payloads.append(topk_weights)
 
+        invalid_token_expert_id = num_experts
+        if expert_map is not None and self.all2all_manager.world_size > 1:
+            assert num_experts % self.all2all_manager.world_size == 0, (
+                "FlashInfer one-sided all2all expects experts to be evenly "
+                "partitioned across EP ranks"
+            )
+            experts_per_rank = num_experts // self.all2all_manager.world_size
+            invalid_token_expert_id = (
+                (self.all2all_manager.rank + 1) % self.all2all_manager.world_size
+            ) * experts_per_rank
+
         assert self.all2all_manager.moe_alltoall is not None  # type: ignore[attr-defined]
         recv_payloads = self.all2all_manager.moe_alltoall.dispatch(  # type: ignore[attr-defined]
             token_selected_experts=topk_ids,
             input_payloads=payloads,
             runtime_max_tokens_per_rank=self.runtime_max_tokens_per_rank,
-            invalid_token_expert_id=-1,  # Follow TRTLLM Pattern
+            # The one-sided kernel pads each source rank to
+            # runtime_max_tokens_per_rank. Use an expert that is invalid for
+            # the local rank when expert_map is present; this avoids negative
+            # IDs entering kernels that index expert_map before filtering.
+            invalid_token_expert_id=invalid_token_expert_id,
             expert_id_payload_index=topk_ids_payload_index,
         )
         if a1q_scale is not None:

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -739,9 +739,9 @@ class SamplingParams(
             return
 
         # Some sampling parameters are not yet compatible with spec decoding.
-        if self.min_p > _SAMPLING_EPS or self.logit_bias:
+        if self.min_p > _SAMPLING_EPS:
             raise ValueError(
-                "The min_p and logit_bias sampling parameters "
+                "The min_p sampling parameters "
                 "are not yet supported with speculative decoding."
             )
 

--- a/vllm/tool_parsers/abstract_tool_parser.py
+++ b/vllm/tool_parsers/abstract_tool_parser.py
@@ -135,6 +135,17 @@ class ToolParser:
             "AbstractToolParser.extract_tool_calls has not been implemented!"
         )
 
+    def reset_streaming_state(self) -> None:
+        """Reset all streaming state between requests.
+
+        Subclasses that maintain additional state (e.g. section tracking,
+        token buffers) should override this method and call ``super()``.
+        """
+        self.prev_tool_call_arr = []
+        self.current_tool_id = -1
+        self.current_tool_name_sent = False
+        self.streamed_args_for_tool = []
+
     def extract_tool_calls_streaming(
         self,
         previous_text: str,

--- a/vllm/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k2_tool_parser.py
@@ -62,6 +62,10 @@ class KimiK2ToolParser(ToolParser):
                 "constructor during construction."
             )
 
+    def reset_streaming_state(self) -> None:
+        super().reset_streaming_state()
+        self._sent_content_idx = 0
+
     def adjust_request(
         self, request: ChatCompletionRequest | ResponsesRequest
     ) -> ChatCompletionRequest | ResponsesRequest:

--- a/vllm/tool_parsers/kimi_k2_tool_parser.py
+++ b/vllm/tool_parsers/kimi_k2_tool_parser.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
 from collections.abc import Sequence
 
 import regex as re
@@ -18,6 +19,7 @@ from vllm.entrypoints.openai.engine.protocol import (
 )
 from vllm.entrypoints.openai.responses.protocol import ResponsesRequest
 from vllm.logger import init_logger
+from vllm.sampling_params import StructuredOutputsParams
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import (
     Tool,
@@ -68,7 +70,61 @@ class KimiK2ToolParser(ToolParser):
             # Ensure special-token markers appear as literal text in
             # current_text so we can do pure text-based parsing.
             request.skip_special_tokens = False
+
+        # Add structural_tag guided decoding to constrain tool name and JSON
+        # schema, preventing hallucinated tool names and malformed arguments.
+        if (
+            request.structured_outputs is None
+            and request.tools
+            and request.tool_choice in ("auto", None)
+        ):
+            tag_json = self._build_structural_tag(request.tools)
+            if tag_json is not None:
+                request.structured_outputs = StructuredOutputsParams(
+                    structural_tag=tag_json
+                )
+
         return request
+
+    def _build_structural_tag(self, tools) -> str | None:
+        """Build structural_tag JSON for guided decoding.
+
+        Constrains the model to only call tools from the provided list and
+        to produce arguments that conform to each tool's JSON schema.
+        """
+        tags = []
+        for tool in tools:
+            name = tool.function.name
+            params = tool.function.parameters or {
+                "type": "object",
+                "properties": {},
+            }
+            tags.append({
+                "type": "tag",
+                "begin": f"<|tool_call_begin|>functions.{name}",
+                "content": {
+                    "type": "sequence",
+                    "elements": [
+                        {"type": "regex", "pattern": r":\d+"},
+                        {"type": "const_string",
+                         "value": "<|tool_call_argument_begin|>"},
+                        {"type": "json_schema", "json_schema": params},
+                    ],
+                },
+                "end": "<|tool_call_end|>",
+            })
+        if not tags:
+            return None
+        return json.dumps({
+            "type": "structural_tag",
+            "format": {
+                "type": "triggered_tags",
+                "triggers": ["<|tool_call_begin|>"],
+                "tags": tags,
+                "at_least_one": False,
+                "stop_after_first": False,
+            },
+        })
 
     def extract_tool_calls(
         self,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -175,6 +175,8 @@ class Scheduler(SchedulerInterface):
         # This is flushed at the end of each scheduling step.
         self.finished_req_ids: set[str] = set()
 
+        self._pending_kv_send_count: int = 0
+
         # Counter for requests waiting for streaming input. Used to calculate
         # number of unfinished requests
         self.num_waiting_for_streaming_input: int = 0
@@ -1838,6 +1840,8 @@ class Scheduler(SchedulerInterface):
         delay_free_blocks |= connector_delay_free_blocks
         if not delay_free_blocks:
             self._free_blocks(request)
+        else:
+            self._pending_kv_send_count += 1
 
         return kv_xfer_params
 
@@ -1866,7 +1870,7 @@ class Scheduler(SchedulerInterface):
         return num_waiting + len(self.running)
 
     def has_finished_requests(self) -> bool:
-        return len(self.finished_req_ids) > 0
+        return len(self.finished_req_ids) > 0 or self._pending_kv_send_count > 0
 
     def reset_prefix_cache(
         self, reset_running_requests: bool = False, reset_connector: bool = False
@@ -2132,6 +2136,7 @@ class Scheduler(SchedulerInterface):
             logger.debug("Finished sending KV transfer for request %s", req_id)
             assert req_id in self.requests
             self._free_blocks(self.requests[req_id])
+            self._pending_kv_send_count -= 1
 
     def _update_requests_with_invalid_blocks(
         self,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -175,8 +175,6 @@ class Scheduler(SchedulerInterface):
         # This is flushed at the end of each scheduling step.
         self.finished_req_ids: set[str] = set()
 
-        self._pending_kv_send_count: int = 0
-
         # Counter for requests waiting for streaming input. Used to calculate
         # number of unfinished requests
         self.num_waiting_for_streaming_input: int = 0
@@ -1840,8 +1838,6 @@ class Scheduler(SchedulerInterface):
         delay_free_blocks |= connector_delay_free_blocks
         if not delay_free_blocks:
             self._free_blocks(request)
-        else:
-            self._pending_kv_send_count += 1
 
         return kv_xfer_params
 
@@ -1870,7 +1866,7 @@ class Scheduler(SchedulerInterface):
         return num_waiting + len(self.running)
 
     def has_finished_requests(self) -> bool:
-        return len(self.finished_req_ids) > 0 or self._pending_kv_send_count > 0
+        return len(self.finished_req_ids) > 0
 
     def reset_prefix_cache(
         self, reset_running_requests: bool = False, reset_connector: bool = False
@@ -2136,7 +2132,6 @@ class Scheduler(SchedulerInterface):
             logger.debug("Finished sending KV transfer for request %s", req_id)
             assert req_id in self.requests
             self._free_blocks(self.requests[req_id])
-            self._pending_kv_send_count -= 1
 
     def _update_requests_with_invalid_blocks(
         self,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -838,6 +838,9 @@ class Scheduler(SchedulerInterface):
                 token_budget -= num_new_tokens
                 request.status = RequestStatus.RUNNING
                 request.num_computed_tokens = num_computed_tokens
+                # Count the number of prefix cached tokens.
+                if request.num_cached_tokens < 0:
+                    request.num_cached_tokens = num_computed_tokens
                 # Encoder-related.
                 if encoder_inputs_to_schedule:
                     scheduled_encoder_inputs[request_id] = encoder_inputs_to_schedule
@@ -1478,6 +1481,11 @@ class Scheduler(SchedulerInterface):
                         prefill_stats=request.take_prefill_stats(),
                         kv_transfer_params=kv_transfer_params,
                         trace_headers=request.trace_headers,
+                        num_cached_tokens=request.num_cached_tokens,
+                        num_cached_tokens_for_output=(
+                            request.num_cached_tokens_for_output
+                        ),
+                        num_external_computed_tokens=request.num_external_computed_tokens,
                         routed_experts=routed_experts,
                         num_nans_in_logits=request.num_nans_in_logits,
                     )
@@ -1504,6 +1512,10 @@ class Scheduler(SchedulerInterface):
                         finish_reason=request.get_finished_reason(),
                         events=request.take_events(),
                         trace_headers=request.trace_headers,
+                        num_cached_tokens=request.num_cached_tokens,
+                        num_cached_tokens_for_output=(
+                            request.num_cached_tokens_for_output
+                        ),
                     )
                 )
 

--- a/vllm/v1/engine/__init__.py
+++ b/vllm/v1/engine/__init__.py
@@ -175,6 +175,12 @@ class EngineCoreOutput(
 
     prefill_stats: PrefillStats | None = None
 
+    # The number of tokens with prefix cache hits (local + external).
+    num_cached_tokens: int = 0
+    # The number of cached tokens to report in user-facing outputs.
+    num_cached_tokens_for_output: int | None = None
+    # The number of tokens computed remotely (original count from connector).
+    num_external_computed_tokens: int = 0
     routed_experts: np.ndarray | None = None
     # The number of NaNs in logits.
     # A value greater than 0 indicates that the output is corrupted.

--- a/vllm/v1/engine/async_llm.py
+++ b/vllm/v1/engine/async_llm.py
@@ -41,6 +41,7 @@ from vllm.v1.engine import EngineCoreRequest, PauseMode
 from vllm.v1.engine.core_client import EngineCoreClient
 from vllm.v1.engine.exceptions import EngineDeadError, EngineGenerateError
 from vllm.v1.engine.input_processor import InputProcessor
+from vllm.v1.engine.kv_consumer_validation import validate_kv_consumer_request
 from vllm.v1.engine.output_processor import OutputProcessor, RequestOutputCollector
 from vllm.v1.engine.parallel_sampling import ParentRequest
 from vllm.v1.executor import Executor
@@ -366,6 +367,7 @@ class AsyncLLM(EngineClient):
             request.reasoning_parser_kwargs = reasoning_parser_kwargs
 
         self.input_processor.assign_request_id(request)
+        validate_kv_consumer_request(request, self.vllm_config.kv_transfer_config)
 
         # We start the output_handler on the first call to add_request() so
         # we can call __init__ before the event loop, which enables us

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -242,13 +242,27 @@ class DPCoordinatorProc:
                 finally:
                     zmq_addr_pipe.close()
             # Wait until all engines subscribe.
-            for _ in self.engines:
-                if publish_back.recv() != b"\x01":
+            total_engines = len(self.engines)
+            for i in range(total_engines):
+                logger.info(
+                    "[DIAG-COORD] Waiting for subscription %d/%d...",
+                    i + 1, total_engines,
+                )
+                msg = publish_back.recv()
+                logger.info(
+                    "[DIAG-COORD] Received subscription %d/%d: %r",
+                    i + 1, total_engines, msg,
+                )
+                if msg != b"\x01":
                     logger.error(
                         "DP Coordinator received unexpected message while "
                         "waiting for engines to subscribe"
                     )
                     return
+            logger.info(
+                "[DIAG-COORD] All %d subscriptions received, sending READY",
+                total_engines,
+            )
             # Send ready message to engines.
             publish_back.send(b"READY")
 

--- a/vllm/v1/engine/coordinator.py
+++ b/vllm/v1/engine/coordinator.py
@@ -242,27 +242,13 @@ class DPCoordinatorProc:
                 finally:
                     zmq_addr_pipe.close()
             # Wait until all engines subscribe.
-            total_engines = len(self.engines)
-            for i in range(total_engines):
-                logger.info(
-                    "[DIAG-COORD] Waiting for subscription %d/%d...",
-                    i + 1, total_engines,
-                )
-                msg = publish_back.recv()
-                logger.info(
-                    "[DIAG-COORD] Received subscription %d/%d: %r",
-                    i + 1, total_engines, msg,
-                )
-                if msg != b"\x01":
+            for _ in self.engines:
+                if publish_back.recv() != b"\x01":
                     logger.error(
                         "DP Coordinator received unexpected message while "
                         "waiting for engines to subscribe"
                     )
                     return
-            logger.info(
-                "[DIAG-COORD] All %d subscriptions received, sending READY",
-                total_engines,
-            )
             # Send ready message to engines.
             publish_back.send(b"READY")
 

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -873,12 +873,20 @@ class EngineCoreProc(EngineCore):
                 )
             self._init_data_parallel(vllm_config)
 
+            import time as _time
+            _dp_rank = getattr(self, 'dp_rank', -1)
+            logger.info("[DIAG-ENGINE] Starting EngineCore.__init__ dp_rank=%d", _dp_rank)
+            _engine_t0 = _time.time()
             super().__init__(
                 vllm_config,
                 executor_class,
                 log_stats,
                 executor_fail_callback,
                 internal_dp_balancing,
+            )
+            logger.info(
+                "[DIAG-ENGINE] EngineCore.__init__ completed in %.1fs dp_rank=%d",
+                _time.time() - _engine_t0, _dp_rank,
             )
 
             # Background Threads and Queues for IO. These enable us to
@@ -1009,6 +1017,11 @@ class EngineCoreProc(EngineCore):
             yield addresses
 
             # Send ready message.
+            logger.info(
+                "[DIAG-HANDSHAKE] Sending READY to main process "
+                "(local=%s, headless=%s)",
+                local_client, headless,
+            )
             ready_msg = {
                 "status": "READY",
                 "local": local_client,
@@ -1217,7 +1230,7 @@ class EngineCoreProc(EngineCore):
         # (e.g., WAITING_FOR_REMOTE_KVS), yield the GIL briefly to allow
         # background threads (like NIXL handshake) to make progress.
         # Without this, the tight polling loop can starve background threads.
-        if not model_executed and self.scheduler.has_unfinished_requests():
+        if not model_executed and self.scheduler.has_requests():
             time.sleep(0.001)
 
         return model_executed
@@ -1406,7 +1419,13 @@ class EngineCoreProc(EngineCore):
                     )
                 )
                 # Send subscription message to coordinator.
+                logger.info(
+                    "[DIAG-INPUT] Sending subscription to coordinator at %s "
+                    "(identity=%s)",
+                    coord_input_address, identity,
+                )
                 coord_socket.send(b"\x01")
+                logger.info("[DIAG-INPUT] Subscription sent")
 
             # Register sockets with poller.
             poller = zmq.Poller()
@@ -1425,9 +1444,13 @@ class EngineCoreProc(EngineCore):
 
             if coord_socket is not None:
                 # Wait for ready message from coordinator.
-                assert coord_socket.recv() == b"READY"
+                logger.info("[DIAG-INPUT] Waiting for READY from coordinator...")
+                msg = coord_socket.recv()
+                logger.info("[DIAG-INPUT] Received from coordinator: %r", msg)
+                assert msg == b"READY"
                 poller.register(coord_socket, zmq.POLLIN)
 
+            logger.info("[DIAG-INPUT] ready_event.set() — input thread ready")
             ready_event.set()
             del ready_event
             while True:
@@ -1654,6 +1677,7 @@ class DPEngineCoreProc(EngineCoreProc):
 
     def _init_data_parallel(self, vllm_config: VllmConfig):
         # Configure GPUs and stateless process group for data parallel.
+        import time as _time
         parallel_config = vllm_config.parallel_config
         dp_rank = parallel_config.data_parallel_rank
         dp_size = parallel_config.data_parallel_size
@@ -1664,7 +1688,20 @@ class DPEngineCoreProc(EngineCoreProc):
         assert 0 <= local_dp_rank <= dp_rank < dp_size
 
         self.dp_rank = dp_rank
+        logger.info(
+            "[DIAG-DP-INIT] Starting stateless_init_dp_group "
+            "dp_rank=%d dp_size=%d master_ip=%s master_port=%s",
+            dp_rank, dp_size,
+            parallel_config.data_parallel_master_ip,
+            parallel_config.data_parallel_master_port,
+        )
+        _t0 = _time.time()
         dp_group, dp_store = parallel_config.stateless_init_dp_group(return_store=True)
+        logger.info(
+            "[DIAG-DP-INIT] stateless_init_dp_group completed in %.1fs "
+            "dp_rank=%d",
+            _time.time() - _t0, dp_rank,
+        )
         self.dp_group, self.dp_store = dp_group, dp_store
 
     def shutdown(self):

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -64,6 +64,10 @@ from vllm.v1.engine import (
     UtilityOutput,
     UtilityResult,
 )
+from vllm.v1.engine.kv_consumer_validation import (
+    KVConsumerRequestError,
+    validate_kv_consumer_request,
+)
 from vllm.v1.engine.tensor_ipc import TensorIpcReceiver
 from vllm.v1.engine.utils import (
     EngineHandshakeMetadata,
@@ -338,6 +342,14 @@ class EngineCore:
         if request.kv_transfer_params is not None and (
             not self.scheduler.get_kv_connector()
         ):
+            if (
+                self.vllm_config.kv_transfer_config is not None
+                and self.vllm_config.kv_transfer_config.kv_role == "kv_consumer"
+            ):
+                raise KVConsumerRequestError(
+                    "kv_consumer instance requires an initialized KVConnector "
+                    f"for request {request.request_id!r}; refusing local prefill."
+                )
             logger.warning(
                 "Got kv_transfer_params, but no KVConnector found. "
                 "Disabling KVTransfer for this request."
@@ -777,6 +789,7 @@ class EngineCore:
             )
 
         req = Request.from_engine_core_request(request, self.request_block_hasher)
+        validate_kv_consumer_request(req, self.vllm_config.kv_transfer_config)
         if req.use_structured_output:
             # Note on thread safety: no race condition.
             # `grammar_init` is only invoked in input processing thread. For
@@ -1274,7 +1287,11 @@ class EngineCoreProc(EngineCore):
             req, request_wave = request
             if self._reject_add_in_shutdown(req):
                 return
-            self.add_request(req, request_wave)
+            try:
+                self.add_request(req, request_wave)
+            except KVConsumerRequestError:
+                logger.exception("Rejecting request %s", req.request_id)
+                self._send_error_outputs_to_client([req.request_id], req.client_index)
         elif request_type == EngineCoreRequestType.ABORT:
             self.abort_requests(request)
         elif request_type == EngineCoreRequestType.UTILITY:

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -873,20 +873,12 @@ class EngineCoreProc(EngineCore):
                 )
             self._init_data_parallel(vllm_config)
 
-            import time as _time
-            _dp_rank = getattr(self, 'dp_rank', -1)
-            logger.info("[DIAG-ENGINE] Starting EngineCore.__init__ dp_rank=%d", _dp_rank)
-            _engine_t0 = _time.time()
             super().__init__(
                 vllm_config,
                 executor_class,
                 log_stats,
                 executor_fail_callback,
                 internal_dp_balancing,
-            )
-            logger.info(
-                "[DIAG-ENGINE] EngineCore.__init__ completed in %.1fs dp_rank=%d",
-                _time.time() - _engine_t0, _dp_rank,
             )
 
             # Background Threads and Queues for IO. These enable us to
@@ -1017,11 +1009,6 @@ class EngineCoreProc(EngineCore):
             yield addresses
 
             # Send ready message.
-            logger.info(
-                "[DIAG-HANDSHAKE] Sending READY to main process "
-                "(local=%s, headless=%s)",
-                local_client, headless,
-            )
             ready_msg = {
                 "status": "READY",
                 "local": local_client,
@@ -1230,7 +1217,7 @@ class EngineCoreProc(EngineCore):
         # (e.g., WAITING_FOR_REMOTE_KVS), yield the GIL briefly to allow
         # background threads (like NIXL handshake) to make progress.
         # Without this, the tight polling loop can starve background threads.
-        if not model_executed and self.scheduler.has_requests():
+        if not model_executed and self.scheduler.has_unfinished_requests():
             time.sleep(0.001)
 
         return model_executed
@@ -1419,13 +1406,7 @@ class EngineCoreProc(EngineCore):
                     )
                 )
                 # Send subscription message to coordinator.
-                logger.info(
-                    "[DIAG-INPUT] Sending subscription to coordinator at %s "
-                    "(identity=%s)",
-                    coord_input_address, identity,
-                )
                 coord_socket.send(b"\x01")
-                logger.info("[DIAG-INPUT] Subscription sent")
 
             # Register sockets with poller.
             poller = zmq.Poller()
@@ -1444,13 +1425,9 @@ class EngineCoreProc(EngineCore):
 
             if coord_socket is not None:
                 # Wait for ready message from coordinator.
-                logger.info("[DIAG-INPUT] Waiting for READY from coordinator...")
-                msg = coord_socket.recv()
-                logger.info("[DIAG-INPUT] Received from coordinator: %r", msg)
-                assert msg == b"READY"
+                assert coord_socket.recv() == b"READY"
                 poller.register(coord_socket, zmq.POLLIN)
 
-            logger.info("[DIAG-INPUT] ready_event.set() — input thread ready")
             ready_event.set()
             del ready_event
             while True:
@@ -1677,7 +1654,6 @@ class DPEngineCoreProc(EngineCoreProc):
 
     def _init_data_parallel(self, vllm_config: VllmConfig):
         # Configure GPUs and stateless process group for data parallel.
-        import time as _time
         parallel_config = vllm_config.parallel_config
         dp_rank = parallel_config.data_parallel_rank
         dp_size = parallel_config.data_parallel_size
@@ -1688,20 +1664,7 @@ class DPEngineCoreProc(EngineCoreProc):
         assert 0 <= local_dp_rank <= dp_rank < dp_size
 
         self.dp_rank = dp_rank
-        logger.info(
-            "[DIAG-DP-INIT] Starting stateless_init_dp_group "
-            "dp_rank=%d dp_size=%d master_ip=%s master_port=%s",
-            dp_rank, dp_size,
-            parallel_config.data_parallel_master_ip,
-            parallel_config.data_parallel_master_port,
-        )
-        _t0 = _time.time()
         dp_group, dp_store = parallel_config.stateless_init_dp_group(return_store=True)
-        logger.info(
-            "[DIAG-DP-INIT] stateless_init_dp_group completed in %.1fs "
-            "dp_rank=%d",
-            _time.time() - _t0, dp_rank,
-        )
         self.dp_group, self.dp_store = dp_group, dp_store
 
     def shutdown(self):

--- a/vllm/v1/engine/kv_consumer_validation.py
+++ b/vllm/v1/engine/kv_consumer_validation.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import Any
+
+from vllm.config import KVTransferConfig
+
+_NIXL_REMOTE_PREFILL_REQUIRED_PARAMS = (
+    "remote_engine_id",
+    "remote_request_id",
+    "remote_host",
+    "remote_port",
+)
+
+
+class KVConsumerRequestError(ValueError):
+    """Raised when a kv_consumer request would fall back to local prefill."""
+
+
+def _kv_config_uses_nixl(kv_transfer_config: KVTransferConfig) -> bool:
+    if kv_transfer_config.kv_connector == "NixlConnector":
+        return True
+
+    connector_configs = kv_transfer_config.kv_connector_extra_config.get(
+        "connectors", []
+    )
+    return any(
+        isinstance(conn_config, dict)
+        and conn_config.get("kv_connector") == "NixlConnector"
+        for conn_config in connector_configs
+    )
+
+
+def _missing_kv_param(value: Any) -> bool:
+    return value is None or (isinstance(value, str) and value == "")
+
+
+def _get_kv_transfer_params(request: Any) -> Any:
+    if hasattr(request, "kv_transfer_params"):
+        return request.kv_transfer_params
+
+    sampling_params = getattr(request, "sampling_params", None)
+    if sampling_params is None or sampling_params.extra_args is None:
+        return None
+    return sampling_params.extra_args.get("kv_transfer_params")
+
+
+def validate_kv_consumer_request(
+    request: Any, kv_transfer_config: KVTransferConfig | None
+) -> None:
+    if (
+        kv_transfer_config is None
+        or kv_transfer_config.kv_role != "kv_consumer"
+        or request.pooling_params is not None
+    ):
+        return
+
+    params = _get_kv_transfer_params(request)
+    if not isinstance(params, dict) or not params:
+        raise KVConsumerRequestError(
+            "kv_consumer instance requires non-empty kv_transfer_params "
+            f"for request {request.request_id!r}; refusing local prefill."
+        )
+
+    if params.get("do_remote_prefill") is not True:
+        raise KVConsumerRequestError(
+            "kv_consumer instance requires "
+            "kv_transfer_params.do_remote_prefill=true "
+            f"for request {request.request_id!r}; refusing local prefill."
+        )
+
+    if params.get("do_remote_decode") is True:
+        raise KVConsumerRequestError(
+            "kv_consumer instance received prefill-side "
+            f"kv_transfer_params for request {request.request_id!r}; "
+            "refusing local prefill."
+        )
+
+    if not _kv_config_uses_nixl(kv_transfer_config):
+        return
+
+    missing = [
+        param
+        for param in _NIXL_REMOTE_PREFILL_REQUIRED_PARAMS
+        if _missing_kv_param(params.get(param))
+    ]
+    if missing:
+        raise KVConsumerRequestError(
+            "NixlConnector kv_consumer instance requires remote prefill "
+            f"metadata {missing} for request {request.request_id!r}; "
+            "refusing local prefill."
+        )
+
+    if "remote_block_ids" not in params or params.get("remote_block_ids") is None:
+        raise KVConsumerRequestError(
+            "NixlConnector kv_consumer instance requires "
+            f"kv_transfer_params.remote_block_ids for request "
+            f"{request.request_id!r}; refusing local prefill."
+        )

--- a/vllm/v1/engine/output_processor.py
+++ b/vllm/v1/engine/output_processor.py
@@ -619,6 +619,11 @@ class OutputProcessor:
             routed_experts = engine_core_output.routed_experts
 
             if req_state.is_prefilling:
+                req_state.num_cached_tokens = (
+                    engine_core_output.num_cached_tokens_for_output
+                    if engine_core_output.num_cached_tokens_for_output is not None
+                    else engine_core_output.num_cached_tokens
+                )
                 if engine_core_output.prefill_stats is not None:
                     req_state.num_cached_tokens = (
                         engine_core_output.prefill_stats.num_cached_tokens

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1170,7 +1170,7 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             )
         for n_param in iteration_stats.n_params_iter:
             self.histogram_n_request[engine_idx].observe(n_param)
-        for ttft in iteration_stats.time_to_first_tokens_iter:
+        for ttft, _input_len in iteration_stats.time_to_first_tokens_iter:
             self.histogram_time_to_first_token[engine_idx].observe(ttft)
         for itl in iteration_stats.inter_token_latencies_iter:
             self.histogram_inter_token_latency[engine_idx].observe(itl)

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -366,12 +366,15 @@ class IterationStats:
             if output.prefill_stats is not None:
                 self.prompt_token_stats.update_from_output(output.prefill_stats)
 
-            first_token_latency = self._time_since(req_stats.arrival_time)
-            non_cached_input_len = prompt_len - output.num_cached_tokens
-            self.time_to_first_tokens_iter.append(
-                (first_token_latency, non_cached_input_len)
-            )
-            req_stats.first_token_latency = first_token_latency
+                first_token_latency = self._time_since(req_stats.arrival_time)
+                non_cached_input_len = (
+                    output.prefill_stats.num_prompt_tokens
+                    - output.prefill_stats.num_cached_tokens
+                )
+                self.time_to_first_tokens_iter.append(
+                    (first_token_latency, non_cached_input_len)
+                )
+                req_stats.first_token_latency = first_token_latency
 
         req_stats.num_generation_tokens += num_new_generation_tokens
 

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -333,7 +333,7 @@ class IterationStats:
         self.finished_requests: list[FinishedRequestStats] = []
         self.max_num_generation_tokens_iter: list[int] = []
         self.n_params_iter: list[int] = []
-        self.time_to_first_tokens_iter: list[float] = []
+        self.time_to_first_tokens_iter: list[tuple[float, int]] = []
         self.inter_token_latencies_iter: list[float] = []
         self.num_corrupted_reqs: int = 0
 
@@ -367,7 +367,10 @@ class IterationStats:
                 self.prompt_token_stats.update_from_output(output.prefill_stats)
 
             first_token_latency = self._time_since(req_stats.arrival_time)
-            self.time_to_first_tokens_iter.append(first_token_latency)
+            non_cached_input_len = prompt_len - output.num_cached_tokens
+            self.time_to_first_tokens_iter.append(
+                (first_token_latency, non_cached_input_len)
+            )
             req_stats.first_token_latency = first_token_latency
 
         req_stats.num_generation_tokens += num_new_generation_tokens

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -141,6 +141,7 @@ class Request:
 
         self.spec_token_ids: list[int] = []
         self.num_computed_tokens = 0
+        self.num_external_computed_tokens = 0
         self.cache_salt: str | None = cache_salt
 
         # Multi-modal related

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -10,6 +10,9 @@ from typing import TYPE_CHECKING, Any
 
 import torch
 
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    PREFILL_NUM_CACHED_TOKENS_KEY,
+)
 from vllm.multimodal.inputs import MultiModalFeatureSpec
 from vllm.pooling_params import PoolingParams
 from vllm.sampling_params import SamplingParams
@@ -150,6 +153,10 @@ class Request:
         self.all_token_ids = ConstantList(self._all_token_ids)
         # trace_headers
         self.trace_headers = trace_headers
+        # State
+        # The number of tokens with prefix cache hits.
+        self.num_cached_tokens = -1
+        self._num_cached_tokens_for_output: int = -1
 
         # True if this request is scheduled as a non-final prefill chunk.
         self.is_prefill_chunk = False
@@ -176,6 +183,27 @@ class Request:
         self.resumable = resumable
         # None entry in the queue means finished.
         self.streaming_queue: deque[StreamingUpdate | None] | None = None
+
+    @property
+    def num_cached_tokens_for_output(self) -> int | None:
+        if self._num_cached_tokens_for_output == -1:
+            self._num_cached_tokens_for_output = (
+                self._extract_num_cached_tokens_for_output()
+            )
+        if self._num_cached_tokens_for_output == -1:
+            return None
+        return self._num_cached_tokens_for_output
+
+    def _extract_num_cached_tokens_for_output(self) -> int:
+        params = self.kv_transfer_params or {}
+        prefill_num_cached_tokens = params.get(PREFILL_NUM_CACHED_TOKENS_KEY)
+        if (
+            isinstance(prefill_num_cached_tokens, int)
+            and not isinstance(prefill_num_cached_tokens, bool)
+            and prefill_num_cached_tokens >= 0
+        ):
+            return prefill_num_cached_tokens
+        return -1
 
     @classmethod
     def from_engine_core_request(

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -56,6 +56,12 @@ BUILTIN_LOGITS_PROCESSORS: list[type[LogitsProcessor]] = [
     ThinkingTokenBudgetLogitsProcessor,
 ]
 
+SPEC_DECODE_LOGITS_PROCESSORS: list[type[LogitsProcessor]] = [
+    MinTokensLogitsProcessor,
+    LogitBiasLogitsProcessor,
+    ReasoningLogitsProcessor,
+]
+
 
 def _load_logitsprocs_plugins() -> list[type[LogitsProcessor]]:
     """Load all installed logit processor plugins"""
@@ -204,15 +210,22 @@ def build_logitsprocs(
     # Check if speculative decoding is enabled.
     if vllm_config.speculative_config:
         if custom_logitsprocs:
-            raise ValueError(STR_SPEC_DEC_REJECTS_LOGITSPROCS)
+            custom_logitsprocs_classes = _load_logitsprocs_by_fqcns(
+                custom_logitsprocs
+            )
+            unsupported_logitsprocs = [
+                logitproc
+                for logitproc in custom_logitsprocs_classes
+                if logitproc not in SPEC_DECODE_LOGITS_PROCESSORS
+            ]
+            if unsupported_logitsprocs:
+                raise ValueError(STR_SPEC_DEC_REJECTS_LOGITSPROCS)
         logger.warning(
             "min_p parameter won't work with speculative decoding."
         )
         return LogitsProcessors(
-            [
-                MinTokensLogitsProcessor(vllm_config, device, is_pin_memory),
-                LogitBiasLogitsProcessor(vllm_config, device, is_pin_memory),
-            ]
+            ctor(vllm_config, device, is_pin_memory)
+            for ctor in SPEC_DECODE_LOGITS_PROCESSORS
         )
 
     custom_logitsprocs_classes = _load_custom_logitsprocs(custom_logitsprocs)

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -206,10 +206,13 @@ def build_logitsprocs(
         if custom_logitsprocs:
             raise ValueError(STR_SPEC_DEC_REJECTS_LOGITSPROCS)
         logger.warning(
-            "min_p and logit_bias parameters won't work with speculative decoding."
+            "min_p parameter won't work with speculative decoding."
         )
         return LogitsProcessors(
-            [MinTokensLogitsProcessor(vllm_config, device, is_pin_memory)]
+            [
+                MinTokensLogitsProcessor(vllm_config, device, is_pin_memory),
+                LogitBiasLogitsProcessor(vllm_config, device, is_pin_memory),
+            ]
         )
 
     custom_logitsprocs_classes = _load_custom_logitsprocs(custom_logitsprocs)

--- a/vllm/v1/sample/logits_processor/__init__.py
+++ b/vllm/v1/sample/logits_processor/__init__.py
@@ -18,6 +18,7 @@ from vllm.v1.sample.logits_processor.builtin import (
     LogitBiasLogitsProcessor,
     MinPLogitsProcessor,
     MinTokensLogitsProcessor,
+    ReasoningLogitsProcessor,
     ThinkingTokenBudgetLogitsProcessor,
     process_dict_updates,
 )
@@ -51,6 +52,7 @@ BUILTIN_LOGITS_PROCESSORS: list[type[LogitsProcessor]] = [
     MinTokensLogitsProcessor,
     LogitBiasLogitsProcessor,
     MinPLogitsProcessor,
+    ReasoningLogitsProcessor,
     ThinkingTokenBudgetLogitsProcessor,
 ]
 
@@ -357,4 +359,5 @@ __all__ = [
     "LOGITSPROCS_GROUP",
     "AdapterLogitsProcessor",
     "ThinkingTokenBudgetLogitsProcessor",
+    "ReasoningLogitsProcessor",
 ]

--- a/vllm/v1/sample/logits_processor/builtin.py
+++ b/vllm/v1/sample/logits_processor/builtin.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import logging
 from collections.abc import Callable, Sequence
 from typing import TYPE_CHECKING, Any, TypeVar
 
@@ -15,6 +16,8 @@ from vllm.v1.sample.logits_processor.interface import (
 
 if TYPE_CHECKING:
     from vllm.config import VllmConfig
+
+logger = logging.getLogger(__name__)
 
 T = TypeVar("T")
 
@@ -591,3 +594,218 @@ def process_dict_updates(
                     req_entries[a_index] = b_entry
 
     return updated
+
+
+class ReasoningLogitsProcessor(LogitsProcessor):
+    """Bans special tokens during reasoning (thinking) mode.
+
+    When a request is inside a <think>...</think> block the model must not
+    emit EOS / BOS or other special tokens that would prematurely end
+    generation.  This processor tracks whether each request is currently
+    reasoning and, if so, sets the logits for all banned special tokens
+    to -inf before sampling.
+    """
+
+    def __init__(
+        self,
+        vllm_config: "VllmConfig",
+        device: torch.device,
+        is_pin_memory: bool,
+    ):
+        self.device = device
+        self.pin_memory = is_pin_memory
+
+        self.think_start_token_id: int | None = None
+        self.think_end_token_id: int | None = None
+        self.banned_special_token_ids: list[int] = []
+        # Pre-computed device tensor of banned token ids (set in _init_token_ids)
+        self.banned_token_ids_tensor = torch.tensor(
+            [], device=self.device, dtype=torch.int64
+        )
+        self._init_token_ids(vllm_config)
+
+        # index -> (output_tok_ids, is_reasoning, last_checked_pos)
+        self.req_states: dict[int, tuple[Sequence[int], bool, int]] = {}
+        self.has_reasoning: bool = False
+
+        # Reasoning request indices tensor, updated each step
+        self.reasoning_indices_tensor = torch.tensor(
+            [], device=self.device, dtype=torch.int64
+        )
+        self.neg_inf_tensor = torch.tensor(
+            -float("inf"), dtype=torch.float32, device=self.device
+        )
+
+    def _init_token_ids(self, vllm_config: "VllmConfig") -> None:
+        reasoning_parser_name = (
+            vllm_config.structured_outputs_config.reasoning_parser
+        )
+        if not reasoning_parser_name:
+            return
+        if vllm_config.model_config.skip_tokenizer_init:
+            return
+
+        try:
+            from vllm.reasoning import ReasoningParserManager
+            from vllm.tokenizers import cached_tokenizer_from_config
+
+            tokenizer = cached_tokenizer_from_config(
+                model_config=vllm_config.model_config
+            )
+            reasoner_cls = ReasoningParserManager.get_reasoning_parser(
+                reasoning_parser_name
+            )
+            reasoner = reasoner_cls(tokenizer=tokenizer)
+
+            if hasattr(reasoner, "start_token_id"):
+                self.think_start_token_id = reasoner.start_token_id
+            elif hasattr(reasoner, "_start_token_id"):
+                self.think_start_token_id = reasoner._start_token_id
+
+            if hasattr(reasoner, "end_token_id"):
+                self.think_end_token_id = reasoner.end_token_id
+            elif hasattr(reasoner, "_end_token_id"):
+                self.think_end_token_id = reasoner._end_token_id
+
+            all_special_ids: set[int] = set()
+            if hasattr(tokenizer, "all_special_ids"):
+                all_special_ids.update(tokenizer.all_special_ids)
+            if hasattr(tokenizer, "added_tokens_encoder"):
+                all_special_ids.update(tokenizer.added_tokens_encoder.values())
+
+            # think_end is allowed during reasoning (it closes the block)
+            if self.think_end_token_id is not None:
+                all_special_ids.discard(self.think_end_token_id)
+
+            self.banned_special_token_ids = list(all_special_ids)
+            self.banned_token_ids_tensor = torch.tensor(
+                self.banned_special_token_ids,
+                device="cpu",
+                dtype=torch.int64,
+                pin_memory=self.pin_memory,
+            ).to(device=self.device, non_blocking=True)
+
+        except Exception as e:
+            logger.warning(
+                "ReasoningLogitsProcessor init token ids failed: %s", e
+            )
+
+    def _device_tensor(
+        self, data: list, dtype: torch.dtype
+    ) -> torch.Tensor:
+        return torch.tensor(
+            data, device="cpu", dtype=dtype, pin_memory=self.pin_memory
+        ).to(device=self.device, non_blocking=True)
+
+    def is_argmax_invariant(self) -> bool:
+        return False
+
+    def _check_prompt_reasoning(
+        self, prompt_tok_ids: Sequence[int] | None
+    ) -> bool:
+        if not prompt_tok_ids:
+            return False
+        is_reasoning = False
+        for tok_id in prompt_tok_ids:
+            if tok_id == self.think_start_token_id:
+                is_reasoning = True
+            elif tok_id == self.think_end_token_id:
+                is_reasoning = False
+        return is_reasoning
+
+    def _check_reasoning_state(
+        self,
+        output_tok_ids: Sequence[int],
+        is_reasoning: bool,
+        last_pos: int,
+    ) -> tuple[bool, int]:
+        current_len = len(output_tok_ids)
+        checked_pos = last_pos
+        for i in range(last_pos, current_len):
+            tok_id = output_tok_ids[i]
+            if tok_id == -1:  # placeholder, not yet sampled
+                break
+            checked_pos = i + 1
+            if tok_id == self.think_start_token_id:
+                is_reasoning = True
+            elif tok_id == self.think_end_token_id:
+                is_reasoning = False
+        return is_reasoning, checked_pos
+
+    def update_state(self, batch_update: BatchUpdate | None) -> None:
+        if (
+            self.think_start_token_id is None
+            or self.think_end_token_id is None
+            or not self.banned_special_token_ids
+        ):
+            return
+
+        if batch_update:
+            for index in batch_update.removed:
+                self.req_states.pop(index, None)
+
+            for index, _, prompt_tok_ids, output_tok_ids in batch_update.added:
+                initial_reasoning = self._check_prompt_reasoning(
+                    prompt_tok_ids
+                )
+                self.req_states[index] = (output_tok_ids, initial_reasoning, 0)
+
+            for a_index, b_index, direct in batch_update.moved:
+                a_state = self.req_states.pop(a_index, None)
+                b_state = self.req_states.pop(b_index, None)
+                if a_state is not None:
+                    self.req_states[b_index] = a_state
+                if b_state is not None and direct == MoveDirectionality.SWAP:
+                    self.req_states[a_index] = b_state
+
+        # Scan delta output tokens for all requests in the batch
+        reasoning_indices: list[int] = []
+        for index, (tok_ids, is_reasoning, last_pos) in self.req_states.items():
+            is_reasoning, last_pos = self._check_reasoning_state(
+                tok_ids, is_reasoning, last_pos
+            )
+            self.req_states[index] = (tok_ids, is_reasoning, last_pos)
+            if is_reasoning:
+                reasoning_indices.append(index)
+
+        self.has_reasoning = bool(reasoning_indices)
+        if self.has_reasoning:
+            self.reasoning_indices_tensor = self._device_tensor(
+                reasoning_indices, torch.int64
+            )
+
+    def apply(self, logits: torch.Tensor) -> torch.Tensor:
+        # logits: [num_requests, vocab_size]
+        if self.has_reasoning:
+            logits[
+                self.reasoning_indices_tensor[:, None],
+                self.banned_token_ids_tensor[None, :],
+            ] = -float("inf")
+        return logits
+
+    def apply_with_spec_decode(
+        self,
+        logits: torch.Tensor,
+        num_draft_tokens: list[int],
+    ) -> torch.Tensor:
+        if not self.has_reasoning:
+            return logits
+
+        num_draft_arr = np.array(num_draft_tokens, dtype=np.int64)
+        cumsum = np.concatenate([[0], np.cumsum(num_draft_arr)])
+
+        all_rows: list[int] = []
+        for index, (_, is_reasoning, _) in self.req_states.items():
+            if is_reasoning:
+                offset = int(cumsum[index])
+                n_draft = int(num_draft_arr[index])
+                all_rows.extend(range(offset, offset + n_draft))
+
+        if all_rows:
+            row_tensor = self._device_tensor(all_rows, torch.int64)
+            logits[
+                row_tensor[:, None],
+                self.banned_token_ids_tensor[None, :],
+            ] = -float("inf")
+
+        return logits

--- a/vllm/v1/sample/logits_processor/builtin.py
+++ b/vllm/v1/sample/logits_processor/builtin.py
@@ -166,6 +166,64 @@ class LogitBiasLogitsProcessor(LogitsProcessor):
             logits[self.logits_slice] += self.bias_tensor
         return logits
 
+    def apply_with_spec_decode(
+        self,
+        logits: torch.Tensor,
+        num_draft_tokens: list[int],
+    ) -> torch.Tensor:
+        """Speculative decoding version of apply().
+
+        logits shape: [sum(num_draft_tokens), vocab_size]，每个 request
+        的 bias 需应用到该 request 所有 draft token 对应的行。
+
+        Example: num_draft_tokens = [2, 3, 1]
+          -> logits shape [6, V], cumsum = [0, 2, 5, 6]
+          -> req 0 -> rows 0-1, req 1 -> rows 2-4, req 2 -> row 5
+        """
+        if not self.biases:
+            return logits
+
+        num_draft_arr = np.array(num_draft_tokens, dtype=np.int64)
+        cumsum = np.concatenate([[0], np.cumsum(num_draft_arr)])
+        vocab_size = logits.shape[-1]
+
+        all_rows: list[np.ndarray] = []
+        all_toks: list[np.ndarray] = []
+        all_biases: list[np.ndarray] = []
+
+        for req_idx, bias_dict in self.biases.items():
+            n_draft = int(num_draft_arr[req_idx])
+            if n_draft == 0:
+                continue
+
+            tok_ids = [tid for tid in bias_dict if tid < vocab_size]
+            bias_vals = [bias_dict[tid] for tid in tok_ids]
+            if not tok_ids:
+                continue
+
+            offset = int(cumsum[req_idx])
+            n_bias = len(tok_ids)
+            row_indices = np.arange(offset, offset + n_draft, dtype=np.int64)
+            all_rows.append(np.repeat(row_indices, n_bias))
+            all_toks.append(np.tile(tok_ids, n_draft))
+            all_biases.append(np.tile(bias_vals, n_draft))
+
+        if all_rows:
+            logits_slice = (
+                torch.from_numpy(np.concatenate(all_rows)).to(
+                    self.device, non_blocking=True
+                ),
+                torch.from_numpy(np.concatenate(all_toks)).to(
+                    self.device, non_blocking=True
+                ),
+            )
+            bias_tensor = torch.from_numpy(
+                np.concatenate(all_biases).astype(np.float32)
+            ).to(self.device, non_blocking=True)
+            logits.index_put_(logits_slice, bias_tensor, accumulate=True)
+
+        return logits
+
 
 class MinTokensLogitsProcessor(LogitsProcessor):
     def __init__(

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -13,7 +13,10 @@ import torch.nn as nn
 from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplerOutput
-from vllm.v1.sample.logits_processor.builtin import MinTokensLogitsProcessor
+from vllm.v1.sample.logits_processor.builtin import (
+    LogitBiasLogitsProcessor,
+    MinTokensLogitsProcessor,
+)
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.bad_words import apply_bad_words_with_drafts
 from vllm.v1.sample.ops.penalties import apply_all_penalties
@@ -324,6 +327,10 @@ class RejectionSampler(nn.Module):
 
         for processor in sampling_metadata.logitsprocs.non_argmax_invariant:
             if isinstance(processor, MinTokensLogitsProcessor):
+                logits = processor.apply_with_spec_decode(
+                    logits, metadata.num_draft_tokens
+                )
+            elif isinstance(processor, LogitBiasLogitsProcessor):
                 logits = processor.apply_with_spec_decode(
                     logits, metadata.num_draft_tokens
                 )

--- a/vllm/v1/sample/rejection_sampler.py
+++ b/vllm/v1/sample/rejection_sampler.py
@@ -13,10 +13,6 @@ import torch.nn as nn
 from vllm.logger import init_logger
 from vllm.triton_utils import tl, triton
 from vllm.v1.outputs import LogprobsLists, LogprobsTensors, SamplerOutput
-from vllm.v1.sample.logits_processor.builtin import (
-    LogitBiasLogitsProcessor,
-    MinTokensLogitsProcessor,
-)
 from vllm.v1.sample.metadata import SamplingMetadata
 from vllm.v1.sample.ops.bad_words import apply_bad_words_with_drafts
 from vllm.v1.sample.ops.penalties import apply_all_penalties
@@ -326,14 +322,10 @@ class RejectionSampler(nn.Module):
             )
 
         for processor in sampling_metadata.logitsprocs.non_argmax_invariant:
-            if isinstance(processor, MinTokensLogitsProcessor):
-                logits = processor.apply_with_spec_decode(
-                    logits, metadata.num_draft_tokens
-                )
-            elif isinstance(processor, LogitBiasLogitsProcessor):
-                logits = processor.apply_with_spec_decode(
-                    logits, metadata.num_draft_tokens
-                )
+            if apply_with_spec_decode := getattr(
+                processor, "apply_with_spec_decode", None
+            ):
+                logits = apply_with_spec_decode(logits, metadata.num_draft_tokens)
 
         return logits
 

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -495,10 +495,16 @@ class Worker(WorkerBase):
         if (metadata := connector.get_handshake_metadata()) is None:
             return None
 
-        tp_rank = get_tp_group().rank_in_group
-        pp_rank = get_pp_group().rank_in_group
+        tp_group = get_tp_group()
+        pp_group = get_pp_group()
+        tp_rank = tp_group.rank_in_group
+        if pp_group is None:
+            return {tp_rank: metadata}
+
+        pp_rank = pp_group.rank_in_group
         tp_size = self.vllm_config.parallel_config.tensor_parallel_size
-        return {pp_rank * tp_size + tp_rank: metadata}
+        global_worker_index = pp_rank * tp_size + tp_rank
+        return {global_worker_index: metadata}
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         return self.model_runner.get_kv_cache_spec()

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -496,7 +496,9 @@ class Worker(WorkerBase):
             return None
 
         tp_rank = get_tp_group().rank_in_group
-        return {tp_rank: metadata}
+        pp_rank = get_pp_group().rank_in_group
+        tp_size = self.vllm_config.parallel_config.tensor_parallel_size
+        return {pp_rank * tp_size + tp_rank: metadata}
 
     def get_kv_cache_spec(self) -> dict[str, KVCacheSpec]:
         return self.model_runner.get_kv_cache_spec()

--- a/vllm/v1/worker/ubatching.py
+++ b/vllm/v1/worker/ubatching.py
@@ -187,7 +187,8 @@ def dbo_register_recv_hook(recv_hook):
     if len(_THREAD_ID_TO_CONTEXT) > 0:
         ctx_idx = _THREAD_ID_TO_CONTEXT[threading.get_ident()]
         next_ctx = _CURRENT_CONTEXTS[(ctx_idx + 1) % _NUM_UBATCHES]
-        next_ctx.recv_hook = recv_hook
+        if next_ctx is not None:
+            next_ctx.recv_hook = recv_hook
 
 
 def dbo_get_previous_event(func, *args, **kwargs):

--- a/vllm/v1/worker/ubatching.py
+++ b/vllm/v1/worker/ubatching.py
@@ -187,8 +187,7 @@ def dbo_register_recv_hook(recv_hook):
     if len(_THREAD_ID_TO_CONTEXT) > 0:
         ctx_idx = _THREAD_ID_TO_CONTEXT[threading.get_ident()]
         next_ctx = _CURRENT_CONTEXTS[(ctx_idx + 1) % _NUM_UBATCHES]
-        if next_ctx is not None:
-            next_ctx.recv_hook = recv_hook
+        next_ctx.recv_hook = recv_hook
 
 
 def dbo_get_previous_event(func, *args, **kwargs):


### PR DESCRIPTION
- **feat(kimi-k2): add structural_tag guided decoding to tool parser**
- **feat: port 5 features from kimi_k25_dev migration to v0.19.0**
- **fix(serving): allow custom temperature in [0,1] for Kimi params validation**
- **feat: port NIXL/scheduler/coordinator/core patches for PD disaggregation**
- **fix(kv_connector): use global worker index as handshake key for PP**
- **feat(kv_connector): add TpKVTopology.get_all_pp_tp_targets for PP support**
- **feat(kv_connector): wire pp_size through handshake for PP KV transfer**
- **fix(kv_connector): correct PP+MLA per-stage TP slice and layer routing**
- **fix(tests): adapt kimi test fixtures for vllm v0.20.0 API changes**
- **feat(spec_decode): add LogitBiasLogitsProcessor.apply_with_spec_decode()**
- **test: update test_nixl_connector_pp to use v0.20.0 TransferTopology API**
- **fix(tests): use create_spec_decode_metadata in logit bias spec decode tests**
- **fix(nixl): wire PP metadata and handshake targets for kv transfer**
- **fix(nixl): align PP stage descriptors by region label**
- **fix(metrics): compute TTFT prompt length from prefill stats**
- **fix(engine): keep idle polling on unfinished requests**
- **docs: add Kimi PD PegaFlow runbook**
- **fix(spec_decode): allow reasoning logits processor**
- **docs: update Kimi PD image digest**
- **docs: record image versioning policy**
- **Fix: Incorrect token usage output in PD**
- **fix unittest**
- **Fix NIXL connector tests for PP metadata**
- **Reject local prefill on KV consumer instances (#62)**
- **fix v2, build v3**
- **Fix one-sided MoE padding sentinel for local expert maps (#64)**
- **Skip draft model KV caches in NIXL registration**
