### PR TITLE
[CI] Narrow engine.yaml source dependencies

### DIFF
--- a/.buildkite/test_areas/engine.yaml
+++ b/.buildkite/test_areas/engine.yaml
@@ -62,21 +62,23 @@ steps:
   optional: true
   num_devices: 2
   source_file_dependencies:
-    - vllm/attention/
     - vllm/compilation/
     - vllm/config/
     - vllm/distributed/
     - vllm/engine/
-    - vllm/executor/
+    - vllm/envs.py
     - vllm/forward_context.py
     - vllm/inputs/
+    - vllm/logger.py
+    - vllm/logging_utils/
     - vllm/model_executor/
+    - vllm/multimodal/
     - vllm/platforms/
     - vllm/sampling_params.py
     - vllm/transformers_utils/
+    - vllm/triton_utils/
     - vllm/utils/
     - vllm/v1/
-    - vllm/worker/
     - tests/v1/e2e/spec_decode
   commands:
     # Only run tests that need exactly 2 GPUs
@@ -88,21 +90,23 @@ steps:
   optional: true
   num_devices: 4
   source_file_dependencies:
-    - vllm/attention/
     - vllm/compilation/
     - vllm/config/
     - vllm/distributed/
     - vllm/engine/
-    - vllm/executor/
+    - vllm/envs.py
     - vllm/forward_context.py
     - vllm/inputs/
+    - vllm/logger.py
+    - vllm/logging_utils/
     - vllm/model_executor/
+    - vllm/multimodal/
     - vllm/platforms/
     - vllm/sampling_params.py
     - vllm/transformers_utils/
+    - vllm/triton_utils/
     - vllm/utils/
     - vllm/v1/
-    - vllm/worker/
     - tests/v1/e2e/spec_decode
   commands:
     # Only run tests that need 4 GPUs

--- a/.buildkite/test_areas/engine.yaml
+++ b/.buildkite/test_areas/engine.yaml
@@ -7,7 +7,17 @@ steps:
   timeout_in_minutes: 15
   device: h200_18gb
   source_file_dependencies:
-  - vllm/
+  - vllm/compilation/
+  - vllm/config/
+  - vllm/engine/
+  - vllm/entrypoints/logger.py
+  - vllm/envs.py
+  - vllm/logger.py
+  - vllm/logging_utils/
+  - vllm/platforms/
+  - vllm/sequence.py
+  - vllm/triton_utils/
+  - vllm/utils/
   - tests/engine
   - tests/test_sequence
   - tests/test_config
@@ -52,8 +62,22 @@ steps:
   optional: true
   num_devices: 2
   source_file_dependencies:
-    - vllm/
-    - tests/v1/e2e
+    - vllm/attention/
+    - vllm/compilation/
+    - vllm/config/
+    - vllm/distributed/
+    - vllm/engine/
+    - vllm/executor/
+    - vllm/forward_context.py
+    - vllm/inputs/
+    - vllm/model_executor/
+    - vllm/platforms/
+    - vllm/sampling_params.py
+    - vllm/transformers_utils/
+    - vllm/utils/
+    - vllm/v1/
+    - vllm/worker/
+    - tests/v1/e2e/spec_decode
   commands:
     # Only run tests that need exactly 2 GPUs
     - pytest -v -s v1/e2e/spec_decode/test_spec_decode.py -k "tensor_parallelism"
@@ -64,8 +88,22 @@ steps:
   optional: true
   num_devices: 4
   source_file_dependencies:
-    - vllm/
-    - tests/v1/e2e
+    - vllm/attention/
+    - vllm/compilation/
+    - vllm/config/
+    - vllm/distributed/
+    - vllm/engine/
+    - vllm/executor/
+    - vllm/forward_context.py
+    - vllm/inputs/
+    - vllm/model_executor/
+    - vllm/platforms/
+    - vllm/sampling_params.py
+    - vllm/transformers_utils/
+    - vllm/utils/
+    - vllm/v1/
+    - vllm/worker/
+    - tests/v1/e2e/spec_decode
   commands:
     # Only run tests that need 4 GPUs
     - pytest -v -s v1/e2e/spec_decode/test_spec_decode.py -k "eagle_correctness_heavy"


### PR DESCRIPTION
## Summary

Three jobs in `.buildkite/test_areas/engine.yaml` listed `vllm/` as a source dependency, causing them to run on any change anywhere under `vllm/`. This PR narrows each to the modules the underlying tests actually exercise.

- **Engine** (line 10): only runs `tests/engine` plus a few standalone tests (`test_sequence`, `test_config`, `test_logger`, `test_vllm_port`, `test_jit_monitor`). Narrowed to: `vllm/engine/`, `vllm/config/`, `vllm/compilation/`, `vllm/sequence.py`, `vllm/logger.py`, `vllm/logging_utils/`, `vllm/triton_utils/`, `vllm/utils/`, `vllm/platforms/`, `vllm/envs.py`, `vllm/entrypoints/logger.py`.
- **V1 e2e (2 GPUs)** and **V1 e2e (4 GPUs)** (optional): only run `tests/v1/e2e/spec_decode/test_spec_decode.py`. Narrowed `vllm/` to the inference-stack modules used (excludes `vllm/lora/`, `vllm/entrypoints/openai/`, `vllm/tracing/`, `vllm/benchmarks/`, etc.) and tightened `tests/v1/e2e` to `tests/v1/e2e/spec_decode`.

## Test plan

- [ ] Verify CI scheduler picks up the narrower paths (jobs should not be triggered by unrelated `vllm/` changes).
- [ ] Confirm `Engine` still runs when any of its listed modules change.
- [ ] Confirm V1 e2e jobs still run when `tests/v1/e2e/spec_decode` or any listed inference-stack module changes.

This change was AI-assisted (Claude Code). Reviewed end-to-end before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)