### PR TITLE
[Bugfix] Reset offloader singleton in shutdown() to prevent GPU memory leak

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -87,6 +87,7 @@ from vllm.model_executor.models.interfaces_base import (
     is_text_generation_model,
 )
 from vllm.model_executor.offloader import (
+    NoopOffloader,
     create_offloader,
     get_offloader,
     set_offloader,
@@ -5965,6 +5966,12 @@ class GPUModelRunner(
         self.compilation_config.static_forward_context.clear()
         self.model = None  # type: ignore[assignment]
         _ROPE_DICT.clear()
+
+        # Reset the global offloader singleton so that UVA/pinned-memory
+        # tensors are released before the CUDA context is torn down.
+        # Without this, on UMA systems (e.g. GH200) the CUDA driver may
+        # not reclaim the mapped memory after process exit.
+        set_offloader(NoopOffloader())
 
         reset_workspace_manager()
 


### PR DESCRIPTION
## Summary

- When `--cpu-offload-gb` is used, `UVAOffloader` is installed as a process-wide singleton via `set_offloader()` in `gpu_model_runner.py`. It holds references to pinned CPU tensors and their CUDA UVA views.
- The existing `shutdown()` path clears model weights and KV caches, but never resets this singleton — so those tensor references remain alive after shutdown.
- On GH200 (UMA), `pin_memory()` is accounted as GPU memory by the CUDA driver. Because the singleton is never released, the driver does not reclaim that memory after process exit, resulting in 20–40 GB of orphaned GPU memory visible in `nvidia-smi` (no reboot required to recover without this fix).
- On discrete GPUs in in-process mode (`VLLM_ENABLE_V1_MULTIPROCESSING=0`), the same leak prevents GPU memory from being freed after `engine.shutdown()` while the calling process is still alive.

**Fix:** call `set_offloader(NoopOffloader())` at the end of `shutdown()`. This drops the singleton's references, allowing the CUDA driver to reclaim mapped memory. `NoopOffloader` is already the module's default initial value and all methods called on it during inference are no-op base implementations, so replacing the singleton at shutdown is safe.

**Related issues:** Fixes #42017

**Why this is not a duplicate PR:** No existing open PR addresses the offloader singleton lifecycle in `shutdown()`. PR #38503 fixed several other shutdown-path leaks (LRU cache, `gc.freeze`, KV cache) but missed the offloader.

## Changes

`vllm/v1/worker/gpu_model_runner.py`:
- Add `NoopOffloader` to the existing offloader import
- Call `set_offloader(NoopOffloader())` at the end of `shutdown()`

## Test plan

- [ ] `pytest tests/basic_correctness/test_prefetch_offload.py -v` — verify offload functionality not regressed
- [ ] Serve a large model with `--cpu-offload-gb` on GH200, stop vLLM normally, confirm `nvidia-smi` shows 0 residual memory (reproduces #42017 comment 2)
- [ ] Serve with `--cpu-offload-gb` on GH200, trigger KV cache OOM crash, confirm `nvidia-smi` shows 0 residual memory (reproduces #42017 original report)
- [ ] Run with `VLLM_ENABLE_V1_MULTIPROCESSING=0` on a discrete GPU, call `engine.shutdown()` in-process, confirm GPU memory is freed before process exits

> **Note:** This PR is in draft pending test results. Hardware access (GH200) is being arranged.

## AI assistance

This fix was identified and implemented with the assistance of Claude (Anthropic). All changed lines have been reviewed by the human submitter.