### PR TITLE
[ROCm] Normalize fp8 scales through float32

### DIFF
--- a/tests/quantization/test_w8a8_utils.py
+++ b/tests/quantization/test_w8a8_utils.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from typing import Any, cast
+
+import torch
+
+
+def _load_w8a8_utils(monkeypatch):
+    fake_vllm = types.ModuleType("vllm")
+    fake_ops = types.ModuleType("vllm._custom_ops")
+    fake_platforms = types.ModuleType("vllm.platforms")
+    fake_vllm_any = cast(Any, fake_vllm)
+    fake_ops_any = cast(Any, fake_ops)
+    fake_platforms_any = cast(Any, fake_platforms)
+
+    fake_ops_any.cutlass_scaled_mm_supports_fp8 = lambda capability: False
+    fake_ops_any.cutlass_scaled_mm_supports_block_fp8 = lambda capability: False
+    fake_ops_any.cutlass_group_gemm_supported = lambda capability: False
+    fake_platforms_any.current_platform = types.SimpleNamespace(
+        is_cuda=lambda: False,
+        get_device_capability=lambda: None,
+    )
+    fake_vllm_any._custom_ops = fake_ops
+
+    monkeypatch.setitem(sys.modules, "vllm", fake_vllm)
+    monkeypatch.setitem(sys.modules, "vllm._custom_ops", fake_ops)
+    monkeypatch.setitem(sys.modules, "vllm.platforms", fake_platforms)
+
+    module_path = (
+        Path(__file__).parents[2]
+        / "vllm"
+        / "model_executor"
+        / "layers"
+        / "quantization"
+        / "utils"
+        / "w8a8_utils.py"
+    )
+    spec = importlib.util.spec_from_file_location("w8a8_utils_under_test", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_normalize_e4m3fn_to_e4m3fnuz_handles_e8m0fnu_scales(monkeypatch):
+    w8a8_utils = _load_w8a8_utils(monkeypatch)
+    weight = torch.tensor([1.0], dtype=torch.float32).to(torch.float8_e4m3fn)
+    weight_scale = torch.tensor([1.0, 2.0], dtype=torch.float32).to(
+        torch.float8_e8m0fnu
+    )
+    input_scale = torch.tensor([4.0], dtype=torch.float32).to(torch.float8_e8m0fnu)
+
+    _, normalized_weight_scale, normalized_input_scale = (
+        w8a8_utils.normalize_e4m3fn_to_e4m3fnuz(
+            weight,
+            weight_scale,
+            input_scale,
+        )
+    )
+
+    assert normalized_weight_scale.dtype == torch.float8_e8m0fnu
+    assert normalized_input_scale is not None
+    assert normalized_input_scale.dtype == torch.float8_e8m0fnu
+    torch.testing.assert_close(
+        normalized_weight_scale.float(),
+        torch.tensor([2.0, 4.0], dtype=torch.float32),
+    )
+    torch.testing.assert_close(
+        normalized_input_scale.float(),
+        torch.tensor([8.0], dtype=torch.float32),
+    )

--- a/tests/quantization/test_w8a8_utils.py
+++ b/tests/quantization/test_w8a8_utils.py
@@ -7,6 +7,7 @@ import types
 from pathlib import Path
 from typing import Any, cast
 
+import pytest
 import torch
 
 
@@ -49,13 +50,18 @@ def _load_w8a8_utils(monkeypatch):
     return module
 
 
+@pytest.mark.skipif(
+    not hasattr(torch, "float8_e8m0fnu"),
+    reason="torch.float8_e8m0fnu is unavailable in this PyTorch build.",
+)
 def test_normalize_e4m3fn_to_e4m3fnuz_handles_e8m0fnu_scales(monkeypatch):
+    e8m0fnu_dtype = getattr(torch, "float8_e8m0fnu", None)
+    assert e8m0fnu_dtype is not None
+
     w8a8_utils = _load_w8a8_utils(monkeypatch)
     weight = torch.tensor([1.0], dtype=torch.float32).to(torch.float8_e4m3fn)
-    weight_scale = torch.tensor([1.0, 2.0], dtype=torch.float32).to(
-        torch.float8_e8m0fnu
-    )
-    input_scale = torch.tensor([4.0], dtype=torch.float32).to(torch.float8_e8m0fnu)
+    weight_scale = torch.tensor([1.0, 2.0], dtype=torch.float32).to(e8m0fnu_dtype)
+    input_scale = torch.tensor([4.0], dtype=torch.float32).to(e8m0fnu_dtype)
 
     _, normalized_weight_scale, normalized_input_scale = (
         w8a8_utils.normalize_e4m3fn_to_e4m3fnuz(
@@ -65,9 +71,9 @@ def test_normalize_e4m3fn_to_e4m3fnuz_handles_e8m0fnu_scales(monkeypatch):
         )
     )
 
-    assert normalized_weight_scale.dtype == torch.float8_e8m0fnu
+    assert normalized_weight_scale.dtype == e8m0fnu_dtype
     assert normalized_input_scale is not None
-    assert normalized_input_scale.dtype == torch.float8_e8m0fnu
+    assert normalized_input_scale.dtype == e8m0fnu_dtype
     torch.testing.assert_close(
         normalized_weight_scale.float(),
         torch.tensor([2.0, 4.0], dtype=torch.float32),

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -40,6 +40,22 @@ def cutlass_group_gemm_supported() -> bool:
 
 CUTLASS_FP8_SUPPORTED = cutlass_fp8_supported()
 CUTLASS_BLOCK_FP8_SUPPORTED = cutlass_block_fp8_supported()
+FP8_SCALE_DTYPES = tuple(
+    dtype
+    for dtype in (
+        torch.float8_e4m3fn,
+        torch.float8_e4m3fnuz,
+        torch.float8_e5m2,
+        getattr(torch, "float8_e8m0fnu", None),
+    )
+    if dtype is not None
+)
+
+
+def _double_scale(scale: torch.Tensor) -> torch.Tensor:
+    if scale.dtype in FP8_SCALE_DTYPES:
+        return (scale.float() * 2.0).to(scale.dtype)
+    return scale * 2.0
 
 
 def per_tensor_dequantize(
@@ -125,7 +141,7 @@ def normalize_e4m3fn_to_e4m3fnuz(
     # the e4m3fn value, so we should double the scaling factor to
     # get the same dequantized value.
     # https://onnx.ai/onnx/technical/float8.html
-    weight_scale = weight_scale * 2.0
+    weight_scale = _double_scale(weight_scale)
     if input_scale is not None:
-        input_scale = input_scale * 2.0
+        input_scale = _double_scale(input_scale)
     return weight, weight_scale, input_scale

--- a/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
+++ b/vllm/model_executor/layers/quantization/utils/w8a8_utils.py
@@ -53,7 +53,7 @@ FP8_SCALE_DTYPES = tuple(
 
 
 def _double_scale(scale: torch.Tensor) -> torch.Tensor:
-    if scale.dtype in FP8_SCALE_DTYPES:
+    if isinstance(scale, torch.Tensor) and scale.dtype in FP8_SCALE_DTYPES:
         return (scale.float() * 2.0).to(scale.dtype)
     return scale * 2.0
 


### PR DESCRIPTION
## Purpose

Fixes #41961. Normalizing e4m3fn weights to e4m3fnuz multiplies the scale tensors by two. PyTorch does not implement that multiplication for `float8_e8m0fnu`, so model loading raises before inference. Convert supported FP8 scales to float32 for the multiplication, then restore their original dtype.

The refresh includes upstream `1fee69838`. Searches for `41961 in:body` and the normalization/scale keywords found no separate PR for this fix. Broader DeepSeek SM12x enablement PRs target a different platform and scope.

## Test Plan

With a uv-managed Python 3.12 environment containing PyTorch 2.13.0+cpu and pytest:

```text
uv run python -m pytest --noconftest tests/quantization/test_w8a8_utils.py -q
uv run pre-commit run --files vllm/model_executor/layers/quantization/utils/w8a8_utils.py tests/quantization/test_w8a8_utils.py
```

## Test Result

The same regression test fails on upstream `1fee69838` with `NotImplementedError: "mul_cpu_reduced_float" not implemented for 'Float8_e8m0fnu'` and passes on the tree committed as `263eecffc`: **1 passed**. It checks doubled weight/input scale values and preservation of their FP8 dtype using real CPU tensors. Platform and custom-op imports are stubbed; this is not a ROCm kernel or model evaluation.

Changed-file checks pass Ruff, formatting, typos, mypy for Python 3.10 and the applicable import/config/SPDX checks. On Windows, test tethering initially failed decoding an upstream shell file; rerunning that hook with `PYTHONUTF8=1` passed. The Docker graph hook initially could not launch `/bin/bash`; invoking the same script through Git Bash with the same two filenames passed as the expected no-op. No contribution files changed during these checks.

Fresh ROCm model startup and generation remain unverified. An [issue reporter confirmed the associated fix on MI300 on May 20](https://github.com/vllm-project/vllm/issues/41961#issuecomment-4499051807); that historical report does not validate this refreshed head.

AI assistance: Codex prepared the refresh, ran these checks and drafted this description. The submitting author reviewed the two-file patch and ran the regression test before this update was published.
