### PR TITLE
[Bugfix] Fix DeepSeek V4 MTP HC state handling

### DIFF
--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -1206,7 +1206,7 @@ class DeepseekV4DecoderLayer(nn.Module):
         post_mix: torch.Tensor | None,
         res_mix: torch.Tensor | None,
         residual: torch.Tensor | None,
-    ) -> torch.Tensor:
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         if residual is None:
             # Run standalone hc_pre on first layer
             residual = x

--- a/vllm/model_executor/models/deepseek_v4.py
+++ b/vllm/model_executor/models/deepseek_v4.py
@@ -1203,9 +1203,9 @@ class DeepseekV4DecoderLayer(nn.Module):
         x: torch.Tensor,
         positions: torch.Tensor,
         input_ids: torch.Tensor | None,
-        post_mix: torch.Tensor | None,
-        res_mix: torch.Tensor | None,
-        residual: torch.Tensor | None,
+        post_mix: torch.Tensor | None = None,
+        res_mix: torch.Tensor | None = None,
+        residual: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         if residual is None:
             # Run standalone hc_pre on first layer

--- a/vllm/model_executor/models/deepseek_v4_mtp.py
+++ b/vllm/model_executor/models/deepseek_v4_mtp.py
@@ -141,8 +141,16 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
         hidden_states = self.h_proj(previous_hidden_states) + self.e_proj(
             inputs_embeds
         ).unsqueeze(-2)
-        hidden_states = self.mtp_block(
-            positions=positions, x=hidden_states, input_ids=None
+        hidden_states, residual, post_mix, res_mix = self.mtp_block(
+            hidden_states,
+            positions,
+            None,
+            None,
+            None,
+            None,
+        )
+        hidden_states = self.mtp_block.hc_post(
+            hidden_states, residual, post_mix, res_mix
         )
         # Return the flat pre-hc_head residual so it can be re-fed as the
         # next spec step's `previous_hidden_states` when

--- a/vllm/model_executor/models/deepseek_v4_mtp.py
+++ b/vllm/model_executor/models/deepseek_v4_mtp.py
@@ -142,12 +142,7 @@ class DeepSeekV4MultiTokenPredictorLayer(nn.Module):
             inputs_embeds
         ).unsqueeze(-2)
         hidden_states, residual, post_mix, res_mix = self.mtp_block(
-            hidden_states,
-            positions,
-            None,
-            None,
-            None,
-            None,
+            positions=positions, x=hidden_states, input_ids=None
         )
         hidden_states = self.mtp_block.hc_post(
             hidden_states, residual, post_mix, res_mix


### PR DESCRIPTION
## Purpose

Fix the DeepSeek V4 MTP path after #41536 changed `DeepseekV4DecoderLayer.forward` to take `post_mix`, `res_mix`, and `residual`. The main model path was updated, but the MTP draft layer still used the old call and failed at startup/profile run. Key error lines:

```text
TypeError: missing required positional argument: post_mix

torch._dynamo.exc.Unsupported: failed to bind arguments when attempting to inline
  Explanation: Argument mismatch when attempting to trace function forward.
  Developer debug context: func='forward' /root/vllm-workspace/vllm/model_executor/models/deepseek_v4.py:1201; args = [<class 'vllm.model_executor.models.deepseek_v4.DeepseekV4DecoderLayer'>]; kwargs = {'positions': TensorVariable(), 'x': TensorVariable(), 'input_ids': ConstantVariable(NoneType: None)}
```

This updates the MTP call site and fixes the `DeepseekV4DecoderLayer.forward` return annotation.

Before this fix, DeepSeek V4 with MTP failed to start. After this fix, it starts successfully.

cc @WoosukKwon