### PR TITLE
[Bugfix][CPU] Accept arm64 host processor for Apple Silicon detection

### DIFF
--- a/cmake/cpu_extension.cmake
+++ b/cmake/cpu_extension.cmake
@@ -86,7 +86,7 @@ function(check_sysctl TARGET OUT)
     endif()
 endfunction()
 
-if (MACOSX_FOUND AND CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64")
+if (MACOSX_FOUND AND (CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64" OR CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "arm64"))
     message(STATUS "Apple Silicon Detected")
     set(APPLE_SILICON_FOUND TRUE)
     set(ENABLE_NUMA OFF)


### PR DESCRIPTION
## Purpose

`cmake/cpu_extension.cmake` gates the Apple Silicon code path on `CMAKE_SYSTEM_PROCESSOR STREQUAL "arm64"` (line 89). On macOS / arm64 with cmake 4.x inside pip's build isolation, `CMAKE_SYSTEM_PROCESSOR` is empty when this file is included — so the build falls through to the Linux/x86 ISA-detection branch and fails:

```
CMake Error at cmake/cpu_extension.cmake:89 (find_isa):
  find_isa Function invoked with incorrect arguments for function named:
  find_isa
...
X86 backend requires gcc/g++ >= 12.3
```

The `find_isa` errors fire because `${CPUINFO}` is only populated on Linux (`/proc/cpuinfo` at line 36, gated by `NOT MACOSX_FOUND`), so on macOS the function expands to two arguments instead of three. The final `gcc/g++ >= 12.3` error is the same branch's compiler check after ISA detection has already failed.

This PR broadens the gate to also accept `CMAKE_HOST_SYSTEM_PROCESSOR`, which is reliably set from `uname -m` on the build host. The new condition is a strict superset of the old one — when `CMAKE_SYSTEM_PROCESSOR` is already `"arm64"`, behavior is unchanged; when it's missing/empty, the host-processor check rescues the build.

## Test Plan

Build from sdist on macOS / arm64 / cmake 4.x / pip 26 with build isolation:

```bash
pip install vllm==0.19.1
```

Before the patch: build fails with the `find_isa` / `X86 backend requires gcc/g++` errors above.

After the patch: build proceeds through the macOS arm64 branch (`check_sysctl hw.optional.neon`, `hw.optional.arm.FEAT_BF16`) and produces a wheel.

## Test Result

Verified on macOS 26 (Darwin 25.5.0) / arm64 / cmake 4.0.0 / pip 26.1 / Python 3.13.13 with the v0.19.1 sdist + this one-line patch:

```
Created wheel for vllm: filename=vllm-0.19.1-cp313-cp313-macosx_26_0_arm64.whl size=6630936
Successfully installed vllm-0.19.1
```

The installed wheel runs end-to-end via an out-of-tree platform plugin loading a 4-bit MLX-quantized Qwen3-4B model and serving via `vllm.entrypoints.openai.api_server`; `/v1/chat/completions` returns a real generation.
