### PR TITLE
[CI][Bugfix] Surface subprocess output in spawn_new_process_for_each_test

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1511,6 +1511,16 @@ def fork_new_process_for_each_test(func: Callable[_P, None]) -> Callable[_P, Non
     return wrapper
 
 
+def _format_subprocess_exit(returncode: int) -> str:
+    """Render a subprocess exit code, naming the signal for negative codes."""
+    if returncode >= 0:
+        return f"exit code {returncode}"
+    try:
+        return f"killed by {signal.Signals(-returncode).name} ({returncode})"
+    except ValueError:
+        return f"exit code {returncode}"
+
+
 # Set on the spawn-child interpreter so the wrapper short-circuits when the
 # child resolves `module.qualname` back to its own decorated form, instead of
 # launching another subprocess.
@@ -1531,6 +1541,12 @@ def spawn_new_process_for_each_test(f: Callable[_P, None]) -> Callable[_P, None]
     ``vllm.compilation.counter.compilation_counter``) into stale clones in
     the child, so increments performed by the production code in the child
     would never be observable to the test.
+
+    The child inherits the parent's stdout/stderr so its output (engine
+    cores, NCCL, CUDA, ...) reaches the test runner live; the Python-level
+    traceback is serialized to ``tb_file`` for structured re-raising. A
+    native crash leaves ``tb_file`` empty — the diagnostic is then only in
+    the inherited subprocess output.
     """
 
     @functools.wraps(f)
@@ -1581,23 +1597,20 @@ def spawn_new_process_for_each_test(f: Callable[_P, None]) -> Callable[_P, None]
             result = subprocess.run(
                 [sys.executable, "-c", child_script],
                 input=payload,
-                capture_output=True,
                 env=env,
             )
 
             if result.returncode != 0:
-                # Prefer the child's traceback file; fall back to stderr if
-                # the child crashed before its except handler ran.
                 try:
                     with open(tb_file) as fp:
                         tb = fp.read()
                 except OSError:
                     tb = ""
                 if not tb:
-                    tb = result.stderr.decode()
+                    tb = "<no Python traceback; see subprocess output above>"
                 raise RuntimeError(
                     f"Test subprocess '{f.__name__}' failed "
-                    f"(exit code {result.returncode}):\n{tb}"
+                    f"({_format_subprocess_exit(result.returncode)}):\n{tb}"
                 )
         finally:
             with contextlib.suppress(OSError):


### PR DESCRIPTION
## Purpose

`spawn_new_process_for_each_test` calls `subprocess.run(..., capture_output=True)` and then drops `result.stderr`/`stdout` whenever the child writes a Python traceback — i.e. on every failure. Engine-core, NCCL and CUDA output is hidden, which is where the actual cause of crashes lives (e.g. the whisper TP=2 failures in [#64813](https://buildkite.com/vllm/ci/builds/64813/canvas?sid=019dff97-0022-45c2-a55a-4af22ee39152&tab=output) / [#64851](https://buildkite.com/vllm/ci/builds/64851/canvas?sid=019e0091-b7d0-4548-bb8d-e88daa50400e&tab=output) / [#64859](https://buildkite.com/vllm/ci/builds/64859/canvas?sid=019e0106-dcf2-4bb8-b0f9-c3c08fedfa90&tab=output) show `Failed core proc(s): {}` with zero engine-subprocess lines).

Drop `capture_output=True` so the child inherits the parent's stdout/stderr, mirroring `fork_new_process_for_each_test`. `tb_file` still re-raises the Python traceback in the parent. A small helper renders signal exits as `killed by SIGSEGV (-11)`.

Related to #41423

## Test Plan

## Test Result