### PR TITLE
[CI][Bugfix] De-flake Fusion E2E TP2 test

### DIFF
--- a/tests/v1/executor/test_tcpstore_fd_adoption.py
+++ b/tests/v1/executor/test_tcpstore_fd_adoption.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Tests for TCPStore master_listen_fd adoption used by MultiprocExecutor.
+
+Without this fix, MultiprocExecutor pre-picked a port via get_open_port()
+(bind + getsockname + close), passed the bare integer to a worker, and
+rank-0 re-bound the port inside libtorch's TCPStore. On a busy host
+another process can grab the port between the two binds → EADDRINUSE,
+which surfaced as CI flake b5cd7338.
+
+The fix holds the listening socket open in the parent, hands the FD to
+rank-0 via send_handle, and adopts it in TCPStore via master_listen_fd.
+"""
+
+import multiprocessing
+import socket
+from datetime import timedelta
+
+import pytest
+
+from vllm.distributed.utils import create_tcp_store
+from vllm.v1.executor.multiproc_executor import _bind_local_listen_socket
+
+
+def _client_sets_key(host: str, port: int, key: str, value: str) -> None:
+    """Run in a child process: connect to the master TCPStore and set a key."""
+    import torch.distributed as dist
+
+    client = dist.TCPStore(
+        host_name=host,
+        port=port,
+        world_size=2,
+        is_master=False,
+        timeout=timedelta(seconds=15),
+        wait_for_workers=False,
+        use_libuv=False,
+    )
+    client.set(key, value)
+
+
+def test_bind_local_listen_socket_returns_listening_socket():
+    s = _bind_local_listen_socket("127.0.0.1")
+    assert s is not None
+    try:
+        host, port = s.getsockname()
+        assert host == "127.0.0.1"
+        assert port > 0
+    finally:
+        s.close()
+
+
+def test_held_listen_socket_blocks_intruders():
+    """While the parent holds the bound listener, no other process can
+    grab the same port. This is the property that closes the TOCTOU
+    window the fix targets."""
+    s = _bind_local_listen_socket("127.0.0.1")
+    assert s is not None
+    try:
+        port = s.getsockname()[1]
+        intruder = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        try:
+            with pytest.raises(OSError):
+                intruder.bind(("127.0.0.1", port))
+        finally:
+            intruder.close()
+    finally:
+        s.close()
+
+
+def test_tcpstore_adopts_pre_bound_fd_end_to_end():
+    """Master TCPStore created via create_tcp_store(listen_socket=...)
+    serves a real client connecting to the same host:port."""
+    s = _bind_local_listen_socket("127.0.0.1")
+    assert s is not None
+    port = s.getsockname()[1]
+
+    # Master adopts the FD via master_listen_fd; no rebind happens.
+    store = create_tcp_store(
+        host="127.0.0.1",
+        port=port,
+        listen_socket=s,
+        world_size=2,
+        is_master=True,
+        timeout=timedelta(seconds=20),
+        wait_for_workers=False,
+        use_libuv=False,
+    )
+
+    ctx = multiprocessing.get_context("spawn")
+    proc = ctx.Process(
+        target=_client_sets_key,
+        args=("127.0.0.1", port, "hello", "world"),
+    )
+    proc.start()
+    try:
+        # Block until the client sets the key. Bounded by the store's
+        # timeout above; if adoption is broken this hangs and fails.
+        value = store.get("hello")
+        assert value == b"world"
+    finally:
+        proc.join(timeout=20)
+        assert proc.exitcode == 0, f"client exit={proc.exitcode}"
+        # Drop the store so its listener FD is released before next test.
+        del store
+
+
+def _send_fd_child(fd_pipe, host: str, port: int, world_size: int, result_q):
+    """Run in a child: receive a listening FD, build a master TCPStore."""
+    from multiprocessing.reduction import recv_handle
+
+    try:
+        fd = recv_handle(fd_pipe)
+        listen_sock = socket.socket(fileno=fd)
+        store = create_tcp_store(
+            host=host,
+            port=port,
+            listen_socket=listen_sock,
+            world_size=world_size,
+            is_master=True,
+            timeout=timedelta(seconds=20),
+            wait_for_workers=False,
+            use_libuv=False,
+        )
+        # Block on a key set by the parent's client to confirm two-way
+        # liveness through the adopted listener.
+        value = store.get("ping")
+        result_q.put(("ok", bytes(value)))
+        del store
+    except Exception as e:
+        result_q.put(("err", repr(e)))
+
+
+def test_url_fallback_works_after_listener_closed():
+    """If FD adoption fails (mocked send_handle failure), the worker must
+    be able to bind the same host:port via the URL path. This requires
+    the parent to release its listener before the worker tries to bind —
+    otherwise EADDRINUSE poisons the fallback."""
+    s = _bind_local_listen_socket("127.0.0.1")
+    assert s is not None
+    port = s.getsockname()[1]
+    # Simulate the post-fix lifecycle: parent attempts send_handle, it
+    # fails, parent immediately closes its copy of the listener.
+    s.close()
+
+    # The fallback URL path now binds a fresh master TCPStore. With the
+    # parent's listener gone, this must succeed (no EADDRINUSE).
+    import torch.distributed as dist
+
+    master = dist.TCPStore(
+        host_name="127.0.0.1",
+        port=port,
+        world_size=2,
+        is_master=True,
+        timeout=timedelta(seconds=20),
+        wait_for_workers=False,
+        use_libuv=False,
+    )
+
+    ctx = multiprocessing.get_context("spawn")
+    proc = ctx.Process(
+        target=_client_sets_key,
+        args=("127.0.0.1", port, "fallback", "ok"),
+    )
+    proc.start()
+    try:
+        value = master.get("fallback")
+        assert value == b"ok"
+    finally:
+        proc.join(timeout=20)
+        assert proc.exitcode == 0
+        del master
+
+
+def test_listener_held_after_close_releases_port():
+    """Confirms the kernel actually releases the port after the parent's
+    close — defensive against any lingering-FD surprise (e.g. another
+    dup somewhere)."""
+    s = _bind_local_listen_socket("127.0.0.1")
+    assert s is not None
+    port = s.getsockname()[1]
+    s.close()
+    # Re-bind succeeds: kernel released the port.
+    s2 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s2.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        s2.bind(("127.0.0.1", port))
+    finally:
+        s2.close()
+
+
+def test_send_handle_to_child_then_adopt():
+    """Mirror what MultiprocExecutor does: parent binds + listens, sends
+    the FD to a child via send_handle, child constructs a master
+    TCPStore via FD adoption. Parent acts as a client."""
+    from multiprocessing.reduction import send_handle
+
+    s = _bind_local_listen_socket("127.0.0.1")
+    assert s is not None
+    port = s.getsockname()[1]
+
+    ctx = multiprocessing.get_context("spawn")
+    # Must be duplex=True so the connection is socketpair-backed (AF_UNIX);
+    # send_handle uses SCM_RIGHTS which is unsupported on os.pipe()-backed
+    # connections.
+    parent_end, child_end = ctx.Pipe(duplex=True)
+    result_q: multiprocessing.Queue = ctx.Queue()
+    proc = ctx.Process(
+        target=_send_fd_child,
+        args=(child_end, "127.0.0.1", port, 2, result_q),
+    )
+    proc.start()
+    try:
+        # Hand off the FD across processes; parent then closes its copy
+        # so the child becomes the sole owner of the listener.
+        send_handle(parent_end, s.fileno(), proc.pid)
+        parent_end.close()
+        child_end.close()
+        s.close()
+
+        # Connect as a client and set the key the child is waiting on.
+        import torch.distributed as dist
+
+        client = dist.TCPStore(
+            host_name="127.0.0.1",
+            port=port,
+            world_size=2,
+            is_master=False,
+            timeout=timedelta(seconds=20),
+            wait_for_workers=False,
+            use_libuv=False,
+        )
+        client.set("ping", "pong")
+        del client
+
+        proc.join(timeout=30)
+        assert proc.exitcode == 0
+        status, value = result_q.get(timeout=5)
+        assert status == "ok", f"child error: {value!r}"
+        assert value == b"pong"
+    finally:
+        if proc.is_alive():
+            proc.terminate()
+            proc.join(timeout=5)

--- a/vllm/distributed/parallel_state.py
+++ b/vllm/distributed/parallel_state.py
@@ -1362,6 +1362,7 @@ def init_distributed_environment(
     local_rank: int = -1,
     backend: str = "nccl",
     timeout: timedelta | None = None,
+    pre_built_store: "torch.distributed.Store | None" = None,
 ):
     logger.debug(
         "world_size=%d rank=%d local_rank=%d distributed_init_method=%s backend=%s",
@@ -1406,6 +1407,13 @@ def init_distributed_environment(
                 rank,
                 distributed_init_method,
             )
+        if pre_built_store is not None:
+            logger.warning(
+                "Discarding pre_built_store: DP/multi-node init rewrites "
+                "host:port to %s, which would not match the FD-adopted store.",
+                distributed_init_method,
+            )
+            pre_built_store = None
     if not torch.distributed.is_initialized():
         logger.info(
             "world_size=%d rank=%d local_rank=%d distributed_init_method=%s backend=%s",
@@ -1415,10 +1423,11 @@ def init_distributed_environment(
             distributed_init_method,
             backend,
         )
-        assert distributed_init_method is not None, (
-            "distributed_init_method must be provided when initializing "
-            "distributed environment"
-        )
+        if pre_built_store is None:
+            assert distributed_init_method is not None, (
+                "distributed_init_method must be provided when initializing "
+                "distributed environment"
+            )
         if not torch.distributed.is_backend_available(backend):
             logger.warning(
                 "Distributed backend %s is not available; falling back to gloo.",
@@ -1428,13 +1437,19 @@ def init_distributed_environment(
                 "Fallback Gloo backend is not available."
             )
             backend = "gloo"
+        # store= and init_method= are mutually exclusive in PyTorch.
+        rendezvous_kwarg: dict[str, Any] = (
+            {"store": pre_built_store}
+            if pre_built_store is not None
+            else {"init_method": distributed_init_method}
+        )
         # this backend is used for WORLD
         torch.distributed.init_process_group(
             backend=backend,
-            init_method=distributed_init_method,
             world_size=world_size,
             rank=rank,
             timeout=timeout,
+            **rendezvous_kwarg,
         )
         if enable_elastic_ep:
             tp_pp_cpu_group = torch.distributed.new_group(

--- a/vllm/v1/executor/multiproc_executor.py
+++ b/vllm/v1/executor/multiproc_executor.py
@@ -5,6 +5,7 @@ import os
 import pickle
 import queue
 import signal
+import socket
 import threading
 import time
 import traceback
@@ -18,6 +19,7 @@ from enum import Enum, auto
 from functools import cached_property, partial
 from multiprocessing.connection import Connection
 from multiprocessing.process import BaseProcess
+from multiprocessing.reduction import recv_handle, send_handle
 from multiprocessing.synchronize import Lock as LockType
 from threading import Thread
 from typing import Any, cast
@@ -64,6 +66,39 @@ from vllm.v1.outputs import AsyncModelRunnerOutput, DraftTokenIds, ModelRunnerOu
 from vllm.v1.worker.worker_base import WorkerWrapperBase
 
 logger = init_logger(__name__)
+
+# How long rank-0 worker waits for the parent to send the TCPStore listening
+# FD over the handshake pipe. send_handle is ~sub-millisecond in the success
+# case; this generous bound only matters if the parent crashes between
+# proc.start() and send_handle.
+_LISTEN_FD_RECV_TIMEOUT_S = 30.0
+
+
+def _bind_local_listen_socket(host: str) -> socket.socket | None:
+    """Bind a TCP listening socket on ``(host, 0)`` and return it.
+
+    The returned socket is held open in the parent until the FD has been
+    sent to rank-0 worker via ``multiprocessing.reduction.send_handle``;
+    rank-0 then adopts the FD via ``torch.distributed.TCPStore``'s
+    ``master_listen_fd`` parameter. This eliminates the TOCTOU window
+    that exists when a port is picked by ``get_open_port()`` (which
+    closes its socket immediately) and re-bound later by libtorch.
+    """
+    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        s.bind((host, 0))
+        s.listen(128)
+    except OSError as e:
+        logger.warning(
+            "Could not pre-bind TCPStore listener on %s: %s; "
+            "falling back to URL-based init",
+            host,
+            e,
+        )
+        s.close()
+        return None
+    return s
 
 
 class FutureWrapper(Future):
@@ -124,9 +159,26 @@ class MultiprocExecutor(Executor):
         set_multiprocessing_worker_envs()
 
         # use the loopback address get_loopback_ip() for communication.
-        distributed_init_method = get_distributed_init_method(
-            get_loopback_ip(), get_open_port()
-        )
+        host = get_loopback_ip()
+        # Pre-bind the TCPStore listener in the parent and pass the FD to
+        # rank-0 via send_handle so libtorch's TCPStore can adopt it
+        # without a separate bind. Single-node, single-DP, non-elastic-EP
+        # only — DP/multi-node init paths overwrite the URL inside
+        # init_distributed_environment, which would invalidate the FD.
+        # Mirrors the inverse gate at parallel_state.init_distributed_environment.
+        listen_socket: socket.socket | None = None
+        if (
+            current_platform.is_cuda_alike()
+            and self.parallel_config.nnodes == 1
+            and self.parallel_config.data_parallel_size == 1
+            and not self.parallel_config.enable_elastic_ep
+        ):
+            listen_socket = _bind_local_listen_socket(host)
+        if listen_socket is not None:
+            port = listen_socket.getsockname()[1]
+        else:
+            port = get_open_port()
+        distributed_init_method = get_distributed_init_method(host, port)
         self.rpc_broadcast_mq: MessageQueue | None = None
         scheduler_output_handle: Handle | None = None
         # Initialize worker and set up message queues for SchedulerOutputs
@@ -187,7 +239,17 @@ class MultiprocExecutor(Executor):
                         shared_worker_lock=shared_worker_lock,
                         is_driver_worker=is_driver_worker,
                         inherited_fds=inherited_fds,
+                        listen_socket=(listen_socket if global_rank == 0 else None),
                     )
+                # Release the parent's copy of the listener as soon as
+                # rank-0 has been spawned: on success the FD has been duped
+                # into rank-0 via send_handle; on send_handle failure the
+                # worker will fall back to URL-based init and must be able
+                # to bind this exact port — which it cannot while the
+                # parent still holds an actively-listening socket on it.
+                if global_rank == 0 and listen_socket is not None:
+                    listen_socket.close()
+                    listen_socket = None
                 unready_workers.append(unready_worker_handle)
                 if inherited_fds is not None:
                     inherited_fds.append(unready_worker_handle.death_writer.fileno())
@@ -242,6 +304,10 @@ class MultiprocExecutor(Executor):
                         uw.death_writer.close()
                         uw.death_writer = None
                 self._ensure_worker_termination([uw.proc for uw in unready_workers])
+            # The listening FD has been duped into rank-0 via send_handle
+            # (or never bound); release the parent's copy unconditionally.
+            if listen_socket is not None:
+                listen_socket.close()
 
         self.output_rank = self._get_output_rank()
 
@@ -585,6 +651,7 @@ class WorkerProc:
         input_shm_handle: Handle,
         shared_worker_lock: LockType,
         is_driver_worker: bool,
+        listen_fd: int | None = None,
     ):
         self.rank = rank
         wrapper = WorkerWrapperBase(rpc_rank=local_rank, global_rank=rank)
@@ -600,6 +667,10 @@ class WorkerProc:
             "is_driver_worker": is_driver_worker,
             "shared_worker_lock": shared_worker_lock,
         }
+        # Only inject when present so non-GPU Worker classes — which do not
+        # accept this kwarg — are unaffected.
+        if listen_fd is not None:
+            all_kwargs[local_rank]["listen_fd"] = listen_fd
         wrapper.init_worker(all_kwargs)
         self.worker = wrapper
 
@@ -650,12 +721,22 @@ class WorkerProc:
         shared_worker_lock: LockType,
         is_driver_worker: bool,
         inherited_fds: list[int] | None = None,
+        listen_socket: socket.socket | None = None,
     ) -> UnreadyWorkerProcHandle:
         context = get_mp_context()
         # Ready pipe to communicate readiness from child to parent
         ready_reader, ready_writer = context.Pipe(duplex=False)
         # Death pipe to let child detect parent process exit
         death_reader, death_writer = context.Pipe(duplex=False)
+        # Dedicated socketpair-backed connection for ferrying the TCPStore
+        # listening FD to rank-0 via multiprocessing.reduction.send_handle.
+        # Must be duplex=True so the underlying FDs are AF_UNIX sockets;
+        # send_handle/recv_handle use SCM_RIGHTS, which Pipe(duplex=False)
+        # (os.pipe-backed) does not support.
+        fd_pipe_parent: Connection | None = None
+        fd_pipe_child: Connection | None = None
+        if listen_socket is not None:
+            fd_pipe_parent, fd_pipe_child = context.Pipe(duplex=True)
         if inherited_fds is not None:
             inherited_fds = inherited_fds.copy()
             inherited_fds.extend((ready_reader.fileno(), death_writer.fileno()))
@@ -667,6 +748,7 @@ class WorkerProc:
             "input_shm_handle": input_shm_handle,
             "ready_pipe": ready_writer,
             "death_pipe": death_reader,
+            "fd_pipe": fd_pipe_child,
             "shared_worker_lock": shared_worker_lock,
             "is_driver_worker": is_driver_worker,
             # Have the worker close parent end of this worker's pipes too
@@ -689,6 +771,25 @@ class WorkerProc:
         # Close child ends of pipes here in the parent
         ready_writer.close()
         death_reader.close()
+        if fd_pipe_child is not None:
+            fd_pipe_child.close()
+
+        # Hand the listening socket FD to rank-0 via SCM_RIGHTS. The child
+        # adopts it inside torch's TCPStore via ``master_listen_fd``, so
+        # rank-0 never re-binds the port. If this hop fails the worker
+        # falls back to the URL-based init path with a warning.
+        if fd_pipe_parent is not None:
+            assert listen_socket is not None
+            try:
+                send_handle(fd_pipe_parent, listen_socket.fileno(), proc.pid)
+            except Exception as e:
+                logger.warning(
+                    "send_handle to rank-0 (pid=%s) failed: %s; "
+                    "rank 0 will fall back to URL-based init",
+                    proc.pid,
+                    e,
+                )
+            fd_pipe_parent.close()
         # Keep death_writer open in parent - when parent exits,
         # death_reader in child will get EOFError
         return UnreadyWorkerProcHandle(proc, rank, ready_reader, death_writer)
@@ -814,6 +915,7 @@ class WorkerProc:
         worker = None
         ready_writer = kwargs.pop("ready_pipe")
         death_pipe = kwargs.pop("death_pipe", None)
+        fd_pipe: Connection | None = kwargs.pop("fd_pipe", None)
 
         # Close inherited pipes from parent (incl. other worker pipes)
         # Explicitly passing in existing pipes and closing them makes the pipe
@@ -824,6 +926,25 @@ class WorkerProc:
                 os.close(fd)
             except Exception as e:
                 logger.warning("Error closing inherited connection: %s: %s", type(e), e)
+
+        # Receive the TCPStore listening FD from the parent (rank-0 only).
+        # Presence of fd_pipe is the signal that we expect a handle.
+        if fd_pipe is not None:
+            try:
+                if fd_pipe.poll(timeout=_LISTEN_FD_RECV_TIMEOUT_S):
+                    kwargs["listen_fd"] = recv_handle(fd_pipe)
+                else:
+                    logger.warning(
+                        "Timed out waiting for TCPStore listen_fd; "
+                        "falling back to URL-based init"
+                    )
+            except Exception as e:
+                logger.warning(
+                    "recv_handle for TCPStore listen_fd failed: %s; "
+                    "falling back to URL-based init",
+                    e,
+                )
+            fd_pipe.close()
 
         try:
             # Initialize tracer

--- a/vllm/v1/worker/gpu_worker.py
+++ b/vllm/v1/worker/gpu_worker.py
@@ -4,6 +4,7 @@
 
 import gc
 import os
+import socket
 from collections.abc import Callable
 from contextlib import AbstractContextManager, contextmanager, nullcontext
 from datetime import timedelta
@@ -111,6 +112,7 @@ class Worker(WorkerBase):
         rank: int,
         distributed_init_method: str,
         is_driver_worker: bool = False,
+        listen_fd: int | None = None,
     ):
         super().__init__(
             vllm_config=vllm_config,
@@ -119,6 +121,9 @@ class Worker(WorkerBase):
             distributed_init_method=distributed_init_method,
             is_driver_worker=is_driver_worker,
         )
+        # Pre-bound TCPStore listening FD adopted via master_listen_fd; only
+        # set on rank 0 of the local node when MultiprocExecutor pre-binds.
+        self.listen_fd = listen_fd
 
         # configure float32 matmul precision according to vLLM env.
         precision = envs.VLLM_FLOAT32_MATMUL_PRECISION
@@ -286,7 +291,11 @@ class Worker(WorkerBase):
                 self.distributed_init_method,
                 self.local_rank,
                 current_platform.dist_backend,
+                listen_fd=self.listen_fd,
             )
+            # FD ownership has been transferred to the TCPStore; clear the
+            # local reference so it isn't re-used.
+            self.listen_fd = None
 
             if self.use_v2_model_runner:
                 logger.info_once("Using V2 Model Runner")
@@ -1118,12 +1127,65 @@ class Worker(WorkerBase):
         return self.elastic_ep_executor.execute(execute_method, *args, **kwargs)
 
 
+def _build_tcp_store_from_fd(
+    init_method: str,
+    listen_fd: int,
+    world_size: int,
+    timeout: timedelta,
+) -> "torch.distributed.Store | None":
+    """Build a master TCPStore that adopts an already-listening FD.
+
+    Returns None and closes the FD on any failure so the caller can fall
+    back to the URL-based init path.
+    """
+    from vllm.distributed.utils import create_tcp_store
+    from vllm.utils.network_utils import split_zmq_path
+
+    try:
+        scheme, host, port_str = split_zmq_path(init_method)
+        port = int(port_str)
+        assert scheme == "tcp"
+    except (ValueError, AssertionError):
+        logger.warning(
+            "Unsupported init_method=%s for FD adoption; "
+            "falling back to URL-based init",
+            init_method,
+        )
+        socket.close(listen_fd)
+        return None
+    listen_socket = socket.socket(fileno=listen_fd)
+    try:
+        store = create_tcp_store(
+            host=host,
+            port=port,
+            listen_socket=listen_socket,
+            world_size=world_size,
+            is_master=True,
+            timeout=timeout,
+            wait_for_workers=False,
+            use_libuv=False,
+        )
+    except Exception as e:
+        logger.warning(
+            "TCPStore FD-adoption failed (%s); falling back to URL-based init",
+            e,
+        )
+        return None
+    logger.info(
+        "Adopted pre-bound TCPStore listener on %s:%d (rank 0)",
+        host,
+        port,
+    )
+    return store
+
+
 def init_worker_distributed_environment(
     vllm_config: VllmConfig,
     rank: int,
     distributed_init_method: str | None = None,
     local_rank: int = -1,
     backend: str = "nccl",
+    listen_fd: int | None = None,
 ) -> None:
     """Initialize the distributed environment."""
     parallel_config = vllm_config.parallel_config
@@ -1139,6 +1201,15 @@ def init_worker_distributed_environment(
     if parallel_config.distributed_timeout_seconds is not None:
         timeout = timedelta(seconds=parallel_config.distributed_timeout_seconds)
 
+    pre_built_store = None
+    if listen_fd is not None and init_method.startswith("tcp://"):
+        pre_built_store = _build_tcp_store_from_fd(
+            init_method=init_method,
+            listen_fd=listen_fd,
+            world_size=parallel_config.world_size,
+            timeout=timeout or timedelta(seconds=600),
+        )
+
     init_distributed_environment(
         parallel_config.world_size,
         rank,
@@ -1146,6 +1217,7 @@ def init_worker_distributed_environment(
         local_rank,
         backend,
         timeout,
+        pre_built_store=pre_built_store,
     )
 
     ensure_model_parallel_initialized(


### PR DESCRIPTION
## Purpose

`MultiprocExecutor` picks a port via `get_open_port()` (bind+getsockname+close), then rank-0 re-binds it inside libtorch's `TCPStore` seconds later. On a busy host another process can grab the port between the two binds → `DistNetworkError: EADDRINUSE`. Surfaced as the failing step in [CI build #65401 — Fusion E2E TP2 (B200)](https://buildkite.com/vllm/ci/builds/65401/canvas?sid=019e0fc6-8a58-457e-852a-ff34b015d7a6&tab=output).

Fix: hold the listening socket open in the parent, send the FD to rank-0 via `multiprocessing.reduction.send_handle`, and adopt it via `TCPStore(master_listen_fd=...)` through the existing `create_tcp_store` helper. Gated to single-node single-DP CUDA paths.

## Test Plan

`tests/v1/executor/test_tcpstore_fd_adoption.py` — bind helper, intruder-blocking, end-to-end FD adoption, URL fallback after listener close, port release, and cross-process `send_handle`/`recv_handle`.

## Test Result

```
$ pytest -v tests/v1/executor/test_tcpstore_fd_adoption.py
======================= 6 passed =======================
```