### PR TITLE
fix: honor CUDA graph memory profiling opt-out

### DIFF
--- a/tests/v1/worker/test_gpu_worker_memory_profiling.py
+++ b/tests/v1/worker/test_gpu_worker_memory_profiling.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import vllm.v1.worker.gpu_worker as gpu_worker
+from vllm.config import CUDAGraphMode
+from vllm.utils.mem_utils import MemorySnapshot
+from vllm.v1.worker.gpu_worker import Worker
+
+
+@contextmanager
+def fake_memory_profiling(
+    init_snapshot: MemorySnapshot,
+    weights_memory: int,
+) -> Iterator[SimpleNamespace]:
+    profile_result = SimpleNamespace(
+        before_profile=SimpleNamespace(torch_peak=100),
+        after_profile=SimpleNamespace(free_memory=90_000),
+        non_torch_increase=1_000,
+        weights_memory=weights_memory,
+        torch_peak_increase=0,
+        non_kv_cache_memory=0,
+    )
+    yield profile_result
+
+
+def make_worker() -> Worker:
+    worker = object.__new__(Worker)
+    worker.device = "cuda:0"
+    worker.init_snapshot = MemorySnapshot(
+        torch_peak=0,
+        free_memory=100_000,
+        total_memory=200_000,
+        device="cpu",
+        auto_measure=False,
+    )
+    worker.requested_memory = 100_000
+    worker.cache_config = SimpleNamespace(
+        kv_cache_memory_bytes=None,
+        gpu_memory_utilization=0.5,
+    )
+    worker.vllm_config = SimpleNamespace(
+        compilation_config=SimpleNamespace(cudagraph_mode=CUDAGraphMode.FULL),
+    )
+    worker.model_runner = MagicMock()
+    worker.model_runner.model_memory_usage = 4_000
+    worker.model_runner.profile_run.return_value = None
+    return worker
+
+
+def patch_memory_profiling_dependencies(monkeypatch) -> None:
+    monkeypatch.setattr(gpu_worker.current_platform, "is_cuda", lambda: True)
+    monkeypatch.setattr(gpu_worker, "memory_profiling", fake_memory_profiling)
+    monkeypatch.setattr(
+        gpu_worker.torch.accelerator,
+        "memory_stats",
+        lambda device: {"allocated_bytes.all.peak": 300},
+    )
+
+
+def test_determine_available_memory_skips_cudagraph_profile_when_env_disabled(
+    monkeypatch,
+):
+    worker = make_worker()
+    worker.model_runner.profile_cudagraph_memory.side_effect = AssertionError(
+        "CUDA graph memory profiling should not run when disabled"
+    )
+
+    monkeypatch.setattr(
+        gpu_worker.envs,
+        "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS",
+        False,
+    )
+    patch_memory_profiling_dependencies(monkeypatch)
+
+    available_memory = Worker.determine_available_memory(worker)
+
+    assert available_memory == 94_800
+    worker.model_runner.profile_run.assert_called_once_with()
+    worker.model_runner.profile_cudagraph_memory.assert_not_called()
+    assert worker.cudagraph_memory_estimate == 0
+    assert worker.non_torch_memory == 1_000
+    assert worker.peak_activation_memory == 200
+    assert worker.available_kv_cache_memory_bytes == 94_800
+
+
+def test_determine_available_memory_applies_cudagraph_estimate_when_env_enabled(
+    monkeypatch,
+):
+    worker = make_worker()
+    worker.model_runner.profile_cudagraph_memory.return_value = 8_192
+
+    monkeypatch.setattr(
+        gpu_worker.envs,
+        "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS",
+        True,
+    )
+    patch_memory_profiling_dependencies(monkeypatch)
+
+    available_memory = Worker.determine_available_memory(worker)
+
+    assert available_memory == 86_608
+    worker.model_runner.profile_run.assert_called_once_with()
+    worker.model_runner.profile_cudagraph_memory.assert_called_once_with()
+    assert worker.cudagraph_memory_estimate == 8_192
+    assert worker.non_torch_memory == 1_000
+    assert worker.peak_activation_memory == 200
+    assert worker.available_kv_cache_memory_bytes == 86_608
+
+
+def test_determine_available_memory_skips_cudagraph_profile_when_cudagraphs_disabled(
+    monkeypatch,
+):
+    worker = make_worker()
+    worker.vllm_config.compilation_config.cudagraph_mode = CUDAGraphMode.NONE
+    worker.model_runner.profile_cudagraph_memory.side_effect = AssertionError(
+        "CUDA graph memory profiling should not run when cudagraphs are disabled"
+    )
+
+    monkeypatch.setattr(
+        gpu_worker.envs,
+        "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS",
+        True,
+    )
+    patch_memory_profiling_dependencies(monkeypatch)
+
+    available_memory = Worker.determine_available_memory(worker)
+
+    assert available_memory == 94_800
+    worker.model_runner.profile_run.assert_called_once_with()
+    worker.model_runner.profile_cudagraph_memory.assert_not_called()
+    assert worker.cudagraph_memory_estimate == 0
+    assert worker.available_kv_cache_memory_bytes == 94_800

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -502,13 +502,6 @@ class Worker(WorkerBase):
             + profile_result.weights_memory
         )
 
-        # Respect the opt-in flag as originally designed.
-        cudagraph_memory_estimate_applied = (
-            cudagraph_memory_estimate
-            if envs.VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS
-            else 0
-        )
-
         self.non_torch_memory = profile_result.non_torch_increase
         self.peak_activation_memory = profile_result.torch_peak_increase
         self.cudagraph_memory_estimate = cudagraph_memory_estimate
@@ -528,7 +521,7 @@ class Worker(WorkerBase):
         self.available_kv_cache_memory_bytes = (
             self.requested_memory
             - profile_result.non_kv_cache_memory
-            - cudagraph_memory_estimate_applied
+            - cudagraph_memory_estimate
         )
 
         unrequested_memory = self.init_snapshot.free_memory - self.requested_memory
@@ -553,40 +546,23 @@ class Worker(WorkerBase):
             total_mem = self.init_snapshot.total_memory
             current_util = self.cache_config.gpu_memory_utilization
             cg_util_delta = cudagraph_memory_estimate / total_mem
-            if envs.VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS:
-                equiv_util = round(current_util - cg_util_delta, 4)
-                suggested_util = min(
-                    round(current_util + cg_util_delta, 4),
-                    1.0,
-                )
-                logger.info(
-                    "CUDA graph memory profiling is enabled (default since "
-                    "v0.21.0). The current --gpu-memory-utilization=%.4f is "
-                    "equivalent to --gpu-memory-utilization=%.4f without "
-                    "CUDA graph memory profiling. To maintain the same "
-                    "effective KV cache size as before, increase "
-                    "--gpu-memory-utilization to %.4f. To disable, set "
-                    "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0.",
-                    current_util,
-                    equiv_util,
-                    suggested_util,
-                )
-            else:
-                suggested_util = min(
-                    round(current_util + cg_util_delta, 4),
-                    1.0,
-                )
-                logger.warning(
-                    "CUDA graph memory profiling is disabled "
-                    "(VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0). "
-                    "Without it, CUDA graph memory is not accounted for "
-                    "during KV cache allocation, which may require lowering "
-                    "--gpu-memory-utilization to avoid OOM. Consider "
-                    "re-enabling it (the default as of v0.21.0) and increasing "
-                    "--gpu-memory-utilization from %.4f to %.4f.",
-                    current_util,
-                    suggested_util,
-                )
+            equiv_util = round(current_util - cg_util_delta, 4)
+            suggested_util = min(
+                round(current_util + cg_util_delta, 4),
+                1.0,
+            )
+            logger.info(
+                "CUDA graph memory profiling is enabled (default since "
+                "v0.21.0). The current --gpu-memory-utilization=%.4f is "
+                "equivalent to --gpu-memory-utilization=%.4f without "
+                "CUDA graph memory profiling. To maintain the same "
+                "effective KV cache size as before, increase "
+                "--gpu-memory-utilization to %.4f. To disable, set "
+                "VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0.",
+                current_util,
+                equiv_util,
+                suggested_util,
+            )
 
         return self._reserve_mm_ipc_gpu_memory(
             int(self.available_kv_cache_memory_bytes)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -485,7 +485,8 @@ class Worker(WorkerBase):
             # XPU stays excluded (see #39977).
             cudagraph_memory_estimate = 0
             if (
-                current_platform.is_cuda_alike()
+                envs.VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS
+                and current_platform.is_cuda_alike()
                 and self.vllm_config.compilation_config.cudagraph_mode
                 != CUDAGraphMode.NONE
             ):


### PR DESCRIPTION
## Summary

- Honor `VLLM_MEMORY_PROFILER_ESTIMATE_CUDAGRAPHS=0` before running CUDA graph memory profiling.
- Avoid allocating the temporary profiling KV cache when CUDA graph memory estimation is disabled.
- Add CPU-only unit coverage for disabled/enabled profiling and `CUDAGraphMode.NONE`.

Fixes #42147.

## Duplicate-work check

- Checked issue comments for #42147.
- Checked open PRs for `42147 in:body`: no matches.
- Checked open PRs for CUDA graph memory profiling keywords: no duplicate fix for this env-var behavior found.

## Test plan

- `git diff --staged --check`
- `.venv/bin/python -m pytest tests/v1/worker/test_gpu_worker_memory_profiling.py -q`
- `.venv/bin/pre-commit run --files vllm/v1/worker/gpu_worker.py tests/v1/worker/test_gpu_worker_memory_profiling.py`
