### PR TITLE
Fix DeepSeek V3 tokenizer class override

### DIFF
--- a/tests/tokenizers_/test_registry.py
+++ b/tests/tokenizers_/test_registry.py
@@ -1,10 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
+from tokenizers import Tokenizer
+from tokenizers.decoders import ByteLevel as ByteLevelDecoder
+from tokenizers.models import BPE
+from tokenizers.pre_tokenizers import ByteLevel
 
 from vllm.tokenizers import TokenizerLike
+from vllm.tokenizers import registry
 from vllm.tokenizers.registry import (
     TokenizerRegistry,
     get_tokenizer,
@@ -75,3 +82,52 @@ def test_customized_tokenizer():
     assert tokenizer.bos_token_id == 0
     assert tokenizer.eos_token_id == 1
     assert tokenizer.pad_token_id == 2
+
+
+def test_deepseek_v3_overrides_incorrect_hub_tokenizer_class(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+):
+    vocab = {
+        "MLA": 0,
+        "Ġattention": 1,
+        ",": 2,
+        "Ġor": 3,
+        "Ġmore": 4,
+        "Ġspecifically": 5,
+        ".ĊĊ": 6,
+        "<｜begin▁of▁sentence｜>": 7,
+        "<｜end▁of▁sentence｜>": 8,
+    }
+    tokenizer = Tokenizer(BPE(vocab=vocab, merges=[], unk_token=None))
+    tokenizer.pre_tokenizer = ByteLevel(add_prefix_space=False)
+    tokenizer.decoder = ByteLevelDecoder()
+    tokenizer.save(str(tmp_path / "tokenizer.json"))
+
+    (tmp_path / "tokenizer_config.json").write_text(
+        json.dumps(
+            {
+                "tokenizer_class": "LlamaTokenizerFast",
+                "legacy": True,
+                "clean_up_tokenization_spaces": False,
+                "bos_token": "<｜begin▁of▁sentence｜>",
+                "eos_token": "<｜end▁of▁sentence｜>",
+                "pad_token": "<｜end▁of▁sentence｜>",
+                "unk_token": None,
+            }
+        )
+    )
+
+    monkeypatch.setattr(
+        registry,
+        "get_config",
+        lambda *args, **kwargs: SimpleNamespace(model_type="deepseek_v3"),
+    )
+    registry.cached_get_tokenizer.cache_clear()
+    registry.cached_resolve_tokenizer_args.cache_clear()
+
+    tokenizer = get_tokenizer(str(tmp_path), trust_remote_code=True)
+
+    assert tokenizer.decode([0, 1, 2, 3, 4, 5, 6]) == (
+        "MLA attention, or more specifically.\n\n"
+    )

--- a/vllm/tokenizers/registry.py
+++ b/vllm/tokenizers/registry.py
@@ -38,7 +38,10 @@ logger = init_logger(__name__)
 # temporary workaround and better long term solutions are:
 # - Add model type to MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS in transformers (better)
 # - Fix tokenizer_class on the hub for the affected models (best)
-_MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS: set[str] = {"step3_vl"}
+_MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS: set[str] = {
+    "deepseek_v3",
+    "step3_vl",
+}
 
 _VLLM_TOKENIZERS = {
     "deepseek_v32": ("deepseek_v32", "DeepseekV32Tokenizer"),


### PR DESCRIPTION


## Purpose

DeepSeek V3's hub `tokenizer_config.json` declares `tokenizer_class: "LlamaTokenizerFast"`, which is incorrect — the underlying `tokenizer.json` is a ByteLevel BPE, not a SentencePiece-derived Llama tokenizer. When vLLM honors that hub-declared class, `LlamaTokenizerFast` skips ByteLevel decoding and the byte-level glyphs (`Ġ` for space, `Ċ` for newline) leak into decoded output.

This PR adds `deepseek_v3` to `_MODEL_TYPES_WITH_INCORRECT_TOKENIZER_CLASS` in `vllm/tokenizers/registry.py`, mirroring the existing `step3_vl` workaround. For these model types, vLLM bypasses `AutoTokenizer` and loads `TokenizersBackend` directly, which decodes correctly.

As noted in the existing comment in `registry.py`, this is a temporary workaround. Better long-term fixes are upstream — adding the model type to `MODELS_WITH_INCORRECT_HUB_TOKENIZER_CLASS` in transformers, or fixing `tokenizer_class` on the hub.

## Test Plan

New unit test `tests/tokenizers_/test_registry.py::test_deepseek_v3_overrides_incorrect_hub_tokenizer_class`:

- Builds a synthetic ByteLevel-BPE tokenizer with DeepSeek-style glyphs (`Ġ`, `Ċ`, `<｜begin▁of▁sentence｜>`, `<｜end▁of▁sentence｜>`) in the vocab.
- Writes a `tokenizer_config.json` pinning the wrong class (`LlamaTokenizerFast`) — i.e. simulates the bad hub state.
- Monkeypatches `registry.get_config` to report `model_type="deepseek_v3"`, clears the `cached_get_tokenizer` / `cached_resolve_tokenizer_args` LRU caches, and calls `get_tokenizer`.
- Asserts the decoded ids round-trip to plain text with no ByteLevel artifacts.

Run with:

```bash
pytest tests/tokenizers_/test_registry.py::test_deepseek_v3_overrides_incorrect_hub_tokenizer_class -v
