### PR TITLE
[Frontend][Bugfix] Forward chat_template_kwargs through GPT-OSS Harmo…

### DIFF
--- a/vllm/entrypoints/serve/render/serving.py
+++ b/vllm/entrypoints/serve/render/serving.py
@@ -414,11 +414,25 @@ class OpenAIServingRender:
         assert not self.supports_code_interpreter
         if (reasoning_effort := request.reasoning_effort) == "none":
             raise ValueError(f"Harmony does not support {reasoning_effort=}")
+        # Forward chat_template_kwargs so callers can override Harmony system
+        # fields (e.g. model_identity, instructions, container_description,
+        # start_date) that are otherwise unreachable from the Chat Completions
+        # request. Reserved keys passed below are stripped to avoid a duplicate
+        # keyword argument TypeError.
+        template_kwargs = dict(request.chat_template_kwargs or {})
+        for reserved in (
+            "reasoning_effort",
+            "browser_description",
+            "python_description",
+            "with_custom_tools",
+        ):
+            template_kwargs.pop(reserved, None)
         sys_msg = get_system_message(
             reasoning_effort=reasoning_effort,
             browser_description=None,
             python_description=None,
             with_custom_tools=should_include_tools,
+            **template_kwargs,
         )
         messages.append(sys_msg)
 


### PR DESCRIPTION
## Summary

`OpenAIServingRender._make_request_with_harmony` builds the Harmony system message via `get_system_message(...)` but currently ignores `request.chat_template_kwargs`.

As a result, `/v1/chat/completions` clients using GPT-OSS Harmony models cannot override supported Harmony system fields such as:

* `model_identity`
* `instructions`
* `container_description`
* `start_date`

These same overrides are already supported on `/v1/responses` through `_construct_harmony_system_input_message`, so the current behavior creates an inconsistency between the two OpenAI-compatible endpoints.

This change forwards `chat_template_kwargs` to `get_system_message(...)` after filtering out the four reserved keys that are already passed explicitly:

* `reasoning_effort`
* `browser_description`
* `python_description`
* `with_custom_tools`

Filtering these keys prevents duplicate-keyword `TypeError` exceptions while still allowing all other recognized Harmony override fields to flow through correctly.

## Why this is not a duplicate of #31607

This PR is orthogonal to #31607.

* #31607 converts a user-provided `{"role": "system"}` chat message into Harmony `instructions`.
* This PR exposes the existing Harmony override surface through `chat_template_kwargs` for Chat Completions clients.

Both changes can coexist independently and improve Harmony compatibility from different directions.

## Purpose

Provide feature parity between:

* `/v1/chat/completions`
* `/v1/responses`

for GPT-OSS Harmony system-message customization.

This allows Chat Completions clients to use the same Harmony override controls already available in the Responses API.

## Test Plan

* Run formatting and lint checks:

```bash
pre-commit run --files vllm/entrypoints/serve/render/serving.py
```

* Run Harmony-related chat completion tests:

```bash
pytest tests/entrypoints/openai/chat_completion/test_serving_chat.py -v -k harmony
```

* Manual validation:

  * Launch a GPT-OSS Harmony model.
  * Call `/v1/chat/completions` with:

```json
{
  "chat_template_kwargs": {
    "model_identity": "TestBot"
  }
}
```

* Verify that the rendered Harmony system message contains `"TestBot"`.

## Test Result

* Static code validation passes locally.
* Patch applies cleanly without modifying existing Harmony explicit parameter handling.
* Reserved-key filtering prevents duplicate-keyword argument errors.
* Non-reserved Harmony override keys propagate correctly to `get_system_message(...)`.

## AI Assistance Disclosure

Per repository policy, this change was drafted with assistance from an AI coding assistant.

The author reviewed all generated changes and is responsible for the correctness of the implementation.
