### PR TITLE
[Bugfix] Preserve leading/trailing whitespace in GLM non-streaming tool parser

### DIFF
--- a/tests/tool_parsers/test_glm47_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm47_moe_tool_parser.py
@@ -91,6 +91,12 @@ class TestGlm47ExtractToolCalls:
         assert r.tools_called
         assert json.loads(r.tool_calls[0].function.arguments) == {"city": "Beijing"}
 
+    def test_whitespace_preserved_in_arg_values(self, glm47_tool_parser, mock_request):
+        out = "<tool_call>get_weather<arg_key>city</arg_key><arg_value>  Beijing  </arg_value></tool_call>"
+        r = glm47_tool_parser.extract_tool_calls(out, request=mock_request)
+        assert r.tools_called
+        assert json.loads(r.tool_calls[0].function.arguments) == {"city": "  Beijing  "}
+
     def test_content_before(self, glm47_tool_parser, mock_request):
         out = "Checking.<tool_call>get_current_date</tool_call>"
         r = glm47_tool_parser.extract_tool_calls(out, request=mock_request)

--- a/tests/tool_parsers/test_glm4_moe_tool_parser.py
+++ b/tests/tool_parsers/test_glm4_moe_tool_parser.py
@@ -801,6 +801,36 @@ def test_extract_tool_calls_numeric_deserialization(glm4_moe_tool_parser, mock_r
     assert isinstance(args["enabled"], bool)
 
 
+def test_whitespace_preserved_in_arg_values(glm4_moe_tokenizer):
+    """Test that string arguments preserve leading and trailing whitespace."""
+    tools = [
+        ChatCompletionToolsParam(
+            function=FunctionDefinition(
+                name="apply_diff",
+                parameters={
+                    "type": "object",
+                    "properties": {
+                        "s": {"type": "string"},
+                    },
+                    "required": ["s"],
+                },
+            ),
+        ),
+    ]
+    parser = Glm4MoeModelToolParser(glm4_moe_tokenizer, tools=tools)
+    request = ChatCompletionRequest(model=MODEL, messages=[], tools=tools)
+
+    model_output = """<tool_call>apply_diff
+<arg_key>s</arg_key>
+<arg_value>    indented code    </arg_value>
+</tool_call>"""
+
+    extracted_tool_calls = parser.extract_tool_calls(model_output, request=request)
+    args = json.loads(extracted_tool_calls.tool_calls[0].function.arguments)
+
+    assert args["s"] == "    indented code    "
+
+
 def test_zero_argument_tool_call(glm4_moe_tool_parser, mock_request):
     """Regression: zero-argument tool call crash (PR #32321)."""
     model_output = """<tool_call>get_time

--- a/vllm/tool_parsers/glm4_moe_tool_parser.py
+++ b/vllm/tool_parsers/glm4_moe_tool_parser.py
@@ -210,9 +210,10 @@ class Glm4MoeModelToolParser(ToolParser):
                 arg_dct: dict[str, Any] = {}
                 for key, value in pairs:
                     arg_key = key.strip()
-                    arg_val = value.strip()
-                    if not self._is_string_type(tc_name, arg_key, self.tools):
-                        arg_val = self._deserialize(arg_val)
+                    if self._is_string_type(tc_name, arg_key, self.tools):
+                        arg_val = value
+                    else:
+                        arg_val = self._deserialize(value.strip())
                     logger.debug("arg_key = %s, arg_val = %s", arg_key, arg_val)
                     arg_dct[arg_key] = arg_val
                 tool_calls.append(


### PR DESCRIPTION
## Purpose

GLM's non-streaming tool parser currently calls `value.strip()` on completed `<arg_value>` text before parsing it, which for string types can remove important leading or trailing whitespace, causing incorrect parsing results in code-editing tools, diffs etc...

For example, when the model generates:

```xml
<tool_call>apply_diff
<arg_key>string</arg_key>
<arg_value>    indented code    </arg_value>
</tool_call>
```

The parser produces: `{"string": "indented code"}` and not: `{"string": "    indented code    "}`

Fixed this by stripping only non-string values, leaving string whitespace intact.

## Test Plan

<details>
<summary>repro script</summary>

```python
.venv/bin/python - <<'PY'
import json
from types import SimpleNamespace

from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionToolsParam
from vllm.entrypoints.openai.engine.protocol import FunctionDefinition
from vllm.tool_parsers.glm4_moe_tool_parser import Glm4MoeModelToolParser
from vllm.tool_parsers.glm47_moe_tool_parser import Glm47MoeModelToolParser


class Tok:
    def get_vocab(self):
        return {
            "<tool_call>": 1,
            "</tool_call>": 2,
        }


glm4_tools = [
    ChatCompletionToolsParam(
        function=FunctionDefinition(
            name="apply_diff",
            parameters={
                "type": "object",
                "properties": {"s": {"type": "string"}},
                "required": ["s"],
            },
        )
    )
]

glm47_tools = [
    ChatCompletionToolsParam(
        function=FunctionDefinition(
            name="get_weather",
            parameters={
                "type": "object",
                "properties": {"city": {"type": "string"}},
            },
        )
    )
]

cases = [
    (
        "glm4",
        Glm4MoeModelToolParser,
        glm4_tools,
        "s",
        "    indented code    ",
        "<tool_call>apply_diff\n"
        "<arg_key>s</arg_key>\n"
        "<arg_value>    indented code    </arg_value>\n"
        "</tool_call>",
    ),
    (
        "glm47",
        Glm47MoeModelToolParser,
        glm47_tools,
        "city",
        "  Beijing  ",
        "<tool_call>get_weather"
        "<arg_key>city</arg_key>"
        "<arg_value>  Beijing  </arg_value>"
        "</tool_call>",
    ),
]

for name, parser_cls, tools, arg_name, expected, text in cases:
    parser = parser_cls(Tok(), tools=tools)
    request = SimpleNamespace(tools=tools, tool_choice="auto")
    result = parser.extract_tool_calls(text, request=request)
    actual = json.loads(result.tool_calls[0].function.arguments)[arg_name]

    print(f"[{name}]")
    print("expected string:", repr(expected))
    print("actual string:", repr(actual))
    print()
PY
```

</details>

Unit tests:

```
.venv/bin/python -m pytest tests/tool_parsers/test_glm4_moe_tool_parser.py tests/tool_parsers/test_glm47_moe_tool_parser.py -v
```

## Test Result

Before:

```
[glm4]
expected string: '    indented code    '
actual string: 'indented code'

[glm47]
expected string: '  Beijing  '
actual string: 'Beijing'
```

After:

```
[glm4]
expected string: '    indented code    '
actual string:   '    indented code    '
[glm47]
expected string: '  Beijing  '
actual string:   '  Beijing  '
```
