### PR TITLE
[WIP][Probe] Force enforce_eager in test_async_scheduling — DO NOT MERGE

### DIFF
--- a/tests/v1/e2e/general/test_async_scheduling.py
+++ b/tests/v1/e2e/general/test_async_scheduling.py
@@ -1,6 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
-import os
 from itertools import repeat
 from typing import Any
 
@@ -24,7 +23,9 @@ MODEL = "Qwen/Qwen3-0.6B"
 MTP_MODEL = "meta-llama/Llama-3.2-1B-Instruct"
 
 # Need to enforce eager for MRV2 while we sort out cudagraph issues.
-ENFORCE_EAGER = os.getenv("ENFORCE_EAGER", "0") == "1"
+# PROBE: force eager (cudagraphs disabled) to test if cudagraph capture is the
+# source of bit-level divergence between async/preempted configs and baseline.
+ENFORCE_EAGER = True
 
 first_prompt = (
     "The following numbers of the sequence "


### PR DESCRIPTION
## Purpose

Investigation probe — **do not merge**. Companion to draft PR [#42041](https://github.com/vllm-project/vllm/pull/42041).

This branch disables cudagraph capture (`enforce_eager=True`) in `test_async_scheduling::test_without_spec_decoding` to determine whether the rank-flip failure observed across 8 builds (e2e Scheduling 1 GPU, see #42041) is caused by cudagraph capturing different kernel choices between async-scheduled and sync baseline configs.

The failure signature on H200 is always: token id 2701 at one prompt position flips between rank 5217 and 5218 with logprob delta ~1.9e-9. Strict rank equality in `_logprobs_match` then fails. We've established the failure does not reproduce on H20-3e (tested 3× full GPU + 3× MIG 2g.35gb 16-SM slice = matched CI's 16 SMs) or GB10. So the divergence is specific to H200 + CI library stack.

This probe isolates one hypothesis. If 5 retries on Buildkite all PASS with eager mode, cudagraph capture is the source. If they still fail with the same signature, we move on to other probes (deterministic cuBLAS algos, attention backend swap, intermediate logit dumps).

## Test Plan

## Test Result