### PR TITLE
[Bugfix] Fix Gemma4ToolParser streaming float corruption

### DIFF
--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -135,6 +135,26 @@ class TestParseGemma4Args:
         result = _parse_gemma4_args('name:<|"|>test<|"|>,flag:', partial=True)
         assert result == {"name": "test"}
 
+    def test_trailing_dot_float_partial_withheld(self):
+        """Bare float ending with '.' is withheld in partial mode.
+
+        Regression test for #42047: float("108.") → 108.0 causes
+        streaming diff corruption (108.0 → 108.2 becomes 108.02).
+        """
+        # Single key with trailing dot — withheld entirely
+        result = _parse_gemma4_args("left:108.,right:22.8", partial=True)
+        assert result == {}
+
+        # Stable key before trailing-dot key — stable key is kept
+        result = _parse_gemma4_args(
+            'name:<|"|>test<|"|>,score:3.,count:1', partial=True
+        )
+        assert result == {"name": "test"}
+
+        # Non-partial mode parses trailing dot normally
+        result = _parse_gemma4_args("left:108.,right:22.8", partial=False)
+        assert result == {"left": 108.0, "right": 22.8}
+
     @pytest.mark.timeout(5)
     def test_malformed_partial_array(self):
         result = _parse_gemma4_args(":[t:[]")
@@ -162,6 +182,15 @@ class TestParseGemma4Array:
     @pytest.mark.timeout(5)
     def test_stray_closing_bracket(self):
         result = _parse_gemma4_array("42,]trailing")
+        assert result == [42]
+
+    def test_trailing_dot_float_partial_withheld(self):
+        """Array elements with trailing dot withheld in partial mode."""
+        result = _parse_gemma4_array("108.,22.8", partial=True)
+        assert result == []
+
+        # Stable elements before trailing-dot element are kept
+        result = _parse_gemma4_array("42,108.,3", partial=True)
         assert result == [42]
 
 

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -211,6 +211,13 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
                     i,
                 )
                 break
+            raw_val = args_str[val_start:i].strip()
+            if partial and raw_val.endswith("."):
+                # Trailing dot means decimal digits may still arrive
+                # (e.g. "108." may become "108.2"). Parsing now would
+                # yield float("108.") == 108.0, whose json repr "108.0"
+                # corrupts the streaming diff when the true digit lands.
+                break
             result[key] = _parse_gemma4_value(args_str[val_start:i])
 
     return result
@@ -293,6 +300,9 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
                     "aborting on malformed input.",
                     i,
                 )
+                break
+            raw_val = arr_str[val_start:i].strip()
+            if partial and raw_val.endswith("."):
                 break
             items.append(_parse_gemma4_value(arr_str[val_start:i]))
 

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -211,13 +211,14 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
                     i,
                 )
                 break
-            raw_val = args_str[val_start:i].strip()
-            if partial and raw_val.endswith("."):
-                # Trailing dot means decimal digits may still arrive
-                # (e.g. "108." may become "108.2"). Parsing now would
-                # yield float("108.") == 108.0, whose json repr "108.0"
-                # corrupts the streaming diff when the true digit lands.
-                break
+            if partial:
+                raw_val = args_str[val_start:i].strip()
+                if raw_val.endswith("."):
+                    # Trailing dot means decimal digits may still arrive
+                    # (e.g. "108." may become "108.2"). Parsing now would
+                    # yield float("108.") == 108.0, whose json repr "108.0"
+                    # corrupts the streaming diff when the true digit lands.
+                    break
             result[key] = _parse_gemma4_value(args_str[val_start:i])
 
     return result
@@ -301,9 +302,10 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
                     i,
                 )
                 break
-            raw_val = arr_str[val_start:i].strip()
-            if partial and raw_val.endswith("."):
-                break
+            if partial:
+                raw_val = arr_str[val_start:i].strip()
+                if raw_val.endswith("."):
+                    break
             items.append(_parse_gemma4_value(arr_str[val_start:i]))
 
     return items


### PR DESCRIPTION
## Summary

Fixes #42047 — `Gemma4ToolParser` produces incorrect float values during streaming (e.g., `108.2` → `108.02`).

**Root cause:** When a bare numeric value ending with `.` (e.g., `"108."`) is terminated by a comma in partial/streaming mode, `float("108.")` evaluates to `108.0`. The JSON serialization `"108.0"` is emitted to the client. When the true decimal digit arrives and the value becomes `108.2`, the streaming diff logic computes a common prefix of `"108."` but the client already received `"108.0"` — the final diff appends `"2"`, producing `"108.02"`.

**Fix:** In `_parse_gemma4_args()` and `_parse_gemma4_array()`, when `partial=True` (streaming mode), withhold bare values that end with `"."` since additional decimal digits may still arrive. This is consistent with the existing end-of-string withholding logic. The final non-partial parse at tool-call-end handles these values correctly.

## Test plan

- [x] Added regression tests in `tests/tool_parsers/test_gemma4_tool_parser.py`:
  - `test_trailing_dot_float_partial_withheld` — verifies `"108."` is withheld in partial mode
  - `test_trailing_dot_float_partial_withheld` (array) — same for array elements
- [x] Verified existing tests still pass (non-partial parsing, other value types)
- [x] Verified non-streaming path is unaffected (`partial=False` still parses `"108."` → `108.0`)

```bash
python -m pytest tests/tool_parsers/test_gemma4_tool_parser.py -v
```