### PR TITLE
[Feat] Add support for per GPU worker RDMA NIC selection

### DIFF
--- a/tests/v1/executor/test_vllm_net_devices.py
+++ b/tests/v1/executor/test_vllm_net_devices.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.v1.executor.vllm_net_devices import normalize_pci
+
+
+@pytest.mark.parametrize(
+    "addr, expected",
+    [
+        ("0000:3f:00.0", (0, 0x3F, 0, 0)),
+        ("0001:00:00.0", (1, 0, 0, 0)),
+        ("00000001:00:00.0", (1, 0, 0, 0)),
+        ("0009:00:00.0", (9, 0, 0, 0)),
+        ("0105:00:00.0", (0x105, 0, 0, 0)),
+        ("0000:0a:1f.7", (0, 0x0A, 0x1F, 7)),
+    ],
+)
+def test_normalize_pci_full_domain(addr, expected):
+    assert normalize_pci(addr) == expected
+
+
+@pytest.mark.parametrize(
+    "addr, expected",
+    [
+        ("01:00.0", (0, 1, 0, 0)),
+        ("3f:00.0", (0, 0x3F, 0, 0)),
+        ("40:00.0", (0, 0x40, 0, 0)),
+        ("ff:1f.7", (0, 0xFF, 0x1F, 7)),
+    ],
+)
+def test_normalize_pci_short_form(addr, expected):
+    assert normalize_pci(addr) == expected
+
+
+def test_normalize_pci_case_insensitive():
+    assert normalize_pci("0A:1F.7") == normalize_pci("0a:1f.7")
+
+
+def test_normalize_pci_strips_whitespace():
+    assert normalize_pci("  0001:00:00.0  ") == (1, 0, 0, 0)
+
+
+def test_normalize_pci_strips_0x_prefix():
+    assert normalize_pci("0x0001:00:00.0") == (1, 0, 0, 0)
+
+
+def test_normalize_pci_missing_function_raises():
+    with pytest.raises(ValueError, match="missing function suffix"):
+        normalize_pci("0001:00:00")
+
+
+def test_normalize_pci_invalid_function_char_raises():
+    with pytest.raises(ValueError, match="invalid PCI function"):
+        normalize_pci("0001:00:00.z")
+
+
+def test_normalize_pci_too_many_segments_raises():
+    with pytest.raises(ValueError, match="invalid PCI BDF"):
+        normalize_pci("a:b:c:d.0")
+
+
+def test_normalize_pci_bus_out_of_range_raises():
+    with pytest.raises(ValueError, match="out of range"):
+        normalize_pci("0000:1ff:00.0")
+
+
+def test_normalize_pci_device_out_of_range_raises():
+    with pytest.raises(ValueError, match="out of range"):
+        normalize_pci("0000:00:20.0")
+
+
+def test_normalize_pci_empty_string_raises():
+    with pytest.raises(ValueError):
+        normalize_pci("")

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -1965,15 +1965,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "VLLM_USE_SPINLOOP_EXT": lambda: bool(int(os.getenv("VLLM_USE_SPINLOOP_EXT", "0"))),
     # Comma-separated GPU_BDF=NIC_BDF pairs for RDMA NIC selection.
     # Must be set together with VLLM_NIC_SELECTION_VARS.
-    "VLLM_GPU_NIC_PCIE_MAPPING": lambda: os.getenv(
-        "VLLM_GPU_NIC_PCIE_MAPPING", ""
-    ),
+    "VLLM_GPU_NIC_PCIE_MAPPING": lambda: os.getenv("VLLM_GPU_NIC_PCIE_MAPPING", ""),
     # Comma-separated list of env vars to set from the GPU-NIC mapping.
     # Each entry is VAR_NAME or VAR_NAME:<suffix> (suffix appended to
     # RDMA device name). Must be set together with VLLM_GPU_NIC_PCIE_MAPPING.
-    "VLLM_NIC_SELECTION_VARS": lambda: os.getenv(
-        "VLLM_NIC_SELECTION_VARS", ""
-    ),
+    "VLLM_NIC_SELECTION_VARS": lambda: os.getenv("VLLM_NIC_SELECTION_VARS", ""),
 }
 
 

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -277,6 +277,8 @@ if TYPE_CHECKING:
     VLLM_XPU_ENABLE_XPU_GRAPH: bool = False
     VLLM_XPU_USE_SAMPLER_KERNEL: bool = True
     VLLM_LORA_ENABLE_DUAL_STREAM: bool = False
+    VLLM_GPU_NIC_PCIE_MAPPING: str = ""
+    VLLM_NIC_SELECTION_VARS: str = ""
 
 
 def get_default_cache_root():
@@ -1961,6 +1963,17 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # If set to 1, use Python spinloop extension to poll in a more efficient
     # way when using the mp backend.
     "VLLM_USE_SPINLOOP_EXT": lambda: bool(int(os.getenv("VLLM_USE_SPINLOOP_EXT", "0"))),
+    # Comma-separated GPU_BDF=NIC_BDF pairs for RDMA NIC selection.
+    # Must be set together with VLLM_NIC_SELECTION_VARS.
+    "VLLM_GPU_NIC_PCIE_MAPPING": lambda: os.getenv(
+        "VLLM_GPU_NIC_PCIE_MAPPING", ""
+    ),
+    # Comma-separated list of env vars to set from the GPU-NIC mapping.
+    # Each entry is VAR_NAME or VAR_NAME:<suffix> (suffix appended to
+    # RDMA device name). Must be set together with VLLM_GPU_NIC_PCIE_MAPPING.
+    "VLLM_NIC_SELECTION_VARS": lambda: os.getenv(
+        "VLLM_NIC_SELECTION_VARS", ""
+    ),
 }
 
 

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -867,7 +867,6 @@ class NonNvmlCudaPlatform(CudaPlatformBase):
         return None
 
 
-
 # Autodetect either NVML-enabled or non-NVML platform
 # based on whether NVML is available.
 nvml_available = False

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -7,7 +7,6 @@ pynvml. However, it should not initialize cuda context.
 from __future__ import annotations
 
 import os
-import subprocess
 from collections.abc import Callable
 from datetime import timedelta
 from functools import cache, lru_cache, wraps
@@ -867,39 +866,6 @@ class NonNvmlCudaPlatform(CudaPlatformBase):
     def get_all_device_numa_nodes(cls) -> list[int] | None:
         return None
 
-    @classmethod
-    def get_all_gpu_pci_bus_ids(cls) -> dict[int, str]:
-        """Query nvidia-smi for GPU index -> PCI bus ID mapping.
-
-        Uses subprocess because pynvml is not available on this
-        platform (e.g. Jetson), while nvidia-smi is still present.
-        """
-        proc = subprocess.run(
-            [
-                "nvidia-smi",
-                "--query-gpu=index,pci.bus_id",
-                "--format=csv,noheader",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=60,
-            check=False,
-        )
-        if proc.returncode != 0:
-            raise RuntimeError(
-                f"nvidia-smi failed (exit {proc.returncode}): "
-                f"{proc.stderr.strip()}"
-            )
-        out: dict[int, str] = {}
-        for line in proc.stdout.strip().splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            idx_part, pci_part = line.split(",", 1)
-            out[int(idx_part.strip())] = pci_part.strip()
-        if not out:
-            raise RuntimeError("nvidia-smi returned no GPU PCI bus ID rows")
-        return out
 
 
 # Autodetect either NVML-enabled or non-NVML platform

--- a/vllm/platforms/cuda.py
+++ b/vllm/platforms/cuda.py
@@ -7,6 +7,7 @@ pynvml. However, it should not initialize cuda context.
 from __future__ import annotations
 
 import os
+import subprocess
 from collections.abc import Callable
 from datetime import timedelta
 from functools import cache, lru_cache, wraps
@@ -802,6 +803,22 @@ class NvmlCudaPlatform(CudaPlatformBase):
 
     @classmethod
     @with_nvml_context
+    def get_all_gpu_pci_bus_ids(cls) -> dict[int, str]:
+        """Query NVML for GPU index -> PCI bus ID mapping."""
+        out: dict[int, str] = {}
+        for idx in range(pynvml.nvmlDeviceGetCount()):
+            handle = pynvml.nvmlDeviceGetHandleByIndex(idx)
+            pci_info = pynvml.nvmlDeviceGetPciInfo(handle)
+            bus_id = pci_info.busId
+            if isinstance(bus_id, bytes):
+                bus_id = bus_id.decode("utf-8")
+            out[idx] = bus_id.rstrip("\x00")
+        if not out:
+            raise RuntimeError("NVML returned no GPU PCI bus ID rows")
+        return out
+
+    @classmethod
+    @with_nvml_context
     def log_warnings(cls):
         device_ids: int = pynvml.nvmlDeviceGetCount()
         if device_ids > 1:
@@ -849,6 +866,40 @@ class NonNvmlCudaPlatform(CudaPlatformBase):
     @classmethod
     def get_all_device_numa_nodes(cls) -> list[int] | None:
         return None
+
+    @classmethod
+    def get_all_gpu_pci_bus_ids(cls) -> dict[int, str]:
+        """Query nvidia-smi for GPU index -> PCI bus ID mapping.
+
+        Uses subprocess because pynvml is not available on this
+        platform (e.g. Jetson), while nvidia-smi is still present.
+        """
+        proc = subprocess.run(
+            [
+                "nvidia-smi",
+                "--query-gpu=index,pci.bus_id",
+                "--format=csv,noheader",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            check=False,
+        )
+        if proc.returncode != 0:
+            raise RuntimeError(
+                f"nvidia-smi failed (exit {proc.returncode}): "
+                f"{proc.stderr.strip()}"
+            )
+        out: dict[int, str] = {}
+        for line in proc.stdout.strip().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            idx_part, pci_part = line.split(",", 1)
+            out[int(idx_part.strip())] = pci_part.strip()
+        if not out:
+            raise RuntimeError("nvidia-smi returned no GPU PCI bus ID rows")
+        return out
 
 
 # Autodetect either NVML-enabled or non-NVML platform

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -387,7 +387,7 @@ class Platform:
 
         Used by ``VLLM_GPU_NIC_PCIE_MAPPING`` for RDMA NIC selection.
         Subclasses should override with platform-specific discovery
-        (e.g. nvidia-smi for CUDA, amd-smi for ROCm).
+        (e.g. pynvml for CUDA).
         """
         raise NotImplementedError(
             "VLLM_GPU_NIC_PCIE_MAPPING is not supported on the "

--- a/vllm/platforms/interface.py
+++ b/vllm/platforms/interface.py
@@ -382,6 +382,19 @@ class Platform:
         raise NotImplementedError
 
     @classmethod
+    def get_all_gpu_pci_bus_ids(cls) -> dict[int, str]:
+        """Return a mapping of device index to PCI bus ID string.
+
+        Used by ``VLLM_GPU_NIC_PCIE_MAPPING`` for RDMA NIC selection.
+        Subclasses should override with platform-specific discovery
+        (e.g. nvidia-smi for CUDA, amd-smi for ROCm).
+        """
+        raise NotImplementedError(
+            "VLLM_GPU_NIC_PCIE_MAPPING is not supported on the "
+            f"current platform ({cls.device_name})"
+        )
+
+    @classmethod
     def inference_mode(cls):
         """A device-specific wrapper of `torch.inference_mode`.
 

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -813,8 +813,7 @@ class WorkerProc:
         signal.signal(signal.SIGINT, signal_handler)
 
         # Set net device env vars for the worker if VLLM_GPU_NIC_PCIE_MAPPING is set
-        set_worker_net_device(
-            kwargs.get("local_rank", 0), kwargs["vllm_config"])
+        set_worker_net_device(kwargs.get("local_rank", 0), kwargs["vllm_config"])
 
         worker = None
         ready_writer = kwargs.pop("ready_pipe")

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -60,10 +60,7 @@ from vllm.utils.system_utils import (
 )
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.executor.abstract import Executor, FailureCallback
-from vllm.v1.executor.vllm_net_devices import (
-    prefetch_gpu_pci_map_when_pcie_mapping_enabled,
-    set_worker_net_device,
-)
+from vllm.v1.executor.vllm_net_devices import set_worker_net_device
 from vllm.v1.outputs import AsyncModelRunnerOutput, DraftTokenIds, ModelRunnerOutput
 from vllm.v1.worker.worker_base import WorkerWrapperBase
 
@@ -126,9 +123,6 @@ class MultiprocExecutor(Executor):
         )
 
         set_multiprocessing_worker_envs()
-
-        # if VLLM_GPU_NIC_PCIE_MAPPING is set, use nvidia-smi to get PCIe bus IDs for all GPUs.
-        prefetch_gpu_pci_map_when_pcie_mapping_enabled()
 
         # use the loopback address get_loopback_ip() for communication.
         distributed_init_method = get_distributed_init_method(

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -60,6 +60,10 @@ from vllm.utils.system_utils import (
 )
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.executor.abstract import Executor, FailureCallback
+from vllm.v1.executor.vllm_net_devices import (
+    prefetch_gpu_pci_map_when_pcie_mapping_enabled,
+    set_worker_net_device,
+)
 from vllm.v1.outputs import AsyncModelRunnerOutput, DraftTokenIds, ModelRunnerOutput
 from vllm.v1.worker.worker_base import WorkerWrapperBase
 
@@ -122,6 +126,9 @@ class MultiprocExecutor(Executor):
         )
 
         set_multiprocessing_worker_envs()
+
+        # if VLLM_GPU_NIC_PCIE_MAPPING is set, use nvidia-smi to get PCIe bus IDs for all GPUs.
+        prefetch_gpu_pci_map_when_pcie_mapping_enabled()
 
         # use the loopback address get_loopback_ip() for communication.
         distributed_init_method = get_distributed_init_method(
@@ -810,6 +817,10 @@ class WorkerProc:
         # Either SIGTERM or SIGINT will terminate the worker
         signal.signal(signal.SIGTERM, signal_handler)
         signal.signal(signal.SIGINT, signal_handler)
+
+        # Set net device env vars for the worker if VLLM_GPU_NIC_PCIE_MAPPING is set
+        set_worker_net_device(
+            kwargs.get("local_rank", 0), kwargs["vllm_config"])
 
         worker = None
         ready_writer = kwargs.pop("ready_pipe")

--- a/vllm/v1/executor/uniproc_executor.py
+++ b/vllm/v1/executor/uniproc_executor.py
@@ -16,6 +16,7 @@ from vllm.platforms import current_platform
 from vllm.utils.network_utils import get_distributed_init_method, get_ip, get_open_port
 from vllm.v1.core.sched.output import GrammarOutput, SchedulerOutput
 from vllm.v1.executor.abstract import Executor
+from vllm.v1.executor.vllm_net_devices import set_worker_net_device
 from vllm.v1.outputs import AsyncModelRunnerOutput, DraftTokenIds, ModelRunnerOutput
 from vllm.v1.serial_utils import run_method
 from vllm.v1.worker.worker_base import WorkerWrapperBase
@@ -55,6 +56,9 @@ class UniProcExecutor(Executor):
             is_driver_worker=True,
             shared_worker_lock=Lock(),
         )
+
+        # Set net device env vars for the worker if VLLM_GPU_NIC_PCIE_MAPPING is set
+        set_worker_net_device(local_rank, self.vllm_config)
 
         self.driver_worker.init_worker(all_kwargs=[kwargs])
         self.driver_worker.init_device()

--- a/vllm/v1/executor/vllm_net_devices.py
+++ b/vllm/v1/executor/vllm_net_devices.py
@@ -12,7 +12,6 @@ Requires two env vars set together:
   each optionally suffixed (e.g. ``UCX_NET_DEVICES:1,NCCL_IB_HCA:1``).
 """
 
-import json
 import os
 from pathlib import Path
 
@@ -21,9 +20,6 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 
 logger = init_logger(__name__)
-
-# Parent executor stores this JSON before spawning workers so each worker avoids nvidia-smi.
-_VLLM_INTERNAL_GPU_PCI_ENV = "VLLM_INTERNAL_GPU_PCI_BY_INDEX_JSON"
 
 
 def normalize_pci(addr: str) -> tuple[int, int, int, int]:
@@ -87,46 +83,6 @@ def parse_gpu_nic_mapping(
     return out
 
 
-def query_all_gpu_pci_bus_ids() -> dict[int, str]:
-    """Device index -> PCI bus ID string via platform-specific discovery.
-
-    Delegates to ``current_platform.get_all_gpu_pci_bus_ids()``.
-    Raises ``NotImplementedError`` on platforms that have not implemented
-    GPU PCI bus ID discovery.
-    """
-    return current_platform.get_all_gpu_pci_bus_ids()
-
-
-def _pci_by_index_from_env_or_query() -> dict[int, str]:
-    raw = os.environ.get(_VLLM_INTERNAL_GPU_PCI_ENV, "").strip()
-    if raw:
-        data = json.loads(raw)
-        return {int(k): str(v) for k, v in data.items()}
-    return query_all_gpu_pci_bus_ids()
-
-
-def prefetch_gpu_pci_map_when_pcie_mapping_enabled() -> None:
-    """Parent-only: one ``nvidia-smi`` when ``VLLM_GPU_NIC_PCIE_MAPPING`` is set.
-
-    Fills ``VLLM_INTERNAL_GPU_PCI_BY_INDEX_JSON`` so workers avoid per-process
-    ``nvidia-smi``. **No-op** if mapping env unset or JSON already present (idempotent).
-    """
-    if not os.environ.get("VLLM_GPU_NIC_PCIE_MAPPING", "").strip():
-        return
-    if os.environ.get(_VLLM_INTERNAL_GPU_PCI_ENV, "").strip():
-        return
-    try:
-        pci_map = query_all_gpu_pci_bus_ids()
-        os.environ[_VLLM_INTERNAL_GPU_PCI_ENV] = json.dumps(pci_map)
-        logger.info(
-            "Prefetched GPU PCI map (%d GPUs) into %s",
-            len(pci_map),
-            _VLLM_INTERNAL_GPU_PCI_ENV,
-        )
-    except Exception as e:
-        logger.warning(
-            "GPU PCI prefetch failed; workers will run nvidia-smi once each: %s", e
-        )
 
 
 def rdma_name_for_nic_pci(nic_pci: tuple[int, int, int, int]) -> str:
@@ -182,9 +138,7 @@ def parse_nic_selection_vars(raw: str) -> list[tuple[str, str]]:
     return result
 
 
-def set_worker_gpu_nic_mapping(
-    local_rank: int, pci_by_index: dict[int, str] | None = None
-) -> None:
+def set_worker_gpu_nic_mapping(local_rank: int) -> None:
     """Set NIC selection env vars from VLLM_GPU_NIC_PCIE_MAPPING for a worker.
 
     Which env vars are set is controlled by ``VLLM_NIC_SELECTION_VARS``.
@@ -195,8 +149,7 @@ def set_worker_gpu_nic_mapping(
     selection_raw = os.environ.get("VLLM_NIC_SELECTION_VARS", "").strip()
     selection_vars = parse_nic_selection_vars(selection_raw)
     mapping = parse_gpu_nic_mapping(raw)
-    if pci_by_index is None:
-        pci_by_index = _pci_by_index_from_env_or_query()
+    pci_by_index = current_platform.get_all_gpu_pci_bus_ids()
     # Translate CUDA-relative local_rank to the physical device index,
     # which accounts for CUDA_VISIBLE_DEVICES narrowing (e.g. DP sharding).
     physical_id = current_platform.device_id_to_physical_device_id(local_rank)
@@ -231,11 +184,11 @@ def set_worker_gpu_nic_mapping(
 
     nic_fmt = f"{nic_pci[0]:04x}:{nic_pci[1]:02x}:{nic_pci[2]:02x}.{nic_pci[3]}"
     logger.info(
-        "[rank %s] GPU PCI %s -> NIC PCI %s (%s) -> %s",
+        "GPU rank %s (PCIe addr %s) mapped to NIC %s (PCIe addr %s) via env vars: %s",
         local_rank,
         gpu_bdf,
-        nic_fmt,
         rdma_dev,
+        nic_fmt,
         ", ".join(set_vars),
     )
 

--- a/vllm/v1/executor/vllm_net_devices.py
+++ b/vllm/v1/executor/vllm_net_devices.py
@@ -15,6 +15,7 @@ Requires two env vars set together:
 import os
 from pathlib import Path
 
+import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
@@ -73,16 +74,14 @@ def parse_gpu_nic_mapping(
             continue
         if "=" not in segment:
             raise ValueError(
-                "VLLM_GPU_NIC_PCIE_MAPPING: expected comma-separated gpu_bdf=nic_bdf pairs; "
-                f"ambiguous segment: {segment!r}"
+                "VLLM_GPU_NIC_PCIE_MAPPING: expected comma-separated"
+                f" gpu_bdf=nic_bdf pairs; ambiguous segment: {segment!r}"
             )
         gpu_s, nic_s = segment.split("=", 1)
         gpu_key = normalize_pci(gpu_s.strip())
         nic_val = normalize_pci(nic_s.strip())
         out[gpu_key] = nic_val
     return out
-
-
 
 
 def rdma_name_for_nic_pci(nic_pci: tuple[int, int, int, int]) -> str:
@@ -114,8 +113,7 @@ def rdma_name_for_nic_pci(nic_pci: tuple[int, int, int, int]) -> str:
         except ValueError:
             continue
     raise RuntimeError(
-        f"No /sys/class/infiniband device for NIC PCI {nic_pci}; "
-        f"have entries: {names}"
+        f"No /sys/class/infiniband device for NIC PCI {nic_pci}; have entries: {names}"
     )
 
 
@@ -143,10 +141,10 @@ def set_worker_gpu_nic_mapping(local_rank: int) -> None:
 
     Which env vars are set is controlled by ``VLLM_NIC_SELECTION_VARS``.
     """
-    raw = os.environ.get("VLLM_GPU_NIC_PCIE_MAPPING", "").strip()
+    raw = envs.VLLM_GPU_NIC_PCIE_MAPPING.strip()
     if not raw:
         return
-    selection_raw = os.environ.get("VLLM_NIC_SELECTION_VARS", "").strip()
+    selection_raw = envs.VLLM_NIC_SELECTION_VARS.strip()
     selection_vars = parse_nic_selection_vars(selection_raw)
     mapping = parse_gpu_nic_mapping(raw)
     pci_by_index = current_platform.get_all_gpu_pci_bus_ids()
@@ -225,10 +223,8 @@ def set_worker_net_device(local_rank: int, vllm_config: VllmConfig) -> None:
     Sets NIC selection env vars from ``VLLM_GPU_NIC_PCIE_MAPPING`` and
     ``VLLM_NIC_SELECTION_VARS`` if present; no-op otherwise.
     """
-    has_pcie_mapping = bool(
-        os.environ.get("VLLM_GPU_NIC_PCIE_MAPPING", "").strip())
-    has_selection_vars = bool(
-        os.environ.get("VLLM_NIC_SELECTION_VARS", "").strip())
+    has_pcie_mapping = bool(envs.VLLM_GPU_NIC_PCIE_MAPPING.strip())
+    has_selection_vars = bool(envs.VLLM_NIC_SELECTION_VARS.strip())
     if has_pcie_mapping and not has_selection_vars:
         raise RuntimeError(
             "VLLM_GPU_NIC_PCIE_MAPPING is set but VLLM_NIC_SELECTION_VARS "

--- a/vllm/v1/executor/vllm_net_devices.py
+++ b/vllm/v1/executor/vllm_net_devices.py
@@ -1,0 +1,294 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""GPU-to-NIC net-device mapping for RDMA transports (UCX, NVSHMEM, ...).
+
+Shared by both UniProcExecutor (TP=1) and MultiprocExecutor (TP>1).
+All transport-specific env vars and sysfs lookups live here so executor
+files only need to call ``set_worker_net_device(local_rank, vllm_config)``.
+
+Requires two env vars set together:
+- ``VLLM_GPU_NIC_PCIE_MAPPING`` -- comma-separated GPU_BDF=NIC_BDF pairs.
+- ``VLLM_NIC_SELECTION_VARS`` -- comma-separated list of env vars to set,
+  each optionally suffixed (e.g. ``UCX_NET_DEVICES:1,NCCL_IB_HCA:1``).
+"""
+
+import json
+import os
+from pathlib import Path
+
+from vllm.config import VllmConfig
+from vllm.logger import init_logger
+from vllm.platforms import current_platform
+
+logger = init_logger(__name__)
+
+# Parent executor stores this JSON before spawning workers so each worker avoids nvidia-smi.
+_VLLM_INTERNAL_GPU_PCI_ENV = "VLLM_INTERNAL_GPU_PCI_BY_INDEX_JSON"
+
+
+def normalize_pci(addr: str) -> tuple[int, int, int, int]:
+    """Parse PCI BDF/domain-bus-device-function into comparable ints (all hex).
+
+    Supported shapes:
+    - ``domain:bus:dev.fn`` -- domain width varies (e.g. ``00000001:00:00.0``,
+      ``0001:00:00.0``, ``0000:3f:00.0``).
+    - ``bus:dev.fn`` -- domain **0** (e.g. ``01:00.0``, ``40:00.0``).
+
+    Function suffix is hex (typically ``0``--``7``). Raises ``ValueError`` if malformed.
+    """
+    s = addr.strip().lower().replace(" ", "")
+    if s.startswith("0x"):
+        s = s[2:]
+    if "." not in s:
+        raise ValueError(f"invalid PCI BDF (missing function suffix): {addr!r}")
+    body, fn_s = s.rsplit(".", 1)
+    if not fn_s or any(c not in "0123456789abcdef" for c in fn_s):
+        raise ValueError(f"invalid PCI function in BDF: {addr!r}")
+    fn = int(fn_s, 16)
+    if fn > 0xFF:
+        raise ValueError(f"PCI function out of range: {addr!r}")
+
+    parts = body.split(":")
+    if len(parts) == 2:
+        domain = 0
+        bus = int(parts[0], 16)
+        device = int(parts[1], 16)
+    elif len(parts) == 3:
+        domain = int(parts[0], 16)
+        bus = int(parts[1], 16)
+        device = int(parts[2], 16)
+    else:
+        raise ValueError(
+            f"invalid PCI BDF (want domain:bus:dev.fn or bus:dev.fn): {addr!r}"
+        )
+
+    if bus > 0xFF or device > 0x1F:
+        raise ValueError(f"PCI bus or device out of range: {addr!r}")
+    return (domain, bus, device, fn)
+
+
+def parse_gpu_nic_mapping(
+    raw: str,
+) -> dict[tuple[int, int, int, int], tuple[int, int, int, int]]:
+    out: dict[tuple[int, int, int, int], tuple[int, int, int, int]] = {}
+    for segment in raw.split(","):
+        segment = segment.strip()
+        if not segment:
+            continue
+        if "=" not in segment:
+            raise ValueError(
+                "VLLM_GPU_NIC_PCIE_MAPPING: expected comma-separated gpu_bdf=nic_bdf pairs; "
+                f"ambiguous segment: {segment!r}"
+            )
+        gpu_s, nic_s = segment.split("=", 1)
+        gpu_key = normalize_pci(gpu_s.strip())
+        nic_val = normalize_pci(nic_s.strip())
+        out[gpu_key] = nic_val
+    return out
+
+
+def query_all_gpu_pci_bus_ids() -> dict[int, str]:
+    """Device index -> PCI bus ID string via platform-specific discovery.
+
+    Delegates to ``current_platform.get_all_gpu_pci_bus_ids()``.
+    Raises ``NotImplementedError`` on platforms that have not implemented
+    GPU PCI bus ID discovery.
+    """
+    return current_platform.get_all_gpu_pci_bus_ids()
+
+
+def _pci_by_index_from_env_or_query() -> dict[int, str]:
+    raw = os.environ.get(_VLLM_INTERNAL_GPU_PCI_ENV, "").strip()
+    if raw:
+        data = json.loads(raw)
+        return {int(k): str(v) for k, v in data.items()}
+    return query_all_gpu_pci_bus_ids()
+
+
+def prefetch_gpu_pci_map_when_pcie_mapping_enabled() -> None:
+    """Parent-only: one ``nvidia-smi`` when ``VLLM_GPU_NIC_PCIE_MAPPING`` is set.
+
+    Fills ``VLLM_INTERNAL_GPU_PCI_BY_INDEX_JSON`` so workers avoid per-process
+    ``nvidia-smi``. **No-op** if mapping env unset or JSON already present (idempotent).
+    """
+    if not os.environ.get("VLLM_GPU_NIC_PCIE_MAPPING", "").strip():
+        return
+    if os.environ.get(_VLLM_INTERNAL_GPU_PCI_ENV, "").strip():
+        return
+    try:
+        pci_map = query_all_gpu_pci_bus_ids()
+        os.environ[_VLLM_INTERNAL_GPU_PCI_ENV] = json.dumps(pci_map)
+        logger.info(
+            "Prefetched GPU PCI map (%d GPUs) into %s",
+            len(pci_map),
+            _VLLM_INTERNAL_GPU_PCI_ENV,
+        )
+    except Exception as e:
+        logger.warning(
+            "GPU PCI prefetch failed; workers will run nvidia-smi once each: %s", e
+        )
+
+
+def rdma_name_for_nic_pci(nic_pci: tuple[int, int, int, int]) -> str:
+    """Map NIC PCI BDF to sysfs RDMA name (mlx5_*, ibp*, ...).
+
+    Under ``/sys/class/infiniband/<name>/``, ``device`` is a **symlink** to the PCI
+    device directory (e.g. ``.../0101:00:00.0``). We take ``Path(...).resolve().name``
+    as the BDF string.
+
+    ``VLLM_GPU_NIC_PCIE_MAPPING`` NIC keys must **normalize** (via ``normalize_pci``)
+    to the same tuple as this basename.
+    """
+    ib = Path("/sys/class/infiniband")
+    if not ib.is_dir():
+        raise RuntimeError("/sys/class/infiniband not found or not a directory")
+    names = sorted(p.name for p in ib.iterdir() if p.is_dir())
+    for name in names:
+        dev_link = ib / name / "device"
+        if not dev_link.exists():
+            continue
+        try:
+            resolved = dev_link.resolve()
+        except OSError:
+            continue
+        pci_name = resolved.name
+        try:
+            if normalize_pci(pci_name) == nic_pci:
+                return name
+        except ValueError:
+            continue
+    raise RuntimeError(
+        f"No /sys/class/infiniband device for NIC PCI {nic_pci}; "
+        f"have entries: {names}"
+    )
+
+
+def parse_nic_selection_vars(raw: str) -> list[tuple[str, str]]:
+    """Parse ``VLLM_NIC_SELECTION_VARS`` into ``(env_var_name, suffix)`` pairs.
+
+    Each entry is ``VAR_NAME`` or ``VAR_NAME:<suffix>``.  The colon and
+    everything after it is appended verbatim to the RDMA device name.
+    """
+    result: list[tuple[str, str]] = []
+    for entry in raw.split(","):
+        entry = entry.strip()
+        if not entry:
+            continue
+        if ":" in entry:
+            var_name, suffix = entry.split(":", 1)
+            result.append((var_name, ":" + suffix))
+        else:
+            result.append((entry, ""))
+    return result
+
+
+def set_worker_gpu_nic_mapping(
+    local_rank: int, pci_by_index: dict[int, str] | None = None
+) -> None:
+    """Set NIC selection env vars from VLLM_GPU_NIC_PCIE_MAPPING for a worker.
+
+    Which env vars are set is controlled by ``VLLM_NIC_SELECTION_VARS``.
+    """
+    raw = os.environ.get("VLLM_GPU_NIC_PCIE_MAPPING", "").strip()
+    if not raw:
+        return
+    selection_raw = os.environ.get("VLLM_NIC_SELECTION_VARS", "").strip()
+    selection_vars = parse_nic_selection_vars(selection_raw)
+    mapping = parse_gpu_nic_mapping(raw)
+    if pci_by_index is None:
+        pci_by_index = _pci_by_index_from_env_or_query()
+    # Translate CUDA-relative local_rank to the physical device index,
+    # which accounts for CUDA_VISIBLE_DEVICES narrowing (e.g. DP sharding).
+    physical_id = current_platform.device_id_to_physical_device_id(local_rank)
+    if physical_id not in pci_by_index:
+        raise RuntimeError(
+            f"No GPU PCI for physical device index {physical_id} "
+            f"(local_rank={local_rank}) in map "
+            f"(have indices {sorted(pci_by_index.keys())})"
+        )
+    gpu_bdf = pci_by_index[physical_id]
+    gpu_key = normalize_pci(gpu_bdf)
+    if gpu_key not in mapping:
+        keys_fmt = ", ".join(
+            f"{d:04x}:{b:02x}:{dev:02x}.{fn}"
+            for d, b, dev, fn in sorted(mapping.keys())
+        )
+        raise RuntimeError(
+            f"No VLLM_GPU_NIC_PCIE_MAPPING entry for GPU PCI {gpu_bdf} "
+            f"(worker local_rank={local_rank}); mapped GPUs: {keys_fmt}"
+        )
+    nic_pci = mapping[gpu_key]
+    rdma_dev = rdma_name_for_nic_pci(nic_pci)
+
+    set_vars: list[str] = []
+    for var_name, suffix in selection_vars:
+        value = f"{rdma_dev}{suffix}"
+        existing = os.environ.get(var_name, "").strip()
+        if existing:
+            value = f"{value},{existing}"
+        os.environ[var_name] = value
+        set_vars.append(f"{var_name}={value}")
+
+    nic_fmt = f"{nic_pci[0]:04x}:{nic_pci[1]:02x}:{nic_pci[2]:02x}.{nic_pci[3]}"
+    logger.info(
+        "[rank %s] GPU PCI %s -> NIC PCI %s (%s) -> %s",
+        local_rank,
+        gpu_bdf,
+        nic_fmt,
+        rdma_dev,
+        ", ".join(set_vars),
+    )
+
+
+def _dp_adjusted_local_rank(tp_local_rank: int, vllm_config: VllmConfig) -> int:
+    """Compute the node-wide GPU index accounting for data parallelism.
+
+    On CUDA-alike platforms without env-var device isolation (the common
+    MP-backend path), the worker sees *all* GPUs on the node and selects
+    its device via ``torch.accelerator.set_device_index()`` using::
+
+        dp_local_rank * tp_pp_world_size + tp_local_rank
+
+    This mirrors the adjustment in ``Worker.init_device()`` so we resolve
+    the correct GPU PCI address *before* the CUDA device is initialised.
+    """
+    pc = vllm_config.parallel_config
+    if (
+        pc.distributed_executor_backend not in ("ray", "external_launcher")
+        and pc.data_parallel_backend != "ray"
+        and pc.nnodes_within_dp == 1
+    ):
+        dp_local_rank = pc.data_parallel_rank_local
+        if dp_local_rank is None:
+            dp_local_rank = pc.data_parallel_index
+        tp_pp_world_size = pc.pipeline_parallel_size * pc.tensor_parallel_size
+        return dp_local_rank * tp_pp_world_size + tp_local_rank
+    return tp_local_rank
+
+
+def set_worker_net_device(local_rank: int, vllm_config: VllmConfig) -> None:
+    """Top-level entry point for both UniProcExecutor and MultiprocExecutor.
+
+    Sets NIC selection env vars from ``VLLM_GPU_NIC_PCIE_MAPPING`` and
+    ``VLLM_NIC_SELECTION_VARS`` if present; no-op otherwise.
+    """
+    has_pcie_mapping = bool(
+        os.environ.get("VLLM_GPU_NIC_PCIE_MAPPING", "").strip())
+    has_selection_vars = bool(
+        os.environ.get("VLLM_NIC_SELECTION_VARS", "").strip())
+    if has_pcie_mapping and not has_selection_vars:
+        raise RuntimeError(
+            "VLLM_GPU_NIC_PCIE_MAPPING is set but VLLM_NIC_SELECTION_VARS "
+            "is not; both must be set together."
+        )
+    if has_selection_vars and not has_pcie_mapping:
+        raise RuntimeError(
+            "VLLM_NIC_SELECTION_VARS is set but VLLM_GPU_NIC_PCIE_MAPPING "
+            "is not; both must be set together."
+        )
+    # No-op when neither env var is present.
+    if not has_pcie_mapping and not has_selection_vars:
+        return
+    # Both env vars are present, so set the NIC selection env vars.
+    adjusted_rank = _dp_adjusted_local_rank(local_rank, vllm_config)
+    set_worker_gpu_nic_mapping(adjusted_rank)


### PR DESCRIPTION
## Purpose

Allow vLLM to control which RDMA NIC each GPU worker process uses for data transfers (KV cache, collective ops, etc.) via two env vars:

- **`VLLM_GPU_NIC_PCIE_MAPPING`** — comma-separated `GPU_BDF=NIC_BDF` pairs that map each GPU to its preferred NIC based on PCIe affinity.
- **`VLLM_NIC_SELECTION_VARS`** — comma-separated list of env vars to set from the mapping. Each entry is `VAR_NAME` or `VAR_NAME:<suffix>` (suffix appended to the RDMA device name).

The executor resolves each worker's GPU PCI bus ID to the mapped NIC's RDMA device name, then sets all env vars listed in `VLLM_NIC_SELECTION_VARS` so that the corresponding libraries pick the correct NIC for that worker.

This is library-agnostic by design. Known NIC selection variables include:

| Library | Env Var |
|---------|---------|
| UCX (NIXL) | `UCX_NET_DEVICES` |
| NVSHMEM (DeepEP) | `NVSHMEM_HCA_LIST` |
| NCCL | `NCCL_IB_HCA` |
| UCCL | `UCCL_P2P_RDMA_DEV` |

But any env var can be specified — no code changes are needed to support new libraries.

**Example:**

```bash
export VLLM_GPU_NIC_PCIE_MAPPING="0009:00:00.0=0105:00:00.0,000a:00:00.0=0205:00:00.0,..."
export VLLM_NIC_SELECTION_VARS="UCX_NET_DEVICES:1,NVSHMEM_HCA_LIST:1,NCCL_IB_HCA:1"
```

This sets `UCX_NET_DEVICES=mlx5_X:1`, `NVSHMEM_HCA_LIST=mlx5_X:1`, and `NCCL_IB_HCA=mlx5_X:1` per worker, where `mlx5_X` is the RDMA device corresponding to the NIC mapped to that worker's GPU.

**Why this matters:** In multi-NIC, multi-GPU nodes, RDMA performance depends on GPU-NIC PCIe affinity. When the topology is flat or not properly discoverable by networking libraries, all workers may default to the same NIC or incorrect NICs, leading to suboptimal RDMA performance.

**Changes:**

* New module `vllm/v1/executor/vllm_net_devices.py` centralizes GPU-to-NIC mapping logic
* Platform-dispatched GPU PCI discovery via `Platform.get_all_gpu_pci_bus_ids()` (`pynvml` for `NvmlCudaPlatform`, `nvidia-smi` subprocess fallback for `NonNvmlCudaPlatform`)
* `CUDA_VISIBLE_DEVICES`-aware `local_rank` to physical device translation using `device_id_to_physical_device_id()`
* Prefetch PCI map once in the parent process for `MultiprocExecutor` (workers read from env var, avoiding per-process GPU PCI discovery)
* `UniProcExecutor` and `MultiprocExecutor` both call `set_worker_net_device(local_rank)` before worker init
* Registered `VLLM_GPU_NIC_PCIE_MAPPING` and `VLLM_NIC_SELECTION_VARS` in `vllm/envs.py`
* Both env vars must be set together; a clear error is raised if only one is provided
* Unsupported platforms get a clear `NotImplementedError` if they have not implemented `get_all_gpu_pci_bus_ids()`

## Test Plan

Tested on Azure Standard_ND96isr_H100_v5 VMs (flat PCIe topology) with various P/D disagg deployments:

- [x] 8ptp1-1dtp8
- [x] 8ptp1-2dtp4
- [x] 4ptp2-4dtp2
- [x] 2ptp4-2dtp4
- [x] 8ptp1-8dtp1
- [x] 1ptp8-1dtp8

Verified correct NIC selection for UCX_NET_DEVICES and NVSHMEM_HCA_LIST across all configurations.

## Test Result - P/D disagg

### Benchmarking Setup

* **Machines:** 2 x Azure Standard_ND96isr_H100_v5 VMs
* **Model:** RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic
* **P/D config:** 1ptp8-1dtp8
* **vllm bench parameters:** MC 32, ISL 24k, OSL 1, Total requests: 300

> **Note:** OSL is 1 and so NIXL xfer metrics are not affected much by the decode step duration.

### Aggregate Results

| Metric | Baseline | Post Fix | Improvement |
|---|---|---|---|
| Avg xfer time (ms) | 175.14 | 36.25 | 4.83x |
| P90 xfer time (ms) | 192.22 | 44.62 | 4.31x |
| Avg Throughput (MB/s) | 5849.50 | 27029.28 | 4.62x |
| Max Throughput (MB/s) | 8059.40 | 37662.72 | 4.67x |

## Test Result - DeepEP high-throughput

### Benchmarking Setup

* **Machines:** 2 x Azure Standard_ND96isr_H100_v5 VMs
* **Model:** Qwen/Qwen3-235B-A22B-Instruct-2507-FP8
* **WideEP config:** EP=16, DP=16
* **vllm bench parameters:** MC 64, ISL 8192, OSL 1, Total requests: 300

> **Note:** OSL is 1 for prefill-only benchmarking

### Aggregate Results

| Metric | Baseline | NIC Selection | Improvement |
|---|---|---|---|
| Request throughput (req/s) | 3.39 | 7.44 | 2.19x |
| Total token throughput (tok/s) | 27,787 | 60,984 | 2.19x |


## Detailed Usage Example

Here are the two examples for the PR description:

---

### Example 1: Flat PCIe topology (Azure Standard_ND96isr_H100_v5)

On certain multi-GPU, multi-NIC VMs (e.g., Azure Standard_ND96isr_H100_v5), the PCIe topology is flat — networking libraries cannot automatically discover the optimal GPU-NIC pairing. For example, NVSHMEM (used by DeepEP high-throughput) defaults to using the first NIC (`mlx5_0`) for all 8 GPUs, causing contention.

**GPU PCIe addresses** (from `nvidia-smi --query-gpu=index,pci.bus_id --format=csv`):

| GPU | PCIe BDF |
|-----|----------|
| 0 | `01:00.0` |
| 1 | `02:00.0` |
| 2 | `03:00.0` |
| 3 | `08:00.0` |
| 4 | `09:00.0` |
| 5 | `0a:00.0` |
| 6 | `0b:00.0` |
| 7 | `0c:00.0` |

**NIC PCIe addresses** (from `/sys/class/infiniband/*/device` symlinks):

| RDMA device | PCIe BDF |
|-------------|----------|
| `mlx5_0` | `41:00.0` |
| `mlx5_1` | `42:00.0` |
| `mlx5_2` | `43:00.0` |
| `mlx5_3` | `44:00.0` |
| `mlx5_4` | `45:00.0` |
| `mlx5_5` | `46:00.0` |
| `mlx5_6` | `47:00.0` |
| `mlx5_7` | `48:00.0` |

From infrastructure documentation or intra-host bandwidth testing, we know the optimal pairing is GPU0↔mlx5_0, GPU1↔mlx5_1, ..., GPU7↔mlx5_7. To enforce this for NIXL/UCX, NCCL, and NVSHMEM:

```bash
export VLLM_GPU_NIC_PCIE_MAPPING="01:00.0=41:00.0,02:00.0=42:00.0,03:00.0=43:00.0,08:00.0=44:00.0,09:00.0=45:00.0,0a:00.0=46:00.0,0b:00.0=47:00.0,0c:00.0=48:00.0"
export VLLM_NIC_SELECTION_VARS="UCX_NET_DEVICES:1,NCCL_IB_HCA:1,NVSHMEM_HCA_LIST:1"
```

vLLM will then set the following env vars **per worker process**:

**GPU 0 worker:**
```
UCX_NET_DEVICES=mlx5_0:1
NCCL_IB_HCA=mlx5_0:1
NVSHMEM_HCA_LIST=mlx5_0:1
```

**GPU 5 worker:**
```
UCX_NET_DEVICES=mlx5_5:1
NCCL_IB_HCA=mlx5_5:1
NVSHMEM_HCA_LIST=mlx5_5:1
```

And so on for each GPU. The `:1` suffix selects port 1 of the RDMA device, as required by UCX, NCCL, and NVSHMEM.

### Example 2: NIC failure — sharing NICs across GPUs

Using the same node from Example 1, suppose two NICs on NUMA 0 have failed (`mlx5_1` at `42:00.0` and `mlx5_3` at `44:00.0`). The 4 GPUs on NUMA 0 must now share the 2 remaining healthy NICs:

| NUMA | GPU | Healthy NIC | Note |
|------|-----|-------------|------|
| 0 | 0 | `mlx5_0` | |
| 0 | 1 | `mlx5_0` | shares with GPU 0 (mlx5_1 failed) |
| 0 | 2 | `mlx5_2` | |
| 0 | 3 | `mlx5_2` | shares with GPU 2 (mlx5_3 failed) |
| 1 | 4 | `mlx5_4` | 1:1 mapping |
| 1 | 5 | `mlx5_5` | 1:1 mapping |
| 1 | 6 | `mlx5_6` | 1:1 mapping |
| 1 | 7 | `mlx5_7` | 1:1 mapping |

```bash
export VLLM_GPU_NIC_PCIE_MAPPING="01:00.0=41:00.0,02:00.0=41:00.0,03:00.0=43:00.0,08:00.0=43:00.0,09:00.0=45:00.0,0a:00.0=46:00.0,0b:00.0=47:00.0,0c:00.0=48:00.0"
export VLLM_NIC_SELECTION_VARS="UCX_NET_DEVICES:1,NCCL_IB_HCA:1"
```

GPUs 0 and 1 both map to `mlx5_0`; GPUs 2 and 3 both map to `mlx5_2`. NUMA 1 GPUs keep their 1:1 mapping. This is a graceful degradation scenario — no code changes needed, just update the mapping string to point multiple GPUs at the same healthy NIC.
