### PR TITLE
[Performance] Bypass vllm_ir custom op wrap when only native impl is registered

### DIFF
--- a/tests/compile/passes/ir/test_lowering.py
+++ b/tests/compile/passes/ir/test_lowering.py
@@ -56,10 +56,17 @@ def test_lowering_rms_norm(rms_provider, default_vllm_config):
         output_unlowered = compiled_unlowered_model(x)
 
     selected = lowering_pass.selected_impls["rms_norm"]
-    assert len(selected) == 3
-    assert selected["rms_norm"] == rms_provider
-    assert selected["rms_norm_1"] == rms_provider
-    assert selected["rms_norm_2"] == "native"
+    if rms_provider == "native":
+        # When the only resolved impl is native, the torch op wrap is
+        # bypassed during Dynamo tracing so Inductor can fuse the
+        # decomposition with surrounding ops. There are therefore no
+        # ``vllm_ir.rms_norm`` nodes for the lowering pass to rewrite.
+        assert len(selected) == 0
+    else:
+        assert len(selected) == 3
+        assert selected["rms_norm"] == rms_provider
+        assert selected["rms_norm_1"] == rms_provider
+        assert selected["rms_norm_2"] == "native"
 
     # Compiled function guards on global value, avoid recompilation
     with ir.enable_torch_wrap(True):

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -36,6 +36,7 @@ from vllm.utils.network_utils import (
     get_open_zmq_inproc_path,
     get_open_zmq_ipc_path,
     is_valid_ipv6_address,
+    split_zmq_path,
 )
 
 if TYPE_CHECKING:
@@ -413,13 +414,18 @@ class MessageQueue:
                 connect_ip = get_ip()
             self.remote_socket = context.socket(XPUB)
             self.remote_socket.setsockopt(XPUB_VERBOSE, True)
-            remote_subscribe_port = get_open_port()
+
+            # Use late binding to avoid port conflicts (issue #28498).
+            # Bind to wildcard address and let OS assign the port.
             if is_valid_ipv6_address(connect_ip):
                 self.remote_socket.setsockopt(IPV6, 1)
                 remote_addr_ipv6 = True
                 connect_ip = f"[{connect_ip}]"
-            socket_addr = f"tcp://{connect_ip}:{remote_subscribe_port}"
-            self.remote_socket.bind(socket_addr)
+            wildcard_addr = f"tcp://{connect_ip}:0"
+            self.remote_socket.bind(wildcard_addr)
+            # Discover the actual bound port from the socket.
+            actual_endpoint = self.remote_socket.last_endpoint.decode("utf-8")
+            remote_subscribe_port = int(actual_endpoint.split(":")[-1])
             remote_subscribe_addr = f"tcp://{connect_ip}:{remote_subscribe_port}"
         else:
             remote_subscribe_addr = None

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -32,7 +32,6 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.network_utils import (
     get_ip,
-    get_open_port,
     get_open_zmq_inproc_path,
     get_open_zmq_ipc_path,
     is_valid_ipv6_address,

--- a/vllm/distributed/device_communicators/shm_broadcast.py
+++ b/vllm/distributed/device_communicators/shm_broadcast.py
@@ -425,7 +425,7 @@ class MessageQueue:
             self.remote_socket.bind(wildcard_addr)
             # Discover the actual bound port from the socket.
             actual_endpoint = self.remote_socket.last_endpoint.decode("utf-8")
-            remote_subscribe_port = int(actual_endpoint.split(":")[-1])
+            remote_subscribe_port = int(split_zmq_path(actual_endpoint)[2])
             remote_subscribe_addr = f"tcp://{connect_ip}:{remote_subscribe_port}"
         else:
             remote_subscribe_addr = None

--- a/vllm/ir/op.py
+++ b/vllm/ir/op.py
@@ -267,6 +267,20 @@ class IrOp:
         if not _ENABLE_TORCH_WRAP:
             return self._inner_call(*args, **kwargs)
 
+        # When the only resolved implementation is the native (Python)
+        # decomposition, skip the torch custom op wrap so that Dynamo traces
+        # through the decomposition. This lets Inductor see the underlying
+        # primitive ops and fuse them with surrounding operations.
+        # Without this, the op stays as an opaque ``vllm_ir.<name>`` node in
+        # the FX graph and the post-grad lowering pass replaces it via
+        # ``replace_by_example``, which can prevent Inductor from fusing
+        # downstream ops (see issue #41804).
+        if (
+            len(self._priority_impls) == 1
+            and self._priority_impls[0].provider == "native"
+        ):
+            return self._inner_call(*args, **kwargs)
+
         return self.torch_op(*args, **kwargs)
 
     def get_priority(self) -> list[str]:

--- a/vllm/utils/network_utils.py
+++ b/vllm/utils/network_utils.py
@@ -10,7 +10,7 @@ from collections.abc import (
     Iterator,
     Sequence,
 )
-from typing import Any
+from typing import Any, Literal, overload
 from uuid import uuid4
 
 import psutil
@@ -280,7 +280,82 @@ def make_zmq_path(scheme: str, host: str, port: int | None = None) -> str:
     return f"{scheme}://{host}:{port}"
 
 
+def is_wildcard_addr(addr: str) -> bool:
+    """Check if an address is a TCP address with wildcard port (port 0).
+
+    A wildcard port address has port 0, telling the OS to assign an available
+    port when binding. This is used for late binding to avoid port conflicts.
+
+    Args:
+        addr: Address string to check (e.g., "tcp://host:0")
+
+    Returns:
+        True if the address is a TCP address with wildcard port (:0)
+    """
+    if not addr.startswith("tcp://"):
+        return False
+    try:
+        _, _, port_str = split_zmq_path(addr)
+        return port_str == "0"
+    except ValueError:
+        return False
+
+
+def _resolve_bound_address(
+    sock: zmq.Socket | zmq.asyncio.Socket, original_path: str
+) -> str:
+    """Resolve the actual bound address from a ZMQ socket.
+
+    After binding to a wildcard address (port 0), the OS assigns a real port.
+    This function discovers that port via socket.last_endpoint and constructs
+    a proper address string preserving the original host.
+
+    Args:
+        sock: The bound ZMQ socket
+        original_path: The original address used for binding
+
+    Returns:
+        The actual address with the OS-assigned port
+    """
+    actual_endpoint = sock.last_endpoint.decode("utf-8")
+    scheme, host, port_str = split_zmq_path(actual_endpoint)
+    if scheme != "tcp":
+        return actual_endpoint
+    # Use the host from the original path since last_endpoint may
+    # return 0.0.0.0 instead of the specific host we intended.
+    orig_scheme, orig_host, _ = split_zmq_path(original_path)
+    return make_zmq_path(orig_scheme, orig_host, int(port_str))
+
+
 # Adapted from: https://github.com/sgl-project/sglang/blob/v0.4.1/python/sglang/srt/utils.py#L783 # noqa: E501
+@overload
+def make_zmq_socket(
+    ctx: zmq.asyncio.Context | zmq.Context,  # type: ignore[name-defined]
+    path: str,
+    socket_type: Any,
+    bind: bool | None = ...,
+    identity: bytes | None = ...,
+    linger: int | None = ...,
+    router_handover: bool = ...,
+    *,
+    return_address: Literal[True],
+) -> tuple[zmq.Socket | zmq.asyncio.Socket, str]: ...  # type: ignore[name-defined]
+
+
+@overload
+def make_zmq_socket(
+    ctx: zmq.asyncio.Context | zmq.Context,  # type: ignore[name-defined]
+    path: str,
+    socket_type: Any,
+    bind: bool | None = ...,
+    identity: bytes | None = ...,
+    linger: int | None = ...,
+    router_handover: bool = ...,
+    *,
+    return_address: Literal[False] = ...,
+) -> zmq.Socket | zmq.asyncio.Socket: ...  # type: ignore[name-defined]
+
+
 def make_zmq_socket(
     ctx: zmq.asyncio.Context | zmq.Context,  # type: ignore[name-defined]
     path: str,
@@ -289,7 +364,8 @@ def make_zmq_socket(
     identity: bytes | None = None,
     linger: int | None = None,
     router_handover: bool = False,
-) -> zmq.Socket | zmq.asyncio.Socket:  # type: ignore[name-defined]
+    return_address: bool = False,
+) -> zmq.Socket | zmq.asyncio.Socket | tuple[zmq.Socket | zmq.asyncio.Socket, str]:  # type: ignore[name-defined]
     """Make a ZMQ socket with the proper bind/connect semantics."""
 
     mem = psutil.virtual_memory()
@@ -336,10 +412,15 @@ def make_zmq_socket(
 
     if bind:
         socket.bind(path)
+        if return_address and is_wildcard_addr(path):
+            actual_address = _resolve_bound_address(socket, path)
+        else:
+            actual_address = path
     else:
         socket.connect(path)
+        actual_address = path
 
-    return socket
+    return (socket, actual_address) if return_address else socket
 
 
 @contextlib.contextmanager

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -537,16 +537,24 @@ class MPClient(EngineCoreClient):
             else:
                 # Engines are managed by this client.
                 addresses = get_engine_zmq_addresses(vllm_config)
-                self.input_socket = self.resources.input_socket = make_zmq_socket(
+                self.input_socket, actual_input = make_zmq_socket(
                     self.ctx,
                     addresses.inputs[0],
                     zmq.ROUTER,
                     bind=True,
                     router_handover=enable_input_socket_handover,
+                    return_address=True,
                 )
-                self.resources.output_socket = make_zmq_socket(
-                    self.ctx, addresses.outputs[0], zmq.PULL
+                self.resources.input_socket = self.input_socket
+                addresses.inputs[0] = actual_input
+
+                self.resources.output_socket, actual_output = make_zmq_socket(
+                    self.ctx,
+                    addresses.outputs[0],
+                    zmq.PULL,
+                    return_address=True,
                 )
+                addresses.outputs[0] = actual_output
 
                 with launch_core_engines(
                     vllm_config, executor_class, log_stats, addresses

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -917,7 +917,13 @@ def get_engine_zmq_addresses(
     vllm_config: VllmConfig,
     num_api_servers: int = 1,
 ) -> EngineZmqAddresses:
-    """Allocate ZMQ addresses for engine-client communication."""
+    """Allocate ZMQ addresses for engine-client communication.
+
+    When num_api_servers == 1, uses late binding (wildcard port 0) so that
+    the actual port is assigned at socket bind time, avoiding port conflicts
+    (issue #28498). When num_api_servers > 1, pre-allocates ports because
+    the binding and port discovery happen in different processes.
+    """
     parallel_config = vllm_config.parallel_config
     local_engine_count = parallel_config.data_parallel_size_local
     local_start_index = parallel_config.data_parallel_rank_local
@@ -939,13 +945,23 @@ def get_engine_zmq_addresses(
     if parallel_config.enable_elastic_ep:
         client_local_only = False
 
+    # Use late binding (wildcard port) when the binding and address
+    # discovery happen in the same process (single API server).
+    # For multi-server, ports must be pre-allocated since workers
+    # bind in separate processes from where addresses are distributed.
+    use_late_binding = num_api_servers == 1
+
     return EngineZmqAddresses(
         inputs=[
-            get_engine_client_zmq_addr(client_local_only, host)
+            get_engine_client_zmq_addr(
+                client_local_only, host, late_binding=use_late_binding
+            )
             for _ in range(num_api_servers)
         ],
         outputs=[
-            get_engine_client_zmq_addr(client_local_only, host)
+            get_engine_client_zmq_addr(
+                client_local_only, host, late_binding=use_late_binding
+            )
             for _ in range(num_api_servers)
         ],
     )

--- a/vllm/v1/utils.py
+++ b/vllm/v1/utils.py
@@ -143,20 +143,37 @@ class CpuGpuBuffer:
         return self.cpu[:n].copy_(self.gpu[:n], non_blocking=True)
 
 
-def get_engine_client_zmq_addr(local_only: bool, host: str, port: int = 0) -> str:
+def get_engine_client_zmq_addr(
+    local_only: bool, host: str, port: int = 0, late_binding: bool = True
+) -> str:
     """Assign a new ZMQ socket address.
 
     If local_only is True, participants are colocated and so a unique IPC
     address will be returned.
 
     Otherwise, the provided host and port will be used to construct a TCP
-    address (port == 0 means assign an available port)."""
+    address. When late_binding is True and port is 0, a wildcard address
+    (tcp://host:0) is returned so that the OS assigns an available port at
+    bind time, avoiding port conflicts (see issue #28498).
 
-    return (
-        get_open_zmq_ipc_path()
-        if local_only
-        else (get_tcp_uri(host, port or get_open_port()))
-    )
+    Args:
+        local_only: If True, return an IPC address.
+        host: Hostname or IP for TCP addresses.
+        port: Specific port to use. 0 means auto-assign.
+        late_binding: If True and port is 0, return wildcard address for
+            late binding. If False, pre-allocate a port via get_open_port().
+    """
+
+    if local_only:
+        return get_open_zmq_ipc_path()
+    if port:
+        return get_tcp_uri(host, port)
+    if late_binding:
+        # Use wildcard port 0 for late binding. The actual port is
+        # determined when make_zmq_socket() binds with return_address=True.
+        return get_tcp_uri(host, 0)
+    # Pre-allocate a port (legacy behavior, has TOCTOU risk).
+    return get_tcp_uri(host, get_open_port())
 
 
 class APIServerProcessManager:


### PR DESCRIPTION
## Summary
Closes #41804. When \`IrOp\` resolves to only the \`native\` (Python decomposition) impl, wrapping in a \`vllm_ir.<name>\` custom op blocks Inductor from fusing the decomposition with surrounding ops because \`dispatch_key=\"CompositeExplicitAutograd\"\` prevents AOTAutograd decomposition. Bypass the wrap on native-only priority so Dynamo can inline the decomposition.