### PR TITLE
[Bugfix][Mooncake] Fix DP worker bootstrap register ReadTimeout race

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py
@@ -922,13 +922,25 @@ class MooncakeConnectorWorker:
         )
         while True:
             try:
-                async with httpx.AsyncClient() as client:
+                # timeout=30s: the bootstrap server runs inside the DP0 worker
+                # process and can stall the uvicorn event loop for several
+                # seconds while DP0 is holding the GIL (e.g. EFA MR
+                # registration of multi-GB KV caches across many NICs). The
+                # httpx default of 5s is not enough headroom and causes
+                # non-DP0 workers to hit ReadTimeout even though the server
+                # eventually responds 200 OK.
+                async with httpx.AsyncClient(timeout=30.0) as client:
                     response = await client.post(url, json=payload.model_dump())
                     response.raise_for_status()
                 logger.debug("Successfully registered with bootstrap server at %s", url)
                 break
-            except httpx.ConnectError:
-                # Bootstrap server not ready, wait for a while and retry.
+            except (
+                httpx.ConnectError,
+                httpx.TimeoutException,
+                httpx.RemoteProtocolError,
+            ):
+                # Bootstrap server not ready / event loop momentarily starved
+                # / connection dropped mid-flight. Wait for a while and retry.
                 await asyncio.sleep(1)
             except Exception as e:
                 err_msg = (


### PR DESCRIPTION
The Mooncake bootstrap server (uvicorn) runs inside the DP0 worker process. During startup, DP0 holds the GIL for several seconds while registering large KV-cache memory regions with the transport backend (e.g. EFA MR registration across many NICs, ~2-3s per chunk), which stalls the uvicorn event loop. Non-DP0 workers calling `/register` concurrently then hit `httpx.ReadTimeout` under the default 5s client timeout, even though the server eventually responds 200 OK. The old code only retried `httpx.ConnectError` and re-raised all other exceptions, so `ready_event` was never set and `register_kv_caches` blocked forever, leading to a NCCL collective timeout across the DP group.

Fix:

- Raise the httpx client timeout to 30s to tolerate event-loop starvation caused by GIL-bound backend registration on DP0.
- Retry `httpx.TimeoutException` and `httpx.RemoteProtocolError` the same way we already retry `httpx.ConnectError`, since both are transient symptoms of a momentarily busy bootstrap server. Non- transient failures (e.g. HTTPStatusError) still propagate.


## Purpose

Fix a startup-time deadlock in the Mooncake KV connector where non-DP0
workers fail to register with the bootstrap server under a GIL-contended
DP0, causing the whole DP group to hang until a NCCL collective timeout.

**File touched:** `vllm/distributed/kv_transfer/kv_connector/v1/mooncake/mooncake_connector.py`
(15 insertions, 3 deletions — most of that is a comment explaining the timing constraint.)

### Root cause

The Mooncake bootstrap server is a uvicorn app that runs **inside the
DP0 worker process**. All DP workers (DP0..DP_N-1) POST `/register` to
it concurrently during startup, right after `register_kv_caches`.

On DP0, `register_kv_caches` calls into the transport backend to
register the KV-cache memory regions. On EFA in particular, each chunk
takes ~2–3s to register, and large KV caches may be spread across many
NICs (we observe 16 NICs on p5en), so this call can hold the GIL for a
while.

While DP0 is in that path, the uvicorn event loop inside the same
process is starved and cannot respond to in-flight POSTs. The httpx
client on the caller side — `httpx.AsyncClient()` with the **default
5s** total timeout — then raises `httpx.ReadTimeout` even though the
server eventually does respond `200 OK` a few seconds later.

Old behavior in `register_worker_with_bootstrap`:

```python
try:
    async with httpx.AsyncClient() as client:         # timeout=5s (default)
        response = await client.post(url, json=...)
        response.raise_for_status()
    break
except httpx.ConnectError:
    await asyncio.sleep(1)                            # only retries ConnectError
except Exception as e:
    err_msg = (... if isinstance(e, HTTPStatusError) else str(e))
    logger.error("Error registering %s with bootstrap server: %s", payload, err_msg)
    raise e                                           # <-- fatal for ReadTimeout
```

Because `httpx.ReadTimeout` is neither `ConnectError` nor
`HTTPStatusError`, it fell through to `raise e` and killed that
worker's registration coroutine. `ready_event` is never set, the
`_mooncake_sender_listener` background task never completes, and
`register_kv_caches` blocks until the NCCL watchdog across the DP group
fires and tears the whole startup down.

One additional cosmetic symptom: `str(httpx.ReadTimeout("", ...))` is
`""`, so the log line reads
`Error registering engine_id='..._dp2' ... with bootstrap server:`
with **empty err_msg**, which makes the failure extra hard to diagnose.

On our reproducer (2× p5en.48xlarge, DP=8), the failing rank is
random (DP1/DP2 most often, but any non-DP0 rank can lose the race),
which further argues for a timing problem rather than a configuration
one.

### Fix

- `httpx.AsyncClient()` → `httpx.AsyncClient(timeout=30.0)`. 30s
  comfortably covers the observed GIL-contended window (a few seconds
  per chunk × a handful of chunks) while still catching genuinely
  broken deployments.
- Add `httpx.TimeoutException` and `httpx.RemoteProtocolError` to the
  retry `except` clause. Both are transient symptoms of a momentarily
  busy bootstrap server; the existing retry loop around
  `httpx.ConnectError` is the right handler for them.
- `except Exception as e: ... raise e` path is **unchanged**. Real
  errors (4xx/5xx from the server, auth issues, etc.) still propagate
  as before.

---

## Test Plan

Verified on the same environment where the deadlock was originally hit:

- **Hardware:** 2× `p5en.48xlarge` (H200, 16× EFA per node)
- **Model:** DeepSeek-V4-Pro
- **vLLM layout:** 1P1D (prefill + decode pods), DP=8 + EP
- **KV transfer backend:** Mooncake (EFA transport)

Steps:

1. Deploy prefill + decode pods against vLLM main **without** the fix —
   observe the deadlock (logs pasted below).
2. Apply this patch (`mooncake_connector.py` only) and redeploy the
   exact same config.
3. Confirm both prefill and decode reach
   `Application startup complete`, bind `:8001` / `:8002`, and that the
   8 DP workers complete `register_kv_caches` without `ReadTimeout`.
4. Run `vllm bench serve` end-to-end against the service.

---

## Test Result

### Before the fix (reproducer)

Representative lines from a failing startup on vLLM HEAD + Mooncake +
EFA, DeepSeek-V4-Pro on 2× p5en.48xlarge, DP=8:

```
ERROR mooncake_connector.py:912 Error registering engine_id='<engine>_dp2' ... with bootstrap server: ⏎
... (other DP ranks stuck in register_kv_caches) ...
[rank0] NCCL WARN ... collective operation timeout ...
```

(The trailing empty line after `bootstrap server:` is `str(e) == ""`
from `httpx.ReadTimeout`.)

Failing rank is random across runs (observed DP1 and DP2 most often,
but any non-DP0 rank can hit it). Server-side the 8 POSTs eventually
all return `200 OK` — the clients are already gone by then, so the
registration is effectively lost.

### After the fix

- All 8 DP workers complete `register_kv_caches` without `ReadTimeout`.
- Prefill + decode both reach `Application startup complete` and
  listen on `:8001` / `:8002` as expected.
- End-to-end: `vllm bench serve` → **100 successful / 100 requests**.
  End-to-end request path OK.
- Re-ran the same startup multiple times; deadlock no longer
  reproducible.



