### PR TITLE
[models] MiMo V2: Pro fused-QKV FP8 loader + fix SWA wrong-data on V2.5 base

### DIFF
--- a/tests/models/quantization/test_mimo_v2_bf16_qkv_loader.py
+++ b/tests/models/quantization/test_mimo_v2_bf16_qkv_loader.py
@@ -1,0 +1,403 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the MiMo-V2 fused-QKV BF16 pre-sharded loader.
+
+When the source's fused QKV is the row-wise concatenation of independently-
+sharded TP chunks (each ``[Q_chunk, K_chunk, V_chunk]``), vLLM's standard
+``QKVParallelLinear`` weight loader assumes a canonical
+``[Q_global, K_global, V_global]`` layout and silently produces structurally
+wrong per-rank slices. The MTP attention path hits this case after a
+derivative export dequantizes the source's FP8 attention back to BF16.
+
+``_mimo_v2_copy_presharded_qkv_bf16`` detects the pre-sharded layout from
+the row count and reassembles per-rank Q / K / V from the relevant ckpt
+chunks. These tests pin every distinct TP path the helper supports:
+
+  * ``tp_size == ckpt_tp`` direct-narrow fast path
+  * ``tp_size < ckpt_tp`` reassembly path (multiple ckpt chunks per local rank)
+  * ``tp_size == 1`` single-rank reassembly (the full Q, K, V)
+  * SWA layer config with ckpt_tp = swa_num_kv_heads
+  * Non pre-sharded shape returns False so the caller can fall through
+
+Any regression in the per-rank Q/K/V reassembly resurfaces immediately
+because each ckpt chunk is filled with a distinct numeric fingerprint.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.models.mimo_v2 import _mimo_v2_copy_presharded_qkv_bf16
+
+HIDDEN = 4096
+
+
+def _config() -> SimpleNamespace:
+    """Mirror XiaomiMiMo/MiMo-V2.5 base for fields the helper reads."""
+    return SimpleNamespace(
+        head_dim=192,
+        v_head_dim=128,
+        num_attention_heads=64,
+        num_key_value_heads=4,
+        swa_head_dim=192,
+        swa_v_head_dim=128,
+        swa_num_attention_heads=64,
+        swa_num_key_value_heads=8,
+        hybrid_layer_pattern=[0, 1, 1, 1, 1, 0],
+    )
+
+
+def _build_chunked_qkv(
+    n_chunks: int,
+    q_heads_per_chunk: int,
+    kv_heads_per_chunk: int,
+    head_dim: int,
+    v_head_dim: int,
+    hidden: int,
+) -> tuple[torch.Tensor, int]:
+    """Build a pre-sharded fused QKV BF16 tensor with per-chunk fingerprints.
+
+    Each ckpt chunk is filled with its index ``c`` so the test can identify
+    which chunk a row came from when verifying per-rank reassembly.
+    """
+    chunk_rows = (
+        q_heads_per_chunk * head_dim
+        + kv_heads_per_chunk * head_dim
+        + kv_heads_per_chunk * v_head_dim
+    )
+    weight = torch.cat(
+        [
+            torch.full((chunk_rows, hidden), c, dtype=torch.bfloat16)
+            for c in range(n_chunks)
+        ],
+        dim=0,
+    )
+    return weight, chunk_rows
+
+
+def _expected_local_shard(
+    weight: torch.Tensor,
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    v_head_dim: int,
+    tp_rank: int,
+    tp_size: int,
+) -> torch.Tensor:
+    """Reference per-rank shard by direct slicing of the pre-sharded weight.
+
+    Mirrors the helper's slicing logic so the test fails on any drift, not
+    just on the cases the helper explicitly enumerates.
+    """
+    q_heads_per_ckpt_rank = num_heads // num_kv_heads
+    ckpt_q_rows = q_heads_per_ckpt_rank * head_dim
+    ckpt_k_rows = head_dim
+    ckpt_v_rows = v_head_dim
+    ckpt_chunk_rows = ckpt_q_rows + ckpt_k_rows + ckpt_v_rows
+
+    def chunk_slice(ckpt_rank: int, row_start: int, row_count: int) -> torch.Tensor:
+        base = ckpt_rank * ckpt_chunk_rows + row_start
+        return weight.narrow(0, base, row_count)
+
+    if tp_size == num_kv_heads:
+        return weight.narrow(0, tp_rank * ckpt_chunk_rows, ckpt_chunk_rows)
+
+    q_heads_per_rank = num_heads // tp_size
+    q_head_start = tp_rank * q_heads_per_rank
+    q_head_end = q_head_start + q_heads_per_rank
+    q_parts: list[torch.Tensor] = []
+    next_q_head = q_head_start
+    while next_q_head < q_head_end:
+        ckpt_rank = next_q_head // q_heads_per_ckpt_rank
+        ckpt_head_start = ckpt_rank * q_heads_per_ckpt_rank
+        part_head_end = min(q_head_end, ckpt_head_start + q_heads_per_ckpt_rank)
+        part_rows = (part_head_end - next_q_head) * head_dim
+        part_start = (next_q_head - ckpt_head_start) * head_dim
+        q_parts.append(chunk_slice(ckpt_rank, part_start, part_rows))
+        next_q_head = part_head_end
+
+    if tp_size >= num_kv_heads:
+        num_replicas = tp_size // num_kv_heads
+        kv_head_start = tp_rank // num_replicas
+        kv_head_count = 1
+    else:
+        kv_head_count = num_kv_heads // tp_size
+        kv_head_start = tp_rank * kv_head_count
+    kv_head_end = kv_head_start + kv_head_count
+    k_parts = [
+        chunk_slice(ckpt_rank, ckpt_q_rows, ckpt_k_rows)
+        for ckpt_rank in range(kv_head_start, kv_head_end)
+    ]
+    v_parts = [
+        chunk_slice(ckpt_rank, ckpt_q_rows + ckpt_k_rows, ckpt_v_rows)
+        for ckpt_rank in range(kv_head_start, kv_head_end)
+    ]
+    return torch.cat([*q_parts, *k_parts, *v_parts], dim=0).contiguous()
+
+
+def _per_rank_shape(
+    *,
+    num_heads: int,
+    num_kv_heads: int,
+    head_dim: int,
+    v_head_dim: int,
+    tp_size: int,
+    hidden: int,
+) -> tuple[int, int]:
+    q_per_rank = (num_heads // tp_size) * head_dim
+    if tp_size >= num_kv_heads:
+        k_per_rank = head_dim
+        v_per_rank = v_head_dim
+    else:
+        per_rank_kv = num_kv_heads // tp_size
+        k_per_rank = per_rank_kv * head_dim
+        v_per_rank = per_rank_kv * v_head_dim
+    return (q_per_rank + k_per_rank + v_per_rank, hidden)
+
+
+@pytest.mark.parametrize("tp_rank", [0, 1, 2, 3])
+def test_ga_layer_tp_matches_ckpt(tp_rank: int) -> None:
+    """tp_size == ckpt_tp: each rank's local weight is one ckpt chunk verbatim.
+
+    Hits the direct-narrow path inside the helper. With per-chunk fingerprints,
+    rank ``r``'s local weight must be filled entirely with ``r``.
+    """
+    config = _config()
+    weight, _ = _build_chunked_qkv(
+        n_chunks=4,
+        q_heads_per_chunk=16,
+        kv_heads_per_chunk=1,
+        head_dim=config.head_dim,
+        v_head_dim=config.v_head_dim,
+        hidden=HIDDEN,
+    )
+    assert weight.shape == (13568, HIDDEN)
+
+    per_rank_shape = _per_rank_shape(
+        num_heads=config.num_attention_heads,
+        num_kv_heads=config.num_key_value_heads,
+        head_dim=config.head_dim,
+        v_head_dim=config.v_head_dim,
+        tp_size=4,
+        hidden=HIDDEN,
+    )
+    weight_param = torch.nn.Parameter(
+        torch.empty(per_rank_shape, dtype=torch.bfloat16),
+        requires_grad=False,
+    )
+
+    handled = _mimo_v2_copy_presharded_qkv_bf16(
+        config=config,
+        weight_name="model.layers.0.self_attn.qkv_proj.weight",
+        weight_param=weight_param,
+        loaded_weight=weight,
+        tp_rank=tp_rank,
+        tp_size=4,
+    )
+
+    assert handled is True
+    assert torch.equal(
+        weight_param.data,
+        torch.full(per_rank_shape, tp_rank, dtype=torch.bfloat16),
+    )
+
+
+@pytest.mark.parametrize("tp_rank", [0, 1])
+def test_ga_layer_tp_below_ckpt(tp_rank: int) -> None:
+    """tp_size < ckpt_tp: each rank reassembles Q/K/V from multiple ckpt chunks.
+
+    At TP=2 with ckpt_tp=4 the helper must collect Q from 2 ckpt chunks,
+    K from 2 ckpt chunks, and V from 2 ckpt chunks, concatenated as
+    [Q, K, V]. The chunk-fingerprint values let us see the right chunks
+    landed in each section.
+    """
+    config = _config()
+    weight, _ = _build_chunked_qkv(
+        n_chunks=4,
+        q_heads_per_chunk=16,
+        kv_heads_per_chunk=1,
+        head_dim=config.head_dim,
+        v_head_dim=config.v_head_dim,
+        hidden=HIDDEN,
+    )
+
+    per_rank_shape = _per_rank_shape(
+        num_heads=config.num_attention_heads,
+        num_kv_heads=config.num_key_value_heads,
+        head_dim=config.head_dim,
+        v_head_dim=config.v_head_dim,
+        tp_size=2,
+        hidden=HIDDEN,
+    )
+    weight_param = torch.nn.Parameter(
+        torch.empty(per_rank_shape, dtype=torch.bfloat16),
+        requires_grad=False,
+    )
+
+    handled = _mimo_v2_copy_presharded_qkv_bf16(
+        config=config,
+        weight_name="model.layers.0.self_attn.qkv_proj.weight",
+        weight_param=weight_param,
+        loaded_weight=weight,
+        tp_rank=tp_rank,
+        tp_size=2,
+    )
+
+    assert handled is True
+    expected = _expected_local_shard(
+        weight,
+        num_heads=config.num_attention_heads,
+        num_kv_heads=config.num_key_value_heads,
+        head_dim=config.head_dim,
+        v_head_dim=config.v_head_dim,
+        tp_rank=tp_rank,
+        tp_size=2,
+    )
+    assert torch.equal(weight_param.data, expected)
+
+
+def test_ga_layer_tp_one() -> None:
+    """tp_size == 1: the single rank gets [Q_all, K_all, V_all].
+
+    Verifies the loop end-condition by walking every ckpt chunk for Q and
+    every ckpt chunk for K and V.
+    """
+    config = _config()
+    weight, _ = _build_chunked_qkv(
+        n_chunks=4,
+        q_heads_per_chunk=16,
+        kv_heads_per_chunk=1,
+        head_dim=config.head_dim,
+        v_head_dim=config.v_head_dim,
+        hidden=HIDDEN,
+    )
+
+    per_rank_shape = _per_rank_shape(
+        num_heads=config.num_attention_heads,
+        num_kv_heads=config.num_key_value_heads,
+        head_dim=config.head_dim,
+        v_head_dim=config.v_head_dim,
+        tp_size=1,
+        hidden=HIDDEN,
+    )
+    weight_param = torch.nn.Parameter(
+        torch.empty(per_rank_shape, dtype=torch.bfloat16),
+        requires_grad=False,
+    )
+
+    handled = _mimo_v2_copy_presharded_qkv_bf16(
+        config=config,
+        weight_name="model.layers.0.self_attn.qkv_proj.weight",
+        weight_param=weight_param,
+        loaded_weight=weight,
+        tp_rank=0,
+        tp_size=1,
+    )
+
+    assert handled is True
+    expected = _expected_local_shard(
+        weight,
+        num_heads=config.num_attention_heads,
+        num_kv_heads=config.num_key_value_heads,
+        head_dim=config.head_dim,
+        v_head_dim=config.v_head_dim,
+        tp_rank=0,
+        tp_size=1,
+    )
+    assert torch.equal(weight_param.data, expected)
+
+
+@pytest.mark.parametrize("tp_rank", [0, 1, 2, 3])
+def test_swa_layer_tp_below_ckpt(tp_rank: int) -> None:
+    """SWA layer at TP=4 with ckpt_tp=8 (swa_num_kv_heads).
+
+    Exercises the SWA branch of ``_mimo_v2_qkv_dims`` and the reassembly
+    path together. Each rank takes Q from 2 ckpt chunks, K from 2 chunks,
+    V from 2 chunks.
+    """
+    config = _config()
+    weight, _ = _build_chunked_qkv(
+        n_chunks=8,
+        q_heads_per_chunk=8,
+        kv_heads_per_chunk=1,
+        head_dim=config.swa_head_dim,
+        v_head_dim=config.swa_v_head_dim,
+        hidden=HIDDEN,
+    )
+
+    per_rank_shape = _per_rank_shape(
+        num_heads=config.swa_num_attention_heads,
+        num_kv_heads=config.swa_num_key_value_heads,
+        head_dim=config.swa_head_dim,
+        v_head_dim=config.swa_v_head_dim,
+        tp_size=4,
+        hidden=HIDDEN,
+    )
+    weight_param = torch.nn.Parameter(
+        torch.empty(per_rank_shape, dtype=torch.bfloat16),
+        requires_grad=False,
+    )
+
+    handled = _mimo_v2_copy_presharded_qkv_bf16(
+        config=config,
+        weight_name="model.layers.1.self_attn.qkv_proj.weight",
+        weight_param=weight_param,
+        loaded_weight=weight,
+        tp_rank=tp_rank,
+        tp_size=4,
+    )
+
+    assert handled is True
+    expected = _expected_local_shard(
+        weight,
+        num_heads=config.swa_num_attention_heads,
+        num_kv_heads=config.swa_num_key_value_heads,
+        head_dim=config.swa_head_dim,
+        v_head_dim=config.swa_v_head_dim,
+        tp_rank=tp_rank,
+        tp_size=4,
+    )
+    assert torch.equal(weight_param.data, expected)
+
+
+def test_non_presharded_shape_returns_false() -> None:
+    """A canonical [Q_global, K_global, V_global] layout (no per-chunk
+    duplication of K/V) does not match ckpt_tp * chunk_rows for any
+    candidate ckpt_tp. The helper must return False so the caller falls
+    through to ``param.weight_loader`` for the normal case.
+    """
+    config = _config()
+    canonical_rows = (
+        config.num_attention_heads * config.head_dim
+        + config.num_key_value_heads * config.head_dim
+        + config.num_key_value_heads * config.v_head_dim
+    )
+    assert canonical_rows == 13568
+    # Force a row count that doesn't equal ckpt_tp * chunk_rows for any
+    # ckpt_tp the helper can derive. Subtract one row to break the match.
+    weight = torch.zeros((canonical_rows - 1, HIDDEN), dtype=torch.bfloat16)
+
+    per_rank_shape = _per_rank_shape(
+        num_heads=config.num_attention_heads,
+        num_kv_heads=config.num_key_value_heads,
+        head_dim=config.head_dim,
+        v_head_dim=config.v_head_dim,
+        tp_size=4,
+        hidden=HIDDEN,
+    )
+    sentinel = torch.full(per_rank_shape, -1.0, dtype=torch.bfloat16)
+    weight_param = torch.nn.Parameter(sentinel.clone(), requires_grad=False)
+
+    handled = _mimo_v2_copy_presharded_qkv_bf16(
+        config=config,
+        weight_name="model.layers.0.self_attn.qkv_proj.weight",
+        weight_param=weight_param,
+        loaded_weight=weight,
+        tp_rank=0,
+        tp_size=4,
+    )
+
+    assert handled is False
+    assert torch.equal(weight_param.data, sentinel)

--- a/tests/models/quantization/test_mimo_v2_fp8_qkv_loader.py
+++ b/tests/models/quantization/test_mimo_v2_fp8_qkv_loader.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Unit tests for the MiMo-V2 fused-QKV FP8 loader's ckpt_tp detection.
+
+The MiMo-V2.5 base checkpoint stores SWA layers' fused-QKV in 4 per-rank
+chunks of [16Q | 2K | 2V] rows, but the SWA layer has num_kv_heads = 8.
+Hardcoding ckpt_tp = num_kv_heads (the previous behavior) makes the
+pre-sharded check reject the layout and the fallback slice the per-rank
+shard at the wrong size, raising on shape mismatch. These tests pin the
+data-driven detection so any regression resurfaces immediately.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from vllm.model_executor.models.mimo_v2 import _mimo_v2_copy_paired_qkv_fp8
+
+HIDDEN = 4096
+BLOCK = [128, 128]
+
+
+def _config() -> SimpleNamespace:
+    # Mirrors XiaomiMiMo/MiMo-V2.5 base for fields the loader reads.
+    return SimpleNamespace(
+        head_dim=192,
+        v_head_dim=128,
+        num_attention_heads=64,
+        num_key_value_heads=4,
+        swa_head_dim=192,
+        swa_v_head_dim=128,
+        swa_num_attention_heads=64,
+        swa_num_key_value_heads=8,
+        hybrid_layer_pattern=[0, 1, 1, 1, 1, 0],
+    )
+
+
+def _build_chunked_qkv(
+    n_chunks: int,
+    q_heads_per_chunk: int,
+    kv_heads_per_chunk: int,
+    head_dim: int,
+    v_head_dim: int,
+    hidden: int,
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    chunk_rows = (
+        q_heads_per_chunk * head_dim
+        + kv_heads_per_chunk * head_dim
+        + kv_heads_per_chunk * v_head_dim
+    )
+    # Distinct per-chunk fingerprint so we can prove the right chunk landed.
+    weight = torch.cat(
+        [
+            torch.full((chunk_rows, hidden), c, dtype=torch.float32)
+            for c in range(n_chunks)
+        ],
+        dim=0,
+    ).to(torch.float8_e4m3fn)
+    scale_rows_per_chunk = -(-chunk_rows // BLOCK[0])
+    scale = torch.ones(
+        (n_chunks * scale_rows_per_chunk, hidden // BLOCK[1]),
+        dtype=torch.float32,
+    )
+    return weight, scale, chunk_rows
+
+
+@pytest.mark.parametrize("tp_rank", [0, 1, 2, 3])
+def test_swa_layer_detects_ckpt_tp_from_scale_shape(tp_rank: int) -> None:
+    config = _config()
+    weight, scale, chunk_rows = _build_chunked_qkv(
+        n_chunks=4,
+        q_heads_per_chunk=16,
+        kv_heads_per_chunk=2,
+        head_dim=config.swa_head_dim,
+        v_head_dim=config.swa_v_head_dim,
+        hidden=HIDDEN,
+    )
+    assert weight.shape == (14848, HIDDEN)
+    assert scale.shape == (116, HIDDEN // BLOCK[1])
+
+    weight_param = torch.nn.Parameter(
+        torch.empty((chunk_rows, HIDDEN), dtype=torch.float8_e4m3fn),
+        requires_grad=False,
+    )
+    scale_param = torch.nn.Parameter(
+        torch.empty((chunk_rows // BLOCK[0], HIDDEN // BLOCK[1]), dtype=torch.float32),
+        requires_grad=False,
+    )
+
+    _mimo_v2_copy_paired_qkv_fp8(
+        config=config,
+        weight_name="model.layers.1.self_attn.qkv_proj.weight",
+        scale_name="model.layers.1.self_attn.qkv_proj.weight_scale_inv",
+        weight_param=weight_param,
+        scale_param=scale_param,
+        loaded_weight=weight,
+        loaded_scale=scale,
+        tp_rank=tp_rank,
+        tp_size=4,
+        block_size=BLOCK,
+    )
+
+    expected = weight.narrow(0, tp_rank * chunk_rows, chunk_rows)
+    assert torch.equal(weight_param.data, expected)
+
+
+@pytest.mark.parametrize("tp_rank", [0, 1, 2, 3])
+def test_ga_layer_unchanged_by_detection_refactor(tp_rank: int) -> None:
+    config = _config()
+    weight, scale, chunk_rows = _build_chunked_qkv(
+        n_chunks=4,
+        q_heads_per_chunk=16,
+        kv_heads_per_chunk=1,
+        head_dim=config.head_dim,
+        v_head_dim=config.v_head_dim,
+        hidden=HIDDEN,
+    )
+    assert weight.shape == (13568, HIDDEN)
+    assert scale.shape == (108, HIDDEN // BLOCK[1])
+
+    weight_param = torch.nn.Parameter(
+        torch.empty((chunk_rows, HIDDEN), dtype=torch.float8_e4m3fn),
+        requires_grad=False,
+    )
+    scale_param = torch.nn.Parameter(
+        torch.empty(
+            (-(-chunk_rows // BLOCK[0]), HIDDEN // BLOCK[1]), dtype=torch.float32
+        ),
+        requires_grad=False,
+    )
+
+    _mimo_v2_copy_paired_qkv_fp8(
+        config=config,
+        weight_name="model.layers.0.self_attn.qkv_proj.weight",
+        scale_name="model.layers.0.self_attn.qkv_proj.weight_scale_inv",
+        weight_param=weight_param,
+        scale_param=scale_param,
+        loaded_weight=weight,
+        loaded_scale=scale,
+        tp_rank=tp_rank,
+        tp_size=4,
+        block_size=BLOCK,
+    )
+
+    expected = weight.narrow(0, tp_rank * chunk_rows, chunk_rows)
+    assert torch.equal(weight_param.data, expected)

--- a/tests/models/quantization/test_mimo_v2_pro_fp8.py
+++ b/tests/models/quantization/test_mimo_v2_pro_fp8.py
@@ -1,0 +1,68 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""
+Optional end-to-end Wikitext PPL test for XiaomiMiMo/MiMo-V2.5-Pro FP8 loading.
+"""
+
+import lm_eval
+import pytest
+
+from tests.utils import large_gpu_mark, multi_gpu_marks
+from vllm.platforms import current_platform
+
+MODEL_NAME = "XiaomiMiMo/MiMo-V2.5-Pro"
+TASK = "wikitext"
+EXPECTED_WORD_PPL = 4.0
+WORD_PPL_RTOL = 0.1
+
+
+@pytest.mark.optional
+@pytest.mark.skipif(
+    not current_platform.supports_fp8(),
+    reason="MiMo-V2.5-Pro FP8 loading requires FP8-capable hardware.",
+)
+@pytest.mark.parametrize(
+    "tp_size",
+    [
+        pytest.param(
+            4,
+            marks=[*multi_gpu_marks(num_gpus=4), large_gpu_mark(min_gb=256)],
+            id="tp4",
+        ),
+        pytest.param(
+            8,
+            marks=[*multi_gpu_marks(num_gpus=8), large_gpu_mark(min_gb=128)],
+            id="tp8",
+        ),
+    ],
+)
+def test_mimo_v25_pro_fp8_wikitext_ppl(
+    tp_size: int,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("VLLM_WORKER_MULTIPROC_METHOD", "spawn")
+    monkeypatch.setenv("VLLM_ALLOW_INSECURE_SERIALIZATION", "1")
+
+    model_args = {
+        "pretrained": MODEL_NAME,
+        "trust_remote_code": True,
+        "dtype": "bfloat16",
+        "quantization": "fp8",
+        "kv_cache_dtype": "bfloat16",
+        "max_model_len": 1024,
+        "max_num_seqs": 1,
+        "tensor_parallel_size": tp_size,
+        "attention_backend": "TRITON_ATTN_DIFFKV",
+        "enforce_eager": True,
+        "disable_custom_all_reduce": True,
+    }
+    results = lm_eval.simple_evaluate(
+        model="vllm",
+        model_args=model_args,
+        tasks=TASK,
+        batch_size=1,
+    )
+    word_ppl = results["results"][TASK]["word_perplexity,none"]
+
+    print(f"MiMo-V2.5-Pro FP8 tp={tp_size} Wikitext word PPL: {word_ppl}")
+    assert word_ppl == pytest.approx(EXPECTED_WORD_PPL, rel=WORD_PPL_RTOL)

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -35,6 +35,11 @@ from vllm.model_executor.layers.linear import (
 )
 from vllm.model_executor.layers.logits_processor import LogitsProcessor
 from vllm.model_executor.layers.quantization import QuantizationConfig
+from vllm.model_executor.layers.quantization.utils.quant_utils import (
+    GroupShape,
+    scaled_dequantize,
+    scaled_quantize,
+)
 from vllm.model_executor.layers.rotary_embedding import get_rope
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead,
@@ -61,6 +66,362 @@ from .utils import (
 )
 
 logger = init_logger(__name__)
+
+
+def _ceil_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def _mimo_v2_qkv_pair_key(name: str) -> tuple[str, str] | None:
+    if name.endswith(".qkv_proj.weight"):
+        return name[: -len(".weight")], "weight"
+    if name.endswith(".qkv_proj.weight_scale_inv"):
+        return name[: -len(".weight_scale_inv")], "scale"
+    return None
+
+
+def _mimo_v2_kv_shard_range(
+    total_num_kv_heads: int,
+    head_size: int,
+    tp_rank: int,
+    tp_size: int,
+) -> tuple[int, int]:
+    if tp_size >= total_num_kv_heads:
+        num_replicas = tp_size // total_num_kv_heads
+        kv_head_idx = tp_rank // num_replicas
+        return kv_head_idx * head_size, head_size
+
+    num_heads = total_num_kv_heads // tp_size
+    shard_size = num_heads * head_size
+    return tp_rank * shard_size, shard_size
+
+
+def _mimo_v2_qkv_dims(
+    config,
+    layer_idx: int | None,
+) -> tuple[int, int, int, int, int, int, int]:
+    is_swa = (
+        layer_idx is not None
+        and hasattr(config, "hybrid_layer_pattern")
+        and layer_idx < len(config.hybrid_layer_pattern)
+        and config.hybrid_layer_pattern[layer_idx] == 1
+    )
+    if is_swa:
+        head_dim = getattr(config, "swa_head_dim", config.head_dim)
+        v_head_dim = getattr(config, "swa_v_head_dim", config.v_head_dim)
+        num_heads = getattr(config, "swa_num_attention_heads",
+                            config.num_attention_heads)
+        num_kv_heads = getattr(config, "swa_num_key_value_heads",
+                               config.num_key_value_heads)
+    else:
+        head_dim = config.head_dim
+        v_head_dim = getattr(config, "v_head_dim", head_dim)
+        num_heads = config.num_attention_heads
+        num_kv_heads = config.num_key_value_heads
+
+    q_rows = num_heads * head_dim
+    k_rows = num_kv_heads * head_dim
+    v_rows = num_kv_heads * v_head_dim
+    return q_rows, k_rows, v_rows, head_dim, v_head_dim, num_heads, num_kv_heads
+
+
+def _mimo_v2_dequant_block_shard(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    row_start: int,
+    row_count: int,
+    block_n: int,
+    block_k: int,
+    device: torch.device,
+) -> torch.Tensor:
+    block_start = row_start // block_n
+    block_end = _ceil_div(row_start + row_count, block_n)
+    expanded_start = block_start * block_n
+    expanded_rows = (block_end - block_start) * block_n
+    available_rows = min(expanded_rows, weight.shape[0] - expanded_start)
+    expanded_weight = weight.narrow(0, expanded_start, available_rows).to(device)
+    if available_rows != expanded_rows:
+        padded = torch.empty(
+            (expanded_rows, weight.shape[1]),
+            dtype=expanded_weight.dtype,
+            device=device,
+        )
+        padded.zero_()
+        padded[:available_rows] = expanded_weight
+        expanded_weight = padded
+    expanded_scale = scale.narrow(0, block_start,
+                                  block_end - block_start).to(device)
+    dequant_weight = scaled_dequantize(
+        expanded_weight,
+        expanded_scale,
+        group_shape=GroupShape(block_n, block_k),
+        out_dtype=torch.float32,
+    )
+    local_start = row_start - expanded_start
+    return dequant_weight.narrow(0, local_start, row_count)
+
+
+def _mimo_v2_quantize_block_weight(
+    weight: torch.Tensor,
+    block_n: int,
+    block_k: int,
+    quant_dtype: torch.dtype,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    rows, cols = weight.shape
+    padded_rows = _ceil_div(rows, block_n) * block_n
+    padded_cols = _ceil_div(cols, block_k) * block_k
+    if padded_rows != rows or padded_cols != cols:
+        padded = torch.empty(
+            (padded_rows, padded_cols),
+            dtype=weight.dtype,
+            device=weight.device,
+        )
+        padded.zero_()
+        padded[:rows, :cols] = weight
+        weight = padded
+
+    qweight, scale = scaled_quantize(
+        weight,
+        GroupShape(block_n, block_k),
+        quant_dtype=quant_dtype,
+        compute_dtype=torch.float32,
+    )
+    return qweight[:rows, :cols].contiguous(), scale
+
+
+def _mimo_v2_copy_paired_qkv_fp8(
+    *,
+    config,
+    weight_name: str,
+    scale_name: str,
+    weight_param: torch.nn.Parameter,
+    scale_param: torch.nn.Parameter,
+    loaded_weight: torch.Tensor,
+    loaded_scale: torch.Tensor,
+    tp_rank: int,
+    tp_size: int,
+    block_size: list[int],
+) -> None:
+    block_n, block_k = block_size
+    layer_idx = extract_layer_index(weight_name)
+    (
+        q_rows,
+        k_rows,
+        v_rows,
+        head_dim,
+        v_head_dim,
+        num_heads,
+        num_kv_heads,
+    ) = _mimo_v2_qkv_dims(config, layer_idx)
+    expected_rows = q_rows + k_rows + v_rows
+    if loaded_weight.shape[0] != expected_rows:
+        raise ValueError(
+            f"{weight_name} has {loaded_weight.shape[0]} rows, expected "
+            f"{expected_rows} from q={q_rows}, k={k_rows}, v={v_rows}.")
+
+    ckpt_tp = num_kv_heads
+    q_heads_per_ckpt_rank = num_heads // ckpt_tp
+    ckpt_q_rows = q_heads_per_ckpt_rank * head_dim
+    ckpt_k_rows = head_dim
+    ckpt_v_rows = v_head_dim
+    ckpt_chunk_rows = ckpt_q_rows + ckpt_k_rows + ckpt_v_rows
+    ckpt_chunk_scale_rows = _ceil_div(ckpt_chunk_rows, block_n)
+    if (
+        loaded_weight.shape[0] == ckpt_tp * ckpt_chunk_rows
+        and loaded_scale.shape[0] == ckpt_tp * ckpt_chunk_scale_rows
+    ):
+        logger.info_once(
+            "Detected MiMo-V2 TP%d pre-sharded fused-QKV FP8 checkpoint layout.",
+            ckpt_tp,
+        )
+        if tp_size == ckpt_tp:
+            local_weight = loaded_weight.narrow(
+                0, tp_rank * ckpt_chunk_rows, ckpt_chunk_rows)
+            local_scale = loaded_scale.narrow(
+                0, tp_rank * ckpt_chunk_scale_rows, ckpt_chunk_scale_rows)
+        else:
+            device = weight_param.device
+
+            def dequant_ckpt_shard(
+                ckpt_rank: int,
+                row_start: int,
+                row_count: int,
+            ) -> torch.Tensor:
+                chunk_weight = loaded_weight.narrow(
+                    0, ckpt_rank * ckpt_chunk_rows, ckpt_chunk_rows)
+                chunk_scale = loaded_scale.narrow(
+                    0, ckpt_rank * ckpt_chunk_scale_rows,
+                    ckpt_chunk_scale_rows)
+                return _mimo_v2_dequant_block_shard(
+                    chunk_weight,
+                    chunk_scale,
+                    row_start,
+                    row_count,
+                    block_n,
+                    block_k,
+                    device,
+                )
+
+            q_heads_per_rank = num_heads // tp_size
+            q_head_start = tp_rank * q_heads_per_rank
+            q_head_end = q_head_start + q_heads_per_rank
+            q_parts: list[torch.Tensor] = []
+            next_q_head = q_head_start
+            while next_q_head < q_head_end:
+                ckpt_rank = next_q_head // q_heads_per_ckpt_rank
+                ckpt_head_start = ckpt_rank * q_heads_per_ckpt_rank
+                part_head_end = min(
+                    q_head_end, ckpt_head_start + q_heads_per_ckpt_rank)
+                part_rows = (part_head_end - next_q_head) * head_dim
+                part_start = (next_q_head - ckpt_head_start) * head_dim
+                q_parts.append(
+                    dequant_ckpt_shard(ckpt_rank, part_start, part_rows))
+                next_q_head = part_head_end
+
+            if tp_size >= num_kv_heads:
+                num_replicas = tp_size // num_kv_heads
+                kv_head_start = tp_rank // num_replicas
+                kv_head_count = 1
+            else:
+                kv_head_count = num_kv_heads // tp_size
+                kv_head_start = tp_rank * kv_head_count
+            kv_head_end = kv_head_start + kv_head_count
+            k_parts = [
+                dequant_ckpt_shard(ckpt_rank, ckpt_q_rows, ckpt_k_rows)
+                for ckpt_rank in range(kv_head_start, kv_head_end)
+            ]
+            v_parts = [
+                dequant_ckpt_shard(
+                    ckpt_rank, ckpt_q_rows + ckpt_k_rows, ckpt_v_rows)
+                for ckpt_rank in range(kv_head_start, kv_head_end)
+            ]
+            local_dense = torch.cat([*q_parts, *k_parts, *v_parts], dim=0)
+            local_weight, local_scale = _mimo_v2_quantize_block_weight(
+                local_dense,
+                block_n,
+                block_k,
+                weight_param.dtype,
+            )
+
+        if tuple(local_weight.shape) != tuple(weight_param.shape):
+            raise ValueError(
+                f"{weight_name} local shard has shape "
+                f"{tuple(local_weight.shape)}, expected "
+                f"{tuple(weight_param.shape)}.")
+        if tuple(local_scale.shape) != tuple(scale_param.shape):
+            raise ValueError(
+                f"{scale_name} local shard has shape "
+                f"{tuple(local_scale.shape)}, expected "
+                f"{tuple(scale_param.shape)}.")
+
+        weight_param.data.copy_(local_weight.to(weight_param.device))
+        scale_param.data.copy_(local_scale.to(scale_param.device))
+        return
+
+    q_scale_rows = _ceil_div(q_rows, block_n)
+    k_scale_rows = _ceil_div(k_rows, block_n)
+    v_scale_rows = _ceil_div(v_rows, block_n)
+    expected_scale_rows = q_scale_rows + k_scale_rows + v_scale_rows
+    if loaded_scale.shape[0] < expected_scale_rows:
+        raise ValueError(
+            f"{scale_name} has {loaded_scale.shape[0]} rows, expected at "
+            f"least {expected_scale_rows}.")
+    extra_scale_rows = loaded_scale.shape[0] - expected_scale_rows
+    if extra_scale_rows:
+        logger.info_once(
+            "Dropping %d extra MiMo-V2 fused-QKV FP8 scale rows from %s. "
+            "The checkpoint has q/k/v scale rows %d/%d/%d plus extras, "
+            "while q/k/v weight rows imply %d/%d/%d.",
+            extra_scale_rows,
+            scale_name,
+            q_scale_rows,
+            k_scale_rows,
+            v_scale_rows,
+            q_rows,
+            k_rows,
+            v_rows,
+        )
+
+    q_weight = loaded_weight.narrow(0, 0, q_rows)
+    k_weight = loaded_weight.narrow(0, q_rows, k_rows)
+    v_weight = loaded_weight.narrow(0, q_rows + k_rows, v_rows)
+    q_scale = loaded_scale.narrow(0, 0, q_scale_rows)
+    k_scale = loaded_scale.narrow(0, q_scale_rows, k_scale_rows)
+    v_scale = loaded_scale.narrow(0, q_scale_rows + k_scale_rows, v_scale_rows)
+
+    q_shard_rows = q_rows // tp_size
+    q_start = tp_rank * q_shard_rows
+    k_start, k_shard_rows = _mimo_v2_kv_shard_range(
+        config.num_key_value_heads, head_dim, tp_rank, tp_size)
+    v_start, v_shard_rows = _mimo_v2_kv_shard_range(
+        config.num_key_value_heads, v_head_dim, tp_rank, tp_size)
+
+    direct_copy = all(
+        value % block_n == 0
+        for value in (
+            q_start,
+            q_shard_rows,
+            k_start,
+            k_shard_rows,
+            v_start,
+            v_shard_rows,
+        )
+    )
+
+    if direct_copy:
+        local_weight = torch.cat(
+            [
+                q_weight.narrow(0, q_start, q_shard_rows),
+                k_weight.narrow(0, k_start, k_shard_rows),
+                v_weight.narrow(0, v_start, v_shard_rows),
+            ],
+            dim=0,
+        )
+        local_scale = torch.cat(
+            [
+                q_scale.narrow(0, q_start // block_n,
+                               q_shard_rows // block_n),
+                k_scale.narrow(0, k_start // block_n,
+                               k_shard_rows // block_n),
+                v_scale.narrow(0, v_start // block_n,
+                               v_shard_rows // block_n),
+            ],
+            dim=0,
+        )
+    else:
+        device = weight_param.device
+        local_dense = torch.cat(
+            [
+                _mimo_v2_dequant_block_shard(q_weight, q_scale, q_start,
+                                             q_shard_rows, block_n, block_k,
+                                             device),
+                _mimo_v2_dequant_block_shard(k_weight, k_scale, k_start,
+                                             k_shard_rows, block_n, block_k,
+                                             device),
+                _mimo_v2_dequant_block_shard(v_weight, v_scale, v_start,
+                                             v_shard_rows, block_n, block_k,
+                                             device),
+            ],
+            dim=0,
+        )
+        local_weight, local_scale = _mimo_v2_quantize_block_weight(
+            local_dense,
+            block_n,
+            block_k,
+            weight_param.dtype,
+        )
+
+    if tuple(local_weight.shape) != tuple(weight_param.shape):
+        raise ValueError(
+            f"{weight_name} local shard has shape {tuple(local_weight.shape)}, "
+            f"expected {tuple(weight_param.shape)}.")
+    if tuple(local_scale.shape) != tuple(scale_param.shape):
+        raise ValueError(
+            f"{scale_name} local shard has shape {tuple(local_scale.shape)}, "
+            f"expected {tuple(scale_param.shape)}.")
+
+    weight_param.data.copy_(local_weight.to(weight_param.device))
+    scale_param.data.copy_(local_scale.to(scale_param.device))
 
 
 class MiMoV2MLP(nn.Module):
@@ -561,6 +922,7 @@ class MiMoV2Model(nn.Module):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         loaded_params: set[str] = set()
         expert_params_mapping = self.get_expert_mapping()
+        qkv_buffers: dict[str, dict[str, torch.Tensor]] = {}
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
                 continue
@@ -603,12 +965,45 @@ class MiMoV2Model(nn.Module):
 
             if expert_matched:
                 continue
-            # Support fused qkv_proj checkpoint (Pro format)
-            if "qkv_proj" in name:
-                if name in params_dict:
-                    param = params_dict[name]
-                    loaded_weight = loaded_weight.chunk(tp_size, dim=0)[tp_rank]
-                    default_weight_loader(param, loaded_weight)
+            qkv_pair = _mimo_v2_qkv_pair_key(name)
+            if qkv_pair is not None:
+                qkv_base_name, qkv_kind = qkv_pair
+                weight_name = f"{qkv_base_name}.weight"
+                scale_name = f"{qkv_base_name}.weight_scale_inv"
+                has_paired_qkv = (
+                    weight_name in params_dict
+                    and scale_name in params_dict
+                    and getattr(self.quant_config, "weight_block_size", None)
+                    is not None
+                )
+                if not has_paired_qkv:
+                    if name in params_dict:
+                        param = params_dict[name]
+                        weight_loader = getattr(
+                            param, "weight_loader", default_weight_loader
+                        )
+                        weight_loader(param, loaded_weight)
+                        loaded_params.add(name)
+                    continue
+
+                qkv_buffer = qkv_buffers.setdefault(qkv_base_name, {})
+                qkv_buffer[qkv_kind] = loaded_weight
+                if "weight" in qkv_buffer and "scale" in qkv_buffer:
+                    _mimo_v2_copy_paired_qkv_fp8(
+                        config=self.config,
+                        weight_name=weight_name,
+                        scale_name=scale_name,
+                        weight_param=params_dict[weight_name],
+                        scale_param=params_dict[scale_name],
+                        loaded_weight=qkv_buffer["weight"],
+                        loaded_scale=qkv_buffer["scale"],
+                        tp_rank=tp_rank,
+                        tp_size=tp_size,
+                        block_size=self.quant_config.weight_block_size,
+                    )
+                    loaded_params.add(weight_name)
+                    loaded_params.add(scale_name)
+                    del qkv_buffers[qkv_base_name]
                 continue
             stacked_matched = False
             for param_name, weight_name, shard_id in stacked_params_mapping:
@@ -663,6 +1058,12 @@ class MiMoV2Model(nn.Module):
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
                 loaded_params.add(name)
+
+        if qkv_buffers:
+            missing = ", ".join(sorted(qkv_buffers))
+            raise RuntimeError(
+                "Missing fused-QKV FP8 weight/scale pair for MiMo-V2 "
+                f"checkpoint tensors: {missing}")
 
         return loaded_params
 

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -219,17 +219,34 @@ def _mimo_v2_copy_paired_qkv_fp8(
             f"{expected_rows} from q={q_rows}, k={k_rows}, v={v_rows}."
         )
 
-    ckpt_tp = num_kv_heads
-    q_heads_per_ckpt_rank = divide(num_heads, ckpt_tp)
-    ckpt_q_rows = q_heads_per_ckpt_rank * head_dim
-    ckpt_k_rows = head_dim
-    ckpt_v_rows = v_head_dim
-    ckpt_chunk_rows = ckpt_q_rows + ckpt_k_rows + ckpt_v_rows
-    ckpt_chunk_scale_rows = cdiv(ckpt_chunk_rows, block_n)
-    if (
-        loaded_weight.shape[0] == ckpt_tp * ckpt_chunk_rows
-        and loaded_scale.shape[0] == ckpt_tp * ckpt_chunk_scale_rows
-    ):
+    # Detect ckpt_tp from scale shape; weight shape alone is degenerate.
+    ckpt_tp = None
+    q_heads_per_ckpt_rank = None
+    ckpt_q_rows = ckpt_k_rows = ckpt_v_rows = 0
+    ckpt_chunk_rows = ckpt_chunk_scale_rows = 0
+    for candidate in range(min(num_heads, num_kv_heads), 0, -1):
+        if num_heads % candidate != 0 or num_kv_heads % candidate != 0:
+            continue
+        cand_q_heads = num_heads // candidate
+        cand_kv_heads = num_kv_heads // candidate
+        cand_q_rows = cand_q_heads * head_dim
+        cand_k_rows = cand_kv_heads * head_dim
+        cand_v_rows = cand_kv_heads * v_head_dim
+        cand_chunk_rows = cand_q_rows + cand_k_rows + cand_v_rows
+        cand_chunk_scale_rows = cdiv(cand_chunk_rows, block_n)
+        if (
+            loaded_weight.shape[0] == candidate * cand_chunk_rows
+            and loaded_scale.shape[0] == candidate * cand_chunk_scale_rows
+        ):
+            ckpt_tp = candidate
+            q_heads_per_ckpt_rank = cand_q_heads
+            ckpt_q_rows = cand_q_rows
+            ckpt_k_rows = cand_k_rows
+            ckpt_v_rows = cand_v_rows
+            ckpt_chunk_rows = cand_chunk_rows
+            ckpt_chunk_scale_rows = cand_chunk_scale_rows
+            break
+    if ckpt_tp is not None:
         logger.info_once(
             "Detected MiMo-V2 TP%d pre-sharded fused-QKV FP8 checkpoint layout.",
             ckpt_tp,
@@ -287,14 +304,30 @@ def _mimo_v2_copy_paired_qkv_fp8(
                 kv_head_count = divide(num_kv_heads, tp_size)
                 kv_head_start = tp_rank * kv_head_count
             kv_head_end = kv_head_start + kv_head_count
-            k_parts = [
-                dequant_ckpt_shard(ckpt_rank, ckpt_q_rows, ckpt_k_rows)
-                for ckpt_rank in range(kv_head_start, kv_head_end)
-            ]
-            v_parts = [
-                dequant_ckpt_shard(ckpt_rank, ckpt_q_rows + ckpt_k_rows, ckpt_v_rows)
-                for ckpt_rank in range(kv_head_start, kv_head_end)
-            ]
+
+            kv_heads_per_ckpt_rank = divide(num_kv_heads, ckpt_tp)
+
+            def _kv_parts(
+                intra_chunk_offset: int, per_head_rows: int
+            ) -> list[torch.Tensor]:
+                parts: list[torch.Tensor] = []
+                next_kv_head = kv_head_start
+                while next_kv_head < kv_head_end:
+                    ckpt_rank = next_kv_head // kv_heads_per_ckpt_rank
+                    ckpt_head_start = ckpt_rank * kv_heads_per_ckpt_rank
+                    part_head_end = min(
+                        kv_head_end, ckpt_head_start + kv_heads_per_ckpt_rank
+                    )
+                    part_rows = (part_head_end - next_kv_head) * per_head_rows
+                    part_start = intra_chunk_offset + (
+                        next_kv_head - ckpt_head_start
+                    ) * per_head_rows
+                    parts.append(dequant_ckpt_shard(ckpt_rank, part_start, part_rows))
+                    next_kv_head = part_head_end
+                return parts
+
+            k_parts = _kv_parts(ckpt_q_rows, head_dim)
+            v_parts = _kv_parts(ckpt_q_rows + ckpt_k_rows, v_head_dim)
             local_dense = torch.cat([*q_parts, *k_parts, *v_parts], dim=0)
             local_weight, local_scale = _mimo_v2_quantize_block_weight(
                 local_dense,

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -14,6 +14,7 @@ from vllm.config import (
     str_dtype_to_torch_dtype,
 )
 from vllm.distributed import (
+    divide,
     get_ep_group,
     get_pp_group,
     get_tensor_model_parallel_rank,
@@ -51,6 +52,7 @@ from vllm.model_executor.model_loader.weight_utils import (
 )
 from vllm.model_executor.models.utils import sequence_parallel_chunk
 from vllm.sequence import IntermediateTensors
+from vllm.utils.math_utils import cdiv, round_up
 from vllm.v1.attention.backend import AttentionType
 from vllm.v1.attention.backends.registry import AttentionBackendEnum
 
@@ -68,10 +70,6 @@ from .utils import (
 logger = init_logger(__name__)
 
 
-def _ceil_div(a: int, b: int) -> int:
-    return (a + b - 1) // b
-
-
 def _mimo_v2_qkv_pair_key(name: str) -> tuple[str, str] | None:
     if name.endswith(".qkv_proj.weight"):
         return name[: -len(".weight")], "weight"
@@ -87,11 +85,11 @@ def _mimo_v2_kv_shard_range(
     tp_size: int,
 ) -> tuple[int, int]:
     if tp_size >= total_num_kv_heads:
-        num_replicas = tp_size // total_num_kv_heads
+        num_replicas = divide(tp_size, total_num_kv_heads)
         kv_head_idx = tp_rank // num_replicas
         return kv_head_idx * head_size, head_size
 
-    num_heads = total_num_kv_heads // tp_size
+    num_heads = divide(total_num_kv_heads, tp_size)
     shard_size = num_heads * head_size
     return tp_rank * shard_size, shard_size
 
@@ -109,10 +107,12 @@ def _mimo_v2_qkv_dims(
     if is_swa:
         head_dim = getattr(config, "swa_head_dim", config.head_dim)
         v_head_dim = getattr(config, "swa_v_head_dim", config.v_head_dim)
-        num_heads = getattr(config, "swa_num_attention_heads",
-                            config.num_attention_heads)
-        num_kv_heads = getattr(config, "swa_num_key_value_heads",
-                               config.num_key_value_heads)
+        num_heads = getattr(
+            config, "swa_num_attention_heads", config.num_attention_heads
+        )
+        num_kv_heads = getattr(
+            config, "swa_num_key_value_heads", config.num_key_value_heads
+        )
     else:
         head_dim = config.head_dim
         v_head_dim = getattr(config, "v_head_dim", head_dim)
@@ -135,7 +135,7 @@ def _mimo_v2_dequant_block_shard(
     device: torch.device,
 ) -> torch.Tensor:
     block_start = row_start // block_n
-    block_end = _ceil_div(row_start + row_count, block_n)
+    block_end = cdiv(row_start + row_count, block_n)
     expanded_start = block_start * block_n
     expanded_rows = (block_end - block_start) * block_n
     available_rows = min(expanded_rows, weight.shape[0] - expanded_start)
@@ -149,8 +149,7 @@ def _mimo_v2_dequant_block_shard(
         padded.zero_()
         padded[:available_rows] = expanded_weight
         expanded_weight = padded
-    expanded_scale = scale.narrow(0, block_start,
-                                  block_end - block_start).to(device)
+    expanded_scale = scale.narrow(0, block_start, block_end - block_start).to(device)
     dequant_weight = scaled_dequantize(
         expanded_weight,
         expanded_scale,
@@ -168,8 +167,8 @@ def _mimo_v2_quantize_block_weight(
     quant_dtype: torch.dtype,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     rows, cols = weight.shape
-    padded_rows = _ceil_div(rows, block_n) * block_n
-    padded_cols = _ceil_div(cols, block_k) * block_k
+    padded_rows = round_up(rows, block_n)
+    padded_cols = round_up(cols, block_k)
     if padded_rows != rows or padded_cols != cols:
         padded = torch.empty(
             (padded_rows, padded_cols),
@@ -217,15 +216,16 @@ def _mimo_v2_copy_paired_qkv_fp8(
     if loaded_weight.shape[0] != expected_rows:
         raise ValueError(
             f"{weight_name} has {loaded_weight.shape[0]} rows, expected "
-            f"{expected_rows} from q={q_rows}, k={k_rows}, v={v_rows}.")
+            f"{expected_rows} from q={q_rows}, k={k_rows}, v={v_rows}."
+        )
 
     ckpt_tp = num_kv_heads
-    q_heads_per_ckpt_rank = num_heads // ckpt_tp
+    q_heads_per_ckpt_rank = divide(num_heads, ckpt_tp)
     ckpt_q_rows = q_heads_per_ckpt_rank * head_dim
     ckpt_k_rows = head_dim
     ckpt_v_rows = v_head_dim
     ckpt_chunk_rows = ckpt_q_rows + ckpt_k_rows + ckpt_v_rows
-    ckpt_chunk_scale_rows = _ceil_div(ckpt_chunk_rows, block_n)
+    ckpt_chunk_scale_rows = cdiv(ckpt_chunk_rows, block_n)
     if (
         loaded_weight.shape[0] == ckpt_tp * ckpt_chunk_rows
         and loaded_scale.shape[0] == ckpt_tp * ckpt_chunk_scale_rows
@@ -236,9 +236,11 @@ def _mimo_v2_copy_paired_qkv_fp8(
         )
         if tp_size == ckpt_tp:
             local_weight = loaded_weight.narrow(
-                0, tp_rank * ckpt_chunk_rows, ckpt_chunk_rows)
+                0, tp_rank * ckpt_chunk_rows, ckpt_chunk_rows
+            )
             local_scale = loaded_scale.narrow(
-                0, tp_rank * ckpt_chunk_scale_rows, ckpt_chunk_scale_rows)
+                0, tp_rank * ckpt_chunk_scale_rows, ckpt_chunk_scale_rows
+            )
         else:
             device = weight_param.device
 
@@ -248,10 +250,11 @@ def _mimo_v2_copy_paired_qkv_fp8(
                 row_count: int,
             ) -> torch.Tensor:
                 chunk_weight = loaded_weight.narrow(
-                    0, ckpt_rank * ckpt_chunk_rows, ckpt_chunk_rows)
+                    0, ckpt_rank * ckpt_chunk_rows, ckpt_chunk_rows
+                )
                 chunk_scale = loaded_scale.narrow(
-                    0, ckpt_rank * ckpt_chunk_scale_rows,
-                    ckpt_chunk_scale_rows)
+                    0, ckpt_rank * ckpt_chunk_scale_rows, ckpt_chunk_scale_rows
+                )
                 return _mimo_v2_dequant_block_shard(
                     chunk_weight,
                     chunk_scale,
@@ -262,7 +265,7 @@ def _mimo_v2_copy_paired_qkv_fp8(
                     device,
                 )
 
-            q_heads_per_rank = num_heads // tp_size
+            q_heads_per_rank = divide(num_heads, tp_size)
             q_head_start = tp_rank * q_heads_per_rank
             q_head_end = q_head_start + q_heads_per_rank
             q_parts: list[torch.Tensor] = []
@@ -270,20 +273,18 @@ def _mimo_v2_copy_paired_qkv_fp8(
             while next_q_head < q_head_end:
                 ckpt_rank = next_q_head // q_heads_per_ckpt_rank
                 ckpt_head_start = ckpt_rank * q_heads_per_ckpt_rank
-                part_head_end = min(
-                    q_head_end, ckpt_head_start + q_heads_per_ckpt_rank)
+                part_head_end = min(q_head_end, ckpt_head_start + q_heads_per_ckpt_rank)
                 part_rows = (part_head_end - next_q_head) * head_dim
                 part_start = (next_q_head - ckpt_head_start) * head_dim
-                q_parts.append(
-                    dequant_ckpt_shard(ckpt_rank, part_start, part_rows))
+                q_parts.append(dequant_ckpt_shard(ckpt_rank, part_start, part_rows))
                 next_q_head = part_head_end
 
             if tp_size >= num_kv_heads:
-                num_replicas = tp_size // num_kv_heads
+                num_replicas = divide(tp_size, num_kv_heads)
                 kv_head_start = tp_rank // num_replicas
                 kv_head_count = 1
             else:
-                kv_head_count = num_kv_heads // tp_size
+                kv_head_count = divide(num_kv_heads, tp_size)
                 kv_head_start = tp_rank * kv_head_count
             kv_head_end = kv_head_start + kv_head_count
             k_parts = [
@@ -291,8 +292,7 @@ def _mimo_v2_copy_paired_qkv_fp8(
                 for ckpt_rank in range(kv_head_start, kv_head_end)
             ]
             v_parts = [
-                dequant_ckpt_shard(
-                    ckpt_rank, ckpt_q_rows + ckpt_k_rows, ckpt_v_rows)
+                dequant_ckpt_shard(ckpt_rank, ckpt_q_rows + ckpt_k_rows, ckpt_v_rows)
                 for ckpt_rank in range(kv_head_start, kv_head_end)
             ]
             local_dense = torch.cat([*q_parts, *k_parts, *v_parts], dim=0)
@@ -307,25 +307,28 @@ def _mimo_v2_copy_paired_qkv_fp8(
             raise ValueError(
                 f"{weight_name} local shard has shape "
                 f"{tuple(local_weight.shape)}, expected "
-                f"{tuple(weight_param.shape)}.")
+                f"{tuple(weight_param.shape)}."
+            )
         if tuple(local_scale.shape) != tuple(scale_param.shape):
             raise ValueError(
                 f"{scale_name} local shard has shape "
                 f"{tuple(local_scale.shape)}, expected "
-                f"{tuple(scale_param.shape)}.")
+                f"{tuple(scale_param.shape)}."
+            )
 
         weight_param.data.copy_(local_weight.to(weight_param.device))
         scale_param.data.copy_(local_scale.to(scale_param.device))
         return
 
-    q_scale_rows = _ceil_div(q_rows, block_n)
-    k_scale_rows = _ceil_div(k_rows, block_n)
-    v_scale_rows = _ceil_div(v_rows, block_n)
+    q_scale_rows = cdiv(q_rows, block_n)
+    k_scale_rows = cdiv(k_rows, block_n)
+    v_scale_rows = cdiv(v_rows, block_n)
     expected_scale_rows = q_scale_rows + k_scale_rows + v_scale_rows
     if loaded_scale.shape[0] < expected_scale_rows:
         raise ValueError(
             f"{scale_name} has {loaded_scale.shape[0]} rows, expected at "
-            f"least {expected_scale_rows}.")
+            f"least {expected_scale_rows}."
+        )
     extra_scale_rows = loaded_scale.shape[0] - expected_scale_rows
     if extra_scale_rows:
         logger.info_once(
@@ -349,12 +352,14 @@ def _mimo_v2_copy_paired_qkv_fp8(
     k_scale = loaded_scale.narrow(0, q_scale_rows, k_scale_rows)
     v_scale = loaded_scale.narrow(0, q_scale_rows + k_scale_rows, v_scale_rows)
 
-    q_shard_rows = q_rows // tp_size
+    q_shard_rows = divide(q_rows, tp_size)
     q_start = tp_rank * q_shard_rows
     k_start, k_shard_rows = _mimo_v2_kv_shard_range(
-        config.num_key_value_heads, head_dim, tp_rank, tp_size)
+        config.num_key_value_heads, head_dim, tp_rank, tp_size
+    )
     v_start, v_shard_rows = _mimo_v2_kv_shard_range(
-        config.num_key_value_heads, v_head_dim, tp_rank, tp_size)
+        config.num_key_value_heads, v_head_dim, tp_rank, tp_size
+    )
 
     direct_copy = all(
         value % block_n == 0
@@ -379,12 +384,9 @@ def _mimo_v2_copy_paired_qkv_fp8(
         )
         local_scale = torch.cat(
             [
-                q_scale.narrow(0, q_start // block_n,
-                               q_shard_rows // block_n),
-                k_scale.narrow(0, k_start // block_n,
-                               k_shard_rows // block_n),
-                v_scale.narrow(0, v_start // block_n,
-                               v_shard_rows // block_n),
+                q_scale.narrow(0, q_start // block_n, q_shard_rows // block_n),
+                k_scale.narrow(0, k_start // block_n, k_shard_rows // block_n),
+                v_scale.narrow(0, v_start // block_n, v_shard_rows // block_n),
             ],
             dim=0,
         )
@@ -392,15 +394,15 @@ def _mimo_v2_copy_paired_qkv_fp8(
         device = weight_param.device
         local_dense = torch.cat(
             [
-                _mimo_v2_dequant_block_shard(q_weight, q_scale, q_start,
-                                             q_shard_rows, block_n, block_k,
-                                             device),
-                _mimo_v2_dequant_block_shard(k_weight, k_scale, k_start,
-                                             k_shard_rows, block_n, block_k,
-                                             device),
-                _mimo_v2_dequant_block_shard(v_weight, v_scale, v_start,
-                                             v_shard_rows, block_n, block_k,
-                                             device),
+                _mimo_v2_dequant_block_shard(
+                    q_weight, q_scale, q_start, q_shard_rows, block_n, block_k, device
+                ),
+                _mimo_v2_dequant_block_shard(
+                    k_weight, k_scale, k_start, k_shard_rows, block_n, block_k, device
+                ),
+                _mimo_v2_dequant_block_shard(
+                    v_weight, v_scale, v_start, v_shard_rows, block_n, block_k, device
+                ),
             ],
             dim=0,
         )
@@ -414,11 +416,13 @@ def _mimo_v2_copy_paired_qkv_fp8(
     if tuple(local_weight.shape) != tuple(weight_param.shape):
         raise ValueError(
             f"{weight_name} local shard has shape {tuple(local_weight.shape)}, "
-            f"expected {tuple(weight_param.shape)}.")
+            f"expected {tuple(weight_param.shape)}."
+        )
     if tuple(local_scale.shape) != tuple(scale_param.shape):
         raise ValueError(
             f"{scale_name} local shard has shape {tuple(local_scale.shape)}, "
-            f"expected {tuple(scale_param.shape)}.")
+            f"expected {tuple(scale_param.shape)}."
+        )
 
     weight_param.data.copy_(local_weight.to(weight_param.device))
     scale_param.data.copy_(local_scale.to(scale_param.device))
@@ -1063,7 +1067,8 @@ class MiMoV2Model(nn.Module):
             missing = ", ".join(sorted(qkv_buffers))
             raise RuntimeError(
                 "Missing fused-QKV FP8 weight/scale pair for MiMo-V2 "
-                f"checkpoint tensors: {missing}")
+                f"checkpoint tensors: {missing}"
+            )
 
         return loaded_params
 

--- a/vllm/model_executor/models/mimo_v2.py
+++ b/vllm/model_executor/models/mimo_v2.py
@@ -188,6 +188,100 @@ def _mimo_v2_quantize_block_weight(
     return qweight[:rows, :cols].contiguous(), scale
 
 
+def _mimo_v2_copy_presharded_qkv_bf16(
+    *,
+    config,
+    weight_name: str,
+    weight_param: torch.nn.Parameter,
+    loaded_weight: torch.Tensor,
+    tp_rank: int,
+    tp_size: int,
+) -> bool:
+    """Handle a pre-sharded fused-QKV BF16 weight at any local TP factor.
+
+    Returns True if the layout was pre-sharded and handled here; False if the
+    layout isn't pre-sharded and the caller should fall back to the regular
+    per-rank weight_loader.
+
+    The source ships the fused QKV as the row-wise concatenation of
+    ``num_kv_heads`` independently-sharded TP chunks, each laid out as
+    ``[Q_chunk, K_chunk, V_chunk]``. vLLM's ``QKVParallelLinear`` weight
+    loader assumes a canonical ``[Q_global, K_global, V_global]`` layout, so
+    handing it the pre-sharded tensor produces structurally wrong slices.
+    Reassemble per-rank Q / K / V from the relevant ckpt chunks instead.
+    """
+    layer_idx = extract_layer_index(weight_name)
+    (
+        q_rows,
+        k_rows,
+        v_rows,
+        head_dim,
+        v_head_dim,
+        num_heads,
+        num_kv_heads,
+    ) = _mimo_v2_qkv_dims(config, layer_idx)
+
+    ckpt_tp = num_kv_heads
+    q_heads_per_ckpt_rank = divide(num_heads, ckpt_tp)
+    ckpt_q_rows = q_heads_per_ckpt_rank * head_dim
+    ckpt_k_rows = head_dim
+    ckpt_v_rows = v_head_dim
+    ckpt_chunk_rows = ckpt_q_rows + ckpt_k_rows + ckpt_v_rows
+
+    if loaded_weight.shape[0] != ckpt_tp * ckpt_chunk_rows:
+        return False
+
+    if tp_size == ckpt_tp:
+        local_weight = loaded_weight.narrow(
+            0, tp_rank * ckpt_chunk_rows, ckpt_chunk_rows
+        )
+    else:
+
+        def chunk_slice(ckpt_rank: int, row_start: int, row_count: int) -> torch.Tensor:
+            base = ckpt_rank * ckpt_chunk_rows + row_start
+            return loaded_weight.narrow(0, base, row_count)
+
+        q_heads_per_rank = divide(num_heads, tp_size)
+        q_head_start = tp_rank * q_heads_per_rank
+        q_head_end = q_head_start + q_heads_per_rank
+        q_parts: list[torch.Tensor] = []
+        next_q_head = q_head_start
+        while next_q_head < q_head_end:
+            ckpt_rank = next_q_head // q_heads_per_ckpt_rank
+            ckpt_head_start = ckpt_rank * q_heads_per_ckpt_rank
+            part_head_end = min(q_head_end, ckpt_head_start + q_heads_per_ckpt_rank)
+            part_rows = (part_head_end - next_q_head) * head_dim
+            part_start = (next_q_head - ckpt_head_start) * head_dim
+            q_parts.append(chunk_slice(ckpt_rank, part_start, part_rows))
+            next_q_head = part_head_end
+
+        if tp_size >= num_kv_heads:
+            num_replicas = divide(tp_size, num_kv_heads)
+            kv_head_start = tp_rank // num_replicas
+            kv_head_count = 1
+        else:
+            kv_head_count = divide(num_kv_heads, tp_size)
+            kv_head_start = tp_rank * kv_head_count
+        kv_head_end = kv_head_start + kv_head_count
+        k_parts = [
+            chunk_slice(ckpt_rank, ckpt_q_rows, ckpt_k_rows)
+            for ckpt_rank in range(kv_head_start, kv_head_end)
+        ]
+        v_parts = [
+            chunk_slice(ckpt_rank, ckpt_q_rows + ckpt_k_rows, ckpt_v_rows)
+            for ckpt_rank in range(kv_head_start, kv_head_end)
+        ]
+        local_weight = torch.cat([*q_parts, *k_parts, *v_parts], dim=0).contiguous()
+
+    if tuple(local_weight.shape) != tuple(weight_param.shape):
+        raise ValueError(
+            f"{weight_name} local shard has shape {tuple(local_weight.shape)}, "
+            f"expected {tuple(weight_param.shape)}."
+        )
+    weight_param.data.copy_(local_weight.to(weight_param.device))
+    return True
+
+
 def _mimo_v2_copy_paired_qkv_fp8(
     *,
     config,
@@ -222,7 +316,7 @@ def _mimo_v2_copy_paired_qkv_fp8(
     # Detect ckpt_tp from scale shape; weight shape alone is degenerate.
     ckpt_tp = None
     q_heads_per_ckpt_rank = None
-    ckpt_q_rows = ckpt_k_rows = ckpt_v_rows = 0
+    ckpt_q_rows = ckpt_k_rows = 0
     ckpt_chunk_rows = ckpt_chunk_scale_rows = 0
     for candidate in range(min(num_heads, num_kv_heads), 0, -1):
         if num_heads % candidate != 0 or num_kv_heads % candidate != 0:
@@ -242,7 +336,6 @@ def _mimo_v2_copy_paired_qkv_fp8(
             q_heads_per_ckpt_rank = cand_q_heads
             ckpt_q_rows = cand_q_rows
             ckpt_k_rows = cand_k_rows
-            ckpt_v_rows = cand_v_rows
             ckpt_chunk_rows = cand_chunk_rows
             ckpt_chunk_scale_rows = cand_chunk_scale_rows
             break
@@ -319,9 +412,10 @@ def _mimo_v2_copy_paired_qkv_fp8(
                         kv_head_end, ckpt_head_start + kv_heads_per_ckpt_rank
                     )
                     part_rows = (part_head_end - next_kv_head) * per_head_rows
-                    part_start = intra_chunk_offset + (
-                        next_kv_head - ckpt_head_start
-                    ) * per_head_rows
+                    part_start = (
+                        intra_chunk_offset
+                        + (next_kv_head - ckpt_head_start) * per_head_rows
+                    )
                     parts.append(dequant_ckpt_shard(ckpt_rank, part_start, part_rows))
                     next_kv_head = part_head_end
                 return parts
@@ -1016,10 +1110,29 @@ class MiMoV2Model(nn.Module):
                 if not has_paired_qkv:
                     if name in params_dict:
                         param = params_dict[name]
-                        weight_loader = getattr(
-                            param, "weight_loader", default_weight_loader
+                        # Detect pre-sharded BF16 layout first. This applies
+                        # when the source's fused QKV is the row-wise concat
+                        # of per-ckpt-TP chunks (e.g. after Quark dequantizes
+                        # the source FP8 to BF16 in --file2file_quantization).
+                        # Vllm's QKVParallelLinear loader assumes canonical
+                        # [Q_global,K,V] and would incorrectly slice the pre-sharded
+                        # tensor; reassemble per-rank Q/K/V from ckpt chunks.
+                        handled = (
+                            qkv_kind == "weight"
+                            and _mimo_v2_copy_presharded_qkv_bf16(
+                                config=self.config,
+                                weight_name=name,
+                                weight_param=param,
+                                loaded_weight=loaded_weight,
+                                tp_rank=tp_rank,
+                                tp_size=tp_size,
+                            )
                         )
-                        weight_loader(param, loaded_weight)
+                        if not handled:
+                            weight_loader = getattr(
+                                param, "weight_loader", default_weight_loader
+                            )
+                            weight_loader(param, loaded_weight)
                         loaded_params.add(name)
                     continue
 

--- a/vllm/model_executor/models/mimo_v2_mtp.py
+++ b/vllm/model_executor/models/mimo_v2_mtp.py
@@ -45,7 +45,13 @@ from .interfaces import (
     SupportsMultiModal,
     _require_is_multimodal,
 )
-from .mimo_v2 import MiMoV2Attention, MiMoV2MLP
+from .mimo_v2 import (
+    MiMoV2Attention,
+    MiMoV2MLP,
+    _mimo_v2_copy_paired_qkv_fp8,
+    _mimo_v2_copy_presharded_qkv_bf16,
+    _mimo_v2_qkv_pair_key,
+)
 from .utils import _merge_multimodal_embeddings, maybe_prefix
 
 # MiMo-V2 checkpoints contain multiple MTP layers, but vLLM currently supports
@@ -219,6 +225,7 @@ class MiMoV2MTP(nn.Module):
     def __init__(self, *, vllm_config: VllmConfig, prefix: str = "") -> None:
         super().__init__()
         self.config = vllm_config.model_config.hf_config
+        self.quant_config = vllm_config.quant_config
         self.model = MiMoV2MultiTokenPredictor(
             vllm_config=vllm_config, prefix=maybe_prefix(prefix, "model")
         )
@@ -266,6 +273,7 @@ class MiMoV2MTP(nn.Module):
 
         params_dict = dict(self.named_parameters())
         loaded_params: set[str] = set()
+        qkv_buffers: dict[str, dict[str, torch.Tensor]] = {}
 
         for name, loaded_weight in weights:
             if "rotary_emb.inv_freq" in name:
@@ -279,18 +287,72 @@ class MiMoV2MTP(nn.Module):
             ):
                 continue
 
-            # Support fused qkv_proj checkpoint (Pro format).
-            # The checkpoint is stored pre-sharded for TP=8 as
-            # [Q_rank0, K_rank0, V_rank0, Q_rank1, ...], so splitting along
-            # dim 0 with chunk(tp_size) gives each rank its Q+K+V slice for
-            # both the FP8 weight and the block weight_scale_inv. This matches
-            # how the main model loads the same layout.
-            if "qkv_proj" in name:
-                if name in params_dict:
-                    param = params_dict[name]
-                    loaded_weight = loaded_weight.chunk(tp_size, dim=0)[tp_rank]
-                    default_weight_loader(param, loaded_weight)
-                    loaded_params.add(name)
+            # Pro fused-QKV checkpoint: the FP8 weight is stored pre-sharded
+            # for TP=8 with per-chunk block_n=128 scales, and chunk_rows
+            # (3392 for MiMo-V2.5-Pro) is not a multiple of block_n. A naive
+            # chunk(tp_size) at the block-misaligned boundaries produces wrong
+            # slices. Route through the same paired loader the main model
+            # uses, which pairs weight + weight_scale_inv via the buffer below
+            # and either does a direct copy (when local TP == ckpt TP) or
+            # per-chunk dequant→requant for arbitrary local TP.
+            qkv_pair = _mimo_v2_qkv_pair_key(name)
+            if qkv_pair is not None:
+                qkv_base_name, qkv_kind = qkv_pair
+                weight_name = f"{qkv_base_name}.weight"
+                scale_name = f"{qkv_base_name}.weight_scale_inv"
+                has_paired_qkv = (
+                    weight_name in params_dict
+                    and scale_name in params_dict
+                    and getattr(self.quant_config, "weight_block_size", None)
+                    is not None
+                )
+                if not has_paired_qkv:
+                    if name in params_dict:
+                        param = params_dict[name]
+                        # Detect pre-sharded BF16 layout first. This applies
+                        # whenever the source's fused QKV was originally a
+                        # row-wise concat of per-ckpt-TP chunks (e.g. after
+                        # Quark dequantizes the source FP8 to BF16 in
+                        # --file2file_quantization). Vllm's QKVParallelLinear
+                        # loader assumes a canonical [Q_global,K,V] layout
+                        # and would incorrectly slice the pre-sharded tensor.
+                        handled = (
+                            qkv_kind == "weight"
+                            and _mimo_v2_copy_presharded_qkv_bf16(
+                                config=self.config,
+                                weight_name=name,
+                                weight_param=param,
+                                loaded_weight=loaded_weight,
+                                tp_rank=tp_rank,
+                                tp_size=tp_size,
+                            )
+                        )
+                        if not handled:
+                            weight_loader = getattr(
+                                param, "weight_loader", default_weight_loader
+                            )
+                            weight_loader(param, loaded_weight)
+                        loaded_params.add(name)
+                    continue
+
+                qkv_buffer = qkv_buffers.setdefault(qkv_base_name, {})
+                qkv_buffer[qkv_kind] = loaded_weight
+                if "weight" in qkv_buffer and "scale" in qkv_buffer:
+                    _mimo_v2_copy_paired_qkv_fp8(
+                        config=self.config,
+                        weight_name=weight_name,
+                        scale_name=scale_name,
+                        weight_param=params_dict[weight_name],
+                        scale_param=params_dict[scale_name],
+                        loaded_weight=qkv_buffer["weight"],
+                        loaded_scale=qkv_buffer["scale"],
+                        tp_rank=tp_rank,
+                        tp_size=tp_size,
+                        block_size=self.quant_config.weight_block_size,
+                    )
+                    loaded_params.add(weight_name)
+                    loaded_params.add(scale_name)
+                    del qkv_buffers[qkv_base_name]
                 continue
 
             # gate_proj/up_proj → gate_up_proj stacking (both formats);
@@ -334,6 +396,13 @@ class MiMoV2MTP(nn.Module):
             weight_loader = getattr(param, "weight_loader", default_weight_loader)
             weight_loader(param, loaded_weight)
             loaded_params.add(name)
+
+        if qkv_buffers:
+            missing = ", ".join(sorted(qkv_buffers))
+            raise RuntimeError(
+                "Missing fused-QKV FP8 weight/scale pair for MiMo-V2 MTP "
+                f"checkpoint tensors: {missing}"
+            )
 
         return loaded_params
 


### PR DESCRIPTION

## Purpose

Fix MiMo-V2.5-Pro FP8 checkpoint loading.

`XiaomiMiMo/MiMo-V2.5-Pro` stores the fused QKV projection differently from the base `XiaomiMiMo/MiMo-V2.5` path. The Pro checkpoint uses pre-sharded fused-QKV FP8 tensors laid out as TP8 chunks: `[Q0, K0, V0, Q1, K1, V1, ...]` with matching `weight_scale_inv` rows per chunk. The previous loader treated the tensor as a normal contiguous fused QKV projection, which assigned Q/K/V rows and FP8 scale rows incorrectly. This caused bad generations / nonsensical output even when the model loaded.

This PR adds a Pro-specific fused-QKV FP8 loader that:
- loads Q/K/V weight and `weight_scale_inv` together;
- recognizes the Pro pre-sharded FP8 layout;
- preserves exact TP8 shards;
- dequantizes and requantizes local shards for TP configurations that cut through 128-row FP8 scale blocks, such as TP4;
- keeps unpaired/non-FP8 loading on the existing path and preserves normal contiguous fused-QKV FP8 semantics.

This PR is stacked on #41797, which adds the Triton DiffKV attention backend for `XiaomiMiMo/MiMo-V2.5`. The additional change here fixes the separate `XiaomiMiMo/MiMo-V2.5-Pro` FP8 fused-QKV checkpoint layout issue.

AI assistance was used while preparing and testing this change.

## Test Plan

Wikitext with TP4 produced word perplexity 3.9625637573861043 using max_model_len=1024, tensor_parallel_size=4, quantization=fp8, dtype=bfloat16, kv_cache_dtype=bfloat16, attention_backend=TRITON_ATTN_DIFFKV, enforce_eager=True, and disable_custom_all_reduce=True.

### GSM8K

Tried the following with tp=4 and tp=8

```bash
HIP_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
lm_eval run \
  --model vllm \
  --model_args pretrained=XiaomiMiMo/MiMo-V2.5-Pro,trust_remote_code=True,tensor_parallel_size=8,quantization=fp8,dtype=bfloat16,kv_cache_dtype=bfloat16,max_model_len=4096,gpu_memory_utilization=0.90,attention_backend=TRITON_ATTN_DIFFKV,enforce_eager=True,disable_log_stats=True \
  --tasks gsm8k \
  --num_fewshot 5 \
  --batch_size auto
```

TP=8 on MI355 with the kernel proposed in the 41797 PR:

| Tasks | Version | Filter | n-shot | Metric | Value | Stderr |
-- | -- | -- | -- | -- | -- | --
gsm8k | 3 | flexible-extract | 5 | exact_match | 0.9522365 | 0.0058744
gsm8k | 3 | strict-match | 5 | exact_match | 0.9529947 | 0.0058299

TP=4 on MI355 with the kernel proposed in the 41797 PR:


| Tasks | Version | Filter | n-shot | Metric | Value | Stderr |
-- | -- | -- | -- | -- | -- | --
gsm8k | 3 | flexible-extract | 5 | exact_match | 0.9454132 | 0.0062574
gsm8k | 3 | strict-match | 5 | exact_match | 0.9461713 | 0.0062163

CC @BowenBao 