### PR TITLE
fix: avoid multiturn benchmark queue drain deadlock

### DIFF
--- a/benchmarks/multi_turn/benchmark_serving_multi_turn.py
+++ b/benchmarks/multi_turn/benchmark_serving_multi_turn.py
@@ -12,6 +12,7 @@ from collections import Counter, deque
 from datetime import datetime
 from enum import Enum
 from http import HTTPStatus
+from queue import Empty
 from statistics import mean
 from typing import NamedTuple
 
@@ -1045,9 +1046,12 @@ async def main_mp(
 
     # Queues should be closed, required to avoid hang at interpreter shutdown
     unfinished_tasks = 0
-    while not task_queue.empty():
-        task_queue.get()
-        unfinished_tasks += 1
+    while True:
+        try:
+            task_queue.get_nowait()
+            unfinished_tasks += 1
+        except Empty:
+            break
 
     if unfinished_tasks > 0:
         # Can happen if not all tasks (conversations) have finished.
@@ -1055,8 +1059,9 @@ async def main_mp(
         # or if an error occurred in one of the clients.
         logger.debug(f"Discarding {unfinished_tasks} unfinished tasks")
 
+    # The producer feeder may still hold discarded tasks; do not wait for it to flush.
+    task_queue.cancel_join_thread()
     task_queue.close()
-    task_queue.join_thread()
 
     result_queue.close()
     result_queue.join_thread()


### PR DESCRIPTION
﻿Fixes #42226.

The multi-turn benchmark tries to drain `task_queue` with `Queue.empty()` and then calls `join_thread()`. That is still vulnerable to the multiprocessing feeder deadlock described in the Python docs: `empty()` can report true while the feeder thread still has buffered items, and `join_thread()` then waits for those discarded items to flush into a pipe nobody is reading.

This switches the drain to best-effort `get_nowait()` and then calls `cancel_join_thread()` before closing the task queue. At that point every client process has already exited, so any remaining task items are intentionally discarded and the parent should not wait for the producer feeder to flush them.

## To verify

- `python -m py_compile benchmarks/multi_turn/benchmark_serving_multi_turn.py`
- `python -m ruff check benchmarks/multi_turn/benchmark_serving_multi_turn.py`
- `python -m ruff format --check benchmarks/multi_turn/benchmark_serving_multi_turn.py`
