### PR TITLE
[Bugfix][KV Connector] Fix SimpleCPUOffloadScheduler TOCTOU between Phase A and Phase B

### DIFF
--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -753,111 +753,6 @@ def test_touched_blocks_survive_eviction() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Test 4b: TOCTOU between Phase A and Phase B (regression for #39702)
-# ---------------------------------------------------------------------------
-def test_toctou_cpu_hit_evicted_between_phases_no_crash() -> None:
-    """Regression for vllm-project/vllm#39702.
-
-    When ``get_num_new_matched_tokens`` (Phase A) reports a CPU cache hit
-    of ``N`` tokens but ``update_state_after_alloc`` (Phase B) runs after
-    other requests have caused LRU eviction of those exact blocks, the
-    second ``find_longest_cache_hit`` call returns 0 while
-    ``num_external_tokens`` is still ``N``, triggering
-    ``AssertionError: Expected N hit tokens, got 0``.
-
-    Setup: ``num_cpu_blocks=5`` (4 usable; null_block takes 1).
-        1. Store req_a's 2 blocks to CPU. CPU: [a0, a1, _, _].
-        2. Phase A on req_b (same prompt as req_a) reports a 2-block hit.
-           Without the fix this does NOT pin a0/a1 — they remain at LRU front.
-        3. Store req_c (2) + req_d (2) — 4 more blocks into 4 slots. With
-           a0/a1 unpinned and at LRU front, they get evicted. CPU: [c0, c1,
-           d0, d1].
-        4. Phase B on req_b: re-searches the CPU coordinator, finds 0
-           cached hashes, asserts.
-
-    After the fix, Phase A pins the hit blocks so step 3 evicts req_c's
-    blocks instead, and Phase B reads the cached ``(cpu_hit_blocks,
-    hit_length)`` tuple without re-searching.
-    """
-    # 5 total = 4 usable (null_block takes 1)
-    fix = make_scheduler(num_cpu_blocks=5, num_gpu_blocks=16, lazy=False)
-    sched = fix.scheduler
-
-    # --- Step 1: Store req_a's 2 blocks to CPU cache ---
-    req_a = make_request(num_blocks=2)
-    kv_a = _alloc_and_register(fix, req_a, 2)
-    sched.update_state_after_alloc(req_a, kv_a, num_external_tokens=0)
-    sched_out_a = make_scheduler_output(
-        {req_a.request_id: 2 * BLOCK_SIZE},
-        new_reqs={req_a.request_id: kv_a.get_block_ids()},
-    )
-    meta_a = sched.build_connector_meta(sched_out_a)
-    assert meta_a.store_event >= 0
-    simulate_store_completion(sched, meta_a.store_event)
-
-    # --- Step 2: Phase A — req_b (same prompt as req_a) reports a CPU hit ---
-    req_b = Request(
-        request_id="req-b-toctou",
-        prompt_token_ids=req_a.prompt_token_ids,
-        sampling_params=req_a.sampling_params,
-        pooling_params=None,
-        mm_features=None,
-        block_hasher=req_a._block_hasher,
-    )
-    hit_tokens, is_async = sched.get_num_new_matched_tokens(
-        req_b, num_computed_tokens=0
-    )
-    assert hit_tokens == 2 * BLOCK_SIZE, (
-        f"Phase A should report 2 blocks of CPU hit, got {hit_tokens}"
-    )
-    assert is_async is True
-
-    # --- Step 3: TOCTOU window — fill CPU cache so LRU evicts req_a's blocks
-    # (in production this corresponds to other concurrent requests landing
-    # between Phase A and Phase B for req_b). 4 usable slots, req_a occupies 2;
-    # req_c (2) + req_d (2) require evicting 2 LRU blocks. ---
-    req_c = make_request(num_blocks=2)
-    req_d = make_request(num_blocks=2)
-    kv_c = _alloc_and_register(fix, req_c, 2)
-    kv_d = _alloc_and_register(fix, req_d, 2)
-    sched.update_state_after_alloc(req_c, kv_c, num_external_tokens=0)
-    sched.update_state_after_alloc(req_d, kv_d, num_external_tokens=0)
-    sched_out_pressure = make_scheduler_output(
-        {
-            req_c.request_id: 2 * BLOCK_SIZE,
-            req_d.request_id: 2 * BLOCK_SIZE,
-        },
-        new_reqs={
-            req_c.request_id: kv_c.get_block_ids(),
-            req_d.request_id: kv_d.get_block_ids(),
-        },
-    )
-    meta_pressure = sched.build_connector_meta(sched_out_pressure)
-    assert meta_pressure.store_event >= 0
-    simulate_store_completion(sched, meta_pressure.store_event)
-
-    # --- Step 4: Phase B — must not crash ---
-    # Before fix: AssertionError: Expected 32 hit tokens, got 0
-    # After fix: Phase A pinned the hits → Step 3 evicted req_c instead,
-    # Phase B consumes the cached (cpu_hit_blocks, hit_length) tuple.
-    gpu_blocks_b = fix.gpu_block_pool.get_new_blocks(2)
-    kv_blocks_b = KVCacheBlocks(blocks=(gpu_blocks_b,))
-    sched.update_state_after_alloc(req_b, kv_blocks_b, num_external_tokens=hit_tokens)
-
-    # --- Step 5: with the fix, the load is queued correctly ---
-    sched_out_b = make_scheduler_output(
-        {req_b.request_id: 1},
-        new_reqs={req_b.request_id: kv_blocks_b.get_block_ids()},
-    )
-    meta_b = sched.build_connector_meta(sched_out_b)
-    assert meta_b.load_event >= 0, (
-        "Phase B should queue a load event using the pinned CPU hit blocks"
-    )
-    assert len(meta_b.load_gpu_blocks) == 2
-    assert len(meta_b.load_cpu_blocks) == 2
-
-
-# ---------------------------------------------------------------------------
 # Test 5: Preemption no CPU block leak
 # ---------------------------------------------------------------------------
 def test_preemption_no_cpu_block_leak() -> None:
@@ -1246,3 +1141,108 @@ def test_partial_gpu_prefix_plus_cpu_load() -> None:
         assert bid in ext_block_ids, (
             f"Load GPU block {bid} should be an ext_comp block, not a comp or new block"
         )
+
+
+# ---------------------------------------------------------------------------
+# Test 11: TOCTOU between Phase A and Phase B (regression for #39702)
+# ---------------------------------------------------------------------------
+def test_toctou_cpu_hit_evicted_between_phases_no_crash() -> None:
+    """Regression for vllm-project/vllm#39702.
+
+    When ``get_num_new_matched_tokens`` (Phase A) reports a CPU cache hit
+    of ``N`` tokens but ``update_state_after_alloc`` (Phase B) runs after
+    other requests have caused LRU eviction of those exact blocks, the
+    second ``find_longest_cache_hit`` call returns 0 while
+    ``num_external_tokens`` is still ``N``, triggering
+    ``AssertionError: Expected N hit tokens, got 0``.
+
+    Setup: ``num_cpu_blocks=5`` (4 usable; null_block takes 1).
+        1. Store req_a's 2 blocks to CPU. CPU: [a0, a1, _, _].
+        2. Phase A on req_b (same prompt as req_a) reports a 2-block hit.
+           Without the fix this does NOT pin a0/a1 — they remain at LRU front.
+        3. Store req_c (2) + req_d (2) — 4 more blocks into 4 slots. With
+           a0/a1 unpinned and at LRU front, they get evicted. CPU: [c0, c1,
+           d0, d1].
+        4. Phase B on req_b: re-searches the CPU coordinator, finds 0
+           cached hashes, asserts.
+
+    After the fix, Phase A pins the hit blocks so step 3 evicts req_c's
+    blocks instead, and Phase B reads the cached ``(cpu_hit_blocks,
+    hit_length)`` tuple without re-searching.
+    """
+    # 5 total = 4 usable (null_block takes 1)
+    fix = make_scheduler(num_cpu_blocks=5, num_gpu_blocks=16, lazy=False)
+    sched = fix.scheduler
+
+    # --- Step 1: Store req_a's 2 blocks to CPU cache ---
+    req_a = make_request(num_blocks=2)
+    kv_a = _alloc_and_register(fix, req_a, 2)
+    sched.update_state_after_alloc(req_a, kv_a, num_external_tokens=0)
+    sched_out_a = make_scheduler_output(
+        {req_a.request_id: 2 * BLOCK_SIZE},
+        new_reqs={req_a.request_id: kv_a.get_block_ids()},
+    )
+    meta_a = sched.build_connector_meta(sched_out_a)
+    assert meta_a.store_event >= 0
+    simulate_store_completion(sched, meta_a.store_event)
+
+    # --- Step 2: Phase A — req_b (same prompt as req_a) reports a CPU hit ---
+    req_b = Request(
+        request_id="req-b-toctou",
+        prompt_token_ids=req_a.prompt_token_ids,
+        sampling_params=req_a.sampling_params,
+        pooling_params=None,
+        mm_features=None,
+        block_hasher=req_a._block_hasher,
+    )
+    hit_tokens, is_async = sched.get_num_new_matched_tokens(
+        req_b, num_computed_tokens=0
+    )
+    assert hit_tokens == 2 * BLOCK_SIZE, (
+        f"Phase A should report 2 blocks of CPU hit, got {hit_tokens}"
+    )
+    assert is_async is True
+
+    # --- Step 3: TOCTOU window — fill CPU cache so LRU evicts req_a's blocks
+    # (in production this corresponds to other concurrent requests landing
+    # between Phase A and Phase B for req_b). 4 usable slots, req_a occupies 2;
+    # req_c (2) + req_d (2) require evicting 2 LRU blocks. ---
+    req_c = make_request(num_blocks=2)
+    req_d = make_request(num_blocks=2)
+    kv_c = _alloc_and_register(fix, req_c, 2)
+    kv_d = _alloc_and_register(fix, req_d, 2)
+    sched.update_state_after_alloc(req_c, kv_c, num_external_tokens=0)
+    sched.update_state_after_alloc(req_d, kv_d, num_external_tokens=0)
+    sched_out_pressure = make_scheduler_output(
+        {
+            req_c.request_id: 2 * BLOCK_SIZE,
+            req_d.request_id: 2 * BLOCK_SIZE,
+        },
+        new_reqs={
+            req_c.request_id: kv_c.get_block_ids(),
+            req_d.request_id: kv_d.get_block_ids(),
+        },
+    )
+    meta_pressure = sched.build_connector_meta(sched_out_pressure)
+    assert meta_pressure.store_event >= 0
+    simulate_store_completion(sched, meta_pressure.store_event)
+
+    # --- Step 4: Phase B — must not crash ---
+    # Before fix: AssertionError: Expected 32 hit tokens, got 0
+    # After fix: Phase A pinned the hits → Step 3 evicted req_c instead,
+    # Phase B consumes the cached (cpu_hit_blocks, hit_length) tuple.
+    gpu_blocks_b = fix.gpu_block_pool.get_new_blocks(2)
+    kv_blocks_b = KVCacheBlocks(blocks=(gpu_blocks_b,))
+    sched.update_state_after_alloc(req_b, kv_blocks_b, num_external_tokens=hit_tokens)
+
+    # --- Step 5: with the fix, the load is queued correctly ---
+    sched_out_b = make_scheduler_output(
+        {req_b.request_id: 1},
+        new_reqs={req_b.request_id: kv_blocks_b.get_block_ids()},
+    )
+    meta_b = sched.build_connector_meta(sched_out_b)
+    assert meta_b.load_event >= 0, (
+        "Phase B should queue a load event using the pinned CPU hit blocks"
+    )
+    assert len(meta_b.load_gpu_blocks) == 2
+    assert len(meta_b.load_cpu_blocks) == 2

--- a/tests/v1/simple_kv_offload/test_scheduler.py
+++ b/tests/v1/simple_kv_offload/test_scheduler.py
@@ -753,6 +753,111 @@ def test_touched_blocks_survive_eviction() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Test 4b: TOCTOU between Phase A and Phase B (regression for #39702)
+# ---------------------------------------------------------------------------
+def test_toctou_cpu_hit_evicted_between_phases_no_crash() -> None:
+    """Regression for vllm-project/vllm#39702.
+
+    When ``get_num_new_matched_tokens`` (Phase A) reports a CPU cache hit
+    of ``N`` tokens but ``update_state_after_alloc`` (Phase B) runs after
+    other requests have caused LRU eviction of those exact blocks, the
+    second ``find_longest_cache_hit`` call returns 0 while
+    ``num_external_tokens`` is still ``N``, triggering
+    ``AssertionError: Expected N hit tokens, got 0``.
+
+    Setup: ``num_cpu_blocks=5`` (4 usable; null_block takes 1).
+        1. Store req_a's 2 blocks to CPU. CPU: [a0, a1, _, _].
+        2. Phase A on req_b (same prompt as req_a) reports a 2-block hit.
+           Without the fix this does NOT pin a0/a1 — they remain at LRU front.
+        3. Store req_c (2) + req_d (2) — 4 more blocks into 4 slots. With
+           a0/a1 unpinned and at LRU front, they get evicted. CPU: [c0, c1,
+           d0, d1].
+        4. Phase B on req_b: re-searches the CPU coordinator, finds 0
+           cached hashes, asserts.
+
+    After the fix, Phase A pins the hit blocks so step 3 evicts req_c's
+    blocks instead, and Phase B reads the cached ``(cpu_hit_blocks,
+    hit_length)`` tuple without re-searching.
+    """
+    # 5 total = 4 usable (null_block takes 1)
+    fix = make_scheduler(num_cpu_blocks=5, num_gpu_blocks=16, lazy=False)
+    sched = fix.scheduler
+
+    # --- Step 1: Store req_a's 2 blocks to CPU cache ---
+    req_a = make_request(num_blocks=2)
+    kv_a = _alloc_and_register(fix, req_a, 2)
+    sched.update_state_after_alloc(req_a, kv_a, num_external_tokens=0)
+    sched_out_a = make_scheduler_output(
+        {req_a.request_id: 2 * BLOCK_SIZE},
+        new_reqs={req_a.request_id: kv_a.get_block_ids()},
+    )
+    meta_a = sched.build_connector_meta(sched_out_a)
+    assert meta_a.store_event >= 0
+    simulate_store_completion(sched, meta_a.store_event)
+
+    # --- Step 2: Phase A — req_b (same prompt as req_a) reports a CPU hit ---
+    req_b = Request(
+        request_id="req-b-toctou",
+        prompt_token_ids=req_a.prompt_token_ids,
+        sampling_params=req_a.sampling_params,
+        pooling_params=None,
+        mm_features=None,
+        block_hasher=req_a._block_hasher,
+    )
+    hit_tokens, is_async = sched.get_num_new_matched_tokens(
+        req_b, num_computed_tokens=0
+    )
+    assert hit_tokens == 2 * BLOCK_SIZE, (
+        f"Phase A should report 2 blocks of CPU hit, got {hit_tokens}"
+    )
+    assert is_async is True
+
+    # --- Step 3: TOCTOU window — fill CPU cache so LRU evicts req_a's blocks
+    # (in production this corresponds to other concurrent requests landing
+    # between Phase A and Phase B for req_b). 4 usable slots, req_a occupies 2;
+    # req_c (2) + req_d (2) require evicting 2 LRU blocks. ---
+    req_c = make_request(num_blocks=2)
+    req_d = make_request(num_blocks=2)
+    kv_c = _alloc_and_register(fix, req_c, 2)
+    kv_d = _alloc_and_register(fix, req_d, 2)
+    sched.update_state_after_alloc(req_c, kv_c, num_external_tokens=0)
+    sched.update_state_after_alloc(req_d, kv_d, num_external_tokens=0)
+    sched_out_pressure = make_scheduler_output(
+        {
+            req_c.request_id: 2 * BLOCK_SIZE,
+            req_d.request_id: 2 * BLOCK_SIZE,
+        },
+        new_reqs={
+            req_c.request_id: kv_c.get_block_ids(),
+            req_d.request_id: kv_d.get_block_ids(),
+        },
+    )
+    meta_pressure = sched.build_connector_meta(sched_out_pressure)
+    assert meta_pressure.store_event >= 0
+    simulate_store_completion(sched, meta_pressure.store_event)
+
+    # --- Step 4: Phase B — must not crash ---
+    # Before fix: AssertionError: Expected 32 hit tokens, got 0
+    # After fix: Phase A pinned the hits → Step 3 evicted req_c instead,
+    # Phase B consumes the cached (cpu_hit_blocks, hit_length) tuple.
+    gpu_blocks_b = fix.gpu_block_pool.get_new_blocks(2)
+    kv_blocks_b = KVCacheBlocks(blocks=(gpu_blocks_b,))
+    sched.update_state_after_alloc(req_b, kv_blocks_b, num_external_tokens=hit_tokens)
+
+    # --- Step 5: with the fix, the load is queued correctly ---
+    sched_out_b = make_scheduler_output(
+        {req_b.request_id: 1},
+        new_reqs={req_b.request_id: kv_blocks_b.get_block_ids()},
+    )
+    meta_b = sched.build_connector_meta(sched_out_b)
+    assert meta_b.load_event >= 0, (
+        "Phase B should queue a load event using the pinned CPU hit blocks"
+    )
+    assert len(meta_b.load_gpu_blocks) == 2
+    assert len(meta_b.load_cpu_blocks) == 2
+
+
+# ---------------------------------------------------------------------------
 # Test 5: Preemption no CPU block leak
 # ---------------------------------------------------------------------------
 def test_preemption_no_cpu_block_leak() -> None:

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -131,6 +131,12 @@ class SimpleCPUOffloadScheduler:
         # the worker reports completions by event index, not request id.
         self._load_event_to_reqs: dict[int, list[str]] = {}
 
+        # Pending CPU hits from get_num_new_matched_tokens() (Phase A) awaiting
+        # consumption in update_state_after_alloc() (Phase B). Found blocks are
+        # temporarily pinned via touch() while pending, preventing LRU eviction
+        # in the window between the two scheduler phases (#39702).
+        self._pending_cpu_hits: dict[str, tuple[list[list[KVCacheBlock]], int]] = {}
+
         # Store metadata
         self._lazy_mode = lazy_offload
         # Lazy mode: use a cursor to track the last scanned block in the GPU free queue.
@@ -211,7 +217,21 @@ class SimpleCPUOffloadScheduler:
     def get_num_new_matched_tokens(
         self, request: "Request", num_computed_tokens: int
     ) -> tuple[int | None, bool]:
-        """Return (num_new_tokens, is_async) from consecutive CPU cache hits."""
+        """Return (num_new_tokens, is_async) from consecutive CPU cache hits.
+
+        Pins found CPU blocks via touch() so they survive LRU eviction in the
+        window between this call and the matching update_state_after_alloc().
+        The temporary pin is released in update_state_after_alloc() once the
+        persistent load pin takes over, or in request_finished() if the request
+        never reaches Phase B (#39702).
+        """
+        # Defensive: release any stale pin from a prior Phase A call on this
+        # request (e.g., allocate_slots() failed and the request was requeued
+        # without an intervening Phase B).
+        stale = self._pending_cpu_hits.pop(request.request_id, None)
+        if stale is not None:
+            self._free_pending_cpu_hit(stale)
+
         skipped = num_computed_tokens // self.block_size
         remaining_hashes = request.block_hashes[skipped:]
 
@@ -222,11 +242,19 @@ class SimpleCPUOffloadScheduler:
         max_hit_len = request.num_tokens - 1 - num_computed_tokens
         if max_hit_len <= 0:
             return 0, False
-        _, hit_length = self.cpu_coordinator.find_longest_cache_hit(
+        cpu_hit_blocks, hit_length = self.cpu_coordinator.find_longest_cache_hit(
             remaining_hashes, max_hit_len
         )
 
         if hit_length > 0:
+            pin_blocks = [
+                blk for grp in cpu_hit_blocks for blk in grp if not blk.is_null
+            ]
+            self.cpu_block_pool.touch(pin_blocks)
+            self._pending_cpu_hits[request.request_id] = (
+                cpu_hit_blocks,
+                hit_length,
+            )
             return hit_length, True
         return 0, False
 
@@ -252,28 +280,53 @@ class SimpleCPUOffloadScheduler:
                 num_stored_blocks=[0] * num_groups,
             )
 
+        # Pop the CPU hit cached by Phase A (get_num_new_matched_tokens). The
+        # found blocks were pinned there to survive LRU eviction in the window
+        # between the two phases (#39702).
+        pending = self._pending_cpu_hits.pop(req_id, None)
+
         if num_external_tokens == 0:
+            # Phase A reported no external hit. Defensive: release any
+            # unexpected pending pin.
+            if pending is not None:
+                self._free_pending_cpu_hit(pending)
             return
+
+        if pending is None:
+            # Phase B invoked with num_external_tokens > 0 but Phase A never
+            # recorded a hit for this request. Should not happen in normal
+            # flow; degrade gracefully instead of crashing the scheduler.
+            logger.warning(
+                "SimpleCPUOffloadScheduler: update_state_after_alloc called "
+                "for req_id=%s with num_external_tokens=%d but no pending "
+                "CPU hit from Phase A; skipping load.",
+                req_id,
+                num_external_tokens,
+            )
+            return
+
+        cpu_hit_blocks_full, _ = pending
 
         num_blocks_to_load = num_external_tokens // self.block_size
         assert num_blocks_to_load > 0
 
         skipped = sum(blk.block_hash is not None for blk in blocks.blocks[self.fa_gidx])
         num_computed_tokens = skipped * self.block_size
-        hashes_to_load = request.block_hashes[skipped : skipped + num_blocks_to_load]
 
-        # Find CPU cached blocks across all groups.
-        max_hit_len = len(hashes_to_load) * self.block_size
-        cpu_hit_blocks, hit_length = self.cpu_coordinator.find_longest_cache_hit(
-            hashes_to_load, max_hit_len
-        )
-        assert hit_length == num_external_tokens, (
-            f"Expected {num_external_tokens} hit tokens, got {hit_length}"
-        )
-
-        # Build transfer pairs across all groups.
+        # Build transfer pairs across all groups using the cached cpu_hit_blocks
+        # from Phase A — no second find_longest_cache_hit() call needed.
         total_computed_tokens = num_computed_tokens + num_external_tokens
         kv_cache_groups = self.cpu_kv_cache_config.kv_cache_groups
+
+        # The scheduler may have accepted fewer blocks than Phase A reported
+        # (e.g. due to token budget). Take only the leading N blocks per group
+        # matching num_external_tokens; the rest will be released along with
+        # the temp pin below.
+        cpu_hit_blocks: list[list[KVCacheBlock]] = []
+        for g in range(num_groups):
+            g_block_size = kv_cache_groups[g].kv_cache_spec.block_size
+            n_take_g = num_external_tokens // g_block_size
+            cpu_hit_blocks.append(cpu_hit_blocks_full[g][:n_take_g])
 
         gpu_block_ids: list[int] = []
         cpu_block_ids: list[int] = []
@@ -301,8 +354,10 @@ class SimpleCPUOffloadScheduler:
                 cpu_block_ids.append(cpu_blk.block_id)
                 cpu_blocks_to_touch.append(cpu_blk)
 
-        # Touch CPU blocks to prevent eviction during async load.
+        # Take a persistent pin on the CPU blocks for the async load.
         self.cpu_block_pool.touch(cpu_blocks_to_touch)
+        # Release the temporary pin held since Phase A.
+        self._free_pending_cpu_hit(pending)
 
         # Touch GPU blocks to prevent freeing during async load
         assert self._gpu_block_pool is not None
@@ -663,6 +718,12 @@ class SimpleCPUOffloadScheduler:
         so the scheduler can free blocks immediately."""
         req_id = request.request_id
 
+        # Release any temp CPU hit pin from Phase A that never reached Phase B
+        # (request canceled or preempted before update_state_after_alloc()).
+        pending = self._pending_cpu_hits.pop(req_id, None)
+        if pending is not None:
+            self._free_pending_cpu_hit(pending)
+
         # Handle load: defer cleanup if load is in-flight
         load_state = self._reqs_to_load.get(req_id)
         if load_state is not None:
@@ -688,6 +749,18 @@ class SimpleCPUOffloadScheduler:
         block_ids: tuple[list[int], ...],
     ) -> tuple[bool, dict[str, Any] | None]:
         return self.request_finished(request, block_ids=[])
+
+    def _free_pending_cpu_hit(self, pending: tuple) -> None:
+        """Release the temporary CPU block pin taken in Phase A
+        (get_num_new_matched_tokens). Called when Phase B consumes the pending
+        entry, or when the request is canceled before Phase B runs.
+        """
+        cpu_hit_blocks, _ = pending
+        blocks_to_free = [
+            blk for grp in cpu_hit_blocks for blk in grp if not blk.is_null
+        ]
+        if blocks_to_free:
+            self.cpu_block_pool.free_blocks(blocks_to_free)
 
     def _cleanup_load_request(self, req_id: str) -> None:
         """Release all load resources for a request.

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -304,7 +304,7 @@ class SimpleCPUOffloadScheduler:
         skipped = sum(blk.block_hash is not None for blk in blocks.blocks[self.fa_gidx])
         num_computed_tokens = skipped * self.block_size
 
-        # Build transfer pairs across all groups
+        # Build transfer pairs across all groups.
         total_computed_tokens = num_computed_tokens + num_external_tokens
         kv_cache_groups = self.cpu_kv_cache_config.kv_cache_groups
 

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -131,10 +131,10 @@ class SimpleCPUOffloadScheduler:
         # the worker reports completions by event index, not request id.
         self._load_event_to_reqs: dict[int, list[str]] = {}
 
-        # Pending CPU hits from get_num_new_matched_tokens() (Phase A) awaiting
-        # consumption in update_state_after_alloc() (Phase B). Found blocks are
+        # Pending CPU hits from get_num_new_matched_tokens() awaiting
+        # consumption in update_state_after_alloc(). Found blocks are
         # temporarily pinned via touch() while pending, preventing LRU eviction
-        # in the window between the two scheduler phases (#39702).
+        # in the window between the two scheduler phases.
         self._pending_cpu_hits: dict[
             str, tuple[tuple[list[KVCacheBlock], ...], int]
         ] = {}
@@ -225,11 +225,10 @@ class SimpleCPUOffloadScheduler:
         window between this call and the matching update_state_after_alloc().
         The temporary pin is released in update_state_after_alloc() once the
         persistent load pin takes over, or in request_finished() if the request
-        never reaches Phase B (#39702).
+        never reaches update_state_after_alloc().
         """
-        # Defensive: release any stale pin from a prior Phase A call on this
-        # request (e.g., allocate_slots() failed and the request was requeued
-        # without an intervening Phase B).
+        # Release any stale pin from a prior
+        # get_num_new_matched_tokens() call on this request
         stale = self._pending_cpu_hits.pop(request.request_id, None)
         if stale is not None:
             self._free_pending_cpu_hit(stale)
@@ -282,30 +281,20 @@ class SimpleCPUOffloadScheduler:
                 num_stored_blocks=[0] * num_groups,
             )
 
-        # Pop the CPU hit cached by Phase A (get_num_new_matched_tokens). The
+        # Pop the CPU hit cached by get_num_new_matched_tokens(). The
         # found blocks were pinned there to survive LRU eviction in the window
-        # between the two phases (#39702).
+        # between get_num_new_matched_tokens() and this matching call.
         pending = self._pending_cpu_hits.pop(req_id, None)
 
         if num_external_tokens == 0:
-            # Phase A reported no external hit. Defensive: release any
-            # unexpected pending pin.
+            # get_num_new_matched_tokens() reported no external hit.
+            # Release any unexpected pending pin.
             if pending is not None:
                 self._free_pending_cpu_hit(pending)
             return
 
         if pending is None:
-            # Phase B invoked with num_external_tokens > 0 but Phase A never
-            # recorded a hit for this request. Should not happen in normal
-            # flow; degrade gracefully instead of crashing the scheduler.
-            logger.warning(
-                "SimpleCPUOffloadScheduler: update_state_after_alloc called "
-                "for req_id=%s with num_external_tokens=%d but no pending "
-                "CPU hit from Phase A; skipping load.",
-                req_id,
-                num_external_tokens,
-            )
-            return
+            return  # graceful fallback instead of assert
 
         cpu_hit_blocks_full, _ = pending
 
@@ -315,15 +304,15 @@ class SimpleCPUOffloadScheduler:
         skipped = sum(blk.block_hash is not None for blk in blocks.blocks[self.fa_gidx])
         num_computed_tokens = skipped * self.block_size
 
-        # Build transfer pairs across all groups using the cached cpu_hit_blocks
-        # from Phase A — no second find_longest_cache_hit() call needed.
+        # Build transfer pairs across all groups
         total_computed_tokens = num_computed_tokens + num_external_tokens
         kv_cache_groups = self.cpu_kv_cache_config.kv_cache_groups
 
-        # The scheduler may have accepted fewer blocks than Phase A reported
-        # (e.g. due to token budget). Take only the leading N blocks per group
-        # matching num_external_tokens; the rest will be released along with
-        # the temp pin below.
+        # The scheduler may have accepted fewer blocks than
+        # get_num_new_matched_tokens() reported.
+        # (e.g. due to token budget in test_partial_gpu_prefix_plus_cpu_load).
+        # Take only the leading N blocks per group matching num_external_tokens;
+        # the rest will be released along with the temp pin below.
         cpu_hit_blocks: list[list[KVCacheBlock]] = []
         for g in range(num_groups):
             g_block_size = kv_cache_groups[g].kv_cache_spec.block_size
@@ -356,9 +345,9 @@ class SimpleCPUOffloadScheduler:
                 cpu_block_ids.append(cpu_blk.block_id)
                 cpu_blocks_to_touch.append(cpu_blk)
 
-        # Take a persistent pin on the CPU blocks for the async load.
+        # Touch CPU blocks to prevent eviction during async load.
         self.cpu_block_pool.touch(cpu_blocks_to_touch)
-        # Release the temporary pin held since Phase A.
+        # Release the temporary pin held since get_num_new_matched_tokens().
         self._free_pending_cpu_hit(pending)
 
         # Touch GPU blocks to prevent freeing during async load
@@ -720,8 +709,8 @@ class SimpleCPUOffloadScheduler:
         so the scheduler can free blocks immediately."""
         req_id = request.request_id
 
-        # Release any temp CPU hit pin from Phase A that never reached Phase B
-        # (request canceled or preempted before update_state_after_alloc()).
+        # Release any temp CPU hit pin from get_num_new_matched_tokens()
+        # if request is canceled or preempted before update_state_after_alloc()
         pending = self._pending_cpu_hits.pop(req_id, None)
         if pending is not None:
             self._free_pending_cpu_hit(pending)
@@ -753,10 +742,7 @@ class SimpleCPUOffloadScheduler:
         return self.request_finished(request, block_ids=[])
 
     def _free_pending_cpu_hit(self, pending: tuple) -> None:
-        """Release the temporary CPU block pin taken in Phase A
-        (get_num_new_matched_tokens). Called when Phase B consumes the pending
-        entry, or when the request is canceled before Phase B runs.
-        """
+        """Release the temporary CPU block pin taken in get_num_new_matched_tokens()."""
         cpu_hit_blocks, _ = pending
         blocks_to_free = [
             blk for grp in cpu_hit_blocks for blk in grp if not blk.is_null

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -131,15 +131,8 @@ class SimpleCPUOffloadScheduler:
         # the worker reports completions by event index, not request id.
         self._load_event_to_reqs: dict[int, list[str]] = {}
 
-        # Pending CPU hits keyed by request_id, awaiting consumption in
-        # update_state_after_alloc(). Found blocks are temporarily pinned
-        # via touch() to survive LRU eviction in the window between the two
-        # scheduler phases. Value layout:
-        #   (cpu_hit_blocks, hit_length_tokens)
-        # where cpu_hit_blocks is the per-group structure returned by
-        # find_longest_cache_hit (outer tuple = kv cache groups, inner list =
-        # consecutive blocks per group, possibly with null_block sentinels);
-        # hit_length_tokens is the block-aligned token count of the match.
+        # Pending (cpu_hit_blocks, hit_length) tuples from find_longest_cache_hit,
+        # kept pinned via touch() while awaiting update_state_after_alloc().
         self._pending_cpu_hits: dict[
             str, tuple[tuple[list[KVCacheBlock], ...], int]
         ] = {}
@@ -226,14 +219,10 @@ class SimpleCPUOffloadScheduler:
     ) -> tuple[int | None, bool]:
         """Return (num_new_tokens, is_async) from consecutive CPU cache hits.
 
-        Pins found CPU blocks via touch() so they survive LRU eviction in the
-        window between this call and the matching update_state_after_alloc().
-        The temporary pin is released in update_state_after_alloc() once the
-        persistent load pin takes over, or in request_finished() if the request
-        never reaches update_state_after_alloc().
-
-        Defensively drops any pin recorded by an earlier call on the same
-        request (e.g., retry after allocate_slots failure).
+        Pins found CPU blocks via touch() so they survive LRU eviction until
+        update_state_after_alloc() consumes them. Any pin from an earlier
+        call on the same request (e.g. retry after a failed allocate_slots)
+        is dropped first.
         """
         stale = self._pending_cpu_hits.pop(request.request_id, None)
         if stale is not None:
@@ -293,9 +282,14 @@ class SimpleCPUOffloadScheduler:
         pending = self._pending_cpu_hits.pop(req_id, None)
 
         if num_external_tokens == 0:
-            # get_num_new_matched_tokens() reported no external hit.
-            # Release any unexpected pending pin.
             if pending is not None:
+                logger.warning(
+                    "SimpleCPUOffloadScheduler: update_state_after_alloc "
+                    "called for req_id=%s with no external tokens but "
+                    "get_num_new_matched_tokens() unexpectedly recorded "
+                    "a pending CPU hit; releasing the stale pin.",
+                    req_id,
+                )
                 self._free_pending_cpu_hit(pending)
             return
 

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -135,7 +135,9 @@ class SimpleCPUOffloadScheduler:
         # consumption in update_state_after_alloc() (Phase B). Found blocks are
         # temporarily pinned via touch() while pending, preventing LRU eviction
         # in the window between the two scheduler phases (#39702).
-        self._pending_cpu_hits: dict[str, tuple[list[list[KVCacheBlock]], int]] = {}
+        self._pending_cpu_hits: dict[
+            str, tuple[tuple[list[KVCacheBlock], ...], int]
+        ] = {}
 
         # Store metadata
         self._lazy_mode = lazy_offload

--- a/vllm/v1/simple_kv_offload/manager.py
+++ b/vllm/v1/simple_kv_offload/manager.py
@@ -131,10 +131,15 @@ class SimpleCPUOffloadScheduler:
         # the worker reports completions by event index, not request id.
         self._load_event_to_reqs: dict[int, list[str]] = {}
 
-        # Pending CPU hits from get_num_new_matched_tokens() awaiting
-        # consumption in update_state_after_alloc(). Found blocks are
-        # temporarily pinned via touch() while pending, preventing LRU eviction
-        # in the window between the two scheduler phases.
+        # Pending CPU hits keyed by request_id, awaiting consumption in
+        # update_state_after_alloc(). Found blocks are temporarily pinned
+        # via touch() to survive LRU eviction in the window between the two
+        # scheduler phases. Value layout:
+        #   (cpu_hit_blocks, hit_length_tokens)
+        # where cpu_hit_blocks is the per-group structure returned by
+        # find_longest_cache_hit (outer tuple = kv cache groups, inner list =
+        # consecutive blocks per group, possibly with null_block sentinels);
+        # hit_length_tokens is the block-aligned token count of the match.
         self._pending_cpu_hits: dict[
             str, tuple[tuple[list[KVCacheBlock], ...], int]
         ] = {}
@@ -226,9 +231,10 @@ class SimpleCPUOffloadScheduler:
         The temporary pin is released in update_state_after_alloc() once the
         persistent load pin takes over, or in request_finished() if the request
         never reaches update_state_after_alloc().
+
+        Defensively drops any pin recorded by an earlier call on the same
+        request (e.g., retry after allocate_slots failure).
         """
-        # Release any stale pin from a prior
-        # get_num_new_matched_tokens() call on this request
         stale = self._pending_cpu_hits.pop(request.request_id, None)
         if stale is not None:
             self._free_pending_cpu_hit(stale)
@@ -294,7 +300,14 @@ class SimpleCPUOffloadScheduler:
             return
 
         if pending is None:
-            return  # graceful fallback instead of assert
+            logger.warning(
+                "SimpleCPUOffloadScheduler: update_state_after_alloc called "
+                "for req_id=%s with num_external_tokens=%d but no pending "
+                "CPU hit from get_num_new_matched_tokens(); skipping load.",
+                req_id,
+                num_external_tokens,
+            )
+            return
 
         cpu_hit_blocks_full, _ = pending
 
@@ -316,6 +329,10 @@ class SimpleCPUOffloadScheduler:
         cpu_hit_blocks: list[list[KVCacheBlock]] = []
         for g in range(num_groups):
             g_block_size = kv_cache_groups[g].kv_cache_spec.block_size
+            assert num_external_tokens % g_block_size == 0, (
+                f"num_external_tokens={num_external_tokens} not aligned to "
+                f"group {g} block_size={g_block_size}"
+            )
             n_take_g = num_external_tokens // g_block_size
             cpu_hit_blocks.append(cpu_hit_blocks_full[g][:n_take_g])
 


### PR DESCRIPTION
## Summary

Fixes #39702. Eliminates the TOCTOU window between `get_num_new_matched_tokens()` (Phase A) and `update_state_after_alloc()` (Phase B) in `SimpleCPUOffloadScheduler` by pinning the found CPU blocks immediately and consuming them in Phase B without a second `find_longest_cache_hit()` search.

Before this fix, the scheduler crashes with `AssertionError: Expected N hit tokens, got 0` once the CPU cache fills up and LRU eviction begins.


## Duplicate check

Per AGENTS.md, the following searches were run before opening this PR. None surfaced an existing fix:

```bash
gh pr list --repo vllm-project/vllm --state open --search "39702 in:body"
# 0 PRs

gh pr list --repo vllm-project/vllm --state open --search "SimpleCPUOffload in:title"
# 1 PR: #41777 — "Flush final KV block when SimpleCPUOffload request finishes
#                 in same step as its last full block".
# Different bug (end-of-step flush correctness), unrelated to the TOCTOU race
# between get_num_new_matched_tokens and update_state_after_alloc.

gh pr list --repo vllm-project/vllm --state open --search "TOCTOU update_state_after_alloc"
# 0 PRs
```

The issue (#39702) is also not self-assigned and the author/reproducer have no prior vLLM PRs, so there is no concurrent submission expected.

## Approach

Following @go-bai's proposed fix in the issue body:

- **Phase A** (`get_num_new_matched_tokens`): pin found CPU blocks via `cpu_block_pool.touch()` and cache `(cpu_hit_blocks, hit_length)` in `self._pending_cpu_hits`.
- **Phase B** (`update_state_after_alloc`): pop the cached tuple, build transfer pairs directly from it, take a persistent pin for the async load, then release the temp Phase A pin.
- **`request_finished`**: release the temp pin if the request never reaches Phase B (cancellation / preemption path).
- **Graceful fallback**: if Phase B is invoked with `num_external_tokens > 0` but no pending entry, log a warning and skip the load instead of asserting.

Two additions beyond the issue body's pseudocode (justified inline):

1. **Partial-take slicing** — the scheduler can accept fewer blocks than Phase A found (token budget). We slice `cpu_hit_blocks[g][:n_take_g]` per group before building transfer pairs. Without this, the existing `test_partial_gpu_prefix_plus_cpu_load` test would fail.
2. **Stale-pin defensive release in Phase A** — if `allocate_slots()` fails and the request is requeued without an intervening Phase B, the next Phase A call pops the old `_pending_cpu_hits` entry and releases the stale pin before searching again. Otherwise the prior pin would leak.

## Test commands run

```bash
# Regression test (added by this PR)
.venv/bin/python -m pytest tests/v1/simple_kv_offload/test_scheduler.py::test_toctou_cpu_hit_evicted_between_phases_no_crash -v
# 1 passed

# Full scheduler test suite (existing tests must continue to pass)
.venv/bin/python -m pytest tests/v1/simple_kv_offload/test_scheduler.py -v
# 13 passed

# Integration tests (skipped — require GPU; CI will run them)
.venv/bin/python -m pytest tests/v1/simple_kv_offload/test_integration.py -v
# 8 skipped

# Lint
.venv/bin/pre-commit run --files vllm/v1/simple_kv_offload/manager.py tests/v1/simple_kv_offload/test_scheduler.py
# All hooks passed (ruff check, ruff format, typos, mypy, SPDX, etc.)
```

The added regression test `test_toctou_cpu_hit_evicted_between_phases_no_crash` fills the CPU cache between Phase A and Phase B (using two additional requests' store activity) to force LRU eviction of the found blocks. On `main` (without this PR's manager.py changes) it reproduces the assertion crash from #39702; with this PR it passes and verifies a load event is correctly queued.

## Scope

This PR fixes the surface-level TOCTOU race. @v1b3coder noted in [this comment](https://github.com/vllm-project/vllm/issues/39702#issuecomment-4407720927) that applying this style of fix surfaces a separate `free_block_queue.popleft_n` block-accounting issue in the async CPU load path. That deeper issue is out of scope here and should be tracked in a follow-up issue/PR.

Thanks for @go-bai's root-cause diagnosis and proposed fix, as well as @v1b3coder's independent reproduction on 2× RTX PRO 6000 Blackwell + DeepSeek-V4-Flash

