### PR TITLE
[Bugfix] Fix MTP draft model using local cache path instead of S3 URL with runai_streamer

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1403,6 +1403,41 @@ def test_draft_sample_method_gumbel_is_rejected():
         )
 
 
+@patch("vllm.config.speculative.ModelConfig")
+def test_mtp_draft_uses_model_weights_not_local_cache(mock_model_config_cls):
+    """Regression test: MTP + runai_streamer should use model_weights (original
+    S3 URL) for the draft model, not model (local cache dir set by
+    pull_runai_model_from_obj_storage)."""
+    from unittest.mock import MagicMock
+
+    s3_url = "s3://my-bucket/Qwen3-35B-A3B-FP8"
+    local_cache = "/root/.cache/vllm/assets/model_streamer/abcd1234"
+
+    mock_draft = MagicMock()
+    mock_draft.model = local_cache
+    mock_draft.hf_config.model_type = "deepseek_mtp"
+    mock_draft.hf_config.n_predict = None
+    mock_draft.max_model_len = 4096
+    mock_model_config_cls.return_value = mock_draft
+
+    target_config = MagicMock()
+    target_config.model = local_cache
+    target_config.model_weights = s3_url
+    target_config.hf_text_config.model_type = "deepseek_v3"
+    target_config.quantization = None
+    target_config.max_model_len = 4096
+
+    SpeculativeConfig(
+        method="mtp",
+        num_speculative_tokens=1,
+        target_model_config=target_config,
+        target_parallel_config=ParallelConfig(),
+    )
+
+    actual_model = mock_model_config_cls.call_args.kwargs["model"]
+    assert actual_model == s3_url
+
+
 def test_ir_op_priority_default():
     """Test that IR op priority defaults are set correctly."""
     from vllm.config.kernel import IrOpPriorityConfig

--- a/vllm/config/speculative.py
+++ b/vllm/config/speculative.py
@@ -553,7 +553,14 @@ class SpeculativeConfig:
                     # remove this when the issue is fixed.
                     self.enforce_eager = True
                 # use the draft model from the same model:
-                self.model = self.target_model_config.model
+                # Use model_weights if set (e.g. runai_streamer replaces
+                # model with a local cache dir but keeps the original path
+                # in model_weights), so the draft model can load weights
+                # from the same source as the target model.
+                self.model = (
+                    self.target_model_config.model_weights
+                    or self.target_model_config.model
+                )
                 # Align the quantization of draft model for cases such as
                 # --quantization fp8 with a bf16 checkpoint.
                 if not self.quantization:


### PR DESCRIPTION
## Purpose
Fix https://github.com/vllm-project/vllm/issues/42060.

## Root Cause

- `ModelConfig.__init__` calls `maybe_pull_model_tokenizer_for_runai()`, which on detecting an S3 URI:

    - Sets `self.model_weights` = original S3 URL (for weight loading)
    - Sets `self.model `= local cache path (for HF config parsing)
- SpeculativeConfig creates a new `ModelConfig` for the MTP draft model using `self.target_model_config.model`, which is already the local cache path

- The new `ModelConfig.__init__` runs `maybe_pull_model_tokenizer_for_runai()`, but the local cache path is not an S3 URI → skipped → model_weights is never set

- `RunaiModelStreamerLoader.load_model()` checks `model_config.model_weights`, finds it empty, falls back to `model_config.model` (the local cache path)

- The local cache directory structure has no top-level `safetensors` files → `list_safetensors()` finds nothing → `RuntimeError`

## Test Plan

Unable to reproduce E2E without a runai_streamer + S3 environment; added a unit test with mocks to verify the config-layer fix.

`python -m pytest tests/test_config.py::test_mtp_draft_uses_model_weights_not_local_cache -v`

## Test Result
<img width="1905" height="888" alt="image" src="https://github.com/user-attachments/assets/9cfe6aa7-31e9-4deb-8bb8-a3015a090430" />

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

