### PR TITLE
[Bugfix][Model] Remove 30s audio cap in Qwen3-ASR dummy inputs builder

### DIFF
--- a/vllm/model_executor/models/qwen3_asr.py
+++ b/vllm/model_executor/models/qwen3_asr.py
@@ -151,12 +151,11 @@ class Qwen3ASRDummyInputsBuilder(BaseDummyInputsBuilder[Qwen3ASRProcessingInfo])
 
         feature_extractor = self.info.get_feature_extractor()
 
-        target_audio_length = (
-            min(
-                feature_extractor.chunk_length,
-                30,
-            )
-            * feature_extractor.sampling_rate
+        # Defer to ``chunk_length`` (overridable via ``--mm-processor-kwargs``)
+        # so the encoder-cache budget can scale past Whisper's 30s default;
+        # Qwen3-ASR's encoder supports much longer audio.
+        target_audio_length = int(
+            feature_extractor.chunk_length * feature_extractor.sampling_rate
         )
 
         audio_overrides = mm_options.get("audio")


### PR DESCRIPTION
## Summary

`Qwen3ASRDummyInputsBuilder.get_dummy_mm_data` clamps the dummy audio length used for memory profiling to 30 s via `min(feature_extractor.chunk_length, 30) * sampling_rate`. The dummy drives the per-item encoder-cache budget (~2048 tokens), so every `vllm serve` deployment of `Qwen/Qwen3-ASR-*` rejects audio longer than ~30 s with:

```
ValueError: ... exceeds the pre-allocated encoder cache size 2048.
Please reduce the input size or increase the encoder cache size by
setting --limit-mm-per-prompt at startup.
```

The error suggestion does not work: `_get_dummy_audios` (`vllm/multimodal/processing/dummy_inputs.py`) explicitly ignores `--limit-mm-per-prompt`'s `length` when it exceeds the model's default and only clamps downward. Setting `--mm-processor-kwargs '{"chunk_length": N}'` is also defeated by the literal `30` in the `min(...)`.

Unlike Whisper / `qwen2_audio` whose encoders have a fixed 30 s positional embedding (where the cap is architecturally meaningful), Qwen3-ASR's audio encoder splits features into `n_window*2` chunks and applies positional embedding *per chunk* via `cu_seqlens` (`max_source_positions=1500` is per-chunk, not total). The encoder supports arbitrarily long audio; the 30 s cap was a copy-paste artifact carried in unreviewed since the original Qwen3-ASR PR.

This PR drops the literal 30 cap and defers to `feature_extractor.chunk_length` directly, matching `funasr.py` and `fireredasr2.py`. Default behavior is unchanged for users who don't override `chunk_length`.

Refs #39408.

## Why this is not duplicating an existing PR

I searched open PRs for `qwen3_asr` / `chunk_length` / encoder-cache changes — none address this. There is an open issue (#39408) where a maintainer suggested `--limit-mm-per-prompt length` as a workaround, but that is decrease-only (see `_get_dummy_audios`); this PR fixes the root cause.

## Test plan

Tested on Linux x86_64, NVIDIA RTX PRO 4500 Blackwell, Python 3.12, `VLLM_USE_PRECOMPILED=1`.

**Lint:**
```
$ pre-commit run --files vllm/model_executor/models/qwen3_asr.py
ruff check.....Passed
ruff format....Passed
mypy...........Passed
(plus all other applicable hooks)
```

**Math sanity check** (no model load needed):
```
default chunk_length=30   → OLD audio_len=480000 (30s),  NEW audio_len=480000 (30s)   # unchanged
chunk_length=300 override → OLD audio_len=480000 (30s),  NEW audio_len=4800000 (300s) # scales
```

**Real-server boot log** (`vllm serve Qwen/Qwen3-ASR-0.6B --max-model-len 16384 --enforce-eager ...`):
| Config | Encoder cache budget log line |
|---|---|
| default (no `--mm-processor-kwargs`) | `... budget of **2048** tokens ...` (reproduces the bug) |
| `--mm-processor-kwargs '{"chunk_length": 300}'` | `... budget of **3900** tokens ...` (cap removed) |

Without this PR, the budget is locked at 2048 regardless of `chunk_length`. With this PR, raising `chunk_length` increases the budget — admitting longer audio at the per-item check in `vllm/v1/engine/input_processor.py`.

## AI assistance

AI assistance was used for the root-cause investigation and patch drafting. I (the submitter) reviewed every changed line and ran the lint and boot-log tests above.