### PR TITLE
[Bugfix] Add Pixtral processor image token properties

### DIFF
--- a/tests/transformers_utils/processors/test_pixtral.py
+++ b/tests/transformers_utils/processors/test_pixtral.py
@@ -4,6 +4,7 @@
 from dataclasses import dataclass
 
 import pytest
+from mistral_common.tokens.tokenizers.base import SpecialTokens
 
 from vllm.transformers_utils.processors import pixtral as pixtral_module
 from vllm.transformers_utils.processors.pixtral import (
@@ -45,45 +46,18 @@ def processor():
     )
 
 
-def test_integer_token_ids(processor):
-    """Integer IDs derived from mistral-common special_ids."""
+def test_token_attributes(processor):
+    """Token IDs, string names, and HF-compatible aliases are all correct."""
     assert processor.image_token_id == 11
     assert processor.image_break_id == 10
     assert processor.image_end_id == 12
 
+    assert processor.image_token == SpecialTokens.img.value
+    assert processor.image_break_token == SpecialTokens.img_break.value
+    assert processor.image_end_token == SpecialTokens.img_end.value
 
-def test_string_token_names(processor):
-    """String tokens match canonical Pixtral vocabulary names."""
-    assert processor.image_token == "[IMG]"
-    assert processor.image_break_token == "[IMG_BREAK]"
-    assert processor.image_end_token == "[IMG_END]"
-
-
-def test_hf_compatible_token_id_aliases(processor):
-    """HF PixtralProcessor-style _token_id aliases agree with base IDs."""
     assert processor.image_break_token_id == processor.image_break_id
     assert processor.image_end_token_id == processor.image_end_id
-
-
-def test_token_properties_are_instance_attributes(processor):
-    """All token attributes must be plain instance attributes, not properties,
-    so that code doing ``vocab[processor.image_break_token]`` or direct
-    assignment works identically to HF PixtralProcessor."""
-    cls = type(processor)
-    for attr in (
-        "image_token",
-        "image_break_token",
-        "image_end_token",
-        "image_token_id",
-        "image_break_token_id",
-        "image_end_token_id",
-    ):
-        assert not isinstance(getattr(cls, attr, None), property), (
-            f"{attr} must be an instance attribute, not a @property"
-        )
-        assert attr in processor.__dict__, (
-            f"{attr} must be set in __init__, not inherited"
-        )
 
 
 def test_image_processor_fetch_images_accepts_images_and_lists(monkeypatch):
@@ -106,4 +80,7 @@ def test_image_processor_fetch_images_rejects_invalid_input(monkeypatch):
 
 
 def test_replace_image_token_is_noop_for_mistral_template_tokens(processor):
-    assert processor.replace_image_token(processed_images={}, image_idx=0) == "[IMG]"
+    assert (
+        processor.replace_image_token(processed_images={}, image_idx=0)
+        == SpecialTokens.img.value
+    )

--- a/tests/transformers_utils/processors/test_pixtral.py
+++ b/tests/transformers_utils/processors/test_pixtral.py
@@ -5,7 +5,11 @@ from dataclasses import dataclass
 
 import pytest
 
-from vllm.transformers_utils.processors.pixtral import MistralCommonPixtralProcessor
+from vllm.transformers_utils.processors import pixtral as pixtral_module
+from vllm.transformers_utils.processors.pixtral import (
+    MistralCommonImageProcessor,
+    MistralCommonPixtralProcessor,
+)
 
 pytestmark = pytest.mark.skip_global_cleanup
 
@@ -80,3 +84,26 @@ def test_token_properties_are_instance_attributes(processor):
         assert attr in processor.__dict__, (
             f"{attr} must be set in __init__, not inherited"
         )
+
+
+def test_image_processor_fetch_images_accepts_images_and_lists(monkeypatch):
+    image_processor = MistralCommonImageProcessor(FakeImageEncoder())
+    image = object()
+    monkeypatch.setattr(
+        pixtral_module, "is_valid_image", lambda candidate: candidate is image
+    )
+
+    assert image_processor.fetch_images(image) is image
+    assert image_processor.fetch_images([image, (image,)]) == [image, [image]]
+
+
+def test_image_processor_fetch_images_rejects_invalid_input(monkeypatch):
+    image_processor = MistralCommonImageProcessor(FakeImageEncoder())
+    monkeypatch.setattr(pixtral_module, "is_valid_image", lambda candidate: False)
+
+    with pytest.raises(TypeError, match="only a single or a list of entries"):
+        image_processor.fetch_images(object())
+
+
+def test_replace_image_token_is_noop_for_mistral_template_tokens(processor):
+    assert processor.replace_image_token(processed_images={}, image_idx=0) == "[IMG]"

--- a/tests/transformers_utils/processors/test_pixtral.py
+++ b/tests/transformers_utils/processors/test_pixtral.py
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import dataclass
+
+import pytest
+
+from vllm.transformers_utils.processors.pixtral import MistralCommonPixtralProcessor
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+@dataclass
+class FakeSpecialIds:
+    img_break: int = 10
+    img: int = 11
+    img_end: int = 12
+
+
+class FakeImageEncoder:
+    special_ids = FakeSpecialIds()
+
+
+class FakeImageProcessor:
+    mm_encoder = FakeImageEncoder()
+
+
+class FakeTransformersTokenizer:
+    pass
+
+
+class FakeTokenizer:
+    transformers_tokenizer = FakeTransformersTokenizer()
+
+
+@pytest.fixture()
+def processor():
+    return MistralCommonPixtralProcessor(
+        tokenizer=FakeTokenizer(),
+        image_processor=FakeImageProcessor(),
+    )
+
+
+def test_integer_token_ids(processor):
+    """Integer IDs derived from mistral-common special_ids."""
+    assert processor.image_token_id == 11
+    assert processor.image_break_id == 10
+    assert processor.image_end_id == 12
+
+
+def test_string_token_names(processor):
+    """String tokens match canonical Pixtral vocabulary names."""
+    assert processor.image_token == "[IMG]"
+    assert processor.image_break_token == "[IMG_BREAK]"
+    assert processor.image_end_token == "[IMG_END]"
+
+
+def test_hf_compatible_token_id_aliases(processor):
+    """HF PixtralProcessor-style _token_id aliases agree with base IDs."""
+    assert processor.image_break_token_id == processor.image_break_id
+    assert processor.image_end_token_id == processor.image_end_id
+
+
+def test_token_properties_are_instance_attributes(processor):
+    """All token attributes must be plain instance attributes, not properties,
+    so that code doing ``vocab[processor.image_break_token]`` or direct
+    assignment works identically to HF PixtralProcessor."""
+    cls = type(processor)
+    for attr in (
+        "image_token",
+        "image_break_token",
+        "image_end_token",
+        "image_token_id",
+        "image_break_token_id",
+        "image_end_token_id",
+    ):
+        assert not isinstance(getattr(cls, attr, None), property), (
+            f"{attr} must be an instance attribute, not a @property"
+        )
+        assert attr in processor.__dict__, (
+            f"{attr} must be set in __init__, not inherited"
+        )

--- a/vllm/transformers_utils/processors/pixtral.py
+++ b/vllm/transformers_utils/processors/pixtral.py
@@ -1,11 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+from typing import Any
+
 import torch
 from mistral_common.protocol.instruct.chunk import ImageChunk
 from mistral_common.tokens.tokenizers.multimodal import ImageEncoder
 from PIL import Image
 from transformers import BatchFeature, ProcessorMixin, TensorType
-from transformers.image_utils import ImageInput
+from transformers.image_utils import ImageInput, is_valid_image, load_image
 
 from vllm.tokenizers.mistral import MistralTokenizer
 
@@ -46,6 +48,20 @@ class MistralCommonImageProcessor:
         ncols, nrows = self.mm_encoder._image_to_num_tokens(image)
         return ncols * nrows, nrows, ncols
 
+    def fetch_images(self, image_url_or_urls: Any) -> Any:
+        if isinstance(image_url_or_urls, (list, tuple)):
+            return [self.fetch_images(image) for image in image_url_or_urls]
+        if isinstance(image_url_or_urls, str):
+            return load_image(image_url_or_urls)
+        if is_valid_image(image_url_or_urls):
+            return image_url_or_urls
+
+        msg = (
+            "only a single or a list of entries is supported but got "
+            f"type={type(image_url_or_urls)}"
+        )
+        raise TypeError(msg)
+
 
 class MistralCommonPixtralProcessor(ProcessorMixin):
     attributes = ["image_processor", "tokenizer"]
@@ -77,3 +93,11 @@ class MistralCommonPixtralProcessor(ProcessorMixin):
         # HF PixtralProcessor-compatible aliases for the integer token IDs.
         self.image_break_token_id = self.image_break_id
         self.image_end_token_id = self.image_end_id
+
+    def replace_image_token(
+        self,
+        processed_images: BatchFeature,
+        image_idx: int = 0,
+    ) -> str:
+        # Mistral chat templates already insert Pixtral image placeholders.
+        return self.image_token

--- a/vllm/transformers_utils/processors/pixtral.py
+++ b/vllm/transformers_utils/processors/pixtral.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import torch
 from mistral_common.protocol.instruct.chunk import ImageChunk
+from mistral_common.tokens.tokenizers.base import SpecialTokens
 from mistral_common.tokens.tokenizers.multimodal import ImageEncoder
 from PIL import Image
 from transformers import BatchFeature, ProcessorMixin, TensorType
@@ -86,9 +87,9 @@ class MistralCommonPixtralProcessor(ProcessorMixin):
 
         # String tokens match the canonical Pixtral vocabulary names used by
         # HF PixtralProcessor, making this class a drop-in replacement.
-        self.image_token = "[IMG]"
-        self.image_break_token = "[IMG_BREAK]"
-        self.image_end_token = "[IMG_END]"
+        self.image_token = SpecialTokens.img.value
+        self.image_break_token = SpecialTokens.img_break.value
+        self.image_end_token = SpecialTokens.img_end.value
 
         # HF PixtralProcessor-compatible aliases for the integer token IDs.
         self.image_break_token_id = self.image_break_id

--- a/vllm/transformers_utils/processors/pixtral.py
+++ b/vllm/transformers_utils/processors/pixtral.py
@@ -67,3 +67,13 @@ class MistralCommonPixtralProcessor(ProcessorMixin):
         self.image_break_id = image_special_ids.img_break
         self.image_token_id = image_special_ids.img
         self.image_end_id = image_special_ids.img_end
+
+        # String tokens match the canonical Pixtral vocabulary names used by
+        # HF PixtralProcessor, making this class a drop-in replacement.
+        self.image_token = "[IMG]"
+        self.image_break_token = "[IMG_BREAK]"
+        self.image_end_token = "[IMG_END]"
+
+        # HF PixtralProcessor-compatible aliases for the integer token IDs.
+        self.image_break_token_id = self.image_break_id
+        self.image_end_token_id = self.image_end_id


### PR DESCRIPTION
## Purpose

- Fix processor interface mismatch. Mistral3DummyInputsBuilder and Mistral3MultiModalProcessor expect Pixtral processors to expose HF-style properties like image_token, image_break_token, and image_end_token, but the Mistral-common Pixtral adapter only exposes numeric IDs. That can cause AttributeError when using Mistral3/Pixtral through the Mistral tokenizer path.
- Add HF-compatible Pixtral image token string properties to `MistralCommonPixtralProcessor`.
- Add image break/end token-id alias properties.

## Test Plan

- Add focused unit coverage for the processor interface.
- `python -m pytest tests/transformers_utils/processors/test_pixtral.py -v'`

## Test Result

- Result: `4 passed`.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

