### PR TITLE
[MoE Refactor] Mk construct

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -177,11 +177,6 @@ repos:
     entry: python tools/pre_commit/mypy.py 1 "3.13"
     <<: *mypy_common
     stages: [manual] # Only run in CI
-  - id: shellcheck
-    name: Lint shell scripts
-    entry: tools/pre_commit/shellcheck.sh
-    language: script
-    types: [shell]
   - id: png-lint
     name: Lint PNG exports from excalidraw
     entry: tools/pre_commit/png-lint.sh

--- a/vllm/model_executor/layers/fused_moe/__init__.py
+++ b/vllm/model_executor/layers/fused_moe/__init__.py
@@ -15,6 +15,7 @@ from vllm.model_executor.layers.fused_moe.config import (
 )
 from vllm.model_executor.layers.fused_moe.fused_moe_method_base import (
     FusedMoEMethodBase,
+    FusedMoEMethodMKBase,
 )
 from vllm.model_executor.layers.fused_moe.layer import (
     FusedMoE,
@@ -56,6 +57,7 @@ __all__ = [
     "FusedMoERouter",
     "FusedMoEConfig",
     "FusedMoEMethodBase",
+    "FusedMoEMethodMKBase",
     "MoEActivation",
     "UnquantizedFusedMoEMethod",
     "FusedMoeWeightScaleSupported",

--- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
+++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
@@ -27,6 +27,12 @@ from vllm.model_executor.layers.fused_moe.prepare_finalize.flashinfer_nvlink_one
 from vllm.model_executor.layers.fused_moe.prepare_finalize.flashinfer_nvlink_two_sided import (  # noqa: E501
     FlashInferNVLinkTwoSidedPrepareAndFinalize,
 )
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    FP4_DTYPE,
+    FP8_DTYPE,
+    GroupShape,
+    QuantKey,
+)
 from vllm.platforms import current_platform
 from vllm.utils.import_utils import has_deep_ep, has_mori, has_nixl_ep
 
@@ -36,12 +42,14 @@ if current_platform.is_cuda_alike():
     if has_deep_ep():
         from .prepare_finalize.deepep_ht import DeepEPHTPrepareAndFinalize
         from .prepare_finalize.deepep_ll import (
+            DEEPEP_QUANT_BLOCK_SHAPE,
             DeepEPLLPrepareAndFinalize,
         )
     if has_mori():
         from .prepare_finalize.mori import MoriPrepareAndFinalize
     if has_nixl_ep():
         from .prepare_finalize.nixl_ep import (
+            NIXL_EP_QUANT_BLOCK_SHAPE,
             NixlEPPrepareAndFinalize,
         )
 
@@ -83,8 +91,36 @@ def maybe_roundup_layer_hidden_size(
     return hidden_size
 
 
+def quant_key_to_quant_info(
+    activation_key: QuantKey | None,
+) -> tuple[torch.dtype | str | None, bool, list[int] | None]:
+    quant_dtype: torch.dtype | str | None = None
+    is_per_act_token = False
+    block_shape: list[int] | None = None
+
+    if activation_key is not None:
+        if activation_key.dtype == FP4_DTYPE:
+            quant_dtype = "mxfp4"
+        elif activation_key.dtype == FP8_DTYPE:
+            quant_dtype = activation_key.dtype
+        else:
+            quant_dtype = activation_key.dtype
+
+        block_shape = None
+        if activation_key.scale.group_shape == GroupShape.PER_TENSOR:
+            is_per_act_token = True
+        elif activation_key.scale.group_shape != GroupShape.PER_TOKEN:
+            is_per_act_token = False
+        else:
+            block_shape = list(activation_key.scale.group_shape)
+
+    return (quant_dtype, is_per_act_token, block_shape)
+
+
 def maybe_make_prepare_finalize(
     moe: FusedMoEConfig,
+    activation_key: QuantKey | None,
+    mx_alignment: int = 0,
     routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
     allow_new_interface: bool = False,
     use_monolithic: bool = False,
@@ -103,6 +139,9 @@ def maybe_make_prepare_finalize(
     #   * maybe_make_prepare_finalize() is called from the oracle. We
     #     always return a PrepareAndFinalize object and the quant method
     #     holds the ModularKernel.
+
+    quant_dtype, is_per_act_token, block_shape = quant_key_to_quant_info(activation_key)
+
     if not moe.moe_parallel_config.use_all2all_kernels:
         if not allow_new_interface:
             return None
@@ -162,34 +201,33 @@ def maybe_make_prepare_finalize(
 
         # Note: We may want to use FP8 dispatch just to reduce
         # data movement.
+        use_fp8_dispatch = (
+            quant_dtype == current_platform.fp8_dtype()
+            and block_shape == DEEPEP_QUANT_BLOCK_SHAPE
+        )
 
         prepare_finalize = DeepEPLLPrepareAndFinalize(
             handle,
             max_tokens_per_rank=moe.max_num_tokens,
             num_dispatchers=all2all_manager.world_size,
+            use_fp8_dispatch=use_fp8_dispatch,
             global_to_physical=global_to_physical,
             physical_to_global=physical_to_global,
             local_expert_global_ids=local_expert_global_ids,
         )
     elif moe.use_mori_kernels:
-        assert quant_config is not None
-
         # Note: We may want to use FP8 dispatch just to reduce
         # data movement.
-        use_fp8_dispatch = (
-            quant_config.is_per_act_token or quant_config.is_block_quantized
-        )
+        use_fp8_dispatch = is_per_act_token or block_shape is not None
         if use_fp8_dispatch:
             # For PTPC (per token per channel) quant, scale dim is 1
             # For 1x128 quant, scale dim is hidden_dim // 128
-            quant_dtype = quant_config.quant_dtype
-            scale_dim = 1 if quant_config.is_per_act_token else moe.hidden_dim // 128
+            scale_dim = 1 if is_per_act_token else moe.hidden_dim // 128
         else:
             # Unquantized dispatch (e.g. AITER with defer_input_quant):
             # dispatch raw BF16/FP16 data, no scales needed.
             quant_dtype = moe.in_dtype
             scale_dim = 0
-
         all_to_all_args = dict(
             rank=all2all_manager.rank,
             num_ep_ranks=all2all_manager.world_size,
@@ -217,19 +255,18 @@ def maybe_make_prepare_finalize(
         )
 
     elif moe.use_fi_nvl_one_sided_kernels:
-        assert quant_config is not None
         max_num_tokens = (
             get_current_vllm_config().scheduler_config.max_num_batched_tokens
         )
-        if quant_config.quant_dtype is None:
+        if quant_dtype is None:
             dispatch_dtype_bytes_per_elem = 2
             dispatch_scale_bytes_per_token = 0
-        elif quant_config.quant_dtype == "nvfp4":
+        elif quant_dtype == "nvfp4":
             dispatch_dtype_bytes_per_elem = 0
             dispatch_scale_bytes_per_token = moe.hidden_dim // 16
-        elif quant_config.quant_dtype == "mxfp8":
+        elif quant_dtype == "mxfp8":
             dispatch_dtype_bytes_per_elem = 1
-            align = quant_config.mx_alignment
+            align = mx_alignment
             if align > 0:
                 padded_k = ((moe.hidden_dim + align - 1) // align) * align
             else:
@@ -239,7 +276,7 @@ def maybe_make_prepare_finalize(
             raise NotImplementedError(
                 "flashinfer_nvlink_one_sided dispatch supports nvfp4, mxfp8, "
                 "and bf16 (quant_dtype=None) today; got "
-                f"quant_dtype={quant_config.quant_dtype!r}"
+                f"quant_dtype={quant_dtype!r}"
             )
         prepare_finalize = FlashInferNVLinkOneSidedPrepareAndFinalize(
             max_num_tokens=max_num_tokens,
@@ -275,10 +312,18 @@ def maybe_make_prepare_finalize(
         )
         handle = all2all_manager.get_handle(all_to_all_args)
 
+        # Note: We may want to use FP8 dispatch just to reduce
+        # data movement.
+        use_fp8_dispatch = (
+            quant_dtype == current_platform.fp8_dtype()
+            and block_shape == NIXL_EP_QUANT_BLOCK_SHAPE
+        )
+
         prepare_finalize = NixlEPPrepareAndFinalize(
             handle,
             max_tokens_per_rank=moe.max_num_tokens,
             num_dispatchers=all2all_manager.world_size,
+            use_fp8_dispatch=use_fp8_dispatch,
             global_to_physical=global_to_physical,
             physical_to_global=physical_to_global,
             local_expert_global_ids=local_expert_global_ids,

--- a/vllm/model_executor/layers/fused_moe/all2all_utils.py
+++ b/vllm/model_executor/layers/fused_moe/all2all_utils.py
@@ -13,7 +13,6 @@ from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig,
     FusedMoEParallelConfig,
-    FusedMoEQuantConfig,
 )
 from vllm.model_executor.layers.fused_moe.modular_kernel import (
     FusedMoEPrepareAndFinalize,
@@ -37,14 +36,12 @@ if current_platform.is_cuda_alike():
     if has_deep_ep():
         from .prepare_finalize.deepep_ht import DeepEPHTPrepareAndFinalize
         from .prepare_finalize.deepep_ll import (
-            DEEPEP_QUANT_BLOCK_SHAPE,
             DeepEPLLPrepareAndFinalize,
         )
     if has_mori():
         from .prepare_finalize.mori import MoriPrepareAndFinalize
     if has_nixl_ep():
         from .prepare_finalize.nixl_ep import (
-            NIXL_EP_QUANT_BLOCK_SHAPE,
             NixlEPPrepareAndFinalize,
         )
 
@@ -88,7 +85,6 @@ def maybe_roundup_layer_hidden_size(
 
 def maybe_make_prepare_finalize(
     moe: FusedMoEConfig,
-    quant_config: FusedMoEQuantConfig | None,
     routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
     allow_new_interface: bool = False,
     use_monolithic: bool = False,
@@ -148,7 +144,6 @@ def maybe_make_prepare_finalize(
         )
 
     elif moe.use_deepep_ll_kernels:
-        assert quant_config is not None
         global_to_physical = physical_to_global = local_expert_global_ids = None
         if routing_tables is not None:
             (
@@ -167,16 +162,11 @@ def maybe_make_prepare_finalize(
 
         # Note: We may want to use FP8 dispatch just to reduce
         # data movement.
-        use_fp8_dispatch = (
-            quant_config.quant_dtype == current_platform.fp8_dtype()
-            and quant_config.block_shape == DEEPEP_QUANT_BLOCK_SHAPE
-        )
 
         prepare_finalize = DeepEPLLPrepareAndFinalize(
             handle,
             max_tokens_per_rank=moe.max_num_tokens,
             num_dispatchers=all2all_manager.world_size,
-            use_fp8_dispatch=use_fp8_dispatch,
             global_to_physical=global_to_physical,
             physical_to_global=physical_to_global,
             local_expert_global_ids=local_expert_global_ids,
@@ -199,6 +189,7 @@ def maybe_make_prepare_finalize(
             # dispatch raw BF16/FP16 data, no scales needed.
             quant_dtype = moe.in_dtype
             scale_dim = 0
+
         all_to_all_args = dict(
             rank=all2all_manager.rank,
             num_ep_ranks=all2all_manager.world_size,
@@ -221,7 +212,6 @@ def maybe_make_prepare_finalize(
         )
 
     elif moe.use_fi_nvl_two_sided_kernels:
-        assert quant_config is not None
         prepare_finalize = FlashInferNVLinkTwoSidedPrepareAndFinalize(
             num_dispatchers=all2all_manager.world_size,
         )
@@ -269,7 +259,6 @@ def maybe_make_prepare_finalize(
         )
 
     elif moe.use_nixl_ep_kernels:
-        assert quant_config is not None
         global_to_physical = physical_to_global = local_expert_global_ids = None
         if routing_tables is not None:
             (
@@ -286,18 +275,10 @@ def maybe_make_prepare_finalize(
         )
         handle = all2all_manager.get_handle(all_to_all_args)
 
-        # Note: We may want to use FP8 dispatch just to reduce
-        # data movement.
-        use_fp8_dispatch = (
-            quant_config.quant_dtype == current_platform.fp8_dtype()
-            and quant_config.block_shape == NIXL_EP_QUANT_BLOCK_SHAPE
-        )
-
         prepare_finalize = NixlEPPrepareAndFinalize(
             handle,
             max_tokens_per_rank=moe.max_num_tokens,
             num_dispatchers=all2all_manager.world_size,
-            use_fp8_dispatch=use_fp8_dispatch,
             global_to_physical=global_to_physical,
             physical_to_global=physical_to_global,
             local_expert_global_ids=local_expert_global_ids,

--- a/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp4_w4a8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/aiter_mxfp4_w4a8_moe.py
@@ -178,7 +178,7 @@ class AiterW4A8ExpertsMonolithic(mk.FusedMoEExpertsMonolithic):
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
+        quant_config: FusedMoEQuantConfig | None = None,
     ):
         super().__init__(moe_config, quant_config)
         self.topk = moe_config.experts_per_token

--- a/vllm/model_executor/layers/fused_moe/experts/batched_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/batched_deep_gemm_moe.py
@@ -270,9 +270,9 @@ class BatchedDeepGemmExperts(mk.FusedMoEExpertsModular):
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
         max_num_tokens: int,
         num_dispatchers: int,
+        quant_config: FusedMoEQuantConfig | None = None,
     ):
         """
         max_num_tokens: Maximum number of tokens from a DP Rank
@@ -285,6 +285,11 @@ class BatchedDeepGemmExperts(mk.FusedMoEExpertsModular):
             max_num_tokens=max_num_tokens,
             num_dispatchers=num_dispatchers,
         )
+
+    def set_quant_config(self, quant_config: FusedMoEQuantConfig | None):
+        if quant_config is None:
+            return
+        super().set_quant_config(quant_config)
         assert self.block_shape == get_mk_alignment_for_contiguous_layout()
         assert self.quant_config.use_fp8_w8a8
 

--- a/vllm/model_executor/layers/fused_moe/experts/cpu_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cpu_moe.py
@@ -8,9 +8,7 @@ import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm._custom_ops import CPUQuantMethod, fused_experts_cpu
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.config import (
-    FusedMoEConfig,
     FusedMoEParallelConfig,
-    FusedMoEQuantConfig,
     RoutingMethodType,
 )
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
@@ -39,16 +37,6 @@ def prepare_fp8_moe_layer_for_cpu(
 
 class CPUExpertsFp8(mk.FusedMoEExpertsMonolithic):
     """CPU FP8 W8A16 block-quantized monolithic MoE experts."""
-
-    def __init__(
-        self,
-        moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
-    ):
-        super().__init__(
-            moe_config,
-            quant_config,
-        )
 
     @property
     def expects_unquantized_inputs(self) -> bool:

--- a/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/cutlass_moe.py
@@ -268,7 +268,7 @@ class CutlassExpertsFp8Base(mk.FusedMoEExpertsModular):
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
+        quant_config: FusedMoEQuantConfig | None = None,
         max_num_tokens: int | None = None,
         num_dispatchers: int | None = None,
     ):
@@ -278,7 +278,6 @@ class CutlassExpertsFp8Base(mk.FusedMoEExpertsModular):
             max_num_tokens=max_num_tokens,
             num_dispatchers=num_dispatchers,
         )
-        assert quant_config.use_fp8_w8a8
 
         e = moe_config.num_local_experts
         n = moe_config.intermediate_size_per_partition
@@ -293,6 +292,12 @@ class CutlassExpertsFp8Base(mk.FusedMoEExpertsModular):
         self.ab_strides2 = ab_strides2
         self.c_strides1 = c_strides1
         self.c_strides2 = ab_strides1_c_strides2
+
+    def set_quant_config(self, quant_config: FusedMoEQuantConfig | None):
+        if quant_config is None:
+            return
+        super().set_quant_config(quant_config)
+        assert quant_config.use_fp8_w8a8
 
     @staticmethod
     def _supports_current_device() -> bool:
@@ -1247,8 +1252,8 @@ class CutlassExpertsW4A8Fp8(mk.FusedMoEExpertsModular):
         s_strides1: torch.Tensor,
         s_strides2: torch.Tensor,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
         group_size: int,
+        quant_config: FusedMoEQuantConfig | None = None,
     ):
         super().__init__(moe_config=moe_config, quant_config=quant_config)
         self.out_dtype = out_dtype

--- a/vllm/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/deep_gemm_moe.py
@@ -7,7 +7,6 @@ import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.fused_moe.config import (
-    FusedMoEConfig,
     FusedMoEParallelConfig,
     FusedMoEQuantConfig,
 )
@@ -121,8 +120,10 @@ def _valid_deep_gemm(
 class DeepGemmExperts(mk.FusedMoEExpertsModular):
     """DeepGemm-based fused MoE expert implementation."""
 
-    def __init__(self, moe_config: FusedMoEConfig, quant_config: FusedMoEQuantConfig):
-        super().__init__(moe_config=moe_config, quant_config=quant_config)
+    def set_quant_config(self, quant_config: FusedMoEQuantConfig | None):
+        if quant_config is None:
+            return
+        super().set_quant_config(quant_config)
         assert quant_config.block_shape == get_mk_alignment_for_contiguous_layout()
         assert quant_config.quant_dtype == torch.float8_e4m3fn
         assert not quant_config.per_act_token_quant
@@ -338,8 +339,10 @@ class DeepGemmFP4Experts(mk.FusedMoEExpertsModular):
     # FP4 weight block size
     _WEIGHT_BLOCK_K = 32
 
-    def __init__(self, moe_config: FusedMoEConfig, quant_config: FusedMoEQuantConfig):
-        super().__init__(moe_config=moe_config, quant_config=quant_config)
+    def set_quant_config(self, quant_config: FusedMoEQuantConfig | None):
+        if quant_config is None:
+            return
+        super().set_quant_config(quant_config)
         assert quant_config.weight_quant_dtype == "mxfp4"
         assert not quant_config.per_act_token_quant
         assert not quant_config.per_out_ch_quant

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutedsl_batched_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutedsl_batched_moe.py
@@ -35,9 +35,9 @@ class FlashInferCuteDSLBatchedExperts(mk.FusedMoEExpertsModular):
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
         max_num_tokens: int,
         num_dispatchers: int,
+        quant_config: FusedMoEQuantConfig | None = None,
     ):
         super().__init__(
             moe_config=moe_config,
@@ -45,14 +45,20 @@ class FlashInferCuteDSLBatchedExperts(mk.FusedMoEExpertsModular):
             max_num_tokens=max_num_tokens,
             num_dispatchers=num_dispatchers,
         )
+        self.out_dtype = moe_config.in_dtype
+
+    def set_quant_config(self, quant_config: FusedMoEQuantConfig | None):
+        if quant_config is None:
+            return
+        super().set_quant_config(quant_config)
         assert quant_config.quant_dtype == "nvfp4", (
             "Only nvfp4 quantization are currently supported."
         )
-        self.out_dtype = moe_config.in_dtype
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         layer.w13_weight_scale_2.data.mul_(layer.w13_input_scale)
         layer.w2_weight_scale_2.data.mul_(layer.w2_input_scale)
+        super().process_weights_after_loading(layer)
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:

--- a/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutedsl_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/flashinfer_cutedsl_moe.py
@@ -37,14 +37,11 @@ class FlashInferCuteDSLExperts(mk.FusedMoEExpertsModular):
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
+        quant_config: FusedMoEQuantConfig | None = None,
     ):
         super().__init__(
             moe_config=moe_config,
             quant_config=quant_config,
-        )
-        assert quant_config.quant_dtype == "nvfp4", (
-            "Only nvfp4 quantization is currently supported."
         )
         self.out_dtype = moe_config.in_dtype
         self.hidden_dim = moe_config.hidden_dim
@@ -57,9 +54,18 @@ class FlashInferCuteDSLExperts(mk.FusedMoEExpertsModular):
         self.ep_rank = moe_config.moe_parallel_config.ep_rank
         self.local_expert_offset = self.ep_rank * self.local_num_experts
 
+    def set_quant_config(self, quant_config: FusedMoEQuantConfig | None):
+        if quant_config is None:
+            return
+        super().set_quant_config(quant_config)
+        assert quant_config.quant_dtype == "nvfp4", (
+            "Only nvfp4 quantization is currently supported."
+        )
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         layer.w13_weight_scale_2.data.mul_(layer.w13_input_scale)
         layer.w2_weight_scale_2.data.mul_(layer.w2_input_scale)
+        super().process_weights_after_loading(layer)
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:

--- a/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/gpt_oss_triton_kernels_moe.py
@@ -921,7 +921,7 @@ class OAITritonMxfp4ExpertsMonolithic(mk.FusedMoEExpertsMonolithic):
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
+        quant_config: FusedMoEQuantConfig | None = None,
     ):
         super().__init__(moe_config, quant_config)
         self.topk = moe_config.experts_per_token

--- a/vllm/model_executor/layers/fused_moe/experts/nvfp4_emulation_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/nvfp4_emulation_moe.py
@@ -45,7 +45,7 @@ class Nvfp4QuantizationEmulationTritonExperts(TritonExperts):
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
+        quant_config: FusedMoEQuantConfig | None = None,
     ):
         super().__init__(moe_config, quant_config)
         logger.warning_once(
@@ -54,7 +54,12 @@ class Nvfp4QuantizationEmulationTritonExperts(TritonExperts):
             " quantized MOE. Consider using a device with native quantization"
             " support (e.g. Nvidia Blackwell) for better performance."
         )
+        self.quantization_emulation = True
 
+    def set_quant_config(self, quant_config: FusedMoEQuantConfig | None):
+        if quant_config is None:
+            return
+        super().set_quant_config(quant_config)
         # `TritonExperts.apply` expects pre-dequantized weights,
         # which we handle in `apply` below.
         self.w1_scale_val = self.quant_config.w1_scale
@@ -62,8 +67,6 @@ class Nvfp4QuantizationEmulationTritonExperts(TritonExperts):
 
         self.quant_config._w1.scale = None
         self.quant_config._w2.scale = None
-
-        self.quantization_emulation = True
 
     @property
     def quant_dtype(self) -> torch.dtype | str | None:

--- a/vllm/model_executor/layers/fused_moe/experts/ocp_mx_emulation_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/ocp_mx_emulation_moe.py
@@ -42,7 +42,7 @@ class OCP_MXQuantizationEmulationTritonExperts(TritonExperts):
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
+        quant_config: FusedMoEQuantConfig | None = None,
     ):
         super().__init__(moe_config, quant_config)
         logger.warning_once(
@@ -51,6 +51,11 @@ class OCP_MXQuantizationEmulationTritonExperts(TritonExperts):
             " quantized MOE. Consider using a device with native OCP MX"
             " quantization support for better performance."
         )
+
+    def set_quant_config(self, quant_config: FusedMoEQuantConfig | None):
+        if quant_config is None:
+            return
+        super().set_quant_config(quant_config)
 
         self.ocp_mx_scheme = quant_config.ocp_mx_scheme
         assert self.ocp_mx_scheme is not None, (

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_bf16_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_bf16_moe.py
@@ -26,7 +26,7 @@ class TrtLlmBf16Experts(mk.FusedMoEExpertsMonolithic):
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
+        quant_config: FusedMoEQuantConfig | None = None,
     ):
         super().__init__(moe_config, quant_config)
         self.routing_method_type = moe_config.routing_method

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_fp8_moe.py
@@ -33,7 +33,7 @@ from vllm.utils.flashinfer import has_flashinfer_trtllm_fused_moe
 logger = init_logger(__name__)
 
 
-class TrtLlmFp8ExpertsBase:
+class TrtLlmFp8ExpertsBase(mk.FusedMoEExpertsConfig):
     """
     Fp8 TRTLLM-Gen MoE kernels. Shared base for modular and monolithic
     interfaces.
@@ -42,8 +42,10 @@ class TrtLlmFp8ExpertsBase:
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
+        quant_config: FusedMoEQuantConfig | None,
     ):
+        super().__init__(moe_config, quant_config)
+
         self.routing_method_type = moe_config.routing_method
         self.topk = moe_config.experts_per_token
         self.intermediate_size_per_partition = (
@@ -52,9 +54,6 @@ class TrtLlmFp8ExpertsBase:
         self.hidden_dim = moe_config.hidden_dim
         self.local_num_experts = moe_config.num_local_experts
         self.ep_rank = moe_config.moe_parallel_config.ep_rank
-
-        self.moe_config = moe_config
-        self.quant_config = quant_config
 
     @staticmethod
     def activation_format() -> mk.FusedMoEActivationFormat:
@@ -219,13 +218,10 @@ class TrtLlmFp8ExpertsMonolithic(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsMonolit
     Fp8 TRTLLM-Gen MoE kernels. Supports monolithic interface.
     """
 
-    def __init__(
-        self,
-        moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
-    ):
-        super().__init__(moe_config, quant_config)
-
+    def set_quant_config(self, quant_config: FusedMoEQuantConfig | None):
+        if quant_config is None:
+            return
+        super().set_quant_config(quant_config)
         # Make additional scales for per-tensor interface.
         if self.quant_config.is_per_tensor:
             w1_scale = self.quant_config.w1_scale
@@ -241,7 +237,7 @@ class TrtLlmFp8ExpertsMonolithic(TrtLlmFp8ExpertsBase, mk.FusedMoEExpertsMonolit
             self._g2_alphas = (w2_scale * a2_scale).squeeze()
             self._g1_scale_c = (
                 self._g1_alphas / self.quant_config.a2_scale
-                if moe_config.is_act_and_mul
+                if self.moe_config.is_act_and_mul
                 else torch.ones_like(self._g1_alphas) / self.quant_config.a2_scale
             )
 

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_mxfp4_moe.py
@@ -24,7 +24,7 @@ from vllm.platforms import current_platform
 from vllm.utils.flashinfer import has_flashinfer
 
 
-class TrtLlmMxfp4ExpertsBase:
+class TrtLlmMxfp4ExpertsBase(mk.FusedMoEExpertsConfig):
     """
     MXFP4 TRTLLM-Gen MoE kernels. Shared base for modular and monolithic.
     """
@@ -32,11 +32,10 @@ class TrtLlmMxfp4ExpertsBase:
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
+        quant_config: FusedMoEQuantConfig | None,
         **kwargs,
     ):
-        self.moe_config = moe_config
-        self.quant_config = quant_config
+        super().__init__(moe_config, quant_config)
 
         self.routing_method_type = moe_config.routing_method
         self.topk = moe_config.experts_per_token
@@ -49,6 +48,11 @@ class TrtLlmMxfp4ExpertsBase:
         )
         self.local_num_experts = moe_config.num_local_experts
         self.ep_rank = moe_config.moe_parallel_config.ep_rank
+
+    def set_quant_config(self, quant_config: FusedMoEQuantConfig | None):
+        if quant_config is None:
+            return
+        super().set_quant_config(quant_config)
 
         # MXFP4-specific TRTLLM parameters from quant_config
         device = torch.accelerator.current_device_index()

--- a/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
+++ b/vllm/model_executor/layers/fused_moe/experts/trtllm_nvfp4_moe.py
@@ -31,7 +31,7 @@ from vllm.utils.flashinfer import has_flashinfer_trtllm_fused_moe
 logger = init_logger(__name__)
 
 
-class TrtLlmNvFp4ExpertsBase:
+class TrtLlmNvFp4ExpertsBase(mk.FusedMoEExpertsConfig):
     """
     NvFp4 TRTLLM-Gen MoE kernels. Supports modular and monolithic interface.
     """
@@ -39,11 +39,8 @@ class TrtLlmNvFp4ExpertsBase:
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
+        quant_config: FusedMoEQuantConfig | None,
     ):
-        self.moe_config = moe_config
-        self.quant_config = quant_config
-
         self.routing_method_type = self.moe_config.routing_method
         self.topk = moe_config.experts_per_token
         self.intermediate_size_per_partition = (
@@ -56,17 +53,9 @@ class TrtLlmNvFp4ExpertsBase:
         self.local_num_experts = moe_config.num_local_experts
         self.ep_rank = moe_config.moe_parallel_config.ep_rank
 
-        assert self.quant_config.g1_alphas is not None
-        assert self.quant_config.a2_gscale is not None
-        if moe_config.is_act_and_mul:
-            # g1_alpha_s = a13_scale * w13_scale_2
-            # a2_gscale = (1 / a2_scale)
-            # g1_scale_c = a13_scale * w13_scale_2 / a2_scale
-            self.g1_scale_c = self.quant_config.g1_alphas * self.quant_config.a2_gscale
-        else:
-            self.g1_scale_c = self.quant_config.a2_gscale.clone()
-
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        # order?
+        self.set_quant_config(layer.moe_quant_config)
         layer.w13_weight_scale_2.data.mul_(layer.w13_input_scale)
         layer.w2_weight_scale_2.data.mul_(layer.w2_input_scale)
         # Recompute g1_scale_c since g1_alphas was just fused in-place.

--- a/vllm/model_executor/layers/fused_moe/fallback.py
+++ b/vllm/model_executor/layers/fused_moe/fallback.py
@@ -7,7 +7,10 @@ import torch
 
 import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
-from vllm.model_executor.layers.fused_moe.config import FusedMoEParallelConfig
+from vllm.model_executor.layers.fused_moe.config import (
+    FusedMoEParallelConfig,
+    FusedMoEQuantConfig,
+)
 from vllm.model_executor.layers.quantization.utils.quant_utils import QuantKey
 
 
@@ -19,11 +22,18 @@ class FallbackExperts(mk.FusedMoEExpertsModular, ABC):
         experts: mk.FusedMoEExpertsModular,
         fallback_experts: mk.FusedMoEExpertsModular,
     ):
-        super().__init__(
-            moe_config=experts.moe_config, quant_config=experts.quant_config
-        )
+        super().__init__(experts.moe_config, experts.quant_config)
         self.fallback_experts = fallback_experts
         self.experts = experts
+
+    def set_quant_config(self, quant_config: FusedMoEQuantConfig | None):
+        if quant_config is None:
+            return
+        super().set_quant_config(quant_config)
+        self.fallback_experts.set_quant_config(quant_config)
+        self.experts.set_quant_config(quant_config)
+
+    # needs PWAL?
 
     @staticmethod
     def get_clses() -> tuple[

--- a/vllm/model_executor/layers/fused_moe/flashinfer_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/flashinfer_cutlass_moe.py
@@ -61,27 +61,13 @@ def is_valid_flashinfer_cutlass_fused_moe(
 
 
 class FlashInferExperts(mk.FusedMoEExpertsModular):
-    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        if self.quant_config.use_nvfp4_w4a4:
-            layer.w13_weight_scale_2.data.mul_(layer.w13_input_scale)
-            layer.w2_weight_scale_2.data.mul_(layer.w2_input_scale)
-
     def __init__(
         self,
         moe_config: mk.FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
+        quant_config: FusedMoEQuantConfig | None = None,
     ):
         super().__init__(moe_config, quant_config)
 
-        assert quant_config.weight_quant_dtype in (
-            "mxfp4",
-            "nvfp4",
-            torch.float8_e4m3fn,
-            None,
-        ), (
-            "Only mxfp4, nvfp4, fp8, bfloat16 and"
-            " float16 quantization are currently supported."
-        )
         self.device = moe_config.device
         self.num_experts = moe_config.num_local_experts
         self.ep_rank = moe_config.moe_parallel_config.ep_rank
@@ -93,10 +79,27 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
         # Enables DeepSeek-style FP8 block-scale path:
         # - pass per-block weight scales to the kernel
         # - skip input activation quantization (kernel applies scaling)
-        self.use_deepseek_fp8_block_scale = quant_config.is_block_quantized
         self.max_capture_size = (
             get_current_vllm_config().compilation_config.max_cudagraph_capture_size
         )
+
+    def set_quant_config(self, quant_config: FusedMoEQuantConfig | None):
+        if quant_config is None:
+            return
+
+        super().set_quant_config(quant_config)
+
+        assert quant_config.weight_quant_dtype in (
+            "mxfp4",
+            "nvfp4",
+            torch.float8_e4m3fn,
+            None,
+        ), (
+            "Only mxfp4, nvfp4, fp8, bfloat16 and"
+            " float16 quantization are currently supported."
+        )
+
+        self.use_deepseek_fp8_block_scale = quant_config.is_block_quantized
 
         if quant_config.weight_quant_dtype == "mxfp4":
             # This value is used specifically for gpt-oss,
@@ -116,6 +119,12 @@ class FlashInferExperts(mk.FusedMoEExpertsModular):
                     device=self.device,
                     dtype=torch.float32,
                 )
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if self.quant_config.use_nvfp4_w4a4:
+            layer.w13_weight_scale_2.data.mul_(layer.w13_input_scale)
+            layer.w2_weight_scale_2.data.mul_(layer.w2_input_scale)
+        super().process_weights_after_loading(layer)
 
     @property
     def expects_unquantized_inputs(self) -> bool:

--- a/vllm/model_executor/layers/fused_moe/fused_batched_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_batched_moe.py
@@ -497,9 +497,9 @@ class NaiveBatchedExperts(mk.FusedMoEExpertsModular):
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
         max_num_tokens: int,
         num_dispatchers: int,
+        quant_config: FusedMoEQuantConfig | None = None,
     ):
         super().__init__(
             moe_config=moe_config,
@@ -507,6 +507,11 @@ class NaiveBatchedExperts(mk.FusedMoEExpertsModular):
             max_num_tokens=max_num_tokens,
             num_dispatchers=num_dispatchers,
         )
+
+    def set_quant_config(self, quant_config: FusedMoEQuantConfig | None):
+        if quant_config is None:
+            return
+        super().set_quant_config(quant_config)
         assert not self.quant_config.use_int8_w8a8, "NYI"
         assert not self.quant_config.use_int8_w8a16, "NYI"
         assert not self.quant_config.use_int4_w4a16, "NYI"
@@ -726,9 +731,9 @@ class BatchedTritonExperts(mk.FusedMoEExpertsModular):
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
         max_num_tokens: int,
         num_dispatchers: int,
+        quant_config: FusedMoEQuantConfig | None = None,
     ):
         super().__init__(
             moe_config=moe_config,
@@ -736,6 +741,11 @@ class BatchedTritonExperts(mk.FusedMoEExpertsModular):
             max_num_tokens=max_num_tokens,
             num_dispatchers=num_dispatchers,
         )
+
+    def set_quant_config(self, quant_config: FusedMoEQuantConfig | None):
+        if quant_config is None:
+            return
+        super().set_quant_config(quant_config)
         assert not self.quant_config.use_int8_w8a8, "NYI"
         assert not self.quant_config.use_int8_w8a16, "NYI"
         assert not self.quant_config.use_int4_w4a16, "NYI"

--- a/vllm/model_executor/layers/fused_moe/fused_humming_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_humming_moe.py
@@ -60,7 +60,7 @@ class HummingExpertsBase(mk.FusedMoEExpertsModular):
         self,
         layer: torch.nn.Module,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
+        quant_config: FusedMoEQuantConfig | None = None,
         max_num_tokens: int | None = None,
         num_dispatchers: int | None = None,
     ):

--- a/vllm/model_executor/layers/fused_moe/fused_marlin_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_marlin_moe.py
@@ -547,7 +547,7 @@ class MarlinExpertsBase(mk.FusedMoEExpertsModular):
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
+        quant_config: FusedMoEQuantConfig | None = None,
         max_num_tokens: int | None = None,
         num_dispatchers: int | None = None,
         w13_g_idx: torch.Tensor | None = None,
@@ -557,19 +557,12 @@ class MarlinExpertsBase(mk.FusedMoEExpertsModular):
         is_k_full: bool = True,
     ):
         # TODO (varun) : Enable activation quantization
-        assert (
-            quant_config.use_mxfp4_w4a16
-            or quant_config.use_nvfp4_w4a16
-            or quant_config.use_int4_w4a16
-            or quant_config.use_fp8_w8a16
-        ), "Supports only {mxfp,nvfp,int}4_w4a16 or fp8_w8a16"
         self.w13_g_idx = w13_g_idx
         self.w2_g_idx = w2_g_idx
         self.w13_g_idx_sort_indices = w13_g_idx_sort_indices
         self.w2_g_idx_sort_indices = w2_g_idx_sort_indices
         self.is_k_full = is_k_full
         self.input_dtype = get_marlin_input_dtype()
-        self.gemm1_clamp_limit = quant_config.gemm1_clamp_limit
 
         super().__init__(
             moe_config=moe_config,
@@ -577,6 +570,18 @@ class MarlinExpertsBase(mk.FusedMoEExpertsModular):
             max_num_tokens=max_num_tokens,
             num_dispatchers=num_dispatchers,
         )
+
+    def set_quant_config(self, quant_config: FusedMoEQuantConfig | None):
+        if quant_config is None:
+            return
+        super().set_quant_config(quant_config)
+        assert (
+            quant_config.use_mxfp4_w4a16
+            or quant_config.use_nvfp4_w4a16
+            or quant_config.use_int4_w4a16
+            or quant_config.use_fp8_w8a16
+        ), "Supports only {mxfp,nvfp,int}4_w4a16 or fp8_w8a16"
+        self.gemm1_clamp_limit = quant_config.gemm1_clamp_limit
 
     @staticmethod
     def _supports_current_device() -> bool:
@@ -878,9 +883,9 @@ class BatchedMarlinExperts(MarlinExpertsBase):
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
         max_num_tokens: int,
         num_dispatchers: int,
+        quant_config: FusedMoEQuantConfig | None = None,
         w13_g_idx: torch.Tensor | None = None,
         w2_g_idx: torch.Tensor | None = None,
         w13_g_idx_sort_indices: torch.Tensor | None = None,

--- a/vllm/model_executor/layers/fused_moe/fused_moe.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe.py
@@ -1893,7 +1893,7 @@ class TritonExperts(LoRAExpertsMixin, mk.FusedMoEExpertsModular):
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
+        quant_config: FusedMoEQuantConfig | None = None,
     ):
         # Whether quantized MOE runs natively, or through
         # higher-precision + activation QDQ.

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -102,7 +102,11 @@ class FusedMoEMethodBase(QuantizeMethodBase):
     ) -> FusedMoEPrepareAndFinalizeModular | None:
         from .all2all_utils import maybe_make_prepare_finalize
 
-        pf = maybe_make_prepare_finalize(self.moe, routing_tables)
+        pf = maybe_make_prepare_finalize(
+            activation_key=None,  # activation_key, # TODO XXXXXXXXXXX
+            moe=self.moe,
+            routing_tables=routing_tables,
+        )
         assert pf is None or isinstance(pf, FusedMoEPrepareAndFinalizeModular)
         return pf
 

--- a/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_method_base.py
@@ -102,9 +102,7 @@ class FusedMoEMethodBase(QuantizeMethodBase):
     ) -> FusedMoEPrepareAndFinalizeModular | None:
         from .all2all_utils import maybe_make_prepare_finalize
 
-        pf = maybe_make_prepare_finalize(
-            self.moe, self.moe_quant_config, routing_tables
-        )
+        pf = maybe_make_prepare_finalize(self.moe, routing_tables)
         assert pf is None or isinstance(pf, FusedMoEPrepareAndFinalizeModular)
         return pf
 
@@ -172,3 +170,74 @@ class FusedMoEMethodBase(QuantizeMethodBase):
         input_ids: torch.Tensor | None = None,
     ) -> torch.Tensor:
         raise NotImplementedError
+
+    # Needs comment about calling convention
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+        if self.moe_kernel is not None:
+            assert self.moe_quant_config is not None
+            self.moe_kernel.set_quant_config(self.moe_quant_config)
+
+
+# Make MK specific subclass that includes apply/apply_monolithic, etc.
+# see online/moe_base.py
+class FusedMoEMethodMKBase(FusedMoEMethodBase):
+    """Base for MoE methods that load full-precision weights on meta device
+    and quantize them after loading via the QeRL layerwise processing system.
+    """
+
+    def maybe_make_prepare_finalize(
+        self,
+        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
+    ) -> mk.FusedMoEPrepareAndFinalizeModular | None:
+        raise ValueError(
+            f"{self.__class__.__name__} uses the new modular kernel "
+            "initialization logic. This function should not be called."
+        )
+
+    def apply_monolithic(
+        self,
+        layer: "FusedMoE",  # type: ignore[name-defined] # noqa: F821
+        x: torch.Tensor,
+        router_logits: torch.Tensor,
+        input_ids: torch.Tensor | None = None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        assert self.is_monolithic
+        assert self.moe_kernel is not None
+        return self.moe_kernel.apply_monolithic(
+            hidden_states=x,
+            w1=layer.w13_weight,
+            w2=layer.w2_weight,
+            router_logits=router_logits,
+            activation=layer.activation,
+            global_num_experts=layer.global_num_experts,
+            expert_map=layer.expert_map,
+            apply_router_weight_on_input=layer.apply_router_weight_on_input,
+            num_expert_group=layer.num_expert_group,
+            topk_group=layer.topk_group,
+            e_score_correction_bias=layer.e_score_correction_bias,
+            routed_scaling_factor=layer.routed_scaling_factor,
+        )
+
+    def apply(
+        self,
+        layer: "FusedMoE",  # type: ignore[name-defined] # noqa: F821
+        x: torch.Tensor,
+        topk_weights: torch.Tensor,
+        topk_ids: torch.Tensor,
+        shared_experts_input: torch.Tensor | None,
+    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
+        assert not self.is_monolithic
+        assert self.moe_kernel is not None
+        return self.moe_kernel.apply(
+            hidden_states=x,
+            w1=layer.w13_weight,
+            w2=layer.w2_weight,
+            topk_weights=topk_weights,
+            topk_ids=topk_ids,
+            activation=layer.activation,
+            global_num_experts=layer.global_num_experts,
+            expert_map=layer.expert_map,
+            apply_router_weight_on_input=layer.apply_router_weight_on_input,
+            shared_experts_input=shared_experts_input,
+        )

--- a/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
+++ b/vllm/model_executor/layers/fused_moe/fused_moe_modular_method.py
@@ -50,15 +50,15 @@ class FusedMoEModularMethod(FusedMoEMethodBase, CustomOp):
         shared_experts: SharedExperts | None,
         inplace: bool = False,
     ) -> "FusedMoEModularMethod":
-        return FusedMoEModularMethod(
-            old_quant_method,
-            FusedMoEKernel(
-                prepare_finalize,
-                old_quant_method.select_gemm_impl(prepare_finalize, moe_layer),
-                shared_experts=shared_experts,
-                inplace=inplace,
-            ),
+        mk = FusedMoEKernel(
+            prepare_finalize,
+            old_quant_method.select_gemm_impl(prepare_finalize, moe_layer),
+            shared_experts=shared_experts,
+            inplace=inplace,
         )
+        assert old_quant_method.moe_quant_config is not None
+        mk.set_quant_config(old_quant_method.moe_quant_config)
+        return FusedMoEModularMethod(old_quant_method, mk)
 
     @property
     def supports_eplb(self) -> bool:

--- a/vllm/model_executor/layers/fused_moe/modular_kernel.py
+++ b/vllm/model_executor/layers/fused_moe/modular_kernel.py
@@ -461,12 +461,110 @@ class FusedMoEPrepareAndFinalizeMonolithic(FusedMoEPrepareAndFinalize):
 ################################################################################
 
 
-# TODO: add supported activations method (return string)
-class FusedMoEExperts(ABC):
+# TODO: needs doc
+class FusedMoEExpertsConfig:
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
+        quant_config: FusedMoEQuantConfig | None = None,
+    ):
+        self.moe_config = moe_config
+        self._quant_config: FusedMoEQuantConfig | None = None
+        self.set_quant_config(quant_config)
+
+    def set_quant_config(self, quant_config: FusedMoEQuantConfig | None):
+        if quant_config is not None:
+            assert self._quant_config is None, "Can't set quant_config more than once."
+            self._quant_config = quant_config
+
+    #
+    # Various helpers for accessing quantization parameters from the
+    # quant_config.
+    #
+
+    @property
+    def quant_config(self) -> FusedMoEQuantConfig:
+        assert self._quant_config is not None, (
+            "Must pass a non-None quant_config to __init__ or call set_quant_config "
+            "(or process_weights_after_loading) before the experts are usable."
+        )
+        return self._quant_config
+
+    @property
+    def quant_dtype(self) -> torch.dtype | str | None:
+        return self.quant_config.quant_dtype
+
+    @property
+    def weight_quant_dtype(self) -> torch.dtype | str | None:
+        return self.quant_config.weight_quant_dtype
+
+    @property
+    def block_shape(self) -> list[int] | None:
+        return self.quant_config.block_shape
+
+    @property
+    def per_act_token_quant(self) -> bool:
+        return self.quant_config.per_act_token_quant
+
+    @property
+    def per_out_ch_quant(self) -> bool:
+        return self.quant_config.per_out_ch_quant
+
+    @property
+    def a1_scale(self) -> torch.Tensor | None:
+        return self.quant_config.a1_scale
+
+    @property
+    def a2_scale(self) -> torch.Tensor | None:
+        return self.quant_config.a2_scale
+
+    @property
+    def a1_gscale(self) -> torch.Tensor | None:
+        return self.quant_config.a1_gscale
+
+    @property
+    def a2_gscale(self) -> torch.Tensor | None:
+        return self.quant_config.a2_gscale
+
+    @property
+    def w1_scale(self) -> torch.Tensor | None:
+        return self.quant_config.w1_scale
+
+    @property
+    def w2_scale(self) -> torch.Tensor | None:
+        return self.quant_config.w2_scale
+
+    @property
+    def w1_zp(self) -> torch.Tensor | None:
+        return self.quant_config.w1_zp
+
+    @property
+    def w2_zp(self) -> torch.Tensor | None:
+        return self.quant_config.w2_zp
+
+    @property
+    def w1_bias(self) -> torch.Tensor | None:
+        return self.quant_config.w1_bias
+
+    @property
+    def w2_bias(self) -> torch.Tensor | None:
+        return self.quant_config.w2_bias
+
+    @property
+    def g1_alphas(self) -> torch.Tensor | None:
+        return self.quant_config.g1_alphas
+
+    @property
+    def g2_alphas(self) -> torch.Tensor | None:
+        return self.quant_config.g2_alphas
+
+
+# TODO: add supported activations method (return string)
+class FusedMoEExperts(ABC, FusedMoEExpertsConfig):
+    def __init__(
+        self,
+        moe_config: FusedMoEConfig,
+        quant_config: FusedMoEQuantConfig | None = None,
         max_num_tokens: int | None = None,
         num_dispatchers: int | None = None,
     ):
@@ -474,6 +572,8 @@ class FusedMoEExperts(ABC):
         moe_config: MoE layer configuration.
         quant_config: Quantization parameters for this experts instance.
         """
+        super().__init__(moe_config, quant_config)
+
         if self.activation_format() == FusedMoEActivationFormat.Standard and (
             max_num_tokens is not None or num_dispatchers is not None
         ):
@@ -489,13 +589,12 @@ class FusedMoEExperts(ABC):
                 "BatchedExperts activation format."
             )
 
-        self.moe_config = moe_config
-        self.quant_config = quant_config
         self.max_num_tokens = max_num_tokens
         self.num_dispatchers = num_dispatchers
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:  # noqa: B027
-        pass
+        # call ensure/get here?
+        self.set_quant_config(layer.moe_quant_config)
 
     @staticmethod
     def is_monolithic() -> bool:
@@ -662,79 +761,6 @@ class FusedMoEExperts(ABC):
         for determining if the kernel can used with VLLM_BATCH_INVARIANT=1.
         """
         return False
-
-    #
-    # Various helpers for accessing quantization parameters from the
-    # quant_config.
-    #
-
-    @property
-    def quant_dtype(self) -> torch.dtype | str | None:
-        return self.quant_config.quant_dtype
-
-    @property
-    def weight_quant_dtype(self) -> torch.dtype | str | None:
-        return self.quant_config.weight_quant_dtype
-
-    @property
-    def block_shape(self) -> list[int] | None:
-        return self.quant_config.block_shape
-
-    @property
-    def per_act_token_quant(self) -> bool:
-        return self.quant_config.per_act_token_quant
-
-    @property
-    def per_out_ch_quant(self) -> bool:
-        return self.quant_config.per_out_ch_quant
-
-    @property
-    def a1_scale(self) -> torch.Tensor | None:
-        return self.quant_config.a1_scale
-
-    @property
-    def a2_scale(self) -> torch.Tensor | None:
-        return self.quant_config.a2_scale
-
-    @property
-    def a1_gscale(self) -> torch.Tensor | None:
-        return self.quant_config.a1_gscale
-
-    @property
-    def a2_gscale(self) -> torch.Tensor | None:
-        return self.quant_config.a2_gscale
-
-    @property
-    def w1_scale(self) -> torch.Tensor | None:
-        return self.quant_config.w1_scale
-
-    @property
-    def w2_scale(self) -> torch.Tensor | None:
-        return self.quant_config.w2_scale
-
-    @property
-    def w1_zp(self) -> torch.Tensor | None:
-        return self.quant_config.w1_zp
-
-    @property
-    def w2_zp(self) -> torch.Tensor | None:
-        return self.quant_config.w2_zp
-
-    @property
-    def w1_bias(self) -> torch.Tensor | None:
-        return self.quant_config.w1_bias
-
-    @property
-    def w2_bias(self) -> torch.Tensor | None:
-        return self.quant_config.w2_bias
-
-    @property
-    def g1_alphas(self) -> torch.Tensor | None:
-        return self.quant_config.g1_alphas
-
-    @property
-    def g2_alphas(self) -> torch.Tensor | None:
-        return self.quant_config.g2_alphas
 
     @staticmethod
     def supports_lora() -> bool:
@@ -1583,6 +1609,12 @@ class FusedMoEKernel:
         is reduced across all ranks.
         """
         return self.prepare_finalize.output_is_reduced()
+
+    def set_quant_config(self, quant_config: FusedMoEQuantConfig | None):
+        self.fused_experts.set_quant_config(quant_config)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        self.fused_experts.process_weights_after_loading(layer)
 
     def apply_monolithic(
         self,

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -585,7 +585,6 @@ def make_fp8_moe_quant_config(
 
 
 def make_fp8_moe_kernel(
-    moe_quant_config: FusedMoEQuantConfig,
     moe_config: FusedMoEConfig,
     experts_cls: type[mk.FusedMoEExperts],
     fp8_backend: Fp8MoeBackend,
@@ -595,7 +594,6 @@ def make_fp8_moe_kernel(
     # Create Prepare/Finalize.
     prepare_finalize = maybe_make_prepare_finalize(
         moe=moe_config,
-        quant_config=moe_quant_config,
         routing_tables=routing_tables,
         allow_new_interface=True,
         use_monolithic=issubclass(experts_cls, mk.FusedMoEExpertsMonolithic),
@@ -610,14 +608,12 @@ def make_fp8_moe_kernel(
         assert max_num_tokens is not None
         experts = experts_cls(
             moe_config=moe_config,
-            quant_config=moe_quant_config,
             max_num_tokens=max_num_tokens,
             num_dispatchers=prepare_finalize.num_dispatchers(),
         )
     else:
         experts = experts_cls(
             moe_config=moe_config,
-            quant_config=moe_quant_config,
         )
 
     # NOTE(rob): we only want the mk to control the shared_expert

--- a/vllm/model_executor/layers/fused_moe/oracle/fp8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/fp8.py
@@ -585,6 +585,7 @@ def make_fp8_moe_quant_config(
 
 
 def make_fp8_moe_kernel(
+    activation_key: QuantKey | None,
     moe_config: FusedMoEConfig,
     experts_cls: type[mk.FusedMoEExperts],
     fp8_backend: Fp8MoeBackend,
@@ -594,6 +595,7 @@ def make_fp8_moe_kernel(
     # Create Prepare/Finalize.
     prepare_finalize = maybe_make_prepare_finalize(
         moe=moe_config,
+        activation_key=activation_key,
         routing_tables=routing_tables,
         allow_new_interface=True,
         use_monolithic=issubclass(experts_cls, mk.FusedMoEExpertsMonolithic),

--- a/vllm/model_executor/layers/fused_moe/oracle/int8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/int8.py
@@ -177,7 +177,6 @@ def make_int8_moe_quant_config(
 
 
 def make_int8_moe_kernel(
-    moe_quant_config: FusedMoEQuantConfig,
     moe_config: FusedMoEConfig,
     experts_cls: type[mk.FusedMoEExperts],
     routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
@@ -186,7 +185,6 @@ def make_int8_moe_kernel(
     # Create Prepare/Finalize.
     prepare_finalize = maybe_make_prepare_finalize(
         moe=moe_config,
-        quant_config=moe_quant_config,
         routing_tables=routing_tables,
         allow_new_interface=True,
         use_monolithic=issubclass(experts_cls, mk.FusedMoEExpertsMonolithic),
@@ -201,14 +199,12 @@ def make_int8_moe_kernel(
         assert max_num_tokens is not None
         experts = experts_cls(
             moe_config=moe_config,
-            quant_config=moe_quant_config,
             max_num_tokens=max_num_tokens,
             num_dispatchers=prepare_finalize.num_dispatchers(),
         )
     else:
         experts = experts_cls(
             moe_config=moe_config,
-            quant_config=moe_quant_config,
         )
 
     kernel = mk.FusedMoEKernel(

--- a/vllm/model_executor/layers/fused_moe/oracle/int8.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/int8.py
@@ -177,6 +177,7 @@ def make_int8_moe_quant_config(
 
 
 def make_int8_moe_kernel(
+    activation_key: QuantKey | None,
     moe_config: FusedMoEConfig,
     experts_cls: type[mk.FusedMoEExperts],
     routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
@@ -185,6 +186,7 @@ def make_int8_moe_kernel(
     # Create Prepare/Finalize.
     prepare_finalize = maybe_make_prepare_finalize(
         moe=moe_config,
+        activation_key=activation_key,
         routing_tables=routing_tables,
         allow_new_interface=True,
         use_monolithic=issubclass(experts_cls, mk.FusedMoEExpertsMonolithic),

--- a/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
@@ -143,6 +143,7 @@ def select_wna16_moe_backend(
 
 
 def make_wna16_moe_kernel(
+    activation_key: QuantKey | None,
     moe_config: FusedMoEConfig,
     experts_cls: type[mk.FusedMoEExperts] | None,
     layer: torch.nn.Module,
@@ -163,6 +164,7 @@ def make_wna16_moe_kernel(
 
     prepare_finalize = maybe_make_prepare_finalize(
         moe=moe_config,
+        activation_key=None,
         routing_tables=routing_tables,
         allow_new_interface=True,
     )

--- a/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/int_wna16.py
@@ -10,7 +10,6 @@ import vllm.model_executor.layers.fused_moe.modular_kernel as mk
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig,
-    FusedMoEQuantConfig,
 )
 from vllm.model_executor.layers.fused_moe.fused_marlin_moe import (
     BatchedMarlinExperts,
@@ -144,7 +143,6 @@ def select_wna16_moe_backend(
 
 
 def make_wna16_moe_kernel(
-    moe_quant_config: FusedMoEQuantConfig,
     moe_config: FusedMoEConfig,
     experts_cls: type[mk.FusedMoEExperts] | None,
     layer: torch.nn.Module,
@@ -165,7 +163,6 @@ def make_wna16_moe_kernel(
 
     prepare_finalize = maybe_make_prepare_finalize(
         moe=moe_config,
-        quant_config=moe_quant_config,
         routing_tables=routing_tables,
         allow_new_interface=True,
     )
@@ -180,7 +177,6 @@ def make_wna16_moe_kernel(
             max_num_tokens=max_num_tokens,
             num_dispatchers=prepare_finalize.num_dispatchers(),
             moe_config=moe_config,
-            quant_config=moe_quant_config,
             w13_g_idx=w13_g_idx,
             w2_g_idx=w2_g_idx,
             w13_g_idx_sort_indices=w13_g_idx_sort_indices,
@@ -191,7 +187,6 @@ def make_wna16_moe_kernel(
         assert experts_cls == MarlinExperts
         experts = MarlinExperts(
             moe_config=moe_config,
-            quant_config=moe_quant_config,
             w13_g_idx=w13_g_idx,
             w2_g_idx=w2_g_idx,
             w13_g_idx_sort_indices=w13_g_idx_sort_indices,

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -1496,7 +1496,6 @@ def make_mxfp4_moe_quant_config(
 
 
 def make_mxfp4_moe_kernel(
-    moe_quant_config: FusedMoEQuantConfig,
     moe_config: FusedMoEConfig,
     experts_cls: type[mk.FusedMoEExperts],
     mxfp4_backend: Mxfp4MoeBackend,
@@ -1509,7 +1508,6 @@ def make_mxfp4_moe_kernel(
 
     prepare_finalize = maybe_make_prepare_finalize(
         moe=moe_config,
-        quant_config=moe_quant_config,
         routing_tables=routing_tables,
         allow_new_interface=True,
         use_monolithic=is_monolithic,
@@ -1529,7 +1527,6 @@ def make_mxfp4_moe_kernel(
         assert max_num_tokens is not None
         experts = experts_cls(
             moe_config=moe_config,
-            quant_config=moe_quant_config,
             max_num_tokens=max_num_tokens,
             num_dispatchers=prepare_finalize.num_dispatchers(),
             **extra_kwargs,
@@ -1537,7 +1534,6 @@ def make_mxfp4_moe_kernel(
     else:
         experts = experts_cls(
             moe_config=moe_config,
-            quant_config=moe_quant_config,
             **extra_kwargs,
         )
 

--- a/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/mxfp4.py
@@ -1496,6 +1496,7 @@ def make_mxfp4_moe_quant_config(
 
 
 def make_mxfp4_moe_kernel(
+    activation_key: QuantKey | None,
     moe_config: FusedMoEConfig,
     experts_cls: type[mk.FusedMoEExperts],
     mxfp4_backend: Mxfp4MoeBackend,
@@ -1506,8 +1507,15 @@ def make_mxfp4_moe_kernel(
     """Create a FusedMoEKernel for the given MXFP4 backend."""
     is_monolithic = issubclass(experts_cls, mk.FusedMoEExpertsMonolithic)
 
+    if mxfp4_backend == Mxfp4MoeBackend.FLASHINFER_TRTLLM_MXFP4_MXFP8:
+        mx_alignment = 256
+    else:
+        mx_alignment = 0
+
     prepare_finalize = maybe_make_prepare_finalize(
         moe=moe_config,
+        activation_key=activation_key,
+        mx_alignment=mx_alignment,
         routing_tables=routing_tables,
         allow_new_interface=True,
         use_monolithic=is_monolithic,

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -472,7 +472,6 @@ def make_nvfp4_moe_quant_config(
 
 
 def make_nvfp4_moe_kernel(
-    moe_quant_config: FusedMoEQuantConfig,
     moe_config: FusedMoEConfig,
     experts_cls: type[mk.FusedMoEExperts],
     routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
@@ -481,7 +480,6 @@ def make_nvfp4_moe_kernel(
     # Create Prepare/Finalize.
     prepare_finalize = maybe_make_prepare_finalize(
         moe=moe_config,
-        quant_config=moe_quant_config,
         routing_tables=routing_tables,
         allow_new_interface=True,
         use_monolithic=issubclass(experts_cls, mk.FusedMoEExpertsMonolithic),
@@ -496,15 +494,11 @@ def make_nvfp4_moe_kernel(
         assert max_num_tokens is not None
         experts = experts_cls(
             moe_config=moe_config,
-            quant_config=moe_quant_config,
             max_num_tokens=max_num_tokens,
             num_dispatchers=prepare_finalize.num_dispatchers(),
         )
     else:
-        experts = experts_cls(
-            moe_config=moe_config,
-            quant_config=moe_quant_config,
-        )
+        experts = experts_cls(moe_config=moe_config)
 
     # NOTE(rob): we only want the mk to control the shared_expert
     # if using all2all (for SBO). bnell is making this explicit in

--- a/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/nvfp4.py
@@ -472,6 +472,7 @@ def make_nvfp4_moe_quant_config(
 
 
 def make_nvfp4_moe_kernel(
+    activation_key: QuantKey | None,
     moe_config: FusedMoEConfig,
     experts_cls: type[mk.FusedMoEExperts],
     routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
@@ -480,6 +481,7 @@ def make_nvfp4_moe_kernel(
     # Create Prepare/Finalize.
     prepare_finalize = maybe_make_prepare_finalize(
         moe=moe_config,
+        activation_key=activation_key,
         routing_tables=routing_tables,
         allow_new_interface=True,
         use_monolithic=issubclass(experts_cls, mk.FusedMoEExpertsMonolithic),

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -16,7 +16,6 @@ from vllm.model_executor.layers.fused_moe.all2all_utils import (
 )
 from vllm.model_executor.layers.fused_moe.config import (
     FusedMoEConfig,
-    FusedMoEQuantConfig,
 )
 from vllm.model_executor.layers.fused_moe.runner.shared_experts import (
     SharedExperts,
@@ -322,7 +321,6 @@ def convert_to_unquantized_kernel_format(
 
 
 def make_unquantized_moe_kernel(
-    quant_config: FusedMoEQuantConfig,
     moe_config: FusedMoEConfig,
     backend: UnquantizedMoeBackend,
     experts_cls: type[mk.FusedMoEExperts],
@@ -333,7 +331,6 @@ def make_unquantized_moe_kernel(
     is_monolithic = issubclass(experts_cls, mk.FusedMoEExpertsMonolithic)
     prepare_finalize = maybe_make_prepare_finalize(
         moe=moe_config,
-        quant_config=quant_config,
         routing_tables=routing_tables,
         allow_new_interface=True,
         use_monolithic=is_monolithic,
@@ -348,14 +345,12 @@ def make_unquantized_moe_kernel(
         assert max_num_tokens is not None
         experts = experts_cls(
             moe_config=moe_config,
-            quant_config=quant_config,
             max_num_tokens=max_num_tokens,
             num_dispatchers=prepare_finalize.num_dispatchers(),
         )
     else:
         experts = experts_cls(
             moe_config=moe_config,
-            quant_config=quant_config,
         )
 
     kernel = mk.FusedMoEKernel(

--- a/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
+++ b/vllm/model_executor/layers/fused_moe/oracle/unquantized.py
@@ -331,6 +331,7 @@ def make_unquantized_moe_kernel(
     is_monolithic = issubclass(experts_cls, mk.FusedMoEExpertsMonolithic)
     prepare_finalize = maybe_make_prepare_finalize(
         moe=moe_config,
+        activation_key=None,
         routing_tables=routing_tables,
         allow_new_interface=True,
         use_monolithic=is_monolithic,

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_ll.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_ll.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.fused_moe.utils import (
     moe_kernel_quantize_input,
     normalize_batched_scales_shape,
 )
+from vllm.platforms import current_platform
 from vllm.v1.worker.ubatching import (
     dbo_current_ubatch_id,
     dbo_enabled,
@@ -87,7 +88,6 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         buffer: deep_ep.Buffer,
         max_tokens_per_rank: int,
         num_dispatchers: int,
-        use_fp8_dispatch: bool = False,
         global_to_physical: torch.Tensor | None = None,
         physical_to_global: torch.Tensor | None = None,
         local_expert_global_ids: torch.Tensor | None = None,
@@ -96,7 +96,7 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
 
         self.buffer = buffer
         self.max_tokens_per_rank = max_tokens_per_rank
-        self.use_fp8_dispatch = use_fp8_dispatch
+        self.use_fp8_dispatch = False
         # The dispatch function returns a handle that the combine function
         # requires. We store the handle here so it is available to the
         # combine function.
@@ -120,6 +120,12 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         self.use_ue8m0_dispatch = False
 
     def post_init_setup(self, fused_experts: mk.FusedMoEExperts):
+        quant_config = fused_experts.quant_config
+        self.use_fp8_dispatch = (
+            quant_config.quant_dtype == current_platform.fp8_dtype()
+            and quant_config.block_shape == DEEPEP_QUANT_BLOCK_SHAPE
+        )
+
         if not fused_experts.supports_packed_ue8m0_act_scales():
             # Early exit.
             return

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_ll.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/deepep_ll.py
@@ -16,7 +16,6 @@ from vllm.model_executor.layers.fused_moe.utils import (
     moe_kernel_quantize_input,
     normalize_batched_scales_shape,
 )
-from vllm.platforms import current_platform
 from vllm.v1.worker.ubatching import (
     dbo_current_ubatch_id,
     dbo_enabled,
@@ -88,6 +87,7 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         buffer: deep_ep.Buffer,
         max_tokens_per_rank: int,
         num_dispatchers: int,
+        use_fp8_dispatch: bool = False,
         global_to_physical: torch.Tensor | None = None,
         physical_to_global: torch.Tensor | None = None,
         local_expert_global_ids: torch.Tensor | None = None,
@@ -96,7 +96,7 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
 
         self.buffer = buffer
         self.max_tokens_per_rank = max_tokens_per_rank
-        self.use_fp8_dispatch = False
+        self.use_fp8_dispatch = use_fp8_dispatch
         # The dispatch function returns a handle that the combine function
         # requires. We store the handle here so it is available to the
         # combine function.
@@ -120,12 +120,6 @@ class DeepEPLLPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         self.use_ue8m0_dispatch = False
 
     def post_init_setup(self, fused_experts: mk.FusedMoEExperts):
-        quant_config = fused_experts.quant_config
-        self.use_fp8_dispatch = (
-            quant_config.quant_dtype == current_platform.fp8_dtype()
-            and quant_config.block_shape == DEEPEP_QUANT_BLOCK_SHAPE
-        )
-
         if not fused_experts.supports_packed_ue8m0_act_scales():
             # Early exit.
             return

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/nixl_ep.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/nixl_ep.py
@@ -16,7 +16,6 @@ from vllm.model_executor.layers.fused_moe.utils import (
     moe_kernel_quantize_input,
     normalize_batched_scales_shape,
 )
-from vllm.platforms import current_platform
 from vllm.v1.worker.ubatching import (
     dbo_current_ubatch_id,
     dbo_enabled,
@@ -77,6 +76,7 @@ class NixlEPPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         buffer: nixl_ep.Buffer,
         max_tokens_per_rank: int,
         num_dispatchers: int,
+        use_fp8_dispatch: bool = False,
         global_to_physical: torch.Tensor | None = None,
         physical_to_global: torch.Tensor | None = None,
         local_expert_global_ids: torch.Tensor | None = None,
@@ -85,7 +85,7 @@ class NixlEPPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
 
         self.buffer = buffer
         self.max_tokens_per_rank = max_tokens_per_rank
-        self.use_fp8_dispatch = False
+        self.use_fp8_dispatch = use_fp8_dispatch
         # The dispatch function returns a handle that the combine function
         # requires. We store the handle here so it is available to the
         # combine function.
@@ -109,14 +109,6 @@ class NixlEPPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         self.use_ue8m0_dispatch = False
 
     def post_init_setup(self, fused_experts: mk.FusedMoEExperts):
-        # Note: We may want to use FP8 dispatch just to reduce
-        # data movement.
-        quant_config = fused_experts.quant_config
-        self.use_fp8_dispatch = (
-            quant_config.quant_dtype == current_platform.fp8_dtype()
-            and quant_config.block_shape == NIXL_EP_QUANT_BLOCK_SHAPE
-        )
-
         if not fused_experts.supports_packed_ue8m0_act_scales():
             # Early exit.
             return

--- a/vllm/model_executor/layers/fused_moe/prepare_finalize/nixl_ep.py
+++ b/vllm/model_executor/layers/fused_moe/prepare_finalize/nixl_ep.py
@@ -16,6 +16,7 @@ from vllm.model_executor.layers.fused_moe.utils import (
     moe_kernel_quantize_input,
     normalize_batched_scales_shape,
 )
+from vllm.platforms import current_platform
 from vllm.v1.worker.ubatching import (
     dbo_current_ubatch_id,
     dbo_enabled,
@@ -76,7 +77,6 @@ class NixlEPPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         buffer: nixl_ep.Buffer,
         max_tokens_per_rank: int,
         num_dispatchers: int,
-        use_fp8_dispatch: bool = False,
         global_to_physical: torch.Tensor | None = None,
         physical_to_global: torch.Tensor | None = None,
         local_expert_global_ids: torch.Tensor | None = None,
@@ -85,7 +85,7 @@ class NixlEPPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
 
         self.buffer = buffer
         self.max_tokens_per_rank = max_tokens_per_rank
-        self.use_fp8_dispatch = use_fp8_dispatch
+        self.use_fp8_dispatch = False
         # The dispatch function returns a handle that the combine function
         # requires. We store the handle here so it is available to the
         # combine function.
@@ -109,6 +109,14 @@ class NixlEPPrepareAndFinalize(mk.FusedMoEPrepareAndFinalizeModular):
         self.use_ue8m0_dispatch = False
 
     def post_init_setup(self, fused_experts: mk.FusedMoEExperts):
+        # Note: We may want to use FP8 dispatch just to reduce
+        # data movement.
+        quant_config = fused_experts.quant_config
+        self.use_fp8_dispatch = (
+            quant_config.quant_dtype == current_platform.fp8_dtype()
+            and quant_config.block_shape == NIXL_EP_QUANT_BLOCK_SHAPE
+        )
+
         if not fused_experts.supports_packed_ue8m0_act_scales():
             # Early exit.
             return

--- a/vllm/model_executor/layers/fused_moe/triton_cutlass_moe.py
+++ b/vllm/model_executor/layers/fused_moe/triton_cutlass_moe.py
@@ -22,7 +22,7 @@ class TritonOrCutlassExperts(FallbackExperts):
     def __init__(
         self,
         moe_config: FusedMoEConfig,
-        quant_config: FusedMoEQuantConfig,
+        quant_config: FusedMoEQuantConfig | None = None,
     ):
         self.is_sm100 = current_platform.has_device_capability(100)
         super().__init__(

--- a/vllm/model_executor/layers/fused_moe/triton_deep_gemm_moe.py
+++ b/vllm/model_executor/layers/fused_moe/triton_deep_gemm_moe.py
@@ -24,7 +24,11 @@ from vllm.utils.deep_gemm import (
 class TritonOrDeepGemmExperts(FallbackExperts):
     """DeepGemm with fallback to Triton for low latency shapes."""
 
-    def __init__(self, moe_config: FusedMoEConfig, quant_config: FusedMoEQuantConfig):
+    def __init__(
+        self,
+        moe_config: FusedMoEConfig,
+        quant_config: FusedMoEQuantConfig | None = None,
+    ):
         super().__init__(
             experts=DeepGemmExperts(moe_config, quant_config),
             fallback_experts=TritonExperts(moe_config, quant_config),

--- a/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
+++ b/vllm/model_executor/layers/fused_moe/unquantized_fused_moe_method.py
@@ -178,11 +178,8 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
             # which references layer.w{13,2}_bias; since weight updates
             # mutate those bias tensors in place, the kernel does not need
             # to be re-built.
-            self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-            assert self.moe_quant_config is not None
             assert self.experts_cls is not None
             self.moe_kernel = make_unquantized_moe_kernel(
-                quant_config=self.moe_quant_config,
                 moe_config=self.moe,
                 backend=self.unquantized_backend,
                 experts_cls=self.experts_cls,
@@ -191,8 +188,6 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
             )
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        super().process_weights_after_loading(layer)
-
         # Padding the weight for better performance on ROCm.
         # _maybe_pad_weight is idempotent: on the first call it allocates a
         # padded storage and returns a strided view; on subsequent calls
@@ -208,6 +203,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
             UnquantizedMoeBackend.OOT,
         ]:
             # OOT handles internally.
+            super().process_weights_after_loading(layer)
             return
 
         elif self.unquantized_backend == UnquantizedMoeBackend.CPU:
@@ -260,6 +256,7 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, CustomOp):
                 w13=layer.w13_weight,
                 w2=layer.w2_weight,
             )
+        super().process_weights_after_loading(layer)
 
     def get_fused_moe_quant_config(self, layer: torch.nn.Module) -> FusedMoEQuantConfig:
         if self.moe.has_bias:

--- a/vllm/model_executor/layers/quantization/awq_marlin.py
+++ b/vllm/model_executor/layers/quantization/awq_marlin.py
@@ -722,6 +722,8 @@ class AWQMarlinMoEMethod(FusedMoEMethodBase):
         if hasattr(layer, "w2_bias") and layer.w2_bias is not None:
             layer.w2_bias.data = marlin_permute_bias(layer.w2_bias)
 
+        super().process_weights_after_loading(layer)
+
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module
     ) -> FusedMoEQuantConfig | None:

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py
@@ -186,16 +186,15 @@ class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
             )
             prepare_moe_fp4_layer_for_marlin(layer)
 
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-        if self.moe_quant_config is not None:
-            self.moe_kernel = make_mxfp4_moe_kernel(
-                moe_quant_config=self.moe_quant_config,
-                moe_config=self.moe,
-                experts_cls=self.experts_cls,
-                mxfp4_backend=self.mxfp4_backend,
-                shared_experts=layer.shared_experts,
-                routing_tables=layer._maybe_init_expert_routing_tables(),
-            )
+        self.moe_kernel = make_mxfp4_moe_kernel(
+            moe_config=self.moe,
+            experts_cls=self.experts_cls,
+            mxfp4_backend=self.mxfp4_backend,
+            shared_experts=layer.shared_experts,
+            routing_tables=layer._maybe_init_expert_routing_tables(),
+        )
+
+        super().process_weights_after_loading(layer)
 
     def apply(
         self,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_mxfp4.py
@@ -188,6 +188,7 @@ class CompressedTensorsW4A4Mxfp4MoEMethod(CompressedTensorsMoEMethod):
 
         self.moe_kernel = make_mxfp4_moe_kernel(
             moe_config=self.moe,
+            activation_key=None,  # TODO XXXXXXXXX
             experts_cls=self.experts_cls,
             mxfp4_backend=self.mxfp4_backend,
             shared_experts=layer.shared_experts,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
@@ -232,6 +232,7 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
         assert self.experts_cls is not None
         self.moe_kernel = make_nvfp4_moe_kernel(
             moe_config=self.moe,
+            activation_key=None,  # TODO XXXXXXXXX
             experts_cls=self.experts_cls,
             shared_experts=layer.shared_experts,
             routing_tables=layer._maybe_init_expert_routing_tables(),

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a4_nvfp4.py
@@ -229,16 +229,14 @@ class CompressedTensorsW4A4Nvfp4MoEMethod(CompressedTensorsMoEMethod):
         layer.w2_input_scale = a2_scale
 
         # Setup modular kernel.
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         assert self.experts_cls is not None
         self.moe_kernel = make_nvfp4_moe_kernel(
-            moe_quant_config=self.moe_quant_config,
             moe_config=self.moe,
             experts_cls=self.experts_cls,
             shared_experts=layer.shared_experts,
             routing_tables=layer._maybe_init_expert_routing_tables(),
         )
-        self.moe_kernel.fused_experts.process_weights_after_loading(layer)
+        super().process_weights_after_loading(layer)
 
     def maybe_make_prepare_finalize(
         self,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a8_fp8.py
@@ -244,12 +244,6 @@ class CompressedTensorsW4A8Fp8MoEMethod(CompressedTensorsMoEMethod):
 
         super().process_weights_after_loading(layer)
 
-    def maybe_make_prepare_finalize(
-        self,
-        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
-    ) -> mk.FusedMoEPrepareAndFinalizeModular | None:
-        return super().maybe_make_prepare_finalize(routing_tables)
-
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module
     ) -> FusedMoEQuantConfig | None:

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a8_fp8.py
@@ -242,6 +242,8 @@ class CompressedTensorsW4A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         )
         replace_parameter(layer, "w2_weight_scale", w2_weight_scale_packed)
 
+        super().process_weights_after_loading(layer)
+
     def maybe_make_prepare_finalize(
         self,
         routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a8_int8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w4a8_int8.py
@@ -201,7 +201,6 @@ class CompressedTensorsW4A8Int8MoEMethod(CompressedTensorsMoEMethod):
             uint8_nibbles = ((tmp[:, 1::2] << 4) | tmp[:, ::2]).to(
                 torch.uint8
             )  # [out, in//2]
-
             # KleidiAI groupwise kernels accepts float32 scales
             # KleidiAI groupwise kernels accepts bfloat16 scales
             scale_dtype = torch.float32 if g == -1 else torch.bfloat16
@@ -288,6 +287,8 @@ class CompressedTensorsW4A8Int8MoEMethod(CompressedTensorsMoEMethod):
                 "w2_bias",
                 torch.nn.Parameter(torch.empty(0), requires_grad=False),
             )
+
+        super().process_weights_after_loading(layer)
 
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
@@ -328,17 +328,16 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         # In non-naive DP/EP case, we will create a ModularKernelMethod.
         # TODO(rob): unify these so FP8MoEMethod owns the ModularKernel
         # in both cases.
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-        if self.moe_quant_config:
-            assert self.experts_cls is not None
-            self.moe_kernel = make_fp8_moe_kernel(
-                moe_quant_config=self.moe_quant_config,
-                moe_config=self.moe,
-                fp8_backend=self.fp8_backend,
-                experts_cls=self.experts_cls,
-                routing_tables=layer._maybe_init_expert_routing_tables(),
-                shared_experts=layer.shared_experts,
-            )
+        assert self.experts_cls is not None
+        self.moe_kernel = make_fp8_moe_kernel(
+            moe_config=self.moe,
+            fp8_backend=self.fp8_backend,
+            experts_cls=self.experts_cls,
+            routing_tables=layer._maybe_init_expert_routing_tables(),
+            shared_experts=layer.shared_experts,
+        )
+
+        super().process_weights_after_loading(layer)
 
     def maybe_make_prepare_finalize(
         self,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_fp8.py
@@ -331,6 +331,7 @@ class CompressedTensorsW8A8Fp8MoEMethod(CompressedTensorsMoEMethod):
         assert self.experts_cls is not None
         self.moe_kernel = make_fp8_moe_kernel(
             moe_config=self.moe,
+            activation_key=None,  # TODO XXXXXXXXX
             fp8_backend=self.fp8_backend,
             experts_cls=self.experts_cls,
             routing_tables=layer._maybe_init_expert_routing_tables(),

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_int8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_int8.py
@@ -141,15 +141,14 @@ class CompressedTensorsW8A8Int8MoEMethod(CompressedTensorsMoEMethod):
         layer.w2_input_scale = None
 
     def process_weights_after_loading(self, layer: FusedMoE) -> None:
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         assert self.experts_cls is not None
         self.moe_kernel = make_int8_moe_kernel(
-            moe_quant_config=self.moe_quant_config,
             moe_config=self.moe,
             experts_cls=self.experts_cls,
             routing_tables=layer._maybe_init_expert_routing_tables(),
             shared_experts=layer.shared_experts,
         )
+        super().process_weights_after_loading(layer)
 
     def maybe_make_prepare_finalize(
         self,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_int8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_int8.py
@@ -144,6 +144,7 @@ class CompressedTensorsW8A8Int8MoEMethod(CompressedTensorsMoEMethod):
         assert self.experts_cls is not None
         self.moe_kernel = make_int8_moe_kernel(
             moe_config=self.moe,
+            activation_key=None,  # TODO XXXXXXXXX
             experts_cls=self.experts_cls,
             routing_tables=layer._maybe_init_expert_routing_tables(),
             shared_experts=layer.shared_experts,

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_mxfp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_mxfp8.py
@@ -133,6 +133,7 @@ class CompressedTensorsW8A8Mxfp8MoEMethod(CompressedTensorsMoEMethod):
         assert self.experts_cls is not None
         self.moe_kernel = make_fp8_moe_kernel(
             moe_config=self.moe,
+            activation_key=None,  # TODO XXXXXXXXX
             fp8_backend=self.fp8_backend,
             experts_cls=self.experts_cls,
             routing_tables=layer._maybe_init_expert_routing_tables(),

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_mxfp8.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_w8a8_mxfp8.py
@@ -130,17 +130,16 @@ class CompressedTensorsW8A8Mxfp8MoEMethod(CompressedTensorsMoEMethod):
         replace_parameter(layer, "w13_weight_scale", w13_scale)
         replace_parameter(layer, "w2_weight_scale", w2_scale)
 
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-        if self.moe_quant_config is not None:
-            assert self.experts_cls is not None
-            self.moe_kernel = make_fp8_moe_kernel(
-                moe_quant_config=self.moe_quant_config,
-                moe_config=self.moe,
-                fp8_backend=self.fp8_backend,
-                experts_cls=self.experts_cls,
-                routing_tables=layer._maybe_init_expert_routing_tables(),
-                shared_experts=layer.shared_experts,
-            )
+        assert self.experts_cls is not None
+        self.moe_kernel = make_fp8_moe_kernel(
+            moe_config=self.moe,
+            fp8_backend=self.fp8_backend,
+            experts_cls=self.experts_cls,
+            routing_tables=layer._maybe_init_expert_routing_tables(),
+            shared_experts=layer.shared_experts,
+        )
+
+        super().process_weights_after_loading(layer)
 
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16.py
@@ -195,6 +195,8 @@ class CompressedTensorsWNA16MoEMethod(CompressedTensorsMoEMethod):
             layer.w2_weight_scale.transpose(1, 2).contiguous(), requires_grad=False
         )
 
+        super().process_weights_after_loading(layer)
+
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module
     ) -> FusedMoEQuantConfig | None:

--- a/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16_marlin.py
+++ b/vllm/model_executor/layers/quantization/compressed_tensors/compressed_tensors_moe/compressed_tensors_moe_wna16_marlin.py
@@ -342,6 +342,7 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
             replace_parameter(
                 layer, "w2_weight_scale", dict_weights_mxint4["gemm2_scales"]
             )
+            super().process_weights_after_loading(layer)
             return None
 
         is_a_8bit = (
@@ -456,6 +457,8 @@ class CompressedTensorsWNA16MarlinMoEMethod(CompressedTensorsMoEMethod):
         replace_parameter(layer, "w2_weight_scale", marlin_w2_scales)
 
         layer.workspace = marlin_make_workspace_new(device, 4)
+
+        super().process_weights_after_loading(layer)
 
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -766,17 +766,14 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         replace_parameter(layer, f"w13_{self.weight_scale_name}", w13_scale)
         replace_parameter(layer, f"w2_{self.weight_scale_name}", w2_scale)
 
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-        if self.moe_quant_config:
-            assert self.experts_cls is not None
-            self.moe_kernel = make_fp8_moe_kernel(
-                moe_quant_config=self.moe_quant_config,
-                moe_config=self.moe,
-                fp8_backend=self.fp8_backend,
-                experts_cls=self.experts_cls,
-                routing_tables=layer._maybe_init_expert_routing_tables(),
-                shared_experts=layer.shared_experts,
-            )
+        assert self.experts_cls is not None
+        self.moe_kernel = make_fp8_moe_kernel(
+            moe_config=self.moe,
+            fp8_backend=self.fp8_backend,
+            experts_cls=self.experts_cls,
+            routing_tables=layer._maybe_init_expert_routing_tables(),
+            shared_experts=layer.shared_experts,
+        )
 
     def process_weights_after_loading(self, layer: Module) -> None:
         # Allow for accessing weights and scales in standard way.
@@ -822,6 +819,8 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         self._setup_kernel(
             layer, w13, w2, w13_scale, w2_scale, w13_input_scale, w2_input_scale
         )
+
+        super().process_weights_after_loading(layer)
 
     def maybe_make_prepare_finalize(
         self,
@@ -1032,6 +1031,8 @@ class Fp8OnlineMoEMethod(Fp8MoEMethod):
             w13_input_scale=layer.w13_input_scale,
             w2_input_scale=layer.w2_input_scale,
         )
+
+        super().process_weights_after_loading(layer)
 
         # Prevent duplicate processing (e.g., during weight reload)
         layer._already_called_process_weights_after_loading = True

--- a/vllm/model_executor/layers/quantization/fp8.py
+++ b/vllm/model_executor/layers/quantization/fp8.py
@@ -769,6 +769,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         assert self.experts_cls is not None
         self.moe_kernel = make_fp8_moe_kernel(
             moe_config=self.moe,
+            activation_key=None,  # TODO XXXXXXXXX
             fp8_backend=self.fp8_backend,
             experts_cls=self.experts_cls,
             routing_tables=layer._maybe_init_expert_routing_tables(),

--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -755,12 +755,12 @@ class GPTQMarlinMoEMethod(FusedMoEMethodBase):
 
         self._setup_kernel(layer)
 
+        super().process_weights_after_loading(layer)
+
     def _setup_kernel(self, layer: FusedMoE) -> None:
         """Build the FusedMoEKernel for this layer."""
 
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         self.moe_kernel = make_wna16_moe_kernel(
-            moe_quant_config=self.moe_quant_config,
             moe_config=self.moe,
             experts_cls=self.experts_cls,
             layer=layer,

--- a/vllm/model_executor/layers/quantization/gptq_marlin.py
+++ b/vllm/model_executor/layers/quantization/gptq_marlin.py
@@ -762,6 +762,7 @@ class GPTQMarlinMoEMethod(FusedMoEMethodBase):
 
         self.moe_kernel = make_wna16_moe_kernel(
             moe_config=self.moe,
+            activation_key=None,  # TODO XXXXXXXXX
             experts_cls=self.experts_cls,
             layer=layer,
             is_k_full=self.is_k_full,

--- a/vllm/model_executor/layers/quantization/humming.py
+++ b/vllm/model_executor/layers/quantization/humming.py
@@ -182,7 +182,7 @@ def compressed_tensors_get_config(config: dict[str, Any], key: str):
 
 
 class HummingConfig(QuantizationConfig):
-    packed_modules_mapping = {}
+    packed_modules_mapping: dict[str, list[str]] = {}
 
     def __init__(self, full_config: dict[str, Any] | None = None):
         assert_humming_available()
@@ -873,6 +873,8 @@ class HummingMoEMethod(FusedMoEMethodBase):
         else:
             experts = HummingGroupedExperts(layer, self.moe, self.moe_quant_config)
         self.experts = experts
+
+        super().process_weights_after_loading(layer)
 
     def select_gemm_impl(
         self,

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -889,10 +889,8 @@ class ModelOptFp8MoEMethod(FusedMoEMethodBase):
         replace_parameter(layer, "w2_weight_scale", w2_scale)
 
         # Setup modular kernel.
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         assert self.experts_cls is not None
         self.moe_kernel = make_fp8_moe_kernel(
-            moe_quant_config=self.moe_quant_config,
             moe_config=self.moe,
             fp8_backend=self.fp8_backend,
             experts_cls=self.experts_cls,
@@ -930,6 +928,8 @@ class ModelOptFp8MoEMethod(FusedMoEMethodBase):
         self._setup_kernel(
             layer, w13, w2, w13_scale, w2_scale, w13_input_scale, w2_input_scale
         )
+
+        super().process_weights_after_loading(layer)
 
     def get_fused_moe_quant_config(self, layer: torch.nn.Module) -> FusedMoEQuantConfig:
         w1_scale = layer.w13_weight_scale
@@ -1412,16 +1412,14 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
         replace_parameter(layer, "w2_input_scale", a2_scale)
 
         # Setup modular kernel.
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
         assert self.experts_cls is not None
         self.moe_kernel = make_nvfp4_moe_kernel(
-            moe_quant_config=self.moe_quant_config,
             moe_config=self.moe,
             experts_cls=self.experts_cls,
             shared_experts=layer.shared_experts,
             routing_tables=layer._maybe_init_expert_routing_tables(),
         )
-        self.moe_kernel.fused_experts.process_weights_after_loading(layer)
+        super().process_weights_after_loading(layer)
 
     def get_fused_moe_quant_config(self, layer: torch.nn.Module) -> FusedMoEQuantConfig:
         return make_nvfp4_moe_quant_config(
@@ -1886,6 +1884,7 @@ class ModelOptMxFp8FusedMoE(FusedMoEMethodBase):
 
         self._check_weight_dtypes(layer)
         self._shuffle_weights_for_trtllm(layer)
+        super().process_weights_after_loading(layer)
         layer._already_called_process_weights_after_loading = True
 
     def maybe_make_prepare_finalize(

--- a/vllm/model_executor/layers/quantization/modelopt.py
+++ b/vllm/model_executor/layers/quantization/modelopt.py
@@ -892,6 +892,7 @@ class ModelOptFp8MoEMethod(FusedMoEMethodBase):
         assert self.experts_cls is not None
         self.moe_kernel = make_fp8_moe_kernel(
             moe_config=self.moe,
+            activation_key=None,  # TODO XXXXXXXXX
             fp8_backend=self.fp8_backend,
             experts_cls=self.experts_cls,
             routing_tables=layer._maybe_init_expert_routing_tables(),
@@ -1415,6 +1416,7 @@ class ModelOptNvFp4FusedMoE(FusedMoEMethodBase):
         assert self.experts_cls is not None
         self.moe_kernel = make_nvfp4_moe_kernel(
             moe_config=self.moe,
+            activation_key=None,  # TODO XXXXXXXXX
             experts_cls=self.experts_cls,
             shared_experts=layer.shared_experts,
             routing_tables=layer._maybe_init_expert_routing_tables(),

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -354,20 +354,16 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
             replace_parameter(layer, "w13_bias", w13_bias)
             replace_parameter(layer, "w2_bias", w2_bias)
 
-        # Build quant config
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-
         # Build kernel (modular or monolithic)
-        if self.moe_quant_config is not None and self.experts_cls is not None:
-            self.moe_kernel = make_mxfp4_moe_kernel(
-                moe_quant_config=self.moe_quant_config,
-                moe_config=self.moe,
-                mxfp4_backend=self.mxfp4_backend,
-                experts_cls=self.experts_cls,
-                routing_tables=layer._maybe_init_expert_routing_tables(),
-                shared_experts=layer.shared_experts,
-                layer=layer,
-            )
+        assert self.experts_cls is not None
+        self.moe_kernel = make_mxfp4_moe_kernel(
+            moe_config=self.moe,
+            mxfp4_backend=self.mxfp4_backend,
+            experts_cls=self.experts_cls,
+            routing_tables=layer._maybe_init_expert_routing_tables(),
+            shared_experts=layer.shared_experts,
+            layer=layer,
+        )
 
     def process_weights_after_loading(self, layer):
         w13 = layer.w13_weight
@@ -381,6 +377,7 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
             return
 
         self._setup_kernel(layer, w13, w2, w13_scale, w2_scale, w13_bias, w2_bias)
+        super().process_weights_after_loading(layer)
 
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module
@@ -682,20 +679,16 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             replace_parameter(layer, "w13_bias", w13_bias)
             replace_parameter(layer, "w2_bias", w2_bias)
 
-        # Build quant config
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-
         # Build kernel (modular or monolithic)
-        if self.moe_quant_config is not None and self.experts_cls is not None:
-            self.moe_kernel = make_mxfp4_moe_kernel(
-                moe_quant_config=self.moe_quant_config,
-                moe_config=self.moe,
-                mxfp4_backend=self.mxfp4_backend,
-                experts_cls=self.experts_cls,
-                routing_tables=layer._maybe_init_expert_routing_tables(),
-                shared_experts=layer.shared_experts,
-                layer=layer,
-            )
+        assert self.experts_cls is not None
+        self.moe_kernel = make_mxfp4_moe_kernel(
+            moe_config=self.moe,
+            mxfp4_backend=self.mxfp4_backend,
+            experts_cls=self.experts_cls,
+            routing_tables=layer._maybe_init_expert_routing_tables(),
+            shared_experts=layer.shared_experts,
+            layer=layer,
+        )
 
     def process_weights_after_loading(self, layer):
         w13 = layer.w13_weight
@@ -709,6 +702,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             return
 
         self._setup_kernel(layer, w13, w2, w13_scale, w2_scale, w13_bias, w2_bias)
+        super().process_weights_after_loading(layer)
 
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module

--- a/vllm/model_executor/layers/quantization/mxfp4.py
+++ b/vllm/model_executor/layers/quantization/mxfp4.py
@@ -358,6 +358,7 @@ class GptOssMxfp4MoEMethod(FusedMoEMethodBase):
         assert self.experts_cls is not None
         self.moe_kernel = make_mxfp4_moe_kernel(
             moe_config=self.moe,
+            activation_key=None,  # TODO XXXXXXXXX
             mxfp4_backend=self.mxfp4_backend,
             experts_cls=self.experts_cls,
             routing_tables=layer._maybe_init_expert_routing_tables(),
@@ -683,6 +684,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
         assert self.experts_cls is not None
         self.moe_kernel = make_mxfp4_moe_kernel(
             moe_config=self.moe,
+            activation_key=None,  # TODO XXXXXXXXX
             mxfp4_backend=self.mxfp4_backend,
             experts_cls=self.experts_cls,
             routing_tables=layer._maybe_init_expert_routing_tables(),

--- a/vllm/model_executor/layers/quantization/online/fp8.py
+++ b/vllm/model_executor/layers/quantization/online/fp8.py
@@ -340,17 +340,14 @@ class _Fp8OnlineMoEBase(OnlineMoEMethodBase):
         replace_parameter(layer, f"w13_{self.weight_scale_name}", w13_scale)
         replace_parameter(layer, f"w2_{self.weight_scale_name}", w2_scale)
 
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-        if self.moe_quant_config:
-            assert self.experts_cls is not None
-            self.moe_kernel = make_fp8_moe_kernel(
-                moe_quant_config=self.moe_quant_config,
-                moe_config=self.moe,
-                fp8_backend=self.fp8_backend,
-                experts_cls=self.experts_cls,
-                routing_tables=layer._maybe_init_expert_routing_tables(),
-                shared_experts=layer.shared_experts,
-            )
+        assert self.experts_cls is not None
+        self.moe_kernel = make_fp8_moe_kernel(
+            moe_config=self.moe,
+            fp8_backend=self.fp8_backend,
+            experts_cls=self.experts_cls,
+            routing_tables=layer._maybe_init_expert_routing_tables(),
+            shared_experts=layer.shared_experts,
+        )
 
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module
@@ -425,6 +422,8 @@ class Fp8PerTensorOnlineMoEMethod(_Fp8OnlineMoEBase):
             w13_input_scale=layer.w13_input_scale,
             w2_input_scale=layer.w2_input_scale,
         )
+
+        super().process_weights_after_loading(layer)
 
         # Prevent duplicate processing (e.g., during weight reload)
         layer._already_called_process_weights_after_loading = True
@@ -501,6 +500,8 @@ class Fp8PerBlockOnlineMoEMethod(_Fp8OnlineMoEBase):
             layer.w13_input_scale,
             layer.w2_input_scale,
         )
+
+        super().process_weights_after_loading(layer)
 
         # Prevent duplicate processing (e.g., during weight reload)
         layer._already_called_process_weights_after_loading = True

--- a/vllm/model_executor/layers/quantization/online/fp8.py
+++ b/vllm/model_executor/layers/quantization/online/fp8.py
@@ -343,6 +343,7 @@ class _Fp8OnlineMoEBase(OnlineMoEMethodBase):
         assert self.experts_cls is not None
         self.moe_kernel = make_fp8_moe_kernel(
             moe_config=self.moe,
+            activation_key=None,  # TODO XXXXXXXXX
             fp8_backend=self.fp8_backend,
             experts_cls=self.experts_cls,
             routing_tables=layer._maybe_init_expert_routing_tables(),

--- a/vllm/model_executor/layers/quantization/online/int8.py
+++ b/vllm/model_executor/layers/quantization/online/int8.py
@@ -50,6 +50,7 @@ class Int8OnlineMoEMethod(OnlineMoEMethodBase):
 
         self._quantize_weights(layer)
         self._setup_kernel(layer)
+        super().process_weights_after_loading(layer)
 
         layer._already_called_process_weights_after_loading = True
 
@@ -92,11 +93,8 @@ class Int8OnlineMoEMethod(OnlineMoEMethodBase):
         replace_parameter(layer, "w2_scale", w2_scale)
 
     def _setup_kernel(self, layer: "FusedMoE") -> None:
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-        assert self.moe_quant_config is not None
         assert self.experts_cls is not None
         self.moe_kernel = make_int8_moe_kernel(
-            moe_quant_config=self.moe_quant_config,
             moe_config=self.moe,
             experts_cls=self.experts_cls,
             routing_tables=layer._maybe_init_expert_routing_tables(),

--- a/vllm/model_executor/layers/quantization/online/int8.py
+++ b/vllm/model_executor/layers/quantization/online/int8.py
@@ -96,6 +96,7 @@ class Int8OnlineMoEMethod(OnlineMoEMethodBase):
         assert self.experts_cls is not None
         self.moe_kernel = make_int8_moe_kernel(
             moe_config=self.moe,
+            activation_key=None,  # TODO XXXXXXXXX
             experts_cls=self.experts_cls,
             routing_tables=layer._maybe_init_expert_routing_tables(),
             shared_experts=layer.shared_experts,

--- a/vllm/model_executor/layers/quantization/online/moe_base.py
+++ b/vllm/model_executor/layers/quantization/online/moe_base.py
@@ -1,12 +1,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
-from abc import abstractmethod
 
 import torch
 
-import vllm.model_executor.layers.fused_moe.modular_kernel as mk
-from vllm.model_executor.layers.fused_moe import FusedMoEMethodBase
+from vllm.model_executor.layers.fused_moe import FusedMoEMethodMKBase
 from vllm.model_executor.layers.fused_moe.config import FusedMoEQuantConfig
 from vllm.model_executor.model_loader.reload.layerwise import (
     initialize_online_processing,
@@ -14,7 +12,7 @@ from vllm.model_executor.model_loader.reload.layerwise import (
 from vllm.model_executor.utils import set_weight_attrs
 
 
-class OnlineMoEMethodBase(FusedMoEMethodBase):
+class OnlineMoEMethodBase(FusedMoEMethodMKBase):
     """Base for MoE methods that load full-precision weights on meta device
     and quantize them after loading via the QeRL layerwise processing system.
     """
@@ -93,9 +91,9 @@ class OnlineMoEMethodBase(FusedMoEMethodBase):
 
         initialize_online_processing(layer)
 
-    @abstractmethod
-    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        pass
+    # @abstractmethod
+    # def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+    #    pass
 
     def _maybe_inject_biases(
         self,
@@ -112,62 +110,6 @@ class OnlineMoEMethodBase(FusedMoEMethodBase):
             if w2_bias is not None:
                 quant_config._w2.bias = w2_bias
 
-    def maybe_make_prepare_finalize(
-        self,
-        routing_tables: tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None = None,
-    ) -> mk.FusedMoEPrepareAndFinalizeModular | None:
-        raise ValueError(
-            f"{self.__class__.__name__} uses the new modular kernel "
-            "initialization logic. This function should not be called."
-        )
-
     @property
     def supports_eplb(self) -> bool:
         return True
-
-    def apply_monolithic(
-        self,
-        layer: "FusedMoE",  # type: ignore[name-defined] # noqa: F821
-        x: torch.Tensor,
-        router_logits: torch.Tensor,
-        input_ids: torch.Tensor | None = None,
-    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        assert self.is_monolithic
-        assert self.moe_kernel is not None
-        return self.moe_kernel.apply_monolithic(
-            x,
-            layer.w13_weight,
-            layer.w2_weight,
-            router_logits,
-            activation=layer.activation,
-            global_num_experts=layer.global_num_experts,
-            expert_map=layer.expert_map,
-            apply_router_weight_on_input=layer.apply_router_weight_on_input,
-            num_expert_group=layer.num_expert_group,
-            topk_group=layer.topk_group,
-            e_score_correction_bias=layer.e_score_correction_bias,
-            routed_scaling_factor=layer.routed_scaling_factor,
-        )
-
-    def apply(
-        self,
-        layer: "FusedMoE",  # type: ignore[name-defined] # noqa: F821
-        x: torch.Tensor,
-        topk_weights: torch.Tensor,
-        topk_ids: torch.Tensor,
-        shared_experts_input: torch.Tensor | None,
-    ) -> torch.Tensor | tuple[torch.Tensor, torch.Tensor]:
-        assert not self.is_monolithic
-        assert self.moe_kernel is not None
-        return self.moe_kernel.apply(
-            x,
-            layer.w13_weight,
-            layer.w2_weight,
-            topk_weights,
-            topk_ids,
-            activation=layer.activation,
-            global_num_experts=layer.global_num_experts,
-            expert_map=layer.expert_map,
-            apply_router_weight_on_input=layer.apply_router_weight_on_input,
-            shared_experts_input=shared_experts_input,
-        )

--- a/vllm/model_executor/layers/quantization/online/mxfp8.py
+++ b/vllm/model_executor/layers/quantization/online/mxfp8.py
@@ -191,17 +191,14 @@ class Mxfp8OnlineMoEMethod(OnlineMoEMethodBase):
         replace_parameter(layer, f"w13_{self.weight_scale_name}", w13_scale)
         replace_parameter(layer, f"w2_{self.weight_scale_name}", w2_scale)
 
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-        if self.moe_quant_config:
-            assert self.experts_cls is not None
-            self.moe_kernel = make_fp8_moe_kernel(
-                moe_quant_config=self.moe_quant_config,
-                moe_config=self.moe,
-                fp8_backend=self.fp8_backend,
-                experts_cls=self.experts_cls,
-                routing_tables=layer._maybe_init_expert_routing_tables(),
-                shared_experts=layer.shared_experts,
-            )
+        assert self.experts_cls is not None
+        self.moe_kernel = make_fp8_moe_kernel(
+            moe_config=self.moe,
+            fp8_backend=self.fp8_backend,
+            experts_cls=self.experts_cls,
+            routing_tables=layer._maybe_init_expert_routing_tables(),
+            shared_experts=layer.shared_experts,
+        )
 
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module
@@ -249,5 +246,6 @@ class Mxfp8OnlineMoEMethod(OnlineMoEMethodBase):
             layer.w13_input_scale,
             layer.w2_input_scale,
         )
+        super().process_weights_after_loading(layer)
 
         layer._already_called_process_weights_after_loading = True

--- a/vllm/model_executor/layers/quantization/online/mxfp8.py
+++ b/vllm/model_executor/layers/quantization/online/mxfp8.py
@@ -194,6 +194,7 @@ class Mxfp8OnlineMoEMethod(OnlineMoEMethodBase):
         assert self.experts_cls is not None
         self.moe_kernel = make_fp8_moe_kernel(
             moe_config=self.moe,
+            activation_key=None,  # TODO XXXXXXXXX
             fp8_backend=self.fp8_backend,
             experts_cls=self.experts_cls,
             routing_tables=layer._maybe_init_expert_routing_tables(),

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -421,6 +421,8 @@ class QuarkW8A8Fp8MoEMethod(QuarkMoEMethod):
                 w2_weight_scale, requires_grad=False
             )
 
+        super().process_weights_after_loading(layer)
+
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module
     ) -> FusedMoEQuantConfig | None:
@@ -731,6 +733,8 @@ class QuarkW8A8Int8MoEMethod(QuarkMoEMethod):
                 max_w13_scales, requires_grad=False
             )
 
+        super().process_weights_after_loading(layer)
+
     def get_fused_moe_quant_config(
         self, layer: torch.nn.Module
     ) -> FusedMoEQuantConfig | None:
@@ -893,6 +897,8 @@ class QuarkW4A8Fp8MoEMethod(QuarkMoEMethod):
         for expert_id in range(layer.local_num_experts):
             layer.w13_weight_scale_2[expert_id] *= max_w13_scales[expert_id]
             layer.w2_weight_scale_2[expert_id] *= layer.w2_weight_scale[expert_id]
+
+        super().process_weights_after_loading(layer)
 
     def get_fused_moe_quant_config(self, layer):
         return fp8_w8a8_moe_quant_config(
@@ -1202,6 +1208,7 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
         # For MXFP4 schemes with native backend, use oracle
         if self.mxfp4_backend != Mxfp4MoeBackend.NONE:
             self._setup_kernel(layer)
+            super().process_weights_after_loading(layer)
             return
 
         if self.static_input_scales and self.input_dtype == "fp8":
@@ -1287,7 +1294,7 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
         layer.w2_weight.is_shuffled = True
 
         # Build quant config for AITER path
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
+        super().process_weights_after_loading(layer)
         torch.accelerator.empty_cache()
 
     def _setup_kernel(self, layer: FusedMoE):
@@ -1333,10 +1340,9 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
         torch.accelerator.empty_cache()
 
         # Build quant config and kernel
-        self.moe_quant_config = self.get_fused_moe_quant_config(layer)
-        if self.moe_quant_config is not None and self.experts_cls is not None:
+        assert self.experts_cls is not None
+        if self.moe_quant_config is not None:
             self.moe_kernel = make_mxfp4_moe_kernel(
-                moe_quant_config=self.moe_quant_config,
                 moe_config=self.moe,
                 mxfp4_backend=self.mxfp4_backend,
                 experts_cls=self.experts_cls,

--- a/vllm/model_executor/layers/quantization/quark/quark_moe.py
+++ b/vllm/model_executor/layers/quantization/quark/quark_moe.py
@@ -1344,6 +1344,7 @@ class QuarkOCP_MX_MoEMethod(QuarkMoEMethod):
         if self.moe_quant_config is not None:
             self.moe_kernel = make_mxfp4_moe_kernel(
                 moe_config=self.moe,
+                activation_key=None,  # TODO XXXXXXXXX
                 mxfp4_backend=self.mxfp4_backend,
                 experts_cls=self.experts_cls,
                 routing_tables=layer._maybe_init_expert_routing_tables(),


### PR DESCRIPTION

## Purpose

Remove `FusedMoEQuantConfig` requirement for constructing MKs.  This would allow us to construct MKs at quant_method `__init__` time.  Still WIP.

@yzong-rh 

## Test Plan

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

