### PR TITLE
[Bugfix] Detect WSL via kernel release/version, not hostname

### DIFF
--- a/tests/test_wsl_detection.py
+++ b/tests/test_wsl_detection.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import platform
+from unittest.mock import patch
+
+from vllm.platforms.interface import in_wsl
+
+
+def _uname(system="Linux", node="host", release="5.15.0", version="#1"):
+    # platform.uname() returns a named tuple; build one here so in_wsl() can
+    # read attributes (uname.release, uname.version) on the mock.
+    return platform.uname_result(system, node, release, version, "x86_64")
+
+
+def test_in_wsl_true_for_wsl2_release():
+    fake = _uname(release="5.15.167.4-microsoft-standard-WSL2")
+    with patch("vllm.platforms.interface.platform.uname", return_value=fake):
+        assert in_wsl()
+
+
+def test_in_wsl_true_for_wsl1_release():
+    fake = _uname(release="4.4.0-19041-Microsoft", version="#1234-Microsoft")
+    with patch("vllm.platforms.interface.platform.uname", return_value=fake):
+        assert in_wsl()
+
+
+def test_in_wsl_false_for_native_linux():
+    fake = _uname(release="6.10.0-generic")
+    with patch("vllm.platforms.interface.platform.uname", return_value=fake):
+        assert not in_wsl()
+
+
+def test_in_wsl_false_when_only_hostname_contains_microsoft():
+    # Regression test for #41933: a pod or host named e.g. "microsoft-pod-0"
+    # must not be detected as WSL.
+    fake = _uname(node="microsoft-pod-0", release="6.10.0-generic")
+    with patch("vllm.platforms.interface.platform.uname", return_value=fake):
+        assert not in_wsl()

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -32,7 +32,11 @@ logger = init_logger(__name__)
 
 def in_wsl() -> bool:
     # Reference: https://github.com/microsoft/WSL/issues/4071
-    return "microsoft" in " ".join(platform.uname()).lower()
+    # Inspect only the kernel release/version strings to avoid false positives
+    # from a hostname (uname.node) that happens to contain "microsoft", e.g.
+    # Kubernetes pods named "microsoft-*".
+    uname = platform.uname()
+    return "microsoft" in f"{uname.release} {uname.version}".lower()
 
 
 class PlatformEnum(enum.Enum):


### PR DESCRIPTION
## Purpose

Fixes #41933.

`in_wsl()` joined every field of `platform.uname()` (including the hostname/`node`) before searching for `"microsoft"`. Any system whose hostname contains `microsoft` is therefore misdetected as WSL, common in Kubernetes pods named `microsoft-*`. The downstream effect is that vLLM disables pinned memory and forces `spawn` multiprocessing on systems that are not WSL.

This restricts the substring check to `uname.release` and `uname.version`, where genuine WSL kernels expose `microsoft-standard-WSL2` (WSL2) or `Microsoft` (WSL1).

## Test Plan

`pytest tests/test_wsl_detection.py -v`

The new test mocks `platform.uname()` and asserts:

- WSL2 release (`5.15.167.4-microsoft-standard-WSL2`) -> detected
- WSL1 release (`4.4.0-19041-Microsoft`) -> detected
- Native Linux release -> not detected
- Hostname `microsoft-pod-0` on a native release -> not detected (regression for #41933)

## Test Result

```
tests/test_wsl_detection.py::test_in_wsl_true_for_wsl2_release PASSED
tests/test_wsl_detection.py::test_in_wsl_true_for_wsl1_release PASSED
tests/test_wsl_detection.py::test_in_wsl_false_for_native_linux PASSED
tests/test_wsl_detection.py::test_in_wsl_false_when_only_hostname_contains_microsoft PASSED
4 passed
```