### PR TITLE
[Scheduler] Optimize priority queue removals with lazy deletion and batch rebuild

### DIFF
--- a/tests/v1/core/test_request_queue.py
+++ b/tests/v1/core/test_request_queue.py
@@ -1,57 +1,51 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from dataclasses import dataclass, field
-
 import pytest
 
 from vllm.v1.core.sched.request_queue import PriorityRequestQueue
 
+from .utils import create_requests
+
 pytestmark = pytest.mark.cpu_test
-
-
-@dataclass(order=True, unsafe_hash=True)
-class DummyRequest:
-    priority: int
-    arrival_time: float
-    request_id: str = field(compare=False)
 
 
 def test_priority_queue_lazy_remove_skips_deleted_requests():
     queue = PriorityRequestQueue()
-    requests = [
-        DummyRequest(priority=3, arrival_time=0.0, request_id="req-3"),
-        DummyRequest(priority=1, arrival_time=0.0, request_id="req-1"),
-        DummyRequest(priority=4, arrival_time=0.0, request_id="req-4"),
-        DummyRequest(priority=0, arrival_time=0.0, request_id="req-0"),
-        DummyRequest(priority=2, arrival_time=0.0, request_id="req-2"),
-    ]
+    requests = create_requests(
+        num_requests=5,
+        req_ids=["req-3", "req-1", "req-4", "req-0", "req-2"],
+    )
+    for req, priority in zip(requests, [3, 1, 4, 0, 2]):
+        req.priority = priority
     for req in requests:
-        queue.add_request(req)  # type: ignore[arg-type]
+        queue.add_request(req)
 
     queue.remove_request(requests[3])  # top
     queue.remove_request(requests[1])  # middle
 
     assert len(queue) == 3
-    popped_ids = [queue.pop_request().request_id for _ in range(3)]  # type: ignore[union-attr]
+    popped_ids = [queue.pop_request().request_id for _ in range(3)]
     assert popped_ids == ["req-2", "req-3", "req-4"]
     assert not queue
 
 
 def test_priority_queue_rebuild_clears_tombstones():
     queue = PriorityRequestQueue()
-    requests = [
-        DummyRequest(priority=i, arrival_time=0.0, request_id=f"req-{i}")
-        for i in range(40)
-    ]
+    requests = create_requests(
+        num_requests=40,
+        req_ids=[f"req-{i}" for i in range(40)],
+    )
+    for i, req in enumerate(requests):
+        req.priority = i
     for req in requests:
-        queue.add_request(req)  # type: ignore[arg-type]
+        queue.add_request(req)
 
     for req in requests[:33]:
         queue.remove_request(req)
 
     # Trigger cleanup path.
-    top = queue.peek_request()  # type: ignore[assignment]
+    top = queue.peek_request()
     assert top.request_id == "req-33"
     assert len(queue) == 7
     assert len(queue._removed_requests) == 0
@@ -60,13 +54,15 @@ def test_priority_queue_rebuild_clears_tombstones():
 
 def test_priority_queue_iter_excludes_deleted_requests():
     queue = PriorityRequestQueue()
-    requests = [
-        DummyRequest(priority=i, arrival_time=0.0, request_id=f"req-{i}")
-        for i in range(6)
-    ]
+    requests = create_requests(
+        num_requests=6,
+        req_ids=[f"req-{i}" for i in range(6)],
+    )
+    for i, req in enumerate(requests):
+        req.priority = i
     for req in requests:
-        queue.add_request(req)  # type: ignore[arg-type]
+        queue.add_request(req)
 
     queue.remove_requests([requests[1], requests[4]])
-    ordered_ids = [req.request_id for req in queue]  # type: ignore[misc]
+    ordered_ids = [req.request_id for req in queue]
     assert ordered_ids == ["req-0", "req-2", "req-3", "req-5"]

--- a/tests/v1/core/test_request_queue.py
+++ b/tests/v1/core/test_request_queue.py
@@ -48,7 +48,6 @@ def test_priority_queue_rebuild_clears_tombstones():
     top = queue.peek_request()
     assert top.request_id == "req-33"
     assert len(queue) == 7
-    assert len(queue._removed_requests) == 0
     assert len(queue._heap) == 7
 
 
@@ -66,3 +65,18 @@ def test_priority_queue_iter_excludes_deleted_requests():
     queue.remove_requests([requests[1], requests[4]])
     ordered_ids = [req.request_id for req in queue]
     assert ordered_ids == ["req-0", "req-2", "req-3", "req-5"]
+
+
+def test_priority_queue_remove_then_readd_same_request():
+    queue = PriorityRequestQueue()
+    req_a, req_b = create_requests(num_requests=2, req_ids=["a", "b"])
+    req_a.priority = 1
+    req_b.priority = 0
+
+    queue.add_request(req_a)
+    queue.remove_request(req_a)
+    queue.add_request(req_a)
+    queue.add_request(req_b)
+
+    assert [queue.pop_request().request_id for _ in range(2)] == ["b", "a"]
+    assert not queue

--- a/tests/v1/core/test_request_queue.py
+++ b/tests/v1/core/test_request_queue.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from dataclasses import dataclass, field
+
+import pytest
+
+from vllm.v1.core.sched.request_queue import PriorityRequestQueue
+
+pytestmark = pytest.mark.cpu_test
+
+
+@dataclass(order=True, unsafe_hash=True)
+class DummyRequest:
+    priority: int
+    arrival_time: float
+    request_id: str = field(compare=False)
+
+
+def test_priority_queue_lazy_remove_skips_deleted_requests():
+    queue = PriorityRequestQueue()
+    requests = [
+        DummyRequest(priority=3, arrival_time=0.0, request_id="req-3"),
+        DummyRequest(priority=1, arrival_time=0.0, request_id="req-1"),
+        DummyRequest(priority=4, arrival_time=0.0, request_id="req-4"),
+        DummyRequest(priority=0, arrival_time=0.0, request_id="req-0"),
+        DummyRequest(priority=2, arrival_time=0.0, request_id="req-2"),
+    ]
+    for req in requests:
+        queue.add_request(req)  # type: ignore[arg-type]
+
+    queue.remove_request(requests[3])  # top
+    queue.remove_request(requests[1])  # middle
+
+    assert len(queue) == 3
+    popped_ids = [queue.pop_request().request_id for _ in range(3)]  # type: ignore[union-attr]
+    assert popped_ids == ["req-2", "req-3", "req-4"]
+    assert not queue
+
+
+def test_priority_queue_rebuild_clears_tombstones():
+    queue = PriorityRequestQueue()
+    requests = [
+        DummyRequest(priority=i, arrival_time=0.0, request_id=f"req-{i}")
+        for i in range(40)
+    ]
+    for req in requests:
+        queue.add_request(req)  # type: ignore[arg-type]
+
+    for req in requests[:33]:
+        queue.remove_request(req)
+
+    # Trigger cleanup path.
+    top = queue.peek_request()  # type: ignore[assignment]
+    assert top.request_id == "req-33"
+    assert len(queue) == 7
+    assert len(queue._removed_requests) == 0
+    assert len(queue._heap) == 7
+
+
+def test_priority_queue_iter_excludes_deleted_requests():
+    queue = PriorityRequestQueue()
+    requests = [
+        DummyRequest(priority=i, arrival_time=0.0, request_id=f"req-{i}")
+        for i in range(6)
+    ]
+    for req in requests:
+        queue.add_request(req)  # type: ignore[arg-type]
+
+    queue.remove_requests([requests[1], requests[4]])
+    ordered_ids = [req.request_id for req in queue]  # type: ignore[misc]
+    assert ordered_ids == ["req-0", "req-2", "req-3", "req-5"]

--- a/vllm/v1/core/sched/request_queue.py
+++ b/vllm/v1/core/sched/request_queue.py
@@ -141,7 +141,6 @@ class PriorityRequestQueue(RequestQueue):
     def __init__(self) -> None:
         self._heap: list[Request] = []
         self._active_requests: set[Request] = set()
-        self._removed_requests: set[Request] = set()
 
     def _rebuild_if_needed(self, min_invalid: int = 32) -> bool:
         """Rebuild the heap when invalid entries accumulate.
@@ -150,27 +149,24 @@ class PriorityRequestQueue(RequestQueue):
         1) large enough in absolute number, and
         2) at least half of heap entries.
         """
-        invalid_count = len(self._removed_requests)
+        invalid_count = len(self._heap) - len(self._active_requests)
         if invalid_count < min_invalid:
             return False
         if invalid_count * 2 < len(self._heap):
             return False
 
-        self._heap = [req for req in self._heap if req not in self._removed_requests]
+        self._heap = list(self._active_requests)
         heapq.heapify(self._heap)
-        self._removed_requests.clear()
         return True
 
     def _clean_heap_top(self) -> None:
         """Discard logically removed requests from the heap top."""
         self._rebuild_if_needed()
-        while self._heap and self._heap[0] in self._removed_requests:
-            request = heapq.heappop(self._heap)
-            self._removed_requests.remove(request)
+        while self._heap and self._heap[0] not in self._active_requests:
+            heapq.heappop(self._heap)
 
     def add_request(self, request: Request) -> None:
         """Add a request to the queue according to priority policy."""
-        self._removed_requests.discard(request)
         heapq.heappush(self._heap, request)
         self._active_requests.add(request)
 
@@ -207,9 +203,7 @@ class PriorityRequestQueue(RequestQueue):
 
     def remove_request(self, request: Request) -> None:
         """Remove a specific request from the queue."""
-        if request in self._active_requests:
-            self._active_requests.remove(request)
-            self._removed_requests.add(request)
+        self._active_requests.discard(request)
 
     def remove_requests(self, requests: Iterable[Request]) -> None:
         """Remove multiple specific requests from the queue."""
@@ -226,8 +220,8 @@ class PriorityRequestQueue(RequestQueue):
 
     def __iter__(self) -> Iterator[Request]:
         """Iterate over the queue according to priority policy."""
-        self._rebuild_if_needed(min_invalid=0)
-        heap_copy = self._heap[:]
+        heap_copy = list(self._active_requests)
+        heapq.heapify(heap_copy)
         while heap_copy:
             yield heapq.heappop(heap_copy)
 

--- a/vllm/v1/core/sched/request_queue.py
+++ b/vllm/v1/core/sched/request_queue.py
@@ -140,19 +140,52 @@ class PriorityRequestQueue(RequestQueue):
 
     def __init__(self) -> None:
         self._heap: list[Request] = []
+        self._active_requests: set[Request] = set()
+        self._removed_requests: set[Request] = set()
+
+    def _rebuild_if_needed(self, min_invalid: int = 32) -> bool:
+        """Rebuild the heap when invalid entries accumulate.
+
+        We rebuild only when tombstones are both:
+        1) large enough in absolute number, and
+        2) at least half of heap entries.
+        """
+        invalid_count = len(self._removed_requests)
+        if invalid_count < min_invalid:
+            return False
+        if invalid_count * 2 < len(self._heap):
+            return False
+
+        self._heap = [req for req in self._heap if req not in self._removed_requests]
+        heapq.heapify(self._heap)
+        self._removed_requests.clear()
+        return True
+
+    def _clean_heap_top(self) -> None:
+        """Discard logically removed requests from the heap top."""
+        self._rebuild_if_needed()
+        while self._heap and self._heap[0] in self._removed_requests:
+            request = heapq.heappop(self._heap)
+            self._removed_requests.remove(request)
 
     def add_request(self, request: Request) -> None:
         """Add a request to the queue according to priority policy."""
+        self._removed_requests.discard(request)
         heapq.heappush(self._heap, request)
+        self._active_requests.add(request)
 
     def pop_request(self) -> Request:
         """Pop a request from the queue according to priority policy."""
+        self._clean_heap_top()
         if not self._heap:
             raise IndexError("pop from empty heap")
-        return heapq.heappop(self._heap)
+        request = heapq.heappop(self._heap)
+        self._active_requests.remove(request)
+        return request
 
     def peek_request(self) -> Request:
         """Peek at the next request in the queue without removing it."""
+        self._clean_heap_top()
         if not self._heap:
             raise IndexError("peek from empty heap")
         return self._heap[0]
@@ -174,25 +207,26 @@ class PriorityRequestQueue(RequestQueue):
 
     def remove_request(self, request: Request) -> None:
         """Remove a specific request from the queue."""
-        self._heap.remove(request)
-        heapq.heapify(self._heap)
+        if request in self._active_requests:
+            self._active_requests.remove(request)
+            self._removed_requests.add(request)
 
     def remove_requests(self, requests: Iterable[Request]) -> None:
         """Remove multiple specific requests from the queue."""
-        requests_to_remove = requests if isinstance(requests, set) else set(requests)
-        self._heap = [r for r in self._heap if r not in requests_to_remove]
-        heapq.heapify(self._heap)
+        for request in requests:
+            self.remove_request(request)
 
     def __bool__(self) -> bool:
         """Check if queue has any requests."""
-        return bool(self._heap)
+        return bool(self._active_requests)
 
     def __len__(self) -> int:
         """Get number of requests in queue."""
-        return len(self._heap)
+        return len(self._active_requests)
 
     def __iter__(self) -> Iterator[Request]:
         """Iterate over the queue according to priority policy."""
+        self._rebuild_if_needed(min_invalid=0)
         heap_copy = self._heap[:]
         while heap_copy:
             yield heapq.heappop(heap_copy)

--- a/vllm/v1/core/sched/request_queue.py
+++ b/vllm/v1/core/sched/request_queue.py
@@ -220,10 +220,7 @@ class PriorityRequestQueue(RequestQueue):
 
     def __iter__(self) -> Iterator[Request]:
         """Iterate over the queue according to priority policy."""
-        heap_copy = list(self._active_requests)
-        heapq.heapify(heap_copy)
-        while heap_copy:
-            yield heapq.heappop(heap_copy)
+        yield from sorted(self._active_requests)
 
 
 def create_request_queue(policy: SchedulingPolicy) -> RequestQueue:


### PR DESCRIPTION
## Summary
This PR improves `PriorityRequestQueue` performance under disconnect-heavy workloads when priority scheduling is enabled.

Previously, removing waiting requests performed immediate physical deletion from the heap, causing frequent `O(N)` operations (`list.remove` + `heapify`) and scheduler CPU stalls at high abort rates.

This change introduces lazy deletion with amortized cleanup:
- Mark removed requests logically in `O(1)`.
- Clean invalid heap entries lazily on `peek` / `pop`.
- Rebuild the heap in batch when tombstones accumulate, using `heapify` for linear-time compaction.

## Changes
- Added `_active_requests` and `_removed_requests` tracking in `PriorityRequestQueue`.
- Replaced immediate heap deletion in `remove_request` with logical tombstoning.
- Added `_clean_heap_top()` to discard invalid top entries during access.
- Added `_rebuild_if_needed()` to compact heap when invalid entries are both:
  - above an absolute threshold, and
  - a large fraction of the heap.
- Updated `__len__` and `__bool__` to reflect active requests, not raw heap size.
- Added unit tests:
  - lazy remove correctness,
  - rebuild behavior,
  - iterator correctness with deleted requests.

## Complexity Impact
- Removal path: frequent `O(N)` -> near `O(1)` logical remove.
- Heap maintenance cost is amortized and shifted to occasional batch rebuilds.