### PR TITLE
Fix spec decode benchmark metrics

### DIFF
--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -127,27 +127,31 @@ async def fetch_spec_decode_metrics(
                 if not line or line.startswith("#"):
                     continue
 
-                if line.startswith("vllm:spec_decode") and "_total" in line:
+                if line.startswith("vllm:spec_decode"):
+                    # Extract metric name (before labels) to avoid matching
+                    # substrings inside label values.
+                    parts = line.split(None, 1)
+                    metric_name = parts[0].split("{")[0]
+                    if not metric_name.endswith("_total"):
+                        continue
                     found_spec_decode = True
-                    parts = line.split()
-                    if parts:
-                        with contextlib.suppress(ValueError):
-                            if "num_drafts" in line:
-                                num_drafts += int(float(parts[-1]))
-                            elif "num_draft_tokens" in line:
-                                num_draft_tokens += int(float(parts[-1]))
-                            elif "num_accepted_tokens_per_pos" in line:
-                                pos_label = 'position="'
-                                if pos_label in line:
-                                    start = line.index(pos_label) + len(pos_label)
-                                    end = line.index('"', start)
-                                    pos = int(line[start:end])
-                                    val = int(float(parts[-1]))
-                                    accepted_per_pos[pos] = (
-                                        accepted_per_pos.get(pos, 0) + val
-                                    )
-                            elif "num_accepted_tokens" in line:
-                                num_accepted_tokens += int(float(parts[-1]))
+                    with contextlib.suppress(ValueError):
+                        if "num_drafts" in metric_name:
+                            num_drafts += int(float(parts[-1]))
+                        elif "num_draft_tokens" in metric_name:
+                            num_draft_tokens += int(float(parts[-1]))
+                        elif "num_accepted_tokens_per_pos" in metric_name:
+                            pos_label = 'position="'
+                            if pos_label in line:
+                                start = line.index(pos_label) + len(pos_label)
+                                end = line.index('"', start)
+                                pos = int(line[start:end])
+                                val = int(float(parts[-1]))
+                                accepted_per_pos[pos] = (
+                                    accepted_per_pos.get(pos, 0) + val
+                                )
+                        elif "num_accepted_tokens" in metric_name:
+                            num_accepted_tokens += int(float(parts[-1]))
 
             if not found_spec_decode:
                 return None

--- a/vllm/benchmarks/serve.py
+++ b/vllm/benchmarks/serve.py
@@ -127,7 +127,7 @@ async def fetch_spec_decode_metrics(
                 if not line or line.startswith("#"):
                     continue
 
-                if line.startswith("vllm:spec_decode"):
+                if line.startswith("vllm:spec_decode") and "_total" in line:
                     found_spec_decode = True
                     parts = line.split()
                     if parts:


### PR DESCRIPTION



## Purpose
Currently, vllm bench serve will return the speculative decoding statistics from the prometheus metrics. However, the extraction logic includes both the gauge and counter values in the metrics. 

example prometheus metrics:
```
# HELP vllm:spec_decode_num_drafts_total Number of spec decoding drafts.
# TYPE vllm:spec_decode_num_drafts_total counter
vllm:spec_decode_num_drafts_total{engine="0",model_name="Qwen/Qwen3.6-35B-A3B-FP8"} 6.491797e+06
# HELP vllm:spec_decode_num_drafts_created Number of spec decoding drafts.
# TYPE vllm:spec_decode_num_drafts_created gauge
vllm:spec_decode_num_drafts_created{engine="0",model_name="Qwen/Qwen3.6-35B-A3B-FP8"} 1.77692439403224e+09
# HELP vllm:spec_decode_num_draft_tokens_total Number of draft tokens.
# TYPE vllm:spec_decode_num_draft_tokens_total counter
vllm:spec_decode_num_draft_tokens_total{engine="0",model_name="Qwen/Qwen3.6-35B-A3B-FP8"} 6.491797e+06
# HELP vllm:spec_decode_num_draft_tokens_created Number of draft tokens.
# TYPE vllm:spec_decode_num_draft_tokens_created gauge
vllm:spec_decode_num_draft_tokens_created{engine="0",model_name="Qwen/Qwen3.6-35B-A3B-FP8"} 1.7769243940322702e+09
# HELP vllm:spec_decode_num_accepted_tokens_total Number of accepted tokens.
# TYPE vllm:spec_decode_num_accepted_tokens_total counter
vllm:spec_decode_num_accepted_tokens_total{engine="0",model_name="Qwen/Qwen3.6-35B-A3B-FP8"} 6.076178e+06
# HELP vllm:spec_decode_num_accepted_tokens_created Number of accepted tokens.
# TYPE vllm:spec_decode_num_accepted_tokens_created gauge
vllm:spec_decode_num_accepted_tokens_created{engine="0",model_name="Qwen/Qwen3.6-35B-A3B-FP8"} 1.7769243940322917e+09
# HELP vllm:spec_decode_num_accepted_tokens_per_pos_total Accepted tokens per draft position.
# TYPE vllm:spec_decode_num_accepted_tokens_per_pos_total counter
vllm:spec_decode_num_accepted_tokens_per_pos_total{engine="0",model_name="Qwen/Qwen3.6-35B-A3B-FP8",position="0"} 6.076178e+06
# HELP vllm:spec_decode_num_accepted_tokens_per_pos_created Accepted tokens per draft position.
# TYPE vllm:spec_decode_num_accepted_tokens_per_pos_created gauge
vllm:spec_decode_num_accepted_tokens_per_pos_created{engine="0",model_name="Qwen/Qwen3.6-35B-A3B-FP8",position="0"} 1.7769243940323143e+09
```

This PR fixed the logic to only get the counter value. 

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

