### PR TITLE
[CI][Examples][RLHF] Disable async scheduling in rlhf_async_new_apis

### DIFF
--- a/examples/rl/rlhf_async_new_apis.py
+++ b/examples/rl/rlhf_async_new_apis.py
@@ -227,6 +227,9 @@ llm_kwargs = dict(
     attention_backend=ATTN_BACKEND,
     gpu_memory_utilization=0.75,
     weight_transfer_config=WeightTransferConfig(backend="nccl"),
+    # TODO(haosdent): re-enable once #42043 is fixed. Both LLM
+    # instances must match.
+    async_scheduling=False,
 )
 llm_kwargs.update(rocm_determinism_kwargs)
 
@@ -364,6 +367,9 @@ llm_v2_kwargs = dict(
     gpu_memory_utilization=0.75,
     distributed_executor_backend="ray",
     attention_backend=ATTN_BACKEND,
+    # TODO(haosdent): re-enable once #42043 is fixed. Both LLM
+    # instances must match.
+    async_scheduling=False,
 )
 llm_v2_kwargs.update(rocm_determinism_kwargs)
 


### PR DESCRIPTION
## Purpose

[Distributed Tests (2 GPUs)(H100)](https://buildkite.com/vllm/ci/builds/65099#019e062d-3022-433d-926e-e15f52dfb524) `examples/rl/rlhf_async_new_apis.py` fails 0/13 since RayExecutorV2 became default (#41421) — `AsyncScheduler` drops the first post-resume token after `pause_generation(mode="keep")`. Workaround: pin `async_scheduling=False` until #42043 is fixed.

## Test Plan

## Test Result