### PR TITLE
[Bugfix] Fix queue cleanup deadlock in multi-turn benchmark

### DIFF
--- a/benchmarks/multi_turn/benchmark_serving_multi_turn.py
+++ b/benchmarks/multi_turn/benchmark_serving_multi_turn.py
@@ -1052,7 +1052,7 @@ async def main_mp(
             task_queue.get_nowait()
             unfinished_tasks += 1
         except Exception:
-            time.sleep(0.1)
+            await asyncio.sleep(0.1)
             try:
                 task_queue.get_nowait()
                 unfinished_tasks += 1
@@ -1061,6 +1061,17 @@ async def main_mp(
 
     if unfinished_tasks > 0:
         logger.debug(f"Discarding {unfinished_tasks} unfinished tasks")
+
+    # Drain result_queue to collect any remaining metrics still in flight.
+    while True:
+        try:
+            client_metrics.append(result_queue.get_nowait())
+        except Exception:
+            await asyncio.sleep(0.1)
+            try:
+                client_metrics.append(result_queue.get_nowait())
+            except Exception:
+                break
 
     # cancel_join_thread() prevents deadlock if any items remain in the OS
     # pipe buffer despite draining (e.g. feeder thread wrote between our

--- a/benchmarks/multi_turn/benchmark_serving_multi_turn.py
+++ b/benchmarks/multi_turn/benchmark_serving_multi_turn.py
@@ -1043,26 +1043,36 @@ async def main_mp(
         f"finished {len(output_conv)} out of {total_convs} conversations)"
     )
 
-    # Queues should be closed, required to avoid hang at interpreter shutdown
+    # Drain unconsumed items from task_queue to unblock the feeder thread.
+    # mp.Queue.empty() is unreliable (races with the feeder), so we use
+    # get_nowait with a double-check after a short sleep.
     unfinished_tasks = 0
-    while not task_queue.empty():
-        task_queue.get()
-        unfinished_tasks += 1
+    while True:
+        try:
+            task_queue.get_nowait()
+            unfinished_tasks += 1
+        except Exception:
+            time.sleep(0.1)
+            try:
+                task_queue.get_nowait()
+                unfinished_tasks += 1
+            except Exception:
+                break
 
     if unfinished_tasks > 0:
-        # Can happen if not all tasks (conversations) have finished.
-        # May happen if --max-num-requests was used,
-        # or if an error occurred in one of the clients.
         logger.debug(f"Discarding {unfinished_tasks} unfinished tasks")
 
+    # cancel_join_thread() prevents deadlock if any items remain in the OS
+    # pipe buffer despite draining (e.g. feeder thread wrote between our
+    # last get_nowait and close).
+    task_queue.cancel_join_thread()
     task_queue.close()
-    task_queue.join_thread()
 
+    result_queue.cancel_join_thread()
     result_queue.close()
-    result_queue.join_thread()
 
+    conv_queue.cancel_join_thread()
     conv_queue.close()
-    conv_queue.join_thread()
 
     return output_conv, client_metrics
 


### PR DESCRIPTION
## Summary

Fixes #42226

When `--max-num-requests` causes early termination in `benchmark_serving_multi_turn.py`, unconsumed items in `task_queue` overflow the OS pipe buffer. `join_thread()` then deadlocks waiting for the feeder thread, which is blocked writing to a full pipe with no readers.

**Changes:**
- Replace unreliable `mp.Queue.empty()`-based drain with `get_nowait()` + double-check loop
- Use `cancel_join_thread()` before `close()` on all three queues to prevent deadlock
- Remove `join_thread()` calls (unnecessary — all data is already collected by this point)
- Drain `result_queue` with the same robust pattern to avoid losing in-flight metrics
- Use `await asyncio.sleep()` instead of `time.sleep()` (function is async)

**AI disclosure:** This PR was developed with assistance from Claude (Anthropic). All code has been reviewed and validated by the submitter.

## Testing

**End-to-end verification (A100 80GB, NousResearch/Hermes-3-Llama-3.1-8B, 500 ShareGPT conversations):**

| Test | Code | Result |
|------|------|--------|
| `--max-num-requests 100` + ShareGPT | **Old** (unfixed) | Hung 16+ min after "All clients exited" — deadlock |
| `--max-num-requests 100` + ShareGPT | **New** (this PR) | Completed, printed full stats summary |
| No `--max-num-requests` (regression) | **New** (this PR) | 21 conversations processed without issue |

**Isolated reproducer test (proves the mechanism):**

| Test | Result |
|------|--------|
| Old pattern (close + join_thread) with pipe overflow | Deadlocks (3s timeout hit) |
| New pattern (cancel_join_thread + close) with pipe overflow | Completes instantly |
| New pattern on empty queue | Completes instantly |

<details>
<summary>Reproducer test script (not part of this PR)</summary>

```python
import multiprocessing as mp
import time

PIPE_OVERFLOW_ITEM_COUNT = 150
ITEM_PAYLOAD = "x" * 500

def _scenario_old_cleanup(item_count):
    q = mp.Queue()
    for i in range(item_count):
        q.put((i, ITEM_PAYLOAD))
    while not q.empty():
        q.get()
    q.close()
    q.join_thread()  # DEADLOCK

def _scenario_new_cleanup(item_count):
    q = mp.Queue()
    for i in range(item_count):
        q.put((i, ITEM_PAYLOAD))
    while True:
        try:
            q.get_nowait()
        except Exception:
            time.sleep(0.1)
            try:
                q.get_nowait()
            except Exception:
                break
    q.cancel_join_thread()
    q.close()

def _scenario_new_cleanup_empty():
    q = mp.Queue()
    for i in range(10):
        q.put((i, ITEM_PAYLOAD))
    time.sleep(0.2)
    while True:
        try:
            q.get_nowait()
        except Exception:
            break
    q.cancel_join_thread()
    q.close()

def _run_with_timeout(target, timeout_sec):
    start = time.monotonic()
    p = mp.Process(target=target)
    p.start()
    p.join(timeout=timeout_sec)
    elapsed = time.monotonic() - start
    if p.is_alive():
        p.terminate()
        p.join()
        return False, elapsed
    return True, elapsed

def test_old_pattern_deadlocks_on_full_pipe():
    completed, _ = _run_with_timeout(
        lambda: _scenario_old_cleanup(PIPE_OVERFLOW_ITEM_COUNT), timeout_sec=3)
    assert not completed

def test_new_pattern_completes_on_full_pipe():
    completed, elapsed = _run_with_timeout(
        lambda: _scenario_new_cleanup(PIPE_OVERFLOW_ITEM_COUNT), timeout_sec=5)
    assert completed and elapsed < 2.0

def test_new_pattern_works_on_empty_queue():
    completed, elapsed = _run_with_timeout(
        _scenario_new_cleanup_empty, timeout_sec=3)
    assert completed and elapsed < 1.0
```

</details>