### PR TITLE
[CI][Bugfix] Fix CI failures for "PyTorch Compilation Unit Tests"

### DIFF
--- a/vllm/compilation/compiler_interface.py
+++ b/vllm/compilation/compiler_interface.py
@@ -141,6 +141,10 @@ class AlwaysHitShapeEnv:
 
     def __init__(self) -> None:
         self.guards: list[Any] = []
+        # Read by torch._inductor.codecache.FxGraphHashDetails (torch>=2.11)
+        # to incorporate user-provided dynamic-shape hint overrides into the
+        # cache key. We never override hints, so an empty dict is correct.
+        self.var_to_hint_override: dict[Any, int] = {}
 
     def evaluate_guards_expression(self, *args: Any, **kwargs: Any) -> Literal[True]:
         return True


### PR DESCRIPTION
## Purpose

vLLM's duck-type `ShapeEnv` mock `AlwaysHitShapeEnv` (used by the legacy
`InductorAdaptor` path when `VLLM_USE_STANDALONE_COMPILE=0`) was missing
`var_to_hint_override`. `torch._inductor.codecache.FxGraphHashDetails`
reads it unconditionally in torch>=2.11, so engine-core init raised
`AttributeError` and surfaced as `Server exited unexpectedly` in CI.

Fix: add the attribute as an empty dict, matching the real `ShapeEnv` default.

Failed buildkite runs (all on unrelated HEAD commits):
- [#64813](https://buildkite.com/vllm/ci/builds/64813/canvas?sid=019dff97-0048-4cd7-86ed-5b90e0deb21d&tab=output)
- [#64851](https://buildkite.com/vllm/ci/builds/64851/canvas?sid=019e0091-b7e9-448d-8999-6fbf149aa8c6&tab=output)
- [#64855](https://buildkite.com/vllm/ci/builds/64855/canvas?sid=019e00cd-c4d6-4820-8d78-687b892f20db&tab=output)
- [#64859](https://buildkite.com/vllm/ci/builds/64859/canvas?sid=019e0106-dd08-49be-8dec-54ba2f84193a&tab=output)

Related to https://github.com/vllm-project/vllm/pull/41423

## Test Plan

## Test Result