### PR TITLE
[Feature] Plugin config cli

### DIFF
--- a/docs/design/plugin_system.md
+++ b/docs/design/plugin_system.md
@@ -143,6 +143,30 @@ Every plugin has three parts:
 
 7. (optional) Implement other pluggable modules, such as lora, graph backend, quantization, mamba attention backend, etc.
 
+### Plugin-owned configuration
+
+Plugins can store their own configuration in
+`vllm_config.plugin_config`, a namespaced dictionary owned by plugins rather
+than core vLLM.
+
+Each top-level key is the plugin namespace, and each value must be a JSON
+object or Python dictionary. Plugins should only read from their own namespace.
+For example, a plugin named `my_plugin` should use
+`vllm_config.plugin_config.get("my_plugin", {})`.
+
+Users can provide this configuration through `EngineArgs`, `LLM(...)`, or the
+`vllm serve` CLI with `--plugin-config`. For example:
+
+??? code
+
+    ```bash
+    vllm serve my-model \
+        --plugin-config '{"my_plugin": {"mode": "fast", "enabled": true}}'
+    ```
+
+Core vLLM validates only the outer structure of `plugin_config`. Each plugin is
+responsible for validating the contents of its own namespace.
+
 ## Compatibility Guarantee
 
 vLLM guarantees the interface of documented plugins, such as `ModelRegistry.register_model`, will always be available for plugins to register models. However, it is the responsibility of plugin developers to ensure their plugins are compatible with the version of vLLM they are targeting. For example, `"vllm_add_dummy_model.my_llava:MyLlava"` should be compatible with the version of vLLM that the plugin targets.

--- a/tests/v1/engine/test_engine_args.py
+++ b/tests/v1/engine/test_engine_args.py
@@ -7,6 +7,7 @@ import pytest
 
 from vllm.config import VllmConfig
 from vllm.engine.arg_utils import EngineArgs
+from vllm.platforms import current_platform
 from vllm.usage.usage_lib import UsageContext
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.utils.hashing import _xxhash
@@ -62,6 +63,36 @@ def test_prefix_caching_xxhash_from_cli():
     args = parser.parse_args(["--prefix-caching-hash-algo", "xxhash_cbor"])
     vllm_config = EngineArgs.from_cli_args(args=args).create_engine_config()
     assert vllm_config.cache_config.prefix_caching_hash_algo == "xxhash_cbor"
+
+
+@pytest.mark.skip_global_cleanup
+def test_plugin_config_from_cli(monkeypatch):
+    monkeypatch.setattr(current_platform, "device_type", "cpu")
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(
+        ["--plugin-config", '{"example": {"mode": "test", "enabled": true}}']
+    )
+
+    engine_args = EngineArgs.from_cli_args(args=args)
+
+    assert engine_args.plugin_config == {
+        "example": {
+            "mode": "test",
+            "enabled": True,
+        }
+    }
+
+
+@pytest.mark.skip_global_cleanup
+def test_plugin_config_validation(monkeypatch):
+    monkeypatch.setattr(current_platform, "device_type", "cpu")
+    parser = EngineArgs.add_cli_args(FlexibleArgumentParser())
+    args = parser.parse_args(["--plugin-config", '{"example": 1}'])
+
+    with pytest.raises(
+        ValueError, match="plugin_config must map plugin names to object values"
+    ):
+        EngineArgs.from_cli_args(args=args)
 
 
 def test_defaults_with_usage_context():

--- a/vllm/config/vllm.py
+++ b/vllm/config/vllm.py
@@ -335,6 +335,8 @@ class VllmConfig:
     """Additional config for specified platform. Different platforms may
     support different configs. Make sure the configs are valid for the platform
     you are using. Contents must be hashable."""
+    plugin_config: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    """Plugin-owned configuration keyed by plugin namespace."""
     instance_id: str = ""
     """The ID of the vLLM instance."""
     optimization_level: OptimizationLevel = OptimizationLevel.O2
@@ -458,6 +460,14 @@ class VllmConfig:
             else:
                 additional_config_hash = additional_config.compute_hash()
             vllm_factors.append(additional_config_hash)
+        else:
+            vllm_factors.append("None")
+        if self.plugin_config:
+            plugin_config_hash = safe_hash(
+                json.dumps(self.plugin_config, sort_keys=True).encode(),
+                usedforsecurity=False,
+            ).hexdigest()
+            vllm_factors.append(plugin_config_hash)
         else:
             vllm_factors.append("None")
         factors.append(vllm_factors)
@@ -1848,6 +1858,7 @@ class VllmConfig:
             f"enable_prefix_caching={self.cache_config.enable_prefix_caching}, "
             f"enable_chunked_prefill={self.scheduler_config.enable_chunked_prefill}, "  # noqa
             f"pooler_config={self.model_config.pooler_config!r}, "
+            f"plugin_config={self.plugin_config!r}, "
             f"compilation_config={self.compilation_config!r}, "
             f"kernel_config={self.kernel_config!r}"
         )

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -667,6 +667,7 @@ class EngineArgs:
     mamba_cache_philox_rounds: int = MambaConfig.stochastic_rounding_philox_rounds
 
     additional_config: dict[str, Any] = get_field(VllmConfig, "additional_config")
+    plugin_config: dict[str, dict[str, Any]] = get_field(VllmConfig, "plugin_config")
 
     use_tqdm_on_load: bool = LoadConfig.use_tqdm_on_load
     pt_load_map_location: str | dict[str, str] = LoadConfig.pt_load_map_location
@@ -716,6 +717,11 @@ class EngineArgs:
             self.weight_transfer_config = WeightTransferConfig(
                 **self.weight_transfer_config
             )
+        if not isinstance(self.plugin_config, dict) or any(
+            not isinstance(key, str) or not isinstance(value, dict)
+            for key, value in self.plugin_config.items()
+        ):
+            raise ValueError("plugin_config must map plugin names to object values")
         if isinstance(self.ir_op_priority, dict):
             self.ir_op_priority = IrOpPriorityConfig(**self.ir_op_priority)
 
@@ -1434,6 +1440,7 @@ class EngineArgs:
         vllm_group.add_argument(
             "--additional-config", **vllm_kwargs["additional_config"]
         )
+        vllm_group.add_argument("--plugin-config", **vllm_kwargs["plugin_config"])
         vllm_group.add_argument(
             "--structured-outputs-config", **vllm_kwargs["structured_outputs_config"]
         )
@@ -2178,6 +2185,7 @@ class EngineArgs:
             reasoning_config=self.reasoning_config,
             profiler_config=self.profiler_config,
             additional_config=self.additional_config,
+            plugin_config=self.plugin_config,
             optimization_level=self.optimization_level,
             performance_mode=self.performance_mode,
             weight_transfer_config=self.weight_transfer_config,


### PR DESCRIPTION
## Purpose

config: add `plugin_config` namespace to `VllmConfig` and `EngineArgs`

Introduce a `plugin_config` field on `VllmConfig` as a generic, namespaced `dict[str, dict[str, Any]]` that plugins can use to carry their own configuration without polluting the core config namespace.

- `VllmConfig.plugin_config`: new field included in `compute_hash` and `repr`
- `EngineArgs.plugin_config`: mirrored field with structural validation (each value must be an object/dict) and a `--plugin-config` CLI flag

## Test Plan

Tests to verify CLI round-trip and schema enforcement
`pytest -q tests/v1/engine/test_engine_args.py -k 'plugin_config'`

## Test Result

`2 passed`

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [x] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

