### PR TITLE
[Performance] Optimize FlatLogprobs tail slices

### DIFF
--- a/benchmarks/overheads/benchmark_flat_logprobs_slice.py
+++ b/benchmarks/overheads/benchmark_flat_logprobs_slice.py
@@ -1,0 +1,232 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+from __future__ import annotations
+
+import argparse
+import gc
+import time
+from collections.abc import Callable
+
+from vllm.logprobs import FlatLogprobs, Logprob
+
+
+def make_flat_logprobs(num_positions: int, num_logprobs: int) -> FlatLogprobs:
+    flat = FlatLogprobs()
+    for pos in range(num_positions):
+        start = len(flat.logprobs)
+        count = num_logprobs + 1
+        flat.start_indices.append(start)
+        flat.end_indices.append(start + count)
+        flat.token_ids.extend(pos * 1000 + i for i in range(count))
+        flat.logprobs.extend(-(i + 1.0) for i in range(count))
+        flat.ranks.extend([0] + list(range(1, count)))
+        flat.decoded_tokens.extend(f"tok-{pos}-{i}" for i in range(count))
+    return flat
+
+
+def old_slice(flat: FlatLogprobs, index: slice) -> FlatLogprobs:
+    min_index = flat.start_indices[index][0]
+    max_index = flat.end_indices[index][-1]
+    return FlatLogprobs(
+        start_indices=[i - min_index for i in flat.start_indices[index]],
+        end_indices=[i - min_index for i in flat.end_indices[index]],
+        token_ids=flat.token_ids[min_index:max_index],
+        logprobs=flat.logprobs[min_index:max_index],
+        ranks=flat.ranks[min_index:max_index],
+        decoded_tokens=flat.decoded_tokens[min_index:max_index],
+    )
+
+
+def old_getitem(flat: FlatLogprobs, index: int | slice):
+    if isinstance(index, int):
+        return {
+            flat.token_ids[i]: Logprob(
+                logprob=flat.logprobs[i],
+                rank=flat.ranks[i],
+                decoded_token=flat.decoded_tokens[i],
+            )
+            for i in range(flat.start_indices[index], flat.end_indices[index])
+        }
+    if isinstance(index, slice):
+        return old_slice(flat, index)
+    raise TypeError(f"Invalid index type: {type(index)}")
+
+
+def assert_equal(left: FlatLogprobs, right: FlatLogprobs) -> None:
+    assert left.start_indices == right.start_indices
+    assert left.end_indices == right.end_indices
+    assert left.token_ids == right.token_ids
+    assert left.logprobs == right.logprobs
+    assert left.ranks == right.ranks
+    assert left.decoded_tokens == right.decoded_tokens
+
+
+def assert_correctness(flat: FlatLogprobs) -> None:
+    cases = [
+        slice(-1, None),
+        slice(-5, None),
+        slice(1, None),
+        slice(None, None),
+        slice(2, 20, 2),
+        slice(None, None, -1),
+    ]
+    for index in cases:
+        assert_equal(old_slice(flat, index), flat[index])
+
+    for index in (slice(0, 0), slice(len(flat), len(flat))):
+        old_error = None
+        new_error = None
+        try:
+            old_slice(flat, index)
+        except Exception as exc:
+            old_error = type(exc)
+        try:
+            flat[index]
+        except Exception as exc:
+            new_error = type(exc)
+        assert old_error is new_error
+
+    old_error = None
+    new_error = None
+    empty = FlatLogprobs()
+    try:
+        old_slice(empty, slice(-1, None))
+    except Exception as exc:
+        old_error = type(exc)
+    try:
+        empty[-1:]
+    except Exception as exc:
+        new_error = type(exc)
+    assert old_error is new_error
+
+
+def measure(fn: Callable[[], object], repeats: int, trials: int) -> float:
+    for _ in range(min(repeats, 1000)):
+        fn()
+
+    timings: list[float] = []
+    was_enabled = gc.isenabled()
+    gc.disable()
+    try:
+        for _ in range(trials):
+            start = time.perf_counter()
+            for _ in range(repeats):
+                fn()
+            timings.append((time.perf_counter() - start) * 1e6 / repeats)
+    finally:
+        if was_enabled:
+            gc.enable()
+    return min(timings)
+
+
+def bench_pair(
+    old_fn: Callable[[], object],
+    new_fn: Callable[[], object],
+    repeats: int,
+    trials: int,
+) -> tuple[float, float]:
+    return (
+        measure(old_fn, repeats, trials),
+        measure(new_fn, repeats, trials),
+    )
+
+
+def bench_case(
+    flat: FlatLogprobs,
+    index: slice,
+    repeats: int,
+    trials: int,
+) -> tuple[float, float]:
+    return bench_pair(
+        lambda: old_getitem(flat, index),
+        lambda: flat[index],
+        repeats,
+        trials,
+    )
+
+
+def old_delta_logprobs(logprobs: FlatLogprobs, token_ids: list[int]):
+    return old_getitem(logprobs, slice(-len(token_ids), None))
+
+
+def new_delta_logprobs(logprobs: FlatLogprobs, token_ids: list[int]):
+    return logprobs[-len(token_ids) :]
+
+
+def bench_delta_selector(
+    logprobs: FlatLogprobs,
+    token_ids: list[int],
+    repeats: int,
+    trials: int,
+) -> tuple[float, float]:
+    old_result = old_delta_logprobs(logprobs, token_ids)
+    new_result = new_delta_logprobs(logprobs, token_ids)
+    assert isinstance(old_result, FlatLogprobs)
+    assert isinstance(new_result, FlatLogprobs)
+    assert_equal(old_result, new_result)
+
+    return bench_pair(
+        lambda: old_delta_logprobs(logprobs, token_ids),
+        lambda: new_delta_logprobs(logprobs, token_ids),
+        repeats,
+        trials,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--positions", type=int, default=2000)
+    parser.add_argument("--num-logprobs", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=20000)
+    parser.add_argument("--trials", type=int, default=7)
+    parser.add_argument("--include-broad-slices", action="store_true")
+    args = parser.parse_args()
+
+    flat = make_flat_logprobs(args.positions, args.num_logprobs)
+    assert_correctness(flat)
+
+    scenarios = [
+        ("last_5", slice(-5, None)),
+        ("last_20", slice(-20, None)),
+    ]
+    if args.include_broad_slices:
+        scenarios.extend(
+            [
+                ("prompt_tail", slice(1, None)),
+                ("full", slice(None, None)),
+                ("step_2", slice(2, 200, 2)),
+            ]
+        )
+
+    print("correctness: old and new FlatLogprobs slices match")
+    print(f"timing: best of {args.trials} trials, {args.repeats} repeats each")
+    print("case         old_us  new_us  speedup")
+    print("-----------  ------  ------  -------")
+    old_us, new_us = bench_case(flat, slice(-1, None), args.repeats, args.trials)
+    print(f"{'last_1':11s}  {old_us:6.2f}  {new_us:6.2f}  "
+          f"{old_us / new_us:7.2f}x")
+    for name, index in scenarios:
+        old_us, new_us = bench_case(flat, index, args.repeats, args.trials)
+        print(f"{name:11s}  {old_us:6.2f}  {new_us:6.2f}  "
+              f"{old_us / new_us:7.2f}x")
+
+    selector_scenarios = [
+        ("flat_1", flat, [1]),
+        ("flat_5", flat, [1, 2, 3, 4, 5]),
+    ]
+
+    print()
+    print("flat delta selection")
+    print("case         old_us  new_us  speedup")
+    print("-----------  ------  ------  -------")
+    for name, logprobs, token_ids in selector_scenarios:
+        old_us, new_us = bench_delta_selector(
+            logprobs, token_ids, args.repeats, args.trials
+        )
+        print(f"{name:11s}  {old_us:6.2f}  {new_us:6.2f}  "
+              f"{old_us / new_us:7.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_logprobs.py
+++ b/tests/test_logprobs.py
@@ -208,3 +208,25 @@ def test_flat_logprobs_access() -> None:
     assert logprobs_last2.logprobs == [0.4, 0.5, 0.6, 0.1]
     assert logprobs_last2.ranks == [40, 50, 60, 10]
     assert logprobs_last2.decoded_tokens == ["40", "50", "60", "10"]
+
+    logprobs_last1 = logprobs[-1:]
+    assert len(logprobs_last1) == 1
+    assert logprobs_last1[0] == LOGPROBS_ONE_POSITION_0
+    assert logprobs_last1.start_indices == [0]
+    assert logprobs_last1.end_indices == [1]
+    assert logprobs_last1.token_ids == [1]
+    assert logprobs_last1.logprobs == [0.1]
+    assert logprobs_last1.ranks == [10]
+    assert logprobs_last1.decoded_tokens == ["10"]
+
+    empty_logprobs = FlatLogprobs()
+    empty_logprobs.append(None)
+    empty_logprobs_last1 = empty_logprobs[-1:]
+    assert len(empty_logprobs_last1) == 1
+    assert empty_logprobs_last1[0] == {}
+    assert empty_logprobs_last1.start_indices == [0]
+    assert empty_logprobs_last1.end_indices == [0]
+    assert empty_logprobs_last1.token_ids == []
+    assert empty_logprobs_last1.logprobs == []
+    assert empty_logprobs_last1.ranks == []
+    assert empty_logprobs_last1.decoded_tokens == []

--- a/vllm/logprobs.py
+++ b/vllm/logprobs.py
@@ -119,13 +119,27 @@ class FlatLogprobs(MutableSequence[LogprobsOnePosition | None]):
                 for i in range(self.start_indices[index], self.end_indices[index])
             }
         elif isinstance(index, slice):
-            min_index = self.start_indices[index][0]
-            max_index = self.end_indices[index][-1]
+            if index.start == -1 and index.stop is None and index.step is None:
+                min_index = self.start_indices[-1]
+                max_index = self.end_indices[-1]
+                return FlatLogprobs(
+                    start_indices=[0],
+                    end_indices=[max_index - min_index],
+                    token_ids=self.token_ids[min_index:max_index],
+                    logprobs=self.logprobs[min_index:max_index],
+                    ranks=self.ranks[min_index:max_index],
+                    decoded_tokens=self.decoded_tokens[min_index:max_index],
+                )
+
+            start_indices = self.start_indices[index]
+            end_indices = self.end_indices[index]
+            min_index = start_indices[0]
+            max_index = end_indices[-1]
             return FlatLogprobs(
                 # Shift updated start_indices and end_indices to
                 # be 0-indexed
-                start_indices=[i - min_index for i in self.start_indices[index]],
-                end_indices=[i - min_index for i in self.end_indices[index]],
+                start_indices=[i - min_index for i in start_indices],
+                end_indices=[i - min_index for i in end_indices],
                 token_ids=self.token_ids[min_index:max_index],
                 logprobs=self.logprobs[min_index:max_index],
                 ranks=self.ranks[min_index:max_index],


### PR DESCRIPTION
## Summary
- Add a fast path for `FlatLogprobs[-1:]`, which is used by DELTA logprobs output when one token is emitted.
- Reuse sliced `start_indices` / `end_indices` in the generic slice path instead of slicing those lists repeatedly.
- Add focused unit coverage for the optimized non-empty and empty-last-position cases.
- Add a synthetic overhead benchmark so the slice and DELTA selection speedup can be reproduced without model downloads.

## Benchmark
Command:

```bash
PYTHONPATH=. python benchmarks/overheads/benchmark_flat_logprobs_slice.py --positions 2000 --num-logprobs 5 --repeats 50000 --trials 7
```

Local Windows CPython 3.11 result:

```text
correctness: old and new FlatLogprobs slices match
timing: best of 7 trials, 50000 repeats each
case         old_us  new_us  speedup
-----------  ------  ------  -------
last_1         1.89    1.34     1.41x
last_5         2.38    2.31     1.03x
last_20        4.55    4.47     1.02x

flat delta selection
case         old_us  new_us  speedup
-----------  ------  ------  -------
flat_1         2.07    1.61     1.29x
flat_5         2.79    2.58     1.08x
```

## Test plan
- `python -m py_compile vllm/logprobs.py tests/test_logprobs.py benchmarks/overheads/benchmark_flat_logprobs_slice.py`
- `PYTHONPATH=. HF_HUB_OFFLINE=1 python -m pytest --noconftest tests/test_logprobs.py -q` (`7 passed`)
- `PYTHONPATH=.test-shims HF_HUB_OFFLINE=1 python -m pytest --confcutdir=tests/v1/engine tests/v1/engine/test_output_processor.py::test_logprobs_processor -v` (`8 passed`)
- Benchmark command above, which also checks old/new slice correctness across tail, full, stepped, reverse, empty, and empty-container cases.

Disclosure: this PR was prepared with AI assistance from OpenAI Codex.