### PR TITLE
fix: replace assert with early return in get_pkg_version for non-Linux platforms

### DIFF
--- a/vllm/collect_env.py
+++ b/vllm/collect_env.py
@@ -301,7 +301,8 @@ def get_xpu_runtime_version():
 
 
 def get_pkg_version(run_lambda, pkg):
-    assert get_platform() == "linux"
+    if get_platform() != "linux":
+        return None
 
     if pkg == "vllm_xpu_kernels":
         rc, out, _ = run_lambda("pip show vllm-xpu-kernels")


### PR DESCRIPTION
## Summary
`get_pkg_version()` in `vllm/collect_env.py` unconditionally asserts
`get_platform() == "linux"`, causing an `AssertionError` when
`vllm collect-env` is run on macOS or Windows.

## Fix
Replace the `assert` with an early `return None`, consistent with how
other platform-specific functions in this file handle non-Linux platforms.

## Test
Verified `python -m vllm.collect_env` runs successfully on macOS (Apple Silicon).

Fixes #41906