### PR TITLE
[Core] Support tuned symmetric memory two-shot fallback

### DIFF
--- a/vllm/distributed/device_communicators/all_reduce_utils.py
+++ b/vllm/distributed/device_communicators/all_reduce_utils.py
@@ -51,7 +51,7 @@ CUSTOM_ALL_REDUCE_MAX_SIZES = {
 
 SYMM_MEM_ALL_REDUCE_MAX_SIZES = {
     "9.0": {
-        2: 64 * MiB,  # 64 MB
+        2: 32 * MiB,  # 32 MB
         4: 32 * MiB,  # 32 MB
         6: 64 * MiB,  # 64 MB
         8: 64 * MiB,  # 64 MB
@@ -59,14 +59,37 @@ SYMM_MEM_ALL_REDUCE_MAX_SIZES = {
     "10.0": {
         2: 8 * MiB,  # 8 MB
         4: 32 * MiB,  # 32 MB
-        6: 128 * MiB,  # 128 MB
+        6: 32 * MiB,  # 32 MB
         8: 128 * MiB,  # 128 MB
     },
     "10.3": {
-        2: 4 * MiB,  # 4 MB
+        2: 8 * MiB,  # 8 MB
+        4: 64 * MiB,  # 64 MB
+        6: 64 * MiB,  # 64 MB
+        8: 128 * MiB,  # 128 MB
+    },
+}
+
+# Max size for symmetric memory allreduce when multicast is unavailable and
+# vLLM must use the two-shot implementation for all world sizes.
+SYMM_MEM_TWO_SHOT_ALL_REDUCE_MAX_SIZES = {
+    "9.0": {
+        2: 32 * MiB,  # 32 MB
+        4: 16 * MiB,  # 16 MB
+        6: 16 * MiB,  # 16 MB
+        8: 16 * MiB,  # 16 MB
+    },
+    "10.0": {
+        2: 8 * MiB,  # 8 MB
         4: 32 * MiB,  # 32 MB
-        6: 32 * MiB,  # 32 MB
-        8: 64 * MiB,  # 64 MB
+        6: 16 * MiB,  # 16 MB
+        8: 128 * MiB,  # 128 MB
+    },
+    "10.3": {
+        2: 8 * MiB,  # 8 MB
+        4: 64 * MiB,  # 64 MB
+        6: 16 * MiB,  # 16 MB
+        8: 128 * MiB,  # 128 MB
     },
 }
 

--- a/vllm/distributed/device_communicators/symm_mem.py
+++ b/vllm/distributed/device_communicators/symm_mem.py
@@ -8,6 +8,7 @@ from torch.distributed import ProcessGroup
 import vllm.envs as envs
 from vllm.distributed.device_communicators.all_reduce_utils import (
     SYMM_MEM_ALL_REDUCE_MAX_SIZES,
+    SYMM_MEM_TWO_SHOT_ALL_REDUCE_MAX_SIZES,
 )
 from vllm.logger import init_logger
 from vllm.platforms import current_platform
@@ -38,6 +39,7 @@ class SymmMemCommunicator:
         max_size_override: int | None = None,
     ):
         self.disabled = True
+        self.multicast_supported = False
 
         if not symm_mem_available:
             return
@@ -102,12 +104,23 @@ class SymmMemCommunicator:
                 str(e),
             )
             return
-        if handle.multicast_ptr == 0:
+        self.multicast_supported = handle.multicast_ptr != 0
+        if not self.multicast_supported:
+            two_shot_max_size = SYMM_MEM_TWO_SHOT_ALL_REDUCE_MAX_SIZES.get(
+                self.device_capability, {}
+            ).get(self.world_size)
+            if max_size_override is None and two_shot_max_size is not None:
+                self.max_size = two_shot_max_size
+                logger.info(
+                    "SymmMemCommunicator: using two-shot allreduce max size "
+                    "of %s bytes.",
+                    self.max_size,
+                )
             logger.warning(
                 "SymmMemCommunicator: symmetric memory "
-                "multicast operations are not supported."
+                "multicast operations are not supported. Falling back to "
+                "two-shot allreduce."
             )
-            return
         self.force_multimem = force_multimem
         self.disabled = False
         if envs.VLLM_BATCH_INVARIANT:
@@ -136,11 +149,19 @@ class SymmMemCommunicator:
         use_multimem = False
         if self.force_multimem is not None:
             # Test override: use forced setting
-            use_multimem = self.force_multimem
+            use_multimem = self.force_multimem and self.multicast_supported
+            if self.force_multimem and not self.multicast_supported:
+                logger.warning_once(
+                    "SymmMemCommunicator: force_multimem=True was requested, "
+                    "but multicast operations are not supported. Falling back "
+                    "to two-shot allreduce."
+                )
         else:
             # Normal logic: use multimem for supported world sizes
             use_multimem = (
-                self.world_size in self._WORLD_SIZES_MULTIMEM[self.device_capability]
+                self.multicast_supported
+                and self.world_size
+                in self._WORLD_SIZES_MULTIMEM.get(self.device_capability, [])
             )
 
         if use_multimem:


### PR DESCRIPTION
## Purpose

Today, `SymmMemCommunicator` returns disabled when PyTorch symmetric memory rendezvous succeeds but reports `handle.multicast_ptr == 0`. That prevents vLLM from using its torch symmetric-memory allreduce communicator, even though multicast is only required for the multimem algorithm; the two-shot allreduce algorithm can still run without multicast support.

This keeps vLLM's torch symmetric-memory allreduce communicator enabled in that case and gates only the multimem path on multicast support, falling back to two-shot allreduce instead. It also updates the SM 9.0, SM 10.0, and SM 10.3 symmetric-memory allreduce limits from recent communicator benchmarks, including separate limits for the two-shot-only fallback path.

## Config Values

`SYMM_MEM_ALL_REDUCE_MAX_SIZES` is used for the normal vLLM symm-mem path. `SYMM_MEM_TWO_SHOT_ALL_REDUCE_MAX_SIZES` is used when multicast is unavailable and vLLM must use two-shot for all supported world sizes. For world sizes that do not normally select multimem, the normal path already uses two-shot, so the two tables intentionally match. The separate fallback table differs only for world sizes that normally select multimem when multicast is available.

| Config | SM | ws=2 | ws=4 | ws=6 | ws=8 |
|--------|----|------|------|------|------|
| `SYMM_MEM_ALL_REDUCE_MAX_SIZES` | 9.0 | 32 MiB | 32 MiB | 64 MiB | 64 MiB |
| `SYMM_MEM_ALL_REDUCE_MAX_SIZES` | 10.0 | 8 MiB | 32 MiB | 32 MiB | 128 MiB |
| `SYMM_MEM_ALL_REDUCE_MAX_SIZES` | 10.3 | 8 MiB | 64 MiB | 64 MiB | 128 MiB |
| `SYMM_MEM_TWO_SHOT_ALL_REDUCE_MAX_SIZES` | 9.0 | 32 MiB | 16 MiB | 16 MiB | 16 MiB |
| `SYMM_MEM_TWO_SHOT_ALL_REDUCE_MAX_SIZES` | 10.0 | 8 MiB | 32 MiB | 16 MiB | 128 MiB |
| `SYMM_MEM_TWO_SHOT_ALL_REDUCE_MAX_SIZES` | 10.3 | 8 MiB | 64 MiB | 16 MiB | 128 MiB |

## Benchmark Summary

- SM 9.0 results were collected on H200. SM 10.0 results were collected on B200. SM 10.3 values use the recent B300 communicator benchmark results.
- The normal table follows vLLM's selected symm-mem algorithm: two-shot for SM 9.0 ws=2 and SM 10.0/10.3 ws=2/4, multimem for configured multimem world sizes when multicast is available.
- The two-shot fallback table follows `symm_mem_two_shot` vs `pynccl` for every listed world size.
- E2E benchmark results will follow.

## Standalone All-Reduce Benchmark Results

All times are milliseconds per allreduce operation.

### SM 9.0 / H200

<details>
<summary>World Size = 2</summary>

| Tensor Size | pynccl | symm_mem_multimem | symm_mem_two_shot | Symm mem result |
|-------------|--------|-------------------|-------------------|-----------------|
| 512 KiB | 0.034 | 0.011 | 0.011 | two-shot/multimem beat pynccl |
| 1 MiB | 0.014 | 0.014 | 0.013 | two-shot/multimem beat pynccl |
| 1.5 MiB | 0.017 | 0.017 | 0.015 | two-shot/multimem beat pynccl |
| 2 MiB | 0.027 | 0.020 | 0.017 | two-shot/multimem beat pynccl |
| 3 MiB | 0.029 | 0.025 | 0.020 | two-shot/multimem beat pynccl |
| 4 MiB | 0.032 | 0.031 | 0.025 | two-shot/multimem beat pynccl |
| 8 MiB | 0.046 | 0.055 | 0.040 | two-shot beats pynccl |
| 16 MiB | 0.076 | 0.105 | 0.076 | two-shot beats pynccl |
| 32 MiB | 0.136 | 0.214 | 0.145 | pynccl beats symm mem |
| 47.84 MiB | 0.189 | 0.323 | 0.210 | pynccl beats symm mem |
| 64 MiB | 0.244 | 0.429 | 0.280 | pynccl beats symm mem |
| 128 MiB | 0.464 | 0.847 | 0.545 | pynccl beats symm mem |

</details>

<details>
<summary>World Size = 4</summary>

| Tensor Size | pynccl | symm_mem_multimem | symm_mem_two_shot | Symm mem result |
|-------------|--------|-------------------|-------------------|-----------------|
| 512 KiB | 0.019 | 0.011 | 0.012 | multimem/two-shot beat pynccl |
| 1 MiB | 0.018 | 0.013 | 0.016 | multimem/two-shot beat pynccl |
| 1.5 MiB | 0.022 | 0.016 | 0.019 | multimem/two-shot beat pynccl |
| 2 MiB | 0.027 | 0.018 | 0.022 | multimem/two-shot beat pynccl |
| 3 MiB | 0.032 | 0.024 | 0.026 | multimem/two-shot beat pynccl |
| 4 MiB | 0.040 | 0.029 | 0.033 | multimem/two-shot beat pynccl |
| 8 MiB | 0.060 | 0.049 | 0.057 | multimem/two-shot beat pynccl |
| 16 MiB | 0.097 | 0.094 | 0.108 | multimem beats pynccl |
| 32 MiB | 0.170 | 0.179 | 0.207 | pynccl beats symm mem |
| 47.84 MiB | 0.243 | 0.264 | 0.304 | pynccl beats symm mem |
| 64 MiB | 0.320 | 0.348 | 0.402 | pynccl beats symm mem |
| 128 MiB | 0.609 | 0.685 | 0.786 | pynccl beats symm mem |

</details>

<details>
<summary>World Size = 6</summary>

| Tensor Size | pynccl | symm_mem_multimem | symm_mem_two_shot | Symm mem result |
|-------------|--------|-------------------|-------------------|-----------------|
| 512 KiB | 0.019 | 0.011 | 0.015 | multimem/two-shot beat pynccl |
| 1 MiB | 0.021 | 0.014 | 0.018 | multimem/two-shot beat pynccl |
| 1.5 MiB | 0.026 | 0.015 | 0.022 | multimem/two-shot beat pynccl |
| 2 MiB | 0.036 | 0.018 | 0.026 | multimem/two-shot beat pynccl |
| 3 MiB | 0.041 | 0.023 | 0.033 | multimem/two-shot beat pynccl |
| 4 MiB | 0.047 | 0.029 | 0.039 | multimem/two-shot beat pynccl |
| 8 MiB | 0.075 | 0.048 | 0.065 | multimem/two-shot beat pynccl |
| 16 MiB | 0.118 | 0.091 | 0.122 | multimem beats pynccl |
| 32 MiB | 0.185 | 0.176 | 0.233 | multimem beats pynccl |
| 47.84 MiB | 0.258 | 0.257 | 0.342 | multimem beats pynccl |
| 64 MiB | 0.320 | 0.343 | 0.454 | pynccl beats symm mem |
| 128 MiB | 0.576 | 0.676 | 0.891 | pynccl beats symm mem |

</details>

<details>
<summary>World Size = 8</summary>

| Tensor Size | pynccl | symm_mem_multimem | symm_mem_two_shot | Symm mem result |
|-------------|--------|-------------------|-------------------|-----------------|
| 512 KiB | 0.024 | 0.011 | 0.015 | multimem/two-shot beat pynccl |
| 1 MiB | 0.025 | 0.014 | 0.017 | multimem/two-shot beat pynccl |
| 1.5 MiB | 0.033 | 0.016 | 0.019 | multimem/two-shot beat pynccl |
| 2 MiB | 0.037 | 0.018 | 0.022 | multimem/two-shot beat pynccl |
| 3 MiB | 0.044 | 0.023 | 0.029 | multimem/two-shot beat pynccl |
| 4 MiB | 0.050 | 0.027 | 0.037 | multimem/two-shot beat pynccl |
| 8 MiB | 0.076 | 0.046 | 0.065 | multimem/two-shot beat pynccl |
| 16 MiB | 0.121 | 0.087 | 0.125 | multimem beats pynccl |
| 32 MiB | 0.195 | 0.165 | 0.242 | multimem beats pynccl |
| 47.84 MiB | 0.267 | 0.244 | 0.354 | multimem beats pynccl |
| 64 MiB | 0.316 | 0.320 | 0.468 | pynccl beats symm mem |
| 128 MiB | 0.561 | 0.631 | 0.923 | pynccl beats symm mem |

</details>

### SM 10.0 / B200

<details>
<summary>World Size = 2</summary>

| Tensor Size | pynccl | symm_mem_multimem | symm_mem_two_shot | Symm mem result |
|-------------|--------|-------------------|-------------------|-----------------|
| 512 KiB | 0.013 | 0.016 | 0.017 | pynccl beats symm mem |
| 1 MiB | 0.017 | 0.021 | 0.020 | pynccl beats symm mem |
| 1.5 MiB | 0.019 | 0.025 | 0.021 | pynccl beats symm mem |
| 2 MiB | 0.021 | 0.029 | 0.024 | pynccl beats symm mem |
| 3 MiB | 0.027 | 0.038 | 0.027 | pynccl beats symm mem |
| 4 MiB | 0.040 | 0.046 | 0.033 | two-shot beats pynccl |
| 8 MiB | 0.044 | 0.080 | 0.049 | pynccl beats symm mem |
| 16 MiB | 0.056 | 0.148 | 0.084 | pynccl beats symm mem |
| 32 MiB | 0.087 | 0.288 | 0.158 | pynccl beats symm mem |
| 47.84 MiB | 0.121 | 0.434 | 0.238 | pynccl beats symm mem |
| 64 MiB | 0.155 | 0.610 | 0.338 | pynccl beats symm mem |
| 128 MiB | 0.282 | 1.238 | 0.680 | pynccl beats symm mem |

</details>

<details>
<summary>World Size = 4</summary>

| Tensor Size | pynccl | symm_mem_multimem | symm_mem_two_shot | Symm mem result |
|-------------|--------|-------------------|-------------------|-----------------|
| 512 KiB | 0.019 | 0.014 | 0.017 | multimem/two-shot beat pynccl |
| 1 MiB | 0.021 | 0.018 | 0.019 | multimem/two-shot beat pynccl |
| 1.5 MiB | 0.023 | 0.020 | 0.019 | two-shot/multimem beat pynccl |
| 2 MiB | 0.026 | 0.023 | 0.023 | multimem/two-shot beat pynccl |
| 3 MiB | 0.031 | 0.027 | 0.025 | two-shot/multimem beat pynccl |
| 4 MiB | 0.038 | 0.032 | 0.029 | two-shot/multimem beat pynccl |
| 8 MiB | 0.048 | 0.053 | 0.041 | two-shot beats pynccl |
| 16 MiB | 0.078 | 0.092 | 0.064 | two-shot beats pynccl |
| 32 MiB | 0.123 | 0.174 | 0.116 | two-shot beats pynccl |
| 47.84 MiB | 0.152 | 0.260 | 0.172 | pynccl beats symm mem |
| 64 MiB | 0.186 | 0.351 | 0.230 | pynccl beats symm mem |
| 128 MiB | 0.353 | 0.735 | 0.450 | pynccl beats symm mem |

</details>

<details>
<summary>World Size = 6</summary>

| Tensor Size | pynccl | symm_mem_multimem | symm_mem_two_shot | Symm mem result |
|-------------|--------|-------------------|-------------------|-----------------|
| 512 KiB | 0.026 | 0.015 | 0.022 | multimem/two-shot beat pynccl |
| 1 MiB | 0.027 | 0.018 | 0.024 | multimem/two-shot beat pynccl |
| 1.5 MiB | 0.027 | 0.018 | 0.024 | multimem/two-shot beat pynccl |
| 2 MiB | 0.032 | 0.021 | 0.026 | multimem/two-shot beat pynccl |
| 3 MiB | 0.035 | 0.024 | 0.035 | multimem/two-shot beat pynccl |
| 4 MiB | 0.045 | 0.029 | 0.037 | multimem/two-shot beat pynccl |
| 8 MiB | 0.079 | 0.042 | 0.059 | multimem/two-shot beat pynccl |
| 16 MiB | 0.084 | 0.071 | 0.100 | multimem beats pynccl |
| 32 MiB | 0.144 | 0.131 | 0.177 | multimem beats pynccl |
| 47.84 MiB | 0.189 | 0.192 | 0.257 | pynccl beats symm mem |
| 64 MiB | 0.220 | 0.261 | 0.336 | pynccl beats symm mem |
| 128 MiB | 0.387 | 0.548 | 0.688 | pynccl beats symm mem |

</details>

<details>
<summary>World Size = 8</summary>

| Tensor Size | pynccl | symm_mem_multimem | symm_mem_two_shot | Symm mem result |
|-------------|--------|-------------------|-------------------|-----------------|
| 512 KiB | 0.030 | 0.015 | 0.022 | multimem/two-shot beat pynccl |
| 1 MiB | 0.031 | 0.016 | 0.022 | multimem/two-shot beat pynccl |
| 1.5 MiB | 0.033 | 0.018 | 0.024 | multimem/two-shot beat pynccl |
| 2 MiB | 0.033 | 0.019 | 0.024 | multimem/two-shot beat pynccl |
| 3 MiB | 0.048 | 0.022 | 0.026 | multimem/two-shot beat pynccl |
| 4 MiB | 0.055 | 0.025 | 0.034 | multimem/two-shot beat pynccl |
| 8 MiB | 0.073 | 0.036 | 0.047 | multimem/two-shot beat pynccl |
| 16 MiB | 0.102 | 0.059 | 0.077 | multimem/two-shot beat pynccl |
| 32 MiB | 0.170 | 0.108 | 0.137 | multimem/two-shot beat pynccl |
| 47.84 MiB | 0.222 | 0.161 | 0.198 | multimem/two-shot beat pynccl |
| 64 MiB | 0.277 | 0.221 | 0.265 | multimem/two-shot beat pynccl |
| 128 MiB | 0.396 | 0.442 | 0.531 | pynccl beats symm mem |

</details>

### SM 10.3 / B300

<details>
<summary>World Size = 2</summary>

| Tensor Size | pynccl | symm_mem_multimem | symm_mem_two_shot | Symm mem result |
|-------------|--------|-------------------|-------------------|-----------------|
| 16 KiB | 0.021 | 0.013 | 0.014 | multimem/two-shot beat pynccl |
| 32 KiB | 0.012 | 0.013 | 0.015 | pynccl beats symm mem |
| 64 KiB | 0.011 | 0.015 | 0.016 | pynccl beats symm mem |
| 128 KiB | 0.011 | 0.016 | 0.018 | pynccl beats symm mem |
| 256 KiB | 0.014 | 0.016 | 0.018 | pynccl beats symm mem |
| 512 KiB | 0.015 | 0.019 | 0.018 | pynccl beats symm mem |
| 1 MiB | 0.017 | 0.023 | 0.021 | pynccl beats symm mem |
| 2 MiB | 0.021 | 0.032 | 0.025 | pynccl beats symm mem |
| 4 MiB | 0.035 | 0.049 | 0.034 | two-shot beats pynccl |
| 8 MiB | 0.046 | 0.085 | 0.049 | pynccl beats symm mem |
| 16 MiB | 0.057 | 0.157 | 0.081 | pynccl beats symm mem |
| 32 MiB | 0.086 | 0.305 | 0.154 | pynccl beats symm mem |
| 64 MiB | 0.150 | 0.638 | 0.333 | pynccl beats symm mem |
| 128 MiB | 0.281 | 1.298 | 0.669 | pynccl beats symm mem |

</details>

<details>
<summary>World Size = 4</summary>

| Tensor Size | pynccl | symm_mem_multimem | symm_mem_two_shot | Symm mem result |
|-------------|--------|-------------------|-------------------|-----------------|
| 16 KiB | 0.025 | 0.013 | 0.014 | multimem/two-shot beat pynccl |
| 32 KiB | 0.017 | 0.013 | 0.014 | multimem/two-shot beat pynccl |
| 64 KiB | 0.018 | 0.013 | 0.016 | multimem/two-shot beat pynccl |
| 128 KiB | 0.019 | 0.015 | 0.017 | multimem/two-shot beat pynccl |
| 256 KiB | 0.019 | 0.017 | 0.019 | multimem/two-shot beat pynccl |
| 512 KiB | 0.020 | 0.017 | 0.019 | multimem/two-shot beat pynccl |
| 1 MiB | 0.022 | 0.019 | 0.020 | multimem/two-shot beat pynccl |
| 2 MiB | 0.027 | 0.024 | 0.024 | multimem/two-shot beat pynccl |
| 4 MiB | 0.039 | 0.033 | 0.029 | two-shot/multimem beat pynccl |
| 8 MiB | 0.049 | 0.054 | 0.042 | two-shot beats pynccl |
| 16 MiB | 0.076 | 0.093 | 0.064 | two-shot beats pynccl |
| 32 MiB | 0.123 | 0.175 | 0.118 | two-shot beats pynccl |
| 64 MiB | 0.189 | 0.367 | 0.234 | pynccl beats symm mem |
| 128 MiB | 0.366 | 0.731 | 0.456 | pynccl beats symm mem |

</details>

<details>
<summary>World Size = 6</summary>

| Tensor Size | pynccl | symm_mem_multimem | symm_mem_two_shot | Symm mem result |
|-------------|--------|-------------------|-------------------|-----------------|
| 16 KiB | 0.029 | 0.013 | 0.019 | multimem/two-shot beat pynccl |
| 32 KiB | 0.024 | 0.013 | 0.019 | multimem/two-shot beat pynccl |
| 64 KiB | 0.025 | 0.013 | 0.020 | multimem/two-shot beat pynccl |
| 128 KiB | 0.026 | 0.015 | 0.022 | multimem/two-shot beat pynccl |
| 256 KiB | 0.027 | 0.015 | 0.022 | multimem/two-shot beat pynccl |
| 512 KiB | 0.027 | 0.017 | 0.024 | multimem/two-shot beat pynccl |
| 1 MiB | 0.027 | 0.018 | 0.024 | multimem/two-shot beat pynccl |
| 2 MiB | 0.032 | 0.022 | 0.027 | multimem/two-shot beat pynccl |
| 4 MiB | 0.046 | 0.029 | 0.038 | multimem/two-shot beat pynccl |
| 8 MiB | 0.080 | 0.043 | 0.059 | multimem/two-shot beat pynccl |
| 16 MiB | 0.083 | 0.072 | 0.099 | multimem beats pynccl |
| 32 MiB | 0.141 | 0.132 | 0.177 | multimem beats pynccl |
| 64 MiB | 0.219 | 0.271 | 0.331 | pynccl beats symm mem |
| 128 MiB | 0.393 | 0.541 | 0.680 | pynccl beats symm mem |

</details>

<details>
<summary>World Size = 8</summary>

| Tensor Size | pynccl | symm_mem_multimem | symm_mem_two_shot | Symm mem result |
|-------------|--------|-------------------|-------------------|-----------------|
| 16 KiB | 0.044 | 0.013 | 0.018 | multimem/two-shot beat pynccl |
| 32 KiB | 0.027 | 0.013 | 0.018 | multimem/two-shot beat pynccl |
| 64 KiB | 0.028 | 0.013 | 0.019 | multimem/two-shot beat pynccl |
| 128 KiB | 0.029 | 0.014 | 0.020 | multimem/two-shot beat pynccl |
| 256 KiB | 0.031 | 0.015 | 0.022 | multimem/two-shot beat pynccl |
| 512 KiB | 0.031 | 0.017 | 0.024 | multimem/two-shot beat pynccl |
| 1 MiB | 0.031 | 0.017 | 0.024 | multimem/two-shot beat pynccl |
| 2 MiB | 0.035 | 0.020 | 0.026 | multimem/two-shot beat pynccl |
| 4 MiB | 0.056 | 0.026 | 0.035 | multimem/two-shot beat pynccl |
| 8 MiB | 0.073 | 0.038 | 0.046 | multimem/two-shot beat pynccl |
| 16 MiB | 0.102 | 0.060 | 0.078 | multimem/two-shot beat pynccl |
| 32 MiB | 0.170 | 0.109 | 0.138 | multimem/two-shot beat pynccl |
| 64 MiB | 0.277 | 0.223 | 0.265 | multimem/two-shot beat pynccl |
| 128 MiB | 0.396 | 0.439 | 0.525 | pynccl beats symm mem |

</details>

## Test Plan

Run vLLM with multicast disabled and tensor parallelism enabled:

```bash
TORCH_SYMM_MEM_DISABLE_MULTICAST=1 \
vllm serve zai-org/GLM-5.1 \
  --trust-remote-code \
  --tensor-parallel-size 8
```

## Test Result

Observed fallback instead of communicator disablement:

```text
SymmMemCommunicator: symmetric memory multicast operations are not supported. Falling back to two-shot allreduce.
```
