### PR TITLE
add last_engine_iteration_timestamp_seconds in metric.

### DIFF
--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -435,10 +435,10 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         }
         per_engine_labelvalues = self.per_engine_labelvalues
 
-        gauge_last_iteration_ts = Gauge(
-            "vllm:last_engine_iteration_timestamp_seconds",
-            "Unix timestamp of the last engine iteration",
-            labelnames=["model_name", "engine"],
+        gauge_last_iteration_ts = self._gauge_cls(
+            name="vllm:last_engine_iteration_timestamp_seconds",
+            documentation="Unix timestamp of the last engine iteration",
+            labelnames=labelnames,
             multiprocess_mode="mostrecent",
         )
         self.gauge_last_iteration_ts = create_metric_per_engine(

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -435,6 +435,16 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
         }
         per_engine_labelvalues = self.per_engine_labelvalues
 
+        gauge_last_iteration_ts = Gauge(
+            "vllm:last_engine_iteration_timestamp_seconds",
+            "Unix timestamp of the last engine iteration",
+            labelnames=["model_name", "engine"],
+            multiprocess_mode="mostrecent",
+        )
+        self.gauge_last_iteration_ts = create_metric_per_engine(
+            gauge_last_iteration_ts, per_engine_labelvalues
+        )
+
         self.spec_decoding_prom = self._spec_decoding_cls(
             vllm_config.speculative_config, labelnames, per_engine_labelvalues
         )
@@ -1142,6 +1152,10 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
 
         if iteration_stats is None:
             return
+        self.gauge_last_iteration_ts[engine_idx].set(
+            iteration_stats.iteration_timestamp
+        )
+
         if envs.VLLM_COMPUTE_NANS_IN_LOGITS:
             self.counter_corrupted_requests[engine_idx].inc(
                 iteration_stats.num_corrupted_reqs


### PR DESCRIPTION



## Purpose
Expose timestamp of last engine iteration for observalibility. It can be used to detect engine core hang.

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

