### PR TITLE
[Misc] Expose host RDMA devices to container in run_cluster.sh

### DIFF
--- a/examples/ray_serving/run_cluster.sh
+++ b/examples/ray_serving/run_cluster.sh
@@ -115,11 +115,31 @@ else
     fi
 fi
 
+# If the host has InfiniBand / RoCE verbs devices, expose them to the
+# container so NCCL can use the IB transport for inter-node collectives.
+# Without these flags, /dev/infiniband is not visible inside the container
+# and NCCL silently falls back to TCP over the Ethernet interface that
+# --network host provides, even when NCCL_IB_HCA / NCCL_IB_DISABLE are set in
+# the container env. The fallback is bandwidth-similar but ~10-20x higher
+# per-message latency and runs the full TCP/IP stack on the host CPU.
+# On hosts without /dev/infiniband, this block is a no-op.
+RDMA_DOCKER_FLAGS=()
+if [ -d /dev/infiniband ] && [ -n "$(ls -A /dev/infiniband 2>/dev/null)" ]; then
+    RDMA_DOCKER_FLAGS+=(
+        --device /dev/infiniband:/dev/infiniband
+        --cap-add IPC_LOCK
+        --ulimit memlock=-1
+        --ulimit stack=67108864
+    )
+fi
+
 # Launch the container with the assembled parameters.
 # --network host: Allows Ray nodes to communicate directly via host networking
 # --shm-size 10.24g: Increases shared memory
 # --gpus all: Gives container access to all GPUs on the host
 # -v HF_HOME: Mounts HuggingFace cache to avoid re-downloading models
+# RDMA_DOCKER_FLAGS: Passes IB/RoCE verbs devices into the container when the
+#   host has them, so NCCL can use IB transport instead of falling back to TCP.
 docker run \
     --entrypoint /bin/bash \
     --network host \
@@ -127,5 +147,6 @@ docker run \
     --shm-size 10.24g \
     --gpus all \
     -v "${PATH_TO_HF_HOME}:/root/.cache/huggingface" \
+    "${RDMA_DOCKER_FLAGS[@]}" \
     "${ADDITIONAL_ARGS[@]}" \
     "${DOCKER_IMAGE}" -c "${RAY_START_CMD}"


### PR DESCRIPTION
## Purpose

`examples/ray_serving/run_cluster.sh` launches the vLLM Ray container with `--network host --gpus all` but does not expose any of the four flags NCCL needs to use the InfiniBand / RoCE transport for inter-node collectives:

```
--device /dev/infiniband:/dev/infiniband
--cap-add IPC_LOCK
--ulimit memlock=-1
--ulimit stack=67108864
```

Without `--device /dev/infiniband`, the verbs character devices (`/dev/infiniband/uverbs*`, `rdma_cm`, etc.) are not visible inside the container, so NCCL cannot open them. NCCL **silently** falls back to `NET/Socket` (plain TCP) over the Ethernet interface that `--network host` provides, even on hosts where:

- The IB / RoCE transport is healthy (`ibv_devinfo` works, `ib_write_bw` saturates the link).
- The container env has `NCCL_IB_DISABLE=0` and a correct `NCCL_IB_HCA=...`.
- Ray correctly selects the high-speed subnet for inter-node bootstrapping.

The fallback is invisible unless the user thinks to set `NCCL_DEBUG=INFO` and inspect the transport log lines. Bandwidth on the TCP path can look superficially similar (~150-180 Gbps TCP vs ~190 Gbps RDMA on a 200 Gb link), but per-message latency is ~10-20× higher (~10 µs TCP vs <1 µs RDMA), and the host CPU runs the full TCP/IP stack instead of zero-copy RDMA. The combination disproportionately hurts collectives like all-reduce that issue many small messages.

This was diagnosed on a 2× DGX Spark TP=2 cluster with a ConnectX-7 200 Gbps QSFP56 DAC link. With the upstream script as-is, NCCL chose `NET/Socket`. The container's `ls /dev/infiniband/` returned `No such file or directory` even though the host had a fully functional RDMA stack with `mlx5_ib`, `rdma_cm`, etc. all loaded. Once the four flags above were added to the `docker run` command line, `ls /dev/infiniband/` listed all `uverbs*`/`rdma_cm`/`umad*` devices and NCCL switched to `NET/IB` on both RoCE adapters.

## What this change does

Adds an auto-detection block before `docker run` that checks for `/dev/infiniband` on the host and, when present, appends the four RDMA flags. On hosts without `/dev/infiniband` (most single-GPU workstations, most cloud VMs, ROCm boxes, etc.) the conditional is a no-op and existing users are unaffected.

```bash
RDMA_DOCKER_FLAGS=()
if [ -d /dev/infiniband ] && [ -n "$(ls -A /dev/infiniband 2>/dev/null)" ]; then
    RDMA_DOCKER_FLAGS+=(
        --device /dev/infiniband:/dev/infiniband
        --cap-add IPC_LOCK
        --ulimit memlock=-1
        --ulimit stack=67108864
    )
fi
```

The flags are then spliced into the existing `docker run` invocation via `"${RDMA_DOCKER_FLAGS[@]}"`. Auto-detection avoids the footgun where a user with RDMA hardware has to discover, on their own, that the example script needs to be edited or that they must inject the flags via `ADDITIONAL_ARGS` to get the performance their hardware can deliver.

## Why each flag is required

- **`--device /dev/infiniband:/dev/infiniband`** — exposes the verbs character devices (`uverbs*`, `umad*`, `rdma_cm`) so NCCL can open them. Without this, `NCCL_IB_DISABLE=0` and `NCCL_IB_HCA` in the container env are simply ignored.
- **`--cap-add IPC_LOCK`** — RDMA needs to `mlock()` user-space buffers (NIC DMA cannot tolerate page migration), which requires this capability inside the container.
- **`--ulimit memlock=-1`** — raises the memlock rlimit so the large MR registrations succeed; the default 64 KB rlimit truncates them.
- **`--ulimit stack=67108864`** — matches NVIDIA NGC's documented baseline for RDMA workloads.

## Test Plan

1. Diagnostic check: `ssh <node> 'docker exec <container> ls /dev/infiniband/'` should list the verbs devices instead of returning `No such file or directory`.
2. NCCL transport log: with `NCCL_DEBUG=INFO` set in the container env, the vLLM startup log should show `NET/IB` for the chosen transport instead of `NET/Socket`.
3. Microbenchmark: `nccl-tests` `all_reduce_perf` across nodes should show bandwidth in the IB ceiling range for the link, not the ~5-10 GB/s typical of TCP-over-host-network.

## Test Result

Verified end-to-end on a 2× DGX Spark TP=2 cluster (Ubuntu 24.04 / kernel 6.17, NVIDIA driver 580, NCCL 2.28.9) with a ConnectX-7 200 Gbps QSFP56 DAC link.

**Before** (upstream script):

```text
$ ssh spark1 'docker exec node-XXX ls /dev/infiniband/'
ls: cannot access '/dev/infiniband': No such file or directory

# vLLM startup log:
NCCL INFO Channel ... [send] via NET/Socket ...
```

**After** (with this change):

```text
$ ssh spark1 'docker exec node-XXX ls /dev/infiniband/'
by-ibdev  by-path  rdma_cm  umad0  umad1  umad2  umad3  uverbs0  uverbs1  uverbs2  uverbs3

# vLLM startup log:
NCCL INFO NET/IB : Using [0]rocep1s0f0:1/RoCE [1]roceP2p1s0f0:1/RoCE
```

Hosts in our test environment that lack `/dev/infiniband` (single-GPU dev box used for unrelated CI) ran the script with no behavior change — the conditional skipped the new flags and the original `docker run` command was emitted unchanged.

## Notes for reviewers

- The change is intentionally conservative. It does not touch any existing flags, env vars, or arguments; it only adds new flags when the host has the corresponding hardware. There is no opt-out env var because there is no scenario where exposing your own host's verbs devices to your own privileged container is undesirable; users who want to disable IB transport at runtime can still set `NCCL_IB_DISABLE=1` in the container env.
- The same fix applies to any multi-node Docker workload that wants to use NCCL/RDMA — the bug is not vLLM-specific. But fixing it in the example script that vLLM ships is a high-leverage place to end the silent-fallback footgun for a large user base.

Signed-off-by: Brad Stancel &lt;brad.stancel@gmail.com&gt;
