### PR TITLE
[Core][Model] Add GDN (Qwen3.5) support to NIXL P/D disaggregation

### DIFF
--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -564,3 +564,58 @@ def test_compute_physical_blocks_per_logical(ssm_sizes, block_len, expected_rati
     )
 
     assert compute_physical_blocks_per_logical(ssm_sizes, block_len) == expected_ratio
+
+
+@pytest.mark.cpu_test
+def test_derive_mamba_conv_split_gdn_layout():
+    from vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils import (
+        derive_mamba_conv_split,
+    )
+    from vllm.v1.kv_cache_interface import MambaSpec
+
+    # GDN local conv layout [K, K, V] with TP-local dims:
+    # K=48, V=16, conv_rows=3 -> conv_dim_local=112
+    spec = MambaSpec(
+        block_size=16,
+        shapes=((112, 3), (4, 4, 8)),
+        dtypes=(torch.float16, torch.float16),
+        mamba_type="gdn_attention",
+    )
+
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils.is_conv_state_dim_first",
+        return_value=True,
+    ):
+        split = derive_mamba_conv_split(spec, local_tp=2)
+    assert (split.p0_local, split.p1_local, split.p2_local) == (48, 48, 16)
+    assert split.local_conv_offsets == [(0, 288), (288, 288), (576, 96)]
+    # tp_ratio=2 means this D rank reads one half of the remote page.
+    assert split.remote_conv_offsets(local_rank_offset=1, tp_ratio=2) == [
+        (288, 288),
+        (864, 288),
+        (1440, 96),
+    ]
+
+
+@pytest.mark.cpu_test
+def test_derive_mamba_conv_split_mamba2_still_supported():
+    from vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils import (
+        derive_mamba_conv_split,
+    )
+    from vllm.v1.kv_cache_interface import MambaSpec
+
+    # Mamba2 local conv layout [x, B, C] with x=64, B=16, C=16 and conv_rows=3.
+    spec = MambaSpec(
+        block_size=16,
+        shapes=((96, 3), (8, 16)),
+        dtypes=(torch.float16, torch.float16),
+        mamba_type="mamba2",
+    )
+
+    with patch(
+        "vllm.distributed.kv_transfer.kv_connector.v1.ssm_conv_transfer_utils.is_conv_state_dim_first",
+        return_value=True,
+    ):
+        split = derive_mamba_conv_split(spec, local_tp=2)
+    assert (split.p0_local, split.p1_local, split.p2_local) == (64, 16, 16)
+    assert split.local_conv_offsets == [(0, 384), (384, 96), (480, 96)]

--- a/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
+++ b/tests/v1/kv_connector/unit/test_nixl_connector_hma.py
@@ -593,7 +593,7 @@ def test_derive_mamba_conv_split_gdn_layout():
     assert split.remote_conv_offsets(local_rank_offset=1, tp_ratio=2) == [
         (288, 288),
         (864, 288),
-        (1440, 96),
+        (1248, 96),
     ]
 
 

--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -1026,9 +1026,10 @@ class NixlConnectorWorker:
             # are smaller than D's. self._conv_decomp has D-sized dimensions,
             # but we need P-sized offsets. Scale down by |tp_ratio|.
             abs_ratio = -tp_ratio
-            xb_p = self._conv_decomp.x_bytes // abs_ratio
-            bb_p = self._conv_decomp.b_bytes // abs_ratio
-            conv_offsets = [(0, xb_p), (xb_p, bb_p), (xb_p + bb_p, bb_p)]
+            p0_p = self._conv_decomp.p0_bytes // abs_ratio
+            p1_p = self._conv_decomp.p1_bytes // abs_ratio
+            p2_p = self._conv_decomp.p2_bytes // abs_ratio
+            conv_offsets = [(0, p0_p), (p0_p, p1_p), (p0_p + p1_p, p2_p)]
             ssm_read_size = nixl_agent_meta.ssm_sizes[1]
 
         remote_physical_per_logical = transfer_info.remote_physical_blocks_per_logical

--- a/vllm/distributed/kv_transfer/kv_connector/v1/ssm_conv_transfer_utils.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/ssm_conv_transfer_utils.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-"""Mamba conv-state sub-projection decomposition for the 3-read transfer.
+"""Mamba/GDN conv-state sub-projection decomposition for the 3-read transfer.
 
-With DS conv state layout (dim, state_len), x/B/C sub-projections are
-contiguous in memory.  Each D rank reads its x, B, C slices via 3
+With DS conv state layout (dim, state_len), the three conv sub-projections are
+contiguous in memory. Each D rank reads its slices via 3
 separate RDMA transfers — no P-side permutation needed.
 """
 
@@ -18,50 +18,57 @@ from vllm.v1.kv_cache_interface import MambaSpec
 
 @dataclass(frozen=True)
 class MambaConvSplitInfo:
-    """Per-rank byte sizes of x, B, C sub-projections in the Mamba conv state.
+    """Per-rank byte sizes of 3 sub-projections in Mamba/GDN conv state.
 
     Used by both P and D sides for NIXL descriptor registration.
     All fields are LOCAL to this engine's TP (already divided by TP size).
 
     DS memory layout within one page (contiguous in memory):
-        |--- x (x_local * conv_rows) ---|- B (b_local * conv_rows) -|- C -|
+        |--- p0 (p0_local * conv_rows) ---|--- p1 ---|--- p2 ---|
     """
 
     conv_rows: int  # conv_kernel - 1 (typically 3)
-    x_local: int  # intermediate_size / TP  (columns for x)
-    b_local: int  # groups_ss / TP  (columns for B; C is same size)
+    p0_local: int  # first projection columns per TP rank
+    p1_local: int  # second projection columns per TP rank
+    p2_local: int  # third projection columns per TP rank
     conv_dtype_size: int  # bytes per element (e.g. 2 for float16)
     ssm_sizes: tuple[int, int]  # (conv_state_bytes, ssm_state_bytes)
 
     @property
     def conv_dim_local(self) -> int:
-        """Total conv columns per rank: x + B + C."""
-        return self.x_local + 2 * self.b_local
+        """Total conv columns per rank: p0 + p1 + p2."""
+        return self.p0_local + self.p1_local + self.p2_local
 
     @property
-    def x_bytes(self) -> int:
-        """Byte size of the x sub-projection for one rank."""
-        return self.x_local * self.conv_rows * self.conv_dtype_size
+    def p0_bytes(self) -> int:
+        """Byte size of the first sub-projection for one rank."""
+        return self.p0_local * self.conv_rows * self.conv_dtype_size
 
     @property
-    def b_bytes(self) -> int:
-        """Byte size of the B (or C) sub-projection for one rank."""
-        return self.b_local * self.conv_rows * self.conv_dtype_size
+    def p1_bytes(self) -> int:
+        """Byte size of the second sub-projection for one rank."""
+        return self.p1_local * self.conv_rows * self.conv_dtype_size
+
+    @property
+    def p2_bytes(self) -> int:
+        """Byte size of the third sub-projection for one rank."""
+        return self.p2_local * self.conv_rows * self.conv_dtype_size
 
     @property
     def local_conv_offsets(self) -> list[tuple[int, int]]:
-        """(byte_offset, byte_size) of x, B, C within this engine's page.
+        """(byte_offset, byte_size) of p0, p1, p2 within this engine's page.
 
         Used by both P and D for local descriptor registration.
         """
-        xb = self.x_bytes
-        bb = self.b_bytes
-        return [(0, xb), (xb, bb), (xb + bb, bb)]
+        p0b = self.p0_bytes
+        p1b = self.p1_bytes
+        p2b = self.p2_bytes
+        return [(0, p0b), (p0b, p1b), (p0b + p1b, p2b)]
 
     def remote_conv_offsets(
         self, local_rank_offset: int, tp_ratio: int
     ) -> list[tuple[int, int]]:
-        """(byte_offset, byte_size) of this D rank's x, B, C slice within
+        """(byte_offset, byte_size) of this D rank's p0, p1, p2 slice within
         one P page.
 
         Used by D side only, during remote descriptor registration.
@@ -73,14 +80,15 @@ class MambaConvSplitInfo:
             tp_ratio: effective ratio (>= 1 when D_TP > P_TP, 1 when
                 P_TP > D_TP since each P rank is read in full).
         """
-        xb = self.x_bytes
-        bb = self.b_bytes
-        xr = xb * tp_ratio  # full remote x section in bytes
-        br = bb * tp_ratio  # full remote B section in bytes
+        p0b = self.p0_bytes
+        p1b = self.p1_bytes
+        p2b = self.p2_bytes
+        p0r = p0b * tp_ratio  # full remote p0 section in bytes
+        p1r = p1b * tp_ratio  # full remote p1 section in bytes
         return [
-            (local_rank_offset * xb, xb),
-            (xr + local_rank_offset * bb, bb),
-            (xr + br + local_rank_offset * bb, bb),
+            (local_rank_offset * p0b, p0b),
+            (p0r + local_rank_offset * p1b, p1b),
+            (p0r + p1r + local_rank_offset * p2b, p2b),
         ]
 
 
@@ -88,27 +96,29 @@ def derive_mamba_conv_split(
     mamba_spec: MambaSpec,
     local_tp: int,
 ) -> MambaConvSplitInfo:
-    """Derive per-rank x/B/C byte sizes from a MambaSpec.
+    """Derive per-rank 3-read split byte sizes from a MambaSpec.
 
-    Called once at init on both P and D.  Decomposes the conv dimension
-    (= intermediate_size + 2 * groups_ss) into its x, B, C parts.
+    Called once at init on both P and D. Decomposes conv state into three
+    contiguous projection slices read independently during transfer.
 
     Args:
         mamba_spec: MambaSpec whose shapes are:
             shapes[0] = conv state: (conv_dim_local, conv_rows) in DS layout.
-            shapes[1] = SSM temporal: (local_num_heads, head_dim).
+            shapes[1] = SSM temporal:
+                - Mamba2: (local_num_heads, head_dim)
+                - GDN: (local_num_v_heads, head_v_dim, head_k_dim)
         local_tp: this engine's tensor-parallel size.
 
     Returns:
-        MambaConvSplitInfo with per-rank x_local, b_local, conv_rows,
+        MambaConvSplitInfo with per-rank p0/p1/p2 locals, conv_rows,
         conv_dtype_size, and ssm_sizes (conv_state_bytes, ssm_state_bytes).
     """
-    if mamba_spec.mamba_type != "mamba2":
+    if mamba_spec.mamba_type not in ("mamba2", "gdn_attention"):
         raise NotImplementedError(
-            f"3-read conv transfer only supports Mamba2 models, "
+            f"3-read conv transfer only supports Mamba2/GDN models, "
             f"got mamba_type={mamba_spec.mamba_type!r}.  "
-            f"Mamba1 SSM temporal shape is (intermediate_size // tp, state_size) "
-            f"which cannot be used to reconstruct intermediate_size."
+            f"Mamba1 SSM temporal shape is (intermediate_size // tp, state_size), "
+            f"which cannot reconstruct the 3-read split."
         )
 
     conv_shape = mamba_spec.shapes[0]
@@ -120,23 +130,47 @@ def derive_mamba_conv_split(
     local_conv_dim = conv_shape[0]  # DS: (conv_dim_local, conv_rows)
     conv_rows = conv_shape[1]
 
-    # NOTE (ZhanqiuHu): intermediate_size (= global x dim) is not stored
-    # in MambaSpec, so we reconstruct it from the SSM temporal state shape:
-    #   shapes[1] = (local_num_heads, head_dim), already divided by TP.
-    head_dim = mamba_spec.shapes[1][1]
-    local_num_heads = mamba_spec.shapes[1][0]
-    intermediate_size = local_num_heads * local_tp * head_dim
+    if mamba_spec.mamba_type == "mamba2":
+        # shapes[1] = (local_num_heads, head_dim), already TP-sharded.
+        head_dim = mamba_spec.shapes[1][1]
+        local_num_heads = mamba_spec.shapes[1][0]
+        intermediate_size = local_num_heads * local_tp * head_dim
 
-    # NOTE (ZhanqiuHu): global conv dim = intermediate_size + 2 * groups_ss,
-    # where groups_ss is the B (= C) dimension.  B and C are always the same
-    # size, so we recover groups_ss from the remainder after subtracting x.
-    remainder = local_conv_dim * local_tp - intermediate_size
-    assert remainder > 0 and remainder % 2 == 0, (
-        f"Conv dim ({local_conv_dim}*tp={local_tp}) doesn't decompose into "
-        f"intermediate_size={intermediate_size} + 2*groups_ss. "
-        f"remainder={remainder}"
-    )
-    groups_ss = remainder // 2
+        # global conv dim = intermediate_size + 2 * groups_ss.
+        remainder = local_conv_dim * local_tp - intermediate_size
+        assert remainder > 0 and remainder % 2 == 0, (
+            f"Conv dim ({local_conv_dim}*tp={local_tp}) doesn't decompose into "
+            f"intermediate_size={intermediate_size} + 2*groups_ss. "
+            f"remainder={remainder}"
+        )
+        groups_ss = remainder // 2
+        p0_local = intermediate_size // local_tp
+        p1_local = groups_ss // local_tp
+        p2_local = groups_ss // local_tp
+    else:
+        # GDN conv layout is [K, K, V].
+        assert len(mamba_spec.shapes[1]) == 3, (
+            "Expected 3D GDN temporal state shape "
+            f"(num_v_heads/tp, head_v_dim, head_k_dim), got {mamba_spec.shapes[1]}"
+        )
+        local_num_v_heads, head_v_dim, head_k_dim = mamba_spec.shapes[1]
+        local_v_dim = local_num_v_heads * head_v_dim
+        assert local_conv_dim >= local_v_dim, (
+            f"GDN conv dim ({local_conv_dim}) must be >= local V dim ({local_v_dim})."
+        )
+        remaining_for_k = local_conv_dim - local_v_dim
+        assert remaining_for_k % 2 == 0, (
+            f"GDN conv dim ({local_conv_dim}) must decompose as K + K + V; "
+            f"remaining_for_k={remaining_for_k} is not divisible by 2."
+        )
+        local_k_dim = remaining_for_k // 2
+        assert local_k_dim % head_k_dim == 0, (
+            f"Derived local K dim ({local_k_dim}) must align with head_k_dim "
+            f"({head_k_dim})."
+        )
+        p0_local = local_k_dim
+        p1_local = local_k_dim
+        p2_local = local_v_dim
 
     conv_dtype_size = torch.tensor(
         [],
@@ -153,8 +187,9 @@ def derive_mamba_conv_split(
     # Divide by TP to get per-rank column counts.
     return MambaConvSplitInfo(
         conv_rows=conv_rows,
-        x_local=intermediate_size // local_tp,
-        b_local=groups_ss // local_tp,
+        p0_local=p0_local,
+        p1_local=p1_local,
+        p2_local=p2_local,
         conv_dtype_size=conv_dtype_size,
         ssm_sizes=(conv_state_bytes, ssm_state_bytes),
     )


### PR DESCRIPTION

## Purpose
Add GDN-based SSM support for NIXL prefill/decode disaggregation (issue [#41886](https://github.com/vllm-project/vllm/issues/41886)) by extending the existing Mamba2-oriented 3-read transfer decomposition to handle Qwen3.5/GDN state layouts.
This PR:
- Extends conv-state split derivation to support both Mamba2 and GDN layouts.
- Adds `gdn_attention` handling in `derive_mamba_conv_split`.
- Generalizes hetero-TP remote slice offset logic to use 3 projection slices (instead of assuming symmetric Mamba2 B/C sizing).
- Adds unit tests covering:
  - GDN split and remote-offset derivation.
  - Mamba2 compatibility to avoid regressions.

## Test Plan
Run targeted unit tests:
```bash
uv run python -m pytest tests/v1/kv_connector/unit/test_nixl_connector_hma.py -k "derive_mamba_conv_split or compute_physical_blocks_per_logical" -q
Run lint checks:

pre-commit run --all-files
```
## Test Result
pre-commit / lint diagnostics on edited files: ✅ no linter errors.
