### PR TITLE
[CI] Make Python-only Installation optional

### DIFF
--- a/.buildkite/test_areas/misc.yaml
+++ b/.buildkite/test_areas/misc.yaml
@@ -210,6 +210,7 @@ steps:
 - label: Python-only Installation
   key: python-only-installation
   depends_on: ~
+  optional: true
   timeout_in_minutes: 20
   source_file_dependencies:
   - tests/standalone_tests/python_only_compile.sh


### PR DESCRIPTION
## Purpose

`Python-only Installation` fetches `wheels.vllm.ai/<commit>/vllm/metadata.json` produced by the release-v2 wheel-publish pipeline. On per-commit postmerge runs (and PRs that hit `RUN_ALL=1` via `csrc/` etc.) it races that publish step and 404s — e.g. [build 65498](https://buildkite.com/vllm/ci/builds/65498/canvas?sid=019e15a0-48a5-4dbb-815f-24bd000da46f&tab=output).

Mark it `optional: true` so it only runs in the scheduled "Full CI run - nightly" (2×/day), where `NIGHTLY=1` unlocks optional steps.

**Limitation**: PRs that change `setup.py` or `tests/standalone_tests/python_only_compile.sh` will no longer trigger this test automatically; coverage shifts to the next nightly run.

## Test Plan

## Test Result