### PR TITLE
[Feature] engine: make engine-core classes configurable via ParallelConfig

### DIFF
--- a/docs/design/plugin_system.md
+++ b/docs/design/plugin_system.md
@@ -143,6 +143,53 @@ Every plugin has three parts:
 
 7. (optional) Implement other pluggable modules, such as lora, graph backend, quantization, mamba attention backend, etc.
 
+### Advanced engine-core extension points
+
+Platform plugins can also replace the classes used to construct and launch
+V1 engine cores. These are advanced hooks intended for platforms that need to
+substitute their own engine-core implementations without forking vLLM's engine
+startup flow.
+
+Set these fields in
+[`Platform.check_and_update_config`][vllm.platforms.interface.Platform.check_and_update_config]
+by assigning fully qualified class names to `vllm_config.parallel_config`:
+
+- `engine_core_cls`: in-process engine core used by `InprocClient`
+- `engine_core_proc_cls`: subprocess engine core used by
+  `CoreEngineProcManager`
+- `dp_engine_core_proc_cls`: data-parallel subprocess engine core used by
+  `run_engine_core`
+- `engine_core_actor_cls`: Ray actor engine core used by
+  `CoreEngineActorManager`
+- `dp_engine_core_actor_cls`: data-parallel Ray actor engine core used by
+  `CoreEngineActorManager`
+
+All of these fields default to the current built-in classes, so plugins only
+need to set the fields they want to override.
+
+For example, a platform plugin can redirect the in-process and subprocess
+engine-core construction like this:
+
+??? code
+
+    ```python
+    class MyPlatform(Platform):
+
+        @classmethod
+        def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
+            parallel_config = vllm_config.parallel_config
+            parallel_config.engine_core_cls = (
+                "my_plugin.engine.MyInprocEngineCore"
+            )
+            parallel_config.engine_core_proc_cls = (
+                "my_plugin.engine.MyEngineCoreProc"
+            )
+    ```
+
+These hooks only change which classes are instantiated. The selected classes
+must remain compatible with the constructor and runtime expectations of the
+call sites above.
+
 ## Compatibility Guarantee
 
 vLLM guarantees the interface of documented plugins, such as `ModelRegistry.register_model`, will always be available for plugins to register models. However, it is the responsibility of plugin developers to ensure their plugins are compatible with the version of vLLM they are targeting. For example, `"vllm_add_dummy_model.my_llava:MyLlava"` should be compatible with the version of vLLM that the plugin targets.

--- a/tests/v1/engine/test_engine_core_class_selection.py
+++ b/tests/v1/engine/test_engine_core_class_selection.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import pytest
+
+from vllm.config import DeviceConfig, ParallelConfig, VllmConfig
+from vllm.v1.engine.core_client import InprocClient
+from vllm.v1.engine.utils import CoreEngineProcManager
+
+
+class SelectedInprocCore:
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+class SelectedEngineCoreProc:
+    @staticmethod
+    def run_engine_core(*args, **kwargs):
+        raise NotImplementedError
+
+
+class FakeProcess:
+    sentinel = object()
+    exitcode = None
+    pid = None
+
+    def __init__(self, target, name, kwargs):
+        self.target = target
+        self.name = name
+        self.kwargs = kwargs
+        self.started = False
+
+    def start(self):
+        self.started = True
+
+    def is_alive(self):
+        return False
+
+    def terminate(self):
+        raise AssertionError("FakeProcess should not be terminated")
+
+    def join(self, timeout=None):
+        return None
+
+
+class FakeMpContext:
+    def __init__(self):
+        self.processes: list[FakeProcess] = []
+
+    def Process(self, target, name, kwargs):
+        process = FakeProcess(target=target, name=name, kwargs=kwargs)
+        self.processes.append(process)
+        return process
+
+
+@pytest.mark.skip_global_cleanup
+def test_inproc_client_uses_configured_engine_core_cls():
+    vllm_config = VllmConfig(
+        device_config=DeviceConfig(device="cpu"),
+        parallel_config=ParallelConfig(
+            engine_core_cls=f"{__name__}.SelectedInprocCore"
+        ),
+    )
+
+    client = InprocClient(vllm_config=vllm_config)
+
+    assert isinstance(client.engine_core, SelectedInprocCore)
+    assert client.engine_core.kwargs["vllm_config"] is vllm_config
+
+
+@pytest.mark.skip_global_cleanup
+def test_proc_manager_uses_configured_engine_core_proc_cls(monkeypatch):
+    fake_context = FakeMpContext()
+    monkeypatch.setattr("vllm.v1.engine.utils.get_mp_context", lambda: fake_context)
+    vllm_config = VllmConfig(
+        device_config=DeviceConfig(device="cpu"),
+        parallel_config=ParallelConfig(
+            engine_core_proc_cls=f"{__name__}.SelectedEngineCoreProc"
+        ),
+    )
+
+    CoreEngineProcManager(
+        local_engine_count=1,
+        start_index=0,
+        local_start_index=0,
+        vllm_config=vllm_config,
+        local_client=True,
+        handshake_address="inproc://test",
+        executor_class=object,
+        log_stats=False,
+        tensor_queue=None,
+    )
+
+    assert len(fake_context.processes) == 1
+    assert fake_context.processes[0].target is SelectedEngineCoreProc.run_engine_core
+    assert fake_context.processes[0].started

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -252,6 +252,16 @@ class ParallelConfig:
     class is dynamically inherited by the worker class. This is used to inject
     new attributes and methods to the worker class for use in collective_rpc
     calls."""
+    engine_core_cls: str = "vllm.v1.engine.core.EngineCore"
+    """The full name of the in-process engine core class to use."""
+    engine_core_proc_cls: str = "vllm.v1.engine.core.EngineCoreProc"
+    """The full name of the multiprocessing engine core class to use."""
+    dp_engine_core_proc_cls: str = "vllm.v1.engine.core.DPEngineCoreProc"
+    """The full name of the data-parallel engine core process class to use."""
+    engine_core_actor_cls: str = "vllm.v1.engine.core.EngineCoreActor"
+    """The full name of the Ray engine core actor class to use."""
+    dp_engine_core_actor_cls: str = "vllm.v1.engine.core.DPMoEEngineCoreActor"
+    """The full name of the data-parallel Ray engine core actor class to use."""
     master_addr: str = "127.0.0.1"
     """distributed master address for multi-node distributed 
     inference when distributed_executor_backend is mp."""

--- a/vllm/v1/engine/core.py
+++ b/vllm/v1/engine/core.py
@@ -37,6 +37,7 @@ from vllm.utils.gc_utils import (
     maybe_attach_gc_debug_callback,
 )
 from vllm.utils.hashing import get_hash_fn_by_name
+from vllm.utils.import_utils import resolve_obj_by_qualname
 from vllm.utils.network_utils import make_zmq_socket
 from vllm.utils.system_utils import decorate_logs, set_process_title
 from vllm.v1.core.kv_cache_utils import (
@@ -1100,10 +1101,19 @@ class EngineCoreProc(EngineCore):
                 )
 
             parallel_config.data_parallel_index = dp_rank
-            if data_parallel and vllm_config.model_config.is_moe:
+            uses_dp_engine_core = (
+                parallel_config.dp_engine_core_proc_cls
+                != "vllm.v1.engine.core.DPEngineCoreProc"
+            )
+            if data_parallel and (
+                vllm_config.model_config.is_moe or uses_dp_engine_core
+            ):
                 # Set data parallel rank for this engine process.
                 parallel_config.data_parallel_rank = dp_rank
-                engine_core = DPEngineCoreProc(*args, **kwargs)
+                engine_core_cls = resolve_obj_by_qualname(
+                    parallel_config.dp_engine_core_proc_cls
+                )
+                engine_core = engine_core_cls(*args, **kwargs)
             else:
                 # Non-MoE DP ranks are completely independent, so treat like DP=1.
                 # Note that parallel_config.data_parallel_index will still reflect
@@ -1111,7 +1121,10 @@ class EngineCoreProc(EngineCore):
                 parallel_config.data_parallel_size = 1
                 parallel_config.data_parallel_size_local = 1
                 parallel_config.data_parallel_rank = 0
-                engine_core = EngineCoreProc(*args, engine_index=dp_rank, **kwargs)
+                engine_core_cls = resolve_obj_by_qualname(
+                    parallel_config.engine_core_proc_cls
+                )
+                engine_core = engine_core_cls(*args, engine_index=dp_rank, **kwargs)
 
             assert engine_core is not None
 
@@ -1637,8 +1650,13 @@ class DPEngineCoreProc(EngineCoreProc):
         client_handshake_address: str | None = None,
         tensor_queue: Queue | None = None,
     ):
-        assert vllm_config.model_config.is_moe, (
-            "DPEngineCoreProc should only be used for MoE models"
+        uses_dp_engine_core = (
+            vllm_config.parallel_config.dp_engine_core_proc_cls
+            != "vllm.v1.engine.core.DPEngineCoreProc"
+        )
+        assert vllm_config.model_config.is_moe or uses_dp_engine_core, (
+            "DPEngineCoreProc should only be used for MoE models or a selected "
+            "DP engine-core subclass"
         )
 
         # Counts forward-passes of the model so that we can synchronize

--- a/vllm/v1/engine/core_client.py
+++ b/vllm/v1/engine/core_client.py
@@ -26,6 +26,7 @@ from vllm.lora.request import LoRARequest
 from vllm.tasks import SupportedTask
 from vllm.tracing import instrument
 from vllm.utils.async_utils import in_loop
+from vllm.utils.import_utils import resolve_obj_by_qualname
 from vllm.utils.network_utils import (
     close_sockets,
     get_open_zmq_inproc_path,
@@ -44,7 +45,7 @@ from vllm.v1.engine import (
     UtilityOutput,
 )
 from vllm.v1.engine.coordinator import DPCoordinator
-from vllm.v1.engine.core import EngineCore, EngineCoreProc
+from vllm.v1.engine.core import EngineCoreProc
 from vllm.v1.engine.exceptions import EngineDeadError
 from vllm.v1.engine.tensor_ipc import TensorIpcSender
 from vllm.v1.engine.utils import (
@@ -282,7 +283,11 @@ class InprocClient(EngineCoreClient):
     """
 
     def __init__(self, *args, **kwargs):
-        self.engine_core = EngineCore(*args, **kwargs)
+        vllm_config: VllmConfig = args[0] if args else kwargs["vllm_config"]
+        engine_core_cls = resolve_obj_by_qualname(
+            vllm_config.parallel_config.engine_core_cls
+        )
+        self.engine_core = engine_core_cls(*args, **kwargs)
 
     def get_output(self) -> EngineCoreOutputs:
         outputs, model_executed = self.engine_core.step_fn()

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -23,6 +23,7 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.ray.ray_env import get_env_vars_to_copy
 from vllm.utils import numa_utils
+from vllm.utils.import_utils import resolve_obj_by_qualname
 from vllm.utils.network_utils import get_open_zmq_ipc_path, zmq_socket_ctx
 from vllm.utils.system_utils import get_mp_context
 from vllm.v1.engine.coordinator import DPCoordinator
@@ -130,7 +131,9 @@ class CoreEngineProcManager:
 
         is_dp = vllm_config.parallel_config.data_parallel_size > 1
 
-        from vllm.v1.engine.core import EngineCoreProc
+        engine_core_proc_cls = resolve_obj_by_qualname(
+            vllm_config.parallel_config.engine_core_proc_cls
+        )
 
         self.processes: list[BaseProcess] = []
         local_dp_ranks = []
@@ -142,7 +145,7 @@ class CoreEngineProcManager:
             local_dp_ranks.append(local_index)
             self.processes.append(
                 context.Process(
-                    target=EngineCoreProc.run_engine_core,
+                    target=engine_core_proc_cls.run_engine_core,
                     name=f"EngineCore_DP{global_index}" if is_dp else "EngineCore",
                     kwargs=common_kwargs
                     | {"dp_rank": global_index, "local_dp_rank": local_index},
@@ -345,14 +348,17 @@ class CoreEngineActorManager:
         from ray.runtime_env import RuntimeEnv
         from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
-        from vllm.v1.engine.core import DPMoEEngineCoreActor, EngineCoreActor
-
         dp_size = vllm_config.parallel_config.data_parallel_size
-        actor_class = (
-            DPMoEEngineCoreActor
-            if dp_size > 1 and vllm_config.model_config.is_moe
-            else EngineCoreActor
+        uses_dp_actor = (
+            vllm_config.parallel_config.dp_engine_core_actor_cls
+            != "vllm.v1.engine.core.DPMoEEngineCoreActor"
         )
+        actor_cls_qualname = (
+            vllm_config.parallel_config.dp_engine_core_actor_cls
+            if dp_size > 1 and (vllm_config.model_config.is_moe or uses_dp_actor)
+            else vllm_config.parallel_config.engine_core_actor_cls
+        )
+        actor_class = resolve_obj_by_qualname(actor_cls_qualname)
 
         self.local_engine_actors: list[ray.ActorHandle] = []
         self.remote_engine_actors: list[ray.ActorHandle] = []
@@ -763,13 +769,16 @@ class CoreEngineActorManager:
         from ray.runtime_env import RuntimeEnv
         from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
-        from vllm.v1.engine.core import DPMoEEngineCoreActor, EngineCoreActor
-
-        actor_class = (
-            DPMoEEngineCoreActor
-            if cur_vllm_config.model_config.is_moe
-            else EngineCoreActor
+        uses_dp_actor = (
+            cur_vllm_config.parallel_config.dp_engine_core_actor_cls
+            != "vllm.v1.engine.core.DPMoEEngineCoreActor"
         )
+        actor_cls_qualname = (
+            cur_vllm_config.parallel_config.dp_engine_core_actor_cls
+            if cur_vllm_config.model_config.is_moe or uses_dp_actor
+            else cur_vllm_config.parallel_config.engine_core_actor_cls
+        )
+        actor_class = resolve_obj_by_qualname(actor_cls_qualname)
 
         cur_data_parallel_size = len(self.local_engine_actors) + len(
             self.remote_engine_actors


### PR DESCRIPTION
## Purpose

Allow plugins and specialised deployments to substitute their own EngineCore subclasses without forking the engine by storing the fully qualified class names in `ParallelConfig` and resolving them at runtime via `resolve_obj_by_qualname`.

New fields (all default to the current hard-coded classes):
*  `engine_core_cls` – in-process core (`InprocClient`)
*  `engine_core_proc_cls` – subprocess core (`CoreEngineProcManager`)
*  `dp_engine_core_proc_cls` – DP subprocess core (`run_engine_core`)
*  `engine_core_actor_cls` – Ray actor core (`CoreEngineActorManager`)
*  `dp_engine_core_actor_cls` – DP Ray actor core (`CoreEngineActorManager`)

`DPEngineCoreProc`'s MoE assertion is relaxed to also allow an explicitly selected DP engine-core subclass.  Default behaviour is identical.

## Test Plan

New test added
```
pytest -q tests/v1/engine/test_engine_core_class_selection.py
```

## Test Result

```2 passed```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

