### PR TITLE
[Model] Add Mistral3 MM LoRA token helper methods

### DIFF
--- a/tests/models/multimodal/test_mistral3.py
+++ b/tests/models/multimodal/test_mistral3.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from types import SimpleNamespace
+
+import pytest
+
+from vllm.model_executor.models.mistral3 import Mistral3ForConditionalGeneration
+
+
+def _make_mistral3_model(
+    spatial_merge_size: int,
+) -> Mistral3ForConditionalGeneration:
+    model = object.__new__(Mistral3ForConditionalGeneration)
+    object.__setattr__(
+        model, "config", SimpleNamespace(spatial_merge_size=spatial_merge_size)
+    )
+    return model
+
+
+@pytest.mark.parametrize(
+    ("spatial_merge_size", "num_image_tokens"),
+    [
+        (1, 16),
+        (2, 16),
+        (4, 8),
+    ],
+)
+def test_mistral3_mm_lora_token_counts(
+    spatial_merge_size: int, num_image_tokens: int
+) -> None:
+    model = _make_mistral3_model(spatial_merge_size)
+
+    num_vision_tokens = num_image_tokens * (spatial_merge_size**2)
+
+    assert model.get_num_mm_encoder_tokens(num_image_tokens) == num_vision_tokens
+    assert model.get_num_mm_connector_tokens(num_vision_tokens) == num_image_tokens

--- a/vllm/model_executor/models/mistral3.py
+++ b/vllm/model_executor/models/mistral3.py
@@ -572,3 +572,11 @@ class Mistral3ForConditionalGeneration(
             connector="multi_modal_projector",
             tower_model="vision_tower",
         )
+
+    def get_num_mm_encoder_tokens(self, num_image_tokens: int) -> int:
+        merge_size = self.config.spatial_merge_size
+        return num_image_tokens * (merge_size**2)
+
+    def get_num_mm_connector_tokens(self, num_vision_tokens: int) -> int:
+        merge_size = self.config.spatial_merge_size
+        return num_vision_tokens // (merge_size**2)


### PR DESCRIPTION
Part of #31479

### Summary

This PR adds the multimodal LoRA token length helper methods for `Mistral3ForConditionalGeneration`:

- `get_num_mm_encoder_tokens`
- `get_num_mm_connector_tokens`

Mistral3 uses a patch merger in the multimodal projector. The language model sees the post-merge image token count, while the vision tower operates on the pre-merge patch token count. Therefore, the helper methods map between these lengths using `spatial_merge_size ** 2`, matching the patch-merging behavior in `Mistral3PatchMerger`.

### Duplicate check

I checked #31479 and searched open PRs for `31479 in:body`, `Mistral3 LoRA`, and `Mistral3ForConditionalGeneration LoRA`. The only open PR referencing #31479 was #34097 for Qwen3 Omni, and I did not find an existing Mistral3 duplicate.

### Tests

- `.venv/bin/python -m pytest -q tests/models/multimodal/test_mistral3.py` — passed
- `.venv/bin/pre-commit run ruff-check --files vllm/model_executor/models/mistral3.py tests/models/multimodal/test_mistral3.py` — passed
- `.venv/bin/pre-commit run ruff-format --files vllm/model_executor/models/mistral3.py tests/models/multimodal/test_mistral3.py` — passed
- `PATH=/home/zhang/project/vllm/.venv/bin:$PATH .venv/bin/python -m pytest -q 'tests/models/test_initialization.py::test_can_initialize_large_subset[Mistral3ForConditionalGeneration]'` — passed

### AI assistance disclosure

AI assistance was used to help inspect related code paths and draft parts of this PR description. I reviewed and validated the final changes.