### PR TITLE
[Bugfix][V1] Warm up slot mapping before JIT monitor

### DIFF
--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -9,6 +9,7 @@ import pytest
 import torch
 import torch.nn as nn
 
+import vllm.v1.worker.gpu.warmup as gpu_warmup
 import vllm.v1.worker.gpu_model_runner as gpu_model_runner_module
 from vllm.config import (
     AttentionConfig,
@@ -57,6 +58,105 @@ from vllm.v1.worker.utils import select_common_block_size
 BLOCK_SIZE = 16
 NUM_BLOCKS = 10
 DEVICE_TYPE = current_platform.device_type
+
+
+class _FakeV1WarmupBlockTable:
+    def __init__(self):
+        self.block_tables = [object(), object()]
+        self.calls = []
+
+    def add_row(self, block_ids, row_idx):
+        self.calls.append(("add_row", block_ids, row_idx))
+
+    def commit_block_table(self, num_reqs):
+        self.calls.append(("commit_block_table", num_reqs))
+
+    def compute_slot_mapping(self, num_reqs, query_start_loc, positions):
+        self.calls.append(
+            (
+                "compute_slot_mapping",
+                num_reqs,
+                query_start_loc.detach().cpu().tolist(),
+                positions.detach().cpu().tolist(),
+                query_start_loc.dtype,
+                positions.dtype,
+            )
+        )
+
+    def clear_row(self, row_idx):
+        self.calls.append(("clear_row", row_idx))
+
+
+def _make_v1_slot_mapping_warmup_runner_stub(block_table=None, num_blocks=12):
+    if block_table is None:
+        block_table = _FakeV1WarmupBlockTable()
+    return SimpleNamespace(
+        device=torch.device("cpu"),
+        kv_cache_config=SimpleNamespace(num_blocks=num_blocks),
+        input_batch=SimpleNamespace(block_table=block_table),
+    )
+
+
+def test_v1_warmup_runs_slot_mapping_and_clears_temporary_row(monkeypatch):
+    monkeypatch.setattr(gpu_warmup.torch.accelerator, "synchronize", lambda: None)
+
+    block_table = _FakeV1WarmupBlockTable()
+    runner = _make_v1_slot_mapping_warmup_runner_stub(block_table)
+
+    gpu_warmup.warmup_v1_slot_mapping_kernel(runner)
+
+    assert block_table.calls == [
+        ("add_row", ([1], [1]), 0),
+        ("commit_block_table", 1),
+        (
+            "compute_slot_mapping",
+            1,
+            [0, 1],
+            [0],
+            torch.int32,
+            torch.int64,
+        ),
+        ("clear_row", 0),
+        ("commit_block_table", 1),
+    ]
+
+
+def test_v1_warmup_clears_row_on_slot_mapping_error(monkeypatch):
+    monkeypatch.setattr(gpu_warmup.torch.accelerator, "synchronize", lambda: None)
+
+    block_table = _FakeV1WarmupBlockTable()
+
+    def raise_on_compute(*args):
+        block_table.calls.append(("compute_slot_mapping_error",))
+        raise RuntimeError("test error")
+
+    monkeypatch.setattr(block_table, "compute_slot_mapping", raise_on_compute)
+    runner = _make_v1_slot_mapping_warmup_runner_stub(block_table)
+
+    with pytest.raises(RuntimeError, match="test error"):
+        gpu_warmup.warmup_v1_slot_mapping_kernel(runner)
+
+    assert block_table.calls == [
+        ("add_row", ([1], [1]), 0),
+        ("commit_block_table", 1),
+        ("compute_slot_mapping_error",),
+        ("clear_row", 0),
+        ("commit_block_table", 1),
+    ]
+
+
+def test_v1_warmup_skips_without_usable_kv_block(monkeypatch):
+    monkeypatch.setattr(gpu_warmup.torch.accelerator, "synchronize", lambda: None)
+
+    block_table = _FakeV1WarmupBlockTable()
+    runner = _make_v1_slot_mapping_warmup_runner_stub(
+        block_table,
+        num_blocks=1,
+    )
+
+    gpu_warmup.warmup_v1_slot_mapping_kernel(runner)
+
+    assert block_table.calls == []
 
 
 def initialize_kv_cache(runner: GPUModelRunner):

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -93,6 +93,8 @@ def _make_v1_slot_mapping_warmup_runner_stub(block_table=None, num_blocks=12):
     return SimpleNamespace(
         device=torch.device("cpu"),
         kv_cache_config=SimpleNamespace(num_blocks=num_blocks),
+        max_model_len=128,
+        max_num_tokens=128,
         input_batch=SimpleNamespace(block_table=block_table),
     )
 
@@ -108,6 +110,22 @@ def test_v1_warmup_runs_slot_mapping_and_clears_temporary_row(monkeypatch):
     assert block_table.calls == [
         ("add_row", ([1], [1]), 0),
         ("commit_block_table", 1),
+        (
+            "compute_slot_mapping",
+            1,
+            [0, 128],
+            list(range(128)),
+            torch.int32,
+            torch.int64,
+        ),
+        (
+            "compute_slot_mapping",
+            1,
+            [0, 2],
+            [0, 1],
+            torch.int32,
+            torch.int64,
+        ),
         (
             "compute_slot_mapping",
             1,

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -152,3 +152,35 @@ def warmup_kernels(
     worker_execute_model(cleanup_output)
     model_runner.kv_connector.set_disabled(False)
     torch.accelerator.synchronize()
+
+
+@torch.inference_mode()
+def warmup_v1_slot_mapping_kernel(model_runner: Any) -> None:
+    """Warm up V1 slot mapping without running model-specific forward paths.
+
+    V1 request input preparation calls `BlockTable.compute_slot_mapping()`.
+    The legacy `_dummy_run()` path does not exercise this kernel, and synthetic
+    `execute_model()` warmups are not model-agnostic. Compile the slot mapping
+    kernel directly before the JIT monitor is enabled.
+    """
+    block_table = model_runner.input_batch.block_table
+
+    if not block_table.block_tables:
+        return
+
+    # Block 0 is the null block. Use block 1 only when it is available.
+    if model_runner.kv_cache_config.num_blocks <= 1:
+        return
+
+    device = model_runner.device
+    block_table.add_row(tuple([1] for _ in block_table.block_tables), 0)
+    block_table.commit_block_table(1)
+    query_start_loc = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    positions = torch.zeros(1, dtype=torch.int64, device=device)
+
+    try:
+        block_table.compute_slot_mapping(1, query_start_loc, positions)
+        torch.accelerator.synchronize()
+    finally:
+        block_table.clear_row(0)
+        block_table.commit_block_table(1)

--- a/vllm/v1/worker/gpu/warmup.py
+++ b/vllm/v1/worker/gpu/warmup.py
@@ -175,11 +175,23 @@ def warmup_v1_slot_mapping_kernel(model_runner: Any) -> None:
     device = model_runner.device
     block_table.add_row(tuple([1] for _ in block_table.block_tables), 0)
     block_table.commit_block_table(1)
-    query_start_loc = torch.tensor([0, 1], dtype=torch.int32, device=device)
-    positions = torch.zeros(1, dtype=torch.int64, device=device)
+    max_warmup_tokens = min(
+        model_runner.max_num_tokens,
+        model_runner.max_model_len,
+        1024,
+    )
+    warmup_sizes: list[int] = []
+    for num_tokens in (max_warmup_tokens, min(max_warmup_tokens, 2), 1):
+        if num_tokens > 0 and num_tokens not in warmup_sizes:
+            warmup_sizes.append(num_tokens)
 
     try:
-        block_table.compute_slot_mapping(1, query_start_loc, positions)
+        for num_tokens in warmup_sizes:
+            query_start_loc = torch.tensor(
+                [0, num_tokens], dtype=torch.int32, device=device
+            )
+            positions = torch.arange(num_tokens, dtype=torch.int64, device=device)
+            block_table.compute_slot_mapping(1, query_start_loc, positions)
         torch.accelerator.synchronize()
     finally:
         block_table.clear_row(0)

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -72,7 +72,7 @@ from vllm.v1.worker.worker_base import CompilationTimes, WorkerBase
 from vllm.v1.worker.workspace import init_workspace_manager
 
 from ...model_executor.model_loader import TensorizerLoader
-from .gpu.warmup import warmup_kernels
+from .gpu.warmup import warmup_kernels, warmup_v1_slot_mapping_kernel
 from .utils import request_memory
 
 logger = init_logger(__name__)
@@ -705,7 +705,12 @@ class Worker(WorkerBase):
         if self.use_v2_model_runner:
             # V2: Run full execute_model + sample_tokens to JIT compile triton kernels.
             warmup_kernels(self.model_runner, self.execute_model, self.sample_tokens)
-        elif get_pp_group().is_last_rank:
+        else:
+            # V1: Compile generic input preparation kernels that legacy
+            # _dummy_run does not cover before the JIT monitor is enabled.
+            warmup_v1_slot_mapping_kernel(self.model_runner)
+
+        if not self.use_v2_model_runner and get_pp_group().is_last_rank:
             # V1: Warm up sampler and preallocate memory buffer for logits and other
             # sampling related tensors of max possible shape to avoid memory
             # fragmentation issue.


### PR DESCRIPTION
## Problem

V1 startup warmup activates before the JIT monitor, but the normal dummy/profile path does not reliably cover `BlockTable.compute_slot_mapping()`. As a result, `_compute_slot_mapping_kernel` can still compile on the first real request after the monitor is active.

There is also a specialization issue. The slot-mapping Triton kernel was specializing on runtime request size, so warming one token count did not necessarily cover the next real request shape.

## Approach

This PR keeps the scope limited to the V1 slot-mapping path.

It adds `do_not_specialize=["num_tokens"]` to `_compute_slot_mapping_kernel` while keeping `max_num_tokens` specialized, since `max_num_tokens` is engine-lifetime configuration and still useful for Triton optimization.

It also adds `warmup_v1_slot_mapping_kernel()`, which calls `compute_slot_mapping()` directly before the JIT monitor is activated. The warmup uses block id 1 instead of the null block and clears temporary state in a `finally` block.

A follow-up commit warms request-shaped slot-mapping variants, because the first real serving request can use small prompt/decode shapes that differ from the original synthetic warmup. This is still slot-mapping only; it does not fold attention, MoE, TurboQuant, or hybrid model kernels into this PR.

I searched open PRs for this exact V1 slot-mapping JIT warmup issue and did not find another one.

## Test Plan

```bash
.venv/bin/python -m pytest tests/v1/worker/test_gpu_model_runner.py -v

pre-commit run ruff-format --files \
  vllm/v1/worker/block_table.py \
  vllm/v1/worker/gpu/warmup.py \
  vllm/v1/worker/gpu_worker.py \
  tests/v1/worker/test_gpu_model_runner.py

pre-commit run ruff-check --files \
  vllm/v1/worker/block_table.py \
  vllm/v1/worker/gpu/warmup.py \
  vllm/v1/worker/gpu_worker.py \
  tests/v1/worker/test_gpu_model_runner.py

pre-commit run mypy-3.10 --files \
  vllm/v1/worker/block_table.py \
  vllm/v1/worker/gpu/warmup.py \
  vllm/v1/worker/gpu_worker.py \
  tests/v1/worker/test_gpu_model_runner.py \
  --hook-stage manual

git diff --check
```

## Test Result

- `tests/v1/worker/test_gpu_model_runner.py`: 34 passed, 16 warnings
- `ruff-format` / `ruff-check`: passed
- `mypy-3.10`: passed
- `git diff --check`: passed

Local smoke on V1 runner with Qwen3-8B text-only: HTTP 200, no `_compute_slot_mapping_kernel` warning on first request.

Combined warmup smoke on the integration branch also showed `_compute_slot_mapping_kernel`: 0 warnings after the request-shaped slot-mapping warmup was included. Other warmup buckets are handled by separate PRs.

<details>
<summary>Checklist</summary>

- [x] Purpose
- [x] Test plan and results
- [x] AI assistance disclosed

</details>

AI assistance: Codex, Claude.
