### PR TITLE
[Feature] Engine core launcher selection

### DIFF
--- a/docs/design/plugin_system.md
+++ b/docs/design/plugin_system.md
@@ -143,6 +143,38 @@ Every plugin has three parts:
 
 7. (optional) Implement other pluggable modules, such as lora, graph backend, quantization, mamba attention backend, etc.
 
+### Advanced engine-core launcher extension point
+
+Platform plugins can also replace the class that owns the
+`launch_core_engines(...)` flow for V1 engine startup. This hook is intended
+for platforms that need to customize engine-process launch or topology setup
+without forking `vllm.v1.engine.utils`.
+
+Set `vllm_config.parallel_config.engine_core_launcher_cls` from
+[`Platform.check_and_update_config`][vllm.platforms.interface.Platform.check_and_update_config]
+to the fully qualified name of a launcher class.
+
+The selected class must provide a `launch_core_engines(...)` context manager
+with the same signature and return value shape as
+`vllm.v1.engine.utils.CoreEngineLauncher.launch_core_engines`.
+
+The default value is `vllm.v1.engine.utils.CoreEngineLauncher`, which
+preserves the current built-in launch behavior.
+
+For example, a platform plugin can redirect engine launch like this:
+
+??? code
+
+    ```python
+    class MyPlatform(Platform):
+
+        @classmethod
+        def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
+            vllm_config.parallel_config.engine_core_launcher_cls = (
+                "my_plugin.engine.MyCoreEngineLauncher"
+            )
+    ```
+
 ## Compatibility Guarantee
 
 vLLM guarantees the interface of documented plugins, such as `ModelRegistry.register_model`, will always be available for plugins to register models. However, it is the responsibility of plugin developers to ensure their plugins are compatible with the version of vLLM they are targeting. For example, `"vllm_add_dummy_model.my_llava:MyLlava"` should be compatible with the version of vLLM that the plugin targets.

--- a/tests/v1/engine/test_engine_core_launcher_selection.py
+++ b/tests/v1/engine/test_engine_core_launcher_selection.py
@@ -1,0 +1,51 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import contextlib
+
+import pytest
+
+from vllm.config import DeviceConfig, ParallelConfig, VllmConfig
+from vllm.v1.engine.utils import EngineZmqAddresses, launch_core_engines
+
+
+class SelectedCoreEngineLauncher:
+    called = False
+
+    @contextlib.contextmanager
+    def launch_core_engines(
+        self,
+        vllm_config,
+        executor_class,
+        log_stats,
+        addresses,
+        num_api_servers=1,
+    ):
+        type(self).called = True
+        yield "manager", None, addresses, "tensor_queue"
+
+
+@pytest.mark.skip_global_cleanup
+def test_launch_core_engines_uses_configured_launcher_cls():
+    SelectedCoreEngineLauncher.called = False
+    addresses = EngineZmqAddresses(inputs=[], outputs=[])
+    vllm_config = VllmConfig(
+        device_config=DeviceConfig(device="cpu"),
+        parallel_config=ParallelConfig(
+            engine_core_launcher_cls=f"{__name__}.SelectedCoreEngineLauncher"
+        ),
+    )
+
+    with launch_core_engines(
+        vllm_config=vllm_config,
+        executor_class=object,
+        log_stats=False,
+        addresses=addresses,
+    ) as launched:
+        manager, coordinator, launched_addresses, tensor_queue = launched
+
+    assert SelectedCoreEngineLauncher.called
+    assert manager == "manager"
+    assert coordinator is None
+    assert launched_addresses is addresses
+    assert tensor_queue == "tensor_queue"

--- a/vllm/config/parallel.py
+++ b/vllm/config/parallel.py
@@ -252,6 +252,8 @@ class ParallelConfig:
     class is dynamically inherited by the worker class. This is used to inject
     new attributes and methods to the worker class for use in collective_rpc
     calls."""
+    engine_core_launcher_cls: str = "vllm.v1.engine.utils.CoreEngineLauncher"
+    """The full name of the engine core launcher class to use."""
     master_addr: str = "127.0.0.1"
     """distributed master address for multi-node distributed 
     inference when distributed_executor_backend is mp."""

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -23,6 +23,7 @@ from vllm.logger import init_logger
 from vllm.platforms import current_platform
 from vllm.ray.ray_env import get_env_vars_to_copy
 from vllm.utils import numa_utils
+from vllm.utils.import_utils import resolve_obj_by_qualname
 from vllm.utils.network_utils import get_open_zmq_ipc_path, zmq_socket_ctx
 from vllm.utils.system_utils import get_mp_context
 from vllm.v1.engine.coordinator import DPCoordinator
@@ -991,6 +992,65 @@ def get_engine_zmq_addresses(
 
 @contextlib.contextmanager
 def launch_core_engines(
+    vllm_config: VllmConfig,
+    executor_class: type[Executor],
+    log_stats: bool,
+    addresses: EngineZmqAddresses,
+    num_api_servers: int = 1,
+) -> Iterator[
+    tuple[
+        CoreEngineProcManager | CoreEngineActorManager | None,
+        DPCoordinator | None,
+        EngineZmqAddresses,
+        Queue | None,
+    ]
+]:
+    """Launch engine and DP coordinator processes as needed."""
+    launcher_cls = resolve_obj_by_qualname(
+        vllm_config.parallel_config.engine_core_launcher_cls
+    )
+    launcher: CoreEngineLauncher = launcher_cls()
+    with launcher.launch_core_engines(
+        vllm_config,
+        executor_class,
+        log_stats,
+        addresses,
+        num_api_servers,
+    ) as launched:
+        yield launched
+
+
+class CoreEngineLauncher:
+    """Default engine-core launcher extension point."""
+
+    @contextlib.contextmanager
+    def launch_core_engines(
+        self,
+        vllm_config: VllmConfig,
+        executor_class: type[Executor],
+        log_stats: bool,
+        addresses: EngineZmqAddresses,
+        num_api_servers: int = 1,
+    ) -> Iterator[
+        tuple[
+            CoreEngineProcManager | CoreEngineActorManager | None,
+            DPCoordinator | None,
+            EngineZmqAddresses,
+            Queue | None,
+        ]
+    ]:
+        with _launch_core_engines(
+            vllm_config,
+            executor_class,
+            log_stats,
+            addresses,
+            num_api_servers,
+        ) as launched:
+            yield launched
+
+
+@contextlib.contextmanager
+def _launch_core_engines(
     vllm_config: VllmConfig,
     executor_class: type[Executor],
     log_stats: bool,

--- a/vllm/v1/engine/utils.py
+++ b/vllm/v1/engine/utils.py
@@ -1009,7 +1009,7 @@ def launch_core_engines(
     launcher_cls = resolve_obj_by_qualname(
         vllm_config.parallel_config.engine_core_launcher_cls
     )
-    launcher: CoreEngineLauncher = launcher_cls()
+    launcher = launcher_cls()
     with launcher.launch_core_engines(
         vllm_config,
         executor_class,


### PR DESCRIPTION
## Purpose

Make engine-core launcher class configurable via `ParallelConfig`

Introduce `CoreEngineLauncher` as the default implementation of the engine-launch extension point.  The module-level `launch_core_engines` context manager resolves the configured class name (stored in `ParallelConfig.engine_core_launcher_cls`) and delegates to it, so a plugin can substitute the entire process-startup and topology logic without touching core vLLM code.

The original launch logic is preserved verbatim as `_launch_core_engines`; `CoreEngineLauncher.launch_core_engines` simply wraps it, keeping the default behaviour bit-for-bit identical.

## Test Plan

Introduce new test: `pytest -q tests/v1/engine/test_engine_core_launcher_selection.py`

## Test Result

`1 passed`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

