### PR TITLE
[CI] [Flaky] Avoid remote default model config in compile tests

### DIFF
--- a/tests/compile/conftest.py
+++ b/tests/compile/conftest.py
@@ -1,12 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import json
 from contextlib import contextmanager
+from typing import Any, Protocol
 from unittest.mock import MagicMock, patch
 
 import pytest
+import torch
 
+from vllm.config import ModelConfig
 from vllm.platforms.interface import DeviceCapability
+
+
+class CompileModelConfigFactory(Protocol):
+    def __call__(self, *, dtype: torch.dtype, **kwargs: Any) -> ModelConfig: ...
 
 
 @pytest.fixture
@@ -46,3 +54,99 @@ def mock_cuda_platform():
             yield mock_platform
 
     return _mock_platform
+
+
+@pytest.fixture(scope="session")
+def compile_test_qwen3_model_path(tmp_path_factory: pytest.TempPathFactory) -> str:
+    model_dir = tmp_path_factory.mktemp("compile_test_qwen3_model")
+    # Minimal local metadata fixture based on Qwen/Qwen3-0.6B's config.json.
+    # Compile pass tests instantiate their own tiny modules and only need
+    # ModelConfig metadata, not tokenizer files or weights.
+    config = {
+        "architectures": ["Qwen3ForCausalLM"],
+        "attention_bias": False,
+        "attention_dropout": 0.0,
+        "bos_token_id": 151643,
+        "eos_token_id": 151645,
+        "head_dim": 128,
+        "hidden_act": "silu",
+        "hidden_size": 1024,
+        "initializer_range": 0.02,
+        "intermediate_size": 3072,
+        "max_position_embeddings": 4096,
+        "max_window_layers": 2,
+        "model_type": "qwen3",
+        "num_attention_heads": 16,
+        "num_hidden_layers": 2,
+        "num_key_value_heads": 8,
+        "rms_norm_eps": 1e-06,
+        "rope_scaling": None,
+        "rope_theta": 1000000,
+        "sliding_window": None,
+        "tie_word_embeddings": True,
+        "torch_dtype": "bfloat16",
+        "transformers_version": "4.51.0",
+        "use_cache": True,
+        "use_sliding_window": False,
+        "vocab_size": 151936,
+    }
+    (model_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    return str(model_dir)
+
+
+@pytest.fixture(scope="session")
+def compile_test_llama_model_path(tmp_path_factory: pytest.TempPathFactory) -> str:
+    model_dir = tmp_path_factory.mktemp("compile_test_llama_model")
+    # Minimal local metadata fixture based on RedHatAI/Llama-3.2-1B-Instruct-FP8's
+    # Llama shape. Distributed compile pass tests use this only to construct a
+    # ModelConfig, not to load tokenizer files or weights.
+    config = {
+        "architectures": ["LlamaForCausalLM"],
+        "attention_bias": False,
+        "attention_dropout": 0.0,
+        "bos_token_id": 1,
+        "eos_token_id": 2,
+        "head_dim": 128,
+        "hidden_act": "silu",
+        "hidden_size": 1024,
+        "initializer_range": 0.02,
+        "intermediate_size": 3072,
+        "max_position_embeddings": 4096,
+        "model_type": "llama",
+        "num_attention_heads": 16,
+        "num_hidden_layers": 2,
+        "num_key_value_heads": 8,
+        "rms_norm_eps": 1e-06,
+        "rope_theta": 1000000,
+        "tie_word_embeddings": False,
+        "torch_dtype": "bfloat16",
+        "transformers_version": "4.51.0",
+        "use_cache": True,
+        "vocab_size": 32000,
+    }
+    (model_dir / "config.json").write_text(json.dumps(config), encoding="utf-8")
+    return str(model_dir)
+
+
+@pytest.fixture
+def make_compile_test_model_config(
+    compile_test_qwen3_model_path: str,
+) -> CompileModelConfigFactory:
+    """Create local model metadata for compile pass unit tests.
+
+    The tests instantiate tiny hand-written modules and only need stable
+    ModelConfig metadata. Use local Qwen3 metadata because it mirrors the
+    ModelConfig default model without requiring HF access, and skip tokenizer
+    init so tests do not depend on tokenizer files or downloads.
+    """
+
+    def make_model_config(*, dtype: torch.dtype, **kwargs: Any) -> ModelConfig:
+        return ModelConfig(
+            model=compile_test_qwen3_model_path,
+            tokenizer=compile_test_qwen3_model_path,
+            dtype=dtype,
+            skip_tokenizer_init=True,
+            **kwargs,
+        )
+
+    return make_model_config

--- a/tests/compile/passes/distributed/test_async_tp.py
+++ b/tests/compile/passes/distributed/test_async_tp.py
@@ -251,6 +251,7 @@ def test_async_tp_pass_replace(
     hidden_size: int,
     dtype: torch.dtype,
     dynamic: bool,
+    compile_test_llama_model_path: str,
 ):
     if (
         test_model
@@ -282,6 +283,7 @@ def test_async_tp_pass_replace(
                 hidden_size,
                 dtype,
                 dynamic,
+                compile_test_llama_model_path,
             ),
             nprocs=nprocs,
         )
@@ -314,6 +316,7 @@ def async_tp_pass_on_test_model(
     hidden_size: int,
     dtype: torch.dtype,
     dynamic: bool,
+    compile_test_llama_model_path: str,
 ):
     set_random_seed(0)
 
@@ -344,11 +347,12 @@ def async_tp_pass_on_test_model(
     )
     vllm_config.device_config = DeviceConfig(device=torch.device(DEVICE_TYPE))
 
-    # this is a fake model name to construct the model config
-    # in the vllm_config, it's not really used.
-    model_name = "RedHatAI/Llama-3.2-1B-Instruct-FP8"
     vllm_config.model_config = ModelConfig(
-        model=model_name, trust_remote_code=True, dtype=dtype, seed=42
+        model=compile_test_llama_model_path,
+        tokenizer=compile_test_llama_model_path,
+        dtype=dtype,
+        skip_tokenizer_init=True,
+        seed=42,
     )
 
     with set_current_vllm_config(vllm_config):

--- a/tests/compile/passes/distributed/test_fusion_all_reduce.py
+++ b/tests/compile/passes/distributed/test_fusion_all_reduce.py
@@ -272,6 +272,7 @@ def test_all_reduce_fusion_pass_replace(
     flashinfer_allreduce_backend,
     use_aiter: bool,
     monkeypatch: pytest.MonkeyPatch,
+    compile_test_llama_model_path: str,
 ):
     if use_aiter:
         with monkeypatch.context() as m:
@@ -303,6 +304,7 @@ def test_all_reduce_fusion_pass_replace(
                 flashinfer_allreduce_backend,
                 use_aiter,
                 monkeypatch,
+                compile_test_llama_model_path,
             ),
             nprocs=nprocs,
         )
@@ -323,6 +325,7 @@ def all_reduce_fusion_pass_on_test_model(
     flashinfer_allreduce_backend,
     use_aiter: bool,
     monkeypatch: pytest.MonkeyPatch,
+    compile_test_llama_model_path: str,
 ):
     set_random_seed(0)
 
@@ -361,11 +364,12 @@ def all_reduce_fusion_pass_on_test_model(
     vllm_config.device_config = DeviceConfig(device=torch.device(DEVICE_TYPE))
     vllm_config.parallel_config.rank = local_rank  # Setup rank for debug path
 
-    # this is a fake model name to construct the model config
-    # in the vllm_config, it's not really used.
-    model_name = "RedHatAI/Llama-3.2-1B-Instruct-FP8"
     vllm_config.model_config = ModelConfig(
-        model=model_name, trust_remote_code=True, dtype=dtype, seed=42
+        model=compile_test_llama_model_path,
+        tokenizer=compile_test_llama_model_path,
+        dtype=dtype,
+        skip_tokenizer_init=True,
+        seed=42,
     )
     with set_current_vllm_config(vllm_config):
         initialize_model_parallel(tensor_model_parallel_size=world_size)

--- a/tests/compile/passes/distributed/test_sequence_parallelism.py
+++ b/tests/compile/passes/distributed/test_sequence_parallelism.py
@@ -189,6 +189,7 @@ def test_sequence_parallelism_pass(
     dtype: torch.dtype,
     fuse_norm_quant: bool,
     dynamic: bool,
+    compile_test_llama_model_path: str,
 ):
     num_processes = 2
 
@@ -207,6 +208,7 @@ def test_sequence_parallelism_pass(
                 dtype,
                 fuse_norm_quant,
                 dynamic,
+                compile_test_llama_model_path,
             ),
             nprocs=nprocs,
         )
@@ -243,6 +245,7 @@ def sequence_parallelism_pass_on_test_model(
     dtype: torch.dtype,
     fuse_norm_quant: bool,
     dynamic: bool,
+    compile_test_llama_model_path: str,
 ):
     set_random_seed(0)
 
@@ -278,11 +281,12 @@ def sequence_parallelism_pass_on_test_model(
     )  # NoOp needed for fusion
     device_config = DeviceConfig(device=torch.device(DEVICE_TYPE))
 
-    # this is a fake model name to construct the model config
-    # in the vllm_config, it's not really used.
-    model_name = "RedHatAI/Llama-3.2-1B-Instruct-FP8"
     model_config = ModelConfig(
-        model=model_name, trust_remote_code=True, dtype=dtype, seed=42
+        model=compile_test_llama_model_path,
+        tokenizer=compile_test_llama_model_path,
+        dtype=dtype,
+        skip_tokenizer_init=True,
+        seed=42,
     )
 
     vllm_config = VllmConfig(

--- a/tests/compile/passes/test_functionalization.py
+++ b/tests/compile/passes/test_functionalization.py
@@ -20,7 +20,6 @@ from vllm.compilation.passes.utility.noop_elimination import NoOpEliminationPass
 from vllm.compilation.passes.utility.post_cleanup import PostCleanupPass
 from vllm.config import (
     CompilationConfig,
-    ModelConfig,
     PassConfig,
     VllmConfig,
     get_current_vllm_config,
@@ -274,14 +273,17 @@ MODELS_AND_DO_FUSION = {
     reason="Only test on cuda and rocm platform",
 )
 def test_fix_functionalization(
-    model_class: torch.nn.Module, do_fusion: bool, dtype: torch.dtype
+    model_class: torch.nn.Module,
+    do_fusion: bool,
+    dtype: torch.dtype,
+    make_compile_test_model_config,
 ):
     torch.set_default_device("cuda")
     torch.set_default_dtype(dtype)
     torch.manual_seed(0)
 
     vllm_config = VllmConfig(
-        model_config=ModelConfig(dtype=dtype),
+        model_config=make_compile_test_model_config(dtype=dtype),
         compilation_config=CompilationConfig(
             custom_ops=["all"],
             pass_config=PassConfig(

--- a/tests/compile/passes/test_fuse_act_padding.py
+++ b/tests/compile/passes/test_fuse_act_padding.py
@@ -13,7 +13,6 @@ from vllm.compilation.passes.utility.post_cleanup import PostCleanupPass
 from vllm.config import (
     CompilationConfig,
     CompilationMode,
-    ModelConfig,
     PassConfig,
     VllmConfig,
 )
@@ -83,9 +82,10 @@ def test_fuse_act_padding(
     num_local_experts: int,
     x_pad_to_multiple: int,
     monkeypatch: pytest.MonkeyPatch,
+    make_compile_test_model_config,
 ):
     vllm_config = VllmConfig(
-        model_config=ModelConfig(dtype=dtype),
+        model_config=make_compile_test_model_config(dtype=dtype),
         compilation_config=CompilationConfig(
             mode=CompilationMode.VLLM_COMPILE,
             custom_ops=["+rms_norm"],

--- a/tests/compile/passes/test_fuse_mla_dual_rms_norm.py
+++ b/tests/compile/passes/test_fuse_mla_dual_rms_norm.py
@@ -18,7 +18,6 @@ from vllm.compilation.passes.utility.post_cleanup import PostCleanupPass
 from vllm.config import (
     CompilationConfig,
     CompilationMode,
-    ModelConfig,
     PassConfig,
     VllmConfig,
 )
@@ -94,11 +93,12 @@ def test_fuse_mla_dual_rms_norm(
     dtype: torch.dtype,
     hidden_size: int,
     monkeypatch: pytest.MonkeyPatch,
+    make_compile_test_model_config,
 ):
     torch._dynamo.reset()
 
     vllm_config = VllmConfig(
-        model_config=ModelConfig(dtype=dtype),
+        model_config=make_compile_test_model_config(dtype=dtype),
         compilation_config=CompilationConfig(
             mode=CompilationMode.VLLM_COMPILE,
             custom_ops=["+rms_norm"],

--- a/tests/compile/passes/test_fusion.py
+++ b/tests/compile/passes/test_fusion.py
@@ -22,7 +22,6 @@ from vllm.compilation.passes.utility.post_cleanup import PostCleanupPass
 from vllm.config import (
     CompilationConfig,
     CompilationMode,
-    ModelConfig,
     PassConfig,
     VllmConfig,
 )
@@ -307,6 +306,7 @@ def test_fusion_rmsnorm_quant(
     kernel_groupshape,
     enable_rms_norm_custom_op,
     enable_quant_fp8_custom_op,
+    make_compile_test_model_config,
 ):
     force_kernel, group_shape = kernel_groupshape
 
@@ -345,7 +345,7 @@ def test_fusion_rmsnorm_quant(
         custom_ops.append("+quant_fp8")
 
     vllm_config = VllmConfig(
-        model_config=ModelConfig(dtype=dtype),
+        model_config=make_compile_test_model_config(dtype=dtype),
         compilation_config=CompilationConfig(
             mode=CompilationMode.VLLM_COMPILE,
             custom_ops=custom_ops,
@@ -402,10 +402,11 @@ def test_aiter_fusion_rmsnorm_quant(
     eps: float,
     kernel_groupshape_quant: tuple,
     monkeypatch: pytest.MonkeyPatch,
+    make_compile_test_model_config,
 ):
     force_kernel, group_shape, use_aiter_quant_op = kernel_groupshape_quant
     vllm_config = VllmConfig(
-        model_config=ModelConfig(dtype=dtype),
+        model_config=make_compile_test_model_config(dtype=dtype),
         compilation_config=CompilationConfig(
             mode=CompilationMode.VLLM_COMPILE,
             custom_ops=["+rms_norm", "+quant_fp8"],

--- a/tests/compile/passes/test_pass_manager.py
+++ b/tests/compile/passes/test_pass_manager.py
@@ -11,7 +11,7 @@ from vllm.compilation.passes.inductor_pass import (
     pass_context,
 )
 from vllm.compilation.passes.pass_manager import PostGradPassManager
-from vllm.config import ModelConfig, VllmConfig
+from vllm.config import VllmConfig
 from vllm.config.utils import Range
 
 
@@ -46,11 +46,13 @@ class ProperPass(InductorPass):
         CallableInductorPass(simple_callable, InductorPass.hash_source(__file__)),
     ],
 )
-def test_pass_manager_uuid(callable):
+def test_pass_manager_uuid(callable, make_compile_test_model_config):
     # Set the pass context as PassManager uuid uses it
     with pass_context(Range(start=1, end=8)):
         # Some passes need dtype to be set
-        config = VllmConfig(model_config=ModelConfig(dtype=torch.bfloat16))
+        config = VllmConfig(
+            model_config=make_compile_test_model_config(dtype=torch.bfloat16)
+        )
 
         pass_manager = PostGradPassManager()
         pass_manager.configure(config)

--- a/tests/compile/passes/test_qk_norm_rope_fusion.py
+++ b/tests/compile/passes/test_qk_norm_rope_fusion.py
@@ -20,7 +20,6 @@ from vllm.compilation.passes.utility.split_coalescing import SplitCoalescingPass
 from vllm.config import (
     CompilationConfig,
     CompilationMode,
-    ModelConfig,
     PassConfig,
     VllmConfig,
     set_current_vllm_config,
@@ -132,6 +131,7 @@ def test_qk_norm_rope_fusion(
     enable_rope_custom_op,
     dtype,
     scattered_split,
+    make_compile_test_model_config,
 ):
     if not hasattr(torch.ops._C, "fused_qk_norm_rope"):
         pytest.skip("fused_qk_norm_rope custom op not available")
@@ -147,7 +147,7 @@ def test_qk_norm_rope_fusion(
         custom_ops.append("+rotary_embedding")
 
     vllm_config = VllmConfig(
-        model_config=ModelConfig(dtype=dtype),
+        model_config=make_compile_test_model_config(dtype=dtype),
         compilation_config=CompilationConfig(
             mode=CompilationMode.VLLM_COMPILE,
             custom_ops=custom_ops,

--- a/tests/compile/passes/test_rope_kvcache_fusion.py
+++ b/tests/compile/passes/test_rope_kvcache_fusion.py
@@ -20,7 +20,6 @@ from vllm.config import (
     CacheConfig,
     CompilationConfig,
     CompilationMode,
-    ModelConfig,
     PassConfig,
     VllmConfig,
 )
@@ -225,6 +224,7 @@ def test_rope_kvcache_fusion(
     dtype: torch.dtype,
     kv_cache_dtype: str,
     monkeypatch: pytest.MonkeyPatch,
+    make_compile_test_model_config,
 ):
     torch.set_default_device("cuda")
     torch.set_default_dtype(dtype)
@@ -235,7 +235,7 @@ def test_rope_kvcache_fusion(
         custom_ops.append("+rotary_embedding")
 
     vllm_config = VllmConfig(
-        model_config=ModelConfig(dtype=dtype),
+        model_config=make_compile_test_model_config(dtype=dtype),
         cache_config=CacheConfig(
             block_size=block_size,
             cache_dtype=kv_cache_dtype,

--- a/tests/compile/test_rotary_embedding_compile.py
+++ b/tests/compile/test_rotary_embedding_compile.py
@@ -8,7 +8,6 @@ import vllm.envs as envs
 from vllm.compilation.decorators import support_torch_compile
 from vllm.config import (
     CompilationConfig,
-    ModelConfig,
     VllmConfig,
     set_current_vllm_config,
 )
@@ -39,7 +38,9 @@ class RotaryEmbeddingCompileModule(torch.nn.Module):
 
 
 @pytest.mark.skipif(current_platform.is_cpu(), reason="Requires GPU for torch.compile")
-def test_rotary_embedding_torch_compile_with_custom_op(monkeypatch):
+def test_rotary_embedding_torch_compile_with_custom_op(
+    monkeypatch, make_compile_test_model_config
+):
     # Ensure env toggles take effect for this test only.
     # The bytecode hook is required to detect buffer mutation in compiled code,
     # and AOT compile bypasses that hook entirely.
@@ -53,7 +54,7 @@ def test_rotary_embedding_torch_compile_with_custom_op(monkeypatch):
     key = torch.randn(16, 32, device=device, dtype=torch.bfloat16)
 
     vllm_config = VllmConfig(
-        model_config=ModelConfig(dtype=torch.bfloat16),
+        model_config=make_compile_test_model_config(dtype=torch.bfloat16),
         compilation_config=CompilationConfig(
             mode=CompilationMode.VLLM_COMPILE,
             backend="inductor",


### PR DESCRIPTION
## Purpose

- Fix compile pass unit test CI stability by making the ModelConfig used in these tests explicit and hermetic.
- failure CI: `buildkite/ci/pytorch-compilation-passes-unit-tests`
    - https://buildkite.com/vllm/ci/builds/65291/canvas?jid=019e0a61-eb13-45e8-a45f-e2334f989865&tab=output

## Error message

```
[2026-05-09T02:23:49Z] FAILED compile/passes/test_qk_norm_rope_fusion.py::test_qk_norm_rope_fusion[dtype0-True-True-True-1e-06-False] - pydantic_core._pydantic_core.ValidationError: 1 validation error for ModelConfig
[2026-05-09T02:23:49Z]   Value error, Unrecognized model in Qwen/Qwen3-0.6B. Should have a `model_type` key in its config.json. [type=value_error, input_value=ArgsKwargs((), {'dtype': torch.bfloat16}), input_type=ArgsKwargs]
[2026-05-09T02:23:49Z]     For further information visit https://errors.pydantic.dev/2.12/v/value_error
```

## Root Cause

Some compile pass tests only need model metadata for hand-written test modules, but `ModelConfig(dtype=dtype)` silently falls back to the default Hugging Face model (`Qwen/Qwen3-0.6B`). That makes the tests depend on implicit HF config / tokenizer behavior even though they are not testing model loading.

## Code Change
- Add local compile-test model metadata fixtures for Qwen3 and Llama.
- Use the Qwen3 fixture for non-distributed compile tests that only need generic
  ModelConfig metadata.
- Use the Llama fixture for distributed compile tests that previously used
  RedHatAI/Llama-3.2-1B-Instruct-FP8 only as fake metadata.
- Skip tokenizer initialization so these tests do not depend on HF downloads,
  tokenizer files, or ModelConfig defaults.


## Test Plan

```python
python -m pytest -q \
  tests/compile/passes/test_qk_norm_rope_fusion.py \
  tests/compile/passes/test_functionalization.py \
  tests/compile/passes/test_fusion.py \
  tests/compile/passes/test_pass_manager.py \
  tests/compile/test_rotary_embedding_compile.py \
  --tb=short --disable-warnings
```

## Test Result
<img width="1914" height="317" alt="image" src="https://github.com/user-attachments/assets/ff312e47-e10f-48aa-919f-a83245f6bbeb" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

