### PR TITLE
[Bugfix] Extend compressed-tensors ignore for Qwen3.5 MTP experts

### DIFF
--- a/vllm/model_executor/models/qwen3_5_mtp.py
+++ b/vllm/model_executor/models/qwen3_5_mtp.py
@@ -79,7 +79,7 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
 
         # Workaround: mtp.fc is stored as BF16 in NVFP4 checkpoints but is
         # missing from hf_quant_config.json exclude_modules. Force unquantized.
-        # Ref: https://github.com/vllm-project/vllm/pull/38650
+        # Ref: https://github.com/vllm-project/vllm/pull/38832
         # Ref: https://github.com/NVIDIA/Model-Optimizer/pull/1124
         fc_quant = (
             None
@@ -95,6 +95,38 @@ class Qwen3_5MultiTokenPredictor(nn.Module):
             quant_config=fc_quant,
             prefix=f"{prefix}.fc",
         )
+
+        # Compressed-tensors NVFP4 Qwen3.5 MoE checkpoints store the MTP
+        # layer's fused expert weights as BF16 unquantized
+        # tensors (`mtp.layers.X.mlp.experts.{down,gate_up}_proj`, shape
+        # `[num_experts, ...]`) but the per-expert MTP linears are not in the
+        # compressed-tensors `ignore` list, so vLLM constructs the FusedMoE
+        # quantized and weight loading fails with
+        # `KeyError: 'layers.X.mlp.experts.w2_weight'` (see
+        # `Qwen3_5MultiTokenPredictor.load_fused_expert_weights`). Mirror the
+        # existing `mtp.fc` workaround (PR #38832) for the experts: extend
+        # the active CT `ignore` list with every per-expert MTP linear so the
+        # FusedMoE picks `UnquantizedFusedMoEMethod` and registers BF16
+        # `w13_weight` / `w2_weight` matching the checkpoint.
+        if (
+            quant_config is not None
+            and quant_config.get_name() == "compressed-tensors"
+            and hasattr(quant_config, "ignore")
+        ):
+            num_experts = getattr(config, "num_experts", 0)
+            extra: list[str] = []
+            for idx in range(self.num_mtp_layers):
+                for eid in range(num_experts):
+                    for proj in ("gate_proj", "up_proj", "down_proj"):
+                        extra.append(f"{prefix}.layers.{idx}.mlp.experts.{eid}.{proj}")
+            new_entries = [n for n in extra if n not in quant_config.ignore]
+            quant_config.ignore.extend(new_entries)
+            if new_entries:
+                logger.info(
+                    "Qwen3_5MTP: extended compressed-tensors ignore with "
+                    "%d per-expert MTP linears (BF16 in the checkpoint)",
+                    len(new_entries),
+                )
 
         self.layers = torch.nn.ModuleList(
             Qwen3_5DecoderLayer(


### PR DESCRIPTION
## Purpose

Fix a startup crash for compressed-tensors NVFP4 Qwen3.5 MoE checkpoints
that store MTP fused expert weights as BF16, when used with
`--quantization=compressed-tensors` and an MTP `--speculative-config`.

**Symptom (without patch):**

```
EngineCore failed to start.
  ...
  File ".../qwen3_5_mtp.py", line ~169, in load_fused_expert_weights
    param = params_dict[name]
KeyError: 'layers.0.mlp.experts.w2_weight'
```

The affected checkpoints' `quantization_config.ignore` lists `mtp.fc`,
`mtp.layers.0.self_attn.*`, and `mtp.layers.0.mlp.shared_expert*`, but
omits `mtp.layers.0.mlp.experts.<eid>.{gate,up,down}_proj` even though
the experts are stored as BF16 fused tensors. vLLM ends up constructing
the MTP `FusedMoE` quantized (registering `w13_weight_packed` /
`w2_weight_packed`) and weight loading fails.

This mirrors the existing `mtp.fc` workaround (#38832) for the experts:
extend the active CT `ignore` list with every per-expert MTP linear
before constructing `self.layers`, so the FusedMoE picks
`UnquantizedFusedMoEMethod` and registers BF16 `w13_weight` /
`w2_weight` matching the checkpoint.

Drive-by: update an in-file comment whose `Ref:` pointed at the closed
unmerged PR #38650; the actually-landed mtp.fc fix is #38832.

## Why this is not duplicating an existing PR

I'm aware of #27608 ("Respect ignore list for NVFP4/BF16 mixed MoE
checkpoints"). The two fixes are **complementary, not duplicative**:

- **#27608** fixes a CT-loader bug — `CompressedTensorsConfig.get_quant_method`
  doesn't honor `ignore` for `FusedMoE` layers (only for `Linear`).
- **This PR** fixes a checkpoint-metadata gap: per-expert MTP entries are
  missing from `ignore` entirely on affected checkpoints.

For these checkpoints, #27608 alone would not prevent the crash because
there is nothing in the publisher's `ignore` list for its
`should_ignore_layer` check to match. Conversely this PR does not help
#27608's test case (their patterns are not MTP-specific).

Once both #27608 lands and the checkpoint metadata is fixed at the
publisher, this workaround becomes unnecessary.

## Test plan

- [x] `pre-commit run --files vllm/model_executor/models/qwen3_5_mtp.py` —
  all hooks pass (ruff, mypy-3.10, typos, SPDX, lazy-imports,
  forbidden-imports, etc.)
- [x] e2e on DGX Spark (GB10), `vllm/vllm-openai:nightly-aarch64`,
  BS=1, concurrency=1, prefix=32768, ISL=2048, OSL=1024:

  | K | Before patch | After patch | ITL   |
  |--:|-------------:|------------:|------:|
  | 0 | 63.08 t/s    | 63.08 t/s   | 15.52 |
  | 1 | crash        | 71.08 t/s   | 13.62 |
  | 3 | crash        | 84.81 t/s   | 11.38 |
  | 5 | crash        | 87.76 t/s   | 10.96 |

  Working serve command shape:

  ```
  vllm serve <model> \
      --quantization=compressed-tensors --moe-backend=triton \
      --speculative-config '{"method":"mtp","num_speculative_tokens":3, ...}'
  ```

## Notes for reviewers

- The fix mutates `quant_config.ignore` rather than passing a per-submodule
  `quant_config=None` (the pattern used for `mtp.fc` above): the experts
  live inside `Qwen3_5DecoderLayer` constructed via `vllm_config`, so
  there is no clean per-submodule override path. The mutation is bounded
  (additive, idempotent, only adds entries that are missing).
- AI-assisted: this patch was developed with the help of an AI coding
  assistant. The change has been reviewed line-by-line by a human and
  validated end-to-end on real hardware.