### PR TITLE
[CI] Fix main branch pre-commit error (1-line change !)

### DIFF
--- a/tests/compile/correctness_e2e/test_sequence_parallel.py
+++ b/tests/compile/correctness_e2e/test_sequence_parallel.py
@@ -435,6 +435,7 @@ def test_tp_sp_nvfp4_generation(num_gpus_available: int):
         num_gpus_available,
         use_inductor_graph_partition=False,
         fuse_gemm_comms=False,
+        enable_prompt_embeds=False,
         method="generate",
         is_multimodal=False,
         dtype="bfloat16",


### PR DESCRIPTION
## Purpose

Fix mypy failures in the sequence parallel correctness tests after _compare_sp was updated to require the enable_prompt_embeds argument.

## Root Cause

[`0b272a6e0`](https://github.com/vllm-project/vllm/commit/0b272a6e01ab49274ce392dc1684d52143d5fd8e) ([#33322](https://github.com/vllm-project/vllm/pull/33322)) added `enable_prompt_embeds: bool` as a required parameter to `_compare_sp` and updated most call sites, but missed the NVFP4 sequence-parallel test added earlier in [`bc5fdc1e6a`](https://github.com/vllm-project/vllm/commit/bc5fdc1e6a) ([#41882](https://github.com/vllm-project/vllm/pull/41882)). As a result, `test_tp_sp_nvfp4_generation` still called `_compare_sp` without the new argument, causing the mypy pre-commit hooks to fail with:

```
Missing positional argument "enable_prompt_embeds" in call to "_compare_sp"
```

Because this landed on main, recent commits that include `0b272a6e0` inherited the same pre-commit failure.


## Test Plan

```
python -m mypy --python-version 3.12 --follow-imports skip tests/compile/correctness_e2e/test_sequence_parallel.py
```

## Test Result

<img width="1699" height="58" alt="image" src="https://github.com/user-attachments/assets/56543492-2330-4022-81f1-a028cb120510" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

