### PR TITLE
Add Laguna-XS.2-NVFP4 to gsm8k

### DIFF
--- a/tests/evals/gsm8k/configs/Laguna-XS.2-NVFP4.yaml
+++ b/tests/evals/gsm8k/configs/Laguna-XS.2-NVFP4.yaml
@@ -1,0 +1,9 @@
+model_name: "poolside/Laguna-XS.2-NVFP4"
+accuracy_threshold: 0.87
+num_questions: 1319
+num_fewshot: 5
+startup_max_wait_seconds: 1200
+server_args: >-
+  --enforce-eager
+  --max-model-len 4096
+  --trust-remote-code

--- a/tests/evals/gsm8k/configs/models-h200.txt
+++ b/tests/evals/gsm8k/configs/models-h200.txt
@@ -4,3 +4,4 @@ DeepSeek-V3.2-TP.yaml
 DeepSeek-V3.2-DP.yaml
 Nemotron-3-Super-120B-A12B-BF16.yaml
 Nemotron-3-Super-120B-A12B-FP8.yaml
+Laguna-XS.2-NVFP4.yaml


### PR DESCRIPTION
## Purpose

Adds a GSM8K accuracy eval for `poolside/Laguna-XS.2-NVFP4` to the native
harness at `tests/evals/gsm8k/`, registered in `configs/models-h200.txt`,
so we catch silent regressions in the vLLM implementation of Laguna-XS.2.

Earlier rev of this branch used the deprecating `.buildkite/lm-eval-harness/`
harness with the FP8 variant; switched to the new harness + NVFP4 per
reviewer feedback.

## Test Plan

```bash
pytest -s -v tests/evals/gsm8k/test_gsm8k_correctness.py \
    --config-list-file=configs/models-h200.txt
```

## Test Result

Run on a single H200 (1319 questions, 5-shot, `--enforce-eager --max-model-len 4096`):

| Metric | Value |
|---|---|
| Accuracy | 0.8704 |
| Threshold | 0.87 |
| Invalid rate | 0.000 |
| Latency | 106.9 s |
| QPS | 12.3 |

`GSM8K test passed for poolside/Laguna-XS.2-NVFP4`

## Follow-ups

- Compound test with `poolside/Laguna-XS.2-speculator.dflash` is deferred:
  upstream `vllm/config/speculative.py` allowlist rejects `model_type='laguna'`
  for `dflash` / `eagle3` / `extract_hidden_states`. Needs a separate change
  to add Laguna once aux hidden states are confirmed exposed.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>