### PR TITLE
[Bugfix] Allow disable_any_whitespace with auto backend

### DIFF
--- a/tests/config/test_structured_outputs_config.py
+++ b/tests/config/test_structured_outputs_config.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.config.structured_outputs import StructuredOutputsConfig
+
+
+class TestDisableAnyWhitespace:
+    """Tests for disable_any_whitespace config validation."""
+
+    def test_auto_backend_allows_disable_any_whitespace(self):
+        """backend='auto' should accept disable_any_whitespace=True,
+        since auto resolves to xgrammar or guidance at runtime."""
+        config = StructuredOutputsConfig(
+            backend="auto",
+            disable_any_whitespace=True,
+        )
+        assert config.disable_any_whitespace is True
+        assert config.backend == "auto"
+
+    def test_xgrammar_backend_allows_disable_any_whitespace(self):
+        config = StructuredOutputsConfig(
+            backend="xgrammar",
+            disable_any_whitespace=True,
+        )
+        assert config.disable_any_whitespace is True
+
+    def test_guidance_backend_allows_disable_any_whitespace(self):
+        config = StructuredOutputsConfig(
+            backend="guidance",
+            disable_any_whitespace=True,
+        )
+        assert config.disable_any_whitespace is True
+
+    def test_outlines_backend_rejects_disable_any_whitespace(self):
+        with pytest.raises(ValueError, match="disable_any_whitespace"):
+            StructuredOutputsConfig(
+                backend="outlines",
+                disable_any_whitespace=True,
+            )
+
+    def test_lm_format_enforcer_rejects_disable_any_whitespace(self):
+        with pytest.raises(ValueError, match="disable_any_whitespace"):
+            StructuredOutputsConfig(
+                backend="lm-format-enforcer",
+                disable_any_whitespace=True,
+            )
+
+    def test_default_disable_any_whitespace_is_false(self):
+        config = StructuredOutputsConfig()
+        assert config.disable_any_whitespace is False

--- a/vllm/config/structured_outputs.py
+++ b/vllm/config/structured_outputs.py
@@ -26,8 +26,9 @@ class StructuredOutputsConfig:
     disable_any_whitespace: bool = False
     """If `True`, json output will always be compact without any whitespace.
     If `False`, the model may generate whitespace between JSON fields,
-    which is still valid JSON. This is only supported for xgrammar
-    and guidance backends."""
+    which is still valid JSON. This is supported for the xgrammar,
+    guidance, and auto backends (auto resolves to one of these at
+    runtime)."""
     disable_additional_properties: bool = False
     """If `True`, the `guidance` backend will not use `additionalProperties`
     in the JSON schema. This is only supported for the `guidance` backend and
@@ -61,7 +62,11 @@ class StructuredOutputsConfig:
 
     @model_validator(mode="after")
     def _validate_structured_output_config(self) -> Self:
-        if self.disable_any_whitespace and self.backend not in ("xgrammar", "guidance"):
+        if self.disable_any_whitespace and self.backend not in (
+            "auto",
+            "xgrammar",
+            "guidance",
+        ):
             raise ValueError(
                 "disable_any_whitespace is only supported for "
                 "xgrammar and guidance backends."

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -890,6 +890,13 @@ class SamplingParams(
                 if skip_guidance:
                     # Fall back to outlines if the tokenizer is non-tekken Mistral or
                     # the schema contains features unsupported by guidance
+                    if structured_outputs_config.disable_any_whitespace:
+                        logger.warning(
+                            "disable_any_whitespace is not supported by the "
+                            "outlines backend and will be ignored. To use "
+                            "disable_any_whitespace, set the backend to "
+                            "'xgrammar' or 'guidance' explicitly."
+                        )
                     validate_structured_output_request_outlines(self)
                     self.structured_outputs._backend = "outlines"
                 else:


### PR DESCRIPTION
## Purpose

The `auto` backend resolves to `xgrammar` or `guidance` at runtime, both of which support `disable_any_whitespace`. But the validator rejected `auto` because it was not in the allow-list, forcing users to hardcode a specific backend to use compact JSON output.

Add `auto` to the allowed backends for `disable_any_whitespace`, update the docstring, and add a warning when `auto` falls back to `outlines` (which ignores the flag).

## Test Plan

```bash
pytest tests/config/test_structured_outputs_config.py -v
```

## Test Result

All 6 tests pass: `auto`, `xgrammar`, and `guidance` accept the flag; `outlines` and `lm-format-enforcer` reject it; default is `False`.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>