### PR TITLE
[CI] Narrow Platform Tests (CUDA) source dependencies

### DIFF
--- a/.buildkite/test_areas/cuda.yaml
+++ b/.buildkite/test_areas/cuda.yaml
@@ -7,7 +7,7 @@ steps:
   timeout_in_minutes: 15
   device: h200_18gb
   source_file_dependencies:
-  - vllm/
+  - vllm/platforms/
   - tests/cuda
   commands:
     - pytest -v -s cuda/test_cuda_context.py

--- a/.buildkite/test_areas/cuda.yaml
+++ b/.buildkite/test_areas/cuda.yaml
@@ -7,7 +7,11 @@ steps:
   timeout_in_minutes: 15
   device: h200_18gb
   source_file_dependencies:
+  - vllm/envs.py
+  - vllm/logger.py
   - vllm/platforms/
+  - vllm/plugins/
+  - vllm/utils/
   - tests/cuda
   commands:
     - pytest -v -s cuda/test_cuda_context.py


### PR DESCRIPTION
## Summary

- The `Platform Tests (CUDA)` job listed `vllm/` as a source file dependency, causing it to run on any change anywhere under `vllm/`.
- Its two tests (`tests/cuda/test_cuda_context.py`, `tests/cuda/test_platform_no_cuda_init.py`) only import `vllm.platforms.current_platform`.
- Narrow the dependency to `vllm/platforms/` so the job only runs when platform code actually changes.

## Test plan

- [ ] Verify CI scheduler picks up the narrower path correctly on this PR (job should not be triggered by unrelated `vllm/` changes).
- [ ] Confirm the job still runs when `vllm/platforms/` is touched.

This change was AI-assisted (Claude Code). Reviewed end-to-end before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)