### PR TITLE
[Bugfix] Fix Gemma4 streaming tool calls with accumulated parser state

### DIFF
--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -11,6 +11,7 @@ from vllm.entrypoints.openai.chat_completion.protocol import ChatCompletionReque
 from vllm.tool_parsers.gemma4_tool_parser import (
     TOOL_CALL_END,
     TOOL_CALL_START,
+    TOOL_RESPONSE,
     Gemma4ToolParser,
     _parse_gemma4_args,
     _parse_gemma4_array,
@@ -25,8 +26,25 @@ from vllm.tool_parsers.gemma4_tool_parser import (
 def mock_tokenizer():
     tokenizer = MagicMock()
     tokenizer.encode.return_value = [1, 2, 3]
-    # Include the tool call start token in the vocab for the parser
-    tokenizer.get_vocab.return_value = {TOOL_CALL_START: 48, TOOL_CALL_END: 49}
+    # Include Gemma4 tool boundary tokens in the vocab for the parser.
+    tokenizer.get_vocab.return_value = {
+        TOOL_CALL_START: 48,
+        TOOL_CALL_END: 49,
+        TOOL_RESPONSE: 50,
+    }
+
+    def decode(token_ids, skip_special_tokens=False):
+        token_map = {
+            48: TOOL_CALL_START,
+            49: TOOL_CALL_END,
+            50: TOOL_RESPONSE,
+            100: "call:first_tool{alpha:15",
+            101: ",beta:1,gamma:1990}",
+            102: "call:second_tool{delta:9,epsilon:30}",
+        }
+        return "".join(token_map.get(token_id, "") for token_id in token_ids)
+
+    tokenizer.decode.side_effect = decode
     return tokenizer
 
 
@@ -40,6 +58,7 @@ def mock_request():
     request = MagicMock(spec=ChatCompletionRequest)
     request.tools = []
     request.tool_choice = "auto"
+    request.parallel_tool_calls = True
     return request
 
 
@@ -76,6 +95,15 @@ class TestParseGemma4Args:
     def test_float_value(self):
         result = _parse_gemma4_args("score:3.14")
         assert result == {"score": 3.14}
+
+    def test_exponent_number_value(self):
+        result = _parse_gemma4_args("score:1e3")
+        assert result == {"score": 1000.0}
+
+    def test_trailing_dot_float_partial_withheld(self):
+        assert _parse_gemma4_args("score:108.", partial=True) == {}
+        assert _parse_gemma4_args("score:108.,next:1", partial=True) == {}
+        assert _parse_gemma4_args("score:108.") == {"score": 108.0}
 
     def test_boolean_true(self):
         result = _parse_gemma4_args("flag:true")
@@ -154,6 +182,11 @@ class TestParseGemma4Array:
         result = _parse_gemma4_array("42,true,3.14")
         assert result == [42, True, 3.14]
 
+    def test_trailing_dot_float_partial_withheld(self):
+        assert _parse_gemma4_array("108.", partial=True) == []
+        assert _parse_gemma4_array("108.,109", partial=True) == []
+        assert _parse_gemma4_array("108.") == [108.0]
+
     @pytest.mark.timeout(5)
     def test_string_element_with_closing_bracket(self):
         result = _parse_gemma4_array('[<|"|>a]b<|"|>,<|"|>c<|"|>],<|"|>tail<|"|>')
@@ -172,7 +205,7 @@ class TestParseGemma4Array:
 
 class TestExtractToolCalls:
     def test_no_tool_calls(self, parser, mock_request):
-        model_output = "Hello, how can I help you today?"
+        model_output = "Hello, how can I help you toalpha?"
         result = parser.extract_tool_calls(model_output, mock_request)
 
         assert result.tools_called is False
@@ -369,6 +402,25 @@ class TestStreamingExtraction:
                     if arg:
                         args_text += arg
         return args_text
+
+    def _collect_tool_calls_by_index(self, results):
+        calls: dict[int, dict[str, str | None]] = {}
+        for delta, _ in results:
+            if delta and delta.tool_calls:
+                for tc in delta.tool_calls:
+                    entry = calls.setdefault(tc.index, {"name": None, "arguments": ""})
+                    func = tc.function if isinstance(tc.function, dict) else tc.function
+                    if isinstance(func, dict):
+                        name = func.get("name")
+                        arg = func.get("arguments", "")
+                    else:
+                        name = getattr(func, "name", None)
+                        arg = getattr(func, "arguments", "") or ""
+                    if name:
+                        entry["name"] = name
+                    if arg:
+                        entry["arguments"] += arg
+        return calls
 
     def _collect_function_name(self, results):
         """Extract the function name from streaming results."""
@@ -620,9 +672,9 @@ class TestStreamingExtraction:
         captured_current_texts: list[str] = []
         original_extract_streaming = parser._extract_streaming
 
-        def wrapped_extract_streaming(previous_text, current_text, delta_text):
+        def wrapped_extract_streaming(current_text, request):
             captured_current_texts.append(current_text)
-            return original_extract_streaming(previous_text, current_text, delta_text)
+            return original_extract_streaming(current_text, request)
 
         monkeypatch.setattr(parser, "_extract_streaming", wrapped_extract_streaming)
 
@@ -699,3 +751,263 @@ class TestStreamingExtraction:
         }
 
         assert args_text.count("replace_all") == 1
+
+    def test_streaming_complete_tool_call_in_single_delta(self, parser, mock_request):
+        """A complete tool call in one delta must be emitted."""
+        chunks = [
+            '<|tool_call>call:get_station{location:<|"|>Milano<|"|>}<tool_call|>',
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        calls = self._collect_tool_calls_by_index(results)
+
+        assert set(calls) == {0}
+        assert calls[0]["name"] == "get_station"
+        assert json.loads(calls[0]["arguments"] or "{}") == {"location": "Milano"}
+
+    def test_streaming_multiple_complete_tool_calls_in_single_delta(
+        self, parser, mock_request
+    ):
+        """Multiple complete calls in one accepted delta must all be emitted."""
+        chunks = [
+            "<|tool_call>call:first_tool{alpha:15,beta:1,gamma:1990}"
+            "<tool_call|><|tool_call>call:second_tool{delta:9,epsilon:30}"
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        calls = self._collect_tool_calls_by_index(results)
+
+        assert set(calls) == {0, 1}
+        assert calls[0]["name"] == "first_tool"
+        assert json.loads(calls[0]["arguments"] or "{}") == {
+            "alpha": 15,
+            "beta": 1,
+            "gamma": 1990,
+        }
+        assert calls[1]["name"] == "second_tool"
+        assert json.loads(calls[1]["arguments"] or "{}") == {
+            "delta": 9,
+            "epsilon": 30,
+        }
+
+    def test_streaming_parallel_false_keeps_only_first_call_in_single_delta(
+        self, parser, mock_request
+    ):
+        """parallel_tool_calls=false exposes only the first streamed call."""
+        mock_request.parallel_tool_calls = False
+        chunks = [
+            "<|tool_call>call:first_tool{alpha:15,beta:1,gamma:1990}"
+            "<tool_call|><|tool_call>call:second_tool{delta:9,epsilon:30}"
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        calls = self._collect_tool_calls_by_index(results)
+
+        assert set(calls) == {0}
+        assert calls[0]["name"] == "first_tool"
+        assert json.loads(calls[0]["arguments"] or "{}") == {
+            "alpha": 15,
+            "beta": 1,
+            "gamma": 1990,
+        }
+
+    def test_streaming_close_then_open_in_same_delta(self, parser, mock_request):
+        """A delta can close one call and open the next without dropping either."""
+        chunks = [
+            "<|tool_call>call:first_tool{alpha:15,beta:1,gamma:1990}",
+            "<tool_call|><|tool_call>call:second_tool{delta:9,epsilon:30}",
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        calls = self._collect_tool_calls_by_index(results)
+
+        assert set(calls) == {0, 1}
+        assert json.loads(calls[0]["arguments"] or "{}") == {
+            "alpha": 15,
+            "beta": 1,
+            "gamma": 1990,
+        }
+        assert json.loads(calls[1]["arguments"] or "{}") == {
+            "delta": 9,
+            "epsilon": 30,
+        }
+
+    def test_streaming_incomplete_tool_call_emits_no_partial_args(
+        self, parser, mock_request
+    ):
+        """Clients cannot retract partial args if generation ends early."""
+        chunks = [
+            "<|tool_call>",
+            "call:first_tool{",
+            "alpha:15,beta:1",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+
+        assert self._collect_arguments(results) == ""
+        assert self._collect_function_name(results) is None
+
+    def test_streaming_repairs_final_end_marker_from_token_ids(
+        self, parser, mock_request
+    ):
+        """Speculative streaming may omit the terminal end marker from text."""
+        chunks = [
+            (TOOL_CALL_START, [48]),
+            ("call:first_tool{alpha:15,beta:1,gamma:1990}", [0]),
+            ("", [49, 50]),
+        ]
+        results = []
+        previous_text = ""
+        previous_token_ids = []
+
+        for delta_text, delta_token_ids in chunks:
+            current_text = previous_text + delta_text
+            current_token_ids = previous_token_ids + delta_token_ids
+            delta = parser.extract_tool_calls_streaming(
+                previous_text=previous_text,
+                current_text=current_text,
+                delta_text=delta_text,
+                previous_token_ids=tuple(previous_token_ids),
+                current_token_ids=tuple(current_token_ids),
+                delta_token_ids=tuple(delta_token_ids),
+                request=mock_request,
+            )
+            results.append((delta, current_text))
+            previous_text = current_text
+            previous_token_ids = list(current_token_ids)
+
+        calls = self._collect_tool_calls_by_index(results)
+        assert calls[0]["name"] == "first_tool"
+        assert json.loads(calls[0]["arguments"] or "{}") == {
+            "alpha": 15,
+            "beta": 1,
+            "gamma": 1990,
+        }
+        assert all(
+            not (delta and delta.content and TOOL_RESPONSE in delta.content)
+            for delta, _ in results
+        )
+
+    def test_streaming_repairs_empty_mtp_tool_text_from_token_ids(
+        self, parser, mock_request
+    ):
+        """MTP can emit tool token IDs while text deltas stay empty."""
+        chunks = [
+            ("", [48]),
+            ("", [100]),
+            ("", [101, 49, 48, 102, 49, 50]),
+        ]
+        results = []
+        previous_text = ""
+        previous_token_ids = []
+
+        for delta_text, delta_token_ids in chunks:
+            current_text = previous_text + delta_text
+            current_token_ids = previous_token_ids + delta_token_ids
+            delta = parser.extract_tool_calls_streaming(
+                previous_text=previous_text,
+                current_text=current_text,
+                delta_text=delta_text,
+                previous_token_ids=tuple(previous_token_ids),
+                current_token_ids=tuple(current_token_ids),
+                delta_token_ids=tuple(delta_token_ids),
+                request=mock_request,
+            )
+            results.append((delta, current_text))
+            previous_text = current_text
+            previous_token_ids = list(current_token_ids)
+
+        calls = self._collect_tool_calls_by_index(results)
+        assert set(calls) == {0, 1}
+        assert calls[0]["name"] == "first_tool"
+        assert json.loads(calls[0]["arguments"] or "{}") == {
+            "alpha": 15,
+            "beta": 1,
+            "gamma": 1990,
+        }
+        assert calls[1]["name"] == "second_tool"
+        assert json.loads(calls[1]["arguments"] or "{}") == {
+            "delta": 9,
+            "epsilon": 30,
+        }
+        assert all(
+            not (delta and delta.content and TOOL_RESPONSE in delta.content)
+            for delta, _ in results
+        )
+
+    def test_streaming_trailing_dot_float_split_across_chunks(
+        self, parser, mock_request
+    ):
+        """Split decimal floats must not corrupt the final streamed JSON."""
+        chunks = [
+            "<|tool_call>",
+            "call:set_coordinates{latitude:108.",
+            "2,longitude:22.",
+            "8}",
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        assert args_text
+        assert json.loads(args_text) == {"latitude": 108.2, "longitude": 22.8}
+
+
+    def test_streaming_split_start_delimiter_after_completed_call(
+        self, parser, mock_request
+    ):
+        """A split start delimiter after a close delimiter should still replay."""
+        chunks = [
+            "<|tool_call>",
+            "call:get_station_info{",
+            'location:<|"|>Milano<|"|>}<tool_call|><',
+            '|tool_call>call:get_station_info{location:<|"|>Piacenza<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        calls = self._collect_tool_calls_by_index(results)
+
+        assert set(calls) == {0, 1}
+        assert calls[0]["name"] == "get_station_info"
+        assert json.loads(calls[0]["arguments"] or "{}") == {"location": "Milano"}
+        assert calls[1]["name"] == "get_station_info"
+        assert json.loads(calls[1]["arguments"] or "{}") == {"location": "Piacenza"}
+
+    def test_streaming_filename_suffix_preserved_across_chunks(
+        self, parser, mock_request
+    ):
+        """File extensions split across chunks must not be dropped."""
+        chunks = [
+            "<|tool_call>",
+            "call:read_file{",
+            'path:<|"|>src/main.',
+            'rs<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        assert json.loads(args_text) == {"path": "src/main.rs"}
+
+    def test_streaming_string_prefix_preserved_across_chunks(
+        self, parser, mock_request
+    ):
+        """String values split after the first character must be preserved."""
+        chunks = [
+            "<|tool_call>",
+            "call:open_item{",
+            'mode:<|"|>e',
+            'dit<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+
+        assert json.loads(args_text) == {"mode": "edit"}

--- a/tests/tool_parsers/test_gemma4_tool_parser.py
+++ b/tests/tool_parsers/test_gemma4_tool_parser.py
@@ -15,6 +15,7 @@ from vllm.tool_parsers.gemma4_tool_parser import (
     Gemma4ToolParser,
     _parse_gemma4_args,
     _parse_gemma4_array,
+    _stable_partial_json_prefix,
 )
 
 # ---------------------------------------------------------------------------
@@ -105,6 +106,11 @@ class TestParseGemma4Args:
         assert _parse_gemma4_args("score:108.,next:1", partial=True) == {}
         assert _parse_gemma4_args("score:108.") == {"score": 108.0}
 
+    def test_partial_exponent_withheld(self):
+        assert _parse_gemma4_args("score:1e", partial=True) == {}
+        assert _parse_gemma4_args("score:1e+", partial=True) == {}
+        assert _parse_gemma4_args("score:1e3") == {"score": 1000.0}
+
     def test_boolean_true(self):
         result = _parse_gemma4_args("flag:true")
         assert result == {"flag": True}
@@ -113,6 +119,11 @@ class TestParseGemma4Args:
         result = _parse_gemma4_args("flag:false")
         assert result == {"flag": False}
 
+    def test_partial_bool_withheld(self):
+        assert _parse_gemma4_args("flag:tru", partial=True) == {}
+        assert _parse_gemma4_args("flag:fals", partial=True) == {}
+        assert _parse_gemma4_args("flag:true") == {"flag": True}
+
     def test_null_value(self):
         # Bare `null` must parse as None (Python), not the string "null".
         # Without this, tool_choice=auto would emit `{"param": "null"}`
@@ -120,6 +131,11 @@ class TestParseGemma4Args:
         result = _parse_gemma4_args("param:null")
         assert result == {"param": None}
         assert json.dumps(result) == '{"param": null}'
+
+    def test_partial_null_withheld(self):
+        assert _parse_gemma4_args("param:nu", partial=True) == {}
+        assert _parse_gemma4_args("param:nul", partial=True) == {}
+        assert _parse_gemma4_args("param:null") == {"param": None}
 
     def test_mixed_types(self):
         result = _parse_gemma4_args(
@@ -144,6 +160,14 @@ class TestParseGemma4Args:
         """Unterminated strings should take everything after the delimiter."""
         result = _parse_gemma4_args('key:<|"|>unterminated')
         assert result == {"key": "unterminated"}
+
+    def test_partial_unterminated_string_keeps_stable_prefix(self):
+        result = _parse_gemma4_args('key:<|"|>unterminated', partial=True)
+        assert result == {"key": "unterminated"}
+
+    def test_partial_string_delimiter_overlap_withheld(self):
+        result = _parse_gemma4_args('key:<|"|>value<|', partial=True)
+        assert result == {"key": "value"}
 
     def test_empty_value(self):
         """Key with no value after colon."""
@@ -187,6 +211,15 @@ class TestParseGemma4Array:
         assert _parse_gemma4_array("108.,109", partial=True) == []
         assert _parse_gemma4_array("108.") == [108.0]
 
+    def test_partial_bare_literal_withheld(self):
+        assert _parse_gemma4_array("tru", partial=True) == []
+        assert _parse_gemma4_array("nu", partial=True) == []
+        assert _parse_gemma4_array("1e", partial=True) == []
+        assert _parse_gemma4_array("42,tru", partial=True) == [42]
+
+    def test_partial_string_delimiter_overlap_withheld(self):
+        assert _parse_gemma4_array('<|"|>value<|', partial=True) == ["value"]
+
     @pytest.mark.timeout(5)
     def test_string_element_with_closing_bracket(self):
         result = _parse_gemma4_array('[<|"|>a]b<|"|>,<|"|>c<|"|>],<|"|>tail<|"|>')
@@ -196,6 +229,24 @@ class TestParseGemma4Array:
     def test_stray_closing_bracket(self):
         result = _parse_gemma4_array("42,]trailing")
         assert result == [42]
+
+
+class TestStablePartialJsonPrefix:
+    def test_trims_only_syntactic_suffix(self):
+        assert _stable_partial_json_prefix('{"path": "src/main.rs"}') == (
+            '{"path": "src/main.rs'
+        )
+
+    def test_preserves_closing_chars_inside_string_values(self):
+        assert _stable_partial_json_prefix('{"pattern": "value}]"}') == (
+            '{"pattern": "value}]'
+        )
+
+    def test_trims_nested_syntactic_suffix(self):
+        assert (
+            _stable_partial_json_prefix('{"payload": {"path": "src/main.rs"}}')
+            == '{"payload": {"path": "src/main.rs'
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -402,6 +453,23 @@ class TestStreamingExtraction:
                     if arg:
                         args_text += arg
         return args_text
+
+    def _collect_argument_prefixes(self, results):
+        """Collect the assembled argument string after each argument delta."""
+        prefixes: list[str] = []
+        args_text = ""
+        for delta, _ in results:
+            if delta and delta.tool_calls:
+                for tc in delta.tool_calls:
+                    func = tc.function if isinstance(tc.function, dict) else tc.function
+                    if isinstance(func, dict):
+                        arg = func.get("arguments", "")
+                    else:
+                        arg = getattr(func, "arguments", "") or ""
+                    if arg:
+                        args_text += arg
+                        prefixes.append(args_text)
+        return prefixes
 
     def _collect_tool_calls_by_index(self, results):
         calls: dict[int, dict[str, str | None]] = {}
@@ -835,10 +903,10 @@ class TestStreamingExtraction:
             "epsilon": 30,
         }
 
-    def test_streaming_incomplete_tool_call_emits_no_partial_args(
+    def test_streaming_incomplete_tool_call_emits_stable_partial_args(
         self, parser, mock_request
     ):
-        """Clients cannot retract partial args if generation ends early."""
+        """Incomplete calls may stream append-only stable argument prefixes."""
         chunks = [
             "<|tool_call>",
             "call:first_tool{",
@@ -847,8 +915,72 @@ class TestStreamingExtraction:
 
         results = self._simulate_streaming(parser, mock_request, chunks)
 
-        assert self._collect_arguments(results) == ""
-        assert self._collect_function_name(results) is None
+        assert self._collect_function_name(results) == "first_tool"
+        args_text = self._collect_arguments(results)
+        assert args_text == '{"alpha": 15'
+        assert "beta" not in args_text
+
+    def test_streaming_partial_string_argument_is_append_only(
+        self, parser, mock_request
+    ):
+        """String argument chunks may stream before the closing delimiter."""
+        chunks = [
+            "<|tool_call>",
+            "call:read_file{",
+            'path:<|"|>src/main.',
+            'rs<|"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+        prefixes = self._collect_argument_prefixes(results)
+
+        assert json.loads(args_text) == {"path": "src/main.rs"}
+        assert any(prefix == '{"path": "src/main.' for prefix in prefixes)
+        assert all(args_text.startswith(prefix) for prefix in prefixes)
+
+    def test_streaming_partial_string_delimiter_overlap_is_withheld(
+        self, parser, mock_request
+    ):
+        """Partial string delimiter bytes must not be streamed as arguments."""
+        chunks = [
+            "<|tool_call>",
+            "call:add_note{",
+            'content:<|"|>Buy milk<|',
+            '"|>}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+        prefixes = self._collect_argument_prefixes(results)
+
+        assert json.loads(args_text) == {"content": "Buy milk"}
+        assert all("<|" not in prefix for prefix in prefixes)
+        assert all(args_text.startswith(prefix) for prefix in prefixes)
+
+    def test_streaming_nested_partial_args_are_append_only(self, parser, mock_request):
+        """Nested objects and arrays stream only prefixes that can grow."""
+        chunks = [
+            "<|tool_call>",
+            "call:update_item{",
+            'payload:{path:<|"|>src/main.',
+            'rs<|"|>,enabled:true},items:[<|"|>a<|"|>,<|"|>b',
+            'eta<|"|>]}',
+            "<tool_call|>",
+        ]
+
+        results = self._simulate_streaming(parser, mock_request, chunks)
+        args_text = self._collect_arguments(results)
+        prefixes = self._collect_argument_prefixes(results)
+
+        assert json.loads(args_text) == {
+            "payload": {"path": "src/main.rs", "enabled": True},
+            "items": ["a", "beta"],
+        }
+        assert any(prefix == '{"payload": {"path": "src/main.' for prefix in prefixes)
+        assert all(args_text.startswith(prefix) for prefix in prefixes)
 
     def test_streaming_repairs_final_end_marker_from_token_ids(
         self, parser, mock_request
@@ -955,7 +1087,6 @@ class TestStreamingExtraction:
 
         assert args_text
         assert json.loads(args_text) == {"latitude": 108.2, "longitude": 22.8}
-
 
     def test_streaming_split_start_delimiter_after_completed_call(
         self, parser, mock_request

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -18,6 +18,7 @@ see ``vllm.tool_parsers.gemma4_utils.parse_tool_calls``.
 
 import json
 from collections.abc import Sequence
+from dataclasses import dataclass
 
 import regex as re
 
@@ -39,14 +40,27 @@ from vllm.entrypoints.openai.responses.protocol import (
 from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import Tool, ToolParser
-from vllm.tool_parsers.utils import find_common_prefix
+from vllm.tool_parsers.utils import find_common_prefix, partial_tag_overlap
 
 logger = init_logger(__name__)
+
 
 # Gemma4 special tokens for tool calls
 TOOL_CALL_START = "<|tool_call>"
 TOOL_CALL_END = "<tool_call|>"
+TOOL_RESPONSE = "<|tool_response>"
 STRING_DELIM = '<|"|>'
+_NUMBER_LITERAL_RE = re.compile(
+    r"^[+-]?(?:(?:\d+(?:\.\d*)?)|(?:\.\d+))(?:[eE][+-]?\d+)?$"
+)
+_INT_LITERAL_RE = re.compile(r"^[+-]?\d+$")
+
+
+@dataclass
+class _StreamingToolCall:
+    name: str
+    raw_arguments: str
+    complete: bool
 
 
 # ---------------------------------------------------------------------------
@@ -70,16 +84,34 @@ def _parse_gemma4_value(value_str: str) -> object:
     if value_str.lower() in ("null", "none", "nil"):
         return None
 
-    # Number (int or float)
-    try:
-        if "." in value_str:
-            return float(value_str)
-        return int(value_str)
-    except ValueError:
-        pass
+    # Number (int or float). Gemma4 follows JSON-like numeric literals, and
+    # exponent-form values such as 1e3 must remain numeric, not bare strings.
+    if _NUMBER_LITERAL_RE.match(value_str):
+        if _INT_LITERAL_RE.match(value_str):
+            return int(value_str)
+        return float(value_str)
 
     # Bare string (no <|"|> delimiters — shouldn't happen but be safe)
     return value_str
+
+
+def _is_unstable_partial_bare_value(value_str: str) -> bool:
+    value_str = value_str.strip()
+    if not value_str:
+        return True
+
+    lower = value_str.lower()
+    for literal in ("true", "false", "null", "none", "nil"):
+        if literal.startswith(lower) and lower != literal:
+            return True
+
+    # Numeric literals are type-unstable while ending in decimal/exponent
+    # punctuation. This mirrors llama.cpp's "maybe number" partial handling.
+    if value_str in {"+", "-"}:
+        return True
+    return value_str[-1] in {".", "e", "E", "+", "-"} and any(
+        char.isdigit() for char in value_str
+    )
 
 
 def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
@@ -211,6 +243,12 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
                     i,
                 )
                 break
+            if partial:
+                raw_val = args_str[val_start:i].strip()
+                if _is_unstable_partial_bare_value(raw_val):
+                    # Decimal/exponent digits may still arrive: "108." can
+                    # become "108.2", and "1e" can become "1e3".
+                    break
             result[key] = _parse_gemma4_value(args_str[val_start:i])
 
     return result
@@ -294,6 +332,10 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
                     i,
                 )
                 break
+            if partial:
+                raw_val = arr_str[val_start:i].strip()
+                if _is_unstable_partial_bare_value(raw_val):
+                    break
             items.append(_parse_gemma4_value(arr_str[val_start:i]))
 
     return items
@@ -343,10 +385,12 @@ class Gemma4ToolParser(ToolParser):
         # Token strings
         self.tool_call_start_token = TOOL_CALL_START
         self.tool_call_end_token = TOOL_CALL_END
+        self.tool_response_token = TOOL_RESPONSE
 
         # Token IDs
         self.tool_call_start_token_id = self.vocab.get(TOOL_CALL_START)
         self.tool_call_end_token_id = self.vocab.get(TOOL_CALL_END)
+        self.tool_response_token_id = self.vocab.get(TOOL_RESPONSE)
 
         if self.tool_call_start_token_id is None:
             raise RuntimeError(
@@ -365,15 +409,17 @@ class Gemma4ToolParser(ToolParser):
         # Streaming state — reset per-request via _reset_streaming_state()
         self._reset_streaming_state()
 
-        # Delta buffer for handling multi-token special sequences
-        self.buffered_delta_text = ""
-
     def _reset_streaming_state(self) -> None:
         """Reset all streaming state for a new request."""
-        self.current_tool_id = -1
-        self.current_tool_name_sent = False
+        # Keep the public backfill fields empty. Gemma4 does its own
+        # complete-call diffing, and the generic serving-layer terminal
+        # backfill cannot safely replay multiple Gemma4 calls from one delta.
         self.prev_tool_call_arr: list[dict] = []
         self.streamed_args_for_tool: list[str] = []
+        self._streaming_tool_states: list[dict] = []
+        self._streamed_args_for_tool: list[str] = []
+        self._streaming_text = ""
+        self._sent_content_idx = 0
 
     def adjust_request(
         self, request: ChatCompletionRequest | ResponsesRequest
@@ -390,36 +436,77 @@ class Gemma4ToolParser(ToolParser):
         return request
 
     # ------------------------------------------------------------------
-    # Delta buffering for multi-token special sequences
+    # Delta repair for multi-token/speculative special sequences
     # ------------------------------------------------------------------
 
-    def _buffer_delta_text(self, delta_text: str) -> str:
-        """Buffer incoming delta text to handle multi-token special sequences.
+    def _repair_delta_text_from_token_ids(
+        self, delta_text: str, delta_token_ids: Sequence[int]
+    ) -> str:
+        """Restore Gemma4 tool-call text when text deltas omit token text.
 
-        Accumulates partial tokens that could be the start of
-        ``<|tool_call>`` or ``<tool_call|>`` and only flushes them
-        when the complete sequence is recognized or the sequence breaks.
-
-        This prevents partial special tokens (e.g., ``<|tool``) from being
-        emitted prematurely as content text.
+        Speculative/MTP streaming can surface tool-call token IDs while the
+        corresponding ``delta_text`` is empty, especially around Gemma4 special
+        tokens. In that case the accumulated text never contains the closing
+        ``<tool_call|>`` marker, so streaming parsers cannot safely expose the
+        completed call. Only repair the Gemma4 tool-call path; normal content
+        continues to use the engine-provided text delta.
         """
-        combined = self.buffered_delta_text + delta_text
+        special_token_ids = {
+            token_id
+            for token_id in (
+                self.tool_call_start_token_id,
+                self.tool_call_end_token_id,
+                self.tool_response_token_id,
+            )
+            if token_id is not None
+        }
+        has_special_token = bool(special_token_ids) and any(
+            token_id in special_token_ids for token_id in delta_token_ids
+        )
+        if not delta_token_ids or (
+            not has_special_token
+            and (delta_text or not self._inside_tool_call_text())
+        ):
+            return delta_text
 
-        # Check if combined ends with a complete special token
-        if combined.endswith(TOOL_CALL_START) or combined.endswith(TOOL_CALL_END):
-            self.buffered_delta_text = ""
-            return combined
+        try:
+            decoded = self.model_tokenizer.decode(
+                list(delta_token_ids), skip_special_tokens=False
+            )
+        except TypeError:
+            decoded = self.model_tokenizer.decode(list(delta_token_ids))
+        except Exception:
+            logger.debug("Could not decode Gemma4 delta token ids", exc_info=True)
+            return delta_text
 
-        # Check if combined ends with a partial prefix of a special token
-        for tag in [TOOL_CALL_START, TOOL_CALL_END]:
-            for i in range(1, len(tag)):
-                if combined.endswith(tag[:i]):
-                    self.buffered_delta_text = combined[-i:]
-                    return combined[:-i]
+        if not isinstance(decoded, str) or not decoded:
+            return delta_text
 
-        # No partial match — flush everything
-        self.buffered_delta_text = ""
-        return combined
+        # <|tool_response> is a stop/control marker for the next turn, not part
+        # of the assistant tool call payload. Keep the tool-call end marker that
+        # may precede it, but never stream the response marker as content.
+        decoded = decoded.replace(self.tool_response_token, "")
+        if not decoded:
+            return delta_text
+
+        missing_start = (
+            self.tool_call_start_token in decoded
+            and self.tool_call_start_token not in delta_text
+        )
+        missing_end = (
+            self.tool_call_end_token in decoded
+            and self.tool_call_end_token not in delta_text
+        )
+        if not delta_text or missing_start or missing_end:
+            return decoded
+        return delta_text
+
+    def _inside_tool_call_text(self) -> bool:
+        last_start = self._streaming_text.rfind(self.tool_call_start_token)
+        if last_start == -1:
+            return False
+        last_end = self._streaming_text.rfind(self.tool_call_end_token)
+        return last_end < last_start
 
     # ------------------------------------------------------------------
     # Non-streaming extraction
@@ -485,24 +572,22 @@ class Gemma4ToolParser(ToolParser):
         delta_token_ids: Sequence[int],
         request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
-        # Buffer delta text to handle multi-token special sequences
-        delta_text = self._buffer_delta_text(delta_text)
-        # Keep current_text from the upstream stream state. The buffered delta
-        # is only for emission, and must not be stitched back into the
-        # accumulated model text or normal content like "<div>" can be
-        # duplicated into "<<div>" when a tool call just ended.
-
-        # If no tool call token seen yet, emit as content
-        if self.tool_call_start_token not in current_text:
-            if delta_text:
-                return DeltaMessage(content=delta_text)
-            return None
+        # Keep a Gemma4-local accumulated text buffer. Speculative/MTP streaming
+        # may provide token IDs with empty text deltas for tool-call spans; the
+        # serving-layer text accumulator cannot represent those repaired deltas.
+        if not previous_text and not previous_token_ids:
+            self._reset_streaming_state()
+        previous_text = self._streaming_text
+        delta_text = self._repair_delta_text_from_token_ids(
+            delta_text, delta_token_ids
+        )
+        current_text = previous_text + delta_text
+        self._streaming_text = current_text
 
         try:
             return self._extract_streaming(
-                previous_text=previous_text,
                 current_text=current_text,
-                delta_text=delta_text,
+                request=request,
             )
         except Exception:
             logger.exception("Error in Gemma4 streaming tool call extraction")
@@ -510,269 +595,203 @@ class Gemma4ToolParser(ToolParser):
 
     def _extract_streaming(
         self,
-        previous_text: str,
         current_text: str,
-        delta_text: str,
+        request: ChatCompletionRequest,
     ) -> DeltaMessage | None:
-        """Tag-counting streaming parser.
+        """Parse accumulated text into structured tool calls, then emit diffs."""
+        tool_calls = self._parse_streaming_tool_calls(current_text)
+        if request.parallel_tool_calls is False:
+            tool_calls = tool_calls[:1]
 
-        Uses the proven approach from FunctionGemma/Hermes: count start/end
-        tags in previous vs current text to determine phase, then
-        accumulate-parse-diff for arguments.
+        content = self._extract_content(current_text)
+        tool_call_deltas = self._diff_streaming_tool_calls(tool_calls)
 
-        Format: ``<|tool_call>call:name{args}<tool_call|>``
-        """
-        start_count = current_text.count(self.tool_call_start_token)
-        end_count = current_text.count(self.tool_call_end_token)
-        prev_start_count = previous_text.count(self.tool_call_start_token)
-        prev_end_count = previous_text.count(self.tool_call_end_token)
-
-        # Case 1: Not inside any tool call — emit as content
-        if (
-            start_count == end_count
-            and prev_end_count == end_count
-            and self.tool_call_end_token not in delta_text
-        ):
-            if delta_text:
-                return DeltaMessage(content=delta_text)
-            return None
-
-        # Case 2: Starting a new tool call
-        if start_count > prev_start_count and start_count > end_count:
-            self.current_tool_id += 1
-            self.current_tool_name_sent = False
-            self.streamed_args_for_tool.append("")
-            self.prev_tool_call_arr.append({})
-            logger.debug("Starting new tool call %d", self.current_tool_id)
-            # Don't return yet — fall through to try parsing if there's
-            # content after <|tool_call> in this same delta
-            # (but usually it's just the token itself, so return None)
-            if len(delta_text) <= len(self.tool_call_start_token):
-                return None
-
-        # Case 3: Tool call just ended
-        if end_count > prev_end_count:
-            return self._handle_tool_call_end(current_text)
-
-        # Case 4: In the middle of a tool call — parse partial content
-        if start_count > end_count:
-            return self._handle_tool_call_middle(current_text)
-
-        # Default: generate text outside tool calls
-        if delta_text:
-            text = delta_text.replace(self.tool_call_start_token, "")
-            text = text.replace(self.tool_call_end_token, "")
-            if text:
-                return DeltaMessage(content=text)
+        if content or tool_call_deltas:
+            return DeltaMessage(content=content, tool_calls=tool_call_deltas)
         return None
 
-    def _extract_partial_call(self, current_text: str) -> tuple[str | None, str]:
-        """Extract function name and raw argument string from partial text.
+    def _parse_streaming_tool_calls(self, text: str) -> list[_StreamingToolCall]:
+        """Extract complete calls plus the active partial call from accumulated text."""
+        tool_calls: list[_StreamingToolCall] = []
+        pos = 0
 
-        Returns (func_name, raw_args_str) or (None, "") if not parseable yet.
-        """
-        # Get the text after the last <|tool_call> token
-        last_start = current_text.rfind(self.tool_call_start_token)
-        if last_start == -1:
-            return None, ""
+        while True:
+            start = text.find(self.tool_call_start_token, pos)
+            if start == -1:
+                break
 
-        partial_call = current_text[last_start + len(self.tool_call_start_token) :]
+            body_start = start + len(self.tool_call_start_token)
+            if not text.startswith("call:", body_start):
+                pos = body_start
+                continue
 
-        # Strip end token if present
-        if self.tool_call_end_token in partial_call:
-            partial_call = partial_call.split(self.tool_call_end_token)[0]
+            name_start = body_start + len("call:")
+            brace = text.find("{", name_start)
+            next_start = text.find(self.tool_call_start_token, body_start)
+            end_before_brace = text.find(self.tool_call_end_token, body_start)
+            if (
+                brace == -1
+                or (next_start != -1 and next_start < brace)
+                or (end_before_brace != -1 and end_before_brace < brace)
+            ):
+                break
 
-        # Expect "call:name{args...}" or "call:name{args...}"
-        if not partial_call.startswith("call:"):
-            return None, ""
+            name = text[name_start:brace].strip()
+            if not name:
+                break
 
-        func_part = partial_call[5:]  # skip "call:"
+            end = text.find(self.tool_call_end_token, brace + 1)
+            complete = end != -1
+            if complete:
+                raw_arguments = text[brace + 1 : end]
+                pos = end + len(self.tool_call_end_token)
+            else:
+                raw_arguments = text[brace + 1 :]
+                next_partial_start = raw_arguments.find(self.tool_call_start_token)
+                if next_partial_start != -1:
+                    raw_arguments = raw_arguments[:next_partial_start]
+                pos = len(text)
 
-        if "{" not in func_part:
-            # Still accumulating function name, not ready yet
-            return None, ""
+            if raw_arguments.endswith("}"):
+                raw_arguments = raw_arguments[:-1]
 
-        func_name, _, args_part = func_part.partition("{")
-        func_name = func_name.strip()
-
-        # Strip trailing '}' if present (Gemma4 structural brace)
-        if args_part.endswith("}"):
-            args_part = args_part[:-1]
-
-        return func_name, args_part
-
-    def _handle_tool_call_middle(self, current_text: str) -> DeltaMessage | None:
-        """Handle streaming when we're inside an active tool call.
-
-        Accumulates the raw Gemma4 arguments, parses them into JSON, and
-        diffs against the previously-streamed JSON to emit only the new
-        fragment.
-        """
-        func_name, args_part = self._extract_partial_call(current_text)
-
-        if func_name is None:
-            return None
-
-        # Step 1: Send function name (once)
-        if not self.current_tool_name_sent and func_name:
-            self.current_tool_name_sent = True
-            self.prev_tool_call_arr[self.current_tool_id] = {
-                "name": func_name,
-                "arguments": {},
-            }
-            return DeltaMessage(
-                tool_calls=[
-                    DeltaToolCall(
-                        index=self.current_tool_id,
-                        type="function",
-                        id=make_tool_call_id(),
-                        function=DeltaFunctionCall(
-                            name=func_name,
-                            arguments="",
-                        ).model_dump(exclude_none=True),
-                    )
-                ]
-            )
-
-        # Step 2: Parse and diff arguments
-        if self.current_tool_name_sent and args_part:
-            return self._emit_argument_diff(args_part)
-
-        return None
-
-    def _handle_tool_call_end(self, current_text: str) -> DeltaMessage | None:
-        """Handle streaming when a tool call has just completed.
-
-        Performs a final parse of the complete tool call and flushes
-        any remaining un-streamed argument fragments.
-        """
-        if self.current_tool_id < 0 or self.current_tool_id >= len(
-            self.prev_tool_call_arr
-        ):
-            logger.debug(
-                "Tool call end detected but no active tool call (current_tool_id=%d)",
-                self.current_tool_id,
-            )
-            return None
-
-        # Parse the complete tool call using regex for accuracy
-        all_matches = self.tool_call_regex.findall(current_text)
-        if self.current_tool_id < len(all_matches):
-            _, args_str = all_matches[self.current_tool_id]
-            final_args = _parse_gemma4_args(args_str)
-            final_args_json = json.dumps(final_args, ensure_ascii=False)
-
-            prev_streamed = self.streamed_args_for_tool[self.current_tool_id]
-            if len(final_args_json) > len(prev_streamed):
-                diff = final_args_json[len(prev_streamed) :]
-                self.streamed_args_for_tool[self.current_tool_id] = final_args_json
-                self.prev_tool_call_arr[self.current_tool_id]["arguments"] = final_args
-
-                return DeltaMessage(
-                    tool_calls=[
-                        DeltaToolCall(
-                            index=self.current_tool_id,
-                            function=DeltaFunctionCall(arguments=diff).model_dump(
-                                exclude_none=True
-                            ),
-                        )
-                    ]
+            tool_calls.append(
+                _StreamingToolCall(
+                    name=name,
+                    raw_arguments=raw_arguments,
+                    complete=complete,
                 )
+            )
 
-        return None
+            if not complete:
+                break
 
-    def _emit_argument_diff(self, raw_args_str: str) -> DeltaMessage | None:
-        """Parse raw Gemma4 arguments, convert to JSON, diff, and emit.
+        return tool_calls
 
-        This is the core of the accumulate-then-parse-then-diff strategy:
-        1. Parse ``raw_args_str`` with ``_parse_gemma4_args()``
-        2. Convert to JSON string with ``json.dumps()``
-        3. Withhold trailing closing characters (``"}``) that may move
-           as more tokens arrive
-        4. Diff against previously streamed JSON and emit only new chars
+    def _diff_streaming_tool_calls(
+        self, tool_calls: list[_StreamingToolCall]
+    ) -> list[DeltaToolCall]:
+        deltas: list[DeltaToolCall] = []
 
-        **Why withholding is necessary:**
+        for index, tool_call in enumerate(tool_calls):
+            # Do not expose partial tool-call arguments. If generation stops
+            # before Gemma4 emits <tool_call|>, streaming clients
+            # cannot retract already-streamed malformed JSON. Buffering until
+            # the complete tool-call marker keeps streamed tool calls valid.
+            if not tool_call.complete:
+                continue
 
-        Gemma4's custom format produces *structurally incomplete* JSON
-        during streaming. For example, when ``<|"|>Paris`` arrives
-        without a closing delimiter, ``_parse_gemma4_args`` treats it
-        as a complete value and produces ``{"location": "Paris"}``. But
-        when ``, France<|"|>`` arrives next, the JSON becomes
-        ``{"location": "Paris, France"}``. If we had sent the closing
-        ``"}`` from the first parse, the concatenated client output
-        would be ``{"location": "Paris"}France"}``, which is garbage.
+            self._ensure_streaming_tool_state(index, tool_call.name)
+            state = self._streaming_tool_states[index]
+            emit_header = not state.get("name_sent", False)
+            arguments_diff = self._compute_arguments_diff(index, tool_call)
 
-        The solution: **never send trailing closing chars during
-        streaming**. They get flushed by ``_handle_tool_call_end()``
-        when the ``<tool_call|>`` end marker arrives.
+            if not emit_header and arguments_diff is None:
+                continue
 
-        Args:
-            raw_args_str: The raw Gemma4 argument text accumulated so far
-                (without the surrounding ``{`` ``}``).
+            deltas.append(
+                DeltaToolCall(
+                    index=index,
+                    id=state["id"] if emit_header else None,
+                    type="function" if emit_header else None,
+                    function=DeltaFunctionCall(
+                        name=tool_call.name if emit_header else None,
+                        arguments=arguments_diff if arguments_diff is not None else "",
+                    ).model_dump(exclude_none=True),
+                )
+            )
+            if emit_header:
+                state["name_sent"] = True
 
-        Returns:
-            DeltaMessage with the argument diff, or None if no new content.
-        """
+        return deltas
+
+    def _ensure_streaming_tool_state(self, index: int, name: str) -> None:
+        while len(self._streaming_tool_states) <= index:
+            self._streaming_tool_states.append({})
+        while len(self._streamed_args_for_tool) <= index:
+            self._streamed_args_for_tool.append("")
+
+        state = self._streaming_tool_states[index]
+        state.setdefault("id", make_tool_call_id())
+        state.setdefault("name", name)
+        state.setdefault("arguments", {})
+
+    def _compute_arguments_diff(
+        self, index: int, tool_call: _StreamingToolCall
+    ) -> str | None:
+        arguments_json = self._arguments_json_for_streaming(tool_call)
+        if arguments_json is None:
+            return None
+
+        prev_streamed = self._streamed_args_for_tool[index]
+        if arguments_json == prev_streamed:
+            return None
+
+        if prev_streamed:
+            prefix = find_common_prefix(prev_streamed, arguments_json)
+            if len(prefix) < len(prev_streamed):
+                self._streamed_args_for_tool[index] = prefix
+                return None
+            diff = arguments_json[len(prev_streamed) :]
+        else:
+            diff = arguments_json
+
+        if not diff:
+            return None
+
+        self._streamed_args_for_tool[index] = arguments_json
+        self._streaming_tool_states[index]["arguments"] = json.loads(arguments_json)
+        return diff
+
+    def _arguments_json_for_streaming(
+        self, tool_call: _StreamingToolCall
+    ) -> str | None:
         try:
-            current_args = _parse_gemma4_args(raw_args_str, partial=True)
+            arguments = _parse_gemma4_args(
+                tool_call.raw_arguments,
+                partial=not tool_call.complete,
+            )
         except Exception:
             logger.debug(
-                "Could not parse partial Gemma4 args yet: %s",
-                raw_args_str[:100],
+                "Could not parse Gemma4 streaming args yet: %s",
+                tool_call.raw_arguments[:100],
             )
             return None
 
-        if not current_args:
+        if not arguments and not tool_call.complete:
             return None
 
-        current_args_json = json.dumps(current_args, ensure_ascii=False)
+        return json.dumps(arguments, ensure_ascii=False)
 
-        # Withhold trailing closing characters that may shift as more
-        # tokens arrive. Strip trailing '}', '"', ']' and partial
-        # STRING_DELIM fragments ('<', '|', '\\', '>') to get the
-        # "safe prefix".
-        safe_json = current_args_json
-        while safe_json and safe_json[-1] in ("}", '"', "]", "<", "|", "\\", ">"):
-            safe_json = safe_json[:-1]
+    def _extract_content(self, current_text: str) -> str | None:
+        """Return unsent non-tool-call text, holding partial start tags."""
+        content_parts: list[str] = []
+        pos = self._sent_content_idx
+        text_len = len(current_text)
 
-        prev_streamed = self.streamed_args_for_tool[self.current_tool_id]
+        while pos < text_len:
+            start = current_text.find(self.tool_call_start_token, pos)
+            if start == -1:
+                overlap = partial_tag_overlap(
+                    current_text[pos:], self.tool_call_start_token
+                )
+                sendable_end = text_len - overlap
+                if sendable_end > pos:
+                    content_parts.append(current_text[pos:sendable_end])
+                    pos = sendable_end
+                break
 
-        if not safe_json or safe_json == prev_streamed:
-            return None
+            if start > pos:
+                content_parts.append(current_text[pos:start])
 
-        # Use find_common_prefix to handle cases where the value changed
-        # structurally (e.g., a string grew).
-        if prev_streamed:
-            prefix = find_common_prefix(prev_streamed, safe_json)
-            sent_len = len(prev_streamed)
-            prefix_len = len(prefix)
-
-            if prefix_len < sent_len:
-                # Structure changed — we sent too much. Truncate our
-                # tracking to the common prefix and wait for the final
-                # flush in _handle_tool_call_end.
-                self.streamed_args_for_tool[self.current_tool_id] = prefix
-                return None
-
-            # Stream the new stable portion
-            diff = safe_json[sent_len:]
-        else:
-            # First emission
-            diff = safe_json
-
-        if diff:
-            self.streamed_args_for_tool[self.current_tool_id] = safe_json
-            self.prev_tool_call_arr[self.current_tool_id]["arguments"] = current_args
-
-            return DeltaMessage(
-                tool_calls=[
-                    DeltaToolCall(
-                        index=self.current_tool_id,
-                        function=DeltaFunctionCall(arguments=diff).model_dump(
-                            exclude_none=True
-                        ),
-                    )
-                ]
+            end = current_text.find(
+                self.tool_call_end_token,
+                start + len(self.tool_call_start_token),
             )
+            if end == -1:
+                pos = start
+                break
+            pos = end + len(self.tool_call_end_token)
 
-        return None
+        self._sent_content_idx = pos
+        return "".join(content_parts) or None

--- a/vllm/tool_parsers/gemma4_tool_parser.py
+++ b/vllm/tool_parsers/gemma4_tool_parser.py
@@ -40,7 +40,7 @@ from vllm.entrypoints.openai.responses.protocol import (
 from vllm.logger import init_logger
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers.abstract_tool_parser import Tool, ToolParser
-from vllm.tool_parsers.utils import find_common_prefix, partial_tag_overlap
+from vllm.tool_parsers.utils import partial_tag_overlap
 
 logger = init_logger(__name__)
 
@@ -114,6 +114,62 @@ def _is_unstable_partial_bare_value(value_str: str) -> bool:
     )
 
 
+def _trim_partial_string_overlap(value: str) -> str:
+    overlap = partial_tag_overlap(value, STRING_DELIM)
+    if overlap:
+        return value[:-overlap]
+    return value
+
+
+def _json_closing_syntax_positions(json_text: str) -> set[int]:
+    """Return positions of syntactic closers in a JSON string."""
+    positions: set[int] = set()
+    in_string = False
+    escaped = False
+
+    for index, char in enumerate(json_text):
+        if in_string:
+            if escaped:
+                escaped = False
+            elif char == "\\":
+                escaped = True
+            elif char == '"':
+                in_string = False
+                positions.add(index)
+            continue
+
+        if char == '"':
+            in_string = True
+        elif char in ("}", "]"):
+            positions.add(index)
+
+    return positions
+
+
+def _stable_partial_json_prefix(json_text: str) -> str:
+    """Remove only syntactic trailing closers from partial JSON.
+
+    Streaming tool-call argument deltas are fragments of one final JSON string.
+    For an incomplete Gemma4 tool call, remove closing quotes/brackets/braces
+    that may need to grow when more raw Gemma4 arguments arrive. Closing
+    characters that belong to string content are preserved.
+    """
+    closing_positions = _json_closing_syntax_positions(json_text)
+    end = len(json_text)
+
+    while end > 0:
+        pos = end - 1
+        if json_text[pos].isspace():
+            end = pos
+            continue
+        if pos in closing_positions:
+            end = pos
+            continue
+        break
+
+    return json_text[:end]
+
+
 def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
     """Parse Gemma4's custom key:value format into a Python dict.
 
@@ -127,9 +183,10 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
 
     Args:
         args_str: The raw Gemma4 argument string.
-        partial: When True (streaming), bare values at end of string are
-            omitted because they may be incomplete and type-unstable
-            (e.g. partial boolean parsed as bare string).
+        partial: When True (streaming), unstable bare values are omitted
+            because they may be incomplete and type-unstable. Partial strings
+            are kept with any trailing delimiter overlap removed so the
+            streaming diff can emit append-only JSON prefixes.
 
     Returns a dict ready for ``json.dumps()``.
     """
@@ -176,8 +233,8 @@ def _parse_gemma4_args(args_str: str, *, partial: bool = False) -> dict:
             val_start = i
             end_pos = args_str.find(STRING_DELIM, i)
             if end_pos == -1:
-                # Unterminated string — take rest
-                result[key] = args_str[val_start:]
+                value = args_str[val_start:]
+                result[key] = _trim_partial_string_overlap(value) if partial else value
                 break
             result[key] = args_str[val_start:end_pos]
             i = end_pos + len(STRING_DELIM)
@@ -271,7 +328,8 @@ def _parse_gemma4_array(arr_str: str, *, partial: bool = False) -> list:
             i += len(STRING_DELIM)
             end_pos = arr_str.find(STRING_DELIM, i)
             if end_pos == -1:
-                items.append(arr_str[i:])
+                value = arr_str[i:]
+                items.append(_trim_partial_string_overlap(value) if partial else value)
                 break
             items.append(arr_str[i:end_pos])
             i = end_pos + len(STRING_DELIM)
@@ -464,8 +522,7 @@ class Gemma4ToolParser(ToolParser):
             token_id in special_token_ids for token_id in delta_token_ids
         )
         if not delta_token_ids or (
-            not has_special_token
-            and (delta_text or not self._inside_tool_call_text())
+            not has_special_token and (delta_text or not self._inside_tool_call_text())
         ):
             return delta_text
 
@@ -578,9 +635,7 @@ class Gemma4ToolParser(ToolParser):
         if not previous_text and not previous_token_ids:
             self._reset_streaming_state()
         previous_text = self._streaming_text
-        delta_text = self._repair_delta_text_from_token_ids(
-            delta_text, delta_token_ids
-        )
+        delta_text = self._repair_delta_text_from_token_ids(delta_text, delta_token_ids)
         current_text = previous_text + delta_text
         self._streaming_text = current_text
 
@@ -674,13 +729,6 @@ class Gemma4ToolParser(ToolParser):
         deltas: list[DeltaToolCall] = []
 
         for index, tool_call in enumerate(tool_calls):
-            # Do not expose partial tool-call arguments. If generation stops
-            # before Gemma4 emits <tool_call|>, streaming clients
-            # cannot retract already-streamed malformed JSON. Buffering until
-            # the complete tool-call marker keeps streamed tool calls valid.
-            if not tool_call.complete:
-                continue
-
             self._ensure_streaming_tool_state(index, tool_call.name)
             state = self._streaming_tool_states[index]
             emit_header = not state.get("name_sent", False)
@@ -727,20 +775,17 @@ class Gemma4ToolParser(ToolParser):
         if arguments_json == prev_streamed:
             return None
 
-        if prev_streamed:
-            prefix = find_common_prefix(prev_streamed, arguments_json)
-            if len(prefix) < len(prev_streamed):
-                self._streamed_args_for_tool[index] = prefix
-                return None
-            diff = arguments_json[len(prev_streamed) :]
-        else:
-            diff = arguments_json
+        if prev_streamed and not arguments_json.startswith(prev_streamed):
+            return None
+
+        diff = arguments_json[len(prev_streamed) :]
 
         if not diff:
             return None
 
         self._streamed_args_for_tool[index] = arguments_json
-        self._streaming_tool_states[index]["arguments"] = json.loads(arguments_json)
+        if tool_call.complete:
+            self._streaming_tool_states[index]["arguments"] = json.loads(arguments_json)
         return diff
 
     def _arguments_json_for_streaming(
@@ -761,7 +806,10 @@ class Gemma4ToolParser(ToolParser):
         if not arguments and not tool_call.complete:
             return None
 
-        return json.dumps(arguments, ensure_ascii=False)
+        arguments_json = json.dumps(arguments, ensure_ascii=False)
+        if not tool_call.complete:
+            return _stable_partial_json_prefix(arguments_json)
+        return arguments_json
 
     def _extract_content(self, current_text: str) -> str | None:
         """Return unsent non-tool-call text, holding partial start tags."""


### PR DESCRIPTION
## Purpose

Fix Gemma4 streaming tool-call corruption when streamed deltas contain split tool-call boundaries, multiple tool-call transitions, or MTP/speculative token-id chunks with missing text. These cases can produce missing or malformed streamed tool-call arguments.

The streaming parser now uses accumulated Gemma4 text as structured state and diffs that state per tool-call index. In particular, it:

- keeps a Gemma4-local accumulated text buffer,
- parses visible tool-call regions into structured state,
- emits tool-call headers as soon as the function name is known,
- streams only stable, append-only partial argument prefixes,
- withholds unstable split suffixes such as partial delimiters, trailing numeric/exponent fragments, booleans, nulls, arrays, and nested objects until they can be emitted safely,
- repairs missing Gemma4 tool boundary text from token IDs for MTP/speculative paths,
- keeps non-tool content behind a cursor with `partial_tag_overlap`,
- keeps Gemma4 streaming state private so the generic terminal backfill path does not rewrite complete Gemma4 deltas,
- exposes only the first call when `parallel_tool_calls=false`.

This follows an accumulated-buffer / structured-diff approach, similar in spirit to robust tool parsers such as llama.cpp, while keeping the implementation inside vLLM's Gemma4 parser and OpenAI-compatible response structures.

Related work:

- Fixes #41967.
- Alternative to #42006 and #42237.
- Covers the streaming numeric corruption class from #42128 / #42047, extended to unstable split strings, booleans, nulls, arrays, nested objects, and exponents.

Why this is not duplicating existing PRs:

- #42006 keeps the old parser model and replays split segments. This PR replaces the event-order-dependent path with accumulated structured parsing.
- #42237 has the same broad direction, but does not cover token-id repair, private Gemma streaming state, or the `parallel_tool_calls=false` behavior validated here.
- #42128 fixes a narrow float case; this PR covers that class as part of the larger streaming parser fix.

AI assistance was used to help draft and validate this change. The submitter should review every changed line before marking this PR ready for review.

## Test Plan

Added parser regression tests for:

- complete tool call in one delta,
- multiple complete calls in one delta,
- close-then-open in one delta,
- split start delimiter after a completed call,
- split string suffixes such as `src/main.` + `rs` and `e` + `xplore`,
- stable partial argument streaming before the Gemma4 end marker,
- partial string delimiter overlap withholding,
- nested object/array partial argument prefixes,
- split floats, booleans, nulls, and other unstable bare values,
- syntax-aware partial JSON suffix trimming,
- `parallel_tool_calls=false`.

## Test Result

```bash
PYTHONPATH=/workspace/vllm-main-check \
  /workspace/gemma4_stream_patch_20260510/pytest_sys_venv/bin/python \
  -m pytest tests/tool_parsers/test_gemma4_tool_parser.py -q
# 72 passed

PYTHONPATH=/workspace/vllm-main-check \
  /workspace/gemma4_stream_patch_20260510/pytest_sys_venv/bin/python \
  -m pytest tests/reasoning/test_gemma4_reasoning_parser.py \
            tests/tool_parsers/test_gemma4_tool_parser.py -q
# 103 passed

git diff --check
# passed
```

Concurrent production-shaped replay used the existing `repro_vllm_stream_tool_payload.py` harness with 160 requests / 80 concurrency per row:

| engine | thinking | max tokens | parallel_tool_calls | stream=true | stream=false |
|---|---|---:|---|---|---|
| non-MTP | off | 500 | false | 160/160 ok, 0 malformed, 0 missing | 160/160 ok, 0 malformed, 0 missing |
| non-MTP | off | 500 | true | 160/160 ok, 0 malformed, 0 missing | 160/160 ok, 0 malformed, 0 missing |
| non-MTP | on | 1200 | false | 160/160 ok, 0 malformed, 0 missing | 160/160 ok, 0 malformed, 0 missing |
| non-MTP | on | 1200 | true | 160/160 ok, 0 malformed, 0 missing | 160/160 ok, 0 malformed, 0 missing |
| MTP | off | 500 | false | 160/160 ok, 0 malformed, 0 missing | 160/160 ok, 0 malformed, 0 missing |
| MTP | off | 500 | true | 160/160 ok, 0 malformed, 0 missing | 160/160 ok, 0 malformed, 0 missing |
| MTP | on | 1200 | false | 160/160 ok, 0 malformed, 0 missing | 160/160 ok, 0 malformed, 0 missing |
| MTP | on | 1200 | true | 160/160 ok, 0 malformed, 0 missing | 160/160 ok, 0 malformed, 0 missing |

Also replayed the existing edge-case harness, `run_tool_stream_edge_cases.py`, at 160 requests / 80 concurrency for MTP and non-MTP. It reported no malformed-argument or argument-before-header failures. Remaining red rows were model-compliance misses where the model chose fewer tool calls than the case expected, not parser corruption.
