### PR TITLE
[Docs] Fix OpenAI batch model argument examples

### DIFF
--- a/examples/features/openai_batch/README.md
+++ b/examples/features/openai_batch/README.md
@@ -193,7 +193,7 @@ You can now run the batch runner, using the urls generated in the previous secti
 python -m vllm.entrypoints.openai.run_batch \
     -i "https://s3.us-west-2.amazonaws.com/MY_BUCKET/MY_INPUT_FILE.jsonl?AWSAccessKeyId=ABCDEFGHIJKLMNOPQRST&Signature=abcdefghijklmnopqrstuvwxyz12345&Expires=1715800091" \
     -o "https://s3.us-west-2.amazonaws.com/MY_BUCKET/MY_OUTPUT_FILE.jsonl?AWSAccessKeyId=ABCDEFGHIJKLMNOPQRST&Signature=abcdefghijklmnopqrstuvwxyz12345&Expires=1715800091" \
-    --model --model meta-llama/Meta-Llama-3-8B-Instruct
+    --model meta-llama/Meta-Llama-3-8B-Instruct
 ```
 
 or use command-line:
@@ -202,7 +202,7 @@ or use command-line:
 vllm run-batch \
     -i "https://s3.us-west-2.amazonaws.com/MY_BUCKET/MY_INPUT_FILE.jsonl?AWSAccessKeyId=ABCDEFGHIJKLMNOPQRST&Signature=abcdefghijklmnopqrstuvwxyz12345&Expires=1715800091" \
     -o "https://s3.us-west-2.amazonaws.com/MY_BUCKET/MY_OUTPUT_FILE.jsonl?AWSAccessKeyId=ABCDEFGHIJKLMNOPQRST&Signature=abcdefghijklmnopqrstuvwxyz12345&Expires=1715800091" \
-    --model --model meta-llama/Meta-Llama-3-8B-Instruct
+    --model meta-llama/Meta-Llama-3-8B-Instruct
 ```
 
 ### Step 4: View your results


### PR DESCRIPTION
## Purpose

  Fix duplicate `--model` arguments in the OpenAI batch S3 example commands.

  The documented commands used `--model --model meta-llama/Meta-Llama-3-8B-Instruct`, which is invalid and confusing for users copying the example. No  duplicate-work found.

  ## Test Result

  - git diff --check passed.
  - Commit pre-commit hooks passed, including markdownlint-cli2.


  <details>
  <summary> Essential Elements of an Effective PR Description Checklist </summary>

  - [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
  - [x] The test plan, such as providing test command.
  - [x] The test results, such as pasting the results comparison before and after, or e2e results.
  - [x] (Optional) The necessary documentation update, such as updating supported_models.md and examples for a new model.
  </details>