### PR TITLE
Fix mypy failure on main

### DIFF
--- a/tests/compile/correctness_e2e/test_sequence_parallel.py
+++ b/tests/compile/correctness_e2e/test_sequence_parallel.py
@@ -435,6 +435,7 @@ def test_tp_sp_nvfp4_generation(num_gpus_available: int):
         num_gpus_available,
         use_inductor_graph_partition=False,
         fuse_gemm_comms=False,
+        enable_prompt_embeds=False,
         method="generate",
         is_multimodal=False,
         dtype="bfloat16",


### PR DESCRIPTION
## Purpose

Fixes the mypy failure caused by #33322 making `enable_prompt_embeds` required in `_compare_sp` while #41882 added an NVFP4 sequence-parallel test call without passing it