### PR TITLE
[CI] Narrow basic_correctness.yaml source dependencies

### DIFF
--- a/.buildkite/test_areas/basic_correctness.yaml
+++ b/.buildkite/test_areas/basic_correctness.yaml
@@ -11,11 +11,13 @@ steps:
   - vllm/device_allocator/
   - vllm/distributed/
   - vllm/engine/
+  - vllm/entrypoints/llm.py
   - vllm/inputs/
   - vllm/model_executor/
   - vllm/multimodal/
   - vllm/platforms/
   - vllm/sampling_params.py
+  - vllm/sequence.py
   - vllm/transformers_utils/
   - vllm/utils/
   - vllm/v1/

--- a/.buildkite/test_areas/basic_correctness.yaml
+++ b/.buildkite/test_areas/basic_correctness.yaml
@@ -7,7 +7,18 @@ steps:
   timeout_in_minutes: 30
   device: h200_18gb
   source_file_dependencies:
-  - vllm/
+  - vllm/config/
+  - vllm/device_allocator/
+  - vllm/distributed/
+  - vllm/engine/
+  - vllm/inputs/
+  - vllm/model_executor/
+  - vllm/multimodal/
+  - vllm/platforms/
+  - vllm/sampling_params.py
+  - vllm/transformers_utils/
+  - vllm/utils/
+  - vllm/v1/
   - tests/basic_correctness/test_basic_correctness
   - tests/basic_correctness/test_cpu_offload
   - tests/basic_correctness/test_cumem.py

--- a/.buildkite/test_areas/basic_correctness.yaml
+++ b/.buildkite/test_areas/basic_correctness.yaml
@@ -7,20 +7,24 @@ steps:
   timeout_in_minutes: 30
   device: h200_18gb
   source_file_dependencies:
+  - vllm/beam_search.py
   - vllm/config/
   - vllm/device_allocator/
   - vllm/distributed/
   - vllm/engine/
   - vllm/entrypoints/llm.py
   - vllm/inputs/
+  - vllm/logging_utils/
   - vllm/model_executor/
   - vllm/multimodal/
   - vllm/platforms/
   - vllm/sampling_params.py
   - vllm/sequence.py
+  - vllm/tasks.py
   - vllm/transformers_utils/
   - vllm/utils/
   - vllm/v1/
+  - vllm/version.py
   - tests/basic_correctness/test_basic_correctness
   - tests/basic_correctness/test_cpu_offload
   - tests/basic_correctness/test_cumem.py


### PR DESCRIPTION
## Summary

The `Basic Correctness` job in `.buildkite/test_areas/basic_correctness.yaml` listed `vllm/` as a source dependency, causing it to run on any change anywhere under `vllm/`. The three tests it runs (`test_basic_correctness.py`, `test_cpu_offload.py`, `test_cumem.py`) instantiate `LLM(...)` and exercise the inference stack plus `vllm.device_allocator.cumem`.

Replace with the modules these tests actually exercise.

Excludes paths that have their own dedicated coverage and aren't directly imported: `vllm/lora/`, `vllm/spec_decode/`, `vllm/tracing/`, `vllm/profiler/`, `vllm/reasoning/`, `vllm/tool_parsers/`, `vllm/renderers/`, `vllm/benchmarks/`, `vllm/entrypoints/openai/`, `vllm/entrypoints/api_server.py`, `vllm/entrypoints/cli/`, `vllm/compilation/`, `vllm/kernels/`, `vllm/ir/`, `vllm/plugins/`, `vllm/triton_utils/`, `vllm/forward_context.py`, `vllm/sequence.py`, `vllm/_aiter_ops.py`, `vllm/_custom_ops.py`.

This is part of a series narrowing broad `vllm/` deps in `.buildkite/test_areas/`. Prior PRs: #42054 (cuda), #42055 (engine), #42057 (pytorch), #42059 (misc), #42219 (entrypoints), #42220 (models_basic), #42221 (models_multimodal), #42222 (models_language).

## Test plan

- [ ] Verify CI scheduler picks up the narrower paths and skips the job on changes confined to excluded directories.
- [ ] Confirm the job still triggers on changes to listed paths.

This change was AI-assisted (Claude Code). Reviewed end-to-end before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)