### PR TITLE
[Bugfix] Gemma 4 chat template crash with missing tool name and tool id

### DIFF
--- a/examples/tool_chat_template_gemma4.jinja
+++ b/examples/tool_chat_template_gemma4.jinja
@@ -263,7 +263,7 @@
             {%- if message.get('tool_responses') -%}
                 {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
                 {%- for tool_response in message['tool_responses'] -%}
-                    {{- format_tool_response_block(tool_response['name'] | default('unknown'), tool_response['response']) -}}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown', true), tool_response['response']) -}}
                     {%- set ns_tr_out.flag = true -%}
                     {%- set ns.prev_message_type = 'tool_response' -%}
                 {%- endfor -%}
@@ -277,7 +277,7 @@
                     {%- else -%}
                         {%- set follow = loop_messages[k] -%}
                         {#- Resolve tool_call_id to function name -#}
-                        {%- set ns_tname = namespace(name=follow.get('name') | default('unknown')) -%}
+                        {%- set ns_tname = namespace(name=follow.get('name') | default('unknown', true)) -%}
                         {%- for tc in message['tool_calls'] -%}
                             {%- if tc.get('id') == follow.get('tool_call_id') -%}
                                 {%- set ns_tname.name = tc['function']['name'] -%}


### PR DESCRIPTION
## Purpose

Gemma 4's chat template does not handle missing names in tool results correctly. The intended behavior is to default to \"unknown\" but it's kept as a `None` value instead. As a result, later in `format_tool_response_block`, the `None` tool name triggers a hard crash.

This bug manifests on the legacy `tool_responses` path when tool name is missing. It manifests on the `OpenAI Chat Completions` path when the following message does not contain a `name` and does not contain a `tool_call_id` (or if the `tool_call_id` does not match the tool call).

This defect is present in both `examples/tool_chat_template_gemma4.jinja` and default chat template from HF.

## Test Plan

`repro.py`
```
import argparse
from pathlib import Path

from transformers import AutoTokenizer


parser = argparse.ArgumentParser()
parser.add_argument(
    "--chat-template",
    type=Path,
    help="Path to a Jinja chat template override.",
)
args = parser.parse_args()

apply_chat_template_kwargs = {}
if args.chat_template is not None:
    apply_chat_template_kwargs["chat_template"] = (
        args.chat_template.expanduser().read_text(encoding="utf-8"))

tok = AutoTokenizer.from_pretrained(
    "google/gemma-4-31B-it",
)
messages = [
    {"role": "user", "content": "hi"},
    {
        "role": "assistant",
        "tool_calls": [
            {
                "id": "call_B",
                "type": "function",
                "function": {
                    "name": "get_weather",
                    "arguments": {"city": "SF"},
                },
            }
        ],
    },
    {
        "role": "tool",
        "tool_call_id": "call_A",  # missing or incorrect tool_call_id
        "content": "sunny",
    },
]
print(
    tok.apply_chat_template(
        messages,
        tokenize=False,
        **apply_chat_template_kwargs,
    ))
```

```
pytest tests/renderers/test_gemma4_chat_template.py
pytest tests/tool_parsers/test_gemma4_tool_parser.py
pytest tests/tool_use/test_gemma4_responses_adjust_request.py
```

## Test Result

```
repro.py --chat-template examples/tool_chat_template_gemma4.jinja
```
crashes with `TypeError: can only concatenate str (not "NoneType") to str` before this fix.

Unit tests pass

Made with [Cursor](https://cursor.com)