### PR TITLE
Rewrite worker block tables after SWA eviction

### DIFF
--- a/tests/v1/core/test_scheduler.py
+++ b/tests/v1/core/test_scheduler.py
@@ -41,6 +41,20 @@ from .utils import EOS_TOKEN_ID, create_requests, create_scheduler, mock_kv
 pytestmark = pytest.mark.cpu_test
 
 
+def _empty_model_runner_output(
+    scheduler_output: SchedulerOutput,
+) -> ModelRunnerOutput:
+    req_ids = list(scheduler_output.num_scheduled_tokens)
+    return ModelRunnerOutput(
+        req_ids=req_ids,
+        req_id_to_index={req_id: i for i, req_id in enumerate(req_ids)},
+        sampled_token_ids=[[] for _ in req_ids],
+        logprobs=None,
+        prompt_logprobs_dict={},
+        pooler_output=[],
+    )
+
+
 def test_add_requests():
     scheduler = create_scheduler()
     requests = create_requests(num_requests=10)
@@ -104,6 +118,42 @@ def test_schedule(enable_prefix_caching: bool, prompt_logprobs: int | None):
     assert len(scheduler.running) == len(requests)
     for i, request in enumerate(requests):
         assert scheduler.running[i] == request
+
+
+def test_swa_eviction_sends_block_table_rewrite_for_cached_request():
+    scheduler = create_scheduler(
+        max_num_seqs=1,
+        max_num_batched_tokens=4,
+        max_model_len=12,
+        block_size=2,
+        sliding_window=4,
+    )
+    (request,) = create_requests(
+        num_requests=1,
+        num_tokens=10,
+        max_tokens=1,
+        block_size=2,
+    )
+    scheduler.add_request(request)
+
+    output = scheduler.schedule()
+    scheduler.update_from_output(output, _empty_model_runner_output(output))
+
+    output = scheduler.schedule()
+    assert output.scheduled_cached_reqs.block_table_rewrite_req_ids == set()
+    scheduler.update_from_output(output, _empty_model_runner_output(output))
+
+    output = scheduler.schedule()
+    cached_reqs = output.scheduled_cached_reqs
+
+    assert cached_reqs.req_ids == [request.request_id]
+    assert cached_reqs.block_table_rewrite_req_ids == {request.request_id}
+    # The scheduler must send the whole block table so workers can replace
+    # stale logical slots with null blocks before appending new entries.
+    assert cached_reqs.new_block_ids[0] == scheduler.kv_cache_manager.get_block_ids(
+        request.request_id
+    )
+    assert cached_reqs.new_block_ids[0][0][0] == 0
 
 
 def test_schedule_multimodal_requests():

--- a/tests/v1/core/test_single_type_kv_cache_manager.py
+++ b/tests/v1/core/test_single_type_kv_cache_manager.py
@@ -232,7 +232,7 @@ def test_chunked_local_attention_remove_skipped_blocks():
     block_table = id_to_block_table(original_block_ids)
     manager.req_to_blocks["test"] = block_table
 
-    manager.remove_skipped_blocks("test", 0)
+    assert manager.remove_skipped_blocks("test", 0) is False
     assert_block_id(block_table, original_block_ids)
 
     # For 4th token (0-indexed), token 0-3 is out of the local attention window.
@@ -299,29 +299,29 @@ def test_sliding_window_remove_skipped_blocks():
     # 4 tokens are computed. Only token 0 is out of the sliding window. As
     # block 1000 also contains token 1 that is in the sliding window, block 1000
     # cannot be removed.
-    manager.remove_skipped_blocks("test", 4)
+    assert manager.remove_skipped_blocks("test", 4) is False
     assert_block_id(block_table, original_block_ids)
 
     # 5 tokens are computed. Token 0 & 1 are out of the sliding window.
     # Block 1000 can be removed.
-    manager.remove_skipped_blocks("test", 5)
+    assert manager.remove_skipped_blocks("test", 5) is True
     assert_block_id(block_table, [null_block_id] + original_block_ids[1:])
 
     # 6 tokens are computed. Token 0-2 are out of the sliding window.
     # Cannot remove new block as the block 1001 is still used by token 3.
-    manager.remove_skipped_blocks("test", 6)
+    assert manager.remove_skipped_blocks("test", 6) is False
     assert_block_id(block_table, [null_block_id] + original_block_ids[1:])
 
     # 7 tokens are computed. Token 0-3 are out of the sliding window.
     # Block 1001 can be removed and block 1000 is already removed.
-    manager.remove_skipped_blocks("test", 7)
+    assert manager.remove_skipped_blocks("test", 7) is True
     assert_block_id(block_table, [null_block_id] * 2 + original_block_ids[2:])
 
     # 11 tokens are computed. Token 0-7 are out of the sliding window.
     # Block 1002 & 1003 can be removed now. Block 1003 represents a longer
     # sequence, and is expected to be evicted earlier than 1002, so the order
     # of removed blocks should be [1003, 1002].
-    manager.remove_skipped_blocks("test", 11)
+    assert manager.remove_skipped_blocks("test", 11) is True
     assert_block_id(block_table, [null_block_id] * 4 + original_block_ids[4:])
 
 

--- a/tests/v1/core/utils.py
+++ b/tests/v1/core/utils.py
@@ -6,6 +6,7 @@ import torch
 from tests.v1.kv_connector.unit.utils import MockKVConfig
 from vllm.config import (
     CacheConfig,
+    DeviceConfig,
     ECTransferConfig,
     KVTransferConfig,
     ModelConfig,
@@ -28,6 +29,7 @@ from vllm.v1.kv_cache_interface import (
     FullAttentionSpec,
     KVCacheConfig,
     KVCacheGroupSpec,
+    SlidingWindowSpec,
 )
 from vllm.v1.request import Request
 from vllm.v1.structured_output import StructuredOutputManager
@@ -57,6 +59,7 @@ def create_scheduler(
     pipeline_parallel_size: int = 1,
     use_ec_connector: bool = False,
     ec_role: str | None = None,
+    sliding_window: int | None = None,
 ) -> Scheduler | AsyncScheduler:
     """Create scheduler under test.
 
@@ -140,24 +143,31 @@ def create_scheduler(
         model_config=model_config,
         cache_config=cache_config,
         parallel_config=ParallelConfig(pipeline_parallel_size=pipeline_parallel_size),
+        device_config=DeviceConfig(device="cpu"),
         kv_transfer_config=kv_transfer_config,
         speculative_config=speculative_config,
         ec_transfer_config=ec_transfer_config,
     )
+    kv_cache_spec = (
+        SlidingWindowSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+            sliding_window=sliding_window,
+        )
+        if sliding_window is not None
+        else FullAttentionSpec(
+            block_size=block_size,
+            num_kv_heads=1,
+            head_size=1,
+            dtype=torch.float32,
+        )
+    )
     kv_cache_config = KVCacheConfig(
         num_blocks=num_blocks,  # A large number of blocks to hold all requests
         kv_cache_tensors=[],
-        kv_cache_groups=[
-            KVCacheGroupSpec(
-                ["layer"],
-                FullAttentionSpec(
-                    block_size=block_size,
-                    num_kv_heads=1,
-                    head_size=1,
-                    dtype=torch.float32,
-                ),
-            )
-        ],
+        kv_cache_groups=[KVCacheGroupSpec(["layer"], kv_cache_spec)],
     )
     cache_config.num_gpu_blocks = num_blocks
     scheduler_cls = AsyncScheduler if async_scheduling else Scheduler

--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -248,6 +248,7 @@ def make_scheduler_output(
             new_token_ids=[[] for _ in cached_req_ids],
             all_token_ids={},
             new_block_ids=cached_new_block_ids,
+            block_table_rewrite_req_ids=set(),
             num_computed_tokens=[0] * len(cached_req_ids),
             num_output_tokens=[0] * len(cached_req_ids),
         )

--- a/tests/v1/worker/test_gpu_model_runner.py
+++ b/tests/v1/worker/test_gpu_model_runner.py
@@ -40,7 +40,7 @@ from vllm.v1.kv_cache_interface import (
     KVCacheTensor,
 )
 from vllm.v1.sample.metadata import SamplingMetadata
-from vllm.v1.worker.gpu_input_batch import InputBatch
+from vllm.v1.worker.gpu_input_batch import CachedRequestState, InputBatch
 from vllm.v1.worker.gpu_model_runner import GPUModelRunner
 from vllm.v1.worker.utils import AttentionGroup, select_common_block_size
 
@@ -178,6 +178,7 @@ def _schedule_cached_requests(
             new_token_ids=new_token_ids,
             all_token_ids={},
             new_block_ids=[None] * len(req_ids),
+            block_table_rewrite_req_ids=set(),
             num_computed_tokens=num_computed_tokens,
             num_output_tokens=num_output_tokens,
         ),
@@ -386,6 +387,7 @@ def test_update_states_request_resumed(model_runner, dist_init):
         new_token_ids=[[]],
         all_token_ids={},
         new_block_ids=[([0],)],
+        block_table_rewrite_req_ids=set(),
         num_computed_tokens=[0],
         num_output_tokens=[0],
     )
@@ -408,6 +410,81 @@ def test_update_states_request_resumed(model_runner, dist_init):
     assert _is_req_added(model_runner, req_id)
     assert _is_req_scheduled(model_runner, req_id)
     assert _is_req_state_block_table_match(model_runner, req_id)
+
+
+def test_update_states_rewrites_cached_block_table(monkeypatch):
+    req_id = "req_0"
+    req_state = CachedRequestState(
+        req_id=req_id,
+        prompt_token_ids=[1, 2, 3],
+        mm_features=[],
+        sampling_params=SamplingParams(),
+        generator=None,
+        block_ids=([1, 2, 3],),
+        num_computed_tokens=3,
+        output_token_ids=[],
+    )
+
+    runner = object.__new__(GPUModelRunner)
+    runner.requests = {req_id: req_state}
+    runner.num_prompt_logprobs = {}
+    runner.late_interaction_runner = SimpleNamespace(
+        on_requests_finished=lambda req_ids: None
+    )
+    runner.input_batch = InputBatch(
+        max_num_reqs=1,
+        max_model_len=16,
+        max_num_batched_tokens=4,
+        device=torch.device("cpu"),
+        pin_memory=False,
+        vocab_size=1024,
+        block_sizes=[BLOCK_SIZE],
+        kernel_block_sizes=[BLOCK_SIZE],
+    )
+    runner.input_batch.add_request(req_state)
+    runner.routed_experts_initialized = False
+    runner.encoder_cache = {}
+    runner.speculative_config = None
+    runner.use_async_spec_decode = False
+    runner._may_reorder_batch = lambda scheduler_output: None
+
+    monkeypatch.setattr(
+        gpu_model_runner_module,
+        "get_pp_group",
+        lambda: SimpleNamespace(is_last_rank=True),
+    )
+
+    rewritten_block_ids = ([0, 2, 3, 4],)
+    scheduler_output = SchedulerOutput(
+        scheduled_new_reqs=[],
+        scheduled_cached_reqs=CachedRequestData(
+            req_ids=[req_id],
+            resumed_req_ids=set(),
+            new_token_ids=[[]],
+            all_token_ids={},
+            new_block_ids=[rewritten_block_ids],
+            block_table_rewrite_req_ids={req_id},
+            num_computed_tokens=[4],
+            num_output_tokens=[0],
+        ),
+        num_scheduled_tokens={req_id: 1},
+        total_num_scheduled_tokens=1,
+        scheduled_spec_decode_tokens={},
+        scheduled_encoder_inputs={},
+        num_common_prefix_blocks=[],
+        finished_req_ids=set(),
+        free_encoder_mm_hashes=[],
+    )
+    runner._update_states(scheduler_output)
+
+    req_index = runner.input_batch.req_id_to_index[req_id]
+    block_table = runner.input_batch.block_table[0]
+    row_len = block_table.num_blocks_per_row[req_index]
+    assert row_len == len(rewritten_block_ids[0])
+    assert block_table.block_table.np[req_index, :row_len].tolist() == list(
+        rewritten_block_ids[0]
+    )
+    assert runner.requests[req_id].block_ids == rewritten_block_ids
 
 
 def test_get_nans_in_logits(model_runner, dist_init):

--- a/vllm/v1/core/kv_cache_coordinator.py
+++ b/vllm/v1/core/kv_cache_coordinator.py
@@ -237,7 +237,7 @@ class KVCacheCoordinator(ABC):
 
     def remove_skipped_blocks(
         self, request_id: str, total_computed_tokens: int
-    ) -> None:
+    ) -> bool:
         """
         Remove the blocks that are no longer needed from `blocks` and replace
         the removed blocks with null_block.
@@ -247,8 +247,12 @@ class KVCacheCoordinator(ABC):
             total_computed_tokens: The total number of computed tokens, including
                 local computed tokens and external computed tokens.
         """
+        block_table_updated = False
         for manager in self.single_type_managers:
-            manager.remove_skipped_blocks(request_id, total_computed_tokens)
+            block_table_updated |= manager.remove_skipped_blocks(
+                request_id, total_computed_tokens
+            )
+        return block_table_updated
 
     def get_blocks(self, request_id: str) -> tuple[list[KVCacheBlock], ...]:
         """

--- a/vllm/v1/core/kv_cache_manager.py
+++ b/vllm/v1/core/kv_cache_manager.py
@@ -158,6 +158,8 @@ class KVCacheManager:
         self.empty_kv_cache_blocks = KVCacheBlocks(
             tuple(() for _ in range(self.num_kv_cache_groups))
         )
+        # Requests whose CPU block table was rewritten and must be resent.
+        self._block_table_update_req_ids: set[str] = set()
 
     @property
     def usage(self) -> float:
@@ -359,9 +361,11 @@ class KVCacheManager:
         # insufficient free blocks.
         # Should call this function before allocating new blocks to reduce
         # the number of evicted blocks.
-        self.coordinator.remove_skipped_blocks(
+        block_table_updated = self.coordinator.remove_skipped_blocks(
             request.request_id, total_computed_tokens
         )
+        if block_table_updated:
+            self._block_table_update_req_ids.add(request.request_id)
 
         num_blocks_to_allocate = self.coordinator.get_num_blocks_to_allocate(
             request_id=request.request_id,
@@ -423,11 +427,12 @@ class KVCacheManager:
         Args:
             request: The request to free the blocks.
         """
+        self._block_table_update_req_ids.discard(request.request_id)
         self.coordinator.free(request.request_id)
 
     def remove_skipped_blocks(
         self, request_id: str, total_computed_tokens: int
-    ) -> None:
+    ) -> bool:
         """Remove the blocks that are no longer needed from `blocks` and replace
         the removed blocks with null_block.
 
@@ -436,7 +441,18 @@ class KVCacheManager:
             total_computed_tokens: The total number of computed tokens, including
                 local computed tokens and external computed tokens.
         """
-        self.coordinator.remove_skipped_blocks(request_id, total_computed_tokens)
+        block_table_updated = self.coordinator.remove_skipped_blocks(
+            request_id, total_computed_tokens
+        )
+        if block_table_updated:
+            self._block_table_update_req_ids.add(request_id)
+        return block_table_updated
+
+    def block_table_updated(self, request_id: str) -> bool:
+        return request_id in self._block_table_update_req_ids
+
+    def clear_block_table_updated(self, request_id: str) -> None:
+        self._block_table_update_req_ids.discard(request_id)
 
     def evict_blocks(self, block_ids: set[int]) -> None:
         """evict blocks from the prefix cache by their block IDs.

--- a/vllm/v1/core/sched/output.py
+++ b/vllm/v1/core/sched/output.py
@@ -122,6 +122,9 @@ class CachedRequestData:
     # connector. Won't contain requests that were scheduled in the prior step.
     all_token_ids: dict[str, list[int]]
     new_block_ids: list[tuple[list[int], ...] | None]
+    # Request ids whose block table entries must replace the worker row rather
+    # than append. SWA eviction can rewrite earlier logical slots to null_block.
+    block_table_rewrite_req_ids: set[str]
     num_computed_tokens: list[int]
     num_output_tokens: list[int]
 
@@ -138,6 +141,7 @@ class CachedRequestData:
             f"new_token_ids_lens={new_token_ids_lens},"
             f"all_token_ids_lens={all_token_ids_lens},"
             f"new_block_ids={self.new_block_ids},"
+            f"block_table_rewrite_req_ids={self.block_table_rewrite_req_ids},"
             f"num_computed_tokens={self.num_computed_tokens},"
             f"num_output_tokens={self.num_output_tokens}"
             f")"
@@ -172,6 +176,7 @@ class CachedRequestData:
             new_token_ids=[],
             all_token_ids={},
             new_block_ids=[],
+            block_table_rewrite_req_ids=set(),
             num_computed_tokens=[],
             num_output_tokens=[],
         )

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -325,6 +325,7 @@ class Scheduler(SchedulerInterface):
         preempted_reqs: list[Request] = []
 
         req_to_new_blocks: dict[str, KVCacheBlocks] = {}
+        block_table_rewrite_req_ids: set[str] = set()
         num_scheduled_tokens: dict[str, int] = {}
         token_budget = self.max_num_scheduled_tokens
         if self._pause_state == PauseState.PAUSED_ALL:
@@ -445,6 +446,7 @@ class Scheduler(SchedulerInterface):
                             scheduled_running_reqs.remove(preempted_req)
                             token_budget += num_scheduled_tokens.pop(preempted_req_id)
                             req_to_new_blocks.pop(preempted_req_id)
+                            block_table_rewrite_req_ids.discard(preempted_req_id)
                             scheduled_spec_decode_tokens.pop(preempted_req_id, None)
                             preempted_encoder_inputs = scheduled_encoder_inputs.pop(
                                 preempted_req_id, None
@@ -474,7 +476,15 @@ class Scheduler(SchedulerInterface):
             # Schedule the request.
             scheduled_running_reqs.append(request)
             request_id = request.request_id
-            req_to_new_blocks[request_id] = new_blocks
+            if self.kv_cache_manager.block_table_updated(request_id):
+                # SWA eviction rewrites older logical slots to null blocks.
+                req_to_new_blocks[request_id] = self.kv_cache_manager.get_blocks(
+                    request_id
+                )
+                block_table_rewrite_req_ids.add(request_id)
+                self.kv_cache_manager.clear_block_table_updated(request_id)
+            else:
+                req_to_new_blocks[request_id] = new_blocks
             num_scheduled_tokens[request_id] = num_new_tokens
             token_budget -= num_new_tokens
             req_index += 1
@@ -853,6 +863,7 @@ class Scheduler(SchedulerInterface):
                 num_scheduled_tokens,
                 scheduled_spec_decode_tokens,
                 req_to_new_blocks,
+                block_table_rewrite_req_ids,
             )
 
         # Record the request ids that were scheduled in this step.
@@ -1005,6 +1016,7 @@ class Scheduler(SchedulerInterface):
         num_scheduled_tokens: dict[str, int],
         spec_decode_tokens: dict[str, list[int]],
         req_to_new_blocks: dict[str, KVCacheBlocks],
+        block_table_rewrite_req_ids: set[str],
     ) -> CachedRequestData:
         req_ids: list[str] = []
         new_token_ids: list[list[int]] = []
@@ -1054,6 +1066,7 @@ class Scheduler(SchedulerInterface):
             new_token_ids=new_token_ids,
             all_token_ids=all_token_ids,
             new_block_ids=new_block_ids,
+            block_table_rewrite_req_ids=block_table_rewrite_req_ids,
             num_computed_tokens=num_computed_tokens,
             num_output_tokens=num_output_tokens,
         )

--- a/vllm/v1/core/single_type_kv_cache_manager.py
+++ b/vllm/v1/core/single_type_kv_cache_manager.py
@@ -384,7 +384,7 @@ class SingleTypeKVCacheManager(ABC):
 
     def remove_skipped_blocks(
         self, request_id: str, total_computed_tokens: int
-    ) -> None:
+    ) -> bool:
         """
         Remove and free the blocks that are no longer needed for attention computation.
         The removed blocks should be replaced by null_block.
@@ -404,7 +404,7 @@ class SingleTypeKVCacheManager(ABC):
             # Thus we do not need to free any blocks outside attention window.
             # A typical case is full attention that we never free any token
             # before the request is finished.
-            return
+            return False
         blocks = self.req_to_blocks[request_id]
         num_skipped_blocks = num_skipped_tokens // self.block_size
         # `num_skipped_tokens` may include tokens that haven't been allocated yet
@@ -424,6 +424,7 @@ class SingleTypeKVCacheManager(ABC):
             removed_blocks.append(blocks[i])
             blocks[i] = self._null_block
         self.block_pool.free_blocks(removed_blocks)
+        return bool(removed_blocks)
 
     def get_num_skipped_tokens(self, num_computed_tokens: int) -> int:
         """
@@ -854,7 +855,7 @@ class MambaManager(SingleTypeKVCacheManager):
 
         return computed_blocks
 
-    def remove_skipped_blocks(self, request_id: str, num_computed_tokens: int) -> None:
+    def remove_skipped_blocks(self, request_id: str, num_computed_tokens: int) -> bool:
         assert isinstance(self.kv_cache_spec, MambaSpec)
 
         # NOTE (tdoublep) with async scheduling, the num_computed_tokens can contain
@@ -864,7 +865,7 @@ class MambaManager(SingleTypeKVCacheManager):
         # that we might actually need.
         num_computed_tokens = max(0, num_computed_tokens - self.num_speculative_blocks)
 
-        super().remove_skipped_blocks(request_id, num_computed_tokens)
+        removed_blocks = super().remove_skipped_blocks(request_id, num_computed_tokens)
         if self.mamba_cache_mode == "align":
             # `last_state_block_idx` refers to the block index allocated two steps ago.
             # The block allocated in the previous step is used to copy Mamba states
@@ -883,6 +884,8 @@ class MambaManager(SingleTypeKVCacheManager):
                 if blocks[last_state_block_idx] != self._null_block:
                     self.block_pool.free_blocks([blocks[last_state_block_idx]])
                     blocks[last_state_block_idx] = self._null_block
+                    removed_blocks = True
+        return removed_blocks
 
     def get_num_common_prefix_blocks(self, running_request_id: str) -> int:
         """

--- a/vllm/v1/worker/gpu/model_runner.py
+++ b/vllm/v1/worker/gpu/model_runner.py
@@ -718,7 +718,9 @@ class GPUModelRunner(LoRAModelRunnerMixin):
             if req_new_block_ids is not None:
                 req_index = self.req_states.req_id_to_index[req_id]
                 self.block_tables.append_block_ids(
-                    req_index, req_new_block_ids, overwrite=False
+                    req_index,
+                    req_new_block_ids,
+                    overwrite=req_id in reqs.block_table_rewrite_req_ids,
                 )
 
     def prepare_inputs(

--- a/vllm/v1/worker/gpu_model_runner.py
+++ b/vllm/v1/worker/gpu_model_runner.py
@@ -1238,6 +1238,7 @@ class GPUModelRunner(
             num_computed_tokens = req_data.num_computed_tokens[i]
             new_block_ids = req_data.new_block_ids[i]
             resumed_from_preemption = req_id in req_data.resumed_req_ids
+            rewrite_block_table = req_id in req_data.block_table_rewrite_req_ids
             num_output_tokens = req_data.num_output_tokens[i]
             req_index = self.input_batch.req_id_to_index.get(req_id)
 
@@ -1322,9 +1323,14 @@ class GPUModelRunner(
             # Update the block IDs.
             if not resumed_from_preemption:
                 if new_block_ids is not None:
-                    # Append the new blocks to the existing block IDs.
-                    for block_ids, new_ids in zip(req_state.block_ids, new_block_ids):
-                        block_ids.extend(new_ids)
+                    if rewrite_block_table:
+                        req_state.block_ids = new_block_ids
+                    else:
+                        # Append the new blocks to the existing block IDs.
+                        for block_ids, new_ids in zip(
+                            req_state.block_ids, new_block_ids
+                        ):
+                            block_ids.extend(new_ids)
             else:
                 assert req_index is None
                 assert new_block_ids is not None
@@ -1352,7 +1358,10 @@ class GPUModelRunner(
             # Update the persistent batch.
             self.input_batch.num_computed_tokens_cpu[req_index] = num_computed_tokens
             if new_block_ids is not None:
-                self.input_batch.block_table.append_row(new_block_ids, req_index)
+                if rewrite_block_table:
+                    self.input_batch.block_table.add_row(new_block_ids, req_index)
+                else:
+                    self.input_batch.block_table.append_row(new_block_ids, req_index)
 
             # For the last rank, we don't need to update the token_ids_cpu
             # because the sampled tokens are already cached.


### PR DESCRIPTION
Fixes #42273

Summary:
- Track requests whose CPU-side block tables are rewritten by SWA skipped-block removal.
- Have the scheduler send the full rewritten block table for those cached requests instead of only incremental new blocks.
- Update both worker block-table paths to overwrite rows when a rewrite is requested.
- Add scheduler/core/worker regressions for SWA eviction and block-table replacement.


Tests:
- `.venv/bin/python -m pytest tests/v1/core/test_scheduler.py::test_schedule tests/v1/core/test_scheduler.py::test_swa_eviction_sends_block_table_rewrite_for_cached_request tests/v1/core/test_single_type_kv_cache_manager.py tests/v1/simple_kv_offload/test_scheduler.py::test_eager_store_and_load_roundtrip tests/v1/worker/test_gpu_model_runner.py::test_update_states_rewrites_cached_block_table -v` (13 passed)
- `.venv/bin/python -m ruff check vllm/v1/core/kv_cache_coordinator.py vllm/v1/core/kv_cache_manager.py vllm/v1/core/sched/output.py vllm/v1/core/sched/scheduler.py vllm/v1/core/single_type_kv_cache_manager.py vllm/v1/worker/gpu/model_runner.py vllm/v1/worker/gpu_model_runner.py tests/v1/core/test_scheduler.py tests/v1/core/test_single_type_kv_cache_manager.py tests/v1/core/utils.py tests/v1/simple_kv_offload/test_scheduler.py tests/v1/worker/test_gpu_model_runner.py` (passed)

