### PR TITLE
[Perf] Cache rotary position IDs in Qwen2-VL vision encoder

### DIFF
--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -27,7 +27,7 @@
 
 import math
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
-from functools import partial
+from functools import lru_cache, partial
 from typing import Annotated, Any, Literal, TypeAlias
 
 import numpy as np
@@ -597,37 +597,42 @@ class Qwen2VisionTransformer(nn.Module):
     def device(self) -> torch.device:
         return self.patch_embed.proj.weight.device
 
+    @staticmethod
+    @lru_cache(maxsize=1024)
+    def rot_pos_ids(h: int, w: int, spatial_merge_size: int) -> torch.Tensor:
+        hpos_ids = np.broadcast_to(np.arange(h).reshape(h, 1), (h, w))
+        h_div = h // spatial_merge_size
+        w_div = w // spatial_merge_size
+        hpos_ids = hpos_ids.reshape(
+            h_div,
+            spatial_merge_size,
+            w_div,
+            spatial_merge_size,
+        )
+        hpos_ids = hpos_ids.transpose(0, 2, 1, 3).flatten()
+
+        wpos_ids = np.broadcast_to(np.arange(w).reshape(1, w), (h, w))
+        wpos_ids = wpos_ids.reshape(
+            h_div,
+            spatial_merge_size,
+            w_div,
+            spatial_merge_size,
+        )
+        wpos_ids = wpos_ids.transpose(0, 2, 1, 3).flatten()
+
+        return torch.from_numpy(np.stack([hpos_ids, wpos_ids], axis=-1))
+
     def rot_pos_emb(
         self, grid_thw: list[list[int]]
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        pos_ids = []
-        max_grid_size = 0
-        for t, h, w in grid_thw:
-            hpos_ids = torch.arange(h).unsqueeze(1).expand(-1, w)
-            wpos_ids = torch.arange(w).unsqueeze(0).expand(h, -1)
-            hpos_ids = (
-                hpos_ids.reshape(
-                    h // self.spatial_merge_size,
-                    self.spatial_merge_size,
-                    w // self.spatial_merge_size,
-                    self.spatial_merge_size,
-                )
-                .permute(0, 2, 1, 3)
-                .flatten()
-            )
-            wpos_ids = (
-                wpos_ids.reshape(
-                    h // self.spatial_merge_size,
-                    self.spatial_merge_size,
-                    w // self.spatial_merge_size,
-                    self.spatial_merge_size,
-                )
-                .permute(0, 2, 1, 3)
-                .flatten()
-            )
-            pos_ids.append(torch.stack([hpos_ids, wpos_ids], dim=-1).repeat(t, 1))
-            max_grid_size = max(max_grid_size, h, w)
-        pos_ids = torch.cat(pos_ids, dim=0)
+        max_grid_size = max(max(h, w) for _, h, w in grid_thw)
+        pos_ids = [
+            self.rot_pos_ids(h, w, self.spatial_merge_size)
+            if t == 1
+            else self.rot_pos_ids(h, w, self.spatial_merge_size).repeat(t, 1)
+            for t, h, w in grid_thw
+        ]
+        pos_ids = torch.cat(pos_ids, dim=0).to(self.device, non_blocking=True)
 
         # Use pre-computed cos_sin_cache from RotaryEmbedding
         cos, sin = self.rotary_pos_emb.get_cos_sin(max_grid_size)

--- a/vllm/model_executor/models/qwen2_vl.py
+++ b/vllm/model_executor/models/qwen2_vl.py
@@ -625,7 +625,7 @@ class Qwen2VisionTransformer(nn.Module):
     def rot_pos_emb(
         self, grid_thw: list[list[int]]
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        max_grid_size = max(max(h, w) for _, h, w in grid_thw)
+        max_grid_size = max((max(h, w) for _, h, w in grid_thw), default=0)
         pos_ids = [
             self.rot_pos_ids(h, w, self.spatial_merge_size)
             if t == 1


### PR DESCRIPTION
## Purpose

`Qwen2VisionTransformer.rot_pos_emb` recomputes the spatial position grids (`hpos_ids` / `wpos_ids`) on every forward call. For video inputs where consecutive frames share the same resolution, this is redundant work on the CPU hot path.

Extract the grid computation into `rot_pos_ids(h, w, spatial_merge_size)` as a `@staticmethod` with `@lru_cache(maxsize=1024)`. Switch the implementation from torch ops to numpy `broadcast_to` + `reshape` + `transpose` so the args are plain ints (hashable without wrappers) and no GPU tensor is allocated for what is fundamentally a CPU index computation. The caller becomes a one-liner with `torch.cat` + `.to(device, non_blocking=True)`.

## Test Plan
test_rot_pos_cache.py — correctness + micro-benchmark
test_e2e_perf.py — E2E with Qwen2.5-VL-3B
[test_rot_pos_cache.py](https://github.com/user-attachments/files/27514189/test_rot_pos_cache.py)
[test_e2e_perf.py](https://github.com/user-attachments/files/27514191/test_e2e_perf.py)

```bash
python tests/test_rot_pos_cache.py
```

Correctness: compares cached numpy path against original torch path for 6 spatial configs typical of Qwen2.5-VL:
```
(h,w,sms): (14,14,2), (28,28,2), (14,28,2), (56,56,2), (28,14,2), (42,28,2)
```

Performance: 500 iters x 3 configs `[(14,14,2), (28,28,2), (56,56,2)]`, measures wall time for baseline vs cache-hit.

E2E with Qwen2.5-VL-3B-Instruct (any variant works), single image 448x448, 4 GPU TP:
```bash
CUDA_VISIBLE_DEVICES=4,5,6,7 python tests/test_e2e_perf.py
```

## Test Result

```
=== Correctness ===
  PASS (6 configs, exact match)

=== Cache identity ===
  PASS (same args -> same object)

=== Performance (500 iters x 3 configs) ===
  baseline (torch recompute):   178.2 us/iter
  patched  (lru_cache hit):       0.3 us/iter
  speedup:                      ~700x

=== E2E (Qwen2.5-VL-3B-Instruct, 448x448, 4xH200) ===
  rot_pos_ids micro:    51 us -> 0.08 us  (666x)
  rot_pos_emb full:    167 us -> 77 us    (2.2x, dominated by cos/sin gather)
  E2E single-image:    ~42 ms both (GPU-bound, rot_pos_ids fraction negligible)
```

Single-image latency is GPU-bound so the saving doesn't surface in E2E numbers. The win matters for video workloads where `rot_pos_emb` is called N_frames times with identical (h, w) -- cumulative CPU overhead drops from milliseconds to microseconds.
