### PR TITLE
[Frontend] Improve interactive input line editing

### DIFF
--- a/tools/generate_cmake_presets.py
+++ b/tools/generate_cmake_presets.py
@@ -1,11 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import argparse
+import contextlib
 import json
 import multiprocessing
 import os
 import sys
 from shutil import which
+
+with contextlib.suppress(ImportError):
+    import readline  # noqa: F401
 
 try:
     # Try to get CUDA_HOME from PyTorch installation, which is the

--- a/vllm/entrypoints/cli/openai.py
+++ b/vllm/entrypoints/cli/openai.py
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import argparse
+import contextlib
 import os
 import signal
 import sys
@@ -16,6 +17,9 @@ if TYPE_CHECKING:
     from vllm.utils.argparse_utils import FlexibleArgumentParser
 else:
     FlexibleArgumentParser = argparse.ArgumentParser
+
+with contextlib.suppress(ImportError):
+    import readline  # noqa: F401
 
 
 def _register_signal_handlers():


### PR DESCRIPTION


## Purpose

This PR improves the interactive input experience for CLI utilities that use
Python's `input()`.

Specifically, this change imports the optional `readline` module in:

- `vllm/entrypoints/cli/openai.py`
- `tools/generate_cmake_presets.py`

When `readline` is available, Python's `input()` can use native terminal
line-editing features such as left/right arrow-key navigation. This makes the
interactive prompts easier to use in supported terminal environments.

The import is wrapped with `contextlib.suppress(ImportError)`, so environments
where `readline` is not available continue to work as before.

## Test Plan

Test environment:

- Ubuntu Server 24.04

Manually tested the interactive input path in `vllm/entrypoints/cli/openai.py`
using the `vllm chat` command.

Tested the following behavior:

1. The `vllm chat` command starts successfully.
2. Text input using `input()` continues to work.
3. Left/right arrow-key navigation works in the interactive prompt when
   `readline` is available.
4. The code remains compatible with environments where `readline` is not
   available because the import is optional and `ImportError` is suppressed.

I did not manually test the interactive path in
`tools/generate_cmake_presets.py`. However, it uses the same optional
`readline` import pattern, and the change should not introduce runtime issues
because `ImportError` is explicitly suppressed.

## Test Result

Manual test passed on Ubuntu Server 24.04.

Before this change, arrow-key navigation did not work properly in the
`vllm chat` interactive prompt in my terminal environment.

After this change, importing `readline` enables native terminal line-editing
support, and arrow-key navigation works as expected in `vllm chat` when
`readline` is available.

No behavior change is expected for environments without `readline`, because
`ImportError` is suppressed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

