### PR TITLE
[Perf] [Qwen3.5] Reenable torch compile for `rearrange_mixed_qkv` in GDN linear attention

### DIFF
--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -649,29 +649,16 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         if mixed_qkv is None:
             return None, None, None
 
-        seq_len = mixed_qkv.shape[0]
-        q_dim = self.key_dim // self.tp_size
-        k_dim = self.key_dim // self.tp_size
-        v_dim = self.value_dim // self.tp_size
+        from vllm.model_executor.layers.mamba.ops.gdn_ops import rearrange_mixed_qkv
 
-        query, key, value = torch.split(mixed_qkv, [q_dim, k_dim, v_dim], dim=-1)
-
-        fused = torch.cat(
-            [query.reshape(-1), key.reshape(-1), value.reshape(-1)], dim=0
+        return rearrange_mixed_qkv(
+            mixed_qkv,
+            self.key_dim,
+            self.value_dim,
+            self.tp_size,
+            self.head_k_dim,
+            self.head_v_dim,
         )
-
-        q_size = seq_len * q_dim
-        k_size = seq_len * k_dim
-
-        q_contig = fused[0:q_size]
-        k_contig = fused[q_size : q_size + k_size]
-        v_contig = fused[q_size + k_size :]
-
-        query = q_contig.view(1, seq_len, -1, self.head_k_dim)
-        key = k_contig.view(1, seq_len, -1, self.head_k_dim)
-        value = v_contig.view(1, seq_len, -1, self.head_v_dim)
-
-        return query, key, value
 
     def forward(
         self,
@@ -983,6 +970,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         cu_seqlens = torch.tensor([0, T], device=device, dtype=torch.int32)
 
         try:
+            self.rearrange_mixed_qkv(dummy_mixed_qkv)
             self.chunk_gated_delta_rule(
                 q=q,
                 k=k,

--- a/vllm/model_executor/layers/mamba/ops/gdn_ops.py
+++ b/vllm/model_executor/layers/mamba/ops/gdn_ops.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Ops for GDN linear attention.
+
+_compiled_rearrange_mixed_qkv and _rearrange_mixed_qkv are
+implemented differently in torch as each other because of
+the different ways they are used (eager vs cudagraph).
+
+"""
+
+import torch
+from einops import rearrange
+
+
+@torch.compile(fullgraph=True)
+def _compiled_rearrange_mixed_qkv(
+    mixed_qkv: torch.Tensor,
+    key_dim: int,
+    value_dim: int,
+    tp_size: int,
+    head_k_dim: int,
+    head_v_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Split packed qkv into contiguous (1, seq, heads, dim) tensors.
+
+    The original code used ``rearrange(x, "l (h d) -> 1 l h d", d=...)``
+    followed by ``.contiguous()`` on each tensor.  This version flattens
+    all three splits into a single buffer via ``torch.cat`` so that
+    torch.compile emits one Triton copy kernel instead of three separate
+    contiguous() calls.
+    """
+    seq_len = mixed_qkv.shape[0]
+    q_dim = key_dim // tp_size
+    k_dim = key_dim // tp_size
+    v_dim = value_dim // tp_size
+
+    query, key, value = torch.split(mixed_qkv, [q_dim, k_dim, v_dim], dim=-1)
+
+    fused = torch.cat([query.reshape(-1), key.reshape(-1), value.reshape(-1)], dim=0)
+
+    q_size = seq_len * q_dim
+    k_size = seq_len * k_dim
+
+    q_contig = fused[0:q_size]
+    k_contig = fused[q_size : q_size + k_size]
+    v_contig = fused[q_size + k_size :]
+
+    query = q_contig.view(1, seq_len, -1, head_k_dim)
+    key = k_contig.view(1, seq_len, -1, head_k_dim)
+    value = v_contig.view(1, seq_len, -1, head_v_dim)
+
+    return query, key, value
+
+
+def _rearrange_mixed_qkv(
+    mixed_qkv: torch.Tensor,
+    key_dim: int,
+    value_dim: int,
+    tp_size: int,
+    head_k_dim: int,
+    head_v_dim: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    query, key, value = torch.split(
+        mixed_qkv,
+        [
+            key_dim // tp_size,
+            key_dim // tp_size,
+            value_dim // tp_size,
+        ],
+        dim=-1,
+    )
+    query, key = map(
+        lambda x: rearrange(x, "l (h d) -> 1 l h d", d=head_k_dim),
+        (query, key),
+    )
+    value = rearrange(value, "l (h d) -> 1 l h d", d=head_v_dim)
+    return query.contiguous(), key.contiguous(), value.contiguous()
+
+
+def rearrange_mixed_qkv(
+    mixed_qkv: torch.Tensor | None,
+    key_dim: int,
+    value_dim: int,
+    tp_size: int,
+    head_k_dim: int,
+    head_v_dim: int,
+) -> tuple[torch.Tensor | None, torch.Tensor | None, torch.Tensor | None]:
+    if mixed_qkv is None:
+        return None, None, None
+
+    # TODO: Find a better way to initialize the function so that
+    # we always use the torch compiled function
+    # For now, we are mixing two kernels implementation to
+    # get the best out of both worlds.
+    if mixed_qkv.is_cuda and torch.cuda.is_current_stream_capturing():
+        return _rearrange_mixed_qkv(
+            mixed_qkv,
+            key_dim,
+            value_dim,
+            tp_size,
+            head_k_dim,
+            head_v_dim,
+        )
+
+    return _compiled_rearrange_mixed_qkv(
+        mixed_qkv,
+        key_dim,
+        value_dim,
+        tp_size,
+        head_k_dim,
+        head_v_dim,
+    )


### PR DESCRIPTION



## Purpose

This PR tries to re-enable torch compile for `rearrange_mixed_qkv` in GDN linear attention introduced by this PR https://github.com/vllm-project/vllm/pull/40711 , and fixes a torch.compile/CUDA graph capture failure in the Gated DeltaNet attention path by moving the mixed QKV rearrangement logic into a dedicated helper and warming that helper before CUDA graph capture.

The failure happened because `rearrange_mixed_qkv` could be compiled for the first time while CUDA graph capture was already active. During that first-time compile, Inductor may lazily initialize attention fusion patterns and perform a CPU-to-CUDA copy. CUDA graph capture rejects that copy, which caused model initialization to fail with:

```text
RuntimeError: Cannot copy between CPU and CUDA tensors during CUDA graph capture
unless the CPU tensor is pinned.
```

The packed QKV split and rearrangement logic is now separated into a helper in:

```text
vllm/model_executor/layers/mamba/ops/gdn_ops.py
```

That helper has two layers:

- `_rearrange_mixed_qkv_impl(...)`: the eager PyTorch implementation.
- `_compiled_rearrange_mixed_qkv(...)`: a `torch.compile(fullgraph=True, dynamic=True)` wrapper around the eager implementation.

`GatedDeltaNetAttention.rearrange_mixed_qkv()` now delegates to this helper.

The GDN prefill warmup path now calls:

```python
self.rearrange_mixed_qkv(dummy_mixed_qkv)
```

This forces the compiled helper to be created during warmup, before CUDA graph capture reaches the real request path. However, I will still encounter dynamo error as I haven't figured out the invocation sequence of torch compile and cudagraph capture yet. So, the following is still needed as I am not able to figure out how to warm up the kernel for all cases (e.g. target and draft model).

```python
if mixed_qkv.is_cuda and torch.cuda.is_current_stream_capturing():
    return _rearrange_mixed_qkv_impl(...)
```

## Test Plan

1. Make sure the unit test passed
2. Run lm-eval to ensure correctness
3. Run benchmark to ensure there are perf gain.


## Test Result

The following tests results are from H100.

The original failing initialization test was rerun:

```bash
pytest tests/models/test_initialization.py::test_can_initialize_large_subset \
    -k 'Qwen3_5MTP' -v
```

Result:

```text
1 passed, 345 deselected, 18 warnings in 71.28s
```

The final implementation was also checked with lm-eval on GSM8K using
`Qwen/Qwen3.5-35B-A3B`:

| Task | Few-shot | Metric | Value |
| --- | ---: | --- | ---: |
| gsm8k | 8 | exact_match, flexible-extract | 0.8870 |
| gsm8k | 8 | exact_match, strict-match | 0.8931 |

## Benchmark Notes

Benchmarks were run with:

```bash
vllm serve Qwen/Qwen3.5-35B-A3B -tp 2 \
  --language-model-only \
  --speculative-config '{"method":"qwen3_next_mtp","num_speculative_tokens":2}' \
  --no-enable-prefix-caching \
  --load-format fastsafetensors
```

and:

```bash
vllm bench serve \
  --model Qwen/Qwen3.5-35B-A3B \
  --dataset-path ./ShareGPT_V3_unfiltered_cleaned_split.json \
  --dataset-name sharegpt \
  --num-prompts 10 \
  --max-concurrency 2 \
  --seed 0
```

The final guarded implementation showed stable behavior across runs:

| Variant | Run | Output tok/s | Total tok/s | Mean TPOT | Acceptance |
| --- | ---: | ---: | ---: | ---: | ---: |
| This PR | 1 | 260.50 | 389.23 | 8.10 ms | 71.59% |
| This PR | 2 | 278.15 | 415.86 | 7.17 ms | 71.09% |
| Without this PR | 1 | 219.73 | 328.32 | 10.03 ms | 69.00% |
| Without this PR | 2 | 265.13 | 396.15 | 8.14 ms | 66.76% |

These numbers are from a small ShareGPT benchmark run, so they should be read
as a sanity check rather than a full performance claim. The main purpose of the
PR is correctness: avoid first-time compilation during CUDA graph capture.

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

