### PR TITLE
[Bugfix][KVConnector] Include prompt_embeds digest in LMCacheMP cache key

### DIFF
--- a/tests/v1/kv_connector/unit/test_lmcache_mp_prompt_embeds_key.py
+++ b/tests/v1/kv_connector/unit/test_lmcache_mp_prompt_embeds_key.py
@@ -10,6 +10,7 @@
 import pytest
 import torch
 
+from vllm.multimodal.inputs import MultiModalFeatureSpec, PlaceholderRange
 from vllm.sampling_params import SamplingParams
 from vllm.v1.request import Request
 
@@ -24,9 +25,10 @@ from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_mp_connector import ( 
 def _make_request(
     request_id: str,
     *,
-    prompt_embeds: torch.Tensor | None,
-    prompt_token_ids: list[int] | None,
-    cache_salt: str | None,
+    prompt_embeds: torch.Tensor | None = None,
+    prompt_token_ids: list[int] | None = None,
+    cache_salt: str | None = None,
+    mm_features: list[MultiModalFeatureSpec] | None = None,
 ) -> Request:
     return Request(
         request_id=request_id,
@@ -35,6 +37,16 @@ def _make_request(
         pooling_params=None,
         prompt_embeds=prompt_embeds,
         cache_salt=cache_salt,
+        mm_features=mm_features,
+    )
+
+
+def _mm_feature(identifier: str, offset: int, length: int) -> MultiModalFeatureSpec:
+    return MultiModalFeatureSpec(
+        data=None,
+        modality="image",
+        identifier=identifier,
+        mm_position=PlaceholderRange(offset=offset, length=length),
     )
 
 
@@ -143,3 +155,120 @@ def test_prompt_embeds_with_no_user_salt_still_isolates():
     assert tracker_a.cache_salt != tracker_b.cache_salt
     assert tracker_a.cache_salt.startswith("|pe:")
     assert tracker_b.cache_salt.startswith("|pe:")
+
+
+def test_prompt_embeds_digest_is_memoized_across_trackers():
+    """Recreating a tracker for the same Request (e.g. on preempt/resume)
+    must reuse the cached digest rather than rehashing the tensor."""
+    torch.manual_seed(3)
+    embeds = torch.randn(16, 8, dtype=torch.float32)
+    req = _make_request("req-memo", prompt_embeds=embeds, cache_salt="s")
+
+    assert req._prompt_embeds_digest is None
+    tracker_first = LMCacheMPRequestTracker(req)
+    digest_after_first = req._prompt_embeds_digest
+    assert digest_after_first is not None
+    # Mutating the underlying tensor in-place after the first construction
+    # must NOT change the cached digest. This is the load-bearing property
+    # of the memoization: subsequent tracker constructions for the same
+    # request reuse the original hash without touching the tensor again.
+    embeds.fill_(0)
+    tracker_second = LMCacheMPRequestTracker(req)
+    assert req._prompt_embeds_digest == digest_after_first
+    assert tracker_first.cache_salt == tracker_second.cache_salt
+
+
+def test_mm_features_distinct_identifiers_yield_distinct_salts():
+    """Two requests with the same text (same placeholder token IDs) but
+    different image identifiers must produce distinct effective cache_salts.
+    Reviewer-flagged gap: same length + same cache_salt + different MM
+    inputs would otherwise collide in the external KV store."""
+    feature_a = _mm_feature("img-hash-A", offset=2, length=336)
+    feature_b = _mm_feature("img-hash-B", offset=2, length=336)
+
+    tracker_a = LMCacheMPRequestTracker(
+        _make_request(
+            "a",
+            prompt_token_ids=[0] * 512,
+            cache_salt="same",
+            mm_features=[feature_a],
+        )
+    )
+    tracker_b = LMCacheMPRequestTracker(
+        _make_request(
+            "b",
+            prompt_token_ids=[0] * 512,
+            cache_salt="same",
+            mm_features=[feature_b],
+        )
+    )
+
+    assert tracker_a.cache_salt.startswith("same|mm:")
+    assert tracker_b.cache_salt.startswith("same|mm:")
+    assert tracker_a.cache_salt != tracker_b.cache_salt
+
+
+def test_mm_features_identical_inputs_yield_identical_salts():
+    """Same text + same images must collapse to the same salt so retrieval
+    after restart still works."""
+    feature = _mm_feature("img-hash", offset=2, length=336)
+
+    tracker_first = LMCacheMPRequestTracker(
+        _make_request(
+            "1", prompt_token_ids=[0] * 512, cache_salt="s", mm_features=[feature]
+        )
+    )
+    tracker_second = LMCacheMPRequestTracker(
+        _make_request(
+            "2",
+            prompt_token_ids=[0] * 512,
+            cache_salt="s",
+            mm_features=[_mm_feature("img-hash", offset=2, length=336)],
+        )
+    )
+
+    assert tracker_first.cache_salt == tracker_second.cache_salt
+
+
+def test_mm_features_position_change_yields_distinct_salts():
+    """Same MM identifier but different placeholder offsets must still
+    produce distinct salts, mirroring local APC's per-block extra keys
+    that include `(identifier, offset)`."""
+    tracker_a = LMCacheMPRequestTracker(
+        _make_request(
+            "a",
+            prompt_token_ids=[0] * 512,
+            cache_salt="s",
+            mm_features=[_mm_feature("img", offset=2, length=336)],
+        )
+    )
+    tracker_b = LMCacheMPRequestTracker(
+        _make_request(
+            "b",
+            prompt_token_ids=[0] * 512,
+            cache_salt="s",
+            mm_features=[_mm_feature("img", offset=64, length=336)],
+        )
+    )
+
+    assert tracker_a.cache_salt != tracker_b.cache_salt
+
+
+def test_prompt_embeds_and_mm_features_compose():
+    """A request with both prompt_embeds and mm_features should fold both
+    digests into the salt, ordered as `<base>|pe:<...>|mm:<...>`."""
+    torch.manual_seed(4)
+    embeds = torch.randn(8, 4, dtype=torch.float32)
+    feature = _mm_feature("img", offset=0, length=8)
+
+    tracker = LMCacheMPRequestTracker(
+        _make_request(
+            "both",
+            prompt_embeds=embeds,
+            cache_salt="user",
+            mm_features=[feature],
+        )
+    )
+
+    assert tracker.cache_salt.startswith("user|pe:")
+    assert "|mm:" in tracker.cache_salt

--- a/tests/v1/kv_connector/unit/test_lmcache_mp_prompt_embeds_key.py
+++ b/tests/v1/kv_connector/unit/test_lmcache_mp_prompt_embeds_key.py
@@ -1,0 +1,145 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+# Regression tests for https://github.com/vllm-project/vllm/issues/42119:
+# two prompt_embeds-only requests with the same length and same cache_salt
+# must not share LMCache external KV entries. The connector achieves this
+# by mixing a digest of the prompt_embeds tensor into tracker.cache_salt,
+# which then propagates into IPCCacheEngineKey on every store/retrieve.
+
+import pytest
+import torch
+
+from vllm.sampling_params import SamplingParams
+from vllm.v1.request import Request
+
+pytest.importorskip("lmcache")
+
+# Imported after the importorskip so collection succeeds without lmcache.
+from vllm.distributed.kv_transfer.kv_connector.v1.lmcache_mp_connector import (  # noqa: E402
+    LMCacheMPRequestTracker,
+)
+
+
+def _make_request(
+    request_id: str,
+    *,
+    prompt_embeds: torch.Tensor | None,
+    prompt_token_ids: list[int] | None,
+    cache_salt: str | None,
+) -> Request:
+    return Request(
+        request_id=request_id,
+        prompt_token_ids=prompt_token_ids,
+        sampling_params=SamplingParams(max_tokens=1),
+        pooling_params=None,
+        prompt_embeds=prompt_embeds,
+        cache_salt=cache_salt,
+    )
+
+
+def test_prompt_embeds_distinct_content_yields_distinct_salts():
+    """Different prompt_embeds tensors of the same shape must produce
+    different effective cache_salts even when the user-provided salt and
+    sequence length are identical."""
+    torch.manual_seed(0)
+    embeds_a = torch.randn(32, 16, dtype=torch.float32)
+    embeds_b = torch.randn(32, 16, dtype=torch.float32)
+
+    req_a = _make_request(
+        "req-a",
+        prompt_embeds=embeds_a,
+        prompt_token_ids=None,
+        cache_salt="same",
+    )
+    req_b = _make_request(
+        "req-b",
+        prompt_embeds=embeds_b,
+        prompt_token_ids=None,
+        cache_salt="same",
+    )
+
+    tracker_a = LMCacheMPRequestTracker(req_a)
+    tracker_b = LMCacheMPRequestTracker(req_b)
+
+    # Both salts carry the user-provided prefix...
+    assert tracker_a.cache_salt.startswith("same|pe:")
+    assert tracker_b.cache_salt.startswith("same|pe:")
+    # ...but the embed-derived suffix diverges, so external keys won't collide.
+    assert tracker_a.cache_salt != tracker_b.cache_salt
+
+
+def test_prompt_embeds_same_content_yields_same_salt():
+    """Identical prompt_embeds with the same user salt must hash identically,
+    so retrieval after a vLLM restart still works for the same input."""
+    torch.manual_seed(1)
+    embeds = torch.randn(8, 4, dtype=torch.float32)
+
+    tracker_first = LMCacheMPRequestTracker(
+        _make_request(
+            "req-1", prompt_embeds=embeds, prompt_token_ids=None, cache_salt="s"
+        )
+    )
+    tracker_second = LMCacheMPRequestTracker(
+        _make_request(
+            "req-2",
+            prompt_embeds=embeds.clone(),
+            prompt_token_ids=None,
+            cache_salt="s",
+        )
+    )
+
+    assert tracker_first.cache_salt == tracker_second.cache_salt
+
+
+def test_token_only_request_salt_is_unchanged():
+    """Token-only requests must keep the original cache_salt verbatim, so
+    the existing token-id key path is unaffected."""
+    req = _make_request(
+        "req-tokens",
+        prompt_embeds=None,
+        prompt_token_ids=[1, 2, 3, 4],
+        cache_salt="user-salt",
+    )
+
+    tracker = LMCacheMPRequestTracker(req)
+
+    assert tracker.cache_salt == "user-salt"
+
+
+def test_token_only_request_without_salt_is_empty_string():
+    """Backwards compat: a request with no cache_salt and no prompt_embeds
+    keeps the historical empty-string salt."""
+    req = _make_request(
+        "req-no-salt",
+        prompt_embeds=None,
+        prompt_token_ids=[1, 2, 3, 4],
+        cache_salt=None,
+    )
+
+    tracker = LMCacheMPRequestTracker(req)
+
+    assert tracker.cache_salt == ""
+
+
+def test_prompt_embeds_with_no_user_salt_still_isolates():
+    """Even without a user-provided salt, distinct embeddings must produce
+    distinct effective salts."""
+    torch.manual_seed(2)
+    embeds_a = torch.randn(16, 8, dtype=torch.float32)
+    embeds_b = torch.randn(16, 8, dtype=torch.float32)
+
+    tracker_a = LMCacheMPRequestTracker(
+        _make_request(
+            "a", prompt_embeds=embeds_a, prompt_token_ids=None, cache_salt=None
+        )
+    )
+    tracker_b = LMCacheMPRequestTracker(
+        _make_request(
+            "b", prompt_embeds=embeds_b, prompt_token_ids=None, cache_salt=None
+        )
+    )
+
+    assert tracker_a.cache_salt != tracker_b.cache_salt
+    assert tracker_a.cache_salt.startswith("|pe:")
+    assert tracker_b.cache_salt.startswith("|pe:")

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -186,6 +186,62 @@ class LMCacheMPRequestState(enum.Enum):
     READY = enum.auto()
 
 
+def _get_prompt_embeds_digest(request: "Request") -> str | None:
+    """Return a memoized hex digest of `request.prompt_embeds`, or None.
+
+    The digest is cached on the request itself so trackers re-created on
+    preempt/resume don't repeat the (potentially large) D2H copy + hash.
+    """
+    if request.prompt_embeds is None:
+        return None
+    cached = request._prompt_embeds_digest
+    if cached is None:
+        cached = hashlib.sha256(tensor_data(request.prompt_embeds)).hexdigest()
+        request._prompt_embeds_digest = cached
+    return cached
+
+
+def _get_mm_features_digest(request: "Request") -> str | None:
+    """Return a stable hex digest of `request.mm_features`, or None.
+
+    Uses the precomputed `identifier` strings on each MultiModalFeatureSpec
+    plus their placeholder offsets/lengths. No tensor data is touched.
+    """
+    if not request.mm_features:
+        return None
+    h = hashlib.sha256()
+    for f in request.mm_features:
+        h.update(f.identifier.encode("utf-8"))
+        h.update(b"|")
+        h.update(str(f.mm_position.offset).encode("utf-8"))
+        h.update(b":")
+        h.update(str(f.mm_position.length).encode("utf-8"))
+        h.update(b";")
+    return h.hexdigest()
+
+
+def _augment_cache_salt(request: "Request") -> str:
+    """Build the effective LMCache cache_salt for a request.
+
+    For token-only requests with no MM inputs, returns the user-provided
+    salt unchanged (preserving historical behavior). When prompt_embeds or
+    mm_features are present, appends `|pe:<digest>` and/or `|mm:<digest>`
+    so two requests with the same token_ids placeholder shape but different
+    content map to distinct external KV keys.
+    """
+    base = request.cache_salt or ""
+    parts = [base]
+    pe = _get_prompt_embeds_digest(request)
+    if pe is not None:
+        parts.append(f"pe:{pe}")
+    mm = _get_mm_features_digest(request)
+    if mm is not None:
+        parts.append(f"mm:{mm}")
+    if len(parts) == 1:
+        return base
+    return "|".join(parts)
+
+
 @dataclass
 class LMCacheMPRequestTracker:
     # NOTE: this class used vLLM data structures, should be part of
@@ -221,22 +277,15 @@ class LMCacheMPRequestTracker:
 
     def __init__(self, request: "Request"):
         self.request_id = request.request_id
-        # When the request is prompt_embeds-only, `request.all_token_ids` is a
-        # placeholder list of zeros (see vllm/v1/request.py). Token IDs alone
-        # therefore cannot distinguish two same-length prompt_embeds requests,
-        # so the LMCache external KV key must also reflect the embedding
-        # contents. We fold a digest of the prompt_embeds tensor into the
-        # cache_salt so it propagates through every IPCCacheEngineKey derived
-        # from this tracker (lookup, store, retrieve, free_lookup_locks).
-        # See https://github.com/vllm-project/vllm/issues/42119.
-        base_salt = request.cache_salt or ""
-        if request.prompt_embeds is not None:
-            embeds_digest = hashlib.sha256(
-                tensor_data(request.prompt_embeds)
-            ).hexdigest()
-            self.cache_salt: str = f"{base_salt}|pe:{embeds_digest}"
-        else:
-            self.cache_salt = base_salt
+        # When a request carries prompt_embeds or mm_features, the placeholder
+        # token IDs in `request.all_token_ids` cannot distinguish requests
+        # with the same length but different content. The LMCache external KV
+        # key (derived from token_ids + cache_salt) would then collide. Mix
+        # stable per-request digests of the embedding bytes / mm identifiers
+        # into the salt so the augmented value propagates through every
+        # IPCCacheEngineKey downstream (lookup, store, retrieve,
+        # free_lookup_locks). See vllm-project/vllm#42119.
+        self.cache_salt: str = _augment_cache_salt(request)
         self.all_token_ids = request.all_token_ids
         self.block_hashes = ConstantList(request.block_hashes)
         self.allocated_block_ids = []

--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 import enum
+import hashlib
 import os
 from collections.abc import Iterable
 from dataclasses import dataclass, field
@@ -21,7 +22,7 @@ from vllm.v1.attention.backend import AttentionMetadata
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.outputs import KVConnectorOutput
 from vllm.v1.request import RequestStatus
-from vllm.v1.utils import ConstantList
+from vllm.v1.utils import ConstantList, tensor_data
 
 try:
     from lmcache.integration.vllm.vllm_multi_process_adapter import (
@@ -220,7 +221,22 @@ class LMCacheMPRequestTracker:
 
     def __init__(self, request: "Request"):
         self.request_id = request.request_id
-        self.cache_salt: str = request.cache_salt or ""
+        # When the request is prompt_embeds-only, `request.all_token_ids` is a
+        # placeholder list of zeros (see vllm/v1/request.py). Token IDs alone
+        # therefore cannot distinguish two same-length prompt_embeds requests,
+        # so the LMCache external KV key must also reflect the embedding
+        # contents. We fold a digest of the prompt_embeds tensor into the
+        # cache_salt so it propagates through every IPCCacheEngineKey derived
+        # from this tracker (lookup, store, retrieve, free_lookup_locks).
+        # See https://github.com/vllm-project/vllm/issues/42119.
+        base_salt = request.cache_salt or ""
+        if request.prompt_embeds is not None:
+            embeds_digest = hashlib.sha256(
+                tensor_data(request.prompt_embeds)
+            ).hexdigest()
+            self.cache_salt: str = f"{base_salt}|pe:{embeds_digest}"
+        else:
+            self.cache_salt = base_salt
         self.all_token_ids = request.all_token_ids
         self.block_hashes = ConstantList(request.block_hashes)
         self.allocated_block_ids = []

--- a/vllm/v1/request.py
+++ b/vllm/v1/request.py
@@ -127,6 +127,11 @@ class Request:
         # Cache per-block prompt-embed hashes to avoid rehashing the same
         # tensor slices when generating extra keys.
         self._prompt_embeds_per_block_hashes: dict[tuple[int, int], bytes] = {}
+        # Cache a single whole-tensor prompt-embed digest. Used by external KV
+        # connectors (e.g. LMCacheMP) that need a request-level identity string
+        # rather than per-block hashes. Lazily populated to avoid the D2H copy
+        # for requests that never reach a KV connector path.
+        self._prompt_embeds_digest: str | None = None
         self.num_prompt_tokens = length_from_prompt_token_ids_or_embeds(
             prompt_token_ids, prompt_embeds
         )


### PR DESCRIPTION
## Summary
- Fixes #42119: two prompt_embeds-only requests with the same length and the same `cache_salt` could share LMCache external KV entries, causing request B to retrieve request A's KV after a vLLM restart.
- Folds a SHA-256 digest of `request.prompt_embeds` into `LMCacheMPRequestTracker.cache_salt`, so the augmented salt propagates into every `IPCCacheEngineKey` derived from the tracker (lookup, store, retrieve, `free_lookup_locks`).
- Token-only requests are unaffected — when `prompt_embeds is None`, the salt is left exactly as before.

## Root cause
For prompt_embeds-only requests, `vllm/v1/request.py` initializes `_all_token_ids` as `[0] * num_prompt_tokens`. The MP connector's key path (`token_ids` + `cache_salt`) therefore cannot distinguish two same-length embedding inputs. Local APC mixes per-block prompt-embed hashes via `_gen_prompt_embeds_extra_hash_keys` (`vllm/v1/core/kv_cache_utils.py`), but that path is bypassed when local prefix caching is disabled (or simply not consulted by the external KV path). The non-MP `lmcache_connector.py` path is unaffected because its adapter asserts `prompt_token_ids is not None`.

## Fix
Augment `tracker.cache_salt` once in `LMCacheMPRequestTracker.__init__`:
```python
if request.prompt_embeds is not None:
    embeds_digest = hashlib.sha256(tensor_data(request.prompt_embeds)).hexdigest()
    self.cache_salt = f"{base_salt}|pe:{embeds_digest}"
```
All four call sites that hand a salt to LMCache (`maybe_submit_lookup_request`, `GetStoreMetadata`, `GetRetrieveMetadata`, and the implicit `free_lookup_locks` keyed on the same lookup) read from `tracker.cache_salt`, so they pick up the augmented value automatically. No LMCache or wire-protocol change required.

### Trade-off
Two requests with the *same* prompt_embeds tensor still produce the same augmented salt, so retrieval after a restart for the same input still works. Cross-request sharing of *identical* embeddings between different sessions remains. We do not get cross-prompt KV sharing for embeddings that happen to share token suffixes — that would require first-class per-block extra-keys in `LoadStoreOp` / `IPCCacheEngineKey` (mirroring vLLM APC's `extra_keys`), which is a larger change worth a follow-up.

## Test plan
**Unit tests** (added in `tests/v1/kv_connector/unit/test_lmcache_mp_prompt_embeds_key.py`):
- [x] Distinct prompt_embeds with same shape + same `cache_salt` produce distinct tracker salts.
- [x] Identical prompt_embeds + same `cache_salt` produce identical tracker salts (retrieval still works post-restart for the same input).
- [x] Token-only requests keep the user-provided `cache_salt` unchanged.
- [x] Token-only request with no `cache_salt` keeps the historical empty-string salt.
- [x] Prompt-embeds requests without a user salt still produce distinct tracker salts.

**Manual reproduction** (from #42119, not run in CI):
- [ ] Serve `Qwen/Qwen2.5-7B-Instruct` with `--enable-prompt-embeds`, `--no-enable-prefix-caching`, and `LMCacheMPConnector` against persistent FS storage.
- [ ] Send prompt_embeds A with `cache_salt="same"`, stop vLLM, restart, send prompt_embeds B (same length, same salt). With this fix, B should not receive an external retrieve and should match the cold-B reference.
- [ ] Confirm A-after-A still hits external KV (sharing the same embedding still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)