### PR TITLE
[Bugfix] Fix Gemma4 MTP streaming multi-tool calls

### DIFF
--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -399,6 +399,37 @@ class TestStreamingExtraction:
                         args_text += arg
         return args_text
 
+    def _collect_arguments_by_index(self, results):
+        """Collect streamed argument deltas by tool-call index."""
+        args_by_index: dict[int, str] = {}
+        for delta, _ in results:
+            if delta and delta.tool_calls:
+                for tc in delta.tool_calls:
+                    func = tc.function if isinstance(tc.function, dict) else tc.function
+                    if isinstance(func, dict):
+                        arg = func.get("arguments", "")
+                    else:
+                        arg = getattr(func, "arguments", "") or ""
+                    if arg:
+                        args_by_index[tc.index] = args_by_index.get(tc.index, "") + arg
+        return args_by_index
+
+    def _collect_arguments_by_index_collapsed_per_delta(self, results):
+        """Collect arguments like a client that coalesces indexes per chunk."""
+        args_by_index: dict[int, str] = {}
+        for delta, _ in results:
+            if delta and delta.tool_calls:
+                tool_calls_by_index = {tc.index: tc for tc in delta.tool_calls}
+                for tc in tool_calls_by_index.values():
+                    func = tc.function if isinstance(tc.function, dict) else tc.function
+                    if isinstance(func, dict):
+                        arg = func.get("arguments", "")
+                    else:
+                        arg = getattr(func, "arguments", "") or ""
+                    if arg:
+                        args_by_index[tc.index] = args_by_index.get(tc.index, "") + arg
+        return args_by_index
+
     def _collect_function_name(self, results):
         """Extract the function name from streaming results."""
         for delta, _ in results:
@@ -641,6 +672,98 @@ class TestStreamingExtraction:
         assert "<|" not in args_text, (
             f"Partial delimiter leaked into JSON: {args_text!r}"
         )
+
+    def test_streaming_mtp_chunk_crossing_tool_call_boundary(
+        self, parser, mock_request
+    ):
+        """MTP-sized deltas can contain one call's end and the next call's start."""
+        chunks = [
+            "<|tool_call>",
+            "call:getStationInfo{",
+            'location:<|"|>Milano<|"|>}<tool_call|><|tool_call>call:getStationInfo{',
+            'location:<|"|>Piacenza<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_by_index = self._collect_arguments_by_index(results)
+
+        assert set(args_by_index) == {0, 1}
+        assert json.loads(args_by_index[0]) == {"location": "Milano"}
+        assert json.loads(args_by_index[1]) == {"location": "Piacenza"}
+
+    def test_streaming_mtp_chunk_closes_existing_and_completes_next_call(
+        self, parser, mock_request
+    ):
+        """One MTP delta can close one call and fully contain the next call."""
+        chunks = [
+            "<|tool_call>",
+            "call:first{x:1",
+            "}<tool_call|><|tool_call>call:second{y:2}<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_by_index = self._collect_arguments_by_index(results)
+
+        assert set(args_by_index) == {0, 1}
+        assert json.loads(args_by_index[0]) == {"x": 1}
+        assert json.loads(args_by_index[1]) == {"y": 2}
+
+    def test_streaming_mtp_chunk_contains_two_complete_tool_calls(
+        self, parser, mock_request
+    ):
+        """A first streamed delta can contain two complete tool calls."""
+        chunks = [
+            "<|tool_call>call:first{x:1}<tool_call|>"
+            "<|tool_call>call:second{y:2}<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_by_index = self._collect_arguments_by_index(results)
+
+        assert set(args_by_index) == {0, 1}
+        assert json.loads(args_by_index[0]) == {"x": 1}
+        assert json.loads(args_by_index[1]) == {"y": 2}
+
+    def test_streaming_mtp_chunk_merges_same_index_argument_segments(
+        self, parser, mock_request
+    ):
+        """Segment replay should not emit duplicate index entries per chunk."""
+        chunks = [
+            "<|tool_call>",
+            "call:write_file{",
+            'path:<|"|>src/main.rs<|"|>}<tool_call|>',
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+
+        for delta, _ in results:
+            if delta and delta.tool_calls:
+                indexes = [tc.index for tc in delta.tool_calls]
+                assert len(indexes) == len(set(indexes))
+
+        args_by_index = self._collect_arguments_by_index_collapsed_per_delta(results)
+        assert set(args_by_index) == {0}
+        assert json.loads(args_by_index[0]) == {"path": "src/main.rs"}
+
+    def test_streaming_mtp_chunk_crossing_buffered_tool_call_boundary(
+        self, parser, mock_request
+    ):
+        """Segment replay must still run when buffering completes a delimiter."""
+        chunks = [
+            "<|tool_call>",
+            "call:getStationInfo{",
+            'location:<|"|>Milano<|"|>}<',
+            'tool_call|><|tool_call>call:getStationInfo{location:<|"|>Piacenza<|"|>}<',
+            "tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_by_index = self._collect_arguments_by_index(results)
+
+        assert set(args_by_index) == {0, 1}
+        assert json.loads(args_by_index[0]) == {"location": "Milano"}
+        assert json.loads(args_by_index[1]) == {"location": "Piacenza"}
 
     def test_streaming_does_not_duplicate_plain_text_after_tool_call(
         self, parser, mock_request, monkeypatch

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -511,7 +511,7 @@ class Gemma4ToolParser(ToolParser):
             return None
 
         try:
-            return self._extract_streaming(
+            return self._extract_streaming_delta_segments(
                 previous_text=previous_text,
                 current_text=current_text,
                 delta_text=delta_text,
@@ -576,6 +576,197 @@ class Gemma4ToolParser(ToolParser):
             text = text.replace(self.tool_call_end_token, "")
             if text:
                 return DeltaMessage(content=text)
+        return None
+
+    def _split_delta_text_on_tool_tokens(self, delta_text: str) -> list[str]:
+        """Split a delta so tool delimiters are processed in order."""
+        segments: list[str] = []
+        i = 0
+        while i < len(delta_text):
+            next_tokens = [
+                (idx, token)
+                for token in (self.tool_call_start_token, self.tool_call_end_token)
+                if (idx := delta_text.find(token, i)) != -1
+            ]
+            if not next_tokens:
+                segments.append(delta_text[i:])
+                break
+
+            next_idx, next_token = min(next_tokens, key=lambda item: item[0])
+            if next_idx > i:
+                segments.append(delta_text[i:next_idx])
+            segments.append(delta_text[next_idx : next_idx + len(next_token)])
+            i = next_idx + len(next_token)
+
+        return segments
+
+    def _combine_delta_messages(
+        self, messages: Sequence[DeltaMessage | None]
+    ) -> DeltaMessage | None:
+        content_parts: list[str] = []
+        reasoning_parts: list[str] = []
+        tool_calls_by_index: dict[int, DeltaToolCall] = {}
+        role: str | None = None
+
+        for message in messages:
+            if message is None:
+                continue
+            if message.role and role is None:
+                role = message.role
+            if message.content:
+                content_parts.append(message.content)
+            if message.reasoning:
+                reasoning_parts.append(message.reasoning)
+            if message.tool_calls:
+                for tool_call in message.tool_calls:
+                    self._merge_delta_tool_call(tool_calls_by_index, tool_call)
+
+        tool_calls = list(tool_calls_by_index.values())
+
+        if (
+            role is None
+            and not content_parts
+            and not reasoning_parts
+            and not tool_calls
+        ):
+            return None
+
+        return DeltaMessage(
+            role=role,
+            content="".join(content_parts) or None,
+            reasoning="".join(reasoning_parts) or None,
+            tool_calls=tool_calls,
+        )
+
+    def _merge_delta_tool_call(
+        self,
+        tool_calls_by_index: dict[int, DeltaToolCall],
+        tool_call: DeltaToolCall,
+    ) -> None:
+        if tool_call.index not in tool_calls_by_index:
+            tool_calls_by_index[tool_call.index] = DeltaToolCall(
+                id=tool_call.id,
+                type=tool_call.type,
+                index=tool_call.index,
+                function=DeltaFunctionCall(
+                    name=tool_call.function.name if tool_call.function else None,
+                    arguments=(
+                        tool_call.function.arguments if tool_call.function else None
+                    ),
+                ),
+            )
+            return
+
+        merged_tool_call = tool_calls_by_index[tool_call.index]
+        if merged_tool_call.id is None and tool_call.id is not None:
+            merged_tool_call.id = tool_call.id
+        if merged_tool_call.type is None and tool_call.type is not None:
+            merged_tool_call.type = tool_call.type
+
+        if tool_call.function is None:
+            return
+        if merged_tool_call.function is None:
+            merged_tool_call.function = DeltaFunctionCall()
+
+        if (
+            merged_tool_call.function.name is None
+            and tool_call.function.name is not None
+        ):
+            merged_tool_call.function.name = tool_call.function.name
+        if tool_call.function.arguments is not None:
+            merged_tool_call.function.arguments = (
+                merged_tool_call.function.arguments or ""
+            ) + tool_call.function.arguments
+
+    def _extract_streaming_delta_segments(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+    ) -> DeltaMessage | None:
+        if not delta_text:
+            return self._extract_streaming(
+                previous_text=previous_text,
+                current_text=current_text,
+                delta_text=delta_text,
+            )
+
+        segments = self._split_delta_text_on_tool_tokens(delta_text)
+        if len(segments) == 1:
+            return self._extract_streaming(
+                previous_text=previous_text,
+                current_text=current_text,
+                delta_text=delta_text,
+            )
+
+        messages: list[DeltaMessage | None] = []
+        segment_previous_text = self._get_segment_previous_text(
+            previous_text=previous_text,
+            current_text=current_text,
+            delta_text=delta_text,
+        )
+        if segment_previous_text is None:
+            # Defensive fallback: segmented replay mutates parser state between
+            # delimiter events, so only use it when the replay base is exact.
+            # Avoid logging generated text or arguments from the stream.
+            logger.warning(
+                "Skipping Gemma4 segmented delta replay because stream text "
+                "could not be reconciled "
+                "(segments=%d, previous_len=%d, current_len=%d, "
+                "delta_len=%d, buffered_suffix_len=%d)",
+                len(segments),
+                len(previous_text),
+                len(current_text),
+                len(delta_text),
+                len(self.buffered_delta_text),
+            )
+            return self._extract_streaming(
+                previous_text=previous_text,
+                current_text=current_text,
+                delta_text=delta_text,
+            )
+
+        for segment in segments:
+            segment_current_text = segment_previous_text + segment
+            messages.append(
+                self._extract_streaming(
+                    previous_text=segment_previous_text,
+                    current_text=segment_current_text,
+                    delta_text=segment,
+                )
+            )
+            segment_previous_text = segment_current_text
+
+        return self._combine_delta_messages(messages)
+
+    def _get_segment_previous_text(
+        self,
+        previous_text: str,
+        current_text: str,
+        delta_text: str,
+    ) -> str | None:
+        """Find the base text to replay buffered delta segments from.
+
+        ``delta_text`` may include leading characters that were buffered from
+        the previous chunk, while ``current_text`` already contains those
+        characters. It may also exclude a trailing delimiter prefix that is
+        buffered for the next chunk. Replaying delimiter segments from the
+        reconciled base avoids duplicating either side.
+        """
+        buffered_suffix = self.buffered_delta_text
+        if buffered_suffix:
+            if not current_text.endswith(buffered_suffix):
+                return None
+            processed_current_text = current_text[: -len(buffered_suffix)]
+        else:
+            processed_current_text = current_text
+
+        if (
+            delta_text
+            and len(delta_text) <= len(processed_current_text)
+            and processed_current_text.endswith(delta_text)
+        ):
+            return processed_current_text[: -len(delta_text)]
         return None
 
     def _extract_partial_call(self, current_text: str) -> tuple[str | None, str]:


### PR DESCRIPTION
Fixes #41967.

## Summary

- Split Gemma4 streaming deltas on `<|tool_call>` / `<tool_call|>` boundaries before feeding them through the existing parser state machine.
- Reconcile buffered delimiter overlap so segment replay still runs when buffering re-emits a leading delimiter prefix or withholds a trailing prefix for the next chunk.
- Merge replayed `DeltaToolCall` fragments with the same tool-call index before returning a streamed chunk, preserving order while avoiding duplicate same-index entries inside one delta.
- Preserve the existing partial-argument diffing, final argument flush, and delimiter-buffering behavior.
- Add regression tests for MTP-sized deltas that close one tool call and start the next, fully complete multiple calls in one chunk, buffered-delimiter replay, and same-index argument fragments such as filenames ending in `.rs`.

## Root Cause

MTP speculative decoding can hand the OpenAI streaming layer an accepted-token delta that spans multiple Gemma4 tool-call delimiters. The old tag-counting parser treated each delta as a single structural event. When one delta closed tool call 0 and opened tool call 1, the parser advanced `current_tool_id` for the new call before flushing the completed call, so `_handle_tool_call_end()` looked up the wrong regex match and dropped the first call's remaining arguments.

The first fix split large deltas into delimiter-bounded pieces and replayed them in order. However, Gemma4's delimiter buffer can make `delta_text` differ from `current_text[len(previous_text):]`: it may prepend a delimiter prefix that already exists at the end of `previous_text`, and it may hold back a new trailing delimiter prefix. Falling back to whole-delta parsing in that case could reintroduce the same multi-event state transition bug.

Segment replay can also produce multiple `DeltaToolCall` entries with the same index in one outbound streamed chunk. Some downstream stream assemblers coalesce tool calls by index within a chunk, so an earlier fragment such as a filename suffix or the opening quote of a string value can be lost when a later closing-tail fragment for the same index is also present.

This change processes delimiter-bounded pieces in order from a reconciled replay base, then merges same-index tool-call fragments before returning the combined delta. Completed calls flush before later calls advance parser state, buffered delimiter fragments are not duplicated, and each streamed chunk contains at most one tool-call delta per index.

## Duplicate Work Check

This is not duplicating an existing PR. I checked:

- `gh issue view 41967 --repo vllm-project/vllm --comments`
- `gh pr list --repo vllm-project/vllm --state open --search "41967 in:body"` - no matches
- `gh pr list --repo vllm-project/vllm --state open --search "Gemma4 MTP streaming tool calls"` - only unrelated Gemma4 KV-cache quantization work appeared
- `gh pr list --repo vllm-project/vllm --state open --search "Gemma4 speculative streaming tool calls"` - no matches
- `gh pr list --repo vllm-project/vllm --state open --search "drops first tool-call arguments"` - unrelated Responses API parallel-tool-call PR appeared

## Tests

- `.venv/bin/python -m pytest tests/tool_parsers/test_gemma4_tool_parser.py -q` - 51 passed
- `.venv/bin/ruff check tests/tool_parsers/test_gemma4_tool_parser.py vllm/tool_parsers/gemma4_tool_parser.py` - All checks passed
- `.venv/bin/python -m ruff check vllm/tool_parsers/gemma4_tool_parser.py tests/tool_parsers/test_gemma4_tool_parser.py` - All checks passed
- `uv pip install 'pre-commit>=4.5.1'` - installed pre-commit 4.6.0
- `.venv/bin/pre-commit install` - installed pre-commit and commit-msg hooks
- `.venv/bin/pre-commit run --all-files` - applied ruff-format changes to the two PR files; after formatting, all hooks passed except `mypy-local`, which reports existing all-files errors outside this PR
- `.venv/bin/pre-commit run --files vllm/tool_parsers/gemma4_tool_parser.py tests/tool_parsers/test_gemma4_tool_parser.py` - passed
- `.venv/bin/pre-commit run --hook-stage manual --all-files mypy-3.10` - passed

## AI Assistance

AI assistance was used to investigate the issue, draft the code change, add the regression tests, run validation, and prepare this PR description. The submitting human should review every changed line and be prepared to defend the change end-to-end.