### PR TITLE
Use `pre-commit / pre-run-check` to gate docs build too

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,14 +16,14 @@ build:
           ELAPSED=0
           while :; do
             RAW=$(curl -sS -w "\n%{http_code}" "https://api.github.com/repos/vllm-project/vllm/commits/${READTHEDOCS_GIT_COMMIT_HASH}/check-runs?check_name=pre-run-check&filter=latest")
-            HTTP_CODE=$(printf '%s' "$RAW" | tail -n1)
-            BODY=$(printf '%s' "$RAW" | sed '$d')
+            HTTP_CODE=$(printf %s "$RAW" | tail -n1)
+            BODY=$(printf %s "$RAW" | head -n -1)
             if [ "$HTTP_CODE" != "200" ]; then
               echo "GitHub API returned HTTP $HTTP_CODE (likely rate-limited); skipping pre-run-check gate."
               break
             fi
-            STATUS=$(printf '%s' "$BODY" | python3 -c "import sys, json; r=json.load(sys.stdin).get('check_runs',[]); print((r[0].get('status') or '') if r else 'none')")
-            CONCLUSION=$(printf '%s' "$BODY" | python3 -c "import sys, json; r=json.load(sys.stdin).get('check_runs',[]); print((r[0].get('conclusion') or '') if r else '')")
+            STATUS=$(printf %s "$BODY" | python3 -c "import sys, json; r=json.load(sys.stdin).get(\"check_runs\",[]); print((r[0].get(\"status\") or \"\") if r else \"none\")")
+            CONCLUSION=$(printf %s "$BODY" | python3 -c "import sys, json; r=json.load(sys.stdin).get(\"check_runs\",[]); print((r[0].get(\"conclusion\") or \"\") if r else \"\")")
             if [ "$STATUS" = "none" ]; then
               echo "no pre-run-check found for this commit; skipping gate."
               break

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,44 @@ build:
     python: "3.12"
   jobs:
     post_checkout:
+      - |
+        if [ "$READTHEDOCS_VERSION_TYPE" = "external" ]; then
+          MAX_WAIT=600
+          INTERVAL=15
+          ELAPSED=0
+          while :; do
+            RAW=$(curl -sS -w "\n%{http_code}" "https://api.github.com/repos/vllm-project/vllm/commits/${READTHEDOCS_GIT_COMMIT_HASH}/check-runs?check_name=pre-run-check&filter=latest")
+            HTTP_CODE=$(printf '%s' "$RAW" | tail -n1)
+            BODY=$(printf '%s' "$RAW" | sed '$d')
+            if [ "$HTTP_CODE" != "200" ]; then
+              echo "GitHub API returned HTTP $HTTP_CODE (likely rate-limited); skipping pre-run-check gate."
+              break
+            fi
+            STATUS=$(printf '%s' "$BODY" | python3 -c "import sys, json; r=json.load(sys.stdin).get('check_runs',[]); print((r[0].get('status') or '') if r else 'none')")
+            CONCLUSION=$(printf '%s' "$BODY" | python3 -c "import sys, json; r=json.load(sys.stdin).get('check_runs',[]); print((r[0].get('conclusion') or '') if r else '')")
+            if [ "$STATUS" = "none" ]; then
+              echo "no pre-run-check found for this commit; skipping gate."
+              break
+            fi
+            if [ -n "$CONCLUSION" ]; then
+              echo "pre-run-check conclusion: $CONCLUSION"
+              if [ "$CONCLUSION" = "failure" ] || [ "$CONCLUSION" = "cancelled" ] || [ "$CONCLUSION" = "timed_out" ]; then
+                echo "pre-run-check did not pass; failing docs build."
+                exit 1
+              fi
+              break
+            fi
+            if [ "$ELAPSED" -ge "$MAX_WAIT" ]; then
+              echo "pre-run-check status=$STATUS after ${MAX_WAIT}s; skipping gate."
+              break
+            fi
+            echo "pre-run-check status=$STATUS; waiting ${INTERVAL}s..."
+            sleep "$INTERVAL"
+            ELAPSED=$((ELAPSED + INTERVAL))
+          done
+        else
+          echo "Not a PR build (version type=$READTHEDOCS_VERSION_TYPE); skipping pre-run-check gate."
+        fi
       - git fetch origin main --unshallow --no-tags --filter=blob:none || true
     pre_create_environment:
       - pip install uv

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -11,8 +11,8 @@ build:
     post_checkout:
       - |
         if [ "$READTHEDOCS_VERSION_TYPE" = "external" ]; then
-          MAX_WAIT=600
-          INTERVAL=15
+          MAX_WAIT=300
+          INTERVAL=60
           ELAPSED=0
           while :; do
             RAW=$(curl -sS -w "\n%{http_code}" "https://api.github.com/repos/vllm-project/vllm/commits/${READTHEDOCS_GIT_COMMIT_HASH}/check-runs?check_name=pre-run-check&filter=latest")


### PR DESCRIPTION
Use the `pre-commit / pre-run-check` result to also skip the docs build:

- Make unauthenticated requests to GitHub (rate limited to 60 per hour) to check the status and conclusion of `pre-run-check`
- If the `pre-run-check`:
  - Passed - continue with the docs build
  - Failed - fail the docs build
  - Is not finished - poll every minute with a 5 minute timeout

With unauthenticated requests this should save 12h of docs builder time every hour.