### PR TITLE
[Bugfix] Stop Harmony stream parsing after parser errors

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -5,7 +5,7 @@ import json
 from contextlib import suppress
 from dataclasses import dataclass, field
 from typing import Any
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import pytest_asyncio
@@ -1269,6 +1269,22 @@ class TestServingChatWithHarmony:
             },
         ]
 
+    @dataclass
+    class MockFailingHarmonyParser:
+        token_deltas: dict[int, str] = field(default_factory=dict)
+        fail_on: set[int] = field(default_factory=set)
+        messages: list[Any] = field(default_factory=list)
+        current_channel: str | None = None
+        current_recipient: str | None = None
+        last_content_delta: str = ""
+
+        def process(self, token_id: int) -> None:
+            if token_id in self.fail_on:
+                raise RuntimeError(f"invalid harmony token {token_id}")
+            self.current_channel = "final"
+            self.current_recipient = None
+            self.last_content_delta = self.token_deltas.get(token_id, "")
+
     async def generate_response_from_harmony_str(
         self,
         serving_chat: OpenAIServingChat,
@@ -1314,6 +1330,228 @@ class TestServingChatWithHarmony:
         if stream:
             return await accumulate_streaming_response(result)
         return await result
+
+    def mock_request_output_for_choices(
+        self,
+        req: ChatCompletionRequest,
+        outputs: list[CompletionOutput],
+        *,
+        finished: bool = False,
+    ) -> RequestOutput:
+        return RequestOutput(
+            request_id=req.request_id,
+            prompt=[],
+            prompt_token_ids=[],
+            prompt_logprobs=None,
+            outputs=outputs,
+            finished=finished,
+        )
+
+    @pytest.mark.asyncio
+    @pytest.mark.skip_global_cleanup
+    async def test_streaming_choice_level_parser_failures_do_not_block_success(
+        self, serving_chat
+    ):
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            n=2,
+            stream=True,
+        )
+        parsers = [
+            self.MockFailingHarmonyParser(token_deltas={1: "A"}),
+            self.MockFailingHarmonyParser(fail_on={99}),
+        ]
+        consumed_outputs = 0
+
+        async def result_generator():
+            nonlocal consumed_outputs
+            consumed_outputs += 1
+            yield self.mock_request_output_for_choices(
+                req,
+                [
+                    CompletionOutput(
+                        index=0,
+                        text="",
+                        token_ids=[1],
+                        cumulative_logprob=0.0,
+                        logprobs=None,
+                    ),
+                    CompletionOutput(
+                        index=1,
+                        text="",
+                        token_ids=[99],
+                        cumulative_logprob=0.0,
+                        logprobs=None,
+                    ),
+                ],
+            )
+            consumed_outputs += 1
+            yield self.mock_request_output_for_choices(
+                req,
+                [
+                    CompletionOutput(
+                        index=0,
+                        text="",
+                        token_ids=[],
+                        cumulative_logprob=0.0,
+                        logprobs=None,
+                        finish_reason="stop",
+                    ),
+                ],
+            )
+            consumed_outputs += 1
+            yield self.mock_request_output_for_choices(
+                req,
+                [
+                    CompletionOutput(
+                        index=1,
+                        text="",
+                        token_ids=[100],
+                        cumulative_logprob=0.0,
+                        logprobs=None,
+                    ),
+                ],
+            )
+
+        chunks = []
+        with patch(
+            "vllm.entrypoints.openai.chat_completion.serving."
+            "get_streamable_parser_for_assistant",
+            side_effect=parsers,
+        ):
+            async for chunk in serving_chat.chat_completion_stream_generator(
+                request=req,
+                result_generator=result_generator(),
+                request_id=req.request_id,
+                model_name=req.model,
+                conversation=[],
+                tokenizer=get_tokenizer(req.model),
+                request_metadata=RequestResponseMetadata(
+                    request_id=req.request_id,
+                    model_name=req.model,
+                ),
+            ):
+                chunks.append(chunk)
+
+        assert consumed_outputs == 2
+        assert chunks[-1] == "data: [DONE]\n\n"
+        assert not any(
+            "All Harmony parser choices failed during streaming" in chunk
+            for chunk in chunks
+        )
+
+        content_by_choice: dict[int, str] = {0: "", 1: ""}
+        finish_reason_by_choice: dict[int, str] = {}
+        stop_reason_by_choice: dict[int, str] = {}
+        for chunk in chunks:
+            if not chunk.startswith("data: {"):
+                continue
+            data = json.loads(chunk[6:].strip())
+            for choice in data.get("choices", []):
+                idx = choice["index"]
+                delta = choice.get("delta", {})
+                content_by_choice[idx] += delta.get("content") or ""
+                if choice.get("finish_reason") is not None:
+                    finish_reason_by_choice[idx] = choice["finish_reason"]
+                if choice.get("stop_reason") is not None:
+                    stop_reason_by_choice[idx] = choice["stop_reason"]
+
+        assert content_by_choice[0] == "A"
+        assert content_by_choice[1] == ""
+        assert finish_reason_by_choice == {0: "stop", 1: "error"}
+        assert stop_reason_by_choice[1] == "error"
+
+    @pytest.mark.asyncio
+    @pytest.mark.skip_global_cleanup
+    async def test_streaming_fails_fast_when_all_harmony_choices_fail(
+        self, serving_chat
+    ):
+        req = ChatCompletionRequest(
+            model=MODEL_NAME,
+            messages=[{"role": "user", "content": "hello"}],
+            n=2,
+            stream=True,
+        )
+        parsers = [
+            self.MockFailingHarmonyParser(fail_on={11}),
+            self.MockFailingHarmonyParser(fail_on={22}),
+        ]
+        consumed_outputs = 0
+
+        async def result_generator():
+            nonlocal consumed_outputs
+            consumed_outputs += 1
+            yield self.mock_request_output_for_choices(
+                req,
+                [
+                    CompletionOutput(
+                        index=0,
+                        text="",
+                        token_ids=[11],
+                        cumulative_logprob=0.0,
+                        logprobs=None,
+                    ),
+                    CompletionOutput(
+                        index=1,
+                        text="",
+                        token_ids=[22],
+                        cumulative_logprob=0.0,
+                        logprobs=None,
+                    ),
+                ],
+            )
+            consumed_outputs += 1
+            yield self.mock_request_output_for_choices(
+                req,
+                [
+                    CompletionOutput(
+                        index=0,
+                        text="",
+                        token_ids=[33],
+                        cumulative_logprob=0.0,
+                        logprobs=None,
+                    ),
+                ],
+            )
+
+        chunks = []
+        with patch(
+            "vllm.entrypoints.openai.chat_completion.serving."
+            "get_streamable_parser_for_assistant",
+            side_effect=parsers,
+        ):
+            async for chunk in serving_chat.chat_completion_stream_generator(
+                request=req,
+                result_generator=result_generator(),
+                request_id=req.request_id,
+                model_name=req.model,
+                conversation=[],
+                tokenizer=get_tokenizer(req.model),
+                request_metadata=RequestResponseMetadata(
+                    request_id=req.request_id,
+                    model_name=req.model,
+                ),
+            ):
+                chunks.append(chunk)
+
+        assert consumed_outputs == 1
+        assert chunks[-1] == "data: [DONE]\n\n"
+
+        finish_reason_by_choice: dict[int, str] = {}
+        stop_reason_by_choice: dict[int, str] = {}
+        for chunk in chunks:
+            if not chunk.startswith("data: {"):
+                continue
+            data = json.loads(chunk[6:].strip())
+            for choice in data.get("choices", []):
+                if choice.get("finish_reason") is not None:
+                    finish_reason_by_choice[choice["index"]] = choice["finish_reason"]
+                if choice.get("stop_reason") is not None:
+                    stop_reason_by_choice[choice["index"]] = choice["stop_reason"]
+
+        assert finish_reason_by_choice == {0: "error", 1: "error"}
+        assert stop_reason_by_choice == {0: "error", 1: "error"}
 
     @pytest.mark.asyncio
     async def test_simple_chat(self, serving_chat, stream):

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat_stream_harmony.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat_stream_harmony.py
@@ -12,7 +12,10 @@ import pytest
 from vllm.entrypoints.openai.chat_completion.stream_harmony import (
     TokenState,
     extract_harmony_streaming_delta,
+    process_harmony_stream_tokens,
 )
+
+pytestmark = pytest.mark.skip_global_cleanup
 
 
 @dataclass
@@ -28,6 +31,49 @@ class MockStreamableParser:
     """Mock StreamableParser for testing without openai_harmony dependency."""
 
     messages: list[MockMessage] = field(default_factory=list)
+
+
+@dataclass
+class ProcessableMockStreamableParser(MockStreamableParser):
+    """Mock parser that records processed token IDs."""
+
+    fail_on: int | None = None
+    current_channel: str | None = "final"
+    current_recipient: str | None = None
+    last_content_delta: str = ""
+    processed_tokens: list[int] = field(default_factory=list)
+
+    def process(self, token_id: int) -> None:
+        if token_id == self.fail_on:
+            raise RuntimeError("invalid harmony token")
+        self.processed_tokens.append(token_id)
+        self.last_content_delta = str(token_id)
+
+
+class TestProcessHarmonyStreamTokens:
+    """Tests for converting Harmony token IDs into token states."""
+
+    def test_processes_all_tokens(self):
+        parser = ProcessableMockStreamableParser()
+
+        token_states, failed = process_harmony_stream_tokens(parser, [1, 2, 3])
+
+        assert failed is False
+        assert parser.processed_tokens == [1, 2, 3]
+        assert token_states == [
+            TokenState("final", None, "1"),
+            TokenState("final", None, "2"),
+            TokenState("final", None, "3"),
+        ]
+
+    def test_stops_at_first_parser_error(self):
+        parser = ProcessableMockStreamableParser(fail_on=2)
+
+        token_states, failed = process_harmony_stream_tokens(parser, [1, 2, 3])
+
+        assert failed is True
+        assert parser.processed_tokens == [1]
+        assert token_states == [TokenState("final", None, "1")]
 
 
 class TestExtractHarmonyStreamingDelta:

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat_stream_harmony.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat_stream_harmony.py
@@ -56,9 +56,9 @@ class TestProcessHarmonyStreamTokens:
     def test_processes_all_tokens(self):
         parser = ProcessableMockStreamableParser()
 
-        token_states, failed = process_harmony_stream_tokens(parser, [1, 2, 3])
+        token_states, error = process_harmony_stream_tokens(parser, [1, 2, 3])
 
-        assert failed is False
+        assert error is None
         assert parser.processed_tokens == [1, 2, 3]
         assert token_states == [
             TokenState("final", None, "1"),
@@ -69,9 +69,10 @@ class TestProcessHarmonyStreamTokens:
     def test_stops_at_first_parser_error(self):
         parser = ProcessableMockStreamableParser(fail_on=2)
 
-        token_states, failed = process_harmony_stream_tokens(parser, [1, 2, 3])
+        token_states, error = process_harmony_stream_tokens(parser, [1, 2, 3])
 
-        assert failed is True
+        assert isinstance(error, RuntimeError)
+        assert str(error) == "invalid harmony token"
         assert parser.processed_tokens == [1]
         assert token_states == [TokenState("final", None, "1")]
 

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -36,6 +36,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
 from vllm.entrypoints.openai.chat_completion.stream_harmony import (
     TokenState,
     extract_harmony_streaming_delta,
+    process_harmony_stream_tokens,
 )
 from vllm.entrypoints.openai.engine.protocol import (
     DeltaMessage,
@@ -420,6 +421,7 @@ class OpenAIServingChat(OpenAIServing):
             harmony_parsers = [
                 get_streamable_parser_for_assistant() for _ in range(num_choices)
             ]
+            harmony_parser_failed = [False] * num_choices
             harmony_tools_streamed = [False] * num_choices
         tools_streamed = [False] * num_choices
 
@@ -586,15 +588,12 @@ class OpenAIServingChat(OpenAIServing):
 
                         # Track accumulated content per token with their state
                         token_states: list[TokenState] = []
-                        for token_id in output.token_ids:
-                            harmony_parser.process(token_id)
-                            token_delta = harmony_parser.last_content_delta or ""
-                            token_states.append(
-                                TokenState(
-                                    harmony_parser.current_channel,
-                                    harmony_parser.current_recipient,
-                                    token_delta,
-                                )
+                        if not harmony_parser_failed[i]:
+                            (
+                                token_states,
+                                harmony_parser_failed[i],
+                            ) = process_harmony_stream_tokens(
+                                harmony_parser, output.token_ids
                             )
                         delta_text = "".join(delta for _, _, delta in token_states)
                         cur_channel = harmony_parser.current_channel

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import io
+import json
 import time
 from collections.abc import AsyncGenerator, AsyncIterator
 from collections.abc import Sequence as GenericSequence
@@ -34,12 +35,13 @@ from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatMessage,
 )
 from vllm.entrypoints.openai.chat_completion.stream_harmony import (
-    TokenState,
     extract_harmony_streaming_delta,
     process_harmony_stream_tokens,
 )
 from vllm.entrypoints.openai.engine.protocol import (
+    DeltaFunctionCall,
     DeltaMessage,
+    DeltaToolCall,
     ErrorResponse,
     FunctionCall,
     PromptTokenUsageInfo,
@@ -65,7 +67,7 @@ from vllm.entrypoints.serve.utils.tool_calls_utils import (
 from vllm.inputs import EngineInput
 from vllm.logger import init_logger
 from vllm.logprobs import Logprob
-from vllm.outputs import RequestOutput
+from vllm.outputs import CompletionOutput, RequestOutput
 from vllm.parser import ParserManager
 from vllm.parser.abstract_parser import Parser
 from vllm.reasoning import ReasoningParser
@@ -421,7 +423,6 @@ class OpenAIServingChat(OpenAIServing):
             harmony_parsers = [
                 get_streamable_parser_for_assistant() for _ in range(num_choices)
             ]
-            harmony_parser_failed = [False] * num_choices
             harmony_tools_streamed = [False] * num_choices
         tools_streamed = [False] * num_choices
 
@@ -470,6 +471,7 @@ class OpenAIServingChat(OpenAIServing):
         )
 
         try:
+            stop_streaming = False
             async for res in result_generator:
                 if res.prompt_token_ids is not None:
                     num_prompt_tokens = len(res.prompt_token_ids)
@@ -587,14 +589,12 @@ class OpenAIServingChat(OpenAIServing):
                         prev_recipient = harmony_parser.current_recipient
 
                         # Track accumulated content per token with their state
-                        token_states: list[TokenState] = []
-                        if not harmony_parser_failed[i]:
-                            (
-                                token_states,
-                                harmony_parser_failed[i],
-                            ) = process_harmony_stream_tokens(
+                        token_states, harmony_parser_error = (
+                            process_harmony_stream_tokens(
                                 harmony_parser, output.token_ids
                             )
+                        )
+                        harmony_choice_failed = harmony_parser_error is not None
                         delta_text = "".join(delta for _, _, delta in token_states)
                         cur_channel = harmony_parser.current_channel
 
@@ -605,6 +605,7 @@ class OpenAIServingChat(OpenAIServing):
                             cur_channel = "final"
                     else:
                         delta_text = output.text
+                        harmony_choice_failed = False
 
                     if (
                         not delta_text
@@ -654,9 +655,8 @@ class OpenAIServingChat(OpenAIServing):
                         # send a chunk with token_ids even if delta_message is None
                         # to ensure all tokens are included in the response
                         if (
-                            output.finish_reason is None
-                            and not request.return_token_ids
-                        ):
+                            output.finish_reason is None and not harmony_choice_failed
+                        ) and not request.return_token_ids:
                             continue
                         delta_message = DeltaMessage()
 
@@ -688,7 +688,25 @@ class OpenAIServingChat(OpenAIServing):
                                 delta=True,
                             )
 
-                    if output.finish_reason is None:
+                    if output.finish_reason == "error":
+                        self._raise_if_error(output.finish_reason, request_id)
+
+                    if harmony_choice_failed:
+                        choice_data = ChatCompletionResponseStreamChoice(
+                            index=i,
+                            delta=delta_message,
+                            logprobs=logprobs,
+                            finish_reason="error",
+                            stop_reason="error",
+                            token_ids=(
+                                as_list(output.token_ids)
+                                if request.return_token_ids
+                                else None
+                            ),
+                        )
+                        finish_reason_sent[i] = True
+
+                    elif output.finish_reason is None:
                         # Send token-by-token response for each request.n
                         choice_data = ChatCompletionResponseStreamChoice(
                             index=i,
@@ -704,17 +722,81 @@ class OpenAIServingChat(OpenAIServing):
 
                     # if the model is finished generating
                     else:
-                        # check for error finish reason and abort streaming
-                        # finish_reason='error' indicates a retryable error
-                        self._raise_if_error(output.finish_reason, request_id)
+                        # check to make sure we haven't "forgotten" to stream
+                        #   any tokens that were generated but previously
+                        #   matched by partial json parsing
+                        # only happens if we are NOT using structured outputs
+                        index = 0
+                        auto_tools_called = False
+                        if tool_parser:
+                            auto_tools_called = len(tool_parser.prev_tool_call_arr) > 0
+                            index = (
+                                len(tool_parser.prev_tool_call_arr) - 1
+                                if auto_tools_called
+                                else 0
+                            )
+                        should_check = (
+                            self._should_check_for_unstreamed_tool_arg_tokens(
+                                delta_message, output
+                            )
+                        )
+                        # only check if there are any tool calls
+                        # detected by partial parsing
+                        if should_check and tool_parser and auto_tools_called:
+                            latest_delta_len = 0
+                            if (
+                                isinstance(
+                                    delta_message.tool_calls[0].function,
+                                    DeltaFunctionCall,
+                                )
+                            ) and isinstance(
+                                delta_message.tool_calls[0].function.arguments, str
+                            ):
+                                latest_delta_len = len(
+                                    delta_message.tool_calls[0].function.arguments
+                                )
+
+                            # get the expected call based on partial JSON
+                            # parsing which "autocompletes" the JSON.
+                            # Tool parsers (e.g. Qwen3Coder) store
+                            # arguments as a JSON string in
+                            # prev_tool_call_arr. Calling json.dumps()
+                            # on an already-serialized string would
+                            # double-serialize it (e.g. '{"k":1}' becomes
+                            # '"{\\"k\\":1}"'), which then causes the
+                            # replace() below to fail and append the
+                            # entire double-serialized string as a
+                            # spurious final delta.
+                            args = tool_parser.prev_tool_call_arr[index].get(
+                                "arguments", {}
+                            )
+                            if isinstance(args, str):
+                                expected_call = args
+                            else:
+                                expected_call = json.dumps(args, ensure_ascii=False)
+
+                            # get what we've streamed so far for arguments
+                            # for the current tool
+                            actual_call = tool_parser.streamed_args_for_tool[index]
+                            if latest_delta_len > 0:
+                                actual_call = actual_call[:-latest_delta_len]
+
+                            # check to see if there's anything left to stream
+                            remaining_call = expected_call.replace(actual_call, "", 1)
+                            # set that as a delta message
+                            delta_message = self._create_remaining_args_delta(
+                                delta_message, remaining_call, index
+                            )
 
                         # Send the finish response for each request.n only once
                         # In OpenAI's API, when a tool is called, the
                         # finish_reason is:
                         # "tool_calls" for "auto" or "required" tool calls,
                         # and "stop" for named tool calls.
-                        if (tools_streamed[i] and not tool_choice_function_name) or (
-                            self.use_harmony and harmony_tools_streamed[i]
+                        if (
+                            auto_tools_called
+                            or (tools_streamed[i] and not tool_choice_function_name)
+                            or (self.use_harmony and harmony_tools_streamed[i])
                         ):
                             finish_reason_ = "tool_calls"
                         else:
@@ -766,6 +848,13 @@ class OpenAIServingChat(OpenAIServing):
 
                     data = chunk.model_dump_json(exclude_unset=True)
                     yield f"data: {data}\n\n"
+
+                    if all(finish_reason_sent):
+                        stop_streaming = True
+                        break
+
+                if stop_streaming:
+                    break
 
             # once the final token is handled, if stream_options.include_usage
             # is sent, send the usage
@@ -1269,3 +1358,72 @@ class OpenAIServingChat(OpenAIServing):
                 )
 
         return ChatCompletionLogProbs(content=logprobs_content)
+
+    def _should_stream_with_auto_tool_parsing(self, request: ChatCompletionRequest):
+        """
+        Utility function to check if streamed tokens should go through the tool
+        call parser that was configured.
+
+        We only want to do this IF user-provided tools are set, a tool parser
+        is configured, "auto" tool choice is enabled, and the request's tool
+        choice field indicates that "auto" tool choice should be used.
+        """
+        return (
+            request.tools
+            and self.tool_parser
+            and self.enable_auto_tools
+            and request.tool_choice in ["auto", None]
+        )
+
+    def _should_check_for_unstreamed_tool_arg_tokens(
+        self,
+        delta_message: DeltaMessage | None,
+        output: CompletionOutput,
+    ) -> bool:
+        """
+        Check whether the final chunk may need remaining tool argument tokens.
+
+        This is only applicable when auto tool parsing is enabled and the
+        current delta is a tool call with arguments.
+        """
+        return bool(
+            output.finish_reason is not None
+            and self.enable_auto_tools
+            and self.tool_parser
+            and delta_message
+            and delta_message.tool_calls
+            and delta_message.tool_calls[0]
+            and delta_message.tool_calls[0].function
+            and delta_message.tool_calls[0].function.arguments is not None
+        )
+
+    @staticmethod
+    def _create_remaining_args_delta(
+        delta_message: DeltaMessage,
+        remaining_call: str,
+        index: int,
+    ) -> DeltaMessage:
+        """
+        Create a delta message for remaining tool arguments.
+
+        The returned delta keeps id/type/name from the original tool call when
+        those fields are available.
+        """
+        original_tc = next(
+            (tc for tc in delta_message.tool_calls if tc.index == index),
+            None,
+        )
+        original_fn = original_tc.function if original_tc else None
+        return DeltaMessage(
+            tool_calls=[
+                DeltaToolCall(
+                    index=index,
+                    id=original_tc.id if original_tc else None,
+                    type=original_tc.type if original_tc else None,
+                    function=DeltaFunctionCall(
+                        name=original_fn.name if original_fn else None,
+                        arguments=remaining_call,
+                    ),
+                )
+            ]
+        )

--- a/vllm/entrypoints/openai/chat_completion/stream_harmony.py
+++ b/vllm/entrypoints/openai/chat_completion/stream_harmony.py
@@ -7,6 +7,7 @@ This module handles the extraction of DeltaMessage objects from
 harmony parser state during streaming chat completions.
 """
 
+from collections.abc import Iterable
 from typing import NamedTuple
 
 from openai_harmony import StreamableParser
@@ -21,12 +22,41 @@ from vllm.entrypoints.openai.parser.harmony_utils import (
     extract_function_from_recipient,
     is_function_recipient,
 )
+from vllm.logger import init_logger
+
+logger = init_logger(__name__)
 
 
 class TokenState(NamedTuple):
     channel: str | None
     recipient: str | None
     text: str
+
+
+def process_harmony_stream_tokens(
+    harmony_parser: StreamableParser, token_ids: Iterable[int]
+) -> tuple[list[TokenState], Exception | None]:
+    """Process streaming token IDs until Harmony parsing fails."""
+    token_states: list[TokenState] = []
+    for token_id in token_ids:
+        try:
+            harmony_parser.process(token_id)
+        except Exception as e:
+            logger.exception(
+                "Harmony parser stopped at token %d",
+                token_id,
+            )
+            return token_states, e
+
+        token_states.append(
+            TokenState(
+                harmony_parser.current_channel,
+                harmony_parser.current_recipient,
+                harmony_parser.last_content_delta or "",
+            )
+        )
+
+    return token_states, None
 
 
 def extract_harmony_streaming_delta(


### PR DESCRIPTION
## Purpose

- Stop feeding tokens into a Harmony stream parser after the first parser exception. That situation may happen when `ignore_eos` is enabled.
- Track parser failure per choice so later invalid tail tokens do not re-enter a failed parser.

## Test Plan

- Add focused unit coverage for successful parsing and stop-on-error behavior.
- `pytest tests/entrypoints/openai/chat_completion/test_serving_chat_stream_harmony.py -v`

## Test Result

- `20 passed`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

