### PR TITLE
[CI/Build] Use modelscope's international site for regression test

### DIFF
--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -56,9 +56,10 @@ def test_gc():
 
 
 def test_model_from_modelscope(monkeypatch: pytest.MonkeyPatch):
-    # model: https://modelscope.cn/models/qwen/Qwen1.5-0.5B-Chat/summary
+    # model: https://www.modelscope.ai/models/qwen/Qwen1.5-0.5B-Chat
     with monkeypatch.context() as m:
         m.setenv("VLLM_USE_MODELSCOPE", "True")
+        m.setenv("MODELSCOPE_DOMAIN", "www.modelscope.ai")
         # Don't use HF_TOKEN for ModelScope repos, otherwise it will fail
         # with 400 Client Error: Bad Request.
         m.setenv("HF_TOKEN", "")


### PR DESCRIPTION



## Purpose
- Refer to https://www.modelscope.ai/docs/models/download (it's not mentioned in the CN site's documentation 😂)
- CI's AWS machine sometimes can hardly connect to the default `modelscope.cn` CN site.
- Use the international site `modelscope.ai` which should be more stable for CI machine

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

