### PR TITLE
[Bugfix] Fix Gemma4 reasoning boundary around tool calls

### DIFF
--- a/tests/reasoning/test_gemma4_reasoning_parser.py
+++ b/tests/reasoning/test_gemma4_reasoning_parser.py
@@ -171,6 +171,16 @@ TEST_CASES = [
 ]
 
 
+def _encode_text(generic_tokenizer, text: str) -> list[int]:
+    if not text:
+        return []
+    enc = getattr(generic_tokenizer, "tokenizer", generic_tokenizer)
+    try:
+        return enc.encode(text, add_special_tokens=False)
+    except TypeError:
+        return enc.encode(text)
+
+
 def gemma4_encode_output(generic_tokenizer, output: str) -> list[int]:
     # Resolve token IDs dynamically from the real tokenizer
     vocab = generic_tokenizer.get_vocab()
@@ -185,14 +195,8 @@ def gemma4_encode_output(generic_tokenizer, output: str) -> list[int]:
     output_tokens = []
 
     def _encode(text: str) -> list[int]:
-        if not text:
-            return []
         # Handle both raw transformers and vLLM wrappers
-        enc = getattr(generic_tokenizer, "tokenizer", generic_tokenizer)
-        try:
-            return enc.encode(text, add_special_tokens=False)
-        except TypeError:
-            return enc.encode(text)
+        return _encode_text(generic_tokenizer, text)
 
     if index_start != -1:
         output_before = output[:index_start]
@@ -273,3 +277,43 @@ def test_gemma4_previous_turn_reasoning_is_reasoning_end(generic_tokenizer):
     )
     is_reasoning_end = parser.is_reasoning_end(output_tokens)
     assert not is_reasoning_end
+
+
+def test_gemma4_tool_call_boundary_before_tool_response(generic_tokenizer):
+    vocab = generic_tokenizer.get_vocab()
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        generic_tokenizer
+    )
+
+    output_tokens = (
+        [vocab["<|channel>"]]
+        + _encode_text(generic_tokenizer, "thought\nNeed a tool.")
+        + [vocab["<channel|>"], vocab["<|tool_call>"]]
+        + _encode_text(generic_tokenizer, '{"name":"first_tool"}')
+        + [vocab["<|tool_response>"]]
+    )
+
+    assert parser.is_reasoning_end(output_tokens)
+    assert parser.is_reasoning_end_streaming(output_tokens, output_tokens)
+    assert parser.extract_content_ids(output_tokens) == output_tokens[
+        output_tokens.index(vocab["<channel|>"]) + 1 :
+    ]
+
+
+def test_gemma4_tool_call_boundary_without_channel_end(generic_tokenizer):
+    vocab = generic_tokenizer.get_vocab()
+    parser: ReasoningParser = ReasoningParserManager.get_reasoning_parser(parser_name)(
+        generic_tokenizer
+    )
+
+    output_tokens = (
+        [vocab["<|channel>"]]
+        + _encode_text(generic_tokenizer, "thought\nNeed a tool.")
+        + [vocab["<|tool_call>"]]
+        + _encode_text(generic_tokenizer, '{"name":"first_tool"}')
+    )
+
+    tool_call_index = output_tokens.index(vocab["<|tool_call>"])
+    assert parser.is_reasoning_end(output_tokens)
+    assert parser.is_reasoning_end_streaming(output_tokens, output_tokens)
+    assert parser.extract_content_ids(output_tokens) == output_tokens[tool_call_index:]

--- a/vllm/reasoning/gemma4_reasoning_parser.py
+++ b/vllm/reasoning/gemma4_reasoning_parser.py
@@ -20,6 +20,14 @@ if TYPE_CHECKING:
 _THOUGHT_PREFIX = "thought\n"
 
 
+def _last_index(input_ids: Sequence[int], token_id: int) -> int:
+    """Return the last index of token_id in input_ids, or -1."""
+    for i in range(len(input_ids) - 1, -1, -1):
+        if input_ids[i] == token_id:
+            return i
+    return -1
+
+
 class Gemma4ReasoningParser(BaseThinkingReasoningParser):
     """
     Reasoning parser for Google Gemma4 thinking models.
@@ -74,27 +82,37 @@ class Gemma4ReasoningParser(BaseThinkingReasoningParser):
         return "<channel|>"
 
     def is_reasoning_end(self, input_ids: Sequence[int]) -> bool:
-        start_token_id = self.start_token_id
-        end_token_id = self.end_token_id
-        new_turn_token_id = self.new_turn_token_id
-        tool_call_token_id = self.tool_call_token_id
-        tool_response_token_id = self.tool_response_token_id
+        """Return whether the current Gemma4 turn has left reasoning mode.
 
-        # Search from the end of input_ids to find the last match.
-        for i in range(len(input_ids) - 1, -1, -1):
-            if input_ids[i] == start_token_id:
+        Gemma4 may emit a tool-call section immediately after a thinking channel:
+
+            <|channel>thought\n...<channel|><|tool_call>...<|tool_response>
+
+        In streaming/MTP chunks the trailing ``<|tool_response>`` can arrive in
+        the same delta as ``<|tool_call>``. The tool-call token is still the
+        handoff boundary for the current turn, so do not let the later tool
+        response sentinel mask it.
+        """
+        for token_id in reversed(input_ids):
+            if token_id in (self.new_turn_token_id, self.start_token_id):
                 return False
-            if input_ids[i] == tool_call_token_id:
-                # We're generating a tool call, so reasoning must be ended.
-                return True
-            if input_ids[i] in (new_turn_token_id, tool_response_token_id):
-                # We found a new turn or tool response token so don't consider
-                # reasoning ended yet, since the model starts new reasoning
-                # after these tokens.
-                return False
-            if input_ids[i] == end_token_id:
+            if token_id in (self.end_token_id, self.tool_call_token_id):
                 return True
         return False
+
+    def is_reasoning_end_streaming(
+        self, input_ids: Sequence[int], delta_ids: Sequence[int]
+    ) -> bool:
+        return self.is_reasoning_end(delta_ids)
+
+    def extract_content_ids(self, input_ids: list[int]) -> list[int]:
+        result = super().extract_content_ids(input_ids)
+        if result:
+            return result
+        tool_call_index = _last_index(input_ids, self.tool_call_token_id)
+        if tool_call_index != -1:
+            return input_ids[tool_call_index:]
+        return []
 
     # ------------------------------------------------------------------
     # Non-streaming path


### PR DESCRIPTION
## Purpose

Fix a Gemma4 streaming reasoning boundary case where a generated `<|tool_response>` marker in the same delta can mask the preceding `<|tool_call>` marker. In that case, the parser can continue treating tool-call output as reasoning/content instead of recognizing that the assistant has left the thinking channel.

The fix makes `Gemma4ReasoningParser` evaluate reasoning end state within the current turn and uses the streaming-specific delta check for in-flight tool-call boundaries.

Related work:
- Related to #40006 / #39885, but narrower: this PR only handles the current-turn tool-call boundary case and does not port the broader no-start-token fallback from #40006.

Why this is not duplicating existing PRs:
- #40006 addresses a broader multi-turn reasoning leak and modifies additional shared parser behavior. This PR keeps the change Gemma4-local and limited to the current-turn tool-call boundary validated here.
- #40965 covers partial marker leakage during reasoning-to-tool transition. This PR specifically fixes the reasoning-end decision when `<|tool_call>` and `<|tool_response>` appear in the same generated sequence.

AI assistance was used to help draft and validate this change. The submitter should review every changed line before marking this PR ready for review.

## Test Plan

- Added Gemma4 reasoning parser regression coverage for tool-call boundary before tool-response.
- Ran the reasoning parser test file against this split PR branch.
- Ran the combined changed-file parser/reasoning tests and concurrent multi-tool replay on the companion validation branch.

## Test Result

```bash
PYTHONPATH=/workspace/vllm-pr-reasoning-test \
  /workspace/gemma4_stream_patch_20260510/pytest_sys_venv/bin/python \
  -m pytest tests/reasoning/test_gemma4_reasoning_parser.py -q
# 31 passed

git diff --check
# passed
```

Combined validation branch:

```bash
PYTHONPATH=/workspace/vllm-main-check \
  /workspace/gemma4_stream_patch_20260510/pytest_sys_venv/bin/python \
  -m pytest \
  tests/reasoning/test_gemma4_reasoning_parser.py \
  tests/tool_parsers/test_gemma4_tool_parser.py \
  -q
# 94 passed
```
