### PR TITLE
[CI] Narrow models_basic.yaml source dependencies

### DIFF
--- a/.buildkite/test_areas/models_basic.yaml
+++ b/.buildkite/test_areas/models_basic.yaml
@@ -7,7 +7,17 @@ steps:
   timeout_in_minutes: 45
   torch_nightly: true
   source_file_dependencies:
-  - vllm/
+  - vllm/config/
+  - vllm/distributed/
+  - vllm/engine/
+  - vllm/inputs/
+  - vllm/model_executor/
+  - vllm/multimodal/
+  - vllm/platforms/
+  - vllm/sampling_params.py
+  - vllm/transformers_utils/
+  - vllm/utils/
+  - vllm/v1/
   - tests/models/test_initialization.py
   - tests/models/registry.py
   commands:
@@ -36,7 +46,17 @@ steps:
   key: basic-models-tests-other
   timeout_in_minutes: 45
   source_file_dependencies:
-  - vllm/
+  - vllm/config/
+  - vllm/distributed/
+  - vllm/engine/
+  - vllm/inputs/
+  - vllm/model_executor/
+  - vllm/multimodal/
+  - vllm/platforms/
+  - vllm/sampling_params.py
+  - vllm/transformers_utils/
+  - vllm/utils/
+  - vllm/v1/
   - tests/models/test_terratorch.py
   - tests/models/test_transformers.py
   - tests/models/test_registry.py
@@ -49,7 +69,10 @@ steps:
   - image-build-cpu
   timeout_in_minutes: 10
   source_file_dependencies:
-  - vllm/
+  - vllm/distributed/
+  - vllm/model_executor/
+  - vllm/platforms/
+  - vllm/utils/
   - tests/models/test_utils.py
   - tests/models/test_vision.py
   device: cpu-small

--- a/.buildkite/test_areas/models_basic.yaml
+++ b/.buildkite/test_areas/models_basic.yaml
@@ -11,14 +11,17 @@ steps:
   - vllm/distributed/
   - vllm/engine/
   - vllm/inputs/
+  - vllm/logging_utils/
   - vllm/model_executor/
   - vllm/multimodal/
   - vllm/platforms/
   - vllm/sampling_params.py
   - vllm/sequence.py
+  - vllm/tasks.py
   - vllm/transformers_utils/
   - vllm/utils/
   - vllm/v1/
+  - vllm/version.py
   - tests/models/test_initialization.py
   - tests/models/registry.py
   commands:
@@ -51,14 +54,17 @@ steps:
   - vllm/distributed/
   - vllm/engine/
   - vllm/inputs/
+  - vllm/logging_utils/
   - vllm/model_executor/
   - vllm/multimodal/
   - vllm/platforms/
   - vllm/sampling_params.py
   - vllm/sequence.py
+  - vllm/tasks.py
   - vllm/transformers_utils/
   - vllm/utils/
   - vllm/v1/
+  - vllm/version.py
   - tests/models/test_terratorch.py
   - tests/models/test_transformers.py
   - tests/models/test_registry.py

--- a/.buildkite/test_areas/models_basic.yaml
+++ b/.buildkite/test_areas/models_basic.yaml
@@ -15,6 +15,7 @@ steps:
   - vllm/multimodal/
   - vllm/platforms/
   - vllm/sampling_params.py
+  - vllm/sequence.py
   - vllm/transformers_utils/
   - vllm/utils/
   - vllm/v1/
@@ -54,6 +55,7 @@ steps:
   - vllm/multimodal/
   - vllm/platforms/
   - vllm/sampling_params.py
+  - vllm/sequence.py
   - vllm/transformers_utils/
   - vllm/utils/
   - vllm/v1/
@@ -69,6 +71,7 @@ steps:
   - image-build-cpu
   timeout_in_minutes: 10
   source_file_dependencies:
+  - vllm/config/
   - vllm/distributed/
   - vllm/model_executor/
   - vllm/platforms/


### PR DESCRIPTION
## Summary

Three jobs in `.buildkite/test_areas/models_basic.yaml` listed `vllm/` as a source dependency. Replace each with what the tests actually import:

- **Basic Models Tests (Initialization)** and **Basic Models Tests (Other)** instantiate models via `vllm_runner` — narrowed to the inference-stack modules actually used during model load.
- **Basic Models Test (Other CPU)** runs `test_utils.py` and `test_vision.py` which only import `vllm.distributed`, `vllm.model_executor.models`, `vllm.platforms`, and `vllm.utils` — narrowed to those four.

`Basic Models Tests (Extra Initialization)` already had a narrow `vllm/model_executor/models/` dep and is unchanged. The optional nightly transformers jobs have no `source_file_dependencies` and are unchanged.

This is part of a series narrowing broad `vllm/` deps in `.buildkite/test_areas/`. Prior PRs: #42054 (cuda), #42055 (engine), #42057 (pytorch), #42059 (misc), #42219 (entrypoints).

## Test plan

- [ ] Verify CI scheduler picks up the narrower paths and skips these jobs on changes confined to excluded directories.
- [ ] Confirm jobs still trigger on changes to listed paths.

This change was AI-assisted (Claude Code). Reviewed end-to-end before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)