### PR TITLE
[MM][Perf][CG] Enable encoder CUDA Graph for MiniCPM-V

### DIFF
--- a/docs/design/cuda_graphs_multimodal.md
+++ b/docs/design/cuda_graphs_multimodal.md
@@ -87,7 +87,7 @@ Models opt-in to encoder CUDA Graphs by implementing the [SupportsEncoderCudaGra
 | ------------ | ------ | ------------ | ------------ |
 | `Qwen3VLForConditionalGeneration` | `Qwen3-VL` | ✅︎ | ✅︎ |
 | `Qwen2_5_VLForConditionalGeneration` | `Qwen2.5-VL` | ✅︎ | ✅︎ |
-| `MiniCPMV` | `MiniCPMV2.5`,`MiniCPMV2.6`,`MiniCPMV4.0`,`MiniCPMV4.5` | ✅︎ | ✅︎ |
+| `MiniCPMV` | `MiniCPMV2.5`,`MiniCPMV2.6`,`MiniCPMV4.0` | ✅︎ | ✅︎ |
 
 !!! note
     Encoder CUDA Graphs have currently been tested with `--mm-encoder-attn-backend=FLASH_ATTN` and `--mm-encoder-attn-backend=FLASHINFER` on Blackwell GPUs.

--- a/docs/design/cuda_graphs_multimodal.md
+++ b/docs/design/cuda_graphs_multimodal.md
@@ -87,6 +87,7 @@ Models opt-in to encoder CUDA Graphs by implementing the [SupportsEncoderCudaGra
 | ------------ | ------ | ------------ | ------------ |
 | `Qwen3VLForConditionalGeneration` | `Qwen3-VL` | ✅︎ | ✅︎ |
 | `Qwen2_5_VLForConditionalGeneration` | `Qwen2.5-VL` | ✅︎ | ✅︎ |
+| `MiniCPMV` | `MiniCPMV2.5`,`MiniCPMV2.6`,`MiniCPMV4.0`,`MiniCPMV4.5` | ✅︎ | ✅︎ |
 
 !!! note
     Encoder CUDA Graphs have currently been tested with `--mm-encoder-attn-backend=FLASH_ATTN` and `--mm-encoder-attn-backend=FLASHINFER` on Blackwell GPUs.

--- a/docs/design/cuda_graphs_multimodal.md
+++ b/docs/design/cuda_graphs_multimodal.md
@@ -1,6 +1,6 @@
 # Vision Encoder (ViT) CUDA Graphs
 
-The [CUDA Graphs](cuda_graphs.md) infrastructure in vLLM primarily targets the **decoder** (language model) forward pass. vLLM also supports capturing the **encoder** (vision transformer) forward pass as CUDA Graphs, independently from the decoder. This is based on <https://github.com/vllm-project/vllm/pull/35963>.
+The [CUDA Graphs](cuda_graphs.md) infrastructure in vLLM primarily targets the **decoder** (language model) forward pass. vLLM also supports capturing the **encoder** (vision transformer) forward pass as CUDA Graphs, independently from the decoder. This is based on [https://github.com/vllm-project/vllm/pull/35963](https://github.com/vllm-project/vllm/pull/35963).
 
 !!! note
     Encoder CUDA Graphs are orthogonal to decoder CUDA Graphs — both can be enabled simultaneously. Encoder graphs capture the vision encoder execution (e.g., ViT in Qwen3-VL), while decoder graphs capture the language model execution as described in the [CUDA Graphs design document](cuda_graphs.md).
@@ -15,9 +15,9 @@ Encoder CUDA Graphs eliminate this overhead by pre-capturing the full encoder fo
 
 The encoder CUDA Graph system uses a **budget-based capture/replay** strategy, managed by [EncoderCudaGraphManager][vllm.v1.worker.encoder_cudagraph.EncoderCudaGraphManager]. The system contains the following core components:
 
-* [EncoderCudaGraphManager][vllm.v1.worker.encoder_cudagraph.EncoderCudaGraphManager]: orchestrates capture, replay, greedy packing, and data-parallel execution for encoder CUDA Graphs.
-* [SupportsEncoderCudaGraph][vllm.model_executor.models.interfaces.SupportsEncoderCudaGraph]: a runtime-checkable protocol that models implement to opt-in to encoder CUDA Graphs.
-* [BudgetGraphMetadata][vllm.v1.worker.encoder_cudagraph.BudgetGraphMetadata]: holds the captured CUDA Graph and its associated I/O buffers for a single token budget level.
+- [EncoderCudaGraphManager][vllm.v1.worker.encoder_cudagraph.EncoderCudaGraphManager]: orchestrates capture, replay, greedy packing, and data-parallel execution for encoder CUDA Graphs.
+- [SupportsEncoderCudaGraph][vllm.model_executor.models.interfaces.SupportsEncoderCudaGraph]: a runtime-checkable protocol that models implement to opt-in to encoder CUDA Graphs.
+- [BudgetGraphMetadata][vllm.v1.worker.encoder_cudagraph.BudgetGraphMetadata]: holds the captured CUDA Graph and its associated I/O buffers for a single token budget level.
 
 ### Budget-based graph capture
 
@@ -54,40 +54,44 @@ When `mm_encoder_tp_mode="data"`, the manager distributes images across TP ranks
 
 ### Video inference support
 
-Following <https://github.com/vllm-project/vllm/pull/35963> (ViT full CUDA graph support for image inference), <https://github.com/vllm-project/vllm/pull/38061> extends the encoder CUDA graph framework to support video inference for Qwen3-VL. Previously, the CUDA graph capture/replay path only handled image inputs (`pixel_values` + `image_grid_thw`). Video inputs use different keys (`pixel_values_videos` + `video_grid_thw`) and require larger `cu_seqlens` buffers because each video item contributes multiple frames (`T` attention sequences). This PR generalizes the protocol and manager to handle both modalities through a single shared graph manager.
+Following [https://github.com/vllm-project/vllm/pull/35963](https://github.com/vllm-project/vllm/pull/35963) (ViT full CUDA graph support for image inference), [https://github.com/vllm-project/vllm/pull/38061](https://github.com/vllm-project/vllm/pull/38061) extends the encoder CUDA graph framework to support video inference for Qwen3-VL. Previously, the CUDA graph capture/replay path only handled image inputs (`pixel_values` + `image_grid_thw`). Video inputs use different keys (`pixel_values_videos` + `video_grid_thw`) and require larger `cu_seqlens` buffers because each video item contributes multiple frames (`T` attention sequences). This PR generalizes the protocol and manager to handle both modalities through a single shared graph manager.
 
 !!! note
     Video CUDA graphs are automatically disabled when EVS (Efficient Video Sampling) pruning is enabled, since EVS makes the token count data-dependent and incompatible with CUDA graph capture.
 
-    Mixed inputs (image+video) per prompt are also supported now.
+```
+Mixed inputs (image+video) per prompt are also supported now.
+```
 
 ## Model integration via `SupportsEncoderCudaGraph`
 
 Models opt-in to encoder CUDA Graphs by implementing the [SupportsEncoderCudaGraph][vllm.model_executor.models.interfaces.SupportsEncoderCudaGraph] protocol. This protocol encapsulates all model-specific logic so that the manager remains model-agnostic. The protocol defines the following methods:
 
-* `get_encoder_cudagraph_config()` — returns static configuration (supported modalities, input key, buffer keys, output hidden size).
-* `get_encoder_cudagraph_budget_range(vllm_config)` — returns `(min_budget, max_budget)` for auto-inference of token budgets.
-* `get_encoder_cudagraph_num_items(mm_kwargs)` — returns the number of items (e.g. images) in the batch.
-* `get_encoder_cudagraph_per_item_output_tokens(mm_kwargs)` — returns per-item output token counts, used for greedy packing.
-* `get_encoder_cudagraph_per_item_input_sizes(mm_kwargs)` — returns per-item input sizes (e.g. patch counts), used for DP load balancing.
-* `select_encoder_cudagraph_items(mm_kwargs, indices)` — extracts a sub-batch of items by index, used during greedy packing and DP sharding.
-* `prepare_encoder_cudagraph_capture_inputs(...)` — creates dummy inputs for graph capture.
-* `prepare_encoder_cudagraph_replay_buffers(...)` — computes new buffer values from actual batch inputs before replay.
-* `encoder_cudagraph_forward(...)` — forward pass using precomputed buffers (called during capture and replay).
-* `encoder_eager_forward(...)` — fallback eager forward when no graph fits.
-* `get_input_modality(...)` - return the modality of the inputs.
-* `get_max_frames_per_video()` - return model-specific max frames per video.
+- `get_encoder_cudagraph_config()` — returns static configuration (supported modalities, input key, buffer keys, output hidden size).
+- `get_encoder_cudagraph_budget_range(vllm_config)` — returns `(min_budget, max_budget)` for auto-inference of token budgets.
+- `get_encoder_cudagraph_num_items(mm_kwargs)` — returns the number of items (e.g. images) in the batch.
+- `get_encoder_cudagraph_per_item_output_tokens(mm_kwargs)` — returns per-item output token counts, used for greedy packing.
+- `get_encoder_cudagraph_per_item_input_sizes(mm_kwargs)` — returns per-item input sizes (e.g. patch counts), used for DP load balancing.
+- `select_encoder_cudagraph_items(mm_kwargs, indices)` — extracts a sub-batch of items by index, used during greedy packing and DP sharding. Models with a second CUDA-graph capture axis may accept keyword-only `secondary_capture_axis_key`.
+- `prepare_encoder_cudagraph_capture_inputs(...)` — creates dummy inputs for graph capture (same optional keyword as above).
+- `prepare_encoder_cudagraph_replay_buffers(...)` — computes new buffer values from actual batch inputs before replay.
+- `encoder_cudagraph_forward(...)` — forward pass using precomputed buffers (called during capture and replay).
+- `encoder_eager_forward(...)` — fallback eager forward when no graph fits.
+- `get_input_modality(...)` - return the modality of the inputs.
+- `get_max_frames_per_video()` - return model-specific max frames per video.
 
 !!! note
     The `SupportsEncoderCudaGraph` protocol is designed to be model-agnostic. New vision encoder models can opt-in by implementing the protocol methods without modifying the manager.
 
 **Supported models:**
 
-| Architecture | Models | CG for Image | CG for Video |
-| ------------ | ------ | ------------ | ------------ |
-| `Qwen3VLForConditionalGeneration` | `Qwen3-VL` | ✅︎ | ✅︎ |
-| `Qwen2_5_VLForConditionalGeneration` | `Qwen2.5-VL` | ✅︎ | ✅︎ |
-| `MiniCPMV` | `MiniCPMV2.5`,`MiniCPMV2.6`,`MiniCPMV4.0` | ✅︎ | ✅︎ |
+
+| Architecture                         | Models                                    | CG for Image | CG for Video |
+| ------------------------------------ | ----------------------------------------- | ------------ | ------------ |
+| `Qwen3VLForConditionalGeneration`    | `Qwen3-VL`                                | ✅︎           | ✅︎           |
+| `Qwen2_5_VLForConditionalGeneration` | `Qwen2.5-VL`                              | ✅︎           | ✅︎           |
+| `MiniCPMV`                           | `MiniCPMV2.5`,`MiniCPMV2.6`,`MiniCPMV4.0` | ✅︎           | ✅︎           |
+
 
 !!! note
     Encoder CUDA Graphs have currently been tested with `--mm-encoder-attn-backend=FLASH_ATTN` and `--mm-encoder-attn-backend=FLASHINFER` on Blackwell GPUs.
@@ -97,10 +101,10 @@ Models opt-in to encoder CUDA Graphs by implementing the [SupportsEncoderCudaGra
 
 Three fields in `CompilationConfig` control encoder CUDA Graphs:
 
-* `cudagraph_mm_encoder` (`bool`, default `False`) — enable CUDA Graph capture for multimodal encoder. When enabled, captures the full encoder forward as a CUDA Graph for each token budget level.
-* `encoder_cudagraph_token_budgets` (`list[int]`, default `[]`) — token budget levels for capture. If empty (default), auto-inferred from model architecture as power-of-2 levels. User-provided values override auto-inference.
-* `encoder_cudagraph_max_vision_items_per_batch` (`int`, default `0`) — maximum number of images/videos per batch during capture. If 0 (default), auto-inferred as `max_budget // min_budget`.
-* `encoder_cudagraph_max_frames_per_batch` (`int`, default `None`) — maximum number of video frames per batch during capture. If `None` (default), auto-inferred as `encoder_cudagraph_max_vision_items_per_batch * max_frames_per_video` (`max_frames_per_video` is a model-specific value according to its `processing_info`). If we limit the video count per prompt to `0`, it will also be set to `0` (i.e., fall back to image-only mode).
+- `cudagraph_mm_encoder` (`bool`, default `False`) — enable CUDA Graph capture for multimodal encoder. When enabled, captures the full encoder forward as a CUDA Graph for each token budget level.
+- `encoder_cudagraph_token_budgets` (`list[int]`, default `[]`) — token budget levels for capture. If empty (default), auto-inferred from model architecture as power-of-2 levels. User-provided values override auto-inference.
+- `encoder_cudagraph_max_vision_items_per_batch` (`int`, default `0`) — maximum number of images/videos per batch during capture. If 0 (default), auto-inferred as `max_budget // min_budget`.
+- `encoder_cudagraph_max_frames_per_batch` (`int`, default `None`) — maximum number of video frames per batch during capture. If `None` (default), auto-inferred as `encoder_cudagraph_max_vision_items_per_batch * max_frames_per_video` (`max_frames_per_video` is a model-specific value according to its `processing_info`). If we limit the video count per prompt to `0`, it will also be set to `0` (i.e., fall back to image-only mode).
 
 ## Usage guide
 
@@ -183,10 +187,12 @@ The following benchmarks were run on Blackwell GPUs (GB200) using `vllm bench mm
 
 Model: `Qwen/Qwen3-VL-30B-A3B-Instruct`, dataset: `lmarena-ai/VisionArena-Chat` (3000 prompts, 300 warmup), `max_model_len=32768`.
 
-| Backend | Mean latency improvement | P99 latency improvement |
-| :------ | :----------------------- | :---------------------- |
-| FLASH_ATTN | +11.8% (5.13→4.52ms) | +31.6% (9.16→6.26ms) |
-| FLASHINFER | +19.6% (5.42→4.36ms) | +40.3% (10.87→6.49ms) |
+
+| Backend    | Mean latency improvement | P99 latency improvement |
+| ---------- | ------------------------ | ----------------------- |
+| FLASH_ATTN | +11.8% (5.13→4.52ms)     | +31.6% (9.16→6.26ms)    |
+| FLASHINFER | +19.6% (5.42→4.36ms)     | +40.3% (10.87→6.49ms)   |
+
 
 To reproduce:
 
@@ -204,10 +210,12 @@ vllm bench mm-processor \
 
 Model: `Qwen/Qwen3-VL-32B-Instruct`, dataset: `random-mm` (1000 prompts, 200 warmup, 20 images/request at 336x336), `max_model_len=8192`.
 
-| Backend | Mean latency improvement | P99 latency improvement |
-| :------ | :----------------------- | :---------------------- |
-| FLASH_ATTN | +18.4% (28.39→23.16ms) | +14.0% (238.78→205.28ms) |
-| FLASHINFER | +44.4% (23.24→12.91ms) | +84.9% (172.41→26.05ms) |
+
+| Backend    | Mean latency improvement | P99 latency improvement  |
+| ---------- | ------------------------ | ------------------------ |
+| FLASH_ATTN | +18.4% (28.39→23.16ms)   | +14.0% (238.78→205.28ms) |
+| FLASHINFER | +44.4% (23.24→12.91ms)   | +84.9% (172.41→26.05ms)  |
+
 
 To reproduce:
 

--- a/examples/generate/multimodal/vision_language_offline.py
+++ b/examples/generate/multimodal/vision_language_offline.py
@@ -2467,6 +2467,7 @@ MODELS_SUPPORT_VIT_CUDA_GRAPH = [
     "qwen3_vl",
     "qwen3_vl_moe",
     "qwen2_5_vl",
+    "minicpmv",
 ]
 
 

--- a/tests/models/multimodal/generation/test_vit_cudagraph.py
+++ b/tests/models/multimodal/generation/test_vit_cudagraph.py
@@ -111,17 +111,6 @@ MODEL_CONFIGS: dict[str, VitCudagraphTestConfig] = {
         vllm_runner_kwargs={"trust_remote_code": True},
         marks=[pytest.mark.core_model],
     ),
-    "minicpmv_45": VitCudagraphTestConfig(
-        model="openbmb/MiniCPM-V-4_5",
-        image_prompt=minicpmv_chat_template(
-            "(<image>./</image>)\nWhat is in this image?"
-        ),
-        video_prompt=minicpmv_chat_template(
-            "(<video>./</video>)\nDescribe this video in one sentence."
-        ),
-        vllm_runner_kwargs={"trust_remote_code": True},
-        marks=[pytest.mark.core_model],
-    ),
 }
 
 

--- a/tests/models/multimodal/generation/test_vit_cudagraph.py
+++ b/tests/models/multimodal/generation/test_vit_cudagraph.py
@@ -41,6 +41,20 @@ def qwen_vl_chat_template(content: str) -> str:
     return f"<|im_start|>user\n{content}<|im_end|>\n<|im_start|>assistant\n"
 
 
+def minicpmv_25_chat_template(content: str) -> str:
+    """Llama3-style chat template used by MiniCPM-V 2.5."""
+    return (
+        f"<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n"
+        f"{content}"
+        f"<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+    )
+
+
+def minicpmv_chat_template(content: str) -> str:
+    """ChatML template used by MiniCPM-V 2.6 / 4.0 / 4.5."""
+    return f"<|im_start|>user\n{content}<|im_end|>\n<|im_start|>assistant\n"
+
+
 MODEL_CONFIGS: dict[str, VitCudagraphTestConfig] = {
     "qwen3_vl": VitCudagraphTestConfig(
         model="Qwen/Qwen3-VL-2B-Instruct",
@@ -64,6 +78,48 @@ MODEL_CONFIGS: dict[str, VitCudagraphTestConfig] = {
             "Describe this video in one sentence."
         ),
         needs_video_metadata=False,
+        marks=[pytest.mark.core_model],
+    ),
+    "minicpmv_25": VitCudagraphTestConfig(
+        model="openbmb/MiniCPM-Llama3-V-2_5",
+        modalities=["image"],
+        image_prompt=minicpmv_25_chat_template(
+            "(<image>./</image>)\nWhat is in this image?"
+        ),
+        vllm_runner_kwargs={"trust_remote_code": True},
+        marks=[pytest.mark.core_model],
+    ),
+    "minicpmv_26": VitCudagraphTestConfig(
+        model="openbmb/MiniCPM-V-2_6",
+        image_prompt=minicpmv_chat_template(
+            "(<image>./</image>)\nWhat is in this image?"
+        ),
+        video_prompt=minicpmv_chat_template(
+            "(<video>./</video>)\nDescribe this video in one sentence."
+        ),
+        vllm_runner_kwargs={"trust_remote_code": True},
+        marks=[pytest.mark.core_model],
+    ),
+    "minicpmv_40": VitCudagraphTestConfig(
+        model="openbmb/MiniCPM-V-4",
+        image_prompt=minicpmv_chat_template(
+            "(<image>./</image>)\nWhat is in this image?"
+        ),
+        video_prompt=minicpmv_chat_template(
+            "(<video>./</video>)\nDescribe this video in one sentence."
+        ),
+        vllm_runner_kwargs={"trust_remote_code": True},
+        marks=[pytest.mark.core_model],
+    ),
+    "minicpmv_45": VitCudagraphTestConfig(
+        model="openbmb/MiniCPM-V-4_5",
+        image_prompt=minicpmv_chat_template(
+            "(<image>./</image>)\nWhat is in this image?"
+        ),
+        video_prompt=minicpmv_chat_template(
+            "(<video>./</video>)\nDescribe this video in one sentence."
+        ),
+        vllm_runner_kwargs={"trust_remote_code": True},
         marks=[pytest.mark.core_model],
     ),
 }

--- a/tests/v1/cudagraph/test_encoder_cudagraph.py
+++ b/tests/v1/cudagraph/test_encoder_cudagraph.py
@@ -42,6 +42,7 @@ def _make_manager_with_budgets(budgets: list[int]) -> EncoderCudaGraphManager:
     mgr.token_budgets = sorted(budgets)
     mgr.max_batch_size = 16
     mgr.use_dp = False
+    mgr._ordered_secondary_capture_axis_keys = None
     mgr.budget_graphs = {}
     mgr.graph_hits = 0
     mgr.graph_misses = 0
@@ -350,6 +351,7 @@ def _make_manager_for_gpu(
         max_frames_per_batch if max_frames_per_batch is not None else max_batch_size * 2
     )
     mgr.use_dp = False
+    mgr._ordered_secondary_capture_axis_keys = None
     mgr.budget_graphs = {}
     mgr.graph_hits = 0
     mgr.graph_misses = 0

--- a/vllm/model_executor/models/idefics2_vision_model.py
+++ b/vllm/model_executor/models/idefics2_vision_model.py
@@ -80,40 +80,55 @@ class Idefics2VisionEmbeddings(nn.Module):
         patch_attention_mask: torch.BoolTensor,
         tgt_sizes: torch.IntTensor | None = None,
     ) -> torch.Tensor:
-        batch_size, _, max_im_h, max_im_w = pixel_values.shape
+        batch_size = pixel_values.shape[0]
         target_dtype = self.patch_embedding.weight.dtype
         patch_embeds = self.patch_embedding(pixel_values.to(target_dtype))
         embeddings = patch_embeds.flatten(2).transpose(1, 2)
-        max_nb_patches_h, max_nb_patches_w = (
-            max_im_h // self.patch_size,
-            max_im_w // self.patch_size,
-        )
         boundaries = torch.arange(
-            1 / self.num_patches_per_side, 1.0, 1 / self.num_patches_per_side
-        )
-        position_ids = torch.full(
-            size=(batch_size, max_nb_patches_h * max_nb_patches_w), fill_value=0
+            1 / self.num_patches_per_side,
+            1.0,
+            1 / self.num_patches_per_side,
+            device=pixel_values.device,
         )
 
-        for batch_idx, p_attn_mask in enumerate(patch_attention_mask):
-            if tgt_sizes is not None:
-                nb_patches_h = tgt_sizes[batch_idx][0]
-                nb_patches_w = tgt_sizes[batch_idx][1]
+        flat_patch_attention_mask = patch_attention_mask.view(batch_size, -1)
+        max_patches = flat_patch_attention_mask.shape[-1]
+
+        if tgt_sizes is not None:
+            nb_patches_h = tgt_sizes[:, 0]
+            nb_patches_w = tgt_sizes[:, 1]
+        else:
+            if patch_attention_mask.dim() == 3:
+                nb_patches_h = patch_attention_mask[:, :, 0].sum(dim=1)
+                nb_patches_w = patch_attention_mask[:, 0, :].sum(dim=1)
             else:
-                nb_patches_h = p_attn_mask[:, 0].sum()
-                nb_patches_w = p_attn_mask[0].sum()
-            fractional_coords_h = torch.arange(0, 1 - 1e-6, 1 / nb_patches_h)
-            fractional_coords_w = torch.arange(0, 1 - 1e-6, 1 / nb_patches_w)
-            bucket_coords_h = torch.bucketize(
-                fractional_coords_h, boundaries, right=True
-            )
-            bucket_coords_w = torch.bucketize(
-                fractional_coords_w, boundaries, right=True
-            )
-            pos_ids = (
-                bucket_coords_h[:, None] * self.num_patches_per_side + bucket_coords_w
-            ).flatten()
-            position_ids[batch_idx][p_attn_mask.view(-1).cpu()] = pos_ids
+                # Fallback for unexpected 2D masks without tgt_sizes
+                nb_patches_h = torch.ones(batch_size, device=pixel_values.device)
+                nb_patches_w = patch_attention_mask.sum(dim=1)
+
+        nb_h = nb_patches_h.clamp(min=1).unsqueeze(1)
+        nb_w = nb_patches_w.clamp(min=1).unsqueeze(1)
+
+        i = torch.arange(max_patches, device=pixel_values.device)
+
+        if patch_attention_mask.dim() == 3 and patch_attention_mask.shape[1] > 1:
+            stride_w = patch_attention_mask.shape[2]  # padded 2D grid width
+        else:
+            stride_w = nb_w  # (batch, 1) — per-item actual patch width
+
+        h_idx = i.unsqueeze(0) // stride_w
+        w_idx = i.unsqueeze(0) % stride_w
+
+        fractional_h = h_idx / nb_h
+        fractional_w = w_idx / nb_w
+
+        bucket_h = torch.bucketize(fractional_h, boundaries, right=True)
+        bucket_w = torch.bucketize(fractional_w, boundaries, right=True)
+
+        pos_ids = bucket_h * self.num_patches_per_side + bucket_w
+
+        position_ids = torch.where(flat_patch_attention_mask, pos_ids.to(torch.long), 0)
+
         position_ids = position_ids.to(self.position_embedding.weight.device)
         embeddings += self.position_embedding(position_ids)
         return embeddings
@@ -430,13 +445,7 @@ class Idefics2VisionTransformer(nn.Module):
         # - if apply_encoder_attention_mask is False, skip (not all models
         #   sharing this encoder apply masking in attention, e.g. Aria, Phi4)
         # - if patch_attention_mask was None, skip attention masking
-        # - if any padding exists, create an additive 4D mask and pass it
-        #   to attention; else skip mask for performance.
-        if (
-            not self.apply_encoder_attention_mask
-            or flat_patch_mask is None
-            or not torch.any(~flat_patch_mask)
-        ):
+        if not self.apply_encoder_attention_mask or flat_patch_mask is None:
             attention_mask = None
         else:
             # Additive mask: masked positions receive a large negative value.

--- a/vllm/model_executor/models/interfaces.py
+++ b/vllm/model_executor/models/interfaces.py
@@ -1590,6 +1590,9 @@ class SupportsEncoderCudaGraph(Protocol):
         - Qwen-family: slice concatenated pixel_values by cumulative
           patch offsets, subset grid_thw by indices.
         - Batched models (CLIP): index pixel_values along dim 0.
+
+        Models with a second CUDA-graph capture axis accept keyword-only
+        ``secondary_capture_axis_key`` (see ``EncoderCudaGraphManager``).
         """
         ...
 
@@ -1601,7 +1604,11 @@ class SupportsEncoderCudaGraph(Protocol):
         device: torch.device,
         dtype: torch.dtype,
     ) -> "EncoderCudaGraphCaptureInputs":
-        """Create dummy inputs and buffers for CUDA graph capture."""
+        """Create dummy inputs and buffers for CUDA graph capture.
+
+        Models with a second capture axis accept keyword-only
+        ``secondary_capture_axis_key``.
+        """
         ...
 
     def prepare_encoder_cudagraph_replay_buffers(

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -29,7 +29,7 @@ from collections import defaultdict
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from functools import partial
 from itertools import chain
-from typing import Annotated, Any, Literal, TypeAlias
+from typing import Annotated, Any, ClassVar, Literal, TypeAlias
 
 import numpy as np
 import torch
@@ -85,10 +85,16 @@ from vllm.sequence import IntermediateTensors
 from vllm.utils.collection_utils import flatten_2d_lists
 from vllm.utils.tensor_schema import TensorSchema, TensorShape
 from vllm.utils.torch_utils import set_default_torch_dtype
+from vllm.v1.worker.encoder_cudagraph_defs import (
+    EncoderCudaGraphCaptureInputs,
+    EncoderCudaGraphConfig,
+    EncoderCudaGraphReplayBuffers,
+)
 
 from .idefics2_vision_model import Idefics2VisionTransformer
 from .interfaces import (
     MultiModalEmbeddings,
+    SupportsEncoderCudaGraph,
     SupportsLoRA,
     SupportsMultiModal,
     SupportsPP,
@@ -1219,6 +1225,392 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
         raise NotImplementedError
 
 
+# --- Encoder CUDA graph (MiniCPM-V 2.5 / 2.6 / 4.0 / 4.5; mixed into subclasses) ---
+# Buffer keys
+_MINICPMV_CUDAGRAPH_BUF_KEY_TGT_SIZES = "minicpmv_tgt_sizes"
+_MINICPMV_CUDAGRAPH_BUF_KEY_PATCH_MASK = "minicpmv_patch_attn_mask"
+_MINICPMV_CUDAGRAPH_BUF_KEY_TEMPORAL_IDS = "minicpmv_temporal_ids"  # v4.5 only
+
+# mm_kwargs keys for the flat pixel-value tensor
+_MINICPMV_CUDAGRAPH_FLAT_KEY_IMAGE = "minicpmv_encoder_input_flat"
+_MINICPMV_CUDAGRAPH_FLAT_KEY_VIDEO = "minicpmv_video_encoder_input_flat"
+
+
+def _mcpmv_tgt_sizes_tensor(mm_kwargs: dict[str, Any], *, video: bool) -> torch.Tensor:
+    key = "video_tgt_sizes" if video else "tgt_sizes"
+    return mm_kwargs[key]
+
+
+def _mcpmv_pack_flat_pixels(
+    slices: list[torch.Tensor],
+    *,
+    pixel_height: int,
+    pixel_width: int,
+    max_num_slices: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    """Pack slice tensors into a fixed ``(max_num_slices, 3*H*W)`` buffer.
+
+    Every slice is ``image_size × image_size`` (see ``_mcpmv_slice_pixel_size``),
+    so all rows in the buffer are fully occupied.
+    """
+    flat_dim = 3 * pixel_height * pixel_width
+    packed = torch.zeros((max_num_slices, flat_dim), device=device, dtype=dtype)
+    n = min(len(slices), max_num_slices)
+    if n > 0:
+        packed[:n] = torch.stack(slices[:n]).reshape(n, -1).to(dtype=dtype)
+    return packed
+
+
+class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
+    """SupportsEncoderCudaGraph for MiniCPM-V Idefics2 + resampler (not 2.0)."""
+
+    supports_encoder_cudagraph: ClassVar[Literal[True]] = True
+
+    def _mcpmv_slice_pixel_size(self) -> tuple[int, int]:
+        """Return (pixel_height, pixel_width) for each slice fed into vpm.
+
+        Every slice is resized to image_size x image_size pixels before being
+        passed to the vision encoder, so this is always (image_size, image_size)
+        regardless of max_slice_num.
+        """
+        image_size = int(self.vpm.embeddings.image_size)
+        return image_size, image_size
+
+    def _mcpmv_max_patches_per_slice(self) -> int:
+        """Return max patch count per slice for patch_attention_mask sizing.
+
+        The vision encoder divides each (image_size x image_size) slice into
+        (image_size // patch_size)^2 patches, so this equals that value.
+        """
+        image_size = int(self.vpm.embeddings.image_size)
+        patch_size = int(self.vpm.embeddings.patch_size)
+        return (image_size // patch_size) ** 2
+
+    def _mcpmv_max_slices_cap(
+        self,
+        token_budget: int,
+        max_batch_size: int,
+        max_frames_per_batch: int,
+    ) -> int:
+        max_slice_num = int(getattr(self.config, "max_slice_num", 9))
+        query_num = max(1, int(self.config.query_num))
+        # Each slice produces query_num output tokens, so token_budget caps slices.
+        max_slices_by_token_budget = max(1, token_budget // query_num)
+        # Buffer must fit the largest possible input from either modality.
+        # Image batch:  max_batch_size images × (max_slice_num + 1) slices each.
+        # Video batch:  max_frames_per_batch frames × (max_slice_num + 1) slices each.
+        # Both modalities share the same captured graph, so take the larger of the two.
+        max_slices_by_content = max_batch_size * (max_slice_num + 1)
+        if self.version in {(2, 6), (4, 0), (4, 5)} and max_frames_per_batch > 0:
+            max_slices_by_content = max(
+                max_slices_by_content,
+                max_frames_per_batch * (max_slice_num + 1),
+            )
+        return max(1, min(max_slices_by_token_budget, max_slices_by_content))
+
+    def get_encoder_cudagraph_config(self) -> EncoderCudaGraphConfig:
+        buffer_keys = [
+            _MINICPMV_CUDAGRAPH_BUF_KEY_TGT_SIZES,
+            _MINICPMV_CUDAGRAPH_BUF_KEY_PATCH_MASK,
+        ]
+        if self.version == (4, 5):
+            buffer_keys.append(_MINICPMV_CUDAGRAPH_BUF_KEY_TEMPORAL_IDS)
+        # Video is only supported from 2.6 onward.
+        modalities = ["image"]
+        if self.version in {(2, 6), (4, 0), (4, 5)}:
+            modalities.append("video")
+        return EncoderCudaGraphConfig(
+            modalities=modalities,
+            input_key_by_modality={
+                "image": _MINICPMV_CUDAGRAPH_FLAT_KEY_IMAGE,
+                "video": _MINICPMV_CUDAGRAPH_FLAT_KEY_VIDEO,
+            },
+            buffer_keys=buffer_keys,
+            out_hidden_size=int(self.embed_dim),
+        )
+
+    def get_input_modality(self, mm_kwargs: dict[str, Any]) -> str:
+        if "video_pixel_values" in mm_kwargs:
+            return "video"
+        return "image"
+
+    def get_max_frames_per_video(self) -> int:
+        info = MULTIMODAL_REGISTRY.get_processing_info(self.vllm_config.model_config)
+        return int(
+            info.get_num_frames_with_most_features(
+                seq_len=self.vllm_config.model_config.max_model_len,
+                mm_counts={
+                    "video": self.multimodal_config.get_limit_per_prompt("video")
+                },
+            )
+        )
+
+    def get_encoder_cudagraph_budget_range(
+        self, vllm_config: VllmConfig
+    ) -> tuple[int, int]:
+        # Each slice produces exactly query_num resampler output tokens.
+        # A thumbnail-only image has 1 slice, so query_num is the smallest
+        # possible encoder output and the natural minimum budget.
+        min_budget = int(self.config.query_num)
+        max_budget = min(
+            vllm_config.scheduler_config.max_num_batched_tokens,
+            vllm_config.model_config.max_model_len,
+        )
+        return (min_budget, max_budget)
+
+    def get_encoder_cudagraph_num_items(self, mm_kwargs: dict[str, Any]) -> int:
+        video = self.get_input_modality(mm_kwargs) == "video"
+        pixel_values_key = "video_pixel_values" if video else "pixel_values"
+        return len(mm_kwargs[pixel_values_key])
+
+    def get_encoder_cudagraph_per_item_output_tokens(
+        self, mm_kwargs: dict[str, Any]
+    ) -> list[int]:
+        query_num = int(self.config.query_num)
+        video = self.get_input_modality(mm_kwargs) == "video"
+        pixel_values_key = "video_pixel_values" if video else "pixel_values"
+        pixel_values: list[list[torch.Tensor]] = mm_kwargs[pixel_values_key]
+        return [len(img) * query_num for img in pixel_values]
+
+    def get_encoder_cudagraph_per_item_input_sizes(
+        self, mm_kwargs: dict[str, Any]
+    ) -> list[int]:
+        video = self.get_input_modality(mm_kwargs) == "video"
+        tgt_sizes = _mcpmv_tgt_sizes_tensor(mm_kwargs, video=video)
+        pixel_values: list[list[torch.Tensor]] = mm_kwargs[
+            "video_pixel_values" if video else "pixel_values"
+        ]
+        slice_counts = [len(img) for img in pixel_values]
+        patch_sums = tgt_sizes.prod(-1)
+        return [
+            int(group.sum().item()) for group in torch.split(patch_sums, slice_counts)
+        ]
+
+    def select_encoder_cudagraph_items(
+        self,
+        mm_kwargs: dict[str, Any],
+        indices: list[int],
+    ) -> dict[str, Any]:
+        video = self.get_input_modality(mm_kwargs) == "video"
+        pixel_values_key = "video_pixel_values" if video else "pixel_values"
+        tgt_key = "video_tgt_sizes" if video else "tgt_sizes"
+        flat_key = (
+            _MINICPMV_CUDAGRAPH_FLAT_KEY_VIDEO
+            if video
+            else _MINICPMV_CUDAGRAPH_FLAT_KEY_IMAGE
+        )
+        device = next(self.vpm.parameters()).device
+        pixel_h, pixel_w = self._mcpmv_slice_pixel_size()
+
+        pixel_values: list[list[torch.Tensor]] = mm_kwargs[pixel_values_key]
+        tgt_sizes = _mcpmv_tgt_sizes_tensor(mm_kwargs, video=video)
+
+        # Base dict without the stale flat buffer (recomputed at the end).
+        subset = {k: v for k, v in mm_kwargs.items() if k != flat_key}
+
+        if not indices:
+            subset.update(
+                {
+                    pixel_values_key: [],
+                    tgt_key: torch.zeros((0, 2), dtype=torch.long, device=device),
+                    flat_key: torch.zeros(
+                        (0, 3 * pixel_h * pixel_w), device=device, dtype=torch.float32
+                    ),
+                }
+            )
+            if self.version == (4, 5):
+                subset["temporal_ids"] = None
+            return subset
+
+        # Select per-item nested slices and matching tgt_sizes rows.
+        slice_counts = [len(item_slices) for item_slices in pixel_values]
+        tgt_groups = torch.split(tgt_sizes, slice_counts)
+        selected_pixel_values = [pixel_values[i] for i in indices]
+        selected_tgt_sizes = torch.cat([tgt_groups[i] for i in indices], dim=0)
+
+        # Pack ragged [3, H, W_i] slices into fixed [num_slices, 3*H*W] buffer.
+        selected_slices = flatten_2d_lists(selected_pixel_values)
+        packed_flat_pixels = _mcpmv_pack_flat_pixels(
+            selected_slices,
+            pixel_height=pixel_h,
+            pixel_width=pixel_w,
+            max_num_slices=len(selected_slices),
+            device=selected_slices[0].device,
+            dtype=selected_slices[0].dtype,
+        )
+
+        subset.update(
+            {
+                pixel_values_key: selected_pixel_values,
+                tgt_key: selected_tgt_sizes,
+                flat_key: packed_flat_pixels,
+            }
+        )
+        if self.version == (4, 5):
+            temporal_ids = mm_kwargs.get("temporal_ids")
+            if temporal_ids is not None:
+                subset["temporal_ids"] = [temporal_ids[i] for i in indices]
+        return subset
+
+    def prepare_encoder_cudagraph_capture_inputs(
+        self,
+        token_budget: int,
+        max_batch_size: int,
+        max_frames_per_batch: int,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> EncoderCudaGraphCaptureInputs:
+        pixel_h, pixel_w = self._mcpmv_slice_pixel_size()
+        max_patches = self._mcpmv_max_patches_per_slice()
+        max_num_slices = self._mcpmv_max_slices_cap(
+            token_budget,
+            max_batch_size,
+            max_frames_per_batch,
+        )
+        flat_dim = 3 * pixel_h * pixel_w
+        flat_pixel_buffer = torch.zeros(
+            (max_num_slices, flat_dim), device=device, dtype=dtype
+        )
+        dummy_tgt_sizes = torch.ones(
+            (max_num_slices, 2), dtype=torch.long, device=device
+        )
+        # Keep capture mask aligned with tgt_sizes semantics: each 1x1 tgt_size
+        # contributes exactly one valid patch.
+        dummy_patches_per_slice = dummy_tgt_sizes.prod(-1).clamp(max=max_patches)
+        col_idx = torch.arange(max_patches, device=device)
+        dummy_patch_mask = col_idx.unsqueeze(0) < dummy_patches_per_slice.unsqueeze(1)
+        buffers: dict[str, torch.Tensor] = {
+            _MINICPMV_CUDAGRAPH_BUF_KEY_TGT_SIZES: dummy_tgt_sizes,
+            _MINICPMV_CUDAGRAPH_BUF_KEY_PATCH_MASK: dummy_patch_mask,
+        }
+        if self.version == (4, 5):
+            buffers[_MINICPMV_CUDAGRAPH_BUF_KEY_TEMPORAL_IDS] = torch.zeros(
+                max_num_slices, dtype=torch.long, device=device
+            )
+        mm_kwargs: dict[str, Any] = {
+            _MINICPMV_CUDAGRAPH_FLAT_KEY_IMAGE: flat_pixel_buffer,
+        }
+        return EncoderCudaGraphCaptureInputs(mm_kwargs=mm_kwargs, buffers=buffers)
+
+    def prepare_encoder_cudagraph_replay_buffers(
+        self,
+        mm_kwargs: dict[str, Any],
+        max_batch_size: int,
+        max_frames_per_batch: int,
+    ) -> EncoderCudaGraphReplayBuffers:
+        _ = max_frames_per_batch
+        _ = max_batch_size
+        video = self.get_input_modality(mm_kwargs) == "video"
+        max_patches = self._mcpmv_max_patches_per_slice()
+        device = next(self.vpm.parameters()).device
+        # After select_encoder_cudagraph_items, tgt_sizes contains exactly one
+        # row per selected slice, so its length equals the total slice count.
+        tgt_sizes = _mcpmv_tgt_sizes_tensor(mm_kwargs, video=video).to(
+            device=device, dtype=torch.long
+        )
+
+        patches_per_slice = tgt_sizes.prod(-1).clamp(max=max_patches)
+        col_idx = torch.arange(max_patches, device=device)
+        patch_attention_mask = col_idx.unsqueeze(0) < patches_per_slice.unsqueeze(1)
+
+        buffers: dict[str, torch.Tensor] = {
+            _MINICPMV_CUDAGRAPH_BUF_KEY_TGT_SIZES: tgt_sizes.clone(),
+            _MINICPMV_CUDAGRAPH_BUF_KEY_PATCH_MASK: patch_attention_mask,
+        }
+        if self.version == (4, 5):
+            temporal_ids = mm_kwargs.get("temporal_ids")
+            if temporal_ids is not None:
+                # temporal_ids is list[list[int]] (per-image, per-slice).
+                # After select_encoder_cudagraph_items it already holds only the
+                # selected items, so flatten directly to a 1-D tensor.
+                flat_ids = torch.tensor(
+                    flatten_2d_lists(temporal_ids), dtype=torch.long, device=device
+                )
+            else:
+                flat_ids = torch.zeros(len(tgt_sizes), dtype=torch.long, device=device)
+            buffers[_MINICPMV_CUDAGRAPH_BUF_KEY_TEMPORAL_IDS] = flat_ids
+        return EncoderCudaGraphReplayBuffers(buffers=buffers)
+
+    def encoder_cudagraph_forward(
+        self,
+        mm_kwargs: dict[str, Any],
+        buffers: dict[str, torch.Tensor],
+    ) -> torch.Tensor:
+        modality = self.get_input_modality(mm_kwargs)
+        flat_key = (
+            _MINICPMV_CUDAGRAPH_FLAT_KEY_VIDEO
+            if modality == "video"
+            else _MINICPMV_CUDAGRAPH_FLAT_KEY_IMAGE
+        )
+        flat_pixel_buffer = mm_kwargs[flat_key]
+        pixel_h, pixel_w = self._mcpmv_slice_pixel_size()
+        max_num_slices, flat_dim = flat_pixel_buffer.shape
+        assert flat_dim == 3 * pixel_h * pixel_w
+        all_pixel_values = flat_pixel_buffer.view(max_num_slices, 3, pixel_h, pixel_w)
+
+        tgt_sizes = buffers[_MINICPMV_CUDAGRAPH_BUF_KEY_TGT_SIZES]
+        patch_attention_mask = buffers[
+            _MINICPMV_CUDAGRAPH_BUF_KEY_PATCH_MASK
+        ].unsqueeze(1)
+
+        # v2.5 vpm does not accept tgt_sizes.
+        vpm_tgt_sizes = None if self.version == (2, 5) else tgt_sizes
+        vision_embedding = self.vpm(
+            all_pixel_values,
+            patch_attention_mask=patch_attention_mask,
+            tgt_sizes=vpm_tgt_sizes,
+        )
+
+        if self.version == (4, 5):
+            temporal_ids = buffers[_MINICPMV_CUDAGRAPH_BUF_KEY_TEMPORAL_IDS]
+            resampler_out = self.resampler(vision_embedding, tgt_sizes, temporal_ids)
+        else:
+            resampler_out = self.resampler(vision_embedding, tgt_sizes)
+
+        query_num = int(self.config.query_num)
+        return resampler_out.reshape(max_num_slices * query_num, int(self.embed_dim))
+
+    def encoder_eager_forward(self, mm_kwargs: dict[str, Any]) -> torch.Tensor:
+        """Eager encoder path; returns ``(total_tokens, embed_dim)`` like
+        ``encoder_cudagraph_forward``.
+
+        Called by the manager only for images/videos that exceed all token
+        budgets (single-item batches), so ``segments`` always has exactly one
+        element in practice.  Version-specific logic (e.g. temporal embeddings
+        for v4.5) is handled transparently by the polymorphic dispatch inside
+        ``get_vision_hidden_states``.
+        """
+        mm_kwargs_no_flat = {
+            k: v
+            for k, v in mm_kwargs.items()
+            if k
+            not in (
+                _MINICPMV_CUDAGRAPH_FLAT_KEY_IMAGE,
+                _MINICPMV_CUDAGRAPH_FLAT_KEY_VIDEO,
+            )
+        }
+        modalities = self._parse_and_validate_multimodal_inputs(**mm_kwargs_no_flat)
+        segments: list[torch.Tensor] = []
+        embed_dim = self.embed_dim
+        for modality in modalities:
+            if modality == "images":
+                image_input = modalities["images"]
+                image_embeddings = self.get_vision_hidden_states(image_input)
+                segments.append(image_embeddings.reshape(-1, embed_dim))
+            elif modality == "videos":
+                video_input = modalities["videos"]
+                video_embeddings = self.get_vision_hidden_states(video_input)
+                segments.append(video_embeddings.reshape(-1, embed_dim))
+        if not segments:
+            raise RuntimeError(
+                "MiniCPM-V encoder cudagraph eager path expects pixel_values "
+                "or video_pixel_values"
+            )
+        return torch.cat(segments, dim=0)
+
+
 class MiniCPMV2_0(MiniCPMVBaseModel):
     supports_encoder_tp_data = False
 
@@ -1310,7 +1702,7 @@ class MiniCPMV2_0(MiniCPMVBaseModel):
         return torch.vstack(res)
 
 
-class MiniCPMV2_5(MiniCPMVBaseModel, SupportsLoRA):
+class MiniCPMV2_5(MiniCPMVBaseModel, SupportsLoRA, _MiniCPMVEncoderCudaGraphMixin):
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",
@@ -1401,7 +1793,7 @@ class MiniCPMV2_5(MiniCPMVBaseModel, SupportsLoRA):
         return self.resampler(vision_embedding, tgt_sizes)
 
 
-class MiniCPMV2_6(MiniCPMVBaseModel, SupportsLoRA):
+class MiniCPMV2_6(MiniCPMVBaseModel, SupportsLoRA, _MiniCPMVEncoderCudaGraphMixin):
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",
@@ -1499,7 +1891,7 @@ class MiniCPMV2_6(MiniCPMVBaseModel, SupportsLoRA):
         return loaded
 
 
-class MiniCPMV4_0(MiniCPMVBaseModel, SupportsLoRA):
+class MiniCPMV4_0(MiniCPMVBaseModel, SupportsLoRA, _MiniCPMVEncoderCudaGraphMixin):
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",
@@ -1596,7 +1988,7 @@ class MiniCPMV4_0(MiniCPMVBaseModel, SupportsLoRA):
         return loaded
 
 
-class MiniCPMV4_5(MiniCPMVBaseModel, SupportsLoRA):
+class MiniCPMV4_5(MiniCPMVBaseModel, SupportsLoRA, _MiniCPMVEncoderCudaGraphMixin):
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -132,6 +132,11 @@ class MiniCPMVImagePixelInputs(TensorSchema):
         TensorShape("bn"),
     ]
 
+    # Handled as batched input but shape check via TensorShape
+    # isn't strictly necessary since it defaults to None
+    # and has a non-tensor type.
+    temporal_ids: list[list[int]] | None = None
+
 
 class MiniCPMVImageEmbeddingInputs(TensorSchema):
     """
@@ -210,25 +215,31 @@ class Resampler2_5(BaseResampler):
 
         patch_len = tgt_sizes[:, 0] * tgt_sizes[:, 1]
 
-        self._adjust_pos_cache(tgt_sizes, device=device)
+        # Only adjust the pos cache in eager mode; during CUDA graph capture
+        # the cache was already expanded by the preceding warmup run
+        if not torch.cuda.is_current_stream_capturing():
+            self._adjust_pos_cache(tgt_sizes, device=device)
 
-        max_patch_len = patch_len.max().item()
-        assert isinstance(max_patch_len, int)
+        max_patch_len = x.shape[1]
 
-        key_padding_mask = torch.zeros(
-            (bs, max_patch_len), dtype=torch.bool, device=device
-        )
+        seq_idx = torch.arange(max_patch_len, device=device).unsqueeze(0)
 
-        pos_embed = []
-        for i in range(bs):
-            tgt_h, tgt_w = tgt_sizes[i].tolist()
-            pos_embed.append(
-                self.pos_embed[:tgt_h, :tgt_w, :].reshape((tgt_h * tgt_w, -1)).to(dtype)
-            )  # patches * D
-            key_padding_mask[i, patch_len[i] :] = True
-        pos_embed = torch.nn.utils.rnn.pad_sequence(
-            pos_embed, batch_first=True, padding_value=0.0
+        tgt_w = tgt_sizes[:, 1].unsqueeze(1)
+        tgt_w = torch.clamp(tgt_w, min=1)
+
+        h_idx = seq_idx // tgt_w
+        w_idx = seq_idx % tgt_w
+
+        h_idx = torch.clamp(h_idx, max=self.pos_embed.shape[0] - 1)
+        w_idx = torch.clamp(w_idx, max=self.pos_embed.shape[1] - 1)
+
+        key_padding_mask = seq_idx >= patch_len.unsqueeze(1)
+
+        pos_embed = self.pos_embed[h_idx, w_idx].to(dtype)
+        pos_embed = torch.where(
+            key_padding_mask.unsqueeze(-1), torch.zeros_like(pos_embed), pos_embed
         ).permute(1, 0, 2)  # BLD => L * B * D
+
         x, _ = self.kv_proj(x)  # B * L * D
         x = self.ln_kv(x).permute(1, 0, 2)  # L * B * D
 
@@ -345,88 +356,110 @@ class Resampler4_5(Resampler2_5):
 
         patch_len = tgt_sizes[:, 0] * tgt_sizes[:, 1]
 
-        self._adjust_pos_cache(tgt_sizes, device=device)
+        # Only adjust the pos cache in eager mode; during CUDA graph capture
+        # the cache was already expanded by the preceding warmup run
+        if not torch.cuda.is_current_stream_capturing():
+            self._adjust_pos_cache(tgt_sizes, device=device)
+
+        max_patch_len = x.shape[1]
 
         temporal_pos_emb = False
         temporal_ids_flatten = None
         if temporal_ids is not None:
-            # example: [[-1], [-1], [2, 6, 9]]
-            temporal_ids_flatten = list(chain.from_iterable(temporal_ids))
-            max_temporal_size = max(temporal_ids_flatten, default=0)
-            if max_temporal_size > -1:
-                temporal_pos_emb = True
-            if max_temporal_size > self.max_temporal_size:
-                self._adjust_temporal_pos_cache(max_temporal_size, device)
+            if isinstance(temporal_ids, torch.Tensor):
+                temporal_ids_flatten = temporal_ids
+                if not torch.cuda.is_current_stream_capturing():
+                    max_temporal_size = temporal_ids_flatten.max().item()
+                    if max_temporal_size > -1:
+                        temporal_pos_emb = True
+                    if max_temporal_size > self.max_temporal_size:
+                        self._adjust_temporal_pos_cache(max_temporal_size, device)
+                else:
+                    temporal_pos_emb = True
+            else:
+                temporal_ids_flatten = list(chain.from_iterable(temporal_ids))
+                max_temporal_size = max(temporal_ids_flatten, default=0)
+                temporal_ids_flatten = torch.tensor(
+                    temporal_ids_flatten, dtype=torch.long, device=device
+                )
+                if max_temporal_size > -1:
+                    temporal_pos_emb = True
+                if max_temporal_size > self.max_temporal_size:
+                    self._adjust_temporal_pos_cache(max_temporal_size, device)
 
-        max_patch_len = patch_len.max().item()
-        assert isinstance(max_patch_len, int)
+        seq_idx = torch.arange(max_patch_len, device=device).unsqueeze(0)
 
-        key_padding_mask = torch.zeros(
-            (bs, max_patch_len), dtype=torch.bool, device=device
-        )
+        tgt_w = tgt_sizes[:, 1].unsqueeze(1)
+        tgt_w = torch.clamp(tgt_w, min=1)
+
+        h_idx = seq_idx // tgt_w
+        w_idx = seq_idx % tgt_w
+
+        h_idx = torch.clamp(h_idx, max=self.pos_embed.shape[0] - 1)
+        w_idx = torch.clamp(w_idx, max=self.pos_embed.shape[1] - 1)
+
+        pos_embed_2d = self.pos_embed[h_idx, w_idx].to(dtype)
+
+        key_padding_mask = seq_idx >= patch_len.unsqueeze(1)
+
+        pos_embed_2d = torch.where(
+            key_padding_mask.unsqueeze(-1), torch.zeros_like(pos_embed_2d), pos_embed_2d
+        ).permute(1, 0, 2)  # (L, bs, D)
 
         x, _ = self.kv_proj(x)  # B * L * D
         x = self.ln_kv(x).permute(1, 0, 2)  # L * B * D
         q = self.ln_q(self.query)  # Q * D
 
-        pos_embed_2d = []
-        pos_embed_temporal = []
-        for i in range(bs):
-            tgt_h, tgt_w = tgt_sizes[i]
-            if temporal_pos_emb:
-                if temporal_ids_flatten[i] == -1:
-                    pos_embed_temporal.append(
-                        torch.zeros(self.embed_dim, dtype=dtype, device=device)
-                    )
-                else:
-                    pos_embed_temporal.append(
-                        self.temporal_pos_embed[temporal_ids_flatten[i]].to(dtype)
-                    )  # D
-
-            pos_embed_2d.append(
-                self.pos_embed[:tgt_h, :tgt_w, :].reshape((tgt_h * tgt_w, -1)).to(dtype)
-            )  # patches * D
-            key_padding_mask[i, patch_len[i] :] = True
-
-        pos_embed_2d = torch.nn.utils.rnn.pad_sequence(
-            pos_embed_2d, batch_first=True, padding_value=0.0
-        ).permute(1, 0, 2)  # BLD => L * B * D
-
         k = x + pos_embed_2d
         v = x
-        if pos_embed_temporal:
-            k += torch.stack(pos_embed_temporal, dim=0)
-            bs = len(temporal_ids)
-            merge_k = []
-            merge_v = []
-            merge_key_padding_mask = []
 
-            start = 0
-            for tp in temporal_ids:
-                end = start + len(tp)
-                # L * (end-start) * D -> (end-start) * L * D
-                # -> 1 * L*(end-start) * D
-                merge_k.append(
-                    k[:, start:end, :].permute(1, 0, 2).reshape(-1, self.embed_dim)
-                )
-                merge_v.append(
-                    v[:, start:end, :].permute(1, 0, 2).reshape(-1, self.embed_dim)
-                )
-                merge_key_padding_mask.append(
-                    key_padding_mask[start:end, :].reshape(-1, 1)
-                )
+        if temporal_pos_emb:
+            # temporal_ids_flatten is 1D tensor of shape (bs,)
+            pos_embed_temporal = torch.where(
+                (temporal_ids_flatten == -1).unsqueeze(-1),
+                torch.zeros(self.embed_dim, dtype=dtype, device=device),
+                self.temporal_pos_embed[torch.clamp(temporal_ids_flatten, min=0)].to(
+                    dtype
+                ),
+            )  # (bs, D)
 
-                start = end
+            k += pos_embed_temporal.unsqueeze(0)  # (L, bs, D) + (1, bs, D)
 
-            k = torch.nn.utils.rnn.pad_sequence(
-                merge_k, batch_first=True, padding_value=0.0
-            ).permute(1, 0, 2)  # L*(end-start)
-            v = torch.nn.utils.rnn.pad_sequence(
-                merge_v, batch_first=True, padding_value=0.0
-            ).permute(1, 0, 2)  # L*(end-start)
-            key_padding_mask = torch.nn.utils.rnn.pad_sequence(
-                merge_key_padding_mask, batch_first=True, padding_value=True
-            ).squeeze(-1)
+            # skip the cross-frame merge loop when compiling into a CUDA graph
+            # (which occurs when temporal_ids is passed as a flat Tensor) because
+            # dynamic sequence lengths and batch sizes cannot be captured.
+            if not isinstance(temporal_ids, torch.Tensor):
+                bs = len(temporal_ids)
+                merge_k = []
+                merge_v = []
+                merge_key_padding_mask = []
+
+                start = 0
+                for tp in temporal_ids:
+                    end = start + len(tp)
+                    # L * (end-start) * D -> (end-start) * L * D
+                    # -> 1 * L*(end-start) * D
+                    merge_k.append(
+                        k[:, start:end, :].permute(1, 0, 2).reshape(-1, self.embed_dim)
+                    )
+                    merge_v.append(
+                        v[:, start:end, :].permute(1, 0, 2).reshape(-1, self.embed_dim)
+                    )
+                    merge_key_padding_mask.append(
+                        key_padding_mask[start:end, :].reshape(-1, 1)
+                    )
+
+                    start = end
+
+                k = torch.nn.utils.rnn.pad_sequence(
+                    merge_k, batch_first=True, padding_value=0.0
+                ).permute(1, 0, 2)  # L*(end-start)
+                v = torch.nn.utils.rnn.pad_sequence(
+                    merge_v, batch_first=True, padding_value=0.0
+                ).permute(1, 0, 2)  # L*(end-start)
+                key_padding_mask = torch.nn.utils.rnn.pad_sequence(
+                    merge_key_padding_mask, batch_first=True, padding_value=True
+                ).squeeze(-1)
 
         out = self.attn(
             self._repeat(q, bs),  # Q * B * D
@@ -465,6 +498,7 @@ def _minicpmv_field_config(hf_inputs: Mapping[str, torch.Tensor]):
         video_image_sizes=MultiModalFieldConfig.batched("video"),
         video_tgt_sizes=MultiModalFieldConfig.batched("video"),
         video_embeds=MultiModalFieldConfig.batched("video"),
+        temporal_ids=MultiModalFieldConfig.batched("video"),
     )
 
 
@@ -1031,6 +1065,7 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
         # and config class
         self.config = config
         self.multimodal_config = multimodal_config
+        self.vllm_config = vllm_config
 
         self.version = get_version_by_config(self.config)
 
@@ -1074,6 +1109,7 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
     ) -> MiniCPMVImageInputs | None:
         pixel_values = kwargs.pop("pixel_values", None)
         image_embeds = kwargs.pop("image_embeds", None)
+        temporal_ids = kwargs.pop("temporal_ids", None)
 
         if pixel_values is None and image_embeds is None:
             return None
@@ -1095,6 +1131,7 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
             pixel_values=pixel_values_flat,
             tgt_sizes=tgt_sizes_flat,
             num_slices=num_slices_flat,
+            temporal_ids=temporal_ids,
         )
 
     def _parse_and_validate_multimodal_inputs(self, **kwargs: object) -> dict:
@@ -1229,16 +1266,38 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
 # Buffer keys
 _MINICPMV_CUDAGRAPH_BUF_KEY_TGT_SIZES = "minicpmv_tgt_sizes"
 _MINICPMV_CUDAGRAPH_BUF_KEY_PATCH_MASK = "minicpmv_patch_attn_mask"
-_MINICPMV_CUDAGRAPH_BUF_KEY_TEMPORAL_IDS = "minicpmv_temporal_ids"  # v4.5 only
+_MINICPMV_CUDAGRAPH_BUF_KEY_TEMPORAL_IDS = "minicpmv_temporal_ids"
 
 # mm_kwargs keys for the flat pixel-value tensor
 _MINICPMV_CUDAGRAPH_FLAT_KEY_IMAGE = "minicpmv_encoder_input_flat"
 _MINICPMV_CUDAGRAPH_FLAT_KEY_VIDEO = "minicpmv_video_encoder_input_flat"
 
 
-def _mcpmv_tgt_sizes_tensor(mm_kwargs: dict[str, Any], *, video: bool) -> torch.Tensor:
+def _mcpmv_tgt_sizes_tensor(
+    mm_kwargs: dict[str, Any], *, video: bool
+) -> torch.Tensor | list[torch.Tensor]:
     key = "video_tgt_sizes" if video else "tgt_sizes"
     return mm_kwargs[key]
+
+
+def _mcpmv_normalize_tgt_sizes(
+    tgt_sizes: torch.Tensor,
+    slice_counts: list[int],
+) -> torch.Tensor:
+    """Normalize tgt_sizes to shape ``(total_slices, 2)``."""
+    total_slices = sum(slice_counts)
+    if tgt_sizes.dim() == 2 and tgt_sizes.shape[0] == total_slices:
+        return tgt_sizes
+    if tgt_sizes.dim() == 3:
+        return torch.cat(
+            [tgt_sizes[i, : slice_counts[i], :] for i in range(len(slice_counts))],
+            dim=0,
+        )
+    return torch.repeat_interleave(
+        tgt_sizes,
+        torch.tensor(slice_counts, device=tgt_sizes.device),
+        dim=0,
+    )
 
 
 def _mcpmv_pack_flat_pixels(
@@ -1249,17 +1308,48 @@ def _mcpmv_pack_flat_pixels(
     max_num_slices: int,
     device: torch.device,
     dtype: torch.dtype,
+    patch_size: int,
+    tgt_sizes: torch.Tensor,
 ) -> torch.Tensor:
-    """Pack slice tensors into a fixed ``(max_num_slices, 3*H*W)`` buffer.
+    """Pack slice tensors into a fixed ``(max_num_slices, 3*H*W)`` buffer."""
+    import torch.nn.functional as F
 
-    Every slice is ``image_size × image_size`` (see ``_mcpmv_slice_pixel_size``),
-    so all rows in the buffer are fully occupied.
-    """
     flat_dim = 3 * pixel_height * pixel_width
+    grid_h = pixel_height // patch_size
+    grid_w = pixel_width // patch_size
+    max_grid_patches = grid_h * grid_w
+
     packed = torch.zeros((max_num_slices, flat_dim), device=device, dtype=dtype)
     n = min(len(slices), max_num_slices)
-    if n > 0:
-        packed[:n] = torch.stack(slices[:n]).reshape(n, -1).to(dtype=dtype)
+    tgt_list = tgt_sizes.tolist()
+    for i, slc in enumerate(slices[:n]):
+        slc = slc.to(dtype=dtype, device=device)
+        C, h, w = slc.shape
+        if h == patch_size:
+            nb_h, nb_w = int(tgt_list[i][0]), int(tgt_list[i][1])
+            num_patches = nb_h * nb_w
+
+            patches = (
+                slc.view(C, patch_size, nb_h, nb_w, patch_size)
+                .permute(0, 2, 3, 1, 4)
+                .reshape(C, num_patches, patch_size, patch_size)
+            )
+
+            col = patches.permute(0, 2, 3, 1).reshape(
+                1, C * patch_size * patch_size, num_patches
+            )
+            col_padded = col.new_zeros(1, C * patch_size * patch_size, max_grid_patches)
+            col_padded[..., :num_patches] = col
+
+            folded = F.fold(
+                col_padded,
+                output_size=(pixel_height, pixel_width),
+                kernel_size=patch_size,
+                stride=patch_size,
+            )
+            packed[i] = folded.reshape(-1)
+        else:
+            packed[i].view(3, pixel_height, pixel_width)[:, :h, :w] = slc
     return packed
 
 
@@ -1269,21 +1359,10 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
     supports_encoder_cudagraph: ClassVar[Literal[True]] = True
 
     def _mcpmv_slice_pixel_size(self) -> tuple[int, int]:
-        """Return (pixel_height, pixel_width) for each slice fed into vpm.
-
-        Every slice is resized to image_size x image_size pixels before being
-        passed to the vision encoder, so this is always (image_size, image_size)
-        regardless of max_slice_num.
-        """
         image_size = int(self.vpm.embeddings.image_size)
         return image_size, image_size
 
     def _mcpmv_max_patches_per_slice(self) -> int:
-        """Return max patch count per slice for patch_attention_mask sizing.
-
-        The vision encoder divides each (image_size x image_size) slice into
-        (image_size // patch_size)^2 patches, so this equals that value.
-        """
         image_size = int(self.vpm.embeddings.image_size)
         patch_size = int(self.vpm.embeddings.patch_size)
         return (image_size // patch_size) ** 2
@@ -1296,12 +1375,7 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
     ) -> int:
         max_slice_num = int(getattr(self.config, "max_slice_num", 9))
         query_num = max(1, int(self.config.query_num))
-        # Each slice produces query_num output tokens, so token_budget caps slices.
         max_slices_by_token_budget = max(1, token_budget // query_num)
-        # Buffer must fit the largest possible input from either modality.
-        # Image batch:  max_batch_size images × (max_slice_num + 1) slices each.
-        # Video batch:  max_frames_per_batch frames × (max_slice_num + 1) slices each.
-        # Both modalities share the same captured graph, so take the larger of the two.
         max_slices_by_content = max_batch_size * (max_slice_num + 1)
         if self.version in {(2, 6), (4, 0), (4, 5)} and max_frames_per_batch > 0:
             max_slices_by_content = max(
@@ -1383,6 +1457,7 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
             "video_pixel_values" if video else "pixel_values"
         ]
         slice_counts = [len(img) for img in pixel_values]
+        tgt_sizes = _mcpmv_normalize_tgt_sizes(tgt_sizes, slice_counts)
         patch_sums = tgt_sizes.prod(-1)
         return [
             int(group.sum().item()) for group in torch.split(patch_sums, slice_counts)
@@ -1403,11 +1478,9 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
         )
         device = next(self.vpm.parameters()).device
         pixel_h, pixel_w = self._mcpmv_slice_pixel_size()
-
         pixel_values: list[list[torch.Tensor]] = mm_kwargs[pixel_values_key]
         tgt_sizes = _mcpmv_tgt_sizes_tensor(mm_kwargs, video=video)
 
-        # Base dict without the stale flat buffer (recomputed at the end).
         subset = {k: v for k, v in mm_kwargs.items() if k != flat_key}
 
         if not indices:
@@ -1426,11 +1499,13 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
 
         # Select per-item nested slices and matching tgt_sizes rows.
         slice_counts = [len(item_slices) for item_slices in pixel_values]
+
+        tgt_sizes = _mcpmv_normalize_tgt_sizes(tgt_sizes, slice_counts)
         tgt_groups = torch.split(tgt_sizes, slice_counts)
         selected_pixel_values = [pixel_values[i] for i in indices]
-        selected_tgt_sizes = torch.cat([tgt_groups[i] for i in indices], dim=0)
+        selected_tgt_sizes_list = [tgt_groups[i] for i in indices]
+        selected_tgt_sizes = torch.cat(selected_tgt_sizes_list, dim=0)
 
-        # Pack ragged [3, H, W_i] slices into fixed [num_slices, 3*H*W] buffer.
         selected_slices = flatten_2d_lists(selected_pixel_values)
         packed_flat_pixels = _mcpmv_pack_flat_pixels(
             selected_slices,
@@ -1439,12 +1514,14 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
             max_num_slices=len(selected_slices),
             device=selected_slices[0].device,
             dtype=selected_slices[0].dtype,
+            patch_size=int(self.vpm.embeddings.patch_size),
+            tgt_sizes=selected_tgt_sizes,
         )
 
         subset.update(
             {
                 pixel_values_key: selected_pixel_values,
-                tgt_key: selected_tgt_sizes,
+                tgt_key: selected_tgt_sizes_list,
                 flat_key: packed_flat_pixels,
             }
         )
@@ -1473,21 +1550,20 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
         flat_pixel_buffer = torch.zeros(
             (max_num_slices, flat_dim), device=device, dtype=dtype
         )
-        dummy_tgt_sizes = torch.ones(
-            (max_num_slices, 2), dtype=torch.long, device=device
+        patch_hw = pixel_h // int(self.vpm.embeddings.patch_size)
+        dummy_tgt_sizes = torch.full(
+            (max_num_slices, 2), patch_hw, dtype=torch.long, device=device
         )
-        # Keep capture mask aligned with tgt_sizes semantics: each 1x1 tgt_size
-        # contributes exactly one valid patch.
-        dummy_patches_per_slice = dummy_tgt_sizes.prod(-1).clamp(max=max_patches)
-        col_idx = torch.arange(max_patches, device=device)
-        dummy_patch_mask = col_idx.unsqueeze(0) < dummy_patches_per_slice.unsqueeze(1)
+        dummy_patch_mask = torch.ones(
+            (max_num_slices, max_patches), dtype=torch.bool, device=device
+        )
         buffers: dict[str, torch.Tensor] = {
             _MINICPMV_CUDAGRAPH_BUF_KEY_TGT_SIZES: dummy_tgt_sizes,
             _MINICPMV_CUDAGRAPH_BUF_KEY_PATCH_MASK: dummy_patch_mask,
         }
         if self.version == (4, 5):
-            buffers[_MINICPMV_CUDAGRAPH_BUF_KEY_TEMPORAL_IDS] = torch.zeros(
-                max_num_slices, dtype=torch.long, device=device
+            buffers[_MINICPMV_CUDAGRAPH_BUF_KEY_TEMPORAL_IDS] = torch.full(
+                (max_num_slices,), -1, dtype=torch.long, device=device
             )
         mm_kwargs: dict[str, Any] = {
             _MINICPMV_CUDAGRAPH_FLAT_KEY_IMAGE: flat_pixel_buffer,
@@ -1505,11 +1581,13 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
         video = self.get_input_modality(mm_kwargs) == "video"
         max_patches = self._mcpmv_max_patches_per_slice()
         device = next(self.vpm.parameters()).device
-        # After select_encoder_cudagraph_items, tgt_sizes contains exactly one
-        # row per selected slice, so its length equals the total slice count.
-        tgt_sizes = _mcpmv_tgt_sizes_tensor(mm_kwargs, video=video).to(
-            device=device, dtype=torch.long
-        )
+        tgt_sizes_raw = _mcpmv_tgt_sizes_tensor(mm_kwargs, video=video)
+        if isinstance(tgt_sizes_raw, list):
+            tgt_sizes = torch.cat(tgt_sizes_raw, dim=0).to(
+                device=device, dtype=torch.long
+            )
+        else:
+            tgt_sizes = tgt_sizes_raw.to(device=device, dtype=torch.long)
 
         patches_per_slice = tgt_sizes.prod(-1).clamp(max=max_patches)
         col_idx = torch.arange(max_patches, device=device)
@@ -1522,14 +1600,13 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
         if self.version == (4, 5):
             temporal_ids = mm_kwargs.get("temporal_ids")
             if temporal_ids is not None:
-                # temporal_ids is list[list[int]] (per-image, per-slice).
-                # After select_encoder_cudagraph_items it already holds only the
-                # selected items, so flatten directly to a 1-D tensor.
                 flat_ids = torch.tensor(
                     flatten_2d_lists(temporal_ids), dtype=torch.long, device=device
                 )
             else:
-                flat_ids = torch.zeros(len(tgt_sizes), dtype=torch.long, device=device)
+                flat_ids = torch.full(
+                    (len(tgt_sizes),), -1, dtype=torch.long, device=device
+                )
             buffers[_MINICPMV_CUDAGRAPH_BUF_KEY_TEMPORAL_IDS] = flat_ids
         return EncoderCudaGraphReplayBuffers(buffers=buffers)
 
@@ -1575,12 +1652,6 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
     def encoder_eager_forward(self, mm_kwargs: dict[str, Any]) -> torch.Tensor:
         """Eager encoder path; returns ``(total_tokens, embed_dim)`` like
         ``encoder_cudagraph_forward``.
-
-        Called by the manager only for images/videos that exceed all token
-        budgets (single-item batches), so ``segments`` always has exactly one
-        element in practice.  Version-specific logic (e.g. temporal embeddings
-        for v4.5) is handled transparently by the polymorphic dispatch inside
-        ``get_vision_hidden_states``.
         """
         mm_kwargs_no_flat = {
             k: v
@@ -2060,9 +2131,6 @@ class MiniCPMV4_5(MiniCPMVBaseModel, SupportsLoRA, _MiniCPMVEncoderCudaGraphMixi
         dtype = pixel_values[0].dtype
 
         all_pixel_values = torch.zeros((B, 3, P, L), dtype=dtype, device=device)
-        all_temporal_ids = (
-            None if temporal_ids is None else flatten_2d_lists(temporal_ids)
-        )
         for i, pixel_values_item in enumerate(pixel_values):
             L_item = pixel_values_item.shape[-1]
             all_pixel_values[i, ..., :L_item] = pixel_values_item
@@ -2081,7 +2149,7 @@ class MiniCPMV4_5(MiniCPMVBaseModel, SupportsLoRA, _MiniCPMVEncoderCudaGraphMixi
             tgt_sizes=tgt_sizes,
         )
 
-        return self.resampler(vision_embedding, tgt_sizes, all_temporal_ids)
+        return self.resampler(vision_embedding, tgt_sizes, temporal_ids)
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
         loader = AutoWeightsLoader(self, skip_prefixes=["apm.", "audio", "tts"])

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -132,11 +132,6 @@ class MiniCPMVImagePixelInputs(TensorSchema):
         TensorShape("bn"),
     ]
 
-    # Handled as batched input but shape check via TensorShape
-    # isn't strictly necessary since it defaults to None
-    # and has a non-tensor type.
-    temporal_ids: list[list[int]] | None = None
-
 
 class MiniCPMVImageEmbeddingInputs(TensorSchema):
     """
@@ -356,110 +351,88 @@ class Resampler4_5(Resampler2_5):
 
         patch_len = tgt_sizes[:, 0] * tgt_sizes[:, 1]
 
-        # Only adjust the pos cache in eager mode; during CUDA graph capture
-        # the cache was already expanded by the preceding warmup run
-        if not torch.cuda.is_current_stream_capturing():
-            self._adjust_pos_cache(tgt_sizes, device=device)
-
-        max_patch_len = x.shape[1]
+        self._adjust_pos_cache(tgt_sizes, device=device)
 
         temporal_pos_emb = False
         temporal_ids_flatten = None
         if temporal_ids is not None:
-            if isinstance(temporal_ids, torch.Tensor):
-                temporal_ids_flatten = temporal_ids
-                if not torch.cuda.is_current_stream_capturing():
-                    max_temporal_size = temporal_ids_flatten.max().item()
-                    if max_temporal_size > -1:
-                        temporal_pos_emb = True
-                    if max_temporal_size > self.max_temporal_size:
-                        self._adjust_temporal_pos_cache(max_temporal_size, device)
-                else:
-                    temporal_pos_emb = True
-            else:
-                temporal_ids_flatten = list(chain.from_iterable(temporal_ids))
-                max_temporal_size = max(temporal_ids_flatten, default=0)
-                temporal_ids_flatten = torch.tensor(
-                    temporal_ids_flatten, dtype=torch.long, device=device
-                )
-                if max_temporal_size > -1:
-                    temporal_pos_emb = True
-                if max_temporal_size > self.max_temporal_size:
-                    self._adjust_temporal_pos_cache(max_temporal_size, device)
+            # example: [[-1], [-1], [2, 6, 9]]
+            temporal_ids_flatten = list(chain.from_iterable(temporal_ids))
+            max_temporal_size = max(temporal_ids_flatten, default=0)
+            if max_temporal_size > -1:
+                temporal_pos_emb = True
+            if max_temporal_size > self.max_temporal_size:
+                self._adjust_temporal_pos_cache(max_temporal_size, device)
 
-        seq_idx = torch.arange(max_patch_len, device=device).unsqueeze(0)
+        max_patch_len = patch_len.max().item()
+        assert isinstance(max_patch_len, int)
 
-        tgt_w = tgt_sizes[:, 1].unsqueeze(1)
-        tgt_w = torch.clamp(tgt_w, min=1)
-
-        h_idx = seq_idx // tgt_w
-        w_idx = seq_idx % tgt_w
-
-        h_idx = torch.clamp(h_idx, max=self.pos_embed.shape[0] - 1)
-        w_idx = torch.clamp(w_idx, max=self.pos_embed.shape[1] - 1)
-
-        pos_embed_2d = self.pos_embed[h_idx, w_idx].to(dtype)
-
-        key_padding_mask = seq_idx >= patch_len.unsqueeze(1)
-
-        pos_embed_2d = torch.where(
-            key_padding_mask.unsqueeze(-1), torch.zeros_like(pos_embed_2d), pos_embed_2d
-        ).permute(1, 0, 2)  # (L, bs, D)
+        key_padding_mask = torch.zeros(
+            (bs, max_patch_len), dtype=torch.bool, device=device
+        )
 
         x, _ = self.kv_proj(x)  # B * L * D
         x = self.ln_kv(x).permute(1, 0, 2)  # L * B * D
         q = self.ln_q(self.query)  # Q * D
 
+        pos_embed_2d = []
+        pos_embed_temporal = []
+        for i in range(bs):
+            tgt_h, tgt_w = tgt_sizes[i]
+            if temporal_pos_emb:
+                if temporal_ids_flatten[i] == -1:
+                    pos_embed_temporal.append(
+                        torch.zeros(self.embed_dim, dtype=dtype, device=device)
+                    )
+                else:
+                    pos_embed_temporal.append(
+                        self.temporal_pos_embed[temporal_ids_flatten[i]].to(dtype)
+                    )  # D
+
+            pos_embed_2d.append(
+                self.pos_embed[:tgt_h, :tgt_w, :].reshape((tgt_h * tgt_w, -1)).to(dtype)
+            )  # patches * D
+            key_padding_mask[i, patch_len[i] :] = True
+
+        pos_embed_2d = torch.nn.utils.rnn.pad_sequence(
+            pos_embed_2d, batch_first=True, padding_value=0.0
+        ).permute(1, 0, 2)  # BLD => L * B * D
+
         k = x + pos_embed_2d
         v = x
+        if pos_embed_temporal:
+            k += torch.stack(pos_embed_temporal, dim=0)
+            bs = len(temporal_ids)
+            merge_k = []
+            merge_v = []
+            merge_key_padding_mask = []
 
-        if temporal_pos_emb:
-            # temporal_ids_flatten is 1D tensor of shape (bs,)
-            pos_embed_temporal = torch.where(
-                (temporal_ids_flatten == -1).unsqueeze(-1),
-                torch.zeros(self.embed_dim, dtype=dtype, device=device),
-                self.temporal_pos_embed[torch.clamp(temporal_ids_flatten, min=0)].to(
-                    dtype
-                ),
-            )  # (bs, D)
+            start = 0
+            for tp in temporal_ids:
+                end = start + len(tp)
+                # L * (end-start) * D -> (end-start) * L * D
+                # -> 1 * L*(end-start) * D
+                merge_k.append(
+                    k[:, start:end, :].permute(1, 0, 2).reshape(-1, self.embed_dim)
+                )
+                merge_v.append(
+                    v[:, start:end, :].permute(1, 0, 2).reshape(-1, self.embed_dim)
+                )
+                merge_key_padding_mask.append(
+                    key_padding_mask[start:end, :].reshape(-1, 1)
+                )
 
-            k += pos_embed_temporal.unsqueeze(0)  # (L, bs, D) + (1, bs, D)
+                start = end
 
-            # skip the cross-frame merge loop when compiling into a CUDA graph
-            # (which occurs when temporal_ids is passed as a flat Tensor) because
-            # dynamic sequence lengths and batch sizes cannot be captured.
-            if not isinstance(temporal_ids, torch.Tensor):
-                bs = len(temporal_ids)
-                merge_k = []
-                merge_v = []
-                merge_key_padding_mask = []
-
-                start = 0
-                for tp in temporal_ids:
-                    end = start + len(tp)
-                    # L * (end-start) * D -> (end-start) * L * D
-                    # -> 1 * L*(end-start) * D
-                    merge_k.append(
-                        k[:, start:end, :].permute(1, 0, 2).reshape(-1, self.embed_dim)
-                    )
-                    merge_v.append(
-                        v[:, start:end, :].permute(1, 0, 2).reshape(-1, self.embed_dim)
-                    )
-                    merge_key_padding_mask.append(
-                        key_padding_mask[start:end, :].reshape(-1, 1)
-                    )
-
-                    start = end
-
-                k = torch.nn.utils.rnn.pad_sequence(
-                    merge_k, batch_first=True, padding_value=0.0
-                ).permute(1, 0, 2)  # L*(end-start)
-                v = torch.nn.utils.rnn.pad_sequence(
-                    merge_v, batch_first=True, padding_value=0.0
-                ).permute(1, 0, 2)  # L*(end-start)
-                key_padding_mask = torch.nn.utils.rnn.pad_sequence(
-                    merge_key_padding_mask, batch_first=True, padding_value=True
-                ).squeeze(-1)
+            k = torch.nn.utils.rnn.pad_sequence(
+                merge_k, batch_first=True, padding_value=0.0
+            ).permute(1, 0, 2)  # L*(end-start)
+            v = torch.nn.utils.rnn.pad_sequence(
+                merge_v, batch_first=True, padding_value=0.0
+            ).permute(1, 0, 2)  # L*(end-start)
+            key_padding_mask = torch.nn.utils.rnn.pad_sequence(
+                merge_key_padding_mask, batch_first=True, padding_value=True
+            ).squeeze(-1)
 
         out = self.attn(
             self._repeat(q, bs),  # Q * B * D
@@ -498,7 +471,6 @@ def _minicpmv_field_config(hf_inputs: Mapping[str, torch.Tensor]):
         video_image_sizes=MultiModalFieldConfig.batched("video"),
         video_tgt_sizes=MultiModalFieldConfig.batched("video"),
         video_embeds=MultiModalFieldConfig.batched("video"),
-        temporal_ids=MultiModalFieldConfig.batched("video"),
     )
 
 
@@ -1262,11 +1234,10 @@ class MiniCPMVBaseModel(nn.Module, SupportsMultiModal, SupportsPP):
         raise NotImplementedError
 
 
-# --- Encoder CUDA graph (MiniCPM-V 2.5 / 2.6 / 4.0 / 4.5; mixed into subclasses) ---
+# --- Encoder CUDA graph (MiniCPM-V 2.5 / 2.6 / 4.0; mixed into subclasses) ---
 # Buffer keys
 _MINICPMV_CUDAGRAPH_BUF_KEY_TGT_SIZES = "minicpmv_tgt_sizes"
 _MINICPMV_CUDAGRAPH_BUF_KEY_PATCH_MASK = "minicpmv_patch_attn_mask"
-_MINICPMV_CUDAGRAPH_BUF_KEY_TEMPORAL_IDS = "minicpmv_temporal_ids"
 
 # mm_kwargs keys for the flat pixel-value tensor
 _MINICPMV_CUDAGRAPH_FLAT_KEY_IMAGE = "minicpmv_encoder_input_flat"
@@ -1377,7 +1348,7 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
         query_num = max(1, int(self.config.query_num))
         max_slices_by_token_budget = max(1, token_budget // query_num)
         max_slices_by_content = max_batch_size * (max_slice_num + 1)
-        if self.version in {(2, 6), (4, 0), (4, 5)} and max_frames_per_batch > 0:
+        if self.version in {(2, 6), (4, 0)} and max_frames_per_batch > 0:
             max_slices_by_content = max(
                 max_slices_by_content,
                 max_frames_per_batch * (max_slice_num + 1),
@@ -1389,11 +1360,9 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
             _MINICPMV_CUDAGRAPH_BUF_KEY_TGT_SIZES,
             _MINICPMV_CUDAGRAPH_BUF_KEY_PATCH_MASK,
         ]
-        if self.version == (4, 5):
-            buffer_keys.append(_MINICPMV_CUDAGRAPH_BUF_KEY_TEMPORAL_IDS)
         # Video is only supported from 2.6 onward.
         modalities = ["image"]
-        if self.version in {(2, 6), (4, 0), (4, 5)}:
+        if self.version in {(2, 6), (4, 0)}:
             modalities.append("video")
         return EncoderCudaGraphConfig(
             modalities=modalities,
@@ -1493,8 +1462,6 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
                     ),
                 }
             )
-            if self.version == (4, 5):
-                subset["temporal_ids"] = None
             return subset
 
         # Select per-item nested slices and matching tgt_sizes rows.
@@ -1525,10 +1492,6 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
                 flat_key: packed_flat_pixels,
             }
         )
-        if self.version == (4, 5):
-            temporal_ids = mm_kwargs.get("temporal_ids")
-            if temporal_ids is not None:
-                subset["temporal_ids"] = [temporal_ids[i] for i in indices]
         return subset
 
     def prepare_encoder_cudagraph_capture_inputs(
@@ -1561,10 +1524,6 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
             _MINICPMV_CUDAGRAPH_BUF_KEY_TGT_SIZES: dummy_tgt_sizes,
             _MINICPMV_CUDAGRAPH_BUF_KEY_PATCH_MASK: dummy_patch_mask,
         }
-        if self.version == (4, 5):
-            buffers[_MINICPMV_CUDAGRAPH_BUF_KEY_TEMPORAL_IDS] = torch.full(
-                (max_num_slices,), -1, dtype=torch.long, device=device
-            )
         mm_kwargs: dict[str, Any] = {
             _MINICPMV_CUDAGRAPH_FLAT_KEY_IMAGE: flat_pixel_buffer,
         }
@@ -1597,17 +1556,6 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
             _MINICPMV_CUDAGRAPH_BUF_KEY_TGT_SIZES: tgt_sizes.clone(),
             _MINICPMV_CUDAGRAPH_BUF_KEY_PATCH_MASK: patch_attention_mask,
         }
-        if self.version == (4, 5):
-            temporal_ids = mm_kwargs.get("temporal_ids")
-            if temporal_ids is not None:
-                flat_ids = torch.tensor(
-                    flatten_2d_lists(temporal_ids), dtype=torch.long, device=device
-                )
-            else:
-                flat_ids = torch.full(
-                    (len(tgt_sizes),), -1, dtype=torch.long, device=device
-                )
-            buffers[_MINICPMV_CUDAGRAPH_BUF_KEY_TEMPORAL_IDS] = flat_ids
         return EncoderCudaGraphReplayBuffers(buffers=buffers)
 
     def encoder_cudagraph_forward(
@@ -1640,11 +1588,7 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
             tgt_sizes=vpm_tgt_sizes,
         )
 
-        if self.version == (4, 5):
-            temporal_ids = buffers[_MINICPMV_CUDAGRAPH_BUF_KEY_TEMPORAL_IDS]
-            resampler_out = self.resampler(vision_embedding, tgt_sizes, temporal_ids)
-        else:
-            resampler_out = self.resampler(vision_embedding, tgt_sizes)
+        resampler_out = self.resampler(vision_embedding, tgt_sizes)
 
         query_num = int(self.config.query_num)
         return resampler_out.reshape(max_num_slices * query_num, int(self.embed_dim))
@@ -2059,7 +2003,7 @@ class MiniCPMV4_0(MiniCPMVBaseModel, SupportsLoRA, _MiniCPMVEncoderCudaGraphMixi
         return loaded
 
 
-class MiniCPMV4_5(MiniCPMVBaseModel, SupportsLoRA, _MiniCPMVEncoderCudaGraphMixin):
+class MiniCPMV4_5(MiniCPMVBaseModel, SupportsLoRA):
     packed_modules_mapping = {
         "qkv_proj": [
             "q_proj",

--- a/vllm/model_executor/models/minicpmv.py
+++ b/vllm/model_executor/models/minicpmv.py
@@ -26,7 +26,7 @@
 
 import math
 from collections import defaultdict
-from collections.abc import Callable, Iterable, Mapping, Sequence
+from collections.abc import Callable, Hashable, Iterable, Mapping, Sequence
 from functools import partial
 from itertools import chain
 from typing import Annotated, Any, ClassVar, Literal, TypeAlias
@@ -1242,6 +1242,23 @@ _MINICPMV_CUDAGRAPH_BUF_KEY_PATCH_MASK = "minicpmv_patch_attn_mask"
 # mm_kwargs keys for the flat pixel-value tensor
 _MINICPMV_CUDAGRAPH_FLAT_KEY_IMAGE = "minicpmv_encoder_input_flat"
 _MINICPMV_CUDAGRAPH_FLAT_KEY_VIDEO = "minicpmv_video_encoder_input_flat"
+_MINICPMV_CUDAGRAPH_PIXEL_HW_KEY = "minicpmv_encoder_pixel_hw"
+_MINICPMV_CUDAGRAPH_MAX_PATCHES_KEY = "minicpmv_encoder_max_patches"
+
+_MINICPMV_BASE_PATCH_BUCKETS: tuple[tuple[int, int], ...] = (
+    (32, 32),
+    (32, 64),
+    (64, 32),
+)
+
+_ENCODER_CUDAGRAPH_MM_KWARGS_SKIP_KEYS = frozenset(
+    {
+        _MINICPMV_CUDAGRAPH_FLAT_KEY_IMAGE,
+        _MINICPMV_CUDAGRAPH_FLAT_KEY_VIDEO,
+        _MINICPMV_CUDAGRAPH_PIXEL_HW_KEY,
+        _MINICPMV_CUDAGRAPH_MAX_PATCHES_KEY,
+    }
+)
 
 
 def _mcpmv_tgt_sizes_tensor(
@@ -1333,10 +1350,68 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
         image_size = int(self.vpm.embeddings.image_size)
         return image_size, image_size
 
+    def _mcpmv_patch_grid_pixel_hw(
+        self, secondary_capture_axis_key: tuple[int, int]
+    ) -> tuple[int, int]:
+        patch_size = int(self.vpm.embeddings.patch_size)
+        th, tw = secondary_capture_axis_key
+        return th * patch_size, tw * patch_size
+
+    def _mcpmv_patch_grid_num_patches(
+        self, secondary_capture_axis_key: tuple[int, int]
+    ) -> int:
+        th, tw = secondary_capture_axis_key
+        return th * tw
+
     def _mcpmv_max_patches_per_slice(self) -> int:
         image_size = int(self.vpm.embeddings.image_size)
         patch_size = int(self.vpm.embeddings.patch_size)
         return (image_size // patch_size) ** 2
+
+    def get_encoder_cudagraph_secondary_capture_axis_keys(
+        self,
+    ) -> tuple[tuple[int, int], ...]:
+        """Ordered patch-grid keys ``(nb_h, nb_w)`` for the second capture axis."""
+        max_side = int(self.vpm.embeddings.image_size) // int(
+            self.vpm.embeddings.patch_size
+        )
+        keys: list[tuple[int, int]] = []
+        seen: set[tuple[int, int]] = set()
+        for th, tw in _MINICPMV_BASE_PATCH_BUCKETS:
+            if th <= max_side and tw <= max_side:
+                keys.append((th, tw))
+                seen.add((th, tw))
+        full = (max_side, max_side)
+        if full not in seen:
+            keys.append(full)
+        return tuple(keys)
+
+    def resolve_encoder_cudagraph_secondary_capture_axis_key(
+        self,
+        mm_kwargs: dict[str, Any],
+        indices: list[int],
+        token_budget: int,
+        ordered_secondary_capture_axis_keys: Sequence[Hashable],
+    ) -> Hashable:
+        _ = token_budget
+        keys = ordered_secondary_capture_axis_keys
+        if not indices:
+            return keys[0]
+        video = self.get_input_modality(mm_kwargs) == "video"
+        pixel_values_key = "video_pixel_values" if video else "pixel_values"
+        pixel_values: list[list[torch.Tensor]] = mm_kwargs[pixel_values_key]
+        slice_counts = [len(img) for img in pixel_values]
+        tgt_sizes = _mcpmv_tgt_sizes_tensor(mm_kwargs, video=video)
+        tgt_sizes = _mcpmv_normalize_tgt_sizes(tgt_sizes, slice_counts)
+        tgt_groups = torch.split(tgt_sizes, slice_counts)
+        selected = torch.cat([tgt_groups[i] for i in indices], dim=0)
+        need_h = int(selected[:, 0].max().item())
+        need_w = int(selected[:, 1].max().item())
+        for candidate_key in keys:
+            th, tw = int(candidate_key[0]), int(candidate_key[1])
+            if th >= need_h and tw >= need_w:
+                return candidate_key
+        return keys[-1]
 
     def _mcpmv_max_slices_cap(
         self,
@@ -1436,6 +1511,8 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
         self,
         mm_kwargs: dict[str, Any],
         indices: list[int],
+        *,
+        secondary_capture_axis_key: Hashable | None = None,
     ) -> dict[str, Any]:
         video = self.get_input_modality(mm_kwargs) == "video"
         pixel_values_key = "video_pixel_values" if video else "pixel_values"
@@ -1446,13 +1523,17 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
             else _MINICPMV_CUDAGRAPH_FLAT_KEY_IMAGE
         )
         device = next(self.vpm.parameters()).device
-        pixel_h, pixel_w = self._mcpmv_slice_pixel_size()
         pixel_values: list[list[torch.Tensor]] = mm_kwargs[pixel_values_key]
         tgt_sizes = _mcpmv_tgt_sizes_tensor(mm_kwargs, video=video)
 
-        subset = {k: v for k, v in mm_kwargs.items() if k != flat_key}
+        subset = {
+            k: v
+            for k, v in mm_kwargs.items()
+            if k not in _ENCODER_CUDAGRAPH_MM_KWARGS_SKIP_KEYS
+        }
 
         if not indices:
+            pixel_h, pixel_w = self._mcpmv_slice_pixel_size()
             subset.update(
                 {
                     pixel_values_key: [],
@@ -1464,11 +1545,23 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
             )
             return subset
 
-        # Select per-item nested slices and matching tgt_sizes rows.
         slice_counts = [len(item_slices) for item_slices in pixel_values]
-
         tgt_sizes = _mcpmv_normalize_tgt_sizes(tgt_sizes, slice_counts)
         tgt_groups = torch.split(tgt_sizes, slice_counts)
+
+        if secondary_capture_axis_key is None:
+            patch_grid_key = self.resolve_encoder_cudagraph_secondary_capture_axis_key(
+                mm_kwargs,
+                indices,
+                0,
+                self.get_encoder_cudagraph_secondary_capture_axis_keys(),
+            )
+        else:
+            patch_grid_key = secondary_capture_axis_key
+        patch_grid = (int(patch_grid_key[0]), int(patch_grid_key[1]))
+        pixel_h, pixel_w = self._mcpmv_patch_grid_pixel_hw(patch_grid)
+        max_patches = self._mcpmv_patch_grid_num_patches(patch_grid)
+
         selected_pixel_values = [pixel_values[i] for i in indices]
         selected_tgt_sizes_list = [tgt_groups[i] for i in indices]
         selected_tgt_sizes = torch.cat(selected_tgt_sizes_list, dim=0)
@@ -1490,6 +1583,8 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
                 pixel_values_key: selected_pixel_values,
                 tgt_key: selected_tgt_sizes_list,
                 flat_key: packed_flat_pixels,
+                _MINICPMV_CUDAGRAPH_PIXEL_HW_KEY: (pixel_h, pixel_w),
+                _MINICPMV_CUDAGRAPH_MAX_PATCHES_KEY: max_patches,
             }
         )
         return subset
@@ -1501,9 +1596,22 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
         max_frames_per_batch: int,
         device: torch.device,
         dtype: torch.dtype,
+        *,
+        secondary_capture_axis_key: Hashable | None = None,
     ) -> EncoderCudaGraphCaptureInputs:
-        pixel_h, pixel_w = self._mcpmv_slice_pixel_size()
-        max_patches = self._mcpmv_max_patches_per_slice()
+        patch_size = int(self.vpm.embeddings.patch_size)
+        if secondary_capture_axis_key is None:
+            pixel_h, pixel_w = self._mcpmv_slice_pixel_size()
+            max_patches = self._mcpmv_max_patches_per_slice()
+            patch_hw = pixel_h // patch_size
+            tgt_th = tgt_tw = patch_hw
+        else:
+            th = int(secondary_capture_axis_key[0])
+            tw = int(secondary_capture_axis_key[1])
+            normalized_key = (th, tw)
+            pixel_h, pixel_w = self._mcpmv_patch_grid_pixel_hw(normalized_key)
+            max_patches = self._mcpmv_patch_grid_num_patches(normalized_key)
+            tgt_th, tgt_tw = normalized_key
         max_num_slices = self._mcpmv_max_slices_cap(
             token_budget,
             max_batch_size,
@@ -1513,10 +1621,11 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
         flat_pixel_buffer = torch.zeros(
             (max_num_slices, flat_dim), device=device, dtype=dtype
         )
-        patch_hw = pixel_h // int(self.vpm.embeddings.patch_size)
-        dummy_tgt_sizes = torch.full(
-            (max_num_slices, 2), patch_hw, dtype=torch.long, device=device
+        dummy_tgt_sizes = torch.zeros(
+            (max_num_slices, 2), dtype=torch.long, device=device
         )
+        dummy_tgt_sizes[:, 0] = tgt_th
+        dummy_tgt_sizes[:, 1] = tgt_tw
         dummy_patch_mask = torch.ones(
             (max_num_slices, max_patches), dtype=torch.bool, device=device
         )
@@ -1526,6 +1635,8 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
         }
         mm_kwargs: dict[str, Any] = {
             _MINICPMV_CUDAGRAPH_FLAT_KEY_IMAGE: flat_pixel_buffer,
+            _MINICPMV_CUDAGRAPH_PIXEL_HW_KEY: (pixel_h, pixel_w),
+            _MINICPMV_CUDAGRAPH_MAX_PATCHES_KEY: max_patches,
         }
         return EncoderCudaGraphCaptureInputs(mm_kwargs=mm_kwargs, buffers=buffers)
 
@@ -1538,7 +1649,7 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
         _ = max_frames_per_batch
         _ = max_batch_size
         video = self.get_input_modality(mm_kwargs) == "video"
-        max_patches = self._mcpmv_max_patches_per_slice()
+        max_patches = int(mm_kwargs[_MINICPMV_CUDAGRAPH_MAX_PATCHES_KEY])
         device = next(self.vpm.parameters()).device
         tgt_sizes_raw = _mcpmv_tgt_sizes_tensor(mm_kwargs, video=video)
         if isinstance(tgt_sizes_raw, list):
@@ -1570,7 +1681,8 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
             else _MINICPMV_CUDAGRAPH_FLAT_KEY_IMAGE
         )
         flat_pixel_buffer = mm_kwargs[flat_key]
-        pixel_h, pixel_w = self._mcpmv_slice_pixel_size()
+        pixel_hw = mm_kwargs[_MINICPMV_CUDAGRAPH_PIXEL_HW_KEY]
+        pixel_h, pixel_w = int(pixel_hw[0]), int(pixel_hw[1])
         max_num_slices, flat_dim = flat_pixel_buffer.shape
         assert flat_dim == 3 * pixel_h * pixel_w
         all_pixel_values = flat_pixel_buffer.view(max_num_slices, 3, pixel_h, pixel_w)
@@ -1600,11 +1712,7 @@ class _MiniCPMVEncoderCudaGraphMixin(SupportsEncoderCudaGraph):
         mm_kwargs_no_flat = {
             k: v
             for k, v in mm_kwargs.items()
-            if k
-            not in (
-                _MINICPMV_CUDAGRAPH_FLAT_KEY_IMAGE,
-                _MINICPMV_CUDAGRAPH_FLAT_KEY_VIDEO,
-            )
+            if k not in _ENCODER_CUDAGRAPH_MM_KWARGS_SKIP_KEYS
         }
         modalities = self._parse_and_validate_multimodal_inputs(**mm_kwargs_no_flat)
         segments: list[torch.Tensor] = []

--- a/vllm/v1/worker/encoder_cudagraph.py
+++ b/vllm/v1/worker/encoder_cudagraph.py
@@ -2,8 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 """CUDA graph manager for vision encoder budget-batch execution."""
 
+from collections.abc import Hashable
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, TypeAlias
 
 import torch
 
@@ -16,11 +17,17 @@ from vllm.distributed import (
 from vllm.logger import init_logger
 from vllm.model_executor.models.interfaces import SupportsEncoderCudaGraph
 from vllm.model_executor.models.vision import get_load_balance_assignment
+from vllm.utils.func_utils import supports_kw
 from vllm.v1.worker.encoder_cudagraph_defs import (
+    EncoderCudaGraphCaptureInputs,
     EncoderCudaGraphConfig,
 )
 
 logger = init_logger(__name__)
+
+_SECONDARY_CAPTURE_AXIS_KW = "secondary_capture_axis_key"
+
+BudgetGraphMapKey: TypeAlias = int | tuple[int, Hashable]
 
 
 @dataclass
@@ -45,6 +52,8 @@ class BudgetGraphMetadata:
     metadata_buffers: dict[str, torch.Tensor]
     # Output written by graph, read after replay
     output_buffer: torch.Tensor
+    # Second CUDA-graph capture axis (opaque ``Hashable``); ``None`` if unused.
+    secondary_capture_axis_key: Hashable | None = None
 
 
 class EncoderCudaGraphManager:
@@ -109,19 +118,67 @@ class EncoderCudaGraphManager:
             and vllm_config.parallel_config.tensor_parallel_size > 1
         )
 
-        self.budget_graphs: dict[int, BudgetGraphMetadata] = {}
+        self._ordered_secondary_capture_axis_keys: tuple[Hashable, ...] | None = None
+        get_axis_keys_fn = getattr(
+            model, "get_encoder_cudagraph_secondary_capture_axis_keys", None
+        )
+        if callable(get_axis_keys_fn):
+            keys = get_axis_keys_fn()
+            if keys is not None:
+                axis_tuple = tuple(keys)
+                if len(axis_tuple) > 0:
+                    self._ordered_secondary_capture_axis_keys = axis_tuple
+
+        self.budget_graphs: dict[BudgetGraphMapKey, BudgetGraphMetadata] = {}
         self.graph_hits = 0
         self.graph_misses = 0
         self.log_stats_interval = 100
 
         logger.info(
             "EncoderCudaGraphManager initialized with "
-            "budgets=%s, max_batch_size=%d, max_frames_per_batch=%s, use_dp=%s",
+            "budgets=%s, max_batch_size=%d, max_frames_per_batch=%s, use_dp=%s, "
+            "ordered_secondary_capture_axis_keys=%s",
             self.token_budgets,
             self.max_batch_size,
             self.max_frames_per_batch,
             self.use_dp,
+            self._ordered_secondary_capture_axis_keys,
         )
+
+    def _prepare_encoder_cudagraph_capture_inputs(
+        self,
+        token_budget: int,
+        secondary_capture_axis_key: Hashable | None,
+    ) -> EncoderCudaGraphCaptureInputs:
+        prepare_fn = self.model.prepare_encoder_cudagraph_capture_inputs
+        args = (
+            token_budget,
+            self.max_batch_size,
+            self.max_frames_per_batch,
+            self.device,
+            self.dtype,
+        )
+        if supports_kw(prepare_fn, _SECONDARY_CAPTURE_AXIS_KW):
+            return prepare_fn(
+                *args,
+                secondary_capture_axis_key=secondary_capture_axis_key,
+            )
+        return prepare_fn(*args)
+
+    def _select_encoder_cudagraph_items(
+        self,
+        mm_kwargs: dict[str, Any],
+        indices: list[int],
+        secondary_capture_axis_key: Hashable | None,
+    ) -> dict[str, Any]:
+        select_fn = self.model.select_encoder_cudagraph_items
+        if supports_kw(select_fn, _SECONDARY_CAPTURE_AXIS_KW):
+            return select_fn(
+                mm_kwargs,
+                indices,
+                secondary_capture_axis_key=secondary_capture_axis_key,
+            )
+        return select_fn(mm_kwargs, indices)
 
     @staticmethod
     def _generate_budgets(min_budget: int, max_budget: int) -> list[int]:
@@ -142,30 +199,39 @@ class EncoderCudaGraphManager:
 
     def capture(self):
         """Capture CUDA graphs for all token budgets."""
-        for token_budget in self.token_budgets:
-            self._capture_budget_graph(token_budget)
+        if self._ordered_secondary_capture_axis_keys is None:
+            for token_budget in self.token_budgets:
+                self._capture_budget_graph(token_budget)
+        else:
+            for token_budget in self.token_budgets:
+                for (
+                    secondary_capture_axis_key
+                ) in self._ordered_secondary_capture_axis_keys:
+                    self._capture_budget_graph(token_budget, secondary_capture_axis_key)
 
         logger.info(
             "Encoder CUDA graph capture complete. Captured %d budget graphs.",
             len(self.budget_graphs),
         )
 
-    def _capture_budget_graph(self, token_budget: int):
+    def _capture_budget_graph(
+        self,
+        token_budget: int,
+        secondary_capture_axis_key: Hashable | None = None,
+    ):
         """Capture CUDA graph for a single token budget."""
         logger.debug(
             "Capturing encoder cudagraph for budget=%d, max_batch_size=%d, "
-            "max_frames_per_batch=%d",
+            "max_frames_per_batch=%d, secondary_capture_axis_key=%s",
             token_budget,
             self.max_batch_size,
             self.max_frames_per_batch,
+            secondary_capture_axis_key,
         )
 
-        capture_inputs = self.model.prepare_encoder_cudagraph_capture_inputs(
+        capture_inputs = self._prepare_encoder_cudagraph_capture_inputs(
             token_budget,
-            self.max_batch_size,
-            self.max_frames_per_batch,
-            self.device,
-            self.dtype,
+            secondary_capture_axis_key,
         )
 
         mm_kwargs = capture_inputs.mm_kwargs
@@ -184,7 +250,12 @@ class EncoderCudaGraphManager:
         # so we can use the image dummy inputs to capture CUDA graph for both
         # image and video.
         input_key = self.config.input_key_by_modality["image"]
-        self.budget_graphs[token_budget] = BudgetGraphMetadata(
+        graph_map_key: BudgetGraphMapKey = (
+            token_budget
+            if secondary_capture_axis_key is None
+            else (token_budget, secondary_capture_axis_key)
+        )
+        self.budget_graphs[graph_map_key] = BudgetGraphMetadata(
             token_budget=token_budget,
             max_batch_size=self.max_batch_size,
             max_frames_per_batch=self.max_frames_per_batch,
@@ -192,6 +263,7 @@ class EncoderCudaGraphManager:
             input_buffer=mm_kwargs[input_key],
             metadata_buffers=buffers,
             output_buffer=output_buffer,
+            secondary_capture_axis_key=secondary_capture_axis_key,
         )
 
     def _find_smallest_fitting_budget_given_tokens(
@@ -235,6 +307,7 @@ class EncoderCudaGraphManager:
         mm_kwargs: dict[str, Any],
         token_budget: int,
         replay_buffers: dict[str, torch.Tensor | None],
+        secondary_capture_axis_key: Hashable | None = None,
     ) -> torch.Tensor | None:
         """Execute budget graph.
 
@@ -248,11 +321,16 @@ class EncoderCudaGraphManager:
             Encoder outputs, or None if graph not captured.
         """
         num_items = self.model.get_encoder_cudagraph_num_items(mm_kwargs)
-        if token_budget not in self.budget_graphs:
+        graph_map_key: BudgetGraphMapKey = (
+            token_budget
+            if secondary_capture_axis_key is None
+            else (token_budget, secondary_capture_axis_key)
+        )
+        if graph_map_key not in self.budget_graphs:
             self.graph_misses += num_items
             return None
 
-        graph_meta = self.budget_graphs[token_budget]
+        graph_meta = self.budget_graphs[graph_map_key]
 
         # Copy the input tensor. Buffers are sized for the full budget;
         # actual inputs may be smaller. Zero then slice-copy so padded
@@ -357,14 +435,16 @@ class EncoderCudaGraphManager:
         outputs_by_orig_idx: dict[int, torch.Tensor] = {}
 
         for batch_orig_indices, token_budget in batches:
-            batch_mm_kwargs = self.model.select_encoder_cudagraph_items(
-                mm_kwargs, batch_orig_indices
-            )
             batch_out_tokens = sum(per_item_out_tokens[i] for i in batch_orig_indices)
 
             if token_budget is None:
                 # Single oversized image: item_tokens > max_budget.
                 # graph_misses counted here for this eager fallback.
+                batch_mm_kwargs = self._select_encoder_cudagraph_items(
+                    mm_kwargs,
+                    batch_orig_indices,
+                    None,
+                )
                 logger.debug(
                     "Encoder CUDA graph fallback to eager: no budget for "
                     "%d tokens from %d images",
@@ -380,33 +460,59 @@ class EncoderCudaGraphManager:
                     per_item_out_tokens,
                     outputs_by_orig_idx,
                 )
-            else:
-                logger.debug(
-                    "Encoder CUDA graph: batch_size=%d, tokens=%d, "
-                    "budget=%d, waste=%.1f%%",
-                    len(batch_orig_indices),
-                    batch_out_tokens,
-                    token_budget,
-                    (token_budget - batch_out_tokens) / token_budget * 100,
+                continue
+
+            secondary_capture_axis_key: Hashable | None = None
+            if self._ordered_secondary_capture_axis_keys is not None:
+                resolve_fn = getattr(
+                    self.model,
+                    "resolve_encoder_cudagraph_secondary_capture_axis_key",
+                    None,
                 )
-                replay = self.model.prepare_encoder_cudagraph_replay_buffers(
-                    batch_mm_kwargs,
-                    self.max_batch_size,
-                    self.max_frames_per_batch,
+                assert callable(resolve_fn), (
+                    "Model declares secondary capture axis keys but is missing "
+                    "resolve_encoder_cudagraph_secondary_capture_axis_key()"
+                )
+                secondary_capture_axis_key = resolve_fn(
+                    mm_kwargs,
+                    batch_orig_indices,
+                    token_budget,
+                    self._ordered_secondary_capture_axis_keys,
                 )
 
-                # graph_hits counted inside _run_budget_graph after replay.
-                output = self._run_budget_graph(
-                    batch_mm_kwargs, token_budget, replay.buffers
-                )
-                assert output is not None
-                self._scatter_output_slices(
-                    output,
-                    batch_orig_indices,
-                    per_item_out_tokens,
-                    outputs_by_orig_idx,
-                    clone=True,
-                )
+            batch_mm_kwargs = self._select_encoder_cudagraph_items(
+                mm_kwargs,
+                batch_orig_indices,
+                secondary_capture_axis_key,
+            )
+            logger.debug(
+                "Encoder CUDA graph: batch_size=%d, tokens=%d, budget=%d, waste=%.1f%%",
+                len(batch_orig_indices),
+                batch_out_tokens,
+                token_budget,
+                (token_budget - batch_out_tokens) / token_budget * 100,
+            )
+            replay = self.model.prepare_encoder_cudagraph_replay_buffers(
+                batch_mm_kwargs,
+                self.max_batch_size,
+                self.max_frames_per_batch,
+            )
+
+            # graph_hits counted inside _run_budget_graph after replay.
+            output = self._run_budget_graph(
+                batch_mm_kwargs,
+                token_budget,
+                replay.buffers,
+                secondary_capture_axis_key,
+            )
+            assert output is not None
+            self._scatter_output_slices(
+                output,
+                batch_orig_indices,
+                per_item_out_tokens,
+                outputs_by_orig_idx,
+                clone=True,
+            )
 
         # Return in original batch order (caller maps outputs to token positions)
         return [outputs_by_orig_idx[i] for i in range(num_items)]
@@ -449,11 +555,11 @@ class EncoderCudaGraphManager:
         ]
 
         if len(local_indices) > 0:
-            local_mm_kwargs = self.model.select_encoder_cudagraph_items(
-                mm_kwargs, local_indices
+            local_mm_kwargs = self._select_encoder_cudagraph_items(
+                mm_kwargs, local_indices, None
             )
         else:
-            local_mm_kwargs = self.model.select_encoder_cudagraph_items(mm_kwargs, [])
+            local_mm_kwargs = self._select_encoder_cudagraph_items(mm_kwargs, [], None)
 
         max_output_tokens_per_rank = (
             max(


### PR DESCRIPTION
## Purpose
Add encoder CUDA Graph support for MiniCPM-V 2.5, 2.6, 4.0  as part of tracker #38175. This implementation follows the existing workflow introduced in #38061. 

The captured graph covers both the ViT encoder (VPM) and the resampler.

MiniCPM-V 2.0 is not included, as it predates the slice-based vision architecture required by this implementation.
MiniCPM‑V 4.5 is not included, as its dynamic frame fusion introduces input-dependent encoder shapes that are not compatible with the current static-shape CUDA Graph capture mechanism. It continues to use the eager path and does not benefit from encoder CUDA Graph replay, which may reduce performance.

## Key Updates
This PR extends the multimodal encoder CUDA Graph cache to key captured graphs by` (token_budget, secondary_capture_axis_key)` instead of `token_budget `alone.

`token_budget` continues to determine greedy packing and output buffer sizing for resampler tokens. However, for vision encoders such as those in OpenBMB's MiniCPM-V models, the encoder capture shape also depends on discrete patch-grid / pixel-layout tiers. As a result, different input shapes can share the same token budget while requiring distinct CUDA Graph captures.

Without this secondary capture axis, inputs with the same token budget are forced into a single capture shape, which can introduce unnecessary padding and reduce the efficiency benefits of CUDA Graphs. By including `secondary_capture_axis_key `in the cache key, the encoder can maintain separate captures for shape-dependent tiers while preserving the existing token-budget-based scheduling and memory allocation logic.


## Test Plan
**Unit test**
```bash
pytest tests/v1/cudagraph/test_encoder_cudagraph.py -v
```

**Functional test**

GPU: RTX 5090   
Model: MiniCPM-V-4_0

No CUDA Graph
```bash
vllm serve /root/autodl-tmp/huggingface/hub/MiniCPM-V-4/OpenBMB/MiniCPM-V-4 \
  --trust-remote-code \
  --served-model-name MiniCPM-V-4 \
  --gpu-memory-utilization 0.75 \
  --max-model-len 4096 \
  --max-num-batched-tokens 4096 \
  --limit-mm-per-prompt '{"video": 1, "image": 1}'
```
With CUDA Graph
```bash
 vllm serve /root/autodl-tmp/huggingface/hub/MiniCPM-V-4/OpenBMB/MiniCPM-V-4 \
  --trust-remote-code \
  --served-model-name MiniCPM-V-4 \
  --gpu-memory-utilization 0.75 \
  --max-model-len 4096 \
  --max-num-batched-tokens 4096 \
  --limit-mm-per-prompt '{"video": 1, "image": 1}' \
  --compilation-config '{
    "cudagraph_mm_encoder": true,
    "encoder_cudagraph_token_budgets": [1024],
    "encoder_cudagraph_max_vision_items_per_batch": 32
  }'
```


**benchmark**

GPU: RTX 5090
Model: MiniCPM-V-2_6 / MiniCPM-V-4_0

```bash
vllm bench mm-processor \
  --model /root/autodl-tmp/huggingface/hub/MiniCPM-V-4/OpenBMB/MiniCPM-V-4 \
  --trust-remote-code \
  --tokenizer-mode slow \
  --dataset-name random-mm \
  --num-prompts 500 \
  --num-warmups 100 \
  --max-model-len 4096 \
  --seed 42 \
  --gpu-memory-utilization 0.8 \
  --random-mm-base-items-per-request 8 \
  --random-mm-num-mm-items-range-ratio 0.0 \
  --random-mm-bucket-config '{"(448, 448, 1)": 1.0}' \
  --compilation-config '{
    "cudagraph_mm_encoder": true, 
    "encoder_cudagraph_token_budgets": [256, 512], 
    "encoder_cudagraph_max_vision_items_per_batch": 8
  }'
```


## Test Result
✅ **Unit test**
```bash
36 passed, 16 warnings in 7.11s 
```

✅**Functional test**

Image
```bash
# No CUDA Graph
--------------------------------------------------
A woman is standing in a room with a television screen in the background displaying an image of a ship and some text in Chinese.
--------------------------------------------------
A woman is standing in a room with a television screen in the background displaying what appears to be a news broadcast about an aircraft carrier.
--------------------------------------------------
# With CUDA Graph 
--------------------------------------------------
A woman is standing in a room with a television screen in the background displaying an image of a ship and some text in Chinese.
--------------------------------------------------
A woman in a green t-shirt and denim shorts standing in a room with a television screen in the background displaying what appears to be a news broadcast about an aircraft carrier.
--------------------------------------------------
```

Video
```bash
# No CUDA Graph
--------------------------------------------------
The video captures a serene evening scene featuring a train crossing a bridge over a body of water. The sky is overcast with a mix of dark and light clouds, suggesting it might be either dawn or dusk. The train, illuminated by its own lights, moves steadily across the bridge, creating a bright line against the dimly lit sky. The reflection of the train's lights shimmers on the water's surface below, adding to the tranquil atmosphere. As the train progresses, the background reveals faint outlines of industrial structures, possibly factories or power plants, with their silhouettes barely visible against the horizon. The overall ambiance is calm and quiet, with the train's movement being the primary action in the scene.
--------------------------------------------------
The video captures a serene evening scene featuring a train crossing a bridge over a body of water. The sky is overcast with varying shades of gray, suggesting it might be either dawn or dusk. The train, illuminated by its own lights, moves steadily across the bridge, casting a reflection on the water below. As the train progresses, the lights on the train create a shimmering effect on the water's surface. In the background, faint outlines of industrial structures can be seen, adding an urban element to the otherwise natural landscape. The overall ambiance of the video is calm and tranquil, with the train's movement providing a subtle dynamic element to the scene.
--------------------------------------------------
# With CUDA Graph 
--------------------------------------------------
The video captures a serene evening scene featuring a train crossing a bridge over a body of water. The sky is overcast with a mix of dark and light clouds, suggesting it might be either dawn or dusk. The train, illuminated by its own lights, moves steadily across the bridge, creating a bright line against the dimly lit sky. The reflection of the train's lights shimmers on the water's surface below, adding to the tranquil atmosphere. As the train progresses, the background reveals faint outlines of industrial structures, possibly factories or power plants, with their silhouettes barely visible against the horizon. The overall ambiance is calm and quiet, with the train's movement being the primary action in the scene.
--------------------------------------------------
The video captures a serene evening scene featuring a train crossing a bridge over a body of water. The sky is overcast with varying shades of gray, suggesting it might be either dawn or dusk. The train, illuminated by its own lights, moves steadily across the bridge, casting a reflection on the water below. As the train progresses, the lights on the train create a shimmering effect on the water's surface. In the background, faint outlines of industrial structures can be seen, adding an urban element to the otherwise natural landscape. The overall ambiance of the video is calm and tranquil, with the train's movement providing a subtle dynamic element to the scene.
--------------------------------------------------
```



✅ **Benchmark:**

> Single RTX 5090 · random-mm · 500 prompts / 100 warmups

Benchmark results for MiniCPM-V 2.6 and 4.0 show no measurable regression. Latency remains within normal run-to-run variance, with small improvements observed in some runs.

| Version | Backend | Mean | P99 |
|------|------|------|------|
| MiniCPM-V-2_6 | FLASH_ATTN2 | +0.60% (44555.14→44286.37ms) | +0.10% (67712.77ms→67644.05ms) |
| MiniCPM-V-4 | FLASH_ATTN2 | +2.01% (44723.41→43822.66ms) | +2.69% (84580.66ms→82305.93ms) |


**MiniCPM-V-2_6**
No CUDA Graph:
```bash
================================================================================
Multimodal Processor Benchmark Results
================================================================================

MM Processor Metrics:
                     Stage  Mean Median   Std  P99.0
          get_mm_hashes_ms  0.35   0.35  0.03   0.39
get_cache_missing_items_ms  0.02   0.02  0.00   0.03
     apply_hf_processor_ms 30.16  29.88  1.43  35.51
        merge_mm_kwargs_ms  0.44   0.41  0.08   0.63
   apply_prompt_updates_ms  6.15   6.39  0.74   7.54
     preprocessor_total_ms 37.13  36.90  1.77  42.96
        encoder_forward_ms 64.14  63.93 14.47 111.22
         num_encoder_calls  1.09   1.00  0.28   2.00

Summary: 544 total encoder calls across 500 requests.

End-to-End Latency (ms):
Metric Value (ms)
  Mean   44723.41
Median   43812.82
   Std   13619.35
 P99.0   84580.66
```

With CUDA Graph:
```bash
================================================================================
Multimodal Processor Benchmark Results
================================================================================

MM Processor Metrics:
                     Stage  Mean Median   Std  P99.0
          get_mm_hashes_ms  0.35   0.35  0.02   0.38
get_cache_missing_items_ms  0.02   0.02  0.00   0.03
     apply_hf_processor_ms 30.12  29.93  1.31  34.74
        merge_mm_kwargs_ms  0.44   0.41  0.06   0.55
   apply_prompt_updates_ms  6.16   6.40  0.73   7.38
     preprocessor_total_ms 37.09  36.92  1.55  43.03
        encoder_forward_ms 62.67  61.63 14.23 113.54
         num_encoder_calls  1.09   1.00  0.28   2.00

Summary: 543 total encoder calls across 500 requests.

End-to-End Latency (ms):
Metric Value (ms)
  Mean   43822.66
Median   42867.49
   Std   13261.40
 P99.0   82305.93
```

**MiniCPM-V-4_0**
No CUDA Graph:
```bash
================================================================================
Multimodal Processor Benchmark Results
================================================================================

MM Processor Metrics:
                     Stage  Mean Median   Std  P99.0
          get_mm_hashes_ms  0.35   0.35  0.03   0.39
get_cache_missing_items_ms  0.02   0.02  0.00   0.03
     apply_hf_processor_ms 30.16  29.88  1.43  35.51
        merge_mm_kwargs_ms  0.44   0.41  0.08   0.63
   apply_prompt_updates_ms  6.15   6.39  0.74   7.54
     preprocessor_total_ms 37.13  36.90  1.77  42.96
        encoder_forward_ms 64.14  63.93 14.47 111.22
         num_encoder_calls  1.09   1.00  0.28   2.00

Summary: 544 total encoder calls across 500 requests.

End-to-End Latency (ms):
Metric Value (ms)
  Mean   44723.41
Median   43812.82
   Std   13619.35
 P99.0   84580.66
```

With CUDA Graph:
```bash
================================================================================
Multimodal Processor Benchmark Results
================================================================================

MM Processor Metrics:
                     Stage  Mean Median   Std  P99.0
          get_mm_hashes_ms  0.35   0.35  0.02   0.38
get_cache_missing_items_ms  0.02   0.02  0.00   0.03
     apply_hf_processor_ms 30.12  29.93  1.31  34.74
        merge_mm_kwargs_ms  0.44   0.41  0.06   0.55
   apply_prompt_updates_ms  6.16   6.40  0.73   7.38
     preprocessor_total_ms 37.09  36.92  1.55  43.03
        encoder_forward_ms 62.67  61.63 14.23 113.54
         num_encoder_calls  1.09   1.00  0.28   2.00

Summary: 543 total encoder calls across 500 requests.

End-to-End Latency (ms):
Metric Value (ms)
  Mean   43822.66
Median   42867.49
   Std   13261.40
 P99.0   82305.93
```



---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>