### PR TITLE
[ROCm] Fix AITER AR+RMSNorm no-residual fusion

### DIFF
--- a/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
+++ b/vllm/compilation/passes/fusion/allreduce_rms_fusion.py
@@ -939,7 +939,7 @@ class AiterAllreduceFusedRMSNormPattern(BasePattern, VllmPatternReplacement):
         def _replacement(
             input: torch.Tensor, weight: torch.Tensor
         ) -> tuple[torch.Tensor, torch.Tensor]:
-            residual = torch.empty_like(input)
+            residual = torch.zeros_like(input)
             allreduce = self.FUSED_AR_RMSNORM_OP(
                 input_=input,
                 residual=residual,


### PR DESCRIPTION
## Purpose

Fix the ROCm AITER allreduce + RMSNorm fusion for the no-residual pattern.

`AiterAllreduceFusedRMSNormPattern` replaces an allreduce followed by RMSNorm without a residual input. However, the AITER fused kernel computes RMSNorm over `allreduce(input) + residual`, so the synthetic residual for this pattern must be zero.

The AITER replacement used `torch.empty_like(input)`, which can add uninitialized memory into the layer output. This PR changes it to `torch.zeros_like(input)`, matching the existing FlashInfer no-residual fusion patterns in the same file.

This restores MiniMax-M2.5 GSM8K accuracy while keeping the AITER fusion enabled.

## Test Plan

Serve MiniMax-M2.5 with ROCm AITER and allreduce RMSNorm fusion enabled:

```bash
vllm serve MiniMaxAI/MiniMax-M2.5 \
  --tensor-parallel-size 4 \
  --attention-backend ROCM_AITER_UNIFIED_ATTN \
  --max-model-len 12288 \
  --block-size 64 \
  --max-num-seqs 512 \
  --max-num-batched-tokens 32768 \
  --gpu-memory-utilization 0.95 \
  --performance-mode balanced \
  --async-scheduling \
  --no-enable-prefix-caching \
  --kv-cache-dtype auto \
  --compilation-config '{"mode":3}'
```
  
  ## Test Result
  
  Before this fix, GSM8K accuracy collapsed with ROCm AITER allreduce RMSNorm fusion enabled 
  
  |Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |    0|±  |     0|
|     |       |strict-match    |     5|exact_match|↑  |    0|±  |     0|
  
  
  After this fix:
  
  
  
  |Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9515|±  |0.0059|
|     |       |strict-match    |     5|exact_match|↑  |0.9454|±  |0.0063|
  