### PR TITLE
[Deps] Temporarily cap `nvidia-cutlass-dsl` below 4.5.0

### DIFF
--- a/requirements/cuda.txt
+++ b/requirements/cuda.txt
@@ -21,5 +21,6 @@ nvidia-cudnn-frontend>=1.13.0,<1.19.0
 fastsafetensors >= 0.2.2
 
 # QuACK and Cutlass DSL for FA4 (cute-DSL implementation)
-nvidia-cutlass-dsl>=4.4.2
+# nvidia-cutlass-dsl 4.5.0 currently has compatibility issues.
+nvidia-cutlass-dsl>=4.4.2,<4.5.0
 quack-kernels>=0.3.3


### PR DESCRIPTION
## Summary

Temporarily caps `nvidia-cutlass-dsl` to `<4.5.0` because `4.5.0` currently has compatibility issues with vLLM. The known failure is in the FA4 path on SM103/B300, but there may be other affected paths that have not been found yet.

vLLM currently allows `nvidia-cutlass-dsl>=4.4.2`, so fresh installs can resolve to `4.5.0`. One observed failure is that FA4 can reject `sm_103a` during arch validation with:

```text
AssertionError: Only SM 10.x and 11.x are supported
```

I opened a flash-attention PR for that specific FA4 issue here: https://github.com/vllm-project/flash-attention/pull/138. This cap is a conservative vLLM-side mitigation while the broader `4.5.0` compatibility impact is understood more fully.