### PR TITLE
[Test][Bugfix] Fix mypy error: missing enable_prompt_embeds arg in test_tp_sp_nvfp4_generation

### DIFF
--- a/tests/compile/correctness_e2e/test_sequence_parallel.py
+++ b/tests/compile/correctness_e2e/test_sequence_parallel.py
@@ -435,6 +435,7 @@ def test_tp_sp_nvfp4_generation(num_gpus_available: int):
         num_gpus_available,
         use_inductor_graph_partition=False,
         fuse_gemm_comms=False,
+        enable_prompt_embeds=False,
         method="generate",
         is_multimodal=False,
         dtype="bfloat16",


### PR DESCRIPTION
 ## Purpose

Fix a mypy error introduced in #33322, which added the enable_prompt_embeds parameter to _compare_sp but missed updating one call site.

  The call in test_tp_sp_nvfp4_generation (line 418) was left without the new required positional argument, causing CI mypy checks to fail across all Python
  versions (3.10–3.13).

  This PR adds enable_prompt_embeds=False to that call. False is correct here — this is a plain generation test with no multimodal prompt embeddings involved.

  This is not a duplicate of any existing open PR.

  ## Test Plan

  mypy --python-version 3.10 --follow-imports skip tests
  mypy --python-version 3.11 --follow-imports skip tests
  mypy --python-version 3.12 --follow-imports skip tests
  mypy --python-version 3.13 --follow-imports skip tests

  ## Test Result

  All four mypy invocations pass with no errors after the fix.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

