### PR TITLE
[Bugfix] Fix test_whisper distributed test stability: torch.compile flakiness and memory utilization

### DIFF
--- a/tests/models/multimodal/generation/test_whisper.py
+++ b/tests/models/multimodal/generation/test_whisper.py
@@ -12,7 +12,7 @@ from vllm.multimodal.audio import AudioResampler
 from vllm.platforms import current_platform
 
 from ....conftest import HfRunner, PromptAudioInput, VllmRunner
-from ....utils import create_new_process_for_each_test, multi_gpu_test
+from ....utils import multi_gpu_test
 from ...registry import HF_EXAMPLE_MODELS
 from ...utils import check_logprobs_close
 
@@ -41,6 +41,7 @@ def run_test(
     tensor_parallel_size: int,
     distributed_executor_backend: str | None = None,
     enforce_eager: bool = True,
+    gpu_memory_utilization: float = 0.9,
 ) -> None:
     """Inference result should be the same between hf and vllm.
 
@@ -57,6 +58,7 @@ def run_test(
         distributed_executor_backend=distributed_executor_backend,
         limit_mm_per_prompt={"audio": 2},
         enforce_eager=enforce_eager,
+        gpu_memory_utilization=gpu_memory_utilization,
         disable_custom_all_reduce=True,
     ) as vllm_model:
         vllm_outputs_per_case = [
@@ -295,7 +297,6 @@ def test_models(
 @pytest.mark.parametrize("dtype", ["half"])
 @pytest.mark.parametrize("max_tokens", [200])
 @pytest.mark.parametrize("num_logprobs", [5])
-@create_new_process_for_each_test("spawn")
 def test_models_distributed(
     hf_runner,
     vllm_runner,
@@ -318,7 +319,8 @@ def test_models_distributed(
         num_logprobs=num_logprobs,
         tensor_parallel_size=2,
         distributed_executor_backend=distributed_executor_backend,
-        enforce_eager=False,
+        enforce_eager=True,
+        gpu_memory_utilization=0.7,
     )
 
 

--- a/tests/models/multimodal/generation/test_whisper.py
+++ b/tests/models/multimodal/generation/test_whisper.py
@@ -290,7 +290,7 @@ def test_models(
     )
 
 
-@multi_gpu_test(num_gpus=2)
+@multi_gpu_test(num_gpus=2, method="spawn")
 @pytest.mark.core_model
 @pytest.mark.parametrize("model", ["openai/whisper-large-v3-turbo"])
 @pytest.mark.parametrize("distributed_executor_backend", ["ray", "mp"])


### PR DESCRIPTION
Follow-up to #41423 and #42038.

test_models_distributed in test_whisper.py was failing in CI build #65117 due to two issues:

1. torch.compile flakiness — with enforce_eager=False, the test triggers torch.compile/AOT cache setup which can fail non-deterministically. 
Fix: use enforce_eager=True for the distributed correctness test.

2. Leftover GPU memory — the Whisper test runs last (command 7/7) in the CI job. Earlier tests leave ~6.6 GiB of GPU memory occupied, causing vLLM's startup memory check to fail: Free memory on device cuda:0 (15.41/22.05 GiB) is less than desired GPU memory utilization (0.92, 20.28 GiB). 
Fix: lower gpu_memory_utilization to 0.7 — sufficient for max_model_len=448. Same issue also catched by @SoluMilken 

@ProExpertProg @DarkLight1337 