### PR TITLE
Fix Molmo2 image token metadata

### DIFF
--- a/tests/models/multimodal/processing/test_molmo2.py
+++ b/tests/models/multimodal/processing/test_molmo2.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import torch
+
+from vllm.model_executor.models.molmo2 import build_flat_image_bool_length
+
+
+def test_build_flat_image_bool_length_matches_molmoweb_processor_tokens():
+    hf_config = SimpleNamespace(
+        image_patch_id=151938,
+        low_res_image_start_token_id=151940,
+        image_start_token_id=151936,
+        image_col_id=151939,
+        image_end_token_id=151937,
+    )
+    image_grids = torch.tensor([[14, 14, 14, 23]], dtype=torch.long)
+
+    image_tokens, num_image_tokens = build_flat_image_bool_length(
+        image_grids,
+        hf_config,
+        image_use_col_tokens=True,
+        use_single_crop_col_tokens=None,
+        use_single_crop_start_token=False,
+    )
+
+    assert num_image_tokens.tolist() == [550]
+    assert len(image_tokens) == 550
+    assert image_tokens[0].item() == hf_config.image_start_token_id
+    assert (image_tokens == hf_config.image_col_id).sum().item() == 28
+
+
+def test_build_flat_image_bool_length_respects_disabled_col_tokens():
+    hf_config = SimpleNamespace(
+        image_patch_id=151938,
+        low_res_image_start_token_id=151940,
+        image_start_token_id=151936,
+        image_col_id=151939,
+        image_end_token_id=151937,
+    )
+    image_grids = torch.tensor([[2, 3, 5, 7]], dtype=torch.long)
+
+    image_tokens, num_image_tokens = build_flat_image_bool_length(
+        image_grids,
+        hf_config,
+        image_use_col_tokens=False,
+        use_single_crop_col_tokens=False,
+        use_single_crop_start_token=True,
+    )
+
+    assert num_image_tokens.tolist() == [45]
+    assert len(image_tokens) == 45
+    assert image_tokens[0].item() == hf_config.low_res_image_start_token_id
+    assert (image_tokens == hf_config.image_col_id).sum().item() == 0

--- a/vllm/model_executor/models/molmo2.py
+++ b/vllm/model_executor/models/molmo2.py
@@ -1338,6 +1338,9 @@ def exif_transpose(
 def build_flat_image_bool_length(
     image_grids: torch.LongTensor,
     hf_config: PretrainedConfig,
+    image_use_col_tokens: bool = True,
+    use_single_crop_col_tokens: bool | None = None,
+    use_single_crop_start_token: bool = True,
 ) -> tuple[torch.LongTensor, torch.LongTensor]:
     image_patch_id = hf_config.image_patch_id
     low_res_image_start_id = hf_config.low_res_image_start_token_id
@@ -1353,7 +1356,17 @@ def build_flat_image_bool_length(
     h = image_grids[:, 2]
     w = image_grids[:, 3]
 
-    lengths = resized_h * resized_w + h * (w + 1) + 4  # [B]
+    low_res_use_col_tokens = (
+        image_use_col_tokens
+        if use_single_crop_col_tokens is None
+        else use_single_crop_col_tokens
+    )
+    low_res_extra = int(low_res_use_col_tokens)
+    high_res_extra = int(image_use_col_tokens)
+
+    lengths = resized_h * (resized_w + low_res_extra) + h * (
+        w + high_res_extra
+    ) + 4  # [B]
     total_len = int(lengths.sum().item())
 
     flat = torch.empty(total_len, dtype=torch.long, device=device)
@@ -1363,16 +1376,24 @@ def build_flat_image_bool_length(
         resized_h_i, resized_w_i, h_i, w_i = image_grids[i].tolist()
         L_i = int(lengths[i].item())
 
-        num_low_res_patches = resized_h_i * resized_w_i
-
         idx = offset
 
-        flat[idx] = low_res_image_start_id
+        flat[idx] = (
+            low_res_image_start_id if use_single_crop_start_token else image_start_id
+        )
         idx += 1
 
-        if num_low_res_patches > 0:
-            flat[idx : idx + num_low_res_patches] = image_patch_id
-            idx += num_low_res_patches
+        low_res_block_len = resized_w_i + low_res_extra
+        if low_res_block_len > 0 and resized_h_i > 0:
+            line = torch.empty(low_res_block_len, dtype=torch.long, device=device)
+            if resized_w_i > 0:
+                line[:resized_w_i] = image_patch_id
+            if low_res_use_col_tokens:
+                line[resized_w_i] = image_col_id
+
+            block = line.repeat(resized_h_i)
+            flat[idx : idx + resized_h_i * low_res_block_len] = block
+            idx += resized_h_i * low_res_block_len
 
         flat[idx] = image_end_id
         idx += 1
@@ -1380,12 +1401,13 @@ def build_flat_image_bool_length(
         flat[idx] = image_start_id
         idx += 1
 
-        block_len = w_i + 1
+        block_len = w_i + high_res_extra
         if block_len > 0 and h_i > 0:
             line = torch.empty(block_len, dtype=torch.long, device=device)
             if w_i > 0:
                 line[:w_i] = image_patch_id
-            line[w_i] = image_col_id
+            if image_use_col_tokens:
+                line[w_i] = image_col_id
 
             block = line.repeat(h_i)
             flat[idx : idx + h_i * block_len] = block
@@ -2108,7 +2130,13 @@ class Molmo2MultiModalProcessor(BaseMultiModalProcessor[Molmo2ProcessingInfo]):
             (
                 processed_outputs["image_tokens"],
                 processed_outputs["num_image_tokens"],
-            ) = build_flat_image_bool_length(image_grids, hf_config)
+            ) = build_flat_image_bool_length(
+                image_grids,
+                hf_config,
+                image_use_col_tokens=hf_processor.image_use_col_tokens,
+                use_single_crop_col_tokens=hf_processor.use_single_crop_col_tokens,
+                use_single_crop_start_token=hf_processor.use_single_crop_start_token,
+            )
 
         return BatchFeature({**processed_outputs, **all_video_outputs})
 


### PR DESCRIPTION
## Summary

Fixes the Molmo2 image-token metadata path so the image tokens used to build multimodal embeddings match the prompt replacements generated from the Hugging Face Molmo2 processor semantics.

The concrete mismatch found while debugging `allenai/MolmoWeb-4B` was:

```text
prompt image placeholder tokens: 550
multimodal image embeddings:    536
missing: 14 low-res row column tokens
```

The CUDA assert originally surfaced later in the attention stack around `mm_prefix_range_tensor`, but with launch blocking/instrumentation the earliest failing invariant was the `_merge_multimodal_embeddings` token/embedding count mismatch.

## Root Cause

`Molmo2MultiModalProcessor._get_prompt_updates()` honors processor fields such as:

- `image_use_col_tokens`
- `use_single_crop_col_tokens`
- `use_single_crop_start_token`

but `build_flat_image_bool_length()` used a hard-coded low-res token layout. For MolmoWeb-style processor configs, vLLM generated a prompt with low-res column tokens and no low-res start token, while the image embedding metadata omitted those low-res column tokens.

## Fix

Update `build_flat_image_bool_length()` to accept the same processor semantic flags and pass those values from the HF processor in `_call_hf_processor()`.

This keeps the Molmo2 invariant intact:

```text
number of selected image placeholder tokens == number of multimodal image embeddings
```

## Duplicate Work Check

Per `AGENTS.md`, I checked for existing work before opening this PR:

```bash
gh issue view 38660 --repo vllm-project/vllm --comments
gh pr list --repo vllm-project/vllm --state open --search '38660 in:body'
gh pr list --repo vllm-project/vllm --state open --search 'Molmo2 image token'
gh pr list --repo vllm-project/vllm --state open --search 'MolmoWeb'
```

No open PR was found that addresses this Molmo2 token metadata mismatch. The only hit for `Molmo2 image token` was an unrelated frontend upload PR.

## Validation

Code checks:

```bash
/home/v-haoqiwang/cua-eval-harness/.venv/bin/python -m ruff check \
  tests/models/multimodal/processing/test_molmo2.py \
  vllm/model_executor/models/molmo2.py
# All checks passed
```

Targeted pytest was attempted but this ad-hoc source checkout does not have the full vLLM test dependency set installed:

```text
ModuleNotFoundError: No module named 'cachetools'
```

Runtime validation on A100 80GB with a local patched vLLM environment:

- `allenai/MolmoWeb-4B` equivalent local HF snapshot completed a full WebVoyager run through vLLM with:
  - `12317` vLLM requests finished with `stop`
  - `0` vLLM requests finished with `length`
  - `0` vLLM requests finished with `error`
  - no `masked_scatter`, `mm_prefix_range_tensor`, or CUDA assert in vLLM logs
- `allenai/Molmo2-8B` control run through ordinary `Molmo2ForConditionalGeneration` returned:
  - HTTP 200
  - `finish_reason=stop`
  - `prompt_tokens=1212`
  - `completion_tokens=67`
  - no CUDA assert or multimodal merge error

## AI Assistance Disclosure

AI assistance was used to investigate the logs, isolate the failing invariant, prepare this patch, and draft this PR description. The human submitter should review every changed line and the validation evidence before marking this PR ready for review.

Fixes #38660.
