### PR TITLE
Fix Mamba copy metadata high-bit pointers

### DIFF
--- a/tests/v1/worker/test_mamba_utils.py
+++ b/tests/v1/worker/test_mamba_utils.py
@@ -10,6 +10,7 @@ import pytest
 import torch
 
 from vllm.model_executor.layers.mamba.mamba_utils import (
+    MambaCopySpec,
     get_conv_copy_spec,
     get_temporal_copy_spec,
 )
@@ -86,6 +87,31 @@ def postprocess_mamba(
             if src_block_idx == dest_block_idx:
                 num_accepted_tokens_cpu[i] = 1
     do_mamba_copy_block(copy_bufs)
+
+
+class _FakeBuffer:
+    def __init__(self, array: np.ndarray):
+        self.np = array
+
+
+class _FakeBlock:
+    def __init__(self, ptr: int):
+        self._ptr = ptr
+
+    def data_ptr(self) -> int:
+        return self._ptr
+
+
+class _FakeState:
+    def __init__(self, ptrs: list[int], element_size: int):
+        self._ptrs = ptrs
+        self._element_size = element_size
+
+    def __getitem__(self, idx: int) -> _FakeBlock:
+        return _FakeBlock(self._ptrs[idx])
+
+    def element_size(self) -> int:
+        return self._element_size
 
 
 def _make_scheduler_output(
@@ -2132,3 +2158,39 @@ class TestPostprocessMambaFusedKernel:
             expected_accepted,
             msg="num_accepted_tokens mismatch at accept_token_bias=2",
         )
+
+
+def test_collect_mamba_copy_meta_accepts_high_bit_device_pointers():
+    """XPU pointers may be >= 2**63; store them by uint64 bit pattern."""
+    src_ptr = 2**63 + 17
+    dst_ptr = 2**63 + 41
+    state = _FakeState([0, dst_ptr], element_size=2)
+
+    copy_bufs = MambaCopyBuffers(
+        src_ptrs=_FakeBuffer(np.zeros(1, dtype=np.int64)),
+        dst_ptrs=_FakeBuffer(np.zeros(1, dtype=np.int64)),
+        sizes=_FakeBuffer(np.zeros(1, dtype=np.int32)),
+        mamba_group_ids=[0],
+        mamba_spec=MagicMock(),
+    )
+    kv_cache_config = MagicMock()
+    kv_cache_config.kv_cache_groups = [MagicMock(layer_names=["layer"])]
+    req_state = MagicMock(block_ids=([0, 1],))
+    forward_context = {"layer": MagicMock(kv_cache=[state])}
+
+    collect_mamba_copy_meta(
+        copy_bufs,
+        kv_cache_config,
+        (lambda *_: MambaCopySpec(start_addr=src_ptr, num_elements=7),),
+        [0],
+        src_block_idx=0,
+        dest_block_idx=1,
+        accept_token_bias=0,
+        req_state=req_state,
+        forward_context=forward_context,
+    )
+
+    assert copy_bufs.src_ptrs.np.view(np.uint64)[0] == src_ptr
+    assert copy_bufs.dst_ptrs.np.view(np.uint64)[0] == dst_ptr
+    assert copy_bufs.sizes.np[0] == 14
+    assert copy_bufs.offset == 1

--- a/vllm/v1/worker/mamba_utils.py
+++ b/vllm/v1/worker/mamba_utils.py
@@ -5,6 +5,7 @@ import itertools
 from collections.abc import Callable
 from typing import Any
 
+import numpy as np
 import torch
 
 from vllm.config import CacheConfig
@@ -583,8 +584,10 @@ def collect_mamba_copy_meta(
     if src_block_idx == dest_block_idx and accept_token_bias == 0:
         return
 
-    src_ptrs_np = copy_bufs.src_ptrs.np
-    dst_ptrs_np = copy_bufs.dst_ptrs.np
+    # Device pointers can use the high bit on XPU. Store them by bit pattern
+    # instead of converting through signed int64, which rejects values >= 2**63.
+    src_ptrs_np = copy_bufs.src_ptrs.np.view(np.uint64)
+    dst_ptrs_np = copy_bufs.dst_ptrs.np.view(np.uint64)
     sizes_np = copy_bufs.sizes.np
     offset = copy_bufs.offset
 


### PR DESCRIPTION
Fixes #41817.

### Summary

`collect_mamba_copy_meta` stores source and destination device pointers in NumPy-backed CPU buffers before Triton consumes them as pointer arguments. On XPU, valid device pointers may have the high bit set (`>= 2**63`). Assigning those Python integers into signed `int64` NumPy arrays raises `OverflowError`.

This change writes pointer values through a `uint64` view of the existing buffers so the raw pointer bit pattern is preserved without signed integer conversion. It also adds a focused regression test that exercises high-bit source and destination pointers.

### Duplicate-work check

I checked that this is not duplicating an existing open PR:

- `gh issue view 41817 --repo vllm-project/vllm --comments`: no comments/output.
- `gh pr list --repo vllm-project/vllm --state open --search "41817 in:body"`: no output.
- `gh pr list --repo vllm-project/vllm --state open --search "collect_mamba_copy_meta OverflowError uint64 XPU"`: no output.

### Tests

- Passed: `.venv/bin/python -m py_compile vllm/v1/worker/mamba_utils.py tests/v1/worker/test_mamba_utils.py`
- Passed: `git diff --check --cached`
- Passed in Docker Linux x86_64:
  - `uv venv --python 3.12 .venv`
  - `VLLM_USE_PRECOMPILED=1 uv pip install --python .venv/bin/python -e . --torch-backend=auto`
  - `uv pip install --python .venv/bin/python pytest tblib`
  - `.venv/bin/python -m pytest tests/v1/worker/test_mamba_utils.py -q`
  - Result: `2 passed, 16 warnings in 1.00s`

Native macOS x86_64 testing is blocked because the repo-pinned `torch==2.11.0` has no `macosx_15_0_x86_64` wheel. The Docker Linux x86_64 run uses a supported Torch platform.

### AI assistance disclosure

AI assistance was used to analyze the issue, implement the patch, run local checks, and draft this PR. The human submitter must review every changed line and run the relevant tests before marking this PR ready for review.
