### PR TITLE
[Bugfix] Fix authentication bypass on /inference/v1/generate

### DIFF
--- a/tests/entrypoints/openai/test_authentication_middleware.py
+++ b/tests/entrypoints/openai/test_authentication_middleware.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Regression tests for ``AuthenticationMiddleware``.
+
+These tests check the *path-matching* behaviour of the middleware in
+isolation. They do not exercise an actual model and do not depend on a
+running engine, which keeps them fast and safe to run in CI.
+
+The motivating issue is that the disaggregated-serving generate route is
+mounted at ``/inference/v1/generate`` and performs full text generation.
+Before the fix, the middleware only required auth for paths starting
+with ``/v1``, so this versioned inference endpoint was reachable
+without an API key whenever ``--api-key`` was set.
+"""
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from fastapi.testclient import TestClient
+
+from vllm.entrypoints.openai.server_utils import AuthenticationMiddleware
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/health")
+    @app.post("/health")
+    async def health():
+        return {"status": "ok"}
+
+    @app.post("/v1/completions")
+    async def completions():
+        return {"ok": True}
+
+    @app.post("/inference/v1/generate")
+    async def generate():
+        return {"ok": True}
+
+    @app.get("/tokenize")
+    async def tokenize():
+        return {"ok": True}
+
+    return app
+
+
+def _make_client(token: str = "secret") -> TestClient:
+    app = _build_app()
+    app.add_middleware(AuthenticationMiddleware, tokens=[token])
+    return TestClient(app)
+
+
+def test_health_does_not_require_auth():
+    client = _make_client()
+    resp = client.get("/health")
+    assert resp.status_code == 200
+
+
+def test_v1_completions_requires_auth():
+    client = _make_client()
+    resp = client.post("/v1/completions")
+    assert resp.status_code == 401
+
+
+def test_v1_completions_with_correct_token_succeeds():
+    client = _make_client(token="secret")
+    resp = client.post(
+        "/v1/completions",
+        headers={"Authorization": "Bearer secret"},
+    )
+    assert resp.status_code == 200
+
+
+def test_v1_completions_with_wrong_token_is_rejected():
+    client = _make_client(token="secret")
+    resp = client.post(
+        "/v1/completions",
+        headers={"Authorization": "Bearer not-the-token"},
+    )
+    assert resp.status_code == 401
+
+
+def test_inference_v1_generate_requires_auth():
+    """Regression test: ``/inference/v1/generate`` performs full text
+    generation and must be authenticated even though its path does not
+    *start* with ``/v1``."""
+    client = _make_client()
+    resp = client.post("/inference/v1/generate")
+    assert resp.status_code == 401, (
+        "/inference/v1/generate must require an API key when --api-key is set; "
+        "previously it was reachable unauthenticated because the middleware "
+        "only checked startswith('/v1')."
+    )
+
+
+def test_inference_v1_generate_with_correct_token_succeeds():
+    client = _make_client(token="secret")
+    resp = client.post(
+        "/inference/v1/generate",
+        headers={"Authorization": "Bearer secret"},
+    )
+    assert resp.status_code == 200
+
+
+def test_options_request_skips_auth():
+    """CORS preflights must always pass through."""
+    client = _make_client()
+    resp = client.options("/v1/completions")
+    # FastAPI's default may 405 OPTIONS on a POST-only route; what matters
+    # here is the middleware did not short-circuit with 401.
+    assert resp.status_code != 401
+
+
+def test_unrelated_path_does_not_require_auth():
+    """Paths outside the auth-required prefixes (e.g. ``/tokenize``) keep
+    their existing behaviour and remain unauthenticated. This matches the
+    project's stance that non-versioned helper endpoints are not in scope
+    for the API-key gate."""
+    client = _make_client()
+    resp = client.get("/tokenize")
+    assert resp.status_code == 200

--- a/tests/entrypoints/openai/test_authentication_middleware.py
+++ b/tests/entrypoints/openai/test_authentication_middleware.py
@@ -14,8 +14,8 @@ with ``/v1``, so this versioned inference endpoint was reachable
 without an API key whenever ``--api-key`` was set.
 """
 
+import pytest
 from fastapi import FastAPI
-from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
 from vllm.entrypoints.openai.server_utils import AuthenticationMiddleware
@@ -119,3 +119,39 @@ def test_unrelated_path_does_not_require_auth():
     client = _make_client()
     resp = client.get("/tokenize")
     assert resp.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "//v1/completions",
+        "///v1/completions",
+        "//inference/v1/generate",
+        "/inference//v1/generate",
+        "/inference///v1/generate",
+    ],
+)
+def test_multi_slash_paths_still_require_auth(path):
+    """Regression test: ``startswith("/v1")`` is bypassable by sending
+    ``//v1/completions`` (multiple leading slashes). ASGI servers like
+    uvicorn pass these through verbatim while the downstream router still
+    normalizes and matches them, so the middleware must normalize the path
+    *before* the prefix check.
+    """
+    client = _make_client()
+    resp = client.post(path)
+    assert resp.status_code == 401, (
+        f"{path} must require auth: multi-slash variants were a known "
+        "bypass vector for prefix-based middleware checks before this fix."
+    )
+
+
+def test_normalize_path_collapses_consecutive_slashes():
+    """Direct check on the path-normalization helper, independent of the
+    HTTP layer."""
+    norm = AuthenticationMiddleware._normalize_path
+    assert norm("/v1/completions") == "/v1/completions"
+    assert norm("//v1/completions") == "/v1/completions"
+    assert norm("///v1/completions") == "/v1/completions"
+    assert norm("/inference//v1/generate") == "/inference/v1/generate"
+    assert norm("/v1//foo//bar") == "/v1/foo/bar"

--- a/vllm/entrypoints/openai/server_utils.py
+++ b/vllm/entrypoints/openai/server_utils.py
@@ -44,8 +44,22 @@ class AuthenticationMiddleware:
     -----
     There are two cases in which authentication is skipped:
         1. The HTTP method is OPTIONS.
-        2. The request path doesn't start with /v1 (e.g. /health).
+        2. The request path is not under one of ``AUTH_REQUIRED_PREFIXES``
+           (e.g. /health, /metrics).
     """
+
+    # Path prefixes that require API-key authentication.
+    #
+    # ``/v1`` covers the bulk of the OpenAI-compatible surface
+    # (/v1/completions, /v1/chat/completions, /v1/responses, /v1/realtime,
+    # /v1/load_lora_adapter, ...).
+    #
+    # ``/inference/v1`` covers the disaggregated-serving generate route at
+    # ``/inference/v1/generate``, which performs full token-in / token-out
+    # inference and was previously reachable without authentication because
+    # its path does not *start* with ``/v1`` even though it is a versioned
+    # inference endpoint.
+    AUTH_REQUIRED_PREFIXES: tuple[str, ...] = ("/v1", "/inference/v1")
 
     def __init__(self, app: ASGIApp, tokens: list[str]) -> None:
         self.app = app
@@ -68,6 +82,9 @@ class AuthenticationMiddleware:
 
         return token_match
 
+    def _requires_auth(self, url_path: str) -> bool:
+        return any(url_path.startswith(p) for p in self.AUTH_REQUIRED_PREFIXES)
+
     def __call__(self, scope: Scope, receive: Receive, send: Send) -> Awaitable[None]:
         if (
             scope["type"] not in ("http", "websocket")
@@ -80,7 +97,7 @@ class AuthenticationMiddleware:
         url_path = URL(scope=scope).path.removeprefix(root_path)
         headers = Headers(scope=scope)
         # Type narrow to satisfy mypy.
-        if url_path.startswith("/v1") and not self.verify_token(headers):
+        if self._requires_auth(url_path) and not self.verify_token(headers):
             response = JSONResponse(content={"error": "Unauthorized"}, status_code=401)
             return response(scope, receive, send)
         return self.app(scope, receive, send)

--- a/vllm/entrypoints/openai/server_utils.py
+++ b/vllm/entrypoints/openai/server_utils.py
@@ -3,6 +3,7 @@
 import asyncio
 import hashlib
 import json
+import re
 import secrets
 import uuid
 from argparse import Namespace
@@ -61,6 +62,13 @@ class AuthenticationMiddleware:
     # inference endpoint.
     AUTH_REQUIRED_PREFIXES: tuple[str, ...] = ("/v1", "/inference/v1")
 
+    # Collapses runs of consecutive ``/`` so that path-prefix checks cannot be
+    # bypassed by sending e.g. ``//v1/completions`` or ``///v1/completions``.
+    # ASGI servers (uvicorn, hypercorn) do not always normalize these, but the
+    # downstream router still happily matches them after its own normalization,
+    # so the middleware must normalize *before* the prefix check.
+    _MULTI_SLASH_RE: re.Pattern[str] = re.compile(r"/+")
+
     def __init__(self, app: ASGIApp, tokens: list[str]) -> None:
         self.app = app
         self.api_tokens = [hashlib.sha256(t.encode("utf-8")).digest() for t in tokens]
@@ -82,8 +90,16 @@ class AuthenticationMiddleware:
 
         return token_match
 
+    @classmethod
+    def _normalize_path(cls, url_path: str) -> str:
+        # Collapse any run of ``/`` into a single ``/`` so that
+        # ``startswith("/v1")`` cannot be evaded by ``//v1`` / ``///v1`` /
+        # encoded variants that uvicorn passes through verbatim.
+        return cls._MULTI_SLASH_RE.sub("/", url_path)
+
     def _requires_auth(self, url_path: str) -> bool:
-        return any(url_path.startswith(p) for p in self.AUTH_REQUIRED_PREFIXES)
+        normalized = self._normalize_path(url_path)
+        return any(normalized.startswith(p) for p in self.AUTH_REQUIRED_PREFIXES)
 
     def __call__(self, scope: Scope, receive: Receive, send: Send) -> Awaitable[None]:
         if (


### PR DESCRIPTION
## Summary

`AuthenticationMiddleware` (vllm/entrypoints/openai/server_utils.py) only required a bearer token for paths starting with `/v1`. The disaggregated-serving generate route is mounted at `/inference/v1/generate` (vllm/entrypoints/serve/disagg/api_router.py) and is attached to the app whenever the model supports the `generate` task -- that is, on every standard text-generation deployment, not just `--tokens-only` / disaggregated mode (see `register_generate_api_routers` and `state.serving_tokens` in vllm/entrypoints/openai/generate/api_router.py).

Because `""/inference/v1/generate"".startswith(""/v1"")` is `False`, the middleware lets the request through without checking the bearer token. The endpoint then dispatches to `ServingTokens.serve_tokens`, which performs full token-in / token-out inference -- the same engine path reached by `/v1/completions`.

With `--api-key` set, an unauthenticated client can call `/inference/v1/generate` and obtain free, unlogged inference and burn GPU time, fully bypassing the API-key gate.

## Repro (before this PR)

`ash
vllm serve <model> --api-key secret &

# 401 as expected:
curl -i -X POST http://localhost:8000/v1/completions \
  -H 'Content-Type: application/json' \
  -d '{""model"": ""<model>"", ""prompt"": ""hi"", ""max_tokens"": 5}'

# 200 -- bypasses --api-key:
curl -i -X POST http://localhost:8000/inference/v1/generate \
  -H 'Content-Type: application/json' \
  -d '{""model"": ""<model>"", ""prompt_token_ids"": [...], ""max_tokens"": 5}'
`

## Fix

Add `AuthenticationMiddleware.AUTH_REQUIRED_PREFIXES = (""/v1"", ""/inference/v1"")` and a `_requires_auth(path)` helper. Any path under one of those prefixes now requires a valid bearer token. All previously-unprotected helper endpoints (`/health`, `/metrics`, `/tokenize`, `/load`, `/server_info`, `/version`, `/ping`, `/invocations`, ...) keep their existing behaviour, matching the project's stance that non-versioned helpers are out of scope for the API-key gate (see prior reports marked ""Not applicable"" / ""Duplicate"" on huntr).

This is *strictly narrower* than re-classifying all non-/v1 endpoints as authenticated. The added prefix matches a route that is itself versioned (`/inference/v1/...`) and performs the same generation work as `/v1/completions`, so the existing API-key contract should apply to it.

## Distinct from prior reports

The disclosed huntr reports for vLLM all targeted non-versioned helpers:

- ""Authentication Bypass on Non-/v1 Endpoints"" -- *Not applicable*
- ""Authentication Bypass via Path Prefix Check"" -- *Not applicable*
- ""Authentication Bypass for Non-/v1 Endpoints Exposes Tokenization"" -- *Duplicate*

This PR addresses a different class: a *versioned* inference route (`/inference/v1/generate`) whose path was simply not anchored at `/v1`. It is the inference-equivalent of `/v1/completions`, not a helper.

## Tests

A new `tests/entrypoints/openai/test_authentication_middleware.py` exercises the path-matching behaviour of `AuthenticationMiddleware` in isolation (no engine, no model). Cases:

- `/health` -- unauthenticated allowed (regression guard for helpers)
- `/v1/completions` -- 401 without token, 200 with correct token, 401 with wrong token
- `/inference/v1/generate` -- 401 without token (regression for this fix), 200 with correct token
- `OPTIONS /v1/completions` -- not 401 (CORS preflight pass-through preserved)
- `/tokenize` -- unauthenticated allowed (existing stance preserved)

`ash
.venv/bin/python -m pytest tests/entrypoints/openai/test_authentication_middleware.py -v
`

## AI assistance disclosure (per AGENTS.md)

This change was prepared with AI assistance. The human submitter reviewed every changed line, ran the new tests locally, and is responsible for defending the change end-to-end.