### PR TITLE
[Bugfix] Fix scipy audio resampling ratio

### DIFF
--- a/tests/multimodal/test_audio.py
+++ b/tests/multimodal/test_audio.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 # test_audio.py
+import math
 from unittest.mock import patch
 
 import numpy as np
@@ -45,7 +46,6 @@ def test_resample_audio_scipy(dummy_audio):
     assert np.all(out_same == dummy_audio)
 
 
-@pytest.mark.xfail(reason="resample_audio_scipy is buggy for non-integer ratios")
 def test_resample_audio_scipy_non_integer_ratio(dummy_audio):
     out = resample_audio_scipy(dummy_audio, orig_sr=5, target_sr=3)
 
@@ -53,6 +53,26 @@ def test_resample_audio_scipy_non_integer_ratio(dummy_audio):
     assert len(out) == expected_len
 
     assert isinstance(out, np.ndarray)
+    assert np.isfinite(out).all()
+
+
+def test_resample_audio_scipy_non_divisible_sample_rates():
+    audio = np.arange(441, dtype=float)
+    out = resample_audio_scipy(audio, orig_sr=44100, target_sr=16000)
+
+    expected_len = math.ceil(len(audio) * 16000 / 44100)
+    assert len(out) == expected_len
+
+    assert isinstance(out, np.ndarray)
+    assert np.isfinite(out).all()
+
+
+def test_resample_audio_scipy_resamples_last_axis_for_multichannel():
+    audio = np.arange(2 * 441, dtype=float).reshape(2, 441)
+    out = resample_audio_scipy(audio, orig_sr=44100, target_sr=16000)
+
+    expected_len = math.ceil(audio.shape[-1] * 16000 / 44100)
+    assert out.shape == (2, expected_len)
     assert np.isfinite(out).all()
 
 

--- a/vllm/multimodal/audio.py
+++ b/vllm/multimodal/audio.py
@@ -230,11 +230,19 @@ def resample_audio_scipy(
     orig_sr: float,
     target_sr: float,
 ) -> npt.NDArray[np.floating]:
-    if orig_sr > target_sr:
-        return scipy_signal.resample_poly(audio, 1, orig_sr // target_sr)
-    elif orig_sr < target_sr:
-        return scipy_signal.resample_poly(audio, target_sr // orig_sr, 1)
-    return audio
+    orig_sr_int = int(round(orig_sr))
+    target_sr_int = int(round(target_sr))
+
+    if orig_sr_int == target_sr_int:
+        return audio
+
+    gcd = math.gcd(orig_sr_int, target_sr_int)
+    return scipy_signal.resample_poly(
+        audio,
+        target_sr_int // gcd,
+        orig_sr_int // gcd,
+        axis=-1,
+    )
 
 
 class AudioResampler:


### PR DESCRIPTION
Fix `resample_audio_scipy` to compute the correct `scipy.signal.resample_poly` ratio when the original and target sample rates are not evenly divisible.

The previous implementation used floor division, so conversions like 44100 -> 16000 were treated as 1/2 instead of 160/441. This can produce incorrect output lengths for audio paths that use the scipy resampler.

Changes:
- Compute the reduced up/down ratio with `math.gcd`.
- Keep the equal-sample-rate path unchanged.
- Resample along `axis=-1` so multichannel audio keeps `(channels, samples)` layout.
- Enable the existing xfailed non-divisible-ratio regression test.
- Add coverage for a common 44100 -> 16000 conversion and multichannel input.

Duplicate check:
- Checked open PRs for `resample_audio_scipy` and `test_resample_audio_scipy_non_integer_ratio`; I did not find an existing PR covering this fix.

Tests:
- `.venv/bin/python -m pytest tests/multimodal/test_audio.py::test_resample_audio_scipy tests/multimodal/test_audio.py::test_resample_audio_scipy_non_integer_ratio tests/multimodal/test_audio.py::test_resample_audio_scipy_non_divisible_sample_rates -q`
- `.venv/bin/python -m pytest tests/multimodal/test_audio.py -q`
- `.venv/bin/pre-commit run ruff-check --files vllm/multimodal/audio.py tests/multimodal/test_audio.py`
- `.venv/bin/pre-commit run ruff-format --files vllm/multimodal/audio.py tests/multimodal/test_audio.py`
- `HF_HOME=$PWD/.hf-cache TRITON_CACHE_DIR=$PWD/.triton-cache .venv/bin/python -m pytest tests/models/multimodal/generation/test_phi4mm.py -q` (`7 skipped`, after vLLM execution; the test currently skips before HF comparison due to the existing HF transformers compatibility guard)

AI assistance was used while checking the existing regression coverage and drafting this change; I reviewed the final diff and test results.