### PR TITLE
[KV Connector] Eager KV prefetch at request enqueue time in `LMCacheMPConnector`

### DIFF
--- a/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
+++ b/vllm/distributed/kv_transfer/kv_connector/v1/lmcache_mp_connector.py
@@ -499,6 +499,12 @@ class LMCacheMPConnectorUpstream(KVConnectorBase_V1):
             )
         )
 
+        self._eager_prefetch: bool = bool(
+            vllm_config.kv_transfer_config.get_from_extra_config(
+                "lmcache.mp.eager_prefetch", False
+            )
+        )
+
         server_url = f"{server_host}:{server_port}"
         zmq_context = zmq.Context.instance()
         if self.role == KVConnectorRole.SCHEDULER:
@@ -799,6 +805,16 @@ class LMCacheMPConnectorUpstream(KVConnectorBase_V1):
             "vLLM hit is: %d, Need to load is %d", num_computed_tokens, need_to_load
         )
         return need_to_load, need_to_load > 0
+
+    def on_new_request(self, request: "Request") -> None:
+        if not self._eager_prefetch or request.resumable:
+            return
+        tracker = self._get_or_create_request_tracker(request)
+        self.scheduler_adapter.maybe_submit_lookup_request(
+            request.request_id,
+            token_ids=list(request.all_token_ids),
+            cache_salt=tracker.cache_salt,
+        )
 
     def update_state_after_alloc(
         self, request: "Request", blocks: "KVCacheBlocks", num_external_tokens: int


### PR DESCRIPTION
**TL;DR:** For disk-backed KV cache workloads, starting LMCache lookup at request enqueue time reduces TTFT by up to 28% under scheduler backlog, with no measurable overhead when backlog is absent. This optimization is fully opt-in and disabled by default.


## Purpose

Fix #41784. Under high load, requests sit in the scheduler's waiting queue for one or more cycles before being picked up. If their KV data is on disk (L2 cache), the retrieval — which can take hundreds of milliseconds — only starts at schedule time, blocking the first prefill step and inflating TTFT.

This PR moves the LMCache lookup to **request-enqueue time**, hiding disk I/O behind the queue wait that already exists.

```
Before:  enqueue → [wait] → schedule → lookup disk → [GPU stall] → prefill
After:   enqueue → lookup disk (async) → [wait] → schedule → prefill
```

## Implementation

PR #41383 introduced `on_new_request()` as a hook called the moment a request enters the waiting queue. This PR implements it in `LMCacheMPConnector` — the multi-process LMCache connector that dispatches lookups  asynchronously to a background worker, as opposed to `LMCacheConnectorV1` which is synchronous and co-process.

The change is 16 lines: read `lmcache.mp.eager_prefetch` from `extra_config` (opt-in, default `false`), then dispatch `maybe_submit_lookup_request()` on arrival, skipping resumable requests whose token IDs may be incomplete. No changes to the scheduler, engine core, or any other connector.

**Usage:** set `lmcache.mp.eager_prefetch: true` in `kv_transfer_config.extra_config` to enable. Disabled by default.

I did not include unit tests in this PR because LMCacheMPConnector currently has no existing test infrastructure and requires a live LMCache server or substantial mocking setup.

Happy to add tests if maintainers prefer.

## Experiments

**Environment:** 
- NVIDIA L20 45 GiB
- Llama-3.1-8B
- Intel Xeon 
- 64 GiB RAM

Per-phase timing was instrumented across both vLLM and LMCache:
- vLLM: https://github.com/chfeng-cs/vllm/tree/lmcache-eager-prefetch-bench
- LMCache: https://github.com/chfeng-cs/LMCache/tree/eager-prefetch-timing

To eliminate interference from GPU/CPU memory KV cache, the following configuration was used: 
- vLLM: `--no-enable-prefix-caching` — disables vLLM's GPU-side prefix cache, ensuring every request must retrieve its KV data from disk rather than GPU memory.
- LMCache: `skip_l1` — demotes L1 to a write-through buffer that holds no data, guaranteeing all reads go to L2 (disk).

Five requests are submitted sequentially at a fixed interval of 2.4 s. Each request reuses a cached KV context of 8 767 tokens stored on disk. All numbers are averaged over three runs.


### Benchmark results

<img width="2255" height="913" alt="image" src="https://github.com/user-attachments/assets/a28df42b-43e7-4881-8c4f-00b6e9723b78" />

For the first request, both variants are nearly identical (~304 ms) — there is no prior queue pressure. The gap widens with each subsequent request: under Baseline, each request waits slightly longer to be scheduled than the one before it (decode takes ~2.24 s but the submission interval is only 2.4 s, leaving ~0.1 s of overlap per cycle). This accumulated scheduling delay pushes the disk lookup later and later, reaching 467 ms of pure wait by req-5. This PR sidesteps this entirely — disk I/O starts at enqueue time regardless of when the scheduler gets around to the request, so TTFT stays flat at ~306 ms throughout.

<img width="2227" height="1194" alt="image" src="https://github.com/user-attachments/assets/59f8b625-4bf8-43ea-bf23-e331ae599515" />


The timeline makes the compounding effect visible. Under Baseline, the [QueueWait] block grows with each row, shifting the entire [Disk → CPU] → [prefill] → [decode] chain rightward. With this PR every request follows the same pattern: disk starts immediately at submission and finishes well before the scheduler picks it up, so there is nothing to wait for. The last request finishes ~470 ms earlier — not because any single operation got faster, but because no delay was allowed to accumulate.