### PR TITLE
[WIP][Probe] use_deterministic_algorithms(warn_only=False) — surface non-det op

### DIFF
--- a/tests/v1/e2e/general/test_async_scheduling.py
+++ b/tests/v1/e2e/general/test_async_scheduling.py
@@ -2,9 +2,9 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import os
 
-# PROBE: log which Triton autotune configs are picked, per kernel+shape, to
-# help see if different configs trigger different config selections.
-os.environ.setdefault("TRITON_PRINT_AUTOTUNING", "1")
+# PROBE: enable per-layer hidden state dump in qwen2.forward at position of
+# token 2701 (' following').
+os.environ.setdefault("VLLM_DEBUG_DUMP_HS", "1")
 
 from itertools import repeat  # noqa: E402
 from typing import Any  # noqa: E402
@@ -28,7 +28,7 @@ from ....models.utils import check_outputs_equal  # noqa: E402
 MODEL = "Qwen/Qwen3-0.6B"
 MTP_MODEL = "meta-llama/Llama-3.2-1B-Instruct"
 
-ENFORCE_EAGER = False
+ENFORCE_EAGER = True  # PROBE: eager so dumps work without cudagraph capture
 
 first_prompt = (
     "The following numbers of the sequence "

--- a/tests/v1/e2e/general/test_async_scheduling.py
+++ b/tests/v1/e2e/general/test_async_scheduling.py
@@ -7,6 +7,14 @@ import os
 os.environ.setdefault("VLLM_DEBUG_DUMP_HS", "1")
 # PROBE: required for cuBLAS deterministic mode to be honored by PyTorch
 os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+# PROBE: enable sub-op deterministic check in Qwen3 layer 0 forward.
+# Each pure sub-op (qkv_proj, q_norm, k_norm, rotary_emb, o_proj,
+# input_layernorm, post_attention_layernorm, mlp) is called twice with
+# cloned input; max diff is logged when non-zero. The op with non-zero
+# diff is the non-deterministic source. self.attn (the attention call)
+# is skipped because it mutates KV cache, but can be deduced by
+# elimination if all other ops are deterministic yet layer output diverges.
+os.environ.setdefault("VLLM_DET_CHECK", "1")
 
 from itertools import repeat  # noqa: E402
 from typing import Any  # noqa: E402

--- a/tests/v1/e2e/general/test_async_scheduling.py
+++ b/tests/v1/e2e/general/test_async_scheduling.py
@@ -367,9 +367,38 @@ def run_test(
         enable_prefix_caching=False,  # PROBE: disable prefix caching
         **cache_arg,
     ) as vllm_model:
+        # PROBE: warm up every parametrization once before the actual test loop.
+        # If failure was caused by Triton kernel JIT compilation occurring
+        # mid-test (which changes GPU/cuBLAS state for the next forward pass),
+        # this warmup will trigger ALL JIT compiles upfront so the actual
+        # measured runs all start from the same post-JIT state.
+        import sys as _probe_sys
+
+        print(
+            "[PROBE_MARKER] WARMUP_START — running all params once to trigger JIT",
+            file=_probe_sys.stderr,
+            flush=True,
+        )
+        for _warmup_params in sampling_param_tests:
+            _ = vllm_model.generate(
+                example_prompts[:2],  # small subset to save time
+                sampling_params=SamplingParams(**default_params, **_warmup_params),
+                return_logprobs=True,
+            )
+        print(
+            "[PROBE_MARKER] WARMUP_END — JIT should be done; starting measured runs",
+            file=_probe_sys.stderr,
+            flush=True,
+        )
+
         results = []
         acceptance_rates: list[float] | None = [] if spec_decoding else None
-        for override_params in sampling_param_tests:
+        for _gen_idx, override_params in enumerate(sampling_param_tests, start=1):
+            print(
+                f"[PROBE_MARKER] GEN_{_gen_idx}_START params={override_params}",
+                file=_probe_sys.stderr,
+                flush=True,
+            )
             metrics_before = vllm_model.llm.get_metrics()
             print(f"----------- RUNNING PARAMS: {override_params}")
             results.append(
@@ -378,6 +407,11 @@ def run_test(
                     sampling_params=SamplingParams(**default_params, **override_params),
                     return_logprobs=True,
                 )
+            )
+            print(
+                f"[PROBE_MARKER] GEN_{_gen_idx}_END params={override_params}",
+                file=_probe_sys.stderr,
+                flush=True,
             )
             metrics_after = vllm_model.llm.get_metrics()
             if acceptance_rates is not None:

--- a/tests/v1/e2e/general/test_async_scheduling.py
+++ b/tests/v1/e2e/general/test_async_scheduling.py
@@ -208,9 +208,8 @@ def run_tests(
     """Test consistency of combos of async scheduling, preemption,
     uni/multiproc executor with spec decoding."""
 
-    # PROBE: switch from FLEX_ATTENTION to TORCH_SDPA (also fp32-capable,
-    # routes through cuDNN/oneDNN — bypasses flex_attention's Triton kernel).
-    attention_config = {"backend": "TORCH_SDPA"}
+    # Flex attention supports float32.
+    attention_config = {"backend": "FLEX_ATTENTION"}
 
     with monkeypatch.context() as m:
         # lock matmul precision to full FP32 (IEEE)

--- a/tests/v1/e2e/general/test_async_scheduling.py
+++ b/tests/v1/e2e/general/test_async_scheduling.py
@@ -5,12 +5,21 @@ import os
 # PROBE: enable per-layer hidden state dump in qwen2.forward at position of
 # token 2701 (' following').
 os.environ.setdefault("VLLM_DEBUG_DUMP_HS", "1")
+# PROBE: required for cuBLAS deterministic mode to be honored by PyTorch
+os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
 
 from itertools import repeat  # noqa: E402
 from typing import Any  # noqa: E402
 
 import pytest  # noqa: E402
+import torch  # noqa: E402
 import torch._dynamo.config as dynamo_config  # noqa: E402
+
+# PROBE: warn_only=False -> RAISE an error at the first non-deterministic op,
+# so we can see exactly which op is the source of bit-level divergence.
+# Previously warn_only=True buried warnings in the log; warn_only=False
+# surfaces a stack trace pointing directly at the offending op.
+torch.use_deterministic_algorithms(True, warn_only=False)
 
 from tests.utils import (  # noqa: E402
     large_gpu_mark,

--- a/tests/v1/e2e/general/test_async_scheduling.py
+++ b/tests/v1/e2e/general/test_async_scheduling.py
@@ -1,30 +1,34 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import os
-from itertools import repeat
-from typing import Any
 
-import pytest
-import torch._dynamo.config as dynamo_config
+# PROBE: log which Triton autotune configs are picked, per kernel+shape, to
+# help see if different configs trigger different config selections.
+os.environ.setdefault("TRITON_PRINT_AUTOTUNING", "1")
 
-from tests.utils import (
+from itertools import repeat  # noqa: E402
+from typing import Any  # noqa: E402
+
+import pytest  # noqa: E402
+import torch._dynamo.config as dynamo_config  # noqa: E402
+
+from tests.utils import (  # noqa: E402
     large_gpu_mark,
     single_gpu_only,
 )
-from vllm import SamplingParams
-from vllm.logprobs import Logprob
-from vllm.platforms import current_platform
-from vllm.sampling_params import StructuredOutputsParams
-from vllm.v1.metrics.reader import Metric
+from vllm import SamplingParams  # noqa: E402
+from vllm.logprobs import Logprob  # noqa: E402
+from vllm.platforms import current_platform  # noqa: E402
+from vllm.sampling_params import StructuredOutputsParams  # noqa: E402
+from vllm.v1.metrics.reader import Metric  # noqa: E402
 
-from ....conftest import VllmRunner
-from ....models.utils import check_outputs_equal
+from ....conftest import VllmRunner  # noqa: E402
+from ....models.utils import check_outputs_equal  # noqa: E402
 
 MODEL = "Qwen/Qwen3-0.6B"
 MTP_MODEL = "meta-llama/Llama-3.2-1B-Instruct"
 
-# Need to enforce eager for MRV2 while we sort out cudagraph issues.
-ENFORCE_EAGER = os.getenv("ENFORCE_EAGER", "0") == "1"
+ENFORCE_EAGER = False
 
 first_prompt = (
     "The following numbers of the sequence "
@@ -204,8 +208,9 @@ def run_tests(
     """Test consistency of combos of async scheduling, preemption,
     uni/multiproc executor with spec decoding."""
 
-    # Flex attention supports float32.
-    attention_config = {"backend": "FLEX_ATTENTION"}
+    # PROBE: switch from FLEX_ATTENTION to TORCH_SDPA (also fp32-capable,
+    # routes through cuDNN/oneDNN — bypasses flex_attention's Triton kernel).
+    attention_config = {"backend": "TORCH_SDPA"}
 
     with monkeypatch.context() as m:
         # lock matmul precision to full FP32 (IEEE)
@@ -360,7 +365,7 @@ def run_test(
         speculative_config=spec_config,
         disable_log_stats=False,
         attention_config=attention_config,
-        enable_prefix_caching=False if current_platform.is_rocm() else None,
+        enable_prefix_caching=False,  # PROBE: disable prefix caching
         **cache_arg,
     ) as vllm_model:
         results = []

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -86,6 +86,13 @@ from .utils import (
 # order. Populated in Qwen2Model.forward; consumed in qwen3.py.
 _probe_target_positions: list[int] = []
 _probe_trigger_idx: int = 0
+# M = leading dim of input_ids in the forward call (= num scheduled tokens for
+# this micro-batch). Needed to test the "cuBLAS picks different GEMM kernel
+# when M changes" hypothesis at qkv_proj. Set together with positions/trigger.
+_probe_batch_M: int = 0
+# Position values at each 2701 occurrence. Same logical-prompt-position should
+# hold across configs; difference would mean scheduler chunked differently.
+_probe_position_vals: list[int] = []
 
 
 class Qwen2MLP(nn.Module):
@@ -414,8 +421,12 @@ class Qwen2Model(nn.Module, EagleModelMixin):
         # If input_ids contains token 2701 in this forward call, capture all
         # positions and bump a monotonic trigger counter so cross-config
         # alignment is possible. Otherwise clear to suppress sub-op dumps on
-        # decode/unrelated-prefill calls.
+        # decode/unrelated-prefill calls. Also records M (batch leading dim)
+        # and the value of `positions` at each 2701 occurrence, so we can
+        # decide whether qkv_proj output drift is explained by M-dependent
+        # cuBLAS algo selection or by scheduler-induced position changes.
         global _probe_target_positions, _probe_trigger_idx
+        global _probe_batch_M, _probe_position_vals
         if _DET and input_ids is not None and input_ids.ndim == 1:
             try:
                 _positions_2701 = (
@@ -426,6 +437,24 @@ class Qwen2Model(nn.Module, EagleModelMixin):
             if _positions_2701:
                 _probe_target_positions = _positions_2701
                 _probe_trigger_idx += 1
+                _probe_batch_M = int(input_ids.shape[0])
+                try:
+                    if positions is not None and positions.ndim == 1:
+                        _probe_position_vals = [
+                            int(positions[p].item()) for p in _positions_2701[:2]
+                        ]
+                    else:
+                        _probe_position_vals = []
+                except Exception:
+                    _probe_position_vals = []
+                import sys as _sys
+
+                print(
+                    f"[SUBOP_META] trigger={_probe_trigger_idx} M={_probe_batch_M} "
+                    f"pos2701={_positions_2701[:4]} posvals={_probe_position_vals}",
+                    file=_sys.stderr,
+                    flush=True,
+                )
             else:
                 _probe_target_positions = []
         elif _DET:

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -393,6 +393,38 @@ class Qwen2Model(nn.Module, EagleModelMixin):
         intermediate_tensors: IntermediateTensors | None = None,
         inputs_embeds: torch.Tensor | None = None,
     ) -> torch.Tensor | IntermediateTensors:
+        # PROBE: per-layer hidden state dump for token id 2701 (' following') at
+        # position 1 of the first prompt. Activated by VLLM_DEBUG_DUMP_HS=1.
+        # Used to find which transformer layer first produces a divergent value
+        # across async-scheduling configs.
+        import os as _os
+
+        _DUMP = _os.environ.get("VLLM_DEBUG_DUMP_HS", "") == "1"
+
+        def _dump(name, t, input_ids_local):
+            if not _DUMP or input_ids_local is None or t is None:
+                return
+            if input_ids_local.ndim != 1 or input_ids_local.shape[0] < 2:
+                return
+            # Find positions where token id == 2701 (' following')
+            try:
+                positions_2701 = (
+                    (input_ids_local == 2701).nonzero(as_tuple=False).flatten().tolist()
+                )
+            except Exception:
+                return
+            if not positions_2701:
+                return
+            import sys
+
+            for pos in positions_2701[:2]:  # at most first 2 occurrences
+                vals = t[pos, :16].detach().cpu().float().tolist()
+                print(
+                    f"[VLLM_DUMP] {name} pos={pos} tok=2701: {vals}",
+                    file=sys.stderr,
+                    flush=True,
+                )
+
         if get_pp_group().is_first_rank:
             if inputs_embeds is not None:
                 hidden_states = inputs_embeds
@@ -404,11 +436,14 @@ class Qwen2Model(nn.Module, EagleModelMixin):
             hidden_states = intermediate_tensors["hidden_states"]
             residual = intermediate_tensors["residual"]
 
+        _dump("embed", hidden_states, input_ids)
+
         aux_hidden_states = self._maybe_add_hidden_state([], 0, hidden_states, residual)
         for idx, layer in enumerate(
             islice(self.layers, self.start_layer, self.end_layer)
         ):
             hidden_states, residual = layer(positions, hidden_states, residual)
+            _dump(f"layer{idx:02d}", hidden_states, input_ids)
             self._maybe_add_hidden_state(
                 aux_hidden_states, idx + 1, hidden_states, residual
             )
@@ -419,6 +454,7 @@ class Qwen2Model(nn.Module, EagleModelMixin):
             )
 
         hidden_states, _ = self.norm(hidden_states, residual)
+        _dump("norm", hidden_states, input_ids)
 
         if len(aux_hidden_states) > 0:
             return hidden_states, aux_hidden_states

--- a/vllm/model_executor/models/qwen2.py
+++ b/vllm/model_executor/models/qwen2.py
@@ -79,6 +79,14 @@ from .utils import (
     maybe_prefix,
 )
 
+# PROBE: module-level state used by qwen3._dump_subop_out to (a) suppress
+# dumps on forward calls that don't contain the failing token, and (b) tag
+# each dump with a monotonic trigger index so logs can be aligned across
+# configs (baseline vs failing) by trigger_idx rather than absolute call
+# order. Populated in Qwen2Model.forward; consumed in qwen3.py.
+_probe_target_positions: list[int] = []
+_probe_trigger_idx: int = 0
+
 
 class Qwen2MLP(nn.Module):
     def __init__(
@@ -400,6 +408,28 @@ class Qwen2Model(nn.Module, EagleModelMixin):
         import os as _os
 
         _DUMP = _os.environ.get("VLLM_DEBUG_DUMP_HS", "") == "1"
+        _DET = _os.environ.get("VLLM_DET_CHECK", "") == "1"
+
+        # PROBE: set/clear module-level state read by qwen3._dump_subop_out.
+        # If input_ids contains token 2701 in this forward call, capture all
+        # positions and bump a monotonic trigger counter so cross-config
+        # alignment is possible. Otherwise clear to suppress sub-op dumps on
+        # decode/unrelated-prefill calls.
+        global _probe_target_positions, _probe_trigger_idx
+        if _DET and input_ids is not None and input_ids.ndim == 1:
+            try:
+                _positions_2701 = (
+                    (input_ids == 2701).nonzero(as_tuple=False).flatten().tolist()
+                )
+            except Exception:
+                _positions_2701 = []
+            if _positions_2701:
+                _probe_target_positions = _positions_2701
+                _probe_trigger_idx += 1
+            else:
+                _probe_target_positions = []
+        elif _DET:
+            _probe_target_positions = []
 
         def _dump(name, t, input_ids_local):
             if not _DUMP or input_ids_local is None or t is None:

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -56,6 +56,36 @@ from .utils import AutoWeightsLoader, PPMissingLayer, extract_layer_index, maybe
 logger = init_logger(__name__)
 
 
+# PROBE: determinism check helper. Calls fn(*args) twice with cloned tensor
+# args and prints max abs diff between the two outputs. Used to find which
+# sub-op of the first transformer layer has non-deterministic output.
+def _det_check_call(name: str, fn, *args):
+    import os as _os
+
+    if _os.environ.get("VLLM_DET_CHECK", "") != "1":
+        return fn(*args)
+    cloned = tuple(a.clone() if isinstance(a, torch.Tensor) else a for a in args)
+    out_a = fn(*args)
+    out_b = fn(*cloned)
+    if isinstance(out_a, tuple):
+        diffs = []
+        for ta, tb in zip(out_a, out_b):
+            if isinstance(ta, torch.Tensor) and isinstance(tb, torch.Tensor):
+                diffs.append((ta - tb).abs().max().item())
+        diff = max(diffs) if diffs else 0.0
+    else:
+        diff = (out_a - out_b).abs().max().item()
+    if diff != 0:
+        import sys as _sys
+
+        print(
+            f"[DET_CHECK] {name} max_diff={diff:.3e}",
+            file=_sys.stderr,
+            flush=True,
+        )
+    return out_a
+
+
 class Qwen3Attention(nn.Module):
     def __init__(
         self,
@@ -147,18 +177,41 @@ class Qwen3Attention(nn.Module):
         positions: torch.Tensor,
         hidden_states: torch.Tensor,
     ) -> torch.Tensor:
-        qkv, _ = self.qkv_proj(hidden_states)
+        # PROBE: only run det check on layer 0 (the first divergence point).
+        _det = (
+            getattr(self, "_probe_layer_idx", -1) == 0
+            and __import__("os").environ.get("VLLM_DET_CHECK", "") == "1"
+        )
+        if _det:
+            qkv, _ = _det_check_call("qkv_proj", self.qkv_proj, hidden_states)
+        else:
+            qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)
         # Add qk-norm
         q_by_head = q.view(*q.shape[:-1], q.shape[-1] // self.head_dim, self.head_dim)
-        q_by_head = self.q_norm(q_by_head)
+        if _det:
+            q_by_head = _det_check_call("q_norm", self.q_norm, q_by_head)
+        else:
+            q_by_head = self.q_norm(q_by_head)
         q = q_by_head.view(q.shape)
         k_by_head = k.view(*k.shape[:-1], k.shape[-1] // self.head_dim, self.head_dim)
-        k_by_head = self.k_norm(k_by_head)
+        if _det:
+            k_by_head = _det_check_call("k_norm", self.k_norm, k_by_head)
+        else:
+            k_by_head = self.k_norm(k_by_head)
         k = k_by_head.view(k.shape)
-        q, k = self.rotary_emb(positions, q, k)
+        if _det:
+            q, k = _det_check_call("rotary_emb", self.rotary_emb, positions, q, k)
+        else:
+            q, k = self.rotary_emb(positions, q, k)
+        # NOTE: self.attn mutates KV cache, so we don't double-call it.
+        # If all other sub-ops are deterministic but the layer output still
+        # diverges across configs, attention is the culprit by elimination.
         attn_output = self.attn(q, k, v)
-        output, _ = self.o_proj(attn_output)
+        if _det:
+            output, _ = _det_check_call("o_proj", self.o_proj, attn_output)
+        else:
+            output, _ = self.o_proj(attn_output)
         return output
 
 
@@ -212,6 +265,9 @@ class Qwen3DecoderLayer(nn.Module):
         self.post_attention_layernorm = RMSNorm(
             config.hidden_size, eps=config.rms_norm_eps
         )
+        # PROBE: layer index for selective det check (only layer 0)
+        self._probe_layer_idx = extract_layer_index(prefix)
+        self.self_attn._probe_layer_idx = self._probe_layer_idx
 
     def forward(
         self,
@@ -219,20 +275,51 @@ class Qwen3DecoderLayer(nn.Module):
         hidden_states: torch.Tensor,
         residual: torch.Tensor | None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
+        import os as _os
+
+        _det = (
+            self._probe_layer_idx == 0 and _os.environ.get("VLLM_DET_CHECK", "") == "1"
+        )
         # Self Attention
         if residual is None:
             residual = hidden_states
-            hidden_states = self.input_layernorm(hidden_states)
+            if _det:
+                hidden_states = _det_check_call(
+                    "input_layernorm", self.input_layernorm, hidden_states
+                )
+            else:
+                hidden_states = self.input_layernorm(hidden_states)
         else:
-            hidden_states, residual = self.input_layernorm(hidden_states, residual)
+            if _det:
+                hidden_states, residual = _det_check_call(
+                    "input_layernorm_w_residual",
+                    self.input_layernorm,
+                    hidden_states,
+                    residual,
+                )
+            else:
+                hidden_states, residual = self.input_layernorm(hidden_states, residual)
         hidden_states = self.self_attn(
             positions=positions,
             hidden_states=hidden_states,
         )
 
         # Fully Connected
-        hidden_states, residual = self.post_attention_layernorm(hidden_states, residual)
-        hidden_states = self.mlp(hidden_states)
+        if _det:
+            hidden_states, residual = _det_check_call(
+                "post_attention_layernorm",
+                self.post_attention_layernorm,
+                hidden_states,
+                residual,
+            )
+        else:
+            hidden_states, residual = self.post_attention_layernorm(
+                hidden_states, residual
+            )
+        if _det:
+            hidden_states = _det_check_call("mlp", self.mlp, hidden_states)
+        else:
+            hidden_states = self.mlp(hidden_states)
         return hidden_states, residual
 
 

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -330,6 +330,35 @@ class Qwen3ForCausalLM(
         hidden_states: torch.Tensor,
     ) -> torch.Tensor | None:
         logits = self.logits_processor(self.lm_head, hidden_states)
+        # PROBE: dump logit row stats at position 1 to find where divergence
+        # originates. Only when VLLM_DEBUG_DUMP_HS=1 and batch is large
+        # enough to be a prefill (not single-token decode).
+        import os as _os
+
+        if (
+            _os.environ.get("VLLM_DEBUG_DUMP_HS", "") == "1"
+            and logits is not None
+            and logits.ndim == 2
+            and logits.shape[0] >= 2
+        ):
+            import sys
+
+            row = logits[1].detach().cpu().float()
+            head8 = row[:8].tolist()
+            tok2701 = float(row[2701].item()) if row.shape[0] > 2701 else None
+            row_max = float(row.max().item())
+            row_argmax = int(row.argmax().item())
+            row_sum = float(row.sum().item())
+            row_abssum = float(row.abs().sum().item())
+            # logsumexp
+            row_lse = float((row - row.max()).exp().sum().log().item() + row_max)
+            print(
+                f"[VLLM_LOGITS] shape={list(logits.shape)} pos=1 "
+                f"head8={head8} tok2701={tok2701} max={row_max} "
+                f"argmax={row_argmax} sum={row_sum} abssum={row_abssum} lse={row_lse}",
+                file=sys.stderr,
+                flush=True,
+            )
         return logits
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -83,6 +83,7 @@ def _dump_subop_out(name: str, output):
     if t.ndim < 2:
         return
     trigger = _qwen2._probe_trigger_idx
+    M = _qwen2._probe_batch_M
     import sys as _sys
 
     for pos in positions[:2]:
@@ -90,10 +91,49 @@ def _dump_subop_out(name: str, output):
             continue
         flat = t[pos].detach().reshape(-1)[:8].cpu().float().tolist()
         print(
-            f"[SUBOP_OUT] trigger={trigger} op={name} pos={pos} first8={flat}",
+            f"[SUBOP_OUT] trigger={trigger} M={M} op={name} pos={pos} "
+            f"shape={list(t.shape)} first8={flat}",
             file=_sys.stderr,
             flush=True,
         )
+
+
+# PROBE: dump qkv_proj weight checksum once per trigger, only from layer 0,
+# to rule out weight-drift as an explanation for output divergence. We log
+# (a) sum of weight[0, :8], (b) sum of full weight tensor, both as float64
+# to avoid the fp32 sum precision issue. If these match across configs but
+# qkv_proj output still differs, the weight is not the cause.
+_weight_dumped_for_trigger: int = -1
+
+
+def _dump_weight_once_per_trigger(weight: torch.Tensor):
+    import os as _os
+
+    if _os.environ.get("VLLM_DET_CHECK", "") != "1":
+        return
+    from . import qwen2 as _qwen2
+
+    if not _qwen2._probe_target_positions:
+        return
+    global _weight_dumped_for_trigger
+    trigger = _qwen2._probe_trigger_idx
+    if trigger == _weight_dumped_for_trigger:
+        return
+    _weight_dumped_for_trigger = trigger
+    try:
+        w0 = weight[0, :8].detach().cpu().float().tolist()
+        wsum = float(weight.detach().double().sum().item())
+        wshape = list(weight.shape)
+    except Exception:
+        return
+    import sys as _sys
+
+    print(
+        f"[SUBOP_WEIGHT] trigger={trigger} op=qkv_proj shape={wshape} "
+        f"row0_first8={w0} fullsum={wsum:.18g}",
+        file=_sys.stderr,
+        flush=True,
+    )
 
 
 # Wrapper that calls fn once and dumps its output. Replaces the old
@@ -202,7 +242,31 @@ class Qwen3Attention(nn.Module):
             and __import__("os").environ.get("VLLM_DET_CHECK", "") == "1"
         )
         if _det:
+            # PROBE: weight checksum once per trigger to rule out weight drift.
+            _dump_weight_once_per_trigger(self.qkv_proj.weight)
             qkv, _ = _det_check_call("qkv_proj", self.qkv_proj, hidden_states)
+            # PROBE: within-call re-run with the SAME input + weight. If qkv ==
+            # qkv_recheck bit-for-bit, cuBLAS is deterministic for this shape
+            # in this forward — and any cross-config divergence is purely a
+            # function of the shape (M-dim) or pre-forward GPU state. If they
+            # differ, cuBLAS handle/workspace state is leaking across calls
+            # within the same forward, and shape-only theories are wrong.
+            qkv_recheck, _ = self.qkv_proj(hidden_states)
+            _dump_subop_out("qkv_proj_recheck", qkv_recheck)
+            # PROBE: float64 reference. F.linear(input.double(), weight.double())
+            # gives an effectively-exact result; the config whose qkv is closer
+            # to this is the "correct" one. Both being equally far means cuBLAS
+            # is picking different but equally-valid algos.
+            try:
+                import torch.nn.functional as _F
+
+                qkv_ref = _F.linear(
+                    hidden_states.detach().double(),
+                    self.qkv_proj.weight.detach().double(),
+                )
+                _dump_subop_out("qkv_proj_ref_fp64", qkv_ref.float())
+            except Exception:
+                pass
         else:
             qkv, _ = self.qkv_proj(hidden_states)
         q, k, v = qkv.split([self.q_size, self.kv_size, self.kv_size], dim=-1)

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -330,9 +330,10 @@ class Qwen3ForCausalLM(
         hidden_states: torch.Tensor,
     ) -> torch.Tensor | None:
         logits = self.logits_processor(self.lm_head, hidden_states)
-        # PROBE: dump logit row stats at position 1 to find where divergence
-        # originates. Only when VLLM_DEBUG_DUMP_HS=1 and batch is large
-        # enough to be a prefill (not single-token decode).
+        # PROBE: scan ALL rows of logits, computing logprob[2701] = logit - lse
+        # at each row. Find the row(s) where logprob matches the failure
+        # signature (-10.5131..., the value at the failing prompt position)
+        # and dump their rank and near-tie candidates.
         import os as _os
 
         if (
@@ -340,51 +341,40 @@ class Qwen3ForCausalLM(
             and logits is not None
             and logits.ndim == 2
             and logits.shape[0] >= 2
+            and logits.shape[1] > 2701
         ):
             import sys
 
-            # PROBE: dump logits ROW 0 — the predictor for position 1's token.
-            # prompt_logprobs[1] = logprob of token at position 1 (=2701, ' following')
-            # is computed using logits[0]. So the rank kernel sees logits[0, :].
-            row = logits[0].detach().cpu().float()
-            head8 = row[:8].tolist()
-            tok2701 = float(row[2701].item()) if row.shape[0] > 2701 else None
-            row_max = float(row.max().item())
-            row_argmax = int(row.argmax().item())
-            row_sum = float(row.sum().item())
-            row_abssum = float(row.abs().sum().item())
-            # logsumexp
-            row_lse = float((row - row.max()).exp().sum().log().item() + row_max)
-            # PROBE: compute the rank directly from logits — exactly what
-            # _ranks_kernel does. If THIS differs across configs while
-            # tok2701 doesn't, the row itself has bit-level differences in
-            # tokens near the comparison boundary.
-            if tok2701 is not None:
-                # Count vocab tokens with logit >= logit[2701] in ROW 0
-                # (matches _ranks_kernel.tl.sum((logits >= x).to(int32)))
-                row_gpu = logits[0].detach()
-                rank_count = int((row_gpu >= row_gpu[2701]).sum().item())
-                # Count "boundary" tokens within tiny tolerance of tok2701
-                # tok_val unused (kept for clarity if extended)
-                # Find tokens within 1e-5 of tok2701 (near-tie candidates)
-                near = (
-                    ((row_gpu - row_gpu[2701]).abs() < 1e-5)
-                    .nonzero(as_tuple=False)
-                    .flatten()
-                    .tolist()
+            logits_gpu = logits.detach()
+            row_max = logits_gpu.max(dim=1).values  # [num_rows]
+            row_lse = (logits_gpu - row_max.unsqueeze(1)).exp().sum(
+                dim=1
+            ).log() + row_max
+            tok2701_per_row = logits_gpu[:, 2701]  # [num_rows]
+            logprob_2701_per_row = tok2701_per_row - row_lse  # [num_rows]
+
+            # Find rows whose logprob[2701] is near the failure signature
+            target = -10.5131
+            near_target_mask = (logprob_2701_per_row - target).abs() < 0.001
+            near_rows = near_target_mask.nonzero(as_tuple=False).flatten().tolist()
+
+            for row_idx in near_rows[:5]:
+                row = logits_gpu[row_idx]
+                tok2701_val = float(row[2701].item())
+                logprob_val = float(logprob_2701_per_row[row_idx].item())
+                lse_val = float(row_lse[row_idx].item())
+                rank_count = int((row >= row[2701]).sum().item())
+                near_mask = (row - row[2701]).abs() < 1e-6
+                near_idx = near_mask.nonzero(as_tuple=False).flatten().tolist()
+                near_vals = [(int(i), float(row[i].item())) for i in near_idx[:8]]
+                print(
+                    f"[VLLM_LOGITS] shape={list(logits.shape)} row={row_idx} "
+                    f"tok2701={tok2701_val:.18g} lse={lse_val:.18g} "
+                    f"logprob={logprob_val:.18g} rank_count={rank_count} "
+                    f"near_count={len(near_idx)} near={near_vals}",
+                    file=sys.stderr,
+                    flush=True,
                 )
-                near_vals = [(int(i), float(row_gpu[i].item())) for i in near[:8]]
-            else:
-                rank_count = None
-                near_vals = []
-            print(
-                f"[VLLM_LOGITS] shape={list(logits.shape)} pos=0_pred_tok2701 "
-                f"head8={head8} tok2701={tok2701} max={row_max} "
-                f"argmax={row_argmax} sum={row_sum} abssum={row_abssum} lse={row_lse} "
-                f"rank_count={rank_count} near={near_vals}",
-                file=sys.stderr,
-                flush=True,
-            )
         return logits
 
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -56,34 +56,43 @@ from .utils import AutoWeightsLoader, PPMissingLayer, extract_layer_index, maybe
 logger = init_logger(__name__)
 
 
-# PROBE: determinism check helper. Calls fn(*args) twice with cloned tensor
-# args and prints max abs diff between the two outputs. Used to find which
-# sub-op of the first transformer layer has non-deterministic output.
-def _det_check_call(name: str, fn, *args):
+# PROBE: dump sub-op outputs at layer 0 position 1 for ACROSS-PASS comparison.
+# Previous within-call _det_check_call showed all sub-ops bit-deterministic
+# within a single forward pass. But that doesn't catch ACROSS-GENERATE
+# non-determinism (e.g., cuBLAS algo caching changes between generates).
+# This dump captures the value at position 1 of each sub-op output every
+# time the forward pass contains token 2701 (the failing prompt position).
+# Post-process: extract per-pid-per-pass values and compare pass 6 vs pass 7
+# within the same config to find the FIRST sub-op whose output differs
+# across passes — that's the actual non-deterministic op.
+def _dump_subop_out(name: str, output):
     import os as _os
 
     if _os.environ.get("VLLM_DET_CHECK", "") != "1":
-        return fn(*args)
-    cloned = tuple(a.clone() if isinstance(a, torch.Tensor) else a for a in args)
-    out_a = fn(*args)
-    out_b = fn(*cloned)
-    if isinstance(out_a, tuple):
-        diffs = []
-        for ta, tb in zip(out_a, out_b):
-            if isinstance(ta, torch.Tensor) and isinstance(tb, torch.Tensor):
-                diffs.append((ta - tb).abs().max().item())
-        diff = max(diffs) if diffs else 0.0
+        return
+    t = output[0] if isinstance(output, tuple) else output
+    if not isinstance(t, torch.Tensor):
+        return
+    if t.ndim >= 2 and t.shape[0] >= 2:
+        flat = t[1].detach().reshape(-1)[:8].cpu().float().tolist()
     else:
-        diff = (out_a - out_b).abs().max().item()
-    if diff != 0:
-        import sys as _sys
+        return
+    import sys as _sys
 
-        print(
-            f"[DET_CHECK] {name} max_diff={diff:.3e}",
-            file=_sys.stderr,
-            flush=True,
-        )
-    return out_a
+    print(
+        f"[SUBOP_OUT] layer0 op={name} pos=1 first8={flat}",
+        file=_sys.stderr,
+        flush=True,
+    )
+
+
+# Wrapper that calls fn once and dumps its output. Replaces the old
+# within-call _det_check_call which we showed only catches within-call
+# non-determinism — not the across-generate variety we need.
+def _det_check_call(name: str, fn, *args):
+    out = fn(*args)
+    _dump_subop_out(name, out)
+    return out
 
 
 class Qwen3Attention(nn.Module):
@@ -204,11 +213,17 @@ class Qwen3Attention(nn.Module):
             q, k = _det_check_call("rotary_emb", self.rotary_emb, positions, q, k)
         else:
             q, k = self.rotary_emb(positions, q, k)
-        # NOTE: self.attn mutates KV cache, so we don't double-call it.
-        # If all other sub-ops are deterministic but the layer output still
-        # diverges across configs, attention is the culprit by elimination.
+        # PROBE: also dump q/k AFTER rotary (the input to attention) and
+        # attn_output (the output of attention) for cross-pass comparison.
+        # self.attn mutates KV cache so we don't re-call it, but we still
+        # dump its output to see if it differs across passes.
+        if _det:
+            _dump_subop_out("q_after_rotary", q)
+            _dump_subop_out("k_after_rotary", k)
+            _dump_subop_out("v_input", v)
         attn_output = self.attn(q, k, v)
         if _det:
+            _dump_subop_out("attn_output", attn_output)
             output, _ = _det_check_call("o_proj", self.o_proj, attn_output)
         else:
             output, _ = self.o_proj(attn_output)

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -343,7 +343,10 @@ class Qwen3ForCausalLM(
         ):
             import sys
 
-            row = logits[1].detach().cpu().float()
+            # PROBE: dump logits ROW 0 — the predictor for position 1's token.
+            # prompt_logprobs[1] = logprob of token at position 1 (=2701, ' following')
+            # is computed using logits[0]. So the rank kernel sees logits[0, :].
+            row = logits[0].detach().cpu().float()
             head8 = row[:8].tolist()
             tok2701 = float(row[2701].item()) if row.shape[0] > 2701 else None
             row_max = float(row.max().item())
@@ -357,9 +360,9 @@ class Qwen3ForCausalLM(
             # tok2701 doesn't, the row itself has bit-level differences in
             # tokens near the comparison boundary.
             if tok2701 is not None:
-                # Count vocab tokens with logit >= logit[2701]
+                # Count vocab tokens with logit >= logit[2701] in ROW 0
                 # (matches _ranks_kernel.tl.sum((logits >= x).to(int32)))
-                row_gpu = logits[1].detach()
+                row_gpu = logits[0].detach()
                 rank_count = int((row_gpu >= row_gpu[2701]).sum().item())
                 # Count "boundary" tokens within tiny tolerance of tok2701
                 # tok_val unused (kept for clarity if extended)
@@ -375,7 +378,7 @@ class Qwen3ForCausalLM(
                 rank_count = None
                 near_vals = []
             print(
-                f"[VLLM_LOGITS] shape={list(logits.shape)} pos=1 "
+                f"[VLLM_LOGITS] shape={list(logits.shape)} pos=0_pred_tok2701 "
                 f"head8={head8} tok2701={tok2701} max={row_max} "
                 f"argmax={row_argmax} sum={row_sum} abssum={row_abssum} lse={row_lse} "
                 f"rank_count={rank_count} near={near_vals}",

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -352,10 +352,33 @@ class Qwen3ForCausalLM(
             row_abssum = float(row.abs().sum().item())
             # logsumexp
             row_lse = float((row - row.max()).exp().sum().log().item() + row_max)
+            # PROBE: compute the rank directly from logits — exactly what
+            # _ranks_kernel does. If THIS differs across configs while
+            # tok2701 doesn't, the row itself has bit-level differences in
+            # tokens near the comparison boundary.
+            if tok2701 is not None:
+                # Count vocab tokens with logit >= logit[2701]
+                # (matches _ranks_kernel.tl.sum((logits >= x).to(int32)))
+                row_gpu = logits[1].detach()
+                rank_count = int((row_gpu >= row_gpu[2701]).sum().item())
+                # Count "boundary" tokens within tiny tolerance of tok2701
+                # tok_val unused (kept for clarity if extended)
+                # Find tokens within 1e-5 of tok2701 (near-tie candidates)
+                near = (
+                    ((row_gpu - row_gpu[2701]).abs() < 1e-5)
+                    .nonzero(as_tuple=False)
+                    .flatten()
+                    .tolist()
+                )
+                near_vals = [(int(i), float(row_gpu[i].item())) for i in near[:8]]
+            else:
+                rank_count = None
+                near_vals = []
             print(
                 f"[VLLM_LOGITS] shape={list(logits.shape)} pos=1 "
                 f"head8={head8} tok2701={tok2701} max={row_max} "
-                f"argmax={row_argmax} sum={row_sum} abssum={row_abssum} lse={row_lse}",
+                f"argmax={row_argmax} sum={row_sum} abssum={row_abssum} lse={row_lse} "
+                f"rank_count={rank_count} near={near_vals}",
                 file=sys.stderr,
                 flush=True,
             )

--- a/vllm/model_executor/models/qwen3.py
+++ b/vllm/model_executor/models/qwen3.py
@@ -56,34 +56,44 @@ from .utils import AutoWeightsLoader, PPMissingLayer, extract_layer_index, maybe
 logger = init_logger(__name__)
 
 
-# PROBE: dump sub-op outputs at layer 0 position 1 for ACROSS-PASS comparison.
-# Previous within-call _det_check_call showed all sub-ops bit-deterministic
-# within a single forward pass. But that doesn't catch ACROSS-GENERATE
-# non-determinism (e.g., cuBLAS algo caching changes between generates).
-# This dump captures the value at position 1 of each sub-op output every
-# time the forward pass contains token 2701 (the failing prompt position).
-# Post-process: extract per-pid-per-pass values and compare pass 6 vs pass 7
-# within the same config to find the FIRST sub-op whose output differs
-# across passes — that's the actual non-deterministic op.
+# PROBE: dump sub-op outputs at the position(s) of token 2701 in the current
+# forward call, tagged by a monotonic trigger index, for cross-config and
+# cross-call comparison. Filtering is gated by qwen2 module-level state set
+# in Qwen2Model.forward, which only marks a forward call as "interesting"
+# when input_ids actually contains 2701. This eliminates noise from warmup,
+# decode-only forwards, and forwards that prefill other prompts.
+#
+# Post-process: the same trigger_idx in baseline vs failing config dumps the
+# same logical prefill (greedy + same prompt order ensures determinism in
+# scheduling). For each (trigger_idx, op, pos) tuple, compare first8 across
+# configs to find the first op whose output differs.
 def _dump_subop_out(name: str, output):
     import os as _os
 
     if _os.environ.get("VLLM_DET_CHECK", "") != "1":
         return
+    from . import qwen2 as _qwen2
+
+    positions = _qwen2._probe_target_positions
+    if not positions:
+        return
     t = output[0] if isinstance(output, tuple) else output
     if not isinstance(t, torch.Tensor):
         return
-    if t.ndim >= 2 and t.shape[0] >= 2:
-        flat = t[1].detach().reshape(-1)[:8].cpu().float().tolist()
-    else:
+    if t.ndim < 2:
         return
+    trigger = _qwen2._probe_trigger_idx
     import sys as _sys
 
-    print(
-        f"[SUBOP_OUT] layer0 op={name} pos=1 first8={flat}",
-        file=_sys.stderr,
-        flush=True,
-    )
+    for pos in positions[:2]:
+        if pos >= t.shape[0]:
+            continue
+        flat = t[pos].detach().reshape(-1)[:8].cpu().float().tolist()
+        print(
+            f"[SUBOP_OUT] trigger={trigger} op={name} pos={pos} first8={flat}",
+            file=_sys.stderr,
+            flush=True,
+        )
 
 
 # Wrapper that calls fn once and dumps its output. Replaces the old

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -5215,6 +5215,54 @@ class GPUModelRunner(
                 logprobs, num_prompt_logprobs, tgt_token_ids
             )
 
+            # PROBE: dump the full chain for rows where tgt token == 2701
+            # (the failing token ' following'). This isolates the EXACT data
+            # that produced rank=5217/5218 in the assertion.
+            import os as _probe_os
+
+            if _probe_os.environ.get("VLLM_DEBUG_DUMP_HS", "") == "1":
+                import sys as _probe_sys
+
+                _tgt_cpu = tgt_token_ids.detach().cpu().tolist()
+                _ranks_cpu = ranks.detach().cpu().tolist()
+                for _i, _t in enumerate(_tgt_cpu):
+                    if _t != 2701:
+                        continue
+                    _row = logits[_i].detach()
+                    _row_cpu = _row.cpu().float()
+                    _tok_val = float(_row_cpu[2701].item())
+                    _row_max = float(_row_cpu.max().item())
+                    _row_argmax = int(_row_cpu.argmax().item())
+                    _row_lse = float(
+                        (_row_cpu - _row_cpu.max()).exp().sum().log().item() + _row_max
+                    )
+                    _row_sum = float(_row_cpu.sum().item())
+                    _logprob_calc = _tok_val - _row_lse
+                    _rank_calc = int((_row >= _row[2701]).sum().item())
+                    _near_mask = (_row - _row[2701]).abs() < 1e-6
+                    _near_idx = _near_mask.nonzero(as_tuple=False).flatten().tolist()
+                    _near_vals = [
+                        (int(_j), float(_row[_j].item())) for _j in _near_idx[:16]
+                    ]
+                    # Hidden state input to lm_head for this row
+                    _hs = prompt_hidden_states[_i].detach()
+                    _hs_cpu = _hs.cpu().float()
+                    _hs_norm = float(_hs_cpu.norm().item())
+                    _hs_sum = float(_hs_cpu.sum().item())
+                    _hs_first8 = _hs_cpu[:8].tolist()
+                    print(
+                        f"[VLLM_TARGET] req={req_id} chunk_row={_i} tgt=2701 "
+                        f"tok_val={_tok_val:.20g} max={_row_max:.20g} "
+                        f"argmax={_row_argmax} lse={_row_lse:.20g} "
+                        f"sum={_row_sum:.20g} logprob_calc={_logprob_calc:.20g} "
+                        f"rank_calc={_rank_calc} rank_kernel={_ranks_cpu[_i]} "
+                        f"near_count={len(_near_idx)} near={_near_vals} "
+                        f"hs_norm={_hs_norm:.20g} hs_sum={_hs_sum:.20g} "
+                        f"hs_first8={_hs_first8}",
+                        file=_probe_sys.stderr,
+                        flush=True,
+                    )
+
             # Transfer GPU->CPU async.
             chunk_slice = slice(start_idx, start_idx + num_logits)
             logprobs_tensors.logprob_token_ids[chunk_slice].copy_(


### PR DESCRIPTION
## Why this probe

User correctly pointed out that if Triton JIT compilation were the root cause, the failure should be deterministic (JIT is deterministic). But it's flaky. So there must be underlying non-determinism in some op that JIT only exposes.

This probe flips `torch.use_deterministic_algorithms(True, warn_only=False)` — instead of warning, PyTorch will RAISE at the first non-deterministic op, surfacing a Python stack trace pointing directly to the offending op.

## Setup

- `CUBLAS_WORKSPACE_CONFIG=:4096:8` (required precondition)
- `torch.use_deterministic_algorithms(True, warn_only=False)` (raise on first non-det op)
- `enforce_eager=True` (kept; cudagraph ruled out)
- `enable_prefix_caching=False` (kept; prefix cache ruled out)
- Warmup loop (kept from prior probe)
- Per-layer / per-row instrumentation (kept)

## Outcomes

- **Error at op X** → op X is the underlying non-deterministic source. Real fix targets that op.
- **Run completes and passes** → determinism stack fully fixes (would mean we missed something earlier).
- **Run completes and fails** → non-determinism is inside a Triton kernel that `CUBLAS_WORKSPACE_CONFIG` doesn't cover. Next step: instrument the Triton kernel directly.

## Probe history

| Probe | Result |
|---|---|
| enforce_eager only | FAIL |
| Full det stack `warn_only=True` | 1 PASS (luck), rerun FAIL |
| TF32 only | FAIL |
| cuBLAS det only | FAIL 4/4 |
| flex_attention compile bypass | OOM |
| No prefix caching + Triton logs | FAIL — prefix caching ruled out |
| Per-layer hidden state dumps | Pass 7 (first prompt_logprobs+logprobs) and pass 8 (first structured_outputs) diverge at layer 0 |
| Per-row logits + VLLM_TARGET | Confirmed lm_head input diverges; jit_monitor warns at pass 7/8 |
| Pre-warmup all params | TBD (not yet run) |
| **use_deterministic_algorithms(warn_only=False)** (this run) | TBD |

## Test Plan

## Test Result