### PR TITLE
[Bugfix][Quantization] Skip 'bias' tensors in online_process_loader

### DIFF
--- a/vllm/model_executor/model_loader/reload/meta.py
+++ b/vllm/model_executor/model_loader/reload/meta.py
@@ -28,6 +28,7 @@ SKIP_TENSORS: set[str] = {
     "expert_physical_to_global",
     "expert_local_to_global",
     "e_score_correction_bias",
+    "bias",
 }
 
 


### PR DESCRIPTION
 <!-- markdownlint-disable -->                                                                                                                                                                                                                        
                                                       
  ## Purpose                                                                                                                                                                                                                                           
                                                       
  `Fp8OnlineLinearMethod` (the dynamic FP8 path triggered by `--quantization fp8` on BF16 checkpoints) silently produces garbage tokens on any model with `bias=True` Linear layers (Qwen2, Qwen2.5, Qwen2.5-Omni's thinker LM, etc.). Architectures   
  without Linear bias (Qwen3, DiTs) are unaffected, which is why this regression has been latent — several FP8 D PRs have merged without exposing it.
                                                                                                                                                                                                                                                       
  **Root cause**: `vllm/model_executor/model_loader/reload/layerwise.py::initialize_online_processing` wraps every parameter's `weight_loader` with `online_process_loader`, deferring loads via `info.loaded_weights`. The skip set `SKIP_TENSORS` in 
  `meta.py` only excludes MoE-specific tensors, so regular Linear `bias` parameters get wrapped. Then `Fp8OnlineLinearMethod.process_weights_after_loading` only handles `weight` and `weight_scale` — the bias enters the deferred-load buffer but
  never gets re-emitted into the actual `bias` parameter, leaving it at its initial uninitialized value.                                                                                                                                               
                                                       
  `bias` is a small tensor (~14 KB for hidden=3584) that doesn't need deferred loading; it can go through the standard (non-deferred) load path like any non-quantized parameter.                                                                      
   
  **Architectural divide explains why this was latent:**                                                                                                                                                                                               
                                                       
  | Family | `qkv_proj` bias | FP8 D status before fix |                                                                                                                                                                                               
  |---|---|---|
  | Qwen2 / Qwen2.5 (`vllm/model_executor/models/qwen2.py:164` → `bias=True`) | True | ❌ garbage |                                                                                                                                                    
  | Qwen3 (`bias=qkv_bias`, defaulting to `False` via `getattr(config, "attention_bias", False)`) | False | ✅ working |                                                                                                                               
  | DiT-style models (Helios, HunyuanVideo, Z-Image, Wan, etc.) | False | ✅ working |                                                                                                                                                                 
                                                                                                                                                                                                                                                       
  This is the diff:                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                       
  ```diff                                                                                                                                                                                                                                              
   SKIP_TENSORS: set[str] = {                          
       "_expert_map",
       "expert_mask",
       "expert_global_to_physical",
       "expert_physical_to_global",
       "expert_local_to_global",
       "e_score_correction_bias",
  +    "bias",
   }
  ```

  ## Test Plan                                                                                                                                                                                                                                         
   
  Minimal reproducer (no extra dependencies, pure vLLM):                                                                                                                                                                                               
                                                       
  ```python                                                                                                                                                                                                                                            
  from vllm import LLM, SamplingParams                 

  llm = LLM(
      model="Qwen/Qwen2.5-7B-Instruct",
      quantization="fp8",                                                                                                                                                                                                                              
      enforce_eager=True,
      gpu_memory_utilization=0.85,                                                                                                                                                                                                                     
      max_model_len=2048,                              
  )                                                                                                                                                                                                                                                    
  sp = SamplingParams(temperature=0.0, max_tokens=80, seed=42)
  prompt = "<|im_start|>user\nExplain photosynthesis in one paragraph.<|im_end|>\n<|im_start|>assistant\n"                                                                                                                                             
  print(llm.generate([prompt], sp)[0].outputs[0].text)                                                                                                                                                                                                 
  ```
                                                                                                                                                                                                                                                       
  Run before and after applying this fix; compare outputs.                                                                                                                                                                                             
   
  Hardware tested: RTX 4090 (Ada sm_89) and RTX 5090 (Blackwell sm_120).                                                                                                                                                                               
  vLLM versions: 0.20.0 and 0.20.1 — both affected before fix, both coherent after fix.
                                                                                                                                                                                                                                                       
  ## Test Result                                       

  **Before this fix** (`Qwen/Qwen2.5-7B-Instruct` + `quantization="fp8"`):                                                                                                                                                                             
  ```
  月\views.                                                                                                                                                                                                                                            
  ```                                                  

  **After this fix** (same command):                                                                                                                                                                                                                   
  ```
  Photosynthesis is the process by which plants, algae, and some bacteria convert                                                                                                                                                                      
  light energy, usually from the sun, into chemical energy stored in glucose
  molecules. This process primarily occurs in the chloroplasts of plant cells,                                                                                                                                                                         
  where chlorophyll pigments capture sunlight and use it to convert ca
  ```                                                                                                                                                                                                                                                  
                                                       
  BF16 baseline (no quantization) for reference:                                                                                                                                                                                                       
  ```                                                  
  Photosynthesis is the process by which plants, algae, and some bacteria convert                                                                                                                                                                      
  light energy, usually from the sun, into chemical energy stored in glucose
  molecules. This process primarily occurs in the chloroplasts of plant cells,                                                                                                                                                                         
  where chlorophyll pigments absorb sunlight. The light energy is used
  ```                                                                                                                                                                                                                                                  
                                                       
  The post-fix FP8 output is a near-paraphrase of BF16, as expected for FP8 dynamic quantization.                                                                                                                                                      
                                                       
  **End-to-end multimodal test** with `Qwen/Qwen2.5-Omni-7B` via vLLM-Omni stage pipeline (audio + image + video input):                                                                                                                               
  - Before fix: garbage tokens like `汆ESPNstile糖尿achsen gunshot...`
  - After fix: coherent text correctly describing the audio recitation, image content, and video humor — semantically matching BF16 baseline.                                                                                                          
                                                                                                                                                                                                                                                       
  **Bisection chain leading to root cause:**                                                                                                                                                                                                           
  1. Initial garbage observed on RTX 5090 with Qwen2.5-Omni → switched to RTX 4090, same garbage → ruled out sm_120-specific FP8 kernel issues.                                                                                                        
  2. Plain `vllm.LLM` + Qwen2.5-7B-Instruct + FP8 reproduces → ruled out vLLM-Omni / multimodal interaction.                                                                                                                                           
  3. `VLLM_BATCH_INVARIANT=1` (forces dequant→BF16 GEMM, bypasses cutlass FP8 kernel) → still garbage → ruled out FP8 GEMM kernel.                                                                                                                     
  4. Probes in `Fp8OnlineLinearMethod.process_weights_after_loading` confirm weight loads correctly (BF16, real Qwen2 weights, abs_max ≈ 0.51) and `scaled_fp8_quant` produces sensible outputs (qweight max=448, scale ≈ max(|w|)/448 = 0.001142) →   
  ruled out weight loading and quantization math.                                                                                                                                                                                                      
  5. Qwen3-1.7B + FP8 produces coherent output → narrowed scope to Qwen2 architecture specifically.                                                                                                                                                    
  6. Identified `bias=True` difference between Qwen2 (`bias=True` at qwen2.py:164) and Qwen3 (`bias=qkv_bias`, defaults False).                                                                                                                        
  7. Adding `"bias"` to `SKIP_TENSORS` → coherent output across all tested models and hardware.                                                                                                                                                        
                                                                                                                                                                                                                                                       
  ---                                                                                                                                                                                                                                                  
  <details>                                                                                                                                                                                                                                            
  <summary> Essential Elements of an Effective PR Description Checklist </summary>

  - [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".                                                                                                                                                   
  - [x] The test plan, such as providing test command.
  - [x] The test results, such as pasting the results comparison before and after, or e2e results                                                                                                                                                      
  - [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.                                                                                                                          
  </details>
                                                                                                                                                                                                                                                       
  