### PR TITLE
[Bugfix] Rewrite Gemma4 streaming tool parser

### DIFF
--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -370,6 +370,21 @@ class TestStreamingExtraction:
                         args_text += arg
         return args_text
 
+    def _collect_arguments_by_index(self, results):
+        """Collect streamed argument deltas by tool-call index."""
+        args_by_index: dict[int, str] = {}
+        for delta, _ in results:
+            if delta and delta.tool_calls:
+                for tc in delta.tool_calls:
+                    func = tc.function if isinstance(tc.function, dict) else tc.function
+                    if isinstance(func, dict):
+                        arg = func.get("arguments", "")
+                    else:
+                        arg = getattr(func, "arguments", "") or ""
+                    if arg:
+                        args_by_index[tc.index] = args_by_index.get(tc.index, "") + arg
+        return args_by_index
+
     def _collect_function_name(self, results):
         """Extract the function name from streaming results."""
         for delta, _ in results:
@@ -613,6 +628,113 @@ class TestStreamingExtraction:
             f"Partial delimiter leaked into JSON: {args_text!r}"
         )
 
+    def test_streaming_mtp_chunk_crossing_tool_call_boundary(
+        self, parser, mock_request
+    ):
+        """MTP-sized deltas can contain one call's end and the next call's start."""
+        chunks = [
+            "<|tool_call>",
+            "call:getStationInfo{",
+            'location:<|"|>Milano<|"|>}<tool_call|><|tool_call>call:getStationInfo{',
+            'location:<|"|>Piacenza<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_by_index = self._collect_arguments_by_index(results)
+
+        assert set(args_by_index) == {0, 1}
+        assert json.loads(args_by_index[0]) == {"location": "Milano"}
+        assert json.loads(args_by_index[1]) == {"location": "Piacenza"}
+
+    def test_streaming_mtp_chunk_crossing_buffered_tool_call_boundary(
+        self, parser, mock_request
+    ):
+        """A split start delimiter after a close delimiter should still replay."""
+        chunks = [
+            "<|tool_call>",
+            "call:getStationInfo{",
+            'location:<|"|>Milano<|"|>}<tool_call|><',
+            '|tool_call>call:getStationInfo{location:<|"|>Piacenza<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_by_index = self._collect_arguments_by_index(results)
+
+        assert set(args_by_index) == {0, 1}
+        assert json.loads(args_by_index[0]) == {"location": "Milano"}
+        assert json.loads(args_by_index[1]) == {"location": "Piacenza"}
+
+    def test_streaming_mtp_chunk_closes_existing_and_completes_next_call(
+        self, parser, mock_request
+    ):
+        """One MTP delta can close one call and contain the whole next call."""
+        chunks = [
+            '<|tool_call>call:getStationInfo{location:<|"|>Milano<|"|>}',
+            "<tool_call|><|tool_call>call:getStationInfo{"
+            'location:<|"|>Piacenza<|"|>}<tool_call|>',
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_by_index = self._collect_arguments_by_index(results)
+
+        assert set(args_by_index) == {0, 1}
+        assert json.loads(args_by_index[0]) == {"location": "Milano"}
+        assert json.loads(args_by_index[1]) == {"location": "Piacenza"}
+
+    def test_streaming_mtp_chunk_contains_two_complete_tool_calls(
+        self, parser, mock_request
+    ):
+        """A single large delta can contain two complete Gemma4 tool calls."""
+        chunks = [
+            "<|tool_call>call:getStationInfo{"
+            'location:<|"|>Milano<|"|>}<tool_call|>'
+            "<|tool_call>call:getStationInfo{"
+            'location:<|"|>Piacenza<|"|>}<tool_call|>',
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_by_index = self._collect_arguments_by_index(results)
+
+        assert set(args_by_index) == {0, 1}
+        assert json.loads(args_by_index[0]) == {"location": "Milano"}
+        assert json.loads(args_by_index[1]) == {"location": "Piacenza"}
+
+    def test_streaming_filename_suffix_preserved_across_chunks(
+        self, parser, mock_request
+    ):
+        """File extensions split across chunks must not be dropped."""
+        chunks = [
+            "<|tool_call>",
+            "call:read_file{",
+            'path:<|"|>src/main.',
+            'rs<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        assert json.loads(args_text) == {"path": "src/main.rs"}
+
+    def test_streaming_string_prefix_preserved_across_chunks(
+        self, parser, mock_request
+    ):
+        """String values split after the first character must be preserved."""
+        chunks = [
+            "<|tool_call>",
+            "call:spawn_agent{",
+            'subagent_type:<|"|>e',
+            'xplore<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        assert json.loads(args_text) == {"subagent_type": "explore"}
+
     def test_streaming_does_not_duplicate_plain_text_after_tool_call(
         self, parser, mock_request, monkeypatch
     ):
@@ -620,9 +742,9 @@ class TestStreamingExtraction:
         captured_current_texts: list[str] = []
         original_extract_streaming = parser._extract_streaming
 
-        def wrapped_extract_streaming(previous_text, current_text, delta_text):
+        def wrapped_extract_streaming(current_text):
             captured_current_texts.append(current_text)
-            return original_extract_streaming(previous_text, current_text, delta_text)
+            return original_extract_streaming(current_text)
 
         monkeypatch.setattr(parser, "_extract_streaming", wrapped_extract_streaming)
 

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -19,8 +19,6 @@ see ``vllm.tool_parsers.gemma4_utils.parse_tool_calls``.
 import json
 from collections.abc import Sequence
 
-import regex as re
-
 from vllm.entrypoints.chat_utils import make_tool_call_id
 from vllm.entrypoints.openai.chat_completion.protocol import (
     ChatCompletionRequest,
@@ -39,7 +37,7 @@ from vllm.entrypoints.openai.responses.protocol import (
 from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import Tool, ToolParser
-from vllm.tool_parsers.utils import find_common_prefix
+from vllm.tool_parsers.utils import find_common_prefix, partial_tag_overlap
 
 logger = init_logger(__name__)
 
@@ -315,20 +313,21 @@ class Gemma4ToolParser(ToolParser):
     Used when ``--enable-auto-tool-choice --tool-call-parser gemma4``
     are set.
 
-    Streaming strategy: **accumulate-then-parse-then-diff**
+    Streaming strategy: **scan accumulated text, parse, then diff**
 
     Instead of trying to convert Gemma4's custom format to JSON
-    token-by-token (which fails because Gemma4 uses bare keys, custom
+    one token at a time (which fails because Gemma4 uses bare keys, custom
     delimiters, and structural braces that differ from JSON), this parser:
 
-    1. Accumulates the raw Gemma4 argument string during streaming
-    2. Parses it with ``_parse_gemma4_args()`` into a Python dict
-    3. Converts to JSON with ``json.dumps()``
-    4. Diffs against the previously-streamed JSON string
-    5. Emits only the new JSON fragment as the delta
+    1. Re-scans the accumulated model output to find tool-call regions
+    2. Parses each visible region with ``_parse_gemma4_args()``
+    3. Converts arguments to JSON with ``json.dumps()``
+    4. Diffs against the JSON prefix already streamed for that tool index
+    5. Emits only the new function names, argument fragments, and content
 
-    This follows the same pattern used by FunctionGemma, Hermes, and Llama
-    tool parsers.
+    This follows the same shape used by Hermes/Kimi-style parsers and makes
+    the parser insensitive to whether speculative decoding delivers one token
+    or several delimiter events in a single streaming delta.
     """
 
     def __init__(self, tokenizer: TokenizerLike, tools: list[Tool] | None = None):
@@ -354,26 +353,15 @@ class Gemma4ToolParser(ToolParser):
                 f"token '{TOOL_CALL_START}' in the tokenizer!"
             )
 
-        # Regex for non-streaming: extract complete tool calls.
-        # Supports function names with letters, digits, underscores,
-        # hyphens, and dots (e.g. "get-weather", "module.func").
-        self.tool_call_regex = re.compile(
-            r"<\|tool_call>call:([\w\-\.]+)\{(.*?)\}<tool_call\|>",
-            re.DOTALL,
-        )
-
         # Streaming state — reset per-request via _reset_streaming_state()
         self._reset_streaming_state()
-
-        # Delta buffer for handling multi-token special sequences
-        self.buffered_delta_text = ""
 
     def _reset_streaming_state(self) -> None:
         """Reset all streaming state for a new request."""
         self.current_tool_id = -1
-        self.current_tool_name_sent = False
         self.prev_tool_call_arr: list[dict] = []
         self.streamed_args_for_tool: list[str] = []
+        self._sent_content_idx = 0
 
     def adjust_request(
         self, request: ChatCompletionRequest | ResponsesRequest
@@ -390,38 +378,6 @@ class Gemma4ToolParser(ToolParser):
         return request
 
     # ------------------------------------------------------------------
-    # Delta buffering for multi-token special sequences
-    # ------------------------------------------------------------------
-
-    def _buffer_delta_text(self, delta_text: str) -> str:
-        """Buffer incoming delta text to handle multi-token special sequences.
-
-        Accumulates partial tokens that could be the start of
-        ``<|tool_call>`` or ``<tool_call|>`` and only flushes them
-        when the complete sequence is recognized or the sequence breaks.
-
-        This prevents partial special tokens (e.g., ``<|tool``) from being
-        emitted prematurely as content text.
-        """
-        combined = self.buffered_delta_text + delta_text
-
-        # Check if combined ends with a complete special token
-        if combined.endswith(TOOL_CALL_START) or combined.endswith(TOOL_CALL_END):
-            self.buffered_delta_text = ""
-            return combined
-
-        # Check if combined ends with a partial prefix of a special token
-        for tag in [TOOL_CALL_START, TOOL_CALL_END]:
-            for i in range(1, len(tag)):
-                if combined.endswith(tag[:i]):
-                    self.buffered_delta_text = combined[-i:]
-                    return combined[:-i]
-
-        # No partial match — flush everything
-        self.buffered_delta_text = ""
-        return combined
-
-    # ------------------------------------------------------------------
     # Non-streaming extraction
     # ------------------------------------------------------------------
 
@@ -436,14 +392,16 @@ class Gemma4ToolParser(ToolParser):
             )
 
         try:
-            matches = self.tool_call_regex.findall(model_output)
-            if not matches:
+            parsed_tool_calls = self._extract_tool_call_regions(
+                model_output, include_partial=False
+            )
+            if not parsed_tool_calls:
                 return ExtractedToolCallInformation(
                     tools_called=False, tool_calls=[], content=model_output
                 )
 
             tool_calls: list[ToolCall] = []
-            for func_name, args_str in matches:
+            for func_name, args_str, _ in parsed_tool_calls:
                 arguments = _parse_gemma4_args(args_str)
                 tool_calls.append(
                     ToolCall(
@@ -472,7 +430,7 @@ class Gemma4ToolParser(ToolParser):
             )
 
     # ------------------------------------------------------------------
-    # Streaming extraction — accumulate-then-parse-then-diff
+    # Streaming extraction — scan accumulated text, parse, then diff
     # ------------------------------------------------------------------
 
     def extract_tool_calls_streaming(
@@ -485,145 +443,32 @@ class Gemma4ToolParser(ToolParser):
         delta_token_ids: Sequence[int],
         request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
-        # Buffer delta text to handle multi-token special sequences
-        delta_text = self._buffer_delta_text(delta_text)
-        # Keep current_text from the upstream stream state. The buffered delta
-        # is only for emission, and must not be stitched back into the
-        # accumulated model text or normal content like "<div>" can be
-        # duplicated into "<<div>" when a tool call just ended.
-
-        # If no tool call token seen yet, emit as content
-        if self.tool_call_start_token not in current_text:
-            if delta_text:
-                return DeltaMessage(content=delta_text)
-            return None
+        if not previous_text:
+            self._reset_streaming_state()
 
         try:
-            return self._extract_streaming(
-                previous_text=previous_text,
-                current_text=current_text,
-                delta_text=delta_text,
-            )
+            return self._extract_streaming(current_text)
         except Exception:
             logger.exception("Error in Gemma4 streaming tool call extraction")
             return None
 
-    def _extract_streaming(
-        self,
-        previous_text: str,
-        current_text: str,
-        delta_text: str,
-    ) -> DeltaMessage | None:
-        """Tag-counting streaming parser.
+    def _extract_streaming(self, current_text: str) -> DeltaMessage | None:
+        """Stream content and Gemma4 tool-call deltas from accumulated text."""
+        content = self._extract_content(current_text)
+        tool_calls = self._extract_tool_call_regions(current_text, include_partial=True)
+        tool_call_deltas: list[DeltaToolCall] = []
 
-        Uses the proven approach from FunctionGemma/Hermes: count start/end
-        tags in previous vs current text to determine phase, then
-        accumulate-parse-diff for arguments.
+        for index, (func_name, raw_args_str, is_complete) in enumerate(tool_calls):
+            self._ensure_tool_state(index)
 
-        Format: ``<|tool_call>call:name{args}<tool_call|>``
-        """
-        start_count = current_text.count(self.tool_call_start_token)
-        end_count = current_text.count(self.tool_call_end_token)
-        prev_start_count = previous_text.count(self.tool_call_start_token)
-        prev_end_count = previous_text.count(self.tool_call_end_token)
-
-        # Case 1: Not inside any tool call — emit as content
-        if (
-            start_count == end_count
-            and prev_end_count == end_count
-            and self.tool_call_end_token not in delta_text
-        ):
-            if delta_text:
-                return DeltaMessage(content=delta_text)
-            return None
-
-        # Case 2: Starting a new tool call
-        if start_count > prev_start_count and start_count > end_count:
-            self.current_tool_id += 1
-            self.current_tool_name_sent = False
-            self.streamed_args_for_tool.append("")
-            self.prev_tool_call_arr.append({})
-            logger.debug("Starting new tool call %d", self.current_tool_id)
-            # Don't return yet — fall through to try parsing if there's
-            # content after <|tool_call> in this same delta
-            # (but usually it's just the token itself, so return None)
-            if len(delta_text) <= len(self.tool_call_start_token):
-                return None
-
-        # Case 3: Tool call just ended
-        if end_count > prev_end_count:
-            return self._handle_tool_call_end(current_text)
-
-        # Case 4: In the middle of a tool call — parse partial content
-        if start_count > end_count:
-            return self._handle_tool_call_middle(current_text)
-
-        # Default: generate text outside tool calls
-        if delta_text:
-            text = delta_text.replace(self.tool_call_start_token, "")
-            text = text.replace(self.tool_call_end_token, "")
-            if text:
-                return DeltaMessage(content=text)
-        return None
-
-    def _extract_partial_call(self, current_text: str) -> tuple[str | None, str]:
-        """Extract function name and raw argument string from partial text.
-
-        Returns (func_name, raw_args_str) or (None, "") if not parseable yet.
-        """
-        # Get the text after the last <|tool_call> token
-        last_start = current_text.rfind(self.tool_call_start_token)
-        if last_start == -1:
-            return None, ""
-
-        partial_call = current_text[last_start + len(self.tool_call_start_token) :]
-
-        # Strip end token if present
-        if self.tool_call_end_token in partial_call:
-            partial_call = partial_call.split(self.tool_call_end_token)[0]
-
-        # Expect "call:name{args...}" or "call:name{args...}"
-        if not partial_call.startswith("call:"):
-            return None, ""
-
-        func_part = partial_call[5:]  # skip "call:"
-
-        if "{" not in func_part:
-            # Still accumulating function name, not ready yet
-            return None, ""
-
-        func_name, _, args_part = func_part.partition("{")
-        func_name = func_name.strip()
-
-        # Strip trailing '}' if present (Gemma4 structural brace)
-        if args_part.endswith("}"):
-            args_part = args_part[:-1]
-
-        return func_name, args_part
-
-    def _handle_tool_call_middle(self, current_text: str) -> DeltaMessage | None:
-        """Handle streaming when we're inside an active tool call.
-
-        Accumulates the raw Gemma4 arguments, parses them into JSON, and
-        diffs against the previously-streamed JSON to emit only the new
-        fragment.
-        """
-        func_name, args_part = self._extract_partial_call(current_text)
-
-        if func_name is None:
-            return None
-
-        # Step 1: Send function name (once)
-        if not self.current_tool_name_sent and func_name:
-            self.current_tool_name_sent = True
-            self.prev_tool_call_arr[self.current_tool_id] = {
-                "name": func_name,
-                "arguments": {},
-            }
-            return DeltaMessage(
-                tool_calls=[
+            if "name" not in self.prev_tool_call_arr[index]:
+                self.prev_tool_call_arr[index] = {
+                    "name": func_name,
+                    "arguments": {},
+                }
+                tool_call_deltas.append(
                     DeltaToolCall(
-                        index=self.current_tool_id,
+                        index=index,
                         type="function",
                         id=make_tool_call_id(),
                         function=DeltaFunctionCall(
@@ -631,90 +476,160 @@ class Gemma4ToolParser(ToolParser):
                             arguments="",
                         ).model_dump(exclude_none=True),
                     )
-                ]
-            )
-
-        # Step 2: Parse and diff arguments
-        if self.current_tool_name_sent and args_part:
-            return self._emit_argument_diff(args_part)
-
-        return None
-
-    def _handle_tool_call_end(self, current_text: str) -> DeltaMessage | None:
-        """Handle streaming when a tool call has just completed.
-
-        Performs a final parse of the complete tool call and flushes
-        any remaining un-streamed argument fragments.
-        """
-        if self.current_tool_id < 0 or self.current_tool_id >= len(
-            self.prev_tool_call_arr
-        ):
-            logger.debug(
-                "Tool call end detected but no active tool call (current_tool_id=%d)",
-                self.current_tool_id,
-            )
-            return None
-
-        # Parse the complete tool call using regex for accuracy
-        all_matches = self.tool_call_regex.findall(current_text)
-        if self.current_tool_id < len(all_matches):
-            _, args_str = all_matches[self.current_tool_id]
-            final_args = _parse_gemma4_args(args_str)
-            final_args_json = json.dumps(final_args, ensure_ascii=False)
-
-            prev_streamed = self.streamed_args_for_tool[self.current_tool_id]
-            if len(final_args_json) > len(prev_streamed):
-                diff = final_args_json[len(prev_streamed) :]
-                self.streamed_args_for_tool[self.current_tool_id] = final_args_json
-                self.prev_tool_call_arr[self.current_tool_id]["arguments"] = final_args
-
-                return DeltaMessage(
-                    tool_calls=[
-                        DeltaToolCall(
-                            index=self.current_tool_id,
-                            function=DeltaFunctionCall(arguments=diff).model_dump(
-                                exclude_none=True
-                            ),
-                        )
-                    ]
                 )
 
+            args_delta = self._compute_args_diff(
+                index=index,
+                raw_args_str=raw_args_str,
+                is_complete=is_complete,
+            )
+            if args_delta:
+                tool_call_deltas.append(
+                    DeltaToolCall(
+                        index=index,
+                        function=DeltaFunctionCall(arguments=args_delta).model_dump(
+                            exclude_none=True
+                        ),
+                    )
+                )
+
+        if content or tool_call_deltas:
+            return DeltaMessage(content=content, tool_calls=tool_call_deltas)
         return None
 
-    def _emit_argument_diff(self, raw_args_str: str) -> DeltaMessage | None:
-        """Parse raw Gemma4 arguments, convert to JSON, diff, and emit.
+    def _extract_content(self, current_text: str) -> str | None:
+        """Return unsent non-tool-call text, holding partial start tags."""
+        content_parts: list[str] = []
+        pos = self._sent_content_idx
+        text_len = len(current_text)
 
-        This is the core of the accumulate-then-parse-then-diff strategy:
-        1. Parse ``raw_args_str`` with ``_parse_gemma4_args()``
-        2. Convert to JSON string with ``json.dumps()``
-        3. Withhold trailing closing characters (``"}``) that may move
-           as more tokens arrive
-        4. Diff against previously streamed JSON and emit only new chars
+        while pos < text_len:
+            start = current_text.find(self.tool_call_start_token, pos)
+            if start == -1:
+                overlap = partial_tag_overlap(
+                    current_text[pos:], self.tool_call_start_token
+                )
+                sendable_end = text_len - overlap
+                if sendable_end > pos:
+                    content_parts.append(current_text[pos:sendable_end])
+                    pos = sendable_end
+                break
 
-        **Why withholding is necessary:**
+            if start > pos:
+                content_parts.append(current_text[pos:start])
 
-        Gemma4's custom format produces *structurally incomplete* JSON
-        during streaming. For example, when ``<|"|>Paris`` arrives
-        without a closing delimiter, ``_parse_gemma4_args`` treats it
-        as a complete value and produces ``{"location": "Paris"}``. But
-        when ``, France<|"|>`` arrives next, the JSON becomes
-        ``{"location": "Paris, France"}``. If we had sent the closing
-        ``"}`` from the first parse, the concatenated client output
-        would be ``{"location": "Paris"}France"}``, which is garbage.
+            end = current_text.find(
+                self.tool_call_end_token, start + len(self.tool_call_start_token)
+            )
+            if end == -1:
+                pos = start
+                break
 
-        The solution: **never send trailing closing chars during
-        streaming**. They get flushed by ``_handle_tool_call_end()``
-        when the ``<tool_call|>`` end marker arrives.
+            pos = end + len(self.tool_call_end_token)
 
-        Args:
-            raw_args_str: The raw Gemma4 argument text accumulated so far
-                (without the surrounding ``{`` ``}``).
+        self._sent_content_idx = pos
+        return "".join(content_parts) or None
 
-        Returns:
-            DeltaMessage with the argument diff, or None if no new content.
-        """
+    def _extract_tool_call_regions(
+        self, current_text: str, *, include_partial: bool
+    ) -> list[tuple[str, str, bool]]:
+        """Extract visible Gemma4 tool-call regions from accumulated text."""
+        tool_calls: list[tuple[str, str, bool]] = []
+        pos = 0
+
+        while True:
+            start = current_text.find(self.tool_call_start_token, pos)
+            if start == -1:
+                break
+
+            body_start = start + len(self.tool_call_start_token)
+            end = current_text.find(self.tool_call_end_token, body_start)
+            if end == -1:
+                if not include_partial:
+                    break
+                body = current_text[body_start:]
+                overlap = partial_tag_overlap(body, self.tool_call_end_token)
+                if overlap:
+                    body = body[:-overlap]
+                is_complete = False
+                pos = len(current_text)
+            else:
+                body = current_text[body_start:end]
+                is_complete = True
+                pos = end + len(self.tool_call_end_token)
+
+            parsed = self._parse_tool_call_body(body)
+            if parsed is not None:
+                func_name, raw_args_str = parsed
+                tool_calls.append((func_name, raw_args_str, is_complete))
+
+            if not is_complete:
+                break
+
+        return tool_calls
+
+    def _parse_tool_call_body(self, body: str) -> tuple[str, str] | None:
+        """Parse ``call:name{args}`` from a raw Gemma4 tool-call body."""
+        if not body.startswith("call:"):
+            return None
+
+        func_part = body[len("call:") :]
+        open_brace = func_part.find("{")
+        if open_brace == -1:
+            return None
+
+        func_name = func_part[:open_brace].strip()
+        if not func_name:
+            return None
+
+        args_start = open_brace + 1
+        args_end = self._find_outer_args_end(func_part, args_start)
+        raw_args_str = (
+            func_part[args_start:args_end]
+            if args_end is not None
+            else func_part[args_start:]
+        )
+        return func_name, raw_args_str
+
+    def _find_outer_args_end(self, text: str, args_start: int) -> int | None:
+        """Return the index of the outer Gemma4 argument brace, if present."""
+        depth = 1
+        i = args_start
+        text_len = len(text)
+
+        while i < text_len:
+            if text[i:].startswith(STRING_DELIM):
+                i += len(STRING_DELIM)
+                next_delim = text.find(STRING_DELIM, i)
+                if next_delim == -1:
+                    return None
+                i = next_delim + len(STRING_DELIM)
+                continue
+
+            if text[i] == "{":
+                depth += 1
+            elif text[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    return i
+            i += 1
+
+        return None
+
+    def _ensure_tool_state(self, index: int) -> None:
+        """Ensure streaming state exists for tool-call index."""
+        while len(self.prev_tool_call_arr) <= index:
+            self.prev_tool_call_arr.append({})
+        while len(self.streamed_args_for_tool) <= index:
+            self.streamed_args_for_tool.append("")
+        self.current_tool_id = max(self.current_tool_id, index)
+
+    def _compute_args_diff(
+        self, index: int, raw_args_str: str, is_complete: bool
+    ) -> str | None:
+        """Return new argument JSON not yet sent for tool-call index."""
         try:
-            current_args = _parse_gemma4_args(raw_args_str, partial=True)
+            current_args = _parse_gemma4_args(raw_args_str, partial=not is_complete)
         except Exception:
             logger.debug(
                 "Could not parse partial Gemma4 args yet: %s",
@@ -722,57 +637,39 @@ class Gemma4ToolParser(ToolParser):
             )
             return None
 
-        if not current_args:
+        if not current_args and not is_complete:
             return None
 
         current_args_json = json.dumps(current_args, ensure_ascii=False)
+        next_json = (
+            current_args_json
+            if is_complete
+            else self._stable_partial_json_prefix(current_args_json)
+        )
 
-        # Withhold trailing closing characters that may shift as more
-        # tokens arrive. Strip trailing '}', '"', ']' and partial
-        # STRING_DELIM fragments ('<', '|', '\\', '>') to get the
-        # "safe prefix".
-        safe_json = current_args_json
-        while safe_json and safe_json[-1] in ("}", '"', "]", "<", "|", "\\", ">"):
-            safe_json = safe_json[:-1]
-
-        prev_streamed = self.streamed_args_for_tool[self.current_tool_id]
-
-        if not safe_json or safe_json == prev_streamed:
+        prev_streamed = self.streamed_args_for_tool[index]
+        if not next_json or next_json == prev_streamed:
             return None
 
-        # Use find_common_prefix to handle cases where the value changed
-        # structurally (e.g., a string grew).
-        if prev_streamed:
-            prefix = find_common_prefix(prev_streamed, safe_json)
-            sent_len = len(prev_streamed)
-            prefix_len = len(prefix)
-
-            if prefix_len < sent_len:
-                # Structure changed — we sent too much. Truncate our
-                # tracking to the common prefix and wait for the final
-                # flush in _handle_tool_call_end.
-                self.streamed_args_for_tool[self.current_tool_id] = prefix
-                return None
-
-            # Stream the new stable portion
-            diff = safe_json[sent_len:]
-        else:
-            # First emission
-            diff = safe_json
-
-        if diff:
-            self.streamed_args_for_tool[self.current_tool_id] = safe_json
-            self.prev_tool_call_arr[self.current_tool_id]["arguments"] = current_args
-
-            return DeltaMessage(
-                tool_calls=[
-                    DeltaToolCall(
-                        index=self.current_tool_id,
-                        function=DeltaFunctionCall(arguments=diff).model_dump(
-                            exclude_none=True
-                        ),
-                    )
-                ]
+        if not next_json.startswith(prev_streamed):
+            prefix = find_common_prefix(prev_streamed, next_json)
+            self.streamed_args_for_tool[index] = prefix
+            logger.debug(
+                "Skipping Gemma4 argument delta for tool %d because parsed "
+                "JSON no longer extends the streamed prefix.",
+                index,
             )
+            return None
 
-        return None
+        diff = next_json[len(prev_streamed) :]
+        if not diff:
+            return None
+
+        self.streamed_args_for_tool[index] = next_json
+        self.prev_tool_call_arr[index]["arguments"] = current_args
+        return diff
+
+    @staticmethod
+    def _stable_partial_json_prefix(json_text: str) -> str:
+        """Trim closing chars that may move while a Gemma4 call is partial."""
+        return json_text.rstrip('}"]<|\\>')


### PR DESCRIPTION
## Summary

Refs #41967.
Alternative to #42006.

This PR is a more invasive version of the Gemma4 MTP streaming tool-call fix. Instead of preserving the existing tag-counting parser and adding segment replay for MTP-sized deltas, it rewrites Gemma4 streaming around an accumulated-text scanner:

- scan `current_text` for visible Gemma4 tool-call regions on each streaming step
- share the same region scanner between streaming and non-streaming extraction
- parse Gemma4's custom argument format into JSON and diff per tool-call index
- hold partial tool delimiters and unstable partial JSON suffixes until they are safe to emit
- move Gemma-specific argument parsing into `gemma4_utils.py`

## Why this is not duplicating an existing PR

#42006 is the smaller targeted fix for #41967. It keeps the previous streaming parser model and splits/replays deltas when MTP speculative decoding emits multiple Gemma4 tool-call delimiter events in one chunk.

This draft is intentionally different. It replaces the streaming parser's event-order dependence with a Hermes-style accumulated-text scan-and-diff approach. That is more invasive, but it avoids the extra complexity of synthesizing and replaying segment deltas while still covering close-then-open, split-delimiter, and multi-call chunks produced by speculative decoding.

I am opening this as a draft so maintainers can compare the two approaches directly.

## Root cause

With MTP/speculative decoding, a single accepted-token delta can span multiple Gemma4 tool-call delimiters, such as closing one call and opening the next. The old streaming parser updated mutable tool-call state based on aggregate delimiter counts, which could advance to the next tool index before flushing the completed call's remaining arguments.

By rescanning the accumulated text and diffing parsed argument JSON per index, this version no longer depends on the exact delimiter event ordering inside one delta.

## Tests

- `.venv/bin/python -m pytest tests/tool_parsers/test_gemma4_tool_parser.py -q` — 55 passed
- `.venv/bin/ruff check vllm/tool_parsers/gemma4_tool_parser.py vllm/tool_parsers/gemma4_utils.py tests/tool_parsers/test_gemma4_tool_parser.py` — passed
- `.venv/bin/ruff format --check vllm/tool_parsers/gemma4_tool_parser.py vllm/tool_parsers/gemma4_utils.py tests/tool_parsers/test_gemma4_tool_parser.py` — passed
- commit hooks, including mypy, passed during `git commit --amend`
- `.venv/bin/python -m pytest tests/tool_parsers -q` was also attempted earlier and failed only because the Llama parser tests require gated Hugging Face access to `meta-llama/Llama-3.2-1B-Instruct`

## AI assistance

AI assistance was used to draft and iterate on this change. The human submitter should review every changed line and be prepared to defend the approach end-to-end.
