### PR TITLE
[Bugfix] FLASH_ATTN_DIFFKV: fix KV cache shape for non-128 head_size_v models (issue #41807)

### DIFF
--- a/vllm/v1/attention/backends/flash_attn_diffkv.py
+++ b/vllm/v1/attention/backends/flash_attn_diffkv.py
@@ -50,8 +50,9 @@ class FlashAttentionDiffKVBackend(FlashAttentionBackend):
 
     # Do not modify the interface of get_kv_cache_shape,
     # but consider head_size_v when returning result.
-    @staticmethod
+    @classmethod
     def get_kv_cache_shape(
+        cls,
         num_blocks: int,
         block_size: int,
         num_kv_heads: int,
@@ -64,7 +65,7 @@ class FlashAttentionDiffKVBackend(FlashAttentionBackend):
             num_blocks,
             block_size,
             num_kv_heads,
-            head_size + FlashAttentionDiffKVBackend.head_size_v,
+            head_size + cls.head_size_v,
         )
 
     @staticmethod


### PR DESCRIPTION
## Summary

Fixes #41807: `FLASH_ATTN_DIFFKV` attention backend crashes on models where `head_size_v != 128`.

**Root cause**: `get_kv_cache_shape()` was a `@staticmethod` that hard-coded `FlashAttentionDiffKVBackend.head_size_v`. When `set_head_size_v()` is called (e.g., for OPT-125m with `head_size_v=64`), the method still reads the class-level default (128), producing an invalid KV cache shape. For OPT-125m, the computed shape `[512, 16, 12, 192]` has 18,874,365 elements while the actual tensor only has 12,582,912 — causing `RuntimeError: shape is invalid for input of size ...`.

**Fix**: Change `get_kv_cache_shape` from `@staticmethod` to `@classmethod` so that `cls.head_size_v` resolves to the value set by `set_head_size_v()`.

## Changes

- `vllm/v1/attention/backends/flash_attn_diffkv.py`: 3 changes — `@staticmethod` → `@classmethod`, add `cls` param, `FlashAttentionDiffKVBackend.head_size_v` → `cls.head_size_v`

## Test Plan

Reproducer from the issue (requires GPU):

```python
import vllm
llm = vllm.LLM(
    "facebook/opt-125m",
    attention_config={"backend": "FLASH_ATTN_DIFFKV"},
)
llm.generate("test")
```

Before fix: `RuntimeError: shape '[512, 16, 12, 192]' is invalid for input of size 12582912`
After fix: no crash, output computed correctly.

## AI Assistance

This PR was developed with AI assistance (Claude). All changed lines have been reviewed by the human submitter.