### PR TITLE
Fix: Prevent GPU Waste From Cancelled Completion Requests

### DIFF
--- a/tests/entrypoints/openai/completion/test_completion_error.py
+++ b/tests/entrypoints/openai/completion/test_completion_error.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
+import asyncio
 from dataclasses import dataclass, field
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -25,6 +26,11 @@ BASE_MODEL_PATHS = [
     BaseModelPath(name=MODEL_NAME, model_path=MODEL_NAME),
     BaseModelPath(name=MODEL_NAME_SHORT, model_path=MODEL_NAME_SHORT),
 ]
+
+
+async def _never_finishes():
+    await asyncio.Event().wait()
+    yield
 
 
 @dataclass
@@ -146,6 +152,51 @@ async def test_completion_error_non_stream():
 
     with pytest.raises(GenerationError):
         await serving_completion.create_completion(request)
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_cancel_aborts_engine_requests():
+    mock_engine = MagicMock(spec=AsyncLLM)
+    mock_engine.errored = False
+    mock_engine.model_config = MockModelConfig()
+    mock_engine.input_processor = MagicMock()
+    mock_engine.renderer = _build_renderer(mock_engine.model_config)
+    mock_engine.generate = MagicMock(
+        side_effect=lambda *_args, **_kwargs: _never_finishes()
+    )
+    mock_engine.abort = AsyncMock()
+
+    serving_completion = _build_serving_completion(mock_engine)
+    serving_completion.render_completion_request = AsyncMock(
+        return_value=[
+            {"prompt_token_ids": [1, 2, 3]},
+            {"prompt_token_ids": [4, 5, 6]},
+        ]
+    )
+
+    request = CompletionRequest(
+        model=MODEL_NAME,
+        prompt=["Test prompt 1", "Test prompt 2"],
+        max_tokens=10,
+        stream=False,
+        request_id="outer-request",
+    )
+
+    task = asyncio.create_task(serving_completion.create_completion(request))
+    await asyncio.sleep(0)
+
+    task.cancel()
+    response = await task
+
+    generated_request_ids = [
+        call.args[2] for call in mock_engine.generate.call_args_list
+    ]
+    assert generated_request_ids == [
+        "cmpl-outer-request-0",
+        "cmpl-outer-request-1",
+    ]
+    mock_engine.abort.assert_awaited_once_with(generated_request_ids)
+    assert response.error.message == "Client disconnected"
 
 
 @pytest.mark.asyncio

--- a/vllm/entrypoints/openai/completion/serving.py
+++ b/vllm/entrypoints/openai/completion/serving.py
@@ -149,91 +149,93 @@ class OpenAIServingCompletion(OpenAIServing):
 
         # Extract data_parallel_rank from header (router can inject it)
         data_parallel_rank = self._get_data_parallel_rank(raw_request)
+        try:
 
-        # Schedule the request and get the result generator.
-        max_model_len = self.model_config.max_model_len
-        generators: list[AsyncGenerator[RequestOutput, None]] = []
-        for i, engine_input in enumerate(engine_inputs):
-            max_tokens = get_max_tokens(
-                max_model_len,
-                request.max_tokens,
-                self._extract_prompt_len(engine_input),
-                self.default_sampling_params,
-                self.override_max_tokens,
-                truncate_prompt_tokens=request.truncate_prompt_tokens,
-            )
-
-            sampling_params: SamplingParams | BeamSearchParams
-            if request.use_beam_search:
-                sampling_params = request.to_beam_search_params(
-                    max_tokens, self.default_sampling_params
-                )
-            else:
-                sampling_params = request.to_sampling_params(
-                    max_tokens,
+            # Schedule the request and get the result generator.
+            max_model_len = self.model_config.max_model_len
+            generators: list[AsyncGenerator[RequestOutput, None]] = []
+            engine_request_ids: list[str] = []
+            for i, engine_input in enumerate(engine_inputs):
+                max_tokens = get_max_tokens(
+                    max_model_len,
+                    request.max_tokens,
+                    self._extract_prompt_len(engine_input),
                     self.default_sampling_params,
+                    self.override_max_tokens,
+                    truncate_prompt_tokens=request.truncate_prompt_tokens,
                 )
 
-            request_id_item = f"{request_id}-{i}"
+                sampling_params: SamplingParams | BeamSearchParams
+                if request.use_beam_search:
+                    sampling_params = request.to_beam_search_params(
+                        max_tokens, self.default_sampling_params
+                    )
+                else:
+                    sampling_params = request.to_sampling_params(
+                        max_tokens,
+                        self.default_sampling_params,
+                    )
 
-            self._log_inputs(
-                request_id_item,
-                engine_input,
-                params=sampling_params,
-                lora_request=lora_request,
-            )
+                request_id_item = f"{request_id}-{i}"
 
-            trace_headers = (
-                None
-                if raw_request is None
-                else await self._get_trace_headers(raw_request.headers)
-            )
-
-            if isinstance(sampling_params, BeamSearchParams):
-                generator = self.beam_search(
-                    prompt=engine_input,
-                    request_id=request_id,
+                self._log_inputs(
+                    request_id_item,
+                    engine_input,
                     params=sampling_params,
                     lora_request=lora_request,
-                    trace_headers=trace_headers,
-                )
-            else:
-                generator = self.engine_client.generate(
-                    engine_input,
-                    sampling_params,
-                    request_id_item,
-                    lora_request=lora_request,
-                    trace_headers=trace_headers,
-                    priority=request.priority,
-                    data_parallel_rank=data_parallel_rank,
                 )
 
-            generators.append(generator)
+                trace_headers = (
+                    None
+                    if raw_request is None
+                    else await self._get_trace_headers(raw_request.headers)
+                )
 
-        result_generator = merge_async_iterators(*generators)
+                if isinstance(sampling_params, BeamSearchParams):
+                    generator = self.beam_search(
+                        prompt=engine_input,
+                        request_id=request_id,
+                        params=sampling_params,
+                        lora_request=lora_request,
+                        trace_headers=trace_headers,
+                    )
+                else:
+                    engine_request_ids.append(request_id_item)
+                    generator = self.engine_client.generate(
+                        engine_input,
+                        sampling_params,
+                        request_id_item,
+                        lora_request=lora_request,
+                        trace_headers=trace_headers,
+                        priority=request.priority,
+                        data_parallel_rank=data_parallel_rank,
+                    )
 
-        model_name = self.models.model_name(lora_request)
-        num_prompts = len(engine_inputs)
+                generators.append(generator)
 
-        # Streaming response
-        tokenizer = self.renderer.tokenizer
+            result_generator = merge_async_iterators(*generators)
 
-        if request.stream:
-            return self.completion_stream_generator(
-                request,
-                engine_inputs,
-                result_generator,
-                request_id,
-                created_time,
-                model_name,
-                num_prompts=num_prompts,
-                tokenizer=tokenizer,
-                request_metadata=request_metadata,
-            )
+            model_name = self.models.model_name(lora_request)
+            num_prompts = len(engine_inputs)
 
-        # Non-streaming response
-        final_res_batch: list[RequestOutput | None] = [None] * num_prompts
-        try:
+            # Streaming response
+            tokenizer = self.renderer.tokenizer
+
+            if request.stream:
+                return self.completion_stream_generator(
+                    request,
+                    engine_inputs,
+                    result_generator,
+                    request_id,
+                    created_time,
+                    model_name,
+                    num_prompts=num_prompts,
+                    tokenizer=tokenizer,
+                    request_metadata=request_metadata,
+                )
+
+            # Non-streaming response
+            final_res_batch: list[RequestOutput | None] = [None] * num_prompts
             async for i, res in result_generator:
                 final_res_batch[i] = res
 
@@ -258,6 +260,11 @@ class OpenAIServingCompletion(OpenAIServing):
                 request_metadata,
             )
         except asyncio.CancelledError:
+            if engine_request_ids:
+                await asyncio.gather(
+                    self.engine_client.abort(engine_request_ids),
+                    return_exceptions=True,
+                )
             return self.create_error_response("Client disconnected")
 
         # When user requests streaming but we don't stream, we still need to


### PR DESCRIPTION
Stop Non-Streaming Completion Requests on Cancellation

## Purpose

Trigger scenario: 
A non-streaming completion request with one or more prompts can be cancelled after the engine requests have already been submitted. The serving layer returns a client-disconnect error, but the underlying generation work may continue, wasting scheduler and GPU resources. Expected behavior is to stop all submitted engine requests once cancellation is observed.

Root cause: T
he cancellation handler only built the client-disconnect error response and did not keep or abort the internal engine request IDs created for the request.

Fix method: 
Track the generated engine request IDs for non-streaming completion generation and call the engine abort API with those IDs before preserving the existing client-disconnect response behavior.
 
## Test Plan

## Test Result

