### PR TITLE
[Bugfix] Fix EPLB expert mapping for DeepSeekV2 and AXK1

### DIFF
--- a/tests/model_executor/models/test_eplb_expert_mapping.py
+++ b/tests/model_executor/models/test_eplb_expert_mapping.py
@@ -37,7 +37,8 @@ def test_get_expert_mapping_matches_load_weights_expert_count(
     )
 
     model = SimpleNamespace(
-        config=SimpleNamespace(n_routed_experts=8, n_shared_experts=2),
+        num_routed_experts=8,
+        num_shared_experts=2,
         num_redundant_experts=3,
     )
 
@@ -46,3 +47,44 @@ def test_get_expert_mapping_matches_load_weights_expert_count(
     expected_num_experts = 10 if shared_experts_enabled else 8
     assert captured_kwargs["num_experts"] == expected_num_experts
     assert captured_kwargs["num_redundant_experts"] == 3
+
+
+@pytest.mark.parametrize(
+    "module_name, class_name",
+    [
+        ("vllm.model_executor.models.deepseek_v2", "DeepseekV2ForCausalLM"),
+        ("vllm.model_executor.models.AXK1", "AXK1ForCausalLM"),
+    ],
+)
+def test_get_expert_mapping_handles_missing_expert_metadata(
+    monkeypatch, module_name, class_name
+):
+    module = pytest.importorskip(module_name)
+    model_cls = getattr(module, class_name)
+
+    captured_kwargs = {}
+
+    def fake_make_mapping(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        module,
+        "fused_moe_make_expert_params_mapping",
+        fake_make_mapping,
+    )
+    monkeypatch.setattr(
+        module.rocm_aiter_ops,
+        "is_fusion_moe_shared_experts_enabled",
+        lambda: True,
+    )
+
+    model = SimpleNamespace(
+        num_routed_experts=None,
+        num_shared_experts=None,
+        num_redundant_experts=None,
+    )
+
+    assert model_cls.get_expert_mapping(model) == []
+    assert captured_kwargs["num_experts"] == 0
+    assert captured_kwargs["num_redundant_experts"] == 0

--- a/tests/model_executor/models/test_eplb_expert_mapping.py
+++ b/tests/model_executor/models/test_eplb_expert_mapping.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "module_name, class_name",
+    [
+        ("vllm.model_executor.models.deepseek_v2", "DeepseekV2ForCausalLM"),
+        ("vllm.model_executor.models.AXK1", "AXK1ForCausalLM"),
+    ],
+)
+@pytest.mark.parametrize("shared_experts_enabled", [False, True])
+def test_get_expert_mapping_matches_load_weights_expert_count(
+    monkeypatch, module_name, class_name, shared_experts_enabled
+):
+    module = pytest.importorskip(module_name)
+    model_cls = getattr(module, class_name)
+
+    captured_kwargs = {}
+
+    def fake_make_mapping(*args, **kwargs):
+        captured_kwargs.update(kwargs)
+        return []
+
+    monkeypatch.setattr(
+        module,
+        "fused_moe_make_expert_params_mapping",
+        fake_make_mapping,
+    )
+    monkeypatch.setattr(
+        module.rocm_aiter_ops,
+        "is_fusion_moe_shared_experts_enabled",
+        lambda: shared_experts_enabled,
+    )
+
+    model = SimpleNamespace(
+        config=SimpleNamespace(n_routed_experts=8, n_shared_experts=2),
+        num_redundant_experts=3,
+    )
+
+    assert model_cls.get_expert_mapping(model) == []
+
+    expected_num_experts = 10 if shared_experts_enabled else 8
+    assert captured_kwargs["num_experts"] == expected_num_experts
+    assert captured_kwargs["num_redundant_experts"] == 3

--- a/vllm/model_executor/models/AXK1.py
+++ b/vllm/model_executor/models/AXK1.py
@@ -1133,13 +1133,19 @@ class AXK1ForCausalLM(
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)
+        rocm_aiter_moe_shared_expert_enabled = (
+            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
+        )
+        num_experts = self.num_routed_experts or 0
+        if rocm_aiter_moe_shared_expert_enabled:
+            num_experts += self.num_shared_experts or 0
         return fused_moe_make_expert_params_mapping(
             self,
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
-            num_experts=self.config.n_routed_experts,
-            num_redundant_experts=0,
+            num_experts=num_experts,
+            num_redundant_experts=self.num_redundant_experts or 0,
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:

--- a/vllm/model_executor/models/deepseek_v2.py
+++ b/vllm/model_executor/models/deepseek_v2.py
@@ -1474,13 +1474,19 @@ class DeepseekV2ForCausalLM(
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:
         # Params for weights, fp8 weight scales, fp8 activation scales
         # (param_name, weight_name, expert_id, shard_id)
+        rocm_aiter_moe_shared_expert_enabled = (
+            rocm_aiter_ops.is_fusion_moe_shared_experts_enabled()
+        )
+        num_experts = self.num_routed_experts or 0
+        if rocm_aiter_moe_shared_expert_enabled:
+            num_experts += self.num_shared_experts or 0
         return fused_moe_make_expert_params_mapping(
             self,
             ckpt_gate_proj_name="gate_proj",
             ckpt_down_proj_name="down_proj",
             ckpt_up_proj_name="up_proj",
-            num_experts=self.config.n_routed_experts,
-            num_redundant_experts=0,
+            num_experts=num_experts,
+            num_redundant_experts=self.num_redundant_experts or 0,
         )
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:


### PR DESCRIPTION
﻿## Purpose
Fixes #41920.

`get_expert_mapping()` for DeepSeekV2 and AXK1 used only `n_routed_experts` and hard-coded `num_redundant_experts=0`. Their `load_weights()` paths include shared experts when ROCm AITER shared experts are enabled and also account for redundant experts, so EPLB expert mapping could diverge from the actual loaded expert weights.

This makes the mapping use the model's normalized expert metadata and the same shared-expert condition as the weight-loading path.

A follow-up commit addresses automated review feedback by treating missing expert metadata as zero instead of adding `None` values.

## Test Plan
- `python -m ruff format vllm\model_executor\models\deepseek_v2.py vllm\model_executor\models\AXK1.py tests\model_executor\models\test_eplb_expert_mapping.py`
- `python -m ruff check vllm\model_executor\models\deepseek_v2.py vllm\model_executor\models\AXK1.py tests\model_executor\models\test_eplb_expert_mapping.py`
- `python -m py_compile vllm\model_executor\models\deepseek_v2.py vllm\model_executor\models\AXK1.py tests\model_executor\models\test_eplb_expert_mapping.py`
- `git diff --check`
- `python -m pytest -q tests\model_executor\models\test_eplb_expert_mapping.py`

## Test Result
- Ruff format/check passed on changed files.
- Py compile passed on changed files.
- `git diff --check` passed except for Windows CRLF conversion warnings.
- Targeted pytest could not start in this Windows environment because `tests/conftest.py` imports vLLM, which imports `uvloop`: `ModuleNotFoundError: No module named 'uvloop'`.

## Notes
- This PR was prepared with AI assistance and reviewed against the vLLM agent guidance for concrete community value.
- The current `pre-run-check` failure is a vLLM new-contributor gate requiring a maintainer to add `ready` or `verified`, or an author with at least 4 merged PRs. I do not have permission to add that label from this fork.
