### PR TITLE
[Metrics] Scope unregister_vllm_metrics() to strictly "vllm:" metrics

### DIFF
--- a/vllm/v1/metrics/prometheus.py
+++ b/vllm/v1/metrics/prometheus.py
@@ -64,7 +64,7 @@ def unregister_vllm_metrics():
     registry = REGISTRY
     # Unregister any existing vLLM collectors
     for collector in list(registry._collector_to_names):
-        if hasattr(collector, "_name") and "vllm" in collector._name:
+        if hasattr(collector, "_name") and collector._name.startswith("vllm:"):
             registry.unregister(collector)
 
 


### PR DESCRIPTION


## Purpose

`unregister_vllm_metrics()` currently uses `"vllm" in collector._name` to decide which collectors to remove from the Prometheus registry. This is a substring match that removes *every* collector whose internal name contains `vllm` anywhere, including metrics registered by other subsystems or downstream extensions that happen to use `vllm` in their metric names.

This came up when trying to add Prometheus support to vLLM-Omni: https://github.com/vllm-project/vllm-omni/pull/3362#discussion_r3212332671 

Since the architecture of vLLM-Omni requires that multiple Prometheus collectors be maintained, `unregister_vllm_metrics()` requires that we use some sort of workaround to preserve our own metrics without messing with the internals of vLLM's metrics. The simpler solution IMO would be for vLLM to just be specific about which metrics it wants to ensure are uninitalized when PrometheusStatLogger is instantiated.

This PR solves this by updating the `startwisth` string match in `unregister_vllm_metrics` from `"vllm"` to `"vllm:"`, meaning that `"vllm_omni:"` 

### Changes

- **`vllm/v1/metrics/prometheus.py`**:  change `startswith("vllm")` to `startwith("vllm:")`
 
## Test Plan

Deploy vLLM-Omni with patched vLLM

## Test Result

No errors

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
</details>

