### PR TITLE
[Spec Decode] Allow DFlash drafter to autoselect non-causal-capable backend on Gemma 4

### DIFF
--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -71,13 +71,36 @@ class DFlashProposer(SpecDecodeBaseProposer):
     @override
     def _create_draft_vllm_config(self) -> VllmConfig:
         base = super()._create_draft_vllm_config()
-        return replace(
+        # [Divinci-AI fork] DEFENSIVE FIX + DIAGNOSTIC: when the target is
+        # Gemma 4 (heterogeneous head dimensions), Gemma4Config force-locks
+        # `attention_config.backend` to TRITON_ATTN. The base proposer at
+        # llm_base_proposer.py:1320-1326 SHOULD reset that to None for the
+        # drafter via spec_cfg.attention_backend, but in practice the
+        # drafter still ends up on TRITON, which DFlash's non-causal
+        # attention then rejects at engine init. Defensively force the
+        # drafter's backend back to None here so the autoselector picks
+        # FlashInfer (which supports non-causal). Diagnostic prints below
+        # let us trace the actual values across base->fix.
+        before_backend = base.attention_config.backend
+        result = replace(
             base,
             attention_config=replace(
                 base.attention_config,
                 use_non_causal=True,
+                backend=None,  # ← DEFENSIVE: force autoselect for drafter
             ),
         )
+        after_backend = result.attention_config.backend
+        logger.warning(
+            "[DIVINCI-FORK] DFlashProposer._create_draft_vllm_config: "
+            "before_backend=%s after_backend=%s spec_cfg.attention_backend=%s "
+            "target_attention_config.backend=%s",
+            before_backend,
+            after_backend,
+            self.vllm_config.speculative_config.attention_backend,
+            self.vllm_config.attention_config.backend,
+        )
+        return result
 
     @override
     def _warn_if_multimodal(self):

--- a/vllm/v1/spec_decode/dflash.py
+++ b/vllm/v1/spec_decode/dflash.py
@@ -71,36 +71,30 @@ class DFlashProposer(SpecDecodeBaseProposer):
     @override
     def _create_draft_vllm_config(self) -> VllmConfig:
         base = super()._create_draft_vllm_config()
-        # [Divinci-AI fork] DEFENSIVE FIX + DIAGNOSTIC: when the target is
-        # Gemma 4 (heterogeneous head dimensions), Gemma4Config force-locks
-        # `attention_config.backend` to TRITON_ATTN. The base proposer at
-        # llm_base_proposer.py:1320-1326 SHOULD reset that to None for the
-        # drafter via spec_cfg.attention_backend, but in practice the
-        # drafter still ends up on TRITON, which DFlash's non-causal
-        # attention then rejects at engine init. Defensively force the
-        # drafter's backend back to None here so the autoselector picks
-        # FlashInfer (which supports non-causal). Diagnostic prints below
-        # let us trace the actual values across base->fix.
-        before_backend = base.attention_config.backend
-        result = replace(
+        # When the target is Gemma 4 (heterogeneous head dimensions:
+        # head_dim=256, global_head_dim=512), Gemma4Config.verify_and_update_config
+        # force-locks `attention_config.backend` to TRITON_ATTN to prevent
+        # mixed-backend numerical divergence within the target's own forward.
+        # The base SpecDecodeBaseProposer._create_draft_vllm_config resets
+        # backend to spec_cfg.attention_backend (default None), but in
+        # practice the drafter still ends up on TRITON_ATTN which then
+        # rejects DFlash's non-causal drafter attention at engine init.
+        #
+        # The "mixed-backend numerical divergence" concern doesn't apply
+        # to spec-decode where target and drafter are separate models with
+        # separate KV caches and separate forwards — rejection sampling
+        # tolerates numerical drift by design. Force backend=None here so
+        # the drafter goes through the standard autoselect path and picks
+        # FLEX_ATTENTION (or any other non-causal-capable backend) when
+        # use_non_causal=True is set.
+        return replace(
             base,
             attention_config=replace(
                 base.attention_config,
                 use_non_causal=True,
-                backend=None,  # ← DEFENSIVE: force autoselect for drafter
+                backend=None,
             ),
         )
-        after_backend = result.attention_config.backend
-        logger.warning(
-            "[DIVINCI-FORK] DFlashProposer._create_draft_vllm_config: "
-            "before_backend=%s after_backend=%s spec_cfg.attention_backend=%s "
-            "target_attention_config.backend=%s",
-            before_backend,
-            after_backend,
-            self.vllm_config.speculative_config.attention_backend,
-            self.vllm_config.attention_config.backend,
-        )
-        return result
 
     @override
     def _warn_if_multimodal(self):


### PR DESCRIPTION
## Summary

Fixes #42068.

When the target is Gemma 4 (heterogeneous head dimensions: `head_dim=256`, `global_head_dim=512`), `Gemma4Config.verify_and_update_config` force-locks `attention_config.backend` to `TRITON_ATTN` to prevent mixed-backend numerical divergence within the target's own forward (sliding vs global attention).

That lock is correct for the target's intra-forward consistency, but it propagates to the drafter via `DFlashProposer._create_draft_vllm_config`. DFlash drafters use **non-causal (bidirectional)** attention to draft a whole block in one pass — `TRITON_ATTN` rejects this:

```
ValueError: Selected backend AttentionBackendEnum.TRITON_ATTN is not valid for
this configuration. Reason: ['non-causal attention not supported']
```

Result: Gemma 4 + DFlash speculative decoding is structurally impossible upstream today.

## Why the lock doesn't apply to spec-decode

The "mixed-backend numerical divergence" risk is legitimate **inside one forward pass** (Gemma 4's own sliding-vs-global layers). It is **not** legitimate across spec-decode where target and drafter are separate `nn.Module`s with separate KV caches and separate forwards — rejection sampling tolerates numerical drift by design. The MTP case (#41745) is the exception (KV-shared with target — must inherit backend); DFlash and any other independent-KV drafter is the general case where the drafter should be free to autoselect.

## The change

One method override in `vllm/v1/spec_decode/dflash.py`:

```python
@override
def _create_draft_vllm_config(self) -> VllmConfig:
    base = super()._create_draft_vllm_config()
    return replace(
        base,
        attention_config=replace(
            base.attention_config,
            use_non_causal=True,
            backend=None,    # <-- bypass the MTP-style propagation
        ),
    )
```

`backend=None` lets the standard autoselect pick a backend that supports non-causal attention (`FLEX_ATTENTION` / `FLASHINFER`) on the drafter, while leaving the target's `TRITON_ATTN` lock untouched. `use_non_causal=True` is preserved.

## Precedent

`vllm-ascend` (sibling project for Ascend NPUs) already merged the equivalent decoupling: vllm-project/vllm-ascend#7342 — *\"Separate attention backend for target and draft model\"* by @SidaoY.

## Measured impact

Modal H100, 10 mixed prompts (5 math + 5 conversational), `temperature=0.0`, `max_new_tokens=256`, vLLM nightly + this patch overlay:

| Phase | Target | Avg speedup | Math-reasoning peak |
|---|---|---|---|
| 1 | `google/gemma-4-31B-it` (stock) | **1.28×** | **4.4×** |
| 2 | `google/gemma-4-31B-it` + Divinci QLoRA-DFO (merged bf16) | **1.18×** | **4.0×** |

Phase 2's QLoRA-fine-tuned target retains **92%** of the stock-target speedup despite the drafter being conditioned on stock Gemma 4 hidden states — confirming the fix is broadly useful for the fine-tune ecosystem, not just stock targets. Output text was bit-identical between with-DFlash and without-DFlash runs (verifier's lossless guarantee held).

## Test plan

- [x] Engine init succeeds end-to-end on Modal H100 with `target=google/gemma-4-31B-it`, `drafter=z-lab/gemma-4-31B-it-DFlash`
- [x] Drafter picks `FLEX_ATTENTION` via autoselect (vs the failing `TRITON_ATTN` on main)
- [x] Both models load; `torch.compile` completes for backbone + eagle_head
- [x] A/B speedup measured (table above)
- [x] Output bit-identical with vs without DFlash on the same prompt set
- [ ] CI

## Related

- Filed issue: #42068
- #38887 — Gemma 4 E4B slow on TRITON_ATTN (open since v0.19.0)
- #41789 — Gemma 4 31B MTP draft acceptance 0.2% (different bug, same area)
- #41745 — Gemma4 MTP speculative decoding (cc @lucianommartins — natural reviewer)

DCO sign-off: yes (`Signed-off-by: Mike Mooring <mike@divinci.ai>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)