### PR TITLE
[Bugfix] Fix int32 overflow in DeepGEMM SiLU/mul FP8 Triton kernel

### DIFF
--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -321,8 +321,8 @@ def _silu_mul_per_token_group_quant_fp8_colmajor(
     pid_n = tl.program_id(1)
     N_2 = N // 2
 
-    m_offset = (pid_m * BLOCK_M).to(tl.int64)
-    n_offset = (pid_n * BLOCK_N).to(tl.int64)
+    m_offset = pid_m.to(tl.int64) * BLOCK_M
+    n_offset = pid_n.to(tl.int64) * BLOCK_N
     if m_offset >= M:
         return
 

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -171,7 +171,7 @@ def _silu_mul_quant_fp8_packed_kernel(
 
     pid_pack = tl.program_id(0)
     pid_m = tl.program_id(1)
-    m_offset = pid_m * BLOCK_M
+    m_offset = (pid_m * BLOCK_M).to(tl.int64)
 
     if m_offset >= M:
         return
@@ -321,8 +321,8 @@ def _silu_mul_per_token_group_quant_fp8_colmajor(
     pid_n = tl.program_id(1)
     N_2 = N // 2
 
-    m_offset = pid_m * BLOCK_M
-    n_offset = pid_n * BLOCK_N
+    m_offset = (pid_m * BLOCK_M).to(tl.int64)
+    n_offset = (pid_n * BLOCK_N).to(tl.int64)
     if m_offset >= M:
         return
 

--- a/vllm/model_executor/layers/quantization/utils/fp8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/fp8_utils.py
@@ -171,7 +171,7 @@ def _silu_mul_quant_fp8_packed_kernel(
 
     pid_pack = tl.program_id(0)
     pid_m = tl.program_id(1)
-    m_offset = (pid_m * BLOCK_M).to(tl.int64)
+    m_offset = pid_m.to(tl.int64) * BLOCK_M
 
     if m_offset >= M:
         return


### PR DESCRIPTION
## Purpose
Fixes #42173

_silu_mul_per_token_group_quant_fp8_colmajor computes row/column offsets using int32 arithmetic:
```python
m_offset = pid_m * BLOCK_M
n_offset = pid_n * BLOCK_N
```
With large DeepGEMM MoE warmup/workspace shapes (e.g. DPEP=16, 36k max tokens per rank), the maximum element offset `M * N - 1 = 18,882,756,607` far exceeds the int32 limit of `2,147,483,647`, causing the Triton kernel to access illegal memory addresses.

This PR promotes m_offset and n_offset to tl.int64 before pointer arithmetic to ensure correct 64-bit memory addressing.

## Test Plan
1. Verified on NVIDIA H100 PCIe (80GB) using a minimal single-GPU reproducer with the first aligned overflow shape:
- M = 524_416, N = 4096
- max_offset = M * N - 1 = 2,148,007,935 (exceeds int32 max)
- Environment: vllm 0.19.0, torch 2.10.0+cu128, triton 3.6.0, cuda 12.8

2. Reproduction script:
```python
import torch
from vllm.model_executor.layers.quantization.utils.fp8_utils import (
    silu_mul_per_token_group_quant_fp8_colmajor,
)

# Single-card minimum overflow shape
M = 524_416
N = 4096

print(f"M={M}, N={N}")
print(f"max_offset = {M*N-1}")
print(f"int32_max  = {2**31-1}")
print(f"overflow?  = {M*N-1 > 2**31-1}")
print()

x = torch.empty((M, N), device="cuda", dtype=torch.bfloat16)
torch.cuda.synchronize()

print("Calling silu_mul_per_token_group_quant_fp8_colmajor ...")
y, scales = silu_mul_per_token_group_quant_fp8_colmajor(x, use_ue8m0=False)
torch.cuda.synchronize()

print(f"successful！output shape={y.shape}, scales shape={scales.shape}")
```

## Test Result

**Before fix:**

```
M=524416, N=4096
max_offset = 2148007935
int32_max  = 2147483647
overflow?  = True
Calling silu_mul_per_token_group_quant_fp8_colmajor ...
File ".../fp8_utils.py", line 785, in silu_mul_per_token_group_quant_fp8_colmajor
_silu_mul_per_token_group_quant_fp8_colmajor[grid](https://github.com/vllm-project/vllm/compare/main...Flink-ddd:vllm:fix/...)
RuntimeError: Triton Error [CUDA]: an illegal memory access was encountered
```

**After fix (testing in progress on H100 PCIe):**

```
M=524416, N=4096
max_offset = 2148007935
int32_max  = 2147483647
overflow?  = True
Calling silu_mul_per_token_group_quant_fp8_colmajor ...
successful！output shape=torch.Size([524416, 2048]), scales shape=torch.Size([524416, 16])
```