### PR TITLE
 [Cache] Opt-in: stop caching KV blocks after thinking start tokens

### DIFF
--- a/vllm/config/cache.py
+++ b/vllm/config/cache.py
@@ -90,6 +90,10 @@ class CacheConfig:
     `ModelConfig` and that value should be manually duplicated here."""
     enable_prefix_caching: bool = True
     """Whether to enable prefix caching."""
+    strip_thinking_tokens_from_cache: bool = False
+    """Stop caching KV blocks once thinking start tokens are detected.
+    Improves prefix cache hit rates for reasoning models. Requires
+    --reasoning-parser or --reasoning-config to be set."""
     prefix_caching_hash_algo: PrefixCachingHashAlgo = "sha256"
     """Set the hash algorithm for prefix caching:
 
@@ -193,6 +197,7 @@ class CacheConfig:
             "is_attention_free",
             "num_gpu_blocks_override",
             "enable_prefix_caching",
+            "strip_thinking_tokens_from_cache",
             "prefix_caching_hash_algo",
             # Prefix-caching implementation detail (doesn't affect compiled graph).
             "hash_block_size",

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -1255,6 +1255,22 @@ class VllmConfig:
                     "the `reasoning_start_str` and `reasoning_end_str`."
                 )
 
+        if self.cache_config.strip_thinking_tokens_from_cache:
+            if not self.cache_config.enable_prefix_caching:
+                logger.warning_once(
+                    "--strip-thinking-tokens-from-cache has no effect when "
+                    "prefix caching is disabled. Disabling the feature."
+                )
+                self.cache_config.strip_thinking_tokens_from_cache = False
+            elif (self.reasoning_config is None
+                  or not self.reasoning_config.enabled):
+                logger.warning_once(
+                    "--strip-thinking-tokens-from-cache requires "
+                    "--reasoning-parser or a valid --reasoning-config. "
+                    "Disabling the feature."
+                )
+                self.cache_config.strip_thinking_tokens_from_cache = False
+
         # Hybrid KV cache manager (HMA) runtime rules:
         # - Explicit enable (--no-disable-kv-cache-manager): error if runtime
         #   disables it

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -487,6 +487,9 @@ class EngineArgs:
     )
     block_size: int | None = None
     enable_prefix_caching: bool | None = None
+    strip_thinking_tokens_from_cache: bool = (
+        CacheConfig.strip_thinking_tokens_from_cache
+    )
     prefix_caching_hash_algo: PrefixCachingHashAlgo = (
         CacheConfig.prefix_caching_hash_algo
     )
@@ -1085,6 +1088,10 @@ class EngineArgs:
                 **cache_kwargs["enable_prefix_caching"],
                 "default": None,
             },
+        )
+        cache_group.add_argument(
+            "--strip-thinking-tokens-from-cache",
+            **cache_kwargs["strip_thinking_tokens_from_cache"],
         )
         cache_group.add_argument(
             "--prefix-caching-hash-algo", **cache_kwargs["prefix_caching_hash_algo"]
@@ -1687,6 +1694,7 @@ class EngineArgs:
             num_gpu_blocks_override=self.num_gpu_blocks_override,
             sliding_window=sliding_window,
             enable_prefix_caching=self.enable_prefix_caching,
+            strip_thinking_tokens_from_cache=self.strip_thinking_tokens_from_cache,
             prefix_caching_hash_algo=self.prefix_caching_hash_algo,
             calculate_kv_scales=self.calculate_kv_scales,
             kv_cache_dtype_skip_layers=self.kv_cache_dtype_skip_layers,

--- a/vllm/v1/core/block_pool.py
+++ b/vllm/v1/core/block_pool.py
@@ -236,8 +236,10 @@ class BlockPool:
         """
         if num_cached_blocks >= num_full_blocks:
             return
+        num_full_blocks = min(num_full_blocks, len(request.block_hashes))
+        if num_cached_blocks >= num_full_blocks:
+            return
         new_full_blocks = blocks[num_cached_blocks:num_full_blocks]
-        assert len(request.block_hashes) >= num_full_blocks
         if block_size == self.hash_block_size:
             # Common case.
             block_hashes: BlockHashList = request.block_hashes

--- a/vllm/v1/core/kv_cache_utils.py
+++ b/vllm/v1/core/kv_cache_utils.py
@@ -632,15 +632,34 @@ def resolve_kv_cache_block_sizes(
     return scheduler_block_size, hash_block_size
 
 
+def _find_token_sequence(
+    token_ids: Sequence[int],
+    start_idx: int,
+    end_idx: int,
+    pattern: Sequence[int],
+) -> int | None:
+    plen = len(pattern)
+    if plen == 0:
+        return None
+    for i in range(start_idx, end_idx - plen + 1):
+        if list(token_ids[i:i + plen]) == list(pattern):
+            return i
+    return None
+
+
 def get_request_block_hasher(
     block_size: int,
     caching_hash_fn: Callable[[Any], bytes],
+    thinking_start_token_ids: Sequence[int] | None = None,
 ) -> Callable[[Request], list[BlockHash]]:
     """
     Returns a function which computes the list of un-computed block hashes
     of a request."""
 
     def request_block_hasher(request: Request) -> list[BlockHash]:
+        if thinking_start_token_ids and request._in_thinking_section:
+            return []
+
         start_token_idx = len(request.block_hashes) * block_size
         num_tokens = request.num_tokens
 
@@ -665,6 +684,17 @@ def get_request_block_hasher(
             if end_token_idx > num_tokens:
                 # We only hash full blocks
                 break
+
+            if thinking_start_token_ids is not None:
+                found = _find_token_sequence(
+                    request.all_token_ids,
+                    start_token_idx,
+                    end_token_idx,
+                    thinking_start_token_ids,
+                )
+                if found is not None:
+                    request._in_thinking_section = True
+                    break
 
             # MM and LoRA requests need extra keys for block-hash computation.
             extra_keys, curr_mm_idx = generate_block_hash_extra_keys(

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -285,6 +285,7 @@ class SingleTypeKVCacheManager(ABC):
         """
         num_cached_blocks = self.num_cached_block.get(request.request_id, 0)
         num_full_blocks = num_tokens // self.block_size
+        num_full_blocks = min(num_full_blocks, len(request.block_hashes))
 
         if num_cached_blocks >= num_full_blocks:
             return

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -206,8 +206,17 @@ class EngineCore:
             )
             init_none_hash(caching_hash_fn)
 
+            thinking_start_ids = None
+            if (vllm_config.cache_config.strip_thinking_tokens_from_cache
+                    and vllm_config.reasoning_config is not None
+                    and vllm_config.reasoning_config.enabled):
+                thinking_start_ids = (
+                    vllm_config.reasoning_config.reasoning_start_token_ids
+                )
+
             self.request_block_hasher = get_request_block_hasher(
-                hash_block_size, caching_hash_fn
+                hash_block_size, caching_hash_fn,
+                thinking_start_token_ids=thinking_start_ids,
             )
 
         self.step_fn = (

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -169,6 +169,7 @@ class Request:
         self.prefill_stats: PrefillStats | None = PrefillStats()
 
         self.block_hashes: list[BlockHash] = []
+        self._in_thinking_section: bool = False
         # Store the block hasher without binding self to avoid creating a
         # reference cycle (Request -> partial -> Request) that prevents
         # immediate garbage collection via reference counting.


### PR DESCRIPTION
# [Cache] Opt-in: stop caching KV blocks after thinking start tokens

## Motivation

Reasoning models (DeepSeek-R1, Qwen3, QwQ, etc.) produce `<think>...</think>` tokens whose content varies across requests even for identical prompts. Under prefix caching, these thinking blocks get hashed, cached, and never reused — pure waste of cache capacity that pressures eviction of actually-reusable prompt blocks.

## Approach

Instead of post-hoc cleanup or adding eviction-priority logic, we take the simplest possible path: once the thinking start token sequence is detected during incremental block hashing, we stop computing hashes for subsequent blocks. No hash means `cache_full_blocks` never registers them — they still exist in GPU memory for the current request but don't pollute the shared cache pool.

Changes:
- `kv_cache_utils.py`: extend `get_request_block_hasher` to accept `thinking_start_token_ids`; the inner closure scans each block and stops hashing once the pattern is found
- `request.py`: add `_in_thinking_section` flag per request
- `engine/core.py`: wire up token ids from `ReasoningConfig`
- `block_pool.py` / `single_type_kv_cache_manager.py`: relax the assumption that `len(block_hashes) >= num_full_blocks` (use min)
- `config/cache.py`: new field `strip_thinking_tokens_from_cache`
- `config/vllm.py`: validation (requires prefix caching + reasoning parser)
- `engine/arg_utils.py`: CLI flag `--strip-thinking-tokens-from-cache`

Default off. No behavioral change unless explicitly enabled.

## Test Plan

Unit tests (`tests/v1/core/test_strip_thinking_cache.py`):
- `_find_token_sequence` correctness (7 cases)
- block hasher stops at thinking boundary, incremental behavior, multi-token pattern, feature-off passthrough (22 cases)

Integration test (cache pressure A/B):

```bash
# Start server with feature enabled (artificially small cache to create pressure)
python -m vllm.entrypoints.openai.api_server \
  --model Qwen/Qwen3-14B \
  --reasoning-parser qwen3 \
  --strip-thinking-tokens-from-cache \
  --enable-prefix-caching \
  --max-model-len 1024 \
  --tensor-parallel-size 1 \
  --gpu-memory-utilization 0.22

# Send 20 concurrent identical requests (enable_thinking=true)
for i in $(seq 1 20); do
  curl -s http://localhost:8080/v1/chat/completions \
    -H "Content-Type: application/json" \
    -d '{"model":"Qwen3-14B","messages":[{"role":"user","content":"What is 2+3? Think step by step."}],"max_tokens":256,"chat_template_kwargs":{"enable_thinking":true}}' &
done
wait

# Check metrics
curl -s http://localhost:8080/metrics | grep prefix_cache
```

## Performance Results

Tested on Qwen3-14B, `--gpu-memory-utilization 0.22` (artificially small cache to create eviction pressure), 20 concurrent identical requests with `enable_thinking=true`:

| Metric | Feature ON | Feature OFF (baseline) |
|--------|:---:|:---:|
| prefix_cache_queries | 400 | 400 |
| prefix_cache_hits | 304 | 304 |
| Hit rate | 76.0% | 76.0% |
| **Peak GPU KV cache usage** | **92.4%** | **100.0%** |

Key observations:
- **7.6% reduction in peak GPU KV cache usage** with feature enabled — thinking blocks are not registered in the cache pool, freeing space for reusable entries.
- Prefix cache hit rate is identical (prompt blocks are reused equally in both modes), confirming the feature only affects thinking blocks.
- Feature OFF saturates the cache at 100%, meaning subsequent requests would trigger eviction of useful prompt blocks. Feature ON leaves headroom for future requests.
- In long-running high-concurrency scenarios, this translates to sustained higher effective cache hit rates as the cache doesn't fill with unreusable thinking blocks.
