### PR TITLE
[Bugfix] Surface KV cache load errors in OpenAI responses

### DIFF
--- a/tests/entrypoints/openai/test_generation_error.py
+++ b/tests/entrypoints/openai/test_generation_error.py
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.entrypoints.openai.engine.serving import GenerationError, OpenAIServing
+
+
+def test_raise_if_error_uses_string_stop_reason():
+    serving = OpenAIServing.__new__(OpenAIServing)
+
+    with pytest.raises(GenerationError, match="KV cache load failed"):
+        serving._raise_if_error(
+            "error",
+            "test-request",
+            "KV cache load failed for one or more remote blocks. "
+            "The request can be retried.",
+        )
+
+
+def test_raise_if_error_falls_back_for_missing_stop_reason():
+    serving = OpenAIServing.__new__(OpenAIServing)
+
+    with pytest.raises(GenerationError, match="Internal server error"):
+        serving._raise_if_error("error", "test-request")

--- a/tests/entrypoints/openai/test_generation_error.py
+++ b/tests/entrypoints/openai/test_generation_error.py
@@ -22,3 +22,10 @@ def test_raise_if_error_falls_back_for_missing_stop_reason():
 
     with pytest.raises(GenerationError, match="Internal server error"):
         serving._raise_if_error("error", "test-request")
+
+
+def test_raise_if_error_falls_back_for_blank_stop_reason():
+    serving = OpenAIServing.__new__(OpenAIServing)
+
+    with pytest.raises(GenerationError, match="Internal server error"):
+        serving._raise_if_error("error", "test-request", "   ")

--- a/tests/v1/kv_connector/unit/test_error_propagation.py
+++ b/tests/v1/kv_connector/unit/test_error_propagation.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock
 
 import pytest
 
-from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.core.sched.scheduler import KV_LOAD_ERROR_STOP_REASON, Scheduler
 from vllm.v1.request import FinishReason, Request, RequestStatus
 
 from .utils import (
@@ -88,6 +88,7 @@ def test_error_propagation_sync_load(fail_scheduler: Scheduler):
     output = engine_outputs.outputs[0]
     assert output.request_id == request.request_id
     assert output.finish_reason == FinishReason.ERROR
+    assert output.stop_reason == KV_LOAD_ERROR_STOP_REASON
 
     assert len(fail_scheduler.running) == 0
 
@@ -143,6 +144,7 @@ def test_error_propagation_async_load(fail_scheduler: Scheduler):
     output = engine_outputs.outputs[0]
     assert output.request_id == request.request_id
     assert output.finish_reason == FinishReason.ERROR
+    assert output.stop_reason == KV_LOAD_ERROR_STOP_REASON
 
     assert len(fail_scheduler.waiting) == 0
     assert len(fail_scheduler.skipped_waiting) == 0

--- a/vllm/entrypoints/openai/chat_completion/batch_serving.py
+++ b/vllm/entrypoints/openai/chat_completion/batch_serving.py
@@ -250,7 +250,9 @@ class OpenAIServingChatBatch(OpenAIServingChat):
             )
 
             for output in final_res.outputs:
-                self._raise_if_error(output.finish_reason, request_id)
+                self._raise_if_error(
+                    output.finish_reason, request_id, output.stop_reason
+                )
 
                 if request.logprobs and request.top_logprobs is not None:
                     assert output.logprobs is not None, "Did not output logprobs"

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -795,7 +795,9 @@ class OpenAIServingChat(OpenAIServing):
                     else:
                         # check for error finish reason and abort streaming
                         # finish_reason='error' indicates a retryable error
-                        self._raise_if_error(output.finish_reason, request_id)
+                        self._raise_if_error(
+                            output.finish_reason, request_id, output.stop_reason
+                        )
 
                         # check to make sure we haven't "forgotten" to stream
                         #   any tokens that were generated but previously
@@ -1024,7 +1026,7 @@ class OpenAIServingChat(OpenAIServing):
         for output in final_res.outputs:
             # check for error finish reason and raise GenerationError
             # finish_reason='error' indicates a retryable request-level internal error
-            self._raise_if_error(output.finish_reason, request_id)
+            self._raise_if_error(output.finish_reason, request_id, output.stop_reason)
             token_ids = output.token_ids
             out_logprobs = output.logprobs
             tool_call_info = None

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -380,7 +380,7 @@ class OpenAIServingCompletion(OpenAIServing):
                     finish_reason = output.finish_reason
                     stop_reason = output.stop_reason
 
-                    self._raise_if_error(finish_reason, request_id)
+                    self._raise_if_error(finish_reason, request_id, stop_reason)
 
                     chunk = CompletionStreamResponse(
                         id=request_id,
@@ -487,7 +487,9 @@ class OpenAIServingCompletion(OpenAIServing):
             out_logprobs: GenericSequence[dict[int, Logprob] | None] | None
 
             for output in final_res.outputs:
-                self._raise_if_error(output.finish_reason, request_id)
+                self._raise_if_error(
+                    output.finish_reason, request_id, output.stop_reason
+                )
 
                 assert request.max_tokens is not None
                 if request.echo:

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -408,7 +408,7 @@ class OpenAIServing:
                 request_id,
                 stop_reason,
             )
-            message = stop_reason if isinstance(stop_reason, str) else None
+            message = stop_reason.strip() if isinstance(stop_reason, str) else None
             raise GenerationError(message or "Internal server error")
 
     def _convert_generation_error_to_streaming_response(

--- a/vllm/entrypoints/openai/engine/serving.py
+++ b/vllm/entrypoints/openai/engine/serving.py
@@ -395,14 +395,21 @@ class OpenAIServing:
         )
         return json_str
 
-    def _raise_if_error(self, finish_reason: str | None, request_id: str) -> None:
+    def _raise_if_error(
+        self,
+        finish_reason: str | None,
+        request_id: str,
+        stop_reason: int | str | None = None,
+    ) -> None:
         """Raise GenerationError if finish_reason indicates an error."""
         if finish_reason == "error":
             logger.error(
-                "Request %s failed with an internal error during generation",
+                "Request %s failed with an internal error during generation: %s",
                 request_id,
+                stop_reason,
             )
-            raise GenerationError("Internal server error")
+            message = stop_reason if isinstance(stop_reason, str) else None
+            raise GenerationError(message or "Internal server error")
 
     def _convert_generation_error_to_streaming_response(
         self, e: GenerationError

--- a/vllm/entrypoints/openai/responses/context.py
+++ b/vllm/entrypoints/openai/responses/context.py
@@ -527,6 +527,7 @@ class HarmonyContext(ConversationContext):
     ):
         self._messages = messages
         self.finish_reason: str | None = None
+        self.stop_reason: int | str | None = None
         self.available_tools = available_tools
         self._tool_sessions: dict[str, ClientSession | Tool] = {}
         self.called_tools: set[str] = set()
@@ -575,7 +576,9 @@ class HarmonyContext(ConversationContext):
         # so we can append all the parser messages to _messages
         output_msgs = self.parser.messages
         # The responses finish reason is set in the last message
-        self.finish_reason = output.outputs[0].finish_reason
+        completion_output = output.outputs[0]
+        self.finish_reason = completion_output.finish_reason
+        self.stop_reason = completion_output.stop_reason
         self._messages.extend(output_msgs)
 
     def append_tool_output(self, output: list[Message]) -> None:
@@ -872,7 +875,8 @@ class StreamingHarmonyContext(HarmonyContext):
         # beginning of a new message
         self.first_tok_of_message = output.finished
         last_delta_text = ""
-        for tok in output.outputs[0].token_ids:
+        output_token_ids = output.outputs[0].token_ids
+        for tok in output_token_ids:
             self.parser.process(tok)
             last_delta_text += self.parser.last_content_delta or ""
         if last_delta_text:
@@ -880,6 +884,10 @@ class StreamingHarmonyContext(HarmonyContext):
         self._update_decode_token_usage(output)
         if output.kv_transfer_params is not None:
             self.kv_transfer_params = output.kv_transfer_params
+        if output.finished:
+            completion_output = output.outputs[0]
+            self.finish_reason = completion_output.finish_reason
+            self.stop_reason = completion_output.stop_reason
 
         # For streaming, update previous turn when message is complete
         if output.finished:
@@ -887,7 +895,8 @@ class StreamingHarmonyContext(HarmonyContext):
             self.current_turn_metrics.reset()
         # Check if the current token is part of reasoning content
         self._update_num_reasoning_tokens()
-        self.last_tok = tok
+        if output_token_ids:
+            self.last_tok = output_token_ids[-1]
         if len(self._messages) - self.num_init_messages < len(self.parser.messages):
             self._messages.extend(
                 self.parser.messages[len(self._messages) - self.num_init_messages :]

--- a/vllm/entrypoints/openai/responses/serving.py
+++ b/vllm/entrypoints/openai/responses/serving.py
@@ -789,7 +789,11 @@ class OpenAIServingResponses(OpenAIServing):
                 elif context.finish_reason == "abort":
                     status = "cancelled"
                 else:
-                    self._raise_if_error(context.finish_reason, request.request_id)
+                    self._raise_if_error(
+                        context.finish_reason,
+                        request.request_id,
+                        context.stop_reason,
+                    )
             else:
                 status = "incomplete"
         elif isinstance(context, ParsableContext):
@@ -815,7 +819,11 @@ class OpenAIServingResponses(OpenAIServing):
             final_output = final_res.outputs[0]
 
             # finish_reason='error' indicates retryable internal error
-            self._raise_if_error(final_output.finish_reason, request.request_id)
+            self._raise_if_error(
+                final_output.finish_reason,
+                request.request_id,
+                final_output.stop_reason,
+            )
 
             # Check if generation was stopped due to max_tokens
             if final_output.finish_reason == "length":
@@ -1373,7 +1381,9 @@ class OpenAIServingResponses(OpenAIServing):
                 continue
 
             output = ctx.last_output.outputs[0]
-            self._raise_if_error(output.finish_reason, request.request_id)
+            self._raise_if_error(
+                output.finish_reason, request.request_id, output.stop_reason
+            )
             delta_text = output.text
             delta_token_ids = as_list(output.token_ids)
 
@@ -1426,7 +1436,7 @@ class OpenAIServingResponses(OpenAIServing):
             assert isinstance(ctx, StreamingHarmonyContext)
 
             # finish_reason='error' indicates a retryable error
-            self._raise_if_error(ctx.finish_reason, request.request_id)
+            self._raise_if_error(ctx.finish_reason, request.request_id, ctx.stop_reason)
 
             if ctx.is_expecting_start():
                 if len(ctx.parser.messages) > 0:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -58,6 +58,10 @@ from vllm.v1.utils import record_function_or_nullcontext
 
 logger = init_logger(__name__)
 
+KV_LOAD_ERROR_STOP_REASON = (
+    "KV cache load failed for one or more remote blocks. The request can be retried."
+)
+
 
 class Scheduler(SchedulerInterface):
     def __init__(
@@ -1451,6 +1455,7 @@ class Scheduler(SchedulerInterface):
                         request_id=request.request_id,
                         new_token_ids=[],
                         finish_reason=request.get_finished_reason(),
+                        stop_reason=KV_LOAD_ERROR_STOP_REASON,
                         events=request.take_events(),
                         trace_headers=request.trace_headers,
                     )


### PR DESCRIPTION
﻿## Purpose
Fixes #40978.

KV connector load failures were surfaced to OpenAI-compatible clients as a generic `Internal server error`. The scheduler marked the request with `finish_reason="error"`, but the OpenAI serving layer discarded the more specific cause and always raised a generic `GenerationError`.

This adds a retryable KV-load failure stop reason in the scheduler and threads `stop_reason` through OpenAI completions, chat completions, batch chat completions, and responses handling so clients receive a more actionable error message.

A follow-up commit addresses automated review feedback by falling back to `Internal server error` when `stop_reason` is missing or whitespace-only.

## Test Plan
- `python -m ruff format vllm\v1\core\sched\scheduler.py vllm\entrypoints\openai\engine\serving.py vllm\entrypoints\openai\chat_completion\batch_serving.py vllm\entrypoints\openai\chat_completion\serving.py vllm\entrypoints\openai\completion\serving.py vllm\entrypoints\openai\responses\serving.py vllm\entrypoints\openai\responses\context.py tests\v1\kv_connector\unit\test_error_propagation.py tests\entrypoints\openai\test_generation_error.py`
- `python -m ruff check vllm\v1\core\sched\scheduler.py vllm\entrypoints\openai\engine\serving.py vllm\entrypoints\openai\chat_completion\batch_serving.py vllm\entrypoints\openai\chat_completion\serving.py vllm\entrypoints\openai\completion\serving.py vllm\entrypoints\openai\responses\serving.py vllm\entrypoints\openai\responses\context.py tests\v1\kv_connector\unit\test_error_propagation.py tests\entrypoints\openai\test_generation_error.py`
- `python -m py_compile vllm\v1\core\sched\scheduler.py vllm\entrypoints\openai\engine\serving.py vllm\entrypoints\openai\chat_completion\batch_serving.py vllm\entrypoints\openai\chat_completion\serving.py vllm\entrypoints\openai\completion\serving.py vllm\entrypoints\openai\responses\serving.py vllm\entrypoints\openai\responses\context.py tests\v1\kv_connector\unit\test_error_propagation.py tests\entrypoints\openai\test_generation_error.py`
- `git diff --check`
- `python -m pytest -q tests\entrypoints\openai\test_generation_error.py`

## Test Result
- Ruff format/check passed on changed files.
- Py compile passed on changed files.
- `git diff --check` passed except for Windows CRLF conversion warnings.
- Targeted pytest could not start in this Windows environment because `tests/conftest.py` imports vLLM, which imports `uvloop`: `ModuleNotFoundError: No module named 'uvloop'`.

## Notes
- This PR was prepared with AI assistance and reviewed against the vLLM agent guidance for concrete community value.
- The current `pre-run-check` failure is a vLLM new-contributor gate requiring a maintainer to add `ready` or `verified`, or an author with at least 4 merged PRs. I do not have permission to add that label from this fork.
