### PR TITLE
[Bugfix] Fix streaming stop handling during tool parsing

### DIFF
--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -2386,3 +2386,41 @@ async def test_streaming_tool_parser_stop_flush_skips_streamed_content():
     assert "".join(content_deltas) == 'Hello {"n'
     assert final_choice["finish_reason"] == "stop"
     assert final_choice["stop_reason"] == "a"
+
+
+def test_has_unstreamed_tool_parser_state_handles_non_integer_tool_ids():
+    """Handle parser states with missing, None, string, and integer tool IDs."""
+    qwen3coder_initial_state = SimpleNamespace(
+        prev_tool_call_arr=[],
+        streamed_args_for_tool=[],
+        current_tool_id=None,
+    )
+    qwen3coder_active_state = SimpleNamespace(
+        prev_tool_call_arr=[],
+        streamed_args_for_tool=[],
+        current_tool_id="call_abc",
+    )
+    inactive_index_state = SimpleNamespace(
+        prev_tool_call_arr=[],
+        streamed_args_for_tool=[],
+        current_tool_id=-1,
+    )
+    active_index_state = SimpleNamespace(
+        prev_tool_call_arr=[],
+        streamed_args_for_tool=[],
+        current_tool_id=0,
+    )
+    missing_tool_id_state = SimpleNamespace(
+        prev_tool_call_arr=[],
+        streamed_args_for_tool=[],
+    )
+
+    assert not OpenAIServingChat._has_unstreamed_tool_parser_state(
+        missing_tool_id_state
+    )
+    assert not OpenAIServingChat._has_unstreamed_tool_parser_state(
+        qwen3coder_initial_state
+    )
+    assert OpenAIServingChat._has_unstreamed_tool_parser_state(qwen3coder_active_state)
+    assert not OpenAIServingChat._has_unstreamed_tool_parser_state(inactive_index_state)
+    assert OpenAIServingChat._has_unstreamed_tool_parser_state(active_index_state)

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 from contextlib import suppress
 from dataclasses import dataclass, field
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -2127,3 +2128,120 @@ async def test_streaming_n_gt1_independent_tool_parsers():
             f"Choice {choice_idx}: expected finish_reason='tool_calls', "
             f"got '{reasons[0]}'"
         )
+
+
+@pytest.mark.asyncio
+async def test_streaming_tool_parser_preserves_requested_stop_reason():
+    """Requested stops should flush parser-buffered text, not tool-call finish."""
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+
+    serving_chat = _build_serving_chat(mock_engine)
+    serving_chat.enable_auto_tools = True
+    serving_chat.tool_parser = object()
+
+    class ParserWithPartialToolState:
+        def __init__(self, *args, **kwargs):
+            self._stream_state = SimpleNamespace(
+                tool_call_id_type="random",
+                history_tool_call_cnt=0,
+            )
+            self.tool_parser = SimpleNamespace(
+                prev_tool_call_arr=[],
+                streamed_args_for_tool=[""],
+                current_tool_id=-1,
+            )
+
+        def parse_delta(self, delta_text, *args, **kwargs):
+            self.tool_parser.prev_tool_call_arr = [{}]
+            self.tool_parser.current_tool_id = 0
+            return None
+
+    serving_chat.parser_cls = ParserWithPartialToolState
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                    "required": ["location"],
+                },
+            },
+        }
+    ]
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "test"}],
+        stream=True,
+        stop=["a"],
+        tools=tools,
+        tool_choice="auto",
+    )
+
+    async def result_generator():
+        yield RequestOutput(
+            request_id="test-req",
+            prompt="test",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text="{",
+                    token_ids=[123],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                )
+            ],
+            finished=False,
+        )
+        yield RequestOutput(
+            request_id="test-req",
+            prompt="test",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text='"n',
+                    token_ids=[124],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                    finish_reason="stop",
+                    stop_reason="a",
+                )
+            ],
+            finished=True,
+        )
+
+    final_choice = None
+    async for chunk_str in serving_chat.chat_completion_stream_generator(
+        request=request,
+        result_generator=result_generator(),
+        request_id="test-req",
+        model_name=MODEL_NAME,
+        conversation=[],
+        tokenizer=get_tokenizer(MODEL_NAME),
+        request_metadata=RequestResponseMetadata(
+            request_id="test-req",
+            model_name=MODEL_NAME,
+        ),
+    ):
+        if not chunk_str.strip() or "data: [DONE]" in chunk_str:
+            continue
+        data = json.loads(chunk_str.removeprefix("data: ").strip())
+        choice = data["choices"][0]
+        if choice["finish_reason"] is not None:
+            final_choice = choice
+
+    assert final_choice is not None
+    assert final_choice["delta"]["content"] == '{"n'
+    assert final_choice["finish_reason"] == "stop"
+    assert final_choice["stop_reason"] == "a"

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -2132,8 +2132,21 @@ async def test_streaming_n_gt1_independent_tool_parsers():
 
 
 @pytest.mark.asyncio
-async def test_streaming_tool_parser_preserves_requested_stop_reason():
-    """Requested stops should flush parser-buffered text, not tool-call finish."""
+@pytest.mark.parametrize(
+    ("finish_reason", "stop_reason", "request_stop"),
+    [
+        ("stop", "a", ["a"]),
+        ("stop", None, None),
+        ("length", None, None),
+    ],
+    ids=["requested-stop", "eos-stop", "length"],
+)
+async def test_streaming_tool_parser_flushes_buffered_content_on_terminal_finish(
+    finish_reason,
+    stop_reason,
+    request_stop,
+):
+    """Flush parser-buffered raw text for stop, EOS, and length finishes."""
     mock_engine = MagicMock(spec=AsyncLLM)
     mock_engine.errored = False
     mock_engine.model_config = MockModelConfig()
@@ -2177,14 +2190,16 @@ async def test_streaming_tool_parser_preserves_requested_stop_reason():
             },
         }
     ]
-    request = ChatCompletionRequest(
-        model=MODEL_NAME,
-        messages=[{"role": "user", "content": "test"}],
-        stream=True,
-        stop=["a"],
-        tools=tools,
-        tool_choice="auto",
-    )
+    request_kwargs = {
+        "model": MODEL_NAME,
+        "messages": [{"role": "user", "content": "test"}],
+        "stream": True,
+        "tools": tools,
+        "tool_choice": "auto",
+    }
+    if request_stop is not None:
+        request_kwargs["stop"] = request_stop
+    request = ChatCompletionRequest(**request_kwargs)
 
     async def result_generator():
         yield RequestOutput(
@@ -2215,8 +2230,8 @@ async def test_streaming_tool_parser_preserves_requested_stop_reason():
                     token_ids=[124],
                     cumulative_logprob=0.0,
                     logprobs=None,
-                    finish_reason="stop",
-                    stop_reason="a",
+                    finish_reason=finish_reason,
+                    stop_reason=stop_reason,
                 )
             ],
             finished=True,
@@ -2244,13 +2259,13 @@ async def test_streaming_tool_parser_preserves_requested_stop_reason():
 
     assert final_choice is not None
     assert final_choice["delta"]["content"] == '{"n'
-    assert final_choice["finish_reason"] == "stop"
-    assert final_choice["stop_reason"] == "a"
+    assert final_choice["finish_reason"] == finish_reason
+    assert final_choice.get("stop_reason") == stop_reason
 
 
 @pytest.mark.asyncio
 async def test_streaming_tool_parser_stop_flush_skips_streamed_content():
-    """Requested-stop flush should not replay content already streamed."""
+    """Terminal flush should not replay content already streamed."""
     mock_engine = MagicMock(spec=AsyncLLM)
     mock_engine.errored = False
     mock_engine.model_config = MockModelConfig()
@@ -2386,6 +2401,141 @@ async def test_streaming_tool_parser_stop_flush_skips_streamed_content():
     assert "".join(content_deltas) == 'Hello {"n'
     assert final_choice["finish_reason"] == "stop"
     assert final_choice["stop_reason"] == "a"
+
+
+@pytest.mark.asyncio
+async def test_streaming_tool_parser_does_not_flush_after_tool_call_delta():
+    """Keep completed tool-call streams on the tool_calls finish path."""
+    from vllm.entrypoints.openai.engine.protocol import (
+        DeltaFunctionCall,
+        DeltaToolCall,
+    )
+
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+
+    serving_chat = _build_serving_chat(mock_engine)
+    serving_chat.enable_auto_tools = True
+    serving_chat.tool_parser = object()
+
+    class ParserWithStreamedToolThenTerminalState:
+        def __init__(self, *args, **kwargs):
+            self._stream_state = SimpleNamespace(
+                tool_call_id_type="random",
+                history_tool_call_cnt=0,
+            )
+            self.tool_parser = SimpleNamespace(
+                prev_tool_call_arr=[],
+                streamed_args_for_tool=[],
+                current_tool_id=-1,
+            )
+
+        def parse_delta(self, delta_text, *args, **kwargs):
+            if delta_text != "<tool>":
+                return None
+
+            self.tool_parser.prev_tool_call_arr = [
+                {"name": "get_weather", "arguments": {}}
+            ]
+            self.tool_parser.streamed_args_for_tool = ["{}"]
+            self.tool_parser.current_tool_id = 0
+            return DeltaMessage(
+                tool_calls=[
+                    DeltaToolCall(
+                        index=0,
+                        id="call_abc",
+                        type="function",
+                        function=DeltaFunctionCall(
+                            name="get_weather",
+                            arguments="{}",
+                        ),
+                    )
+                ]
+            )
+
+    serving_chat.parser_cls = ParserWithStreamedToolThenTerminalState
+
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "test"}],
+        stream=True,
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+        tool_choice="auto",
+    )
+
+    async def result_generator():
+        yield RequestOutput(
+            request_id="test-req",
+            prompt="test",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text="<tool>",
+                    token_ids=[123],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                )
+            ],
+            finished=False,
+        )
+        yield RequestOutput(
+            request_id="test-req",
+            prompt="test",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text="",
+                    token_ids=[],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                    finish_reason="stop",
+                )
+            ],
+            finished=True,
+        )
+
+    saw_tool_delta = False
+    final_choice = None
+    async for chunk_str in serving_chat.chat_completion_stream_generator(
+        request=request,
+        result_generator=result_generator(),
+        request_id="test-req",
+        model_name=MODEL_NAME,
+        conversation=[],
+        tokenizer=get_tokenizer(MODEL_NAME),
+        request_metadata=RequestResponseMetadata(
+            request_id="test-req",
+            model_name=MODEL_NAME,
+        ),
+    ):
+        if not chunk_str.strip() or "data: [DONE]" in chunk_str:
+            continue
+        data = json.loads(chunk_str.removeprefix("data: ").strip())
+        choice = data["choices"][0]
+        saw_tool_delta |= bool(choice["delta"].get("tool_calls"))
+        if choice["finish_reason"] is not None:
+            final_choice = choice
+
+    assert saw_tool_delta
+    assert final_choice is not None
+    assert final_choice["finish_reason"] == "tool_calls"
+    assert final_choice["delta"].get("content") is None
 
 
 def test_has_unstreamed_tool_parser_state_handles_non_integer_tool_ids():

--- a/tests/entrypoints/openai/chat_completion/test_serving_chat.py
+++ b/tests/entrypoints/openai/chat_completion/test_serving_chat.py
@@ -30,6 +30,7 @@ from vllm.entrypoints.openai.chat_completion.serving import (
     _make_prompt_tokens_details,
 )
 from vllm.entrypoints.openai.engine.protocol import (
+    DeltaMessage,
     ErrorResponse,
     RequestResponseMetadata,
 )
@@ -2243,5 +2244,145 @@ async def test_streaming_tool_parser_preserves_requested_stop_reason():
 
     assert final_choice is not None
     assert final_choice["delta"]["content"] == '{"n'
+    assert final_choice["finish_reason"] == "stop"
+    assert final_choice["stop_reason"] == "a"
+
+
+@pytest.mark.asyncio
+async def test_streaming_tool_parser_stop_flush_skips_streamed_content():
+    """Requested-stop flush should not replay content already streamed."""
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+
+    serving_chat = _build_serving_chat(mock_engine)
+    serving_chat.enable_auto_tools = True
+    serving_chat.tool_parser = object()
+
+    class ParserWithContentThenPartialToolState:
+        def __init__(self, *args, **kwargs):
+            self._stream_state = SimpleNamespace(
+                tool_call_id_type="random",
+                history_tool_call_cnt=0,
+            )
+            self.tool_parser = SimpleNamespace(
+                prev_tool_call_arr=[],
+                streamed_args_for_tool=[""],
+                current_tool_id=-1,
+            )
+
+        def parse_delta(self, delta_text, *args, **kwargs):
+            if delta_text == "Hello ":
+                return DeltaMessage(content=delta_text)
+            self.tool_parser.prev_tool_call_arr = [{}]
+            self.tool_parser.current_tool_id = 0
+            return None
+
+    serving_chat.parser_cls = ParserWithContentThenPartialToolState
+
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "description": "Get weather",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"location": {"type": "string"}},
+                    "required": ["location"],
+                },
+            },
+        }
+    ]
+    request = ChatCompletionRequest(
+        model=MODEL_NAME,
+        messages=[{"role": "user", "content": "test"}],
+        stream=True,
+        stop=["a"],
+        tools=tools,
+        tool_choice="auto",
+    )
+
+    async def result_generator():
+        yield RequestOutput(
+            request_id="test-req",
+            prompt="test",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text="Hello ",
+                    token_ids=[122],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                )
+            ],
+            finished=False,
+        )
+        yield RequestOutput(
+            request_id="test-req",
+            prompt="test",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text="{",
+                    token_ids=[123],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                )
+            ],
+            finished=False,
+        )
+        yield RequestOutput(
+            request_id="test-req",
+            prompt="test",
+            prompt_token_ids=[1, 2, 3],
+            prompt_logprobs=None,
+            outputs=[
+                CompletionOutput(
+                    index=0,
+                    text='"n',
+                    token_ids=[124],
+                    cumulative_logprob=0.0,
+                    logprobs=None,
+                    finish_reason="stop",
+                    stop_reason="a",
+                )
+            ],
+            finished=True,
+        )
+
+    content_deltas = []
+    final_choice = None
+    async for chunk_str in serving_chat.chat_completion_stream_generator(
+        request=request,
+        result_generator=result_generator(),
+        request_id="test-req",
+        model_name=MODEL_NAME,
+        conversation=[],
+        tokenizer=get_tokenizer(MODEL_NAME),
+        request_metadata=RequestResponseMetadata(
+            request_id="test-req",
+            model_name=MODEL_NAME,
+        ),
+    ):
+        if not chunk_str.strip() or "data: [DONE]" in chunk_str:
+            continue
+        data = json.loads(chunk_str.removeprefix("data: ").strip())
+        choice = data["choices"][0]
+        delta_content = choice["delta"].get("content")
+        if delta_content:
+            content_deltas.append(delta_content)
+        if choice["finish_reason"] is not None:
+            final_choice = choice
+
+    assert final_choice is not None
+    assert final_choice["delta"]["content"] == '{"n'
+    assert "".join(content_deltas) == 'Hello {"n'
     assert final_choice["finish_reason"] == "stop"
     assert final_choice["stop_reason"] == "a"

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1217,8 +1217,14 @@ class OpenAIServingChat(OpenAIServing):
         shape need to expose equivalent state here, or provide a generic flush
         hook, so requested-stop handling can preserve their buffered text.
         """
+        current_tool_id = getattr(tool_parser, "current_tool_id", None)
+        has_current_tool = (
+            isinstance(current_tool_id, int)
+            and not isinstance(current_tool_id, bool)
+            and current_tool_id >= 0
+        ) or (isinstance(current_tool_id, str) and bool(current_tool_id))
         return bool(
             getattr(tool_parser, "prev_tool_call_arr", None)
             or getattr(tool_parser, "streamed_args_for_tool", None)
-            or getattr(tool_parser, "current_tool_id", -1) >= 0
+            or has_current_tool
         )

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -430,6 +430,15 @@ class OpenAIServingChat(OpenAIServing):
         else:
             tool_choice_function_name = None
 
+        # Whether tools are in use with "auto" tool choice
+        tool_choice_auto = (
+            not tool_choice_function_name
+            and bool(request.tools)
+            and self.parser_cls is not None
+            and self.enable_auto_tools
+            and request.tool_choice in ("auto", None)
+        )
+
         previous_texts = [""] * num_choices
 
         try:
@@ -559,6 +568,7 @@ class OpenAIServingChat(OpenAIServing):
                 for output in res.outputs:
                     i = output.index
                     parser = parsers[i]
+                    tool_parser = parser.tool_parser if parser is not None else None
                     if finish_reason_sent[i]:
                         continue
 
@@ -632,6 +642,27 @@ class OpenAIServingChat(OpenAIServing):
                             continue
                         delta_message = DeltaMessage()
 
+                    requested_stop = self._is_requested_stop_reason(
+                        request, output.stop_reason
+                    )
+                    # If a requested stop interrupts auto tool parsing before
+                    # any tool-call delta is emitted, the parser may have
+                    # buffered raw text while deciding if it is a tool call.
+                    # Flush that text as content so streaming matches
+                    # non-streaming, and preserve finish_reason="stop".
+                    if (
+                        output.finish_reason is not None
+                        and requested_stop
+                        and tool_choice_auto
+                        and tool_parser
+                        and not tools_streamed[i]
+                        and self._has_unstreamed_tool_parser_state(tool_parser)
+                        and not delta_message.content
+                        and not delta_message.reasoning
+                        and not delta_message.tool_calls
+                    ):
+                        delta_message = DeltaMessage(content=previous_texts[i])
+
                     # Log streaming delta if output logging is enabled
                     if self.enable_log_outputs and self.request_logger:
                         delta_content_parts = []
@@ -685,7 +716,9 @@ class OpenAIServingChat(OpenAIServing):
                         # finish_reason is:
                         # "tool_calls" for "auto" or "required" tool calls,
                         # and "stop" for named tool calls.
-                        if tools_streamed[i] and not tool_choice_function_name:
+                        if not requested_stop and (
+                            tools_streamed[i] and not tool_choice_function_name
+                        ):
                             finish_reason_ = "tool_calls"
                         else:
                             finish_reason_ = (
@@ -1142,3 +1175,40 @@ class OpenAIServingChat(OpenAIServing):
                 )
 
         return ChatCompletionLogProbs(content=logprobs_content)
+
+    @staticmethod
+    def _is_requested_stop_reason(
+        request: ChatCompletionRequest,
+        stop_reason: int | str | None,
+    ) -> bool:
+        """Return whether ``stop_reason`` came from the request stop settings.
+
+        Tool-call parsing can observe partial tool-call text before generation
+        stops. When the engine reports a user-requested stop string or stop
+        token, the OpenAI response should preserve ``finish_reason="stop"``
+        instead of rewriting it to ``tool_calls``.
+        """
+        if stop_reason is None:
+            return False
+
+        if isinstance(stop_reason, str):
+            if isinstance(request.stop, str):
+                return stop_reason == request.stop
+            return request.stop is not None and stop_reason in request.stop
+
+        return stop_reason in (request.stop_token_ids or [])
+
+    @staticmethod
+    def _has_unstreamed_tool_parser_state(tool_parser: Any) -> bool:
+        """Return whether a tool parser may be buffering unstreamed text.
+
+        Some streaming tool parsers suppress raw text while they decide whether
+        it is a tool call. If a requested stop interrupts that parsing before a
+        tool-call delta is emitted, the serving layer flushes the buffered text
+        as normal content to match non-streaming behavior.
+        """
+        return bool(
+            getattr(tool_parser, "prev_tool_call_arr", None)
+            or getattr(tool_parser, "streamed_args_for_tool", None)
+            or getattr(tool_parser, "current_tool_id", -1) >= 0
+        )

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -1211,6 +1211,11 @@ class OpenAIServingChat(OpenAIServing):
         it is a tool call. If a requested stop interrupts that parsing before a
         tool-call delta is emitted, the serving layer flushes the buffered text
         as normal content to match non-streaming behavior.
+
+        This helper recognizes the parser state fields used by the built-in
+        streaming tool parsers. Parsers that buffer unstreamed text in another
+        shape need to expose equivalent state here, or provide a generic flush
+        hook, so requested-stop handling can preserve their buffered text.
         """
         return bool(
             getattr(tool_parser, "prev_tool_call_arr", None)

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -440,6 +440,7 @@ class OpenAIServingChat(OpenAIServing):
         )
 
         previous_texts = [""] * num_choices
+        streamed_content_lengths = [0] * num_choices
 
         try:
             if self.parser_cls is not None:
@@ -648,8 +649,8 @@ class OpenAIServingChat(OpenAIServing):
                     # If a requested stop interrupts auto tool parsing before
                     # any tool-call delta is emitted, the parser may have
                     # buffered raw text while deciding if it is a tool call.
-                    # Flush that text as content so streaming matches
-                    # non-streaming, and preserve finish_reason="stop".
+                    # Flush any unstreamed suffix as content so streaming
+                    # matches non-streaming, and preserve finish_reason="stop".
                     if (
                         output.finish_reason is not None
                         and requested_stop
@@ -661,7 +662,9 @@ class OpenAIServingChat(OpenAIServing):
                         and not delta_message.reasoning
                         and not delta_message.tool_calls
                     ):
-                        delta_message = DeltaMessage(content=previous_texts[i])
+                        delta_message = DeltaMessage(
+                            content=previous_texts[i][streamed_content_lengths[i] :]
+                        )
 
                     # Log streaming delta if output logging is enabled
                     if self.enable_log_outputs and self.request_logger:
@@ -740,6 +743,8 @@ class OpenAIServingChat(OpenAIServing):
                         finish_reason_sent[i] = True
 
                     choice_data = maybe_filter_parallel_tool_calls(choice_data, request)
+                    if choice_data.delta.content:
+                        streamed_content_lengths[i] += len(choice_data.delta.content)
                     chunk = ChatCompletionStreamResponse(
                         id=request_id,
                         object=chunk_object_type,

--- a/vllm/entrypoints/openai/chat_completion/serving.py
+++ b/vllm/entrypoints/openai/chat_completion/serving.py
@@ -643,17 +643,14 @@ class OpenAIServingChat(OpenAIServing):
                             continue
                         delta_message = DeltaMessage()
 
-                    requested_stop = self._is_requested_stop_reason(
-                        request, output.stop_reason
-                    )
-                    # If a requested stop interrupts auto tool parsing before
-                    # any tool-call delta is emitted, the parser may have
-                    # buffered raw text while deciding if it is a tool call.
-                    # Flush any unstreamed suffix as content so streaming
-                    # matches non-streaming, and preserve finish_reason="stop".
-                    if (
+                    # If generation ends while auto tool parsing is still
+                    # holding raw text, and the client has not seen a tool-call
+                    # delta, flush the buffered suffix as normal content. This
+                    # keeps streaming aligned with non-streaming for malformed
+                    # or incomplete tool-looking output while preserving the
+                    # engine's finish_reason, such as stop or length.
+                    flush_buffered_content = (
                         output.finish_reason is not None
-                        and requested_stop
                         and tool_choice_auto
                         and tool_parser
                         and not tools_streamed[i]
@@ -661,7 +658,8 @@ class OpenAIServingChat(OpenAIServing):
                         and not delta_message.content
                         and not delta_message.reasoning
                         and not delta_message.tool_calls
-                    ):
+                    )
+                    if flush_buffered_content:
                         delta_message = DeltaMessage(
                             content=previous_texts[i][streamed_content_lengths[i] :]
                         )
@@ -719,7 +717,7 @@ class OpenAIServingChat(OpenAIServing):
                         # finish_reason is:
                         # "tool_calls" for "auto" or "required" tool calls,
                         # and "stop" for named tool calls.
-                        if not requested_stop and (
+                        if not flush_buffered_content and (
                             tools_streamed[i] and not tool_choice_function_name
                         ):
                             finish_reason_ = "tool_calls"
@@ -1182,40 +1180,18 @@ class OpenAIServingChat(OpenAIServing):
         return ChatCompletionLogProbs(content=logprobs_content)
 
     @staticmethod
-    def _is_requested_stop_reason(
-        request: ChatCompletionRequest,
-        stop_reason: int | str | None,
-    ) -> bool:
-        """Return whether ``stop_reason`` came from the request stop settings.
-
-        Tool-call parsing can observe partial tool-call text before generation
-        stops. When the engine reports a user-requested stop string or stop
-        token, the OpenAI response should preserve ``finish_reason="stop"``
-        instead of rewriting it to ``tool_calls``.
-        """
-        if stop_reason is None:
-            return False
-
-        if isinstance(stop_reason, str):
-            if isinstance(request.stop, str):
-                return stop_reason == request.stop
-            return request.stop is not None and stop_reason in request.stop
-
-        return stop_reason in (request.stop_token_ids or [])
-
-    @staticmethod
     def _has_unstreamed_tool_parser_state(tool_parser: Any) -> bool:
         """Return whether a tool parser may be buffering unstreamed text.
 
         Some streaming tool parsers suppress raw text while they decide whether
-        it is a tool call. If a requested stop interrupts that parsing before a
-        tool-call delta is emitted, the serving layer flushes the buffered text
-        as normal content to match non-streaming behavior.
+        it is a tool call. If generation terminates before a tool-call delta is
+        emitted, the serving layer can flush the buffered text as normal content
+        to match non-streaming behavior.
 
         This helper recognizes the parser state fields used by the built-in
         streaming tool parsers. Parsers that buffer unstreamed text in another
         shape need to expose equivalent state here, or provide a generic flush
-        hook, so requested-stop handling can preserve their buffered text.
+        hook, so terminal handling can preserve their buffered text.
         """
         current_tool_id = getattr(tool_parser, "current_tool_id", None)
         has_current_tool = (


### PR DESCRIPTION
## Purpose

Fixes #42210.

When streaming auto tool parsing ends before a valid tool-call delta is emitted, vLLM can drop parser-buffered raw text and incorrectly finish as `tool_calls`. This PR flushes the buffered suffix as plain assistant `content` whenever generation reaches a terminal finish before a tool call is streamed, preserving the engine's original `finish_reason`, such as `stop` or `length`.

If a real tool-call delta has already been streamed, the response still finishes as `tool_calls`.

## Test Plan

```bash
.venv/bin/python -m pytest tests/entrypoints/openai/chat_completion/test_serving_chat.py -q -k "streaming_tool_parser_flushes_buffered_content_on_terminal_finish or streaming_tool_parser_stop_flush_skips_streamed_content or streaming_tool_parser_does_not_flush_after_tool_call_delta or has_unstreamed_tool_parser_state_handles_non_integer_tool_ids"
```

## Test Result

```text
6 passed, 38 deselected
pre-commit hooks passed
```

## AI assistance
AI assistance (Codex GPT-5.5) was used to help prepare this patch. The human submitter reviewed the changed lines and ran the tests above.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

