### PR TITLE
[Bugfix] Accept canonicalized `modelopt_*` quant_method in `_extract_modelopt_quant_algo`

### DIFF
--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -245,7 +245,7 @@ class ModelOptQuantConfigBase(QuantizationConfig):
         """
         if hf_quant_cfg is None:
             return None
-        if hf_quant_cfg.get("quant_method", "").lower() != "modelopt":
+        if not hf_quant_cfg.get("quant_method", "").lower().startswith("modelopt"):
             return None
         if "quantization" in hf_quant_cfg:
             quant_config = hf_quant_cfg["quantization"]


### PR DESCRIPTION
`ModelArchConfigConvertorBase._normalize_quantization_config` rewrites `quant_method` to the family-specific name (e.g. `"modelopt_fp4"` for the legacy `hf_quant_config.json` shape with `quant_algo: "NVFP4"`). `_extract_modelopt_quant_algo` then strict-equals against `"modelopt"` and returns `None`, so the override loop in `ModelConfig._verify_quantization` finds no match and validation raises:

> Quantization method specified in the model config (modelopt_fp4) does not match the quantization method specified in the `quantization` argument (modelopt).

This was hitting `nvidia/Qwen3.5-397B-A17B-NVFP4` with `--quantization modelopt` intermittently — one of several spawn-context API-server processes resolved the legacy `hf_quant_config.json` instead of the modern `config.json` and the strict check tipped it over.

Replace the equality with `startswith("modelopt")`. Covers all four registered variants (`modelopt`, `modelopt_fp4`, `modelopt_mxfp8`, `modelopt_mixed`) and matches what `humming.py` (`config["quant_method"] in [..., "modelopt"]`) and `utils/torch_utils.py:315` (`quant_method.startswith("modelopt")`) already accept.