### PR TITLE
[Model] llama: add FP8 scale name remapping to LlamaForCausalLM and LlamaModel

### DIFF
--- a/tests/models/test_llama_fp8_weight_remapping.py
+++ b/tests/models/test_llama_fp8_weight_remapping.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for FP8 weight name remapping in LlamaForCausalLM.
+
+FP8 quantized HuggingFace checkpoints (e.g. Devstral-2-123B-Instruct)
+store per-tensor scales as ``activation_scale`` and ``weight_scale_inv``,
+but vLLM's FP8 linear layers register them as ``input_scale`` and
+``weight_scale``.  The remapping added to ``LlamaForCausalLM`` and
+``LlamaModel`` ensures these names are translated during weight loading.
+"""
+
+import pytest
+
+from vllm.model_executor.models.llama import LlamaForCausalLM
+from vllm.model_executor.models.utils import WeightsMapper
+
+
+# ---------------------------------------------------------------------------
+# WeightsMapper suffix remapping (unit test, no GPU required)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.cpu_test
+class TestLlamaFP8WeightsMapper:
+    """Verify the hf_to_vllm_mapper on LlamaForCausalLM correctly
+    remaps FP8 scale names used by HuggingFace checkpoints."""
+
+    @pytest.fixture
+    def mapper(self) -> WeightsMapper:
+        return LlamaForCausalLM.hf_to_vllm_mapper
+
+    def test_activation_scale_remapped(self, mapper: WeightsMapper):
+        result = mapper._map_name(
+            "model.layers.0.mlp.down_proj.activation_scale"
+        )
+        assert result == "model.layers.0.mlp.down_proj.input_scale"
+
+    def test_weight_scale_inv_remapped(self, mapper: WeightsMapper):
+        result = mapper._map_name(
+            "model.layers.0.mlp.down_proj.weight_scale_inv"
+        )
+        assert result == "model.layers.0.mlp.down_proj.weight_scale"
+
+    def test_non_fp8_name_unchanged(self, mapper: WeightsMapper):
+        name = "model.layers.0.self_attn.q_proj.weight"
+        assert mapper._map_name(name) == name
+
+    def test_all_linear_suffixes(self, mapper: WeightsMapper):
+        """Ensure both suffixes are remapped for every linear layer type."""
+        linear_names = [
+            "model.layers.0.self_attn.q_proj",
+            "model.layers.0.self_attn.k_proj",
+            "model.layers.0.self_attn.v_proj",
+            "model.layers.0.self_attn.o_proj",
+            "model.layers.0.mlp.gate_proj",
+            "model.layers.0.mlp.up_proj",
+            "model.layers.0.mlp.down_proj",
+        ]
+        for prefix in linear_names:
+            assert mapper._map_name(f"{prefix}.activation_scale") == \
+                f"{prefix}.input_scale", f"Failed for {prefix}.activation_scale"
+            assert mapper._map_name(f"{prefix}.weight_scale_inv") == \
+                f"{prefix}.weight_scale", f"Failed for {prefix}.weight_scale_inv"
+
+    def test_mapper_as_generator(self, mapper: WeightsMapper):
+        """Verify apply() works as a lazy generator over weight tuples."""
+        import torch
+        fake_weights = [
+            ("model.layers.0.mlp.down_proj.activation_scale", torch.tensor(1.0)),
+            ("model.layers.0.mlp.down_proj.weight_scale_inv", torch.tensor(0.5)),
+            ("model.layers.0.mlp.down_proj.weight", torch.randn(4, 4)),
+        ]
+        remapped = dict(mapper.apply(fake_weights))
+        assert "model.layers.0.mlp.down_proj.input_scale" in remapped
+        assert "model.layers.0.mlp.down_proj.weight_scale" in remapped
+        assert "model.layers.0.mlp.down_proj.weight" in remapped
+        assert "model.layers.0.mlp.down_proj.activation_scale" not in remapped
+        assert "model.layers.0.mlp.down_proj.weight_scale_inv" not in remapped

--- a/vllm/model_executor/models/llama.py
+++ b/vllm/model_executor/models/llama.py
@@ -70,6 +70,7 @@ from .interfaces import (
 from .utils import (
     AutoWeightsLoader,
     PPMissingLayer,
+    WeightsMapper,
     extract_layer_index,
     is_pp_missing_parameter,
     make_empty_intermediate_tensors_factory,
@@ -445,6 +446,12 @@ class LlamaModel(nn.Module, EagleModelMixin):
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
         for name, loaded_weight in weights:
+            # FP8: remap HF scale names to vLLM scale names
+            if name.endswith('.activation_scale'):
+                name = name[:-len('.activation_scale')] + '.input_scale'
+            elif name.endswith('.weight_scale_inv'):
+                name = name[:-len('.weight_scale_inv')] + '.weight_scale'
+
             if "rotary_emb.inv_freq" in name:
                 continue
             if "rotary_emb.cos_cached" in name or "rotary_emb.sin_cached" in name:
@@ -505,6 +512,16 @@ class LlamaForCausalLM(
         "qkv_proj": ["q_proj", "k_proj", "v_proj"],
         "gate_up_proj": ["gate_proj", "up_proj"],
     }
+
+    # FP8 quantized HF checkpoints use "activation_scale" and
+    # "weight_scale_inv" but vLLM's FP8 linear layers register
+    # them as "input_scale" and "weight_scale".
+    hf_to_vllm_mapper = WeightsMapper(
+        orig_to_new_suffix={
+            ".activation_scale": ".input_scale",
+            ".weight_scale_inv": ".weight_scale",
+        },
+    )
 
     # LoRA specific attributes
     embedding_modules = {
@@ -586,7 +603,7 @@ class LlamaForCausalLM(
             self,
             skip_prefixes=(["lm_head."] if self.config.tie_word_embeddings else None),
         )
-        return loader.load_weights(weights)
+        return loader.load_weights(weights, mapper=self.hf_to_vllm_mapper)
 
 
 class LlamaBidirectionalForSequenceClassification(as_seq_cls_model(LlamaForCausalLM)):


### PR DESCRIPTION
## [Model] llama: add FP8 scale name remapping to LlamaForCausalLM and LlamaModel

### Summary

FP8 quantized HuggingFace checkpoints (e.g. `Devstral-2-123B-Instruct-2512`) store per-tensor scales as `activation_scale` and `weight_scale_inv`, but vLLM's FP8 linear layers register them as `input_scale` and `weight_scale` respectively.

`Mistral3ForConditionalGeneration` already handles this via a `hf_to_vllm_mapper` with `orig_to_new_suffix` ([mistral3.py L375-393](https://github.com/vllm-project/vllm/blob/main/vllm/model_executor/models/mistral3.py)), but `LlamaForCausalLM` — which Devstral 2 routes through as a Llama-architecture model — does not have this mapping.

### Problem

Loading FP8 quantized Llama-architecture models (especially with `--load-format fastsafetensors`) causes:

```
KeyError: 'model.layers.0.mlp.down_proj.activation_scale'
```

The `fastsafetensors` loader bypasses the old `LlamaModel.load_weights()` code path and goes through `LlamaForCausalLM.load_weights()` → `AutoWeightsLoader` directly, which had no suffix remapping.

### Fix

Two layers of defense:

1. **`hf_to_vllm_mapper` class attribute** on `LlamaForCausalLM` with the same FP8 suffix remapping that `mistral3.py` uses, passed to `AutoWeightsLoader.load_weights()` via the `mapper=` parameter.

2. **Direct name remapping** inside `LlamaModel.load_weights()` for the case where `AutoWeightsLoader._load_module` dispatches to the old-style `params_dict` loader and the mapper's lazy generator renaming doesn't survive the delegation chain.

### Testing

- **Unit tests**: Added `tests/models/test_llama_fp8_weight_remapping.py` with tests for both suffix remappings, non-FP8 names passing through unchanged, and the `apply()` generator path.
- **Integration**: Tested with `Devstral-2-123B-Instruct-2512` (FP8, 128 experts MoE) on a 2-GPU DGX Spark Ray cluster with `--load-format fastsafetensors`. Model loads successfully and serves inference requests.

### Checklist

- [x] Follows existing `hf_to_vllm_mapper` pattern from `mistral3.py`
- [x] Minimal diff — only touches `llama.py`
- [x] Unit tests added
- [x] No breaking changes to existing weight loading paths
- [x] `Signed-off-by` included
