### PR TITLE
Improve Mooncake host IP diagnostics

### DIFF
--- a/tests/v1/kv_connector/unit/test_mooncake_connector.py
+++ b/tests/v1/kv_connector/unit/test_mooncake_connector.py
@@ -276,6 +276,15 @@ def patch_worker_dependencies():
         patch(
             "vllm.distributed.kv_transfer.kv_connector.v1.mooncake.mooncake_connector.make_zmq_socket"
         ) as mock_make_zmq,
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake"
+            ".mooncake_connector.torch.accelerator.current_device_index",
+            return_value=0,
+        ),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake"
+            ".mooncake_connector.current_platform.set_device"
+        ),
         patch("httpx.AsyncClient") as mock_async_client,
     ):
         # Mock PP group
@@ -300,6 +309,37 @@ def patch_worker_dependencies():
             "mock_async_client": mock_async_client,
             "mock_http_client": mock_http_client_instance,
         }
+
+
+def test_mooncake_worker_warns_for_multiple_candidate_host_ips(monkeypatch):
+    """Warn users when Mooncake auto-selects an IP on a multi-NIC host."""
+    monkeypatch.delenv("VLLM_HOST_IP", raising=False)
+    vllm_config = create_vllm_config(
+        kv_connector="MooncakeConnector", kv_role="kv_producer"
+    )
+
+    with (
+        set_current_vllm_config(vllm_config),
+        patch_worker_dependencies(),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake"
+            ".mooncake_connector.get_non_loopback_ip_addresses",
+            return_value=["10.208.130.185", "192.168.30.10"],
+        ),
+        patch(
+            "vllm.distributed.kv_transfer.kv_connector.v1.mooncake"
+            ".mooncake_connector.logger.warning"
+        ) as mock_warning,
+    ):
+        connector = MooncakeConnector(vllm_config, KVConnectorRole.WORKER)
+        assert connector.connector_worker is not None
+        connector.connector_worker.shutdown()
+
+    warning_message = mock_warning.call_args.args[0]
+    warning_args = mock_warning.call_args.args[1:]
+    assert "multiple non-loopback IP addresses were detected" in warning_message
+    assert "Set VLLM_HOST_IP" in warning_message
+    assert warning_args == ("10.208.130.185, 192.168.30.10", "127.0.0.1")
 
 
 @pytest.mark.asyncio
@@ -452,7 +492,11 @@ async def test_kv_producer(monkeypatch):
             mock_socket.send_multipart.assert_called_once()
             _, sent_payload = mock_socket.send_multipart.call_args[0][0]
             response = prefill_worker._xfer_resp_decoder.decode(sent_payload)
-            assert response.err_msg == "Mooncake transfer engine returned 123"
+            assert response.err_msg is not None
+            assert "Mooncake transfer engine returned 123" in response.err_msg
+            assert "remote session consumer-host:54321" in response.err_msg
+            assert "local advertised address 127.0.0.1:12345" in response.err_msg
+            assert "Set VLLM_HOST_IP" in response.err_msg
             assert response.err_reqs == ["d-req-1"]
 
         # Clean up

--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -49,7 +49,12 @@ from vllm.forward_context import ForwardContext
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.utils.math_utils import cdiv
-from vllm.utils.network_utils import get_ip, make_zmq_path, make_zmq_socket
+from vllm.utils.network_utils import (
+    get_ip,
+    get_non_loopback_ip_addresses,
+    make_zmq_path,
+    make_zmq_socket,
+)
 from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.attention.backends.utils import get_kv_cache_layout
 from vllm.v1.core.sched.output import SchedulerOutput
@@ -745,6 +750,30 @@ class MooncakeConnectorWorker:
 
         self.engine = TransferEngine()
         self.hostname = get_ip()
+        if envs.VLLM_HOST_IP:
+            logger.info(
+                "Mooncake Transfer Engine using VLLM_HOST_IP=%s as its "
+                "advertised host IP for KV transfer.",
+                self.hostname,
+            )
+        else:
+            candidate_ips = get_non_loopback_ip_addresses()
+            if len(candidate_ips) > 1:
+                logger.warning(
+                    "VLLM_HOST_IP is not set and multiple non-loopback IP "
+                    "addresses were detected: %s. Mooncake Transfer Engine "
+                    "selected %s as its advertised host IP for KV transfer. "
+                    "Set VLLM_HOST_IP to the address reachable by remote "
+                    "prefill/decode workers if this is incorrect.",
+                    ", ".join(candidate_ips),
+                    self.hostname,
+                )
+            else:
+                logger.info(
+                    "Mooncake Transfer Engine selected %s as its advertised "
+                    "host IP for KV transfer. Set VLLM_HOST_IP to override.",
+                    self.hostname,
+                )
 
         assert (kv_transfer_config := vllm_config.kv_transfer_config)
         self.is_kv_producer: bool = kv_transfer_config.kv_role == "kv_producer"
@@ -1138,7 +1167,13 @@ class MooncakeConnectorWorker:
                 )
 
                 if ret_value != 0:
-                    transfer_err_msg = f"Mooncake transfer engine returned {ret_value}"
+                    transfer_err_msg = (
+                        f"Mooncake transfer engine returned {ret_value} "
+                        f"while sending to remote session {remote_session} "
+                        f"from local advertised address "
+                        f"{self.hostname}:{self.rpc_port}. Set VLLM_HOST_IP "
+                        "if remote workers cannot reach this address."
+                    )
                     err_msg = (
                         transfer_err_msg
                         if err_msg is None

--- a/vllm/utils/network_utils.py
+++ b/vllm/utils/network_utils.py
@@ -30,6 +30,42 @@ def close_sockets(sockets: Sequence[zmq.Socket | zmq.asyncio.Socket]):
             sock.close(linger=0)
 
 
+def get_non_loopback_ip_addresses() -> list[str]:
+    """Return routable-looking local IPs for diagnostics.
+
+    This is intentionally diagnostic only. ``get_ip()`` keeps the existing
+    address selection behavior, while callers can use this list to explain
+    ambiguous multi-NIC environments to users.
+    """
+    addresses: list[str] = []
+    seen: set[str] = set()
+
+    for addr_infos in psutil.net_if_addrs().values():
+        for addr_info in addr_infos:
+            if addr_info.family not in (socket.AF_INET, socket.AF_INET6):
+                continue
+
+            address = addr_info.address.split("%", 1)[0]
+            try:
+                ip_addr = ipaddress.ip_address(address)
+            except ValueError:
+                continue
+
+            if (
+                ip_addr.is_loopback
+                or ip_addr.is_unspecified
+                or ip_addr.is_link_local
+                or ip_addr.is_multicast
+            ):
+                continue
+
+            if address not in seen:
+                seen.add(address)
+                addresses.append(address)
+
+    return addresses
+
+
 def get_ip() -> str:
     host_ip = envs.VLLM_HOST_IP
     if "HOST_IP" in os.environ and "VLLM_HOST_IP" not in os.environ:


### PR DESCRIPTION
Fixes #42023.

## Summary

Mooncake currently relies on the shared `get_ip()` auto-detection path when `VLLM_HOST_IP` is unset. On multi-homed hosts, that can select an address that remote prefill/decode workers cannot reach, and the transfer error only reported the Mooncake return code.

This change keeps the existing IP selection behavior, but makes the failure mode diagnosable:

- logs the advertised host IP selected by Mooncake KV transfer
- warns when `VLLM_HOST_IP` is unset and multiple non-loopback local IPs are detected
- includes the remote session and local advertised address in Mooncake transfer failure messages

## Duplicate-work check

I checked for existing work before opening this PR:

```bash
gh issue view 42023 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search "42023 in:body"
gh pr list --repo vllm-project/vllm --state open --search "MooncakeConnector VLLM_HOST_IP multi-homed wrong host IP"
```

The issue has no comments, and both open-PR searches returned no matching PRs.

## Tests

```bash
.venv/bin/python -m py_compile vllm/utils/network_utils.py vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py tests/v1/kv_connector/unit/test_mooncake_connector.py
git diff --check
docker run --rm --platform linux/amd64 -e PYTHONDONTWRITEBYTECODE=1 -v "$PWD":/workspace -v vllm-docker-venv:/workspace/.venv -v vllm-uv-cache:/root/.cache/uv -w /workspace ghcr.io/astral-sh/uv:python3.12-bookworm bash -lc 'uv pip install --python .venv/bin/python pytest-asyncio; .venv/bin/python -m pytest tests/v1/kv_connector/unit/test_mooncake_connector.py -q'
```

Result: the Docker test run passed with `12 passed, 19 warnings in 43.50s`.

## AI Assistance

AI assistance was used to analyze the issue, implement the patch, run local checks, and draft this PR. The human submitter must review every changed line and run relevant tests before marking ready.
