### PR TITLE
[Bugfix] Route INT8 GPTQ MoE to WNA16 fallback

### DIFF
--- a/tests/quantization/test_gptq_int8_moe_fallback.py
+++ b/tests/quantization/test_gptq_int8_moe_fallback.py
@@ -1,0 +1,215 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Test that INT8 GPTQ MoE layers fall back to MoeWNA16 kernels.
+
+MarlinExperts does not support INT8 MoE weights. When a GPTQ model has
+8-bit MoE expert layers (e.g., mixed INT4/INT8 models), the quantization
+dispatch must route those layers to MoeWNA16Method which handles INT8 via
+Triton fused_experts kernels.
+
+See: https://github.com/vllm-project/vllm/issues/41955
+"""
+
+from copy import deepcopy
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from vllm.model_executor.layers.quantization.gptq_marlin import (
+    GPTQMarlinConfig,
+    get_moe_quant_method,
+)
+from vllm.model_executor.layers.quantization.moe_wna16 import MoeWNA16Method
+from vllm.platforms import current_platform
+
+
+def _make_gptq_config(weight_bits: int = 4, group_size: int = 128) -> GPTQMarlinConfig:
+    """Create a GPTQMarlinConfig for testing."""
+    full_config = {
+        "quant_method": "gptq",
+        "bits": weight_bits,
+        "group_size": group_size,
+        "sym": True,
+        "desc_act": False,
+        "lm_head": False,
+        "dynamic": {},
+    }
+    return GPTQMarlinConfig(
+        weight_bits=weight_bits,
+        group_size=group_size,
+        desc_act=False,
+        is_sym=True,
+        lm_head_quantized=False,
+        dynamic={},
+        full_config=full_config,
+    )
+
+
+def _make_gptq_config_with_dynamic(
+    base_bits: int = 4, override_bits: int = 8, group_size: int = 128
+) -> GPTQMarlinConfig:
+    """Create a GPTQMarlinConfig with dynamic per-layer overrides."""
+    dynamic = {
+        r"+:.*\.moe\..*": {"bits": override_bits},
+    }
+    full_config = {
+        "quant_method": "gptq",
+        "bits": base_bits,
+        "group_size": group_size,
+        "sym": True,
+        "desc_act": False,
+        "lm_head": False,
+        "dynamic": dynamic,
+    }
+    return GPTQMarlinConfig(
+        weight_bits=base_bits,
+        group_size=group_size,
+        desc_act=False,
+        is_sym=True,
+        lm_head_quantized=False,
+        dynamic=dynamic,
+        full_config=full_config,
+    )
+
+
+def _make_mock_fused_moe_layer():
+    """Create a mock FusedMoE layer with valid shapes for Marlin."""
+    from vllm.model_executor.layers.fused_moe.layer import FusedMoE
+
+    mock_layer = MagicMock(spec=FusedMoE)
+    mock_layer.hidden_size = 4096  # divisible by 128
+    mock_layer.intermediate_size_per_partition = 11008  # typical MoE size
+    mock_layer.apply_router_weight_on_input = False
+    mock_layer.moe_config = MagicMock()
+    return mock_layer
+
+
+@pytest.mark.skipif(
+    not current_platform.is_cuda(),
+    reason="GPTQ Marlin requires CUDA.",
+)
+class TestInt8MoEFallback:
+    """Test that INT8 MoE layers are routed to MoeWNA16 kernels."""
+
+    def test_int8_base_config_falls_back_to_wna16(self):
+        """When base weight_bits=8, MoE layers should use MoeWNA16Method."""
+        config = _make_gptq_config(weight_bits=8)
+        layer = _make_mock_fused_moe_layer()
+
+        from vllm.model_executor.layers.quantization.gptq_marlin import (
+            GPTQMarlinMoEMethod,
+        )
+
+        result = get_moe_quant_method(
+            config, layer, "model.layers.0.moe.experts", GPTQMarlinMoEMethod
+        )
+
+        assert isinstance(result, MoeWNA16Method), (
+            f"Expected MoeWNA16Method for INT8 MoE, got {type(result).__name__}"
+        )
+
+    def test_int4_base_config_uses_marlin(self):
+        """When base weight_bits=4, MoE layers should use GPTQMarlinMoEMethod."""
+        config = _make_gptq_config(weight_bits=4)
+        layer = _make_mock_fused_moe_layer()
+
+        from vllm.model_executor.layers.quantization.gptq_marlin import (
+            GPTQMarlinMoEMethod,
+        )
+
+        result = get_moe_quant_method(
+            config, layer, "model.layers.0.moe.experts", GPTQMarlinMoEMethod
+        )
+
+        assert isinstance(result, GPTQMarlinMoEMethod), (
+            f"Expected GPTQMarlinMoEMethod for INT4 MoE, got {type(result).__name__}"
+        )
+
+    def test_dynamic_override_to_int8_falls_back(self):
+        """When dynamic override sets a MoE layer to 8-bit, it should
+        fall back to MoeWNA16Method."""
+        config = _make_gptq_config_with_dynamic(base_bits=4, override_bits=8)
+        layer = _make_mock_fused_moe_layer()
+
+        from vllm.model_executor.layers.quantization.gptq_marlin import (
+            GPTQMarlinMoEMethod,
+        )
+
+        # The prefix matches the dynamic rule "+:.*\.moe\..*"
+        result = get_moe_quant_method(
+            config, layer, "model.layers.5.moe.experts", GPTQMarlinMoEMethod
+        )
+
+        assert isinstance(result, MoeWNA16Method), (
+            f"Expected MoeWNA16Method for dynamically overridden INT8 MoE, "
+            f"got {type(result).__name__}"
+        )
+
+    def test_dynamic_override_non_matching_stays_int4(self):
+        """When dynamic override exists but doesn't match the prefix,
+        INT4 base config should use GPTQMarlinMoEMethod."""
+        config = _make_gptq_config_with_dynamic(base_bits=4, override_bits=8)
+        layer = _make_mock_fused_moe_layer()
+
+        from vllm.model_executor.layers.quantization.gptq_marlin import (
+            GPTQMarlinMoEMethod,
+        )
+
+        # This prefix does NOT match "+:.*\.moe\..*"
+        result = get_moe_quant_method(
+            config, layer, "model.layers.5.mlp.experts", GPTQMarlinMoEMethod
+        )
+
+        assert isinstance(result, GPTQMarlinMoEMethod), (
+            f"Expected GPTQMarlinMoEMethod for non-matching INT4 MoE, "
+            f"got {type(result).__name__}"
+        )
+
+    def test_int8_fallback_propagates_config_values(self):
+        """Verify that group_size and other config fields propagate
+        correctly through the INT8 fallback path."""
+        config = _make_gptq_config(weight_bits=8, group_size=64)
+        layer = _make_mock_fused_moe_layer()
+
+        from vllm.model_executor.layers.quantization.gptq_marlin import (
+            GPTQMarlinMoEMethod,
+        )
+
+        result = get_moe_quant_method(
+            config, layer, "model.layers.0.moe.experts", GPTQMarlinMoEMethod
+        )
+
+        assert isinstance(result, MoeWNA16Method)
+        assert result.quant_config.weight_bits == 8
+        assert result.quant_config.group_size == 64
+
+    def test_int8_with_desc_act_raises(self):
+        """INT8 MoE with desc_act=True should raise ValueError."""
+        full_config = {
+            "quant_method": "gptq",
+            "bits": 8,
+            "group_size": 128,
+            "sym": True,
+            "desc_act": True,
+            "lm_head": False,
+            "dynamic": {},
+        }
+        config = GPTQMarlinConfig(
+            weight_bits=8,
+            group_size=128,
+            desc_act=True,
+            is_sym=True,
+            lm_head_quantized=False,
+            dynamic={},
+            full_config=full_config,
+        )
+        layer = _make_mock_fused_moe_layer()
+
+        from vllm.model_executor.layers.quantization.gptq_marlin import (
+            GPTQMarlinMoEMethod,
+        )
+
+        with pytest.raises(ValueError, match="desc_act=True.*not supported"):
+            get_moe_quant_method(
+                config, layer, "model.layers.0.moe.experts", GPTQMarlinMoEMethod
+            )

--- a/vllm/model_executor/layers/fused_moe/fused_marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_marlin_moe.py
@@ -561,8 +561,9 @@ class MarlinExpertsBase(mk.FusedMoEExpertsModular):
             quant_config.use_mxfp4_w4a16
             or quant_config.use_nvfp4_w4a16
             or quant_config.use_int4_w4a16
+            or quant_config.use_int8_w8a16
             or quant_config.use_fp8_w8a16
-        ), "Supports only {mxfp,nvfp,int}4_w4a16 or fp8_w8a16"
+        ), "Supports only {mxfp,nvfp,int}4_w4a16, int8_w8a16, or fp8_w8a16"
         self.w13_g_idx = w13_g_idx
         self.w2_g_idx = w2_g_idx
         self.w13_g_idx_sort_indices = w13_g_idx_sort_indices
@@ -635,6 +636,8 @@ class MarlinExpertsBase(mk.FusedMoEExpertsModular):
             return scalar_types.uint4b8.id
         elif self.quant_config.use_mxfp4_w4a16 or self.quant_config.use_nvfp4_w4a16:
             return scalar_types.float4_e2m1f.id
+        elif self.quant_config.use_int8_w8a16:
+            return scalar_types.uint8b128.id
         elif (
             self.quant_config.use_fp8_w8a16
             and current_platform.fp8_dtype() == torch.float8_e4m3fn

--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -92,6 +92,38 @@ def get_moe_quant_method(
             # Dynamic per module/layer rules may override base config
             override_config(cloned_config, prefix=prefix)
 
+        # MarlinExperts does not support INT8 MoE weights (only INT4/FP8).
+        # Route INT8 MoE layers to MoeWNA16 which handles them via Triton
+        # fused_experts kernels. See: github.com/vllm-project/vllm/issues/41955
+        if cloned_config.weight_bits == 8:
+            from vllm.model_executor.layers.quantization.moe_wna16 import (
+                MoeWNA16Config,
+            )
+
+            if cloned_config.desc_act:
+                raise ValueError(
+                    f"Layer '{prefix}' uses 8-bit MoE weights with "
+                    "desc_act=True, which is not supported. INT8 MoE "
+                    "requires desc_act=False."
+                )
+
+            logger.warning_once(
+                f"Layer '{prefix}' uses 8-bit MoE weights which are not "
+                "supported by Marlin MoE kernels. Falling back to "
+                "MoeWNA16 kernels."
+            )
+            # Sync all dynamically overridden fields into the fallback
+            # config dict, since override_config() only updates the
+            # cloned GPTQMarlinConfig object, not its full_config dict.
+            fallback_config = deepcopy(cloned_config.full_config)
+            fallback_config["bits"] = cloned_config.weight_bits
+            fallback_config["group_size"] = cloned_config.group_size
+            fallback_config["sym"] = cloned_config.is_sym
+            fallback_config["desc_act"] = cloned_config.desc_act
+            return MoeWNA16Config.from_config(
+                fallback_config
+            ).get_quant_method(layer, prefix)
+
         return moe_method_cls(cloned_config, layer.moe_config)
     return None
 

--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -112,16 +112,16 @@ def get_moe_quant_method(
                 "supported by Marlin MoE kernels. Falling back to "
                 "MoeWNA16 kernels."
             )
-            # Sync all dynamically overridden fields into the fallback
-            # config dict, since override_config() only updates the
-            # cloned GPTQMarlinConfig object, not its full_config dict.
-            fallback_config = deepcopy(cloned_config.full_config)
-            fallback_config["bits"] = cloned_config.weight_bits
-            fallback_config["group_size"] = cloned_config.group_size
-            fallback_config["sym"] = cloned_config.is_sym
-            fallback_config["desc_act"] = cloned_config.desc_act
+            # Sync dynamically overridden fields into full_config dict
+            # (override_config only updates the GPTQMarlinConfig object,
+            # not its full_config dict). Safe to mutate — cloned_config
+            # is already a deepcopy.
+            cloned_config.full_config["bits"] = cloned_config.weight_bits
+            cloned_config.full_config["group_size"] = cloned_config.group_size
+            cloned_config.full_config["sym"] = cloned_config.is_sym
+            cloned_config.full_config["desc_act"] = cloned_config.desc_act
             return MoeWNA16Config.from_config(
-                fallback_config
+                cloned_config.full_config
             ).get_quant_method(layer, prefix)
 
         return moe_method_cls(cloned_config, layer.moe_config)


### PR DESCRIPTION
## Purpose

Mixed-precision GPTQ models with INT8 MoE expert layers (e.g., `QuantTrio/GLM-4.7-GPTQ-Int4-Int8Mix`) crash during model loading with:

```
AssertionError: Supports only {mxfp,nvfp,int}4_w4a16 or fp8_w8a16
```

**Root cause:** `MarlinExpertsBase.__init__()` asserts only INT4/FP8 quant types, but `_supports_quant_scheme()` lists `kInt8Static` as supported. When `select_wna16_moe_backend()` selects MarlinExperts for an INT8 MoE layer, backend selection succeeds but initialization immediately crashes. This inconsistency was introduced by the modular kernel refactor in #37990.

**Fix:** Detect INT8 MoE weight configuration in `get_moe_quant_method()` (after dynamic per-layer overrides are applied) and route to `MoeWNA16Config`, which fully supports INT8 via `int8_w8a16_moe_quant_config` + Triton `fused_experts` kernels. This mirrors the existing shape-incompatibility fallback in `GPTQMarlinConfig.get_quant_method()`.

The fix also:
- Syncs all dynamically overridden fields (`group_size`, `sym`, `desc_act`) into the fallback config to prevent stale base values
- Validates that `desc_act=True` is not used with INT8 MoE (unsupported by MoeWNA16)

Fixes #41955

## Test Plan

```bash
pytest tests/quantization/test_gptq_int8_moe_fallback.py -v
```

Six test cases covering:
- Base INT8 config falls back to `MoeWNA16Method`
- Base INT4 config still uses `GPTQMarlinMoEMethod` (no regression)
- Dynamic override to INT8 triggers fallback
- Dynamic override non-matching prefix stays INT4
- Config values (`weight_bits`, `group_size`) propagate correctly through fallback
- INT8 + `desc_act=True` raises `ValueError`

For end-to-end validation with the affected model (requires multi-GPU setup):
```bash
vllm serve QuantTrio/GLM-4.7-GPTQ-Int4-Int8Mix --dtype half --tensor-parallel-size 2
```

## Test Result

Unit tests pass (routing logic verified via mock layers). End-to-end test with the actual model requires the multi-GPU setup described in #41955 — requesting validation from the issue reporter.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the Google Doc.
</details>