### PR TITLE
[Docs] Fix RLHF example links

### DIFF
--- a/docs/training/async_rl.md
+++ b/docs/training/async_rl.md
@@ -60,4 +60,4 @@ The key insight is that requests paused with `mode="keep"` will produce tokens f
 
 ## Example
 
-The [async RLHF example](../examples/rl/rlhf_async_new_apis.md) demonstrates this pattern with `vllm.AsyncLLMEngine`, NCCL weight transfer, and mid-flight pause/resume with validation.
+The [async RLHF example](../../examples/rl/rlhf_async_new_apis.py) demonstrates this pattern with `vllm.AsyncLLMEngine`, NCCL weight transfer, and mid-flight pause/resume with validation.

--- a/docs/training/weight_transfer/ipc.md
+++ b/docs/training/weight_transfer/ipc.md
@@ -69,5 +69,5 @@ See [`IPCTrainerSendWeightsArgs`](https://github.com/vllm-project/vllm/blob/main
 
 ## Examples
 
-- [RLHF with IPC weight syncing (offline, Ray)](../../examples/rl/rlhf_ipc.md) - Colocated training and inference on a single GPU using Ray placement groups and CUDA IPC handles
-- [RLHF with IPC weight syncing (online serving, HTTP)](../../examples/rl/rlhf_http_ipc.md) - Weight transfer with a vLLM HTTP server where both server and trainer share the same GPU
+- [RLHF with IPC weight syncing (offline, Ray)](../../../examples/rl/rlhf_ipc.py) - Colocated training and inference on a single GPU using Ray placement groups and CUDA IPC handles
+- [RLHF with IPC weight syncing (online serving, HTTP)](../../../examples/rl/rlhf_http_ipc.py) - Weight transfer with a vLLM HTTP server where both server and trainer share the same GPU

--- a/docs/training/weight_transfer/nccl.md
+++ b/docs/training/weight_transfer/nccl.md
@@ -105,6 +105,6 @@ The `names`, `dtype_names`, and `shapes` lists describe each parameter. These mu
 
 ## Examples
 
-- [RLHF with NCCL weight syncing (offline, Ray)](../../examples/rl/rlhf_nccl.md) - Trainer on one GPU, 2x tensor-parallel vLLM engine on two others, with packed NCCL weight broadcast
-- [RLHF with async weight syncing (offline, Ray)](../../examples/rl/rlhf_async_new_apis.md) - Async generation with mid-flight pause, weight sync, resume, and validation against a fresh model
-- [RLHF with NCCL weight syncing (online serving, HTTP)](../../examples/rl/rlhf_http_nccl.md) - Weight transfer with a running vLLM HTTP server using HTTP control plane and NCCL data plane
+- [RLHF with NCCL weight syncing (offline, Ray)](../../../examples/rl/rlhf_nccl.py) - Trainer on one GPU, 2x tensor-parallel vLLM engine on two others, with packed NCCL weight broadcast
+- [RLHF with async weight syncing (offline, Ray)](../../../examples/rl/rlhf_async_new_apis.py) - Async generation with mid-flight pause, weight sync, resume, and validation against a fresh model
+- [RLHF with NCCL weight syncing (online serving, HTTP)](../../../examples/rl/rlhf_http_nccl.py) - Weight transfer with a running vLLM HTTP server using HTTP control plane and NCCL data plane


### PR DESCRIPTION
## Purpose

Fix broken RLHF example links in the training docs.

The documentation currently links to generated `.md` pages under `docs/examples/rl/`, but those files do not exist in the repository and result in 404 pages.

The actual runnable examples live under `examples/rl/` as Python scripts, so this PR updates the links accordingly.

Example from:
https://github.com/vllm-project/vllm/blob/main/docs/training/weight_transfer/ipc.md

### Before

The docs linked to:

`docs/examples/rl/rlhf_ipc.md`

Direct link:
https://github.com/vllm-project/vllm/blob/main/docs/examples/rl/rlhf_ipc.md

This currently returns a GitHub 404 page.

<img width="1320" height="345" alt="image" src="https://github.com/user-attachments/assets/3ba8102f-aacc-4aee-884c-802274ab3969" />

### After

Updated to:

`examples/rl/rlhf_ipc.py`

Direct link:
https://github.com/vllm-project/vllm/blob/main/examples/rl/rlhf_ipc.py

This link resolves correctly to the actual example file.



  ## Test Result

  - `git diff --check` passed
  - Updated links resolve to existing files
  - Commit hooks passed, including `markdownlint-cli2`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

