### PR TITLE
[Bugfix][V1] Defensive guard for stale req_id in `_update_after_schedule`

### DIFF
--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -941,7 +941,19 @@ class Scheduler(SchedulerInterface):
         #    computed tokens will be adjusted in update_from_output.
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
         for req_id, num_scheduled_token in num_scheduled_tokens.items():
-            request = self.requests[req_id]
+            # Guard against stale req_id removed by finish_requests() between
+            # schedule build and post-schedule update. Surfaces in multi-stage
+            # serving paths (e.g. vllm-omni) where an async abort/finish can
+            # race with schedule(). Same defensive `.get()` pattern is already
+            # used elsewhere in this file (e.g. lines around 1296, 1606, 1633).
+            request = self.requests.get(req_id)
+            if request is None:
+                logger.debug(
+                    "Skipping stale req_id %s in _update_after_schedule "
+                    "(likely finished/aborted concurrently)",
+                    req_id,
+                )
+                continue
             request.num_computed_tokens += num_scheduled_token
             request.is_prefill_chunk = request.num_computed_tokens < (
                 request.num_tokens + request.num_output_placeholders


### PR DESCRIPTION
### Summary

Add a defensive guard in `_update_after_schedule()` to handle stale `req_id` (request finished/aborted concurrently). Aligns with the existing `self.requests.get(req_id)` convention already used elsewhere in the same file.

**This PR is not a fix for the underlying race.** It only prevents the engine from hard-failing when the race manifests. The race itself (e.g. abort/finish ordering) is a separate concern and out of scope here.

### Change

`vllm/v1/core/sched/scheduler.py` — `_update_after_schedule()`:

```diff
         num_scheduled_tokens = scheduler_output.num_scheduled_tokens
         for req_id, num_scheduled_token in num_scheduled_tokens.items():
-            request = self.requests[req_id]
+            request = self.requests.get(req_id)
+            if request is None:
+                logger.debug(
+                    "Skipping stale req_id %s in _update_after_schedule "
+                    "(likely finished/aborted concurrently)",
+                    req_id,
+                )
+                continue
             request.num_computed_tokens += num_scheduled_token
```

### Why a defensive guard, not a race fix

- `_update_after_schedule()` is post-schedule accounting (advances `num_computed_tokens`). Skipping a stale id means that one request's accounting is dropped — it has no effect on KV cache state or scheduler invariants for surviving requests.
- The same file already follows this defensive convention at lines 1235, 1296, 1606, 1633, 1715. Lines 944 (this PR), 1446, 2049, and 2054 are the remaining unchecked `self.requests[req_id]` callsites; this PR fixes the one that's actively crashing engines in the wild.
- A real race fix (engine loop ordering, synchronization, etc.) is a much larger change and belongs in a separate PR — see #26400 for prior discussion of the ordering side.

### Test

Local reproducer using vllm-omni's MiniCPM-o-Demo (`backend=vllm_omni`) over realtime WebSocket. Before the patch, cancelling an in-flight request crashes the engine core with the `KeyError` shown in the linked issue. After the patch, the stale id is logged at debug level and the engine continues normally on the next step.

No existing test impact (the surviving path is unchanged).

### Risk

Minimal. Same defensive pattern already used in the same file. No state-corruption risk — this runs after `super().schedule()` completes, before model execution; dropping post-schedule accounting for an already-finished request is correct behavior.

### Related
Closes #42157

Related: #26400 (different layer), #25991 (different surface, same broader pattern).
