### PR TITLE
[CI] Narrow misc.yaml source dependencies

### DIFF
--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -6,7 +6,28 @@ steps:
   key: v1-spec-decode
   timeout_in_minutes: 30
   source_file_dependencies:
-    - vllm/
+    - vllm/_aiter_ops.py
+    - vllm/_custom_ops.py
+    - vllm/benchmarks/datasets
+    - vllm/compilation/
+    - vllm/config/
+    - vllm/distributed/
+    - vllm/engine/
+    - vllm/envs.py
+    - vllm/forward_context.py
+    - vllm/inputs/
+    - vllm/ir/
+    - vllm/kernels/
+    - vllm/model_executor/
+    - vllm/multimodal/
+    - vllm/platforms/
+    - vllm/plugins/
+    - vllm/sampling_params.py
+    - vllm/sequence.py
+    - vllm/transformers_utils/
+    - vllm/triton_utils/
+    - vllm/utils/
+    - vllm/v1/
     - tests/v1/spec_decode
   commands:
     - export VLLM_WORKER_MULTIPROC_METHOD=spawn
@@ -18,7 +39,27 @@ steps:
   timeout_in_minutes: 30
   device: h200_18gb
   source_file_dependencies:
-    - vllm/
+    - vllm/_aiter_ops.py
+    - vllm/_custom_ops.py
+    - vllm/compilation/
+    - vllm/config/
+    - vllm/distributed/
+    - vllm/engine/
+    - vllm/envs.py
+    - vllm/forward_context.py
+    - vllm/inputs/
+    - vllm/ir/
+    - vllm/kernels/
+    - vllm/model_executor/
+    - vllm/multimodal/
+    - vllm/platforms/
+    - vllm/plugins/
+    - vllm/sampling_params.py
+    - vllm/sequence.py
+    - vllm/transformers_utils/
+    - vllm/triton_utils/
+    - vllm/utils/
+    - vllm/v1/
     - tests/v1/sample
     - tests/v1/logits_processors
     - tests/v1/test_oracle.py
@@ -41,7 +82,34 @@ steps:
   key: v1-core-kv-metrics
   timeout_in_minutes: 30
   source_file_dependencies:
-    - vllm/
+    - vllm/_aiter_ops.py
+    - vllm/_custom_ops.py
+    - vllm/assets/
+    - vllm/compilation/
+    - vllm/config/
+    - vllm/distributed/
+    - vllm/engine/
+    - vllm/entrypoints/
+    - vllm/envs.py
+    - vllm/forward_context.py
+    - vllm/inputs/
+    - vllm/ir/
+    - vllm/kernels/
+    - vllm/lora/
+    - vllm/model_executor/
+    - vllm/multimodal/
+    - vllm/outputs.py
+    - vllm/platforms/
+    - vllm/plugins/
+    - vllm/pooling_params.py
+    - vllm/profiler/
+    - vllm/sampling_params.py
+    - vllm/sequence.py
+    - vllm/tokenizers/
+    - vllm/transformers_utils/
+    - vllm/triton_utils/
+    - vllm/utils/
+    - vllm/v1/
     - tests/v1/core
     - tests/v1/executor
     - tests/v1/kv_offload
@@ -68,7 +136,22 @@ steps:
   depends_on:
     - image-build-cpu
   source_file_dependencies:
-    - vllm/
+    - vllm/config/
+    - vllm/distributed/
+    - vllm/engine/
+    - vllm/envs.py
+    - vllm/forward_context.py
+    - vllm/inputs/
+    - vllm/lora/
+    - vllm/multimodal/
+    - vllm/platforms/
+    - vllm/pooling_params.py
+    - vllm/profiler/
+    - vllm/sampling_params.py
+    - vllm/tokenizers/
+    - vllm/transformers_utils/
+    - vllm/utils/
+    - vllm/v1/
     - tests/v1
   device: cpu-small
   commands:
@@ -84,7 +167,27 @@ steps:
   timeout_in_minutes: 20
   device: h200_18gb
   source_file_dependencies:
-  - vllm/
+  - vllm/_aiter_ops.py
+  - vllm/_custom_ops.py
+  - vllm/compilation/
+  - vllm/config/
+  - vllm/distributed/
+  - vllm/engine/
+  - vllm/envs.py
+  - vllm/forward_context.py
+  - vllm/inputs/
+  - vllm/ir/
+  - vllm/kernels/
+  - vllm/model_executor/
+  - vllm/multimodal/
+  - vllm/platforms/
+  - vllm/plugins/
+  - vllm/sampling_params.py
+  - vllm/sequence.py
+  - vllm/transformers_utils/
+  - vllm/triton_utils/
+  - vllm/utils/
+  - vllm/v1/
   - tests/test_regression
   commands:
   - pip install modelscope
@@ -128,7 +231,28 @@ steps:
   timeout_in_minutes: 20
   num_devices: 2
   source_file_dependencies:
-  - vllm/
+  - vllm/_aiter_ops.py
+  - vllm/_custom_ops.py
+  - vllm/compilation/
+  - vllm/config/
+  - vllm/distributed/
+  - vllm/engine/
+  - vllm/envs.py
+  - vllm/forward_context.py
+  - vllm/inputs/
+  - vllm/ir/
+  - vllm/kernels/
+  - vllm/model_executor/
+  - vllm/multimodal/
+  - vllm/platforms/
+  - vllm/plugins/
+  - vllm/sampling_params.py
+  - vllm/sequence.py
+  - vllm/tracing/
+  - vllm/transformers_utils/
+  - vllm/triton_utils/
+  - vllm/utils/
+  - vllm/v1/
   - tests/v1/tracing
   commands:
   - "pip install \
@@ -152,7 +276,31 @@ steps:
   key: async-engine-inputs-utils-worker
   timeout_in_minutes: 50
   source_file_dependencies:
-  - vllm/
+  - vllm/_aiter_ops.py
+  - vllm/_custom_ops.py
+  - vllm/assets/
+  - vllm/compilation/
+  - vllm/config/
+  - vllm/distributed/
+  - vllm/engine/
+  - vllm/entrypoints/llm.py
+  - vllm/envs.py
+  - vllm/forward_context.py
+  - vllm/inputs/
+  - vllm/ir/
+  - vllm/kernels/
+  - vllm/model_executor/
+  - vllm/multimodal/
+  - vllm/platforms/
+  - vllm/plugins/
+  - vllm/ray/
+  - vllm/sampling_params.py
+  - vllm/sequence.py
+  - vllm/tokenizers/
+  - vllm/transformers_utils/
+  - vllm/triton_utils/
+  - vllm/utils/
+  - vllm/v1/
   - tests/detokenizer
   - tests/multimodal
   - tests/utils_
@@ -167,7 +315,30 @@ steps:
   - image-build-cpu
   timeout_in_minutes: 30
   source_file_dependencies:
-  - vllm/
+  - vllm/assets/
+  - vllm/config/
+  - vllm/engine/arg_utils.py
+  - vllm/entrypoints/chat_utils.py
+  - vllm/entrypoints/mcp/
+  - vllm/entrypoints/openai/chat_completion/protocol.py
+  - vllm/entrypoints/openai/engine/protocol.py
+  - vllm/envs.py
+  - vllm/exceptions.py
+  - vllm/inputs/
+  - vllm/model_executor/layers/quantization/quark/
+  - vllm/multimodal/
+  - vllm/outputs.py
+  - vllm/platforms/
+  - vllm/pooling_params.py
+  - vllm/ray/
+  - vllm/reasoning/
+  - vllm/renderers/
+  - vllm/sampling_params.py
+  - vllm/tokenizers/
+  - vllm/tool_parsers/
+  - vllm/transformers_utils/
+  - vllm/utils/
+  - vllm/v1/
   - tests/test_inputs.py
   - tests/test_outputs.py
   - tests/test_pooling_params.py

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -30,6 +30,7 @@ steps:
     - vllm/distributed/
     - vllm/engine/
     - vllm/inputs/
+    - vllm/logger.py
     - vllm/model_executor/
     - vllm/platforms/
     - vllm/sampling_params.py
@@ -107,6 +108,7 @@ steps:
     - vllm/inputs/
     - vllm/lora/
     - vllm/multimodal/
+    - vllm/outputs.py
     - vllm/platforms/
     - vllm/pooling_params.py
     - vllm/profiler/

--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -6,26 +6,13 @@ steps:
   key: v1-spec-decode
   timeout_in_minutes: 30
   source_file_dependencies:
-    - vllm/_aiter_ops.py
-    - vllm/_custom_ops.py
-    - vllm/benchmarks/datasets
-    - vllm/compilation/
     - vllm/config/
     - vllm/distributed/
-    - vllm/engine/
-    - vllm/envs.py
-    - vllm/forward_context.py
     - vllm/inputs/
-    - vllm/ir/
-    - vllm/kernels/
     - vllm/model_executor/
-    - vllm/multimodal/
     - vllm/platforms/
-    - vllm/plugins/
     - vllm/sampling_params.py
-    - vllm/sequence.py
     - vllm/transformers_utils/
-    - vllm/triton_utils/
     - vllm/utils/
     - vllm/v1/
     - tests/v1/spec_decode
@@ -39,25 +26,14 @@ steps:
   timeout_in_minutes: 30
   device: h200_18gb
   source_file_dependencies:
-    - vllm/_aiter_ops.py
-    - vllm/_custom_ops.py
-    - vllm/compilation/
     - vllm/config/
     - vllm/distributed/
     - vllm/engine/
-    - vllm/envs.py
-    - vllm/forward_context.py
     - vllm/inputs/
-    - vllm/ir/
-    - vllm/kernels/
     - vllm/model_executor/
-    - vllm/multimodal/
     - vllm/platforms/
-    - vllm/plugins/
     - vllm/sampling_params.py
-    - vllm/sequence.py
     - vllm/transformers_utils/
-    - vllm/triton_utils/
     - vllm/utils/
     - vllm/v1/
     - tests/v1/sample
@@ -82,32 +58,21 @@ steps:
   key: v1-core-kv-metrics
   timeout_in_minutes: 30
   source_file_dependencies:
-    - vllm/_aiter_ops.py
-    - vllm/_custom_ops.py
-    - vllm/assets/
-    - vllm/compilation/
     - vllm/config/
     - vllm/distributed/
     - vllm/engine/
-    - vllm/entrypoints/
-    - vllm/envs.py
-    - vllm/forward_context.py
+    - vllm/entrypoints/pooling/
     - vllm/inputs/
-    - vllm/ir/
-    - vllm/kernels/
     - vllm/lora/
     - vllm/model_executor/
     - vllm/multimodal/
     - vllm/outputs.py
     - vllm/platforms/
-    - vllm/plugins/
     - vllm/pooling_params.py
     - vllm/profiler/
     - vllm/sampling_params.py
-    - vllm/sequence.py
     - vllm/tokenizers/
     - vllm/transformers_utils/
-    - vllm/triton_utils/
     - vllm/utils/
     - vllm/v1/
     - tests/v1/core
@@ -139,8 +104,6 @@ steps:
     - vllm/config/
     - vllm/distributed/
     - vllm/engine/
-    - vllm/envs.py
-    - vllm/forward_context.py
     - vllm/inputs/
     - vllm/lora/
     - vllm/multimodal/
@@ -167,25 +130,15 @@ steps:
   timeout_in_minutes: 20
   device: h200_18gb
   source_file_dependencies:
-  - vllm/_aiter_ops.py
-  - vllm/_custom_ops.py
-  - vllm/compilation/
   - vllm/config/
   - vllm/distributed/
   - vllm/engine/
-  - vllm/envs.py
-  - vllm/forward_context.py
   - vllm/inputs/
-  - vllm/ir/
-  - vllm/kernels/
   - vllm/model_executor/
   - vllm/multimodal/
   - vllm/platforms/
-  - vllm/plugins/
   - vllm/sampling_params.py
-  - vllm/sequence.py
   - vllm/transformers_utils/
-  - vllm/triton_utils/
   - vllm/utils/
   - vllm/v1/
   - tests/test_regression
@@ -231,26 +184,16 @@ steps:
   timeout_in_minutes: 20
   num_devices: 2
   source_file_dependencies:
-  - vllm/_aiter_ops.py
-  - vllm/_custom_ops.py
-  - vllm/compilation/
   - vllm/config/
   - vllm/distributed/
   - vllm/engine/
-  - vllm/envs.py
-  - vllm/forward_context.py
   - vllm/inputs/
-  - vllm/ir/
-  - vllm/kernels/
   - vllm/model_executor/
   - vllm/multimodal/
   - vllm/platforms/
-  - vllm/plugins/
   - vllm/sampling_params.py
-  - vllm/sequence.py
   - vllm/tracing/
   - vllm/transformers_utils/
-  - vllm/triton_utils/
   - vllm/utils/
   - vllm/v1/
   - tests/v1/tracing
@@ -276,29 +219,17 @@ steps:
   key: async-engine-inputs-utils-worker
   timeout_in_minutes: 50
   source_file_dependencies:
-  - vllm/_aiter_ops.py
-  - vllm/_custom_ops.py
   - vllm/assets/
-  - vllm/compilation/
   - vllm/config/
   - vllm/distributed/
   - vllm/engine/
-  - vllm/entrypoints/llm.py
-  - vllm/envs.py
-  - vllm/forward_context.py
   - vllm/inputs/
-  - vllm/ir/
-  - vllm/kernels/
   - vllm/model_executor/
   - vllm/multimodal/
   - vllm/platforms/
-  - vllm/plugins/
-  - vllm/ray/
   - vllm/sampling_params.py
-  - vllm/sequence.py
   - vllm/tokenizers/
   - vllm/transformers_utils/
-  - vllm/triton_utils/
   - vllm/utils/
   - vllm/v1/
   - tests/detokenizer


### PR DESCRIPTION
## Summary

Eight jobs in `.buildkite/test_areas/misc.yaml` listed `vllm/` as a source dependency, causing them to run on any change anywhere under `vllm/`. This PR replaces each with the specific subdirectories the underlying tests actually exercise (verified via import scan).

| Job | Notable exclusions |
| --- | --- |
| V1 Spec Decode | lora, tracing, profiler, reasoning, tool_parsers, renderers, openai, cli, benchmarks (other than `datasets`) |
| V1 Sample + Logits | lora, tracing, profiler, reasoning, tool_parsers, renderers, openai, cli, benchmarks |
| V1 Core + KV + Metrics | tracing, reasoning, tool_parsers, renderers, benchmarks, spec_decode (still broad — touches lora/profiler/entrypoints via the lmeval correctness command) |
| V1 Others (CPU) | compile, kernels, ir, model_executor, plugins, and other GPU-only paths |
| Regression | lora, tracing, profiler, reasoning, tool_parsers, renderers, openai, cli, benchmarks |
| Metrics, Tracing (2 GPUs) | lora, spec_decode, profiler, reasoning, tool_parsers, renderers, openai, cli, benchmarks |
| Async Engine, Inputs, Utils, Worker | lora, spec_decode, tracing, profiler, reasoning, tool_parsers, renderers, openai, cli, benchmarks |
| Async Engine ... Config (CPU) | distributed, compile, kernels, forward_context, plugins, v1.spec_decode and other GPU/inference paths the unit tests don't touch |

## Test plan

- [ ] Verify CI scheduler picks up the narrower paths and skips these jobs on changes confined to excluded directories.
- [ ] Confirm jobs still trigger on changes to listed paths.

This change was AI-assisted (Claude Code). Reviewed end-to-end before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)