### PR TITLE
[ROCm][CI] Fix custom logits entrypoints for ROCm/XPU spawn

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -20,9 +20,9 @@ import time
 import warnings
 from collections.abc import Callable, Iterable, Sequence
 from contextlib import ExitStack, contextmanager
-from multiprocessing import Process
+from multiprocessing import Process, get_context
 from pathlib import Path
-from typing import Any, Literal
+from typing import Any, Literal, cast
 from unittest.mock import patch
 
 import anthropic
@@ -125,6 +125,11 @@ ROCM_ENGINE_KWARGS: dict = (
     if current_platform.is_rocm()
     else {}
 )
+
+
+def requires_spawn_multiprocessing() -> bool:
+    """Whether this platform requires spawn instead of fork for test processes."""
+    return current_platform.is_rocm() or current_platform.is_xpu()
 
 
 class RemoteVLLMServer:
@@ -738,9 +743,11 @@ class RemoteOpenAIServerCustom(RemoteOpenAIServer):
     def _start_server(
         self, model: str, vllm_serve_args: list[str], env_dict: dict[str, str] | None
     ) -> None:
-        self.proc: Process = Process(
+        method = "spawn" if requires_spawn_multiprocessing() else "fork"
+        ctx = get_context(method)
+        self.proc: Process = cast(Any, ctx).Process(  # type: ignore[assignment]
             target=self.child_process_fxn, args=(env_dict, model, vllm_serve_args)
-        )  # type: ignore[assignment]
+        )
         self.proc.start()
 
     def __init__(
@@ -769,12 +776,21 @@ class RemoteOpenAIServerCustom(RemoteOpenAIServer):
     def _poll(self) -> int | None:
         return self.proc.exitcode
 
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.proc.terminate()
-        self.proc.join(8)
+    def _terminate_process_tree(self) -> None:
+        pid = self.proc.pid
+
+        with contextlib.suppress(ProcessLookupError, OSError):
+            self.proc.terminate()
+            print(f"[RemoteOpenAIServerCustom] Sent SIGTERM to process {pid}")
+
+        self.proc.join(15)
         if self.proc.is_alive():
-            # force kill if needed
+            print(
+                f"[RemoteOpenAIServerCustom] Server {pid} did not respond "
+                "to SIGTERM, sending SIGKILL"
+            )
             self.proc.kill()
+            self.proc.join(10)
 
 
 def _test_completion(
@@ -1511,16 +1527,6 @@ def fork_new_process_for_each_test(func: Callable[_P, None]) -> Callable[_P, Non
     return wrapper
 
 
-def _format_subprocess_exit(returncode: int) -> str:
-    """Render a subprocess exit code, naming the signal for negative codes."""
-    if returncode >= 0:
-        return f"exit code {returncode}"
-    try:
-        return f"killed by {signal.Signals(-returncode).name} ({returncode})"
-    except ValueError:
-        return f"exit code {returncode}"
-
-
 # Set on the spawn-child interpreter so the wrapper short-circuits when the
 # child resolves `module.qualname` back to its own decorated form, instead of
 # launching another subprocess.
@@ -1541,12 +1547,6 @@ def spawn_new_process_for_each_test(f: Callable[_P, None]) -> Callable[_P, None]
     ``vllm.compilation.counter.compilation_counter``) into stale clones in
     the child, so increments performed by the production code in the child
     would never be observable to the test.
-
-    The child inherits the parent's stdout/stderr so its output (engine
-    cores, NCCL, CUDA, ...) reaches the test runner live; the Python-level
-    traceback is serialized to ``tb_file`` for structured re-raising. A
-    native crash leaves ``tb_file`` empty — the diagnostic is then only in
-    the inherited subprocess output.
     """
 
     @functools.wraps(f)
@@ -1597,20 +1597,23 @@ def spawn_new_process_for_each_test(f: Callable[_P, None]) -> Callable[_P, None]
             result = subprocess.run(
                 [sys.executable, "-c", child_script],
                 input=payload,
+                capture_output=True,
                 env=env,
             )
 
             if result.returncode != 0:
+                # Prefer the child's traceback file; fall back to stderr if
+                # the child crashed before its except handler ran.
                 try:
                     with open(tb_file) as fp:
                         tb = fp.read()
                 except OSError:
                     tb = ""
                 if not tb:
-                    tb = "<no Python traceback; see subprocess output above>"
+                    tb = result.stderr.decode()
                 raise RuntimeError(
                     f"Test subprocess '{f.__name__}' failed "
-                    f"({_format_subprocess_exit(result.returncode)}):\n{tb}"
+                    f"(exit code {result.returncode}):\n{tb}"
                 )
         finally:
             with contextlib.suppress(OSError):
@@ -1633,8 +1636,7 @@ def create_new_process_for_each_test(
         A decorator to run test functions in separate processes.
     """
     if method is None:
-        use_spawn = current_platform.is_rocm() or current_platform.is_xpu()
-        method = "spawn" if use_spawn else "fork"
+        method = "spawn" if requires_spawn_multiprocessing() else "fork"
 
     assert method in ["spawn", "fork"], "Method must be either 'spawn' or 'fork'"
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -132,6 +132,16 @@ def requires_spawn_multiprocessing() -> bool:
     return current_platform.is_rocm() or current_platform.is_xpu()
 
 
+def _run_in_new_process_group(
+    child_process_fxn: Callable[[dict[str, str] | None, str, list[str]], None],
+    env_dict: dict[str, str] | None,
+    model: str,
+    vllm_serve_args: list[str],
+) -> None:
+    os.setsid()
+    child_process_fxn(env_dict, model, vllm_serve_args)
+
+
 class RemoteVLLMServer:
     """Base class for launching vLLM server subprocesses for testing.
 
@@ -745,9 +755,10 @@ class RemoteOpenAIServerCustom(RemoteOpenAIServer):
     ) -> None:
         method = "spawn" if requires_spawn_multiprocessing() else "fork"
         ctx = get_context(method)
-        self.proc: Process = cast(Any, ctx).Process(  # type: ignore[assignment]
-            target=self.child_process_fxn, args=(env_dict, model, vllm_serve_args)
-        )
+        self.proc: Process = cast(Any, ctx).Process(
+            target=_run_in_new_process_group,
+            args=(self.child_process_fxn, env_dict, model, vllm_serve_args),
+        )  # type: ignore[assignment]
         self.proc.start()
 
     def __init__(
@@ -778,6 +789,19 @@ class RemoteOpenAIServerCustom(RemoteOpenAIServer):
 
     def _terminate_process_tree(self) -> None:
         pid = self.proc.pid
+        if pid is None:
+            return
+
+        pgid: int | None
+        try:
+            pgid = os.getpgid(pid)
+            # _run_in_new_process_group should make the child the group
+            # leader. Avoid signaling pytest's process group if startup failed
+            # before os.setsid() ran.
+            if pgid != pid:
+                pgid = None
+        except (ProcessLookupError, OSError):
+            pgid = None
 
         with contextlib.suppress(ProcessLookupError, OSError):
             self.proc.terminate()
@@ -787,10 +811,16 @@ class RemoteOpenAIServerCustom(RemoteOpenAIServer):
         if self.proc.is_alive():
             print(
                 f"[RemoteOpenAIServerCustom] Server {pid} did not respond "
-                "to SIGTERM, sending SIGKILL"
+                "to SIGTERM, sending SIGKILL to process group"
             )
-            self.proc.kill()
+            if pgid is not None:
+                with contextlib.suppress(ProcessLookupError, OSError):
+                    os.killpg(pgid, signal.SIGKILL)
+            else:
+                self.proc.kill()
             self.proc.join(10)
+
+        self._kill_process_group_survivors(pgid)
 
 
 def _test_completion(

--- a/tests/v1/logits_processors/test_custom_offline.py
+++ b/tests/v1/logits_processors/test_custom_offline.py
@@ -16,8 +16,8 @@ from tests.v1.logits_processors.utils import (
     DummyLogitsProcessor,
     WrappedPerReqLogitsProcessor,
     prompts,
+    register_fake_entrypoint,
 )
-from tests.v1.logits_processors.utils import entry_points as fake_entry_points
 from vllm import LLM, SamplingParams
 from vllm.v1.sample.logits_processor import (
     STR_POOLING_REJECTS_LOGITSPROCS,
@@ -145,13 +145,9 @@ def test_custom_logitsprocs(monkeypatch, logitproc_source: CustomLogitprocSource
 
     if logitproc_source == CustomLogitprocSource.LOGITPROC_SOURCE_ENTRYPOINT:
         # Scenario: vLLM loads a logitproc from a preconfigured entrypoint
-        # To that end, mock a dummy logitproc entrypoint
-        import importlib.metadata
-
-        importlib.metadata.entry_points = fake_entry_points  # type: ignore
-
-        # fork is required for workers to see entrypoint patch
-        monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "fork")
+        # To that end, register a real dist-info package so spawned
+        # workers can discover the entrypoint via PYTHONPATH
+        register_fake_entrypoint(monkeypatch)
         _run_test({}, logitproc_loaded=True)
         return
 
@@ -266,14 +262,9 @@ def test_rejects_custom_logitsprocs(
         # Scenario: vLLM loads a model and ignores a logitproc that is
         # available at a preconfigured entrypoint
 
-        # Patch in dummy logitproc entrypoint
-        import importlib.metadata
-
-        importlib.metadata.entry_points = fake_entry_points  # type: ignore
-
-        # fork is required for entrypoint patch to be visible to workers,
-        # although they should ignore the entrypoint patch anyway
-        monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "fork")
+        # Register real dist-info package so spawned workers can
+        # discover the entrypoint via PYTHONPATH (spawn-compatible)
+        register_fake_entrypoint(monkeypatch)
 
         llm = LLM(**llm_kwargs)
         # Require that no custom logitsprocs have been loaded

--- a/tests/v1/logits_processors/test_custom_offline.py
+++ b/tests/v1/logits_processors/test_custom_offline.py
@@ -16,7 +16,7 @@ from tests.v1.logits_processors.utils import (
     DummyLogitsProcessor,
     WrappedPerReqLogitsProcessor,
     prompts,
-    register_fake_entrypoint,
+    setup_fake_entrypoint,
 )
 from vllm import LLM, SamplingParams
 from vllm.v1.sample.logits_processor import (
@@ -147,7 +147,7 @@ def test_custom_logitsprocs(monkeypatch, logitproc_source: CustomLogitprocSource
         # Scenario: vLLM loads a logitproc from a preconfigured entrypoint
         # To that end, register a real dist-info package so spawned
         # workers can discover the entrypoint via PYTHONPATH
-        register_fake_entrypoint(monkeypatch)
+        setup_fake_entrypoint(monkeypatch)
         _run_test({}, logitproc_loaded=True)
         return
 
@@ -264,7 +264,7 @@ def test_rejects_custom_logitsprocs(
 
         # Register real dist-info package so spawned workers can
         # discover the entrypoint via PYTHONPATH (spawn-compatible)
-        register_fake_entrypoint(monkeypatch)
+        setup_fake_entrypoint(monkeypatch)
 
         llm = LLM(**llm_kwargs)
         # Require that no custom logitsprocs have been loaded

--- a/tests/v1/logits_processors/test_custom_online.py
+++ b/tests/v1/logits_processors/test_custom_online.py
@@ -18,8 +18,8 @@ from tests.v1.logits_processors.utils import (
     MODEL_NAME,
     TEMP_GREEDY,
     prompts,
+    setup_fake_entrypoint,
 )
-from tests.v1.logits_processors.utils import entry_points as fake_entry_points
 
 
 def _server_with_logitproc_entrypoint(
@@ -27,16 +27,9 @@ def _server_with_logitproc_entrypoint(
     model: str,
     vllm_serve_args: list[str],
 ) -> None:
-    """Start vLLM server, inject dummy logitproc entrypoint"""
-
-    # Patch `entry_points` to inject logitproc entrypoint
-    import importlib.metadata
-
-    importlib.metadata.entry_points = fake_entry_points  # type: ignore
+    """Start vLLM server with dummy logitproc entrypoint."""
     from vllm.entrypoints.cli import main
 
-    # fork is required for workers to see entrypoint patch
-    os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "fork"
     if env_dict is not None:
         os.environ.update(env_dict)
 
@@ -50,7 +43,7 @@ def _server_with_logitproc_fqcn(
     model: str,
     vllm_serve_args: list[str],
 ) -> None:
-    """Start vLLM server, inject module with dummy logitproc"""
+    """Start vLLM server with dummy logitproc specified by FQCN."""
     from vllm.entrypoints.cli import main
 
     if env_dict is not None:
@@ -80,8 +73,8 @@ def default_server_args():
 def server(default_server_args, request, monkeypatch):
     """Consider two server configurations:
     (1) --logits-processors cli arg specifies dummy logits processor via fully-
-    qualified class name (FQCN); patch in a dummy logits processor module
-    (2) No --logits-processors cli arg; patch in a dummy logits processor
+    qualified class name (FQCN)
+    (2) No --logits-processors cli arg; inject a dummy logits processor
     entrypoint
     """
 
@@ -94,6 +87,7 @@ def server(default_server_args, request, monkeypatch):
         _server_fxn = _server_with_logitproc_fqcn
     else:
         # Launch server, inject dummy logitproc entrypoint
+        setup_fake_entrypoint(monkeypatch)
         args = default_server_args
         _server_fxn = _server_with_logitproc_entrypoint
 
@@ -119,7 +113,6 @@ api_keyword_args = {
 }
 
 
-@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "model_name",
     [MODEL_NAME],

--- a/tests/v1/logits_processors/utils.py
+++ b/tests/v1/logits_processors/utils.py
@@ -220,6 +220,10 @@ def register_fake_entrypoint(monkeypatch) -> str:
         "PYTHONPATH", tmpdir + (os.pathsep + existing if existing else "")
     )
 
+    # Also update sys.path for the current process so the driver can
+    # discover the entrypoint.
+    monkeypatch.syspath_prepend(tmpdir)
+
     return tmpdir
 
 

--- a/tests/v1/logits_processors/utils.py
+++ b/tests/v1/logits_processors/utils.py
@@ -3,12 +3,13 @@
 
 import os
 import tempfile
-import types
 from enum import Enum, auto
+from pathlib import Path
 from typing import Any
 
 import torch
 
+from tests.utils import requires_spawn_multiprocessing
 from vllm.config import VllmConfig
 from vllm.logger import init_logger
 from vllm.sampling_params import SamplingParams
@@ -104,11 +105,6 @@ class DummyLogitsProcessor(LogitsProcessor):
         return logits
 
 
-"""Dummy module with dummy logitproc class"""
-dummy_module = types.ModuleType(DUMMY_LOGITPROC_MODULE)
-dummy_module.DummyLogitsProcessor = DummyLogitsProcessor  # type: ignore
-
-
 class EntryPoint:
     """Dummy entrypoint class for logitsprocs testing"""
 
@@ -199,33 +195,49 @@ def register_fake_entrypoint(monkeypatch) -> str:
 
     Returns the temp directory path.
     """
-    tmpdir = tempfile.mkdtemp()
-    dist_info = os.path.join(tmpdir, "dummy_logitproc-0.1.dist-info")
-    os.makedirs(dist_info)
+    tmpdir = Path(tempfile.mkdtemp(prefix="dummy-logitproc-"))
+    dist_info = tmpdir / "dummy_logitproc-0.1.dist-info"
+    dist_info.mkdir()
 
     # Write METADATA file (required by importlib.metadata)
-    with open(os.path.join(dist_info, "METADATA"), "w") as f:
-        f.write("Metadata-Version: 2.1\nName: dummy-logitproc\nVersion: 0.1\n")
+    (dist_info / "METADATA").write_text(
+        "Metadata-Version: 2.1\nName: dummy-logitproc\nVersion: 0.1\n",
+        encoding="utf-8",
+    )
 
     # Write entry_points.txt
-    with open(os.path.join(dist_info, "entry_points.txt"), "w") as f:
-        f.write(
-            f"[{LOGITSPROCS_GROUP}]\n"
-            f"{DUMMY_LOGITPROC_ENTRYPOINT} = {DUMMY_LOGITPROC_FQCN}\n"
-        )
+    (dist_info / "entry_points.txt").write_text(
+        f"[{LOGITSPROCS_GROUP}]\n"
+        f"{DUMMY_LOGITPROC_ENTRYPOINT} = {DUMMY_LOGITPROC_FQCN}\n",
+        encoding="utf-8",
+    )
 
     # Add to PYTHONPATH so spawned subprocesses can discover it
     existing = os.environ.get("PYTHONPATH", "")
     monkeypatch.setenv(
-        "PYTHONPATH", tmpdir + (os.pathsep + existing if existing else "")
+        "PYTHONPATH", str(tmpdir) + (os.pathsep + existing if existing else "")
     )
 
     # Also update sys.path for the current process so the driver can
     # discover the entrypoint.
-    monkeypatch.syspath_prepend(tmpdir)
+    monkeypatch.syspath_prepend(str(tmpdir))
 
-    return tmpdir
+    return str(tmpdir)
 
 
-"""Fake version of importlib.metadata.entry_points"""
-entry_points = lambda group: EntryPoints(group)
+def fake_entry_points(group: str) -> EntryPoints:
+    """Fake version of importlib.metadata.entry_points."""
+    return EntryPoints(group)
+
+
+def setup_fake_entrypoint(monkeypatch) -> None:
+    """Expose the dummy logitproc entrypoint for the current platform."""
+    if requires_spawn_multiprocessing():
+        register_fake_entrypoint(monkeypatch)
+        monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+        return
+
+    import importlib.metadata
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", fake_entry_points)
+    monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "fork")

--- a/tests/v1/logits_processors/utils.py
+++ b/tests/v1/logits_processors/utils.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import os
+import tempfile
 import types
 from enum import Enum, auto
 from typing import Any
@@ -185,6 +187,40 @@ class WrappedPerReqLogitsProcessor(AdapterLogitsProcessor):
             )
             return None
         return DummyPerReqLogitsProcessor(target_token)
+
+
+def register_fake_entrypoint(monkeypatch) -> str:
+    """Register the dummy logitsproc entrypoint in a way that is visible
+    to spawned subprocesses by creating a real dist-info directory on disk.
+
+    Unlike monkey-patching importlib.metadata.entry_points (which only works
+    with fork), this approach writes a real dist-info package that
+    importlib.metadata can discover in any subprocess via PYTHONPATH.
+
+    Returns the temp directory path.
+    """
+    tmpdir = tempfile.mkdtemp()
+    dist_info = os.path.join(tmpdir, "dummy_logitproc-0.1.dist-info")
+    os.makedirs(dist_info)
+
+    # Write METADATA file (required by importlib.metadata)
+    with open(os.path.join(dist_info, "METADATA"), "w") as f:
+        f.write("Metadata-Version: 2.1\nName: dummy-logitproc\nVersion: 0.1\n")
+
+    # Write entry_points.txt
+    with open(os.path.join(dist_info, "entry_points.txt"), "w") as f:
+        f.write(
+            f"[{LOGITSPROCS_GROUP}]\n"
+            f"{DUMMY_LOGITPROC_ENTRYPOINT} = {DUMMY_LOGITPROC_FQCN}\n"
+        )
+
+    # Add to PYTHONPATH so spawned subprocesses can discover it
+    existing = os.environ.get("PYTHONPATH", "")
+    monkeypatch.setenv(
+        "PYTHONPATH", tmpdir + (os.pathsep + existing if existing else "")
+    )
+
+    return tmpdir
 
 
 """Fake version of importlib.metadata.entry_points"""


### PR DESCRIPTION
Follow-up: #42040

- Centralize test multiprocessing start-method selection in `tests/utils.py`.
- Make custom logits processor entrypoint setup choose fork-compatible monkeypatching or spawn-compatible dist-info registration by platform.
- Update online and offline custom logits processor tests to use the shared entrypoint setup helper.
- Keep CUDA and other fork-capable platforms on the fork path while using spawn on ROCm/XPU.

cc @kenroche 