### PR TITLE
[ROCm][Bugfix] Re-tag AITER MoE weights as preshuffled after replace_parameter

### DIFF
--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -171,6 +171,11 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
         replace_parameter(layer, "w13_weight", w13_new, prefer_copy=is_weight_update)
         replace_parameter(layer, "w2_weight", w2_new, prefer_copy=is_weight_update)
 
+        # AITER backend requires weights to be marked as shuffled.
+        if self.unquantized_backend == UnquantizedMoeBackend.AITER:
+            layer.w13_weight.is_shuffled = True
+            layer.w2_weight.is_shuffled = True
+
         if not is_weight_update:
             # Setup moe kernel only on the first call. For the unquantized
             # method, moe_quant_config is either the constant

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -28,6 +28,7 @@ from vllm.model_executor.layers.fused_moe.config import (
 )
 from vllm.model_executor.layers.fused_moe.layer import UnquantizedFusedMoEMethod
 from vllm.model_executor.layers.fused_moe.oracle.fp8 import (
+    Fp8MoeBackend,
     convert_to_fp8_moe_kernel_format,
     make_fp8_moe_kernel,
     make_fp8_moe_quant_config,
@@ -765,6 +766,11 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         replace_parameter(layer, "w2_weight", w2)
         replace_parameter(layer, f"w13_{self.weight_scale_name}", w13_scale)
         replace_parameter(layer, f"w2_{self.weight_scale_name}", w2_scale)
+
+        # AITER backend requires weights to be marked as shuffled.
+        if self.fp8_backend == Fp8MoeBackend.AITER:
+            layer.w13_weight.is_shuffled = True
+            layer.w2_weight.is_shuffled = True
 
         self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         if self.moe_quant_config:

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -350,6 +350,11 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
             self.w13_precision_config = w13_scale
             self.w2_precision_config = w2_scale
 
+        # AITER backend requires weights to be marked as shuffled.
+        if self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16:
+            layer.w13_weight.is_shuffled = True
+            layer.w2_weight.is_shuffled = True
+
         if w13_bias is not None and w2_bias is not None:
             replace_parameter(layer, "w13_bias", w13_bias)
             replace_parameter(layer, "w2_bias", w2_bias)
@@ -677,6 +682,11 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             layer.w2_weight = w2
             self.w13_precision_config = w13_scale
             self.w2_precision_config = w2_scale
+
+        # AITER backend requires weights to be marked as shuffled.
+        if self.mxfp4_backend == Mxfp4MoeBackend.AITER_MXFP4_BF16:
+            layer.w13_weight.is_shuffled = True
+            layer.w2_weight.is_shuffled = True
 
         if w13_bias is not None and w2_bias is not None:
             replace_parameter(layer, "w13_bias", w13_bias)


### PR DESCRIPTION
## Summary

In `Fp8MoEMethod`, `Mxfp4MoEMethod`, `GptOssMxfp4MoEMethod`, and `UnquantizedFusedMoEMethod`, the AITER MoE backends call `rocm_aiter_ops.shuffle_weights()` (FP8 / unquantized via `aiter.ops.shuffle.shuffle_weight`) or `rocm_aiter_ops.shuffle_weight_a16w4()` (MXFP4 BF16) to lay the MoE weights out for AITER's tuned 2-stage CK kernels.

The follow-up `replace_parameter(layer, "w13_weight", ...)` calls then wrap the shuffled tensors in fresh `nn.Parameter` instances, **which do not propagate the custom `is_shuffled = True` Python attribute** that the shuffle helper attaches to the inner tensor. As a result, AITER's runtime kernel selection reads `getattr(layer.w13_weight, "is_shuffled", False) -> False`, falls back to the non-tuned preshuffle-off (`Nswizzle0`) path, and emits

```
[aiter] [fused_moe] tuned config found for (...) but is_shuffled=False.
Tuned kernels are optimized for preshuffled weights (preshuffle_on).
Running with preshuffle_off may produce incorrect results.
```

once per MoE layer per worker. The Quark MoE method already handles this correctly (`vllm/model_executor/layers/quantization/quark/quark_moe.py:1286-1287`, which sets `layer.w{13,2}_weight.is_shuffled = True` after the equivalent `shuffle_weights()` + `replace_parameter`).

This PR re-tags the layer Parameters explicitly after the `replace_parameter` calls in the four affected MoE methods, bringing them in line with the Quark path.

## Files changed

- `vllm/model_executor/layers/quantization/fp8.py` — `Fp8MoEMethod` (1 site)
- `vllm/model_executor/layers/quantization/mxfp4.py` — `GptOssMxfp4MoEMethod._setup_kernel` and `Mxfp4MoEMethod._setup_kernel` (2 sites; both use the identical `_setup_kernel` block, so the patch is the same)
- `vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py` — `UnquantizedFusedMoEMethod._setup_kernel` (1 site)

`AITER_MXFP4_FP8` is intentionally **excluded**: that backend uses Triton kernels (not AITER's 2-stage CK kernels) and does not go through the AITER `is_shuffled` check at runtime. The patch gates on `Mxfp4MoeBackend.AITER_MXFP4_BF16` specifically.

## Root cause walk-through (FP8 case, others analogous)

1. `vllm/model_executor/layers/fused_moe/oracle/fp8.py:445`:
   ```python
   elif fp8_backend == Fp8MoeBackend.AITER:
       w13, w2 = rocm_aiter_ops.shuffle_weights(w13, w2)
   ```
   `shuffle_weights()` returns tensors with `tensor.is_shuffled = True` (set in `aiter/ops/shuffle.py`).
2. `vllm/model_executor/layers/quantization/fp8.py:765`:
   ```python
   replace_parameter(layer, "w13_weight", w13)
   replace_parameter(layer, "w2_weight", w2)
   ```
   `replace_parameter` wraps the data in `nn.Parameter(w13, requires_grad=False)`. The new Parameter is a separate Python object; `Parameter.is_shuffled` raises `AttributeError`, so `getattr(..., False) -> False`.
3. At runtime, AITER's dispatcher (`aiter/fused_moe.py`) does
   ```python
   is_shuffled = getattr(w1, "is_shuffled", False)
   ...
   if not is_shuffled and not run_1stage:
       logger.warning(f"[fused_moe] tuned config found for {keys} but is_shuffled=False ...")
   ```
   The data IS in the preshuffled layout (we ran the shuffle in step 1), but AITER doesn't know that, so it picks the non-tuned `Nswizzle0` kernel variant.

## Test plan

Empirical verification on **DeepSeek-V3.2-Exp w8a8 block-scale FP8** running with `--tensor-parallel-size 4` on **MI355X**:

| | warnings per process | tuned 2-stage kernel selected |
|---|---:|---|
| before | **24** (`is_shuffled=False ... may produce incorrect results`) | `Nswizzle0` (preshuffle-off fallback) |
| after  | **0** | `Nswizzle1` (preshuffle-on, from `aiter/configs/model_configs/a8w8_blockscale_tuned_fmoe_ds_v3.csv`) |

`lm_eval` `gsm8k` (`num_concurrent=1, max_gen_toks=8192, --limit 24`) flexible-extract: 0.9583 (no regression vs. unpatched).

For MXFP4 / unquantized, the patch is structurally identical and verified by code review against the Quark precedent (`quark_moe.py:1286-1287`); empirical confirmation will follow as we run MXFP4-BF16 / unquantized MoE workloads through the same harness.
