### PR TITLE
[Bugfix] Forward tokenization kwargs for token prompts

### DIFF
--- a/tests/inputs/test_preprocess.py
+++ b/tests/inputs/test_preprocess.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.inputs.preprocess import InputPreprocessor
+
+pytestmark = pytest.mark.skip_global_cleanup
+
+
+class FakeTokenizationParams:
+    def with_kwargs(self, **kwargs):
+        return kwargs
+
+
+class FakeRenderer:
+    default_cmpl_tok_params = FakeTokenizationParams()
+
+    def _tokenize_singleton_prompt(self, prompt, tokenization_params):
+        truncate_prompt_tokens = tokenization_params.get("truncate_prompt_tokens")
+        prompt_token_ids = prompt["prompt_token_ids"]
+        if truncate_prompt_tokens is not None:
+            prompt_token_ids = prompt_token_ids[-truncate_prompt_tokens:]
+        return {"prompt_token_ids": prompt_token_ids}
+
+
+def test_prompt_token_ids_respect_tokenization_kwargs():
+    preprocessor = object.__new__(InputPreprocessor)
+    preprocessor.renderer = FakeRenderer()
+
+    inputs = preprocessor._prompt_to_llm_inputs(
+        {"prompt_token_ids": [1, 2, 3, 4]},
+        tokenization_kwargs={"truncate_prompt_tokens": 2},
+    )
+
+    assert inputs["prompt_token_ids"] == [3, 4]

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -217,7 +217,10 @@ class InputPreprocessor:
             return self._process_embeds(prompt)  # type: ignore[arg-type]
 
         if "prompt_token_ids" in prompt:
-            return self._process_tokens(prompt)  # type: ignore[arg-type]
+            return self._process_tokens(  # type: ignore[arg-type]
+                prompt,
+                tokenization_kwargs=tokenization_kwargs,
+            )
 
         if "prompt" in prompt:
             return self._process_text(

--- a/vllm/inputs/preprocess.py
+++ b/vllm/inputs/preprocess.py
@@ -217,8 +217,8 @@ class InputPreprocessor:
             return self._process_embeds(prompt)  # type: ignore[arg-type]
 
         if "prompt_token_ids" in prompt:
-            return self._process_tokens(  # type: ignore[arg-type]
-                prompt,
+            return self._process_tokens(
+                prompt,  # type: ignore[arg-type]
                 tokenization_kwargs=tokenization_kwargs,
             )
 


### PR DESCRIPTION
## Purpose

- Forward `tokenization_kwargs` into the `prompt_token_ids` preprocessing path.
- Fixes pre-tokenized prompts skipping options such as `truncate_prompt_tokens`.

## Test Plan

- Add a focused regression test with a fake renderer.
- `pytest tests/inputs/test_preprocess.py -v`

## Test Result

- `1 passed`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

