### PR TITLE
[Bugfix] Fix MoE fake output shape for TRTLLM MXFP4

### DIFF
--- a/tests/model_executor/layers/fused_moe/test_moe_runner_fake.py
+++ b/tests/model_executor/layers/fused_moe/test_moe_runner_fake.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.model_executor.layers.fused_moe.runner import moe_runner
+
+
+class FakeTrtLlmMxfp4Experts:
+    __module__ = "vllm.model_executor.layers.fused_moe.experts.trtllm_mxfp4_moe"
+
+
+class FakeOtherExperts:
+    pass
+
+
+def test_moe_forward_fake_uses_trtllm_mxfp4_unpadded_dim(
+    monkeypatch,
+) -> None:
+    experts = FakeTrtLlmMxfp4Experts()
+    experts.hidden_dim_unpadded = 2880
+    layer = SimpleNamespace(
+        runner=SimpleNamespace(
+            _quant_method=SimpleNamespace(
+                moe_kernel=SimpleNamespace(fused_experts=experts)
+            )
+        )
+    )
+    monkeypatch.setattr(moe_runner, "get_layer_from_name", lambda _: layer)
+
+    hidden_states = torch.empty(2, 3072, device="meta")
+    out = moe_runner._moe_forward_fake(
+        hidden_states,
+        torch.empty(2, 128, device="meta"),
+        None,
+        None,
+        "model.layers.0.mlp.experts",
+    )
+
+    assert out.shape == (2, 2880)
+
+
+def test_moe_forward_fake_keeps_default_hidden_dim(monkeypatch) -> None:
+    layer = SimpleNamespace(
+        runner=SimpleNamespace(
+            _quant_method=SimpleNamespace(
+                moe_kernel=SimpleNamespace(fused_experts=FakeOtherExperts())
+            )
+        )
+    )
+    monkeypatch.setattr(moe_runner, "get_layer_from_name", lambda _: layer)
+
+    hidden_states = torch.empty(2, 3072, device="meta")
+    out = moe_runner._moe_forward_fake(
+        hidden_states,
+        torch.empty(2, 128, device="meta"),
+        None,
+        None,
+        "model.layers.0.mlp.experts",
+    )
+
+    assert out.shape == hidden_states.shape
+
+
+def test_moe_forward_shared_fake_uses_trtllm_mxfp4_unpadded_dim(
+    monkeypatch,
+) -> None:
+    experts = FakeTrtLlmMxfp4Experts()
+    experts.hidden_dim_unpadded = 2880
+    layer = SimpleNamespace(
+        runner=SimpleNamespace(
+            _quant_method=SimpleNamespace(
+                moe_kernel=SimpleNamespace(fused_experts=experts)
+            )
+        )
+    )
+    monkeypatch.setattr(moe_runner, "get_layer_from_name", lambda _: layer)
+
+    hidden_states = torch.empty(2, 3072, device="meta")
+    shared_input = torch.empty(2, 3072, device="meta")
+    shared_out, fused_out = moe_runner._moe_forward_shared_fake(
+        hidden_states,
+        torch.empty(2, 128, device="meta"),
+        shared_input,
+        None,
+        "model.layers.0.mlp.experts",
+    )
+
+    assert shared_out.shape == shared_input.shape
+    assert fused_out.shape == (2, 2880)

--- a/tests/model_executor/layers/fused_moe/test_moe_runner_fake.py
+++ b/tests/model_executor/layers/fused_moe/test_moe_runner_fake.py
@@ -1,91 +1,52 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from types import SimpleNamespace
-
 import torch
 
 from vllm.model_executor.layers.fused_moe.runner import moe_runner
 
 
-class FakeTrtLlmMxfp4Experts:
-    __module__ = "vllm.model_executor.layers.fused_moe.experts.trtllm_mxfp4_moe"
-
-
-class FakeOtherExperts:
-    pass
-
-
-def test_moe_forward_fake_uses_trtllm_mxfp4_unpadded_dim(
-    monkeypatch,
-) -> None:
-    experts = FakeTrtLlmMxfp4Experts()
-    experts.hidden_dim_unpadded = 2880
-    layer = SimpleNamespace(
-        runner=SimpleNamespace(
-            _quant_method=SimpleNamespace(
-                moe_kernel=SimpleNamespace(fused_experts=experts)
-            )
-        )
-    )
-    monkeypatch.setattr(moe_runner, "get_layer_from_name", lambda _: layer)
-
+def test_moe_forward_fake_uses_trtllm_mxfp4_unpadded_dim() -> None:
     hidden_states = torch.empty(2, 3072, device="meta")
+
     out = moe_runner._moe_forward_fake(
         hidden_states,
         torch.empty(2, 128, device="meta"),
         None,
         None,
         "model.layers.0.mlp.experts",
+        2880,
     )
 
     assert out.shape == (2, 2880)
 
 
-def test_moe_forward_fake_keeps_default_hidden_dim(monkeypatch) -> None:
-    layer = SimpleNamespace(
-        runner=SimpleNamespace(
-            _quant_method=SimpleNamespace(
-                moe_kernel=SimpleNamespace(fused_experts=FakeOtherExperts())
-            )
-        )
-    )
-    monkeypatch.setattr(moe_runner, "get_layer_from_name", lambda _: layer)
-
+def test_moe_forward_fake_keeps_default_hidden_dim() -> None:
     hidden_states = torch.empty(2, 3072, device="meta")
+
     out = moe_runner._moe_forward_fake(
         hidden_states,
         torch.empty(2, 128, device="meta"),
         None,
         None,
         "model.layers.0.mlp.experts",
+        0,
     )
 
     assert out.shape == hidden_states.shape
 
 
-def test_moe_forward_shared_fake_uses_trtllm_mxfp4_unpadded_dim(
-    monkeypatch,
-) -> None:
-    experts = FakeTrtLlmMxfp4Experts()
-    experts.hidden_dim_unpadded = 2880
-    layer = SimpleNamespace(
-        runner=SimpleNamespace(
-            _quant_method=SimpleNamespace(
-                moe_kernel=SimpleNamespace(fused_experts=experts)
-            )
-        )
-    )
-    monkeypatch.setattr(moe_runner, "get_layer_from_name", lambda _: layer)
-
+def test_moe_forward_shared_fake_uses_trtllm_mxfp4_unpadded_dim() -> None:
     hidden_states = torch.empty(2, 3072, device="meta")
     shared_input = torch.empty(2, 3072, device="meta")
+
     shared_out, fused_out = moe_runner._moe_forward_shared_fake(
         hidden_states,
         torch.empty(2, 128, device="meta"),
         shared_input,
         None,
         "model.layers.0.mlp.experts",
+        2880,
     )
 
     assert shared_out.shape == shared_input.shape


### PR DESCRIPTION
﻿## Purpose
Fixes #41645.

`vllm.moe_forward` and `vllm.moe_forward_shared` fake implementations always returned tensors with the same trailing dimension as `hidden_states`. The TRTLLM MXFP4 MoE kernels can return `hidden_dim_unpadded` instead, so `torch.compile` shape propagation could see a padded dimension that does not match the real kernel output.

This updates the fake implementations to inspect the MoE layer's selected TRTLLM MXFP4 expert implementation and use its `hidden_dim_unpadded` for fake output tensors. Other MoE kernels keep the existing `empty_like(hidden_states)` shape.

A follow-up commit addresses automated review feedback by making the fake shape lookup side-effect-free for `from_forward_context` and by continuing through nested MXFP4 candidates until one has `hidden_dim_unpadded`.

## Test Plan
- `python -m ruff format vllm\model_executor\layers\fused_moe\runner\moe_runner.py tests\model_executor\layers\fused_moe\test_moe_runner_fake.py`
- `python -m ruff check vllm\model_executor\layers\fused_moe\runner\moe_runner.py tests\model_executor\layers\fused_moe\test_moe_runner_fake.py`
- `python -m py_compile vllm\model_executor\layers\fused_moe\runner\moe_runner.py tests\model_executor\layers\fused_moe\test_moe_runner_fake.py`
- `git diff --check`
- `python -m pytest -q tests\model_executor\layers\fused_moe\test_moe_runner_fake.py`

## Test Result
- Ruff format/check passed on changed files.
- Py compile passed on changed files.
- `git diff --check` passed except for Windows CRLF conversion warnings.
- Targeted pytest could not start in this Windows environment because `tests/conftest.py` imports vLLM, which imports `uvloop`: `ModuleNotFoundError: No module named 'uvloop'`.
- Full Blackwell + TP + `torch.compile` validation requires upstream CI or maintainer hardware.

## Notes
- This PR was prepared with AI assistance and reviewed against the vLLM agent guidance for concrete community value.
- The current `pre-run-check` failure is a vLLM new-contributor gate requiring a maintainer to add `ready` or `verified`, or an author with at least 4 merged PRs. I do not have permission to add that label from this fork.
