### PR TITLE
Isolate workspaces by CUDA graph runtime mode

### DIFF
--- a/tests/v1/worker/test_workspace.py
+++ b/tests/v1/worker/test_workspace.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+from vllm.config import CUDAGraphMode
+from vllm.forward_context import ForwardContext, override_forward_context
+from vllm.v1.worker import workspace
+from vllm.v1.worker.workspace import WorkspaceManager
+
+
+def _forward_context(mode: CUDAGraphMode) -> ForwardContext:
+    return ForwardContext(
+        no_compile_layers={},
+        attn_metadata={},
+        slot_mapping={},
+        cudagraph_runtime_mode=mode,
+    )
+
+
+def _workspace_data_ptr(manager: WorkspaceManager) -> int:
+    (buffer,) = manager.get_simultaneous(((4,), torch.float32))
+    return buffer.data_ptr()
+
+
+def test_workspace_buffers_are_isolated_by_cudagraph_runtime_mode():
+    manager = WorkspaceManager(torch.device("cpu"), num_ubatches=1)
+
+    ptrs = []
+    for mode in (
+        CUDAGraphMode.NONE,
+        CUDAGraphMode.PIECEWISE,
+        CUDAGraphMode.FULL,
+    ):
+        with override_forward_context(_forward_context(mode)):
+            ptrs.append(_workspace_data_ptr(manager))
+
+    assert len(ptrs) == len(set(ptrs))
+
+
+def test_workspace_buffer_is_reused_for_same_cudagraph_runtime_mode():
+    manager = WorkspaceManager(torch.device("cpu"), num_ubatches=1)
+
+    with override_forward_context(_forward_context(CUDAGraphMode.FULL)):
+        first_ptr = _workspace_data_ptr(manager)
+        second_ptr = _workspace_data_ptr(manager)
+
+    assert first_ptr == second_ptr
+
+
+def test_workspace_buffers_remain_isolated_by_ubatch(monkeypatch):
+    manager = WorkspaceManager(torch.device("cpu"), num_ubatches=2)
+
+    with override_forward_context(_forward_context(CUDAGraphMode.FULL)):
+        monkeypatch.setattr(workspace, "dbo_current_ubatch_id", lambda: 0)
+        ubatch0_ptr = _workspace_data_ptr(manager)
+        monkeypatch.setattr(workspace, "dbo_current_ubatch_id", lambda: 1)
+        ubatch1_ptr = _workspace_data_ptr(manager)
+
+    assert ubatch0_ptr != ubatch1_ptr

--- a/vllm/v1/worker/workspace.py
+++ b/vllm/v1/worker/workspace.py
@@ -31,7 +31,8 @@ _manager: "WorkspaceManager | None" = None
 class WorkspaceManager:
     """Manager for workspace allocation.
 
-    Manages one workspace buffer per active ubatch slot.
+    Manages workspace buffers per active ubatch slot and CUDA graph
+    runtime mode.
     Can be locked to prevent further growth during execution.
     """
 
@@ -39,9 +40,10 @@ class WorkspaceManager:
         self._device = device
         # Cache num ubatches at init based on configuration (default to 1)
         self._num_ubatches = num_ubatches if num_ubatches is not None else 1
+        self._num_runtime_modes = 3
         self._current_workspaces: list[torch.Tensor | None] = [
             None
-        ] * self._num_ubatches
+        ] * (self._num_ubatches * self._num_runtime_modes)
         self._locked: bool = False
 
     @staticmethod
@@ -125,8 +127,8 @@ class WorkspaceManager:
         Returns:
             The current workspace tensor.
         """
-        ubatch_id = dbo_current_ubatch_id()
-        current_workspace = self._current_workspaces[ubatch_id]
+        ubatch_id, workspace_idx = self._get_workspace_index()
+        current_workspace = self._current_workspaces[workspace_idx]
         current_size = self._workspace_size_bytes(current_workspace)
 
         if current_size < required_bytes:
@@ -165,7 +167,7 @@ class WorkspaceManager:
             # ubatches resize lazily on their next get_simultaneous call.
             # Resizing all ubatches here would orphan the other ubatch's
             # old tensor when it still holds views into it (DBO leak).
-            self._current_workspaces[ubatch_id] = None
+            self._current_workspaces[workspace_idx] = None
             del current_workspace
             # Release the freed segment back to CUDA so the caching
             # allocator can reuse the GPU memory for the larger
@@ -173,22 +175,40 @@ class WorkspaceManager:
             # dead segment in reserved memory which can cause higher peak
             # memory usage.
             torch.accelerator.empty_cache()
-            self._current_workspaces[ubatch_id] = torch.empty(
+            self._current_workspaces[workspace_idx] = torch.empty(
                 (required_bytes,), dtype=torch.uint8, device=self._device
             )
-            current_workspace = self._current_workspaces[ubatch_id]
+            current_workspace = self._current_workspaces[workspace_idx]
 
             if envs.VLLM_DEBUG_WORKSPACE:
                 logger.info(
                     "[WORKSPACE DEBUG] Resized workspace from '%s': %.2f MB -> "
-                    "%.2f MB (ubatch %d)",
+                    "%.2f MB (ubatch %d, workspace slot %d)",
                     get_caller_info(),
                     current_size / _MB,
                     required_bytes / _MB,
                     ubatch_id,
+                    workspace_idx,
                 )
 
         return current_workspace
+
+    def _get_workspace_index(self) -> tuple[int, int]:
+        """Return the ubatch id and workspace slot for the current forward."""
+        ubatch_id = dbo_current_ubatch_id()
+        mode_offset = 0
+
+        from vllm.forward_context import (
+            get_forward_context,
+            is_forward_context_available,
+        )
+
+        if is_forward_context_available():
+            cudagraph_runtime_mode = get_forward_context().cudagraph_runtime_mode
+            if cudagraph_runtime_mode.is_valid_runtime_mode():
+                mode_offset = int(cudagraph_runtime_mode.value)
+
+        return ubatch_id, ubatch_id * self._num_runtime_modes + mode_offset
 
 
 def is_workspace_manager_initialized() -> bool:


### PR DESCRIPTION
## Summary

Fixes CUDA graph workspace aliasing by keying `WorkspaceManager` scratch
buffers by both ubatch slot and CUDA graph runtime mode.

Before this change, all runtime modes for a ubatch reused the same workspace
buffer. With mixed `FULL_AND_PIECEWISE` CUDA graphs, that lets `FULL` and
`PIECEWISE` graph capture/replay share mutable scratch addresses. This PR gives
`NONE`, `PIECEWISE`, and `FULL` separate workspace slots while preserving reuse
within the same runtime mode.

This is a code fix, not a settings workaround: it keeps `FULL_AND_PIECEWISE`
enabled.

## Why this is not a duplicate

Required duplicate-work checks:

- Fetched issue #31856 comments with:
  `gh issue view 31856 --repo vllm-project/vllm --json number,title,state,comments`
- Searched open PRs with:
  `gh pr list --repo vllm-project/vllm --state open --search "31856 in:body"`
- Searched open PRs with:
  `gh pr list --repo vllm-project/vllm --state open --search "NVFP4 MoE CUTLASS FULL_AND_PIECEWISE workspace cudagraph repeats"`

The only matching open PR was my superseded draft #42171. I closed it before
opening this PR. After closing #42171, both open-PR searches returned no
matches.

## Evidence

Earlier paired traces on `umb-b300-dp-146`, using `MiniMax-M2.7-NVFP4`, q8,
concurrency 2, 16k tokens, CUTLASS NVFP4 MoE:

- `FULL_AND_PIECEWISE + VLLM_CUTLASS`: `2/2` strict repeats
- `FULL_DECODE_ONLY + VLLM_CUTLASS`: `0/2` strict repeats

Both replayed token batch 2 as runtime mode `FULL`, so the issue is not simply
FULL decode graph replay. The bad interaction is mixed graph runtime state plus
shared mutable workspace scratch.

Larger fix experiments on `umb-b300-dp-146`:

- no-overlay stock A: `2/2` strict repeats
- no-overlay stock B: `0/2` strict repeats, showing launch-to-launch intermittency
- separate output/workspace buffer experiment: `2/2` strict repeats
- workspace-by-graph-mode experiment: `0/2` strict repeats

Follow-up on `umb-b300-dp-199`:

- Pulled matching `vllm/vllm-openai:v0.20.1` image.
- Created an exact PR-code package overlay from stock `v0.20.1` plus this
  `workspace.py` patch.
- Import-tested the overlay in Docker successfully.
- Launched a 4-lane validation on GPUs 0-7:
  - two stock `FULL_AND_PIECEWISE` lanes
  - two PR-code overlay `FULL_AND_PIECEWISE` lanes
- SSH to `umb-b300-dp-199` later started closing after auth, so I could not
  recover final JSON artifacts. All four experiment HTTP ports later went down,
  so the launched GPU servers were no longer reachable.

## Tests

- `git diff --check`
- Docker import test of the PR-code overlay on `umb-b300-dp-199`
- Added CPU unit coverage in `tests/v1/worker/test_workspace.py`:
  - workspace pointers differ across `NONE`, `PIECEWISE`, and `FULL`
  - workspace pointer is reused for the same runtime mode
  - workspace pointers still differ across ubatch slots

I could not run local pytest because this checkout has no `.venv/bin/python`
and no `uv` on PATH, and the repo instructions prohibit system `python3` or
bare `pip`.

## AI assistance

AI assistance was used to investigate the issue, run experiments, and draft the
patch. A human submitter should review every changed line and validate the test
coverage before marking this PR ready for review.
