### PR TITLE
[WIP][Bugfix][LoRA] Honor device kwarg in tensorizer LoRA deserialization

### DIFF
--- a/vllm/lora/lora_model.py
+++ b/vllm/lora/lora_model.py
@@ -203,6 +203,7 @@ class LoRAModel:
             tensors = TensorDeserializer(
                 lora_tensor_path,
                 dtype=tensorizer_config.dtype,
+                device=device,
                 **tensorizer_args.deserialization_kwargs,
             )
             check_unexpected_modules(tensors)


### PR DESCRIPTION
## Purpose

Fix the flaky CUDA OOM in `tests/lora/test_llama_tp.py::test_tp2_serialize_and_deserialize_lora` on memory-tight 22 GiB L4s.

`LoRAModel.from_local_checkpoint`'s tensorizer branch silently ignored the `device` kwarg, letting `TensorDeserializer` eagerly place tensors on GPU. The non-tensorizer branches honor `device`, and `WorkerLoRAManager._load_adapter` always passes `device="cpu"` so the loaded adapter can be `copy_(non_blocking=True)`'d into the pre-allocated GPU LoRA slots. The eager GPU placement collided with the post-profile slack and OOMed inside `_to_torch_parameter`.

Forward `device=device` to `TensorDeserializer` so the tensorizer LoRA path matches the safetensors / bin / pt branches and the existing pattern at `vllm/model_executor/model_loader/tensorizer.py:589`.

## Test Plan

## Test Result