### PR TITLE
[Docs] Update server entrypoint examples

### DIFF
--- a/docs/deployment/frameworks/runpod.md
+++ b/docs/deployment/frameworks/runpod.md
@@ -12,8 +12,7 @@ vLLM can be deployed on [RunPod](https://www.runpod.io/), a cloud GPU platform t
 SSH into your RunPod pod and launch the vLLM OpenAI-compatible server:
 
 ```bash
-python -m vllm.entrypoints.openai.api_server \
-    --model <model-name> \
+vllm serve <model-name> \
     --host 0.0.0.0 \
     --port 8000
 ```

--- a/docs/deployment/integrations/kthena.md
+++ b/docs/deployment/integrations/kthena.md
@@ -79,9 +79,8 @@ Key points from the example YAML:
     - -c
     - >
       bash /vllm-workspace/examples/ray_serving/multi-node-serving.sh leader --ray_cluster_size=2;
-      python3 -m vllm.entrypoints.openai.api_server
+      vllm serve meta-llama/Llama-3.1-405B-Instruct
         --port 8080
-        --model meta-llama/Llama-3.1-405B-Instruct
         --tensor-parallel-size 8
         --pipeline-parallel-size 2
   ```
@@ -145,7 +144,7 @@ spec:
                   - sh
                   - -c
                   - "bash /vllm-workspace/examples/ray_serving/multi-node-serving.sh leader --ray_cluster_size=2; 
-                    python3 -m vllm.entrypoints.openai.api_server --port 8080 --model meta-llama/Llama-3.1-405B-Instruct --tensor-parallel-size 8 --pipeline-parallel-size 2"
+                    vllm serve meta-llama/Llama-3.1-405B-Instruct --port 8080 --tensor-parallel-size 8 --pipeline-parallel-size 2"
                 resources:
                   limits:
                     nvidia.com/gpu: "8"

--- a/docs/design/lora_resolver_plugins.md
+++ b/docs/design/lora_resolver_plugins.md
@@ -62,8 +62,7 @@ The filesystem resolver is installed with vLLM by default and enables loading Lo
 3. **Start vLLM server**:
    Your base model can be `meta-llama/Llama-2-7b-hf`. Please make sure you set up the Hugging Face token in your env var `export HF_TOKEN=xxx235`.
    ```bash
-   python -m vllm.entrypoints.openai.api_server \
-       --model your-base-model \
+   vllm serve your-base-model \
        --enable-lora
    ```
 

--- a/docs/design/optimization_levels.md
+++ b/docs/design/optimization_levels.md
@@ -16,7 +16,7 @@ User-set flags take precedence over optimization level defaults.
 
 ```bash
 # CLI usage
-python -m vllm.entrypoints.api_server --model RedHatAI/Llama-3.2-1B-FP8 -O1
+vllm serve RedHatAI/Llama-3.2-1B-FP8 -O1
 
 # Python API usage
 from vllm.entrypoints.llm import LLM


### PR DESCRIPTION

## Purpose

Some docs still show OpenAI-compatible server startup commands using deprecated module entrypoints, such as `python -m vllm.entrypoints.openai.api_server` and `python -m vllm.entrypoints.api_server`.

  This PR updates those examples to the recommended `vllm serve <model>` CLI form while preserving the existing options like `--port`, `--host`, `--enable-lora`, and parallelism flags. This keeps the deployment and design docs
  aligned with the current server startup path.

  No duplicate-work found.

  ## Test Plan

  Ran docs/lint checks through commit hooks.

  ## Test Result

  Passed `git diff --check` and commit hooks, including `markdownlint-cli2`.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

