### PR TITLE
[Bugfix] restore MLA notif request_id accidentally reverted in #40731

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/nixl/worker.py
@@ -1959,7 +1959,7 @@ class NixlConnectorWorker:
         if self.use_mla and tp_ratio < 0 and read_specs:
             # ..but we still need to notify the other remote ranks that we
             # have the blocks we need so they can update the request state.
-            notif_id = f"{req_id}:{self.world_size}".encode()
+            notif_id = f"{meta.remote.request_id}:{self.world_size}".encode()
             remote_agents = self._remote_agents[meta.remote.engine_id]
             read_ranks = {s.remote_rank for s in read_specs}
             for rank_to_notify, agent in remote_agents.items():


### PR DESCRIPTION
## Purpose

Restore the fix from #40449 that was accidentally reverted during the refactor in #40731.

In `_read_blocks_for_req`, when MLA is enabled and P_TP > D_TP, the broadcast notification to non-reading P-ranks was using `req_id` (decode-side) instead of `meta.remote.request_id` (prefill-side). This caused "Potentially invalid KV blocks for unrecognized request" errors and eventual timeout-based block release on skipped P-ranks.

Fixes #41974
