### PR TITLE
[CI] De-flake failure CI test "test_async_scheduling::test_without_spec_decoding"

### DIFF
--- a/tests/v1/e2e/general/test_async_scheduling.py
+++ b/tests/v1/e2e/general/test_async_scheduling.py
@@ -26,6 +26,13 @@ MTP_MODEL = "meta-llama/Llama-3.2-1B-Instruct"
 # Need to enforce eager for MRV2 while we sort out cudagraph issues.
 ENFORCE_EAGER = os.getenv("ENFORCE_EAGER", "0") == "1"
 
+# Rank can flip by ±1 across executor / async-scheduling / preemption /
+# chunked-prefill paths when two vocab tokens have logits within fp32 precision
+# of the prompt token's logit (see _ranks_kernel in
+# vllm/v1/worker/gpu/sample/logprob.py). _logprobs_match accepts that drift
+# only when the logprob value already matches within tolerance.
+RANK_TIE_TOL = 1
+
 first_prompt = (
     "The following numbers of the sequence "
     + ", ".join(str(i) for i in range(10))
@@ -429,11 +436,17 @@ def _logprobs_match(
         and lps_a.keys() == lps_b.keys()
         and all(
             a.decoded_token == b.decoded_token
-            and a.rank == b.rank
             and a.logprob == pytest.approx(b.logprob, rel=rel_tol, abs=abs_tol)
+            and _ranks_match(a.rank, b.rank)
             for a, b in ((lps_a[x], lps_b[x]) for x in lps_a)
         )
     )
+
+
+def _ranks_match(rank_a: int | None, rank_b: int | None) -> bool:
+    if rank_a is None or rank_b is None:
+        return rank_a is rank_b
+    return abs(rank_a - rank_b) <= RANK_TIE_TOL
 
 
 def _get_acceptance_rate(before: list[Metric], after: list[Metric]) -> float:


### PR DESCRIPTION
## Purpose

`test_async_scheduling::test_without_spec_decoding` flakes on e2e Scheduling (1 GPU) — observed in 8 builds over 4 days: [#64449](https://buildkite.com/vllm/ci/builds/64449/canvas?sid=019df79d-d916-423f-be33-634ca6866f72&tab=output), [#64459](https://buildkite.com/vllm/ci/builds/64459/canvas?sid=019df7fe-ab89-497e-9f42-78bbe04eaa74&tab=output), [#64647](https://buildkite.com/vllm/ci/builds/64647/canvas?sid=019dfc71-4152-474a-a305-7e8b6fe2b679&tab=output), [#64851](https://buildkite.com/vllm/ci/builds/64851/canvas?sid=019e0091-b72e-48dc-b3e6-f000b8bcc959&tab=output), [#64953](https://buildkite.com/vllm/ci/builds/64953/canvas?sid=019e0348-1e4b-4c2a-b183-54f72056a82f&tab=output), [#65010](https://buildkite.com/vllm/ci/builds/65010/canvas?sid=019e0412-2011-4cb0-bdc4-fa726afc37c1&tab=output), [#65072](https://buildkite.com/vllm/ci/builds/65072/canvas?sid=019e057a-0494-424d-a368-5828da0cd3fa&tab=output), [#65099](https://buildkite.com/vllm/ci/builds/65099/canvas?sid=019e062d-3034-4f41-8e54-824b55c28e11&tab=output). Every failing config exercises one of the two `prompt_logprobs=2` parametrizations added by [#41411](https://github.com/vllm-project/vllm/pull/41411).

The failure is always a rank flip of ±1 at one prompt position with logprob delta ~1.9e-9 (well inside the existing `rel=1e-3, abs=1e-6` tolerance). `_ranks_kernel` counts vocab logits ≥ the token's logit; when two vocab tokens are within fp32 precision of the prompt token's logit, matmul reduction order across executor / async-scheduling / preemption / chunked-prefill paths flips the boundary by one — irreducible fp32 noise, not an algorithmic regression.

Allow rank to differ by `RANK_TIE_TOL=1` only when the logprob value already matches within tolerance, so real top-K ordering regressions still surface.

## Test Plan

## Test Result