### PR TITLE
[Bugfix][GGUF] Fix deepseek2 architecture not supported when loading without config.json

### DIFF
--- a/tests/models/test_gguf_download.py
+++ b/tests/models/test_gguf_download.py
@@ -9,6 +9,10 @@ from vllm.config import ModelConfig
 from vllm.config.load import LoadConfig
 from vllm.model_executor.model_loader.gguf_loader import GGUFModelLoader
 from vllm.model_executor.model_loader.weight_utils import download_gguf
+from vllm.transformers_utils.gguf_utils import (
+    _DEEPSEEK2_GGUF_CONFIG_MAPPING,
+    GGUF_ARCH_TO_HF_MODEL_TYPE,
+)
 
 
 class TestGGUFDownload:
@@ -219,3 +223,60 @@ class TestGGUFModelLoader:
         model_config.model = "invalid-format"
         with pytest.raises(ValueError, match="Unrecognised GGUF reference"):
             loader._prepare_weights(model_config)
+
+
+class TestDeepSeek2GGUFSupport:
+    """Tests for deepseek2 GGUF architecture support in transformers patch."""
+
+    def test_gguf_arch_to_hf_model_type_has_deepseek2(self):
+        """GGUF_ARCH_TO_HF_MODEL_TYPE must map deepseek2 to deepseek_v2."""
+        assert "deepseek2" in GGUF_ARCH_TO_HF_MODEL_TYPE
+        assert GGUF_ARCH_TO_HF_MODEL_TYPE["deepseek2"] == "deepseek_v2"
+
+    def test_deepseek2_gguf_config_mapping_contains_core_fields(self):
+        """deepseek2 config mapping must cover the key model and MoE fields."""
+        required = {
+            "context_length",
+            "block_count",
+            "embedding_length",
+            "attention.head_count",
+            "attention.kv_lora_rank",
+            "expert_count",
+            "expert_used_count",
+        }
+        assert required.issubset(_DEEPSEEK2_GGUF_CONFIG_MAPPING)
+
+    def test_transformers_gguf_config_mapping_patched(self):
+        """_patch_transformers_gguf_for_deepseek2 must add deepseek2 to
+        transformers' GGUF_CONFIG_MAPPING and GGUF_SUPPORTED_ARCHITECTURES."""
+        from transformers import modeling_gguf_pytorch_utils
+        from transformers.integrations.ggml import GGUF_CONFIG_MAPPING
+
+        assert "deepseek2" in GGUF_CONFIG_MAPPING, (
+            "deepseek2 should be in GGUF_CONFIG_MAPPING after vllm import"
+        )
+        supported = modeling_gguf_pytorch_utils.GGUF_SUPPORTED_ARCHITECTURES
+        assert "deepseek2" in supported, (
+            "deepseek2 should be in GGUF_SUPPORTED_ARCHITECTURES after vllm import"
+        )
+
+    def test_ensure_gguf_arch_registered_creates_alias(self):
+        """_ensure_gguf_arch_registered_in_autoconfig registers a class for
+        deepseek2 that AutoConfig can resolve."""
+        from transformers import AutoConfig
+
+        from vllm.transformers_utils.config import (
+            _ensure_gguf_arch_registered_in_autoconfig,
+        )
+
+        _ensure_gguf_arch_registered_in_autoconfig("deepseek2")
+
+        # Should not raise; AutoConfig must know about deepseek2 now.
+        cfg = AutoConfig.for_model(
+            "deepseek2",
+            hidden_size=512,
+            num_hidden_layers=2,
+            num_attention_heads=8,
+            num_key_value_heads=2,
+        )
+        assert cfg.model_type == "deepseek2"

--- a/vllm/transformers_utils/config.py
+++ b/vllm/transformers_utils/config.py
@@ -35,6 +35,7 @@ from vllm.utils.torch_utils import common_broadcastable_dtype
 
 from .config_parser_base import ConfigParserBase
 from .gguf_utils import (
+    GGUF_ARCH_TO_HF_MODEL_TYPE,
     check_gguf_file,
     is_gguf,
     is_remote_gguf,
@@ -169,6 +170,45 @@ def _mistral_patch_hf_hub_constants() -> Iterator[None]:
         constants.SAFETENSORS_INDEX_FILE = hf_safetensors_index_file
 
 
+# Cache for GGUF architecture → AutoConfig-registered subclass mappings.
+# Each subclass keeps the GGUF arch name as model_type so that AutoConfig can
+# find it; vllm's post-processing in get_config() remaps it to the canonical HF
+# model_type afterwards.
+_gguf_arch_config_class_cache: dict[str, type[PretrainedConfig]] = {}
+
+
+def _ensure_gguf_arch_registered_in_autoconfig(gguf_arch: str) -> None:
+    """Register a config class for the given GGUF architecture name.
+
+    Creates a thin subclass of the target HF config class with model_type set to
+    the GGUF architecture name so that AutoConfig.from_pretrained can resolve the
+    class when loading from a GGUF file without config.json.
+    """
+    if gguf_arch in _gguf_arch_config_class_cache:
+        # Already registered; AutoConfig.register is idempotent with exist_ok=True.
+        AutoConfig.register(
+            gguf_arch, _gguf_arch_config_class_cache[gguf_arch], exist_ok=True
+        )
+        return
+
+    hf_model_type = GGUF_ARCH_TO_HF_MODEL_TYPE[gguf_arch]
+    from transformers.models.auto.configuration_auto import CONFIG_MAPPING
+
+    base_class = CONFIG_MAPPING[hf_model_type]
+
+    # Create a subclass with the GGUF arch name as model_type so that
+    # AutoConfig.register accepts it (the model_type attribute must match the
+    # registration key).
+    alias_class = type(
+        f"_{gguf_arch.capitalize()}GGUFConfig",
+        (base_class,),
+        {"model_type": gguf_arch},
+    )
+
+    _gguf_arch_config_class_cache[gguf_arch] = alias_class
+    AutoConfig.register(gguf_arch, alias_class, exist_ok=True)
+
+
 class HFConfigParser(ConfigParserBase):
     def parse(
         self,
@@ -207,6 +247,14 @@ class HFConfigParser(ConfigParserBase):
                 dummy_config = PretrainedConfig(**dummy_kwargs)
                 dummy_model_type = hf_overrides(dummy_config).model_type
                 model_type = dummy_model_type.removeprefix("dummy_")
+
+        # When a GGUF file is loaded without an accompanying config.json,
+        # transformers reads general.architecture from the GGUF metadata and
+        # uses it as model_type.  Some architectures (e.g. "deepseek2") are not
+        # registered in AutoConfig, so we register them here as aliases for their
+        # corresponding HF model types.
+        if "gguf_file" in kwargs and model_type in GGUF_ARCH_TO_HF_MODEL_TYPE:
+            _ensure_gguf_arch_registered_in_autoconfig(model_type)
 
         if model_type in _SPECULATIVE_DECODING_CONFIGS:
             config_class = _CONFIG_REGISTRY[model_type]
@@ -760,6 +808,11 @@ def get_config(
 
     # Special architecture mapping check for GGUF models
     if _is_gguf:
+        # Remap GGUF-native architecture names (e.g. "deepseek2") to the
+        # canonical HF model_type (e.g. "deepseek_v2") so that subsequent
+        # lookups into MODEL_FOR_CAUSAL_LM_MAPPING_NAMES succeed.
+        if config.model_type in GGUF_ARCH_TO_HF_MODEL_TYPE:
+            config.update({"model_type": GGUF_ARCH_TO_HF_MODEL_TYPE[config.model_type]})
         if config.model_type not in MODEL_FOR_CAUSAL_LM_MAPPING_NAMES:
             raise RuntimeError(f"Can't get gguf config for {config.model_type}.")
         model_type = MODEL_FOR_CAUSAL_LM_MAPPING_NAMES[config.model_type]

--- a/vllm/transformers_utils/gguf_utils.py
+++ b/vllm/transformers_utils/gguf_utils.py
@@ -18,6 +18,69 @@ from .repo_utils import list_filtered_repo_files
 
 logger = init_logger(__name__)
 
+# Mapping from GGUF architecture names to HF model types for architectures that
+# transformers does not natively support in its GGUF_CONFIG_MAPPING. Both
+# DeepSeek-V2 and V3 models use "deepseek2" as the GGUF general.architecture.
+GGUF_ARCH_TO_HF_MODEL_TYPE: dict[str, str] = {
+    "deepseek2": "deepseek_v2",
+}
+
+# GGUF metadata field → HF config attribute mapping for the deepseek2 architecture.
+# These fields cover both DeepSeek-V2 and V3 (which share the same GGUF arch name).
+_DEEPSEEK2_GGUF_CONFIG_MAPPING: dict[str, str | None] = {
+    "context_length": "max_position_embeddings",
+    "block_count": "num_hidden_layers",
+    "embedding_length": "hidden_size",
+    "feed_forward_length": "intermediate_size",
+    "rope.freq_base": "rope_theta",
+    "attention.head_count": "num_attention_heads",
+    "attention.head_count_kv": "num_key_value_heads",
+    "attention.layer_norm_rms_epsilon": "rms_norm_eps",
+    "vocab_size": "vocab_size",
+    # MoE parameters
+    "expert_count": "n_routed_experts",
+    "expert_used_count": "num_experts_per_tok",
+    "expert_shared_count": "n_shared_experts",
+    "expert_feed_forward_length": "moe_intermediate_size",
+    # MLA (Multi-head Latent Attention) parameters
+    "attention.kv_lora_rank": "kv_lora_rank",
+    "attention.q_lora_rank": "q_lora_rank",
+    "attention.qk_nope_head_dim": "qk_nope_head_dim",
+    "attention.qk_rope_head_dim": "qk_rope_head_dim",
+    "attention.v_head_dim": "v_head_dim",
+    # Dense prefix layers before MoE kicks in
+    "leading_dense_block_count": "first_k_dense_replace",
+}
+
+
+def _patch_transformers_gguf_for_deepseek2() -> None:
+    """Patch transformers to recognize deepseek2 as a supported GGUF architecture.
+
+    Transformers' GGUF_CONFIG_MAPPING omits deepseek2, so loading a standalone
+    DeepSeek-V2/V3 GGUF file (without config.json) raises a ValueError.  This
+    function adds the required entries to the mapping and to the derived
+    GGUF_SUPPORTED_ARCHITECTURES list so that load_gguf_checkpoint succeeds.
+    """
+    try:
+        from transformers import modeling_gguf_pytorch_utils
+        from transformers.integrations.ggml import GGUF_CONFIG_MAPPING
+    except ImportError:
+        return
+
+    if "deepseek2" in GGUF_CONFIG_MAPPING:
+        return
+
+    GGUF_CONFIG_MAPPING["deepseek2"] = _DEEPSEEK2_GGUF_CONFIG_MAPPING
+
+    supported = getattr(
+        modeling_gguf_pytorch_utils, "GGUF_SUPPORTED_ARCHITECTURES", None
+    )
+    if supported is not None and "deepseek2" not in supported:
+        supported.append("deepseek2")
+
+
+_patch_transformers_gguf_for_deepseek2()
+
 
 @cache
 def check_gguf_file(model: str | PathLike) -> bool:


### PR DESCRIPTION
## What this PR does

  Fixes `ValueError: GGUF model with architecture deepseek2 is not supported yet.`
  when loading a DeepSeek-V2 or V3 GGUF file without an accompanying `config.json`.

  ## Root cause

  Transformers 5.x `GGUF_CONFIG_MAPPING` omits the `deepseek2` architecture
  (the GGUF arch name used by both DeepSeek-V2 and V3). When a standalone GGUF
  file is loaded, `load_gguf_checkpoint` reads `general.architecture = deepseek2`,
  checks it against `GGUF_SUPPORTED_ARCHITECTURES`, and raises a ValueError.

  ## Changes

  - `vllm/transformers_utils/gguf_utils.py` — patches `GGUF_CONFIG_MAPPING` and
    `GGUF_SUPPORTED_ARCHITECTURES` at import time with full deepseek2 field
    mappings (attention, MoE, MLA parameters).
  - `vllm/transformers_utils/config.py` — registers a `_Deepseek2GGUFConfig`
    alias in AutoConfig; remaps `model_type="deepseek2"` → `"deepseek_v2"` in
    post-processing.
  - `tests/models/test_gguf_download.py` — 4 unit tests covering the fix.

  ## Why this is not a duplicate

  Checked open PRs — no existing PR addresses this issue.

  ## Tests

  python -m pytest tests/models/test_gguf_download.py::TestDeepSeek2GGUFSupport -v
  4 passed


  All pre-commit hooks passed (ruff check, ruff format, mypy, typos, etc.).