### PR TITLE
[Bugfix] EPLB - Mistral

### DIFF
--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutlass_moe.py
@@ -286,10 +286,25 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
             and not self.use_deepseek_fp8_block_scale
         ):
             # FP8 per-tensor path: use global alphas/scales; do not pass input_sf
+            if self.moe_config.moe_parallel_config.enable_eplb:
+                # Account for weight scale rearrangement with EPLB
+                # TODO (varun): This is wasteful recomputation on every step.
+                # Hook this computation to EPLB rearrangement directly.
+
+                assert self.w1_scale is not None and self.w2_scale is not None
+                assert self.a1_scale is not None and self.a2_scale is not None
+                # w13_weight_scale * w13_input_scale
+                g1_alphas = (self.w1_scale * self.a1_scale).squeeze()
+                # w2_weight_scale * w2_input_scale
+                g2_alphas = (self.w2_scale * self.a2_scale).squeeze()
+            else:
+                # Use precomputed g1_alphas, g2_alphas
+                g1_alphas, g2_alphas = self.g1_alphas, self.g2_alphas
+
             quant_scales = [
-                self.g1_alphas,  # w13_weight_scale * w13_input_scale
+                g1_alphas,  # w13_weight_scale * w13_input_scale
                 self.a2_gscale,  # 1.0 / w2_input_scale
-                self.g2_alphas,  # w2_weight_scale * w2_input_scale
+                g2_alphas,  # w2_weight_scale * w2_input_scale
                 self.a1_scale,
             ]
 

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -920,6 +920,36 @@ class MixtureOfExperts(Protocol):
     ) -> None: ...
 
 
+def get_mixture_of_experts_model(model: object) -> MixtureOfExperts | None:
+    """
+    Given an arbitrary model,
+     - if the model itself is a MixtureOfExperts, return the model directly.
+     - if the model is a multi-modal model, and its `language_model` is a
+       MixtureOfExperts, return the `language_model`.
+     - if neither, return None.
+
+    :param model: Model being served.
+    :type model: object
+    :return: Return MixtureOfExperts instance contained within the model.
+    :rtype: MixtureOfExperts | None
+    """
+
+    if is_mixture_of_experts(model):
+        return model
+
+    if isinstance(model, SupportsMultiModal):
+        try:
+            mm_language_model = model.get_language_model()
+            return (
+                mm_language_model if is_mixture_of_experts(mm_language_model) else None
+            )
+        except (NotImplementedError, AttributeError):
+            logger.info_once("Cannot fetch language_model from MultiModal model")
+            return None
+
+    return None
+
+
 def is_mixture_of_experts(model: object) -> TypeIs[MixtureOfExperts]:
     return (
         isinstance(model, MixtureOfExperts) and getattr(model, "num_moe_layers", 0) > 0

--- a/vllm/v1/worker/gpu/eplb_utils.py
+++ b/vllm/v1/worker/gpu/eplb_utils.py
@@ -10,7 +10,7 @@ import torch.nn as nn
 
 from vllm.distributed.eplb.eplb_state import EplbState
 from vllm.logger import init_logger
-from vllm.model_executor.models.interfaces import is_mixture_of_experts
+from vllm.model_executor.models.interfaces import get_mixture_of_experts_model
 
 logger = init_logger(__name__)
 
@@ -64,7 +64,8 @@ class EPLBController:
             return False
 
         draft_model = speculator.model
-        if not is_mixture_of_experts(draft_model):
+        draft_moe_model = get_mixture_of_experts_model(draft_model)
+        if draft_moe_model is None:
             return False
 
         assert not self.parallel_config.enable_elastic_ep, (
@@ -74,7 +75,7 @@ class EPLBController:
         assert speculative_config.draft_model_config is not None
         assert self.state is not None
         self.state.add_model(
-            draft_model,
+            draft_moe_model,
             speculative_config.draft_model_config,
         )
         self._has_registered_models = True
@@ -89,12 +90,15 @@ class EPLBController:
         if not self.parallel_config.enable_eplb or load_dummy_weights:
             return False
 
-        if not is_mixture_of_experts(model):
+        moe_model = get_mixture_of_experts_model(model)
+        if moe_model is None:
             return False
 
-        logger.info_once("EPLB is enabled for model %s.", model_config.model)
+        logger.info_once(
+            "EPLB is enabled for MoE part of model %s.", model_config.model
+        )
         assert self.state is not None
-        self.state.add_model(model, model_config)
+        self.state.add_model(moe_model, model_config)
         self._has_registered_models = True
         return True
 
@@ -128,10 +132,11 @@ class EPLBController:
         expanded_physical_to_logical: torch.Tensor,
         old_num_physical_experts: int,
     ) -> None:
-        assert is_mixture_of_experts(model)
+        moe_model = get_mixture_of_experts_model(model)
+        assert moe_model is not None
 
         self.state = EplbState.from_mapping(
-            model=model,
+            model=moe_model,
             model_config=model_config,
             device=self.device,
             parallel_config=self.parallel_config,

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -77,7 +77,7 @@ from vllm.model_executor.models.interfaces import (
     SupportsMRoPE,
     SupportsMultiModal,
     SupportsXDRoPE,
-    is_mixture_of_experts,
+    get_mixture_of_experts_model,
     supports_eagle3,
     supports_mrope,
     supports_multimodal_pruning,
@@ -3173,8 +3173,7 @@ class GPUModelRunner(
             return
 
         assert self.eplb_state is not None
-        model = self.get_model()
-        assert is_mixture_of_experts(model)
+        assert get_mixture_of_experts_model(self.get_model()) is not None
         self.eplb_state.step(
             is_dummy,
             is_profile,
@@ -3187,10 +3186,11 @@ class GPUModelRunner(
         old_num_physical_experts: int,
     ) -> None:
         model = self.get_model()
-        assert is_mixture_of_experts(model)
+        moe_model = get_mixture_of_experts_model(model)
+        assert moe_model is not None
 
         self.eplb_state = EplbState.from_mapping(
-            model=model,
+            model=moe_model,
             model_config=self.model_config,
             device=self.device,
             parallel_config=self.parallel_config,
@@ -4886,10 +4886,16 @@ class GPUModelRunner(
                 if hasattr(self, "drafter"):
                     logger.info_once("Loading drafter model...")
                     self.drafter.load_model(self.model)
+
                     if (
-                        hasattr(self.drafter, "model")
-                        and is_mixture_of_experts(self.drafter.model)
-                        and self.parallel_config.enable_eplb
+                        self.parallel_config.enable_eplb
+                        and hasattr(self.drafter, "model")
+                        and (
+                            drafter_moe_model := get_mixture_of_experts_model(
+                                self.drafter.model
+                            )
+                        )
+                        is not None
                     ):
                         assert not self.parallel_config.enable_elastic_ep, (
                             "Elastic EP is not supported with drafter model."
@@ -4898,7 +4904,7 @@ class GPUModelRunner(
                         assert spec_config is not None
                         assert spec_config.draft_model_config is not None
                         logger.info_once(
-                            "EPLB is enabled for drafter model %s.",
+                            "EPLB is enabled for MoE part of drafter model %s.",
                             spec_config.draft_model_config.model,
                         )
                         if self.eplb_state is None:
@@ -4906,7 +4912,7 @@ class GPUModelRunner(
                                 self.parallel_config, self.device
                             )
                         self.eplb_state.add_model(
-                            self.drafter.model,
+                            drafter_moe_model,
                             spec_config.draft_model_config,
                         )
                         eplb_models += 1
@@ -4934,17 +4940,18 @@ class GPUModelRunner(
                     self.model.set_aux_hidden_state_layers(aux_layers)
 
                 if (
-                    is_mixture_of_experts(self.model)
-                    and self.parallel_config.enable_eplb
+                    self.parallel_config.enable_eplb
                     and not load_dummy_weights
+                    and (moe_model := get_mixture_of_experts_model(self.model))
+                    is not None
                 ):
                     logger.info_once(
-                        "EPLB is enabled for model %s.",
+                        "EPLB is enabled for MoE part of model %s.",
                         self.model_config.model,
                     )
                     assert self.eplb_state is not None
                     self.eplb_state.add_model(
-                        self.model,
+                        moe_model,
                         self.model_config,
                     )
                     eplb_models += 1
@@ -4984,8 +4991,8 @@ class GPUModelRunner(
         )  # Temporary hack for dynamic res video w/o support for bs>1 yet
 
         if (
-            is_mixture_of_experts(self.model)
-            and self.parallel_config.enable_eplb
+            self.parallel_config.enable_eplb
+            and get_mixture_of_experts_model(self.model) is not None
             and not load_dummy_weights
             and self.eplb_state is not None
             and self.eplb_state.is_async


### PR DESCRIPTION
## Purpose
on `main` running 

```
vllm serve mistralai/Mistral-Small-4-119B-2603  --data-parallel-size 2 --enable-expert-parallel  --enable-eplb --eplb-config '{"window_size":100, "step_interval":10, "num_redundant_experts":0, "log_balancedness":true}' --port 9010
```
hits the ValueError 
```
ValueError: enable_eplb=True requiere expert_load_view != None
```

## Fix
Mistral 3 Small is a multi-modal model that contains within it, an MoE language model. Even though the model as a whole is not an MoE model, the language model is an MoE. EPLB on main, works only if the entire model is an MoE model. This PR, adds additional logic to detect if the given model contains an MoE language_model and plumbs it correctly to the EPLB interface.

This should also fix similar issues with mistralai/Mistral-Large-3-675B-Instruct-2512

## Test Plan

server command without EPLB : 
```
canhazgpu run -g2 -- vllm serve mistralai/Mistral-Small-4-119B-2603  --data-parallel-size 2 --enable-expert-parallel --port 9010
```

server command with EPLB : 
```
canhazgpu run -g2 -- vllm serve mistralai/Mistral-Small-4-119B-2603  --data-parallel-size 2 --enable-expert-parallel  --enable-eplb --eplb-config '{"window_size":100, "step_interval":10, "num_redundant_experts":0, "log_balancedness":true}' --port 9010
```

lm_eval command : 
```
lm_eval --model local-completions --model_args model=mistralai/Mistral-Small-4-119B-2603,base_url=http://127.0.0.1:9010/v1/completions,tokenized_requests=False,num_concurrent=100,trust_remote_code=True --tasks gsm8k
```

## Test Result
without EPLB 
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8560|±  |0.0097|
|     |       |strict-match    |     5|exact_match|↑  |0.8264|±  |0.0104|
```

with EPLB
```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.8484|±  |0.0099|
|     |       |strict-match    |     5|exact_match|↑  |0.8294|±  |0.0104|
```

Also tested regression with Qwen/Qwen3-30B-A3B-FP8