### PR TITLE
 [Model][Perf] Overlap Qwen3.5 GDN input projections (in_proj_qkvz / in_proj_ba) on dual CUDA streams     

### DIFF
--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -57,6 +57,7 @@ from vllm.model_executor.utils import set_weight_attrs
 from vllm.platforms import current_platform
 from vllm.transformers_utils.configs.qwen3_next import Qwen3NextConfig
 from vllm.triton_utils import tl, triton
+from vllm.utils.multi_stream_utils import maybe_execute_in_parallel
 from vllm.utils.torch_utils import (
     LayerNameType,
     _encode_layer_name,
@@ -401,6 +402,17 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
             envs.VLLM_ENABLE_FLA_PACKED_RECURRENT_DECODE
         )
 
+        # Auxiliary CUDA stream + events used to overlap the two independent
+        # input projections (in_proj_qkvz and in_proj_ba) in forward_cuda.
+        # On non-CUDA-alike platforms maybe_execute_in_parallel falls back to
+        # serial execution when aux_stream is None.
+        if current_platform.is_cuda_alike():
+            self._in_proj_aux_stream = torch.cuda.Stream()
+            self._in_proj_events = (torch.cuda.Event(), torch.cuda.Event())
+        else:
+            self._in_proj_aux_stream = None
+            self._in_proj_events = (None, None)
+
         compilation_config = get_current_vllm_config().compilation_config
         if prefix in compilation_config.static_forward_context:
             raise ValueError(f"Duplicate layer name: {prefix}")
@@ -734,8 +746,15 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         # ============================================================
         # Part 1: Input Projection
         # ============================================================
-        mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)
-        ba, _ = self.in_proj_ba(hidden_states)
+        # in_proj_qkvz and in_proj_ba are two independent GEMMs on the same
+        # input. Run them on separate CUDA streams to overlap their kernels.
+        (mixed_qkvz, _), (ba, _) = maybe_execute_in_parallel(
+            lambda: self.in_proj_qkvz(hidden_states),
+            lambda: self.in_proj_ba(hidden_states),
+            self._in_proj_events[0],
+            self._in_proj_events[1],
+            self._in_proj_aux_stream,
+        )
 
         if self.gqa_interleaved_layout:
             # Qwen3-Next: unpack the interleaved GQA layout


### PR DESCRIPTION
## Summary                                                                                                                                                                                
                                                                                                                                                                                            
  In GatedDeltaNetAttention.forward_cuda, the input-projection stage runs two independent GEMMs serially on the same stream:                                                                
                                                                                                                                                                                            
    mixed_qkvz, _ = self.in_proj_qkvz(hidden_states)                                                                                                                                        
    ba, _        = self.in_proj_ba(hidden_states)                                                                                                                                           
                                                                                                                                                                                            
  Both linears consume the same hidden_states and have no data dependency on each other, but they are issued back-to-back on the default stream, leaving an obvious launch/execution overlap
  on the table. This PR uses the existing vllm.utils.multi_stream_utils.maybe_execute_in_parallel helper to run them concurrently on an auxiliary CUDA stream, following the same dual-     
  stream pattern already used in vllm/lora/layers/base_linear.py.                                                                                                                           
                                                                                                                                                                                            
  ## Changes                                                                                                                                                                                
                                                                                                                                                                                            
  All code changes are scoped to the source tree at /opt/tiger/vllm/vllm. Only one file is modified:                                                                                        
                                                                                                                                                                                            
  /opt/tiger/vllm/vllm/vllm/model_executor/layers/mamba/gdn_linear_attn.py                                                                                                                  
                                                                                                                                                                                            
  1. Import maybe_execute_in_parallel from the existing vllm.utils.multi_stream_utils.                                                                                                      
  2. In GatedDeltaNetAttention.__init__, allocate one torch.cuda.Stream and a (start, done) event pair per layer, gated on current_platform.is_cuda_alike(). Non-CUDA-alike platforms get   
  None, so the helper transparently falls back to serial execution.                                                                                                                         
  3. In forward_cuda, replace the two back-to-back in_proj_qkvz / in_proj_ba calls with a single maybe_execute_in_parallel(...) invocation that issues in_proj_ba onto the aux stream while 
  in_proj_qkvz keeps running on the default stream, joined via the two events.                                                                                                              
                                                                                                                                                                                            
  No other files in /opt/tiger/vllm/vllm are touched. Weight loading, tensor shapes, public APIs, and downstream conv1d / RMSNormGated / fix_query_key_value_ordering / ChunkGatedDeltaRule 
  / out_proj paths are all untouched.                                                                                                                                                       
                                                                                                                                                                                            
  ## Why this is safe                                                                                                                                                                       
                                                                                                                                                                                            
  • in_proj_qkvz and in_proj_ba have no WAR/RAW dependency; they only read hidden_states.                                                                                                   
  • maybe_execute_in_parallel fences correctly: the default stream calls event0.record() before fn0 launches, the aux stream event0.wait()s before launching fn1, then records event1, and  
  the default stream event1.wait()s on join — fully compliant with the CUDA memory model.                                                                                                   
  • The stream and events live for the lifetime of the module, so there is no per-forward construction overhead.                                                                            
                                                                                                                                                                                            
  ## Performance                                                                                                                                                                            
                                                                                                                                                                                            
  Model:Qwen3.5-35b-a3b, TP=1, single B200, --optimization-level 3 --async-scheduling.                                                                                             
  Tool: run benchmark, random data, input=16384, output=512, duration=180s.                                                                                                            
                                                                                                               
<img width="369" height="286" alt="截屏2026-05-11 22 45 59" src="https://github.com/user-attachments/assets/3bf3be3c-8c26-4fd3-b453-11c769e90085" />

                                                                                                                                                                                         
  Observations:                                                                                                                                                                             
                                                                                                                                                                                            
  • qps=0.5                                                                                                                                                                                                                                                                                                                                                                                                                       
    • total throughput: +0.11%                                                                                                                                                                                                                                                                                                                                                                                                    
    • mean TTFT: +0.95%                                                                                                                                                                                                                                                                                                                                                                                                          
    • mean TPOT: -2.89%                                                                                                                                                                                                                                                                                                                                                                                                           
    • mean E2EL: -2.53%                                                                                                                                                                                                                                                                                                                                                                                                           
  • qps=1.0                                                                                                                                                                                                                                                                                                                                                                                                                       
    • total throughput: +0.21%     
    • mean TTFT: -0.36%                                                                                                                                                                                                                                                                                                                                                                                                  
    • mean TPOT: -1.20%                                                                                                                                                                                                                                                                                                                                                                                                           
    • mean E2EL: -1.08%                                                                
  ### Torch.profile behavier change
before:
<img width="1381" height="304" alt="image" src="https://github.com/user-attachments/assets/506d0ac1-f87c-47d2-b6fe-32d6797a2a78" />
after:
<img width="719" height="195" alt="image" src="https://github.com/user-attachments/assets/f99785ce-52e4-48b7-96b7-241f3742c9a5" />
                                                                                                                                                           
  ## Test Plan                                                                                                                                                                              
                                                                                                                                                                                            
  • End-to-end serving benchmark: Qwen3.5-35b-a3b, TP=1, B200, --optimization-level 3 --async-scheduling, input=16384 / output=512 / qps={0.5, 1.0}; numbers above.                 
  • Platform fallback: when current_platform.is_cuda_alike() is False, both stream and events are None, and maybe_execute_in_parallel takes the serial branch — bitwise-identical behavior  
  to the prior code.                                                                                                                                                                        
                                                                                                                                                                                            
  ## Risks / Compatibility                                                                                                                                                                  
                                                                                                                                                                                            
  • Touches only GatedDeltaNetAttention.__init__ and forward_cuda in /opt/tiger/vllm/vllm/vllm/model_executor/layers/mamba/gdn_linear_attn.py; weight loading, tensor shapes, and external  
  APIs are unchanged.                                                                                                                                                                       
  • No new dependency: multi_stream_utils.maybe_execute_in_parallel is an existing in-tree utility.                                                                                         
  • CUDA Graph capture compatible: this dual-stream + event pattern is structurally identical to the LoRA dual-stream path in BaseLinearLayerWithLoRA, which is already exercised in production.