### PR TITLE
[Bugfix] Skip non-local layers in initialize_attn_backend for PP

### DIFF
--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -6360,6 +6360,17 @@ class GPUModelRunner(
             # they are cached correctly, there will be different objects per
             # layer.
             for layer_name in kv_cache_group_spec.layer_names:
+                # In pipeline-parallel setups with custom layer
+                # partitions, ``kv_cache_group_spec.layer_names``
+                # contains the global layer names (across all PP
+                # ranks) but ``layers`` is the rank-local dict of
+                # layers actually instantiated on this worker. Skip
+                # layers not owned by the current rank — they will be
+                # set up on the rank that does own them. Without this
+                # guard we KeyError on the next line for any layer
+                # that lives on another PP rank.
+                if layer_name not in layers:
+                    continue
                 attn_backend = layers[layer_name].get_attn_backend()
 
                 if layer_name in self.kv_sharing_fast_prefill_eligible_layers:


### PR DESCRIPTION
## Summary

Fix a `KeyError: 'model.layers.X.attn.attn'` raised during engine initialisation when pipeline-parallel is used with a custom layer partition.

## The bug

`initialize_attn_backend` (in `vllm/v1/worker/gpu_model_runner.py`) iterates over `kv_cache_group_spec.layer_names`, which contains the **global** layer names across the whole pipeline, but indexes the **rank-local** `layers` dict returned by `get_layers_from_vllm_config`. Layers belonging to other PP ranks are absent from `layers`, so the `layers[layer_name]` lookup raises `KeyError` during engine startup.

## The fix

Add an `if layer_name not in layers: continue` guard. Layers owned by other ranks have their attention backends set up on those ranks; the local rank only needs to register backends for its own layers.

## Reproducers

**Reproducer 1 — `gpt-oss-120b` PP-3:**
```bash
VLLM_PP_LAYER_PARTITION="22,3,11" vllm serve openai/gpt-oss-120b \
  --pipeline-parallel-size 3 \
  --distributed-executor-backend ray \
  --gpu-memory-utilization 0.95 \
  --max-model-len 4096 \
  --enforce-eager
```
Output:
```
KeyError: 'model.layers.22.attn.attn'
  File "vllm/v1/worker/gpu_model_runner.py", line 6362, in <listcomp>
    attn_backend = layers[layer_name].get_attn_backend()
```

**Reproducer 2 — `Qwen2.5-72B-Instruct-AWQ` PP-2 asymmetric:**
```bash
VLLM_PP_LAYER_PARTITION="48,32" vllm serve Qwen/Qwen2.5-72B-Instruct-AWQ \
  --pipeline-parallel-size 2 \
  --distributed-executor-backend ray \
  --quantization awq_marlin \
  --enforce-eager
```
Same error class (different layer index).

## Verification

Patched build run on a homelab GPU cluster (A6000 + 3090 + A2000 12GB) using `vLLM v0.20.1`. With the patch applied, both reproducers progress past `initialize_attn_backend` and reach the KV-cache budgeting step (the next stage of engine init).

The patched copy lives downstream as a Dockerfile post-install script while waiting for the upstream merge: https://github.com/imlach/cluster-iac/blob/spike/vllm-pp-keyerror-patch/containers/vllm-ray/patch_pp_keyerror.py

## What this PR does NOT change

The deeper question of whether `kv_cache_group_spec.layer_names` should be pre-filtered to local layers is left to maintainers — this PR is a defensive guard at the consumer site that unblocks PP+custom-partition users today without affecting non-PP code paths (`layer_name in layers` is true for all elements when PP=1 or when partition is contiguous).

🤖 Generated with [Claude Code](https://claude.com/claude-code)