### PR TITLE
[Model] [Perf] Use flatten for Qwen3.5's GDN output projection

### DIFF
--- a/vllm/model_executor/layers/mamba/gdn_linear_attn.py
+++ b/vllm/model_executor/layers/mamba/gdn_linear_attn.py
@@ -697,7 +697,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         z = z.reshape(-1, z.shape[-1])
         core_attn_out = self.norm(core_attn_out, z)
         core_attn_out = core_attn_out.reshape(z_shape_og)
-        core_attn_out = rearrange(core_attn_out, "... h d -> ... (h d)")
+        core_attn_out = core_attn_out.flatten(-2)  # ... h d -> ... (h d)
         output[:num_tokens], _ = self.out_proj(core_attn_out)
 
     def forward_hip(
@@ -857,7 +857,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         z = z.reshape(-1, z.shape[-1])
         core_attn_out = self.norm(core_attn_out, z)
         core_attn_out = core_attn_out.reshape(z_shape_og)
-        core_attn_out = rearrange(core_attn_out, "... h d -> ... (h d)")
+        core_attn_out = core_attn_out.flatten(-2)  # ... h d -> ... (h d)
         output[:num_tokens], _ = self.out_proj(core_attn_out)
 
     def forward_cpu(
@@ -907,7 +907,7 @@ class GatedDeltaNetAttention(PluggableLayer, MambaBase):
         z = z.reshape(-1, z.shape[-1])
         core_attn_out = self.norm(core_attn_out, z)
         core_attn_out = core_attn_out.reshape(z_shape_og)
-        core_attn_out = rearrange(core_attn_out, "... h d -> ... (h d)")
+        core_attn_out = core_attn_out.flatten(-2)  # ... h d -> ... (h d)
         output[:num_tokens], _ = self.out_proj(core_attn_out)
 
     def _warmup_prefill_kernels(self, qkv_or_qkvz: torch.Tensor, v_dim: int) -> None:


### PR DESCRIPTION
## Purpose
For Qwen3.5's GDN output projection we currently use einops's `rearrange(core_attn_out, "... h d -> ... (h d)")` to merge the last 2 dimensions, which causes expensive python-level string parsing and validation on every GDN forward call. We can use the pytorch equivalent `core_attn_out.flatten(-2)` to avoid this.

## Test Plan

Profiler repro on `Qwen/Qwen3.5-0.8B`.


<details>
<summary>CUDA</summary>

```python
.venv/bin/vllm bench latency \
  --model Qwen/Qwen3.5-0.8B \
  --trust-remote-code \
  --dtype float16 \
  --max-model-len 64 \
  --language-model-only \
  --input-len 16 \
  --output-len 32 \
  --batch-size 1 \
  --num-iters-warmup 1 \
  --profile \
  --disable-detokenize \
  --enforce-eager \
  --kv-cache-memory-bytes 64M \
  --profiler-config "{\"profiler\":\"torch\",\"torch_profiler_dir\":\"${VLLM_PROFILE_DIR}\",\"torch_profiler_use_gzip\":false,\"torch_profiler_with_stack\":true,\"torch_profiler_dump_cuda_time_total\":true}"
```
</details>

<details>
<summary>CPU</summary>

```python
.venv/bin/vllm bench latency \
  --model Qwen/Qwen3.5-0.8B \
  --trust-remote-code \
  --dtype float32 \
  --max-model-len 16 \
  --language-model-only \
  --input-len 8 \
  --output-len 8 \
  --batch-size 1 \
  --num-iters-warmup 0 \
  --disable-detokenize \
  --gpu-memory-utilization 0.3 \
  --max-num-seqs 1 \
  --enforce-eager \
  --profile \
  --profiler-config "{\"profiler\":\"torch\",\"torch_profiler_dir\":\"${VLLM_PROFILE_DIR}\",\"torch_profiler_use_gzip\":false,\"torch_profiler_with_stack\":true,\"ignore_frontend\":true}"
```
</details>

Correctness test: `pytest tests/models/language/generation_ppl_test/test_qwen.py` with the following tweak:
```python
 if model_info.name == "Qwen/Qwen3.5-0.8B":
      vllm_extra_kwargs["language_model_only"] = True
      vllm_extra_kwargs["cpu_offload_gb"] = 10
      vllm_extra_kwargs["kv_cache_memory_bytes"] = 256 * 1024 * 1024

```

## Test Result

CUDA, eager mode:

| Event | Calls | Avg | Min | Max |
|---|---:|---:|---:|---:|
| einops/einops.py(561): rearrange| 576 | 23.261 us | 12.949 us | 103.882 us |
| aten::flatten| 576 | 2.828 us | 1.486 us | 94.331 us |

Per-call average speedup: `8.23x`

CPU, eager mode:

| Event | Calls | Avg | Min | Max |
|---|---:|---:|---:|---:|
|einops/einops.py(561): rearrange| 144 | 41.741 us | 29.737 us | 106.243 us |
|aten::flatten| 144 | 1.949 us | 1.203 us | 19.260 us |

Per-call average speedup: `21.41x`

Correctness, CUDA only:

| Method | our PPL | HF expected PPL | Relative difference |
|---|---:|---:|---:|
| einops.rearrange | 19.509801864624023 | 19.38858413696289 | 0.6252% |
| flatten | 19.510005950927734 | 19.38858413696289 | 0.6263% |