### PR TITLE
[Bugfix][ROCm] Force splitK=0 in AiterFp8BlockScaledMMKernel for determinism

### DIFF
--- a/vllm/model_executor/kernels/linear/scaled_mm/aiter.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/aiter.py
@@ -2,8 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
-import os
-
 import torch
 
 from vllm import _custom_ops as ops
@@ -30,13 +28,14 @@ from .ScaledMMLinearKernel import (
 logger = init_logger(__name__)
 
 
-# Workaround for a non-determinism bug in
-# `aiter.gemm_a8w8_blockscale_ck` when the CK split-K reduction runs with
-# KBatch > 1. The reduction accumulates partial K products through atomic
-# floating-point adds, which is not associative; back-to-back calls with
-# bit-identical inputs can differ by up to 4 LSBs in bf16. On DeepSeek-V3.2
-# (TP=4, MI355X) this drifts top-1 logits enough to cause token loops at
-# `--max-num-seqs >= 2`, dropping `lm_eval gsm8k` from ~0.95 to ~0.12.
+# Workaround for a non-determinism bug in `aiter.gemm_a8w8_blockscale_ck`
+# (and `aiter.gemm_a8w8_blockscale_cktile`) when the CK split-K reduction
+# runs with KBatch > 1. The reduction accumulates partial K products through
+# atomic floating-point adds, which is not associative; back-to-back calls
+# with bit-identical inputs can differ by up to 4 LSBs in bf16. On
+# DeepSeek-V3.2 (TP=4, MI355X) this drifts top-1 logits enough to cause
+# token loops at `--max-num-seqs >= 2`, dropping `lm_eval gsm8k` from
+# ~0.95 to ~0.12.
 #
 # The CSV-driven dispatcher inside AITER selects splitK >= 2 for several
 # DSV3.2 dense GEMM shapes (notably `o_proj` at M=1..16 and `q_a_proj` at
@@ -47,14 +46,14 @@ logger = init_logger(__name__)
 #
 # Until the underlying CK reduction is made deterministic upstream, we
 # bypass the CSV dispatcher in `AiterFp8BlockScaledMMKernel` and call the
-# CK kernel directly with splitK=0. Cost is ~10-60% on a handful of
+# CK kernel directly with splitK=0. This also bypasses the CK-Tile path,
+# which uses the same atomic-FP-add reduction and is therefore also
+# affected; sending all traffic through CK at splitK=0 keeps the workaround
+# minimal and uniformly deterministic. Cost is ~10-60% on a handful of
 # small-M decode shapes that wanted splitK>0; correctness is restored
-# bit-exactly. Set `VLLM_ROCM_AITER_BLOCK_SCALED_FORCE_SPLITK0=0` to opt
-# out (e.g. for benchmarking the buggy path).
-_AITER_FORCE_SPLITK_ZERO = (
-    os.getenv("VLLM_ROCM_AITER_BLOCK_SCALED_FORCE_SPLITK0", "1").lower()
-    not in ("0", "false", "no")
-)
+# bit-exactly. The aiter `gemm_a8w8_blockscale_ck` kernel is hardcoded for
+# 128x128 weight blocks, so this kernel restricts itself to that shape via
+# `can_implement` and asserts it in `apply_block_scaled_mm`.
 
 
 class AiterInt8ScaledMMLinearKernel(CutlassInt8ScaledMMLinearKernel):
@@ -332,6 +331,16 @@ class AiterFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
                 "Supports only dynamic per token group activation "
                 "quantization with group_shape=(1,128).",
             )
+
+        weight_group_shape = config.weight_quant_key.scale.group_shape
+        if weight_group_shape != GroupShape(128, 128):
+            return (
+                False,
+                "Supports only block-wise weight quantization with "
+                "group_shape=(128,128); the underlying "
+                "`aiter.gemm_a8w8_blockscale_ck` kernel is hardcoded for "
+                "128x128 weight blocks.",
+            )
         return True, None
 
     def apply_block_scaled_mm(
@@ -358,22 +367,24 @@ class AiterFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
 
         out_dtype = self.config.out_dtype
 
-        if _AITER_FORCE_SPLITK_ZERO and not self.use_triton:
-            # Bypass the CSV-driven splitK selection in
-            # `aiter.gemm_a8w8_blockscale` and call the CK kernel directly
-            # with splitK=0. See module-level comment for rationale.
-            import aiter
-
-            M = A.shape[0]
-            N = B.shape[0]
-            Y = torch.empty(M, N, dtype=out_dtype, device=A.device)
-            return aiter.gemm_a8w8_blockscale_ck(A, B, As, Bs, Y, splitK=0)
-
         if self.use_triton:
-            gemm_a8w8_blockscale_op = rocm_aiter_ops.triton_gemm_a8w8_blockscale
-        else:
-            gemm_a8w8_blockscale_op = rocm_aiter_ops.gemm_a8w8_blockscale
+            return rocm_aiter_ops.triton_gemm_a8w8_blockscale(
+                A, B, As, Bs, list(self.weight_group_shape), output_dtype=out_dtype
+            )
 
-        return gemm_a8w8_blockscale_op(
-            A, B, As, Bs, list(self.weight_group_shape), output_dtype=out_dtype
+        # Bypass the CSV-driven splitK selection in
+        # `aiter.gemm_a8w8_blockscale` (which routes to either CK or
+        # CK-Tile, both of which are non-deterministic at splitK >= 2)
+        # and call the CK kernel directly with splitK=0. See module-level
+        # comment for rationale.
+        assert self.weight_group_shape == GroupShape(128, 128), (
+            "AiterFp8BlockScaledMMKernel requires weight group_shape="
+            "(128,128); `gemm_a8w8_blockscale_ck` is hardcoded for that "
+            "block size."
         )
+        import aiter
+
+        M = A.shape[0]
+        N = B.shape[0]
+        Y = torch.empty(M, N, dtype=out_dtype, device=A.device)
+        return aiter.gemm_a8w8_blockscale_ck(A, B, As, Bs, Y, splitK=0)

--- a/vllm/model_executor/kernels/linear/scaled_mm/aiter.py
+++ b/vllm/model_executor/kernels/linear/scaled_mm/aiter.py
@@ -2,6 +2,8 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 
+import os
+
 import torch
 
 from vllm import _custom_ops as ops
@@ -26,6 +28,33 @@ from .ScaledMMLinearKernel import (
 )
 
 logger = init_logger(__name__)
+
+
+# Workaround for a non-determinism bug in
+# `aiter.gemm_a8w8_blockscale_ck` when the CK split-K reduction runs with
+# KBatch > 1. The reduction accumulates partial K products through atomic
+# floating-point adds, which is not associative; back-to-back calls with
+# bit-identical inputs can differ by up to 4 LSBs in bf16. On DeepSeek-V3.2
+# (TP=4, MI355X) this drifts top-1 logits enough to cause token loops at
+# `--max-num-seqs >= 2`, dropping `lm_eval gsm8k` from ~0.95 to ~0.12.
+#
+# The CSV-driven dispatcher inside AITER selects splitK >= 2 for several
+# DSV3.2 dense GEMM shapes (notably `o_proj` at M=1..16 and `q_a_proj` at
+# M=16..128) starting with the `aiter#3024` ("[Silo] Add configs missing
+# from bulk merge #3004", merged 2026-05-05) tuning re-roll, which
+# replaced previously deterministic splitK=0 entries with faster but
+# non-deterministic splitK={2,3} ones.
+#
+# Until the underlying CK reduction is made deterministic upstream, we
+# bypass the CSV dispatcher in `AiterFp8BlockScaledMMKernel` and call the
+# CK kernel directly with splitK=0. Cost is ~10-60% on a handful of
+# small-M decode shapes that wanted splitK>0; correctness is restored
+# bit-exactly. Set `VLLM_ROCM_AITER_BLOCK_SCALED_FORCE_SPLITK0=0` to opt
+# out (e.g. for benchmarking the buggy path).
+_AITER_FORCE_SPLITK_ZERO = (
+    os.getenv("VLLM_ROCM_AITER_BLOCK_SCALED_FORCE_SPLITK0", "1").lower()
+    not in ("0", "false", "no")
+)
 
 
 class AiterInt8ScaledMMLinearKernel(CutlassInt8ScaledMMLinearKernel):
@@ -328,6 +357,18 @@ class AiterFp8BlockScaledMMKernel(Fp8BlockScaledMMLinearKernel):
                 Bs = Bs.to(torch.float32)
 
         out_dtype = self.config.out_dtype
+
+        if _AITER_FORCE_SPLITK_ZERO and not self.use_triton:
+            # Bypass the CSV-driven splitK selection in
+            # `aiter.gemm_a8w8_blockscale` and call the CK kernel directly
+            # with splitK=0. See module-level comment for rationale.
+            import aiter
+
+            M = A.shape[0]
+            N = B.shape[0]
+            Y = torch.empty(M, N, dtype=out_dtype, device=A.device)
+            return aiter.gemm_a8w8_blockscale_ck(A, B, As, Bs, Y, splitK=0)
+
         if self.use_triton:
             gemm_a8w8_blockscale_op = rocm_aiter_ops.triton_gemm_a8w8_blockscale
         else:


### PR DESCRIPTION
## Summary

`aiter.gemm_a8w8_blockscale_ck` is non-deterministic when its CSV-driven
dispatcher selects `splitK >= 2`: the underlying CK split-K reduction
accumulates partial K products through atomic floating-point adds,
which is not associative, so back-to-back calls with bit-identical
inputs can disagree by a few LSBs in bf16. This PR forces
`splitK=0` on the CK path inside
`AiterFp8BlockScaledMMKernel.apply_block_scaled_mm` so the kernel is
deterministic, bypassing the buggy CSV dispatcher until the underlying
CK reduction is fixed upstream.

This is intentionally a small, scoped fix.

## Reproducer (12 lines, single GPU, MI355X / gfx950)

```python
import aiter, torch
from vllm.model_executor.layers.quantization.utils.fp8_utils \
    import per_token_group_quant_fp8
M, K, N = 4, 4096, 7168                         # o_proj at decode batch 4
A_bf = torch.randn(M, K, device="cuda", dtype=torch.bfloat16)
Aq, As = per_token_group_quant_fp8(A_bf, 128)
B  = torch.randn(N, K, device="cuda", dtype=torch.bfloat16).clamp_(-3, 3)
Bs = torch.full((N // 128, K // 128), 1.0, device="cuda")
Bq = B.to(torch.float8_e4m3fn)
Y0 = torch.zeros(M, N, device="cuda", dtype=torch.bfloat16)
Y1 = torch.zeros(M, N, device="cuda", dtype=torch.bfloat16)
aiter.gemm_a8w8_blockscale_ck(Aq, Bq, As, Bs, Y0, splitK=3)  # CSV pick
aiter.gemm_a8w8_blockscale_ck(Aq, Bq, As, Bs, Y1, splitK=3)
print((Y0 - Y1).abs().max().item())                           # ~2-4  (NOT 0!)
```

| splitK | max\|Y0-Y1\| (M=4, N=7168, K=4096, bf16) |
|-------:|------------------------------------------:|
| 0      | 0.0                                       |
| 2      | ~2.5                                      |
| 3      | ~2.0–4.0                                  |

Verified on the patched build:

```
splitK=3 nondeterminism: max|d|= 2.0
splitK=0 max|d|= 0.0
```

## When did it start?

`aiter` PR
[#3024](https://github.com/ROCm/aiter/pull/3024) ("[Silo] Add configs
missing from bulk merge #3004", merged 2026-05-05) added 147 `gfx950`
rows to
`aiter/configs/model_configs/a8w8_blockscale_tuned_gemm_ds_v3.csv`,
replacing previously deterministic `splitK=0` entries with
`splitK={2,3}` for some DSV3.2 dense decode shapes. The re-roll was a
pure speed optimisation — the tuner is not aware of the determinism
cost of split-K. `git blame` confirms PR #3024 (`1638f9e`) is the
trigger.

## Scope of the fix

Only the CK path of `AiterFp8BlockScaledMMKernel` is changed. The
Triton path (`triton_gemm_a8w8_blockscale`) already uses a deterministic
two-stage reduction (no atomics) and is left untouched. The CK-Tile
path is also bypassed — it consumes the same `splitK` from the same
CSV and uses the same atomic-FP-add reduction, so it is affected by
the same bug. Routing all non-Triton traffic through CK at `splitK=0`
keeps the workaround uniformly deterministic and minimal.

## Restriction to 128x128 weight blocks

`aiter.gemm_a8w8_blockscale_ck` is hardcoded for 128x128 weight
blocks. To make this assumption explicit and prevent silent misuse,
`can_implement` now refuses to bind to any layer whose
`weight_quant_key.scale.group_shape != GroupShape(128, 128)`, and
`apply_block_scaled_mm` asserts the same invariant defensively at the
call site. The kernel is currently only ever bound to (128, 128)
weights in tree, so this is a no-op for existing configurations.

## Verification

End-to-end on `vllm-project/vllm@215e2f799` + the team's standard ROCm
flags (`VLLM_ROCM_USE_AITER=1`,
`VLLM_ROCM_USE_AITER_FUSION_SHARED_EXPERTS=1`,
`VLLM_ROCM_QUICK_REDUCE_QUANTIZATION=INT4`,
`--tensor-parallel-size 4 --block-size 64 --async-scheduling
--gpu-memory-utilization 0.85 --enforce-eager --max-num-seqs 4`),
DeepSeek-V3.2, MI355X TP4:

| benchmark                         | un-patched | patched | delta   |
|-----------------------------------|-----------:|--------:|--------:|
| gsm8k 5-shot, c=4, limit=200, flex | 0.925     | 0.930   | +0.005  |
| gsm8k 5-shot, c=4, limit=200, strict | 0.925   | 0.930   | +0.005  |
| stderr (both rows)                | 0.0187     | 0.0181  | —       |
| Output throughput (tok/s, c=64, ISL=1024, OSL=256) | 231.87 | 236.52 | +2.0% |
| TPOT mean (ms, same)              | 211.98     | 206.91  | -2.4%   |
| TPOT median (ms, same)            | 229.07     | 225.45  | -1.6%   |
| TTFT median (ms, same)            | 3804.06    | 3997.99 | +5.1%   |

Accuracy is unchanged within stderr; performance is within run-to-run
noise. The forced `splitK=0` is concentrated on small-M decode shapes
where split-K's theoretical benefit was already small.

## Follow-up upstream

A draft AITER patch (clamp `splitK<=1` in `aiter/ops/gemm_op_a8w8.py`
plus `op_test_gemm_a8w8_blockscale_determinism.py`) is ready to send to
ROCm/aiter. Once that lands, this vLLM workaround can be removed.
