### PR TITLE
[CI] Narrow pytorch.yaml compile job source dependencies

### DIFF
--- a/.buildkite/test_areas/pytorch.yaml
+++ b/.buildkite/test_areas/pytorch.yaml
@@ -6,7 +6,27 @@ steps:
   key: pytorch-compilation-unit-tests
   timeout_in_minutes: 10
   source_file_dependencies:
-    - vllm/
+    - vllm/_aiter_ops.py
+    - vllm/_custom_ops.py
+    - vllm/compilation/
+    - vllm/config/
+    - vllm/distributed/
+    - vllm/engine/
+    - vllm/envs.py
+    - vllm/forward_context.py
+    - vllm/inputs/
+    - vllm/ir/
+    - vllm/kernels/
+    - vllm/model_executor/
+    - vllm/multimodal/
+    - vllm/platforms/
+    - vllm/plugins/
+    - vllm/sampling_params.py
+    - vllm/sequence.py
+    - vllm/transformers_utils/
+    - vllm/triton_utils/
+    - vllm/utils/
+    - vllm/v1/
     - tests/compile
   commands:
   # Run unit tests defined directly under compile/,
@@ -24,7 +44,27 @@ steps:
   device: h100
   num_devices: 1
   source_file_dependencies:
-    - vllm/
+    - vllm/_aiter_ops.py
+    - vllm/_custom_ops.py
+    - vllm/compilation/
+    - vllm/config/
+    - vllm/distributed/
+    - vllm/engine/
+    - vllm/envs.py
+    - vllm/forward_context.py
+    - vllm/inputs/
+    - vllm/ir/
+    - vllm/kernels/
+    - vllm/model_executor/
+    - vllm/multimodal/
+    - vllm/platforms/
+    - vllm/plugins/
+    - vllm/sampling_params.py
+    - vllm/sequence.py
+    - vllm/transformers_utils/
+    - vllm/triton_utils/
+    - vllm/utils/
+    - vllm/v1/
     - tests/compile/h100/
   commands:
   - "find compile/h100/ -name 'test_*.py' -print0 | xargs -0 -n1 -I{} pytest -s -v '{}'"
@@ -33,7 +73,27 @@ steps:
   key: pytorch-compilation-passes-unit-tests
   timeout_in_minutes: 20
   source_file_dependencies:
-    - vllm/
+    - vllm/_aiter_ops.py
+    - vllm/_custom_ops.py
+    - vllm/compilation/
+    - vllm/config/
+    - vllm/distributed/
+    - vllm/engine/
+    - vllm/envs.py
+    - vllm/forward_context.py
+    - vllm/inputs/
+    - vllm/ir/
+    - vllm/kernels/
+    - vllm/model_executor/
+    - vllm/multimodal/
+    - vllm/platforms/
+    - vllm/plugins/
+    - vllm/sampling_params.py
+    - vllm/sequence.py
+    - vllm/transformers_utils/
+    - vllm/triton_utils/
+    - vllm/utils/
+    - vllm/v1/
     - tests/compile/passes
   commands:
   - pytest -s -v compile/passes --ignore compile/passes/distributed
@@ -42,7 +102,27 @@ steps:
   key: pytorch-fullgraph-smoke-test
   timeout_in_minutes: 35
   source_file_dependencies:
-  - vllm/
+  - vllm/_aiter_ops.py
+  - vllm/_custom_ops.py
+  - vllm/compilation/
+  - vllm/config/
+  - vllm/distributed/
+  - vllm/engine/
+  - vllm/envs.py
+  - vllm/forward_context.py
+  - vllm/inputs/
+  - vllm/ir/
+  - vllm/kernels/
+  - vllm/model_executor/
+  - vllm/multimodal/
+  - vllm/platforms/
+  - vllm/plugins/
+  - vllm/sampling_params.py
+  - vllm/sequence.py
+  - vllm/transformers_utils/
+  - vllm/triton_utils/
+  - vllm/utils/
+  - vllm/v1/
   - tests/compile
   commands:
   # Run smoke tests under fullgraph directory, except test_full_graph.py
@@ -56,7 +136,27 @@ steps:
   timeout_in_minutes: 30
   device: h200_18gb
   source_file_dependencies:
-  - vllm/
+  - vllm/_aiter_ops.py
+  - vllm/_custom_ops.py
+  - vllm/compilation/
+  - vllm/config/
+  - vllm/distributed/
+  - vllm/engine/
+  - vllm/envs.py
+  - vllm/forward_context.py
+  - vllm/inputs/
+  - vllm/ir/
+  - vllm/kernels/
+  - vllm/model_executor/
+  - vllm/multimodal/
+  - vllm/platforms/
+  - vllm/plugins/
+  - vllm/sampling_params.py
+  - vllm/sequence.py
+  - vllm/transformers_utils/
+  - vllm/triton_utils/
+  - vllm/utils/
+  - vllm/v1/
   - tests/compile
   commands:
     # fp8 kv scales not supported on sm89, tested on Blackwell instead

--- a/.buildkite/test_areas/pytorch.yaml
+++ b/.buildkite/test_areas/pytorch.yaml
@@ -6,17 +6,20 @@ steps:
   key: pytorch-compilation-unit-tests
   timeout_in_minutes: 10
   source_file_dependencies:
+    - vllm/__init__.py
     - vllm/_aiter_ops.py
     - vllm/_custom_ops.py
     - vllm/compilation/
     - vllm/config/
     - vllm/distributed/
     - vllm/engine/
+    - vllm/env_override.py
     - vllm/envs.py
     - vllm/forward_context.py
     - vllm/inputs/
     - vllm/ir/
     - vllm/kernels/
+    - vllm/logger.py
     - vllm/model_executor/
     - vllm/multimodal/
     - vllm/platforms/
@@ -44,17 +47,20 @@ steps:
   device: h100
   num_devices: 1
   source_file_dependencies:
+    - vllm/__init__.py
     - vllm/_aiter_ops.py
     - vllm/_custom_ops.py
     - vllm/compilation/
     - vllm/config/
     - vllm/distributed/
     - vllm/engine/
+    - vllm/env_override.py
     - vllm/envs.py
     - vllm/forward_context.py
     - vllm/inputs/
     - vllm/ir/
     - vllm/kernels/
+    - vllm/logger.py
     - vllm/model_executor/
     - vllm/multimodal/
     - vllm/platforms/
@@ -73,17 +79,20 @@ steps:
   key: pytorch-compilation-passes-unit-tests
   timeout_in_minutes: 20
   source_file_dependencies:
+    - vllm/__init__.py
     - vllm/_aiter_ops.py
     - vllm/_custom_ops.py
     - vllm/compilation/
     - vllm/config/
     - vllm/distributed/
     - vllm/engine/
+    - vllm/env_override.py
     - vllm/envs.py
     - vllm/forward_context.py
     - vllm/inputs/
     - vllm/ir/
     - vllm/kernels/
+    - vllm/logger.py
     - vllm/model_executor/
     - vllm/multimodal/
     - vllm/platforms/
@@ -102,17 +111,20 @@ steps:
   key: pytorch-fullgraph-smoke-test
   timeout_in_minutes: 35
   source_file_dependencies:
+  - vllm/__init__.py
   - vllm/_aiter_ops.py
   - vllm/_custom_ops.py
   - vllm/compilation/
   - vllm/config/
   - vllm/distributed/
   - vllm/engine/
+  - vllm/env_override.py
   - vllm/envs.py
   - vllm/forward_context.py
   - vllm/inputs/
   - vllm/ir/
   - vllm/kernels/
+  - vllm/logger.py
   - vllm/model_executor/
   - vllm/multimodal/
   - vllm/platforms/
@@ -136,17 +148,20 @@ steps:
   timeout_in_minutes: 30
   device: h200_18gb
   source_file_dependencies:
+  - vllm/__init__.py
   - vllm/_aiter_ops.py
   - vllm/_custom_ops.py
   - vllm/compilation/
   - vllm/config/
   - vllm/distributed/
   - vllm/engine/
+  - vllm/env_override.py
   - vllm/envs.py
   - vllm/forward_context.py
   - vllm/inputs/
   - vllm/ir/
   - vllm/kernels/
+  - vllm/logger.py
   - vllm/model_executor/
   - vllm/multimodal/
   - vllm/platforms/


### PR DESCRIPTION
## Summary

All five PyTorch compile jobs in `.buildkite/test_areas/pytorch.yaml` listed `vllm/` as a source dependency, causing them to run on any change anywhere under `vllm/`. They only exercise the compilation infrastructure plus the inference-stack modules required to compile and run a model.

Affected jobs:

- PyTorch Compilation Unit Tests
- PyTorch Compilation Unit Tests (H100)
- PyTorch Compilation Passes Unit Tests
- PyTorch Fullgraph Smoke Test
- PyTorch Fullgraph

Replaced `vllm/` with the explicit set of compile-relevant modules they actually import. Excludes paths the compile tests do not touch: `vllm/lora/`, `vllm/tracing/`, `vllm/profiler/`, `vllm/reasoning/`, `vllm/tool_parsers/`, `vllm/renderers/`, `vllm/benchmarks/`, `vllm/entrypoints/openai/`, `vllm/entrypoints/api_server.py`, `vllm/entrypoints/cli/`, `vllm/tokenizers/`, etc.

## Test plan

- [ ] Verify CI scheduler picks up the narrower paths and skips these jobs on changes only under excluded directories.
- [ ] Confirm jobs still trigger on changes to listed compile-relevant modules.

This change was AI-assisted (Claude Code). Reviewed end-to-end before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)