### PR TITLE
[Metrics] Clamp prefill KV computed token metric

### DIFF
--- a/tests/v1/metrics/test_stats.py
+++ b/tests/v1/metrics/test_stats.py
@@ -38,11 +38,7 @@ def test_prefill_kv_computed_with_cache():
     assert finished_req.num_cached_tokens == 1200
     assert finished_req.request_id == "test-req-001"
 
-    # Verify calculation: prefill KV = prompt tokens - cached tokens
-    prefill_kv_computed = finished_req.num_prompt_tokens - max(
-        finished_req.num_cached_tokens, 0
-    )
-    assert prefill_kv_computed == 8800  # 10000 - 1200
+    assert finished_req.num_prefill_kv_computed_tokens == 8800  # 10000 - 1200
 
 
 def test_prefill_kv_computed_no_cache():
@@ -69,11 +65,7 @@ def test_prefill_kv_computed_no_cache():
     assert finished_req.num_cached_tokens == 0
     assert finished_req.request_id == "test-req-002"
 
-    # Verify calculation: prefill KV = full prompt when no cache
-    prefill_kv_computed = finished_req.num_prompt_tokens - max(
-        finished_req.num_cached_tokens, 0
-    )
-    assert prefill_kv_computed == 2000
+    assert finished_req.num_prefill_kv_computed_tokens == 2000
 
 
 def test_prefill_kv_computed_edge_cases():
@@ -96,11 +88,7 @@ def test_prefill_kv_computed_edge_cases():
     )
 
     finished_req = iteration_stats.finished_requests[0]
-    # max() should handle negative values
-    prefill_kv_computed = finished_req.num_prompt_tokens - max(
-        finished_req.num_cached_tokens, 0
-    )
-    assert prefill_kv_computed == 100  # Should treat negative as 0
+    assert finished_req.num_prefill_kv_computed_tokens == 100
     assert finished_req.request_id == "test-req-003"
 
     # Case 4: All tokens cached (shouldn't happen in practice)
@@ -115,11 +103,23 @@ def test_prefill_kv_computed_edge_cases():
     )
 
     finished_req2 = iteration_stats2.finished_requests[0]
-    prefill_kv_computed2 = finished_req2.num_prompt_tokens - max(
-        finished_req2.num_cached_tokens, 0
-    )
-    assert prefill_kv_computed2 == 0  # All cached, nothing computed
+    assert finished_req2.num_prefill_kv_computed_tokens == 0
     assert finished_req2.request_id == "test-req-004"
+
+    # Case 5: Cached-token bookkeeping should not produce negative metrics.
+    iteration_stats3 = IterationStats()
+    iteration_stats3.update_from_finished_request(
+        finish_reason=FinishReason.STOP,
+        request_id="test-req-005",
+        num_prompt_tokens=100,
+        max_tokens_param=10,
+        req_stats=req_stats,
+        num_cached_tokens=120,
+    )
+
+    finished_req3 = iteration_stats3.finished_requests[0]
+    assert finished_req3.num_prefill_kv_computed_tokens == 0
+    assert finished_req3.request_id == "test-req-005"
 
 
 def test_prompt_token_stats_all_computed():

--- a/vllm/v1/metrics/loggers.py
+++ b/vllm/v1/metrics/loggers.py
@@ -1194,12 +1194,8 @@ class PrometheusStatLogger(AggregateStatLoggerBase):
             self.histogram_decode_time_request[engine_idx].observe(
                 finished_request.decode_time
             )
-            # Calculate prefill KV compute (excludes cached tokens)
-            prefill_kv_computed = finished_request.num_prompt_tokens - max(
-                finished_request.num_cached_tokens, 0
-            )
             self.histogram_prefill_kv_computed_request[engine_idx].observe(
-                prefill_kv_computed
+                finished_request.num_prefill_kv_computed_tokens
             )
             self.histogram_num_prompt_tokens_request[engine_idx].observe(
                 finished_request.num_prompt_tokens

--- a/vllm/v1/metrics/stats.py
+++ b/vllm/v1/metrics/stats.py
@@ -238,6 +238,11 @@ class FinishedRequestStats:
     is_corrupted: bool = False
     num_cached_tokens: int = 0
 
+    @property
+    def num_prefill_kv_computed_tokens(self) -> int:
+        """Tokens computed for prefill KV, excluding cached tokens."""
+        return max(self.num_prompt_tokens - max(self.num_cached_tokens, 0), 0)
+
 
 @dataclass
 class PrefillStats:


### PR DESCRIPTION
## Summary

Clamp the request-level prefill KV computed token metric at zero and keep the calculation in `FinishedRequestStats`.

This prevents malformed cached-token bookkeeping from producing negative observations for `vllm:request_prefill_kv_computed_tokens`.

## Not a duplicate

#37460 fixed the broader prompt-token source accounting path with `PrefillStats`. #38712 targets negative `prompt_tokens_by_source_total` counter increments. This PR is narrower and only hardens the request-level prefill KV computed histogram.

## Tests

- `.venv/bin/python -m pytest tests/v1/metrics/test_stats.py -v`: 10 passed
- `.venv/bin/ruff check vllm/v1/metrics/stats.py vllm/v1/metrics/loggers.py tests/v1/metrics/test_stats.py`: passed
- `git diff --check upstream/main..HEAD`: passed

AI assistance was used for this PR.